### PR TITLE
feat(scheduler): Phase 6 — legacy prompt deprecation warning

### DIFF
--- a/src/scheduler/JobLoader.ts
+++ b/src/scheduler/JobLoader.ts
@@ -107,7 +107,63 @@ export function loadJobs(jobsFile: string): JobDefinition[] {
   // Grounding-by-default audit — warn about jobs missing grounding config
   auditGrounding(merged);
 
+  // Phase 6 deprecation audit — warn about legacy execute.type: 'prompt'
+  // entries for slugs that have a shipped agentmd default. These are
+  // structurally inert (the agentmd entry shadows them) but their presence
+  // means the operator hasn't confirmed migration. Two-release removal
+  // cycle per INSTAR-JOBS-AS-AGENTMD spec §Rollout step 6.
+  auditLegacyPromptDeprecation(legacyJobs, agentMdResult.jobs, jobsRootDir);
+
   return merged;
+}
+
+/**
+ * Phase 6 — deprecation audit for legacy `execute.type: 'prompt'` entries
+ * whose slug also appears as a shipped agentmd default. Emits a single
+ * deprecation warning per boot per affected slug.
+ *
+ * The warning fires only when:
+ *   - the slug is present in BOTH legacy jobs.json AND the per-slug
+ *     manifest (shadowed); AND
+ *   - the legacy entry's execute.type is 'prompt'; AND
+ *   - `.migration-complete.json` is NOT present (operator hasn't
+ *     confirmed migration yet).
+ *
+ * When `.migration-complete.json` is present, the legacy entries are about
+ * to be removed by the release-cut gate, so the deprecation warning would
+ * be noise.
+ *
+ * Spec: docs/specs/INSTAR-JOBS-AS-AGENTMD-SPEC.md §Rollout step 6.
+ */
+function auditLegacyPromptDeprecation(
+  legacy: JobDefinition[],
+  agentMd: JobDefinition[],
+  jobsRootDir: string,
+): void {
+  if (legacy.length === 0 || agentMd.length === 0) return;
+  const completedMarker = path.join(jobsRootDir, '.migration-complete.json');
+  if (fs.existsSync(completedMarker)) return;
+
+  const shippedAgentMdSlugs = new Set(
+    agentMd.filter((j) => j.origin === 'instar').map((j) => j.slug),
+  );
+  const deprecated: string[] = [];
+  for (const j of legacy) {
+    if (j.execute?.type !== 'prompt') continue;
+    if (!shippedAgentMdSlugs.has(j.slug)) continue;
+    deprecated.push(j.slug);
+  }
+
+  if (deprecated.length === 0) return;
+
+  console.warn(
+    `[JobLoader] DEPRECATION: ${deprecated.length} legacy jobs.json ` +
+    `entry(ies) with execute.type:"prompt" shadow agentmd defaults: ` +
+    `${deprecated.join(', ')}. These will be removed two releases after ` +
+    `Dashboard ships the "Confirm migration complete" action. ` +
+    `Run \`instar job migrate\` (or wait for the next update's auto-run) ` +
+    `then confirm completion via Dashboard to suppress this warning.`,
+  );
 }
 
 /**

--- a/tests/unit/scheduler/JobLoader.deprecation.test.ts
+++ b/tests/unit/scheduler/JobLoader.deprecation.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Phase 6 — deprecation audit for legacy execute.type:"prompt" entries
+ * that shadow agentmd defaults.
+ *
+ * Spec: INSTAR-JOBS-AS-AGENTMD-SPEC.md §Rollout step 6.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { loadJobs } from '../../../src/scheduler/JobLoader.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+describe('JobLoader Phase 6 deprecation audit', () => {
+  let workspace: string;
+  let stateDir: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-deprecate-'));
+    stateDir = path.join(workspace, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    SafeFsExecutor.safeRmSync(workspace, { recursive: true, force: true, operation: 'JobLoader.deprecation.test cleanup' });
+  });
+
+  function writeJobsJson(entries: any[]) {
+    fs.writeFileSync(path.join(stateDir, 'jobs.json'), JSON.stringify(entries, null, 2));
+  }
+
+  function writeAgentmd(slug: string, body: string) {
+    const instarDir = path.join(stateDir, 'jobs', 'instar');
+    const scheduleDir = path.join(stateDir, 'jobs', 'schedule');
+    fs.mkdirSync(instarDir, { recursive: true });
+    fs.mkdirSync(scheduleDir, { recursive: true });
+    const fm = [
+      `name: "${slug}"`,
+      'description: "test"',
+      'toolAllowlist: ["Read"]',
+    ].join('\n');
+    fs.writeFileSync(path.join(instarDir, `${slug}.md`), `---\n${fm}\n---\n${body}`);
+    fs.writeFileSync(path.join(scheduleDir, `${slug}.json`), JSON.stringify({
+      slug,
+      origin: 'instar',
+      schedule: '*/5 * * * *',
+      priority: 'low',
+      expectedDurationMinutes: 1,
+      model: 'haiku',
+      enabled: true,
+      execute: { type: 'agentmd' },
+      manifestVersion: 1,
+    }, null, 2));
+  }
+
+  it('emits deprecation warning when legacy prompt shadows agentmd default', () => {
+    writeJobsJson([
+      {
+        slug: 'health-check',
+        name: 'Health Check',
+        description: 'd',
+        schedule: '*/5 * * * *',
+        priority: 'low',
+        expectedDurationMinutes: 1,
+        model: 'haiku',
+        enabled: true,
+        execute: { type: 'prompt', value: 'check' },
+      },
+    ]);
+    writeAgentmd('health-check', 'check\n');
+
+    loadJobs(path.join(stateDir, 'jobs.json'));
+
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).toContain('DEPRECATION');
+    expect(allWarnings).toContain('health-check');
+  });
+
+  it('does NOT emit deprecation when .migration-complete.json exists', () => {
+    writeJobsJson([
+      { slug: 'a', execute: { type: 'prompt', value: 'x' }, schedule: '*/5 * * * *', name: 'A', description: 'd', priority: 'low', expectedDurationMinutes: 1, model: 'haiku', enabled: true },
+    ]);
+    writeAgentmd('a', 'x\n');
+    fs.writeFileSync(path.join(stateDir, 'jobs', '.migration-complete.json'), '{}');
+
+    loadJobs(path.join(stateDir, 'jobs.json'));
+
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).not.toContain('DEPRECATION');
+  });
+
+  it('does NOT emit deprecation for legacy entries whose slug is not in agentmd defaults', () => {
+    writeJobsJson([
+      { slug: 'user-job', execute: { type: 'prompt', value: 'x' }, schedule: '*/5 * * * *', name: 'A', description: 'd', priority: 'low', expectedDurationMinutes: 1, model: 'haiku', enabled: true },
+    ]);
+    // No agentmd file for 'user-job'.
+
+    loadJobs(path.join(stateDir, 'jobs.json'));
+
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).not.toContain('DEPRECATION');
+  });
+
+  it('does NOT emit deprecation when legacy entry is script (not prompt)', () => {
+    writeJobsJson([
+      { slug: 'a', execute: { type: 'script', value: 'echo' }, schedule: '*/5 * * * *', name: 'A', description: 'd', priority: 'low', expectedDurationMinutes: 1, model: 'haiku', enabled: true },
+    ]);
+    writeAgentmd('a', 'x\n');
+
+    loadJobs(path.join(stateDir, 'jobs.json'));
+
+    const allWarnings = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(allWarnings).not.toContain('DEPRECATION');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -5,9 +5,9 @@ note (`upgrades/<version>.md`) at release-cut time.
 
 ---
 
-### feat(updates): Phase 5 — auto-migrate legacy jobs.json on update
+### feat(scheduler): Phase 6 — legacy `execute.type:"prompt"` deprecation warning
 
-`PostUpdateMigrator` now auto-runs `instar job migrate --default-action=fork` once per update when an agent has a legacy `jobs.json` AND has not yet completed-or-abandoned migration. Skip-rules: jobs.json absent → silent no-op; `.migration-complete.json` present → log + skip; `.migration-abandoned.json` present → log + skip. Fork policy preserves operator-edited bodies verbatim under `.instar/jobs/user/` — nothing is silently dropped. Auto-runner does NOT write `.migration-complete.json` (only the operator-confirmed Dashboard action does that — release-cut gate continues to block jobs.json deletion until operator confirms). 5 unit tests in `tests/unit/PostUpdateMigrator-autoMigrate.test.ts`. Closes the Phase 5 commitment from the INSTAR-JOBS-AS-AGENTMD spec rollout.
+`JobLoader.loadJobs` now emits a single boot-time warning per slug when a legacy `jobs.json` entry has `execute.type: "prompt"` AND the same slug also appears as a shipped agentmd default AND `.instar/jobs/.migration-complete.json` is absent. This is the operator-facing nudge that legacy `prompt` entries for instar defaults will be removed two releases after Phase 4 Dashboard ships the "Confirm migration complete" action. The warning is silenced once the operator confirms migration via Dashboard. 4 unit tests pass locally.
 
 ## What Changed
 

--- a/upgrades/side-effects/jobs-as-agentmd-phase-6.md
+++ b/upgrades/side-effects/jobs-as-agentmd-phase-6.md
@@ -1,0 +1,53 @@
+# Side-effects review — Phase 6 (deprecation cycle start)
+
+## What changed
+
+`JobLoader.loadJobs` now runs a deprecation audit (new `auditLegacyPromptDeprecation` helper) after the existing merge step. The audit emits a single boot-time warning per affected slug when:
+
+- A legacy `jobs.json` entry has `execute.type: 'prompt'` AND
+- The same slug also appears as an agentmd default (in `.instar/jobs/schedule/`) with `origin: 'instar'` AND
+- `.instar/jobs/.migration-complete.json` is absent (operator hasn't confirmed migration).
+
+The legacy entry is structurally inert in this case (already shadowed by the per-slug manifest), but its presence indicates the operator hasn't run "Confirm migration complete" via Dashboard yet. The warning is the operator-facing nudge that the legacy entry will be removed two releases after Phase 4 Dashboard ships.
+
+## Side-effects review
+
+### 1. Over-block / under-block
+
+- **Over-block:** the warning is silenced once `.migration-complete.json` exists, so a confirmed-migrated agent does NOT emit it. Also silenced for slugs that don't have an agentmd shadow (those are genuine user jobs).
+- **Under-block:** the warning is loud but non-blocking — boot proceeds normally. The actual removal happens in a future release when the spec's two-release deprecation window expires.
+
+### 2. Level-of-abstraction fit
+
+Trivial pure-function helper inside `JobLoader.ts`. Reads only legacy + agentmd arrays + checks one file. No state, no events, no side effects beyond `console.warn`.
+
+### 3. Signal-vs-authority compliance
+
+The warning is a signal ("legacy entries detected"). The authority that REMOVES legacy entries is the release-cut gate (the spec's two-release timer). This PR ships the signal, NOT the removal.
+
+### 4. Interactions
+
+- **Phase 5 auto-migrate** — after the auto-migrate runs, the slugs appear in BOTH `jobs.json` (legacy) and `.instar/jobs/schedule/` (migrated). The warning fires for these UNTIL operator confirms via Dashboard.
+- **Phase 4 Dashboard** — provides the "Confirm migration complete" button that writes `.migration-complete.json`, silencing the warning.
+- **Release-cut gate** — already refuses to delete `jobs.json` without `.migration-complete.json`. The deprecation warning is the operator-facing prompt that closes the loop.
+
+### 5. Rollback cost
+
+Revert one function. Zero on-disk state. The warning is purely advisory.
+
+### 6. Phase 6 deprecation window
+
+Per spec §Rollout step 6: "execute.type: 'prompt' for instar default jobs deprecated; removed two releases later." Phase 6 START is this PR; Phase 6 REMOVAL is two minor releases after Phase 4 Dashboard ships. The removal will be a separate PR that:
+- Adds a gate to `JobLoader.loadLegacyJobsJson` that hard-errors on `execute.type: 'prompt'` for slugs in the shipped agentmd defaults.
+- Bumps the deprecation warning's URL to point at the removal release notes.
+
+## Test coverage
+
+`tests/unit/scheduler/JobLoader.deprecation.test.ts` — 4 cases:
+
+1. Emits warning when legacy prompt shadows agentmd default
+2. Does NOT emit when `.migration-complete.json` exists
+3. Does NOT emit for user-slug entries
+4. Does NOT emit for legacy script entries
+
+All 4 pass locally.


### PR DESCRIPTION
## Summary

- `JobLoader.loadJobs` emits a boot-time deprecation warning per slug when a legacy `jobs.json` entry has `execute.type: "prompt"` AND the same slug also appears as a shipped agentmd default AND `.instar/jobs/.migration-complete.json` is absent.
- Silenced once the operator confirms migration via Dashboard.
- Closes Phase 6 of the INSTAR-JOBS-AS-AGENTMD rollout. Actual removal happens two releases after Phase 4 Dashboard ships.

## Test plan

- [x] 4 cases pass
- [x] Lint + type-check pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)