### PR TITLE
fix(compaction): tighten recovery preamble tone + intent (0.28.66)

### DIFF
--- a/.instar/instar-dev-traces/20260420T194541Z-compaction-preamble-tightening.json
+++ b/.instar/instar-dev-traces/20260420T194541Z-compaction-preamble-tightening.json
@@ -1,0 +1,15 @@
+{
+  "sessionId": "echo-topic-6795-compaction-preamble",
+  "timestamp": "2026-04-20T19:45:00Z",
+  "artifactPath": "upgrades/side-effects/0.28.66.md",
+  "specPath": "docs/specs/compaction-preamble-tone-and-intent.md",
+  "coveredFiles": [
+    "package.json",
+    "src/messaging/shared/compactionResumePayload.ts",
+    "tests/unit/compactionResumePayload.test.ts",
+    "upgrades/NEXT.md"
+  ],
+  "phase": "complete",
+  "secondPass": true,
+  "reviewerConcurred": true
+}

--- a/docs/specs/compaction-preamble-tone-and-intent.md
+++ b/docs/specs/compaction-preamble-tone-and-intent.md
@@ -1,0 +1,75 @@
+---
+title: "Compaction-resume preamble prescribes calm acknowledgment + respond-to-last-message"
+slug: "compaction-preamble-tone-and-intent"
+author: "echo"
+created: "2026-04-20"
+supersedes: "none — follow-up to docs/specs/compaction-resume-payload.md"
+review-convergence: "2026-04-20T19:50:00.000Z"
+review-iterations: 1
+review-completed-at: "2026-04-20T19:50:00.000Z"
+approved: true
+approved-by: "Justin"
+approved-at: "2026-04-20T21:20:17.000Z"
+approval-note: "Approved by Justin on Telegram topic 6795 after review of the private-view render of this spec."
+---
+
+# Compaction-Resume Preamble Tone + Intent Tightening
+
+## Problem Statement
+
+The prior fix (`compaction-resume-payload`, shipped as 0.28.52) closed the **information** failure of the compaction-recovery path: `COMPACTION_RESUME_PREAMBLE` now ships a rich context block (summary + recent messages + search hint) to the recovered agent. That fix shipped and recovered agents now have the context they need.
+
+Two screenshots from topic 6795 on 2026-04-20 surfaced a **third** failure layer, one the prior fixes don't touch: the preamble text itself is too loose. The full preamble was:
+
+> "Your session just went through context compaction — your working memory was reset. The context below is what you had before the reset. Briefly let the user know compaction occurred, then continue the conversation naturally."
+
+Two observed failure modes, both on live 0.28.52 sessions:
+
+1. **Tone failure (Mew / session-robustness topic, 12:12 PM)**. User asked a simple question about the /loop skill. Recovered agent opened with: "Quick heads-up: I lost track of what we were working on for a second, but I found my notes and caught back up." — then answered the question correctly. Agent HAD the context. Phrasing was the issue. "Let the user know" is open-ended, agents free-form narrate it with alarming language ("lost track", "got lost", "got confused").
+
+2. **Intent failure (Bob / instar-agent-robustness topic, 12:04 PM)**. User's pre-compaction last message was "Your call." — a delegated decision. Recovered agent's response: a recap of the recent work + the same two choices offered before + "Your call." at the end. Infinite ping-pong. "Continue the conversation naturally" triggers a safe status-summary reflex instead of directing the agent to make the delegated decision.
+
+## Root Cause
+
+Open-ended instruction text in `COMPACTION_RESUME_PREAMBLE`. The rich context block from 0.28.52 gives the agent the raw material; the preamble tells the agent what to do with it. "Let the user know" and "continue naturally" are both too permissive — the agent has wide latitude, and under that latitude the default LLM behaviors are (a) hedge/apologize/narrate uncertainty and (b) reconstruct a plausible status summary with options.
+
+## Proposed Fix
+
+Rewrite `COMPACTION_RESUME_PREAMBLE` in `src/messaging/shared/compactionResumePayload.ts` with three explicit instructions, in order:
+
+1. **First sentence must be a calm acknowledgment**: "your session paused for context compaction and has now resumed." Explicitly forbid "lost track", "got lost", "got confused", "lost your place".
+
+2. **Then respond to the user's MOST RECENT message**. If a question, answer it. If a directive or delegated decision ("your call", "you decide", "proceed as you see fit"), make the decision and act — do NOT reconstruct a generic status summary, re-offer options already delegated, or hand the choice back.
+
+3. **Assume full continuity**. Any work-in-progress, open commitments, or next steps recorded in the context are still the agent's to carry forward.
+
+Mirror the same three-step instruction in `prepareInjectionText`'s over-threshold (file-reference) branch so long-context recoveries get identical guardrails to short ones.
+
+## Non-Goals
+
+- No change to `findLastRealMessage` or `isSystemOrProxyMessage` (0.28.51).
+- No change to `topicMemory.formatContextForSession` (0.28.52).
+- No outbound-message rewriting or tone-gate integration. Preamble is INPUT to the authority (recovered agent); the agent remains the sole authority on its response.
+- No prompt-injection surface widening; the user's last message is already in the recovered agent's context via the 0.28.52 payload, and this spec does not change what context is provided — only how the agent is instructed to use it.
+
+## Signal-vs-Authority
+
+Not applicable. This change adds no decision point, no filter, no gate. It is instruction text fed to an existing LLM-backed authority (the recovered agent). Detectors remain detectors, authorities remain authorities.
+
+## Acceptance Criteria
+
+- `COMPACTION_RESUME_PREAMBLE` contains the prescribed acknowledgment phrasing ("paused for context compaction", "resumed") and explicit prohibitions ("do not say you 'lost track'/'got lost'/'got confused'").
+- `COMPACTION_RESUME_PREAMBLE` explicitly directs the agent to respond to the user's most recent message, with special handling of delegated decisions.
+- The calm acknowledgment appears BEFORE the respond-to-last-message instruction (order matters — first output must be the acknowledgment).
+- `prepareInjectionText` over-threshold branch carries the same three instructions.
+- Regression tests pin all invariants on both branches.
+
+## Rollback
+
+Pure text change in one file. Revert single commit, ship as next patch. No persistent state, no runtime flow change, zero agent-state repair.
+
+## Evidence
+
+- Topic 6795 screenshots 2026-04-20 (Mew 12:12 PM, Bob 12:04 PM).
+- Thread context in `/tmp/instar-telegram/ctx-6795-1776712790539.txt`.
+- Diagnosis confirmed by reading the shipped 0.28.52 preamble against both failure modes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "0.28.65",
+  "version": "0.28.66",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/messaging/shared/compactionResumePayload.ts
+++ b/src/messaging/shared/compactionResumePayload.ts
@@ -26,7 +26,14 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 
 export const COMPACTION_RESUME_PREAMBLE =
