### PR TITLE
feat(projects): /project skill + session-start digest (Phase 1a PR 3 of 3)

### DIFF
--- a/.claude/skills/instar-project/SKILL.md
+++ b/.claude/skills/instar-project/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: instar-project
+description: Register and inspect multi-spec projects via the instar /projects API. Phase 1a ships read-only commands (create, status, next); advance / drift / run-round / halt / ack / resume / abandon ship in Phase 1b.
+user_invocable: true
+---
+
+# /project — Multi-Spec Project Surface (Phase 1a, read-only + create)
+
+> Spec: `docs/specs/PROJECT-SCOPE-SPEC.md` § Phase 1.7.
+> A project bundles many feature initiatives into rounds. The dashboard
+> Projects tab + session-start digest line keep them visible; this skill
+> is the user-invocable surface for inspecting and registering them.
+
+**Phase 1a scope:** `create`, `status`, `next`. Mutating commands
+(`advance`, `drift`, `run-round`, `halt`, `ack`, `resume`, `abandon`,
+`accept-partial`, `claim-ownership`, `resolve-conflict`) ship in Phase 1b
+once the round-runner and drift checker land.
+
+---
+
+## Setup — read the auth token once
+
+```bash
+AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+PORT=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('port',4040))" 2>/dev/null)
+```
+
+Use `Authorization: Bearer $AUTH` on every call. The `/health` endpoint
+is the only one that doesn't require auth.
+
+---
+
+## `/project create <plan-doc-path>`
+
+Register a new project from a plan-doc markdown file. The plan-doc
+schema is `PlanDocParser`'s contract (PR 2 spec § Phase 1.6 — frontmatter
++ roster tables under `### Tier N` headers).
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $AUTH" \
+  -H "Content-Type: application/json" \
+  -d "{\"planDocPath\": \"$(realpath PLAN_DOC.md)\"}" \
+  "http://localhost:${PORT}/projects"
+```
+
+**Responses:**
+- `201` — project + children created. Body: `{project, children}`.
+- `400` — plan-doc validation failed. Body: `{error, errors[]}` —
+  surface each error to the user; the parser names the offending field.
+- `409` — slug already exists. Surface "project `<id>` already
+  registered" to the user; they can pick a new slug.
+- `429` — rate-limited (5 creates/hour per auth token). Body includes
+  `windowEnds`. Tell the user the next window.
+
+**Pre-flight check (recommended for long plan docs):** dry-run the parse
+first so you can show errors without consuming the rate-limit budget.
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $AUTH" \
+  -H "Content-Type: application/json" \
+  -d "{\"planDocPath\": \"$(realpath PLAN_DOC.md)\"}" \
+  "http://localhost:${PORT}/projects/validate"
+```
+
+`POST /projects/validate` always returns `200` with `{ok, project,
+children, errors}`. Iterate on the plan doc until `ok:true`, then
+`create`.
+
+---
+
+## `/project status [id]`
+
+**No id:** list all active projects with per-project round progress.
+
+```bash
+curl -sS -H "Authorization: Bearer $AUTH" "http://localhost:${PORT}/projects"
+```
+
+Response: `{ items: [...], count: N }`. Each item is a full `Initiative`
+record with `kind:'project'`. Render a short table to the user — `id`,
+`title`, `rounds[].status` summary (e.g. `0/4 complete, 1 in-progress,
+3 pending`).
+
+**With id:** fetch the project + its children (the per-feature tasks
+attached via `parentProjectId`).
+
+```bash
+curl -sS -H "Authorization: Bearer $AUTH" "http://localhost:${PORT}/projects/<id>"
+```
+
+Response: `{project, children}`. Render to the user as:
+- Title, status, `version`
+- Round-by-round breakdown: round name, member item titles, item
+  `pipelineStage`
+- Any `blockers` or `needsUser` reasons
+
+**Common errors:**
+- `404 project not found` — id is wrong or the record is a `kind:'task'`
+  initiative. Suggest `/project status` (no id) to list valid ids.
+
+---
+
+## `/project next [id]`
+
+Phase 1a placeholder. The endpoint returns `501` until Phase 1b's
+`ProjectRoundRunner` lands.
+
+```bash
+curl -sS -H "Authorization: Bearer $AUTH" \
+  "http://localhost:${PORT}/projects/<id>/next"
+```
+
+Expected response right now: `501 { action: "not-implemented", message:
+"next-action computation lands in Phase 1b" }`. Surface to the user:
+"`/project next` is a placeholder until Phase 1b lands the round
+runner. Use `/project status` for current state."
+
+---
+
+## Session-start integration
+
+Active projects (top 5 by `lastTouchedAt`) show up automatically at
+session start and after context compaction. The data comes from
+`.instar/projects-digest.cache`, written by the server every time a
+project mutates. You don't need to invoke `/project status` to see what
+projects are open — the digest is already in your context.
+
+If the cache is missing the hook emits:
+
+> Active projects: state unavailable — run /project status when ready.
+
+That's the cue to call `/project status` (no id) once and let the
+agent re-render its mental model.
+
+---
+
+## What's coming in Phase 1b
+
+The mutating commands ship next. Skill body will grow to cover:
+
+- `/project advance <id> <stage>` — manual stage transition (uses
+  `POST /projects/:id/advance`).
+- `/project drift <id>` — run drift check now (signal-only).
+- `/project run-round <id> [roundIndex]` — start a round
+  (`ProjectRoundRunner` dispatch).
+- `/project halt <id>` — immediate cancel.
+- `/project ack <id> [roundIndex]` — record user ack to allow auto-advance.
+- `/project resume <id>` / `/project resume --force <id>` — resume halted/failed rounds.
+- `/project abandon <id>` — archive halted round; children stay where they are.
+- `/project accept-partial <id> <roundIndex> <reason>` — close partially-complete round.
+- `/project claim-ownership <id>` — multi-machine ownership transfer.
+
+Until those land, treat this skill as read-only for projects already
+in flight, plus a create entry point.

--- a/.instar/hooks/instar/compaction-recovery.sh
+++ b/.instar/hooks/instar/compaction-recovery.sh
@@ -237,4 +237,54 @@ except Exception:
   fi
 fi
 
+# Active projects digest — file-first, no HTTP (PROJECT-SCOPE-SPEC Phase 1.9).
+# Re-injects the active-project orientation after compaction so the agent
+# doesn't lose track of multi-spec work. Same cache as session-start.sh.
+DIGEST_FILE="$INSTAR_DIR/projects-digest.cache"
+echo ""
+if [ -f "$DIGEST_FILE" ]; then
+  PROJ_DIGEST=$(python3 - "$DIGEST_FILE" <<'PYEOF' 2>/dev/null
+import json, re, sys
+path = sys.argv[1]
+try:
+    with open(path, 'r', encoding='utf-8') as f:
+        d = json.load(f)
+    lines = d.get('digestLines') or []
+    if not isinstance(lines, list):
+        sys.exit(0)
+    ctrl = re.compile(r'[\x00-\x1F\x7F]')
+    cleaned = []
+    for ln in lines[:5]:
+        if not isinstance(ln, str):
+            continue
+        s = ctrl.sub(' ', ln)
+        s = re.sub(r'\s+', ' ', s).strip()
+        if not s:
+            continue
+        cleaned.append(s[:200])
+    if not cleaned:
+        print('Active projects: none')
+    else:
+        print('--- ACTIVE PROJECTS (post-compaction) ---')
+        for c in cleaned:
+            print(c)
+        truncated = bool(d.get('truncated'))
+        total = d.get('totalActiveProjects')
+        if truncated and isinstance(total, int) and total > len(cleaned):
+            more = total - len(cleaned)
+            print(f'+{more} more on dashboard.')
+        print('--- END ACTIVE PROJECTS ---')
+except Exception:
+    sys.exit(0)
+PYEOF
+)
+  if [ -n "$PROJ_DIGEST" ]; then
+    echo "$PROJ_DIGEST"
+  else
+    echo "Active projects: state unavailable — run /project status when ready"
+  fi
+else
+  echo "Active projects: state unavailable — run /project status when ready"
+fi
+
 echo "=== END IDENTITY RECOVERY ==="

--- a/.instar/hooks/instar/session-start.sh
+++ b/.instar/hooks/instar/session-start.sh
@@ -270,4 +270,55 @@ if [ -f "$GUIDE_FILE" ]; then
   echo "=== END UPGRADE GUIDE ==="
 fi
 
+# Active projects digest — file-first, no HTTP (PROJECT-SCOPE-SPEC Phase 1.9).
+# Reads .instar/projects-digest.cache, written by the server on every
+# project mutation. Re-sanitizes each line on read for defense in depth.
+DIGEST_FILE="$INSTAR_DIR/projects-digest.cache"
+echo ""
+if [ -f "$DIGEST_FILE" ]; then
+  PROJ_DIGEST=$(python3 - "$DIGEST_FILE" <<'PYEOF' 2>/dev/null
+import json, re, sys
+path = sys.argv[1]
+try:
+    with open(path, 'r', encoding='utf-8') as f:
+        d = json.load(f)
+    lines = d.get('digestLines') or []
+    if not isinstance(lines, list):
+        sys.exit(0)
+    ctrl = re.compile(r'[\x00-\x1F\x7F]')
+    cleaned = []
+    for ln in lines[:5]:
+        if not isinstance(ln, str):
+            continue
+        s = ctrl.sub(' ', ln)
+        s = re.sub(r'\s+', ' ', s).strip()
+        if not s:
+            continue
+        # 200-char hard cap on the rendered line (≥ 80-char title + framing)
+        cleaned.append(s[:200])
+    if not cleaned:
+        print('Active projects: none')
+    else:
+        print('--- ACTIVE PROJECTS ---')
+        for c in cleaned:
+            print(c)
+        truncated = bool(d.get('truncated'))
+        total = d.get('totalActiveProjects')
+        if truncated and isinstance(total, int) and total > len(cleaned):
+            more = total - len(cleaned)
+            print(f'+{more} more on dashboard.')
+        print('--- END ACTIVE PROJECTS ---')
+except Exception:
+    sys.exit(0)
+PYEOF
+)
+  if [ -n "$PROJ_DIGEST" ]; then
+    echo "$PROJ_DIGEST"
+  else
+    echo "Active projects: state unavailable — run /project status when ready"
+  fi
+else
+  echo "Active projects: state unavailable — run /project status when ready"
+fi
+
 echo "=== END SESSION START ==="

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6199,6 +6199,16 @@ export async function startServer(options: StartOptions): Promise<void> {
     const { InitiativeTracker } = await import('../core/InitiativeTracker.js');
     const initiativeTracker = new InitiativeTracker(config.stateDir);
 
+    // Project-scope Phase 1.9 — wire the digest cache writer so every
+    // project mutation re-renders `.instar/projects-digest.cache`. The
+    // session-start + compaction-recovery hooks read this file directly
+    // (≤50ms budget, no HTTP). First-start writes the file unconditionally
+    // so the hooks always have something to read on a fresh install.
+    const { ProjectDigestCache } = await import('../core/ProjectDigestCache.js');
+    const projectDigestCache = new ProjectDigestCache(config.stateDir, initiativeTracker);
+    initiativeTracker.setDigestCacheInvalidator(() => projectDigestCache.writeDigestCache());
+    projectDigestCache.writeDigestCache();
+
     // TaskFlow registry — opt-in via config.taskFlow.enabled (default: off in v1).
     // Owns its own SQLite file under .instar/task-flows.db. The maintenance
     // sweeper and due-waker start with the registry; both .unref() their timers

--- a/src/core/ProjectDigestCache.ts
+++ b/src/core/ProjectDigestCache.ts
@@ -1,0 +1,179 @@
+/**
+ * ProjectDigestCache — writes a sanitized JSON snapshot of active projects
+ * to `.instar/projects-digest.cache` for cheap, no-HTTP consumption by
+ * session-start and compaction-recovery hooks.
+ *
+ * Spec source: PROJECT-SCOPE-SPEC.md § Phase 1.9 (session-start + compaction
+ * recovery hooks). The hooks have a ≤50ms budget — pure file read, no HTTP.
+ *
+ * Invariants:
+ *   - Top 5 active projects by `lastTouchedAt` (desc) are included; the
+ *     `truncated` flag + `totalActiveProjects` count make over-limit visible.
+ *   - Every string field that lands in the cache is sanitized at write time:
+ *     control chars (incl. newline + CR) stripped, and the result capped at
+ *     80 characters. The hooks ALSO sanitize on read (defense in depth),
+ *     so direct cache-file poisoning can't smuggle an unprintable string
+ *     into orientation output.
+ *   - Atomic on-disk write (temp file + rename) — readers never observe a
+ *     partial file. Matches the pattern `InitiativeTracker.saveToDisk()`
+ *     uses for its own persistence.
+ *
+ * This module is the **read side** of the invalidator hook PR 1 added on
+ * InitiativeTracker (`setDigestCacheInvalidator`). The server wires
+ * `writeDigestCache()` as the invalidator at boot, so every successful
+ * project mutation re-renders the file. Mutations on `kind:'task'`
+ * initiatives also trigger a rewrite — the function filters internally to
+ * `kind:'project' && status:'active'`, so the side effect is a no-op when
+ * no project state changed.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import type { InitiativeTracker, Initiative } from './InitiativeTracker.js';
+
+/** Where the digest lands. Hooks read this exact path. */
+export const DIGEST_CACHE_FILENAME = 'projects-digest.cache';
+
+/** Max projects rendered into `digestLines`. Top-N by `lastTouchedAt`. */
+export const MAX_PROJECTS_IN_DIGEST = 5;
+
+/** Max characters per sanitized string (titles, round names). */
+export const MAX_STRING_LENGTH = 80;
+
+/** JSON shape that the hooks deserialize. */
+export interface ProjectDigestCacheFile {
+  /** ISO timestamp when this snapshot was written. */
+  generatedAt: string;
+  /** One sanitized one-liner per active project, top-N by `lastTouchedAt`. */
+  digestLines: string[];
+  /** Total active projects in the tracker (independent of truncation). */
+  totalActiveProjects: number;
+  /** True iff `totalActiveProjects > MAX_PROJECTS_IN_DIGEST`. */
+  truncated: boolean;
+}
+
+/**
+ * Strip control chars (incl. \n, \r, \t), then collapse runs of internal
+ * whitespace to single spaces and cap at `cap` chars.
+ *
+ * Exported so the hooks (well, their JS-side helpers) and tests can apply
+ * the same rule on read. The bash hooks themselves use a `tr`-based
+ * equivalent — the literal regex below is the canonical implementation.
+ */
+export function sanitizeDigestString(input: unknown, cap = MAX_STRING_LENGTH): string {
+  const raw = typeof input === 'string' ? input : input == null ? '' : String(input);
+  // Strip ASCII control chars (0x00-0x1F) and DEL (0x7F).
+  // Replaces with a single space so words don't collide.
+  // eslint-disable-next-line no-control-regex
+  const stripped = raw.replace(/[\x00-\x1F\x7F]/g, ' ');
+  // Collapse internal whitespace runs, trim ends.
+  const collapsed = stripped.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= cap) return collapsed;
+  return collapsed.slice(0, cap);
+}
+
+/**
+ * Render one digest line for a single project. Pure function — caller
+ * provides the project; sanitization happens inside.
+ */
+export function formatProjectDigestLine(project: Initiative): string {
+  const id = sanitizeDigestString(project.id, MAX_STRING_LENGTH);
+  const rounds = Array.isArray(project.rounds) ? project.rounds : [];
+  const total = rounds.length;
+  const done = rounds.filter(
+    (r) => r && (r.status === 'complete' || r.status === 'complete-with-skips')
+  ).length;
+
+  // Next round: first non-complete round in order. Falls through to "(none)"
+  // when every round is done.
+  const next = rounds.find(
+    (r) =>
+      r &&
+      r.status !== 'complete' &&
+      r.status !== 'complete-with-skips' &&
+      r.status !== 'failed'
+  );
+  const nextLabel = next
+    ? sanitizeDigestString(next.name || '(unnamed round)', MAX_STRING_LENGTH)
+    : '(none — all rounds complete)';
+
+  return `Project [${id}]: ${done} of ${total} done. Next round: ${nextLabel}.`;
+}
+
+/**
+ * Sort projects by `lastTouchedAt` descending. Ties broken by `id` ascending
+ * so the output is stable.
+ */
+function sortByLastTouched(a: Initiative, b: Initiative): number {
+  const at = a.lastTouchedAt ?? '';
+  const bt = b.lastTouchedAt ?? '';
+  if (at === bt) return a.id.localeCompare(b.id);
+  return bt.localeCompare(at);
+}
+
+/**
+ * ProjectDigestCache — single-responsibility writer. Construct once at
+ * server boot; pass `writeDigestCache.bind(this)` as the invalidator on
+ * `InitiativeTracker.setDigestCacheInvalidator(fn)`.
+ */
+export class ProjectDigestCache {
+  private readonly filePath: string;
+  private readonly tracker: InitiativeTracker;
+  /** Bound to `process.pid` so concurrent writers (test sandbox + main
+   *  process) don't trample one another's temp files. */
+  private readonly tmpSuffix: string;
+
+  constructor(stateDir: string, tracker: InitiativeTracker) {
+    this.filePath = path.join(stateDir, DIGEST_CACHE_FILENAME);
+    this.tracker = tracker;
+    this.tmpSuffix = `.${process.pid}.tmp`;
+  }
+
+  /** Absolute path to the cache file. Exposed for diagnostics. */
+  getCachePath(): string {
+    return this.filePath;
+  }
+
+  /**
+   * Snapshot all active projects, render the top-N digest lines, and write
+   * the result atomically. Synchronous on purpose — runs in the
+   * invalidator hot path (every project mutation calls it once).
+   *
+   * Best-effort: any thrown error is swallowed after logging, so a hiccup
+   * writing the cache never blocks a successful mutation.
+   */
+  writeDigestCache(): void {
+    try {
+      const all = this.tracker.list({ kind: 'project', status: 'active' });
+      // `list()` already sorts by `lastTouchedAt` desc; re-sort defensively
+      // in case the contract changes underneath us.
+      const sorted = [...all].sort(sortByLastTouched);
+      const total = sorted.length;
+      const truncated = total > MAX_PROJECTS_IN_DIGEST;
+      const top = sorted.slice(0, MAX_PROJECTS_IN_DIGEST);
+      const digestLines = top.map((p) => formatProjectDigestLine(p));
+
+      const payload: ProjectDigestCacheFile = {
+        generatedAt: new Date().toISOString(),
+        digestLines,
+        totalActiveProjects: total,
+        truncated,
+      };
+
+      this.atomicWrite(JSON.stringify(payload, null, 2));
+    } catch (err) {
+      console.warn(
+        `[ProjectDigestCache] writeDigestCache failed (non-fatal): ${
+          err instanceof Error ? err.message : err
+        }`
+      );
+    }
+  }
+
+  private atomicWrite(contents: string): void {
+    const dir = path.dirname(this.filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${this.filePath}${this.tmpSuffix}`;
+    fs.writeFileSync(tmp, contents);
+    fs.renameSync(tmp, this.filePath);
+  }
+}

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-10T22:52:04.920Z",
-  "instarVersion": "0.28.83",
-  "entryCount": 187,
+  "generatedAt": "2026-05-11T19:56:59.389Z",
+  "instarVersion": "0.28.86",
+  "entryCount": 188,
   "entries": {
     "hook:session-start": {
       "id": "hook:session-start",
@@ -363,6 +363,14 @@
       "contentHash": "5b3557fa3662cf0c7b7bab85a252cc2e567b3fc64a04a92d430374ef1f264ca6",
       "since": "2025-01-01"
     },
+    "skill:instar-project": {
+      "id": "skill:instar-project",
+      "type": "skill",
+      "domain": "skills",
+      "sourcePath": ".claude/skills/instar-project/skill.md",
+      "contentHash": "8c8a924740d8afedeb5e0b4bea7a3760c9654dc6b49a9a415429fe0366ff8429",
+      "since": "2025-01-01"
+    },
     "skill:secret-setup": {
       "id": "skill:secret-setup",
       "type": "skill",
@@ -384,7 +392,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -392,7 +400,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -400,7 +408,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -408,7 +416,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -416,7 +424,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -424,7 +432,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -432,7 +440,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -440,7 +448,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -448,7 +456,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -456,7 +464,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -464,7 +472,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -472,7 +480,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -480,7 +488,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -488,7 +496,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -496,7 +504,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -504,7 +512,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -512,7 +520,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -520,7 +528,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -528,7 +536,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -536,7 +544,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -544,7 +552,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -552,7 +560,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -560,7 +568,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -568,7 +576,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -576,7 +584,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -584,7 +592,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -592,7 +600,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -600,7 +608,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -608,7 +616,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -616,7 +624,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -624,7 +632,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -632,7 +640,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -640,7 +648,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -648,7 +656,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -656,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -664,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -672,7 +680,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -680,7 +688,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -688,7 +696,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -696,7 +704,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -704,7 +712,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -712,7 +720,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -720,7 +728,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -736,7 +744,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "11305bef37175027b04584093c71e0e967efcc65a1f8d439ea398ccfadc3bc91",
+      "contentHash": "1ecd66f6392872c8c208d1b19d5af5b1b5228e843fdcb60467da55d5972b888b",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -984,7 +992,7 @@
       "type": "template",
       "domain": "safety",
       "sourcePath": "src/templates/hooks/compaction-recovery.sh",
-      "contentHash": "97929330cdb4794117bbaafbfbd0635d95c27b24a1189a685eae9f5445000642",
+      "contentHash": "ca6a2a5c2ee03839654c9708912292bc03d81c61281dffbbb958d4877ee1dc91",
       "since": "2025-01-01"
     },
     "template:dangerous-command-guard.sh": {
@@ -1024,7 +1032,7 @@
       "type": "template",
       "domain": "safety",
       "sourcePath": "src/templates/hooks/session-start.sh",
-      "contentHash": "1b63c4646f30126601f8e425359d9638442e92561e27fa404d33f832bd03e263",
+      "contentHash": "4d98736d3ee30fe8639f0851e5e492416ad05f4ae49f84e8695723faa4b9398e",
       "since": "2025-01-01"
     },
     "template:settings-template.json": {
@@ -1512,7 +1520,7 @@
       "type": "subsystem",
       "domain": "evolution",
       "sourcePath": "src/core/EvolutionManager.ts",
-      "contentHash": "0d421ddf5b2a08ca257b52f11c1afc6ede3b79d8934faae7101a7d15b99d05f0",
+      "contentHash": "2c77de28e6cb3e53eeb92369d13cb324426929a8038f90a3e9e4d60fc7d3ce86",
       "since": "2025-01-01"
     }
   }

--- a/src/templates/hooks/compaction-recovery.sh
+++ b/src/templates/hooks/compaction-recovery.sh
@@ -464,5 +464,55 @@ if [ -f "$CONFIG_FILE" ] && command -v tmux >/dev/null 2>&1; then
   fi
 fi
 
+# Active projects digest — file-first, no HTTP (PROJECT-SCOPE-SPEC Phase 1.9).
+# Re-injects the active-project orientation after compaction so the agent
+# doesn't lose track of multi-spec work. Same cache as session-start.sh.
+DIGEST_FILE="$INSTAR_DIR/projects-digest.cache"
+echo ""
+if [ -f "$DIGEST_FILE" ]; then
+  PROJ_DIGEST=$(python3 - "$DIGEST_FILE" <<'PYEOF' 2>/dev/null
+import json, re, sys
+path = sys.argv[1]
+try:
+    with open(path, 'r', encoding='utf-8') as f:
+        d = json.load(f)
+    lines = d.get('digestLines') or []
+    if not isinstance(lines, list):
+        sys.exit(0)
+    ctrl = re.compile(r'[\x00-\x1F\x7F]')
+    cleaned = []
+    for ln in lines[:5]:
+        if not isinstance(ln, str):
+            continue
+        s = ctrl.sub(' ', ln)
+        s = re.sub(r'\s+', ' ', s).strip()
+        if not s:
+            continue
+        cleaned.append(s[:200])
+    if not cleaned:
+        print('Active projects: none')
+    else:
+        print('--- ACTIVE PROJECTS (post-compaction) ---')
+        for c in cleaned:
+            print(c)
+        truncated = bool(d.get('truncated'))
+        total = d.get('totalActiveProjects')
+        if truncated and isinstance(total, int) and total > len(cleaned):
+            more = total - len(cleaned)
+            print(f'+{more} more on dashboard.')
+        print('--- END ACTIVE PROJECTS ---')
+except Exception:
+    sys.exit(0)
+PYEOF
+)
+  if [ -n "$PROJ_DIGEST" ]; then
+    echo "$PROJ_DIGEST"
+  else
+    echo "Active projects: state unavailable — run /project status when ready"
+  fi
+else
+  echo "Active projects: state unavailable — run /project status when ready"
+fi
+
 echo ""
 echo "=== RECOVERY COMPLETE — You are grounded. Continue your work. ==="

--- a/src/templates/hooks/session-start.sh
+++ b/src/templates/hooks/session-start.sh
@@ -355,4 +355,54 @@ except Exception:
   fi
 fi
 
+# Active projects digest — file-first, no HTTP (PROJECT-SCOPE-SPEC Phase 1.9).
+# Reads .instar/projects-digest.cache, written by the server on every
+# project mutation. Re-sanitizes each line on read for defense in depth.
+DIGEST_FILE="$INSTAR_DIR/projects-digest.cache"
+echo ""
+if [ -f "$DIGEST_FILE" ]; then
+  PROJ_DIGEST=$(python3 - "$DIGEST_FILE" <<'PYEOF' 2>/dev/null
+import json, re, sys
+path = sys.argv[1]
+try:
+    with open(path, 'r', encoding='utf-8') as f:
+        d = json.load(f)
+    lines = d.get('digestLines') or []
+    if not isinstance(lines, list):
+        sys.exit(0)
+    ctrl = re.compile(r'[\x00-\x1F\x7F]')
+    cleaned = []
+    for ln in lines[:5]:
+        if not isinstance(ln, str):
+            continue
+        s = ctrl.sub(' ', ln)
+        s = re.sub(r'\s+', ' ', s).strip()
+        if not s:
+            continue
+        cleaned.append(s[:200])
+    if not cleaned:
+        print('Active projects: none')
+    else:
+        print('--- ACTIVE PROJECTS ---')
+        for c in cleaned:
+            print(c)
+        truncated = bool(d.get('truncated'))
+        total = d.get('totalActiveProjects')
+        if truncated and isinstance(total, int) and total > len(cleaned):
+            more = total - len(cleaned)
+            print(f'+{more} more on dashboard.')
+        print('--- END ACTIVE PROJECTS ---')
+except Exception:
+    sys.exit(0)
+PYEOF
+)
+  if [ -n "$PROJ_DIGEST" ]; then
+    echo "$PROJ_DIGEST"
+  else
+    echo "Active projects: state unavailable — run /project status when ready"
+  fi
+else
+  echo "Active projects: state unavailable — run /project status when ready"
+fi
+
 exit 0

--- a/tests/unit/ProjectDigestCache.test.ts
+++ b/tests/unit/ProjectDigestCache.test.ts
@@ -1,0 +1,332 @@
+/**
+ * ProjectDigestCache unit tests (Phase 1a PR 3).
+ *
+ * Covers:
+ *   - empty case → 0 lines, total=0, truncated=false
+ *   - 3 projects → 3 lines, ordered by lastTouchedAt desc
+ *   - 7 projects → 5 lines + truncated=true + totalActiveProjects=7
+ *   - sanitization: control chars + newlines stripped from titles/round names
+ *   - 80-char cap on each sanitized field
+ *   - cache invalidator hook: every mutation through InitiativeTracker
+ *     triggers a writeDigestCache() call
+ *   - atomic write: no partial file ever visible
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  InitiativeTracker,
+  type InitiativeCreateInput,
+} from '../../src/core/InitiativeTracker.js';
+import {
+  ProjectDigestCache,
+  DIGEST_CACHE_FILENAME,
+  MAX_PROJECTS_IN_DIGEST,
+  MAX_STRING_LENGTH,
+  sanitizeDigestString,
+  formatProjectDigestLine,
+  type ProjectDigestCacheFile,
+} from '../../src/core/ProjectDigestCache.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let tmpDir: string;
+let tracker: InitiativeTracker;
+let cache: ProjectDigestCache;
+
+function projectInput(
+  id: string,
+  overrides: Partial<InitiativeCreateInput> = {}
+): InitiativeCreateInput {
+  return {
+    id,
+    title: `Project ${id}`,
+    description: 'test project',
+    phases: [{ id: 'p1', name: 'Phase 1' }],
+    kind: 'project',
+    rounds: [
+      { name: 'Round 1', itemIds: [], status: 'complete' },
+      { name: 'Round 2', itemIds: [], status: 'ready' },
+      { name: 'Round 3', itemIds: [], status: 'pending' },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'project-digest-cache-'));
+  tracker = new InitiativeTracker(tmpDir);
+  cache = new ProjectDigestCache(tmpDir, tracker);
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(tmpDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/ProjectDigestCache.test.ts',
+  });
+});
+
+function readCacheFile(): ProjectDigestCacheFile {
+  const raw = fs.readFileSync(path.join(tmpDir, DIGEST_CACHE_FILENAME), 'utf-8');
+  return JSON.parse(raw) as ProjectDigestCacheFile;
+}
+
+// ─── Empty case ────────────────────────────────────────────────────────────
+
+describe('writeDigestCache — empty', () => {
+  it('writes 0 digestLines and totalActiveProjects=0 when no projects exist', () => {
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    expect(c.digestLines).toEqual([]);
+    expect(c.totalActiveProjects).toBe(0);
+    expect(c.truncated).toBe(false);
+    expect(typeof c.generatedAt).toBe('string');
+    // ISO timestamp shape
+    expect(c.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('skips kind:"task" initiatives (only kind:"project" are counted)', async () => {
+    await tracker.create({
+      id: 'task-only',
+      title: 'A Task',
+      description: 'leaf',
+      phases: [{ id: 'p', name: 'P' }],
+      // kind defaults to 'task' when omitted
+    });
+    cache.writeDigestCache();
+    expect(readCacheFile().totalActiveProjects).toBe(0);
+  });
+
+  it('skips non-active projects (archived, paused, halted)', async () => {
+    await tracker.create(projectInput('proj-archived'));
+    await tracker.update('proj-archived', { status: 'archived' });
+    await tracker.create(projectInput('proj-paused'));
+    await tracker.update('proj-paused', { status: 'paused' });
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    expect(c.totalActiveProjects).toBe(0);
+    expect(c.digestLines).toEqual([]);
+  });
+});
+
+// ─── 3 projects ────────────────────────────────────────────────────────────
+
+describe('writeDigestCache — under MAX_PROJECTS_IN_DIGEST', () => {
+  it('writes one digestLine per active project, no truncation', async () => {
+    await tracker.create(projectInput('proj-a'));
+    await tracker.create(projectInput('proj-b'));
+    await tracker.create(projectInput('proj-c'));
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    expect(c.digestLines).toHaveLength(3);
+    expect(c.totalActiveProjects).toBe(3);
+    expect(c.truncated).toBe(false);
+  });
+
+  it('includes round progress + next round name in each line', async () => {
+    await tracker.create(projectInput('proj-x'));
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    expect(c.digestLines[0]).toContain('Project [proj-x]');
+    // 1 of 3 rounds is `complete`, so "1 of 3 done"
+    expect(c.digestLines[0]).toContain('1 of 3 done');
+    // first non-complete round is "Round 2"
+    expect(c.digestLines[0]).toContain('Next round: Round 2');
+  });
+
+  it('marks "(none — all rounds complete)" when every round is done', async () => {
+    await tracker.create(
+      projectInput('proj-done', {
+        rounds: [
+          { name: 'R1', itemIds: [], status: 'complete' },
+          { name: 'R2', itemIds: [], status: 'complete-with-skips' },
+        ],
+      })
+    );
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    expect(c.digestLines[0]).toContain('2 of 2 done');
+    expect(c.digestLines[0]).toContain('Next round: (none — all rounds complete)');
+  });
+});
+
+// ─── 7 projects (truncation) ───────────────────────────────────────────────
+
+describe('writeDigestCache — over MAX_PROJECTS_IN_DIGEST', () => {
+  it('caps digestLines at MAX, sets truncated=true, exposes total count', async () => {
+    for (let i = 0; i < 7; i++) {
+      await tracker.create(projectInput(`proj-${i}`));
+    }
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    expect(c.digestLines).toHaveLength(MAX_PROJECTS_IN_DIGEST); // 5
+    expect(c.totalActiveProjects).toBe(7);
+    expect(c.truncated).toBe(true);
+  });
+
+  it('keeps the most-recently-touched projects, drops the oldest', async () => {
+    // Create with manually-controlled lastTouchedAt by interleaving updates.
+    // tracker writes `lastTouchedAt = now()` on every successful mutation,
+    // so the LAST one touched should be first in the digest.
+    for (let i = 0; i < 7; i++) {
+      await tracker.create(projectInput(`p${i}`));
+    }
+    // Touch p3 last — should appear in the digest even though it was
+    // created 4th of 7.
+    await tracker.update('p3', { blockers: ['marker'] });
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    const ids = c.digestLines.map((ln) => {
+      const m = ln.match(/Project \[(.+?)\]/);
+      return m ? m[1] : '';
+    });
+    expect(ids[0]).toBe('p3'); // most recently touched
+    expect(ids).toHaveLength(5);
+  });
+});
+
+// ─── Sanitization ──────────────────────────────────────────────────────────
+
+describe('sanitizeDigestString', () => {
+  it('strips control chars and newlines, returns a single-line string', () => {
+    expect(sanitizeDigestString('hello\nworld')).toBe('hello world');
+    expect(sanitizeDigestString('a\x00b\x01c\x1Fd\x7Fe')).toBe('a b c d e');
+    expect(sanitizeDigestString('tab\there')).toBe('tab here');
+  });
+
+  it('collapses runs of whitespace', () => {
+    expect(sanitizeDigestString('a    b\t\tc')).toBe('a b c');
+  });
+
+  it('caps at the requested length', () => {
+    const long = 'a'.repeat(200);
+    expect(sanitizeDigestString(long, 80)).toHaveLength(80);
+  });
+
+  it('handles non-string input safely', () => {
+    expect(sanitizeDigestString(undefined)).toBe('');
+    expect(sanitizeDigestString(null)).toBe('');
+    expect(sanitizeDigestString(42)).toBe('42');
+  });
+});
+
+describe('writeDigestCache — sanitization at write time', () => {
+  it('strips newlines and control chars from project ids and round names', async () => {
+    // Slug rules forbid control chars in `id`, so inject via round name.
+    await tracker.create(
+      projectInput('proj-evil', {
+        rounds: [
+          { name: 'Round\nWith\x00Newlines\tEverywhere', itemIds: [], status: 'ready' },
+        ],
+      })
+    );
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    expect(c.digestLines[0]).not.toMatch(/[\x00-\x1F\x7F]/);
+    expect(c.digestLines[0]).toContain('Round With Newlines Everywhere');
+  });
+
+  it('caps round names at MAX_STRING_LENGTH (80 chars)', async () => {
+    const longName = 'x'.repeat(200);
+    await tracker.create(
+      projectInput('proj-long', {
+        rounds: [{ name: longName, itemIds: [], status: 'ready' }],
+      })
+    );
+    cache.writeDigestCache();
+    const c = readCacheFile();
+    // 200-char name must be capped to 80 before landing in the digest
+    const line = c.digestLines[0];
+    expect(line).toContain('Project [proj-long]:');
+    // The cap is on each sanitized field, not the whole rendered line;
+    // verify the round-name substring length doesn't exceed 80.
+    const m = line.match(/Next round: (.+?)\.$/);
+    expect(m).not.toBeNull();
+    expect(m![1].length).toBeLessThanOrEqual(MAX_STRING_LENGTH);
+  });
+});
+
+// ─── Cache invalidator hook ────────────────────────────────────────────────
+
+describe('setDigestCacheInvalidator wiring', () => {
+  it('every mutation through InitiativeTracker triggers a cache rewrite', async () => {
+    let invalidations = 0;
+    tracker.setDigestCacheInvalidator(() => {
+      invalidations++;
+      cache.writeDigestCache();
+    });
+    expect(invalidations).toBe(0);
+    await tracker.create(projectInput('proj-1'));
+    expect(invalidations).toBe(1);
+    await tracker.update('proj-1', { blockers: ['x'] });
+    expect(invalidations).toBe(2);
+    await tracker.update('proj-1', { status: 'archived' });
+    expect(invalidations).toBe(3);
+    // Cache file reflects the most recent state on disk.
+    const c = readCacheFile();
+    expect(c.totalActiveProjects).toBe(0); // proj-1 is archived
+  });
+
+  it('rewriting reflects the latest project set on every mutation', async () => {
+    tracker.setDigestCacheInvalidator(() => cache.writeDigestCache());
+    await tracker.create(projectInput('a'));
+    expect(readCacheFile().totalActiveProjects).toBe(1);
+    await tracker.create(projectInput('b'));
+    expect(readCacheFile().totalActiveProjects).toBe(2);
+    await tracker.update('a', { status: 'archived' });
+    expect(readCacheFile().totalActiveProjects).toBe(1);
+  });
+});
+
+// ─── Atomic write ──────────────────────────────────────────────────────────
+
+describe('writeDigestCache — atomic write', () => {
+  it('uses temp-file + rename so readers never see a partial file', () => {
+    // Implementation invariant: no .tmp file remains after a successful
+    // write. The cache file itself must be complete-and-parseable
+    // immediately after the call returns.
+    cache.writeDigestCache();
+    const dir = fs.readdirSync(tmpDir);
+    const tmpFiles = dir.filter((n) => n.startsWith(DIGEST_CACHE_FILENAME) && n.endsWith('.tmp'));
+    expect(tmpFiles).toEqual([]);
+    // Parseability: full JSON document on disk.
+    expect(() => readCacheFile()).not.toThrow();
+  });
+
+  it('repeated writes never leak partial state — every read is well-formed', async () => {
+    // Write a bunch in quick succession, parse the file every time.
+    tracker.setDigestCacheInvalidator(() => cache.writeDigestCache());
+    for (let i = 0; i < 10; i++) {
+      await tracker.create(projectInput(`p${i}`));
+      const c = readCacheFile();
+      expect(c.totalActiveProjects).toBe(i + 1);
+    }
+  });
+});
+
+// ─── formatProjectDigestLine pure function ─────────────────────────────────
+
+describe('formatProjectDigestLine', () => {
+  it('handles empty rounds gracefully', () => {
+    const line = formatProjectDigestLine({
+      id: 'no-rounds',
+      title: 't',
+      description: 'd',
+      status: 'active',
+      phases: [],
+      currentPhaseIndex: 0,
+      lastTouchedAt: '2026-05-11T00:00:00.000Z',
+      needsUser: false,
+      blockers: [],
+      links: [],
+      createdAt: '',
+      updatedAt: '',
+      kind: 'project',
+      rounds: [],
+    });
+    expect(line).toContain('Project [no-rounds]');
+    expect(line).toContain('0 of 0 done');
+    expect(line).toContain('(none — all rounds complete)');
+  });
+});

--- a/tests/unit/project-digest-hooks.test.ts
+++ b/tests/unit/project-digest-hooks.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Smoke test for the bash hooks that read .instar/projects-digest.cache.
+ *
+ * Both `.instar/hooks/instar/session-start.sh` (in the startup branch)
+ * and `.instar/hooks/instar/compaction-recovery.sh` read the cache file
+ * via an inline python heredoc. The hook must:
+ *
+ *   1. Exit 0 against a present, well-formed cache file
+ *   2. Print sanitized digest lines from `digestLines[]`
+ *   3. Print "+N more on dashboard." when `truncated: true`
+ *   4. Re-sanitize control chars on read (defense in depth — direct
+ *      cache poisoning that bypasses the TypeScript write path can't
+ *      smuggle ANSI escapes into orientation output)
+ *   5. Emit `Active projects: state unavailable — run /project status
+ *      when ready` and exit 0 when the cache file is missing
+ *   6. Emit the same fallback message on a malformed/unparseable cache
+ *
+ * The hooks shell out from a context-injection slot in Claude Code, so
+ * "exit 0" is the only acceptable failure mode — a non-zero exit would
+ * leak a hook error into the orientation block.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SESSION_START_HOOK = path.join(
+  REPO_ROOT,
+  '.instar',
+  'hooks',
+  'instar',
+  'session-start.sh'
+);
+const COMPACTION_HOOK = path.join(
+  REPO_ROOT,
+  '.instar',
+  'hooks',
+  'instar',
+  'compaction-recovery.sh'
+);
+
+let projectDir: string;
+let instarDir: string;
+
+beforeAll(() => {
+  // The actual hook files must exist in the repo. If a refactor moves
+  // them, this test surfaces the breakage immediately.
+  expect(fs.existsSync(SESSION_START_HOOK)).toBe(true);
+  expect(fs.existsSync(COMPACTION_HOOK)).toBe(true);
+});
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'digest-hook-test-'));
+  instarDir = path.join(projectDir, '.instar');
+  fs.mkdirSync(instarDir, { recursive: true });
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(projectDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/project-digest-hooks.test.ts',
+  });
+});
+
+function runHook(hookPath: string): { stdout: string; status: number } {
+  try {
+    const out = execFileSync('bash', [hookPath], {
+      env: {
+        ...process.env,
+        CLAUDE_PROJECT_DIR: projectDir,
+        CLAUDE_HOOK_MATCHER: 'startup',
+        // Strip variables that would make session-start.sh delegate elsewhere
+        // or hit network paths: no Telegram, no upstream config.
+        INSTAR_TELEGRAM_TOPIC: '',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout: out.toString('utf-8'), status: 0 };
+  } catch (err: unknown) {
+    // execFileSync throws on non-zero exit; surface what we got
+    type ExecErr = { status?: number; stdout?: Buffer; stderr?: Buffer };
+    const e = err as ExecErr;
+    return {
+      stdout: (e.stdout ?? Buffer.from('')).toString('utf-8'),
+      status: typeof e.status === 'number' ? e.status : 1,
+    };
+  }
+}
+
+function writeCache(payload: unknown): void {
+  fs.writeFileSync(
+    path.join(instarDir, 'projects-digest.cache'),
+    typeof payload === 'string' ? payload : JSON.stringify(payload),
+    'utf-8'
+  );
+}
+
+// ─── session-start.sh ──────────────────────────────────────────────────────
+
+describe('session-start.sh — project digest block', () => {
+  it('exits 0 against a missing cache file and emits the fallback', () => {
+    const r = runHook(SESSION_START_HOOK);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('Active projects: state unavailable');
+  });
+
+  it('exits 0 and emits sanitized digestLines against a present cache', () => {
+    writeCache({
+      generatedAt: '2026-05-11T00:00:00.000Z',
+      digestLines: ['Project [a]: 0 of 1 done. Next round: R.'],
+      totalActiveProjects: 1,
+      truncated: false,
+    });
+    const r = runHook(SESSION_START_HOOK);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('--- ACTIVE PROJECTS ---');
+    expect(r.stdout).toContain('Project [a]: 0 of 1 done. Next round: R.');
+    expect(r.stdout).toContain('--- END ACTIVE PROJECTS ---');
+  });
+
+  it('appends "+N more on dashboard." when truncated', () => {
+    writeCache({
+      generatedAt: '2026-05-11T00:00:00.000Z',
+      digestLines: ['Project [a]: 0/1', 'P [b]: 0/1', 'P [c]: 0/1', 'P [d]: 0/1', 'P [e]: 0/1'],
+      totalActiveProjects: 7,
+      truncated: true,
+    });
+    const r = runHook(SESSION_START_HOOK);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('+2 more on dashboard.');
+  });
+
+  it('re-sanitizes control chars on read (defense in depth)', () => {
+    writeCache({
+      generatedAt: '2026-05-11T00:00:00.000Z',
+      // Direct poisoning bypasses the TypeScript writer; reader must clean.
+      digestLines: ['Project [evil]: \x00\x07\x1B[31mRED\x1B[0m\n\rinjection'],
+      totalActiveProjects: 1,
+      truncated: false,
+    });
+    const r = runHook(SESSION_START_HOOK);
+    expect(r.status).toBe(0);
+    // No ASCII control chars should appear in the orientation output.
+    const projectDigestSection =
+      r.stdout.split('--- ACTIVE PROJECTS ---')[1]?.split('--- END ACTIVE PROJECTS ---')[0] ?? '';
+    expect(projectDigestSection).not.toMatch(/[\x00-\x08\x0B-\x1F\x7F]/);
+  });
+
+  it('emits fallback on malformed JSON cache', () => {
+    writeCache('{not valid json');
+    const r = runHook(SESSION_START_HOOK);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('Active projects: state unavailable');
+  });
+});
+
+// ─── compaction-recovery.sh ────────────────────────────────────────────────
+
+describe('compaction-recovery.sh — project digest block', () => {
+  it('exits 0 against a missing cache file', () => {
+    const r = runHook(COMPACTION_HOOK);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('Active projects: state unavailable');
+  });
+
+  it('emits the digest with post-compaction header against a present cache', () => {
+    writeCache({
+      generatedAt: '2026-05-11T00:00:00.000Z',
+      digestLines: ['Project [x]: 1 of 2 done. Next round: R2.'],
+      totalActiveProjects: 1,
+      truncated: false,
+    });
+    const r = runHook(COMPACTION_HOOK);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('--- ACTIVE PROJECTS (post-compaction) ---');
+    expect(r.stdout).toContain('Project [x]: 1 of 2 done. Next round: R2.');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,114 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+### Project-scope Phase 1a PR 3 — `/project` skill + session-start digest
+
+Final of three PRs scaffolding the project-scope feature. PR 1 added
+the type-level fields; PR 2 added the stage-transition validator and
+HTTP surface; PR 3 ships the user-invocable surface and the
+session-start orientation block so active projects stay visible across
+new sessions.
+
+Spec source: `docs/specs/PROJECT-SCOPE-SPEC.md` §§ Phase 1.7 (skill),
+Phase 1.9 (session-start + compaction-recovery hooks).
+
+**New files:**
+- `src/core/ProjectDigestCache.ts` — synchronous writer that
+  snapshots active projects to `.instar/projects-digest.cache`. Top 5
+  by `lastTouchedAt`, sanitized strings (control-char strip + 80-char
+  per-field cap), atomic write.
+- `.claude/skills/instar-project/SKILL.md` — slash-command skill. Phase
+  1a ships `/project create`, `/project status`, and `/project next`
+  (read-only + create). The mutating commands ship in Phase 1b along
+  with the round-runner.
+
+**Wired-in behavior:**
+- Server boot now constructs a `ProjectDigestCache` and registers it
+  as the digest invalidator on `InitiativeTracker`. Every successful
+  project mutation (create / update / status change) re-renders the
+  cache file atomically. First boot writes the cache unconditionally
+  so the hook scripts always have a well-formed file to read.
+- `.instar/hooks/instar/session-start.sh` and
+  `.instar/hooks/instar/compaction-recovery.sh` append an
+  `--- ACTIVE PROJECTS ---` block at the end of their orientation
+  output. They read the cache file (no HTTP, ≤50ms budget), re-sanitize
+  each line on read (defense in depth), and fall back to
+  `Active projects: state unavailable — run /project status when ready`
+  on miss / parse error.
+
+**Cache file shape (`.instar/projects-digest.cache`):**
+```json
+{
+  "generatedAt": "2026-05-11T...",
+  "digestLines": [
+    "Project [my-project]: 2 of 5 done. Next round: Round 3."
+  ],
+  "totalActiveProjects": 1,
+  "truncated": false
+}
+```
+
+## What to Tell Your User
+
+PR 3 closes the Phase 1a slice. Your agent now has a built-in
+`/project` slash command for inspecting and registering projects, and
+a session-start orientation line that keeps active projects visible at
+the top of every new conversation.
+
+What you'll see at session start: a short `--- ACTIVE PROJECTS ---`
+block with up to five projects, one line each (`Project [id]: X of Y
+rounds done. Next round: <name>.`). If you have more than five active
+projects, the block ends with `+N more on dashboard.` — open the
+dashboard to see the rest. If your agent has no projects registered
+yet, the block is empty.
+
+What this changes day-to-day: your agent won't lose track of multi-spec
+projects after a session restart or a context compaction. Before this,
+the first few features in a project would get attention and the rest
+would drift off the radar. Now the project roster is structurally
+visible at every new conversation. The same digest re-injects after
+context compression, so a long session that hits the compaction window
+still keeps the active-project orientation in context.
+
+The `/project` skill itself is Phase 1a's read-only slice: you can
+register a project from a markdown plan doc, list all projects, fetch
+one with its children, or ask "what's next?" (which currently returns
+a placeholder — Phase 1b will wire the real answer). The mutating
+commands (`advance`, `halt`, `ack`, `resume`, `abandon`,
+`run-round`, `drift`, `accept-partial`, `claim-ownership`) ship in
+Phase 1b once the round-runner lands.
+
+Nothing existing changes shape. The `/initiatives/*` routes still
+return what they always did. The new session-start block appears at
+the end of the orientation output and is plain text. If your agent
+doesn't register projects, you won't see any difference.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| `/project create <plan-doc>` | Register a project from a markdown plan via `POST /projects` |
+| `/project status [id]` | List all projects, or fetch one with its children, via `GET /projects[/:id]` |
+| `/project next [id]` | Phase 1a placeholder; returns the spec's 501 response |
+| Session-start project digest | Top 5 active projects rendered at every new session start (no extra config) |
+| Compaction-recovery digest | Same digest re-injects after context compression |
+| Cache file (read-only consumer) | `.instar/projects-digest.cache` — JSON snapshot, atomic writes, sanitized |
+
+## Evidence
+
+Spec: `docs/specs/PROJECT-SCOPE-SPEC.md` §§ 1.7, 1.9.
+
+- `tests/unit/ProjectDigestCache.test.ts` — 19 new tests covering
+  empty case, 3-project + 7-project cases, sanitization (control char
+  strip + 80-char cap), atomic write, invalidator wiring.
+- `tests/unit/project-digest-hooks.test.ts` — 7 new tests exercising
+  the bash hook scripts against present / missing / malformed /
+  poisoned cache files.
+- Side-effects review: `upgrades/side-effects/project-scope-phase1a-pr3.md`.

--- a/upgrades/side-effects/0.28.87.md
+++ b/upgrades/side-effects/0.28.87.md
@@ -1,0 +1,13 @@
+# Side-Effects Review — v0.28.87
+
+This release shipped two user-facing changes:
+
+- **Stuck-Telegram-message auto-recovery (PR #151)** — side-effects review at
+  [`verify-injection-stuck-input.md`](./verify-injection-stuck-input.md).
+- **Project-scope Phase 1a PR 2 — stage validator + `/projects` API** —
+  side-effects review at
+  [`project-scope-phase1a-pr2.md`](./project-scope-phase1a-pr2.md).
+
+This file is the version-keyed pointer the pre-push gate looks for; the
+per-change artifacts above contain the actual side-effects analysis. No
+other behavior changed in 0.28.87 beyond what those two reviews cover.

--- a/upgrades/side-effects/project-scope-phase1a-pr3.md
+++ b/upgrades/side-effects/project-scope-phase1a-pr3.md
@@ -1,0 +1,477 @@
+# Side-Effects Review — project-scope Phase 1a PR 3 (`/project` skill + session-start digest)
+
+**Version / slug:** `project-scope-phase1a-pr3`
+**Date:** `2026-05-11`
+**Author:** `echo`
+**Second-pass reviewer:** `required (new context-surface for the agent: session-start hook output)`
+
+## Summary of the change
+
+Final of three PRs for project-scope Phase 1a. Adds the user-facing
+surface and the session-start digest surface so active projects stay
+visible across new sessions and after context compaction.
+
+Spec source: `docs/specs/PROJECT-SCOPE-SPEC.md` §§ Phase 1.7 (skill),
+Phase 1.9 (session-start + compaction-recovery hooks).
+
+**New files:**
+- `src/core/ProjectDigestCache.ts` (~170 lines) — synchronous JSON
+  digest writer. Renders one sanitized line per active project,
+  top-N by `lastTouchedAt`, atomic write to
+  `.instar/projects-digest.cache`. No I/O beyond the cache write and
+  a `tracker.list()` read.
+- `.claude/skills/instar-project/SKILL.md` — user-invocable slash
+  command surface. Phase 1a ships `/project create`, `/project status`,
+  `/project next` only. The mutating commands ship in Phase 1b once
+  the round-runner exists.
+- `tests/unit/ProjectDigestCache.test.ts` — 19 tests covering empty
+  case, 3-project case, 7-project truncation, sanitization (control
+  chars, newlines, 80-char cap), atomic write, and cache invalidator
+  wiring.
+- `tests/unit/project-digest-hooks.test.ts` — 7 tests exercising both
+  hook scripts against present, missing, and malformed cache files;
+  asserts the read-time sanitization re-strips control chars.
+
+**Modified files:**
+- `src/commands/server.ts` (+10) — instantiates `ProjectDigestCache`,
+  wires the invalidator on `InitiativeTracker`, and writes the cache
+  unconditionally on first boot so the hook scripts always have
+  something to read on a fresh install.
+- `.instar/hooks/instar/session-start.sh` (+50) — appends a
+  `--- ACTIVE PROJECTS ---` block after the existing orientation. Pure
+  file read (no HTTP). Falls back to `Active projects: state
+  unavailable — run /project status when ready` on miss / parse error.
+- `.instar/hooks/instar/compaction-recovery.sh` (+50) — same block
+  with a `(post-compaction)` label.
+- `upgrades/NEXT.md` — adds the Phase 1a PR 3 entry to the in-progress
+  release-notes file.
+
+**Cross-spec links:**
+- The cache file format is the same JSON shape PR 1 documented in the
+  `setDigestCacheInvalidator()` hook stub and Phase 1.9 of the spec.
+- The skill's `POST /projects` flow uses the rate-limited handler PR 2
+  shipped.
+
+## Decision-point inventory
+
+- **Cache write — what to include.** Hard-invariant filter:
+  `kind:'project' && status:'active'`, sorted by `lastTouchedAt` desc,
+  capped at 5. No LLM, no scored ranking. The `truncated` flag +
+  `totalActiveProjects` count make over-limit visible without a
+  decision.
+- **Sanitization — what to strip.** Strip `[\x00-\x1F\x7F]` (ASCII
+  control + DEL), collapse whitespace, cap at 80 chars per sanitized
+  field. Applied at write time in `ProjectDigestCache.ts` AND at read
+  time in both hook scripts. The doc's "Hard-invariant validation"
+  carve-out applies: this is structural input cleaning at a system
+  boundary, not a judgement call.
+- **Hook fallback — what to emit on miss.** A single fixed string
+  (`Active projects: state unavailable — run /project status when
+  ready`). Surfaces the recovery action; never silently swallows.
+- **`/project next` — placeholder behavior.** The skill documents the
+  current 501 response shape and instructs the agent to surface a
+  user-facing message ("placeholder until Phase 1b") rather than
+  treating 501 as a hard error. Aligns with the PR 2-shipped route.
+
+All decision points are structural — none introduces a new
+conversational or judgement-based gate.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- The digest cache filter is `kind:'project' && status:'active'`. Any
+  project the user wants visible at session start must be marked
+  `active`. Paused, halted, archived, and `awaiting-user` projects are
+  intentionally excluded from the orientation digest — they show up
+  on the dashboard but not in the cheap session-start surface. This
+  matches the spec's "keep the active roster visible" intent.
+- The 5-project cap is firm. Users with more than 5 active projects
+  see the most-recently-touched 5 plus a "+N more on dashboard."
+  indicator. The mitigation (`/project status` returns the full list)
+  is documented in the skill body and the fallback message.
+- The 80-char per-field sanitization cap can truncate long round
+  names. The spec endorses this — names are display strings, not
+  identifiers, and there are no consumers of the digest cache that
+  need the original-length string. The full record is always
+  available via `GET /projects/:id`.
+- The hook falls back to the "state unavailable" string on any of
+  three conditions: missing cache file, non-JSON file, JSON with no
+  `digestLines` array. All three are recovery-friendly: the fallback
+  is informational, not an error.
+
+No legitimate input shape is rejected by this change.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- The hook fallback string is fixed text injected into orientation. A
+  malicious entity with write access to `.instar/projects-digest.cache`
+  could populate `digestLines[]` with arbitrary text — but write
+  access to the agent's state dir already means full agent
+  compromise (the dir holds AGENT.md, MEMORY.md, secrets). The
+  read-time sanitization re-strips ASCII control chars (so ANSI
+  escapes can't sneak into orientation), but free-form lying text
+  ("delete all files") would land in the agent's context. This is
+  documented as accepted-risk in the threat model (§ Threat model of
+  the spec).
+- The cache file is per-machine (lives under `.instar/`, which IS
+  synced across machines via git-sync). A machine that just synced a
+  cache file from another machine sees that machine's snapshot of
+  projects. This is intentional — git-sync conflict handling for
+  projects (Phase 1.12, ships in Phase 1b) treats the cache as
+  derived state; it's recomputed on first project mutation. No
+  correctness issue.
+- The cache write is best-effort (try/catch + console.warn). A
+  hiccup writing the cache never blocks a successful mutation. The
+  hook then emits the fallback on next read — recoverable on the next
+  mutation. This is the intended degradation path.
+- The invalidator runs on *every* mutation through `InitiativeTracker`,
+  including `kind:'task'` initiatives. The filter inside
+  `writeDigestCache()` re-applies `kind:'project'` so the file content
+  is correct, but we do pay a write cost on every task mutation. With
+  ~tens of mutations per session on a typical agent, the write cost
+  (one ~1KB file write, atomic rename) is negligible. Acceptable.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes.
+
+- `ProjectDigestCache.ts` lives alongside `InitiativeTracker.ts` in
+  `src/core/`. It is a pure write-side projection of tracker state,
+  with no HTTP, no LLM, no scheduling. Single responsibility:
+  serialise the project roster.
+- The skill's body is procedural — `curl` commands plus a description
+  of expected response shapes. It does not duplicate validation logic;
+  it points the agent at the existing HTTP surface from PR 2 and
+  describes how to interpret each status code.
+- Hook scripts read a file. They do not call HTTP, do not consult the
+  tracker, do not load `node`. The whole hot path is one `python3 -c`
+  with a JSON parse and a regex sanitization pass. Stays inside the
+  50ms budget the spec specifies for the orientation surface.
+- Server boot is the right place to wire the invalidator: it's the
+  single chokepoint where every consumer of `InitiativeTracker` gets
+  the same wiring. Boot also seeds the cache once so a fresh install
+  has a non-empty file (`{ digestLines: [], totalActiveProjects: 0,
+  truncated: false }`) before any session starts.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this is structural sanitization + a context-surface
+      writer. Explicitly within the doc's "Hard-invariant validation"
+      and "Display rendering" carve-outs.
+
+The doc's carve-outs that apply here:
+
+1. **"Hard-invariant validation"** — `sanitizeDigestString()` is a
+   character-class strip (`/[\x00-\x1F\x7F]/g`). It does not inspect
+   meaning, does not judge intent, does not call out to a model. It
+   is a literal regex that runs on every output string. The same
+   logic re-applies on the read side in the hook scripts (Python's
+   `re.compile(r'[\x00-\x1F\x7F]')`).
+
+2. **"Display rendering"** — `formatProjectDigestLine()` is a template
+   function. Inputs come from the tracker (already type-validated by
+   PR 1's create/update paths); outputs are a fixed-shape
+   `Project [<id>]: <X> of <Y> done. Next round: <name>.` string. No
+   decision points inside.
+
+There is no detector here that emits signals into a higher authority,
+and no authority here that gates an action. The whole module is a
+write-side projection. The "decision" of what to include is the
+`status === 'active' && kind === 'project'` predicate, which is a
+type-level filter, not a judgement.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Existing hooks.** The session-start and compaction-recovery hooks
+  already emit a long orientation block (identity, project map,
+  capabilities, working memory). The PR 3 addition is appended at the
+  *end* of each script's main flow, immediately before the closing
+  `=== END SESSION START ===` / `=== END IDENTITY RECOVERY ===`
+  banner. It does not replace existing content. If the new block
+  fails (which can only happen on a python3 absence), the orientation
+  block still ends cleanly — the python heredoc swallows its own
+  errors with `sys.exit(0)` and the surrounding bash falls through
+  to the fallback string.
+- **InitiativeTracker invalidator.** PR 1 wired the
+  `setDigestCacheInvalidator` hook with a no-op default. PR 3 swaps
+  the no-op for `() => projectDigestCache.writeDigestCache()`. The
+  hook is fired after `create()`, `update()`, `setPhaseStatus()`, and
+  `remove()`. Every legacy caller is unaffected — the invalidator was
+  always called; we just gave it a real body.
+- **TaskFlow.** When TaskFlow is wired (`config.taskFlow.enabled`),
+  the invalidator still fires after each tracker mutation (the
+  invalidator call is outside the TaskFlow branch in
+  `InitiativeTracker.ts`). The cache write reflects whichever store
+  is authoritative; `tracker.list()` already handles the projection.
+- **HTTP routes.** No new routes. The skill calls the routes PR 2
+  shipped. No re-validation, no shadowing.
+- **Auth.** The skill body documents the `Authorization: Bearer
+  <token>` requirement and shows how to read it from the config file.
+  No new auth path.
+- **File-system contention.** Atomic write uses `temp + rename` with a
+  PID-suffixed temp file. Two processes writing concurrently each
+  use their own temp name; the final rename is atomic on the same
+  filesystem (POSIX guarantees). Last-writer-wins, but every write
+  is well-formed.
+- **Race condition: hook reads while server writes.** Reader sees
+  either the prior complete file or the new complete file — never a
+  partial. POSIX rename atomicity is what the test
+  `tests/unit/ProjectDigestCache.test.ts > atomic write` asserts.
+- **First-boot ordering.** The cache write happens before
+  `server.start()`, so the file exists on disk before any HTTP
+  request can arrive (or any session-start hook can fire from a
+  spawned subprocess).
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Slash command surface.** A new `/project` skill is invocable
+  from any Claude Code session that has the `.claude/skills/`
+  directory. The skill is documented as `user_invocable: true` —
+  intentional surface, exposed by the harness.
+- **Session-start orientation.** Every session that hits the
+  session-start hook now sees a `--- ACTIVE PROJECTS ---` block when
+  the cache file is present. On a fresh install the block emits an
+  empty section (`Active projects: none` after the header) — no
+  noise.
+- **Compaction-recovery orientation.** Same block re-injects after
+  compaction. The agent reads this from context, not from disk
+  directly.
+- **New persistent state.** `.instar/projects-digest.cache` — JSON
+  file, ~1KB typical. Written by every project mutation. Lives
+  alongside the existing initiative state. No migration required;
+  the file is fully derived.
+- **Other agents on the same machine.** Each agent has its own
+  `.instar/`, so the cache file is per-agent. Other agents are
+  unaffected.
+- **External systems.** None. No new outbound network call. No
+  shell-out to `git`, `gh`, or any external CLI. The hook scripts
+  use `python3` (already a dependency of the existing hooks).
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+- **Hot-fix release.** Revert the commit. The new files
+  (`ProjectDigestCache.ts`, `SKILL.md`, two test files,
+  `side-effects/project-scope-phase1a-pr3.md`) delete cleanly. The
+  modifications to `server.ts` and the two hook scripts revert with
+  no follow-up — the hook additions are appended, not interleaved,
+  so the diff is a clean removal.
+- **Data migration.** None. The cache file is derived. If a
+  pre-rollback file remains on disk, the hook scripts will read it
+  using the pre-rollback shape (still valid JSON, still emits a
+  digest block) — but with the invalidator wiring gone, the file is
+  no longer updated. Deleting the file is safe; the hook falls back
+  to "state unavailable".
+- **Agent state repair.** Not needed. Initiative records are
+  untouched.
+- **User visibility.** Rollback removes the orientation digest block
+  and the `/project` skill. Anyone who'd started using `/project` would
+  need to call `curl` directly until a re-roll.
+- **Phase 1b dependencies.** Phase 1b ships the round-runner and the
+  mutating skill commands. Phase 1b's PRs depend on the invalidator
+  wiring being in place (so the digest stays fresh through the
+  runner's mutations). If PR 3 is reverted, Phase 1b's first PR must
+  re-add the wiring at the same time. Tracking note for the Phase
+  1a → 1b gate.
+
+Rollback is a single `git revert`; the only follow-up is reverting
+Phase 1b's first PR if it's already shipped (it has not, as of this
+commit).
+
+---
+
+## Conclusion
+
+PR 3 ships the user-facing surface and the session-start digest for
+project-scope Phase 1a. No new decision points beyond hard-invariant
+sanitization + a structural type filter. All sanitization is applied
+at write AND at read time (defense in depth against direct cache
+poisoning). The hook scripts have a fixed fallback string and stay
+inside the 50ms budget. Cache invalidator wiring uses the hook PR 1
+prepared; tests assert end-to-end through `InitiativeTracker.create() →
+invalidator → cache file → hook script → parsed orientation output`.
+Typecheck clean, 26 new tests passing, no existing test broken. Clear
+to ship pending second-pass review.
+
+---
+
+## Second-pass review (required)
+
+**Reviewer:** independent audit pass
+**Date:** `2026-05-11`
+
+Independently re-read the new ProjectDigestCache module, both hook
+scripts, and the server-boot wiring. Audited along three axes the brief
+flagged:
+
+1. **Sanitization at BOTH write time AND read time.** Verified:
+   - Write side: `sanitizeDigestString` in `ProjectDigestCache.ts`
+     applies `replace(/[\x00-\x1F\x7F]/g, ' ')` to every string that
+     lands in the cache (project id via `formatProjectDigestLine`,
+     round name, and the literal "Project [<id>]:" rendering). The
+     80-char cap is enforced on each field before composition.
+   - Read side: the python heredoc in both hooks (`session-start.sh`,
+     `compaction-recovery.sh`) re-applies `re.sub(r'[\x00-\x1F\x7F]',
+     ' ', ln)` plus a 200-char hard cap on the rendered line. This is
+     the defense-in-depth pass the spec calls for: direct
+     cache-file poisoning that skips the TypeScript write path
+     cannot smuggle ANSI escapes or unprintable bytes into
+     orientation output. Asserted by the `re-sanitizes control chars
+     on read` test.
+
+2. **Prompt-injection surface.** The free-form text that lands in the
+   digest is `(project.id, round.name)`. Project id is constrained to
+   `^[a-z0-9-]{1,63}$` by `InitiativeTracker.create()`'s slug regex —
+   no injection vector there. Round name is user-supplied (via plan
+   doc) and gets sanitized and capped to 80 chars. The cap, combined
+   with the fixed prefix "Project [<id>]: X of Y done. Next round:"
+   and trailing period, bounds the maximum-attack payload to <200
+   chars of clean ASCII per line, repeated at most 5 times. No
+   ANSI escapes survive (control char strip). No newlines survive
+   (control char strip). No structured-output injection possible (the
+   orientation block is delimited by `--- ACTIVE PROJECTS ---` /
+   `--- END ACTIVE PROJECTS ---` and the digest contents cannot
+   produce those literal strings without including control chars,
+   which we strip).
+
+3. **Hook-script failure mode.** Both hooks wrap the python heredoc
+   with bash conditional logic that emits the fallback string on any
+   non-zero or empty output path. The python script itself uses
+   `sys.exit(0)` on every error branch, so the hook never propagates
+   a non-zero exit status into the orientation flow. Smoke tests
+   assert exit-status 0 on missing, present, malformed, and poisoned
+   cache files.
+
+**Other findings:**
+- Server-boot ordering is correct: `projectDigestCache.writeDigestCache()`
+  fires before `server.start()`, so the file is on disk before any
+  spawned session-start hook can fire from a child process. First
+  boot writes the empty-state file (`{ digestLines: [],
+  totalActiveProjects: 0, truncated: false }`).
+- Atomic write is correct: temp file uses `process.pid` suffix; rename
+  is atomic on the same filesystem. The repeated-write test asserts
+  no partial JSON ever appears on disk.
+- The `/project next` skill doc correctly surfaces the 501 placeholder
+  rather than treating it as an error. This matches the route shape
+  PR 2 shipped.
+
+**Verdict: Concur with the review.** Clear to ship.
+
+---
+
+## Second-pass review — independent audit (PR-driver pass)
+
+**Reviewer:** independent audit pass (PR driver, separate context from
+artifact author)
+**Date:** `2026-05-11`
+**Specific concern flagged in brief:** prompt-injection via digest
+content flowing into agent context (session-start + compaction-recovery
+hook output). Reviewer must verify sanitization happens at BOTH write
+time (in `ProjectDigestCache`) AND read time (in the hook scripts) —
+defense in depth.
+
+### Findings — defense-in-depth verification
+
+**Write-time sanitization (verified in `src/core/ProjectDigestCache.ts`):**
+- `sanitizeDigestString()` strips `[\x00-\x1F\x7F]` (ASCII control +
+  DEL) by literal regex, collapses internal whitespace, then hard-caps
+  at `MAX_STRING_LENGTH = 80` chars per field.
+- `formatProjectDigestLine()` applies `sanitizeDigestString()` to BOTH
+  `project.id` and `next.name` BEFORE composing the fixed-shape line
+  `Project [<id>]: X of Y done. Next round: <name>.`.
+- `writeDigestCache()` JSON-encodes the payload and writes atomically
+  via temp-file + rename (PID-suffixed temp name, POSIX rename
+  atomicity).
+
+**Read-time sanitization (verified in both hook scripts):**
+- `.instar/hooks/instar/session-start.sh` (lines 279-313) and
+  `.instar/hooks/instar/compaction-recovery.sh` (lines 246-279) each
+  run an embedded python heredoc that:
+  - JSON-parses the cache file
+  - Iterates `digestLines[:5]` (defense against truncation bypass)
+  - Re-applies `re.compile(r'[\x00-\x1F\x7F]').sub(' ', ln)`
+  - Collapses internal whitespace and hard-caps each rendered line
+    at 200 chars
+  - Silently exits 0 on any exception → falls back to
+    "Active projects: state unavailable" string
+- Template files (`src/templates/hooks/{session-start,compaction-recovery}.sh`)
+  carry the identical block so fresh installs get the same protection.
+
+**Prompt-injection threat model audit:**
+1. Project id is regex-constrained (`^[a-z0-9-]{1,63}$`) at create
+   time by `InitiativeTracker.create()` — no injection vector.
+2. Round name is user-supplied via plan-doc YAML. Strip + 80-char cap
+   bounds it. Combined with the fixed prefix `Project [<id>]: X of Y
+   done. Next round:` and trailing period, max attack payload per line
+   is < 200 chars of clean printable ASCII, ≤ 5 lines.
+3. ANSI escape injection — blocked. `\x1B` is in the control char
+   class; stripped at both write and read.
+4. Newline / structured-output injection — blocked. `\n`, `\r`, `\t`
+   are in the control char class; stripped at both write and read.
+5. Delimiter injection (`--- END ACTIVE PROJECTS ---` as content) —
+   the 80-char per-field cap bounds round name, and even if the
+   literal delimiter string appears as content, the surrounding LLM
+   reads orientation as semantic content, not as a parser-delimited
+   structure. Not exploitable for instruction injection.
+6. Direct cache-file poisoning by an attacker with write access to
+   `.instar/projects-digest.cache` — read-side sanitization strips
+   any control chars the poisoned file might contain. Cap-and-strip
+   apply unconditionally on every read, independent of whether the
+   bytes ever passed through `ProjectDigestCache.ts`.
+
+**Other findings:**
+- Atomic write semantics verified by the `tests/unit/ProjectDigestCache.test.ts
+  > atomic write` test — repeated writes never expose a partial file.
+- Hook-script exit status is 0 on every failure branch (missing file,
+  malformed JSON, non-list `digestLines`, empty list, exception). The
+  orientation flow never propagates a non-zero exit.
+- First-boot ordering is correct: `projectDigestCache.writeDigestCache()`
+  runs before `server.start()` in `src/commands/server.ts`, so any
+  spawned session-start hook will see a valid file.
+- `/project next` skill doc correctly surfaces the Phase 1b placeholder
+  shape (501) rather than treating it as a hard error.
+
+**Verdict: Concur with the review.** Sanitization is applied at BOTH
+boundaries with the same character-class strip and equivalent caps.
+Defense-in-depth requirement met. Clear to ship.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/ProjectDigestCache.test.ts` — 19 passing
+- `tests/unit/project-digest-hooks.test.ts` — 7 passing
+- `tests/unit/InitiativeTracker.project.test.ts` — 26 passing (PR 1 + this PR's invalidator wiring)
+- `tests/integration/projects-api.test.ts` — 14 passing (PR 2 routes)
+- `node_modules/.bin/tsc --noEmit` → clean
+- `npm run lint` → clean
+- Spec: `docs/specs/PROJECT-SCOPE-SPEC.md` §§ 1.7, 1.9
+- Signal-vs-authority reference: `docs/signal-vs-authority.md` § "Hard-invariant validation" + § "Display rendering"


### PR DESCRIPTION
## Summary

Closes the Phase 1a thin slice for project-scope. Final of three PRs scaffolding the multi-spec project layer (PR 1 added the type-level surface, PR 2 added the stage validator + `/projects` HTTP API, PR 3 ships the user-invocable surface + session-start digest).

- **`/project` skill** (`.claude/skills/instar-project/SKILL.md`) — read-only commands (`create`, `status`, `next`). Mutating commands (`advance`, `drift`, `run-round`, `halt`, `ack`, `resume`, `abandon`, `accept-partial`, `claim-ownership`, `resolve-conflict`) ship in Phase 1b alongside the round runner.
- **`ProjectDigestCache`** (`src/core/ProjectDigestCache.ts`) — synchronous writer for `.instar/projects-digest.cache`. Top-5 active projects by `lastTouchedAt`, sanitized strings (control-char strip + 80-char per-field cap), atomic temp+rename write. Wired as the invalidator on `InitiativeTracker` so every project mutation re-renders the cache.
- **Session-start + compaction-recovery digest** — both `.instar/hooks/instar/session-start.sh` and `.instar/hooks/instar/compaction-recovery.sh` (and their `src/templates/hooks/*` source-of-truth copies) append an `--- ACTIVE PROJECTS ---` block at the end of orientation. Pure file read (no HTTP, ≤50ms budget). Re-sanitizes each line on read (defense in depth against direct cache poisoning). Falls back to `Active projects: state unavailable` on miss / parse error.
- **First-boot seeding** — server boot writes the cache unconditionally so a fresh install always has a well-formed file before any session-start hook fires.

Spec: `docs/specs/PROJECT-SCOPE-SPEC.md` §§ Phase 1.7 (skill), Phase 1.9 (hooks).
Side-effects review (with appended independent second-pass): `upgrades/side-effects/project-scope-phase1a-pr3.md`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `tests/unit/ProjectDigestCache.test.ts` — 19 new tests (empty / 3-project / 7-project truncation / sanitization / atomic write / invalidator wiring)
- [x] `tests/unit/project-digest-hooks.test.ts` — 7 new tests (bash hooks against present / missing / malformed / poisoned cache; read-side re-sanitization)
- [x] `npm run test:push` — 14094 passing, 6 skipped, 0 failing (full pre-push gate including pre-push-gate.test.ts)
- [x] Pre-push smoke tier — 26/26 affected tests pass
- [ ] CI green
- [ ] After merge: Phase 1a → 1b gate verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)