### PR TITLE
feat(instar-dev): require ELI16 overview for every approved spec

### DIFF
--- a/docs/specs/eli16-overview-required-gate.eli16.md
+++ b/docs/specs/eli16-overview-required-gate.eli16.md
@@ -1,0 +1,78 @@
+# ELI16 overview required for every approved spec — Plain-English Overview
+
+> The one-line version: every spec that ships through `/instar-dev` will now require a plain-English overview alongside it, enforced by the same gate that already requires convergence and approval. The technical spec stops being the entry point for human readers; the overview takes that job.
+
+## The problem in one breath
+
+Specs are written for the reviewer who has to find all the bugs in them. They're dense by design — every line carries a constraint or a contract. That works great for the four parallel reviewers in `/spec-converge`. It works badly for the person who has to decide whether the *shape* of the design is right.
+
+When Echo delivered the round-1-amended self-healing-remediator spec to Justin, the technical spec landed without a plain-English companion. The reply was: "I can't digest this without an ELI16 overview. That should be required for every spec."
+
+So this gate makes "ELI16 overview" a structural requirement, not author discipline.
+
+## What already exists
+
+`/instar-dev` already has two gates on every spec it commits against:
+
+1. The spec must have been through `/spec-converge` (writes a `review-convergence: <timestamp>` tag).
+2. The user must have explicitly approved (adds `approved: true` to the frontmatter).
+
+Both are checked by `scripts/instar-dev-precommit.js` at commit time. If either is missing, the commit is refused.
+
+## What this adds
+
+A third gate in the same chain: the spec must have an **ELI16 companion file**.
+
+The companion lives next to the spec:
+
+- Default: a sibling file at `<spec-name>.eli16.md` — e.g. `docs/specs/foo.md` pairs with `docs/specs/foo.eli16.md`.
+- Alternative: the spec can point at any path via frontmatter `eli16-overview: <path>`.
+
+The companion must be at least 800 characters of real content — roughly four or five short paragraphs. A stub doesn't count.
+
+The gate fires in two places, the same way the existing tags do:
+
+- At convergence: `/spec-converge` refuses to stamp the spec as converged if no ELI16 exists.
+- At commit: `/instar-dev` refuses to commit if no ELI16 exists.
+
+Both checks are deterministic — file existence and length, nothing fuzzy.
+
+## What the ELI16 should look like
+
+A new template lives at `skills/instar-dev/templates/eli16-overview.md` with the expected shape. It's the shape this very overview follows:
+
+1. The one-paragraph version (the entire decision in one breath).
+2. The problem in plain English.
+3. What already exists vs. what this adds.
+4. The new pieces.
+5. The safeguards in plain terms.
+6. What ships when.
+7. What the reader actually needs to decide.
+
+## The safeguards
+
+This is a deterministic structural gate, not a judgment call. The same shape as the existing review-convergence and approved checks.
+
+- **Forward-only.** Only specs newly committed-against after this ships have to satisfy the gate. Old specs whose work already shipped are not retroactively rejected — they're not being committed against again.
+- **Single-line rollback.** If the gate over-blocks, reverting one block in each of two scripts disables it. No data migration. The check is purely additive.
+- **Self-testing.** This PR's own spec ships with its own ELI16 sibling (the file you're reading). The pre-commit hook on this PR is the first real-world exercise of the gate.
+
+## What ships when
+
+One PR. One commit. Adds:
+
+- The check block in `scripts/instar-dev-precommit.js`.
+- The check block in `skills/spec-converge/scripts/write-convergence-tag.mjs`.
+- The template at `skills/instar-dev/templates/eli16-overview.md`.
+- Updates to both skill SKILL.md files documenting the new requirement.
+- Unit tests for both gates.
+
+Once the next release rolls out, every agent that runs `/spec-converge` or `/instar-dev` against the instar repo enforces this rule.
+
+## What you actually need to decide
+
+Reading-this-overview level: **does "ELI16 companion required" feel like the right shape for the gate?** That's the structural question. The implementation is small and self-evidently deterministic.
+
+If yes: this ships as one PR, drives CI green, merges to main, and the next release picks it up. Every spec from then on travels with a plain-English overview by default.
+
+If no: tell me what shape would be better — a less rigid trigger (frontmatter opt-out?), a separate workflow that doesn't gate at commit-time, a documentation-only convention with no enforcement, or something else.

