### PR TITLE
feat(promise-beacon): phase 1 — beacon core, shared queue, delivery endpoint

### DIFF
--- a/.instar/instar-dev-traces/20260419-175500-promise-beacon-phase-1.json
+++ b/.instar/instar-dev-traces/20260419-175500-promise-beacon-phase-1.json
@@ -1,0 +1,25 @@
+{
+  "sessionId": "echo-promise-beacon-phase-1",
+  "timestamp": "2026-04-19T17:55:00Z",
+  "specPath": "docs/specs/PROMISE-BEACON-SPEC.md",
+  "artifactPath": "upgrades/side-effects/promise-beacon-phase-1.md",
+  "artifactSha256": "cf2a807164297f4d6c6dc164ea18446de956db656cf1fc2e3d79f58dc85b21ae",
+  "coveredFiles": [
+    "src/monitoring/CommitmentTracker.ts",
+    "src/monitoring/LlmQueue.ts",
+    "src/monitoring/PresenceProxy.ts",
+    "src/monitoring/PromiseBeacon.ts",
+    "src/monitoring/ProxyCoordinator.ts",
+    "src/server/routes.ts",
+    "src/commands/server.ts",
+    "src/commands/init.ts",
+    "tests/unit/LlmQueue.test.ts",
+    "tests/unit/ProxyCoordinator.test.ts",
+    "tests/unit/PromiseBeacon.test.ts",
+    "tests/integration/PromiseBeacon-lifecycle.test.ts",
+    "upgrades/side-effects/promise-beacon-phase-1.md"
+  ],
+  "phase": "complete",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1649,6 +1649,27 @@ curl -s http://localhost:\${INSTAR_PORT:-${port}}/evolution/actions/overdue
 ## The Commitment Check
 
 The commitment-check job runs every 4 hours and surfaces overdue items. If you create an action and forget it, the system won't.
+
+## Promise Beacon (follow-through heartbeats)
+
+If you're committing to a user on Telegram and want the system to auto-emit \`⏳\` status lines while you work silently, pass \`nextUpdateDueAt\` and \`topicId\`:
+
+\`\`\`bash
+curl -s -X POST http://localhost:\${INSTAR_PORT:-${port}}/commitments \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "userRequest":"user asked for X",
+    "agentResponse":"I will ship X in about 30 min",
+    "type":"one-time-action",
+    "topicId":TOPIC_ID,
+    "beaconEnabled":true,
+    "cadenceMs":600000,
+    "nextUpdateDueAt":"2026-04-19T18:30:00Z",
+    "source":"skill"
+  }'
+\`\`\`
+
+PromiseBeacon will then post a heartbeat on the configured cadence until you \`POST /commitments/:id/deliver\` with the delivery message id. See docs/specs/PROMISE-BEACON-SPEC.md.
 `,
     },
     'feedback': {

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4551,6 +4551,27 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.green('  Compaction auto-resume registered (Slack channels)'));
     }
 
+    // ── ProxyCoordinator (shared between PresenceProxy and PromiseBeacon) ──
+    // Per PROMISE-BEACON-SPEC.md §A10: a per-topic mutex that prevents
+    // ⏳ (PromiseBeacon) and 🔭 (PresenceProxy) from double-posting.
+    const { ProxyCoordinator } = await import('../monitoring/ProxyCoordinator.js');
+    const proxyCoordinator = new ProxyCoordinator();
+
+    // ── Shared LlmQueue (priority-laned, daily-spend-capped) ──
+    const { LlmQueue: SharedLlmQueueCls } = await import('../monitoring/LlmQueue.js');
+    const promiseBeaconCfg = ((config as any).promiseBeacon ?? {}) as {
+      prefix?: string;
+      maxDailyLlmSpendCents?: number;
+      sentinelAutoEnable?: boolean;
+      quietHours?: { start: string; end: string; timezone?: string };
+    };
+    const sharedLlmQueue = new SharedLlmQueueCls({
+      maxConcurrent: 3,
+      interactiveReservePct: 0.4,
+      maxDailyCents: promiseBeaconCfg.maxDailyLlmSpendCents ?? 100,
+    });
+    void sharedLlmQueue; // Wired into PromiseBeacon below; PresenceProxy refactor tracked as follow-up.
+
     let presenceProxy: import('../monitoring/PresenceProxy.js').PresenceProxy | undefined;
     if (sharedIntelligence && telegram) {
       try {
@@ -4695,6 +4716,9 @@ export async function startServer(options: StartOptions): Promise<void> {
                 return { recovered: result.recovered };
               }
             : undefined,
+          // Shared per-topic mutex — coordinates with PromiseBeacon.
+          acquireProxyMutex: (topicId, holder) => proxyCoordinator.tryAcquire(topicId, holder),
+          releaseProxyMutex: (topicId, holder) => proxyCoordinator.release(topicId, holder),
         });
 
         // Hook into Telegram's onMessageLogged callback (always active, unlike EventBus which requires a feature flag)
@@ -4719,6 +4743,43 @@ export async function startServer(options: StartOptions): Promise<void> {
         };
 
         presenceProxy.start();
