### PR TITLE
feat(updates): Phase 5 — auto-migrate legacy jobs.json on update

### DIFF
--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -29,6 +29,7 @@ import { HTTP_HOOK_TEMPLATES, buildHttpHookSettings } from '../data/http-hook-te
 import { getMigrationDefaults, applyDefaults } from '../config/ConfigDefaults.js';
 import { installBuiltinSkills } from '../commands/init.js';
 import { installBuiltinJobs } from '../scheduler/InstallBuiltinJobs.js';
+import { jobsMigrate } from '../commands/jobMigrate.js';
 import {
   ELIGIBILITY_SCHEMA_SQL,
   ELIGIBILITY_SCHEMA_SQL_SHA256,
@@ -89,6 +90,7 @@ export class PostUpdateMigrator {
     this.migrateGitignore(result);
     this.migrateBuiltinSkills(result);
     this.migrateBuiltinJobs(result);
+    this.autoMigrateLegacyJobsJson(result);
     this.migrateSkillPortHardcoding(result);
     this.migrateSelfKnowledgeTree(result);
     this.migrateSoulMd(result);
@@ -301,6 +303,78 @@ export class PostUpdateMigrator {
       }
     } catch (err) {
       result.errors.push(`built-in agentmd jobs: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Phase 5 — auto-run `instar jobs migrate` for pre-spec agents on update.
+   *
+   * Behavior:
+   *   - SKIP entirely if `.instar/jobs/.migration-complete.json` exists
+   *     (operator already confirmed completion via Dashboard).
+   *   - SKIP entirely if `.instar/jobs/.migration-abandoned.json` exists
+   *     (operator explicitly chose to roll back).
+   *   - SKIP if `.instar/jobs.json` is absent (nothing to migrate).
+   *   - Otherwise, invoke `jobsMigrate({ defaultAction: 'fork' })` —
+   *     fork policy preserves the operator's customized body in user/
+   *     namespace, never silently drops content. This is the
+   *     spec-mandated default for the auto-run path.
+   *   - Emit a Dashboard banner event via the migration result so the
+   *     operator sees "migration ran on update — confirm in Dashboard."
+   *
+   * Seamless Migration Guarantee invariants enforced at this layer
+   * (PR #180 §Seamless Migration Guarantee):
+   *   #6 in-flight protection — JobScheduler.activeRuns() check is
+   *      currently a defensive no-op until Phase 4 wires the scheduler
+   *      back-reference; the migration runs at update time, before the
+   *      new scheduler instance comes up, so by construction nothing is
+   *      in flight.
+   *   #7 transactional safety on interrupt — `jobsMigrate` is structurally
+   *      safe (backup-first, idempotent, rollback via --abandon).
+   *   #8 telemetry — outcome is appended to result.upgraded/errors.
+   */
+  private autoMigrateLegacyJobsJson(result: MigrationResult): void {
+    try {
+      const stateDir = this.config.stateDir;
+      const jobsJsonPath = path.join(stateDir, 'jobs.json');
+      const jobsRoot = path.join(stateDir, 'jobs');
+      const completedMarker = path.join(jobsRoot, '.migration-complete.json');
+      const abandonedMarker = path.join(jobsRoot, '.migration-abandoned.json');
+
+      if (!fs.existsSync(jobsJsonPath)) {
+        return; // nothing to migrate
+      }
+      if (fs.existsSync(completedMarker)) {
+        result.skipped.push('legacy jobs.json migration: already complete (operator-confirmed)');
+        return;
+      }
+      if (fs.existsSync(abandonedMarker)) {
+        result.skipped.push('legacy jobs.json migration: explicitly abandoned by operator');
+        return;
+      }
+
+      const packageRoot = path.resolve(__dirname, '..', '..');
+      const outcome = jobsMigrate({
+        agentStateDir: stateDir,
+        packageRoot,
+        defaultAction: 'fork',
+      });
+
+      if (outcome.status === 'completed') {
+        const migratedCount = outcome.perEntry.filter((e: { action: string }) => e.action === 'migrated-instar').length;
+        const forkedCount = outcome.perEntry.filter((e: { action: string }) => e.action === 'forked-user' || e.action === 'kept-user').length;
+        const renamedCount = outcome.perEntry.filter((e: { action: string }) => e.action === 'renamed-user').length;
+        result.upgraded.push(
+          `legacy jobs.json migration: auto-ran on update — ${migratedCount} migrated to instar, ${forkedCount} preserved in user namespace, ${renamedCount} renamed. Confirm via Dashboard to allow jobs.json removal.`,
+        );
+        if (outcome.backupPath) {
+          result.upgraded.push(`legacy jobs.json migration: backup at ${path.basename(outcome.backupPath)}`);
+        }
+      } else if (outcome.status === 'aborted') {
+        result.errors.push(`legacy jobs.json migration: aborted — ${outcome.errors.join('; ')}`);
+      }
+    } catch (err) {
+      result.errors.push(`legacy jobs.json migration: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/unit/PostUpdateMigrator-autoMigrate.test.ts
+++ b/tests/unit/PostUpdateMigrator-autoMigrate.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Phase 5 — PostUpdateMigrator auto-migrate path for legacy jobs.json.
+ *
+ * Asserts the auto-migrate step:
+ *   - SKIP when .migration-complete.json exists
+ *   - SKIP when .migration-abandoned.json exists
+ *   - SKIP when jobs.json is absent
+ *   - Auto-runs jobsMigrate with --default-action=fork when none of the
+ *     above sentinels are present
+ *   - Honors the Seamless Migration Guarantee invariants 5 and 7
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('PostUpdateMigrator auto-migrate-legacy-jobs.json (Phase 5)', () => {
+  let workspace: string;
+  let projectDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-pum-am-'));
+    projectDir = path.join(workspace, 'project');
+    stateDir = path.join(projectDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(workspace, { recursive: true, force: true, operation: 'PostUpdateMigrator-autoMigrate.test cleanup' });
+  });
+
+  function makeMigrator() {
+    return new PostUpdateMigrator({
+      projectDir,
+      stateDir,
+      port: 4042,
+      hasTelegram: false,
+      projectName: 'test-agent',
+    });
+  }
+
+  function writeJobsJson(entries: any[]) {
+    fs.writeFileSync(path.join(stateDir, 'jobs.json'), JSON.stringify(entries, null, 2), 'utf-8');
+  }
+
+  it('skips when jobs.json is absent (fresh install)', () => {
+    const m = makeMigrator();
+    // Run only the auto-migrate path via a focused proxy.
+    const result = { upgraded: [], skipped: [], errors: [] };
+    (m as any).autoMigrateLegacyJobsJson(result);
+    expect(result.upgraded).toEqual([]);
+    expect(result.errors).toEqual([]);
+    // No skipped entry either, since absence of jobs.json is a non-event.
+    expect(result.skipped.filter((s: string) => s.includes('legacy jobs.json'))).toEqual([]);
+  });
+
+  it('skips when .migration-complete.json exists (operator confirmed)', () => {
+    writeJobsJson([{ slug: 'a', execute: { type: 'prompt', value: 'x' }, schedule: '* * * * *' }]);
+    fs.mkdirSync(path.join(stateDir, 'jobs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'jobs', '.migration-complete.json'), '{"confirmedAt":"2026-01-01"}');
+
+    const m = makeMigrator();
+    const result = { upgraded: [], skipped: [], errors: [] };
+    (m as any).autoMigrateLegacyJobsJson(result);
+
+    expect(result.skipped.some((s: string) => s.includes('operator-confirmed'))).toBe(true);
+    // No schedule manifest written.
+    expect(fs.existsSync(path.join(stateDir, 'jobs', 'schedule'))).toBe(false);
+  });
+
+  it('skips when .migration-abandoned.json exists (operator rolled back)', () => {
+    writeJobsJson([{ slug: 'a', execute: { type: 'prompt', value: 'x' }, schedule: '* * * * *' }]);
+    fs.mkdirSync(path.join(stateDir, 'jobs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'jobs', '.migration-abandoned.json'), '{"abandonedAt":"2026-01-01"}');
+
+    const m = makeMigrator();
+    const result = { upgraded: [], skipped: [], errors: [] };
+    (m as any).autoMigrateLegacyJobsJson(result);
+
+    expect(result.skipped.some((s: string) => s.includes('explicitly abandoned'))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, 'jobs', 'schedule'))).toBe(false);
+  });
+
+  it('runs jobsMigrate with --default-action=fork when no sentinels present', () => {
+    writeJobsJson([
+      {
+        slug: 'my-user-job',
+        name: 'My User Job',
+        description: 'd',
+        schedule: '0 9 * * *',
+        priority: 'low',
+        expectedDurationMinutes: 1,
+        model: 'haiku',
+        enabled: true,
+        execute: { type: 'prompt', value: 'Do thing\n' },
+      },
+    ]);
+
+    const m = makeMigrator();
+    const result = { upgraded: [], skipped: [], errors: [] };
+    (m as any).autoMigrateLegacyJobsJson(result);
+
+    // The auto-runner produces an upgraded message.
+    expect(result.upgraded.some((s: string) => s.includes('auto-ran on update'))).toBe(true);
+    // Schedule manifest was written.
+    expect(fs.existsSync(path.join(stateDir, 'jobs', 'schedule', 'my-user-job.json'))).toBe(true);
+    // Backup was written.
+    const stateContents = fs.readdirSync(stateDir);
+    expect(stateContents.some((f) => f.startsWith('jobs.json.pre-migrate-'))).toBe(true);
+  });
+
+  it('does NOT auto-write .migration-complete.json (only Dashboard does)', () => {
+    writeJobsJson([{ slug: 'a', execute: { type: 'prompt', value: 'x' }, schedule: '* * * * *' }]);
+
+    const m = makeMigrator();
+    const result = { upgraded: [], skipped: [], errors: [] };
+    (m as any).autoMigrateLegacyJobsJson(result);
+
+    expect(fs.existsSync(path.join(stateDir, 'jobs', '.migration-complete.json'))).toBe(false);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -5,9 +5,9 @@ note (`upgrades/<version>.md`) at release-cut time.
 
 ---
 
-### test(scheduler): Seamless Migration Guarantee suite + 8 fixtures
+### feat(updates): Phase 5 — auto-migrate legacy jobs.json on update
 
-The binding gate the INSTAR-JOBS-AS-AGENTMD spec §Seamless Migration Guarantee promises lands here: `tests/integration/migration-guarantee.test.ts` iterates 8 fixtures (`pristine`, `customized`, `body-edited`, `user-jobs`, `retired-defaults`, `mixed-state`, `multi-machine-drift`, `in-flight`) and asserts invariants 1, 2, 4, 5, 7, 9 + idempotency + dry-run on every shape under the CLI migration path. 50 test cases, all green. Fixtures live under `tests/fixtures/migration-agents/<shape>/shape.json` as declarative transformations on top of `getDefaultJobs()` output. New pre-commit gate `scripts/protect-migration-guarantee.js` refuses commits that delete the test file or any fixture's `shape.json`. Phase 5 auto-migrate (#193), Phase 6 deprecation (#194), and Phase 4 endpoints (#195) are held as drafts until this lands, per the spec's gate-wiring requirement.
+`PostUpdateMigrator` now auto-runs `instar job migrate --default-action=fork` once per update when an agent has a legacy `jobs.json` AND has not yet completed-or-abandoned migration. Skip-rules: jobs.json absent → silent no-op; `.migration-complete.json` present → log + skip; `.migration-abandoned.json` present → log + skip. Fork policy preserves operator-edited bodies verbatim under `.instar/jobs/user/` — nothing is silently dropped. Auto-runner does NOT write `.migration-complete.json` (only the operator-confirmed Dashboard action does that — release-cut gate continues to block jobs.json deletion until operator confirms). 5 unit tests in `tests/unit/PostUpdateMigrator-autoMigrate.test.ts`. Closes the Phase 5 commitment from the INSTAR-JOBS-AS-AGENTMD spec rollout.
 
 ## What Changed
 

--- a/upgrades/side-effects/jobs-as-agentmd-phase-5.md
+++ b/upgrades/side-effects/jobs-as-agentmd-phase-5.md
@@ -1,0 +1,67 @@
+# Side-effects review — Phase 5 (auto-migrate on update)
+
+## What changed
+
+`PostUpdateMigrator.autoMigrateLegacyJobsJson` is a new private step that runs once per update. It auto-invokes `jobsMigrate({ defaultAction: 'fork' })` when an agent has a legacy `jobs.json` AND has not yet completed-or-abandoned migration.
+
+Decision matrix:
+
+| Agent state on update | What happens |
+|---|---|
+| `jobs.json` absent (fresh install) | Skip silently — nothing to migrate |
+| `.migration-complete.json` present | Skip with informational log line (operator already confirmed) |
+| `.migration-abandoned.json` present | Skip with informational log line (operator chose rollback) |
+| Otherwise (legacy state) | Run `jobsMigrate({ defaultAction: 'fork' })`; report migrated/forked counts; flag for operator to confirm via Dashboard |
+
+The fork policy is the spec-mandated default for the auto-run path: any operator-edited default whose body differs from the shipped template is preserved verbatim under `.instar/jobs/user/<slug>.md`. Nothing is silently dropped.
+
+## Side-effects review (mandatory gate)
+
+### 1. Over-block / under-block
+
+- **Over-block:** the carve-outs for `.migration-complete.json` and `.migration-abandoned.json` ensure the auto-run never re-fires after the operator has confirmed either path. The auto-run also writes a fresh `jobs.json.pre-migrate-<ts>` backup every time it executes — small disk cost (the backup is the rollback anchor for the SECOND interrupted update, in the unlikely event Phase 6 deprecation triggers another transition cycle).
+- **Under-block:** the auto-run does NOT auto-write `.migration-complete.json` — that's the operator's Dashboard confirm. So the loader continues to read from BOTH `jobs.json` (legacy) AND `.instar/jobs/schedule/` (migrated) until operator confirms. The loader already handles the overlap (schedule shadows jobs.json on same-slug), so no behavioral drift.
+
+### 2. Level-of-abstraction fit
+
+`autoMigrateLegacyJobsJson` is a thin wrapper around `jobsMigrate`. It owns ONLY the decision-to-run logic (sentinel file checks). The actual migration is delegated. This keeps the per-layer responsibility clean: `jobsMigrate` is the migration authority, the auto-runner is the decision-to-run signal.
+
+### 3. Signal-vs-authority compliance
+
+The PostUpdateMigrator step is the signal ("the agent just updated, time to check migration state"). `jobsMigrate` is the authority on routing each entry. The operator (via Dashboard confirm) is the higher authority that flips `.migration-complete.json` — until that flips, the release-cut gate refuses to delete `jobs.json`. This Phase 5 PR does NOT shift authority; it just removes the need for the operator to invoke the CLI command manually.
+
+### 4. Interactions
+
+- **Phase 2 installBuiltinJobs** — runs BEFORE the auto-migrate step. So when auto-migrate fires, the shipped templates are already on disk at `.instar/jobs/instar/<slug>.md`. The body-match check in `jobsMigrate` compares jobs.json's `execute.value` against those just-installed templates — semantically correct.
+- **Phase 3 jobsMigrate** — reused unchanged. The `defaultAction: 'fork'` argument preserves operator-edited bodies in `user/`.
+- **Phase 4 Dashboard** — will surface the `migration-available` / `migration-completed` state via existing event stream. Phase 5 emits structured upgrade messages that the dashboard reads from the migration result.
+- **Seamless Migration Guarantee invariants**:
+  - Invariant 5 (one-button rollback) — `--abandon` flag on the CLI continues to work; the auto-runner respects the abandonment marker.
+  - Invariant 6 (in-flight protection) — by construction, the auto-runner runs during `instar update apply`, BEFORE the new scheduler instance comes up. No jobs in flight at this moment.
+  - Invariant 7 (transactional safety) — `jobsMigrate` is structurally safe (backup-first, idempotent). If SIGKILL hits mid-migration, the next boot will detect the partial state and either retry (no `.migration-complete.json`) or skip (operator wrote it).
+  - Invariant 8 (telemetry) — every auto-run produces upgrade-message entries in the MigrationResult, which surfaces to the operator via the standard update-output channel.
+  - Invariant 9 (fail-closed) — `jobsMigrate({ defaultAction: 'fork' })` cannot fail-closed because fork is a non-failure action. If a per-entry write fails, `outcome.errors` captures the specific failure, but the migration as a whole completes (the loader handles partial state). The auto-runner surfaces `outcome.errors` as `result.errors`.
+
+### 5. Rollback cost
+
+Trivial.
+- Per-update: remove `autoMigrateLegacyJobsJson` call from `migrate()`. Existing agents either have `.migration-complete.json` (and stay completed) or have an unfinished migration state that the loader handles.
+- Per-agent: `instar job migrate --abandon` (existing Phase 3 path) is the agent-side rollback.
+
+### 6. What is NOT in this PR
+
+- **Dashboard "migration ran on update" banner** — Phase 4. The auto-runner emits the structured upgrade message that the banner reads.
+- **Interactive three-choice prompt** — Phase 4. Auto-run uses `--default-action=fork` non-interactively, which is the safer default.
+- **In-flight scheduler check** — currently a no-op because update-apply happens before scheduler restart. If Phase 4 introduces a hot-reload path, the check becomes meaningful.
+
+## Test coverage
+
+`tests/unit/PostUpdateMigrator-autoMigrate.test.ts` — 5 cases:
+
+1. Skips when jobs.json is absent
+2. Skips when .migration-complete.json exists
+3. Skips when .migration-abandoned.json exists
+4. Runs jobsMigrate with --default-action=fork when no sentinels
+5. Does NOT auto-write .migration-complete.json
+
+All 5 pass locally. Lint + type-check pass.


### PR DESCRIPTION
## Summary

- New `PostUpdateMigrator.autoMigrateLegacyJobsJson` step auto-runs `instar job migrate --default-action=fork` once per update when an agent has legacy `jobs.json` AND has not yet completed-or-abandoned migration.
- Honors `.migration-complete.json` and `.migration-abandoned.json` sentinels — operator authority is preserved.
- Fork policy preserves operator-edited bodies verbatim under `.instar/jobs/user/`.
- Does NOT auto-write `.migration-complete.json` — that's still the operator's Dashboard confirm.
- 5 unit tests in `tests/unit/PostUpdateMigrator-autoMigrate.test.ts`.

This closes Phase 5 of the INSTAR-JOBS-AS-AGENTMD rollout.

## Test plan

- [x] All 5 cases pass
- [x] Lint + type-check pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)