### PR TITLE
feat(parallel-dev): composition-root wiring for WorktreeManager

### DIFF
--- a/.instar/instar-dev-traces/2026-04-18T17-40-00-000Z-parallel-dev-composition-root.json
+++ b/.instar/instar-dev-traces/2026-04-18T17-40-00-000Z-parallel-dev-composition-root.json
@@ -1,0 +1,17 @@
+{
+  "sessionId": "echo-parallel-dev-composition-root",
+  "timestamp": "2026-04-18T17:40:00.000Z",
+  "artifactPath": "upgrades/side-effects/parallel-dev-composition-root.md",
+  "artifactSha256": "0613d6c73322701c1b4ff8b6e9845e601c4fe19fd6ec5fccfa7d9d86a2799b79",
+  "specPath": "docs/specs/PARALLEL-DEV-ISOLATION-SPEC.md",
+  "coveredFiles": [
+    "src/commands/server.ts",
+    "src/core/ParallelDevWiring.ts",
+    "src/core/types.ts",
+    "tests/unit/ParallelDevWiring.test.ts"
+  ],
+  "phase": "complete",
+  "secondPass": "in-scope-followup",
+  "reviewerConcurred": true,
+  "convergenceNote": "Follow-up composition-root wiring for the already-converged PARALLEL-DEV-ISOLATION-SPEC.md (iter 4, approved 2026-04-17). This PR is an implementation of the spec, not a new spec — it wires the shipped WorktreeManager into server startup behind a feature flag that defaults to 'off'. 7 new regression tests pass; 20 pre-existing parallel-dev tests still pass; typecheck clean."
+}

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5773,7 +5773,29 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry });
+    // Parallel-dev isolation (PARALLEL-DEV-ISOLATION-SPEC.md) — off by default.
+    // When enabled, each topic session spawns in its own git worktree, with
+    // fencing tokens, Ed25519-signed commit trailers, and (at phase='enforce')
+    // an authoritative push gate at GitHub Actions.
+    let worktreeManager: import('../core/WorktreeManager.js').WorktreeManager | undefined;
+    const parallelDevConfig = config.parallelDev;
+    if (parallelDevConfig && parallelDevConfig.phase !== 'off') {
+      const { wireParallelDev } = await import('../core/ParallelDevWiring.js');
+      const wired = await wireParallelDev({
+        config: parallelDevConfig,
+        projectDir: config.projectDir,
+        stateDir: config.stateDir,
+      });
+      if (wired) {
+        worktreeManager = wired.worktreeManager;
+        sessionManager.setWorktreeManager(worktreeManager, wired.shimRoot);
+        console.log(
+          pc.green(`  Parallel-dev isolation: ${parallelDevConfig.phase} (WorktreeManager wired)`)
+        );
+      }
+    }
+
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos });
     await server.start();
 
     // Connect DegradationReporter downstream systems now that everything is initialized.

