### PR TITLE
fix(imessage): mention trigger mode should not gate 1:1 conversations

### DIFF
--- a/src/messaging/imessage/IMessageAdapter.ts
+++ b/src/messaging/imessage/IMessageAdapter.ts
@@ -465,10 +465,18 @@ export class IMessageAdapter implements MessagingAdapter {
     }
 
     // 1:1 chats always trigger — mention mode only applies to group chats.
-    // iMessage 1:1 chatIds look like phone numbers (+1...) or emails (foo@bar).
-    // Group chats have identifiers like "chat123456789".
-    if (chatId && (chatId.startsWith('+') || chatId.includes('@'))) {
-      return { triggered: true, strippedText: text };
+    // iMessage chatIds have format: iMessage;-;{identifier}
+    // For 1:1 chats, identifier is a phone number (+1...) or email (foo@bar).
+    // For group chats, identifier looks like "chat123456789" or a group GUID.
+    if (chatId) {
+      // Extract the identifier part after "iMessage;-;" (or use full chatId as fallback)
+      const parts = chatId.split(';-;');
+      const identifier = parts.length > 1 ? parts[1] : chatId;
+
+      // Check if this is a 1:1 chat (phone or email identifier)
+      if (identifier.startsWith('+') || identifier.includes('@')) {
+        return { triggered: true, strippedText: text };
+      }
     }
 
     // Mention mode for group chats — require @{agentName}

--- a/src/messaging/imessage/IMessageAdapter.ts
+++ b/src/messaging/imessage/IMessageAdapter.ts
@@ -453,18 +453,26 @@ export class IMessageAdapter implements MessagingAdapter {
 
   /**
    * Check whether an incoming message triggers the agent.
-   * In "mention" mode, requires @{agentName} in the message text.
+   * In "mention" mode, requires @{agentName} in the message text — but only
+   * for group chats. 1:1 conversations always trigger regardless of mode,
+   * because mention gating only makes sense when multiple people are talking.
    * In "all" mode, every message triggers.
    * Returns the stripped text (mention removed) if triggered.
    */
-  _checkTrigger(text: string): { triggered: boolean; strippedText: string } {
+  _checkTrigger(text: string, chatId?: string): { triggered: boolean; strippedText: string } {
     if (this.triggerMode === 'all') {
       return { triggered: true, strippedText: text };
     }
 
-    // Mention mode — require @{agentName}
+    // 1:1 chats always trigger — mention mode only applies to group chats.
+    // iMessage 1:1 chatIds look like phone numbers (+1...) or emails (foo@bar).
+    // Group chats have identifiers like "chat123456789".
+    if (chatId && (chatId.startsWith('+') || chatId.includes('@'))) {
+      return { triggered: true, strippedText: text };
+    }
+
+    // Mention mode for group chats — require @{agentName}
     if (!this.agentName) {
-      // No agent name configured — fall back to triggering on all messages
       return { triggered: true, strippedText: text };
     }
 
@@ -577,7 +585,7 @@ export class IMessageAdapter implements MessagingAdapter {
     this.lastInboundFrom.set(senderNormalized, Date.now());
 
     // Check trigger mode — in "mention" mode, only respond if @agentName is present
-    const triggerResult = this._checkTrigger(msg.text);
+    const triggerResult = this._checkTrigger(msg.text, msg.chatId);
     if (!triggerResult.triggered) {
       console.log(`[imessage] Message from ${IMessageAdapter.maskIdentifier(msg.sender)} logged but not triggered (mention mode, no @${this.agentName})`);
       // Still log the message for awareness, just don't route it

--- a/tests/unit/imessage-adapter.test.ts
+++ b/tests/unit/imessage-adapter.test.ts
@@ -315,4 +315,148 @@ describe('IMessageAdapter', () => {
         .rejects.toThrow('Cannot send from server process');
     });
   });
+
+  describe('_checkTrigger', () => {
+    describe('triggerMode: all', () => {
+      it('always triggers regardless of chatId', () => {
+        const adapter = new IMessageAdapter(
+          { authorizedSenders: ['+14081234567'], triggerMode: 'all' },
+          project.stateDir,
+        );
+        const result = (adapter as any)._checkTrigger('hello', 'iMessage;-;+14081234567');
+        expect(result.triggered).toBe(true);
+        expect(result.strippedText).toBe('hello');
+      });
+    });
+
+    describe('triggerMode: mention', () => {
+      describe('1:1 chats', () => {
+        it('triggers for 1:1 phone number chat without mention', () => {
+          const adapter = new IMessageAdapter(
+            { authorizedSenders: ['+14081234567'], triggerMode: 'mention', agentName: 'Roland' },
+            project.stateDir,
+          );
+          const result = (adapter as any)._checkTrigger(
+            'hello there',
+            'iMessage;-;+14081234567',
+          );
+          expect(result.triggered).toBe(true);
+          expect(result.strippedText).toBe('hello there');
+        });
+
+        it('triggers for 1:1 email chat without mention', () => {
+          const adapter = new IMessageAdapter(
+            { authorizedSenders: ['user@icloud.com'], triggerMode: 'mention', agentName: 'Roland' },
+            project.stateDir,
+          );
+          const result = (adapter as any)._checkTrigger(
+            'hello there',
+            'iMessage;-;user@icloud.com',
+          );
+          expect(result.triggered).toBe(true);
+          expect(result.strippedText).toBe('hello there');
+        });
+      });
+
+      describe('group chats', () => {
+        it('requires mention for group chat (chatXXX identifier)', () => {
+          const adapter = new IMessageAdapter(
+            { authorizedSenders: ['+14081234567'], triggerMode: 'mention', agentName: 'Roland' },
+            project.stateDir,
+          );
+          const resultWithoutMention = (adapter as any)._checkTrigger(
+            'hello everyone',
+            'iMessage;-;chat123456789',
+          );
+          expect(resultWithoutMention.triggered).toBe(false);
+
+          const resultWithMention = (adapter as any)._checkTrigger(
+            '@Roland hello there',
+            'iMessage;-;chat123456789',
+          );
+          expect(resultWithMention.triggered).toBe(true);
+          expect(resultWithMention.strippedText).toBe('hello there');
+        });
+
+        it('requires mention for group chat (GUID identifier)', () => {
+          const adapter = new IMessageAdapter(
+            { authorizedSenders: ['+14081234567'], triggerMode: 'mention', agentName: 'Roland' },
+            project.stateDir,
+          );
+          const resultWithoutMention = (adapter as any)._checkTrigger(
+            'hello everyone',
+            'iMessage;-;550e8400-e29b-41d4-a716-446655440000',
+          );
+          expect(resultWithoutMention.triggered).toBe(false);
+
+          const resultWithMention = (adapter as any)._checkTrigger(
+            '@Roland what do you think?',
+            'iMessage;-;550e8400-e29b-41d4-a716-446655440000',
+          );
+          expect(resultWithMention.triggered).toBe(true);
+          expect(resultWithMention.strippedText).toBe('what do you think?');
+        });
+
+        it('strips mention from message text', () => {
+          const adapter = new IMessageAdapter(
+            { authorizedSenders: ['+14081234567'], triggerMode: 'mention', agentName: 'Roland' },
+            project.stateDir,
+          );
+          const result = (adapter as any)._checkTrigger(
+            'hey @Roland can you help?',
+            'iMessage;-;chat999',
+          );
+          expect(result.triggered).toBe(true);
+          expect(result.strippedText).toBe('hey can you help?');
+        });
+      });
+
+      describe('edge cases', () => {
+        it('handles chatId without iMessage;-; prefix (legacy format)', () => {
+          const adapter = new IMessageAdapter(
+            { authorizedSenders: ['+14081234567'], triggerMode: 'mention', agentName: 'Roland' },
+            project.stateDir,
+          );
+          // Bare phone number - should trigger as 1:1
+          const resultPhone = (adapter as any)._checkTrigger(
+            'hello',
+            '+14081234567',
+          );
+          expect(resultPhone.triggered).toBe(true);
+
+          // Bare email - should trigger as 1:1
+          const resultEmail = (adapter as any)._checkTrigger(
+            'hello',
+            'user@example.com',
+          );
+          expect(resultEmail.triggered).toBe(true);
+        });
+
+        it('triggers when no agentName is configured', () => {
+          const adapter = new IMessageAdapter(
+            { authorizedSenders: ['+14081234567'], triggerMode: 'mention' },
+            project.stateDir,
+          );
+          const result = (adapter as any)._checkTrigger(
+            'hello',
+            'iMessage;-;chat123',
+          );
+          expect(result.triggered).toBe(true);
+        });
+
+        it('handles undefined chatId', () => {
+          const adapter = new IMessageAdapter(
+            { authorizedSenders: ['+14081234567'], triggerMode: 'mention', agentName: 'Roland' },
+            project.stateDir,
+          );
+          // Without chatId, falls through to mention check for group chat logic
+          const resultWithoutMention = (adapter as any)._checkTrigger('hello', undefined);
+          expect(resultWithoutMention.triggered).toBe(false);
+
+          const resultWithMention = (adapter as any)._checkTrigger('@Roland hello', undefined);
+          expect(resultWithMention.triggered).toBe(true);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `triggerMode: "mention"` was silently dropping all messages in direct (1:1) iMessage conversations because users don't type `@AgentName` when texting one person
- Mention gating now only applies to group chats — 1:1 chats always trigger
- Detection: iMessage 1:1 chatIds are phone numbers (`+1...`) or emails (`foo@bar`); group chats have identifiers like `chat123456789`

## Changes

One file: `src/messaging/imessage/IMessageAdapter.ts`
- `_checkTrigger()` accepts optional `chatId` parameter
- 1:1 chats bypass mention check entirely
- Group chats still require `@AgentName` in mention mode

## Test plan

- [ ] Send message in 1:1 iMessage chat with `triggerMode: "mention"` — should trigger
- [ ] Send message in group chat without `@AgentName` — should NOT trigger
- [ ] Send message in group chat with `@AgentName` — should trigger and strip mention
- [ ] `triggerMode: "all"` unchanged — always triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)