### PR TITLE
feat(server): wire HelperWatchdog alerts into parent session

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4358,6 +4358,55 @@ export async function startServer(options: StartOptions): Promise<void> {
     const subagentTracker = new SubagentTracker({ stateDir: config.stateDir });
     console.log(pc.green('  Subagent tracker enabled'));
 
+    // Helper Watchdog — detects subagent stalls and rate-limit failures,
+    // surfacing them back into the parent session's stdin so the agent
+    // can decide whether to retry smaller. Complements SessionWatchdog,
+    // which only covers the top-level session.
+    const { HelperWatchdog } = await import('../monitoring/HelperWatchdog.js');
+    const helperWatchdog = new HelperWatchdog({ subagentTracker });
+    helperWatchdog.start();
+    const findTmuxForClaudeSession = (claudeSessionId: string): string | null => {
+      const running = sessionManager
+        .listRunningSessions()
+        .filter((s) => s.claudeSessionId === claudeSessionId);
+      return running[0]?.tmuxSession ?? null;
+    };
+    const deliverHelperAlert = (tmux: string | null, msg: string): void => {
+      console.warn(msg);
+      if (!tmux) return;
+      try {
+        sessionManager.injectMessage(tmux, msg);
+      } catch (err) {
+        console.warn(
+          `[HelperWatchdog] inject failed for ${tmux}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    };
+    helperWatchdog.on(
+      'stall',
+      (e: { agentId: string; agentType: string; sessionId: string; elapsedMs: number }) => {
+        const minutes = Math.round(e.elapsedMs / 60_000);
+        deliverHelperAlert(
+          findTmuxForClaudeSession(e.sessionId),
+          `[helper-watchdog] Your ${e.agentType} helper (agent ${e.agentId}) has been running for ${minutes}m with no stop event — likely stalled. Consider retrying with a smaller scope or aborting.`,
+        );
+      },
+    );
+    helperWatchdog.on(
+      'helper-failed',
+      (e: {
+        record: { agentId: string; agentType: string; sessionId: string; lastMessage: string | null };
+        reason: string;
+      }) => {
+        const snippet = (e.record.lastMessage ?? '').slice(0, 160);
+        deliverHelperAlert(
+          findTmuxForClaudeSession(e.record.sessionId),
+          `[helper-watchdog] Your ${e.record.agentType} helper (agent ${e.record.agentId}) died with reason=${e.reason}. Last message: ${snippet}`,
+        );
+      },
+    );
+    console.log(pc.green('  Helper watchdog enabled'));
+
     // Wire subagent awareness into zombie cleanup — prevents killing sessions
     // that are idle at the prompt but waiting for subagent results.
     const MAX_SUBAGENT_WAIT_MS = 60 * 60_000; // 60 minutes — stale subagent safety cap

--- a/tests/unit/HelperWatchdog.wireup.test.ts
+++ b/tests/unit/HelperWatchdog.wireup.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Integration-style test for HelperWatchdog's expected contract with
+ * a SessionManager-shaped consumer — proves that stall and helper-failed
+ * events produce injectable alert strings containing the agent id,
+ * type, and failure reason. The real wire-up lives in
+ * src/commands/server.ts; this test pins the event payload shape the
+ * wire-up depends on so a payload rename can't silently regress it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SubagentTracker } from '../../src/monitoring/SubagentTracker.js';
+import { HelperWatchdog } from '../../src/monitoring/HelperWatchdog.js';
+
+function tmp() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hw-wireup-'));
+  return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe('HelperWatchdog wire-up contract', () => {
+  it('helper-failed event carries the fields server.ts relies on', () => {
+    const { dir, cleanup } = tmp();
+    try {
+      const tracker = new SubagentTracker({ stateDir: dir });
+      const wd = new HelperWatchdog({ subagentTracker: tracker });
+      wd.start();
+
+      const captured: Array<{ record: { agentId: string; agentType: string; sessionId: string; lastMessage: string | null }; reason: string }> = [];
+      wd.on('helper-failed', (e) => captured.push(e as typeof captured[0]));
+
+      tracker.onStart('agent-X', 'Explore', 'sess-1');
+      tracker.onStop('agent-X', 'sess-1', '429 rate limit hit');
+
+      expect(captured.length).toBe(1);
+      const e = captured[0];
+      expect(e.record.agentId).toBe('agent-X');
+      expect(e.record.agentType).toBe('Explore');
+      expect(e.record.sessionId).toBe('sess-1');
+      expect(e.reason).toBe('rate-limit');
+      expect(typeof e.record.lastMessage).toBe('string');
+
+      // The server wire-up constructs a message like this — verify the
+      // derived alert string is non-empty and includes the key fields.
+      const snippet = (e.record.lastMessage ?? '').slice(0, 160);
+      const msg = `[helper-watchdog] Your ${e.record.agentType} helper (agent ${e.record.agentId}) died with reason=${e.reason}. Last message: ${snippet}`;
+      expect(msg).toContain('Explore');
+      expect(msg).toContain('agent-X');
+      expect(msg).toContain('rate-limit');
+      expect(msg).toContain('429');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('stall event carries the fields server.ts relies on', () => {
+    const { dir, cleanup } = tmp();
+    try {
+      const tracker = new SubagentTracker({ stateDir: dir });
+      const fakeTimers: Array<() => void> = [];
+      const wd = new HelperWatchdog({
+        subagentTracker: tracker,
+        stallTimeoutMs: 1000,
+        setTimeoutFn: (fn) => {
+          fakeTimers.push(fn);
+          return 1 as unknown as NodeJS.Timeout;
+        },
+        clearTimeoutFn: () => {},
+      });
+      wd.start();
+
+      const captured: Array<{ agentId: string; agentType: string; sessionId: string; elapsedMs: number }> = [];
+      wd.on('stall', (e) => captured.push(e as typeof captured[0]));
+
+      tracker.onStart('agent-Y', 'Plan', 'sess-2');
+      fakeTimers[0]();
+
+      expect(captured.length).toBe(1);
+      const e = captured[0];
+      expect(e.agentId).toBe('agent-Y');
+      expect(e.agentType).toBe('Plan');
+      expect(e.sessionId).toBe('sess-2');
+      expect(typeof e.elapsedMs).toBe('number');
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- HelperWatchdog (#78) emitted events but had no consumer — the detector was dark.
- On server startup, now instantiates HelperWatchdog next to SubagentTracker and wires both events to inject an alert string into the owning Claude session's tmux stdin.
- Alert names agent type, agent id, and failure reason so the parent can decide to retry smaller or abort.
- Falls back to console.warn when the owning session isn't resolvable.

## Test plan
- [x] 2 new wire-up contract tests pin the event payload shape server.ts depends on
- [x] Existing 12 HelperWatchdog unit tests still green
- [x] `npx tsc --noEmit` clean