### PR TITLE
fix(commitments): stop false violations on unverifiable one-time-actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,24 @@ src/
                   # CrashLoopPauser (auto-pause runaway jobs),
                   # CompactionSentinel (verified compaction recovery lifecycle —
                   # dedupe across triggers, JSONL-growth verification, retry with
-                  # backoff, zombie-kill veto while recovery is in flight)
-  messaging/      # TelegramAdapter (long-polling, JSONL history)
+                  # backoff, zombie-kill veto while recovery is in flight),
+                  # PresenceProxy (standby heartbeat — fires when a user message
+                  # goes unanswered past the tier threshold),
+                  # PromiseBeacon (commitment follow-through — cadenced heartbeats
+                  # on open beacon-enabled commitments; atRisk non-terminal state;
+                  # boot-cap enforcement via maxActiveBeacons),
+                  # CommitmentTracker (commitment lifecycle + single-writer CAS
+                  # mutate(); feeds PromiseBeacon and /commitments/* routes),
+                  # LlmQueue (rate-limited, priority-laned LLM call queue shared
+                  # across PresenceProxy and PromiseBeacon; enforces daily spend cap),
+                  # SessionWatchdog (stuck-process detection + escalating kill
+                  # sequence; watchdog-notifications for user-facing messages)
+  messaging/      # TelegramAdapter (long-polling, JSONL history),
+                  # WhatsAppAdapter, SlackAdapter, iMessage (platform adapters);
+                  # MessageRouter (topic → adapter routing),
+                  # DeliveryRetryManager (retry on failed delivery),
+                  # SpawnRequestManager (cross-session spawn coordination),
+                  # MessageStore (cross-platform message persistence)
   users/          # Multi-user identity resolution and permissions
   server/         # HTTP server, routes, middleware (auth, CORS)
   scaffold/       # Identity bootstrap, template file generation

