### PR TITLE
fix(threadline): nickname-store is authority for outbound name resolution

### DIFF
--- a/docs/specs/THREADLINE-NICKNAME-RESOLVER-AUTHORITY-SPEC.md
+++ b/docs/specs/THREADLINE-NICKNAME-RESOLVER-AUTHORITY-SPEC.md
@@ -1,0 +1,157 @@
+---
+title: "Threadline name-resolver honors user-curated nicknames as authority"
+slug: "threadline-nickname-resolver-authority"
+author: "Echo"
+status: "Approved"
+review-convergence: "2026-05-08T20:46:30Z"
+review-iterations: 3
+review-completed-at: "2026-05-08T20:46:30Z"
+review-report: "docs/specs/reports/threadline-nickname-resolver-authority-convergence.md"
+approved: true
+approved-by: "Justin"
+approved-at: "2026-05-09T09:28:03Z"
+---
+
+# Threadline name-resolver honors user-curated nicknames as authority
+
+## Problem statement
+
+The MCP `threadline_send` tool's name → fingerprint resolver consults only the relay's discovery cache via `ThreadlineClient.resolveAgent()`. That resolver returns the first agent in its cache whose name matches the requested string (case-insensitive). When the relay's directory holds a stale entry, an imposter, or simply the wrong instance for a name, the resolver silently returns that wrong fingerprint. The `/threadline/relay-send` route then encrypts and delivers the message to that wrong recipient.
+
+The user maintains a hand-curated map at `.instar/threadline/nicknames.json` that records `fingerprint → user-chosen display name`. No source-tree code on `main` reads that file for outbound sends. The mapping exists for dashboard observability only.
+
+**Real-world failure (2026-05-08, this agent's own):** Echo sent two follow-up messages to "Dawn" on Threadline thread `thread-2ebce60b`. The MCP resolver returned fingerprint `5c338c63cd2ecebc8f52483d5bba6486` for the name "Dawn"; Dawn's real fingerprint per Echo's nicknames.json (and per every prior message in that thread) is `8c7928aa9f04fbda947172a2f9b2d81a`. The messages were silently delivered to a wrong/stale recipient. The bug surfaced only because the user noticed the silence — there is no signal in the existing pipeline that this happened.
+
+The failure mode is invisible from inside the agent: the relay accepts the encrypted envelope, returns success, the canonical outbox records "relay-sent" with the requested `recipientName`, and the local agent has no way to know the message reached the wrong endpoint. The only feedback channel is the human noticing that the recipient never replied.
+
+## Proposed design
+
+User-curated nicknames are the highest-authority mapping for outbound sends. Relay discovery is a signal that the resolver consults only when the user has not nicknamed the target.
+
+### 1. Bring `ThreadlineNicknames` onto `main`
+
+The `ThreadlineNicknames` class (originally implemented on `feat/dashboard-grouped-nav`, commit `16c605ce`) is cherry-picked onto `main` and hardened in two small ways during convergence review:
+
+- **Atomic writes via temp+rename.** `persist()` writes to a `${file}.tmp-${pid}-${ts}` sibling and `rename(2)`s into place. Prevents a concurrent dashboard reader from observing a half-written file (which would parse-fail and degrade to "no nicknames" — a silent authority loss). POSIX guarantees rename atomicity when source and destination are on the same filesystem; `.instar/threadline/` always satisfies that.
+- **30-second internal read cache** with manual `invalidate()`. Note: this cache is *instance-local*. The send route currently instantiates a fresh `ThreadlineNicknames` per request, so on the relay-send hot path this cache does NOT amortize across requests — every send pays one `fs.readFileSync` of a small JSON file. This is an explicit, accepted cost for v1: the file is small (≤ a few KB in realistic use), the route is low-volume (interactive MCP send, not a fan-out fanin path), and the simplicity of a per-request instance avoids singleton-lifecycle complexity. If profiling later shows this read on a hotter path, the route can hold a process-level singleton; the class is already shaped for that.
+- **Corrupt-file tolerance with observability.** `load()` catches JSON parse errors, emits a one-shot warn (see §4), and returns an empty map. Sends fall back to relay-discovery; the corruption is visible in operator logs without spamming.
+
+Methods: `get(fingerprint)`, `all()`, `set(fingerprint, nickname, source)`, `delete(fingerprint)`, `invalidate()`, plus the static `canonicalizeName(name)` (see §2 below).
+
+The class is structured to be reused by the dashboard PR when that lands; the cherry-pick avoids duplicate file content.
+
+### 2. Add a reverse-lookup method with canonicalization
+
+`resolveByName(name): { fingerprint, entry } | { ambiguous: true, candidates } | null`
+
+Match is by **canonicalized** equality, not naive `toLowerCase()`. The static helper `ThreadlineNicknames.canonicalizeName(name)` applies, in order:
+
+1. **Unicode NFC normalization** — collapses combining-character forms so "é" (precomposed U+00E9) and "é" (e + U+0301) compare equal.
+2. **Trim** surrounding whitespace.
+3. **Collapse internal whitespace runs** to a single space — so a hand-edited "Dawn  Q " (double internal space, trailing space) resolves the same as "dawn q".
+4. **Lowercase** for case-insensitivity.
+
+Both the lookup key and the stored entry's nickname are canonicalized **at compare time**, so a `nicknames.json` edited by hand (or written by a future tool that doesn't normalize) still resolves correctly. Note that `set()` does NOT pre-canonicalize on store — the stored string preserves the user's chosen casing and spacing for the dashboard's display purposes; only the comparison is canonical. This means a user who writes `Dawn` and another who writes `DAWN  ` for different fingerprints will still trigger the ambiguous-mapping path (canonical-equal), and the dashboard will show their chosen forms verbatim.
+
+Returns `null` when canonicalized input is empty (covers empty string, whitespace-only, and `null`/`undefined`). Returns the single match when one fingerprint maps to the canonical name. Returns `{ ambiguous: true, candidates }` when two or more fingerprints share the canonical name (the file allows it; `set()` is keyed by fingerprint, not name).
+
+**What canonicalization does NOT cover:** confusables/homoglyphs (Cyrillic "а" vs. Latin "a"). A user who deliberately enters a homoglyph nickname will get a distinct authority entry — and that's acceptable, because nicknames are user-curated; if the user wrote it, they meant it. A homoglyph-detection step would belong in a future Haiku-driven nickname review on `set()`, out of scope for this fix.
+
+### 3. Wire into `/threadline/relay-send`
+
+At the top of the route handler, after request validation:
+
+```
+if (!looksLikeFingerprint(targetAgent)) {
+  const fpPrefixParse = parseNameFpPrefix(targetAgent);  // {name, fpPrefix} | null
+  const lookupName = fpPrefixParse ? fpPrefixParse.name : targetAgent;
+  const lookup = nicknameStore.resolveByName(lookupName);
+  // Three cases:
+  // (a) lookup is null → no nickname; existing relay-discovery path runs.
+  // (b) lookup is single → nicknameResolvedFp = lookup.fingerprint, UNLESS
+  //     fpPrefixParse is set and its prefix disagrees with the curated fp,
+  //     in which case the caller's prefix wins (warn-logged).
+  // (c) lookup is ambiguous → if fpPrefixParse is set, filter candidates by
+  //     prefix: exactly-one → use it; zero → 409 with candidate list; many
+  //     → 409 asking for a longer prefix. If fpPrefixParse is null → 409
+  //     with the bare candidate list.
+}
+```
+
+`looksLikeFingerprint` matches `/^[0-9a-f]{16,64}$/i`. The `name:fpPrefix` qualifier is a `:`-suffix that is 4–32 hex chars. The nickname lookup runs even when the qualifier is present so that the documented disambiguation remedy actually disambiguates among nickname candidates (the original draft skipped nickname lookup whenever `:fpPrefix` was present, which made the spec's prescribed remedy a dead end — corrected during convergence review).
+
+`nicknameResolvedFp` is then propagated through the existing flow:
+
+- **Local-delivery match** (against `known-agents.json`): when set, filter agents by fingerprint instead of by name. Same-name local agents are bypassed in favor of the user's curated mapping; if the nickname's fingerprint matches a local agent, local delivery still happens, just routed by fingerprint.
+- **Relay-delivery resolver**: when set, use it directly as `resolvedId`, skipping `relayClient.resolveAgent`. As a probe, still call `resolveAgent` and log a `[relay-send] Nickname/discovery mismatch …` warning when discovery returns a different fingerprint for the same name; the route honors the nickname regardless.
+
+### 4. Failure modes and their handling
+
+- **`nicknames.json` missing or empty**: `ThreadlineNicknames.load()` returns an empty map; `resolveByName` returns null; behavior is unchanged from today.
+- **`nicknames.json` corrupt JSON**: `load()` catches the parse error and emits a one-shot warn `[ThreadlineNicknames] nicknames.json parse failed at <path>: <message>. Treating as empty (no user-curated authority for this load cycle). Outbound sends will fall back to relay-discovery for nicknamed names.` then returns an empty map. The warn fires at most once per cache cycle (every 30s), so a persistently-corrupt file is observable in operator logs without spamming. Sends still go through via the existing relay-discovery path. **This is a deliberate fail-soft choice**: we'd rather route via discovery (which historically worked) than 5xx on every send while a JSON syntax error is being fixed. The route's outer `try/catch` around the lookup remains as a defense-in-depth catch for any unforeseen throw from `load()` or `resolveByName()`; under normal corrupt-file behavior, only the inner `load()` warn fires.
+- **Concurrent dashboard write while route reads**: atomic temp+rename in `persist()` (see §1) means the reader either sees the old file or the new file, never a half-written one. Worst case: a route request that started reading the old file just before a dashboard edit honors the old mapping; the next request (after cache TTL) honors the new one. Acceptable — there is no transactional contract between dashboard edits and in-flight sends.
+- **Ambiguous nickname (two fingerprints sharing one name)**: 409 with all candidates listed (each as `nickname:fpPrefix (fullFp)`). The caller's documented remedy is to retry as `name:fpPrefix` or as a raw fingerprint. The nickname-lookup branch handles `name:fpPrefix` correctly: it parses the prefix, looks up the bare name in the nickname store, and filters the candidates by the prefix — exactly one match yields the curated fingerprint, zero matches returns 409 with the candidate list, multiple matches returns 409 asking for a longer prefix. This means the documented operator remedy is wired end-to-end (it is NOT a dead-end skip of the nickname store, which an earlier draft incorrectly described).
+- **Nickname/prefix disagreement** (caller passes `name:fpPrefix` and the curated nickname's fingerprint doesn't start with that prefix): the route honors the caller's prefix and skips nickname authority for this send, with a warn `[relay-send] Nickname/prefix disagreement for <name>: nickname maps to X…, caller prefix is Y. Honoring caller prefix.` The reasoning: a caller who explicitly typed a prefix is making a more specific assertion than the curated mapping (e.g., they may know the nickname is stale and be sending to the new fingerprint). The conflict is observable.
+- **Stale nickname — nickname disagrees with discovery** (relay returns a different fingerprint for the same name): mismatch warning fires (`[relay-send] Nickname/discovery mismatch …`); authority wins; send proceeds to the user-curated fingerprint. This is the canonical case the fix is designed for.
+- **Stale nickname — fingerprint unreachable or unknown to relay** (discovery returns null/empty for the same name, or the fingerprint is simply offline): no mismatch warning fires (there's nothing to compare against); send proceeds to the user-curated fingerprint and fails downstream the same way an ordinary unreachable-recipient send fails today. No new observability is added in this fix for that case — the operator's signal is the existing relay-side delivery failure. **Future work:** structured "authority-routed" metadata in the canonical outbox entry would let the dashboard surface stale-fingerprint patterns; tracked separately from this spec.
+
+### 5. Trust boundary
+
+The authority elevation in this fix rests on one assumption: **`ctx.config.stateDir` is process-owned, locally controlled, and not derivable from any request-time input.** That assumption already holds throughout instar — `stateDir` is fixed at server-start from on-disk config, not from any HTTP body, header, or query parameter. The nickname store inherits the same trust boundary as every other `.instar/` file (jobs.json, identity.json, known-agents.json). If a future change ever lets a request influence `stateDir`, this fix's authority elevation must be re-evaluated; that's a structural invariant, not an implementation detail.
+
+There is no remote write surface to `nicknames.json`. Today it is written by (a) hand-editing, (b) the dashboard route on the dashboard branch (which itself requires an authenticated session), and (c) a future Haiku suggester. All three operate inside the trust boundary. Nickname strings flow through the system as comparison keys and log/error fields only — they are never executed, never used as paths, never serialized into shells.
+
+### 6. Multi-machine semantics
+
+`nicknames.json` is **per-machine** authority. If "echo-laptop" and "echo-server" are two physical instances of the same logical agent identity, they each maintain their own `nicknames.json` and may resolve the same display name to different fingerprints. This is intentional:
+
+- Nickname authority is a **statement of intent by the operator on that machine** — "on this machine, when I say Dawn, I mean *this* fingerprint." Two machines may legitimately disagree (e.g., one of them is mid-rekey for a peer; one has been told the new fingerprint, one hasn't).
+- The alternative (a synced authoritative store) would re-introduce the gossip-style staleness this fix exists to defeat — sync delay would mean either machine could route to a wrong fingerprint while waiting for replication.
+- For operators who want consistency, the existing instar git-sync of `.instar/` already replicates `nicknames.json` byte-identically across paired machines on the next sync. That's the right transport: explicit, observable, and on the operator's schedule.
+
+The acceptance bar: a single send from a single machine routes correctly. Cross-machine consistency is an operational concern, not a correctness concern.
+
+### 7. Local-delivery filter narrowing
+
+When `nicknameResolvedFp` is set, the local-delivery branch filters `known-agents.json` entries by **fingerprint match** (`a.fingerprint || a.publicKey?.substring(0,32)` lowercased equality), not by name. This is intentional and tighter than the un-nicknamed path:
+
+- If a local agent has a fingerprint and it matches the nickname, local delivery proceeds.
+- If a local agent has the right name but a different fingerprint (or no fingerprint recorded), the nickname-routed send goes to the relay path instead. This is the correct outcome: the user's curated mapping says "Dawn is fingerprint X"; a local entry that calls itself "Dawn" but isn't fingerprint X is, by the user's own authoritative statement, not the right Dawn.
+- A local agent missing fingerprint AND publicKey can't be matched on this branch. That's a legitimate gap in `known-agents.json`, not a bug in this resolver — it would also fail any fingerprint-based delivery elsewhere. The fix is to populate the entry's fingerprint, not to weaken the matcher.
+
+### 8. Out of scope
+
+- The dashboard UI for editing nicknames lives on `feat/dashboard-grouped-nav` and lands separately. This spec covers the send-path only.
+- The Haiku-driven nickname suggester (also on the dashboard branch) is unrelated.
+- Listener-daemon's inbound resolution is unchanged. Inbound messages already have a verified fingerprint from the encrypted envelope; no name lookup is needed.
+- Local `known-agents.json` semantics are unchanged for un-nicknamed names.
+
+## Authority/signal mapping
+
+This change is the canonical signal-vs-authority move (per `docs/signal-vs-authority.md`), scoped precisely:
+
+- **For nicknamed names**: `ThreadlineNicknames` is **authority** (full-context, user-curated, set explicitly by the user). `relayClient.resolveAgent(name)` becomes a **signal** in this branch — it's still called as a probe so that nickname/discovery disagreements are visible in operator logs, but the resolver does not consult it for the routing decision.
+- **For un-nicknamed names**: `relayClient.resolveAgent(name)` remains the deciding resolver. The principle's "single authority per decision point" still holds — the decision point is "resolve a name the user hasn't curated," and relay discovery is the only authority instar has for that. This fix does not weaken or strengthen that path; it only carves out an authoritative override for the curated case.
+- **For fingerprint inputs and `name:fpPrefix` qualifiers**: the caller has already done the disambiguation; neither nickname nor relay discovery is consulted as authority for the name half — the caller's bytes win.
+
+The earlier framing "relay discovery becomes signal-only" was overbroad and is corrected here: relay discovery is signal-only *when nickname authority is present*, and authority *when it isn't*. That is the honest architectural story.
+
+## Acceptance criteria
+
+1. A send to a user-nicknamed name routes to the nickname's fingerprint, not the relay's resolved one, even when the relay returns a different (wrong) fingerprint for the same name.
+2. A send to an un-nicknamed name continues to use relay discovery (no behavior change).
+3. A send to a raw fingerprint (matching `^[0-9a-f]{16,64}$`) skips the nickname check entirely. A `name:fpPrefix`-qualified name does NOT skip the nickname check — it consults the store, and (a) when the nickname has multiple candidates, filters by the prefix; (b) when the nickname has a single candidate that disagrees with the prefix, honors the caller's prefix and warn-logs the disagreement; (c) when no nickname matches the bare name, falls through to relay discovery as today.
+4. A corrupt `nicknames.json` does not crash sends — it falls through to relay discovery.
+5. An ambiguous nickname (two fingerprints, one name) returns 409 with both candidates listed.
+6. The mismatch between relay discovery and a nickname is logged at warning level when both fire.
+7. Tests cover the production-bug reproduction (relay returns wrong fingerprint, nickname authority overrides).
+
+## Rollback
+
+Single-commit revert. The change touches `src/server/routes.ts` (additive nickname-lookup block + filter swap), adds `src/threadline/ThreadlineNicknames.ts` (new file), and adds tests + release notes. No data migration, no schema change, no deployment ordering. The `nicknames.json` file format is read-only from this route — no writes. Reverting leaves the system in a consistent state.
+
+## Test plan
+
+- **Unit (`tests/unit/ThreadlineNicknames.test.ts`, 8 cases)**: `resolveByName` with missing file, empty/whitespace input, single user-curated match (case-insensitive), ambiguous-mapping detection, on-disk file written outside the process, corrupt-file tolerance, no-match, **and canonicalization** (NFC + internal-whitespace-collapse — a hand-edited `"Dawn  Q "` resolves the same as `"dawn q"`).
+- **Integration (`tests/integration/threadline-relay-send-nickname.test.ts`, 3 cases)**: stub relay client whose `resolveAgent('Dawn')` returns the WRONG fingerprint `5c338c63…`; `nicknames.json` curates `Dawn` → `8c7928aa…`; assert the route sends to `8c7928aa…` and the response's `resolvedAgent` field is `8c7928aa…`. Plus the no-nickname (404) and raw-fingerprint pass-through cases.
+- **Push gate**: full unit suite must remain green on the threadline-area subtree (~1493 tests including the existing ThreadlineClient affinity, MCP server relay, observability, and listener tests).

--- a/docs/specs/reports/threadline-nickname-resolver-authority-convergence.md
+++ b/docs/specs/reports/threadline-nickname-resolver-authority-convergence.md
@@ -1,0 +1,85 @@
+# Convergence Report — Threadline name-resolver honors user-curated nicknames as authority
+
+**Spec:** `docs/specs/THREADLINE-NICKNAME-RESOLVER-AUTHORITY-SPEC.md`
+**Slug:** `threadline-nickname-resolver-authority`
+**Author:** Echo
+**Iterations:** 3
+**Verdict:** Converged
+
+## ELI10 Overview
+
+There's a part of Echo (and any agent on Threadline) that takes a friendly name like "Dawn" and looks up who that actually is, so it can send a message. Until now, Echo only asked the **shared address book on the relay server** — the same way you'd ask the postal service "who is Dawn?" The relay sometimes gives back the wrong person, because its address book gets stale or has duplicates with the same name. When that happens, your message goes to the wrong person, and you don't find out unless they never reply.
+
+This fix adds a **personal address book on Echo's own machine**: `nicknames.json`. When you've personally written down "Dawn is fingerprint 8c79…", Echo trusts your note over the relay's guess. The relay is still consulted, but only as a hint that gets logged when it disagrees — not as the final answer. If you haven't named someone, nothing changes: Echo still asks the relay.
+
+What changes for the user: messages addressed by curated nicknames now go to the right recipient even when the relay's directory is wrong. The bug Echo hit on 2026-05-08 (two messages to "Dawn" silently misrouted to fingerprint `5c33…` instead of `8c79…`) is reproduced as a regression test and verified to stop.
+
+The main tradeoff: your personal address book lives on your machine. If you have Echo running on two laptops, they can disagree about who "Dawn" is — that's intentional. The fix optimizes for "the message you send right now, from this machine, goes to the recipient *you* meant" over "every machine routes identically." Operators who want consistency can sync `.instar/` between machines (which Echo already does via git-sync).
+
+## Original vs Converged
+
+The original spec was a clean, narrow description of a small bug fix: cherry-pick an existing `ThreadlineNicknames` class, add a reverse-lookup method, wire it into one route. Three rounds of review (internal angles + GPT/Gemini/Grok) tightened it in five concrete ways:
+
+1. **Honesty about the cache.** The original spec advertised a "30-second internal read cache" as if it amortized. All three external models flagged the same issue: the route creates a fresh instance per request, so the cache is per-instance and doesn't help across requests. The converged spec acknowledges the per-request file read explicitly, justifies it (small file, low-volume route), and documents the singleton path as a future option. No false advertising.
+
+2. **Real canonicalization, not naive lowercase.** The original used `name.trim().toLowerCase()`, which silently fails on hand-edited entries like "Dawn  Q " (double space, trailing space) or NFD-form Unicode. The converged design canonicalizes both lookup keys and stored entries at compare time using NFC + whitespace-collapse + lowercase, so visually-identical names always resolve the same. A unit test was added.
+
+3. **Atomic writes for real.** The original spec claimed "atomic writes" but the code used a plain `writeFileSync`. A concurrent reader could observe a half-written file, parse-fail, and silently lose all nickname authority. The converged code writes to a temp file and renames, which POSIX guarantees is atomic on the same filesystem.
+
+4. **Corrupt-file observability.** The original silently swallowed JSON parse errors. The converged version emits a one-shot warn (rate-limited by the cache cycle) so operators can see when a corrupt nicknames file is silently degrading authority — without spamming logs while the issue is being fixed.
+
+5. **The disambiguation remedy actually works.** The original spec told ambiguous-nickname callers to retry as `name:fpPrefix`. But the route was coded to *skip the nickname check entirely* whenever `name:fpPrefix` was present — so the documented remedy didn't disambiguate among nickname candidates at all; it just punted to the relay. The converged route parses the prefix, looks up the bare name, and filters candidates accordingly (1 → use it, 0 → 409 with candidates, many → 409 asking for a longer prefix). It also handles the case where a caller's explicit prefix disagrees with a single-candidate nickname (caller wins, warn-logged).
+
+Two further angles were validated in writing without code change:
+- **Multi-machine semantics** (per-machine authority is intentional; sync via git-sync if needed).
+- **Trust boundary** (`stateDir` must remain process-controlled — already a structural invariant in instar, just made explicit here).
+
+The architecture/signal-vs-authority framing was also tightened: instead of "relay discovery becomes signal-only" (overbroad), the converged language is "for nicknamed names, nicknames are authority and relay is signal-only; for un-nicknamed names, relay remains the deciding resolver."
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec/code changes |
+|-----------|-----------------------|-------------------|-------------------|
+| 1         | GPT, Gemini, Grok + internal | 8 | Cache honesty, multi-machine, observability gap, normalization (NFC + collapse + canonical helper), wording, trust boundary, local-delivery filter, atomic writes; new unit test for canonicalization |
+| 2         | GPT (3), Gemini (1), Grok (0) | 3 | Corrupt-file warn in load(), `name:fpPrefix` disambiguation wired through nickname store, docstring fixed re: set() not pre-canonicalizing |
+| 3         | GPT, Gemini, Grok all flagged the same single residual | 1 | Acceptance Criterion #3 rewritten to match new dispatcher logic for `name:fpPrefix` |
+| 3+ (post-fix) | (converged) | 0 | none |
+
+## Full Findings Catalog
+
+### Iteration 1
+
+| # | Severity | Reviewer(s) | Original | Resolution |
+|---|----------|-------------|----------|------------|
+| 1.1 | High | GPT, Gemini, Grok | Per-request `new ThreadlineNicknames()` defeats the 30s cache; spec advertised cache benefit it didn't deliver. | §1 rewritten — explicitly states per-request file read cost is accepted for v1, justifies (small file + low-volume route), documents singleton as future optimization. No false advertising. |
+| 1.2 | High | Grok | `nicknames.json` is per-machine; multi-instance deployments diverge silently. | New §6 explicitly documents per-machine authority as intentional with rationale. Notes git-sync as the consistency transport. Updates acceptance bar: single-machine correctness, not cross-machine consistency. |
+| 1.3 | Medium | GPT | Stale-authority observability incomplete: warning only fires when relay returns a *different* fp, not when relay is silent. | §4 rewritten to distinguish "nickname disagrees with discovery" (warn fires) vs "discovery silent" (no warn — same failure mode as ordinary unreachable-recipient). Future canonical-outbox metadata noted as out-of-scope follow-up. |
+| 1.4 | Medium | GPT, Grok | `trim().toLowerCase()` misses NFC, internal whitespace, and `set()` doesn't canonicalize stored values. | New `canonicalizeName()` helper (NFC + trim + collapse-internal-whitespace + lowercase). Applied at compare time on both lookup key and stored entries. New unit test. |
+| 1.5 | Medium | GPT | "Relay discovery becomes signal-only" overbroad — relay is still authority for un-nicknamed names. | "Authority/signal mapping" section rewritten: scoped per-input-type (nicknamed → authority/signal split; un-nicknamed → relay authority; fp-input/prefix → caller). |
+| 1.6 | Medium | GPT | `stateDir` trust assumption is implicit but load-bearing. | New §5 explicitly states the structural invariant: `stateDir` is process-controlled, not request-derivable. Inherits trust boundary of all `.instar/` files. |
+| 1.7 | Low | Grok | Local-delivery filter swap to fp-only silently drops name-only same-name agents. | New §7 documents intentional behavior: by user's curated mapping, a name-matching local agent without the right fingerprint is by definition not the right Dawn. The fix for missing fp is in `known-agents.json`, not the resolver. |
+| 1.8 | Material (internal angle) | Echo (spec-vs-code audit) | Spec claimed atomic writes but `persist()` used plain `writeFileSync`. | Code changed to temp+rename (`${file}.tmp-${pid}-${ts}` then `rename()`). §1 describes the actual mechanism. |
+
+Non-material in iter1 (noted, no change): nickname strings echoed in error/log responses are user-controlled but non-executable; resolveByName is O(n) which is fine for small n; cache TTL doesn't auto-invalidate on dashboard writes (acceptable for v1).
+
+### Iteration 2
+
+| # | Severity | Reviewer(s) | Original | Resolution |
+|---|----------|-------------|----------|------------|
+| 2.1 | Medium | GPT (twice — sec & arch) | Corrupt-file fail-open is silent: `load()` swallows the parse error, so the route's outer try/catch never fires. Operator has no signal that authority is being silently bypassed. | `load()` now emits a one-shot warn `[ThreadlineNicknames] nicknames.json parse failed at <path>: <message>. Treating as empty (no user-curated authority for this load cycle). Outbound sends will fall back to relay-discovery for nicknamed names.` Rate-limited by 30s cache cycle (no spam). §4 documents the deliberate fail-soft choice and the route's outer try/catch as defense-in-depth only. |
+| 2.2 | Medium | GPT | Documented disambiguation remedy (`name:fpPrefix`) was a dead end — route skipped nickname lookup whenever `:fpPrefix` was present, so it couldn't disambiguate among nickname candidates. | Route rewritten: nickname lookup runs even for `name:fpPrefix` inputs; ambiguous candidates filtered by prefix (1 → use, 0 → 409 with candidate list, many → 409 asking longer prefix). Single-candidate-vs-prefix disagreement: caller's prefix wins, warn-logged. §3 and §4 updated. |
+| 2.3 | Low | Gemini | `canonicalizeName` docstring claimed `set()` uses it for stored values, but `set()` doesn't. | Docstring rewritten to state set() deliberately does NOT pre-canonicalize on store (preserves user's display string for the dashboard); compare-time canonicalization only. §2 has matching note. |
+
+### Iteration 3
+
+| # | Severity | Reviewer(s) | Original | Resolution |
+|---|----------|-------------|----------|------------|
+| 3.1 | High (Gemini) / Medium (GPT) | GPT, Gemini, Grok all flagged the identical issue | Acceptance Criterion #3 was stale: said `name:fpPrefix` "skips the nickname check entirely," contradicting the new §3/§4 logic. A test author working from AC #3 would re-introduce the disambiguation dead end. | AC #3 rewritten to match: raw fingerprint skips the check; `name:fpPrefix` does NOT skip — it consults the store, filters ambiguous candidates by prefix, honors caller's prefix on disagreement, falls through on no nickname match. |
+
+### Convergence
+
+A fourth round was not run. The iteration-3 finding was a single mechanical text inconsistency that all three external models flagged identically; the fix is a one-paragraph rewrite of one acceptance criterion to align with already-converged §3/§4 semantics. There is no remaining design space to re-explore. The 3-iteration cap set by the user matches this judgment.
+
+## Convergence verdict
+
+Converged at iteration 3. All material findings from rounds 1–3 are addressed in spec text and (where applicable) implementation code. Tests pass: 11/11 (8 unit, 3 integration). The spec is ready for user review and approval.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "0.28.82",
+  "version": "0.28.83",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-06T16:49:59.688Z",
-  "instarVersion": "0.28.81",
+  "generatedAt": "2026-05-09T03:48:45.408Z",
+  "instarVersion": "0.28.83",
   "entryCount": 187,
   "entries": {
     "hook:session-start": {
@@ -384,7 +384,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -720,7 +720,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -736,7 +736,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c6f6089f5b68c53ea212ae3ace1ceb6ca8d89437bb9079168585f234bd92dfa",
+      "contentHash": "50dd7ce0b9b9918de65ee2729e804505a9120456d2f0db1ed06b4afe2528df50",
       "since": "2025-01-01"
     },
     "cli:init": {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -164,6 +164,7 @@ import type { ThreadlineRouter } from '../threadline/ThreadlineRouter.js';
 import type { HandshakeManager } from '../threadline/HandshakeManager.js';
 import { createThreadlineRoutes } from '../threadline/ThreadlineEndpoints.js';
 import type { UnifiedTrustSystem } from '../threadline/UnifiedTrustWiring.js';
+import { ThreadlineNicknames } from '../threadline/ThreadlineNicknames.js';
 import { ScopeCoherenceTracker } from '../core/ScopeCoherenceTracker.js';
 import type { ScopeCoherenceState } from '../core/ScopeCoherenceTracker.js';
 import type { HookEventReceiver } from '../monitoring/HookEventReceiver.js';
@@ -10743,6 +10744,93 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
 
+    // Nickname-first resolution. User-curated names in nicknames.json are the
+    // highest-authority mapping (signal-vs-authority: relay discovery is signal,
+    // user nickname is authority). If "Dawn" maps to fingerprint X here, we
+    // route to X regardless of what the relay's discovery cache says about
+    // some other agent that also calls itself "Dawn". Skip when caller used
+    // a "name:fpPrefix" qualifier (they're explicitly disambiguating) or
+    // when the input already looks like a fingerprint.
+    let nicknameResolvedFp: string | null = null;
+    const looksLikeFingerprint = /^[0-9a-f]{16,64}$/i.test(targetAgent);
+    // Parse "name:fpPrefix" once so both branches below can reuse it.
+    const fpPrefixParse = (() => {
+      const ci = targetAgent.lastIndexOf(':');
+      if (ci <= 0 || ci >= targetAgent.length - 1) return null;
+      const suffix = targetAgent.substring(ci + 1);
+      if (!/^[0-9a-f]{4,32}$/i.test(suffix)) return null;
+      return { name: targetAgent.substring(0, ci), fpPrefix: suffix.toLowerCase() };
+    })();
+    const usesFpPrefixSyntax = fpPrefixParse !== null;
+    if (!looksLikeFingerprint) {
+      try {
+        const nicknameStore = new ThreadlineNicknames({ stateDir: ctx.config.stateDir });
+        // For "name:fpPrefix" inputs, look up the bare name in the nickname
+        // store and filter the candidates by the prefix. This lets the user
+        // disambiguate ambiguous nickname entries with the same syntax that
+        // works for known-agents.json — the spec promises this remedy.
+        // Without this, "Dawn:abcd" would skip nickname lookup entirely and
+        // the documented disambiguation path would be a dead end.
+        const lookupName = fpPrefixParse ? fpPrefixParse.name : targetAgent;
+        const lookup = nicknameStore.resolveByName(lookupName);
+        if (lookup && 'ambiguous' in lookup) {
+          if (fpPrefixParse) {
+            const matched = lookup.candidates.filter(c =>
+              c.fingerprint.toLowerCase().startsWith(fpPrefixParse.fpPrefix)
+            );
+            if (matched.length === 1) {
+              nicknameResolvedFp = matched[0].fingerprint;
+            } else if (matched.length === 0) {
+              const hints = lookup.candidates
+                .map(c => `${c.entry.nickname}:${c.fingerprint.substring(0, 8)}`)
+                .join(', ');
+              res.status(409).json({
+                success: false,
+                error: `Nickname "${fpPrefixParse.name}" has no candidate matching prefix "${fpPrefixParse.fpPrefix}". Candidates: ${hints}.`,
+              });
+              return;
+            } else {
+              const hints = matched
+                .map(c => `${c.entry.nickname}:${c.fingerprint.substring(0, 8)}`)
+                .join(', ');
+              res.status(409).json({
+                success: false,
+                error: `Prefix "${fpPrefixParse.fpPrefix}" still ambiguous among nickname "${fpPrefixParse.name}" candidates: ${hints}. Use a longer prefix.`,
+              });
+              return;
+            }
+          } else {
+            const hints = lookup.candidates
+              .map(c => `${c.entry.nickname}:${c.fingerprint.substring(0, 8)} (${c.fingerprint})`)
+              .join(', ');
+            res.status(409).json({
+              success: false,
+              error: `Ambiguous nickname "${targetAgent}" — multiple fingerprints share this name in nicknames.json: ${hints}. Send by fingerprint or use "name:fpPrefix" syntax.`,
+            });
+            return;
+          }
+        } else if (lookup) {
+          // Single-candidate match. If caller also passed a fpPrefix, sanity-
+          // check that it agrees with the curated mapping; on disagreement,
+          // honor the caller's explicit prefix (they may be telling us the
+          // nickname is stale) and skip nickname authority for this send.
+          if (fpPrefixParse && !lookup.fingerprint.toLowerCase().startsWith(fpPrefixParse.fpPrefix)) {
+            console.warn(
+              `[relay-send] Nickname/prefix disagreement for "${fpPrefixParse.name}": ` +
+              `nickname maps to ${lookup.fingerprint.substring(0, 8)}…, ` +
+              `caller prefix is "${fpPrefixParse.fpPrefix}". Honoring caller prefix.`,
+            );
+          } else {
+            nicknameResolvedFp = lookup.fingerprint;
+          }
+        }
+      } catch (err) {
+        // Nickname store read failed — fall through to existing resolution.
+        // Don't block sends on a corrupt nicknames file.
+        console.warn(`[relay-send] Nickname store read failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
     const msgId = `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     // Mint a stable UUID threadId when caller didn't provide one so
     // first-contact messages aren't dropped on the recipient side. Both
@@ -10771,9 +10859,16 @@ export function createRoutes(ctx: RouteContext): Router {
           }
         }
 
-        const nameMatches = agents.filter(a =>
-          a.name === targetName || a.name?.toLowerCase() === targetName?.toLowerCase()
-        );
+        // If a nickname resolved upstream, prefer fingerprint match over
+        // name match — the user-curated mapping is authoritative.
+        const nameMatches = nicknameResolvedFp
+          ? agents.filter(a => {
+              const fp = (a.fingerprint || a.publicKey?.substring(0, 32) || '').toLowerCase();
+              return fp === nicknameResolvedFp!.toLowerCase();
+            })
+          : agents.filter(a =>
+              a.name === targetName || a.name?.toLowerCase() === targetName?.toLowerCase()
+            );
 
         // PR-3: Fingerprint-based disambiguation. If multiple known agents
         // share a name, require a `name:fpPrefix` qualifier to pick one.
@@ -10970,8 +11065,31 @@ export function createRoutes(ctx: RouteContext): Router {
     }
 
     try {
-      // Resolve name → fingerprint if targetAgent isn't already a fingerprint
-      const resolvedId = await relayClient.resolveAgent(targetAgent);
+      // Resolve name → fingerprint. Nickname store wins over relay discovery
+      // when the user has explicitly curated a mapping (set above). Falling
+      // back to relay discovery only when no nickname matched. If the relay
+      // happens to also know this name but maps it to a different fingerprint,
+      // we silently override with the nickname mapping — the user's choice is
+      // authority. Logged so the conflict is visible in operator logs.
+      let resolvedId: string | null;
+      if (nicknameResolvedFp) {
+        resolvedId = nicknameResolvedFp;
+        try {
+          const discoveryFp = await relayClient.resolveAgent(targetAgent);
+          if (discoveryFp && discoveryFp.toLowerCase() !== nicknameResolvedFp.toLowerCase()) {
+            console.warn(
+              `[relay-send] Nickname/discovery mismatch for "${targetAgent}": ` +
+              `nickname maps to ${nicknameResolvedFp.substring(0, 8)}…, ` +
+              `relay discovery returned ${discoveryFp.substring(0, 8)}…. ` +
+              `Honoring user-curated nickname.`,
+            );
+          }
+        } catch {
+          // Discovery probe is best-effort for the conflict warning only.
+        }
+      } else {
+        resolvedId = await relayClient.resolveAgent(targetAgent);
+      }
       if (!resolvedId) {
         res.status(404).json({
           success: false,

--- a/src/threadline/ThreadlineNicknames.ts
+++ b/src/threadline/ThreadlineNicknames.ts
@@ -1,0 +1,218 @@
+/**
+ * ThreadlineNicknames — user-editable display names for threadline agents,
+ * keyed by fingerprint (or any stable id).
+ *
+ * Storage: .instar/threadline/nicknames.json
+ *   {
+ *     "version": 1,
+ *     "nicknames": {
+ *       "8c7928aa9f04fbda...": {
+ *         "nickname": "Dawn",
+ *         "source": "user" | "haiku" | "import",
+ *         "updatedAt": "2026-05-06T17:00:00.000Z"
+ *       }
+ *     }
+ *   }
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type NicknameSource = 'user' | 'haiku' | 'import';
+
+export interface NicknameEntry {
+  nickname: string;
+  source: NicknameSource;
+  updatedAt: string;
+}
+
+interface NicknamesFile {
+  version: number;
+  nicknames: Record<string, NicknameEntry>;
+}
+
+export interface ThreadlineNicknamesOptions {
+  stateDir: string;
+}
+
+const FILE_VERSION = 1;
+
+export class ThreadlineNicknames {
+  private readonly stateDir: string;
+  private cache: Map<string, NicknameEntry> | null = null;
+  private cacheReadAt = 0;
+  private static readonly CACHE_TTL_MS = 30_000;
+
+  constructor(opts: ThreadlineNicknamesOptions) {
+    this.stateDir = opts.stateDir;
+  }
+
+  /** Path to the nicknames JSON file. */
+  filePath(): string {
+    return path.join(this.stateDir, 'threadline', 'nicknames.json');
+  }
+
+  /** Returns the nickname for a fingerprint, or null if none set. */
+  get(fingerprint: string): NicknameEntry | null {
+    if (!fingerprint) return null;
+    const map = this.load();
+    return map.get(fingerprint) ?? null;
+  }
+
+  /** Returns all nicknames as a plain map. */
+  all(): Record<string, NicknameEntry> {
+    const map = this.load();
+    const out: Record<string, NicknameEntry> = {};
+    for (const [k, v] of map) out[k] = v;
+    return out;
+  }
+
+  /**
+   * Canonicalize a name for authority-grade comparison.
+   *
+   * Applies Unicode NFC normalization, trims surrounding whitespace,
+   * collapses internal whitespace runs to a single space, and lowercases.
+   * This is what makes two visually-identical names compare equal even
+   * when one was hand-edited with stray whitespace, mixed case, or
+   * combining-character forms.
+   *
+   * Used by `resolveByName()` on BOTH the lookup key AND each stored
+   * entry's nickname at compare time — so we never mutate the user's
+   * chosen display string on disk (preserving their preferred casing
+   * and spacing for the dashboard), but lookups still match across
+   * cosmetic differences. `set()` does NOT pre-canonicalize on store
+   * for the same reason: the stored string is user-presentation; the
+   * canonical form is comparison-only.
+   */
+  static canonicalizeName(name: string): string {
+    if (!name) return '';
+    return name
+      .normalize('NFC')
+      .trim()
+      .replace(/\s+/g, ' ')
+      .toLowerCase();
+  }
+
+  /**
+   * Reverse-lookup: nickname → fingerprint. Canonicalized exact match
+   * (NFC-normalized, internal-whitespace-collapsed, case-insensitive).
+   *
+   * Returns null if no nickname matches. If multiple fingerprints share
+   * the same nickname (rare; user shouldn't do this but the file allows it),
+   * returns { ambiguous: true, candidates: [...] } so callers can fail
+   * loudly instead of silently picking one.
+   *
+   * The send-path resolver consults this BEFORE relay discovery so that
+   * user-curated names take authority over potentially-stale or imposter
+   * presence entries. See routes.ts /threadline/relay-send.
+   */
+  resolveByName(name: string): { fingerprint: string; entry: NicknameEntry } | { ambiguous: true; candidates: Array<{ fingerprint: string; entry: NicknameEntry }> } | null {
+    const canonical = ThreadlineNicknames.canonicalizeName(name);
+    if (!canonical) return null;
+    const map = this.load();
+    const matches: Array<{ fingerprint: string; entry: NicknameEntry }> = [];
+    for (const [fp, entry] of map) {
+      if (ThreadlineNicknames.canonicalizeName(entry.nickname) === canonical) {
+        matches.push({ fingerprint: fp, entry });
+      }
+    }
+    if (matches.length === 0) return null;
+    if (matches.length === 1) return matches[0];
+    return { ambiguous: true, candidates: matches };
+  }
+
+  /** Set a nickname for a fingerprint. Empty/whitespace nickname clears it. */
+  set(fingerprint: string, nickname: string, source: NicknameSource = 'user'): NicknameEntry | null {
+    if (!fingerprint) throw new Error('fingerprint required');
+    const trimmed = nickname.trim();
+    const map = this.load();
+    if (trimmed.length === 0) {
+      map.delete(fingerprint);
+      this.persist(map);
+      return null;
+    }
+    if (trimmed.length > 64) {
+      throw new Error('nickname too long (max 64 chars)');
+    }
+    const entry: NicknameEntry = {
+      nickname: trimmed,
+      source,
+      updatedAt: new Date().toISOString(),
+    };
+    map.set(fingerprint, entry);
+    this.persist(map);
+    return entry;
+  }
+
+  /** Delete a nickname mapping. Returns true if one existed. */
+  delete(fingerprint: string): boolean {
+    const map = this.load();
+    if (!map.has(fingerprint)) return false;
+    map.delete(fingerprint);
+    this.persist(map);
+    return true;
+  }
+
+  /** Force-reload on next get(). */
+  invalidate(): void {
+    this.cache = null;
+    this.cacheReadAt = 0;
+  }
+
+  // ── internal ───────────────────────────────────────────────────
+
+  private load(): Map<string, NicknameEntry> {
+    const fresh = Date.now() - this.cacheReadAt < ThreadlineNicknames.CACHE_TTL_MS;
+    if (this.cache && fresh) return this.cache;
+    const map = new Map<string, NicknameEntry>();
+    const file = this.filePath();
+    if (fs.existsSync(file)) {
+      try {
+        const raw = fs.readFileSync(file, 'utf-8');
+        const parsed = JSON.parse(raw) as NicknamesFile;
+        const items = parsed?.nicknames ?? {};
+        for (const [k, v] of Object.entries(items)) {
+          if (v && typeof v.nickname === 'string') {
+            map.set(k, {
+              nickname: v.nickname,
+              source: (v.source as NicknameSource) ?? 'user',
+              updatedAt: v.updatedAt ?? new Date().toISOString(),
+            });
+          }
+        }
+      } catch (err) {
+        // Corrupt file — degrade to empty map (sends still flow via
+        // relay-discovery fallback) but make the silent authority loss
+        // visible. One log per cache cycle (every 30s at most), so a
+        // persistently-corrupt file doesn't spam logs but is observable.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[ThreadlineNicknames] nicknames.json parse failed at ${file}: ${msg}. ` +
+          `Treating as empty (no user-curated authority for this load cycle). ` +
+          `Outbound sends will fall back to relay-discovery for nicknamed names.`,
+        );
+      }
+    }
+    this.cache = map;
+    this.cacheReadAt = Date.now();
+    return map;
+  }
+
+  private persist(map: Map<string, NicknameEntry>): void {
+    const file = this.filePath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const obj: NicknamesFile = {
+      version: FILE_VERSION,
+      nicknames: Object.fromEntries(map),
+    };
+    // Atomic write: temp + rename. Prevents a concurrent reader from
+    // observing a half-written file (which would parse-fail and degrade
+    // to "no nicknames" — silent authority loss). rename(2) is atomic on
+    // POSIX when source and destination live on the same filesystem.
+    const tmp = `${file}.tmp-${process.pid}-${Date.now()}`;
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2), 'utf-8');
+    fs.renameSync(tmp, file);
+    this.cache = map;
+    this.cacheReadAt = Date.now();
+  }
+}

--- a/tests/integration/threadline-relay-send-nickname.test.ts
+++ b/tests/integration/threadline-relay-send-nickname.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Integration test — /threadline/relay-send respects the nickname store.
+ *
+ * REGRESSION: prior to this fix, the route only consulted the relay's
+ * discovery cache via relayClient.resolveAgent(). When the relay returned
+ * a stale or imposter agent named "Dawn" with a wrong fingerprint, the
+ * route silently sent to the wrong recipient — Dawn's real instance never
+ * received the message. The user-curated mapping in nicknames.json was
+ * ignored.
+ *
+ * Fix: nickname store is consulted first; user-curated names are authority
+ * over relay discovery. This test reproduces the original failure
+ * conditions and verifies the route now routes to the nickname's
+ * fingerprint, NOT the relay's.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Server } from 'node:http';
+import { createRoutes } from '../../src/server/routes.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const CORRECT_DAWN_FP = '8c7928aa9f04fbda947172a2f9b2d81a';
+const WRONG_DAWN_FP   = '5c338c63cd2ecebc8f52483d5bba6486';
+
+let projectDir: string;
+let stateDir: string;
+let server: Server;
+let baseUrl: string;
+let relaySendCalls: Array<{ recipientId: string; message: string; threadId?: string }>;
+
+describe('/threadline/relay-send nickname authority (regression)', () => {
+  beforeAll(async () => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-relay-nick-'));
+    stateDir = path.join(projectDir, '.instar');
+
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'threadline'), { recursive: true });
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({ projectName: 'echo-test' }),
+    );
+
+    // User-curated nickname mapping. Source-of-truth: "Dawn" is fingerprint
+    // 8c7928aa…, NOT 5c338c63… (the imposter the relay returns below).
+    fs.writeFileSync(
+      path.join(stateDir, 'threadline', 'nicknames.json'),
+      JSON.stringify({
+        version: 1,
+        nicknames: {
+          [CORRECT_DAWN_FP]: {
+            nickname: 'Dawn',
+            source: 'user',
+            updatedAt: '2026-05-07T00:44:34.234Z',
+          },
+        },
+      }),
+      'utf-8',
+    );
+
+    const config = {
+      projectDir,
+      stateDir,
+      projectName: 'echo-test',
+      port: 4042,
+    } as InstarConfig;
+
+    const state = new StateManager(stateDir);
+
+    // Stub relay client that simulates the production bug:
+    // the relay's discovery resolver returns the WRONG fingerprint for "Dawn".
+    relaySendCalls = [];
+    const stubRelayClient = {
+      connectionState: 'connected',
+      resolveAgent: async (name: string) => {
+        // Reproduce the original failure: relay says "Dawn" is the wrong fp.
+        if (name === 'Dawn') return WRONG_DAWN_FP;
+        return null;
+      },
+      sendAuto: (recipientId: string, message: string, threadId?: string) => {
+        relaySendCalls.push({ recipientId, message, threadId });
+        return `msg-stub-${Date.now()}`;
+      },
+    };
+
+    const app = express();
+    app.use(express.json());
+
+    const router = createRoutes({
+      config,
+      state,
+      sessionManager: null as any,
+      scheduler: null,
+      telegram: null,
+      relationships: null,
+      feedback: null,
+      dispatches: null,
+      updateChecker: null,
+      autoUpdater: null,
+      autoDispatcher: null,
+      quotaTracker: null,
+      publisher: null,
+      viewer: null,
+      tunnel: null,
+      evolution: null,
+      watchdog: null,
+      triageNurse: null,
+      topicMemory: null,
+      feedbackAnomalyDetector: null,
+      projectMapper: null,
+      coherenceGate: null,
+      contextHierarchy: null,
+      canonicalState: null,
+      operationGate: null,
+      sentinel: null,
+      adaptiveTrust: null,
+      memoryMonitor: null,
+      orphanReaper: null,
+      coherenceMonitor: null,
+      commitmentTracker: null,
+      semanticMemory: null,
+      activitySentinel: null,
+      messageRouter: null,
+      summarySentinel: null,
+      spawnManager: null,
+      workingMemory: null,
+      quotaManager: null,
+      systemReviewer: null,
+      capabilityMapper: null,
+      selfKnowledgeTree: null,
+      coverageAuditor: null,
+      topicResumeMap: null,
+      autonomyManager: null,
+      trustElevationTracker: null,
+      autonomousEvolution: null,
+      whatsapp: null,
+      messageBridge: null,
+      hookEventReceiver: null,
+      worktreeMonitor: null,
+      subagentTracker: null,
+      instructionsVerifier: null,
+      threadlineRouter: null,
+      handshakeManager: null,
+      threadlineRelayClient: stubRelayClient as any,
+      listenerManager: null,
+      responseReviewGate: null,
+      telemetryHeartbeat: null,
+      pasteManager: null,
+      wsManager: null,
+      soulManager: null,
+      discoveryEvaluator: null,
+      startTime: new Date(),
+    } as any);
+
+    app.use(router);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, '127.0.0.1', () => {
+        const addr = server.address() as { port: number };
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/integration/threadline-relay-send-nickname.test.ts:cleanup',
+    });
+  });
+
+  it('routes to the nickname fingerprint, NOT the (wrong) relay-resolved one', async () => {
+    relaySendCalls.length = 0;
+    const res = await fetch(`${baseUrl}/threadline/relay-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targetAgent: 'Dawn',
+        message: 'where does feedback clustering live?',
+        waitForReply: false,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.deliveryPath).toBe('relay');
+
+    // The bug-shape: prior code would have called sendAuto with WRONG_DAWN_FP
+    // because resolveAgent returned it. Now nickname authority overrides:
+    expect(relaySendCalls).toHaveLength(1);
+    expect(relaySendCalls[0].recipientId).toBe(CORRECT_DAWN_FP);
+    expect(relaySendCalls[0].recipientId).not.toBe(WRONG_DAWN_FP);
+    expect(body.resolvedAgent).toBe(CORRECT_DAWN_FP);
+  });
+
+  it('falls back to relay discovery when no nickname matches', async () => {
+    relaySendCalls.length = 0;
+    // "Stranger" has no nickname mapping; resolver returns null and the
+    // route should 404 (per existing behavior).
+    const res = await fetch(`${baseUrl}/threadline/relay-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targetAgent: 'Stranger',
+        message: 'hello',
+        waitForReply: false,
+      }),
+    });
+    expect(res.status).toBe(404);
+    expect(relaySendCalls).toHaveLength(0);
+  });
+
+  it('passes through unchanged when the input is a raw fingerprint', async () => {
+    relaySendCalls.length = 0;
+    // A raw hex fingerprint that isn't in nicknames.json should bypass the
+    // nickname check entirely (no risk of false-positive matching).
+    const someOtherFp = 'aabbccddeeff00112233445566778899';
+    const res = await fetch(`${baseUrl}/threadline/relay-send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targetAgent: someOtherFp,
+        message: 'direct',
+        waitForReply: false,
+      }),
+    });
+    // resolveAgent returns null for non-"Dawn" inputs in our stub, so 404.
+    // The important part: nickname store wasn't consulted (would have been
+    // null anyway, but the fingerprint-shape short-circuits the check).
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/ThreadlineNicknames.test.ts
+++ b/tests/unit/ThreadlineNicknames.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests — ThreadlineNicknames store.
+ *
+ * Focus: reverse-lookup (name → fingerprint), which is what the
+ * `/threadline/relay-send` resolver uses to short-circuit relay discovery.
+ *
+ * Regression for the "Dawn → wrong fingerprint" silent-delivery bug:
+ * the resolver used to consult only the relay's discovery cache, which
+ * returned a stale/imposter fingerprint for the name "Dawn" while the
+ * user's curated mapping at .instar/threadline/nicknames.json had the
+ * correct one. resolveByName() is the authority lookup.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ThreadlineNicknames } from '../../src/threadline/ThreadlineNicknames.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('ThreadlineNicknames.resolveByName', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nicknames-test-'));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmp, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/ThreadlineNicknames.test.ts:cleanup',
+    });
+  });
+
+  it('returns null when nicknames file is absent', () => {
+    const store = new ThreadlineNicknames({ stateDir: tmp });
+    expect(store.resolveByName('Dawn')).toBeNull();
+  });
+
+  it('returns null for empty/whitespace input', () => {
+    const store = new ThreadlineNicknames({ stateDir: tmp });
+    store.set('8c7928aa9f04fbda947172a2f9b2d81a', 'Dawn');
+    expect(store.resolveByName('')).toBeNull();
+    expect(store.resolveByName('   ')).toBeNull();
+  });
+
+  it('resolves a single user-curated nickname → fingerprint (case-insensitive)', () => {
+    const store = new ThreadlineNicknames({ stateDir: tmp });
+    const fp = '8c7928aa9f04fbda947172a2f9b2d81a';
+    store.set(fp, 'Dawn');
+
+    const lower = store.resolveByName('dawn');
+    const upper = store.resolveByName('DAWN');
+    const exact = store.resolveByName('Dawn');
+
+    expect(lower).not.toBeNull();
+    expect(upper).not.toBeNull();
+    expect(exact).not.toBeNull();
+    if (lower && !('ambiguous' in lower)) {
+      expect(lower.fingerprint).toBe(fp);
+      expect(lower.entry.nickname).toBe('Dawn');
+      expect(lower.entry.source).toBe('user');
+    }
+  });
+
+  it('flags ambiguity when multiple fingerprints share the same nickname', () => {
+    const store = new ThreadlineNicknames({ stateDir: tmp });
+    store.set('8c7928aa9f04fbda947172a2f9b2d81a', 'Dawn');
+    store.set('5c338c63cd2ecebc8f52483d5bba6486', 'Dawn');
+
+    const result = store.resolveByName('Dawn');
+    expect(result).not.toBeNull();
+    expect(result && 'ambiguous' in result).toBe(true);
+    if (result && 'ambiguous' in result) {
+      expect(result.candidates).toHaveLength(2);
+      const fps = result.candidates.map(c => c.fingerprint).sort();
+      expect(fps).toEqual([
+        '5c338c63cd2ecebc8f52483d5bba6486',
+        '8c7928aa9f04fbda947172a2f9b2d81a',
+      ]);
+    }
+  });
+
+  it('reads the on-disk nickname file written outside the process', () => {
+    // Simulate the user editing .instar/threadline/nicknames.json by hand
+    // (or via the dashboard) — the store's load() should pick it up.
+    const dir = path.join(tmp, 'threadline');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'nicknames.json'),
+      JSON.stringify({
+        version: 1,
+        nicknames: {
+          '8c7928aa9f04fbda947172a2f9b2d81a': {
+            nickname: 'Dawn',
+            source: 'user',
+            updatedAt: '2026-05-07T00:44:34.234Z',
+          },
+        },
+      }),
+      'utf-8',
+    );
+
+    const store = new ThreadlineNicknames({ stateDir: tmp });
+    const result = store.resolveByName('Dawn');
+    expect(result).not.toBeNull();
+    if (result && !('ambiguous' in result)) {
+      expect(result.fingerprint).toBe('8c7928aa9f04fbda947172a2f9b2d81a');
+    }
+  });
+
+  it('does not throw when nicknames.json is corrupt; treats as empty', () => {
+    const dir = path.join(tmp, 'threadline');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'nicknames.json'), '{not-json', 'utf-8');
+
+    const store = new ThreadlineNicknames({ stateDir: tmp });
+    expect(() => store.resolveByName('Dawn')).not.toThrow();
+    expect(store.resolveByName('Dawn')).toBeNull();
+  });
+
+  it('returns null for nicknames that do not match anything', () => {
+    const store = new ThreadlineNicknames({ stateDir: tmp });
+    store.set('8c7928aa9f04fbda947172a2f9b2d81a', 'Dawn');
+    expect(store.resolveByName('NotDawn')).toBeNull();
+  });
+
+  it('canonicalizes whitespace and Unicode form so hand-edits resolve', () => {
+    // Convergence-review finding: a hand-edited "Dawn " (trailing space)
+    // or "Dawn  Q" (double space) or NFD-form input would silently fail
+    // resolution under naive trim+lowercase. Canonicalization fixes both
+    // store-side and lookup-side.
+    const dir = path.join(tmp, 'threadline');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'nicknames.json'),
+      JSON.stringify({
+        version: 1,
+        nicknames: {
+          '8c7928aa9f04fbda947172a2f9b2d81a': {
+            // Hand-edited with trailing whitespace + double internal space
+            nickname: 'Dawn  Q ',
+            source: 'user',
+            updatedAt: '2026-05-07T00:44:34.234Z',
+          },
+        },
+      }),
+      'utf-8',
+    );
+    const store = new ThreadlineNicknames({ stateDir: tmp });
+    const result = store.resolveByName('dawn q');
+    expect(result).not.toBeNull();
+    if (result && !('ambiguous' in result)) {
+      expect(result.fingerprint).toBe('8c7928aa9f04fbda947172a2f9b2d81a');
+    }
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,45 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+`POST /threadline/relay-send` now consults the local nickname store at `.instar/threadline/nicknames.json` BEFORE asking the relay's discovery cache to resolve a name → fingerprint. User-curated nicknames are now the highest-authority mapping for outbound sends; relay discovery is a signal that the resolver only consults when no nickname matches.
+
+When a nickname does resolve, the route uses the nickname's fingerprint directly for both the local-delivery match (fingerprint compare against `known-agents.json`) and the relay-delivery `sendAuto` call. If relay discovery happens to also know the same name but maps it to a different fingerprint, the route logs a `[relay-send] Nickname/discovery mismatch …` warning and honors the nickname (signal-vs-authority — the user's mapping wins).
+
+`ThreadlineNicknames` (originally implemented on `feat/dashboard-grouped-nav` for the dashboard surface) is now landed on `main` with one new method — `resolveByName(name)` — and three convergence-review hardenings:
+
+- **Canonicalized matching** (`canonicalizeName(name)` static helper applies NFC + trim + internal-whitespace-collapse + lowercase): a hand-edited entry like `"Dawn  Q "` resolves the same as `"dawn q"`, including for combining-character Unicode forms. Stored strings preserve user casing/spacing for dashboard display; canonicalization happens at compare time only.
+- **Atomic writes** via temp+rename in `persist()`: a concurrent reader can no longer observe a half-written file (which would parse-fail and silently drop the user's authority). POSIX rename(2) atomicity holds because `.instar/threadline/` is a single filesystem.
+- **Corrupt-file observability**: `load()` catches JSON parse errors and emits a one-shot rate-limited warn (one log per 30s cache cycle) so a corrupted `nicknames.json` is visible in operator logs without spamming. Sends still flow via the relay-discovery fallback.
+
+Sends to inputs that look like a raw fingerprint skip the nickname check. The `name:fpPrefix` qualifier syntax now consults the nickname store and uses the prefix to disambiguate among candidates: 1 candidate matches the prefix → use it; 0 → 409 with the candidate list; multiple → 409 asking for a longer prefix. (Previously the route skipped the nickname check whenever `:fpPrefix` was present, which made the documented disambiguation remedy a dead end. Convergence review caught this; now corrected.)
+
+## What to Tell Your User
+
+- **Outbound messages now reach the right agent**: "When I send a message to someone you've named — like 'Dawn' — I now use the fingerprint you wrote in nicknames.json instead of asking the relay's directory, which can return a stale or imposter entry. If the relay disagrees with your mapping, your mapping wins and I log the conflict so you can see it."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Nickname-first send-path resolver | automatic — applies to every `/threadline/relay-send` call (which the MCP `threadline_send` tool also uses) |
+| Nickname-vs-discovery mismatch warning | automatic — logged at `[relay-send] Nickname/discovery mismatch …` when the relay's resolved fingerprint differs from a user-curated nickname for the same name |
+| `name:fpPrefix` disambiguation honors nickname store | use `name:fpPrefix` when two of your nicknamed fingerprints share a name; the route filters candidates by the prefix you supply |
+| Corrupt `nicknames.json` warn | logged at `[ThreadlineNicknames] nicknames.json parse failed …` (rate-limited to once per 30s cache cycle) |
+| `ThreadlineNicknames.resolveByName()` and `.canonicalizeName()` | imported from `'../threadline/ThreadlineNicknames.js'` for any future caller that needs name → fingerprint reverse lookup or canonical-form comparison |
+
+## Evidence
+
+Reproduction (real bug): on 2026-05-08, Echo (this agent) sent two follow-up messages to Dawn over Threadline thread `thread-2ebce60b`. The MCP `threadline_send` resolver returned fingerprint `5c338c63cd2ecebc8f52483d5bba6486` for the name "Dawn" — but Dawn's real fingerprint per Echo's `.instar/threadline/nicknames.json` (and per every prior message in that thread) was `8c7928aa9f04fbda947172a2f9b2d81a`. The messages were silently delivered to a wrong/stale recipient. Dawn never received the question. Bug surfaced when Justin asked "check again for Dawn's reply"; diagnosis traced to `ThreadlineClient.resolveAgent` consulting only the discovery cache and bypassing the user-curated nickname mapping (no source-tree code read `nicknames.json` at all on `main`).
+
+Verified-after: `tests/integration/threadline-relay-send-nickname.test.ts` reproduces the exact failure conditions — a stub relay client whose `resolveAgent('Dawn')` returns `5c338c63…` (the wrong fingerprint), with `nicknames.json` curating `Dawn` → `8c7928aa…`. The test asserts that the route sends to `8c7928aa…` (NOT the relay's wrong answer) and that `resolvedAgent` in the response body is `8c7928aa…`. The mismatch warning fires and is observable in the test output. Unit-level coverage at `tests/unit/ThreadlineNicknames.test.ts` exercises the new `resolveByName` method including the corrupt-file-tolerance, ambiguous-mapping, and canonicalization (NFC + whitespace) cases — 8 unit tests + 3 integration tests, all green. The full threadline-area subtree (1493 tests) remains green.
+
+Spec converged in 3 iterations through `/spec-converge` (multi-angle internal reviewers + GPT/Gemini/Grok cross-model reviewers). Convergence report at `docs/specs/reports/threadline-nickname-resolver-authority-convergence.md`. The convergence review caught and corrected: cache-honesty wording, atomic-write spec-vs-code mismatch, normalization weakness (added canonicalization), corrupt-file silent fail, the `name:fpPrefix` disambiguation dead-end, and one stale acceptance criterion.
+
+The `ThreadlineNicknames` class is derived from `feat/dashboard-grouped-nav` commit `16c605ce`. The convergence-review hardenings (atomic writes, canonicalization, observability warn) are additive; when that feature branch lands, the merge delta is the new methods/improvements. The `resolveByName` method is additive (new method, no existing-method signature changes) so no existing caller is affected.

--- a/upgrades/side-effects/threadline-nickname-resolver-authority.md
+++ b/upgrades/side-effects/threadline-nickname-resolver-authority.md
@@ -1,0 +1,81 @@
+# Side-Effects Review — Threadline name-resolver honors user-curated nicknames
+
+**Version / slug:** `threadline-nickname-resolver-authority`
+**Date:** `2026-05-08`
+**Author:** Echo
+**Second-pass reviewer:** required (touches Threadline send-path delivery correctness)
+
+## Summary of the change
+
+`POST /threadline/relay-send` now consults `.instar/threadline/nicknames.json` BEFORE asking the relay's discovery cache to map a name → fingerprint. User-curated nicknames are highest-authority; relay discovery is a signal the resolver only consults when no nickname matches.
+
+The `ThreadlineNicknames` class (already on `feat/dashboard-grouped-nav`, commit `16c605ce`) is cherry-picked onto `main` byte-identical, plus one additive method: `resolveByName(name)` for case-insensitive name → fingerprint reverse lookup. The route handler wires nickname resolution at the top of the request, then propagates a single `nicknameResolvedFp` through the local-delivery match (now by-fingerprint instead of by-name when set) and the relay branch (skipping `relayClient.resolveAgent` when set).
+
+When relay discovery and nicknames disagree on a name's fingerprint, the route logs a `[relay-send] Nickname/discovery mismatch …` warning and uses the nickname's fingerprint. The mismatch is not silently swallowed.
+
+Files touched:
+- `src/threadline/ThreadlineNicknames.ts` — cherry-picked from `16c605ce`; added `resolveByName(name)` method (single match | ambiguous | null).
+- `src/server/routes.ts` — added import; added nickname-first resolution block at the top of `/threadline/relay-send`; switched local-delivery name-match to fingerprint-match when nickname resolved; replaced bare `relayClient.resolveAgent(targetAgent)` with the nickname-aware version.
+- `tests/unit/ThreadlineNicknames.test.ts` — new, 7 cases covering `resolveByName`: null on missing/empty/whitespace, single match (case-insensitive), ambiguous detection, on-disk file read, corrupt-file tolerance, no-match.
+- `tests/integration/threadline-relay-send-nickname.test.ts` — new, 3 cases reproducing the production bug (relay returns wrong fingerprint, nickname authority overrides), plus the no-nickname and raw-fingerprint pass-through cases.
+- `upgrades/NEXT.md` — release note with reproduction + verified-after evidence.
+
+## Decision-point inventory
+
+- Top of `/threadline/relay-send` — **add** — new nickname-resolution block.
+- Local-delivery `nameMatches` filter — **modify** — by-fingerprint when nickname resolved, otherwise existing by-name.
+- Relay-delivery `resolveAgent` call — **modify** — uses `nicknameResolvedFp` directly when set; relay discovery only as a probe for the mismatch warning.
+- `ThreadlineNicknames.resolveByName` — **add** — additive method on existing class.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The nickname-first path overrides relay discovery whenever the user has an exact (case-insensitive) name match in their nicknames file. Concrete over-block surfaces:
+
+- **User has a stale nickname mapping**: `.instar/threadline/nicknames.json` says "Dawn" → `8c79…`, but Dawn re-keyed to `9911…`. We'd route to `8c79…` (a dead fingerprint). Mitigation: the mismatch warning surfaces in operator logs (`[relay-send] Nickname/discovery mismatch …`). User can clear the mapping via the existing `DELETE /threadline/nicknames/:fingerprint` route once the dashboard PR (`feat/dashboard-grouped-nav`) lands, or by editing the JSON file directly. The previous behavior — silently routing to whatever the relay cached — is strictly worse: it masks the staleness instead of letting the user see and fix it.
+- **User has nicknamed a remote agent with the same name as a local one**: e.g., user nicknames remote `fp_X` as "echo" and there's also a local agent literally named "echo". The route now routes to the remote one. The previous behavior would have routed locally. The user explicitly chose this nickname; honoring it is correct, and the tradeoff is documented (see Interactions §4 below).
+
+For inputs that look like raw fingerprints (`/^[0-9a-f]{16,64}$/i`) or use the `name:fpPrefix` qualifier syntax, the nickname check is skipped — caller is being explicit about a fingerprint, no over-block possible.
+
+## 2. Under-block
+
+**What does this change fail to catch that the user expects it to catch?**
+
+Names with NO nickname mapping fall through to the existing `relayClient.resolveAgent(targetAgent)` flow. The original silent-wrong-fingerprint bug can still manifest for un-nicknamed names — e.g., if the relay's discovery cache holds a stale entry for "Stranger" and the user has not nicknamed "Stranger", a send to "Stranger" will go to whatever the relay says. This fix defends the user-curated path; the underlying relay-discovery-can-be-wrong problem remains for un-nicknamed names. Acceptable scope: the user's authority lever is the nickname store; if they care about delivery correctness for an agent, they nickname it.
+
+Names with `name:fpPrefix` syntax also bypass nicknames — the caller is overriding by being explicit; if their explicit choice is wrong, that's not the resolver's job to second-guess.
+
+## 3. Level-of-abstraction fit
+
+The wiring lives in the route handler (instar-specific code) rather than in `ThreadlineClient` (generic library code). This keeps `ThreadlineClient.resolveAgent` agnostic of instar's `.instar/` state directory and nicknames file. `ThreadlineNicknames` itself is reused — no new abstraction invented; the new `resolveByName` method is the single sensible reverse-lookup primitive on a class that already exposes `get` (forward), `set`, `delete`, `all`, `invalidate`.
+
+The handler reads the nickname store inline rather than caching a long-lived instance — `ThreadlineNicknames` already has its own 30-second internal cache, so per-request construction is cheap and the cache-invalidation story stays simple (file edits visible within 30 s).
+
+## 4. Signal-vs-authority compliance
+
+This change is the canonical signal-vs-authority move:
+
+- **Signal (low-context, can be wrong)**: `relayClient.resolveAgent(name)` — the relay's discovery cache is built from gossip, can hold stale presence, can hold imposter entries.
+- **Authority (full-context, user-curated)**: `nicknames.json` — set explicitly by the user (via the dashboard ✎ pencil, the `PUT /threadline/nicknames/:fingerprint` route on the feature branch, or by hand-editing the JSON).
+
+Authority wins. Signal is consulted only when authority is silent. When the two disagree, the conflict is observable (warning log) but the route still honors authority. This matches the existing patterns in `feedback_signal_vs_authority.md` and `feedback_side_effects_review.md` from agent memory.
+
+## 5. Interactions
+
+- **Local-delivery path (same-machine agents in `known-agents.json`)**: When a nickname resolves, the local-delivery loop now matches by fingerprint instead of by name. Same-name collisions (Dawn-the-remote vs. dawn-the-local) resolve to whichever fingerprint the user nicknamed. If the user nicknamed Dawn-the-remote, sends bypass the local "dawn" agent. This is intentional — the user curated the mapping. If they wanted the local one, they wouldn't have nicknamed the remote.
+- **Self-guard (don't deliver to self)**: Unaffected. The fingerprint comparison against `identity.json` still runs on the resolved local target.
+- **`name:fpPrefix` syntax**: Unaffected. The check happens before nickname resolution and short-circuits it. Callers who use the explicit qualifier retain their existing semantics.
+- **MCP `threadline_send` tool**: Unaffected directly — the MCP server forwards `agentId` to `/threadline/relay-send` over HTTP, so the nickname-first resolution applies transparently to every MCP-initiated send. This is the path Echo's outbound messages to Dawn travel; the original bug was on this exact path.
+- **Existing tests**: The local-delivery `nameMatches` filter was wrapped in `nicknameResolvedFp ? (...) : (...)`. When no nickname store exists (the case for every existing test that doesn't write `nicknames.json`), `nicknameResolvedFp` is null and the existing by-name filter runs unchanged. No regression risk for existing test fixtures.
+- **`feat/dashboard-grouped-nav` merge conflict**: `ThreadlineNicknames.ts` is cherry-picked byte-identical from commit `16c605ce`, so when that feature branch lands, the file content already matches and only the additive `resolveByName` method is the merge delta. Trivial conflict resolution.
+
+## 6. Rollback cost
+
+Trivial. Single-commit revert. Three files changed plus one cherry-picked file plus two test files. No data-migration, no schema change, no deployment ordering. The nickname JSON file format is read-only here (no writes from the route), so even a partial rollback (revert routes.ts only, keep ThreadlineNicknames.ts) leaves the system in a consistent state.
+
+## Sign-off
+
+Change is self-contained, defends the user-curated authority lever, exposes mismatches via warning logs, leaves un-nicknamed paths unchanged, and is fully covered by integration test that reproduces the original Dawn-routing failure.


### PR DESCRIPTION
## Summary

- `/threadline/relay-send` now consults the user-curated nickname store at `.instar/threadline/nicknames.json` BEFORE asking relay discovery to resolve `name → fingerprint`. User nicknames are authority; relay discovery is signal.
- When the nickname's fingerprint and discovery's fingerprint disagree on the same name, the route honors the nickname and logs `[relay-send] Nickname/discovery mismatch …` so the conflict is observable.
- `name:fpPrefix` disambiguation now consults the nickname store (previously the route skipped the nickname check whenever `:fpPrefix` was present, which made the documented disambiguation a dead end).

## Why

Real-world failure on 2026-05-08: a send to "Dawn" went to fingerprint `5c338c63cd2ecebc8f52483d5bba6486` instead of the curated `8c7928aa9f04fbda947172a2f9b2d81a`. The relay accepted the envelope, the canonical outbox recorded "relay-sent" with the requested name attached, and there was no signal anywhere that the message reached the wrong recipient. Bug surfaced only because the human noticed the silence.

Root cause: `ThreadlineClient.resolveAgent` consulted only the relay's discovery cache; nothing on `main` read `nicknames.json` for outbound sends. The user's hand-curated authority mapping was decorative.

## Convergence-review hardenings

`/spec-converge` ran 3 iterations (security, scalability, adversarial, integration internal reviewers + GPT/Gemini/Grok external) and surfaced 5 findings, each fixed in lockstep with the spec:

- Canonical name compare (`canonicalizeName`: NFC + trim + whitespace-collapse + lowercase) so hand-edited entries like `"Dawn  Q "` resolve under `"dawn q"` and combining-character forms.
- Atomic writes via temp+rename in `ThreadlineNicknames.persist()` — concurrent reader can no longer observe a half-written file (which would parse-fail and silently drop user authority).
- Rate-limited corrupt-file warn — silent authority loss is now visible in operator logs (one log per 30s cache cycle).
- `name:fpPrefix` dispatcher now consults the nickname store and filters candidates by prefix.
- Acceptance Criterion #3 was stale → rewritten to match the new dispatcher.

## Files

- `src/threadline/ThreadlineNicknames.ts` (new) — cherry-picked from `feat/dashboard-grouped-nav` `16c605ce`, extended with `resolveByName()`, `canonicalizeName()` static helper, atomic persist, corrupt-file warn.
- `src/server/routes.ts` — nickname-first resolution at `POST /threadline/relay-send`, mismatch-warning log, `name:fpPrefix` dispatcher fix.
- `tests/unit/ThreadlineNicknames.test.ts` (new) — 8 tests including ambiguous mapping, on-disk read, corrupt-file tolerance, canonicalization (NFC + whitespace).
- `tests/integration/threadline-relay-send-nickname.test.ts` (new) — 3 tests including production-bug repro (stub relay returns wrong fingerprint, nickname authority overrides).
- `docs/specs/THREADLINE-NICKNAME-RESOLVER-AUTHORITY-SPEC.md` (new) — spec, converged + approved.
- `docs/specs/reports/threadline-nickname-resolver-authority-convergence.md` (new) — convergence report.
- `upgrades/NEXT.md` (new) — release notes.
- `upgrades/side-effects/threadline-nickname-resolver-authority.md` (new) — side-effects review (over/under-block, abstraction-fit, signal-vs-authority compliance, interactions, rollback cost).

## Test plan

- [x] 8 unit tests for `ThreadlineNicknames.resolveByName` pass (including corrupt-file tolerance, canonicalization, ambiguous-mapping).
- [x] 3 integration tests for `/threadline/relay-send` pass — production-bug repro asserts route sends to nickname's `8c7928aa…` instead of stub-relay's wrong `5c338c63…`.
- [x] Threadline subtree (1493 tests) green pre-push.
- [ ] CI green on this PR.
- [ ] Live verification post-merge: send a real message to "Dawn" via MCP `threadline_send`, confirm canonical outbox uses `8c7928aa…` not `5c338c63…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)