### PR TITLE
feat(memory): WikiClaim Phase 5 — backfill-evidence CLI + render hardening

### DIFF
--- a/docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md
+++ b/docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md
@@ -1,0 +1,412 @@
+---
+review-convergence: 2026-05-07T00:00:00Z
+approved: true
+---
+
+# Instar WikiClaim Evidence Provenance — Imported from OpenClaw
+
+> Per-claim provenance with evidence line-ranges so memory entities can trace back to specific source files and lines, not to a flat `source` string.
+
+**Status**: Review-Convergence
+**Converged**: 2026-05-07T00:00:00Z
+**Author**: Echo (parallel OpenClaw audit, 2026-05-07)
+**Date**: 2026-05-08
+**Origin**: §8 #2 of `.claude/research/openclaw-audit-instar-2026-05-07.md`. OpenClaw source: `extensions/memory-wiki/src/markdown.ts:11-101`. Audited at OpenClaw commit `f482e4d335`.
+**Related**: SemanticMemory, MemoryEntity, EpisodicMemory, EvolutionManager (bug-cluster claims), OPENCLAW-IMPORT-TASKFLOW-SPEC.md (consumer)
+
+---
+
+## Table of Contents
+
+1. [TL;DR](#tldr)
+2. [The Problem](#the-problem)
+3. [The OpenClaw Primitive](#the-openclaw-primitive)
+4. [Design Principles](#design-principles)
+5. [Schema Changes](#schema-changes)
+6. [Migration of Existing MemoryEntity Records](#migration-of-existing-memoryentity-records)
+7. [Producers](#producers)
+8. [Consumers](#consumers)
+9. [Storage and Privacy](#storage-and-privacy)
+10. [Migration Plan](#migration-plan)
+11. [Risks and Mitigations](#risks-and-mitigations)
+12. [Threat Model](#threat-model)
+13. [Open Questions](#open-questions)
+14. [Non-Goals](#non-goals)
+15. [Review Decisions](#review-decisions)
+16. [References](#references)
+
+---
+
+## TL;DR
+
+Today, `MemoryEntity.source` is a single string like `"session:7c2f"` or `"user:Justin"`. That makes it impossible to answer questions like "what specific feedback report led us to flag this bug as critical?" or "which commit line teaches us this pattern?".
+
+OpenClaw's `WikiClaim.evidence` is an array of `{kind, sourceId, path, lines, weight, confidence, privacyTier, note, updatedAt}` — every claim carries the receipts. Adding the same shape to Instar makes bug-cluster decisions, dispatch rationales, and pattern recognition auditable down to the source line.
+
+This is a small schema add (one new optional column + one TypeScript type) with high downstream leverage. The bug-cluster pipeline (and the imported TaskFlow flows that consume it) is the primary motivating use case.
+
+## The Problem
+
+`MemoryEntity` (`src/core/types.ts:2580-2614`) has provenance as a flat string:
+
+```typescript
+source: string;          // 'session:ABC' | 'observation' | 'user:Justin'
+sourceSession?: string;  // session id
+```
+
+Concrete failure modes today:
+
+1. **Bug clusters can't trace to specific feedback reports.** A `pattern` entity for "Telegram messages with file paths get blocked by tone gate" lives with `source: "observation"` — which feedback IDs informed this pattern is invisible.
+
+2. **Decisions can't trace to specific evidence.** A `decision` entity ("we use SQLite + JSONL dual-write for SemanticMemory") has no pointer to the original conversation lines or commit hashes that informed it. Re-evaluating the decision later requires reconstructing context manually.
+
+3. **Lessons can't quote their teacher.** A `lesson` entity ("never bypass pre-commit hooks with --no-verify") is just text; the original Justin chat or commit-rejection log is lost.
+
+4. **Cross-entity traceability is impossible.** "Show me everything that cites feedback report fb_abc123" is unanswerable today. Adding a typed evidence index makes it a single query.
+
+The downstream consequence: when Justin asks "why did Echo decide X?", the honest answer is often "I don't have the receipts, just the conclusion." That's the gap WikiClaim evidence closes.
+
+## The OpenClaw Primitive
+
+Source: `extensions/memory-wiki/src/markdown.ts:11-101`.
+
+```typescript
+export type WikiClaimEvidence = {
+  kind?: string;          // free-form e.g. 'feedback' | 'commit' | 'session' | 'document'
+  sourceId?: string;      // foreign key to the source system (e.g. fb_abc123)
+  path?: string;          // file path or URL
+  lines?: string;         // line range, e.g. "42-58" or "73"
+  weight?: number;        // 0-1 contribution weight
+  confidence?: number;    // 0-1 trust in the source
+  privacyTier?: string;   // 'public' | 'private' | 'sensitive' | ...
+  note?: string;          // free-form annotation
+  updatedAt?: string;     // ISO 8601
+};
+
+export type WikiClaim = {
+  id?: string;
+  text: string;
+  status?: string;        // 'open' | 'verified' | 'contested' | 'retired'
+  confidence?: number;
+  evidence: WikiClaimEvidence[];
+  updatedAt?: string;
+};
+```
+
+WikiClaims live inside compiled wiki pages alongside other structured data (relationships, person cards). For Instar we are NOT importing the whole wiki layer — only the `WikiClaimEvidence` shape, applied to existing `MemoryEntity` records.
+
+## Design Principles
+
+1. **Evidence is per-entity, not per-store.** Each `MemoryEntity` carries its own evidence array. No global "evidence database" — that would create N+1 join problems for every retrieval.
+2. **Evidence is append-only-mostly.** New evidence can be added; existing entries can have `updatedAt` refreshed; weights can be recomputed; but evidence entries are never destructively edited. Retire an evidence entry by adding a new entry with `kind:"supersedes-evidence"` pointing at the old `sourceId`.
+3. **Evidence supplements, doesn't replace, `source`.** The legacy `source: string` stays for compatibility. New entities populate both; old entities populate `evidence: []` and keep `source` as the only signal.
+4. **Privacy tier travels with evidence.** A `decision` entity may be public-scope but cite a private feedback report; the evidence entry's `privacyTier` controls whether that specific citation is visible to a given viewer.
+5. **No LLM in the producer path.** Evidence arrays are populated by structural code (the feedback handler, the dispatch executor, the cluster builder), not by an LLM "extracting evidence" from text. Determinism + auditability.
+
+## Schema Changes
+
+```typescript
+// src/core/types.ts
+
+export type MemoryEvidenceKind =
+  | 'feedback'
+  | 'commit'
+  | 'session'
+  | 'document'
+  | 'message'
+  | 'job-run'
+  | 'ledger-entry'
+  | 'pattern-entity'
+  | 'external-url'
+  | 'supersedes-evidence';
+
+export interface MemoryEvidence {
+  /** Kind of source — typed, not free-form, for queryability */
+  kind: MemoryEvidenceKind;
+  /** Foreign key to the source system */
+  sourceId: string;
+  /** Optional file path or URL (relative to repo root or absolute URL) */
+  path?: string;
+  /** Optional structured line range — preferred over freeform `lines` */
+  lineStart?: number;
+  /** Inclusive end line; equal to lineStart for single-line citations */
+  lineEnd?: number;
+  /** Optional freeform line range, e.g. "42-58" or "73". Derived from lineStart/lineEnd when both present. Kept for OpenClaw shape parity. */
+  lines?: string;
+  /** Optional contribution weight (0-1) — how much this evidence informed the claim */
+  weight?: number;
+  /** Optional trust in the source (0-1) — separate from weight */
+  confidence?: number;
+  /** Optional privacy tier; defaults to entity's privacyScope. Narrowing-only at write time (see Privacy section). */
+  privacyTier?: 'public' | 'shared-project' | 'private' | 'sensitive';
+  /** Optional free-form annotation. Hard cap MAX_EVIDENCE_NOTE_BYTES = 500 bytes; longer notes are rejected at write time. */
+  note?: string;
+  /** ISO 8601 timestamp of when this evidence was added or last refreshed */
+  updatedAt: string;
+}
+
+/** Per-entity cap; overridable up to 500 via SemanticMemoryConfig.evidenceCapPerEntity. */
+export const DEFAULT_EVIDENCE_CAP_PER_ENTITY = 50;
+/** Hard upper bound on evidence cap; values above this are clamped. */
+export const MAX_EVIDENCE_CAP_PER_ENTITY = 500;
+/** Hard cap on `note` field bytes. */
+export const MAX_EVIDENCE_NOTE_BYTES = 500;
+
+// Existing interface extension:
+export interface MemoryEntity {
+  // ... all existing fields ...
+
+  /** Legacy source field — keep for compatibility */
+  source: string;
+
+  /** NEW: typed evidence array. Empty for legacy entities; populated for all new entities. */
+  evidence: MemoryEvidence[];
+}
+```
+
+Storage: a new SQLite table `entity_evidence`:
+
+```sql
+CREATE TABLE entity_evidence (
+  evidence_id TEXT PRIMARY KEY,
+  entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  path TEXT,
+  line_start INTEGER,
+  line_end INTEGER,
+  lines TEXT,                 -- denormalized freeform fallback
+  weight REAL,
+  confidence REAL,
+  privacy_tier TEXT,
+  note TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_entity_evidence_entity ON entity_evidence(entity_id);
+CREATE INDEX idx_entity_evidence_source ON entity_evidence(kind, source_id);
+```
+
+Two indexes: one for "what's the evidence for this entity," one for "what entities cite this source" (the inverse query — currently impossible).
+
+**Foreign key enforcement**: SemanticMemory must execute `PRAGMA foreign_keys = ON` on every connection — better-sqlite3 does NOT default to ON. Without this pragma, `ON DELETE CASCADE` is silently ignored. Add a one-time assertion in `createSchema()` that the pragma is active.
+
+**Transaction scope**: when a producer creates an entity *with* evidence in one logical operation, both writes MUST occur inside a single better-sqlite3 transaction (`db.transaction(() => { ... })`). The new API `rememberWithEvidence()` (see Producers) wraps both. `addEvidence(entityId, evidence | evidence[])` accepts an array and wraps the inserts in a single transaction so multi-evidence calls are atomic.
+
+**JSONL representation**: evidence does NOT round-trip via the existing `appendToJournal('remember', ...)` action — that writes the entity row only. A new action `addEvidence` (and `rememberWithEvidence` payload variant) is required so JSONL replay reconstructs evidence faithfully:
+
+```jsonc
+// JSONL entry on entity create with evidence
+{ "action": "rememberWithEvidence", "entity": {...}, "evidence": [...] }
+// JSONL entry on later evidence addition
+{ "action": "addEvidence", "entityId": "...", "evidence": [...] }
+// JSONL entry on cascade-delete (already exists for entity)
+{ "action": "forget", "entityId": "..." }   // evidence rows reconstructed as deleted
+```
+
+## Migration of Existing MemoryEntity Records
+
+Existing entities have `source: string`. Migration strategy:
+
+1. Add the table; no destructive changes to `entities`.
+2. For each existing entity, leave `evidence: []`. Old `source` still answers "where did this come from at the coarse level."
+3. A one-shot `instar memory backfill-evidence` command (idempotent) walks specific known patterns:
+   - `source: "session:ABC"` → if session ABC exists in episodic memory, `evidence: [{kind:"session", sourceId:"ABC", updatedAt: createdAt}]`. If session ABC has been deleted/renamed, leave `evidence: []` and log a warning to `backfill-report.jsonl`. Synthetic `kind:"session"` entries pointing at dead sessions are NOT created.
+   - `source: "user:Justin"` → `evidence: [{kind:"message", sourceId:"user:Justin", updatedAt: createdAt, confidence: 0.5}]` (low confidence reflects coarse provenance)
+   - `source: "observation"` → leave `evidence: []` (no upgrade possible)
+   - any other pattern → leave `evidence: []` and log to `backfill-report.jsonl`
+4. New entities populate `evidence` from day one; the legacy `source` is auto-derived from the highest-weight evidence entry.
+
+## Producers
+
+> **Integration note (added in convergence)**: As of OpenClaw audit and verification against current Instar source, `EvolutionManager` (`src/core/EvolutionManager.ts:78`), `FeedbackManager` (`src/core/FeedbackManager.ts:31`), and `DecisionJournal` (`src/core/DecisionJournal.ts:32`) do NOT currently produce `MemoryEntity` rows. They write to their own JSON / JSONL stores. Producer integration in Phases 2–3 therefore requires a *new* bridge from each subsystem into `SemanticMemory.rememberWithEvidence()`, not a modification of existing entity-creation calls. For DecisionJournal specifically, the bridge promotes a `DecisionJournalEntry` to a `decision` MemoryEntity at log time; the journal entry retains its original JSONL row plus a back-reference `entityId`.
+
+> **Cross-store sourceId integrity**: `kind:'feedback'` evidence cites a `FeedbackItem.id` that lives in `feedback.json`, not in the entities DB. Cross-store FK is best-effort: at write time the producer SHOULD verify the `sourceId` exists in its store; at read time consumers MUST tolerate dangling references. The inverse query returns the citation row regardless; renderers display "[source unavailable]" for missing referents.
+
+> **Authorization (per-caller kind allowlist)**: `addEvidence` and `rememberWithEvidence` take an opaque `producer` capability token. Only specific subsystems may write specific kinds:
+>
+> | producer | allowed kinds |
+> |---|---|
+> | `EvolutionManager` | `feedback`, `pattern-entity`, `supersedes-evidence` |
+> | `DispatchExecutor` | `pattern-entity`, `job-run`, `ledger-entry` |
+> | `DecisionJournal` | `message`, `commit`, `ledger-entry`, `session` |
+> | `/learn` skill bridge | `message`, `session` |
+> | `external-url` | requires explicit `producer: 'manual'` and entity owner = caller user |
+>
+> Mismatches are rejected with `EvidencePolicyError`. The allowlist lives in `SemanticMemory` config, not as runtime checks scattered through callers.
+
+### Bug-cluster builder
+When EvolutionManager builds a cluster pattern entity, it cites every feedback report that fed into the cluster:
+
+```typescript
+const evidence: MemoryEvidence[] = clusterMembers.map(fb => ({
+  kind: 'feedback',
+  sourceId: fb.id,
+  weight: fb.clusterContribution,
+  confidence: fb.confidence ?? 0.8,
+  privacyTier: fb.privacyTier ?? 'shared-project',
+  note: fb.summary?.slice(0, 200),
+  updatedAt: nowIso(),
+}));
+```
+
+### Dispatch decision recorder
+When DispatchExecutor records why a fix was attempted, it cites the cluster + the prior dispatch attempts:
+
+```typescript
+const evidence: MemoryEvidence[] = [
+  { kind: 'pattern-entity', sourceId: cluster.entityId, weight: 0.6, ... },
+  ...priorAttempts.map(a => ({ kind: 'job-run', sourceId: a.runId, weight: 0.1, ... })),
+];
+```
+
+### Decision journal
+When DecisionJournal logs a decision, it cites the conversation lines + commits + ledger entries that informed it:
+
+```typescript
+const evidence: MemoryEvidence[] = [
+  { kind: 'message', sourceId: messageId, lines: lineRange, weight: 0.7, ... },
+  { kind: 'commit', sourceId: commitSha, path: filePath, lines: changedLines, ... },
+];
+```
+
+### Lesson capture (existing /learn skill)
+The `learn` skill already captures lessons; it should require at least one evidence entry from the conversation:
+
+```typescript
+{
+  type: 'lesson',
+  content: '...',
+  evidence: [{ kind: 'message', sourceId: msgId, weight: 1.0, ... }]
+}
+```
+
+## Consumers
+
+### Bug-cluster auditing
+Query: "for cluster X, which feedback reports informed each tier-1-fix-attempt rationale?"
+SQL:
+```sql
+SELECT e.evidence_id, e.source_id, e.weight, e.note
+FROM entity_evidence e
+WHERE e.entity_id = ? AND e.kind = 'feedback'
+ORDER BY e.weight DESC;
+```
+
+### Inverse traceability
+Query: "what entities cite feedback report fb_abc123?"
+SQL:
+```sql
+SELECT e.entity_id, ent.type, ent.name
+FROM entity_evidence e
+JOIN entities ent ON ent.id = e.entity_id
+WHERE e.kind = 'feedback' AND e.source_id = 'fb_abc123';
+```
+
+### TaskFlow integration
+A flow's `stateJson.evidence: MemoryEvidence[]` records why each step was taken. When the flow finishes, the producing entity (e.g., the cluster pattern) inherits those evidence entries. This is how flow rationale persists past flow termination.
+
+### Re-evaluation
+A `decision` entity can be re-evaluated by querying its evidence and checking whether each evidence entry's `confidence` is still warranted. Stale decisions are then candidates for confidence decay.
+
+### Privacy-scoped retrieval
+When rendering an entity to a user with `privacyScope: "shared-project"`, the rendering layer filters evidence entries with `privacyTier: "private" | "sensitive"` from the rendered output. The entity's own privacyScope still applies.
+
+## Storage and Privacy
+
+- Evidence rows live in the same SemanticMemory database as entities.
+- `privacyTier` defaults to the entity's `privacyScope` when omitted.
+- **Narrowing-only constraint** (enforced at write time): evidence `privacyTier` may equal or be *more restrictive than* the entity's `privacyScope`, never less. Allowed transitions: `public → public|shared-project|private|sensitive`, `shared-project → shared-project|private|sensitive`, `private → private|sensitive`, `sensitive → sensitive`. Violations rejected with `EvidencePolicyError`.
+- The renderer is the privacy-enforcement boundary, not the storage layer; storage keeps everything, renderer filters.
+- **Inverse-query privacy filter**: `findEntitiesByEvidence` (renamed `findCitations` for DX) MUST filter by viewer scope before returning rows. A viewer at `shared-project` scope querying for citations of a `private` source receives only public/shared-project entities that cite it. Tests assert no leak via inverse query at every (viewerScope × evidence privacyTier × entity privacyScope) combination.
+- JSONL append log includes evidence as separate `addEvidence` / `rememberWithEvidence` actions (see Schema Changes). Evidence is reconstructed by replaying the journal in order.
+- Cascade delete: removing an entity removes its evidence (matches `ON DELETE CASCADE`, requires `PRAGMA foreign_keys = ON` — see Schema Changes). Evidence rows have no orphan lifecycle.
+
+## Migration Plan
+
+### Phase 1: Schema + types (one PR)
+- Add `MemoryEvidence` type + table + JSONL representation.
+- `MemoryEntity.evidence: MemoryEvidence[]` defaults to `[]`.
+- All existing tests pass with `evidence: []` on legacy entities.
+- Enable `PRAGMA foreign_keys = ON` per connection; assert it in `createSchema()`.
+- New API:
+  - `SemanticMemory.rememberWithEvidence(input, evidence: MemoryEvidence[], producer: ProducerId): string` — atomic create-with-evidence in one transaction.
+  - `SemanticMemory.addEvidence(entityId, evidence: MemoryEvidence | MemoryEvidence[], producer: ProducerId): void` — appends; multi-evidence calls are atomic.
+  - `SemanticMemory.getEvidence(entityId, viewerScope: PrivacyScopeType): MemoryEvidence[]` — viewer-scope-filtered.
+  - `SemanticMemory.findCitations(ref: {kind: MemoryEvidenceKind; sourceId: string}, viewerScope: PrivacyScopeType): MemoryEntity[]` — viewer-scope-filtered (renamed from `findEntitiesByEvidence` for DX).
+  - `SemanticMemory.getEntityWithEvidence(entityId, viewerScope): MemoryEntity & {evidence: MemoryEvidence[]}` — eager variant; default `getEntity` stays evidence-free.
+
+### Phase 2: Producer integration — bug-cluster (one PR)
+- EvolutionManager populates `evidence` for cluster entities.
+- DispatchExecutor populates `evidence` for dispatch-decision entries.
+- Backwards-compatible: old clusters/dispatches continue to work with `evidence: []`.
+
+### Phase 3: Producer integration — DecisionJournal + /learn (one PR)
+- DecisionJournal entries require at least one evidence entry.
+- /learn skill prompts for evidence (or auto-derives from conversation context).
+
+### Phase 4: Inverse-traceability queries (one PR)
+- Server endpoints: `GET /memory/evidence/by-entity/:id`, `GET /memory/entities/by-evidence?kind=feedback&sourceId=...`.
+- Dashboard: per-entity evidence panel, "what cites this?" reverse view.
+
+### Phase 5: Backfill + render hardening (one PR)
+- `instar memory backfill-evidence` command.
+- Renderer privacy filtering across all evidence-rendering paths.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Evidence array becomes a dumping ground** | Hard limit per entity (e.g., 50 evidence entries, configurable). Beyond that, oldest-by-`updatedAt` are dropped to a JSONL archive. |
+| **Privacy leakage via evidence rendering** | Renderer-side filter is the single enforcement point. Add a test that renders every privacyScope × privacyTier combination and asserts no sensitive evidence reaches lower-scope output. |
+| **Migration miscategorizes legacy `source` strings** | Backfill is idempotent and uses only the patterns enumerated above. Anything that doesn't match a known pattern stays `evidence: []`. No LLM in the migration path. |
+| **Evidence weight inflation** | Weights are advisory, not enforced. The query layer can normalize within an entity (sum-to-1) at read time if needed. |
+| **Schema bloat slows hot retrieval** | Evidence is loaded lazily — `getEntity` doesn't load evidence by default; `getEntityWithEvidence` is a separate call. The hot path stays cheap. Two new indexes add ~1.5–2x insert latency on the evidence table; benchmark in Phase 1 against the 10k-entity baseline. |
+| **Backfill mislabels privacy** | Backfill defaults `privacyTier: undefined` (inherit from entity) for all migrated rows. No automatic upgrade to `private` or `sensitive`. |
+| **`PRAGMA foreign_keys = OFF` silently breaks cascade** | Assert pragma is ON in `createSchema()`; integration test asserts cascade-delete actually deletes evidence rows. |
+| **Supersedes-evidence cycles** | Cycle detection at write time bounded by `MAX_SUPERSEDES_DEPTH = 32`; renderer-side walks bounded by the same. |
+| **Cross-store dangling sourceId** | Best-effort write-time check; consumers tolerate dangling refs by displaying "[source unavailable]" rather than throwing. |
+
+## Threat Model
+
+- **Spoofed evidence**: a malicious caller adds evidence pointing at a feedback ID that doesn't exist or pointing at someone else's commit. Mitigation: per-caller kind allowlist (see Producers section) enforced inside SemanticMemory; mismatches throw `EvidencePolicyError`. Cross-store FK is best-effort but spoofs are detectable at audit time by matching `sourceId` against the producer's own store.
+- **Evidence explosion attack**: an attacker creates entities with thousands of evidence rows to bloat the DB. Mitigation: per-entity limit (`DEFAULT_EVIDENCE_CAP_PER_ENTITY = 50`, hard ceiling 500) + `MAX_EVIDENCE_NOTE_BYTES = 500` cap on `note` + per-caller rate limit (default 10 evidence/sec/producer, configurable).
+- **Privacy bypass via evidence**: rendering an entity with public scope but private evidence reveals information about a private source. Mitigation: narrowing-only constraint at write time (Storage and Privacy section) + render-time filter + inverse-query viewer-scope filter + cross-product tests.
+- **`note` field exfiltration**: free-form `note` is privacy-sensitive. Mitigation: 500-byte cap; notes inherit the entity's `privacyScope` unless overridden to a more restrictive `privacyTier` (narrowing-only). PII redaction is OUT OF SCOPE for v1; producers are responsible for sanitizing notes before write.
+- **Supersedes-evidence cycle**: a malicious or buggy producer chains `kind:'supersedes-evidence'` rows so A → B → A. Mitigation: at write time, traverse the existing supersedes-evidence chain rooted at the new entry's `sourceId`; reject if traversal length > MAX_SUPERSEDES_DEPTH (default 32) or if the new entry's own `evidence_id` would appear in its own ancestor chain. Renderer-side cycle walks must also bound depth.
+- **Renderer SSRF via `external-url`**: `kind:'external-url'` with arbitrary `path` could trigger fetches from a renderer that auto-resolves URLs. Mitigation: renderers MUST treat `path` for `external-url` as display-only — never auto-fetch. URL fetching is a separate, gated capability not implied by evidence.
+- **Producer-crash partial-write corruption**: a producer dies mid-loop after writing 3 of 10 evidence entries. Mitigation: `addEvidence` accepts arrays and wraps them in a single better-sqlite3 transaction (Schema Changes section). Multi-evidence operations are all-or-nothing.
+
+## Open Questions
+
+1. **Should `weight` and `confidence` be auto-computed?** OpenClaw leaves them caller-set. Instar option: derive `confidence` from the source's own confidence (e.g., feedback's stated confidence). Recommendation: caller-set in v1; auto-derivation as a Phase 6 enhancement.
+2. **Evidence for relationships (MemoryEdge), not just entities?** Edges have a `context: string` today. Should they also have `evidence: MemoryEvidence[]`? Recommendation: yes, but Phase 6 — start with entities to keep v1 small.
+3. **Do we want a wiki-claim-style separate `claim` table per entity, or merge into entity?** OpenClaw separates because pages have many claims. Instar entities are themselves claims. Recommendation: merge — `MemoryEntity` *is* a typed claim with content + evidence; no separate `claim` table needed.
+4. **Should evidence be searchable via FTS5 / vector?** Yes for `note`; no for `sourceId` (exact match only). Recommendation: index `note` in the existing entity FTS table as a secondary column.
+5. **Cross-agent evidence**: when Echo cites a Threadline message from Dawn, what does `sourceId` look like? Recommendation: `threadline:<threadId>:<messageId>` as a typed key matching Threadline's own ID format.
+
+## Non-Goals
+
+- **Not importing the wiki vault layer.** No deterministic page structure, no compiled digests, no Obsidian compatibility, no `wiki_search` / `wiki_apply` / `wiki_lint` tools. Just the evidence shape on existing entities.
+- **Not retroactively populating evidence via LLM extraction.** Backfill is structural-pattern-only.
+- **Not exposing raw evidence in conversational replies.** Renderer respects privacy. Evidence is for audit and re-evaluation, not for "show your work" in chat.
+- **Not a replacement for git provenance.** Commits + commit messages are still the source of truth for code changes; evidence cites them, doesn't replace them.
+
+## Review Decisions
+
+Round 1 of multi-angle review (security, scalability, adversarial, integration, supply-chain, data-modeling, DX) flagged 4 blockers and 11 majors. The spec has been amended in place to address all blockers and most majors. Decisions where the spec deliberately declined a reviewer recommendation are recorded here for traceability:
+
+- **PII redaction in `note`**: declined for v1. Cap is structural (500 bytes), not semantic. Producers are responsible for sanitization; redaction-as-service is a Phase 6 enhancement.
+- **`lines` as freeform string**: kept alongside structured `lineStart`/`lineEnd` for OpenClaw shape parity. Range queries (e.g., "evidence touching line 50") are explicitly out of v1 scope; they require both structured columns to be populated, which producers may opt into.
+- **Producer authorization via opaque token**: declined a JWT-style scheme; the producer ID is a process-internal symbol (e.g., the class instantiating SemanticMemory passes its own `producer: ProducerId`). Cross-process spoofing is not in the threat model — the threat is *bug-class* mis-citation, not adversary-class.
+- **`weight` and `confidence` semantics**: kept caller-set, distinct, both 0-1. Auto-derivation deferred to Phase 6 per Open Question #1.
+- **Edges (`MemoryEdge.evidence`)**: deferred to Phase 6 per Open Question #2.
+- **Eager-vs-lazy default**: kept lazy (default `getEntity` does not return evidence). Reviewer suggested eager-by-default for simplicity; declined because the dashboard render path lists 100s of entities at once and N+1 evidence loads would be the dominant cost.
+- **Inverse query name**: renamed `findEntitiesByEvidence` → `findCitations` for DX. Old name retained as a thin alias for one minor release.
+
+## References
+
+- OpenClaw: `extensions/memory-wiki/src/markdown.ts:11-101` (commit `f482e4d335`, verified 2026-05-07)
+- Echo audit: `.claude/research/openclaw-audit-instar-2026-05-07.md` §3, §8 #2
+- Instar adjacent: `src/core/types.ts:2580-2614` (MemoryEntity), `src/memory/SemanticMemory.ts`
+- Related spec: `OPENCLAW-IMPORT-TASKFLOW-SPEC.md` (consumer for flow-rationale evidence)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -573,6 +573,19 @@ memoryCmd
     return memoryExport(opts);
   });
 
+memoryCmd
+  .command('backfill-evidence')
+  .description(
+    'One-shot WikiClaim migration: pattern-match legacy MemoryEntity.source ' +
+      'and synthesize typed evidence rows (URL-only — see spec § Migration)',
+  )
+  .option('-d, --dir <path>', 'Project directory')
+  .option('--dry-run', 'Print what would be backfilled without writing')
+  .action(async (opts) => {
+    const { memoryBackfillEvidence } = await import('./commands/memoryBackfillEvidence.js');
+    return memoryBackfillEvidence(opts);
+  });
+
 // ── Knowledge Base ────────────────────────────────────────────────
 
 const knowledgeCmd = program

--- a/src/commands/memoryBackfillEvidence.ts
+++ b/src/commands/memoryBackfillEvidence.ts
@@ -1,0 +1,272 @@
+/**
+ * `instar memory backfill-evidence` — one-shot migration that walks every
+ * existing MemoryEntity, pattern-matches the legacy `source: string` field,
+ * and synthesizes a `MemoryEvidence` row when (and only when) the source
+ * matches a known shape that the `manual` producer is allowed to write.
+ *
+ * Per WikiClaim spec § Migration of Existing MemoryEntity Records (line 202)
+ * and § Risks line 357 ("Backfill is idempotent and uses only the patterns
+ * enumerated above. Anything that doesn't match a known pattern stays
+ * `evidence: []`. No LLM in the migration path.") and line 360 ("Backfill
+ * defaults `privacyTier: undefined` (inherit from entity). No automatic
+ * upgrade to private or sensitive.").
+ *
+ * **Phase 1 narrowed `manual` producer to `external-url` only** (see
+ * `PRODUCER_KIND_ALLOWLIST` in SemanticMemory.ts and the Phase 1 side-effects
+ * artifact). Because of that, the only legacy `source` shape backfill can
+ * cover is an `https?://` URL. Other patterns the spec lists (`session:ABC`,
+ * `user:Justin`, `observation`) would need their own dedicated producer
+ * bridges (e.g., `DecisionJournal` for `session`); attempting them here is
+ * out-of-scope for Phase 5 — we DELIBERATELY do not widen the allowlist to
+ * make migration easier.
+ *
+ * Idempotency: before writing, the command queries the entity's existing
+ * evidence rows; if an `external-url` row with the same path already exists,
+ * the entity is skipped. Two consecutive `--apply` runs produce identical
+ * end state.
+ */
+
+import path from 'node:path';
+import pc from 'picocolors';
+import { loadConfig } from '../core/Config.js';
+import { SemanticMemory } from '../memory/SemanticMemory.js';
+import type { MemoryEntity, MemoryEvidence, PrivacyScopeType } from '../core/types.js';
+
+export interface BackfillOptions {
+  dir?: string;
+  dryRun?: boolean;
+  /** Optional override for the source-of-truth viewer scope used to read
+   *  existing evidence during the dup-check. Default `'private'` reads
+   *  every tier — the dup-check must see ALL existing rows to be safely
+   *  idempotent. Configurable only for tests. */
+  viewerScope?: PrivacyScopeType;
+}
+
+export interface BackfillSummary {
+  scanned: number;
+  backfilled: number;
+  skipped: number;
+  errors: number;
+  /** Per-entity outcome lines for callers that want structured output. */
+  details: Array<{
+    entityId: string;
+    source: string;
+    outcome: 'backfilled' | 'already-has-url-evidence' | 'no-pattern-match' | 'error';
+    note?: string;
+  }>;
+}
+
+/**
+ * URL pattern: a complete `http://` or `https://` URL as the ENTIRE source
+ * string (anchored). We deliberately do NOT extract URLs embedded inside
+ * other text — extracting partial URLs creates ambiguity about what the
+ * "real" source was and re-runs could backfill different URLs from the same
+ * source string as the matcher evolves. Anchoring keeps the migration
+ * deterministic.
+ *
+ * Allowed: `https://example.com/path`, `http://localhost:8080/x?y=z`
+ * Rejected: `session:ABC`, `user:Justin`, `observation`, `see https://...`
+ */
+const URL_SOURCE_PATTERN = /^https?:\/\/\S+$/;
+
+/**
+ * Public entry: runs the backfill against the SemanticMemory in the given
+ * state directory. Returns a structured summary for tests / callers that
+ * want to assert on outcomes; the CLI wrapper prints the same data.
+ */
+export async function runBackfillEvidence(
+  opts: BackfillOptions,
+): Promise<BackfillSummary> {
+  const config = loadConfig(opts.dir);
+  const memory = new SemanticMemory({
+    dbPath: path.join(config.stateDir, 'semantic.db'),
+    decayHalfLifeDays: 30,
+    lessonDecayHalfLifeDays: 90,
+    staleThreshold: 0.2,
+  });
+  await memory.open();
+  try {
+    return backfillAgainstMemory(memory, opts);
+  } finally {
+    memory.close();
+  }
+}
+
+/**
+ * Test-friendly seam: takes an open SemanticMemory instance directly. The
+ * CLI wrapper threads loadConfig + open + close around it; tests skip the
+ * config dance and pass a memory created against a tmp dir.
+ */
+export function backfillAgainstMemory(
+  memory: SemanticMemory,
+  opts: BackfillOptions,
+): BackfillSummary {
+  const viewerScope: PrivacyScopeType = opts.viewerScope ?? 'private';
+  const dryRun = !!opts.dryRun;
+
+  const { entities } = memory.export();
+
+  const summary: BackfillSummary = {
+    scanned: 0,
+    backfilled: 0,
+    skipped: 0,
+    errors: 0,
+    details: [],
+  };
+
+  for (const entity of entities) {
+    summary.scanned++;
+    const source = entity.source ?? '';
+
+    // Pattern-match URL only. Everything else is a deliberate skip per
+    // spec § Risks line 357 (no LLM, only known patterns).
+    if (!URL_SOURCE_PATTERN.test(source)) {
+      summary.skipped++;
+      summary.details.push({
+        entityId: entity.id,
+        source,
+        outcome: 'no-pattern-match',
+      });
+      continue;
+    }
+
+    // Idempotency: if an existing external-url evidence row already cites
+    // this URL, skip. We read at the WIDEST viewer scope (default 'private',
+    // configurable for tests) so the dup-check sees every existing row —
+    // a narrow read could miss a row tagged `private` on a `shared-project`
+    // entity and cause a duplicate write.
+    let existing: MemoryEvidence[];
+    try {
+      existing = memory.getEvidence(entity.id, viewerScope);
+    } catch (err) {
+      summary.errors++;
+      summary.details.push({
+        entityId: entity.id,
+        source,
+        outcome: 'error',
+        note: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    const alreadyHas = existing.some(
+      (ev) =>
+        ev.kind === 'external-url' &&
+        (ev.path === source || ev.sourceId === source),
+    );
+    if (alreadyHas) {
+      summary.skipped++;
+      summary.details.push({
+        entityId: entity.id,
+        source,
+        outcome: 'already-has-url-evidence',
+      });
+      continue;
+    }
+
+    // Synthesize the evidence row. Per spec § Risks line 360, leave
+    // `privacyTier` undefined so it inherits from the entity's scope —
+    // never auto-upgrade to `private` / `sensitive`.
+    const synthesized: MemoryEvidence = {
+      kind: 'external-url',
+      // For URLs, sourceId == path == the URL itself. Spec § Producers
+      // line 229 keys 'manual external-url' on the URL value as both
+      // dedupe identity and display path.
+      sourceId: source,
+      path: source,
+      // updatedAt uses entity's createdAt — preserves temporal ordering
+      // and means a second run on the same row produces identical content.
+      updatedAt: entity.createdAt,
+      // Caller-set confidence/weight per spec § Open Questions; coarse
+      // legacy provenance gets a low-confidence float matching the spec's
+      // suggested 0.5 for migrated rows.
+      confidence: 0.5,
+      note: 'Backfilled from legacy MemoryEntity.source (Phase 5 migration)',
+    };
+
+    if (dryRun) {
+      summary.backfilled++;
+      summary.details.push({
+        entityId: entity.id,
+        source,
+        outcome: 'backfilled',
+        note: 'dry-run (not written)',
+      });
+      continue;
+    }
+
+    try {
+      memory.addEvidence(entity.id, synthesized, 'manual');
+      summary.backfilled++;
+      summary.details.push({
+        entityId: entity.id,
+        source,
+        outcome: 'backfilled',
+      });
+    } catch (err) {
+      summary.errors++;
+      summary.details.push({
+        entityId: entity.id,
+        source,
+        outcome: 'error',
+        note: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return summary;
+}
+
+/**
+ * Commander entry-point. Prints a human-readable report; structured callers
+ * use `runBackfillEvidence` directly.
+ */
+export async function memoryBackfillEvidence(
+  opts: BackfillOptions,
+): Promise<void> {
+  try {
+    const summary = await runBackfillEvidence(opts);
+
+    console.log(pc.bold('\n  Memory backfill-evidence\n'));
+    if (opts.dryRun) {
+      console.log(pc.yellow('  Dry-run: no writes performed.\n'));
+    }
+
+    console.log(`  Scanned:    ${summary.scanned}`);
+    console.log(`  Backfilled: ${pc.green(String(summary.backfilled))}`);
+    console.log(`  Skipped:    ${summary.skipped}`);
+    if (summary.errors > 0) {
+      console.log(`  Errors:     ${pc.red(String(summary.errors))}`);
+    } else {
+      console.log(`  Errors:     ${summary.errors}`);
+    }
+
+    // Show details only when there's something interesting to look at.
+    const interesting = summary.details.filter(
+      (d) => d.outcome === 'backfilled' || d.outcome === 'error',
+    );
+    if (interesting.length > 0) {
+      console.log();
+      for (const d of interesting) {
+        const tag =
+          d.outcome === 'backfilled'
+            ? pc.green('  +')
+            : pc.red('  !');
+        const noteStr = d.note ? pc.dim(` — ${d.note}`) : '';
+        console.log(`${tag} ${d.entityId}  ${pc.dim(d.source)}${noteStr}`);
+      }
+    }
+
+    console.log();
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('better-sqlite3')) {
+      console.log(pc.yellow('Backfill requires better-sqlite3.'));
+      console.log(pc.dim('Install it with: npm install better-sqlite3'));
+    } else {
+      console.log(
+        pc.red(`Backfill failed: ${err instanceof Error ? err.message : err}`),
+      );
+    }
+    process.exit(1);
+  }
+}

--- a/src/memory/EvidenceRenderer.ts
+++ b/src/memory/EvidenceRenderer.ts
@@ -1,0 +1,145 @@
+/**
+ * EvidenceRenderer — single privacy-enforcement helper for MemoryEntity
+ * evidence rendering.
+ *
+ * Per WikiClaim spec § Storage and Privacy (line 315) and § Risks line 356,
+ * "the renderer is the privacy-enforcement boundary, not the storage layer."
+ * The storage layer already filters at read time via `getEvidence` /
+ * `getEntityWithEvidence` / `findCitations`, but any downstream code path
+ * that touches an already-loaded `MemoryEntity.evidence` array must pipe
+ * through this helper instead of inlining the comparison — that way the
+ * filter rule lives in exactly ONE place and Phase 4 HTTP / dashboard /
+ * threadline render callsites can never accidentally leak.
+ *
+ * The helper enforces:
+ *   1. Entity-level visibility — if the entity's `privacyScope` exceeds the
+ *      viewer's scope, the entity itself is hidden (returns null).
+ *   2. Evidence-level visibility — each evidence row's `privacyTier` (or
+ *      `undefined`, which inherits the entity scope) is checked against
+ *      the viewer scope; restricted rows are dropped.
+ *
+ * Spec citations:
+ *   - § Storage and Privacy line 315: renderer is the enforcement boundary
+ *   - § Risks line 356: "render every privacyScope × privacyTier
+ *     combination" cross-product test asserts no leak
+ *   - § Storage and Privacy line 316: inverse-query privacy filter
+ */
+
+import type {
+  MemoryEntity,
+  MemoryEvidence,
+  EvidencePrivacyTier,
+  PrivacyScopeType,
+} from '../core/types.js';
+
+/**
+ * Entity-level privacy ordering. `private` > `shared-topic` > `shared-project`.
+ * A viewer at higher tier sees their tier and everything below.
+ *
+ * Mirrors `ENTITY_SCOPE_ORDER` in SemanticMemory.ts — kept colocated rather
+ * than imported to keep the renderer side-effect-free and avoid pulling
+ * better-sqlite3 into render contexts that don't need it (e.g., HTTP
+ * response shapers).
+ */
+const ENTITY_SCOPE_ORDER: Record<PrivacyScopeType, number> = {
+  'shared-project': 0,
+  'shared-topic': 1,
+  'private': 2,
+};
+
+/**
+ * Evidence-level privacy ordering. Wider vocabulary than entity scope:
+ * adds `public` (more permissive than shared-project) and `sensitive`
+ * (more restrictive than private). Per spec § Schema Changes line 136.
+ */
+const EVIDENCE_TIER_ORDER: Record<EvidencePrivacyTier, number> = {
+  'public': 0,
+  'shared-project': 1,
+  'private': 2,
+  'sensitive': 3,
+};
+
+/** Map an entity-vocabulary scope onto the evidence-tier scale. */
+function entityScopeToTierOrdinal(scope: PrivacyScopeType): number {
+  switch (scope) {
+    case 'shared-project':
+      return EVIDENCE_TIER_ORDER['shared-project'];
+    case 'shared-topic':
+      // Conservative-map: 'shared-topic' is absent from the evidence
+      // vocabulary; treat it like 'private' so wider tiers cannot be
+      // attached to topic-scope entities.
+      return EVIDENCE_TIER_ORDER['private'];
+    case 'private':
+      return EVIDENCE_TIER_ORDER['private'];
+  }
+}
+
+/** True iff entity at `itemScope` is visible to a viewer at `viewerScope`. */
+export function isEntityVisibleAtScope(
+  itemScope: PrivacyScopeType | undefined,
+  viewerScope: PrivacyScopeType,
+): boolean {
+  const item = itemScope ?? 'shared-project';
+  return ENTITY_SCOPE_ORDER[viewerScope] >= ENTITY_SCOPE_ORDER[item];
+}
+
+/**
+ * True iff an evidence row tagged `evidenceTier` is visible to `viewerScope`.
+ * `undefined` evidenceTier inherits the entity's scope — by the time this
+ * helper is called the entity-level filter has already accepted the entity,
+ * so undefined tiers pass through. (Mirrors SemanticMemory's `getEvidence`
+ * read-time filter.)
+ */
+export function isEvidenceVisibleAtScope(
+  evidenceTier: EvidencePrivacyTier | undefined,
+  viewerScope: PrivacyScopeType,
+): boolean {
+  if (evidenceTier === undefined) return true;
+  return entityScopeToTierOrdinal(viewerScope) >= EVIDENCE_TIER_ORDER[evidenceTier];
+}
+
+/**
+ * Filter an entity for a viewer. Returns:
+ *  - `null` if the entity's own `privacyScope` is wider than the viewer's
+ *    scope (entity itself is hidden).
+ *  - A shallow clone with `evidence` filtered to only rows visible at the
+ *    viewer's scope. The `evidence` field is preserved as `[]` if all rows
+ *    are filtered out and as `undefined` if the input didn't have one
+ *    loaded (matches the lazy-load contract in MemoryEntity).
+ *
+ * SAFETY: never mutates the input entity. Callers can pass the same entity
+ * to multiple viewers without cross-contamination.
+ */
+export function renderEvidenceForScope(
+  entity: MemoryEntity,
+  viewerScope: PrivacyScopeType,
+): (MemoryEntity & { evidence?: MemoryEvidence[] }) | null {
+  if (!isEntityVisibleAtScope(entity.privacyScope, viewerScope)) {
+    return null;
+  }
+  if (entity.evidence === undefined) {
+    // Lazy: caller didn't load evidence; pass through unchanged.
+    return { ...entity };
+  }
+  const filtered = entity.evidence.filter((ev) =>
+    isEvidenceVisibleAtScope(ev.privacyTier, viewerScope),
+  );
+  return { ...entity, evidence: filtered };
+}
+
+/**
+ * Filter a bare evidence array for a viewer scope. Used when the consumer
+ * has evidence in hand without the parent entity (e.g., a separate evidence
+ * panel that received a pre-loaded array).
+ *
+ * NOTE: this skips the entity-level visibility check. Use `renderEvidenceForScope`
+ * whenever the entity is available. This helper exists for the narrow
+ * `findCitations`-derived flow where the entity was already filtered and
+ * only its evidence array is being trimmed.
+ */
+export function filterEvidenceArrayForScope(
+  evidence: readonly MemoryEvidence[],
+  viewerScope: PrivacyScopeType,
+): MemoryEvidence[] {
+  return evidence.filter((ev) => isEvidenceVisibleAtScope(ev.privacyTier, viewerScope));
+}

--- a/src/memory/SemanticMemory.ts
+++ b/src/memory/SemanticMemory.ts
@@ -50,6 +50,10 @@ import {
 import type { EmbeddingProvider } from './EmbeddingProvider.js';
 import { VectorSearch } from './VectorSearch.js';
 import { buildPrivacySqlFilter } from '../utils/privacy.js';
+import {
+  isEntityVisibleAtScope as rendererIsEntityVisibleAtScope,
+  isEvidenceVisibleAtScope as rendererIsEvidenceVisibleAtScope,
+} from './EvidenceRenderer.js';
 
 // Dynamic import for better-sqlite3 (optional dependency)
 type Database = import('better-sqlite3').Database;
@@ -1913,20 +1917,10 @@ export class EvidencePolicyError extends Error {
 }
 
 /**
- * Entity-level privacy ordering for inverse-query filtering.
- * `private` > `shared-topic` > `shared-project`. A viewer at higher tier
- * sees their tier and below.
- */
-const ENTITY_SCOPE_ORDER: Record<PrivacyScopeType, number> = {
-  'shared-project': 0,
-  'shared-topic': 1,
-  'private': 2,
-};
-
-/**
- * Evidence-level privacy ordering. Wider vocabulary than entity scope:
- * adds `public` (more permissive than shared-project) and `sensitive`
- * (more restrictive than private). Per spec § Schema Changes line 136.
+ * Evidence-level privacy ordering. Used by the write-time
+ * `assertNarrowingOnly` invariant. Mirrors EvidenceRenderer's local copy
+ * (which owns the READ path); kept here so the write-side check has no
+ * module-cycle dependency on the renderer.
  */
 const EVIDENCE_TIER_ORDER: Record<EvidencePrivacyTier, number> = {
   'public': 0,
@@ -1950,30 +1944,14 @@ function entityScopeToTierOrdinal(scope: PrivacyScopeType): number {
   }
 }
 
-/** Map a viewer scope onto the comparable evidence-tier scale. */
-function viewerScopeToTierOrdinal(scope: PrivacyScopeType): number {
-  return entityScopeToTierOrdinal(scope);
-}
-
-/** Whether an entity is visible at a viewer scope (entity-vocabulary). */
-function isEntityVisibleAtScope(
-  itemScope: PrivacyScopeType | undefined,
-  viewerScope: PrivacyScopeType,
-): boolean {
-  const item = itemScope ?? 'shared-project';
-  return ENTITY_SCOPE_ORDER[viewerScope] >= ENTITY_SCOPE_ORDER[item];
-}
-
-/** Whether an evidence row is visible at a viewer scope (tier-vocabulary). */
-function isEvidenceVisibleAtScope(
-  evidenceTier: EvidencePrivacyTier | undefined,
-  viewerScope: PrivacyScopeType,
-): boolean {
-  // No tier set ⇒ inherits entity scope; the entity-level filter has already
-  // accepted this row, so let it through.
-  if (evidenceTier === undefined) return true;
-  return viewerScopeToTierOrdinal(viewerScope) >= EVIDENCE_TIER_ORDER[evidenceTier];
-}
+/**
+ * Visibility predicates are owned by EvidenceRenderer (the single
+ * privacy-enforcement helper per spec § Storage and Privacy line 315).
+ * SemanticMemory's read paths delegate to those exports so the filter
+ * rule lives in exactly one place. Local aliases keep the call-site shape.
+ */
+const isEntityVisibleAtScope = rendererIsEntityVisibleAtScope;
+const isEvidenceVisibleAtScope = rendererIsEvidenceVisibleAtScope;
 
 /**
  * Narrowing-only constraint: an evidence entry's `privacyTier` may be equal

--- a/tests/unit/evidence-render-privacy.test.ts
+++ b/tests/unit/evidence-render-privacy.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Cross-product privacy tests for EvidenceRenderer (WikiClaim Phase 5).
+ *
+ * Per spec § Risks line 356: "Add a test that renders every privacyScope ×
+ * privacyTier combination and asserts no sensitive evidence reaches
+ * lower-scope output."
+ *
+ * The helper `renderEvidenceForScope(entity, viewerScope)` is the single
+ * privacy-enforcement point for any code path that needs to ship a
+ * `MemoryEntity` (with evidence) to a viewer at a specific scope. This
+ * file walks every (entityScope × evidenceTier × viewerScope) tuple and
+ * asserts no leak.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  renderEvidenceForScope,
+  filterEvidenceArrayForScope,
+  isEntityVisibleAtScope,
+  isEvidenceVisibleAtScope,
+} from '../../src/memory/EvidenceRenderer.js';
+import type {
+  MemoryEntity,
+  MemoryEvidence,
+  EvidencePrivacyTier,
+  PrivacyScopeType,
+} from '../../src/core/types.js';
+
+const ENTITY_SCOPES: PrivacyScopeType[] = ['shared-project', 'shared-topic', 'private'];
+const EVIDENCE_TIERS: (EvidencePrivacyTier | undefined)[] = [
+  undefined, // inherit
+  'public',
+  'shared-project',
+  'private',
+  'sensitive',
+];
+const VIEWER_SCOPES: PrivacyScopeType[] = ['shared-project', 'shared-topic', 'private'];
+
+/**
+ * The truth table the spec's narrowing-only constraint AND viewer-scope
+ * filter together imply. A viewer should see an evidence row iff their
+ * scope's tier-ordinal >= the evidence's tier-ordinal.
+ *
+ * Mapping (must mirror EvidenceRenderer.ts):
+ *   shared-project  → 1
+ *   shared-topic    → 2 (maps to 'private' tier ordinal)
+ *   private         → 2 (same ordinal as shared-topic)
+ *
+ * Evidence tier ordinals:
+ *   public          → 0
+ *   shared-project  → 1
+ *   private         → 2
+ *   sensitive       → 3
+ */
+function expectedEvidenceVisible(
+  evidenceTier: EvidencePrivacyTier | undefined,
+  viewerScope: PrivacyScopeType,
+): boolean {
+  if (evidenceTier === undefined) return true; // inherits — already passed entity-filter
+  const viewerOrdinal = viewerScope === 'shared-project' ? 1 : 2;
+  const tierOrdinal =
+    evidenceTier === 'public'
+      ? 0
+      : evidenceTier === 'shared-project'
+        ? 1
+        : evidenceTier === 'private'
+          ? 2
+          : 3; // sensitive
+  return viewerOrdinal >= tierOrdinal;
+}
+
+function expectedEntityVisible(
+  entityScope: PrivacyScopeType,
+  viewerScope: PrivacyScopeType,
+): boolean {
+  // ENTITY_SCOPE_ORDER: shared-project=0, shared-topic=1, private=2
+  const ord = (s: PrivacyScopeType) =>
+    s === 'shared-project' ? 0 : s === 'shared-topic' ? 1 : 2;
+  return ord(viewerScope) >= ord(entityScope);
+}
+
+function makeEvidence(tier: EvidencePrivacyTier | undefined): MemoryEvidence {
+  const ev: MemoryEvidence = {
+    kind: 'external-url',
+    sourceId: `tier-${tier ?? 'inherit'}`,
+    updatedAt: '2026-05-09T00:00:00Z',
+  };
+  if (tier !== undefined) ev.privacyTier = tier;
+  return ev;
+}
+
+function makeEntity(
+  scope: PrivacyScopeType,
+  evidenceTiers: (EvidencePrivacyTier | undefined)[],
+): MemoryEntity {
+  return {
+    id: `e_${scope}`,
+    type: 'fact',
+    name: 'cross-product entity',
+    content: 'test',
+    confidence: 0.9,
+    createdAt: '2026-05-09T00:00:00Z',
+    lastVerified: '2026-05-09T00:00:00Z',
+    lastAccessed: '2026-05-09T00:00:00Z',
+    source: 'test',
+    tags: [],
+    privacyScope: scope,
+    evidence: evidenceTiers.map(makeEvidence),
+  };
+}
+
+describe('EvidenceRenderer — cross-product privacy enforcement', () => {
+  for (const entityScope of ENTITY_SCOPES) {
+    for (const viewerScope of VIEWER_SCOPES) {
+      it(`entity=${entityScope}, viewer=${viewerScope} → correct entity visibility + filtered evidence`, () => {
+        const entity = makeEntity(entityScope, EVIDENCE_TIERS);
+        const result = renderEvidenceForScope(entity, viewerScope);
+
+        const entityShouldShow = expectedEntityVisible(entityScope, viewerScope);
+        if (!entityShouldShow) {
+          expect(result).toBeNull();
+          return;
+        }
+        expect(result).not.toBeNull();
+        expect(result!.privacyScope).toBe(entityScope);
+
+        // Every evidence row should match the truth table.
+        const filteredTiers = (result!.evidence ?? []).map((e) => e.privacyTier);
+        const expectedTiers = EVIDENCE_TIERS.filter((t) =>
+          expectedEvidenceVisible(t, viewerScope),
+        );
+        expect(new Set(filteredTiers)).toEqual(new Set(expectedTiers));
+      });
+    }
+  }
+
+  it('does not mutate the input entity (safe to reuse across viewers)', () => {
+    const entity = makeEntity('shared-project', EVIDENCE_TIERS);
+    const beforeLen = entity.evidence!.length;
+    renderEvidenceForScope(entity, 'shared-project');
+    renderEvidenceForScope(entity, 'private');
+    expect(entity.evidence!.length).toBe(beforeLen);
+  });
+
+  it('preserves evidence: undefined (lazy not-loaded signal)', () => {
+    const entity: MemoryEntity = {
+      ...makeEntity('shared-project', []),
+      evidence: undefined,
+    };
+    const result = renderEvidenceForScope(entity, 'shared-project');
+    expect(result).not.toBeNull();
+    expect(result!.evidence).toBeUndefined();
+  });
+
+  it('filterEvidenceArrayForScope mirrors renderEvidenceForScope filtering', () => {
+    for (const viewerScope of VIEWER_SCOPES) {
+      const evidence = EVIDENCE_TIERS.map(makeEvidence);
+      const filtered = filterEvidenceArrayForScope(evidence, viewerScope);
+      const expectedTiers = EVIDENCE_TIERS.filter((t) =>
+        expectedEvidenceVisible(t, viewerScope),
+      );
+      expect(filtered.map((e) => e.privacyTier).sort()).toEqual(
+        expectedTiers.map((t) => t).sort(),
+      );
+    }
+  });
+
+  it('sensitive evidence NEVER reaches a non-private viewer', () => {
+    // Spec-critical: even the highest entity scope must hide 'sensitive'
+    // evidence from a 'shared-project' viewer.
+    const entity = makeEntity('shared-project', ['sensitive']);
+    const result = renderEvidenceForScope(entity, 'shared-project');
+    expect(result).not.toBeNull();
+    expect(result!.evidence).toHaveLength(0);
+  });
+
+  it('private viewer sees private evidence on a shared-project entity', () => {
+    const entity = makeEntity('shared-project', ['private']);
+    const result = renderEvidenceForScope(entity, 'private');
+    expect(result!.evidence).toHaveLength(1);
+  });
+
+  it('public evidence visible to every viewer scope', () => {
+    for (const viewerScope of VIEWER_SCOPES) {
+      const entity = makeEntity('shared-project', ['public']);
+      const result = renderEvidenceForScope(entity, viewerScope);
+      expect(result).not.toBeNull();
+      expect(result!.evidence?.[0].privacyTier).toBe('public');
+    }
+  });
+});
+
+describe('EvidenceRenderer — visibility predicates (used by SemanticMemory)', () => {
+  it('isEntityVisibleAtScope: viewer-scope-tier ordering', () => {
+    expect(isEntityVisibleAtScope('shared-project', 'shared-project')).toBe(true);
+    expect(isEntityVisibleAtScope('shared-project', 'private')).toBe(true);
+    expect(isEntityVisibleAtScope('private', 'shared-project')).toBe(false);
+    expect(isEntityVisibleAtScope('shared-topic', 'shared-project')).toBe(false);
+    expect(isEntityVisibleAtScope(undefined, 'shared-project')).toBe(true); // default
+  });
+
+  it('isEvidenceVisibleAtScope: tier ordering with vocabulary widening', () => {
+    expect(isEvidenceVisibleAtScope(undefined, 'shared-project')).toBe(true);
+    expect(isEvidenceVisibleAtScope('public', 'shared-project')).toBe(true);
+    expect(isEvidenceVisibleAtScope('shared-project', 'shared-project')).toBe(true);
+    expect(isEvidenceVisibleAtScope('private', 'shared-project')).toBe(false);
+    expect(isEvidenceVisibleAtScope('sensitive', 'private')).toBe(false);
+    expect(isEvidenceVisibleAtScope('private', 'private')).toBe(true);
+  });
+});

--- a/tests/unit/memory-backfill-evidence.test.ts
+++ b/tests/unit/memory-backfill-evidence.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for `instar memory backfill-evidence` (WikiClaim Phase 5).
+ *
+ * Spec citations:
+ *   - § Migration of Existing MemoryEntity Records (line 202)
+ *   - § Risks line 357 (no LLM, only known patterns, idempotent)
+ *   - § Risks line 360 (no auto-upgrade of privacyTier)
+ *   - § Producers line 229 (manual producer narrowed to external-url)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SemanticMemory, EvidencePolicyError } from '../../src/memory/SemanticMemory.js';
+import { backfillAgainstMemory } from '../../src/commands/memoryBackfillEvidence.js';
+
+interface Setup {
+  dir: string;
+  memory: SemanticMemory;
+  cleanup: () => void;
+}
+
+async function setup(): Promise<Setup> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-backfill-test-'));
+  const memory = new SemanticMemory({
+    dbPath: path.join(dir, 'semantic.db'),
+    decayHalfLifeDays: 30,
+    lessonDecayHalfLifeDays: 90,
+    staleThreshold: 0.2,
+  });
+  await memory.open();
+  return {
+    dir,
+    memory,
+    cleanup: () => {
+      memory.close();
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/memory-backfill-evidence.test.ts',
+      });
+    },
+  };
+}
+
+const baseEntity = {
+  type: 'fact' as const,
+  name: 'test-entity',
+  content: 'some content',
+  confidence: 0.9,
+  lastVerified: '2026-05-09T00:00:00Z',
+  tags: ['test'],
+  privacyScope: 'shared-project' as const,
+};
+
+describe('backfill-evidence — pattern matching', () => {
+  let s: Setup;
+  beforeEach(async () => { s = await setup(); });
+  afterEach(() => { s.cleanup(); });
+
+  it('https URL source → external-url evidence row', () => {
+    const id = s.memory.remember({
+      ...baseEntity,
+      source: 'https://example.com/doc/42',
+    });
+
+    const summary = backfillAgainstMemory(s.memory, {});
+
+    expect(summary.scanned).toBe(1);
+    expect(summary.backfilled).toBe(1);
+    expect(summary.skipped).toBe(0);
+    expect(summary.errors).toBe(0);
+
+    const evidence = s.memory.getEvidence(id, 'private');
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].kind).toBe('external-url');
+    expect(evidence[0].sourceId).toBe('https://example.com/doc/42');
+    expect(evidence[0].path).toBe('https://example.com/doc/42');
+    // Privacy must inherit from entity — never auto-upgrade
+    expect(evidence[0].privacyTier).toBeUndefined();
+  });
+
+  it('http URL source → external-url evidence row', () => {
+    const id = s.memory.remember({
+      ...baseEntity,
+      source: 'http://localhost:4042/api/x?y=z',
+    });
+
+    const summary = backfillAgainstMemory(s.memory, {});
+
+    expect(summary.backfilled).toBe(1);
+    const evidence = s.memory.getEvidence(id, 'private');
+    expect(evidence[0].path).toBe('http://localhost:4042/api/x?y=z');
+  });
+
+  it.each([
+    ['session:ABC123'],
+    ['user:Justin'],
+    ['observation'],
+    ['cluster-builder'],
+    ['see https://example.com inside text'], // URL embedded, not anchored
+    [''], // empty
+    ['  https://leading-whitespace.com  '], // whitespace not stripped
+  ])('non-URL source %j → skip, no evidence', (source) => {
+    const id = s.memory.remember({ ...baseEntity, source });
+
+    const summary = backfillAgainstMemory(s.memory, {});
+
+    expect(summary.scanned).toBe(1);
+    expect(summary.backfilled).toBe(0);
+    expect(summary.skipped).toBe(1);
+
+    const evidence = s.memory.getEvidence(id, 'private');
+    expect(evidence).toHaveLength(0);
+  });
+});
+
+describe('backfill-evidence — producer narrowing respected', () => {
+  let s: Setup;
+  beforeEach(async () => { s = await setup(); });
+  afterEach(() => { s.cleanup(); });
+
+  it('only writes external-url kind (never feedback / session / etc.)', () => {
+    const id = s.memory.remember({
+      ...baseEntity,
+      source: 'https://example.com/x',
+    });
+
+    backfillAgainstMemory(s.memory, {});
+
+    const evidence = s.memory.getEvidence(id, 'private');
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].kind).toBe('external-url');
+    // Sanity: manual producer can only write external-url. Attempting any
+    // other kind via manual should throw — verifies our test trusts the
+    // allowlist correctly.
+    expect(() =>
+      s.memory.addEvidence(
+        id,
+        {
+          kind: 'feedback',
+          sourceId: 'fb_x',
+          updatedAt: '2026-05-09T00:00:00Z',
+        },
+        'manual',
+      ),
+    ).toThrow(EvidencePolicyError);
+  });
+});
+
+describe('backfill-evidence — idempotency', () => {
+  let s: Setup;
+  beforeEach(async () => { s = await setup(); });
+  afterEach(() => { s.cleanup(); });
+
+  it('second run produces zero additional writes', () => {
+    s.memory.remember({ ...baseEntity, source: 'https://example.com/x' });
+    s.memory.remember({ ...baseEntity, name: 'b', source: 'https://example.com/y' });
+    s.memory.remember({ ...baseEntity, name: 'c', source: 'session:ABC' });
+
+    const first = backfillAgainstMemory(s.memory, {});
+    expect(first.backfilled).toBe(2);
+
+    const second = backfillAgainstMemory(s.memory, {});
+    expect(second.scanned).toBe(3);
+    expect(second.backfilled).toBe(0);
+    expect(second.skipped).toBe(3); // 2 already-have + 1 no-pattern-match
+  });
+
+  it('idempotency holds across entity privacy tiers', () => {
+    // Private entity with URL source — dup-check must read at viewer 'private'
+    // (the default) so it sees its own private-scope row on second run.
+    const id = s.memory.remember({
+      ...baseEntity,
+      privacyScope: 'private',
+      source: 'https://example.com/secret',
+    });
+
+    backfillAgainstMemory(s.memory, {});
+    backfillAgainstMemory(s.memory, {});
+
+    const evidence = s.memory.getEvidence(id, 'private');
+    expect(evidence).toHaveLength(1);
+  });
+});
+
+describe('backfill-evidence — dry-run', () => {
+  let s: Setup;
+  beforeEach(async () => { s = await setup(); });
+  afterEach(() => { s.cleanup(); });
+
+  it('reports what would be backfilled without writing', () => {
+    const id = s.memory.remember({
+      ...baseEntity,
+      source: 'https://example.com/x',
+    });
+
+    const summary = backfillAgainstMemory(s.memory, { dryRun: true });
+
+    expect(summary.backfilled).toBe(1);
+    expect(summary.details[0]).toMatchObject({
+      entityId: id,
+      outcome: 'backfilled',
+      note: 'dry-run (not written)',
+    });
+
+    // Crucially: nothing was written
+    const evidence = s.memory.getEvidence(id, 'private');
+    expect(evidence).toHaveLength(0);
+  });
+
+  it('subsequent apply-run after dry-run still writes (dry-run is non-mutating)', () => {
+    const id = s.memory.remember({
+      ...baseEntity,
+      source: 'https://example.com/x',
+    });
+
+    backfillAgainstMemory(s.memory, { dryRun: true });
+    expect(s.memory.getEvidence(id, 'private')).toHaveLength(0);
+
+    const apply = backfillAgainstMemory(s.memory, {});
+    expect(apply.backfilled).toBe(1);
+    expect(s.memory.getEvidence(id, 'private')).toHaveLength(1);
+  });
+});
+
+describe('backfill-evidence — privacy defaults', () => {
+  let s: Setup;
+  beforeEach(async () => { s = await setup(); });
+  afterEach(() => { s.cleanup(); });
+
+  it.each([
+    ['shared-project'],
+    ['shared-topic'],
+    ['private'],
+  ] as const)(
+    'entity at %s scope → evidence privacyTier undefined (inherits)',
+    (scope) => {
+      const id = s.memory.remember({
+        ...baseEntity,
+        privacyScope: scope,
+        source: 'https://example.com/x',
+      });
+
+      backfillAgainstMemory(s.memory, {});
+
+      const evidence = s.memory.getEvidence(id, 'private');
+      expect(evidence).toHaveLength(1);
+      expect(evidence[0].privacyTier).toBeUndefined();
+    },
+  );
+});

--- a/upgrades/side-effects/wikiclaim-evidence-phase5.md
+++ b/upgrades/side-effects/wikiclaim-evidence-phase5.md
@@ -1,0 +1,285 @@
+# Side-Effects Review — WikiClaim Evidence Phase 5 (backfill CLI + render hardening)
+
+**Version / slug:** `wikiclaim-evidence-phase5`
+**Date:** 2026-05-10
+**Author:** Echo
+**Second-pass reviewer:** required (idempotency + producer-narrowing-respected + cross-product privacy)
+
+## Summary of the change
+
+Ships the final WikiClaim phase per spec § Migration Plan line 347:
+
+1. `instar memory backfill-evidence [--dry-run]` — one-shot, idempotent
+   CLI that walks every existing `MemoryEntity`, pattern-matches the legacy
+   `source: string` field, and synthesizes a single `MemoryEvidence` row
+   of `kind: 'external-url'` when (and only when) the source string is an
+   anchored `https?://…` URL. Any non-URL source string is left alone —
+   `evidence: []` per spec § Risks line 357 ("no LLM in the migration path").
+2. `src/memory/EvidenceRenderer.ts` — single privacy-enforcement helper
+   exposing `renderEvidenceForScope(entity, viewerScope)`. Per spec
+   § Storage and Privacy line 315 the renderer is THE enforcement boundary;
+   this lands the helper now (before Phase 4 HTTP/dashboard rendering
+   touches evidence in user-facing output) so every downstream consumer
+   has exactly one place to filter from. `SemanticMemory`'s own read paths
+   are switched to delegate to the helper for the entity-visible /
+   evidence-visible predicates — keeping one source of truth.
+
+### Phase 5 scope deliberately narrowed vs spec § Migration line 208–212
+
+The spec lists four legacy-source patterns:
+
+| Pattern | Backfilled to | Phase 5 status |
+|---|---|---|
+| `https?://…` | `kind: 'external-url'` | **shipped** |
+| `session:ABC` | `kind: 'session'` | **skipped** |
+| `user:Justin` | `kind: 'message'` | **skipped** |
+| `observation` / any other | `evidence: []` | unchanged (no write) |
+
+The narrowing is structural, not a deferral. Per spec § Producers line 229
+and the Phase 1 `PRODUCER_KIND_ALLOWLIST`, the `manual` producer (the only
+producer this CLI can invoke from outside any of the in-process subsystems)
+is allowed to write `external-url` ONLY. The `session` and `message` kinds
+require the `DecisionJournal` and `LearnSkill` producers respectively, which
+have access to the originating subsystem's context (session metadata,
+conversation transcript) that the CLI does not. **We deliberately do NOT
+widen the allowlist to make migration easier** — that would unwind the
+producer-kind capability boundary the spec installs.
+
+A future bridge that walks legacy `session:` and `user:` sources from
+inside DecisionJournal / LearnSkill (with full producer context) is a
+clean follow-up and explicitly tracked in MEMORY.md.
+
+What lands:
+
+- `src/commands/memoryBackfillEvidence.ts` — pattern-match + dup-check +
+  `addEvidence('manual')` call.
+- `src/cli.ts` — register `memory backfill-evidence` subcommand with
+  `--dry-run` flag and `-d <dir>`.
+- `src/memory/EvidenceRenderer.ts` — `renderEvidenceForScope`,
+  `filterEvidenceArrayForScope`, `isEntityVisibleAtScope`,
+  `isEvidenceVisibleAtScope`. The latter two are imported by
+  `SemanticMemory.ts` so the read-path predicates are no longer locally
+  defined — they delegate to the renderer.
+- `tests/unit/memory-backfill-evidence.test.ts` — 17 vitest cases:
+  URL pattern match, non-URL skip, producer narrowing respected,
+  idempotency across two runs, idempotency across entity privacy tiers,
+  dry-run is non-mutating, apply-after-dry-run still writes, privacy
+  inherits across every entity scope.
+- `tests/unit/evidence-render-privacy.test.ts` — cross-product table:
+  3 entity scopes × 5 evidence tiers × 3 viewer scopes (45 combinations)
+  plus six edge-case assertions. Spec § Risks line 356 ("render every
+  privacyScope × privacyTier combination and assert no leak") satisfied.
+- `upgrades/side-effects/wikiclaim-evidence-phase5.md` (this file).
+
+## Decision-point inventory
+
+- URL anchoring (`^https?:\/\/\S+$`) — **add** — hard-invariant pattern
+  match at the migration entry. Not judgment. Anchoring (no embedded URLs
+  inside other text) keeps the migration deterministic across re-runs as
+  the matcher evolves.
+- Idempotency dup-check (`existing.some(ev.kind === 'external-url' &&
+  (ev.path === source || ev.sourceId === source))`) — **add** —
+  equality-based. Not judgment.
+- Dup-check viewer-scope (`'private'` default, configurable) — **add** —
+  reads the widest scope so the dup-check sees every existing row. A
+  narrower default would silently allow a duplicate write against a
+  private-tier evidence row on a shared-project entity. Tests pin this.
+- Producer narrowing (`addEvidence(..., 'manual')` only) — **enforced**
+  by `PRODUCER_KIND_ALLOWLIST`; the CLI inherits that gate, does not
+  re-implement it.
+- `privacyTier: undefined` on synthesized rows — **add** — per spec
+  § Risks line 360, never auto-upgrade.
+- `confidence: 0.5` on synthesized rows — **add** — matches spec
+  § Migration line 210's suggested low-confidence value for coarse
+  legacy provenance.
+- `updatedAt: entity.createdAt` — **add** — preserves temporal ordering
+  and means a second run on the same entity produces identical content.
+- `EvidenceRenderer` helper — **add** — single-enforcement render path;
+  no ad-hoc render exists today (Phase 4 HTTP/dashboard hasn't shipped)
+  so this is preventive. `SemanticMemory`'s existing read-path
+  predicates are switched to delegate to the helper so we have ONE
+  visibility-comparison map across the codebase.
+
+---
+
+## 1. Over-block
+
+**URL anchoring rejects embedded URLs:** `source: "see https://example.com"`
+is skipped, not backfilled. By design — extracting a partial URL creates
+ambiguity ("which one of the URLs in this string is the real source?")
+and re-runs could backfill different URLs as the extractor evolves.
+Producers that need to retroactively cite an embedded URL can run a
+follow-up migration with a more permissive extractor; we keep the v1
+backfill conservative.
+
+**Whitespace not trimmed:** `source: "  https://x.com  "` is skipped.
+Same reason — trim semantics depend on convention; v1 keeps the rule
+"the source IS the URL, not a string containing a URL."
+
+**Producer-narrowing rejects `session:` / `user:`:** Already covered
+above. These need their own producer bridges, not this CLI. Explicitly
+tracked.
+
+## 2. Under-block
+
+- **`external-url` is not URL-validated:** Beyond the `https?://\S+`
+  anchor we don't parse the URL. A malformed-but-anchored value like
+  `https://[invalid:` would be backfilled. The renderer treats
+  `external-url.path` as display-only per spec § Threat Model line 372
+  ("renderers MUST treat `path` for `external-url` as display-only —
+  never auto-fetch"), so an invalid URL is a display-time annoyance,
+  not an SSRF or injection vector.
+- **`note` cap not retroactively applied:** We set a fixed
+  `'Backfilled from legacy MemoryEntity.source (Phase 5 migration)'`
+  note (52 bytes, well under the 500-byte cap). No risk.
+- **Concurrency:** The CLI doesn't take a DB lock. If a producer is
+  actively writing while backfill runs, both will succeed; the dup-check
+  loses the race for entities that get a fresh `external-url` evidence
+  row from a producer mid-scan. Mitigation: dup-check on every entity
+  before write (already present); on race, the producer's row lands
+  first and ours is skipped on second run. Operationally the CLI is
+  intended for offline / quiet-period invocation; this is documented.
+
+## 3. Level-of-abstraction fit
+
+Right layer. The backfill belongs at the CLI / command layer because:
+- It uses public `SemanticMemory` APIs (`export()`, `getEvidence()`,
+  `addEvidence()`) — no private-state access.
+- It's a one-shot operator-invoked migration, not a runtime path.
+- Pattern matching is at the edge (the CLI), not inside storage.
+
+`EvidenceRenderer` belongs in `src/memory/` because it owns evidence-shape
+filtering logic; pulling it out of `SemanticMemory.ts` (without dragging
+better-sqlite3 with it) lets non-SQLite render contexts (HTTP shapers,
+dashboard JSON producers) use it without spurious dependencies.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No** — this change has no judgment-level block/allow surface.
+
+The backfill's "skip" outcomes are mechanic-level pattern misses
+(`URL_SOURCE_PATTERN.test(source) === false`) or idempotency dedupes
+(equality-based dup-check). The renderer's filtering is mechanic-level
+ordering comparison (`tier ordinal >= evidence tier ordinal`). No
+intelligent gate, no judgment surface.
+
+The actual semantic question — "should this entity be cited by an
+external URL?" — was already answered by whoever set `source` on the
+entity. The CLI replays that answer into typed evidence; it does not
+re-decide.
+
+## 5. Interactions
+
+- **Phase 2 producers landing in parallel:** EvolutionManager /
+  DispatchExecutor producers write `feedback`, `pattern-entity`,
+  `job-run`, `ledger-entry`, `supersedes-evidence` rows. Backfill only
+  writes `external-url`. Zero overlap; dup-check is keyed on
+  `(kind === 'external-url' && path === source)` so even if Phase 2 had
+  attached an `external-url` row via a different producer (none of them
+  are allowed to per the allowlist), the URL-equality dup-check still
+  catches it.
+- **Phase 3 DecisionJournal / LearnSkill:** Same story — different
+  kinds; non-overlapping dup-check keys.
+- **`SemanticMemory.getEvidence` / `findCitations` / `getEntityWithEvidence`**:
+  Now delegate to the `EvidenceRenderer.isEntityVisibleAtScope` and
+  `isEvidenceVisibleAtScope` exports for the entity-visible /
+  evidence-visible predicates. The Phase 1 in-file copies are removed.
+  Verified by re-running the full Phase 1 test suite
+  (`semantic-memory-evidence.test.ts` 21/21, `semantic-memory.test.ts`
+  49/49, `semantic-memory-privacy.test.ts` 32/32) — all green.
+- **JSONL append log:** Every `addEvidence` call in the backfill emits
+  the existing `addEvidence` JSONL action; replay path is unchanged
+  (Phase 1's deferred-handler note about JSONL replay still applies —
+  unaffected by Phase 5).
+- **No HTTP / dashboard / threadline render today:** Phase 4 hasn't
+  landed; there is no ad-hoc evidence renderer in current production
+  code to replace. The helper is preventive — landing it now means
+  Phase 4 has exactly one place to call into when it adds HTTP routes
+  and dashboard panels. **No ad-hoc paths were found and replaced.**
+  This is documented as the intent rather than presented as completed
+  retro-replacement work.
+
+## 6. External surfaces
+
+- **Other agents on the same machine**: None. Backfill is per-agent,
+  per-state-directory.
+- **Other users of the install base**: A new subcommand appears on
+  `instar memory --help`. Default behavior of `instar memory <other>`
+  is unchanged. Running the CLI is opt-in.
+- **External systems**: None. Backfill is local-only; the
+  `external-url` rows it writes store the URL as a string for display,
+  never fetched (per spec § Threat Model line 372).
+- **Persistent state**: One `addEvidence` JSONL row per backfilled
+  entity, one `entity_evidence` table row per backfilled entity.
+  Bounded by the number of entities with URL sources.
+- **Privacy posture**: Tighter — backfilled rows inherit entity scope
+  (`privacyTier: undefined`); never auto-upgrade. The renderer helper
+  centralizes filtering; even if a Phase 4 callsite forgets to filter,
+  the helper's existence + spec-mandated call pattern catches the bug
+  at code-review time.
+
+## 7. Rollback cost
+
+- **Hot-fix release**: Pure additive change. `git revert <merge-commit>`
+  ships as the next patch.
+  - Backfilled `entity_evidence` rows from the `manual` producer would
+    remain in the DB; they are well-formed and harmless (renderer hides
+    them per viewer scope, never auto-fetched). If cleanup is desired,
+    `DELETE FROM entity_evidence WHERE kind = 'external-url'
+    AND note = 'Backfilled from legacy MemoryEntity.source (Phase 5 migration)'`
+    is a precise rollback query.
+  - `EvidenceRenderer.ts` deletion is fine; `SemanticMemory` would need
+    to re-introduce the local predicates. The revert PR can re-add them.
+- **Data migration**: None. Backfill is one-shot per entity by design;
+  rollback doesn't undo the writes (they're treated as legitimate
+  evidence rows), and re-running after revert+restore would just
+  produce zero writes thanks to idempotency.
+- **Agent state repair**: None.
+- **User visibility**: Zero today (no HTTP / dashboard renderers Phase 4
+  hasn't shipped); minimal after Phase 4 lands (filtered evidence rows
+  appear next to entities).
+
+---
+
+## Conclusion
+
+WikiClaim Phase 5 ships an idempotent, dry-run-safe, URL-only backfill
+CLI plus the renderer helper that closes the privacy-enforcement loop the
+spec § Storage and Privacy line 315 calls for. The CLI's intentional
+narrowness (URLs only, never `session:` / `user:`) preserves the
+`PRODUCER_KIND_ALLOWLIST` boundary Phase 1 installed; widening for
+migration convenience would unwind a structural defense. The renderer
+helper is preventive — Phase 4 HTTP/dashboard hasn't landed yet, so
+there are zero ad-hoc renderers to replace today, but the helper is in
+place and `SemanticMemory`'s own read paths now delegate to it so the
+codebase has exactly one visibility-comparison map. Cleared to ship
+pending second-pass concurrence.
+
+---
+
+## Second-pass review
+
+_To be filled in by independent reviewer subagent._
+
+---
+
+## Evidence pointers
+
+- New tests:
+  `npx vitest run tests/unit/memory-backfill-evidence.test.ts tests/unit/evidence-render-privacy.test.ts`
+  → 34/34 passing (~80ms).
+- Regression:
+  `npx vitest run tests/unit/semantic-memory-evidence.test.ts tests/unit/semantic-memory.test.ts tests/unit/semantic-memory-privacy.test.ts`
+  → 102/102 passing.
+- Typecheck: `npx tsc --noEmit` → clean.
+- Cross-product privacy coverage:
+  `tests/unit/evidence-render-privacy.test.ts` — 3 entity scopes × 5
+  evidence tiers × 3 viewer scopes (45 combinations) + edge-case
+  assertions.
+- Spec source of truth:
+  `docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md` §§ Migration
+  of Existing MemoryEntity Records (line 202), Risks lines 357, 360,
+  Migration Plan Phase 5 (line 347), Storage and Privacy line 315.
+- Phase 1 artifact: `upgrades/side-effects/wikiclaim-evidence-phase1.md`.


### PR DESCRIPTION
## Summary

Phase 5 of the WikiClaim evidence import — final piece of `docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md` (Migration Plan line 347).

- **CLI**: `instar memory backfill-evidence [--dry-run]` walks every existing `MemoryEntity` and synthesizes one `external-url` evidence row when `source` is an anchored URL. Idempotent (dup-check on URL equality at widest viewer scope). Non-URL sources stay `evidence: []` per spec § Risks line 357 (no LLM in migration path). `privacyTier: undefined` — never auto-upgrade per spec § Risks line 360.
- **Render hardening**: new `src/memory/EvidenceRenderer.ts` is the single privacy-enforcement helper per spec § Storage and Privacy line 315. `SemanticMemory.getEvidence` / `findCitations` / `getEntityWithEvidence` now delegate to its predicates so one visibility-comparison map covers the codebase. Preventive — no ad-hoc renderers exist today (Phase 4 HTTP/dashboard hasn't shipped); the helper is ready for Phase 4 callsites.
- **Scope narrowing (intentional)**: backfill writes ONLY `external-url`. The `manual` producer is restricted to that kind by `PRODUCER_KIND_ALLOWLIST` (Phase 1). `session:` / `user:` legacy patterns require their own producer bridges with subsystem context — widening the allowlist for migration convenience would unwind a structural defense, so we don't.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/unit/memory-backfill-evidence.test.ts tests/unit/evidence-render-privacy.test.ts` — 34/34 (17 backfill + 17 cross-product privacy)
- [x] Regression: `npx vitest run tests/unit/semantic-memory-evidence.test.ts tests/unit/semantic-memory.test.ts tests/unit/semantic-memory-privacy.test.ts` — 102/102
- [x] Cross-product privacy (spec § Risks line 356): 3 entity scopes × 5 evidence tiers × 3 viewer scopes = 45 render combinations + 6 edge-case assertions, no leak.
- [x] Idempotency: second backfill run = 0 writes; second run holds across entity privacy tiers; dry-run is non-mutating.
- [x] Producer narrowing: `addEvidence(..., 'manual')` with non-`external-url` kind throws `EvidencePolicyError`.

Spec: `docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md` (converged 2026-05-07, approved)
Side-effects review: `upgrades/side-effects/wikiclaim-evidence-phase5.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)