### PR TITLE
feat(tasks): TaskFlow Phase 4 — InitiativeTracker migration to TaskFlow

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6259,6 +6259,24 @@ export async function startServer(options: StartOptions): Promise<void> {
           ledger: sharedStateLedger ?? undefined,
         });
         divergenceChecker.start();
+
+        // Phase 4 — wire InitiativeTracker to TaskFlow as the single source of
+        // truth. Backfill any initiatives present in the legacy
+        // `initiatives.json` file. Idempotent via `findIdempotent` on
+        // `(controllerId="InitiativeTracker", ownerKey, idempotencyKey)`.
+        initiativeTracker.setTaskFlowRegistry(taskFlowRegistry, controllerInstanceId);
+        try {
+          const initiativeReport = await initiativeTracker.migrateExistingToTaskFlow();
+          console.log(
+            pc.green(
+              `  TaskFlow: backfilled initiatives created=${initiativeReport.created} ` +
+              `existed=${initiativeReport.alreadyExisted} advanced=${initiativeReport.advanced} ` +
+              `skipped=${initiativeReport.skipped}`
+            )
+          );
+        } catch (err) {
+          console.warn('[instar] taskflow initiative backfill failed (non-fatal):', err);
+        }
       } catch (err) {
         console.warn('[instar] task-flow init failed (non-fatal):', err);
         taskFlowRegistry = undefined;

--- a/src/core/InitiativeTracker.ts
+++ b/src/core/InitiativeTracker.ts
@@ -5,13 +5,44 @@
  * scheduled Jobs (recurring cron task). An Initiative represents a
  * bounded-but-multi-week effort with phases, each advancing in order.
  *
- * Persistence: `.instar/initiatives.json` (atomic rename pattern).
+ * Storage:
+ *   - When TaskFlow is wired (`setTaskFlowRegistry`), TaskFlow is the
+ *     **single source of truth** (per OPENCLAW-IMPORT-TASKFLOW-SPEC.md
+ *     § Phase 4, lines 645–648). Each initiative is one TaskFlow record:
+ *     `controllerId="InitiativeTracker"`, `ownerKey="initiative:<id>"`,
+ *     `idempotencyKey="initiative:<id>"`. The full Initiative shape is
+ *     persisted in `stateJson`. The active phase id maps to `currentStep`;
+ *     `needsUser` / blockers map to `setFlowWaiting({kind:"human-review"})`.
+ *   - When TaskFlow is NOT wired, behavior falls back to legacy
+ *     `.instar/initiatives.json`. This keeps the disabled-feature path
+ *     working for installs where `taskFlow.enabled` is false.
+ *
+ * Migration:
+ *   - On startup, the server calls `migrateExistingToTaskFlow()` once when
+ *     TaskFlow is enabled. It backfills any initiatives present in the
+ *     legacy JSON file into TaskFlow. Idempotent via `findIdempotent` on
+ *     `(controllerId, ownerKey, idempotencyKey)` — running twice produces
+ *     no duplicates.
+ *
+ * API shape:
+ *   - All public mutators are `async` to allow TaskFlow's promise-based
+ *     write API to complete before returning. Reads are `sync` (TaskFlow's
+ *     read API uses `better-sqlite3` synchronously through the in-memory
+ *     cache).
+ *
  * Consumers: HTTP routes (`/initiatives/*`), dashboard "Initiatives" tab,
  * daily digest job (alerts when initiatives go stale / need user input /
  * are ready to advance).
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import type { TaskFlowRegistry } from '../tasks/TaskFlowRegistry.js';
+import type {
+  TaskFlowPrincipal,
+  TaskFlowRecord,
+  WaitJson,
+} from '../tasks/task-flow-types.js';
+import { TaskFlowError } from '../tasks/task-flow-types.js';
 
 export type InitiativePhaseStatus = 'pending' | 'in-progress' | 'done' | 'blocked';
 
@@ -104,16 +135,74 @@ export interface Digest {
  */
 export const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
 
+/**
+ * TaskFlow controller identity for InitiativeTracker (Phase 4 migration).
+ * Every initiative's flow is owned by this controllerId; the registry uses
+ * it for OCC scope checks. Single instance per server process.
+ */
+export const INITIATIVE_TASKFLOW_CONTROLLER_ID = 'InitiativeTracker';
+
+function ownerKeyForInitiative(initiativeId: string): string {
+  return `initiative:${initiativeId}`;
+}
+
+function idempotencyKeyForInitiative(initiativeId: string): string {
+  return `initiative:${initiativeId}`;
+}
+
 export class InitiativeTracker {
   private readonly filePath: string;
+  /** In-process cache. Authoritative when TaskFlow is not wired; otherwise
+   * a read-side projection of TaskFlow's stateJson. */
   private readonly initiatives = new Map<string, Initiative>();
+
+  // ── TaskFlow Phase 4 wiring ────────────────────────────────────
+  private taskFlowRegistry: TaskFlowRegistry | null = null;
+  private taskFlowControllerInstanceId: string | null = null;
 
   constructor(stateDir: string) {
     this.filePath = path.join(stateDir, 'initiatives.json');
-    this.load();
+    this.loadFromDisk();
   }
 
-  private load(): void {
+  /**
+   * Wire a TaskFlow registry to make TaskFlow the source of truth.
+   * Idempotent — safe to call multiple times. After wiring, all reads come
+   * from TaskFlow and all writes go through TaskFlow APIs. The legacy JSON
+   * file is no longer written.
+   *
+   * Callers are expected to call `migrateExistingToTaskFlow()` after this
+   * to backfill any initiatives that were loaded from the legacy file.
+   */
+  setTaskFlowRegistry(
+    registry: TaskFlowRegistry,
+    controllerInstanceId: string
+  ): void {
+    this.taskFlowRegistry = registry;
+    this.taskFlowControllerInstanceId = controllerInstanceId;
+    // Layer existing TaskFlow records over legacy-loaded data without
+    // clearing the cache: any legacy initiatives still need to be backfilled
+    // via `migrateExistingToTaskFlow()`. TaskFlow records win on collision.
+    this.layerCacheFromTaskFlow();
+  }
+
+  /** True when TaskFlow is wired and authoritative. */
+  isTaskFlowEnabled(): boolean {
+    return this.taskFlowRegistry !== null && this.taskFlowControllerInstanceId !== null;
+  }
+
+  private taskFlowPrincipal(): TaskFlowPrincipal | null {
+    if (!this.taskFlowRegistry || !this.taskFlowControllerInstanceId) return null;
+    return {
+      scope: 'controller',
+      controllerId: INITIATIVE_TASKFLOW_CONTROLLER_ID,
+      controllerInstanceId: this.taskFlowControllerInstanceId,
+    };
+  }
+
+  // ── Legacy JSON storage (used until TaskFlow is wired) ─────────
+
+  private loadFromDisk(): void {
     try {
       if (!fs.existsSync(this.filePath)) return;
       const raw = JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
@@ -129,7 +218,8 @@ export class InitiativeTracker {
     }
   }
 
-  private save(): void {
+  private saveToDisk(): void {
+    if (this.isTaskFlowEnabled()) return; // TaskFlow's SQLite is the durable store.
     const dir = path.dirname(this.filePath);
     fs.mkdirSync(dir, { recursive: true });
     const payload = { initiatives: Array.from(this.initiatives.values()) };
@@ -138,25 +228,391 @@ export class InitiativeTracker {
     fs.renameSync(tmp, this.filePath);
   }
 
+  // ── TaskFlow ↔ Initiative serialization ─────────────────────────
+
+  private initiativeFromFlow(flow: TaskFlowRecord): Initiative | null {
+    const state = flow.stateJson as { initiative?: Initiative } | undefined;
+    if (!state || typeof state !== 'object' || !state.initiative) return null;
+    return state.initiative;
+  }
+
+  private refreshCacheFromTaskFlow(): void {
+    if (!this.taskFlowRegistry) return;
+    const flows = this.taskFlowRegistry.findByControllerId(
+      INITIATIVE_TASKFLOW_CONTROLLER_ID
+    );
+    this.initiatives.clear();
+    for (const f of flows) {
+      const init = this.initiativeFromFlow(f);
+      // Tombstone-removed initiatives are filtered out so callers can't
+      // see them via list() / get() after remove().
+      if (init && !this.isTombstoned(f)) {
+        this.initiatives.set(init.id, init);
+      }
+    }
+  }
+
+  /**
+   * Layer TaskFlow data on top of the existing cache without clearing it.
+   * Used during `setTaskFlowRegistry` so legacy-loaded initiatives are
+   * preserved as backfill candidates while any pre-existing TaskFlow
+   * records take precedence.
+   */
+  private layerCacheFromTaskFlow(): void {
+    if (!this.taskFlowRegistry) return;
+    const flows = this.taskFlowRegistry.findByControllerId(
+      INITIATIVE_TASKFLOW_CONTROLLER_ID
+    );
+    for (const f of flows) {
+      const init = this.initiativeFromFlow(f);
+      if (init && !this.isTombstoned(f)) {
+        this.initiatives.set(init.id, init);
+      } else if (this.isTombstoned(f) && init) {
+        // Tombstoned flows shadow legacy entries.
+        this.initiatives.delete(init.id);
+      }
+    }
+  }
+
+  /**
+   * A flow is "tombstoned" when remove() marked it as removed before
+   * cancelling. The marker lives in stateJson._removed and is the
+   * single signal that a flow's owning Initiative should be hidden from
+   * list() / get(). We can't delete TaskFlow records from this layer, so
+   * the marker is the durable equivalent of deletion.
+   */
+  private isTombstoned(flow: TaskFlowRecord): boolean {
+    const state = flow.stateJson as { _removed?: boolean } | undefined;
+    return state?._removed === true;
+  }
+
+  private waitJsonForInitiative(init: Initiative): WaitJson | null {
+    const blocked = init.needsUser || init.blockers.length > 0;
+    if (!blocked) return null;
+    const reason = init.needsUser
+      ? init.needsUserReason ?? 'Initiative needs user decision'
+      : init.blockers.join('; ');
+    const question = (reason || 'Initiative blocked').slice(0, 2000);
+    return { kind: 'human-review', question };
+  }
+
+  /** Determine the desired TaskFlow status for an Initiative. */
+  private desiredFlowStatus(init: Initiative):
+    | { kind: 'running'; step: string }
+    | { kind: 'waiting'; step: string; waitJson: WaitJson }
+    | { kind: 'succeeded'; step: string }
+    | { kind: 'failed'; step: string }
+    | { kind: 'cancelled'; step: string } {
+    const phase = init.phases[init.currentPhaseIndex];
+    const step = phase ? phase.id : 'unknown';
+    if (init.status === 'completed') return { kind: 'succeeded', step };
+    if (init.status === 'abandoned') return { kind: 'failed', step };
+    if (init.status === 'archived') return { kind: 'cancelled', step };
+    const wait = this.waitJsonForInitiative(init);
+    if (wait) return { kind: 'waiting', step, waitJson: wait };
+    return { kind: 'running', step };
+  }
+
+  /**
+   * Persist an Initiative through TaskFlow. Walks the flow state machine
+   * to the desired target (running / waiting / succeeded / failed /
+   * cancelled), updating `stateJson` along the way so reads see the latest
+   * shape. Returns the Initiative as projected from TaskFlow after
+   * transitions settle.
+   */
+  private async persistThroughTaskFlow(init: Initiative): Promise<Initiative> {
+    const registry = this.taskFlowRegistry;
+    const principal = this.taskFlowPrincipal();
+    if (!registry || !principal || principal.scope !== 'controller') return init;
+
+    const ownerKey = ownerKeyForInitiative(init.id);
+    const idemKey = idempotencyKeyForInitiative(init.id);
+    const desired = this.desiredFlowStatus(init);
+    const stateJson = { initiative: init };
+
+    let existing = registry.findByIdempotency(
+      INITIATIVE_TASKFLOW_CONTROLLER_ID,
+      ownerKey,
+      idemKey
+    );
+    if (!existing) {
+      const r = await registry.createFlow({
+        controllerId: INITIATIVE_TASKFLOW_CONTROLLER_ID,
+        controllerInstanceId: principal.controllerInstanceId,
+        ownerKey,
+        idempotencyKey: idemKey,
+        goal: init.title.slice(0, 1024),
+        currentStep: desired.step,
+        stateJson,
+      });
+      existing = r.flow;
+    }
+    let cur = registry.getFlow(existing.flowId, { bypassCache: true }) ?? existing;
+
+    try {
+      // Already terminal? Accept and stop — terminal flows are immutable
+      // per TaskFlow contract. The Initiative's local terminal state stays
+      // in sync via the cache, but we never re-mutate the flow.
+      if (
+        cur.status === 'succeeded' ||
+        cur.status === 'failed' ||
+        cur.status === 'cancelled' ||
+        cur.status === 'lost'
+      ) {
+        return this.initiativeFromFlow(cur) ?? init;
+      }
+
+      // queued → running (always; a fresh create lands in queued).
+      if (cur.status === 'queued') {
+        const r = await registry.startStep({
+          flowId: cur.flowId,
+          expectedRevision: cur.revision,
+          principal,
+          currentStep: desired.step,
+        });
+        cur = r.flow;
+      }
+
+      // waiting → running (resume), in case desired wait is different or
+      // we're moving to running/terminal. resumeFlow accepts statePatch so
+      // we update stateJson here too.
+      if (cur.status === 'waiting') {
+        if (cur.waitInstanceId) {
+          const r = await registry.resumeFlow({
+            flowId: cur.flowId,
+            expectedRevision: cur.revision,
+            principal,
+            waitInstanceId: cur.waitInstanceId,
+            currentStep: desired.step,
+            statePatch: stateJson,
+          });
+          cur = r.flow;
+        }
+      }
+
+      // Now cur.status === 'running'. Drive to the desired terminal state.
+      if (cur.status === 'running') {
+        if (desired.kind === 'running') {
+          // Re-startStep when currentStep changed; this updates the step.
+          if (cur.currentStep !== desired.step) {
+            const r = await registry.startStep({
+              flowId: cur.flowId,
+              expectedRevision: cur.revision,
+              principal,
+              currentStep: desired.step,
+            });
+            cur = r.flow;
+          }
+          // Always patch stateJson to reflect the latest Initiative shape.
+          cur = await this.patchStateJson(cur, stateJson);
+        } else if (desired.kind === 'waiting') {
+          const r = await registry.setFlowWaiting({
+            flowId: cur.flowId,
+            expectedRevision: cur.revision,
+            principal,
+            waitJson: desired.waitJson,
+            currentStep: desired.step,
+            statePatch: stateJson,
+          });
+          cur = r.flow;
+        } else if (desired.kind === 'succeeded') {
+          cur = await this.patchStateJson(cur, stateJson);
+          const r = await registry.finishFlow({
+            flowId: cur.flowId,
+            expectedRevision: cur.revision,
+            principal,
+          });
+          cur = r.flow;
+        } else if (desired.kind === 'failed') {
+          cur = await this.patchStateJson(cur, stateJson);
+          const r = await registry.failFlow({
+            flowId: cur.flowId,
+            expectedRevision: cur.revision,
+            principal,
+            failureReason: 'abandoned',
+          });
+          cur = r.flow;
+        } else if (desired.kind === 'cancelled') {
+          cur = await this.patchStateJson(cur, stateJson);
+          const cr = await registry.requestFlowCancel({
+            flowId: cur.flowId,
+            expectedRevision: cur.revision,
+            requesterOrigin: { kind: 'system', id: 'InitiativeTracker' },
+          });
+          const r = await registry.cancelFlow({
+            flowId: cur.flowId,
+            expectedRevision: cr.flow.revision,
+            principal,
+          });
+          cur = r.flow;
+        }
+      }
+    } catch (err) {
+      this.logTaskFlowError('persist', init.id, err);
+    }
+
+    const fresh = registry.getFlow(cur.flowId, { bypassCache: true }) ?? cur;
+    const persisted = this.initiativeFromFlow(fresh) ?? init;
+    this.initiatives.set(persisted.id, persisted);
+    return persisted;
+  }
+
+  /**
+   * Patch a running flow's stateJson without changing its observable
+   * status. Uses a brief setFlowWaiting → resumeFlow round-trip (the only
+   * atomic state-bearing transitions for `running` flows that accept
+   * `statePatch`). The wait kind `'human-review'` with a sentinel question
+   * is used; the wait is consumed in the same call, so no external
+   * observer sees `waiting`.
+   */
+  private async patchStateJson(
+    flow: TaskFlowRecord,
+    stateJson: { initiative: Initiative }
+  ): Promise<TaskFlowRecord> {
+    const registry = this.taskFlowRegistry;
+    const principal = this.taskFlowPrincipal();
+    if (!registry || !principal || principal.scope !== 'controller') return flow;
+    if (flow.status !== 'running') return flow;
+    try {
+      const w = await registry.setFlowWaiting({
+        flowId: flow.flowId,
+        expectedRevision: flow.revision,
+        principal,
+        waitJson: { kind: 'human-review', question: '__statePatch__' },
+        statePatch: stateJson,
+      });
+      const r = await registry.resumeFlow({
+        flowId: w.flow.flowId,
+        expectedRevision: w.flow.revision,
+        principal,
+        waitInstanceId: w.flow.waitInstanceId!,
+        statePatch: stateJson,
+      });
+      return r.flow;
+    } catch (err) {
+      this.logTaskFlowError('patchStateJson', flow.flowId, err);
+      return flow;
+    }
+  }
+
+  private findFlowIdForInitiative(id: string): string | null {
+    const registry = this.taskFlowRegistry;
+    if (!registry) return null;
+    const f = registry.findByIdempotency(
+      INITIATIVE_TASKFLOW_CONTROLLER_ID,
+      ownerKeyForInitiative(id),
+      idempotencyKeyForInitiative(id)
+    );
+    return f?.flowId ?? null;
+  }
+
+  private logTaskFlowError(op: string, key: string, err: unknown): void {
+    if (err instanceof TaskFlowError) {
+      console.warn(
+        `[InitiativeTracker] taskflow ${op} for ${key} skipped: ${err.code} (${err.message})`
+      );
+    } else {
+      console.warn(
+        `[InitiativeTracker] taskflow ${op} for ${key} unexpected error:`,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+
+  /**
+   * Backfill all initiatives currently in the in-memory cache (loaded from
+   * legacy JSON in the constructor) into TaskFlow. Idempotent via
+   * `findIdempotent`. Safe to call multiple times.
+   */
+  async migrateExistingToTaskFlow(): Promise<{
+    created: number;
+    alreadyExisted: number;
+    advanced: number;
+    skipped: number;
+  }> {
+    const registry = this.taskFlowRegistry;
+    const principal = this.taskFlowPrincipal();
+    if (!registry || !principal || principal.scope !== 'controller') {
+      return { created: 0, alreadyExisted: 0, advanced: 0, skipped: 0 };
+    }
+    let created = 0;
+    let alreadyExisted = 0;
+    let advanced = 0;
+    let skipped = 0;
+    const candidates = Array.from(this.initiatives.values());
+    for (const init of candidates) {
+      try {
+        const ownerKey = ownerKeyForInitiative(init.id);
+        const idemKey = idempotencyKeyForInitiative(init.id);
+        const existing = registry.findByIdempotency(
+          INITIATIVE_TASKFLOW_CONTROLLER_ID,
+          ownerKey,
+          idemKey
+        );
+        if (existing) {
+          alreadyExisted++;
+        } else {
+          await registry.createFlow({
+            controllerId: INITIATIVE_TASKFLOW_CONTROLLER_ID,
+            controllerInstanceId: principal.controllerInstanceId,
+            ownerKey,
+            idempotencyKey: idemKey,
+            goal: init.title.slice(0, 1024),
+            currentStep: init.phases[init.currentPhaseIndex]?.id ?? 'start',
+            stateJson: { initiative: init },
+          });
+          created++;
+        }
+        const persisted = await this.persistThroughTaskFlow(init);
+        if (persisted) advanced++;
+      } catch (err) {
+        skipped++;
+        this.logTaskFlowError('migrate', init.id, err);
+      }
+    }
+    this.refreshCacheFromTaskFlow();
+    return { created, alreadyExisted, advanced, skipped };
+  }
+
+  // ── Public API ─────────────────────────────────────────────────
+
   list(filter?: { status?: InitiativeStatus }): Initiative[] {
+    if (this.isTaskFlowEnabled()) this.refreshCacheFromTaskFlow();
     const all = Array.from(this.initiatives.values());
     const filtered = filter?.status ? all.filter((i) => i.status === filter.status) : all;
     return filtered.sort((a, b) => b.lastTouchedAt.localeCompare(a.lastTouchedAt));
   }
 
   get(id: string): Initiative | undefined {
+    if (this.isTaskFlowEnabled()) {
+      const fid = this.findFlowIdForInitiative(id);
+      if (!fid) return undefined;
+      const f = this.taskFlowRegistry!.getFlow(fid, { bypassCache: true });
+      if (!f) return undefined;
+      if (this.isTombstoned(f)) {
+        this.initiatives.delete(id);
+        return undefined;
+      }
+      const init = this.initiativeFromFlow(f);
+      if (init) this.initiatives.set(id, init);
+      return init ?? undefined;
+    }
     return this.initiatives.get(id);
   }
 
-  create(input: InitiativeCreateInput): Initiative {
-    if (this.initiatives.has(input.id)) {
-      throw new Error(`Initiative "${input.id}" already exists`);
-    }
+  async create(input: InitiativeCreateInput): Promise<Initiative> {
     if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(input.id)) {
       throw new Error('Initiative id must be lowercase kebab-case, 1–63 chars');
     }
     if (!input.phases.length) {
       throw new Error('Initiative must have at least one phase');
+    }
+    if (this.isTaskFlowEnabled()) {
+      if (this.findFlowIdForInitiative(input.id)) {
+        throw new Error(`Initiative "${input.id}" already exists`);
+      }
+    } else if (this.initiatives.has(input.id)) {
+      throw new Error(`Initiative "${input.id}" already exists`);
     }
     const now = new Date().toISOString();
     const phases: InitiativePhase[] = input.phases.map((p) => ({
@@ -165,7 +621,6 @@ export class InitiativeTracker {
       summary: p.summary,
       status: p.status ?? 'pending',
     }));
-    // currentPhaseIndex: first non-'done' phase, else last phase.
     const firstOpen = phases.findIndex((p) => p.status !== 'done');
     const currentPhaseIndex = firstOpen === -1 ? phases.length - 1 : firstOpen;
     const allDone = phases.every((p) => p.status === 'done');
@@ -186,12 +641,15 @@ export class InitiativeTracker {
       updatedAt: now,
     };
     this.initiatives.set(initiative.id, initiative);
-    this.save();
+    if (this.isTaskFlowEnabled()) {
+      return await this.persistThroughTaskFlow(initiative);
+    }
+    this.saveToDisk();
     return initiative;
   }
 
-  update(id: string, input: InitiativeUpdateInput): Initiative {
-    const existing = this.initiatives.get(id);
+  async update(id: string, input: InitiativeUpdateInput): Promise<Initiative> {
+    const existing = this.get(id);
     if (!existing) throw new Error(`Initiative "${id}" not found`);
     const now = new Date().toISOString();
     const next: Initiative = { ...existing, updatedAt: now, lastTouchedAt: now };
@@ -208,18 +666,19 @@ export class InitiativeTracker {
     if (input.blockers !== undefined) next.blockers = input.blockers;
     if (input.links !== undefined) next.links = input.links;
     this.initiatives.set(id, next);
-    this.save();
+    if (this.isTaskFlowEnabled()) {
+      return await this.persistThroughTaskFlow(next);
+    }
+    this.saveToDisk();
     return next;
   }
 
-  /**
-   * Transition a phase's status. Updates currentPhaseIndex to point to the
-   * earliest non-done phase; marks the whole initiative 'completed' when
-   * all phases are 'done'. Sets startedAt/completedAt the first time a
-   * phase reaches 'in-progress' / 'done' respectively.
-   */
-  setPhaseStatus(id: string, phaseId: string, status: InitiativePhaseStatus): Initiative {
-    const existing = this.initiatives.get(id);
+  async setPhaseStatus(
+    id: string,
+    phaseId: string,
+    status: InitiativePhaseStatus
+  ): Promise<Initiative> {
+    const existing = this.get(id);
     if (!existing) throw new Error(`Initiative "${id}" not found`);
     const phases = existing.phases.map((p) => ({ ...p }));
     const phase = phases.find((p) => p.id === phaseId);
@@ -239,22 +698,88 @@ export class InitiativeTracker {
       lastTouchedAt: now,
     };
     this.initiatives.set(id, next);
-    this.save();
+    if (this.isTaskFlowEnabled()) {
+      return await this.persistThroughTaskFlow(next);
+    }
+    this.saveToDisk();
     return next;
   }
 
-  remove(id: string): boolean {
+  async remove(id: string): Promise<boolean> {
+    if (this.isTaskFlowEnabled()) {
+      const fid = this.findFlowIdForInitiative(id);
+      if (!fid) {
+        return this.initiatives.delete(id);
+      }
+      const registry = this.taskFlowRegistry!;
+      const principal = this.taskFlowPrincipal();
+      let flow = registry.getFlow(fid, { bypassCache: true });
+      if (flow && principal && principal.scope === 'controller') {
+        try {
+          if (flow.status === 'queued') {
+            const r = await registry.startStep({
+              flowId: flow.flowId,
+              expectedRevision: flow.revision,
+              principal,
+              currentStep: flow.currentStep ?? 'remove',
+            });
+            flow = r.flow;
+          }
+          if (flow.status === 'waiting' && flow.waitInstanceId) {
+            const r = await registry.resumeFlow({
+              flowId: flow.flowId,
+              expectedRevision: flow.revision,
+              principal,
+              waitInstanceId: flow.waitInstanceId,
+            });
+            flow = r.flow;
+          }
+          // Stamp the tombstone marker into stateJson so subsequent reads
+          // hide the initiative. Done before cancel because terminal flows
+          // are immutable.
+          const init = this.initiativeFromFlow(flow);
+          if (flow.status === 'running' && init) {
+            const tomb = await this.patchStateJson(
+              flow,
+              { initiative: init, _removed: true } as { initiative: Initiative }
+            );
+            flow = tomb;
+          }
+          if (
+            flow.status !== 'succeeded' &&
+            flow.status !== 'failed' &&
+            flow.status !== 'cancelled' &&
+            flow.status !== 'lost'
+          ) {
+            const cr = await registry.requestFlowCancel({
+              flowId: flow.flowId,
+              expectedRevision: flow.revision,
+              requesterOrigin: { kind: 'system', id: 'InitiativeTracker' },
+            });
+            await registry.cancelFlow({
+              flowId: flow.flowId,
+              expectedRevision: cr.flow.revision,
+              principal,
+            });
+          }
+        } catch (err) {
+          this.logTaskFlowError('remove', id, err);
+        }
+      }
+      this.initiatives.delete(id);
+      return true;
+    }
     const removed = this.initiatives.delete(id);
-    if (removed) this.save();
+    if (removed) this.saveToDisk();
     return removed;
   }
 
   /**
-   * Scan active initiatives for anything actionable. The digest job uses
-   * this to decide whether to send a push notification. Empty items[]
-   * means "quiet day, don't spam the user."
+   * Scan active initiatives for anything actionable. Empty items[] means
+   * "quiet day, don't spam the user."
    */
   digest(now: Date = new Date()): Digest {
+    if (this.isTaskFlowEnabled()) this.refreshCacheFromTaskFlow();
     const items: DigestItem[] = [];
     const nowMs = now.getTime();
     for (const initiative of this.initiatives.values()) {
@@ -283,10 +808,6 @@ export class InitiativeTracker {
         }
       }
 
-      // Ready-to-advance: the previous phase is done AND the current
-      // phase is still untouched ('pending'). Once the current phase
-      // is 'in-progress' or 'blocked', the advance has already begun,
-      // so we stop emitting this signal.
       const current = initiative.phases[initiative.currentPhaseIndex];
       const previous = initiative.currentPhaseIndex > 0
         ? initiative.phases[initiative.currentPhaseIndex - 1]

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5322,7 +5322,7 @@ export function createRoutes(ctx: RouteContext): Router {
     res.json(initiative);
   });
 
-  router.post('/initiatives', (req, res) => {
+  router.post('/initiatives', async (req, res) => {
     if (!ctx.initiativeTracker) {
       res.status(503).json({ error: 'Initiative tracker not configured' });
       return;
@@ -5345,7 +5345,7 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     try {
-      const created = ctx.initiativeTracker.create({
+      const created = await ctx.initiativeTracker.create({
         id, title, description, phases, links, nextCheckAt,
         needsUser, needsUserReason, blockers,
       });
@@ -5355,7 +5355,7 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
-  router.patch('/initiatives/:id', (req, res) => {
+  router.patch('/initiatives/:id', async (req, res) => {
     if (!ctx.initiativeTracker) {
       res.status(503).json({ error: 'Initiative tracker not configured' });
       return;
@@ -5365,7 +5365,7 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     try {
-      const updated = ctx.initiativeTracker.update(req.params.id, req.body ?? {});
+      const updated = await ctx.initiativeTracker.update(req.params.id, req.body ?? {});
       res.json(updated);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -5374,7 +5374,7 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
-  router.post('/initiatives/:id/phase/:phaseId', (req, res) => {
+  router.post('/initiatives/:id/phase/:phaseId', async (req, res) => {
     if (!ctx.initiativeTracker) {
       res.status(503).json({ error: 'Initiative tracker not configured' });
       return;
@@ -5385,7 +5385,7 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     try {
-      const updated = ctx.initiativeTracker.setPhaseStatus(req.params.id, req.params.phaseId, status);
+      const updated = await ctx.initiativeTracker.setPhaseStatus(req.params.id, req.params.phaseId, status);
       res.json(updated);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -5393,12 +5393,12 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
-  router.delete('/initiatives/:id', (req, res) => {
+  router.delete('/initiatives/:id', async (req, res) => {
     if (!ctx.initiativeTracker) {
       res.status(503).json({ error: 'Initiative tracker not configured' });
       return;
     }
-    const removed = ctx.initiativeTracker.remove(req.params.id);
+    const removed = await ctx.initiativeTracker.remove(req.params.id);
     if (!removed) {
       res.status(404).json({ error: 'initiative not found' });
       return;

--- a/tests/unit/InitiativeTracker.test.ts
+++ b/tests/unit/InitiativeTracker.test.ts
@@ -1,7 +1,7 @@
 /**
- * InitiativeTracker unit tests.
+ * InitiativeTracker unit tests (legacy JSON-storage mode).
  *
- * Covers:
+ * Covers (legacy / TaskFlow-disabled) behavior:
  *  - CRUD lifecycle (create, get, list, update, remove)
  *  - Validation (id format, unique, phase required)
  *  - Phase status transitions (startedAt/completedAt timestamps,
@@ -9,6 +9,9 @@
  *  - Persistence across instances (atomic write + reload)
  *  - Digest scan: stale / needs-user / ready-to-advance / next-check-due
  *  - Ordering (list sorted by lastTouchedAt DESC)
+ *
+ * TaskFlow-enabled behavior is covered in
+ * `tests/unit/initiative-tracker-taskflow.test.ts`.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
@@ -46,8 +49,8 @@ function baseInput(id = 'demo') {
 }
 
 describe('InitiativeTracker — CRUD', () => {
-  it('creates an initiative with sane defaults', () => {
-    const created = tracker.create(baseInput());
+  it('creates an initiative with sane defaults', async () => {
+    const created = await tracker.create(baseInput());
     expect(created.id).toBe('demo');
     expect(created.status).toBe('active');
     expect(created.phases).toHaveLength(3);
@@ -59,43 +62,43 @@ describe('InitiativeTracker — CRUD', () => {
     expect(created.createdAt).toBe(created.updatedAt);
   });
 
-  it('rejects duplicate ids', () => {
-    tracker.create(baseInput());
-    expect(() => tracker.create(baseInput())).toThrow(/already exists/);
+  it('rejects duplicate ids', async () => {
+    await tracker.create(baseInput());
+    await expect(tracker.create(baseInput())).rejects.toThrow(/already exists/);
   });
 
-  it('rejects invalid id format', () => {
-    expect(() => tracker.create({ ...baseInput(), id: 'Bad_ID' })).toThrow();
-    expect(() => tracker.create({ ...baseInput(), id: '-leading-dash' })).toThrow();
-    expect(() => tracker.create({ ...baseInput(), id: '' })).toThrow();
+  it('rejects invalid id format', async () => {
+    await expect(tracker.create({ ...baseInput(), id: 'Bad_ID' })).rejects.toThrow();
+    await expect(tracker.create({ ...baseInput(), id: '-leading-dash' })).rejects.toThrow();
+    await expect(tracker.create({ ...baseInput(), id: '' })).rejects.toThrow();
   });
 
-  it('rejects empty phases array', () => {
-    expect(() => tracker.create({ ...baseInput(), phases: [] })).toThrow(/at least one phase/);
+  it('rejects empty phases array', async () => {
+    await expect(tracker.create({ ...baseInput(), phases: [] })).rejects.toThrow(/at least one phase/);
   });
 
   it('lists initiatives sorted by lastTouchedAt DESC', async () => {
-    tracker.create(baseInput('a'));
+    await tracker.create(baseInput('a'));
     await new Promise((r) => setTimeout(r, 5));
-    tracker.create(baseInput('b'));
+    await tracker.create(baseInput('b'));
     await new Promise((r) => setTimeout(r, 5));
-    tracker.update('a', { description: 'touched' });
+    await tracker.update('a', { description: 'touched' });
     const listed = tracker.list();
     expect(listed.map((i) => i.id)).toEqual(['a', 'b']);
   });
 
-  it('filters list by status', () => {
-    tracker.create(baseInput('a'));
-    tracker.create(baseInput('b'));
-    tracker.update('b', { status: 'archived' });
+  it('filters list by status', async () => {
+    await tracker.create(baseInput('a'));
+    await tracker.create(baseInput('b'));
+    await tracker.update('b', { status: 'archived' });
     expect(tracker.list({ status: 'active' }).map((i) => i.id)).toEqual(['a']);
     expect(tracker.list({ status: 'archived' }).map((i) => i.id)).toEqual(['b']);
   });
 
   it('update() modifies fields and bumps timestamps', async () => {
-    const created = tracker.create(baseInput());
+    const created = await tracker.create(baseInput());
     await new Promise((r) => setTimeout(r, 5));
-    const updated = tracker.update('demo', {
+    const updated = await tracker.update('demo', {
       title: 'Renamed',
       needsUser: true,
       needsUserReason: 'decide scope',
@@ -106,78 +109,78 @@ describe('InitiativeTracker — CRUD', () => {
     expect(updated.updatedAt > created.updatedAt).toBe(true);
   });
 
-  it('update() clears nullable fields when set to null', () => {
-    tracker.create({ ...baseInput(), nextCheckAt: '2099-01-01T00:00:00.000Z' });
-    const cleared = tracker.update('demo', { nextCheckAt: null });
+  it('update() clears nullable fields when set to null', async () => {
+    await tracker.create({ ...baseInput(), nextCheckAt: '2099-01-01T00:00:00.000Z' });
+    const cleared = await tracker.update('demo', { nextCheckAt: null });
     expect(cleared.nextCheckAt).toBeUndefined();
   });
 
-  it('remove() deletes and returns true', () => {
-    tracker.create(baseInput());
-    expect(tracker.remove('demo')).toBe(true);
+  it('remove() deletes and returns true', async () => {
+    await tracker.create(baseInput());
+    expect(await tracker.remove('demo')).toBe(true);
     expect(tracker.get('demo')).toBeUndefined();
   });
 
-  it('remove() returns false for unknown id', () => {
-    expect(tracker.remove('ghost')).toBe(false);
+  it('remove() returns false for unknown id', async () => {
+    expect(await tracker.remove('ghost')).toBe(false);
   });
 });
 
 describe('InitiativeTracker — phase transitions', () => {
-  it('marks startedAt when phase first goes in-progress', () => {
-    tracker.create(baseInput());
-    const updated = tracker.setPhaseStatus('demo', 'plan', 'in-progress');
+  it('marks startedAt when phase first goes in-progress', async () => {
+    await tracker.create(baseInput());
+    const updated = await tracker.setPhaseStatus('demo', 'plan', 'in-progress');
     expect(updated.phases[0].status).toBe('in-progress');
     expect(updated.phases[0].startedAt).toBeDefined();
     expect(updated.phases[0].completedAt).toBeUndefined();
   });
 
-  it('marks completedAt when phase first goes done', () => {
-    tracker.create(baseInput());
-    const updated = tracker.setPhaseStatus('demo', 'plan', 'done');
+  it('marks completedAt when phase first goes done', async () => {
+    await tracker.create(baseInput());
+    const updated = await tracker.setPhaseStatus('demo', 'plan', 'done');
     expect(updated.phases[0].completedAt).toBeDefined();
   });
 
-  it('advances currentPhaseIndex past completed phases', () => {
-    tracker.create(baseInput());
-    const a = tracker.setPhaseStatus('demo', 'plan', 'done');
+  it('advances currentPhaseIndex past completed phases', async () => {
+    await tracker.create(baseInput());
+    const a = await tracker.setPhaseStatus('demo', 'plan', 'done');
     expect(a.currentPhaseIndex).toBe(1);
-    const b = tracker.setPhaseStatus('demo', 'build', 'done');
+    const b = await tracker.setPhaseStatus('demo', 'build', 'done');
     expect(b.currentPhaseIndex).toBe(2);
   });
 
-  it('marks initiative completed when all phases are done', () => {
-    tracker.create(baseInput());
-    tracker.setPhaseStatus('demo', 'plan', 'done');
-    tracker.setPhaseStatus('demo', 'build', 'done');
-    const final = tracker.setPhaseStatus('demo', 'ship', 'done');
+  it('marks initiative completed when all phases are done', async () => {
+    await tracker.create(baseInput());
+    await tracker.setPhaseStatus('demo', 'plan', 'done');
+    await tracker.setPhaseStatus('demo', 'build', 'done');
+    const final = await tracker.setPhaseStatus('demo', 'ship', 'done');
     expect(final.status).toBe('completed');
     expect(final.currentPhaseIndex).toBe(2);
   });
 
-  it('reverts to active when a completed initiative has a phase reopened', () => {
-    tracker.create(baseInput());
-    tracker.setPhaseStatus('demo', 'plan', 'done');
-    tracker.setPhaseStatus('demo', 'build', 'done');
-    tracker.setPhaseStatus('demo', 'ship', 'done');
-    const reopened = tracker.setPhaseStatus('demo', 'ship', 'in-progress');
+  it('reverts to active when a completed initiative has a phase reopened', async () => {
+    await tracker.create(baseInput());
+    await tracker.setPhaseStatus('demo', 'plan', 'done');
+    await tracker.setPhaseStatus('demo', 'build', 'done');
+    await tracker.setPhaseStatus('demo', 'ship', 'done');
+    const reopened = await tracker.setPhaseStatus('demo', 'ship', 'in-progress');
     expect(reopened.status).toBe('active');
   });
 
-  it('throws on unknown phase id', () => {
-    tracker.create(baseInput());
-    expect(() => tracker.setPhaseStatus('demo', 'ghost', 'done')).toThrow(/not found/);
+  it('throws on unknown phase id', async () => {
+    await tracker.create(baseInput());
+    await expect(tracker.setPhaseStatus('demo', 'ghost', 'done')).rejects.toThrow(/not found/);
   });
 
-  it('throws on unknown initiative id', () => {
-    expect(() => tracker.setPhaseStatus('ghost', 'plan', 'done')).toThrow(/not found/);
+  it('throws on unknown initiative id', async () => {
+    await expect(tracker.setPhaseStatus('ghost', 'plan', 'done')).rejects.toThrow(/not found/);
   });
 });
 
 describe('InitiativeTracker — persistence', () => {
-  it('round-trips through a second instance', () => {
-    tracker.create(baseInput());
-    tracker.setPhaseStatus('demo', 'plan', 'done');
+  it('round-trips through a second instance', async () => {
+    await tracker.create(baseInput());
+    await tracker.setPhaseStatus('demo', 'plan', 'done');
     const reloaded = new InitiativeTracker(tmpDir);
     const fetched = reloaded.get('demo');
     expect(fetched).toBeDefined();
@@ -185,8 +188,8 @@ describe('InitiativeTracker — persistence', () => {
     expect(fetched!.currentPhaseIndex).toBe(1);
   });
 
-  it('writes to initiatives.json in stateDir', () => {
-    tracker.create(baseInput());
+  it('writes to initiatives.json in stateDir', async () => {
+    await tracker.create(baseInput());
     const raw = JSON.parse(fs.readFileSync(path.join(tmpDir, 'initiatives.json'), 'utf-8'));
     expect(raw.initiatives).toHaveLength(1);
     expect(raw.initiatives[0].id).toBe('demo');
@@ -206,8 +209,8 @@ describe('InitiativeTracker — persistence', () => {
 });
 
 describe('InitiativeTracker — digest', () => {
-  it('emits needs-user items first', () => {
-    tracker.create({
+  it('emits needs-user items first', async () => {
+    await tracker.create({
       ...baseInput('a'),
       needsUser: true,
       needsUserReason: 'pick scope',
@@ -218,49 +221,49 @@ describe('InitiativeTracker — digest', () => {
     expect(d.items[0].detail).toBe('pick scope');
   });
 
-  it('emits ready-to-advance when current phase is done but more remain', () => {
-    tracker.create(baseInput('a'));
-    tracker.setPhaseStatus('a', 'plan', 'done');
+  it('emits ready-to-advance when current phase is done but more remain', async () => {
+    await tracker.create(baseInput('a'));
+    await tracker.setPhaseStatus('a', 'plan', 'done');
     const d = tracker.digest();
     expect(d.items).toHaveLength(1);
     expect(d.items[0].reason).toBe('ready-to-advance');
     expect(d.items[0].detail).toMatch(/Plan.*Build/);
   });
 
-  it('emits stale when lastTouchedAt is older than STALE_THRESHOLD_MS', () => {
-    tracker.create(baseInput('a'));
+  it('emits stale when lastTouchedAt is older than STALE_THRESHOLD_MS', async () => {
+    await tracker.create(baseInput('a'));
     const future = new Date(Date.now() + STALE_THRESHOLD_MS + 60_000);
     const d = tracker.digest(future);
     expect(d.items).toHaveLength(1);
     expect(d.items[0].reason).toBe('stale');
   });
 
-  it('emits next-check-due when nextCheckAt is in the past', () => {
+  it('emits next-check-due when nextCheckAt is in the past', async () => {
     const pastISO = new Date(Date.now() - 60_000).toISOString();
-    tracker.create({ ...baseInput('a'), nextCheckAt: pastISO });
+    await tracker.create({ ...baseInput('a'), nextCheckAt: pastISO });
     const d = tracker.digest();
     expect(d.items).toHaveLength(1);
     expect(d.items[0].reason).toBe('next-check-due');
   });
 
-  it('does NOT emit for completed initiatives', () => {
-    tracker.create(baseInput('a'));
-    tracker.setPhaseStatus('a', 'plan', 'done');
-    tracker.setPhaseStatus('a', 'build', 'done');
-    tracker.setPhaseStatus('a', 'ship', 'done');
+  it('does NOT emit for completed initiatives', async () => {
+    await tracker.create(baseInput('a'));
+    await tracker.setPhaseStatus('a', 'plan', 'done');
+    await tracker.setPhaseStatus('a', 'build', 'done');
+    await tracker.setPhaseStatus('a', 'ship', 'done');
     const d = tracker.digest();
     expect(d.items).toHaveLength(0);
   });
 
-  it('does NOT emit for archived initiatives', () => {
-    tracker.create(baseInput('a'));
-    tracker.update('a', { status: 'archived' });
+  it('does NOT emit for archived initiatives', async () => {
+    await tracker.create(baseInput('a'));
+    await tracker.update('a', { status: 'archived' });
     const future = new Date(Date.now() + STALE_THRESHOLD_MS * 10);
     expect(tracker.digest(future).items).toHaveLength(0);
   });
 
-  it('returns empty items when everything is healthy', () => {
-    tracker.create(baseInput('a'));
+  it('returns empty items when everything is healthy', async () => {
+    await tracker.create(baseInput('a'));
     const d = tracker.digest();
     expect(d.items).toEqual([]);
   });

--- a/tests/unit/initiative-tracker-taskflow.test.ts
+++ b/tests/unit/initiative-tracker-taskflow.test.ts
@@ -1,0 +1,337 @@
+/**
+ * InitiativeTracker × TaskFlow Phase 4 migration tests.
+ *
+ * Real SQLite (no mocking) per /instar-dev constraints. Verifies:
+ *   1. create() writes a TaskFlow record under controllerId=InitiativeTracker.
+ *   2. setPhaseStatus advances `currentStep` on the flow.
+ *   3. update({needsUser:true}) drives the flow into `waiting` with
+ *      a `human-review` waitJson; clearing needsUser resumes to running.
+ *   4. update({blockers:[...]}) drives the flow into `waiting`.
+ *   5. setPhaseStatus to all-done drives the flow to `succeeded`.
+ *   6. update({status:'archived'}) drives the flow to `cancelled`.
+ *   7. update({status:'abandoned'}) drives the flow to `failed`.
+ *   8. remove() drives the flow to `cancelled` and removes from cache.
+ *   9. migrateExistingToTaskFlow is idempotent — running twice = no
+ *      duplicates; second pass reports alreadyExisted == count.
+ *  10. All existing InitiativeTracker behavior (validation, digest,
+ *      legacy JSON fallback) still works when TaskFlow is wired.
+ *  11. Reads after a write reflect the latest TaskFlow stateJson.
+ *
+ * Per spec § Phase 4 (lines 645–648), TaskFlow is read-authoritative and
+ * the legacy JSON file is migrated once and never written again while
+ * TaskFlow is wired.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TaskFlowStore } from '../../src/tasks/task-flow-registry.store.sqlite.js';
+import { TaskFlowRegistry } from '../../src/tasks/TaskFlowRegistry.js';
+import {
+  InitiativeTracker,
+  INITIATIVE_TASKFLOW_CONTROLLER_ID,
+  type InitiativeCreateInput,
+} from '../../src/core/InitiativeTracker.js';
+
+interface Rig {
+  dir: string;
+  store: TaskFlowStore;
+  registry: TaskFlowRegistry;
+  tracker: InitiativeTracker;
+  cleanup: () => Promise<void>;
+}
+
+async function rig(opts: { wireTaskFlow: boolean; preexistingJson?: unknown[] } = {
+  wireTaskFlow: true,
+}): Promise<Rig> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'init-taskflow-test-'));
+  const store = new TaskFlowStore({ dbPath: path.join(dir, 'task-flows.db') });
+  await store.open();
+  const registry = new TaskFlowRegistry({ store });
+  if (opts.preexistingJson) {
+    fs.writeFileSync(
+      path.join(dir, 'initiatives.json'),
+      JSON.stringify({ initiatives: opts.preexistingJson }, null, 2)
+    );
+  }
+  const tracker = new InitiativeTracker(dir);
+  if (opts.wireTaskFlow) {
+    tracker.setTaskFlowRegistry(registry, 'test-instance-1');
+  }
+  return {
+    dir,
+    store,
+    registry,
+    tracker,
+    cleanup: async () => {
+      store.close();
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/initiative-tracker-taskflow.test.ts',
+      });
+    },
+  };
+}
+
+function baseInput(id = 'demo'): InitiativeCreateInput {
+  return {
+    id,
+    title: 'Demo Initiative',
+    description: 'A worked example for TaskFlow tests.',
+    phases: [
+      { id: 'plan', name: 'Plan' },
+      { id: 'build', name: 'Build' },
+      { id: 'ship', name: 'Ship' },
+    ],
+  };
+}
+
+describe('InitiativeTracker × TaskFlow Phase 4 — basic lifecycle', () => {
+  let r: Rig;
+  afterEach(async () => {
+    if (r) await r.cleanup();
+  });
+
+  it('create() writes a TaskFlow record under controllerId=InitiativeTracker', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows).toHaveLength(1);
+    expect(flows[0].ownerKey).toBe('initiative:demo');
+    expect(flows[0].goal).toBe('Demo Initiative');
+    // Active, no blockers ⇒ flow should be running on first phase.
+    expect(flows[0].status).toBe('running');
+    expect(flows[0].currentStep).toBe('plan');
+  });
+
+  it('create() persists the full Initiative shape in stateJson', async () => {
+    r = await rig();
+    const created = await r.tracker.create(baseInput());
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    const state = flows[0].stateJson as { initiative: typeof created };
+    expect(state.initiative.id).toBe('demo');
+    expect(state.initiative.phases).toHaveLength(3);
+    expect(state.initiative.status).toBe('active');
+  });
+
+  it('rejects duplicate ids via TaskFlow lookup', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await expect(r.tracker.create(baseInput())).rejects.toThrow(/already exists/);
+  });
+
+  it('setPhaseStatus advances currentStep on the flow', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.setPhaseStatus('demo', 'plan', 'done');
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('running');
+    expect(flows[0].currentStep).toBe('build');
+  });
+
+  it('all-phases-done drives the flow to succeeded', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.setPhaseStatus('demo', 'plan', 'done');
+    await r.tracker.setPhaseStatus('demo', 'build', 'done');
+    const final = await r.tracker.setPhaseStatus('demo', 'ship', 'done');
+    expect(final.status).toBe('completed');
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('succeeded');
+  });
+
+  it('update({needsUser:true}) drives the flow to waiting with human-review', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.update('demo', { needsUser: true, needsUserReason: 'pick scope' });
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('waiting');
+    expect(flows[0].waitJson?.kind).toBe('human-review');
+    if (flows[0].waitJson?.kind === 'human-review') {
+      expect(flows[0].waitJson.question).toBe('pick scope');
+    }
+  });
+
+  it('clearing needsUser resumes from waiting back to running', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.update('demo', { needsUser: true, needsUserReason: 'pick scope' });
+    let flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('waiting');
+    await r.tracker.update('demo', { needsUser: false, needsUserReason: null });
+    flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('running');
+    expect(flows[0].waitJson).toBeUndefined();
+  });
+
+  it('update({blockers:[...]}) drives the flow to waiting', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.update('demo', { blockers: ['external service down'] });
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('waiting');
+    expect(flows[0].waitJson?.kind).toBe('human-review');
+  });
+
+  it('update({status:"archived"}) drives the flow to cancelled', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.update('demo', { status: 'archived' });
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('cancelled');
+  });
+
+  it('update({status:"abandoned"}) drives the flow to failed', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.update('demo', { status: 'abandoned' });
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('failed');
+  });
+
+  it('remove() drives the flow to cancelled and removes from cache', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    expect(await r.tracker.remove('demo')).toBe(true);
+    expect(r.tracker.get('demo')).toBeUndefined();
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows[0].status).toBe('cancelled');
+  });
+
+  it('reads after a write reflect the latest TaskFlow stateJson', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.update('demo', { description: 'updated description' });
+    const fetched = r.tracker.get('demo');
+    expect(fetched?.description).toBe('updated description');
+  });
+});
+
+describe('InitiativeTracker × TaskFlow — backfill idempotency', () => {
+  let r: Rig;
+  afterEach(async () => {
+    if (r) await r.cleanup();
+  });
+
+  it('migrateExistingToTaskFlow is idempotent — second pass produces no duplicates', async () => {
+    const preexisting = [
+      {
+        id: 'legacy-a',
+        title: 'Legacy A',
+        description: 'A previously persisted initiative.',
+        status: 'active',
+        phases: [
+          { id: 'plan', name: 'Plan', status: 'in-progress', startedAt: '2026-04-01T00:00:00.000Z' },
+          { id: 'ship', name: 'Ship', status: 'pending' },
+        ],
+        currentPhaseIndex: 0,
+        lastTouchedAt: '2026-04-01T00:00:00.000Z',
+        needsUser: false,
+        blockers: [],
+        links: [],
+        createdAt: '2026-04-01T00:00:00.000Z',
+        updatedAt: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        id: 'legacy-b',
+        title: 'Legacy B',
+        description: 'A second pre-existing initiative, blocked.',
+        status: 'active',
+        phases: [{ id: 'phase-a', name: 'Phase A', status: 'pending' }],
+        currentPhaseIndex: 0,
+        lastTouchedAt: '2026-04-02T00:00:00.000Z',
+        needsUser: true,
+        needsUserReason: 'awaiting decision',
+        blockers: [],
+        links: [],
+        createdAt: '2026-04-02T00:00:00.000Z',
+        updatedAt: '2026-04-02T00:00:00.000Z',
+      },
+    ];
+    r = await rig({ wireTaskFlow: false, preexistingJson: preexisting });
+    // Cache should be loaded from the legacy file.
+    expect(r.tracker.list().map((i) => i.id).sort()).toEqual(['legacy-a', 'legacy-b']);
+    r.tracker.setTaskFlowRegistry(r.registry, 'test-instance-1');
+
+    const first = await r.tracker.migrateExistingToTaskFlow();
+    expect(first.created).toBe(2);
+    expect(first.alreadyExisted).toBe(0);
+
+    const second = await r.tracker.migrateExistingToTaskFlow();
+    expect(second.created).toBe(0);
+    expect(second.alreadyExisted).toBe(2);
+
+    // No duplicate flows.
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows).toHaveLength(2);
+    // legacy-b should be in waiting (needsUser=true).
+    const legacyB = flows.find((f) => f.ownerKey === 'initiative:legacy-b')!;
+    expect(legacyB.status).toBe('waiting');
+    if (legacyB.waitJson?.kind === 'human-review') {
+      expect(legacyB.waitJson.question).toBe('awaiting decision');
+    }
+  });
+
+  it('after wiring, legacy initiatives.json is no longer overwritten', async () => {
+    r = await rig({ wireTaskFlow: true });
+    const beforeStat = fs.existsSync(path.join(r.dir, 'initiatives.json'));
+    expect(beforeStat).toBe(false);
+    await r.tracker.create(baseInput());
+    const afterStat = fs.existsSync(path.join(r.dir, 'initiatives.json'));
+    // No JSON file should be written when TaskFlow is wired.
+    expect(afterStat).toBe(false);
+  });
+
+  it('TaskFlow disabled: falls back to legacy JSON storage', async () => {
+    r = await rig({ wireTaskFlow: false });
+    const created = await r.tracker.create(baseInput());
+    expect(created.id).toBe('demo');
+    expect(fs.existsSync(path.join(r.dir, 'initiatives.json'))).toBe(true);
+    const flows = r.registry.findByControllerId(INITIATIVE_TASKFLOW_CONTROLLER_ID);
+    expect(flows).toHaveLength(0);
+  });
+});
+
+describe('InitiativeTracker × TaskFlow — read consistency + digest', () => {
+  let r: Rig;
+  afterEach(async () => {
+    if (r) await r.cleanup();
+  });
+
+  it('digest reads from TaskFlow when wired', async () => {
+    r = await rig();
+    await r.tracker.create({
+      ...baseInput('a'),
+      needsUser: true,
+      needsUserReason: 'decide scope',
+    });
+    const d = r.tracker.digest();
+    expect(d.items).toHaveLength(1);
+    expect(d.items[0].reason).toBe('needs-user');
+    expect(d.items[0].detail).toBe('decide scope');
+  });
+
+  it('list() picks up new initiatives written through TaskFlow by another caller', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput('a'));
+    await r.tracker.create(baseInput('b'));
+    const tracker2 = new InitiativeTracker(r.dir);
+    tracker2.setTaskFlowRegistry(r.registry, 'test-instance-2');
+    expect(tracker2.list().map((i) => i.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('persistence: a fresh instance with TaskFlow wired sees prior state', async () => {
+    r = await rig();
+    await r.tracker.create(baseInput());
+    await r.tracker.setPhaseStatus('demo', 'plan', 'done');
+    const tracker2 = new InitiativeTracker(r.dir);
+    tracker2.setTaskFlowRegistry(r.registry, 'test-instance-2');
+    const fetched = tracker2.get('demo');
+    expect(fetched).toBeDefined();
+    expect(fetched!.phases[0].status).toBe('done');
+    expect(fetched!.currentPhaseIndex).toBe(1);
+  });
+});

--- a/tests/unit/routes-initiatives.test.ts
+++ b/tests/unit/routes-initiatives.test.ts
@@ -40,41 +40,41 @@ function mountRoutes(tr: InitiativeTracker): { server: Server; port: number } {
     if (!i) return res.status(404).json({ error: 'not found' });
     res.json(i);
   });
-  router.post('/initiatives', (req, res) => {
+  router.post('/initiatives', async (req, res) => {
     const { id, title, description, phases } = req.body ?? {};
     if (typeof id !== 'string' || !initiativeIdRe.test(id)) return res.status(400).json({ error: 'bad id' });
     if (typeof title !== 'string' || !title.trim()) return res.status(400).json({ error: 'bad title' });
     if (typeof description !== 'string') return res.status(400).json({ error: 'bad description' });
     if (!Array.isArray(phases) || phases.length === 0) return res.status(400).json({ error: 'bad phases' });
     try {
-      const created = tr.create(req.body);
+      const created = await tr.create(req.body);
       res.status(201).json(created);
     } catch (err) {
       res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
     }
   });
-  router.patch('/initiatives/:id', (req, res) => {
+  router.patch('/initiatives/:id', async (req, res) => {
     try {
-      res.json(tr.update(req.params.id, req.body ?? {}));
+      res.json(await tr.update(req.params.id, req.body ?? {}));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       res.status(msg.includes('not found') ? 404 : 400).json({ error: msg });
     }
   });
-  router.post('/initiatives/:id/phase/:phaseId', (req, res) => {
+  router.post('/initiatives/:id/phase/:phaseId', async (req, res) => {
     const { status } = req.body ?? {};
     if (!['pending', 'in-progress', 'done', 'blocked'].includes(status)) {
       return res.status(400).json({ error: 'bad status' });
     }
     try {
-      res.json(tr.setPhaseStatus(req.params.id, req.params.phaseId, status));
+      res.json(await tr.setPhaseStatus(req.params.id, req.params.phaseId, status));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       res.status(msg.includes('not found') ? 404 : 400).json({ error: msg });
     }
   });
-  router.delete('/initiatives/:id', (req, res) => {
-    if (!tr.remove(req.params.id)) return res.status(404).json({ error: 'not found' });
+  router.delete('/initiatives/:id', async (req, res) => {
+    if (!(await tr.remove(req.params.id))) return res.status(404).json({ error: 'not found' });
     res.json({ id: req.params.id, deleted: true });
   });
 

--- a/upgrades/side-effects/taskflow-phase4.md
+++ b/upgrades/side-effects/taskflow-phase4.md
@@ -1,0 +1,377 @@
+# Side-Effects Review — TaskFlow Phase 4 (InitiativeTracker migration to TaskFlow)
+
+**Version / slug:** `taskflow-phase4`
+**Date:** 2026-05-10
+**Author:** Echo
+**Second-pass reviewer:** required (touches state-machine authority for an
+existing user-facing surface — Initiative CRUD via HTTP + Initiatives dashboard
+tab — and changes the storage substrate)
+
+## Summary of the change
+
+Phase 4 replaces `InitiativeTracker`'s internal state with **TaskFlow as the
+single source of truth** when TaskFlow is enabled. Each Initiative is one
+TaskFlow record under `controllerId="InitiativeTracker"`,
+`ownerKey="initiative:<id>"`, `idempotencyKey="initiative:<id>"`. The full
+Initiative shape is persisted in `stateJson`. The active phase id maps to
+`currentStep`; `needsUser` / blockers map to `setFlowWaiting({kind:"human-review"})`;
+the four Initiative statuses map to TaskFlow terminal statuses
+(active/running, completed/succeeded, archived/cancelled, abandoned/failed).
+
+Per spec (`docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md` § Phase 4, lines
+645–648), this is a **clean migration**, not a dual-write. The existing
+`.instar/initiatives.json` artifact is read once on startup as a backfill
+source; `migrateExistingToTaskFlow()` (called by the server on TaskFlow init)
+copies legacy initiatives into TaskFlow, idempotent via
+`registry.findByIdempotency(...)`. After backfill, the JSON file is never
+written again while TaskFlow is wired — TaskFlow's SQLite is the durable
+store. When TaskFlow is **not** enabled (`config.taskFlow.enabled !== true`),
+InitiativeTracker continues to read/write the legacy JSON file as before;
+existing installs are unaffected.
+
+The public API is now `async` for mutators (`create`, `update`,
+`setPhaseStatus`, `remove`). HTTP route handlers awaited accordingly. Reads
+(`get`, `list`, `digest`) remain synchronous — they pull from the in-memory
+cache that mirrors TaskFlow's state. Cache reads are O(1) and cache-warm by
+construction (refresh on every read for `list`/`digest`, single-row read on
+`get`).
+
+A `_removed: true` tombstone marker is stamped into `stateJson` before
+cancelling a flow on `remove()`, so subsequent reads (which can't tell
+"deleted by user" from "archived" via TaskFlow status alone — both are
+`cancelled`) can hide deleted initiatives without losing the audit trail.
+
+Files touched:
+- `src/core/InitiativeTracker.ts` — full rewrite of storage layer; legacy JSON
+  fallback retained behind `isTaskFlowEnabled()` gate; TaskFlow path is
+  default when wired.
+- `src/server/routes.ts` — five route handlers converted to `async` to
+  await the new async mutators.
+- `src/commands/server.ts` — Phase 4 wiring: calls
+  `initiativeTracker.setTaskFlowRegistry(...)` and
+  `initiativeTracker.migrateExistingToTaskFlow()` after TaskFlow boot.
+- `tests/unit/InitiativeTracker.test.ts` — updated to await async mutators
+  (28 cases).
+- `tests/unit/routes-initiatives.test.ts` — handler mirrors converted to
+  async (15 cases).
+- `tests/unit/initiative-tracker-taskflow.test.ts` (new) — 18 cases covering
+  the TaskFlow-wired path: lifecycle, blockers↔waiting, terminal mapping,
+  remove tombstone, backfill idempotency, cross-instance read consistency.
+- `upgrades/side-effects/taskflow-phase4.md` (this file).
+
+## Decision-point inventory
+
+- `InitiativeTracker.setTaskFlowRegistry(registry, instanceId)` — **add** —
+  switches the storage backend from JSON to TaskFlow. Idempotent. Layers
+  existing TaskFlow rows over the legacy-loaded cache without clearing it,
+  so backfill candidates remain visible to `migrateExistingToTaskFlow()`.
+- `InitiativeTracker.persistThroughTaskFlow(initiative)` — **add** — internal
+  state-machine driver: takes an Initiative, walks the TaskFlow flow from its
+  current status to the desired target (running / waiting / succeeded /
+  failed / cancelled), and re-projects the Initiative back from the flow's
+  `stateJson`. Pure mechanic; no judgment, no signal authority.
+- `InitiativeTracker.patchStateJson(flow, stateJson)` — **add** — internal
+  helper that updates a `running` flow's `stateJson` via a
+  `setFlowWaiting → resumeFlow` round-trip with a sentinel
+  `human-review` waitJson. The wait is opened and closed in the same call so
+  no external observer sees `waiting`.
+- `InitiativeTracker.migrateExistingToTaskFlow()` — **add** — one-shot
+  backfill of legacy-JSON-loaded initiatives. Idempotent via
+  `findIdempotent` on the deterministic `idempotencyKey`.
+- `InitiativeTracker.isTombstoned(flow)` — **add** — read-side filter that
+  treats flows with `stateJson._removed=true` as deleted. Hides them from
+  `get` / `list` / `digest`.
+- `InitiativeTracker.{create, update, setPhaseStatus, remove}` — **change** —
+  signature is now `async` and returns `Promise<...>`. Behavior is identical
+  in legacy-JSON mode; in TaskFlow mode, the return value is sourced from
+  TaskFlow's `stateJson` after transitions settle.
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable.**
+
+Phase 4 introduces no new gating or filter authority. The state-machine
+transition validations in `TaskFlowRegistry` (e.g. `unauthorized_controller`,
+`invalid_transition`, `revision_conflict`) are inherited from Phase 1 and not
+new in this change. InitiativeTracker validates input the same way it did
+before (`id` regex, non-empty phases, duplicate-id check) — those checks
+remain at the same strictness.
+
+The duplicate-id check on `create()` now consults TaskFlow first when wired
+(`findFlowIdForInitiative(id)` → not null ⇒ duplicate), then falls back to
+the in-memory cache. This is structurally tighter than the legacy
+`Map.has(id)` check because TaskFlow records survive across process restarts;
+a duplicate id created in one process and visible in TaskFlow will be
+rejected in another. That's a feature, not over-blocking.
+
+## 2. Under-block
+
+**Failure modes the change does not catch:**
+
+- A buggy controller (other than InitiativeTracker) that writes flows under
+  `controllerId="InitiativeTracker"` would shadow legitimate initiatives.
+  Mitigation: `unauthorized_controller` enforcement at the OCC layer prevents
+  cross-controller mutation. Phase 5 will add per-controller rate limits and
+  active-flow caps (default 50/controller) that further bound this risk.
+- Two server instances pointing at the same `task-flows.db` violate the
+  single-writer assumption. Phase 1 documents this as a v1 constraint.
+  Phase 4 inherits the same constraint.
+- A crash mid-`persistThroughTaskFlow` (e.g. between `setFlowWaiting` and
+  `resumeFlow` of a `patchStateJson` round-trip) leaves the flow in
+  `waiting` with the sentinel `__statePatch__` question. `TaskFlowMaintenanceSweeper`
+  will mark it `lost` after `HUMAN_REVIEW_LOST_MS` (default 30 days). Before
+  then, the flow is observable to admin tools but not to end users (no
+  Telegram routing for the sentinel waitJson, since `notifyPolicy` defaults
+  to `silent`). Risk is low: the round-trip is two synchronous-under-the-hood
+  better-sqlite3 calls; a server crash mid-trip is very unlikely.
+- `_removed` tombstones grow in the database over time. Phase 5 archival
+  policy (Open Question 2 in the spec) will address terminal-flow retention.
+  Until then: every removal leaves one cancelled+tombstoned row.
+- The legacy `initiatives.json` file is **not** deleted on backfill. It
+  remains as a historical artifact. If an operator disables TaskFlow after
+  using TaskFlow for some time, fresh writes go back to JSON, and the JSON
+  file is whatever was last loaded from disk — potentially stale relative to
+  TaskFlow. Documented behavior; rolling back across the TaskFlow boundary
+  is operator-supervised.
+
+## 3. Level-of-abstraction fit
+
+The TaskFlow integration is on `InitiativeTracker` itself rather than a
+separate `InitiativeTaskFlowAdapter` class, mirroring the Phase 3a decision
+for `EvolutionManager`. Reasoning is the same: the persistence logic is
+~150 lines of class methods conceptually paired with InitiativeTracker's
+existing CRUD; an adapter would create indirect coupling without removing
+complexity.
+
+The `patchStateJson` helper uses the
+`setFlowWaiting → resumeFlow` round-trip rather than introducing a new
+TaskFlow API. Reasoning: TaskFlow's contract is that `stateJson` updates ride
+on `statePatch` arguments to existing transitions; adding a dedicated
+"patch state" endpoint would broaden the registry's surface and weaken the
+"every transition is audit-loggable" property. The round-trip costs two
+revision bumps but stays inside Phase 1's contract.
+
+The `_removed` tombstone is a data-layer marker rather than a TaskFlow-status
+extension. Reasoning: TaskFlow's status enum is closed (Phase 1 spec).
+"User asked to remove this" and "user archived this" both terminate at
+`cancelled`; the only way to distinguish them later is via `stateJson`.
+Tombstones are a clean data-only convention.
+
+The async API change is the right shape: TaskFlow operations return
+`Promise<ApplyResult>`, and propagating that up through InitiativeTracker
+keeps the call graph honest about I/O. The five HTTP routes were trivially
+async-ified.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No new authority surface.** Phase 4 is a storage-layer migration. The
+  authority over Initiative state — `is this initiative allowed to advance
+  to `done`? does this user own this initiative?` — is unchanged from before
+  (the HTTP layer's auth-token check is the only authorization, and it's
+  unchanged). InitiativeTracker is a **TaskFlow consumer**, not a gate.
+
+Specifically:
+- `persistThroughTaskFlow` is a pure mechanic that translates Initiative
+  shape → TaskFlow API calls. It has no judgment about which initiatives
+  should exist or what statuses are valid; it faithfully mirrors what the
+  caller already decided.
+- Status mapping is data-driven: an Initiative whose status field is `'archived'`
+  drives the flow to `cancelled`. The mapping is structural, not adjudicative.
+- `setFlowWaiting({kind:"human-review"})` is the same wait kind any other
+  consumer would use; we don't reuse the "waiting" status to mean anything
+  novel.
+- Tombstones are a data-layer convention (`stateJson._removed=true`), not a
+  signal that another subsystem reads to decide anything. They're a hint to
+  this single class's read filter.
+
+No brittle blocker is introduced. No existing authority is shadowed. The
+TaskFlow registry's existing OCC + scope checks remain the only structural
+authority.
+
+---
+
+## 5. Interactions
+
+- **Phase 3a EvolutionManager dual-write** — Disjoint controllers (`EvolutionManager` vs
+  `InitiativeTracker`); no shared rows. `findByControllerId` queries are
+  controller-scoped at the SQL level. The DivergenceChecker only watches
+  `EvolutionManager`-controlled flows; Phase 4 introduces no parallel checker
+  for InitiativeTracker because there's no JSON↔TaskFlow dual-write to
+  diverge — TaskFlow is the single source of truth.
+- **TaskFlowMaintenanceSweeper** — Sees Initiative flows in `running` and
+  `waiting` states, both of which are normal. Default thresholds apply:
+  `RUNNING_LOST_MS=6h`, `HUMAN_REVIEW_LOST_MS=30d`. A long-blocked
+  initiative (>30 days `needsUser=true`) would be marked `lost` and would
+  disappear from InitiativeTracker's read view. This is appropriate
+  behavior — a 30-day-blocked initiative needs human triage, and the
+  ledger note from sweeper marking will surface it. If desired, the user
+  can resurrect via `update({needsUser:false})` on a fresh initiative.
+- **TaskFlowDueWaker** — Only fires on `scheduled-tick` waits. Initiative
+  flows use `human-review` waits. No interaction.
+- **ThreadlineFlowBridge** — Only consumes `cross-agent-callback` waits. No
+  interaction with `human-review` waits used here.
+- **Initiative HTTP routes** — Five routes converted to `async`. Behavior
+  unchanged; client-side compatibility preserved (responses are the same
+  Initiative JSON shape).
+- **Dashboard "Initiatives" tab** — Reads via the existing routes. No
+  change needed.
+- **Daily digest job** — Calls `initiativeTracker.digest()` synchronously.
+  Digest still works synchronously because TaskFlow reads are sync (the
+  registry's `findByControllerId` is a synchronous SQL query). Digest
+  filters by `status==='active'`, which projects from TaskFlow's
+  stateJson — identical semantics.
+- **Cross-instance read consistency** — When two `InitiativeTracker`
+  instances share the same TaskFlow registry (rare; only relevant in tests
+  today), they see each other's writes via `findByControllerId` on every
+  read. Verified by test `list() picks up new initiatives written through
+  TaskFlow by another caller`.
+- **Cache coherence** — Read-side cache (`this.initiatives` Map) is
+  refreshed via `findByControllerId` on every `list()` and `digest()` call,
+  and via `findByIdempotency` on every `get()`. The cache exists for legacy
+  fallback; it is effectively a stale view in TaskFlow mode, always
+  bypassed for reads.
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** No new surface. New rows go to the
+  agent's own `.instar/task-flows.db` (already in the git-sync deny-list as
+  of Phase 1). No cross-agent visibility.
+- **Other users of the install base:** Phase 4 is gated on
+  `config.taskFlow.enabled` (default off, established in Phase 1). Existing
+  installs with TaskFlow disabled continue to use the legacy JSON path
+  unchanged. Existing installs with TaskFlow enabled get a one-shot
+  migration on the first server boot after upgrading; the migration is
+  idempotent and logged.
+- **External systems:** None. No outbound HTTP, no LLM calls, no Telegram
+  sends. Initiative `notifyPolicy` defaults to `silent` (Phase 1 default).
+- **Persistent state:** New rows written to `.instar/task-flows.db` for
+  every initiative. `.instar/initiatives.json` remains on disk as a
+  read-only historical artifact when TaskFlow is wired.
+- **Timing or runtime conditions:** The startup migration runs once per
+  server start, sequentially after sweeper/waker boot. A backfill of N
+  initiatives makes up to ~5N registry calls (create + start + optional
+  setFlowWaiting + optional finishFlow/failFlow/cancelFlow); for the typical
+  N≤20 initiatives, sub-second. Each runtime mutation costs 2–4 registry
+  calls; user-perceived latency is dominated by HTTP round-trip, not
+  TaskFlow write time.
+
+## 7. Rollback cost
+
+- **Hot-fix release:** Revert the PR. Restart the server. Existing
+  `task-flows.db` rows for `controllerId="InitiativeTracker"` remain in the
+  table but become unreferenced (the next-version InitiativeTracker would
+  read JSON instead). No data corruption. If `taskFlow.enabled` was true
+  during Phase 4 and JSON state had not been written for some time, a
+  rollback would briefly read whatever the JSON file held when TaskFlow was
+  first wired — typically the last pre-migration snapshot. Operators can
+  re-enable TaskFlow to restore the post-migration state.
+- **Data migration:** None on rollback. To clean up: `DELETE FROM flows
+  WHERE controller_id='InitiativeTracker'`. Optional and not required for
+  correctness.
+- **Agent state repair:** None. Disabling `taskFlow.enabled` after rollback
+  is the entire repair.
+- **User visibility:** A handful of initiatives may regress to a stale state
+  if TaskFlow was the source of truth and significant mutations happened
+  there. For agents with a small initiative count (typical ≤10), this is
+  recoverable by manual re-update through the API. For larger counts, an
+  operator can write a one-off export script that reads from TaskFlow and
+  writes back to `initiatives.json` before disabling.
+
+---
+
+## Conclusion
+
+Phase 4 ships InitiativeTracker as a TaskFlow consumer. Every TaskFlow
+surface introduced is either a read-only lookup (`findByControllerId`,
+`findByIdempotency`) or a pure mechanic (status-machine driver, tombstone
+marker, sentinel-wait state patcher). The new authority surface is zero —
+InitiativeTracker translates Initiative shapes into TaskFlow API calls and
+projects results back. Backfill is idempotent via the deterministic
+`idempotencyKey`. Rollback is `git revert` + `taskFlow.enabled: false`.
+Tests cover the core lifecycle, terminal mappings, blockers↔waiting
+transitions, remove-tombstone behavior, backfill idempotency, and
+cross-instance read consistency.
+
+The change is opt-in (gated on `taskFlow.enabled`), additive (legacy JSON
+mode unchanged), non-blocking (no new gates), and rollback-cheap. Cleared
+to ship pending second-pass concurrence.
+
+---
+
+## Second-pass review
+
+**Reviewer:** adversarial self-review (Task/Agent subagent tool not available
+in this skill harness; conducted in-line with a fresh adversarial framing
+after the primary implementation pass).
+**Independent read of the artifact: concur after fixes**
+
+Findings raised during adversarial pass and addressed in the same diff:
+
+1. **Cache-clear-on-wire wiped backfill candidates** — The first version of
+   `setTaskFlowRegistry` called `refreshCacheFromTaskFlow()` which
+   `clear()`'d the in-memory cache before populating it from TaskFlow. When
+   TaskFlow was wired *after* legacy JSON load (the production path), this
+   wiped the legacy initiatives that needed to be backfilled, and
+   `migrateExistingToTaskFlow()` saw an empty cache. **Fix applied:** added
+   `layerCacheFromTaskFlow()` which preserves legacy entries while merging in
+   TaskFlow rows. Backfill idempotency test now passes (`first.created==2`).
+
+2. **`remove()` left initiatives readable post-cancel** — Cancelled flows
+   still carried valid `stateJson.initiative` shape, so `get()` happily
+   returned them. The user-facing semantic of `remove()` is "gone, not
+   archived." **Fix applied:** stamp `stateJson._removed=true` via
+   `patchStateJson` before issuing `requestFlowCancel + cancelFlow`. Added
+   `isTombstoned()` filter in `get`/`list`/`digest` paths. Test
+   `remove() drives the flow to cancelled and removes from cache` now
+   passes.
+
+3. **Async-API breakage of HTTP routes** — Converting
+   `tracker.create/update/...` to `async` requires every caller to await.
+   The five `/initiatives/*` routes in `src/server/routes.ts` were
+   non-async; the test mirror in `tests/unit/routes-initiatives.test.ts`
+   was also non-async. **Fix applied:** all five route handlers and their
+   test mirror were converted to `async (req, res) => ...` with
+   `await tracker.X(...)`. Verified by re-running the routes test (15/15
+   passing).
+
+4. **Sentinel-wait could be promoted to user-visible state** — The
+   `__statePatch__` sentinel uses `kind:"human-review"` with the same wait
+   shape end users would see. If a server crashed between
+   `setFlowWaiting` and `resumeFlow`, the flow would end up `waiting` with
+   the sentinel question, potentially confusing operators. Considered: this
+   is a Phase 5 concern (sentinel hygiene); the sentinel question is
+   intentionally distinctive (`__statePatch__`), and the
+   `notifyPolicy: 'silent'` default ensures no Telegram routing fires.
+   `TaskFlowMaintenanceSweeper` will mark a stuck sentinel flow `lost`
+   after the human-review threshold (30 days). Documented under § 2
+   Under-block.
+
+5. **Cross-instance writes during a single test** — Initial test for
+   "list() picks up writes from another tracker" was over-strict: the
+   second tracker's read had to go through `findByControllerId`, which is
+   a fresh DB query — verified that this works even when the second
+   tracker's `setTaskFlowRegistry` is called after the first tracker
+   already wrote. No fix needed; test passes as-is.
+
+No remaining critical concerns. The change is cleared to ship.
+
+---
+
+## Evidence pointers
+
+- New tests: `npx vitest run tests/unit/initiative-tracker-taskflow.test.ts`
+  → 18/18 passing.
+- Existing tests: `npx vitest run tests/unit/InitiativeTracker.test.ts
+  tests/unit/routes-initiatives.test.ts tests/unit/dashboard-initiativesTab.test.ts
+  tests/unit/evolution-manager-taskflow-dualwrite.test.ts
+  tests/unit/divergence-checker.test.ts tests/unit/task-flow-registry.test.ts`
+  → 96/96 passing (28 + 15 + 9 + 10 + 10 + 24).
+- Typecheck: `npx tsc --noEmit` → clean.
+- Spec source of truth: `docs/specs/OPENCLAW-IMPORT-TASKFLOW-SPEC.md` § Phase
+  4 (lines 645–648).
+- Phase 1 trace context: `upgrades/side-effects/taskflow-phase1.md`.
+- Phase 3a trace context: `upgrades/side-effects/taskflow-phase3a.md`.


### PR DESCRIPTION
## Summary

- Replace InitiativeTracker's internal state with TaskFlow consumption per spec § Phase 4 (lines 645–648). When `config.taskFlow.enabled` is true, each Initiative is one TaskFlow record under `controllerId="InitiativeTracker"`, `ownerKey="initiative:<id>"`. Active phase id → `currentStep`; needsUser/blockers → `setFlowWaiting({kind:"human-review"})`; status → terminal mapping. Legacy JSON path preserved for TaskFlow-disabled installs.
- Public API mutators are now `async`; HTTP routes converted to `async/await`. Backfill is idempotent via `findIdempotent` on the deterministic `idempotencyKey`. `remove()` stamps a `_removed` tombstone in stateJson before cancelling so reads can hide deleted initiatives without losing the audit trail.
- 18 new test cases (`tests/unit/initiative-tracker-taskflow.test.ts`); 28 existing InitiativeTracker tests updated to async; all 153 tests in the relevant suites pass. TS clean. Side-effects review at `upgrades/side-effects/taskflow-phase4.md`.

## Test plan

- [x] `npx vitest run tests/unit/initiative-tracker-taskflow.test.ts` → 18/18
- [x] `npx vitest run tests/unit/InitiativeTracker.test.ts tests/unit/routes-initiatives.test.ts tests/unit/dashboard-initiativesTab.test.ts` → 52/52
- [x] `npx vitest run tests/unit/evolution-manager-taskflow-dualwrite.test.ts tests/unit/divergence-checker.test.ts tests/unit/task-flow-registry.test.ts tests/unit/threadline-flow-bridge.test.ts` → cross-controller regression green
- [x] `npx tsc --noEmit` → clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)