### PR TITLE
feat(telegram): wire HTML formatter into Bot API chokepoints (default disabled) [PR2]

### DIFF
--- a/docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md
+++ b/docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md
@@ -1,0 +1,474 @@
+---
+title: Telegram markdown renderer (server-side HTML formatter + lint + parse_mode migration)
+slug: telegram-markdown-renderer
+author: echo
+review-iterations: 6
+review-convergence: "2026-04-24T19:28:38Z"
+review-completed-at: "2026-04-24T19:28:38Z"
+review-report: "docs/specs/reports/telegram-markdown-renderer-convergence.md"
+approved: true
+approved-by: Justin
+approved-at: "2026-04-24T20:53:47Z"
+approved-via: "Telegram topic 8183"
+approval-context: "Telegram topic 8183 'telegram markdown' 2026-04-24 — Justin asked Echo to port Dawn's formatter into instar. Dawn's impl lives in the-portal/.claude/scripts/telegram_format.py + telegram-reply.py (merged 2026-04-24T17:57Z). Spec must pass convergent review (internal + crossreview) before /instar-dev touches code. Iteration 1 corrected a factual error in the premise (instar uses parse_mode='Markdown', not 'HTML') and addressed 20+ findings."
+---
+
+# Telegram markdown renderer (server-side HTML formatter + lint + parse_mode migration)
+
+## Problem
+
+**Corrected premise** (iteration-1 finding from integration reviewer, refined in iteration-2): instar's outbound Telegram path is NOT uniform. The majority of send sites use `parse_mode: 'Markdown'` (`TelegramAdapter.ts` lines 722, 790, 1212, 3646, 3654; `TelegramLifeline.ts:1816`), but at least ONE callsite already uses `'HTML'` (`TelegramAdapter.ts:2889`, the onboarding/welcome path). The codebase mixes modes by callsite. Any spec that treats "current baseline = Markdown everywhere" is wrong; rollback must preserve per-callsite historical mode, not force Markdown on every send.
+
+That matters because agent output is Claude-native GitHub-flavored markdown (`**bold**`, `` `code` ``, `# headings`, `| tables |`, `[text](url)`). Legacy Telegram Markdown uses `*bold*` (single asterisk) and has no syntax for headings or tables. The mismatch produces:
+
+1. `**bold**` renders as literal `**bold**` (legacy Markdown doesn't understand double-asterisk).
+2. `| table |` rows render as literal pipes; alignment is lost.
+3. `# Heading` renders as literal `# Heading`.
+4. Bracket-link `[text](url)` *does* work in legacy Markdown but breaks when the URL or text contains reserved chars because legacy Markdown has no standardized escape.
+5. Any literal `_`, `*`, `` ` ``, `[` inside prose can silently open an unterminated entity, which makes the send fail or the rest of the message render incorrectly.
+
+Dawn hit the same problem and landed a client-side fix at 2026-04-24T17:57Z (`the-portal/.claude/scripts/telegram_format.py` + `telegram-reply.py`). Her fix lives in the CLI client; any send path that bypasses that script bypasses the fix. Instar has multiple bypass paths (jobs, dispatch, attention-queue, lifeline pings, MCP-triggered sends, direct route POSTs) so a client-side fix is structurally insufficient here.
+
+This spec proposes: (a) migrate the outbound parse_mode from `Markdown` → `HTML`, and (b) add a server-side formatter that converts agent-authored GitHub markdown → Telegram HTML on every outbound path. Both together, because the HTML migration without the formatter is net-worse (current legacy Markdown handles `*italic*` and `[text](url)` reasonably; HTML mode without a formatter renders those literally too).
+
+## Non-goals
+
+- Not switching to `MarkdownV2`. MarkdownV2 requires escaping every reserved char in every non-formatting position — strictly worse operationally than HTML.
+- Not rewriting message *content* (that's the tone / style / plain-language gates).
+- Not supporting every GitHub markdown feature — only bold, italic, code, pre, headings, bullets, tables, links. (Reference-style links, footnotes, images, definition lists, strikethrough-via-tilde are out of scope.)
+- Not adding any LLM call to the formatter. Pure deterministic string transformation.
+- Not changing the `onboarding/welcome` path that already uses `parse_mode: 'HTML'` (it becomes a consumer of the new formatter like everything else).
+
+## Solution
+
+### Architecture: server is authoritative, shell script is a thin flag
+
+**Layer 1 — server-side formatter (authoritative).** New module at `src/messaging/TelegramMarkdownFormatter.ts`:
+
+```ts
+export type FormatMode =
+  | 'plain'            // HTML-escape; strip markdown to unicode (•, '')
+  | 'html'             // passthrough for internal callers emitting Telegram HTML
+  | 'code'             // wrap whole message in <pre>
+  | 'markdown'         // convert GH markdown -> Telegram HTML (default)
+  | 'legacy-passthrough'; // passthrough using parse_mode:'Markdown' (rollback)
+
+export interface FormatResult {
+  text: string;
+  parseMode: 'HTML' | 'Markdown' | undefined;
+  lintIssues: string[];
+  modeApplied: FormatMode;
+  truncated: boolean;
+}
+
+export function formatForTelegram(text: string, mode?: FormatMode): FormatResult;
+export function lintTelegramMarkdown(text: string): string[];
+```
+
+The formatter returns BOTH the rendered text AND the `parse_mode` the caller should set. Previously the adapter hard-coded `'Markdown'`; after this change the adapter reads `parse_mode` from the formatter result, so a single config flip can select `markdown` (→ HTML) or `legacy-passthrough` (→ Markdown, passthrough) without another code change.
+
+**Wiring point — corrected** (iteration-1 integration finding): the spec originally claimed a single `sendMessage` funnel. That's wrong. The real chokepoints are the private `apiCall()` methods:
+
+- `TelegramAdapter.apiCall()` (`src/messaging/TelegramAdapter.ts:3996`) — used by `send()`, `sendToTopic()`, edit paths, attention queue, welcomes.
+- `TelegramLifeline.apiCall()` (`src/lifeline/TelegramLifeline.ts:1837`) — duplicate Bot API client with its own token, bypasses the adapter entirely.
+
+The formatter runs inside both `apiCall()` methods, conditional on `method === 'sendMessage' || method === 'editMessageText'`. This catches every send path, including the 6+ direct `apiCall('sendMessage', ...)` sites and the Lifeline's independent client.
+
+**Layer 2 — shell-script convenience (thin).** `.claude/scripts/telegram-reply.sh` gains `--format <mode>` and `--lint-strict` flags. The flag is forwarded via `X-Telegram-Format` header (auth-gated — see Security) and a `format` field in the POST body. If absent, the server uses its configured default. The shell script does NOT re-implement formatting.
+
+The shell script lives in `src/templates/scripts/telegram-reply.sh` (instar template distributed to every scaffolded agent). Existing agents keep their old script until they re-scaffold; the server default handles the missing-header case correctly, so older scripts continue to work.
+
+### Modes — exact contract
+
+- **`plain`** — HTML-escape `<`, `>`, `&`, `"`, `'`. Strip markdown down to unicode: `**bold**` → `bold`; `` `code` `` → `'code'`; `- bullet`/`* bullet`/`+ bullet` → `• bullet`; `# Heading` → `HEADING` (uppercased for emphasis). Lint rejects markdown tables. `parseMode: 'HTML'`.
+- **`html`** — Passthrough. Reserved for internal callers already producing Telegram HTML (e.g. the onboarding welcome path). Runs ONLY when the caller identity is on the trusted-internal-callers list (see Security). `parseMode: 'HTML'`.
+- **`code`** — Wrap message in `<pre>...</pre>`; inner content HTML-escaped. For tables and aligned monospace output. `parseMode: 'HTML'`.
+- **`markdown`** (DEFAULT after cutover) — Convert GH markdown → Telegram HTML. Details below. `parseMode: 'HTML'`.
+- **`legacy-passthrough`** (renamed from `legacy-passthrough` — iteration-2 INT-2): Passthrough, no conversion, `parseMode` is **whatever the callsite originally passed** (preserved via per-call override rather than global setting). Restores exact pre-cutover byte-for-byte behavior even for callsites that already use HTML (e.g. `TelegramAdapter.ts:2889` onboarding path). Implementation: when `legacy-passthrough` is the configured default, `apiCall()` passes `parse_mode` through from the caller's explicit argument unchanged, bypassing the formatter entirely. This is the true rollback target.
+
+### Markdown conversion rules
+
+Processing order matters for correctness. Exact sequence:
+
+0. **Strip NUL bytes** (iteration-2 scalability finding S1): remove all `\x00` from input before any further processing. Placeholder sentinels use NUL-bracketed tokens (`\x00INSTAR_TOK_<n>\x00`); stripping up front eliminates collision risk. NUL is not legal in Telegram HTML anyway.
+1. **Length guard**: if `text.length > 32768`, skip conversion and return `plain` mode output with a `conversionSkipped: true` flag (ReDoS defense — iteration-1 scalability finding). The distinct `truncated: true` flag is reserved for bytes-dropped cases (see Iteration-3 hardening).
+2. **Extract fenced code blocks** (``` ``` fences ```) — replace with placeholder tokens. Inner content HTML-escaped, wrapped in `<pre>`.
+3. **Extract table blocks** — contiguous lines matching `^\s*\|.+\|\s*$` with an alignment row (`^\s*\|[\s\-:|]+\|\s*$`). Escape inner text, wrap entire block in `<pre>`. Replace with placeholder tokens.
+4. **Extract inline code spans** (`` `x` ``) — placeholder tokens; inner escaped, wrapped in `<code>`.
+5. **HTML-escape remaining prose** (`<`, `>`, `&`, `"`, `'`).
+6. **Bold-italic** (triple-asterisk, must run BEFORE steps 7-8 — iteration-3 GPT finding): `\*\*\*([^*\n]+?)\*\*\*` → `<b><i>$1</i></b>`.
+7. **Bold**: `\*\*([^*\n]+?)\*\*` → `<b>$1</b>`. Not greedy, bounded by newline.
+8. **Italic** (tightened — iteration-1 adversarial finding H1): `(?<=^|[\s(,.;:!?])\*(?!\s)([^*\n]{1,200}?)(?<!\s)\*(?=$|[\s),.;:!?])` → `<i>$1</i>`. Requires word-boundary-ish context on both sides; does NOT match `3*5`, `f(x) = x * y`, `a*b*c`.
+9. **Headings**: `^(#{1,6})\s+(.+?)\s*#*\s*$` → `<b>$2</b>` (Telegram supports only bold, not h1-h6).
+10. **Bullets**: `^(\s*)[-*+]\s+` → `$1• `.
+11. **Links** (balanced-paren scanner — iteration-3 Gemini finding): NOT a regex. Find every `[` / `](` sequence. For each:
+    - Capture visible text (already HTML-escaped from step 5) until matching `]`.
+    - After `](`, walk forward counting `(` and `)` until balanced (first `(` opens count 1; matching `)` closes it; nested parens increment and decrement; `\(` and `\)` are treated as LITERAL parens, not escape sequences — markdown has no defined paren-escape, so the scanner treats a preceding backslash as already-escaped text and still counts the paren). If balance not reached within 2048 chars of URL content, emit literal `[text](url-so-far` as fallback.
+    - On balance, extract URL text.
+    - Parse URL with WHATWG URL. If parse fails, emit literal text `[text](url)` (already escaped).
+    - Reject scheme unless ∈ `{http, https}` (lowercased after trimming leading whitespace/control chars). `tg:`, `javascript:`, `data:`, `file:`, etc. become literal text. (Explicit over-block of `tg:` noted; a future spec may allow it.)
+    - URL goes through `escapeHtmlAttribute()` (distinct from `escapeHtmlText`): escapes `"`, `'`, `<`, `>`, `&`, and strips `\x00-\x1f`, `\x7f`, CR, LF.
+    - Emit `<a href="escaped-url">escaped-text</a>`.
+12. **Splice placeholder tokens back in** (pre blocks, table blocks, code spans).
+
+The italic regex (step 8) is the only subtle one; the rest are bounded by `\n` or `\|`-anchored to avoid backtracking. A fuzz test (see Tests) covers adversarial inputs.
+
+### Security hardening
+
+#### URL attribute escaping
+
+`escapeHtmlAttribute(url)` is a DISTINCT function from `escapeHtmlText`. Contract:
+
+```
+escapeHtmlAttribute(s):
+  1. strip chars in \x00-\x1f\x7f
+  2. replace CR and LF with nothing
+  3. replace & with &amp;
+  4. replace " with &quot;
+  5. replace ' with &#39;
+  6. replace < with &lt;
+  7. replace > with &gt;
+```
+
+Tests: URLs containing `"`, `'`, `\n`, `\r`, NUL, `<`, `>`, `&`, mixed.
+
+#### Scheme allowlist
+
+```
+isSafeUrl(raw):
+  trimmed = raw.replace(/^[\s\x00-\x1f]+/, '')
+  parsed = try new URL(trimmed); catch { return false }
+  scheme = parsed.protocol.toLowerCase().replace(':','')
+  return scheme === 'http' || scheme === 'https'
+```
+
+IDN homoglyph attacks: WHATWG URL normalizes via Punycode, so `һttps://evil` (Cyrillic `һ`) either parses to punycode (detectable — not `https`) or fails parse.
+
+#### Auth scope for `X-Telegram-Format` and `format` body field
+
+- All Telegram send routes (`/telegram/reply/:topic`, `/telegram/topic/:topic/send`, any future route) already require the server auth token (per existing instar auth policy). Format inputs are honored ONLY on authed requests; unauthenticated POST with format=html is rejected at auth layer BEFORE reaching the formatter.
+- `format: 'html'` is further restricted: server maintains an allowlist of trusted internal caller identities (request originates from server-internal code, e.g. the onboarding path, the attention-queue renderer). Shell script and remote HTTP callers are REFUSED `html` mode — they get a 422 with message "html mode is reserved for trusted internal callers; use markdown, plain, code, or legacy-passthrough". (Iteration-1 adversarial finding H2.)
+- Identity check uses the existing `requestOrigin` metadata the server attaches to authed calls; no new auth mechanism.
+
+#### ReDoS bound
+
+- 32KB hard cap (step 1 above).
+- Italic regex body bounded by `{1,200}` (step 8).
+- Safe-regex CI lint (safe-regex2) runs on every commit; any new pattern must pass.
+- Fuzz test: 10K random strings with pathological patterns (nested `*`, repeated `|`, long runs of `` ` ``). p99 must be < 5ms.
+
+#### Lint self-safety
+
+Lint issue strings MUST NOT contain markdown tokens or excerpts from input. Canonical messages use plain prose:
+- `"markdown bold syntax detected (double-asterisk)"` — NOT `"**bold** detected"`.
+- `"markdown heading syntax detected (leading hash)"`.
+- `"markdown table syntax detected (pipe rows with alignment separator)"`.
+- Lint strings NEVER include user/agent text.
+
+#### Lint span-stripping is advisory-only
+
+`<code>` / `<pre>` stripping runs in `lintTelegramMarkdown()` only, to avoid flagging literal examples. That function does NOT feed into the converter. The converter path (markdown mode) extracts code/pre blocks with its own tokenizer (step 2-4), not via the advisory strip. Invariant stated in comments + asserted in tests.
+
+### Pipeline ordering — corrected (iteration-1 adversarial findings C1, C2)
+
+The original spec placed the formatter BEFORE the rewrite gates (plain-language, closure-reflex), which would have corrupted HTML when the LLM-based rewriters re-wrote the bytes. Corrected order:
+
+```
+raw_text
+  ↓
+plain-language gate (may rewrite)
+  ↓
+closure-reflex gate (may rewrite; dryrun by default)
+  ↓
+messaging tone / style gate (may reject or rewrite)
+  ↓
+FORMAT  ← here
+  ↓
+length-split (tag-aware, entity-aware)
+  ↓
+Bot API sendMessage with computed parse_mode and stable idempotency key
+```
+
+Formatting runs AFTER all rewrites. Gates see/produce agent-native markdown (their native input distribution); no gate is required to preserve HTML bytes; no double-escape on retry.
+
+#### Plain-retry fallback — corrected
+
+When Bot API returns `400 Bad Request: can't parse entities`, the adapter retries WITHOUT re-entering the formatter. It retries the Bot API call with `parse_mode: undefined` and the ORIGINAL pre-format text. The adapter caches `(rawText, formattedText)` tuple per request so retry has access to raw. This avoids C1 double-escape.
+
+### Length splitting
+
+- Implemented as a single-pass O(N) walk. Upper-bound: one pass to find the chunk boundary, one pass to copy. No retry loops.
+- Safe boundary search walks backward from the 4096-char cap to find the nearest preceding `\n\n` (paragraph), `\n` (line), space (word), OR safe inter-tag position.
+- MUST NOT split inside `<a>...</a>`, `<b>...</b>`, `<i>...</i>`, `<code>...</code>`, `<pre>...</pre>`, or an HTML entity (`&...;`).
+- Edge case: a single `<pre>` larger than 4096 chars → the splitter surfaces this via `FormatResult.truncated = true` and the adapter falls back to `plain` mode on the RAW text (not re-formatted output), then splits that.
+- Split chunks share the original idempotency namespace: each chunk gets `${originalIdempotencyKey}:part:${N}/${total}` so retries of a partial send don't double-post.
+- Rate-limit: split chunks enter the existing per-chat rate-limit queue; spec requires extending the queue to treat a group of chunks as a single FIFO admission (no interleaving with unrelated messages).
+
+### Config — corrected plumbing
+
+Additions to `InstarConfig` (`src/core/types.ts`):
+- `telegramFormatMode?: FormatMode` — default `'markdown'` after cutover; `'legacy-passthrough'` during canary.
+- `telegramLintStrict?: boolean` — default `false`.
+
+Propagation:
+- `Config.ts` loads these into the top-level config object.
+- `server.ts` (`src/commands/server.ts` ~:4628, :4760) passes an accessor closure `() => config.telegramFormatMode` into the `TelegramAdapter` constructor's `TelegramConfig`.
+- `TelegramAdapter.apiCall()` reads the accessor on each send (live reflection, no restart needed). Same for `TelegramLifeline.apiCall()`.
+- Config hot-reload works because the accessor reads the current config object on each invocation.
+- Override precedence (per send) — updated in Iteration-3: explicit arg (trusted-by-construction, internal callers only) → body field (authed request) → request header → config accessor → hard default `'markdown'`. The `html` mode gate applies to sources 2 and 3 identically; explicit-arg callers are implicitly trusted by virtue of being internal server code, bound by the trusted-internal-callers list in Security.
+
+### Multi-machine
+
+- Formatting is SEND-side only. The machine holding the Telegram token formats; other machines never touch Telegram directly.
+- GitSyncTransport (`src/messaging/GitSyncTransport.ts`) forwards messages across machines with envelope metadata. Add envelope flag `alreadyFormatted: false` (default). When a machine relays a message to the sending machine, the relay carries the RAW text (not HTML); the sending machine formats at send time. This avoids per-machine config divergence producing double-formatting.
+- Migration path: existing GitSync envelopes without the flag are treated as raw (default).
+
+### Template composition safety
+
+New helper `formatTemplate(template, vars, mode)`:
+
+```ts
+export function formatTemplate(
+  template: string,
+  vars: Record<string, string>,
+  mode: FormatMode = 'markdown'
+): FormatResult;
+```
+
+The helper:
+1. Strips BOTH NUL bytes AND the Supplementary-PUA-B range (`U+100000..U+10FFFD`) from template body and every variable value. Sentinel codepoints are drawn from this PUA-B range, so scrubbing user content up front prevents collision. This range has near-zero real-world usage and is not valid Telegram HTML text.
+2. Splices each `${var}` value into the template as a TEXT-NODE SENTINEL drawn from Supplementary-PUA-B (`U+100000..U+10FFFD`) — e.g. `U+100000 + n` bracketed by `U+10FFFD`. Sentinels cannot collide with user content because substep 1 already stripped that range. Variable content is NOT pre-escaped; the sentinel ensures step 5 HTML-escapes the variable as plain text exactly once. The inner formatter treats these sentinels the same way it treats NUL-bracketed placeholders.
+3. Runs the spliced template through `formatForTelegram(mode)` with `skipNulStrip: true` (step 0 already ran at substep 1).
+Callers that currently build message bodies via string concatenation (attention-queue alerts, job status pings, etc.) migrate to `formatTemplate`.
+
+Lint rule (build-time): any `.ts` file matching `templates/messages/` or `attention-queue/` that contains `${` inside a template literal passed to `sendMessage` without going through `formatTemplate` fails CI.
+
+### Idempotency
+
+- Current idempotency key includes request payload hash. After formatting moves server-side, the key is computed from RAW text (pre-format) so `format(x) === format(x)` determinism plus raw-keying guarantees retries (including the 400 plain-retry path) land in the same dedup window.
+- Formatter is deterministic → identical inputs produce identical outputs (byte-for-byte). Test asserts `format(x).text === format(x).text` across 1000 fixtures.
+- Lint-strict rejection: no idempotency key is written (send never attempted). Agent retry with fixed text gets a new key. Lint-strict toggles are logged as auditable events with timestamp + operator identity.
+
+### Audit trail on non-default mode
+
+- Every send where the applied mode differs from the configured default emits a structured log record `{ timestamp, mode, configuredDefault, caller, topicId }`.
+- A self-monitor job (runs hourly) checks: "has `telegramFormatMode` been set to a non-`markdown` value for >24h?" — surfaces to attention queue if true. Prevents operator-debug-left-on scenarios.
+
+### Rollback
+
+True rollback target: set `telegramFormatMode = 'legacy-passthrough'`. This:
+- Skips all conversion (passthrough).
+- Preserves each callsite's ORIGINAL `parse_mode` byte-for-byte — `Markdown` for the Markdown sites (`TelegramAdapter.ts:722, 790, 1212, 3646, 3654`, `TelegramLifeline.ts:1816`), `HTML` for the onboarding site (`TelegramAdapter.ts:2889`). No global `parse_mode` forcing. (Iteration-3 GPT finding.)
+- Restores exact pre-cutover behavior including `*italic*`/`[text](url)` working as they do today.
+
+Not a code revert — a config flip. Rollback is O(1) operational cost.
+
+### Staged rollout
+
+1. **Pre-GA canary**: merge with `telegramFormatMode = 'legacy-passthrough'` as the shipped default. Formatter code is present but not applied. Canary flip on Echo's own agent: set `legacy-passthrough` → `markdown`, monitor for 24h.
+2. **Expand canary**: after 24h clean, flip `markdown` on a second agent.
+3. **Flip shipped default** to `markdown` after 72h clean across canary agents.
+4. **Monitor post-GA**: alert on any increase in Bot API 400 errors. Instantly revertable by config flip.
+
+## Tests
+
+New test files (framework: **Vitest**, matching instar's actual setup):
+
+- `tests/unit/telegram-markdown-formatter.test.ts`:
+  - Mode contracts (each of 5 modes × fixture set of 15 messages).
+  - HTML escape correctness across all positions incl. attribute context.
+  - Attribute-escape specific tests: URLs with `"`, `'`, `\n`, `\r`, NUL, `<`, `>`, `&`.
+  - Scheme allowlist: http, https allow; javascript, data, tg, file, mailto, and IDN homoglyph reject.
+  - Table extraction: with/without alignment row; adjacent tables; table at message end; table containing `</pre>` in a cell.
+  - Link safety: bad schemes become literal text; malformed URLs become literal text.
+  - Italic edge cases: `3*5`, `f(x) = x * y`, `a*b*c`, `*valid italic*`, `*unterminated`, `***triple***` (bold+italic).
+  - Bold edge cases: `**valid**`, `**nested `` `code` `` **`, `**unterminated`, `*****` quintuple.
+  - Lint: each rule positive + negative; literal-example carve-out.
+  - Lint-self-safety: lint messages never contain `**` or `#` tokens.
+  - Lint-strict: route returns 422 with issue list.
+  - Length splitting: paragraph, line, space boundaries; tag boundaries; entity boundaries; oversized single `<pre>` fallback.
+  - Determinism: `format(x).text === format(x).text` over 1000 fixtures.
+  - Idempotency of already-formatted input (envelope flag case).
+  - ReDoS fuzz: 10K random pathological strings; p99 < 5ms.
+  - Length guard: 33KB input returns `plain` mode with `truncated: true`.
+
+- `tests/integration/telegram-adapter-format.test.ts`:
+  - `**bold**` at route send → Bot API body contains `<b>bold</b>` + `parse_mode: 'HTML'`.
+  - Markdown table at route send → Bot API body contains `<pre>` with preserved alignment.
+  - Malformed HTML path → plain-retry fires with ORIGINAL raw text, not re-formatted output.
+  - `format: 'html'` from unauthenticated caller → 401.
+  - `format: 'html'` from authenticated but non-trusted caller → 422.
+  - `format: 'html'` from trusted internal caller (onboarding path) → passthrough.
+  - `legacy-passthrough` mode → Bot API body is raw text + `parse_mode: 'Markdown'`.
+  - Idempotency key derived from raw text → retry after formatter change produces same key.
+  - `TelegramLifeline.apiCall` formats with same pipeline as `TelegramAdapter.apiCall` (separate test — Lifeline has its own class).
+
+- `tests/integration/telegram-template-composition.test.ts`:
+  - `formatTemplate('Alert: ${title} is down', {title: 'User **pwned** us'}, 'markdown')` → asterisks in value are HTML-escaped, not interpreted.
+  - Build-time lint catches `${` in message templates not routed through `formatTemplate`.
+
+- `scripts/verify-telegram-render.ts` (dev-only, not CI): sends each fixture to a verification topic; prints Bot API message IDs for eyeball check. Runs on request.
+
+## Migration
+
+- **Behavioral change**: messages currently rendered as literal `**bold**` start rendering bold. Messages currently using legacy-Markdown-compatible `*italic*` render bold-italic or italic depending on context (tightened italic regex mostly preserves intent; edge-case fixtures enumerate). Operators should expect visible-but-desirable changes in the week after flip.
+- **Existing tests**: any integration test asserting exact Bot API body content (`expect(body).toContain('**bold**')`) breaks. Migration command: `grep -rn "parse_mode.*Markdown" tests/` and `grep -rn "\\*\\*.*\\*\\*" tests/fixtures/` to enumerate. Updated in the wiring PR.
+- **Message store**: `src/messaging/MessageStore.ts` currently stores `text` (ambiguously pre-or-post-format). Adjust to store `rawText` + `sentText` + `modeApplied`; dashboard displays `rawText` with a "rendered preview" toggle that shows the formatter's output.
+- **Agent scripts**: `src/templates/scripts/telegram-reply.sh` is updated to understand `--format`/`--lint-strict`. Existing scaffolded agent copies keep their old script; server default handles missing header. `CLAUDE.md` scaffold text is updated so new agents learn the flag exists.
+- **Docs**: update Self-Knowledge Tree telegram entry, instar `CLAUDE.md` Telegram Relay section, agent scaffold template docs, `docs/specs/` index.
+
+## Iteration-2 hardening (consolidated)
+
+The following refinements address iteration-2 reviewer findings and are stated here for convergence review:
+
+**Pipeline invariants (adversarial C3, C4):**
+- Rewrite gates (plain-language, closure-reflex, tone) declare a RAW-MARKDOWN output contract. Gate output is treated as raw markdown and fed to the formatter. If a gate's LLM incidentally produces literal `<b>` or `<i>`, step 5's HTML-escape converts them to `&lt;b&gt;` — safety-preserving; the agent's unintended HTML is not rendered. A fixture test covers "gate rewrites `**bold**` → `*strong*`" to document the bold→italic drift and confirm it doesn't regress past an accepted fixture set.
+- 422 lint-strict responses contain ONLY canonical lint messages + optional (line, col) coordinates. Never an excerpt of the submitted text. Response body shape: `{ issues: [{ code: 'MD_BOLD', message: 'markdown bold syntax detected (double-asterisk)', line: 3, col: 12 }] }`.
+
+**GitSync envelope trust (security + scalability S3 + adversarial M5):**
+- The `alreadyFormatted` field exists on the envelope for observability/future use but is **ignored by the receiving (sending-to-Telegram) machine**. The sending machine ALWAYS re-formats from raw. This makes formatting strictly send-side authoritative and prevents a non-sending machine from injecting pre-built HTML.
+- Formatter MUST be idempotent on its own output: `format(format(x).text).text === format(x).text` for any `x`. Enforced by test over 1000 fixtures. Idempotency matters because some future optimization may opportunistically skip re-formatting; the correctness-preserving version of that optimization depends on idempotency.
+- Any future change that would make the sending machine trust `alreadyFormatted: true` requires a minimum-version gate across the fleet and a separate spec.
+
+**Audit log shape (security):**
+- `caller` field is a closed enum: `route-reply | route-send | attention-queue | onboarding | lifeline | dispatch | mcp | job-template | other`. Never free-form. Prevents log-forging via header injection.
+- `topicId` is numeric-validated before logging.
+
+**Fuzz test rigor (scalability S2):**
+- Seeded RNG (seed committed in the test file) for deterministic, reproducible runs.
+- Vitest per-test `timeout: 30_000`; test suite fails if fuzz total wall-clock exceeds the cap.
+
+**Canary observability (adversarial H5):**
+- 24h canary on Echo's agent requires BOTH (a) zero increase in Bot API 4xx/5xx rate AND (b) eyeball-pass of `scripts/verify-telegram-render.ts` output at t=1h, t=6h, t=24h marks. Passing only (a) is not sufficient — rendering bugs most often produce 200 OK with visibly wrong output.
+- Verification fixture set has 30 entries covering all mode × feature combinations.
+
+**Chunk-retry semantics (adversarial M6):**
+- Chunked idempotency keys (`${key}:part:N/total`) apply ONLY when retrying the byte-identical raw text. If the agent paraphrases between attempts, the retry is treated as a fresh send (new top-level key, new chunking).
+
+**Drift-detection ownership (adversarial M7):**
+- Weekly Dawn-vs-instar formatter drift test is owned by Echo. Echo triages drift items; escalates to Justin only if the drift is behavioral (different rendered output for the same input), not cosmetic (different internal comments / test fixture shape).
+
+**Documented accepted trade-offs (adversarial L4):**
+- Italic between emoji (`🎉*bold*🎉`) renders with literal asterisks because the punctuation-class lookaround doesn't include emoji. Accepted v1; follow-up spec may extend the class.
+
+**Template-composition edge case (adversarial L5):**
+- Test fixture: `formatTemplate('${x}', {x: '<b>pwned</b>'}, 'markdown')` — output is the escaped literal `&lt;b&gt;pwned&lt;/b&gt;`, which Telegram renders as the literal string `<b>pwned</b>`. Not bold, not re-escaped further. One fixture pins this.
+
+**Config hot-mutable accessor (integration INT-5):**
+- `TelegramConfig` carries `getFormatMode: () => FormatMode` (closure over a mutable reference, not a captured value). Config mutations update the reference; subsequent sends read the new value without restart. Both `TelegramAdapter` and `TelegramLifeline` receive the same accessor.
+- Both server.ts instantiation sites (`:2375`, `:2430` per iteration-2 INT-3) wire the accessor identically.
+
+**MessageStore migration (integration INT-1):**
+- `MessageStore` is JSON-file-backed (`src/messaging/MessageStore.ts`), not SQLite/FTS. Adding `rawText` / `sentText` / `modeApplied` is a purely additive change on `AgentMessage` / the envelope. Older records missing the fields are tolerated by readers (`undefined` check). No backfill job, no schema migration, no FTS reindex.
+
+**Pre-push guidance (integration INT-6):**
+- Cutover PR sets `INSTAR_PRE_PUSH_FULL=1` so the full sharded suite runs locally before the push, not just the smoke tier.
+
+**PR scope revision (integration):**
+- Revised estimate: ~12 files in PR1 (formatter + types + tests + envelope field + MessageStore field additions + template helper) and ~14-16 files in PR2 (adapter wire + lifeline wire + server.ts × 2 + shell template + migrations of existing message builders to `formatTemplate` + docs + canary flip + integration tests).
+
+## Iteration-3 hardening (external cross-model review)
+
+GPT 5.4, Gemini 3.1 Pro, and Grok 4.1 Fast reviewed the iteration-2 spec. External consensus: conditionally approved with a set of tactical fixes below. Addressed:
+
+**Link regex — paren-balanced URLs (Gemini critical):**
+- Step 10's pattern `\[([^\]\n]+)\]\(([^)\n]+)\)` fails on Wikipedia-style `https://en.wikipedia.org/wiki/Foo_(bar)`. Replacement: use a balanced-paren scanner, not a regex. Algorithm: after finding `](`, walk forward counting `(` / `)` (ignoring escaped parens), terminating on the balancing close-paren. If no balance within 2048 chars of URL scan → fall back to literal `[text](url)` output. Test fixtures: Wikipedia URLs, URL with trailing `)`, unbalanced URL (literal fallback).
+
+**Plain-retry key + length-splitter re-entry (Gemini critical):**
+- On Bot API `400 can't parse entities`, the adapter retries with the ORIGINAL raw text. Iteration-3 corrections:
+  - Idempotency key for the retry is `${originalIdempotencyKey}:fallback-plain`. Distinct from the original key so downstream dedup treats it as a fresh send, not a cached 400.
+  - The raw text re-enters the length-splitter (which may produce different chunk boundaries than the HTML-formatted text did). If the resulting chunk count differs from the original, each chunk uses `${originalIdempotencyKey}:fallback-plain:part:N/total`.
+  - Plain-retry consumes a fresh per-chat rate-limit token (not the original one, which already fired on the failed HTML send). Retry ordering is NOT guaranteed under rate-limit pressure: if other messages are queued between the failed HTML send and the plain-retry, the retry may arrive after them. Callers that require strict ordering (rare) must serialize through the existing per-chat queue with explicit ordering constraints — out-of-scope for this spec.
+
+**Rollback inconsistency (GPT critical):**
+- The earlier "set `parse_mode: 'Markdown'`" language was contradicted by `legacy-passthrough`'s per-callsite preservation. Canonical statement: `legacy-passthrough` does not force any global `parse_mode`. It passes through whatever the callsite originally specified, byte-for-byte — Markdown for the Markdown sites, HTML for the HTML onboarding site. Rollback = flip config to `legacy-passthrough`; per-callsite modes resume exactly as before the cutover. The Rollback section's prior language is superseded by this statement.
+
+**Nested markdown grammar (GPT):**
+- Explicit grammar for nesting at conversion step 2-11:
+  - Fenced code and inline code have HIGHEST priority (no markdown interpreted inside).
+  - Inside a link's visible text (`[text]`): bold and italic are permitted; code spans are permitted; links are NOT nested.
+  - Inside bold: italic is permitted (`**bold *italic***` → `<b>bold <i>italic</i></b>`). Code spans are permitted. Links are NOT nested inside bold.
+  - Triple asterisk (`***x***`) parses as bold-italic (`<b><i>x</i></b>`) — requires explicit rule ordering: match triple BEFORE double BEFORE single. Test fixtures pin this.
+  - `***` at the start of a line without closing triple → literal asterisks (bullet-like? no — only `-/*/+ SPACE` is bullet; unterminated emphasis becomes literal).
+
+**editMessageText split policy (GPT critical):**
+- Telegram's `editMessageText` cannot be split — a single edit must map to a single message. Spec correction: if a formatted edit text exceeds 4096 chars post-format, the adapter returns an error to the caller (`TELEGRAM_EDIT_TOO_LONG`). It does NOT split the edit into multiple messages. The caller is responsible for content brevity on edits. Integration test covers this path.
+
+**32KB guard vs 4096 limit flag ambiguity (GPT):**
+- Replace single `truncated: true` with two distinct flags:
+  - `conversionSkipped: true` — formatter bypassed markdown conversion because input > 32KB; applied `plain` mode instead. No bytes dropped.
+  - `truncated: true` — output was byte-truncated to fit within Bot API single-message cap. Can only occur alongside the single-`<pre>` oversized-block fallback path.
+
+**formatTemplate double-escape (GPT critical):**
+- Canonical pipeline clarified: `formatTemplate(template, vars, mode)` does NOT HTML-escape variables in advance. Instead, it splices the raw variable values into the template as TEXT NODES with a sentinel boundary (NUL-bracketed like other placeholders), such that step 5's HTML-escape sees them as plain text and escapes them exactly once. The template's own markdown (`**`, `` ` ``) is interpreted normally; variable content is not. This produces the iteration-2 fixture L5 result (`{x: '<b>pwned</b>'}` → rendered literal `<b>pwned</b>`) with exactly one round of escaping, not two. Implementation test: `formatTemplate('hi ${x}', {x: 'a & b'}) → 'hi a &amp; b'` (single-escape).
+
+**Telegram HTML allowlist appendix (GPT):**
+- Add an appendix to the spec listing the exact set of Telegram-valid HTML tags the formatter is permitted to emit, cited to the Bot API docs (https://core.telegram.org/bots/api#html-style): `<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<ins>`, `<s>`, `<strike>`, `<del>`, `<span class="tg-spoiler">`, `<tg-spoiler>`, `<a href="...">`, `<tg-emoji emoji-id="...">`, `<code>`, `<pre>`, `<pre><code class="language-...">`, `<blockquote>`, `<blockquote expandable>`. Formatter emits a strict subset: `<b>`, `<i>`, `<code>`, `<pre>`, `<a href>`. `html`-mode (trusted-caller) passthrough permits the full allowlist.
+
+**Override precedence unambiguous (GPT):**
+- Corrected precedence (highest wins):
+  1. Explicit `mode` argument to `formatForTelegram()` call — used by internal server code.
+  2. `format` body field on authed HTTP POST — used by `.claude/scripts/telegram-reply.sh`.
+  3. `X-Telegram-Format` header on authed HTTP POST — used for sidecar tooling.
+  4. `InstarConfig.telegramFormatMode` accessor.
+  5. Hard default: `markdown`.
+- The original list had header above body; flipped so the body field (explicitly chosen by the request author) wins over a header (often auto-populated by a proxy or template). Security gate on `html` mode applies to sources 2 and 3 identically — only authenticated requests from identity-whitelisted callers may select `html`.
+
+**Lint runtime behavior (Grok):**
+- When lint runs: every invocation of `formatForTelegram()` runs `lintTelegramMarkdown()` on the input text and populates `FormatResult.lintIssues`. Issues are informational by default.
+- Non-strict (default): issues are logged at INFO level, included in the `FormatResult`, and optionally surfaced via audit log. Send proceeds.
+- Strict (`telegramLintStrict: true` OR request `lint-strict` flag): any issue returns 422 to HTTP callers or throws `TelegramLintError` to internal callers. Send does not proceed.
+
+**Edge cases (Grok):**
+- Zero-length / whitespace-only input: formatter returns empty string, no-op, no send attempted (adapter returns early before Bot API call).
+- Emoji in URL query params: WHATWG URL parse accepts percent-encoded or IDN-form. Native emoji survives parse. Covered by fixture test.
+- `(raw, formatted)` retry-cache eviction: cache is scoped to a single `apiCall()` invocation; on function return the cache is released. No cross-invocation cache, no concurrency issue.
+
+**MessageStore bloat (Gemini):**
+- Storing `rawText + sentText + modeApplied` on every outbound message approximately doubles MessageStore disk usage. Phase 1 (current scale ~100s/day per agent) is fine. At phase 3 (>5000/day) the JSON file approach starts straining. Out-of-scope for this spec; flagged as a known follow-up: migrate MessageStore to SQLite when message volume exceeds 10K/day sustained. Track under a separate issue.
+
+**Cost / monitoring (Grok, Gemini):**
+- Add Prometheus-style counters on the outbound path:
+  - `telegram_format_duration_ms` histogram per `modeApplied`.
+  - `telegram_format_lint_issues_total` counter by `code` (MD_BOLD, MD_HEADING, MD_TABLE, etc.).
+  - `telegram_format_fallback_total` counter for plain-retry invocations.
+- These feed the existing dashboard; no new monitoring stack required.
+
+**Scalability trigger (Grok):**
+- If `telegram_format_duration_ms.p99` exceeds 10% of total send-path duration at canary flip + 2 weeks, open a follow-up spec for extracting the formatter to a dedicated service. Until then, in-process is correct.
+
+## Semantic alignment with Dawn
+
+- Dawn's default mode is `plain`. Instar's default after this spec is `markdown`. **Intentional divergence** — Dawn's repo uses markdown heavily enough that `plain` is safer; instar agents are more formatting-aware and benefit from default conversion. Divergence is documented here and tracked by a drift-detection test that pins a 50-fixture suite against Dawn's `telegram_format.py` output. Test runs weekly; failure opens an attention-queue item for review.
+- Modes themselves (names, semantics for shared modes) match Dawn exactly for copy-paste safety.
+- `legacy-passthrough` is instar-specific (Dawn was never on legacy Markdown).
+
+## Rollback cost
+
+Low. Config flip `telegramFormatMode = 'legacy-passthrough'` restores exact pre-cutover behavior. No schema migration, no data migration, no code revert. Rollback can be performed in seconds during an incident without restart (config hot-reload).
+
+## PR plan
+
+Two PRs:
+
+1. **PR1: formatter module + tests + legacy-mode passthrough.** Adds `TelegramMarkdownFormatter.ts`, full test suite, `formatTemplate` helper, envelope flag in `GitSyncTransport`, new config fields. No adapter wiring. Default stays `legacy-passthrough`. CI green, no behavior change.
+
+2. **PR2: wire adapter + lifeline + shell script + templates + docs + canary flip.** Wires `apiCall` paths in both `TelegramAdapter` and `TelegramLifeline`. Updates `telegram-reply.sh` template. Migrates existing message builders to `formatTemplate`. Updates docs. Ships with `legacy-passthrough` still the shipped default; flip to `markdown` on Echo's agent as canary.
+
+Estimated scope: ~8 files in PR1, ~10-12 files in PR2.
+
+## Open questions
+
+- `tg://` deep links over-blocked. Acceptable v1; follow-up spec can add them back with a safe-URL check.
+- Should `formatTemplate` produce split chunks atomically (no interleaving), or is that a separate spec? (Recommendation: this spec; the length-splitter change already covers it.)
+
+## Success criteria
+
+1. Agent-authored `**bold**` renders bold; `` `code` `` renders code; `# Heading` renders bold; markdown tables render with alignment preserved via `<pre>`.
+2. Every server send path (route, job, dispatch, attention, lifeline, MCP, edit) gets the same formatting — verified by integration tests against both `TelegramAdapter.apiCall` and `TelegramLifeline.apiCall`.
+3. Rollback to pre-cutover behavior requires one config flip, no code change.
+4. No regression in existing gates, idempotency, or 408-ambiguous handling.
+5. No increase in Bot API 400 errors post-cutover (≤ pre-cutover baseline).
+6. Shell-script `.claude/scripts/telegram-reply.sh --format code "..."` works for operational monospace output on new agents; old agents continue to work unchanged (server default).
+7. `html` mode is refused for untrusted callers (unit + integration test proof).
+8. ReDoS fuzz test p99 < 5ms for 4KB pathological input.

--- a/docs/specs/reports/telegram-markdown-renderer-convergence.md
+++ b/docs/specs/reports/telegram-markdown-renderer-convergence.md
@@ -1,0 +1,159 @@
+# Convergence Report — Telegram markdown renderer (server-side HTML formatter + lint + parse_mode migration)
+
+**Spec**: `docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md`
+**Slug**: `telegram-markdown-renderer`
+**Author**: echo
+**Convergence timestamp**: 2026-04-24T19:28:38Z
+**Iterations**: 6 (4 internal rounds + external cross-model + 2 integration rounds)
+
+## ELI16 Overview
+
+Justin and Dawn improved how Dawn sends messages to Telegram — before, Dawn's messages showed `**bold**` and `| tables |` as literal asterisks and pipes instead of rendering properly. Dawn's fix was a client-side script. This spec brings the same fix to instar, but **on the server** instead of the client so every send path benefits — whether a message comes from a job, a dispatch, an alert, a lifeline ping, or the shell script, it all goes through the same formatter and renders correctly in the Telegram chat.
+
+The way it works: when instar is about to send a Telegram message, it runs the text through a small module that converts GitHub-style markdown (what Claude natively writes) into Telegram's HTML format. Bold becomes bold, tables become aligned monospace blocks, links become actual links, headings become bold text (Telegram doesn't support real headings), and bullets get a `•` character. The module is a pure string transformation — no AI calls, no network, a few milliseconds at most.
+
+Important: we're also switching instar's Telegram parse mode from legacy `Markdown` to `HTML`. That's a bigger change than the formatter itself — it means every Telegram callsite starts sending HTML instead of old-style Markdown. To make rollback safe, the spec adds a `legacy-passthrough` mode that restores exact pre-change byte-for-byte behavior with a single config flip. The formatter ships disabled by default (pre-GA canary on Echo's own agent first), gets eyeballed at 1h/6h/24h, and only then flips as the default across all agents.
+
+## Original vs Converged
+
+**The original spec** (iteration 0) assumed instar sent all Telegram messages as `parse_mode: 'HTML'` and said "every send path goes through one `sendMessage` method, so we intercept there." Both of those premises were wrong. The real state is: instar sends mostly as `parse_mode: 'Markdown'` (legacy Markdown), ONE callsite already uses HTML, and send paths flow through two separate `apiCall()` methods (one in `TelegramAdapter`, one in `TelegramLifeline` — different class, different Bot API client, same token). That alone would have broken the feature on deployment.
+
+**The converged spec** (iteration 6) gets the plumbing right. It identifies both `apiCall()` chokepoints and wires the formatter into both. It adds a `legacy-passthrough` mode that preserves each callsite's original parse_mode byte-for-byte, so rollback actually reverts to the pre-change state (not a worse-than-baseline state). It reorders the pipeline so formatting runs AFTER the LLM rewrite gates, not before — this prevents the gates from corrupting HTML with their own rewrites. It hardens link parsing against `javascript:` URLs, IDN homoglyphs, Wikipedia-style parens in URLs, and attribute-quote injection. It caps input at 32KB to prevent regex DoS. It defines nested-markdown grammar (bold-italic triple-asterisk, no nested links). It distinguishes `conversionSkipped` from `truncated` as separate flags. It adds a `formatTemplate` helper with a sentinel scheme that escapes variable content exactly once (not zero or two times). It adds Prometheus counters. And it specifies a 24-hour canary on Echo's agent with visual verification at t=1h, 6h, 24h (not just "no 400 errors" — which would miss silent render bugs).
+
+The shape of change: the original was a terse 2-page port of Dawn's Python into TypeScript. The converged spec is a full 400-line design doc that survives the mixed-parse-mode reality, the dual send-path reality, the LLM-gate pipeline reality, and the multi-machine relay reality, with cutover and rollback procedures that actually work.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1 | security, scalability, adversarial, integration | 20+ including 1 critical factual error (wrong parse_mode premise) | Major rewrite — correct premise, identify real chokepoints, reorder pipeline, add rollback mode |
+| 2 | security, scalability, adversarial, integration | 14 including envelope trust, placeholder collision, gate HTML corruption, canary silent-failure, per-callsite rollback | Consolidated hardening section covering pipeline invariants, audit enum, fuzz rigor, drift ownership |
+| 3 | GPT 5.4, Gemini 3.1 Pro, Grok 4.1 Fast (external cross-model) | 11 including paren-in-URL regex, plain-retry idempotency collision, editMessageText split policy, formatTemplate double-escape, override precedence | External hardening section: balanced-paren scanner, retry-key suffix, nested grammar, HTML allowlist appendix |
+| 4 | Internal convergence synthesis | 5 spec-internal contradictions between iteration-3 additions and pre-existing text | In-place updates to length-guard flag, precedence list, formatTemplate description, rollback section |
+| 5 | Internal convergence synthesis | 3 (step-number stale refs, NUL vs formatTemplate sentinel collision, frontmatter staleness) | Triple-asterisk as step 6, formatTemplate switched to PUA-B sentinels with substep-1 strip, step references updated |
+| 6 | Internal convergence synthesis | CONVERGED — no material findings | None |
+
+## Full Findings Catalog
+
+### Iteration 1
+
+**Security (7 findings):**
+- Critical: `href` attribute escaping "URL-escaped" too vague → added `escapeHtmlAttribute()` with explicit contract.
+- High: scheme allowlist under-specified → WHATWG URL parse + lowercase+trim, http/https only, `tg:` explicit over-block.
+- High: lint span-stripping parser-confusion bypass → clarified lint-only, converter has its own tokenizer.
+- Medium: ReDoS on italic/bold with adversarial input → 32KB cap, bounded `{1,200}`, safe-regex2 CI, fuzz p99 < 5ms.
+- Medium: `X-Telegram-Format` auth scope unstated → restricted to authed routes; html mode to trusted callers only.
+- Medium: confused deputy via `</pre>` in table cells → invariant: pre contents always escapeHtmlText, never re-injection.
+- Low: lint log leakage → canonical messages, never agent text.
+
+**Scalability (8 findings):**
+- High: no input length cap → 32KB hard cap.
+- High: pipeline pass O(N·k) allocations → single tokenizer pass w/ placeholder tokens.
+- High: length-splitter unbounded walk → single-pass O(N).
+- Medium: unverified "<1ms" claim → replaced with measured threshold + bench.
+- Medium: gate input distribution shift → mitigated by reordering (format runs AFTER gates).
+- Medium: rate-limit interaction with split chunks → queue treats chunk-group as single FIFO.
+- Low: config hot-reload unspecified → now accessor closure, per-send.
+- Low: test migration cost → migration command specified.
+
+**Adversarial (10 findings):**
+- Critical C1: plain-retry double-escape → retries from ORIGINAL raw text.
+- Critical C2: gate pipeline HTML corruption → format runs AFTER rewrite gates.
+- High H1: ambiguous italic (`3*5`) → tightened regex with word-boundary context.
+- High H2: `format:'html'` passthrough bypass → trusted-internal-callers only; shell/remote 422'd.
+- High H3: template composition unsafety → `formatTemplate()` helper with per-variable escaping.
+- Medium M1: semantic drift from Dawn → documented divergence; drift-detection test.
+- Medium M2: idempotency + lint-strict race → key derived from raw text; deterministic formatter.
+- Medium M3: operator debug leak → audit log; 24h self-monitor alert.
+- Medium M4: 422 error body misrender → canonical prose only.
+- Low L1-L3: various nits addressed.
+
+**Integration (CRITICAL factual correction + 11 findings):**
+- **CRITICAL**: parse_mode is actually `'Markdown'` in most places, not `'HTML'` → entire premise rewritten; spec now proposes Markdown→HTML migration alongside the formatter.
+- High: single-funnel wrong → identified dual chokepoint `TelegramAdapter.apiCall()` + `TelegramLifeline.apiCall()`.
+- High: class/file paths wrong → corrected to `src/messaging/TelegramAdapter.ts`, `tests/unit/`, Vitest.
+- High: rollback worse than baseline → `legacy-passthrough` restores pre-cutover exactly.
+- Medium: config plumbing details → Config → server.ts → accessor closure.
+- Medium: multi-machine → envelope flag; formatting send-side only.
+- Medium: shell script is templated → `src/templates/scripts/telegram-reply.sh`; server default handles old agents.
+- Low: idempotency / 408 interaction → raw-text-keyed, deterministic formatter.
+- Low: dashboard surface → store rawText + sentText + modeApplied.
+- Low: docs surface → Self-Knowledge Tree, CLAUDE.md, scaffolding docs updated.
+
+### Iteration 2
+
+**Security (2 new):**
+- Medium: `alreadyFormatted` envelope trust → sending machine always re-formats from raw, ignores flag.
+- Low: audit log `caller` field enum → closed enum, topicId numeric-validated.
+
+**Scalability (3 new):**
+- S1: placeholder token collision → NUL-bracketed sentinels; step 0 strips NUL from input.
+- S2: fuzz determinism → seeded RNG + 30s Vitest timeout cap.
+- S3: envelope flag trust + formatter idempotency → idempotent on own output (test over 1000 fixtures).
+
+**Adversarial (9 new):**
+- C3: gate-output HTML-like tokens → gates declare raw-markdown contract; fixture test.
+- C4: 422 lint-strict leakage → canonical messages + (line, col); no excerpts.
+- H4: `legacy-markdown` imprecise rollback → renamed `legacy-passthrough`, preserves per-callsite parse_mode.
+- H5: canary silent failure → 24h canary requires both API-error-flat AND eyeball-pass at 1h/6h/24h.
+- M5: envelope version gate → reserved field; future flip requires min-version + separate spec.
+- M6: chunk-retry semantics → paraphrase = fresh send; chunk-retry only for byte-equal raw.
+- M7: drift-detection owner → Echo triages; escalate to Justin if behavioral.
+- L4: italic between emoji → documented accepted trade-off.
+- L5: formatTemplate + `<` round-trip → fixture pinned.
+
+**Integration (6 new):**
+- INT-1: MessageStore is JSON → no schema migration, additive fields.
+- INT-2: non-uniform parse_mode today → `legacy-passthrough` preserves per-callsite.
+- INT-3: two server.ts instantiation sites → both wire identical accessor.
+- INT-5: closure needs mutable holder → `getFormatMode: () => FormatMode` pattern.
+- INT-6: pre-push full suite → `INSTAR_PRE_PUSH_FULL=1`.
+- PR scope revision: ~12 / ~14-16 files.
+
+### Iteration 3 (external cross-model)
+
+**Gemini 3.1 Pro (3 critical):**
+- Paren-in-URL regex fails on Wikipedia-style URLs → balanced-paren scanner with 2048-char cap and literal fallback.
+- Plain-retry idempotency collision → `${key}:fallback-plain` suffix.
+- Plain-retry length-splitter re-entry → raw text re-enters splitter; chunks get `:fallback-plain:part:N/total`.
+
+**GPT 5.4 (7 findings):**
+- Rollback inconsistency (`parse_mode: 'Markdown'` global vs per-callsite) → canonical statement added.
+- Nested markdown grammar undefined → explicit grammar; code highest priority; triple-asterisk = bold-italic before bold before italic.
+- `editMessageText` split policy → cannot chunk edits; `TELEGRAM_EDIT_TOO_LONG` error.
+- 32KB guard vs 4096 flag ambiguity → two distinct flags (`conversionSkipped` vs `truncated`).
+- `formatTemplate` double-escape risk → sentinel-based single-escape.
+- Telegram HTML allowlist appendix → full allowlist with Bot API citation.
+- Override precedence → explicit arg > body field > header > config > default.
+
+**Grok 4.1 Fast (approve; 5 gaps):**
+- Lint runtime semantics → informational by default; strict returns 422.
+- Edge cases (zero-length, emoji URLs, retry-cache eviction) → each specified.
+- Prometheus counters → three added (duration, lint_issues, fallback).
+- Scalability trigger → p99 > 10% at canary+2w opens formatter-to-service spec.
+- MessageStore bloat → out-of-scope follow-up at 10K/day sustained.
+
+### Iterations 4, 5, 6 (internal consistency)
+
+**Iteration 4 (5 findings):**
+- Line 89 `truncated` stale → `conversionSkipped`.
+- Line 209 precedence order stale → updated.
+- Line 230 formatTemplate pre-escape stale → sentinel approach.
+- Line 251 rollback `parse_mode: 'Markdown'` stale → per-callsite.
+- Step 10 link regex → balanced-paren scanner numbered.
+
+**Iteration 5 (3 findings):**
+- Step 7/8 reference staleness after triple-asterisk insertion → updated.
+- NUL-sentinel collision with formatTemplate → switched to Supplementary-PUA-B sentinels with substep-1 scrub.
+- Frontmatter `review-iterations` stale → 5 then 6.
+
+**Iteration 6 (convergence):**
+- No material findings. Spec is internally consistent and addresses every prior round.
+
+## Convergence Verdict
+
+**Converged at iteration 6.** Four internal review rounds and one external cross-model round produced findings; each was addressed without introducing new material issues at the next round. The iteration-6 verification round returned zero material findings. Spec is ready for user review and approval.
+
+The `approved: true` frontmatter tag is NOT set by this skill. Justin must read this report and either set the tag himself or ask Echo to set it after he confirms — the approval is the structural human contribution to the process.
+
+Once `approved: true` is set, `/instar-dev` is unblocked on this spec and implementation can proceed per the two-PR plan (formatter module + tests + legacy-passthrough first; adapter + lifeline + shell template + canary flip second).

--- a/docs/specs/side-effects/telegram-markdown-renderer-pr2.md
+++ b/docs/specs/side-effects/telegram-markdown-renderer-pr2.md
@@ -1,0 +1,112 @@
+---
+spec: telegram-markdown-renderer
+pr: 2
+status: shipped-disabled
+default-behavior-change: none
+rollback: config flip (`telegramFormatMode = 'legacy-passthrough'`)
+---
+
+# Side-effects review — Telegram markdown renderer (PR2: wire-up)
+
+## Summary
+
+PR2 wires the PR1 formatter into the two Bot API chokepoints
+(`TelegramAdapter.apiCall`, `TelegramLifeline.apiCall`) behind a config
+flag. The shipped default is `'legacy-passthrough'` — byte-for-byte identical
+to pre-PR2 behavior. No agent sees a behavioral change from this merge.
+
+## Changes enumerated
+
+### Source changes
+
+| File | Change | Blast radius | Rollback cost |
+|------|--------|--------------|---------------|
+| `src/core/types.ts` | Add `telegramFormatMode` + `telegramLintStrict` to `InstarConfig`. Optional; absence = legacy behavior. | None until set. | Zero — fields ignored when unset. |
+| `src/messaging/TelegramAdapter.ts` | Add `getFormatMode` / `getLintStrict` accessors to `TelegramConfig`. Insert `applyTelegramFormatter()` call at top of `apiCall()`. Add 400 plain-retry path that suffixes idempotency key with `:fallback-plain`. Export `applyTelegramFormatter` for reuse by Lifeline + tests. | Every outbound Bot API call goes through the helper. In `legacy-passthrough` (default), the helper is a byte-for-byte pass-through — only the internal `_isPlainRetry` / `_idempotencyKey` keys are stripped before send, and neither was ever accepted by Bot API. | Config flip to `'legacy-passthrough'` (already default). |
+| `src/lifeline/TelegramLifeline.ts` | Mirror the same `applyTelegramFormatter()` wire-up on the Lifeline's independent Bot API client. Reads `projectConfig.telegramFormatMode` on each call (hot-reloadable). | Independent Bot API client (lifeline pings, server-down notifications). Same default: passthrough. | Config flip. |
+| `src/commands/server.ts` | Pass `getFormatMode` / `getLintStrict` closures into both `TelegramAdapter` constructor sites. Closures read live config on each call (hot-reloadable). | None behavioral — closures are only consulted inside the chokepoint we just added. | N/A. |
+| `src/messaging/types.ts` | Add optional `alreadyFormatted?: boolean` to `TransportMetadata`. Observability-only; **receiver ignores it** (send-side authoritative). | None. Flag is unread by the sending path. | N/A. |
+| `src/messaging/telegramFormatMetrics.ts` | New file. In-process counters (`format_applied_total`, `format_lint_issues_total`, `format_fallback_plain_retry_total`). No scrape endpoint yet — used for test assertions and future dashboard. | None. | Delete file. |
+| `src/templates/scripts/telegram-reply.sh` | Add `--format <mode>` flag; forwards as `{"format": ...}` in POST body. No flag = server default. | Only affects newly scaffolded agents; existing agents keep their old script (server default handles missing field). | Revert template. |
+
+### Docs / spec changes
+
+| File | Change |
+|------|--------|
+| `docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md` | Copied in from approved spec worktree. |
+| `docs/specs/reports/telegram-markdown-renderer-convergence.md` | Copied in from convergence worktree. |
+| `docs/specs/side-effects/telegram-markdown-renderer-pr2.md` | This file. |
+
+### Test changes
+
+| File | Change |
+|------|--------|
+| `tests/unit/telegram-format-wireup.test.ts` | New. Verifies: legacy-passthrough byte-for-byte; markdown mode converts + sets HTML parse_mode; editMessageText formats; plain/code modes; `_isPlainRetry` recursion guard; 400 plain-retry replays raw text with key suffix; hot-reload of mode. |
+
+## Signal vs authority review
+
+- `getFormatMode` is a **signal** reader — it reads what config says, nothing more.
+- Actual authority (blocking / rejecting) lives in the existing 400-retry path
+  on Bot API. If Telegram rejects the HTML, we fall back to raw text with the
+  historical `parse_mode: undefined` behavior. No new blocking gate introduced.
+
+## Level-of-abstraction fit
+
+- Wire-up lives inside `apiCall()`, the lowest common chokepoint per the spec's
+  "Pipeline ordering" section. This places formatting AFTER all rewrite gates
+  (they run upstream in `send()`/`sendToTopic()`/dispatch paths that call
+  `apiCall`) and BEFORE the Bot API HTTP call. Correct per spec.
+
+## Interactions
+
+- **Existing 400-retry in `send()`**: PR2 adds a second 400-retry layer inside
+  `apiCall`. Order: apiCall-level plain-retry fires first (raw text, parse_mode
+  stripped); if that also 400s, the `send()`-level retry path catches it. Tests
+  confirm no infinite recursion via `_isPlainRetry` flag.
+- **Rate-limit queue (429 handling)**: Unchanged. Formatting happens before
+  fetch; 429 retries re-enter `apiCall` with the already-formatted params
+  (via `_isPlainRetry` or the existing 429 recursion) and we set
+  `_isPlainRetry = false` unchanged — correct, because a 429 is not a format
+  error.
+- **Idempotency keys**: PR2 introduces `_idempotencyKey` as an internal-only
+  flag that the helper strips before the Bot API send. No existing callsite
+  uses that name, verified by grep.
+
+## Rollback cost
+
+**O(1) config flip**: set `telegramFormatMode = 'legacy-passthrough'` in
+`.instar/config.json` (or delete the field — same effect). Adapter/lifeline
+read on every send, so the next outbound message uses the new mode without
+restart.
+
+If a deeper rollback is needed: revert this PR. No schema migration, no data
+migration, no state cleanup.
+
+## What is deliberately out of scope for PR2
+
+- **Length-splitting module**: the spec's tag-aware splitter is a distinct
+  component. The current codebase has no separate splitter; adding one is a
+  PR3-scale change. PR2's 400 plain-retry covers the highest-value failure
+  mode (entity parse errors) and mirrors the existing retry-without-parse_mode
+  behavior the codebase already has.
+- **`formatTemplate` helper + migrations**: spec's template-composition helper
+  and the build-time lint that enforces it are deferred to PR3.
+- **Audit-log caller enum**: we record metrics; structured audit events with
+  the closed caller enum are PR3.
+- **Prometheus scrape endpoint**: counters exist in-process; no HTTP endpoint
+  wired yet. The existing metrics/dashboard work can pick these up with a
+  one-line registration.
+- **`/telegram/reply` body `format` field parsing**: the shell script sends it;
+  the route does not consume it yet (deferred — shell-script is forward-
+  compatible, no breaking change). This means `--format` from the CLI is a
+  no-op against current main, but becomes live in PR3 without re-deploying the
+  template.
+
+## Canary plan
+
+1. Merge PR2 with shipped default `'legacy-passthrough'`. No behavior change.
+2. Post-merge, flip Echo's agent config: `telegramFormatMode: 'markdown'`.
+3. Monitor Bot API 4xx rate + eyeball `scripts/verify-telegram-render.ts`
+   fixtures at t=1h, t=6h, t=24h.
+4. After 24h clean → expand to second agent.
+5. After 72h clean across canary agents → flip shipped default.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2390,7 +2390,19 @@ export async function startServer(options: StartOptions): Promise<void> {
     const isStandbyTelegram = !coordinator.isAwake && telegramConfig;
     if ((skipTelegram || isStandbyTelegram) && telegramConfig) {
       // Send-only mode: no polling, but sendToTopic() works for session replies
-      telegram = new TelegramAdapter(telegramConfig.config as any, config.stateDir);
+      telegram = new TelegramAdapter(
+        {
+          ...(telegramConfig.config as any),
+          // PR2: hot-reloadable accessors. Sending-side authoritative —
+          // each send re-reads config so a canary flip lands without restart.
+          getFormatMode: () =>
+            (config as unknown as { telegramFormatMode?: 'plain' | 'html' | 'code' | 'markdown' | 'legacy-passthrough' })
+              .telegramFormatMode,
+          getLintStrict: () =>
+            (config as unknown as { telegramLintStrict?: boolean }).telegramLintStrict,
+        },
+        config.stateDir,
+      );
       console.log(pc.green(`  Telegram send-only mode (${isStandbyTelegram ? 'standby' : 'lifeline owns polling'})`));
 
       // Resolve any topic names still using the fallback "topic-NNNN" pattern
@@ -2445,7 +2457,19 @@ export async function startServer(options: StartOptions): Promise<void> {
     }
 
     if (telegramConfig && !skipTelegram && !isStandbyTelegram) {
-      telegram = new TelegramAdapter(telegramConfig.config as any, config.stateDir);
+      telegram = new TelegramAdapter(
+        {
+          ...(telegramConfig.config as any),
+          // PR2: hot-reloadable accessors. Sending-side authoritative —
+          // each send re-reads config so a canary flip lands without restart.
+          getFormatMode: () =>
+            (config as unknown as { telegramFormatMode?: 'plain' | 'html' | 'code' | 'markdown' | 'legacy-passthrough' })
+              .telegramFormatMode,
+          getLintStrict: () =>
+            (config as unknown as { telegramLintStrict?: boolean }).telegramLintStrict,
+        },
+        config.stateDir,
+      );
       telegram.intelligence = sharedIntelligence ?? null;
       await telegram.start();
       console.log(pc.green(`  Telegram connected (stall alerts: ${sharedIntelligence ? 'LLM-gated' : 'timer-only'})`));

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1485,6 +1485,16 @@ export interface InstarConfig {
   /** Dashboard configuration */
   dashboard?: DashboardConfig;
   /**
+   * Telegram markdown formatter mode. Default `'legacy-passthrough'` —
+   * byte-for-byte identical to pre-PR2 behavior (formatter bypassed; callsite
+   * parse_mode preserved). Flip to `'markdown'` / `'plain'` / `'code'` / `'html'`
+   * to enable formatting. See docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md.
+   * Hot-reloadable: the adapter/lifeline read the config on every send.
+   */
+  telegramFormatMode?: 'plain' | 'html' | 'code' | 'markdown' | 'legacy-passthrough';
+  /** When true, lint issues return 422 / throw instead of just being logged. */
+  telegramLintStrict?: boolean;
+  /**
    * Free-text description of how outbound agent-to-user messages should be
    * written for this agent's user. Consumed by the MessagingToneGate's style
    * rule (B11_STYLE_MISMATCH). Generic by design — every agent's operator sets

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -58,6 +58,9 @@ import {
   type RestartBucket,
 } from './rateLimitState.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { applyTelegramFormatter } from '../messaging/TelegramAdapter.js';
+import type { FormatMode } from '../messaging/TelegramMarkdownFormatter.js';
+import { recordFormatFallbackPlainRetry } from '../messaging/telegramFormatMetrics.js';
 
 /**
  * Acquire an exclusive lock file to prevent multiple lifeline instances.
@@ -2190,7 +2193,23 @@ export class TelegramLifeline {
     return (result as TelegramUpdate[]) ?? [];
   }
 
+  /**
+   * Resolve the current format mode from the loaded project config. Read on
+   * each call so hot-reload works without restart.
+   * Multi-machine: this machine is the SENDER, so its own config is authoritative
+   * (per spec "Multi-machine send-side-only"). We ignore any upstream envelope
+   * `alreadyFormatted` flag.
+   */
+  private currentFormatMode(): FormatMode | undefined {
+    const mode = (this.projectConfig as unknown as { telegramFormatMode?: FormatMode })
+      .telegramFormatMode;
+    return mode;
+  }
+
   private async apiCall(method: string, params: Record<string, unknown>, retryCount = 0): Promise<unknown> {
+    // PR2: format sendMessage / editMessageText via the shared helper used by
+    // TelegramAdapter. Legacy-passthrough (default) preserves caller parse_mode.
+    const sendParams = applyTelegramFormatter(method, params, this.currentFormatMode());
     const url = `https://api.telegram.org/bot${this.config.token}/${method}`;
     const timeoutMs = method === 'getUpdates' ? 60_000 : 15_000;
     const controller = new AbortController();
@@ -2201,7 +2220,7 @@ export class TelegramLifeline {
       response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(params),
+        body: JSON.stringify(sendParams.outgoingParams),
         signal: controller.signal,
       });
     } finally {
@@ -2226,6 +2245,21 @@ export class TelegramLifeline {
         }
       }
       const text = await response.text();
+      if (
+        response.status === 400 &&
+        method === 'sendMessage' &&
+        sendParams.didFormat &&
+        !sendParams.isPlainRetry
+      ) {
+        recordFormatFallbackPlainRetry();
+        const retryParams: Record<string, unknown> = { ...sendParams.originalParams };
+        delete retryParams.parse_mode;
+        (retryParams as { _isPlainRetry?: boolean })._isPlainRetry = true;
+        if (typeof retryParams._idempotencyKey === 'string') {
+          retryParams._idempotencyKey = `${retryParams._idempotencyKey}:fallback-plain`;
+        }
+        return this.apiCall(method, retryParams, retryCount);
+      }
       throw new Error(`Telegram API error (${response.status}): ${text}`);
     }
 

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -26,6 +26,12 @@ import { MessagingEventBus } from './shared/MessagingEventBus.js';
 import { CallbackRegistry, isAllowedButtonKey } from '../core/CallbackRegistry.js';
 import type { DetectedPrompt } from '../monitoring/PromptGate.js';
 import { sanitizeForPrompt } from '../monitoring/SessionRecovery.js';
+import { formatForTelegram, type FormatMode } from './TelegramMarkdownFormatter.js';
+import {
+  recordFormatApplied,
+  recordFormatLintIssue,
+  recordFormatFallbackPlainRetry,
+} from './telegramFormatMetrics.js';
 
 export interface TelegramConfig {
   /** Bot token from @BotFather */
@@ -57,6 +63,15 @@ export interface TelegramConfig {
     /** Timeout in seconds for relay responses (default: 300 = 5 min) */
     relayTimeoutSeconds?: number;
   };
+  /**
+   * Hot-reloadable accessor for the Telegram format mode. Returning a falsy
+   * value or `'legacy-passthrough'` preserves pre-PR2 behavior (byte-for-byte
+   * passthrough, caller-supplied parse_mode honored). See
+   * docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md.
+   */
+  getFormatMode?: () => FormatMode | undefined;
+  /** Hot-reloadable accessor for lint-strict mode. */
+  getLintStrict?: () => boolean | undefined;
 }
 
 /** Tracks a pending text reply for a Prompt Gate relay (no-button prompts) */
@@ -3993,6 +4008,14 @@ export class TelegramAdapter implements MessagingAdapter {
   }
 
   private async apiCall(method: string, params: Record<string, unknown>, retryCount: number = 0): Promise<unknown> {
+    // PR2: run the formatter on sendMessage / editMessageText when a non-legacy
+    // mode is configured. Legacy-passthrough (default) preserves the caller's
+    // parse_mode byte-for-byte. See docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md.
+    const sendParams = applyTelegramFormatter(
+      method,
+      params,
+      this.config.getFormatMode?.(),
+    );
     const url = `https://api.telegram.org/bot${this.config.token}/${method}`;
     const safeUrl = `https://api.telegram.org/bot[REDACTED]/${method}`;
 
@@ -4006,7 +4029,7 @@ export class TelegramAdapter implements MessagingAdapter {
       response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(params),
+        body: JSON.stringify(sendParams.outgoingParams),
         signal: controller.signal,
       });
     } finally {
@@ -4031,6 +4054,29 @@ export class TelegramAdapter implements MessagingAdapter {
         }
       }
       const text = await response.text();
+      // Plain-retry fallback on 400 for formatted sends. See spec
+      // "Plain-retry fallback". Only applies to sendMessage — editMessageText
+      // cannot be split/retried identically (TELEGRAM_EDIT_TOO_LONG).
+      if (
+        response.status === 400 &&
+        method === 'sendMessage' &&
+        sendParams.didFormat &&
+        !sendParams.isPlainRetry
+      ) {
+        recordFormatFallbackPlainRetry();
+        const retryParams: Record<string, unknown> = {
+          ...sendParams.originalParams,
+          parse_mode: undefined,
+        };
+        // Suffix idempotency key so downstream dedup treats this as fresh.
+        if (typeof retryParams._idempotencyKey === 'string') {
+          retryParams._idempotencyKey = `${retryParams._idempotencyKey}:fallback-plain`;
+        }
+        // Mark so we don't recurse.
+        (retryParams as { _isPlainRetry?: boolean })._isPlainRetry = true;
+        delete retryParams.parse_mode;
+        return this.apiCall(method, retryParams, retryCount);
+      }
       throw new Error(`Telegram API error ${safeUrl} (${response.status}): ${text}`);
     }
 
@@ -4041,4 +4087,69 @@ export class TelegramAdapter implements MessagingAdapter {
 
     return data.result;
   }
+}
+
+/**
+ * Shared formatter wire-up used by both TelegramAdapter.apiCall and
+ * TelegramLifeline.apiCall. Pure function for testability.
+ *
+ * For non-send methods, or when mode is undefined / `'legacy-passthrough'`,
+ * returns params unchanged. For `sendMessage` / `editMessageText` in a
+ * formatting mode, runs the formatter on `params.text` and overrides
+ * `params.parse_mode` with the formatter's output.
+ *
+ * Callers may opt out per-call by passing `params._isPlainRetry = true`
+ * (internal flag for the 400 retry path).
+ */
+export function applyTelegramFormatter(
+  method: string,
+  params: Record<string, unknown>,
+  configMode: FormatMode | undefined,
+): {
+  outgoingParams: Record<string, unknown>;
+  originalParams: Record<string, unknown>;
+  didFormat: boolean;
+  isPlainRetry: boolean;
+} {
+  const isPlainRetry = (params as { _isPlainRetry?: boolean })._isPlainRetry === true;
+  // Strip internal flags before sending to Bot API.
+  const stripped: Record<string, unknown> = { ...params };
+  delete (stripped as { _isPlainRetry?: boolean })._isPlainRetry;
+  delete (stripped as { _idempotencyKey?: unknown })._idempotencyKey;
+
+  const isSendMethod = method === 'sendMessage' || method === 'editMessageText';
+  const mode: FormatMode = configMode ?? 'legacy-passthrough';
+
+  if (
+    !isSendMethod ||
+    mode === 'legacy-passthrough' ||
+    isPlainRetry ||
+    typeof stripped.text !== 'string'
+  ) {
+    return {
+      outgoingParams: stripped,
+      originalParams: params,
+      didFormat: false,
+      isPlainRetry,
+    };
+  }
+
+  const result = formatForTelegram(stripped.text as string, mode);
+  recordFormatApplied(result.modeApplied);
+  for (const issue of result.lintIssues) {
+    recordFormatLintIssue(issue);
+  }
+  const outgoing: Record<string, unknown> = { ...stripped, text: result.text };
+  if (result.parseMode !== undefined) {
+    outgoing.parse_mode = result.parseMode;
+  } else {
+    // legacy-passthrough returns parseMode undefined; fall back to caller's
+    // explicit parse_mode if any (preserved above via ...stripped).
+  }
+  return {
+    outgoingParams: outgoing,
+    originalParams: params,
+    didFormat: true,
+    isPlainRetry: false,
+  };
 }

--- a/src/messaging/telegramFormatMetrics.ts
+++ b/src/messaging/telegramFormatMetrics.ts
@@ -1,0 +1,55 @@
+/**
+ * Lightweight in-process counters for the Telegram formatter pipeline.
+ *
+ * Prometheus-style labels are modeled as nested maps. There is no scrape
+ * endpoint yet — consumers call `getFormatMetricsSnapshot()` for test
+ * assertions and dashboard/debug exposure. When a real metrics registry
+ * lands, swap these functions to adapters without touching callers.
+ *
+ * Spec: docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md ("Cost / monitoring").
+ */
+
+interface FormatMetricsState {
+  formatAppliedTotal: Map<string, number>; // key = mode
+  formatLintIssuesTotal: Map<string, number>; // key = issue code/message
+  formatFallbackPlainRetryTotal: number;
+}
+
+const state: FormatMetricsState = {
+  formatAppliedTotal: new Map(),
+  formatLintIssuesTotal: new Map(),
+  formatFallbackPlainRetryTotal: 0,
+};
+
+export function recordFormatApplied(mode: string): void {
+  state.formatAppliedTotal.set(mode, (state.formatAppliedTotal.get(mode) ?? 0) + 1);
+}
+
+export function recordFormatLintIssue(issue: string): void {
+  state.formatLintIssuesTotal.set(issue, (state.formatLintIssuesTotal.get(issue) ?? 0) + 1);
+}
+
+export function recordFormatFallbackPlainRetry(): void {
+  state.formatFallbackPlainRetryTotal += 1;
+}
+
+export interface FormatMetricsSnapshot {
+  formatAppliedTotal: Record<string, number>;
+  formatLintIssuesTotal: Record<string, number>;
+  formatFallbackPlainRetryTotal: number;
+}
+
+export function getFormatMetricsSnapshot(): FormatMetricsSnapshot {
+  return {
+    formatAppliedTotal: Object.fromEntries(state.formatAppliedTotal),
+    formatLintIssuesTotal: Object.fromEntries(state.formatLintIssuesTotal),
+    formatFallbackPlainRetryTotal: state.formatFallbackPlainRetryTotal,
+  };
+}
+
+/** Testing-only: reset all counters. */
+export function resetFormatMetrics(): void {
+  state.formatAppliedTotal.clear();
+  state.formatLintIssuesTotal.clear();
+  state.formatFallbackPlainRetryTotal = 0;
+}

--- a/src/messaging/types.ts
+++ b/src/messaging/types.ts
@@ -204,6 +204,13 @@ export interface TransportMetadata {
   nonce: string;
   /** ISO timestamp — validated per transport type (see Clock Skew Tolerance) */
   timestamp: string;
+  /**
+   * Observability-only flag indicating the sender believed the message body
+   * was already rendered to Telegram HTML. **The receiving (sending-to-Telegram)
+   * machine IGNORES this flag** and re-runs its own formatter with its own
+   * local config. Spec: "Multi-machine send-side-only".
+   */
+  alreadyFormatted?: boolean;
 }
 
 /**

--- a/src/templates/scripts/telegram-reply.sh
+++ b/src/templates/scripts/telegram-reply.sh
@@ -3,18 +3,52 @@
 #
 # Usage:
 #   ./telegram-reply.sh TOPIC_ID "message text"
+#   ./telegram-reply.sh --format markdown TOPIC_ID "**bold**"
 #   echo "message text" | ./telegram-reply.sh TOPIC_ID
 #   cat <<'EOF' | ./telegram-reply.sh TOPIC_ID
 #   Multi-line message here
 #   EOF
 #
+# Flags:
+#   --format <mode>   Override server-side format mode for this send.
+#                     Valid: plain, code, markdown, legacy-passthrough
+#                     ('html' is reserved for trusted internal callers.)
+#                     When absent, the server's configured default applies.
+#
 # Reads INSTAR_PORT from environment (default: 4040).
+
+FORMAT=""
+
+# Parse leading flags before positional args.
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --format)
+      FORMAT="$2"
+      shift 2
+      ;;
+    --format=*)
+      FORMAT="${1#--format=}"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Unknown flag: $1" >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 TOPIC_ID="$1"
 shift
 
 if [ -z "$TOPIC_ID" ]; then
-  echo "Usage: telegram-reply.sh TOPIC_ID [message]" >&2
+  echo "Usage: telegram-reply.sh [--format MODE] TOPIC_ID [message]" >&2
   exit 1
 fi
 
@@ -38,22 +72,32 @@ if [ -f ".instar/config.json" ]; then
   AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
 fi
 
-# Escape for JSON
-JSON_MSG=$(printf '%s' "$MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))' 2>/dev/null)
-if [ -z "$JSON_MSG" ]; then
-  # Fallback if python3 not available: basic escape
-  JSON_MSG="\"$(printf '%s' "$MSG" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g')\""
+# Build JSON body (text + optional format).
+JSON_BODY=$(python3 -c '
+import sys, json
+msg = sys.argv[1]
+fmt = sys.argv[2]
+body = {"text": msg}
+if fmt:
+    body["format"] = fmt
+print(json.dumps(body))
+' "$MSG" "$FORMAT" 2>/dev/null)
+
+if [ -z "$JSON_BODY" ]; then
+  # Fallback if python3 not available: basic escape, no format override.
+  ESCAPED=$(printf '%s' "$MSG" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g')
+  JSON_BODY="{\"text\":\"${ESCAPED}\"}"
 fi
 
 if [ -n "$AUTH_TOKEN" ]; then
   RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "http://localhost:${PORT}/telegram/reply/${TOPIC_ID}" \
     -H 'Content-Type: application/json' \
     -H "Authorization: Bearer ${AUTH_TOKEN}" \
-    -d "{\"text\":${JSON_MSG}}")
+    -d "$JSON_BODY")
 else
   RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "http://localhost:${PORT}/telegram/reply/${TOPIC_ID}" \
     -H 'Content-Type: application/json' \
-    -d "{\"text\":${JSON_MSG}}")
+    -d "$JSON_BODY")
 fi
 
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)

--- a/tests/unit/telegram-format-wireup.test.ts
+++ b/tests/unit/telegram-format-wireup.test.ts
@@ -1,0 +1,224 @@
+/**
+ * PR2 wire-up tests — verify the formatter runs inside both Bot API chokepoints
+ * (TelegramAdapter.apiCall, TelegramLifeline.apiCall) exactly where the spec
+ * says, and that `'legacy-passthrough'` preserves byte-for-byte behavior.
+ *
+ * Spec: docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter, applyTelegramFormatter } from '../../src/messaging/TelegramAdapter.js';
+import { resetFormatMetrics, getFormatMetricsSnapshot } from '../../src/messaging/telegramFormatMetrics.js';
+
+describe('applyTelegramFormatter (pure wire-up helper)', () => {
+  beforeEach(() => resetFormatMetrics());
+
+  it('bypasses formatter for non-send methods', () => {
+    const r = applyTelegramFormatter('getUpdates', { offset: 1 }, 'markdown');
+    expect(r.didFormat).toBe(false);
+    expect(r.outgoingParams).toEqual({ offset: 1 });
+  });
+
+  it('bypasses formatter in legacy-passthrough mode (byte-for-byte)', () => {
+    const params = { text: '**bold**', chat_id: '1', parse_mode: 'Markdown' };
+    const r = applyTelegramFormatter('sendMessage', params, 'legacy-passthrough');
+    expect(r.didFormat).toBe(false);
+    expect(r.outgoingParams.text).toBe('**bold**');
+    expect(r.outgoingParams.parse_mode).toBe('Markdown');
+  });
+
+  it('bypasses formatter when mode is undefined (config not set)', () => {
+    const params = { text: '**bold**', chat_id: '1', parse_mode: 'Markdown' };
+    const r = applyTelegramFormatter('sendMessage', params, undefined);
+    expect(r.didFormat).toBe(false);
+    expect(r.outgoingParams.text).toBe('**bold**');
+    expect(r.outgoingParams.parse_mode).toBe('Markdown');
+  });
+
+  it('runs formatter for sendMessage in markdown mode and overrides parse_mode', () => {
+    const params = { text: '**bold**', chat_id: '1', parse_mode: 'Markdown' };
+    const r = applyTelegramFormatter('sendMessage', params, 'markdown');
+    expect(r.didFormat).toBe(true);
+    expect(r.outgoingParams.text).toBe('<b>bold</b>');
+    expect(r.outgoingParams.parse_mode).toBe('HTML');
+    const snap = getFormatMetricsSnapshot();
+    expect(snap.formatAppliedTotal.markdown).toBe(1);
+  });
+
+  it('runs formatter for editMessageText too', () => {
+    const r = applyTelegramFormatter('editMessageText',
+      { text: '**x**', chat_id: '1', message_id: 9 },
+      'markdown');
+    expect(r.didFormat).toBe(true);
+    expect(r.outgoingParams.text).toBe('<b>x</b>');
+  });
+
+  it('honors plain mode', () => {
+    const r = applyTelegramFormatter('sendMessage', { text: '**x**' }, 'plain');
+    expect(r.outgoingParams.parse_mode).toBe('HTML');
+    // plain strips markdown tokens but HTML-escapes the result
+    expect(r.outgoingParams.text).not.toContain('**');
+  });
+
+  it('honors code mode — wraps in <pre>', () => {
+    const r = applyTelegramFormatter('sendMessage', { text: 'x' }, 'code');
+    expect(r.outgoingParams.text).toBe('<pre>x</pre>');
+    expect(r.outgoingParams.parse_mode).toBe('HTML');
+  });
+
+  it('does NOT re-format when _isPlainRetry flag is set (recursion guard)', () => {
+    const params = { text: '**x**', _isPlainRetry: true };
+    const r = applyTelegramFormatter('sendMessage', params, 'markdown');
+    expect(r.didFormat).toBe(false);
+    expect(r.isPlainRetry).toBe(true);
+    expect(r.outgoingParams.text).toBe('**x**');
+    // _isPlainRetry should be stripped before going to Bot API
+    expect((r.outgoingParams as Record<string, unknown>)._isPlainRetry).toBeUndefined();
+  });
+
+  it('strips internal _idempotencyKey flag from outgoing params', () => {
+    const r = applyTelegramFormatter('sendMessage',
+      { text: 'x', _idempotencyKey: 'key1' } as Record<string, unknown>,
+      'legacy-passthrough');
+    expect((r.outgoingParams as Record<string, unknown>)._idempotencyKey).toBeUndefined();
+  });
+
+  it('records lint issue counters when formatter reports them', () => {
+    applyTelegramFormatter('sendMessage', { text: '**bold**' }, 'markdown');
+    const snap = getFormatMetricsSnapshot();
+    // The formatter's lintTelegramMarkdown emits canonical prose for bold.
+    const keys = Object.keys(snap.formatLintIssuesTotal);
+    expect(keys.some(k => k.includes('bold'))).toBe(true);
+  });
+});
+
+describe('TelegramAdapter — formatter wire-up in apiCall', () => {
+  let adapter: TelegramAdapter;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-fmt-wire-'));
+    resetFormatMetrics();
+  });
+
+  afterEach(async () => {
+    if (adapter) await adapter.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  it('legacy-passthrough (default): preserves per-callsite parse_mode byte-for-byte', async () => {
+    adapter = new TelegramAdapter(
+      { token: 't', chatId: '-1001', getFormatMode: () => 'legacy-passthrough' },
+      tmpDir,
+    );
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, result: { message_id: 1 } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await adapter.send({
+      userId: 'u',
+      content: '**bold** still literal',
+      channel: { type: 'telegram', identifier: '42' },
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.text).toBe('**bold** still literal');
+    expect(body.parse_mode).toBe('Markdown'); // from the Markdown callsite in send()
+  });
+
+  it('markdown mode: converts **bold** to <b>bold</b> and sets parse_mode=HTML', async () => {
+    adapter = new TelegramAdapter(
+      { token: 't', chatId: '-1001', getFormatMode: () => 'markdown' },
+      tmpDir,
+    );
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, result: { message_id: 2 } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await adapter.send({
+      userId: 'u',
+      content: '**bold**',
+      channel: { type: 'telegram', identifier: '42' },
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.text).toBe('<b>bold</b>');
+    expect(body.parse_mode).toBe('HTML');
+  });
+
+  it('400 response triggers plain-retry with raw text and increments fallback counter', async () => {
+    adapter = new TelegramAdapter(
+      { token: 't', chatId: '-1001', getFormatMode: () => 'markdown' },
+      tmpDir,
+    );
+    // First call returns 400, second call (retry) returns 200.
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => '{"ok":false,"description":"can\'t parse entities"}',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, result: { message_id: 3 } }),
+      });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // send() catches 400 and retries WITHOUT parse_mode; that's the existing
+    // adapter-level retry. The apiCall-level plain-retry fires first (formatter
+    // fallback) before the send()-level retry. Either way, mockFetch is called
+    // at least twice and the retry body uses the RAW text, not re-formatted.
+    await adapter.send({
+      userId: 'u',
+      content: '**bold**',
+      channel: { type: 'telegram', identifier: '42' },
+    });
+
+    expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+    const firstBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    const retryBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(firstBody.text).toBe('<b>bold</b>');
+    expect(firstBody.parse_mode).toBe('HTML');
+    // Retry uses the raw (pre-format) text and drops parse_mode.
+    expect(retryBody.text).toBe('**bold**');
+    expect(retryBody.parse_mode).toBeUndefined();
+    expect(getFormatMetricsSnapshot().formatFallbackPlainRetryTotal).toBeGreaterThanOrEqual(1);
+  });
+
+  it('hot-reloads: changing the accessor return value flips behavior without restart', async () => {
+    let mode: 'legacy-passthrough' | 'markdown' = 'legacy-passthrough';
+    adapter = new TelegramAdapter(
+      { token: 't', chatId: '-1001', getFormatMode: () => mode },
+      tmpDir,
+    );
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, result: { message_id: 10 } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await adapter.send({
+      userId: 'u',
+      content: '**x**',
+      channel: { type: 'telegram', identifier: '42' },
+    });
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body).text).toBe('**x**');
+
+    // Flip the closure mid-session — no restart.
+    mode = 'markdown';
+
+    await adapter.send({
+      userId: 'u',
+      content: '**x**',
+      channel: { type: 'telegram', identifier: '42' },
+    });
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body).text).toBe('<b>x</b>');
+  });
+});


### PR DESCRIPTION
## Summary

PR2 of the Telegram markdown renderer spec — wires the HTML formatter (shipped disabled in PR1) into the Bot API chokepoints (`TelegramAdapter`, `TelegramLifeline`, and the `telegram-reply.sh` template).

**Ships DISABLED.** Default is `legacy-passthrough` — byte-for-byte identical to current behavior. No user-visible change on merge. Canary flip on Echo's agent is a separate post-merge config change.

## What's in this PR

- Wires the formatter into every outbound Bot API call site (`sendMessage`, `editMessageText`, onboarding path, lifeline send path, reply script).
- Adds `telegramFormatMetrics.ts` — per-mode counters (legacy-passthrough / format / lint-fail / fallback) for observability once enabled.
- Adds wire-up unit tests (`tests/unit/telegram-format-wireup.test.ts`, 14 tests, all passing) covering: default-disabled behavior, per-callsite mode preservation, fallback on format error, metric emission.
- Server config plumbing + `core/types.ts` surface for the per-agent format mode.

## References

- Approved spec: `docs/specs/TELEGRAM-MARKDOWN-RENDERER-SPEC.md` (converged 2026-04-24, approved by Justin via Telegram topic 8183)
- Convergence report: `docs/specs/reports/telegram-markdown-renderer-convergence.md`
- Side-effects review: `docs/specs/side-effects/telegram-markdown-renderer-pr2.md`

## Rollout

1. Merge this PR → no behavior change (defaults to legacy-passthrough everywhere).
2. Separate post-merge config change flips Echo's agent to `format` mode as the canary.
3. Monitor `telegramFormatMetrics` and Telegram send error rate before broader rollout.

## Test plan

- [x] `npm run test -- telegram-format-wireup` — 14/14 passing
- [x] `npx tsc --noEmit` — clean
- [x] Full vitest suite via pre-push hook — 599/599 passing
- [ ] CI green on this PR
- [ ] Post-merge: flip Echo's agent config and verify metrics + no send regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)