### PR TITLE
fix(imessage-tests): add attachment tables to test fixtures (unblocks CI)

### DIFF
--- a/tests/integration/imessage-review-blockers.test.ts
+++ b/tests/integration/imessage-review-blockers.test.ts
@@ -66,6 +66,19 @@ function createTestDb(dbPath: string): Database.Database {
       FOREIGN KEY (chat_id) REFERENCES chat(ROWID),
       FOREIGN KEY (message_id) REFERENCES message(ROWID)
     );
+    CREATE TABLE attachment (
+      ROWID INTEGER PRIMARY KEY,
+      filename TEXT,
+      mime_type TEXT,
+      transfer_name TEXT,
+      total_bytes INTEGER
+    );
+    CREATE TABLE message_attachment_join (
+      message_id INTEGER,
+      attachment_id INTEGER,
+      FOREIGN KEY (message_id) REFERENCES message(ROWID),
+      FOREIGN KEY (attachment_id) REFERENCES attachment(ROWID)
+    );
   `);
   return db;
 }

--- a/tests/unit/imessage-native-backend.test.ts
+++ b/tests/unit/imessage-native-backend.test.ts
@@ -61,6 +61,21 @@ function createTestDb(dbPath: string): Database.Database {
       FOREIGN KEY (chat_id) REFERENCES chat(ROWID),
       FOREIGN KEY (message_id) REFERENCES message(ROWID)
     );
+
+    CREATE TABLE attachment (
+      ROWID INTEGER PRIMARY KEY,
+      filename TEXT,
+      mime_type TEXT,
+      transfer_name TEXT,
+      total_bytes INTEGER
+    );
+
+    CREATE TABLE message_attachment_join (
+      message_id INTEGER,
+      attachment_id INTEGER,
+      FOREIGN KEY (message_id) REFERENCES message(ROWID),
+      FOREIGN KEY (attachment_id) REFERENCES attachment(ROWID)
+    );
   `);
 
   return db;


### PR DESCRIPTION
## Summary

Integration + unit test fixtures for the iMessage adapter create \`handle\`, \`chat\`, \`message\`, \`chat_message_join\` — but the native backend now prepares a query against \`attachment\` and \`message_attachment_join\` at init time (added by the auto-hardlink attachments feature, commit 85812e1).

Result: every \`imessage-review-blockers.test.ts\` and \`imessage-native-backend.test.ts\` case fails with \`no such table: attachment\`, and Integration Tests has been red on main since that change merged. This blocks ALL PR merges because Integration Tests is a required check.

Fixture-only change — adds the two missing CREATE TABLE statements to both test files. No src changes.

## Test plan

- [x] CI Integration Tests goes green
- [x] CI Unit Tests stays green