### PR TITLE
Improve missing Claude CLI errors during startup

### DIFF
--- a/src/core/ClaudeCliErrors.ts
+++ b/src/core/ClaudeCliErrors.ts
@@ -1,0 +1,27 @@
+export const CLAUDE_CODE_INSTALL_URL = 'https://docs.anthropic.com/en/docs/claude-code';
+
+export function buildClaudeCliNotFoundMessage(): string {
+  return [
+    'Error: Claude Code CLI not found.',
+    '',
+    'Instar requires Claude Code to be installed. Install it from:',
+    `  ${CLAUDE_CODE_INSTALL_URL}`,
+    '',
+    'After installing, make sure `claude` is available in your PATH, then try again.',
+  ].join('\n');
+}
+
+export function isClaudeCliMissingError(error: unknown, output: string = ''): boolean {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    return (error as { code?: unknown }).code === 'ENOENT';
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  if (message.toLowerCase().includes('enoent')) {
+    return true;
+  }
+
+  const combinedOutput = `${message}\n${output}`;
+  return /(?:^|\n)\s*(?:zsh|bash|sh): command not found: claude\b/i.test(combinedOutput)
+    || /\bclaude: command not found\b/i.test(combinedOutput);
+}

--- a/src/core/ClaudeCliIntelligenceProvider.ts
+++ b/src/core/ClaudeCliIntelligenceProvider.ts
@@ -16,6 +16,7 @@
 import { execFile } from 'node:child_process';
 import type { IntelligenceProvider, IntelligenceOptions } from './types.js';
 import { resolveCliFlag } from './models.js';
