### PR TITLE
fix(native-module): source-build fallback + loop-breaker for better-sqlite3 self-heal

### DIFF
--- a/scripts/fix-better-sqlite3.cjs
+++ b/scripts/fix-better-sqlite3.cjs
@@ -2,20 +2,37 @@
 /**
  * fix-better-sqlite3.cjs
  *
- * Ensures better-sqlite3 has the correct native binary for the current Node.js version.
- * prebuild-install sometimes downloads the wrong ABI version (especially on Node 25+).
- * This script detects the mismatch and fetches the correct prebuild from GitHub.
+ * Ensures better-sqlite3 has a working native binary for the current Node.js
+ * version. Strategy, in order:
+ *
+ *   1. Test the current binary. If it works, stop.
+ *   2. If a prior attempt on THIS (version, MODULE_VERSION, platform, arch)
+ *      tuple already exhausted both prebuild AND source, exit 1 immediately.
+ *      Prevents the "loop forever re-downloading the same broken prebuild"
+ *      failure mode observed on Dawn's machine 2026-04-20 where launchd
+ *      respawn + this script kept pulling a bad tarball.
+ *   3. If no prior attempt for this tuple, try the prebuild from GitHub.
+ *   4. If the prebuild download fails OR the downloaded prebuild still fails
+ *      to load, fall back to a source build via
+ *      `npm rebuild better-sqlite3 --build-from-source`. node-gyp compiles
+ *      against the current Node's headers, so it works for any Node version
+ *      that has headers + a toolchain available.
+ *   5. If source build also fails, mark tuple as `source-failed` and exit 1.
+ *
+ * Attempt state lives at <better-sqlite3>/.instar-fix-state.json and is
+ * keyed by (betterSqliteVersion, MODULE_VERSION, platform, arch) so a Node
+ * upgrade naturally invalidates stale state.
  */
 
 const { execSync } = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const MODULE_VERSION = process.versions.modules;
 const ARCH = process.arch;
 const PLATFORM = process.platform;
 
