### PR TITLE
docs: iMessage photo attachments watcher with dedicated Go binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,15 +206,16 @@ iMessage support lets your agent send and receive iMessages on macOS. Messages a
 ### Prerequisites
 
 1. **macOS** with Messages.app signed into an Apple ID
-2. **Full Disk Access** for your terminal app, *for first startup only* (System Settings → Privacy & Security → Full Disk Access → add Terminal.app or iTerm). Instar hardlinks `chat.db` to `.instar/imessage/` on first startup so subsequent runs don't need FDA — useful for LaunchDaemon deployments.
+2. **Full Disk Access** for your terminal app (System Settings → Privacy & Security → Full Disk Access → add Terminal.app or iTerm)
 3. **imsg CLI** installed:
    ```bash
    brew install steipete/tap/imsg
    ```
 4. **Automation permission** for Messages.app — macOS will prompt on first send
 
-For running as a LaunchDaemon (always-on, survives reboots), see [docs/LAUNCHDAEMON-SETUP.md](docs/LAUNCHDAEMON-SETUP.md).
+> **Photo attachments:** If you want your agent to process images and files sent via iMessage, the `instar-attachments-sync` binary must also be running with Full Disk Access granted to it. It mirrors attachments from the Messages sandbox to a readable location. See [docs/LAUNCHDAEMON-SETUP.md#3-imessage-photo-attachments-optional](docs/LAUNCHDAEMON-SETUP.md#3-imessage-photo-attachments-optional) for setup.
 
+For running as a LaunchDaemon (always-on, survives reboots), see [docs/LAUNCHDAEMON-SETUP.md](docs/LAUNCHDAEMON-SETUP.md).
 ### Configuration
 
 Add to your `.instar/config.json`:

--- a/docs/LAUNCHDAEMON-SETUP.md
+++ b/docs/LAUNCHDAEMON-SETUP.md
@@ -75,7 +75,96 @@ When `dbPath` is set, the adapter uses it as-is and does not create hardlinks.
 
 In practice: most setups have someone log in eventually, and sending works thereafter.
 
-## 3. Node binary path
+## 3. iMessage photo attachments (optional)
+
+If your agent needs to receive and process **photo attachments** sent via iMessage (not just text), a second piece of infrastructure is required. The `chat.db` hardlink approach only covers message text — photo files live in `~/Library/Messages/Attachments/`, which is a separate TCC-protected directory.
+
+### Why a dedicated binary
+
+Granting FDA to a general-purpose binary like `bash`, `node`, or `fswatch` works but is broader than necessary — any process using that binary gets the same access. The right approach is a **purpose-built binary** whose name makes the FDA grant self-documenting: `instar-attachments-sync`.
+
+### What it does
+
+`instar-attachments-sync` is a small Go binary (~3MB) that:
+1. On startup, hardlinks all existing image/video attachments from `~/Library/Messages/Attachments/` to `.instar/imessage/attachments/`
+2. Watches for new files via FSEvents and hardlinks them within ~500ms of arrival
+3. Prunes hardlinks whose source has been deleted
+
+Hardlinks share the same inode as the originals, so the agent can read them without any FDA grant of its own.
+
+### Build and install
+
+```bash
+# Requires Go (brew install go)
+cd scripts/attachments-sync
+go build -o ~/.instar/agents/AGENT/.instar/bin/instar-attachments-sync .
+```
+
+Or copy a pre-built binary from the [releases page](https://github.com/JKHeadley/instar/releases) *(coming soon)*.
+
+### Grant Full Disk Access
+
+In **System Settings → Privacy & Security → Full Disk Access**, click `+` and add:
+
+```
+~/.instar/agents/AGENT/.instar/bin/instar-attachments-sync
+```
+
+> **Important:** FDA is granted per resolved binary path. If you rebuild or replace the binary, you must re-grant FDA. Use the Cellar path or a stable location that won't change.
+
+### LaunchAgent plist
+
+The attachments watcher should run as a **LaunchAgent** (not a Daemon) because it needs a user session context to access the Messages sandbox. Save to `~/Library/LaunchAgents/ai.instar.AttachmentsWatcher.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.instar.AttachmentsWatcher</string>
+    <key>Program</key>
+    <string>/Users/YOU/.instar/agents/AGENT/.instar/bin/instar-attachments-sync</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/YOU/.instar/agents/AGENT/.instar/logs/attachments-watcher.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOU/.instar/agents/AGENT/.instar/logs/attachments-watcher.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/YOU</string>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+</dict>
+</plist>
+```
+
+Load it:
+```bash
+launchctl load ~/Library/LaunchAgents/ai.instar.AttachmentsWatcher.plist
+```
+
+### Verify
+
+```bash
+tail -f ~/.instar/agents/AGENT/.instar/logs/attachments-watcher.log
+```
+
+You should see:
+```
+2026-01-01T00:00:00Z instar-attachments-sync starting
+2026-01-01T00:00:00Z initial sync: linked N new files
+2026-01-01T00:00:00Z watching /Users/YOU/Library/Messages/Attachments
+```
+
+If you see `operation not permitted`, FDA has not been granted or was granted to a different binary path.
+
+## 4. Node binary path
 
 Instar symlinks `.instar/bin/node` to a node binary. If multiple Homebrew prefixes exist (e.g., `/opt/homebrew` and `/Users/you/homebrew`), the symlink may point to the wrong one. This matters if you've granted FDA to a specific binary — FDA is per-path.
 

--- a/scripts/attachments-sync/go.mod
+++ b/scripts/attachments-sync/go.mod
@@ -1,0 +1,8 @@
+module instar-attachments-sync
+
+go 1.26.2
+
+require (
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+)

--- a/scripts/attachments-sync/go.sum
+++ b/scripts/attachments-sync/go.sum
@@ -1,0 +1,4 @@
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/scripts/attachments-sync/main.go
+++ b/scripts/attachments-sync/main.go
@@ -1,0 +1,253 @@
+// instar-attachments-sync
+//
+// Purpose-built binary for mirroring iMessage photo attachments to a
+// readable location for the Instar agent. This binary is granted Full
+// Disk Access in macOS Privacy settings — nothing else needs it.
+//
+// What it does (and only what it does):
+//   1. On startup: hardlink all existing image/video attachments from
+//      ~/Library/Messages/Attachments/ to DEST_DIR.
+//   2. Continuously watch for new files via FSEvents and hardlink them.
+//   3. Prune dead hardlinks (source deleted, link count == 1).
+//
+// Naming convention: {first8ofUUID}__{original-filename}
+// This mirrors the bash script it replaces, so existing hardlinks remain valid.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+var (
+	homeDir  = os.Getenv("HOME")
+	srcDir   = filepath.Join(homeDir, "Library/Messages/Attachments")
+	destDir  string
+	logFile  string
+)
+
+// Supported extensions to mirror
+var exts = map[string]bool{
+	".jpeg": true, ".jpg": true, ".png": true, ".heic": true,
+	".mov": true, ".mp4": true, ".pdf": true, ".gif": true,
+	".caf": true, ".m4a": true, ".3gpp": true,
+}
+
+func main() {
+	// Resolve paths relative to this binary's location.
+	// Binary lives at <agentRoot>/.instar/bin/instar-attachments-sync
+	// So .instar dir is filepath.Dir(filepath.Dir(exe))
+	exe, err := os.Executable()
+	if err != nil {
+		log.Fatalf("cannot resolve executable path: %v", err)
+	}
+	dotInstar := filepath.Dir(filepath.Dir(exe)) // <agentRoot>/.instar
+	destDir = filepath.Join(dotInstar, "imessage/attachments")
+	logFile = filepath.Join(dotInstar, "logs/attachments-watcher.log")
+
+	// Override via env for testing
+	if v := os.Getenv("ATTACHMENTS_DEST"); v != "" {
+		destDir = v
+	}
+	if v := os.Getenv("ATTACHMENTS_LOG"); v != "" {
+		logFile = v
+	}
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		log.Fatalf("cannot create dest dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(logFile), 0755); err != nil {
+		log.Fatalf("cannot create log dir: %v", err)
+	}
+
+	lf, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatalf("cannot open log: %v", err)
+	}
+	log.SetOutput(lf)
+	log.SetFlags(0) // we write our own timestamps
+
+	logMsg("instar-attachments-sync starting")
+	logMsg("src=%s dest=%s", srcDir, destDir)
+
+	// Initial sync
+	n, err := syncOnce()
+	if err != nil {
+		logMsg("initial sync error: %v", err)
+	} else {
+		logMsg("initial sync: linked %d new files", n)
+	}
+
+	// Watch for new files
+	if err := watch(); err != nil {
+		logMsg("watcher error: %v", err)
+		os.Exit(1)
+	}
+}
+
+// syncOnce walks srcDir and hardlinks any new supported files to destDir.
+// Returns count of newly linked files.
+func syncOnce() (int, error) {
+	count := 0
+	err := filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// Skip dirs/files we can't read — log once at top level
+			if path == srcDir {
+				return fmt.Errorf("cannot read source dir %s: %w", srcDir, err)
+			}
+			return nil
+		}
+		if info.IsDir() || strings.HasPrefix(info.Name(), ".") {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(info.Name()))
+		if !exts[ext] {
+			return nil
+		}
+		if linked, err := linkFile(path); err != nil {
+			logMsg("link error %s: %v", path, err)
+		} else if linked {
+			count++
+		}
+		return nil
+	})
+	// Prune dead hardlinks
+	pruneDeadLinks()
+	return count, err
+}
+
+// linkFile creates a hardlink in destDir for the given source file.
+// Returns true if a new link was created, false if it already existed.
+func linkFile(src string) (bool, error) {
+	base := filepath.Base(src)
+	// Parent dir is the UUID directory
+	uuid := filepath.Base(filepath.Dir(src))
+	prefix := uuid
+	if len(prefix) > 8 {
+		prefix = prefix[:8]
+	}
+	destName := prefix + "__" + base
+	dest := filepath.Join(destDir, destName)
+
+	// Check if already linked (same inode)
+	if isSameInode(src, dest) {
+		return false, nil
+	}
+
+	// Remove stale dest if present
+	if _, err := os.Lstat(dest); err == nil {
+		os.Remove(dest)
+	}
+
+	if err := os.Link(src, dest); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// isSameInode returns true if both paths exist and share an inode.
+func isSameInode(a, b string) bool {
+	sa, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	sb, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	sia, ok1 := sa.Sys().(*syscall.Stat_t)
+	sib, ok2 := sb.Sys().(*syscall.Stat_t)
+	return ok1 && ok2 && sia.Ino == sib.Ino
+}
+
+// pruneDeadLinks removes hardlinks whose source has been deleted (link count == 1).
+func pruneDeadLinks() {
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		path := filepath.Join(destDir, e.Name())
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if st, ok := info.Sys().(*syscall.Stat_t); ok && st.Nlink == 1 {
+			os.Remove(path)
+		}
+	}
+}
+
+// watch uses fsnotify to watch srcDir and re-runs syncOnce on changes.
+func watch() error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("fsnotify: %w", err)
+	}
+	defer watcher.Close()
+
+	// Watch top-level src dir; we'll add subdirs as they appear
+	if err := watcher.Add(srcDir); err != nil {
+		return fmt.Errorf("watch %s: %w", srcDir, err)
+	}
+
+	// Also watch existing subdirs (Messages uses 2-level nesting)
+	_ = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err == nil && info.IsDir() {
+			watcher.Add(path) //nolint
+		}
+		return nil
+	})
+
+	logMsg("watching %s", srcDir)
+
+	debounce := time.NewTimer(0)
+	<-debounce.C // drain initial fire
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return fmt.Errorf("watcher channel closed")
+			}
+			// Watch new subdirectories as they're created
+			if event.Has(fsnotify.Create) {
+				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+					watcher.Add(event.Name) //nolint
+				}
+			}
+			// Debounce: wait 500ms after last event before syncing
+			debounce.Reset(500 * time.Millisecond)
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return fmt.Errorf("watcher error channel closed")
+			}
+			logMsg("watcher error: %v", err)
+
+		case <-debounce.C:
+			n, err := syncOnce()
+			if err != nil {
+				logMsg("sync error: %v", err)
+			} else if n > 0 {
+				logMsg("linked %d new files", n)
+			}
+		}
+	}
+}
+
+func logMsg(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	log.Printf("%s %s", time.Now().UTC().Format("2006-01-02T15:04:05Z"), msg)
+}


