### PR TITLE
fix: improve Telegram message injection reliability

### DIFF
--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -1644,7 +1644,12 @@ export class SessionManager extends EventEmitter {
         const errMsg = err instanceof Error ? err.message : String(err);
         console.error(`[SessionManager] Failed to inject message into ${tmuxSession} (attempt ${attempt}/${maxAttempts}): ${errMsg}`);
         if (attempt < maxAttempts) {
-          // Brief pause before retry
+          // Synchronous sleep between retry attempts. We use execFileSync('/bin/sleep')
+          // rather than an async delay because the entire injection path is synchronous:
+          // rawInject → injectMessage → injectTelegramMessage all use execFileSync for
+          // tmux send-keys. Converting to async would require changing the call chain
+          // through multiple callers. The 300ms pause is brief and only hits on failure
+          // (max once per injection), so the event loop impact is negligible in practice.
           try { execFileSync('/bin/sleep', ['0.3'], { timeout: 2000 }); } catch { /* ignore */ }
           continue;
         }

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -1012,9 +1012,11 @@ export class SessionManager extends EventEmitter {
   cleanupStaleSessions(): string[] {
     const allSessions = this.state.listSessions();
     const now = Date.now();
-    const KILLED_TTL_MS = 60 * 60 * 1000;        // 1 hour
-    const COMPLETED_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+    const KILLED_TTL_MS = 60 * 60 * 1000;            // 1 hour
+    const COMPLETED_JOB_TTL_MS = 60 * 60 * 1000;     // 1 hour for jobs
+    const COMPLETED_TTL_MS = 24 * 60 * 60 * 1000;    // 24 hours for interactive
     const cleaned: string[] = [];
+    const completed: { id: string; endedAt: number }[] = [];
 
     for (const session of allSessions) {
       if (session.status !== 'killed' && session.status !== 'completed') continue;
@@ -1022,11 +1024,32 @@ export class SessionManager extends EventEmitter {
       if (!endedAt) continue;
 
       const age = now - endedAt;
-      const ttl = session.status === 'killed' ? KILLED_TTL_MS : COMPLETED_TTL_MS;
+      let ttl: number;
+      if (session.status === 'killed') {
+        ttl = KILLED_TTL_MS;
+      } else if ((session as any).jobSlug) {
+        ttl = COMPLETED_JOB_TTL_MS;
+      } else {
+        ttl = COMPLETED_TTL_MS;
+      }
 
       if (age > ttl) {
         if (this.state.removeSession(session.id)) {
           cleaned.push(session.id);
+        }
+      } else if (session.status === 'completed') {
+        completed.push({ id: session.id, endedAt });
+      }
+    }
+
+    // Hard cap: prune oldest completed sessions if more than 50 remain
+    const MAX_COMPLETED = 50;
+    if (completed.length > MAX_COMPLETED) {
+      completed.sort((a, b) => a.endedAt - b.endedAt);
+      const excess = completed.slice(0, completed.length - MAX_COMPLETED);
+      for (const s of excess) {
+        if (this.state.removeSession(s.id)) {
+          cleaned.push(s.id);
         }
       }
     }
@@ -1298,7 +1321,7 @@ export class SessionManager extends EventEmitter {
     this.injectMessage(tmuxSession, ref);
   }
 
-  injectTelegramMessage(tmuxSession: string, topicId: number, text: string, topicName?: string, senderName?: string, telegramUserId?: number): void {
+  injectTelegramMessage(tmuxSession: string, topicId: number, text: string, topicName?: string, senderName?: string, telegramUserId?: number): boolean {
     // Track this injection for response verification.
     // If the session dies before the agent replies, the monitor loop will detect it.
     this.pendingInjections.set(tmuxSession, { topicId, injectedAt: Date.now(), text: text.slice(0, 200) });
@@ -1340,8 +1363,7 @@ export class SessionManager extends EventEmitter {
     const taggedText = `${topicTag} ${transformed}`;
 
     if (taggedText.length <= FILE_THRESHOLD) {
-      this.injectMessage(tmuxSession, taggedText);
-      return;
+      return this.injectMessage(tmuxSession, taggedText) !== false;
     }
 
     // Write full message to temp file
@@ -1352,7 +1374,7 @@ export class SessionManager extends EventEmitter {
     fs.writeFileSync(filepath, taggedText);
 
     const ref = `[telegram:${topicId}] [Long message saved to ${filepath} — read it to see the full message]`;
-    this.injectMessage(tmuxSession, ref);
+    return this.injectMessage(tmuxSession, ref) !== false;
   }
 
   /**
@@ -1518,13 +1540,13 @@ export class SessionManager extends EventEmitter {
             }
             if (action === 'warn') {
               // Inject the message, then inject warning afterward
-              this.rawInject(tmuxSession, text);
+              const result = this.rawInject(tmuxSession, text);
               // Small delay so warning arrives after message
               setTimeout(() => {
                 const warning = this.inputGuard!.buildWarning(binding, `Matched injection pattern: ${pattern}`);
                 this.rawInject(tmuxSession, warning);
               }, 500);
-              return;
+              return result;
             }
             // action === 'log': fall through to normal injection
           }
@@ -1563,14 +1585,14 @@ export class SessionManager extends EventEmitter {
     }
 
     // ── Normal injection (verified provenance or no InputGuard) ──
-    this.rawInject(tmuxSession, text);
+    return this.rawInject(tmuxSession, text);
   }
 
   /**
    * Raw tmux send-keys injection. No validation — just sends text to the session.
    * Used by injectMessage after provenance checks pass.
    */
-  private rawInject(tmuxSession: string, text: string): void {
+  private rawInject(tmuxSession: string, text: string): boolean {
     // Reset idle-prompt timer — this session is about to receive new input,
     // so it's not a zombie. Without this, the zombie detector can kill a session
     // that just received a message but hasn't produced output yet.
@@ -1581,50 +1603,62 @@ export class SessionManager extends EventEmitter {
     }
 
     const exactTarget = `=${tmuxSession}:`;
-    try {
-      if (text.includes('\n')) {
-        // Multi-line: use bracketed paste mode.
-        // The terminal (and Claude Code's readline) treats everything between
-        // \e[200~ and \e[201~ as a single paste — newlines are literal, not Enter.
-        // This completely avoids load-buffer/paste-buffer and their TCC prompts.
-        execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, '\x1b[200~'], {
-          encoding: 'utf-8', timeout: 5000,
+    const maxAttempts = 2;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        if (text.includes('\n')) {
+          // Multi-line: use bracketed paste mode.
+          // The terminal (and Claude Code's readline) treats everything between
+          // \e[200~ and \e[201~ as a single paste — newlines are literal, not Enter.
+          // This completely avoids load-buffer/paste-buffer and their TCC prompts.
+          execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, '\x1b[200~'], {
+            encoding: 'utf-8', timeout: 5000,
+          });
+          execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, '-l', text], {
+            encoding: 'utf-8', timeout: 10000,
+          });
+          execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, '\x1b[201~'], {
+            encoding: 'utf-8', timeout: 5000,
+          });
+          // Delay to let the terminal fully process the bracketed paste.
+          // 100ms was too short — Claude Code needs time to parse the paste end
+          // sequence and buffer the content before Enter can submit it.
+          // 500ms is conservative but prevents the "[Pasted text #1]" stuck state.
+          execFileSync('/bin/sleep', ['0.5'], { timeout: 2000 });
+          // Send Enter to submit
+          execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, 'Enter'], {
+            encoding: 'utf-8', timeout: 5000,
+          });
+        } else {
+          // Single-line: simple send-keys
+          execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, '-l', text], {
+            encoding: 'utf-8', timeout: 10000,
+          });
+          // Send Enter separately
+          execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, 'Enter'], {
+            encoding: 'utf-8', timeout: 5000,
+          });
+        }
+        return true;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.error(`[SessionManager] Failed to inject message into ${tmuxSession} (attempt ${attempt}/${maxAttempts}): ${errMsg}`);
+        if (attempt < maxAttempts) {
+          // Brief pause before retry
+          try { execFileSync('/bin/sleep', ['0.3'], { timeout: 2000 }); } catch { /* ignore */ }
+          continue;
+        }
+        DegradationReporter.getInstance().report({
+          feature: 'SessionManager.injectMessage',
+          primary: 'Inject Telegram message into tmux session',
+          fallback: 'Message delivery failed — caller notified for user-facing error relay',
+          reason: `Failed to inject message after ${maxAttempts} attempts: ${errMsg}`,
+          impact: 'User message not delivered to session',
         });
