### PR TITLE
ci(unit): shard test:push across 4 vitest runners per Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,14 @@ jobs:
       - run: npm run lint
 
   unit:
-    name: Unit Tests
+    name: Unit Tests (node ${{ matrix.node-version }}, shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     strategy:
+      # Don't cancel other shards if one fails — we want the full picture.
+      fail-fast: false
       matrix:
         node-version: [20, 22]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -35,7 +38,10 @@ jobs:
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux
       - run: npm ci
-      - run: npm run test:push
+      # vitest shard syntax: --shard=<index>/<total>. Each runner executes a
+      # deterministic disjoint slice of the test files; union is the full suite.
+      # fileParallelism stays off within each shard to preserve isolation.
+      - run: npm run test:push -- --shard=${{ matrix.shard }}/4
 
   integration:
     name: Integration Tests

--- a/upgrades/side-effects/0.28.57.md
+++ b/upgrades/side-effects/0.28.57.md
@@ -1,0 +1,33 @@
+# Side-Effects Review — 0.28.57 (release aggregate)
+
+**Version:** `0.28.57`
+**Date:** `2026-04-19`
+**Author:** `echo` (backfill)
+**Second-pass reviewer:** `not required`
+
+## Summary
+
+Release 0.28.57 bundles two changes that were each reviewed individually at merge time. The publish workflow's file-renamer skipped the corresponding `upgrades/side-effects/` artifact during the 0.28.57 finalization (it renames `upgrades/NEXT.md → upgrades/{version}.md` but not the side-effects counterpart), so this file is a minimal aggregator that points at the two component reviews already on disk. Captured as a follow-up in the pre-push gate: teach `publish.yml` or `check-upgrade-guide.js` to also rename the matching side-effects artifact so this backfill isn't needed on future releases.
+
+## Components
+
+### 1. TelegramLifeline sends auth on `/internal/*` forwards
+
+Landed via PR #64. Surgical fix in `src/lifeline/TelegramLifeline.ts` to add `Authorization: Bearer <authToken>` to `forwardToServer()` and `handleCallbackQuery()`. Reasoning: the 0.28.53 server-side tightening that required auth on `/internal/*` had no matching client-side update in the lifeline — every inbound Telegram message was 401ing.
+
+- No runtime decision points introduced; a signal-less, surface-narrow header addition.
+- Over-block / under-block: not applicable — no block/allow surface.
+- Level-of-abstraction: header is constructed exactly where the fetch is built; no new indirection.
+- Signal-vs-authority: not applicable — hard-invariant transport-layer auth.
+- Interactions: none with other gates; backwards-compatible on servers that don't require the header.
+- Rollback: revert the single file.
+
+### 2. Drop duplicate CI gate from `publish.yml` (PR #67)
+
+Full review: `upgrades/side-effects/publish-drop-duplicate-ci-gate.md` (in this directory). Summary: removed the `ci` job from `publish.yml` that duplicated `ci.yml` on the same `push: branches: [main]` event. Publish wall-clock measured 11m → 55s on the first post-merge run. Branch-protection-at-PR-time remains the actual authority.
+
+## Notes
+
+This aggregator file exists to satisfy the `pre-push-gate.js` requirement that `upgrades/side-effects/{version}.md` exists whenever `upgrades/{version}.md` exists and claims fix/feature content. The finer-grained artifacts for each component are the authoritative reviews; this file only provides the version-named pointer.
+
+Follow-up captured: either (a) teach `publish.yml` to also rename the matching side-effects artifact during NEXT → version finalization, or (b) relax `pre-push-gate.js` to accept any side-effects artifact dated within the release window rather than requiring a version-exact filename.

--- a/upgrades/side-effects/0.28.58.md
+++ b/upgrades/side-effects/0.28.58.md
@@ -1,0 +1,24 @@
+# Side-Effects Review — 0.28.58 (release aggregate)
+
+**Version:** `0.28.58`
+**Date:** `2026-04-19`
+**Author:** `echo` (backfill)
+**Second-pass reviewer:** `not required`
+
+## Summary
+
+Release 0.28.58 shipped the Initiative Tracker recovery merge (PR #68). The two component reviews exist in this directory under slug names because `publish.yml`'s finalization renames `upgrades/NEXT.md → upgrades/{version}.md` but does not rename the corresponding side-effects artifact. This file is a minimal aggregator that satisfies `pre-push-gate.js`'s requirement that `upgrades/side-effects/{version}.md` exists whenever `upgrades/{version}.md` exists and claims fix/feature content.
+
+## Components
+
+### Initiative Tracker — core and API
+
+Full review: `upgrades/side-effects/initiative-tracker-core-and-api.md`. Persisted multi-phase work tracker with phase / blocker / last-touched state; backed by a JSON store; 28 core tests + 15 route tests added.
+
+### Initiative Tracker — dashboard tab
+
+Full review: `upgrades/side-effects/initiative-tracker-dashboard-tab.md`. New "Initiatives" tab in the dashboard rendering the tracker state; 9 dashboard smoke tests added.
+
+## Notes
+
+Same follow-up as noted in `0.28.57.md` aggregator: either (a) teach `publish.yml` to also rename the matching side-effects artifact during NEXT → version finalization, or (b) relax `pre-push-gate.js` to accept any side-effects artifact dated within the release window rather than requiring a version-exact filename. Until one of those lands, each release will need a backfill aggregator like this one.

--- a/upgrades/side-effects/0.28.59.md
+++ b/upgrades/side-effects/0.28.59.md
@@ -1,0 +1,20 @@
+# Side-Effects Review — 0.28.59 (release aggregate)
+
+**Version:** `0.28.59`
+**Date:** `2026-04-19`
+**Author:** `echo` (backfill)
+**Second-pass reviewer:** `not required`
+
+## Summary
+
+Release 0.28.59 shipped the dashboard "Resume live output" scroll-reliability + always-visible control fix (PR #63). The component review exists in this directory under its slug name (`dashboard-resume-live-scroll.md`) because `publish.yml`'s finalization renames `upgrades/NEXT.md → upgrades/{version}.md` but does not rename the corresponding side-effects artifact. This file is a minimal aggregator that satisfies `pre-push-gate.js`'s requirement that `upgrades/side-effects/{version}.md` exists whenever `upgrades/{version}.md` exists and claims fix/feature content.
+
+## Components
+
+### Dashboard "Resume live output" reliability + always-visible control
+
+Full review: `upgrades/side-effects/dashboard-resume-live-scroll.md`. Pure UI timing + visibility fix — all three resume paths now use xterm's write-completion callback so `scrollToBottom()` runs after the buffer is populated; button visibility now mirrors `!userIsFollowing` from every code path that flips the flag. 10 regression tests added at `tests/unit/dashboard-resumeLive.test.ts`.
+
+## Notes
+
+Same follow-up as captured in `0.28.57.md` and `0.28.58.md` aggregators: either (a) teach `publish.yml` to also rename the matching side-effects artifact during NEXT → version finalization, or (b) relax `pre-push-gate.js` to accept any side-effects artifact dated within the release window rather than requiring a version-exact filename. Until one of those lands, each release will need a backfill aggregator like this one.

--- a/upgrades/side-effects/ci-shard-unit-tests.md
+++ b/upgrades/side-effects/ci-shard-unit-tests.md
@@ -1,0 +1,108 @@
+# Side-Effects Review — Shard CI unit tests across 4 parallel runners
+
+**Version / slug:** `ci-shard-unit-tests`
+**Date:** `2026-04-19`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`.github/workflows/ci.yml` unit-test job is extended to run the pre-push test suite across 4 vitest shards per Node version, using vitest's built-in `--shard=N/M` file-partitioning. The matrix changes from `{ node-version: [20, 22] }` (2 runners, each ~9½ min serial) to `{ node-version: [20, 22], shard: [1,2,3,4] }` (8 runners, each ~2½ min serial inside its shard). `fileParallelism: false` in `vitest.push.config.ts` stays untouched — each shard still runs its files one-at-a-time to preserve the port / SQLite / npm isolation that commit `002a463` established. `fail-fast: false` is added so one flaky shard doesn't kill the others. Expected impact on CI wall-clock: unit-test phase 9½ min → ~3 min, which pulls overall PR-CI time from ~12 min toward ~5-6 min (next bottleneck becomes integration/e2e). Only file touched: `.github/workflows/ci.yml`.
+
+## Decision-point inventory
+
+- `ci.yml.unit` — **modify** — job matrix gains a `shard` dimension; test runner invoked with `--shard=${{ matrix.shard }}/4`.
+
+No runtime / agent-behavior decision points touched.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface on message flow — over-block not applicable in the runtime sense.
+
+In the CI sense: the change runs *exactly the same* set of tests as before, just partitioned across 4 runners per Node version. Vitest's sharding is deterministic and disjoint — the union of `--shard=1/4 … 4/4` is the full include set. A commit that passed unsharded would pass sharded. No new rejection surface.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+Same as before: anything `test:push` doesn't cover (the flaky-exclusion list in `vitest.push.config.ts` is unchanged — the same ~30 files that were excluded as flaky remain excluded; full suite still runs separately via `npm test` and is not part of CI gating). No new under-block introduced by this change.
+
+One theoretical concern: if the shard hash assignment is not stable across vitest versions, a file could disappear from all shards after a vitest upgrade. This is vanishingly unlikely in practice because vitest's shard algorithm is documented and stable; the union is enforced by the CLI. If we ever suspect it, a simple sanity check is to run with `--shard=` omitted and compare the test count.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. File-level parallelism was disabled in `vitest.push.config.ts` because tests spawn HTTP servers, SQLite DBs, and real npm operations that collide when running in the same process pool (see commit `002a463`). Sharding at the CI-runner level (one process per shard on its own VM) sidesteps that collision entirely — each shard has its own ports, own filesystem, own npm cache — without re-enabling in-process parallelism. This is the right layer: the isolation problem was resource-contention across a single machine's pool; moving to multiple machines solves the resource contention without touching the isolation invariant.
+
+Signal/authority lens: not applicable. CI test-pass is still an authority-grade signal computed over the same logical test set; we're just distributing the computation.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface on message flow or agent behavior.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic.
+
+CI sharding is a runtime-distribution change. The test suite itself is unchanged — same authority (the full union of tests), same verdict logic (all must pass), just faster. Signal-vs-authority domain untouched.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** `unit` is a `needs:` target for `integration`, `e2e`, `contract`, and `build`. GitHub Actions' default behavior when a `needs:` target is a matrix is to wait for **all** combinations to succeed before downstream jobs run. With 8 combinations (2 node × 4 shard), downstream jobs now wait for all 8 instead of 2. This is a stricter gate, not weaker. No shadowing introduced.
+- **Double-fire:** n/a — the old 2-runner unit matrix was the only thing that ran tests. The new 8-runner matrix replaces it; total test-run count remains "once per Node × shard" (1 per runner).
+- **Races:** each shard runs in its own ephemeral GitHub-hosted runner VM. No shared filesystem, no shared ports, no shared npm cache across shards. No race surface.
+- **Feedback loops:** none. CI result feeds into PR-level required status checks, unchanged by this.
+
+One behavioral nuance worth noting: with `fail-fast: false`, a PR that has genuinely broken tests will now consume 8 runners (all reporting the same failure) instead of 2. Cost is small (GitHub-hosted free minutes; we're not anywhere near the cap), and the upside is clearer diagnostic signal — if only shard-3 fails, the problem is isolated; if all 8 fail, the problem is universal.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Other agents on the same machine:** no.
+- **Other users of the install base:** no runtime behavior change. The shipped package is identical byte-for-byte.
+- **External systems:** GitHub Actions runs more matrix combinations. Cost impact for public repos on GitHub-hosted free runners: negligible — Actions minutes are free for public repos. If a private fork is on a paid plan, the extra 6 runners per CI run will show up in billing; flag to callers who fork.
+- **Persistent state:** none touched.
+- **Status check names:** the job name becomes `Unit Tests (node 20, shard 1/4)` etc. instead of `Unit Tests (20)`. Only required status check in the branch ruleset today is `verify`; `Unit Tests` matrix jobs are **not** required checks (confirmed via `gh api repos/JKHeadley/instar/rules/branches/main` on 2026-04-19). So the rename does not break branch protection. If a watcher tool or dashboard specifically hardcoded `Unit Tests (20)` / `Unit Tests (22)` as an expected name, it would need updating — unlikely, but captured here.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Trivial. Revert the single `.github/workflows/ci.yml` change — restore the 2-runner matrix and the original `name:` / `run:` lines. No persistent state. No downstream code affected. Worst realistic "wrong" outcome: the shard hash algorithm has a pathological case that leaves one shard with most of the heavy tests, so the wall-clock win is smaller than projected. That's an optimization miss, not a correctness failure — still faster than pre-change, and the remediation is increasing shard count (6 or 8) rather than reverting. Full revert cost: one commit, no migration, no user impact.
+
+---
+
+## Conclusion
+
+Pure CI distribution change with no runtime surface, no decision-point surface, no signal/authority interaction. Preserves the isolation invariant from commit `002a463` by sharding at the runner level instead of re-enabling in-process parallelism. Expected wall-clock win on unit-test phase: 9½ min → ~3 min; overall CI: ~12 min → ~5-6 min (next bottleneck likely integration/e2e, captured as follow-up). Rollback is one revert. Cleared to ship.
+
+---
+
+## Evidence pointers
+
+- Root cause of current serial execution: commit `002a463` (2026-02-28) — "fix(test): disable file parallelism to prevent lock contention". Confirms the isolation problem is real and resource-contention-based; sharding at the VM level is the right remediation.
+- Shard algorithm: [vitest docs — CLI `--shard`](https://vitest.dev/guide/cli.html) — deterministic file-path hash distribution; union of all shards equals the full include set.
+- Required-check topology: `gh api repos/JKHeadley/instar/rules/branches/main` (2026-04-19) shows only `verify` as a required context. Unit-test matrix jobs are observed green on recent PRs but are not ruleset-required.


### PR DESCRIPTION
## Summary

- Shards the `unit` job's `npm run test:push` run across **4 vitest shards per Node version** using `--shard=N/4`. Matrix goes from 2 runners (one per Node) to 8 runners (2 Node × 4 shard).
- Keeps `fileParallelism: false` in `vitest.push.config.ts` — each shard still runs its files one-at-a-time, preserving the port / SQLite / npm isolation invariant from commit `002a463`. Parallelism is across runner VMs, not inside one.
- Adds `fail-fast: false` so one flaky shard doesn't kill the others — clearer diagnostic signal (isolated vs universal failure).

Expected CI wall-clock impact on the unit-test phase: **~9½ min → ~3 min**. Overall PR-CI: **~12 min → ~5-6 min** (next bottleneck becomes integration/e2e).

Also includes two small backfill commits:
- `upgrades/side-effects/0.28.57.md`, `0.28.58.md`, `0.28.59.md` — minimal aggregator files the pre-push gate requires. Root cause captured inline: `publish.yml`'s NEXT→version finalization renames `upgrades/NEXT.md` but skips the matching side-effects artifact. Follow-up: either fix the rename step in publish.yml or relax the gate to accept any artifact dated within the release window.

## Evidence

- Full side-effects review: `upgrades/side-effects/ci-shard-unit-tests.md` — covers over/under-block, level-of-abstraction fit, signal-vs-authority compliance, interactions, external surfaces, rollback cost.
- Sharding algorithm: vitest's documented `--shard=N/M` deterministic file-path hash. Union of all shards equals the full include set.
- Required-check topology: `gh api repos/JKHeadley/instar/rules/branches/main` (2026-04-19) shows only `verify` as a required context — matrix job name change is safe.

## Rollback

Revert the single `.github/workflows/ci.yml` change. No persistent state, no user impact, no schema or API changes.