### PR TITLE
feat(projects): drift verdict cache + cost ledger (Phase 1b PR 2)

### DIFF
--- a/src/core/DriftSpendLedger.ts
+++ b/src/core/DriftSpendLedger.ts
@@ -1,0 +1,313 @@
+/**
+ * DriftSpendLedger — daily-rotated, lock-coordinated cost ledger for the
+ * drift checker.
+ *
+ * Spec: docs/specs/PROJECT-SCOPE-SPEC.md § Phase 1.4 ("Cost ceiling").
+ *
+ * Contract:
+ *   - Total drift-check spend per agent ≤ DEFAULT_DAILY_CAP_USD ($1) per UTC
+ *     day. Cap enforcement is `spent + estimated > cap → reject` (strict
+ *     `>` boundary, per spec corrected from iter 2).
+ *   - One file per UTC day at `.instar/drift-spend-YYYY-MM-DD.jsonl`.
+ *   - Old files retained ≤ DEFAULT_RETENTION_DAYS (30). Anything older is
+ *     archived to `.instar/drift-spend-archive/<year>-<month>.tar.gz` by
+ *     `pruneOlderThan()` (caller-driven; no internal timer).
+ *   - Each call pre-reserves estimated cost in an append-only row
+ *     `{recordId, projectId, estimatedCost, actualCost?: null, timestamp}`.
+ *     After the call returns, `reconcile(recordId, actualCost)` appends a
+ *     second row with `actualCost` set, so a tally over the day is
+ *     `sum(estimatedCost where actualCost is null) +
+ *      sum(actualCost where present)` — O(rows in the day).
+ *   - Advisory file lock on `.instar/local/drift-spend.lock` via
+ *     proper-lockfile (consistent with AgentRegistry, SharedStateLedger,
+ *     PlatformActivityRegistry). Lock file lives under `.instar/local/`
+ *     (machine-local, NOT git-synced — same convention as
+ *     `round-runner.lock`).
+ *   - Multi-machine semantics: each machine writes its own ledger. The
+ *     cap is per-machine, summed via git-sync at the file layer. The spec
+ *     documents this as "up to N machines × cap/day in worst case"; the
+ *     true atomic cross-machine cap is a separately-tracked deferred
+ *     child (`drift-spend-cross-machine`).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import lockfile from 'proper-lockfile';
+
+import { SafeFsExecutor } from './SafeFsExecutor.js';
+
+export const DEFAULT_DAILY_CAP_USD = 1.0;
+export const DEFAULT_RETENTION_DAYS = 30;
+/** proper-lockfile options that match the rest of the codebase. */
+const LOCK_OPTIONS: lockfile.LockOptions = {
+  retries: { retries: 50, factor: 1.2, minTimeout: 50, maxTimeout: 500 },
+  stale: 10_000,
+  realpath: false,
+};
+
+export interface DriftSpendLedgerConfig {
+  /** Absolute path to the agent's `.instar/` directory. */
+  stateDir: string;
+  /** Cap in USD per UTC day. Defaults to $1. Tests can lower. */
+  dailyCapUsd?: number;
+  /** Retention window in days; defaults to 30. */
+  retentionDays?: number;
+}
+
+export interface ReserveInput {
+  projectId: string;
+  /** Best-effort upfront estimate; refined by `reconcile`. */
+  estimatedCost: number;
+}
+
+export interface ReserveResult {
+  /** Stable id used to reconcile actualCost later. */
+  recordId: string;
+  /** Cumulative spent today AFTER this reservation. */
+  spentToday: number;
+}
+
+export class OverBudgetError extends Error {
+  constructor(public capUsd: number, public spentToday: number, public estimatedCost: number) {
+    super(
+      `drift-spend daily cap exceeded: spent ${spentToday.toFixed(4)} + estimated ${estimatedCost.toFixed(4)} > cap ${capUsd.toFixed(2)}`
+    );
+    this.name = 'OverBudgetError';
+  }
+}
+
+interface LedgerRow {
+  recordId: string;
+  projectId: string;
+  estimatedCost: number;
+  actualCost: number | null;
+  timestamp: string;
+}
+
+export class DriftSpendLedger {
+  private stateDir: string;
+  private capUsd: number;
+  private retentionDays: number;
+
+  constructor(config: DriftSpendLedgerConfig) {
+    this.stateDir = config.stateDir;
+    this.capUsd = config.dailyCapUsd ?? DEFAULT_DAILY_CAP_USD;
+    this.retentionDays = config.retentionDays ?? DEFAULT_RETENTION_DAYS;
+  }
+
+  /**
+   * Pre-reserve `estimatedCost`. Throws `OverBudgetError` if doing so would
+   * exceed the daily cap. The reservation is appended as a row with
+   * `actualCost: null`; the caller MUST call `reconcile()` after the LLM
+   * returns. If the caller dies before reconcile, the reservation stays in
+   * place as `estimatedCost` and contributes to the cap until UTC rollover.
+   */
+  async reserve(input: ReserveInput): Promise<ReserveResult> {
+    if (!Number.isFinite(input.estimatedCost) || input.estimatedCost < 0) {
+      throw new Error(`reserve: estimatedCost must be a non-negative finite number; got ${input.estimatedCost}`);
+    }
+    this.ensureDirs();
+    const release = await lockfile.lock(this.lockTargetPath(), LOCK_OPTIONS);
+    try {
+      const today = this.todayLedgerPath();
+      const rows = this.readRows(today);
+      const spentToday = this.tallySpent(rows);
+      // Strict greater-than per spec § Phase 1.4. Equal-to-cap is allowed.
+      if (spentToday + input.estimatedCost > this.capUsd) {
+        throw new OverBudgetError(this.capUsd, spentToday, input.estimatedCost);
+      }
+      const recordId = crypto.randomBytes(8).toString('hex');
+      const row: LedgerRow = {
+        recordId,
+        projectId: input.projectId,
+        estimatedCost: input.estimatedCost,
+        actualCost: null,
+        timestamp: new Date().toISOString(),
+      };
+      this.appendRow(today, row);
+      return { recordId, spentToday: spentToday + input.estimatedCost };
+    } finally {
+      await release();
+    }
+  }
+
+  /**
+   * Record the actual cost after the LLM call. Appends a SECOND row with
+   * the same `recordId`, `estimatedCost: 0`, and `actualCost: <real>`.
+   * `tallySpent()` already de-duplicates by recordId (a present `actualCost`
+   * supersedes any pending `estimatedCost` rows for the same id).
+   *
+   * Idempotent: calling reconcile twice with the same recordId+actualCost
+   * is harmless — the tally still resolves to one actual row.
+   */
+  async reconcile(recordId: string, actualCost: number): Promise<void> {
+    if (!Number.isFinite(actualCost) || actualCost < 0) {
+      throw new Error(`reconcile: actualCost must be a non-negative finite number; got ${actualCost}`);
+    }
+    this.ensureDirs();
+    const release = await lockfile.lock(this.lockTargetPath(), LOCK_OPTIONS);
+    try {
+      // Walk forward through TODAY first (the common case), then yesterday
+      // (in case the LLM call straddled UTC midnight). Beyond that we
+      // refuse — a record that lived more than ~24h is stale anyway.
+      const candidates = [this.todayLedgerPath(), this.yesterdayLedgerPath()];
+      for (const file of candidates) {
+        const rows = this.readRows(file);
+        if (!rows.some((r) => r.recordId === recordId)) continue;
+        const row: LedgerRow = {
+          recordId,
+          projectId: rows.find((r) => r.recordId === recordId)?.projectId ?? '<reconcile>',
+          estimatedCost: 0,
+          actualCost,
+          timestamp: new Date().toISOString(),
+        };
+        this.appendRow(file, row);
+        return;
+      }
+      // No matching reservation found. Still record the actualCost — the
+      // caller's spend is real even if the bookkeeping is messy. Today's
+      // file is the right home.
+      const row: LedgerRow = {
+        recordId,
+        projectId: '<unknown>',
+        estimatedCost: 0,
+        actualCost,
+        timestamp: new Date().toISOString(),
+      };
+      this.appendRow(this.todayLedgerPath(), row);
+    } finally {
+      await release();
+    }
+  }
+
+  /**
+   * Cumulative spent today, lock-coordinated for safety.
+   * Useful for digests / dashboards.
+   */
+  async spentToday(): Promise<number> {
+    this.ensureDirs();
+    const release = await lockfile.lock(this.lockTargetPath(), LOCK_OPTIONS);
+    try {
+      return this.tallySpent(this.readRows(this.todayLedgerPath()));
+    } finally {
+      await release();
+    }
+  }
+
+  /**
+   * Prune ledger files older than `retentionDays`. NOT called automatically;
+   * the caller (server startup, a scheduled job, or a CLI) decides when.
+   * Files older than the window are moved to
+   * `.instar/drift-spend-archive/<year>-<month>.tar.gz` — but for Phase 1
+   * we just delete them via SafeFsExecutor. The tarball archive is a
+   * later refinement (the spec describes it but explicitly leaves the
+   * concrete archive format open).
+   */
+  async pruneOlderThan(now: Date = new Date()): Promise<{ removed: string[] }> {
+    this.ensureDirs();
+    const release = await lockfile.lock(this.lockTargetPath(), LOCK_OPTIONS);
+    try {
+      const dir = this.stateDir;
+      const cutoff = new Date(now);
+      cutoff.setUTCDate(cutoff.getUTCDate() - this.retentionDays);
+      const removed: string[] = [];
+      for (const entry of fs.readdirSync(dir)) {
+        const m = entry.match(/^drift-spend-(\d{4}-\d{2}-\d{2})\.jsonl$/);
+        if (!m) continue;
+        const fileDate = new Date(m[1] + 'T00:00:00Z');
+        if (fileDate < cutoff) {
+          const abs = path.join(dir, entry);
+          SafeFsExecutor.safeRmSync(abs, { force: true, operation: 'src/core/DriftSpendLedger.ts:pruneOlderThan' });
+          removed.push(entry);
+        }
+      }
+      return { removed };
+    } finally {
+      await release();
+    }
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────
+
+  private ensureDirs(): void {
+    if (!fs.existsSync(this.stateDir)) fs.mkdirSync(this.stateDir, { recursive: true });
+    const localDir = path.join(this.stateDir, 'local');
+    if (!fs.existsSync(localDir)) fs.mkdirSync(localDir, { recursive: true });
+    // proper-lockfile needs the target file to exist.
+    const lockTarget = this.lockTargetPath();
+    if (!fs.existsSync(lockTarget)) {
+      fs.writeFileSync(lockTarget, '');
+    }
+  }
+
+  private lockTargetPath(): string {
+    return path.join(this.stateDir, 'local', 'drift-spend.lock');
+  }
+
+  private todayLedgerPath(): string {
+    return this.ledgerPathForDate(new Date());
+  }
+
+  private yesterdayLedgerPath(): string {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - 1);
+    return this.ledgerPathForDate(d);
+  }
+
+  private ledgerPathForDate(d: Date): string {
+    const utc = d.toISOString().slice(0, 10); // YYYY-MM-DD
+    return path.join(this.stateDir, `drift-spend-${utc}.jsonl`);
+  }
+
+  private readRows(file: string): LedgerRow[] {
+    if (!fs.existsSync(file)) return [];
+    const raw = fs.readFileSync(file, 'utf-8');
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+    const rows: LedgerRow[] = [];
+    for (const line of lines) {
+      try {
+        const obj = JSON.parse(line);
+        if (typeof obj.recordId !== 'string') continue;
+        if (typeof obj.projectId !== 'string') continue;
+        if (typeof obj.estimatedCost !== 'number') continue;
+        if (obj.actualCost !== null && typeof obj.actualCost !== 'number') continue;
+        if (typeof obj.timestamp !== 'string') continue;
+        rows.push(obj as LedgerRow);
+      } catch {
+        // Skip malformed rows. The append path always writes valid JSON,
+        // so any corruption is either external editing or partial-write
+        // — neither should crash the checker.
+        continue;
+      }
+    }
+    return rows;
+  }
+
+  private appendRow(file: string, row: LedgerRow): void {
+    fs.appendFileSync(file, JSON.stringify(row) + '\n', { mode: 0o600 });
+  }
+
+  /**
+   * Sum cost across a row set: present `actualCost` supersedes the
+   * matching pending `estimatedCost`. O(rows).
+   */
+  private tallySpent(rows: LedgerRow[]): number {
+    // De-dup by recordId: actualCost present wins; otherwise sum estimatedCost.
+    const byId = new Map<string, { estimated: number; actual: number | null }>();
+    for (const r of rows) {
+      const existing = byId.get(r.recordId) ?? { estimated: 0, actual: null };
+      if (r.actualCost !== null) {
+        existing.actual = r.actualCost;
+      } else {
+        existing.estimated = r.estimatedCost;
+      }
+      byId.set(r.recordId, existing);
+    }
+    let total = 0;
+    for (const v of byId.values()) {
+      total += v.actual ?? v.estimated;
+    }
+    return total;
+  }
+}

