### PR TITLE
Stream JSONL import to prevent OOM on large files

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2664,7 +2664,7 @@ export async function startServer(options: StartOptions): Promise<void> {
 
         const jsonlPath = path.join(config.stateDir, 'telegram-messages.jsonl');
         if (fs.existsSync(jsonlPath)) {
-          const imported = topicMemory.importFromJsonl(jsonlPath);
+          const imported = await topicMemory.importFromJsonl(jsonlPath);
           if (imported > 0) {
             console.log(pc.green(`  TopicMemory: imported ${imported} messages from JSONL`));
           }

--- a/src/memory/TopicMemory.ts
+++ b/src/memory/TopicMemory.ts
@@ -20,6 +20,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import readline from 'node:readline';
 
 // Dynamic import for better-sqlite3
 type Database = import('better-sqlite3').Database;
@@ -183,7 +184,7 @@ export class TopicMemory {
     if (this._needsRebuild) {
       const jsonlPath = path.join(this.stateDir, 'telegram-messages.jsonl');
       if (fs.existsSync(jsonlPath)) {
-        const imported = this.importFromJsonl(jsonlPath);
+        const imported = await this.importFromJsonl(jsonlPath);
         console.log(`[TopicMemory] Auto-rebuilt from JSONL: ${imported} messages reimported`);
       } else {
         console.warn('[TopicMemory] No JSONL log found for rebuild — starting fresh');
@@ -717,23 +718,55 @@ export class TopicMemory {
   // ── Import / Rebuild ────────────────────────────────────────
 
   /**
-   * Import messages from the JSONL log file.
+   * Import messages from the JSONL log file using streaming reads.
    * Idempotent — only inserts messages not already in the database.
    * Returns the number of new messages imported.
+   *
+   * Uses readline.createInterface on a read stream instead of
+   * fs.readFileSync to avoid OOM on large JSONL files (100K+ messages).
    */
-  importFromJsonl(jsonlPath: string): number {
+  async importFromJsonl(jsonlPath: string): Promise<number> {
     if (!this.db) return 0;
     if (!fs.existsSync(jsonlPath)) return 0;
 
-    const content = fs.readFileSync(jsonlPath, 'utf-8');
-    const lines = content.split('\n').filter(Boolean);
+    const db = this.db;
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO messages (message_id, topic_id, text, from_user, timestamp, session_name, sender_name, sender_username, telegram_user_id, user_id, privacy_scope)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
 
-    const messages: TopicMessage[] = [];
-    for (const line of lines) {
+    let count = 0;
+    const BATCH_SIZE = 500;
+    let batch: TopicMessage[] = [];
+
+    const flushBatch = () => {
+      if (batch.length === 0) return;
+      const tx = db.transaction(() => {
+        for (const msg of batch) {
+          const result = insert.run(
+            msg.messageId, msg.topicId, msg.text, msg.fromUser ? 1 : 0,
+            msg.timestamp, msg.sessionName,
+            msg.senderName ?? null, msg.senderUsername ?? null, msg.telegramUserId ?? null,
+            msg.userId ?? null, msg.privacyScope ?? 'private',
+          );
+          if (result.changes > 0) count++;
+        }
+      });
+      tx();
+      batch = [];
+    };
+
+    const rl = readline.createInterface({
+      input: fs.createReadStream(jsonlPath, { encoding: 'utf-8' }),
+      crlfDelay: Infinity,
+    });
+
+    for await (const line of rl) {
+      if (!line) continue;
       try {
         const entry = JSON.parse(line);
         if (entry.topicId != null && entry.text) {
-          messages.push({
+          batch.push({
             messageId: entry.messageId,
             topicId: entry.topicId,
             text: entry.text,
@@ -746,17 +779,26 @@ export class TopicMemory {
             userId: entry.userId ?? undefined,
             privacyScope: entry.privacyScope ?? undefined,
           });
+          if (batch.length >= BATCH_SIZE) {
+            flushBatch();
+          }
         }
       } catch { /* @silent-fallback-ok — JSONL parse, skip corrupted */ }
     }
 
-    return this.insertMessages(messages);
+    // Flush remaining
+    flushBatch();
+
+    // Rebuild topic_meta from messages after import
+    this.rebuildTopicMeta();
+
+    return count;
   }
 
   /**
    * Full rebuild — drop all data and reimport from JSONL.
    */
-  rebuild(jsonlPath: string): number {
+  async rebuild(jsonlPath: string): Promise<number> {
     if (!this.db) return 0;
 
     this.db.exec('DELETE FROM messages');

--- a/src/memory/TopicMemory.ts
+++ b/src/memory/TopicMemory.ts
@@ -119,6 +119,8 @@ export class TopicMemory {
   private stateDir: string;
   /** Set after corruption auto-recovery — caller should reimport from JSONL */
   private _needsRebuild = false;
+  /** Stats from the most recent importFromJsonl() / rebuild() call */
+  private _lastImportStats: { imported: number; malformed: number; missingFields: number } | null = null;
 
   constructor(stateDir: string) {
     this.stateDir = stateDir;
@@ -736,6 +738,8 @@ export class TopicMemory {
     `);
 
     let count = 0;
+    let malformed = 0;
+    let missingFields = 0;
     const BATCH_SIZE = 500;
     let batch: TopicMessage[] = [];
 
@@ -782,8 +786,14 @@ export class TopicMemory {
           if (batch.length >= BATCH_SIZE) {
             flushBatch();
           }
+        } else {
+          // Valid JSON but missing the fields we need — count separately from malformed JSON.
+          missingFields++;
         }
-      } catch { /* @silent-fallback-ok — JSONL parse, skip corrupted */ }
+      } catch {
+        // @silent-fallback-ok — JSONL parse error; count so we can surface it at end.
+        malformed++;
+      }
     }
 
     // Flush remaining
@@ -792,7 +802,25 @@ export class TopicMemory {
     // Rebuild topic_meta from messages after import
     this.rebuildTopicMeta();
 
+    // Surface parse / schema problems at end of import so operators can
+    // diagnose corrupted JSONL without tailing logs during the hot path.
+    if (malformed > 0 || missingFields > 0) {
+      console.warn(
+        `[TopicMemory] importFromJsonl(${jsonlPath}): imported=${count} malformed_json=${malformed} missing_fields=${missingFields}`,
+      );
+    }
+
+    this._lastImportStats = { imported: count, malformed, missingFields };
     return count;
+  }
+
+  /**
+   * Returns stats from the most recent importFromJsonl() / rebuild() call.
+   * Useful for tests and /topic/rebuild endpoints that want to surface
+   * parse-error counts in the API response.
+   */
+  getLastImportStats(): { imported: number; malformed: number; missingFields: number } | null {
+    return this._lastImportStats;
   }
 
   /**

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -6427,14 +6427,14 @@ export function createRoutes(ctx: RouteContext): Router {
    * Rebuild topic memory from JSONL (idempotent import).
    * POST /topic/rebuild
    */
-  router.post('/topic/rebuild', (_req, res) => {
+  router.post('/topic/rebuild', async (_req, res) => {
     if (!ctx.topicMemory) {
       res.status(503).json({ error: 'TopicMemory not initialized' });
       return;
     }
 
     const jsonlPath = path.join(ctx.config.stateDir, 'telegram-messages.jsonl');
-    const imported = ctx.topicMemory.rebuild(jsonlPath);
+    const imported = await ctx.topicMemory.rebuild(jsonlPath);
     res.json({ rebuilt: true, messagesImported: imported, stats: ctx.topicMemory.stats() });
   });
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -6435,7 +6435,13 @@ export function createRoutes(ctx: RouteContext): Router {
 
     const jsonlPath = path.join(ctx.config.stateDir, 'telegram-messages.jsonl');
     const imported = await ctx.topicMemory.rebuild(jsonlPath);
-    res.json({ rebuilt: true, messagesImported: imported, stats: ctx.topicMemory.stats() });
+    const importStats = ctx.topicMemory.getLastImportStats();
+    res.json({
+      rebuilt: true,
+      messagesImported: imported,
+      parseErrors: importStats ? { malformed: importStats.malformed, missingFields: importStats.missingFields } : null,
+      stats: ctx.topicMemory.stats(),
+    });
   });
 
   // ── Pairing API — Multi-machine state sync (Phase 4.5) ────────

--- a/tests/e2e/topic-memory-lifecycle.test.ts
+++ b/tests/e2e/topic-memory-lifecycle.test.ts
@@ -71,7 +71,7 @@ describe('TopicMemory E2E lifecycle', () => {
     // Step 2: Initialize TopicMemory and import from JSONL
     topicMemory = new TopicMemory(stateDir);
     await topicMemory.open();
-    const importCount = topicMemory.importFromJsonl(jsonlPath);
+    const importCount = await topicMemory.importFromJsonl(jsonlPath);
     expect(importCount).toBe(48);
 
     // Step 3: Start server

--- a/tests/integration/user-agent-topology.test.ts
+++ b/tests/integration/user-agent-topology.test.ts
@@ -313,7 +313,7 @@ describe('pipeline → TopicMemory storage', () => {
     expect(context).not.toContain('User: How do I deploy?');
   });
 
-  it('JSONL round-trip preserves sender identity', () => {
+  it('JSONL round-trip preserves sender identity', async () => {
     // Create JSONL with sender identity (simulating pipeline log entries)
     const jsonlPath = path.join(tmpDir, 'messages.jsonl');
     const entries = [
@@ -335,7 +335,7 @@ describe('pipeline → TopicMemory storage', () => {
     fs.writeFileSync(jsonlPath, entries.map(e => JSON.stringify(e)).join('\n'));
 
     // Import
-    const count = topicMemory.importFromJsonl(jsonlPath);
+    const count = await topicMemory.importFromJsonl(jsonlPath);
     expect(count).toBe(3);
 
     // Verify identity survived round-trip

--- a/tests/unit/topic-memory-privacy.test.ts
+++ b/tests/unit/topic-memory-privacy.test.ts
@@ -443,7 +443,7 @@ describe('insertMessages (batch) with privacy fields', () => {
 // ── JSONL Import with Privacy Fields ─────────────────────────────
 
 describe('importFromJsonl with privacy fields', () => {
-  it('imports userId and privacyScope from JSONL', () => {
+  it('imports userId and privacyScope from JSONL', async () => {
     const jsonlPath = path.join(testDir, 'messages.jsonl');
     const lines = [
       JSON.stringify({
@@ -457,7 +457,7 @@ describe('importFromJsonl with privacy fields', () => {
     ];
     fs.writeFileSync(jsonlPath, lines.join('\n'));
 
-    const imported = memory.importFromJsonl(jsonlPath);
+    const imported = await memory.importFromJsonl(jsonlPath);
     expect(imported).toBe(2);
 
     const messages = memory.getRecentMessages(42);
@@ -467,7 +467,7 @@ describe('importFromJsonl with privacy fields', () => {
     expect(messages[1].privacyScope).toBe('shared-project');
   });
 
-  it('handles legacy JSONL without privacy fields', () => {
+  it('handles legacy JSONL without privacy fields', async () => {
     const jsonlPath = path.join(testDir, 'messages.jsonl');
     const lines = [
       JSON.stringify({
@@ -477,7 +477,7 @@ describe('importFromJsonl with privacy fields', () => {
     ];
     fs.writeFileSync(jsonlPath, lines.join('\n'));
 
-    const imported = memory.importFromJsonl(jsonlPath);
+    const imported = await memory.importFromJsonl(jsonlPath);
     expect(imported).toBe(1);
 
     const messages = memory.getRecentMessages(42);

--- a/tests/unit/topic-memory.test.ts
+++ b/tests/unit/topic-memory.test.ts
@@ -388,7 +388,7 @@ describe('TopicMemory', () => {
   });
 
   describe('JSONL import with sender identity', () => {
-    it('imports sender identity from JSONL entries', () => {
+    it('imports sender identity from JSONL entries', async () => {
       const jsonlPath = path.join(tmpDir, 'messages-with-sender.jsonl');
       const lines = [
         JSON.stringify({
@@ -403,7 +403,7 @@ describe('TopicMemory', () => {
       ];
       fs.writeFileSync(jsonlPath, lines.join('\n'));
 
-      const count = topicMemory.importFromJsonl(jsonlPath);
+      const count = await topicMemory.importFromJsonl(jsonlPath);
       expect(count).toBe(2);
 
       const messages = topicMemory.getRecentMessages(100);
@@ -413,7 +413,7 @@ describe('TopicMemory', () => {
       expect(messages[1].senderName).toBeUndefined(); // Agent message
     });
 
-    it('imports JSONL entries without sender identity (pre-migration)', () => {
+    it('imports JSONL entries without sender identity (pre-migration)', async () => {
       const jsonlPath = path.join(tmpDir, 'messages-old.jsonl');
       const lines = [
         JSON.stringify({
@@ -424,7 +424,7 @@ describe('TopicMemory', () => {
       ];
       fs.writeFileSync(jsonlPath, lines.join('\n'));
 
-      const count = topicMemory.importFromJsonl(jsonlPath);
+      const count = await topicMemory.importFromJsonl(jsonlPath);
       expect(count).toBe(1);
 
       const messages = topicMemory.getRecentMessages(100);
@@ -726,7 +726,7 @@ describe('TopicMemory', () => {
   // ── JSONL Import ────────────────────────────────────────────
 
   describe('importFromJsonl', () => {
-    it('imports messages from JSONL file', () => {
+    it('imports messages from JSONL file', async () => {
       const jsonlPath = path.join(tmpDir, 'messages.jsonl');
       const lines = [
         JSON.stringify({ messageId: 1, topicId: 100, text: 'Hello', fromUser: true, timestamp: '2026-02-24T12:00:00Z', sessionName: null }),
@@ -735,7 +735,7 @@ describe('TopicMemory', () => {
       ];
       fs.writeFileSync(jsonlPath, lines.join('\n'));
 
-      const count = topicMemory.importFromJsonl(jsonlPath);
+      const count = await topicMemory.importFromJsonl(jsonlPath);
       expect(count).toBe(3);
 
       const messages100 = topicMemory.getRecentMessages(100);
@@ -745,7 +745,7 @@ describe('TopicMemory', () => {
       expect(messages200).toHaveLength(1);
     });
 
-    it('skips entries without topicId', () => {
+    it('skips entries without topicId', async () => {
       const jsonlPath = path.join(tmpDir, 'messages.jsonl');
       const lines = [
         JSON.stringify({ messageId: 1, topicId: null, text: 'No topic', fromUser: true, timestamp: '2026-02-24T12:00:00Z' }),
@@ -753,29 +753,62 @@ describe('TopicMemory', () => {
       ];
       fs.writeFileSync(jsonlPath, lines.join('\n'));
 
-      const count = topicMemory.importFromJsonl(jsonlPath);
+      const count = await topicMemory.importFromJsonl(jsonlPath);
       expect(count).toBe(1);
     });
 
-    it('is idempotent — reimport does not duplicate', () => {
+    it('is idempotent — reimport does not duplicate', async () => {
       const jsonlPath = path.join(tmpDir, 'messages.jsonl');
       fs.writeFileSync(jsonlPath, JSON.stringify({ messageId: 1, topicId: 100, text: 'Hello', fromUser: true, timestamp: '2026-02-24T12:00:00Z' }));
 
-      topicMemory.importFromJsonl(jsonlPath);
-      const count2 = topicMemory.importFromJsonl(jsonlPath);
+      await topicMemory.importFromJsonl(jsonlPath);
+      const count2 = await topicMemory.importFromJsonl(jsonlPath);
       expect(count2).toBe(0);
 
       expect(topicMemory.getRecentMessages(100)).toHaveLength(1);
     });
 
-    it('returns 0 for missing file', () => {
-      const count = topicMemory.importFromJsonl('/nonexistent/path.jsonl');
+    it('returns 0 for missing file', async () => {
+      const count = await topicMemory.importFromJsonl('/nonexistent/path.jsonl');
       expect(count).toBe(0);
+    });
+
+    it('returns 0 for an empty file and leaves the DB untouched', async () => {
+      const jsonlPath = path.join(tmpDir, 'empty.jsonl');
+      fs.writeFileSync(jsonlPath, '');
+
+      const count = await topicMemory.importFromJsonl(jsonlPath);
+      expect(count).toBe(0);
+      expect(topicMemory.stats().totalMessages).toBe(0);
+    });
+
+    it('tolerates blank lines between JSONL entries', async () => {
+      const jsonlPath = path.join(tmpDir, 'blanks.jsonl');
+      const body = [
+        '',
+        JSON.stringify({ messageId: 1, topicId: 100, text: 'First', fromUser: true, timestamp: '2026-02-24T12:00:00Z' }),
+        '',
+        JSON.stringify({ messageId: 2, topicId: 100, text: 'Second', fromUser: false, timestamp: '2026-02-24T12:01:00Z' }),
+        '',
+      ].join('\n');
+      fs.writeFileSync(jsonlPath, body);
+
+      const count = await topicMemory.importFromJsonl(jsonlPath);
+      expect(count).toBe(2);
+    });
+
+    it('returns a Promise<number> (async signature)', () => {
+      const jsonlPath = path.join(tmpDir, 'signature.jsonl');
+      fs.writeFileSync(jsonlPath, '');
+
+      const result = topicMemory.importFromJsonl(jsonlPath);
+      expect(result).toBeInstanceOf(Promise);
+      return expect(result).resolves.toBe(0);
     });
   });
 
   describe('rebuild', () => {
-    it('clears existing messages and reimports', () => {
+    it('clears existing messages and reimports', async () => {
       // Insert a message directly
       topicMemory.insertMessage({
         messageId: 999, topicId: 100, text: 'Direct insert',
@@ -788,7 +821,7 @@ describe('TopicMemory', () => {
         messageId: 1, topicId: 200, text: 'From JSONL', fromUser: true, timestamp: '2026-02-24T12:01:00Z',
       }));
 
-      const count = topicMemory.rebuild(jsonlPath);
+      const count = await topicMemory.rebuild(jsonlPath);
       expect(count).toBe(1);
 
       // Old message should be gone
@@ -797,16 +830,25 @@ describe('TopicMemory', () => {
       expect(topicMemory.getRecentMessages(200)).toHaveLength(1);
     });
 
-    it('preserves summaries across rebuild', () => {
+    it('preserves summaries across rebuild', async () => {
       topicMemory.saveTopicSummary(100, 'Important summary', 10, 5);
 
       const jsonlPath = path.join(tmpDir, 'messages.jsonl');
       fs.writeFileSync(jsonlPath, '');
-      topicMemory.rebuild(jsonlPath);
+      await topicMemory.rebuild(jsonlPath);
 
       const summary = topicMemory.getTopicSummary(100);
       expect(summary).not.toBeNull();
       expect(summary!.summary).toBe('Important summary');
+    });
+
+    it('returns a Promise<number> (async signature)', () => {
+      const jsonlPath = path.join(tmpDir, 'signature-rebuild.jsonl');
+      fs.writeFileSync(jsonlPath, '');
+
+      const result = topicMemory.rebuild(jsonlPath);
+      expect(result).toBeInstanceOf(Promise);
+      return expect(result).resolves.toBe(0);
     });
   });
 
@@ -1007,12 +1049,12 @@ describe('TopicMemory', () => {
       expect(uninit.listTopics()).toHaveLength(0);
     });
 
-    it('importFromJsonl returns 0', () => {
-      expect(uninit.importFromJsonl('/nonexistent')).toBe(0);
+    it('importFromJsonl returns 0', async () => {
+      await expect(uninit.importFromJsonl('/nonexistent')).resolves.toBe(0);
     });
 
-    it('rebuild returns 0', () => {
-      expect(uninit.rebuild('/nonexistent')).toBe(0);
+    it('rebuild returns 0', async () => {
+      await expect(uninit.rebuild('/nonexistent')).resolves.toBe(0);
     });
 
     it('getMessageCount returns 0', () => {

--- a/tests/unit/topic-memory.test.ts
+++ b/tests/unit/topic-memory.test.ts
@@ -20,7 +20,7 @@
  * - Empty/edge cases
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -804,6 +804,81 @@ describe('TopicMemory', () => {
       const result = topicMemory.importFromJsonl(jsonlPath);
       expect(result).toBeInstanceOf(Promise);
       return expect(result).resolves.toBe(0);
+    });
+
+    it('counts malformed JSON lines and surfaces them via getLastImportStats()', async () => {
+      const jsonlPath = path.join(tmpDir, 'corrupt.jsonl');
+      const body = [
+        JSON.stringify({ messageId: 1, topicId: 100, text: 'Valid', fromUser: true, timestamp: '2026-02-24T12:00:00Z' }),
+        '{ not valid json',                                              // malformed
+        'also not json at all',                                          // malformed
+        JSON.stringify({ messageId: 2, topicId: 100, text: 'Valid 2', fromUser: false, timestamp: '2026-02-24T12:01:00Z' }),
+        '{"messageId":3}',                                               // valid json, missing topicId/text
+      ].join('\n');
+      fs.writeFileSync(jsonlPath, body);
+
+      const count = await topicMemory.importFromJsonl(jsonlPath);
+      expect(count).toBe(2);
+
+      const stats = topicMemory.getLastImportStats();
+      expect(stats).not.toBeNull();
+      expect(stats!.imported).toBe(2);
+      expect(stats!.malformed).toBe(2);
+      expect(stats!.missingFields).toBe(1);
+    });
+
+    it('logs a single summary warning when malformed lines are present', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const jsonlPath = path.join(tmpDir, 'warn.jsonl');
+        fs.writeFileSync(jsonlPath, [
+          JSON.stringify({ messageId: 1, topicId: 100, text: 'Ok', fromUser: true, timestamp: '2026-02-24T12:00:00Z' }),
+          'garbage line',
+        ].join('\n'));
+
+        await topicMemory.importFromJsonl(jsonlPath);
+
+        const matchingCalls = warnSpy.mock.calls.filter(
+          (call) => typeof call[0] === 'string' && call[0].includes('importFromJsonl') && call[0].includes('malformed_json=1'),
+        );
+        expect(matchingCalls.length).toBe(1);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('does NOT log a warning when the JSONL is clean (quiet by default)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const jsonlPath = path.join(tmpDir, 'clean.jsonl');
+        fs.writeFileSync(jsonlPath, [
+          JSON.stringify({ messageId: 1, topicId: 100, text: 'Ok', fromUser: true, timestamp: '2026-02-24T12:00:00Z' }),
+          JSON.stringify({ messageId: 2, topicId: 100, text: 'Ok2', fromUser: false, timestamp: '2026-02-24T12:01:00Z' }),
+          '',
+        ].join('\n'));
+
+        await topicMemory.importFromJsonl(jsonlPath);
+
+        const matchingCalls = warnSpy.mock.calls.filter(
+          (call) => typeof call[0] === 'string' && call[0].includes('importFromJsonl'),
+        );
+        expect(matchingCalls.length).toBe(0);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('getLastImportStats() returns null before any import runs', async () => {
+      // Fresh instance, no import yet
+      const freshDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fresh-tm-'));
+      const fresh = new TopicMemory(freshDir);
+      await fresh.open();
+      try {
+        expect(fresh.getLastImportStats()).toBeNull();
+      } finally {
+        fresh.close();
+        fs.rmSync(freshDir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace `fs.readFileSync` + `.split('\n')` in `TopicMemory.importFromJsonl()` with `readline.createInterface` on a `fs.createReadStream`
- Process lines in batches of 500 (transaction per batch) for write efficiency while keeping memory usage constant
- `importFromJsonl()` and `rebuild()` are now async; the `open()` call is updated to await

## Problem

`TopicMemory.importFromJsonl()` loads the entire JSONL file into memory as a single string, then splits it into an array of lines. For agents with 100K+ messages, this means holding the full file (potentially hundreds of MB) plus the split array plus the parsed message objects all in memory simultaneously. This will OOM on resource-constrained environments.

## Test plan

- [ ] Verify import still works correctly with small JSONL files
- [ ] Test with a large synthetic JSONL (100K+ lines) — memory usage should stay flat
- [ ] Confirm deduplication still works (INSERT OR IGNORE)
- [ ] Verify auto-rebuild from JSONL in open() still functions after corruption recovery
- [ ] Check that rebuild() correctly awaits the streaming import

🤖 Generated with [Claude Code](https://claude.com/claude-code)