### PR TITLE
feat(monitoring): HelperWatchdog — detect subagent stalls and rate-limit failures

### DIFF
--- a/src/monitoring/HelperWatchdog.ts
+++ b/src/monitoring/HelperWatchdog.ts
@@ -1,0 +1,212 @@
+/**
+ * HelperWatchdog — stall / failure detection for spawned subagents.
+ *
+ * The built-in SessionWatchdog notices when the top-level Claude Code
+ * session hangs. It does NOT cover helper subagents spawned via the
+ * Task tool: when one of those hits a rate limit or silently stalls,
+ * the parent agent has no signal and goes quiet. This module closes
+ * that gap.
+ *
+ * The watchdog subscribes to SubagentTracker's `start` and `stop`
+ * events, schedules a per-agent stall timer on start, and inspects
+ * the stop payload for failure markers. Two event types are emitted:
+ *
+ *   - `stall`         — a subagent has been running longer than the
+ *                       configured stall timeout. Consumers should
+ *                       surface this to the user so the parent agent
+ *                       can decide whether to retry smaller.
+ *   - `helper-failed` — a subagent stopped with a recognised failure
+ *                       marker in its lastMessage (rate limit / 429 /
+ *                       quota exhaustion / auth error). Payload
+ *                       includes the original record and a reason.
+ *
+ * The watchdog is deliberately signal-only (see signal-vs-authority
+ * discipline): it detects and emits. Retry-smaller logic and user
+ * messaging live outside this module.
+ */
+
+import { EventEmitter } from 'node:events';
+import type { SubagentTracker, SubagentRecord } from './SubagentTracker.js';
+
+/** Default stall timeout: 5 minutes. */
+export const DEFAULT_STALL_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Patterns that identify a failure message from a stopped subagent. */
+const FAILURE_PATTERNS: Array<{ reason: string; pattern: RegExp }> = [
+  { reason: 'rate-limit', pattern: /\b(rate[\s-]?limit|too\s+many\s+requests?|429)\b/i },
+  { reason: 'quota-exhausted', pattern: /\b(quota\s+(?:exhausted|exceeded)|out\s+of\s+(?:credits?|tokens?))\b/i },
+  { reason: 'auth-error', pattern: /\b(unauthori[sz]ed|invalid\s+api\s+key|401|403)\b/i },
+  { reason: 'timeout', pattern: /\b(timed?\s*out|timeout|request\s+timeout)\b/i },
+  { reason: 'api-error', pattern: /\b(api[\s-]?error|anthropic[\s-]?error|internal[\s-]?server[\s-]?error|5\d{2})\b/i },
+];
+
+export interface HelperWatchdogConfig {
+  subagentTracker: SubagentTracker;
+  /** Stall timeout in ms. Default: 5 minutes. */
+  stallTimeoutMs?: number;
+  /** Injectable timer for tests. */
+  setTimeoutFn?: (fn: () => void, ms: number) => NodeJS.Timeout;
+  clearTimeoutFn?: (handle: NodeJS.Timeout) => void;
+  /** Injectable clock. */
+  now?: () => number;
+}
+
+export interface StallEvent {
+  agentId: string;
+  agentType: string;
+  sessionId: string;
+  startedAt: string;
+  elapsedMs: number;
+  reason: 'stall-timeout';
+}
+
+export interface HelperFailedEvent {
+  record: SubagentRecord;
+  reason: string;
+  matchedPattern: string;
+}
+
+export class HelperWatchdog extends EventEmitter {
+  private readonly tracker: SubagentTracker;
+  private readonly stallTimeoutMs: number;
+  private readonly setTimeoutFn: (fn: () => void, ms: number) => NodeJS.Timeout;
+  private readonly clearTimeoutFn: (handle: NodeJS.Timeout) => void;
+  private readonly now: () => number;
+
+  /** Active stall timers, keyed by `${sessionId}:${agentId}`. */
+  private readonly timers: Map<string, NodeJS.Timeout> = new Map();
+  /** Start metadata, keyed by `${sessionId}:${agentId}`. */
+  private readonly starts: Map<
+    string,
+    { agentId: string; agentType: string; sessionId: string; startedAt: string }
+  > = new Map();
+
+  private readonly onStart = (record: SubagentRecord): void => {
+    this.handleStart(record);
+  };
+  private readonly onStop = (p: {
+    agentId: string;
+    sessionId: string;
+    lastMessage?: string;
+  }): void => {
+    this.handleStop(p);
+  };
+
+  constructor(config: HelperWatchdogConfig) {
+    super();
+    this.tracker = config.subagentTracker;
+    this.stallTimeoutMs = config.stallTimeoutMs ?? DEFAULT_STALL_TIMEOUT_MS;
+    this.setTimeoutFn = config.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimeoutFn = config.clearTimeoutFn ?? ((h) => clearTimeout(h));
+    this.now = config.now ?? Date.now;
+  }
+
+  /** Start subscribing to tracker events. */
+  start(): void {
+    this.tracker.on('start', this.onStart);
+    this.tracker.on('stop', this.onStop);
+  }
+
+  /** Stop and clear all pending stall timers. */
+  stop(): void {
+    this.tracker.off('start', this.onStart);
+    this.tracker.off('stop', this.onStop);
+    for (const h of this.timers.values()) {
+      this.clearTimeoutFn(h);
+    }
+    this.timers.clear();
+    this.starts.clear();
+  }
+
+  /**
+   * Inspect a stop message for a known failure pattern. Exposed as a
+   * static method so callers that don't want the full watchdog wiring
+   * (tests, post-mortem analyzers) can reuse the classifier.
+   */
+  static classifyStopMessage(
+    lastMessage: string | null | undefined,
+  ): { reason: string; matchedPattern: string } | null {
+    if (!lastMessage) return null;
+    for (const { reason, pattern } of FAILURE_PATTERNS) {
+      if (pattern.test(lastMessage)) {
+        return { reason, matchedPattern: pattern.source };
+      }
+    }
+    return null;
+  }
+
+  // ── Internal handlers ────────────────────────────────────────────
+
+  private handleStart(record: SubagentRecord): void {
+    const key = `${record.sessionId}:${record.agentId}`;
+    if (this.timers.has(key)) return; // idempotent
+    this.starts.set(key, {
+      agentId: record.agentId,
+      agentType: record.agentType,
+      sessionId: record.sessionId,
+      startedAt: record.startedAt,
+    });
+    const handle = this.setTimeoutFn(() => {
+      this.fireStall(key);
+    }, this.stallTimeoutMs);
+    this.timers.set(key, handle);
+  }
+
+  private handleStop(p: {
+    agentId: string;
+    sessionId: string;
+    lastMessage?: string;
+  }): void {
+    const key = `${p.sessionId}:${p.agentId}`;
+    const handle = this.timers.get(key);
+    if (handle) {
+      this.clearTimeoutFn(handle);
+      this.timers.delete(key);
+    }
+    this.starts.delete(key);
+
+    const failure = HelperWatchdog.classifyStopMessage(p.lastMessage);
+    if (failure) {
+      const records = this.tracker.getSessionRecords(p.sessionId);
+      const record =
+        records.find(
+          (r: SubagentRecord) => r.agentId === p.agentId && r.stoppedAt !== null,
+        ) ??
+        ({
+          agentId: p.agentId,
+          agentType: 'unknown',
+          sessionId: p.sessionId,
+          startedAt: new Date().toISOString(),
+          stoppedAt: new Date().toISOString(),
+          lastMessage: p.lastMessage ?? null,
+          transcriptPath: null,
+        } as SubagentRecord);
+      const event: HelperFailedEvent = {
+        record,
+        reason: failure.reason,
+        matchedPattern: failure.matchedPattern,
+      };
+      this.emit('helper-failed', event);
+    }
+  }
+
+  private fireStall(key: string): void {
+    const meta = this.starts.get(key);
+    this.timers.delete(key);
+    this.starts.delete(key);
+    if (!meta) return;
+    const elapsedMs = Math.max(
+      0,
+      this.now() - Date.parse(meta.startedAt) || this.stallTimeoutMs,
+    );
+    const event: StallEvent = {
+      agentId: meta.agentId,
+      agentType: meta.agentType,
+      sessionId: meta.sessionId,
+      startedAt: meta.startedAt,
+      elapsedMs,
+      reason: 'stall-timeout',
+    };
+    this.emit('stall', event);
+  }
+}