--- a/src/core/ProjectDriftChecker.ts
+++ b/src/core/ProjectDriftChecker.ts
@@ -64,6 +64,8 @@ import path from 'node:path';
 
 import { jailPath } from './StageTransitionValidator.js';
 import type { DriftVerdict, IntelligenceProvider, VerifiedCitation } from './types.js';
+import type { ProjectDriftCheckerCache } from './ProjectDriftCheckerCache.js';
+import { DriftSpendLedger, OverBudgetError } from './DriftSpendLedger.js';
 
 /** Bumped whenever the system prompt changes; part of the future cache key. */
 export const DRIFT_PROMPT_TEMPLATE_VERSION = 1;
@@ -142,15 +144,31 @@ export interface ProjectDriftCheckerConfig {
   intelligence?: IntelligenceProvider;
   /** Defaults to spec § Phase 1.4 hard limits; tests can override. */
   limits?: Partial<typeof DRIFT_LIMITS>;
+  /** Optional verdict cache. When absent, every call recomputes from scratch. */
+  cache?: ProjectDriftCheckerCache;
+  /** Optional spend ledger. When absent, no cap enforcement. */
+  ledger?: DriftSpendLedger;
+  /**
+   * Best-effort cost estimate per call in USD; ledger pre-reserves this
+   * amount before the LLM call. Default $0.01 — conservative for the
+   * 'balanced' tier on the 50k-token-budget cap.
+   */
+  estimatedCostPerCallUsd?: number;
 }
 
 export class ProjectDriftChecker {
   private intelligence?: IntelligenceProvider;
   private limits: typeof DRIFT_LIMITS;
+  private cache?: ProjectDriftCheckerCache;
+  private ledger?: DriftSpendLedger;
+  private estimatedCostPerCallUsd: number;
 
   constructor(config: ProjectDriftCheckerConfig = {}) {
     this.intelligence = config.intelligence;
     this.limits = { ...DRIFT_LIMITS, ...(config.limits ?? {}) };
+    this.cache = config.cache;
+    this.ledger = config.ledger;
+    this.estimatedCostPerCallUsd = config.estimatedCostPerCallUsd ?? 0.01;
   }
 
   async run(input: DriftCheckInput): Promise<DriftVerdict> {
@@ -265,11 +283,59 @@ export class ProjectDriftChecker {
       };
     }
 
+    // ── Cache lookup ──────────────────────────────────────────────
+    // After validation but BEFORE the LLM call. A hit returns the
+    // cached verdict directly; no ledger spend, no provider call.
+    const resolvedModelId = input.modelId ?? 'balanced';
+    let cacheKey: string | undefined;
+    if (this.cache) {
+      const lookup = this.cache.lookup({
+        projectId: input.projectId,
+        roundIndex: input.roundIndex,
+        promptTemplateVersion: DRIFT_PROMPT_TEMPLATE_VERSION,
+        modelId: resolvedModelId,
+        specPath: specJailed.absPath,
+        referencedFilePaths: prepared.map((p) => p.absPath),
+        referencedFileBytes: prepared.map((p) => p.bytes),
+        specBytes,
+      });
+      if (lookup.hit) {
+        return lookup.verdict;
+      }
+      cacheKey = lookup.key;
+    }
+
+    // ── Ledger pre-reserve ────────────────────────────────────────
+    // Strict spec § Phase 1.4: `spent + estimated > cap` → reject as
+    // manual-review-required (over-budget). The reserve appends a pending
+    // row; reconcile() at the end of the call upgrades it with the actual
+    // cost. If the call throws/crashes, the pending estimate still counts
+    // toward the cap until UTC rollover — fail-safe rather than fail-open.
+    let ledgerRecordId: string | undefined;
+    if (this.ledger) {
+      try {
+        const reservation = await this.ledger.reserve({
+          projectId: input.projectId,
+          estimatedCost: this.estimatedCostPerCallUsd,
+        });
+        ledgerRecordId = reservation.recordId;
+      } catch (err) {
+        if (err instanceof OverBudgetError) {
+          return {
+            verdict: 'manual-review-required',
+            reason: 'over-budget',
+            rationale: err.message,
+          };
+        }
+        throw err;
+      }
+    }
+
     // ── Build prompt ──────────────────────────────────────────────
     const prompt = buildPrompt({
       specBody: specBytes.toString('utf-8'),
       files: prepared,
-      modelId: input.modelId,
+      modelId: resolvedModelId,
       templateVersion: DRIFT_PROMPT_TEMPLATE_VERSION,
       deletedFiles: deleted,
     });
@@ -346,11 +412,47 @@ export class ProjectDriftChecker {
       };
     }
 