-  'Your session just went through context compaction — your working memory was reset. The context below is what you had before the reset. Briefly let the user know compaction occurred, then continue the conversation naturally.';
+  [
+    'Your session just went through context compaction — your working memory was reset. The context below is what you had before the reset.',
+    '',
+    'How to respond:',
+    '1. Your FIRST sentence must be a brief, calm statement that your session paused for context compaction and has now resumed. Do NOT say you "lost track," "got lost," "got confused," or "lost your place" — you did not. Compaction is a routine pause; narrate it as one.',
+    '2. Then respond directly to the user\'s MOST RECENT message in the context below. If it was a question, answer it. If it was a directive or a decision the user handed back to you ("your call", "you decide", "proceed as you see fit"), make the decision and act on it — do NOT reconstruct a generic status summary, re-offer options the user already delegated, or hand the choice back to them.',
+    '3. Assume full continuity. Any work-in-progress, open commitments, or next steps recorded in the context below are still yours to carry forward.',
+  ].join('\n');
 
 export interface HistoryEntryLike {
   text?: string;
@@ -103,9 +110,11 @@ export function prepareInjectionText(
   );
 
   return (
-    `Your session just went through context compaction. Your prior working memory — ` +
-    `summary, recent messages, and lookup hints — has been preserved at ${filepath}. ` +
-    `Read that file IMMEDIATELY to re-orient, briefly let the user know compaction ` +
-    `occurred, then continue the conversation naturally.`
+    `Your session just went through context compaction — your working memory was reset. ` +
+    `Your prior context (summary, recent messages, and lookup hints) has been preserved at ${filepath}. ` +
+    `Read that file IMMEDIATELY to re-orient, then respond to the user as follows:\n\n` +
+    `1. Your FIRST sentence must be a brief, calm statement that your session paused for context compaction and has now resumed. Do NOT say you "lost track," "got lost," "got confused," or "lost your place" — you did not. Compaction is a routine pause; narrate it as one.\n` +
+    `2. Then respond directly to the user's MOST RECENT message in the preserved context. If it was a question, answer it. If it was a directive or a decision the user handed back to you ("your call", "you decide", "proceed as you see fit"), make the decision and act on it — do NOT reconstruct a generic status summary, re-offer options the user already delegated, or hand the choice back to them.\n` +
+    `3. Assume full continuity. Any work-in-progress, open commitments, or next steps recorded in the preserved context are still yours to carry forward.`
   );
 }

