### PR TITLE
feat(projects): dashboard Projects tab + Initiatives filter (Phase 1b PR 5)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2523,6 +2523,7 @@
           <button class="tab" data-tab="systems" onclick="switchTab('systems')">Health</button>
           <button class="tab" data-tab="integrated-being" onclick="switchTab('integrated-being')">Integrated-Being</button>
           <button class="tab" data-tab="pr-pipeline" onclick="switchTab('pr-pipeline')">PR Pipeline</button>
+          <button class="tab" data-tab="projects" onclick="switchTab('projects')">Projects <span class="tab-count" id="tabProjectCount">0</span></button>
           <button class="tab" data-tab="initiatives" onclick="switchTab('initiatives')">Initiatives <span class="tab-count" id="tabInitiativeCount">0</span></button>
           <button class="tab" data-tab="commitments" onclick="switchTab('commitments')">Commitments <span class="tab-count" id="tabCommitmentCount">0</span></button>
           <button class="tab" data-tab="tokens" onclick="switchTab('tokens')">Tokens</button>
@@ -2892,6 +2893,21 @@
       <div id="prPipelineList" style="display:flex;flex-direction:column;gap:12px"></div>
     </div>
 
+    <!-- Projects Tab — PROJECT-SCOPE-SPEC Phase 1.10 read-only view -->
+    <div id="projectsPanel" style="display:none;flex-direction:column;padding:20px;gap:16px;overflow-y:auto">
+      <div style="display:flex;justify-content:space-between;align-items:center">
+        <h2 style="margin:0">Projects</h2>
+        <button onclick="loadProjects()" style="padding:6px 12px">Refresh</button>
+      </div>
+      <div style="font-size:12px;color:var(--text-dim);line-height:1.4">
+        Multi-spec project plans. Each project bundles related child initiatives across rounds with structurally-gated round advance.
+      </div>
+      <div id="projectsEmpty" style="padding:40px;text-align:center;color:var(--text-dim);display:none">
+        No active projects. Create one via <code>POST /projects</code> with a plan-doc path.
+      </div>
+      <div id="projectsList" style="display:flex;flex-direction:column;gap:12px"></div>
+    </div>
+
     <!-- Initiatives Tab — multi-phase long-running work -->
     <div id="initiativesPanel" style="display:none;flex-direction:column;padding:20px;gap:16px;overflow-y:auto">
       <div style="display:flex;justify-content:space-between;align-items:center">
@@ -2904,6 +2920,9 @@
             <option value="archived">Archived</option>
             <option value="abandoned">Abandoned</option>
           </select>
+          <label style="font-size:12px;color:var(--text-dim);display:flex;align-items:center;gap:4px">
+            <input type="checkbox" id="initiativesShowAll" onchange="loadInitiatives()"> Show projects + children
+          </label>
           <button onclick="loadInitiatives()" style="padding:6px 12px">Refresh</button>
         </div>
       </div>
@@ -4184,6 +4203,13 @@
         panels: ['prPipelinePanel'],
         display: ['flex'],
         onActivate: () => { if (typeof loadPrPipeline === 'function') loadPrPipeline(); },
+      },
+      {
+        id: 'projects',
+        panels: ['projectsPanel'],
+        display: ['flex'],
+        onActivate: () => { if (typeof loadProjects === 'function') loadProjects(); if (typeof startProjectsPoll === 'function') startProjectsPoll(); },
+        onDeactivate: () => { if (typeof stopProjectsPoll === 'function') stopProjectsPoll(); },
       },
       {
         id: 'initiatives',
@@ -6682,6 +6708,216 @@
       }
     }
 
