### PR TITLE
feat(core): F-7 — PostUpdateMigrator atomic-step + announceOnce primitives (Tier-2)

### DIFF
--- a/.instar/instar-dev-traces/f7-post-update-migrator-atomic-step.json
+++ b/.instar/instar-dev-traces/f7-post-update-migrator-atomic-step.json
@@ -1,0 +1,20 @@
+{
+  "phase": "complete",
+  "slug": "f7-post-update-migrator-atomic-step",
+  "coveredFiles": [
+    "src/core/BackupManager.ts",
+    "src/core/GitStateManager.ts",
+    "src/core/MigratorStepEngine.ts",
+    "src/core/PostUpdateMigrator.ts",
+    "src/data/builtin-manifest.json",
+    "tests/unit/AnnouncementManager.test.ts",
+    "tests/unit/PostUpdateMigrator-a35-remediationPaths.test.ts",
+    "tests/unit/PostUpdateMigrator-atomicStep.test.ts",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/f7-post-update-migrator-atomic-step.md"
+  ],
+  "artifactPath": "upgrades/side-effects/f7-post-update-migrator-atomic-step.md",
+  "artifactSha256": "d96218a0149d421687e3178f8c000a08f57e1ad88fa9515c0a337a68bc921538",
+  "specPath": "docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md",
+  "createdAt": "2026-05-13T17:55:00Z"
+}

--- a/src/core/BackupManager.ts
+++ b/src/core/BackupManager.ts
@@ -31,6 +31,31 @@ const BLOCKED_PATH_PREFIXES = new Set([
   '.instar/secrets/',
 ]);
 
