### PR TITLE
chore: fix upgrade-notes format so publish workflow passes

### DIFF
--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -33,18 +33,16 @@ that quickly saved a new UUID won't have it wiped.
 - **No more "session appears stopped" after a pause**: When you message your
   agent after stepping away for a while, you'll go straight to a live
   response instead of waiting through a 5-minute presence-proxy warning and
-  having to reply "unstick" or copy-paste your message. The agent's tmux
-  session stays alive while it's bound to your conversation, so your next
-  message reaches it directly without a respawn detour.
+  having to reply "unstick" or copy-paste your message. The agent stays
+  alive while it's bound to your conversation, so your next message reaches
+  it directly without a respawn detour.
 - **Multi-topic agents will hold more memory between conversations**: Each
-  bound session now stays resident for up to 4 hours of pure idle (was 15
-  minutes). On a memory-constrained host with 8+ active conversations, that
-  can mean 2-4 GB of additional resident Claude TUI processes during a
-  long-tail idle window. If that's a problem, override
-  `idlePromptKillMinutesBoundToTopic` in your `.instar/config.json`:
-  ```json
-  { "sessions": { "idlePromptKillMinutesBoundToTopic": 60 } }
-  ```
+  bound agent now stays resident for up to 4 hours of pure idle (was 15
+  minutes). On a memory-constrained host with 8 or more active
+  conversations, that can mean a few extra gigabytes of resident memory
+  during long idle windows. If that's a problem on your machine, ask your
+  agent to lower the bound-session idle threshold for you — it'll handle
+  the change conversationally, no config editing needed.
 
 ## Summary of New Capabilities
 


### PR DESCRIPTION
## Summary

Publish-to-npm workflow run [25355995695](https://github.com/JKHeadley/instar/actions/runs/25355995695) failed with:

> ERROR: Guide for v0.28.79 exists but is malformed:
>   - "What to Tell Your User" contains inline code (\`...\`). Remove code formatting — user-facing language should be plain and conversational.
>   - "What to Tell Your User" contains a fenced code block. This section is for user-facing narrative — move technical examples to "What Changed".

This PR removes both issues from the "What to Tell Your User" section. The config-override example was rephrased into the conversational guidance the checker wants ("ask your agent to lower the threshold for you"). No code change.

Verified locally: `node scripts/check-upgrade-guide.js` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)