### PR TITLE
feat(attention): wire POST /attention through tone-gate authority

### DIFF
--- a/docs/specs/attention-tone-gate-and-stable-id.md
+++ b/docs/specs/attention-tone-gate-and-stable-id.md
@@ -1,0 +1,94 @@
+---
+title: "Wire /attention through the existing tone-gate authority + stable-id skill recipe"
+slug: "attention-tone-gate-and-stable-id"
+author: "echo"
+date: "2026-05-06"
+status: "approved"
+review-iterations: 1
+review-convergence: "converged"
+review-completed-at: "2026-05-06T15:20:00Z"
+approved: true
+approved-by: justin
+approved-date: 2026-05-06
+approval-context: "Telegram topic 8937 — Justin reported an instar agent (Bob) had spammed 7+ duplicate Telegram topics for one recurring 'git conflict auto-resolution' degradation event over 2026-05-02→05-05, said 'NONE of these should have been created. They are noise, and none of the messages in the topics are helpful to the user at all.' On clarifying scope I proposed wiring /attention through the existing tone gate + a stable-id skill recipe fix; Justin reinforced the three requirements (must require user attention/action, must contain everything needed to act, must be plain English) and replied 'please proceed' (2026-05-06 14:55 PT) — explicit approval to ship the change."
+---
+
+# Wire /attention through the existing tone-gate authority + stable-id skill recipe
+
+## 1. Problem
+
+A live instar agent ("Bob") created seven near-duplicate Telegram topics in four days for one recurring "git conflict auto-resolution disabled" degradation event. Each occurrence took the form `Server degraded | Priority: LOW Git conflicts may not auto-r...` — no call to action, jargon-laden category header, no explanation of impact in user-readable terms. The user said: "NONE of these should have been created. They are noise, and none of the messages in the topics are helpful to the user at all."
+
+Two structural causes:
+
+1. **`POST /attention` is the one outbound-message path NOT consulted by the existing `MessagingToneGate`.** Every other channel — `telegram-reply`, `slack-reply`, `whatsapp-send`, `imessage-send` — runs candidates through `checkOutboundMessage` before delivery. `/attention` does not, so attention items reach the user's Telegram as new topics without any quality check. The existing B12 (`HEALTH_ALERT_INTERNALS`), B13 (`HEALTH_ALERT_SUPPRESSED_BY_HEAL`), and B14 (`HEALTH_ALERT_NO_CTA`) rules are perfectly suited to what Justin is asking for — they encode "must contain user-readable info," "must require action (not silently self-healed)," and "must end with a yes/no the user can answer in one word." But they only fire when `messageKind === 'health-alert'`, and `/attention` never invokes the gate at all.
+
+2. **The `guardian-pulse` skill template instructs agents to use `id = "degradation:${FEATURE}:${TIMESTAMP}"` when posting to `/attention`.** The timestamp varies per detection, so even with a stable `feature`, repeated detections of the same feature produce distinct IDs and bypass the existing strict-id dedup in `createAttentionItem`. Each pulse spawns a new topic.
+
+## 2. Scope
+
+In scope:
+
+- **§3.** Extend `checkOutboundMessage` to accept an optional `messageKind` and an optional `jargon` flag (no behavior change for existing callers).
+- **§4.** Wire `POST /attention` through `checkOutboundMessage`. For health-class categories (`degradation`, `health`, `health-alert`, `alert`), invoke with `messageKind: 'health-alert'` and populate the jargon signal so B12/B13/B14 can fire. For other categories, invoke with `messageKind: 'reply'` so the standard ruleset (B1–B7, B11) still applies.
+- **§5.** Fix the `guardian-pulse` skill template to use a stable id `degradation:${FEATURE}` with no timestamp suffix. Add an explanatory note about WHY the id omits the timestamp so future maintainers don't accidentally reintroduce it.
+- **§6.** Tests: a focused unit test of `POST /attention` exercising pass / block / non-health / alias paths, plus a regression test on the rendered skill template content.
+
+Out of scope (explicitly):
+
+- The broader `MessageDispatch` boundary refactor proposed in `docs/specs/memory-rot-gates.md`. That refactor will route every outbound path through one module — including `createAttentionItem`'s direct Telegram send and the other ungated paths. This change does NOT preempt that refactor: the new `checkOutboundMessage` call site at the route handler is exactly where `MessageDispatch.send()` would later sit when the refactor lands.
+- A "fuzzy feature dedup" for `/attention` (matching on `(category, feature)` when callers use unstable IDs). Defer until we see whether the tone-gate authority alone closes the visible spam — the user's primary complaint is message quality, not topic count, and the tone gate addresses both at once.
+- Cleanup of Bob's existing seven topics. Those persist on the user's Telegram; cheapest cleanup is `/done` per topic from Bob's side. Out of scope for this PR.
+- Self-heal signal lookup at the route handler. The existing `DegradationReporter.gateHealthAlert` populates `selfHeal` from its own internal state; surfacing that to `/attention` callers requires either a new lookup API or pushing the signal into the POST body as a new optional field. Defer until we have a concrete need — B14 (no CTA) alone catches Bob's observed spam.
+
+## 3. Change to `checkOutboundMessage`
+
+Add two optional fields to the options bag:
+
+- `messageKind?: 'reply' | 'health-alert' | 'unknown'` — passed through to `MessagingToneGate.review` unchanged. Defaults to undefined; the gate already defaults to `'reply'`.
+- `jargon?: boolean` — when true, the helper invokes `detectJargon(text)` and attaches the result as `signals.jargon`. This matches the existing pattern in `DegradationReporter.gateHealthAlert`. The default is false to keep prompts focused for non-health calls.
+
+Both fields are additive. All existing call sites continue to work without modification.
+
+## 4. Wiring at `POST /attention`
+
+The route currently delegates straight to `ctx.telegram.createAttentionItem`. Insert a `checkOutboundMessage` call between input validation and `createAttentionItem`:
+
+- Build the candidate string from `[title, summary, description].filter(present).join('\n\n')` — this matches the user-visible body that `createAttentionItem` will format into the topic's first message.
+- Determine `isHealthAlert` via case-insensitive exact match on category against `degradation|health|health-alert|alert`.
+- Call `checkOutboundMessage(candidate, 'telegram', res, { messageKind: isHealthAlert ? 'health-alert' : 'reply', jargon: isHealthAlert })`.
+- If the gate blocks, return immediately — `checkOutboundMessage` already wrote the 422 response. `createAttentionItem` is not invoked, so no topic gets spawned and no item gets persisted.
+
+The 422 response shape is identical to the one telegram-reply / slack-reply / etc. already return; any caller that already handles tone-gate-blocked responses will handle this transparently.
+
+## 5. Skill recipe fix
+
+In `src/commands/init.ts` within the `guardian-pulse` skill template, change the POST body from `{"id": "degradation:${FEATURE}:${TIMESTAMP}", ...}` to `{"id": "degradation:${FEATURE}", ...}`. Add a short paragraph below the example explaining that the id deliberately omits the timestamp so repeated detections collapse onto the existing item.
+
+`migrateBuiltinSkills` is non-destructive — it only writes `SKILL.md` files that don't already exist. So agents installed before this change will keep the timestamped id until they reinstall the skill or accept a destructive migration. The tone gate at `/attention` is the primary defense and works regardless of skill version.
+
+## 6. Tests
+
+- `tests/unit/attention-route-tone-gate.test.ts` — four cases:
+  1. category=degradation + valid candidate → 201, gate invoked with `messageKind='health-alert'`, jargon signal populated.
+  2. category=degradation + no-CTA candidate → 422 with `rule=B14_HEALTH_ALERT_NO_CTA`, `createAttentionItem` not invoked.
+  3. category=general → gate invoked with `messageKind='reply'`, no jargon signal.
+  4. category=health → treated as health-alert (alias coverage).
+- `tests/unit/guardian-pulse-skill-stable-id.test.ts` — runs `installBuiltinSkills` to a temp dir, reads the rendered `guardian-pulse/SKILL.md`, asserts the timestamp suffix is gone and the stable form is present. This guards against accidental reintroduction of the timestamp.
+
+## 7. Signal vs authority compliance
+
+This change is fully compliant with `docs/signal-vs-authority.md`:
+
+- The category regex is a routing hint that toggles which ruleset the existing authority considers. It is not a blocker — the gate decides.
+- `JargonDetector.detectJargon` is documented signal-only and is consumed via `signals.jargon`, never used as an independent block.
+- The only blocking decision in the new code path is `MessagingToneGate.review` — the existing single authority for outbound user-facing messages.
+- No new authority is introduced. No brittle logic is given block power.
+
+## 8. Rollback
+
+Pure code revert. No data migration. `attention-items.json` schema unchanged. Existing skill installations continue to work whether the recipe is the old or new form. The tone gate fail-opens on LLM error, so production never sees a hard outage from this change.
+
+## 9. Convergence note
+
+Single-iteration internal convergence — proportional to the change size (~30 lines of code, defensive extension of an already-converged authority). The independent second-pass review by a separate reviewer agent (recorded in `upgrades/side-effects/attention-tone-gate-and-stable-id.md` § "Second-pass review") concurred without raising blocking concerns. Two minor observations (in-memory dedup volatility across restarts; no per-thread context fed to gate) were inspected and accepted: the first is mitigated by existing `attention-items.json` persistence, the second is correct-by-design (attention items create new topics, no prior thread context applies).

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2287,13 +2287,15 @@ Two parts: pipeline health AND active consumption.
 UNREPORTED=$(curl -s -H "Authorization: Bearer $AUTH" http://localhost:\${INSTAR_PORT:-${port}}/health/degradations | jq -c '.events[] | select(.reported == false)')
 \\\`\\\`\\\`
 
-For each unreported event, surface it to the attention queue using a stable id (so re-runs are idempotent):
+For each unreported event, surface it to the attention queue using a stable id (one feature = one topic, even across days):
 
 \\\`\\\`\\\`
 curl -X POST -H "Authorization: Bearer $AUTH" -H 'Content-Type: application/json' \\\\
   http://localhost:\${INSTAR_PORT:-${port}}/attention \\\\
-  -d "{\\"id\\": \\"degradation:\${FEATURE}:\${TIMESTAMP}\\", \\"title\\": \\"Degradation: \${FEATURE}\\", \\"summary\\": \\"\${NARRATIVE}\\", \\"category\\": \\"degradation\\", \\"priority\\": \\"NORMAL\\"}"
+  -d "{\\"id\\": \\"degradation:\${FEATURE}\\", \\"title\\": \\"Degradation: \${FEATURE}\\", \\"summary\\": \\"\${NARRATIVE}\\", \\"category\\": \\"degradation\\", \\"priority\\": \\"NORMAL\\"}"
 \\\`\\\`\\\`
+
+The id deliberately omits a timestamp so repeated detections of the same feature collapse onto the existing attention item rather than spawning a new Telegram topic each pulse. (The attention endpoint also runs the message through the outbound tone gate as a health-alert, so jargon-heavy or no-call-to-action candidates are rejected before any topic gets created.)
 
 Then close the loop so next pulse doesn't re-surface the same event:
 

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-05T03:10:42.243Z",
-  "instarVersion": "0.28.78",
+  "generatedAt": "2026-05-06T16:49:59.688Z",
+  "instarVersion": "0.28.81",
   "entryCount": 187,
   "entries": {
     "hook:session-start": {
@@ -384,7 +384,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -720,7 +720,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -736,7 +736,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e05554b595d6a0b067ce8fa659f0cc2948c9428ad412163b5c13ae5e9e378337",
+      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
       "since": "2025-01-01"
     },
     "cli:init": {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -173,6 +173,7 @@ import type { InstructionsVerifier } from '../monitoring/InstructionsVerifier.js
 import type { CoherenceGate } from '../core/CoherenceGate.js';
 import type { MessagingToneGate } from '../core/MessagingToneGate.js';
 import { isJunkPayload } from '../core/junk-payload.js';
+import { detectJargon } from '../core/JargonDetector.js';
 import type { PasteManager } from '../paste/PasteManager.js';
 import type { WebSocketManager } from './WebSocketManager.js';
 import { TruncationDetector } from '../paste/TruncationDetector.js';
@@ -729,6 +730,8 @@ export function createRoutes(ctx: RouteContext): Router {
       topicId?: number;
       allowDebugText?: boolean;
       allowDuplicate?: boolean;
+      messageKind?: 'reply' | 'health-alert' | 'unknown';
+      jargon?: boolean;
     },
   ): Promise<boolean> {
     if (!ctx.messagingToneGate) return false; // No authority configured — pass through
@@ -743,6 +746,15 @@ export function createRoutes(ctx: RouteContext): Router {
           detected: junkResult.junk,
           reason: junkResult.reason,
         };
+      }
+
+      if (options.jargon) {
+        try {
+          const j = detectJargon(text);
+          signals.jargon = { detected: j.detected, terms: j.terms, score: j.score };
+        } catch {
+          // Detector errors never override the authority — skip the signal.
+        }
       }
 
       // Recent conversation — used by both the authority and the dedup detector.
@@ -782,6 +794,7 @@ export function createRoutes(ctx: RouteContext): Router {
         recentMessages,
         signals,
         targetStyle: ctx.config.messagingStyle,
+        messageKind: options.messageKind,
       });
 
       // Structured observability: log every decision the authority made. This is
@@ -5142,6 +5155,24 @@ export function createRoutes(ctx: RouteContext): Router {
     }
     if (priority !== undefined && !['URGENT', 'HIGH', 'NORMAL', 'LOW'].includes(priority)) {
       res.status(400).json({ error: '"priority" must be one of: URGENT, HIGH, NORMAL, LOW' });
+      return;
+    }
+
+    // Attention items reach the user as a new Telegram topic with the title,
+    // summary, and (optional) description as the body. Run that user-facing
+    // candidate through the outbound-message authority before creating the
+    // topic. For health-class categories ("degradation", "health"), invoke
+    // the health-alert ruleset (B12/B13/B14) so jargon-laden, no-CTA, and
+    // self-healed-event messages get suppressed instead of spawning topics.
+    const isHealthAlert = typeof category === 'string' && /^(degradation|health|health-alert|alert)$/i.test(category);
+    const candidate = [title, summary, description].filter((s): s is string => typeof s === 'string' && s.length > 0).join('\n\n');
+    const blocked = await checkOutboundMessage(candidate, 'telegram', res, {
+      messageKind: isHealthAlert ? 'health-alert' : 'reply',
+      jargon: isHealthAlert,
+      // No topicId — attention items create new topics; no prior thread context applies.
+    });
+    if (blocked) {
+      // checkOutboundMessage already wrote the 422 response.
       return;
     }
 

--- a/tests/unit/attention-route-tone-gate.test.ts
+++ b/tests/unit/attention-route-tone-gate.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Server-side test for POST /attention — verifies that:
+ *
+ *   1. Candidate attention items run through MessagingToneGate before any
+ *      Telegram topic gets created.
+ *   2. For category=degradation (and other health-class categories), the
+ *      gate is invoked with messageKind="health-alert" so the B12/B13/B14
+ *      ruleset fires.
+ *   3. When the gate blocks, the route returns 422 and createAttentionItem
+ *      is NOT called (no topic spawned, item not persisted).
+ *   4. When the gate passes, the item is created normally (201).
+ *   5. For non-health categories, messageKind defaults to "reply" — the
+ *      health-alert rules do not apply.
+ *
+ * Regression context: agents using POST /attention were spawning new Telegram
+ * topics for every recurring degradation event because /attention was the one
+ * outbound path NOT wired through the existing tone-gate authority.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import { createRoutes } from '../../src/server/routes.js';
+import { MessagingToneGate, type ToneReviewContext } from '../../src/core/MessagingToneGate.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+interface TestServer { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => srv.close(() => r())),
+      });
+    });
+  });
+}
+
+interface AttentionItemStub {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  priority: 'URGENT' | 'HIGH' | 'NORMAL' | 'LOW';
+  status: 'OPEN' | 'ACKNOWLEDGED' | 'IN_PROGRESS' | 'DONE' | 'WONT_DO';
+  description?: string;
+  sourceContext?: string;
+  createdAt: string;
+  updatedAt: string;
+  topicId?: number;
+}
+
+function buildApp(opts: {
+  toneGate: MessagingToneGate;
+  recordedCalls: ToneReviewContext[];
+  createAttention: (item: Omit<AttentionItemStub, 'createdAt' | 'updatedAt' | 'status'>) => Promise<AttentionItemStub>;
+  createAttentionCalls: { count: number };
+}): express.Express {
+  const app = express();
+  app.use(express.json());
+
+  // Wrap review() so we can record contexts the route passes in. The wrapping
+  // preserves the gate's pass/block decision (driven by the mocked provider).
+  const originalReview = opts.toneGate.review.bind(opts.toneGate);
+  opts.toneGate.review = async (text: string, context: ToneReviewContext) => {
+    opts.recordedCalls.push(context);
+    return originalReview(text, context);
+  };
+
+  const ctx: any = {
+    config: { authToken: 'test', stateDir: '/tmp', port: 0 },
+    messagingToneGate: opts.toneGate,
+    telegram: {
+      createAttentionItem: async (item: Omit<AttentionItemStub, 'createdAt' | 'updatedAt' | 'status'>) => {
+        opts.createAttentionCalls.count += 1;
+        return opts.createAttention(item);
+      },
+      // Other adapter methods aren't touched by the POST /attention path under test.
+    },
+    // All other ctx fields default to undefined; route only touches the above.
+  };
+
+  const router = createRoutes(ctx);
+  app.use(router);
+  return app;
+}
+
+function makeProvider(response: { pass: boolean; rule: string; issue: string; suggestion: string }): IntelligenceProvider {
+  return {
+    evaluate: vi.fn(async () => JSON.stringify(response)),
+  } as unknown as IntelligenceProvider;
+}
+
+describe('POST /attention — tone-gate wiring', () => {
+  let server: TestServer;
+  let recordedCalls: ToneReviewContext[];
+  let createAttentionCalls: { count: number };
+
+  async function api(path: string, body: object) {
+    const res = await fetch(server.url + path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const responseBody = await res.json().catch(() => ({}));
+    return { status: res.status, body: responseBody };
+  }
+
+  beforeEach(() => {
+    recordedCalls = [];
+    createAttentionCalls = { count: 0 };
+  });
+
+  afterEach(async () => {
+    await server?.close();
+  });
+
+  it('passes a valid candidate through the gate, creates the item (201), and uses messageKind=health-alert for category=degradation', async () => {
+    const provider = makeProvider({ pass: true, rule: '', issue: '', suggestion: '' });
+    const toneGate = new MessagingToneGate(provider);
+
+    const stubItem: AttentionItemStub = {
+      id: 'degradation:git-conflict',
+      title: 'Degradation: git-conflict',
+      summary: 'A git conflict could not auto-resolve. Want me to dig in?',
+      category: 'degradation',
+      priority: 'NORMAL',
+      status: 'OPEN',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      topicId: 42,
+    };
+
+    server = await listen(
+      buildApp({
+        toneGate,
+        recordedCalls,
+        createAttention: async () => stubItem,
+        createAttentionCalls,
+      }),
+    );
+
+    const r = await api('/attention', {
+      id: 'degradation:git-conflict',
+      title: 'Degradation: git-conflict',
+      summary: 'A git conflict could not auto-resolve. Want me to dig in?',
+      category: 'degradation',
+      priority: 'NORMAL',
+    });
+
+    expect(r.status).toBe(201);
+    expect(r.body.id).toBe('degradation:git-conflict');
+    expect(createAttentionCalls.count).toBe(1);
+    // The route consulted the gate exactly once.
+    expect(recordedCalls.length).toBe(1);
+    expect(recordedCalls[0].messageKind).toBe('health-alert');
+    // Jargon signal must be populated for health-alert kinds (so B12 has evidence).
+    expect(recordedCalls[0].signals?.jargon).toBeDefined();
+  });
+
+  it('returns 422 and does not create the item when the gate blocks (no-CTA health alert → B14)', async () => {
+    const provider = makeProvider({
+      pass: false,
+      rule: 'B14_HEALTH_ALERT_NO_CTA',
+      issue: 'Health-alert candidate does not end with a yes/no question',
+      suggestion: 'Add a closing yes/no question the user can answer in one word',
+    });
+    const toneGate = new MessagingToneGate(provider);
+
+    server = await listen(
+      buildApp({
+        toneGate,
+        recordedCalls,
+        createAttention: async () => {
+          throw new Error('createAttentionItem must not be invoked when the gate blocks');
+        },
+        createAttentionCalls,
+      }),
+    );
+
+    const r = await api('/attention', {
+      id: 'degradation:server-degraded',
+      title: 'Server degraded',
+      summary: 'Git conflict auto-resolution disabled. Priority: LOW',
+      category: 'degradation',
+      priority: 'LOW',
+    });
+
+    expect(r.status).toBe(422);
+    expect(r.body.error).toBe('tone-gate-blocked');
+    expect(r.body.rule).toBe('B14_HEALTH_ALERT_NO_CTA');
+    expect(createAttentionCalls.count).toBe(0);
+    expect(recordedCalls[0].messageKind).toBe('health-alert');
+  });
+
+  it('uses messageKind=reply for non-health categories (general, etc.)', async () => {
+    const provider = makeProvider({ pass: true, rule: '', issue: '', suggestion: '' });
+    const toneGate = new MessagingToneGate(provider);
+
+    const stubItem: AttentionItemStub = {
+      id: 'review:pr-42',
+      title: 'PR ready for review',
+      summary: 'I opened a PR; want me to walk you through the changes?',
+      category: 'general',
+      priority: 'NORMAL',
+      status: 'OPEN',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      topicId: 99,
+    };
+
+    server = await listen(
+      buildApp({
+        toneGate,
+        recordedCalls,
+        createAttention: async () => stubItem,
+        createAttentionCalls,
+      }),
+    );
+
+    const r = await api('/attention', {
+      id: 'review:pr-42',
+      title: 'PR ready for review',
+      summary: 'I opened a PR; want me to walk you through the changes?',
+      category: 'general',
+      priority: 'NORMAL',
+    });
+
+    expect(r.status).toBe(201);
+    expect(recordedCalls[0].messageKind).toBe('reply');
+    // No jargon signal for non-health-alert kinds — keep the prompt focused
+    // on the rules that actually apply.
+    expect(recordedCalls[0].signals?.jargon).toBeUndefined();
+  });
+
+  it('treats "health" and "alert" categories as health-alert too (alias coverage)', async () => {
+    const provider = makeProvider({ pass: true, rule: '', issue: '', suggestion: '' });
+    const toneGate = new MessagingToneGate(provider);
+
+    const stubItem: AttentionItemStub = {
+      id: 'health:rss',
+      title: 'Memory pressure',
+      summary: 'Memory pressure looks high. Want me to investigate?',
+      category: 'health',
+      priority: 'NORMAL',
+      status: 'OPEN',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      topicId: 100,
+    };
+
+    server = await listen(
+      buildApp({
+        toneGate,
+        recordedCalls,
+        createAttention: async () => stubItem,
+        createAttentionCalls,
+      }),
+    );
+
+    await api('/attention', {
+      id: 'health:rss',
+      title: 'Memory pressure',
+      summary: 'Memory pressure looks high. Want me to investigate?',
+      category: 'health',
+      priority: 'NORMAL',
+    });
+
+    expect(recordedCalls[0].messageKind).toBe('health-alert');
+  });
+});

--- a/tests/unit/guardian-pulse-skill-stable-id.test.ts
+++ b/tests/unit/guardian-pulse-skill-stable-id.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression test for the guardian-pulse skill recipe.
+ *
+ * The recipe was previously instructing agents to surface degradations to
+ * the attention queue with id = "degradation:{FEATURE}:{TIMESTAMP}". The
+ * timestamp made the id unique per detection time, so each pulse spawned a
+ * new Telegram topic for the SAME recurring feature — exactly the noise
+ * pattern that prompted this fix.
+ *
+ * The recipe must use a stable id that collapses repeated detections of the
+ * same feature onto the same attention item: "degradation:{FEATURE}".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { installBuiltinSkills } from '../../src/commands/init.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('guardian-pulse skill — attention-id is stable per feature', () => {
+  let tmpDir: string;
+  let skillsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guardian-pulse-id-'));
+    skillsDir = path.join(tmpDir, 'skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/guardian-pulse-skill-stable-id.test.ts:cleanup' });
+  });
+
+  it('omits the per-detection timestamp from the attention id', () => {
+    installBuiltinSkills(skillsDir, 4242);
+    const skillFile = path.join(skillsDir, 'guardian-pulse', 'SKILL.md');
+    expect(fs.existsSync(skillFile)).toBe(true);
+
+    const content = fs.readFileSync(skillFile, 'utf8');
+
+    // Negative assertion — the timestamp-suffixed id must be gone. If this
+    // ever regresses, the tone-gate at /attention is the only thing keeping
+    // an agent from spamming N topics for one recurring issue.
+    expect(content).not.toMatch(/degradation:\$\{FEATURE\}:\$\{TIMESTAMP\}/);
+
+    // Positive assertion — the recipe instructs a stable id.
+    expect(content).toMatch(/degradation:\$\{FEATURE\}/);
+  });
+});

--- a/upgrades/side-effects/attention-tone-gate-and-stable-id.md
+++ b/upgrades/side-effects/attention-tone-gate-and-stable-id.md
@@ -1,0 +1,162 @@
+# Side-Effects Review — Attention queue tone-gate wiring + guardian-pulse stable id
+
+**Version / slug:** `attention-tone-gate-and-stable-id`
+**Date:** `2026-05-06`
+**Author:** `echo`
+**Second-pass reviewer:** `pending — required (touches outbound-message block/allow surface)`
+
+## Summary of the change
+
+A user-reported bug: an instar agent ("Bob") created 7+ near-duplicate Telegram topics for the same recurring "git conflict auto-resolution" degradation event over Sat–Tue. Two layered fixes:
+
+1. **Wire `POST /attention` through the existing `MessagingToneGate` authority.** Until now, `/attention` was the only outbound-message path that did NOT consult the gate — every other channel (telegram-reply, slack-reply, whatsapp, imessage) goes through `checkOutboundMessage`. Attention items reach the user as new Telegram topics with the title + summary as the body, so they are absolutely outbound user-facing messages and must pass the same authority. For `category=degradation|health|alert|health-alert` the route invokes the gate with `messageKind: 'health-alert'`, firing the existing B12 (jargon-laden internals), B13 (suppressed-by-self-heal), and B14 (no call-to-action) ruleset. For other categories the gate runs with `messageKind: 'reply'` — the standard ruleset still applies (B1–B7 prevent CLI/path/code leakage; B11 enforces target-style). When the gate blocks, the route returns 422 with the same shape `checkOutboundMessage` already returns elsewhere; `createAttentionItem` is not invoked, so no Telegram topic gets spawned.
+
+2. **Skill recipe fix in `src/commands/init.ts`.** The `guardian-pulse` skill template instructed agents to POST attention items with `id = "degradation:${FEATURE}:${TIMESTAMP}"`. The timestamp made the id unique per detection, so each pulse spawned a new topic for the SAME recurring feature. Changed to `id = "degradation:${FEATURE}"` so repeated detections collapse onto the existing attention item via `createAttentionItem`'s strict-id check.
+
+Files touched:
+
+- `src/server/routes.ts` — `checkOutboundMessage` accepts new `messageKind` + `jargon` options; `POST /attention` invokes it; `JargonDetector` import added.
+- `src/commands/init.ts` — guardian-pulse skill template id changed to stable form; explanatory note added.
+- `tests/unit/attention-route-tone-gate.test.ts` — new (4 tests): pass/block/non-health/alias coverage for `/attention` POST.
+- `tests/unit/guardian-pulse-skill-stable-id.test.ts` — new (1 test): regression guard against the timestamp suffix returning.
+
+## Decision-point inventory
+
+- `POST /attention` route handler (src/server/routes.ts) — **modify** — adds an outbound-message authority call before `createAttentionItem` so the existing tone-gate block/allow decision now applies to attention-queue topic creation.
+- `checkOutboundMessage` helper (src/server/routes.ts) — **modify** — accepts `messageKind` + `jargon` options. Pass-through to existing `MessagingToneGate.review`, which is already an authority. No new decision power introduced — only a new entry point feeding the same authority.
+- `installBuiltinSkills` → guardian-pulse template (src/commands/init.ts) — **modify** — changes the static instruction string the recipe gives agents. No runtime decision logic.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The gate is the existing `MessagingToneGate`; its over-block surface is unchanged. The new entry point preserves the gate's "favor false-negatives over false-positives" disposition — when a candidate is borderline, the gate passes. Specific scenarios examined:
+
+- **A genuinely actionable health-alert with a yes/no question and no jargon.** Passes — B12/B13/B14 all require concrete failure conditions to fire.
+- **A non-health attention item that contains a literal path or CLI command.** B1/B2/B5 fire as they would on any other route — this is the intended behavior, not over-block.
+- **An attention item whose summary mentions a feature name that overlaps a jargon term** (e.g., title = "Cron job stuck" with `category=general`). `messageKind` defaults to `reply` for non-health categories, so the jargon signal isn't even gathered — the health-alert ruleset doesn't fire. No over-block.
+- **A deliberately verbose health-alert summary including a yes/no CTA**. Passes B14; `description` text is appended to the candidate so longer descriptions don't accidentally bury the CTA below the body the gate sees.
+
+The candidate text the gate sees is `[title, summary, description]` joined with double newlines — this matches the user-visible body Telegram will post on topic creation. No legitimate-input pathway is rejected here that would not be rejected on `telegram-reply`.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **An agent that posts a long descriptive title that ITSELF is the jargon vehicle.** The gate sees the title; no special-casing required.
+- **An agent that bypasses `/attention` entirely and calls `TelegramAdapter.createForumTopic` directly.** This was never gated and remains ungated — out of scope for this change. The Memory Rot Gates spec proposes a `MessageDispatch` boundary refactor that would close every direct call site; this fix is a targeted band-aid for the noisiest known path until that lands.
+- **A genuinely new degradation event for a previously-known feature.** The skill recipe now produces the same id, so the second detection silently no-ops — the user does NOT get notified about the recurrence. Trade-off: chosen deliberately. The user's complaint was "none of these should have been created"; quiet recurrence is preferable to a new topic per recurrence. If recurrences need re-surfacing, that's a follow-up via an explicit `lastSeenAt` / occurrence counter on `AttentionItem` and an "append to existing topic" branch — not this fix.
+- **`/attention` calls that supply `category` in mixed case or with whitespace.** The regex normalization is `^(degradation|health|health-alert|alert)$/i` — exact match (case-insensitive). Trailing whitespace, plurals, or aliases like "system-health" would default to `messageKind=reply`. Acceptable: the gate still runs the standard ruleset; only the health-alert-specific rules are skipped. If callers consistently use a non-matching alias we'll see it in the tone-gate-decision log and can extend the regex.
+- **The gate fail-opens on LLM error/timeout.** Inherited from the existing gate behavior — not a regression. Fail-open is the existing system-wide policy and is documented in `MessagingToneGate.ts`.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The fix is at the route-handler layer where every other outbound-message gate already sits. The `MessagingToneGate` is the single existing authority for "should this user-facing text be sent" — feeding `/attention` into it is the layer-correct move. The alternative — putting the gate inside `TelegramAdapter.createAttentionItem` — would be lower-level, but `createAttentionItem` doesn't know about `messageKind` semantics or how to format a 422 response shape, and other adapters (Slack, WhatsApp) would need the same wiring. Doing it at the route handler keeps the authority single-locus.
+
+The skill template fix is a documentation-layer change (the skill is a markdown recipe rendered to disk; agents read it). It belongs in `src/commands/init.ts` where the rest of the skill content already lives.
+
+The fix does NOT preempt the planned `MessageDispatch` refactor in the Memory Rot Gates spec (`docs/specs/memory-rot-gates.md`) — that refactor would route ALL outbound message paths through one module, including `createAttentionItem` and the other direct-send paths. This fix is a route-level wiring that the future refactor will subsume cleanly: `MessageDispatch` will absorb the `checkOutboundMessage` call site without behavior change.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The brittle pieces here are:
+1. The `category ∈ {degradation, health, alert, health-alert}` regex that decides whether to invoke `messageKind='health-alert'`. This is a routing hint, not a block decision — it just toggles which ruleset the gate considers. The gate is the only thing with blocking power.
+2. The `JargonDetector.detectJargon` call. `JargonDetector.ts` opens with "SIGNAL ONLY. This detector produces evidence; it does not block." Already-compliant; we're using it as designed — the detector populates `signals.jargon` and the gate decides.
+
+Both pieces feed the existing `MessagingToneGate` as a SIGNAL. No new brittle authority is introduced. The 422 response that the route returns is sourced from `MessagingToneGate.review(...).pass === false` — i.e., the existing authority's decision, not a new one.
+
+The skill recipe fix is a string change in a template — it has no decision logic at all and trivially complies.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** The new gate call runs BEFORE `createAttentionItem`. `createAttentionItem` already has a strict-id dedup (line 2845-2847) — that dedup is preserved unchanged. The two layer correctly: gate decides if the message is appropriate for the user; dedup decides if a same-id item is already known. They do not shadow each other.
+- **Double-fire:** The gate is invoked on `/attention` POST and on the four direct messaging routes (telegram-reply, slack-reply, whatsapp, imessage). An attention item that gets created produces a Telegram message via `TelegramAdapter` internals — that downstream send does NOT re-invoke the gate (no double-fire). The DegradationReporter has its own `gateHealthAlert` for its DIRECT alert path (a different path that doesn't go through `/attention`). The new route-level gate does not interact with the reporter's internal gate.
+- **Races:** The gate is a single LLM call before `createAttentionItem`. `createAttentionItem` is async and uses an in-memory `Map<id, AttentionItem>`. Two concurrent `/attention` POSTs with the same id could both pass the gate and both reach `createAttentionItem`; the second hits the strict-id check and returns the existing item without creating a duplicate topic. No new race; existing race-free behavior preserved.
+- **Feedback loops:** The gate's decision log writes to stderr (existing behavior). The 422 response shape is unchanged from existing gate-blocked responses, so any caller-side retry logic that already handles 422 from telegram-reply will handle it the same way from /attention. No new feedback loop.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Other agents on the same machine:** Agents that POST to `/attention` may now receive 422 responses they didn't receive before. The 422 body shape (`{error, rule, issue, suggestion, latencyMs}`) matches the existing telegram-reply 422 shape, so any caller that already handles telegram-reply rejects can handle attention rejects identically. The guardian-pulse recipe in particular runs in a shell script that does not check HTTP status — it will silently swallow the 422, which is the desired behavior for noisy degradation events. Agents using `mark-reported` after `/attention` will still call mark-reported regardless of the attention POST status; the event stays out of the user's face whether the attention item created or got blocked.
+- **Other users of the install base:** Behavioral change visible at the user's Telegram: fewer noise topics created. This IS the requested behavior. Existing topics created before this fix shipped are NOT cleaned up — that's a separate concern (the `/done` command per topic).
+- **External systems:** No new Telegram API calls. Fewer `createForumTopic` calls when the gate blocks. No change to Slack/WhatsApp/iMessage paths.
+- **Persistent state:** None. `attention-items.json` schema unchanged. The skill recipe fix only changes the rendered SKILL.md content for newly-installed agents (`migrateBuiltinSkills` is non-destructive and skips files that already exist) — existing agents will continue using the timestamped id until they reinstall the skill or get a destructive migration. The tone-gate at `/attention` is the primary defense and works regardless of skill version.
+- **Timing / runtime:** Adds one Haiku-class LLM call per `/attention` POST (~500ms p50, ~3s p99). The existing `checkOutboundMessage` already absorbs this latency on every other outbound path; `/attention` is not user-facing latency-critical (agents calling it are background pulses, not interactive flows).
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Pure code revert. No data migration. No agent state repair.
+
+- The route changes (the gate call and the `messageKind`/`jargon` options on `checkOutboundMessage`) revert cleanly — no callers outside this PR depend on the new options.
+- The skill template change reverts cleanly. New agents installed during the rollout will have the stable-id template; reverting the change does not invalidate their existing SKILL.md.
+- `attention-items.json` unchanged in shape, so no DB-style migration concerns.
+- During the rollback window, agents that received 422 responses they don't know how to handle would not have been retrying anyway (the recipe doesn't); rollback simply lets the previous noisy behavior return.
+
+Estimated rollback time: hot-fix release, < 5 minutes from decision to ship.
+
+---
+
+## Conclusion
+
+The change closes the one outbound-message path (`/attention`) that wasn't already gated, using the existing authority and existing rules. It is signal-vs-authority compliant: brittle bits are routing hints and signal producers, never blockers. The skill recipe fix is a one-line content change with a regression test guarding the regression. Both layered together give defense-in-depth: even if a future agent ignores the recipe and uses unstable IDs, the gate catches the message-quality failure (no CTA, jargon, suppressed-by-self-heal). And even if the gate fail-opens on an LLM error, the stable-id recipe prevents same-feature spam via `createAttentionItem`'s strict-id dedup.
+
+Clear to ship pending second-pass review (required — touches outbound-message block/allow surface).
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** independent general-purpose subagent (instar-dev Phase 5 — outbound-message block/allow surface)
+**Independent read of the artifact: CONCUR**
+
+The reviewer independently read `signal-vs-authority.md`, the artifact, the source diff against main, and both new test files. Findings:
+
+- **Signal vs authority audit clean.** `JargonDetector` is documented as signal-only and consumed via `signals.jargon`. The category regex is a routing hint that toggles which ruleset the gate considers, not a blocker. The only blocking decision is the LLM-backed `MessagingToneGate.review` call.
+- **Tests genuinely exercise the claimed behavior.** Pass/block/non-health/alias paths each assert the recorded `messageKind` and verify `createAttentionItem` is NOT invoked on block.
+- **Rollback claim verified.** `attention-items.json` schema unchanged. Skill template change is content-only.
+
+Two minor observations the reviewer flagged but accepted:
+
+1. **In-memory dedup volatility across restarts.** `attentionItems` is a `Map` rebuilt on server start. Across server restarts a fresh map could let `degradation:foo` spawn a new topic. Mitigation: the file is persisted to `attention-items.json` and loaded on init (existing behavior — see `loadAttentionItems` at TelegramAdapter.ts:3001), so cross-restart dedup IS preserved. The reviewer's concern is satisfied by existing persistence; documenting here for completeness.
+2. **No topicId on attention POSTs → no recent-context history fed to the gate.** Acceptable: attention items create new topics, so there is no prior thread context applicable. The health-alert ruleset (B12/B13/B14) does not depend on per-thread history.
+
+Conclusion: clear to ship.
+
+---
+
+## Evidence pointers
+
+- New tests: `tests/unit/attention-route-tone-gate.test.ts` (4 tests), `tests/unit/guardian-pulse-skill-stable-id.test.ts` (1 test). All pass.
+- Existing adjacent tests verified non-regressing: `tests/unit/MessagingToneGate.test.ts` (27), `tests/unit/messaging-tone-gate-health-alerts.test.ts` (8), `tests/unit/reply-scripts.test.ts` (15), `tests/unit/server.test.ts` (16) — all pass.
+- Tone-gate decision log captured in test runs confirms `messageKind=health-alert` for `category=degradation` and `messageKind=reply` for `category=general`, with the correct rule fired (B14_HEALTH_ALERT_NO_CTA) when the mocked provider blocks a no-CTA degradation candidate.
+- Original user report: Telegram screenshot showing 7+ duplicate "Server degraded / git conflict auto-resolution" topics from Bob agent over 2026-05-02 → 2026-05-05, all with no CTA and Priority: LOW headers — the exact pattern this fix structurally prevents.


### PR DESCRIPTION
## Summary
- POST /attention was the one outbound user-message path NOT consulted by the existing MessagingToneGate. Wired it through, with messageKind='health-alert' for category=degradation/health/alert so the existing B12/B13/B14 ruleset (jargon, suppressed-by-self-heal, no-CTA) fires.
- Fixed the guardian-pulse skill recipe to use a stable id `degradation:{FEATURE}` (no timestamp). Repeated detections of the same feature now collapse onto the existing attention item via createAttentionItem's strict-id dedup, instead of spawning a fresh Telegram topic each pulse.
- Tests cover pass/block/non-health/alias paths on the route plus a regression guard against the timestamped id returning to the skill template.

## Why
A user-reported bug: an instar agent created 7+ near-duplicate "Server degraded | Priority: LOW Git conflicts may not auto-r..." topics in four days for one recurring degradation event — no call to action, jargon-laden header, no actionable info. Justin (Telegram topic 8937) said: "NONE of these should have been created. They are noise, and none of the messages in the topics are helpful to the user at all."

The change pairs structural enforcement (the gate now sees /attention candidates) with the recipe fix (same-feature collapses onto same id). Defense-in-depth: the gate catches low-quality candidates regardless of skill version; the recipe fix prevents same-feature spam regardless of LLM availability.

## Signal vs authority
The category routing hint is signal-only — it toggles which ruleset the existing authority considers. JargonDetector is documented signal-only and consumed via signals.jargon. The only blocking decision is MessagingToneGate.review (the existing single authority for outbound user-facing messages). No new authority introduced; no brittle logic given block power. Spec: `docs/specs/attention-tone-gate-and-stable-id.md`. Side-effects review: `upgrades/side-effects/attention-tone-gate-and-stable-id.md` (with second-pass concur from independent reviewer).

## Test plan
- [x] New unit tests pass: `attention-route-tone-gate.test.ts` (4), `guardian-pulse-skill-stable-id.test.ts` (1)
- [x] Adjacent tests verified non-regressing: MessagingToneGate, messaging-tone-gate-health-alerts, reply-scripts, server
- [x] Pre-push gate ran the full unit suite: 2026 tests passed
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Pre-commit instar-dev gate passed: trace verified, artifact verified, spec converged + approved
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)