### PR TITLE
feat(tasks): TaskFlow Phase 1 — skeleton + storage + sweeper + waker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ dist/
 .instar/shared-state.jsonl
 .instar/shared-state.jsonl.*
 
+# TaskFlow registry — local SQLite + WAL/SHM. May contain user PII in stateJson.
+# Cross-machine sync of flow state is not in v1 scope.
+.instar/task-flows.db
+.instar/task-flows.db-*
+
 # OS
 .DS_Store
 Thumbs.db

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6199,8 +6199,45 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { InitiativeTracker } = await import('../core/InitiativeTracker.js');
     const initiativeTracker = new InitiativeTracker(config.stateDir);
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, proxyCoordinator, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory });
+    // TaskFlow registry — opt-in via config.taskFlow.enabled (default: off in v1).
+    // Owns its own SQLite file under .instar/task-flows.db. The maintenance
+    // sweeper and due-waker start with the registry; both .unref() their timers
+    // so they never keep the process alive on shutdown.
+    let taskFlowRegistry: import('../tasks/TaskFlowRegistry.js').TaskFlowRegistry | undefined;
+    let taskFlowSweeper: import('../tasks/TaskFlowMaintenanceSweeper.js').TaskFlowMaintenanceSweeper | undefined;
+    let taskFlowDueWaker: import('../tasks/TaskFlowDueWaker.js').TaskFlowDueWaker | undefined;
+    if ((config as any).taskFlow?.enabled) {
+      try {
+        const { TaskFlowStore } = await import('../tasks/task-flow-registry.store.sqlite.js');
+        const { TaskFlowRegistry } = await import('../tasks/TaskFlowRegistry.js');
+        const { TaskFlowMaintenanceSweeper } = await import('../tasks/TaskFlowMaintenanceSweeper.js');
+        const { TaskFlowDueWaker } = await import('../tasks/TaskFlowDueWaker.js');
+        const path = await import('node:path');
+        const dbPath = path.default.join(config.stateDir, 'task-flows.db');
+        const store = new TaskFlowStore({ dbPath });
+        await store.open();
+        taskFlowRegistry = new TaskFlowRegistry({
+          store,
+          ledger: sharedStateLedger ?? undefined,
+          thresholds: (config as any).taskFlow?.thresholds,
+        });
+        taskFlowSweeper = new TaskFlowMaintenanceSweeper({
+          registry: taskFlowRegistry,
+          store,
+          ledger: sharedStateLedger ?? undefined,
+        });
+        taskFlowDueWaker = new TaskFlowDueWaker({ registry: taskFlowRegistry });
+        taskFlowSweeper.start();
+        taskFlowDueWaker.start();
+      } catch (err) {
+        console.warn('[instar] task-flow init failed (non-fatal):', err);
+        taskFlowRegistry = undefined;
+      }
+    }
+
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, proxyCoordinator, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry });
     await server.start();
+    void taskFlowSweeper; void taskFlowDueWaker;
 
     // Connect DegradationReporter downstream systems now that everything is initialized.
     // Any degradation events queued during startup will drain to feedback + telegram.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -164,6 +164,8 @@ export class AgentServer {
     telegramBridge?: import('../threadline/TelegramBridge.js').TelegramBridge;
     /** Threadline observability — read-only views over inbox/outbox/bindings. */
     threadlineObservability?: import('../threadline/ThreadlineObservability.js').ThreadlineObservability;
+    /** TaskFlow registry — durable multi-step job records (OpenClaw import). */
+    taskFlowRegistry?: import('../tasks/TaskFlowRegistry.js').TaskFlowRegistry;
   }) {
     this.config = options.config;
     this.startTime = new Date();
@@ -428,6 +430,7 @@ export class AgentServer {
       telegramBridgeConfig: options.telegramBridgeConfig ?? null,
       telegramBridge: options.telegramBridge ?? null,
       threadlineObservability: options.threadlineObservability ?? null,
+      taskFlowRegistry: options.taskFlowRegistry ?? null,
       startTime: this.startTime,
     };
     this.routeContext = routeCtx;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -12980,7 +12980,8 @@ export function createRoutes(ctx: RouteContext): Router {
         const out = await ctx.taskFlowRegistry.createFlow(req.body ?? {});
         res.status(out.created ? 201 : 200).json(out.flow);
       } catch (err) {
-        taskFlowError(res, err);
+        if (err instanceof Error) taskFlowError(res, err);
+        else res.status(500).json({ error: 'internal_error' });
       }
     });
 
@@ -13119,7 +13120,8 @@ export function createRoutes(ctx: RouteContext): Router {
         }
         res.json(result);
       } catch (err) {
-        taskFlowError(res, err);
+        if (err instanceof Error) taskFlowError(res, err);
+        else res.status(500).json({ error: 'internal_error' });
       }
     };
 
@@ -13150,7 +13152,8 @@ export function createRoutes(ctx: RouteContext): Router {
         });
         res.json(result);
       } catch (err) {
-        taskFlowError(res, err);
+        if (err instanceof Error) taskFlowError(res, err);
+        else res.status(500).json({ error: 'internal_error' });
       }
     });
 
@@ -13174,7 +13177,8 @@ export function createRoutes(ctx: RouteContext): Router {
         });
         res.json(flow);
       } catch (err) {
-        taskFlowError(res, err);
+        if (err instanceof Error) taskFlowError(res, err);
+        else res.status(500).json({ error: 'internal_error' });
       }
     });
   }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -606,6 +606,10 @@ export interface RouteContext {
   /** Token-usage ledger (read-only observability over Claude Code JSONL
    *  transcripts). Null when stateDir is unavailable. */
   tokenLedger: import('../monitoring/TokenLedger.js').TokenLedger | null;
+  /** TaskFlow registry — durable multi-step job records (OpenClaw import).
+   *  Null when not enabled. Phase 1: no business consumers; admin endpoints
+   *  only. */
+  taskFlowRegistry: import('../tasks/TaskFlowRegistry.js').TaskFlowRegistry | null;
   startTime: Date;
 }
 
@@ -12937,6 +12941,243 @@ export function createRoutes(ctx: RouteContext): Router {
       });
     }
   );
+
+  // ─── TaskFlow registry (OpenClaw import — Phase 1) ──────────────────
+  // Admin Bearer-token auth via global authMiddleware. The HTTP API exists for
+  // debugging and out-of-process tooling; production controllers run
+  // in-process inside the server and call the registry directly.
+  // See docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md.
+  {
+    const taskFlowError = (
+      res: ExpressResponse,
+      err: unknown
+    ): void => {
+      const e = err as { name?: string; code?: string; message?: string; detail?: Record<string, unknown> };
+      if (e?.name !== 'TaskFlowError') {
+        res.status(500).json({ error: 'internal_error', message: e?.message });
+        return;
+      }
+      const status = ({
+        not_found: 404,
+        revision_conflict: 409,
+        already_terminal: 410,
+        invalid_transition: 422,
+        invalid_argument: 422,
+        unauthorized_controller: 422,
+        already_consumed: 422,
+        wait_collision: 422,
+        quota_exceeded: 429,
+      } as Record<string, number>)[e.code ?? ''] ?? 500;
+      res.status(status).json({ error: e.code, ...(e.detail ?? {}), message: e.message });
+    };
+
+    router.post('/flows', async (req, res) => {
+      if (!ctx.taskFlowRegistry) {
+        res.status(503).json({ error: 'taskflow_not_enabled' });
+        return;
+      }
+      try {
+        const out = await ctx.taskFlowRegistry.createFlow(req.body ?? {});
+        res.status(out.created ? 201 : 200).json(out.flow);
+      } catch (err) {
+        taskFlowError(res, err);
+      }
+    });
+
+    router.get('/flows/:flowId', (req, res) => {
+      if (!ctx.taskFlowRegistry) {
+        res.status(503).json({ error: 'taskflow_not_enabled' });
+        return;
+      }
+      const flow = ctx.taskFlowRegistry.getFlow(req.params.flowId);
+      if (!flow) {
+        res.status(404).json({ error: 'not_found', flowId: req.params.flowId });
+        return;
+      }
+      // The owning controller may identify itself via header to receive the
+      // unredacted record. Otherwise we return the redacted shape (no
+      // stateJson, waitJson reduced to {kind}).
+      const callerControllerId = req.header('x-taskflow-controller-id');
+      if (callerControllerId && callerControllerId === flow.controllerId) {
+        res.json(flow);
+        return;
+      }
+      res.json(ctx.taskFlowRegistry.getRedactedFlow(req.params.flowId));
+    });
+
+    router.get('/flows/waiting', (req, res) => {
+      if (!ctx.taskFlowRegistry) {
+        res.status(503).json({ error: 'taskflow_not_enabled' });
+        return;
+      }
+      const channel = typeof req.query.channel === 'string' ? req.query.channel : undefined;
+      const threadId = typeof req.query.threadId === 'string' ? req.query.threadId : undefined;
+      const peer = typeof req.query.peer === 'string' ? req.query.peer : undefined;
+      const correlationId =
+        typeof req.query.correlationId === 'string' ? req.query.correlationId : undefined;
+      const waitKind = typeof req.query.waitKind === 'string' ? req.query.waitKind : undefined;
+      if (channel && threadId && peer) {
+        res.json({
+          matches: ctx.taskFlowRegistry.findWaitingByReply({ channel, threadId, peer }),
+        });
+        return;
+      }
+      if (correlationId && (waitKind === 'external-call' || waitKind === 'cross-agent-callback')) {
+        res.json({
+          matches: ctx.taskFlowRegistry.findWaitingByCorrelation({ waitKind, correlationId }),
+        });
+        return;
+      }
+      res.status(400).json({ error: 'invalid_query', message: 'specify (channel,threadId,peer) or (correlationId,waitKind)' });
+    });
+
+    const occMutationHandler = (
+      op: 'startStep' | 'setFlowWaiting' | 'resumeFlow' | 'finishFlow' | 'failFlow' | 'cancelFlow' | 'markLost'
+    ) => async (req: ExpressRequest, res: ExpressResponse) => {
+      if (!ctx.taskFlowRegistry) {
+        res.status(503).json({ error: 'taskflow_not_enabled' });
+        return;
+      }
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const flowId = req.params.flowId;
+      const expectedRevision = Number(body.expectedRevision);
+      if (!Number.isFinite(expectedRevision)) {
+        res.status(422).json({ error: 'invalid_argument', field: 'expectedRevision' });
+        return;
+      }
+      const principal = body.principal as
+        | { scope: 'controller'; controllerId: string; controllerInstanceId: string }
+        | { scope: 'system-waker'; wakerId: string }
+        | { scope: 'admin' }
+        | undefined;
+      if (!principal || typeof principal !== 'object' || !('scope' in principal)) {
+        res.status(422).json({ error: 'invalid_argument', field: 'principal' });
+        return;
+      }
+      try {
+        let result;
+        switch (op) {
+          case 'startStep':
+            result = await ctx.taskFlowRegistry.startStep({
+              flowId,
+              expectedRevision,
+              principal: principal as any,
+              currentStep: String(body.currentStep ?? ''),
+            });
+            break;
+          case 'setFlowWaiting':
+            result = await ctx.taskFlowRegistry.setFlowWaiting({
+              flowId,
+              expectedRevision,
+              principal: principal as any,
+              waitJson: body.waitJson as any,
+              currentStep: body.currentStep as string | undefined,
+              statePatch: body.statePatch,
+            });
+            break;
+          case 'resumeFlow':
+            result = await ctx.taskFlowRegistry.resumeFlow({
+              flowId,
+              expectedRevision,
+              principal: principal as any,
+              waitInstanceId: String(body.waitInstanceId ?? ''),
+              currentStep: body.currentStep as string | undefined,
+              statePatch: body.statePatch,
+            });
+            break;
+          case 'finishFlow':
+            result = await ctx.taskFlowRegistry.finishFlow({
+              flowId,
+              expectedRevision,
+              principal: principal as any,
+              result: body.result,
+            });
+            break;
+          case 'failFlow':
+            result = await ctx.taskFlowRegistry.failFlow({
+              flowId,
+              expectedRevision,
+              principal: principal as any,
+              failureReason: String(body.failureReason ?? ''),
+            });
+            break;
+          case 'cancelFlow':
+            result = await ctx.taskFlowRegistry.cancelFlow({
+              flowId,
+              expectedRevision,
+              principal: principal as any,
+            });
+            break;
+          case 'markLost':
+            result = await ctx.taskFlowRegistry.markLost({
+              flowId,
+              expectedRevision,
+              ledgerEntryId: String(body.ledgerEntryId ?? ''),
+              reason: body.reason === 'stranded' ? 'stranded' : 'lost',
+            });
+            break;
+        }
+        res.json(result);
+      } catch (err) {
+        taskFlowError(res, err);
+      }
+    };
+
+    router.post('/flows/:flowId/start-step', occMutationHandler('startStep'));
+    router.post('/flows/:flowId/wait', occMutationHandler('setFlowWaiting'));
+    router.post('/flows/:flowId/resume', occMutationHandler('resumeFlow'));
+    router.post('/flows/:flowId/finish', occMutationHandler('finishFlow'));
+    router.post('/flows/:flowId/fail', occMutationHandler('failFlow'));
+    router.post('/flows/:flowId/cancel-flow', occMutationHandler('cancelFlow'));
+    router.post('/flows/:flowId/mark-lost', occMutationHandler('markLost'));
+
+    router.post('/flows/:flowId/cancel-request', async (req, res) => {
+      if (!ctx.taskFlowRegistry) {
+        res.status(503).json({ error: 'taskflow_not_enabled' });
+        return;
+      }
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const expectedRevision = Number(body.expectedRevision);
+      if (!Number.isFinite(expectedRevision)) {
+        res.status(422).json({ error: 'invalid_argument', field: 'expectedRevision' });
+        return;
+      }
+      try {
+        const result = await ctx.taskFlowRegistry.requestFlowCancel({
+          flowId: req.params.flowId,
+          expectedRevision,
+          requesterOrigin: body.requesterOrigin as any,
+        });
+        res.json(result);
+      } catch (err) {
+        taskFlowError(res, err);
+      }
+    });
+
+    router.post('/flows/:flowId/ping', async (req, res) => {
+      if (!ctx.taskFlowRegistry) {
+        res.status(503).json({ error: 'taskflow_not_enabled' });
+        return;
+      }
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const principal = body.principal as
+        | { scope: 'controller'; controllerId: string; controllerInstanceId: string }
+        | undefined;
+      if (!principal || principal.scope !== 'controller') {
+        res.status(422).json({ error: 'invalid_argument', field: 'principal' });
+        return;
+      }
+      try {
+        const flow = await ctx.taskFlowRegistry.pingFlow({
+          flowId: req.params.flowId,
+          principal,
+        });
+        res.json(flow);
+      } catch (err) {
+        taskFlowError(res, err);
+      }
+    });
+  }
 
   return router;
 }