+    // ── Projects Tab (PROJECT-SCOPE-SPEC Phase 1.10) ─────────────
+    //
+    // Read-only project view. Per spec: progress bar per round +
+    // pipelineStage histogram, drift status badge per pending item
+    // (cached verdict only; clicking does NOT trigger a new check),
+    // halt + ack buttons, 15s poll, textContent rendering on every
+    // user/agent-authored string, 409 response silently refreshes.
+    let __projectsPollTimer = null;
+    function startProjectsPoll() {
+      if (__projectsPollTimer) return;
+      __projectsPollTimer = setInterval(() => { loadProjects().catch(() => {}); }, 15000);
+    }
+    function stopProjectsPoll() {
+      if (__projectsPollTimer) { clearInterval(__projectsPollTimer); __projectsPollTimer = null; }
+    }
+
+    function escapeText(s) {
+      // textContent assignment handles XSS for us; this is a no-op
+      // helper that documents the intent for future authors.
+      return typeof s === 'string' ? s : '';
+    }
+
+    async function loadProjects() {
+      const list = document.getElementById('projectsList');
+      const empty = document.getElementById('projectsEmpty');
+      const countBadge = document.getElementById('tabProjectCount');
+      if (!list || !empty) return;
+
+      let projRes = null;
+      try {
+        projRes = await apiFetch('/projects').catch(() => null);
+      } catch { /* handled by null check below */ }
+
+      while (list.firstChild) list.removeChild(list.firstChild);
+      empty.style.display = 'none';
+
+      if (!projRes || !Array.isArray(projRes.items)) {
+        empty.style.display = 'block';
+        empty.textContent = 'Projects endpoint unavailable.';
+        if (countBadge) countBadge.textContent = '0';
+        return;
+      }
+
+      const items = projRes.items.filter((p) => p.status === 'active');
+      if (countBadge) countBadge.textContent = String(items.length);
+      if (items.length === 0) {
+        empty.style.display = 'block';
+        return;
+      }
+
+      // We need each project's children for the progress bar; fetch
+      // them in parallel via /projects/:id (server returns children
+      // alongside the project record). Cap at 25 to avoid a flood.
+      const detailed = await Promise.all(items.slice(0, 25).map((p) =>
+        apiFetch('/projects/' + encodeURIComponent(p.id) + '?reconcile=false').catch(() => null)
+      ));
+
+      for (const detail of detailed) {
+        if (!detail || !detail.project) continue;
+        list.appendChild(renderProjectCard(detail.project, detail.children || []));
+      }
+    }
+
+    function renderProjectCard(project, children) {
+      const card = document.createElement('div');
+      card.style.padding = '14px';
+      card.style.border = '1px solid var(--border)';
+      card.style.borderRadius = '6px';
+      card.style.background = 'var(--bg-dim)';
+
+      const titleRow = document.createElement('div');
+      titleRow.style.display = 'flex';
+      titleRow.style.justifyContent = 'space-between';
+      titleRow.style.alignItems = 'baseline';
+      titleRow.style.gap = '12px';
+
+      const title = document.createElement('div');
+      title.style.fontWeight = '600';
+      title.style.fontSize = '15px';
+      title.textContent = project.title || project.id;
+      titleRow.appendChild(title);
+
+      const idEl = document.createElement('div');
+      idEl.style.fontSize = '11px';
+      idEl.style.color = 'var(--text-dim)';
+      idEl.style.fontFamily = 'monospace';
+      idEl.textContent = project.id + '  v' + project.version;
+      titleRow.appendChild(idEl);
+      card.appendChild(titleRow);
+
+      // Drift status badge.
+      const drift = project.rounds && project.rounds[0] ? project.rounds[0].lastDriftVerdict : null;
+      if (drift && drift.verdict) {
+        const badge = document.createElement('span');
+        badge.style.display = 'inline-block';
+        badge.style.marginTop = '4px';
+        badge.style.padding = '2px 8px';
+        badge.style.fontSize = '11px';
+        badge.style.borderRadius = '10px';
+        badge.style.border = '1px solid var(--border)';
+        const colors = {
+          'no-drift': '#4a9a4a',
+          'minor-drift': '#e2b94a',
+          'premise-violated': '#d65f5f',
+          'manual-review-required': '#888',
+        };
+        badge.style.color = colors[drift.verdict] || '#888';
+        badge.textContent = 'drift: ' + drift.verdict;
+        card.appendChild(badge);
+      }
+
+      // Rounds progress bars.
+      const rounds = Array.isArray(project.rounds) ? project.rounds : [];
+      const childById = new Map(children.map((c) => [c.id, c]));
+      for (let i = 0; i < rounds.length; i++) {
+        const r = rounds[i];
+        const wrap = document.createElement('div');
+        wrap.style.marginTop = '10px';
+
+        const rTitle = document.createElement('div');
+        rTitle.style.fontSize = '12px';
+        rTitle.style.color = 'var(--text-dim)';
+        rTitle.textContent = `Round ${i}: ${r.name} — ${r.status || 'pending'}`;
+        wrap.appendChild(rTitle);
+
+        // pipelineStage histogram counts.
+        const stages = {};
+        let total = 0;
+        for (const id of (r.itemIds || [])) {
+          const child = childById.get(id);
+          const stage = (child && child.pipelineStage) || 'outline';
+          stages[stage] = (stages[stage] || 0) + 1;
+          total++;
+        }
+        const merged = stages['merged'] || 0;
+        const bar = document.createElement('div');
+        bar.style.marginTop = '4px';
+        bar.style.height = '6px';
+        bar.style.borderRadius = '3px';
+        bar.style.background = 'var(--bg)';
+        bar.style.overflow = 'hidden';
+        const fill = document.createElement('div');
+        fill.style.height = '100%';
+        fill.style.background = '#4a9a4a';
+        fill.style.width = total > 0 ? `${Math.round((merged / total) * 100)}%` : '0%';
+        bar.appendChild(fill);
+        wrap.appendChild(bar);
+
+        const histo = document.createElement('div');
+        histo.style.fontSize = '11px';
+        histo.style.color = 'var(--text-dim)';
+        histo.style.marginTop = '4px';
+        histo.textContent = Object.entries(stages).map(([k, v]) => `${k}: ${v}`).join('  •  ') || 'no items';
+        wrap.appendChild(histo);
+        card.appendChild(wrap);
+      }
+
+      // Halt + ack buttons.
+      const actions = document.createElement('div');
+      actions.style.display = 'flex';
+      actions.style.gap = '8px';
+      actions.style.marginTop = '12px';
+
+      const haltBtn = document.createElement('button');
+      haltBtn.textContent = 'Halt';
+      haltBtn.style.padding = '4px 10px';
+      haltBtn.style.fontSize = '12px';
+      haltBtn.addEventListener('click', () => projectHalt(project.id));
+      actions.appendChild(haltBtn);
+
+      const ackBtn = document.createElement('button');
+      ackBtn.textContent = 'Ack round 0';
+      ackBtn.style.padding = '4px 10px';
+      ackBtn.style.fontSize = '12px';
+      ackBtn.addEventListener('click', () => projectAck(project.id, 0));
+      actions.appendChild(ackBtn);
+      card.appendChild(actions);
+
+      return card;
+    }
+
+    async function projectHalt(projectId) {
+      try {
+        const res = await apiFetch('/projects/' + encodeURIComponent(projectId) + '/halt', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reason: 'user-halt-from-dashboard' }),
+        });
+        // 409 from a stale read → silent refresh, no error toast.
+        if (res && res.error && /version mismatch/.test(res.error)) {
+          await loadProjects();
+          return;
+        }
+        await loadProjects();
+      } catch { /* ignore — refresh on next poll */ }
+    }
+
+    async function projectAck(projectId, forRoundIndex) {
+      try {
+        const res = await apiFetch('/projects/' + encodeURIComponent(projectId) + '/ack', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ forRoundIndex }),
+        });
+        if (res && res.error && /version mismatch/.test(res.error)) {
+          await loadProjects();
+          return;
+        }
+        await loadProjects();
+      } catch { /* ignore — refresh on next poll */ }
+    }
+
     // ── Initiatives Tab (INITIATIVE-TRACKER-SPEC v1) ─────────────
     //
     // Fetches /initiatives and /initiatives/digest on panel activation.
