### PR TITLE
feat(monitoring): F-2 — Redactor + ErrorCodeExtractor (Self-Healing Remediator v2 foundation)

### DIFF
--- a/src/monitoring/ErrorCodeExtractor.ts
+++ b/src/monitoring/ErrorCodeExtractor.ts
@@ -1,0 +1,177 @@
+/**
+ * ErrorCodeExtractor — structured errorCode extraction with provenance.
+ *
+ * Owns the contract that NormalizedDegradationEvent.errorCode carries a
+ * provenance tag. Per SELF-HEALING-REMEDIATOR-V2-SPEC.md §A6, runbooks
+ * may only match against events whose errorCode came from a structured
+ * source ("native-binding", "probe-id", "subsystem-explicit"). Free-text
+ * extraction is allowed at the event layer (so events aren't dropped)
+ * but the registry-load-time validator REFUSES to register any runbook
+ * whose eventPrefilter.errorCode matches free-text-provenance events.
+ *
+ * Extraction priority (highest first):
+ *   1. probeEmission with verified signature → "probe-id"
+ *   2. subsystemExplicit                     → "subsystem-explicit"
+ *   3. nativeError.code (Node Error.code)    → "native-binding"
+ *   4. freeText regex extraction             → "free-text"
+ *   5. Fallback                              → "UNKNOWN_ERROR" / "free-text"
+ *
+ * F-2 foundation module — built before any v2 wrapper PR (W-*) so the
+ * provenance contract exists before runbook matchers consume it.
+ */
+
+export type ErrorProvenance =
+  | 'native-binding'
+  | 'probe-id'
+  | 'subsystem-explicit'
+  | 'free-text';
+
+export interface ExtractedErrorCode {
+  /** Canonical errorCode string, e.g. 'NATIVE_MODULE_ABI_MISMATCH'. */
+  code: string;
+  /** Where the code came from — gates runbook matching. */
+  provenance: ErrorProvenance;
+}
+
+export interface ProbeEmission {
+  probeId: string;
+  errorCode: string;
+  /** HMAC signature of (probeId|errorCode) — must verify before trust. */
+  signature: string;
+}
+
+export interface ErrorCodeExtractorInput {
+  /** The original Error object, if available. */
+  nativeError?: unknown;
+  /** Probe-supplied errorCode + signature, if probe-emitted. */
+  probeEmission?: ProbeEmission;
+  /** Subsystem-supplied explicit errorCode, if caller set one. */
+  subsystemExplicit?: string;
+  /** Free-form error text for fallback regex extraction. */
+  freeText?: string;
+  /**
+   * Probe signature verifier. Injected so tests don't need real HMAC keys.
+   * Returns true if the probe emission is trustworthy. If not provided,
+   * probe emissions are treated as unverified and skipped (falling through
+   * to lower-priority sources). Per A6, only verified probe emissions are
+   * allowed to populate provenance: "probe-id".
+   */
+  verifyProbeSignature?: (emission: ProbeEmission) => boolean;
+}
+
+/**
+ * Free-text fallback patterns. Order matters — more specific patterns
+ * (NODE_MODULE_VERSION, SQLITE_*) run before generic ones so they win.
+ *
+ * NOTE: matchers consuming free-text-provenance results are refused at
+ * registry load (§A6). These patterns exist for observability and for
+ * SystemReviewer clustering (proposing new runbooks), not for matching.
+ */
+const FREE_TEXT_PATTERNS: Array<{ pattern: RegExp; mapper: (m: RegExpExecArray) => string }> = [
+  {
+    // Node native module ABI mismatches surface NODE_MODULE_VERSION first.
+    pattern: /NODE_MODULE_VERSION\s+\d+/,
+    mapper: () => 'NATIVE_MODULE_ABI_MISMATCH',
+  },
+  {
+    // better-sqlite3 / sqlite3 module errors prefix with SQLITE_*.
+    pattern: /SQLITE_([A-Z0-9]+)/,
+    mapper: (m) => `SQLITE_${m[1]}`,
+  },
+  {
+    pattern: /\b(EACCES|EPERM)\b/,
+    mapper: () => 'PERMISSION_DENIED',
+  },
+  {
+    pattern: /\b(ECONNREFUSED|ECONNRESET)\b/,
+    mapper: () => 'CONNECTION_FAILURE',
+  },
+];
+
+function extractFromFreeText(text: string): string {
+  for (const { pattern, mapper } of FREE_TEXT_PATTERNS) {
+    const m = pattern.exec(text);
+    if (m) return mapper(m);
+  }
+  return 'UNKNOWN_ERROR';
+}
+
+/**
+ * Read a `.code` property off a thrown value if present and string-typed.
+ * Node native modules and several stdlib paths set this (`ERR_*`, `EACCES`,
+ * etc.). We trust this field because it comes from a structured property,
+ * not parsed text — hence provenance: "native-binding".
+ */
+function readNativeCode(err: unknown): string | null {
+  if (err && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code: unknown }).code;
+    if (typeof code === 'string' && code.length > 0) return code;
+  }
+  return null;
+}
+
+export class ErrorCodeExtractor {
+  /**
+   * Extract a single ExtractedErrorCode following the priority ladder
+   * documented at the top of this file. Always returns a result — never
+   * throws — so callers can normalize unconditionally.
+   */
+  static extract(input: ErrorCodeExtractorInput): ExtractedErrorCode {
+    // 1. Verified probe emission wins. Without a verifier, probe emissions
+    //    are untrusted (an attacker could shape errorCode by spoofing the
+    //    probe path) so we fall through to the next source.
+    if (input.probeEmission) {
+      const verifier = input.verifyProbeSignature;
+      if (verifier && verifier(input.probeEmission)) {
+        return {
+          code: input.probeEmission.errorCode,
+          provenance: 'probe-id',
+        };
+      }
+      // Unverified probe emission — skip and try lower-priority sources.
+      // We don't trust the emission, but we also don't reject the whole
+      // event; the subsystem may still have supplied a structured code.
+    }
+
+    // 2. Subsystem-explicit errorCode — caller set this with no string
+    //    extraction, so we trust the structured source.
+    if (typeof input.subsystemExplicit === 'string' && input.subsystemExplicit.length > 0) {
+      return {
+        code: input.subsystemExplicit,
+        provenance: 'subsystem-explicit',
+      };
+    }
+
+    // 3. Native binding: Error.code from Node native modules.
+    const nativeCode = readNativeCode(input.nativeError);
+    if (nativeCode) {
+      return {
+        code: nativeCode,
+        provenance: 'native-binding',
+      };
+    }
+
+    // 4. Free-text fallback. Always free-text provenance, even when a
+    //    known pattern matches — the input was untrusted parsed text.
+    const freeText = typeof input.freeText === 'string' ? input.freeText : '';
+    return {
+      code: extractFromFreeText(freeText),
+      provenance: 'free-text',
+    };
+  }
+
+  /**
+   * Used by the runbook registry validator to refuse runbooks whose
+   * `eventPrefilter.errorCode` could match free-text-provenance events
+   * (§A6). Free-text matchers create an injection surface — attacker
+   * shapes error message → forces unintended runbook to fire — and are
+   * structurally forbidden at registry load.
+   */
+  static isAllowedForRunbookMatch(extracted: ExtractedErrorCode): boolean {
+    return (
+      extracted.provenance === 'native-binding' ||
+      extracted.provenance === 'probe-id' ||
+      extracted.provenance === 'subsystem-explicit'
+    );
+  }
+}

