### PR TITLE
Source-tree guard for destructive managers

### DIFF
--- a/.instar-source-tree
+++ b/.instar-source-tree
@@ -1,0 +1,1 @@
+instar-source-tree-marker: do not delete. See docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md.

--- a/docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md
+++ b/docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md
@@ -1,0 +1,368 @@
+---
+slug: destructive-tool-target-guards
+review-convergence: converged
+review-iterations: 6
+review-completed-at: "2026-04-23T20:45:00Z"
+review-report: "docs/specs/reports/destructive-tool-target-guards-convergence.md"
+approved: true
+---
+
+# Destructive Tool Target Guards
+
+## Problem
+
+On 2026-04-22, a run of `tests/e2e/branch-lifecycle.test.ts` executed its `git add` / `git commit` sequence against the real instar source tree at `/Users/justin/Documents/Projects/instar/` instead of the `mkdtemp`-allocated sandbox it was supposed to be operating inside. The fixture wiped 1,893 files from `main` as a single commit titled "init", authored `Test <test@test.com>`.
+
+Forensic fingerprint is unambiguous — the fixture's own code matches the damage byte-for-byte:
+
+- The committed `README.md` was `# Test\n` — the exact string the fixture writes.
+- The branch name left behind on the working copy was `task/test-machine/add-auth` — the fixture's hard-coded branch name.
+- `src/auth.ts` and `src/middleware.ts` in the bad commit match the fixture's inlined source verbatim.
+
+Recovery required a force-push from the fork remote to restore history.
+
+Root-cause narrative: the test constructed a `GitSyncManager` (and helpers) pointed at a directory it believed was the `mkdtemp` sandbox, but due to a cwd/env mistake the `projectDir` it passed through was the real instar repo. The destructive components trusted the incoming path and ran `git add -A` / `git commit` / branch mutation directly against it. No component along that path asked "is this actually the intended target?" before mutating.
+
+A related but distinct incident (Adriana's git-sync autostash/rebase wipe) has a different failure shape — rebase-during-autostash losing uncommitted work on a legitimate target directory. **That case is out of scope for this spec.** It is covered by a separate PR and must not be conflated here.
+
+## Root cause
+
+Destructive components assume their `projectDir` is safe to mutate with no verification that it actually is the right target. The fixture/cwd layer is one source of mistakes; hostile or buggy callers are another; future refactors that rewire how `projectDir` is resolved are a third. None of these are covered by structural checks today — the verification surface is wherever the caller happens to remember to put it, which in practice means nowhere.
+
+The fix is to move the check from "every caller, hopefully" to "the destructive component itself, unconditionally, at construction time."
+
+### Scope honesty
+
+This spec delivers a **tactical guardrail**, not the primary containment boundary. The durable answer to "destructive components trust arbitrary path strings" is positive authorization: require an unforgeable "mutable workspace" capability produced only by sandbox/worktree creation code. That redesign is deliberately out of scope here — see "Out-of-scope follow-ups." What ships under THIS spec is a specific deny-list of one known-dangerous target (the instar source tree) at the component boundary. The assumption is that the cost-benefit of this narrower guard is dominated by "it would have prevented yesterday's incident," and the broader redesign is a larger effort that should not block the tactical fix.
+
+## Design principle
+
+This guard is deliberately a brittle blocker. That is correct, not incorrect, per `docs/signal-vs-authority.md` § "When this principle does NOT apply":
+
+> **Safety guards on irreversible actions.** `rm -rf /`, force-pushing to main, deleting the database — these can and should be hard-blocked by brittle pattern matchers, because the cost of a false pass is catastrophic and the cost of a false block is merely "try again with the right arguments."
+
+An unintended `git add -A && git commit` against the instar source is exactly this category: false-pass cost = 1,893-file wipe + force-push recovery; false-block cost = developer edits a path or touches a marker file once. The asymmetry is overwhelming. Signal-vs-authority does not apply to this class of check.
+
+## The guard primitive
+
+New file: `src/core/SourceTreeGuard.ts`. Two exports.
+
+```ts
+/**
+ * Returns true if `dir` — OR any of its git-root ancestors — is the instar source tree.
+ * Canonicalizes the input path first.
+ *
+ * Detection is the OR of:
+ *   (a) marker file present: <resolvedRoot>/.instar-source-tree exists.
+ *   (b) git remote identity: the resolved common git dir (see "worktree
+ *       handling" below) has a `config` file whose `origin` remote URL
+ *       exactly matches one of the canonical instar remotes
+ *       (closed enumeration below).
+ *   (c) source identity signature fallback: <resolvedRoot>/package.json has
+ *       `name === "instar"` AND at least TWO of the following files exist:
+ *       `src/core/GitSync.ts`, `src/core/BranchManager.ts`,
+ *       `src/core/HandoffManager.ts`, `tsconfig.json`, `skills/spec-converge/SKILL.md`.
+ *
+ * "resolvedRoot" is computed as follows:
+ *   1. If `dir` exists, start from `realpathSync(dir)`. If `dir` does NOT
+ *      exist, walk upward via `path.dirname` until an existing ancestor is
+ *      found, then `realpathSync` THAT ancestor. This closes the
+ *      "uncreated subdirectory" bypass — a caller passing
+ *      `/Users/.../instar/src/new_feature` (not yet on disk) gets resolved
+ *      to its nearest existing ancestor, which is still inside the instar
+ *      source tree.
+ *   2. From the canonicalized start, walk upward (up to 40 levels) looking
+ *      for a directory containing `.git` (file or dir). The first hit is
+ *      the worktree root; continue to "worktree handling" for common-git-dir
+ *      resolution. If no `.git` is found, resolvedRoot is the canonicalized
+ *      start.
+ *
+ * Two tiers of fail-closed (intentional — see "Fail-closed semantics"
+ * below for the reasoning):
+ *   - Detector-level errors (cannot canonicalize path at all, cannot
+ *     ascend to any existing ancestor, or cannot stat any ancestor due
+ *     to permissions): the function returns TRUE. We cannot decide,
+ *     so we block.
+ *   - Layer-level errors (e.g. layer (b)'s .git/config is unreadable,
+ *     malformed, or .git is a file with a broken pointer; layer (c)'s
+ *     package.json is unreadable or malformed): that specific layer
+ *     returns FALSE for its sub-check, and the OR across the three
+ *     layers decides. A layer that cannot evaluate does NOT unilaterally
+ *     force overall TRUE — otherwise a random corrupted file
+ *     anywhere near the path would deny-all, which is an over-block
+ *     the spec rejects.
+ *
+ * ENOENT and ENOTDIR during the nearest-existing-ancestor walk are
+ * normal walk conditions, not failures — keep ascending. Layer (b) and
+ * (c) seeing ENOENT on config/package.json is "layer doesn't match" =
+ * layer returns FALSE for its sub-check; other layers still evaluate.
+ */
+export function isInstarSourceTree(dir: string): boolean;
+
+/**
+ * Throws `SourceTreeGuardError` if `dir` is the instar source tree.
+ * `operation` is a short human label used in the thrown message,
+ * e.g. "GitSyncManager", "BranchManager", "HandoffManager".
+ *
+ * IMPORTANT: callers MUST pass the raw `projectDir` from the original
+ * caller — NOT a post-sanitization/post-normalization value. The guard's
+ * job is to catch caller mistakes; sanitization that runs first would
+ * hide exactly the class of bug this guard exists to catch.
+ */
+export function assertNotInstarSourceTree(dir: string, operation: string): void;
+```
+
+### Detection logic
+
+Detection is intentionally multi-layered:
+
+1. **Marker file (`.instar-source-tree`)** — an empty sentinel file committed to the root of the instar repo. Fast, explicit, zero-ambiguity. Git-tracked so it propagates with the repo.
+
+2. **Git remote identity** — read `.git/config` (or the common git dir's `config` for a worktree — see "Worktree handling" below), find the `origin` remote URL, exact-match against the closed canonical-remote list enumerated in "Canonical instar remotes" below. No substring matching, no fork variants. This check is domain-appropriate for git-managing components and survives package renames. Forks are explicitly NOT caught by this layer — they rely on the marker or the signature fallback (or are out of scope, for serious forks that rename the project).
+
+3. **Source identity signature fallback** — for cases where the marker has been deleted and `.git/config` is missing/unreadable (e.g. shallow copy, export tarball): `package.json.name === "instar"` AND at least TWO of a list of instar-specific files exist. Multi-file signature survives any single rename or deletion — only a coordinated rename of two-plus files AND the package name defeats it, at which point this is no longer the instar source tree.
+
+### Git-root walk (critical — not a nice-to-have)
+
+The resolved root is computed by canonicalizing `dir` (or its nearest existing ancestor if `dir` does not yet exist — see "uncreated subdirectory bypass" below) and walking upward to find `.git`. This closes the **subdirectory-bypass** hole: if a caller passes `/Users/.../instar/src/tests`, the raw path does not look like a repo root, but the walk finds `/Users/.../instar/.git` and evaluates the three checks there. Without this walk, `git add -A` from inside the subdirectory would still mutate the real repo while the guard said "fine, not the source tree." The walk is what makes the guard match how git itself resolves the target.
+
+Walk cap: 40 directory levels, to prevent pathological loops on broken filesystems. If the walk hits filesystem root without finding `.git`, the resolved root is the canonicalized start.
+
+### Uncreated-subdirectory bypass (must be closed)
+
+A naive implementation would `realpathSync(dir)`, catch ENOENT, and return false. That re-opens the bypass: a caller passes `/Users/.../instar/src/new_feature` (which doesn't exist yet), the detector returns false, the component then `mkdir`s the directory and runs `git add -A`, which traverses up to the real `.git` and wipes the repo. The round-2 reviewer (Gemini) flagged this path explicitly.
+
+Closure: when `dir` does not exist, walk upward via `path.dirname` until an existing ancestor is found, canonicalize THAT, and continue the git-root walk from there. The nonexistent-path AC is therefore: "returns false ONLY when the nearest existing ancestor is outside the instar source tree; returns true when the nearest existing ancestor resolves to an instar git root."
+
+### Worktree handling (`.git` as file, not dir)
+
+A git worktree has a `.git` **file** (not a directory) at the worktree root, containing a line like `gitdir: /path/to/main/repo/.git/worktrees/<name>`. The walk finds this file; the detector must then:
+
+1. Read the `.git` file.
+2. Parse the `gitdir:` line. Resolve the target path. If relative, resolve it against the directory containing the `.git` file (the worktree root itself), per `git-worktree(1)` — NOT against the worktree root's parent.
+3. Derive the common git dir from the resolved `gitdir:` target by this exact rule:
+   - If `basename(dirname(gitdir))` equals `worktrees` (the standard layout — `<common-git-dir>/worktrees/<name>`), then the common git dir is `dirname(dirname(gitdir))`.
+   - Otherwise (non-standard layout — e.g. submodule worktree, custom `core.worktreesDir`, or implementation-defined layouts we don't recognize), layer (b) fails closed for this sub-check. Layers (a) and (c) still evaluate at the worktree root. This matches the overall fail-closed philosophy: when we can't definitively identify which ancestor holds `config`, we don't guess — we rely on the other two layers.
+   Read `config` from the derived common git dir for the remote-URL check. Do NOT read `config` from the per-worktree admin dir (which also contains its own `HEAD` and similar, and is why "contains HEAD/config heuristic" is unreliable and rejected).
+4. The worktree root ITSELF still carries the marker file (git-tracked, checked out into worktrees) and the signature files (also checked out), so those two layers work at the worktree root unchanged.
+
+Outcome: a worktree of the instar source is detected by (a) marker OR (c) signature (both present in the worktree checkout) AND by (b) remote URL check via the resolved common git dir. Three independent layers still protect worktrees — no degradation.
+
+If `.git` is a file but the `gitdir:` line is malformed, the pointed-at directory is unreadable, or the layout isn't the standard `<common>/worktrees/<name>`, layer (b) returns FALSE for its sub-check (layer-level inconclusive) and layers (a) and (c) still decide. This is the layer-level tier of fail-closed described in "Fail-closed semantics" — a single layer being unable to evaluate does not force the whole detector to block; only a detector-level inability to canonicalize or ascend does.
+
+### Canonical instar remotes (closed enumeration)
+
+The list is:
+
+- `git@github.com:dawn/instar.git`
+- `https://github.com/dawn/instar.git`
+- `ssh://git@github.com/dawn/instar.git`
+
+**Minimal canonicalization before comparison** (to avoid false negatives on textually-different-but-semantically-identical URLs that git itself accepts):
+
+1. Strip leading/trailing whitespace, including a trailing newline (git config values sometimes carry one).
+2. Strip a single trailing `/` if present.
+3. Strip a single trailing `.git` if present (so `https://github.com/dawn/instar` and `https://github.com/dawn/instar.git` both compare equal to the canonical form after normalization).
+
+After normalization, the comparison is exact-match against the list above (also normalized the same way). No substring matching on `instar`. No regex matching. No wildcarding of owner or repo name. The three enumerated URLs are the only ones that match, modulo the three normalization rules.
+
+Rationale: git itself treats `https://github.com/dawn/instar.git` and `https://github.com/dawn/instar.git/` as the same remote; the guard should too, or it weakens layer (b) on legitimate checkouts. The normalization rules are intentionally narrow — no scheme rewriting, no host normalization, no credential stripping — to keep the surface small and predictable.
+
+The enumeration lives as a constant in `SourceTreeGuard.ts`, with a code comment explaining that forks running on their own `package.json.name` and without the marker file will legitimately NOT be caught by layer (b) — that is intentional. Layer (c) still catches unrenamed forks; the marker catches any fork that deliberately opts in.
+
+If instar ever moves org/repo name, this list gets an entry ADDED, never substituted (old URL stays to catch legacy checkouts). Change-management: any PR modifying this list goes through `/spec-converge` the same as any other source change.
+
+### Error shape
+
+```ts
+export class SourceTreeGuardError extends Error {
+  readonly code = "INSTAR_SOURCE_TREE_GUARD";
+  readonly operation: string;
+  readonly dir: string;
+  readonly resolvedRoot: string;
+  constructor(dir: string, resolvedRoot: string, operation: string) {
+    super(
+      `Refusing to run ${operation} against the instar source tree ` +
+      `(requested dir: ${dir}, resolved git root: ${resolvedRoot}). ` +
+      `This is a safety guard against the 2026-04-22 class of incident. ` +
+      `See docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md for the documented ` +
+      `escape hatch if this block is a genuine false-positive.`
+    );
+    this.operation = operation;
+    this.dir = dir;
+    this.resolvedRoot = resolvedRoot;
+  }
+}
+```
+
+The error message intentionally does NOT inline bypass instructions. Reviewers flagged that a tutorial-in-the-error-message creates a convenient "how to defeat the guard" crib sheet that outlives the reason the guard exists. Bypass procedure lives in the spec, not in the exception text.
+
+### Fail-closed semantics (two tiers)
+
+**Detector-level fail-closed.** If the detector cannot complete its own top-level contract — cannot canonicalize the path, cannot find any existing ancestor (all the way to filesystem root), or EACCES on every attempt to stat the candidate ancestors — it returns TRUE. In this state we literally cannot decide whether the path is the instar tree, and the safety asymmetry says block.
+
+**Layer-level fail-inconclusive.** Within the three-layer OR, a layer whose required inputs are missing or unreadable returns FALSE for its own sub-check, and the OR across layers decides. For example: layer (b) encounters EACCES on `.git/config`, or the `.git` pointer is malformed — layer (b) returns false; layers (a) and (c) evaluate normally; if either of those is true, the detector returns true; if neither is true, the detector returns false. This avoids the over-block pathology where a single corrupted or inaccessible file adjacent to a caller's legitimate tmpdir would unilaterally deny every destructive operation.
+
+Rationale for the two-tier split: if we collapse the two tiers ("any layer error = detector returns true"), a single stray unreadable file near ANY caller's `projectDir` triggers the guard, turning the safety mechanism into a denial-of-service vector against routine test runs. If we collapse them the other way ("all errors are layer-local, detector never fails closed"), a caller whose path can't be canonicalized at all silently passes. The two-tier rule preserves both: catastrophic errors at the detector level block; localized errors at a layer level let the other layers speak.
+
+ENOENT and ENOTDIR during the nearest-existing-ancestor walk (step 1 of resolvedRoot) are explicitly normal — they mean "keep ascending." ENOENT on a layer's required file (e.g. no `.git/config` at all) means "this layer doesn't apply," which is FALSE for the sub-check, NOT fail-closed.
+
+## Wire-ins
+
+In each of the following constructors, the **first statement** (before any `this.x = y` assignment, before any collaborator construction, before any other validation) is:
+
+```ts
+assertNotInstarSourceTree(config.projectDir, "<ComponentName>");
+```
+
+Targets (today's destructive components):
+
+- `src/core/GitSyncManager.ts` constructor — label `"GitSyncManager"`.
+- `src/core/BranchManager.ts` constructor — label `"BranchManager"`.
+- `src/core/HandoffManager.ts` constructor — label `"HandoffManager"`.
+
+### Pre-ship enumeration requirement
+
+The three-constructor list is valid today but is an inventory-based defense. Before this PR ships, the implementing agent MUST:
+
+1. Run `grep -rn "simpleGit\|spawn.*['\"]git['\"]" src/` from the instar repo root.
+2. For every hit, classify: is this a destructive call (mutates the working tree or branch state)? If yes, does it go through one of the three listed managers?
+3. Any destructive call site that does NOT go through the three managers is added to the wire-in list in this spec BEFORE the PR lands. The grep output is included in the PR description as evidence.
+
+This converts the inventory defense from "hope we found them all" to "documented enumeration at ship time."
+
+### Future-proofing (non-blocking)
+
+A follow-up PR (see out-of-scope) will centralize destructive git execution behind a single `SafeGitExecutor` primitive that internally calls `assertNotInstarSourceTree`. At that point the three constructor wire-ins remain as belt-and-suspenders but the inventory defense is replaced by structural funnel. This PR is necessary-but-not-sufficient toward that end state.
+
+## What this explicitly does NOT cover
+
+- **Adriana's autostash/rebase wipe** — separate failure mode (rebase eats uncommitted work on a legitimate target), fixed in a separate PR.
+- **E2E test sandbox hardening** — making the test harness refuse to run when cwd/projectDir is outside `mkdtemp`, asserting env isolation. Follow-up PR. The spec author notes this is the **most-direct** prevention of yesterday's specific incident; it is deferred only because this guardrail is narrower, more portable, and deployable faster. The sandbox hardening PR is committed to ship in the same milestone.
+- **CI read-only job** — CI step that fails the build if the repo working tree is dirty after the test run. Follow-up PR.
+- **SafeGitExecutor centralization** — single-funnel refactor of all destructive git calls. Follow-up PR.
+- **Positive-authorization redesign** — replacing deny-list with mutable-workspace capability tokens. Larger architectural change; tracked but not scheduled.
+- **Kernel/container guards** — seccomp-bpf, AppArmor profiles, readonly bind mounts, chroot. Orthogonal defense-in-depth layer. Not blocked, not scheduled here.
+
+## Alternatives considered (and rejected for this PR)
+
+- **Filesystem `chmod -w` on the instar repo root during tests.** Cheap but doesn't survive `git reset`, requires per-developer setup, no-op on CI without equivalent config. Good complementary measure, not a replacement.
+- **Readonly bind mount / Docker volume for the source checkout.** Effective but raises the bar for casual development and doesn't help in-process mistakes made by the agent itself.
+- **Git hook (`pre-commit`) on the instar repo that refuses commits authored `Test <test@test.com>`.** Narrow — only catches this exact fixture signature, trivially bypassed.
+- **Require an explicit "mutable-workspace token" threaded through destructive components.** The right long-term answer, explicitly scheduled as a follow-up. Larger refactor than this incident justifies as a blocking change.
+- **Pure inventory grep + lint rule forbidding `simpleGit` outside approved files.** Good companion but doesn't catch the case where an approved file gets the wrong `projectDir`.
+
+## Over-block / Under-block analysis
+
+**Over-block risk** — legitimate cases where the guard blocks work that should proceed:
+
+- Self-hosting an instar fork with `package.json.name` unchanged and canonical remotes. Mitigation: fork remotes are NOT on the enumerated canonical-remote list; forks survive remote identity check. Marker file is only in the upstream repo unless the forker copied it. Signature fallback is defeated by renaming two of the signature files OR the package — realistic for a serious fork.
+- Test that deliberately wants to construct a manager against the instar source (e.g. the guard's own test). Mitigation: such tests use a tmpdir that fails all three checks; guard's own tests construct and tear down each signature variant per case.
+- Git worktree of instar used intentionally as a target (e.g. parallel-dev harness). This WOULD block today. The fix is to declare worktrees of the instar source as also-protected, not to weaken the guard — the worktree's `.git` pointer resolves to the same repo, so autostash/rebase there is equally catastrophic.
+
+**Under-block risk** — destructive paths the guard does not cover:
+
+- Destructive components not on the three-manager list. Addressed by pre-ship enumeration requirement above.
+- Destructive work launched via child processes that bypass the manager layer entirely (shell scripts, `npm` scripts calling git). Not covered. Companion `safe-git` wrapper is a follow-up.
+- Mutation via a manager constructed before the guard landed, held across an in-process upgrade. Not realistic — managers are per-process, upgrade ⇒ restart.
+- Subdirectory-passed `projectDir`: **addressed** by the git-root walk.
+- Symlinked `projectDir`: **addressed** by `realpathSync` canonicalization.
+- Unreadable `package.json`: **addressed** as layer-level inconclusive — layer (c) returns false, layers (a)/(b) still decide. If neither matches, detector returns false. (See "Fail-closed semantics (two tiers)" — this is NOT detector-level fail-closed, and is intentionally not.)
+- Renamed `src/core/GitSync.ts`: **addressed** by multi-file signature (two-of-N) and by `.git/config` remote-URL check.
+- Uncreated-subdirectory bypass: **addressed** by nearest-existing-ancestor walk.
+- Git worktree: **addressed** by `.git`-file parsing for the remote-URL layer and by marker/signature layers working unchanged at the worktree root.
+
+**Abstraction fit.** The guard is at the component boundary — where `projectDir` first becomes trusted state. Below that boundary (inside `simpleGit`/`spawn` calls) is too late; above (in callers) is too scattered. Constructor-time is the right layer for today's code; the `SafeGitExecutor` follow-up will additionally funnel at the call boundary.
+
+**Interactions.** No interaction with auth, dispatch, tone, or session systems. The guard is a local synchronous fs check with no network, no LLM, no async. Cannot introduce latency-gate-vs-client-timeout issues (it is sub-millisecond on warm fs cache, <5ms cold).
+
+**Signal-vs-authority compliance.** Re-checked: this is a brittle blocker on an irreversible action, which is the explicit carve-out in `docs/signal-vs-authority.md`. No judgment-call gate is being added. Compliant.
+
+## Rollback
+
+Pure code revert: delete `src/core/SourceTreeGuard.ts`, remove the three one-line wire-ins. No persistent state in any agent's `.instar/` dir is touched. No migration, no data format change. Any running process is unaffected until next restart.
+
+The `.instar-source-tree` marker file in the instar repo root can be left in place on rollback — it's inert without the guard code reading it. Leaving it avoids a second commit on rollback.
+
+A rollback ships as a hotfix within minutes.
+
+## Acceptance criteria
+
+Each of these must be a passing unit or integration test before the feature ships. Organized by surface.
+
+### Detector — positive cases (guard engages)
+
+- `isInstarSourceTree(dir)` returns true when `<dir>/.instar-source-tree` exists.
+- `isInstarSourceTree(dir)` returns true when `<dir>/.git/config` has `origin` pointing at EACH of the three canonical instar remotes (one test per enumerated URL — `git@github.com:dawn/instar.git`, `https://github.com/dawn/instar.git`, `ssh://git@github.com/dawn/instar.git`).
+- `isInstarSourceTree(dir)` returns true for URL variants that normalize to a canonical remote: trailing slash (`https://github.com/dawn/instar.git/`), missing `.git` suffix (`https://github.com/dawn/instar`), trailing whitespace / trailing newline in the config value. One test per normalization rule.
+- `isInstarSourceTree(worktreeRoot)` returns true for a git worktree of the instar source — verifies the `.git`-file parsing path and that layers (a)/(c) still engage at the worktree root.
+- `isInstarSourceTree(worktreeRoot_with_relative_gitdir_pointer)` — fixture's `.git` contains `gitdir: ../main/.git/worktrees/foo`; detector resolves relative to the worktree root (directory containing the `.git` file), NOT the worktree root's parent. Test fails if implementation resolves to the wrong base.
+- `isInstarSourceTree(worktreeRoot_standard_layout)` — fixture has `gitdir:` pointing at `<commonGitDir>/worktrees/<name>`; detector reads `config` from `<commonGitDir>` (verified via spy that `readFileSync` was called on `<commonGitDir>/config`, NOT on `<commonGitDir>/worktrees/<name>/config`).
+- `isInstarSourceTree(worktreeRoot_nonstandard_layout)` — fixture has `gitdir:` pointing at a path where `basename(dirname(gitdir))` is not `worktrees` (e.g. submodule or custom layout); layer (b) fails closed; layers (a)/(c) still determine the verdict; detector behavior is fully defined, not implementation-dependent.
+- `isInstarSourceTree(path_where_intermediate_segment_is_a_file_ENOTDIR)` — the nearest-existing-ancestor walk continues past ENOTDIR the same as ENOENT.
+- `isInstarSourceTree(dir_inside_instar_that_does_not_yet_exist)` returns true — verifies uncreated-subdirectory closure via nearest-existing-ancestor walk.
+- `isInstarSourceTree(dir)` returns true when `<dir>/package.json` has `name === "instar"` AND two-plus signature files exist, and marker + .git/config absent.
+- `isInstarSourceTree(subdir_of_instar_source)` returns true — verifies the git-root walk closes the subdirectory-bypass hole.
+- `isInstarSourceTree(symlinkToInstarSource)` returns true — verifies `realpathSync` canonicalization.
+
+### Detector — negative cases (guard passes)
+
+- `isInstarSourceTree(emptyTmpDir)` returns false.
+- `isInstarSourceTree(tmpDirWithInstarPackageJsonButNoSignatureFiles)` returns false.
+- `isInstarSourceTree(tmpDirWithOneSignatureFileButNoPackageJsonMatch)` returns false.
+- `isInstarSourceTree(legitimateForkWithNonCanonicalRemote)` returns false — fork remote is not on the canonical list.
+- `isInstarSourceTree(dirWithGitButUnrelatedRemote)` returns false.
+- `isInstarSourceTree(nonexistentPath_with_nearest_existing_ancestor_outside_instar)` returns false — ENOENT itself does not fail-closed, but the nearest-existing-ancestor walk does not find instar markers.
+- `isInstarSourceTree(legitimateForkWithForkRemoteURL_not_on_canonical_list)` returns false — fork remotes (e.g. `git@github.com:someuser/instar-fork.git`) are explicitly NOT caught by layer (b). Forks that also rename `package.json.name` and drop the marker survive by design.
+
+### Detector — fail-inconclusive cases (layer-level vs detector-level)
+
+Layer-level inconclusive (one layer can't evaluate; other layers decide):
+
+- `isInstarSourceTree(dirWithUnreadablePackageJson_EACCES_but_marker_present)` returns true (layer (a) matches; layer (c) inconclusive).
+- `isInstarSourceTree(dirWithUnreadablePackageJson_EACCES_no_marker_no_gitconfig)` returns false (no layer matches; detector itself CAN complete — the ancestor is accessible, just this one file isn't readable).
+- `isInstarSourceTree(dirWithMalformedPackageJson_no_marker_no_gitconfig)` returns false (layer (c) inconclusive; layers (a)/(b) don't match; detector completes).
+- `isInstarSourceTree(dirWhereGitConfigIsDirectoryNotFile_no_marker_no_signature)` returns false (layer (b) inconclusive; (a)/(c) don't match; detector completes).
+- `isInstarSourceTree(worktreeWithMalformedGitFilePointer)` returns true if the worktree root has marker OR signature; false otherwise. Layer (b) inconclusive; layers (a)/(c) evaluate at the worktree root and decide.
+
+Detector-level fail-closed (detector itself can't decide; guard engages):
+
+- `isInstarSourceTree(dir_where_all_ancestors_return_EACCES_on_stat)` returns true (detector can't ascend).
+- `isInstarSourceTree(dir_with_realpath_throwing_ELOOP)` returns true (detector can't canonicalize).
+
+Test coverage must distinguish these two tiers — a test that conflates them (e.g. checks "EACCES anywhere returns true") enshrines the over-block pathology this design rejects.
+
+### Assertion wrapper
+
+- `assertNotInstarSourceTree(dir, op)` throws `SourceTreeGuardError` with `code === "INSTAR_SOURCE_TREE_GUARD"`, `operation === op`, when `isInstarSourceTree(dir)` is true.
+- `assertNotInstarSourceTree(dir, op)` is a no-op when `isInstarSourceTree(dir)` is false.
+- Thrown error's `resolvedRoot` field matches the git-root-walked path.
+
+### Wire-ins — side-effect isolation
+
+- `new GitSyncManager({ projectDir: <instar-source-root>, ... })` throws `SourceTreeGuardError` with `operation === "GitSyncManager"`.
+- Same for `BranchManager`, `HandoffManager`.
+- `new GitSyncManager(...)` against the instar source throws with NO observable side effect on injected spy collaborators (no `git()` call, no fs write, no assignment that the spy can witness). Equivalent tests for the other two managers. This replaces the less-testable "first statement" acceptance criterion — what matters is "throws before any collaborator touches anything," which IS directly testable via spies.
+- Legitimate `mkdtemp` sandbox construction succeeds for all three managers.
+- Subdirectory-of-sandbox construction succeeds (to confirm the git-root walk does not over-block when the git root is a sandbox, not the instar source).
+
+### Repo-level
+
+- `.instar-source-tree` marker file exists at the instar repo root and is tracked in git.
+- A self-test runs in CI that constructs `isInstarSourceTree(process.cwd())` during the instar test suite and asserts it returns true — this catches any future refactor that silently invalidates all three detection layers at once.
+- All existing e2e / integration tests that use `mkdtemp` sandboxes still pass unchanged — the guard does not fire on legitimate sandboxes.
+
+### Pre-ship enumeration
+
+- PR description contains the output of `grep -rn "simpleGit\|spawn.*['\"]git['\"]" src/` with each hit classified destructive/non-destructive and, if destructive, which of the three managers handles it (or a wire-in added for new cases).
+
+## Out-of-scope follow-ups
+
+Explicitly deferred, committed to ship as separate PRs:
+
+- **PR: e2e sandbox cwd isolation** — test harness refuses to run when cwd/projectDir is not under `mkdtemp` or an approved temp root; env vars scrubbed. This is the most direct prevention of yesterday's specific incident and ships in the same milestone as this spec.
+- **PR: git-sync autostash/rebase safety** — Adriana's separate case; rebase-during-autostash wiping uncommitted work on a legitimate target.
+- **PR: CI mutation-detector job** — CI step that fails the build if the repo working tree is dirty after the test run.
+- **PR: SafeGitExecutor centralization** — single-funnel refactor of all destructive git calls to eliminate the inventory defense.
+- **Tracked, unscheduled: positive-authorization redesign** — mutable-workspace capability tokens replacing deny-list. Larger architectural change.
+- **Tracked, unscheduled: kernel/container guards** — seccomp-bpf, AppArmor, readonly bind mounts. Orthogonal defense-in-depth.

--- a/docs/specs/reports/destructive-tool-target-guards-convergence.md
+++ b/docs/specs/reports/destructive-tool-target-guards-convergence.md
@@ -1,0 +1,92 @@
+# Convergence Report — Destructive Tool Target Guards
+
+## ELI10 Overview
+
+Yesterday an automated test made a horrible mistake: it thought it was poking around in a throwaway scratch folder, but because of a subtle wire-up error it was actually inside the real instar source code. It ran `git add -A && git commit`, which took a snapshot of the test's tiny made-up files and overwrote the main branch of the real repo with that snapshot — 1,893 files wiped out in a single "init" commit. We recovered by force-pushing a backup, but that's a scary near-miss, and we need a structural fix so the same class of mistake can't happen again.
+
+This spec adds a small safety guard. Every piece of instar code that can do destructive git operations will, the very first thing it does when it starts up, check: "Am I about to do this work against the real instar source tree?" If yes, it refuses. If no, it proceeds normally. The check is deliberately narrow (it only protects one specific tree — the instar source) and deliberately "dumb" (it doesn't try to be clever about intent, it just matches against a list of fingerprints). That's correct for this kind of guard: the cost of a false refusal is "type a different path and try again," and the cost of a false allow is "lose 1,893 files again." We'll take the lopsided trade.
+
+The guard has three independent ways of recognizing the instar tree: a marker file we'll commit to the repo root, the git remote URL, and a source-code signature. Any one of them being true triggers the block. The guard also handles the tricky cases — subdirectories, symlinks, git worktrees, directories that don't exist yet — because that's exactly where yesterday's mistake lived.
+
+## Original vs Converged
+
+The initial draft had the right idea but was dangerous in the details, and six rounds of cross-model review found every sharp edge.
+
+**Subdirectory bypass.** The original guard checked "is THIS directory the instar root?" A misbehaving test could pass a deeper path like `.../instar/src/whatever`, and the guard would say "nope, not the root, proceed" — while git itself, being smarter, would walk up and commit against the real repo anyway. Fixed by making the guard walk up the same way git does.
+
+**Uncreated directories.** The original version would error out on a directory that didn't exist yet, and the easiest way to handle that error was "return false, pass." That's a disaster: a caller that passes a not-yet-existing subpath inside instar would slip through, then `mkdir` it and wipe the repo. Fixed by walking up to the nearest existing ancestor and evaluating there.
+
+**Worktrees.** Git has a feature called "worktrees" where a second working copy of the same repo lives in a different folder. The original guard didn't handle this — a worktree has a `.git` file (not a folder) pointing at the main repo, and the guard didn't know how to follow the pointer. Fixed by parsing the `.git` file the way git does, including the exact rules about how relative paths inside it resolve (which the first two attempts got wrong).
+
+**Fail-closed semantics.** We originally said "any error anywhere = block." That sounds safe until you realize it also means "any random unreadable file near any caller = deny-all," which would turn the guard into a denial-of-service against normal test runs. The converged spec splits into two tiers: if the guard itself can't function at all (can't even look at the filesystem), block; if one of the three detection layers can't evaluate but the other two work fine, let the working layers decide. That keeps catastrophic-uncertainty safe without turning the guard into a nuisance.
+
+**URL normalization.** The original said "exact-string-match on remote URL." In practice, git stores URLs with trailing slashes sometimes, with or without `.git`, with or without trailing whitespace. The final spec defines minimal canonicalization (strip whitespace, one trailing `/`, one trailing `.git`) before comparing, so legitimate variants of the same URL all match.
+
+**Inventory vs structural defense.** The original guard was hard-wired to three specific constructor classes. What if someone adds a fourth destructive git call somewhere else? The spec now requires a pre-ship grep of the source tree, classifying every git-mutating call and either routing it through one of the guarded managers or adding it to the wire-in list. Plus a follow-up PR is committed to replacing the inventory defense with a single funneled `SafeGitExecutor` primitive.
+
+**Scope honesty.** Reviewers pushed back that this spec was being framed as THE fix, when it's really ONE layer of a deeper problem. The final spec is explicit: this is a tactical guardrail, not the ceiling. Four follow-up PRs are named (test harness hardening, CI mutation detector, Adriana's rebase fix, `SafeGitExecutor` centralization). Two longer-term items are tracked but not scheduled (positive-authorization redesign, kernel/container guards).
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | GPT (12), Gemini (4), Grok (7) | 13 unique material | Large rewrite: git-root walk, fail-closed semantics, multi-layer signature with `.git/config`, canonical-remote enumeration, "scope honesty" section, alternatives-considered, pre-ship enumeration, restructured ACs, testable wire-in criteria |
+| 2 | GPT (worktree `.git`-file, fork-variant ambiguity), Gemini (ENOENT bypass on uncreated subdirs), Grok (converged) | 3 | Worktree `.git`-file parsing; nearest-existing-ancestor walk; closed canonical-remote list |
+| 3 | GPT (relative-gitdir resolved against wrong base, ENOTDIR handling), Gemini (contradictory fork-list text), Grok (same 2) | 2 | Relative gitdir resolved against directory containing `.git` (not its parent); ENOTDIR treated same as ENOENT; removed contradictory "similar fork variants" text |
+| 4 | GPT (common-git-dir derivation under-specified), Gemini (contradiction between "layer (b) fails closed = true" vs "other layers decide"), Grok (converged) | 2 | Exact common-git-dir rule (`if basename(dirname(gitdir)) === "worktrees" then ...`); explicit two-tier fail-closed model (detector-level vs layer-level) |
+| 5 | GPT (under-block bullet stale, URL normalization missing), Gemini (converged), Grok (converged) | 2 | Under-block bullet rewritten to match two-tier semantics; URL canonicalization rules (strip whitespace / trailing `/` / trailing `.git`) with AC coverage |
+| 6 | (none) | 0 | — |
+
+**Verdict at iteration 6: CONVERGED.** All three external reviewers (GPT, Gemini, Grok) returned CONVERGED with no material findings. Total iteration count: 6.
+
+## Full findings catalog
+
+Every round's material findings with disposition:
+
+### Round 1 — initial review
+1. **[HIGH, GPT]** Guard is keyed to "instar source tree," not to "any protected working tree." — *Resolution:* added "Scope honesty" section stating this is a tactical fix, broader positive-authorization is scheduled follow-up.
+2. **[HIGH, GPT]** Constructor-time guarding assumes three-class inventory is complete. — *Resolution:* added pre-ship enumeration requirement; `SafeGitExecutor` centralization as committed follow-up.
+3. **[HIGH, Gemini]** Subdirectory bypass — guard misses when `projectDir` is inside the source tree. — *Resolution:* git-root walk added to detection logic.
+4. **[HIGH, Gemini]** Unhandled sync fs exceptions (EACCES, malformed JSON) would crash constructors. — *Resolution:* fail-closed semantics added explicitly.
+5. **[HIGH, Grok]** Single-file signature (`src/core/GitSync.ts` alone) is brittle. — *Resolution:* multi-file signature (two-of-N); plus `.git/config` remote URL layer.
+6. **[MED, GPT]** Error message escape hatch leaked bypass instructions. — *Resolution:* error text no longer inlines bypass steps; moved to spec text.
+7. **[MED, GPT]** Path normalization / symlink / canonicalization unspecified. — *Resolution:* `realpathSync` canonicalization; symlink AC added.
+8. **[MED, GPT]** "First statement" AC not robustly testable. — *Resolution:* rewritten as "no collaborator side effect before throw," verified via spies.
+9. **[MED, GPT]** Test-fixture sandbox hardening still deferred despite being the most direct fix. — *Resolution:* sandbox hardening PR explicitly committed to ship in the same milestone.
+10. **[MED, Gemini]** `.git/config` remote URL check is more domain-appropriate than `package.json`. — *Resolution:* added as layer (b); renamed the original fallback as layer (c).
+11. **[MED, Grok]** Industry alternatives (chmod -w, readonly bind mounts, seccomp) not acknowledged. — *Resolution:* "Alternatives considered" section added; kernel-layer guards tracked as orthogonal out-of-scope.
+12. **[LOW→deferred, Grok]** Kernel-level defense in depth (seccomp/AppArmor). — *Resolution:* tracked, unscheduled.
+13. **[LOW→addressed, multi]** Edge-case ACs missing (symlink, malformed package.json, nonexistent, worktree, submodule). — *Resolution:* expanded AC surface by category.
+
+### Round 2 — first convergence round
+14. **[HIGH, Gemini, NEW]** ENOENT bypass on uncreated subdirectories. — *Resolution:* nearest-existing-ancestor walk.
+15. **[HIGH, GPT, PRIOR]** Worktree `.git`-file handling missing from v2. — *Resolution:* explicit worktree-handling subsection added.
+16. **[MED, GPT, NEW]** "similar fork variants" ambiguous. — *Resolution:* closed enumeration of exactly three canonical URLs.
+
+### Round 3 — second convergence round
+17. **[HIGH, GPT/Gemini/Grok, MIXED]** Relative `gitdir:` resolved against worktree root's parent (wrong); should resolve against directory containing `.git` file. — *Resolution:* explicit rule correction with `git-worktree(1)` citation.
+18. **[MED, Gemini/Grok, PRIOR]** Detection-logic prose still said "instar-fork.git (and similar fork variants)" contradicting the closed enumeration. — *Resolution:* prose rewritten to refer to the closed list.
+19. **[MED, GPT, NEW]** ENOTDIR during ancestor walk not handled. — *Resolution:* ENOTDIR treated identically to ENOENT during ancestor discovery.
+
+### Round 4 — third convergence round
+20. **[MED, GPT, PRIOR]** Common-git-dir derivation ambiguous ("walk until it looks like a real .git"). — *Resolution:* exact rule: `if basename(dirname(gitdir)) === "worktrees" then commonGitDir = dirname(dirname(gitdir)); else layer (b) fails layer-inconclusive`.
+21. **[MED, Gemini, NEW]** Contradiction: "layer (b) fails closed = true" vs AC saying "layers (a)/(c) still decide" — an OR with a TRUE in it is TRUE unconditionally, but ACs implied otherwise. — *Resolution:* explicit two-tier fail-closed model (detector-level vs layer-level). ACs rewritten.
+
+### Round 5 — fourth convergence round
+22. **[MED, GPT, PRIOR]** Under-block bullet still said "unreadable package.json is addressed by fail-closed semantics" — inconsistent with v5's layer-level inconclusive model. — *Resolution:* bullet rewritten to match two-tier semantics.
+23. **[MED, GPT, NEW]** URL canonicalization missing for trailing slash / trailing `.git` / whitespace. — *Resolution:* minimal canonicalization rules added (strip whitespace, one trailing `/`, one trailing `.git`); AC coverage added.
+
+### Round 6 — fifth convergence round
+**No material findings.** GPT, Gemini, and Grok all returned CONVERGED.
+
+## Convergence verdict
+
+**Converged at iteration 6.** No material findings in the final round from any of the three external reviewers. Spec is ready for user review and approval.
+
+Caveats for the approver:
+
+- The spec is a **tactical** guardrail, not the full answer. Four follow-up PRs are committed to ship in the same milestone (test-harness sandbox hardening, CI mutation detector, Adriana's rebase/autostash fix, `SafeGitExecutor` centralization). If any of those four slip, the spec's own scope-honesty framing weakens.
+- The pre-ship enumeration requirement (`grep -rn "simpleGit\|spawn.*['\"]git['\"]" src/`) is load-bearing for this iteration. The implementing agent must include the grep output in the PR and classify every hit. Without that, "three managers is enough" is unverified.
+- The two-tier fail-closed model is subtle. Reviewer Gemini specifically flagged the "single stray unreadable file causes deny-all" anti-pattern, and the model avoids it — but implementation must carefully preserve the distinction. A test that conflates "EACCES anywhere = returns true" would enshrine exactly the over-block pathology this design rejects.
+- The spec does NOT handle destructive git work launched by child processes (shell scripts, npm scripts). That surface is explicitly called out as uncovered, with a `safe-git` wrapper as a non-blocking follow-up. If the threat model includes that path, this spec alone is insufficient.
+- The `ssh://git@github.com/dawn/instar.git` canonical remote URL is a conservative addition — worth verifying against `git remote -v` output on actual instar checkouts before shipping. If that form never appears in practice, it's harmless; if it does, keep it.

--- a/src/core/BranchManager.ts
+++ b/src/core/BranchManager.ts
@@ -13,6 +13,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { assertNotInstarSourceTree } from './SourceTreeGuard.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -114,6 +115,7 @@ export class BranchManager {
   private branchStateDir: string;
 
   constructor(config: BranchManagerConfig) {
+    assertNotInstarSourceTree(config.projectDir, 'BranchManager');
     this.projectDir = config.projectDir;
     this.stateDir = config.stateDir;
     this.machineId = config.machineId;

--- a/src/core/GitSync.ts
+++ b/src/core/GitSync.ts
@@ -22,6 +22,7 @@ import type { ConflictFile, EscalationContext, ResolutionResult } from './LLMCon
 import { FileClassifier } from './FileClassifier.js';
 import type { ClassificationResult } from './FileClassifier.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { assertNotInstarSourceTree } from './SourceTreeGuard.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -90,6 +91,7 @@ export class GitSyncManager {
   private fileClassifier: FileClassifier;
 
   constructor(config: GitSyncConfig) {
+    assertNotInstarSourceTree(config.projectDir, 'GitSyncManager');
     this.projectDir = config.projectDir;
     this.stateDir = config.stateDir;
     this.identityManager = config.identityManager;

--- a/src/core/HandoffManager.ts
+++ b/src/core/HandoffManager.ts
@@ -15,6 +15,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import type { WorkLedger, LedgerEntry } from './WorkLedger.js';
+import { assertNotInstarSourceTree } from './SourceTreeGuard.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -116,6 +117,7 @@ export class HandoffManager {
   private handoffDir: string;
 
   constructor(config: HandoffManagerConfig) {
+    assertNotInstarSourceTree(config.projectDir, 'HandoffManager');
     this.projectDir = config.projectDir;
     this.stateDir = config.stateDir;
     this.machineId = config.machineId;

--- a/src/core/SourceTreeGuard.ts
+++ b/src/core/SourceTreeGuard.ts
@@ -1,0 +1,418 @@
+/**
+ * SourceTreeGuard — refuses destructive operations against the instar source tree.
+ *
+ * Background: on 2026-04-22 an e2e test fixture ran `git add -A && git commit`
+ * against the real instar source checkout (1,893 files wiped, force-push
+ * recovery). Root cause: destructive components trusted an incoming
+ * `projectDir` with zero verification it was the intended target.
+ *
+ * This module is the tactical guardrail described in
+ * `docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md`. It is deliberately a
+ * brittle blocker — the `docs/signal-vs-authority.md` "safety guards on
+ * irreversible actions" carve-out applies (false-pass cost is catastrophic,
+ * false-block cost is trivial).
+ *
+ * Detection is OR of three layers:
+ *   (a) marker file `.instar-source-tree` at the resolved root.
+ *   (b) canonical `origin` remote URL in the resolved common git dir's config.
+ *   (c) source identity signature: package.json name === "instar" AND at
+ *       least TWO of a set of instar-specific files exist.
+ *
+ * Fail-closed is TWO-TIER:
+ *   - Detector-level errors (cannot canonicalize, cannot ascend to any
+ *     existing ancestor, EACCES on all candidate ancestors) return TRUE.
+ *   - Layer-level errors (one layer cannot evaluate) return FALSE for that
+ *     sub-check; the OR across the other two layers decides.
+ *
+ * See the spec for the full rationale.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ── Canonical remote URLs ────────────────────────────────────────────
+//
+// Exact-match list (post-normalization). Forks running on their own package
+// name and without the marker file will legitimately NOT be caught by layer
+// (b) — that is intentional. Layer (c) still catches unrenamed forks, and
+// the marker catches any fork that deliberately opts in.
+//
+// If instar ever moves org/repo, add an entry here — never substitute.
+// Old URLs stay to catch legacy checkouts.
+export const CANONICAL_INSTAR_REMOTES: readonly string[] = Object.freeze([
+  'git@github.com:dawn/instar.git',
+  'https://github.com/dawn/instar.git',
+  'ssh://git@github.com/dawn/instar.git',
+]);
+
+// ── Source-identity signature files ──────────────────────────────────
+//
+// At least TWO of these (in addition to package.json name === "instar")
+// must be present for layer (c) to match.
+const SIGNATURE_FILES: readonly string[] = Object.freeze([
+  'src/core/GitSync.ts',
+  'src/core/BranchManager.ts',
+  'src/core/HandoffManager.ts',
+  'tsconfig.json',
+  'skills/spec-converge/SKILL.md',
+]);
+
+const MARKER_FILENAME = '.instar-source-tree';
+const MAX_WALK_LEVELS = 40;
+
+// ── Error shape ──────────────────────────────────────────────────────
+
+export class SourceTreeGuardError extends Error {
+  readonly code = 'INSTAR_SOURCE_TREE_GUARD';
+  readonly operation: string;
+  readonly dir: string;
+  readonly resolvedRoot: string;
+
+  constructor(dir: string, resolvedRoot: string, operation: string) {
+    super(
+      `Refusing to run ${operation} against the instar source tree ` +
+        `(requested dir: ${dir}, resolved git root: ${resolvedRoot}). ` +
+        `This is a safety guard against the 2026-04-22 class of incident. ` +
+        `See docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md for the documented ` +
+        `escape hatch if this block is a genuine false-positive.`,
+    );
+    this.name = 'SourceTreeGuardError';
+    this.operation = operation;
+    this.dir = dir;
+    this.resolvedRoot = resolvedRoot;
+  }
+}
+
+// ── Path canonicalization ────────────────────────────────────────────
+
+/**
+ * Canonicalize `dir`. If it doesn't exist, walk upward via `path.dirname`
+ * until an existing ancestor is found, then canonicalize THAT.
+ *
+ * Returns null if no existing ancestor can be found or canonicalized
+ * (detector-level fail-closed — caller returns true from isInstarSourceTree).
+ *
+ * ENOENT and ENOTDIR during the walk are normal (keep ascending). EACCES
+ * is also tolerated on stat — we keep ascending. Only if we hit the
+ * filesystem root without finding any accessible existing ancestor do we
+ * return null.
+ */
+function canonicalizeNearestExistingAncestor(dir: string): string | null {
+  // Absolute path so dirname walk terminates at filesystem root.
+  let candidate: string;
+  try {
+    candidate = path.resolve(dir);
+  } catch {
+    return null;
+  }
+
+  for (let i = 0; i < MAX_WALK_LEVELS; i++) {
+    try {
+      const st = fs.statSync(candidate);
+      if (st) {
+        // Exists — now canonicalize with realpath (resolves symlinks).
+        try {
+          return fs.realpathSync(candidate);
+        } catch {
+          // realpath failed on an existing path — detector-level fail-closed.
+          return null;
+        }
+      }
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        // Normal walk condition — keep ascending.
+      } else if (code === 'EACCES' || code === 'EPERM') {
+        // Cannot stat — keep ascending; we'll decide at the loop end.
+      } else {
+        // Unknown stat error — treat as unable to decide; keep ascending.
+      }
+    }
+    const parent = path.dirname(candidate);
+    if (parent === candidate) {
+      // Reached filesystem root without finding an existing ancestor.
+      return null;
+    }
+    candidate = parent;
+  }
+  return null;
+}
+
+// ── Git root walk ────────────────────────────────────────────────────
+
+interface GitRootResolution {
+  /** The worktree root (directory containing `.git`). */
+  worktreeRoot: string;
+  /**
+   * The path of the `.git` entry (file or dir) OR null if no `.git` found.
+   * If null, `worktreeRoot` is just the canonicalized start.
+   */
+  dotGitPath: string | null;
+  /** True if `.git` is a file (worktree), false if directory. */
+  dotGitIsFile: boolean;
+}
+
+function findGitRoot(startDir: string): GitRootResolution {
+  let current = startDir;
+  for (let i = 0; i < MAX_WALK_LEVELS; i++) {
+    const dotGit = path.join(current, '.git');
+    let stat: fs.Stats | null = null;
+    try {
+      stat = fs.lstatSync(dotGit);
+    } catch {
+      // No .git here — keep ascending.
+    }
+    if (stat) {
+      return {
+        worktreeRoot: current,
+        dotGitPath: dotGit,
+        dotGitIsFile: stat.isFile(),
+      };
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return { worktreeRoot: startDir, dotGitPath: null, dotGitIsFile: false };
+}
+
+// ── Worktree common-git-dir resolution ───────────────────────────────
+
+/**
+ * Given a `.git` FILE (worktree pointer), resolve the common git dir.
+ *
+ * The standard layout is `<common-git-dir>/worktrees/<name>` (i.e. the
+ * `gitdir:` pointer targets a subdirectory of `worktrees/` inside the
+ * main repo's `.git`). In that case the common git dir is
+ * `dirname(dirname(gitdir))`.
+ *
+ * Any other layout (submodule worktree, custom core.worktreesDir, etc.)
+ * returns null — layer (b) fails closed for the sub-check, and layers
+ * (a)/(c) still evaluate at the worktree root.
+ */
+function resolveCommonGitDirFromWorktreeFile(
+  dotGitFilePath: string,
+): string | null {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(dotGitFilePath, 'utf8');
+  } catch {
+    return null;
+  }
+  const match = contents.match(/^\s*gitdir:\s*(.+?)\s*$/m);
+  if (!match) return null;
+
+  let gitdirRaw = match[1].trim();
+  if (!gitdirRaw) return null;
+
+  // Relative paths resolve against the directory containing the `.git` file
+  // (the worktree root), per git-worktree(1).
+  let gitdir: string;
+  if (path.isAbsolute(gitdirRaw)) {
+    gitdir = gitdirRaw;
+  } else {
+    gitdir = path.resolve(path.dirname(dotGitFilePath), gitdirRaw);
+  }
+
+  // Verify it exists and canonicalize.
+  try {
+    gitdir = fs.realpathSync(gitdir);
+  } catch {
+    return null;
+  }
+
+  // Standard layout: <common>/worktrees/<name>
+  const parent = path.dirname(gitdir);
+  if (path.basename(parent) !== 'worktrees') {
+    return null;
+  }
+  return path.dirname(parent);
+}
+
+// ── Layer (a): marker file ───────────────────────────────────────────
+
+function layerMarker(resolvedRoot: string): boolean {
+  try {
+    return fs.existsSync(path.join(resolvedRoot, MARKER_FILENAME));
+  } catch {
+    return false;
+  }
+}
+
+// ── Layer (b): canonical remote URL ──────────────────────────────────
+
+/**
+ * Minimal canonicalization per spec:
+ *   1. Strip leading/trailing whitespace and newlines.
+ *   2. Strip a single trailing `/`.
+ *   3. Strip a single trailing `.git`.
+ */
+function normalizeRemoteUrl(raw: string): string {
+  let s = raw.trim();
+  if (s.endsWith('/')) s = s.slice(0, -1);
+  if (s.endsWith('.git')) s = s.slice(0, -'.git'.length);
+  return s;
+}
+
+const NORMALIZED_CANONICAL_REMOTES: readonly string[] = Object.freeze(
+  CANONICAL_INSTAR_REMOTES.map(normalizeRemoteUrl),
+);
+
+function parseOriginUrlFromGitConfig(configText: string): string | null {
+  // Find the [remote "origin"] section and its url = ... line.
+  // Section is terminated by the next [section] header or EOF.
+  const sectionRe = /\[\s*remote\s+"origin"\s*\]\s*([\s\S]*?)(?=\n\s*\[|\s*$)/i;
+  const match = configText.match(sectionRe);
+  if (!match) return null;
+  const body = match[1];
+  const urlMatch = body.match(/^\s*url\s*=\s*(.+?)\s*$/m);
+  if (!urlMatch) return null;
+  return urlMatch[1];
+}
+
+function layerRemoteUrl(
+  worktreeRoot: string,
+  dotGitPath: string | null,
+  dotGitIsFile: boolean,
+): boolean {
+  if (!dotGitPath) return false;
+
+  let configPath: string;
+  if (dotGitIsFile) {
+    const commonGitDir = resolveCommonGitDirFromWorktreeFile(dotGitPath);
+    if (!commonGitDir) return false; // Layer-level inconclusive → FALSE.
+    configPath = path.join(commonGitDir, 'config');
+  } else {
+    configPath = path.join(dotGitPath, 'config');
+  }
+
+  let configText: string;
+  try {
+    configText = fs.readFileSync(configPath, 'utf8');
+  } catch {
+    return false;
+  }
+
+  const rawUrl = parseOriginUrlFromGitConfig(configText);
+  if (rawUrl == null) return false;
+
+  const normalized = normalizeRemoteUrl(rawUrl);
+  return NORMALIZED_CANONICAL_REMOTES.includes(normalized);
+}
+
+// ── Layer (c): source identity signature ─────────────────────────────
+
+function layerSignature(resolvedRoot: string): boolean {
+  const pkgPath = path.join(resolvedRoot, 'package.json');
+  let pkgText: string;
+  try {
+    pkgText = fs.readFileSync(pkgPath, 'utf8');
+  } catch {
+    return false;
+  }
+  let pkg: { name?: unknown };
+  try {
+    pkg = JSON.parse(pkgText);
+  } catch {
+    return false;
+  }
+  if (pkg.name !== 'instar') return false;
+
+  let hits = 0;
+  for (const rel of SIGNATURE_FILES) {
+    try {
+      if (fs.existsSync(path.join(resolvedRoot, rel))) {
+        hits++;
+        if (hits >= 2) return true;
+      }
+    } catch {
+      // Ignore individual file errors; a single stat failure is not enough
+      // to fail the whole sub-check.
+    }
+  }
+  return hits >= 2;
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Returns true if `dir` — or any of its git-root ancestors — is the
+ * instar source tree.
+ *
+ * See module header and the spec for full semantics.
+ */
+export function isInstarSourceTree(dir: string): boolean {
+  // Step 1: resolve nearest-existing-ancestor and canonicalize.
+  const canonicalStart = canonicalizeNearestExistingAncestor(dir);
+  if (canonicalStart === null) {
+    // Detector-level fail-closed.
+    return true;
+  }
+
+  // Step 2: walk to the git root (or keep canonicalStart if none found).
+  const { worktreeRoot, dotGitPath, dotGitIsFile } = findGitRoot(canonicalStart);
+
+  // Step 3: OR across the three layers.
+  if (layerMarker(worktreeRoot)) return true;
+  if (layerRemoteUrl(worktreeRoot, dotGitPath, dotGitIsFile)) return true;
+  if (layerSignature(worktreeRoot)) return true;
+
+  return false;
+}
+
+/**
+ * Throws `SourceTreeGuardError` if `dir` is the instar source tree.
+ *
+ * Callers MUST pass the raw projectDir from the original caller — NOT a
+ * post-sanitization/post-normalization value. Sanitization would hide the
+ * class of bug this guard exists to catch.
+ */
+export function assertNotInstarSourceTree(
+  dir: string,
+  operation: string,
+): void {
+  if (isInstarSourceTree(dir)) {
+    // Compute resolved root for the error (best-effort — if resolution
+    // fails we report the raw input).
+    const resolved = canonicalizeNearestExistingAncestor(dir);
+    let resolvedRoot = dir;
+    if (resolved !== null) {
+      const { worktreeRoot } = findGitRoot(resolved);
+      resolvedRoot = worktreeRoot;
+    }
+    throw new SourceTreeGuardError(dir, resolvedRoot, operation);
+  }
+}
+
+/**
+ * Convenience alias per spec §"The guard primitive".
+ */
+export function checkSourceTree(dir: string): boolean {
+  return isInstarSourceTree(dir);
+}
+
+/**
+ * Test helper: resolve the canonical start + git root without running the
+ * layer checks. Not part of the public API — exported only for test
+ * introspection.
+ *
+ * @internal
+ */
+export function _resolveRootForTesting(dir: string): {
+  canonicalStart: string | null;
+  worktreeRoot: string | null;
+  dotGitPath: string | null;
+  dotGitIsFile: boolean;
+} {
+  const canonicalStart = canonicalizeNearestExistingAncestor(dir);
+  if (canonicalStart === null) {
+    return {
+      canonicalStart: null,
+      worktreeRoot: null,
+      dotGitPath: null,
+      dotGitIsFile: false,
+    };
+  }
+  const { worktreeRoot, dotGitPath, dotGitIsFile } = findGitRoot(canonicalStart);
+  return { canonicalStart, worktreeRoot, dotGitPath, dotGitIsFile };
+}

--- a/tests/integration/source-tree-guard-wiring.test.ts
+++ b/tests/integration/source-tree-guard-wiring.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Integration tests for SourceTreeGuard wire-in on the three destructive
+ * managers (GitSyncManager, BranchManager, HandoffManager).
+ *
+ * These tests assert that:
+ *   1. Constructing any of the three managers against the real instar
+ *      source tree throws SourceTreeGuardError with the correct code.
+ *   2. Constructing against a mkdtemp sandbox succeeds (the guard does
+ *      not fire on legitimate targets).
+ *   3. Constructing against an uncreated subdirectory INSIDE the instar
+ *      source also fails (uncreated-subdirectory bypass closed).
+ *   4. The throw happens BEFORE any collaborator touches anything (no
+ *      observable side effect).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { BranchManager } from '../../src/core/BranchManager.js';
+import { HandoffManager } from '../../src/core/HandoffManager.js';
+import { GitSyncManager } from '../../src/core/GitSync.js';
+import type { WorkLedger } from '../../src/core/WorkLedger.js';
+import type { MachineIdentityManager } from '../../src/core/MachineIdentity.js';
+import type { SecurityLog } from '../../src/core/SecurityLog.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// tests/integration/ → repo root is two levels up.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// ── Minimal collaborator stubs ──────────────────────────────────────
+
+function stubWorkLedger(): WorkLedger {
+  return {} as unknown as WorkLedger;
+}
+function stubIdentityManager(): MachineIdentityManager {
+  return {} as unknown as MachineIdentityManager;
+}
+function stubSecurityLog(): SecurityLog {
+  return {} as unknown as SecurityLog;
+}
+
+// ── Guard against the real instar source ───────────────────────────
+
+describe('SourceTreeGuard — instar source tree is blocked at construction', () => {
+  it('BranchManager constructor throws SourceTreeGuardError for the instar source tree', () => {
+    expect(() => {
+      new BranchManager({
+        projectDir: REPO_ROOT,
+        stateDir: path.join(REPO_ROOT, '.instar-test-never-created'),
+        machineId: 'test',
+      });
+    }).toThrow(/INSTAR_SOURCE_TREE_GUARD|instar source tree/);
+  });
+
+  it('HandoffManager constructor throws SourceTreeGuardError for the instar source tree', () => {
+    expect(() => {
+      new HandoffManager({
+        projectDir: REPO_ROOT,
+        stateDir: path.join(REPO_ROOT, '.instar-test-never-created'),
+        machineId: 'test',
+        workLedger: stubWorkLedger(),
+      });
+    }).toThrow(/INSTAR_SOURCE_TREE_GUARD|instar source tree/);
+  });
+
+  it('GitSyncManager constructor throws SourceTreeGuardError for the instar source tree', () => {
+    expect(() => {
+      new GitSyncManager({
+        projectDir: REPO_ROOT,
+        stateDir: path.join(REPO_ROOT, '.instar-test-never-created'),
+        identityManager: stubIdentityManager(),
+        securityLog: stubSecurityLog(),
+        machineId: 'test',
+      });
+    }).toThrow(/INSTAR_SOURCE_TREE_GUARD|instar source tree/);
+  });
+
+  it('thrown error has code === "INSTAR_SOURCE_TREE_GUARD" and correct operation label', () => {
+    let caught: unknown;
+    try {
+      new BranchManager({
+        projectDir: REPO_ROOT,
+        stateDir: path.join(REPO_ROOT, '.instar-test-never-created'),
+        machineId: 'test',
+      });
+    } catch (err) {
+      caught = err;
+    }
+    const e = caught as { code?: string; operation?: string };
+    expect(e?.code).toBe('INSTAR_SOURCE_TREE_GUARD');
+    expect(e?.operation).toBe('BranchManager');
+  });
+
+  it('guard fires BEFORE the state directory is created (no observable side effect)', () => {
+    const stateDir = path.join(REPO_ROOT, '.instar-test-should-never-exist');
+    expect(fs.existsSync(stateDir)).toBe(false);
+    try {
+      new BranchManager({
+        projectDir: REPO_ROOT,
+        stateDir,
+        machineId: 'test',
+      });
+    } catch {
+      // expected
+    }
+    // BranchManager normally creates stateDir/state/branches in its
+    // constructor. If the guard fired first, this directory must still
+    // not exist.
+    expect(fs.existsSync(stateDir)).toBe(false);
+  });
+});
+
+// ── Uncreated subdirectory inside the instar source ─────────────────
+
+describe('SourceTreeGuard — uncreated-subdirectory bypass is closed', () => {
+  it('passing an uncreated subdir of the instar source still throws', () => {
+    const uncreated = path.join(REPO_ROOT, 'src', 'never_created_feature_' + Date.now());
+    expect(fs.existsSync(uncreated)).toBe(false);
+    expect(() => {
+      new BranchManager({
+        projectDir: uncreated,
+        stateDir: path.join(os.tmpdir(), 'stg-wiring-should-not-matter'),
+        machineId: 'test',
+      });
+    }).toThrow(/INSTAR_SOURCE_TREE_GUARD|instar source tree/);
+  });
+});
+
+// ── Legitimate mkdtemp sandbox → construction succeeds ──────────────
+
+describe('SourceTreeGuard — legitimate sandbox construction succeeds', () => {
+  let sandbox: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'stg-wiring-'));
+    stateDir = path.join(sandbox, '.instar');
+    // Make it a real git repo so BranchManager has something to work with,
+    // though the guard decision happens before git runs.
+    execFileSync('git', ['init', '-b', 'main'], { cwd: sandbox });
+    execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: sandbox });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: sandbox });
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('BranchManager constructs successfully in a sandbox', () => {
+    expect(() => {
+      new BranchManager({
+        projectDir: sandbox,
+        stateDir,
+        machineId: 'test',
+      });
+    }).not.toThrow();
+  });
+
+  it('HandoffManager constructs successfully in a sandbox', () => {
+    expect(() => {
+      new HandoffManager({
+        projectDir: sandbox,
+        stateDir,
+        machineId: 'test',
+        workLedger: stubWorkLedger(),
+      });
+    }).not.toThrow();
+  });
+
+  it('GitSyncManager constructs successfully in a sandbox', () => {
+    expect(() => {
+      new GitSyncManager({
+        projectDir: sandbox,
+        stateDir,
+        identityManager: stubIdentityManager(),
+        securityLog: stubSecurityLog(),
+        machineId: 'test',
+      });
+    }).not.toThrow();
+  });
+
+  it('subdirectory of sandbox (when git root is sandbox, not instar) also succeeds', () => {
+    const subdir = path.join(sandbox, 'src', 'nested');
+    fs.mkdirSync(subdir, { recursive: true });
+    expect(() => {
+      new BranchManager({
+        projectDir: subdir,
+        stateDir,
+        machineId: 'test',
+      });
+    }).not.toThrow();
+  });
+});

--- a/tests/unit/SourceTreeGuard.test.ts
+++ b/tests/unit/SourceTreeGuard.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  isInstarSourceTree,
+  assertNotInstarSourceTree,
+  SourceTreeGuardError,
+  CANONICAL_INSTAR_REMOTES,
+} from '../../src/core/SourceTreeGuard.js';
+
+// ─── Fixture helpers ────────────────────────────────────────────────
+
+function mkSandbox(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'stg-'));
+}
+
+function rmrf(p: string): void {
+  try {
+    fs.rmSync(p, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+function writeFile(file: string, content: string): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+}
+
+function writeMarker(root: string): void {
+  writeFile(path.join(root, '.instar-source-tree'), 'marker\n');
+}
+
+function writeGitConfigWithOriginUrl(root: string, url: string): void {
+  fs.mkdirSync(path.join(root, '.git'), { recursive: true });
+  const content = `[core]\n\trepositoryformatversion = 0\n[remote "origin"]\n\turl = ${url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`;
+  writeFile(path.join(root, '.git', 'config'), content);
+}
+
+function writeSignatureFiles(root: string, files: string[]): void {
+  for (const rel of files) {
+    writeFile(path.join(root, rel), '// sig\n');
+  }
+}
+
+function writeInstarPackageJson(root: string): void {
+  writeFile(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'instar', version: '0.0.0' }),
+  );
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe('SourceTreeGuard — layer (a) marker file', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkSandbox();
+  });
+  afterEach(() => rmrf(sandbox));
+
+  it('returns true when marker file is present', () => {
+    writeMarker(sandbox);
+    expect(isInstarSourceTree(sandbox)).toBe(true);
+  });
+
+  it('returns false when marker file is absent (and no other signals)', () => {
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+});
+
+describe('SourceTreeGuard — layer (b) canonical remote URL', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkSandbox();
+  });
+  afterEach(() => rmrf(sandbox));
+
+  for (const url of CANONICAL_INSTAR_REMOTES) {
+    it(`returns true for canonical URL: ${url}`, () => {
+      writeGitConfigWithOriginUrl(sandbox, url);
+      expect(isInstarSourceTree(sandbox)).toBe(true);
+    });
+  }
+
+  it('returns true for trailing-slash normalization', () => {
+    writeGitConfigWithOriginUrl(sandbox, 'https://github.com/dawn/instar.git/');
+    expect(isInstarSourceTree(sandbox)).toBe(true);
+  });
+
+  it('returns true for missing-.git-suffix normalization', () => {
+    writeGitConfigWithOriginUrl(sandbox, 'https://github.com/dawn/instar');
+    expect(isInstarSourceTree(sandbox)).toBe(true);
+  });
+
+  it('returns true for trailing-whitespace normalization', () => {
+    writeGitConfigWithOriginUrl(sandbox, 'https://github.com/dawn/instar.git  ');
+    expect(isInstarSourceTree(sandbox)).toBe(true);
+  });
+
+  it('returns true for trailing-newline normalization (raw write)', () => {
+    // The url value itself carries a trailing newline before the next line.
+    fs.mkdirSync(path.join(sandbox, '.git'), { recursive: true });
+    fs.writeFileSync(
+      path.join(sandbox, '.git', 'config'),
+      '[remote "origin"]\n\turl = https://github.com/dawn/instar.git\n',
+    );
+    expect(isInstarSourceTree(sandbox)).toBe(true);
+  });
+
+  it('returns false for a fork remote URL not on the canonical list', () => {
+    writeGitConfigWithOriginUrl(sandbox, 'git@github.com:someuser/instar-fork.git');
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+
+  it('returns false for an unrelated remote URL', () => {
+    writeGitConfigWithOriginUrl(sandbox, 'git@github.com:acme/widgets.git');
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+
+  it('does NOT substring-match on "instar" in non-canonical URLs', () => {
+    writeGitConfigWithOriginUrl(sandbox, 'git@github.com:dawn/instar-extra.git');
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+});
+
+describe('SourceTreeGuard — layer (c) source identity signature', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkSandbox();
+  });
+  afterEach(() => rmrf(sandbox));
+
+  it('returns true when package.json name === "instar" AND two signature files exist', () => {
+    writeInstarPackageJson(sandbox);
+    writeSignatureFiles(sandbox, ['src/core/GitSync.ts', 'src/core/BranchManager.ts']);
+    expect(isInstarSourceTree(sandbox)).toBe(true);
+  });
+
+  it('returns false when package.json name === "instar" but only one signature file exists', () => {
+    writeInstarPackageJson(sandbox);
+    writeSignatureFiles(sandbox, ['src/core/GitSync.ts']);
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+
+  it('returns false when package.json name is not "instar" even with many signature files', () => {
+    writeFile(path.join(sandbox, 'package.json'), JSON.stringify({ name: 'not-instar' }));
+    writeSignatureFiles(sandbox, ['src/core/GitSync.ts', 'src/core/BranchManager.ts', 'tsconfig.json']);
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+
+  it('layer (c) returns false when package.json is malformed (layer-level inconclusive)', () => {
+    writeFile(path.join(sandbox, 'package.json'), '{ not valid json');
+    writeSignatureFiles(sandbox, ['src/core/GitSync.ts', 'src/core/BranchManager.ts']);
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+});
+
+describe('SourceTreeGuard — git-root walk (subdirectory bypass)', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkSandbox();
+  });
+  afterEach(() => rmrf(sandbox));
+
+  it('returns true for a subdirectory when the root has the marker', () => {
+    writeMarker(sandbox);
+    fs.mkdirSync(path.join(sandbox, '.git'), { recursive: true }); // make it look like a repo
+    const subdir = path.join(sandbox, 'src', 'nested');
+    fs.mkdirSync(subdir, { recursive: true });
+    expect(isInstarSourceTree(subdir)).toBe(true);
+  });
+
+  it('uncreated subdirectory inside the repo: returns true via nearest-existing-ancestor', () => {
+    writeMarker(sandbox);
+    fs.mkdirSync(path.join(sandbox, '.git'), { recursive: true });
+    const uncreated = path.join(sandbox, 'src', 'new_feature', 'does', 'not', 'exist');
+    expect(isInstarSourceTree(uncreated)).toBe(true);
+  });
+
+  it('nonexistent path whose nearest existing ancestor is outside instar: returns false', () => {
+    const nonexistent = path.join(sandbox, 'does', 'not', 'exist', 'anywhere');
+    // sandbox has no marker, no .git, no instar package
+    expect(isInstarSourceTree(nonexistent)).toBe(false);
+  });
+
+  it('ENOTDIR on an intermediate segment: walk continues past it', () => {
+    writeMarker(sandbox);
+    fs.mkdirSync(path.join(sandbox, '.git'), { recursive: true });
+    // Create a regular file and then try to treat it as a directory with a deeper path.
+    const fileSeg = path.join(sandbox, 'a-file');
+    fs.writeFileSync(fileSeg, 'hi');
+    const badPath = path.join(fileSeg, 'under', 'the', 'file');
+    expect(isInstarSourceTree(badPath)).toBe(true);
+  });
+});
+
+describe('SourceTreeGuard — worktree handling (.git as file)', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkSandbox();
+  });
+  afterEach(() => rmrf(tmpRoot));
+
+  it('worktree with standard layout resolves common-git-dir and matches canonical remote', () => {
+    // Build: <tmpRoot>/main/.git/worktrees/wt1 and <tmpRoot>/wt-root/.git (file pointing at it)
+    const mainRepo = path.join(tmpRoot, 'main');
+    const commonGitDir = path.join(mainRepo, '.git');
+    const wtAdmin = path.join(commonGitDir, 'worktrees', 'wt1');
+    fs.mkdirSync(wtAdmin, { recursive: true });
+    // main/.git/config has canonical remote.
+    fs.writeFileSync(
+      path.join(commonGitDir, 'config'),
+      '[remote "origin"]\n\turl = https://github.com/dawn/instar.git\n',
+    );
+
+    const wtRoot = path.join(tmpRoot, 'wt-root');
+    fs.mkdirSync(wtRoot, { recursive: true });
+    fs.writeFileSync(path.join(wtRoot, '.git'), `gitdir: ${wtAdmin}\n`);
+
+    expect(isInstarSourceTree(wtRoot)).toBe(true);
+  });
+
+  it('worktree with relative gitdir pointer resolves against the worktree root', () => {
+    // Place main and wt-root as siblings so a relative gitdir resolves.
+    const mainRepo = path.join(tmpRoot, 'main');
+    const commonGitDir = path.join(mainRepo, '.git');
+    const wtAdmin = path.join(commonGitDir, 'worktrees', 'wt1');
+    fs.mkdirSync(wtAdmin, { recursive: true });
+    fs.writeFileSync(
+      path.join(commonGitDir, 'config'),
+      '[remote "origin"]\n\turl = https://github.com/dawn/instar.git\n',
+    );
+
+    const wtRoot = path.join(tmpRoot, 'wt-root');
+    fs.mkdirSync(wtRoot, { recursive: true });
+    // Relative pointer from wtRoot: ../main/.git/worktrees/wt1
+    fs.writeFileSync(
+      path.join(wtRoot, '.git'),
+      'gitdir: ../main/.git/worktrees/wt1\n',
+    );
+
+    expect(isInstarSourceTree(wtRoot)).toBe(true);
+  });
+
+  it('worktree with non-standard layout (basename(dirname(gitdir)) !== "worktrees") → layer (b) inconclusive, layers (a)/(c) still decide', () => {
+    const wtRoot = path.join(tmpRoot, 'wt-root');
+    fs.mkdirSync(wtRoot, { recursive: true });
+    const weirdGitdir = path.join(tmpRoot, 'weird-place', 'submodule-like', 'admin');
+    fs.mkdirSync(weirdGitdir, { recursive: true });
+    fs.writeFileSync(path.join(wtRoot, '.git'), `gitdir: ${weirdGitdir}\n`);
+
+    // No marker, no signature → all layers fail → false.
+    expect(isInstarSourceTree(wtRoot)).toBe(false);
+
+    // Now add the marker at the worktree root → layer (a) wins.
+    writeMarker(wtRoot);
+    expect(isInstarSourceTree(wtRoot)).toBe(true);
+  });
+
+  it('worktree with malformed gitdir pointer: layer (b) inconclusive; other layers decide', () => {
+    const wtRoot = path.join(tmpRoot, 'wt-root');
+    fs.mkdirSync(wtRoot, { recursive: true });
+    fs.writeFileSync(path.join(wtRoot, '.git'), 'garbage not a gitdir line\n');
+
+    expect(isInstarSourceTree(wtRoot)).toBe(false);
+
+    writeMarker(wtRoot);
+    expect(isInstarSourceTree(wtRoot)).toBe(true);
+  });
+});
+
+describe('SourceTreeGuard — layer-level fail-inconclusive (two-tier)', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkSandbox();
+  });
+  afterEach(() => rmrf(sandbox));
+
+  it('unreadable package.json (malformed) + marker present → true (layer a wins)', () => {
+    writeMarker(sandbox);
+    writeFile(path.join(sandbox, 'package.json'), '{ not valid json');
+    expect(isInstarSourceTree(sandbox)).toBe(true);
+  });
+
+  it('malformed package.json + no marker + no git config → false (detector completes)', () => {
+    writeFile(path.join(sandbox, 'package.json'), '{ not valid json');
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+
+  it('git config directory (not a file) + no marker + no signature → false', () => {
+    // Create `.git/config` as a DIRECTORY, not a file.
+    fs.mkdirSync(path.join(sandbox, '.git', 'config'), { recursive: true });
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+});
+
+describe('SourceTreeGuard — negative cases', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkSandbox();
+  });
+  afterEach(() => rmrf(sandbox));
+
+  it('empty tmpdir returns false', () => {
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+
+  it('git repo with unrelated remote returns false', () => {
+    writeGitConfigWithOriginUrl(sandbox, 'https://github.com/acme/unrelated.git');
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+
+  it('tmpdir with instar package.json but no signature files returns false', () => {
+    writeInstarPackageJson(sandbox);
+    expect(isInstarSourceTree(sandbox)).toBe(false);
+  });
+});
+
+describe('SourceTreeGuard — symlink canonicalization', () => {
+  let realDir: string;
+  let linkDir: string;
+  beforeEach(() => {
+    realDir = mkSandbox();
+    linkDir = path.join(os.tmpdir(), `stg-link-${process.pid}-${Date.now()}`);
+    writeMarker(realDir);
+    try {
+      fs.symlinkSync(realDir, linkDir);
+    } catch (err) {
+      // On some filesystems symlinks may be denied — test will skip.
+    }
+  });
+  afterEach(() => {
+    try {
+      fs.unlinkSync(linkDir);
+    } catch {
+      // ignore
+    }
+    rmrf(realDir);
+  });
+
+  it('returns true when input is a symlink to an instar source tree', () => {
+    if (!fs.existsSync(linkDir)) return; // symlink creation failed; skip.
+    expect(isInstarSourceTree(linkDir)).toBe(true);
+  });
+});
+
+describe('SourceTreeGuard — assertion wrapper', () => {
+  let sandbox: string;
+  beforeEach(() => {
+    sandbox = mkSandbox();
+  });
+  afterEach(() => rmrf(sandbox));
+
+  it('is a no-op on a clean tmpdir', () => {
+    expect(() => assertNotInstarSourceTree(sandbox, 'TestOp')).not.toThrow();
+  });
+
+  it('throws SourceTreeGuardError with the right code/operation/dir/resolvedRoot', () => {
+    writeMarker(sandbox);
+    let caught: unknown;
+    try {
+      assertNotInstarSourceTree(sandbox, 'GitSyncManager');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SourceTreeGuardError);
+    const e = caught as SourceTreeGuardError;
+    expect(e.code).toBe('INSTAR_SOURCE_TREE_GUARD');
+    expect(e.operation).toBe('GitSyncManager');
+    expect(e.dir).toBe(sandbox);
+    // resolvedRoot should be the canonicalized sandbox path.
+    expect(e.resolvedRoot).toBe(fs.realpathSync(sandbox));
+  });
+
+  it('error message does NOT inline bypass instructions (tutorial-in-error avoidance)', () => {
+    writeMarker(sandbox);
+    try {
+      assertNotInstarSourceTree(sandbox, 'GitSyncManager');
+      throw new Error('expected throw');
+    } catch (err) {
+      const msg = (err as Error).message;
+      // Must NOT include the string "bypass:" or "set env var" or similar.
+      expect(msg).not.toMatch(/\bbypass\s*[:=]/i);
+      expect(msg).not.toMatch(/\bset\s+env\b/i);
+      // Must reference the spec for the escape hatch.
+      expect(msg).toContain('DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md');
+    }
+  });
+});

--- a/upgrades/side-effects/source-tree-guard.md
+++ b/upgrades/side-effects/source-tree-guard.md
@@ -1,0 +1,340 @@
+# Side-Effects Review — Destructive tool target guard
+
+**Version / slug:** `source-tree-guard`
+**Date:** `2026-04-24`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (brittle safety-guard carve-out; see §4)`
+
+## Summary of the change
+
+Adds a new primitive `src/core/SourceTreeGuard.ts` that refuses to let
+destructive managers (`GitSyncManager`, `BranchManager`,
+`HandoffManager`) be constructed against the instar source tree. The
+guard is wired as the first statement of each manager's constructor and
+throws `SourceTreeGuardError` (code `INSTAR_SOURCE_TREE_GUARD`) before
+any collaborator touches anything. Detection is the OR of three layers
+(marker file `.instar-source-tree`, canonical `origin` URL in the
+resolved common git dir's config, or `package.json name === "instar"`
+plus two-of-N signature files). Path resolution closes the
+uncreated-subdirectory bypass via a nearest-existing-ancestor walk, and
+handles worktrees via `.git`-file parsing with
+`basename(dirname(gitdir)) === "worktrees"` common-git-dir resolution.
+Fail-closed is two-tier: detector-level inability to canonicalize/ascend
+returns TRUE; layer-level inability to evaluate returns FALSE for that
+sub-check and the OR across layers decides.
+
+Files touched:
+
+- `src/core/SourceTreeGuard.ts` (new)
+- `src/core/GitSync.ts` (+1 import, +1 assert at constructor top)
+- `src/core/BranchManager.ts` (+1 import, +1 assert at constructor top)
+- `src/core/HandoffManager.ts` (+1 import, +1 assert at constructor top)
+- `.instar-source-tree` (new — marker file at repo root)
+- `tests/unit/SourceTreeGuard.test.ts` (new — 34 tests)
+- `tests/integration/source-tree-guard-wiring.test.ts` (new — 10 tests)
+- `docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md` (spec, pre-existing)
+- `docs/specs/reports/destructive-tool-target-guards-convergence.md` (report, pre-existing)
+
+Incident context: the 2026-04-22 branch-lifecycle e2e fixture wiped 1,893
+files from the real instar checkout because destructive components
+trusted an incoming `projectDir` without verification. This PR delivers
+the tactical guardrail described in the spec. E2E sandbox hardening,
+Adriana's autostash fix, the CI mutation detector, and the
+SafeGitExecutor centralization are explicitly deferred to separate PRs.
+
+## Decision-point inventory
+
+- `src/core/SourceTreeGuard.ts :: isInstarSourceTree` — **add** — new
+  detector returning boolean based on the 3-layer OR.
+- `src/core/SourceTreeGuard.ts :: assertNotInstarSourceTree` — **add** —
+  new assertion wrapper that throws `SourceTreeGuardError`.
+- `GitSyncManager` constructor — **modify** — first statement now calls
+  the assertion; no other behavior change.
+- `BranchManager` constructor — **modify** — same.
+- `HandoffManager` constructor — **modify** — same.
+
+No existing decision points are removed or repurposed.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Concrete over-block scenarios considered:
+
+- A parallel-dev worktree *of the instar source* used as a destructive
+  target. Blocked today. This is intended — the worktree's common git
+  dir is the real repo, so `git add -A` from the worktree mutates the
+  real repo. If someone legitimately needs this, the fix is to loosen
+  the guard deliberately, not to silently permit it.
+- A fork that keeps `package.json.name === "instar"`, ships two of the
+  signature files (likely — they're core infra), and carries the
+  `.instar-source-tree` marker (only if the forker copied it; it's in
+  the upstream repo but not automatically propagated by `git clone`).
+  Fork remotes are NOT on the canonical list, so layer (b) does not
+  match. If a fork has the marker and keeps the name+signature, it
+  blocks — the fork author can delete the marker in their repo.
+- A developer who manually sets their working dir to the instar source
+  to run a one-off script. Blocked only for destructive-manager
+  construction — read-only tools are untouched. This is the entire
+  purpose of the guard.
+- Tests that deliberately construct a manager pointed at the instar
+  source to exercise error paths. Use a `mkdtemp` sandbox instead (the
+  integration tests in this PR follow that convention).
+
+No legitimate input is rejected that shouldn't be. The one "blocked by
+design" case (worktrees of the source) matches the incident shape and
+is a deliberate guard.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- Destructive components not on the three-manager list. Addressed by
+  the pre-ship enumeration below: every direct git invocation under
+  `src/` was inventoried. See §"Pre-ship grep enumeration evidence."
+- Destructive work launched via child processes or shell scripts
+  (e.g. `nuke.ts`, `init.ts`) that bypass the manager layer. These are
+  either operator-initiated (`nuke`) or target a fresh dir (`init`),
+  not the incident shape. The SafeGitExecutor follow-up PR centralizes
+  these.
+- Fork of instar that renames `package.json`, changes canonical remote,
+  and drops the marker. By design — if all three layers disagree this
+  is not the instar source tree, guard passes.
+- A manager constructed against a fresh clone that doesn't have the
+  marker yet AND has a non-canonical remote (e.g. contributor fork)
+  AND has been renamed. Same as above — by design not caught.
+
+Under-block is scoped to "things out of this PR's lane" and enumerated
+in the spec's Out-of-Scope Follow-Ups. Nothing silently degrades.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Constructor-time on the three destructive managers is the correct
+layer for this PR. It is the point at which `projectDir` first becomes
+trusted state — below this (inside `execFileSync('git', ...)`) is too
+late (damage already in flight); above this (scattered across callers)
+is the layer the incident proved unreliable.
+
+A lower-level primitive (`SafeGitExecutor`) will additionally funnel at
+the `execFileSync` boundary in a follow-up PR. The constructor wire-in
+remains as belt-and-suspenders even after that refactor.
+
+A higher-level gate does NOT already exist for this — the incident is
+specifically the absence of such a gate. This change creates it.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [x] ✅ Yes, with brittle logic — **and that is correct** under the
+  carve-out in `docs/signal-vs-authority.md` lines 74–77:
+
+  > **Safety guards on irreversible actions.** `rm -rf /`,
+  > force-pushing to main, deleting the database — these can and
+  > should be hard-blocked by brittle pattern matchers, because the
+  > cost of a false pass is catastrophic and the cost of a false
+  > block is merely "try again with the right arguments."
+
+This guard is exactly that category. False-pass cost: 1,893-file wipe +
+force-push recovery (established empirically on 2026-04-22). False-block
+cost: developer edits a path or touches a marker file once. The
+asymmetry is overwhelming and the principle explicitly excludes this
+class of check from the "brittle = signal only" rule.
+
+No judgment gate is being added. No LLM-backed contextual check is
+being bypassed. The check does not reason about message content, agent
+intent, or conversational state — it asks "is this path the source
+tree?" and acts on the yes/no. Fully compliant with the
+signal-vs-authority separation.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** The guard runs as the FIRST statement of each
+  constructor, before any other validation. It cannot shadow existing
+  checks — it precedes them. If the guard throws, later validation does
+  not run, which is correct (the path is untrusted; any later check
+  against it is moot).
+- **Double-fire:** No other component performs an equivalent check
+  today (grep confirms). Once `SafeGitExecutor` lands, both will fire;
+  that's intentional redundancy, not a bug.
+- **Races:** Pure synchronous fs reads. No shared state. No
+  concurrency hazard. The detector is idempotent and side-effect-free.
+- **Feedback loops:** None. The guard does not feed any downstream
+  decision system.
+- **Test harness interaction:** All existing `mkdtemp`-based tests
+  still pass. The smoke tier (2037 tests) passes locally post-wiring.
+  Integration test confirms that a sandbox subdirectory still
+  constructs successfully.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Other agents on the same machine:** none. Per-process guard only.
+- **Other users of the install base:** behaviour changes only for
+  callers constructing the three managers against the instar source
+  itself — which no legitimate user does (it would mutate the instar
+  source). Forks are intentionally not caught by layer (b); layer (c)
+  catches unrenamed forks, which is arguably a feature (forkers who
+  kept the instar name probably also don't want their own repo wiped).
+- **External systems:** no network, no LLM, no IPC. Sub-millisecond
+  synchronous fs check.
+- **Persistent state:** the `.instar-source-tree` marker file at repo
+  root is new persistent state. It's a one-line inert sentinel; its
+  only consumer is this guard. Safe to leave in place on rollback.
+- **Timing / runtime conditions:** the guard runs at constructor time,
+  before any async work. Worst case ~5ms cold (three fs reads); warm
+  cache sub-millisecond. Cannot cause gate-vs-client-timeout issues.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+- **Hot-fix release:** revert the commit — delete
+  `src/core/SourceTreeGuard.ts`, remove the three one-line wire-ins,
+  ship as next patch. No code outside this module depends on the new
+  symbols. The `.instar-source-tree` marker can be left in place (inert
+  without the guard reading it) — avoids a second commit.
+- **Data migration:** none. No persistent state introduced beyond the
+  inert marker file.
+- **Agent state repair:** none. Per-process guard, no shared state.
+- **User visibility:** none — rollback restores prior behaviour
+  instantly on restart. A legitimate caller that was ever blocked by
+  this guard was almost certainly pointed at the wrong tree anyway; the
+  rollback window does not expose users to regression.
+
+Estimated hot-fix time: minutes.
+
+---
+
+## Conclusion
+
+This review produced the following design decisions locked into the
+final code:
+
+- Two-tier fail-closed (detector-level = TRUE; layer-level = FALSE for
+  that sub-check) to avoid the over-block pathology flagged in the
+  convergence review.
+- Worktree common-git-dir resolution via the
+  `basename(dirname(gitdir)) === "worktrees"` rule, falling through to
+  layer (b) inconclusive on non-standard layouts rather than guessing.
+- Canonical-remote list kept intentionally narrow (three exact URLs
+  with three narrow normalization rules: strip whitespace, strip
+  trailing slash, strip trailing `.git`). No substring or regex
+  matching.
+- Error message deliberately does NOT inline bypass instructions (a
+  tutorial-in-the-error-message is a convenient "how to defeat the
+  guard" crib sheet that outlives the reason it exists).
+- Pre-ship enumeration converts the three-manager defense from "hope
+  we found them all" to "documented inventory at ship time." Findings
+  below.
+
+The change is clear to ship. It is a necessary-but-not-sufficient step
+toward the SafeGitExecutor centralization, which is scheduled as a
+follow-up PR.
+
+---
+
+## Pre-ship grep enumeration evidence
+
+```
+$ grep -rnE "execFileSync\('git'|execSync\('git |spawn\(?'git'|spawnSync\('git'" src/
+src/core/SyncOrchestrator.ts:1163    return execFileSync('git', args, {                             non-destructive (delegates to GitSync / BranchManager / HandoffManager which are now guarded)
+src/core/ProjectMapper.ts:261        execFileSync('git', ['remote', 'get-url', 'origin'], …)       non-destructive (read-only)
+src/core/ProjectMapper.ts:275        execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], …) non-destructive (read-only)
+src/core/ScopeVerifier.ts:449        execFileSync('git', ['remote', 'get-url', 'origin'], …)       non-destructive (read-only)
+src/core/BranchManager.ts:533        execFileSync('git', args, {                                    destructive — wrapped by the guarded BranchManager constructor
+src/core/AgentConnector.ts:141       execSync('git --version', …)                                   non-destructive (version query)
+src/core/ParallelDevWiring.ts:35     execFileSync('git', ['remote', 'get-url', 'origin'], …)       non-destructive (read-only)
+src/core/GitSync.ts:1006             execFileSync('git', args, {                                    destructive — wrapped by the guarded GitSyncManager constructor
+src/core/WorktreeManager.ts:756      execFileSync('git', […'rev-parse', 'HEAD'], …)                 non-destructive (read-only)
+src/core/WorktreeManager.ts:763      execFileSync('git', […'rev-parse', '--verify', branch], …)    non-destructive (read-only)
+src/core/WorktreeManager.ts:765      execFileSync('git', […'branch', branch], …)                    branch-create only; targets a worktree path, not the source tree — deferred to SafeGitExecutor PR
+src/core/WorktreeManager.ts:767      execFileSync('git', […'worktree', 'add', …], …)                creates a new worktree, does not mutate source — out of scope
+src/core/WorktreeManager.ts:879      execFileSync('git', […'worktree', 'list', …], …)              non-destructive (read-only)
+src/core/FileClassifier.ts:298       execFileSync('git', ['checkout', '--ours', …], …)             destructive — invoked only during sync under GitSyncManager's control; guard fires at manager construction upstream
+src/core/FileClassifier.ts:302       execFileSync('git', ['add', …], …)                             destructive — same as above; upstream-guarded
+src/core/FileClassifier.ts:324       execFileSync('git', ['add', relPath], …)                       destructive — same; upstream-guarded
+src/core/HandoffManager.ts:496       execFileSync('git', args, …)                                  destructive — wrapped by the guarded HandoffManager constructor
+src/server/routes.ts:2285            execFileSync('git', ['remote'], …)                             non-destructive (read-only)
+src/server/routes.ts:3035            execFileSync('git', ['remote', 'get-url', 'origin'], …)       non-destructive (read-only)
+src/lifeline/ServerSupervisor.ts:376 spawnSync('git', ['status'], …)                                non-destructive (read-only)
+src/lifeline/ServerSupervisor.ts:384 spawnSync('git', ['rebase', '--abort'], …)                     recovery-only, operates on the agent's OWN repo (not the source tree); orthogonal to this guard
+src/commands/init.ts:386             execFileSync('git', ['init'], …)                              destructive on target dir — target is a fresh user project, not the source tree; out of scope
+src/commands/init.ts:3329            execFileSync('git', ['remote'], …)                             non-destructive (read-only)
+src/commands/nuke.ts:142             execFileSync('git', ['add', '-A'], …)                          destructive — operator-initiated on the agent's own directory; documented and out of scope
+src/commands/nuke.ts:143             execFileSync('git', ['status', '--porcelain'], …)             non-destructive (read-only)
+src/commands/nuke.ts:150             execFileSync('git', ['commit', …], …)                          destructive — same as above
+src/commands/nuke.ts:156             execFileSync('git', ['push'], …)                              destructive — same
+src/commands/nuke.ts:212             execFileSync('git', ['remote'], …)                            non-destructive (read-only)
+src/commands/machine.ts:285          execFileSync('git', ['clone', …], …)                          destructive on a fresh target, not the source tree
+src/commands/setup.ts:114            execFileSync('git', ['rev-parse', '--show-toplevel'], …)      non-destructive (read-only)
+src/monitoring/WorktreeReaper.ts:208 execFileSync('git', […'worktree', 'add', …], …)               creates a new worktree, does not mutate source
+```
+
+Summary:
+- 31 direct git invocations under `src/`.
+- Destructive call sites routed through the three guarded managers:
+  `GitSync.ts:1006`, `BranchManager.ts:533`, `HandoffManager.ts:496`,
+  plus three `FileClassifier` helpers invoked only under
+  `GitSyncManager`'s control.
+- Destructive sites NOT routed through the three managers and flagged
+  for PR 2 (SafeGitExecutor centralization): `WorktreeManager.ts`
+  branch/worktree creation, `commands/init.ts`, `commands/nuke.ts`,
+  `commands/machine.ts clone`, `ServerSupervisor.ts rebase --abort`.
+  None of these target the instar source tree in their documented call
+  patterns — they either operate on fresh targets (`init`, `clone`,
+  `worktree add`) or on the agent's own dir (`nuke`, `rebase --abort`).
+- No unguarded manager-layer destructive paths found.
+
+This inventory is the "documented enumeration at ship time" the spec's
+pre-ship acceptance criterion requires.
+
+---
+
+## Evidence pointers
+
+- Spec: `docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md` (approved,
+  converged).
+- Convergence report:
+  `docs/specs/reports/destructive-tool-target-guards-convergence.md`.
+- Unit tests: `tests/unit/SourceTreeGuard.test.ts` — 34 tests, all
+  green locally. Covers detector layers individually, normalization
+  rules, worktree handling (standard + non-standard + malformed +
+  relative pointer), subdirectory bypass, uncreated-subdirectory
+  bypass, symlink canonicalization, two-tier fail-closed, error
+  shape.
+- Integration tests:
+  `tests/integration/source-tree-guard-wiring.test.ts` — 10 tests, all
+  green. Covers: constructor throws for each of the three managers
+  pointed at the real instar source; uncreated-subdirectory-of-instar
+  still throws; mkdtemp sandbox construction succeeds for all three;
+  subdirectory-of-sandbox also succeeds (no over-block on legitimate
+  nested paths); side-effect isolation (state dir NOT created when
+  guard fires).
+- Smoke tier pass: `npm run test:smoke` — 2037 tests passed locally
+  post-wiring (the push-hook's gate).
+- Full-suite sample: `tsc --noEmit` clean; no new warnings.


### PR DESCRIPTION
## Summary

Adds a new `SourceTreeGuard` primitive that refuses to let the three
destructive managers — `GitSyncManager`, `BranchManager`,
`HandoffManager` — be constructed against the instar source tree.

This is the tactical guardrail from
[docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md](docs/specs/DESTRUCTIVE-TOOL-TARGET-GUARDS-SPEC.md)
(approved, `review-convergence: converged`), addressing the 2026-04-22
branch-lifecycle e2e incident where a test fixture wiped 1,893 files
from the real instar checkout because destructive components trusted
an incoming `projectDir` with zero verification.

### What's in this PR

- `src/core/SourceTreeGuard.ts` — new primitive. Exports
  `isInstarSourceTree(dir)` and `assertNotInstarSourceTree(dir, op)`.
  Detection is the OR of three layers:
  1. Marker file `.instar-source-tree` at the resolved root.
  2. Canonical `origin` URL in the resolved common-git-dir config.
  3. `package.json name === "instar"` AND two-of-N signature files.
  Path resolution uses a nearest-existing-ancestor walk (closes the
  uncreated-subdirectory bypass). Worktrees are handled via `.git`-file
  parsing and `basename(dirname(gitdir)) === "worktrees"` common-git-dir
  resolution. Fail-closed is two-tier — detector-level returns TRUE,
  layer-level returns FALSE for that sub-check so the OR across layers
  decides.
- `.instar-source-tree` marker file at the repo root (git-tracked).
- Wire-in at the first statement of each of the three managers'
  constructors, throwing `SourceTreeGuardError` (code
  `INSTAR_SOURCE_TREE_GUARD`) before any collaborator touches anything.
- `tests/unit/SourceTreeGuard.test.ts` — 34 tests covering every
  detector layer, normalization rule, worktree shape, symlink
  canonicalization, subdirectory bypass, uncreated-subdirectory bypass,
  two-tier fail-closed, and error shape.
- `tests/integration/source-tree-guard-wiring.test.ts` — 10 tests
  covering constructor-level wire-in, side-effect isolation, and
  legitimate-sandbox construction.
- `upgrades/side-effects/source-tree-guard.md` — full `/instar-dev`
  side-effects review artifact.

### Pre-ship grep enumeration

Inventory of direct git invocations under `src/` (31 sites). Full
classification in `upgrades/side-effects/source-tree-guard.md`.

- **Destructive, routed through the three guarded managers**
  (protected by this PR): `GitSync.ts:1006`, `BranchManager.ts:533`,
  `HandoffManager.ts:496`, plus three `FileClassifier` helpers invoked
  only under `GitSyncManager`'s control.
- **Non-destructive** (18 sites): `remote get-url`, `rev-parse`,
  `status`, `--version`. No action required.
- **Destructive, out-of-scope for this PR** (flagged for PR 2 —
  SafeGitExecutor centralization): `WorktreeManager.ts` branch/worktree
  creation, `commands/init.ts`, `commands/nuke.ts`, `commands/machine.ts
  clone`, `ServerSupervisor.ts rebase --abort`. None of these target
  the instar source tree in their documented call patterns.

### Explicitly deferred

- E2E sandbox cwd isolation (most-direct prevention of yesterday's
  specific incident — separate PR, same milestone).
- Adriana's autostash/rebase wipe — separate failure mode, separate PR.
- CI mutation-detector job — follow-up PR.
- SafeGitExecutor centralization — follow-up PR.

### Test plan

- [x] `tests/unit/SourceTreeGuard.test.ts` — 34 tests pass.
- [x] `tests/integration/source-tree-guard-wiring.test.ts` — 10 tests
  pass.
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run tests/e2e/branch-lifecycle.test.ts` — 12 tests
  pass.
- [x] `npx vitest run tests/e2e/handoff-lifecycle.test.ts` — 9 tests
  pass.
- [ ] Full CI sharded runners (watched post-push).