### PR TITLE
fix(upgrade): regenerate built-in SKILL.md when bundled template drifts (PROP-337 v1)

### DIFF
--- a/src/core/BuiltinSkillRegenerator.ts
+++ b/src/core/BuiltinSkillRegenerator.ts
@@ -1,0 +1,279 @@
+/**
+ * Built-in Skill Regenerator (PROP-337 v1)
+ *
+ * Closes the upgrade gap: when an inline SKILL template in
+ * `installBuiltinSkills` (init.ts) is updated in a new package release,
+ * existing installs never see the new content because the migrator's
+ * `migrateBuiltinSkills` is non-destructive — it only writes files that
+ * are missing.
+ *
+ * This module adds fingerprint-based drift detection and safe
+ * regeneration:
+ *
+ *   - On first observation (or after first regeneration), the on-disk
+ *     SHA-256 of each built-in SKILL.md is recorded in
+ *     `.instar/state/builtin-skill-fingerprints.json`.
+ *   - On each migrator run we render the CURRENT bundled template into a
+ *     scratch directory by calling the existing `installBuiltinSkills`
+ *     into a tempdir. The rendered content is the source-of-truth for
+ *     what THIS package version intends each skill to look like.
+ *   - For each skill we compare three hashes:
+ *       on-disk         = SHA-256 of .claude/skills/<slug>/SKILL.md
+ *       fingerprint     = SHA-256 we recorded after the last write/observe
+ *       currentBundled  = SHA-256 of the freshly rendered template
+ *   - Decision:
+ *       missing on disk            -> install fresh
+ *       on-disk == currentBundled  -> in sync (refresh fingerprint)
+ *       on-disk == fingerprint     -> unmodified by user, safe to upgrade
+ *                                     -> overwrite with currentBundled,
+ *                                        update fingerprint
+ *       else                       -> user-modified, leave alone, record
+ *                                     finding (so the operator can see
+ *                                     drift without losing customizations)
+ *
+ * Custom skills (anything not in the built-in template set) are never
+ * touched — we only enumerate slugs produced by `installBuiltinSkills`.
+ *
+ * Design notes / scope (v1):
+ *   - This handles INLINE templates owned by `installBuiltinSkills` plus
+ *     the `build` skill bundled as a file in `.claude/skills/build/` of
+ *     the package. Hooks, jobs, scripts, and the `autonomous` skill are
+ *     out of scope for v1; PostUpdateMigrator already overwrites those
+ *     unconditionally, so they don't suffer the same gap.
+ *   - Default mode is `apply: true` — the call site (PostUpdateMigrator)
+ *     can pass `apply: false` to get a dry-run report (useful for
+ *     debugging without writing).
+ *   - Failure mode: any error rendering or hashing a skill is recorded
+ *     in `result.errors` but never aborts the whole migration. Worst
+ *     case we no-op for that skill, which preserves the pre-PROP-337
+ *     behavior.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { installBuiltinSkills } from '../commands/init.js';
+
+export interface RegeneratorResult {
+  upgraded: string[];
+  skipped: string[];
+  errors: string[];
+}
+
+export interface RegeneratorOptions {
+  projectDir: string;
+  stateDir: string;
+  port: number;
+  apply?: boolean;
+}
+
+interface FingerprintFile {
+  $schema?: string;
+  schemaVersion: number;
+  updatedAt: string;
+  /** keyed by slug -> sha256 of the SKILL.md we wrote (or first observed) */
+  skills: Record<string, { contentHash: string; observedAt: string }>;
+}
+
+const FINGERPRINT_SCHEMA_VERSION = 1;
+
+function sha256(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function readFingerprints(stateDir: string): FingerprintFile {
+  const file = path.join(stateDir, 'state', 'builtin-skill-fingerprints.json');
+  if (!fs.existsSync(file)) {
+    return {
+      schemaVersion: FINGERPRINT_SCHEMA_VERSION,
+      updatedAt: new Date().toISOString(),
+      skills: {},
+    };
+  }
+  try {
+    const raw = fs.readFileSync(file, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && parsed.skills) {
+      return {
+        schemaVersion: parsed.schemaVersion ?? FINGERPRINT_SCHEMA_VERSION,
+        updatedAt: parsed.updatedAt ?? new Date().toISOString(),
+        skills: parsed.skills as FingerprintFile['skills'],
+      };
+    }
+  } catch {
+    /* fall through to fresh state */
+  }
+  return {
+    schemaVersion: FINGERPRINT_SCHEMA_VERSION,
+    updatedAt: new Date().toISOString(),
+    skills: {},
+  };
+}
+
+function writeFingerprints(stateDir: string, fp: FingerprintFile): void {
+  const dir = path.join(stateDir, 'state');
+  fs.mkdirSync(dir, { recursive: true });
+  fp.updatedAt = new Date().toISOString();
+  fs.writeFileSync(
+    path.join(dir, 'builtin-skill-fingerprints.json'),
+    JSON.stringify(fp, null, 2),
+  );
+}
+
+/**
+ * Render the bundled built-in skills into a tempdir by invoking the
+ * canonical `installBuiltinSkills` and snapshotting the result. Returns
+ * a map from slug -> rendered SKILL.md content.
+ *
+ * Note: `installBuiltinSkills` itself ALSO emits the `build` and
+ * `autonomous` skill bundles. We only collect SKILL.md files at the top
+ * level of each skill folder, since those are the in-scope artifacts
+ * for v1. Subdirectories (autonomous/scripts, autonomous/hooks) are
+ * intentionally ignored.
+ */
+export function renderBundledSkills(port: number): Record<string, string> {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-skill-render-'));
+  try {
+    installBuiltinSkills(tmpRoot, port);
+    const slugs = fs.readdirSync(tmpRoot, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
+    const out: Record<string, string> = {};
+    for (const slug of slugs) {
+      const skillFile = path.join(tmpRoot, slug, 'SKILL.md');
+      if (fs.existsSync(skillFile)) {
+        out[slug] = fs.readFileSync(skillFile, 'utf-8');
+      }
+    }
+    return out;
+  } finally {
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}
+
+/**
+ * Run drift detection + regeneration. Returns a structured result with
+ * per-skill outcomes for the migrator to merge into its own log.
+ *
+ * Idempotent: a no-op run after a successful run produces all-skipped.
+ */
+export function regenerateBuiltinSkills(opts: RegeneratorOptions): RegeneratorResult {
+  const result: RegeneratorResult = { upgraded: [], skipped: [], errors: [] };
+  const apply = opts.apply !== false;
+  const skillsDir = path.join(opts.projectDir, '.claude', 'skills');
+
+  let bundled: Record<string, string>;
+  try {
+    bundled = renderBundledSkills(opts.port);
+  } catch (err) {
+    result.errors.push(
+      `builtin-skill-regen: failed to render bundled templates: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return result;
+  }
+
+  const fingerprints = readFingerprints(opts.stateDir);
+  let dirty = false;
+
+  for (const [slug, bundledContent] of Object.entries(bundled)) {
+    try {
+      const skillDir = path.join(skillsDir, slug);
+      const skillFile = path.join(skillDir, 'SKILL.md');
+      const bundledHash = sha256(bundledContent);
+
+      if (!fs.existsSync(skillFile)) {
+        // Missing on disk — install fresh. This duplicates the existing
+        // non-destructive path in `migrateBuiltinSkills`, but is harmless
+        // (we just wrote what that method would have written). It also
+        // ensures fingerprint is recorded on a fresh install.
+        if (apply) {
+          fs.mkdirSync(skillDir, { recursive: true });
+          fs.writeFileSync(skillFile, bundledContent);
+          fingerprints.skills[slug] = {
+            contentHash: bundledHash,
+            observedAt: new Date().toISOString(),
+          };
+          dirty = true;
+          result.upgraded.push(`skills/${slug}/SKILL.md (installed)`);
+        } else {
+          result.upgraded.push(`skills/${slug}/SKILL.md (would install)`);
+        }
+        continue;
+      }
+
+      const onDisk = fs.readFileSync(skillFile, 'utf-8');
+      const onDiskHash = sha256(onDisk);
+      const fp = fingerprints.skills[slug];
+
+      if (onDiskHash === bundledHash) {
+        // In sync — refresh fingerprint if missing/outdated.
+        if (!fp || fp.contentHash !== bundledHash) {
+          fingerprints.skills[slug] = {
+            contentHash: bundledHash,
+            observedAt: new Date().toISOString(),
+          };
+          dirty = true;
+        }
+        result.skipped.push(`skills/${slug}/SKILL.md (in sync)`);
+        continue;
+      }
+
+      if (fp && fp.contentHash === onDiskHash) {
+        // On-disk file matches our fingerprint — user has not modified
+        // it since the last install/observe. Bundled hash differs, so
+        // the template was upgraded upstream. Safe to regenerate.
+        if (apply) {
+          fs.writeFileSync(skillFile, bundledContent);
+          fingerprints.skills[slug] = {
+            contentHash: bundledHash,
+            observedAt: new Date().toISOString(),
+          };
+          dirty = true;
+          result.upgraded.push(`skills/${slug}/SKILL.md (regenerated from upgraded template)`);
+        } else {
+          result.upgraded.push(`skills/${slug}/SKILL.md (would regenerate)`);
+        }
+        continue;
+      }
+
+      // No fingerprint OR on-disk diverges from both fingerprint and
+      // bundled. Treat as user-customized; preserve and record.
+      result.skipped.push(
+        `skills/${slug}/SKILL.md (user-modified — preserving; bundled drift detected)`,
+      );
+
+      // First-observe seeding: if there's no fingerprint at all, record
+      // the current on-disk hash so future template upgrades can
+      // recognize "user has not touched it since now". This converts
+      // pre-PROP-337 installs into PROP-337-aware ones over time.
+      if (!fp) {
+        fingerprints.skills[slug] = {
+          contentHash: onDiskHash,
+          observedAt: new Date().toISOString(),
+        };
+        dirty = true;
+      }
+    } catch (err) {
+      result.errors.push(
+        `skills/${slug}/SKILL.md: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (dirty && apply) {
+    try {
+      writeFingerprints(opts.stateDir, fingerprints);
+    } catch (err) {
+      result.errors.push(
+        `builtin-skill-regen: failed to write fingerprints: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return result;
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -28,6 +28,7 @@ import { TreeGenerator } from '../knowledge/TreeGenerator.js';
 import { HTTP_HOOK_TEMPLATES, buildHttpHookSettings } from '../data/http-hook-templates.js';
 import { getMigrationDefaults, applyDefaults } from '../config/ConfigDefaults.js';
 import { installBuiltinSkills } from '../commands/init.js';
+import { regenerateBuiltinSkills } from './BuiltinSkillRegenerator.js';
 import {
   ELIGIBILITY_SCHEMA_SQL,
   ELIGIBILITY_SCHEMA_SQL_SHA256,
@@ -87,6 +88,7 @@ export class PostUpdateMigrator {
     this.migrateBackupManifest(result);
     this.migrateGitignore(result);
     this.migrateBuiltinSkills(result);
+    this.migrateBuiltinSkillRegeneration(result);
     this.migrateSkillPortHardcoding(result);
     this.migrateSelfKnowledgeTree(result);
     this.migrateSoulMd(result);
@@ -247,6 +249,35 @@ export class PostUpdateMigrator {
       } catch (err) {
         result.errors.push(`skills/${name}/SKILL.md port migration: ${err instanceof Error ? err.message : String(err)}`);
       }
+    }
+  }
+
+  /**
+   * PROP-337: regenerate built-in SKILL.md files when their bundled
+   * templates have been updated upstream. Fingerprint-gated so
+   * user-modified skills are preserved; see BuiltinSkillRegenerator
+   * for the decision logic.
+   *
+   * Runs AFTER `migrateBuiltinSkills` so fresh installs are seeded by
+   * the existing non-destructive path first, then this method handles
+   * any drift between the on-disk file and the freshly-rendered
+   * bundled template.
+   */
+  private migrateBuiltinSkillRegeneration(result: MigrationResult): void {
+    try {
+      const regen = regenerateBuiltinSkills({
+        projectDir: this.config.projectDir,
+        stateDir: this.config.stateDir,
+        port: this.config.port,
+        apply: true,
+      });
+      result.upgraded.push(...regen.upgraded);
+      result.skipped.push(...regen.skipped);
+      result.errors.push(...regen.errors);
+    } catch (err) {
+      result.errors.push(
+        `builtin-skill-regen: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-04-28T19:10:24.472Z",
-  "instarVersion": "0.28.76",
+  "generatedAt": "2026-05-02T10:37:46.450Z",
+  "instarVersion": "0.28.78",
   "entryCount": 187,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -384,7 +384,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -720,7 +720,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -736,7 +736,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ca574387ec0c87b9933caa3708494c4a6660692a82fdbbb66e9cd1750138d7ba",
+      "contentHash": "2f75380a8bf19777fb1e44a1d80a728c7b0747ba06c266fcc4f5f3887afdd251",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1408,7 +1408,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "1e520c520a556c9ab100f5c4588b87a96cde8c1194b03cc4f830df615a98f6c1",
+      "contentHash": "699f34ca3364384b00a722407aa728d529dc869c2c4947200fed5753a3b52a3e",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1440,7 +1440,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "7dc6b7215d2641378a4f60ba558c620d706dec2a1dcff75bb2998385a13cfa54",
+      "contentHash": "1ed5a98c9249d4a4ba3a855794f72165bb32f9f94273b95aa332225ec80d0c2a",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {
@@ -1472,7 +1472,7 @@
       "type": "subsystem",
       "domain": "communication",
       "sourcePath": "src/lifeline/TelegramLifeline.ts",
-      "contentHash": "fc5eac2df08d939b8421eed28ceff53d64be1a9006f2ca1a5bac075e30aecef0",
+      "contentHash": "929f5d73988708cda922e1c8a3f2229524872ff88d9d8d5dda891dc1fbbd2b24",
       "since": "2025-01-01"
     },
     "subsystem:orphan-process-reaper": {

--- a/tests/unit/BuiltinSkillRegenerator.test.ts
+++ b/tests/unit/BuiltinSkillRegenerator.test.ts
@@ -1,0 +1,207 @@
+/**
+ * PROP-337 v1 — BuiltinSkillRegenerator
+ *
+ * Verifies the fingerprint-based drift / regeneration logic for
+ * built-in SKILL.md templates.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import {
+  regenerateBuiltinSkills,
+  renderBundledSkills,
+} from '../../src/core/BuiltinSkillRegenerator.js';
+
+function sha256(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+function makeTempProject(): { projectDir: string; stateDir: string; cleanup: () => void } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-regen-test-'));
+  const projectDir = path.join(root, 'project');
+  const stateDir = path.join(root, '.instar');
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.mkdirSync(path.join(stateDir, 'state'), { recursive: true });
+  return {
+    projectDir,
+    stateDir,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe('BuiltinSkillRegenerator (PROP-337 v1)', () => {
+  let tmp: ReturnType<typeof makeTempProject>;
+  const PORT = 4321;
+
+  beforeEach(() => {
+    tmp = makeTempProject();
+  });
+
+  afterEach(() => {
+    tmp.cleanup();
+  });
+
+  it('renderBundledSkills produces non-empty SKILL.md for known builtins', () => {
+    const rendered = renderBundledSkills(PORT);
+    // We don't enumerate every slug — just spot-check the headline ones
+    // PROP-337 mentions are at risk of stale upgrades.
+    expect(Object.keys(rendered).length).toBeGreaterThan(0);
+    expect(rendered.evolve).toBeDefined();
+    expect(rendered.evolve).toContain('# /evolve');
+    expect(rendered.learn).toContain('# /learn');
+  });
+
+  it('installs missing skills and seeds fingerprints', () => {
+    const result = regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some(s => s.includes('skills/evolve/SKILL.md'))).toBe(true);
+
+    const fp = JSON.parse(
+      fs.readFileSync(path.join(tmp.stateDir, 'state', 'builtin-skill-fingerprints.json'), 'utf-8'),
+    );
+    expect(fp.skills.evolve).toBeDefined();
+    expect(fp.skills.evolve.contentHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('is idempotent — second run reports all in-sync', () => {
+    regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+    });
+    const second = regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+    });
+
+    expect(second.errors).toEqual([]);
+    expect(second.upgraded).toEqual([]);
+    expect(second.skipped.some(s => s.includes('in sync'))).toBe(true);
+  });
+
+  it('regenerates when bundled template differs from on-disk AND on-disk matches fingerprint', () => {
+    // Seed: install everything, then mutate one skill's fingerprint to
+    // claim it was previously a DIFFERENT version. This simulates the
+    // upgrade case: the package shipped a new version of the inline
+    // template, the user never customized it, and we should overwrite.
+    regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+    });
+
+    const skillPath = path.join(tmp.projectDir, '.claude', 'skills', 'evolve', 'SKILL.md');
+    const stalePrior = '# /evolve\n\n[old version of template]\n';
+    fs.writeFileSync(skillPath, stalePrior);
+
+    // Update the fingerprint to point at the stale-prior content. This
+    // is the state we'd be in mid-upgrade: previous package wrote
+    // stalePrior, we recorded its hash, then user upgraded and the
+    // bundled template is now different.
+    const fpPath = path.join(tmp.stateDir, 'state', 'builtin-skill-fingerprints.json');
+    const fp = JSON.parse(fs.readFileSync(fpPath, 'utf-8'));
+    fp.skills.evolve = {
+      contentHash: sha256(stalePrior),
+      observedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(fpPath, JSON.stringify(fp));
+
+    const result = regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+    });
+
+    expect(result.errors).toEqual([]);
+    const regenerated = result.upgraded.find(s => s.includes('skills/evolve/SKILL.md'));
+    expect(regenerated).toBeDefined();
+    expect(regenerated).toContain('regenerated from upgraded template');
+
+    const after = fs.readFileSync(skillPath, 'utf-8');
+    expect(after).not.toBe(stalePrior);
+    expect(after).toContain('Propose an evolution improvement');
+  });
+
+  it('preserves user customizations (on-disk diverges from fingerprint)', () => {
+    // Seed: install everything (this records fingerprints).
+    regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+    });
+
+    const skillPath = path.join(tmp.projectDir, '.claude', 'skills', 'evolve', 'SKILL.md');
+    const userCustom = fs.readFileSync(skillPath, 'utf-8') + '\n\n## My Custom Section\n\nUser edits.\n';
+    fs.writeFileSync(skillPath, userCustom);
+
+    // Run again — the fingerprint reflects the original install hash,
+    // not the user's edited hash, so this should be classified as
+    // "user-modified" and preserved.
+    const result = regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+    });
+
+    expect(result.errors).toEqual([]);
+    const skipped = result.skipped.find(s => s.includes('skills/evolve/SKILL.md'));
+    expect(skipped).toBeDefined();
+    expect(skipped).toContain('user-modified');
+
+    const after = fs.readFileSync(skillPath, 'utf-8');
+    expect(after).toBe(userCustom);
+  });
+
+  it('seeds fingerprint on first observe of a pre-existing user-modified file', () => {
+    // Pre-existing skill that PROP-337 has never seen — write it
+    // BEFORE running the regenerator and DO NOT seed any fingerprints.
+    const skillDir = path.join(tmp.projectDir, '.claude', 'skills', 'evolve');
+    fs.mkdirSync(skillDir, { recursive: true });
+    const customContent = '# /evolve\n\nMy custom evolve before regen ever ran.\n';
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), customContent);
+
+    const result = regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+    });
+
+    expect(result.errors).toEqual([]);
+    const skipped = result.skipped.find(s => s.includes('skills/evolve/SKILL.md'));
+    expect(skipped).toContain('user-modified');
+
+    // Fingerprint should now reflect the on-disk hash so future
+    // upgrades can distinguish "user edited again" from "user never
+    // touched it since now".
+    const fp = JSON.parse(
+      fs.readFileSync(path.join(tmp.stateDir, 'state', 'builtin-skill-fingerprints.json'), 'utf-8'),
+    );
+    expect(fp.skills.evolve.contentHash).toBe(sha256(customContent));
+  });
+
+  it('apply=false leaves the disk untouched (dry run)', () => {
+    const skillPath = path.join(tmp.projectDir, '.claude', 'skills', 'evolve', 'SKILL.md');
+    expect(fs.existsSync(skillPath)).toBe(false);
+
+    const result = regenerateBuiltinSkills({
+      projectDir: tmp.projectDir,
+      stateDir: tmp.stateDir,
+      port: PORT,
+      apply: false,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some(s => s.includes('would install'))).toBe(true);
+    expect(fs.existsSync(skillPath)).toBe(false);
+    expect(fs.existsSync(path.join(tmp.stateDir, 'state', 'builtin-skill-fingerprints.json'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes Portal-tracked **PROP-337** — chronic for 21 cycles. The non-destructive `migrateBuiltinSkills` only writes SKILL.md files that don't already exist; when the inline template in `installBuiltinSkills` is updated in a new release, existing installs never see the new content. The fix lives only in fresh installs, which is exactly the drift gap PROP-337 names.

This adds `BuiltinSkillRegenerator` and a new `migrateBuiltinSkillRegeneration` step in `PostUpdateMigrator` that:

- Renders the bundled template into a tempdir by invoking `installBuiltinSkills` (no refactor of the 1187-line function needed).
- Records the SHA-256 of each installed skill in `.instar/state/builtin-skill-fingerprints.json`.
- On each migrator run, compares on-disk hash against fingerprint+bundled hash:
  - `missing` → install
  - `on-disk == bundled` → in sync (refresh fingerprint)
  - `on-disk == fp` → safe regenerate, update fingerprint
  - `else` → user-customized, preserve, seed fp on first observe
- Custom skills are never enumerated, so they're untouchable.

Hooks already overwrite unconditionally (verified) so they're out of scope for this PROP — the gap was SKILL.md drift only.

## Test plan

- [x] 7 new unit tests cover install, idempotency, regenerate-on-template-bump, preserve-user-customizations, first-observe seeding, and dry-run.
- [x] All 71 existing `PostUpdateMigrator` tests still pass.
- [ ] Pre-push smoke tier passes in CI.
- [ ] Manual verification on next release: existing install picks up an updated bundled SKILL.md without losing user customizations.

## Cross-repo close-out

Portal-side `upstream-prop-watcher` is registered against this branch (commit `33c0c353`, file `src/core/BuiltinSkillRegenerator.ts`). Once this PR merges to `main`, the next `cycle-escalator` run auto-flips PROP-337 to `COMPLETED` in Portal's evolution queue — closing the cross-repo loop the chronic detector kept reopening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)