### PR TITLE
fix(ci): remove inline code from What to Tell Your User in NEXT.md

### DIFF
--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -36,7 +36,7 @@ Existing `tests/unit/JobLoader.test.ts` (the pre-spec test suite) continues to p
 
 ## What to Tell Your User
 
-Instar is preparing to move job prompts out of one big `jobs.json` blob and into individual markdown files (one file per job). This update lays the groundwork: the loader now understands the new format, and the new validation rules are all in place. Nothing changes for you yet — your existing jobs keep running exactly as before, and you can ignore this change entirely if you want. The actual cut-over (where jobs start firing from their `.md` files) happens in the next few releases. If you ever see a warning in your logs about an `agentmd` job being "deferred — Phase 1b adds the dispatch path," that's expected for now.
+Instar is preparing to move job prompts out of one big jobs.json blob and into individual markdown files (one file per job). This update lays the groundwork: the loader now understands the new format, and the new validation rules are all in place. Nothing changes for you yet — your existing jobs keep running exactly as before, and you can ignore this change entirely if you want. The actual cut-over (where jobs start firing from their .md files) happens in the next few releases. If you ever see a warning in your logs about an agentmd job being "deferred — Phase 1b adds the dispatch path," that's expected for now.
 
 ## Summary of New Capabilities
 


### PR DESCRIPTION
## Summary

- NEXT.md's "What to Tell Your User" section had three inline code backtick references (`jobs.json`, `.md`, `agentmd`) that fail the upgrade-guide validator
- The Publish to npm workflow has been failing on the "Check upgrade guide" step since the Phase 1a agentmd feature was merged (#173)
- Removed all three backtick wrappings — plain text reads better in user-facing narrative anyway

## Root cause

`validateGuideContent` in `scripts/upgrade-guide-validator.mjs` explicitly rejects inline code in the "What to Tell Your User" section. The Phase 1a PR introduced these three backtick references when writing the user narrative.

## Test plan

- [x] Ran `node scripts/check-upgrade-guide.js` locally in the worktree — output: `✓ Upgrade guide finalized and validated for v0.28.98`
- [ ] CI publish run should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)