### PR TITLE
feat(scheduler): migration telemetry — invariant 8

### DIFF
--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -31,6 +31,8 @@ import { installBuiltinSkills } from '../commands/init.js';
 import { installBuiltinJobs } from '../scheduler/InstallBuiltinJobs.js';
 import { jobsMigrate } from '../commands/jobMigrate.js';
 import { snapshotUserNamespace, verifyMigrationInvariants } from '../scheduler/MigrationInvariants.js';
+import { appendMigrationEvent, normalizePerEntryAction, type MigrationEvent } from '../scheduler/MigrationLedger.js';
+import { randomUUID } from 'node:crypto';
 import {
   ELIGIBILITY_SCHEMA_SQL,
   ELIGIBILITY_SCHEMA_SQL_SHA256,
@@ -385,6 +387,8 @@ export class PostUpdateMigrator {
    *   #8 telemetry — outcome is appended to result.upgraded/errors.
    */
   private autoMigrateLegacyJobsJson(result: MigrationResult): void {
+    const runId = randomUUID();
+    const startedAt = new Date().toISOString();
     try {
       const stateDir = this.config.stateDir;
       const jobsJsonPath = path.join(stateDir, 'jobs.json');
@@ -419,6 +423,7 @@ export class PostUpdateMigrator {
       const preMigrationUserSnapshot = snapshotUserNamespace(stateDir);
 
       const packageRoot = path.resolve(__dirname, '..', '..');
+      const instarVersion = this.readBundledInstarVersion(packageRoot);
       const outcome = jobsMigrate({
         agentStateDir: stateDir,
         packageRoot,
@@ -458,11 +463,71 @@ export class PostUpdateMigrator {
         if (outcome.backupPath) {
           result.upgraded.push(`legacy jobs.json migration: backup at ${path.basename(outcome.backupPath)}`);
         }
+        // Spec invariant 8: telemetry write is the LAST action of a
+        // successful migration. Append the migration.completed event.
+        this.appendMigrationTelemetry({
+          kind: 'migration.completed',
+          runId,
+          startedAt,
+          completedAt: new Date().toISOString(),
+          trigger: 'post-update',
+          perEntry: outcome.perEntry.map((e) => ({
+            slug: e.slug,
+            action: normalizePerEntryAction(e.action),
+            reason: e.reason,
+          })),
+          backupPath: outcome.backupPath,
+          instarVersion,
+        });
       } else if (outcome.status === 'aborted') {
         result.errors.push(`legacy jobs.json migration: aborted — ${outcome.errors.join('; ')}`);
+        this.appendMigrationTelemetry({
+          kind: 'migration.aborted',
+          runId,
+          startedAt,
+          completedAt: new Date().toISOString(),
+          trigger: 'post-update',
+          perEntry: outcome.perEntry.map((e) => ({
+            slug: e.slug,
+            action: normalizePerEntryAction(e.action),
+            reason: e.reason,
+          })),
+          abortReason: outcome.errors.join('; '),
+          instarVersion,
+        });
       }
     } catch (err) {
       result.errors.push(`legacy jobs.json migration: ${err instanceof Error ? err.message : String(err)}`);
+      this.appendMigrationTelemetry({
+        kind: 'migration.aborted',
+        runId,
+        startedAt,
+        completedAt: new Date().toISOString(),
+        trigger: 'post-update',
+        perEntry: [],
+        abortReason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Read the installed package's version, for the migration event's
+   *  `instarVersion` field. Best-effort — returns undefined on failure. */
+  private readBundledInstarVersion(packageRoot: string): string | undefined {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8'));
+      return typeof pkg.version === 'string' ? pkg.version : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Best-effort telemetry write. Missing telemetry is degradation, not a
+   *  release-blocker, so failures are swallowed. */
+  private appendMigrationTelemetry(event: MigrationEvent): void {
+    try {
+      appendMigrationEvent(this.config.stateDir, event);
+    } catch {
+      // @silent-fallback-ok — telemetry is non-load-bearing
     }
   }
 

--- a/src/scheduler/MigrationLedger.ts
+++ b/src/scheduler/MigrationLedger.ts
@@ -1,0 +1,147 @@
+/**
+ * MigrationLedger — append-only telemetry writer for migration runs.
+ *
+ * Per INSTAR-JOBS-AS-AGENTMD spec §Seamless Migration Guarantee invariant 8:
+ *
+ *   Every migrator run emits exactly one `migration.completed` or
+ *   `migration.aborted` event to `.instar/ledger/job-runs.jsonl` with
+ *   start/end timestamps, per-entry outcomes (`migrated | forked |
+ *   renamed | skipped | failed | deferred-in-flight`), backup file path,
+ *   lock-file `instarVersion`, and trigger (`post-update | cli |
+ *   dashboard`). Telemetry write is the LAST action of a successful
+ *   migration. Presence of a `migration.completed` row with matching
+ *   `instarVersion` is the canonical signal that migration finished for
+ *   this update.
+ *
+ * The event coexists in `job-runs.jsonl` alongside regular JobRun rows;
+ * readers discriminate via the `kind` field (absent on JobRun, present
+ * with `migration.*` value on migration events).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type MigrationEventKind = 'migration.completed' | 'migration.aborted';
+
+export type MigrationTrigger = 'post-update' | 'cli' | 'dashboard';
+
+export type MigrationPerEntryAction =
+  | 'migrated'
+  | 'forked'
+  | 'renamed'
+  | 'skipped'
+  | 'failed'
+  | 'deferred-in-flight';
+
+export interface MigrationEvent {
+  /** Discriminator. Present on every migration event row. Absent on JobRun rows. */
+  kind: MigrationEventKind;
+  /** UUID-style run id. */
+  runId: string;
+  /** ISO 8601 when the migrator started. */
+  startedAt: string;
+  /** ISO 8601 when the migrator finished (or aborted). */
+  completedAt: string;
+  /** What triggered the run. */
+  trigger: MigrationTrigger;
+  /** Per-entry routing summary. The action mirrors jobsMigrate's
+   *  perEntry.action, normalized to the spec's outcome vocabulary. */
+  perEntry: Array<{ slug: string; action: MigrationPerEntryAction; reason?: string }>;
+  /** Path to the pre-migrate backup of jobs.json. Present on completed runs. */
+  backupPath?: string;
+  /** instarVersion read from the bundled lock-file at migration time (when
+   *  present). Absent in the transitional state where no lock-file ships. */
+  instarVersion?: string;
+  /** Reason for abort. Present on `migration.aborted` events. */
+  abortReason?: string;
+}
+
+/**
+ * Append a single migration event to `.instar/ledger/job-runs.jsonl`.
+ *
+ * The append is a best-effort write — failures are surfaced via the
+ * returned `ok` flag rather than thrown. The caller's behavior on
+ * failure is deliberately a no-op: missing telemetry is a degradation,
+ * not a release-blocker.
+ */
+export function appendMigrationEvent(stateDir: string, event: MigrationEvent): { ok: true } | { ok: false; reason: string } {
+  const ledgerDir = path.join(stateDir, 'ledger');
+  const ledgerFile = path.join(ledgerDir, 'job-runs.jsonl');
+  try {
+    fs.mkdirSync(ledgerDir, { recursive: true });
+    fs.appendFileSync(ledgerFile, JSON.stringify(event) + '\n', 'utf-8');
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Read every migration event row from `.instar/ledger/job-runs.jsonl`.
+ *
+ * Filters out non-`migration.*` rows (regular JobRun records). Malformed
+ * lines are silently skipped to match the existing JobRunHistory.readLines
+ * convention.
+ */
+export function readMigrationEvents(stateDir: string): MigrationEvent[] {
+  const ledgerFile = path.join(stateDir, 'ledger', 'job-runs.jsonl');
+  if (!fs.existsSync(ledgerFile)) return [];
+  let content: string;
+  try {
+    content = fs.readFileSync(ledgerFile, 'utf-8').trim();
+  } catch {
+    return [];
+  }
+  if (!content) return [];
+  const events: MigrationEvent[] = [];
+  for (const line of content.split('\n')) {
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === 'object' && typeof parsed.kind === 'string' && parsed.kind.startsWith('migration.')) {
+        events.push(parsed as MigrationEvent);
+      }
+    } catch {
+      // Skip malformed line (consistent with readLines convention).
+    }
+  }
+  return events;
+}
+
+/**
+ * Return the latest `migration.completed` event whose `instarVersion`
+ * matches the given version, or null when no such event exists. Used by
+ * the release-cut gate to confirm migration completed for THIS release
+ * before allowing `jobs.json` deletion.
+ */
+export function findCompletedFor(stateDir: string, instarVersion: string): MigrationEvent | null {
+  const events = readMigrationEvents(stateDir);
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.kind === 'migration.completed' && e.instarVersion === instarVersion) return e;
+  }
+  return null;
+}
+
+/**
+ * Normalize a `jobsMigrate.MigrationOutcome.perEntry` action to the spec's
+ * canonical outcome vocabulary. The CLI/auto-runner uses richer action
+ * names; the telemetry rolls them up.
+ */
+export function normalizePerEntryAction(action: string): MigrationPerEntryAction {
+  switch (action) {
+    case 'migrated-instar':
+      return 'migrated';
+    case 'forked-user':
+    case 'kept-user':
+      return 'forked';
+    case 'renamed-user':
+      return 'renamed';
+    case 'failed':
+      return 'failed';
+    case 'deferred-in-flight':
+      return 'deferred-in-flight';
+    case 'skipped':
+    default:
+      return 'skipped';
+  }
+}

--- a/tests/unit/scheduler/MigrationLedger.test.ts
+++ b/tests/unit/scheduler/MigrationLedger.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Migration telemetry ledger tests.
+ *
+ * Per INSTAR-JOBS-AS-AGENTMD spec §Seamless Migration Guarantee invariant 8.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  appendMigrationEvent,
+  readMigrationEvents,
+  findCompletedFor,
+  normalizePerEntryAction,
+  type MigrationEvent,
+} from '../../../src/scheduler/MigrationLedger.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+describe('MigrationLedger', () => {
+  let workspace: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-ml-'));
+    stateDir = path.join(workspace, '.instar');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(workspace, { recursive: true, force: true, operation: 'MigrationLedger.test cleanup' });
+  });
+
+  const sampleCompleted: MigrationEvent = {
+    kind: 'migration.completed',
+    runId: '00000000-0000-0000-0000-000000000001',
+    startedAt: '2026-05-13T13:00:00.000Z',
+    completedAt: '2026-05-13T13:00:02.000Z',
+    trigger: 'post-update',
+    perEntry: [
+      { slug: 'health-check', action: 'migrated' },
+      { slug: 'user-job', action: 'forked', reason: 'slug not in shipped defaults' },
+    ],
+    backupPath: '.instar/jobs.json.pre-migrate-2026-05-13T13-00-00-000Z',
+    instarVersion: '0.28.103',
+  };
+
+  it('appendMigrationEvent writes a parseable JSONL row to job-runs.jsonl', () => {
+    const r = appendMigrationEvent(stateDir, sampleCompleted);
+    expect(r.ok).toBe(true);
+    const ledgerFile = path.join(stateDir, 'ledger', 'job-runs.jsonl');
+    expect(fs.existsSync(ledgerFile)).toBe(true);
+    const lines = fs.readFileSync(ledgerFile, 'utf-8').trim().split('\n');
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.kind).toBe('migration.completed');
+    expect(parsed.runId).toBe(sampleCompleted.runId);
+    expect(parsed.perEntry).toHaveLength(2);
+  });
+
+  it('readMigrationEvents returns appended events in order', () => {
+    appendMigrationEvent(stateDir, sampleCompleted);
+    appendMigrationEvent(stateDir, {
+      ...sampleCompleted,
+      runId: '00000000-0000-0000-0000-000000000002',
+      kind: 'migration.aborted',
+      abortReason: 'invariant 1 failed',
+    });
+
+    const events = readMigrationEvents(stateDir);
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe('migration.completed');
+    expect(events[1].kind).toBe('migration.aborted');
+  });
+
+  it('readMigrationEvents skips non-migration JobRun rows', () => {
+    appendMigrationEvent(stateDir, sampleCompleted);
+
+    // Manually append a JobRun-shaped row.
+    const ledgerFile = path.join(stateDir, 'ledger', 'job-runs.jsonl');
+    fs.appendFileSync(
+      ledgerFile,
+      JSON.stringify({
+        runId: 'job-run-1',
+        slug: 'health-check',
+        sessionId: 'sess-1',
+        trigger: 'scheduled',
+        startedAt: '2026-05-13T14:00:00.000Z',
+        result: 'success',
+      }) + '\n',
+      'utf-8',
+    );
+
+    const events = readMigrationEvents(stateDir);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('migration.completed');
+  });
+
+  it('readMigrationEvents tolerates malformed lines', () => {
+    appendMigrationEvent(stateDir, sampleCompleted);
+    const ledgerFile = path.join(stateDir, 'ledger', 'job-runs.jsonl');
+    fs.appendFileSync(ledgerFile, 'this is not json\n', 'utf-8');
+
+    const events = readMigrationEvents(stateDir);
+    expect(events).toHaveLength(1);
+  });
+
+  it('findCompletedFor returns the most recent completion for an instarVersion', () => {
+    appendMigrationEvent(stateDir, sampleCompleted); // 0.28.103
+    appendMigrationEvent(stateDir, {
+      ...sampleCompleted,
+      runId: '00000000-0000-0000-0000-000000000003',
+      instarVersion: '0.28.104',
+      completedAt: '2026-05-14T13:00:00.000Z',
+    });
+
+    const found = findCompletedFor(stateDir, '0.28.103');
+    expect(found).not.toBeNull();
+    expect(found!.instarVersion).toBe('0.28.103');
+
+    const found2 = findCompletedFor(stateDir, '0.28.104');
+    expect(found2!.instarVersion).toBe('0.28.104');
+
+    expect(findCompletedFor(stateDir, '0.28.999')).toBeNull();
+  });
+
+  it('findCompletedFor returns null when only aborted events exist for that version', () => {
+    appendMigrationEvent(stateDir, {
+      ...sampleCompleted,
+      kind: 'migration.aborted',
+      abortReason: 'test',
+    });
+    expect(findCompletedFor(stateDir, '0.28.103')).toBeNull();
+  });
+
+  it('readMigrationEvents on empty/missing ledger returns []', () => {
+    expect(readMigrationEvents(stateDir)).toEqual([]);
+    fs.mkdirSync(path.join(stateDir, 'ledger'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'ledger', 'job-runs.jsonl'), '', 'utf-8');
+    expect(readMigrationEvents(stateDir)).toEqual([]);
+  });
+
+  // ── normalizePerEntryAction ───────────────────────────────────────
+
+  it('normalizePerEntryAction maps jobsMigrate vocabulary to the spec\'s outcome set', () => {
+    expect(normalizePerEntryAction('migrated-instar')).toBe('migrated');
+    expect(normalizePerEntryAction('forked-user')).toBe('forked');
+    expect(normalizePerEntryAction('kept-user')).toBe('forked');
+    expect(normalizePerEntryAction('renamed-user')).toBe('renamed');
+    expect(normalizePerEntryAction('failed')).toBe('failed');
+    expect(normalizePerEntryAction('deferred-in-flight')).toBe('deferred-in-flight');
+    expect(normalizePerEntryAction('skipped')).toBe('skipped');
+    // Unknown actions fall back to 'skipped' (defensive default).
+    expect(normalizePerEntryAction('weird-new-action-from-future')).toBe('skipped');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -8,6 +8,9 @@ note (`upgrades/<version>.md`) at release-cut time.
 ### fix(server): File Viewer extends never-editable to .instar/jobs/instar/
 
 The Dashboard file editor's never-editable list now includes `.instar/jobs/instar/`. Per INSTAR-JOBS-AS-AGENTMD spec §Decision Points: that namespace is owned by the update process and any direct edit would (a) be overwritten on next update and (b) break the body-hash verification. Operators who want to customize a shipped default use the override flow (fork to `.instar/jobs/user/`). The CLAUDE.md doc string emitted by PostUpdateMigrator is updated to list the new entry alongside `.claude/hooks/`, `.claude/scripts/`, `node_modules/`. One new e2e test case in `tests/e2e/file-viewer-e2e.test.ts`.
+### feat(scheduler): migration telemetry to job-runs.jsonl (Seamless Migration Guarantee invariant 8)
+
+New `src/scheduler/MigrationLedger.ts` writes a single `migration.completed` or `migration.aborted` event per migrator run to `.instar/ledger/job-runs.jsonl`. `PostUpdateMigrator.autoMigrateLegacyJobsJson` emits the event on every terminal path (success, jobsMigrate abort, thrown exception). The event records per-entry outcomes (normalized to `migrated | forked | renamed | skipped | failed | deferred-in-flight`), backup path, instarVersion, and trigger. `findCompletedFor(stateDir, version)` is the canonical signal for "did migration finish for this release" — usable by the release-cut gate when it ships. Co-locates with the existing JobRun ledger via a `kind` discriminator field; non-migration consumers ignore the new rows. 8 unit tests pass.
 
 ### test(release): npm-pack smoke test for shipped templates + bundled public key
 

--- a/upgrades/side-effects/migration-telemetry-invariant-8.md
+++ b/upgrades/side-effects/migration-telemetry-invariant-8.md
@@ -1,0 +1,68 @@
+# Side-effects review — Migration telemetry (invariant 8)
+
+## What changed
+
+Implements Seamless Migration Guarantee invariant 8 — "Every migrator run emits exactly one `migration.completed` or `migration.aborted` event to `.instar/ledger/job-runs.jsonl`."
+
+New module + wiring:
+
+- **`src/scheduler/MigrationLedger.ts`** — pure append/read helpers for migration events. Co-locates with the existing `JobRunHistory` ledger file (`.instar/ledger/job-runs.jsonl`). Uses a `kind` discriminator field so readers can distinguish migration events from regular `JobRun` rows.
+  - `appendMigrationEvent(stateDir, event)` — best-effort append. Missing telemetry is degradation, not a release-blocker.
+  - `readMigrationEvents(stateDir)` — filters out non-migration rows; tolerates malformed lines.
+  - `findCompletedFor(stateDir, instarVersion)` — release-cut helper; returns the most recent `migration.completed` for a given version.
+  - `normalizePerEntryAction(action)` — maps `jobsMigrate`'s richer perEntry vocabulary (`migrated-instar`, `forked-user`, …) to the spec's canonical set (`migrated | forked | renamed | skipped | failed | deferred-in-flight`).
+- **`PostUpdateMigrator.autoMigrateLegacyJobsJson`** — assigns a `runId` + `startedAt` at the top of the method, then appends exactly one event on every code path:
+  - On invariant-verified success: `migration.completed` (the LAST action per spec).
+  - On `jobsMigrate` abort: `migration.aborted` with `abortReason = outcome.errors.join('; ')`.
+  - On thrown exception: `migration.aborted` with `abortReason = err.message`.
+- **`readBundledInstarVersion(packageRoot)`** helper reads `package.json` for the `instarVersion` field of the event.
+
+## Side-effects review
+
+### 1. Over-block / under-block
+
+- **Over-block:** none. Telemetry writes are best-effort — a write failure does NOT block the migration or the update.
+- **Under-block:** events are emitted from three code paths in `autoMigrateLegacyJobsJson` (success, aborted-by-jobsMigrate, thrown-exception). The Phase 3 CLI path (`instar job migrate`) does NOT currently emit telemetry — operator-initiated migrations are visible directly to the operator and don't need ledger surfacing. Adding CLI-path telemetry is a follow-up if Dashboard needs the unified view.
+
+### 2. Level-of-abstraction fit
+
+`MigrationLedger.ts` is a pure append/read facade. It does not depend on `JobRunHistory` (which has a richer in-memory schema). It writes to the same file format because the spec requires co-location. The discriminator field (`kind`) keeps the formats from confusing each other.
+
+The PostUpdateMigrator integration is three short `appendMigrationTelemetry` calls — one per terminal path. Pure additive.
+
+### 3. Signal-vs-authority compliance
+
+The ledger is a write-only signal. The authority for "did migration complete for this release" is `findCompletedFor(stateDir, currentVersion)` returning non-null. The release-cut gate (future work) can call this; the Dashboard "Confirm migration complete" UI (future work) can surface it.
+
+### 4. Interactions
+
+- **`JobRunHistory.readLines()`** — currently casts every line to `JobRun`. After this PR, lines with `kind: 'migration.*'` will be returned as JobRun objects with `kind` set and most other JobRun fields undefined. Downstream consumers that index by `slug` (e.g., job-run dashboard) will see undefined and skip. Not a problem because (a) JobRun consumers filter on `slug` non-empty and (b) `kind` is a deliberate discriminator. A future PR can add the symmetric "skip non-JobRun rows" filter to `readLines()` if it surfaces unexpected behavior.
+- **Phase 3 jobsMigrate CLI** — does NOT emit telemetry. Operator runs the CLI interactively; the telemetry surface is the auto-migrate (unattended) path. Adding CLI telemetry is straightforward but out of scope here.
+- **Runtime invariant gate (PR #199)** — completed-event is written AFTER the gate passes. Aborted-event is written on rollback. Telemetry never lies about state.
+- **Spec §Seamless Migration Guarantee** — invariant 8 is now structurally enforced for the auto-migrate path.
+
+### 5. Rollback cost
+
+Trivial. Three files; remove MigrationLedger.ts + revert the three append calls in PostUpdateMigrator.
+
+## Test coverage
+
+`tests/unit/scheduler/MigrationLedger.test.ts` — 8 cases:
+
+1. `appendMigrationEvent` writes a parseable JSONL row
+2. `readMigrationEvents` returns appended events in order
+3. `readMigrationEvents` skips JobRun-shaped rows
+4. `readMigrationEvents` tolerates malformed lines
+5. `findCompletedFor` returns the most recent completion for a version
+6. `findCompletedFor` returns null when only aborted events exist
+7. Empty/missing ledger handled
+8. `normalizePerEntryAction` maps every vocabulary
+
+All 8 pass locally. Lint + type-check pass.
+
+## What is NOT in this PR
+
+- CLI-path telemetry (operator-initiated `instar job migrate` does not emit).
+- Release-cut gate consuming `findCompletedFor`.
+- Dashboard surface for migration events.
+- JobRunHistory reader filtering — currently the existing reader returns migration-event lines as malformed-shaped JobRun objects; downstream consumers tolerate this today, but a future PR can tighten the type.


### PR DESCRIPTION
## Summary

Closes Seamless Migration Guarantee invariant 8. New `src/scheduler/MigrationLedger.ts` writes one `migration.completed` or `migration.aborted` event per migrator run to `.instar/ledger/job-runs.jsonl`. `PostUpdateMigrator.autoMigrateLegacyJobsJson` emits on every terminal path. `findCompletedFor(stateDir, version)` is the canonical signal for "did migration finish for this release."

8 unit tests pass.

## Test plan

- [x] 8 cases pass
- [x] Lint + type-check pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)