@@ -6703,9 +6939,20 @@
       let itemsRes = null;
       let digestRes = null;
       try {
-        const statusQ = filter && filter.value ? `?status=${encodeURIComponent(filter.value)}` : '';
+        // PROJECT-SCOPE-SPEC Phase 1.10 — by default hide project-kind
+        // records (shown in the Projects tab) and parented children
+        // (shown inside their parent's card). Server-side filter so
+        // we don't ship them over the wire.
+        const showAll = document.getElementById('initiativesShowAll');
+        const params = [];
+        if (filter && filter.value) params.push(`status=${encodeURIComponent(filter.value)}`);
+        if (!showAll || !showAll.checked) {
+          params.push('excludeKind=project');
+          params.push('excludeParented=true');
+        }
+        const q = params.length ? '?' + params.join('&') : '';
         const [a, b] = await Promise.all([
-          apiFetch('/initiatives' + statusQ).catch(() => null),
+          apiFetch('/initiatives' + q).catch(() => null),
           apiFetch('/initiatives/digest').catch(() => null),
         ]);
         itemsRes = a;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -5617,9 +5617,21 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     const status = typeof req.query.status === 'string' ? req.query.status : undefined;
-    const items = status
+    // Phase 1b PR 5 — server-side filters added so the dashboard
+    // Initiatives tab can hide project-kind records (rendered in the
+    // separate Projects tab) and any record that's a child of a
+    // project (rendered inside its parent's card).
+    const excludeKind = typeof req.query.excludeKind === 'string' ? req.query.excludeKind : undefined;
+    const excludeParented = req.query.excludeParented === 'true';
+    let items = status
       ? ctx.initiativeTracker.list({ status: status as 'active' | 'completed' | 'archived' | 'abandoned' })
       : ctx.initiativeTracker.list();
+    if (excludeKind) {
+      items = items.filter((i) => (i.kind ?? 'task') !== excludeKind);
+    }
+    if (excludeParented) {
+      items = items.filter((i) => !i.parentProjectId);
+    }
     res.json({ items, count: items.length });
   });
 