-// Find better-sqlite3 location (works with both pnpm and npm node_modules)
 function findBetterSqlite3() {
   try {
     const resolved = require.resolve('better-sqlite3/package.json');
@@ -30,15 +47,136 @@ function getBetterSqliteVersion(pkgDir) {
   return pkg.version;
 }
 
+/** Spawn a fresh node process to avoid any require-cache contamination. */
 function testBinary(pkgDir) {
-  // Spawn a completely fresh node process to avoid any require cache
   try {
     execSync(
-      `node -e "const Database = require('better-sqlite3'); const db = new Database(':memory:'); db.close();"`,
-      { stdio: 'pipe', timeout: 5000, cwd: pkgDir }
+      `node -e "const Database = require('better-sqlite3'); const db = new Database(':memory:'); db.pragma('journal_mode = WAL'); db.close();"`,
+      { stdio: 'pipe', timeout: 10000, cwd: pkgDir }
     );
     return true;
   } catch {
+    return false;
+  }
+}
+
+function stateFilePath(pkgDir) {
+  return path.join(pkgDir, '.instar-fix-state.json');
+}
+
+function tupleKey(betterSqliteVersion) {
+  return `${betterSqliteVersion}|${MODULE_VERSION}|${PLATFORM}|${ARCH}`;
+}
+
+function readState(pkgDir) {
+  try {
+    const raw = fs.readFileSync(stateFilePath(pkgDir), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeState(pkgDir, state) {
+  try {
+    fs.writeFileSync(stateFilePath(pkgDir), JSON.stringify(state, null, 2));
+  } catch (err) {
+    // Best-effort; don't block the fix on state-write failure.
+    console.warn(`[fix-better-sqlite3] failed to persist state: ${err.message}`);
+  }
+}
+
+function recordAttempt(pkgDir, existing, betterSqliteVersion, step, result) {
+  const key = tupleKey(betterSqliteVersion);
+  const state = existing && existing.key === key
+    ? existing
+    : {
+        key,
+        moduleVersion: MODULE_VERSION,
+        platform: PLATFORM,
+        arch: ARCH,
+        betterSqliteVersion,
+        attempts: [],
+      };
+  state.attempts.push({ at: new Date().toISOString(), step, result });
+  state.lastResult = result;
+  state.lastStep = step;
+  writeState(pkgDir, state);
+  return state;
+}
+
+/** Download + extract prebuild from GitHub. Returns true on success. */
+function tryPrebuild(pkgDir, betterSqliteVersion) {
+  const prebuildName =
+    `better-sqlite3-v${betterSqliteVersion}-node-v${MODULE_VERSION}-${PLATFORM}-${ARCH}.tar.gz`;
+  const url =
+    `https://github.com/WiseLibs/better-sqlite3/releases/download/v${betterSqliteVersion}/${prebuildName}`;
+  const tmpFile = path.join(os.tmpdir(), prebuildName);
+  const buildDir = path.join(pkgDir, 'build');
+
+  try {
+    console.log(`[fix-better-sqlite3] Downloading ${url}`);
+    execSync(`curl -L -f -o "${tmpFile}" "${url}"`, { stdio: 'pipe', timeout: 30000 });
+
+    if (fs.existsSync(buildDir)) fs.rmSync(buildDir, { recursive: true });
+    execSync(`tar xzf "${tmpFile}" -C "${pkgDir}"`, { stdio: 'pipe' });
+    return true;
+  } catch (err) {
+    console.warn(`[fix-better-sqlite3] prebuild download/extract failed: ${err.message}`);
+    return false;
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch {}
+  }
+}
+
+/** Locate npm's CLI entry without needing a shell. */
+function findNpmCli() {
+  const nodeDir = path.dirname(process.execPath);
+  const candidates = [
+    path.resolve(nodeDir, '..', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    '/opt/homebrew/lib/node_modules/npm/bin/npm-cli.js',
+    '/usr/local/lib/node_modules/npm/bin/npm-cli.js',
+    '/usr/lib/node_modules/npm/bin/npm-cli.js',
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+/**
+ * Compile better-sqlite3 from source via node-gyp. Runs against the current
+ * Node.js headers; works for any Node version with headers + a toolchain.
+ */
+function trySourceBuild(pkgDir) {
+  const npmCli = findNpmCli();
+  if (!npmCli) {
+    console.warn('[fix-better-sqlite3] cannot locate npm CLI for source build');
+    return false;
+  }
+  // `npm rebuild` needs to be run from the nearest node_modules parent for
+  // correct resolution. Walk up from pkgDir to find it.
+  let rebuildCwd = pkgDir;
+  const nmIdx = pkgDir.lastIndexOf(`${path.sep}node_modules${path.sep}`);
+  if (nmIdx >= 0) {
+    rebuildCwd = pkgDir.slice(0, nmIdx);
+  }
+  try {
+    console.log(`[fix-better-sqlite3] Source-building better-sqlite3 in ${rebuildCwd} (~30s)`);
+    execSync(
+      `"${process.execPath}" "${npmCli}" rebuild better-sqlite3 --build-from-source`,
+      {
+        cwd: rebuildCwd,
+        stdio: 'pipe',
+        timeout: 180_000, // 3 min — source builds on older hardware are slow
+        env: { ...process.env, npm_config_build_from_source: 'true' },
+      }
+    );
+    return true;
+  } catch (err) {
+    console.warn(`[fix-better-sqlite3] source build failed: ${err.message}`);
     return false;
   }
 }
@@ -47,54 +185,82 @@ function main() {
   const pkgDir = findBetterSqlite3();
   if (!pkgDir) {
     console.log('[fix-better-sqlite3] better-sqlite3 not found, skipping.');
-    return;
+    return 0;
   }
 
-  const version = getBetterSqliteVersion(pkgDir);
-  console.log(`[fix-better-sqlite3] Found better-sqlite3@${version} at ${pkgDir}`);
-  console.log(`[fix-better-sqlite3] Node MODULE_VERSION=${MODULE_VERSION}, arch=${ARCH}, platform=${PLATFORM}`);
+  const betterSqliteVersion = getBetterSqliteVersion(pkgDir);
+  console.log(`[fix-better-sqlite3] Found better-sqlite3@${betterSqliteVersion} at ${pkgDir}`);
+  console.log(
+    `[fix-better-sqlite3] Node MODULE_VERSION=${MODULE_VERSION}, arch=${ARCH}, platform=${PLATFORM}`
+  );
 
-  // Test if current binary works
   if (testBinary(pkgDir)) {
     console.log('[fix-better-sqlite3] Native binary is working correctly.');
-    return;
+    return 0;
   }
 
-  console.log('[fix-better-sqlite3] Native binary mismatch detected. Fetching correct prebuild...');
+  const existing = readState(pkgDir);
+  const currentKey = tupleKey(betterSqliteVersion);
 
-  const prebuildName = `better-sqlite3-v${version}-node-v${MODULE_VERSION}-${PLATFORM}-${ARCH}.tar.gz`;
-  const url = `https://github.com/WiseLibs/better-sqlite3/releases/download/v${version}/${prebuildName}`;
-  const tmpFile = path.join(require('os').tmpdir(), prebuildName);
-  const buildDir = path.join(pkgDir, 'build');
-
-  try {
-    // Download
-    console.log(`[fix-better-sqlite3] Downloading ${url}`);
-    execSync(`curl -L -f -o "${tmpFile}" "${url}"`, { stdio: 'pipe', timeout: 30000 });
-
-    // Clean old build and extract
-    if (fs.existsSync(buildDir)) {
-      fs.rmSync(buildDir, { recursive: true });
-    }
-    execSync(`tar xzf "${tmpFile}" -C "${pkgDir}"`, { stdio: 'pipe' });
-
-    // Verify
-    if (testBinary(pkgDir)) {
-      console.log('[fix-better-sqlite3] Successfully installed correct prebuild.');
-    } else {
-      console.error('[fix-better-sqlite3] WARNING: Installed prebuild but it still fails to load.');
-      console.error('[fix-better-sqlite3] You may need to use a different Node.js version.');
-      process.exit(1);
-    }
-  } catch (err) {
-    console.error(`[fix-better-sqlite3] Failed to fetch prebuild: ${err.message}`);
-    console.error(`[fix-better-sqlite3] No prebuild available for node-v${MODULE_VERSION}-${PLATFORM}-${ARCH}`);
-    console.error('[fix-better-sqlite3] Try using Node 22 LTS or Node 24 instead.');
-    process.exit(1);
-  } finally {
-    // Cleanup temp file
-    try { fs.unlinkSync(tmpFile); } catch {}
+  // Loop-breaker: if prior attempts on this exact tuple have already
+  // exhausted both prebuild AND source, don't try again.
+  if (existing && existing.key === currentKey && existing.lastResult === 'source-failed') {
+    console.error(
+      '[fix-better-sqlite3] prior attempt on this (better-sqlite3, Node, platform, arch) ' +
+      'tuple exhausted both prebuild and source build. Not retrying. Remove ' +
+      `${stateFilePath(pkgDir)} to force another attempt.`
+    );
+    return 1;
   }
+
+  // Step A: prebuild (skip if a prior attempt on this tuple already failed it)
+  const priorPrebuildFailed =
+    existing && existing.key === currentKey && existing.lastResult === 'prebuild-failed';
+
+  if (!priorPrebuildFailed) {
+    const prebuildTried = tryPrebuild(pkgDir, betterSqliteVersion);
+    if (prebuildTried && testBinary(pkgDir)) {
+      recordAttempt(pkgDir, existing, betterSqliteVersion, 'prebuild', 'prebuild-ok');
+      console.log('[fix-better-sqlite3] Prebuild installed and verified.');
+      return 0;
+    }
+    if (prebuildTried) {
+      console.warn('[fix-better-sqlite3] Prebuild installed but still fails to load.');
+    }
+    recordAttempt(pkgDir, existing, betterSqliteVersion, 'prebuild', 'prebuild-failed');
+  } else {
+    console.log(
+      '[fix-better-sqlite3] Prior prebuild attempt failed for this tuple; skipping to source build.'
+    );
+  }
+
+  // Step B: source build fallback
+  if (trySourceBuild(pkgDir) && testBinary(pkgDir)) {
+    recordAttempt(pkgDir, readState(pkgDir), betterSqliteVersion, 'source', 'source-ok');
+    console.log('[fix-better-sqlite3] Source build succeeded and binary is working.');
+    return 0;
+  }
+  recordAttempt(pkgDir, readState(pkgDir), betterSqliteVersion, 'source', 'source-failed');
+  console.error(
+    '[fix-better-sqlite3] Both prebuild and source-build paths failed. ' +
+    'SQLite subsystems will degrade to JSONL-only mode. ' +
+    'Try: 1) install Xcode command-line tools (xcode-select --install on macOS), ' +
+    '2) ensure python3 + make are on PATH, 3) check Node version compatibility.'
+  );
+  return 1;
 }
 
-main();
+if (require.main === module) {
+  process.exit(main());
+}
+
+module.exports = {
+  main,
+  tupleKey,
+  readState,
+  writeState,
+  recordAttempt,
+  testBinary,
+  findBetterSqlite3,
+  findNpmCli,
+};

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-04-20T23:21:39.225Z",
-  "instarVersion": "0.28.65",
+  "generatedAt": "2026-04-21T02:18:50.807Z",
+  "instarVersion": "0.28.67",
   "entryCount": 186,
   "entries": {
     "hook:session-start": {
@@ -376,7 +376,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -384,7 +384,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -728,7 +728,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "565e08212873eea431b18217daf9041f21ddc94f3f2b38732f4a0e28585d503f",
+      "contentHash": "94091ba4187c5ce71ffc5a8a2bbbd8086e95fa2f1fefcba832e99420df8fb48e",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -736,7 +736,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:setup": {
@@ -744,7 +744,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:add": {
@@ -752,7 +752,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:backup": {
@@ -760,7 +760,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:git": {
@@ -768,7 +768,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:memory": {
@@ -776,7 +776,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:knowledge": {
@@ -784,7 +784,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:semantic": {
@@ -792,7 +792,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:intent": {
@@ -800,7 +800,7 @@
       "type": "cli-command",
       "domain": "intent",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:feedback": {
@@ -808,7 +808,7 @@
       "type": "cli-command",
       "domain": "feedback",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:server": {
@@ -816,7 +816,7 @@
       "type": "cli-command",
       "domain": "server",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:status": {
@@ -824,7 +824,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:user": {
@@ -832,7 +832,7 @@
       "type": "cli-command",
       "domain": "users",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:relationship": {
@@ -840,7 +840,7 @@
       "type": "cli-command",
       "domain": "relationships",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:job": {
@@ -848,7 +848,7 @@
       "type": "cli-command",
       "domain": "scheduling",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:lifeline": {
@@ -856,7 +856,7 @@
       "type": "cli-command",
       "domain": "communication",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:list": {
@@ -864,7 +864,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:autostart": {
@@ -872,7 +872,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:migrate": {
@@ -880,7 +880,7 @@
       "type": "cli-command",
       "domain": "updates",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:machines": {
@@ -888,7 +888,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:whoami": {
@@ -896,7 +896,7 @@
       "type": "cli-command",
       "domain": "identity",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:pair": {
@@ -904,7 +904,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:join": {
@@ -912,7 +912,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:wakeup": {
@@ -920,7 +920,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:leave": {
@@ -928,7 +928,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:doctor": {
@@ -936,7 +936,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:review": {
@@ -944,7 +944,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:nuke": {
@@ -952,7 +952,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "cli:playbook": {
@@ -960,7 +960,7 @@
       "type": "cli-command",
       "domain": "context",
       "sourcePath": "src/cli.ts",
-      "contentHash": "06f6b50263b88d615b6e5b09b7c3b9ba0226a020a3cdec7527a213940ec49712",
+      "contentHash": "3c2ee870e6867d0d4671d1eaec6c58380ce944c631ba8dd34e551e9aa6b2466a",
       "since": "2025-01-01"
     },
     "template:build-stop-hook.sh": {
@@ -1464,7 +1464,7 @@
       "type": "subsystem",
       "domain": "communication",
       "sourcePath": "src/lifeline/TelegramLifeline.ts",
-      "contentHash": "3f3aed5e112a4117ac25caac145aeb1f3c29ed6bf60b9b7c73604b4ed19c4817",
+      "contentHash": "c9c7fd786bbab2bfefff986a3882a6267b6d5c1f2efb6a386626e65eeefc0fb8",
       "since": "2025-01-01"
     },
     "subsystem:orphan-process-reaper": {

--- a/tests/unit/fix-better-sqlite3-state.test.ts
+++ b/tests/unit/fix-better-sqlite3-state.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the attempt-tracking state in scripts/fix-better-sqlite3.cjs.
+ * Protects the loop-breaker guarantee: once a tuple has exhausted both
+ * prebuild AND source, the next invocation must short-circuit instead of
+ * re-downloading the same broken prebuild on every launchd respawn.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+// Load the .cjs via createRequire so ESM doesn't choke on the non-module format.
+const fixModule: {
+  tupleKey: (v: string) => string;
+  readState: (dir: string) => unknown;
+  writeState: (dir: string, state: unknown) => void;
+  recordAttempt: (
+    dir: string,
+    existing: unknown,
+    version: string,
+    step: string,
+    result: string,
+  ) => { key: string; attempts: Array<{ step: string; result: string }>; lastResult: string };
+} = require('../../scripts/fix-better-sqlite3.cjs');
+
+let tmpPkg: string;
+
+beforeEach(() => {
+  tmpPkg = fs.mkdtempSync(path.join(os.tmpdir(), 'fix-bs3-'));
+});
+
+afterEach(() => {
+  try {
+    if (fs.existsSync(tmpPkg)) fs.rmSync(tmpPkg, { recursive: true, force: true });
+  } catch { /* best effort */ }
+});
+
+describe('fix-better-sqlite3 state machine', () => {
+  it('tupleKey includes version, moduleVersion, platform, and arch', () => {
+    const key = fixModule.tupleKey('11.3.0');
+    // Should not be empty and must contain the version.
+    expect(key).toContain('11.3.0');
+    expect(key.split('|')).toHaveLength(4);
+  });
+
+  it('readState returns null when no state file exists', () => {
+    expect(fixModule.readState(tmpPkg)).toBeNull();
+  });
+
+  it('readState returns null on corrupt JSON', () => {
+    fs.writeFileSync(path.join(tmpPkg, '.instar-fix-state.json'), '{not: valid');
+    expect(fixModule.readState(tmpPkg)).toBeNull();
+  });
+
+  it('recordAttempt creates a new state with the correct tuple key', () => {
+    const state = fixModule.recordAttempt(tmpPkg, null, '11.3.0', 'prebuild', 'prebuild-ok');
+    expect(state.key).toBe(fixModule.tupleKey('11.3.0'));
+    expect(state.attempts).toHaveLength(1);
+    expect(state.attempts[0].step).toBe('prebuild');
+    expect(state.attempts[0].result).toBe('prebuild-ok');
+    expect(state.lastResult).toBe('prebuild-ok');
+  });
+
+  it('recordAttempt appends to existing state when the tuple key matches', () => {
+    const first = fixModule.recordAttempt(tmpPkg, null, '11.3.0', 'prebuild', 'prebuild-failed');
+    const second = fixModule.recordAttempt(tmpPkg, first, '11.3.0', 'source', 'source-ok');
+    expect(second.attempts).toHaveLength(2);
+    expect(second.lastResult).toBe('source-ok');
+    // Persisted to disk.
+    const onDisk = fixModule.readState(tmpPkg) as typeof second;
+    expect(onDisk.attempts).toHaveLength(2);
+  });
+
+  it('recordAttempt resets the attempt log when the tuple key changes', () => {
+    const first = fixModule.recordAttempt(tmpPkg, null, '11.3.0', 'prebuild', 'prebuild-failed');
+    expect(first.attempts).toHaveLength(1);
+    // Simulate a different tuple (e.g., bumping better-sqlite3 version) —
+    // caller passes `first` as existing, but the key won't match, so recordAttempt
+    // must start fresh.
+    const second = fixModule.recordAttempt(tmpPkg, first, '11.4.0', 'prebuild', 'prebuild-ok');
+    expect(second.key).not.toBe(first.key);
+    expect(second.attempts).toHaveLength(1);
+    expect(second.lastResult).toBe('prebuild-ok');
+  });
+
+  it('state persists across readState/writeState roundtrip with attempt history intact', () => {
+    const written = fixModule.recordAttempt(tmpPkg, null, '11.3.0', 'prebuild', 'prebuild-failed');
+    const appended = fixModule.recordAttempt(tmpPkg, written, '11.3.0', 'source', 'source-failed');
+    const reloaded = fixModule.readState(tmpPkg) as {
+      key: string;
+      lastResult: string;
+      attempts: Array<{ step: string; result: string }>;
+    };
+    expect(reloaded.key).toBe(appended.key);
+    expect(reloaded.lastResult).toBe('source-failed');
+    expect(reloaded.attempts.map((a) => `${a.step}:${a.result}`)).toEqual([
+      'prebuild:prebuild-failed',
+      'source:source-failed',
+    ]);
+  });
+
+  it('writeState tolerates an unwritable state-file path without throwing', () => {
+    // Point at a directory the caller cannot write to; writeState is best-effort.
+    const unwritable = '/dev/null/blocked';
+    expect(() => fixModule.writeState(unwritable, { key: 'x', attempts: [] })).not.toThrow();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,32 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+`scripts/fix-better-sqlite3.cjs` — the startup self-heal for better-sqlite3 native bindings — now has a source-build fallback and a loop-breaker, closing the "keep redownloading the same broken prebuild forever" failure mode observed on Dawn's machine on 2026-04-20.
+
+**Previously**, the fix script had exactly one strategy: download the matching prebuild from the WiseLibs/better-sqlite3 GitHub release. If the prebuild didn't exist for the current `(better-sqlite3 version, Node MODULE_VERSION, platform, arch)` tuple, or if the downloaded tarball's binary still failed to load, the script exited 1. Under launchd KeepAlive, a crashing server would respawn, re-enter the fix script, redownload the same broken tarball, and fail again — wasting bandwidth and hiding the real problem.
+
+**Now:**
+
+1. **Prebuild attempt** (unchanged) — curl the prebuild, extract, test.
+2. **Source-build fallback** — if the prebuild is missing OR fails to load after install, run `npm rebuild better-sqlite3 --build-from-source`. node-gyp compiles against the local Node's headers and works for any Node version that has headers + a toolchain on PATH.
+3. **Attempt-state tracking** — each fix attempt writes to `<better-sqlite3>/.instar-fix-state.json`, keyed by the `(version, MODULE_VERSION, platform, arch)` tuple. A Node upgrade naturally invalidates stale state.
+4. **Loop-breaker** — if state shows the current tuple has already exhausted both prebuild AND source-build, the script exits 1 immediately without any further network or build activity. Caller (`ensureSqliteBindings` in `src/commands/server.ts`) then degrades to JSONL-only mode instead of crash-looping.
+
+The prebuild path is still attempted first (faster than a source build when it works). Source build is the safety net, not the default.
+
+## Why This Matters
+
+Native-module self-heal is the second self-healing system we're hardening this sprint (the first was Stage B lifeline self-restart). Same pattern: an automated recovery path needs both a primary attempt AND a deterministic terminal condition. Without the loop-breaker, launchd respawn cycles can drown the machine in repeated downloads of a binary we already know is broken. Without the source-build fallback, any Node version without a published prebuild (e.g., fresh major releases) is unrecoverable without manual intervention.
+
+## Test Plan
+
+- [x] `tests/unit/fix-better-sqlite3-state.test.ts` — 8 scenarios covering tuple-key derivation, state read/write roundtrip, attempt append, tuple-change state reset, best-effort write-failure tolerance.
+- [x] CLI smoke-test: `node scripts/fix-better-sqlite3.cjs` on a machine with a valid binary reports "Native binary is working correctly" and exits 0.
+- [ ] Manual verification on a machine with a deliberately-broken prebuild would exercise the full fallback chain (not scripted — requires toolchain).
+
+## Side Effects
+
+See `upgrades/side-effects/native-module-source-build-fallback.md`.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -2,6 +2,16 @@
 
 <!-- bump: patch -->
 
+## Summary of New Capabilities
+
+The better-sqlite3 native-bindings self-heal gains a source-build fallback and a loop-breaker. You'll notice the difference if an install on a fresh Node major version (where no prebuild exists yet) or a machine with a corrupted prebuild now recovers automatically instead of crash-looping. There's no new agent-facing surface — this is all under-the-hood install-time machinery.
+
+## What to Tell Your User
+
+Nothing unless they ask. If they've seen their agent crash-loop on startup with `better-sqlite3` errors in the logs, tell them:
+
+> I patched the startup self-heal. If the native binding is missing or broken, I'll now rebuild it from source instead of redownloading the same broken prebuild over and over. And if both paths fail, I'll stop retrying and degrade to a slower backing store so your agent stays up — you'll see a log line, not a crash loop. You can clear the attempt state and force another try by deleting `<instar-install>/node_modules/better-sqlite3/.instar-fix-state.json`.
+
 ## What Changed
 
 `scripts/fix-better-sqlite3.cjs` — the startup self-heal for better-sqlite3 native bindings — now has a source-build fallback and a loop-breaker, closing the "keep redownloading the same broken prebuild forever" failure mode observed on Dawn's machine on 2026-04-20.

--- a/upgrades/side-effects/native-module-source-build-fallback.md
+++ b/upgrades/side-effects/native-module-source-build-fallback.md
@@ -1,0 +1,86 @@
+# Side-Effects Review — Native-module self-heal source-build fallback + loop-breaker
+
+**Version / slug:** `native-module-source-build-fallback`
+**Date:** `2026-04-21`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (no runtime gate; install-time self-heal with deterministic terminal condition)`
+
+## Summary of the change
+
+`scripts/fix-better-sqlite3.cjs` — the startup self-heal for better-sqlite3 native bindings — gains two things: (1) a source-build fallback via `npm rebuild better-sqlite3 --build-from-source` when the prebuild is missing or the downloaded binary still fails to load, and (2) an attempt-state tracker at `<better-sqlite3>/.instar-fix-state.json`, keyed by `(version, MODULE_VERSION, platform, arch)`, that makes the script short-circuit after it has exhausted both paths on the current tuple. This closes the launchd-respawn-redownload loop seen on Dawn's machine 2026-04-20.
+
+Files touched:
+- `scripts/fix-better-sqlite3.cjs` — rewrite (still CLI-invocable; now also exports pure helpers for unit tests)
+- `tests/unit/fix-better-sqlite3-state.test.ts` — new, 8 scenarios
+- `upgrades/NEXT.md` — new release note
+- `upgrades/side-effects/native-module-source-build-fallback.md` — this artifact
+
+Decision points it interacts with:
+- The caller `ensureSqliteBindings` in `src/commands/server.ts` treats script exit 0 as "bindings are good," non-zero as "degrade to JSONL-only." That contract is unchanged; the script just becomes smarter about when to give up.
+
+## Decision-point inventory
+
+- `fix-better-sqlite3.main()` — modify — adds a source-build branch and a loop-breaker branch. Still returns 0 for "bindings good" and 1 for "give up; degrade."
+- `recordAttempt` / `readState` / `writeState` — add — pure state-file helpers, no runtime gate.
+- `tupleKey` — add — identity function over `(version, MODULE_VERSION, platform, arch)`; used only for state keying.
+- No new block/allow path. No new runtime authority anywhere.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The only "block" in this script is the loop-breaker exit 1 when the current tuple has a `source-failed` marker. Scenarios where that would be wrong:
+
+- **Toolchain installed after a prior failure.** User had no Xcode CLT when source-build last failed, then installed CLT. Script would still short-circuit. Mitigation: the error message explicitly tells the user to remove `<better-sqlite3>/.instar-fix-state.json` to force another attempt. Acceptable — the loop-breaker's raison d'être is preventing crash-loops, and a one-off manual file removal is the right escape valve.
+- **Tuple change across the invocation.** If npm rebuild during the Stage-3 source-build branch mutates the installed `better-sqlite3` version, the tuple key changes and the loop-breaker would not short-circuit. The code compares `existing.key === currentKey` — a mismatch means the prior state is not a bar. Correct by construction.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **Transient network failure during prebuild.** First attempt curl-fails → marked `prebuild-failed` → next startup skips straight to source build even though the prebuild might now be reachable. Acceptable: source build is slower but more reliable; the user's machine benefits from a working binary one way or another.
+- **Partial source build** — if `npm rebuild` exits 0 but produces no usable binary (unlikely; the post-build `testBinary` catches this), we'd record `source-ok` but the binary would still fail at runtime. Mitigated by `testBinary` gating the `source-ok` recording.
+- **Corrupted state file.** `readState` returns `null` on parse error — the script then proceeds as if no prior attempt existed, retrying both paths. Acceptable.
+
+## 3. Level-of-abstraction fit
+
+Right layer. This is install-time / boot-time machinery that's invoked before any runtime subsystem initializes. It doesn't touch any runtime decision point. The state file sits next to the npm package it remediates, not inside `.instar/state/`, because the remediation target IS the node_modules directory — stale state is naturally invalidated whenever npm reinstalls.
+
+The attempt-state tracker is NOT a detector-vs-authority concern because the logic is deterministic and has no brittle pattern-matching: `(version, MODULE_VERSION, platform, arch)` tuple equality + `lastResult === 'source-failed'` check. It's mechanical idempotency, not a classifier.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** `docs/signal-vs-authority.md`
+
+- [x] **No** — this change has no block/allow surface at the runtime-authority layer. The script either ensures the binary works (exit 0) or declares itself exhausted (exit 1). The runtime caller decides what to do with that information (currently: log + degrade to JSONL-only mode).
+
+The loop-breaker's exit 1 is not a "block" in the signal-vs-authority sense — it's a terminal condition on a self-heal attempt, with deterministic inputs (file contents + env snapshot), not a classifier over user/agent behavior.
+
+---
+
+## 5. Interactions
+
+- **Shadowing.** `src/commands/server.ts::ensureSqliteBindings` has a fallback branch that runs `npm rebuild better-sqlite3` directly when the fix script file is absent. The fix script IS present in normal installs, so that branch is only reached in unusual deploys (e.g., scripts/ directory stripped). No change in behavior there.
+- **Shadow-install update.** `src/core/UpdateChecker.ts::applyUpdate` runs `npm rebuild better-sqlite3` under the shadow-install's own node_modules. The fix script's state file lives next to the package, so each shadow install gets its own state. No cross-contamination.
+- **Race with launchd respawn.** Previous failure mode: crash → respawn → same redownload → crash. New behavior: crash → respawn → script reads state, sees `source-failed` → exit 1 → `ensureSqliteBindings` degrades to JSONL-only → server stays up without sqlite. This is the intended outcome.
+- **Concurrency.** `execSync` is synchronous; the script holds a single logical critical section. No two fix scripts should run simultaneously on the same node_modules tree; if they did, the later state-file write wins, which is acceptable (last-writer-wins semantics match the script's own retry behavior).
+
+## 6. External surfaces
+
+- **Network.** Same curl call as before (unchanged URL, same 30 s timeout). Now optionally followed by an npm rebuild which fetches headers via node-gyp the first time. node-gyp downloads Node headers to `~/.node-gyp/` by default — this is npm's well-trodden default path and not a new external surface for instar.
+- **Filesystem.** New state file at `<better-sqlite3>/.instar-fix-state.json`. Written with default permissions (not security-sensitive). Confined to the npm package directory, which is already machine-local and not synced.
+- **No changes visible to other agents, other users, other systems.** Pure local self-heal.
+
+## 7. Rollback cost
+
+Trivial. Revert the PR. Script reverts to single-strategy download-only behavior. `.instar-fix-state.json` files left behind by the new version are ignored by the old version (unknown field); no migration needed. No data loss.
+
+---
+
+## Conclusion
+
+Install-time self-heal improvement. No runtime decision surface. Loop-breaker is the key addition — prevents a diagnosed infinite crash-loop under launchd KeepAlive. Source-build fallback is the reliability addition — covers Node versions without published prebuilds. Both are additive safety; nothing that previously worked will stop working.
+
+Safe to ship.


### PR DESCRIPTION
## Summary

Closes the **launchd respawn → same broken prebuild redownloaded → crash → respawn** loop observed on Dawn's machine 2026-04-20.

Two additions to `scripts/fix-better-sqlite3.cjs`:

1. **Source-build fallback.** When the prebuild is missing or the downloaded binary fails to load, fall back to `npm rebuild better-sqlite3 --build-from-source`. node-gyp compiles against the local Node headers — works for any Node version with headers + a toolchain.
2. **Loop-breaker via attempt-state tracking** at `<better-sqlite3>/.instar-fix-state.json`, keyed by `(better-sqlite3 version, Node MODULE_VERSION, platform, arch)`. Once a tuple has exhausted both paths, the script exits 1 immediately without network or build activity — the caller in `src/commands/server.ts::ensureSqliteBindings` then degrades to JSONL-only mode instead of crash-looping.

Tuple-keyed state means a Node upgrade naturally re-arms the fix without manual intervention.

## Test plan

- [x] 8 unit tests in `tests/unit/fix-better-sqlite3-state.test.ts` (tuple derivation, state roundtrip, attempt append, tuple-change reset, write-failure tolerance)
- [x] CLI smoke-test: `node scripts/fix-better-sqlite3.cjs` reports "Native binary is working correctly" on a healthy install
- [x] All 86 existing lifeline unit tests still pass
- [x] `npm run build` clean

## Files

- `scripts/fix-better-sqlite3.cjs` — rewrite (CLI + pure helpers exported for tests)
- `tests/unit/fix-better-sqlite3-state.test.ts` — 8 scenarios
- `upgrades/NEXT.md` — patch-bump release note
- `upgrades/side-effects/native-module-source-build-fallback.md` — side-effects review (no runtime gate; install-time self-heal with deterministic terminal condition)