### PR TITLE
feat(initiatives): extend Initiative type for project-scope layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "0.28.85",
+  "version": "0.28.86",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/InitiativeTracker.ts
+++ b/src/core/InitiativeTracker.ts
@@ -60,7 +60,63 @@ export interface InitiativePhase {
   completedAt?: string;
 }
 
-export type InitiativeStatus = 'active' | 'completed' | 'archived' | 'abandoned';
+export type InitiativeStatus =
+  | 'active'
+  | 'completed'
+  | 'archived'
+  | 'abandoned'
+  | 'paused'
+  | 'halted'
+  | 'awaiting-user';
+
+export type InitiativeKind = 'task' | 'project';
+
+export type PipelineStage =
+  | 'outline'
+  | 'spec-drafted'
+  | 'spec-converged'
+  | 'approved'
+  | 'building'
+  | 'merged'
+  | 'regressed'
+  | 'skipped';
+
+export type RoundStatus =
+  | 'pending'
+  | 'ready'
+  | 'in-progress'
+  | 'partially-complete'
+  | 'complete'
+  | 'complete-with-skips'
+  | 'failed'
+  | 'regressed';
+
+export interface InitiativeRound {
+  name: string;
+  /** Child initiative IDs in this round. */
+  itemIds: string[];
+  status: RoundStatus;
+  /** ISO; populated when prior round completes and this one becomes ready. */
+  autoAdvanceAt?: string;
+  completedAt?: string;
+  haltedAt?: string;
+  haltReason?: string;
+  /** Counter; round-runner caps this at 3. */
+  resumeAttempts?: number;
+  /** Cached drift verdict from the most recent attempt. Typed in Phase 1b. */
+  lastDriftVerdict?: unknown;
+}
+
+export interface InitiativeConflictPatch {
+  patchId: string;
+  recordId: string;
+  path: string;
+  oursValue: unknown;
+  theirsValue: unknown;
+  baseValue?: unknown;
+  losingMachineId: string;
+  capturedAt: string;
+}
 
 export interface InitiativeLink {
   type: 'spec' | 'pr' | 'commit' | 'topic' | 'doc' | 'other';
@@ -92,6 +148,63 @@ export interface Initiative {
   links: InitiativeLink[];
   createdAt: string;
   updatedAt: string;
+
+  // ── Project-scope additions (Phase 1.1) ──────────────────────────
+  // All fields below are OPTIONAL. Pre-project-scope records leave them
+  // undefined; backfill writes `kind: 'task' + schemaVersion: 1` to legacy
+  // records on first load.
+
+  /** Distinguishes leaf work items ('task') from rollups ('project').
+   *  Immutable after creation. Defaults to 'task' when omitted. */
+  kind?: InitiativeKind;
+  /** Bumped on backfill / migration. */
+  schemaVersion?: number;
+  /** Optimistic concurrency counter. Increments on every successful write.
+   *  Starts at 1 on create. */
+  version?: number;
+  /** Back-pointer to a project that lists this child in `rounds[].itemIds`. */
+  parentProjectId?: string;
+
+  // Child-only fields (only meaningful when `kind === 'task'`):
+  pipelineStage?: PipelineStage;
+  /** Relative to repo root; required for stages ≥ 'spec-drafted'. */
+  specPath?: string;
+  /** Required for stages = 'building' or 'merged'. */
+  prNumber?: number;
+  /** GitHub-reported merge commit; recorded at building → merged. */
+  mergeCommitOid?: string;
+  /** ISO; last revalidation against origin/main. */
+  ciCheckedAt?: string;
+  skippedAt?: string;
+  skippedBy?: string;
+  skippedReason?: string;
+  /** Recorded on skipped → outline reverse transition. */
+  unskippedAt?: string;
+  /** Default true at runtime; false marks infrastructure-of-tracker specs. */
+  driftCheck?: boolean;
+
+  // Project-only fields (only meaningful when `kind === 'project'`):
+  rounds?: InitiativeRound[];
+  /** Paths jailed to project-root allowlist. */
+  sourceDocs?: string[];
+  /** Default true at runtime. */
+  autoAdvance?: boolean;
+  /** For round-complete and halt notifications. */
+  telegramTopicId?: string;
+  /** Current round owner (Phase 1.5). */
+  ownerMachineId?: string;
+  /** Absolute path to the target source repo; required for projects. */
+  targetRepoPath?: string;
+  /** Increments on each auto-advance without ack; pauses project at ≥ 2. */
+  unacknowledgedAdvanceCount?: number;
+  /** Populated when user acks the first-launch digest. */
+  firstLaunchAckAt?: string;
+  /** Highest round index acked. */
+  lastAckedRoundIndex?: number;
+  /** Populated by git-sync conflict handler (Phase 1.12). */
+  awaitingReconciliation?: InitiativeConflictPatch[];
+  /** For cache invalidation on drift-prompt edits. */
+  driftPromptTemplateVersion?: number;
 }
 
 export interface InitiativeCreateInput {
@@ -104,6 +217,24 @@ export interface InitiativeCreateInput {
   needsUser?: boolean;
   needsUserReason?: string;
   blockers?: string[];
+
+  // ── Project-scope additions ─────────────────────────────────────
+  /** Defaults to 'task' if omitted. Immutable after creation. */
+  kind?: InitiativeKind;
+  parentProjectId?: string;
+  pipelineStage?: PipelineStage;
+  specPath?: string;
+  prNumber?: number;
+  mergeCommitOid?: string;
+  ciCheckedAt?: string;
+  driftCheck?: boolean;
+  rounds?: InitiativeRound[];
+  sourceDocs?: string[];
+  autoAdvance?: boolean;
+  telegramTopicId?: string;
+  ownerMachineId?: string;
+  targetRepoPath?: string;
+  driftPromptTemplateVersion?: number;
 }
 
 export interface InitiativeUpdateInput {
@@ -115,6 +246,77 @@ export interface InitiativeUpdateInput {
   needsUserReason?: string | null;
   blockers?: string[];
   links?: InitiativeLink[];
+
+  // ── Project-scope additions ─────────────────────────────────────
+  /** Optimistic concurrency guard. When provided, must equal the current
+   *  `version` or update() throws `OccVersionMismatchError`. Backward
+   *  compatible: callers that omit ifMatch get unconditional writes. */
+  ifMatch?: number;
+  /** Presence triggers immutability check: any value that differs from
+   *  the current `kind` throws `KindImmutableError`. */
+  kind?: InitiativeKind;
+  /** Set to a project id to attach; set to null to clear. Bidirectional
+   *  validation against the named project's `rounds[].itemIds` runs on set. */
+  parentProjectId?: string | null;
+  pipelineStage?: PipelineStage;
+  specPath?: string | null;
+  prNumber?: number | null;
+  mergeCommitOid?: string | null;
+  ciCheckedAt?: string | null;
+  skippedAt?: string | null;
+  skippedBy?: string | null;
+  skippedReason?: string | null;
+  unskippedAt?: string | null;
+  driftCheck?: boolean;
+  rounds?: InitiativeRound[];
+  sourceDocs?: string[];
+  autoAdvance?: boolean;
+  telegramTopicId?: string | null;
+  ownerMachineId?: string | null;
+  targetRepoPath?: string;
+  unacknowledgedAdvanceCount?: number;
+  firstLaunchAckAt?: string | null;
+  lastAckedRoundIndex?: number;
+  awaitingReconciliation?: InitiativeConflictPatch[];
+  driftPromptTemplateVersion?: number;
+}
+
+/**
+ * Thrown by `update()` when the caller supplied `ifMatch` and it didn't
+ * equal the current `version`. The HTTP layer (Phase 1.3) translates this
+ * to a 409 response with body `{ currentVersion }`.
+ */
+export class OccVersionMismatchError extends Error {
+  readonly currentVersion: number;
+  constructor(message: string, currentVersion: number) {
+    super(message);
+    this.name = 'OccVersionMismatchError';
+    this.currentVersion = currentVersion;
+  }
+}
+
+/**
+ * Thrown by `update()` when the caller attempted to change `kind`. The
+ * `kind` field is set at creation time and never changes thereafter.
+ */
+export class KindImmutableError extends Error {
+  constructor(message = '`kind` is immutable after initiative creation') {
+    super(message);
+    this.name = 'KindImmutableError';
+  }
+}
+
+/**
+ * Thrown by `update()` when setting `parentProjectId` and the named parent
+ * either doesn't exist, isn't a `kind: 'project'` initiative, or doesn't
+ * list this child in any of its `rounds[].itemIds`. Bidirectional check
+ * keeps the parent/child relationship internally consistent.
+ */
+export class InvalidParentProjectError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidParentProjectError';
+  }
 }
 
 export interface DigestItem {
@@ -142,6 +344,51 @@ export const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
  */
 export const INITIATIVE_TASKFLOW_CONTROLLER_ID = 'InitiativeTracker';
 
+/**
+ * JSON.stringify replacer that omits any property whose value is exactly
+ * `undefined`. Native JSON.stringify already drops undefined object values,
+ * but using an explicit replacer makes intent visible AND ensures we never
+ * accidentally serialize a `null` for an optional field — the runtime
+ * guards in `update()` already reject `null`, so this is belt-and-braces.
+ *
+ * Round-trip stability: a record loaded and saved without mutation
+ * produces byte-identical output (asserted by the unit tests).
+ */
+function omitUndefinedReplacer(_key: string, value: unknown): unknown {
+  return value === undefined ? undefined : value;
+}
+
+/**
+ * Reject `null` for any of the project-scope optional fields when supplied
+ * via `InitiativeCreateInput`. (Update inputs are field-by-field; null
+ * means "clear" for nullable fields and "reject" for the rest, enforced
+ * inline in `update()`.)
+ */
+function rejectNullCreateInput(input: InitiativeCreateInput): void {
+  const forbiddenNullKeys: Array<keyof InitiativeCreateInput> = [
+    'kind',
+    'parentProjectId',
+    'pipelineStage',
+    'specPath',
+    'prNumber',
+    'mergeCommitOid',
+    'ciCheckedAt',
+    'driftCheck',
+    'rounds',
+    'sourceDocs',
+    'autoAdvance',
+    'telegramTopicId',
+    'ownerMachineId',
+    'targetRepoPath',
+    'driftPromptTemplateVersion',
+  ];
+  for (const k of forbiddenNullKeys) {
+    if ((input as unknown as Record<string, unknown>)[k as string] === null) {
+      throw new Error(`Initiative create input field "${k}" must not be null`);
+    }
+  }
+}
+
 function ownerKeyForInitiative(initiativeId: string): string {
   return `initiative:${initiativeId}`;
 }
@@ -160,9 +407,25 @@ export class InitiativeTracker {
   private taskFlowRegistry: TaskFlowRegistry | null = null;
   private taskFlowControllerInstanceId: string | null = null;
 
+  // ── Digest cache invalidator hook (Phase 1.1) ──────────────────
+  // PR 3 wires the real invalidator (clears the project-scope digest cache
+  // so the next read recomputes). Until then this is a no-op. The hook
+  // fires after every successful mutating call.
+  private digestCacheInvalidator: () => void = () => {};
+
   constructor(stateDir: string) {
     this.filePath = path.join(stateDir, 'initiatives.json');
     this.loadFromDisk();
+  }
+
+  /**
+   * Register a callback invoked once after every successful mutating call
+   * (`create`, `update`, `setPhaseStatus`, `remove`). The default is a
+   * no-op so legacy callers see no change. PR 3 wires the real cache
+   * invalidator.
+   */
+  setDigestCacheInvalidator(fn: () => void): void {
+    this.digestCacheInvalidator = typeof fn === 'function' ? fn : () => {};
   }
 
   /**
@@ -207,10 +470,26 @@ export class InitiativeTracker {
       if (!fs.existsSync(this.filePath)) return;
       const raw = JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
       if (Array.isArray(raw?.initiatives)) {
+        let backfilled = 0;
         for (const item of raw.initiatives) {
           if (item && typeof item.id === 'string') {
+            // Phase 1.1 idempotent backfill: legacy records (missing `kind`)
+            // get `kind: 'task'` + `schemaVersion: 1`. Records that already
+            // carry `kind` are untouched. Second load is a no-op because
+            // nothing changes after the first pass.
+            if (item.kind === undefined) {
+              item.kind = 'task';
+              if (item.schemaVersion === undefined) item.schemaVersion = 1;
+              backfilled++;
+            }
             this.initiatives.set(item.id, item as Initiative);
           }
+        }
+        // Rewrite the file exactly once if any record was backfilled. The
+        // rewrite uses the same omit-undefined replacer as `saveToDisk()`
+        // so the file is stable on a subsequent load.
+        if (backfilled > 0) {
+          this.saveToDisk();
         }
       }
     } catch (err) {
@@ -224,7 +503,7 @@ export class InitiativeTracker {
     fs.mkdirSync(dir, { recursive: true });
     const payload = { initiatives: Array.from(this.initiatives.values()) };
     const tmp = `${this.filePath}.${process.pid}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(payload, null, 2));
+    fs.writeFileSync(tmp, JSON.stringify(payload, omitUndefinedReplacer, 2));
     fs.renameSync(tmp, this.filePath);
   }
 
@@ -607,6 +886,7 @@ export class InitiativeTracker {
     if (!input.phases.length) {
       throw new Error('Initiative must have at least one phase');
     }
+    rejectNullCreateInput(input);
     if (this.isTaskFlowEnabled()) {
       if (this.findFlowIdForInitiative(input.id)) {
         throw new Error(`Initiative "${input.id}" already exists`);
@@ -639,18 +919,72 @@ export class InitiativeTracker {
       links: input.links ?? [],
       createdAt: now,
       updatedAt: now,
+
+      // Project-scope: default kind to 'task' and start version at 1. Both
+      // are persisted from create-time so subsequent backfill is a no-op.
+      kind: input.kind ?? 'task',
+      schemaVersion: 1,
+      version: 1,
     };
-    this.initiatives.set(initiative.id, initiative);
-    if (this.isTaskFlowEnabled()) {
-      return await this.persistThroughTaskFlow(initiative);
+    // Optional project-layer fields are passed through if present. Stored
+    // as-is; runtime validation (parentProjectId existence, etc.) happens
+    // on subsequent updates that mutate the relationship.
+    if (input.parentProjectId !== undefined) initiative.parentProjectId = input.parentProjectId;
+    if (input.pipelineStage !== undefined) initiative.pipelineStage = input.pipelineStage;
+    if (input.specPath !== undefined) initiative.specPath = input.specPath;
+    if (input.prNumber !== undefined) initiative.prNumber = input.prNumber;
+    if (input.mergeCommitOid !== undefined) initiative.mergeCommitOid = input.mergeCommitOid;
+    if (input.ciCheckedAt !== undefined) initiative.ciCheckedAt = input.ciCheckedAt;
+    if (input.driftCheck !== undefined) initiative.driftCheck = input.driftCheck;
+    if (input.rounds !== undefined) initiative.rounds = input.rounds;
+    if (input.sourceDocs !== undefined) initiative.sourceDocs = input.sourceDocs;
+    if (input.autoAdvance !== undefined) initiative.autoAdvance = input.autoAdvance;
+    if (input.telegramTopicId !== undefined) initiative.telegramTopicId = input.telegramTopicId;
+    if (input.ownerMachineId !== undefined) initiative.ownerMachineId = input.ownerMachineId;
+    if (input.targetRepoPath !== undefined) initiative.targetRepoPath = input.targetRepoPath;
+    if (input.driftPromptTemplateVersion !== undefined) {
+      initiative.driftPromptTemplateVersion = input.driftPromptTemplateVersion;
     }
-    this.saveToDisk();
-    return initiative;
+
+    this.initiatives.set(initiative.id, initiative);
+    let result: Initiative;
+    if (this.isTaskFlowEnabled()) {
+      result = await this.persistThroughTaskFlow(initiative);
+    } else {
+      this.saveToDisk();
+      result = initiative;
+    }
+    this.digestCacheInvalidator();
+    return result;
   }
 
   async update(id: string, input: InitiativeUpdateInput): Promise<Initiative> {
     const existing = this.get(id);
     if (!existing) throw new Error(`Initiative "${id}" not found`);
+
+    // ── kind immutability check (Phase 1.1) ────────────────────────
+    // The `kind` field is set at creation and never mutates. We treat the
+    // current kind as 'task' when undefined (legacy records pre-backfill).
+    if (input.kind !== undefined) {
+      const currentKind = existing.kind ?? 'task';
+      if (input.kind !== currentKind) {
+        throw new KindImmutableError(
+          `Cannot change kind from "${currentKind}" to "${input.kind}"`
+        );
+      }
+    }
+
+    // ── OCC version check (Phase 1.1) ──────────────────────────────
+    // Only enforce when caller supplied ifMatch — preserves backward
+    // compatibility for legacy callers that never knew about versioning.
+    const currentVersion = existing.version ?? 1;
+    if (input.ifMatch !== undefined && input.ifMatch !== currentVersion) {
+      throw new OccVersionMismatchError(
+        `Initiative "${id}" version mismatch: expected ${input.ifMatch}, current ${currentVersion}`,
+        currentVersion
+      );
+    }
+
     const now = new Date().toISOString();
     const next: Initiative = { ...existing, updatedAt: now, lastTouchedAt: now };
     if (input.title !== undefined) next.title = input.title;
@@ -665,12 +999,112 @@ export class InitiativeTracker {
     }
     if (input.blockers !== undefined) next.blockers = input.blockers;
     if (input.links !== undefined) next.links = input.links;
-    this.initiatives.set(id, next);
-    if (this.isTaskFlowEnabled()) {
-      return await this.persistThroughTaskFlow(next);
+
+    // ── Project-scope field updates ────────────────────────────────
+    // Bidirectional parentProjectId validation: when setting (not clearing),
+    // the named parent must exist as kind:'project' AND list this child in
+    // rounds[].itemIds. Clearing (null) skips validation.
+    if (input.parentProjectId !== undefined) {
+      if (input.parentProjectId === null) {
+        next.parentProjectId = undefined;
+      } else {
+        this.assertValidParentProject(input.parentProjectId, id);
+        next.parentProjectId = input.parentProjectId;
+      }
     }
-    this.saveToDisk();
-    return next;
+    if (input.pipelineStage !== undefined) next.pipelineStage = input.pipelineStage;
+    if (input.specPath !== undefined) {
+      next.specPath = input.specPath === null ? undefined : input.specPath;
+    }
+    if (input.prNumber !== undefined) {
+      next.prNumber = input.prNumber === null ? undefined : input.prNumber;
+    }
+    if (input.mergeCommitOid !== undefined) {
+      next.mergeCommitOid = input.mergeCommitOid === null ? undefined : input.mergeCommitOid;
+    }
+    if (input.ciCheckedAt !== undefined) {
+      next.ciCheckedAt = input.ciCheckedAt === null ? undefined : input.ciCheckedAt;
+    }
+    if (input.skippedAt !== undefined) {
+      next.skippedAt = input.skippedAt === null ? undefined : input.skippedAt;
+    }
+    if (input.skippedBy !== undefined) {
+      next.skippedBy = input.skippedBy === null ? undefined : input.skippedBy;
+    }
+    if (input.skippedReason !== undefined) {
+      next.skippedReason = input.skippedReason === null ? undefined : input.skippedReason;
+    }
+    if (input.unskippedAt !== undefined) {
+      next.unskippedAt = input.unskippedAt === null ? undefined : input.unskippedAt;
+    }
+    if (input.driftCheck !== undefined) next.driftCheck = input.driftCheck;
+    if (input.rounds !== undefined) next.rounds = input.rounds;
+    if (input.sourceDocs !== undefined) next.sourceDocs = input.sourceDocs;
+    if (input.autoAdvance !== undefined) next.autoAdvance = input.autoAdvance;
+    if (input.telegramTopicId !== undefined) {
+      next.telegramTopicId = input.telegramTopicId === null ? undefined : input.telegramTopicId;
+    }
+    if (input.ownerMachineId !== undefined) {
+      next.ownerMachineId = input.ownerMachineId === null ? undefined : input.ownerMachineId;
+    }
+    if (input.targetRepoPath !== undefined) next.targetRepoPath = input.targetRepoPath;
+    if (input.unacknowledgedAdvanceCount !== undefined) {
+      next.unacknowledgedAdvanceCount = input.unacknowledgedAdvanceCount;
+    }
+    if (input.firstLaunchAckAt !== undefined) {
+      next.firstLaunchAckAt =
+        input.firstLaunchAckAt === null ? undefined : input.firstLaunchAckAt;
+    }
+    if (input.lastAckedRoundIndex !== undefined) {
+      next.lastAckedRoundIndex = input.lastAckedRoundIndex;
+    }
+    if (input.awaitingReconciliation !== undefined) {
+      next.awaitingReconciliation = input.awaitingReconciliation;
+    }
+    if (input.driftPromptTemplateVersion !== undefined) {
+      next.driftPromptTemplateVersion = input.driftPromptTemplateVersion;
+    }
+
+    // Bump version on every successful write.
+    next.version = currentVersion + 1;
+
+    this.initiatives.set(id, next);
+    let result: Initiative;
+    if (this.isTaskFlowEnabled()) {
+      result = await this.persistThroughTaskFlow(next);
+    } else {
+      this.saveToDisk();
+      result = next;
+    }
+    this.digestCacheInvalidator();
+    return result;
+  }
+
+  /**
+   * Verify that `parentId` names an existing `kind: 'project'` initiative
+   * AND that one of its rounds lists `childId` in itemIds. Throws
+   * `InvalidParentProjectError` on any failure. Used by `update()` when
+   * a child's `parentProjectId` is set to a non-null value.
+   */
+  private assertValidParentProject(parentId: string, childId: string): void {
+    const parent = this.get(parentId);
+    if (!parent) {
+      throw new InvalidParentProjectError(
+        `Parent project "${parentId}" not found`
+      );
+    }
+    if ((parent.kind ?? 'task') !== 'project') {
+      throw new InvalidParentProjectError(
+        `Initiative "${parentId}" is not a project (kind="${parent.kind ?? 'task'}")`
+      );
+    }
+    const rounds = parent.rounds ?? [];
+    const listed = rounds.some((r) => Array.isArray(r.itemIds) && r.itemIds.includes(childId));
+    if (!listed) {
+      throw new InvalidParentProjectError(
+        `Project "${parentId}" does not list child "${childId}" in any round`
+      );
+    }
   }
 
   async setPhaseStatus(
@@ -696,20 +1130,27 @@ export class InitiativeTracker {
       status: allDone ? 'completed' : existing.status === 'completed' ? 'active' : existing.status,
       updatedAt: now,
       lastTouchedAt: now,
+      version: (existing.version ?? 1) + 1,
     };
     this.initiatives.set(id, next);
+    let result: Initiative;
     if (this.isTaskFlowEnabled()) {
-      return await this.persistThroughTaskFlow(next);
+      result = await this.persistThroughTaskFlow(next);
+    } else {
+      this.saveToDisk();
+      result = next;
     }
-    this.saveToDisk();
-    return next;
+    this.digestCacheInvalidator();
+    return result;
   }
 
   async remove(id: string): Promise<boolean> {
     if (this.isTaskFlowEnabled()) {
       const fid = this.findFlowIdForInitiative(id);
       if (!fid) {
-        return this.initiatives.delete(id);
+        const removed = this.initiatives.delete(id);
+        if (removed) this.digestCacheInvalidator();
+        return removed;
       }
       const registry = this.taskFlowRegistry!;
       const principal = this.taskFlowPrincipal();
@@ -767,11 +1208,56 @@ export class InitiativeTracker {
         }
       }
       this.initiatives.delete(id);
+      this.digestCacheInvalidator();
       return true;
     }
     const removed = this.initiatives.delete(id);
-    if (removed) this.saveToDisk();
+    if (removed) {
+      this.saveToDisk();
+      this.digestCacheInvalidator();
+    }
     return removed;
+  }
+
+  /**
+   * One-time backfill helper for TaskFlow-enabled installs: scans all
+   * records, identifies those missing `kind`, and updates them through
+   * TaskFlow. Idempotent — running twice produces no change after the
+   * first pass. The legacy-JSON path runs an equivalent backfill inside
+   * `loadFromDisk()` on first load.
+   *
+   * Returns counts so callers can log/observe what happened.
+   */
+  async backfillKindAndSchema(): Promise<{ backfilled: number; scanned: number }> {
+    if (!this.isTaskFlowEnabled()) {
+      // Legacy path is backfilled during load. A no-op here is correct
+      // because the in-memory cache already reflects the backfill.
+      let backfilled = 0;
+      for (const init of this.initiatives.values()) {
+        if (init.kind === undefined) {
+          init.kind = 'task';
+          if (init.schemaVersion === undefined) init.schemaVersion = 1;
+          backfilled++;
+        }
+      }
+      if (backfilled > 0) this.saveToDisk();
+      return { backfilled, scanned: this.initiatives.size };
+    }
+    this.refreshCacheFromTaskFlow();
+    let backfilled = 0;
+    const records = Array.from(this.initiatives.values());
+    for (const init of records) {
+      if (init.kind !== undefined) continue;
+      const patched: Initiative = {
+        ...init,
+        kind: 'task',
+        schemaVersion: init.schemaVersion ?? 1,
+      };
+      this.initiatives.set(init.id, patched);
+      await this.persistThroughTaskFlow(patched);
+      backfilled++;
+    }
+    return { backfilled, scanned: records.length };
   }
 
   /**

--- a/tests/unit/InitiativeTracker.project.test.ts
+++ b/tests/unit/InitiativeTracker.project.test.ts
@@ -1,0 +1,404 @@
+/**
+ * InitiativeTracker project-scope unit tests (Phase 1.1).
+ *
+ * Covers the project-layer additions to the Initiative type and tracker:
+ *  - Idempotent `kind`/`schemaVersion` backfill on first load
+ *  - `kind` immutability on update (KindImmutableError)
+ *  - Bidirectional `parentProjectId` validation (InvalidParentProjectError)
+ *  - OCC `ifMatch` enforcement (OccVersionMismatchError) + version bump
+ *  - Serialization round-trip (byte-identical for unchanged records)
+ *  - Extended status enum (paused / halted / awaiting-user)
+ *  - Digest cache invalidator hook fires once per successful mutation
+ *
+ * Legacy-JSON path is exercised here. TaskFlow-enabled behavior reuses the
+ * same code paths (the project-layer logic lives outside the TaskFlow
+ * branch); a separate suite covers TaskFlow specifics.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  InitiativeTracker,
+  KindImmutableError,
+  OccVersionMismatchError,
+  InvalidParentProjectError,
+  type Initiative,
+  type InitiativeCreateInput,
+} from '../../src/core/InitiativeTracker.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let tmpDir: string;
+let tracker: InitiativeTracker;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'initiatives-project-test-'));
+  tracker = new InitiativeTracker(tmpDir);
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(tmpDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/InitiativeTracker.project.test.ts',
+  });
+});
+
+function baseInput(id = 'demo'): InitiativeCreateInput {
+  return {
+    id,
+    title: 'Demo Initiative',
+    description: 'A worked example for project-scope tests.',
+    phases: [
+      { id: 'plan', name: 'Plan' },
+      { id: 'build', name: 'Build' },
+    ],
+  };
+}
+
+function readFileRaw(): string {
+  return fs.readFileSync(path.join(tmpDir, 'initiatives.json'), 'utf8');
+}
+
+function writeLegacyRecords(records: Array<Partial<Initiative>>): void {
+  fs.writeFileSync(
+    path.join(tmpDir, 'initiatives.json'),
+    JSON.stringify({ initiatives: records }, null, 2)
+  );
+}
+
+// ─── Backfill ──────────────────────────────────────────────────────────────
+
+describe('backfill (Phase 1.1)', () => {
+  it('writes kind:"task" + schemaVersion:1 to records missing kind on first load', () => {
+    // Write a legacy-shaped record (no kind, no schemaVersion, no version).
+    writeLegacyRecords([
+      {
+        id: 'legacy-a',
+        title: 'Legacy A',
+        description: 'pre-project-scope',
+        status: 'active',
+        phases: [{ id: 'p1', name: 'P1', status: 'pending' }],
+        currentPhaseIndex: 0,
+        lastTouchedAt: '2025-01-01T00:00:00.000Z',
+        needsUser: false,
+        blockers: [],
+        links: [],
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    // Constructor triggers loadFromDisk → backfill.
+    const t = new InitiativeTracker(tmpDir);
+    const got = t.get('legacy-a');
+    expect(got).toBeDefined();
+    expect(got!.kind).toBe('task');
+    expect(got!.schemaVersion).toBe(1);
+  });
+
+  it('does not touch records that already have kind', () => {
+    writeLegacyRecords([
+      {
+        id: 'already-tagged',
+        title: 'Already Tagged',
+        description: 'has kind',
+        status: 'active',
+        phases: [{ id: 'p1', name: 'P1', status: 'pending' }],
+        currentPhaseIndex: 0,
+        lastTouchedAt: '2025-01-01T00:00:00.000Z',
+        needsUser: false,
+        blockers: [],
+        links: [],
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        kind: 'project',
+        schemaVersion: 7,
+      },
+    ]);
+
+    const t = new InitiativeTracker(tmpDir);
+    const got = t.get('already-tagged');
+    expect(got!.kind).toBe('project');
+    expect(got!.schemaVersion).toBe(7);
+  });
+
+  it('second load is byte-identical no-op', () => {
+    writeLegacyRecords([
+      {
+        id: 'legacy-b',
+        title: 'Legacy B',
+        description: 'pre-project-scope',
+        status: 'active',
+        phases: [{ id: 'p1', name: 'P1', status: 'pending' }],
+        currentPhaseIndex: 0,
+        lastTouchedAt: '2025-01-01T00:00:00.000Z',
+        needsUser: false,
+        blockers: [],
+        links: [],
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    // First load triggers backfill + rewrite.
+    new InitiativeTracker(tmpDir);
+    const afterFirst = readFileRaw();
+
+    // Second load: nothing should change.
+    new InitiativeTracker(tmpDir);
+    const afterSecond = readFileRaw();
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+});
+
+// ─── kind immutability ─────────────────────────────────────────────────────
+
+describe('kind immutability (Phase 1.1)', () => {
+  it('rejects update() that changes kind', async () => {
+    await tracker.create(baseInput('k1'));
+    // Created with default kind: 'task'. Try to flip to project.
+    await expect(tracker.update('k1', { kind: 'project' })).rejects.toBeInstanceOf(
+      KindImmutableError
+    );
+  });
+
+  it('allows update() that passes the same kind (no-op)', async () => {
+    await tracker.create(baseInput('k2'));
+    const out = await tracker.update('k2', { kind: 'task' });
+    expect(out.kind).toBe('task');
+  });
+
+  it('create() defaults kind to "task" when omitted', async () => {
+    const out = await tracker.create(baseInput('k3'));
+    expect(out.kind).toBe('task');
+  });
+});
+
+// ─── parentProjectId bidirectional validation ──────────────────────────────
+
+describe('parentProjectId validation (Phase 1.1)', () => {
+  it('rejects setting parentProjectId to a non-existent project', async () => {
+    await tracker.create(baseInput('child-1'));
+    await expect(
+      tracker.update('child-1', { parentProjectId: 'no-such-project' })
+    ).rejects.toBeInstanceOf(InvalidParentProjectError);
+  });
+
+  it('rejects setting parentProjectId to a project that does not list this child', async () => {
+    await tracker.create({
+      ...baseInput('proj-a'),
+      kind: 'project',
+      rounds: [{ name: 'r1', itemIds: ['someone-else'], status: 'pending' }],
+    });
+    await tracker.create(baseInput('child-2'));
+    await expect(
+      tracker.update('child-2', { parentProjectId: 'proj-a' })
+    ).rejects.toBeInstanceOf(InvalidParentProjectError);
+  });
+
+  it('rejects setting parentProjectId to a non-project initiative', async () => {
+    await tracker.create(baseInput('not-a-project'));
+    await tracker.create(baseInput('child-3'));
+    await expect(
+      tracker.update('child-3', { parentProjectId: 'not-a-project' })
+    ).rejects.toBeInstanceOf(InvalidParentProjectError);
+  });
+
+  it('accepts setting parentProjectId when the project lists the child', async () => {
+    await tracker.create({
+      ...baseInput('proj-b'),
+      kind: 'project',
+      rounds: [{ name: 'r1', itemIds: ['child-4'], status: 'pending' }],
+    });
+    await tracker.create(baseInput('child-4'));
+    const out = await tracker.update('child-4', { parentProjectId: 'proj-b' });
+    expect(out.parentProjectId).toBe('proj-b');
+  });
+
+  it('accepts clearing parentProjectId (set to null)', async () => {
+    await tracker.create({
+      ...baseInput('proj-c'),
+      kind: 'project',
+      rounds: [{ name: 'r1', itemIds: ['child-5'], status: 'pending' }],
+    });
+    await tracker.create(baseInput('child-5'));
+    await tracker.update('child-5', { parentProjectId: 'proj-c' });
+    const cleared = await tracker.update('child-5', { parentProjectId: null });
+    expect(cleared.parentProjectId).toBeUndefined();
+  });
+});
+
+// ─── OCC / version field ───────────────────────────────────────────────────
+
+describe('OCC (Phase 1.1)', () => {
+  it('starts version at 1 on create', async () => {
+    const out = await tracker.create(baseInput('occ-1'));
+    expect(out.version).toBe(1);
+  });
+
+  it('increments version on every successful update', async () => {
+    await tracker.create(baseInput('occ-2'));
+    const v1 = await tracker.update('occ-2', { title: 'first' });
+    expect(v1.version).toBe(2);
+    const v2 = await tracker.update('occ-2', { title: 'second' });
+    expect(v2.version).toBe(3);
+    const v3 = await tracker.update('occ-2', { title: 'third' });
+    expect(v3.version).toBe(4);
+  });
+
+  it('increments version on setPhaseStatus', async () => {
+    await tracker.create(baseInput('occ-phase'));
+    const out = await tracker.setPhaseStatus('occ-phase', 'plan', 'in-progress');
+    expect(out.version).toBe(2);
+  });
+
+  it('throws OccVersionMismatchError with currentVersion when ifMatch is stale', async () => {
+    await tracker.create(baseInput('occ-3'));
+    await tracker.update('occ-3', { title: 'bumped to 2' });
+    // current version is now 2; ifMatch=1 is stale.
+    let caught: unknown = null;
+    try {
+      await tracker.update('occ-3', { title: 'should fail', ifMatch: 1 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(OccVersionMismatchError);
+    expect((caught as OccVersionMismatchError).currentVersion).toBe(2);
+  });
+
+  it('succeeds when ifMatch equals current version', async () => {
+    await tracker.create(baseInput('occ-4'));
+    const out = await tracker.update('occ-4', { title: 'ok', ifMatch: 1 });
+    expect(out.version).toBe(2);
+  });
+
+  it('succeeds when ifMatch is omitted (backward compatibility)', async () => {
+    await tracker.create(baseInput('occ-5'));
+    await tracker.update('occ-5', { title: 'no guard' });
+    const out = await tracker.update('occ-5', { title: 'still no guard' });
+    expect(out.version).toBe(3);
+  });
+});
+
+// ─── Serialization round-trip ──────────────────────────────────────────────
+
+describe('serialization (Phase 1.1)', () => {
+  it('round-trip: load + save with no mutation is byte-identical', async () => {
+    await tracker.create(baseInput('rt-1'));
+    await tracker.create({
+      ...baseInput('rt-2'),
+      kind: 'project',
+      rounds: [{ name: 'r1', itemIds: ['rt-1'], status: 'pending' }],
+    });
+    const first = readFileRaw();
+
+    // Reload with a new tracker instance. The backfill path is a no-op
+    // (records already have kind). The new tracker should not rewrite.
+    const t2 = new InitiativeTracker(tmpDir);
+    const afterLoad = readFileRaw();
+    expect(afterLoad).toBe(first);
+
+    // Touch read-only API; still byte-identical.
+    t2.list();
+    expect(readFileRaw()).toBe(first);
+  });
+
+  it('omits undefined-valued optional fields on write', async () => {
+    await tracker.create(baseInput('omit-1'));
+    const raw = readFileRaw();
+    // None of the project-only fields should appear because they're undefined.
+    expect(raw).not.toContain('"rounds"');
+    expect(raw).not.toContain('"sourceDocs"');
+    expect(raw).not.toContain('"telegramTopicId"');
+  });
+});
+
+// ─── Status enum extension ─────────────────────────────────────────────────
+
+describe('status enum extension (Phase 1.1)', () => {
+  it('accepts "paused"', async () => {
+    await tracker.create(baseInput('s-paused'));
+    const out = await tracker.update('s-paused', { status: 'paused' });
+    expect(out.status).toBe('paused');
+  });
+
+  it('accepts "halted"', async () => {
+    await tracker.create(baseInput('s-halted'));
+    const out = await tracker.update('s-halted', { status: 'halted' });
+    expect(out.status).toBe('halted');
+  });
+
+  it('accepts "awaiting-user"', async () => {
+    await tracker.create(baseInput('s-awaiting'));
+    const out = await tracker.update('s-awaiting', { status: 'awaiting-user' });
+    expect(out.status).toBe('awaiting-user');
+  });
+});
+
+// ─── Digest cache invalidator hook ─────────────────────────────────────────
+
+describe('digest cache invalidator (Phase 1.1)', () => {
+  it('fires once per successful mutation', async () => {
+    let calls = 0;
+    tracker.setDigestCacheInvalidator(() => {
+      calls++;
+    });
+
+    await tracker.create(baseInput('inv-1'));
+    expect(calls).toBe(1);
+
+    await tracker.update('inv-1', { title: 'updated' });
+    expect(calls).toBe(2);
+
+    await tracker.setPhaseStatus('inv-1', 'plan', 'in-progress');
+    expect(calls).toBe(3);
+
+    await tracker.remove('inv-1');
+    expect(calls).toBe(4);
+  });
+
+  it('default invalidator is a no-op (safe when not wired)', async () => {
+    // No setDigestCacheInvalidator call — mutations must still succeed.
+    await tracker.create(baseInput('inv-2'));
+    await tracker.update('inv-2', { title: 'updated' });
+    expect(tracker.get('inv-2')!.title).toBe('updated');
+  });
+
+  it('replacing the invalidator with a non-function falls back to no-op', async () => {
+    tracker.setDigestCacheInvalidator(undefined as unknown as () => void);
+    // Must not throw.
+    await tracker.create(baseInput('inv-3'));
+    expect(tracker.get('inv-3')).toBeDefined();
+  });
+});
+
+// ─── backfillKindAndSchema (public helper) ─────────────────────────────────
+
+describe('backfillKindAndSchema()', () => {
+  it('legacy-JSON path: idempotent (second call is no-op)', async () => {
+    writeLegacyRecords([
+      {
+        id: 'bf-1',
+        title: 'BF 1',
+        description: 'pre-project-scope',
+        status: 'active',
+        phases: [{ id: 'p1', name: 'P1', status: 'pending' }],
+        currentPhaseIndex: 0,
+        lastTouchedAt: '2025-01-01T00:00:00.000Z',
+        needsUser: false,
+        blockers: [],
+        links: [],
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    ]);
+    // Load triggers backfill via loadFromDisk; backfillKindAndSchema should now be a no-op.
+    const t = new InitiativeTracker(tmpDir);
+    const first = await t.backfillKindAndSchema();
+    expect(first.backfilled).toBe(0); // already done by load
+    const second = await t.backfillKindAndSchema();
+    expect(second.backfilled).toBe(0);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,87 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+### Project-scope Phase 1a PR 1 — Initiative type extension
+
+First of three PRs scaffolding the project-scope feature. This PR adds the
+type-level surface that the round-runner, drift checker, and HTTP routes
+will rely on in PR 2/3.
+
+Spec source: `docs/specs/PROJECT-SCOPE-SPEC.md` § Phase 1.1.
+
+- `Initiative` gains optional project-layer fields: `kind` (`'task' |
+  'project'`, immutable after creation, defaults to `'task'`),
+  `schemaVersion`, `version` (OCC counter), `parentProjectId`, plus
+  child-only fields (`pipelineStage`, `specPath`, `prNumber`,
+  `mergeCommitOid`, `ciCheckedAt`, `skipped*`, `unskippedAt`,
+  `driftCheck`) and project-only fields (`rounds[]`, `sourceDocs`,
+  `autoAdvance`, `telegramTopicId`, `ownerMachineId`, `targetRepoPath`,
+  `unacknowledgedAdvanceCount`, `firstLaunchAckAt`,
+  `lastAckedRoundIndex`, `awaitingReconciliation`,
+  `driftPromptTemplateVersion`). All optional → fully backward compatible.
+- `InitiativeStatus` is extended with `'paused' | 'halted' |
+  'awaiting-user'`. Existing four values unchanged.
+- New error classes for structural validators:
+  - `OccVersionMismatchError extends Error` (carries `currentVersion`)
+  - `KindImmutableError extends Error`
+  - `InvalidParentProjectError extends Error`
+- `InitiativeTracker.update()` accepts `ifMatch?: number` for optimistic
+  concurrency. When provided and stale, throws `OccVersionMismatchError`
+  (the HTTP layer in PR 2 will translate this to 409 with body
+  `{currentVersion}`). When omitted, last-write-wins — backward compatible.
+- `update()` rejects mutations of `kind` (`KindImmutableError`).
+- Setting `parentProjectId` requires a bidirectional match: the named
+  parent must exist, be `kind: 'project'`, and list this child in one of
+  its `rounds[].itemIds`. Clearing (`null`) skips validation.
+- One-time idempotent backfill: `loadFromDisk()` writes
+  `kind: 'task' + schemaVersion: 1` to legacy records on first load and
+  rewrites the file. Second load is a byte-identical no-op. A parallel
+  `backfillKindAndSchema()` public method handles TaskFlow-enabled installs.
+- Serialization rule: `saveToDisk()` omits any field whose value is
+  `undefined`. Round-trip stability asserted in tests.
+- New `setDigestCacheInvalidator(fn)` hook fires after every successful
+  mutation (`create`, `update`, `setPhaseStatus`, `remove`). Default is a
+  no-op; PR 3 wires the real invalidator for the project-scope digest cache.
+
+## What to Tell Your User
+
+Your agent now has the type-level scaffolding for multi-spec projects.
+This PR alone doesn't change anything visible — no new commands, no new
+dashboard tab, no new behavior on existing endpoints. It lays the
+foundation so PR 2 can expose `/projects` HTTP routes and PR 3 can wire
+the `/project` skill and the session-start digest.
+
+The only thing you might notice is a very small one-time write at server
+startup if your `.instar/initiatives.json` predates this version — your
+agent will mark existing records as `kind: "task"` and add a
+`schemaVersion: 1` field so they roundtrip cleanly with new project
+records.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Optional project-layer fields on `Initiative` | additive; existing callers unaffected |
+| OCC on initiative updates | pass `ifMatch: <currentVersion>` in `InitiativeUpdateInput` to enforce |
+| `kind` immutability gate | automatic — `update()` rejects `kind` mutation |
+| Bidirectional `parentProjectId` validation | automatic on `update({ parentProjectId })` |
+| Backfill of legacy initiative records | automatic on server start; idempotent |
+| Digest-cache invalidator hook | `tracker.setDigestCacheInvalidator(fn)` (PR 3 wires it) |
+
+## Evidence
+
+Spec: `docs/specs/PROJECT-SCOPE-SPEC.md` § Phase 1.1.
+
+- `tests/unit/InitiativeTracker.project.test.ts` — 26 new tests covering
+  backfill, kind immutability, parent validation, OCC, serialization
+  round-trip, status enum extension, and the invalidator hook.
+- Full InitiativeTracker test sweep (87 tests across 4 suites) passes
+  unchanged.
+- Side-effects review: `upgrades/side-effects/project-scope-phase1a-pr1.md`.

--- a/upgrades/side-effects/project-scope-phase1a-pr1.md
+++ b/upgrades/side-effects/project-scope-phase1a-pr1.md
@@ -1,0 +1,232 @@
+# Side-Effects Review — project-scope Phase 1a PR 1 (Initiative type extension)
+
+**Version / slug:** `project-scope-phase1a-pr1`
+**Date:** `2026-05-11`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Extends `src/core/InitiativeTracker.ts` with the project-layer scaffolding
+called for by `docs/specs/PROJECT-SCOPE-SPEC.md` Phase 1.1: optional `kind`,
+`schemaVersion`, `version` (OCC counter), `parentProjectId`, child-only
+fields (`pipelineStage`, `specPath`, `prNumber`, `mergeCommitOid`,
+`ciCheckedAt`, `skip*`, `unskippedAt`, `driftCheck`), and project-only
+fields (`rounds[]`, `sourceDocs`, `autoAdvance`, `telegramTopicId`,
+`ownerMachineId`, `targetRepoPath`, `unacknowledgedAdvanceCount`,
+`firstLaunchAckAt`, `lastAckedRoundIndex`, `awaitingReconciliation`,
+`driftPromptTemplateVersion`). The `InitiativeStatus` union is extended
+with `'paused' | 'halted' | 'awaiting-user'` — pre-project-scope records
+continue to use the original four values. Three new error classes
+(`OccVersionMismatchError`, `KindImmutableError`,
+`InvalidParentProjectError`) cover the validation paths; an
+`omitUndefinedReplacer` and `null`-rejection guards keep serialization
+stable; a digest-cache-invalidator hook (`setDigestCacheInvalidator`)
+fires after every successful mutation (no-op default until PR 3 wires it).
+A one-time idempotent backfill in `loadFromDisk()` writes
+`kind: 'task' + schemaVersion: 1` to legacy records; the parallel
+`backfillKindAndSchema()` public method handles the TaskFlow-enabled
+install path. Tests: `tests/unit/InitiativeTracker.project.test.ts` (26
+new tests).
+
+## Decision-point inventory
+
+- `Initiative.kind` immutability — **add** — `update()` throws
+  `KindImmutableError` if the caller tries to change `kind` away from its
+  current value.
+- `InitiativeUpdateInput.ifMatch` (OCC) — **add** — when provided, must
+  equal current `version` or `OccVersionMismatchError` is thrown.
+- `parentProjectId` bidirectional validator — **add** — `update()` rejects
+  attaching a child to a parent that doesn't exist, isn't `kind: 'project'`,
+  or doesn't list this child in any of its `rounds[].itemIds`.
+
+No other decision points are touched. The new validators sit at the
+persistence-layer edge and are structural — they accept/reject based on
+type and reference integrity, not on conversational context.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No new rejections for legitimate input shapes. The new fields are all
+optional and additive — pre-existing callers that don't touch them are
+not affected. The OCC check only fires when `ifMatch` is explicitly
+provided, so backward-compatible callers continue to enjoy unconditional
+writes. The `parentProjectId` validator only fires when the caller is
+actually setting that field; clearing (set to null) skips validation.
+The `kind` immutability check only rejects values that differ from the
+current kind — passing the same kind value is accepted as a no-op.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The OCC check is opt-in — old callers that don't provide `ifMatch` still
+get last-write-wins semantics. This is intentional for backward
+compatibility. The HTTP layer (PR 2) will enforce `If-Match` on the
+project-kind `PATCH /projects/:id` endpoint specifically, where staleness
+matters; legacy `/initiatives/*` keeps current semantics.
+
+`parentProjectId` validation only fires inside `update()`. A caller
+that sets `parentProjectId` at create time (via
+`InitiativeCreateInput.parentProjectId`) bypasses the bidirectional
+check. This is acceptable for Phase 1.1 because the round-runner and HTTP
+layer (PR 2 / Phase 1.5) construct child initiatives and then attach them
+in a separate update — the create-time field exists for migration/testing
+shapes only. PR 2 may tighten this if the create flow uses it directly.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. Type extension, OCC counter, `kind` immutability, and the
+`parentProjectId` bidirectional check all live at the persistence layer,
+which is correct because the tracker is the single source of truth for
+both project and task initiative records. The validators compare to
+fields already owned by the tracker (`rounds[].itemIds`, `kind`,
+`version`), so reaching outside the tracker would only add coupling, not
+clarity. The HTTP layer (PR 2) will map the three error classes to 4xx
+responses; that's a thin translation, not a re-implementation.
+
+The digest-cache-invalidator hook is a deliberate inversion of
+dependency — the tracker doesn't know about the cache (which is owned by
+PR 3's project-scope digest), it just signals "something changed." This
+keeps the layering clean.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface in the
+      conversational-content sense.
+
+The three new validators (`KindImmutableError`,
+`OccVersionMismatchError`, `InvalidParentProjectError`) are structural
+schema/reference checks, not behavioral content gates. They fall under
+the "When this principle does NOT apply" carve-out in
+`docs/signal-vs-authority.md`: schema validators, type guards, and
+referential-integrity checks at API edges are expected to be structural
+and brittle by design — the right answer to "does this PATCH change an
+immutable field?" is a deterministic yes/no, not an LLM judgment. The
+spec calls this out explicitly in Phase 1.1.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** The backfill in `loadFromDisk()` runs once at construction
+  time. It does not shadow other checks because it operates on raw JSON
+  before the cache is populated. The version-bump in `update()` runs
+  after all field assignments and before the persistence call; it
+  doesn't shadow any existing check.
+- **Double-fire:** `setPhaseStatus()` and `update()` both bump `version`
+  and both call the digest-cache invalidator. They're separate code
+  paths called by different callers, never on the same logical write.
+  `create()` and `remove()` likewise each invalidate exactly once per
+  successful mutation. No double-fire.
+- **Races:** The legacy-JSON path is single-process (one server, one
+  tracker instance). The TaskFlow path inherits TaskFlow's existing
+  concurrency model (controllerInstanceId + expectedRevision). PR 4 will
+  add multi-machine reconciliation via `awaitingReconciliation`; the
+  field is present in this PR but unused.
+- **Feedback loops:** The digest cache invalidator hook is a one-way
+  signal; no feedback path is created. The default no-op cannot loop.
+
+The backfill rewrite happens inside `loadFromDisk()`. The constructor
+runs `loadFromDisk()` synchronously before any caller can touch the
+tracker, so there's no race between backfill and the first read. If
+`fs.writeFileSync` fails, the cache still reflects the backfilled shape
+(in-memory) and the next mutation will rewrite to disk — the legacy
+file remains valid because `kind`/`schemaVersion` are optional.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Other agents on the same machine:** No. The new fields are all
+  optional; agents that read `Initiative` records without expecting them
+  see the same shape as before.
+- **Other users of the install base:** No HTTP changes in this PR.
+  Endpoints in `routes-initiatives.ts` continue to operate on the
+  pre-existing field set. PR 2 will introduce `/projects` routes.
+- **External systems:** None.
+- **Persistent state:** Legacy `initiatives.json` files gain a one-time
+  backfill: each record acquires `kind: 'task'` and `schemaVersion: 1`.
+  This is forward-compatible — old code reading the file ignores the
+  new fields. The TaskFlow path stores the same shape in `stateJson`.
+  No schema migration is required for rollback (see § 7).
+- **Timing / runtime conditions:** The backfill adds a small write at
+  startup the first time a server boots with this code on a legacy
+  install. Bounded by the number of legacy records; in practice
+  microseconds.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+- **Hot-fix release:** Revert the commit. All new fields are optional;
+  rollback restores the original behavior.
+- **Data migration:** None required. Records that received
+  `kind: 'task' + schemaVersion: 1` from the backfill simply carry
+  those extra fields after rollback — old code ignores them. The
+  `version` field was added to in-memory records during this PR's
+  lifetime; if it survives the rollback in the on-disk file, old code
+  ignores it.
+- **Agent state repair:** Not needed. The legacy JSON path tolerates
+  unknown extra fields. TaskFlow's `stateJson` is opaque to TaskFlow
+  itself; only the projector cares.
+- **User visibility:** No user-visible regression during rollback. No
+  HTTP responses or dashboard surfaces change in this PR.
+
+Rollback is a single `git revert` with no follow-up.
+
+---
+
+## Conclusion
+
+PR 1 of 3 for the project-scope Phase 1a build. All changes are
+additive and structural: optional type fields, three error classes for
+structural validators, a one-time idempotent backfill, and a no-op
+digest-cache hook. The 26 new tests in
+`tests/unit/InitiativeTracker.project.test.ts` cover backfill,
+immutability, OCC, parent validation, serialization stability, the
+extended status enum, and the invalidator hook. The full existing
+InitiativeTracker suite (87 tests across 4 files) continues to pass.
+Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+Not required. No new decision points, no sentinel/gate/watchdog
+touched, no externally-visible behavior change. Per the
+`/instar-dev` rubric in `skills/instar-dev/SKILL.md` § Phase 5, a
+second-pass review is reserved for changes that alter conversational
+gates or recovery infrastructure.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/InitiativeTracker.project.test.ts` — 26 new tests, all
+  passing.
+- Full InitiativeTracker test sweep:
+  `node node_modules/vitest/vitest.mjs run tests/unit/InitiativeTracker tests/unit/initiative-tracker-taskflow tests/unit/routes-initiatives` → 87 tests, all passing.
+- `node_modules/typescript/bin/tsc --noEmit` → clean.
+- Spec: `docs/specs/PROJECT-SCOPE-SPEC.md` Phase 1.1.


### PR DESCRIPTION
## Summary

Phase 1a PR 1 of 3 for the **project-scope** feature. This PR adds the
type-level surface (no HTTP routes yet — PR 2 brings those). All changes
are optional/additive and fully backward compatible.

Spec: [`docs/specs/PROJECT-SCOPE-SPEC.md`](docs/specs/PROJECT-SCOPE-SPEC.md) § Phase 1.1 (converged + approved).

### What lands

- `Initiative` gains optional project-layer fields (`kind`, `schemaVersion`,
  `version` OCC counter, `parentProjectId`, plus child-only and project-only
  field groups).
- `InitiativeStatus` extended with `'paused' | 'halted' | 'awaiting-user'`.
- Three new error classes: `OccVersionMismatchError`, `KindImmutableError`,
  `InvalidParentProjectError`.
- `update()` accepts `ifMatch?: number` (opt-in OCC), rejects `kind`
  mutation, runs bidirectional `parentProjectId` validation against the
  named parent's `rounds[].itemIds`.
- One-time idempotent backfill writes `kind: 'task' + schemaVersion: 1`
  to legacy records on first load. Parallel `backfillKindAndSchema()`
  public method handles the TaskFlow-enabled install path.
- `saveToDisk()` omits `undefined` fields; round-trip stable.
- New `setDigestCacheInvalidator(fn)` hook fires after every successful
  mutation. Default is a no-op — PR 3 wires the real invalidator.

### Constraints honored

- No `/projects` endpoints (PR 2 territory).
- No stage-transition validators (PR 2 territory).
- No `/spec` or `/skill` files touched (PR 3 territory).
- No TaskFlow source files modified.

## Test plan

- [x] `tests/unit/InitiativeTracker.project.test.ts` — 26 new tests
      covering backfill, immutability, OCC, parent validation,
      serialization round-trip, status enum, invalidator hook.
- [x] Full InitiativeTracker test sweep — 87 tests across 4 suites pass
      unchanged (`InitiativeTracker.test.ts`,
      `initiative-tracker-taskflow.test.ts`,
      `routes-initiatives.test.ts`, `dashboard-initiativesTab.test.ts`).
- [x] `tsc --noEmit` clean.
- [x] `lint-no-direct-destructive` clean.
- [x] Pre-commit gate (`/instar-dev` trace + spec verification) passes.
- [x] Pre-push gate (NEXT.md + side-effects artifact) passes.
- [ ] CI green (squash merge once verified).

### Side-effects review

[`upgrades/side-effects/project-scope-phase1a-pr1.md`](upgrades/side-effects/project-scope-phase1a-pr1.md) — no new decision points; structural validators only; per signal-vs-authority "When this principle does NOT apply."

### Rollback

Single `git revert`. All new fields optional; the backfilled
`kind: 'task' + schemaVersion: 1` on legacy records remains valid after
revert (ignored by old code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)