-    return {
+    const finalVerdict: DriftVerdict = {
       verdict,
       rationale,
       evidenceCitations: verified,
     };
+
+    // ── Cache + ledger reconciliation ─────────────────────────────
+    // Cache only "real" verdicts — no-drift / minor-drift / premise-violated.
+    // LLM-failure paths (schema-fail / timeout) are not cached so a retry
+    // can succeed. Input-validation failures (over-budget etc.) are cheap
+    // to recompute and don't benefit from caching.
+    if (this.cache && cacheKey) {
+      this.cache.put(
+        {
+          projectId: input.projectId,
+          roundIndex: input.roundIndex,
+          promptTemplateVersion: DRIFT_PROMPT_TEMPLATE_VERSION,
+          modelId: resolvedModelId,
+          specPath: specJailed.absPath,
+          referencedFilePaths: prepared.map((p) => p.absPath),
+          referencedFileBytes: prepared.map((p) => p.bytes),
+          specBytes,
+        },
+        cacheKey,
+        finalVerdict
+      );
+    }
+    if (this.ledger && ledgerRecordId) {
+      // Best-effort reconcile. We don't currently get usage stats back from
+      // the provider abstraction, so actual ≈ estimated. When a future
+      // provider returns token usage, reconcile to the real number.
+      try {
+        await this.ledger.reconcile(ledgerRecordId, this.estimatedCostPerCallUsd);
+      } catch {
+        // Reconcile failure is non-fatal — the pending reservation already
+        // counts toward the cap, so the worst case is a slight overshoot
+        // of "spent" vs "actually spent" until UTC rollover.
+      }
+    }
+
+    return finalVerdict;
   }
 }
 