+import { buildClaudeCliNotFoundMessage, isClaudeCliMissingError } from './ClaudeCliErrors.js';
 
 const DEFAULT_MODEL = 'fast';
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -55,7 +56,11 @@ export class ClaudeCliIntelligenceProvider implements IntelligenceProvider {
         env: childEnv,
       }, (error, stdout, stderr) => {
         if (error) {
-          // Timeout or other error — return empty so caller can fall back
+          if (isClaudeCliMissingError(error, stderr)) {
+            reject(new Error(buildClaudeCliNotFoundMessage()));
+            return;
+          }
+
           reject(new Error(`Claude CLI error: ${error.message}${stderr ? ` — ${stderr.slice(0, 200)}` : ''}`));
           return;
         }

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -40,6 +40,7 @@ export interface SessionDiagnostics {
   suggestions: string[];
 }
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { buildClaudeCliNotFoundMessage, isClaudeCliMissingError } from './ClaudeCliErrors.js';
 import { InputGuard, type TopicBinding } from './InputGuard.js';
 import type { InputDetector } from '../monitoring/PromptGate.js';
 
@@ -1016,10 +1017,15 @@ export class SessionManager extends EventEmitter {
           // Stabilization delay: Claude's TUI may redraw after loading large JONSLs,
           // clearing any text injected too early. Wait for the redraw to settle.
           const stabilizationMs = options?.resumeSessionId ? 5000 : 0;
-          setTimeout(() => {
+          if (stabilizationMs > 0) {
+            setTimeout(() => {
+              this.injectMessage(tmuxSession, initialMessage);
+              console.log(`[SessionManager] Injected initial message into "${tmuxSession}" (${initialMessage.length} chars${stabilizationMs ? ', after stabilization delay' : ''})`);
+            }, stabilizationMs);
+          } else {
             this.injectMessage(tmuxSession, initialMessage);
-            console.log(`[SessionManager] Injected initial message into "${tmuxSession}" (${initialMessage.length} chars${stabilizationMs ? ', after stabilization delay' : ''})`);
-          }, stabilizationMs);
+            console.log(`[SessionManager] Injected initial message into "${tmuxSession}" (${initialMessage.length} chars)`);
+          }
         } else {
           console.error(`[SessionManager] Claude not ready in session "${tmuxSession}" — message NOT injected. Session may need manual intervention.`);
           // Still try to inject — Claude might be ready but prompt detection failed
@@ -1029,7 +1035,8 @@ export class SessionManager extends EventEmitter {
           }
         }
       }).catch((err) => {
-        console.error(`[SessionManager] Error waiting for Claude ready in "${tmuxSession}": ${err}`);
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[SessionManager] Error waiting for Claude ready in "${tmuxSession}": ${message}`);
       });
     }
 
@@ -1434,26 +1441,37 @@ export class SessionManager extends EventEmitter {
    */
   private async waitForClaudeReady(tmuxSession: string, timeoutMs: number = 30000): Promise<boolean> {
     const start = Date.now();
-    // Wait a minimum startup delay before checking (Claude needs time to load)
-    await new Promise(r => setTimeout(r, 3000));
+    const startupGraceMs = 3000;
+    let lastOutput = '';
+
     while (Date.now() - start < timeoutMs) {
+      const output = this.captureOutput(tmuxSession, 5);
+      if (output) {
+        lastOutput = output;
+      }
+
       if (!this.tmuxSessionExists(tmuxSession)) {
+        if (isClaudeCliMissingError(null, lastOutput)) {
+          throw new Error(buildClaudeCliNotFoundMessage());
+        }
         console.error(`[SessionManager] Session "${tmuxSession}" died during startup`);
         return false;
       }
-      const output = this.captureOutput(tmuxSession, 5);
+
       // Check only the last 3 lines for Claude Code's prompt character (❯).
       // Checking all captured lines can false-positive on ❯ appearing in prior output
       // (e.g., during TUI redraw of a resumed session's history).
       const lines = (output || '').split('\n').filter(l => l.trim());
       const tail = lines.slice(-3).join('\n');
-      if (tail.includes('❯') || tail.includes('bypass permissions')) {
+
+      if (Date.now() - start >= startupGraceMs && (tail.includes('❯') || tail.includes('bypass permissions'))) {
         console.log(`[SessionManager] Claude ready in "${tmuxSession}" after ${Date.now() - start}ms`);
         return true;
       }
+
       await new Promise(r => setTimeout(r, 500));
     }
-    // Log what we see on timeout for debugging
+
     const finalOutput = this.captureOutput(tmuxSession, 20);
     console.error(`[SessionManager] Claude not ready in "${tmuxSession}" after ${timeoutMs}ms. Output: ${(finalOutput || '').slice(-200)}`);
     return false;

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-03-27T04:01:15.284Z",
-  "instarVersion": "0.24.9",
+  "generatedAt": "2026-03-27T05:38:48.498Z",
+  "instarVersion": "0.24.10",
   "entryCount": 176,
   "entries": {
     "hook:session-start": {
@@ -1328,7 +1328,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "573edc8f44698dba1fcb5bf0d30b73825362b47043f865c29ea64ebd41c163a4",
+      "contentHash": "133cf7d5070727ab76780b967b7d7f3d8a7a2ee63eedfd3a47a130b208b134c0",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {

--- a/tests/unit/ClaudeCliIntelligenceProvider.test.ts
+++ b/tests/unit/ClaudeCliIntelligenceProvider.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execFileMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+describe('ClaudeCliIntelligenceProvider', () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it('translates ENOENT into an actionable Claude Code install error', async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const error = Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' });
+      cb?.(error, '', '');
+      return { stdin: { end: vi.fn() } };
+    });
+
+    const { ClaudeCliIntelligenceProvider } = await import('../../src/core/ClaudeCliIntelligenceProvider.js');
+    const provider = new ClaudeCliIntelligenceProvider('claude');
+    const result = provider.evaluate('test prompt');
+
+    await expect(result).rejects.toThrow('Claude Code CLI not found.');
+    await expect(result).rejects.toThrow('https://docs.anthropic.com/en/docs/claude-code');
+  });
+
+  it('preserves non-ENOENT Claude CLI failures as regular CLI errors', async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const error = new Error('subprocess exited with code 1');
+      cb?.(error, '', 'command not found: claude');
+      return { stdin: { end: vi.fn() } };
+    });
+
+    const { ClaudeCliIntelligenceProvider } = await import('../../src/core/ClaudeCliIntelligenceProvider.js');
+    const provider = new ClaudeCliIntelligenceProvider('claude');
+    const result = provider.evaluate('test prompt');
+
+    await expect(result).rejects.toThrow('Claude CLI error: subprocess exited with code 1 — command not found: claude');
+    await expect(result).rejects.not.toThrow('Claude Code CLI not found.');
+  });
+});

--- a/tests/unit/session-manager-behavioral.test.ts
+++ b/tests/unit/session-manager-behavioral.test.ts
@@ -19,6 +19,8 @@ import os from 'node:os';
 
 // Track mock tmux sessions at module scope so the mock and tests share state
 const mockTmuxSessions = new Set<string>();
+const mockCapturePaneOutput = new Map<string, string>();
+const mockStartupDeathDelayMs = new Map<string, number>();
 
 // Mock child_process to avoid needing real tmux
 vi.mock('node:child_process', () => {
@@ -39,7 +41,17 @@ vi.mock('node:child_process', () => {
       if (args[0] === 'new-session') {
         const sIdx = args.indexOf('-s');
         if (sIdx >= 0 && args[sIdx + 1]) {
-          mockTmuxSessions.add(args[sIdx + 1]);
+          const sessionName = args[sIdx + 1];
+          mockTmuxSessions.add(sessionName);
+          if (!mockCapturePaneOutput.has(sessionName)) {
+            mockCapturePaneOutput.set(sessionName, '❯');
+          }
+          const deathDelayMs = mockStartupDeathDelayMs.get(sessionName);
+          if (deathDelayMs !== undefined) {
+            setTimeout(() => {
+              mockTmuxSessions.delete(sessionName);
+            }, deathDelayMs);
+          }
         }
         return '';
       }
@@ -53,7 +65,8 @@ vi.mock('node:child_process', () => {
 
       // tmux capture-pane
       if (args[0] === 'capture-pane') {
-        return '';
+        const target = args[2]?.replace(/^=/, '').replace(/:$/, '');
+        return target ? (mockCapturePaneOutput.get(target) ?? '') : '';
       }
 
       // tmux send-keys
@@ -117,6 +130,8 @@ describe('SessionManager behavioral tests', () => {
 
     // Clear mock session tracking
     mockTmuxSessions.clear();
+    mockCapturePaneOutput.clear();
+    mockStartupDeathDelayMs.clear();
   });
 
   afterEach(() => {
@@ -312,10 +327,45 @@ describe('SessionManager behavioral tests', () => {
   });
 
   describe('spawnInteractiveSession', () => {
-    it('creates session with custom name', async () => {
-      const tmuxSession = await manager.spawnInteractiveSession(undefined, 'my-chat');
+    it('creates session with custom name without waiting for startup when no initial message is provided', async () => {
+      vi.useFakeTimers();
+      try {
+        let resolvedSession: string | undefined;
+        const spawnPromise = manager.spawnInteractiveSession(undefined, 'my-chat');
+        spawnPromise.then(tmuxSession => {
+          resolvedSession = tmuxSession;
+        });
 
-      expect(tmuxSession).toContain('my-chat');
+        await Promise.resolve();
+
+        expect(resolvedSession).toBeDefined();
+        expect(resolvedSession).toContain('my-chat');
+        await expect(spawnPromise).resolves.toContain('my-chat');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('returns immediately even when an initial message is waiting for Claude to become ready', async () => {
+      vi.useFakeTimers();
+      try {
+        const safeName = 'delayed-ready';
+        const tmuxName = `${path.basename(tmpDir)}-${safeName}`;
+        mockCapturePaneOutput.set(tmuxName, '');
+
+        let resolvedSession: string | undefined;
+        const spawnPromise = manager.spawnInteractiveSession('hello Claude', safeName);
+        spawnPromise.then(sessionName => {
+          resolvedSession = sessionName;
+        });
+
+        await Promise.resolve();
+
+        expect(resolvedSession).toBe(tmuxName);
+        await expect(spawnPromise).resolves.toBe(tmuxName);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('reuses existing session if tmux session exists', async () => {
@@ -369,6 +419,28 @@ describe('SessionManager behavioral tests', () => {
       await expect(
         manager.spawnInteractiveSession(undefined, 'chat-overflow')
       ).rejects.toThrow('Absolute session limit');
+    });
+
+    it('logs a friendly error when Claude is missing and the tmux session dies before the startup grace period ends', async () => {
+      vi.useFakeTimers();
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const safeName = 'missing-claude';
+        const tmuxName = `${path.basename(tmpDir)}-${safeName}`;
+        mockCapturePaneOutput.set(tmuxName, 'zsh: command not found: claude');
+        mockStartupDeathDelayMs.set(tmuxName, 1000);
+
+        const spawnPromise = manager.spawnInteractiveSession('hello Claude', safeName);
+        await expect(spawnPromise).resolves.toContain(safeName);
+        await vi.advanceTimersByTimeAsync(4000);
+
+        const combinedErrors = errorSpy.mock.calls.flat().join('\n');
+        expect(combinedErrors).toContain('Claude Code CLI not found.');
+        expect(combinedErrors).toContain('https://docs.anthropic.com/en/docs/claude-code');
+      } finally {
+        errorSpy.mockRestore();
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- surface actionable Claude Code CLI install guidance when Claude CLI execution fails
- detect missing Claude CLI during tmux session startup and log the same friendly message
- preserve the non-blocking `spawnInteractiveSession(initialMessage, ...)` contract while readiness happens in the background
- add regression coverage for provider errors, startup death handling, and the non-blocking interactive path

Closes #13.

## Testing
- `npx vitest run tests/unit/ClaudeCliIntelligenceProvider.test.ts tests/unit/session-manager-behavioral.test.ts tests/unit/session-resume.test.ts tests/unit/builtin-manifest.test.ts`
- `npx vitest run tests/integration/session-resume-flow.test.ts`
- `npm run lint`