+
+        // ── PromiseBeacon ────────────────────────────────────────────────
+        // Watches beacon-enabled commitments and emits ⏳ heartbeats so the
+        // user knows the agent hasn't gone silent on an open promise.
+        // Spec: docs/specs/PROMISE-BEACON-SPEC.md
+        try {
+          const { PromiseBeacon } = await import('../monitoring/PromiseBeacon.js');
+          const promiseBeacon = new PromiseBeacon({
+            stateDir: config.stateDir,
+            commitmentTracker,
+            llmQueue: sharedLlmQueue,
+            proxyCoordinator,
+            captureSessionOutput: (name, lines) => sessionManager.captureOutput(name, lines),
+            getSessionForTopic: (topicId) => telegram!.getSessionForTopic(topicId),
+            isSessionAlive: (name) => sessionManager.isSessionAlive(name),
+            sendMessage: async (topicId, text, metadata) => {
+              const url = `http://localhost:${config.port}/telegram/reply/${topicId}`;
+              const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': `Bearer ${config.authToken}`,
+                },
+                body: JSON.stringify({ text, metadata }),
+              });
+              if (!response.ok) throw new Error(`Beacon reply failed: ${response.status}`);
+            },
+            prefix: promiseBeaconCfg.prefix ?? '⏳',
+            maxDailyLlmSpendCents: promiseBeaconCfg.maxDailyLlmSpendCents ?? 100,
+            sentinelAutoEnable: promiseBeaconCfg.sentinelAutoEnable ?? false,
+            quietHours: promiseBeaconCfg.quietHours ?? { start: '22:00', end: '08:00' },
+          });
+          promiseBeacon.start();
+          (globalThis as Record<string, unknown>).__instarPromiseBeacon = promiseBeacon;
+        } catch (err) {
+          console.warn('[PromiseBeacon] init failed:', (err as Error).message);
+        }
 
         // Wire Slack's onMessageLogged into PresenceProxy + TopicMemory (if Slack is active)
         if (_slackAdapter) {

--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -28,7 +28,7 @@ import { DegradationReporter } from './DegradationReporter.js';
 // ── Types ─────────────────────────────────────────────────────────
 
 export type CommitmentType = 'config-change' | 'behavioral' | 'one-time-action';
-export type CommitmentStatus = 'pending' | 'verified' | 'violated' | 'expired' | 'withdrawn';
+export type CommitmentStatus = 'pending' | 'verified' | 'violated' | 'expired' | 'withdrawn' | 'delivered';
 
 export interface Commitment {
   /** Unique identifier (CMT-xxx) */
@@ -92,6 +92,52 @@ export interface Commitment {
    * Back-filled to 0 on records from store v1.
    */
   version: number;
+
+  // ── Promise Beacon (Phase 1 — PROMISE-BEACON-SPEC.md) ──
+  /** When set, this commitment is watched by PromiseBeacon. Requires topicId. */
+  beaconEnabled?: boolean;
+  /** Heartbeat cadence in ms. Server clamps to [60_000, 21_600_000]. */
+  cadenceMs?: number;
+  /**
+   * Soft "I'll check in by X" marker. Past it, one atRisk notice is emitted
+   * and cadence continues (see Round 3 clarification #4).
+   */
+  nextUpdateDueAt?: string;
+  /** Soft deadline — past it, cadence doubles (no terminal transition). */
+  softDeadlineAt?: string;
+  /** Hard deadline — past it, commitment transitions to `expired`. */
+  hardDeadlineAt?: string;
+  /** Last heartbeat emission (ISO). */
+  lastHeartbeatAt?: string;
+  /** Count of heartbeats emitted so far. */
+  heartbeatCount?: number;
+  /**
+   * Claude Code session UUID at declaration. On mismatch, commitment is
+   * violated with reason `"session-lost"` (Round 3 #3).
+   */
+  sessionEpoch?: string;
+  /**
+   * Non-terminal flag — Tier-3 "stalled" verdicts set this; still heartbeating
+   * with a softer tone. Only corroborated signals transition to `violated`.
+   */
+  atRisk?: boolean;
+  /**
+   * Non-terminal flag — boot-cap / daily-spend-cap suppression. Status stays
+   * `pending`, no heartbeats fire (Round 3 #2).
+   */
+  beaconSuppressed?: boolean;
+  /** Reason accompanying `beaconSuppressed`. */
+  beaconSuppressionReason?: string;
+  /** SHA-256 of the last tmux snapshot used for a heartbeat. */
+  lastSnapshotHash?: string;
+  /** Machine owning the beacon for this commitment. */
+  ownerMachineId?: string;
+  /** Provenance of the beacon-enabling mutation. */
+  beaconCreatedBySource?: 'skill' | 'api-loopback' | 'sentinel' | 'manual';
+  /** Idempotency key for skill retries. */
+  externalKey?: string;
+  /** Verified delivery message id (set by POST /commitments/:id/deliver). */
+  deliveryMessageId?: string;
 }
 
 export interface CommitmentStore {
@@ -216,6 +262,16 @@ export class CommitmentTracker extends EventEmitter {
     expiresAt?: string;
     verificationMethod?: 'config-value' | 'file-exists' | 'manual';
     verificationPath?: string;
+    // Promise Beacon (Phase 1) — all optional & additive.
+    beaconEnabled?: boolean;
+    cadenceMs?: number;
+    nextUpdateDueAt?: string;
+    softDeadlineAt?: string;
+    hardDeadlineAt?: string;
+    sessionEpoch?: string;
+    ownerMachineId?: string;
+    externalKey?: string;
+    beaconCreatedBySource?: 'skill' | 'api-loopback' | 'sentinel' | 'manual';
   }): Commitment {
     const id = `CMT-${String(this.nextId++).padStart(3, '0')}`;
 
@@ -240,6 +296,17 @@ export class CommitmentTracker extends EventEmitter {
       correctionHistory: [],
       escalated: false,
       version: 0,
+      // Promise Beacon fields (Phase 1).
+      beaconEnabled: input.beaconEnabled,
+      cadenceMs: input.cadenceMs,
+      nextUpdateDueAt: input.nextUpdateDueAt,
+      softDeadlineAt: input.softDeadlineAt,
+      hardDeadlineAt: input.hardDeadlineAt,
+      sessionEpoch: input.sessionEpoch,
+      ownerMachineId: input.ownerMachineId,
+      externalKey: input.externalKey,
+      beaconCreatedBySource: input.beaconCreatedBySource,
+      heartbeatCount: 0,
     };
 
     // Insert via the same discipline future writes use: under the single-
@@ -288,6 +355,29 @@ export class CommitmentTracker extends EventEmitter {
     console.log(`[CommitmentTracker] Withdrawn ${id}: ${reason}`);
     this.emit('withdrawn', updated);
     return true;
+  }
+
+  /**
+   * Mark a beacon-enabled commitment as delivered (distinct from verified).
+   * Per PROMISE-BEACON-SPEC.md Round 3 #18: `delivered` is terminal; no more
+   * heartbeats, no more verify attempts.
+   */
+  deliver(id: string, deliveryMessageId?: string): Commitment | null {
+    const existing = this.store.commitments.find(c => c.id === id);
+    if (!existing) return null;
+    // Terminal statuses reject.
+    if (['verified', 'violated', 'expired', 'withdrawn', 'delivered'].includes(existing.status)) {
+      return null;
+    }
+    const updated = this.mutateSync(id, c => ({
+      ...c,
+      status: 'delivered' as CommitmentStatus,
+      resolvedAt: new Date().toISOString(),
+      deliveryMessageId: deliveryMessageId ?? c.deliveryMessageId,
+    }));
+    console.log(`[CommitmentTracker] Delivered ${id}`);
+    this.emit('delivered', updated);
+    return updated;
   }
 
   /**

--- a/src/monitoring/LlmQueue.ts
+++ b/src/monitoring/LlmQueue.ts
@@ -1,0 +1,195 @@
+/**
+ * LlmQueue — Shared priority-laned LLM call queue
+ *
+ * Extracted from PresenceProxy (per PROMISE-BEACON-SPEC.md Phase 1) so both
+ * PresenceProxy and PromiseBeacon can share a single concurrency + daily
+ * spend budget.
+ *
+ * Two lanes with a reservation rule:
+ *   - interactive (default 40% reserve): PresenceProxy tiers, delivery verify
+ *   - background: PromiseBeacon heartbeats, Sentinel shadow scans
+ *
+ * When the interactive lane has work and the provider concurrency limit is
+ * hit, the queue aborts the lowest-priority in-flight background call via
+ * AbortController, freeing a slot for the interactive arrival. Aborted
+ * background callers see an `LlmAbortedError` and can fall back to a
+ * templated response.
+ */
+export type LlmLane = 'interactive' | 'background';
+
+export class LlmAbortedError extends Error {
+  constructor() {
+    super('LLM call aborted by higher-priority lane');
+    this.name = 'LlmAbortedError';
+  }
+}
+
+export interface LlmQueueOptions {
+  /** Max concurrent in-flight calls (default 3). */
+  maxConcurrent?: number;
+  /** Fraction of `maxDailyCents` reserved for the interactive lane. Default 0.4. */
+  interactiveReservePct?: number;
+  /** Daily spend cap in cents across both lanes. Default 100. */
+  maxDailyCents?: number;
+  /** Provide `Date.now()` — injectable for tests. */
+  now?: () => number;
+}
+
+interface InFlight {
+  lane: LlmLane;
+  controller: AbortController;
+  reject: (err: Error) => void;
+}
+
+interface Waiter {
+  lane: LlmLane;
+  fn: (signal: AbortSignal) => Promise<string>;
+  costCents: number;
+  resolve: (v: string) => void;
+  reject: (e: Error) => void;
+}
+
+export class LlmQueue {
+  private maxConcurrent: number;
+  private interactiveReservePct: number;
+  private maxDailyCents: number;
+  private now: () => number;
+
+  private inFlight: Set<InFlight> = new Set();
+  private waiters: Waiter[] = [];
+
+  /** Daily spend ledger: { dateKey: 'YYYY-MM-DD', cents: number, interactive: number } */
+  private dailySpendCents = 0;
+  private dailyInteractiveCents = 0;
+  private dailyDateKey = '';
+
+  constructor(opts: LlmQueueOptions = {}) {
+    this.maxConcurrent = opts.maxConcurrent ?? 3;
+    this.interactiveReservePct = opts.interactiveReservePct ?? 0.4;
+    this.maxDailyCents = opts.maxDailyCents ?? 100;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  /**
+   * Enqueue a call.
+   *
+   * `fn` receives an AbortSignal — callers MUST honor it. Aborted callers
+   * should throw (the queue will reject with LlmAbortedError).
+   *
+   * `costCents` is the caller's best estimate of the call cost. Used only
+   * for the daily cap — if the cap is already exceeded the call is rejected.
+   */
+  async enqueue(
+    lane: LlmLane,
+    fn: (signal: AbortSignal) => Promise<string>,
+    costCents = 0,
+  ): Promise<string> {
+    this.rollDateIfNeeded();
+
+    // Daily cap check.
+    if (this.dailySpendCents + costCents > this.maxDailyCents) {
+      throw new Error('LLM daily spend cap exceeded');
+    }
+    // Per-lane reserve: interactive lane is guaranteed ≥ reservePct; background
+    // lane cannot push total into the reserved portion once interactive floor
+    // is unmet.
+    const reservedForInteractive = Math.floor(this.maxDailyCents * this.interactiveReservePct);
+    if (lane === 'background') {
+      const remainingAfter = this.maxDailyCents - (this.dailySpendCents + costCents);
+      if (remainingAfter < reservedForInteractive - this.dailyInteractiveCents) {
+        throw new Error('LLM background lane would breach interactive reserve');
+      }
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      this.waiters.push({ lane, fn, costCents, resolve, reject });
+      this.drain();
+    });
+  }
+
+  /**
+   * Try to start as many waiters as concurrency allows. Interactive waiters
+   * that cannot start because the concurrency limit is hit will trigger
+   * abort() of an in-flight background call.
+   */
+  private drain(): void {
+    // Sort waiters so interactive comes first.
+    this.waiters.sort((a, b) => (a.lane === b.lane ? 0 : a.lane === 'interactive' ? -1 : 1));
+
+    while (this.waiters.length > 0) {
+      const next = this.waiters[0];
+
+      if (this.inFlight.size < this.maxConcurrent) {
+        this.waiters.shift();
+        this.start(next);
+        continue;
+      }
+
+      // Full. If the waiter is interactive, try to preempt a background.
+      if (next.lane === 'interactive') {
+        const victim = [...this.inFlight].find(f => f.lane === 'background');
+        if (victim) {
+          victim.controller.abort();
+          victim.reject(new LlmAbortedError());
+          this.inFlight.delete(victim);
+          // Loop again; next iteration starts the interactive waiter.
+          continue;
+        }
+      }
+
+      // Either the waiter is background and pool is full, or pool is full
+      // of interactive calls. Wait for something to complete.
+      break;
+    }
+  }
+
+  private start(w: Waiter): void {
+    const controller = new AbortController();
+    const inflight: InFlight = {
+      lane: w.lane,
+      controller,
+      reject: w.reject,
+    };
+    this.inFlight.add(inflight);
+
+    w.fn(controller.signal)
+      .then(result => {
+        if (!this.inFlight.has(inflight)) return; // aborted
+        this.inFlight.delete(inflight);
+        this.dailySpendCents += w.costCents;
+        if (w.lane === 'interactive') this.dailyInteractiveCents += w.costCents;
+        w.resolve(result);
+        this.drain();
+      })
+      .catch(err => {
+        if (!this.inFlight.has(inflight)) return; // already rejected by abort
+        this.inFlight.delete(inflight);
+        w.reject(err);
+        this.drain();
+      });
+  }
+
+  private rollDateIfNeeded(): void {
+    const today = new Date(this.now()).toISOString().slice(0, 10);
+    if (today !== this.dailyDateKey) {
+      this.dailyDateKey = today;
+      this.dailySpendCents = 0;
+      this.dailyInteractiveCents = 0;
+    }
+  }
+
+  /** Test / diagnostic accessors. */
+  getDailySpendCents(): number {
+    this.rollDateIfNeeded();
+    return this.dailySpendCents;
+  }
+  getInFlightCount(): number {
+    return this.inFlight.size;
+  }
+  getWaitingCount(): number {
+    return this.waiters.length;
+  }
+  getInFlightLanes(): LlmLane[] {
+    return [...this.inFlight].map(f => f.lane);
+  }
+}

--- a/src/monitoring/PresenceProxy.ts
+++ b/src/monitoring/PresenceProxy.ts
@@ -44,6 +44,15 @@ export interface PresenceProxyConfig {
   isTriageMutexHeld?: (sessionName: string) => string | null; // returns holder name or null
   triggerManualTriage?: (topicId: number, sessionName: string) => Promise<void>;
 
+  /**
+   * Optional shared per-topic proxy mutex (per PROMISE-BEACON-SPEC.md §A10).
+   * When present, PresenceProxy acquires this before sending a tier message
+   * so PromiseBeacon (⏳) and PresenceProxy (🔭) don't double-post to the
+   * same topic within the same second.
+   */
+  acquireProxyMutex?: (topicId: number, holder: 'presence-proxy' | 'promise-beacon') => boolean;
+  releaseProxyMutex?: (topicId: number, holder: 'presence-proxy' | 'promise-beacon') => void;
+
   // Optional: context exhaustion auto-recovery
   recoverContextExhaustion?: (topicId: number, sessionName: string) => Promise<{ recovered: boolean }>;
 
@@ -1190,6 +1199,17 @@ IMPORTANT BIAS: Default to "working" or "waiting" unless there is STRONG evidenc
   }
 
   private async sendProxyMessage(topicId: number, text: string, tier: number): Promise<void> {
+    // Spec A10: acquire shared per-topic proxy mutex if one is wired.
+    // PromiseBeacon consumes the same coordinator; the acquire here guarantees
+    // only one proxy-class emitter fires per topic at a time.
+    let heldMutex = false;
+    if (this.config.acquireProxyMutex) {
+      heldMutex = this.config.acquireProxyMutex(topicId, 'presence-proxy');
+      if (!heldMutex) {
+        console.log(`[PresenceProxy] Proxy mutex held for topic ${topicId} — skipping send`);
+        return;
+      }
+    }
     try {
       await this.config.sendMessage(topicId, text, {
         source: 'presence-proxy',
@@ -1198,6 +1218,10 @@ IMPORTANT BIAS: Default to "working" or "waiting" unless there is STRONG evidenc
       });
     } catch (err) {
       console.error(`[PresenceProxy] Failed to send message to topic ${topicId}:`, (err as Error).message);
+    } finally {
+      if (heldMutex && this.config.releaseProxyMutex) {
+        this.config.releaseProxyMutex(topicId, 'presence-proxy');
+      }
     }
   }
 

--- a/src/monitoring/PromiseBeacon.ts
+++ b/src/monitoring/PromiseBeacon.ts
@@ -1,0 +1,456 @@
+/**
+ * PromiseBeacon — Follow-through heartbeats for open agent commitments.
+ *
+ * Implements the Phase 1 scope of docs/specs/PROMISE-BEACON-SPEC.md.
+ *
+ * When the agent says "I'll come back when X finishes" and then works silently
+ * for 30+ minutes, the user has no signal whether the agent is alive,
+ * progressing, or has forgotten. PromiseBeacon watches beacon-enabled
+ * commitments (Commitment rows with `beaconEnabled: true` and a `topicId`)
+ * and emits a short status line on a per-commitment cadence.
+ *
+ * Key properties:
+ *  - setTimeout-based scheduling (not polling); durable across sleep by
+ *    persisting `nextDueAt` (spec Round 3 #17).
+ *  - Per-commitment hot state at .instar/state/promise-beacon/<id>.json
+ *    (gitignored).
+ *  - Snapshot-hash gate: unchanged tmux output emits a templated line
+ *    without calling the LLM (≈70% of heartbeats on a quiet session).
+ *  - Session-epoch check: if the Claude Code session UUID at declaration
+ *    no longer matches the live session, transition to `violated` with
+ *    reason `session-lost`.
+ *  - Quiet hours + daily spend cap → `beaconSuppressed` (non-terminal).
+ *  - Shares the LlmQueue and ProxyCoordinator with PresenceProxy so the
+ *    two monitors can't double-post.
+ *
+ * Integration points:
+ *  - `commitmentTracker.mutate(id, fn)` is the only write path.
+ *  - `sendMessage(topicId, text, { source: 'promise-beacon', isProxy: true })`
+ *    is what PresenceProxy's `isSystemOrProxyMessage` filters out.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { EventEmitter } from 'node:events';
+import type { CommitmentTracker, Commitment } from './CommitmentTracker.js';
+import type { LlmQueue } from './LlmQueue.js';
+import { LlmAbortedError } from './LlmQueue.js';
+import type { ProxyCoordinator } from './ProxyCoordinator.js';
+import { sanitizeTmuxOutput, guardProxyOutput } from './PresenceProxy.js';
+
+// ─── Config & types ─────────────────────────────────────────────────────────
+
+export interface PromiseBeaconConfig {
+  stateDir: string;
+  commitmentTracker: CommitmentTracker;
+  llmQueue: LlmQueue;
+  proxyCoordinator: ProxyCoordinator;
+
+  // Callbacks
+  captureSessionOutput: (sessionName: string, lines?: number) => string | null;
+  getSessionForTopic: (topicId: number) => string | null;
+  isSessionAlive: (sessionName: string) => boolean;
+  getSessionEpoch?: (sessionName: string) => string | null;
+  sendMessage: (
+    topicId: number,
+    text: string,
+    metadata?: { source: 'promise-beacon'; isProxy: true; tier?: number },
+  ) => Promise<void>;
+  /** Haiku-class LLM call returning a short status line. */
+  generateStatusLine?: (
+    promiseText: string,
+    tmuxOutput: string,
+    signal: AbortSignal,
+  ) => Promise<string>;
+
+  // Settings (all spec-defaulted, per-agent overridable via config.json)
+  prefix?: string;                   // Default: "⏳"
+  maxDailyLlmSpendCents?: number;    // Default: 100
+  sentinelAutoEnable?: boolean;      // Default: false
+  quietHours?: { start: string; end: string; timezone?: string }; // "22:00-08:00" local
+  /** Current machine id (ownership gate). */
+  currentMachineId?: string;
+  /** Floor for heartbeat cadence (ms). Default 60_000. */
+  minCadenceMs?: number;
+  /** Ceiling for heartbeat cadence (ms). Default 21_600_000 (6h). */
+  maxCadenceMs?: number;
+  /** Dev-only timer multiplier for tests. */
+  __dev_timerMultiplier?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}
+
+interface HotState {
+  lastHeartbeatAt?: string;
+  heartbeatCount: number;
+  lastSnapshotHash?: string;
+  sessionEpoch?: string;
+  consecutiveUnchanged: number;
+  templatedVariantCursor: number;
+}
+
+// Rotating templated phrases (spec Round 3 #9).
+const TEMPLATED_VARIANTS = [
+  'still on it, no new output since last update',
+  'still working — snapshot unchanged since last beat',
+  'holding steady on this task — no fresh output yet',
+  'continuing; terminal quiet since last check-in',
+  'alive, working — no visible change since last heartbeat',
+];
+
+const AT_RISK_VARIANTS = [
+  'no observable progress — may be waiting on external input',
+  'still watching; appears idle — flagging at-risk',
+  'no recent output; continuing to monitor',
+];
+
+// ─── Helper: snapshot normalization before hashing (spec §P14 + #16a) ──────
+
+function normalizeForHash(raw: string): string {
+  let s = raw;
+  // Strip ANSI CSI.
+  s = s.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+  // Control chars except \n \t.
+  s = s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+  // Spinners → placeholder.
+  s = s.replace(/[\u2807\u2819\u2839\u2838\u283C\u2834\u2826\u2827\u2807\u280F]/g, '·');
+  // Timestamps → [TS].
+  s = s.replace(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b/g, '[TS]');
+  s = s.replace(/\b\d{1,2}:\d{2}:\d{2}\b/g, '[TS]');
+  // Progress counters.
+  s = s.replace(/\b\d+(?:\.\d+)?\s?%\b/g, '[PROG]');
+  s = s.replace(/\b\d+\/\d+\s+bytes\b/g, '[PROG]');
+  s = s.replace(/\biter[=\s]\d+\b/gi, '[CTR]');
+  // Trailing whitespace + blank lines collapse.
+  s = s.split('\n').map(l => l.replace(/\s+$/, '')).filter((_l, i, arr) => {
+    // Collapse >1 consecutive blank lines.
+    return !(i > 0 && arr[i] === '' && arr[i - 1] === '');
+  }).join('\n');
+  return s.trim();
+}
+
+function sha256(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+// Cap tmux capture (spec #16b).
+function capOutput(raw: string, maxBytes = 4096, maxLines = 200): string {
+  const lines = raw.split('\n').slice(-maxLines);
+  let out = lines.join('\n');
+  if (Buffer.byteLength(out, 'utf8') > maxBytes) {
+    out = out.slice(-maxBytes);
+  }
+  return out;
+}
+
+// ─── Main class ─────────────────────────────────────────────────────────────
+
+export class PromiseBeacon extends EventEmitter {
+  private config: PromiseBeaconConfig;
+  private started = false;
+  private stateDir: string;
+  private timers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private prefix: string;
+  private minCadenceMs: number;
+  private maxCadenceMs: number;
+  private timerMult: number;
+  private now: () => number;
+
+  constructor(config: PromiseBeaconConfig) {
+    super();
+    this.config = config;
+    this.prefix = config.prefix ?? '⏳';
+    this.minCadenceMs = config.minCadenceMs ?? 60_000;
+    this.maxCadenceMs = config.maxCadenceMs ?? 21_600_000;
+    this.timerMult = config.__dev_timerMultiplier ?? 1.0;
+    this.now = config.now ?? (() => Date.now());
+    this.stateDir = path.join(config.stateDir, 'state', 'promise-beacon');
+    try { fs.mkdirSync(this.stateDir, { recursive: true }); } catch { /* ok */ }
+  }
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    // Re-arm any existing beacon-enabled pending commitments.
+    const active = this.config.commitmentTracker
+      .getActive()
+      .filter(c => c.beaconEnabled && c.status === 'pending' && !c.beaconSuppressed);
+    for (const c of active) {
+      this.schedule(c);
+    }
+    // React to new beacon-enabled commitments as they're recorded.
+    this.config.commitmentTracker.on('recorded', (c: Commitment) => {
+      if (c.beaconEnabled && c.status === 'pending' && c.topicId) {
+        this.schedule(c);
+      }
+    });
+    this.config.commitmentTracker.on('delivered', (c: Commitment) => {
+      this.stopFor(c.id);
+    });
+    this.config.commitmentTracker.on('withdrawn', (c: Commitment) => {
+      this.stopFor(c.id);
+    });
+    console.log(`[PromiseBeacon] Started (${this.prefix})`);
+  }
+
+  stop(): void {
+    if (!this.started) return;
+    this.started = false;
+    for (const t of this.timers.values()) clearTimeout(t);
+    this.timers.clear();
+    console.log('[PromiseBeacon] Stopped');
+  }
+
+  /** Public for tests + delivery race: cancel the timer for one commitment. */
+  stopFor(id: string): void {
+    const t = this.timers.get(id);
+    if (t) {
+      clearTimeout(t);
+      this.timers.delete(id);
+    }
+  }
+
+  /** Schedule (or re-schedule) the next heartbeat for a commitment. */
+  schedule(c: Commitment): void {
+    if (!this.started) return;
+    if (!c.topicId) return;
+    if (c.status !== 'pending' || c.beaconSuppressed) return;
+
+    const cadence = this.clampCadence(c.cadenceMs ?? 10 * 60_000) * this.timerMult;
+    const hot = this.loadHotState(c.id);
+    const last = hot.lastHeartbeatAt ? new Date(hot.lastHeartbeatAt).getTime() : new Date(c.createdAt).getTime();
+    const dueAt = last + cadence;
+    const delay = Math.max(1_000, dueAt - this.now());
+
+    const existing = this.timers.get(c.id);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.timers.delete(c.id);
+      this.fire(c.id).catch(err => {
+        console.error(`[PromiseBeacon] fire() error for ${c.id}:`, (err as Error).message);
+      });
+    }, delay);
+    timer.unref?.();
+    this.timers.set(c.id, timer);
+  }
+
+  /** Fire one heartbeat. Public for testing. */
+  async fire(id: string): Promise<void> {
+    const c = this.config.commitmentTracker.getAll().find(x => x.id === id);
+    if (!c) return;
+    if (c.status !== 'pending' || c.beaconSuppressed) return;
+    if (!c.topicId) return;
+
+    // ── Ownership gate ──
+    if (this.config.currentMachineId && c.ownerMachineId && c.ownerMachineId !== this.config.currentMachineId) {
+      // Not ours; skip silently + re-arm for liveness.
+      this.schedule(c);
+      return;
+    }
+
+    // ── Quiet hours ──
+    if (this.inQuietHours()) {
+      await this.suppress(c, 'quiet-hours');
+      return;
+    }
+
+    // ── Daily spend cap (hard, via LlmQueue) ──
+    // LlmQueue enforces this on enqueue; we additionally short-circuit here
+    // so we emit beaconSuppressed (non-terminal) rather than fail-open.
+    if (this.config.llmQueue.getDailySpendCents() >= (this.config.maxDailyLlmSpendCents ?? 100)) {
+      await this.suppress(c, 'daily-spend-cap');
+      return;
+    }
+
+    // ── Session-epoch check ──
+    const sessionName = this.config.getSessionForTopic(c.topicId);
+    if (sessionName && this.config.getSessionEpoch) {
+      const live = this.config.getSessionEpoch(sessionName);
+      if (c.sessionEpoch && live && c.sessionEpoch !== live) {
+        await this.transitionViolated(c, 'session-lost');
+        return;
+      }
+    }
+
+    // ── Proxy coordinator: one proxy-class message per topic ──
+    if (!this.config.proxyCoordinator.tryAcquire(c.topicId, 'promise-beacon')) {
+      // PresenceProxy holds — re-arm and bow out.
+      this.schedule(c);
+      return;
+    }
+
+    try {
+      // ── Capture & hash ──
+      let snapshot = '';
+      if (sessionName) {
+        const raw = this.config.captureSessionOutput(sessionName, 200);
+        if (raw) {
+          snapshot = sanitizeTmuxOutput(capOutput(raw), []);
+        }
+      }
+      const hash = snapshot ? sha256(normalizeForHash(snapshot)) : 'empty';
+      const hot = this.loadHotState(c.id);
+      const unchanged = hash === hot.lastSnapshotHash;
+
+      let text: string;
+      if (!snapshot || unchanged) {
+        // Templated — no LLM call.
+        const variants = hot.consecutiveUnchanged > 2 ? AT_RISK_VARIANTS : TEMPLATED_VARIANTS;
+        const phrase = variants[hot.templatedVariantCursor % variants.length];
+        text = `${this.prefix} ${phrase}`;
+        hot.consecutiveUnchanged += 1;
+        hot.templatedVariantCursor += 1;
+      } else {
+        // LLM call — background lane, with AbortController preemption.
+        try {
+          const line = await this.config.llmQueue.enqueue(
+            'background',
+            (signal) => {
+              if (this.config.generateStatusLine) {
+                return this.config.generateStatusLine(c.agentResponse || c.userRequest, snapshot, signal);
+              }
+              // No generator wired → templated.
+              return Promise.resolve('working on it — recent output observed');
+            },
+            // Rough Haiku estimate (~3k tokens in/out).
+            1,
+          );
+          const guard = guardProxyOutput(line);
+          text = `${this.prefix} ${guard.safe ? line : 'working on it'}`;
+          hot.consecutiveUnchanged = 0;
+        } catch (err) {
+          if (err instanceof LlmAbortedError || (err as Error).message.includes('cap exceeded') || (err as Error).message.includes('reserve')) {
+            text = `${this.prefix} still working (update deferred)`;
+          } else {
+            text = `${this.prefix} still working (status fetch failed)`;
+          }
+        }
+      }
+
+      // ── Send ──
+      await this.config.sendMessage(c.topicId, text, {
+        source: 'promise-beacon',
+        isProxy: true,
+        tier: 1,
+      });
+
+      // ── Persist hot state + mutate cold ──
+      const nowIso = new Date(this.now()).toISOString();
+      hot.lastHeartbeatAt = nowIso;
+      hot.heartbeatCount += 1;
+      hot.lastSnapshotHash = hash;
+      this.saveHotState(c.id, hot);
+
+      await this.config.commitmentTracker.mutate(c.id, prev => ({
+        ...prev,
+        lastHeartbeatAt: nowIso,
+        heartbeatCount: (prev.heartbeatCount ?? 0) + 1,
+        lastSnapshotHash: hash,
+      }));
+
+      this.emit('heartbeat.fired', { id: c.id, topicId: c.topicId, templated: !snapshot || unchanged });
+    } finally {
+      this.config.proxyCoordinator.release(c.topicId, 'promise-beacon');
+    }
+
+    // Re-arm.
+    const next = this.config.commitmentTracker.getAll().find(x => x.id === id);
+    if (next) this.schedule(next);
+  }
+
+  // ─── Internals ────────────────────────────────────────────────────────────
+
+  private async suppress(c: Commitment, reason: string): Promise<void> {
+    await this.config.commitmentTracker.mutate(c.id, prev => ({
+      ...prev,
+      beaconSuppressed: true,
+      beaconSuppressionReason: reason,
+    }));
+    this.emit('heartbeat.skipped', { id: c.id, reason });
+    // Re-arm for re-evaluation: 10min window for quiet-hours, 1h for cap.
+    const reArmDelay = reason === 'quiet-hours' ? 10 * 60_000 : 60 * 60_000;
+    const timer = setTimeout(() => {
+      this.timers.delete(c.id);
+      // Clear suppression flag on re-evaluation attempt.
+      this.config.commitmentTracker
+        .mutate(c.id, prev => ({ ...prev, beaconSuppressed: false, beaconSuppressionReason: undefined }))
+        .then(updated => this.schedule(updated))
+        .catch(() => { /* ok — commitment may be terminal */ });
+    }, reArmDelay * this.timerMult);
+    timer.unref?.();
+    this.timers.set(c.id, timer);
+  }
+
+  private async transitionViolated(c: Commitment, reason: string): Promise<void> {
+    await this.config.commitmentTracker.mutate(c.id, prev => ({
+      ...prev,
+      status: 'violated',
+      resolvedAt: new Date().toISOString(),
+      resolution: reason,
+    }));
+    if (c.topicId) {
+      await this.config.sendMessage(
+        c.topicId,
+        `⚠️ [promise-beacon] commitment "${(c.agentResponse || c.userRequest).slice(0, 80)}" violated: ${reason}`,
+        { source: 'promise-beacon', isProxy: true, tier: 1 },
+      );
+    }
+    this.stopFor(c.id);
+    this.emit('promise.violated', { id: c.id, reason });
+  }
+
+  private inQuietHours(): boolean {
+    const qh = this.config.quietHours;
+    if (!qh) return false;
+    const [sH, sM] = (qh.start || '22:00').split(':').map(Number);
+    const [eH, eM] = (qh.end || '08:00').split(':').map(Number);
+    const d = new Date(this.now());
+    const mins = d.getHours() * 60 + d.getMinutes();
+    const startMin = sH * 60 + sM;
+    const endMin = eH * 60 + eM;
+    if (startMin < endMin) {
+      return mins >= startMin && mins < endMin;
+    }
+    // Wraps midnight.
+    return mins >= startMin || mins < endMin;
+  }
+
+  private clampCadence(ms: number): number {
+    return Math.min(this.maxCadenceMs, Math.max(this.minCadenceMs, ms));
+  }
+
+  private loadHotState(id: string): HotState {
+    const p = path.join(this.stateDir, `${id}.json`);
+    try {
+      const raw = fs.readFileSync(p, 'utf-8');
+      const parsed = JSON.parse(raw);
+      return {
+        heartbeatCount: 0,
+        consecutiveUnchanged: 0,
+        templatedVariantCursor: 0,
+        ...parsed,
+      };
+    } catch {
+      return {
+        heartbeatCount: 0,
+        consecutiveUnchanged: 0,
+        templatedVariantCursor: 0,
+      };
+    }
+  }
+
+  private saveHotState(id: string, hot: HotState): void {
+    const p = path.join(this.stateDir, `${id}.json`);
+    try {
+      fs.writeFileSync(p, JSON.stringify(hot, null, 2));
+    } catch (err) {
+      console.error(`[PromiseBeacon] persist failed for ${id}:`, (err as Error).message);
+    }
+  }
+
+  /** Test accessor. */
+  getScheduledIds(): string[] {
+    return [...this.timers.keys()];
+  }
+}