--- a/src/core/ProjectDriftCheckerCache.ts
+++ b/src/core/ProjectDriftCheckerCache.ts
@@ -1,0 +1,296 @@
+/**
+ * ProjectDriftCheckerCache — verdict cache with mtime fast-path.
+ *
+ * Spec: docs/specs/PROJECT-SCOPE-SPEC.md § Phase 1.4 ("Cache key" + mtime
+ * fast-path).
+ *
+ * Cache key:  sha256(promptTemplateVersion + modelId + specBodySha + sortedFileHashes)
+ * TTL:        24h (cache entries older than this are treated as misses)
+ *
+ * Mtime fast-path:
+ *   Before computing the cache key, the cache compares (specPath mtime,
+ *   referencedFile mtimes) to the values it last saw associated with the
+ *   stored entry. If every mtime matches, the cache key is REUSED without
+ *   re-hashing — file contents haven't changed. If any mtime moved, full
+ *   hashing falls back. This is the spec's stated optimization: hashing
+ *   only happens when an mtime moved.
+ *
+ * Storage:
+ *   In-memory Map keyed by `${projectId}:${roundIndex}` (the natural id
+ *   for a drift check). Disk-backed snapshot at
+ *   `.instar/drift-verdict-cache.json` so the cache survives restarts
+ *   without a cold first-call penalty after a sleep/wake.
+ *
+ * Concurrency:
+ *   This cache is consulted INSIDE the per-project mutex held by
+ *   `POST /projects/:id/drift-check` (Phase 1.5 round runner has its own
+ *   round-runner lock). Within a single process there's no race; across
+ *   processes the JSON snapshot is read on construction and written on
+ *   every put, atomically (tmp + rename).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+import type { DriftVerdict } from './types.js';
+
+export const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+export const SNAPSHOT_FILENAME = 'drift-verdict-cache.json';
+
+export interface ProjectDriftCheckerCacheConfig {
+  /** Absolute path to the agent's `.instar/` directory. */
+  stateDir: string;
+  /** Override the 24h TTL (tests dial this down). */
+  ttlMs?: number;
+  /** When false, the cache does not read/write disk (in-memory only). */
+  persist?: boolean;
+}
+
+export interface CacheLookupInput {
+  projectId: string;
+  roundIndex: number;
+  /** Bumped on every prompt-template edit; part of the cache key. */
+  promptTemplateVersion: number;
+  /** Resolved model id from the provider; part of the cache key. */
+  modelId: string;
+  /** Absolute path to the spec file (used for mtime fast-path). */
+  specPath: string;
+  /** Absolute paths to referenced files. Order matters for fast-path but
+   *  not for the cache key (sortedFileHashes is order-stable). */
+  referencedFilePaths: string[];
+  /** Buffers, in the same order as `referencedFilePaths`. Used to compute
+   *  sha256 inputs when mtime fast-path misses. */
+  referencedFileBytes: Buffer[];
+  /** Spec body bytes — sha256 input. */
+  specBytes: Buffer;
+}
+
+export interface CacheHit {
+  hit: true;
+  verdict: DriftVerdict;
+  computedAt: string;
+  /** Cache key that matched. */
+  key: string;
+  /** True if served by the mtime fast-path (no re-hash performed). */
+  mtimeFastPath: boolean;
+}
+export interface CacheMiss {
+  hit: false;
+  /** Cache key the caller should associate with the verdict on put(). */
+  key: string;
+}
+
+export type CacheLookupResult = CacheHit | CacheMiss;
+
+interface CacheEntry {
+  key: string;
+  verdict: DriftVerdict;
+  computedAt: string; // ISO
+  /** Captured at write time; the mtime fast-path requires both to match. */
+  promptTemplateVersion: number;
+  modelId: string;
+  /** mtime in ms, captured at write time. Used by the fast-path on next read. */
+  specMtimeMs: number;
+  /** Map of relativeOrAbsolutePath → mtime ms at write time. */
+  referencedFileMtimesMs: Record<string, number>;
+}
+
+export class ProjectDriftCheckerCache {
+  private stateDir: string;
+  private ttlMs: number;
+  private persist: boolean;
+  private entries = new Map<string, CacheEntry>();
+
+  constructor(config: ProjectDriftCheckerCacheConfig) {
+    this.stateDir = config.stateDir;
+    this.ttlMs = config.ttlMs ?? DEFAULT_TTL_MS;
+    this.persist = config.persist ?? true;
+    if (this.persist) this.loadSnapshot();
+  }
+
+  /**
+   * Look up an entry for `(projectId, roundIndex)`. Returns a hit ONLY if:
+   *   (a) an entry exists, AND
+   *   (b) the entry is within the TTL, AND
+   *   (c) either the mtime fast-path matches (no re-hash needed) OR the
+   *       full sha256 cache key matches.
+   *
+   * On miss, the returned `key` is the freshly-computed sha256, which the
+   * caller should pass back to `put()` after running drift.
+   */
+  lookup(input: CacheLookupInput): CacheLookupResult {
+    const entryId = `${input.projectId}:${input.roundIndex}`;
+    const existing = this.entries.get(entryId);
+    const now = Date.now();
+
+    // ── Mtime fast-path ──────────────────────────────────────────
+    // Cheap: verify the non-content cache-key inputs (templateVersion,
+    // modelId) match, then stat() each file and compare mtimes to the
+    // recorded mtimes. If everything matches, the cached entry is still
+    // valid and the cache key the entry holds is the one that matches
+    // the current bytes — we don't need to re-hash.
+    if (
+      existing &&
+      now - Date.parse(existing.computedAt) < this.ttlMs &&
+      existing.promptTemplateVersion === input.promptTemplateVersion &&
+      existing.modelId === input.modelId
+    ) {
+      try {
+        const specMtime = fs.statSync(input.specPath).mtimeMs;
+        if (specMtime === existing.specMtimeMs) {
+          const allMatch = input.referencedFilePaths.every((p) => {
+            const recorded = existing.referencedFileMtimesMs[p];
+            if (recorded === undefined) return false;
+            try {
+              return fs.statSync(p).mtimeMs === recorded;
+            } catch {
+              return false;
+            }
+          });
+          // Also require referenced set hasn't shrunk OR grown
+          const sameSet =
+            Object.keys(existing.referencedFileMtimesMs).length === input.referencedFilePaths.length;
+          if (allMatch && sameSet) {
+            return {
+              hit: true,
+              verdict: existing.verdict,
+              computedAt: existing.computedAt,
+              key: existing.key,
+              mtimeFastPath: true,
+            };
+          }
+        }
+      } catch {
+        // statSync failure on the spec or a referenced file = treat as miss.
+      }
+    }
+
+    // ── Full hash path ───────────────────────────────────────────
+    const key = computeCacheKey(
+      input.promptTemplateVersion,
+      input.modelId,
+      input.specBytes,
+      input.referencedFilePaths.map((p, i) => ({
+        relPath: p,
+        bytes: input.referencedFileBytes[i] ?? Buffer.alloc(0),
+      }))
+    );
+    if (existing && existing.key === key && now - Date.parse(existing.computedAt) < this.ttlMs) {
+      return {
+        hit: true,
+        verdict: existing.verdict,
+        computedAt: existing.computedAt,
+        key,
+        mtimeFastPath: false,
+      };
+    }
+    return { hit: false, key };
+  }
+
+  /**
+   * Store `verdict` under `(projectId, roundIndex)` keyed by `key`. Captures
+   * file mtimes for the next mtime fast-path lookup.
+   *
+   * `manual-review-required` verdicts ARE cached too — re-running drift
+   * immediately won't change a deterministic over-budget or
+   * empty-spec answer. The TTL still expires them after 24h.
+   */
+  put(
+    input: CacheLookupInput,
+    key: string,
+    verdict: DriftVerdict
+  ): void {
+    const entryId = `${input.projectId}:${input.roundIndex}`;
+    const referencedFileMtimesMs: Record<string, number> = {};
+    let specMtimeMs = 0;
+    try {
+      specMtimeMs = fs.statSync(input.specPath).mtimeMs;
+    } catch {
+      // Spec gone — caller will probably get an `empty-spec` verdict
+      // anyway; record a zero so the next fast-path correctly invalidates.
+    }
+    for (const p of input.referencedFilePaths) {
+      try {
+        referencedFileMtimesMs[p] = fs.statSync(p).mtimeMs;
+      } catch {
+        referencedFileMtimesMs[p] = -1; // Forces a future miss.
+      }
+    }
+    this.entries.set(entryId, {
+      key,
+      verdict,
+      computedAt: new Date().toISOString(),
+      promptTemplateVersion: input.promptTemplateVersion,
+      modelId: input.modelId,
+      specMtimeMs,
+      referencedFileMtimesMs,
+    });
+    if (this.persist) this.saveSnapshot();
+  }
+
+  /** Remove an entry for `(projectId, roundIndex)`. */
+  invalidate(projectId: string, roundIndex: number): void {
+    this.entries.delete(`${projectId}:${roundIndex}`);
+    if (this.persist) this.saveSnapshot();
+  }
+
+  /** For tests / digest. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  // ── Snapshot persistence (atomic write) ───────────────────────────
+
+  private snapshotPath(): string {
+    return path.join(this.stateDir, SNAPSHOT_FILENAME);
+  }
+
+  private loadSnapshot(): void {
+    const p = this.snapshotPath();
+    if (!fs.existsSync(p)) return;
+    try {
+      const raw = fs.readFileSync(p, 'utf-8');
+      const obj = JSON.parse(raw) as { entries: Array<[string, CacheEntry]> };
+      if (!obj || !Array.isArray(obj.entries)) return;
+      for (const [id, entry] of obj.entries) {
+        if (typeof id !== 'string') continue;
+        if (!entry || typeof entry !== 'object') continue;
+        if (typeof entry.key !== 'string') continue;
+        this.entries.set(id, entry);
+      }
+    } catch {
+      // Corrupt snapshot → start fresh, will be overwritten on next put.
+    }
+  }
+
+  private saveSnapshot(): void {
+    if (!fs.existsSync(this.stateDir)) fs.mkdirSync(this.stateDir, { recursive: true });
+    const tmp = this.snapshotPath() + '.tmp';
+    const body = JSON.stringify({ entries: Array.from(this.entries.entries()) });
+    fs.writeFileSync(tmp, body, { mode: 0o600 });
+    fs.renameSync(tmp, this.snapshotPath());
+  }
+}
+
+/**
+ * Compute the deterministic cache key. Exported for tests and for the
+ * `cacheKeyInputs` helper in ProjectDriftChecker.ts (which produces the
+ * same inputs — this function hashes them into a stable string).
+ */
+export function computeCacheKey(
+  promptTemplateVersion: number,
+  modelId: string,
+  specBytes: Buffer,
+  referencedFileBytes: Array<{ relPath: string; bytes: Buffer }>
+): string {
+  const sortedFileEntries = referencedFileBytes
+    .map((f) => `${f.relPath}:${crypto.createHash('sha256').update(f.bytes).digest('hex')}`)
+    .sort();
+  const h = crypto.createHash('sha256');
+  h.update(`v=${promptTemplateVersion}\n`);
+  h.update(`m=${modelId}\n`);
+  h.update(`s=${crypto.createHash('sha256').update(specBytes).digest('hex')}\n`);
+  for (const entry of sortedFileEntries) h.update(`f=${entry}\n`);
+  return h.digest('hex');
+}

--- a/tests/unit/DriftSpendLedger.test.ts
+++ b/tests/unit/DriftSpendLedger.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for DriftSpendLedger.
+ *
+ * Covers:
+ *   - Reserve + tally + cap (strict-greater-than boundary per spec).
+ *   - Reconcile supersedes the pending estimate (no double-count).
+ *   - Idempotent reconcile (calling twice doesn't double the cost).
+ *   - Lock coordination across concurrent reserves on one process.
+ *   - File rotation by UTC day (verified via fake date manipulation).
+ *   - pruneOlderThan removes files outside the retention window.
+ *   - OverBudgetError is the thrown type (callers branch on it).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DriftSpendLedger,
+  OverBudgetError,
+  DEFAULT_DAILY_CAP_USD,
+} from '../../src/core/DriftSpendLedger.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function makeStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'drift-ledger-'));
+}
+
+describe('DriftSpendLedger', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = makeStateDir();
+  });
+  afterEach(() => {
+    try {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/DriftSpendLedger.test.ts:afterEach' });
+    } catch { /* ignore */ }
+  });
+
+  it('default cap is the spec value (1.0 USD)', () => {
+    expect(DEFAULT_DAILY_CAP_USD).toBe(1.0);
+  });
+
+  it('reserves estimated cost and reports cumulative spent', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir });
+    const r1 = await l.reserve({ projectId: 'p1', estimatedCost: 0.02 });
+    expect(r1.spentToday).toBeCloseTo(0.02, 6);
+    const r2 = await l.reserve({ projectId: 'p2', estimatedCost: 0.03 });
+    expect(r2.spentToday).toBeCloseTo(0.05, 6);
+    expect(r1.recordId).not.toBe(r2.recordId);
+  });
+
+  it('throws OverBudgetError when reservation would exceed cap', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir, dailyCapUsd: 0.1 });
+    await l.reserve({ projectId: 'p', estimatedCost: 0.08 });
+    await expect(
+      l.reserve({ projectId: 'p', estimatedCost: 0.05 })
+    ).rejects.toBeInstanceOf(OverBudgetError);
+  });
+
+  it('allows reservation equal to cap (strict-greater-than boundary)', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir, dailyCapUsd: 0.5 });
+    await l.reserve({ projectId: 'p', estimatedCost: 0.2 });
+    // Spent=0.2, reserve=0.3 → spent+est=0.5 NOT > cap=0.5 → allow.
+    const r = await l.reserve({ projectId: 'p', estimatedCost: 0.3 });
+    expect(r.spentToday).toBeCloseTo(0.5, 6);
+  });
+
+  it('reconcile supersedes the pending estimate', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir, dailyCapUsd: 1.0 });
+    const r = await l.reserve({ projectId: 'p', estimatedCost: 0.2 });
+    expect(await l.spentToday()).toBeCloseTo(0.2, 6);
+    await l.reconcile(r.recordId, 0.05); // Actual was lower than estimate.
+    expect(await l.spentToday()).toBeCloseTo(0.05, 6);
+  });
+
+  it('reconcile is idempotent — calling twice does not double-count', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir });
+    const r = await l.reserve({ projectId: 'p', estimatedCost: 0.1 });
+    await l.reconcile(r.recordId, 0.04);
+    await l.reconcile(r.recordId, 0.04);
+    expect(await l.spentToday()).toBeCloseTo(0.04, 6);
+  });
+
+  it('rejects negative / non-finite costs', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir });
+    await expect(l.reserve({ projectId: 'p', estimatedCost: -1 })).rejects.toThrow();
+    await expect(l.reserve({ projectId: 'p', estimatedCost: NaN })).rejects.toThrow();
+    await expect(l.reconcile('missing-id', -0.01)).rejects.toThrow();
+  });
+
+  it('writes one JSONL row per reserve and one per reconcile', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir });
+    const r = await l.reserve({ projectId: 'p', estimatedCost: 0.07 });
+    await l.reconcile(r.recordId, 0.03);
+    const today = new Date().toISOString().slice(0, 10);
+    const file = path.join(dir, `drift-spend-${today}.jsonl`);
+    expect(fs.existsSync(file)).toBe(true);
+    const lines = fs.readFileSync(file, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const reserveRow = JSON.parse(lines[0]);
+    const reconcileRow = JSON.parse(lines[1]);
+    expect(reserveRow.actualCost).toBe(null);
+    expect(reserveRow.estimatedCost).toBeCloseTo(0.07, 6);
+    expect(reconcileRow.actualCost).toBeCloseTo(0.03, 6);
+    expect(reconcileRow.recordId).toBe(reserveRow.recordId);
+  });
+
+  it('spentToday is lock-coordinated and stable across calls', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir });
+    await l.reserve({ projectId: 'p', estimatedCost: 0.04 });
+    const a = await l.spentToday();
+    const b = await l.spentToday();
+    expect(a).toBe(b);
+  });
+
+  it('concurrent reserves serialize through the lock and the second sees the first', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir });
+    const [a, b] = await Promise.all([
+      l.reserve({ projectId: 'p1', estimatedCost: 0.1 }),
+      l.reserve({ projectId: 'p2', estimatedCost: 0.1 }),
+    ]);
+    expect(await l.spentToday()).toBeCloseTo(0.2, 6);
+    // Both succeed because cap is the default $1; recordIds distinct.
+    expect(a.recordId).not.toBe(b.recordId);
+  });
+
+  it('pruneOlderThan removes files older than retentionDays', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir, retentionDays: 3 });
+    // Lay down a fake old ledger file.
+    const oldDate = new Date();
+    oldDate.setUTCDate(oldDate.getUTCDate() - 10);
+    const oldFile = path.join(dir, `drift-spend-${oldDate.toISOString().slice(0, 10)}.jsonl`);
+    fs.writeFileSync(oldFile, '');
+    await l.reserve({ projectId: 'p', estimatedCost: 0.01 });
+    const result = await l.pruneOlderThan();
+    expect(result.removed.length).toBeGreaterThanOrEqual(1);
+    expect(fs.existsSync(oldFile)).toBe(false);
+    // Today's file remains.
+    const today = new Date().toISOString().slice(0, 10);
+    expect(fs.existsSync(path.join(dir, `drift-spend-${today}.jsonl`))).toBe(true);
+  });
+
+  it('tolerates corrupt rows in the ledger file without throwing', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir });
+    await l.reserve({ projectId: 'p', estimatedCost: 0.04 });
+    const today = new Date().toISOString().slice(0, 10);
+    const file = path.join(dir, `drift-spend-${today}.jsonl`);
+    fs.appendFileSync(file, 'not json\n{"missing":"fields"}\n');
+    expect(await l.spentToday()).toBeCloseTo(0.04, 6);
+    // New reserve still works.
+    await l.reserve({ projectId: 'p', estimatedCost: 0.01 });
+    expect(await l.spentToday()).toBeCloseTo(0.05, 6);
+  });
+
+  it('OverBudgetError exposes cap, spentToday, and estimatedCost', async () => {
+    const l = new DriftSpendLedger({ stateDir: dir, dailyCapUsd: 0.1 });
+    await l.reserve({ projectId: 'p', estimatedCost: 0.08 });
+    try {
+      await l.reserve({ projectId: 'p', estimatedCost: 0.05 });
+      throw new Error('should have thrown');
+    } catch (e) {
+      const err = e as OverBudgetError;
+      expect(err).toBeInstanceOf(OverBudgetError);
+      expect(err.capUsd).toBe(0.1);
+      expect(err.spentToday).toBeCloseTo(0.08, 6);
+      expect(err.estimatedCost).toBeCloseTo(0.05, 6);
+    }
+  });
+});

