### PR TITLE
chore: rename 0.28.79.md → NEXT.md so publish workflow triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "0.28.79",
+  "version": "0.28.78",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-05T02:58:22.332Z",
-  "instarVersion": "0.28.79",
+  "generatedAt": "2026-05-05T03:10:42.243Z",
+  "instarVersion": "0.28.78",
   "entryCount": 187,
   "entries": {
     "hook:session-start": {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,4 +1,4 @@
-# Upgrade Guide — v0.28.79
+# Upgrade Guide — vNEXT
 
 <!-- bump: patch -->
 


### PR DESCRIPTION
## Summary

PR #125 (1f908bd5) shipped the upgrade notes as the released-format `upgrades/0.28.79.md` instead of the workflow's expected `upgrades/NEXT.md` template, so Publish-to-npm logged "No NEXT.md found — nothing to publish" and skipped. The npm package is still at 0.28.78 even though the code (binding-aware zombie kill + resume-failure fresh-spawn fallback) is on main.

This rename gets the publish workflow to do its bump-and-rename on merge. No behavioural code changes.

## Test plan

- [x] `node scripts/pre-push-gate.js` exits 0
- [x] Publish workflow's check `if [ ! -f "upgrades/NEXT.md" ]` will now find the file with non-template content → workflow proceeds → bumps to 0.28.79 → renames NEXT.md → 0.28.79.md → publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)