+/**
+ * F-7 / A35 — Remediation runtime-state path prefixes that must NEVER
+ * be included in a backup snapshot. These files are per-machine
+ * scratch state (SystemReviewer cluster cursors, inbox queues, audit
+ * projections, cross-process attempt ledgers, raw LLM responses). They
+ * are gated by `config.remediation.enabled` — when remediation is off
+ * the prefixes are inactive; when remediation is on the prefixes
+ * actively exclude any user-added `includeFiles` entry whose path
+ * starts with one of them.
+ *
+ * Same shape as the `shared-state.jsonl*` feature-flag gate used today
+ * for Integrated-Being v1 (see resolveIncludedFiles()). Documented in
+ * `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A14 + §A35 + §A50.
+ *
+ * Exported for the F-7 atomic step that registers these exclusions on
+ * the user's `config.backup.excludePaths` post-update.
+ */
+export const REMEDIATION_EXCLUDED_PATH_PREFIXES: readonly string[] = Object.freeze([
+  '.instar/remediation/system-reviewer-state-',
+  '.instar/remediation/inbox-',
+  '.instar/remediation/audit-projection-',
+  '.instar/remediation/cross-process-attempts-',
+  '.instar/remediation/llm-raw-',
+]);
+
 const DEFAULT_CONFIG: BackupConfig = {
   enabled: true,
   maxSnapshots: 20,
@@ -79,6 +104,14 @@ export class BackupManager {
   /** Optional resolver — called at snapshot time to check if Integrated-Being
    *  is enabled. When false, shared-state.jsonl* is excluded. See spec §Config knob. */
   private readonly isIntegratedBeingEnabled?: () => boolean;
+  /**
+   * F-7 / A35 — Optional resolver: when `true`, the
+   * `REMEDIATION_EXCLUDED_PATH_PREFIXES` are applied to drop any
+   * `includeFiles` entry whose path begins with one of those prefixes.
+   * When `false` or absent, the prefixes are inactive. Same shape as
+   * `isIntegratedBeingEnabled`. See spec §A35 + §A50.
+   */
+  private readonly isRemediationEnabled?: () => boolean;
   private lastAutoSnapshot: number = 0;
 
   constructor(
@@ -86,6 +119,7 @@ export class BackupManager {
     config?: Partial<BackupConfig>,
     isSessionActive?: () => boolean,
     isIntegratedBeingEnabled?: () => boolean,
+    isRemediationEnabled?: () => boolean,
   ) {
     this.stateDir = path.resolve(stateDir);
     this.backupsDir = path.resolve(stateDir, 'backups');
@@ -104,6 +138,7 @@ export class BackupManager {
     };
     this.isSessionActive = isSessionActive;
     this.isIntegratedBeingEnabled = isIntegratedBeingEnabled;
+    this.isRemediationEnabled = isRemediationEnabled;
   }
 
   /**
@@ -115,9 +150,30 @@ export class BackupManager {
     const sharedStateGateOff = this.isIntegratedBeingEnabled
       ? !this.isIntegratedBeingEnabled()
       : false;
+    // F-7 / A35: when remediation is ENABLED, the per-machine
+    // remediation runtime paths get actively excluded. When remediation
+    // is off, the exclusion is a no-op (no such files exist anyway).
+    const remediationExclusionActive = this.isRemediationEnabled
+      ? this.isRemediationEnabled()
+      : false;
     for (const entry of this.config.includeFiles) {
       // Gate: exclude the shared-state pattern when feature is disabled.
       if (sharedStateGateOff && entry.startsWith('shared-state.jsonl')) continue;
+      // F-7 / A35 gate: drop remediation runtime paths from any
+      // user-added includeFiles entry. Same prefix-string shape as
+      // BLOCKED_PATH_PREFIXES — caller is expected to normalize paths
+      // before passing them in.
+      if (remediationExclusionActive) {
+        const normalized = path.normalize(entry);
+        let blocked = false;
+        for (const prefix of REMEDIATION_EXCLUDED_PATH_PREFIXES) {
+          if (normalized.startsWith(prefix)) {
+            blocked = true;
+            break;
+          }
+        }
+        if (blocked) continue;
+      }
       if (entry.includes('*')) {
         for (const real of expandGlob(this.stateDir, entry)) expanded.push(real);
       } else {

--- a/src/core/GitStateManager.ts
+++ b/src/core/GitStateManager.ts
@@ -29,7 +29,24 @@ const BLOCKED_REMOTE_SCHEMES = [
   /^ftp:\/\//,
 ];
 
-const DEFAULT_GITIGNORE = `# Runtime state -- NOT tracked
+// F-7 / A35 — Remediation runtime paths are per-machine and MUST NOT
+// be tracked in the cross-machine state repo. They contain
+// agent-internal scratch data (cluster cursor state, audit projections,
+// inbox queues, raw LLM responses, cross-process attempt ledgers) that
+// would otherwise pollute git history and create cross-machine race
+// conditions. See docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md §A14 +
+// §A35 + §A50 for the per-path rationale. The globs match the file
+// naming conventions used by the Remediator family (system-reviewer-
+// state, inbox, audit-projection, cross-process-attempts, llm-raw).
+const REMEDIATION_GITIGNORE_BLOCK = `# Remediation runtime (F-7/A35) -- per-machine, NEVER synced
+remediation/system-reviewer-state-*.json
+remediation/inbox-*.jsonl
+remediation/audit-projection-*.jsonl
+remediation/cross-process-attempts-*.jsonl
+remediation/llm-raw-*.jsonl
+`;
+
+export const DEFAULT_GITIGNORE = `# Runtime state -- NOT tracked
 state/
 logs/
 *.tmp
@@ -44,6 +61,7 @@ memory.db-wal
 memory.db-shm
 backups/
 
+${REMEDIATION_GITIGNORE_BLOCK}
 # Tracked state:
 # AGENT.md, USER.md, MEMORY.md
 # jobs.json
@@ -51,6 +69,20 @@ backups/
 # hooks/ (generated but version-trackable)
 # evolution/ (proposals, learnings, gaps)
 `;
+
+/**
+ * F-7 / A35 — exported for the F-7 atomic step that patches the user's
+ * `.instar/.gitignore` post-update. Tests assert presence of these
+ * entries. The list is the source of truth for the gitignore-extension
+ * atomic step.
+ */
+export const REMEDIATION_GITIGNORE_ENTRIES: readonly string[] = Object.freeze([
+  'remediation/system-reviewer-state-*.json',
+  'remediation/inbox-*.jsonl',
+  'remediation/audit-projection-*.jsonl',
+  'remediation/cross-process-attempts-*.jsonl',
+  'remediation/llm-raw-*.jsonl',
+]);
 
 const DEFAULT_CONFIG: GitStateConfig = {
   enabled: false,

--- a/src/core/MigratorStepEngine.ts
+++ b/src/core/MigratorStepEngine.ts
@@ -1,0 +1,434 @@
+/**
+ * MigratorStepEngine — atomic-step primitive for post-update migrations.
+ *
+ * Implements F-7 of `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md`
+ * (§R1 Upgrade invariants + §A35 + §A50 + §A57 Tier-2). Provides:
+ *
+ *   1. `MigratorStepEngine` — registers named, idempotent, run-once-per-
+ *      version atomic steps that fire at release boundaries. Each step is
+ *      self-contained; one step failing does NOT roll back prior steps or
+ *      prevent subsequent steps from running. Persisted state lives at
+ *      `<stateDir>/migrator-steps-completed.json` keyed by
+ *      `<version>:<step-name>`.
+ *
+ *   2. `AnnouncementManager` — `announceOnce` primitive for "show this
+ *      message to the user exactly once and then never again". Used for
+ *      surfacing migration completions, structural changes, or any other
+ *      one-shot user-facing notice. Persisted state lives at
+ *      `<stateDir>/announcements-shown.json` keyed by announcementId.
+ *
+ * Design notes:
+ *
+ *   - Atomic: each step records outcome (completed | skipped | failed)
+ *     atomically (temp-file → fsync → rename). A crash mid-step leaves
+ *     the ledger consistent — either the step is recorded or it isn't,
+ *     never partial.
+ *
+ *   - Version-gated: a step `version: "1.2.3"` runs only when the engine
+ *     is invoked with `toVersion >= "1.2.3"` (semver compare). Steps for
+ *     versions strictly newer than `toVersion` are skipped without being
+ *     recorded — they will run on the next update boundary that catches
+ *     up to them.
+ *
+ *   - Once-per-version-step pair: a successful step is recorded with key
+ *     `<version>:<step-name>`. Re-runs of `runPendingSteps()` short-circuit
+ *     on that key. A FAILED step IS also recorded (with outcome `failed`)
+ *     so the same broken step doesn't re-run unbounded on every update —
+ *     operators see the failure in the report and decide whether to retry.
+ *
+ *   - No rollback. Each step must be self-contained and atomic on its
+ *     own. The spec deliberately rejects step ordering / dependency /
+ *     rollback semantics — those couplings are what made v1's migrator
+ *     unmaintainable.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ── Public types ─────────────────────────────────────────────────────
+
+export interface MigratorContext {
+  /** State directory (typically `<projectDir>/.instar`). */
+  stateDir: string;
+  /** Previous version on disk (may be empty on first install). */
+  fromVersion: string;
+  /** Version we're upgrading to. */
+  toVersion: string;
+  /** Per-run logger — step writes diagnostics here. */
+  logger: (msg: string) => void;
+}
+
+export interface MigratorStepRunResult {
+  outcome: 'completed' | 'skipped' | 'failed';
+  details?: string;
+}
+
+export interface MigratorStep {
+  /** Globally unique step name. */
+  name: string;
+  /**
+   * Semver version this step runs on/after. The step runs when invoked
+   * with `toVersion >= step.version`. Use the version in which the step
+   * was introduced.
+   */
+  version: string;
+  /** Idempotent worker. Must NOT throw — return `{ outcome: 'failed' }` on error. */
+  run: (ctx: MigratorContext) => Promise<MigratorStepRunResult>;
+}
+
+export interface RunPendingStepsResult {
+  steps: Array<{ name: string; outcome: string; details?: string }>;
+}
+
+// ── Internal types ───────────────────────────────────────────────────
+
+interface StepLedgerEntry {
+  outcome: 'completed' | 'skipped' | 'failed';
+  details?: string;
+  /** ISO timestamp at which the step was recorded. */
+  recordedAt: string;
+}
+
+type StepLedger = Record<string, StepLedgerEntry>;
+
+// ── Semver comparison (minimal, sufficient for this engine) ─────────
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+function parseVersion(v: string): [number, number, number, string] | null {
+  const m = VERSION_RE.exec(v.trim());
+  if (!m) return null;
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10), m[4] ?? ''];
+}
+
+/**
+ * Compare two semver strings. Returns -1 / 0 / 1. Pre-release strings are
+ * compared lexically when major.minor.patch match (good-enough for our
+ * "run on version >= X" usage). Unparseable inputs sort as -Infinity so
+ * a malformed `fromVersion` never blocks step execution.
+ */
+export function compareSemver(a: string, b: string): number {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa && !pb) return 0;
+  if (!pa) return -1;
+  if (!pb) return 1;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] < pb[i]) return -1;
+    if ((pa[i] as number) > (pb[i] as number)) return 1;
+  }
+  // major.minor.patch equal — compare pre-release. Absent pre-release
+  // outranks any pre-release (e.g. 1.0.0 > 1.0.0-rc1).
+  const preA = pa[3] as string;
+  const preB = pb[3] as string;
+  if (preA === '' && preB === '') return 0;
+  if (preA === '') return 1;
+  if (preB === '') return -1;
+  if (preA < preB) return -1;
+  if (preA > preB) return 1;
+  return 0;
+}
+
+// ── MigratorStepEngine ───────────────────────────────────────────────
+
+export class MigratorStepEngine {
+  private readonly stateDir: string;
+  private readonly steps: MigratorStep[] = [];
+  /** Path to the step-completion ledger. */
+  private readonly ledgerPath: string;
+
+  constructor(stateDir: string) {
+    this.stateDir = path.resolve(stateDir);
+    this.ledgerPath = path.join(this.stateDir, 'migrator-steps-completed.json');
+  }
+
+  /**
+   * Register an atomic step. Steps run in registration order on each
+   * invocation of `runPendingSteps()`, subject to the version gate and
+   * the per-version-per-step idempotency guard.
+   *
+   * Duplicate `name` values are rejected at registration time — names
+   * are global identifiers in the ledger.
+   */
+  registerStep(step: MigratorStep): void {
+    if (!step.name || typeof step.name !== 'string') {
+      throw new Error('MigratorStepEngine.registerStep: step.name is required');
+    }
+    if (!step.version || typeof step.version !== 'string') {
+      throw new Error(`MigratorStepEngine.registerStep: step.version is required (step=${step.name})`);
+    }
+    if (typeof step.run !== 'function') {
+      throw new Error(`MigratorStepEngine.registerStep: step.run must be a function (step=${step.name})`);
+    }
+    for (const existing of this.steps) {
+      if (existing.name === step.name) {
+        throw new Error(`MigratorStepEngine.registerStep: duplicate step name "${step.name}"`);
+      }
+    }
+    this.steps.push(step);
+  }
+
+  /**
+   * Run every pending step. A step is "pending" when:
+   *   - its `version <= toVersion` (semver compare), AND
+   *   - no ledger entry exists for `<version>:<name>`.
+   *
+   * Steps for versions strictly newer than `toVersion` are reported as
+   * `skipped` (with details: `future-version`) but NOT recorded — they
+   * will run on a later update boundary that crosses their threshold.
+   *
+   * Steps whose ledger entry already exists are reported as `skipped`
+   * (with details: `already-recorded:<previous-outcome>`).
+   *
+   * Each step is executed under a try/catch; thrown errors are converted
+   * to `outcome: 'failed'` and recorded. The engine never propagates
+   * step failures to the caller — one broken step cannot block subsequent
+   * steps.
+   */
+  async runPendingSteps(fromVersion: string, toVersion: string): Promise<RunPendingStepsResult> {
+    if (!fs.existsSync(this.stateDir)) {
+      fs.mkdirSync(this.stateDir, { recursive: true });
+    }
+    const ledger = this.readLedger();
+    const report: RunPendingStepsResult = { steps: [] };
+
+    for (const step of this.steps) {
+      const key = `${step.version}:${step.name}`;
+
+      // Already recorded — skip.
+      if (ledger[key]) {
+        report.steps.push({
+          name: step.name,
+          outcome: 'skipped',
+          details: `already-recorded:${ledger[key].outcome}`,
+        });
+        continue;
+      }
+
+      // Future-version — skip without recording.
+      if (compareSemver(step.version, toVersion) > 0) {
+        report.steps.push({
+          name: step.name,
+          outcome: 'skipped',
+          details: `future-version:${step.version} > ${toVersion}`,
+        });
+        continue;
+      }
+
+      // Execute.
+      const ctx: MigratorContext = {
+        stateDir: this.stateDir,
+        fromVersion,
+        toVersion,
+        logger: (_msg: string) => {
+          /* default no-op; callers wire a real logger via wrapping */
+        },
+      };
+
+      let result: MigratorStepRunResult;
+      try {
+        result = await step.run(ctx);
+        if (!result || typeof result.outcome !== 'string') {
+          result = { outcome: 'failed', details: 'step returned malformed result' };
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        result = { outcome: 'failed', details: `threw: ${msg}` };
+      }
+
+      // Record outcome (including failures — see class docstring).
+      ledger[key] = {
+        outcome: result.outcome,
+        details: result.details,
+        recordedAt: new Date().toISOString(),
+      };
+      this.writeLedger(ledger);
+
+      report.steps.push({
+        name: step.name,
+        outcome: result.outcome,
+        details: result.details,
+      });
+    }
+
+    return report;
+  }
+
+  /**
+   * Look up whether `<version>:<name>` is recorded. Returns the ledger
+   * entry or `undefined`. Intended for callers that want to render a
+   * migration report.
+   */
+  getRecorded(version: string, name: string): StepLedgerEntry | undefined {
+    const ledger = this.readLedger();
+    return ledger[`${version}:${name}`];
+  }
+
+  // ── Ledger I/O ─────────────────────────────────────────────────────
+
+  private readLedger(): StepLedger {
+    try {
+      if (!fs.existsSync(this.ledgerPath)) return {};
+      const raw = fs.readFileSync(this.ledgerPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as StepLedger;
+      }
+      return {};
+    } catch {
+      // Corrupt ledger — treat as empty rather than blocking. The crash
+      // recovery path is: subsequent run records its results into a
+      // fresh ledger. Lost history of past runs is acceptable; blocked
+      // upgrades are not.
+      return {};
+    }
+  }
+
+  private writeLedger(ledger: StepLedger): void {
+    const tmpPath = `${this.ledgerPath}.tmp-${process.pid}-${Date.now()}`;
+    const serialized = JSON.stringify(ledger, null, 2) + '\n';
+    const fd = fs.openSync(tmpPath, 'w', 0o600);
+    try {
+      fs.writeSync(fd, serialized);
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmpPath, this.ledgerPath);
+  }
+}
+
+// ── AnnouncementManager ──────────────────────────────────────────────
+
+export type AnnouncementChannel = 'telegram' | 'dashboard' | 'log';
+
+export interface AnnouncementSink {
+  (announcementId: string, message: string, channel: AnnouncementChannel): void | Promise<void>;
+}
+
+interface AnnouncementLedgerEntry {
+  channel: AnnouncementChannel;
+  shownAt: string;
+}
+
+type AnnouncementLedger = Record<string, AnnouncementLedgerEntry>;
+
+/**
+ * AnnouncementManager — "show this message to the user once, then never
+ * again" primitive. Used for one-shot migration completions, structural-
+ * change notices, etc.
+ *
+ * The default sink writes to stderr with an `[announcement]` prefix.
+ * Callers can pass a custom sink (e.g. routed to Telegram or the
+ * dashboard's attention queue) via the constructor.
+ *
+ * Persisted state at `<stateDir>/announcements-shown.json`. The ledger
+ * survives across instances and across agent restarts.
+ */
+export class AnnouncementManager {
+  private readonly stateDir: string;
+  private readonly ledgerPath: string;
+  private readonly sink: AnnouncementSink;
+
+  constructor(stateDir: string, sink?: AnnouncementSink) {
+    this.stateDir = path.resolve(stateDir);
+    this.ledgerPath = path.join(this.stateDir, 'announcements-shown.json');
+    this.sink = sink ?? defaultSink;
+  }
+
+  /**
+   * Emit the announcement exactly once per `announcementId`.
+   *
+   * Returns `true` if the announcement was emitted this call; `false`
+   * if a prior call (in this process or a previous run) already
+   * emitted it.
+   *
+   * Caller-side idempotency: the ledger is consulted BEFORE the sink
+   * is invoked. Repeated calls with the same id are O(1) reads.
+   */
+  async announceOnce(
+    announcementId: string,
+    message: string,
+    channel: AnnouncementChannel,
+  ): Promise<boolean> {
+    if (!announcementId || typeof announcementId !== 'string') {
+      throw new Error('AnnouncementManager.announceOnce: announcementId is required');
+    }
+    if (typeof message !== 'string') {
+      throw new Error('AnnouncementManager.announceOnce: message must be a string');
+    }
+    if (channel !== 'telegram' && channel !== 'dashboard' && channel !== 'log') {
+      throw new Error(`AnnouncementManager.announceOnce: invalid channel "${channel}"`);
+    }
+
+    if (!fs.existsSync(this.stateDir)) {
+      fs.mkdirSync(this.stateDir, { recursive: true });
+    }
+
+    const ledger = this.readLedger();
+    if (ledger[announcementId]) {
+      return false;
+    }
+
+    // Record BEFORE emitting so a sink that throws cannot leave us
+    // emitting twice on the next call. Worst case: announcement was
+    // recorded but the sink failed — operator sees a missed notice
+    // once, never a duplicate.
+    ledger[announcementId] = {
+      channel,
+      shownAt: new Date().toISOString(),
+    };
+    this.writeLedger(ledger);
+
+    try {
+      await this.sink(announcementId, message, channel);
+    } catch {
+      // Swallow — see comment above. The ledger entry stands.
+    }
+    return true;
+  }
+
+  /** Has this announcement been shown? Read-only check. */
+  hasBeenShown(announcementId: string): boolean {
+    const ledger = this.readLedger();
+    return Boolean(ledger[announcementId]);
+  }
+
+  private readLedger(): AnnouncementLedger {
+    try {
+      if (!fs.existsSync(this.ledgerPath)) return {};
+      const raw = fs.readFileSync(this.ledgerPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as AnnouncementLedger;
+      }
+      return {};
+    } catch {
+      return {};
+    }
+  }
+
+  private writeLedger(ledger: AnnouncementLedger): void {
+    const tmpPath = `${this.ledgerPath}.tmp-${process.pid}-${Date.now()}`;
+    const serialized = JSON.stringify(ledger, null, 2) + '\n';
+    const fd = fs.openSync(tmpPath, 'w', 0o600);
+    try {
+      fs.writeSync(fd, serialized);
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmpPath, this.ledgerPath);
+  }
+}
+
+function defaultSink(
+  announcementId: string,
+  message: string,
+  channel: AnnouncementChannel,
+): void {
+  // Default sink writes to stderr so it never interferes with stdout
+  // RPC responses or CLI output capture.
+  const line = `[announcement:${channel}] ${announcementId}: ${message}`;
+  process.stderr.write(line + '\n');
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -43,6 +43,11 @@ import {
 } from '../data/pr-gate-artifacts.js';
 import { SafeFsExecutor } from './SafeFsExecutor.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import {
+  MigratorStepEngine,
+  type MigratorStep,
+  type RunPendingStepsResult,
+} from './MigratorStepEngine.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -65,9 +70,54 @@ export interface MigratorConfig {
 
 export class PostUpdateMigrator {
   private config: MigratorConfig;
+  /**
+   * F-7 atomic-step engine. Lazily constructed on first access via
+   * `getStepEngine()` so existing callers that never touch atomic steps
+   * pay zero cost. See `src/core/MigratorStepEngine.ts` for the primitive
+   * docs; see `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A35/§A50
+   * for the spec.
+   */
+  private stepEngine: MigratorStepEngine | undefined;
 
   constructor(config: MigratorConfig) {
     this.config = config;
+  }
+
+  /**
+   * F-7 atomic-step primitive: register a step that will run once on
+   * the release boundary where `step.version <= toVersion`. Idempotent
+   * across runs — the engine records every step's outcome in
+   * `<stateDir>/migrator-steps-completed.json` keyed by
+   * `<version>:<step-name>`.
+   *
+   * Steps are atomic and self-contained: a failure in one step does not
+   * roll back prior steps and does not block subsequent steps.
+   *
+   * See `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A35 + §A50.
+   */
+  registerStep(step: MigratorStep): void {
+    this.getStepEngine().registerStep(step);
+  }
+
+  /**
+   * F-7 atomic-step primitive: execute every pending step. Pending =
+   * step.version <= toVersion AND no ledger entry recorded yet.
+   *
+   * Steps run in registration order. Failures are recorded (never
+   * thrown) and do not stop subsequent steps.
+   */
+  async runPendingSteps(
+    fromVersion: string,
+    toVersion: string,
+  ): Promise<RunPendingStepsResult> {
+    return this.getStepEngine().runPendingSteps(fromVersion, toVersion);
+  }
+
+  private getStepEngine(): MigratorStepEngine {
+    if (!this.stepEngine) {
+      this.stepEngine = new MigratorStepEngine(this.config.stateDir);
+    }
+    return this.stepEngine;
   }
 
   /**

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-14T00:21:51.657Z",
+  "generatedAt": "2026-05-14T00:53:53.009Z",
   "instarVersion": "0.28.103",
   "entryCount": 188,
   "entries": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -1448,7 +1448,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "f1cec15b03ee27f139ecdbce7a5e9a6094bb7aaafa219d7adb83a61597f78640",
+      "contentHash": "9b7c1ab750f1c82dfcd80cd5da3eefd03ff7f28a3245735d30c8c8806e1b1a96",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {
@@ -1512,7 +1512,7 @@
       "type": "subsystem",
       "domain": "operations",
       "sourcePath": "src/core/BackupManager.ts",
-      "contentHash": "4c62de805431c4ffe4fd3eb039306e94d2eab3999ab601f2c60ee7f6c8381f33",
+      "contentHash": "d19cab90a6189a817c698345d30cab3150dadca8ca6174053e5c6400b76c2945",
       "since": "2025-01-01"
     },
     "subsystem:evolution-manager": {

--- a/tests/unit/AnnouncementManager.test.ts
+++ b/tests/unit/AnnouncementManager.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for the F-7 `announceOnce` primitive on
+ * `AnnouncementManager`.
+ *
+ * Spec: docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md §R1 (Upgrade
+ * invariants) + §A35 + §A57 Tier-2 — "primitive for show this message
+ * once to the user, then never again".
+ *
+ * Covers:
+ *   1. announceOnce returns true on the first call, false on subsequent.
+ *   2. Different announcementIds are independent.
+ *   3. State persists across AnnouncementManager instances (ledger on
+ *      disk at `<stateDir>/announcements-shown.json`).
+ *
+ * Cleanup uses `SafeFsExecutor.safeRmSync` per the F-7 brief.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AnnouncementManager } from '../../src/core/MigratorStepEngine.js';
+import type { AnnouncementChannel } from '../../src/core/MigratorStepEngine.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('AnnouncementManager.announceOnce (F-7 primitive)', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-f7-announce-'));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(stateDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/AnnouncementManager.test.ts:afterEach',
+    });
+  });
+
+  it('1. returns true on first call, false on subsequent', async () => {
+    const sinkCalls: Array<{ id: string; msg: string; channel: AnnouncementChannel }> = [];
+    const manager = new AnnouncementManager(stateDir, (id, msg, channel) => {
+      sinkCalls.push({ id, msg, channel });
+    });
+
+    const first = await manager.announceOnce('migration-complete-1.2.3', 'Upgrade applied', 'log');
+    expect(first).toBe(true);
+    expect(sinkCalls).toHaveLength(1);
+    expect(sinkCalls[0]).toEqual({
+      id: 'migration-complete-1.2.3',
+      msg: 'Upgrade applied',
+      channel: 'log',
+    });
+
+    const second = await manager.announceOnce(
+      'migration-complete-1.2.3',
+      'Upgrade applied',
+      'log',
+    );
+    expect(second).toBe(false);
+    // Sink must not be called again.
+    expect(sinkCalls).toHaveLength(1);
+
+    // hasBeenShown() reflects the same state.
+    expect(manager.hasBeenShown('migration-complete-1.2.3')).toBe(true);
+    expect(manager.hasBeenShown('something-else')).toBe(false);
+  });
+
+  it('2. different announcementIds are independent', async () => {
+    const sinkCalls: string[] = [];
+    const manager = new AnnouncementManager(stateDir, (id) => {
+      sinkCalls.push(id);
+    });
+
+    expect(await manager.announceOnce('alpha', 'A', 'log')).toBe(true);
+    expect(await manager.announceOnce('beta', 'B', 'log')).toBe(true);
+    expect(await manager.announceOnce('gamma', 'C', 'log')).toBe(true);
+
+    // Re-call each — all must return false.
+    expect(await manager.announceOnce('alpha', 'A', 'log')).toBe(false);
+    expect(await manager.announceOnce('beta', 'B', 'log')).toBe(false);
+    expect(await manager.announceOnce('gamma', 'C', 'log')).toBe(false);
+
+    expect(sinkCalls).toEqual(['alpha', 'beta', 'gamma']);
+
+    // Channel-specific announcements with different channels but same id
+    // still collapse — id is the dedup key, not (id, channel).
+    expect(await manager.announceOnce('alpha', 'A', 'telegram')).toBe(false);
+  });
+
+  it('3. state persists across AnnouncementManager instances', async () => {
+    const manager1 = new AnnouncementManager(stateDir);
+    expect(await manager1.announceOnce('persisted-id', 'message', 'log')).toBe(true);
+
+    // Ledger written to disk.
+    const ledgerPath = path.join(stateDir, 'announcements-shown.json');
+    expect(fs.existsSync(ledgerPath)).toBe(true);
+    const ledger = JSON.parse(fs.readFileSync(ledgerPath, 'utf-8'));
+    expect(ledger['persisted-id']).toMatchObject({ channel: 'log' });
+    expect(ledger['persisted-id'].shownAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // Brand-new instance — announceOnce must return false.
+    const manager2 = new AnnouncementManager(stateDir);
+    expect(await manager2.announceOnce('persisted-id', 'message', 'log')).toBe(false);
+    expect(manager2.hasBeenShown('persisted-id')).toBe(true);
+  });
+
+  it('records the announcement even if the sink throws (no duplicate emission)', async () => {
+    const sinkCalls: string[] = [];
+    const manager = new AnnouncementManager(stateDir, (id) => {
+      sinkCalls.push(id);
+      throw new Error('sink down');
+    });
+
+    // First call: sink throws but we still ledger and return true (the
+    // emission was attempted; we cannot guarantee delivery to a broken
+    // sink). Subsequent calls return false — we do NOT retry, because
+    // the brittle / no-context sink layer does not have authority over
+    // the ledger.
+    const first = await manager.announceOnce('flaky-sink', 'message', 'log');
+    expect(first).toBe(true);
+    expect(sinkCalls).toEqual(['flaky-sink']);
+
+    const second = await manager.announceOnce('flaky-sink', 'message', 'log');
+    expect(second).toBe(false);
+    expect(sinkCalls).toEqual(['flaky-sink']); // sink not re-invoked
+  });
+
+  it('rejects invalid channel/id/message inputs', async () => {
+    const manager = new AnnouncementManager(stateDir);
+    await expect(
+      manager.announceOnce('', 'msg', 'log'),
+    ).rejects.toThrow(/announcementId is required/);
+    await expect(
+      manager.announceOnce('id', 'msg', 'invalid' as AnnouncementChannel),
+    ).rejects.toThrow(/invalid channel/);
+  });
+});

--- a/tests/unit/PostUpdateMigrator-a35-remediationPaths.test.ts
+++ b/tests/unit/PostUpdateMigrator-a35-remediationPaths.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the F-7 / A35 hook-shape changes:
+ *
+ *   - `GitStateManager.DEFAULT_GITIGNORE` const literal carries the
+ *     five remediation runtime path globs (per §A35 + §A50). Fresh
+ *     `instar git init` writes them out.
+ *
+ *   - `BackupManager`'s inline exclusion list (the
+ *     `REMEDIATION_EXCLUDED_PATH_PREFIXES`) is feature-flag gated by
+ *     `isRemediationEnabled` — same pattern as `shared-state.jsonl*` /
+ *     `isIntegratedBeingEnabled`. When the gate is on, user-added
+ *     includeFiles entries whose paths begin with a remediation prefix
+ *     are dropped from the resolved include list.
+ *
+ * Spec: docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md §A14 §A35 §A50.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  DEFAULT_GITIGNORE,
+  REMEDIATION_GITIGNORE_ENTRIES,
+} from '../../src/core/GitStateManager.js';
+import {
+  BackupManager,
+  REMEDIATION_EXCLUDED_PATH_PREFIXES,
+} from '../../src/core/BackupManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('A35 — DEFAULT_GITIGNORE remediation entries', () => {
+  it('contains every required remediation glob', () => {
+    expect(REMEDIATION_GITIGNORE_ENTRIES).toEqual([
+      'remediation/system-reviewer-state-*.json',
+      'remediation/inbox-*.jsonl',
+      'remediation/audit-projection-*.jsonl',
+      'remediation/cross-process-attempts-*.jsonl',
+      'remediation/llm-raw-*.jsonl',
+    ]);
+    for (const entry of REMEDIATION_GITIGNORE_ENTRIES) {
+      expect(DEFAULT_GITIGNORE).toContain(entry);
+    }
+  });
+});
+
+describe('A35 — BackupManager remediation exclusion (feature-flag gated)', () => {
+  let stateDir: string;
+
+  function makeStateDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'instar-f7-bm-excl-'));
+  }
+
+  function cleanup(dir: string): void {
+    SafeFsExecutor.safeRmSync(dir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-a35-remediationPaths.test.ts:cleanup',
+    });
+  }
+
+  it('exports the five remediation path prefixes', () => {
+    expect(REMEDIATION_EXCLUDED_PATH_PREFIXES).toEqual([
+      '.instar/remediation/system-reviewer-state-',
+      '.instar/remediation/inbox-',
+      '.instar/remediation/audit-projection-',
+      '.instar/remediation/cross-process-attempts-',
+      '.instar/remediation/llm-raw-',
+    ]);
+  });
+
+  it('drops remediation-prefixed includeFiles entries when the gate is ON', () => {
+    stateDir = makeStateDir();
+    try {
+      const bm = new BackupManager(
+        stateDir,
+        {
+          enabled: true,
+          maxSnapshots: 1,
+          includeFiles: [
+            '.instar/remediation/system-reviewer-state-abc.json',
+            '.instar/remediation/inbox-default.jsonl',
+            'AGENT.md', // should survive
+          ],
+        },
+        undefined,
+        undefined,
+        () => true, // isRemediationEnabled
+      );
+      const resolved = (bm as unknown as {
+        resolveIncludedFiles: () => string[];
+      }).resolveIncludedFiles.call(bm);
+
+      expect(resolved).toContain('AGENT.md');
+      expect(resolved).not.toContain('.instar/remediation/system-reviewer-state-abc.json');
+      expect(resolved).not.toContain('.instar/remediation/inbox-default.jsonl');
+    } finally {
+      cleanup(stateDir);
+    }
+  });
+
+  it('keeps remediation-prefixed includeFiles entries when the gate is OFF', () => {
+    stateDir = makeStateDir();
+    try {
+      const bm = new BackupManager(
+        stateDir,
+        {
+          enabled: true,
+          maxSnapshots: 1,
+          includeFiles: ['.instar/remediation/system-reviewer-state-abc.json', 'AGENT.md'],
+        },
+        undefined,
+        undefined,
+        () => false, // isRemediationEnabled
+      );
+      const resolved = (bm as unknown as {
+        resolveIncludedFiles: () => string[];
+      }).resolveIncludedFiles.call(bm);
+
+      expect(resolved).toContain('.instar/remediation/system-reviewer-state-abc.json');
+      expect(resolved).toContain('AGENT.md');
+    } finally {
+      cleanup(stateDir);
+    }
+  });
+
+  it('treats absent isRemediationEnabled callback as gate=OFF (back-compat)', () => {
+    stateDir = makeStateDir();
+    try {
+      const bm = new BackupManager(stateDir, {
+        enabled: true,
+        maxSnapshots: 1,
+        includeFiles: ['.instar/remediation/inbox-default.jsonl', 'AGENT.md'],
+      });
+      const resolved = (bm as unknown as {
+        resolveIncludedFiles: () => string[];
+      }).resolveIncludedFiles.call(bm);
+
+      // No callback supplied — exclusion is inactive, entry survives.
+      // This is what every existing caller in the codebase expects;
+      // F-7 is strictly additive.
+      expect(resolved).toContain('.instar/remediation/inbox-default.jsonl');
+      expect(resolved).toContain('AGENT.md');
+    } finally {
+      cleanup(stateDir);
+    }
+  });
+});

--- a/tests/unit/PostUpdateMigrator-atomicStep.test.ts
+++ b/tests/unit/PostUpdateMigrator-atomicStep.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the F-7 atomic-step primitive on `PostUpdateMigrator`.
+ *
+ * Spec: docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md §R1 (Upgrade
+ * invariants) + §A35 + §A50 + §A57 Tier-2.
+ *
+ * Covers:
+ *   1. New step runs once and records completion in the ledger.
+ *   2. Already-completed step is skipped on subsequent runs.
+ *   3. Failed step records a failure entry AND does not block other steps.
+ *   4. Step whose version is newer than `toVersion` is skipped (and not
+ *      recorded — it will run on a later upgrade boundary).
+ *   5. State persists across PostUpdateMigrator instances (ledger lives
+ *      on disk at `<stateDir>/migrator-steps-completed.json`).
+ *
+ * Cleanup uses `SafeFsExecutor.safeRmSync` per the F-7 brief.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import type { MigratorStep, MigratorContext } from '../../src/core/MigratorStepEngine.js';
+import { compareSemver } from '../../src/core/MigratorStepEngine.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function buildMigrator(projectDir: string): PostUpdateMigrator {
+  const stateDir = path.join(projectDir, '.instar');
+  fs.mkdirSync(stateDir, { recursive: true });
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir,
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+describe('PostUpdateMigrator.runPendingSteps (F-7 atomic-step primitive)', () => {
+  let projectDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-f7-atomicstep-'));
+    stateDir = path.join(projectDir, '.instar');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-atomicStep.test.ts:afterEach',
+    });
+  });
+
+  it('1. runs a new step once and records completion in the ledger', async () => {
+    const migrator = buildMigrator(projectDir);
+    let runCount = 0;
+    const step: MigratorStep = {
+      name: 'test-step-completes',
+      version: '1.0.0',
+      run: async (_ctx: MigratorContext) => {
+        runCount++;
+        return { outcome: 'completed', details: 'did the thing' };
+      },
+    };
+    migrator.registerStep(step);
+
+    const report = await migrator.runPendingSteps('0.9.0', '1.0.0');
+
+    expect(runCount).toBe(1);
+    expect(report.steps).toHaveLength(1);
+    expect(report.steps[0]).toMatchObject({
+      name: 'test-step-completes',
+      outcome: 'completed',
+      details: 'did the thing',
+    });
+
+    // Ledger written.
+    const ledgerPath = path.join(stateDir, 'migrator-steps-completed.json');
+    expect(fs.existsSync(ledgerPath)).toBe(true);
+    const ledger = JSON.parse(fs.readFileSync(ledgerPath, 'utf-8'));
+    expect(ledger['1.0.0:test-step-completes']).toMatchObject({
+      outcome: 'completed',
+      details: 'did the thing',
+    });
+    expect(ledger['1.0.0:test-step-completes'].recordedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('2. skips an already-completed step on subsequent runs', async () => {
+    const migrator = buildMigrator(projectDir);
+    let runCount = 0;
+    migrator.registerStep({
+      name: 'test-step-once',
+      version: '1.0.0',
+      run: async () => {
+        runCount++;
+        return { outcome: 'completed' };
+      },
+    });
+
+    await migrator.runPendingSteps('0.9.0', '1.0.0');
+    expect(runCount).toBe(1);
+
+    // Second invocation — step body must not re-run.
+    const report = await migrator.runPendingSteps('0.9.0', '1.0.0');
+    expect(runCount).toBe(1);
+    expect(report.steps[0].outcome).toBe('skipped');
+    expect(report.steps[0].details).toBe('already-recorded:completed');
+  });
+
+  it('3. records a failed step AND does not block subsequent steps', async () => {
+    const migrator = buildMigrator(projectDir);
+    let step3Ran = false;
+    migrator.registerStep({
+      name: 'failing-step',
+      version: '1.0.0',
+      run: async () => {
+        throw new Error('boom');
+      },
+    });
+    migrator.registerStep({
+      name: 'failing-via-outcome',
+      version: '1.0.0',
+      run: async () => ({ outcome: 'failed', details: 'I tried' }),
+    });
+    migrator.registerStep({
+      name: 'subsequent-step',
+      version: '1.0.0',
+      run: async () => {
+        step3Ran = true;
+        return { outcome: 'completed' };
+      },
+    });
+
+    const report = await migrator.runPendingSteps('0.9.0', '1.0.0');
+
+    // Subsequent step still ran — the failure did not abort the engine.
+    expect(step3Ran).toBe(true);
+
+    // All three outcomes surfaced in the report.
+    expect(report.steps).toHaveLength(3);
+    expect(report.steps[0]).toMatchObject({ name: 'failing-step', outcome: 'failed' });
+    expect(report.steps[0].details).toMatch(/threw: boom/);
+    expect(report.steps[1]).toMatchObject({
+      name: 'failing-via-outcome',
+      outcome: 'failed',
+      details: 'I tried',
+    });
+    expect(report.steps[2]).toMatchObject({
+      name: 'subsequent-step',
+      outcome: 'completed',
+    });
+
+    // Ledger captured all three outcomes — failed steps are NOT retried
+    // on subsequent runs (operator must intervene).
+    const ledger = JSON.parse(
+      fs.readFileSync(path.join(stateDir, 'migrator-steps-completed.json'), 'utf-8'),
+    );
+    expect(ledger['1.0.0:failing-step'].outcome).toBe('failed');
+    expect(ledger['1.0.0:failing-via-outcome'].outcome).toBe('failed');
+    expect(ledger['1.0.0:subsequent-step'].outcome).toBe('completed');
+
+    // Re-run: failing steps stay failed-not-rerun.
+    const report2 = await migrator.runPendingSteps('0.9.0', '1.0.0');
+    for (const s of report2.steps) {
+      expect(s.outcome).toBe('skipped');
+    }
+  });
+
+  it('4. skips a step whose version > toVersion and does NOT record it', async () => {
+    const migrator = buildMigrator(projectDir);
+    let runCount = 0;
+    migrator.registerStep({
+      name: 'future-step',
+      version: '2.0.0',
+      run: async () => {
+        runCount++;
+        return { outcome: 'completed' };
+      },
+    });
+
+    const report = await migrator.runPendingSteps('0.9.0', '1.5.0');
+
+    expect(runCount).toBe(0);
+    expect(report.steps[0].outcome).toBe('skipped');
+    expect(report.steps[0].details).toMatch(/future-version/);
+
+    // Ledger must not record a future-version skip — when the agent
+    // eventually upgrades past 2.0.0 the step needs to fire.
+    const ledgerPath = path.join(stateDir, 'migrator-steps-completed.json');
+    if (fs.existsSync(ledgerPath)) {
+      const ledger = JSON.parse(fs.readFileSync(ledgerPath, 'utf-8'));
+      expect(ledger['2.0.0:future-step']).toBeUndefined();
+    }
+
+    // Now bump toVersion past the step's version — it must run.
+    const report2 = await migrator.runPendingSteps('1.5.0', '2.0.0');
+    expect(runCount).toBe(1);
+    expect(report2.steps[0].outcome).toBe('completed');
+  });
+
+  it('5. state persists across PostUpdateMigrator instances', async () => {
+    // First instance — register and run.
+    const migrator1 = buildMigrator(projectDir);
+    let runCount = 0;
+    const stepFactory = (name: string): MigratorStep => ({
+      name,
+      version: '1.0.0',
+      run: async () => {
+        runCount++;
+        return { outcome: 'completed' };
+      },
+    });
+    migrator1.registerStep(stepFactory('persisted-step'));
+    await migrator1.runPendingSteps('0.9.0', '1.0.0');
+    expect(runCount).toBe(1);
+
+    // Brand-new instance pointed at the same stateDir — step body must
+    // not re-run because the ledger is on disk.
+    const migrator2 = buildMigrator(projectDir);
+    migrator2.registerStep(stepFactory('persisted-step'));
+    const report = await migrator2.runPendingSteps('0.9.0', '1.0.0');
+
+    expect(runCount).toBe(1); // unchanged
+    expect(report.steps[0].outcome).toBe('skipped');
+    expect(report.steps[0].details).toBe('already-recorded:completed');
+  });
+});
+
+describe('compareSemver (engine internals)', () => {
+  it('compares major.minor.patch correctly', () => {
+    expect(compareSemver('1.0.0', '1.0.0')).toBe(0);
+    expect(compareSemver('1.0.0', '1.0.1')).toBe(-1);
+    expect(compareSemver('1.1.0', '1.0.99')).toBe(1);
+    expect(compareSemver('2.0.0', '1.99.99')).toBe(1);
+  });
+
+  it('treats release > pre-release on the same triple', () => {
+    expect(compareSemver('1.0.0', '1.0.0-rc1')).toBe(1);
+    expect(compareSemver('1.0.0-rc1', '1.0.0')).toBe(-1);
+    expect(compareSemver('1.0.0-rc1', '1.0.0-rc2')).toBe(-1);
+  });
+
+  it('treats unparseable as -Infinity (cannot block step execution)', () => {
+    // fromVersion of '' (fresh install) must be < any real version.
+    expect(compareSemver('', '1.0.0')).toBe(-1);
+    expect(compareSemver('1.0.0', 'not-a-version')).toBe(1);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -35,6 +35,28 @@ This is the backend half of Phase 4. The Dashboard UI rewrite (Jobs tab, Issues 
 
 ## What Changed
 
+### feat(core): F-7 — PostUpdateMigrator atomic-step + announceOnce primitives (Tier-2)
+
+Ships F-7 from `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (§R1 Upgrade invariants + §A35 backup/sync wiring + §A50 hook-shape corrections + §A57 Tier-2). Two new primitives plus the A35 const-literal hook-shape changes.
+
+New module `src/core/MigratorStepEngine.ts`:
+
+- **`MigratorStepEngine`** — register named, idempotent atomic steps with a semver `version: string`. `runPendingSteps(fromVersion, toVersion)` executes every step whose `version <= toVersion` and isn't yet recorded. Ledger at `<stateDir>/migrator-steps-completed.json` keyed by `<version>:<step-name>`. Failed steps record `outcome: 'failed'` and do NOT roll back prior steps or block subsequent steps — each step is atomic and self-contained per spec. Atomic temp-file → fsync → rename writes.
+- **`AnnouncementManager`** — `announceOnce(announcementId, message, channel)` returns `true` if announced now, `false` if already shown. Ledger at `<stateDir>/announcements-shown.json` keyed by announcementId. Ledger is recorded BEFORE the sink fires so a flaky sink cannot cause duplicate emission. Default sink writes to stderr; callers can pass a Telegram/dashboard sink.
+
+Extension on `src/core/PostUpdateMigrator.ts`: new `registerStep(step)` + async `runPendingSteps(from, to)` methods delegate to a lazy `MigratorStepEngine`. The existing `MigratorConfig` constructor + all 15 existing `migrate*` methods + `migrate()` orchestrator are unchanged — F-7 is strictly additive.
+
+A35 hook-shape changes:
+
+- `src/core/GitStateManager.ts` — `DEFAULT_GITIGNORE` const literal now contains the five remediation runtime path globs (`remediation/system-reviewer-state-*.json`, `remediation/inbox-*.jsonl`, `remediation/audit-projection-*.jsonl`, `remediation/cross-process-attempts-*.jsonl`, `remediation/llm-raw-*.jsonl`). Exported `REMEDIATION_GITIGNORE_ENTRIES` as the canonical list. Fresh `instar git init` writes these out; existing `.gitignore` files are unchanged (the F-7 atomic step is responsible for patching them post-update).
+- `src/core/BackupManager.ts` — new exported const `REMEDIATION_EXCLUDED_PATH_PREFIXES` (the five remediation path prefixes). New optional 5th constructor arg `isRemediationEnabled?: () => boolean` parallels the existing `isIntegratedBeingEnabled` gate. When the gate returns true, the prefixes drop any user-added `includeFiles` entry whose path starts with a remediation prefix from the resolved include list. When false/absent (the default for every existing caller), behavior is identical to pre-F-7. No new plugin/register API per §A50.
+
+18 new tests across `tests/unit/PostUpdateMigrator-atomicStep.test.ts` (8), `tests/unit/AnnouncementManager.test.ts` (5), `tests/unit/PostUpdateMigrator-a35-remediationPaths.test.ts` (5). Covers: step runs once and records completion; subsequent runs skip; failed step records failure and doesn't block other steps; future-version step skipped without ledger entry; state persists across instances; semver compare; announceOnce true-then-false; independent ids; persistence; sink-throw does not cause re-emission; input validation; remediation entries in `DEFAULT_GITIGNORE`; exclusion-prefix gate ON/OFF/absent. All 76 pre-existing `PostUpdateMigrator-*` tests and 47 `BackupManager*` tests pass unchanged.
+
+No production wiring yet. Tier-2 surfaces (W-2..W-4, S-1..S-3) will register their own steps via `migrator.registerStep(...)` and surface migration outcomes via `announcer.announceOnce(...)`.
+
+Side-effects review: `upgrades/side-effects/f7-post-update-migrator-atomic-step.md`.
+
 ### feat(remediation): F-5 — TrustElevationSource + AutonomyProfileLevel wiring (Tier-2 foundation)
 
 First Tier-2 foundation module from `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (Trust elevation policy section + amendments A11, A22, A25, A41, A53, A57, A59). Three new modules under `src/remediation/`:
@@ -195,6 +217,8 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 
 **ELI16-overview gate.** When your agent hands you a spec for approval, you'll now always get a plain-English overview alongside the dense technical document. The instar repo refuses to commit any code change whose driving spec lacks a readable companion file. The technical spec becomes the appendix; the overview is the entry point. No setup required; the new behavior takes effect on the next agent update.
 
+**F-7 — Smarter upgrade migrations.** Instar can now run small, named "atomic steps" on each update — like "add this new entry to the agent's ignore list" or "back up this newly-introduced state file." Each step is recorded once it runs, so the next update doesn't redo it. If one step fails, it just records the failure and keeps going with the others; nothing rolls back. The same release adds a new "say this once" notice primitive so the agent can surface a migration result to you exactly once and never again, even after restarts. Nothing visible today — Tier-2 work is the first consumer. The same release also pre-loads ignore-list entries for the self-healing system's per-machine scratch files so they never get accidentally synced across your machines.
+
 ## Summary of New Capabilities
 
 - **`TrustElevationSource`** (F-5) — Authoritative policy module for runbook lifecycle transitions. Encodes the asymmetric trust-elevation table from the v2 spec: `live→quarantined` always-allowed (pessimistic), upward transitions require `collaborative` trust + the spec's freshness / history / approval-channel conditions, `proposal→registered` / `live→deprecated` / `deprecated→removed` are source-change-only (always refused programmatically).
@@ -231,3 +255,8 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 - **`NativeModuleHealer.invokeFromRemediator(ctx)`** (W-1) — Parallel entry point alongside the unchanged `openWithHeal` CLI safety net. Rebuilds via `npm rebuild --ignore-scripts --build-from-source better-sqlite3` (§A28 + §A45 — never bare `npm rebuild`, never picks up a poisoned prebuild binary). Records sha256 of the rebuilt `.node` binary for cross-process binary-divergence detection.
 - **Public types `RemediatorInvocationContext` / `RemediatorExecutionResult`** (W-1) — Structurally compatible with F-8's `RemediationContext` / `ExecutionResult` so the runbook's `surfaceCallable` typechecks without a hard import dependency from `src/memory/*` onto `src/remediation/*`.
 - **§A21-conformant verify probe** (W-1) — Opens an in-memory better-sqlite3 handle and runs `integrity_check`. `ok` → `verified-healthy`; non-`ok` row → `verify-failed`; constructor or pragma throw → `verify-inconclusive` (probe error, never failed).
+- **`MigratorStepEngine`** (F-7) — Atomic-step primitive: register named, idempotent migration steps versioned by semver. `runPendingSteps(from, to)` executes pending steps once per version with a `<stateDir>/migrator-steps-completed.json` ledger keyed by `<version>:<step-name>`. Failed steps record outcome `failed` but do not block subsequent steps.
+- **`PostUpdateMigrator.registerStep` / `.runPendingSteps`** (F-7) — Additive methods on the existing class; existing 15 `migrate*` methods + `migrate()` orchestrator unchanged. Tier-2 surfaces register their own steps via this API.
+- **`AnnouncementManager.announceOnce(id, message, channel)`** (F-7) — Show-once primitive backed by `<stateDir>/announcements-shown.json`. Returns true on first call, false on subsequent. Ledger written before sink fires, so a flaky sink cannot cause duplicate emission.
+- **`REMEDIATION_GITIGNORE_ENTRIES`** (F-7/A35) — Five remediation runtime path globs embedded into `GitStateManager.DEFAULT_GITIGNORE` const literal and exported as the source-of-truth list for the F-7 gitignore atomic step.
+- **`REMEDIATION_EXCLUDED_PATH_PREFIXES` + `isRemediationEnabled` gate** (F-7/A35) — `BackupManager` exclusion list with feature-flag gating that parallels the existing `isIntegratedBeingEnabled` pattern. Gate ON drops any user-added `includeFiles` entry that begins with a remediation prefix; gate OFF/absent preserves them for back-compat.

--- a/upgrades/side-effects/f7-post-update-migrator-atomic-step.md
+++ b/upgrades/side-effects/f7-post-update-migrator-atomic-step.md
@@ -1,0 +1,129 @@
+# Side-Effects Review — F-7: PostUpdateMigrator atomic-step + announceOnce primitives (Tier-2)
+
+**Version / slug:** `f7-post-update-migrator-atomic-step`
+**Date:** `2026-05-13`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Ships F-7 from the Self-Healing Remediator v2 spec (`docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §R1 Upgrade invariants + §A35 backup/sync wiring + §A50 hook-shape corrections + §A57 Tier-2 phase manifest).
+
+Two new primitives plus the A35 hook-shape changes:
+
+1. **`MigratorStepEngine`** — atomic, idempotent, run-once-per-version migration steps. Steps are registered by name + version. The engine writes a ledger at `<stateDir>/migrator-steps-completed.json` keyed by `<version>:<step-name>`. A step failure records `outcome: 'failed'` and does NOT roll back prior steps or block subsequent steps — each step is self-contained.
+
+2. **`AnnouncementManager`** — `announceOnce(id, message, channel)` primitive. Emits a message exactly once per id, then never again. Ledger at `<stateDir>/announcements-shown.json`. Used for surfacing migration completions and structural-change notices without spamming the user across restarts.
+
+3. **A35 hook-shape — `GitStateManager.DEFAULT_GITIGNORE` extension.** Const literal now contains five remediation runtime path globs (`remediation/system-reviewer-state-*.json`, `remediation/inbox-*.jsonl`, `remediation/audit-projection-*.jsonl`, `remediation/cross-process-attempts-*.jsonl`, `remediation/llm-raw-*.jsonl`). Exported as `REMEDIATION_GITIGNORE_ENTRIES` for the F-7 atomic step to use as the source-of-truth list.
+
+4. **A35 hook-shape — `BackupManager` exclusion list with feature-flag gate.** New const `REMEDIATION_EXCLUDED_PATH_PREFIXES` (exported) — the five remediation path prefixes. New optional constructor arg `isRemediationEnabled?: () => boolean` parallels the existing `isIntegratedBeingEnabled` gate. When the gate is ON, the prefixes drop any user-added `includeFiles` entry that begins with a remediation prefix. When OFF (or absent), the prefixes are inactive — strictly additive, no back-compat break.
+
+Files touched:
+- `src/core/MigratorStepEngine.ts` (add)
+- `src/core/PostUpdateMigrator.ts` (modify — add `registerStep` + `runPendingSteps` + lazy engine field; existing constructor + all 15 existing migration methods unchanged)
+- `src/core/GitStateManager.ts` (modify — extend `DEFAULT_GITIGNORE` const literal; export `REMEDIATION_GITIGNORE_ENTRIES`)
+- `src/core/BackupManager.ts` (modify — add `REMEDIATION_EXCLUDED_PATH_PREFIXES` const + export; add 5th optional constructor arg `isRemediationEnabled`; gate logic in `resolveIncludedFiles`)
+- `tests/unit/PostUpdateMigrator-atomicStep.test.ts` (add — 8 cases)
+- `tests/unit/AnnouncementManager.test.ts` (add — 5 cases)
+- `tests/unit/PostUpdateMigrator-a35-remediationPaths.test.ts` (add — 5 cases)
+- `upgrades/NEXT.md` (modify — preserves all existing entries; adds A35 + announceOnce entries)
+
+## Decision-point inventory
+
+- `PostUpdateMigrator.registerStep()` — **add** — delegates to lazy `MigratorStepEngine`. Existing 15 `migrate*` methods + `migrate()` orchestrator untouched.
+- `PostUpdateMigrator.runPendingSteps()` — **add** — async; returns `{ steps: [{name, outcome, details}] }`. Never throws.
+- `MigratorStepEngine.registerStep()` — rejects duplicate names, missing version/run.
+- `MigratorStepEngine.runPendingSteps()` — three skip reasons: `already-recorded:<outcome>`, `future-version:<step.version> > <toVersion>`, and explicit `'skipped'` from the step itself. Failed steps record `outcome: 'failed'` and DO NOT retry (operator must clear the ledger entry to retry — surfaces the failure in the report).
+- `MigratorStepEngine.writeLedger()` — atomic temp-file → fsync → rename, `0600` perms.
+- `AnnouncementManager.announceOnce()` — three-input validation (id, message, channel); records BEFORE sink-invoke so a flaky sink cannot cause duplicate emission. Sink throws are swallowed (ledger entry stands).
+- `GitStateManager.DEFAULT_GITIGNORE` const literal — **modify** — append remediation block. Backwards-compatible: previously private const is now exported (no internal call sites broken).
+- `BackupManager` constructor — **modify** — append 5th optional argument. All four existing call sites pass ≤4 args and continue to work.
+- `BackupManager.resolveIncludedFiles()` — **modify** — adds gated exclusion loop. When gate is OFF (the default — every existing caller), behavior is identical to pre-PR.
+
+No new HTTP routes. No new daemon processes. No new file types beyond two JSON ledgers in `<stateDir>`.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- **A future-version step is silently skipped.** Intended. The ledger is NOT written when the step's version > `toVersion`, so the next upgrade boundary that crosses the threshold runs the step.
+- **A failed step is NOT auto-retried on the next `runPendingSteps()` invocation.** This could be seen as over-blocking — a transient failure (disk full, network blip) gets recorded as `failed` and stays that way. Trade-off accepted because the alternative (unbounded retry on every update) lets a broken step DoS every release. Operator-facing mitigation: the failed entry surfaces in the migration report; clearing the ledger key allows retry.
+- **The `BackupManager` remediation-prefix gate, when ON, drops includeFiles entries whose paths begin with a remediation prefix.** A user who manually adds `.instar/remediation/system-reviewer-state-mine.json` to `config.backup.includeFiles` will see it silently dropped. Mitigated by: (a) the gate defaults to OFF until remediation is enabled; (b) the prefixes are documented in code + spec; (c) this is the explicit spec requirement (A14 "Backed up? no" rows).
+
+No unintended over-blocks.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **No cross-machine coordination of step execution.** Two machines updating to the same version in parallel each run their own steps independently. The ledger is per-machine. This is the correct model for per-machine state (gitignore lives in `<stateDir>/.gitignore` which is per-machine via the `.instar` git repo), but a future cross-machine migration would need additional coordination.
+- **Step `run()` is not deadline-enforced.** A hung step could block subsequent steps. The engine relies on step authors to be well-behaved. Real-world steps are file I/O against `<stateDir>` and complete in <50ms; a step that calls external APIs should add its own timeout. Worst case: the migrator hangs, the next update boundary sees the same situation; the user can `kill` the process and the ledger remains consistent.
+- **The `announceOnce` sink does not retry.** If a sink fails (e.g. Telegram offline), the announcement is recorded as shown but never delivered. This is the deliberate signal-vs-authority separation: the brittle sink layer does not have authority over the ledger. A future enhancement could add a separate delivery queue; F-7 keeps the primitive minimal.
+- **Ledger corruption is treated as empty.** If `migrator-steps-completed.json` becomes corrupt (truncated, bad JSON), the engine falls back to an empty ledger. This is intentional — the alternative (refuse to migrate) would be worse. Cost: a corrupt ledger causes one round of step re-runs; each step is idempotent by spec.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The two primitives sit at the `src/core/` layer — the same layer as `PostUpdateMigrator`, `GitStateManager`, `BackupManager`. They compose on top of `node:fs` only; no dependency on the Remediator (Tier-2 surfaces will register their own steps via `migrator.registerStep(...)` after import). The A35 const-literal extensions sit where the const lives — `GitStateManager` for the gitignore, `BackupManager` for the exclusion prefixes. No new plugin/register API was introduced per A50's explicit ruling.
+
+The `PostUpdateMigrator` class is the right owner for the public-facing `registerStep`/`runPendingSteps` methods even though the engine logic lives in `MigratorStepEngine` — the existing class is already the documented entry point for "thing that runs on update boundary". Tier-2/Tier-3 surfaces (S-2, S-3) will reach for `PostUpdateMigrator` first.
+
+---
+
+## 4. Signal-vs-authority compliance
+
+The brittle/low-context layers (file I/O ledger reads, sink invocations) are signal layers. The higher-context layer (the `runPendingSteps` orchestrator) is the authority. Specifically:
+
+- A corrupt ledger does NOT block migration — the ledger is treated as a signal ("here's what we believe happened"), and the engine recovers by treating it as empty. Authority over "should this step run" lives in the in-memory step list + the version comparison.
+- A failing sink does NOT block `announceOnce` from recording the announcement — sink delivery is signal; the ledger record is authority over "have we already attempted to surface this".
+- A failing step does NOT block other steps — the per-step try/catch isolates signals; the engine retains authority over the run sequence.
+
+This matches the §A50 / signal-vs-authority principle in MEMORY.md.
+
+---
+
+## 5. Interactions with existing surfaces
+
+- **`PostUpdateMigrator.migrate()` is untouched.** Existing callers (`src/update/UpdateService.ts`, `src/commands/init.ts`, etc.) continue to work — they call `migrate()` and never touch the new methods.
+- **`GitStateManager.init()`** — writes `DEFAULT_GITIGNORE` only when no `.gitignore` exists. Existing repos with `.gitignore` already on disk are unaffected. New repos get the remediation entries pre-included.
+- **`BackupManager` callers** — 14 existing call sites pass at most 4 constructor args. The new 5th arg is optional + defaults to no-op behavior. Verified by running the full `backup-manager.test.ts` (44 cases) and `BackupManager-sharedState.test.ts` (3 cases) — all pass unchanged.
+- **`upgrades/NEXT.md`** — only appended to (preserving the W-1, F-8, F-3, F-4, F-1..F-2 entries already on main).
+
+---
+
+## 6. Rollback cost
+
+Low. The two new modules (`MigratorStepEngine.ts`, the new methods on `PostUpdateMigrator.ts`) are dormant unless something calls `registerStep` — and nothing calls it in this PR. Tier-2 surfaces will be the first consumers. Reverting requires:
+
+1. `git revert` the PR. No data migration. No format changes. Existing `migrate()` behavior is untouched.
+2. If any agent has already created `migrator-steps-completed.json` or `announcements-shown.json` files, they become unused leftovers — no harm. They can be deleted at leisure.
+
+The A35 const-literal changes are inline edits to existing files; revert restores the prior literal. The `BackupManager`'s 5th constructor arg is optional and unused by every current caller, so removing it has zero blast radius.
+
+---
+
+## Tests
+
+- `tests/unit/PostUpdateMigrator-atomicStep.test.ts` — 8 cases covering: step runs once and records completion; step is skipped on subsequent runs; failed step records failure and doesn't block other steps; future-version step skipped without ledger entry; state persists across instances; semver compare correctness.
+- `tests/unit/AnnouncementManager.test.ts` — 5 cases covering: first-true / subsequent-false; independent ids; persistence across instances; sink-throw does not cause re-emission; input validation.
+- `tests/unit/PostUpdateMigrator-a35-remediationPaths.test.ts` — 5 cases covering: `DEFAULT_GITIGNORE` contains all five remediation entries; `REMEDIATION_EXCLUDED_PATH_PREFIXES` exported correctly; gate ON drops remediation entries; gate OFF preserves them; absent callback = back-compat (gate OFF).
+
+All 18 new tests pass. All 76 pre-existing `PostUpdateMigrator-*` tests pass unchanged. All 47 `BackupManager*` tests pass unchanged. TypeScript clean (`tsc --noEmit`).
+
+---
+
+## Gate trace
+
+- side-effects review: this document
+- NEXT.md: amended, preserving every prior entry
+- spec citation: `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §R1 + §A35 + §A50 + §A57
+- worktree: `/tmp/instar-f7-post-update-migrator` (branch `f7-post-update-migrator`)
+- no bypass; no `--no-verify`


### PR DESCRIPTION
## Summary

Ships F-7 from `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (§R1 Upgrade invariants + §A35 backup/sync wiring + §A50 hook-shape corrections + §A57 Tier-2). Two new primitives plus the A35 const-literal hook-shape changes.

- **`MigratorStepEngine`** (new module `src/core/MigratorStepEngine.ts`) — register named, idempotent atomic steps with a semver `version: string`. `runPendingSteps(from, to)` executes pending steps once per version. Ledger at `<stateDir>/migrator-steps-completed.json` keyed by `<version>:<step-name>`. Failed steps record `outcome: 'failed'` and do NOT roll back prior steps or block subsequent steps.
- **`AnnouncementManager`** (same module) — `announceOnce(id, message, channel)` primitive for "show this once, never again". Ledger at `<stateDir>/announcements-shown.json`. Ledger is recorded BEFORE the sink fires so a flaky sink cannot cause duplicate emission.
- **Additive on `PostUpdateMigrator`** — new `registerStep` + async `runPendingSteps` methods backed by a lazy engine. The existing `MigratorConfig` constructor + all 15 existing `migrate*` methods + `migrate()` orchestrator are unchanged.
- **A35 hook-shape** — `GitStateManager.DEFAULT_GITIGNORE` const literal carries the five remediation runtime path globs; exported as `REMEDIATION_GITIGNORE_ENTRIES`. `BackupManager` gains `REMEDIATION_EXCLUDED_PATH_PREFIXES` const + optional 5th constructor arg `isRemediationEnabled` that parallels `isIntegratedBeingEnabled`. Gate ON drops user-added remediation-prefixed `includeFiles`; OFF/absent preserves back-compat for every existing caller. No new plugin/register API per §A50.

No production wiring yet. Tier-2 surfaces (W-2..W-4, S-1..S-3) will register their own steps via `migrator.registerStep(...)` and surface migration outcomes via `announcer.announceOnce(...)`.

Side-effects review: `upgrades/side-effects/f7-post-update-migrator-atomic-step.md`.

## Test plan

- [x] 8 new tests in `tests/unit/PostUpdateMigrator-atomicStep.test.ts` — step runs once + records, subsequent runs skip, failed step doesn't block others, future-version skipped without ledger entry, state persists across instances, semver compare correctness.
- [x] 5 new tests in `tests/unit/AnnouncementManager.test.ts` — first-true/subsequent-false, independent ids, persistence, sink-throw cannot cause re-emission, input validation.
- [x] 5 new tests in `tests/unit/PostUpdateMigrator-a35-remediationPaths.test.ts` — `DEFAULT_GITIGNORE` contains all five entries, `REMEDIATION_EXCLUDED_PATH_PREFIXES` exported, gate ON drops, gate OFF preserves, absent callback = back-compat.
- [x] All 76 pre-existing `PostUpdateMigrator-*` tests pass unchanged.
- [x] All 47 `BackupManager*` + `git-state-manager` tests pass unchanged.
- [x] Full suite: 83 files / 2437 tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)