--- a/src/core/ParallelDevWiring.ts
+++ b/src/core/ParallelDevWiring.ts
@@ -1,0 +1,85 @@
+/**
+ * ParallelDevWiring — composition helper for turning a ParallelDevConfig into
+ * a running WorktreeManager (PARALLEL-DEV-ISOLATION-SPEC.md).
+ *
+ * Kept tiny on purpose so the composition root in `commands/server.ts` stays
+ * a one-line call and the wiring logic is unit-testable on its own.
+ */
+
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import type { ParallelDevConfig } from './types.js';
+import { WorktreeKeyVault } from './WorktreeKeyVault.js';
+import { WorktreeManager } from './WorktreeManager.js';
+
+export interface ParallelDevWiringOptions {
+  config: ParallelDevConfig;
+  projectDir: string;
+  stateDir: string;
+  /** Overridable for tests (defaults to reading `git remote get-url origin`). */
+  repoOriginUrlResolver?: (projectDir: string) => string;
+  /** Overridable for tests (defaults to `process.env.INSTAR_WORKTREE_PASSPHRASE`). */
+  passphraseResolver?: () => Promise<string> | string;
+  /** Force keyvault backend (tests only). */
+  keyVaultBackend?: 'keychain' | 'flatfile';
+}
+
+export interface ParallelDevWiringResult {
+  worktreeManager: WorktreeManager;
+  shimRoot: string;
+}
+
+function defaultRepoOriginUrl(projectDir: string): string {
+  try {
+    return execFileSync('git', ['remote', 'get-url', 'origin'], {
+      cwd: projectDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Builds + initializes a WorktreeManager per the supplied ParallelDevConfig.
+ *
+ * Returns `null` when `config.phase === 'off'` (caller should skip wiring).
+ * Throws when headless-fallback is chosen but no passphrase is reachable
+ * (K1 mitigation — no silent weak-key material).
+ */
+export async function wireParallelDev(
+  opts: ParallelDevWiringOptions,
+): Promise<ParallelDevWiringResult | null> {
+  if (opts.config.phase === 'off') return null;
+
+  const vault = new WorktreeKeyVault({
+    stateDir: opts.stateDir,
+    headlessAllowed: opts.config.headlessAllowed ?? false,
+    passphraseResolver: opts.config.headlessAllowed
+      ? (opts.passphraseResolver ?? (() => process.env.INSTAR_WORKTREE_PASSPHRASE ?? ''))
+      : undefined,
+    forceBackend: opts.keyVaultBackend,
+  });
+  const keys = await vault.loadOrInit();
+
+  const repoOriginUrl = (opts.repoOriginUrlResolver ?? defaultRepoOriginUrl)(opts.projectDir);
+
+  const worktreeManager = new WorktreeManager({
+    projectDir: opts.projectDir,
+    stateDir: opts.stateDir,
+    signingKey: keys.signing,
+    hmacKey: keys.hmacKey,
+    machineId: keys.machineId,
+    bootId: crypto.randomUUID(),
+    repoOriginUrl,
+    maxPushDelaySeconds: opts.config.maxPushDelaySeconds,
+  });
+  worktreeManager.initialize();
+
+  return {
+    worktreeManager,
+    shimRoot: path.join(opts.stateDir, 'session-shims'),
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1507,6 +1507,41 @@ export interface InstarConfig {
    * docs/specs/PR-REVIEW-HARDENING-SPEC.md §"Rollout plan".
    */
   prGate?: PrGateConfig;
+  /**
+   * PARALLEL-DEV-ISOLATION rollout phase. Default 'off' (no WorktreeManager
+   * instantiated, sessions share one working tree). Flipping to 'shadow' or
+   * 'enforce' spins up the WorktreeManager and gives each topic session its
+   * own isolated worktree — see docs/specs/PARALLEL-DEV-ISOLATION-SPEC.md.
+   */
+  parallelDev?: ParallelDevConfig;
+}
+
+// ── Parallel-dev isolation (PARALLEL-DEV-ISOLATION-SPEC) ────────────
+
+export interface ParallelDevConfig {
+  /**
+   * Rollout phase.
+   *   'off'      — no WorktreeManager; sessions share one working tree (legacy).
+   *   'shadow'   — WorktreeManager active locally; sessions spawn in isolated
+   *                worktrees, but the GitHub workflow check is advisory only.
+   *   'enforce'  — WorktreeManager active AND the push gate at GitHub Actions
+   *                blocks unsigned commits. Requires a working OIDC verifier
+   *                and installed GH rulesets.
+   */
+  phase: 'off' | 'shadow' | 'enforce';
+  /**
+   * Allow the headless AES-GCM + scrypt flat-file fallback when no OS keychain
+   * is reachable. When true, `INSTAR_WORKTREE_PASSPHRASE` (≥12 chars) must be
+   * set in the server's environment. See WorktreeKeyVault K1.
+   */
+  headlessAllowed?: boolean;
+  /**
+   * Repos enrolled for OIDC-authenticated push-gate calls, e.g.
+   * `[{ owner: 'JKHeadley', repo: 'instar' }]`. Empty = accept no OIDC tokens.
+   */
+  oidcEnrolledRepos?: Array<{ owner: string; repo: string }>;
+  /** Maximum commit→push delay before a trailer nonce expires (seconds). */
+  maxPushDelaySeconds?: number;
 }
 
 // ── PR-gate (PR-REVIEW-HARDENING-SPEC Phase A) ────────────────────

--- a/tests/unit/ParallelDevWiring.test.ts
+++ b/tests/unit/ParallelDevWiring.test.ts
@@ -1,0 +1,108 @@
+/**
+ * ParallelDevWiring composition-root tests.
+ *
+ * Covers the wiring helper that flips sessions onto worktree-per-topic
+ * isolation (PARALLEL-DEV-ISOLATION-SPEC.md §"Composition root").
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { wireParallelDev } from '../../src/core/ParallelDevWiring.js';
+import { WorktreeManager } from '../../src/core/WorktreeManager.js';
+
+let tmp: string;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-wiring-')); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+describe('wireParallelDev', () => {
+  it('returns null when phase="off" — sessions stay on legacy single-tree', async () => {
+    const result = await wireParallelDev({
+      config: { phase: 'off' },
+      projectDir: tmp,
+      stateDir: tmp,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns a WorktreeManager + shimRoot when phase="shadow"', async () => {
+    const result = await wireParallelDev({
+      config: { phase: 'shadow', headlessAllowed: true },
+      projectDir: tmp,
+      stateDir: tmp,
+      passphraseResolver: () => 'wiring-test-passphrase-xyz',
+      repoOriginUrlResolver: () => 'https://github.com/test/instar.git',
+      keyVaultBackend: 'flatfile',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.worktreeManager).toBeInstanceOf(WorktreeManager);
+    expect(result!.shimRoot).toBe(path.join(tmp, 'session-shims'));
+  });
+
+  it('returns a WorktreeManager when phase="enforce"', async () => {
+    const result = await wireParallelDev({
+      config: { phase: 'enforce', headlessAllowed: true },
+      projectDir: tmp,
+      stateDir: tmp,
+      passphraseResolver: () => 'wiring-test-passphrase-xyz',
+      repoOriginUrlResolver: () => 'https://github.com/test/instar.git',
+      keyVaultBackend: 'flatfile',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.worktreeManager).toBeInstanceOf(WorktreeManager);
+  });
+
+  it('initialize() is called — worktrees root and bindings dir exist on disk', async () => {
+    await wireParallelDev({
+      config: { phase: 'shadow', headlessAllowed: true },
+      projectDir: tmp,
+      stateDir: tmp,
+      passphraseResolver: () => 'wiring-test-passphrase-xyz',
+      repoOriginUrlResolver: () => '',
+      keyVaultBackend: 'flatfile',
+    });
+    expect(fs.existsSync(path.join(tmp, 'worktrees'))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, 'worktrees', '.snapshots'))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, 'worktrees', '.quarantine'))).toBe(true);
+    expect(fs.existsSync(path.join(tmp, 'local-state'))).toBe(true);
+  });
+
+  it('K1: headless mode with missing passphrase fails loudly, not silently', async () => {
+    await expect(
+      wireParallelDev({
+        config: { phase: 'shadow', headlessAllowed: true },
+        projectDir: tmp,
+        stateDir: tmp,
+        passphraseResolver: () => '',
+        repoOriginUrlResolver: () => '',
+        keyVaultBackend: 'flatfile',
+      }),
+    ).rejects.toThrow(/passphrase/);
+  });
+
+  it('maxPushDelaySeconds propagates to the WorktreeManager', async () => {
+    const result = await wireParallelDev({
+      config: { phase: 'shadow', headlessAllowed: true, maxPushDelaySeconds: 1234 },
+      projectDir: tmp,
+      stateDir: tmp,
+      passphraseResolver: () => 'wiring-test-passphrase-xyz',
+      repoOriginUrlResolver: () => '',
+      keyVaultBackend: 'flatfile',
+    });
+    expect((result!.worktreeManager as unknown as { opts: { maxPushDelaySeconds: number } }).opts.maxPushDelaySeconds).toBe(1234);
+  });
+
+  it('default repo-origin resolver does not throw when there is no origin remote', async () => {
+    // No git init, no origin — the default resolver should swallow the error and pass ''.
+    const result = await wireParallelDev({
+      config: { phase: 'shadow', headlessAllowed: true },
+      projectDir: tmp,
+      stateDir: tmp,
+      passphraseResolver: () => 'wiring-test-passphrase-xyz',
+      keyVaultBackend: 'flatfile',
+      // no repoOriginUrlResolver — use the default
+    });
+    expect(result).not.toBeNull();
+  });
+});

--- a/upgrades/side-effects/parallel-dev-composition-root.md
+++ b/upgrades/side-effects/parallel-dev-composition-root.md
@@ -1,0 +1,90 @@
+# Side-effects review — parallel-dev composition-root wiring
+
+**Scope**: Wire the already-shipped WorktreeManager + WorktreeKeyVault into the
+server startup so that, when `config.parallelDev.phase !== 'off'`, each topic
+session spawns in its own git worktree. Default stays `'off'` — this PR does
+not flip behavior on for any existing deployment.
+
+**Files touched**:
+- `src/core/types.ts` — add `ParallelDevConfig` and `InstarConfig.parallelDev?`
+- `src/core/ParallelDevWiring.ts` — new helper `wireParallelDev()` that builds
+  and initializes the WorktreeManager from config
+- `src/commands/server.ts` — conditional call to `wireParallelDev`, pass
+  `worktreeManager` + `oidcEnrolledRepos` to `new AgentServer({...})`, call
+  `sessionManager.setWorktreeManager(manager, shimRoot)`
+- `tests/unit/ParallelDevWiring.test.ts` — 7 regression tests
+
+**Under-block**: none. The helper degrades to `null` when `phase === 'off'`, so
+the existing one-tree-per-server behavior is preserved bit-for-bit. The
+pre-existing AgentServer contract (`worktreeManager?` optional) already handled
+the absent-manager case by mounting neither the OIDC route nor the auth-required
+`/worktrees/*` routes — we rely on that.
+
+**Over-block**: none. The wiring does not alter any existing session-spawn path
+until `phase` is promoted. `setWorktreeManager` is additive — it stores the
+reference; `SessionManager.spawnSession` only consults it when `topicId` is
+present *and* the manager is set.
+
+**Level-of-abstraction fit**: the wiring is extracted into a single
+~50-line helper so (a) composition root stays readable and (b) the logic is
+unit-testable without having to stand up a full server. `buildX + initialize`
+is a standard composition-root idiom.
+
+**Signal vs authority**: no authority change. The WorktreeManager itself is
+authoritative for bindings/locks/trailers; the wiring just hands it to
+SessionManager + AgentServer. No gate is added or removed.
+
+**Interactions**:
+- **K1 (flat-file passphrase)**: wiring honors `headlessAllowed` and reads
+  `INSTAR_WORKTREE_PASSPHRASE` when it's set. A unit test asserts the
+  passphrase-missing path throws rather than silently generating weak keys.
+- **OIDC verifier**: intentionally *not* wired yet. `oidcVerify` remains
+  `undefined` in this PR, so the GH-check route (`/gh-check/verify-nonce`) is
+  not mounted. That keeps `phase='shadow'` safe to flip on before the OIDC
+  JWK fetcher exists. `phase='enforce'` will require a follow-up PR that
+  plugs in a real verifier.
+- **SessionManager.setWorktreeManager**: pre-existing API from the Phase-A
+  merge. This is the intended consumer.
+- **oidcEnrolledRepos passthrough**: still useful at `shadow` so operators
+  can pre-configure the list without flipping enforce; the AgentServer guard
+  (`worktreeManager && oidcVerify`) keeps the route unmounted until both are
+  present.
+
+**External surfaces**:
+- New config key `parallelDev` on `.instar/config.json`. Absent key = `off` =
+  no change. Loaders merge-under-default; no migration is needed.
+- No new CLI, no new endpoint, no new external dep.
+
+**Rollback cost**: trivial — revert the two edits to `server.ts` + `types.ts`
+and the two new files. No data migration, no on-disk state is created unless
+`phase !== 'off'` is actively set. Worktree state that *is* created is
+confined to `<stateDir>/worktrees/` and `<stateDir>/local-state/`, both
+gitignored, and can be removed via `WorktreeReaper` or `rm -rf`.
+
+**Tests**:
+- `tests/unit/ParallelDevWiring.test.ts` — 7 tests, all passing:
+  - off-phase returns null (legacy behavior preserved)
+  - shadow-phase returns manager + shimRoot
+  - enforce-phase returns manager
+  - initialize() creates worktrees root + snapshots + quarantine + local-state
+  - K1: headless + no passphrase throws
+  - maxPushDelaySeconds propagates
+  - default repo-origin resolver tolerates missing origin
+- 20/20 pre-existing parallel-dev tests still pass
+- `npx tsc --noEmit` clean
+- 8 pre-existing test failures (agent-registry, feature-delivery,
+  listener-session, no-silent-fallbacks, security execSync) are unchanged by
+  this PR — verified by running the same tests on origin/main before applying
+  the edits.
+
+**Decision-point inventory**:
+1. Extract to `ParallelDevWiring.ts` helper (vs inline in server.ts) — chosen
+   for testability; a 50-line helper with 7 unit tests beats a 50-line inline
+   block that can only be tested via full server spin-up.
+2. Dynamic `import()` in server.ts — keeps worktree code out of the server
+   module's import graph when `phase === 'off'`.
+3. Feature-flag default `'off'` (vs `'shadow'`) — flipping on requires
+   operator intent; matches the `prGate` rollout pattern.
+4. Do not wire `oidcVerify` in this PR — the real GitHub OIDC JWK fetcher is a
+   separate concern and will gate `phase='enforce'`. Landing the wiring first
+   keeps the PR small and reversible.


### PR DESCRIPTION
## Summary
- Adds `ParallelDevConfig` (phase: `off` | `shadow` | `enforce`) and wires `WorktreeManager` + `WorktreeKeyVault` into the server startup via a new `ParallelDevWiring` helper.
- When `phase !== 'off'`, each topic session spawns in its own git worktree with fencing tokens and Ed25519-signed commit trailers (per `docs/specs/PARALLEL-DEV-ISOLATION-SPEC.md`).
- Default is `'off'` — behavior unchanged for existing deployments. No migration needed.

## Files
- `src/core/types.ts` — `ParallelDevConfig` + `parallelDev?` on `InstarConfig`
- `src/core/ParallelDevWiring.ts` — `wireParallelDev()` composition helper (unit-testable)
- `src/commands/server.ts` — conditional wire + `sessionManager.setWorktreeManager`
- `tests/unit/ParallelDevWiring.test.ts` — 7 regression tests
- `upgrades/side-effects/parallel-dev-composition-root.md` — side-effects review
- `.instar/instar-dev-traces/…parallel-dev-composition-root.json` — instar-dev trace

## Test plan
- [x] 7 new tests in `ParallelDevWiring.test.ts` pass (off-phase, shadow, enforce, initialize side-effects, K1 passphrase-missing, maxPushDelay propagation, no-origin tolerance)
- [x] 20 pre-existing parallel-dev tests still pass
- [x] `npx tsc --noEmit` clean
- [x] 8 pre-existing test failures (agent-registry, feature-delivery, listener-session, no-silent-fallbacks, security/execSync) unchanged — verified on origin/main before applying edits
- [x] instar-dev gate satisfied (trace + artifact + spec-converged+approved)

## Rollout
- Lands at `phase: 'off'` — zero behavioral change.
- Promoting to `'shadow'` spins up a WorktreeManager locally; push gate remains advisory.
- Promoting to `'enforce'` requires a follow-up wiring for the GitHub OIDC verifier + installed rulesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)