### PR TITLE
feat(remediation): F-6 — ServerSupervisor + Remediator HMAC handshake (Tier-2)

### DIFF
--- a/src/lifeline/ServerSupervisor.ts
+++ b/src/lifeline/ServerSupervisor.ts
@@ -46,6 +46,59 @@ export interface SupervisorEvents {
   updateApplied: [targetVersion: string];
 }
 
+// ── F-6: Remediator ↔ ServerSupervisor handshake ─────────────────────
+//
+// Per v2 spec §A15 (partial-upgrade window) + v3 §3 (state-file taxonomy:
+// `.instar/state/supervisor-handshake.json` and `restart-requested.json`
+// extended with HMAC). The Remediator signs a `restart-requested` request
+// with the capability-context leaf key from F-1 RemediationKeyVault; the
+// supervisor verifies the HMAC before honouring the request and notifies
+// the Remediator once the restart cycle completes (so the attempt state
+// machine can advance to verify-phase).
+
+/**
+ * The signed payload a Remediator sends to the supervisor to request a
+ * planned restart. The HMAC covers the canonical serialization of
+ * `{requestId, runbookId, attemptId, blastRadius, requestedAt, monotonicTs,
+ * handshakeVersion}` using the Remediator's per-call capability leaf key
+ * (RemediationKeyVault.deriveLeafKey('capability', runbookId)).
+ */
+export interface RestartRequestedPayload {
+  requestId: string;
+  runbookId: string;
+  attemptId: string;
+  blastRadius: 'process' | 'machine' | 'fleet';
+  /** Wall-clock ms (Date.now()). Used for staleness rejection. */
+  requestedAt: number;
+  /** `process.hrtime.bigint()` at request issuance. Informational. */
+  monotonicTs: bigint;
+  /** Handshake protocol version the Remediator is speaking. */
+  handshakeVersion: number;
+  /** HMAC-SHA256 over canonical payload using the Remediator's capability leaf. */
+  hmac: Buffer;
+}
+
+/** Reply the supervisor returns from `handleRestartRequested`. */
+export interface RestartRequestedReply {
+  requestId: string;
+  accepted: boolean;
+  /** Machine-readable reason code, e.g. `'accepted'`, `'invalid-hmac'`,
+   *  `'stale'`, `'blast-radius-out-of-scope'`, `'handshake-version-mismatch'`. */
+  reason: string;
+  /** Supervisor's handshake protocol version (informational). */
+  supervisorHandshakeVersion: number;
+  /** Supervisor's build id (informational; A15 lag check). */
+  supervisorBuildId: string;
+}
+
+/** The Remediator instance interface the supervisor calls back into. */
+export interface RegisteredRemediator {
+  /** Called by supervisor after a planned restart completes. */
+  onRestartComplete: (req: { requestId: string }) => void;
+  /** Returns the leaf key the Remediator used to sign restart-requested. */
+  getCapabilityLeafKey: () => Buffer;
+}
+
 export class ServerSupervisor extends EventEmitter {
   private projectDir: string;
   private projectName: string;
@@ -98,6 +151,17 @@ export class ServerSupervisor extends EventEmitter {
   private sleepWakeDetector: SleepWakeDetector | null = null; // Detects short sleeps that gap-based detection misses
   private wakeTransitionUntil = 0; // Timestamp until which we're in a wake transition (lenient health checks)
   private readonly wakeTransitionMs = 60_000; // 60 seconds of lenient health checking after wake
+
+  // ── F-6 handshake state ────────────────────────────────────────────
+  /** Current handshake protocol version. Bump on any wire-format change. */
+  static readonly HANDSHAKE_PROTOCOL_VERSION = 1;
+  /** Max staleness of a restart-requested payload before it's rejected. */
+  static readonly RESTART_REQUEST_MAX_AGE_MS = 5 * 60_000;
+  private registeredRemediator: RegisteredRemediator | null = null;
+  /** Pending restart requests awaiting completion notification, keyed by requestId. */
+  private pendingRemediatorRequests = new Map<string, { requestId: string; runbookId: string; attemptId: string; }>();
+  /** Build id surfaced via handshake. Tests inject; production reads package.json. */
+  private supervisorBuildId: string = process.env.INSTAR_SUPERVISOR_BUILD_ID || 'unknown';
 
   constructor(options: {
     projectDir: string;
@@ -747,6 +811,10 @@ export class ServerSupervisor extends EventEmitter {
           this.consecutiveFailures = 0;
           this.consecutiveBindFailures = 0;
 
+          // F-6: notify any pending Remediator restart-requested entries
+          // that the planned restart has completed. Idempotent.
+          this.notifyPendingRemediatorRequestsOnHealthy();
+
           // If circuit breaker was tripped and we recovered, reset it
           if (this.circuitBroken) {
             console.log('[Supervisor] Server recovered after circuit breaker — resetting');
@@ -1000,6 +1068,227 @@ export class ServerSupervisor extends EventEmitter {
     } catch {
       return false;
     }
+  }
+
+  // ── F-6: Remediator handshake ───────────────────────────────────
+  //
+  // Per v2 spec §A15 + v3 §3. The Remediator registers itself, providing
+  // a `getCapabilityLeafKey()` callback so the supervisor can verify
+  // HMACs on `restart-requested` requests, and a `onRestartComplete`
+  // callback so the supervisor can notify the Remediator when a planned
+  // restart cycle finishes (advancing the attempt to verify-phase).
+  //
+  // Registration also writes `.instar/state/supervisor-handshake.json`
+  // so a freshly-spawned Remediator can detect the supervisor's
+  // handshake protocol version + build id without an in-process handle.
+  // The A15 partial-upgrade rule lives Remediator-side: a Remediator
+  // whose handshakeVersion is NEWER than the supervisor's must refuse to
+  // issue `restart-requested` and fall back to alert-only.
+
+  /**
+   * Register a Remediator instance for the handshake. Idempotent; calling
+   * twice with the same instance is a no-op. Calling with a different
+   * instance replaces the previous registration (last-writer-wins is
+   * fine because there is only ever one Remediator per process).
+   */
+  registerRemediator(remediator: RegisteredRemediator): void {
+    this.registeredRemediator = remediator;
+    this.writeSupervisorHandshakeFile();
+  }
+
+  /** Current handshake protocol version (instance accessor). */
+  getHandshakeProtocolVersion(): number {
+    return ServerSupervisor.HANDSHAKE_PROTOCOL_VERSION;
+  }
+
+  /** Build id used for the A15 partial-upgrade lag check. */
+  getSupervisorBuildId(): string {
+    return this.supervisorBuildId;
+  }
+
+  /** Tests inject; production callers should not need to set this. */
+  setSupervisorBuildId(buildId: string): void {
+    this.supervisorBuildId = buildId;
+    if (this.registeredRemediator) this.writeSupervisorHandshakeFile();
+  }
+
+  /**
+   * Receive a restart-requested from a Remediator. Verifies, in order:
+   *   1. A Remediator is registered.
+   *   2. Required fields are present and well-typed.
+   *   3. `handshakeVersion` matches the supervisor's (A15 rule).
+   *   4. `requestedAt` is within RESTART_REQUEST_MAX_AGE_MS of now.
+   *   5. `blastRadius` is in {process, machine}. Tier-2 refuses 'fleet'.
+   *   6. The HMAC verifies against the canonical payload using the
+   *      Remediator's capability leaf key.
+   *
+   * On accept, the request is tracked under `pendingRemediatorRequests`
+   * and a planned graceful restart is initiated. The Remediator's
+   * `onRestartComplete` callback fires once the supervisor sees the
+   * restart cycle finish (next healthy tick after a serverRestarting).
+   */
+  async handleRestartRequested(payload: RestartRequestedPayload): Promise<RestartRequestedReply> {
+    const supervisorBuildId = this.supervisorBuildId;
+    const supervisorHandshakeVersion = ServerSupervisor.HANDSHAKE_PROTOCOL_VERSION;
+    const requestId = (payload && typeof payload.requestId === 'string') ? payload.requestId : '';
+
+    const reject = (reason: string): RestartRequestedReply => ({
+      requestId,
+      accepted: false,
+      reason,
+      supervisorHandshakeVersion,
+      supervisorBuildId,
+    });
+
+    if (!this.registeredRemediator) {
+      return reject('no-remediator-registered');
+    }
+
+    if (!payload || typeof payload !== 'object') {
+      return reject('malformed-payload');
+    }
+    if (
+      typeof payload.requestId !== 'string' || !payload.requestId ||
+      typeof payload.runbookId !== 'string' || !payload.runbookId ||
+      typeof payload.attemptId !== 'string' || !payload.attemptId ||
+      typeof payload.blastRadius !== 'string' ||
+      typeof payload.requestedAt !== 'number' || !Number.isFinite(payload.requestedAt) ||
+      typeof payload.monotonicTs !== 'bigint' ||
+      typeof payload.handshakeVersion !== 'number' || !Number.isInteger(payload.handshakeVersion) ||
+      !Buffer.isBuffer(payload.hmac)
+    ) {
+      return reject('malformed-payload');
+    }
+
+    // A15: handshake-version mismatch. We accept ONLY exact equality.
+    // A Remediator running a newer handshake than the supervisor must
+    // fall back to alert-only (rejection is informative, not negotiation).
+    if (payload.handshakeVersion !== supervisorHandshakeVersion) {
+      return reject(
+        `handshake-version-mismatch: remediator=${payload.handshakeVersion} supervisor=${supervisorHandshakeVersion} ` +
+        `(A15 partial-upgrade rule — Remediator must fall back to alert-only)`,
+      );
+    }
+
+    // Staleness check — requestedAt must be within the window. Future
+    // timestamps are also rejected to bound clock-skew abuse.
+    const ageMs = Date.now() - payload.requestedAt;
+    if (ageMs > ServerSupervisor.RESTART_REQUEST_MAX_AGE_MS || ageMs < -ServerSupervisor.RESTART_REQUEST_MAX_AGE_MS) {
+      return reject(`stale: ageMs=${ageMs}`);
+    }
+
+    // Blast radius — Tier-2 supervisor handles process + machine restarts.
+    // 'fleet' is reserved for a future coordination-protocol surface and
+    // is refused by Tier-2 unconditionally.
+    if (payload.blastRadius !== 'process' && payload.blastRadius !== 'machine') {
+      return reject(`blast-radius-out-of-scope: ${payload.blastRadius}`);
+    }
+
+    // HMAC verification — use the Remediator's capability leaf key.
+    // Canonical payload format MUST be deterministic; see
+    // canonicalRestartRequestedBody() below.
+    let expected: Buffer;
+    try {
+      const key = this.registeredRemediator.getCapabilityLeafKey();
+      if (!Buffer.isBuffer(key) || key.length === 0) {
+        return reject('invalid-leaf-key');
+      }
+      const body = canonicalRestartRequestedBody(payload);
+      expected = crypto.createHmac('sha256', key).update(body).digest();
+    } catch (err) {
+      return reject(`hmac-compute-failed: ${(err as Error).message}`);
+    }
+
+    if (
+      expected.length !== payload.hmac.length ||
+      !crypto.timingSafeEqual(expected, payload.hmac)
+    ) {
+      return reject('invalid-hmac');
+    }
+
+    // Accepted. Track the pending request for completion notification,
+    // then initiate the planned restart. The graceful-restart path
+    // already emits `serverRestarting` and pre-sets maintenance wait via
+    // performGracefulRestart(); we wire the completion callback through
+    // the next healthy tick (see notifyPendingRemediatorRequestsOnHealthy).
+    this.pendingRemediatorRequests.set(payload.requestId, {
+      requestId: payload.requestId,
+      runbookId: payload.runbookId,
+      attemptId: payload.attemptId,
+    });
+
+    // Fire-and-forget restart; the request is already tracked and the
+    // completion callback fires on the next healthy tick.
+    this.maintenanceWaitStartedAt = Date.now();
+    void this.performGracefulRestart(`remediator:${payload.runbookId}:${payload.attemptId}`);
+
+    return {
+      requestId: payload.requestId,
+      accepted: true,
+      reason: 'accepted',
+      supervisorHandshakeVersion,
+      supervisorBuildId,
+    };
+  }
+
+  /**
+   * Notify any pending Remediator restart-requested entries that the
+   * server is healthy again. Called from the health-check loop after a
+   * serverRestarting → healthy transition. Safe to call repeatedly; each
+   * entry is removed after its callback fires so subsequent ticks are
+   * no-ops.
+   */
+  private notifyPendingRemediatorRequestsOnHealthy(): void {
+    if (this.pendingRemediatorRequests.size === 0) return;
+    if (!this.registeredRemediator) {
+      // Lost the registration mid-flight; drop the pending entries so we
+      // don't leak memory. The Remediator will time out attempt-side.
+      this.pendingRemediatorRequests.clear();
+      return;
+    }
+    for (const [, entry] of this.pendingRemediatorRequests) {
+      try {
+        this.registeredRemediator.onRestartComplete({ requestId: entry.requestId });
+      } catch (err) {
+        console.error(`[Supervisor] Remediator onRestartComplete threw: ${(err as Error).message}`);
+      }
+    }
+    this.pendingRemediatorRequests.clear();
+  }
+
+  /**
+   * Write the supervisor-handshake state file so a freshly-spawned
+   * Remediator (post-restart, post-crash, cross-process) can read the
+   * supervisor's protocol version + build id without an in-process
+   * handle. Best-effort; failure is logged and ignored — the
+   * Remediator's A15 fallback then trips, which is the correct fail-safe
+   * shape.
+   */
+  private writeSupervisorHandshakeFile(): void {
+    if (!this.stateDir) return;
+    try {
+      const stateSubdir = path.join(this.stateDir, 'state');
+      fs.mkdirSync(stateSubdir, { recursive: true });
+      const filePath = path.join(stateSubdir, 'supervisor-handshake.json');
+      const body = {
+        version: ServerSupervisor.HANDSHAKE_PROTOCOL_VERSION,
+        supervisorBuildId: this.supervisorBuildId,
+        writtenAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(filePath, JSON.stringify(body, null, 2));
+    } catch (err) {
+      console.error(`[Supervisor] Failed to write supervisor-handshake.json: ${(err as Error).message}`);
+    }
+  }
+
+  /** Test helper — surface pending-request count for assertions. */
+  getPendingRemediatorRequestCount(): number {
+    return this.pendingRemediatorRequests.size;
+  }
+
+  /** Test helper — simulate a healthy tick driving completion notifications. */
+  triggerHealthyTickForTests(): void {
+    this.notifyPendingRemediatorRequestsOnHealthy();
   }
 
   // ── Unhealthy handling ──────────────────────────────────────────
@@ -1422,4 +1711,66 @@ export function findBetterSqlite3Copies(nodeModulesRoot: string): BetterSqlite3C
     console.warn(`[Supervisor] findBetterSqlite3Copies: hit MAX_COPIES=${MAX_COPIES} cap under ${nodeModulesRoot} — additional copies will not be checked. If this is a real install layout (not pathological), raise the cap.`);
   }
   return found;
+}
+
+// ── F-6 handshake helpers ───────────────────────────────────────────
+
+/**
+ * Canonical, deterministic serialization of a restart-requested payload
+ * EXCLUDING the `hmac` field, used as the HMAC input on both sides of
+ * the handshake. Field order is fixed and lengths are length-prefixed
+ * so a malicious crafter cannot shift bytes across field boundaries.
+ *
+ * Format (network byte order, big-endian):
+ *   "instar-f6-restart-v1\0"          // 21-byte version tag
+ *   uint32 version                    // 4 bytes — handshakeVersion
+ *   uint8  blastRadiusTag             // 1 = process, 2 = machine, 3 = fleet
+ *   uint64 requestedAt (BE)           // wall-clock ms
+ *   uint64 monotonicTs (BE)           // hrtime ns
+ *   uint32 requestIdLen + requestId   // utf-8
+ *   uint32 runbookIdLen + runbookId   // utf-8
+ *   uint32 attemptIdLen + attemptId   // utf-8
+ *
+ * The tag byte for `blastRadius` ensures unknown future values cannot
+ * be silently re-cast to a known value at canonicalization time.
+ */
+export function canonicalRestartRequestedBody(payload: RestartRequestedPayload): Buffer {
+  const tag = Buffer.from('instar-f6-restart-v1\x00', 'utf-8');
+
+  const versionBuf = Buffer.alloc(4);
+  versionBuf.writeUInt32BE(payload.handshakeVersion >>> 0, 0);
+
+  let blastTag = 0;
+  if (payload.blastRadius === 'process') blastTag = 1;
+  else if (payload.blastRadius === 'machine') blastTag = 2;
+  else if (payload.blastRadius === 'fleet') blastTag = 3;
+  // Unknown values become 0 → HMAC mismatch on legitimate side, which is
+  // the intended fail-closed shape.
+  const blastBuf = Buffer.from([blastTag]);
+
+  const requestedAtBuf = Buffer.alloc(8);
+  requestedAtBuf.writeBigUInt64BE(BigInt(Math.max(0, Math.floor(payload.requestedAt))), 0);
+
+  const monoBuf = Buffer.alloc(8);
+  // monotonicTs is `bigint`; clamp non-negative for unsigned write.
+  const mono = payload.monotonicTs >= 0n ? payload.monotonicTs : 0n;
+  monoBuf.writeBigUInt64BE(mono, 0);
+
+  const writeStr = (s: string): Buffer => {
+    const body = Buffer.from(s, 'utf-8');
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(body.length, 0);
+    return Buffer.concat([len, body]);
+  };
+
+  return Buffer.concat([
+    tag,
+    versionBuf,
+    blastBuf,
+    requestedAtBuf,
+    monoBuf,
+    writeStr(payload.requestId),
+    writeStr(payload.runbookId),
+    writeStr(payload.attemptId),
+  ]);
 }

--- a/tests/unit/ServerSupervisor-handshake.test.ts
+++ b/tests/unit/ServerSupervisor-handshake.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for ServerSupervisor — F-6 Remediator ↔ Supervisor
+ * handshake. Per v2 spec §A15 (partial-upgrade lag rule), v3 §3 (state-
+ * file taxonomy: `supervisor-handshake.json` + HMAC-extended
+ * `restart-requested.json`), and v3 §9 (Tier-2 sequencing).
+ *
+ * Tests:
+ *  1. Valid signed restart-requested with matching HMAC → accepted.
+ *  2. Forged HMAC → rejected with `invalid-hmac`.
+ *  3. Stale request (requestedAt > 5 minutes ago) → rejected with `stale`.
+ *  4. blastRadius === 'fleet' → rejected with `blast-radius-out-of-scope`.
+ *  5. Handshake protocol version mismatch → rejected with A15 message.
+ *  6. onRestartComplete fires after the restart cycle completes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+// Mock child_process so spawn/execFile from the supervisor don't touch
+// the real shell. We never invoke a real tmux session in these tests.
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    spawnSync: vi.fn(() => ({ stdout: '', stderr: '', status: 0, signal: null, pid: 0, output: [] })),
+    execFileSync: vi.fn(() => ''),
+  };
+});
+
+vi.mock('../../src/core/Config.js', () => ({
+  detectTmuxPath: () => '/usr/bin/tmux',
+}));
+
+vi.mock('../../src/core/SleepWakeDetector.js', () => ({
+  SleepWakeDetector: vi.fn().mockImplementation(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+    on: vi.fn(),
+  })),
+}));
+
+// Import after mocks.
+import {
+  ServerSupervisor,
+  canonicalRestartRequestedBody,
+  type RestartRequestedPayload,
+  type RegisteredRemediator,
+} from '../../src/lifeline/ServerSupervisor.js';
+
+function createTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'supervisor-handshake-test-'));
+  fs.mkdirSync(path.join(dir, '.instar', 'state'), { recursive: true });
+  return dir;
+}
+
+function buildPayload(
+  key: Buffer,
+  overrides: Partial<RestartRequestedPayload> = {},
+): RestartRequestedPayload {
+  const base: Omit<RestartRequestedPayload, 'hmac'> = {
+    requestId: overrides.requestId ?? crypto.randomUUID(),
+    runbookId: overrides.runbookId ?? 'supervisor-preflight',
+    attemptId: overrides.attemptId ?? crypto.randomUUID(),
+    blastRadius: overrides.blastRadius ?? 'machine',
+    requestedAt: overrides.requestedAt ?? Date.now(),
+    monotonicTs: overrides.monotonicTs ?? process.hrtime.bigint(),
+    handshakeVersion: overrides.handshakeVersion ?? ServerSupervisor.HANDSHAKE_PROTOCOL_VERSION,
+  };
+  const draft = { ...base, hmac: Buffer.alloc(0) } as RestartRequestedPayload;
+  const body = canonicalRestartRequestedBody(draft);
+  const hmac = crypto.createHmac('sha256', key).update(body).digest();
+  return { ...draft, hmac };
+}
+
+describe('ServerSupervisor F-6 handshake', () => {
+  let tmpDir: string;
+  let projectDir: string;
+  let supervisor: ServerSupervisor;
+  let leafKey: Buffer;
+  let remediator: RegisteredRemediator & {
+    onRestartComplete: ReturnType<typeof vi.fn>;
+    getCapabilityLeafKey: ReturnType<typeof vi.fn>;
+  };
+  let performGracefulRestartSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+    projectDir = tmpDir;
+    leafKey = crypto.randomBytes(32);
+    supervisor = new ServerSupervisor({
+      projectDir,
+      projectName: 'test-agent',
+      port: 0,
+      stateDir: path.join(tmpDir, '.instar'),
+    });
+    remediator = {
+      onRestartComplete: vi.fn(),
+      getCapabilityLeafKey: vi.fn(() => leafKey),
+    };
+    // Stop the supervisor from actually attempting a tmux restart when
+    // a request is accepted; the handshake itself is what we're testing.
+    performGracefulRestartSpy = vi.spyOn(supervisor, 'performGracefulRestart').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    performGracefulRestartSpy.mockRestore();
+    if (fs.existsSync(tmpDir)) {
+      SafeFsExecutor.safeRmSync(tmpDir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/ServerSupervisor-handshake.test.ts',
+      });
+    }
+  });
+
+  it('accepts a validly signed restart-requested with matching HMAC', async () => {
+    supervisor.registerRemediator(remediator);
+
+    const payload = buildPayload(leafKey);
+    const reply = await supervisor.handleRestartRequested(payload);
+
+    expect(reply.accepted).toBe(true);
+    expect(reply.reason).toBe('accepted');
+    expect(reply.requestId).toBe(payload.requestId);
+    expect(reply.supervisorHandshakeVersion).toBe(ServerSupervisor.HANDSHAKE_PROTOCOL_VERSION);
+    expect(performGracefulRestartSpy).toHaveBeenCalledTimes(1);
+    expect(supervisor.getPendingRemediatorRequestCount()).toBe(1);
+  });
+
+  it('rejects a payload with a forged HMAC', async () => {
+    supervisor.registerRemediator(remediator);
+
+    const wrongKey = crypto.randomBytes(32);
+    const payload = buildPayload(wrongKey);
+    // Bypass the canonical helper so the inner body matches what we sent,
+    // but the HMAC is from the wrong key.
+
+    const reply = await supervisor.handleRestartRequested(payload);
+
+    expect(reply.accepted).toBe(false);
+    expect(reply.reason).toBe('invalid-hmac');
+    expect(performGracefulRestartSpy).not.toHaveBeenCalled();
+    expect(supervisor.getPendingRemediatorRequestCount()).toBe(0);
+  });
+
+  it('rejects a stale request (requestedAt > 5 minutes ago)', async () => {
+    supervisor.registerRemediator(remediator);
+
+    const sixMinutesAgo = Date.now() - 6 * 60_000;
+    const payload = buildPayload(leafKey, { requestedAt: sixMinutesAgo });
+
+    const reply = await supervisor.handleRestartRequested(payload);
+
+    expect(reply.accepted).toBe(false);
+    expect(reply.reason).toMatch(/^stale:/);
+    expect(performGracefulRestartSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects blastRadius === 'fleet' as out-of-scope for Tier-2", async () => {
+    supervisor.registerRemediator(remediator);
+
+    const payload = buildPayload(leafKey, { blastRadius: 'fleet' });
+
+    const reply = await supervisor.handleRestartRequested(payload);
+
+    expect(reply.accepted).toBe(false);
+    expect(reply.reason).toBe('blast-radius-out-of-scope: fleet');
+    expect(performGracefulRestartSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects handshake-protocol version mismatch with the A15 message', async () => {
+    supervisor.registerRemediator(remediator);
+
+    const payload = buildPayload(leafKey, {
+      handshakeVersion: ServerSupervisor.HANDSHAKE_PROTOCOL_VERSION + 1,
+    });
+
+    const reply = await supervisor.handleRestartRequested(payload);
+
+    expect(reply.accepted).toBe(false);
+    expect(reply.reason).toContain('handshake-version-mismatch');
+    expect(reply.reason).toContain('A15');
+    expect(reply.reason).toContain('alert-only');
+    expect(performGracefulRestartSpy).not.toHaveBeenCalled();
+  });
+
+  it('fires onRestartComplete after the restart cycle completes', async () => {
+    supervisor.registerRemediator(remediator);
+
+    const payload = buildPayload(leafKey);
+    const reply = await supervisor.handleRestartRequested(payload);
+    expect(reply.accepted).toBe(true);
+    expect(remediator.onRestartComplete).not.toHaveBeenCalled();
+
+    // Simulate the supervisor seeing a healthy tick after the restart.
+    supervisor.triggerHealthyTickForTests();
+
+    expect(remediator.onRestartComplete).toHaveBeenCalledTimes(1);
+    expect(remediator.onRestartComplete).toHaveBeenCalledWith({ requestId: payload.requestId });
+    expect(supervisor.getPendingRemediatorRequestCount()).toBe(0);
+
+    // Subsequent healthy ticks must be no-ops (idempotency guard).
+    supervisor.triggerHealthyTickForTests();
+    expect(remediator.onRestartComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when no Remediator is registered', async () => {
+    const payload = buildPayload(leafKey);
+    const reply = await supervisor.handleRestartRequested(payload);
+
+    expect(reply.accepted).toBe(false);
+    expect(reply.reason).toBe('no-remediator-registered');
+  });
+
+  it('writes supervisor-handshake.json on registration', () => {
+    supervisor.setSupervisorBuildId('v0.99.0-test');
+    supervisor.registerRemediator(remediator);
+
+    const filePath = path.join(tmpDir, '.instar', 'state', 'supervisor-handshake.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const body = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(body.version).toBe(ServerSupervisor.HANDSHAKE_PROTOCOL_VERSION);
+    expect(body.supervisorBuildId).toBe('v0.99.0-test');
+    expect(typeof body.writtenAt).toBe('string');
+  });
+
+  it('rejects a malformed payload (missing fields)', async () => {
+    supervisor.registerRemediator(remediator);
+    const bogus = { requestId: 'r1' } as unknown as RestartRequestedPayload;
+    const reply = await supervisor.handleRestartRequested(bogus);
+    expect(reply.accepted).toBe(false);
+    expect(reply.reason).toBe('malformed-payload');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -51,6 +51,25 @@ No consumers in this PR. The dispatcher (F-8 Tier-2 wiring) and the un-quarantin
 
 Side-effects review: `upgrades/side-effects/f5-trust-elevation-source.md`.
 
+### feat(remediation): F-6 — ServerSupervisor ↔ Remediator handshake (Tier-2)
+
+Extends `src/lifeline/ServerSupervisor.ts` with the HMAC-signed Remediator handshake described in `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (§A15 partial-upgrade rule, carried-forward §Supervisor coordination) and `docs/specs/SELF-HEALING-REMEDIATOR-V3-CONSOLIDATED-SPEC.md` (§3 state-file taxonomy, §9 Tier-2 sequencing). After this PR ages ≥ 7 days on main (A15 lag rule), wrapper PRs W-2..W-4 can begin to merge.
+
+New public surface on `ServerSupervisor`:
+
+- Static `HANDSHAKE_PROTOCOL_VERSION = 1`.
+- Types: `RestartRequestedPayload`, `RestartRequestedReply`, `RegisteredRemediator`.
+- `registerRemediator(remediator)` — writes `<stateDir>/state/supervisor-handshake.json` (`{version, supervisorBuildId, writtenAt}`) so cross-process Remediators can detect the supervisor's protocol version without an in-process handle.
+- `handleRestartRequested(payload)` — verifies in order: registration → required-field shape → handshake-version equality (A15) → 5-minute staleness window → blastRadius allowlist (`process | machine` only; `fleet` is refused for Tier-2) → HMAC via `crypto.timingSafeEqual` against the Remediator's capability-context leaf key (F-1 RemediationKeyVault). On accept, tracks the request and initiates the existing `performGracefulRestart` cycle.
+- Pending-request notification fires `remediator.onRestartComplete({requestId})` on the next healthy tick after a serverRestarting → healthy transition (idempotent).
+- Exported helper `canonicalRestartRequestedBody(payload)` — deterministic length-prefixed byte serialization that both sides use as HMAC input. Co-located in the supervisor file so the wire format has one canonical owner.
+
+The existing `private preflightSelfHeal()` is unchanged in behavior (W-2 will wrap it). The existing `restart-requested.json` file path is unchanged in this PR — the in-process handshake is the Tier-2 canonical surface; HMAC migration for the file shape is deferred to a follow-up alongside the AutoUpdater path.
+
+9 new unit tests in `tests/unit/ServerSupervisor-handshake.test.ts`: accept on valid HMAC; reject forged HMAC; reject stale request (> 5 min); reject `blastRadius: 'fleet'`; reject handshake-version mismatch with the A15 message; `onRestartComplete` fires once after the healthy tick (and only once on subsequent ticks); reject when no Remediator registered; `supervisor-handshake.json` written on registration; reject malformed payload. Existing supervisor preflight + serverDown-rate-limit tests unaffected.
+
+Side-effects review: `upgrades/side-effects/f6-supervisor-handshake.md`.
+
 ### feat(remediation): W-1 — node-abi-mismatch runbook + NativeModuleHealer.invokeFromRemediator (FINAL Tier-1 PR)
 
 Ships the first dispatchable runbook for the F-8 Remediator and the matching surface entry-point per `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (§A6, §A9, §A21, §A28, §A36, §A45, §A55, §A57). After this PR, Tier-1 is complete and the Remediator is dispatchable end-to-end via test fixtures.

--- a/upgrades/side-effects/f6-supervisor-handshake.md
+++ b/upgrades/side-effects/f6-supervisor-handshake.md
@@ -1,0 +1,234 @@
+# Side-Effects Review — F-6 ServerSupervisor handshake
+
+**Version / slug:** `f6-supervisor-handshake`
+**Date:** 2026-05-13
+**Author:** echo (instar-developing agent)
+**Second-pass reviewer:** not required
+
+## Summary of the change
+
+Extends `src/lifeline/ServerSupervisor.ts` with the Remediator ↔ Supervisor
+handshake described in `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md`
+(§A15 partial-upgrade rule, carried forward from v1 §Supervisor
+coordination) and `docs/specs/SELF-HEALING-REMEDIATOR-V3-CONSOLIDATED-SPEC.md`
+(§3 state-file taxonomy: `supervisor-handshake.json`, HMAC-extended
+`restart-requested.json`; §9 Tier-2 sequencing). Adds:
+
+- `ServerSupervisor.HANDSHAKE_PROTOCOL_VERSION = 1` (static).
+- `RestartRequestedPayload`, `RestartRequestedReply`, `RegisteredRemediator`
+  public types.
+- `ServerSupervisor.registerRemediator(remediator)` — writes
+  `<stateDir>/state/supervisor-handshake.json` (`{version,
+  supervisorBuildId, writtenAt}`).
+- `ServerSupervisor.handleRestartRequested(payload)` — verifies HMAC,
+  handshake-version, staleness (5-minute window), and blastRadius
+  (`process | machine` only — `fleet` is refused for Tier-2). On accept,
+  tracks the request and initiates a `performGracefulRestart` cycle.
+- `notifyPendingRemediatorRequestsOnHealthy()` — fires
+  `remediator.onRestartComplete({requestId})` once the next healthy tick
+  lands after a serverRestarting → healthy transition.
+- `canonicalRestartRequestedBody(payload)` exported helper —
+  deterministic byte serialization used as HMAC input on both sides.
+
+The existing `private preflightSelfHeal()` is unchanged; W-2 will wrap
+it. The existing `restart-requested.json` flag path is unchanged (the
+in-process handshake is the canonical F-6 surface; the file-based flag
+remains for AutoUpdater and is co-owned per v3 §3).
+
+Files touched: `src/lifeline/ServerSupervisor.ts`,
+`tests/unit/ServerSupervisor-handshake.test.ts` (new, 9 tests),
+`upgrades/NEXT.md`, this artifact.
+
+## Decision-point inventory
+
+- `handleRestartRequested` — **add** — verifies signed restart requests.
+  This holds blocking authority: a rejection refuses to restart the
+  server. Each rejection branch is a deterministic check on
+  cryptographic state (HMAC, monotonic clock, declared protocol
+  version, declared blast radius), NOT a heuristic message classifier.
+  See section 4 for signal-vs-authority analysis.
+- `registerRemediator` — **add** — idempotent registration; no
+  authority. Side-effects writes `supervisor-handshake.json`.
+- `notifyPendingRemediatorRequestsOnHealthy` — **add** — fires
+  callbacks. Idempotent (entries deleted after first call). No
+  authority.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- `blastRadius: 'fleet'` is rejected. Tier-2's ServerSupervisor only
+  handles `process` and `machine` restarts. A fleet-wide restart is the
+  coordination-protocol surface's responsibility, not the supervisor's.
+  Refusal is by design and matches v3 §9 Tier-3 deferral; Remediator
+  must not issue fleet-scope restart-requested in Tier-2 anyway.
+- Clock skew > 5 minutes (in either direction) rejects valid requests.
+  This is the documented staleness window per the F-6 spec; widening it
+  would weaken replay defense. Operators with persistent clock skew
+  receive `stale: ageMs=…` in the reject reason; the Remediator
+  surfaces this in audit + alerts via the higher-level dispatch path.
+- Handshake version mismatch is exact-equality only. A future v2
+  protocol must be negotiated by bumping `HANDSHAKE_PROTOCOL_VERSION`
+  on both sides; legacy Remediators speaking v1 will be rejected. This
+  is the A15 contract — partial-upgrade DoS is prevented by refusing,
+  not by best-effort interpolation.
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- The `monotonicTs` field is informational; the HMAC covers it but the
+  supervisor does NOT enforce monotonic ordering across requests. A
+  per-Remediator monotonic counter would close the residual replay
+  window inside the 5-minute staleness budget. F-8 (rest) owns the
+  per-surface monotonic counter (A42); F-6 deliberately punts.
+- The supervisor accepts only the registered Remediator's leaf key. If
+  the Remediator's RemediationKeyVault is rotated mid-flight, an
+  in-flight request signed with the old leaf will fail HMAC
+  verification. This is expected — the overlap window is owned at the
+  vault rotation layer (per F-1's `rotateContext` contract).
+- `RegisteredRemediator.getCapabilityLeafKey()` is called per
+  verification — the supervisor does not cache. This is intentional
+  (lets the Remediator rotate without re-registration) but pushes a
+  small constant cost onto each call. Negligible at expected throughput
+  (≤ 1 restart-requested per process per ~24h per A7 cross-process cap).
+- File-based `restart-requested.json` path is unchanged in this PR.
+  Adding HMAC to the file shape is described in v3 §9 ("HMAC required on
+  ANY plannedRestart:true post-F-6"); the in-process handshake is the
+  Tier-2 canonical surface and file-shape HMAC migration tracks under
+  the AutoUpdater path, not F-6 proper. NEXT.md documents the gap.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. F-6 lives in `src/lifeline/ServerSupervisor.ts` because the
+supervisor is the only authority that can request a tmux-session
+restart safely. The handshake protocol surface is a thin layer on top
+of the supervisor's existing `performGracefulRestart()`; it does NOT
+re-implement restart logic, doesn't reach into runbook internals, and
+doesn't speak any domain vocabulary above
+`{requestId, runbookId, attemptId, blastRadius}`.
+
+The `canonicalRestartRequestedBody()` exported helper deliberately
+lives at the bottom of the same file so the wire format has one
+canonical owner — both the supervisor's verify path and the
+Remediator's sign path (in F-8 rest) call the same function. Cross-file
+divergence is the most common HMAC-protocol bug; co-locating prevents
+it.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [x] Yes — but the logic is a smart gate with full conversational context.
+- [ ] Yes, with brittle logic — STOP.
+
+`handleRestartRequested` is a blocking gate. Each rejection condition
+is a deterministic check on cryptographic + structural state, not a
+heuristic message classifier:
+
+1. HMAC verification via `crypto.timingSafeEqual` — pure crypto.
+2. Handshake-version equality — integer compare.
+3. `requestedAt` staleness — wall-clock arithmetic on a signed field.
+4. `blastRadius` allowlist — string-set membership on a signed field.
+5. Required-field shape check — typeof guards.
+
+Every gated field is HMAC-covered by `canonicalRestartRequestedBody()`,
+so an attacker who shifts any field invalidates the signature. The
+gate has the FULL context needed to decide — the canonical body IS the
+context — and the decision is reproducible. This matches the
+"signal-vs-authority" contract: the gate that holds blocking authority
+has the full structured payload, not a free-text excerpt.
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **`performGracefulRestart`:** `handleRestartRequested` calls the
+  existing method on accept. Maintenance wait is pre-set so existing
+  `handleUnhealthy`/serverDown suppression behaves as it does for
+  AutoUpdater-driven restarts.
+- **`restart-requested.json` file path:** Untouched. Both the file path
+  (AutoUpdater) and the in-process path (Remediator) trigger the same
+  `performGracefulRestart`. The two paths are independent and cannot
+  race destructively — `performGracefulRestart` is idempotent at the
+  tmux-session level.
+- **Pending-request notification:** Wired into the existing healthy-
+  tick branch of the health check loop. Idempotent (clears the map
+  after firing). If `onRestartComplete` throws, the supervisor logs and
+  continues — a faulty Remediator callback cannot wedge the supervisor.
+- **`debug-restart-request.json`:** Unrelated path; doctor-session
+  HMAC uses a different secret (`setDoctorSessionSecret`) and a
+  different file. No interaction.
+- **State-file: `supervisor-handshake.json`:** Newly written by
+  `registerRemediator` + `setSupervisorBuildId`. Per v3 §3 it is NOT
+  backed up and NOT git-synced. The path matches v3 §3 verbatim.
+- **`RemediationKeyVault` (F-1):** F-6 takes the leaf key from the
+  registered Remediator via callback, NOT directly from the vault.
+  This keeps the supervisor decoupled from F-1's API surface; the
+  Remediator (which owns the vault lifecycle) injects the key. If F-1
+  rotates the context, the next registration / next call sees the new
+  key.
+
+## 6. External surfaces
+
+**Does this change anything visible to other agents, other users, other systems?**
+
+- **State file:** `<stateDir>/state/supervisor-handshake.json` (new).
+  JSON `{version, supervisorBuildId, writtenAt}`. World-readable by
+  default (same as sibling files in the same dir). No secrets in the
+  body.
+- **Public types:** `RestartRequestedPayload`,
+  `RestartRequestedReply`, `RegisteredRemediator`,
+  `canonicalRestartRequestedBody()` exported from
+  `src/lifeline/ServerSupervisor.ts`. These are stable API surfaces
+  that F-8-rest will consume; bump `HANDSHAKE_PROTOCOL_VERSION` on any
+  wire-format change.
+- **Events:** No new EventEmitter events. The existing
+  `serverRestarting` event still fires from `performGracefulRestart`.
+  `onRestartComplete` is delivered via callback, not event, because it
+  is a per-request notification with a `requestId` correlator (events
+  fan out; callbacks correlate).
+- **No telegram, slack, or external API calls** added.
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+`git revert` on the F-6 PR removes the surface. No data migration:
+
+- `supervisor-handshake.json` is regenerated on next registration; if
+  no consumer registers (post-revert state), the file is stale but inert.
+- No keychain or vault state is touched. F-1 vault is untouched.
+- No restart-requested.json or other state-file shape changes (file
+  shape additions are deferred to a follow-up per §2 above).
+- The F-6 surface is currently uncalled in production code (no
+  Remediator instance calls `registerRemediator` on main yet). Revert
+  is safe at any point before the wrapper-PR series ships.
+
+The A15 7-day age rule is what bounds the rollback risk for downstream
+wrappers: a wrapper that depends on F-6 must wait until F-6 has been
+on main + auto-updated for 7 days before merging, so a revert window
+of < 7 days has zero downstream consumers to break.
+
+---
+
+## Spec anchor
+
+This change implements:
+- **v2 §A15** (partial-upgrade window — supervisor handshake lag rule),
+- **v2 carried-forward §Supervisor coordination** (HMAC-signed
+  restart-requested),
+- **v2 §A20** (key segregation — the supervisor verifies HMACs against
+  the capability-context leaf, not the legacy `~/.instar/agent.key`),
+- **v3 §3** (state-file taxonomy — `supervisor-handshake.json`,
+  `restart-requested.json` co-ownership),
+- **v3 §9** (Tier-2 sequencing — F-6 unblocks W-2..W-4 after the 7-day
+  age requirement).


### PR DESCRIPTION
## Summary

Extends `src/lifeline/ServerSupervisor.ts` with the HMAC-signed Remediator handshake per `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A15 (carried forward from v1 §Supervisor coordination) and v3 §3 / §9. After this PR ages ≥ 7 days on main (A15 lag rule), wrapper PRs W-2..W-4 can begin to merge.

New public surface on `ServerSupervisor`:
- Static `HANDSHAKE_PROTOCOL_VERSION = 1`
- Types `RestartRequestedPayload`, `RestartRequestedReply`, `RegisteredRemediator`
- `registerRemediator(remediator)` — writes `supervisor-handshake.json` per v3 §3
- `handleRestartRequested(payload)` — verifies registration, shape, A15 handshake version, 5-min staleness, blast-radius allowlist (`process|machine` only; `fleet` refused for Tier-2), and HMAC via `crypto.timingSafeEqual` against the Remediator's capability-context leaf key
- `onRestartComplete` fires once per request on the next healthy tick after a restart cycle completes
- Exported `canonicalRestartRequestedBody(payload)` — deterministic length-prefixed byte serialization (single owner of the wire format)

The existing private `preflightSelfHeal()` is unchanged in behavior; W-2 will wrap it. The `restart-requested.json` file path is unchanged in this PR — the in-process handshake is the Tier-2 canonical surface.

Side-effects review: [`upgrades/side-effects/f6-supervisor-handshake.md`](https://github.com/JKHeadley/instar/blob/f6-supervisor-handshake/upgrades/side-effects/f6-supervisor-handshake.md).

## Test plan

- [x] 9 unit tests in `tests/unit/ServerSupervisor-handshake.test.ts` pass (valid HMAC accept; forged HMAC reject; stale-request reject; `fleet` blast-radius reject; A15 version-mismatch reject; `onRestartComplete` fires once after healthy tick; no-remediator reject; handshake file written; malformed payload reject)
- [x] Existing `server-supervisor-preflight` + `server-down-notification-rate-limit` + `graceful-updates-phase1` + `find-better-sqlite3-copies` tests still pass (32/32 in smoke tier)
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run check:pre-push-gate` clean
- [x] `instar-dev-precommit` gate verified trace + artifact + spec convergence + ELI16

🤖 Generated with [Claude Code](https://claude.com/claude-code)