### PR TITLE
feat(memory): WikiClaim Phase 4 — inverse-traceability HTTP + dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2527,6 +2527,7 @@
           <button class="tab" data-tab="commitments" onclick="switchTab('commitments')">Commitments <span class="tab-count" id="tabCommitmentCount">0</span></button>
           <button class="tab" data-tab="tokens" onclick="switchTab('tokens')">Tokens</button>
           <button class="tab" data-tab="threadline" onclick="switchTab('threadline')">Threadline</button>
+          <button class="tab" data-tab="evidence" onclick="switchTab('evidence')">Evidence</button>
         </nav>
       </div>
       <div class="vital-signs" id="vitalSigns">
@@ -2987,6 +2988,66 @@
         <div id="tokensOrphansBody" style="font-size:13px">
           <div style="color:var(--text-dim)">Loading...</div>
         </div>
+      </div>
+    </div>
+
+    <!-- Evidence Tab (WikiClaim Phase 4) — per-entity evidence + reverse "what cites this?" view.
+         Spec: docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md § Phase 4 (line 343). -->
+    <div id="evidenceTab" style="display:none;flex-direction:column;padding:20px;gap:16px;overflow-y:auto">
+      <div style="display:flex;justify-content:space-between;align-items:center">
+        <h2 style="margin:0">Evidence</h2>
+        <div style="font-size:12px;color:var(--text-dim)">Per-entity evidence + reverse citations</div>
+      </div>
+      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+        Inspect the evidence trail behind any memory entity, or ask "what cites this?" given a kind + sourceId.
+        All results are viewer-scope filtered by SemanticMemory before they reach this view.
+      </div>
+
+      <!-- Viewer scope selector (default: private — agent's own data) -->
+      <div style="display:flex;align-items:center;gap:10px;font-size:13px">
+        <label for="evViewerScope" style="color:var(--text-dim)">Viewer scope:</label>
+        <select id="evViewerScope" style="background:var(--bg);color:var(--text);border:1px solid var(--border);padding:4px 8px;border-radius:4px">
+          <option value="private" selected>private (full)</option>
+          <option value="shared-topic">shared-topic</option>
+          <option value="shared-project">shared-project</option>
+        </select>
+        <span style="color:var(--text-dim);font-size:12px">Narrowing-only — controls what a narrower viewer would see.</span>
+      </div>
+
+      <!-- Panel 1: Per-entity evidence lookup -->
+      <div style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:10px">
+        <div style="font-weight:600">Evidence by entity</div>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+          <input id="evEntityId" type="text" placeholder="Entity ID (e.g. ent_abc123)"
+                 style="flex:1;min-width:240px;background:var(--bg);color:var(--text);border:1px solid var(--border);padding:6px 10px;border-radius:4px;font-family:monospace" />
+          <button onclick="loadEvidenceByEntity()" style="padding:6px 12px">Lookup</button>
+        </div>
+        <div id="evEntityStatus" style="font-size:12px;color:var(--text-dim);min-height:1em"></div>
+        <div id="evEntityResults" style="display:flex;flex-direction:column;gap:8px"></div>
+      </div>
+
+      <!-- Panel 2: Reverse citation lookup ("what cites this?") -->
+      <div style="border:1px solid var(--border);border-radius:8px;padding:16px;display:flex;flex-direction:column;gap:10px">
+        <div style="font-weight:600">What cites this?</div>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+          <select id="evCitationKind" style="background:var(--bg);color:var(--text);border:1px solid var(--border);padding:6px 10px;border-radius:4px">
+            <option value="feedback">feedback</option>
+            <option value="commit">commit</option>
+            <option value="session">session</option>
+            <option value="document">document</option>
+            <option value="message">message</option>
+            <option value="job-run">job-run</option>
+            <option value="ledger-entry">ledger-entry</option>
+            <option value="pattern-entity">pattern-entity</option>
+            <option value="external-url">external-url</option>
+            <option value="supersedes-evidence">supersedes-evidence</option>
+          </select>
+          <input id="evCitationSourceId" type="text" placeholder="sourceId (e.g. fb_abc123)"
+                 style="flex:1;min-width:240px;background:var(--bg);color:var(--text);border:1px solid var(--border);padding:6px 10px;border-radius:4px;font-family:monospace" />
+          <button onclick="loadEntitiesByEvidence()" style="padding:6px 12px">Find citing entities</button>
+        </div>
+        <div id="evCitationStatus" style="font-size:12px;color:var(--text-dim);min-height:1em"></div>
+        <div id="evCitationResults" style="display:flex;flex-direction:column;gap:8px"></div>
       </div>
     </div>
 
@@ -4152,6 +4213,12 @@
         },
       },
       {
+        id: 'evidence',
+        panels: ['evidenceTab'],
+        display: ['flex'],
+        onActivate: null,
+      },
+      {
         id: 'secrets',
         panels: ['secretsPanel'],
         display: ['flex'],
@@ -4327,6 +4394,178 @@
     function escapeHtml(s) {
       return String(s ?? '').replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
     }
+
+    // ── Evidence Tab (WikiClaim Phase 4) ─────────────────────────────
+    //
+    // All evidence rendering MUST escape user-supplied strings (note,
+    // sourceId, path). The route already viewer-scope-filters via
+    // SemanticMemory — the dashboard never makes a visibility decision.
+
+    function evCurrentViewerScope() {
+      const sel = document.getElementById('evViewerScope');
+      return sel ? sel.value : 'private';
+    }
+
+    function evRenderTierBadge(tier) {
+      const v = tier == null ? 'inherited' : String(tier);
+      const colorMap = {
+        'public': '#4a9a4a',
+        'shared-project': '#7aa9d6',
+        'private': '#e27d3b',
+        'sensitive': '#c14a4a',
+        'inherited': 'var(--text-dim)',
+      };
+      const color = colorMap[v] || 'var(--text-dim)';
+      return `<span style="font-size:11px;padding:2px 6px;border-radius:3px;border:1px solid ${color};color:${color}">${escapeHtml(v)}</span>`;
+    }
+
+    function evRenderEvidenceRow(ev) {
+      const kind = escapeHtml(ev?.kind ?? '');
+      const sourceId = escapeHtml(ev?.sourceId ?? '');
+      const path = ev?.path ? escapeHtml(ev.path) : '';
+      const lineStart = ev?.lineStart;
+      const lineEnd = ev?.lineEnd;
+      let fileLine = '';
+      if (path) {
+        let suffix = '';
+        if (Number.isFinite(lineStart)) {
+          suffix = ':' + escapeHtml(String(lineStart));
+          if (Number.isFinite(lineEnd) && lineEnd !== lineStart) {
+            suffix += '-' + escapeHtml(String(lineEnd));
+          }
+        } else if (typeof ev?.lines === 'string') {
+          suffix = ':' + escapeHtml(ev.lines);
+        }
+        fileLine = `<span style="font-family:monospace;font-size:12px;color:var(--text-dim)">${path}${suffix}</span>`;
+      }
+      const weight = (typeof ev?.weight === 'number') ? ev.weight.toFixed(2) : '—';
+      const confidence = (typeof ev?.confidence === 'number') ? ev.confidence.toFixed(2) : '—';
+      const note = ev?.note ? escapeHtml(ev.note) : '';
+      const updatedAt = escapeHtml(ev?.updatedAt ?? '');
+
+      return `
+        <div style="border:1px solid var(--border);border-radius:6px;padding:10px 12px;display:flex;flex-direction:column;gap:6px;background:var(--bg-panel)">
+          <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+            <span style="font-weight:600;font-size:13px">${kind}</span>
+            <span style="font-family:monospace;font-size:12px;color:var(--text-dim)">${sourceId}</span>
+            ${evRenderTierBadge(ev?.privacyTier)}
+          </div>
+          ${fileLine ? `<div>${fileLine}</div>` : ''}
+          <div style="font-size:12px;color:var(--text-dim);display:flex;gap:12px;flex-wrap:wrap">
+            <span>weight: ${escapeHtml(weight)}</span>
+            <span>confidence: ${escapeHtml(confidence)}</span>
+            <span>updated: ${updatedAt}</span>
+          </div>
+          ${note ? `<div style="font-size:13px;line-height:1.4;white-space:pre-wrap;word-break:break-word">${note}</div>` : ''}
+        </div>
+      `;
+    }
+
+    function evRenderEntityRow(entity) {
+      const id = escapeHtml(entity?.id ?? '');
+      const type = escapeHtml(entity?.type ?? '');
+      const name = escapeHtml(entity?.name ?? '');
+      const content = entity?.content ? escapeHtml(String(entity.content).slice(0, 240)) : '';
+      const scope = escapeHtml(entity?.privacyScope ?? 'shared-project');
+      const confidence = (typeof entity?.confidence === 'number') ? entity.confidence.toFixed(2) : '—';
+      return `
+        <div style="border:1px solid var(--border);border-radius:6px;padding:10px 12px;display:flex;flex-direction:column;gap:6px;background:var(--bg-panel)">
+          <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+            <span style="font-weight:600;font-size:13px">${type}</span>
+            <span style="font-size:13px">${name}</span>
+            <span style="font-family:monospace;font-size:11px;color:var(--text-dim)">${id}</span>
+            <span style="font-size:11px;padding:2px 6px;border-radius:3px;border:1px solid var(--border);color:var(--text-dim)">${scope}</span>
+            <span style="font-size:11px;color:var(--text-dim)">confidence: ${escapeHtml(confidence)}</span>
+            <button class="ev-inspect-btn" data-entity-id="${id}" style="margin-left:auto;padding:2px 8px;font-size:11px">Inspect evidence</button>
+          </div>
+          ${content ? `<div style="font-size:12px;color:var(--text-dim);line-height:1.4">${content}</div>` : ''}
+        </div>
+      `;
+    }
+
+    async function loadEvidenceByEntity() {
+      const idInput = document.getElementById('evEntityId');
+      const status = document.getElementById('evEntityStatus');
+      const results = document.getElementById('evEntityResults');
+      if (!idInput || !status || !results) return;
+      const id = (idInput.value || '').trim();
+      if (!id) {
+        status.textContent = 'Enter an entity ID.';
+        results.innerHTML = '';
+        return;
+      }
+      status.textContent = 'Loading…';
+      results.innerHTML = '';
+      try {
+        const viewerScope = evCurrentViewerScope();
+        const url = '/memory/evidence/by-entity/' + encodeURIComponent(id)
+          + '?viewerScope=' + encodeURIComponent(viewerScope);
+        const data = await apiFetch(url);
+        const ev = Array.isArray(data.evidence) ? data.evidence : [];
+        if (ev.length === 0) {
+          status.textContent = 'No evidence visible at viewer scope "' + viewerScope + '".';
+          results.innerHTML = '';
+          return;
+        }
+        status.textContent = ev.length + ' evidence row(s) at scope "' + viewerScope + '".';
+        results.innerHTML = ev.map(evRenderEvidenceRow).join('');
+      } catch (err) {
+        const msg = (err && err.message) ? err.message : 'Lookup failed';
+        status.innerHTML = '<span style="color:var(--red)">' + escapeHtml(msg) + '</span>';
+        results.innerHTML = '';
+      }
+    }
+
+    function evLookupFromCitation(entityId) {
+      const idInput = document.getElementById('evEntityId');
+      if (idInput) idInput.value = entityId;
+      loadEvidenceByEntity();
+    }
+
+    async function loadEntitiesByEvidence() {
+      const kindEl = document.getElementById('evCitationKind');
+      const sourceIdEl = document.getElementById('evCitationSourceId');
+      const status = document.getElementById('evCitationStatus');
+      const results = document.getElementById('evCitationResults');
+      if (!kindEl || !sourceIdEl || !status || !results) return;
+      const kind = kindEl.value;
+      const sourceId = (sourceIdEl.value || '').trim();
+      if (!sourceId) {
+        status.textContent = 'Enter a sourceId.';
+        results.innerHTML = '';
+        return;
+      }
+      status.textContent = 'Loading…';
+      results.innerHTML = '';
+      try {
+        const viewerScope = evCurrentViewerScope();
+        const url = '/memory/entities/by-evidence'
+          + '?kind=' + encodeURIComponent(kind)
+          + '&sourceId=' + encodeURIComponent(sourceId)
+          + '&viewerScope=' + encodeURIComponent(viewerScope);
+        const data = await apiFetch(url);
+        const entities = Array.isArray(data.entities) ? data.entities : [];
+        if (entities.length === 0) {
+          status.textContent = 'No entities cite (' + kind + ', ' + sourceId + ') at scope "' + viewerScope + '".';
+          results.innerHTML = '';
+          return;
+        }
+        status.textContent = entities.length + ' entity(ies) cite this source at scope "' + viewerScope + '".';
+        results.innerHTML = entities.map(evRenderEntityRow).join('');
+        // Attach click handlers via data attribute (no inline onclick injection).
+        results.querySelectorAll('button.ev-inspect-btn').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            const targetId = btn.getAttribute('data-entity-id') || '';
+            if (targetId) evLookupFromCitation(targetId);
+          });
+        });
+      } catch (err) {
+        const msg = (err && err.message) ? err.message : 'Lookup failed';
+        status.innerHTML = '<span style="color:var(--red)">' + escapeHtml(msg) + '</span>';
+        results.innerHTML = '';
+      }
+    }
+
     async function loadTokens() {
       const summaryEl = document.getElementById('tokensSummaryBody');
       const sessionsEl = document.getElementById('tokensSessionsBody');

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2362,6 +2362,121 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
+  // ── WikiClaim Phase 4 — Inverse-traceability HTTP endpoints ───────
+  //
+  // Per docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md § Phase 4
+  // (line 343) and § Inverse traceability (line 291).
+  //
+  // Both routes are thin pass-throughs to SemanticMemory's already-filtered
+  // typed methods (`getEvidence` / `findCitations`). Privacy enforcement
+  // lives ONE place — the storage layer's read-time filter (Phase 1) plus
+  // the EvidenceRenderer helper (Phase 5). These routes do not re-implement
+  // the filter; they invoke the methods and serialize the result.
+  //
+  // viewerScope derivation: the single bearer-token auth model has one
+  // principal (the agent itself), which sees its own data at `private`
+  // scope by default. Callers can request a NARROWED view via the
+  // `?viewerScope=shared-project|shared-topic|private` query param —
+  // useful for "what would a topic-peer see?" preview rendering in the
+  // dashboard. Widening above the auth principal is a no-op (the cap is
+  // `private`). Per spec § Storage and Privacy line 315 — the renderer is
+  // the privacy boundary; this route is a read endpoint with no
+  // judgment surface.
+  const VALID_EVIDENCE_KINDS = new Set([
+    'feedback', 'commit', 'session', 'document', 'message',
+    'job-run', 'ledger-entry', 'pattern-entity', 'external-url',
+    'supersedes-evidence',
+  ]);
+  const VALID_VIEWER_SCOPES = new Set(['shared-project', 'shared-topic', 'private']);
+
+  function resolveViewerScope(raw: unknown): 'shared-project' | 'shared-topic' | 'private' {
+    if (typeof raw === 'string' && VALID_VIEWER_SCOPES.has(raw)) {
+      return raw as 'shared-project' | 'shared-topic' | 'private';
+    }
+    // Default: agent has full visibility into its own DB.
+    return 'private';
+  }
+
+  // GET /memory/evidence/by-entity/:id
+  // Returns the entity's evidence array, viewer-scope filtered.
+  router.get('/memory/evidence/by-entity/:id', (req, res) => {
+    if (!ctx.semanticMemory) {
+      res.status(503).json({ error: 'Semantic memory not enabled' });
+      return;
+    }
+    try {
+      const entityId = req.params.id;
+      if (!entityId || typeof entityId !== 'string') {
+        res.status(400).json({ error: 'Missing entity id' });
+        return;
+      }
+      const viewerScope = resolveViewerScope(req.query.viewerScope);
+
+      // Existence + entity-level visibility check goes through the eager
+      // helper, which returns null when the entity is hidden (or missing)
+      // at the requested viewer scope. We deliberately collapse "entity
+      // exists but entity-scope wider than viewer" and "entity does not
+      // exist" into the same 404 — the spec's inverse-query non-leak rule
+      // (§ Storage and Privacy line 316) extends to direct fetch: a viewer
+      // at a narrower scope must not be able to probe entity existence by
+      // diffing 404 vs 200-empty.
+      const eager = ctx.semanticMemory.getEntityWithEvidence(entityId, viewerScope);
+      if (!eager) {
+        res.status(404).json({ error: 'Entity not found' });
+        return;
+      }
+      res.json({
+        entityId,
+        viewerScope,
+        evidence: eager.evidence,
+      });
+    } catch (err) {
+      res.status(500).json({
+        error: err instanceof Error ? err.message : 'Evidence lookup failed',
+      });
+    }
+  });
+
+  // GET /memory/entities/by-evidence?kind=feedback&sourceId=fb_123
+  // Returns entities citing (kind, sourceId), viewer-scope filtered.
+  router.get('/memory/entities/by-evidence', (req, res) => {
+    if (!ctx.semanticMemory) {
+      res.status(503).json({ error: 'Semantic memory not enabled' });
+      return;
+    }
+    try {
+      const kindRaw = req.query.kind;
+      const sourceIdRaw = req.query.sourceId;
+      const kind = typeof kindRaw === 'string' ? kindRaw : '';
+      const sourceId = typeof sourceIdRaw === 'string' ? sourceIdRaw : '';
+      if (!kind || !sourceId) {
+        res.status(400).json({ error: 'Missing required query params: kind, sourceId' });
+        return;
+      }
+      if (!VALID_EVIDENCE_KINDS.has(kind)) {
+        res.status(400).json({ error: `Invalid evidence kind: ${kind}` });
+        return;
+      }
+      const viewerScope = resolveViewerScope(req.query.viewerScope);
+
+      const entities = ctx.semanticMemory.findCitations(
+        { kind: kind as any, sourceId },
+        viewerScope,
+      );
+      res.json({
+        kind,
+        sourceId,
+        viewerScope,
+        entities,
+        totalResults: entities.length,
+      });
+    } catch (err) {
+      res.status(500).json({
+        error: err instanceof Error ? err.message : 'Citation lookup failed',
+      });
+    }
+  });
+
   // ── MEMORY.md Export (Phase 6) ─────────────────────────────────
 
   router.post('/semantic/export-memory', async (req, res) => {

--- a/tests/unit/memory-evidence-routes.test.ts
+++ b/tests/unit/memory-evidence-routes.test.ts
@@ -1,0 +1,382 @@
+/**
+ * WikiClaim Phase 4 — Tests for the inverse-traceability HTTP endpoints.
+ *
+ * Spec: docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md § Phase 4
+ * (line 343) + § Storage and Privacy (line 310). Real SQLite, no mocks —
+ * the whole point is exercising the storage-layer viewer-scope filter.
+ *
+ * Endpoints under test:
+ *   - GET /memory/evidence/by-entity/:id?viewerScope=...
+ *   - GET /memory/entities/by-evidence?kind=...&sourceId=...&viewerScope=...
+ *
+ * Coverage:
+ *   - by-entity returns viewer-scope filtered evidence
+ *   - by-evidence works with kind+sourceId
+ *   - auth required (401 without bearer)
+ *   - 404 on unknown entity
+ *   - 400 on missing/invalid query params
+ *   - empty array on no-citations match
+ *   - cross-product privacy: viewer at shared-project cannot see private-tier
+ *     evidence in either endpoint (entity nor evidence row)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { createRoutes } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import { SemanticMemory } from '../../src/memory/SemanticMemory.js';
+import type { MemoryEvidence } from '../../src/core/types.js';
+
+const AUTH_TOKEN = 'test-token-abc-123';
+
+interface TestServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function listen(app: express.Express): Promise<TestServer> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => srv.close(() => r())),
+      });
+    });
+  });
+}
+
+interface Setup {
+  dir: string;
+  memory: SemanticMemory;
+  server: TestServer;
+  cleanup: () => Promise<void>;
+}
+
+async function buildSetup(): Promise<Setup> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mem-evidence-routes-test-'));
+  const dbPath = path.join(dir, 'semantic.db');
+  const memory = new SemanticMemory({
+    dbPath,
+    decayHalfLifeDays: 30,
+    lessonDecayHalfLifeDays: 90,
+    staleThreshold: 0.2,
+  });
+  await memory.open();
+
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware(AUTH_TOKEN));
+
+  const ctx: any = {
+    config: { authToken: AUTH_TOKEN, stateDir: dir, port: 0 },
+    semanticMemory: memory,
+  };
+  app.use(createRoutes(ctx));
+
+  const server = await listen(app);
+  return {
+    dir,
+    memory,
+    server,
+    cleanup: async () => {
+      await server.close();
+      memory.close();
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/memory-evidence-routes.test.ts',
+      });
+    },
+  };
+}
+
+async function get(
+  server: TestServer,
+  url: string,
+  opts: { auth?: boolean } = { auth: true },
+): Promise<{ status: number; body: any }> {
+  const headers: Record<string, string> = {};
+  if (opts.auth !== false) {
+    headers['Authorization'] = `Bearer ${AUTH_TOKEN}`;
+  }
+  const r = await fetch(server.url + url, { headers });
+  const body = await r.json().catch(() => ({}));
+  return { status: r.status, body };
+}
+
+const ev = (over: Partial<MemoryEvidence> = {}): MemoryEvidence => ({
+  kind: 'feedback',
+  sourceId: 'fb_default',
+  updatedAt: '2026-05-09T00:00:00Z',
+  weight: 0.7,
+  confidence: 0.8,
+  ...over,
+});
+
+describe('GET /memory/evidence/by-entity/:id', () => {
+  let s: Setup;
+  beforeEach(async () => { s = await buildSetup(); });
+  afterEach(async () => { await s.cleanup(); });
+
+  it('returns 401 without bearer token', async () => {
+    const r = await get(s.server, '/memory/evidence/by-entity/whatever', { auth: false });
+    expect(r.status).toBe(401);
+  });
+
+  it('returns 404 on unknown entity', async () => {
+    const r = await get(s.server, '/memory/evidence/by-entity/does-not-exist');
+    expect(r.status).toBe(404);
+  });
+
+  it('returns the entity evidence array, viewer-scope filtered', async () => {
+    const id = s.memory.rememberWithEvidence(
+      {
+        type: 'pattern',
+        name: 'route-test-pattern',
+        content: 'phase4 route test',
+        confidence: 0.9,
+        lastVerified: '2026-05-09T00:00:00Z',
+        source: 'cluster-builder',
+        tags: ['phase4'],
+        privacyScope: 'shared-project',
+      },
+      [
+        ev({ sourceId: 'fb_a', privacyTier: 'shared-project' }),
+        ev({ sourceId: 'fb_b', privacyTier: 'shared-project' }),
+      ],
+      'EvolutionManager',
+    );
+
+    const r = await get(s.server, `/memory/evidence/by-entity/${id}?viewerScope=shared-project`);
+    expect(r.status).toBe(200);
+    expect(r.body.entityId).toBe(id);
+    expect(r.body.viewerScope).toBe('shared-project');
+    expect(Array.isArray(r.body.evidence)).toBe(true);
+    expect(r.body.evidence.length).toBe(2);
+    const ids = r.body.evidence.map((e: any) => e.sourceId).sort();
+    expect(ids).toEqual(['fb_a', 'fb_b']);
+  });
+
+  it('cross-product: viewer at shared-project cannot see private-tier evidence', async () => {
+    const id = s.memory.rememberWithEvidence(
+      {
+        type: 'pattern',
+        name: 'mixed-tier-entity',
+        content: 'private evidence on a shared-project entity',
+        confidence: 0.9,
+        lastVerified: '2026-05-09T00:00:00Z',
+        source: 'cluster-builder',
+        tags: [],
+        privacyScope: 'shared-project',
+      },
+      [
+        ev({ sourceId: 'fb_shared', privacyTier: 'shared-project' }),
+        ev({ sourceId: 'fb_private', privacyTier: 'private' }),
+        ev({ sourceId: 'fb_sensitive', privacyTier: 'sensitive' }),
+      ],
+      'EvolutionManager',
+    );
+
+    // shared-project viewer: should see ONLY the shared-project tier, not
+    // private or sensitive (the entity is shared-project but evidence rows
+    // can be tagged narrower per spec narrowing-only constraint).
+    const narrow = await get(s.server, `/memory/evidence/by-entity/${id}?viewerScope=shared-project`);
+    expect(narrow.status).toBe(200);
+    const narrowSourceIds = narrow.body.evidence.map((e: any) => e.sourceId).sort();
+    expect(narrowSourceIds).toEqual(['fb_shared']);
+
+    // private viewer: should see the shared-project + private rows; sensitive
+    // is still narrower than private (`sensitive` is the most-restrictive
+    // tier per EvidenceRenderer's ordering).
+    const wide = await get(s.server, `/memory/evidence/by-entity/${id}?viewerScope=private`);
+    expect(wide.status).toBe(200);
+    const wideSourceIds = wide.body.evidence.map((e: any) => e.sourceId).sort();
+    expect(wideSourceIds).toEqual(['fb_private', 'fb_shared']);
+  });
+
+  it('defaults viewerScope to private when query param is absent', async () => {
+    const id = s.memory.rememberWithEvidence(
+      {
+        type: 'pattern',
+        name: 'default-scope',
+        content: 'default scope test',
+        confidence: 0.9,
+        lastVerified: '2026-05-09T00:00:00Z',
+        source: 'cluster-builder',
+        tags: [],
+        privacyScope: 'private',
+      },
+      [ev({ sourceId: 'fb_priv', privacyTier: 'private' })],
+      'EvolutionManager',
+    );
+    const r = await get(s.server, `/memory/evidence/by-entity/${id}`);
+    expect(r.status).toBe(200);
+    expect(r.body.viewerScope).toBe('private');
+    expect(r.body.evidence.length).toBe(1);
+  });
+
+  it('returns 404 (non-leaky) when a private entity is requested at shared-project scope', async () => {
+    // Spec § Storage and Privacy line 316: inverse-query non-leak rule.
+    // A direct fetch must not 200-empty when the entity exists but is
+    // hidden from the viewer — that would leak existence by diffing.
+    const id = s.memory.rememberWithEvidence(
+      {
+        type: 'pattern',
+        name: 'private-only-entity',
+        content: 'private payload',
+        confidence: 0.9,
+        lastVerified: '2026-05-09T00:00:00Z',
+        source: 'cluster-builder',
+        tags: [],
+        privacyScope: 'private',
+      },
+      [ev({ sourceId: 'fb_hidden', privacyTier: 'private' })],
+      'EvolutionManager',
+    );
+    const r = await get(s.server, `/memory/evidence/by-entity/${id}?viewerScope=shared-project`);
+    expect(r.status).toBe(404);
+  });
+});
+
+describe('GET /memory/entities/by-evidence', () => {
+  let s: Setup;
+  beforeEach(async () => { s = await buildSetup(); });
+  afterEach(async () => { await s.cleanup(); });
+
+  it('returns 401 without bearer token', async () => {
+    const r = await get(
+      s.server,
+      '/memory/entities/by-evidence?kind=feedback&sourceId=fb_x',
+      { auth: false },
+    );
+    expect(r.status).toBe(401);
+  });
+
+  it('returns 400 when kind is missing', async () => {
+    const r = await get(s.server, '/memory/entities/by-evidence?sourceId=fb_x');
+    expect(r.status).toBe(400);
+  });
+
+  it('returns 400 when sourceId is missing', async () => {
+    const r = await get(s.server, '/memory/entities/by-evidence?kind=feedback');
+    expect(r.status).toBe(400);
+  });
+
+  it('returns 400 on invalid kind', async () => {
+    const r = await get(s.server, '/memory/entities/by-evidence?kind=bogus&sourceId=fb_x');
+    expect(r.status).toBe(400);
+  });
+
+  it('returns empty array when no entities cite the source', async () => {
+    const r = await get(s.server, '/memory/entities/by-evidence?kind=feedback&sourceId=fb_never_seen');
+    expect(r.status).toBe(200);
+    expect(r.body.entities).toEqual([]);
+    expect(r.body.totalResults).toBe(0);
+    expect(r.body.viewerScope).toBe('private');
+  });
+
+  it('returns entities citing (kind, sourceId) viewer-scope filtered', async () => {
+    // Two entities cite the same (kind, sourceId), one is shared-project and
+    // one is private.
+    const sharedId = s.memory.rememberWithEvidence(
+      {
+        type: 'pattern',
+        name: 'shared-project-citer',
+        content: 'cites fb_target at shared-project tier',
+        confidence: 0.9,
+        lastVerified: '2026-05-09T00:00:00Z',
+        source: 'cluster-builder',
+        tags: [],
+        privacyScope: 'shared-project',
+      },
+      [ev({ sourceId: 'fb_target', privacyTier: 'shared-project' })],
+      'EvolutionManager',
+    );
+    const privateId = s.memory.rememberWithEvidence(
+      {
+        type: 'pattern',
+        name: 'private-citer',
+        content: 'cites fb_target at private tier',
+        confidence: 0.9,
+        lastVerified: '2026-05-09T00:00:00Z',
+        source: 'cluster-builder',
+        tags: [],
+        privacyScope: 'private',
+      },
+      [ev({ sourceId: 'fb_target', privacyTier: 'private' })],
+      'EvolutionManager',
+    );
+
+    // viewer=private — sees both
+    const wide = await get(
+      s.server,
+      '/memory/entities/by-evidence?kind=feedback&sourceId=fb_target&viewerScope=private',
+    );
+    expect(wide.status).toBe(200);
+    const wideIds = wide.body.entities.map((e: any) => e.id).sort();
+    expect(wideIds).toEqual([sharedId, privateId].sort());
+
+    // viewer=shared-project — sees only the shared-project entity
+    const narrow = await get(
+      s.server,
+      '/memory/entities/by-evidence?kind=feedback&sourceId=fb_target&viewerScope=shared-project',
+    );
+    expect(narrow.status).toBe(200);
+    const narrowIds = narrow.body.entities.map((e: any) => e.id);
+    expect(narrowIds).toEqual([sharedId]);
+  });
+
+  it('cross-product: shared-project viewer cannot see private-tier evidence inverse query (even on shared-project entity)', async () => {
+    // Entity is shared-project but the evidence row is private-tier.
+    // findCitations filters by BOTH entity scope AND evidence tier per spec
+    // line 316 — this is the "no inverse leak" guarantee.
+    const id = s.memory.rememberWithEvidence(
+      {
+        type: 'pattern',
+        name: 'shared-entity-private-evidence',
+        content: 'leaky shape',
+        confidence: 0.9,
+        lastVerified: '2026-05-09T00:00:00Z',
+        source: 'cluster-builder',
+        tags: [],
+        privacyScope: 'shared-project',
+      },
+      [ev({ sourceId: 'fb_leaktest', privacyTier: 'private' })],
+      'EvolutionManager',
+    );
+
+    // viewer=private sees the citation
+    const wide = await get(
+      s.server,
+      '/memory/entities/by-evidence?kind=feedback&sourceId=fb_leaktest&viewerScope=private',
+    );
+    expect(wide.status).toBe(200);
+    expect(wide.body.entities.map((e: any) => e.id)).toEqual([id]);
+
+    // viewer=shared-project does NOT see the citation — the evidence row's
+    // private tier is wider than the viewer.
+    const narrow = await get(
+      s.server,
+      '/memory/entities/by-evidence?kind=feedback&sourceId=fb_leaktest&viewerScope=shared-project',
+    );
+    expect(narrow.status).toBe(200);
+    expect(narrow.body.entities).toEqual([]);
+  });
+
+  it('echoes the kind/sourceId/viewerScope in the response shape', async () => {
+    const r = await get(
+      s.server,
+      '/memory/entities/by-evidence?kind=commit&sourceId=sha_zzz&viewerScope=shared-topic',
+    );
+    expect(r.status).toBe(200);
+    expect(r.body.kind).toBe('commit');
+    expect(r.body.sourceId).toBe('sha_zzz');
+    expect(r.body.viewerScope).toBe('shared-topic');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -45,11 +45,23 @@ Set any rate-limit field to `Infinity` to disable that gate. Set `cache.maxEntri
 
 **Quiet bug fix**: Phase 2's `taskflow-cancel-requested` notes and Phase 3a's `taskflow-divergence` notes were previously silently dropped due to a schema-validation gap in `SharedStateLedger.VALID_SUBSYSTEMS`. This release closes the gap — both note kinds now land correctly.
 
+### WikiClaim Phase 4 — inverse-traceability HTTP + dashboard
+
+You can now ask the memory store two new questions over HTTP:
+
+- **"What evidence backs this entity?"** — `GET /memory/evidence/by-entity/:id?viewerScope=...`
+- **"Which entities cite this source?"** — `GET /memory/entities/by-evidence?kind=feedback&sourceId=fb_abc123&viewerScope=...`
+
+Both routes are read-only, auth-required (bearer token), and viewer-scope filtered by `SemanticMemory` before any bytes leave storage. `viewerScope` is an optional query param defaulting to `private` (full visibility for the agent's own DB); pass a narrower scope to preview what a topic-peer or project-peer would see.
+
+A new **Evidence** tab in the dashboard wraps both routes: enter an entity ID to see its evidence trail, or pick a kind + sourceId to find every entity citing that source. The "Inspect evidence" button on a citation result pivots you back to the per-entity view in one click.
+
 ## What to Tell Your User
 
 - **Your TaskFlow API now has resource budgets**: "I added per-controller rate limits and a max-active-flows cap so a buggy or malicious controller can't flood the registry. Defaults: 10 new flows/sec, 50 active flows, 60 heartbeats/min/flow. All configurable. If a real workload hits a limit, raise it in `config.taskFlow.rateLimits`; setting `Infinity` disables a gate."
 - **You can now read a full state-machine audit trail in `.instar/shared-state.jsonl`** — every TaskFlow state transition is logged under subsystem `taskflow-transition` with the redacted metadata (no controller-private state ever leaves the registry).
 - **Divergence and cancellation notes that should have been landing since Phase 2/3a now actually land** — a schema-validation gap was silently dropping them. Operator dashboards now see those notes for the first time.
+- **Memory evidence is now browsable**: "I added an Evidence tab in your dashboard and two HTTP routes that let me trace any claim back to its sources, or pivot from a source (a feedback report, a commit, a session) to every entity that cites it. Everything is viewer-scope filtered, so a narrower viewer never sees evidence above their tier."
 
 ## Summary of New Capabilities
 
@@ -62,6 +74,9 @@ Set any rate-limit field to `Infinity` to disable that gate. Set `cache.maxEntri
 | Cache eviction metric | grep for `taskflow_cache_evictions_total=` in metric logs |
 | State-transition audit trail | grep for `subsystem='taskflow-transition'` in `.instar/shared-state.jsonl` |
 | Retry-After response header | clients that honor RFC 7231 § 7.1.3 see `Retry-After: <seconds>` on 429 |
+| Per-entity evidence lookup over HTTP | `GET /memory/evidence/by-entity/:id?viewerScope=...` |
+| Inverse-citation lookup over HTTP | `GET /memory/entities/by-evidence?kind=...&sourceId=...&viewerScope=...` |
+| Dashboard Evidence tab | Open the dashboard → click "Evidence" |
 
 ## Evidence
 

--- a/upgrades/side-effects/wikiclaim-evidence-phase4.md
+++ b/upgrades/side-effects/wikiclaim-evidence-phase4.md
@@ -1,0 +1,129 @@
+# Side-Effects Review — WikiClaim Evidence Phase 4 (HTTP + dashboard)
+
+**Version / slug:** `wikiclaim-evidence-phase4`
+**Date:** 2026-05-10
+**Author:** Echo
+**Second-pass reviewer:** required (auth-principal-to-viewer-scope mapping; XSS; visibility-filter correctness)
+
+## Summary of the change
+
+Adds inverse-traceability HTTP endpoints + dashboard panels that consume the typed evidence APIs landed in Phase 1 and hardened in Phase 5. No new policy, no new storage shape, no new filter — this PR is a thin pass-through from HTTP/dashboard to `SemanticMemory.getEvidence` / `SemanticMemory.findCitations` / `SemanticMemory.getEntityWithEvidence`.
+
+Spec: `docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md` § Phase 4 (line 343), Inverse traceability (line 291), Storage and Privacy (line 310).
+
+What lands:
+- `GET /memory/evidence/by-entity/:id?viewerScope=...` — returns the entity's evidence array, viewer-scope filtered. Routes through `getEntityWithEvidence` so the entity-level visibility check and the per-row evidence-tier filter both fire BEFORE any bytes leave the storage layer. 404 collapses "entity missing" and "entity hidden at viewer scope" into the same response per spec § Storage and Privacy line 316 (non-leaky inverse-query rule extended to direct fetch).
+- `GET /memory/entities/by-evidence?kind=...&sourceId=...&viewerScope=...` — returns entities citing `(kind, sourceId)`. Pass-through to `findCitations`, which filters by BOTH the citing entity's `privacyScope` AND the citing evidence row's `privacyTier`. Returns `{kind, sourceId, viewerScope, entities, totalResults}`.
+- `viewerScope` resolution: optional query param, default `private` (full visibility for the agent's own DB; the single-bearer-token auth model has one principal). Narrowing-only — callers can request a more restrictive view to preview "what would a topic-peer see?" Invalid scope values fall back silently to the default rather than 400'ing, mirroring how other Express handlers in this file treat unknown enum input.
+- Evidence kind whitelist on the inverse endpoint — `VALID_EVIDENCE_KINDS` set matches `MemoryEvidenceKind` exactly. Unknown kinds → 400 (this is mechanic-level validation, not judgment).
+- Auth: both routes sit behind the global `authMiddleware` applied at app level in `AgentServer`. No route-local auth code (and no new code to maintain that could drift).
+- Dashboard "Evidence" tab: per-entity evidence panel (text input + Lookup button → render evidence list with kind, sourceId, file:line, weight, confidence, privacyTier badge, note); "what cites this?" panel (kind dropdown + sourceId input → render entities with type, name, id, scope, confidence, and an "Inspect evidence" button that pivots to the per-entity panel). One viewer-scope dropdown drives both panels.
+- Dashboard XSS posture: every user-supplied string (entity id, name, content, sourceId, note, path, privacyTier label) flows through the local `escapeHtml` helper before reaching `innerHTML`. The "Inspect evidence" button uses a `data-entity-id` attribute + a delegated `addEventListener('click', …)` — NOT an inline `onclick` string interpolation — so even pathologically-shaped IDs cannot break out of the attribute context.
+
+Files touched:
+- `src/server/routes.ts` — adds `/memory/evidence/by-entity/:id` and `/memory/entities/by-evidence` after the existing `/semantic/*` routes; adds local `VALID_EVIDENCE_KINDS`, `VALID_VIEWER_SCOPES`, `resolveViewerScope`.
+- `dashboard/index.html` — adds an "Evidence" tab button to the tab bar, an `evidenceTab` panel container, a registry entry in `TAB_REGISTRY`, and a JS section (`evCurrentViewerScope`, `evRenderTierBadge`, `evRenderEvidenceRow`, `evRenderEntityRow`, `loadEvidenceByEntity`, `loadEntitiesByEvidence`, `evLookupFromCitation`) inserted before `loadTokens`.
+- `tests/unit/memory-evidence-routes.test.ts` — 14 vitest cases against real SQLite + a real Express app with the production `authMiddleware`.
+- `upgrades/side-effects/wikiclaim-evidence-phase4.md` (this file)
+
+## Decision-point inventory
+
+- `resolveViewerScope(raw)` — **add** — mechanic-level enum lookup against `VALID_VIEWER_SCOPES`. Not judgment.
+- `VALID_EVIDENCE_KINDS` lookup on the inverse endpoint — **add** — mechanic-level enum match. Not judgment.
+- `escapeHtml`-on-every-field render path — **add** — structural HTML escape, not judgment.
+- 404-vs-200-empty collapse on `by-entity` — **add** — spec-mandated non-leak (§ Storage and Privacy line 316).
+
+---
+
+## 1. Over-block
+
+**`viewerScope` query param ignored when invalid (default-to-private).** A caller sending `?viewerScope=garbage` does not get a 400; they get private-scope results. Rationale: viewerScope is narrowing-only and the agent's principal is already `private`; widening doesn't exist, so misspellings can only narrow OR be ignored. The safest fallback for a typo is the agent's own scope (private) — i.e., NO over-block. A stricter 400 would be a usability regression with no privacy benefit.
+
+**`findCitations` returns an empty array on missing entities or zero matches.** Both paths look identical to the caller. By design — the inverse query is exactly the "is there any citation of this source anywhere I can see?" probe; differentiating "no matches" from "no visible matches at your scope" would itself be the leak the spec is closing.
+
+## 2. Under-block
+
+- **Rate limiting:** these are read endpoints with no LLM call, no mutation, no fan-out. Per the patterns in routes.ts, hot read endpoints in `/semantic/*` (e.g. `/semantic/recall/:id`, `/semantic/search`, `/semantic/explore/:id`) ALSO don't carry a `rateLimiter` wrapper — they rely on the global auth gate. The new routes follow the same convention. If abuse appears in observability, attaching `rateLimiter(60_000, 60)` is a one-line follow-up; the per-entity evidence cap (50 default, 500 hard) caps the response size regardless.
+- **viewerScope authentication binding:** the `viewerScope` query param is caller-controlled. This is acceptable because the auth model has ONE principal (the agent itself, full bearer token = `private` ceiling), and the param can only *narrow*. A caller cannot widen to `private` if they were given a `shared-project` token, because there is no such token — the system has one. When multi-tenant auth lands (not in scope), this resolver becomes the seam: it must read principal claims off the request and clamp the param to the principal's ceiling. Currently documented in the inline comment on `resolveViewerScope`.
+- **`note` field rendering on the dashboard:** notes are free-form text, capped at 500 bytes at write time (Phase 1). The dashboard renders them via `escapeHtml`, NOT `marked` / `DOMPurify` — even though those libraries are loaded for the file viewer. Treating notes as plain text is the safer default; if markdown rendering is wanted later, route through `DOMPurify.sanitize(marked.parse(note))` like the file viewer does.
+- **Dashboard does not paginate** when the inverse query returns many entities. The per-entity evidence cap means the forward endpoint is bounded; the inverse endpoint is bounded only by "how many entities cite this source" which has no hard cap. v1 dashboards expect human-scale lookups; a follow-up can add `limit`/`offset` if needed.
+
+## 3. Level-of-abstraction fit
+
+Right layer.
+
+- HTTP route is a 30-line pass-through to the storage primitive. Privacy decisions live in `SemanticMemory.getEvidence` / `findCitations` (read-time filter) and in `EvidenceRenderer` (the documented enforcement point for already-loaded entities, per Phase 5). The route does not re-decide visibility — it serializes whatever the storage layer returned.
+- Dashboard panels invoke the route via `apiFetch` and render the result. They do not contain a copy of the privacy filter; they trust the server to have filtered.
+- `viewerScope` derivation is owned by `resolveViewerScope` — one function, one place to retrofit when multi-tenant auth lands.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] **No** — these are read endpoints with no judgment-level block/allow surface.
+
+The "decisions" in this PR:
+- Mechanic-level enum lookups (`VALID_VIEWER_SCOPES`, `VALID_EVIDENCE_KINDS`);
+- Mechanic-level scope ordering (already owned by `EvidenceRenderer`, not duplicated here);
+- Mechanic-level escape on the dashboard.
+
+None of those answers the question "should this evidence be visible to this caller?" — that question is answered exactly once, in `SemanticMemory`. The route is dumb; the renderer is the boundary.
+
+## 5. Interactions
+
+- **Phase 1 (#137):** consumes `getEntityWithEvidence`, `getEvidence`, `findCitations` — all already viewer-scope-filtered. No re-wiring of those methods.
+- **Phase 5 (#141):** the `EvidenceRenderer` helper is the documented single enforcement point. This PR uses storage-layer methods that internally use the same predicates that `EvidenceRenderer` uses (`isEntityVisibleAtScope`, `isEvidenceVisibleAtScope`); the rules are colocated, no drift. If a future caller has an already-loaded entity in memory and wants to ship it to a viewer, they should call `renderEvidenceForScope` — these routes don't go through that path because they load fresh from SQLite.
+- **Phase 2 (#139) and Phase 3 (#142) in flight:** they touch producer code (EvolutionManager, DispatchExecutor, DecisionJournal). They don't touch routes.ts or the dashboard. Conflict-free.
+- **TaskFlow Phase 5 (#143 merged d7d4eba9):** added rate-limit middleware to `/flows/*`. This PR does NOT add rate-limit to `/memory/*` evidence routes — the convention in `/semantic/*` is no per-route limiter, relying on global auth + per-entity bound. If a follow-up wants to standardize, it's a one-liner.
+- **Dashboard tab registry:** new `evidence` entry sits between `threadline` and `secrets`. The mobile nav menu / `updateNavToggleLabel` keys off `data-tab="evidence"` and works without changes (the existing logic reads the button text dynamically).
+- **`authMiddleware`:** the existing global middleware sits in front of every non-public route. Both new routes inherit it without local code. Test file mounts `authMiddleware(AUTH_TOKEN)` directly to exercise the 401 path.
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** none. The routes return only this agent's own data.
+- **Other users of the install base:** two new GET routes appear. No breaking changes to existing routes. Anyone hitting `/memory/*` paths today gets a 404 (we use those URLs first time here, no collision check needed — `grep` confirms no `/memory/evidence/*` or `/memory/entities/*` exists in routes.ts before this PR).
+- **External systems:** none.
+- **Persistent state:** none — read-only routes.
+- **Privacy posture:** unchanged. The visibility surface is exactly what `SemanticMemory` already exposes; this PR only adds an HTTP/dashboard frontend.
+- **Cloudflare tunnel:** if the agent exposes its server via Cloudflare tunnel, the new routes are reachable from the internet under the same bearer-token auth as everything else. No new exposure shape; the auth boundary is unchanged.
+
+## 7. Rollback cost
+
+- **Hot-fix release:** pure additive change; `git revert <merge-commit>` ships as the next patch.
+- **Data migration:** none.
+- **Agent state repair:** none. No state written.
+- **User visibility:** mild — the Evidence tab disappears from the dashboard. No data loss; the underlying DB is untouched.
+
+---
+
+## Conclusion
+
+Phase 4 ships two read-only HTTP routes plus a single dashboard tab. All privacy decisions remain in the Phase 1 storage-layer filter and the Phase 5 `EvidenceRenderer` boundary; this PR does not introduce a second filter. Auth is the existing bearer-token model. XSS is structurally prevented by `escapeHtml`-on-every-interpolation plus the absence of inline `onclick` string-interpolation patterns. 14 new vitest cases cover viewer-scope filtering, auth, 404, 400, empty results, and the inverse-leak cross-product. Cleared to ship pending second-pass concurrence on auth/XSS/filter-correctness.
+
+---
+
+## Second-pass review
+
+**Reviewer:** independent code-audit subagent (adversarial), one round.
+**Round 1 findings:**
+
+1. **Inline `onclick` with `${id}` interpolation in `evRenderEntityRow`** — flagged at draft time. `escapeHtml` does encode `'`/`"`, so a payload like `id="x'),alert(1);//"` would render as `&#39;`, structurally inert. Still: an inline `onclick="..."` string-build is a brittle pattern; one future edit forgetting the escape is a foot-gun. **Resolution:** rewrote as `data-entity-id="${id}"` + `addEventListener` delegation. No string-interpolation into an HTML attribute that becomes a JS expression at parse time.
+2. **`viewerScope` widening attempt** — a caller could send `?viewerScope=private` even if they "shouldn't" have private access. **Resolution:** the auth model has one principal (the agent itself = private ceiling). There is no "shouldn't" right now — the bearer token IS the private credential. The resolver is the documented seam for future multi-tenant scope clamping, and the inline comment in routes.ts says so. Cleared.
+3. **Visibility-filter correctness on `by-entity` for a private entity at shared-project viewer** — confirmed: `getEntityWithEvidence` returns `null` when the entity scope exceeds the viewer scope (`SemanticMemory.ts:775`). Route returns 404 in that case. Test `returns 404 (non-leaky) when a private entity is requested at shared-project scope` proves it.
+4. **Inverse leak via `by-evidence` when entity scope is shared-project but evidence row is private** — confirmed: `findCitations` checks BOTH entity scope AND evidence tier (`SemanticMemory.ts:752-754`). Test `cross-product: shared-project viewer cannot see private-tier evidence inverse query` covers this exact shape. Cleared.
+5. **`viewerScope` enum bypass via prototype-pollution / non-string input** — `req.query.viewerScope` may be a string, an array, or undefined. `resolveViewerScope` only returns one of the three known scopes; anything else falls to `'private'`. Even with `?viewerScope=__proto__`, the `VALID_VIEWER_SCOPES.has()` check rejects (`Set.prototype.has` does not match own/prototype keys of arbitrary strings). Cleared.
+
+Cleared to ship.
+
+---
+
+## Evidence pointers
+
+- New tests: `npx vitest run tests/unit/memory-evidence-routes.test.ts` → 14/14 passing (102ms).
+- Typecheck: `npx tsc --noEmit` → clean.
+- Spec source of truth: `docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md` (Phase 4 at line 343).
+- Predecessor PRs: #137 (Phase 1 schema), #141 (Phase 5 backfill + render hardening).
+- Privacy enforcement evidence:
+  - `SemanticMemory.getEntityWithEvidence` (entity scope filter): `src/memory/SemanticMemory.ts:765-779`
+  - `SemanticMemory.findCitations` (dual filter on entity scope + evidence tier): `src/memory/SemanticMemory.ts:735-759`
+  - `EvidenceRenderer` (documented enforcement boundary): `src/memory/EvidenceRenderer.ts`


### PR DESCRIPTION
## Summary

Adds two read-only HTTP endpoints + a dashboard tab that consume the typed evidence APIs from Phase 1 (#137) and the `EvidenceRenderer` hardening from Phase 5 (#141).

- `GET /memory/evidence/by-entity/:id?viewerScope=...` — entity's evidence array, viewer-scope filtered
- `GET /memory/entities/by-evidence?kind=...&sourceId=...&viewerScope=...` — entities citing `(kind, sourceId)`, viewer-scope filtered

Both routes are thin pass-throughs to `SemanticMemory.getEntityWithEvidence` / `findCitations`. Privacy enforcement remains in the storage-layer filter (Phase 1) + `EvidenceRenderer` (Phase 5) — this PR does NOT introduce a second filter.

Dashboard adds an "Evidence" tab with two panels (per-entity lookup + reverse "what cites this?") that share one viewer-scope selector. All user-supplied strings flow through `escapeHtml`; the pivot button uses a `data-entity-id` attribute + delegated `addEventListener('click')` — no inline `onclick` string interpolation.

Spec: `docs/specs/OPENCLAW-IMPORT-WIKICLAIM-EVIDENCE-SPEC.md` § Phase 4 (line 343), Inverse traceability (line 291), Storage and Privacy (line 310).

## Privacy posture

- `viewerScope` query param defaults to `private` (full visibility — single-bearer-token auth principal = the agent itself). Narrowing-only.
- `getEntityWithEvidence` returns `null` when the entity's `privacyScope` exceeds the viewer's scope → route returns 404 (non-leaky per spec § Storage and Privacy line 316).
- `findCitations` filters on BOTH entity scope AND evidence-row tier per spec line 316.

## Test plan

- [x] `npx vitest run tests/unit/memory-evidence-routes.test.ts` → 14/14 passing (real SQLite, no mocks, real `authMiddleware` mounted)
  - viewer-scope filtering on both endpoints
  - 401 without bearer
  - 404 on unknown entity AND on private-entity-at-shared-project-viewer (non-leaky)
  - 400 on missing kind/sourceId/invalid kind
  - empty array on no-citations match
  - cross-product: shared-project viewer cannot see private-tier evidence in either endpoint
- [x] `npx vitest run tests/unit/route-completeness.test.ts` → 9/9
- [x] `npx vitest run tests/unit/semantic-memory.test.ts tests/unit/semantic-memory-evidence.test.ts tests/unit/evidence-render-privacy.test.ts` → 87/87
- [x] `npx tsc --noEmit` → clean
- [x] Side-effects review: `upgrades/side-effects/wikiclaim-evidence-phase4.md` (second-pass concurred)
- [x] Release notes: `upgrades/NEXT.md` (added "WikiClaim Phase 4" section + capability table rows + user-facing message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)