### PR TITLE
feat(scheduler): Phase-1b-gap closure — lockTrust gates tool elevation

### DIFF
--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -1614,6 +1614,18 @@ export class JobScheduler {
       // Two-flag guard: "*" + unrestrictedTools:true → full tools.
       // Otherwise clamp to [Read] and signal the clamp.
       if (job.unrestrictedTools === true) {
+        // Phase-1b-gap closure: an origin:instar job in a real-tamper lockTrust
+        // state cannot escape to full tools, regardless of what the manifest
+        // claims. The lock-file is the higher trust authority.
+        if (job.origin === 'instar' && JobScheduler.isLockUntrustedTamper(job.lockTrust)) {
+          return {
+            kind: 'lock-untrusted-clamped',
+            allowlist: ['Read'],
+            unrestrictedTools: false,
+            clampedAllowlist: true,
+            lockUntrustedClamp: true,
+          };
+        }
         return {
           kind: 'unrestricted',
           allowlist: '*',
@@ -1643,12 +1655,40 @@ export class JobScheduler {
     // Instar-origin without an explicit allowlist: documented temporary
     // behavior — spawn with full tools, emit a degradation event so the
     // gap is visible until Phase 1c lock-file defaults close it.
+    //
+    // Phase-1b-gap closure: refuse the implicit full-tools fallback when
+    // lockTrust signals a real tamper. The transitional
+    // `untrusted-no-lockfile` state preserves the documented temporary
+    // behavior so existing agents don't lose tool access when they apply
+    // the update before the build-pipeline signing ships.
+    if (job.origin === 'instar' && JobScheduler.isLockUntrustedTamper(job.lockTrust)) {
+      return {
+        kind: 'lock-untrusted-clamped',
+        allowlist: ['Read'],
+        unrestrictedTools: false,
+        clampedAllowlist: true,
+        lockUntrustedClamp: true,
+      };
+    }
+
     return {
       kind: 'instar-no-allowlist',
       allowlist: null,
       unrestrictedTools: false,
       clampedAllowlist: false,
     };
+  }
+
+  /** Classify a lockTrust value as a real-tamper signal. The transitional
+   *  `untrusted-no-lockfile` is intentionally NOT a tamper signal — until
+   *  Phase 1c-build ships, every instar agent carries this value on every
+   *  origin:instar entry; treating it as tamper would break the rollout. */
+  static isLockUntrustedTamper(lockTrust: JobDefinition['lockTrust']): boolean {
+    return (
+      lockTrust === 'untrusted-bad-signature' ||
+      lockTrust === 'untrusted-not-in-lockfile' ||
+      lockTrust === 'untrusted-hash-mismatch'
+    );
   }
 
   /**
@@ -1766,12 +1806,43 @@ export class JobScheduler {
         // @silent-fallback-ok — degradation reporting is best-effort
       }
     }
+
+    if (resolution.kind === 'lock-untrusted-clamped') {
+      // Real-tamper lockTrust state refused trust elevation. Surface to BOTH
+      // event stream (Dashboard) and degradation digest so operator sees it.
+      this.state.appendEvent({
+        type: 'job_lock_untrusted_clamped',
+        summary:
+          `Job "${job.slug}" claims origin:instar but its lock-file trust state is "${job.lockTrust}" — ` +
+          `tool elevation refused, clamped to [Read].`,
+        timestamp: new Date().toISOString(),
+        metadata: { slug: job.slug, lockTrust: job.lockTrust },
+      });
+      try {
+        DegradationReporter.getInstance().report({
+          feature: 'JobScheduler.allowlistResolution',
+          primary: 'Spawn the instar default with its requested tool authorization',
+          fallback: 'Clamp the spawn to ["Read"]',
+          reason: `Instar-origin agentmd job "${job.slug}" has lockTrust="${job.lockTrust}" (real-tamper state)`,
+          impact: 'Job runs Read-only until the lock-file mismatch is acknowledged or repaired',
+        });
+      } catch {
+        // @silent-fallback-ok — degradation reporting is best-effort
+      }
+    }
   }
 }
 
 /** Result of {@link JobScheduler.resolveAllowlist}. Pure-data; no state. */
 export interface AllowlistResolution {
-  kind: 'legacy' | 'array' | 'unrestricted' | 'clamped' | 'default-user' | 'instar-no-allowlist';
+  kind:
+    | 'legacy'
+    | 'array'
+    | 'unrestricted'
+    | 'clamped'
+    | 'default-user'
+    | 'instar-no-allowlist'
+    | 'lock-untrusted-clamped';
   /** What the resolver will pass to the spawn:
    *  - `string[]` → spawn receives `--allowedTools <comma-separated>`
    *  - `"*"` → spawn omits `--allowedTools` (full tools authorized)
@@ -1779,6 +1850,12 @@ export interface AllowlistResolution {
   allowlist: string[] | '*' | null;
   unrestrictedTools: boolean;
   clampedAllowlist: boolean;
+  /** True when an `origin:instar` agentmd job had its tool elevation refused
+   *  because lockTrust is in a real-tamper state (`bad-signature`,
+   *  `not-in-lockfile`, or `hash-mismatch`). The transitional
+   *  `untrusted-no-lockfile` state does NOT trigger this clamp — see
+   *  {@link JobScheduler.resolveAllowlist} for the rationale. */
+  lockUntrustedClamp?: boolean;
 }
 
 /** Phase 1b run-record observability payload. */

--- a/tests/unit/scheduler/JobScheduler.tool-allowlist.test.ts
+++ b/tests/unit/scheduler/JobScheduler.tool-allowlist.test.ts
@@ -145,6 +145,117 @@ describe('JobScheduler.resolveAllowlist (Phase 1b, pure)', () => {
   });
 });
 
+describe('JobScheduler.resolveAllowlist lockTrust gap-closure', () => {
+  // ─── Real-tamper lockTrust states clamp instar elevation ──────────────────
+
+  for (const lockTrust of ['untrusted-bad-signature', 'untrusted-not-in-lockfile', 'untrusted-hash-mismatch'] as const) {
+    it(`refuses "*" + unrestrictedTools elevation for origin:instar when lockTrust=${lockTrust}`, () => {
+      const job: JobDefinition = {
+        ...makeAgentMdJob({
+          slug: 'j', origin: 'instar',
+          frontmatter: { toolAllowlist: '*' },
+          unrestrictedTools: true,
+        }),
+        lockTrust,
+      };
+      const r = JobScheduler.resolveAllowlist(job);
+      expect(r.kind).toBe('lock-untrusted-clamped');
+      expect(r.allowlist).toEqual(['Read']);
+      expect(r.unrestrictedTools).toBe(false);
+      expect(r.clampedAllowlist).toBe(true);
+      expect(r.lockUntrustedClamp).toBe(true);
+    });
+
+    it(`refuses the implicit full-tools fallback for origin:instar no-allowlist when lockTrust=${lockTrust}`, () => {
+      const job: JobDefinition = {
+        ...makeAgentMdJob({ slug: 'j', origin: 'instar', frontmatter: {} }),
+        lockTrust,
+      };
+      const r = JobScheduler.resolveAllowlist(job);
+      expect(r.kind).toBe('lock-untrusted-clamped');
+      expect(r.allowlist).toEqual(['Read']);
+      expect(r.lockUntrustedClamp).toBe(true);
+    });
+  }
+
+  // ─── Trusted + transitional preserve elevation (seamless migration) ───────
+
+  it('allows "*" + unrestrictedTools elevation for origin:instar when lockTrust=trusted', () => {
+    const job: JobDefinition = {
+      ...makeAgentMdJob({
+        slug: 'j', origin: 'instar',
+        frontmatter: { toolAllowlist: '*' },
+        unrestrictedTools: true,
+      }),
+      lockTrust: 'trusted',
+    };
+    const r = JobScheduler.resolveAllowlist(job);
+    expect(r.kind).toBe('unrestricted');
+    expect(r.allowlist).toBe('*');
+    expect(r.unrestrictedTools).toBe(true);
+    expect(r.lockUntrustedClamp).toBeUndefined();
+  });
+
+  it('allows elevation when lockTrust=untrusted-no-lockfile (transitional, pre-Phase-1c-build)', () => {
+    // This is the "every existing agent right after applying the update" state.
+    // Clamping here would break working agents on the seamless-migration path.
+    const job: JobDefinition = {
+      ...makeAgentMdJob({
+        slug: 'j', origin: 'instar',
+        frontmatter: { toolAllowlist: '*' },
+        unrestrictedTools: true,
+      }),
+      lockTrust: 'untrusted-no-lockfile',
+    };
+    const r = JobScheduler.resolveAllowlist(job);
+    expect(r.kind).toBe('unrestricted');
+    expect(r.allowlist).toBe('*');
+    expect(r.lockUntrustedClamp).toBeUndefined();
+  });
+
+  it('preserves instar-no-allowlist behavior when lockTrust=untrusted-no-lockfile (transitional)', () => {
+    const job: JobDefinition = {
+      ...makeAgentMdJob({ slug: 'j', origin: 'instar', frontmatter: {} }),
+      lockTrust: 'untrusted-no-lockfile',
+    };
+    const r = JobScheduler.resolveAllowlist(job);
+    expect(r.kind).toBe('instar-no-allowlist');
+    expect(r.allowlist).toBeNull();
+  });
+
+  // ─── User-origin jobs unaffected by lockTrust gating ──────────────────────
+
+  it('does NOT clamp user-origin jobs based on lockTrust (gate is instar-scoped)', () => {
+    const job: JobDefinition = {
+      ...makeAgentMdJob({
+        slug: 'j', origin: 'user',
+        frontmatter: { toolAllowlist: '*' },
+        unrestrictedTools: true,
+      }),
+      // User jobs have no lockTrust by design; even if a stale value leaks
+      // through, the gate must not fire (this is a defense-in-depth assertion).
+      lockTrust: 'untrusted-bad-signature' as JobDefinition['lockTrust'],
+    };
+    const r = JobScheduler.resolveAllowlist(job);
+    expect(r.kind).toBe('unrestricted');
+    expect(r.allowlist).toBe('*');
+  });
+
+  // ─── isLockUntrustedTamper classifier ─────────────────────────────────────
+
+  it('isLockUntrustedTamper classifies the three real-tamper states as tamper', () => {
+    expect(JobScheduler.isLockUntrustedTamper('untrusted-bad-signature')).toBe(true);
+    expect(JobScheduler.isLockUntrustedTamper('untrusted-not-in-lockfile')).toBe(true);
+    expect(JobScheduler.isLockUntrustedTamper('untrusted-hash-mismatch')).toBe(true);
+  });
+
+  it('isLockUntrustedTamper classifies trusted, transitional, and undefined as NOT tamper', () => {
+    expect(JobScheduler.isLockUntrustedTamper('trusted')).toBe(false);
+    expect(JobScheduler.isLockUntrustedTamper('untrusted-no-lockfile')).toBe(false);
+    expect(JobScheduler.isLockUntrustedTamper(undefined)).toBe(false);
+  });
+});
+
 describe('JobScheduler agentmd spawn-time allowlist plumbing (Phase 1b, integration)', () => {
   let stateDir: string;
   let state: StateManager;

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,5 +1,18 @@
 # Upgrade Notes (Unreleased)
 
+### feat(scheduler): Phase-1b-gap closure — lockTrust gates tool elevation
+
+`JobScheduler.resolveAllowlist` now refuses tool elevation for `origin:instar` agentmd jobs whose `lockTrust` signals real tamper (`untrusted-bad-signature`, `untrusted-not-in-lockfile`, `untrusted-hash-mismatch`). When the gate fires, the resolution kind is `'lock-untrusted-clamped'`, the allowlist clamps to `['Read']`, and both a Dashboard event (`job_lock_untrusted_clamped`) and a degradation event surface.
+
+Two values intentionally do NOT trigger the clamp:
+
+- `'trusted'` — proceed normally.
+- `'untrusted-no-lockfile'` — the documented transitional state. Until Phase 1c-build signs lock-files at release time, every existing agent's `origin:instar` job carries this value on the first boot after applying the update. Clamping here would break working agents on the seamless-migration path, violating the Seamless Migration Guarantee invariants (see PR #180).
+
+A new pure classifier `JobScheduler.isLockUntrustedTamper` is exported for reuse by other gates (grounding audit, future Dashboard "degraded trust" indicators).
+
+Tests: 12 new cases in `tests/unit/scheduler/JobScheduler.tool-allowlist.test.ts`. Total file: 27 tests, all passing.
+
 ## What Changed
 
 This release adds the runtime consumer for the signed instar-default lock-file described in the INSTAR-JOBS-AS-AGENTMD spec §Trust Model. The lock-file at `.instar/jobs/instar.lock.json` is the structural trust authority for "is this slug a real instar default": a separate build-time pipeline (Phase 1c-build, follow-up PR) signs it at release time; the corresponding public key is bundled at `dist/keys/instar-release-pub.pem`. This PR ships the loader-side consumer (Ed25519 signature verification using `node:crypto`, hash-equality check on body and frontmatter, four-state load result, skip-until-ack on per-slug hash mismatch) and a new `JobDefinition.lockTrust` field that downstream consumers will use to refuse trust elevation when not `'trusted'`. The build pipeline and the Phase-1b-gap closure (allowlist resolver consuming `lockTrust`) are explicitly out of scope and will land in their own PRs.

--- a/upgrades/side-effects/jobs-as-agentmd-phase-1b-gap.md
+++ b/upgrades/side-effects/jobs-as-agentmd-phase-1b-gap.md
@@ -1,0 +1,81 @@
+# Side-effects review — Phase 1b-gap closure (lockTrust → allowlist gate)
+
+## What changed
+
+`JobScheduler.resolveAllowlist` now refuses tool elevation for `origin:instar` agentmd jobs whose `lockTrust` is in a real-tamper state. Three lockTrust values are real-tamper:
+
+- `untrusted-bad-signature`
+- `untrusted-not-in-lockfile`
+- `untrusted-hash-mismatch`
+
+When any of those values is present on an `origin:instar` job, the resolver returns a new resolution kind `lock-untrusted-clamped` with `allowlist: ['Read']`. This applies both to the explicit `toolAllowlist:"*" + unrestrictedTools:true` elevation path AND to the implicit `instar-no-allowlist` full-tools fallback.
+
+Two states intentionally do NOT trigger the clamp:
+
+- `trusted` — elevation proceeds normally.
+- `untrusted-no-lockfile` — the documented transitional state. Until Phase 1c-build ships the signing pipeline, every existing agent's instar-origin job will be in this state on the very first boot after applying the update. Clamping here would break the seamless-migration property — agents would lose tool access until they get a new release.
+
+A new event `job_lock_untrusted_clamped` is emitted to the state event stream and a degradation event is reported when the clamp fires. The `clampedAllowlist` run-record field is already set, so the run-history table surfaces the clamp without any schema change.
+
+## Side-effects review (mandatory gate)
+
+### 1. Over-block / under-block
+
+- **Over-block:** transitional `untrusted-no-lockfile` is excluded from the tamper set. Without this carve-out, the very first boot after applying this PR would clamp every existing agent's instar default to `[Read]`, breaking working jobs that have legitimate full-tool authorization. The Seamless Migration Guarantee invariants 1, 2, and 4 require existing-agent operation to be preserved on update; clamping here would violate them.
+- **Under-block:** all three real-tamper states are covered. The Phase 1c loader already excludes `hash-mismatch` entries from `jobs[]` (skip-until-ack), so in practice that state never reaches the resolver — the test exercises it for defense-in-depth.
+
+### 2. Level-of-abstraction fit
+
+The clamp lives in `resolveAllowlist`, the pure decision point for allowlist resolution. It is NOT layered on top in the caller. Putting it inside `resolveAllowlist` means:
+
+- Every call site is covered without needing to remember the gate.
+- The decision is auditable in one place.
+- Unit tests exercise the gate as a pure function on `JobDefinition`.
+
+A new pure classifier `JobScheduler.isLockUntrustedTamper` exists so the same predicate can be reused by future callers (e.g., grounding-audit gate, Dashboard "this job's trust is degraded" indicator). It is exported alongside `resolveAllowlist`.
+
+### 3. Signal-vs-authority compliance
+
+`lockTrust` is computed by `AgentMdLockFile.readLockFile` — a low-level Ed25519 verifier with full per-slug hash check context. That layer is the canonical signal. `resolveAllowlist` consumes the signal and applies a structural rule. The resolver is the authority for "what tools does this job spawn with"; the lock-file is the signal for "is this job's content trusted." Authority sits at the spawn-decision layer, not the verifier — correct separation.
+
+### 4. Interactions
+
+- **Grounding-audit gate** (`JobLoader.auditGrounding`) — also consumes `lockTrust`. Behavior is preserved: tamper states already cause the entry to be excluded from `jobs[]` for `untrusted-hash-mismatch`; for the other two, the audit gate's separate decision is unchanged.
+- **`emitAllowlistSignals`** — extended to emit one Dashboard event (`job_lock_untrusted_clamped`) and one degradation event when the new clamp fires. Both surfaces are best-effort (existing pattern: try/catch around `DegradationReporter.report` with `@silent-fallback-ok`).
+- **Run record** — `clampedAllowlist: true` already gets written for any clamp; the new clamp surfaces through the same field. No schema migration needed. `unrestrictedTools` correctly reports `false` for the new clamp.
+- **Existing tests** — no behavioral regression. All 27 tests in `tool-allowlist.test.ts` pass (15 original + 12 new). All 130 unit-scheduler tests pass.
+
+### 5. Rollback cost
+
+Trivial. The clamp is one branch in a pure function and one branch in the signal emitter. Reverting is a one-commit `git revert`. There is no on-disk state change associated with this PR — the resolver computes per call, no caching.
+
+### 6. Seamless Migration Guarantee compliance
+
+This PR is the first one to LAND under the new guarantee (PR #180 merged the spec). The carve-out for `untrusted-no-lockfile` is exactly the spec's "existing agents do not lose tool access on the very first boot after applying the update" invariant. The test
+`'allows elevation when lockTrust=untrusted-no-lockfile (transitional, pre-Phase-1c-build)'`
+is the structural assertion of that invariant for this code path.
+
+## Test coverage
+
+`tests/unit/scheduler/JobScheduler.tool-allowlist.test.ts` adds 12 new tests under a new `describe('JobScheduler.resolveAllowlist lockTrust gap-closure')` block:
+
+- 3× real-tamper elevation refusal (one per tamper state, explicit `"*"` + `unrestrictedTools:true`)
+- 3× real-tamper implicit-fallback refusal (one per tamper state, no-allowlist path)
+- `trusted` elevation allowed
+- `untrusted-no-lockfile` elevation allowed (seamless-migration invariant)
+- `untrusted-no-lockfile` no-allowlist preserves transitional behavior
+- User-origin not gated even with stale lockTrust value (defense-in-depth)
+- `isLockUntrustedTamper` classifier — positive cases
+- `isLockUntrustedTamper` classifier — negative cases including `undefined`
+
+All 27 tests in the file pass locally. Broader 130-test scheduler suite is green.
+
+## Spec reference
+
+INSTAR-JOBS-AS-AGENTMD-SPEC §Trust Model + §Per-job tool allowlist + the new §Seamless Migration Guarantee invariants 1, 2, 4 (merged via PR #180).
+
+## What is NOT in this PR
+
+- The grounding-audit gate's structural integration with `lockTrust` (already shipped in Phase 1c-runtime).
+- Dashboard surface for the new `job_lock_untrusted_clamped` event — Phase 4.
+- Build-pipeline signing that moves agents from `untrusted-no-lockfile` to `trusted` — Phase 1c-build (next PR).


### PR DESCRIPTION
## Summary

- Closes the Phase 1b documented gap: `origin:instar` agentmd jobs in a real-tamper `lockTrust` state can no longer reach full tools.
- New resolution kind `'lock-untrusted-clamped'` is returned when the gate fires on `untrusted-bad-signature` / `untrusted-not-in-lockfile` / `untrusted-hash-mismatch`.
- `'untrusted-no-lockfile'` (transitional) and `'trusted'` are NOT gated — required by the Seamless Migration Guarantee landed in #180.
- New pure classifier `JobScheduler.isLockUntrustedTamper` for reuse by future gates.

## Why this carve-out matters

`untrusted-no-lockfile` is the state every existing agent enters on the first boot after applying the update. Phase 1c-build (the next PR) is what moves them to `'trusted'`. If we gated on `untrusted-no-lockfile` here, applying this PR would Read-clamp every existing instar default job on every agent — the Seamless Migration Guarantee (PR #180) calls this out as a Phase ≥ 4 release-blocker.

## Test plan

- [x] 12 new tests in `tests/unit/scheduler/JobScheduler.tool-allowlist.test.ts` covering every lockTrust state × both elevation paths + classifier truth table
- [x] All 27 tests in the file pass
- [x] All 130 unit-scheduler tests pass locally
- [x] All 171 push-config tests pass locally (full pre-push suite)
- [x] Lint + type check pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)