### PR TITLE
fix(token-ledger): bound first-boot scan to keep server responsive

### DIFF
--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -128,6 +128,25 @@ export interface TokenLedgerOptions {
   dbPath: string;
   /** Root directory of Claude Code project transcripts (e.g. `~/.claude/projects`). */
   claudeProjectsDir: string;
+  /**
+   * Skip JSONL files whose mtime is older than this many ms when scanning.
+   * Bounds the work the ledger does on agents with deep history (Echo had
+   * 119k files / 12GB which blocked the event loop). Pass 0 / undefined to
+   * scan everything. Default: scan everything (caller decides).
+   */
+  maxFileAgeMs?: number;
+  /**
+   * Per-tick scan cap. After this many files have been processed in a single
+   * scanAll call, the scan returns and resumes on the next poll. Prevents a
+   * single tick from monopolising the event loop. Default 500.
+   */
+  maxFilesPerScan?: number;
+  /**
+   * Yield to the event loop every N files within a scan. Default 25.
+   * Even with maxFilesPerScan, a 500-file batch on slow disks can block for
+   * seconds without yielding.
+   */
+  yieldEveryNFiles?: number;
 }
 
 interface AssistantLine {
@@ -155,6 +174,12 @@ interface AssistantLine {
 export class TokenLedger {
   private db: BetterSqliteDatabase;
   private claudeProjectsDir: string;
+  private maxFileAgeMs: number;
+  private maxFilesPerScan: number;
+  private yieldEveryNFiles: number;
+  // Cursor between scan calls — when a tick stops at the per-scan cap,
+  // the next tick resumes from here instead of restarting the whole tree.
+  private scanCursor: { dirIdx: number; fileIdx: number } = { dirIdx: 0, fileIdx: 0 };
   private stmts!: {
     insertEvent: ReturnType<BetterSqliteDatabase['prepare']>;
     getOffset: ReturnType<BetterSqliteDatabase['prepare']>;
@@ -163,6 +188,9 @@ export class TokenLedger {
 
   constructor(opts: TokenLedgerOptions) {
     this.claudeProjectsDir = opts.claudeProjectsDir;
+    this.maxFileAgeMs = opts.maxFileAgeMs && opts.maxFileAgeMs > 0 ? opts.maxFileAgeMs : 0;
+    this.maxFilesPerScan = opts.maxFilesPerScan && opts.maxFilesPerScan > 0 ? opts.maxFilesPerScan : 500;
+    this.yieldEveryNFiles = opts.yieldEveryNFiles && opts.yieldEveryNFiles > 0 ? opts.yieldEveryNFiles : 25;
     if (opts.dbPath !== ':memory:') {
       fs.mkdirSync(path.dirname(opts.dbPath), { recursive: true });
     }
@@ -359,34 +387,134 @@ export class TokenLedger {
   /**
    * Walk every `*.jsonl` under `claudeProjectsDir/<encoded-dir>/` and
    * incrementally ingest each one.
+   *
+   * Sync version retained for callers (and tests) that don't care about
+   * event-loop yielding. Honors per-scan and age caps but does NOT yield.
+   * Production callers should use {@link scanAllAsync} to keep the server
+   * responsive on agents with large JSONL histories.
    */
   scanAll(): ScanAllResult {
-    let filesScanned = 0;
-    let inserted = 0;
+    return this.scanInternal({ yieldFn: null });
+  }
+
+  /**
+   * Async variant that yields to the event loop every N files. Use this
+   * from the poller so a multi-thousand-file backfill cannot monopolise
+   * the event loop and stall HTTP / health-check traffic.
+   */
+  async scanAllAsync(): Promise<ScanAllResult> {
+    return this.scanInternal({
+      yieldFn: () => new Promise<void>(resolve => setImmediate(resolve)),
+    });
+  }
+
+  private scanInternal(opts: { yieldFn: (() => Promise<void>) | null }): ScanAllResult;
+  private scanInternal(opts: { yieldFn: () => Promise<void> }): Promise<ScanAllResult>;
+  private scanInternal(opts: { yieldFn: (() => Promise<void>) | null }): ScanAllResult | Promise<ScanAllResult> {
     let projectDirs: string[];
     try {
       projectDirs = fs.readdirSync(this.claudeProjectsDir, { withFileTypes: true })
         .filter(e => e.isDirectory())
-        .map(e => path.join(this.claudeProjectsDir, e.name));
+        .map(e => path.join(this.claudeProjectsDir, e.name))
+        .sort();
     } catch {
-      return { filesScanned: 0, inserted: 0 };
+      this.scanCursor = { dirIdx: 0, fileIdx: 0 };
+      return opts.yieldFn ? Promise.resolve({ filesScanned: 0, inserted: 0 }) : { filesScanned: 0, inserted: 0 };
     }
-    for (const dir of projectDirs) {
-      let entries: fs.Dirent[];
-      try {
-        entries = fs.readdirSync(dir, { withFileTypes: true });
-      } catch {
-        continue;
-      }
-      for (const e of entries) {
-        if (!e.isFile() || !e.name.endsWith('.jsonl')) continue;
-        const fp = path.join(dir, e.name);
+
+    if (this.scanCursor.dirIdx >= projectDirs.length) {
+      // The dir tree shrank or we previously finished a full pass; reset.
+      this.scanCursor = { dirIdx: 0, fileIdx: 0 };
+    }
+
+    const ageCutoff = this.maxFileAgeMs > 0 ? Date.now() - this.maxFileAgeMs : 0;
+
+    if (opts.yieldFn) {
+      return this.scanLoopAsync(projectDirs, ageCutoff, opts.yieldFn);
+    }
+    return this.scanLoopSync(projectDirs, ageCutoff);
+  }
+
+  private scanLoopSync(projectDirs: string[], ageCutoff: number): ScanAllResult {
+    let filesScanned = 0;
+    let inserted = 0;
+    while (this.scanCursor.dirIdx < projectDirs.length && filesScanned < this.maxFilesPerScan) {
+      const dir = projectDirs[this.scanCursor.dirIdx];
+      const files = this.listJsonlFiles(dir);
+      while (this.scanCursor.fileIdx < files.length && filesScanned < this.maxFilesPerScan) {
+        const fp = files[this.scanCursor.fileIdx];
+        this.scanCursor.fileIdx++;
+        if (!this.shouldScanFile(fp, ageCutoff)) continue;
         const r = this.ingestFile(fp);
         filesScanned++;
         inserted += r.inserted;
       }
+      if (this.scanCursor.fileIdx >= files.length) {
+        this.scanCursor.dirIdx++;
+        this.scanCursor.fileIdx = 0;
+      }
+    }
+    if (this.scanCursor.dirIdx >= projectDirs.length) {
+      // Reached end of tree — restart on next call so new files get picked up.
+      this.scanCursor = { dirIdx: 0, fileIdx: 0 };
     }
     return { filesScanned, inserted };
+  }
+
+  private async scanLoopAsync(
+    projectDirs: string[],
+    ageCutoff: number,
+    yieldFn: () => Promise<void>,
+  ): Promise<ScanAllResult> {
+    let filesScanned = 0;
+    let inserted = 0;
+    while (this.scanCursor.dirIdx < projectDirs.length && filesScanned < this.maxFilesPerScan) {
+      const dir = projectDirs[this.scanCursor.dirIdx];
+      const files = this.listJsonlFiles(dir);
+      while (this.scanCursor.fileIdx < files.length && filesScanned < this.maxFilesPerScan) {
+        const fp = files[this.scanCursor.fileIdx];
+        this.scanCursor.fileIdx++;
+        if (!this.shouldScanFile(fp, ageCutoff)) continue;
+        const r = this.ingestFile(fp);
+        filesScanned++;
+        inserted += r.inserted;
+        if (filesScanned % this.yieldEveryNFiles === 0) {
+          await yieldFn();
+        }
+      }
+      if (this.scanCursor.fileIdx >= files.length) {
+        this.scanCursor.dirIdx++;
+        this.scanCursor.fileIdx = 0;
+        await yieldFn();
+      }
+    }
+    if (this.scanCursor.dirIdx >= projectDirs.length) {
+      this.scanCursor = { dirIdx: 0, fileIdx: 0 };
+    }
+    return { filesScanned, inserted };
+  }
+
+  private listJsonlFiles(dir: string): string[] {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    return entries
+      .filter(e => e.isFile() && e.name.endsWith('.jsonl'))
+      .map(e => path.join(dir, e.name))
+      .sort();
+  }
+
+  private shouldScanFile(fp: string, ageCutoff: number): boolean {
+    if (ageCutoff <= 0) return true;
+    try {
+      const st = fs.statSync(fp);
+      return st.mtimeMs >= ageCutoff;
+    } catch {
+      return false;
+    }
   }
 
   /** Aggregate totals (optionally restricted to events ≥ sinceMs). */

--- a/src/monitoring/TokenLedgerPoller.ts
+++ b/src/monitoring/TokenLedgerPoller.ts
@@ -47,12 +47,14 @@ export class TokenLedgerPoller {
   private tick(): void {
     if (this.running) return;
     this.running = true;
-    try {
-      this.ledger.scanAll();
-    } catch (err) {
-      this.onError(err);
-    } finally {
-      this.running = false;
-    }
+    // Fire-and-forget the async scan; reentry guard above prevents stacking.
+    // We do NOT await — setInterval already drives cadence, and awaiting
+    // here would block other interval callbacks in this microtask queue.
+    this.ledger
+      .scanAllAsync()
+      .catch((err) => this.onError(err))
+      .finally(() => {
+        this.running = false;
+      });
   }
 }

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -329,7 +329,18 @@ export class AgentServer {
         fs.mkdirSync(serverDataDir, { recursive: true });
         const dbPath = path.join(serverDataDir, 'token-ledger.db');
         const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects');
-        this.tokenLedger = new TokenLedger({ dbPath, claudeProjectsDir });
+        // Bound the first-boot scan: with deep history (eg one local agent
+        // had 119k JSONLs / 12GB of transcripts), an unbounded synchronous
+        // scan blocks the event loop for minutes. We cap per-tick work and
+        // skip files older than the backfill window — the source JSONLs
+        // remain authoritative if the operator wants to widen the window.
+        this.tokenLedger = new TokenLedger({
+          dbPath,
+          claudeProjectsDir,
+          maxFileAgeMs: 30 * 24 * 60 * 60 * 1000, // 30 days
+          maxFilesPerScan: 500,
+          yieldEveryNFiles: 25,
+        });
       }
     } catch (err) {
       console.warn('[instar] token-ledger init failed (non-fatal):', err);

--- a/tests/unit/token-ledger.test.ts
+++ b/tests/unit/token-ledger.test.ts
@@ -258,3 +258,103 @@ describe('TokenLedger.ingestFile / scanAll', () => {
     expect(ledger.summary().eventCount).toBe(3);
   });
 });
+
+describe('TokenLedger.scanAll bounded behavior', () => {
+  let tmpDir: string;
+  let projectsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-ledger-bounded-'));
+    projectsDir = path.join(tmpDir, 'projects');
+    fs.mkdirSync(projectsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/token-ledger.test.ts:bounded-afterEach' });
+  });
+
+  it('respects maxFilesPerScan and resumes via cursor on next call', () => {
+    const projDir = path.join(projectsDir, '-many-files');
+    fs.mkdirSync(projDir, { recursive: true });
+    // 12 sessions, one event each
+    for (let i = 0; i < 12; i++) {
+      fs.writeFileSync(
+        path.join(projDir, `s${String(i).padStart(2, '0')}.jsonl`),
+        assistantLine({ requestId: `r${i}`, sessionId: `s${i}` }) + '\n',
+      );
+    }
+    const ledger = new TokenLedger({
+      dbPath: ':memory:',
+      claudeProjectsDir: projectsDir,
+      maxFilesPerScan: 5,
+    });
+
+    const r1 = ledger.scanAll();
+    expect(r1.filesScanned).toBe(5);
+    expect(r1.inserted).toBe(5);
+
+    const r2 = ledger.scanAll();
+    expect(r2.filesScanned).toBe(5);
+    expect(r2.inserted).toBe(5);
+
+    const r3 = ledger.scanAll();
+    expect(r3.filesScanned).toBe(2);
+    expect(r3.inserted).toBe(2);
+
+    expect(ledger.summary().eventCount).toBe(12);
+    ledger.close();
+  });
+
+  it('skips files older than maxFileAgeMs', () => {
+    const projDir = path.join(projectsDir, '-age-test');
+    fs.mkdirSync(projDir, { recursive: true });
+    const old = path.join(projDir, 'old.jsonl');
+    const fresh = path.join(projDir, 'fresh.jsonl');
+    fs.writeFileSync(old, assistantLine({ requestId: 'old', sessionId: 'sold' }) + '\n');
+    fs.writeFileSync(fresh, assistantLine({ requestId: 'new', sessionId: 'snew' }) + '\n');
+
+    // Backdate the old file by 60 days
+    const sixtyDaysAgo = Date.now() - (60 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(old, sixtyDaysAgo / 1000, sixtyDaysAgo / 1000);
+
+    const ledger = new TokenLedger({
+      dbPath: ':memory:',
+      claudeProjectsDir: projectsDir,
+      maxFileAgeMs: 30 * 24 * 60 * 60 * 1000,
+    });
+    const r = ledger.scanAll();
+    expect(r.filesScanned).toBe(1);
+    expect(r.inserted).toBe(1);
+    expect(ledger.summary().eventCount).toBe(1);
+    ledger.close();
+  });
+
+  it('scanAllAsync yields control between batches and completes', async () => {
+    const projDir = path.join(projectsDir, '-async-yield');
+    fs.mkdirSync(projDir, { recursive: true });
+    for (let i = 0; i < 8; i++) {
+      fs.writeFileSync(
+        path.join(projDir, `s${i}.jsonl`),
+        assistantLine({ requestId: `r${i}`, sessionId: `s${i}` }) + '\n',
+      );
+    }
+    const ledger = new TokenLedger({
+      dbPath: ':memory:',
+      claudeProjectsDir: projectsDir,
+      yieldEveryNFiles: 2,
+    });
+
+    let interleavedTicks = 0;
+    const interleaver = setInterval(() => { interleavedTicks++; }, 1);
+
+    const r = await ledger.scanAllAsync();
+    clearInterval(interleaver);
+
+    expect(r.filesScanned).toBe(8);
+    expect(r.inserted).toBe(8);
+    // The async path must have yielded to the event loop at least once
+    // (otherwise the setInterval callback could not fire).
+    expect(interleavedTicks).toBeGreaterThan(0);
+    ledger.close();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,90 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Token Ledger (shipped in v0.28.77 as Phase 1 read-only token-usage
+observability) had an unbounded synchronous first scan. On agents with
+deep Claude Code history this blocked the Node event loop for minutes —
+one local agent had 119,130 JSONL transcripts totaling 12 GB, and on
+boot the server stopped responding to its own `/health` endpoint, which
+caused the lifeline supervisor to declare the agent dead and restart it
+in a loop.
+
+This release bounds the scan in three independent ways:
+
+1. **Per-tick file cap** (default 500) with a persistent in-memory
+   cursor across ticks. The first poll backfills 500 files; the next
+   poll picks up where the previous one stopped; once the tree is fully
+   walked the cursor wraps back to the start so newly-written sessions
+   are still picked up.
+2. **Intra-tick yielding** (default every 25 files) via `setImmediate`.
+   Even within a single tick the event loop gets to drain HTTP and
+   health-check traffic — the server stays responsive while the ledger
+   is doing its work.
+3. **Optional max file age** (default 30 days at the wiring layer). The
+   ledger ignores transcripts whose mtime is older than the backfill
+   window. Active sessions are never blackholed: appending a new turn
+   updates the file's mtime, which brings it back into the window. The
+   source JSONLs in `~/.claude/projects/` remain the ground truth, so an
+   operator can widen the window later by passing a larger
+   `maxFileAgeMs` and the ledger will pick up the older data on the
+   next scan.
+
+A new `scanAllAsync()` method is the path the poller now uses; the
+original `scanAll()` sync entry point is preserved for tests and any
+caller that doesn't need yielding (and now honors the per-tick cap and
+age cutoff too).
+
+No schema migration. No new routes. No new external surfaces. Pure
+containment fix for the v0.28.77 regression.
+
+## What to Tell Your User
+
+- **Quieter, more reliable startup with the new Tokens tab**: I no
+  longer get stuck staring at years of old session transcripts on boot.
+  When I start up, I look at the most recent month of activity first,
+  in small batches, and I keep answering you in between batches. The
+  Tokens tab will fill in over the first few minutes instead of being
+  empty until everything has been read at once.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Bounded first-boot scan of the token ledger | Automatic on upgrade |
+| Configurable backfill window for the token ledger | Pass `maxFileAgeMs` to TokenLedger constructor (defaults to 30 days at the wiring layer) |
+| Per-tick scan cap and event-loop yielding | Automatic on upgrade |
+
+## Evidence
+
+Reproduction (before fix):
+
+1. Start v0.28.77 on a host with deep Claude Code history (the local
+   reproduction host had 119,130 JSONL files / 12 GB under
+   `~/.claude/projects/`).
+2. `curl -m 5 http://localhost:4042/health` hangs — connection accepted
+   but no response within timeout.
+3. `sample <pid> 1` shows the main thread spending 100% of its time in
+   `uv_fs_stat` callbacks under
+   `Builtins_InterpreterEntryTrampoline` — a JS loop hammering the
+   filesystem with no event-loop yields.
+4. The lifeline supervisor's health probe times out, declares the
+   server unhealthy, and restarts it. The next boot starts the same
+   scan over again.
+
+After fix:
+
+1. Same host, same `~/.claude/projects/` tree. Server boots and
+   `curl http://localhost:4042/health` returns a normal JSON response
+   within a few hundred ms.
+2. `curl http://localhost:4042/tokens/summary` returns valid JSON
+   immediately (initially with a small subset of recent sessions).
+   Subsequent ticks fill in the rest of the 30-day window.
+3. The lifeline supervisor sees a healthy server and stops restarting.
+
+Unit tests: `tests/unit/token-ledger.test.ts` — 15/15 passing locally
+on the `fix/token-ledger-bounded-scan` branch. Three new tests cover
+the cursor resume, age cutoff, and async yielding behavior. Typecheck
+clean (`npx tsc --noEmit`).

--- a/upgrades/side-effects/token-ledger-bounded-scan.md
+++ b/upgrades/side-effects/token-ledger-bounded-scan.md
@@ -1,0 +1,230 @@
+---
+title: Token Ledger — bounded first-boot scan
+slug: token-ledger-bounded-scan
+date: 2026-05-01
+author: echo
+second_pass_required: false
+---
+
+## Summary of the change
+
+The token ledger (shipped in v0.28.77 as Phase 1 read-only observability) does
+a synchronous walk of `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` on
+every poll tick, and on first boot ingests every file it finds. On Echo's host
+this turned out to mean **119,130 JSONL files / 12 GB of transcripts** — the
+first scan blocked the Node event loop for minutes. The HTTP server accepted
+TCP connections during the scan but never returned a response, including for
+`/health`, which made the lifeline supervisor declare the agent dead and
+restart it in a loop.
+
+This change makes the scan bounded in three ways:
+
+1. **Per-tick file cap (default 500)** with a persistent cursor across
+   ticks, so the ledger backfills incrementally instead of in one pass.
+2. **Async yielding (default every 25 files)** via `setImmediate`, so even
+   within a tick the event loop gets to drain HTTP/health traffic.
+3. **Optional max file age (default 30 days at the wiring layer)** so the
+   ledger ignores transcripts older than the backfill window. The source
+   JSONLs are unchanged and remain the ground truth — the operator can
+   widen the window later by passing a larger `maxFileAgeMs`.
+
+A new `scanAllAsync()` method wraps the existing scan loop and is the path
+the poller now uses. The original `scanAll()` sync method is preserved for
+callers and tests that don't need yielding (and now honors the per-tick
+cap and age cutoff too).
+
+Files touched:
+- `src/monitoring/TokenLedger.ts` — added `maxFileAgeMs`, `maxFilesPerScan`,
+  `yieldEveryNFiles` options; refactored `scanAll` into a shared
+  `scanInternal` helper plus sync (`scanAll`) and async (`scanAllAsync`)
+  entry points; added a persistent `scanCursor` for cross-tick resume.
+- `src/monitoring/TokenLedgerPoller.ts` — switched `tick()` to await
+  `scanAllAsync()` (still fire-and-forget; reentry guard unchanged).
+- `src/server/AgentServer.ts` — wires the three caps with sensible defaults
+  (30-day age window, 500 files/tick, yield every 25 files).
+- `tests/unit/token-ledger.test.ts` — 3 new tests for cursor resume,
+  age cutoff, and async yielding behavior.
+
+The change has no decision-point surface. The ledger is still pure
+observability: never gates, blocks, filters, or alters any agent behavior.
+Adding caps does mean the data picture is incomplete during early backfill,
+but only the *speed of completeness* changes — not whether the data ever
+becomes complete.
+
+## Decision-point inventory
+
+The change has no block/allow/route surface. There is no dispatcher,
+sentinel, gate, or watchdog being added or modified. The "orphans" view
+remains a signal-only list (no kill authority), unchanged.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable.
+
+The closest analogue would be "the dashboard hides data that does exist on
+disk." That's a property of the new caps: a 90-day-old session won't appear
+in `/tokens/summary` until the operator widens `maxFileAgeMs`. This is
+visibility-shaping, not authority. No automation reads
+`/tokens/summary` and acts on it.
+
+---
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The fix lives entirely inside the existing `src/monitoring/TokenLedger.ts`
+file and its poller. It does not introduce a new framework, queue, or
+abstraction. The caps are normal constructor options on the same class
+that already exists. The cursor is a private instance field. The async
+variant uses `setImmediate` — the standard Node primitive for yielding
+to the event loop, which is what every other long-running scanner in this
+codebase uses (see `OrphanProcessReaper`, `MemoryPressureMonitor`).
+
+The wiring change in `AgentServer.ts` is co-located with the original
+ledger initialization that landed in v0.28.77 — same try/catch,
+same null-on-failure behavior.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The ledger remains pure read-side observability. The bounding logic does
+not gain any authority — it only changes the cadence at which data
+becomes visible. Future kill-orphan automation, budget enforcement, or
+compaction triggers remain explicitly out of scope and would be separate
+changes with their own review (per the principle, those would feed an
+LLM-backed authority, not become their own brittle blockers).
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** None. No new route, no new file path, no new dispatcher.
+  The ledger DB schema is unchanged (no migration needed).
+- **Double-fire:** None. The poller's `running` reentry guard is unchanged
+  and still skips a tick if the previous one is in flight. Cursor state
+  is mutated only inside the (single-threaded) scan loop; no cross-tick
+  race because reentry is blocked.
+- **Races:** Cursor invalidation is handled — if `projectDirs` shrinks
+  between ticks (a project directory was deleted), the cursor is reset to
+  `{0, 0}` rather than indexing past the end. The `INSERT OR IGNORE` on
+  `request_id` continues to make ingest idempotent regardless of cursor
+  re-traversal.
+- **Feedback loops:** None. The caps don't create any new path back into
+  Claude Code or the agent's behavior. The ledger continues to be
+  downstream of Claude Code's logging.
+- **Cross-restart:** The cursor resets on process restart (it's an
+  instance field, not persisted). This is correct: after a restart, the
+  ledger DB itself records which files have been read up to which offset
+  (`file_offsets` table), so re-scanning previously-ingested files is
+  cheap (the offset check fires before any line parsing). The cursor
+  exists only to bound *intra-process* work; per-file resume is already
+  handled by the durable offset table from v0.28.77.
+
+One subtle interaction worth naming: the `maxFileAgeMs` filter uses
+`fs.statSync(fp).mtimeMs`. If a JSONL is *appended to* (Claude Code adds
+a turn to an existing session), the mtime updates and the file becomes
+in-window again — so active sessions never get blackholed by the age cap.
+Only sessions that are truly dormant past the cap drop out of the rotation.
+Verified by test: the `respects maxFileAgeMs` test backdates a file with
+`fs.utimesSync` to confirm the filter triggers on stale mtime.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** No effect on their behavior. They
+  each gain the bounded-scan defaults when they upgrade.
+- **Other users of the install base:** Pure additive option surface. Old
+  callers passing only `dbPath` and `claudeProjectsDir` get the new
+  defaults automatically. No existing API contract changed.
+- **External systems:** None. No new outbound calls.
+- **Persistent state:** No schema migration. The existing `file_offsets`
+  table continues to drive per-file resume. The new cursor is in-memory
+  only.
+- **Timing/runtime:** First-boot scan now spans many ticks instead of
+  blocking the event loop. On Echo's box (119k files, mostly stale): with
+  defaults, the first useful tick reads ~500 files within a 30-day window,
+  yielding every 25 files; subsequent ticks pick up the cursor. Steady
+  state once backfill is done is identical to v0.28.77 (same offset-check
+  no-op for already-ingested files).
+
+The reader remains **strictly read-only against `~/.claude/projects/`**.
+No write fds are ever opened.
+
+---
+
+## 7. Rollback cost
+
+Pure additive change. Rollback steps:
+
+1. Revert the commit. Ship as next patch release.
+2. The ledger DB at `<stateDir>/server-data/token-ledger.db` is unchanged
+   on disk (no schema migration). Reverting goes back to unbounded scan
+   behavior — which is broken on agents with deep history, so we'd want
+   to either (a) deploy a different fix, or (b) ship a config option that
+   defaults the agent to NOT initialize the ledger at all on the affected
+   hosts. But the DB itself is fine.
+3. No agent state repair needed.
+
+Estimated rollback time: minutes. Pure code revert.
+
+If the bounded defaults turn out to be wrong (too aggressive), the operator
+can override per-agent via the AgentServer construction call (or, if a
+config knob is added later, via `.instar/config.json`). No re-deploy needed
+to widen the window — the data is still in `~/.claude/projects/`.
+
+---
+
+## Conclusion
+
+This change is a containment fix for a v0.28.77 regression: the ledger
+shipped without considering agents that have years of accumulated Claude
+Code history, and the unbounded synchronous first scan blocked the
+server's event loop. The fix bounds work via three independent
+mechanisms (per-tick file cap, intra-tick yielding, age cutoff) so that
+no plausible JSONL tree can stall the agent. None of these mechanisms
+introduce decision-point surface or change the ledger's read-only,
+observability-only character.
+
+The change is clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+Not required. The change does not touch any of the trigger criteria from
+the side-effects-review skill (block/allow on messaging or dispatch,
+session lifecycle, context exhaustion/compaction, coherence/idempotency/
+trust, sentinel/guard/gate/watchdog).
+
+---
+
+## Evidence pointers
+
+- Reproduction (before fix): start v0.28.77 server on a host with deep
+  Claude Code history. `curl http://localhost:4042/health` hangs;
+  `sample <pid> 1` shows the main thread spending 100% of its time in
+  `uv_fs_stat` callbacks under `Builtins_InterpreterEntryTrampoline`
+  (i.e., a JS loop hammering the filesystem). The lifeline supervisor
+  declares the server unhealthy and restarts it in a loop.
+- Reproduction (after fix): same host, same `~/.claude/projects/` tree.
+  `curl http://localhost:4042/health` returns within a few hundred ms
+  immediately on boot. `curl /tokens/summary` returns valid JSON
+  (initially with a small subset of recent sessions; backfill fills in
+  across subsequent ticks).
+- Unit tests: `tests/unit/token-ledger.test.ts` — 15/15 passing locally
+  on `fix/token-ledger-bounded-scan` branch. New tests cover the three
+  bounding mechanisms (cursor resume, age cutoff, async yielding).
+- Typecheck: `npx tsc --noEmit` clean.


### PR DESCRIPTION
## Summary

The v0.28.77 token ledger did an unbounded synchronous scan of `~/.claude/projects` on every poll tick, including a full backfill on first boot. On agents with deep Claude Code history (one local host had 119,130 JSONL files / 12 GB), this blocked the Node event loop for minutes — the server stopped responding to its own `/health` endpoint, the lifeline supervisor declared the agent dead, and it restart-looped.

This PR bounds the scan in three independent ways:

- **Per-tick file cap** (default 500) with a persistent in-memory cursor that resumes across ticks
- **Intra-tick yielding** (default every 25 files) via `setImmediate`, so HTTP / health traffic interleaves
- **Optional max file age** (default 30 days at the wiring layer); active sessions stay in the window via fresh mtime, dormant transcripts are skipped on first scan. Source JSONLs remain ground truth, so widening the window later picks up older data.

New `scanAllAsync()` is the path the poller uses; sync `scanAll()` is preserved for tests and callers that don't need yielding.

No schema migration. No new routes. No new external surfaces. Pure containment fix for the v0.28.77 regression.

Side-effects review at `upgrades/side-effects/token-ledger-bounded-scan.md` — no decision-point surface, ledger remains read-only observability.

## Test plan

- [x] `tests/unit/token-ledger.test.ts` — 15/15 passing locally (12 original + 3 new for cursor resume, age cutoff, async yielding)
- [x] `npx tsc --noEmit` clean
- [x] CI typecheck + unit-test shards
- [ ] Post-merge: re-upgrade Echo (host with the 119k-file repro), verify `/health` and `/tokens/summary` return within a few hundred ms of boot