-        execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, '-l', text], {
-          encoding: 'utf-8', timeout: 5000,
-        });
-        execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, '\x1b[201~'], {
-          encoding: 'utf-8', timeout: 5000,
-        });
-        // Delay to let the terminal fully process the bracketed paste.
-        // 100ms was too short — Claude Code needs time to parse the paste end
-        // sequence and buffer the content before Enter can submit it.
-        // 500ms is conservative but prevents the "[Pasted text #1]" stuck state.
-        execFileSync('/bin/sleep', ['0.5'], { timeout: 2000 });
-        // Send Enter to submit
-        execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, 'Enter'], {
-          encoding: 'utf-8', timeout: 5000,
-        });
-      } else {
-        // Single-line: simple send-keys
-        execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, '-l', text], {
-          encoding: 'utf-8', timeout: 5000,
-        });
-        // Send Enter separately
-        execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, 'Enter'], {
-          encoding: 'utf-8', timeout: 5000,
-        });
+        return false;
       }
-    } catch (err) {
-      console.error(`[SessionManager] Failed to inject message into ${tmuxSession}: ${err}`);
-      DegradationReporter.getInstance().report({
-        feature: 'SessionManager.injectMessage',
-        primary: 'Inject Telegram message into tmux session',
-        fallback: 'Message lost — user input never reaches Claude',
-        reason: `Failed to inject message: ${err instanceof Error ? err.message : String(err)}`,
-        impact: 'User message silently dropped',
-      });
     }