--- a/tests/unit/routes-initiatives.test.ts
+++ b/tests/unit/routes-initiatives.test.ts
@@ -28,9 +28,13 @@ function mountRoutes(tr: InitiativeTracker): { server: Server; port: number } {
   // Mirror of the production handlers (kept in sync with src/server/routes.ts).
   router.get('/initiatives', (req, res) => {
     const status = typeof req.query.status === 'string' ? req.query.status : undefined;
-    const items = status
+    const excludeKind = typeof req.query.excludeKind === 'string' ? req.query.excludeKind : undefined;
+    const excludeParented = req.query.excludeParented === 'true';
+    let items = status
       ? tr.list({ status: status as 'active' })
       : tr.list();
+    if (excludeKind) items = items.filter((i) => (i.kind ?? 'task') !== excludeKind);
+    if (excludeParented) items = items.filter((i) => !i.parentProjectId);
     res.json({ items, count: items.length });
   });
   router.get('/initiatives/digest', (_req, res) => res.json(tr.digest()));
@@ -215,5 +219,60 @@ describe('routes /initiatives — CRUD', () => {
     const archived = await req('GET', '/initiatives?status=archived');
     expect(active.json.items.map((i: { id: string }) => i.id)).toEqual(['demo']);
     expect(archived.json.items.map((i: { id: string }) => i.id)).toEqual(['demo2']);
+  });
+
+  // ── Phase 1b PR 5 — dashboard server-side filters ───────────────
+
+  it('GET ?excludeKind=project hides project-kind records', async () => {
+    // Create a task-kind initiative directly via the tracker so we
+    // don't have to extend the test's POST shape with `kind`.
+    await req('POST', '/initiatives', body);
+    await tracker.create({
+      id: 'a-project',
+      title: 'pr',
+      description: 'd',
+      phases: [{ id: 'p1', name: 'p1' }],
+      kind: 'project',
+    });
+    const filtered = await req('GET', '/initiatives?excludeKind=project');
+    const ids = (filtered.json.items as Array<{ id: string }>).map((i) => i.id);
+    expect(ids).toContain('demo');
+    expect(ids).not.toContain('a-project');
+  });
+
+  it('GET ?excludeParented=true hides children of any project', async () => {
+    await req('POST', '/initiatives', body); // no parent
+    await tracker.create({
+      id: 'child',
+      title: 'c',
+      description: 'd',
+      phases: [{ id: 'p1', name: 'p1' }],
+      parentProjectId: 'some-project',
+    });
+    const filtered = await req('GET', '/initiatives?excludeParented=true');
+    const ids = (filtered.json.items as Array<{ id: string }>).map((i) => i.id);
+    expect(ids).toContain('demo');
+    expect(ids).not.toContain('child');
+  });
+
+  it('combines excludeKind + excludeParented + status filters', async () => {
+    await req('POST', '/initiatives', body);
+    await tracker.create({
+      id: 'parented-task',
+      title: 'pt',
+      description: 'd',
+      phases: [{ id: 'p1', name: 'p1' }],
+      parentProjectId: 'p',
+    });
+    await tracker.create({
+      id: 'a-project',
+      title: 'pr',
+      description: 'd',
+      phases: [{ id: 'p1', name: 'p1' }],
+      kind: 'project',
+    });
+    const r = await req('GET', '/initiatives?status=active&excludeKind=project&excludeParented=true');
+    const ids = (r.json.items as Array<{ id: string }>).map((i) => i.id);
+    expect(ids).toEqual(['demo']);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -8,6 +8,34 @@
 
 ## What Changed
 
+### Project-scope Phase 1b PR 5 — dashboard Projects tab + Initiatives filter
+
+Fifth PR of project-scope Phase 1b. Ships the dashboard view of the
+project surface and the small server-side filter the dashboard depends
+on:
+
+- **Projects tab** in the dashboard. Read-only card per active project
+  with title + id + version + drift status badge + per-round progress
+  bar + pipelineStage histogram. Halt + Ack buttons route through the
+  PR 3 endpoints; 409 responses silently re-render (no error toast).
+  15-second poll while the tab is active; cleared on deactivation.
+  XSS-safe — every rendered string goes through `textContent`, no
+  `innerHTML`.
+- **Initiatives tab filter** — by default the tab now hides
+  project-kind records (shown in their own Projects tab) and child
+  initiatives of any project (shown inside the parent's card). A
+  "Show projects + children" checkbox bypasses the filter for users
+  who want the full list. The filter is server-side: the records
+  never cross the wire when excluded.
+- **`GET /initiatives` filter params** — accepts `excludeKind=<kind>`
+  (drops records of that kind) and `excludeParented=true` (drops
+  records that are children of any project). Additive — existing
+  callers see no behavior change.
+
+The compaction-recovery hook's active-projects digest was already in
+the template (it shipped alongside session-start.sh in PR 1's Phase
+1.9 work), so no template change is needed here.
+
 ### Project-scope Phase 1b PR 4 — auto-advance poller + multi-machine claim-ownership
 
 Fourth PR of project-scope Phase 1b. Ships three pieces:
@@ -86,6 +114,15 @@ permanently block subsequent acquires.
 
 ## What to Tell Your User
 
+- **Projects have a dashboard tab now**: open the dashboard and you'll
+  see every active project I'm tracking with its round-by-round
+  progress, which items have merged vs which are still in flight, and
+  any drift warnings I've recorded. Halt and ack buttons are right
+  there if you want to stop me or tell me you've seen the digest. The
+  Initiatives tab no longer mixes project plumbing in by default —
+  flip the "Show projects + children" toggle if you want to see
+  everything together.
+
 - **You can now drive a project round through the HTTP layer**: I can
   advance a single item one stage with a real artifact check, halt the
   active round on demand, record acknowledgment when I've shown you a
@@ -143,3 +180,11 @@ permanently block subsequent acquires.
   `in-progress` round to `pending`. Best-effort; OCC races are
   silently retried on subsequent reconciler passes (or via the
   auto-advance poller's filter).
+- Dashboard `Projects` tab — read-only project cards with progress
+  bar + drift badge + halt/ack buttons. 15-second poll while active.
+- Dashboard `Initiatives` tab now defaults to hiding project-kind +
+  child records. "Show projects + children" checkbox bypasses.
+- `GET /initiatives` accepts new optional query params: `excludeKind`
+  (drops records where `kind ?? 'task'` matches) and
+  `excludeParented=true` (drops records with a `parentProjectId`).
+  Additive; existing clients see no behavior change.

--- a/upgrades/side-effects/project-scope-phase1b-pr5.md
+++ b/upgrades/side-effects/project-scope-phase1b-pr5.md
@@ -1,0 +1,150 @@
+# Side-Effects Review — project-scope Phase 1b PR 5 (Dashboard Projects tab + Initiatives filter)
+
+**Version / slug:** `project-scope-phase1b-pr5`
+**Date:** `2026-05-11`
+**Author:** `echo`
+**Second-pass reviewer:** `required (new dashboard surface + new server-side filter)`
+
+## Summary of the change
+
+Fifth PR of project-scope Phase 1b. Ships the dashboard surface plus
+the small server-side filter the dashboard depends on. The compaction-
+recovery hook's active-projects digest was already in the template (it
+shipped alongside session-start.sh in Phase 1.9 / PR 1's session-start
+work and the equivalent block is present at lines 467-509 of
+`src/templates/hooks/compaction-recovery.sh`), so no template change
+is needed for this PR.
+
+Spec source: `docs/specs/PROJECT-SCOPE-SPEC.md` § Phase 1.10
+("Dashboard Projects tab"), § Phase 1.10 ("Initiatives tab filter").
+
+Modified files:
+- `dashboard/index.html` (+~210 lines) — adds the Projects tab button
+  alongside the Initiatives tab, adds the Projects panel HTML (header,
+  empty state, list container), registers the tab in the panel router,
+  and ships ~180 lines of JS:
+  - `loadProjects()` — fetches `/projects`, filters to `status:'active'`
+    client-side, fetches each project's joined view via
+    `/projects/:id?reconcile=false` in parallel (capped at 25), renders
+    cards.
+  - `renderProjectCard(project, children)` — XSS-safe construction
+    (`textContent` everywhere, `appendChild` only, no `innerHTML`).
+    Per spec: title row, drift status badge (colored per verdict),
+    round-by-round progress bar + pipelineStage histogram + Halt
+    + Ack buttons.
+  - `startProjectsPoll` / `stopProjectsPoll` — 15-second `setInterval`
+    when the tab is active, cleared on deactivation.
+  - `projectHalt(id)` + `projectAck(id, idx)` — POST to the new
+    runner-backed routes. 409 ("version mismatch") triggers a silent
+    `loadProjects()` re-render rather than an error toast.
+  - `loadInitiatives()` is updated to pass
+    `?excludeKind=project&excludeParented=true` by default, with a
+    "Show projects + children" checkbox to bypass. The filter is
+    server-side; the records never make the wire-trip.
+- `src/server/routes.ts` (+~10 lines) — `GET /initiatives` now accepts
+  `excludeKind=<string>` (drops records where `kind ?? 'task'` matches)
+  and `excludeParented=true` (drops records with a `parentProjectId`).
+- `tests/unit/routes-initiatives.test.ts` (+3 cases + mirror update) —
+  exercises both new params individually and combined with the existing
+  `status=` filter. The test mirror at the top of the file (which
+  duplicates the production handler shape) was updated in lockstep.
+
+## Decision-point inventory
+
+- **Initiatives filter** — **add** — `excludeKind` and
+  `excludeParented` are additive query parameters that DEFAULT TO NOT
+  EXCLUDING. Existing callers see no behavior change. The dashboard
+  opts in via a UI checkbox that defaults to "exclude" (matches the
+  spec's "filter project-kind by default").
+- **Projects tab read-only verbs** — **add** — the Halt and Ack
+  buttons route through the existing `POST /projects/:id/halt` and
+  `POST /projects/:id/ack` (shipped in PR 3). No new HTTP surface in
+  this PR. The buttons act on the project record's current version
+  (from the latest `loadProjects()` fetch); the routes enforce OCC
+  via `If-Match` — actually, `/halt` and `/ack` do NOT require
+  `If-Match` in PR 3's design (they use the tracker's internal
+  version-aware update via `ifMatch` from the latest `get()`). The
+  dashboard relies on that internal handling rather than passing
+  `If-Match` itself.
+- **15-second poll cadence** — **add** — matches the spec exactly.
+  The interval is cleared when the tab deactivates so a hidden tab
+  doesn't burn cycles.
+
+## Over-block vs under-block analysis
+
+### Server-side filter
+Over-block: the dashboard's default-on filter means a user who clicks
+"Initiatives" no longer sees project-kind records or child items
+unless they tick the "Show projects + children" checkbox. This is the
+spec's documented behavior (Projects get their own tab; children live
+inside their parent's card). No information is lost, just relocated.
+
+Under-block: the filter is purely additive. Existing scripts or
+clients that hit `/initiatives` without the new params see the same
+behavior they always have.
+
+### Dashboard rendering
+Over-block: 409 from `/halt` or `/ack` is treated as "stale view,
+just refresh" — no error toast, no user-visible noise. The spec
+explicitly calls this out: "409 response handled silently: refresh
++ re-render, no error toast."
+
+Under-block: the project-list fetch caps detailed lookups at 25. A
+deployment with >25 active projects would have the rest rendered as
+empty cards (since `detailed` is `null` for un-fetched IDs and we
+skip nulls). Acceptable for Phase 1; a follow-up PR can add pagination
+when project count actually exceeds the cap.
+
+### XSS safety
+Every rendered string goes through `.textContent` (never `.innerHTML`).
+Project ids, titles, round names, child stages, drift verdicts — all
+constructed via `createElement` + `textContent` + `appendChild`. The
+existing `dashboard/index.html` conventions already enforce this; the
+new code follows the same pattern.
+
+## Signal vs authority audit
+
+Dashboard is **read-only display** for the project surface (with two
+button-triggered mutating calls to existing PR 3 routes). The
+authority for halt and ack lives in `ProjectRoundRunner` — the
+dashboard just calls the documented endpoints. No new authority
+introduced.
+
+The initiatives filter is a **read-side** filter, not a
+record-modifying gate. The records themselves are unchanged; the
+filter only affects the response set.
+
+## Interactions with existing systems
+
+- **PR Pipeline tab.** No interaction — the Projects tab uses its
+  own panel + JS namespace.
+- **Initiatives tab.** Shares the existing `loadInitiatives()`
+  function; the new filter is a query-string addition with a UI
+  checkbox to bypass. Existing tab behavior preserved when the
+  checkbox is checked.
+- **`/projects/:id?reconcile=false`.** This query parameter is
+  already documented in the spec (Phase 1.3 — "Clients that need
+  pure-read semantics use `?reconcile=false`"). The dashboard uses
+  it to avoid triggering the lazy reconciler on every 15-second
+  poll. The `?reconcile=false` parameter is honored as a passthrough
+  in the existing route (the lazy reconciler isn't wired yet, so
+  it's a no-op today — when the reconciler ships, the dashboard
+  poll won't trigger it).
+- **Compaction-recovery hook.** Already includes the active-projects
+  digest section (PR 1's template work). No change needed in this PR.
+
+## Rollback cost
+
+Revert removes the new tab button, the new panel HTML, the JS block,
+the Initiatives filter checkbox, the server-side filter, and the test
+cases. No schema changes. Existing project records and initiatives
+are unaffected.
+
+## Verification
+
+- `npm run lint` — passes (tsc + lint-no-direct-destructive).
+- `npx vitest run tests/unit/routes-initiatives.test.ts
+  tests/unit/route-completeness.test.ts
+  tests/integration/projects-api.test.ts
+  tests/unit/dashboard-initiativesTab.test.ts` — 66/66 pass.
+- Existing PR 1-4 invariants still green.


### PR DESCRIPTION
## Summary

Fifth PR of project-scope Phase 1b (PROJECT-SCOPE-SPEC § Phase 1.10). Ships the dashboard view of the project surface and the small server-side filter it depends on.

- **Projects tab** — read-only card per active project: title + id + version + drift status badge + per-round progress bar + pipelineStage histogram + Halt/Ack buttons (route through PR 3 endpoints; 409 silently re-renders). 15-second poll while the tab is active; cleared on deactivation. XSS-safe textContent rendering everywhere.
- **Initiatives tab filter** — defaults to hiding project-kind records and parented children. "Show projects + children" checkbox bypasses. Server-side: filtered records never cross the wire.
- **`GET /initiatives` filter params** — `excludeKind=<kind>` and `excludeParented=true`. Additive.

The compaction-recovery hook's active-projects digest block was already in the template from PR 1's Phase 1.9 work, so no template change needed here.

## Test plan

- [x] `npm run lint` — passes.
- [x] `npx vitest run tests/unit/routes-initiatives.test.ts tests/unit/route-completeness.test.ts tests/integration/projects-api.test.ts tests/unit/dashboard-initiativesTab.test.ts` — 66/66 pass.
- [ ] CI full sharded suite — pending.

## Coverage

| Property | Tests |
|---|---|
| `excludeKind=project` hides project-kind records | 1 |
| `excludeParented=true` hides parented children | 1 |
| Combined `excludeKind` + `excludeParented` + `status` filters | 1 |
| Existing PR 1-4 invariants (runner / heartbeat / poller / routes) | 63 |

Side-effects review: `upgrades/side-effects/project-scope-phase1b-pr5.md`
Release notes: `upgrades/NEXT.md` (PR 3 + PR 4 + PR 5 content; all ship in next release cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)