### PR TITLE
relay: fix wrong /docs/ prefix in threadline-protocol URLs

### DIFF
--- a/src/threadline/relay/ConnectionManager.ts
+++ b/src/threadline/relay/ConnectionManager.ts
@@ -169,7 +169,7 @@ export class ConnectionManager {
         message:
           `Invalid public key — expected raw 32-byte Ed25519, got ${publicKey.length} bytes after base64 decode.` +
           hint +
-          ' See https://instar.sh/docs/reference/threadline-protocol/ for the identity format, or use the threadline-starter-kit npm package.',
+          ' See https://instar.sh/reference/threadline-protocol/ for the identity format, or use the threadline-starter-kit npm package.',
       });
       return false;
     }
@@ -182,7 +182,7 @@ export class ConnectionManager {
         code: RELAY_ERROR_CODES.AUTH_FAILED,
         message:
           `Agent ID does not match public key. Got agentId="${frame.agentId}" but the first 16 bytes of your public key (hex) are "${expectedFingerprint}". ` +
-          'Compute agentId from your publicKey rather than choosing it. See https://instar.sh/docs/reference/threadline-protocol/.',
+          'Compute agentId from your publicKey rather than choosing it. See https://instar.sh/reference/threadline-protocol/.',
       });
       return false;
     }
@@ -219,7 +219,7 @@ export class ConnectionManager {
         message:
           'Signature verification failed. Common causes: (1) signing the wrong nonce — sign the raw UTF-8 bytes of the challenge nonce, not the hex/base64 string; ' +
           '(2) signing with the wrong key — verify your privateKey matches your publicKey; ' +
-          '(3) using a hash before signing — Ed25519 signs the message directly. See https://instar.sh/docs/reference/threadline-protocol/.',
+          '(3) using a hash before signing — Ed25519 signs the message directly. See https://instar.sh/reference/threadline-protocol/.',
       });
       return false;
     }


### PR DESCRIPTION
## Summary

Follow-up to #122. The merged PR baked `https://instar.sh/docs/reference/threadline-protocol/` into the three relay auth-error messages, but Starlight serves the page at `/reference/threadline-protocol/` (no `/docs/` prefix). The page is live at the correct path; the URLs in the error messages were 404ing for anyone who clicked them.

Drops the `/docs/` prefix in all three `ConnectionManager.ts` references.

## Verification

- `curl -sI https://instar.sh/reference/threadline-protocol/` → **HTTP 200** ✓
- `curl -sI https://instar.sh/docs/reference/threadline-protocol/` → HTTP 404 (the bad URL)
- All three URL refs updated (verified via grep).

## Test plan

- [ ] CI passes.
- [ ] After merge: redeploy `site/` is not needed (the page is already live at the correct path).
- [ ] After merge: relay redeploy on fly so the running process emits the corrected URLs (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)