### PR TITLE
fix(security): API safety guard — subscription-by-default enforcement

### DIFF
--- a/docs/specs/API-SAFETY-GUARD-SPEC.eli16.md
+++ b/docs/specs/API-SAFETY-GUARD-SPEC.eli16.md
@@ -1,0 +1,51 @@
+# API Safety Guard — Plain-English Overview
+
+This is the plain-English companion to `API-SAFETY-GUARD-SPEC.md`. Read this first.
+
+## What we're changing
+
+Instar has two ways to talk to Claude. One uses your Claude subscription (no extra cost — it's the same one your sessions use). The other uses the metered Anthropic API, which charges per call. The subscription one is the default and the API one is supposed to be opt-in.
+
+Today there's one place where instar can quietly slip from "subscription" to "metered API" without you noticing. If your Claude CLI breaks for any reason — an expired login, a corrupted install, a transient network problem — AND you happen to have `ANTHROPIC_API_KEY` set in your shell environment for some other tool, instar treats that key as "well, you have it, so let's use it" and starts spending real money on every internal LLM call. Sentinel checks, tone-gate reviews, stall-triage, input-guard: all of it billed.
+
+You'd find out from the Anthropic billing dashboard, not from instar.
+
+This change removes that silent path. From now on:
+
+- **Subscription only**, unless you explicitly say otherwise. Even if your CLI is broken and a key is sitting in your environment, instar will degrade to its non-LLM heuristics rather than spend money behind your back.
+- **API mode requires two flags in your config**, not one. You have to set both `intelligenceProvider: "anthropic-api"` and `intelligenceProviderConfirmed: true`. A single typo or stale copy-pasted config field can't engage API mode on its own.
+- **When API mode IS active, you see a billing banner** in the server startup log every time. Yellow, boxed, hard to miss. The line literally reads "BILLING: Anthropic API mode is ACTIVE — per-call charges apply."
+
+## What you'll see day to day
+
+Nothing changes for the vast majority of users — you were already on subscription, you'll stay on subscription. The only people who see new behavior are:
+
+1. **Anyone whose CLI breaks AND has an `ANTHROPIC_API_KEY` in their environment.** Before: instar silently switched to billed API. Now: instar degrades to heuristic-only mode (tone-gate, sentinel, input-guard run with their non-LLM fallbacks), prints a yellow log line saying "ANTHROPIC_API_KEY detected but not in use because subscription-by-default," and routes a degradation alert through the normal channels. Fix the CLI to restore full intelligence.
+
+2. **Anyone who deliberately wants API mode.** Before: one config field was enough. Now: you need two fields, and you'll see a billing banner on every server start. Set `intelligenceProvider: "anthropic-api"` and `intelligenceProviderConfirmed: true` in `.instar/config.json` and have `ANTHROPIC_API_KEY` in your environment.
+
+3. **Anyone who copy-pasted a config template that happened to include `intelligenceProvider: "anthropic-api"`.** Before: that single field engaged API mode silently. Now: instar prints a warning at startup ("API mode requested but intelligenceProviderConfirmed is missing — using Claude CLI subscription") and uses subscription regardless. Two-flag rule means the typo or template artefact can't accidentally cost you money.
+
+## What's under the hood
+
+A small new file `src/core/selectIntelligenceProvider.ts` is the only place in instar that decides which LLM provider to use. The decision is a pure function — no side effects, easy to unit-test. The startup logic in `src/commands/server.ts` just calls this function and renders the result.
+
+Fourteen unit tests assert every cell of the decision table — including the critical one: "CLI broken, API key present, no opt-in → provider is null, no silent API use." If anyone ever tries to re-add the silent fallback, the test fails.
+
+## What's NOT changing
+
+- The `AnthropicIntelligenceProvider` class still exists. People who actually want API mode can still use it.
+- No other LLM call sites change. The shared-intelligence chokepoint is the only one affected.
+- No new permissions, no new state files, no new endpoints. The change is purely how the existing provider is selected.
+
+## How to push back
+
+If you ever want the old silent-fallback behavior back, you'd be reversing the principle "by default Instar should only run on subscription." That's a values change, not a code rollback. The technical rollback is one revert commit, but I'd push back hard before doing it — the original behavior was a hidden spend path and removing it is a security win.
+
+If you find the two-flag opt-in too clunky for your real API-mode use, we can revisit. The current design is deliberately a tiny bit annoying for opt-in users so it's structurally impossible for accidental users.
+
+## Reference
+
+- Full spec: `API-SAFETY-GUARD-SPEC.md`
+- Side-effects review: `upgrades/side-effects/api-safety-guard.md`
+- Approval: Telegram topic 9003, Justin, 2026-05-13

--- a/docs/specs/API-SAFETY-GUARD-SPEC.md
+++ b/docs/specs/API-SAFETY-GUARD-SPEC.md
@@ -1,0 +1,111 @@
+---
+slug: api-safety-guard
+title: API Safety Guard — Subscription-by-Default Enforcement
+review-convergence: true
+approved: true
+approved-by: justin
+approved-at: 2026-05-13
+approval-channel: telegram/9003
+---
+
+# API Safety Guard — Subscription-by-Default Enforcement
+
+## TL;DR
+
+Instar must NEVER silently fall back to billed Anthropic API mode. Today there is one path in `src/commands/server.ts` that does exactly that: if the Claude CLI is unavailable and `ANTHROPIC_API_KEY` is present in the environment, the server silently uses the API "as a last resort." This spec removes that path, strengthens the opt-in (two required flags), and adds a visible billing banner when API mode is engaged. Codified by Justin in topic 9003 on 2026-05-13: "By default Instar should only run on subscription."
+
+## Problem
+
+`src/commands/server.ts` lines 2081–2092 (pre-fix):
+
+```ts
+if (!sharedIntelligence && explicitIntelligenceProvider !== 'anthropic-api') {
+  // Last resort: if user has API key but didn't explicitly opt in, use it rather
+  // than leaving the agent flying blind.
+  try {
+    const apiProvider = AnthropicIntelligenceProvider.fromEnv();
+    if (apiProvider) {
+      sharedIntelligence = apiProvider;
+      intelligenceSource = 'Anthropic API (CLI unavailable — last resort)';
+    }
+  } catch { /* no API key available */ }
+}
+```
+
+Failure mode: a user has `ANTHROPIC_API_KEY` set in their shell rc for some other tool. Their Claude CLI breaks for any reason — OAuth expired, install corruption, network hiccup. Instar silently starts spending real money on every LLM-gated feature (sentinel, input guard, tone gate, stall triage, coherence checks). The user finds out via their Anthropic billing dashboard.
+
+The rationale comment ("degrading to heuristics is worse than using whatever LLM is available") encodes a trade-off the principal rejects: spending money silently is worse than degrading.
+
+## Design
+
+### Three changes, one chokepoint
+
+The provider-selection logic moves out of inline server-startup code into a pure, testable function `selectIntelligenceProvider()` (new file `src/core/selectIntelligenceProvider.ts`). All three safety changes land in that function so the rules are unit-testable.
+
+### Rule 1 — Remove the silent fallback
+
+The last-resort branch is deleted. If neither (a) confirmed API opt-in nor (b) Claude CLI succeeds, the result is `{ provider: null, source: 'none' }`. Caller degrades gracefully. **Never silent API use, regardless of environment.**
+
+When the selection returns `provider: null` AND an `ANTHROPIC_API_KEY` was detected in the environment, the function returns `apiKeyIgnored: true` and emits a warning explaining why the key was not used. The caller surfaces the warning via the existing console + DegradationReporter pipeline.
+
+### Rule 2 — Strengthen the explicit opt-in (two flags required)
+
+Setting `intelligenceProvider: "anthropic-api"` alone is no longer sufficient. The user must also set `intelligenceProviderConfirmed: true` in config.json. Reasoning: a single field is too easy to set accidentally (copy-pasted config, sample template, typo correction). Two fields make accidental engagement of paid mode structurally implausible — the user has to have read at least one warning explaining the second flag.
+
+Selection table:
+
+| `intelligenceProvider` | `intelligenceProviderConfirmed` | `ANTHROPIC_API_KEY` | Result |
+|------------------------|--------------------------------|---------------------|--------|
+| unset                  | any                            | any                 | CLI (or none if CLI fails) |
+| `"anthropic-api"`      | unset / false                  | any                 | CLI + warning; API REFUSED |
+| `"anthropic-api"`      | `true`                         | unset               | CLI + warning; API not possible |
+| `"anthropic-api"`      | `true`                         | present             | **API mode active** (banner + log) |
+
+### Rule 3 — Visible billing banner
+
+When API mode is active, the server startup log prints a yellow boxed banner:
+
+```
+  ┌─────────────────────────────────────────────────────────────────────┐
+  │ BILLING: Anthropic API mode is ACTIVE — per-call charges apply      │
+  │ To switch back to subscription, unset intelligenceProvider in config│
+  └─────────────────────────────────────────────────────────────────────┘
+```
+
+The banner is impossible to miss in any terminal that respects ANSI colors, and is on stdout (not stderr) so it lands in the standard server log.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `src/core/selectIntelligenceProvider.ts` | NEW — pure selection function with the safety rules |
+| `src/commands/server.ts` | replace inline provider-selection block (lines 2050–2114) with a `selectIntelligenceProvider()` call + warning/banner rendering |
+| `tests/unit/selectIntelligenceProvider.test.ts` | NEW — 14 assertions covering every cell of the selection table plus failure modes |
+| `upgrades/NEXT.md` | append release note |
+| `upgrades/side-effects/api-safety-guard.md` | NEW — comprehensive side-effects review |
+| `package.json` + `package-lock.json` | version bump |
+
+## What is NOT in this spec
+
+- **Telegram alert on first API-mode startup**: deferred. The visible startup banner + every-startup yellow log already provide loud signal. Adding a Telegram alert needs a per-machine "acknowledged" state file and integration with the attention queue — orthogonal scope.
+- **Removing `AnthropicIntelligenceProvider`**: out of scope. The provider remains available for explicit opt-in users; only the silent path is removed.
+- **Other LLM call sites**: this spec covers the shared-intelligence chokepoint. A separate audit will sweep `StallTriageNurse`, `reflect.ts`, and `relationships.intelligence` to ensure they all read from the shared provider (most already do via the same selection layer; spot-checked above).
+
+## Risk assessment
+
+- **Over-block risk**: any operator who previously relied on the silent fallback (had `ANTHROPIC_API_KEY` in env, broken CLI, and was unknowingly billed) will now see degraded LLM features instead. This is the *intended* behavior change — the silent fallback was the bug.
+- **Under-block risk**: if a user accidentally sets BOTH flags (e.g., copy-pasted from a doc), they could still engage API mode. The visible banner mitigates: they will see the billing warning on every server restart. Future tightening could require an interactive confirmation, but per-startup banner is sufficient for v1.
+- **Latency**: no change. The selection runs once at startup.
+- **Spend**: strictly downward — removes a hidden spend path.
+- **Rollback**: this is a security fix, not a feature flag. Rollback = revert the commit. Operators who want the old silent-fallback behavior back are explicitly outside Justin's stated security stance ("By default Instar should only run on subscription"); they would need to fork.
+
+## Acceptance criteria
+
+1. `selectIntelligenceProvider()` is the sole logic location for shared-intel-provider selection.
+2. Selection table above is exhaustively covered by unit tests; every cell asserted.
+3. `apiKeyIgnored: true` surfaces when an env key is present but opt-in is absent.
+4. Server startup with both confirmed flags + key → API mode + banner printed.
+5. Server startup with only `intelligenceProvider: "anthropic-api"` and no confirmation → warning + CLI fallback; API NOT used even if key is present.
+6. Server startup with CLI failing + env key present + no opt-in → `provider: null`; warning printed; **NO silent API use** (assertion in unit test).
+7. CI green on all shards.
+8. ELI16 companion published at `docs/specs/API-SAFETY-GUARD-SPEC.eli16.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "0.28.102",
+  "version": "0.28.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "0.28.102",
+      "version": "0.28.103",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "0.28.102",
+  "version": "0.28.103",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -28,6 +28,7 @@ import { TelegramAdapter, TOPIC_STYLE, selectTopicEmoji } from '../messaging/Tel
 import { RelationshipManager } from '../core/RelationshipManager.js';
 import { ClaudeCliIntelligenceProvider } from '../core/ClaudeCliIntelligenceProvider.js';
 import { AnthropicIntelligenceProvider } from '../core/AnthropicIntelligenceProvider.js';
+import { selectIntelligenceProvider } from '../core/selectIntelligenceProvider.js';
 import { FeedbackManager } from '../core/FeedbackManager.js';
 import { FeedbackAnomalyDetector } from '../monitoring/FeedbackAnomalyDetector.js';
 import { DispatchManager } from '../core/DispatchManager.js';
@@ -2048,48 +2049,35 @@ export async function startServer(options: StartOptions): Promise<void> {
     _projectDir = config.sessions.projectDir;
 
     // Shared intelligence provider — lightweight LLM for internal classification tasks.
-    // Priority: Claude CLI subscription (zero extra cost, default) → Anthropic API (explicit opt-in)
-    // Components that need LLM intelligence (Sentinel, TelegramAdapter, etc.) share this.
-    //
-    // Rationale: Instar must not depend on an API key. The subscription path is the default so
-    // every agent gets LLM-gated features out of the box. Users who prefer direct API access can
-    // set `intelligenceProvider: "anthropic-api"` in config.json.
-    let sharedIntelligence: IntelligenceProvider | undefined;
-    const explicitIntelligenceProvider =
-      (config as unknown as { intelligenceProvider?: string }).intelligenceProvider;
-    let intelligenceSource = 'none';
-
-    if (explicitIntelligenceProvider === 'anthropic-api') {
-      try {
-        const apiProvider = AnthropicIntelligenceProvider.fromEnv();
-        if (apiProvider) {
-          sharedIntelligence = apiProvider;
-          intelligenceSource = 'Anthropic API (explicit opt-in)';
-        } else {
-          console.log(pc.yellow('  intelligenceProvider: "anthropic-api" set but ANTHROPIC_API_KEY not found — falling back to Claude CLI'));
-        }
-      } catch { /* no API key available */ }
+    // Subscription-by-default: API mode requires BOTH `intelligenceProvider: "anthropic-api"`
+    // AND `intelligenceProviderConfirmed: true`. The selection logic lives in a separate
+    // pure function so the safety rules are unit-testable.
+    const apiOpts = config as unknown as {
+      intelligenceProvider?: string;
+      intelligenceProviderConfirmed?: boolean;
+    };
+    const selection = selectIntelligenceProvider({
+      intelligenceProvider: apiOpts.intelligenceProvider,
+      intelligenceProviderConfirmed: apiOpts.intelligenceProviderConfirmed,
+      anthropicApiKey: process.env['ANTHROPIC_API_KEY'],
+      claudePath: config.sessions.claudePath,
+      buildClaude: (claudePath) => new ClaudeCliIntelligenceProvider(claudePath),
+      buildAnthropic: (apiKey) => new AnthropicIntelligenceProvider(apiKey),
+    });
+    const sharedIntelligence: IntelligenceProvider | undefined = selection.provider ?? undefined;
+    for (const w of selection.warnings) console.log(pc.yellow(`  ${w}`));
+    if (selection.apiModeActive) {
+      console.log(pc.yellow('  ┌─────────────────────────────────────────────────────────────────────┐'));
+      console.log(pc.yellow('  │ BILLING: Anthropic API mode is ACTIVE — per-call charges apply      │'));
+      console.log(pc.yellow('  │ To switch back to subscription, unset intelligenceProvider in config│'));
+      console.log(pc.yellow('  └─────────────────────────────────────────────────────────────────────┘'));
     }
-
-    if (!sharedIntelligence) {
-      try {
-        sharedIntelligence = new ClaudeCliIntelligenceProvider(config.sessions.claudePath);
-        intelligenceSource = 'Claude CLI subscription';
-      } catch { /* CLI not available */ }
-    }
-
-    if (!sharedIntelligence && explicitIntelligenceProvider !== 'anthropic-api') {
-      // Last resort: if user has API key but didn't explicitly opt in, use it rather than
-      // leaving the agent flying blind. We prefer subscription, but degrading to heuristics
-      // is worse than using whatever LLM is available.
-      try {
-        const apiProvider = AnthropicIntelligenceProvider.fromEnv();
-        if (apiProvider) {
-          sharedIntelligence = apiProvider;
-          intelligenceSource = 'Anthropic API (CLI unavailable — last resort)';
-        }
-      } catch { /* no API key available */ }
-    }
+    const intelligenceSourceLabel: Record<typeof selection.source, string> = {
+      'anthropic-api-confirmed': 'Anthropic API (explicit opt-in, confirmed)',
+      'claude-cli': 'Claude CLI subscription',
+      'none': 'none',
+    };
+    const intelligenceSource = intelligenceSourceLabel[selection.source];
 
     _sharedIntelligence = sharedIntelligence ?? null;
     if (sharedIntelligence) {

--- a/src/core/selectIntelligenceProvider.ts
+++ b/src/core/selectIntelligenceProvider.ts
@@ -1,0 +1,126 @@
+/**
+ * selectIntelligenceProvider — choose the shared LLM provider with subscription-by-default
+ * safety guarantees.
+ *
+ * Rules:
+ *   1. Anthropic API mode requires BOTH `intelligenceProvider: "anthropic-api"` AND
+ *      `intelligenceProviderConfirmed: true` in config. Either one alone is rejected with
+ *      a visible warning, and selection falls through to Claude CLI.
+ *   2. With both flags set and an `ANTHROPIC_API_KEY` available, API mode engages and the
+ *      caller is expected to render a billing banner (signaled via `apiModeActive`).
+ *   3. If API mode is rejected (or never requested), Claude CLI is attempted next.
+ *   4. If neither succeeds, the result is `provider: null, source: 'none'`. The caller
+ *      degrades gracefully — there is NO silent fallback to the API even if an
+ *      `ANTHROPIC_API_KEY` is present in the environment. The presence of the env key
+ *      without explicit opt-in is reported via `apiKeyIgnored: true`.
+ *
+ * This is the single chokepoint where Instar's subscription-by-default principle is
+ * enforced. Every other LLM-gated feature shares the provider this function returns.
+ */
+
+import type { IntelligenceProvider } from './types.js';
+
+export interface IntelligenceSelectionInput {
+  intelligenceProvider?: string;
+  intelligenceProviderConfirmed?: boolean;
+  anthropicApiKey?: string | undefined;
+  claudePath?: string | undefined;
+  buildClaude: (claudePath: string) => IntelligenceProvider | null;
+  buildAnthropic: (apiKey: string) => IntelligenceProvider | null;
+}
+
+export type IntelligenceSource =
+  | 'anthropic-api-confirmed'
+  | 'claude-cli'
+  | 'none';
+
+export interface IntelligenceSelection {
+  provider: IntelligenceProvider | null;
+  source: IntelligenceSource;
+  /** Human-readable warnings the caller should surface via console + degradation log. */
+  warnings: string[];
+  /** True iff API mode is the active, confirmed selection (caller should render billing banner). */
+  apiModeActive: boolean;
+  /** True iff ANTHROPIC_API_KEY was present in env but NOT used due to subscription-by-default. */
+  apiKeyIgnored: boolean;
+}
+
+export function selectIntelligenceProvider(input: IntelligenceSelectionInput): IntelligenceSelection {
+  const warnings: string[] = [];
+  const wantsApi = input.intelligenceProvider === 'anthropic-api';
+  const apiConfirmed = input.intelligenceProviderConfirmed === true;
+  const hasKey = typeof input.anthropicApiKey === 'string' && input.anthropicApiKey.length > 0;
+
+  // Step 1 — explicit, confirmed API opt-in.
+  if (wantsApi && apiConfirmed) {
+    if (hasKey) {
+      const apiProvider = safeBuild(() => input.buildAnthropic(input.anthropicApiKey!));
+      if (apiProvider) {
+        return {
+          provider: apiProvider,
+          source: 'anthropic-api-confirmed',
+          warnings,
+          apiModeActive: true,
+          apiKeyIgnored: false,
+        };
+      }
+      warnings.push(
+        'intelligenceProvider "anthropic-api" + intelligenceProviderConfirmed true set, ' +
+          'but the Anthropic provider constructor returned null — falling back to Claude CLI.',
+      );
+    } else {
+      warnings.push(
+        'intelligenceProvider "anthropic-api" requested but ANTHROPIC_API_KEY not found in environment ' +
+          '— falling back to Claude CLI.',
+      );
+    }
+  } else if (wantsApi && !apiConfirmed) {
+    // Strong guard: setting the provider name alone is not consent to spend.
+    warnings.push(
+      'intelligenceProvider "anthropic-api" is set but intelligenceProviderConfirmed is missing or false. ' +
+        'API mode is DISABLED until both flags are explicitly set in config.json ' +
+        '(Anthropic API charges per call). Using Claude CLI subscription instead.',
+    );
+  }
+
+  // Step 2 — Claude CLI subscription (the default).
+  if (input.claudePath) {
+    const cliProvider = safeBuild(() => input.buildClaude(input.claudePath!));
+    if (cliProvider) {
+      return {
+        provider: cliProvider,
+        source: 'claude-cli',
+        warnings,
+        apiModeActive: false,
+        apiKeyIgnored: hasKey && !wantsApi,
+      };
+    }
+  }
+
+  // Step 3 — neither path succeeded. Subscription-by-default: do NOT fall through
+  // to the API "as a last resort." That was the old silent behaviour. Now we
+  // surface the env-key-present case explicitly and degrade.
+  if (hasKey && !wantsApi) {
+    warnings.push(
+      'ANTHROPIC_API_KEY detected in environment but intelligenceProvider is not set to "anthropic-api". ' +
+        'Subscription-by-default: ignoring the key. To opt in to API mode, set BOTH ' +
+        'intelligenceProvider: "anthropic-api" AND intelligenceProviderConfirmed: true in config.json.',
+    );
+  }
+
+  return {
+    provider: null,
+    source: 'none',
+    warnings,
+    apiModeActive: false,
+    apiKeyIgnored: hasKey && !wantsApi,
+  };
+}
+
+function safeBuild<T>(fn: () => T | null): T | null {
+  try {
+    return fn();
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/selectIntelligenceProvider.test.ts
+++ b/tests/unit/selectIntelligenceProvider.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for selectIntelligenceProvider — the single chokepoint that enforces
+ * Instar's subscription-by-default principle.
+ *
+ * Critical safety properties under test:
+ *   - API mode requires BOTH flags (intelligenceProvider AND intelligenceProviderConfirmed).
+ *   - Setting only intelligenceProvider does NOT engage API mode.
+ *   - An ANTHROPIC_API_KEY in the environment alone does NOT cause silent API use.
+ *   - Selection always prefers Claude CLI subscription when API mode is rejected.
+ *   - `apiKeyIgnored` accurately reports the "env key present, opt-in missing" case.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { selectIntelligenceProvider } from '../../src/core/selectIntelligenceProvider.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+const fakeClaude: IntelligenceProvider = { evaluate: async () => 'cli-response' };
+const fakeAnthropic: IntelligenceProvider = { evaluate: async () => 'api-response' };
+
+const buildClaudeOK = (_: string) => fakeClaude;
+const buildAnthropicOK = (_: string) => fakeAnthropic;
+const buildClaudeFail = (_: string): IntelligenceProvider | null => {
+  throw new Error('CLI not available');
+};
+const buildAnthropicFail = (_: string): IntelligenceProvider | null => {
+  throw new Error('API not available');
+};
+
+describe('selectIntelligenceProvider — subscription-by-default safety', () => {
+  describe('API mode (both flags required)', () => {
+    it('engages API mode when both flags AND a key are present', () => {
+      const result = selectIntelligenceProvider({
+        intelligenceProvider: 'anthropic-api',
+        intelligenceProviderConfirmed: true,
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.provider).toBe(fakeAnthropic);
+      expect(result.source).toBe('anthropic-api-confirmed');
+      expect(result.apiModeActive).toBe(true);
+      expect(result.apiKeyIgnored).toBe(false);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('REFUSES API mode when intelligenceProvider is set but confirmed is missing', () => {
+      const result = selectIntelligenceProvider({
+        intelligenceProvider: 'anthropic-api',
+        intelligenceProviderConfirmed: false,
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.provider).toBe(fakeClaude);
+      expect(result.source).toBe('claude-cli');
+      expect(result.apiModeActive).toBe(false);
+      expect(result.warnings.length).toBe(1);
+      expect(result.warnings[0]).toContain('intelligenceProviderConfirmed');
+      expect(result.warnings[0]).toContain('DISABLED');
+    });
+
+    it('REFUSES API mode when confirmed is undefined (default)', () => {
+      const result = selectIntelligenceProvider({
+        intelligenceProvider: 'anthropic-api',
+        // intelligenceProviderConfirmed omitted entirely
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.provider).toBe(fakeClaude);
+      expect(result.source).toBe('claude-cli');
+      expect(result.apiModeActive).toBe(false);
+      expect(result.warnings[0]).toContain('intelligenceProviderConfirmed');
+    });
+
+    it('falls back to CLI when API flags are set but no key is present', () => {
+      const result = selectIntelligenceProvider({
+        intelligenceProvider: 'anthropic-api',
+        intelligenceProviderConfirmed: true,
+        anthropicApiKey: undefined,
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.provider).toBe(fakeClaude);
+      expect(result.source).toBe('claude-cli');
+      expect(result.apiModeActive).toBe(false);
+      expect(result.warnings[0]).toContain('ANTHROPIC_API_KEY not found');
+    });
+
+    it('falls back to CLI when the Anthropic constructor throws', () => {
+      const result = selectIntelligenceProvider({
+        intelligenceProvider: 'anthropic-api',
+        intelligenceProviderConfirmed: true,
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicFail,
+      });
+      expect(result.provider).toBe(fakeClaude);
+      expect(result.source).toBe('claude-cli');
+      expect(result.apiModeActive).toBe(false);
+      expect(result.warnings[0]).toContain('Anthropic provider constructor returned null');
+    });
+  });
+
+  describe('subscription-by-default (no silent API use)', () => {
+    it('uses CLI when no flags are set, even if an API key is in env', () => {
+      const result = selectIntelligenceProvider({
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.provider).toBe(fakeClaude);
+      expect(result.source).toBe('claude-cli');
+      expect(result.apiModeActive).toBe(false);
+      expect(result.apiKeyIgnored).toBe(true);
+      // No warning on the success path — apiKeyIgnored is the signal for the caller.
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('does NOT silently fall through to API when CLI is unavailable but key is present', () => {
+      const result = selectIntelligenceProvider({
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeFail,
+        buildAnthropic: buildAnthropicOK,
+      });
+      // The critical property: provider is null. No silent API use.
+      expect(result.provider).toBe(null);
+      expect(result.source).toBe('none');
+      expect(result.apiModeActive).toBe(false);
+      expect(result.apiKeyIgnored).toBe(true);
+      expect(result.warnings.some((w) => w.includes('ANTHROPIC_API_KEY detected'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('Subscription-by-default'))).toBe(true);
+    });
+
+    it('returns provider:null with no warnings when neither CLI nor key is available', () => {
+      const result = selectIntelligenceProvider({
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeFail,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.provider).toBe(null);
+      expect(result.source).toBe('none');
+      expect(result.apiModeActive).toBe(false);
+      expect(result.apiKeyIgnored).toBe(false);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('treats empty-string API key as not present', () => {
+      const result = selectIntelligenceProvider({
+        intelligenceProvider: 'anthropic-api',
+        intelligenceProviderConfirmed: true,
+        anthropicApiKey: '',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.provider).toBe(fakeClaude);
+      expect(result.source).toBe('claude-cli');
+      expect(result.apiModeActive).toBe(false);
+      expect(result.apiKeyIgnored).toBe(false);
+    });
+  });
+
+  describe('CLI failure modes', () => {
+    it('returns provider:null with empty warnings when CLI fails and no API mode requested', () => {
+      const result = selectIntelligenceProvider({
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeFail,
+        buildAnthropic: buildAnthropicOK,
+        // no api key, no api opt-in
+      });
+      expect(result.provider).toBe(null);
+      expect(result.source).toBe('none');
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('returns provider:null when claudePath is undefined', () => {
+      const result = selectIntelligenceProvider({
+        claudePath: undefined,
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.provider).toBe(null);
+      expect(result.source).toBe('none');
+    });
+  });
+
+  describe('apiKeyIgnored flag accuracy', () => {
+    it('is true when key is present and no opt-in, regardless of outcome', () => {
+      const a = selectIntelligenceProvider({
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(a.apiKeyIgnored).toBe(true);
+
+      const b = selectIntelligenceProvider({
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeFail,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(b.apiKeyIgnored).toBe(true);
+    });
+
+    it('is false when API opt-in is active', () => {
+      const result = selectIntelligenceProvider({
+        intelligenceProvider: 'anthropic-api',
+        intelligenceProviderConfirmed: true,
+        anthropicApiKey: 'sk-test',
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.apiKeyIgnored).toBe(false);
+    });
+
+    it('is false when no key is present', () => {
+      const result = selectIntelligenceProvider({
+        claudePath: '/usr/bin/claude',
+        buildClaude: buildClaudeOK,
+        buildAnthropic: buildAnthropicOK,
+      });
+      expect(result.apiKeyIgnored).toBe(false);
+    });
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -11,6 +11,18 @@ The binding gate the INSTAR-JOBS-AS-AGENTMD spec §Seamless Migration Guarantee 
 
 ## What Changed
 
+### fix(security): API safety guard — subscription-by-default enforcement
+
+`src/commands/server.ts` had one silent-fallback path that could engage billed Anthropic API mode without explicit user consent: if the Claude CLI was unavailable and `ANTHROPIC_API_KEY` happened to be set in the environment, instar would silently use the API "as a last resort." That trade-off ("degrading to heuristics is worse than using whatever LLM is available") encoded a values choice the principal rejects. Removed.
+
+Selection logic moves to a new pure function `src/core/selectIntelligenceProvider.ts`. API mode now requires BOTH `intelligenceProvider: "anthropic-api"` AND `intelligenceProviderConfirmed: true` in config.json. Server startup with API mode active prints a visible yellow boxed billing banner. An `ANTHROPIC_API_KEY` in env without the two-flag opt-in is surfaced as a warning and explicitly ignored.
+
+- New `src/core/selectIntelligenceProvider.ts` — pure selection function; 14 unit tests in `tests/unit/selectIntelligenceProvider.test.ts` exhaustively cover the selection table.
+- `src/commands/server.ts` replaces the inline 70-line selection block (formerly lines 2050–2114) with a `selectIntelligenceProvider()` call plus warning/banner rendering.
+- Spec: `docs/specs/API-SAFETY-GUARD-SPEC.md` + ELI16 companion at `API-SAFETY-GUARD-SPEC.eli16.md`. Side-effects review: `upgrades/side-effects/api-safety-guard.md`.
+
+Driven by Telegram topic 9003 on 2026-05-13: "By default Instar should only run on subscription."
+
 ### F-1 — RemediationKeyVault (Tier-1 foundation for Self-Healing Remediator)
 
 - **Adds** `src/remediation/RemediationKeyVault.ts` — per-context, per-scope HKDF-SHA256 leaf-key derivation with a 4-backend secret store (OS keychain, hardware enclave stub, cloud KMS stub, env-passphrase + AES-256-GCM flatfile).
@@ -33,6 +45,8 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 
 ## What to Tell Your User
 
+**Stronger API-billing safety.** Instar will no longer silently switch from your Claude subscription to the metered Anthropic API just because your CLI broke and you happen to have an API key in your environment. The default has always been subscription-only; this fix removes the one path that could quietly bill you. If you actually want API mode, you now need to set two flags in config (`intelligenceProvider: "anthropic-api"` AND `intelligenceProviderConfirmed: true`), and every server startup in API mode prints a yellow boxed banner so it's impossible to miss. No setup needed for the subscription path — that is the default and it stays the default.
+
 **F-1 — Cryptographic foundation for self-healing.** Nothing user-visible yet. Operators running on headless Linux without libsecret should set `INSTAR_REMEDIATION_KEY_PASSPHRASE` in their environment before any F-2+ feature ships. macOS and Linux+libsecret have nothing to do.
 
 **ELI16-overview gate.** When your agent hands you a spec for approval, you'll now always get a plain-English overview alongside the dense technical document. The instar repo refuses to commit any code change whose driving spec lacks a readable companion file. The technical spec becomes the appendix; the overview is the entry point. No setup required; the new behavior takes effect on the next agent update.
@@ -46,3 +60,4 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 - **Shared check module** at `scripts/eli16-overview-check.mjs` — `resolveEli16Path()` and `checkEli16Overview()` with 800-char minimum-length floor.
 - **Template for ELI16 overviews** at `skills/instar-dev/templates/eli16-overview.md`.
 - **Forward-only enforcement** — only specs newly committed-against after this ships have to satisfy the gate.
+- **`selectIntelligenceProvider()`** — single chokepoint enforcing subscription-by-default for the shared LLM provider; refuses silent API fallback; requires two explicit flags for API opt-in; prints a billing banner when API mode is active.

--- a/upgrades/side-effects/api-safety-guard.md
+++ b/upgrades/side-effects/api-safety-guard.md
@@ -1,0 +1,80 @@
+# Side-Effects Review — API Safety Guard
+
+Spec: `docs/specs/API-SAFETY-GUARD-SPEC.md`
+Driving topic: Telegram 9003, Justin, 2026-05-13.
+
+## What's IN
+
+1. Extract shared-intel-provider selection into a pure function `selectIntelligenceProvider()` at `src/core/selectIntelligenceProvider.ts`.
+2. Remove the silent last-resort fallback at `src/commands/server.ts:2081-2092`.
+3. Require BOTH `intelligenceProvider: "anthropic-api"` AND `intelligenceProviderConfirmed: true` for API mode to engage.
+4. Render a visible billing banner on every startup when API mode is active.
+5. Surface `ANTHROPIC_API_KEY` in env without opt-in as a warning (not a spend).
+6. 14 unit tests asserting every cell of the selection table plus failure modes.
+
+## What's DEFERRED
+
+- **Telegram alert on first API-mode engagement**: would require per-machine "acknowledged" state file + attention queue routing. The visible banner + per-startup yellow log are sufficient signal for v1. Future spec: `api-mode-first-use-alert`.
+- **Audit of every LLM call site**: the shared provider is used by Sentinel, InputGuard, Coherence checks, etc. — they all read from the chokepoint we just hardened. `StallTriageNurse` and `reflect.ts` also receive the shared provider. A separate audit would confirm no orthogonal API call sites exist. Spot-checked above; full audit deferred.
+- **Removal of `AnthropicIntelligenceProvider` class**: explicit opt-in users still need it. Out of scope.
+
+## Over-block analysis
+
+The new behavior REFUSES API mode in two cases that previously allowed it:
+
+1. **Single-flag opt-in** (`intelligenceProvider: "anthropic-api"` without `intelligenceProviderConfirmed: true`). Previously: API mode active. Now: warning + CLI fallback. **Intended over-block**: a single field is too easy to set accidentally.
+2. **Silent env-key fallback** (CLI fails + key in env + no opt-in). Previously: API mode silently active. Now: `provider: null`, degradation. **Intended over-block**: this is the security hole the spec exists to close.
+
+No unintended over-block: the new `selectIntelligenceProvider()` function exhaustively covers every previously-allowed case that should still work.
+
+## Under-block analysis
+
+After this lands, the remaining accidental-spend surface area is:
+
+- A user who deliberately sets BOTH flags and forgets they did so. The visible banner on every startup is the mitigation — they will see the billing warning until they remove the flags.
+- A user who explicitly runs in API mode and is surprised by the cost. This is consent + visibility; outside the scope of "silent" spend.
+
+No under-block paths remain in the shared-provider selection logic.
+
+## Level-of-abstraction fit
+
+The selection logic was inline in a 70-line block inside the server-startup procedure. Extracting it to a named function:
+
+- **Improves**: testability (the safety rules are now unit-tested rather than encoded in integration startup behavior), reviewability (one place to audit the selection rules), separation of concerns (selection vs rendering).
+- **Costs**: one new file, ~120 lines (most of which is JSDoc and types). Net positive — the spec itself is the documentation surface for the chokepoint principle.
+
+The function takes constructor functions as dependencies, not class instances, so it's pure and doesn't require a process or env to test.
+
+## Signal-vs-authority compliance
+
+Per CLAUDE.md "Signal vs authority separation" rule: brittle filters emit signals; intelligent gates with full context have blocking authority.
+
+This change is not a filter — it's a configuration gate at startup. The "signal" here is the config (user's stated intent). The "authority" is the selection function (one place that enforces the rule). Compliant.
+
+## Interactions
+
+- **`InputGuard`**: receives `sharedIntelligence` from server.ts. With API mode disabled, falls back to `provenance + patterns only (no LLM review)` — already the documented degraded mode. No new interaction.
+- **`StallTriageNurse`**: same as above. No new interaction.
+- **`DegradationReporter`**: still reports the `SharedIntelligenceProvider` degradation when `provider: null`. The reporter call site is unchanged (we wrap the existing call rather than replacing it). New: the warnings array from `selectIntelligenceProvider()` adds context to the console output, but does not change degradation routing.
+- **Git sync intelligence wiring** (`gitSync.setIntelligence(sharedIntelligence)` at line 2117): unchanged. If selection returns `null`, gitSync gets no intelligence (same as before).
+- **`relationships.intelligence` wiring** (lines 2150–2179): a separate code path that already has correct subscription-by-default behavior (does NOT silently fall back to API). Untouched by this PR but worth noting it's the model the new chokepoint mimics.
+- **Test isolation**: new unit tests use injected constructor functions, no real CLI or API. Tests cannot accidentally spend money even if `ANTHROPIC_API_KEY` is in CI env.
+
+## Rollback cost
+
+- One commit revert undoes the change. No data migrations, no state files written.
+- No downstream consumers schema-changed; `IntelligenceProvider` interface unchanged.
+- After revert, the silent-fallback security hole returns. Operators who want the rollback are explicitly outside the principal's stated security stance.
+
+## CI surface
+
+Touches:
+- `src/commands/server.ts` (modified) — Build, Type Check, all unit shards (server startup tests live in `tests/integration/server-startup.test.ts` — none rely on the old silent-fallback path; checked).
+- `src/core/selectIntelligenceProvider.ts` (new) — new unit test file.
+- `tests/unit/selectIntelligenceProvider.test.ts` (new) — 14 assertions.
+
+No CI workflow changes. No husky hook changes. No native module changes.
+
+## Open questions
+
+None. The change is fully specified by the user statement in topic 9003: "By default Instar should only run on subscription," paired with my reported finding of the single silent-fallback location.


### PR DESCRIPTION
## Summary

Remove the silent last-resort fallback in `src/commands/server.ts` that silently engaged billed Anthropic API mode when the Claude CLI was unavailable and `ANTHROPIC_API_KEY` happened to be present in the environment. Per principal direction in Telegram topic 9003 on 2026-05-13: "By default Instar should only run on subscription."

- Selection logic moves to a pure function `src/core/selectIntelligenceProvider.ts`.
- API mode now requires BOTH `intelligenceProvider: "anthropic-api"` AND `intelligenceProviderConfirmed: true` in `.instar/config.json`. A single field is no longer sufficient.
- Server startup with API mode active prints a visible yellow boxed billing banner.
- An `ANTHROPIC_API_KEY` in env without the two-flag opt-in is surfaced as a warning and explicitly ignored — never silent API use.

## Spec / review artifacts

- Spec: `docs/specs/API-SAFETY-GUARD-SPEC.md`
- ELI16 companion: `docs/specs/API-SAFETY-GUARD-SPEC.eli16.md`
- Side-effects review: `upgrades/side-effects/api-safety-guard.md`
- /instar-dev trace: `.instar/instar-dev-traces/20260513T185500Z-api-safety-guard.json`

## Test plan

- [x] 14 new unit tests in `tests/unit/selectIntelligenceProvider.test.ts` exhaustively cover the selection table plus failure modes
- [x] Critical assertion: "CLI broken + API key present + no opt-in → provider is null, NO silent API use"
- [x] Typecheck: `tsc --noEmit` clean
- [ ] Full CI shards green