### PR TITLE
fix(session): unset CLAUDECODE via tmux -e flag (no bash intermediary)

### DIFF
--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -157,6 +157,8 @@ export class SessionManager extends EventEmitter {
     // Build Claude CLI arguments — no shell intermediary.
     // tmux new-session executes the command directly (no bash -c needed)
     // when given as separate arguments after the session options.
+    // Use -e CLAUDECODE= to unset the CLAUDECODE env var in spawned sessions,
+    // preventing nested Claude Code detection when instar runs inside Claude Code.
     const claudeArgs = ['--dangerously-skip-permissions'];
     if (options.model) {
       claudeArgs.push('--model', options.model);
@@ -168,6 +170,7 @@ export class SessionManager extends EventEmitter {
         'new-session', '-d',
         '-s', tmuxSession,
         '-c', this.config.projectDir,
+        '-e', 'CLAUDECODE=',
         this.config.claudePath, ...claudeArgs,
       ], { encoding: 'utf-8' });
     } catch (err) {


### PR DESCRIPTION
## Summary

- Fixes the CLAUDECODE env var issue when instar runs inside Claude Code
- Previous fix (PR #5) used `bash -c "unset CLAUDECODE; ..."` which violated the no-shell-intermediary requirement
- This fix uses tmux's `-e CLAUDECODE=` flag to clear the variable without bash

## Problem

When instar spawns sessions while running inside Claude Code, the `CLAUDECODE` env var is inherited, causing nested Claude Code detection issues. The previous fix (PR #5, closed) solved this but used a bash wrapper in `spawnSession` which:
1. Introduced shell injection risk
2. Failed the `session-reap-detect` test that explicitly checks for no bash intermediary

## Solution

Use tmux's `-e` flag: `tmux new-session ... -e CLAUDECODE= claude -p "..."`. This clears `CLAUDECODE` in the spawned session's environment without any shell intermediary.

## Test plan
- [x] `tests/unit/session-reap-detect.test.ts` — all 19 tests pass (including the bash-check test)
- [x] Full test suite — 1068/1068 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)