--- a/src/monitoring/Redactor.ts
+++ b/src/monitoring/Redactor.ts
@@ -1,0 +1,190 @@
+/**
+ * Redactor — content sanitization for normalized degradation events.
+ *
+ * Owns the redaction boundary that strips secrets, identifiers, and
+ * absolute paths from text before it crosses any persistence, alert,
+ * or LLM-prompt surface. The DegradationReporter (F-3) and downstream
+ * NormalizedDegradationEvent producers route every user-visible string
+ * through this module before emitting events.
+ *
+ * Surface (per SELF-HEALING-REMEDIATOR-V2-SPEC.md A26 / R1 carry-forward):
+ *
+ *   const r = new Redactor();
+ *   const { text, redactions } = r.redact(raw);
+ *   const safe = r.redactFields(event, ['reason', 'detail']);
+ *
+ * Default rules cover home-directory paths, bearer tokens, Telegram bot
+ * tokens, emails, long hex strings, UUIDs, IP addresses, and long numeric
+ * IDs. Custom rules can be appended via `extraRules`.
+ *
+ * F-2 foundation module — built before any v2 wrapper PR (W-*) so that
+ * normalized events have a single redaction owner. See spec §A1.
+ */
+
+export type RedactionCategory = 'path' | 'secret' | 'pii' | 'identifier' | 'custom';
+
+export interface RedactionRule {
+  pattern: RegExp;
+  replacement: string;
+  category: RedactionCategory;
+}
+
+export interface RedactorOptions {
+  /** Custom redaction rules to apply in addition to defaults. */
+  extraRules?: RedactionRule[];
+  /** Whether to redact home-directory paths (default true). */
+  redactHomePath?: boolean;
+}
+
+export interface RedactionSummary {
+  category: string;
+  count: number;
+}
+
+export interface RedactionResult {
+  text: string;
+  redactions: RedactionSummary[];
+}
+
+/**
+ * Build the default rule set. Order matters: more specific patterns must
+ * run before generic catch-alls (e.g., UUID before long-hex before NUM)
+ * so the broader rule doesn't shadow the specific one.
+ */
+function buildDefaultRules(redactHomePath: boolean): RedactionRule[] {
+  const rules: RedactionRule[] = [];
+
+  if (redactHomePath) {
+    // Home directory paths on macOS and Linux. Captures path after the
+    // username so the entire user-anchored prefix collapses to <HOME>.
+    rules.push({
+      pattern: /\/(?:Users|home)\/[^/\s]+/g,
+      replacement: '<HOME>',
+      category: 'path',
+    });
+  }
+
+  // Bearer tokens — match common Authorization-header shape.
+  rules.push({
+    pattern: /Bearer\s+[A-Za-z0-9_\-.]{20,}/g,
+    replacement: 'Bearer <REDACTED>',
+    category: 'secret',
+  });
+
+  // Telegram bot tokens — numeric chat-id : random suffix.
+  rules.push({
+    pattern: /\b\d{8,12}:[A-Za-z0-9_-]{30,}\b/g,
+    replacement: '<TELEGRAM_TOKEN>',
+    category: 'secret',
+  });
+
+  // Email addresses.
+  rules.push({
+    pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+    replacement: '<EMAIL>',
+    category: 'pii',
+  });
+
+  // UUIDs — run before generic long-hex so they keep their dash form.
+  rules.push({
+    pattern: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+    replacement: '<UUID>',
+    category: 'identifier',
+  });
+
+  // Long hex strings (SHA hashes, content addresses).
+  rules.push({
+    pattern: /\b[0-9a-f]{32,64}\b/gi,
+    replacement: '<HEX>',
+    category: 'identifier',
+  });
+
+  // IPv4 addresses.
+  rules.push({
+    pattern: /\b(?:\d{1,3}\.){3}\d{1,3}\b/g,
+    replacement: '<IP>',
+    category: 'identifier',
+  });
+
+  // IPv6 addresses — match colon-separated hextet groups. Lenient enough
+  // to cover compressed forms while avoiding false positives on times.
+  rules.push({
+    pattern: /\b(?:[0-9a-f]{1,4}:){2,7}[0-9a-f]{1,4}\b/gi,
+    replacement: '<IP>',
+    category: 'identifier',
+  });
+
+  // Long numeric IDs / timestamps (≥ 6 digits). Lowest priority so it
+  // doesn't eat hex/UUID prefixes that already redacted above.
+  rules.push({
+    pattern: /\b\d{6,}\b/g,
+    replacement: '<NUM>',
+    category: 'identifier',
+  });
+
+  return rules;
+}
+
+export class Redactor {
+  private readonly rules: RedactionRule[];
+
+  constructor(options: RedactorOptions = {}) {
+    const redactHomePath = options.redactHomePath !== false;
+    const defaults = buildDefaultRules(redactHomePath);
+    this.rules = [...defaults, ...(options.extraRules ?? [])];
+  }
+
+  /**
+   * Apply every rule in order; tally how many substitutions each category
+   * produced so callers can record a redaction summary on the event.
+   */
+  redact(text: string): RedactionResult {
+    if (typeof text !== 'string' || text.length === 0) {
+      return { text: text ?? '', redactions: [] };
+    }
+
+    const counts = new Map<string, number>();
+    let current = text;
+
+    for (const rule of this.rules) {
+      // Clone the regex with the global flag so we get an accurate match
+      // count without state leakage across calls.
+      const flags = rule.pattern.flags.includes('g')
+        ? rule.pattern.flags
+        : `${rule.pattern.flags}g`;
+      const re = new RegExp(rule.pattern.source, flags);
+
+      let matchCount = 0;
+      current = current.replace(re, () => {
+        matchCount += 1;
+        return rule.replacement;
+      });
+
+      if (matchCount > 0) {
+        counts.set(rule.category, (counts.get(rule.category) ?? 0) + matchCount);
+      }
+    }
+
+    const redactions: RedactionSummary[] = Array.from(counts.entries()).map(
+      ([category, count]) => ({ category, count }),
+    );
+
+    return { text: current, redactions };
+  }
+
+  /**
+   * Apply `redact` to every string-valued field named in `fields`. Non-string
+   * fields pass through untouched; missing fields are skipped. Returns a
+   * shallow clone — does NOT mutate the caller's object.
+   */
+  redactFields<T extends Record<string, unknown>>(obj: T, fields: (keyof T)[]): T {
+    const clone: Record<string, unknown> = { ...obj };
+    for (const key of fields) {
+      const value = clone[key as string];
+      if (typeof value === 'string') {
+        clone[key as string] = this.redact(value).text;
+      }
+    }
+    return clone as T;
+  }
+}