--- a/tests/unit/ProjectDriftChecker.test.ts
+++ b/tests/unit/ProjectDriftChecker.test.ts
@@ -753,3 +753,147 @@ describe('DRIFT_LIMITS contract', () => {
     expect(DRIFT_LIMITS.defaultTimeoutMs).toBe(30_000);
   });
 });
+
+// ── Cache + ledger integration (Phase 1b PR 2) ──────────────────────
+
+describe('ProjectDriftChecker with cache + ledger', () => {
+  let tmpRoot: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpRoot = makeRepo();
+    stateDir = makeRepo();
+  });
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(tmpRoot, { recursive: true, force: true, operation: 'tests/unit/ProjectDriftChecker.test.ts:cache-afterEach-tmpRoot' }); } catch { /* ignore */ }
+    try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/ProjectDriftChecker.test.ts:cache-afterEach-stateDir' }); } catch { /* ignore */ }
+  });
+
+  it('cache hit on the second call avoids the LLM and returns the same verdict', async () => {
+    const { ProjectDriftCheckerCache } = await import('../../src/core/ProjectDriftCheckerCache.js');
+    const cache = new ProjectDriftCheckerCache({ stateDir, persist: false });
+    const stub = new StubProvider().enqueue(JSON.stringify({
+      verdict: 'minor-drift',
+      rationale: 'a tiny rename',
+      evidenceCitations: [],
+    }));
+    const c = new ProjectDriftChecker({ intelligence: stub, cache });
+
+    writeFile(tmpRoot, 'spec.md', '# spec');
+    writeFile(tmpRoot, 'a.ts', 'export const a = 1;');
+    const input = {
+      projectId: 'p',
+      roundIndex: 0,
+      targetRepoPath: tmpRoot,
+      specPath: 'spec.md',
+      referencedFiles: ['a.ts'],
+    };
+
+    const first = await c.run(input);
+    expect(first.verdict).toBe('minor-drift');
+    expect(stub.calls).toHaveLength(1);
+
+    const second = await c.run(input);
+    expect(second.verdict).toBe('minor-drift');
+    // The LLM was NOT called again — cache served it.
+    expect(stub.calls).toHaveLength(1);
+  });
+
+  it('content change forces a re-run when the cache is in use', async () => {
+    const { ProjectDriftCheckerCache } = await import('../../src/core/ProjectDriftCheckerCache.js');
+    const cache = new ProjectDriftCheckerCache({ stateDir, persist: false });
+    const stub = new StubProvider()
+      .enqueue(validResponse())
+      .enqueue(validResponse());
+    const c = new ProjectDriftChecker({ intelligence: stub, cache });
+
+    writeFile(tmpRoot, 'spec.md', '# spec');
+    writeFile(tmpRoot, 'a.ts', 'A');
+    const baseInput = {
+      projectId: 'p',
+      roundIndex: 0,
+      targetRepoPath: tmpRoot,
+      specPath: 'spec.md',
+      referencedFiles: ['a.ts'],
+    };
+    await c.run(baseInput);
+    expect(stub.calls).toHaveLength(1);
+
+    writeFile(tmpRoot, 'a.ts', 'A_CHANGED');
+    await c.run(baseInput);
+    expect(stub.calls).toHaveLength(2);
+  });
+
+  it('returns over-budget without calling LLM when ledger cap is exceeded', async () => {
+    const { DriftSpendLedger } = await import('../../src/core/DriftSpendLedger.js');
+    const ledger = new DriftSpendLedger({ stateDir, dailyCapUsd: 0.005 });
+    const stub = new StubProvider().enqueue(validResponse());
+    const c = new ProjectDriftChecker({
+      intelligence: stub,
+      ledger,
+      estimatedCostPerCallUsd: 0.01,
+    });
+    writeFile(tmpRoot, 'spec.md', '# spec');
+    const v = await c.run({
+      projectId: 'p',
+      roundIndex: 0,
+      targetRepoPath: tmpRoot,
+      specPath: 'spec.md',
+      referencedFiles: [],
+    });
+    expect(v.verdict).toBe('manual-review-required');
+    if (v.verdict === 'manual-review-required') expect(v.reason).toBe('over-budget');
+    expect(stub.calls).toHaveLength(0);
+  });
+
+  it('reserves and reconciles when ledger is present', async () => {
+    const { DriftSpendLedger } = await import('../../src/core/DriftSpendLedger.js');
+    const ledger = new DriftSpendLedger({ stateDir });
+    const stub = new StubProvider().enqueue(validResponse());
+    const c = new ProjectDriftChecker({
+      intelligence: stub,
+      ledger,
+      estimatedCostPerCallUsd: 0.02,
+    });
+    writeFile(tmpRoot, 'spec.md', '# spec');
+    expect(await ledger.spentToday()).toBe(0);
+    await c.run({
+      projectId: 'p',
+      roundIndex: 0,
+      targetRepoPath: tmpRoot,
+      specPath: 'spec.md',
+      referencedFiles: [],
+    });
+    // Reserve appended 0.02; reconcile capped at 0.02 (actual ≈ estimated).
+    expect(await ledger.spentToday()).toBeCloseTo(0.02, 6);
+  });
+
+  it('does NOT cache LLM-failure verdicts (schema-fail allowed to retry)', async () => {
+    const { ProjectDriftCheckerCache } = await import('../../src/core/ProjectDriftCheckerCache.js');
+    const cache = new ProjectDriftCheckerCache({ stateDir, persist: false });
+    const stub = new StubProvider()
+      .enqueue('not json')              // schema-fail
+      .enqueue(validResponse());        // success on retry
+    const c = new ProjectDriftChecker({ intelligence: stub, cache });
+    writeFile(tmpRoot, 'spec.md', '# spec');
+
+    const a = await c.run({
+      projectId: 'p',
+      roundIndex: 0,
+      targetRepoPath: tmpRoot,
+      specPath: 'spec.md',
+      referencedFiles: [],
+    });
+    expect(a.verdict).toBe('manual-review-required');
+
+    const b = await c.run({
+      projectId: 'p',
+      roundIndex: 0,
+      targetRepoPath: tmpRoot,
+      specPath: 'spec.md',
+      referencedFiles: [],
+    });
+    expect(b.verdict).toBe('no-drift');
+    expect(stub.calls).toHaveLength(2);
+  });
+});

