### PR TITLE
Integrate origin fixes + unblock pre-push test (scratch experiment)

### DIFF
--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -167,8 +167,10 @@ async function showHistory(baseUrl: string, authToken: string | undefined, json?
       reports: Array<{
         timestamp: string;
         status: string;
-        summary: { total: number; passed: number; failed: number };
-        duration: number;
+        stats?: { total: number; passed: number; failed: number; skipped: number; durationMs: number };
+        summary?: { total: number; passed: number; failed: number };
+        duration?: number;
+        results?: Array<{ name: string; passed: boolean }>;
       }>;
     };
 
@@ -189,7 +191,14 @@ async function showHistory(baseUrl: string, authToken: string | undefined, json?
         : r.status === 'degraded' ? pc.yellow
         : pc.red;
       const date = new Date(r.timestamp).toLocaleString();
-      console.log(`  ${pc.dim(date)}  ${statusColor(r.status.padEnd(10))}  ${pc.green(String(r.summary.passed))}/${r.summary.total} passed  ${pc.dim(`${r.duration}ms`)}`);
+      const stats = r.stats ?? (r.summary ? { total: r.summary.total, passed: r.summary.passed, failed: r.summary.failed, durationMs: r.duration ?? 0 } : { total: 0, passed: 0, failed: 0, durationMs: 0 });
+      console.log(`  ${pc.dim(date)}  ${statusColor(r.status.padEnd(10))}  ${pc.green(String(stats.passed))}/${stats.total} passed  ${pc.dim(`${stats.durationMs}ms`)}`);
+      if (stats.failed > 0 && Array.isArray(r.results)) {
+        const failedNames = r.results.filter(x => !x.passed).map(x => x.name);
+        if (failedNames.length > 0) {
+          console.log(pc.red(`      ✗ ${failedNames.join(', ')}`));
+        }
+      }
     }
     console.log();
   } catch (err) {

--- a/src/core/ContextHierarchy.ts
+++ b/src/core/ContextHierarchy.ts
@@ -280,19 +280,39 @@ export class ContextHierarchy {
 
   /**
    * List all context segments with their status.
+   *
+   * Returns absolute filePath and a stat error (if any) for each segment so
+   * that agents seeing unexpected zero sizes can self-diagnose path or
+   * permission mismatches instead of guessing. A single fs.statSync is used
+   * (no existsSync + statSync race window) so `exists` and `sizeBytes` always
+   * agree: if the stat succeeds, both reflect reality; if it fails, both are
+   * defaulted and `statError` explains why.
    */
-  listSegments(): Array<ContextSegment & { exists: boolean; sizeBytes: number }> {
+  listSegments(): Array<ContextSegment & {
+    exists: boolean;
+    sizeBytes: number;
+    filePath: string;
+    statError?: string;
+  }> {
     return DEFAULT_SEGMENTS.map(s => {
       const filePath = path.join(this.contextDir, s.file);
       let exists = false;
       let sizeBytes = 0;
+      let statError: string | undefined;
       try {
-        if (fs.existsSync(filePath)) {
-          exists = true;
-          sizeBytes = fs.statSync(filePath).size;
+        const stat = fs.statSync(filePath);
+        exists = true;
+        sizeBytes = stat.size;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        // ENOENT = file doesn't exist, which is a normal "not yet created"
+        // state. Anything else (EACCES, EISDIR, etc.) is a real signal worth
+        // surfacing so agents can investigate.
+        if (code !== 'ENOENT') {
+          statError = `${code ?? 'UNKNOWN'}: ${(err as Error).message}`;
         }
-      } catch { /* ignore */ }
-      return { ...s, exists, sizeBytes };
+      }
+      return { ...s, exists, sizeBytes, filePath, ...(statError ? { statError } : {}) };
     });
   }
 

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-04-13T06:07:11.663Z",
-  "instarVersion": "0.28.30",
+  "generatedAt": "2026-04-14T18:20:59.324Z",
+  "instarVersion": "0.28.34",
   "entryCount": 186,
   "entries": {
     "hook:session-start": {
@@ -376,7 +376,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -384,7 +384,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -728,7 +728,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "37726327a3bb8661140d5b9d33b3dba62aa47714691fdba8257299ed4d080e62",
+      "contentHash": "8d678480ddb948808a5f6a8546cd8d5f63e3f76b48328dd3176335d00900fa19",
       "since": "2025-01-01"
     },
     "cli:init": {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -3002,6 +3002,73 @@ export function createRoutes(ctx: RouteContext): Router {
     res.json({ slug, enabled: body.enabled, message: `Job ${body.enabled ? 'enabled' : 'disabled'}` });
   });
 
+  // ── Reset Job State ───────────────────────────────────────────
+  //
+  // Clears stale pending/failure state for a job. Useful when a session dies
+  // without reporting back, leaving lastResult stuck on 'pending' forever.
+
+  router.post('/jobs/:slug/reset-state', (req, res) => {
+    const { slug } = req.params;
+
+    if (!/^[a-z0-9-]+$/.test(slug)) {
+      res.status(400).json({ error: 'Invalid job slug' });
+      return;
+    }
+    if (!ctx.scheduler) {
+      res.status(503).json({ error: 'Scheduler not running' });
+      return;
+    }
+
+    const job = ctx.scheduler.getJobs().find(j => j.slug === slug);
+    if (!job) {
+      res.status(404).json({ error: `Job not found: ${slug}` });
+      return;
+    }
+
+    const existing = ctx.state.getJobState(slug);
+    const previousResult = existing?.lastResult ?? 'none';
+
+    const resetState: import('../core/types.js').JobState = {
+      slug,
+      lastRun: existing?.lastRun,
+      lastResult: 'failure',
+      lastError: `Manually reset from '${previousResult}' state`,
+      lastHandoff: existing?.lastHandoff,
+      nextScheduled: existing?.nextScheduled,
+      consecutiveFailures: 0,
+    };
+    ctx.state.saveJobState(resetState);
+
+    ctx.state.appendEvent({
+      type: 'job_state_reset',
+      summary: `Job "${slug}" state manually reset from '${previousResult}'`,
+      timestamp: new Date().toISOString(),
+      metadata: { slug, previousResult },
+    });
+
+    // Security log
+    try {
+      const securityEntry = JSON.stringify({
+        timestamp: new Date().toISOString(),
+        action: 'job-reset-state',
+        slug,
+        previousResult,
+        source: req.body?.source ?? 'api',
+        ip: req.ip,
+      });
+      fs.appendFileSync(path.join(ctx.config.stateDir, 'security.jsonl'), securityEntry + '\n');
+    } catch {
+      // Security logging failure is non-fatal
+    }
+
+    res.json({
+      slug,
+      previousResult,
+      newResult: 'failure',
+      message: `Job state reset from '${previousResult}' to 'failure'. Job can now be re-triggered.`,
+    });
+  });
+
   // ── Job Events (SSE) ──────────────────────────────────────────
   //
   // Server-Sent Events stream for real-time job state changes.

--- a/tests/unit/ContextHierarchy.test.ts
+++ b/tests/unit/ContextHierarchy.test.ts
@@ -163,6 +163,44 @@ describe('ContextHierarchy', () => {
         expect(s.sizeBytes).toBe(0);
       }
     });
+
+    it('returns absolute filePath for every segment for self-diagnosis', () => {
+      const ctx = new ContextHierarchy({ stateDir, projectDir, projectName: 'test-project' });
+      ctx.initialize();
+
+      const segments = ctx.listSegments();
+      for (const s of segments) {
+        expect(path.isAbsolute(s.filePath)).toBe(true);
+        expect(s.filePath).toBe(path.join(stateDir, 'context', s.file));
+      }
+    });
+
+    it('does not set statError for a missing (ENOENT) segment', () => {
+      const ctx = new ContextHierarchy({ stateDir, projectDir, projectName: 'test-project' });
+      // Don't initialize — ENOENT is the normal "not created yet" state.
+
+      const segments = ctx.listSegments();
+      for (const s of segments) {
+        expect(s.statError).toBeUndefined();
+      }
+    });
+
+    it('reports exists and sizeBytes consistently (no existsSync/statSync race)', () => {
+      const ctx = new ContextHierarchy({ stateDir, projectDir, projectName: 'test-project' });
+      ctx.initialize();
+
+      // Real bug signature from feedback: exists=true but sizeBytes=0 despite
+      // files having content. With the atomic-stat implementation, `exists`
+      // is only true when the stat succeeded — so size is the same stat's
+      // result, not a second call that could race or silently fail.
+      const segments = ctx.listSegments();
+      for (const s of segments) {
+        if (s.exists) {
+          const actual = fs.statSync(s.filePath).size;
+          expect(s.sizeBytes).toBe(actual);
+        }
+      }
+    });
   });
 
   describe('template content', () => {

--- a/tests/unit/refresh-jobs.test.ts
+++ b/tests/unit/refresh-jobs.test.ts
@@ -192,7 +192,7 @@ describe('refreshJobs()', () => {
       expect(stateCheck!.execute!.type).toBe('skill');
     });
 
-    it('uses default port 4321 when config is missing', () => {
+    it('uses default port 4040 when config is missing', () => {
       project = createTestProject({ jobs: [makeJob('health-check')] });
 
       // Delete config to simulate missing config
@@ -207,7 +207,7 @@ describe('refreshJobs()', () => {
 
       const stateCheck = updatedJobs.find(j => j.slug === 'state-integrity-check');
       if (stateCheck?.gate) {
-        expect(stateCheck.gate).toContain('4321');
+        expect(stateCheck.gate).toContain('4040');
       }
     });
   });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,35 +1,17 @@
 # Upgrade Guide — vNEXT
 
 <!-- bump: patch -->
-<!-- Valid values: patch, minor, major -->
-<!-- patch = bug fixes, refactors, test additions, doc updates -->
-<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
-<!-- major = breaking changes to existing APIs or behavior -->
 
 ## What Changed
 
-<!-- Describe what changed technically. What new features, APIs, behavioral changes? -->
-<!-- Write this for the AGENT — they need to understand the system deeply. -->
+`instar review --history` now shows the names of failing probes beneath each failed review entry, not just the pass/fail count. Previously, a report showing "13/16 passed" gave no indication of which probes failed, forcing agents to re-run a full review to diagnose. The CLI now reads the `results` array from each history entry (which was already returned by `/system-reviews/history`) and prints the names of probes where `passed === false` in red beneath the summary line. No server change — this is a pure display fix in `src/commands/review.ts`.
 
 ## What to Tell Your User
 
-<!-- Write talking points the agent should relay to their user. -->
-<!-- This should be warm, conversational, user-facing — not a changelog. -->
-<!-- Focus on what THEY can now do, not internal plumbing. -->
-<!--                                                                    -->
-<!-- PROHIBITED in this section (will fail validation):                 -->
-<!--   camelCase config keys: silentReject, maxRetries, telegramNotify -->
-<!--   Inline code backtick references like silentReject: false        -->
-<!--   Fenced code blocks                                              -->
-<!--   Instructions to edit files or run commands                      -->
-<!--                                                                    -->
-<!-- CORRECT style: "I can turn that on for you" not "set X to false"  -->
-<!-- The agent relays this to their user — keep it human.              -->
-
-- **[Feature name]**: "[Brief, friendly description of what this means for the user]"
+- **Faster health diagnosis**: "When I check my review history now, I can see exactly which probes are failing — no more re-running a full review just to find out what went wrong."
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| [Capability] | [Endpoint, command, or "automatic"] |
+| Failed probe names in review history | `instar review --history` |


### PR DESCRIPTION
## Summary

Cherry-picks origin's 3 non-tag fix commits onto local main to resolve cross-machine divergence, plus a fix to an unrelated pre-existing test that was blocking all pushes.

## Background

Session AUT-5397-wo (instar-bug-fix) executed review findings from the prior run, which specified: "try cherry-pick of origin's 3 non-tag functional commits on a scratch branch".

Local main and origin/main diverged significantly — both sides independently minted v0.28.27, v0.28.28, v0.28.29 tags pointing to **different commits with different content** (tag collisions require human resolution). But the underlying fix commits can be integrated without touching the tag namespace.

## Contents

1. cherry-pick: **fix: add POST /jobs/:slug/reset-state endpoint for stale pending recovery** (from origin 8b36c11)
2. cherry-pick: **fix(context): atomic stat + diagnostic filePath for listSegments** (from origin 0505227)
3. cherry-pick: **fix(review): show failing probe names in --history view** (from origin c0cd67e) — conflict on builtin-manifest.json metadata only, resolved + regenerated
4. chore: regenerate builtin-manifest after cherry-pick
5. **fix(tests): update refresh-jobs test to expect default port 4040** — the test expected port 4321, but src/core/Config.ts DEFAULT_PORT is 4040. Stale expectation blocking all pushes via pre-push hook.

## Verification

- npm run build passes
- npm run test:push passes: **11,902 tests passed, 6 skipped, 0 failed**

## Still needs human decision

Tag collision resolution for v0.28.27, v0.28.28, v0.28.29 (local and origin point different commits to the same tag names). This PR does not touch that.

## Related proposals

- PROP-366: Pre-flight git-state check for instar-bug-fix Phase -1
- PROP-367: Lock version-bump to workstation (machineAffinity.mode = exclusive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)