### PR TITLE
feat(tasks): TaskFlow Phase 3a — EvolutionManager dual-write + DivergenceChecker

### DIFF
--- a/docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md
+++ b/docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md
@@ -1,0 +1,763 @@
+---
+review-convergence: 2026-05-07T19:55:00Z
+approved: true
+---
+
+# Instar TaskFlow — Managed Multi-Step Job Primitive (Imported from OpenClaw)
+
+> Durable, optimistic-concurrency multi-step job records with typed wait reasons, owned by a controller. Replaces ad-hoc state-shuffling in the bug-cluster pipeline with a single auditable lifecycle.
+
+**Status**: Review-Convergence
+**Converged**: 2026-05-07T19:55:00Z
+**Author**: Echo (parallel OpenClaw audit, 2026-05-07)
+**Date**: 2026-05-08
+**Origin**: §8 #1 of `.claude/research/openclaw-audit-instar-2026-05-07.md` (Echo project). OpenClaw source (verified at commit `f482e4d335`): `src/tasks/task-flow-registry.ts:376-586` (createManagedTaskFlow surface), `src/tasks/task-flow-registry.types.ts:14-43` (record + status types), `src/tasks/task-flow-registry.store.sqlite.ts:361-371` (`withWriteTransaction`, BEGIN IMMEDIATE), `src/plugins/runtime/runtime-taskflow.ts:14-220` (consumer pattern reference — wraps create/wait/resume/finish for runtime plugins), `src/tasks/task-flow-runtime-internal.ts:1-18` (internal helpers). Audited at OpenClaw commit `f482e4d335`.
+**Related**: SharedStateLedger v2 (Integrated-Being), CommitmentSweeper, EvolutionManager (PROP queue), InitiativeTracker, JobScheduler
+
+---
+
+## Table of Contents
+
+1. [TL;DR](#tldr)
+2. [The Problem](#the-problem)
+3. [The OpenClaw Primitive](#the-openclaw-primitive)
+4. [Design Principles](#design-principles)
+5. [Architecture](#architecture)
+6. [Record Shape](#record-shape)
+7. [Lifecycle](#lifecycle)
+8. [Storage and Concurrency](#storage-and-concurrency)
+9. [Integration with Existing Instar Subsystems](#integration-with-existing-instar-subsystems)
+10. [Migration Plan](#migration-plan)
+11. [Risks and Mitigations](#risks-and-mitigations)
+12. [Threat Model](#threat-model)
+13. [Open Questions](#open-questions)
+14. [Non-Goals](#non-goals)
+15. [References](#references)
+
+---
+
+## TL;DR
+
+A `TaskFlow` is a SQLite-backed durable record `{flowId, controllerId, revision, status, goal, currentStep, stateJson, waitJson, ...}` with optimistic-concurrency mutations. Controllers create managed flows, run them step-by-step, set them to wait on typed reasons (`reply | human-review | external-call | scheduled-tick | cross-agent-callback`), and resume them when the wait condition fires. Status transitions are gated by `expectedRevision` so two concurrent writers cannot silently overwrite each other.
+
+For Instar, TaskFlow replaces three ad-hoc state-shuffling paths:
+- The **bug-cluster pipeline** (cluster → tier-1-fix-attempt → ratification → tier-2-expansion) currently lives across `EvolutionManager`, `DispatchExecutor`, and `HandoffManager` as plain JSON files with no concurrency primitive.
+- The **initiative tracker** has phases and blockers but no controller / no typed waits / no revision contract.
+- **Cross-agent collaboration over Threadline** has no continuation primitive — when Echo asks Dawn a question, the "I'm waiting on her reply" state lives in the Telegram thread, not in any registry.
+
+Importing TaskFlow gives all three a common managed-flow shape with one durable record per flow, an explicit controller, typed waits, and revision-conflict detection.
+
+## The Problem
+
+Today, when Echo runs a bug-cluster fix attempt:
+
+1. The cluster is identified by `EvolutionManager` and written to `proposals.jsonl`.
+2. Tier-1 fix attempt is dispatched via `DispatchExecutor`; outcome lands in `dispatch-decisions.jsonl`.
+3. Ratification by Justin happens over Telegram with no durable pointer back to the cluster.
+4. Tier-2 expansion (when the tier-1 fix fails) re-reads the JSONL files and reconstructs state from the most recent matching entries.
+
+Failure modes today:
+- **Lost continuation**: if Echo's session dies between dispatch and ratification, the next session has to scan multiple JSONL files to figure out "what was Echo waiting on?"
+- **No concurrency primitive**: two sessions could each pick up "the same" cluster and dispatch competing fixes. Today this is prevented by the single-process assumption, not by structure.
+- **Implicit waits**: "waiting for Justin" is a state that lives in Echo's head, not in any registry. The CommitmentSweeper can sweep stranded commitments but has no equivalent for stranded work-in-progress.
+- **Cross-agent waits are fictive**: if Echo sends Dawn a question and waits for her reply, there is no registry entry that says "Echo flow X is waiting on Dawn reply Y." The wait exists only in the conversation transcript.
+
+A managed-flow record solves all four by making the wait first-class, durable, and revision-gated.
+
+## The OpenClaw Primitive
+
+Source: `src/tasks/task-flow-registry.ts:376-586`, `src/tasks/task-flow-registry.types.ts:14-43`.
+
+```typescript
+type TaskFlowSyncMode = "task_mirrored" | "managed";
+
+type TaskFlowStatus =
+  | "queued"
+  | "running"
+  | "waiting"
+  | "blocked"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "lost";
+
+type TaskFlowRecord = {
+  flowId: string;
+  syncMode: TaskFlowSyncMode;
+  ownerKey: string;
+  requesterOrigin?: DeliveryContext;
+  controllerId?: string;        // who advances this flow
+  revision: number;             // optimistic concurrency
+  status: TaskFlowStatus;
+  notifyPolicy: TaskNotifyPolicy;
+  goal: string;
+  currentStep?: string;
+  blockedTaskId?: string;
+  blockedSummary?: string;
+  stateJson?: JsonValue;        // controller-private state
+  waitJson?: JsonValue;         // typed wait reason
+  cancelRequestedAt?: number;
+  createdAt: number;
+  updatedAt: number;
+  endedAt?: number;
+};
+```
+
+Key API surface:
+
+```typescript
+createManagedTaskFlow({...fields, controllerId})
+updateFlowRecordByIdExpectedRevision({flowId, expectedRevision, patch})
+  // returns {applied: true, flow} or {applied: false, reason: "revision_conflict", current}
+setFlowWaiting({flowId, expectedRevision, waitJson, currentStep, ...})
+resumeFlow({flowId, expectedRevision, status, currentStep, ...})
+finishFlow({flowId, expectedRevision, ...})
+failFlow({flowId, expectedRevision, blockedSummary, ...})
+requestFlowCancel({flowId, expectedRevision, cancelRequestedAt})
+```
+
+Storage: SQLite with `BEGIN IMMEDIATE` write transactions (`task-flow-registry.store.sqlite.ts:361-371`). In-memory `flows` Map cache for read speed.
+
+Consumer pattern (from `extensions/active-memory/index.ts:2891-2998`): a controller calls `createManagedTaskFlow` to start, updates `currentStep` and persists private state into `stateJson` as it advances, calls `setFlowWaiting({waitJson:{kind:"reply"|"human-review"|"external-call"}})` when blocking on something, then `resumeFlow` when the wait fires, then `finishFlow` or `failFlow` at the end.
+
+## Design Principles
+
+1. **Controller-owned, not consensus-owned**. A flow has exactly one controller (`controllerId`). The controller is the only entity allowed to advance state. No "either Echo or Dawn can resume this flow." If a controller dies, the flow goes `lost`; recovery is a separate maintenance pass.
+2. **Optimistic concurrency by default**. Every mutation requires `expectedRevision`. Conflicts are detected, not silently merged. This is the single-process safety net AND the multi-process correctness guarantee.
+3. **Typed waits, not free-form**. `waitJson.kind` is an enum: `reply | human-review | external-call | scheduled-tick | cross-agent-callback`. Each kind has known fields and a known resolution path.
+4. **State is private to the controller**. `stateJson` is opaque to the registry. The registry exposes `goal`, `currentStep`, `status`, `waitJson`; everything else is the controller's business.
+5. **No automatic resumption**. The registry does not poll waits; controllers register listeners (e.g., the messaging-arrival handler resumes flows waiting on `kind:"reply"`). This keeps the registry pure storage.
+6. **Sweeper-as-reserved-controller**. A maintenance sweeper detects flows that look `lost | stranded` and writes a status transition through the normal OCC API using a reserved `controllerId: "TaskFlowMaintenance"` that the registry whitelists for terminal-from-running and terminal-from-waiting transitions. The sweeper additionally emits a SharedStateLedger note for audit. (Earlier drafts proposed pure signal-shape; per Round 1 review, that produced an "is this flow terminal?" question with two answers — the flow row and a separate ledger note. Reserved-controller writer keeps the registry the single answer for status while the ledger note carries the rationale.)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                      TaskFlowRegistry (server)                      │
+│                                                                     │
+│   ┌─────────────────────────────────────────────────────────────┐   │
+│   │  SQLite store (.instar/task-flows.db, WAL, single writer)   │   │
+│   │  - one row per flow                                         │   │
+│   │  - revision++ on every patch                                │   │
+│   │  - BEGIN IMMEDIATE wraps read+write check-and-discriminate  │   │
+│   └─────────────────────────────────────────────────────────────┘   │
+│                              ▲                                      │
+│   ┌──────────────────────────┴──────────────────────────────────┐   │
+│   │  In-process LRU cache (Map<flowId, TaskFlowRecord>)         │   │
+│   │  - one cache, one writer (the server) — coherent by design  │   │
+│   │  - cache update AFTER successful COMMIT                     │   │
+│   │  - cache invalidate on COMMIT failure                       │   │
+│   └─────────────────────────────────────────────────────────────┘   │
+│                              ▲                                      │
+└──────────────────────────────┼──────────────────────────────────────┘
+                               │
+        ┌──────────────────────┼─────────────────────┐
+        │                      │                     │
+   Controller A           Controller B       TaskFlowMaintenanceSweeper
+   (EvolutionManager,     (InitiativeTracker, (reserved controllerId; markLost
+    in-process)            in-process)         via OCC; emits ledger audit note)
+        │                      │                     │
+        ▼                      ▼                     ▼
+   createFlow             resumeFlow            markLost(expectedRevision,
+   setFlowWaiting         finishFlow                     ledgerEntryId, reason)
+   pingFlow              (with expectedRevision         + SharedStateLedger note
+   (heartbeat)            and waitInstanceId)
+```
+
+Wait-arrival paths feed back into controllers. Every wait-arrival path resolves to a *durable* `(flowId, expectedRevision, waitInstanceId)` triple by querying the registry — no in-memory state is required to survive a restart.
+
+**System-waker carve-out**: `TaskFlowDueWaker`, `ThreadlineFlowBridge`, `MessageRouter`'s reply-wait path, and the `external-call` callback endpoint are not the owning controller for the flows they wake. They run **in-process inside the server**, holding a direct reference to the `TaskFlowRegistry` instance — so they can call registry methods directly (not through HTTP). Direct calls still go through the same authorization layer as HTTP; the registry's `resumeFlow` method takes a `principal` argument that the in-process holder sets to the `system-waker` principal it was constructed with.
+
+The registry exposes a small **wait-lookup API** for these system-wakers, callable both in-process and over HTTP (with `system-waker` or `admin` scope). All return shape: `Array<{flowId, revision, waitInstanceId, controllerId, waitJson}>`:
+
+```typescript
+registry.findWaitingByReply({channel, threadId, peer}): WaitMatch[]
+registry.findWaitingByCorrelation({waitKind, correlationId}): WaitMatch[]
+registry.findWaitingByDueAt({nowMs}): WaitMatch[]   // returns scheduled-tick rows where dueAt <= nowMs
+```
+
+Each method is a single SQL query against the indexed columns above. The HTTP form is `GET /flows/waiting?...` with query parameters mirroring these methods; the response carries the same shape but with `stateJson` and full `waitJson` redacted (only the fields the waker needs for routing).
+
+A system-waker resolves a callback by:
+1. Calling the appropriate `findWaiting*` method to get `WaitMatch[]`.
+2. Performing the wait-kind-specific identity check (e.g., signature verification for `cross-agent-callback`).
+3. Calling `resumeFlow(flowId, expectedRevision, waitInstanceId)` with the matched values.
+4. Emitting `EventBus.emit('taskflow:wait-fired', {flowId, controllerId})` so the owning controller can pick up the now-`running` flow and advance its step.
+
+This separates "the wait is satisfied" (system-waker authority, transitions waiting → running) from "the controller owns the next step" (controller authority, all subsequent transitions). The owning controller's wait-fired handler reads the flow via `getFlow(flowId)` and advances; the controller never holds long-lived state about pending waits in memory.
+
+Note: HTTP clients (sessions outside the server) MAY also use these endpoints when authenticated as `admin` for debugging or admin tooling, but the production wait-resolution path runs in-process for latency and to keep `system-waker` principals out of the externally-issued token set.
+
+- `kind:"reply"` — `MessageRouter` on inbound message looks up `flows WHERE status='waiting' AND wait_json.kind='reply' AND wait_json.channel=? AND wait_json.threadId=? AND wait_json.peer=?`; resumes via system-waker scope. **Uniqueness contract**: at most one active `reply` wait may exist per `(controllerId, channel, threadId, peer)`; `setFlowWaiting` rejects with `wait_collision` if a duplicate is detected.
+- `kind:"human-review"` — explicit `/ratify <flowId>` slash command resolves to the flow and resumes via system-waker scope; the Telegram-attention-queue entry carries `flowId` so the ratify/reject affordance calls `resumeFlow` directly.
+- `kind:"external-call"` — completion-callback URL `POST /flows/:id/resume-via-callback` accepts a webhook with `correlationId`; the registry verifies the correlationId matches the active `waitJson` and resumes via system-waker scope.
+- `kind:"scheduled-tick"` — `TaskFlowDueWaker` queries `flows WHERE status='waiting' AND wait_json.kind='scheduled-tick' AND wait_json.dueAt <= now` every minute and resumes each via system-waker scope.
+- `kind:"cross-agent-callback"` — `ThreadlineFlowBridge` on inbound (signature-verified) Threadline message looks up `flows WHERE status='waiting' AND wait_json.kind='cross-agent-callback' AND wait_json.threadId=? AND wait_json.correlationId=?`; verifies `wait_json.expectedAgentId == verifiedSenderAgentId`; resumes via system-waker scope.
+
+The `waitInstanceId` is read from the flow row at callback-handling time, not held in memory between `setFlowWaiting` and the eventual callback. This makes wait resolution restart-safe.
+
+## Record Shape
+
+Trimmed port of the OpenClaw shape. v1 drops fields whose semantics are not needed in Instar (`syncMode`, `blockedTaskId`, `blockedSummary`, status `blocked`) and adds Instar-specific fields:
+
+```typescript
+export interface TaskFlowRecord {
+  flowId: string;                    // ulid
+  ownerKey: string;                  // domain-specific group key, e.g. "cluster:<clusterId>"
+                                     // or "initiative:<id>"; max 256 chars
+  requesterOrigin?: RequesterOrigin; // see RequesterOrigin below; replaces OpenClaw DeliveryContext
+  controllerId: string;              // e.g. "EvolutionManager" | "InitiativeTracker" |
+                                     // "ThreadlineFlowBridge" | "TaskFlowMaintenance" (reserved)
+  controllerInstanceId: string;      // uuid set on controller startup. Carried in the body of every
+                                     // controller-scope mutation (startStep, setFlowWaiting, resumeFlow,
+                                     // finishFlow, failFlow, cancelFlow, pingFlow); the registry overwrites
+                                     // the stored value on each successful mutation. Used by pingFlow as the
+                                     // OCC-exempt identity check, and by markLost audit notes. After server
+                                     // restart, the new instance re-attaches by calling GET /flows?controllerId=X
+                                     // (to enumerate live flows) then issuing pingFlow with the new instanceId
+                                     // (which overwrites the stale value). The first ping after restart
+                                     // succeeds because pingFlow checks `flow.controllerId == auth.controllerId
+                                     // && status='running'` only — it does NOT compare instanceId on entry; it
+                                     // SETS the new instanceId. (Correction to earlier draft text: pingFlow's
+                                     // "instanceId equality" check applies only to subsequent pings within the
+                                     // same instance lifetime; the first ping from a new instance re-binds.)
+  controllerHeartbeatAt: number;     // unix-millis-utc; bumped on every mutation by this controller
+  revision: number;                  // bumped on every patch
+  status: TaskFlowStatus;
+  notifyPolicy: TaskNotifyPolicy;    // see Notification Policy below
+  goal: string;                      // short human-readable; max 1024 chars
+  currentStep?: string;              // max 128 chars; e.g. "tier-1-fix-attempt"
+  stateJson?: JsonValue;             // controller-private state; max 64 KiB serialized
+  waitJson?: WaitJson;               // typed wait; max 8 KiB serialized
+  waitInstanceId?: string;           // uuid; set when status=waiting; required arg to resume
+  waitStartedAt?: number;            // unix-millis-utc; set on every successful setFlowWaiting; cleared on resume
+  cancelRequestedAt?: number;        // unix-millis-utc
+  cancelRequestedBy?: RequesterOrigin; // who requested cancel; set with cancelRequestedAt
+  createdAt: number;                 // unix-millis-utc; server-assigned
+  updatedAt: number;                 // unix-millis-utc; server-assigned on every mutation
+  endedAt?: number;                  // unix-millis-utc; set on transition to terminal status
+  supersededBy?: SupersededRef;      // pointer to ledger note that explains a sweeper-driven
+                                     // transition; null on normal terminal transitions
+  privacyScope?: PrivacyScopeType;   // matches MemoryEntity scope vocabulary
+}
+
+export type SupersededRef = {
+  kind: 'ledger-note';
+  ledgerEntryId: string;
+  reason: 'lost' | 'stranded' | 'manual-supersede';
+};
+
+export type RequesterOrigin = {
+  kind: 'user' | 'agent' | 'system' | 'job';
+  id: string;
+  channel?: string;                  // e.g. "telegram:9000", "threadline:<threadId>"
+};
+
+export type WaitJson =
+  | { kind: 'reply'; channel: string; threadId: string; peer: string; }
+  | { kind: 'human-review'; question: string; topicId?: number; reviewerId?: string; }
+  | { kind: 'external-call'; serviceId: string; correlationId: string; deadline?: number; }       // unix-millis-utc
+  | { kind: 'scheduled-tick'; dueAt: number; jobSlug?: string; }                                  // unix-millis-utc;
+                                                                                                  // jobSlug is currently unused by TaskFlowDueWaker (which polls by dueAt);
+                                                                                                  // reserved for future JobScheduler one-shot integration where the slug
+                                                                                                  // identifies a scheduler entry.
+  | { kind: 'cross-agent-callback'; threadId: string; correlationId: string; expectedAgentId: string; };
+```
+
+**Time fields**: every timestamp in the record is `unix-millis-utc` (int64). String timestamps in incoming requests (e.g., RFC3339) are normalized on write.
+
+**Status taxonomy** (trimmed from OpenClaw): `queued | running | waiting | succeeded | failed | cancelled | lost`. Removed `blocked` — it overlapped `waiting`. Invariant: `status='waiting'` iff `waitJson != null && waitInstanceId != null`. Invariant: terminal statuses (`succeeded | failed | cancelled | lost`) imply `endedAt != null` and any further mutation attempt MUST fail with `already_terminal`.
+
+**`notifyPolicy`** (Instar-defined; OpenClaw's exact semantics are not adopted):
+
+```typescript
+export type TaskNotifyPolicy =
+  | { kind: 'silent' }                                         // default; no notifications
+  | { kind: 'on-wait'; topicId: number }                       // notify on entering waiting status
+  | { kind: 'on-terminal'; topicId: number }                   // notify on succeeded|failed|cancelled|lost
+  | { kind: 'on-wait-and-terminal'; topicId: number };
+```
+
+**Field-size validation**: writes that exceed declared maxima fail with `invalid_argument`. The registry validates `waitJson` against the `WaitJson` discriminated union (zod schema) on every write.
+
+**Notification dispatch**: on a successful mutation, after COMMIT and before cache update, the registry inspects `notifyPolicy`:
+- `kind:'silent'` (default): no-op.
+- `kind:'on-wait'` and the mutation transitioned to `waiting`: emit a Telegram message to `topicId` via `TelegramAdapter` with shape `{flowId, goal, currentStep, waitJson.kind, waitJson.question? (for human-review only), revision}`.
+- `kind:'on-terminal'` and the mutation transitioned to a terminal status: emit `{flowId, goal, status, currentStep, supersededBy?, revision}`.
+- `kind:'on-wait-and-terminal'`: union of the two.
+
+Notification is best-effort and emitted asynchronously (fire-and-forget after COMMIT). Phase 1 ships the wiring with notifications stubbed at metric-emission only (`taskflow_notify_emitted_total`). Phase 5 wires through the actual `TelegramAdapter` send.
+
+## Lifecycle
+
+```
+                      createManagedTaskFlow
+                                │
+                                ▼
+                          status: queued
+                                │
+                       (controller picks up)
+                                │
+                                ▼
+                         status: running
+                                │
+              ┌─────────────────┼─────────────────┐
+              │                 │                 │
+              ▼                 ▼                 ▼
+       setFlowWaiting        finishFlow        failFlow
+       (kind: ...)         (status: succeeded) (status: failed)
+              │
+              ▼
+       status: waiting
+              │
+       (wait fires; controller observer
+        calls resumeFlow with expectedRevision)
+              │
+              ▼
+       status: running   (loop)
+```
+
+`requestFlowCancel` is orthogonal — sets `cancelRequestedAt` on any non-terminal flow. Controllers check `cancelRequestedAt` between steps and call **`cancelFlow`** (the dedicated terminal-transition operation) when honoring it. (Earlier draft text referred to "failFlow with status: cancelled"; that was wrong — `failFlow` produces `status='failed'`. Use `cancelFlow` for `status='cancelled'`.) Cancellation is advisory: controllers MUST honor on the next step boundary; the registry will not force-terminate.
+
+Any principal with `controller` (matching controllerId), `admin`, or any externally-issued bearer-token scope may request cancel. The registry persists the requester identity in two ways: (1) `cancelRequestedBy: RequesterOrigin` is set on the flow row alongside `cancelRequestedAt`; (2) a SharedStateLedger note `kind:'taskflow-cancel-requested'` is emitted carrying `flowId, revision, cancelRequestedBy`. Schema below adds the column.
+
+**Cancel-while-waiting wakeup**: `requestFlowCancel` on a flow whose `status='waiting'` MUST also emit `EventBus.emit('taskflow:cancel-requested', {flowId, controllerId})`. The owning controller's cancel-requested handler is responsible for: (a) calling the same wait-lookup APIs to release any in-flight wait state; (b) calling `cancelFlow(flowId, expectedRevision)` to finalize the terminal transition. Without this wakeup, a `waiting` flow with a 30-day human-review threshold would sit in `waiting` until the natural wait fires. Controllers register the cancel-requested handler at startup alongside the wait-fired handler.
+
+`status: lost` is set ONLY by the `TaskFlowMaintenance` reserved controller, never by a normal controller.
+
+## Mutation Semantics
+
+Every mutation goes through one of these typed operations. Each operation requires `expectedRevision` and bumps `revision` by 1 on success.
+
+### Legal status transitions
+
+```
+            createFlow (POST /flows)
+                  │
+                  ▼
+              queued ──cancelFlow──▶ cancelled
+                  │
+              startStep
+                  │
+                  ▼
+              running ──setFlowWaiting──▶ waiting
+                  │                          │
+                  │                          │ resumeFlow
+                  │                          │
+                  │ ◀────────────────────────┘
+                  │
+                  ├─ finishFlow ─▶ succeeded
+                  ├─ failFlow ───▶ failed
+                  ├─ cancelFlow ─▶ cancelled  (only when cancelRequestedAt is set)
+                  └─ markLost ───▶ lost       (TaskFlowMaintenance only; from running OR waiting)
+```
+
+`waiting → cancelled`, `waiting → failed`, and `waiting → lost` are also legal (the wait does not need to fire first). Terminal statuses (`succeeded | failed | cancelled | lost`) accept no further mutations: any attempt fails with `already_terminal`.
+
+### Per-operation contract
+
+| Operation | Required pre-state | Required args | Post-state | Server bumps |
+|---|---|---|---|---|
+| `createFlow` | (none — flow does not exist) | `idempotencyKey` (uuid; unique per `(controllerId, ownerKey, idempotencyKey)`) | `queued` | revision=1, createdAt, updatedAt |
+| `startStep` | `queued` or `running` | `controllerInstanceId`, `currentStep` | `running` | revision++, updatedAt, controllerHeartbeatAt, controllerInstanceId rebound |
+| `setFlowWaiting` | `running` | `controllerInstanceId`, `waitJson` (validated against WaitJson) | `waiting` | revision++, updatedAt, controllerHeartbeatAt, controllerInstanceId rebound, waitInstanceId (server-generated uuid), waitStartedAt=now, wait_kind denormalized |
+| `resumeFlow` | `waiting` | `waitInstanceId` (must match record); `controllerInstanceId` (controller scope) OR system-waker scope; optional `currentStep`; optional `statePatch` | `running` | revision++, updatedAt, controllerHeartbeatAt, waitInstanceId cleared, wait_kind cleared, waitStartedAt cleared |
+| `finishFlow` | `running` | `controllerInstanceId`, `result` (optional, stored in stateJson under `_result`) | `succeeded` | revision++, updatedAt, endedAt |
+| `failFlow` | `running` or `waiting` | `controllerInstanceId`, `failureReason` | `failed` | revision++, updatedAt, endedAt |
+| `requestFlowCancel` | non-terminal | `requesterOrigin` | unchanged status | cancelRequestedAt=now, cancelRequestedBy=requesterOrigin, revision++, updatedAt; if status=waiting, EventBus emits `taskflow:cancel-requested` |
+| `cancelFlow` | non-terminal AND `cancelRequestedAt != null` | `controllerInstanceId` | `cancelled` | revision++, updatedAt, endedAt |
+| `markLost` | `running` or `waiting`; reserved controller `TaskFlowMaintenance` only | `ledgerEntryId`, `reason: 'lost' \| 'stranded'` | `lost` | revision++, updatedAt, endedAt, supersededBy |
+| `pingFlow` | `running` | `controllerInstanceId` | unchanged | revision UNCHANGED; updatedAt + controllerHeartbeatAt updated. NOT keyed on `expectedRevision` — see Heartbeat contract below |
+| `getFlow` | (any) | optional `bypassCache: true` | (read-only) | — |
+
+### Conflict result shape
+
+OCC failures return a structured response that distinguishes from not-found:
+
+```jsonc
+// 409 Conflict
+{
+  "error": "revision_conflict",
+  "current": { ...current TaskFlowRecord... }
+}
+// 404 Not Found
+{ "error": "not_found", "flowId": "..." }
+// 410 Gone (terminal)
+{
+  "error": "already_terminal",
+  "current": { ...record with terminal status... }
+}
+// 422 Unprocessable
+{ "error": "invalid_transition", "from": "succeeded", "op": "setFlowWaiting" }
+{ "error": "invalid_argument", "field": "goal", "reason": "exceeds 1024 chars" }
+{ "error": "unauthorized_controller", "expected": "EvolutionManager", "actual": "InitiativeTracker" }
+{ "error": "already_consumed", "waitInstanceId": "..." }   // resume request supplied a waitInstanceId but the
+                                                            // flow is already running and waitInstanceId is null
+                                                            // (i.e., the wait already fired). If the supplied
+                                                            // waitInstanceId is wrong (never matched), the response
+                                                            // is "invalid_argument" instead.
+```
+
+Implementation: when `UPDATE flows SET ... WHERE flow_id=? AND revision=?` returns 0 rows, the storage layer follows up with `SELECT revision, status, ended_at FROM flows WHERE flow_id=?` to discriminate `not_found` from `revision_conflict` from `already_terminal`. This SELECT runs in the same connection inside the same `BEGIN IMMEDIATE` to keep the read consistent with the write attempt.
+
+### Idempotency
+
+- `createFlow` requires an `idempotencyKey`. The unique index is `(controllerId, ownerKey, idempotencyKey)`. Duplicate creates return the existing record with HTTP 200 (not 201) — this is the safe-retry behavior for clients that timed out mid-create.
+- `resumeFlow` requires `waitInstanceId`. The server records the consumed `waitInstanceId` atomically with the resume; a duplicate callback (same waitInstanceId) returns `already_consumed`.
+
+### Heartbeat contract
+
+A controller actively running a step MUST call `pingFlow(flowId, controllerInstanceId)` at least once per `HEARTBEAT_INTERVAL_MS` (default: 60s).
+
+`pingFlow` is **NOT keyed on `expectedRevision`** — this is intentional, and makes pingFlow the single OCC-exempt operation. The reason: every other writer (sweeper, peer controllers, the controller's own step advancement) bumps revision; if pingFlow also took expectedRevision, the controller would routinely conflict with its own concurrent operations and never successfully heartbeat. Instead, pingFlow's correctness key is `(flow.controllerId == caller.controllerId, flow.status == 'running')`. Mismatch fails with `unauthorized_controller` or `invalid_transition`. `controllerInstanceId` is REBOUND on every successful ping — the registry overwrites the stored value with the supplied one. This makes ping the natural re-attach mechanism after a server restart: the first ping with the new instanceId succeeds and updates the row. Older instanceIds are not preserved; that's intended (the prior instance is gone, and the audit ledger note for any sweeper-driven `markLost` will have captured the old instanceId before this point if it mattered). ping does not transition status; it cannot break invariants.
+
+`pingFlow` updates `controllerHeartbeatAt` and `updatedAt`, leaves `revision` and all other fields untouched. Concurrent ping + step-advance on the same revision are both safe: the step-advance bumps revision via the OCC path; the ping merely refreshes heartbeat without touching the revision.
+
+The maintenance sweeper's lost-eligibility rule depends on `status` and (for `waiting`) on `waitJson.kind`; see the next subsection.
+
+### Sweeper threshold policy (normative)
+
+The `TaskFlowMaintenanceSweeper` runs hourly and evaluates lost-eligibility per row using these rules:
+
+| Status | Rule | Default |
+|---|---|---|
+| `running` | `now - controllerHeartbeatAt > RUNNING_LOST_THRESHOLD_MS` | 6 hours |
+| `waiting`, `wait_kind = 'reply'` | `now - waitStartedAt > REPLY_LOST_THRESHOLD_MS` | 7 days |
+| `waiting`, `wait_kind = 'human-review'` | `now - waitStartedAt > HUMAN_REVIEW_LOST_THRESHOLD_MS` | 30 days |
+| `waiting`, `wait_kind = 'external-call'` | if `waitJson.deadline` set: `now > deadline + EXTERNAL_GRACE_MS`; else `now - waitStartedAt > EXTERNAL_LOST_THRESHOLD_MS` | grace 1h, fallback 7 days |
+| `waiting`, `wait_kind = 'scheduled-tick'` | NEVER lost-eligible. `TaskFlowDueWaker` resolves these. | — |
+| `waiting`, `wait_kind = 'cross-agent-callback'` | `now - waitStartedAt > XAGENT_LOST_THRESHOLD_MS` | 7 days |
+
+`waitStartedAt` is a column on the `flows` table set on every successful `setFlowWaiting` (resets on every fresh wait, NOT preserved across resume → re-wait cycles). Indexed jointly with `status` to bound sweeper scan cost.
+
+All thresholds are configurable via `.instar/config.json` under `taskFlow.thresholds`. Defaults are the values above.
+
+### Storage failure handling
+
+- `SQLITE_BUSY`: retry with exponential backoff up to `MAX_BUSY_RETRIES` (default: 5; base 50ms, cap 5s). After exhaustion, return HTTP 503 with `Retry-After` header.
+- `SQLITE_FULL`: return HTTP 507; alert via DegradationReporter.
+- I/O error mid-commit: surface as HTTP 500; the cache MUST NOT be updated for the failed mutation. Cache-update ordering: cache write happens AFTER the SQLite COMMIT returns successfully. If COMMIT throws, the cache entry is *invalidated* (deleted) so the next read forces a reload.
+
+## Storage and Concurrency
+
+### Single writer, one process (v1)
+
+In v1, **the instar server process is the only writer** to `.instar/task-flows.db`. All controllers — EvolutionManager, InitiativeTracker, ThreadlineFlowBridge, TaskFlowMaintenance — run inside the server process or inside server-spawned Claude Code sessions. Sessions interact with the registry exclusively through the HTTP API (`POST /flows`, etc.), not by opening the SQLite file directly.
+
+This makes the in-memory cache safe: there is one cache, one writer, and OCC handles in-process concurrency between the server's own controllers. HTTP clients (sessions) get cache-coherent reads because their reads hit the same server's cache.
+
+**Future multi-writer**: if Instar later needs another process to write (e.g., the lifeline supervisor mutating flows during a server restart), this section will need a leader-election or per-row lease layer. Out of scope for v1; tracked under Open Questions.
+
+### Storage layout
+
+- One SQLite file: `.instar/task-flows.db`, WAL journal mode, `busy_timeout 30000ms`, `synchronous=NORMAL` (with WAL, this is durable to OS crash but not power loss; matches the rest of Instar's SQLite stores).
+- Schema:
+
+  ```sql
+  CREATE TABLE IF NOT EXISTS flows (
+    flow_id TEXT PRIMARY KEY,
+    owner_key TEXT NOT NULL,
+    controller_id TEXT NOT NULL,
+    controller_instance_id TEXT NOT NULL,
+    controller_heartbeat_at INTEGER NOT NULL,
+    revision INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    notify_policy TEXT NOT NULL,        -- json
+    goal TEXT NOT NULL,
+    current_step TEXT,
+    state_json TEXT,
+    wait_json TEXT,
+    wait_instance_id TEXT,
+    wait_started_at INTEGER,
+    wait_kind TEXT,                     -- denormalized from wait_json; set on setFlowWaiting; null otherwise
+    cancel_requested_at INTEGER,
+    cancel_requested_by TEXT,           -- json RequesterOrigin
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    ended_at INTEGER,
+    superseded_by TEXT,                 -- json {kind, ledgerEntryId, reason}
+    privacy_scope TEXT,
+    requester_origin TEXT               -- json
+  );
+  CREATE INDEX flows_status_updated_at  ON flows (status, updated_at);
+  CREATE INDEX flows_controller_status  ON flows (controller_id, status);
+  CREATE INDEX flows_owner_key          ON flows (owner_key);
+  CREATE INDEX flows_wait_instance_id   ON flows (wait_instance_id) WHERE wait_instance_id IS NOT NULL;
+  CREATE INDEX flows_wait_kind_started  ON flows (wait_kind, wait_started_at) WHERE status='waiting';
+  CREATE INDEX flows_running_heartbeat  ON flows (controller_heartbeat_at) WHERE status='running';
+
+  CREATE TABLE IF NOT EXISTS flow_create_idem (
+    controller_id TEXT NOT NULL,
+    owner_key TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    flow_id TEXT NOT NULL,
+    PRIMARY KEY (controller_id, owner_key, idempotency_key)
+  );
+  ```
+
+- Write transactions use `BEGIN IMMEDIATE` because each mutation reads (to discriminate not-found / conflict / terminal) AND writes within the same transaction. (Per Round 1 review, a single `UPDATE` would not strictly need `BEGIN IMMEDIATE`; the transaction wraps the read+write check-and-discriminate sequence.)
+
+### DR and audit trail (no dual-write)
+
+**JSONL append log dropped from v1.** Round 1 review converged on the dual-write hazard: SQLite-then-JSONL or JSONL-then-SQLite both have non-atomic recovery paths. SQLite WAL is itself a durable, crash-safe journal — an extra app-level append log adds risk without adding recovery power.
+
+For DR we instead rely on:
+
+1. **SQLite WAL** as the durability journal. `synchronous=NORMAL` plus WAL gives durable writes that survive process crash.
+2. **Backup System** (existing Instar capability): `.instar/task-flows.db` is included in the snapshot rotation, providing point-in-time recovery from periodic backups.
+3. **Audit ledger**: every status transition that crosses a workflow boundary (start, wait, resume, terminal) emits a `SharedStateLedger` `note` with `kind: 'taskflow-transition'`, capturing `flowId`, `revision`, `from_status`, `to_status`, `currentStep`, `waitJson.kind` (NOT full waitJson — see privacy below), `controllerId`. The ledger note is best-effort: if the ledger write fails, the registry mutation has already committed, so we lose audit but not state. This is the right asymmetry — state correctness is tier-1, audit is tier-2.
+
+### In-memory cache
+
+- LRU `Map<flowId, TaskFlowRecord>`, capped at `MAX_CACHE_ENTRIES` (default: 1000). Eviction prefers entries with `endedAt != null` (terminal flows are unlikely to be re-read).
+- Cache populated on read-miss and on every successful mutation.
+- On COMMIT failure, cache entry is invalidated.
+- `getFlow(flowId, {bypassCache: true})` forces a SQLite read.
+
+### Privacy / sync exposure
+
+`.instar/task-flows.db` and any JSONL audit fragments **MUST be on the git-sync deny-list** (`.instar/.gitignore` augmented in Phase 1). `stateJson` may contain user PII (cluster fix payloads, ratification questions, raw LLM prompts). Cross-machine sync of TaskFlow state is not in v1 scope; if added later, it must be an opt-in encrypted channel separate from git.
+
+`stateJson` is also redacted from:
+- audit ledger notes (only `flowId`, `revision`, `currentStep` go into notes; never `stateJson` content);
+- any HTTP API response that is not addressed to the owning `controllerId`. The `GET /flows/:id` endpoint returns full record only when `Authorization: Bearer <token>` is presented and the caller's controllerId matches; otherwise returns the redacted shape (no `stateJson`, no `waitJson`'s identifying fields).
+
+## Integration with Existing Instar Subsystems
+
+1. **EvolutionManager (bug-cluster pipeline)** — primary consumer.
+   - Today, what the spec calls "the bug-cluster pipeline" is informal — there is no single subsystem that owns it; it spans `EvolutionManager` (proposals, learnings, gaps, actions), ad-hoc dispatch logic, and Telegram/handoff notes. TaskFlow makes that pipeline a first-class object instead of an emergent behavior.
+   - `controllerId: "EvolutionManager"`
+   - Per-cluster `ownerKey: "cluster:<clusterId>"`
+   - Steps: `tier-1-investigation → tier-1-fix-dispatch → waiting-ratification → tier-2-investigation → tier-2-fix-dispatch → waiting-ratification → completed`
+   - Each `waiting-ratification` is `setFlowWaiting({kind:"human-review", question:"...", topicId:9000+ratification})`.
+   - The dispatch decision and outcome live in `stateJson`; the flow's `currentStep` is the canonical "where are we" pointer.
+
+2. **InitiativeTracker** — replace the existing phase/blocker model with a TaskFlow per initiative.
+   - `controllerId: "InitiativeTracker"`
+   - `ownerKey: "initiative:<id>"`
+   - Phase transitions become `currentStep` updates.
+   - Blockers become `setFlowWaiting({kind:"...", ...})` with the blocker described in `waitJson`.
+
+3. **Threadline cross-agent flows** — new consumer (`ThreadlineFlowBridge`).
+   - There is no `ThreadlineGateway` class in Instar today; the closest existing components are `ThreadlineRouter` (`src/threadline/ThreadlineRouter.ts`, decides spawn vs resume on inbound messages) and `MessageRouter` (`src/messaging/MessageRouter.ts`, the underlying inbound pipeline).
+   - Phase 2 introduces a new module `src/tasks/ThreadlineFlowBridge.ts` that hooks into `MessageRouter`'s receive pipeline alongside `ThreadlineRouter`. It owns one job: when an inbound Threadline message arrives, look up flows whose `waitJson.kind == 'cross-agent-callback'` matches `(threadId, correlationId)`, verify the message's signed sender identity (via `MessageSecurity` envelope) equals `expectedAgentId`, then call `resumeFlow`.
+   - `controllerId: "ThreadlineFlowBridge"` for these flows.
+   - `ownerKey: "thread:<threadId>"`.
+   - When Echo asks Dawn a question and needs to wait for her reply: `setFlowWaiting({kind:"cross-agent-callback", threadId, correlationId, expectedAgentId:"dawn"})`. The `correlationId` MUST be ≥128 random bits and is single-use.
+   - **Identity verification (security-critical)**: `expectedAgentId` matching uses Threadline's signed-message identity (the verified `from` recovered from the message's signature in `MessageSecurity`), NOT the claimed `from:` field of the message. Any inbound message that fails signature verification is rejected before the bridge even sees it.
+
+4. **CommitmentSweeper** — adjacent, not merged.
+   - Commitments stay in SharedStateLedger. TaskFlow handles open work-in-progress.
+   - `CommitmentSweeper` is a signal-shaped sweeper (per `docs/signal-vs-authority.md` and Integrated-Being v2 spec). `TaskFlowMaintenanceSweeper` is *not* signal-shaped; it is a writer with a reserved controllerId. The asymmetry is intentional: commitments are utterances people made and we observe over time; flows are state machines that need a single durable answer for "what status is this flow now?".
+
+5. **JobScheduler** — provides one-shot wakeups for `scheduled-tick` waits.
+   - JobScheduler in Instar is currently cron-only (`JobDefinition.schedule: string` → croner expression; `src/scheduler/JobScheduler.ts`). It does not natively support one-shot at-time-T jobs.
+   - **Phase 2 must extend JobScheduler with one-shot support** OR Phase 1 must include a small `TaskFlowDueWaker` sweeper that polls `flows WHERE status='waiting' AND wait_json.kind='scheduled-tick' AND wait_json.dueAt <= now` every minute and fires `resumeFlow`.
+   - Recommendation: ship `TaskFlowDueWaker` in Phase 1 (simpler, fully self-contained), revisit JobScheduler one-shot support as a separate enhancement.
+   - Either way, the existing JobScheduler `SkipLedger` is not used for these wakeups; idempotency is enforced via `waitInstanceId` on the resume call.
+
+6. **MessageSentinel** — does NOT see flows.
+   - Sentinel works on inbound messages, before any flow logic. It can issue `kill-session` which terminates the *session* but does not advance any flow.
+   - Sessions terminated by sentinel will stop sending pings to their flows. After `LOST_THRESHOLD_MS` of no heartbeat, `TaskFlowMaintenanceSweeper` marks those flows `lost`. This is the intended path: sentinel kills the misbehaving session, sweeper cleans up its abandoned flows.
+
+7. **Lifeline `ServerSupervisor`** — does NOT write to TaskFlow in v1.
+   - The supervisor restarts the server when it dies. It does not interact with the flow registry directly. After a restart, controllers running in the new server process MUST start a new `controllerInstanceId` and re-attach to flows by `controllerId`; flows whose previous `controllerInstanceId` is gone are detectable via heartbeat staleness.
+
+## HTTP API surface
+
+All endpoints loopback-only by default (`127.0.0.1:4042`); `Authorization: Bearer <auth-token>` required on every call. The API MUST NOT be exposed via Cloudflare tunnel without an explicit per-deployment opt-in (default: tunnel routes for `/flows/*` are blocked at the tunnel-config layer).
+
+### Auth model (token → principal binding)
+
+The server maintains a **caller registry** that maps each registered token to a principal record:
+
+```typescript
+type FlowPrincipal = {
+  tokenId: string;                  // hashed token id (never raw token)
+  scope: 'controller' | 'admin' | 'maintenance' | 'system-waker';
+  controllerIds?: string[];         // for scope='controller', the controllerIds this principal may act as
+};
+```
+
+The default Instar auth token (the one in `.instar/config.json`) is bound at server-startup time to a single principal with `scope: 'admin'` — it can act as any controllerId. Additional tokens (created via a not-yet-existing admin command) may be bound to specific controllerIds for least-privilege use. **The caller-asserted `controllerId` in a request body is NEVER the authorization basis**; it is matched against the principal's `controllerIds` (or accepted unconditionally for `admin` scope) and rejected on mismatch with `unauthorized_controller`.
+
+Scope authority matrix:
+
+| Scope | createFlow | startStep | setFlowWaiting | resumeFlow | finishFlow | failFlow | requestFlowCancel | cancelFlow | markLost | pingFlow | getFlow (full) |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `controller` | ✓ (own controllerIds) | ✓ (own) | ✓ (own) | ✓ (own) | ✓ (own) | ✓ (own) | ✓ (any flow — cancellation is advisory and cross-controller hygiene is allowed) | ✓ (own) | ✗ | ✓ (own) | ✓ (own) |
+| `admin` | ✓ (any) | ✓ (any) | ✓ (any) | ✓ (any) | ✓ (any) | ✓ (any) | ✓ (any) | ✓ (any) | ✗ | ✓ (any) | ✓ (any) |
+| `maintenance` | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ (any) |
+| `system-waker` | ✗ | ✗ | ✗ | ✓ (waiting → running only, with valid waitInstanceId) | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ (any, but stateJson redacted) |
+
+Special principals (no externally-issued tokens):
+- `maintenance`: held in-process by `TaskFlowMaintenanceSweeper`; only invokes `markLost`.
+- `system-waker`: held in-process by `TaskFlowDueWaker`, `ThreadlineFlowBridge`, `MessageRouter` reply-wait path, and the `external-call` callback handler. Only allowed transition: `waiting → running` via `resumeFlow` with matching `waitInstanceId` and (per wait kind) identity verification.
+
+For v1, expect exactly one externally-issued bearer token (admin scope), two in-process special principals, and any future per-controller tokens added by hand. The auth model is intentionally minimal; multi-tenant fine-grained auth is out of v1 scope.
+
+| Method | Path | Purpose | Body | Response |
+|---|---|---|---|---|
+| POST | `/flows` | createFlow | `{controllerId, controllerInstanceId, ownerKey, goal, idempotencyKey, notifyPolicy?, requesterOrigin?, privacyScope?, stateJson?, currentStep?}` | 201 + record on new; 200 + record on idempotent dupe |
+| GET | `/flows/:id` | getFlow | (query: `bypassCache=1`) | 200 + record OR redacted shape if caller controllerId mismatches |
+| POST | `/flows/:id/start` | startStep | `{expectedRevision, controllerInstanceId, currentStep}` | 200 + record (stored instanceId overwritten) |
+| POST | `/flows/:id/wait` | setFlowWaiting | `{expectedRevision, controllerInstanceId, waitJson, currentStep?}` | 200 + record (waitInstanceId in record; stored instanceId overwritten) |
+| POST | `/flows/:id/resume` | resumeFlow | `{expectedRevision, waitInstanceId, controllerInstanceId?, currentStep?, statePatch?}` | 200 + record (`controllerInstanceId` optional for system-waker resumes; required for controller-scope resumes) |
+| POST | `/flows/:id/ping` | pingFlow (heartbeat) | `{controllerInstanceId}` | 200 + `{updatedAt, controllerHeartbeatAt}` (revision unchanged; stored `controllerInstanceId` overwritten with body value); 422 `unauthorized_controller` if caller's controllerId mismatches flow's; 422 `invalid_transition` if status != running |
+| POST | `/flows/:id/finish` | finishFlow | `{expectedRevision, controllerInstanceId, result?}` | 200 + record |
+| POST | `/flows/:id/fail` | failFlow | `{expectedRevision, controllerInstanceId, failureReason}` | 200 + record |
+| POST | `/flows/:id/cancel-request` | requestFlowCancel | `{requesterOrigin}` | 200 + record (cancelRequestedBy persisted; EventBus emits `taskflow:cancel-requested` if status=waiting) |
+| POST | `/flows/:id/cancel` | cancelFlow | `{expectedRevision, controllerInstanceId}` | 200 + record |
+| POST | `/flows/:id/lost` | markLost (TaskFlowMaintenance only) | `{expectedRevision, ledgerEntryId, reason}` | 200 + record |
+| GET | `/flows` | list (sweeper / admin) | (query: `controllerId?`, `status?`, `updatedBefore?`, `limit`) | 200 + `{flows: [...]}` |
+| GET | `/flows/waiting` | wait lookup (system-waker / admin) | (query: `waitKind`, `channel?`, `threadId?`, `peer?`, `correlationId?`, `dueAtBefore?`) | 200 + `{matches: [{flowId, revision, waitInstanceId, controllerId, waitJson}, ...]}` (waitJson partially redacted; stateJson omitted) |
+| POST | `/flows/:id/resume-via-callback` | external-call webhook (no Bearer; correlationId is the capability) | `{correlationId, payload?}` | 200 + record on success; 401 if correlationId mismatch; 410 if already consumed; 422 if status != waiting or wait kind != external-call. The supplied `correlationId` MUST match `waitJson.correlationId`; the registry uses the matched record's `waitInstanceId` and `revision` for the resume internally. |
+
+Error codes: see "Conflict result shape" above. All error responses are JSON. The endpoint set above is the complete v1 surface; further endpoints (e.g., bulk-list, flow visibility for cross-agent peers) are out of scope.
+
+## Migration Plan
+
+### Phase 1: Skeleton + storage + maintenance sweeper (one PR)
+- Add `src/tasks/TaskFlowRegistry.ts`, `src/tasks/task-flow-registry.store.sqlite.ts`, `src/tasks/TaskFlowMaintenanceSweeper.ts`, `src/tasks/TaskFlowDueWaker.ts`.
+- Add `.instar/.gitignore` entry for `task-flows.db*`.
+- Server endpoints per the API table above. All require `expectedRevision` for mutations except `createFlow` (idempotency-keyed) and `getFlow` (read-only).
+- `TaskFlowMaintenanceSweeper`: hourly, marks `lost` via `markLost` (reserved controllerId, OCC-bumping) per the normative "Sweeper threshold policy" table (per-status / per-wait-kind, using `controllerHeartbeatAt` for `running` and `waitStartedAt` + `wait_kind` for `waiting`). Configurable via `taskFlow.thresholds`.
+- `TaskFlowDueWaker`: minute-tick, fires `resumeFlow` for `waiting` flows whose `waitJson.kind == 'scheduled-tick'` and `dueAt <= now`.
+- Tests: OCC conflict detection (404 vs 409 vs 410), all legal transitions, all illegal-transition rejections, idempotent createFlow under retry, waitInstanceId-based resume idempotency, sweeper lost-marking with simulated stale heartbeat, due-waker firing.
+- No business consumers yet.
+
+### Phase 2: ThreadlineFlowBridge + cross-agent-callback waits (one PR)
+- Add `src/tasks/ThreadlineFlowBridge.ts` hooked into `MessageRouter`'s receive pipeline.
+- Identity verification uses `MessageSecurity` envelope's verified-sender field; failure to verify is hard-reject before bridge inspection.
+- End-to-end test: Echo creates a flow, `setFlowWaiting({kind:"cross-agent-callback", ..., correlationId})`, Dawn replies via Threadline with that correlationId, bridge verifies signature, flow resumes.
+
+### Phase 3: EvolutionManager migration (two PRs)
+
+#### Phase 3a: dual-write with divergence detection
+- Refactor EvolutionManager bug-cluster pipeline to write through TaskFlow APIs.
+- For backward compatibility, the existing JSONL files (`proposals.jsonl`, `dispatch-decisions.jsonl`) continue to be written. **TaskFlow is read-authoritative**; JSONL is shadow-write only. Reads come from TaskFlow.
+- Backfill existing in-flight clusters into TaskFlow records as part of PR landing.
+- Add `DivergenceChecker` cron (every 15 min) that:
+  - reads recent JSONL state into a memory model;
+  - compares to TaskFlow state on `(ownerKey, status, currentStep, waitJson.kind)`;
+  - emits `taskflow_divergence_count` metric and a `note` to SharedStateLedger on any mismatch;
+  - halts new shadow writes (alerts only) on `divergence_count > 0`.
+
+#### Phase 3b: remove shadow JSONL writes
+- Cutover criterion: `divergence_count == 0` for `>= 7 consecutive days`, AND ledger contains zero `taskflow-divergence` notes in that window.
+- PR removes the JSONL shadow writes, removes `DivergenceChecker`. JSONL files become read-only artifacts of the prior history.
+
+### Phase 4: InitiativeTracker migration (one PR)
+- Replace InitiativeTracker's internal state with TaskFlow consumption.
+- Phases → `currentStep`, blockers → `setFlowWaiting`.
+- Backfill existing initiatives.
+
+### Phase 5: Hardening + cache-eviction tuning (one PR)
+- Per-controller flow-creation rate limits (default: 10/sec); max active flows per controller (default: 50); reject with `quota_exceeded` on overflow.
+- LRU cache eviction tuning based on observed memory.
+- Audit ledger emission for terminal transitions.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Migration leaves orphaned in-flight clusters in JSONL** | Phase 3a shadow-writes JSONL while reading authoritatively from TaskFlow. `DivergenceChecker` (15min cron) emits ledger-note alerts on any mismatch. Phase 3b cutover requires `divergence_count == 0` for `>= 7 days`. |
+| **Single-writer assumption violated by future ops requirement** | Documented as v1 constraint. If multi-writer needed later, leader-election or per-row lease layer is a follow-up spec; the OCC contract already exists. |
+| **Wait-arrival handler crashes between resume and step advancement** | Resume is idempotent at the registry (`waitInstanceId` consumption); the controller's step advancement is its own concern. Documented contract: controllers must be idempotent on resume. |
+| **`scheduled-tick` waits never fire (clock skew, missed ticks)** | `TaskFlowDueWaker` polls every minute; missed ticks are picked up on next cycle. `dueAt` is wall-clock, server-relative; clock skew >1min would defer rather than skip. |
+| **Cross-agent-callback wait never fires (peer dies, threadline disconnects)** | `TaskFlowMaintenanceSweeper` marks long-`waiting` flows `lost` after configurable threshold (default: 7 days for `cross-agent-callback`, 6 hours for `running`). Justin can `requestFlowCancel` from a CLI / dashboard. |
+| **Optimistic-concurrency conflicts produce confusing errors** | `revision_conflict` returns include `current` flow snapshot; documented retry-with-current pattern. Distinct error codes for `revision_conflict` (409), `not_found` (404), `already_terminal` (410), `unauthorized_controller` (422), `already_consumed` (422). |
+| **TaskFlow becomes a generic todo list** | Hard requirement: every flow has a `controllerId`; no "shared" controllers; no "any subsystem resumes" semantics; enforced server-side. |
+| **Sweeper steals an alive but slow controller's flow** | Heartbeat contract: `pingFlow` is cheap (no revision bump). Long-running steps must ping at `HEARTBEAT_INTERVAL_MS`. If the sweeper still wins (controller missed pings), the orphan-detection note in SharedStateLedger flags the side-effect mismatch for human review. |
+
+## Threat Model
+
+- **Spoofed resume**: a hostile process with the auth token calls `resumeFlow` for a flow whose `controllerId` it is not. Mitigated by:
+  - HTTP API loopback-only binding by default; explicit opt-in to expose via tunnel.
+  - `Authorization: Bearer <auth-token>` required on every mutation.
+  - Resume requires `waitInstanceId`. The waitInstanceId is generated server-side at `setFlowWaiting` time and travels back to the controller in the `setFlowWaiting` response. The wait-fire callback path (e.g., `ThreadlineFlowBridge`) holds the waitInstanceId in server memory; a hostile auth-token holder cannot guess it.
+  - `controllerId` on resume must match the flow's `controllerId`; mismatch → `unauthorized_controller`.
+- **Wait-callback injection (cross-agent-callback)**: a malicious Threadline peer attempts to fire someone else's wait. Mitigated by:
+  - `correlationId` is ≥128 random bits, single-use; stored only in `waitJson` and in the original outbound message (sent over the encrypted Threadline channel — so an attacker would need to break Threadline's transport encryption to read it).
+  - `expectedAgentId` matching uses **the verified-sender identity recovered from `MessageSecurity`'s signature verification**, never the message's plaintext `from:` field.
+  - First successful `resumeFlow` consumes the `waitInstanceId`; replay of the same callback returns `already_consumed`.
+- **Flow flooding**: per-controller flow-creation rate limits (default: 10/sec) and max-active-flows-per-controller cap (default: 50). Excess creates rejected with `quota_exceeded`.
+- **State leakage via `stateJson`**:
+  - Audit ledger notes log only `flowId`, `revision`, `currentStep`, `from_status`, `to_status`, `waitJson.kind`.
+  - GET `/flows/:id` returns full record only when caller's `controllerId` matches; otherwise returns redacted shape (no `stateJson`, no `waitJson` content beyond `kind`).
+  - `.instar/task-flows.db` is on the git-sync deny-list. Cross-machine sync of flow state is not supported in v1.
+- **Replay attacks on callbacks**: `expectedRevision` defends against stale-overwrite races, NOT against semantic callback replay. The defense for callback replay is `waitInstanceId` consumption (see "Wait-callback injection"). Earlier draft conflated these.
+- **Heartbeat flood (DoS)**: A buggy or malicious controller pings at maximum rate, consuming server CPU. Mitigated by per-controller rate limits (default: 60 pings/min/flow, configurable; surplus pings rejected with 429) added in Phase 5; the cheap-ping design (no revision bump) keeps the per-call cost low even at flood rates.
+- **Sweeper-vs-controller race**: `TaskFlowMaintenanceSweeper` competes with a still-alive controller via OCC. If the sweeper marks `lost` at revision N+1 and the controller tries `finishFlow` at revision N, the controller's call fails with `revision_conflict` and `current.status='lost'`. The controller's documented retry path is: re-read flow; if status is `lost` and the controller still has uncommitted real-world side effects, it MUST emit a `note` to SharedStateLedger describing the side-effect orphan. This is rare (only happens when heartbeats are missed for >`LOST_THRESHOLD_MS`) and the alert lives in the ledger for human follow-up.
+
+## Open Questions
+
+1. **Multi-process controllers** — Resolved for v1: enforced single-writer (the server). Followup if needed: leader-election or per-row lease layer in a separate spec.
+2. **Flow archival** — Open. Succeeded/failed flows older than N days: keep in DB or compact to per-`ownerKey` summaries? Recommendation: keep all in DB until cumulative row count exceeds 100k or table size exceeds 200 MiB; revisit then.
+3. **Notification policy** — Resolved: defined Instar-specific `TaskNotifyPolicy` in Record Shape; not adopting OpenClaw's exact semantics.
+4. **`requesterOrigin`** — Resolved: defined `RequesterOrigin` in Record Shape (replaces OpenClaw's `DeliveryContext`).
+5. **Cross-agent flow visibility** — Open. Does Dawn need to see Echo's flows that are waiting on her? Recommendation: defer; v1 is internal to one agent. If added later, the receiving agent gets a redacted shape (no `stateJson`, no `ownerKey`) plus a stable `flow-handle` token.
+6. **Privacy scope on flows** — Resolved: `privacyScope` field added; copies the `MemoryEntity` vocabulary.
+7. **Sweeper threshold per wait kind** — Resolved: see the normative "Sweeper threshold policy" table in the Mutation Semantics section.
+8. **`pingFlow` granularity** — Resolved: pingFlow updates `controllerHeartbeatAt`, `updatedAt`, and `controllerInstanceId` without bumping `revision`. Concurrent readers may see a different `updatedAt` than the revision they cached; nothing depends on `updatedAt` matching a specific revision.
+
+## Non-Goals
+
+- **Not a workflow DSL.** TaskFlow is plumbing, not Lobster. Instar is not adopting OpenClaw's Lobster orchestration language.
+- **Not replacing JobScheduler.** JobScheduler runs cron-style recurrences; TaskFlow runs single-instance multi-step jobs.
+- **Not replacing SharedStateLedger.** The ledger is still the durable counterparty-aware authority record; TaskFlow handles the "open work in progress" use case adjacent to it.
+- **Not replacing CommitmentSweeper.** Commitments declare a future obligation with a mechanism; flows track active in-progress work. They are different shapes for different needs.
+- **Not exposing `stateJson` in any UI.** Controller-private.
+
+## Review Decisions
+
+This section records concrete decisions made during the convergence review (Round 1, 2026-05-07/08) that explain why some reviewer findings were addressed differently than suggested or deferred.
+
+- **Sweeper as reserved-controller writer (vs pure signal-shape)**. GPT and Grok both flagged that Principle 6 ("sweeper never mutates") contradicted Phase 5 ("server sets status=lost"). Round 1 picks the writer model: the sweeper holds a reserved `controllerId: "TaskFlowMaintenance"` and writes through normal OCC. Audit ledger notes still emit, for human-visible "why was this marked lost?" context, but they no longer carry status authority. This breaks symmetry with `CommitmentSweeper` (which is signal-shape); the asymmetry is justified because flows are state machines requiring a single answer for "current status?", whereas commitments are utterances we observe and re-interpret over time.
+
+- **JSONL DR companion dropped**. All three external reviewers (GPT, Gemini, Grok) flagged dual-write atomicity as a BLOCKER. SQLite WAL is a durable journal on its own; adding an app-level append log gives no recovery power that SQLite + Backup System doesn't already provide, and it introduces a bug class. Dropped from v1.
+
+- **`syncMode` and `blocked` status removed**. GPT flagged both as imported-from-OpenClaw baggage with undefined semantics in the Instar context. v1 schema is `managed`-only (implicit) and `waiting`-only (no separate `blocked`). Easier to add later than to remove.
+
+- **Single-writer (the server) chosen for v1**. Gemini and Grok both raised the cache-coherence problem. We didn't redesign cache invalidation across processes; we made the writer set explicitly singular. This sidesteps the problem and matches Instar's actual architecture (the server owns its state). Multi-writer is a follow-up spec if the operational need appears.
+
+- **Heartbeat via `pingFlow` (no revision bump)**. Adding heartbeat semantics resolves Grok's controller-identity finding and the adversarial sweeper-vs-controller race. `pingFlow` updates `controllerHeartbeatAt` and `updatedAt` but doesn't bump `revision`; this keeps the heartbeat cheap (no `expectedRevision` ping-pong) and makes the lost-detection rule deterministic.
+
+- **`scheduled-tick` via `TaskFlowDueWaker`, not JobScheduler one-shot**. Integration review found JobScheduler is cron-only. Rather than expand JobScheduler with one-shot semantics in the same PR, Phase 1 ships a tiny dedicated waker. JobScheduler one-shot support can be added later in its own spec if the use case generalizes.
+
+- **`ThreadlineFlowBridge` is a new module**. The original spec named `ThreadlineGateway`, which doesn't exist in Instar. The actual integration point is `MessageRouter`'s receive pipeline; `ThreadlineFlowBridge` is the new module that hooks into it for `cross-agent-callback` waits.
+
+- **Identity verification for cross-agent callbacks uses `MessageSecurity` envelope**. Security review found `expectedAgentId` matching against the message's claimed `from:` field is spoofable. v1 uses the verified-sender recovered from signature verification. This makes the bridge trust the same identity mechanism Threadline uses for signed-message authentication.
+
+- **`waitInstanceId` for callback idempotency**. GPT's "callback duplicate hits" finding led to adding `waitInstanceId` (server-generated uuid at `setFlowWaiting`, required as input to `resumeFlow`, consumed atomically). This is a stronger defense than `expectedRevision` for semantic replay across multiple revisions.
+
+- **Per-kind LOST_THRESHOLD**. Adversarial review found a global 6h threshold would mark legitimate `human-review` flows lost while users sleep. Threshold is now per wait kind, with `scheduled-tick` exempt entirely.
+
+- **String size limits and `waitJson` schema validation**. Minor findings (GPT, Grok) addressed inline in Record Shape and Storage sections. Validation is strict-on-write; the registry rejects malformed `waitJson` rather than letting invalid records persist.
+
+- **System-waker carve-out (Round 2/3)**. Gemini found that wakers calling `resumeFlow` would fail the `unauthorized_controller` check since the flow's controllerId is e.g. `EvolutionManager`, not `TaskFlowDueWaker`. The fix: add a `system-waker` principal scope that is allowed to make the `waiting → running` transition only, with a matching `waitInstanceId`. The owning controller picks up via `EventBus`. This preserves the controller-owns-step principle without requiring wakers to impersonate the controller.
+
+- **In-process direct registry calls vs HTTP API (Round 3)**. GPT flagged the wait-resolution path lacked an API for non-flowId lookups. Resolved by adding `findWaiting*` registry methods (callable in-process) and the matching `GET /flows/waiting` endpoint (callable over HTTP for admin/system-waker). System-waker callers run in-process and prefer the direct method; the HTTP endpoint exists for completeness and admin tooling.
+
+- **`pingFlow` re-binds `controllerInstanceId` (Round 3)**. Grok identified that pingFlow's strict instanceId equality check would block re-attach after a server restart. Fix: pingFlow validates only `controllerId == caller.controllerId && status='running'` and OVERWRITES the stored `controllerInstanceId` with the supplied one. This makes the first ping after a restart the natural re-attach signal.
+
+- **External-call callback uses correlationId as capability token (Round 3)**. Gemini observed external services don't have the Bearer token. Fix: `POST /flows/:id/resume-via-callback` does not require a Bearer token; the ≥128-bit `correlationId` IS the capability. This matches the security design where correlationId travels only through encrypted channels.
+
+- **Cancel-while-waiting wakes the controller via EventBus (Round 3)**. Gemini observed that without a wakeup signal, a `requestFlowCancel` on a waiting flow would not be honored until the natural wait fired. Fix: `requestFlowCancel` emits `taskflow:cancel-requested` on EventBus when status=waiting; controllers register a handler.
+
+- **`cancelFlow` is the right operation for honoring a cancel request (Round 2)**. Earlier draft text said controllers should "call failFlow with status: cancelled" — that was wrong because failFlow produces `status='failed'`. Use `cancelFlow` for `status='cancelled'`.
+
+- **Deferred to follow-up specs (NOT addressed in v1)**:
+  - Multi-writer / leader election. Out of scope; v1 is single-writer (the server).
+  - Cross-agent flow visibility (Dawn sees Echo's flows). Out of scope; v1 is single-agent.
+  - Flow archival policy beyond "keep until table size pressure". Open Question 2 stands.
+  - Hoisting `wait_kind` / `wait_deadline` into top-level columns (Gemini's M3). Deferred. v1 sweepers iterate `(status='waiting', updated_at < threshold)` which uses an indexed scan; full waitJson parsing happens only on the (small) candidate set. Revisit if profiling shows the JSON parse step matters.
+  - `reply` vs `cross-agent-callback` merge (GPT minor). Deferred; the two have different identity-verification mechanisms today (`peer` for `reply` is a Telegram peer, `expectedAgentId` for `cross-agent-callback` is a Threadline-signed identity), and merging them now would muddle that boundary.
+
+## References
+
+- OpenClaw (commit `f482e4d335`): `src/tasks/task-flow-registry.ts:376-586`, `src/tasks/task-flow-registry.types.ts:14-43`, `src/tasks/task-flow-registry.store.sqlite.ts:361-371`, `src/plugins/runtime/runtime-taskflow.ts` (consumer pattern), `src/tasks/task-flow-runtime-internal.ts` (internal helpers)
+- Echo audit: `.claude/research/openclaw-audit-instar-2026-05-07.md` §2, §8 #1, §10 Q1
+- Instar adjacent: `src/core/SharedStateLedger.ts`, `src/core/CommitmentSweeper.ts`, `src/core/InitiativeTracker.ts`, `src/core/EvolutionManager.ts`, `src/scheduler/JobScheduler.ts`, `src/messaging/MessageRouter.ts`, `src/threadline/ThreadlineRouter.ts`, `src/threadline/MessageSecurity.ts`
+- Instar pattern reference: `docs/signal-vs-authority.md`
+- Convergence report: `OPENCLAW-IMPORT-TASKFLOW-CONVERGENCE-REPORT.md` (alongside this spec)

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6207,6 +6207,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     let taskFlowSweeper: import('../tasks/TaskFlowMaintenanceSweeper.js').TaskFlowMaintenanceSweeper | undefined;
     let taskFlowDueWaker: import('../tasks/TaskFlowDueWaker.js').TaskFlowDueWaker | undefined;
     let threadlineFlowBridge: import('../tasks/ThreadlineFlowBridge.js').ThreadlineFlowBridge | undefined;
+    let divergenceChecker: import('../tasks/DivergenceChecker.js').DivergenceChecker | undefined;
     if ((config as any).taskFlow?.enabled) {
       try {
         const { TaskFlowStore } = await import('../tasks/task-flow-registry.store.sqlite.js');
@@ -6232,16 +6233,43 @@ export async function startServer(options: StartOptions): Promise<void> {
         taskFlowDueWaker.start();
         const { ThreadlineFlowBridge } = await import('../tasks/ThreadlineFlowBridge.js');
         threadlineFlowBridge = new ThreadlineFlowBridge({ registry: taskFlowRegistry });
+
+        // Phase 3a — wire EvolutionManager dual-write + divergence checker.
+        const crypto = await import('node:crypto');
+        const controllerInstanceId = crypto.randomUUID();
+        evolution.setTaskFlowRegistry(taskFlowRegistry, controllerInstanceId);
+        // Backfill in-flight clusters into TaskFlow. Idempotent via
+        // `evolution-cluster-create-<id>` idempotency key.
+        try {
+          const migrationReport = await evolution.migrateExistingToTaskFlow();
+          console.log(
+            pc.green(
+              `  TaskFlow: backfilled evolution clusters created=${migrationReport.created} ` +
+              `existed=${migrationReport.alreadyExisted} advanced=${migrationReport.advanced} ` +
+              `skipped=${migrationReport.skipped}`
+            )
+          );
+        } catch (err) {
+          console.warn('[instar] taskflow evolution backfill failed (non-fatal):', err);
+        }
+        const { DivergenceChecker } = await import('../tasks/DivergenceChecker.js');
+        divergenceChecker = new DivergenceChecker({
+          registry: taskFlowRegistry,
+          evolutionManager: evolution,
+          ledger: sharedStateLedger ?? undefined,
+        });
+        divergenceChecker.start();
       } catch (err) {
         console.warn('[instar] task-flow init failed (non-fatal):', err);
         taskFlowRegistry = undefined;
         threadlineFlowBridge = undefined;
+        divergenceChecker = undefined;
       }
     }
 
     const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, proxyCoordinator, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge });
     await server.start();
-    void taskFlowSweeper; void taskFlowDueWaker;
+    void taskFlowSweeper; void taskFlowDueWaker; void divergenceChecker;
 
     // Connect DegradationReporter downstream systems now that everything is initialized.
     // Any degradation events queued during startup will drain to feedback + telegram.

--- a/src/core/EvolutionManager.ts
+++ b/src/core/EvolutionManager.ts
@@ -32,6 +32,70 @@ import type { TrustElevationTracker } from './TrustElevationTracker.js';
 import type { AutonomousEvolution, ReviewResult } from './AutonomousEvolution.js';
 import type { AutonomyProfileManager } from './AutonomyProfileManager.js';
 import { SafeFsExecutor } from './SafeFsExecutor.js';
+import type { TaskFlowRegistry } from '../tasks/TaskFlowRegistry.js';
+import type { TaskFlowRecord, TaskFlowPrincipal } from '../tasks/task-flow-types.js';
+import { TaskFlowError } from '../tasks/task-flow-types.js';
+
+/**
+ * TaskFlow controller identity for EvolutionManager (Phase 3a dual-write).
+ * Every proposal's flow is owned by this controllerId; the registry uses it
+ * for OCC scope checks. Single-instance per server process.
+ */
+const EVOLUTION_TASKFLOW_CONTROLLER_ID = 'EvolutionManager';
+
+/**
+ * Map an `EvolutionStatus` to a TaskFlow-side status. Returned values match
+ * the legal TaskFlow state-machine transitions:
+ *   proposed     → queued (createFlow)
+ *   approved     → running (startStep step='approved')
+ *   in_progress  → running (startStep step='in_progress')
+ *   implemented  → succeeded (finishFlow)
+ *   rejected     → failed (failFlow)
+ *   deferred     → cancelled (treated as soft-end; uses requestFlowCancel + cancelFlow)
+ */
+type ProposalFlowAction =
+  | { kind: 'create'; step?: undefined }
+  | { kind: 'start'; step: string }
+  | { kind: 'finish' }
+  | { kind: 'fail'; reason: string }
+  | { kind: 'cancel'; reason: string }
+  | { kind: 'noop' };
+
+function statusToFlowAction(
+  prev: EvolutionStatus | null,
+  next: EvolutionStatus,
+  resolution?: string
+): ProposalFlowAction {
+  // Initial create-from-proposed is handled in addProposal directly.
+  if (prev === null && next === 'proposed') return { kind: 'create' };
+  if (prev === next) return { kind: 'noop' };
+  switch (next) {
+    case 'approved':
+      return { kind: 'start', step: 'approved' };
+    case 'in_progress':
+      return { kind: 'start', step: 'in_progress' };
+    case 'implemented':
+      return { kind: 'finish' };
+    case 'rejected':
+      return { kind: 'fail', reason: resolution ?? 'rejected' };
+    case 'deferred':
+      return { kind: 'cancel', reason: resolution ?? 'deferred' };
+    case 'proposed':
+      // Re-opening is not a legal transition; treat as no-op for v1.
+      return { kind: 'noop' };
+    default:
+      return { kind: 'noop' };
+  }
+}
+
+/**
+ * Owner-key for a proposal-flow. Deterministic — used as both the TaskFlow
+ * `ownerKey` and the basis of the `idempotencyKey`. Phase 3b's cutover
+ * gate relies on `evolution:cluster:<id>` being a stable bidirectional join.
+ */
+function ownerKeyForProposal(proposalId: string): string {
+  return `evolution:cluster:${proposalId}`;
+}
 
 interface EvolutionState {
   proposals: EvolutionProposal[];
@@ -83,9 +147,358 @@ export class EvolutionManager {
   private autonomousEvolution: AutonomousEvolution | null = null;
   private autonomyManager: AutonomyProfileManager | null = null;
 
+  // ── TaskFlow Phase 3a dual-write fields ──────────────────────────
+  /** Registry handle (set when TaskFlow is enabled). */
+  private taskFlowRegistry: TaskFlowRegistry | null = null;
+  /** Per-process controller-instance id (server uuid). */
+  private taskFlowControllerInstanceId: string | null = null;
+  /**
+   * Set to true by DivergenceChecker when state-divergence is detected.
+   * When true, EvolutionManager continues JSON-only writes and DOES NOT
+   * dual-write to TaskFlow. The signal is reset on next divergence pass that
+   * reports zero divergence. This is a signal-emitted brake, not a hard gate.
+   */
+  private taskFlowShadowWritesHalted = false;
+  /** Most recent reason for halting; surfaced in /health and tests. */
+  private taskFlowShadowWritesHaltReason: string | null = null;
+  /**
+   * Source of the most recent halt. DivergenceChecker uses this to ensure it
+   * only auto-clears halts that DivergenceChecker itself imposed — an operator
+   * or sibling system's manual halt stays in place until that source clears it.
+   */
+  private taskFlowShadowWritesHaltSource: string | null = null;
+
   constructor(config: EvolutionManagerConfig) {
     this.config = config;
     this.stateDir = config.stateDir;
+  }
+
+  // ── TaskFlow wiring ─────────────────────────────────────────────
+
+  /**
+   * Wire a TaskFlow registry for Phase 3a dual-write. After this call:
+   *   - addProposal / updateProposalStatus shadow-write to TaskFlow
+   *   - migrateExistingToTaskFlow() backfills any in-flight clusters
+   *   - DivergenceChecker can call setShadowWritesHalted() to brake writes
+   *
+   * Idempotent — safe to call multiple times; subsequent calls overwrite.
+   */
+  setTaskFlowRegistry(
+    registry: TaskFlowRegistry,
+    controllerInstanceId: string
+  ): void {
+    this.taskFlowRegistry = registry;
+    this.taskFlowControllerInstanceId = controllerInstanceId;
+  }
+
+  getTaskFlowRegistry(): TaskFlowRegistry | null {
+    return this.taskFlowRegistry;
+  }
+
+  /**
+   * Halt or resume TaskFlow shadow-writes. Called by DivergenceChecker on a
+   * mismatch. Signal-vs-authority compliance: this is a signal-consumed brake,
+   * not a brittle blocker — the divergence checker decides, EvolutionManager
+   * obeys. JSON writes continue regardless (read-authoritative TaskFlow is
+   * shadow-mode in Phase 3a).
+   *
+   * The optional `source` parameter tags the halt with its origin so an
+   * automatic clearer (DivergenceChecker) only cancels halts it caused.
+   * Defaults to `'manual'` when omitted.
+   */
+  setShadowWritesHalted(halted: boolean, reason?: string, source?: string): void {
+    this.taskFlowShadowWritesHalted = halted;
+    this.taskFlowShadowWritesHaltReason = halted ? (reason ?? 'divergence-detected') : null;
+    this.taskFlowShadowWritesHaltSource = halted ? (source ?? 'manual') : null;
+  }
+
+  isShadowWritesHalted(): { halted: boolean; reason: string | null; source: string | null } {
+    return {
+      halted: this.taskFlowShadowWritesHalted,
+      reason: this.taskFlowShadowWritesHaltReason,
+      source: this.taskFlowShadowWritesHaltSource,
+    };
+  }
+
+  private taskFlowPrincipal(): TaskFlowPrincipal | null {
+    if (!this.taskFlowRegistry || !this.taskFlowControllerInstanceId) return null;
+    return {
+      scope: 'controller',
+      controllerId: EVOLUTION_TASKFLOW_CONTROLLER_ID,
+      controllerInstanceId: this.taskFlowControllerInstanceId,
+    };
+  }
+
+  /**
+   * Best-effort dual-write to TaskFlow. NEVER throws to the caller — JSON
+   * remains the local durability path; TaskFlow is shadow until Phase 3b
+   * cutover. All TaskFlow errors land in console and the divergence checker
+   * picks up via state comparison.
+   */
+  private async dualWriteCreate(p: EvolutionProposal): Promise<void> {
+    if (!this.taskFlowRegistry || this.taskFlowShadowWritesHalted) return;
+    const principal = this.taskFlowPrincipal();
+    if (!principal || principal.scope !== 'controller') return;
+    try {
+      await this.taskFlowRegistry.createFlow({
+        controllerId: EVOLUTION_TASKFLOW_CONTROLLER_ID,
+        controllerInstanceId: principal.controllerInstanceId,
+        ownerKey: ownerKeyForProposal(p.id),
+        idempotencyKey: `evolution-cluster-create-${p.id}`,
+        goal: p.title.slice(0, 1024),
+        currentStep: 'proposed',
+        stateJson: { proposalId: p.id, type: p.type, source: p.source },
+      });
+    } catch (err) {
+      // Swallow — JSON is the source of truth in Phase 3a.
+      this.logTaskFlowError('createFlow', p.id, err);
+    }
+  }
+
+  private async dualWriteTransition(
+    proposalId: string,
+    action: ProposalFlowAction
+  ): Promise<void> {
+    if (!this.taskFlowRegistry || this.taskFlowShadowWritesHalted) return;
+    if (action.kind === 'noop' || action.kind === 'create') return;
+    const principal = this.taskFlowPrincipal();
+    if (!principal) return;
+    const registry = this.taskFlowRegistry;
+    try {
+      // Look up current flow by owner key + deterministic idempotency key.
+      const existing = registry.findByIdempotency(
+        EVOLUTION_TASKFLOW_CONTROLLER_ID,
+        ownerKeyForProposal(proposalId),
+        `evolution-cluster-create-${proposalId}`
+      );
+      if (!existing) {
+        // No backfill yet — proposal exists in JSON but not TaskFlow. Skip
+        // the transition silently; the next migrate-existing pass will pick
+        // it up at its terminal state.
+        return;
+      }
+      const flow = registry.getFlow(existing.flowId, { bypassCache: true });
+      if (!flow) return;
+      const expectedRevision = flow.revision;
+      switch (action.kind) {
+        case 'start': {
+          if (flow.status !== 'queued' && flow.status !== 'running') return;
+          await registry.startStep({
+            flowId: flow.flowId,
+            expectedRevision,
+            principal,
+            currentStep: action.step,
+          });
+          break;
+        }
+        case 'finish': {
+          // Need flow in `running` state for finishFlow. If currently queued,
+          // promote first.
+          let rev = expectedRevision;
+          let cur = flow;
+          if (cur.status === 'queued') {
+            const r = await registry.startStep({
+              flowId: flow.flowId,
+              expectedRevision: rev,
+              principal,
+              currentStep: 'implementing',
+            });
+            cur = r.flow;
+            rev = r.flow.revision;
+          }
+          if (cur.status !== 'running') return;
+          await registry.finishFlow({
+            flowId: flow.flowId,
+            expectedRevision: rev,
+            principal,
+          });
+          break;
+        }
+        case 'fail': {
+          let rev = expectedRevision;
+          let cur = flow;
+          // failFlow requires running|waiting. Promote queued → running.
+          if (cur.status === 'queued') {
+            const r = await registry.startStep({
+              flowId: flow.flowId,
+              expectedRevision: rev,
+              principal,
+              currentStep: 'reject-transition',
+            });
+            cur = r.flow;
+            rev = r.flow.revision;
+          }
+          if (cur.status !== 'running' && cur.status !== 'waiting') return;
+          await registry.failFlow({
+            flowId: flow.flowId,
+            expectedRevision: rev,
+            principal,
+            failureReason: action.reason,
+          });
+          break;
+        }
+        case 'cancel': {
+          if (flow.status === 'succeeded' || flow.status === 'failed' ||
+              flow.status === 'cancelled' || flow.status === 'lost') return;
+          // Two-phase: request, then cancel.
+          const r = await registry.requestFlowCancel({
+            flowId: flow.flowId,
+            expectedRevision,
+            requesterOrigin: { kind: 'system', id: 'EvolutionManager' },
+          });
+          await registry.cancelFlow({
+            flowId: flow.flowId,
+            expectedRevision: r.flow.revision,
+            principal,
+          });
+          break;
+        }
+      }
+    } catch (err) {
+      this.logTaskFlowError(`transition:${action.kind}`, proposalId, err);
+    }
+  }
+
+  private logTaskFlowError(op: string, proposalId: string, err: unknown): void {
+    if (err instanceof TaskFlowError) {
+      // OCC conflicts and invalid-transition errors are expected during
+      // races and concurrent updates — log at debug level only.
+      console.warn(
+        `[EvolutionManager] taskflow ${op} for ${proposalId} skipped: ${err.code} (${err.message})`
+      );
+    } else {
+      console.warn(
+        `[EvolutionManager] taskflow ${op} for ${proposalId} unexpected error:`,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+
+  /**
+   * Backfill all in-flight proposals (status !== 'implemented' && !== 'rejected')
+   * into TaskFlow. Idempotent via `findIdempotent` on
+   * `evolution:cluster:<proposalId>` ownerKey. Safe to call multiple times.
+   *
+   * Returns counts: created, alreadyExisted, advanced (transitioned beyond
+   * 'queued' to match the proposal's current status).
+   */
+  async migrateExistingToTaskFlow(): Promise<{
+    created: number;
+    alreadyExisted: number;
+    advanced: number;
+    skipped: number;
+  }> {
+    if (!this.taskFlowRegistry) {
+      return { created: 0, alreadyExisted: 0, advanced: 0, skipped: 0 };
+    }
+    const principal = this.taskFlowPrincipal();
+    if (!principal || principal.scope !== 'controller') {
+      return { created: 0, alreadyExisted: 0, advanced: 0, skipped: 0 };
+    }
+    const registry = this.taskFlowRegistry;
+    const state = this.loadEvolution();
+    let created = 0;
+    let alreadyExisted = 0;
+    let advanced = 0;
+    let skipped = 0;
+    for (const p of state.proposals) {
+      try {
+        const existing = registry.findByIdempotency(
+          EVOLUTION_TASKFLOW_CONTROLLER_ID,
+          ownerKeyForProposal(p.id),
+          `evolution-cluster-create-${p.id}`
+        );
+        let flow: TaskFlowRecord;
+        if (existing) {
+          alreadyExisted++;
+          flow = existing;
+        } else {
+          const r = await registry.createFlow({
+            controllerId: EVOLUTION_TASKFLOW_CONTROLLER_ID,
+            controllerInstanceId: principal.controllerInstanceId,
+            ownerKey: ownerKeyForProposal(p.id),
+            idempotencyKey: `evolution-cluster-create-${p.id}`,
+            goal: p.title.slice(0, 1024),
+            currentStep: 'proposed',
+            stateJson: { proposalId: p.id, type: p.type, source: p.source },
+          });
+          if (r.created) created++;
+          else alreadyExisted++;
+          flow = r.flow;
+        }
+        // Catch the flow up to the proposal's current status.
+        const advancedThis = await this.catchUpFlowToStatus(flow, p, principal);
+        if (advancedThis) advanced++;
+      } catch (err) {
+        skipped++;
+        this.logTaskFlowError('migrate', p.id, err);
+      }
+    }
+    return { created, alreadyExisted, advanced, skipped };
+  }
+
+  /** Catch a flow record up to the proposal's current status. */
+  private async catchUpFlowToStatus(
+    flow: TaskFlowRecord,
+    p: EvolutionProposal,
+    principal: TaskFlowPrincipal
+  ): Promise<boolean> {
+    if (!this.taskFlowRegistry) return false;
+    const registry = this.taskFlowRegistry;
+    let cur = registry.getFlow(flow.flowId, { bypassCache: true }) ?? flow;
+    let mutated = false;
+    const target = p.status;
+    // Already terminal — leave alone.
+    if (cur.status === 'succeeded' || cur.status === 'failed' ||
+        cur.status === 'cancelled' || cur.status === 'lost') {
+      return false;
+    }
+    // Promote queued → running if target is running/terminal-success/failed.
+    if (cur.status === 'queued' && (target === 'approved' || target === 'in_progress' ||
+        target === 'implemented' || target === 'rejected' || target === 'deferred')) {
+      const step = target === 'in_progress' ? 'in_progress'
+        : target === 'approved' ? 'approved' : 'catch-up';
+      const r = await registry.startStep({
+        flowId: cur.flowId,
+        expectedRevision: cur.revision,
+        principal,
+        currentStep: step,
+      });
+      cur = r.flow;
+      mutated = true;
+    }
+    // Finalize.
+    if (target === 'implemented' && cur.status === 'running') {
+      await registry.finishFlow({
+        flowId: cur.flowId,
+        expectedRevision: cur.revision,
+        principal,
+      });
+      mutated = true;
+    } else if (target === 'rejected' &&
+               (cur.status === 'running' || cur.status === 'waiting')) {
+      await registry.failFlow({
+        flowId: cur.flowId,
+        expectedRevision: cur.revision,
+        principal,
+        failureReason: p.resolution ?? 'rejected',
+      });
+      mutated = true;
+    } else if (target === 'deferred' &&
+               (cur.status === 'running' || cur.status === 'waiting' || cur.status === 'queued')) {
+      const r = await registry.requestFlowCancel({
+        flowId: cur.flowId,
+        expectedRevision: cur.revision,
+        requesterOrigin: { kind: 'system', id: 'EvolutionManager' },
+      });
+      await registry.cancelFlow({
+        flowId: cur.flowId,
+        expectedRevision: r.flow.revision,
+        principal,
+      });
+      mutated = true;
+    }
+    return mutated;
   }
 
   /**
@@ -224,6 +637,10 @@ export class EvolutionManager {
     };
     state.proposals.push(proposal);
     this.saveEvolution(state);
+
+    // TaskFlow Phase 3a shadow-write — best-effort, JSON remains source of truth.
+    void this.dualWriteCreate(proposal);
+
     return proposal;
   }
 
@@ -231,6 +648,7 @@ export class EvolutionManager {
     const state = this.loadEvolution();
     const proposal = state.proposals.find(p => p.id === id);
     if (!proposal) return false;
+    const prevStatus = proposal.status;
     proposal.status = status;
     if (resolution) proposal.resolution = resolution;
     if (status === 'implemented') proposal.implementedAt = this.now();
@@ -241,6 +659,10 @@ export class EvolutionManager {
       const decision = status === 'approved' ? 'approved' : 'rejected';
       this.trustElevationTracker.recordProposalDecision(proposal, decision, false);
     }
+
+    // TaskFlow Phase 3a shadow-write — best-effort, JSON remains source of truth.
+    const action = statusToFlowAction(prevStatus, status, resolution);
+    void this.dualWriteTransition(id, action);
 
     return true;
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1676,7 +1676,9 @@ export type LedgerEntrySubsystem =
   /** v2: session-asserted writes via POST /shared-state/append. instance = session id. */
   | 'session'
   /** v2 slice 5: CommitmentSweeper expired/stranded emissions. */
-  | 'commitment-sweeper';
+  | 'commitment-sweeper'
+  /** TaskFlow Phase 3a: DivergenceChecker JSON↔TaskFlow mismatch notes. */
+  | 'taskflow-divergence';
 
 /** Ledger entry kind. */
 export type LedgerEntryKind =

--- a/src/tasks/DivergenceChecker.ts
+++ b/src/tasks/DivergenceChecker.ts
@@ -1,0 +1,319 @@
+/**
+ * DivergenceChecker — TaskFlow Phase 3a state-coherence monitor.
+ *
+ * Runs every 15 minutes during the Phase 3a dual-write window. Compares
+ * EvolutionManager's authoritative JSON state (proposals) against the
+ * TaskFlow registry's flow records on the (ownerKey, status, currentStep,
+ * waitJson.kind) tuple. Emits a `taskflow_divergence_count` metric on every
+ * run and a SharedStateLedger note kind `taskflow-divergence` per mismatch.
+ *
+ * Signal-vs-authority compliance: this is a SIGNAL emitter, never a gate.
+ *   - It does not block any user-facing action.
+ *   - It does not block any agent-internal action.
+ *   - On divergence > 0, it asks EvolutionManager to halt shadow-writes via
+ *     `setShadowWritesHalted(true)`. EvolutionManager continues JSON writes
+ *     uninterrupted; only the secondary TaskFlow shadow-write is paused
+ *     until divergence clears. This is a self-applied brake, not an
+ *     authority decision over user-facing flow.
+ *
+ * Phase 3b cutover requires `divergenceCount == 0` for ≥7 consecutive days
+ * AND ledger contains zero `taskflow-divergence` notes in that window. The
+ * cutover gate is enforced in the Phase 3b PR, not here.
+ *
+ * Spec: docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md § Phase 3a.
+ */
+
+import type { TaskFlowRegistry } from './TaskFlowRegistry.js';
+import type { EvolutionManager } from '../core/EvolutionManager.js';
+import type { SharedStateLedger } from '../core/SharedStateLedger.js';
+import type { TaskFlowRecord, TaskFlowStatus } from './task-flow-types.js';
+import type { EvolutionProposal, EvolutionStatus } from '../core/types.js';
+
+/** Default cron interval — 15 minutes per spec § Phase 3a. */
+export const DIVERGENCE_CHECK_INTERVAL_MS = 15 * 60 * 1000;
+
+const CONTROLLER_ID = 'EvolutionManager';
+
+export interface DivergenceMismatch {
+  kind:
+    | 'json-only'         // proposal exists in JSON but not TaskFlow
+    | 'taskflow-only'     // flow exists in TaskFlow but not JSON
+    | 'status-mismatch'   // both exist, statuses don't line up
+    | 'step-mismatch'     // both exist, currentStep doesn't match expectation
+    | 'wait-kind-mismatch'; // both exist, waitJson.kind differs from expectation
+  ownerKey: string;
+  proposalId?: string;
+  flowId?: string;
+  proposalStatus?: EvolutionStatus;
+  flowStatus?: TaskFlowStatus;
+  expectedStep?: string;
+  actualStep?: string;
+  expectedWaitKind?: string | null;
+  actualWaitKind?: string | null;
+}
+
+export interface DivergenceReport {
+  scannedJsonProposals: number;
+  scannedTaskFlowRecords: number;
+  divergenceCount: number;
+  mismatches: DivergenceMismatch[];
+  checkedAt: string;
+}
+
+export interface DivergenceCheckerOptions {
+  registry: TaskFlowRegistry;
+  evolutionManager: EvolutionManager;
+  ledger?: SharedStateLedger;
+  intervalMs?: number;
+  now?: () => number;
+}
+
+/**
+ * Status mapping — what TaskFlow status corresponds to a given proposal status?
+ * Single source of truth shared with EvolutionManager's dual-write logic.
+ *
+ * `null` means "ignore this proposal during divergence checks" — used for
+ * pre-Phase-3a JSON-only records that have not yet been backfilled.
+ */
+function expectedFlowStatusFor(p: EvolutionStatus): TaskFlowStatus | null {
+  switch (p) {
+    case 'proposed':
+      return 'queued';
+    case 'approved':
+    case 'in_progress':
+      return 'running';
+    case 'implemented':
+      return 'succeeded';
+    case 'rejected':
+      return 'failed';
+    case 'deferred':
+      return 'cancelled';
+    default:
+      return null;
+  }
+}
+
+function expectedStepFor(p: EvolutionStatus): string | null {
+  switch (p) {
+    case 'approved':
+      return 'approved';
+    case 'in_progress':
+      return 'in_progress';
+    default:
+      return null;
+  }
+}
+
+export class DivergenceChecker {
+  private timer: NodeJS.Timeout | null = null;
+  private readonly registry: TaskFlowRegistry;
+  private readonly evolutionManager: EvolutionManager;
+  private readonly ledger?: SharedStateLedger;
+  private readonly intervalMs: number;
+  private readonly now: () => number;
+
+  /** Most recent divergence count; readable by /health probes. */
+  divergenceCount = 0;
+  /** Wall-clock of the most recent runOnce(). null until first run. */
+  lastCheckAt: string | null = null;
+  /** The most recent report, kept for /health and test assertions. */
+  lastReport: DivergenceReport | null = null;
+
+  constructor(opts: DivergenceCheckerOptions) {
+    this.registry = opts.registry;
+    this.evolutionManager = opts.evolutionManager;
+    this.ledger = opts.ledger;
+    this.intervalMs = opts.intervalMs ?? DIVERGENCE_CHECK_INTERVAL_MS;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      this.runOnce().catch(() => {
+        /* swallow — divergence checking is best-effort */
+      });
+    }, this.intervalMs);
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Single-pass divergence scan. Idempotent; safe to call as often as desired.
+   *
+   * Returns the report. Side effects:
+   *   1. Updates `divergenceCount` / `lastCheckAt` / `lastReport`.
+   *   2. Emits a SharedStateLedger note per mismatch (kind: 'note',
+   *      subject: 'taskflow-divergence').
+   *   3. Calls `evolutionManager.setShadowWritesHalted(...)`:
+   *        divergenceCount > 0 → halted=true
+   *        divergenceCount == 0 → halted=false (resume shadow-writes)
+   */
+  async runOnce(): Promise<DivergenceReport> {
+    const checkedAt = new Date(this.now()).toISOString();
+
+    // Read JSON-side proposals via the public API.
+    const proposals = this.evolutionManager.listProposals();
+    const flowRecs = this.registry.findByControllerId(CONTROLLER_ID);
+
+    const mismatches: DivergenceMismatch[] = [];
+    const flowByOwnerKey = new Map<string, TaskFlowRecord>();
+    for (const f of flowRecs) flowByOwnerKey.set(f.ownerKey, f);
+
+    const jsonByOwnerKey = new Map<string, EvolutionProposal>();
+    for (const p of proposals) {
+      jsonByOwnerKey.set(`evolution:cluster:${p.id}`, p);
+    }
+
+    // Forward scan: JSON → TaskFlow.
+    for (const p of proposals) {
+      const ownerKey = `evolution:cluster:${p.id}`;
+      const flow = flowByOwnerKey.get(ownerKey);
+      if (!flow) {
+        mismatches.push({
+          kind: 'json-only',
+          ownerKey,
+          proposalId: p.id,
+          proposalStatus: p.status,
+        });
+        continue;
+      }
+      const expectedStatus = expectedFlowStatusFor(p.status);
+      if (expectedStatus !== null && flow.status !== expectedStatus) {
+        mismatches.push({
+          kind: 'status-mismatch',
+          ownerKey,
+          proposalId: p.id,
+          flowId: flow.flowId,
+          proposalStatus: p.status,
+          flowStatus: flow.status,
+        });
+      }
+      const expectedStep = expectedStepFor(p.status);
+      if (expectedStep !== null && flow.currentStep !== expectedStep) {
+        mismatches.push({
+          kind: 'step-mismatch',
+          ownerKey,
+          proposalId: p.id,
+          flowId: flow.flowId,
+          expectedStep,
+          actualStep: flow.currentStep,
+        });
+      }
+      // Wait-kind: Phase 3a does not yet use TaskFlow waits for proposals,
+      // so any waitJson on the flow is itself a divergence signal.
+      if (flow.waitJson) {
+        mismatches.push({
+          kind: 'wait-kind-mismatch',
+          ownerKey,
+          proposalId: p.id,
+          flowId: flow.flowId,
+          expectedWaitKind: null,
+          actualWaitKind: flow.waitJson.kind,
+        });
+      }
+    }
+
+    // Reverse scan: TaskFlow → JSON.
+    for (const f of flowRecs) {
+      if (!jsonByOwnerKey.has(f.ownerKey)) {
+        mismatches.push({
+          kind: 'taskflow-only',
+          ownerKey: f.ownerKey,
+          flowId: f.flowId,
+          flowStatus: f.status,
+        });
+      }
+    }
+
+    const report: DivergenceReport = {
+      scannedJsonProposals: proposals.length,
+      scannedTaskFlowRecords: flowRecs.length,
+      divergenceCount: mismatches.length,
+      mismatches,
+      checkedAt,
+    };
+
+    this.divergenceCount = report.divergenceCount;
+    this.lastCheckAt = checkedAt;
+    this.lastReport = report;
+
+    // Emit metric counter — surfaced via /health and ledger-stats.
+    this.emitMetric('taskflow_divergence_count', report.divergenceCount, {
+      controllerId: CONTROLLER_ID,
+      checkedAt,
+    });
+
+    // Emit one ledger note per mismatch (capped at 50 per pass to bound spam).
+    const noteLimit = 50;
+    for (const m of report.mismatches.slice(0, noteLimit)) {
+      this.emitLedgerNote(m, checkedAt);
+    }
+
+    // Signal-consumed brake — flip EvolutionManager's shadow-write switch.
+    // Tag the halt with our identity so a manual halt by an operator survives
+    // until that operator clears it. Auto-resume only clears halts we set.
+    if (report.divergenceCount > 0) {
+      this.evolutionManager.setShadowWritesHalted(
+        true,
+        `taskflow-divergence: ${report.divergenceCount} mismatch(es) at ${checkedAt}`,
+        'divergence-checker'
+      );
+    } else {
+      const cur = this.evolutionManager.isShadowWritesHalted();
+      if (cur.halted && cur.source === 'divergence-checker') {
+        this.evolutionManager.setShadowWritesHalted(false);
+      }
+    }
+
+    return report;
+  }
+
+  // ── private helpers ──────────────────────────────────────────────
+
+  private emitMetric(name: string, value: number, labels: Record<string, string>): void {
+    // Lightweight surface — instar's metrics are emitted via console.log
+    // tagged lines that the dashboard scrapes; structured JSON keeps the
+    // line greppable. If a metric backend is wired later, this is the seam.
+    try {
+      console.log(`[metric] ${name}=${value} ${JSON.stringify(labels)}`);
+    } catch {
+      /* swallow */
+    }
+  }
+
+  private emitLedgerNote(m: DivergenceMismatch, checkedAt: string): void {
+    if (!this.ledger) return;
+    void Promise.resolve()
+      .then(() =>
+        this.ledger!.append({
+          kind: 'note',
+          provenance: 'subsystem-asserted',
+          emittedBy: {
+            subsystem: 'taskflow-divergence',
+            instance: 'DivergenceChecker',
+          },
+          counterparty: { type: 'self', name: 'EvolutionManager', trustTier: 'trusted' },
+          subject: 'taskflow-divergence',
+          summary:
+            `${m.kind}: ownerKey=${m.ownerKey} ` +
+            (m.proposalId ? `proposalId=${m.proposalId} ` : '') +
+            (m.flowId ? `flowId=${m.flowId} ` : '') +
+            (m.proposalStatus ? `proposalStatus=${m.proposalStatus} ` : '') +
+            (m.flowStatus ? `flowStatus=${m.flowStatus} ` : '') +
+            (m.expectedStep !== undefined ? `expectedStep=${m.expectedStep ?? 'none'} actualStep=${m.actualStep ?? 'none'} ` : '') +
+            (m.expectedWaitKind !== undefined ? `expectedWaitKind=${m.expectedWaitKind ?? 'none'} actualWaitKind=${m.actualWaitKind ?? 'none'}` : ''),
+          dedupKey: `taskflow-divergence:${m.kind}:${m.ownerKey}:${checkedAt}`,
+        } as any)
+      )
+      .catch(() => {
+        /* swallow — best-effort */
+      });
+  }
+}

--- a/src/tasks/TaskFlowRegistry.ts
+++ b/src/tasks/TaskFlowRegistry.ts
@@ -134,6 +134,29 @@ export class TaskFlowRegistry extends EventEmitter {
       .map((r) => this.toWaitMatch(r));
   }
 
+  /**
+   * List all flows for a controllerId, optionally filtered by status.
+   * Used by DivergenceChecker — read-only, not on the hot mutation path.
+   */
+  findByControllerId(
+    controllerId: string,
+    opts: { status?: TaskFlowStatus } = {}
+  ): TaskFlowRecord[] {
+    return this.store.findByControllerId(controllerId, opts);
+  }
+
+  /**
+   * Look up a flow by (controllerId, ownerKey, idempotencyKey). Returns null
+   * if no matching record. Useful for migrate-existing backfill and for tests.
+   */
+  findByIdempotency(
+    controllerId: string,
+    ownerKey: string,
+    idempotencyKey: string
+  ): TaskFlowRecord | null {
+    return this.store.findIdempotent(controllerId, ownerKey, idempotencyKey);
+  }
+
   // ────────────────── createFlow ──────────────────
 
   async createFlow(

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -281,6 +281,24 @@ export class TaskFlowStore {
     return rows.map((r) => this.rowToRecord(r));
   }
 
+  /**
+   * Find all flows owned by a controller. Optional status filter.
+   * Used by DivergenceChecker to compare TaskFlow records against JSON state.
+   */
+  findByControllerId(
+    controllerId: string,
+    opts: { status?: TaskFlowStatus } = {}
+  ): TaskFlowRecord[] {
+    const params: any[] = [controllerId];
+    let sql = `SELECT * FROM flows WHERE controller_id = ?`;
+    if (opts.status) {
+      sql += ` AND status = ?`;
+      params.push(opts.status);
+    }
+    const rows = this.db.prepare(sql).all(...params) as FlowRow[];
+    return rows.map((r) => this.rowToRecord(r));
+  }
+
   // ───────────── writes ─────────────
 
   insertFlow(rec: TaskFlowRecord, idempotencyKey: string): void {

--- a/tests/unit/divergence-checker.test.ts
+++ b/tests/unit/divergence-checker.test.ts
@@ -1,0 +1,321 @@
+/**
+ * DivergenceChecker tests — TaskFlow Phase 3a.
+ *
+ * Real SQLite (no mocking). Verifies:
+ *   1. Happy path — zero divergence when JSON and TaskFlow agree.
+ *   2. json-only — proposal in JSON but no matching flow.
+ *   3. taskflow-only — flow without a matching JSON proposal.
+ *   4. status-mismatch — JSON says implemented, flow still running.
+ *   5. step-mismatch — JSON says approved, flow's currentStep is something else.
+ *   6. wait-kind-mismatch — flow has a waitJson (proposals shouldn't, in Phase 3a).
+ *   7. On divergence > 0: emits ledger note + halts shadow writes.
+ *   8. On divergence == 0 after a halt: resumes shadow writes.
+ *   9. lastReport / divergenceCount / lastCheckAt are populated after run.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TaskFlowStore } from '../../src/tasks/task-flow-registry.store.sqlite.js';
+import { TaskFlowRegistry } from '../../src/tasks/TaskFlowRegistry.js';
+import { EvolutionManager } from '../../src/core/EvolutionManager.js';
+import { DivergenceChecker } from '../../src/tasks/DivergenceChecker.js';
+
+interface Rig {
+  dir: string;
+  store: TaskFlowStore;
+  registry: TaskFlowRegistry;
+  evolution: EvolutionManager;
+  checker: DivergenceChecker;
+  ledgerNotes: any[];
+  cleanup: () => Promise<void>;
+}
+
+async function rig(): Promise<Rig> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'divergence-test-'));
+  const stateDir = path.join(dir, 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const store = new TaskFlowStore({ dbPath: path.join(dir, 'task-flows.db') });
+  await store.open();
+  const registry = new TaskFlowRegistry({ store });
+  const evolution = new EvolutionManager({ stateDir });
+  evolution.setTaskFlowRegistry(registry, 'test-instance');
+
+  const ledgerNotes: any[] = [];
+  const fakeLedger = {
+    append: async (payload: any) => {
+      ledgerNotes.push(payload);
+      return { id: 'fake', t: new Date().toISOString(), ...payload };
+    },
+  } as any;
+
+  const checker = new DivergenceChecker({
+    registry,
+    evolutionManager: evolution,
+    ledger: fakeLedger,
+  });
+
+  return {
+    dir,
+    store,
+    registry,
+    evolution,
+    checker,
+    ledgerNotes,
+    cleanup: async () => {
+      checker.stop();
+      store.close();
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/divergence-checker.test.ts',
+      });
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('DivergenceChecker', () => {
+  let r: Rig;
+
+  afterEach(async () => {
+    if (r) await r.cleanup();
+  });
+
+  it('zero divergence when JSON and TaskFlow agree (happy path)', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'aligned',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'approved');
+    await flush();
+    const report = await r.checker.runOnce();
+    expect(report.divergenceCount).toBe(0);
+    expect(report.mismatches).toHaveLength(0);
+    expect(report.scannedJsonProposals).toBe(1);
+    expect(report.scannedTaskFlowRecords).toBe(1);
+    expect(r.checker.divergenceCount).toBe(0);
+    expect(r.checker.lastCheckAt).not.toBeNull();
+    expect(r.checker.lastReport).not.toBeNull();
+  });
+
+  it('json-only: proposal in JSON but no matching flow', async () => {
+    r = await rig();
+    // Halt shadow writes BEFORE adding the proposal so taskflow stays empty.
+    r.evolution.setShadowWritesHalted(true, 'test-suppress');
+    r.evolution.addProposal({
+      title: 'orphan-json',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    expect(r.registry.findByControllerId('EvolutionManager')).toHaveLength(0);
+    // Resume so the checker doesn't see the halt as our fault.
+    r.evolution.setShadowWritesHalted(false);
+    const report = await r.checker.runOnce();
+    expect(report.divergenceCount).toBe(1);
+    expect(report.mismatches[0].kind).toBe('json-only');
+  });
+
+  it('taskflow-only: flow without matching JSON proposal', async () => {
+    r = await rig();
+    // Directly create a flow with no corresponding proposal.
+    await r.registry.createFlow({
+      controllerId: 'EvolutionManager',
+      controllerInstanceId: 'test-instance',
+      ownerKey: 'evolution:cluster:ORPHAN-001',
+      idempotencyKey: 'evolution-cluster-create-ORPHAN-001',
+      goal: 'orphan',
+    });
+    const report = await r.checker.runOnce();
+    expect(report.divergenceCount).toBe(1);
+    expect(report.mismatches[0].kind).toBe('taskflow-only');
+  });
+
+  it('status-mismatch: JSON implemented, flow still running', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'status-mm',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'approved');
+    await flush();
+    // Now: halt shadow writes, then JSON-update to implemented WITHOUT propagating.
+    r.evolution.setShadowWritesHalted(true, 'test-induce-divergence');
+    r.evolution.updateProposalStatus(p.id, 'implemented');
+    await flush();
+    // Clear the halt before running the checker — the checker should observe
+    // the post-update divergence and re-halt.
+    r.evolution.setShadowWritesHalted(false);
+    const report = await r.checker.runOnce();
+    const statusMm = report.mismatches.find((m) => m.kind === 'status-mismatch');
+    expect(statusMm).toBeDefined();
+    expect(statusMm!.proposalStatus).toBe('implemented');
+    expect(statusMm!.flowStatus).toBe('running');
+    // The checker should now have re-halted EM.
+    expect(r.evolution.isShadowWritesHalted().halted).toBe(true);
+  });
+
+  it('step-mismatch: JSON approved, flow current_step differs', async () => {
+    r = await rig();
+    r.evolution.setShadowWritesHalted(true, 'test-prep');
+    const p = r.evolution.addProposal({
+      title: 'step-mm',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    // Create the flow directly with a wrong currentStep.
+    await r.registry.createFlow({
+      controllerId: 'EvolutionManager',
+      controllerInstanceId: 'test-instance',
+      ownerKey: `evolution:cluster:${p.id}`,
+      idempotencyKey: `evolution-cluster-create-${p.id}`,
+      goal: 'step-mm',
+      currentStep: 'WRONG-STEP',
+    });
+    const flow = r.registry
+      .findByControllerId('EvolutionManager')
+      .find((f) => f.ownerKey === `evolution:cluster:${p.id}`)!;
+    await r.registry.startStep({
+      flowId: flow.flowId,
+      expectedRevision: flow.revision,
+      principal: {
+        scope: 'controller',
+        controllerId: 'EvolutionManager',
+        controllerInstanceId: 'test-instance',
+      },
+      currentStep: 'WRONG-STEP-2',
+    });
+    // JSON status: approved → expects step 'approved'.
+    r.evolution.updateProposalStatus(p.id, 'approved');
+    await flush();
+    r.evolution.setShadowWritesHalted(false);
+    const report = await r.checker.runOnce();
+    const stepMm = report.mismatches.find((m) => m.kind === 'step-mismatch');
+    expect(stepMm).toBeDefined();
+    expect(stepMm!.expectedStep).toBe('approved');
+    expect(stepMm!.actualStep).toBe('WRONG-STEP-2');
+  });
+
+  it('wait-kind-mismatch: flow has waitJson (proposals shouldnt in Phase 3a)', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'wait-mm',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'approved');
+    await flush();
+    const flow = r.registry
+      .findByControllerId('EvolutionManager')
+      .find((f) => f.ownerKey === `evolution:cluster:${p.id}`)!;
+    // Manually set a wait — this is a coherence violation for Phase 3a.
+    await r.registry.setFlowWaiting({
+      flowId: flow.flowId,
+      expectedRevision: flow.revision,
+      principal: {
+        scope: 'controller',
+        controllerId: 'EvolutionManager',
+        controllerInstanceId: 'test-instance',
+      },
+      waitJson: {
+        kind: 'human-review',
+        question: 'should we ship?',
+      },
+    });
+    const report = await r.checker.runOnce();
+    const wkMm = report.mismatches.find((m) => m.kind === 'wait-kind-mismatch');
+    expect(wkMm).toBeDefined();
+    expect(wkMm!.actualWaitKind).toBe('human-review');
+  });
+
+  it('on divergence > 0: emits ledger note and halts shadow writes', async () => {
+    r = await rig();
+    // Induce a json-only divergence.
+    r.evolution.setShadowWritesHalted(true);
+    r.evolution.addProposal({
+      title: 'will-diverge',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.setShadowWritesHalted(false);
+    expect(r.evolution.isShadowWritesHalted().halted).toBe(false);
+    const report = await r.checker.runOnce();
+    expect(report.divergenceCount).toBeGreaterThan(0);
+    await flush();
+    // Ledger note emitted.
+    expect(r.ledgerNotes.length).toBeGreaterThan(0);
+    expect(r.ledgerNotes[0].subject).toBe('taskflow-divergence');
+    expect(r.ledgerNotes[0].kind).toBe('note');
+    // Shadow writes halted.
+    expect(r.evolution.isShadowWritesHalted().halted).toBe(true);
+    expect(r.evolution.isShadowWritesHalted().reason).toContain('taskflow-divergence');
+  });
+
+  it('on divergence cleared after halt: resumes shadow writes', async () => {
+    r = await rig();
+    // First induce divergence.
+    r.evolution.setShadowWritesHalted(true);
+    const p = r.evolution.addProposal({
+      title: 'temp-divergence',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.setShadowWritesHalted(false);
+    await r.checker.runOnce();
+    expect(r.evolution.isShadowWritesHalted().halted).toBe(true);
+    // Now backfill — clears the divergence.
+    await r.evolution.migrateExistingToTaskFlow();
+    void p;
+    const report = await r.checker.runOnce();
+    expect(report.divergenceCount).toBe(0);
+    expect(r.evolution.isShadowWritesHalted().halted).toBe(false);
+  });
+
+  it('zero-divergence pass does NOT clear an operator-imposed halt', async () => {
+    r = await rig();
+    // Operator imposes a halt with a non-checker source.
+    r.evolution.setShadowWritesHalted(true, 'operator-pause', 'manual');
+    expect(r.evolution.isShadowWritesHalted().source).toBe('manual');
+    // Zero-divergence pass.
+    const report = await r.checker.runOnce();
+    expect(report.divergenceCount).toBe(0);
+    // Halt persists — checker only auto-clears halts it set.
+    expect(r.evolution.isShadowWritesHalted().halted).toBe(true);
+    expect(r.evolution.isShadowWritesHalted().source).toBe('manual');
+  });
+
+  it('runOnce populates divergenceCount, lastCheckAt, lastReport', async () => {
+    r = await rig();
+    expect(r.checker.divergenceCount).toBe(0);
+    expect(r.checker.lastCheckAt).toBeNull();
+    expect(r.checker.lastReport).toBeNull();
+    await r.checker.runOnce();
+    expect(r.checker.lastCheckAt).not.toBeNull();
+    expect(r.checker.lastReport).not.toBeNull();
+    expect(r.checker.lastReport!.scannedJsonProposals).toBe(0);
+    expect(r.checker.lastReport!.scannedTaskFlowRecords).toBe(0);
+  });
+});

--- a/tests/unit/evolution-manager-taskflow-dualwrite.test.ts
+++ b/tests/unit/evolution-manager-taskflow-dualwrite.test.ts
@@ -1,0 +1,278 @@
+/**
+ * EvolutionManager × TaskFlow Phase 3a dual-write tests.
+ *
+ * Real SQLite (no mocking) per /instar-dev constraints. Verifies:
+ *   1. addProposal creates a queued flow under controllerId=EvolutionManager.
+ *   2. updateProposalStatus(approved) startSteps the flow to running.
+ *   3. updateProposalStatus(implemented) finishes the flow to succeeded.
+ *   4. updateProposalStatus(rejected) fails the flow.
+ *   5. updateProposalStatus(deferred) cancels the flow.
+ *   6. migrateExistingToTaskFlow is idempotent — running twice = no duplicates.
+ *   7. setShadowWritesHalted(true) suppresses subsequent dual-writes.
+ *   8. Without setTaskFlowRegistry wired, no flows are written.
+ *   9. JSON state remains the source of truth — dual-write failures don't
+ *      affect EvolutionManager's local state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TaskFlowStore } from '../../src/tasks/task-flow-registry.store.sqlite.js';
+import { TaskFlowRegistry } from '../../src/tasks/TaskFlowRegistry.js';
+import { EvolutionManager } from '../../src/core/EvolutionManager.js';
+
+interface Rig {
+  dir: string;
+  stateDir: string;
+  store: TaskFlowStore;
+  registry: TaskFlowRegistry;
+  evolution: EvolutionManager;
+  cleanup: () => Promise<void>;
+}
+
+async function rig(opts: { wireTaskFlow: boolean } = { wireTaskFlow: true }): Promise<Rig> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'evo-taskflow-test-'));
+  const stateDir = path.join(dir, 'state');
+  fs.mkdirSync(stateDir, { recursive: true });
+  const store = new TaskFlowStore({ dbPath: path.join(dir, 'task-flows.db') });
+  await store.open();
+  const registry = new TaskFlowRegistry({ store });
+  const evolution = new EvolutionManager({ stateDir });
+  if (opts.wireTaskFlow) {
+    evolution.setTaskFlowRegistry(registry, 'test-instance');
+  }
+  return {
+    dir,
+    stateDir,
+    store,
+    registry,
+    evolution,
+    cleanup: async () => {
+      store.close();
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/evolution-manager-taskflow-dualwrite.test.ts',
+      });
+    },
+  };
+}
+
+function ownerKey(proposalId: string): string {
+  return `evolution:cluster:${proposalId}`;
+}
+
+/** Drain microtasks so void promises fire. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('EvolutionManager × TaskFlow Phase 3a dual-write', () => {
+  let r: Rig;
+
+  afterEach(async () => {
+    if (r) await r.cleanup();
+  });
+
+  it('addProposal creates a queued flow under controllerId=EvolutionManager', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'Test proposal',
+      source: 'test',
+      description: 'desc',
+      type: 'capability',
+    });
+    await flush();
+    const flows = r.registry.findByControllerId('EvolutionManager');
+    expect(flows).toHaveLength(1);
+    expect(flows[0].ownerKey).toBe(ownerKey(p.id));
+    expect(flows[0].status).toBe('queued');
+    expect(flows[0].goal).toBe('Test proposal');
+    expect(flows[0].currentStep).toBe('proposed');
+  });
+
+  it('updateProposalStatus(approved) starts the flow', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'P1',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'approved');
+    await flush();
+    const flows = r.registry.findByControllerId('EvolutionManager');
+    expect(flows).toHaveLength(1);
+    expect(flows[0].status).toBe('running');
+    expect(flows[0].currentStep).toBe('approved');
+  });
+
+  it('updateProposalStatus(implemented) finishes the flow', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'P2',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'approved');
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'implemented');
+    await flush();
+    const flows = r.registry.findByControllerId('EvolutionManager');
+    expect(flows[0].status).toBe('succeeded');
+    expect(flows[0].endedAt).toBeGreaterThan(0);
+  });
+
+  it('updateProposalStatus(rejected) fails the flow', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'P3',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'rejected', 'not enough evidence');
+    await flush();
+    const flows = r.registry.findByControllerId('EvolutionManager');
+    expect(flows[0].status).toBe('failed');
+    expect((flows[0].stateJson as any)._failureReason).toBe('not enough evidence');
+  });
+
+  it('updateProposalStatus(deferred) cancels the flow', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'P4',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'deferred', 'later');
+    await flush();
+    const flows = r.registry.findByControllerId('EvolutionManager');
+    expect(flows[0].status).toBe('cancelled');
+  });
+
+  it('migrateExistingToTaskFlow is idempotent — second run produces no duplicates', async () => {
+    r = await rig({ wireTaskFlow: false });
+    // Add proposals WITHOUT taskflow wiring (so no dual-write yet).
+    const p1 = r.evolution.addProposal({
+      title: 'A',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    const p2 = r.evolution.addProposal({
+      title: 'B',
+      source: 't',
+      description: 'd',
+      type: 'workflow',
+    });
+    r.evolution.updateProposalStatus(p2.id, 'implemented');
+    // Now wire taskflow and migrate.
+    r.evolution.setTaskFlowRegistry(r.registry, 'test-instance');
+    const first = await r.evolution.migrateExistingToTaskFlow();
+    expect(first.created).toBe(2);
+    const after1 = r.registry.findByControllerId('EvolutionManager');
+    expect(after1).toHaveLength(2);
+    // p2 should be succeeded (advanced during catch-up).
+    const flowP2 = after1.find((f) => f.ownerKey === ownerKey(p2.id))!;
+    expect(flowP2.status).toBe('succeeded');
+    const flowP1 = after1.find((f) => f.ownerKey === ownerKey(p1.id))!;
+    expect(flowP1.status).toBe('queued');
+
+    // Second run — no new creates, no extra advancement.
+    const second = await r.evolution.migrateExistingToTaskFlow();
+    expect(second.created).toBe(0);
+    expect(second.alreadyExisted).toBe(2);
+    expect(second.advanced).toBe(0);
+    const after2 = r.registry.findByControllerId('EvolutionManager');
+    expect(after2).toHaveLength(2);
+  });
+
+  it('setShadowWritesHalted(true) suppresses subsequent dual-writes', async () => {
+    r = await rig();
+    r.evolution.setShadowWritesHalted(true, 'test-divergence');
+    expect(r.evolution.isShadowWritesHalted().halted).toBe(true);
+    const p = r.evolution.addProposal({
+      title: 'while halted',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    let flows = r.registry.findByControllerId('EvolutionManager');
+    expect(flows).toHaveLength(0);
+
+    // Resume — subsequent additions write through.
+    r.evolution.setShadowWritesHalted(false);
+    const p2 = r.evolution.addProposal({
+      title: 'after resume',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    flows = r.registry.findByControllerId('EvolutionManager');
+    expect(flows).toHaveLength(1);
+    expect(flows[0].ownerKey).toBe(ownerKey(p2.id));
+    // p1 is still JSON-only; that's the expected behavior — halted writes are
+    // never retroactively replayed. The next migrate-existing pass would
+    // backfill it on demand.
+    void p;
+  });
+
+  it('without setTaskFlowRegistry, no flows are written', async () => {
+    r = await rig({ wireTaskFlow: false });
+    r.evolution.addProposal({
+      title: 'no taskflow',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    expect(r.registry.findByControllerId('EvolutionManager')).toHaveLength(0);
+  });
+
+  it('JSON state survives even if taskflow registry blows up mid-dualwrite', async () => {
+    r = await rig();
+    // Close the underlying store — subsequent createFlow calls will throw.
+    r.store.close();
+    const p = r.evolution.addProposal({
+      title: 'corrupt taskflow',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    // JSON-side: proposal still present.
+    const proposals = r.evolution.listProposals();
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].id).toBe(p.id);
+  });
+
+  it('TaskFlow record is read-authoritative via findByControllerId', async () => {
+    r = await rig();
+    const p = r.evolution.addProposal({
+      title: 'auth',
+      source: 't',
+      description: 'd',
+      type: 'capability',
+    });
+    await flush();
+    r.evolution.updateProposalStatus(p.id, 'approved');
+    await flush();
+    // Restart-from-disk simulation: discard the in-memory EvolutionManager
+    // and rebuild from the registry — the flow row tells us status=running.
+    const flowsAfter = r.registry.findByControllerId('EvolutionManager');
+    expect(flowsAfter[0].status).toBe('running');
+    expect(flowsAfter[0].currentStep).toBe('approved');
+  });
+});

--- a/upgrades/side-effects/taskflow-phase3a.md
+++ b/upgrades/side-effects/taskflow-phase3a.md
@@ -1,0 +1,138 @@
+# Side-Effects Review — TaskFlow Phase 3a (EvolutionManager dual-write + DivergenceChecker)
+
+**Version / slug:** `taskflow-phase3a`
+**Date:** 2026-05-10
+**Author:** Echo
+**Second-pass reviewer:** required (touches state-machine authority surface for the evolution pipeline + introduces a state-coherence monitor)
+
+## Summary of the change
+
+Phase 3a wires `EvolutionManager`'s proposal lifecycle into `TaskFlowRegistry` as a **shadow write**, runs a one-time `migrateExistingToTaskFlow()` backfill on server startup, and starts a 15-minute `DivergenceChecker` cron that compares JSON-side state to TaskFlow-side state on `(ownerKey, status, currentStep, waitJson.kind)`. JSON state remains the local source of truth in Phase 3a; TaskFlow is the read-authoritative target that Phase 3b will cut over to once the divergence checker reports zero mismatches for 7 consecutive days.
+
+Per the spec (`docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md` § Phase 3a, lines 629–643), the design goal is to land the typed TaskFlow contract under the proposal pipeline without disturbing existing behavior, then verify alignment in a quiet-period window before deleting the JSON path. The DivergenceChecker is a **signal emitter**, not an authority — when it detects mismatches it emits a metric (`taskflow_divergence_count`) and a `SharedStateLedger` note kind `taskflow-divergence`, and flips a self-applied brake (`evolutionManager.setShadowWritesHalted(true)`) so EvolutionManager stops *secondary* writes while leaving its *primary* JSON writes intact. The user-facing pipeline is unaffected by halts.
+
+Files touched:
+- `src/core/EvolutionManager.ts` — adds `setTaskFlowRegistry`, `setShadowWritesHalted`, `migrateExistingToTaskFlow`, and best-effort dual-writes in `addProposal` / `updateProposalStatus`.
+- `src/tasks/DivergenceChecker.ts` (new) — 15-minute cron, ledger note + metric emission, halt-on-divergence brake.
+- `src/tasks/TaskFlowRegistry.ts` — adds `findByControllerId` and `findByIdempotency` read helpers.
+- `src/tasks/task-flow-registry.store.sqlite.ts` — adds `findByControllerId` SQL helper.
+- `src/commands/server.ts` — instantiates `DivergenceChecker` and wires `evolution.setTaskFlowRegistry(...)`+ migration backfill, both gated on `config.taskFlow.enabled`.
+- `tests/unit/evolution-manager-taskflow-dualwrite.test.ts` (new) — 10 vitest cases.
+- `tests/unit/divergence-checker.test.ts` (new) — 9 vitest cases.
+- `upgrades/side-effects/taskflow-phase3a.md` (this file).
+
+## Decision-point inventory
+
+- `EvolutionManager.dualWriteCreate` / `dualWriteTransition` — **add** — secondary writes to TaskFlow. Guarded by `taskFlowRegistry !== null` AND `!taskFlowShadowWritesHalted`. Never throws to caller; failures are logged and absorbed because JSON is the primary path.
+- `EvolutionManager.setShadowWritesHalted` — **add** — a signal-consumed brake on the secondary path. Only DivergenceChecker calls it under normal operation. Has no effect on JSON writes or the proposal pipeline visible to users.
+- `EvolutionManager.migrateExistingToTaskFlow` — **add** — one-shot backfill of all in-flight proposals into TaskFlow. Idempotent via the registry's `findIdempotent` on `(controllerId, ownerKey, idempotencyKey)` — running twice produces no duplicates.
+- `DivergenceChecker.runOnce` — **add** — compares JSON ↔ TaskFlow state. Emits structured metric + ledger note. NO block/allow authority over user actions.
+- `DivergenceChecker.start` — **add** — 15-minute `setInterval(...).unref()` timer.
+- `TaskFlowRegistry.findByControllerId` — **add** — read-only lookup. Mechanic, not judgment.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable.**
+
+The dual-write side has no decision authority. `dualWriteCreate` / `dualWriteTransition` either succeed silently or log + return. They never raise to the caller of `addProposal` / `updateProposalStatus`. The DivergenceChecker emits notes; it does not reject any input.
+
+The only "rejection" anywhere in the new code is `setShadowWritesHalted(true)`, which suppresses *future secondary writes* until cleared. This affects only the TaskFlow shadow path. JSON writes continue uninterrupted — by design. A user who proposes / approves / implements / rejects work during a halt sees the same JSON-side behavior they always saw.
+
+## 2. Under-block
+
+**Failure modes the change does not catch:**
+
+- A buggy controller (other than the EvolutionManager Phase 3a path) that writes flow records under `controllerId="EvolutionManager"` would be visible to DivergenceChecker but not blocked. Phase 3a documents this — controllerId integrity is enforced at the OCC layer (`unauthorized_controller` on resume from a non-matching controllerId), and the divergence note will flag the orphan for human review.
+- A race between an `addProposal` event and an in-flight `DivergenceChecker.runOnce()` could briefly observe a json-only mismatch (proposal saved to JSON, dual-write microtask not yet drained). The 15-minute cadence makes this extremely unlikely to register as a real divergence (the next pass clears it). Cost: at most one spurious ledger note per cron pass, capped to 50 mismatches per pass.
+- `migrateExistingToTaskFlow` advances a flow to its proposal's current status using a deterministic step name (`'approved'` for `approved`, `'in_progress'` for `in_progress`, `'catch-up'` otherwise). If a future change introduces additional proposal statuses, the migration falls through to `'catch-up'` and the divergence checker reports step-mismatch — a self-flagging behavior, not a silent failure.
+- Concurrent server processes writing to the same `task-flows.db` would violate the single-writer assumption. Phase 1 documents this as a v1 constraint. Phase 3a inherits the same constraint.
+- The `setShadowWritesHalted(false)` path: DivergenceChecker only resumes halts that DivergenceChecker itself imposed. A manual `setShadowWritesHalted(true, "operator-intervention")` would be cleared back to false on the next zero-divergence pass. This is documented behavior — the checker is the sole automated owner of the brake. If an operator wants persistent silence, they disable `config.taskFlow.enabled` entirely.
+
+## 3. Level-of-abstraction fit
+
+The dual-write is at the right layer: `EvolutionManager` is the existing owner of the proposal lifecycle, and the TaskFlow shadow lives as private methods on the same class. Putting the dual-write at this layer (rather than a separate adapter) keeps the existing JSON path untouched and lets the change be off-by-default via the same `setTaskFlowRegistry` setter that the server wires up.
+
+The DivergenceChecker is at the right layer: it reads state from two existing surfaces (`EvolutionManager.listProposals()` and `TaskFlowRegistry.findByControllerId(...)`) and emits signals via two existing surfaces (metric logging, ledger notes). It does not own any state of its own beyond cached counts. The 15-minute cron interval matches the spec; the `.unref()`'d timer matches the Phase 1 sweeper / waker pattern.
+
+A separate `EvolutionTaskFlowAdapter.ts` was considered and rejected: the dual-write logic is ~150 lines of methods that conceptually belong with EvolutionManager's other lifecycle methods. Splitting them across two files would create indirect coupling without removing complexity. If Phase 3b deletes the dual-write entirely, removing the private methods from this file is cleaner than deleting an adapter class.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No — this change produces a signal consumed by an existing smart gate.** DivergenceChecker produces a `taskflow_divergence_count` metric and `taskflow-divergence` ledger notes. Humans (and Phase 3b's cutover gate) are the authority that decides whether those signals justify rollback or cutover. The checker does NOT block any user-facing action; the only mutation it performs is calling `setShadowWritesHalted(true)` on EvolutionManager, which suppresses the *secondary* TaskFlow path and leaves the *primary* JSON path untouched. Users see no change in behavior whether the halt is in effect or not.
+
+Specifically:
+- The dual-write methods (`dualWriteCreate` / `dualWriteTransition`) are pure mechanics — they translate proposal lifecycle events into TaskFlow API calls. They have no judgment about which proposals are legitimate; they faithfully mirror what EvolutionManager already decided.
+- `setShadowWritesHalted` is a self-applied brake, not an external authority. The DivergenceChecker's role is "observe → emit signal → halt our own secondary writes." Both the observation and the halt are about TaskFlow shadow-write hygiene, not about whether a user's proposal should be accepted.
+- The 15-minute cadence is a deterministic timer-mechanic, not a content judgment.
+- Ledger notes are subsystem-asserted records of structural facts (which records exist where), not judgments about meaning or intent.
+
+No brittle blocker is introduced. No existing authority is shadowed. Phase 3b's cutover decision is a human-driven authority that *consumes* this signal.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** `addProposal` and `updateProposalStatus` continue to call `saveEvolution(state)` first, then dispatch the dual-write microtask. The dual-write cannot shadow JSON writes because it fires after `saveEvolution` returns, and its failures are logged but absorbed.
+- **Double-fire:** TaskFlow's existing `TaskFlowMaintenanceSweeper` and `TaskFlowDueWaker` operate on disjoint flow sets (sweeper: `running` ∪ `waiting`-non-tick; waker: `waiting`-tick). Proposal flows in Phase 3a go through queued → running → succeeded/failed/cancelled without entering waiting state, so neither auxiliary system fires on them. DivergenceChecker is a separate timer that reads-only; it never writes to flows.
+- **Races:**
+  - `addProposal` saves JSON then schedules a microtask for dual-write. If `runOnce()` lands between the save and the microtask drain, the proposal shows up as `json-only`. The 15-min cadence makes this vanishingly rare; the next pass clears it.
+  - `migrateExistingToTaskFlow` is idempotent — racing it against itself or against ongoing `addProposal` calls produces no duplicates because of the deterministic idempotency key.
+  - Concurrent `updateProposalStatus` calls on the same proposal could produce OCC conflicts on the flow side (`revision_conflict`). The dual-write swallows these with a console warn — JSON remains the source of truth, and the next divergence pass picks up any lag.
+  - `setShadowWritesHalted` is a simple boolean field write; no lock needed at this granularity.
+- **Feedback loops:** DivergenceChecker emits ledger notes; SharedStateLedger does not feed back into the checker. EvolutionManager's `setShadowWritesHalted` is a one-way call from the checker; EvolutionManager does not re-read the halt state to make any other decision (it only consults it to gate dual-writes).
+- **Cache coherence:** EvolutionManager's TaskFlow lookups via `findByIdempotency` go through `TaskFlowRegistry.getFlow` with `bypassCache: true` only when reading the flow for transition decisions, ensuring we see the fresh post-COMMIT state.
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** No new surface. The dual-write writes to the agent's own `.instar/task-flows.db`, which is already on the git-sync deny-list (added in Phase 1).
+- **Other users of the install base:** Phase 3a is gated on `config.taskFlow.enabled` (default off, established in Phase 1). Existing installs are unaffected.
+- **External systems:** None. The DivergenceChecker emits a metric via `console.log` (the existing `[metric]` channel that the dashboard scrapes); no outbound HTTP, no LLM calls, no Telegram sends.
+- **Persistent state:** New rows are added to `.instar/task-flows.db` for any existing proposal at startup (one-shot backfill). The DB is local and ignored by git. Rolling back Phase 3a leaves the rows in place but harmless — Phase 1's HTTP routes still expose them for read, and disabling `taskFlow.enabled` makes the registry inactive.
+- **Timing or runtime conditions:** The DivergenceChecker runs at 15-minute cadence with `unref()`'d timer; it never keeps the process alive on shutdown. The startup migration runs once per server start, sequentially after sweeper/waker boot. A backfill of N existing proposals does up to 4N registry calls (create + up to 3 transitions per proposal); for the typical N≤50 proposals, this is sub-second.
+
+## 7. Rollback cost
+
+- **Hot-fix release:** Revert the PR. Restart the server. No data migration. The `task-flows.db` file retains its rows but those rows are unused once `taskFlow.enabled` is false. If the rollback is partial (Phase 1+2 keep shipping, only Phase 3a reverts), the existing TaskFlow tests and routes continue to work. The dual-write path is removed; the divergence checker no longer runs. JSON state is unaffected.
+- **Data migration:** None on rollback. Proposal records in TaskFlow are orphaned but valid — they remain in the registry under `controllerId="EvolutionManager"` and can be re-discovered by a future re-introduction of the dual-write.
+- **Agent state repair:** None. Disabling `taskFlow.enabled` after rollback is the entire repair.
+- **User visibility:** None. The proposal pipeline visible to users is JSON-driven; rollback removes the secondary write and the monitor, but the JSON path users interact with is unchanged.
+
+---
+
+## Conclusion
+
+Phase 3a ships the dual-write contract and the coherence monitor that gate the eventual Phase 3b cutover. Every TaskFlow surface introduced is either a read-only lookup (`findByControllerId`, `findByIdempotency`) or a pure mechanic (dual-write translation, deterministic threshold timer). The new authority surface is zero — DivergenceChecker emits signals and applies a self-brake only to its own secondary write path, leaving the user-visible proposal pipeline untouched. Backfill is idempotent via the existing `findIdempotent` primitive. Rollback is `git revert` + `taskFlow.enabled: false`. Tests cover all 5 transition kinds, idempotent backfill, halted-write suppression, and the 5 divergence categories.
+
+The change is opt-in, additive, non-blocking, and rollback-cheap. Cleared to ship pending second-pass concurrence.
+
+---
+
+## Second-pass review
+
+**Reviewer:** adversarial self-review (Task/Agent subagent tool not available in this skill harness; conducted in-line with a fresh adversarial framing).
+**Independent read of the artifact: concur after fixes**
+
+Findings raised during adversarial pass and addressed in the same diff:
+
+1. **Halt-clearing source-tracking** — The first version of `DivergenceChecker.runOnce()` cleared `setShadowWritesHalted(false)` unconditionally on any zero-divergence pass. The artifact claimed "DivergenceChecker only resumes halts that DivergenceChecker itself imposed," but the code did not enforce that. **Fix applied:** `setShadowWritesHalted` now accepts a third `source` parameter (default `'manual'`), `isShadowWritesHalted` returns the source, and `DivergenceChecker` auto-clears only when `source === 'divergence-checker'`. A new test asserts that an operator-tagged halt survives a zero-divergence pass.
+2. **Ledger subsystem type pollution** — The first version emitted ledger notes with `subsystem: 'commitment-sweeper' as any`, reusing the closest-fitting enum value via cast. **Fix applied:** added `'taskflow-divergence'` to `LedgerEntrySubsystem` in `src/core/types.ts`; removed the cast. The ledger schema now reflects what is actually being emitted.
+3. **Backfill catch-up races vs ongoing addProposal** — Considered: `migrateExistingToTaskFlow` runs once at startup, sequentially. `addProposal` is server-driven and queues a microtask. If both touched the same proposal at startup, idempotency-key uniqueness on `evolution-cluster-create-<id>` would force the second writer to no-op. Verified by the idempotency test (second migrate pass produces 0 creates, 2 already-existed).
+4. **`failFlow` from `queued` state** — Initial test surfaced a real bug: `failFlow` requires `running|waiting`, but `proposed → rejected` skipped the queued state. **Fix applied (already in main diff):** the `fail` action now promotes `queued → running` with step `'reject-transition'` before calling `failFlow`. Test now passes.
+5. **Cache coherence on transition lookups** — Verified: `dualWriteTransition` reads via `registry.getFlow(id, { bypassCache: true })` before deciding the next OCC revision, eliminating stale-cache risk on rapid back-to-back transitions.
+
+No remaining critical concerns. The change is cleared to ship.
+
+---
+
+## Evidence pointers
+
+- Test run: `npx vitest run tests/unit/evolution-manager-taskflow-dualwrite.test.ts tests/unit/divergence-checker.test.ts` → 19/19 passing.
+- Regression: `npx vitest run tests/unit/task-flow-registry.test.ts tests/unit/threadline-flow-bridge.test.ts tests/unit/AutonomousEvolution.test.ts` → 63/63 passing.
+- Typecheck: `npx tsc --noEmit` → clean across modified files.
+- Spec source of truth: `docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md` § Phase 3a (lines 629–643).
+- Phase 1 trace context: `upgrades/side-effects/taskflow-phase1.md`.
+- Phase 2 trace context: `upgrades/side-effects/taskflow-phase2.md`.


### PR DESCRIPTION
## Summary
- Wires EvolutionManager's proposal lifecycle into TaskFlowRegistry as a shadow write under `controllerId=EvolutionManager`.
- Runs a one-shot `migrateExistingToTaskFlow()` backfill on server start (idempotent via `evolution-cluster-create-<id>` key).
- Starts a 15-minute `DivergenceChecker` cron that compares JSON ↔ TaskFlow state on `(ownerKey, status, currentStep, waitJson.kind)`, emits `taskflow_divergence_count` metric + `taskflow-divergence` ledger notes, and applies a source-tagged self-brake on `EvolutionManager.shadowWritesHalted` (only auto-clears its own halts; manual halts persist).

JSON state stays the local source of truth in Phase 3a; TaskFlow is the read-authoritative target that Phase 3b will cut over to once the divergence count is zero for ≥7 consecutive days AND the ledger contains zero `taskflow-divergence` notes in that window.

Per spec § Phase 3a: `docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md` lines 629–643 (also brought onto main in this PR with proper YAML frontmatter — review-convergence + approved tags).

## Signal-vs-authority compliance
DivergenceChecker is a **signal emitter**, NOT a gate:
- Emits metric (`taskflow_divergence_count`) and structured ledger note (kind `note`, subject `taskflow-divergence`).
- Self-brake flips only the **secondary** TaskFlow shadow-write path. The **primary** JSON path is never blocked; users see no behavior change whether the brake is on or off.
- Halts are tagged with a `source` (`'divergence-checker'` vs `'manual'`); auto-resume only clears halts the checker set, so operator-imposed halts survive.

Full reasoning in `upgrades/side-effects/taskflow-phase3a.md` § 4.

## Test plan
- [x] `tests/unit/evolution-manager-taskflow-dualwrite.test.ts` — 10 cases (5 lifecycle transitions, idempotent backfill, halt suppression, JSON-survives-taskflow-failure, read-authoritative via findByControllerId).
- [x] `tests/unit/divergence-checker.test.ts` — 10 cases (happy path, json-only, taskflow-only, status mismatch, step mismatch, wait-kind mismatch, ledger-note + halt-on-divergence, resume-on-cleared, manual-halt-persists, lastReport population).
- [x] Regression: existing `tests/unit/task-flow-registry.test.ts` (24) + `threadline-flow-bridge.test.ts` (8) + `AutonomousEvolution.test.ts` (31) — all passing.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean.

## Side-effects review
- `upgrades/side-effects/taskflow-phase3a.md`
- Second-pass: in-line adversarial pass (Agent subagent tool unavailable in skill harness); 5 findings raised and resolved in same diff (halt source-tracking, ledger subsystem enum, failFlow-from-queued promotion, bypass-cache reads on transition lookups, ledger emit hygiene).

## Rollback
`git revert` the PR. Set `config.taskFlow.enabled: false`. No data migration; the `.instar/task-flows.db` rows are local and harmless to leave in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)