--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -215,6 +215,43 @@ export class CommitmentTracker extends EventEmitter {
     this.rulesPath = path.join(config.stateDir, 'state', 'commitment-rules.md');
     this.store = this.loadStore();
     this.nextId = this.computeNextId();
+    this.backfillUnverifiableOneTimeActions();
+  }
+
+  /**
+   * One-shot migration: any pre-existing one-time-action that is stuck
+   * in `violated` with no real verification method (violationCount > 0,
+   * verificationCount === 0, no verificationMethod) is retro-transitioned
+   * to `delivered` with a clear resolution. This drains the ~270 noisy
+   * rows that accumulated before this fix shipped. Idempotent — rows
+   * already `delivered`/`withdrawn`/`expired` are skipped.
+   */
+  private backfillUnverifiableOneTimeActions(): void {
+    let changed = 0;
+    for (const c of this.store.commitments) {
+      if (c.type !== 'one-time-action') continue;
+      if (c.status === 'delivered' || c.status === 'withdrawn' || c.status === 'expired') continue;
+      if (!CommitmentTracker.isUnverifiableOneTime(c)) continue;
+      c.status = 'delivered';
+      c.resolvedAt = c.resolvedAt ?? new Date().toISOString();
+      c.resolution =
+        c.resolution ??
+        'Backfilled: no automated verification method — trusting agent acknowledgment.';
+      c.version = (c.version ?? 0) + 1;
+      changed++;
+    }
+    if (changed > 0) {
+      try {
+        this.saveStore();
+        console.log(
+          `[CommitmentTracker] Backfill: ${changed} unverifiable one-time-action(s) transitioned to delivered`,
+        );
+      } catch (err) {
+        console.warn(
+          `[CommitmentTracker] Backfill save failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────
@@ -382,15 +419,32 @@ export class CommitmentTracker extends EventEmitter {
 
   /**
    * Get all active commitments (pending or verified, not expired).
+   *
+   * `delivered` is a terminal state for one-time-actions that have no
+   * automated verification method — once transitioned, they are not
+   * re-checked (Phase 1 of commitment signal-quality fix).
    */
   getActive(): Commitment[] {
     const now = new Date().toISOString();
     return this.store.commitments.filter(c => {
-      if (c.status === 'withdrawn' || c.status === 'expired') return false;
+      if (c.status === 'withdrawn' || c.status === 'expired' || c.status === 'delivered') return false;
       if (c.expiresAt && c.expiresAt < now) return false;
       // Active = pending, verified, or violated (violated is still "active" — it needs attention)
       return c.status === 'pending' || c.status === 'verified' || c.status === 'violated';
     });
+  }
+
+  /**
+   * True if a one-time-action commitment has no way to be verified
+   * automatically — no verificationMethod at all, an unknown method, or
+   * the `manual` method (which by design cannot self-resolve). Such
+   * commitments should not keep accumulating violations on every sweep;
+   * they transition to `delivered` on the first verify call.
+   */
+  private static isUnverifiableOneTime(c: Commitment): boolean {
+    if (c.type !== 'one-time-action') return false;
+    const m = c.verificationMethod;
+    return m === undefined || m === null || m === 'manual';
   }
 
   /**
@@ -464,7 +518,28 @@ export class CommitmentTracker extends EventEmitter {
   verifyOne(id: string): { passed: boolean; detail: string } | null {
     const commitment = this.store.commitments.find(c => c.id === id);
     if (!commitment) return null;
-    if (commitment.status === 'withdrawn' || commitment.status === 'expired') return null;
+    if (
+      commitment.status === 'withdrawn' ||
+      commitment.status === 'expired' ||
+      commitment.status === 'delivered'
+    ) return null;
+
+    // One-time-actions with no automated verification path cannot keep
+    // being "violated" on every sweep — that's how a single commitment
+    // accumulated 51,000+ violation ticks. Transition once to
+    // `delivered` (terminal) with a clear resolution note, then skip.
+    if (CommitmentTracker.isUnverifiableOneTime(commitment)) {
+      const updated = this.mutateSync(id, c => ({
+        ...c,
+        status: 'delivered',
+        resolvedAt: new Date().toISOString(),
+        resolution:
+          'No automated verification method — trusting agent acknowledgment. ' +
+          'Use PATCH /commitments/:id or markDelivered() to change this.',
+      }));
+      if (this.config.onVerified) this.config.onVerified(updated);
+      return { passed: true, detail: 'Trusted — no automated verification method' };
+    }
 
     let result: { passed: boolean; detail: string };
 

--- a/tests/unit/CommitmentTracker.test.ts
+++ b/tests/unit/CommitmentTracker.test.ts
@@ -564,7 +564,7 @@ describe('CommitmentTracker', () => {
       expect(result!.passed).toBe(true);
     });
 
-    it('manual verification stays pending', () => {
+    it('manual verification transitions to delivered (terminal) with trust note', () => {
       const tracker = makeTracker(stateDir);
       const c = tracker.record({
         type: 'one-time-action',
@@ -574,8 +574,131 @@ describe('CommitmentTracker', () => {
       });
 
       const result = tracker.verifyOne(c.id);
-      expect(result!.passed).toBe(false);
-      expect(result!.detail).toContain('manual verification');
+      expect(result!.passed).toBe(true);
+      expect(result!.detail).toContain('Trusted');
+
+      const updated = tracker.get(c.id)!;
+      expect(updated.status).toBe('delivered');
+      expect(updated.resolvedAt).toBeTruthy();
+      expect(updated.resolution).toMatch(/No automated verification/);
+    });
+
+    it('one-time-action with no verificationMethod transitions to delivered instead of accumulating violations', () => {
+      const tracker = makeTracker(stateDir);
+      const c = tracker.record({
+        type: 'one-time-action',
+        userRequest: 'bump the version and deploy',
+        agentResponse: '✓ Delivered',
+      });
+
+      // Simulate 10 sweep ticks
+      for (let i = 0; i < 10; i++) tracker.verifyOne(c.id);
+
+      const updated = tracker.get(c.id)!;
+      expect(updated.status).toBe('delivered');
+      expect(updated.violationCount).toBe(0);
+      // Delivered commitments are not active — sweeps skip them
+      const active = tracker.getActive().find(x => x.id === c.id);
+      expect(active).toBeUndefined();
+    });
+
+    it('verifyOne returns null for already-delivered commitments', () => {
+      const tracker = makeTracker(stateDir);
+      const c = tracker.record({
+        type: 'one-time-action',
+        userRequest: 'one-shot',
+        agentResponse: 'done',
+      });
+      tracker.verifyOne(c.id); // transitions to delivered
+      const second = tracker.verifyOne(c.id);
+      expect(second).toBeNull();
+    });
+  });
+
+  // ── Backfill: legacy violated rows with no verification method ────
+
+  describe('backfill on construction', () => {
+    it('transitions pre-existing unverifiable violated one-time-actions to delivered', () => {
+      // Seed a store file mimicking the 272-violated state
+      const storePath = path.join(stateDir, 'state', 'commitments.json');
+      const seed = {
+        version: 1,
+        commitments: [
+          {
+            id: 'CMT-LEGACY-1',
+            userRequest: 'bump the version and deploy this properly',
+            agentResponse: '✓ Delivered',
+            type: 'one-time-action',
+            status: 'violated',
+            createdAt: '2026-03-10T00:22:11.260Z',
+            verificationCount: 0,
+            violationCount: 51669,
+            correctionCount: 0,
+            correctionHistory: [],
+            escalated: false,
+            version: 94,
+          },
+          {
+            id: 'CMT-LEGACY-2',
+            userRequest: 'keep verified',
+            agentResponse: 'done',
+            type: 'behavioral',
+            status: 'verified',
+            behavioralRule: 'always do X',
+            createdAt: '2026-03-10T00:00:00.000Z',
+            verificationCount: 1,
+            violationCount: 0,
+            correctionCount: 0,
+            correctionHistory: [],
+            escalated: false,
+            version: 1,
+          },
+        ],
+      };
+      fs.writeFileSync(storePath, JSON.stringify(seed));
+
+      const tracker = makeTracker(stateDir);
+      const legacy1 = tracker.get('CMT-LEGACY-1')!;
+      expect(legacy1.status).toBe('delivered');
+      expect(legacy1.resolvedAt).toBeTruthy();
+      expect(legacy1.resolution).toMatch(/Backfilled/);
+
+      // Behavioral commitment untouched
+      const legacy2 = tracker.get('CMT-LEGACY-2')!;
+      expect(legacy2.status).toBe('verified');
+    });
+
+    it('is idempotent — second construction does not re-backfill', () => {
+      const storePath = path.join(stateDir, 'state', 'commitments.json');
+      const seed = {
+        version: 1,
+        commitments: [
+          {
+            id: 'CMT-IDEM-1',
+            userRequest: 'x',
+            agentResponse: 'y',
+            type: 'one-time-action',
+            status: 'violated',
+            createdAt: '2026-03-10T00:00:00.000Z',
+            verificationCount: 0,
+            violationCount: 5,
+            correctionCount: 0,
+            correctionHistory: [],
+            escalated: false,
+            version: 1,
+          },
+        ],
+      };
+      fs.writeFileSync(storePath, JSON.stringify(seed));
+
+      const t1 = makeTracker(stateDir);
+      const afterFirst = t1.get('CMT-IDEM-1')!;
+      const resolvedAt1 = afterFirst.resolvedAt;
+
+      const t2 = makeTracker(stateDir);
+      const afterSecond = t2.get('CMT-IDEM-1')!;
+      expect(afterSecond.status).toBe('delivered');
+      expect(afterSecond.resolvedAt).toBe(resolvedAt1); // unchanged
     });
   });
 


### PR DESCRIPTION
## Summary
- One-time-action commitments with no verificationMethod (or method=manual) were being re-marked violated on every sweep tick. CMT-002 in prod hit 51,669 ticks. Signal was 272/317 violated — pure noise.
- Transition such rows to the existing terminal `delivered` state on first verify with resolution "trusting agent acknowledgment."
- Backfill migration runs on tracker construction (idempotent).

## Test plan
- [x] 4 new unit tests covering: manual method transition, unverifiable-no-method transition, delivered returns null from verifyOne, backfill migrates and is idempotent
- [x] Full CommitmentTracker.test.ts suite (64 tests) green
- [x] `npx tsc --noEmit` clean