--- a/tests/unit/compactionResumePayload.test.ts
+++ b/tests/unit/compactionResumePayload.test.ts
@@ -36,11 +36,53 @@ describe('buildCompactionResumePayload', () => {
     expect(payload).toBe(`${COMPACTION_RESUME_PREAMBLE}\n\n${block}`);
   });
 
-  it('tells the agent compaction occurred (lets user know) and to continue naturally', () => {
-    // These phrases are what prevent the generic status-summary failure mode.
+  it('tells the agent compaction occurred', () => {
     expect(COMPACTION_RESUME_PREAMBLE).toMatch(/compaction/i);
-    expect(COMPACTION_RESUME_PREAMBLE).toMatch(/let the user know/i);
-    expect(COMPACTION_RESUME_PREAMBLE).toMatch(/continue the conversation/i);
+  });
+
+  // Regression: screenshots on topic 6795 (2026-04-20) showed two failure
+  // modes on the 0.28.52 preamble. Pin them down so they can't come back.
+  describe('preamble guardrails', () => {
+    it('prescribes calm acknowledgment phrasing (not open-ended "let the user know")', () => {
+      // The open-ended phrasing produced alarming self-narration like
+      // "I lost track of what we were working on" on active sessions.
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/paused for context compaction/i);
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/resumed/i);
+    });
+
+    it('explicitly forbids "lost track" / "got lost" / "got confused" self-narration', () => {
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/lost track/i);
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/got lost/i);
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/got confused/i);
+      // Verify they appear as prohibitions, not descriptions.
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/do not|don't/i);
+    });
+
+    it('directs the agent to respond to the user\'s most recent message', () => {
+      // Without this, the recovered agent defaults to status-summary reflex.
+      // Topic 6795 / Bob thread showed the user say "Your call" and the agent
+      // re-offer the same two choices and hand "Your call" back — ping-pong.
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/most recent message/i);
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/your call|you decide|delegated/i);
+      // Must explicitly forbid the status-summary + re-offer reflex.
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/status summary/i);
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/re-offer|re offer/i);
+    });
+
+    it('instructs the agent to assume continuity (not treat recovery as a fresh start)', () => {
+      expect(COMPACTION_RESUME_PREAMBLE).toMatch(/continuity|carry forward|work-in-progress/i);
+    });
+
+    it('places the calm-acknowledgment instruction BEFORE the respond-to-last-message instruction', () => {
+      // Order matters: the first sentence the agent emits must be the calm
+      // compaction acknowledgment. If the "respond to most recent message"
+      // instruction came first, the agent could skip the acknowledgment
+      // entirely. Topic 6795 Mew screenshot is exactly this failure.
+      const ackIdx = COMPACTION_RESUME_PREAMBLE.search(/paused for context compaction/i);
+      const respondIdx = COMPACTION_RESUME_PREAMBLE.search(/most recent message/i);
+      expect(ackIdx).toBeGreaterThanOrEqual(0);
+      expect(respondIdx).toBeGreaterThan(ackIdx);
+    });
   });
 });
 
