### PR TITLE
fix(server): File Viewer extends never-editable to .instar/jobs/instar/

### DIFF
--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1498,7 +1498,7 @@ The user has been talking to you (possibly for days). A generic greeting like "H
 - **Generate a file link**: \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/api/files/link?path=.claude/CLAUDE.md"\`
 - **Download a file**: \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/api/files/download?path=.claude/CLAUDE.md" -O\`
 - **Default config**: Browsing and editing enabled for the entire project directory (\`./\`) by default.
-- **Never editable**: \`.claude/hooks/\`, \`.claude/scripts/\`, \`node_modules/\` are always read-only regardless of config.
+- **Never editable**: \`.claude/hooks/\`, \`.claude/scripts/\`, \`node_modules/\`, \`.instar/jobs/instar/\` are always read-only regardless of config.
 `;
       // Insert after Dashboard section
       const dashboardIdx = content.indexOf('**Dashboard**');

--- a/src/server/fileRoutes.ts
+++ b/src/server/fileRoutes.ts
@@ -188,6 +188,13 @@ const NEVER_EDITABLE_PREFIXES = [
   '.claude/hooks/',
   '.claude/scripts/',
   'node_modules/',
+  // INSTAR-JOBS-AS-AGENTMD spec §Decision Points: the .instar/jobs/instar/
+  // namespace is owned by the update process; the Dashboard editor MUST NOT
+  // permit edits here. Operators who want to customize a shipped default
+  // must Fork it (writes to .instar/jobs/user/ via the override flow);
+  // direct edits to instar/ would be overwritten on next update and risk
+  // breaking the signed lock-file's body-hash verification.
+  '.instar/jobs/instar/',
 ];
 
 function isNeverEditable(relativePath: string): boolean {

--- a/tests/e2e/file-viewer-e2e.test.ts
+++ b/tests/e2e/file-viewer-e2e.test.ts
@@ -732,6 +732,14 @@ describe('E2E: Dashboard File Viewer', () => {
       expect(res.body.error).toContain('never editable');
     });
 
+    it('rejects editablePaths targeting .instar/jobs/instar/ (jobs-as-agentmd update-managed namespace)', async () => {
+      const res = await request(baseUrl, 'PATCH', '/api/files/config', {
+        editablePaths: ['.instar/jobs/instar/'],
+      }, { 'x-instar-request': '1' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('never editable');
+    });
+
     it('rejects non-array allowedPaths', async () => {
       const res = await request(baseUrl, 'PATCH', '/api/files/config', {
         allowedPaths: 'not-an-array',

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -5,6 +5,10 @@ note (`upgrades/<version>.md`) at release-cut time.
 
 ---
 
+### fix(server): File Viewer extends never-editable to .instar/jobs/instar/
+
+The Dashboard file editor's never-editable list now includes `.instar/jobs/instar/`. Per INSTAR-JOBS-AS-AGENTMD spec §Decision Points: that namespace is owned by the update process and any direct edit would (a) be overwritten on next update and (b) break the body-hash verification. Operators who want to customize a shipped default use the override flow (fork to `.instar/jobs/user/`). The CLAUDE.md doc string emitted by PostUpdateMigrator is updated to list the new entry alongside `.claude/hooks/`, `.claude/scripts/`, `node_modules/`. One new e2e test case in `tests/e2e/file-viewer-e2e.test.ts`.
+
 ### test(release): npm-pack smoke test for shipped templates + bundled public key
 
 New integration test asserts the published tarball contains ≥14 prompt-type default templates, the source-tree and dist/-copied release public keys, and either a real signed lock-file or a clean absence (no malformed placeholders). Closes the INSTAR-JOBS-AS-AGENTMD spec §Security Model threat row "Build pipeline: source-tree templates not packaged."

--- a/upgrades/side-effects/file-viewer-jobs-instar-never-editable.md
+++ b/upgrades/side-effects/file-viewer-jobs-instar-never-editable.md
@@ -1,0 +1,41 @@
+# Side-effects review — File Viewer extends never-editable to .instar/jobs/instar/
+
+## What changed
+
+Two-line spec compliance item from INSTAR-JOBS-AS-AGENTMD §Decision Points:
+
+- `src/server/fileRoutes.ts:NEVER_EDITABLE_PREFIXES` adds `.instar/jobs/instar/`. Any `PATCH /api/files/config` attempt to declare an `editablePath` under that prefix is rejected with HTTP 400 + "never editable" error. Direct save attempts on a file under that path are rejected the same way.
+- Migrator-emitted CLAUDE.md doc string (`PostUpdateMigrator.ts` line 1501) updated to list `.instar/jobs/instar/` alongside the existing never-editable namespaces.
+
+## Why
+
+The `.instar/jobs/instar/` namespace is owned by the update process and signed against the bundled lock-file. A Dashboard editor that lets the operator edit a default's body would (a) be overwritten on next update, (b) break the body-hash verification, and (c) bypass the spec's intended override flow (fork to `.instar/jobs/user/` via the Override action).
+
+## Side-effects review
+
+### 1. Over-block / under-block
+
+- **Over-block:** none for users — the override flow is the documented path for customizing a default. Hand-edits in the file viewer were never useful here (they'd revert on update).
+- **Under-block:** the prefix check is exact-startswith. A path like `.instar/jobs/instar.lock.json` is NOT under `.instar/jobs/instar/` (different filename), so the lock-file itself remains read-accessible. That's correct: the lock-file is JSON that the operator may want to view for debugging.
+
+### 2. Level-of-abstraction fit
+
+One entry in a closed-set array. Zero new code paths.
+
+### 3. Signal-vs-authority compliance
+
+`NEVER_EDITABLE_PREFIXES` is the authority for "what can be edited via the Dashboard." Adding to the list strengthens, not weakens, the structural property.
+
+### 4. Interactions
+
+- **Phase 2 installBuiltinJobs** — already writes `.instar/jobs/instar/<slug>.md` on init + update; the never-editable list is the matching read-only enforcement.
+- **Phase 4 Dashboard UI rewrite (future)** — the future override/unfork UI lives at a different path; not affected by this change.
+- **File Viewer config UI** — config save endpoint already rejects never-editable prefixes; this addition is automatically enforced there.
+
+### 5. Rollback cost
+
+Trivial. Remove one line + revert one CLAUDE.md doc-string line.
+
+## Test coverage
+
+`tests/e2e/file-viewer-e2e.test.ts` adds one case in the existing "rejects editablePaths targeting <never-editable>" cluster — same shape as the `node_modules/` test. The pre-existing file-viewer-e2e suite covers the read/write enforcement that the new prefix automatically inherits.


### PR DESCRIPTION
## Summary

Per INSTAR-JOBS-AS-AGENTMD spec §Decision Points. The `.instar/jobs/instar/` namespace is owned by the update process; direct Dashboard edits would be overwritten on next update AND break body-hash verification. Operators use the override flow (fork to `.instar/jobs/user/`) instead.

One new e2e test case.

## Test plan

- [x] Lint + type-check pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)