### PR TITLE
feat(monitoring): F-3 — DegradationReporter normalization shim

### DIFF
--- a/scripts/lint-degradation-emit-sites.js
+++ b/scripts/lint-degradation-emit-sites.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * lint-degradation-emit-sites.js — warning-only lint over DegradationReporter
+ * emit sites.
+ *
+ * Per SELF-HEALING-REMEDIATOR-V2-SPEC.md §A33 / §A50, F-3 ships a back-compat
+ * shim that lets legacy `.report(...)` callers continue to work. The lint
+ * catalogues every emit site so an incremental migration to the go-forward
+ * `reportStructured(...)` API can be tracked. **This lint NEVER blocks** —
+ * it always exits 0. F-8 may upgrade it to blocking once the Remediator
+ * dispatcher is live and a deprecation timeline is agreed.
+ *
+ * Output shape (one line per site):
+ *   <category>  <relpath>:<line>  <snippet>
+ *
+ * Categories:
+ *   legacy      — `.report({...})` call against a DegradationReporter
+ *                 instance (uses the legacy quintuple shape).
+ *   structured  — `.reportStructured({...})` call (already migrated).
+ *
+ * Counts go to stderr; the final exit code is always 0.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+
+// Walk src/ collecting .ts files. The reporter is only consumed from src/ at
+// runtime — tests use their own reset/configure dance, and other paths are
+// out of scope for the emit-site catalogue.
+function walk(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip generated / vendored dirs.
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '.git') continue;
+      walk(full, acc);
+    } else if (entry.isFile() && /\.(ts|tsx|js|mjs|cjs)$/.test(entry.name)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Match the bare expression `.report(` immediately following an identifier
+// that plausibly references DegradationReporter. Two recognised shapes:
+//   DegradationReporter.getInstance().report(
+//   <name>.report(   where <name> is a binding to a reporter
+// Plus `.reportStructured(` for migrated callers.
+//
+// This is intentionally string-matching: F-8 may upgrade to AST-aware
+// detection, but for a warning-only catalogue grep is enough.
+const LEGACY_RE = /\.(report)\s*\(/g;
+const STRUCTURED_RE = /\.(reportStructured)\s*\(/g;
+
+const SRC_DIR = path.join(ROOT, 'src');
+if (!fs.existsSync(SRC_DIR)) {
+  console.warn(`[lint-degradation-emit-sites] src/ not found at ${SRC_DIR} — nothing to scan.`);
+  process.exit(0);
+}
+
+let legacyCount = 0;
+let structuredCount = 0;
+const lines = [];
+
+for (const file of walk(SRC_DIR)) {
+  // Skip the reporter itself — its `.report(` references are method
+  // definitions / internal calls, not emit sites we want to track.
+  const rel = path.relative(ROOT, file);
+  if (rel === path.join('src', 'monitoring', 'DegradationReporter.ts')) continue;
+
+  let content;
+  try { content = fs.readFileSync(file, 'utf-8'); }
+  catch { continue; }
+
+  // Only files that mention DegradationReporter count as emit sites.
+  if (!content.includes('DegradationReporter')) continue;
+
+  const fileLines = content.split('\n');
+  for (let i = 0; i < fileLines.length; i++) {
+    const line = fileLines[i];
+    if (STRUCTURED_RE.test(line)) {
+      STRUCTURED_RE.lastIndex = 0;
+      structuredCount += 1;
+      lines.push(`structured  ${rel}:${i + 1}  ${line.trim()}`);
+      continue;
+    }
+    LEGACY_RE.lastIndex = 0;
+    if (LEGACY_RE.test(line)) {
+      // Filter `reportStructured` false-positives (regex above matched
+      // because `.report(` is a prefix of `.reportStructured(`). The
+      // STRUCTURED_RE branch above already handled the structured case,
+      // so a line matching both is structured and skipped here.
+      if (/\.reportStructured\s*\(/.test(line)) continue;
+      legacyCount += 1;
+      lines.push(`legacy      ${rel}:${i + 1}  ${line.trim()}`);
+    }
+    LEGACY_RE.lastIndex = 0;
+    STRUCTURED_RE.lastIndex = 0;
+  }
+}
+
+// Print catalogue to stdout — caller can pipe to a file / grep further.
+for (const line of lines) console.log(line);
+
+// Summary to stderr so it doesn't pollute the parseable list.
+console.error('');
+console.error(`[lint-degradation-emit-sites] legacy:     ${legacyCount}`);
+console.error(`[lint-degradation-emit-sites] structured: ${structuredCount}`);
+console.error('[lint-degradation-emit-sites] warning-only — exit 0 always (per spec A33 / A50).');
+
+process.exit(0);

--- a/src/monitoring/DegradationReporter.ts
+++ b/src/monitoring/DegradationReporter.ts
@@ -32,6 +32,9 @@ import path from 'node:path';
 import os from 'node:os';
 import { detectJargon } from '../core/JargonDetector.js';
 import type { MessagingToneGate } from '../core/MessagingToneGate.js';
+import { Redactor } from './Redactor.js';
+import { ErrorCodeExtractor, type ErrorProvenance } from './ErrorCodeExtractor.js';
+import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
 
 export interface DegradationEvent {
   /** Which feature degraded */
@@ -50,6 +53,53 @@ export interface DegradationEvent {
   reported: boolean;
   /** Whether this was sent as a Telegram alert */
   alerted: boolean;
+}
+
+/**
+ * Normalized degradation event — the go-forward shape per
+ * SELF-HEALING-REMEDIATOR-V2-SPEC.md §A33. Replaces the legacy
+ * `{feature, primary, fallback, reason, impact}` quintuple with a
+ * structured form usable by the Remediator dispatcher (F-8) and the
+ * runbook registry's `eventPrefilter.errorCode` matcher (§A6).
+ *
+ * F-3 ships this contract as additive; emit-site migration is incremental.
+ * Legacy `.report(...)` flows through `_normalize()` and arrives at the
+ * Remediator as `provenance: 'free-text'`, which §A6 forbids from matching
+ * any runbook prefilter. Legacy events therefore route to
+ * `no-matching-runbook` and feed NovelFailureReviewer's clustering pipeline.
+ */
+export interface NormalizedDegradationEvent {
+  /** The subsystem that degraded — equivalent of the legacy `feature` field. */
+  subsystem: string;
+  /** Canonical error code extracted via ErrorCodeExtractor. */
+  errorCode: string;
+  /** Where the errorCode came from — gates runbook matching per §A6. */
+  provenance: ErrorProvenance;
+  /** Redacted + full reason payload. `full` stays internal; `redacted` is the only outbound form. */
+  reason: {
+    redacted: string;
+    /** Full unredacted text — never crosses persistence/alert/LLM-prompt boundaries. */
+    full: string;
+  };
+  /** ISO timestamp of detection. */
+  timestamp: string;
+  /** Monotonic timestamp (Number from `performance.now()` or equivalent) for cross-event ordering. */
+  monotonicTs: number;
+  /**
+   * Optional legacy-event reference. Populated when a normalized event was
+   * produced from a legacy `.report(...)` call so downstream consumers
+   * (alert path, audit log) can recover the original quintuple.
+   */
+  legacy?: DegradationEvent;
+}
+
+/**
+ * Remediator dispatch surface — F-8 implements this. F-3 only exposes the
+ * hook (`setRemediator`) so the dispatcher can subscribe; no consumer is
+ * wired in this PR.
+ */
+export interface RemediatorLike {
+  dispatch(event: NormalizedDegradationEvent): Promise<void>;
 }
 
 type TelegramSender = (topicId: number, text: string) => Promise<unknown>;
@@ -81,6 +131,31 @@ type FeedbackSubmitter = (item: {
 // How long before the same feature can trigger another Telegram alert (ms)
 const ALERT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 
+/**
+ * Monotonic timestamp source. Prefers `performance.now()` (high-resolution,
+ * monotonic across process lifetime). Falls back to `Date.now()` on
+ * environments that don't expose it. Returns a Number, not a bigint, so
+ * the value JSON-serializes cleanly into the durable queue.
+ */
+function monotonicNow(): number {
+  try {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+      return performance.now();
+    }
+  } catch { /* environments without performance API */ }
+  return Date.now();
+}
+
+// Durable RestartPending queue caps (per §A5). When `_setRestartPending(true)`
+// is asserted (e.g., by the lifeline supervisor staging a restart), incoming
+// events are appended to a JSONL queue instead of dispatched immediately.
+// Drop-and-counter on overflow — older events stay on disk, new events past
+// the cap increment a counter and are discarded so the queue can't grow
+// unbounded during a long restart-pending window.
+const RESTART_QUEUE_MAX_ENTRIES = 1000;
+const RESTART_QUEUE_MAX_BYTES = 5 * 1024 * 1024; // 5 MiB
+const RESTART_QUEUE_REL_PATH = path.join('remediation', 'degradations-queue.jsonl');
+
 export class DegradationReporter {
   private static instance: DegradationReporter | null = null;
 
@@ -98,6 +173,28 @@ export class DegradationReporter {
 
   // Dedup: track last alert time per feature to avoid spamming Telegram
   private lastAlertTime: Map<string, number> = new Map();
+
+  // F-3 additions ─────────────────────────────────────────────
+  // The Remediator dispatch hook (F-8 wires the consumer). When set, the
+  // legacy `.report(...)` and the new `.reportStructured(...)` both route
+  // their normalized events to `remediator.dispatch()` instead of the
+  // legacy alert path. When unset, the legacy alert path runs unchanged
+  // (backward compat — F-3 ships a shim only, no emit-site migration).
+  private remediator: RemediatorLike | null = null;
+
+  // Centralized redactor for the `reason.full → reason.redacted` step.
+  // Lazily instantiated so tests that don't exercise normalization don't pay
+  // the (cheap) construction cost.
+  private redactor: Redactor | null = null;
+
+  // RestartPending — when true, events queue to disk instead of dispatching.
+  // Flipped by the lifeline supervisor (or test harness) via _setRestartPending.
+  private restartPending = false;
+
+  // Overflow counter — incremented when the queue cap is hit so we know
+  // how many events were dropped during a restart-pending window. Persisted
+  // alongside the queue file as a sidecar JSON.
+  private queueDropCount = 0;
 
   private constructor() {}
 
@@ -167,6 +264,12 @@ export class DegradationReporter {
    *
    * This is the primary API. Call this whenever a fallback activates.
    * If downstream systems aren't ready yet, the event is queued.
+   *
+   * Per spec §A33 (F-3), legacy `.report(...)` callers continue to work
+   * unchanged. Internally the event is normalized via `_normalize()` and
+   * either dispatched to the registered Remediator (if `setRemediator()`
+   * has been called) or sent through the legacy alert path (backward
+   * compat). RestartPending re-routes everything to the durable queue.
    */
   report(event: Omit<DegradationEvent, 'timestamp' | 'reported' | 'alerted'>): void {
     const full: DegradationEvent = {
@@ -187,8 +290,170 @@ export class DegradationReporter {
     this.events.push(full);
     this.persistToDisk(full);
 
-    // Try to report immediately if downstream is connected
+    // F-3 path: produce a NormalizedDegradationEvent and either dispatch
+    // it to the Remediator (if set) or queue it (if RestartPending).
+    const normalized = this._normalize(full);
+
+    if (this.restartPending) {
+      this.enqueueRestartPending(normalized);
+      return;
+    }
+
+    if (this.remediator) {
+      // Fire-and-forget — dispatch errors land in console.error but never
+      // crash the caller. The legacy `.report(...)` API is sync-shaped.
+      this.remediator.dispatch(normalized).catch((err) => {
+        console.error(
+          `[DEGRADATION] Remediator dispatch failed for ${full.feature}: ${err instanceof Error ? err.message : err}`
+        );
+      });
+      return;
+    }
+
+    // No Remediator wired — legacy alert path runs unchanged.
     this.reportEvent(full);
+  }
+
+  /**
+   * Report a structured degradation event (F-3 / §A33 go-forward API).
+   *
+   * Callers that have already produced a NormalizedDegradationEvent (e.g.,
+   * via the ErrorCodeExtractor with a verified probe emission) skip the
+   * legacy normalization step. The caller's provenance is preserved verbatim
+   * — F-3 does NOT downgrade structured callers to `free-text`.
+   *
+   * Behaviour:
+   * - Always logged with `[DEGRADATION-NORMALIZED]` prefix for grep-ability.
+   * - If RestartPending → queue to disk.
+   * - Else if Remediator wired → dispatch.
+   * - Else → no consumer (event is recorded but not alerted). Structured
+   *   callers must wire the Remediator (F-8) for it to route anywhere; this
+   *   is intentional, since structured callers bypass the legacy alert path.
+   */
+  reportStructured(event: NormalizedDegradationEvent): void {
+    const stamped: NormalizedDegradationEvent = {
+      ...event,
+      // Preserve caller-provided timestamp/monotonicTs if present; fill if not.
+      timestamp: event.timestamp || new Date().toISOString(),
+      monotonicTs: typeof event.monotonicTs === 'number'
+        ? event.monotonicTs
+        : monotonicNow(),
+    };
+
+    console.warn(
+      `[DEGRADATION-NORMALIZED] ${stamped.subsystem}: ${stamped.errorCode} (provenance=${stamped.provenance})`
+    );
+
+    if (this.restartPending) {
+      this.enqueueRestartPending(stamped);
+      return;
+    }
+
+    if (this.remediator) {
+      this.remediator.dispatch(stamped).catch((err) => {
+        console.error(
+          `[DEGRADATION] Remediator dispatch failed for ${stamped.subsystem}: ${err instanceof Error ? err.message : err}`
+        );
+      });
+    }
+  }
+
+  /**
+   * Register the Remediator dispatcher (F-8 wires the consumer). When set,
+   * incoming events route to `remediator.dispatch()` instead of the legacy
+   * alert path. Passing `null` clears the hook.
+   *
+   * F-3 only exposes the hook surface — there is no consumer in this PR.
+   */
+  setRemediator(remediator: RemediatorLike | null): void {
+    this.remediator = remediator;
+  }
+
+  /**
+   * Internal: convert a legacy `DegradationEvent` into the normalized form.
+   * Public for testability — F-8 / downstream consumers should never call
+   * this directly. Exposed as `_normalize` (leading underscore) per the
+   * project's "private-ish" convention.
+   *
+   * Mapping (per §A33):
+   *   feature   → subsystem
+   *   reason    → reason.full (and .redacted, via Redactor)
+   *   errorCode → extracted via ErrorCodeExtractor from free text → 'LEGACY_DEGRADATION' fallback
+   *   provenance → always 'free-text' (legacy callers are unstructured by definition)
+   *
+   * §A6 forbids matchers against `free-text` provenance — legacy events
+   * therefore route to `no-matching-runbook` once F-8 ships.
+   */
+  _normalize(legacy: DegradationEvent): NormalizedDegradationEvent {
+    const redactor = this.getRedactor();
+    const { text: redacted } = redactor.redact(legacy.reason);
+
+    // Attempt errorCode extraction from the legacy reason. Per §A33 the
+    // canonical fallback is the literal 'LEGACY_DEGRADATION' sentinel so
+    // downstream observability can count legacy emit-sites distinctly.
+    const extracted = ErrorCodeExtractor.extract({ freeText: legacy.reason });
+    const errorCode = extracted.code === 'UNKNOWN_ERROR'
+      ? 'LEGACY_DEGRADATION'
+      : extracted.code;
+
+    return {
+      subsystem: legacy.feature,
+      errorCode,
+      provenance: 'free-text',
+      reason: { redacted, full: legacy.reason },
+      timestamp: legacy.timestamp,
+      monotonicTs: monotonicNow(),
+      legacy,
+    };
+  }
+
+  /**
+   * Flip the RestartPending flag. When true, incoming events queue to disk
+   * (`<stateDir>/remediation/degradations-queue.jsonl`) instead of being
+   * dispatched. When flipped back to false, the queue replays through the
+   * normal dispatch path.
+   *
+   * Caller contract (per §A5): the lifeline supervisor asserts this flag
+   * during a staged restart window; flips it off once the restart has
+   * completed (or aborted). F-3 exposes the hook; F-8 wires the supervisor.
+   */
+  _setRestartPending(pending: boolean): void {
+    const prev = this.restartPending;
+    this.restartPending = pending;
+    if (prev && !pending) {
+      // Edge transition true→false: replay queued events.
+      this.replayRestartPendingQueue();
+    }
+  }
+
+  /**
+   * Read the durable RestartPending queue file. Public for testability /
+   * external observability. Returns an empty array if no queue file exists.
+   */
+  _readRestartPendingQueue(): NormalizedDegradationEvent[] {
+    const queuePath = this.restartQueuePath();
+    if (!queuePath || !fs.existsSync(queuePath)) return [];
+    try {
+      const raw = fs.readFileSync(queuePath, 'utf-8');
+      return raw
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => {
+          try { return JSON.parse(line) as NormalizedDegradationEvent; }
+          catch { return null; }
+        })
+        .filter((x): x is NormalizedDegradationEvent => x !== null);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * How many events were dropped during a RestartPending window because the
+   * queue hit its cap. Persists across the queue's lifetime.
+   */
+  _getQueueDropCount(): number {
+    return this.queueDropCount;
   }
 
   /**
@@ -418,6 +683,124 @@ export class DegradationReporter {
         this.reportEvent(event);
       }
     }
+  }
+
+  /** Lazily construct the shared Redactor used by `_normalize`. */
+  private getRedactor(): Redactor {
+    if (!this.redactor) this.redactor = new Redactor();
+    return this.redactor;
+  }
+
+  /**
+   * Absolute path to the RestartPending queue JSONL file. Returns null if
+   * no stateDir is configured — in that case events are dropped (and counted
+   * via `queueDropCount`) since there's nowhere durable to persist them.
+   */
+  private restartQueuePath(): string | null {
+    if (!this.stateDir) return null;
+    return path.join(this.stateDir, RESTART_QUEUE_REL_PATH);
+  }
+
+  /**
+   * Append a normalized event to the durable RestartPending queue. Enforces
+   * the §A5 cap (1000 entries / 5 MiB) via drop-and-counter.
+   */
+  private enqueueRestartPending(event: NormalizedDegradationEvent): void {
+    const queuePath = this.restartQueuePath();
+    if (!queuePath) {
+      // No stateDir → no durable surface → count as dropped so callers can
+      // observe the loss via _getQueueDropCount.
+      this.queueDropCount += 1;
+      return;
+    }
+
+    try {
+      const dir = path.dirname(queuePath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+
+      // Check current size + entry count for the cap.
+      let entryCount = 0;
+      let byteSize = 0;
+      try {
+        const stat = fs.statSync(queuePath);
+        byteSize = stat.size;
+        const raw = fs.readFileSync(queuePath, 'utf-8');
+        entryCount = raw.split('\n').filter(Boolean).length;
+      } catch { /* first write */ }
+
+      const line = JSON.stringify(event) + '\n';
+      if (entryCount >= RESTART_QUEUE_MAX_ENTRIES || byteSize + line.length > RESTART_QUEUE_MAX_BYTES) {
+        this.queueDropCount += 1;
+        // Sidecar drop-count file so it survives across processes.
+        try {
+          fs.writeFileSync(
+            queuePath + '.drops.json',
+            JSON.stringify({ dropped: this.queueDropCount, ts: new Date().toISOString() }, null, 2)
+          );
+        } catch { /* best-effort */ }
+        return;
+      }
+
+      fs.appendFileSync(queuePath, line);
+    } catch (err) {
+      // Disk failure inside the durable queue is itself a degradation. Log it
+      // and bump the drop counter — the legacy alert path is unavailable
+      // during RestartPending so there's nothing else to do.
+      console.error(
+        `[DEGRADATION] RestartPending enqueue failed: ${err instanceof Error ? err.message : err}`
+      );
+      this.queueDropCount += 1;
+    }
+  }
+
+  /**
+   * Replay the durable queue once `_setRestartPending(false)` fires. Each
+   * event is dispatched (or sent through the legacy alert path) in the order
+   * it was enqueued; the queue file is then removed on success.
+   *
+   * Replay is best-effort — if dispatch throws, the queue file is kept on
+   * disk so the next replay attempt can retry. Per §A30 the higher-layer
+   * Remediator dispatcher owns the 5s wall-time cap and coalescing; F-3
+   * does not impose its own.
+   */
+  private replayRestartPendingQueue(): void {
+    const queuePath = this.restartQueuePath();
+    if (!queuePath || !fs.existsSync(queuePath)) return;
+
+    const queued = this._readRestartPendingQueue();
+    if (queued.length === 0) {
+      // Empty / unreadable — clean up the file.
+      try {
+        SafeFsExecutor.safeUnlinkSync(queuePath, {
+          operation: 'DegradationReporter.replayRestartPendingQueue: empty queue cleanup',
+        });
+      } catch { /* ignore */ }
+      return;
+    }
+
+    for (const event of queued) {
+      if (this.remediator) {
+        // Fire-and-forget; replay does not wait for individual dispatches.
+        this.remediator.dispatch(event).catch((err) => {
+          console.error(
+            `[DEGRADATION] Replay dispatch failed for ${event.subsystem}: ${err instanceof Error ? err.message : err}`
+          );
+        });
+      } else if (event.legacy) {
+        // Fall back to the legacy alert path for legacy-shaped queued events.
+        this.reportEvent(event.legacy);
+      }
+    }
+
+    // Truncate the queue file. We don't delete the drop-count sidecar — it
+    // records cumulative drops across restart windows.
+    try {
+      SafeFsExecutor.safeUnlinkSync(queuePath, {
+        operation: 'DegradationReporter.replayRestartPendingQueue: drain queue after replay',
+      });
+    } catch { /* ignore */ }
   }
 
   private persistToDisk(event: DegradationEvent): void {

--- a/tests/unit/degradation-reporter.test.ts
+++ b/tests/unit/degradation-reporter.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { DegradationReporter } from '../../src/monitoring/DegradationReporter.js';
+import { DegradationReporter, type NormalizedDegradationEvent } from '../../src/monitoring/DegradationReporter.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 describe('DegradationReporter', () => {
@@ -198,6 +198,303 @@ describe('DegradationReporter', () => {
     expect(reporter.getEvents()[0].reported).toBe(false);
 
     vi.restoreAllMocks();
+  });
+
+  // ── F-3 (NormalizedDegradationEvent shim, §A33 / §A50) ───────────
+
+  describe('F-3 normalization shim', () => {
+    it('legacy .report() produces a normalized event with provenance: free-text', () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // No remediator wired → legacy alert path runs unchanged (test 4
+      // covers backward compat). Here we only assert the _normalize output.
+      reporter.report({
+        feature: 'PaymentSubsystem',
+        primary: 'Real provider',
+        fallback: 'Cache',
+        reason: 'gateway timeout',
+        impact: 'slow checkout',
+      });
+
+      const legacy = reporter.getEvents()[0];
+      const normalized = reporter._normalize(legacy);
+
+      expect(normalized.subsystem).toBe('PaymentSubsystem');
+      expect(normalized.provenance).toBe('free-text');
+      expect(normalized.errorCode).toBe('LEGACY_DEGRADATION');
+      expect(normalized.reason.full).toBe('gateway timeout');
+      expect(normalized.reason.redacted).toBeDefined();
+      expect(typeof normalized.monotonicTs).toBe('number');
+      expect(normalized.legacy).toBeDefined();
+      expect(normalized.legacy?.feature).toBe('PaymentSubsystem');
+
+      vi.restoreAllMocks();
+    });
+
+    it('reportStructured() preserves caller-provided provenance', async () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const dispatched: NormalizedDegradationEvent[] = [];
+      reporter.setRemediator({
+        dispatch: async (e) => { dispatched.push(e); },
+      });
+
+      reporter.reportStructured({
+        subsystem: 'lifeline',
+        errorCode: 'SUPERVISOR_PROCESS_GONE',
+        provenance: 'probe-id',
+        reason: { redacted: 'pid 1234 missing', full: 'pid 1234 missing' },
+        timestamp: '2026-05-13T00:00:00.000Z',
+        monotonicTs: 12345,
+      });
+
+      await vi.waitFor(() => {
+        expect(dispatched).toHaveLength(1);
+      }, { timeout: 1000, interval: 10 });
+
+      expect(dispatched[0].provenance).toBe('probe-id');
+      expect(dispatched[0].errorCode).toBe('SUPERVISOR_PROCESS_GONE');
+      expect(dispatched[0].subsystem).toBe('lifeline');
+
+      vi.restoreAllMocks();
+    });
+
+    it('setRemediator(r) causes legacy events to flow to r.dispatch()', async () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const feedbackSubmitter = vi.fn().mockResolvedValue({});
+      const telegramSender = vi.fn().mockResolvedValue({});
+      reporter.connectDownstream({ feedbackSubmitter, telegramSender, alertTopicId: 99 });
+
+      const dispatched: NormalizedDegradationEvent[] = [];
+      reporter.setRemediator({
+        dispatch: async (e) => { dispatched.push(e); },
+      });
+
+      reporter.report({
+        feature: 'TopicMemory',
+        primary: 'SQLite',
+        fallback: 'JSONL',
+        reason: 'better-sqlite3 failed',
+        impact: 'no summaries',
+      });
+
+      await vi.waitFor(() => {
+        expect(dispatched).toHaveLength(1);
+      }, { timeout: 1000, interval: 10 });
+
+      // Legacy alert path MUST NOT have run.
+      expect(feedbackSubmitter).not.toHaveBeenCalled();
+      expect(telegramSender).not.toHaveBeenCalled();
+
+      expect(dispatched[0].subsystem).toBe('TopicMemory');
+      expect(dispatched[0].provenance).toBe('free-text');
+
+      vi.restoreAllMocks();
+    });
+
+    it('with no remediator set, legacy alert path runs unchanged (backward compat)', async () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // NO setRemediator() call — this is the backward-compat path.
+      const feedbackSubmitter = vi.fn().mockResolvedValue({});
+      const telegramSender = vi.fn().mockResolvedValue({});
+      reporter.connectDownstream({ feedbackSubmitter, telegramSender, alertTopicId: 7 });
+
+      reporter.report({
+        feature: 'BackwardCompat',
+        primary: 'P', fallback: 'F',
+        reason: 'r', impact: 'i',
+      });
+
+      // Legacy alert path should fire.
+      await vi.waitFor(() => {
+        expect(feedbackSubmitter).toHaveBeenCalledTimes(1);
+        expect(telegramSender).toHaveBeenCalledTimes(1);
+      }, { timeout: 2000, interval: 20 });
+
+      vi.restoreAllMocks();
+    });
+
+    it('_setRestartPending(true) queues events to a durable file', () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      reporter.setRemediator({ dispatch: async () => {} });
+      reporter._setRestartPending(true);
+
+      reporter.report({
+        feature: 'A', primary: 'P', fallback: 'F',
+        reason: 'r1', impact: 'i',
+      });
+      reporter.report({
+        feature: 'B', primary: 'P', fallback: 'F',
+        reason: 'r2', impact: 'i',
+      });
+
+      const queuePath = path.join(tmpDir, 'remediation', 'degradations-queue.jsonl');
+      expect(fs.existsSync(queuePath)).toBe(true);
+
+      const queued = reporter._readRestartPendingQueue();
+      expect(queued).toHaveLength(2);
+      expect(queued[0].subsystem).toBe('A');
+      expect(queued[1].subsystem).toBe('B');
+
+      vi.restoreAllMocks();
+    });
+
+    it('_setRestartPending(false) replays queued events', async () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const dispatched: NormalizedDegradationEvent[] = [];
+      reporter.setRemediator({
+        dispatch: async (e) => { dispatched.push(e); },
+      });
+      reporter._setRestartPending(true);
+
+      reporter.report({
+        feature: 'Queued1', primary: 'P', fallback: 'F',
+        reason: 'r', impact: 'i',
+      });
+      reporter.report({
+        feature: 'Queued2', primary: 'P', fallback: 'F',
+        reason: 'r', impact: 'i',
+      });
+
+      expect(dispatched).toHaveLength(0); // No dispatch during RestartPending
+
+      reporter._setRestartPending(false);
+
+      await vi.waitFor(() => {
+        expect(dispatched).toHaveLength(2);
+      }, { timeout: 1000, interval: 10 });
+
+      expect(dispatched[0].subsystem).toBe('Queued1');
+      expect(dispatched[1].subsystem).toBe('Queued2');
+
+      // Queue file is cleaned up after successful replay.
+      const queuePath = path.join(tmpDir, 'remediation', 'degradations-queue.jsonl');
+      expect(fs.existsSync(queuePath)).toBe(false);
+
+      vi.restoreAllMocks();
+    });
+
+    it('queue cap (1000 entries) trips drop-and-counter', () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      reporter.setRemediator({ dispatch: async () => {} });
+
+      // Pre-seed the queue with 1000 entries to hit the cap without
+      // hammering the test with 1001 .report() calls (which would also
+      // trip console-warn rate limits).
+      const queueDir = path.join(tmpDir, 'remediation');
+      fs.mkdirSync(queueDir, { recursive: true });
+      const queuePath = path.join(queueDir, 'degradations-queue.jsonl');
+      const filler = JSON.stringify({
+        subsystem: 'filler', errorCode: 'X', provenance: 'free-text',
+        reason: { redacted: 'x', full: 'x' },
+        timestamp: '2026-01-01T00:00:00.000Z', monotonicTs: 0,
+      }) + '\n';
+      fs.writeFileSync(queuePath, filler.repeat(1000));
+
+      reporter._setRestartPending(true);
+
+      const beforeDrops = reporter._getQueueDropCount();
+      reporter.report({
+        feature: 'OverflowEvent', primary: 'P', fallback: 'F',
+        reason: 'should be dropped', impact: 'i',
+      });
+
+      expect(reporter._getQueueDropCount()).toBe(beforeDrops + 1);
+
+      // Sidecar drop-count file is written for cross-process visibility.
+      const dropsSidecar = queuePath + '.drops.json';
+      expect(fs.existsSync(dropsSidecar)).toBe(true);
+      const drops = JSON.parse(fs.readFileSync(dropsSidecar, 'utf-8'));
+      expect(drops.dropped).toBeGreaterThan(0);
+
+      vi.restoreAllMocks();
+    });
+
+    it('redaction in _normalize strips secrets from reason', () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      reporter.report({
+        feature: 'AuthSubsystem',
+        primary: 'P', fallback: 'F',
+        reason: 'failed with token Bearer abcdef1234567890abcdef1234567890abcdef at /Users/justin/.instar/config.json',
+        impact: 'i',
+      });
+
+      const legacy = reporter.getEvents()[0];
+      const normalized = reporter._normalize(legacy);
+
+      // Original full text retained.
+      expect(normalized.reason.full).toContain('Bearer abcdef');
+      expect(normalized.reason.full).toContain('/Users/justin');
+      // Redacted form has the secrets stripped.
+      expect(normalized.reason.redacted).not.toContain('abcdef1234567890');
+      expect(normalized.reason.redacted).toContain('<REDACTED>');
+      expect(normalized.reason.redacted).toContain('<HOME>');
+
+      vi.restoreAllMocks();
+    });
+
+    it('errorCode extraction from legacy feature/reason works', () => {
+      const reporter = DegradationReporter.getInstance();
+      reporter.configure({ stateDir: tmpDir, agentName: 'test-agent', instarVersion: '0.9.17' });
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // ABI-mismatch flavored reason text.
+      reporter.report({
+        feature: 'better-sqlite3-loader',
+        primary: 'native',
+        fallback: 'JSONL',
+        reason: 'NODE_MODULE_VERSION 127 mismatch detected',
+        impact: 'no summaries',
+      });
+      const abiNorm = reporter._normalize(reporter.getEvents()[0]);
+      expect(abiNorm.errorCode).toBe('NATIVE_MODULE_ABI_MISMATCH');
+      expect(abiNorm.provenance).toBe('free-text');
+
+      // SQLite-error flavored reason text.
+      reporter.report({
+        feature: 'sqlite-writer',
+        primary: 'SQLite',
+        fallback: 'memory',
+        reason: 'SQLITE_CORRUPT: database disk image is malformed',
+        impact: 'data loss',
+      });
+      const sqliteNorm = reporter._normalize(reporter.getEvents()[1]);
+      expect(sqliteNorm.errorCode).toBe('SQLITE_CORRUPT');
+
+      // Unknown reason — falls back to LEGACY_DEGRADATION sentinel.
+      reporter.report({
+        feature: 'mystery',
+        primary: 'P', fallback: 'F',
+        reason: 'something happened that was not parseable',
+        impact: 'i',
+      });
+      const mysteryNorm = reporter._normalize(reporter.getEvents()[2]);
+      expect(mysteryNorm.errorCode).toBe('LEGACY_DEGRADATION');
+
+      vi.restoreAllMocks();
+    });
   });
 
   it('works without stateDir configured (no disk persistence)', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -41,6 +41,22 @@ Driven by Telegram topic 9003 on 2026-05-13: "By default Instar should only run 
 - Per amendments A20, A23, A39, A42, A51, A54, A58, A62 of `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md`.
 - **No runtime consumers yet.** F-2+ wires capability tokens, probe authentication, in-flight lockfiles, the cross-process attempt ledger, and the audit-token writer onto the leaf-key surface.
 
+### feat(monitoring): F-3 — DegradationReporter normalization shim (Self-Healing Remediator v2 foundation)
+
+Adds the F-3 milestone of the Self-Healing Remediator v2 foundation (per `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A5, §A33, §A50). `DegradationReporter` gains a back-compat shim that converts legacy `DegradationEvent` quintuples into a new `NormalizedDegradationEvent` (`{subsystem, errorCode, provenance, reason: {redacted, full}, timestamp, monotonicTs}`) using the F-2 `Redactor` and `ErrorCodeExtractor`. All ~103 legacy `.report(...)` emit sites continue to work unchanged; they normalize to `provenance: 'free-text'` and (per §A6) cannot match any runbook prefilter — they will route to `no-matching-runbook` once F-8 ships the Remediator dispatcher.
+
+New surface on the reporter:
+- `reportStructured(event)` — go-forward emit API for callers that already have a NormalizedDegradationEvent.
+- `setRemediator(remediator)` — registration hook for the F-8 dispatcher (no consumer wired in this PR).
+- `_normalize(legacy)` — pure transform exposed for testability.
+- `_setRestartPending(true|false)` — supervisor-controlled flag that re-routes events to a durable JSONL queue at `<stateDir>/remediation/degradations-queue.jsonl` (1000 entries / 5 MiB cap, drop-and-counter on overflow per §A5).
+
+New `scripts/lint-degradation-emit-sites.js` — warning-only catalogue of legacy vs structured emit sites. Exits 0 always; F-8 may upgrade to blocking once a deprecation timeline is agreed.
+
+9 new unit tests appended to `tests/unit/degradation-reporter.test.ts` covering normalization, structured-emit provenance preservation, Remediator routing, backward compat, RestartPending enqueue/replay, queue-cap drop-counter, secret redaction, and errorCode extraction.
+
+Side-effects review: `upgrades/side-effects/f3-degradation-reporter-shim.md`.
+
 ### feat(monitoring): F-2 — Redactor + ErrorCodeExtractor (Self-Healing Remediator v2 foundation)
 
 Adds two foundation modules from the Self-Healing Remediator v2 spec (§A1 manifest, F-2): `src/monitoring/Redactor.ts` and `src/monitoring/ErrorCodeExtractor.ts`. The Redactor centralizes content sanitization (home-directory paths, bearer tokens, Telegram bot tokens, emails, UUIDs, long hex strings, IPv4/IPv6, and ≥6-digit numeric IDs). The ErrorCodeExtractor enforces the §A6 errorCode-provenance contract: returns `{code, provenance}` where provenance is `native-binding | probe-id | subsystem-explicit | free-text`, following a priority ladder. A static `isAllowedForRunbookMatch` predicate gives the runbook registry validator a single call to refuse matchers that would consume free-text-provenance events — the §A6 structural defense against attacker-shaped error-text. Neither module has any consumer in this PR; F-3 (DegradationReporter migration) and the W-* runbook wrappers wire them up in follow-up PRs. 46 new unit tests across `tests/unit/Redactor.test.ts` (25) and `tests/unit/ErrorCodeExtractor.test.ts` (21).
@@ -97,6 +113,11 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 - **Template for ELI16 overviews** at `skills/instar-dev/templates/eli16-overview.md`.
 - **Forward-only enforcement** — only specs newly committed-against after this ships have to satisfy the gate.
 - **`selectIntelligenceProvider()`** — single chokepoint enforcing subscription-by-default for the shared LLM provider; refuses silent API fallback; requires two explicit flags for API opt-in; prints a billing banner when API mode is active.
+- **NormalizedDegradationEvent contract** (F-3) — `{subsystem, errorCode, provenance, reason: {redacted, full}, timestamp, monotonicTs}` — the go-forward event shape; F-3 ships the additive type plus the legacy → normalized shim.
+- **`DegradationReporter.reportStructured(event)`** (F-3) — go-forward emit API for callers that already produced a NormalizedDegradationEvent.
+- **`DegradationReporter.setRemediator(remediator)`** (F-3) — registration hook for the F-8 dispatcher; no consumer wired in this PR.
+- **Durable RestartPending queue** (F-3) — `<stateDir>/remediation/degradations-queue.jsonl`, 1000 entries / 5 MiB cap, drop-and-counter on overflow (per spec §A5).
+- **`scripts/lint-degradation-emit-sites.js`** (F-3) — warning-only catalogue of legacy vs structured emit sites; exits 0 always.
 - **Centralized content redaction** (F-2) — `new Redactor().redact(text)` / `.redactFields(obj, fields)` — wired into DegradationReporter in F-3.
 - **Structured errorCode extraction with provenance** (F-2) — `ErrorCodeExtractor.extract({ nativeError, probeEmission, subsystemExplicit, freeText, verifyProbeSignature })`.
 - **Runbook-match provenance gate** (F-2) — `ErrorCodeExtractor.isAllowedForRunbookMatch(extracted)` — refuses free-text-provenance matchers.

--- a/upgrades/side-effects/f3-degradation-reporter-shim.md
+++ b/upgrades/side-effects/f3-degradation-reporter-shim.md
@@ -1,0 +1,105 @@
+# Side-Effects Review — F-3: DegradationReporter normalization shim
+
+**Version / slug:** `f3-degradation-reporter-shim`
+**Date:** `2026-05-13`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Ships the F-3 milestone of the Self-Healing Remediator v2 foundation (per `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A5, §A33, §A50): an **additive, back-compat shim** on `DegradationReporter` that introduces the `NormalizedDegradationEvent` contract, a `reportStructured()` go-forward emit API, a `setRemediator()` hook for the future F-8 dispatcher, and a durable `RestartPending` queue at `<stateDir>/remediation/degradations-queue.jsonl` (1000 entries / 5 MiB cap, drop-and-counter on overflow). All ~103 existing legacy `.report(...)` callers continue to work unchanged; they are normalized internally to `provenance: 'free-text'` and (per §A6) cannot match any runbook prefilter — they will route to `no-matching-runbook` once F-8 ships.
+
+A new warning-only lint at `scripts/lint-degradation-emit-sites.js` catalogues every emit site (legacy vs structured) without blocking. F-8 may upgrade it to blocking once a deprecation timeline is agreed.
+
+Files touched:
+- `src/monitoring/DegradationReporter.ts` (modify — adds `NormalizedDegradationEvent`, `RemediatorLike`, `reportStructured()`, `setRemediator()`, `_normalize()`, `_setRestartPending()`, `_readRestartPendingQueue()`, `_getQueueDropCount()`, plus durable-queue plumbing)
+- `scripts/lint-degradation-emit-sites.js` (new — warning-only)
+- `tests/unit/degradation-reporter.test.ts` (extend — 9 new tests for the F-3 shim)
+- `upgrades/NEXT.md` (append F-3 entry)
+
+## Decision-point inventory
+
+- `DegradationReporter.report` — **modify** — legacy entry point. New behaviour: routes to Remediator (if wired) OR to RestartPending queue (if flag set) OR to legacy alert path (default). Backward-compat: when no Remediator and no RestartPending, behaviour is byte-identical to pre-F-3.
+- `DegradationReporter.reportStructured` — **add** — new emit API for go-forward callers. No legacy alert path — structured callers MUST wire a Remediator (F-8) or their events are recorded-only.
+- `DegradationReporter.setRemediator` — **add** — registration hook for the F-8 dispatcher. No consumer wired in this PR.
+- `DegradationReporter._setRestartPending` — **add** — supervisor-controlled flag that re-routes events to the durable queue. The flag itself is the authority; no brittle inference logic.
+- `DegradationReporter._normalize` — **add** — pure transform from legacy → normalized. Always tags `provenance: 'free-text'`. §A6 already forbids matchers against free-text-provenance events; no new authority is added by the normalization.
+- `scripts/lint-degradation-emit-sites.js` — **add** — warning-only catalogue. Exits 0 always.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- The change has no block/allow surface on the emit path itself — legacy `.report()` still always succeeds in recording an event. The only "rejection" is the queue cap: events emitted during RestartPending past entry 1000 or byte 5 MiB are silently dropped and counted. That's per spec §A5 (drop-and-counter on overflow) and is by design: the alternative (unbounded queue growth during a long restart-pending window) is worse. Operators see the loss via `_getQueueDropCount()` and the sidecar file `degradations-queue.jsonl.drops.json`.
+- `reportStructured()` does NOT fall through to the legacy alert path. Structured callers without a wired Remediator will see their events recorded but not alerted. This is intentional per §A33: legacy alert side-channel is for legacy callers; structured callers belong to the Remediator path.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- Legacy callers continue to land at `no-matching-runbook` because their provenance is `free-text` — per §A6 this is the intended steady state, not a gap. The under-block here is exactly what NovelFailureReviewer (A26 — not in this PR) is designed to consume: cluster the unmatched events and propose new runbooks.
+- The `_normalize` errorCode extraction inherits the F-2 free-text regex set. Novel error-text shapes return `LEGACY_DEGRADATION` rather than a more specific code; NovelFailureReviewer (later PR) is the smart layer that proposes new runbooks for those.
+- RestartPending replay does NOT enforce the §A30 5-second wall-time cap or coalescing logic — that authority belongs to the F-8 Remediator dispatcher, which sees the replayed events one by one. F-3 only provides the durable surface.
+- The queue file is per-machine and not synced. If a machine restart-pending-windows and the agent's state-dir is on a different machine after rebalancing, the queue is lost. Acceptable: RestartPending is a process-lifetime concept tied to the lifeline supervisor that owns the file.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+`DegradationReporter` is the right layer for the shim. It's the single emit point for every degradation in the codebase; placing the normalize/dispatch wiring elsewhere would require touching all ~103 emit sites today instead of zero. The shim preserves the legacy emit API exactly and lets the migration be incremental — which is the precise intent of §A33 / §A50.
+
+The RestartPending queue lives inside `DegradationReporter` rather than a separate `RestartPendingQueue` module because (a) only this reporter feeds it, (b) the durability story is local to the reporter's stateDir, and (c) F-8 will own the higher-layer replay scheduler. Pulling it out to its own module now would over-fit; pulling it out later if F-8 needs cross-reporter queue management is a refactor with no behaviour change.
+
+The lint is at the right layer (a repo-level grep), produces a single warning-only signal, and explicitly defers authority to F-8 — that matches signal-vs-authority.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface.
+
+The shim is a routing change, not a decision point. `_normalize()` is a pure transform. `setRemediator()` is a registration hook. `_setRestartPending()` is set by the lifeline supervisor (the higher-layer authority), not inferred by the reporter. The lint script is warning-only and exits 0 always. The §A6 free-text provenance contract IS an authority — refusing runbook matchers — but that authority lives in the runbook registry validator (F-8), not here. F-3 only stamps the provenance; F-8's smart gate enforces the refusal.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** The existing legacy alert path (`reportEvent`) still runs when no Remediator is wired. When a Remediator IS wired, the legacy alert path is BYPASSED for new events — that's the point of A33's "the legacy Telegram-alert path fires only on `no-matching-runbook`." F-3 wires the bypass; F-8 wires the round-trip back to `no-matching-runbook → legacy alert`.
+- **Self-heal interaction:** The existing `registerHealer` / `attemptSelfHeal` flow runs inside `reportEvent`. When a Remediator IS wired, healers are NOT invoked — the Remediator is expected to own the heal-or-alert decision. This is acceptable for the F-3 PR because no Remediator is wired today; healers continue to run on every emit. F-8's design must explicitly cover healer composition with runbooks (it does — A50 places healer-vs-runbook precedence on the Remediator side).
+- **Persistence:** The legacy `degradations.json` file continues to receive every event for the health-check API. The new queue file (`remediation/degradations-queue.jsonl`) is independent — events under RestartPending are recorded in both. No double-dispatch risk: queued events flow through replay → dispatch, never through the legacy alert path twice.
+- **Drop-counter sidecar:** `degradations-queue.jsonl.drops.json` is the only new file outside the reporter's `degradations.json`. Backup/sync rules (per A35): the queue lives under `.instar/remediation/` which F-7 will add to `BackupManager`'s exclusion list (per-machine). No backup-sync changes ship in this PR.
+
+---
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents, other users, other systems?**
+
+- **Behavioural surface:** Zero change for current users. No Remediator is wired in F-3, so every legacy `.report()` call follows the same code path it did pre-F-3. No new files exist on disk until F-8 sets RestartPending, which it cannot yet.
+- **Type surface:** `NormalizedDegradationEvent` and `RemediatorLike` are exported from `src/monitoring/DegradationReporter.ts`. They are additive — existing consumers' imports remain valid. The exported `DegradationEvent` shape is unchanged.
+- **CLI / config / endpoint surface:** None changed.
+- **Tests:** 9 new unit tests under the existing file. No changes to existing tests.
+- **Lint behaviour:** The new lint script is not wired into any existing gate (pre-commit / pre-push / CI). It is a documented manual command per §A33: `node scripts/lint-degradation-emit-sites.js`. Adding it to CI is explicitly deferred to F-8.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+- **Revert path:** This is a single-PR shim with no consumer (no Remediator wired anywhere). A `git revert <merge-commit>` followed by a patch release rolls back the entire change with no data migration. The `degradations.json` file (legacy) is untouched.
+- **Stuck-state risk:** If F-8 ships partial Remediator wiring and is reverted, any events accumulated in `<stateDir>/remediation/degradations-queue.jsonl` during a RestartPending window would be orphaned. Mitigation: F-3 has no way to set RestartPending (no caller wires it), so the queue file cannot be populated until F-8 ships. F-8's own rollback story must include a queue-drain step.
+- **Compat risk for downstream consumers:** Code outside this PR that imports `DegradationEvent` continues to compile unchanged. Code that imports the new `NormalizedDegradationEvent` would need to bridge to the legacy type — but no such code exists in this PR or on main today.
+- **Worst-case incident:** A bug in `_normalize` could break the legacy `.report()` path. The integration test for "with no remediator set, legacy alert path runs unchanged" catches the obvious regression; a more exotic bug (e.g. Redactor crash) would be caught by the existing legacy tests because `_normalize` is invoked in every `.report()` call. If it slipped through, the back-out is a one-line revert in the `report()` method to skip the normalize-and-route block.


### PR DESCRIPTION
## Summary

Adds the Tier-1 foundation F-3 milestone for the Self-Healing Remediator v2 (per `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A5 / §A33 / §A50).

- **Back-compat shim** on `DegradationReporter` that normalizes legacy `DegradationEvent` quintuples into the new `NormalizedDegradationEvent` shape (`{subsystem, errorCode, provenance, reason: {redacted, full}, timestamp, monotonicTs}`) via the F-2 `Redactor` + `ErrorCodeExtractor`. All ~103 existing `.report(...)` emit sites continue to work unchanged — they normalize with `provenance: 'free-text'` and (per §A6) route to `no-matching-runbook` once F-8 ships.
- **New surface:** `reportStructured()` go-forward emit API, `setRemediator(remediator)` hook for the future F-8 dispatcher (no consumer wired in this PR), `_normalize()` pure transform, `_setRestartPending(bool)` supervisor-controlled flag.
- **Durable RestartPending queue** at `<stateDir>/remediation/degradations-queue.jsonl` (1000 entries / 5 MiB cap, drop-and-counter on overflow per §A5).
- **Warning-only lint** `scripts/lint-degradation-emit-sites.js` cataloguing legacy vs structured emit sites. Exits 0 always.
- **9 new unit tests** appended to `tests/unit/degradation-reporter.test.ts`.

Side-effects review: `upgrades/side-effects/f3-degradation-reporter-shim.md`.

## Test plan

- [x] 17 tests in `tests/unit/degradation-reporter.test.ts` pass (8 existing + 9 new).
- [x] Related test files (`degradation-reporter-self-heal`, `degradation-reporter-mark-reported`, `routes-degradations-mark-reported`, `Redactor`, `ErrorCodeExtractor`) — 81/81 passing.
- [x] `npm run lint` (tsc + lint-no-direct-destructive) — clean.
- [x] `node scripts/lint-degradation-emit-sites.js` — reports 103 legacy + 0 structured emit sites, exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)