--- a/src/tasks/TaskFlowDueWaker.ts
+++ b/src/tasks/TaskFlowDueWaker.ts
@@ -1,0 +1,80 @@
+/**
+ * TaskFlowDueWaker — minute-tick poll that resumes `scheduled-tick` waits
+ * whose `dueAt` has passed.
+ *
+ * Acts under the system-waker scope: it does not own the controller of the
+ * woken flow. Per spec § Architecture, it transitions waiting → running and
+ * leaves step advancement to the owning controller (which subscribes to
+ * `taskflow:wait-fired`).
+ */
+
+import { TaskFlowRegistry } from './TaskFlowRegistry.js';
+import { DUE_WAKER_INTERVAL_MS, TaskFlowError } from './task-flow-types.js';
+
+export interface DueWakerOptions {
+  registry: TaskFlowRegistry;
+  intervalMs?: number;
+  now?: () => number;
+  wakerId?: string;
+}
+
+export class TaskFlowDueWaker {
+  private timer: NodeJS.Timeout | null = null;
+  private readonly registry: TaskFlowRegistry;
+  private readonly intervalMs: number;
+  private readonly now: () => number;
+  private readonly wakerId: string;
+
+  constructor(opts: DueWakerOptions) {
+    this.registry = opts.registry;
+    this.intervalMs = opts.intervalMs ?? DUE_WAKER_INTERVAL_MS;
+    this.now = opts.now ?? (() => Date.now());
+    this.wakerId = opts.wakerId ?? 'TaskFlowDueWaker';
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      this.tick().catch(() => {
+        /* swallow — best-effort */
+      });
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Wake every scheduled-tick wait with `dueAt <= now`. Returns rows woken. */
+  async tick(): Promise<number> {
+    const matches = this.registry.findWaitingByDueAt(this.now());
+    let resumed = 0;
+    for (const m of matches) {
+      try {
+        await this.registry.resumeFlow({
+          flowId: m.flowId,
+          expectedRevision: m.revision,
+          waitInstanceId: m.waitInstanceId,
+          principal: { scope: 'system-waker', wakerId: this.wakerId },
+        });
+        this.registry.emit('taskflow:wait-fired', {
+          flowId: m.flowId,
+          controllerId: m.controllerId,
+        });
+        resumed++;
+      } catch (err) {
+        if (err instanceof TaskFlowError) {
+          if (err.code === 'revision_conflict') continue;
+          if (err.code === 'already_terminal') continue;
+          if (err.code === 'already_consumed') continue;
+        }
+        // Other errors: swallow and continue with the rest.
+      }
+    }
+    return resumed;
+  }
+}

--- a/src/tasks/TaskFlowMaintenanceSweeper.ts
+++ b/src/tasks/TaskFlowMaintenanceSweeper.ts
@@ -1,0 +1,150 @@
+/**
+ * TaskFlowMaintenanceSweeper — hourly scan that marks stranded flows `lost`.
+ *
+ * Acts as a reserved controller (`TaskFlowMaintenance`); the registry
+ * whitelists this id for terminal-from-running and terminal-from-waiting
+ * transitions via `markLost`. Every transition emits a SharedStateLedger note
+ * for human-visible audit context.
+ *
+ * Threshold rules per spec § Sweeper threshold policy.
+ */
+
+import crypto from 'node:crypto';
+import { TaskFlowRegistry } from './TaskFlowRegistry.js';
+import { TaskFlowStore } from './task-flow-registry.store.sqlite.js';
+import {
+  SWEEPER_INTERVAL_MS,
+  SweeperEvalCounts,
+  TaskFlowError,
+  TaskFlowThresholds,
+} from './task-flow-types.js';
+import type { SharedStateLedger } from '../core/SharedStateLedger.js';
+
+export interface SweeperOptions {
+  registry: TaskFlowRegistry;
+  store: TaskFlowStore;
+  ledger?: SharedStateLedger;
+  intervalMs?: number;
+  now?: () => number;
+}
+
+export class TaskFlowMaintenanceSweeper {
+  private timer: NodeJS.Timeout | null = null;
+  private readonly registry: TaskFlowRegistry;
+  private readonly store: TaskFlowStore;
+  private readonly ledger?: SharedStateLedger;
+  private readonly intervalMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: SweeperOptions) {
+    this.registry = opts.registry;
+    this.store = opts.store;
+    this.ledger = opts.ledger;
+    this.intervalMs = opts.intervalMs ?? SWEEPER_INTERVAL_MS;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      this.sweep().catch(() => {
+        /* swallow — best-effort hourly sweep */
+      });
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Scan candidate flows and mark eligible rows as `lost`. Returns counts.
+   * Idempotent — safe to call as often as desired.
+   */
+  async sweep(): Promise<SweeperEvalCounts> {
+    const t = this.registry.getThresholds();
+    const candidates = this.store.findSweeperCandidates();
+    let marked = 0;
+    for (const flow of candidates) {
+      if (!this.isLostEligible(flow, t)) continue;
+      // Best-effort ledger note BEFORE markLost so we have the explanation
+      // even if markLost loses an OCC race.
+      const ledgerEntryId = await this.appendSweeperLedgerNote(flow, t);
+      try {
+        await this.registry.markLost({
+          flowId: flow.flowId,
+          expectedRevision: flow.revision,
+          ledgerEntryId,
+          reason: 'lost',
+        });
+        marked++;
+      } catch (err) {
+        if (err instanceof TaskFlowError && err.code === 'revision_conflict') continue;
+        if (err instanceof TaskFlowError && err.code === 'already_terminal') continue;
+        // Anything else: swallow but keep going. The ledger note remains as a
+        // hint for human follow-up.
+      }
+    }
+    return { scanned: candidates.length, marked };
+  }
+
+  private isLostEligible(
+    flow: { status: string; controllerHeartbeatAt: number; waitJson?: any; waitStartedAt?: number },
+    t: TaskFlowThresholds
+  ): boolean {
+    const now = this.now();
+    if (flow.status === 'running') {
+      return now - flow.controllerHeartbeatAt > t.RUNNING_LOST_MS;
+    }
+    if (flow.status !== 'waiting') return false;
+    const startedAt = flow.waitStartedAt ?? 0;
+    const kind = flow.waitJson?.kind;
+    switch (kind) {
+      case 'reply':
+        return now - startedAt > t.REPLY_LOST_MS;
+      case 'human-review':
+        return now - startedAt > t.HUMAN_REVIEW_LOST_MS;
+      case 'external-call': {
+        const deadline = flow.waitJson?.deadline as number | undefined;
+        if (typeof deadline === 'number') return now > deadline + t.EXTERNAL_GRACE_MS;
+        return now - startedAt > t.EXTERNAL_LOST_MS;
+      }
+      case 'cross-agent-callback':
+        return now - startedAt > t.XAGENT_LOST_MS;
+      case 'scheduled-tick':
+      default:
+        return false;
+    }
+  }
+
+  private async appendSweeperLedgerNote(
+    flow: { flowId: string; revision: number; controllerId: string; status: string },
+    _t: TaskFlowThresholds
+  ): Promise<string> {
+    const id = crypto.randomUUID();
+    if (!this.ledger) return id;
+    try {
+      const entry = await this.ledger.append({
+        kind: 'note:taskflow-lost',
+        provenance: 'TaskFlowMaintenanceSweeper',
+        emittedBy: 'TaskFlowMaintenanceSweeper',
+        counterparty: 'self',
+        subject: 'taskflow-lost',
+        dedupKey: `taskflow-lost:${flow.flowId}:${flow.revision}`,
+        payload: {
+          flowId: flow.flowId,
+          revision: flow.revision,
+          controllerId: flow.controllerId,
+          fromStatus: flow.status,
+        },
+      } as any);
+      return entry?.id ?? id;
+    } catch {
+      return id;
+    }
+  }
+}

--- a/src/tasks/TaskFlowRegistry.ts
+++ b/src/tasks/TaskFlowRegistry.ts
@@ -1,0 +1,770 @@
+/**
+ * TaskFlowRegistry — durable, optimistic-concurrency multi-step job records.
+ *
+ * Imported (trimmed) from OpenClaw's task-flow-registry. See
+ * `docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md` for full design.
+ *
+ * v1 constraints (deliberate):
+ *   - Single writer (the instar server process).
+ *   - `managed` sync mode only.
+ *   - No `blocked` status (overlapped `waiting`).
+ *   - Notification dispatch is wired but stubbed at metric-emission only;
+ *     Phase 5 wires through `TelegramAdapter` send.
+ */
+
+import { EventEmitter } from 'node:events';
+import crypto from 'node:crypto';
+import { TaskFlowStore } from './task-flow-registry.store.sqlite.js';
+import {
+  TaskFlowRecord,
+  TaskFlowStatus,
+  TaskFlowError,
+  TaskFlowPrincipal,
+  TaskNotifyPolicy,
+  TaskFlowThresholds,
+  CreateFlowInput,
+  WaitJson,
+  RequesterOrigin,
+  SupersededRef,
+  ApplyResult,
+  WaitMatch,
+  createFlowInputSchema,
+  waitJsonSchema,
+  isTerminalStatus,
+  jsonByteLength,
+  MAX_STATE_JSON_BYTES,
+  MAX_WAIT_JSON_BYTES,
+  MAX_GOAL_CHARS,
+  MAX_CURRENT_STEP_CHARS,
+  MAX_CACHE_ENTRIES,
+  DEFAULT_THRESHOLDS,
+  RESERVED_MAINTENANCE_CONTROLLER,
+} from './task-flow-types.js';
+import type { SharedStateLedger } from '../core/SharedStateLedger.js';
+
+export interface TaskFlowRegistryOptions {
+  store: TaskFlowStore;
+  ledger?: SharedStateLedger;
+  thresholds?: Partial<TaskFlowThresholds>;
+  now?: () => number;
+}
+
+interface NotifyMetrics {
+  emitted: number;
+  byKind: Record<string, number>;
+}
+
+export class TaskFlowRegistry extends EventEmitter {
+  private readonly store: TaskFlowStore;
+  private readonly ledger?: SharedStateLedger;
+  private readonly thresholds: TaskFlowThresholds;
+  private readonly now: () => number;
+  private readonly cache = new Map<string, TaskFlowRecord>();
+  readonly notifyMetrics: NotifyMetrics = { emitted: 0, byKind: {} };
+
+  constructor(opts: TaskFlowRegistryOptions) {
+    super();
+    this.store = opts.store;
+    this.ledger = opts.ledger;
+    this.thresholds = { ...DEFAULT_THRESHOLDS, ...(opts.thresholds ?? {}) };
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  getThresholds(): TaskFlowThresholds {
+    return { ...this.thresholds };
+  }
+
+  // ────────────────── reads ──────────────────
+
+  getFlow(flowId: string, opts: { bypassCache?: boolean } = {}): TaskFlowRecord | null {
+    if (!opts.bypassCache) {
+      const cached = this.cache.get(flowId);
+      if (cached) return cached;
+    }
+    const rec = this.store.getFlow(flowId);
+    if (rec) this.cachePut(rec);
+    return rec;
+  }
+
+  /** Returns the redacted view safe to expose to non-owning callers. */
+  getRedactedFlow(flowId: string): Partial<TaskFlowRecord> | null {
+    const rec = this.getFlow(flowId);
+    if (!rec) return null;
+    return {
+      flowId: rec.flowId,
+      ownerKey: rec.ownerKey,
+      controllerId: rec.controllerId,
+      revision: rec.revision,
+      status: rec.status,
+      goal: rec.goal,
+      currentStep: rec.currentStep,
+      createdAt: rec.createdAt,
+      updatedAt: rec.updatedAt,
+      endedAt: rec.endedAt,
+      // wait_kind only — never the identifying fields inside waitJson
+      waitJson: rec.waitJson ? ({ kind: rec.waitJson.kind } as WaitJson) : undefined,
+    };
+  }
+
+  findWaitingByReply(args: {
+    channel: string;
+    threadId: string;
+    peer: string;
+  }): WaitMatch[] {
+    return this.store
+      .findWaitingReplyByTarget(args)
+      .filter((r) => r.waitInstanceId)
+      .map((r) => this.toWaitMatch(r));
+  }
+
+  findWaitingByCorrelation(args: {
+    waitKind: 'external-call' | 'cross-agent-callback';
+    correlationId: string;
+  }): WaitMatch[] {
+    return this.store
+      .findWaitingByCorrelation(args)
+      .filter((r) => r.waitInstanceId)
+      .map((r) => this.toWaitMatch(r));
+  }
+
+  findWaitingByDueAt(nowMs: number): WaitMatch[] {
+    return this.store
+      .findWaitingDue(nowMs)
+      .filter((r) => r.waitInstanceId)
+      .map((r) => this.toWaitMatch(r));
+  }
+
+  // ────────────────── createFlow ──────────────────
+
+  async createFlow(
+    input: CreateFlowInput
+  ): Promise<{ flow: TaskFlowRecord; created: boolean }> {
+    const parsed = createFlowInputSchema.safeParse(input);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      throw new TaskFlowError(
+        'invalid_argument',
+        `${issue.path.join('.')}: ${issue.message}`,
+        { field: issue.path.join('.'), reason: issue.message }
+      );
+    }
+    if (parsed.data.controllerId === RESERVED_MAINTENANCE_CONTROLLER) {
+      throw new TaskFlowError(
+        'unauthorized_controller',
+        'TaskFlowMaintenance is a reserved controllerId; createFlow rejected',
+        { actual: parsed.data.controllerId }
+      );
+    }
+    if (parsed.data.stateJson !== undefined) {
+      this.validateStateJsonSize(parsed.data.stateJson);
+    }
+    return this.store.withWriteTransaction(() => {
+      const existing = this.store.findIdempotent(
+        parsed.data.controllerId,
+        parsed.data.ownerKey,
+        parsed.data.idempotencyKey
+      );
+      if (existing) return { flow: existing, created: false };
+      const ts = this.now();
+      const rec: TaskFlowRecord = {
+        flowId: this.genId(),
+        ownerKey: parsed.data.ownerKey,
+        controllerId: parsed.data.controllerId,
+        controllerInstanceId: parsed.data.controllerInstanceId,
+        controllerHeartbeatAt: ts,
+        revision: 1,
+        status: 'queued',
+        notifyPolicy: parsed.data.notifyPolicy ?? { kind: 'silent' },
+        goal: parsed.data.goal,
+        currentStep: parsed.data.currentStep,
+        stateJson: parsed.data.stateJson,
+        requesterOrigin: parsed.data.requesterOrigin,
+        privacyScope: parsed.data.privacyScope,
+        createdAt: ts,
+        updatedAt: ts,
+      };
+      this.store.insertFlow(rec, parsed.data.idempotencyKey);
+      this.cachePut(rec);
+      this.emitTransitionLedgerNote(rec, null, 'queued', 'createFlow');
+      return { flow: rec, created: true };
+    });
+  }
+
+  // ────────────────── transitions ──────────────────
+
+  async startStep(args: {
+    flowId: string;
+    expectedRevision: number;
+    principal: TaskFlowPrincipal;
+    currentStep: string;
+  }): Promise<ApplyResult> {
+    if (args.currentStep.length > MAX_CURRENT_STEP_CHARS) {
+      throw new TaskFlowError('invalid_argument', 'currentStep exceeds limit', {
+        field: 'currentStep',
+      });
+    }
+    return this.applyOcc(args.flowId, args.expectedRevision, (cur) => {
+      this.assertControllerScope(cur, args.principal);
+      if (cur.status !== 'queued' && cur.status !== 'running') {
+        throw new TaskFlowError('invalid_transition', `cannot startStep from ${cur.status}`, {
+          from: cur.status,
+          op: 'startStep',
+        });
+      }
+      const next: TaskFlowRecord = {
+        ...cur,
+        status: 'running',
+        currentStep: args.currentStep,
+        controllerInstanceId: this.controllerInstanceFromPrincipal(args.principal, cur),
+        controllerHeartbeatAt: this.now(),
+        revision: cur.revision + 1,
+        updatedAt: this.now(),
+      };
+      return next;
+    }, 'startStep');
+  }
+
+  async setFlowWaiting(args: {
+    flowId: string;
+    expectedRevision: number;
+    principal: TaskFlowPrincipal;
+    waitJson: WaitJson;
+    currentStep?: string;
+    notifyPolicy?: TaskNotifyPolicy;
+    statePatch?: unknown;
+  }): Promise<ApplyResult> {
+    const parsed = waitJsonSchema.safeParse(args.waitJson);
+    if (!parsed.success) {
+      throw new TaskFlowError('invalid_argument', 'waitJson failed validation', {
+        field: 'waitJson',
+        reason: parsed.error.issues[0]?.message,
+      });
+    }
+    if (jsonByteLength(parsed.data) > MAX_WAIT_JSON_BYTES) {
+      throw new TaskFlowError('invalid_argument', 'waitJson exceeds size limit', {
+        field: 'waitJson',
+      });
+    }
+    return this.applyOcc(args.flowId, args.expectedRevision, (cur) => {
+      this.assertControllerScope(cur, args.principal);
+      if (cur.status !== 'running') {
+        throw new TaskFlowError(
+          'invalid_transition',
+          `cannot setFlowWaiting from ${cur.status}`,
+          { from: cur.status, op: 'setFlowWaiting' }
+        );
+      }
+      // Reply uniqueness: at most one active reply wait per (controllerId, channel, threadId, peer).
+      if (parsed.data.kind === 'reply') {
+        const collisions = this.store.findWaitingReplyByTarget({
+          channel: parsed.data.channel,
+          threadId: parsed.data.threadId,
+          peer: parsed.data.peer,
+          controllerId: cur.controllerId,
+        });
+        if (collisions.length > 0) {
+          throw new TaskFlowError(
+            'wait_collision',
+            'duplicate reply wait for (controllerId, channel, threadId, peer)',
+            { existingFlowId: collisions[0].flowId }
+          );
+        }
+      }
+      const ts = this.now();
+      let nextState = cur.stateJson;
+      if (args.statePatch !== undefined) {
+        nextState = args.statePatch;
+        this.validateStateJsonSize(nextState);
+      }
+      const next: TaskFlowRecord = {
+        ...cur,
+        status: 'waiting',
+        waitJson: parsed.data,
+        waitInstanceId: this.genId(),
+        waitStartedAt: ts,
+        currentStep: args.currentStep ?? cur.currentStep,
+        notifyPolicy: args.notifyPolicy ?? cur.notifyPolicy,
+        stateJson: nextState,
+        controllerInstanceId: this.controllerInstanceFromPrincipal(args.principal, cur),
+        controllerHeartbeatAt: ts,
+        revision: cur.revision + 1,
+        updatedAt: ts,
+      };
+      return next;
+    }, 'setFlowWaiting');
+  }
+
+  async resumeFlow(args: {
+    flowId: string;
+    expectedRevision: number;
+    principal: TaskFlowPrincipal;
+    waitInstanceId: string;
+    currentStep?: string;
+    statePatch?: unknown;
+  }): Promise<ApplyResult> {
+    return this.applyOcc(args.flowId, args.expectedRevision, (cur) => {
+      // controller principal must match controllerId; system-waker permitted.
+      if (args.principal.scope === 'controller') {
+        this.assertControllerScope(cur, args.principal);
+      } else if (args.principal.scope !== 'system-waker' && args.principal.scope !== 'admin') {
+        throw new TaskFlowError(
+          'unauthorized_controller',
+          'resumeFlow requires controller / system-waker / admin scope',
+          {}
+        );
+      }
+      if (cur.status !== 'waiting') {
+        // If the wait already fired, return already_consumed; if the supplied id was never
+        // valid, invalid_argument.
+        if (cur.waitInstanceId == null && !isTerminalStatus(cur.status)) {
+          throw new TaskFlowError('already_consumed', 'wait already fired', {
+            waitInstanceId: args.waitInstanceId,
+          });
+        }
+        throw new TaskFlowError(
+          'invalid_transition',
+          `cannot resumeFlow from ${cur.status}`,
+          { from: cur.status, op: 'resumeFlow' }
+        );
+      }
+      if (cur.waitInstanceId !== args.waitInstanceId) {
+        throw new TaskFlowError('invalid_argument', 'waitInstanceId mismatch', {
+          field: 'waitInstanceId',
+        });
+      }
+      const ts = this.now();
+      let nextState = cur.stateJson;
+      if (args.statePatch !== undefined) {
+        nextState = args.statePatch;
+        this.validateStateJsonSize(nextState);
+      }
+      const next: TaskFlowRecord = {
+        ...cur,
+        status: 'running',
+        waitJson: undefined,
+        waitInstanceId: undefined,
+        waitStartedAt: undefined,
+        currentStep: args.currentStep ?? cur.currentStep,
+        stateJson: nextState,
+        controllerInstanceId:
+          args.principal.scope === 'controller'
+            ? args.principal.controllerInstanceId
+            : cur.controllerInstanceId,
+        controllerHeartbeatAt: ts,
+        revision: cur.revision + 1,
+        updatedAt: ts,
+      };
+      return next;
+    }, 'resumeFlow');
+  }
+
+  async finishFlow(args: {
+    flowId: string;
+    expectedRevision: number;
+    principal: TaskFlowPrincipal;
+    result?: unknown;
+  }): Promise<ApplyResult> {
+    return this.applyOcc(args.flowId, args.expectedRevision, (cur) => {
+      this.assertControllerScope(cur, args.principal);
+      if (cur.status !== 'running') {
+        throw new TaskFlowError('invalid_transition', `cannot finishFlow from ${cur.status}`, {
+          from: cur.status,
+          op: 'finishFlow',
+        });
+      }
+      const ts = this.now();
+      let nextState: any = cur.stateJson ?? {};
+      if (args.result !== undefined) {
+        if (typeof nextState !== 'object' || nextState === null) nextState = {};
+        nextState = { ...(nextState as object), _result: args.result };
+        this.validateStateJsonSize(nextState);
+      }
+      const next: TaskFlowRecord = {
+        ...cur,
+        status: 'succeeded',
+        stateJson: nextState,
+        revision: cur.revision + 1,
+        updatedAt: ts,
+        endedAt: ts,
+      };
+      return next;
+    }, 'finishFlow');
+  }
+
+  async failFlow(args: {
+    flowId: string;
+    expectedRevision: number;
+    principal: TaskFlowPrincipal;
+    failureReason: string;
+  }): Promise<ApplyResult> {
+    return this.applyOcc(args.flowId, args.expectedRevision, (cur) => {
+      this.assertControllerScope(cur, args.principal);
+      if (cur.status !== 'running' && cur.status !== 'waiting') {
+        throw new TaskFlowError('invalid_transition', `cannot failFlow from ${cur.status}`, {
+          from: cur.status,
+          op: 'failFlow',
+        });
+      }
+      const ts = this.now();
+      let nextState: any = cur.stateJson ?? {};
+      if (typeof nextState !== 'object' || nextState === null) nextState = {};
+      nextState = { ...(nextState as object), _failureReason: args.failureReason };
+      this.validateStateJsonSize(nextState);
+      const next: TaskFlowRecord = {
+        ...cur,
+        status: 'failed',
+        stateJson: nextState,
+        // clear wait state since transitioning from waiting → failed
+        waitJson: undefined,
+        waitInstanceId: undefined,
+        waitStartedAt: undefined,
+        revision: cur.revision + 1,
+        updatedAt: ts,
+        endedAt: ts,
+      };
+      return next;
+    }, 'failFlow');
+  }
+
+  async requestFlowCancel(args: {
+    flowId: string;
+    expectedRevision: number;
+    requesterOrigin: RequesterOrigin;
+  }): Promise<ApplyResult> {
+    return this.applyOcc(args.flowId, args.expectedRevision, (cur) => {
+      if (isTerminalStatus(cur.status)) {
+        throw new TaskFlowError('already_terminal', 'cannot cancel a terminal flow', {});
+      }
+      const ts = this.now();
+      const next: TaskFlowRecord = {
+        ...cur,
+        cancelRequestedAt: ts,
+        cancelRequestedBy: args.requesterOrigin,
+        revision: cur.revision + 1,
+        updatedAt: ts,
+      };
+      return next;
+    }, 'requestFlowCancel', (next, prev) => {
+      if (next.status === 'waiting') {
+        this.emit('taskflow:cancel-requested', {
+          flowId: next.flowId,
+          controllerId: next.controllerId,
+        });
+      }
+      // Audit ledger note for cancel-request
+      this.emitLedgerNote('taskflow-cancel-requested', {
+        flowId: next.flowId,
+        revision: next.revision,
+        cancelRequestedBy: args.requesterOrigin,
+      });
+    });
+  }
+
+  async cancelFlow(args: {
+    flowId: string;
+    expectedRevision: number;
+    principal: TaskFlowPrincipal;
+  }): Promise<ApplyResult> {
+    return this.applyOcc(args.flowId, args.expectedRevision, (cur) => {
+      this.assertControllerScope(cur, args.principal);
+      if (isTerminalStatus(cur.status)) {
+        throw new TaskFlowError('already_terminal', 'flow is already terminal', {});
+      }
+      if (cur.cancelRequestedAt == null) {
+        throw new TaskFlowError(
+          'invalid_transition',
+          'cancelFlow requires a prior requestFlowCancel',
+          { from: cur.status, op: 'cancelFlow' }
+        );
+      }
+      const ts = this.now();
+      const next: TaskFlowRecord = {
+        ...cur,
+        status: 'cancelled',
+        waitJson: undefined,
+        waitInstanceId: undefined,
+        waitStartedAt: undefined,
+        revision: cur.revision + 1,
+        updatedAt: ts,
+        endedAt: ts,
+      };
+      return next;
+    }, 'cancelFlow');
+  }
+
+  async markLost(args: {
+    flowId: string;
+    expectedRevision: number;
+    ledgerEntryId: string;
+    reason: 'lost' | 'stranded';
+  }): Promise<ApplyResult> {
+    return this.applyOcc(args.flowId, args.expectedRevision, (cur) => {
+      if (cur.status !== 'running' && cur.status !== 'waiting') {
+        throw new TaskFlowError('invalid_transition', `cannot markLost from ${cur.status}`, {
+          from: cur.status,
+          op: 'markLost',
+        });
+      }
+      const ts = this.now();
+      const next: TaskFlowRecord = {
+        ...cur,
+        status: 'lost',
+        waitJson: undefined,
+        waitInstanceId: undefined,
+        waitStartedAt: undefined,
+        supersededBy: { kind: 'ledger-note', ledgerEntryId: args.ledgerEntryId, reason: args.reason },
+        revision: cur.revision + 1,
+        updatedAt: ts,
+        endedAt: ts,
+      };
+      return next;
+    }, 'markLost');
+  }
+
+  async pingFlow(args: {
+    flowId: string;
+    principal: TaskFlowPrincipal;
+  }): Promise<TaskFlowRecord> {
+    if (args.principal.scope !== 'controller') {
+      throw new TaskFlowError('unauthorized_controller', 'pingFlow requires controller scope', {});
+    }
+    const cur = this.store.getFlow(args.flowId);
+    if (!cur) throw new TaskFlowError('not_found', 'flow not found', { flowId: args.flowId });
+    if (cur.controllerId !== args.principal.controllerId) {
+      throw new TaskFlowError('unauthorized_controller', 'controllerId mismatch', {
+        expected: cur.controllerId,
+        actual: args.principal.controllerId,
+      });
+    }
+    if (cur.status !== 'running') {
+      throw new TaskFlowError('invalid_transition', `cannot pingFlow when status=${cur.status}`, {
+        from: cur.status,
+        op: 'pingFlow',
+      });
+    }
+    const ts = this.now();
+    const updated = this.store.pingFlowRow({
+      flowId: args.flowId,
+      controllerInstanceId: args.principal.controllerInstanceId,
+      controllerHeartbeatAt: ts,
+      updatedAt: ts,
+    });
+    if (updated === 0) {
+      // Race: the row's status changed between read and write. Return current.
+      const fresh = this.store.getFlow(args.flowId);
+      if (fresh) this.cachePut(fresh);
+      throw new TaskFlowError('invalid_transition', 'pingFlow lost a race', {
+        from: fresh?.status ?? 'unknown',
+        op: 'pingFlow',
+      });
+    }
+    const next: TaskFlowRecord = {
+      ...cur,
+      controllerInstanceId: args.principal.controllerInstanceId,
+      controllerHeartbeatAt: ts,
+      updatedAt: ts,
+    };
+    this.cachePut(next);
+    return next;
+  }
+
+  // ────────────────── internal: OCC apply ──────────────────
+
+  private async applyOcc(
+    flowId: string,
+    expectedRevision: number,
+    mutate: (cur: TaskFlowRecord) => TaskFlowRecord,
+    op: string,
+    afterCommit?: (next: TaskFlowRecord, prev: TaskFlowRecord) => void
+  ): Promise<ApplyResult> {
+    const result = await this.store.withWriteTransaction(() => {
+      const cur = this.store.getFlow(flowId);
+      if (!cur) throw new TaskFlowError('not_found', 'flow not found', { flowId });
+      if (isTerminalStatus(cur.status)) {
+        throw new TaskFlowError('already_terminal', 'flow already terminal', {
+          current: cur,
+        });
+      }
+      if (cur.revision !== expectedRevision) {
+        throw new TaskFlowError(
+          'revision_conflict',
+          `expected revision ${expectedRevision}, current ${cur.revision}`,
+          { current: cur }
+        );
+      }
+      const next = mutate(cur);
+      const changes = this.store.patchFlowOcc(next, expectedRevision);
+      if (changes !== 1) {
+        // Highly unlikely inside BEGIN IMMEDIATE — re-read for the discriminator.
+        const meta = this.store.getFlowMeta(flowId);
+        if (!meta) throw new TaskFlowError('not_found', 'flow not found', { flowId });
+        throw new TaskFlowError(
+          'revision_conflict',
+          'patch returned 0 rows mid-transaction',
+          { current: this.store.getFlow(flowId) }
+        );
+      }
+      return { prev: cur, next };
+    });
+    this.cachePut(result.next);
+    this.emitTransitionLedgerNote(result.next, result.prev.status, result.next.status, op);
+    if (afterCommit) {
+      try {
+        afterCommit(result.next, result.prev);
+      } catch (err) {
+        // afterCommit failures are best-effort — never roll back state.
+        // Fall through.
+      }
+    }
+    this.maybeNotify(result.next, result.prev.status);
+    return { applied: true, flow: result.next };
+  }
+
+  private cachePut(rec: TaskFlowRecord): void {
+    this.cache.set(rec.flowId, rec);
+    if (this.cache.size > MAX_CACHE_ENTRIES) {
+      // Evict the oldest insertion-order key. (Map preserves insertion order.)
+      // Prefer terminal flows for eviction by scanning the head a bit.
+      let evicted = false;
+      let i = 0;
+      for (const [k, v] of this.cache) {
+        if (i++ > 32) break;
+        if (v.endedAt != null) {
+          this.cache.delete(k);
+          evicted = true;
+          break;
+        }
+      }
+      if (!evicted) {
+        const firstKey = this.cache.keys().next().value as string | undefined;
+        if (firstKey) this.cache.delete(firstKey);
+      }
+    }
+  }
+
+  private assertControllerScope(rec: TaskFlowRecord, principal: TaskFlowPrincipal): void {
+    if (principal.scope === 'admin') return;
+    if (principal.scope !== 'controller') {
+      throw new TaskFlowError('unauthorized_controller', 'controller scope required', {});
+    }
+    if (rec.controllerId !== principal.controllerId) {
+      throw new TaskFlowError('unauthorized_controller', 'controllerId mismatch', {
+        expected: rec.controllerId,
+        actual: principal.controllerId,
+      });
+    }
+  }
+
+  private controllerInstanceFromPrincipal(
+    principal: TaskFlowPrincipal,
+    cur: TaskFlowRecord
+  ): string {
+    if (principal.scope === 'controller') return principal.controllerInstanceId;
+    return cur.controllerInstanceId;
+  }
+
+  private validateStateJsonSize(value: unknown): void {
+    const bytes = jsonByteLength(value);
+    if (bytes > MAX_STATE_JSON_BYTES) {
+      throw new TaskFlowError('invalid_argument', 'stateJson exceeds size limit', {
+        field: 'stateJson',
+        bytes,
+      });
+    }
+  }
+
+  private toWaitMatch(rec: TaskFlowRecord): WaitMatch {
+    return {
+      flowId: rec.flowId,
+      revision: rec.revision,
+      waitInstanceId: rec.waitInstanceId!,
+      controllerId: rec.controllerId,
+      waitJson: rec.waitJson!,
+    };
+  }
+
+  private genId(): string {
+    return crypto.randomUUID();
+  }
+
+  // ────────────────── audit + notify ──────────────────
+
+  private emitTransitionLedgerNote(
+    rec: TaskFlowRecord,
+    fromStatus: TaskFlowStatus | null,
+    toStatus: TaskFlowStatus,
+    op: string
+  ): void {
+    if (!this.crossesAuditBoundary(fromStatus, toStatus, op)) return;
+    this.emitLedgerNote('taskflow-transition', {
+      flowId: rec.flowId,
+      revision: rec.revision,
+      from_status: fromStatus,
+      to_status: toStatus,
+      currentStep: rec.currentStep,
+      waitKind: rec.waitJson?.kind ?? null,
+      controllerId: rec.controllerId,
+      op,
+    });
+  }
+
+  private crossesAuditBoundary(
+    fromStatus: TaskFlowStatus | null,
+    toStatus: TaskFlowStatus,
+    op: string
+  ): boolean {
+    if (op === 'createFlow') return true;
+    if (op === 'startStep') return true;
+    if (op === 'setFlowWaiting') return true;
+    if (op === 'resumeFlow') return true;
+    if (isTerminalStatus(toStatus)) return true;
+    return false;
+  }
+
+  private emitLedgerNote(kind: string, payload: Record<string, unknown>): void {
+    if (!this.ledger) return;
+    // Best-effort: ledger.append is async but we don't await — tier-2 audit, never
+    // blocks state correctness (per spec § Storage and Concurrency).
+    void Promise.resolve()
+      .then(() =>
+        this.ledger!.append({
+          kind: `note:${kind}`,
+          provenance: 'TaskFlowRegistry',
+          emittedBy: 'TaskFlowRegistry',
+          counterparty: 'self',
+          subject: kind,
+          dedupKey: `${kind}:${payload.flowId}:${payload.revision ?? 'na'}`,
+          payload,
+        } as any)
+      )
+      .catch(() => {
+        /* swallow — audit best-effort */
+      });
+  }
+
+  private maybeNotify(rec: TaskFlowRecord, fromStatus: TaskFlowStatus): void {
+    const policy = rec.notifyPolicy;
+    if (policy.kind === 'silent') return;
+    const enteredWaiting = fromStatus !== 'waiting' && rec.status === 'waiting';
+    const enteredTerminal = !isTerminalStatus(fromStatus) && isTerminalStatus(rec.status);
+    let fire = false;
+    if (policy.kind === 'on-wait' && enteredWaiting) fire = true;
+    if (policy.kind === 'on-terminal' && enteredTerminal) fire = true;
+    if (policy.kind === 'on-wait-and-terminal' && (enteredWaiting || enteredTerminal)) fire = true;
+    if (!fire) return;
+    // Phase 1 ships the wiring with metric-only emission. Phase 5 wires through
+    // TelegramAdapter.send.
+    this.notifyMetrics.emitted++;
+    const k = enteredTerminal ? `terminal:${rec.status}` : 'wait';
+    this.notifyMetrics.byKind[k] = (this.notifyMetrics.byKind[k] ?? 0) + 1;
+    this.emit('taskflow:notify', {
+      flowId: rec.flowId,
+      goal: rec.goal,
+      currentStep: rec.currentStep,
+      status: rec.status,
+      waitKind: rec.waitJson?.kind,
+      revision: rec.revision,
+      topicId: 'topicId' in policy ? policy.topicId : undefined,
+    });
+  }
+}

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -1,0 +1,416 @@
+/**
+ * TaskFlow SQLite store.
+ *
+ * Single-writer (the instar server process). Wraps mutations in
+ * `BEGIN IMMEDIATE` so the read-then-write check-and-discriminate sequence
+ * inside each operation is consistent.
+ *
+ * No JSONL dual-write — SQLite WAL is the durability journal (see spec §
+ * Storage and Concurrency, "DR and audit trail").
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  TaskFlowRecord,
+  TaskFlowStatus,
+  WaitJson,
+  RequesterOrigin,
+  SupersededRef,
+  TaskNotifyPolicy,
+  MAX_BUSY_RETRIES,
+  BUSY_BASE_DELAY_MS,
+  BUSY_CAP_DELAY_MS,
+} from './task-flow-types.js';
+
+type Database = import('better-sqlite3').Database;
+
+interface FlowRow {
+  flow_id: string;
+  owner_key: string;
+  controller_id: string;
+  controller_instance_id: string;
+  controller_heartbeat_at: number;
+  revision: number;
+  status: string;
+  notify_policy: string;
+  goal: string;
+  current_step: string | null;
+  state_json: string | null;
+  wait_json: string | null;
+  wait_instance_id: string | null;
+  wait_started_at: number | null;
+  wait_kind: string | null;
+  cancel_requested_at: number | null;
+  cancel_requested_by: string | null;
+  created_at: number;
+  updated_at: number;
+  ended_at: number | null;
+  superseded_by: string | null;
+  privacy_scope: string | null;
+  requester_origin: string | null;
+}
+
+export interface StoreOpenOptions {
+  dbPath: string;
+}
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS flows (
+  flow_id TEXT PRIMARY KEY,
+  owner_key TEXT NOT NULL,
+  controller_id TEXT NOT NULL,
+  controller_instance_id TEXT NOT NULL,
+  controller_heartbeat_at INTEGER NOT NULL,
+  revision INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  notify_policy TEXT NOT NULL,
+  goal TEXT NOT NULL,
+  current_step TEXT,
+  state_json TEXT,
+  wait_json TEXT,
+  wait_instance_id TEXT,
+  wait_started_at INTEGER,
+  wait_kind TEXT,
+  cancel_requested_at INTEGER,
+  cancel_requested_by TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  ended_at INTEGER,
+  superseded_by TEXT,
+  privacy_scope TEXT,
+  requester_origin TEXT
+);
+CREATE INDEX IF NOT EXISTS flows_status_updated_at  ON flows (status, updated_at);
+CREATE INDEX IF NOT EXISTS flows_controller_status  ON flows (controller_id, status);
+CREATE INDEX IF NOT EXISTS flows_owner_key          ON flows (owner_key);
+CREATE INDEX IF NOT EXISTS flows_wait_instance_id   ON flows (wait_instance_id) WHERE wait_instance_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS flows_wait_kind_started  ON flows (wait_kind, wait_started_at) WHERE status='waiting';
+CREATE INDEX IF NOT EXISTS flows_running_heartbeat  ON flows (controller_heartbeat_at) WHERE status='running';
+
+CREATE TABLE IF NOT EXISTS flow_create_idem (
+  controller_id TEXT NOT NULL,
+  owner_key TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  flow_id TEXT NOT NULL,
+  PRIMARY KEY (controller_id, owner_key, idempotency_key)
+);
+`;
+
+export class TaskFlowStore {
+  private db!: Database;
+  private opened = false;
+
+  constructor(private readonly opts: StoreOpenOptions) {}
+
+  async open(): Promise<void> {
+    if (this.opened) return;
+    let BetterSqlite3: any;
+    try {
+      BetterSqlite3 = await import('better-sqlite3');
+    } catch {
+      throw new Error('TaskFlowStore requires better-sqlite3. Run: npm install better-sqlite3');
+    }
+    const Constructor = BetterSqlite3.default || BetterSqlite3;
+    const dbDir = path.dirname(this.opts.dbPath);
+    if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true });
+    this.db = Constructor(this.opts.dbPath) as Database;
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('busy_timeout = 30000');
+    this.db.pragma('synchronous = NORMAL');
+    this.db.pragma('foreign_keys = ON');
+    this.db.exec(SCHEMA_SQL);
+    this.opened = true;
+  }
+
+  close(): void {
+    if (this.opened) {
+      this.db.close();
+      this.opened = false;
+    }
+  }
+
+  rawDb(): Database {
+    return this.db;
+  }
+
+  // ───────────── helpers ─────────────
+
+  private rowToRecord(r: FlowRow): TaskFlowRecord {
+    const rec: TaskFlowRecord = {
+      flowId: r.flow_id,
+      ownerKey: r.owner_key,
+      controllerId: r.controller_id,
+      controllerInstanceId: r.controller_instance_id,
+      controllerHeartbeatAt: r.controller_heartbeat_at,
+      revision: r.revision,
+      status: r.status as TaskFlowStatus,
+      notifyPolicy: JSON.parse(r.notify_policy) as TaskNotifyPolicy,
+      goal: r.goal,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    };
+    if (r.current_step !== null) rec.currentStep = r.current_step;
+    if (r.state_json !== null) rec.stateJson = JSON.parse(r.state_json);
+    if (r.wait_json !== null) rec.waitJson = JSON.parse(r.wait_json) as WaitJson;
+    if (r.wait_instance_id !== null) rec.waitInstanceId = r.wait_instance_id;
+    if (r.wait_started_at !== null) rec.waitStartedAt = r.wait_started_at;
+    if (r.cancel_requested_at !== null) rec.cancelRequestedAt = r.cancel_requested_at;
+    if (r.cancel_requested_by !== null)
+      rec.cancelRequestedBy = JSON.parse(r.cancel_requested_by) as RequesterOrigin;
+    if (r.ended_at !== null) rec.endedAt = r.ended_at;
+    if (r.superseded_by !== null)
+      rec.supersededBy = JSON.parse(r.superseded_by) as SupersededRef;
+    if (r.privacy_scope !== null) rec.privacyScope = r.privacy_scope as TaskFlowRecord['privacyScope'];
+    if (r.requester_origin !== null)
+      rec.requesterOrigin = JSON.parse(r.requester_origin) as RequesterOrigin;
+    return rec;
+  }
+
+  /**
+   * Run a write closure inside `BEGIN IMMEDIATE` with retry-on-busy.
+   * Returns the closure's result.
+   */
+  async withWriteTransaction<T>(fn: () => T): Promise<T> {
+    let attempt = 0;
+    let lastErr: unknown;
+    while (attempt <= MAX_BUSY_RETRIES) {
+      try {
+        const txn = this.db.transaction(fn);
+        // exclusive=false, immediate=true matches BEGIN IMMEDIATE behavior.
+        return (txn as any).immediate();
+      } catch (err: any) {
+        lastErr = err;
+        if (err?.code === 'SQLITE_BUSY' && attempt < MAX_BUSY_RETRIES) {
+          const delay = Math.min(BUSY_BASE_DELAY_MS * Math.pow(2, attempt), BUSY_CAP_DELAY_MS);
+          await new Promise((r) => setTimeout(r, delay));
+          attempt++;
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw lastErr;
+  }
+
+  // ───────────── reads ─────────────
+
+  getFlow(flowId: string): TaskFlowRecord | null {
+    const row = this.db
+      .prepare('SELECT * FROM flows WHERE flow_id = ?')
+      .get(flowId) as FlowRow | undefined;
+    return row ? this.rowToRecord(row) : null;
+  }
+
+  getFlowMeta(flowId: string): { revision: number; status: TaskFlowStatus; endedAt: number | null } | null {
+    const row = this.db
+      .prepare('SELECT revision, status, ended_at FROM flows WHERE flow_id = ?')
+      .get(flowId) as { revision: number; status: string; ended_at: number | null } | undefined;
+    if (!row) return null;
+    return { revision: row.revision, status: row.status as TaskFlowStatus, endedAt: row.ended_at };
+  }
+
+  findIdempotent(
+    controllerId: string,
+    ownerKey: string,
+    idempotencyKey: string
+  ): TaskFlowRecord | null {
+    const row = this.db
+      .prepare(
+        `SELECT f.* FROM flows f
+         JOIN flow_create_idem i ON i.flow_id = f.flow_id
+         WHERE i.controller_id = ? AND i.owner_key = ? AND i.idempotency_key = ?`
+      )
+      .get(controllerId, ownerKey, idempotencyKey) as FlowRow | undefined;
+    return row ? this.rowToRecord(row) : null;
+  }
+
+  /**
+   * Find a waiting `reply` flow for a (controllerId, channel, threadId, peer)
+   * tuple — used by setFlowWaiting collision detection AND by MessageRouter.
+   */
+  findWaitingReplyByTarget(args: {
+    channel: string;
+    threadId: string;
+    peer: string;
+    controllerId?: string;
+  }): TaskFlowRecord[] {
+    const params: any[] = [args.channel, args.threadId, args.peer];
+    let sql = `SELECT * FROM flows WHERE status='waiting' AND wait_kind='reply'
+      AND json_extract(wait_json, '$.channel') = ?
+      AND json_extract(wait_json, '$.threadId') = ?
+      AND json_extract(wait_json, '$.peer') = ?`;
+    if (args.controllerId) {
+      sql += ' AND controller_id = ?';
+      params.push(args.controllerId);
+    }
+    const rows = this.db.prepare(sql).all(...params) as FlowRow[];
+    return rows.map((r) => this.rowToRecord(r));
+  }
+
+  findWaitingByCorrelation(args: {
+    waitKind: 'external-call' | 'cross-agent-callback';
+    correlationId: string;
+  }): TaskFlowRecord[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM flows WHERE status='waiting' AND wait_kind = ?
+           AND json_extract(wait_json, '$.correlationId') = ?`
+      )
+      .all(args.waitKind, args.correlationId) as FlowRow[];
+    return rows.map((r) => this.rowToRecord(r));
+  }
+
+  findWaitingDue(nowMs: number): TaskFlowRecord[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM flows WHERE status='waiting' AND wait_kind='scheduled-tick'
+           AND CAST(json_extract(wait_json, '$.dueAt') AS INTEGER) <= ?`
+      )
+      .all(nowMs) as FlowRow[];
+    return rows.map((r) => this.rowToRecord(r));
+  }
+
+  findSweeperCandidates(): TaskFlowRecord[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM flows
+         WHERE status='running' OR (status='waiting' AND wait_kind != 'scheduled-tick')`
+      )
+      .all() as FlowRow[];
+    return rows.map((r) => this.rowToRecord(r));
+  }
+
+  // ───────────── writes ─────────────
+
+  insertFlow(rec: TaskFlowRecord, idempotencyKey: string): void {
+    const stmt = this.db.prepare(
+      `INSERT INTO flows (
+        flow_id, owner_key, controller_id, controller_instance_id, controller_heartbeat_at,
+        revision, status, notify_policy, goal, current_step, state_json, wait_json,
+        wait_instance_id, wait_started_at, wait_kind, cancel_requested_at, cancel_requested_by,
+        created_at, updated_at, ended_at, superseded_by, privacy_scope, requester_origin
+      ) VALUES (
+        @flow_id, @owner_key, @controller_id, @controller_instance_id, @controller_heartbeat_at,
+        @revision, @status, @notify_policy, @goal, @current_step, @state_json, @wait_json,
+        @wait_instance_id, @wait_started_at, @wait_kind, @cancel_requested_at, @cancel_requested_by,
+        @created_at, @updated_at, @ended_at, @superseded_by, @privacy_scope, @requester_origin
+      )`
+    );
+    stmt.run({
+      flow_id: rec.flowId,
+      owner_key: rec.ownerKey,
+      controller_id: rec.controllerId,
+      controller_instance_id: rec.controllerInstanceId,
+      controller_heartbeat_at: rec.controllerHeartbeatAt,
+      revision: rec.revision,
+      status: rec.status,
+      notify_policy: JSON.stringify(rec.notifyPolicy),
+      goal: rec.goal,
+      current_step: rec.currentStep ?? null,
+      state_json: rec.stateJson === undefined ? null : JSON.stringify(rec.stateJson),
+      wait_json: rec.waitJson ? JSON.stringify(rec.waitJson) : null,
+      wait_instance_id: rec.waitInstanceId ?? null,
+      wait_started_at: rec.waitStartedAt ?? null,
+      wait_kind: rec.waitJson?.kind ?? null,
+      cancel_requested_at: rec.cancelRequestedAt ?? null,
+      cancel_requested_by: rec.cancelRequestedBy
+        ? JSON.stringify(rec.cancelRequestedBy)
+        : null,
+      created_at: rec.createdAt,
+      updated_at: rec.updatedAt,
+      ended_at: rec.endedAt ?? null,
+      superseded_by: rec.supersededBy ? JSON.stringify(rec.supersededBy) : null,
+      privacy_scope: rec.privacyScope ?? null,
+      requester_origin: rec.requesterOrigin ? JSON.stringify(rec.requesterOrigin) : null,
+    });
+    this.db
+      .prepare(
+        `INSERT INTO flow_create_idem (controller_id, owner_key, idempotency_key, flow_id)
+         VALUES (?, ?, ?, ?)`
+      )
+      .run(rec.controllerId, rec.ownerKey, idempotencyKey, rec.flowId);
+  }
+
+  /**
+   * OCC patch: sets every column on the row to match `next`, gated on
+   * `expectedRevision`. Returns the number of rows updated.
+   */
+  patchFlowOcc(next: TaskFlowRecord, expectedRevision: number): number {
+    const result = this.db
+      .prepare(
+        `UPDATE flows SET
+           controller_instance_id = @controller_instance_id,
+           controller_heartbeat_at = @controller_heartbeat_at,
+           revision = @revision,
+           status = @status,
+           notify_policy = @notify_policy,
+           goal = @goal,
+           current_step = @current_step,
+           state_json = @state_json,
+           wait_json = @wait_json,
+           wait_instance_id = @wait_instance_id,
+           wait_started_at = @wait_started_at,
+           wait_kind = @wait_kind,
+           cancel_requested_at = @cancel_requested_at,
+           cancel_requested_by = @cancel_requested_by,
+           updated_at = @updated_at,
+           ended_at = @ended_at,
+           superseded_by = @superseded_by,
+           privacy_scope = @privacy_scope,
+           requester_origin = @requester_origin
+         WHERE flow_id = @flow_id AND revision = @expected_revision`
+      )
+      .run({
+        flow_id: next.flowId,
+        expected_revision: expectedRevision,
+        controller_instance_id: next.controllerInstanceId,
+        controller_heartbeat_at: next.controllerHeartbeatAt,
+        revision: next.revision,
+        status: next.status,
+        notify_policy: JSON.stringify(next.notifyPolicy),
+        goal: next.goal,
+        current_step: next.currentStep ?? null,
+        state_json: next.stateJson === undefined ? null : JSON.stringify(next.stateJson),
+        wait_json: next.waitJson ? JSON.stringify(next.waitJson) : null,
+        wait_instance_id: next.waitInstanceId ?? null,
+        wait_started_at: next.waitStartedAt ?? null,
+        wait_kind: next.waitJson?.kind ?? null,
+        cancel_requested_at: next.cancelRequestedAt ?? null,
+        cancel_requested_by: next.cancelRequestedBy
+          ? JSON.stringify(next.cancelRequestedBy)
+          : null,
+        updated_at: next.updatedAt,
+        ended_at: next.endedAt ?? null,
+        superseded_by: next.supersededBy ? JSON.stringify(next.supersededBy) : null,
+        privacy_scope: next.privacyScope ?? null,
+        requester_origin: next.requesterOrigin ? JSON.stringify(next.requesterOrigin) : null,
+      });
+    return result.changes;
+  }
+
+  /**
+   * Cheap pingFlow update — does NOT bump revision. Returns rows updated (0 or 1).
+   */
+  pingFlowRow(args: {
+    flowId: string;
+    controllerInstanceId: string;
+    controllerHeartbeatAt: number;
+    updatedAt: number;
+  }): number {
+    return this.db
+      .prepare(
+        `UPDATE flows SET
+           controller_instance_id = @cii,
+           controller_heartbeat_at = @hb,
+           updated_at = @ua
+         WHERE flow_id = @flow_id AND status = 'running'`
+      )
+      .run({
+        flow_id: args.flowId,
+        cii: args.controllerInstanceId,
+        hb: args.controllerHeartbeatAt,
+        ua: args.updatedAt,
+      }).changes;
+  }
+}

--- a/src/tasks/task-flow-types.ts
+++ b/src/tasks/task-flow-types.ts
@@ -1,0 +1,247 @@
+/**
+ * TaskFlow — types and constants.
+ *
+ * Imported from OpenClaw's task-flow-registry shape, trimmed for Instar v1
+ * (single-writer; managed-only; no `blocked` status).
+ *
+ * See docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md for full design.
+ */
+
+import { z } from 'zod';
+import type { PrivacyScopeType } from '../core/types.js';
+
+export type TaskFlowStatus =
+  | 'queued'
+  | 'running'
+  | 'waiting'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled'
+  | 'lost';
+
+export const TERMINAL_STATUSES: ReadonlySet<TaskFlowStatus> = new Set([
+  'succeeded',
+  'failed',
+  'cancelled',
+  'lost',
+]);
+
+export type WaitKind =
+  | 'reply'
+  | 'human-review'
+  | 'external-call'
+  | 'scheduled-tick'
+  | 'cross-agent-callback';
+
+export type WaitJson =
+  | { kind: 'reply'; channel: string; threadId: string; peer: string }
+  | { kind: 'human-review'; question: string; topicId?: number; reviewerId?: string }
+  | { kind: 'external-call'; serviceId: string; correlationId: string; deadline?: number }
+  | { kind: 'scheduled-tick'; dueAt: number; jobSlug?: string }
+  | {
+      kind: 'cross-agent-callback';
+      threadId: string;
+      correlationId: string;
+      expectedAgentId: string;
+    };
+
+export type RequesterOrigin = {
+  kind: 'user' | 'agent' | 'system' | 'job';
+  id: string;
+  channel?: string;
+};
+
+export type SupersededRef = {
+  kind: 'ledger-note';
+  ledgerEntryId: string;
+  reason: 'lost' | 'stranded' | 'manual-supersede';
+};
+
+export type TaskNotifyPolicy =
+  | { kind: 'silent' }
+  | { kind: 'on-wait'; topicId: number }
+  | { kind: 'on-terminal'; topicId: number }
+  | { kind: 'on-wait-and-terminal'; topicId: number };
+
+export interface TaskFlowRecord {
+  flowId: string;
+  ownerKey: string;
+  requesterOrigin?: RequesterOrigin;
+  controllerId: string;
+  controllerInstanceId: string;
+  controllerHeartbeatAt: number;
+  revision: number;
+  status: TaskFlowStatus;
+  notifyPolicy: TaskNotifyPolicy;
+  goal: string;
+  currentStep?: string;
+  stateJson?: unknown;
+  waitJson?: WaitJson;
+  waitInstanceId?: string;
+  waitStartedAt?: number;
+  cancelRequestedAt?: number;
+  cancelRequestedBy?: RequesterOrigin;
+  createdAt: number;
+  updatedAt: number;
+  endedAt?: number;
+  supersededBy?: SupersededRef;
+  privacyScope?: PrivacyScopeType;
+}
+
+// ---------- size limits ----------
+
+export const MAX_OWNER_KEY_CHARS = 256;
+export const MAX_GOAL_CHARS = 1024;
+export const MAX_CURRENT_STEP_CHARS = 128;
+export const MAX_STATE_JSON_BYTES = 64 * 1024;
+export const MAX_WAIT_JSON_BYTES = 8 * 1024;
+
+// ---------- defaults ----------
+
+export const DEFAULT_THRESHOLDS = {
+  RUNNING_LOST_MS: 6 * 60 * 60 * 1000, // 6h
+  REPLY_LOST_MS: 7 * 24 * 60 * 60 * 1000, // 7d
+  HUMAN_REVIEW_LOST_MS: 30 * 24 * 60 * 60 * 1000, // 30d
+  EXTERNAL_LOST_MS: 7 * 24 * 60 * 60 * 1000, // 7d
+  EXTERNAL_GRACE_MS: 60 * 60 * 1000, // 1h
+  XAGENT_LOST_MS: 7 * 24 * 60 * 60 * 1000, // 7d
+} as const;
+
+export const HEARTBEAT_INTERVAL_MS = 60 * 1000;
+export const SWEEPER_INTERVAL_MS = 60 * 60 * 1000; // hourly
+export const DUE_WAKER_INTERVAL_MS = 60 * 1000; // every minute
+export const MAX_CACHE_ENTRIES = 1000;
+export const MAX_BUSY_RETRIES = 5;
+export const BUSY_BASE_DELAY_MS = 50;
+export const BUSY_CAP_DELAY_MS = 5000;
+
+export const RESERVED_MAINTENANCE_CONTROLLER = 'TaskFlowMaintenance';
+
+// ---------- error shapes ----------
+
+export type TaskFlowErrorCode =
+  | 'not_found'
+  | 'revision_conflict'
+  | 'already_terminal'
+  | 'invalid_transition'
+  | 'invalid_argument'
+  | 'unauthorized_controller'
+  | 'already_consumed'
+  | 'wait_collision'
+  | 'quota_exceeded';
+
+export class TaskFlowError extends Error {
+  code: TaskFlowErrorCode;
+  detail: Record<string, unknown>;
+  constructor(code: TaskFlowErrorCode, message: string, detail: Record<string, unknown> = {}) {
+    super(message);
+    this.name = 'TaskFlowError';
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+// ---------- principal scope (auth) ----------
+
+export type TaskFlowPrincipal =
+  | { scope: 'controller'; controllerId: string; controllerInstanceId: string }
+  | { scope: 'system-waker'; wakerId: string }
+  | { scope: 'admin' };
+
+// ---------- zod schemas ----------
+
+const requesterOriginSchema = z.object({
+  kind: z.enum(['user', 'agent', 'system', 'job']),
+  id: z.string().min(1).max(256),
+  channel: z.string().max(256).optional(),
+});
+
+const notifyPolicySchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('silent') }),
+  z.object({ kind: z.literal('on-wait'), topicId: z.number().int() }),
+  z.object({ kind: z.literal('on-terminal'), topicId: z.number().int() }),
+  z.object({ kind: z.literal('on-wait-and-terminal'), topicId: z.number().int() }),
+]);
+
+export const waitJsonSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('reply'),
+    channel: z.string().min(1).max(256),
+    threadId: z.string().min(1).max(256),
+    peer: z.string().min(1).max(256),
+  }),
+  z.object({
+    kind: z.literal('human-review'),
+    question: z.string().min(1).max(2000),
+    topicId: z.number().int().optional(),
+    reviewerId: z.string().max(256).optional(),
+  }),
+  z.object({
+    kind: z.literal('external-call'),
+    serviceId: z.string().min(1).max(256),
+    correlationId: z.string().min(16).max(256),
+    deadline: z.number().int().optional(),
+  }),
+  z.object({
+    kind: z.literal('scheduled-tick'),
+    dueAt: z.number().int(),
+    jobSlug: z.string().max(256).optional(),
+  }),
+  z.object({
+    kind: z.literal('cross-agent-callback'),
+    threadId: z.string().min(1).max(256),
+    correlationId: z.string().min(16).max(256),
+    expectedAgentId: z.string().min(1).max(256),
+  }),
+]);
+
+export const createFlowInputSchema = z.object({
+  ownerKey: z.string().min(1).max(MAX_OWNER_KEY_CHARS),
+  controllerId: z.string().min(1).max(256),
+  controllerInstanceId: z.string().min(1).max(256),
+  idempotencyKey: z.string().min(8).max(256),
+  goal: z.string().min(1).max(MAX_GOAL_CHARS),
+  currentStep: z.string().max(MAX_CURRENT_STEP_CHARS).optional(),
+  stateJson: z.unknown().optional(),
+  notifyPolicy: notifyPolicySchema.optional(),
+  requesterOrigin: requesterOriginSchema.optional(),
+  privacyScope: z.enum(['private', 'shared-topic', 'shared-project']).optional(),
+});
+
+export type CreateFlowInput = z.infer<typeof createFlowInputSchema>;
+
+export interface ApplyResult {
+  applied: boolean;
+  flow: TaskFlowRecord;
+}
+
+export interface WaitMatch {
+  flowId: string;
+  revision: number;
+  waitInstanceId: string;
+  controllerId: string;
+  waitJson: WaitJson;
+}
+
+export interface SweeperEvalCounts {
+  scanned: number;
+  marked: number;
+}
+
+export interface TaskFlowThresholds {
+  RUNNING_LOST_MS: number;
+  REPLY_LOST_MS: number;
+  HUMAN_REVIEW_LOST_MS: number;
+  EXTERNAL_LOST_MS: number;
+  EXTERNAL_GRACE_MS: number;
+  XAGENT_LOST_MS: number;
+}
+
+export function jsonByteLength(value: unknown): number {
+  if (value === undefined) return 0;
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+export function isTerminalStatus(status: TaskFlowStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}

--- a/tests/unit/task-flow-registry.test.ts
+++ b/tests/unit/task-flow-registry.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Tests for TaskFlowRegistry — durable multi-step job records with OCC.
+ *
+ * Real SQLite DBs (no mocking). Verifies the contract from
+ * docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md § Mutation Semantics.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TaskFlowStore } from '../../src/tasks/task-flow-registry.store.sqlite.js';
+import { TaskFlowRegistry } from '../../src/tasks/TaskFlowRegistry.js';
+import { TaskFlowMaintenanceSweeper } from '../../src/tasks/TaskFlowMaintenanceSweeper.js';
+import { TaskFlowDueWaker } from '../../src/tasks/TaskFlowDueWaker.js';
+import {
+  TaskFlowError,
+  CreateFlowInput,
+  TaskFlowPrincipal,
+  WaitJson,
+} from '../../src/tasks/task-flow-types.js';
+
+interface TestRig {
+  dir: string;
+  store: TaskFlowStore;
+  registry: TaskFlowRegistry;
+  clock: { now: number };
+  cleanup: () => Promise<void>;
+}
+
+async function rig(): Promise<TestRig> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'taskflow-test-'));
+  const store = new TaskFlowStore({ dbPath: path.join(dir, 'task-flows.db') });
+  await store.open();
+  const clock = { now: 1_700_000_000_000 };
+  const registry = new TaskFlowRegistry({ store, now: () => clock.now });
+  return {
+    dir,
+    store,
+    registry,
+    clock,
+    cleanup: async () => {
+      store.close();
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/task-flow-registry.test.ts',
+      });
+    },
+  };
+}
+
+const baseInput: CreateFlowInput = {
+  ownerKey: 'cluster:abc-123',
+  controllerId: 'EvolutionManager',
+  controllerInstanceId: 'inst-1',
+  idempotencyKey: 'idem-create-1234567890',
+  goal: 'tier-1 fix attempt for duplicate-reply cluster',
+};
+
+const ctrl: TaskFlowPrincipal = {
+  scope: 'controller',
+  controllerId: 'EvolutionManager',
+  controllerInstanceId: 'inst-1',
+};
+
+describe('TaskFlowRegistry — createFlow', () => {
+  let r: TestRig;
+  beforeEach(async () => { r = await rig(); });
+  afterEach(async () => { await r.cleanup(); });
+
+  it('creates a queued flow with revision=1', async () => {
+    const { flow, created } = await r.registry.createFlow(baseInput);
+    expect(created).toBe(true);
+    expect(flow.status).toBe('queued');
+    expect(flow.revision).toBe(1);
+    expect(flow.controllerId).toBe('EvolutionManager');
+    expect(flow.flowId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(flow.createdAt).toBe(r.clock.now);
+  });
+
+  it('idempotently returns the same flow on duplicate idempotencyKey', async () => {
+    const a = await r.registry.createFlow(baseInput);
+    const b = await r.registry.createFlow(baseInput);
+    expect(a.created).toBe(true);
+    expect(b.created).toBe(false);
+    expect(b.flow.flowId).toBe(a.flow.flowId);
+  });
+
+  it('rejects oversized goal', async () => {
+    await expect(
+      r.registry.createFlow({ ...baseInput, goal: 'x'.repeat(2000) })
+    ).rejects.toThrow(TaskFlowError);
+  });
+
+  it('rejects use of reserved TaskFlowMaintenance controllerId', async () => {
+    await expect(
+      r.registry.createFlow({ ...baseInput, controllerId: 'TaskFlowMaintenance' })
+    ).rejects.toThrow(/TaskFlowMaintenance/);
+  });
+});
+
+describe('TaskFlowRegistry — startStep / setFlowWaiting / resumeFlow / finishFlow', () => {
+  let r: TestRig;
+  beforeEach(async () => { r = await rig(); });
+  afterEach(async () => { await r.cleanup(); });
+
+  it('walks queued → running → waiting → running → succeeded', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    const { flow: f1 } = await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 'tier-1-fix-attempt',
+    });
+    expect(f1.status).toBe('running');
+    expect(f1.revision).toBe(2);
+
+    const wait: WaitJson = {
+      kind: 'human-review',
+      question: 'Approve the tier-1 fix?',
+      topicId: 9000,
+    };
+    const { flow: f2 } = await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: wait,
+    });
+    expect(f2.status).toBe('waiting');
+    expect(f2.waitInstanceId).toBeTruthy();
+    expect(f2.waitStartedAt).toBe(r.clock.now);
+
+    const { flow: f3 } = await r.registry.resumeFlow({
+      flowId: f0.flowId,
+      expectedRevision: 3,
+      principal: ctrl,
+      waitInstanceId: f2.waitInstanceId!,
+    });
+    expect(f3.status).toBe('running');
+    expect(f3.waitInstanceId).toBeUndefined();
+
+    const { flow: f4 } = await r.registry.finishFlow({
+      flowId: f0.flowId,
+      expectedRevision: 4,
+      principal: ctrl,
+      result: { ok: true },
+    });
+    expect(f4.status).toBe('succeeded');
+    expect(f4.endedAt).toBe(r.clock.now);
+    expect((f4.stateJson as any)._result.ok).toBe(true);
+  });
+
+  it('rejects setFlowWaiting from queued', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await expect(
+      r.registry.setFlowWaiting({
+        flowId: f0.flowId,
+        expectedRevision: 1,
+        principal: ctrl,
+        waitJson: { kind: 'human-review', question: 'q' },
+      })
+    ).rejects.toMatchObject({ code: 'invalid_transition' });
+  });
+
+  it('returns revision_conflict on stale expectedRevision', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 'tier-1-fix-attempt',
+    });
+    await expect(
+      r.registry.startStep({
+        flowId: f0.flowId,
+        expectedRevision: 1, // stale
+        principal: ctrl,
+        currentStep: 'tier-1-fix-attempt',
+      })
+    ).rejects.toMatchObject({ code: 'revision_conflict' });
+  });
+
+  it('returns not_found for unknown flowId', async () => {
+    await expect(
+      r.registry.startStep({
+        flowId: 'no-such-flow',
+        expectedRevision: 1,
+        principal: ctrl,
+        currentStep: 's',
+      })
+    ).rejects.toMatchObject({ code: 'not_found' });
+  });
+
+  it('rejects waitInstanceId mismatch on resume', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    const { flow: f2 } = await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: { kind: 'human-review', question: 'q' },
+    });
+    await expect(
+      r.registry.resumeFlow({
+        flowId: f0.flowId,
+        expectedRevision: f2.revision,
+        principal: ctrl,
+        waitInstanceId: 'wrong-id',
+      })
+    ).rejects.toMatchObject({ code: 'invalid_argument' });
+  });
+
+  it('detects reply wait collisions', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    const reply: WaitJson = {
+      kind: 'reply',
+      channel: 'telegram',
+      threadId: '9000',
+      peer: 'justin',
+    };
+    await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: reply,
+    });
+    // Second flow under same controller cannot create the same reply wait.
+    const second = await r.registry.createFlow({
+      ...baseInput,
+      idempotencyKey: 'idem-create-second-1',
+      ownerKey: 'cluster:other',
+    });
+    await r.registry.startStep({
+      flowId: second.flow.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    await expect(
+      r.registry.setFlowWaiting({
+        flowId: second.flow.flowId,
+        expectedRevision: 2,
+        principal: ctrl,
+        waitJson: reply,
+      })
+    ).rejects.toMatchObject({ code: 'wait_collision' });
+  });
+});
+
+describe('TaskFlowRegistry — terminal + cancel', () => {
+  let r: TestRig;
+  beforeEach(async () => { r = await rig(); });
+  afterEach(async () => { await r.cleanup(); });
+
+  it('rejects mutations on terminal flows with already_terminal', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    await r.registry.finishFlow({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+    });
+    await expect(
+      r.registry.startStep({
+        flowId: f0.flowId,
+        expectedRevision: 3,
+        principal: ctrl,
+        currentStep: 's2',
+      })
+    ).rejects.toMatchObject({ code: 'already_terminal' });
+  });
+
+  it('cancelFlow requires prior requestFlowCancel', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await expect(
+      r.registry.cancelFlow({
+        flowId: f0.flowId,
+        expectedRevision: 1,
+        principal: ctrl,
+      })
+    ).rejects.toMatchObject({ code: 'invalid_transition' });
+  });
+
+  it('requestFlowCancel emits taskflow:cancel-requested when waiting', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: { kind: 'human-review', question: 'q' },
+    });
+    let fired: any = null;
+    r.registry.on('taskflow:cancel-requested', (e) => { fired = e; });
+    await r.registry.requestFlowCancel({
+      flowId: f0.flowId,
+      expectedRevision: 3,
+      requesterOrigin: { kind: 'user', id: 'justin' },
+    });
+    expect(fired?.flowId).toBe(f0.flowId);
+  });
+});
+
+describe('TaskFlowRegistry — pingFlow', () => {
+  let r: TestRig;
+  beforeEach(async () => { r = await rig(); });
+  afterEach(async () => { await r.cleanup(); });
+
+  it('updates heartbeat without bumping revision', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    r.clock.now += 1000;
+    const pinged = await r.registry.pingFlow({ flowId: f0.flowId, principal: ctrl });
+    expect(pinged.revision).toBe(2); // unchanged
+    expect(pinged.controllerHeartbeatAt).toBe(r.clock.now);
+  });
+
+  it('rebinds controllerInstanceId on ping (re-attach)', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    const reattach: TaskFlowPrincipal = {
+      scope: 'controller',
+      controllerId: 'EvolutionManager',
+      controllerInstanceId: 'inst-2-after-restart',
+    };
+    const pinged = await r.registry.pingFlow({ flowId: f0.flowId, principal: reattach });
+    expect(pinged.controllerInstanceId).toBe('inst-2-after-restart');
+  });
+
+  it('rejects ping on non-running flow', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await expect(
+      r.registry.pingFlow({ flowId: f0.flowId, principal: ctrl })
+    ).rejects.toMatchObject({ code: 'invalid_transition' });
+  });
+
+  it('rejects ping with wrong controllerId', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    const other: TaskFlowPrincipal = {
+      scope: 'controller',
+      controllerId: 'InitiativeTracker',
+      controllerInstanceId: 'inst-x',
+    };
+    await expect(
+      r.registry.pingFlow({ flowId: f0.flowId, principal: other })
+    ).rejects.toMatchObject({ code: 'unauthorized_controller' });
+  });
+});
+
+describe('TaskFlowMaintenanceSweeper', () => {
+  let r: TestRig;
+  beforeEach(async () => { r = await rig(); });
+  afterEach(async () => { await r.cleanup(); });
+
+  it('marks running flow lost when heartbeat is stale', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    // Advance clock past RUNNING_LOST (6h default).
+    r.clock.now += 7 * 60 * 60 * 1000;
+    const sweeper = new TaskFlowMaintenanceSweeper({
+      registry: r.registry,
+      store: r.store,
+      now: () => r.clock.now,
+    });
+    const counts = await sweeper.sweep();
+    expect(counts.scanned).toBeGreaterThanOrEqual(1);
+    expect(counts.marked).toBe(1);
+    const after = r.registry.getFlow(f0.flowId, { bypassCache: true })!;
+    expect(after.status).toBe('lost');
+    expect(after.supersededBy?.reason).toBe('lost');
+  });
+
+  it('does NOT mark a fresh running flow lost', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    const sweeper = new TaskFlowMaintenanceSweeper({
+      registry: r.registry,
+      store: r.store,
+      now: () => r.clock.now,
+    });
+    const counts = await sweeper.sweep();
+    expect(counts.marked).toBe(0);
+  });
+
+  it('exempts scheduled-tick waits from lost-eligibility', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: { kind: 'scheduled-tick', dueAt: r.clock.now + 30 * 24 * 60 * 60 * 1000 },
+    });
+    r.clock.now += 365 * 24 * 60 * 60 * 1000; // a year
+    const sweeper = new TaskFlowMaintenanceSweeper({
+      registry: r.registry,
+      store: r.store,
+      now: () => r.clock.now,
+    });
+    const counts = await sweeper.sweep();
+    expect(counts.marked).toBe(0);
+  });
+});
+
+describe('TaskFlowDueWaker', () => {
+  let r: TestRig;
+  beforeEach(async () => { r = await rig(); });
+  afterEach(async () => { await r.cleanup(); });
+
+  it('resumes scheduled-tick waits whose dueAt has passed', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    const dueAt = r.clock.now + 1000;
+    await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: { kind: 'scheduled-tick', dueAt },
+    });
+
+    // Before dueAt: tick wakes nothing.
+    const waker = new TaskFlowDueWaker({ registry: r.registry, now: () => r.clock.now });
+    expect(await waker.tick()).toBe(0);
+
+    // After dueAt: tick resumes.
+    r.clock.now += 2000;
+    let firedFlowId = '';
+    r.registry.on('taskflow:wait-fired', (e) => { firedFlowId = e.flowId; });
+    expect(await waker.tick()).toBe(1);
+    expect(firedFlowId).toBe(f0.flowId);
+    const after = r.registry.getFlow(f0.flowId, { bypassCache: true })!;
+    expect(after.status).toBe('running');
+    expect(after.waitInstanceId).toBeUndefined();
+  });
+});
+
+describe('TaskFlowRegistry — find* lookups', () => {
+  let r: TestRig;
+  beforeEach(async () => { r = await rig(); });
+  afterEach(async () => { await r.cleanup(); });
+
+  it('findWaitingByCorrelation matches cross-agent-callback waits', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    const correlationId = 'a'.repeat(32);
+    await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: {
+        kind: 'cross-agent-callback',
+        threadId: 'th-1',
+        correlationId,
+        expectedAgentId: 'Dawn',
+      },
+    });
+    const matches = r.registry.findWaitingByCorrelation({
+      waitKind: 'cross-agent-callback',
+      correlationId,
+    });
+    expect(matches.length).toBe(1);
+    expect(matches[0].flowId).toBe(f0.flowId);
+  });
+
+  it('findWaitingByReply matches reply waits by tuple', async () => {
+    const { flow: f0 } = await r.registry.createFlow(baseInput);
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: { kind: 'reply', channel: 'telegram', threadId: '9000', peer: 'justin' },
+    });
+    const matches = r.registry.findWaitingByReply({
+      channel: 'telegram',
+      threadId: '9000',
+      peer: 'justin',
+    });
+    expect(matches.length).toBe(1);
+    expect(matches[0].flowId).toBe(f0.flowId);
+  });
+});
+
+describe('TaskFlowRegistry — redaction', () => {
+  let r: TestRig;
+  beforeEach(async () => { r = await rig(); });
+  afterEach(async () => { await r.cleanup(); });
+
+  it('getRedactedFlow strips stateJson and waitJson identifying fields', async () => {
+    const { flow: f0 } = await r.registry.createFlow({
+      ...baseInput,
+      stateJson: { secret: 'do-not-leak' },
+    });
+    await r.registry.startStep({
+      flowId: f0.flowId,
+      expectedRevision: 1,
+      principal: ctrl,
+      currentStep: 's1',
+    });
+    await r.registry.setFlowWaiting({
+      flowId: f0.flowId,
+      expectedRevision: 2,
+      principal: ctrl,
+      waitJson: {
+        kind: 'reply',
+        channel: 'telegram',
+        threadId: '9000',
+        peer: 'justin',
+      },
+    });
+    const redacted = r.registry.getRedactedFlow(f0.flowId)!;
+    expect(redacted.stateJson).toBeUndefined();
+    expect(redacted.waitJson).toEqual({ kind: 'reply' });
+  });
+});

--- a/upgrades/side-effects/taskflow-phase1.md
+++ b/upgrades/side-effects/taskflow-phase1.md
@@ -1,0 +1,129 @@
+# Side-Effects Review — TaskFlow Phase 1 (skeleton + storage + sweeper + waker)
+
+**Version / slug:** `taskflow-phase1`
+**Date:** 2026-05-09
+**Author:** Echo
+**Second-pass reviewer:** required (idempotency checks + state-machine authority surface)
+
+## Summary of the change
+
+Imports OpenClaw's TaskFlow primitive into instar as a new SQLite-backed registry of durable, optimistic-concurrency multi-step job records. Phase 1 ships only the plumbing: types, store, registry surface (createFlow / startStep / setFlowWaiting / resumeFlow / finishFlow / failFlow / cancel / markLost / pingFlow / find* lookups), an hourly maintenance sweeper that marks stranded flows `lost`, and a minute-tick due-waker for `scheduled-tick` waits. No business consumers — `EvolutionManager`, `InitiativeTracker`, and `ThreadlineFlowBridge` are integrated in later phases.
+
+Files touched:
+- `src/tasks/task-flow-types.ts` (new) — types, zod schemas, error class, default thresholds
+- `src/tasks/task-flow-registry.store.sqlite.ts` (new) — SQLite store with `BEGIN IMMEDIATE` writes
+- `src/tasks/TaskFlowRegistry.ts` (new) — registry surface, OCC apply, EventBus, audit notes
+- `src/tasks/TaskFlowMaintenanceSweeper.ts` (new) — hourly lost-eligibility scan
+- `src/tasks/TaskFlowDueWaker.ts` (new) — minute-tick scheduled-tick resume
+- `tests/unit/task-flow-registry.test.ts` (new) — 24 vitest cases (OCC, transitions, sweeper, waker, find lookups, redaction)
+- `src/server/routes.ts` — adds `RouteContext.taskFlowRegistry` + admin HTTP routes (`POST /flows`, `GET /flows/:id`, mutation routes, `GET /flows/waiting`, `POST /flows/:id/ping`)
+- `src/server/AgentServer.ts` — adds `taskFlowRegistry` option, propagates to `RouteContext`
+- `src/commands/server.ts` — opt-in instantiation gated on `config.taskFlow.enabled`; sweeper + waker started with `unref()`'d timers
+- `.gitignore` — adds `.instar/task-flows.db*` (per-machine, may contain user PII)
+- `upgrades/side-effects/taskflow-phase1.md` (this file)
+
+## Decision-point inventory
+
+- `TaskFlowRegistry.applyOcc` (registry-internal) — **add** — gates every mutation on `expectedRevision`; rejects `not_found / revision_conflict / already_terminal / invalid_transition`. Storage-mechanics, not judgment.
+- `TaskFlowMaintenanceSweeper.isLostEligible` — **add** — deterministic threshold rule per (status × wait-kind), configurable via `config.taskFlow.thresholds`. Marks flows `lost` via the registry's `markLost` (reserved-controller writer per spec § Design Principles 6).
+- `TaskFlowRegistry.maybeNotify` — **add** — fires `taskflow:notify` events. Phase 1 ships metric-only; no actual messages sent. No block/allow surface.
+- `WaitJson` zod validation — **add** — strict-on-write structural validation at the API edge. Hard-invariant validation, not judgment (signal-vs-authority exemption "Hard-invariant validation").
+- `createFlow` idempotency-key uniqueness — **add** — mechanics for retry-safe creates; not judgment.
+- HTTP route auth — **pass-through** — global `authMiddleware` already protects `/flows*`; no new auth surface.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The OCC mutation surface rejects:
+- Stale `expectedRevision` → `409 revision_conflict` with the current record body. Caller's documented retry path is "re-read flow, retry with new revision." A controller that lost a race retries; nothing legitimate is permanently rejected.
+- Mutations on terminal flows → `410 already_terminal`. By definition no legitimate work happens on terminal flows.
+- `setFlowWaiting` for a `reply` wait whose `(controllerId, channel, threadId, peer)` already has an active wait → `wait_collision`. The spec calls for this — preventing two flows from racing to consume the same Telegram-thread reply. If a controller legitimately wants to "wait for whichever reply lands first", that is NOT v1 semantics; v1 says one flow per tuple.
+- `WaitJson` validation rejects malformed inputs (e.g. negative `dueAt`, missing `correlationId`). Edge structural validation, not judgment.
+
+The sweeper marks `lost` only after configured thresholds. Defaults are deliberately conservative (running 6h, reply 7d, human-review 30d, scheduled-tick never). All thresholds are configurable in `.instar/config.json` under `taskFlow.thresholds`. A controller that legitimately runs 5 hours of work without heartbeating could be incorrectly marked `lost`; the documented contract is "ping at least every `HEARTBEAT_INTERVAL_MS` (60s)." The 6h threshold gives a 360× heartbeat-failure margin before the sweeper fires.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A flow that runs >6h with regular pings continues running indefinitely. By design — `pingFlow` is the heartbeat-renewal mechanism. The sweeper does not enforce a ceiling on legitimate work.
+- Cross-store dangling foreign keys: `cancelRequestedBy.id` may point at a user who has been removed; we don't validate. v1 explicitly tolerates dangling refs (see WikiClaim spec for the analogous policy).
+- A buggy controller can `finishFlow` with `result: { ... }` that exceeds 64 KiB only if the existing `stateJson` plus result merger pushes it over. We validate post-merger, so this is detected.
+- HTTP body fields are normal JSON — a caller that posts `principal: null` gets `422 invalid_argument`. Anyone with the bearer token can pass `scope: 'admin'` and bypass controllerId checks. v1 is single-process / loopback-only; admin scope from a token-holder is the intended trust model.
+- Sweeper-vs-controller race: spec § Threat Model documents this. A controller that misses pings AND has unfinished side effects emits a SharedStateLedger note for human follow-up. The registry rejects the controller's late `finishFlow` with `already_terminal` (the sweeper's `markLost` won the OCC race).
+- **Quota enforcement is deferred** — spec Phase 5 adds per-controller flow-creation rate limits and max-active-flows-per-controller. Phase 1 does not enforce these. A buggy controller could create a runaway number of flows; until Phase 5 ships, mitigation is monitoring (`flows_status_updated_at` index makes a "how many flows are running for X" query cheap).
+
+## 3. Level-of-abstraction fit
+
+This is plumbing — a typed, durable state machine for in-flight work. It belongs at the same layer as `JobScheduler` and `InitiativeTracker`. It does NOT replace either: JobScheduler runs cron-style recurrences, InitiativeTracker tracks multi-phase work without typed waits or OCC. TaskFlow fills the gap for "single-instance multi-step jobs with typed, durable waits."
+
+The maintenance sweeper is the right level: it reads structural state (heartbeat timestamps, wait kinds, configured thresholds) and applies a deterministic rule. It does NOT inspect `stateJson` content (which would require domain knowledge it shouldn't have). The threshold rule lives in config, so a future smarter-authority migration could replace it without restructuring (signal-shape → authority-consumer evolution is preserved).
+
+The HTTP API is intentionally minimal. Production controllers run in-process inside the server and call the registry directly; the HTTP surface exists for admin/debugging and out-of-process tooling.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No** — this change has no block/allow surface in the judgment sense. Every "rejection" is either:
+  - Hard-invariant structural validation at the API edge (zod, size limits, type-check), which the principle explicitly exempts ("Hard-invariant validation");
+  - State-machine mechanics (terminal status, OCC revision, controllerId match), which is not a judgment about meaning or intent;
+  - Deterministic threshold mechanics (heartbeat-stale, dueAt-passed) operating on numeric timestamps with configurable thresholds.
+
+The maintenance sweeper specifically: it is the *enforcement mechanic* for the lost-eligibility rule. It does not interpret what work the controller is doing; it counts seconds since heartbeat. The accompanying SharedStateLedger note is *audit*, decoupled from authority — humans review notes; the note does not gate any action.
+
+The notification dispatch surface (`TaskNotifyPolicy`) emits messages to topics. It does NOT decide whether a message is legitimate; that belongs to the existing `MessagingToneGate`. Phase 5 wiring will route notifications through `TelegramAdapter.send`, which already runs through the tone gate. Phase 1 ships metric-only emission to keep the tone-gate seam well-defined.
+
+No brittle authorities introduced.
+
+## 5. Interactions
+
+- **Shadowing**: TaskFlow does not shadow `JobScheduler` (cron-recurrence) or `InitiativeTracker` (multi-phase) — they cover different use cases. EvolutionManager / DispatchExecutor will migrate to TaskFlow in Phases 3–5; until then, they continue to write to their own JSONL files. Phase 3 adds a `DivergenceChecker` for the dual-write window.
+- **Double-fire**: The maintenance sweeper and the due-waker operate on disjoint flow sets (sweeper excludes `wait_kind='scheduled-tick'`; waker only handles that kind). They cannot both fire on the same flow.
+- **Races**: `pingFlow` is OCC-exempt by design (spec § Heartbeat contract). It uses `WHERE flow_id=? AND status='running'` and rebinds `controllerInstanceId` on every successful call — this is the documented re-attach-after-restart mechanism. A concurrent step-advance would fail pingFlow's status check (status no longer 'running' inside the transaction), which the registry handles by re-reading and throwing `invalid_transition`. Sweeper-vs-controller races are documented in § Threat Model.
+- **Feedback loops**: The sweeper emits SharedStateLedger notes; the ledger does not feed back into TaskFlow. The notification surface emits `taskflow:notify` events that Phase 5 routes through TelegramAdapter; that send path does not write back to TaskFlow.
+- **Cache coherence**: The in-process LRU cache is updated AFTER `COMMIT` (registry's `applyOcc`). On COMMIT failure the cache entry is invalidated (deleted), so the next read forces a SQLite reload. Single-writer (the server process) means the cache is coherent by construction.
+
+## 6. External surfaces
+
+- **Other agents on the same machine**: None directly. Other agents do not share the TaskFlow DB. The DB file is on the git-sync deny-list (`.gitignore` updated).
+- **Other users of the install base**: New module is opt-in via `config.taskFlow.enabled` (default off). Existing installs continue to work unchanged. Even when enabled, no existing routes / behaviors change.
+- **External systems**: None. No outbound HTTP, no LLM calls, no Telegram sends in Phase 1 (notification dispatch ships at metric-emission level only).
+- **Persistent state**: New SQLite file `.instar/task-flows.db` (+ WAL/SHM) created on first use. Backup System rotation already covers `.instar/*.db` patterns where applicable. Cross-machine sync explicitly OUT of v1 scope (spec § Privacy / sync exposure).
+- **Timing or runtime conditions**: Sweeper runs hourly; due-waker runs every minute. Both timers `unref()` so they never keep the process alive on shutdown. Server restart re-attaches via the natural `pingFlow` rebind path; no special restart logic needed.
+
+## 7. Rollback cost
+
+- **Hot-fix release**: Pure additive change. Rollback is `git revert <pr-merge-commit>`; ship as next patch. The opt-in `config.taskFlow.enabled` flag means a partial rollback path also exists: set the flag to `false` in `.instar/config.json` and the registry won't instantiate (HTTP routes return `503 taskflow_not_enabled`).
+- **Data migration**: None on rollback. The `.instar/task-flows.db` file is local, ignored by git, and contains no data any other subsystem depends on. Operators can safely delete it after rollback if they want a clean reinstall.
+- **Agent state repair**: None. No existing agent has any flow records yet (Phase 1 has no producers). Reset is a no-op.
+- **User visibility**: None during rollback window. No user-facing surface in Phase 1.
+
+---
+
+## Conclusion
+
+Phase 1 ships TaskFlow as opt-in plumbing: types, SQLite store, registry surface, hourly sweeper, minute-tick waker, admin HTTP routes, and 24 unit tests covering OCC + transitions + sweeper + waker + find-lookups + redaction. The change has no block/allow judgment surface — every "rejection" is structural validation, state-machine mechanics, or deterministic threshold mechanics, all of which the signal-vs-authority principle exempts. The notification surface is wired but stubbed at metric-emission only, preserving the seam where Phase 5 will route through the existing tone-gate authority.
+
+The change is opt-in (default off), additive (no existing behavior modified), and rollback-cheap (revert + flag flip). Cleared to ship pending second-pass concurrence.
+
+---
+
+## Second-pass review
+
+**Reviewer:** independent code-audit subagent (general-purpose)
+**Independent read of the artifact: concur**
+
+The artifact's claims match the code: (1) `applyOcc` updates the cache only after `withWriteTransaction` returns post-COMMIT; (2) `findSweeperCandidates` filters `wait_kind != 'scheduled-tick'` and `findWaitingDue` filters `wait_kind='scheduled-tick'`, making the sweeper/waker sets provably disjoint; (3) `createFlow` lookup-then-insert runs inside `BEGIN IMMEDIATE` against a `(controller_id, owner_key, idempotency_key)` PRIMARY KEY, so duplicate keys return the existing flow with `created:false`; (4) `maybeNotify` increments local counters and emits an EventEmitter event but performs no outbound send; (5) the sweeper's `isLostEligible` is pure deterministic threshold arithmetic on numeric timestamps with config-overridable thresholds — a state-machine mechanic, not judgment, properly exempt under signal-vs-authority §"Hard-invariant validation" / §"Idempotency keys"; (6) `setFlowWaiting`'s `wait_collision` is uniqueness-mechanic on (controllerId, channel, threadId, peer), matching the spec's v1 semantics. No brittle blocking authority is introduced; rollback is revert + flag flip, and Phase 1 has no producers yet.
+
+---
+
+## Evidence pointers
+
+- Test run: `npx vitest run tests/unit/task-flow-registry.test.ts` → 24/24 passing (135ms).
+- Typecheck: `npx tsc --noEmit` → clean across modified files.
+- Spec source of truth: `docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md` (Convergence: 2026-05-07; rounded through three review passes).
+- OpenClaw provenance: commit `f482e4d335`, files `src/tasks/task-flow-registry.ts:376-586`, `task-flow-registry.types.ts:14-43`, `task-flow-registry.store.sqlite.ts:361-371`.

--- a/upgrades/side-effects/taskflow-phase1.md
+++ b/upgrades/side-effects/taskflow-phase1.md
@@ -125,5 +125,6 @@ The artifact's claims match the code: (1) `applyOcc` updates the cache only afte
 
 - Test run: `npx vitest run tests/unit/task-flow-registry.test.ts` → 24/24 passing (135ms).
 - Typecheck: `npx tsc --noEmit` → clean across modified files.
+- Route-completeness test: `npx vitest run tests/unit/route-completeness.test.ts` → 9/9 passing. Catch blocks in new TaskFlow routes guard with `if (err instanceof Error)` to satisfy the routes-source invariant (every `catch (err)` paired with an `instanceof Error` check).
 - Spec source of truth: `docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md` (Convergence: 2026-05-07; rounded through three review passes).
 - OpenClaw provenance: commit `f482e4d335`, files `src/tasks/task-flow-registry.ts:376-586`, `task-flow-registry.types.ts:14-43`, `task-flow-registry.store.sqlite.ts:361-371`.


### PR DESCRIPTION
## Summary

- Imports OpenClaw's TaskFlow primitive as a new SQLite-backed registry of durable, optimistic-concurrency multi-step job records — the substrate for Phases 2–5 (Threadline cross-agent waits, EvolutionManager bug-cluster pipeline migration, InitiativeTracker migration, hardening).
- Phase 1 ships only plumbing: 5 new files in \`src/tasks/\`, admin HTTP routes, opt-in via \`config.taskFlow.enabled\` (default: off). No business consumers yet.
- 24 unit tests covering OCC contract, full transition lifecycle, sweeper threshold rules, due-waker resume, find-lookups, and redaction.

## Scope (per spec § Migration Plan / Phase 1)

- \`src/tasks/task-flow-types.ts\` — types, zod schemas, error class, defaults
- \`src/tasks/task-flow-registry.store.sqlite.ts\` — SQLite store with \`BEGIN IMMEDIATE\` writes
- \`src/tasks/TaskFlowRegistry.ts\` — registry surface (createFlow, startStep, setFlowWaiting, resumeFlow, finishFlow, failFlow, requestFlowCancel, cancelFlow, markLost, pingFlow, find*); EventBus emissions for \`taskflow:wait-fired\` / \`taskflow:cancel-requested\` / \`taskflow:notify\`; SharedStateLedger audit notes
- \`src/tasks/TaskFlowMaintenanceSweeper.ts\` — hourly lost-eligibility scan via reserved \`TaskFlowMaintenance\` controller
- \`src/tasks/TaskFlowDueWaker.ts\` — minute-tick scheduled-tick resume
- \`src/server/routes.ts\` / \`src/server/AgentServer.ts\` / \`src/commands/server.ts\` — wiring
- \`.gitignore\` — \`.instar/task-flows.db*\` (per-machine, may contain user PII)
- \`upgrades/side-effects/taskflow-phase1.md\` — full review (over-block, under-block, level-of-abstraction, signal-vs-authority compliance, interactions, external surfaces, rollback cost) + independent second-pass concurrence

## Spec source

- [\`OPENCLAW-IMPORT-TASKFLOW-SPEC.md\`](https://github.com/JKHeadley/instar) — converged 2026-05-07 through three review rounds.
- OpenClaw provenance: commit \`f482e4d335\`.

## Test plan

- [x] \`npx vitest run tests/unit/task-flow-registry.test.ts\` — 24/24 passing locally
- [x] \`npx tsc --noEmit\` — clean
- [x] /instar-dev pre-commit gate satisfied (trace + artifact + sha + second-pass concurrence)
- [ ] CI green
- [ ] Phase 2 follow-up: ThreadlineFlowBridge + cross-agent-callback waits

## Signal-vs-authority compliance

No new brittle authority. The registry's "rejections" are structural validation (zod), state-machine mechanics (terminal status, OCC, controllerId match), or deterministic threshold mechanics (sweeper). All exempt under the principle's "Hard-invariant validation" / "Idempotency keys at the transport layer" carve-outs. Notification dispatch is wired but metric-only; Phase 5 routes through the existing tone-gate authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)