--- a/tests/unit/HelperWatchdog.test.ts
+++ b/tests/unit/HelperWatchdog.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for HelperWatchdog — stall + failure detection for
+ * spawned subagents. Sits on top of SubagentTracker's event stream.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SubagentTracker } from '../../src/monitoring/SubagentTracker.js';
+import { HelperWatchdog } from '../../src/monitoring/HelperWatchdog.js';
+
+function createTmpState(): { stateDir: string; cleanup: () => void } {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'helper-watchdog-test-'));
+  return {
+    stateDir,
+    cleanup: () => fs.rmSync(stateDir, { recursive: true, force: true }),
+  };
+}
+
+interface MockTimer {
+  fn: () => void;
+  ms: number;
+  handle: number;
+  cleared: boolean;
+}
+
+function makeFakeTimers(): {
+  setTimeoutFn: (fn: () => void, ms: number) => NodeJS.Timeout;
+  clearTimeoutFn: (h: NodeJS.Timeout) => void;
+  fireAll: () => void;
+  pending: () => MockTimer[];
+} {
+  let nextId = 1;
+  const timers: MockTimer[] = [];
+  return {
+    setTimeoutFn: (fn, ms) => {
+      const t: MockTimer = { fn, ms, handle: nextId++, cleared: false };
+      timers.push(t);
+      return t.handle as unknown as NodeJS.Timeout;
+    },
+    clearTimeoutFn: (h) => {
+      const t = timers.find((x) => x.handle === (h as unknown as number));
+      if (t) t.cleared = true;
+    },
+    fireAll: () => {
+      for (const t of timers) {
+        if (!t.cleared) t.fn();
+      }
+    },
+    pending: () => timers.filter((t) => !t.cleared),
+  };
+}
+
+describe('HelperWatchdog', () => {
+  let stateDir: string;
+  let cleanup: () => void;
+  let tracker: SubagentTracker;
+
+  beforeEach(() => {
+    ({ stateDir, cleanup } = createTmpState());
+    tracker = new SubagentTracker({ stateDir });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── classifyStopMessage ────────────────────────────────
+
+  describe('classifyStopMessage (static)', () => {
+    it('detects rate-limit phrasing', () => {
+      expect(HelperWatchdog.classifyStopMessage('Error: rate limit exceeded')?.reason).toBe(
+        'rate-limit',
+      );
+      expect(HelperWatchdog.classifyStopMessage('429 Too Many Requests')?.reason).toBe(
+        'rate-limit',
+      );
+    });
+
+    it('detects quota exhaustion', () => {
+      expect(HelperWatchdog.classifyStopMessage('Quota exhausted, try again later')?.reason).toBe(
+        'quota-exhausted',
+      );
+      expect(HelperWatchdog.classifyStopMessage('Out of credits')?.reason).toBe(
+        'quota-exhausted',
+      );
+    });
+
+    it('detects auth errors', () => {
+      expect(HelperWatchdog.classifyStopMessage('Unauthorized: invalid API key')?.reason).toBe(
+        'auth-error',
+      );
+      expect(HelperWatchdog.classifyStopMessage('HTTP 403 Forbidden')?.reason).toBe('auth-error');
+    });
+
+    it('detects timeout markers', () => {
+      expect(HelperWatchdog.classifyStopMessage('Request timed out after 60s')?.reason).toBe(
+        'timeout',
+      );
+    });
+
+    it('returns null for clean stop messages', () => {
+      expect(HelperWatchdog.classifyStopMessage('Task complete')).toBeNull();
+      expect(HelperWatchdog.classifyStopMessage('')).toBeNull();
+      expect(HelperWatchdog.classifyStopMessage(null)).toBeNull();
+      expect(HelperWatchdog.classifyStopMessage(undefined)).toBeNull();
+    });
+  });
+
+  // ── Stall detection ────────────────────────────────────
+
+  describe('stall detection', () => {
+    it('emits `stall` after stallTimeoutMs with no stop event', () => {
+      const timers = makeFakeTimers();
+      const wd = new HelperWatchdog({
+        subagentTracker: tracker,
+        stallTimeoutMs: 5000,
+        setTimeoutFn: timers.setTimeoutFn,
+        clearTimeoutFn: timers.clearTimeoutFn,
+      });
+      wd.start();
+
+      const events: unknown[] = [];
+      wd.on('stall', (e) => events.push(e));
+
+      tracker.onStart('agent-1', 'Explore', 'session-a');
+      expect(timers.pending().length).toBe(1);
+
+      timers.fireAll();
+      expect(events.length).toBe(1);
+      const ev = events[0] as { agentId: string; reason: string };
+      expect(ev.agentId).toBe('agent-1');
+      expect(ev.reason).toBe('stall-timeout');
+    });
+
+    it('does NOT emit stall if the subagent stops in time', () => {
+      const timers = makeFakeTimers();
+      const wd = new HelperWatchdog({
+        subagentTracker: tracker,
+        stallTimeoutMs: 5000,
+        setTimeoutFn: timers.setTimeoutFn,
+        clearTimeoutFn: timers.clearTimeoutFn,
+      });
+      wd.start();
+
+      const stallEvents: unknown[] = [];
+      wd.on('stall', (e) => stallEvents.push(e));
+
+      tracker.onStart('agent-2', 'Plan', 'session-b');
+      tracker.onStop('agent-2', 'session-b', 'Done');
+
+      // Firing any remaining pending timers to prove the start-timer
+      // was properly cleared (it should not fire).
+      timers.fireAll();
+      expect(stallEvents.length).toBe(0);
+    });
+
+    it('is idempotent on duplicate start events', () => {
+      const timers = makeFakeTimers();
+      const wd = new HelperWatchdog({
+        subagentTracker: tracker,
+        setTimeoutFn: timers.setTimeoutFn,
+        clearTimeoutFn: timers.clearTimeoutFn,
+      });
+      wd.start();
+      tracker.onStart('agent-3', 'Explore', 'session-c');
+      tracker.onStart('agent-3', 'Explore', 'session-c');
+      expect(timers.pending().length).toBe(1);
+    });
+  });
+
+  // ── Failure detection via stop payload ─────────────────
+
+  describe('helper-failed on rate-limit stop', () => {
+    it('emits `helper-failed` when stop lastMessage contains a rate-limit marker', () => {
+      const timers = makeFakeTimers();
+      const wd = new HelperWatchdog({
+        subagentTracker: tracker,
+        setTimeoutFn: timers.setTimeoutFn,
+        clearTimeoutFn: timers.clearTimeoutFn,
+      });
+      wd.start();
+
+      const events: unknown[] = [];
+      wd.on('helper-failed', (e) => events.push(e));
+
+      tracker.onStart('agent-4', 'Explore', 'session-d');
+      tracker.onStop('agent-4', 'session-d', '429 rate limit — please retry later');
+
+      expect(events.length).toBe(1);
+      const ev = events[0] as { reason: string; record: { agentId: string } };
+      expect(ev.reason).toBe('rate-limit');
+      expect(ev.record.agentId).toBe('agent-4');
+    });
+
+    it('does not emit `helper-failed` on a clean stop message', () => {
+      const wd = new HelperWatchdog({ subagentTracker: tracker });
+      wd.start();
+
+      const events: unknown[] = [];
+      wd.on('helper-failed', (e) => events.push(e));
+
+      tracker.onStart('agent-5', 'Plan', 'session-e');
+      tracker.onStop('agent-5', 'session-e', 'Task completed successfully');
+
+      expect(events.length).toBe(0);
+    });
+
+    it('clears the stall timer when stop fires, even if the message is a failure', () => {
+      const timers = makeFakeTimers();
+      const wd = new HelperWatchdog({
+        subagentTracker: tracker,
+        stallTimeoutMs: 5000,
+        setTimeoutFn: timers.setTimeoutFn,
+        clearTimeoutFn: timers.clearTimeoutFn,
+      });
+      wd.start();
+
+      const stallEvents: unknown[] = [];
+      wd.on('stall', (e) => stallEvents.push(e));
+
+      tracker.onStart('agent-6', 'Explore', 'session-f');
+      tracker.onStop('agent-6', 'session-f', 'quota exhausted');
+      timers.fireAll();
+      expect(stallEvents.length).toBe(0);
+    });
+  });
+
+  // ── Teardown ───────────────────────────────────────────
+
+  describe('stop()', () => {
+    it('unsubscribes and clears pending timers', () => {
+      const timers = makeFakeTimers();
+      const wd = new HelperWatchdog({
+        subagentTracker: tracker,
+        setTimeoutFn: timers.setTimeoutFn,
+        clearTimeoutFn: timers.clearTimeoutFn,
+      });
+      wd.start();
+      tracker.onStart('agent-7', 'Explore', 'session-g');
+      expect(timers.pending().length).toBe(1);
+
+      wd.stop();
+      expect(timers.pending().length).toBe(0);
+
+      const events: unknown[] = [];
+      wd.on('stall', (e) => events.push(e));
+      wd.on('helper-failed', (e) => events.push(e));
+
+      // Further tracker events should be ignored after stop().
+      tracker.onStart('agent-8', 'Plan', 'session-h');
+      tracker.onStop('agent-8', 'session-h', '429 rate limit');
+      expect(events.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- SessionWatchdog watches the top-level session but not the Task-tool subagents the parent spawns. A rate-limited helper dies and the parent goes quiet.
- HelperWatchdog listens to SubagentTracker's `start`/`stop` and emits two signal-only events: `stall` (no stop after N ms) and `helper-failed` (stop message matches rate-limit / 429 / quota / auth / timeout / API error).
- Signal-only by design — retry-smaller logic and user messaging live outside this module.

## Test plan
- [x] 12 new unit tests covering stop-message classification (all failure families), stall fire + cancel, duplicate-start idempotency, teardown
- [x] `npx tsc --noEmit` clean