### PR TITLE
feat(commitment-tracker): add single-writer mutate() with CAS

### DIFF
--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -84,10 +84,18 @@ export interface Commitment {
   escalated: boolean;
   /** Escalation details */
   escalationDetail?: string;
+
+  // ── Concurrency ───────────────────────────────────────
+
+  /**
+   * Monotonically-increasing version for optimistic CAS in mutate().
+   * Back-filled to 0 on records from store v1.
+   */
+  version: number;
 }
 
 export interface CommitmentStore {
-  version: 1;
+  version: 2;
   commitments: Commitment[];
   lastModified: string;
 }
@@ -125,6 +133,18 @@ export interface CommitmentTrackerConfig {
 
 // ── Implementation ────────────────────────────────────────────────
 
+/** Max depth of the per-id mutate queue. Enqueue beyond this rejects. */
+const MUTATE_QUEUE_MAX_DEPTH = 256;
+/** Max CAS retries when the version drifts under an apply. */
+const MUTATE_CAS_MAX_RETRIES = 5;
+
+type MutateFn = (c: Commitment) => Commitment | Promise<Commitment>;
+interface MutateQueueEntry {
+  fn: MutateFn;
+  resolve: (c: Commitment) => void;
+  reject: (err: Error) => void;
+}
+
 export class CommitmentTracker extends EventEmitter {
   private config: CommitmentTrackerConfig;
   private store: CommitmentStore;
@@ -132,6 +152,15 @@ export class CommitmentTracker extends EventEmitter {
   private rulesPath: string;
   private interval: ReturnType<typeof setInterval> | null = null;
   private nextId: number;
+
+  /**
+   * Single-writer FIFO queues, keyed by commitment id. Every write path
+   * (record/withdraw/verifyOne/expire/auto-correct/escalate) serialises
+   * through mutate(), which CAS-retries on the commitment's `version`
+   * field. p99 target for the caller-supplied fn is 50ms under load.
+   */
+  private mutateQueues: Map<string, MutateQueueEntry[]> = new Map();
+  private mutateRunning: Set<string> = new Set();
 
   constructor(config: CommitmentTrackerConfig) {
     super();
@@ -210,10 +239,12 @@ export class CommitmentTracker extends EventEmitter {
       correctionCount: 0,
       correctionHistory: [],
       escalated: false,
+      version: 0,
     };
 
-    this.store.commitments.push(commitment);
-    this.saveStore();
+    // Insert via the same discipline future writes use: under the single-
+    // writer surface, initial version is 0 and future mutations CAS from there.
+    this.insertNew(commitment);
 
     // Regenerate behavioral rules file if this is a behavioral commitment
     if (input.type === 'behavioral') {
@@ -223,34 +254,39 @@ export class CommitmentTracker extends EventEmitter {
     console.log(`[CommitmentTracker] Recorded ${id}: "${input.userRequest}" (${input.type})`);
     this.emit('recorded', commitment);
 
-    // Run immediate verification for config-change commitments
+    // Run immediate verification for config-change commitments.
+    // verifyOne goes through mutateSync, which replaces the store entry
+    // with a new object — return the freshest snapshot so callers see
+    // the post-verification status.
     if (input.type === 'config-change') {
       this.verifyOne(id);
     }
 
-    return commitment;
+    return this.get(id) ?? commitment;
   }
 
   /**
    * Withdraw a commitment (user changed their mind).
    */
   withdraw(id: string, reason: string): boolean {
-    const commitment = this.store.commitments.find(c => c.id === id);
-    if (!commitment || commitment.status === 'withdrawn' || commitment.status === 'expired') {
+    const existing = this.store.commitments.find(c => c.id === id);
+    if (!existing || existing.status === 'withdrawn' || existing.status === 'expired') {
       return false;
     }
 
-    commitment.status = 'withdrawn';
-    commitment.resolvedAt = new Date().toISOString();
-    commitment.resolution = reason;
-    this.saveStore();
+    const updated = this.mutateSync(id, c => ({
+      ...c,
+      status: 'withdrawn',
+      resolvedAt: new Date().toISOString(),
+      resolution: reason,
+    }));
 
-    if (commitment.type === 'behavioral') {
+    if (updated.type === 'behavioral') {
       this.writeBehavioralRules();
     }
 
     console.log(`[CommitmentTracker] Withdrawn ${id}: ${reason}`);
-    this.emit('withdrawn', commitment);
+    this.emit('withdrawn', updated);
     return true;
   }
 
@@ -356,43 +392,49 @@ export class CommitmentTracker extends EventEmitter {
         result = { passed: false, detail: `Unknown commitment type: ${commitment.type}` };
     }
 
-    // Update commitment status based on result
-    if (result.passed) {
-      const wasFirstVerification = commitment.status === 'pending';
-      const wasViolated = commitment.status === 'violated';
+    // Update commitment status based on result — route through the
+    // single-writer mutateSync surface so concurrent write paths can't
+    // clobber each other.
+    const wasFirstVerification = commitment.status === 'pending';
+    const wasViolated = commitment.status === 'violated';
+    const wasVerified = commitment.status === 'verified';
 
-      commitment.status = 'verified';
-      commitment.lastVerifiedAt = new Date().toISOString();
-      commitment.verificationCount++;
-
-      if (wasFirstVerification && this.config.onVerified) {
-        this.config.onVerified(commitment);
-      }
-
-      if (wasViolated) {
-        console.log(`[CommitmentTracker] ${id} recovered: "${commitment.userRequest}"`);
-      }
-
-      // Close one-time actions after first verification
-      if (commitment.type === 'one-time-action') {
-        commitment.resolvedAt = new Date().toISOString();
-        commitment.resolution = 'Verified complete';
-      }
-    } else {
-      const wasVerified = commitment.status === 'verified';
-      commitment.status = 'violated';
-      commitment.violationCount++;
-
-      if (wasVerified) {
-        // Regression — was verified, now violated
-        console.warn(`[CommitmentTracker] VIOLATION ${id}: "${commitment.userRequest}" — ${result.detail}`);
-        if (this.config.onViolation) {
-          this.config.onViolation(commitment, result.detail);
+    const updated = this.mutateSync(id, c => {
+      if (result.passed) {
+        const next: Commitment = {
+          ...c,
+          status: 'verified',
+          lastVerifiedAt: new Date().toISOString(),
+          verificationCount: c.verificationCount + 1,
+        };
+        if (c.type === 'one-time-action') {
+          next.resolvedAt = new Date().toISOString();
+          next.resolution = 'Verified complete';
         }
+        return next;
+      }
+      return {
+        ...c,
+        status: 'violated',
+        violationCount: c.violationCount + 1,
+      };
+    });
+
+    if (result.passed) {
+      if (wasFirstVerification && this.config.onVerified) {
+        this.config.onVerified(updated);
+      }
+      if (wasViolated) {
+        console.log(`[CommitmentTracker] ${id} recovered: "${updated.userRequest}"`);
+      }
+    } else if (wasVerified) {
+      // Regression — was verified, now violated
+      console.warn(`[CommitmentTracker] VIOLATION ${id}: "${updated.userRequest}" — ${result.detail}`);
+      if (this.config.onViolation) {
+        this.config.onViolation(updated, result.detail);
       }
     }
 
-    this.saveStore();
     return result;
   }
 
@@ -530,21 +572,21 @@ export class CommitmentTracker extends EventEmitter {
       // Re-verify after correction
       const recheck = this.verifyConfigChange(commitment);
       if (recheck.passed) {
-        commitment.status = 'verified';
-        commitment.lastVerifiedAt = new Date().toISOString();
-        commitment.verificationCount++;
-
-        // Track correction for escalation detection
         const now = new Date().toISOString();
-        commitment.correctionCount = (commitment.correctionCount ?? 0) + 1;
-        commitment.correctionHistory = [...(commitment.correctionHistory ?? []), now];
+        const updated = this.mutateSync(commitment.id, c => ({
+          ...c,
+          status: 'verified',
+          lastVerifiedAt: now,
+          verificationCount: c.verificationCount + 1,
+          correctionCount: (c.correctionCount ?? 0) + 1,
+          correctionHistory: [...(c.correctionHistory ?? []), now],
+        }));
 
         // Check for escalation: too many corrections in a time window suggests a bug
-        this.checkForEscalation(commitment);
+        this.checkForEscalation(updated);
 
-        this.saveStore();
-        console.log(`[CommitmentTracker] Auto-corrected ${commitment.id}: ${commitment.configPath} → ${JSON.stringify(commitment.configExpectedValue)} (correction #${commitment.correctionCount})`);
-        this.emit('corrected', commitment);
+        console.log(`[CommitmentTracker] Auto-corrected ${updated.id}: ${updated.configPath} → ${JSON.stringify(updated.configExpectedValue)} (correction #${updated.correctionCount})`);
+        this.emit('corrected', updated);
         return true;
       }
     } catch (err) {
@@ -578,15 +620,19 @@ export class CommitmentTracker extends EventEmitter {
     });
 
     if (recentCorrections.length >= threshold) {
-      commitment.escalated = true;
       const detail = `Commitment ${commitment.id} ("${commitment.userRequest}") has been auto-corrected ${recentCorrections.length} times in the last ${Math.round(windowMs / 60_000)} minutes. Config path: ${commitment.configPath}. This pattern suggests something is actively overwriting the value — likely a bug in initialization, a conflicting process, or a default value that resets on restart.`;
-      commitment.escalationDetail = detail;
 
-      console.warn(`[CommitmentTracker] ESCALATION ${commitment.id}: ${detail}`);
-      this.emit('escalation', commitment, detail);
+      const updated = this.mutateSync(commitment.id, c => ({
+        ...c,
+        escalated: true,
+        escalationDetail: detail,
+      }));
+
+      console.warn(`[CommitmentTracker] ESCALATION ${updated.id}: ${detail}`);
+      this.emit('escalation', updated, detail);
 
       if (this.config.onEscalation) {
-        this.config.onEscalation(commitment, detail);
+        this.config.onEscalation(updated, detail);
       }
     }
   }
@@ -623,20 +669,152 @@ export class CommitmentTracker extends EventEmitter {
     const now = new Date().toISOString();
     let changed = false;
 
-    for (const c of this.store.commitments) {
-      if (c.expiresAt && c.expiresAt < now && c.status !== 'expired' && c.status !== 'withdrawn') {
-        c.status = 'expired';
-        c.resolvedAt = now;
-        c.resolution = 'Expired';
-        changed = true;
-        console.log(`[CommitmentTracker] Expired ${c.id}: "${c.userRequest}"`);
-      }
+    // Snapshot ids before mutating so we don't iterate a live array under
+    // concurrent mutateSync() index-preserving writes.
+    const targets = this.store.commitments
+      .filter(c => c.expiresAt && c.expiresAt < now && c.status !== 'expired' && c.status !== 'withdrawn')
+      .map(c => c.id);
+
+    for (const id of targets) {
+      this.mutateSync(id, c => ({
+        ...c,
+        status: 'expired',
+        resolvedAt: now,
+        resolution: 'Expired',
+      }));
+      changed = true;
+      const c = this.get(id);
+      if (c) console.log(`[CommitmentTracker] Expired ${c.id}: "${c.userRequest}"`);
     }
 
     if (changed) {
-      this.saveStore();
       this.writeBehavioralRules();
     }
+  }
+
+  // ── Single-writer mutation ─────────────────────────────────────
+
+  /**
+   * Single-writer mutate surface. Every write path routes through here so
+   * concurrent writers (CommitmentSentinel, PresenceProxy, future
+   * PromiseBeacon) can't clobber each other.
+   *
+   * Contract:
+   *   - FIFO queue per commitment id, max depth 256.
+   *   - Optimistic CAS on the `version` field: read → fn(clone) → write if
+   *     version unchanged, else retry (max 5). On success, version is
+   *     incremented and the store is persisted atomically.
+   *   - Caller-supplied fn p99 target: 50ms. Long work belongs outside.
+   *
+   * Returns the persisted commitment snapshot (post-increment).
+   */
+  async mutate(id: string, fn: MutateFn): Promise<Commitment> {
+    return new Promise<Commitment>((resolve, reject) => {
+      let queue = this.mutateQueues.get(id);
+      if (!queue) {
+        queue = [];
+        this.mutateQueues.set(id, queue);
+      }
+      if (queue.length >= MUTATE_QUEUE_MAX_DEPTH) {
+        reject(new Error(
+          `CommitmentTracker.mutate: queue full for ${id} (depth ${queue.length} >= ${MUTATE_QUEUE_MAX_DEPTH})`
+        ));
+        return;
+      }
+      queue.push({ fn, resolve, reject });
+      // Fire-and-forget drain; errors already propagate via entry.reject.
+      void this.drainMutateQueue(id);
+    });
+  }
+
+  private async drainMutateQueue(id: string): Promise<void> {
+    if (this.mutateRunning.has(id)) return;
+    this.mutateRunning.add(id);
+    try {
+      const queue = this.mutateQueues.get(id);
+      while (queue && queue.length > 0) {
+        const entry = queue.shift()!;
+        try {
+          const result = await this.applyMutationWithCAS(id, entry.fn);
+          entry.resolve(result);
+        } catch (err) {
+          entry.reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
+      // Clean up empty queue so Maps don't grow unbounded.
+      if (queue && queue.length === 0) this.mutateQueues.delete(id);
+    } finally {
+      this.mutateRunning.delete(id);
+    }
+  }
+
+  private async applyMutationWithCAS(id: string, fn: MutateFn): Promise<Commitment> {
+    let attempt = 0;
+    while (attempt <= MUTATE_CAS_MAX_RETRIES) {
+      const idx = this.store.commitments.findIndex(c => c.id === id);
+      if (idx === -1) {
+        throw new Error(`CommitmentTracker.mutate: unknown commitment id ${id}`);
+      }
+      const current = this.store.commitments[idx];
+      const observedVersion = current.version ?? 0;
+
+      // Provide a shallow clone so fn mutations don't prematurely touch store.
+      const draft: Commitment = { ...current };
+      const next = await fn(draft);
+
+      // CAS check: the record's version must not have drifted underneath us.
+      const latestIdx = this.store.commitments.findIndex(c => c.id === id);
+      if (latestIdx === -1) {
+        throw new Error(`CommitmentTracker.mutate: commitment ${id} disappeared mid-apply`);
+      }
+      const latest = this.store.commitments[latestIdx];
+      if ((latest.version ?? 0) !== observedVersion) {
+        attempt++;
+        continue;
+      }
+
+      const committed: Commitment = { ...next, version: observedVersion + 1 };
+      this.store.commitments[latestIdx] = committed;
+      this.saveStore();
+      return committed;
+    }
+    throw new Error(
+      `CommitmentTracker.mutate: CAS retry budget exhausted for ${id} after ${MUTATE_CAS_MAX_RETRIES} retries`
+    );
+  }
+
+  /**
+   * Synchronous mutation helper used by existing sync write paths
+   * (withdraw, verifyOne, expireCommitments, attemptAutoCorrection,
+   * checkForEscalation). Since JS is single-threaded, synchronous fn
+   * bodies cannot race against each other — this path does a straight
+   * read → apply → version++ → persist. Async callers must use
+   * mutate() for proper queueing across awaits.
+   */
+  private mutateSync(id: string, fn: (c: Commitment) => Commitment): Commitment {
+    const idx = this.store.commitments.findIndex(c => c.id === id);
+    if (idx === -1) {
+      throw new Error(`CommitmentTracker.mutateSync: unknown commitment id ${id}`);
+    }
+    const current = this.store.commitments[idx];
+    const observedVersion = current.version ?? 0;
+    const next = fn({ ...current });
+    const committed: Commitment = { ...next, version: observedVersion + 1 };
+    this.store.commitments[idx] = committed;
+    this.saveStore();
+    return committed;
+  }
+
+  /**
+   * Insert a brand-new commitment under the mutate discipline. Used by
+   * record(); creates an initial version-0 record, then serialises future
+   * writes through mutate(id, fn).
+   */
+  private insertNew(commitment: Commitment): Commitment {
+    const withVersion: Commitment = { ...commitment, version: commitment.version ?? 0 };
+    this.store.commitments.push(withVersion);
+    this.saveStore();
+    return withVersion;
   }
 
   // ── Persistence ────────────────────────────────────────────────
@@ -645,20 +823,24 @@ export class CommitmentTracker extends EventEmitter {
     try {
       if (fs.existsSync(this.storePath)) {
         const data = JSON.parse(fs.readFileSync(this.storePath, 'utf-8'));
-        if (data.version === 1 && Array.isArray(data.commitments)) {
+        if ((data.version === 1 || data.version === 2) && Array.isArray(data.commitments)) {
           // Migrate: add self-healing fields to existing commitments
           for (const c of data.commitments) {
             if (c.correctionCount === undefined) c.correctionCount = 0;
             if (c.correctionHistory === undefined) c.correctionHistory = [];
             if (c.escalated === undefined) c.escalated = false;
+            // v1 → v2: back-fill version field on every commitment.
+            if (typeof c.version !== 'number') c.version = 0;
           }
+          // Bump on-disk version tag; persisted on next saveStore().
+          data.version = 2;
           return data as CommitmentStore;
         }
       }
     } catch {
       // Start fresh on corruption
     }
-    return { version: 1, commitments: [], lastModified: new Date().toISOString() };
+    return { version: 2, commitments: [], lastModified: new Date().toISOString() };
   }
 
   private saveStore(): void {

--- a/tests/unit/CommitmentTracker-mutate.test.ts
+++ b/tests/unit/CommitmentTracker-mutate.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for CommitmentTracker.mutate() — single-writer queue with CAS.
+ *
+ * These tests are the prerequisite for the Promise Beacon feature
+ * (see docs/specs/PROMISE-BEACON-SPEC.md §"Prerequisite PR"). They cover:
+ *   - Concurrent mutates on the same id serialise correctly (no lost updates).
+ *   - v1 store auto-migrates on load (back-fills version: 0).
+ *   - Queue-full (depth 256) rejects with a clear error.
+ *   - CAS retry works when version drifts between reads and apply.
+ *   - Round-trip: mutate → persist → reload → version preserved.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+
+function createTmpState(): { stateDir: string; cleanup: () => void } {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'commitment-mutate-'));
+  fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, 'config.json'),
+    JSON.stringify({ updates: { autoApply: true } }, null, 2)
+  );
+  return {
+    stateDir,
+    cleanup: () => fs.rmSync(stateDir, { recursive: true, force: true }),
+  };
+}
+
+function makeTracker(stateDir: string): CommitmentTracker {
+  return new CommitmentTracker({ stateDir, liveConfig: new LiveConfig(stateDir) });
+}
+
+describe('CommitmentTracker.mutate()', () => {
+  let stateDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ stateDir, cleanup } = createTmpState());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('starts new commitments at version 0 and bumps on mutate', async () => {
+    const tracker = makeTracker(stateDir);
+    const c = tracker.record({
+      userRequest: 'test',
+      agentResponse: 'ok',
+      type: 'behavioral',
+      behavioralRule: 'Do the thing',
+    });
+    expect(c.version).toBe(0);
+
+    const updated = await tracker.mutate(c.id, cur => ({
+      ...cur,
+      verificationCount: cur.verificationCount + 1,
+    }));
+    expect(updated.version).toBe(1);
+    expect(updated.verificationCount).toBe(1);
+
+    const again = await tracker.mutate(c.id, cur => ({ ...cur }));
+    expect(again.version).toBe(2);
+  });
+
+  it('serialises concurrent mutates on the same id (no lost updates)', async () => {
+    const tracker = makeTracker(stateDir);
+    const c = tracker.record({
+      userRequest: 'concurrent',
+      agentResponse: 'ok',
+      type: 'behavioral',
+      behavioralRule: 'rule',
+    });
+
+    const N = 50;
+    const promises: Promise<unknown>[] = [];
+    for (let i = 0; i < N; i++) {
+      promises.push(
+        tracker.mutate(c.id, cur => ({
+          ...cur,
+          verificationCount: cur.verificationCount + 1,
+        }))
+      );
+    }
+    await Promise.all(promises);
+
+    const final = tracker.get(c.id)!;
+    // Started at 0, N increments — no lost updates.
+    expect(final.verificationCount).toBe(N);
+    // Version bumps once per mutate (record inserted at v0, then N mutates).
+    expect(final.version).toBe(N);
+  });
+
+  it('serialises async mutate bodies (FIFO, no interleave)', async () => {
+    const tracker = makeTracker(stateDir);
+    const c = tracker.record({
+      userRequest: 'async-serial',
+      agentResponse: 'ok',
+      type: 'behavioral',
+      behavioralRule: 'rule',
+    });
+
+    const order: number[] = [];
+    const promises: Promise<unknown>[] = [];
+    for (let i = 0; i < 10; i++) {
+      const idx = i;
+      promises.push(
+        tracker.mutate(c.id, async cur => {
+          order.push(idx);
+          // Give the event loop a chance to interleave — it shouldn't.
+          await new Promise(resolve => setImmediate(resolve));
+          order.push(idx);
+          return { ...cur, verificationCount: cur.verificationCount + 1 };
+        })
+      );
+    }
+    await Promise.all(promises);
+
+    // Each index should appear twice in a row, proving no interleaving.
+    for (let i = 0; i < 10; i++) {
+      expect(order[i * 2]).toBe(i);
+      expect(order[i * 2 + 1]).toBe(i);
+    }
+    expect(tracker.get(c.id)!.verificationCount).toBe(10);
+  });
+
+  it('rejects when the queue exceeds max depth (256)', async () => {
+    const tracker = makeTracker(stateDir);
+    const c = tracker.record({
+      userRequest: 'qfull',
+      agentResponse: 'ok',
+      type: 'behavioral',
+      behavioralRule: 'rule',
+    });
+
+    // Block the drain by making the first mutation wait on a barrier.
+    let releaseFirst: (() => void) | null = null;
+    const firstBarrier = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+
+    // Start the in-flight mutation.
+    const inflight = tracker.mutate(c.id, async cur => {
+      await firstBarrier;
+      return cur;
+    });
+
+    // Fill the queue to capacity (256 additional, since 1 is running).
+    const queued: Promise<unknown>[] = [];
+    for (let i = 0; i < 256; i++) {
+      queued.push(tracker.mutate(c.id, cur => ({ ...cur })));
+    }
+
+    // The 257th enqueue should reject immediately with a clear error.
+    await expect(
+      tracker.mutate(c.id, cur => ({ ...cur }))
+    ).rejects.toThrow(/queue full/i);
+
+    // Drain.
+    releaseFirst!();
+    await inflight;
+    await Promise.all(queued);
+  });
+
+  it('rejects mutate() for unknown ids', async () => {
+    const tracker = makeTracker(stateDir);
+    await expect(
+      tracker.mutate('CMT-999', cur => cur)
+    ).rejects.toThrow(/unknown commitment/i);
+  });
+
+  it('retries on CAS drift (async fn reads, external write drifts version)', async () => {
+    const tracker = makeTracker(stateDir);
+    const c = tracker.record({
+      userRequest: 'cas-drift',
+      agentResponse: 'ok',
+      type: 'behavioral',
+      behavioralRule: 'rule',
+    });
+
+    // Drive CAS drift by having the fn (inside mutate) await while we
+    // directly mutate the in-memory record's version underneath it.
+    // This simulates another writer completing between our read and write.
+    let driftAttempts = 0;
+    const firstVersion = tracker.get(c.id)!.version;
+
+    await tracker.mutate(c.id, async cur => {
+      driftAttempts++;
+      if (driftAttempts === 1) {
+        // Simulate concurrent write: bump the stored version so our CAS fails.
+        const store = (tracker as unknown as {
+          store: { commitments: Array<{ id: string; version: number }> };
+        }).store;
+        const rec = store.commitments.find(r => r.id === c.id)!;
+        rec.version = (rec.version ?? 0) + 1;
+      }
+      return { ...cur, verificationCount: cur.verificationCount + 1 };
+    });
+
+    // fn ran at least twice (first attempt, then retry after drift).
+    expect(driftAttempts).toBeGreaterThanOrEqual(2);
+    const final = tracker.get(c.id)!;
+    // Version moved forward past both the injected drift and our commit.
+    expect(final.version).toBeGreaterThan(firstVersion);
+    expect(final.verificationCount).toBe(1);
+  });
+
+  it('round-trip: mutate → persist → reload → version preserved', async () => {
+    const tracker = makeTracker(stateDir);
+    const c = tracker.record({
+      userRequest: 'roundtrip',
+      agentResponse: 'ok',
+      type: 'behavioral',
+      behavioralRule: 'rule',
+    });
+    await tracker.mutate(c.id, cur => ({ ...cur, verificationCount: 5 }));
+    await tracker.mutate(c.id, cur => ({ ...cur, verificationCount: 6 }));
+
+    // Reload a fresh tracker from the same state dir.
+    const reloaded = makeTracker(stateDir);
+    const rec = reloaded.get(c.id)!;
+    expect(rec.version).toBe(2);
+    expect(rec.verificationCount).toBe(6);
+  });
+
+  it('auto-migrates a v1 store by back-filling version: 0', () => {
+    // Write a v1-shaped store directly, omitting the version field.
+    const storePath = path.join(stateDir, 'state', 'commitments.json');
+    const v1 = {
+      version: 1,
+      commitments: [
+        {
+          id: 'CMT-001',
+          userRequest: 'legacy',
+          agentResponse: 'ok',
+          type: 'behavioral',
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+          verificationCount: 0,
+          violationCount: 0,
+          correctionCount: 0,
+          correctionHistory: [],
+          escalated: false,
+          behavioralRule: 'legacy rule',
+          // no version field
+        },
+      ],
+      lastModified: new Date().toISOString(),
+    };
+    fs.writeFileSync(storePath, JSON.stringify(v1, null, 2));
+
+    const tracker = makeTracker(stateDir);
+    const rec = tracker.get('CMT-001')!;
+    expect(rec.version).toBe(0);
+
+    // Confirm the store-level version is bumped on next save.
+    const after = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    // Migration bumps on load; saveStore() on next mutation persists v2.
+    expect([1, 2]).toContain(after.version);
+  });
+
+  it('persists store version 2 after any write', async () => {
+    const tracker = makeTracker(stateDir);
+    const c = tracker.record({
+      userRequest: 'v2-on-disk',
+      agentResponse: 'ok',
+      type: 'behavioral',
+      behavioralRule: 'rule',
+    });
+    await tracker.mutate(c.id, cur => ({ ...cur }));
+    const storePath = path.join(stateDir, 'state', 'commitments.json');
+    const onDisk = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
+    expect(onDisk.version).toBe(2);
+    expect(onDisk.commitments[0].version).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/unit/CommitmentTracker.test.ts
+++ b/tests/unit/CommitmentTracker.test.ts
@@ -173,7 +173,7 @@ describe('CommitmentTracker', () => {
       const storePath = path.join(stateDir, 'state', 'commitments.json');
       expect(fs.existsSync(storePath)).toBe(true);
       const data = JSON.parse(fs.readFileSync(storePath, 'utf-8'));
-      expect(data.version).toBe(1);
+      expect(data.version).toBe(2);
       expect(data.commitments).toHaveLength(1);
       expect(data.commitments[0].id).toBe('CMT-001');
     });

--- a/upgrades/side-effects/commitment-tracker-mutate.md
+++ b/upgrades/side-effects/commitment-tracker-mutate.md
@@ -1,0 +1,99 @@
+# Side-Effects Review — CommitmentTracker.mutate() single-writer surface
+
+**Version / slug:** `commitment-tracker-mutate`
+**Date:** `2026-04-19`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Adds a single-writer `mutate(id, fn)` API to `CommitmentTracker` as the prerequisite micro-PR called out in `docs/specs/PROMISE-BEACON-SPEC.md §"Prerequisite PR"`. Every in-tree write path (`record` initialization, `withdraw`, `verifyOne`, `expireCommitments`, `attemptAutoCorrection`, `checkForEscalation`) now serialises through this surface so the forthcoming Promise Beacon, PresenceProxy, and CommitmentSentinel can't clobber each other's writes. The `Commitment` record gains a monotonic `version: number` field; `CommitmentStore.version` bumps from 1 to 2; loader back-fills `version: 0` on every legacy record.
+
+Files touched:
+- `src/monitoring/CommitmentTracker.ts` — new async `mutate`, internal `mutateSync`, CAS retry, FIFO queue (depth 256), schema bump, v1→v2 migration, all existing write paths routed through the single-writer surface.
+- `tests/unit/CommitmentTracker-mutate.test.ts` — new (9 tests).
+- `tests/unit/CommitmentTracker.test.ts` — existing test updated for store version 2.
+
+Decision-point surfaces touched: none. This change is a concurrency-control primitive, not a block/allow surface.
+
+## Decision-point inventory
+
+- No decision points added, modified, or removed. This PR is a data-model + concurrency-control refactor. `mutate()` does not filter, gate, or reject any agent input — it only serialises writes to a record that already existed.
+- `queue-full` rejection at depth 256 is backpressure, not authority over agent behavior: it rejects *its own caller's write attempt* to protect memory, it does not decide what agents are allowed to say or do.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable.
+
+The only rejection path is `queue-full` at depth 256 of in-flight writes for the same commitment id. Reaching that depth requires 256 pending writes on a single commitment — under the spec's `globalMaxOpen: 20` and normal timer cadence this is structurally unreachable outside of a test harness. If it ever fires in practice, the caller sees a clear error (not a silent drop) and can retry or surface the failure.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+The CAS retry budget is 5. If five consecutive writers drift a record's version between one caller's read and write, that caller's mutation is dropped with a clear error. Under `globalMaxOpen: 20` with per-id queues that serialise synchronously, this is unreachable in practice — but if it ever is, the error is explicit, not silent, and the caller can surface it.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Right layer. `CommitmentTracker` owns the commitment record's lifecycle; the single-writer queue belongs inside the class that owns the data. Putting it higher (e.g., a route-level lock) would force every caller to know about the invariant; putting it lower (e.g., a filesystem lock) would miss in-memory writes. The `mutate(id, fn)` shape matches the spec's prereq contract and is the same surface PromiseBeacon will consume without any additional adapter.
+
+A sync fast-path (`mutateSync`) is preserved for the existing synchronous write paths because JS is single-threaded — synchronous fn bodies cannot race each other — so forcing the existing callers through an async queue would add gratuitous microtask latency to every write without any concurrency benefit. Async `mutate()` is the surface that matters when fn bodies await (e.g., beacon timer handlers calling the LLM).
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] Yes, with brittle logic — STOP.
+
+`mutate()` is a concurrency primitive. It does not decide what agents are allowed to do. The only error responses (`queue full`, `unknown id`, `CAS retry exhausted`) are structural backpressure, not agent-behavior authority. Signal-vs-authority is not applicable to this surface.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** None. `mutate()` is a new internal surface; all existing write paths funnel *through* it rather than running in parallel. No existing check is shadowed by or shadows the new code.
+- **Double-fire:** None. The FIFO-per-id discipline means two write attempts on the same commitment serialise; they cannot both win. The existing `emit('recorded' | 'withdrawn' | 'corrected' | 'escalation' | 'verification')` events fire exactly where they did before — the refactor preserves emission sites.
+- **Races:** The one place to watch is `expireCommitments` iterating the store while `mutateSync` replaces records in-place. The code snapshot-collects target ids *before* iterating so we don't iterate a live array under index-preserving writes. `verifyOne` uses the latest snapshot from the store after mutation to pass to callbacks. The sync helper preserves array index (`store.commitments[idx] = committed`), so stable id-based lookup is intact.
+- **Feedback loops:** `attemptAutoCorrection` still calls `checkForEscalation(updated)` which can itself mutate — this was the prior behavior, now both routed through `mutateSync`. No new feedback loop introduced.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** None. `CommitmentTracker` is in-process server state.
+- **Other users of the install base:** Agents upgrading from a v1 commitments store transparently get a v2 on-disk format after the first write post-upgrade. Pre-upgrade records are auto-migrated on load (`version: 0` back-filled). No user action needed.
+- **External systems:** None.
+- **Persistent state:** `state/commitments.json` bumps from `"version": 1` to `"version": 2` and gains a `version: N` field per commitment. Forward-compatible in the sense that v2 is a strict superset of v1 by field set; backward-compatible on load because the loader still accepts `version: 1` and migrates. A v1-only reader would see the new top-level version and the new per-record field; the only in-tree v1 reader is the loader itself, which is already v2-aware.
+- **Timing:** `mutate()` adds one FS `writeFile`-then-`rename` per successful apply (same pattern the file already used). No new timing dependency.
+
+---
+
+## 7. Rollback cost
+
+- **Hot-fix release:** Revert the commit. No code downstream depends on `mutate()` yet — PromiseBeacon and PresenceProxy adoption is explicitly deferred to follow-up PRs. A straight revert is clean.
+- **Data migration:** Rolling back *with* existing agents on v2 stores on disk is slightly awkward — the old loader only accepts `version: 1`. The loader's pre-rollback behavior was to discard unknown versions and start fresh, which would wipe live commitments. **Mitigation if rollback becomes necessary:** include a one-shot rewrite step in the rollback patch that copies the old loader's v1 acceptance back in, or ship a migration script that rewrites v2 stores down to v1 (drop `version` field, set top-level to 1). Estimated effort: 15 minutes of code + a release.
+- **Agent state repair:** None beyond the note above. No events, no external deps, no cached derived state.
+- **User visibility:** None during rollout. If rollback happens without the loader-compat patch, affected agents would lose their commitments list (reset to empty) — a rare but non-trivial user-visible regression. The low-friction fix is "don't roll back blindly — include the loader-compat step".
+
+## Conclusion
+
+This is an internal refactor + new API surface. No decision-point surface is touched, no block/allow authority is added, and signal-vs-authority does not apply. The main rollback caveat is the v1→v2 store-version bump: a blind revert would leave agents unable to read their own commitments. A rollback, if ever needed, needs to include a 15-minute compat patch. All 122 commitment-related tests pass (9 new in `CommitmentTracker-mutate.test.ts`, 113 pre-existing across `CommitmentTracker`, `CommitmentSentinel`, `CommitmentSweeper`, `commitment-routes`). Clear to ship as the Promise Beacon prerequisite PR.
+
+---
+
+## Evidence pointers
+
+- Tests: `tests/unit/CommitmentTracker-mutate.test.ts` (9 tests covering concurrency serialisation, FIFO across awaits, queue-full rejection, CAS retry under drift, v1→v2 migration, round-trip version preservation).
+- Spec: `docs/specs/PROMISE-BEACON-SPEC.md §"Prerequisite PR — CommitmentTracker.mutate()"`.
+- Verification: `npx vitest run tests/unit/CommitmentTracker*.test.ts tests/unit/CommitmentSentinel.test.ts tests/unit/CommitmentSweeper.test.ts tests/unit/commitment-routes.test.ts` — 122 passed, 0 failed.


### PR DESCRIPTION
## Why

Prerequisite micro-PR for the Promise Beacon feature (see `docs/specs/PROMISE-BEACON-SPEC.md §"Prerequisite PR — CommitmentTracker.mutate()"`). The beacon, PresenceProxy, and CommitmentSentinel all write to the same commitment records; without a single-writer surface they can (and under P3 analysis will) clobber each other. This PR extracts that surface so the beacon can land cleanly on top.

## What changed

- `Commitment` gains a `version: number` field (monotonic, back-filled to `0` on legacy records).
- `CommitmentStore.version` bumps from `1` to `2`; loader auto-migrates v1 stores on load.
- New async `mutate(id, fn)`:
  - FIFO queue per commitment id, max depth **256** — overflow rejects with a clear error (never silently drops).
  - Optimistic CAS on `version`; retries up to **5** times when the version drifts under an `await`.
  - p99 target for the caller-supplied `fn` is **50 ms** (documented in-code).
  - Atomic write + rename on each successful apply (same pattern the file already used).
- Existing synchronous write paths (`record` init, `withdraw`, `verifyOne`, `expireCommitments`, `attemptAutoCorrection`, `checkForEscalation`) route through a new internal `mutateSync()` helper. JS is single-threaded, so sync `fn` bodies cannot race each other — `mutateSync` is just read → apply → version++ → persist, no queue overhead. The async `mutate()` is what matters once `fn` bodies `await` (beacon handlers, LLM calls, etc.).

## Scope

- **In:** `src/monitoring/CommitmentTracker.ts`, new `tests/unit/CommitmentTracker-mutate.test.ts`, one store-version assertion updated in `tests/unit/CommitmentTracker.test.ts`.
- **Out (follow-up):** PresenceProxy and CommitmentSentinel adoption of `mutate()`. Those callers will move over in the PromiseBeacon PR to keep this one small and reviewable.

## How tested

- 9 new tests in `tests/unit/CommitmentTracker-mutate.test.ts` covering:
  - Concurrent mutates on the same id serialise correctly (no lost updates).
  - Async `fn` bodies are FIFO-serialised across `await` points (no interleave).
  - Queue-full at depth 256 rejects with a clear "queue full" error.
  - CAS retry works when `version` drifts between read and write.
  - `mutate()` on unknown id rejects with a clear error.
  - v1 store auto-migrates on load (`version: 0` back-fill).
  - Round-trip: `mutate → persist → reload → version preserved`.
  - Store `version: 2` is persisted after any write.
- Full commitment-suite: `npx vitest run tests/unit/CommitmentTracker*.test.ts tests/unit/CommitmentSentinel.test.ts tests/unit/CommitmentSweeper.test.ts tests/unit/commitment-routes.test.ts` — **122 passed, 0 failed**.
- Pre-push test suite (`npm run test:push`) — **141 passed, 0 failed** on the scoped smoke tier.

## Side-effects review

See `upgrades/side-effects/commitment-tracker-mutate.md`. No decision-point surface is touched; signal-vs-authority is not applicable. Rollback caveat: the v1→v2 on-disk bump means a blind revert needs a loader-compat shim (~15 min of code) or agents could start fresh on revert. Documented in the artifact.

## Notes

- Branch was force-pushed once to overwrite a stale autonomous-session scratch branch at the same name. The force-push was `--force-with-lease` and the overwritten commits were scratch (`init`, `plan: .instar/autonomous-plan.md`, etc. from a prior autonomous run), not real work.
- During `git push`, the pre-push smoke tier tripped on two untracked test files from another in-flight session (`tests/unit/SessionManager.rawInject-verify.test.ts`, `tests/integration/tmux-inject-verify.test.ts`) that assert on a `scheduleInjectionWatchdog` method not present in this branch. Those files are not part of this PR; they were stashed aside for the push (per the "concurrent session push hygiene" learning in MEMORY) and restored to the working tree afterwards. Nothing in this PR touches SessionManager.