### PR DESCRIPTION
## Summary

- Introduces `instar-attachments-sync`, a purpose-built Go binary that mirrors iMessage photo attachments from the macOS Messages sandbox to a readable location for the agent
- Adds **Section 3** to `docs/LAUNCHDAEMON-SETUP.md` covering the attachments watcher, FDA grant, and LaunchAgent plist template
- Adds a callout in the README iMessage prerequisites pointing to the new section

## Problem

The existing iMessage setup docs covered `chat.db` hardlinks for receiving message text, but said nothing about photo attachments. `~/Library/Messages/Attachments/` is a separate TCC-protected directory — neither `node`, `bash`, nor `fswatch` should be granted broad FDA just to watch it.

## Solution

A dedicated Go binary (`instar-attachments-sync`) with a self-documenting name. FDA is granted only to this one binary, keeping the permission scope minimal and auditable. It:

1. Hardlinks existing attachments on startup
2. Watches for new files via FSEvents (fsnotify) with 500ms debounce
3. Prunes dead hardlinks when source files are deleted

## Files changed

- `scripts/attachments-sync/` — Go source (main.go, go.mod, go.sum)
- `docs/LAUNCHDAEMON-SETUP.md` — new section with build instructions, FDA grant steps, LaunchAgent plist template, and verification steps
- `README.md` — callout note in iMessage prerequisites

## Test plan

- [ ] Build binary: `cd scripts/attachments-sync && go build -o ~/.instar/agents/AGENT/.instar/bin/instar-attachments-sync .`
- [ ] Grant FDA to binary in System Settings → Privacy & Security → Full Disk Access
- [ ] Load LaunchAgent plist and verify log shows `initial sync: linked N new files` then `watching ...`
- [ ] Send a photo via iMessage and verify it appears in `.instar/imessage/attachments/` within ~1 second
- [ ] Verify `operation not permitted` appears in log if FDA is revoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)