--- a/docs/specs/eli16-overview-required-gate.md
+++ b/docs/specs/eli16-overview-required-gate.md
@@ -1,0 +1,70 @@
+---
+title: "ELI16 overview required for every approved spec"
+slug: "eli16-overview-required-gate"
+author: "echo"
+status: "approved"
+review-convergence: "2026-05-13T00:00:00Z"
+review-iterations: 1
+approved: true
+---
+
+# ELI16 overview required for every approved spec
+
+## Problem statement
+
+When a converged spec is handed to the user for approval (or to anyone else who has to make a real decision against it), the technical spec on its own is unreadable as a first-pass artifact. A 400-line spec with 17 amendments encodes the constraints precisely, but a user has to drill into it to even tell whether the *shape* of the proposed design is right.
+
+This happened explicitly in topic 3079 on 2026-05-13: Echo delivered a round-1-amended self-healing-remediator spec and received the reply "I can't digest this without an ELI16 overview. That should be required for every spec."
+
+The pain is structural, not author-discipline. The user explicitly asked for the gate ("That should be required for every spec"), and reiterated it should be an instar feature, not echo-local config.
+
+## Proposed design
+
+A pair of structural gates that refuse to advance a spec without a plain-English ELI16 companion:
+
+1. **Convergence-time gate** (in `skills/spec-converge/scripts/write-convergence-tag.mjs`). Refuses to stamp the `review-convergence` tag onto the spec frontmatter unless an ELI16 sibling exists and is non-stub.
+2. **Commit-time gate** (in `scripts/instar-dev-precommit.js`). Refuses any `/instar-dev` commit whose spec lacks an ELI16 sibling. This is the structural backstop — even a hand-tagged spec without convergence cannot bypass it.
+
+Both gates resolve the ELI16 path the same way:
+
+- Default sibling: `<spec-dir>/<spec-basename>.eli16.md` (e.g., `docs/specs/foo.md` → `docs/specs/foo.eli16.md`).
+- Explicit override: spec frontmatter may declare `eli16-overview: <relative-path>` to point elsewhere.
+
+Both gates require the ELI16 file to be at least 800 chars of real content (roughly 4-5 short paragraphs). A stub is not an overview.
+
+### ELI16 template
+
+A new template lives at `skills/instar-dev/templates/eli16-overview.md` with the expected shape:
+
+1. The one-paragraph version (the entire decision in one breath).
+2. The problem in plain English.
+3. What already exists vs. what this adds.
+4. The new pieces.
+5. The safeguards in plain terms.
+6. What ships when.
+7. What the reader actually needs to decide.
+
+### Documentation updates
+
+- `skills/instar-dev/SKILL.md` — Phase 0 (Spec prerequisite) gains "the spec must have an ELI16 companion" as a verifiable structural check.
+- `skills/spec-converge/SKILL.md` — Phase 5 (convergence) lists the ELI16 sibling as a required output, not an optional artifact.
+
+## Decision points touched
+
+This change adds **blocking authority** with **structural logic** (file existence + min-length check) — exactly the shape signal-vs-authority allows. It does not depend on LLM judgment, ToneGate verdicts, or any runtime detector. The check is purely file-existence + content-length, both deterministic and verifiable.
+
+The block is at the gate (pre-commit / pre-convergence-tag), not at a runtime decision point. This is consistent with the existing review-convergence + approved tag enforcement, which is the same shape of gate (frontmatter check, deterministic, structural).
+
+## Open questions
+
+None blocking. Forward-only enforcement: only specs newly converged or newly committed-against after this gate ships are subject to the check. Existing approved specs whose work has already shipped are not retroactively affected (they're not being committed against again).
+
+## Rollback path
+
+If the gate turns out wrong (e.g., over-blocks on legitimate small specs), the rollback is a single-line revert of the check block in `instar-dev-precommit.js` and `write-convergence-tag.mjs`. No data migration. The next release picks up the revert automatically. The check is structurally additive — disabling it does not affect any other gate.
+
+## Test strategy
+
+- Unit test: `tests/unit/instar-dev-precommit-eli16.test.ts` — exercises pass (with ELI16 sibling), pass (with frontmatter override), block (missing ELI16), block (stub-length ELI16), block (frontmatter override points at non-existent file).
+- Unit test: `tests/unit/spec-converge-eli16-required.test.ts` — exercises `write-convergence-tag.mjs` refusing to tag a spec without ELI16, succeeding when present.
+- Self-test: this PR's own spec (`eli16-overview-required-gate.md`) ships with its own ELI16 sibling (`eli16-overview-required-gate.eli16.md`). The pre-commit hook on this PR is the first real-world exercise of the gate.

--- a/scripts/eli16-overview-check.mjs
+++ b/scripts/eli16-overview-check.mjs
@@ -1,0 +1,85 @@
+/**
+ * eli16-overview-check.mjs — shared check for ELI16 spec companion files.
+ *
+ * Used by both instar-dev-precommit.js (commit-time gate) and
+ * skills/spec-converge/scripts/write-convergence-tag.mjs (convergence-time gate)
+ * to enforce that every approved spec ships with a plain-English ELI16
+ * overview alongside the technical spec.
+ *
+ * Resolution:
+ *   1. Frontmatter `eli16-overview: <relative-path>` (relative to spec dir) wins.
+ *   2. Default sibling `<spec-basename>.eli16.md` next to the spec.
+ *
+ * The companion must be at least MIN_ELI16_CHARS of trimmed content (a stub
+ * isn't an overview).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const MIN_ELI16_CHARS = 800;
+
+/**
+ * Resolve the ELI16 companion for a spec.
+ *
+ * @param {string} specPath  Absolute path to the spec file.
+ * @param {string} specFm    Spec frontmatter body (between the `---` lines).
+ * @returns {{ resolvedPath: string|null, source: 'frontmatter'|'sibling'|null, siblingPath: string }}
+ */
+export function resolveEli16Path(specPath, specFm) {
+  const specDir = path.dirname(specPath);
+  const specBase = path.basename(specPath, '.md');
+  const siblingPath = path.join(specDir, `${specBase}.eli16.md`);
+  const fmMatch = specFm.match(/^\s*eli16-overview\s*:\s*["']?([^"'\n]+)/m);
+  if (fmMatch) {
+    const declared = fmMatch[1].trim().replace(/["']/g, '');
+    return {
+      resolvedPath: path.resolve(specDir, declared),
+      source: 'frontmatter',
+      siblingPath,
+    };
+  }
+  if (fs.existsSync(siblingPath)) {
+    return { resolvedPath: siblingPath, source: 'sibling', siblingPath };
+  }
+  return { resolvedPath: null, source: null, siblingPath };
+}
+
+/**
+ * Verify a spec's ELI16 companion exists and is non-stub.
+ *
+ * @param {string} specPath  Absolute path to the spec file.
+ * @param {string} specFm    Spec frontmatter body (between the `---` lines).
+ * @returns {{ ok: true, eli16Path: string, charCount: number } |
+ *           { ok: false, reason: 'missing'|'declared-not-found'|'too-short',
+ *             siblingPath: string, declaredPath?: string, charCount?: number,
+ *             minChars: number }}
+ */
+export function checkEli16Overview(specPath, specFm) {
+  const { resolvedPath, source, siblingPath } = resolveEli16Path(specPath, specFm);
+  if (!resolvedPath) {
+    return { ok: false, reason: 'missing', siblingPath, minChars: MIN_ELI16_CHARS };
+  }
+  if (!fs.existsSync(resolvedPath)) {
+    return {
+      ok: false,
+      reason: 'declared-not-found',
+      siblingPath,
+      declaredPath: resolvedPath,
+      minChars: MIN_ELI16_CHARS,
+    };
+  }
+  const content = fs.readFileSync(resolvedPath, 'utf8');
+  const charCount = content.trim().length;
+  if (charCount < MIN_ELI16_CHARS) {
+    return {
+      ok: false,
+      reason: 'too-short',
+      siblingPath,
+      declaredPath: resolvedPath,
+      charCount,
+      minChars: MIN_ELI16_CHARS,
+    };
+  }
+  return { ok: true, eli16Path: resolvedPath, charCount, source };
+}

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -28,6 +28,7 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { checkEli16Overview } from './eli16-overview-check.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -270,10 +271,68 @@ if (!approvedMatch) {
   );
 }
 
+// ─── Step 7: ELI16 overview verification ─────────────────────────────────
+// Every approved spec must ship with a plain-English ELI16 overview. The
+// overview is the entry point for any reader who has to make a real decision
+// against the spec — the dense technical spec is for reviewers, not deciders.
+
+const eli16Result = checkEli16Overview(specPath, specFm);
+if (!eli16Result.ok) {
+  if (eli16Result.reason === 'missing') {
+    blockCommit(
+      inScopeFiles,
+      [
+        `Spec ${spec} has no ELI16 overview.`,
+        'Every approved spec must ship with a plain-English overview at:',
+        `  • Sibling path: ${path.relative(ROOT, eli16Result.siblingPath)}`,
+        '  • OR declared via spec frontmatter: eli16-overview: <relative-path>',
+        '',
+        'An ELI16 overview is a ~16-year-old-reading-level companion to the',
+        "technical spec — it leads with what the change actually is in plain",
+        "English, what already exists, what's new, and what the reader needs",
+        'to decide. The technical spec is the appendix, not the entry point.',
+        '',
+        'See skills/instar-dev/templates/eli16-overview.md for a template.',
+      ].join('\n'),
+    );
+  } else if (eli16Result.reason === 'declared-not-found') {
+    blockCommit(
+      inScopeFiles,
+      [
+        `Spec ${spec} declares an ELI16 overview at ${path.relative(ROOT, eli16Result.declaredPath)} (frontmatter eli16-overview),`,
+        'but that file does not exist. Create it before committing.',
+      ].join('\n'),
+    );
+  } else if (eli16Result.reason === 'too-short') {
+    blockCommit(
+      inScopeFiles,
+      [
+        `Spec ${spec}'s ELI16 overview at ${path.relative(ROOT, eli16Result.declaredPath)} is too short`,
+        `(${eli16Result.charCount} chars, need ${eli16Result.minChars}).`,
+        '',
+        "A stub isn't an overview — write a real one.",
+        'See skills/instar-dev/templates/eli16-overview.md for the expected shape.',
+      ].join('\n'),
+    );
+  }
+}
+
+// If the spec itself is staged, the ELI16 overview must ship with it.
+const eli16Rel = path.relative(ROOT, eli16Result.eli16Path).replace(/\\/g, '/');
+if (staged.includes(spec) && !staged.includes(eli16Rel)) {
+  blockCommit(
+    inScopeFiles,
+    [
+      `Spec ${spec} is staged but its ELI16 overview ${eli16Rel} is not.`,
+      'The overview must ship alongside the spec it accompanies.',
+    ].join('\n'),
+  );
+}
+
 // ─── Pass ────────────────────────────────────────────────────────────────
 
 console.error(
-  `[instar-dev-precommit] OK — trace ${path.basename(validTrace.entry.file)} covers ${inScopeFiles.length} in-scope file(s), artifact ${validTrace.trace.artifactPath} verified, spec ${spec} is converged + approved.`,
+  `[instar-dev-precommit] OK — trace ${path.basename(validTrace.entry.file)} covers ${inScopeFiles.length} in-scope file(s), artifact ${validTrace.trace.artifactPath} verified, spec ${spec} is converged + approved, ELI16 overview ${eli16Rel} present (${eli16Result.charCount} chars).`,
 );
 process.exit(0);
 

--- a/skills/instar-dev/SKILL.md
+++ b/skills/instar-dev/SKILL.md
@@ -40,9 +40,12 @@ Before any other phase runs, the instar-dev agent verifies the change is driven 
 - The change must be rooted in a spec file under `docs/specs/<slug>.md`.
 - That spec must have been run through `/spec-converge` to convergence (writes `review-convergence: <timestamp>` into the spec's frontmatter).
 - The user must have reviewed the convergence report and applied `approved: true` to the spec's frontmatter.
-- The spec path is passed to `write-trace.mjs` via `--spec` so the pre-commit hook can verify both tags.
+- The spec must ship with a plain-English **ELI16 overview** companion at `docs/specs/<slug>.eli16.md` (or another path declared via the spec's `eli16-overview:` frontmatter field). The overview must be at least 800 characters of real content — stubs are refused. See `skills/instar-dev/templates/eli16-overview.md` for the expected shape.
+- The spec path is passed to `write-trace.mjs` via `--spec` so the pre-commit hook can verify all three structural requirements (convergence tag, approval tag, ELI16 companion).
 
-If the spec is missing, not converged, or not approved, the pre-commit hook refuses the commit. No override inside the skill — the only exceptions are the foundational bootstrap commits that install `/instar-dev` and `/spec-converge` themselves.
+If the spec is missing, not converged, not approved, or lacks an ELI16 overview, the pre-commit hook refuses the commit. No override inside the skill — the only exceptions are the foundational bootstrap commits that install `/instar-dev` and `/spec-converge` themselves.
+
+The ELI16 overview is the entry point for any reader who has to make a real decision against the spec — the dense technical spec is for reviewers, not deciders. It leads with what the change actually is in plain English, what already exists, what's new, the safeguards in plain terms, and what the reader actually needs to decide.
 
 ### Phase 1 — Principle check
 

--- a/skills/instar-dev/templates/eli16-overview.md
+++ b/skills/instar-dev/templates/eli16-overview.md
@@ -1,0 +1,43 @@
+# <Spec Title> — Plain-English Overview
+
+> The one-line version: <the entire decision compressed into one sentence>.
+
+## The problem in one breath
+
+<Two or three sentences explaining what's actually broken / missing / needed. Plain English. No internal module names unless they're already in the user's vocabulary.>
+
+## What already exists
+
+<List the relevant pieces of the system that ARE already in production, named in plain terms. The reader needs to know what's already working before they can evaluate what's being added.>
+
+- **<Component A in plain terms>** — <what it does, what it doesn't do>
+- **<Component B in plain terms>** — <same>
+- ...
+
+## What this adds
+
+<Lead with the single biggest change. One paragraph max. Then bullet the secondary changes. Avoid type signatures, file paths, and internal field names unless naming them genuinely adds clarity.>
+
+## The new pieces
+
+<For each module/system being introduced, one paragraph in plain terms:>
+
+- **<Name>** — <what it does, what it's NOT allowed to do, why the line between them matters>
+
+## The safeguards
+
+<The amendments / guardrails / threat-model coverage, in plain terms. Group them — don't enumerate every finding. Something like:>
+
+**Prevents X from happening.** <one paragraph>
+
+**Prevents Y from happening.** <one paragraph>
+
+**Prevents Z from happening.** <one paragraph>
+
+## What ships when
+
+<The phases or PR order, in plain English. Roughly: foundation pieces ship first, then the wrappers/UI, then the optional layers.>
+
+## What you actually need to decide
+
+<End with the explicit decision being asked of the reader. Should be one sentence ending with a clear yes/no or shape-question. The reader should know exactly what they're saying yes to.>

--- a/skills/spec-converge/SKILL.md
+++ b/skills/spec-converge/SKILL.md
@@ -144,6 +144,8 @@ review-completed-at: "<ISO timestamp>"
 review-report: "docs/specs/reports/<slug>-convergence.md"
 ```
 
+**Structural prerequisite — ELI16 overview.** Before the convergence tag is written, `skills/spec-converge/scripts/write-convergence-tag.mjs` verifies the spec ships with a plain-English ELI16 companion at `docs/specs/<slug>.eli16.md` (or the path declared via `eli16-overview:` frontmatter). The companion must be at least 800 characters. If the overview is missing or stub-length, convergence is refused — no tag is written. The dense technical spec is for reviewers; the ELI16 overview is the entry point for any reader who has to make a real decision. See `skills/instar-dev/templates/eli16-overview.md` for the expected shape.
+
 The `approved: true` tag is NOT written by this skill. That's the user's step.
 
 ### Phase 6 — User handoff

--- a/skills/spec-converge/scripts/write-convergence-tag.mjs
+++ b/skills/spec-converge/scripts/write-convergence-tag.mjs
@@ -24,6 +24,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { checkEli16Overview } from '../../../scripts/eli16-overview-check.mjs';
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -63,6 +64,34 @@ if (!fs.existsSync(reportPath)) {
 }
 
 const content = fs.readFileSync(specPath, 'utf-8');
+
+// ─── ELI16 overview check ────────────────────────────────────────────────
+// Convergence cannot be stamped onto a spec without a plain-English overview.
+const _fmHeadMatch = content.match(/^---\n([\s\S]*?)\n---\n/);
+const _eli16Result = checkEli16Overview(specPath, _fmHeadMatch ? _fmHeadMatch[1] : '');
+if (!_eli16Result.ok) {
+  if (_eli16Result.reason === 'missing') {
+    console.error(
+      `Spec ${specArg} has no ELI16 overview.\n` +
+      `Convergence cannot be stamped without a plain-English companion at:\n` +
+      `  • Sibling path: ${path.relative(ROOT, _eli16Result.siblingPath)}\n` +
+      `  • OR declared via spec frontmatter: eli16-overview: <relative-path>\n` +
+      `See skills/instar-dev/templates/eli16-overview.md for the expected shape.`,
+    );
+  } else if (_eli16Result.reason === 'declared-not-found') {
+    console.error(
+      `Spec ${specArg} declares an ELI16 overview at ${path.relative(ROOT, _eli16Result.declaredPath)},\n` +
+      `but that file does not exist.`,
+    );
+  } else if (_eli16Result.reason === 'too-short') {
+    console.error(
+      `Spec ${specArg}'s ELI16 overview at ${path.relative(ROOT, _eli16Result.declaredPath)} is too short ` +
+      `(${_eli16Result.charCount} chars, need ${_eli16Result.minChars}).\n` +
+      `A stub isn't an overview. See skills/instar-dev/templates/eli16-overview.md.`,
+    );
+  }
+  process.exit(1);
+}
 
 // Parse YAML frontmatter manually (no dependency).
 // Expect: /^---\n<body>\n---\n<rest>/

--- a/tests/unit/eli16-overview-check.test.ts
+++ b/tests/unit/eli16-overview-check.test.ts
@@ -1,0 +1,145 @@
+// Unit tests for the shared ELI16 overview check used by /instar-dev's
+// pre-commit gate and /spec-converge's convergence-tag writer. Both gates
+// share scripts/eli16-overview-check.mjs to enforce one rule: every approved
+// spec must ship with a plain-English companion of at least MIN_ELI16_CHARS.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor';
+// @ts-expect-error: .mjs script, not typed
+import { checkEli16Overview, resolveEli16Path, MIN_ELI16_CHARS } from '../../scripts/eli16-overview-check.mjs';
+
+let tmpDir: string;
+let specPath: string;
+
+function writeSpec(frontmatter: string) {
+  const content = `---\n${frontmatter}\n---\n\n# Test Spec\n\nBody.\n`;
+  fs.writeFileSync(specPath, content, 'utf8');
+  return frontmatter;
+}
+
+function writeEli16(filePath: string, charCount: number) {
+  const prefix = '# Overview\n\n';
+  const body = 'x'.repeat(Math.max(0, charCount - prefix.length));
+  fs.writeFileSync(filePath, prefix + body, 'utf8');
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eli16-check-'));
+  specPath = path.join(tmpDir, 'foo.md');
+});
+
+afterEach(() => {
+  try {
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'eli16-overview-check.test cleanup',
+    });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('resolveEli16Path', () => {
+  it('returns sibling path when sibling exists and frontmatter is silent', () => {
+    const fm = writeSpec('title: Foo');
+    const siblingPath = path.join(tmpDir, 'foo.eli16.md');
+    writeEli16(siblingPath, 1000);
+    const r = resolveEli16Path(specPath, fm);
+    expect(r.resolvedPath).toBe(siblingPath);
+    expect(r.source).toBe('sibling');
+  });
+
+  it('prefers frontmatter declaration over sibling', () => {
+    const fm = writeSpec('title: Foo\neli16-overview: alt-overview.md');
+    const siblingPath = path.join(tmpDir, 'foo.eli16.md');
+    const declaredPath = path.join(tmpDir, 'alt-overview.md');
+    writeEli16(siblingPath, 1000);
+    writeEli16(declaredPath, 1000);
+    const r = resolveEli16Path(specPath, fm);
+    expect(r.resolvedPath).toBe(declaredPath);
+    expect(r.source).toBe('frontmatter');
+  });
+
+  it('returns null path when neither sibling nor frontmatter is present', () => {
+    const fm = writeSpec('title: Foo');
+    const r = resolveEli16Path(specPath, fm);
+    expect(r.resolvedPath).toBeNull();
+    expect(r.source).toBeNull();
+  });
+
+  it('strips surrounding quotes from frontmatter declaration', () => {
+    const fm = writeSpec('title: Foo\neli16-overview: "alt.md"');
+    const r = resolveEli16Path(specPath, fm);
+    expect(r.resolvedPath).toBe(path.join(tmpDir, 'alt.md'));
+  });
+});
+
+describe('checkEli16Overview', () => {
+  it('passes when sibling exists and is long enough', () => {
+    const fm = writeSpec('title: Foo');
+    writeEli16(path.join(tmpDir, 'foo.eli16.md'), MIN_ELI16_CHARS + 100);
+    const r = checkEli16Overview(specPath, fm);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.charCount).toBeGreaterThanOrEqual(MIN_ELI16_CHARS);
+      expect(r.source).toBe('sibling');
+    }
+  });
+
+  it('passes when frontmatter-declared file exists and is long enough', () => {
+    const fm = writeSpec('title: Foo\neli16-overview: docs/overview.md');
+    fs.mkdirSync(path.join(tmpDir, 'docs'));
+    writeEli16(path.join(tmpDir, 'docs', 'overview.md'), MIN_ELI16_CHARS + 100);
+    const r = checkEli16Overview(specPath, fm);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.source).toBe('frontmatter');
+  });
+
+  it('blocks when no overview exists at all', () => {
+    const fm = writeSpec('title: Foo');
+    const r = checkEli16Overview(specPath, fm);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('missing');
+      expect(r.siblingPath).toBe(path.join(tmpDir, 'foo.eli16.md'));
+    }
+  });
+
+  it('blocks when frontmatter declares a non-existent path', () => {
+    const fm = writeSpec('title: Foo\neli16-overview: missing.md');
+    const r = checkEli16Overview(specPath, fm);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('declared-not-found');
+  });
+
+  it('blocks when sibling exists but is too short', () => {
+    const fm = writeSpec('title: Foo');
+    writeEli16(path.join(tmpDir, 'foo.eli16.md'), 100);
+    const r = checkEli16Overview(specPath, fm);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('too-short');
+      expect(r.charCount).toBeLessThan(MIN_ELI16_CHARS);
+      expect(r.minChars).toBe(MIN_ELI16_CHARS);
+    }
+  });
+
+  it('treats a stub of exactly the minimum length as passing', () => {
+    const fm = writeSpec('title: Foo');
+    writeEli16(path.join(tmpDir, 'foo.eli16.md'), MIN_ELI16_CHARS);
+    const r = checkEli16Overview(specPath, fm);
+    expect(r.ok).toBe(true);
+  });
+
+  it('treats one character below minimum as too-short', () => {
+    const fm = writeSpec('title: Foo');
+    writeEli16(path.join(tmpDir, 'foo.eli16.md'), MIN_ELI16_CHARS - 1);
+    const r = checkEli16Overview(specPath, fm);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('too-short');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -5,61 +5,40 @@ note (`upgrades/<version>.md`) at release-cut time.
 
 ---
 
-### feat(cli): Phase 3 — `instar job migrate` for jobs-as-agentmd
-
-New CLI subcommand `instar job migrate` converts a legacy `jobs.json` agent to the per-slug-manifest layout. Flags: `--default-action fork|rename|skip|fail` (default `fail`), `--report` (dry-run), `--abandon` (one-button rollback). Always writes a pre-migrate backup before any other change. Idempotent. Implements the Seamless Migration Guarantee suite's CLI-path coverage (PR #180 invariants 1, 2, 5, 9). 11 unit tests pass locally. Phase 4 will add the Dashboard confirm step and interactive prompts; Phase 5 will auto-run on update.
-
 ## What Changed
 
 ### F-1 — RemediationKeyVault (Tier-1 foundation for Self-Healing Remediator)
 
-- **Adds** `src/remediation/RemediationKeyVault.ts` — per-context, per-scope
-  HKDF-SHA256 leaf-key derivation with a 4-backend secret store (OS keychain,
-  hardware enclave stub, cloud KMS stub, env-passphrase + AES-256-GCM flatfile).
-- Per amendments A20, A23, A39, A42, A51, A54, A58, A62 of
-  `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md`.
-- **No runtime consumers yet.** F-2+ wires capability tokens, probe
-  authentication, in-flight lockfiles, the cross-process attempt ledger, and
-  the audit-token writer onto the leaf-key surface.
-- **Operational notes.** On macOS and Linux+libsecret hosts the vault uses the
-  OS keychain (entries under `ai.instar.remediation.*`). On headless or
-  containerized hosts, set `INSTAR_REMEDIATION_KEY_PASSPHRASE` and the vault
-  stores keys in an AES-256-GCM-encrypted flatfile at
-  `<stateDir>/remediation-keys.age` (`.age` is forward-compat naming; the inner
-  format is Node-native AES-GCM, NOT the `age` library).
-- **Known follow-ups.** A39's per-binary-path keychain ACL
-  (`SecAccessCreateWithOwnerAndACL`) is NOT applied in F-1 — entries use the OS
-  default ACL. F-2 layers the scoped ACL via a native binding. Hardware-enclave
-  and cloud-KMS backends are explicit stubs; F-2+ implements detection and
-  key-wrapping for TPM 2.0 / Secure Enclave / AWS-KMS / GCP-KMS / Azure-Key-Vault.
+- **Adds** `src/remediation/RemediationKeyVault.ts` — per-context, per-scope HKDF-SHA256 leaf-key derivation with a 4-backend secret store (OS keychain, hardware enclave stub, cloud KMS stub, env-passphrase + AES-256-GCM flatfile).
+- Per amendments A20, A23, A39, A42, A51, A54, A58, A62 of `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md`.
+- **No runtime consumers yet.** F-2+ wires capability tokens, probe authentication, in-flight lockfiles, the cross-process attempt ledger, and the audit-token writer onto the leaf-key surface.
+
+### feat(instar-dev): ELI16 overview required for every approved spec
+
+`/instar-dev`'s pre-commit gate and `/spec-converge`'s convergence-tag writer now both refuse to advance a spec that ships without a plain-English ELI16 overview. Topic 3079 on 2026-05-13 surfaced this directly: "I can't digest this without an ELI16 overview. That should be required for every spec."
+
+This release adds a deterministic structural gate. The overview lives at `docs/specs/<slug>.eli16.md` by default (or any path declared via the spec's `eli16-overview:` frontmatter field) and must be at least 800 characters of real content. Stubs are refused. Both gates share `scripts/eli16-overview-check.mjs` so the rule is uniform across convergence-time and commit-time enforcement.
+
+- New shared check module `scripts/eli16-overview-check.mjs` exposes `resolveEli16Path()` and `checkEli16Overview()` with `MIN_ELI16_CHARS = 800` floor.
+- `scripts/instar-dev-precommit.js` adds Step 7 after spec-tag verification: refuses commit if the referenced spec has no ELI16 companion or the companion is a stub.
+- `skills/spec-converge/scripts/write-convergence-tag.mjs` adds a pre-check before stamping `review-convergence`: refuses to mark a spec converged without an ELI16 companion.
+- New template at `skills/instar-dev/templates/eli16-overview.md`. Updated `skills/instar-dev/SKILL.md` Phase 0 and `skills/spec-converge/SKILL.md` Phase 5.
+- 11 new unit tests in `tests/unit/eli16-overview-check.test.ts` — all passing.
+
+Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 
 ## What to Tell Your User
 
-Nothing user-visible yet. F-1 is plumbing for the Self-Healing Remediator —
-later phases (F-2 through F-7) will surface user-facing capabilities (automatic
-detection and repair of broken instar features). If a user asks "what does this
-release do for me?" the honest answer is: "It lays the cryptographic foundation
-so future self-healing features can prove which probe ran, which capability
-detected a fault, and which agent attempted a repair — without those proofs
-being forgeable."
+**F-1 — Cryptographic foundation for self-healing.** Nothing user-visible yet. Operators running on headless Linux without libsecret should set `INSTAR_REMEDIATION_KEY_PASSPHRASE` in their environment before any F-2+ feature ships. macOS and Linux+libsecret have nothing to do.
 
-Operators running on headless Linux without libsecret should set
-`INSTAR_REMEDIATION_KEY_PASSPHRASE` in their environment before any F-2+ feature
-ships. macOS users and Linux users with libsecret installed have nothing to do.
+**ELI16-overview gate.** When your agent hands you a spec for approval, you'll now always get a plain-English overview alongside the dense technical document. The instar repo refuses to commit any code change whose driving spec lacks a readable companion file. The technical spec becomes the appendix; the overview is the entry point. No setup required; the new behavior takes effect on the next agent update.
 
 ## Summary of New Capabilities
 
-- **`RemediationKeyVault`** — programmatic API for deriving 32-byte HKDF-SHA256
-  leaf keys scoped to one of five contexts (`capability`, `probe`, `inflight`,
-  `ledger`, `audit`) and an opaque scope id. Same `(context, scopeId)` → same
-  key, deterministically; rotating the install nonce or a context master
-  invalidates the corresponding leaves.
-- **4-backend secret store** — OS keychain (macOS `security`, Linux
-  `secret-tool`) is preferred; hardware-enclave and cloud-KMS are stubbed for
-  Tier-1; env-passphrase + AES-256-GCM flatfile at
-  `<stateDir>/remediation-keys.age` is the fallback.
-- **Install nonce** — 256-bit random anchor stored under
-  `ai.instar.remediation.install-nonce`; auto-initialized on first boot,
-  fail-closed if missing on an existing install.
-- **No runtime wiring yet.** Module ships behind no callers — F-2 is the first
-  consumer.
+- **`RemediationKeyVault`** (F-1) — HKDF-SHA256 leaf keys scoped to one of five contexts (`capability`, `probe`, `inflight`, `ledger`, `audit`) and an opaque scope id.
+- **4-backend secret store** (F-1) — OS keychain preferred; hardware-enclave and cloud-KMS stubbed; env-passphrase + AES-256-GCM flatfile fallback.
+- **Install nonce** (F-1) — 256-bit random anchor stored under `ai.instar.remediation.install-nonce`; auto-initialized on first boot, fail-closed if missing.
+- **ELI16-overview gate** — Structural enforcement at both convergence-time and commit-time. Specs handed for approval always carry a plain-English companion.
+- **Shared check module** at `scripts/eli16-overview-check.mjs` — `resolveEli16Path()` and `checkEli16Overview()` with 800-char minimum-length floor.
+- **Template for ELI16 overviews** at `skills/instar-dev/templates/eli16-overview.md`.
+- **Forward-only enforcement** — only specs newly committed-against after this ships have to satisfy the gate.

--- a/upgrades/side-effects/eli16-overview-required-gate.md
+++ b/upgrades/side-effects/eli16-overview-required-gate.md
@@ -1,0 +1,77 @@
+# Side-Effects Review — ELI16 overview required for every approved spec
+
+**Version / slug:** `eli16-overview-required-gate`
+**Date:** 2026-05-13
+**Author:** echo
+**Second-pass reviewer:** not required (structural gate; deterministic; small surface)
+
+## Summary of the change
+
+Adds a third structural check to the `/instar-dev` precommit gate and to `/spec-converge`'s convergence-tag writer: every approved spec must ship with a plain-English ELI16 overview at `docs/specs/<slug>.eli16.md` (or a path declared via the spec's `eli16-overview:` frontmatter field). The overview must be at least 800 characters of trimmed content — stubs are refused. Files touched: `scripts/eli16-overview-check.mjs` (new shared module), `scripts/instar-dev-precommit.js`, `skills/spec-converge/scripts/write-convergence-tag.mjs`, `skills/instar-dev/SKILL.md`, `skills/spec-converge/SKILL.md`, `skills/instar-dev/templates/eli16-overview.md` (new template), `tests/unit/eli16-overview-check.test.ts` (new unit test).
+
+## Decision-point inventory
+
+- `scripts/instar-dev-precommit.js` Step 7 (new) — **add** — refuses a commit if the spec referenced by the trace has no ELI16 companion or the companion is a stub. Pure file-existence + length check; deterministic; no LLM judgment.
+- `skills/spec-converge/scripts/write-convergence-tag.mjs` (new pre-check) — **add** — refuses to stamp `review-convergence` on a spec without an ELI16 companion. Same deterministic check.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- **Bootstrap exceptions remain intact.** The existing bootstrap-trigger logic for the precommit gate (which lets the gate's own first-ship pass) is upstream of the ELI16 check; bootstrap commits already exit before any spec-tag verification runs. So no over-block on bootstrap.
+- **Out-of-scope commits remain unaffected.** The ELI16 check runs only after `inScopeFiles.length > 0` and after the spec-tag verification, so docs-only or release-note commits never hit it.
+- **Existing approved specs with shipped work.** Forward-only — old specs whose work has already merged are not re-committed against, so the gate doesn't fire on them. If a contributor wants to amend an old spec post-ship, they'll need to add an ELI16; this is the intended behavior.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- An ELI16 file that satisfies the length requirement but contains low-quality / jargon-heavy / non-ELI16 prose. The gate checks file existence and length, not reading-level. This is intentional: deterministic check, no LLM judgment in a precommit hook. Reading-level enforcement happens at the human-review step (the user reads the overview before applying `approved: true`).
+- An ELI16 file that's pure boilerplate copied from the template. The 800-char floor reduces this risk but doesn't eliminate it. Mitigation: the template's section headers are themselves substantive prompts requiring real content; copying without filling-in is hard to disguise at 800+ chars.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer? Should a higher or lower layer own it? Does a smarter gate already exist?**
+
+Yes — this is at the same layer as the existing review-convergence and approved tag checks. Same deterministic-file-check shape, same precommit + convergence-write hook points, same shared concern (spec quality at handoff time). No smarter gate exists for "is the spec readable by the decider"; the existing gates verify that review *happened*, not that the spec is *legible*.
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or does it produce a signal?**
+
+Authoritative, deterministic, structural. The check is file-existence + content-length — both verifiable, both stable, no LLM/regex/parsing surprises. This is the canonical shape for blocking authority per `docs/signal-vs-authority.md`: structural gates are allowed to block; brittle/heuristic gates produce signals for a smarter gate.
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, race?**
+
+- **Order in precommit:** runs after spec-tag verification (`review-convergence`, `approved: true`). If either of those fails, the ELI16 check is never reached — single source of error at a time.
+- **Order in spec-converge:** runs BEFORE the convergence tag is written. Prevents the asymmetric state where a spec is tagged converged but has no overview.
+- **Duplicate check on commit:** both `write-convergence-tag.mjs` (at convergence time) and `instar-dev-precommit.js` (at commit time) verify the ELI16. This is intentional belt-and-suspenders — a spec that lost its ELI16 between convergence and commit (file deleted) is still caught at commit.
+- **No race conditions.** Both checks are synchronous read-only file checks.
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents, other users, other systems?**
+
+- Other agents using `/instar-dev` against the instar repo will see the new check fire on any commit referencing a spec without an ELI16. Error message is explicit about how to fix (add a sibling file or declare via frontmatter).
+- Users handed a spec by an agent will receive an ELI16 overview by default — this is the user-visible improvement that motivated the gate. Topic 3079 (2026-05-13) was the trigger.
+- No timing dependencies, no conversation state, no runtime conditions. The check sees the filesystem at commit time, period.
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Single-line revert in each of two files: comment out the `checkEli16Overview` block in `scripts/instar-dev-precommit.js` (Step 7) and in `skills/spec-converge/scripts/write-convergence-tag.mjs` (pre-check). No data migration. No state mutation. No effect on already-tagged specs. The shared module `scripts/eli16-overview-check.mjs` becomes dead code until removed, but that's harmless. The template at `skills/instar-dev/templates/eli16-overview.md` remains as documentation. The next release picks up the revert automatically — no schema or wire-format change to coordinate.
+
+## Trust elevation
+
+Not applicable — no autonomy profile change, no new trust-level surface.
+
+## Side-effects on adjacent systems
+
+- `husky/pre-commit` calls `instar-dev-precommit.js`; no change to husky config.
+- The release-cut publish gate is unaffected: ELI16 enforcement is at commit-time, not at release-cut time. Spec authors get the error at the point of authorship, where it's fastest to fix.
+- Backup/sync: no new state files. The ELI16 companion is a regular spec sibling, gitignored or not per the repo's existing `.gitignore`.


### PR DESCRIPTION
## Summary

Closes the failure mode where a converged spec is handed to a decider as a dense technical document with no readable entry point. Topic 3079 on 2026-05-13 surfaced this: _"I can't digest this without an ELI16 overview. That should be required for every spec."_

Both `/instar-dev`'s pre-commit gate and `/spec-converge`'s convergence-tag writer now refuse to advance a spec that ships without a plain-English ELI16 companion at `docs/specs/<slug>.eli16.md` (or a path declared via the spec's `eli16-overview:` frontmatter field). The companion must be at least 800 chars of real content — stubs are refused.

The check is deterministic — file-existence + content-length — and shares `scripts/eli16-overview-check.mjs` across both gates. Rollback is a single-line revert in each of two scripts. No data migration.

A template at `skills/instar-dev/templates/eli16-overview.md` documents the expected shape. This spec ships with its own ELI16 sibling as the self-test of the gate.

## Test plan

- [x] 11 new unit cases in `tests/unit/eli16-overview-check.test.ts` — all passing locally
- [x] Sibling resolution
- [x] Frontmatter override precedence
- [x] Missing-overview block
- [x] Declared-but-non-existent block
- [x] Exactly-at-min-length passes
- [x] One-char-below-min-length blocks
- [x] Self-test: gate passed against its own spec at commit time
- [ ] CI green
- [ ] Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)