### PR TITLE
feat(remediation): F-8 — Remediator orchestrator skeleton (Tier-1)

### DIFF
--- a/src/remediation/Remediator.ts
+++ b/src/remediation/Remediator.ts
@@ -1,0 +1,509 @@
+/**
+ * Remediator — Tier-1 orchestrator skeleton for the Self-Healing Remediator v2.
+ *
+ * SELF-HEALING-REMEDIATOR-V2-SPEC §A1 (F-8), §A2 (lock-bound co-existence),
+ * §A3 (RemediationContext as capability token), §A4 (deadline enforcement),
+ * §A6 (errorCode provenance — free-text rejected at registry-load),
+ * §A21 (verify-failed strict typing — distinct from verify-inconclusive),
+ * §A36 (essential-runbook validator), §A57 (Tier-1 subset).
+ *
+ * Scope of this PR (Tier-1 subset per A57):
+ *   - Match incoming `NormalizedDegradationEvent` against registered runbooks
+ *     using `eventPrefilter` (errorCode + provenance) and `match()`.
+ *   - Acquire in-flight `MachineLock` keyed by `tupleHash = sha256(runbookId +
+ *     signatureHash)`. Detect existing in-flight lock with same tuple →
+ *     `covered-by-inline`.
+ *   - Issue a `RemediationContext` carrying:
+ *       - attemptId (uuid),
+ *       - runbookId,
+ *       - lockHandle (from MachineLock),
+ *       - auditToken (leaf key from RemediationKeyVault, audit context),
+ *       - abortSignal wired to deadline via AbortController,
+ *       - expiresAt + monotonicDeadline.
+ *   - Declare intent via IntentJournal.
+ *   - Audit-append `started` + final outcome via AuditWriter.
+ *   - Enforce `expectedRuntimeMs` deadline. surfaceCallable that hangs past the
+ *     deadline trips the AbortController and yields `aborted-deadline`.
+ *   - On surfaceCallable success → call `runbook.verify(ctx)` and audit the
+ *     result with the verified taxonomy (A21).
+ *   - On surfaceCallable failure → audit `verify-failed` without calling
+ *     `verify()` (a failed surface cannot return a healthy outcome).
+ *
+ * Explicitly OUT of scope (Tier-2 per A57):
+ *   - Trust elevation source.
+ *   - Probe authentication.
+ *   - Capability token HMAC enforcement on the surface side.
+ *   - Supervisor handshake.
+ *   - Runbook registry validation against a signed manifest.
+ *
+ * Audit-token issuance per call uses `RemediationKeyVault.deriveLeafKey('audit',
+ * null)` (the audit context shares one machine-wide leaf per §A20). The actual
+ * verification of that token happens inside `AuditWriter.append()`'s injected
+ * `tokenVerifier` — the writer is the authority, the dispatcher merely issues.
+ */
+
+import crypto from 'node:crypto';
+import type { NormalizedDegradationEvent } from '../monitoring/DegradationReporter.js';
+import type { ErrorProvenance } from '../monitoring/ErrorCodeExtractor.js';
+import type { RemediationKeyVault } from './RemediationKeyVault.js';
+import type { MachineLock, InFlightHandle } from './MachineLock.js';
+import type { IntentJournal } from './IntentJournal.js';
+import type {
+  AuditWriter,
+  AuditOutcome,
+  AuditEntry,
+} from './audit/AuditWriter.js';
+
+// ── Public types ─────────────────────────────────────────────────────────
+
+export type BlastRadius = 'process' | 'machine' | 'fleet';
+export type Reversibility = 'reversible' | 'irreversible';
+
+export interface RemediationContext {
+  attemptId: string;
+  runbookId: string;
+  lockHandle: InFlightHandle;
+  auditToken: Buffer;
+  abortSignal: AbortSignal;
+  /** Wall-clock expiry (informational; the monotonic deadline is authoritative). */
+  expiresAt: number;
+  /** `process.hrtime.bigint()` at issuance + expectedRuntimeMs converted to ns. */
+  monotonicDeadline: bigint;
+}
+
+export interface ExecutionResult {
+  outcome: 'success' | 'failure';
+  details: Record<string, unknown>;
+}
+
+export interface VerifyOutcome {
+  outcome: 'verified-healthy' | 'verify-failed' | 'verify-inconclusive';
+  reason: string;
+}
+
+export interface ApprovedRunbook {
+  id: string;
+  priority: number;
+  surface: string;
+  /**
+   * §A6: provenance MUST NOT include `'free-text'`. Validator at
+   * registerRunbook() refuses such matchers.
+   */
+  eventPrefilter: {
+    errorCode: string[];
+    provenance: ErrorProvenance[];
+  };
+  match: (event: NormalizedDegradationEvent) => boolean;
+  preconditions: (event: NormalizedDegradationEvent) => Promise<boolean>;
+  surfaceCallable: (ctx: RemediationContext) => Promise<ExecutionResult>;
+  verify: (ctx: RemediationContext) => Promise<VerifyOutcome>;
+  blastRadius: BlastRadius;
+  reversibility: Reversibility;
+  expectedRuntimeMs: number;
+  /** §A36: only valid when blastRadius === 'machine'. */
+  essential?: boolean;
+}
+
+export type DispatchOutcome =
+  | { outcome: 'no-matching-runbook' }
+  | { outcome: 'covered-by-inline'; existingAttemptId: string }
+  | { outcome: 'verified-healthy'; attemptId: string }
+  | { outcome: 'verify-failed'; attemptId: string }
+  | { outcome: 'verify-inconclusive'; attemptId: string }
+  | { outcome: 'aborted-deadline'; attemptId: string };
+
+export interface RemediatorOptions {
+  stateDir: string;
+  keyVault: RemediationKeyVault;
+  machineLock: MachineLock;
+  intentJournal: IntentJournal;
+  auditWriter: AuditWriter;
+  /**
+   * HMAC signer/verifier pair used to sign the in-flight lock envelope. In
+   * production the dispatcher derives these from
+   * `keyVault.deriveLeafKey('inflight', surfaceId)` per-runbook. Tests inject
+   * a fixed pair for determinism. If omitted, the dispatcher derives the
+   * pair at acquire-time using the keyVault's `inflight` context.
+   */
+  lockSigner?: (payload: Buffer) => Buffer;
+  lockVerifier?: (payload: Buffer, signature: Buffer) => boolean;
+}
+
+// ── Implementation ───────────────────────────────────────────────────────
+
+export class Remediator {
+  private readonly opts: RemediatorOptions;
+  private readonly runbooks = new Map<string, ApprovedRunbook>();
+
+  constructor(opts: RemediatorOptions) {
+    this.opts = opts;
+  }
+
+  /**
+   * Register a runbook. Enforces §A6 (no free-text prefilter) and §A36
+   * (essential ⇒ blastRadius === 'machine'). Rejection throws.
+   */
+  registerRunbook(runbook: ApprovedRunbook): void {
+    if (!runbook.id) {
+      throw new Error('Remediator.registerRunbook: runbook.id is required');
+    }
+    // §A6 — registry-load-time refusal of free-text prefilters.
+    if (runbook.eventPrefilter.provenance.includes('free-text')) {
+      throw new Error(
+        `Remediator.registerRunbook: runbook "${runbook.id}" prefilter includes ` +
+          `provenance 'free-text' (§A6 — structured sources only)`
+      );
+    }
+    // §A36 — essential is only valid for machine-level blast-radius.
+    if (runbook.essential === true && runbook.blastRadius !== 'machine') {
+      throw new Error(
+        `Remediator.registerRunbook: runbook "${runbook.id}" sets essential=true ` +
+          `but blastRadius="${runbook.blastRadius}" (§A36 — essential requires 'machine')`
+      );
+    }
+    if (this.runbooks.has(runbook.id)) {
+      throw new Error(
+        `Remediator.registerRunbook: runbook "${runbook.id}" already registered`
+      );
+    }
+    this.runbooks.set(runbook.id, runbook);
+  }
+
+  /**
+   * Dispatch a normalized degradation event. Resolves to a `DispatchOutcome`
+   * describing the terminal state of the attempt (or the reason it never
+   * started).
+   *
+   * Note: this method never throws on policy-level rejections; it returns a
+   * structured outcome. It MAY throw on infrastructure failures (lock
+   * acquisition error, audit write error not classified as token-rejected).
+   */
+  async dispatch(event: NormalizedDegradationEvent): Promise<DispatchOutcome> {
+    const matched = this.matchRunbook(event);
+    if (!matched) {
+      await this.auditAppendNoAttempt(
+        'no-matching-runbook',
+        event,
+        /* runbookId */ undefined
+      );
+      return { outcome: 'no-matching-runbook' };
+    }
+
+    const signatureHash = computeSignatureHash(event);
+    const tupleHash = sha256Hex(`${matched.id}:${signatureHash}`);
+
+    // §A2 — covered-by-inline check via existing in-flight lock.
+    const inFlight = await this.opts.machineLock.listInFlight(
+      this.opts.lockVerifier
+    );
+    const existing = inFlight.find((e) => e.tupleHash === tupleHash);
+    if (existing) {
+      await this.auditAppendNoAttempt(
+        'covered-by-inline',
+        event,
+        matched.id,
+        existing.attemptId
+      );
+      return {
+        outcome: 'covered-by-inline',
+        existingAttemptId: existing.attemptId,
+      };
+    }
+
+    // Derive lock signer/verifier — either caller-provided (tests) or fresh
+    // from the keyVault's `inflight` context for this surface.
+    const { signer, verifier } = this.resolveLockKey(matched.surface);
+
+    const attemptId = crypto.randomUUID();
+    const lockHandle = await this.opts.machineLock.acquireInFlight({
+      surfaceId: matched.surface,
+      attemptId,
+      tupleHash,
+      expectedRuntimeMs: matched.expectedRuntimeMs,
+      signer,
+      verifier,
+    });
+
+    // Declare intent (durable witness) BEFORE running the surface.
+    await this.opts.intentJournal.declareIntent({
+      attemptId,
+      runbookId: matched.id,
+      signatureHash,
+      blastRadius: matched.blastRadius,
+      intent: 'dispatch',
+    });
+
+    // Build RemediationContext with deadline-wired AbortController (§A4).
+    const abortController = new AbortController();
+    const issuedAt = Date.now();
+    const issuedHrtime = process.hrtime.bigint();
+    const expectedRuntimeNs = BigInt(matched.expectedRuntimeMs) * 1_000_000n;
+    const auditToken = this.opts.keyVault.deriveLeafKey('audit', null);
+    const ctx: RemediationContext = {
+      attemptId,
+      runbookId: matched.id,
+      lockHandle,
+      auditToken,
+      abortSignal: abortController.signal,
+      expiresAt: issuedAt + matched.expectedRuntimeMs,
+      monotonicDeadline: issuedHrtime + expectedRuntimeNs,
+    };
+
+    await this.auditAppend(
+      'started',
+      attemptId,
+      matched.id,
+      event,
+      auditToken
+    );
+
+    // Deadline timer — fires AbortSignal at expectedRuntimeMs. The Tier-1
+    // skeleton stops at the AbortSignal; child-process SIGTERM/SIGKILL
+    // escalation is a surface-side concern (W-1 ships that).
+    let deadlineTimer: NodeJS.Timeout | null = null;
+    let deadlineFired = false;
+    const deadlinePromise = new Promise<DispatchOutcome>((resolve) => {
+      deadlineTimer = setTimeout(() => {
+        deadlineFired = true;
+        abortController.abort(new Error('Remediator: expectedRuntimeMs exceeded'));
+        resolve({ outcome: 'aborted-deadline', attemptId });
+      }, matched.expectedRuntimeMs);
+      // Don't block process exit on the timer.
+      if (typeof (deadlineTimer as { unref?: () => void }).unref === 'function') {
+        (deadlineTimer as { unref: () => void }).unref();
+      }
+    });
+
+    try {
+      const racePromise: Promise<DispatchOutcome> = (async () => {
+        let execResult: ExecutionResult;
+        try {
+          execResult = await matched.surfaceCallable(ctx);
+        } catch (err) {
+          if (deadlineFired) {
+            // Surface threw because of the abort — let the deadline branch win.
+            return { outcome: 'aborted-deadline', attemptId };
+          }
+          await this.auditAppend(
+            'verify-failed',
+            attemptId,
+            matched.id,
+            event,
+            auditToken,
+            {
+              redacted: `surfaceCallable threw: ${redactErr(err)}`,
+            }
+          );
+          return { outcome: 'verify-failed', attemptId };
+        }
+
+        if (deadlineFired) {
+          return { outcome: 'aborted-deadline', attemptId };
+        }
+
+        if (execResult.outcome === 'failure') {
+          await this.auditAppend(
+            'verify-failed',
+            attemptId,
+            matched.id,
+            event,
+            auditToken,
+            { redacted: 'surfaceCallable returned outcome=failure' }
+          );
+          return { outcome: 'verify-failed', attemptId };
+        }
+
+        // surfaceCallable succeeded — proceed to verify (§A21).
+        let verifyOutcome: VerifyOutcome;
+        try {
+          verifyOutcome = await matched.verify(ctx);
+        } catch (err) {
+          // §A21 — verify probe error => verify-inconclusive (NOT verify-failed).
+          await this.auditAppend(
+            'verify-inconclusive',
+            attemptId,
+            matched.id,
+            event,
+            auditToken,
+            { redacted: `verify threw: ${redactErr(err)}` }
+          );
+          return { outcome: 'verify-inconclusive', attemptId };
+        }
+
+        if (deadlineFired) {
+          return { outcome: 'aborted-deadline', attemptId };
+        }
+
+        await this.auditAppend(
+          verifyOutcome.outcome,
+          attemptId,
+          matched.id,
+          event,
+          auditToken,
+          { redacted: verifyOutcome.reason }
+        );
+        return { outcome: verifyOutcome.outcome, attemptId };
+      })();
+
+      const result = await Promise.race([racePromise, deadlinePromise]);
+
+      if (result.outcome === 'aborted-deadline') {
+        await this.auditAppend(
+          'aborted-deadline',
+          attemptId,
+          matched.id,
+          event,
+          auditToken,
+          { redacted: `expectedRuntimeMs=${matched.expectedRuntimeMs} exceeded` }
+        );
+      }
+
+      return result;
+    } finally {
+      if (deadlineTimer) clearTimeout(deadlineTimer);
+      try {
+        await lockHandle.release();
+      } catch {
+        // Best-effort release — the stale-reclamation path will reclaim
+        // if anything went wrong with the unlink.
+      }
+    }
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────────
+
+  private matchRunbook(
+    event: NormalizedDegradationEvent
+  ): ApprovedRunbook | undefined {
+    // §A6 — events whose provenance is 'free-text' cannot match any runbook
+    // even if the runbook somehow registered such a prefilter. We enforce at
+    // registry-load (registerRunbook above), but defend in depth here too.
+    if (event.provenance === 'free-text') return undefined;
+
+    const candidates: ApprovedRunbook[] = [];
+    for (const rb of this.runbooks.values()) {
+      // errorCode prefilter — empty list means "no filter".
+      if (
+        rb.eventPrefilter.errorCode.length > 0 &&
+        !rb.eventPrefilter.errorCode.includes(event.errorCode)
+      ) {
+        continue;
+      }
+      // provenance prefilter — empty list means "no filter".
+      if (
+        rb.eventPrefilter.provenance.length > 0 &&
+        !rb.eventPrefilter.provenance.includes(event.provenance)
+      ) {
+        continue;
+      }
+      if (!rb.match(event)) continue;
+      candidates.push(rb);
+    }
+    if (candidates.length === 0) return undefined;
+    // Highest priority wins. Ties broken by id for deterministic ordering.
+    candidates.sort((a, b) => {
+      if (b.priority !== a.priority) return b.priority - a.priority;
+      return a.id.localeCompare(b.id);
+    });
+    return candidates[0];
+  }
+
+  private resolveLockKey(surfaceId: string): {
+    signer: (payload: Buffer) => Buffer;
+    verifier: (payload: Buffer, signature: Buffer) => boolean;
+  } {
+    if (this.opts.lockSigner && this.opts.lockVerifier) {
+      return { signer: this.opts.lockSigner, verifier: this.opts.lockVerifier };
+    }
+    const leaf = this.opts.keyVault.deriveLeafKey('inflight', surfaceId);
+    return {
+      signer: (payload) =>
+        crypto.createHmac('sha256', leaf).update(payload).digest(),
+      verifier: (payload, signature) => {
+        const expected = crypto
+          .createHmac('sha256', leaf)
+          .update(payload)
+          .digest();
+        if (expected.length !== signature.length) return false;
+        return crypto.timingSafeEqual(expected, signature);
+      },
+    };
+  }
+
+  private async auditAppend(
+    outcome: AuditOutcome,
+    attemptId: string,
+    runbookId: string,
+    event: NormalizedDegradationEvent,
+    auditToken: Buffer,
+    reasonOverride?: AuditEntry['reason']
+  ): Promise<void> {
+    const entry: AuditEntry = {
+      entryId: crypto.randomUUID(),
+      attemptId,
+      outcome,
+      runbookId,
+      subsystem: event.subsystem,
+      reason: reasonOverride ?? {
+        redacted: event.reason.redacted,
+        // intentionally NOT propagating event.reason.full into audit
+        // projection — per §A14 the projection is a redacted read view.
+      },
+      timestamp: Date.now(),
+      monotonicTs: process.hrtime.bigint(),
+      auditToken,
+    };
+    await this.opts.auditWriter.append(entry);
+  }
+
+  private async auditAppendNoAttempt(
+    outcome: AuditOutcome,
+    event: NormalizedDegradationEvent,
+    runbookId?: string,
+    coveredByAttemptId?: string
+  ): Promise<void> {
+    const auditToken = this.opts.keyVault.deriveLeafKey('audit', null);
+    const entry: AuditEntry = {
+      entryId: crypto.randomUUID(),
+      attemptId: coveredByAttemptId ?? `none:${crypto.randomUUID()}`,
+      outcome,
+      runbookId,
+      subsystem: event.subsystem,
+      reason: { redacted: event.reason.redacted },
+      timestamp: Date.now(),
+      monotonicTs: process.hrtime.bigint(),
+      auditToken,
+    };
+    await this.opts.auditWriter.append(entry);
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function sha256Hex(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+/**
+ * Stable signature hash over the structured fields of a normalized event.
+ * Used for tuple keying + cross-process attempt ledger.
+ *
+ * Includes: subsystem, errorCode, provenance. Excludes timestamps and the
+ * `reason` payload (which carries variable text). This is the same shape the
+ * future cross-process ledger (A7) keys on; keeping the formula here keeps
+ * F-8 and the ledger consistent without a shared helper module (which the
+ * ledger PR is free to extract).
+ */
+function computeSignatureHash(event: NormalizedDegradationEvent): string {
+  const canonical = JSON.stringify([
+    event.subsystem,
+    event.errorCode,
+    event.provenance,
+  ]);
+  return sha256Hex(canonical);
+}
+
+function redactErr(err: unknown): string {
+  if (err instanceof Error) return err.message.slice(0, 200);
+  return String(err).slice(0, 200);
+}

--- a/tests/unit/Remediator.test.ts
+++ b/tests/unit/Remediator.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Unit tests for Remediator — Tier-1 orchestrator skeleton.
+ *
+ * Covers SELF-HEALING-REMEDIATOR-V2-SPEC §A2, §A4, §A6, §A21, §A36, §A57.
+ *
+ * Strategy: use real tmpdir-backed `MachineLock`, `IntentJournal`, and
+ * `AuditWriter` instances for integration realism (F-4 primitives are cheap
+ * to instantiate and the cleanup is bounded by tmpdir).
+ *
+ * `RemediationKeyVault` is mocked via a minimal interface-compatible stub so
+ * the tests don't hit the OS keychain. The mock derives deterministic leaf
+ * keys via HKDF over a fixed in-memory master, mirroring F-1's contract.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  Remediator,
+  type ApprovedRunbook,
+  type RemediationContext,
+  type VerifyOutcome,
+} from '../../src/remediation/Remediator.js';
+import type { NormalizedDegradationEvent } from '../../src/monitoring/DegradationReporter.js';
+import { MachineLock } from '../../src/remediation/MachineLock.js';
+import { IntentJournal } from '../../src/remediation/IntentJournal.js';
+import {
+  AuditWriter,
+  deserializeAuditEntry,
+  type AuditEntry,
+} from '../../src/remediation/audit/AuditWriter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+// ── Mocks / fakes ────────────────────────────────────────────────────────
+
+/**
+ * Minimal RemediationKeyVault stub. Derives one leaf per (context, scopeId)
+ * via HKDF over a fixed in-memory master + nonce. Same shape as F-1's
+ * `deriveLeafKey` but no keychain dependency.
+ */
+class FakeKeyVault {
+  private readonly master = crypto.randomBytes(32);
+  private readonly nonce = crypto.randomBytes(32);
+  deriveLeafKey(context: string, scopeId: string | null): Buffer {
+    const info = Buffer.from(`${context}:${scopeId ?? ''}`);
+    return Buffer.from(crypto.hkdfSync('sha256', this.master, this.nonce, info, 32));
+  }
+}
+
+function makeSignerPair(): {
+  signer: (payload: Buffer) => Buffer;
+  verifier: (payload: Buffer, signature: Buffer) => boolean;
+} {
+  const key = crypto.randomBytes(32);
+  return {
+    signer: (payload) =>
+      crypto.createHmac('sha256', key).update(payload).digest(),
+    verifier: (payload, signature) => {
+      const expected = crypto
+        .createHmac('sha256', key)
+        .update(payload)
+        .digest();
+      if (expected.length !== signature.length) return false;
+      return crypto.timingSafeEqual(expected, signature);
+    },
+  };
+}
+
+/**
+ * AuditWriter token-verifier that accepts any non-empty buffer. Forged-token
+ * tests inject a strict verifier that requires a specific magic prefix.
+ */
+function permissiveTokenVerifier(): (e: AuditEntry) => boolean {
+  return (e) => e.auditToken.length > 0;
+}
+
+function makeEvent(
+  overrides?: Partial<NormalizedDegradationEvent>
+): NormalizedDegradationEvent {
+  return {
+    subsystem: overrides?.subsystem ?? 'memory',
+    errorCode: overrides?.errorCode ?? 'NATIVE_MODULE_ABI_MISMATCH',
+    provenance: overrides?.provenance ?? 'native-binding',
+    reason: overrides?.reason ?? {
+      redacted: 'native module ABI mismatch (redacted)',
+      full: 'native module ABI mismatch for better-sqlite3 against Node 127',
+    },
+    timestamp: overrides?.timestamp ?? new Date().toISOString(),
+    monotonicTs: overrides?.monotonicTs ?? performance.now(),
+  };
+}
+
+function makeRunbook(overrides?: Partial<ApprovedRunbook>): ApprovedRunbook {
+  return {
+    id: overrides?.id ?? 'node-abi-mismatch',
+    priority: overrides?.priority ?? 10,
+    surface: overrides?.surface ?? 'native-module-healer',
+    eventPrefilter: overrides?.eventPrefilter ?? {
+      errorCode: ['NATIVE_MODULE_ABI_MISMATCH'],
+      provenance: ['native-binding'],
+    },
+    match: overrides?.match ?? (() => true),
+    preconditions: overrides?.preconditions ?? (async () => true),
+    surfaceCallable:
+      overrides?.surfaceCallable ??
+      (async () => ({ outcome: 'success', details: {} })),
+    verify:
+      overrides?.verify ??
+      (async () => ({
+        outcome: 'verified-healthy',
+        reason: 'health check returned ok',
+      })),
+    blastRadius: overrides?.blastRadius ?? 'process',
+    reversibility: overrides?.reversibility ?? 'reversible',
+    expectedRuntimeMs: overrides?.expectedRuntimeMs ?? 1_000,
+    essential: overrides?.essential,
+  };
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+interface Fixture {
+  tmpDir: string;
+  remediator: Remediator;
+  machineLock: MachineLock;
+  intentJournal: IntentJournal;
+  auditWriter: AuditWriter;
+  keyVault: FakeKeyVault;
+  signerPair: ReturnType<typeof makeSignerPair>;
+  machineId: string;
+}
+
+function makeFixture(opts?: {
+  tokenVerifier?: (e: AuditEntry) => boolean;
+}): Fixture {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remediator-'));
+  const machineId = 'm-test';
+  const machineLock = new MachineLock(tmpDir);
+  const intentJournal = new IntentJournal(tmpDir, { machineId });
+  const auditWriter = new AuditWriter(tmpDir, {
+    machineId,
+    tokenVerifier: opts?.tokenVerifier ?? permissiveTokenVerifier(),
+  });
+  const keyVault = new FakeKeyVault();
+  const signerPair = makeSignerPair();
+  const remediator = new Remediator({
+    stateDir: tmpDir,
+    // FakeKeyVault duck-types RemediationKeyVault's deriveLeafKey.
+    keyVault: keyVault as unknown as Parameters<
+      typeof Remediator.prototype.constructor
+    >[0]['keyVault'],
+    machineLock,
+    intentJournal,
+    auditWriter,
+    lockSigner: signerPair.signer,
+    lockVerifier: signerPair.verifier,
+  });
+  return {
+    tmpDir,
+    remediator,
+    machineLock,
+    intentJournal,
+    auditWriter,
+    keyVault,
+    signerPair,
+    machineId,
+  };
+}
+
+function cleanup(fx: Fixture): void {
+  SafeFsExecutor.safeRmSync(fx.tmpDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/Remediator.test.ts:cleanup',
+  });
+}
+
+function readProjection(tmpDir: string, machineId: string): AuditEntry[] {
+  const p = path.join(
+    tmpDir,
+    'remediation',
+    `audit-projection-${machineId}.jsonl`
+  );
+  if (!fs.existsSync(p)) return [];
+  return fs
+    .readFileSync(p, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(deserializeAuditEntry);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('Remediator', () => {
+  let fx: Fixture;
+
+  beforeEach(() => {
+    fx = makeFixture();
+  });
+
+  afterEach(() => {
+    cleanup(fx);
+  });
+
+  it('registers a valid runbook', () => {
+    expect(() => fx.remediator.registerRunbook(makeRunbook())).not.toThrow();
+  });
+
+  it('rejects a runbook whose prefilter includes provenance "free-text" (§A6)', () => {
+    expect(() =>
+      fx.remediator.registerRunbook(
+        makeRunbook({
+          id: 'bad-freetext',
+          eventPrefilter: {
+            errorCode: [],
+            provenance: ['free-text'],
+          },
+        })
+      )
+    ).toThrow(/free-text/);
+  });
+
+  it('rejects essential=true when blastRadius !== "machine" (§A36)', () => {
+    expect(() =>
+      fx.remediator.registerRunbook(
+        makeRunbook({
+          id: 'bad-essential',
+          essential: true,
+          blastRadius: 'process',
+        })
+      )
+    ).toThrow(/essential/);
+    // essential + machine OK
+    expect(() =>
+      fx.remediator.registerRunbook(
+        makeRunbook({
+          id: 'ok-essential',
+          essential: true,
+          blastRadius: 'machine',
+        })
+      )
+    ).not.toThrow();
+  });
+
+  it('dispatch with no matching runbook → "no-matching-runbook" + audit entry', async () => {
+    // No runbooks registered.
+    const result = await fx.remediator.dispatch(makeEvent());
+    expect(result).toEqual({ outcome: 'no-matching-runbook' });
+
+    const entries = readProjection(fx.tmpDir, fx.machineId);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.outcome).toBe('no-matching-runbook');
+  });
+
+  it('dispatch with matching runbook → lock + intent + surfaceCallable + verify + release', async () => {
+    let surfaceCalled = false;
+    let verifyCalled = false;
+    let ctxSeen: RemediationContext | null = null;
+    fx.remediator.registerRunbook(
+      makeRunbook({
+        surfaceCallable: async (ctx) => {
+          surfaceCalled = true;
+          ctxSeen = ctx;
+          return { outcome: 'success', details: {} };
+        },
+        verify: async () => {
+          verifyCalled = true;
+          return { outcome: 'verified-healthy', reason: 'ok' };
+        },
+      })
+    );
+
+    const result = await fx.remediator.dispatch(makeEvent());
+    expect(result.outcome).toBe('verified-healthy');
+    expect(surfaceCalled).toBe(true);
+    expect(verifyCalled).toBe(true);
+    expect(ctxSeen).not.toBeNull();
+    expect(ctxSeen!.attemptId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(ctxSeen!.runbookId).toBe('node-abi-mismatch');
+    expect(ctxSeen!.auditToken.length).toBeGreaterThan(0);
+
+    // Lock should be released by now.
+    const lockDir = path.join(fx.tmpDir, 'machine-locks', 'in-flight');
+    expect(
+      fs.existsSync(lockDir) ? fs.readdirSync(lockDir) : []
+    ).toEqual([]);
+
+    // Intent journal contains one entry.
+    const intents = await fx.intentJournal.readSince(0);
+    expect(intents).toHaveLength(1);
+    expect(intents[0]!.intent).toBe('dispatch');
+    expect(intents[0]!.runbookId).toBe('node-abi-mismatch');
+
+    // Audit projection contains started + verified-healthy.
+    const entries = readProjection(fx.tmpDir, fx.machineId);
+    expect(entries.map((e) => e.outcome)).toEqual([
+      'started',
+      'verified-healthy',
+    ]);
+  });
+
+  it('dispatch with existing in-flight lock for same tuple → "covered-by-inline" (§A2)', async () => {
+    fx.remediator.registerRunbook(makeRunbook());
+
+    // Pre-seed an in-flight lock with the same tupleHash the dispatcher
+    // will compute. tupleHash = sha256(`${runbookId}:${signatureHash}`)
+    // where signatureHash = sha256(JSON.stringify([subsystem, errorCode, provenance])).
+    const ev = makeEvent();
+    const signatureHash = crypto
+      .createHash('sha256')
+      .update(JSON.stringify([ev.subsystem, ev.errorCode, ev.provenance]))
+      .digest('hex');
+    const tupleHash = crypto
+      .createHash('sha256')
+      .update(`node-abi-mismatch:${signatureHash}`)
+      .digest('hex');
+
+    const preHandle = await fx.machineLock.acquireInFlight({
+      surfaceId: 'native-module-healer',
+      attemptId: 'pre-existing-attempt-xyz',
+      tupleHash,
+      expectedRuntimeMs: 60_000,
+      signer: fx.signerPair.signer,
+      verifier: fx.signerPair.verifier,
+    });
+
+    const result = await fx.remediator.dispatch(ev);
+    expect(result.outcome).toBe('covered-by-inline');
+    if (result.outcome === 'covered-by-inline') {
+      expect(result.existingAttemptId).toBe('pre-existing-attempt-xyz');
+    }
+
+    await preHandle.release();
+  });
+
+  it('surfaceCallable that hangs past expectedRuntimeMs → "aborted-deadline" + lock released (§A4)', async () => {
+    fx.remediator.registerRunbook(
+      makeRunbook({
+        expectedRuntimeMs: 50,
+        surfaceCallable: (ctx) =>
+          new Promise((resolve, reject) => {
+            ctx.abortSignal.addEventListener('abort', () => {
+              reject(new Error('aborted'));
+            });
+            // Otherwise never resolves.
+          }),
+      })
+    );
+
+    const result = await fx.remediator.dispatch(makeEvent());
+    expect(result.outcome).toBe('aborted-deadline');
+
+    // Lock released.
+    const lockDir = path.join(fx.tmpDir, 'machine-locks', 'in-flight');
+    expect(
+      fs.existsSync(lockDir) ? fs.readdirSync(lockDir) : []
+    ).toEqual([]);
+
+    const entries = readProjection(fx.tmpDir, fx.machineId);
+    const outcomes = entries.map((e) => e.outcome);
+    expect(outcomes).toContain('started');
+    expect(outcomes).toContain('aborted-deadline');
+  });
+
+  it('surfaceCallable failure → verify NEVER called + audit shows verify-failed', async () => {
+    let verifyCalled = false;
+    fx.remediator.registerRunbook(
+      makeRunbook({
+        surfaceCallable: async () => ({
+          outcome: 'failure',
+          details: { reason: 'rebuild exited 1' },
+        }),
+        verify: async () => {
+          verifyCalled = true;
+          return { outcome: 'verified-healthy', reason: 'should not be reached' };
+        },
+      })
+    );
+
+    const result = await fx.remediator.dispatch(makeEvent());
+    expect(result.outcome).toBe('verify-failed');
+    expect(verifyCalled).toBe(false);
+
+    const entries = readProjection(fx.tmpDir, fx.machineId);
+    const outcomes = entries.map((e) => e.outcome);
+    expect(outcomes).toEqual(['started', 'verify-failed']);
+  });
+
+  it('verify-inconclusive (probe error per §A21) is distinct from verify-failed', async () => {
+    fx.remediator.registerRunbook(
+      makeRunbook({
+        id: 'inconclusive-rb',
+        eventPrefilter: {
+          errorCode: ['NATIVE_MODULE_ABI_MISMATCH'],
+          provenance: ['native-binding'],
+        },
+        verify: async (): Promise<VerifyOutcome> => ({
+          outcome: 'verify-inconclusive',
+          reason: 'probe returned ambiguous payload',
+        }),
+      })
+    );
+
+    const result = await fx.remediator.dispatch(makeEvent());
+    expect(result.outcome).toBe('verify-inconclusive');
+
+    const entries = readProjection(fx.tmpDir, fx.machineId);
+    const last = entries[entries.length - 1]!;
+    expect(last.outcome).toBe('verify-inconclusive');
+    expect(last.outcome).not.toBe('verify-failed');
+  });
+
+  it('verify that THROWS (probe error) → verify-inconclusive (§A21)', async () => {
+    fx.remediator.registerRunbook(
+      makeRunbook({
+        id: 'throws-rb',
+        verify: async () => {
+          throw new Error('probe timed out');
+        },
+      })
+    );
+
+    const result = await fx.remediator.dispatch(makeEvent());
+    expect(result.outcome).toBe('verify-inconclusive');
+  });
+
+  it('audit entries land in audit-projection-<machineId>.jsonl', async () => {
+    fx.remediator.registerRunbook(makeRunbook());
+    await fx.remediator.dispatch(makeEvent());
+
+    const projPath = path.join(
+      fx.tmpDir,
+      'remediation',
+      `audit-projection-${fx.machineId}.jsonl`
+    );
+    expect(fs.existsSync(projPath)).toBe(true);
+    const lines = fs
+      .readFileSync(projPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(2); // started + verify outcome
+  });
+
+  it('forged audit-token entries route to audit-rejected.jsonl', async () => {
+    // Strict token verifier: only accept tokens whose first byte is 0x42.
+    const strictFx = makeFixture({
+      tokenVerifier: (e) =>
+        e.auditToken.length > 0 && e.auditToken[0] === 0x42,
+    });
+    try {
+      // FakeKeyVault produces random HKDF output; the leaf almost certainly
+      // does not start with 0x42, so every dispatch will be rejected.
+      strictFx.remediator.registerRunbook(makeRunbook());
+      await strictFx.remediator.dispatch(makeEvent());
+
+      const rejPath = path.join(
+        strictFx.tmpDir,
+        'remediation',
+        'audit-rejected.jsonl'
+      );
+      expect(fs.existsSync(rejPath)).toBe(true);
+      const rejLines = fs
+        .readFileSync(rejPath, 'utf8')
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+      expect(rejLines.length).toBeGreaterThan(0);
+      const parsed = JSON.parse(rejLines[0]!);
+      expect(parsed.reason).toBe('token-verify-failed');
+
+      // Projection should be empty (or absent) — every entry was rejected.
+      const projection = readProjection(strictFx.tmpDir, strictFx.machineId);
+      expect(projection).toHaveLength(0);
+    } finally {
+      cleanup(strictFx);
+    }
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -23,6 +23,32 @@ This is the backend half of Phase 4. The Dashboard UI rewrite (Jobs tab, Issues 
 
 ## What Changed
 
+### feat(remediation): F-8 — Remediator orchestrator skeleton (Tier-1 subset)
+
+Ships the Tier-1 subset of F-8 from `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (§A2, §A4, §A6, §A21, §A36, §A57). New module `src/remediation/Remediator.ts` exposes the orchestrator class plus public types `ApprovedRunbook`, `RemediationContext`, `ExecutionResult`, `VerifyOutcome`, `BlastRadius`, `Reversibility`, `DispatchOutcome`.
+
+`Remediator.registerRunbook()` enforces two registry-load-time gates:
+- §A6: refuses any prefilter that includes `provenance: 'free-text'` (structured sources only).
+- §A36: refuses `essential: true` unless `blastRadius === 'machine'`.
+
+`Remediator.dispatch()` composes the F-1..F-4 primitives:
+- Match candidate runbooks via `eventPrefilter` (errorCode + provenance) + `match()`; pick highest priority.
+- Compute `tupleHash = sha256(runbookId + signatureHash)`, check existing in-flight locks (§A2 covered-by-inline detection).
+- Acquire `MachineLock` (HMAC-signed via F-1 leaf key for the `inflight` context).
+- Declare intent via `IntentJournal` BEFORE running the surface.
+- Build a `RemediationContext` carrying `attemptId, runbookId, lockHandle, auditToken (F-1 audit-context leaf), abortSignal, expiresAt, monotonicDeadline`.
+- Race `surfaceCallable + verify` against an `AbortController` timer (§A4 deadline enforcement); on timeout returns `aborted-deadline` and releases the lock.
+- §A21 strict verify typing: probe error or verify-THROW maps to `verify-inconclusive`, never `verify-failed`.
+- Audit-append via F-4 `AuditWriter` at every state transition.
+
+Tier-2 carve-outs (deferred per A57): trust elevation source, probe authentication (A40/A52), surface-side capability-token HMAC enforcement (A3/A23/A42), supervisor handshake (A15), signed-manifest registry validation (A56/A66), child-process SIGTERM/SIGKILL escalation (W-1's concern).
+
+No production consumer in this PR — the dispatcher is constructible but not yet wired into `DegradationReporter.setRemediator()`. W-1 (NativeModuleHealer wrapper) is the first caller.
+
+12 new unit tests in `tests/unit/Remediator.test.ts` cover: register-valid, register-rejects-free-text (§A6), register-rejects-essential-on-non-machine (§A36), no-matching-runbook + audit entry, full success-path with lock+intent+verify+release, covered-by-inline (§A2) for pre-existing same-tuple lock, aborted-deadline (§A4) on hanging surface, verify-NEVER-called on surfaceCallable failure, verify-inconclusive distinct from verify-failed (§A21), verify-THROW → verify-inconclusive, audit entries land in `audit-projection-<machineId>.jsonl`, forged-token entries route to `audit-rejected.jsonl`.
+
+Side-effects review: `upgrades/side-effects/f8-remediator-skeleton.md`.
+
 ### fix(security): API safety guard — subscription-by-default enforcement
 
 `src/commands/server.ts` had one silent-fallback path that could engage billed Anthropic API mode without explicit user consent: if the Claude CLI was unavailable and `ANTHROPIC_API_KEY` happened to be set in the environment, instar would silently use the API "as a last resort." That trade-off ("degrading to heuristics is worse than using whatever LLM is available") encoded a values choice the principal rejects. Removed.
@@ -99,6 +125,8 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 
 **F-4 — Coordination + audit primitives.** This release adds plumbing for a self-healing system that is not yet active. Nothing changes about how the agent behaves today.
 
+**F-8 — Self-healing orchestrator skeleton.** The piece that decides which repair runs when, makes sure only one repair runs against the same problem at a time, and forcibly stops a repair that takes too long. Wired into the existing audit log, intent journal, and lock primitives from earlier foundation work. Still no user-facing change yet — there are no actual repair playbooks plugged in. The first real playbook (rebuilding the SQLite native module after a Node upgrade) arrives in the next foundation PR. The skeleton fails fast at startup if a playbook is mis-configured (e.g., declared "essential" but only affecting a single process), so misbehaving playbooks can't sneak past review.
+
 **F-1 — Cryptographic foundation for self-healing.** Nothing user-visible yet. Operators running on headless Linux without libsecret should set `INSTAR_REMEDIATION_KEY_PASSPHRASE` in their environment before any F-2+ feature ships. macOS and Linux+libsecret have nothing to do.
 
 **ELI16-overview gate.** When your agent hands you a spec for approval, you'll now always get a plain-English overview alongside the dense technical document. The instar repo refuses to commit any code change whose driving spec lacks a readable companion file. The technical spec becomes the appendix; the overview is the entry point. No setup required; the new behavior takes effect on the next agent update.
@@ -124,3 +152,9 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 - **In-flight tuple lock** (F-4) — Prevents two heal paths from racing on the same problem.
 - **Intent journal** (F-4) — Durable log of "what an attempt declared it was about to do."
 - **Audit-writer + projection** (F-4) — Verified-append audit log + read view consumed by later remediation modules.
+- **`Remediator` class** (F-8 Tier-1) — Orchestrator skeleton that matches normalized degradation events to registered runbooks, acquires a per-tuple in-flight lock, declares intent, runs the surface callable with deadline enforcement, races verify, and audit-logs every state transition.
+- **`ApprovedRunbook` contract** (F-8) — Public type with `eventPrefilter`, `match`, `preconditions`, `surfaceCallable`, `verify`, `blastRadius`, `reversibility`, `expectedRuntimeMs`, optional `essential`. Registry-load-time validators refuse free-text-provenance prefilters (§A6) and `essential` on non-machine blast radius (§A36).
+- **`RemediationContext`** (F-8) — Capability-token-shaped context handed to surfaces: `attemptId`, `runbookId`, `lockHandle`, `auditToken` (from F-1 audit-context leaf), `abortSignal`, `expiresAt`, `monotonicDeadline`. Surface-side HMAC enforcement is Tier-2.
+- **§A4 deadline enforcement** (F-8) — `AbortController` race against `expectedRuntimeMs`; surfaces that hang are aborted, lock is released, outcome is `aborted-deadline`.
+- **§A21 verify taxonomy** (F-8) — `verified-healthy | verify-failed | verify-inconclusive`. Verify-THROW and surface-throw map to `verify-inconclusive` and `verify-failed` respectively; only a clean structured failure increments churn.
+- **§A2 covered-by-inline** (F-8) — Pre-existing in-flight lock with same tuple short-circuits dispatch with the existing attemptId.

--- a/upgrades/side-effects/f8-remediator-skeleton.md
+++ b/upgrades/side-effects/f8-remediator-skeleton.md
@@ -1,0 +1,153 @@
+# Side-Effects Review — F-8: Remediator orchestrator skeleton (Tier-1 subset)
+
+**Version / slug:** `f8-remediator-skeleton`
+**Date:** `2026-05-13`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Ships the Tier-1 subset of F-8 from the Self-Healing Remediator v2 spec (`docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A1 manifest, §A2 lock-bound co-existence, §A3 capability-token context, §A4 deadline enforcement, §A6 errorCode-provenance gate, §A21 verify-failed strict typing, §A36 essential-runbook validator, §A57 phase tiering).
+
+New module: `src/remediation/Remediator.ts`. A single orchestrator class plus the surface types `ApprovedRunbook`, `RemediationContext`, `ExecutionResult`, `VerifyOutcome`, `BlastRadius`, `Reversibility`, `DispatchOutcome`.
+
+What this PR DOES include (per A57's Tier-1 carve-out):
+- Runbook registration with §A6 + §A36 registry-load-time refusal.
+- Dispatch loop: match by `eventPrefilter` (errorCode + provenance) + `match()`; refuse `provenance: 'free-text'` events at the matcher; pick highest-priority candidate.
+- Lock acquisition via the F-4 `MachineLock` using `tupleHash = sha256(runbookId + signatureHash)`. Existing in-flight lock with same tuple → `covered-by-inline`.
+- Intent journal declaration via the F-4 `IntentJournal` (durable witness before any mutation).
+- `RemediationContext` carrying `attemptId, runbookId, lockHandle, auditToken (leaf from F-1 keyVault), abortSignal, expiresAt, monotonicDeadline`.
+- Deadline enforcement (§A4): an `AbortController` fires at `expectedRuntimeMs`; the dispatcher races the surface against the timer; on deadline, the result is `aborted-deadline` and the lock is released in the `finally` block.
+- Verify-outcome wiring (§A21): verify is only called when surfaceCallable returned `outcome: 'success'`; verify-THROW is mapped to `verify-inconclusive` (probe error), never `verify-failed`.
+- Audit-append via the F-4 `AuditWriter` at every state transition (`started`, `verified-healthy | verify-failed | verify-inconclusive`, `aborted-deadline`, `no-matching-runbook`, `covered-by-inline`).
+
+What this PR explicitly does NOT include (per A57 Tier-2 carve-out, deferred):
+- Trust elevation source.
+- Probe authentication (A40, A52).
+- Capability-token HMAC enforcement on the surface side (A3, A23, A42).
+- Supervisor handshake (A15).
+- Runbook registry validation against a signed manifest (A56, A66).
+- Child-process SIGTERM/SIGKILL escalation — surfaces (W-1..W-4) implement that; the skeleton's AbortSignal is the in-process enforcement handle only.
+
+Files touched:
+- `src/remediation/Remediator.ts` (add)
+- `tests/unit/Remediator.test.ts` (add — 12 cases)
+- `upgrades/NEXT.md` (modify — preserves F-1..F-4 + Phase 4/5 + ELI16 + API-safety entries)
+
+## Decision-point inventory
+
+- `Remediator.registerRunbook()` — **add** — registry-load-time gate; rejects free-text-provenance prefilters (§A6) and essential-on-non-machine (§A36). Hard error: throws on misconfig so boot fails fast.
+- `Remediator.dispatch()` — **add** — orchestration entry; produces a `DispatchOutcome` discriminated union. Five terminal states. Does not throw on policy rejections; throws only on infrastructure failures (lock acquire error not covered by `covered-by-inline`).
+- Internal: `matchRunbook()` — defends-in-depth against `provenance: 'free-text'` events even if a runbook somehow registered such a prefilter.
+- Internal: deadline race via `Promise.race(racePromise, deadlinePromise)` — the AbortController is the surface-facing signal; the race is the dispatcher-side authority.
+
+No new HTTP routes. No new persistent files beyond what F-4 already creates (audit-projection-*, intent-journal-*, machine-locks/*). The skeleton consumes those primitives; it does not create new file types.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- **`provenance: 'free-text'` events never match.** This is by design (§A6). Legacy `.report(...)` callers normalize through DegradationReporter's F-3 shim to `free-text` provenance and route to `no-matching-runbook` (which is fine — they still produce an audit entry; SystemReviewer clusters them for novel-failure proposals). The "rejection" is exactly what §A6 mandates as the structural defense against attacker-shaped error text.
+- **Concurrent dispatch against the same tuple while in-flight → `covered-by-inline`.** Intended (§A2). The second caller is not silently dropped — it receives a structured outcome naming the existing attempt. The caller can subscribe to the audit log for the in-flight attempt's terminal outcome.
+- **Essential on non-machine blast radius rejected at register-time.** Intended (§A36). A boot-time misconfig fails fast rather than allowing a non-machine runbook to skip auto-quarantine (which would be a DoS vector).
+- **Verify probe error → `verify-inconclusive`.** Intended (§A21). The spec explicitly carves out probe error / timeout / unsigned payload as `verify-inconclusive` so attackers cannot DoS a working heal by making the verify probe fail.
+
+There is no legitimate path this PR over-blocks. The four rejections above are all structural defenses with no false-positive surface.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **No capability-token HMAC enforcement on the surface side.** A surface that receives `RemediationContext` could theoretically be invoked by a forged context (no token verification on the surface). Tier-2 fixes this with A3 + A23 + A42. The Tier-1 skeleton's mitigation: only the dispatcher creates contexts, and the surface package is co-installed with the dispatcher; in this PR there are no real surface consumers yet (W-1 ships the first one). Forging requires in-process code-exec, at which point all bets are off anyway.
+- **No probe authentication.** Verify outcomes from the runbook's `verify()` callback are trusted by-signature only insofar as the runbook author wrote them correctly. A40 will harden this with per-probe leaf-key signatures over the verify envelope. Tier-1 trusts the runbook code itself.
+- **No cross-machine coordination.** The lock is per-machine. Two machines healing the same tuple are not coordinated by F-8. Cross-process attempt ledger (A7) and primary-aggregator lease (A47) handle that at Tier-2/Tier-3.
+- **No child-process abort escalation.** A surface that spawns a child process and ignores `abortSignal` won't be force-killed by F-8; the dispatcher only signals. Child-process SIGTERM/SIGKILL ladder is W-1's concern. Mitigation: the lock IS released by the dispatcher's `finally` block, so the orphaned child does not block a re-dispatch.
+- **No deadline enforcement on `verify()` itself.** If a surface succeeds but verify hangs, the same AbortController fires and the dispatcher returns `aborted-deadline` (the deadline race is around the entire `surfaceCallable + verify` chain). However, verify is not given a separate deadline budget. Tier-2 may refine this.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The Remediator is the orchestrator — its job is *to compose* the F-1..F-4 primitives. It owns:
+- Match policy (which runbook fires for which event).
+- Coordination policy (lock acquire, tuple compute, covered-by-inline detection).
+- Deadline policy (AbortController + timer race).
+- Verify-outcome interpretation (success/failure/inconclusive mapping).
+
+It does NOT own:
+- Key material (F-1).
+- Lock-file format (F-4 MachineLock).
+- Intent durability semantics (F-4 IntentJournal).
+- Audit-token verification (F-4 AuditWriter's injected verifier).
+- Surface implementations (W-*).
+
+Each of those concerns lives in its rightful module. The dispatcher is the thin glue layer that the spec mandates.
+
+No higher-level smart gate is shadowed. The dispatch decision is structural (does the event match this runbook's prefilter?), not heuristic. The signal-vs-authority principle is honoured because matching is deterministic and the authority is bounded to "which surfaceCallable to invoke" — a runbook-author-controlled invariant, not a content-classifier's call.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface beyond structural primitives (errorCode equality, provenance enum membership, runbook id presence).
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The match function `eventPrefilter.errorCode.includes(event.errorCode) && eventPrefilter.provenance.includes(event.provenance) && runbook.match(event)` is precise, not heuristic. There is no regex, no string-pattern matching, no LLM call. The only "intelligence" is the runbook author's `match()` callback, which is structural code shipped in `src/remediation/runbooks/*` (none exist yet — W-* PRs add them).
+
+The blocking decisions held by the dispatcher (free-text rejection, essential validator, deadline enforcement) are all over precise structural inputs:
+- §A6 free-text rejection: enum equality.
+- §A36 essential validator: enum equality + boolean.
+- §A4 deadline: monotonic clock comparison.
+
+These are exactly the kind of authority that *should* be hard-coded structurally. The smart gate (the runbook author + the user who approves runbook PRs through `/instar-dev`) holds policy authority over which runbooks exist; the dispatcher's job is to enforce structural invariants on registration and dispatch.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** None. There is no existing dispatcher in `src/remediation/`. The closest prior art is the in-line `NativeModuleHealer` path inside the existing native-binding error handling — that path remains untouched in this PR. W-1 ships the wrapper that makes the inline healer addressable from F-8 *as a runbook*, at which point §A2's lock-bound co-existence rule kicks in (both the inline and the F-8 path acquire the same MachineLock tuple; only one runs).
+- **Race with adjacent cleanup:** The dispatcher's `finally` block always releases the lock. If `acquireInFlight` succeeded but the surface throws before `surfaceCallable` is invoked (currently impossible — the dispatcher calls it directly), the lock would still be released. The release is idempotent (F-4 contract).
+- **Double-fire:** `dispatch()` for the same event called twice concurrently → second call observes the first's lock and returns `covered-by-inline`. `dispatch()` called sequentially → second call proceeds (the first released its lock).
+- **DegradationReporter wiring:** F-3 ships `setRemediator(remediatorLike)`. THIS PR does not call `setRemediator()` from anywhere — the dispatcher is constructible but not yet wired into the DegradationReporter pipeline. A subsequent PR (or W-1) wires the dispatcher into the reporter, at which point legacy events route through `dispatch()`. Until then, the dispatcher only fires when called explicitly (e.g., from tests).
+- **Audit-projection consumer:** F-4's `AuditProjection` reads from the same file the dispatcher writes to. Live: as soon as the dispatcher is invoked, `AuditProjection.recentByRunbook()` reflects the new entries. No coupling beyond the file path contract.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible to other agents, other users, other systems?**
+
+- No HTTP routes, no Telegram surfaces, no dashboard tabs, no config-flip entries, no CLI commands.
+- No new file types on disk. The dispatcher consumes the F-4 primitives' files (`<stateDir>/machine-locks/in-flight/*.lock`, `<stateDir>/remediation/intent-journal-*.jsonl`, `<stateDir>/remediation/audit-projection-*.jsonl`, `<stateDir>/remediation/audit-rejected.jsonl`). Files only materialize when the dispatcher is actually invoked.
+- The default exported class is a new symbol. No existing imports break.
+- The DegradationReporter `RemediatorLike` interface declared in F-3 is structurally compatible with the new `Remediator.dispatch()` signature: both accept `NormalizedDegradationEvent` and return `Promise`. The dispatcher's return type is richer (`DispatchOutcome`), which is a widening from F-3's `Promise<void>` — backwards-compatible.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Trivially low. The dispatcher is a new symbol that is not yet imported by any production code path. `git revert` of this PR removes the class and the test file with zero state migration cost. The on-disk artifacts (audit-projection, intent-journal, machine-locks) are F-4's responsibility; the revert doesn't touch them, and they remain consumable by whichever future PR re-introduces the dispatcher.
+
+If a future consumer-PR (W-1) wires the dispatcher into `setRemediator()` and a bug surfaces, the back-out path is "revert the consumer PR" — the dispatcher itself never runs without a caller. The fail-safe shape of the design means a dispatcher bug cannot break legacy `.report(...)` flow (which never reaches the dispatcher absent a `setRemediator()` call).
+
+---
+
+## Reviewer concurrence (Phase 5)
+
+Not required. This change introduces no live consumers, no block/allow surface for messaging, no session lifecycle, no coherence/sentinel/gate authority. It is foundation infrastructure that becomes load-bearing only once W-1 wires a real runbook. At that point W-1 carries its own side-effects review covering the dispatcher's first production caller.


### PR DESCRIPTION
## Summary

Tier-1 subset of F-8 from `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (§A2, §A4, §A6, §A21, §A36, §A57). Composes the foundation primitives F-1..F-4 into a working dispatch loop.

- `Remediator.registerRunbook()` enforces §A6 (no free-text prefilters) and §A36 (essential ⇒ blastRadius === 'machine').
- `Remediator.dispatch()` matches → checks in-flight lock (§A2 covered-by-inline) → acquires MachineLock → declares intent → races surfaceCallable+verify against an AbortController timer at `expectedRuntimeMs` (§A4) → audit-appends every state transition.
- §A21 strict verify typing: verify-THROW → `verify-inconclusive`; only clean failure increments the failed taxonomy.
- `DispatchOutcome` union covers all five terminal states.

Tier-2 carve-outs deferred per A57: probe authentication, surface-side capability-token enforcement, supervisor handshake, signed-manifest registry validation, child-process SIGTERM/SIGKILL escalation.

No production consumer in this PR — dispatcher is constructible but not yet wired into `DegradationReporter.setRemediator()`. W-1 (NativeModuleHealer wrapper) is the first caller.

## Test plan

- [x] 12 new unit tests in `tests/unit/Remediator.test.ts` — all pass locally.
- [x] Existing F-4 primitives' tests (`MachineLock`, `IntentJournal`, `AuditWriter`) still pass alongside.
- [x] `tests/unit/upgrade-guide-check.test.ts` (1290 cases) passes — NEXT.md structure preserved.
- [x] `tsc --noEmit` clean.
- [x] `npm run test:smoke` (changed-files vitest run) clean.
- [x] Side-effects review at `upgrades/side-effects/f8-remediator-skeleton.md` covers all 7 questions; reviewer-concurrence not required (no live consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)