--- a/tests/unit/ErrorCodeExtractor.test.ts
+++ b/tests/unit/ErrorCodeExtractor.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ErrorCodeExtractor,
+  type ProbeEmission,
+} from '../../src/monitoring/ErrorCodeExtractor.js';
+
+describe('ErrorCodeExtractor — priority ladder', () => {
+  it('verified probe emission wins over native code', () => {
+    const probe: ProbeEmission = {
+      probeId: 'probe-abi',
+      errorCode: 'NATIVE_MODULE_ABI_MISMATCH',
+      signature: 'sig',
+    };
+    const err = Object.assign(new Error('boom'), { code: 'ERR_NATIVE_MODULE_ABI_MISMATCH' });
+    const result = ErrorCodeExtractor.extract({
+      probeEmission: probe,
+      nativeError: err,
+      verifyProbeSignature: () => true,
+    });
+    expect(result.code).toBe('NATIVE_MODULE_ABI_MISMATCH');
+    expect(result.provenance).toBe('probe-id');
+  });
+
+  it('unverified probe emission falls through to lower-priority sources', () => {
+    const probe: ProbeEmission = {
+      probeId: 'probe-abi',
+      errorCode: 'SPOOFED_CODE',
+      signature: 'bad',
+    };
+    const err = Object.assign(new Error('boom'), { code: 'EACCES' });
+    const result = ErrorCodeExtractor.extract({
+      probeEmission: probe,
+      nativeError: err,
+      verifyProbeSignature: () => false,
+    });
+    expect(result.code).toBe('EACCES');
+    expect(result.provenance).toBe('native-binding');
+  });
+
+  it('subsystem-explicit wins over native code', () => {
+    const err = Object.assign(new Error('boom'), { code: 'EACCES' });
+    const result = ErrorCodeExtractor.extract({
+      subsystemExplicit: 'TOPIC_MEMORY_REINDEX_FAILED',
+      nativeError: err,
+    });
+    expect(result.code).toBe('TOPIC_MEMORY_REINDEX_FAILED');
+    expect(result.provenance).toBe('subsystem-explicit');
+  });
+
+  it('subsystem-explicit wins over free-text', () => {
+    const result = ErrorCodeExtractor.extract({
+      subsystemExplicit: 'CUSTOM_CODE',
+      freeText: 'NODE_MODULE_VERSION 127 something',
+    });
+    expect(result.code).toBe('CUSTOM_CODE');
+    expect(result.provenance).toBe('subsystem-explicit');
+  });
+});
+
+describe('ErrorCodeExtractor — native binding', () => {
+  it('extracts .code from a native Error', () => {
+    const err = Object.assign(new Error('open failed'), {
+      code: 'ERR_NATIVE_MODULE_ABI_MISMATCH',
+    });
+    const result = ErrorCodeExtractor.extract({ nativeError: err });
+    expect(result.code).toBe('ERR_NATIVE_MODULE_ABI_MISMATCH');
+    expect(result.provenance).toBe('native-binding');
+  });
+
+  it('extracts .code from a plain object with code field', () => {
+    const result = ErrorCodeExtractor.extract({
+      nativeError: { code: 'EACCES', message: 'permission denied' },
+    });
+    expect(result.code).toBe('EACCES');
+    expect(result.provenance).toBe('native-binding');
+  });
+
+  it('falls through to free-text when nativeError has no string .code', () => {
+    const err = Object.assign(new Error('boom'), { code: 123 as unknown });
+    const result = ErrorCodeExtractor.extract({
+      nativeError: err,
+      freeText: 'NODE_MODULE_VERSION 127',
+    });
+    expect(result.code).toBe('NATIVE_MODULE_ABI_MISMATCH');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('falls through to free-text when nativeError is null/undefined', () => {
+    const result = ErrorCodeExtractor.extract({
+      nativeError: null,
+      freeText: 'ECONNREFUSED at peer',
+    });
+    expect(result.code).toBe('CONNECTION_FAILURE');
+    expect(result.provenance).toBe('free-text');
+  });
+});
+
+describe('ErrorCodeExtractor — free-text patterns', () => {
+  it('matches NODE_MODULE_VERSION → NATIVE_MODULE_ABI_MISMATCH', () => {
+    const result = ErrorCodeExtractor.extract({
+      freeText:
+        'Error: The module was compiled against NODE_MODULE_VERSION 127. This version of Node.js requires NODE_MODULE_VERSION 141.',
+    });
+    expect(result.code).toBe('NATIVE_MODULE_ABI_MISMATCH');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('matches SQLITE_CORRUPT → SQLITE_CORRUPT', () => {
+    const result = ErrorCodeExtractor.extract({
+      freeText: 'SQLITE_CORRUPT: database disk image is malformed',
+    });
+    expect(result.code).toBe('SQLITE_CORRUPT');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('matches SQLITE_BUSY → SQLITE_BUSY', () => {
+    const result = ErrorCodeExtractor.extract({
+      freeText: 'SQLITE_BUSY: database is locked',
+    });
+    expect(result.code).toBe('SQLITE_BUSY');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('matches EACCES → PERMISSION_DENIED', () => {
+    const result = ErrorCodeExtractor.extract({
+      freeText: 'EACCES: permission denied, open /etc/shadow',
+    });
+    expect(result.code).toBe('PERMISSION_DENIED');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('matches EPERM → PERMISSION_DENIED', () => {
+    const result = ErrorCodeExtractor.extract({
+      freeText: 'EPERM: operation not permitted',
+    });
+    expect(result.code).toBe('PERMISSION_DENIED');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('matches ECONNREFUSED → CONNECTION_FAILURE', () => {
+    const result = ErrorCodeExtractor.extract({
+      freeText: 'connect ECONNREFUSED 127.0.0.1:4042',
+    });
+    expect(result.code).toBe('CONNECTION_FAILURE');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('matches ECONNRESET → CONNECTION_FAILURE', () => {
+    const result = ErrorCodeExtractor.extract({
+      freeText: 'socket hang up ECONNRESET',
+    });
+    expect(result.code).toBe('CONNECTION_FAILURE');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('returns UNKNOWN_ERROR for unrecognized free-text', () => {
+    const result = ErrorCodeExtractor.extract({
+      freeText: 'something completely novel happened in module X',
+    });
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    expect(result.provenance).toBe('free-text');
+  });
+
+  it('returns UNKNOWN_ERROR with no inputs at all', () => {
+    const result = ErrorCodeExtractor.extract({});
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    expect(result.provenance).toBe('free-text');
+  });
+});
+
+describe('ErrorCodeExtractor — isAllowedForRunbookMatch', () => {
+  it('rejects free-text provenance', () => {
+    expect(
+      ErrorCodeExtractor.isAllowedForRunbookMatch({
+        code: 'NATIVE_MODULE_ABI_MISMATCH',
+        provenance: 'free-text',
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts native-binding provenance', () => {
+    expect(
+      ErrorCodeExtractor.isAllowedForRunbookMatch({
+        code: 'EACCES',
+        provenance: 'native-binding',
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts probe-id provenance', () => {
+    expect(
+      ErrorCodeExtractor.isAllowedForRunbookMatch({
+        code: 'NATIVE_MODULE_ABI_MISMATCH',
+        provenance: 'probe-id',
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts subsystem-explicit provenance', () => {
+    expect(
+      ErrorCodeExtractor.isAllowedForRunbookMatch({
+        code: 'TOPIC_MEMORY_REINDEX_FAILED',
+        provenance: 'subsystem-explicit',
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/Redactor.test.ts
+++ b/tests/unit/Redactor.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+import { Redactor, type RedactionRule } from '../../src/monitoring/Redactor.js';
+
+describe('Redactor — default rules', () => {
+  it('redacts macOS home-directory paths', () => {
+    const r = new Redactor();
+    const result = r.redact('error reading /Users/justin/.instar/config.json');
+    expect(result.text).toContain('<HOME>');
+    expect(result.text).not.toContain('/Users/justin');
+    expect(result.redactions).toEqual(expect.arrayContaining([{ category: 'path', count: 1 }]));
+  });
+
+  it('redacts Linux home-directory paths', () => {
+    const r = new Redactor();
+    const result = r.redact('error reading /home/alice/.instar/config.json');
+    expect(result.text).toContain('<HOME>');
+    expect(result.text).not.toContain('/home/alice');
+  });
+
+  it('redacts bearer tokens', () => {
+    const r = new Redactor();
+    const result = r.redact('Authorization: Bearer sk_live_abcdef1234567890abcdef');
+    expect(result.text).toContain('Bearer <REDACTED>');
+    expect(result.text).not.toContain('sk_live_abcdef1234567890abcdef');
+    expect(result.redactions).toEqual(expect.arrayContaining([{ category: 'secret', count: 1 }]));
+  });
+
+  it('redacts Telegram bot tokens', () => {
+    const r = new Redactor();
+    const result = r.redact('bot token 1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_');
+    expect(result.text).toContain('<TELEGRAM_TOKEN>');
+    expect(result.text).not.toContain('1234567890:ABCDEFG');
+  });
+
+  it('redacts email addresses', () => {
+    const r = new Redactor();
+    const result = r.redact('contact alice@example.com for details');
+    expect(result.text).toContain('<EMAIL>');
+    expect(result.text).not.toContain('alice@example.com');
+    expect(result.redactions).toEqual(expect.arrayContaining([{ category: 'pii', count: 1 }]));
+  });
+
+  it('redacts UUIDs', () => {
+    const r = new Redactor();
+    const result = r.redact('session 550e8400-e29b-41d4-a716-446655440000 failed');
+    expect(result.text).toContain('<UUID>');
+    expect(result.text).not.toContain('550e8400');
+  });
+
+  it('redacts long hex strings', () => {
+    const r = new Redactor();
+    // 40-char SHA-1
+    const result = r.redact('commit da39a3ee5e6b4b0d3255bfef95601890afd80709 landed');
+    expect(result.text).toContain('<HEX>');
+    expect(result.text).not.toContain('da39a3ee5e6b4b0d3255bfef95601890afd80709');
+  });
+
+  it('redacts IPv4 addresses', () => {
+    const r = new Redactor();
+    const result = r.redact('connection to 192.168.1.42 refused');
+    expect(result.text).toContain('<IP>');
+    expect(result.text).not.toContain('192.168.1.42');
+  });
+
+  it('redacts IPv6 addresses', () => {
+    const r = new Redactor();
+    const result = r.redact('peer 2001:db8:85a3:0:0:8a2e:370:7334 closed');
+    expect(result.text).toContain('<IP>');
+    expect(result.text).not.toContain('2001:db8:85a3');
+  });
+
+  it('redacts long numeric IDs (≥ 6 digits)', () => {
+    const r = new Redactor();
+    const result = r.redact('user 1234567 not found');
+    expect(result.text).toContain('<NUM>');
+    expect(result.text).not.toContain('1234567');
+  });
+
+  it('does not redact short numbers (< 6 digits)', () => {
+    const r = new Redactor();
+    const result = r.redact('returned 42 records, retry in 30 seconds');
+    expect(result.text).toBe('returned 42 records, retry in 30 seconds');
+  });
+});
+
+describe('Redactor — composition', () => {
+  it('applies multiple rules in a single pass', () => {
+    const r = new Redactor();
+    const result = r.redact(
+      'user alice@example.com on session 550e8400-e29b-41d4-a716-446655440000 from 10.0.0.1',
+    );
+    expect(result.text).toContain('<EMAIL>');
+    expect(result.text).toContain('<UUID>');
+    expect(result.text).toContain('<IP>');
+    expect(result.text).not.toContain('alice@example.com');
+    expect(result.text).not.toContain('550e8400');
+    expect(result.text).not.toContain('10.0.0.1');
+  });
+
+  it('reports redaction counts grouped by category', () => {
+    const r = new Redactor();
+    const result = r.redact('a@b.co and c@d.co both at /Users/justin/x');
+    const pii = result.redactions.find((x) => x.category === 'pii');
+    const path = result.redactions.find((x) => x.category === 'path');
+    expect(pii?.count).toBe(2);
+    expect(path?.count).toBe(1);
+  });
+
+  it('UUIDs are not eaten by the long-hex rule (UUID runs first)', () => {
+    const r = new Redactor();
+    const result = r.redact('id=550e8400-e29b-41d4-a716-446655440000');
+    expect(result.text).toContain('<UUID>');
+    expect(result.text).not.toContain('<HEX>');
+  });
+
+  it('returns empty redactions array when nothing matches', () => {
+    const r = new Redactor();
+    const result = r.redact('a plain sentence with no secrets');
+    expect(result.text).toBe('a plain sentence with no secrets');
+    expect(result.redactions).toEqual([]);
+  });
+
+  it('handles empty input gracefully', () => {
+    const r = new Redactor();
+    expect(r.redact('').text).toBe('');
+    expect(r.redact('').redactions).toEqual([]);
+  });
+});
+
+describe('Redactor — redactFields', () => {
+  it('redacts only the specified fields', () => {
+    const r = new Redactor();
+    const event = {
+      subsystem: 'TopicMemory',
+      reason: 'failed at /Users/justin/.instar/db',
+      stack: 'Error at /Users/justin/code/file.ts:42',
+      retries: 3,
+    } as const;
+
+    const redacted = r.redactFields(event, ['reason']);
+    expect(redacted.reason).toContain('<HOME>');
+    // stack was NOT in the field list, so it stays unredacted
+    expect(redacted.stack).toContain('/Users/justin');
+    // non-string fields pass through
+    expect(redacted.retries).toBe(3);
+    // subsystem unchanged
+    expect(redacted.subsystem).toBe('TopicMemory');
+  });
+
+  it('does not mutate the input object', () => {
+    const r = new Redactor();
+    const event = { reason: 'leak alice@example.com', other: 'x' };
+    const before = event.reason;
+    r.redactFields(event, ['reason']);
+    expect(event.reason).toBe(before);
+  });
+
+  it('skips missing fields without throwing', () => {
+    const r = new Redactor();
+    const event = { reason: 'plain' } as Record<string, unknown>;
+    const redacted = r.redactFields(event, ['reason', 'missing']);
+    expect(redacted.reason).toBe('plain');
+    expect(redacted.missing).toBeUndefined();
+  });
+
+  it('skips non-string fields without throwing', () => {
+    const r = new Redactor();
+    const event = { reason: 'alice@example.com', count: 42, nested: { inner: 'x' } };
+    const redacted = r.redactFields(event, ['reason', 'count', 'nested']);
+    expect(redacted.reason).toContain('<EMAIL>');
+    expect(redacted.count).toBe(42);
+    expect(redacted.nested).toEqual({ inner: 'x' });
+  });
+});
+
+describe('Redactor — custom rules', () => {
+  it('applies extraRules in addition to defaults', () => {
+    const extra: RedactionRule = {
+      pattern: /\bsecret-[a-z]+\b/g,
+      replacement: '<CUSTOM>',
+      category: 'custom',
+    };
+    const r = new Redactor({ extraRules: [extra] });
+    const result = r.redact('value secret-foo and alice@example.com');
+    expect(result.text).toContain('<CUSTOM>');
+    expect(result.text).toContain('<EMAIL>');
+    expect(result.redactions).toEqual(expect.arrayContaining([{ category: 'custom', count: 1 }]));
+  });
+
+  it('extraRules with non-global pattern still match all occurrences', () => {
+    const extra: RedactionRule = {
+      pattern: /badword/,
+      replacement: '<BAD>',
+      category: 'custom',
+    };
+    const r = new Redactor({ extraRules: [extra] });
+    const result = r.redact('badword and badword again');
+    expect(result.text).toBe('<BAD> and <BAD> again');
+    expect(result.redactions).toEqual(expect.arrayContaining([{ category: 'custom', count: 2 }]));
+  });
+});
+
+describe('Redactor — home-path toggle', () => {
+  it('redactHomePath:false disables home-dir redaction', () => {
+    const r = new Redactor({ redactHomePath: false });
+    const result = r.redact('error at /Users/justin/.instar/db');
+    expect(result.text).toContain('/Users/justin');
+    expect(result.text).not.toContain('<HOME>');
+  });
+
+  it('redactHomePath:true (default) redacts home dir', () => {
+    const r = new Redactor({ redactHomePath: true });
+    const result = r.redact('error at /Users/justin/.instar/db');
+    expect(result.text).toContain('<HOME>');
+  });
+
+  it('other rules still fire when home-path is disabled', () => {
+    const r = new Redactor({ redactHomePath: false });
+    const result = r.redact('email alice@example.com path /Users/justin');
+    expect(result.text).toContain('<EMAIL>');
+    expect(result.text).toContain('/Users/justin');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -29,6 +29,12 @@ Driven by Telegram topic 9003 on 2026-05-13: "By default Instar should only run 
 - Per amendments A20, A23, A39, A42, A51, A54, A58, A62 of `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md`.
 - **No runtime consumers yet.** F-2+ wires capability tokens, probe authentication, in-flight lockfiles, the cross-process attempt ledger, and the audit-token writer onto the leaf-key surface.
 
+### feat(monitoring): F-2 — Redactor + ErrorCodeExtractor (Self-Healing Remediator v2 foundation)
+
+Adds two foundation modules from the Self-Healing Remediator v2 spec (§A1 manifest, F-2): `src/monitoring/Redactor.ts` and `src/monitoring/ErrorCodeExtractor.ts`. The Redactor centralizes content sanitization (home-directory paths, bearer tokens, Telegram bot tokens, emails, UUIDs, long hex strings, IPv4/IPv6, and ≥6-digit numeric IDs). The ErrorCodeExtractor enforces the §A6 errorCode-provenance contract: returns `{code, provenance}` where provenance is `native-binding | probe-id | subsystem-explicit | free-text`, following a priority ladder. A static `isAllowedForRunbookMatch` predicate gives the runbook registry validator a single call to refuse matchers that would consume free-text-provenance events — the §A6 structural defense against attacker-shaped error-text. Neither module has any consumer in this PR; F-3 (DegradationReporter migration) and the W-* runbook wrappers wire them up in follow-up PRs. 46 new unit tests across `tests/unit/Redactor.test.ts` (25) and `tests/unit/ErrorCodeExtractor.test.ts` (21).
+
+Side-effects review: `upgrades/side-effects/f2-redactor-errorcode-extractor.md`.
+
 ### feat(instar-dev): ELI16 overview required for every approved spec
 
 `/instar-dev`'s pre-commit gate and `/spec-converge`'s convergence-tag writer now both refuse to advance a spec that ships without a plain-English ELI16 overview. Topic 3079 on 2026-05-13 surfaced this directly: "I can't digest this without an ELI16 overview. That should be required for every spec."
@@ -47,6 +53,8 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 
 **Stronger API-billing safety.** Instar will no longer silently switch from your Claude subscription to the metered Anthropic API just because your CLI broke and you happen to have an API key in your environment. The default has always been subscription-only; this fix removes the one path that could quietly bill you. If you actually want API mode, you now need to set two flags in config (`intelligenceProvider: "anthropic-api"` AND `intelligenceProviderConfirmed: true`), and every server startup in API mode prints a yellow boxed banner so it's impossible to miss. No setup needed for the subscription path — that is the default and it stays the default.
 
+**F-2 — Redaction + errorCode normalization.** The self-healing system is getting a safety layer underneath it. Every error report now gets stamped with where the error name came from — a trusted system field, a verified probe, an explicit subsystem call, or just parsed text. Only the trusted sources can trigger automated repair. The same release adds a single place that scrubs personal paths, tokens, emails, and IDs out of every error report before it leaves the agent.
+
 **F-1 — Cryptographic foundation for self-healing.** Nothing user-visible yet. Operators running on headless Linux without libsecret should set `INSTAR_REMEDIATION_KEY_PASSPHRASE` in their environment before any F-2+ feature ships. macOS and Linux+libsecret have nothing to do.
 
 **ELI16-overview gate.** When your agent hands you a spec for approval, you'll now always get a plain-English overview alongside the dense technical document. The instar repo refuses to commit any code change whose driving spec lacks a readable companion file. The technical spec becomes the appendix; the overview is the entry point. No setup required; the new behavior takes effect on the next agent update.
@@ -61,3 +69,6 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 - **Template for ELI16 overviews** at `skills/instar-dev/templates/eli16-overview.md`.
 - **Forward-only enforcement** — only specs newly committed-against after this ships have to satisfy the gate.
 - **`selectIntelligenceProvider()`** — single chokepoint enforcing subscription-by-default for the shared LLM provider; refuses silent API fallback; requires two explicit flags for API opt-in; prints a billing banner when API mode is active.
+- **Centralized content redaction** (F-2) — `new Redactor().redact(text)` / `.redactFields(obj, fields)` — wired into DegradationReporter in F-3.
+- **Structured errorCode extraction with provenance** (F-2) — `ErrorCodeExtractor.extract({ nativeError, probeEmission, subsystemExplicit, freeText, verifyProbeSignature })`.
+- **Runbook-match provenance gate** (F-2) — `ErrorCodeExtractor.isAllowedForRunbookMatch(extracted)` — refuses free-text-provenance matchers.

--- a/upgrades/side-effects/f2-redactor-errorcode-extractor.md
+++ b/upgrades/side-effects/f2-redactor-errorcode-extractor.md
@@ -1,0 +1,130 @@
+# Side-Effects Review — F-2: Redactor + ErrorCodeExtractor
+
+**Version / slug:** `f2-redactor-errorcode-extractor`
+**Date:** `2026-05-13`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Adds two new foundation modules for the Self-Healing Remediator v2 (per spec §A1 Foundation manifest, F-2):
+
+- `src/monitoring/Redactor.ts` — centralized redaction pipeline that strips secrets, identifiers, and absolute paths from text before it crosses any persistence, alert, or LLM-prompt boundary. Default rules cover home-dir paths, bearer/Telegram tokens, emails, UUIDs, long hex, IPv4/IPv6, and ≥6-digit numeric IDs. Composable via `extraRules`.
+- `src/monitoring/ErrorCodeExtractor.ts` — extracts a canonical `errorCode` from one of four structured sources and stamps a `provenance` tag (`native-binding | probe-id | subsystem-explicit | free-text`). Implements §A6: the runbook registry validator can call `isAllowedForRunbookMatch` to refuse matchers that would consume free-text-provenance events.
+
+Tests: `tests/unit/Redactor.test.ts` (25 cases) + `tests/unit/ErrorCodeExtractor.test.ts` (21 cases). No consumer code yet — F-3 (DegradationReporter migration) and W-* runbook wrappers wire these up.
+
+Files touched:
+- `src/monitoring/Redactor.ts` (new)
+- `src/monitoring/ErrorCodeExtractor.ts` (new)
+- `tests/unit/Redactor.test.ts` (new)
+- `tests/unit/ErrorCodeExtractor.test.ts` (new)
+- `upgrades/NEXT.md` (entry append)
+
+## Decision-point inventory
+
+- `ErrorCodeExtractor.isAllowedForRunbookMatch` — **add** — gating predicate the registry-load-time validator (built in a later PR) calls to refuse matchers against free-text-provenance events. The predicate itself is pure and side-effect-free.
+- `Redactor.redact` / `Redactor.redactFields` — **add** — content transformation, no block/allow surface. Used by callers to sanitize before crossing trust boundaries.
+- `ErrorCodeExtractor.extract` priority ladder — **add** — chooses which input source becomes the `errorCode` for a NormalizedDegradationEvent. Unverified probe emissions are silently demoted (signal source is untrusted) rather than producing a probe-id provenance.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- `Redactor.redact` may over-redact in two cases: (a) a legitimate ≥6-digit number (e.g. an HTTP status code referenced as a literal `200000`) collapses to `<NUM>` — acceptable because run-of-the-mill error text rarely contains literal big numbers, and false-positive redaction is preferable to leaking a real ID; (b) a real path on disk that happens to look like `/Users/<word>` always redacts, even when no user data is in it. Both are intentional: the redactor is the brittle low-level signal, not the smart authority — false positives are safe, false negatives are not.
+- `ErrorCodeExtractor.extract` does not "reject" any input — it always returns a result. The `isAllowedForRunbookMatch` predicate rejects free-text provenance, which is the entire point of §A6. No legitimate runbook should match on free-text by design (matchers must consume structured sources).
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- `Redactor` cannot redact what it doesn't pattern-match. Novel secret shapes (a new vendor's API-key format, an unusual UUID variant, base64-only tokens without a `Bearer` prefix) will pass through. Mitigation: `extraRules` lets callers extend per-surface; the F-3 DegradationReporter migration will set a baseline set of patterns; SystemReviewer corpus tests (later phases) catch drift.
+- `ErrorCodeExtractor` will return `provenance: 'free-text'` + `UNKNOWN_ERROR` for any novel failure shape. That's the intended steady state — A26 NovelFailureReviewer clusters these and proposes new runbooks via the /instar-dev path. The under-block here is not a bug; it's the trigger for SystemReviewer.
+- Probe-id provenance is gated on a caller-supplied `verifyProbeSignature` function. If a caller forgets to pass one, the probe emission silently demotes to lower-priority sources. This is fail-closed (an attacker can't shape errorCode by spoofing the probe path) but a caller could mistakenly believe probe emissions are honored when they aren't. F-3 / W-* PRs that wire this up will own the verifier.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+`Redactor` is a **low-level detector** — it produces sanitized text plus a count summary. It does NOT decide whether to alert, persist, or drop an event. That authority belongs to DegradationReporter (F-3) and downstream consumers. Correct level.
+
+`ErrorCodeExtractor` is also a **low-level extractor** — pure function over a structured input. It does NOT decide what to do with the extracted code. The `isAllowedForRunbookMatch` predicate is a signal the runbook registry validator (a smart authority, built in a later PR) calls — the extractor itself has no block/allow surface on the event path. Correct level.
+
+Neither module re-implements anything that exists today: there is no shared redactor in src/ to replace (the spec §A1 explicitly notes "v1 was never built"), and ErrorCodeExtractor is genuinely new.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+
+`Redactor` produces sanitized strings + a redaction summary — pure transformation, no block/allow. Callers (DegradationReporter F-3, runbook auditors, SystemReviewer) own any decisions.
+
+`ErrorCodeExtractor.extract` is pure extraction. `isAllowedForRunbookMatch` is a predicate the runbook **registry validator** (a smart authority with full context — sees the entire matcher definition, the event corpus, and the runbook lifecycle state) calls. The extractor publishes the signal (the provenance tag); the validator decides whether to load the runbook. This is exactly the signal-vs-authority split §A6 requires.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** none today — these modules have no callers in this PR. F-3 will wire `DegradationReporter` to use them; until then they're dead code, by spec design (foundation must land before any wrapper).
+- **Double-fire:** none — pure functions, no side effects.
+- **Races:** none — no shared mutable state. Each `Redactor` instance owns its rule list; `ErrorCodeExtractor` is static.
+- **Feedback loops:** none — these modules don't write to disk, network, or any other surface that could feed back.
+- **Adjacent cleanup:** the existing `DegradationReporter` (untouched in this PR per F-3 scope boundary) continues to produce its legacy `DegradationEvent` shape. F-3 will introduce the back-compat shim per §A33; until then there's zero behavioral change for any current degradation emit-site.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Other agents on the same machine:** no — no shared state.
+- **Other users of the install base:** no — modules are not wired into any runtime path in this PR. Behavior on `main` after merge is unchanged for end users.
+- **External systems:** no.
+- **Persistent state:** no — these modules don't read or write any file. (Future callers in F-3 will, but not these modules themselves.)
+- **Timing or runtime conditions:** no — pure synchronous functions, no clocks.
+- **API surface changes:** two new exported modules under `src/monitoring/`. They appear in the public surface of the package, but with no consumers in this PR, no migration risk.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+- Pure code addition, no consumers. Revert = delete files + revert the NEXT.md entry. No persistent state, no user-visible regression during rollback window. No agent state repair needed.
+- If a default redaction rule produces a false positive that surprises a downstream caller in F-3+, the fix is to refine the regex in `Redactor.ts` and ship a patch. The redactor's API (the `RedactionRule` type + the `redact`/`redactFields` shape) is stable and the cost of a rule tweak is one PR.
+- If a free-text pattern in `ErrorCodeExtractor` produces a misclassification, downstream consumers see `provenance: 'free-text'` and the runbook registry refuses any matcher that would have fired on it. The misclassification surfaces as a clustering signal in SystemReviewer (a later phase), not as a misfired runbook. Fail-safe by design.
+
+---
+
+## Conclusion
+
+Pure-foundation PR with two new modules and 46 passing unit tests. No consumers wired in this PR (per spec §A1 ordering: F-2 must land before F-3, and F-3 owns the wiring). Signal-vs-authority compliance is straightforward — both modules are detectors/extractors with no blocking surface; the §A6 provenance gate is a signal consumed by a smart authority (the runbook registry validator) that will be built in a later PR.
+
+Clear to ship.
+
+---
+
+## Second-pass review (if required)
+
+Not required — this PR has no block/allow surface on outbound/inbound messaging, no session lifecycle touch, no context-exhaustion handling, no coherence/idempotency/trust gates, and is not a sentinel/guard/gate/watchdog.
+
+---
+
+## Evidence pointers
+
+- `npx vitest run tests/unit/Redactor.test.ts tests/unit/ErrorCodeExtractor.test.ts` → 46 passed, 0 failed (run during build).
+- `npx tsc --noEmit` → clean.
+- Spec section references: `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A1 (foundation manifest F-2 ordering), §A6 (errorCode provenance), §A26 (Redactor consumer in NovelFailureReviewer), §A33 (DegradationReporter migration — out of scope, for F-3).


### PR DESCRIPTION
## Summary

F-2 of the Self-Healing Remediator v2 foundation manifest (spec §A1). Two new monitoring modules, no consumers wired in this PR (per spec ordering — F-3 wires them).

- **`src/monitoring/Redactor.ts`** — centralized content sanitization. Default rules: home-dir paths, bearer tokens, Telegram bot tokens, emails, UUIDs, long hex, IPv4/IPv6, ≥6-digit numeric IDs. Returns transformed text + per-category redaction count summary. Composable via `extraRules`. `redactFields(obj, fields)` for selective struct redaction.
- **`src/monitoring/ErrorCodeExtractor.ts`** — enforces §A6 errorCode provenance contract. Returns `{code, provenance}` via priority ladder: verified probe emission → subsystem-explicit → native `Error.code` → free-text regex fallback (`NODE_MODULE_VERSION`, `SQLITE_*`, `EACCES/EPERM`, `ECONNREFUSED/ECONNRESET`). `isAllowedForRunbookMatch` predicate refuses free-text-provenance events at runbook registry load.

## Why this is safe to land alone

Zero callers in this PR — both modules are pure additions. Per spec §A1, F-2 must merge before F-3 (DegradationReporter migration) so the provenance contract exists before consumers depend on it. No behavioral change for any current degradation emit-site.

## Spec + side-effects review

- Spec: `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (approved 2026-05-13 in topic 3079, convergence `2026-05-13T16:50:00Z`)
- Side-effects review: `upgrades/side-effects/f2-redactor-errorcode-extractor.md` (no block/allow surface; signal-vs-authority compliant; rollback = revert)

## Test plan

- [x] `npx vitest run tests/unit/Redactor.test.ts tests/unit/ErrorCodeExtractor.test.ts` → 46/46 pass
- [x] `npx tsc --noEmit` → clean
- [x] Pre-commit gate (instar-dev trace, spec convergence + approval, ELI16 sibling) passes
- [x] Pre-push smoke tier passes
- [ ] CI green
- [ ] F-3 PR (separate) will wire DegradationReporter through these modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)