### PR TITLE
fix: wire threadline_history to actually retrieve messages

### DIFF
--- a/src/threadline/ThreadlineEndpoints.ts
+++ b/src/threadline/ThreadlineEndpoints.ts
@@ -427,16 +427,31 @@ export function createThreadlineRoutes(
 
   // ── Messages: Thread (AUTHENTICATED) ───────────────────────────
 
-  router.get('/threadline/messages/thread/:id', threadlineAuth, (_req: Request, res: Response) => {
-    // Thread retrieval — returns messages in this thread
-    // For now, this returns a placeholder. Full implementation depends on
-    // MessageStore integration which is outside Phase 3 scope.
+  router.get('/threadline/messages/thread/:id', threadlineAuth, async (_req: Request, res: Response) => {
     const threadId = _req.params.id;
-    res.json({
-      threadId,
-      messages: [],
-      messageCount: 0,
-    });
+    const limit = parseInt(_req.query.limit as string, 10) || 50;
+
+    if (!threadlineRouter) {
+      res.json({ threadId, messages: [], messageCount: 0 });
+      return;
+    }
+
+    try {
+      const result = await threadlineRouter.getThreadMessages(threadId, limit);
+      res.json({
+        threadId: result.threadId,
+        messages: result.messages,
+        messageCount: result.totalCount,
+        hasMore: result.hasMore,
+      });
+    } catch (err) {
+      res.status(500).json(makeError(
+        ERROR_CODES.TL_INTERNAL_ERROR,
+        `Thread retrieval failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        true,
+        5,
+      ));
+    }
   });
 
   // ── Blobs: Fetch (AUTHENTICATED) ──────────────────────────────

--- a/src/threadline/ThreadlineRouter.ts
+++ b/src/threadline/ThreadlineRouter.ts
@@ -18,7 +18,7 @@ import crypto from 'node:crypto';
 import type { MessageRouter } from '../messaging/MessageRouter.js';
 import type { SpawnRequestManager, SpawnResult } from '../messaging/SpawnRequestManager.js';
 import type { MessageStore } from '../messaging/MessageStore.js';
-import type { IMessageDelivery } from '../messaging/types.js';
+import type { IMessageDelivery, MessageThread } from '../messaging/types.js';
 import type { MessageEnvelope, AgentMessage } from '../messaging/types.js';
 import type { ThreadResumeMap, ThreadResumeEntry, ThreadState } from './ThreadResumeMap.js';
 import type { AutonomyGate } from './AutonomyGate.js';
@@ -179,6 +179,11 @@ export class ThreadlineRouter {
     try {
       this.pendingSpawns.add(threadId);
 
+      // Persist the inbound message to the MessageStore so it can be queried
+      // later via threadline_history. Without this, relay messages were only
+      // injected as session context and lost after session end.
+      await this.persistInboundMessage(envelope);
+
       // Phase 2: Check the autonomy gate before processing
       if (this.autonomyGate) {
         const gateResult = await this.autonomyGate.evaluate(envelope);
@@ -235,6 +240,39 @@ export class ThreadlineRouter {
     } finally {
       this.pendingSpawns.delete(threadId);
     }
+  }
+
+  /**
+   * Get thread messages from the MessageStore. Used by ThreadlineEndpoints
+   * and the threadline_history MCP tool to retrieve conversation history.
+   */
+  async getThreadMessages(threadId: string, limit?: number): Promise<{
+    threadId: string;
+    messages: Array<{ id: string; from: string; body: string; timestamp: string; threadId: string }>;
+    totalCount: number;
+    hasMore: boolean;
+  }> {
+    const threadData = await this.messageRouter.getThread(threadId);
+    if (!threadData || threadData.messages.length === 0) {
+      return { threadId, messages: [], totalCount: 0, hasMore: false };
+    }
+
+    const maxMessages = limit ?? 50;
+    const allMessages = threadData.messages.map(env => ({
+      id: env.message.id,
+      from: env.message.from.agent,
+      body: env.message.body,
+      timestamp: env.message.createdAt,
+      threadId: env.message.threadId ?? threadId,
+    }));
+
+    const limited = allMessages.slice(-maxMessages);
+    return {
+      threadId,
+      messages: limited,
+      totalCount: threadData.thread.messageCount,
+      hasMore: allMessages.length > maxMessages,
+    };
   }
 
   /**
@@ -468,6 +506,77 @@ export class ThreadlineRouter {
     } catch (err) {
       console.warn(`[ThreadlineRouter] Live-session injection threw for thread ${threadId}:`, err);
       return null;
+    }
+  }
+
+  // ── Private: Persist inbound message to MessageStore ─────────
+
+  /**
+   * Save an inbound relay message to the local MessageStore and update
+   * thread tracking. This makes relay messages queryable via the
+   * threadline_history MCP tool and the /messages/thread/:id endpoint.
+   */
+  private async persistInboundMessage(envelope: MessageEnvelope): Promise<void> {
+    try {
+      const { message } = envelope;
+      const threadId = message.threadId;
+      if (!threadId) return;
+
+      // Save the envelope to the message store
+      await this.messageStore.save(envelope);
+
+      // Update thread tracking (create or append to thread)
+      const now = message.createdAt || new Date().toISOString();
+      let thread = await this.messageStore.getThread(threadId);
+
+      if (!thread) {
+        thread = {
+          id: threadId,
+          subject: message.subject || 'Relay conversation',
+          participants: [{
+            agent: message.from.agent,
+            session: message.from.session || 'relay',
+            joinedAt: now,
+            lastMessageAt: now,
+          }],
+          createdAt: now,
+          lastMessageAt: now,
+          messageCount: 1,
+          status: 'active',
+          messageIds: [message.id],
+        };
+      } else {
+        thread.lastMessageAt = now;
+        thread.messageCount++;
+        if (!thread.messageIds.includes(message.id)) {
+          thread.messageIds.push(message.id);
+        }
+
+        // Un-stale the thread if it received a new message
+        if (thread.status === 'stale') {
+          thread.status = 'active';
+        }
+
+        // Add or update participant
+        const participant = thread.participants.find(
+          p => p.agent === message.from.agent,
+        );
+        if (participant) {
+          participant.lastMessageAt = now;
+        } else {
+          thread.participants.push({
+            agent: message.from.agent,
+            session: message.from.session || 'relay',
+            joinedAt: now,
+            lastMessageAt: now,
+          });
+        }
+      }
+
+      await this.messageStore.saveThread(thread);
+    } catch (err) {
+      // Non-fatal: persistence failure should not block message handling
+      console.warn(`[ThreadlineRouter] Failed to persist inbound message: ${err instanceof Error ? err.message : err}`);
     }
   }
 

--- a/src/threadline/mcp-stdio-entry.ts
+++ b/src/threadline/mcp-stdio-entry.ts
@@ -153,6 +153,71 @@ async function sendMessageViaHttp(
   }
 }
 
+// ── Thread history retrieval via HTTP (talks to the running agent server) ──
+
+/**
+ * Retrieve thread history via the agent server's messaging endpoint.
+ * The server stores messages in its MessageStore and tracks threads;
+ * this function queries that data through the /messages/thread/:id API.
+ */
+async function getThreadHistoryViaHttp(
+  threadId: string,
+  limit: number,
+  before: string | undefined,
+  serverPort: number,
+  agentToken: string,
+): Promise<ThreadHistoryResult> {
+  try {
+    const url = `http://localhost:${serverPort}/messages/thread/${encodeURIComponent(threadId)}`;
+    const response = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${agentToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      return { threadId, messages: [], totalCount: 0, hasMore: false };
+    }
+
+    const data = await response.json() as {
+      thread?: { messageCount?: number; subject?: string };
+      messages?: Array<{
+        message: { id: string; from: { agent: string }; body: string; createdAt: string; threadId?: string };
+      }>;
+    };
+
+    const rawMessages = data.messages ?? [];
+
+    // Apply 'before' filter if provided
+    let filtered = before
+      ? rawMessages.filter(env => env.message.createdAt < before)
+      : rawMessages;
+
+    // Sort chronologically (oldest first)
+    filtered.sort((a, b) => a.message.createdAt.localeCompare(b.message.createdAt));
+
+    const totalCount = data.thread?.messageCount ?? filtered.length;
+    const hasMore = filtered.length > limit;
+    const limited = filtered.slice(-limit);
+
+    return {
+      threadId,
+      messages: limited.map(env => ({
+        id: env.message.id,
+        from: env.message.from.agent,
+        body: env.message.body,
+        timestamp: env.message.createdAt,
+        threadId: env.message.threadId ?? threadId,
+      })),
+      totalCount,
+      hasMore,
+    };
+  } catch {
+    // Server unreachable — return empty rather than failing the tool
+    return { threadId, messages: [], totalCount: 0, hasMore: false };
+  }
+}
+
 // ── Registry Client Setup ────────────────────────────────────────────
 
 async function setupRegistryClient(
@@ -248,8 +313,8 @@ async function main(): Promise<void> {
       trustManager,
       auth: null, // No auth for stdio
       sendMessage: (params) => sendMessageViaHttp(params, serverPort, agentToken),
-      getThreadHistory: (threadId, _limit) =>
-        Promise.resolve({ threadId, messages: [], totalCount: 0, hasMore: false } as ThreadHistoryResult),
+      getThreadHistory: (threadId, limit, before) =>
+        getThreadHistoryViaHttp(threadId, limit, before, serverPort, agentToken),
       registry: registryClient,
     },
   );


### PR DESCRIPTION
## Summary

- **threadline_history MCP tool** was a stub returning empty arrays — agents could detect message count changes but never read content
- **Inbound relay messages** were injected as session context but never persisted to MessageStore, making them unqueryable
- **/threadline/messages/thread/:id** HTTP endpoint was a placeholder returning empty

## Changes

1. **ThreadlineRouter**: persist inbound relay messages to MessageStore when they arrive via `persistInboundMessage()`, with full thread tracking (create/update thread, manage participants)
2. **mcp-stdio-entry**: replace hardcoded empty stub with `getThreadHistoryViaHttp()` that calls the server's existing `/messages/thread/:id` endpoint
3. **ThreadlineEndpoints**: wire the placeholder endpoint to use the new `ThreadlineRouter.getThreadMessages()` public method

## Root cause

In `mcp-stdio-entry.ts`, the `getThreadHistory` dependency was:
\`\`\`typescript
getThreadHistory: (threadId, _limit) =>
  Promise.resolve({ threadId, messages: [], totalCount: 0, hasMore: false })
\`\`\`

And relay messages bypassed the MessageStore entirely — they were converted to spawn prompts but never saved for later retrieval.

## Test plan

- [x] TypeScript compiles cleanly (tsc --noEmit)
- [x] All 39 ThreadlineMCPServer unit tests pass
- [x] All 16 ThreadlineEndpoints unit tests pass
- [x] Full test suite: 11,879 tests passed, 0 failed
- [ ] Integration test: send a relay message, then call threadline_history — should return the message content
- [ ] Verify buildHistoryContext now returns history for relay threads (used by session resume prompts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)