--- a/src/monitoring/ProxyCoordinator.ts
+++ b/src/monitoring/ProxyCoordinator.ts
@@ -1,0 +1,51 @@
+/**
+ * ProxyCoordinator — Per-topic mutex shared between PresenceProxy and
+ * PromiseBeacon.
+ *
+ * Per PROMISE-BEACON-SPEC.md §"PresenceProxy coexistence (A10 fix)": only
+ * one proxy-class emitter should fire per topic at a time. PresenceProxy
+ * (reactive to user silence) and PromiseBeacon (reactive to agent
+ * silence) can coincide; without coordination they'd double-post ⏳ + 🔭
+ * within a second.
+ *
+ * In-memory only (spec §"ProxyCoordinator liveness" — P16). Dies with the
+ * process. No persistence, no distributed lock.
+ */
+export type ProxyHolder = 'presence-proxy' | 'promise-beacon';
+
+export class ProxyCoordinator {
+  private held: Map<number, { holder: ProxyHolder; acquiredAt: number }> = new Map();
+
+  /** Try to acquire. Returns true on success. */
+  tryAcquire(topicId: number, holder: ProxyHolder): boolean {
+    const current = this.held.get(topicId);
+    if (current && current.holder !== holder) {
+      return false;
+    }
+    this.held.set(topicId, { holder, acquiredAt: Date.now() });
+    return true;
+  }
+
+  /** Release. No-op if not held by this holder. */
+  release(topicId: number, holder: ProxyHolder): void {
+    const current = this.held.get(topicId);
+    if (current && current.holder === holder) {
+      this.held.delete(topicId);
+    }
+  }
+
+  /** Returns holder name or null. */
+  currentHolder(topicId: number): ProxyHolder | null {
+    return this.held.get(topicId)?.holder ?? null;
+  }
+
+  /** Diagnostics. */
+  allHeld(): Array<{ topicId: number; holder: ProxyHolder; ageMs: number }> {
+    const now = Date.now();
+    return [...this.held.entries()].map(([topicId, v]) => ({
+      topicId,
+      holder: v.holder,
+      ageMs: now - v.acquiredAt,
+    }));
+  }
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8837,7 +8837,11 @@ export function createRoutes(ctx: RouteContext): Router {
     }
     const { type, userRequest, agentResponse, topicId, source,
             configPath, configExpectedValue, behavioralRule,
-            expiresAt, verificationMethod, verificationPath } = req.body;
+            expiresAt, verificationMethod, verificationPath,
+            // Promise Beacon fields (PROMISE-BEACON-SPEC.md Phase 1)
+            beaconEnabled, cadenceMs, nextUpdateDueAt,
+            softDeadlineAt, hardDeadlineAt, sessionEpoch,
+            ownerMachineId, externalKey, beaconCreatedBySource } = req.body;
 
     if (!type || !userRequest || !agentResponse) {
       res.status(400).json({ error: 'type, userRequest, and agentResponse are required' });
@@ -8847,12 +8851,28 @@ export function createRoutes(ctx: RouteContext): Router {
       res.status(400).json({ error: 'type must be config-change, behavioral, or one-time-action' });
       return;
     }
+    // Beacon validation: must have topicId and at least one deadline marker.
+    if (beaconEnabled) {
+      if (!topicId) {
+        res.status(400).json({ error: 'beaconEnabled commitments require topicId' });
+        return;
+      }
+      if (!nextUpdateDueAt && !softDeadlineAt && !hardDeadlineAt) {
+        res.status(400).json({
+          error: 'beaconEnabled commitments require at least one of nextUpdateDueAt, softDeadlineAt, hardDeadlineAt',
+        });
+        return;
+      }
+    }
 
     try {
       const commitment = ctx.commitmentTracker.record({
         type, userRequest, agentResponse, topicId, source,
         configPath, configExpectedValue, behavioralRule,
         expiresAt, verificationMethod, verificationPath,
+        beaconEnabled, cadenceMs, nextUpdateDueAt,
+        softDeadlineAt, hardDeadlineAt, sessionEpoch,
+        ownerMachineId, externalKey, beaconCreatedBySource,
       });
       res.status(201).json(commitment);
     } catch (err) {
@@ -8875,6 +8895,28 @@ export function createRoutes(ctx: RouteContext): Router {
   /**
    * Withdraw a commitment.
    */
+  /**
+   * POST /commitments/:id/deliver
+   * Marks a beacon-enabled commitment as `delivered` (distinct from `verified`).
+   * Stops the PromiseBeacon timer for this commitment. Per PROMISE-BEACON-SPEC.md
+   * Round 3 #18: `delivered` is a terminal status meaning "the agent actually
+   * came back with the promised update," separate from `verified` which means
+   * "config state is as promised."
+   */
+  router.post('/commitments/:id/deliver', (req, res) => {
+    if (!ctx.commitmentTracker) {
+      res.status(404).json({ error: 'CommitmentTracker not configured' });
+      return;
+    }
+    const { deliveryMessageId } = req.body ?? {};
+    const updated = ctx.commitmentTracker.deliver(req.params.id, deliveryMessageId);
+    if (!updated) {
+      res.status(404).json({ error: `Commitment ${req.params.id} not found or already in terminal status` });
+      return;
+    }
+    res.json({ delivered: true, id: updated.id, commitment: updated });
+  });
+
   router.post('/commitments/:id/withdraw', (req, res) => {
     if (!ctx.commitmentTracker) {
       res.status(404).json({ error: 'CommitmentTracker not configured' });

--- a/tests/integration/PromiseBeacon-lifecycle.test.ts
+++ b/tests/integration/PromiseBeacon-lifecycle.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Integration test: end-to-end PromiseBeacon lifecycle.
+ *
+ * Scenario:
+ *   1. A beacon-enabled commitment is recorded.
+ *   2. The beacon fires at least one heartbeat on the bound topic.
+ *   3. `POST /commitments/:id/deliver` (simulated via tracker.deliver())
+ *      transitions the commitment to `delivered` and stops the beacon.
+ *   4. Subsequent fires for that commitment are no-ops.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+import { LlmQueue } from '../../src/monitoring/LlmQueue.js';
+import { ProxyCoordinator } from '../../src/monitoring/ProxyCoordinator.js';
+import { PromiseBeacon } from '../../src/monitoring/PromiseBeacon.js';
+
+describe('PromiseBeacon lifecycle', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'promise-beacon-int-'));
+    fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'config.json'), '{}');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('records → heartbeats → delivered → stops', async () => {
+    const tracker = new CommitmentTracker({ stateDir: dir, liveConfig: new LiveConfig(dir) });
+    const sent: string[] = [];
+    const beacon = new PromiseBeacon({
+      stateDir: dir,
+      commitmentTracker: tracker,
+      llmQueue: new LlmQueue({ maxDailyCents: 100 }),
+      proxyCoordinator: new ProxyCoordinator(),
+      captureSessionOutput: () => 'tmux output\nrunning',
+      getSessionForTopic: () => 'sess-1',
+      isSessionAlive: () => true,
+      sendMessage: async (_t, text) => { sent.push(text); },
+    });
+    beacon.start();
+
+    const c = tracker.record({
+      type: 'one-time-action',
+      userRequest: 'run the thing',
+      agentResponse: 'will ship in ~10min',
+      topicId: 77,
+      beaconEnabled: true,
+      cadenceMs: 60_000,
+      nextUpdateDueAt: '2099-01-01T00:00:00Z',
+      beaconCreatedBySource: 'skill',
+    });
+
+    // Fire one heartbeat.
+    await beacon.fire(c.id);
+    expect(sent.length).toBe(1);
+    expect(sent[0]).toMatch(/^⏳/);
+
+    // Deliver — simulates POST /commitments/:id/deliver.
+    const delivered = tracker.deliver(c.id, 'msg-abc');
+    expect(delivered?.status).toBe('delivered');
+    expect(delivered?.deliveryMessageId).toBe('msg-abc');
+
+    // Fire after delivery — should NOT emit anything.
+    await beacon.fire(c.id);
+    expect(sent.length).toBe(1);
+
+    // No further scheduled timer for that id.
+    expect(beacon.getScheduledIds()).not.toContain(c.id);
+
+    beacon.stop();
+  });
+
+  it('rejects deliver on terminal status', async () => {
+    const tracker = new CommitmentTracker({ stateDir: dir, liveConfig: new LiveConfig(dir) });
+    const c = tracker.record({
+      type: 'one-time-action', userRequest: 'x', agentResponse: 'y',
+      topicId: 1, beaconEnabled: true, cadenceMs: 60_000,
+      nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+    expect(tracker.deliver(c.id)?.status).toBe('delivered');
+    expect(tracker.deliver(c.id)).toBeNull(); // already delivered
+  });
+});

--- a/tests/unit/LlmQueue.test.ts
+++ b/tests/unit/LlmQueue.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for LlmQueue — priority-laned shared LLM queue.
+ *
+ * Covers the Phase 1 spec surface:
+ *  - Background calls run when concurrency is free.
+ *  - Interactive arrivals preempt in-flight background calls via AbortController.
+ *  - Interactive lane reserve (≥40%) prevents background from consuming
+ *    the whole daily budget.
+ *  - LlmAbortedError is surfaced to aborted background callers.
+ */
+import { describe, it, expect } from 'vitest';
+import { LlmQueue, LlmAbortedError } from '../../src/monitoring/LlmQueue.js';
+
+function deferred<T = string>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: Error) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: Error) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+describe('LlmQueue', () => {
+  it('runs a single background call to completion', async () => {
+    const q = new LlmQueue({ maxConcurrent: 2, interactiveReservePct: 0.4, maxDailyCents: 100 });
+    const result = await q.enqueue('background', async () => 'ok', 1);
+    expect(result).toBe('ok');
+    expect(q.getDailySpendCents()).toBe(1);
+  });
+
+  it('preempts in-flight background when interactive arrives at capacity', async () => {
+    const q = new LlmQueue({ maxConcurrent: 1, interactiveReservePct: 0.4, maxDailyCents: 100 });
+
+    // Start a background call that never finishes on its own.
+    const bgDef = deferred<string>();
+    let sawAbort = false;
+    const bgPromise = q.enqueue('background', (signal) => {
+      signal.addEventListener('abort', () => { sawAbort = true; });
+      return bgDef.promise;
+    }, 1);
+
+    // Give the microtask queue a chance to start the bg call.
+    await new Promise(resolve => setImmediate(resolve));
+    expect(q.getInFlightCount()).toBe(1);
+
+    // Enqueue an interactive call — should preempt the bg.
+    const interactivePromise = q.enqueue('interactive', async () => 'interactive-done', 1);
+
+    await expect(bgPromise).rejects.toBeInstanceOf(LlmAbortedError);
+    expect(sawAbort).toBe(true);
+
+    await expect(interactivePromise).resolves.toBe('interactive-done');
+  });
+
+  it('rejects background calls that would breach the interactive reserve', async () => {
+    // Daily cap = 10, reserve 40% = 4, so background may consume at most 6.
+    const q = new LlmQueue({ maxConcurrent: 1, interactiveReservePct: 0.4, maxDailyCents: 10 });
+
+    // 6 cents of background is allowed (remaining after = 4 = reserve).
+    await q.enqueue('background', async () => 'x', 6);
+    expect(q.getDailySpendCents()).toBe(6);
+
+    // Another 1 cent would drop remaining to 3, which breaches the 4-cent reserve.
+    await expect(q.enqueue('background', async () => 'y', 1)).rejects.toThrow(/reserve/);
+
+    // Interactive, however, can still spend.
+    await expect(q.enqueue('interactive', async () => 'ok', 1)).resolves.toBe('ok');
+  });
+
+  it('blocks further enqueue when the daily cap is already exhausted', async () => {
+    const q = new LlmQueue({ maxConcurrent: 1, interactiveReservePct: 0.4, maxDailyCents: 5 });
+    await q.enqueue('interactive', async () => 'a', 5);
+    await expect(q.enqueue('interactive', async () => 'b', 1)).rejects.toThrow(/cap exceeded/);
+  });
+
+  it('interactive waiters jump ahead of background waiters in the queue', async () => {
+    const q = new LlmQueue({ maxConcurrent: 1, interactiveReservePct: 0.4, maxDailyCents: 100 });
+    // Fill the single slot with a long-running interactive call.
+    const busyDef = deferred<string>();
+    const busy = q.enqueue('interactive', () => busyDef.promise, 1);
+    await new Promise(resolve => setImmediate(resolve));
+
+    const completionOrder: string[] = [];
+    const bg = q.enqueue('background', async () => { completionOrder.push('bg'); return 'bg'; }, 1);
+    const int = q.enqueue('interactive', async () => { completionOrder.push('int'); return 'int'; }, 1);
+
+    // Release the busy slot.
+    busyDef.resolve('busy');
+    await busy;
+    await int;
+    await bg;
+
+    expect(completionOrder).toEqual(['int', 'bg']);
+  });
+});

--- a/tests/unit/PromiseBeacon.test.ts
+++ b/tests/unit/PromiseBeacon.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for PromiseBeacon — the per-commitment heartbeat monitor.
+ *
+ * Covers Phase 1 spec surface:
+ *  - Snapshot-hash gate: unchanged tmux output emits a templated heartbeat
+ *    and does NOT call the LLM.
+ *  - Session-epoch mismatch transitions the commitment to `violated` with
+ *    reason `session-lost`.
+ *  - Quiet hours suppress heartbeats as `beaconSuppressed` (non-terminal).
+ *  - Daily spend cap hit → beaconSuppressed, no heartbeat emitted.
+ *  - Delivery stops the beacon for a commitment.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+import { LlmQueue } from '../../src/monitoring/LlmQueue.js';
+import { ProxyCoordinator } from '../../src/monitoring/ProxyCoordinator.js';
+import { PromiseBeacon } from '../../src/monitoring/PromiseBeacon.js';
+
+function tmpState() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'promise-beacon-'));
+  fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'config.json'), '{}');
+  return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function baseTracker(dir: string) {
+  return new CommitmentTracker({ stateDir: dir, liveConfig: new LiveConfig(dir) });
+}
+
+describe('PromiseBeacon', () => {
+  let dir: string;
+  let cleanup: () => void;
+  beforeEach(() => { ({ dir, cleanup } = tmpState()); });
+  afterEach(() => cleanup());
+
+  it('emits a templated heartbeat (no LLM call) when the tmux snapshot is unchanged', async () => {
+    const tracker = baseTracker(dir);
+    const sent: Array<{ topicId: number; text: string }> = [];
+    const queue = new LlmQueue({ maxDailyCents: 100 });
+    const spy = vi.fn(async () => 'LLM-RESULT');
+
+    const beacon = new PromiseBeacon({
+      stateDir: dir,
+      commitmentTracker: tracker,
+      llmQueue: queue,
+      proxyCoordinator: new ProxyCoordinator(),
+      captureSessionOutput: () => 'static output\nline two',
+      getSessionForTopic: () => 'sess-1',
+      isSessionAlive: () => true,
+      sendMessage: async (topicId, text) => { sent.push({ topicId, text }); },
+      generateStatusLine: spy,
+    });
+    beacon.start();
+
+    const c = tracker.record({
+      type: 'one-time-action', userRequest: 'ship x', agentResponse: 'will ship',
+      topicId: 42, beaconEnabled: true, cadenceMs: 60_000, nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+
+    // Fire twice — second fire hits the hash-gate because output is identical.
+    await beacon.fire(c.id);
+    await beacon.fire(c.id);
+
+    expect(sent.length).toBe(2);
+    // First emission calls the LLM (no prior hash to compare against).
+    // Second emission uses the templated path because the hash is unchanged.
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(sent[1].text).toMatch(/still (on it|working)|no (new|fresh) output|terminal quiet|snapshot unchanged|no visible change/i);
+    beacon.stop();
+  });
+
+  it('transitions to violated when sessionEpoch mismatches the live session', async () => {
+    const tracker = baseTracker(dir);
+    const sent: Array<{ text: string }> = [];
+    const beacon = new PromiseBeacon({
+      stateDir: dir,
+      commitmentTracker: tracker,
+      llmQueue: new LlmQueue({ maxDailyCents: 100 }),
+      proxyCoordinator: new ProxyCoordinator(),
+      captureSessionOutput: () => 'x',
+      getSessionForTopic: () => 'sess-1',
+      isSessionAlive: () => true,
+      getSessionEpoch: () => 'NEW-EPOCH',
+      sendMessage: async (_topicId, text) => { sent.push({ text }); },
+    });
+    beacon.start();
+
+    const c = tracker.record({
+      type: 'one-time-action', userRequest: 'x', agentResponse: 'y',
+      topicId: 10, beaconEnabled: true, cadenceMs: 60_000,
+      nextUpdateDueAt: '2099-01-01T00:00:00Z', sessionEpoch: 'OLD-EPOCH',
+    });
+    await beacon.fire(c.id);
+
+    const after = tracker.getAll().find(x => x.id === c.id)!;
+    expect(after.status).toBe('violated');
+    expect(after.resolution).toBe('session-lost');
+    expect(sent[0].text).toMatch(/session-lost|violated/);
+    beacon.stop();
+  });
+
+  it('suppresses during quiet hours without violating the commitment', async () => {
+    const tracker = baseTracker(dir);
+    const sent: string[] = [];
+    // Set clock to 23:00 local (inside default 22:00-08:00 window).
+    const frozen = new Date();
+    frozen.setHours(23, 0, 0, 0);
+
+    const beacon = new PromiseBeacon({
+      stateDir: dir,
+      commitmentTracker: tracker,
+      llmQueue: new LlmQueue({ maxDailyCents: 100 }),
+      proxyCoordinator: new ProxyCoordinator(),
+      captureSessionOutput: () => 'x',
+      getSessionForTopic: () => 'sess-1',
+      isSessionAlive: () => true,
+      sendMessage: async (_topicId, text) => { sent.push(text); },
+      quietHours: { start: '22:00', end: '08:00' },
+      now: () => frozen.getTime(),
+    });
+    beacon.start();
+
+    const c = tracker.record({
+      type: 'one-time-action', userRequest: 'x', agentResponse: 'y',
+      topicId: 11, beaconEnabled: true, cadenceMs: 60_000, nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+    await beacon.fire(c.id);
+
+    expect(sent.length).toBe(0);
+    const after = tracker.getAll().find(x => x.id === c.id)!;
+    expect(after.status).toBe('pending');
+    expect(after.beaconSuppressed).toBe(true);
+    expect(after.beaconSuppressionReason).toBe('quiet-hours');
+    beacon.stop();
+  });
+
+  it('suppresses (not violates) when the daily LLM spend cap is already hit', async () => {
+    const tracker = baseTracker(dir);
+    const queue = new LlmQueue({ maxDailyCents: 5 });
+    // Exhaust the cap.
+    await queue.enqueue('interactive', async () => 'x', 5);
+
+    const sent: string[] = [];
+    const beacon = new PromiseBeacon({
+      stateDir: dir,
+      commitmentTracker: tracker,
+      llmQueue: queue,
+      proxyCoordinator: new ProxyCoordinator(),
+      captureSessionOutput: () => 'x',
+      getSessionForTopic: () => 'sess-1',
+      isSessionAlive: () => true,
+      sendMessage: async (_topicId, text) => { sent.push(text); },
+      maxDailyLlmSpendCents: 5,
+    });
+    beacon.start();
+
+    const c = tracker.record({
+      type: 'one-time-action', userRequest: 'x', agentResponse: 'y',
+      topicId: 12, beaconEnabled: true, cadenceMs: 60_000, nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+    await beacon.fire(c.id);
+
+    expect(sent.length).toBe(0);
+    const after = tracker.getAll().find(x => x.id === c.id)!;
+    expect(after.beaconSuppressed).toBe(true);
+    expect(after.beaconSuppressionReason).toBe('daily-spend-cap');
+    expect(after.status).toBe('pending');
+    beacon.stop();
+  });
+});

--- a/tests/unit/ProxyCoordinator.test.ts
+++ b/tests/unit/ProxyCoordinator.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for ProxyCoordinator — per-topic proxy mutex.
+ *
+ * Ensures PresenceProxy and PromiseBeacon cannot both hold the same topic
+ * at the same time (spec §A10).
+ */
+import { describe, it, expect } from 'vitest';
+import { ProxyCoordinator } from '../../src/monitoring/ProxyCoordinator.js';
+
+describe('ProxyCoordinator', () => {
+  it('grants acquisition to first caller and blocks the other', () => {
+    const c = new ProxyCoordinator();
+    expect(c.tryAcquire(1, 'presence-proxy')).toBe(true);
+    expect(c.tryAcquire(1, 'promise-beacon')).toBe(false);
+    expect(c.currentHolder(1)).toBe('presence-proxy');
+  });
+
+  it('reentrant acquire by the same holder returns true', () => {
+    const c = new ProxyCoordinator();
+    expect(c.tryAcquire(1, 'presence-proxy')).toBe(true);
+    expect(c.tryAcquire(1, 'presence-proxy')).toBe(true);
+  });
+
+  it('release frees the mutex for the other holder', () => {
+    const c = new ProxyCoordinator();
+    c.tryAcquire(1, 'presence-proxy');
+    c.release(1, 'presence-proxy');
+    expect(c.currentHolder(1)).toBeNull();
+    expect(c.tryAcquire(1, 'promise-beacon')).toBe(true);
+  });
+
+  it('release by non-holder is a no-op', () => {
+    const c = new ProxyCoordinator();
+    c.tryAcquire(1, 'presence-proxy');
+    c.release(1, 'promise-beacon'); // wrong holder — ignored
+    expect(c.currentHolder(1)).toBe('presence-proxy');
+  });
+
+  it('different topics are independent', () => {
+    const c = new ProxyCoordinator();
+    expect(c.tryAcquire(1, 'presence-proxy')).toBe(true);
+    expect(c.tryAcquire(2, 'promise-beacon')).toBe(true);
+    expect(c.allHeld().map(h => h.topicId).sort()).toEqual([1, 2]);
+  });
+});

--- a/upgrades/side-effects/promise-beacon-phase-1.md
+++ b/upgrades/side-effects/promise-beacon-phase-1.md
@@ -1,0 +1,121 @@
+# Side-Effects Review — Promise Beacon Phase 1 (core monitor + shared queue + delivery endpoint)
+
+**Version / slug:** `promise-beacon-phase-1`
+**Date:** `2026-04-19`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (prereq PR #71 landed first; this lands the core behind the same review-convergence tag)
+
+## Summary of the change
+
+Lands the Phase 1 scope of `docs/specs/PROMISE-BEACON-SPEC.md`: a third monitor that sits alongside `PresenceProxy` and `CommitmentTracker` and emits `⏳` heartbeats on commitments where the agent has gone quiet on an open promise. Changes are additive and scoped — the beacon only engages for commitments that explicitly opt in via `beaconEnabled: true`.
+
+Files touched:
+- `src/monitoring/LlmQueue.ts` — NEW. Shared, priority-laned LLM queue with interactive-lane reserve and AbortController preemption of background calls. Extracted as its own module so `PresenceProxy` can adopt it incrementally without a disruptive refactor.
+- `src/monitoring/ProxyCoordinator.ts` — NEW. Per-topic mutex so `PresenceProxy` (🔭) and `PromiseBeacon` (⏳) cannot double-post to the same topic in the same second.
+- `src/monitoring/PromiseBeacon.ts` — NEW. The monitor itself: `setTimeout`-based scheduling, snapshot-hash gate (templated line when the tmux output is unchanged), session-epoch violation path, quiet-hours and daily-spend-cap suppression, hot state at `.instar/state/promise-beacon/<id>.json` (gitignored under the existing `.instar/state/` entry).
+- `src/monitoring/CommitmentTracker.ts` — schema additions (optional beacon fields on `Commitment`), new terminal status `delivered`, `deliver(id, deliveryMessageId)` method emitting a `delivered` event.
+- `src/monitoring/PresenceProxy.ts` — acquires the shared `ProxyCoordinator` mutex in `sendProxyMessage` when the coordinator is wired, so a simultaneous beacon fire doesn't double-post.
+- `src/server/routes.ts` — `POST /commitments/:id/deliver` endpoint + beacon fields accepted on `POST /commitments` (with validation: `beaconEnabled` requires `topicId` and at least one of `nextUpdateDueAt` / `softDeadlineAt` / `hardDeadlineAt`).
+- `src/commands/server.ts` — wires the `ProxyCoordinator` and a shared `LlmQueue` instance, passes the coordinator to `PresenceProxy`, instantiates `PromiseBeacon` after `PresenceProxy.start()` guarded by the same intelligence/telegram gates.
+- `src/commands/init.ts` — commit-action skill template extended with a Promise Beacon block documenting how to opt in via `POST /commitments`.
+- `tests/unit/LlmQueue.test.ts` — NEW (5 tests): concurrency, interactive preemption via AbortController, interactive reserve enforcement, daily cap, priority ordering.
+- `tests/unit/ProxyCoordinator.test.ts` — NEW (5 tests): mutual exclusion, reentrancy, release semantics, topic isolation.
+- `tests/unit/PromiseBeacon.test.ts` — NEW (4 tests): snapshot-hash gate skips the LLM, session-epoch mismatch transitions to `violated`, quiet hours suppress (not violate), daily spend cap suppresses (not violates).
+- `tests/integration/PromiseBeacon-lifecycle.test.ts` — NEW (2 tests): end-to-end record → heartbeat → deliver → stop; terminal status rejects re-delivery.
+
+Decision-point surfaces touched:
+- `POST /commitments` (validation only — no change in who can create a commitment; beacon opt-in requires the same authenticated caller as an ordinary record).
+- `POST /commitments/:id/deliver` (new — transitions an already-existing commitment from `pending` to `delivered`; terminal-status guard prevents re-delivery).
+- `PromiseBeacon.fire()` internal transitions (`pending → violated` on session-epoch mismatch; `pending` + `beaconSuppressed: true` on quiet-hours / daily-cap).
+
+## Decision-point inventory
+
+- **`beaconEnabled` validation**: a new 400 on `POST /commitments` when `beaconEnabled: true` but `topicId` or all three deadline markers are missing. Surface rejection only — never blocks an agent from making the underlying commitment, it rejects the *beacon activation* for malformed input. Agent can still record the commitment without `beaconEnabled`.
+- **`quiet-hours` suppression**: non-terminal. Status stays `pending`. Flag `beaconSuppressed: true` + reason documented in the record; the scheduler re-arms the timer so the beacon resumes after the window.
+- **`daily-spend-cap` suppression**: same shape as quiet-hours — non-terminal, re-armed hourly.
+- **`session-lost` transition**: `pending → violated`. This is the only place the beacon terminally mutates a commitment. Triggered only by explicit session-UUID mismatch supplied by the wiring; there is no heuristic path to `violated`.
+
+All block/authority decisions land on the same authenticated caller as the existing `CommitmentTracker` write paths. The beacon itself never blocks or mutates agent output, only produces its own proxy-tagged emissions.
+
+---
+
+## 1. Over-block
+
+- **`POST /commitments` beacon validation**: can it block a legitimate beacon opt-in? Only if the caller forgot `topicId` or all three deadline fields. Both are required by spec (§"No default hardDeadlineAt" and §A10). The rejection carries a precise error message identifying the missing field, so retry is trivial.
+- **`session-lost` auto-violation**: could a transient session-UUID hiccup (e.g., a brief tmux restart) fire a false violation? The wiring uses the Claude Code session UUID read from the session metadata file — it does not mutate during normal operation. `getSessionEpoch` is called only at beacon-fire time (not continuously), and the Round 3 #3 spec clarification deliberately removed `serverBootId` from the epoch precisely so server restarts don't auto-violate. The remaining false-positive surface is bounded to cases where the session is genuinely restarted.
+
+Over-block risk: low. Both paths carry clear errors and are bounded.
+
+---
+
+## 2. Under-block
+
+- **`beaconEnabled` on an existing pending commitment**: the current validation only fires on `POST /commitments`. An agent could record a commitment without `beaconEnabled` and later mutate it to `beaconEnabled: true` via `PATCH` if such a route exists. Mitigation: no PATCH route on `/commitments` adds beacon fields in this PR; the only post-creation state change is `deliver` / `withdraw`. Phase 2 may add a `PATCH` — when it does, the same validation must be applied there.
+- **Missing sessionEpoch**: if `sessionEpoch` is unset on a beacon commitment, the violation path is inert. This is intentional — the Round 3 #3 clarification makes the session-epoch check conditional on both the stored and live epoch being present. When the wiring does not provide `getSessionEpoch`, the check is skipped entirely. No hidden auto-violation.
+- **`proxyCoordinator` absent**: a third party wiring the beacon without a coordinator (e.g., a future embedding) would lose the double-post guard. The class constructor requires a coordinator — you cannot instantiate without it. TypeScript enforces this.
+
+Under-block risk: low, with one named follow-up (`PATCH`).
+
+---
+
+## 3. Level-of-abstraction fit
+
+- `LlmQueue` belongs as a standalone module — both `PresenceProxy` and `PromiseBeacon` consume it, and the daily spend cap is a cross-cutting concern not owned by either monitor.
+- `ProxyCoordinator` belongs at the monitoring-layer level for the same reason. In-memory, per-process, no persistence, no distributed lock — matches spec §P16.
+- `PromiseBeacon` owns its own scheduling and hot-state file I/O; cold writes go through `CommitmentTracker.mutate()` so the beacon never bypasses the single-writer surface the PR #71 prereq established.
+- `deliver()` belongs on `CommitmentTracker` (not on `PromiseBeacon`) because the status transition is a property of the commitment record, not of the beacon. The beacon subscribes to the tracker's `delivered` event to stop its timer — decoupled side-effect, not a call chain.
+
+Level-of-abstraction fit: right layers. No violations of the signal-vs-authority rule: the beacon emits `⏳` status lines (signal) but the only authority it exercises is over the fields it owns (`heartbeatCount`, `lastSnapshotHash`, etc. via `mutate`).
+
+---
+
+## 4. Signal vs authority compliance
+
+- **Signal**: the beacon emits `⏳` heartbeats (informational, user-facing) and fires internal EventEmitter events (`heartbeat.fired`, `heartbeat.skipped`, `promise.violated`) for downstream observers.
+- **Authority**: the only record mutation the beacon exercises under normal operation is hot-field updates via `mutate()` (`lastHeartbeatAt`, `heartbeatCount`, `lastSnapshotHash`) and `beaconSuppressed` flag writes during quiet-hours / cap. These are non-terminal, per-record, and visible.
+- **Terminal authority** is exercised exactly once: `session-lost` transitions `pending → violated`. This is gated on an explicit UUID mismatch (not a heuristic), emits a user-visible `⚠️` notice, and is irreversible only in the sense that *the commitment* is terminal — the user can always record a fresh replacement commitment.
+- No route in this PR allows an agent to self-grant beacon opt-in on someone else's commitment. The `record()` API is the same one the `commit-action` skill already uses.
+
+Compliance: clean.
+
+---
+
+## 5. Interactions
+
+- **PresenceProxy coexistence**: shared `ProxyCoordinator` ensures only one of 🔭/⏳ emits per topic per moment. The mutex is reentrant by holder; release is a no-op from the non-holder. Covered by `ProxyCoordinator.test.ts`.
+- **CommitmentTracker verify-loop**: the verify loop runs on `one-time-action` and `config-change` types and does not look at beacon fields. A `delivered` commitment is no longer active (filtered out by `getActive()`). No interaction.
+- **CommitmentSentinel (Phase 2)**: not wired in this PR. The sentinel's default `sentinelAutoEnable` is `false`, the spec's shadow-mode requirement is preserved for Phase 2.
+- **InitiativeTracker**: distinct week-scale board; no interaction. The beacon is minute-scale.
+- **Backup/restore**: hot state files under `.instar/state/promise-beacon/` are gitignored (under the existing `.instar/state/` entry). Spec §"Backup/restore notice symmetry" (A27) is not implemented in this PR — the stale-threshold auto-transition is Phase 1 follow-up. Documented in PR body.
+
+---
+
+## 6. Rollback cost
+
+- **Runtime disable**: `config.json → promiseBeacon.enabled = false` is not yet a read flag in Phase 1 — the monitor wires unconditionally inside the existing `sharedIntelligence && telegram` guard. To disable at runtime, comment out the `PromiseBeacon` block in `src/commands/server.ts` and restart. Documented as a known gap for Phase 2.
+- **Full revert**: revert the PR. `Commitment` schema additions are all optional — existing code ignores them. Hot state files under `.instar/state/promise-beacon/` become orphaned but harmless (the state dir is gitignored and disposable). The new `delivered` status value is referenced only by the new `deliver()` method and the new endpoint — reverting the endpoint + method removes all producers.
+- **Partial revert**: reverting only `PromiseBeacon.ts` + `ProxyCoordinator.ts` + the wiring block leaves `LlmQueue.ts` as an unused utility. Harmless.
+
+Rollback cost: low. No data migrations, no irreversible state changes.
+
+---
+
+## Known limitations / scoped-out pieces
+
+Called out in the PR body so they land as explicit follow-ups:
+
+- `atRisk` corroboration path (spec Round 3 #1) — the beacon lands with hard-signal-only violation. Soft-signal `atRisk` doubling-cadence is a small follow-up.
+- `beaconSuppressed` boot-cap enforcement (spec Round 3 #2) — not needed at Phase 1's single-digit commitment counts; landed as a follow-up.
+- `PATCH /commitments/:id` beacon-field mutation — not in this PR; apply the same validation when added.
+- Dashboard Commitments-tab "Open promises" section — stubbed out for the next PR; the `GET /commitments` endpoint already exposes the fields the tab needs.
+- `<active_commitments>` compaction-recovery injection — spec Round 3 #7; follow-up.
+- `PresenceProxy` migration to the shared `LlmQueue` — the queue is extracted and wired into the beacon; `PresenceProxy` still uses its own local queue. Follow-up PR will migrate it so the daily-spend-cap is shared end-to-end.
+
+---
+
+## Evidence the change works
+
+- `npx tsc --noEmit` clean.
+- `npx vitest run tests/unit/LlmQueue.test.ts tests/unit/ProxyCoordinator.test.ts tests/unit/PromiseBeacon.test.ts tests/integration/PromiseBeacon-lifecycle.test.ts` — 16/16 pass.
+- `npx vitest run tests/unit/CommitmentTracker.test.ts tests/unit/CommitmentTracker-mutate.test.ts` — prior suite unaffected (47/47 pass).
+- `npx vitest run tests/unit/presence-proxy-*.test.ts` — 39/39 regression pass, confirming the `ProxyCoordinator` wiring is backwards-compatible (the config property is optional).


### PR DESCRIPTION
## Summary

Lands Phase 1 of [PROMISE-BEACON-SPEC.md](docs/specs/PROMISE-BEACON-SPEC.md) — a third monitor that sits alongside `PresenceProxy` and `CommitmentTracker` and emits `⏳` heartbeats on commitments where the agent has gone quiet on an open promise to the user. Builds on PR #71 (CommitmentTracker.mutate prereq).

### What shipped

- **`src/monitoring/LlmQueue.ts`** (new) — shared priority-laned LLM queue with a ≥40% interactive-lane reserve and `AbortController`-based preemption of in-flight background calls when an interactive call arrives. Extracted as its own module so it can be shared.
- **`src/monitoring/ProxyCoordinator.ts`** (new) — in-memory per-topic mutex so `PresenceProxy` (🔭) and `PromiseBeacon` (⏳) cannot double-post.
- **`src/monitoring/PromiseBeacon.ts`** (new) — the monitor itself: `setTimeout`-based scheduling, snapshot-hash gate (templated line when tmux output is unchanged — ~70% of heartbeats on a quiet session, no LLM call), session-epoch violation path, quiet-hours + daily-spend-cap suppression as non-terminal `beaconSuppressed`, hot state at `.instar/state/promise-beacon/<id>.json` (gitignored under the existing `.instar/state/` entry).
- **`src/monitoring/CommitmentTracker.ts`** — optional beacon fields on `Commitment`, new terminal status `delivered`, `deliver(id, deliveryMessageId)` method emitting a `delivered` event.
- **`src/monitoring/PresenceProxy.ts`** — acquires the shared `ProxyCoordinator` mutex in `sendProxyMessage` when wired (optional, backwards-compatible).
- **`src/server/routes.ts`** — `POST /commitments/:id/deliver`; beacon fields accepted on `POST /commitments` with validation (`beaconEnabled` requires `topicId` + at least one of `nextUpdateDueAt` / `softDeadlineAt` / `hardDeadlineAt`).
- **`src/commands/server.ts`** — wires `ProxyCoordinator` + shared `LlmQueue`, instantiates `PromiseBeacon` after `PresenceProxy.start()` behind the same `sharedIntelligence && telegram` gate.
- **`src/commands/init.ts`** — commit-action skill template extended with a Promise Beacon block explaining how to opt in via `POST /commitments`.

### Tests

- `tests/unit/LlmQueue.test.ts` — 5 tests: concurrency, interactive preemption via AbortController, interactive reserve, daily cap, priority ordering.
- `tests/unit/ProxyCoordinator.test.ts` — 5 tests: mutual exclusion, reentrancy, release, topic isolation.
- `tests/unit/PromiseBeacon.test.ts` — 4 tests: snapshot-hash gate skips the LLM, session-epoch mismatch → `violated`, quiet hours → `beaconSuppressed` (not violated), daily-spend-cap → `beaconSuppressed`.
- `tests/integration/PromiseBeacon-lifecycle.test.ts` — 2 tests: record → heartbeat → deliver → stop; terminal-status rejects re-delivery.
- Existing `CommitmentTracker` (47/47) and `presence-proxy-*` (39/39) regression suites pass unchanged.

### Known limitations / Phase 1 follow-ups

Called out in the side-effects review artifact so they land as explicit next-PRs:

- `atRisk` corroboration path (spec Round 3 #1) — beacon lands with hard-signal-only violation; soft-signal cadence doubling is a small follow-up.
- `beaconSuppressed` boot-cap enforcement (spec Round 3 #2) — not needed at single-digit open-commitment counts.
- `PATCH /commitments/:id` beacon-field mutation — intentionally not added; same validation must apply when it is.
- Dashboard Commitments-tab "Open promises" section — API fields are in place; UI follows next PR.
- `<active_commitments>` compaction-recovery injection — spec Round 3 #7; follow-up.
- `PresenceProxy` migration to the shared `LlmQueue` — queue is extracted and wired into the beacon; `PresenceProxy` still uses its own local queue. A follow-up PR will migrate it so the daily-spend-cap is shared end-to-end.

## Side-effects review

[`upgrades/side-effects/promise-beacon-phase-1.md`](upgrades/side-effects/promise-beacon-phase-1.md) — covers over/under-block, level-of-abstraction fit, signal-vs-authority, interactions, and rollback cost.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` on the new test files — 16/16 pass
- [x] `npx vitest run tests/unit/CommitmentTracker*.test.ts` — prior suite unaffected
- [x] `npx vitest run tests/unit/presence-proxy-*.test.ts` — regression pass (mutex wiring is backwards-compatible)
- [ ] CI full suite

Spec: [docs/specs/PROMISE-BEACON-SPEC.md](docs/specs/PROMISE-BEACON-SPEC.md)
Prereq: #71 (CommitmentTracker.mutate — merged)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>