### PR TITLE
feat(telegram): add HTML formatter module (disabled) per spec [PR1]

### DIFF
--- a/src/messaging/TelegramMarkdownFormatter.ts
+++ b/src/messaging/TelegramMarkdownFormatter.ts
@@ -1,0 +1,595 @@
+/**
+ * TelegramMarkdownFormatter — server-side formatter that converts agent-authored
+ * GitHub-flavored markdown into Telegram HTML on outbound sends.
+ *
+ * Ported from Dawn's `telegram_format.py` (the-portal/.claude/scripts/telegram_format.py).
+ * Spec: docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md
+ *
+ * PR1: module + tests only. Not wired into any send path. PR2 wires into
+ * TelegramAdapter.apiCall() and TelegramLifeline.apiCall() behind a canary flag.
+ */
+
+export type FormatMode =
+  | 'plain'
+  | 'html'
+  | 'code'
+  | 'markdown'
+  | 'legacy-passthrough';
+
+export interface FormatResult {
+  /** The rendered output text (or the raw input, for `legacy-passthrough`). */
+  text: string;
+  /**
+   * The parse_mode the caller should set on the Bot API call.
+   * - `'HTML'` for plain/html/code/markdown.
+   * - `undefined` for `legacy-passthrough` — caller MUST use its callsite-historical
+   *   parse_mode (the formatter refuses to decide for legacy-passthrough).
+   */
+  parseMode: 'HTML' | 'Markdown' | undefined;
+  /** Lint issue strings (canonical prose; never contains user text). */
+  lintIssues: string[];
+  /** The mode actually applied (may differ from requested if conversionSkipped). */
+  modeApplied: FormatMode;
+  /** Output was byte-truncated to fit a Bot API limit. */
+  truncated: boolean;
+  /**
+   * Markdown conversion was bypassed (input > 32KB) and plain mode was applied.
+   * Distinct from `truncated` (which is byte-loss).
+   */
+  conversionSkipped: boolean;
+  /**
+   * For `legacy-passthrough`: signals to caller that formatter declined to
+   * transform the bytes; caller should use its historical parse_mode.
+   */
+  legacyPassthrough: boolean;
+}
+
+/** 32KB hard cap. Above this, markdown conversion is skipped (ReDoS defense). */
+export const MAX_INPUT_LENGTH = 32_768;
+
+/** Safe bound for quantifier in italic regex (ReDoS defense). */
+const ITALIC_MAX_LEN = 200;
+
+/** Max chars scanned forward in the balanced-paren URL walker. */
+const URL_SCAN_MAX = 2048;
+
+// ─── Placeholder sentinels ──────────────────────────────────────────────────
+// Use Supplementary-PUA-B (U+100000..U+10FFFD) — near-zero real-world usage,
+// invalid in Telegram HTML text anyway. We strip this range from user input
+// BEFORE inserting any sentinel, so collision is structurally impossible.
+// PUA-A (U+E000..U+F8FF) is NOT used — it frequently collides with user input
+// (private emoji, legacy fonts).
+
+// Supplementary-PUA-B is U+100000..U+10FFFD (codepoint max is 0x10FFFF).
+// We carve three 20000-wide blocks, one per kind.
+const PUA_B_START = 0x100000;
+const BLOCK_SIZE = 0x5000; // 20480 entries per kind — plenty
+const SENTINEL_CLOSE = String.fromCodePoint(0x10fffd);
+
+const KIND_PRE = 0;
+const KIND_TABLE = 1;
+const KIND_CODE = 2;
+
+function makeSentinel(kind: number, n: number): string {
+  if (n < 0 || n >= BLOCK_SIZE) {
+    throw new Error(`sentinel index out of range: ${n}`);
+  }
+  const code = PUA_B_START + kind * BLOCK_SIZE + n;
+  return SENTINEL_CLOSE + String.fromCodePoint(code) + SENTINEL_CLOSE;
+}
+
+function decodeSentinelCodepoint(cp: number): { kind: number; n: number } | null {
+  const offset = cp - PUA_B_START;
+  if (offset < 0) return null;
+  const kind = Math.floor(offset / BLOCK_SIZE);
+  const n = offset % BLOCK_SIZE;
+  if (kind > 2) return null;
+  return { kind, n };
+}
+
+/** Strip the entire Supplementary-PUA-B range from user input. */
+function stripPuaB(s: string): string {
+  // Two-surrogate range: 0x100000..0x10FFFD. Regex with /u flag.
+  return s.replace(/[\u{100000}-\u{10FFFD}]/gu, '');
+}
+
+/** Strip NUL bytes. Always step 0. */
+function stripNul(s: string): string {
+  return s.replace(/\x00/g, '');
+}
+
+// ─── HTML escape ────────────────────────────────────────────────────────────
+
+/** Escape for HTML text nodes. */
+export function escapeHtmlText(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Escape for HTML attribute values (href). Distinct from text: also escapes
+ * quotes and strips control chars that could break attribute quoting.
+ */
+export function escapeHtmlAttribute(s: string): string {
+  return s
+    // Strip C0 controls + DEL + CR/LF (CR/LF already in C0 range).
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// ─── URL safety ─────────────────────────────────────────────────────────────
+
+const SAFE_SCHEMES = new Set(['http', 'https', 'tg', 'mailto']);
+
+/**
+ * Check a URL against the scheme allowlist using WHATWG URL parsing.
+ * Returns the trimmed+parsed URL string on success, or null on reject.
+ *
+ * Scheme allowlist: http, https, tg, mailto. Everything else (javascript:,
+ * data:, file:, vbscript:, etc.) is refused and the link becomes literal text.
+ */
+export function isSafeUrl(raw: string): string | null {
+  // Trim leading whitespace and C0 controls (URL smuggling defense).
+  const trimmed = raw.replace(/^[\s\x00-\x1f]+/, '');
+  if (!trimmed) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  const scheme = parsed.protocol.toLowerCase().replace(':', '');
+  if (!SAFE_SCHEMES.has(scheme)) return null;
+  return trimmed;
+}
+
+// ─── Extraction: fenced code, tables, inline code ──────────────────────────
+
+interface Extracted {
+  text: string;
+  pre: string[];
+  table: string[];
+  code: string[];
+}
+
+/**
+ * Step 2: extract fenced code blocks. Replaces each with a PUA sentinel.
+ * Inner content HTML-escaped, wrapped in <pre>.
+ */
+function extractFencedCode(text: string, pre: string[]): string {
+  // Bounded fence regex: ``` ... ```, non-greedy.
+  // Use a manual scan to avoid regex backtracking on unbalanced fences.
+  const out: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    if (text.startsWith('```', i)) {
+      // Find closing ```
+      const start = i + 3;
+      const end = text.indexOf('```', start);
+      if (end === -1) {
+        // No closing — emit literal backticks, keep scanning.
+        out.push('```');
+        i += 3;
+        continue;
+      }
+      // Optional language tag on the opening line (skip to first \n).
+      let contentStart = start;
+      const nl = text.indexOf('\n', start);
+      if (nl !== -1 && nl < end) {
+        contentStart = nl + 1;
+      }
+      const inner = text.slice(contentStart, end);
+      const idx = pre.length;
+      pre.push(`<pre>${escapeHtmlText(inner)}</pre>`);
+      out.push(makeSentinel(KIND_PRE, idx));
+      i = end + 3;
+    } else {
+      out.push(text[i]);
+      i++;
+    }
+  }
+  return out.join('');
+}
+
+/**
+ * Step 3: extract markdown table blocks. Requires both pipe-rows and an
+ * alignment separator row. Escape inner text, wrap whole block in <pre>.
+ */
+function extractTables(text: string, table: string[]): string {
+  const lines = text.split('\n');
+  const isRow = (s: string) => /^\s*\|.{1,2000}\|\s*$/.test(s);
+  const isSep = (s: string) => /^\s*\|[\s\-:|]{1,2000}\|\s*$/.test(s);
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (isRow(lines[i])) {
+      const block: string[] = [];
+      let hasSep = false;
+      let j = i;
+      while (j < lines.length && isRow(lines[j])) {
+        if (isSep(lines[j])) {
+          hasSep = true;
+        } else {
+          block.push(lines[j]);
+        }
+        j++;
+      }
+      if (hasSep && block.length > 0) {
+        const escaped = block.map(escapeHtmlText).join('\n');
+        const idx = table.length;
+        table.push(`<pre>${escaped}</pre>`);
+        out.push(makeSentinel(KIND_TABLE, idx));
+        i = j;
+        continue;
+      }
+    }
+    out.push(lines[i]);
+    i++;
+  }
+  return out.join('\n');
+}
+
+/**
+ * Step 4: extract inline code spans (`x`). Non-greedy, newline-bounded.
+ */
+function extractInlineCode(text: string, code: string[]): string {
+  // Bounded quantifier; no nested backticks; newline terminates.
+  return text.replace(/`([^`\n]{1,500})`/g, (_m, inner: string) => {
+    const idx = code.length;
+    code.push(`<code>${escapeHtmlText(inner)}</code>`);
+    return makeSentinel(KIND_CODE, idx);
+  });
+}
+
+// ─── Link scanner (balanced-paren; not regex) ───────────────────────────────
+
+/**
+ * Step 11: find `[text](url)` links with a balanced-paren URL scanner so
+ * Wikipedia-style URLs like `https://en.wikipedia.org/wiki/Entity_(computer_science)`
+ * parse correctly.
+ *
+ * Input: text where prose is already HTML-escaped (step 5 ran).
+ *        `[`, `]`, `(`, `)` survive escape.
+ */
+function convertLinks(text: string): string {
+  const out: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch !== '[') {
+      out.push(ch);
+      i++;
+      continue;
+    }
+    // Find matching ] on same line, with bounded length.
+    let j = i + 1;
+    let foundClose = -1;
+    const maxTextEnd = Math.min(text.length, i + 1 + 500);
+    while (j < maxTextEnd) {
+      const c = text[j];
+      if (c === '\n') break;
+      if (c === ']') {
+        foundClose = j;
+        break;
+      }
+      j++;
+    }
+    if (foundClose === -1 || text[foundClose + 1] !== '(') {
+      out.push(ch);
+      i++;
+      continue;
+    }
+    const visibleText = text.slice(i + 1, foundClose);
+    // Walk URL with paren balance.
+    let k = foundClose + 2;
+    let depth = 1;
+    const urlStart = k;
+    const scanEnd = Math.min(text.length, urlStart + URL_SCAN_MAX);
+    let urlEnd = -1;
+    while (k < scanEnd) {
+      const c = text[k];
+      if (c === '\n') break;
+      if (c === '\\' && k + 1 < scanEnd) {
+        // Backslash: skip next char as literal (does NOT count parens).
+        k += 2;
+        continue;
+      }
+      if (c === '(') depth++;
+      else if (c === ')') {
+        depth--;
+        if (depth === 0) {
+          urlEnd = k;
+          break;
+        }
+      }
+      k++;
+    }
+    if (urlEnd === -1) {
+      // Unbalanced — emit literal prefix `[text](` and keep scanning from
+      // right after the `(`.
+      out.push(text.slice(i, foundClose + 2));
+      i = foundClose + 2;
+      continue;
+    }
+    const rawUrl = text.slice(urlStart, urlEnd);
+    const safeUrl = isSafeUrl(rawUrl);
+    if (safeUrl === null) {
+      // Emit the original construct as literal.
+      out.push(text.slice(i, urlEnd + 1));
+      i = urlEnd + 1;
+      continue;
+    }
+    out.push(`<a href="${escapeHtmlAttribute(safeUrl)}">${visibleText}</a>`);
+    i = urlEnd + 1;
+  }
+  return out.join('');
+}
+
+// ─── Emphasis/headings/bullets ──────────────────────────────────────────────
+
+/**
+ * Step 6 bold-italic, step 7 bold, step 8 italic (tightened).
+ *
+ * Order is load-bearing: triple BEFORE double BEFORE single so `***x***` parses
+ * as <b><i>x</i></b>, not `**` + `*x*` + `**`.
+ */
+function applyEmphasis(text: string): string {
+  // Bold-italic (triple asterisk). Bounded quantifier.
+  text = text.replace(
+    /\*\*\*([^*\n]{1,200}?)\*\*\*/g,
+    '<b><i>$1</i></b>'
+  );
+  // Bold (double asterisk).
+  text = text.replace(
+    /\*\*([^*\n]{1,200}?)\*\*/g,
+    '<b>$1</b>'
+  );
+  // Italic — tightened boundary. Requires word-boundary-like context on both
+  // sides. Does NOT match `3*5`, `f(x) = x * y`, `a*b*c`.
+  // Using bounded quantifier (ReDoS defense).
+  text = text.replace(
+    /(^|[\s(,.;:!?])\*(?!\s)([^*\n]{1,200}?)(?<!\s)\*(?=$|[\s),.;:!?])/g,
+    '$1<i>$2</i>'
+  );
+  return text;
+}
+
+/** Step 9: headings → <b>. Telegram supports bold, not h1-h6. */
+function applyHeadings(text: string): string {
+  return text.replace(
+    /^(#{1,6})\s+(.{1,2000}?)\s*#*\s*$/gm,
+    '<b>$2</b>'
+  );
+}
+
+/** Step 10: bullets → • */
+function applyBullets(text: string): string {
+  return text.replace(/^(\s{0,20})[-*+]\s+/gm, '$1• ');
+}
+
+// ─── Plain mode (Dawn parity) ──────────────────────────────────────────────
+
+function plainUnicode(text: string): string {
+  // Heading: uppercase the heading text.
+  text = text.replace(
+    /^(#{1,6})\s+(.{1,2000}?)\s*#*\s*$/gm,
+    (_m, _h, t: string) => t.toUpperCase()
+  );
+  text = text.replace(/\*\*\*([^*\n]{1,200}?)\*\*\*/g, '$1');
+  text = text.replace(/\*\*([^*\n]{1,200}?)\*\*/g, '$1');
+  text = text.replace(
+    /(^|[\s(,.;:!?])\*(?!\s)([^*\n]{1,200}?)(?<!\s)\*(?=$|[\s),.;:!?])/g,
+    '$1$2'
+  );
+  text = text.replace(/`([^`\n]{1,500})`/g, "'$1'");
+  text = text.replace(/^(\s{0,20})[-*+]\s+/gm, '$1• ');
+  return text;
+}
+
+// ─── Lint ───────────────────────────────────────────────────────────────────
+
+/**
+ * Strip <code>...</code> and <pre>...</pre> spans so lint doesn't flag markdown
+ * chars inside deliberately-literal examples.
+ *
+ * ADVISORY-ONLY — not used by the converter. The converter has its own
+ * tokenizer (extractFencedCode / extractInlineCode).
+ */
+function stripHtmlCodePreForLint(text: string): string {
+  // Bounded quantifiers; non-greedy.
+  text = text.replace(/<pre>[\s\S]{0,32000}?<\/pre>/g, '');
+  text = text.replace(/<code>[\s\S]{0,2000}?<\/code>/g, '');
+  return text;
+}
+
+/**
+ * Lint — canonical messages only. Never contains user text.
+ */
+export function lintTelegramMarkdown(text: string): string[] {
+  const stripped = stripHtmlCodePreForLint(text);
+  const issues: string[] = [];
+  // Table: requires BOTH a row and an alignment separator.
+  const hasTableRow = /^\s*\|.{1,2000}\|\s*$/m.test(stripped);
+  const hasTableSep = /^\s*\|[\s\-:|]{1,2000}\|\s*$/m.test(stripped);
+  if (hasTableRow && hasTableSep) {
+    issues.push('markdown table syntax detected (pipe rows with alignment separator)');
+  }
+  if (/\*\*([^*\n]{1,200}?)\*\*/.test(stripped)) {
+    issues.push('markdown bold syntax detected (double-asterisk)');
+  }
+  if (/^#{1,6}\s+.{1,2000}$/m.test(stripped)) {
+    issues.push('markdown heading syntax detected (leading hash)');
+  }
+  // Nested markdown: bold-inside-bold or italic-inside-bold literal concern.
+  if (/\*\*[^*\n]{0,200}\*[^*\n]{0,200}\*[^*\n]{0,200}\*\*/.test(stripped)) {
+    issues.push('nested markdown emphasis detected');
+  }
+  return issues;
+}
+
+// ─── Main entry ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert GitHub-flavored markdown to Telegram HTML per spec's 12-step pipeline.
+ */
+function convertMarkdownToHtml(text: string): string {
+  const pre: string[] = [];
+  const table: string[] = [];
+  const code: string[] = [];
+
+  // Step 2: fenced code.
+  text = extractFencedCode(text, pre);
+  // Step 3: tables.
+  text = extractTables(text, table);
+  // Step 4: inline code.
+  text = extractInlineCode(text, code);
+  // Step 5: HTML-escape remaining prose.
+  text = escapeHtmlText(text);
+  // Steps 6-8: bold-italic, bold, italic.
+  text = applyEmphasis(text);
+  // Step 9: headings.
+  text = applyHeadings(text);
+  // Step 10: bullets.
+  text = applyBullets(text);
+  // Step 11: links (balanced-paren scan).
+  text = convertLinks(text);
+  // Step 12: splice placeholders back.
+  text = splicePlaceholders(text, pre, table, code);
+  return text;
+}
+
+function splicePlaceholders(
+  text: string,
+  pre: string[],
+  table: string[],
+  code: string[]
+): string {
+  // Replace every sentinel pattern: SENTINEL_CLOSE + codepoint + SENTINEL_CLOSE.
+  const re = /\u{10FFFD}([\u{100000}-\u{10FFFC}])\u{10FFFD}/gu;
+  return text.replace(re, (_m, ch: string) => {
+    const cp = ch.codePointAt(0)!;
+    const dec = decodeSentinelCodepoint(cp);
+    if (!dec) return '';
+    if (dec.kind === KIND_PRE) return pre[dec.n] ?? '';
+    if (dec.kind === KIND_TABLE) return table[dec.n] ?? '';
+    if (dec.kind === KIND_CODE) return code[dec.n] ?? '';
+    return '';
+  });
+}
+
+/**
+ * Format text for Telegram send.
+ *
+ * See spec's "Modes — exact contract" and "Markdown conversion rules" sections.
+ */
+export function formatForTelegram(
+  text: string,
+  mode: FormatMode = 'markdown'
+): FormatResult {
+  // legacy-passthrough: byte-for-byte unchanged, parseMode undefined so caller
+  // uses its historical mode.
+  if (mode === 'legacy-passthrough') {
+    return {
+      text,
+      parseMode: undefined,
+      lintIssues: [],
+      modeApplied: 'legacy-passthrough',
+      truncated: false,
+      conversionSkipped: false,
+      legacyPassthrough: true,
+    };
+  }
+
+  // Step 0: strip NUL. ALWAYS first.
+  let working = stripNul(text);
+  // Defensive: strip PUA-B to prevent sentinel collisions. Range is near-zero
+  // real-world usage and invalid in Telegram HTML anyway.
+  working = stripPuaB(working);
+
+  const lintIssues = lintTelegramMarkdown(working);
+
+  // Step 1: length guard (ReDoS defense). Applies to markdown conversion only.
+  if (mode === 'markdown' && working.length > MAX_INPUT_LENGTH) {
+    // Fall back to plain.
+    const plain = escapeHtmlText(plainUnicode(working));
+    return {
+      text: plain,
+      parseMode: 'HTML',
+      lintIssues,
+      modeApplied: 'plain',
+      truncated: false,
+      conversionSkipped: true,
+      legacyPassthrough: false,
+    };
+  }
+
+  if (mode === 'html') {
+    return {
+      text: working,
+      parseMode: 'HTML',
+      lintIssues,
+      modeApplied: 'html',
+      truncated: false,
+      conversionSkipped: false,
+      legacyPassthrough: false,
+    };
+  }
+
+  if (mode === 'code') {
+    return {
+      text: `<pre>${escapeHtmlText(working)}</pre>`,
+      parseMode: 'HTML',
+      lintIssues,
+      modeApplied: 'code',
+      truncated: false,
+      conversionSkipped: false,
+      legacyPassthrough: false,
+    };
+  }
+
+  if (mode === 'plain') {
+    return {
+      text: escapeHtmlText(plainUnicode(working)),
+      parseMode: 'HTML',
+      lintIssues,
+      modeApplied: 'plain',
+      truncated: false,
+      conversionSkipped: false,
+      legacyPassthrough: false,
+    };
+  }
+
+  // markdown (default)
+  return {
+    text: convertMarkdownToHtml(working),
+    parseMode: 'HTML',
+    lintIssues,
+    modeApplied: 'markdown',
+    truncated: false,
+    conversionSkipped: false,
+    legacyPassthrough: false,
+  };
+}
+
+/**
+ * Convenience: `format(text, mode)` → `{ text, parseMode }` shape per the
+ * parent prompt. Full result available via `formatForTelegram()`.
+ */
+export function format(
+  text: string,
+  mode: FormatMode = 'markdown'
+): { text: string; parseMode: 'HTML' | 'Markdown' | undefined } {
+  const r = formatForTelegram(text, mode);
+  return { text: r.text, parseMode: r.parseMode };
+}
+
+/** Short alias for the lint function. */
+export function lint(text: string): string[] {
+  return lintTelegramMarkdown(text);
+}

--- a/tests/unit/telegram-markdown-formatter.test.ts
+++ b/tests/unit/telegram-markdown-formatter.test.ts
@@ -1,0 +1,541 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatForTelegram,
+  format,
+  lint,
+  lintTelegramMarkdown,
+  escapeHtmlText,
+  escapeHtmlAttribute,
+  isSafeUrl,
+  MAX_INPUT_LENGTH,
+  type FormatMode,
+} from '../../src/messaging/TelegramMarkdownFormatter.js';
+
+// ─── HTML escape primitives ─────────────────────────────────────────────────
+
+describe('escapeHtmlText', () => {
+  it('escapes < > &', () => {
+    expect(escapeHtmlText('<script>alert(1)&')).toBe(
+      '&lt;script&gt;alert(1)&amp;'
+    );
+  });
+  it('does NOT escape quotes (text context)', () => {
+    expect(escapeHtmlText('"hello"')).toBe('"hello"');
+    expect(escapeHtmlText("it's")).toBe("it's");
+  });
+  it('leaves plain text unchanged', () => {
+    expect(escapeHtmlText('hello world')).toBe('hello world');
+  });
+});
+
+describe('escapeHtmlAttribute', () => {
+  it('escapes double quote to &quot;', () => {
+    expect(escapeHtmlAttribute('a"b')).toBe('a&quot;b');
+  });
+  it('escapes single quote to &#39;', () => {
+    expect(escapeHtmlAttribute("a'b")).toBe('a&#39;b');
+  });
+  it('escapes < > &', () => {
+    expect(escapeHtmlAttribute('<a&b>')).toBe('&lt;a&amp;b&gt;');
+  });
+  it('strips C0 controls, DEL, CR, LF, NUL', () => {
+    expect(escapeHtmlAttribute('a\x00b\rc\nd\x7fe\x1ff')).toBe('abcdef');
+  });
+  it('handles mixed attack payload', () => {
+    const input = 'javascript:alert("x")\n<img>';
+    const result = escapeHtmlAttribute(input);
+    expect(result).not.toContain('\n');
+    expect(result).not.toContain('"');
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('>');
+  });
+});
+
+// ─── URL safety ─────────────────────────────────────────────────────────────
+
+describe('isSafeUrl', () => {
+  it('allows http', () => {
+    expect(isSafeUrl('http://example.com')).toBe('http://example.com');
+  });
+  it('allows https', () => {
+    expect(isSafeUrl('https://example.com')).toBe('https://example.com');
+  });
+  it('allows tg', () => {
+    expect(isSafeUrl('tg://resolve?domain=foo')).not.toBeNull();
+  });
+  it('allows mailto', () => {
+    expect(isSafeUrl('mailto:foo@bar.com')).not.toBeNull();
+  });
+  it('rejects javascript:', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBeNull();
+  });
+  it('rejects data:', () => {
+    expect(isSafeUrl('data:text/html,<script>')).toBeNull();
+  });
+  it('rejects file:', () => {
+    expect(isSafeUrl('file:///etc/passwd')).toBeNull();
+  });
+  it('rejects vbscript:', () => {
+    expect(isSafeUrl('vbscript:msgbox(1)')).toBeNull();
+  });
+  it('rejects malformed URL', () => {
+    expect(isSafeUrl('not a url')).toBeNull();
+  });
+  it('rejects empty/whitespace', () => {
+    expect(isSafeUrl('')).toBeNull();
+    expect(isSafeUrl('   ')).toBeNull();
+  });
+  it('trims leading whitespace and control chars (URL smuggling)', () => {
+    expect(isSafeUrl('\t  https://example.com')).toBe('https://example.com');
+    expect(isSafeUrl('\x01https://example.com')).toBe('https://example.com');
+  });
+  it('rejects uppercase-scheme attack (case-insensitive match)', () => {
+    // URL normalizes scheme; uppercase HTTPS should still resolve to https.
+    expect(isSafeUrl('HTTPS://example.com')).not.toBeNull();
+  });
+});
+
+// ─── Modes ─────────────────────────────────────────────────────────────────
+
+describe('formatForTelegram — plain mode', () => {
+  it('escapes HTML', () => {
+    const r = formatForTelegram('<script>', 'plain');
+    expect(r.text).toBe('&lt;script&gt;');
+    expect(r.parseMode).toBe('HTML');
+  });
+  it('converts **bold** to plain text', () => {
+    const r = formatForTelegram('**hi**', 'plain');
+    expect(r.text).toBe('hi');
+  });
+  it('converts `code` to quoted text', () => {
+    const r = formatForTelegram('`x`', 'plain');
+    expect(r.text).toBe("'x'");
+  });
+  it('uppercases headings', () => {
+    const r = formatForTelegram('# Hello', 'plain');
+    expect(r.text).toBe('HELLO');
+  });
+  it('converts bullets to •', () => {
+    const r = formatForTelegram('- item', 'plain');
+    expect(r.text).toBe('• item');
+  });
+});
+
+describe('formatForTelegram — html mode', () => {
+  it('passes text through unchanged', () => {
+    const r = formatForTelegram('<b>hi</b>', 'html');
+    expect(r.text).toBe('<b>hi</b>');
+    expect(r.parseMode).toBe('HTML');
+  });
+});
+
+describe('formatForTelegram — code mode', () => {
+  it('wraps in <pre> and escapes inner', () => {
+    const r = formatForTelegram('<hi>', 'code');
+    expect(r.text).toBe('<pre>&lt;hi&gt;</pre>');
+    expect(r.parseMode).toBe('HTML');
+  });
+});
+
+describe('formatForTelegram — markdown mode', () => {
+  it('converts **bold** to <b>', () => {
+    const r = formatForTelegram('**hi**', 'markdown');
+    expect(r.text).toBe('<b>hi</b>');
+    expect(r.parseMode).toBe('HTML');
+  });
+  it('converts ***x*** to <b><i>x</i></b>', () => {
+    const r = formatForTelegram('***x***', 'markdown');
+    expect(r.text).toBe('<b><i>x</i></b>');
+  });
+  it('converts `code` to <code>', () => {
+    const r = formatForTelegram('`x`', 'markdown');
+    expect(r.text).toBe('<code>x</code>');
+  });
+  it('converts # heading to <b>', () => {
+    const r = formatForTelegram('# Hi', 'markdown');
+    expect(r.text).toBe('<b>Hi</b>');
+  });
+  it('converts bullets to •', () => {
+    const r = formatForTelegram('- a\n- b', 'markdown');
+    expect(r.text).toBe('• a\n• b');
+  });
+  it('escapes < > & in prose', () => {
+    const r = formatForTelegram('<script>&', 'markdown');
+    expect(r.text).toBe('&lt;script&gt;&amp;');
+  });
+  it('tables become <pre>', () => {
+    const table = '| a | b |\n| --- | --- |\n| 1 | 2 |';
+    const r = formatForTelegram(table, 'markdown');
+    expect(r.text).toContain('<pre>');
+    expect(r.text).toContain('| a | b |');
+    expect(r.text).toContain('| 1 | 2 |');
+  });
+  it('fenced code blocks become <pre>', () => {
+    const r = formatForTelegram('```\nhi <world>\n```', 'markdown');
+    expect(r.text).toContain('<pre>hi &lt;world&gt;');
+  });
+  it('fenced code with language tag strips the lang line', () => {
+    const r = formatForTelegram('```js\nconst x = 1;\n```', 'markdown');
+    expect(r.text).toContain('<pre>const x = 1;');
+    expect(r.text).not.toContain('<pre>js');
+  });
+  it('does NOT interpret markdown inside inline code', () => {
+    const r = formatForTelegram('`**bold**`', 'markdown');
+    expect(r.text).toBe('<code>**bold**</code>');
+  });
+  it('does NOT interpret markdown inside fenced code', () => {
+    const r = formatForTelegram('```\n**nope**\n```', 'markdown');
+    expect(r.text).toContain('**nope**');
+    expect(r.text).not.toContain('<b>nope</b>');
+  });
+});
+
+describe('formatForTelegram — legacy-passthrough mode', () => {
+  it('returns input byte-for-byte unchanged', () => {
+    const input = '**bold** `code` # heading | table |\nwith NUL\x00 and PUA \u{100000}';
+    const r = formatForTelegram(input, 'legacy-passthrough');
+    expect(r.text).toBe(input);
+    expect(r.text.length).toBe(input.length);
+  });
+  it('signals legacyPassthrough: true', () => {
+    const r = formatForTelegram('x', 'legacy-passthrough');
+    expect(r.legacyPassthrough).toBe(true);
+  });
+  it('returns parseMode undefined so caller uses its historical mode', () => {
+    const r = formatForTelegram('x', 'legacy-passthrough');
+    expect(r.parseMode).toBeUndefined();
+  });
+  it('emits no lint issues (skipped)', () => {
+    const r = formatForTelegram('**bold** # heading', 'legacy-passthrough');
+    expect(r.lintIssues).toEqual([]);
+  });
+});
+
+// ─── Italic edge cases ─────────────────────────────────────────────────────
+
+describe('italic edge cases', () => {
+  it('does NOT match arithmetic 3*5', () => {
+    const r = formatForTelegram('3*5=15', 'markdown');
+    expect(r.text).toBe('3*5=15');
+    expect(r.text).not.toContain('<i>');
+  });
+  it('does NOT match f(x) = x * y', () => {
+    const r = formatForTelegram('f(x) = x * y', 'markdown');
+    expect(r.text).not.toContain('<i>');
+  });
+  it('does NOT match a*b*c (no word boundaries)', () => {
+    const r = formatForTelegram('a*b*c', 'markdown');
+    expect(r.text).not.toContain('<i>');
+  });
+  it('matches *valid italic*', () => {
+    const r = formatForTelegram('this is *valid italic* here', 'markdown');
+    expect(r.text).toContain('<i>valid italic</i>');
+  });
+  it('does NOT match *unterminated', () => {
+    const r = formatForTelegram('*unterminated text', 'markdown');
+    expect(r.text).not.toContain('<i>');
+  });
+});
+
+// ─── Link safety ───────────────────────────────────────────────────────────
+
+describe('links', () => {
+  it('converts [text](https://x) to <a>', () => {
+    const r = formatForTelegram('[hi](https://example.com)', 'markdown');
+    expect(r.text).toBe('<a href="https://example.com">hi</a>');
+  });
+  it('handles Wikipedia-style URL with parens (balanced-paren scan)', () => {
+    const r = formatForTelegram(
+      '[Entity](https://en.wikipedia.org/wiki/Entity_(computer_science))',
+      'markdown'
+    );
+    expect(r.text).toBe(
+      '<a href="https://en.wikipedia.org/wiki/Entity_(computer_science)">Entity</a>'
+    );
+  });
+  it('handles deeply nested parens', () => {
+    const r = formatForTelegram(
+      '[x](https://a.com/foo(bar(baz))qux)',
+      'markdown'
+    );
+    expect(r.text).toContain('<a href="https://a.com/foo(bar(baz))qux">x</a>');
+  });
+  it('rejects javascript: as literal text (no <a href>)', () => {
+    const r = formatForTelegram('[click](javascript:alert(1))', 'markdown');
+    expect(r.text).not.toContain('<a ');
+    expect(r.text).not.toContain('href=');
+  });
+  it('rejects data: as literal text', () => {
+    const r = formatForTelegram('[x](data:text/html,<script>)', 'markdown');
+    expect(r.text).not.toContain('<a ');
+  });
+  it('escapes quotes in URL attribute', () => {
+    const r = formatForTelegram('[x](https://a.com/"quote")', 'markdown');
+    // " in URL should become &quot; in attribute value.
+    expect(r.text).not.toMatch(/href="[^"]*"[^"]*"/);
+  });
+  it('emits literal text for malformed URL', () => {
+    const r = formatForTelegram('[x](not a url)', 'markdown');
+    expect(r.text).not.toContain('<a ');
+  });
+  it('emits literal text for unbalanced URL (fallback)', () => {
+    const r = formatForTelegram('[x](https://a.com/foo(bar', 'markdown');
+    // Should NOT emit <a>.
+    expect(r.text).not.toContain('<a ');
+  });
+});
+
+// ─── Lint ─────────────────────────────────────────────────────────────────
+
+describe('lint', () => {
+  it('detects markdown tables', () => {
+    const issues = lint('| a | b |\n| --- | --- |\n| 1 | 2 |');
+    expect(issues.some(i => i.includes('table'))).toBe(true);
+  });
+  it('does NOT flag single pipe-row without separator', () => {
+    const issues = lint('| not | a | table |');
+    expect(issues.some(i => i.includes('table'))).toBe(false);
+  });
+  it('detects **bold**', () => {
+    const issues = lint('hello **world**');
+    expect(issues.some(i => i.includes('bold'))).toBe(true);
+  });
+  it('detects # headings', () => {
+    const issues = lint('# Heading');
+    expect(issues.some(i => i.includes('heading'))).toBe(true);
+  });
+  it('detects nested markdown', () => {
+    const issues = lint('**bold *italic* more**');
+    expect(issues.some(i => i.includes('nested'))).toBe(true);
+  });
+  it('lint messages NEVER contain user text or markdown tokens', () => {
+    const issues = lint('# SECRET_TOKEN **pwn**');
+    for (const msg of issues) {
+      expect(msg).not.toContain('SECRET_TOKEN');
+      expect(msg).not.toContain('**pwn**');
+      expect(msg).not.toMatch(/\*\*[^(]/);  // no literal ** other than in parens
+    }
+  });
+  it('carves out literal examples inside <code>', () => {
+    const issues = lint('see <code>**bold**</code> syntax');
+    // The ** inside <code> should be stripped before lint.
+    expect(issues.some(i => i.includes('bold'))).toBe(false);
+  });
+  it('carves out literal examples inside <pre>', () => {
+    const issues = lint('<pre>| a | b |\n| --- | --- |</pre>');
+    expect(issues.some(i => i.includes('table'))).toBe(false);
+  });
+});
+
+// ─── Security: NUL and PUA-B stripping ────────────────────────────────────
+
+describe('security hardening', () => {
+  it('strips NUL bytes as first step', () => {
+    const r = formatForTelegram('a\x00b\x00c', 'markdown');
+    expect(r.text).toBe('abc');
+  });
+  it('strips PUA-B range (sentinel collision defense)', () => {
+    const sentinel = String.fromCodePoint(0x100000);
+    const close = String.fromCodePoint(0x10fffd);
+    const r = formatForTelegram(`hi${sentinel}${close}there`, 'markdown');
+    expect(r.text).not.toContain(sentinel);
+    expect(r.text).not.toContain(close);
+  });
+  it('user-supplied PUA-B cannot forge a placeholder', () => {
+    // Attempt: inject what looks like a sentinel to splice out a <pre>.
+    const sentinel = String.fromCodePoint(0x10fffd) +
+      String.fromCodePoint(0x100001) +
+      String.fromCodePoint(0x10fffd);
+    const r = formatForTelegram(`prefix${sentinel}suffix`, 'markdown');
+    // The attempted sentinel should be stripped, not resolved.
+    expect(r.text).toBe('prefixsuffix');
+  });
+});
+
+// ─── Length guard ─────────────────────────────────────────────────────────
+
+describe('32KB length guard', () => {
+  it('32KB exact is accepted', () => {
+    const input = 'a'.repeat(MAX_INPUT_LENGTH);
+    const r = formatForTelegram(input, 'markdown');
+    expect(r.conversionSkipped).toBe(false);
+  });
+  it('32KB+1 triggers conversionSkipped fallback to plain', () => {
+    const input = 'a'.repeat(MAX_INPUT_LENGTH + 1);
+    const r = formatForTelegram(input, 'markdown');
+    expect(r.conversionSkipped).toBe(true);
+    expect(r.modeApplied).toBe('plain');
+  });
+  it('conversionSkipped is distinct from truncated', () => {
+    const input = 'a'.repeat(MAX_INPUT_LENGTH + 1);
+    const r = formatForTelegram(input, 'markdown');
+    expect(r.truncated).toBe(false);  // no bytes lost
+    expect(r.conversionSkipped).toBe(true);
+  });
+});
+
+// ─── ReDoS fuzz ───────────────────────────────────────────────────────────
+
+describe('ReDoS fuzz', () => {
+  const SEED_INPUTS = [
+    // Nested asterisks
+    '*'.repeat(100),
+    '**'.repeat(100),
+    '***'.repeat(100),
+    // Nested brackets
+    '['.repeat(100) + ']'.repeat(100),
+    // Backticks
+    '`'.repeat(500),
+    // Fences
+    '```'.repeat(100),
+    // Parens
+    '(' + 'x('.repeat(100) + 'y' + ')'.repeat(100),
+    // Mixed
+    '**' + '*'.repeat(500) + '**',
+    // Long single line bold-italic-like
+    '***' + 'a'.repeat(300) + '***',
+    // Table-like
+    '|'.repeat(1000),
+    // URL with many parens
+    '[x](https://a.com/' + '(x)'.repeat(100) + ')',
+    // Heading with many hashes
+    '#'.repeat(50) + ' ' + 'x'.repeat(500),
+  ];
+
+  it.each(SEED_INPUTS)('p99 < 50ms for pathological input %#', (input) => {
+    const start = performance.now();
+    const r = formatForTelegram(input, 'markdown');
+    const elapsed = performance.now() - start;
+    expect(r.text).toBeDefined();
+    // Generous bound (spec says p99 <5ms at 4KB; we run tiny inputs with
+    // CI variance). 50ms floor catches actual ReDoS (which hangs indefinitely).
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it('deterministic pseudo-random fuzz (1000 iterations)', () => {
+    // Mulberry32 seeded RNG for reproducibility.
+    let seed = 0xc0ffee;
+    const rand = () => {
+      seed |= 0;
+      seed = (seed + 0x6d2b79f5) | 0;
+      let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+    const chars = '*`[](){}|#-_\\/abc\n ';
+    for (let i = 0; i < 1000; i++) {
+      const len = Math.floor(rand() * 200);
+      let s = '';
+      for (let j = 0; j < len; j++) {
+        s += chars[Math.floor(rand() * chars.length)];
+      }
+      const start = performance.now();
+      formatForTelegram(s, 'markdown');
+      const elapsed = performance.now() - start;
+      expect(elapsed).toBeLessThan(100);
+    }
+  }, 30_000);
+});
+
+// ─── Idempotency ──────────────────────────────────────────────────────────
+
+describe('idempotency', () => {
+  const FIXTURES = [
+    '**bold**',
+    '*italic*',
+    '`code`',
+    '# heading',
+    '- bullet',
+    '```\npre\n```',
+    '[link](https://example.com)',
+    '[wiki](https://en.wikipedia.org/wiki/X_(y))',
+    'plain prose',
+    'multi\nline\ntext',
+    '<script>alert(1)</script>',
+    '| a | b |\n| --- | --- |\n| 1 | 2 |',
+  ];
+
+  it.each(FIXTURES)('format is deterministic: %s', (fixture) => {
+    const a = formatForTelegram(fixture, 'markdown').text;
+    const b = formatForTelegram(fixture, 'markdown').text;
+    expect(a).toBe(b);
+  });
+
+  it('html mode is trivially idempotent', () => {
+    const x = '<b>hi</b>';
+    expect(formatForTelegram(formatForTelegram(x, 'html').text, 'html').text).toBe(x);
+  });
+
+  it('markdown mode is idempotent on HTML-only input', () => {
+    // After one pass, markdown-escape prose. Second pass on that plain prose
+    // (which has no markdown tokens or HTML chars) should be a fixed point.
+    const x = 'hello world';
+    const r1 = formatForTelegram(x, 'markdown').text;
+    const r2 = formatForTelegram(r1, 'markdown').text;
+    expect(r2).toBe(r1);
+  });
+
+  it('plain mode is idempotent on plain input', () => {
+    const x = 'hello world';
+    const r1 = formatForTelegram(x, 'plain').text;
+    const r2 = formatForTelegram(r1, 'plain').text;
+    expect(r2).toBe(r1);
+  });
+
+  it('legacy-passthrough is trivially idempotent', () => {
+    const x = '**bold** `x`';
+    const r1 = formatForTelegram(x, 'legacy-passthrough').text;
+    const r2 = formatForTelegram(r1, 'legacy-passthrough').text;
+    expect(r2).toBe(x);
+  });
+});
+
+// ─── format() convenience shape ──────────────────────────────────────────
+
+describe('format() convenience shape', () => {
+  it('returns { text, parseMode }', () => {
+    const r = format('**hi**', 'markdown');
+    expect(r.text).toBe('<b>hi</b>');
+    expect(r.parseMode).toBe('HTML');
+  });
+  it('legacy-passthrough returns parseMode undefined', () => {
+    const r = format('hi', 'legacy-passthrough');
+    expect(r.parseMode).toBeUndefined();
+  });
+});
+
+// ─── Extended escape assertions ──────────────────────────────────────────
+
+describe('escape behavior round-trip', () => {
+  it('<script> in text becomes &lt;script&gt;', () => {
+    const r = formatForTelegram('<script>', 'markdown');
+    expect(r.text).toBe('&lt;script&gt;');
+  });
+  it('" in URL attribute becomes &quot;', () => {
+    // Test escapeHtmlAttribute directly (URLs with " are rare but testable).
+    expect(escapeHtmlAttribute('"')).toBe('&quot;');
+  });
+});
+
+// ─── Nested markdown grammar ─────────────────────────────────────────────
+
+describe('nested markdown', () => {
+  it('triple asterisk becomes bold-italic', () => {
+    const r = formatForTelegram('***hi***', 'markdown');
+    expect(r.text).toBe('<b><i>hi</i></b>');
+  });
+  it('inline code inside bold leaves code span intact', () => {
+    const r = formatForTelegram('**and `code`**', 'markdown');
+    expect(r.text).toContain('<code>code</code>');
+    expect(r.text).toContain('<b>');
+  });
+});
+
+// ─── Lint function alias ─────────────────────────────────────────────────
+
+describe('lint aliases', () => {
+  it('lint() === lintTelegramMarkdown()', () => {
+    const input = '**bold**';
+    expect(lint(input)).toEqual(lintTelegramMarkdown(input));
+  });
+});

--- a/upgrades/side-effects/telegram-markdown-renderer-pr1.md
+++ b/upgrades/side-effects/telegram-markdown-renderer-pr1.md
@@ -1,0 +1,124 @@
+# Side-Effects Review — Telegram markdown renderer (PR1: formatter module, disabled)
+
+**Version / slug:** `telegram-markdown-renderer-pr1`
+**Date:** `2026-04-24`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (no block/allow surface, no wiring into send paths, shipped disabled)`
+
+## Summary of the change
+
+PR1 of the two-PR plan in `docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md` (approved 2026-04-24 by Justin via Telegram topic 8183). Adds a new pure-function module `src/messaging/TelegramMarkdownFormatter.ts` that ports Dawn's `telegram_format.py` (the-portal) to TypeScript, plus a Vitest test suite `tests/unit/telegram-markdown-formatter.test.ts` with 105 passing tests.
+
+The module exports `formatForTelegram(text, mode)`, `format(text, mode)`, `lintTelegramMarkdown(text)`, and primitives (`escapeHtmlText`, `escapeHtmlAttribute`, `isSafeUrl`). It implements the spec's full 12-step markdown→Telegram-HTML pipeline, a balanced-paren URL scanner (Wikipedia-style parens), WHATWG URL scheme allowlist, distinct HTML-text vs HTML-attribute escapers, NUL + Supplementary-PUA-B stripping for sentinel-collision safety, a 32KB input guard that falls back to plain mode without byte loss (`conversionSkipped: true`), and a `legacy-passthrough` mode that returns input byte-for-byte unchanged with `parseMode: undefined` so callers retain their historical `parse_mode`.
+
+**Critically, no send path is wired to this module.** `TelegramAdapter.ts` and `TelegramLifeline.ts` are untouched. The module is dead code at runtime until PR2 wires `apiCall()` behind the `telegramFormatMode` config accessor. PR2 ships with `legacy-passthrough` as the default, so PR1 has zero behavioral effect on any agent even after PR2 merges.
+
+## Decision-point inventory
+
+This PR contains no runtime decision points — the module is not called by anything. The future decision points it enables (documented here for completeness; all are PR2 scope):
+
+- `TelegramAdapter.apiCall` — formatter invocation conditional on `method === 'sendMessage' || method === 'editMessageText'`. **Not in this PR.**
+- `TelegramLifeline.apiCall` — same. **Not in this PR.**
+- Trusted-internal-caller allowlist for `html` mode. **Not in this PR.**
+
+Decision points inside the module itself (pure functions, no runtime authority):
+
+- `isSafeUrl(raw)` — scheme allowlist (http/https/tg/mailto). Pure function; refuses unsafe schemes by returning `null`. Caller decides what to do with the rejection (emit literal text).
+- `lintTelegramMarkdown(text)` — pure detector returning string array. Advisory-only; no blocking authority in this PR.
+- 32KB length guard in `formatForTelegram` — falls back to plain mode on oversized input. Pure transformation; no network/storage side effect.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface in PR1 — module is not wired. Future-facing concerns the module itself introduces:
+
+- `legacy-passthrough` mode emits no lint issues (by design — it's the rollback target and must be behaviorally identical to pre-cutover). A future operator might want lint-as-observation in passthrough mode; noted as open question for PR2.
+- `isSafeUrl` rejects `javascript:`, `data:`, `file:`, `vbscript:`, and any non-allowlisted scheme. Rejected links become literal text (`[click](javascript:...)` rendered verbatim) — a legitimate agent-authored `tg://resolve?domain=foo` link is permitted (mode allowed). Wikipedia-style `https://...wiki/X_(y)` URLs parse correctly via the balanced-paren scanner (covered by fixture test).
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+No block/allow surface in PR1. Module-internal known gaps (documented in spec, accepted as v1):
+
+- Italic between emoji (`🎉*bold*🎉`) renders literal asterisks because the punctuation-class lookaround doesn't include emoji — accepted v1 per spec iteration-2 L4.
+- `tg://` deep links are permitted (spec allowlists them); future spec may tighten.
+- PUA-B range is stripped from input before sentinels are inserted — this means a user message legitimately containing PUA-B codepoints will lose those bytes. Near-zero real-world usage; accepted trade-off per spec. Not flagged as `truncated` because "byte loss" in the spec is reserved for the oversized-`<pre>` fallback.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The module is a pure string-transform library at the same layer as `MessageFormatter.ts`. It owns no I/O, no config reading, no network, no logging. It does not hold blocking authority. The decision "should this send happen at all?" stays with the adapter/lifeline chokepoints; the formatter only answers "given this text and mode, what bytes go on the wire?"
+
+This is consistent with the spec's architectural intent: the formatter is a detector+transformer producing `{ text, parseMode, lintIssues }`, consumed downstream by the adapter which holds the authoritative send/no-send decision.
+
+---
+
+## 4. Signal vs authority compliance
+
+Per `docs/signal-vs-authority.md`:
+
+- **Lint is a signal, not an authority.** `lintTelegramMarkdown` returns canonical prose-string issues. It does not reject a send. The spec specifies lint-strict mode (which a downstream authority can consume to return 422) as PR2 scope; PR1's lint is purely observational.
+- **Scheme allowlist is a deterministic transform, not a policy decision.** `isSafeUrl` is brittle-by-design (WHATWG URL + scheme set). It does not block a send — it causes a link to render as literal text. The outbound send still happens. This satisfies the "brittle logic must not hold blocking authority" rule: brittle logic (regex/parse) produces a transformation, not a decision to refuse a user action.
+- **No sentinel, gate, watchdog, or sentinel-class name is introduced by this PR.**
+
+Compliance: PASS.
+
+---
+
+## 5. Interactions
+
+- No shadow/shadowed interactions in PR1 — module is not called by anything. Search confirms no existing import site.
+- Module name collision check: `src/messaging/` contains `MessageFormatter.ts` (different purpose: envelope formatting) and no `TelegramMarkdownFormatter.ts` prior to this PR. No collision.
+- Test file name: `tests/unit/telegram-markdown-formatter.test.ts`. No existing test file of that name.
+- PR2 will introduce interactions with `TelegramAdapter.apiCall`, `TelegramLifeline.apiCall`, `MessageStore` (raw/sent fields), and `GitSyncTransport` (envelope flag). Those interactions get their own artifact at PR2 time.
+
+---
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents, other users, other systems?**
+
+No. PR1 ships dead code. No route changes, no message format changes on the wire, no config schema changes applied (config fields `telegramFormatMode` / `telegramLintStrict` are spec'd but deliberately not added in PR1 — they land in PR2 alongside the wiring), no database changes, no envelope changes.
+
+- Bot API: untouched — adapter still sends exactly the bytes it sends today with exactly the `parse_mode` it uses today.
+- MessageStore: untouched.
+- GitSyncTransport: untouched.
+- Shell-script `.claude/scripts/telegram-reply.sh`: untouched.
+- Agent dashboards / self-knowledge: untouched.
+
+No timing dependencies, no conversation state dependencies.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Trivial. PR1 is a code-only addition with no runtime invocation. Rollback options in order of cost:
+
+1. **Do nothing.** The module is not on any call path; a latent bug is invisible until PR2.
+2. **Revert the merge commit.** Standard `git revert` — affects only two new files. No data migration, no agent state repair, no config flip.
+3. **Fix forward.** The module is pure functions with 105 unit tests; most fixes ship as deltas.
+
+PR2 itself is governed by the spec's staged-rollout (ships with `legacy-passthrough` default; canary via config flip). That's PR2's rollback story — out of scope for this artifact.
+
+---
+
+## Second-pass review
+
+Not required. PR1 has no block/allow surface, no session-lifecycle surface, no sentinel/gate/watchdog, no coherence/idempotency/trust change, and is shipped disabled. High-risk criteria from Phase 5 are not met.
+
+## Spec linkage
+
+- Approved spec: `docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md` (approved 2026-04-24T20:53:47Z by Justin via Telegram topic 8183).
+- Convergence report: `docs/specs/reports/telegram-markdown-renderer-convergence.md`.
+- Dawn reference impl: `the-portal/.claude/scripts/telegram_format.py` (merged 2026-04-24T17:57Z).


### PR DESCRIPTION
## Summary

PR1 of two-PR plan in [`docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md`](docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md) (approved by Justin 2026-04-24 via Telegram topic 8183).

- Adds `src/messaging/TelegramMarkdownFormatter.ts` — pure-function port of Dawn's [`telegram_format.py`](https://github.com/JKHeadley/the-portal/blob/main/.claude/scripts/telegram_format.py) with instar-specific hardening per spec.
- Adds `tests/unit/telegram-markdown-formatter.test.ts` — 105 passing tests covering every conversion step, security hardening, edge cases, ReDoS fuzz, idempotency, and boundary conditions.
- **Shipped disabled** — `TelegramAdapter.ts` and `TelegramLifeline.ts` are untouched; module is not on any send path.

## Security hardening included

- 32KB input guard → falls back to plain mode with `conversionSkipped: true` (no byte loss)
- Bounded regex quantifiers `{1,200}` everywhere (ReDoS defense, fuzz-tested)
- NUL strip as step 0; Supplementary-PUA-B strip to prevent sentinel collision
- Distinct `escapeHtmlText` vs `escapeHtmlAttribute` (quotes + C0 strip in attribute)
- Balanced-paren URL scanner (not regex) — handles Wikipedia `https://.../Entity_(computer_science)`
- WHATWG URL scheme allowlist: `http`, `https`, `tg`, `mailto` — everything else becomes literal text
- Placeholder sentinels in three isolated 20K blocks of PUA-B (never collide, user content stripped of that range up front)

## Modes

All five per spec: `plain`, `html`, `code`, `markdown`, `legacy-passthrough`. `legacy-passthrough` returns input byte-for-byte unchanged with `parseMode: undefined` so callers use their callsite-historical mode (critical for the PR2 rollback path).

## What's next (PR2)

Wires `apiCall()` in `TelegramAdapter` and `TelegramLifeline` behind a config accessor `telegramFormatMode` defaulting to `legacy-passthrough`. Adds `formatTemplate` helper, `MessageStore` rawText/sentText/modeApplied fields, GitSync envelope flag, shell script flag support, docs. Canary flip on Echo's agent first.

## Side-effects review

[`upgrades/side-effects/telegram-markdown-renderer-pr1.md`](upgrades/side-effects/telegram-markdown-renderer-pr1.md) — covers over/under-block, level-of-abstraction, signal-vs-authority compliance, interactions, external surfaces, rollback cost. Second-pass reviewer not required (no block/allow surface, shipped disabled, not on any call path).

## Convergence report

[`docs/specs/reports/telegram-markdown-renderer-convergence.md`](docs/specs/reports/telegram-markdown-renderer-convergence.md) — 6 iterations of internal + external (GPT/Gemini/Grok) review before approval.

## Test plan

- [x] `npm run test -- telegram-markdown-formatter` — 105/105 passing locally
- [x] `npm run lint` (tsc --noEmit) — clean
- [ ] CI full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)