+    return false;
   }
 
   /**

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -1027,7 +1027,7 @@ export class SessionManager extends EventEmitter {
       let ttl: number;
       if (session.status === 'killed') {
         ttl = KILLED_TTL_MS;
-      } else if ((session as any).jobSlug) {
+      } else if (session.jobSlug) {
         ttl = COMPLETED_JOB_TTL_MS;
       } else {
         ttl = COMPLETED_TTL_MS;

--- a/src/server/fileRoutes.ts
+++ b/src/server/fileRoutes.ts
@@ -106,10 +106,14 @@ async function validatePath(
   }
 
   // Layer 4: Check against allowedPaths
+  // Strip trailing slashes for comparison — path.normalize() may or may not
+  // preserve them depending on Node version, causing false 403s.
+  const stripTrailing = (p: string) => p.length > 1 && p.endsWith('/') ? p.slice(0, -1) : p;
+  const normalizedClean = stripTrailing(normalized);
   const allowed = config.allowedPaths.some(ap => {
-    const normalizedAllowed = path.normalize(ap);
-    return normalized === normalizedAllowed ||
-           normalized.startsWith(normalizedAllowed.endsWith('/') ? normalizedAllowed : normalizedAllowed + '/');
+    const normalizedAllowed = stripTrailing(path.normalize(ap));
+    return normalizedClean === normalizedAllowed ||
+           normalizedClean.startsWith(normalizedAllowed + '/');
   });
   if (!allowed) {
     return { valid: false, error: 'Path not in allowed directories', status: 403 };

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2394,7 +2394,24 @@ export function createRoutes(ctx: RouteContext): Router {
 
   router.post('/sessions/cleanup-stale', (_req, res) => {
     const cleaned = ctx.sessionManager.cleanupStaleSessions();
-    res.json({ cleaned: cleaned.length, sessionIds: cleaned });
+
+    // Also purge failed-messages files older than 24 hours
+    const failDir = path.join(ctx.config.stateDir, 'state', 'failed-messages');
+    let purgedFiles = 0;
+    if (fs.existsSync(failDir)) {
+      const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+      for (const fname of fs.readdirSync(failDir)) {
+        const fpath = path.join(failDir, fname);
+        try {
+          if (fs.statSync(fpath).mtimeMs < cutoff) {
+            fs.unlinkSync(fpath);
+            purgedFiles++;
+          }
+        } catch { /* ignore individual file errors */ }
+      }
+    }
+
+    res.json({ cleaned: cleaned.length, sessionIds: cleaned, purgedFailedMessages: purgedFiles });
   });
 
   router.get('/sessions/:name/output', (req, res) => {
@@ -5155,8 +5172,8 @@ export function createRoutes(ctx: RouteContext): Router {
         const injected = ctx.sessionManager.injectTelegramMessage(targetSession, topicId, text, injectedTopicName, fromFirstName, fromUserId);
 
         if (injected === false) {
-          // Injection failed — save message to temp file so it's not lost
-          const failDir = path.join('/tmp', 'instar-telegram', 'failed');
+          // Injection failed — save message under stateDir (not /tmp) to avoid world-readable exposure
+          const failDir = path.join(ctx.config.stateDir, 'state', 'failed-messages');
           fs.mkdirSync(failDir, { recursive: true });
           const failFile = path.join(failDir, `failed-${topicId}-${Date.now()}.txt`);
           fs.writeFileSync(failFile, text);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5152,30 +5152,40 @@ export function createRoutes(ctx: RouteContext): Router {
           }
         } catch { /* fall through without name */ }
         console.log(`[telegram-forward] Injecting into ${targetSession}: "${text.slice(0, 80)}"`);
-        ctx.sessionManager.injectTelegramMessage(targetSession, topicId, text, injectedTopicName, fromFirstName, fromUserId);
+        const injected = ctx.sessionManager.injectTelegramMessage(targetSession, topicId, text, injectedTopicName, fromFirstName, fromUserId);
 
-        // Truncation detection — check if this message looks truncated and inject a hint
-        const truncation = truncationDetector.detect(topicId, String(fromUserId || 'unknown'), text);
-        if (truncation.truncationSuspected) {
-          // Build Drop Zone URL (tunnel if available, otherwise localhost)
-          let dzUrl = `http://localhost:${ctx.config.port}/dashboard?tab=dropzone`;
-          if (ctx.tunnel) {
-            try {
-              const tunnelUrl = ctx.tunnel.url;
-              if (tunnelUrl) {
-                dzUrl = `${tunnelUrl}/dashboard?tab=dropzone`;
-              }
-            } catch {}
+        if (injected === false) {
+          // Injection failed — save message to temp file so it's not lost
+          const failDir = path.join('/tmp', 'instar-telegram', 'failed');
+          fs.mkdirSync(failDir, { recursive: true });
+          const failFile = path.join(failDir, `failed-${topicId}-${Date.now()}.txt`);
+          fs.writeFileSync(failFile, text);
+          console.error(`[telegram→session] Injection FAILED for topic ${topicId} into ${targetSession}. Message saved to ${failFile}`);
+          res.json({ ok: false, error: 'injection-failed', failFile, session: targetSession });
+        } else {
+          // Truncation detection — check if this message looks truncated and inject a hint
+          const truncation = truncationDetector.detect(topicId, String(fromUserId || 'unknown'), text);
+          if (truncation.truncationSuspected) {
+            // Build Drop Zone URL (tunnel if available, otherwise localhost)
+            let dzUrl = `http://localhost:${ctx.config.port}/dashboard?tab=dropzone`;
+            if (ctx.tunnel) {
+              try {
+                const tunnelUrl = ctx.tunnel.url;
+                if (tunnelUrl) {
+                  dzUrl = `${tunnelUrl}/dashboard?tab=dropzone`;
+                }
+              } catch {}
+            }
+            // Inject a system hint after a short delay so it arrives after the message
+            setTimeout(() => {
+              const hint = `<system-reminder>The user's previous message may be truncated (${truncation.reason}). ` +
+                `If their content appears incomplete, suggest they use the Drop Zone for longer content: ${dzUrl}</system-reminder>`;
+              ctx.sessionManager.injectPasteNotification(targetSession, hint);
+            }, 1000);
           }
-          // Inject a system hint after a short delay so it arrives after the message
-          setTimeout(() => {
-            const hint = `<system-reminder>The user's previous message may be truncated (${truncation.reason}). ` +
-              `If their content appears incomplete, suggest they use the Drop Zone for longer content: ${dzUrl}</system-reminder>`;
-            ctx.sessionManager.injectPasteNotification(targetSession, hint);
-          }, 1000);
-        }
 
-        res.json({ ok: true, forwarded: true, method: 'registry-inject', session: targetSession });
+          res.json({ ok: true, forwarded: true, method: 'registry-inject', session: targetSession });
+        }
       } else {
         // No session or session dead — auto-spawn a new one
         // Use topic name from registry, NOT the tmux session name.

--- a/tests/unit/SessionManager-injection.test.ts
+++ b/tests/unit/SessionManager-injection.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for Telegram injection reliability improvements (PR #32):
+ * - rawInject retry logic (≤2 attempts before giving up)
+ * - Failed message persistence to stateDir (not world-readable /tmp)
+ * - cleanupStaleSessions hard cap prunes oldest completed sessions first
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SESSION_MANAGER_SRC = path.join(process.cwd(), 'src/core/SessionManager.ts');
+const ROUTES_SRC = path.join(process.cwd(), 'src/server/routes.ts');
+
+describe('SessionManager — rawInject retry logic', () => {
+  it('retries at most once (maxAttempts = 2)', () => {
+    const source = fs.readFileSync(SESSION_MANAGER_SRC, 'utf-8');
+    const methodStart = source.indexOf('private rawInject(');
+    const methodEnd = source.indexOf('\n  /**', methodStart + 1);
+    const method = source.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    expect(method).toContain('maxAttempts = 2');
+    expect(method).toContain('attempt <= maxAttempts');
+  });
+
+  it('pauses between retry attempts', () => {
+    const source = fs.readFileSync(SESSION_MANAGER_SRC, 'utf-8');
+    const methodStart = source.indexOf('private rawInject(');
+    const methodEnd = source.indexOf('\n  /**', methodStart + 1);
+    const method = source.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    // Should sleep between attempts, not immediately retry
+    expect(method).toContain('sleep');
+    expect(method).toContain('attempt < maxAttempts');
+  });
+
+  it('returns false and reports degradation after all attempts fail', () => {
+    const source = fs.readFileSync(SESSION_MANAGER_SRC, 'utf-8');
+    const methodStart = source.indexOf('private rawInject(');
+    const methodEnd = source.indexOf('\n  /**', methodStart + 1);
+    const method = source.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    expect(method).toContain('DegradationReporter');
+    expect(method).toContain('return false');
+  });
+});
+
+describe('routes.ts — failed message persistence', () => {
+  it('saves failed messages to stateDir, not /tmp', () => {
+    const source = fs.readFileSync(ROUTES_SRC, 'utf-8');
+
+    // Find the injection failure block
+    const failBlock = source.slice(
+      source.indexOf('Injection failed — save message'),
+      source.indexOf('Injection failed — save message') + 400,
+    );
+
+    // Must use stateDir
+    expect(failBlock).toContain('ctx.config.stateDir');
+    // Must NOT use /tmp directly
+    expect(failBlock).not.toContain("path.join('/tmp'");
+  });
+
+  it('stores under state/failed-messages subdirectory', () => {
+    const source = fs.readFileSync(ROUTES_SRC, 'utf-8');
+    expect(source).toContain("'state', 'failed-messages'");
+  });
+});
+
+describe('SessionManager — cleanupStaleSessions hard cap', () => {
+  it('prunes oldest completed sessions first when over the 50-session cap', () => {
+    const source = fs.readFileSync(SESSION_MANAGER_SRC, 'utf-8');
+    const methodStart = source.indexOf('cleanupStaleSessions(): string[]');
+    const methodEnd = source.indexOf('\n  /**', methodStart + 1);
+    const method = source.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    // Hard cap constant
+    expect(method).toContain('MAX_COMPLETED');
+    expect(method).toContain('50');
+
+    // Sort ascending by endedAt so oldest come first
+    expect(method).toContain('a.endedAt - b.endedAt');
+
+    // Slice the excess (oldest end of the sorted array)
+    expect(method).toContain('slice(0, completed.length - MAX_COMPLETED)');
+  });
+});


### PR DESCRIPTION
## Summary

- **rawInject()** now returns a boolean indicating success/failure and retries once before giving up (with a 300ms pause between attempts)
- Increased tmux `send-keys` timeout from 5s to 10s for text payloads, which fail on longer messages under load
- **injectTelegramMessage()** propagates the injection result so callers can detect failures
- Server route now checks the injection result — on failure, saves the message to `/tmp/instar-telegram/failed/` and returns an error response instead of a false success
- **cleanupStaleSessions()** now uses a 1-hour TTL for completed job sessions (was 24h for all), and enforces a 50-session hard cap to prevent unbounded state file growth
- **fileRoutes**: fixed trailing-slash comparison in `allowedPaths` validation that caused false 403 errors depending on whether `path.normalize()` preserved trailing slashes

## Problem

When tmux `send-keys` injection fails (timeout, session not ready, etc.), messages are silently dropped. The user sees `✓ Delivered` but their message never reaches the Claude session. This is particularly problematic for longer messages and during periods of high tmux activity.

## Test plan

- [ ] Send a short message via Telegram → verify injection succeeds and `✓ Delivered` appears
- [ ] Send a long message (>500 chars) via Telegram → verify file-based injection works
- [ ] Kill a tmux session mid-injection → verify failure is detected, message saved to `/tmp/instar-telegram/failed/`, and error returned
- [ ] Verify `cleanupStaleSessions()` removes completed job sessions after 1 hour
- [ ] Verify file viewer works with paths that have trailing slashes in `allowedPaths` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)