@@ -109,6 +151,24 @@ describe('prepareInjectionText', () => {
     const filepath = match![0];
     expect(fs.existsSync(filepath)).toBe(true);
     expect(fs.readFileSync(filepath, 'utf-8')).toBe(payload);
+  });
+
+  it('file-reference stub carries the same tone + intent guardrails as the inline preamble', () => {
+    // The two branches (under threshold vs over) must give the agent the
+    // same instructions — otherwise long-context recoveries fail in ways
+    // short-context ones don't. Regression anchor: topic 6795 screenshots.
+    const payload = 'x'.repeat(COMPACTION_RESUME_FILE_THRESHOLD + 100);
+    const out = prepareInjectionText(payload, 'test', 42, { tmpDir });
+    // Prescribed acknowledgment
+    expect(out).toMatch(/paused for context compaction/i);
+    // Forbids the alarming self-narration
+    expect(out).toMatch(/lost track/i);
+    expect(out).toMatch(/got lost/i);
+    // Directs answering the user's most recent message
+    expect(out).toMatch(/most recent message/i);
+    expect(out).toMatch(/your call|you decide|delegated/i);
+    // Forbids status-summary + re-offer reflex
+    expect(out).toMatch(/status summary/i);
   });
 
   it('respects a custom threshold', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,53 +1,44 @@
 # Upgrade Guide — vNEXT
 
 <!-- bump: patch -->
-<!-- Valid values: patch, minor, major -->
-<!-- patch = bug fixes, refactors, test additions, doc updates -->
-<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
-<!-- major = breaking changes to existing APIs or behavior -->
 
 ## What Changed
 
-<!-- Describe what changed technically. What new features, APIs, behavioral changes? -->
-<!-- Write this for the AGENT — they need to understand the system deeply. -->
+Tightens the instruction prompt injected into a session after context compaction. Two empirical failure modes on active sessions (topic 6795, 2026-04-20) drove this change:
+
+1. **Tone failure**: recovered agents self-narrated compaction as "I lost track of what we were working on" / "I got lost for a second" — alarming phrasing for what was a routine pause-and-resume. The agent had full context; the phrasing was the issue.
+2. **Intent failure**: when the user's last message was a delegated decision ("Your call"), recovered agents regenerated a status summary and re-offered the same options — handing "Your call" back to the user for an infinite ping-pong.
+
+Both traced to a single loose line in `COMPACTION_RESUME_PREAMBLE`: "Briefly let the user know compaction occurred, then continue the conversation naturally." Open-ended "let the user know" produced free-form alarming narration; "continue naturally" triggered the status-summary reflex.
+
+Fix: `COMPACTION_RESUME_PREAMBLE` in `src/messaging/shared/compactionResumePayload.ts` now:
+
+- Prescribes the acknowledgment phrasing: "your session paused for context compaction and has now resumed." Explicitly forbids "lost track," "got lost," "got confused," "lost your place."
+- Directs the agent to respond to the user's **most recent message** — answer questions, make delegated decisions, do NOT reconstruct a generic status summary or re-offer options already delegated back.
+- Instructs the agent to assume continuity with any in-progress work in the context block.
+
+The over-threshold (file-reference) branch in `prepareInjectionText` carries the same guardrails, so long-context recoveries get the same instruction as short ones.
+
+No change to `findLastRealMessage` (0.28.51), `isSystemOrProxyMessage` (0.28.51), `formatContextForSession` (0.28.52), or any other compaction-recovery plumbing. Pure preamble text change + 7 new regression tests (18 total on the file).
 
 ## What to Tell Your User
 
-<!-- Write talking points the agent should relay to their user. -->
-<!-- This should be warm, conversational, user-facing — not a changelog. -->
-<!-- Focus on what THEY can now do, not internal plumbing. -->
-<!--                                                                    -->
-<!-- PROHIBITED in this section (will fail validation):                 -->
-<!--   camelCase config keys: silentReject, maxRetries, telegramNotify -->
-<!--   Inline code backtick references like silentReject: false        -->
-<!--   Fenced code blocks                                              -->
-<!--   Instructions to edit files or run commands                      -->
-<!--                                                                    -->
-<!-- CORRECT style: "I can turn that on for you" not "set X to false"  -->
-<!-- The agent relays this to their user — keep it human.              -->
-
-- **[Feature name]**: "[Brief, friendly description of what this means for the user]"
+- **Calmer compaction recoveries**: "When I pause to compress older parts of our conversation and come back, I won't say alarming things like 'I lost track' or 'I got confused' — because I didn't. It's a routine pause, and I'll just tell you that."
+- **No more ping-pong on delegated decisions**: "If you hand a decision back to me and I happen to pause for compaction right after, when I come back I'll actually make the call instead of re-offering you the same choices."
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| [Capability] | [Endpoint, command, or "automatic"] |
+| Tighter compaction-recovery tone | Automatic — applies to every session recovery on 0.28.66+ |
 
 ## Evidence
 
-<!-- REQUIRED if this release claims to fix a bug. -->
-<!-- Unit tests passing is NOT evidence. Provide ONE of: -->
-<!--   (a) Reproduction steps + observed before/after on a live system. -->
-<!--       Include log excerpts, observed command output, or behavior -->
-<!--       description. Make it specific enough that a future reader can -->
-<!--       re-run it and see the same thing. -->
-<!--   (b) "Not reproducible in dev — [concrete reason]" if the failure -->
-<!--       mode truly can't be exercised locally (race conditions, -->
-<!--       event-driven paths requiring external signals, etc). -->
-<!--                                                                 -->
-<!-- If this release doesn't claim a bug fix (pure feature / refactor), -->
-<!-- leave this section blank or delete it — it's only enforced when -->
-<!-- "What Changed" describes a fix. -->
+Reproduction: topic 6795 on 2026-04-20, two screenshots at ~12:04 PM and ~12:12 PM showing both failure modes on active sessions running 0.28.52.
 