--- a/tests/unit/ProjectDriftCheckerCache.test.ts
+++ b/tests/unit/ProjectDriftCheckerCache.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Unit tests for ProjectDriftCheckerCache.
+ *
+ * Covers:
+ *   - Hit / miss
+ *   - Cache key includes promptTemplateVersion, modelId, sortedFileHashes,
+ *     specBodySha — so any of them changing yields a fresh key (and miss).
+ *   - Mtime fast-path: when an entry exists and all file mtimes match,
+ *     a hit is returned without recomputing the cache key.
+ *   - Mtime invalidation: bumping the mtime forces a recomputation.
+ *   - TTL expiry: entries past TTL miss.
+ *   - Disk persistence: a fresh checker instance reloads prior verdicts.
+ *   - invalidate() removes an entry.
+ *   - Snapshot tolerates corruption.
+ *   - Set-shrink / set-grow correctly invalidate the fast-path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  ProjectDriftCheckerCache,
+  computeCacheKey,
+  SNAPSHOT_FILENAME,
+} from '../../src/core/ProjectDriftCheckerCache.js';
+import type { DriftVerdict } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function makeDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'drift-cache-'));
+}
+
+function writeFile(root: string, rel: string, body: string): string {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, body);
+  return abs;
+}
+
+function noDrift(): DriftVerdict {
+  return {
+    verdict: 'no-drift',
+    rationale: 'all good',
+    evidenceCitations: [],
+  };
+}
+
+describe('ProjectDriftCheckerCache', () => {
+  let dir: string;
+  let workdir: string;
+
+  beforeEach(() => {
+    dir = makeDir();
+    workdir = makeDir();
+  });
+
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/ProjectDriftCheckerCache.test.ts:afterEach-dir' }); } catch { /* ignore */ }
+    try { SafeFsExecutor.safeRmSync(workdir, { recursive: true, force: true, operation: 'tests/unit/ProjectDriftCheckerCache.test.ts:afterEach-workdir' }); } catch { /* ignore */ }
+  });
+
+  it('misses on first lookup and returns a stable key', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const filePath = writeFile(workdir, 'a.ts', 'export const a = 1;');
+    const result = c.lookup({
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [filePath],
+      referencedFileBytes: [fs.readFileSync(filePath)],
+      specBytes: fs.readFileSync(specPath),
+    });
+    expect(result.hit).toBe(false);
+    if (!result.hit) {
+      expect(typeof result.key).toBe('string');
+      expect(result.key.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('hits via the mtime fast-path when nothing changed', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const filePath = writeFile(workdir, 'a.ts', 'A');
+    const input = {
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [filePath],
+      referencedFileBytes: [fs.readFileSync(filePath)],
+      specBytes: fs.readFileSync(specPath),
+    };
+    const miss = c.lookup(input);
+    expect(miss.hit).toBe(false);
+    if (miss.hit) return;
+    c.put(input, miss.key, noDrift());
+    const hit = c.lookup(input);
+    expect(hit.hit).toBe(true);
+    if (hit.hit) {
+      expect(hit.mtimeFastPath).toBe(true);
+      expect(hit.verdict.verdict).toBe('no-drift');
+    }
+  });
+
+  it('falls back to full-hash key when a file mtime moves but content matches', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const filePath = writeFile(workdir, 'a.ts', 'A');
+    const input = () => ({
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [filePath],
+      referencedFileBytes: [fs.readFileSync(filePath)],
+      specBytes: fs.readFileSync(specPath),
+    });
+    const miss = c.lookup(input());
+    if (miss.hit) throw new Error('expected miss');
+    c.put(input(), miss.key, noDrift());
+    // Touch the file (same content) to bump mtime.
+    const ms = Date.now() / 1000 + 60; // 1 minute in the future
+    fs.utimesSync(filePath, ms, ms);
+    const hit = c.lookup(input());
+    expect(hit.hit).toBe(true);
+    if (hit.hit) {
+      // Full-hash path matched because content is unchanged.
+      expect(hit.mtimeFastPath).toBe(false);
+    }
+  });
+
+  it('misses when file CONTENT changes (cache key shifts)', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const filePath = writeFile(workdir, 'a.ts', 'A');
+    const v1 = () => ({
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [filePath],
+      referencedFileBytes: [fs.readFileSync(filePath)],
+      specBytes: fs.readFileSync(specPath),
+    });
+    const miss = c.lookup(v1());
+    if (miss.hit) throw new Error();
+    c.put(v1(), miss.key, noDrift());
+    fs.writeFileSync(filePath, 'A_CHANGED');
+    const result = c.lookup({
+      ...v1(),
+      referencedFileBytes: [fs.readFileSync(filePath)],
+    });
+    expect(result.hit).toBe(false);
+  });
+
+  it('misses when promptTemplateVersion bumps', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const base = {
+      projectId: 'p',
+      roundIndex: 0,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [],
+      referencedFileBytes: [],
+      specBytes: fs.readFileSync(specPath),
+    };
+    const miss = c.lookup({ ...base, promptTemplateVersion: 1 });
+    if (miss.hit) throw new Error();
+    c.put({ ...base, promptTemplateVersion: 1 }, miss.key, noDrift());
+    const result = c.lookup({ ...base, promptTemplateVersion: 2 });
+    expect(result.hit).toBe(false);
+  });
+
+  it('misses when modelId changes', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const base = {
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      specPath,
+      referencedFilePaths: [],
+      referencedFileBytes: [],
+      specBytes: fs.readFileSync(specPath),
+    };
+    const miss = c.lookup({ ...base, modelId: 'fast' });
+    if (miss.hit) throw new Error();
+    c.put({ ...base, modelId: 'fast' }, miss.key, noDrift());
+    const result = c.lookup({ ...base, modelId: 'capable' });
+    expect(result.hit).toBe(false);
+  });
+
+  it('TTL expiry forces miss', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false, ttlMs: 5 });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const input = {
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [],
+      referencedFileBytes: [],
+      specBytes: fs.readFileSync(specPath),
+    };
+    const miss = c.lookup(input);
+    if (miss.hit) throw new Error();
+    c.put(input, miss.key, noDrift());
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const result = c.lookup(input);
+        expect(result.hit).toBe(false);
+        resolve();
+      }, 50);
+    });
+  });
+
+  it('invalidate() removes an entry', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const input = {
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [],
+      referencedFileBytes: [],
+      specBytes: fs.readFileSync(specPath),
+    };
+    const miss = c.lookup(input);
+    if (miss.hit) throw new Error();
+    c.put(input, miss.key, noDrift());
+    expect(c.size()).toBe(1);
+    c.invalidate('p', 0);
+    expect(c.size()).toBe(0);
+  });
+
+  it('persists across instances when persist=true', () => {
+    const c1 = new ProjectDriftCheckerCache({ stateDir: dir, persist: true });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const input = {
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [],
+      referencedFileBytes: [],
+      specBytes: fs.readFileSync(specPath),
+    };
+    const miss = c1.lookup(input);
+    if (miss.hit) throw new Error();
+    c1.put(input, miss.key, noDrift());
+
+    // Snapshot file exists.
+    expect(fs.existsSync(path.join(dir, SNAPSHOT_FILENAME))).toBe(true);
+
+    // Fresh instance picks it up.
+    const c2 = new ProjectDriftCheckerCache({ stateDir: dir, persist: true });
+    const result = c2.lookup(input);
+    expect(result.hit).toBe(true);
+  });
+
+  it('tolerates a corrupt snapshot on reload', () => {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, SNAPSHOT_FILENAME), 'not json');
+    // Should not throw.
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: true });
+    expect(c.size()).toBe(0);
+  });
+
+  it('invalidates the fast-path when referenced-file SET changes', () => {
+    const c = new ProjectDriftCheckerCache({ stateDir: dir, persist: false });
+    const specPath = writeFile(workdir, 'spec.md', '# spec');
+    const fileA = writeFile(workdir, 'a.ts', 'A');
+    const fileB = writeFile(workdir, 'b.ts', 'B');
+    const v1 = {
+      projectId: 'p',
+      roundIndex: 0,
+      promptTemplateVersion: 1,
+      modelId: 'fast',
+      specPath,
+      referencedFilePaths: [fileA],
+      referencedFileBytes: [fs.readFileSync(fileA)],
+      specBytes: fs.readFileSync(specPath),
+    };
+    const miss = c.lookup(v1);
+    if (miss.hit) throw new Error();
+    c.put(v1, miss.key, noDrift());
+    // Add a second file to the referenced set.
+    const v2 = {
+      ...v1,
+      referencedFilePaths: [fileA, fileB],
+      referencedFileBytes: [fs.readFileSync(fileA), fs.readFileSync(fileB)],
+    };
+    const result = c.lookup(v2);
+    expect(result.hit).toBe(false);
+  });
+});
+
+describe('computeCacheKey', () => {
+  it('is deterministic across file-order permutations', () => {
+    const spec = Buffer.from('# spec');
+    const a = { relPath: 'a.ts', bytes: Buffer.from('A') };
+    const b = { relPath: 'b.ts', bytes: Buffer.from('B') };
+    const k1 = computeCacheKey(1, 'fast', spec, [a, b]);
+    const k2 = computeCacheKey(1, 'fast', spec, [b, a]);
+    expect(k1).toBe(k2);
+  });
+
+  it('changes when ANY input changes', () => {
+    const spec = Buffer.from('# spec');
+    const a = { relPath: 'a.ts', bytes: Buffer.from('A') };
+    const baseline = computeCacheKey(1, 'fast', spec, [a]);
+    expect(computeCacheKey(2, 'fast', spec, [a])).not.toBe(baseline);
+    expect(computeCacheKey(1, 'capable', spec, [a])).not.toBe(baseline);
+    expect(computeCacheKey(1, 'fast', Buffer.from('# different'), [a])).not.toBe(baseline);
+    expect(
+      computeCacheKey(1, 'fast', spec, [{ relPath: 'a.ts', bytes: Buffer.from('A_DIFF') }])
+    ).not.toBe(baseline);
+    // Renaming a file with same bytes still changes the key (path is part of input).
+    expect(computeCacheKey(1, 'fast', spec, [{ relPath: 'renamed.ts', bytes: Buffer.from('A') }])).not.toBe(baseline);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,60 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+### Project-scope Phase 1b PR 2 — drift cache + cost ledger
+
+Second PR of project-scope Phase 1b. Adds two persistent-state
+primitives the drift checker has been operating without since v0.28.93:
+
+- **Verdict cache** — `ProjectDriftCheckerCache`. 24-hour TTL,
+  mtime-fast-path before computing the cache key, disk-backed
+  snapshot at `.instar/drift-verdict-cache.json` so the cache
+  survives restarts. When file mtimes match the recorded entry and
+  template version + model id are unchanged, the prior verdict is
+  returned without re-hashing or calling the model. When content
+  changes, the cache key shifts and the LLM is consulted again.
+
+- **Cost ledger** — `DriftSpendLedger`. Daily-rotated append-only
+  JSONL at `.instar/drift-spend-YYYY-MM-DD.jsonl` enforcing the
+  spec's $1/day per-agent spend cap. Strict-greater-than boundary
+  (equal-to-cap is allowed; one cent over is not). Pre-reservation
+  rows are append-only and reconciled with the actual spend after
+  the call. Lock-coordinated on `.instar/local/drift-spend.lock`
+  via proper-lockfile (same convention as AgentRegistry and
+  SharedStateLedger). 30-day retention; older files are pruned
+  through `SafeFsExecutor.safeRmSync`.
+
+Both are optional fields on `ProjectDriftChecker`'s config. The
+v0.28.93 contract — neither cache nor ledger — is preserved
+exactly when neither is passed. Wiring into the round runner
+(consumer) ships in the next PR.
+
+## What to Tell Your User
+
+- **Drift checks won't burn budget**: I now have a daily spending cap
+  on the model calls that power drift checks, plus a cache so I don't
+  pay for the same check twice. You don't have to do anything; it just
+  works. If I ever hit the daily limit, I escalate to you rather than
+  silently overspending.
+
+## Summary of New Capabilities
+
+- `ProjectDriftCheckerCache` class — sha256-keyed verdict cache with
+  24-hour TTL, mtime fast-path, and disk-backed snapshot at
+  `.instar/drift-verdict-cache.json`. Avoids redundant LLM calls when
+  spec + referenced files are unchanged.
+- `DriftSpendLedger` class — daily-rotated JSONL cost ledger
+  (`.instar/drift-spend-YYYY-MM-DD.jsonl`) enforcing a $1-per-agent
+  per-UTC-day spend cap. Lock-coordinated via proper-lockfile. Exposes
+  `reserve()`, `reconcile()`, `spentToday()`, `pruneOlderThan()`,
+  and the `OverBudgetError` thrown class.
+- `ProjectDriftChecker` config now accepts optional `cache`, `ledger`,
+  and `estimatedCostPerCallUsd` fields. Backwards-compatible: passing
+  neither preserves the v0.28.93 contract.

--- a/upgrades/side-effects/project-scope-phase1b-pr2.md
+++ b/upgrades/side-effects/project-scope-phase1b-pr2.md
@@ -1,0 +1,198 @@
+# Side-Effects Review — project-scope Phase 1b PR 2 (Drift cache + cost ledger)
+
+**Version / slug:** `project-scope-phase1b-pr2`
+**Date:** `2026-05-11`
+**Author:** `echo`
+**Second-pass reviewer:** `required (new persistent-state + cost-control surface)`
+
+## Summary of the change
+
+Second PR of Phase 1b. Ships the two persistent-state primitives the drift
+checker has been operating without since PR 1:
+
+- A verdict cache with mtime fast-path that avoids redundant LLM calls
+  when the spec and its referenced files haven't changed.
+- A daily-rotated cost ledger that enforces the $1/day per-agent
+  spend ceiling the spec requires.
+
+Both classes are usable on their own; `ProjectDriftChecker` now accepts
+them as optional config and wires them in around the LLM call. When
+neither is passed (the PR 1 contract), behavior is unchanged.
+
+The `POST /projects/:id/drift-check` HTTP endpoint and the per-project
+mutex around it ship in PR 3 alongside the round runner. PR 2 is the
+data-plane piece; PR 3 is the routing.
+
+Spec source: `docs/specs/PROJECT-SCOPE-SPEC.md` § Phase 1.4 ("Cache key",
+mtime fast-path, "Cost ceiling").
+
+New files:
+- `src/core/ProjectDriftCheckerCache.ts` (~230 lines) — sha256-keyed
+  in-memory verdict cache. Mtime fast-path checks file mtimes against
+  the recorded entry before computing the cache key; full-hash path is
+  fallback. 24h TTL. Disk-backed snapshot at
+  `.instar/drift-verdict-cache.json` so the cache survives restarts
+  without a cold first-call after sleep/wake. Snapshot is corruption-
+  tolerant (corrupt file → start fresh, will be overwritten on next put).
+- `src/core/DriftSpendLedger.ts` (~240 lines) — daily-rotated append-only
+  JSONL ledger at `.instar/drift-spend-YYYY-MM-DD.jsonl`. Each `reserve()`
+  appends a `{recordId, projectId, estimatedCost, actualCost: null,
+  timestamp}` row under an advisory file lock on
+  `.instar/local/drift-spend.lock` (proper-lockfile, same options as
+  the rest of the codebase). `reconcile(recordId, actualCost)` appends
+  a superseding row. `spentToday()` returns the de-duplicated tally.
+  `pruneOlderThan()` removes files outside the 30-day retention window
+  (via `SafeFsExecutor.safeRmSync`, NOT raw `fs.rmSync`).
+- `tests/unit/ProjectDriftCheckerCache.test.ts` (13 cases) — hit/miss,
+  mtime fast-path (match, content-change miss, set-shrink invalidation),
+  cache-key invalidation on every input (templateVersion, modelId,
+  specBody, file content, file rename), TTL expiry, invalidate(),
+  disk persistence across instances, corrupt-snapshot tolerance,
+  `computeCacheKey` determinism + instability semantics.
+- `tests/unit/DriftSpendLedger.test.ts` (13 cases) — default cap matches
+  spec, reserve + tally, strict-greater-than boundary at the cap
+  (equal-to-cap allowed), reconcile supersedes (no double-count),
+  idempotent reconcile, negative/non-finite rejected, JSONL row count
+  + shape after reserve+reconcile, lock-coordinated `spentToday`,
+  concurrent reserves serialize, `pruneOlderThan` removes old files,
+  corrupt row tolerance, `OverBudgetError` exposes cap/spent/estimated.
+
+Modified files:
+- `src/core/ProjectDriftChecker.ts` (~+80 lines) — config accepts
+  optional `cache` and `ledger`. Order of operations inside `run()`:
+  (1) all input validation (unchanged from PR 1) → (2) cache lookup
+  (skip LLM on hit) → (3) ledger reserve (return over-budget on cap)
+  → (4) LLM call → (5) on success, cache.put + ledger.reconcile.
+  LLM-failure verdicts (schema-fail, timeout) are NOT cached; input-
+  validation verdicts (over-budget, deleted-files, path-jail-fail) are
+  cheap to recompute and don't benefit from caching.
+- `tests/unit/ProjectDriftChecker.test.ts` (+5 cases) — cache hit avoids
+  LLM, content change forces re-run, over-budget short-circuits before
+  the LLM, reserve+reconcile round-trip, LLM-failure not cached.
+
+## Decision-point inventory
+
+- **Cache hit short-circuit** (`ProjectDriftCheckerCache.lookup`) —
+  **add** — on hit, returns the cached verdict directly, bypassing
+  the LLM. Cache key is `sha256(promptTemplateVersion + modelId +
+  specBodySha + sortedFileHashes)`; mtime fast-path bypasses the hash
+  but checks `(templateVersion, modelId, all file mtimes)`. Cache
+  invariants — TTL, hash key on file content, mtime equality — are
+  exercised by 13 unit tests.
+- **Daily cap rejection** (`DriftSpendLedger.reserve` → throws
+  `OverBudgetError`) — **add** — if `spent + estimated > cap`, throw.
+  `ProjectDriftChecker` catches it and returns
+  `manual-review-required(over-budget)`. Strict greater-than boundary
+  matches the spec (iter-2 correction).
+- **Verdict NOT cached on LLM failure** (`run` post-call) — **add** —
+  schema-fail / timeout / failed-citation-verification all return
+  before the cache write; only `no-drift`, `minor-drift`,
+  `premise-violated` reach the put path. A second call gets a fresh
+  LLM attempt rather than the previously-cached failure verdict.
+
+All three decisions are conservative: hit-on-content-match (never
+hit on stale content), reject-at-strict-cap (never overshoot), no
+cached failure (always re-try).
+
+## Over-block vs under-block analysis
+
+### Cache
+
+Over-block risk: returning a stale verdict. The cache key includes the
+full sha256 of every relevant input, so a stale verdict can only be
+served if (a) file content is unchanged AND (b) within TTL AND (c)
+modelId + templateVersion match. The mtime fast-path only fires when
+the recorded mtimes match the current stat() results — `touch` without
+content change does NOT cause a hit; it forces a full-hash fall-back
+that then matches (correct outcome). The 24h TTL is the durable floor
+even when nothing else moves.
+
+Under-block risk: cache miss when it should have hit. Acceptable —
+correctness costs an extra LLM call. The mtime fast-path is a
+performance optimization, not a correctness invariant.
+
+### Ledger
+
+Over-block risk: rejecting a call that wouldn't actually exceed the
+cap. Pre-reserve uses the `estimatedCostPerCallUsd` constant (default
+$0.01) rather than the call's real cost; in the worst case we
+over-reserve and over-block. Acceptable because the cap is the AGENT
+ceiling, not a hard per-call limit. Reconcile lowers the recorded
+spend back to actual, so subsequent calls aren't penalized.
+
+Under-block risk: under-counting. The strict `>` boundary lets
+`spent + estimated == cap` pass; that's the documented behavior, not
+a bug. A reservation that's never reconciled (caller crashed) stays as
+the pending estimate and contributes to the cap until UTC rollover —
+fail-safe rather than fail-open.
+
+The cap is per-machine. On multi-machine setups, the spec documents
+the worst-case as `N × cap` per day; the true atomic cross-machine
+cap is a same-PR tracked deferred child (`drift-spend-cross-machine`)
+referenced in the spec. PR 2 does not change that posture.
+
+## Signal vs authority audit
+
+Neither primitive holds authority. They're persistence + cost-control
+plumbing. The drift verdict is still a signal; the cache returns a
+prior signal, the ledger throws on overshoot but the resulting verdict
+(`manual-review-required(over-budget)`) is again just a signal. The
+round-runner in PR 3 holds authority for round-start, combining drift
++ artifact checks.
+
+## Interactions with existing systems
+
+- **`ProjectDriftChecker`.** Both fields are optional — passing
+  neither preserves the PR 1 contract exactly. Passing one but not
+  the other is supported (cache-only / ledger-only).
+- **`proper-lockfile`.** Already a dep (used by AgentRegistry,
+  SharedStateLedger, PlatformActivityRegistry). Same `LOCK_OPTIONS`
+  shape, same stale-detection convention.
+- **`.instar/local/`.** Lock file lives under this machine-local
+  subdirectory by spec — same convention as `round-runner.lock` (the
+  PR 3 chokepoint). Not git-synced, so two machines don't fight over
+  a 0-byte lockfile in the sync layer.
+- **`SafeFsExecutor`.** Used for `pruneOlderThan` rather than direct
+  `fs.rmSync`, matching the lint-no-direct-destructive contract.
+- **Backup / snapshot.** The spec lists
+  `.instar/drift-spend-*.jsonl` in the snapshot-include set (so a
+  restore can see the prior day's spend); this PR creates the files
+  that the existing snapshot job already names — no snapshot code
+  change needed.
+
+## Rollback cost
+
+- **Cache.** Revert restores PR 1 behavior. The snapshot file at
+  `.instar/drift-verdict-cache.json` becomes orphaned but harmless
+  (no other code reads it).
+- **Ledger.** Revert restores PR 1 behavior. The JSONL files at
+  `.instar/drift-spend-*.jsonl` are orphaned; the existing
+  snapshot/cleanup tooling still sweeps them via retention rules.
+- **No schema migrations.** Both primitives are file-backed,
+  forward-compatible. Older agent versions that don't know about
+  these fields ignore them.
+
+## What this PR explicitly defers
+
+Per spec § Phase 1.4 and § Phase 1.5, these belong to drift but ship
+in PR 3 (round runner) alongside the consumer that needs them:
+
+- `POST /projects/:id/drift-check` HTTP endpoint with per-project
+  mutex. PR 2 ships the primitive; PR 3 ships the route + server
+  wiring (cache + ledger instantiation on `AgentServer` startup,
+  injection into the routes ctx, mutex map keyed by `projectId`).
+- Integration into `ProjectRoundRunner.preflight()` step 10 ("Drift
+  check: load cached verdict if fresh + present + all hashes match;
+  otherwise run drift").
+- Multi-machine "documented worst case is `N × cap` per day"
+  visibility — surfacing the per-machine spend in the digest or
+  dashboard.
+
+## Verification
+
+- `npm run lint` — passes (tsc + lint-no-direct-destructive).
+- `npx vitest run tests/unit/ProjectDriftChecker.test.ts
+  tests/unit/DriftSpendLedger.test.ts
+  tests/unit/ProjectDriftCheckerCache.test.ts` — 76/76 pass.
+- PR 1's 45 existing tests still green; the 5 new cache+ledger
+  integration tests assert the contract changes.


### PR DESCRIPTION
## Summary

Second PR of project-scope Phase 1b (PROJECT-SCOPE-SPEC § Phase 1.4). Adds the two persistent-state primitives the drift checker has been operating without since PR 1:

- **`ProjectDriftCheckerCache`**: sha256-keyed verdict cache with 24h TTL, mtime fast-path, disk-backed snapshot at `.instar/drift-verdict-cache.json`. Cache key is `sha256(promptTemplateVersion + modelId + specBodySha + sortedFileHashes)` — any input change yields a miss. Mtime fast-path requires `templateVersion + modelId + all file mtimes` to match; hash-fallback covers same-content-different-mtime. Corrupt snapshots tolerated (fresh start, will be overwritten on next put).
- **`DriftSpendLedger`**: daily-rotated append-only JSONL at `.instar/drift-spend-YYYY-MM-DD.jsonl` with strict-greater-than `$1`/day per-agent spend cap (iter-2 spec correction — equal-to-cap is allowed). Lock-coordinated via proper-lockfile on `.instar/local/drift-spend.lock` (matches `AgentRegistry`/`SharedStateLedger` convention). Reserve appends a pending row; `reconcile()` appends a superseding row. Tally de-duplicates by `recordId`. `pruneOlderThan()` removes files past 30 days via `SafeFsExecutor.safeRmSync`. `OverBudgetError` exposes cap/spent/estimated for callers.

`ProjectDriftChecker` now accepts optional `cache` and `ledger` config. When present, the order of operations is: input validation (unchanged from PR 1) → cache lookup (skip LLM on hit) → ledger reserve (return `over-budget` on cap) → LLM call → `cache.put` + `ledger.reconcile`. LLM-failure verdicts (schema-fail / timeout) are NOT cached so a retry can succeed; input-validation verdicts (over-budget, deleted-files, path-jail-fail) are cheap to recompute and aren't worth caching either.

Backwards-compatible: passing neither cache nor ledger preserves PR 1 behavior exactly. The 50 existing tests still pass unchanged.

## Test plan

- [x] `npm run lint` — passes (tsc + lint-no-direct-destructive).
- [x] `npx vitest run tests/unit/ProjectDriftChecker.test.ts tests/unit/DriftSpendLedger.test.ts tests/unit/ProjectDriftCheckerCache.test.ts` — 76/76 pass.
- [x] Pre-push smoke tier — passes (push gate ran on commit).
- [ ] CI full sharded suite — pending.

## What's NOT in this PR (ships in PR 3)

Per spec § Phase 1.4 and § Phase 1.5, these belong to drift but ship alongside the round-runner:

- `POST /projects/:id/drift-check` HTTP endpoint with per-project mutex.
- Server-startup wiring of cache + ledger into the routes ctx.
- `ProjectRoundRunner.preflight()` step 10 calling the integrated checker.

PR 2 is the data-plane primitive; PR 3 is the routing + the consumer.

## Coverage

| Property | Tests |
|---|---|
| Cache: hit / miss / TTL / invalidate / persistence / corruption | 8 |
| Cache: fast-path match, set-change miss, templateVersion + modelId invalidation | 3 |
| `computeCacheKey` determinism + instability | 2 |
| Ledger: reserve, tally, strict-greater-than boundary, reconcile, idempotency | 5 |
| Ledger: input validation, JSONL row shape, lock coordination, concurrent reserves | 4 |
| Ledger: pruneOlderThan, corrupt-row tolerance, OverBudgetError shape | 3 |
| `ProjectDriftChecker` + cache: hit avoids LLM, content change forces re-run, failure not cached | 3 |
| `ProjectDriftChecker` + ledger: over-budget short-circuits, reserve + reconcile round-trip | 2 |
| Existing PR 1 invariants still green | 45 |

Side-effects review: `upgrades/side-effects/project-scope-phase1b-pr2.md`
Release notes appended to: `upgrades/NEXT.md` (alongside PR 1's content; both ship in next release-cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)