### PR TITLE
fix(scripts): import SafeGitExecutor from dist/, not src/, in publish gate

### DIFF
--- a/scripts/check-contract-evidence.js
+++ b/scripts/check-contract-evidence.js
@@ -15,7 +15,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { SafeGitExecutor } from '../src/core/SafeGitExecutor.js';
+// Import from compiled output, not source. The script runs as part of the
+// `prepublishOnly` chain (`npm run build && check:upgrade-guide &&
+// check:contract-evidence`), so `dist/` is guaranteed to exist by the time
+// we reach this import. Importing from `src/` fails because that tree is
+// `.ts` only — Node's ESM resolver cannot map `.js` → `.ts` here.
+import { SafeGitExecutor } from '../dist/core/SafeGitExecutor.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');


### PR DESCRIPTION
## Summary

Fixes a latent ERR_MODULE_NOT_FOUND in the `prepublishOnly` chain.

## Root cause

PR #99 (destructive-tool containment) added an import to
`scripts/check-contract-evidence.js`:

\`\`\`js
import { SafeGitExecutor } from '../src/core/SafeGitExecutor.js';
\`\`\`

`src/` is a `.ts` tree. Node's ESM resolver does not map `.js` to `.ts`
in this directory, so the import fails immediately:

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '/.../src/core/SafeGitExecutor.js'
\`\`\`

## Why this stayed latent

`scripts/check-contract-evidence.js` is invoked through `prepublishOnly`,
which only runs when `npm publish` is invoked. Between #99 (Apr 26) and
now, every push to `main` triggered the publish workflow, but every one
of them short-circuited at the "Check if NEXT.md has content to publish"
guard because `upgrades/NEXT.md` was the empty template. So `npm publish`
was never invoked → `prepublishOnly` never ran → the broken import was
never exercised.

PR #115 (token ledger release notes) was the first push to clear the
NEXT.md guard. The publish step then failed with this import error.
Result: the four PRs that piled up on main (#110, #111, #112, #113) plus
#114 are still un-published; npm is still serving v0.28.76.

## Fix

Import from `'../dist/core/SafeGitExecutor.js'`. The `prepublishOnly`
chain is `npm run build && check:upgrade-guide && check:contract-evidence`,
so the build always runs first and `dist/` is guaranteed to exist when
the import resolves. Inline comment explains why we point at the build
output.

## Verification

\`\`\`
$ npm run build && node scripts/check-contract-evidence.js
$ echo \$?
0
\`\`\`

Vs. before the fix, on the same checkout:

\`\`\`
$ node scripts/check-contract-evidence.js
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../src/core/SafeGitExecutor.js'
\`\`\`

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, the publish workflow on main runs the full `npm publish`
      step (not skipped). `Determine next version` bumps to 0.28.77,
      `Publish to npm` succeeds, `Commit version bump & tag` lands the
      version bump on main.
- [ ] `npm view instar version` returns 0.28.77.
- [ ] On the echo agent, `POST /updates/apply` pulls 0.28.77 and
      `GET /tokens/summary` returns valid JSON instead of 404.

## Out of scope

- The script also has a separate `execSync` call from `node:child_process`
  that does not go through SafeGitExecutor. Per #99 it would be more
  consistent to route everything through the executor, but that is a
  pure-cosmetic follow-up and not on the critical path for unsticking
  publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)