-[Describe reproduction + verified fix, OR "Not reproducible in dev — [concrete reason]"]
+- Mew topic (session-robustness): recovered agent opened with "Quick heads-up: I lost track of what we were working on for a second, but I found my notes and caught back up" — user flagged as alarming.
+- Bob topic (instar-agent-robustness): user had said "Your call." Recovered agent's response ended with "Your call." on the same two options — infinite delegation ping-pong.
+
+Root cause traced to the open-ended phrasing of `COMPACTION_RESUME_PREAMBLE` in 0.28.52. After the fix in 0.28.66, the preamble explicitly prohibits the alarming self-narration phrases and explicitly requires responding to the user's most recent message (including making delegated decisions). 18 unit tests pin the invariants (presence, order, prohibition language, file-reference branch parity).
+
+Cannot reproduce the end-to-end tone failure in an automated dev test without spinning up a real compaction event, which requires a long-running session — the unit tests are the strongest evidence achievable without waiting for a natural compaction in an active session. Live verification will come from the next compaction on the affected topics once the hot-patch lands.

--- a/upgrades/side-effects/0.28.66.md
+++ b/upgrades/side-effects/0.28.66.md
@@ -1,0 +1,130 @@
+# Side-Effects Review — compaction-recovery preamble tightening
+
+**Version / slug:** `0.28.66`
+**Date:** `2026-04-20`
+**Author:** `echo`
+**Second-pass reviewer:** `required — compaction / session-lifecycle surface`
+
+## Summary of the change
+
+Rewrites the `COMPACTION_RESUME_PREAMBLE` string in `src/messaging/shared/compactionResumePayload.ts` and the mirror instruction in `prepareInjectionText`'s over-threshold branch. No code-flow change, no new helper, no new decision point — the change is entirely in the text of the instruction a compaction-recovered agent reads on wake-up. Fixes two empirically observed failure modes on topic 6795 (2026-04-20): (a) agents self-narrating compaction as "I lost track / got lost / got confused" instead of a calm "paused for context compaction, now resumed"; (b) agents reconstructing a generic status-summary + re-offering options the user had already delegated back (the "Your call → Your call" ping-pong). Tests added in `tests/unit/compactionResumePayload.test.ts` pin the two invariants on both the inline and file-reference branches.
+
+## Decision-point inventory
+
+- `COMPACTION_RESUME_PREAMBLE` (text fed to recovered agent) — **modify** — tightens instruction content; no change to when or how the preamble is emitted.
+- `prepareInjectionText` over-threshold branch (text fed to recovered agent when payload > 500 chars) — **modify** — same tightening, applied to the file-reference variant so both branches give the agent the same guardrails.
+- No runtime gate, filter, or authority is added, removed, or modified. The recovered agent remains the only authority; this change is pure input to it.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. The change is instruction text. The recovered agent may choose to phrase its compaction acknowledgment in a way that still uses one of the forbidden phrases ("lost track," "got lost," "got confused") — but the preamble can only ask it not to; there is no downstream check that rejects or rewrites its output.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+No block/allow surface — under-block not applicable. Known residual risks:
+- Agents may invent new alarming phrasings not covered by the explicit prohibitions (e.g. "I drew a blank," "I lost the thread"). The preamble addresses this by also prescribing the positive phrasing ("paused for context compaction and has now resumed"), but compliance is still LLM-discretion.
+- Agents may still reconstruct status summaries when the user's last message is genuinely ambiguous (not a directive, not a question). The preamble cannot solve ambiguity; it only forbids summary-reflex when the user's last message was a delegated decision.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The preamble is the only layer where this content can live — it is the one piece of text guaranteed to be in the recovered agent's context on wake-up. Alternatives considered and rejected:
+- **Detector on the recovered agent's outbound message** (match "lost track" and rewrite): this is exactly the brittle-detector-with-authority anti-pattern the signal-vs-authority doctrine forbids. Also, rewriting the agent's message would distort its voice and break tone-gate compatibility.
+- **Coaching via MEMORY.md**: memory is not guaranteed loaded early enough on recovery, and this fix must work for first-run agents too.
+- **Post-compaction reflection hook**: fires after the first response, too late to prevent the tone failure the user sees.
+
+The preamble is the correct layer: it's instruction-to-the-authority, not authority-itself.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] **No — this change has no block/allow surface.**
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic.
+
+This change is text fed to an LLM-backed authority (the recovered agent). It does not filter, reject, or gate any input or output. The authority structure is unchanged. Compliance is trivially satisfied: detectors remain detectors, authorities remain authorities, and the preamble is an instruction INPUT to an existing authority.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** No. The preamble is the only text ever injected in this code path; nothing else injects into the same byte-range.
+- **Double-fire:** No. `buildCompactionResumePayload` is called once per compaction recovery event; `prepareInjectionText` is called once per payload. Both changes alter static text, not call-count.
+- **Races:** No. The function is a pure string builder. No shared mutable state.
+- **Feedback loops:** Indirect only. The recovered agent's response (shaped by the preamble) is seen by the user and becomes part of the next topic context, but this is normal conversational loop and not a self-reinforcing system.
+- **Adjacent compaction infrastructure:** `findLastRealMessage` (0.28.51), `isSystemOrProxyMessage` (0.28.51), and `formatContextForSession` (0.28.52) are all unchanged. The preamble text is independent of which messages are selected; this change only affects how the agent is instructed to respond to them.
+- **Tone gate interaction:** The preamble is not itself sent through the tone gate (it's injected into the agent's context, not emitted as a user-facing message). The agent's RESPONSE to the preamble is sent through the tone gate, as normal. The forbidden phrases ("lost track," etc.) in the preamble are inside a prohibition instruction ("Do NOT say you..."); the tone gate parses agent output, not its input context, so no collision.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** No effect. Each agent's recovery is independent.
+- **Other users of the install base:** Yes — every instar user running 0.28.66+ will see recovered agents produce a different tone on compaction. This is the intended improvement. No breaking change to message format.
+- **External systems (Telegram, Slack, GitHub):** No. The output format is still a single text message in the agent's voice.
+- **Persistent state:** None. Text change only.
+- **Timing / runtime conditions:** No. Purely static text; no new async, no new timeouts.
+- **File-reference branch:** when payload > 500 chars, a temp file path appears in the recovered agent's context as before. File format unchanged; only the surrounding instruction text is tightened.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+- **Hot-fix release:** revert the single file (`src/messaging/shared/compactionResumePayload.ts`) + the added tests. Ship as 0.28.67. No code-path change to untangle.
+- **Data migration:** None. No persistent state touched.
+- **Agent state repair:** None. Live agents pick up the new preamble on next compaction event; if reverted, they pick up the old one on the one after. No stuck-state risk.
+- **User visibility during rollback:** A single recovery event in flight might land on mixed wording. Zero-downtime revert.
+
+Total rollback cost: one revert commit, one patch release. Lowest possible risk tier.
+
+---
+
+## Conclusion
+
+The change is low-risk, surgical, and addresses two specific user-observed failures with the minimum possible surface area — instruction text in one file, plus a mirrored update in the same file's over-threshold branch. No decision points are added, no gate logic is modified, no authority is reshaped. Signal-vs-authority compliance is trivially satisfied (no block/allow surface). Rollback is one revert.
+
+One residual risk: LLM compliance with prescribed tone language is not guaranteed, only strongly directed. If telemetry shows the new preamble still produces alarming narrations in practice, the next iteration would be to fold compaction-recovery outputs through a dedicated lightweight tone-checker before emit — but that is a future change, not a reason to block this one.
+
+Clear to ship as 0.28.66.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** general-purpose subagent (independent read, did not see the author's reasoning)
+**Independent read of the artifact: concur**
+
+Concerns raised (non-blocking):
+
+- Test strength: initial suite asserted magic-string presence only, not order. Addressed in this pass by adding a test that pins "calm acknowledgment appears before respond-to-most-recent-message" in `COMPACTION_RESUME_PREAMBLE` — the order was itself a core part of the failure mode.
+- Prompt-injection surface: the user's last message was already concatenated into the recovered agent's context via `formatInlineHistory` (pre-existing). The new preamble's directive to "act on a delegated decision" slightly raises the stakes of a hostile last message. Residual risk, not a new surface. The recovered agent remains the authority and retains judgment — same trust boundary as any other user-input-in-context scenario. Accepted as pre-existing, not introduced.
+- i18n / backward-compat: instar is English-only today; compaction payloads are transient (not persisted across versions), so no in-flight compatibility concern. Noted for completeness.
+
+Reviewer verdict: clear to ship.
+
+---
+
+## Evidence pointers
+
+- Targeted unit tests: `tests/unit/compactionResumePayload.test.ts` — 17 tests, 42 combined with `isSystemOrProxyMessage.test.ts`, all green in worktree.
+- Failure-mode source: topic 6795 screenshots 2026-04-20 (Mew / session-robustness at 12:12 PM; Bob / instar-agent-robustness at 12:04 PM).
+- Prior art in this line: 0.28.51 (classifier fix), 0.28.52 (rich context payload). This is the third tightening in the compaction-recovery lineage.


### PR DESCRIPTION
## Summary

- Tightens `COMPACTION_RESUME_PREAMBLE` with three prescribed instructions: calm acknowledgment ("paused for context compaction and has now resumed"), respond-to-most-recent-message (making delegated decisions rather than re-offering them), and continuity assumption.
- Explicitly forbids alarming self-narration ("lost track", "got lost", "got confused", "lost your place").
- Mirrors guardrails in `prepareInjectionText`'s over-threshold branch so long-context recoveries get identical instructions.

Driven by two empirical failure modes on topic 6795 (2026-04-20): alarming self-narration on a routine pause, and a "Your call -> Your call" ping-pong when the user had already delegated the decision. Root cause: open-ended instruction text in the 0.28.52 preamble.

Spec: `docs/specs/compaction-preamble-tone-and-intent.md` (approved 2026-04-20)
Side-effects review: `upgrades/side-effects/0.28.66.md` (second-pass reviewer concurred)

## Test plan

- [x] 18 unit tests on `tests/unit/compactionResumePayload.test.ts` — all green
- [x] Order invariant pinned (calm acknowledgment appears before respond-to-most-recent)
- [x] File-reference branch parity pinned
- [ ] Live verification: next natural compaction on topic 6795 shows new preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)