### PR TITLE
fix(promise-beacon): heartbeat context + auto-pause + keep-watching resume

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4992,6 +4992,69 @@ export async function startServer(options: StartOptions): Promise<void> {
           });
           promiseBeacon.start();
           (globalThis as Record<string, unknown>).__instarPromiseBeacon = promiseBeacon;
+
+          // ── "keep watching" resume detector ─────────────────────────────
+          // When a user replies on a topic that has any auto-paused beacons,
+          // a literal "keep watching" match resumes them. Brittle detector
+          // (regex) with no blocking authority — it only triggers the
+          // structurally-symmetric /resume endpoint. False-positive cost:
+          // one extra heartbeat that re-pauses on next idle cycle.
+          const KEEP_WATCHING_RE = /\bkeep[\s-]?watching\b/i;
+          const previousTelegramHook = telegram.onMessageLogged;
+          telegram.onMessageLogged = (entry) => {
+            if (previousTelegramHook) previousTelegramHook(entry);
+            if (!entry.fromUser) return;
+            if (!entry.topicId) return;
+            if (!entry.text || !KEEP_WATCHING_RE.test(entry.text)) return;
+            const topicId = entry.topicId;
+            const paused = commitmentTracker
+              .getActive()
+              .filter(c => c.topicId === topicId && c.beaconPaused);
+            if (paused.length === 0) return;
+            (async () => {
+              let resumed = 0;
+              for (const c of paused) {
+                try {
+                  const url = `http://localhost:${config.port}/commitments/${c.id}/resume`;
+                  const resp = await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'Authorization': `Bearer ${config.authToken}`,
+                    },
+                  });
+                  if (resp.ok) resumed += 1;
+                  else console.warn(`[PromiseBeacon] resume call returned ${resp.status} for ${c.id}`);
+                } catch (err) {
+                  console.warn(`[PromiseBeacon] resume call failed for ${c.id}:`, (err as Error).message);
+                }
+              }
+              let ackText: string;
+              if (resumed === paused.length && resumed > 0) {
+                ackText = `⏳ resumed ${resumed === 1 ? 'watcher' : `${resumed} watchers`} on this topic.`;
+              } else if (resumed > 0) {
+                ackText = `⏳ resumed ${resumed} of ${paused.length} watchers — ${paused.length - resumed} didn't resume. Try again or open the dashboard.`;
+              } else {
+                ackText = `⚠️ couldn't resume the watcher${paused.length === 1 ? '' : 's'} on this topic — try again or open the dashboard.`;
+              }
+              try {
+                const ackUrl = `http://localhost:${config.port}/telegram/reply/${topicId}`;
+                await fetch(ackUrl, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${config.authToken}`,
+                  },
+                  body: JSON.stringify({
+                    text: ackText,
+                    metadata: { source: 'promise-beacon', isProxy: true, tier: 1 },
+                  }),
+                });
+              } catch (err) {
+                console.warn('[PromiseBeacon] resume ack send failed:', (err as Error).message);
+              }
+            })();
+          };
         } catch (err) {
           console.warn('[PromiseBeacon] init failed:', (err as Error).message);
         }

--- a/src/monitoring/CommitmentTracker.ts
+++ b/src/monitoring/CommitmentTracker.ts
@@ -157,6 +157,31 @@ export interface Commitment {
   externalKey?: string;
   /** Verified delivery message id (set by POST /commitments/:id/deliver). */
   deliveryMessageId?: string;
+  /**
+   * Non-terminal: beacon is paused because nothing has changed for
+   * `beaconAutoPauseAfterUnchanged` consecutive heartbeats. Status stays
+   * `pending`. Cleared by POST /commitments/:id/resume (or by a "keep watching"
+   * Telegram reply on the same topic).
+   */
+  beaconPaused?: boolean;
+  /** Reason accompanying `beaconPaused` (e.g. `"auto-paused-no-progress"`). */
+  beaconPausedReason?: string;
+  /** When the beacon was paused (ISO). */
+  beaconPausedAt?: string;
+  /**
+   * Number of consecutive unchanged-snapshot heartbeats before auto-pausing.
+   * Default 12 (≈2h at 10-min cadence). 0 disables auto-pause.
+   */
+  beaconAutoPauseAfterUnchanged?: number;
+  /**
+   * Snapshot of the unchanged-streak length at the pause boundary, written
+   * only when the beacon auto-pauses or when /resume zeroes it. Hot-state
+   * (in PromiseBeacon's per-id JSON) is authoritative during a live run;
+   * this cold-state field exists for dashboard / API observability of paused
+   * beacons. Not updated on every heartbeat to avoid serialized-write
+   * amplification on the mutate queue.
+   */
+  consecutiveUnchanged?: number;
 }
 
 export interface CommitmentStore {
@@ -449,6 +474,33 @@ export class CommitmentTracker extends EventEmitter {
     console.log(`[CommitmentTracker] Withdrawn ${id}: ${reason}`);
     this.emit('withdrawn', updated);
     return true;
+  }
+
+  /**
+   * Resume a paused beacon. Clears `beaconPaused`/`beaconPausedReason`/
+   * `beaconPausedAt` and resets `consecutiveUnchanged` to zero. The caller
+   * (PromiseBeacon) re-schedules on the `resumed` event.
+   *
+   * Returns the updated commitment, or null if not found or not in a
+   * resumable state (terminal status, or not paused).
+   */
+  resume(id: string): Commitment | null {
+    const existing = this.store.commitments.find(c => c.id === id);
+    if (!existing) return null;
+    if (['verified', 'violated', 'expired', 'withdrawn', 'delivered'].includes(existing.status)) {
+      return null;
+    }
+    if (!existing.beaconPaused) return null;
+    const updated = this.mutateSync(id, c => ({
+      ...c,
+      beaconPaused: false,
+      beaconPausedReason: undefined,
+      beaconPausedAt: undefined,
+      consecutiveUnchanged: 0,
+    }));
+    console.log(`[CommitmentTracker] Resumed ${id}`);
+    this.emit('resumed', updated);
+    return updated;
   }
 
   /**

--- a/src/monitoring/PromiseBeacon.ts
+++ b/src/monitoring/PromiseBeacon.ts
@@ -104,6 +104,13 @@ export interface PromiseBeaconConfig {
    * Spec Round 3 #2. Default: 20.
    */
   maxActiveBeacons?: number;
+  /**
+   * Default cycle count for auto-pause when a commitment doesn't specify
+   * `beaconAutoPauseAfterUnchanged`. At default 10-min cadence, 12 cycles
+   * ≈ 2 hours of silence before the beacon stops firing. Set to 0 to
+   * disable globally. Default 12.
+   */
+  defaultAutoPauseAfterUnchanged?: number;
 }
 
 interface HotState {
@@ -159,6 +166,28 @@ function sha256(s: string): string {
   return crypto.createHash('sha256').update(s).digest('hex');
 }
 
+/**
+ * Build a short promise-text excerpt to suffix on heartbeat messages so the
+ * user can tell *which* watched promise this heartbeat is about.
+ *
+ * Prefers `agentResponse` (what the agent actually said it would do),
+ * falls back to `userRequest`. Strips newlines, collapses whitespace,
+ * truncates with an ellipsis at ~80 chars on a word boundary.
+ *
+ * Returns an empty string if no usable text is available (defensive only —
+ * a commitment without either field is malformed).
+ */
+function promiseExcerpt(c: Pick<Commitment, 'agentResponse' | 'userRequest'>): string {
+  const raw = (c.agentResponse || c.userRequest || '').replace(/\s+/g, ' ').trim();
+  if (!raw) return '';
+  const MAX = 80;
+  if (raw.length <= MAX) return raw;
+  const cut = raw.slice(0, MAX);
+  const lastSpace = cut.lastIndexOf(' ');
+  const boundary = lastSpace > 40 ? lastSpace : MAX;
+  return cut.slice(0, boundary) + '…';
+}
+
 // Cap tmux capture (spec #16b).
 function capOutput(raw: string, maxBytes = 4096, maxLines = 200): string {
   const lines = raw.split('\n').slice(-maxLines);
@@ -182,6 +211,7 @@ export class PromiseBeacon extends EventEmitter {
   private timerMult: number;
   private now: () => number;
   private maxActiveBeacons: number;
+  private defaultAutoPauseAfterUnchanged: number;
 
   constructor(config: PromiseBeaconConfig) {
     super();
@@ -192,6 +222,7 @@ export class PromiseBeacon extends EventEmitter {
     this.timerMult = config.__dev_timerMultiplier ?? 1.0;
     this.now = config.now ?? (() => Date.now());
     this.maxActiveBeacons = config.maxActiveBeacons ?? 20;
+    this.defaultAutoPauseAfterUnchanged = config.defaultAutoPauseAfterUnchanged ?? 12;
     this.stateDir = path.join(config.stateDir, 'state', 'promise-beacon');
     try { fs.mkdirSync(this.stateDir, { recursive: true }); } catch { /* ok */ }
   }
@@ -244,6 +275,16 @@ export class PromiseBeacon extends EventEmitter {
     this.config.commitmentTracker.on('withdrawn', (c: Commitment) => {
       this.stopFor(c.id);
     });
+    // Re-arm when a paused beacon is resumed via API / Telegram intent.
+    this.config.commitmentTracker.on('resumed', (c: Commitment) => {
+      if (c.beaconEnabled && c.status === 'pending' && c.topicId) {
+        // Reset the hot-state counter so the resumed run starts fresh.
+        const hot = this.loadHotState(c.id);
+        hot.consecutiveUnchanged = 0;
+        this.saveHotState(c.id, hot);
+        this.schedule(c);
+      }
+    });
     console.log(`[PromiseBeacon] Started (${this.prefix})`);
   }
 
@@ -268,7 +309,7 @@ export class PromiseBeacon extends EventEmitter {
   schedule(c: Commitment): void {
     if (!this.started) return;
     if (!c.topicId) return;
-    if (c.status !== 'pending' || c.beaconSuppressed) return;
+    if (c.status !== 'pending' || c.beaconSuppressed || c.beaconPaused) return;
 
     // atRisk doubles cadence (spec Round 3 #1) — softer-toned + less frequent.
     const baseCadence = c.cadenceMs ?? 10 * 60_000;
@@ -296,7 +337,7 @@ export class PromiseBeacon extends EventEmitter {
   async fire(id: string): Promise<void> {
     const c = this.config.commitmentTracker.getAll().find(x => x.id === id);
     if (!c) return;
-    if (c.status !== 'pending' || c.beaconSuppressed) return;
+    if (c.status !== 'pending' || c.beaconSuppressed || c.beaconPaused) return;
     if (!c.topicId) return;
 
     // ── Ownership gate ──
@@ -350,6 +391,9 @@ export class PromiseBeacon extends EventEmitter {
       const hot = this.loadHotState(c.id);
       const unchanged = hash === hot.lastSnapshotHash;
 
+      const excerpt = promiseExcerpt(c);
+      const suffix = excerpt ? ` — re: ${excerpt}` : '';
+
       let text: string;
       let atRiskSignal = false;
       if (!snapshot || unchanged) {
@@ -358,7 +402,7 @@ export class PromiseBeacon extends EventEmitter {
         const unchangedIsAtRisk = hot.consecutiveUnchanged >= 2;
         const variants = unchangedIsAtRisk ? AT_RISK_VARIANTS : TEMPLATED_VARIANTS;
         const phrase = variants[hot.templatedVariantCursor % variants.length];
-        text = `${this.prefix} ${phrase}`;
+        text = `${this.prefix} ${phrase}${suffix}`;
         if (unchangedIsAtRisk) atRiskSignal = true;
         hot.consecutiveUnchanged += 1;
         hot.templatedVariantCursor += 1;
@@ -402,13 +446,13 @@ export class PromiseBeacon extends EventEmitter {
             }
           }
 
-          text = `${this.prefix} ${safeLine}`;
+          text = `${this.prefix} ${safeLine}${suffix}`;
           hot.consecutiveUnchanged = 0;
         } catch (err) {
           if (err instanceof LlmAbortedError || (err as Error).message.includes('cap exceeded') || (err as Error).message.includes('reserve')) {
-            text = `${this.prefix} still working (update deferred)`;
+            text = `${this.prefix} still working (update deferred)${suffix}`;
           } else {
-            text = `${this.prefix} still working (status fetch failed)`;
+            text = `${this.prefix} still working (status fetch failed)${suffix}`;
           }
         }
       }
@@ -443,6 +487,18 @@ export class PromiseBeacon extends EventEmitter {
         templated: !snapshot || unchanged,
         atRisk: atRiskSignal,
       });
+
+      // ── Auto-pause gate ───────────────────────────────────────────
+      // After enough consecutive unchanged-snapshot heartbeats, emit one
+      // final "auto-paused" message and stop firing. Non-terminal: status
+      // stays `pending`; resume via POST /commitments/:id/resume or a
+      // "keep watching" reply on the same topic.
+      const threshold = c.beaconAutoPauseAfterUnchanged ?? this.defaultAutoPauseAfterUnchanged;
+      const isUnchangedThisCycle = !snapshot || unchanged;
+      if (threshold > 0 && isUnchangedThisCycle && hot.consecutiveUnchanged >= threshold) {
+        await this.autoPause(c, excerpt);
+        return; // do NOT re-arm
+      }
     } finally {
       this.config.proxyCoordinator.release(c.topicId, 'promise-beacon');
     }
@@ -450,6 +506,38 @@ export class PromiseBeacon extends EventEmitter {
     // Re-arm.
     const next = this.config.commitmentTracker.getAll().find(x => x.id === id);
     if (next) this.schedule(next);
+  }
+
+  /**
+   * Auto-pause a beacon after a run of unchanged heartbeats. Emits one final
+   * user-visible line telling them how to resume, mutates the commitment to
+   * set `beaconPaused`, and clears the timer. Non-terminal: status stays
+   * `pending`. Resume re-arms via the `resumed` event handler.
+   */
+  private async autoPause(c: Commitment, excerpt: string): Promise<void> {
+    const suffix = excerpt ? ` — re: ${excerpt}` : '';
+    const finalText = `${this.prefix} auto-paused after long quiet${suffix}\nReply "keep watching" on this topic to resume.`;
+    try {
+      await this.config.sendMessage(c.topicId!, finalText, {
+        source: 'promise-beacon',
+        isProxy: true,
+        tier: 1,
+      });
+    } catch (err) {
+      console.warn(`[PromiseBeacon] auto-pause send failed for ${c.id}:`, (err as Error).message);
+    }
+    const hot = this.loadHotState(c.id);
+    await this.config.commitmentTracker.mutate(c.id, prev => ({
+      ...prev,
+      beaconPaused: true,
+      beaconPausedReason: 'auto-paused-no-progress',
+      beaconPausedAt: new Date(this.now()).toISOString(),
+      // Snapshot the streak length that triggered the pause — written ONLY
+      // at the pause boundary, not on every heartbeat (review feedback).
+      consecutiveUnchanged: hot.consecutiveUnchanged,
+    }));
+    this.stopFor(c.id);
+    this.emit('auto-paused', { id: c.id, topicId: c.topicId });
   }
 
   // ─── Internals ────────────────────────────────────────────────────────────

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -10563,6 +10563,27 @@ export function createRoutes(ctx: RouteContext): Router {
     res.json({ withdrawn: true, id: req.params.id });
   });
 
+  /**
+   * POST /commitments/:id/resume
+   * Resume a beacon that was auto-paused after a run of unchanged heartbeats.
+   * Clears `beaconPaused` / `beaconPausedReason` / `beaconPausedAt` and resets
+   * `consecutiveUnchanged`. PromiseBeacon re-arms the timer on the `resumed`
+   * event. No-op (404) for commitments that aren't paused or are in a terminal
+   * status.
+   */
+  router.post('/commitments/:id/resume', (req, res) => {
+    if (!ctx.commitmentTracker) {
+      res.status(404).json({ error: 'CommitmentTracker not configured' });
+      return;
+    }
+    const updated = ctx.commitmentTracker.resume(req.params.id);
+    if (!updated) {
+      res.status(404).json({ error: `Commitment ${req.params.id} not found, not paused, or in terminal status` });
+      return;
+    }
+    res.json({ resumed: true, id: updated.id, commitment: updated });
+  });
+
   // ── Episodic Memory (Activity Sentinel) ──────────────────────────
 
   router.get('/episodes/stats', (req, res) => {

--- a/tests/unit/PromiseBeacon-ux-fixes.test.ts
+++ b/tests/unit/PromiseBeacon-ux-fixes.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for PromiseBeacon UX fixes:
+ *  - Heartbeat messages include a "re: <promise excerpt>" suffix.
+ *  - After N consecutive unchanged-snapshot cycles, the beacon auto-pauses,
+ *    emits a single final "auto-paused — reply 'keep watching' to resume"
+ *    message, and stops firing. Status stays `pending`.
+ *  - Resume clears the paused flag, resets the counter, and re-arms.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { CommitmentTracker } from '../../src/monitoring/CommitmentTracker.js';
+import { LiveConfig } from '../../src/config/LiveConfig.js';
+import { LlmQueue } from '../../src/monitoring/LlmQueue.js';
+import { ProxyCoordinator } from '../../src/monitoring/ProxyCoordinator.js';
+import { PromiseBeacon } from '../../src/monitoring/PromiseBeacon.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function tmpState() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'promise-beacon-ux-'));
+  fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'config.json'), '{}');
+  return { dir, cleanup: () => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/PromiseBeacon-ux-fixes.test.ts:21' }) };
+}
+
+function baseTracker(dir: string) {
+  return new CommitmentTracker({ stateDir: dir, liveConfig: new LiveConfig(dir) });
+}
+
+describe('PromiseBeacon — UX fixes', () => {
+  let dir: string;
+  let cleanup: () => void;
+  beforeEach(() => { ({ dir, cleanup } = tmpState()); });
+  afterEach(() => cleanup());
+
+  it('appends a "re: <promise excerpt>" suffix to every templated heartbeat', async () => {
+    const tracker = baseTracker(dir);
+    const sent: Array<{ text: string }> = [];
+    const beacon = new PromiseBeacon({
+      stateDir: dir,
+      commitmentTracker: tracker,
+      llmQueue: new LlmQueue({ maxDailyCents: 100 }),
+      proxyCoordinator: new ProxyCoordinator(),
+      captureSessionOutput: () => 'static\noutput',
+      getSessionForTopic: () => 'sess-1',
+      isSessionAlive: () => true,
+      sendMessage: async (_topicId, text) => { sent.push({ text }); },
+      defaultAutoPauseAfterUnchanged: 0, // disable auto-pause for this test
+    });
+    beacon.start();
+
+    const c = tracker.record({
+      type: 'one-time-action',
+      userRequest: 'ship the thing',
+      agentResponse: 'Sent threadline message to luna, awaiting reply.',
+      topicId: 42,
+      beaconEnabled: true,
+      cadenceMs: 60_000,
+      nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+
+    // First fire seeds the hash; second fire hits the templated branch.
+    await beacon.fire(c.id);
+    await beacon.fire(c.id);
+
+    expect(sent.length).toBe(2);
+    expect(sent[1].text).toContain('re: Sent threadline message to luna, awaiting reply.');
+    beacon.stop();
+  });
+
+  it('auto-pauses after N consecutive unchanged-snapshot heartbeats and emits a final resume hint', async () => {
+    const tracker = baseTracker(dir);
+    const sent: Array<{ text: string }> = [];
+    const beacon = new PromiseBeacon({
+      stateDir: dir,
+      commitmentTracker: tracker,
+      llmQueue: new LlmQueue({ maxDailyCents: 100 }),
+      proxyCoordinator: new ProxyCoordinator(),
+      captureSessionOutput: () => 'identical output',
+      getSessionForTopic: () => 'sess-1',
+      isSessionAlive: () => true,
+      sendMessage: async (_topicId, text) => { sent.push({ text }); },
+      defaultAutoPauseAfterUnchanged: 3,
+    });
+    beacon.start();
+
+    const c = tracker.record({
+      type: 'one-time-action',
+      userRequest: 'watch a quiet build',
+      agentResponse: 'will keep an eye on the build',
+      topicId: 99,
+      beaconEnabled: true,
+      cadenceMs: 60_000,
+      nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+
+    // Fire enough times to cross the threshold. Each fire after the first
+    // sees an unchanged snapshot.
+    for (let i = 0; i < 6; i++) {
+      await beacon.fire(c.id);
+    }
+
+    // Last message should be the auto-pause notice.
+    const last = sent[sent.length - 1].text;
+    expect(last).toMatch(/auto-paused/i);
+    expect(last).toMatch(/keep watching/i);
+    expect(last).toContain('re: will keep an eye on the build');
+
+    // Commitment is paused but not terminal.
+    const after = tracker.getAll().find(x => x.id === c.id)!;
+    expect(after.status).toBe('pending');
+    expect(after.beaconPaused).toBe(true);
+    expect(after.beaconPausedReason).toBe('auto-paused-no-progress');
+    expect(after.beaconPausedAt).toBeDefined();
+
+    // Further fires must not produce more messages.
+    const beforeCount = sent.length;
+    await beacon.fire(c.id);
+    expect(sent.length).toBe(beforeCount);
+
+    beacon.stop();
+  });
+
+  it('resume() clears paused flag, resets counter, and emits a resumed event', async () => {
+    const tracker = baseTracker(dir);
+    const c = tracker.record({
+      type: 'one-time-action',
+      userRequest: 'x',
+      agentResponse: 'y',
+      topicId: 7,
+      beaconEnabled: true,
+      cadenceMs: 60_000,
+      nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+    // Simulate auto-pause state.
+    await tracker.mutate(c.id, prev => ({
+      ...prev,
+      beaconPaused: true,
+      beaconPausedReason: 'auto-paused-no-progress',
+      beaconPausedAt: new Date().toISOString(),
+      consecutiveUnchanged: 42,
+    }));
+
+    const events: string[] = [];
+    tracker.on('resumed', (updated) => events.push(updated.id));
+
+    const updated = tracker.resume(c.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.beaconPaused).toBeFalsy();
+    expect(updated!.beaconPausedReason).toBeUndefined();
+    expect(updated!.beaconPausedAt).toBeUndefined();
+    expect(updated!.consecutiveUnchanged).toBe(0);
+    expect(events).toEqual([c.id]);
+  });
+
+  it('resume() returns null for non-paused or terminal commitments', () => {
+    const tracker = baseTracker(dir);
+    const c = tracker.record({
+      type: 'one-time-action',
+      userRequest: 'x',
+      agentResponse: 'y',
+      topicId: 7,
+      beaconEnabled: true,
+      cadenceMs: 60_000,
+      nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+    // Not paused → null.
+    expect(tracker.resume(c.id)).toBeNull();
+
+    // Withdrawn → null even if some other state existed.
+    tracker.withdraw(c.id, 'test');
+    expect(tracker.resume(c.id)).toBeNull();
+  });
+
+  it('a resumed beacon re-arms via the resumed event handler', async () => {
+    const tracker = baseTracker(dir);
+    const beacon = new PromiseBeacon({
+      stateDir: dir,
+      commitmentTracker: tracker,
+      llmQueue: new LlmQueue({ maxDailyCents: 100 }),
+      proxyCoordinator: new ProxyCoordinator(),
+      captureSessionOutput: () => 'x',
+      getSessionForTopic: () => 'sess-1',
+      isSessionAlive: () => true,
+      sendMessage: async () => {},
+    });
+    beacon.start();
+
+    const c = tracker.record({
+      type: 'one-time-action',
+      userRequest: 'x',
+      agentResponse: 'y',
+      topicId: 11,
+      beaconEnabled: true,
+      cadenceMs: 60_000,
+      nextUpdateDueAt: '2099-01-01T00:00:00Z',
+    });
+    // Put it into paused state directly.
+    await tracker.mutate(c.id, prev => ({ ...prev, beaconPaused: true, beaconPausedReason: 'auto-paused-no-progress' }));
+    beacon.stopFor(c.id);
+    expect(beacon.getScheduledIds()).not.toContain(c.id);
+
+    tracker.resume(c.id);
+    // Resume event handler must have re-armed the timer.
+    expect(beacon.getScheduledIds()).toContain(c.id);
+
+    beacon.stop();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,55 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+PromiseBeacon's heartbeat messages used to give the user no idea what was being tracked ("still working — snapshot unchanged since last beat") and ran forever even when nothing was changing, producing extended runs of context-free hourglass spam on Telegram. This release fixes three things:
+
+- Every heartbeat now appends a `re: <promise excerpt>` suffix so the user can see which watched promise it's about.
+- Beacons auto-pause after a run of consecutive unchanged-snapshot heartbeats (default 12 cycles, ≈2h at 10-min cadence). When the threshold is hit, the beacon emits one final "auto-paused after long quiet — reply 'keep watching' on this topic to resume" message and stops firing. Status stays `pending` — this is non-terminal suppression, not delivery or violation. New optional Commitment fields: `beaconPaused`, `beaconPausedReason`, `beaconPausedAt`, `beaconAutoPauseAfterUnchanged`, `consecutiveUnchanged`.
+- New endpoint `POST /commitments/:id/resume` clears the paused flags and resets the counter; PromiseBeacon re-arms on the `resumed` event. A literal "keep watching" detector in the Telegram inbound path calls this endpoint for any paused beacons on the originating topic and now reports per-call success ("⏳ resumed N watchers", "⏳ resumed X of Y watchers", or "⚠️ couldn't resume — try again").
+
+Honors PROMISE-BEACON-SPEC.md line 161 ("suggest, don't auto-close"): this is auto-pause, not auto-delivery — `status` stays `pending` and the beacon can be resumed at any time.
+
+## What to Tell Your User
+
+- "I'll now tell you what I'm tracking in every progress update, instead of just saying 'still working'."
+- "If a watcher goes silent for too long with no change, I'll send one last note and stop pestering you. Reply 'keep watching' on that topic and I'll pick it back up."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Heartbeat shows which promise is being tracked | automatic |
+| Beacon auto-pauses after extended silence | automatic (default 12 unchanged cycles) |
+| Resume a paused beacon | `POST /commitments/:id/resume` or reply "keep watching" on the topic |
+
+## Evidence
+
+<!-- REQUIRED if this release claims to fix a bug. -->
+<!-- Unit tests passing is NOT evidence. Provide ONE of: -->
+<!--   (a) Reproduction steps + observed before/after on a live system. -->
+<!--       Include log excerpts, observed command output, or behavior -->
+<!--       description. Make it specific enough that a future reader can -->
+<!--       re-run it and see the same thing. -->
+<!--   (b) "Not reproducible in dev — [concrete reason]" if the failure -->
+<!--       mode truly can't be exercised locally (race conditions, -->
+<!--       event-driven paths requiring external signals, etc). -->
+<!--                                                                 -->
+<!-- If this release doesn't claim a bug fix (pure feature / refactor), -->
+<!-- leave this section blank or delete it — it's only enforced when -->
+<!-- "What Changed" describes a fix. -->
+
+**Reproduction (live):** Telegram topic 9210 ("threadline dev") on the echo agent. Three commitments (CMT-381, CMT-382, CMT-383) were detected by CommitmentSentinel after three separate threadline-send actions over ~28 minutes; each one became a beacon-enabled commitment with `agentResponse` "Sent threadline message to <recipient>, awaiting reply." All three fired heartbeats independently on the default 10-min cadence. tmux output was idle, so every heartbeat hit the unchanged-snapshot branch and rotated through `TEMPLATED_VARIANTS` then `AT_RISK_VARIANTS`, producing ~30+ context-free hourglass messages between 18:35 and 19:55. None of the messages identified which commitment they were about. Withdrawn via `POST /commitments/:id/withdraw` to stop the spam.
+
+**Fix verification (unit):** New test file `tests/unit/PromiseBeacon-ux-fixes.test.ts` covers the three failure modes the live reproduction exposed:
+- `appends a "re: <promise excerpt>" suffix to every templated heartbeat` — passes; the heartbeat text contains the truncated `agentResponse`.
+- `auto-pauses after N consecutive unchanged-snapshot heartbeats and emits a final resume hint` — passes; with threshold=3, the 4th unchanged-snapshot heartbeat emits the auto-pause message and subsequent fires emit nothing.
+- `a resumed beacon re-arms via the resumed event handler` — passes; calling `tracker.resume(id)` re-arms PromiseBeacon's timer via the new `resumed` event.
+
+**Fix verification (live, post-merge):** will be performed by enabling beaconEnabled on a fresh test commitment on a quiet topic and confirming (a) the heartbeat text contains the promise excerpt, (b) the beacon auto-pauses after the configured threshold, (c) replying "keep watching" on the topic resumes it. Reported in the release notes for the next version after merge.

--- a/upgrades/side-effects/promise-beacon-ux-fixes.md
+++ b/upgrades/side-effects/promise-beacon-ux-fixes.md
@@ -1,0 +1,146 @@
+<!--
+  Side-Effects Review — PromiseBeacon UX fixes
+  Phase 4 artifact for /instar-dev pass on echo/promise-beacon-ux-fixes.
+-->
+
+# Side-Effects Review — PromiseBeacon UX fixes
+
+**Version / slug:** `promise-beacon-ux-fixes`
+**Date:** `2026-05-12`
+**Author:** `echo`
+**Second-pass reviewer:** `pending`
+
+## Summary of the change
+
+PromiseBeacon's heartbeat templates ("still working — snapshot unchanged since last beat") gave the user no context about which promise was being watched, and heartbeats ran forever even when nothing was changing. Three commitments stacked on the same Telegram topic produced ~30+ context-free "no observable progress" messages over an evening with no way to stop them short of opening the dashboard. This change:
+
+1. Includes a truncated form of the promise text in every heartbeat so the user can see what's being tracked.
+2. Adds an auto-pause: after N consecutive unchanged-snapshot heartbeats (default N=12, ~2h at 10-min cadence), the beacon emits one final "auto-paused — reply 'keep watching' to resume" message and stops firing. Non-terminal; status stays `pending`.
+3. Adds `POST /commitments/:id/resume` and a literal "keep watching" detector in the Telegram inbound path that calls it for any paused beacon on the originating topic.
+
+Files touched:
+- `src/monitoring/CommitmentTracker.ts` — new optional schema fields (`beaconPaused`, `beaconPausedReason`, `beaconPausedAt`, `beaconAutoPauseAfterUnchanged`, `consecutiveUnchanged`); `resume(id)` method.
+- `src/monitoring/PromiseBeacon.ts` — promise-text excerpt in heartbeat composition; consecutive-unchanged counter; auto-pause flow; paused-state gate in `fire` and `schedule`.
+- `src/server/routes.ts` — `POST /commitments/:id/resume`.
+- `src/commands/server.ts` — extend `telegram.onMessageLogged` with literal "keep watching" detector that calls the resume endpoint.
+- Tests: new files under `tests/unit/` and `tests/integration/`.
+
+Decision points the change interacts with:
+- PromiseBeacon's heartbeat composition path (template selection, LLM call gating).
+- PromiseBeacon's scheduling path (timer arming, suppression checks).
+- Commitment lifecycle (new non-terminal state combination: `pending + beaconPaused`).
+- Telegram inbound path (new literal-match detector that triggers a server-side action).
+
+## Decision-point inventory
+
+- `PromiseBeacon.fire` heartbeat-template selection — **modify** — adds promise-text prefix to every template; adds auto-pause branch.
+- `PromiseBeacon.schedule` arming guard — **modify** — skips arming when `beaconPaused`.
+- `CommitmentTracker.resume(id)` — **add** — non-terminal flag clear + counter reset.
+- `POST /commitments/:id/resume` — **add** — API entrypoint for resume.
+- Telegram `onMessageLogged` literal-match — **add** — produces resume signal that calls the new endpoint.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The auto-pause has no block/allow surface — it stops outbound heartbeats from this agent, doesn't reject inputs. Strictly speaking it could "over-stop" if the user genuinely wanted updates on a long-running silent process. Mitigation: the final pause message tells the user how to resume; the resume path itself is idempotent.
+
+The "keep watching" detector uses literal substring match (`/keep[\s-]?watching/i`). False positives:
+- A user typing "I want to keep watching the build logs" while not intending to resume a beacon. Cost: a paused beacon resumes; user gets one more heartbeat and can re-pause by ignoring it (it'll auto-pause again after N cycles) or by withdrawing the commitment.
+- Whichever paused beacons exist on the topic all resume simultaneously, not selectively. Cost: minor; same recovery path.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- The literal detector won't match paraphrases ("keep an eye on it", "stay on it", "don't give up"). Intentional: per signal-vs-authority, a brittle detector with blocking authority is forbidden. The detector is structurally simple by design. The final auto-pause message tells the user the exact phrase to use.
+- If the user wants to resume one specific paused beacon out of many, this implementation resumes all paused beacons on the topic. A future iteration could accept "keep watching <commitment-id>".
+- The auto-pause counter is per-commitment; multiple beacons on the same topic still produce N heartbeats each before pausing. The total heartbeat volume on a topic is not bounded by this change — only the per-beacon volume.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The auto-pause counter belongs in PromiseBeacon — it's the only thing that knows the snapshot-hash and the consecutive-unchanged history. Putting it elsewhere would require lifting that state up.
+
+The resume endpoint mirrors the existing `/deliver` and `/withdraw` endpoints on `/commitments/:id` — it's at the same layer as those, which is correct.
+
+The Telegram "keep watching" detector lives in `server.ts`'s existing `onMessageLogged` extension because that's where every inbound message is observed once already (for PresenceProxy + TopicMemory). Adding a third small hook there is cheaper than building a new fan-out point. The detector itself is brittle by design (regex), but it only produces a signal — the resume endpoint is the authority for whether to act.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — the brittle parts (counter, regex) hold no blocking authority over messages or behavior. The counter triggers a structural state transition (pause); the regex triggers a structural state transition (resume). Neither blocks or modifies an inbound user message.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic.
+
+The auto-pause counter is mechanics, not judgment (signal-vs-authority §"When this principle does NOT apply" — "Idempotency keys and dedup at the transport layer... not a judgment call — it's mechanics"). It counts identical snapshot hashes; that's a structural fact.
+
+The "keep watching" detector is a brittle regex that calls a structural API. The API itself is symmetric with `/withdraw` — idempotent, no judgment, just toggles state. A false positive resumes a paused beacon, which costs one more heartbeat and re-pauses if still idle. No message is blocked, filtered, or rejected; no agent behavior is constrained beyond the toggle.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The auto-pause check sits inside `PromiseBeacon.fire` after the existing suppression/ownership/quiet-hours checks. It runs only when those passed and templated-unchanged branch was taken. It does not shadow `beaconSuppressed` (which is for boot-cap / spend-cap, distinct semantics) — `beaconPaused` is a new orthogonal non-terminal flag with `resolved-by` `/resume` (not by the existing suppression-clear path).
+- **Double-fire:** The "keep watching" detector lives inside the same `onMessageLogged` callback chain that already feeds PresenceProxy. Calling the resume endpoint enqueues a single mutate operation per matched commitment; no duplicate timers are created because `schedule()` clears any existing timer before arming.
+- **Races:** Concurrent withdraw + resume on the same commitment: the existing `mutate(id, fn)` queue serializes writes; resume is rejected by `mutate` if the commitment is already terminal (withdrawn).
+- **Feedback loops:** Resume → fire → snapshot unchanged → counter increments → re-pauses after N cycles. This is the intended steady state when a watched task is genuinely idle; the user can resume again. There is no autonomous loop that re-resumes itself.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** No. PromiseBeacon state is per-agent.
+- **Other users of the install base:** Yes — every instar agent ships with PromiseBeacon. After this change, every install gets the new heartbeat text format, the auto-pause behavior, and the Telegram resume detector. The new endpoint is additive (no behavior change for callers that don't use it).
+- **External systems:** The Telegram messages emitted change format (now include promise text). Anyone tooling against the exact "still working — snapshot unchanged since last beat" string would break; we know of no such consumer outside test fixtures.
+- **Persistent state:** Three new optional fields on the Commitment schema. Forward-compatible: missing fields default to "not paused, counter at zero, threshold default 12." Existing commitments load cleanly without migration.
+- **Timing / runtime:** The 12-cycle threshold at default 10-min cadence yields ~2-hour silence before auto-pause. Tunable per-commitment via `beaconAutoPauseAfterUnchanged`. Quiet hours and boot-cap interactions unchanged.
+
+---
+
+## 7. Rollback cost
+
+Pure code change. Schema additions are optional. Revert the commit and ship the next patch — existing agents will continue to use whatever schema they had; new fields are simply ignored. No data migration. No agent state repair. Users see the previous (broken) UX again until a roll-forward fix; not a regression in correctness, only in UX.
+
+---
+
+## Conclusion
+
+The change addresses the user-reported spam directly: heartbeats now say what they're tracking, beacons stop themselves after extended silence, and the user can resume them from Telegram. The signal-vs-authority principle is honored: the brittle parts (counter, regex) only trigger structural state transitions, never block or judge messages. Schema additions are backward-compatible and rollback is a code revert. Clear to ship after Phase 5 second-pass review (required: change touches outbound messaging composition and commitment lifecycle).
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** echo (Phase-5 independent pass)
+**Independent read of the artifact: concern → resolved**
+
+Concerns raised, with resolutions:
+
+- **Misleading resume ack on failure.** In `src/commands/server.ts` the "keep watching" handler `await`ed `fetch` to `/commitments/:id/resume` inside a `try`/`catch` that only `console.warn`'d on throw, never checked the HTTP response, and then unconditionally posted `⏳ resumed N watcher(s) on this topic.` to the user. A 404 (not paused / terminal), a 5xx, or a thrown fetch (server restart, partial outage) would all result in the user being told the beacon resumed when it did not.
+  **Fix applied:** the handler now inspects `response.ok` per call, counts successes, and tailors the ack: `⏳ resumed N watcher(s)` on full success, `⏳ resumed X of Y watchers — N didn't resume` on partial success, `⚠️ couldn't resume the watcher(s) on this topic — try again or open the dashboard` on total failure or fetch throw.
+- **Cold-mirror write of `consecutiveUnchanged` had no consumer.** The cold mirror was written every fire but never consulted by `fire()` or the threshold check (which uses `hot.consecutiveUnchanged`). Write amplification on the CAS queue with no benefit and a footgun for a future reader.
+  **Fix applied:** dropped the per-cycle cold write. The field is now written only at the pause boundary (with a comment in `autoPause()`) and on resume (set to 0). The schema field carries a docstring marking it as a non-authoritative observability mirror — hot-state is authoritative during a live run.
+
+Lower-priority observations (not blocking):
+- Over-match on "keep watching": "I'll keep watching the build logs", "good — keep watching for the alert" both resume any paused beacons on the topic. Cost is bounded (one more heartbeat, re-pauses) and matches the artifact's analysis. Acceptable.
+- `beaconSuppressed` × `beaconPaused` interaction: traced through — `fire()` early-exits on `beaconSuppressed` before reaching the auto-pause branch, so the two flags are mutually exclusive within a single fire. `schedule()` correctly rejects when either is set. No race.
+- Backwards-compat for existing commitments: `hot.consecutiveUnchanged` initializes to 0 in `loadHotState`'s defaults block (not undefined/NaN), and `beaconAutoPauseAfterUnchanged ?? defaultAutoPauseAfterUnchanged` falls back cleanly. Confirmed safe.
+- Spec line 161 ("suggest, don't auto-close"): this change is auto-PAUSE (`status` stays `pending`, resumable, no delivery semantics). Does not violate.
+
+---
+
+## Evidence pointers
+
+- Originating user report: Telegram topic 9429 ("progress update bug"), 2026-05-12.
+- Withdrawn runaway commitments providing the live reproduction: CMT-381, CMT-382, CMT-383 on topic 9210.
+- Spec extended (not violated): docs/specs/PROMISE-BEACON-SPEC.md (auto-pause is a new non-terminal suppression; auto-close-on-reply explicitly NOT added per spec line 161).


### PR DESCRIPTION
## Summary

- Heartbeats now say *what* is being tracked: append `re: <promise excerpt>` to every message so users aren't staring at context-free "still working" lines.
- Beacons auto-pause after a run of consecutive unchanged-snapshot heartbeats (default 12 ≈ 2h), emit one final "reply 'keep watching' to resume" message, and stop firing. Non-terminal — status stays `pending`.
- New `POST /commitments/:id/resume` + Telegram literal-match "keep watching" detector that calls it. Per-call success reported back to the user.

Honors PROMISE-BEACON-SPEC.md line 161 (auto-pause is non-terminal suppression, not auto-delivery).

Live repro: Telegram topic 9210 on echo. Three "Sent threadline message, awaiting reply" commitments stacked and produced 30+ context-free hourglass messages between 18:35 and 19:55. Withdrawn via API to stop the spam; reported by the user via topic 9429.

Side-effects artifact: `upgrades/side-effects/promise-beacon-ux-fixes.md` — independent Phase-5 reviewer raised two concerns (misleading resume ack, no-consumer cold-mirror write), both addressed in-PR.

## Test plan

- [x] `tests/unit/PromiseBeacon-ux-fixes.test.ts` — 5 new tests, all passing
- [x] Existing PromiseBeacon suite (3 files, 8 tests) — no regressions
- [x] Existing CommitmentTracker suite (2 files, 83 tests) — no regressions
- [x] Existing PresenceProxy / CommitmentSentinel sanity — no regressions
- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] Live verification post-merge: enable beaconEnabled on a fresh test commitment, confirm (a) heartbeat contains promise excerpt, (b) auto-pause fires at threshold, (c) "keep watching" reply resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)