### PR TITLE
feat(scheduler): reconcile() boot lifecycle + GET /jobs/reconcile

### DIFF
--- a/src/scheduler/AgentMdReconcile.ts
+++ b/src/scheduler/AgentMdReconcile.ts
@@ -1,0 +1,251 @@
+/**
+ * AgentMdReconcile — boot-time consistency check for the agentmd job tree.
+ *
+ * Per INSTAR-JOBS-AS-AGENTMD spec §Runtime "Load lifecycle (boot)":
+ *
+ *   reconcile() runs at boot, surfaces orphan/shadow/missing on boot.
+ *   Output goes to Dashboard Issues card.
+ *
+ * Categories surfaced:
+ *
+ *   - ORPHAN-MANIFEST: A `<slug>.json` per-slug manifest exists but the
+ *     `.md` it references does NOT. Scheduler cannot resolve the body;
+ *     entry is excluded from jobs[] and surfaced as Issues-card row.
+ *
+ *   - SHADOW-MD: A `<slug>.md` exists in either `instar/` or `user/` but
+ *     has no per-slug manifest. The body is on disk but the scheduler
+ *     has no schedule for it — Issues-card "Add to schedule (disabled)"
+ *     or "Delete file" actions apply.
+ *
+ *   - MISSING-FROM-JOBS-JSON: A legacy `jobs.json` entry has no
+ *     corresponding per-slug manifest AND no `.md` under user/ or
+ *     instar/. Mid-migration state; not yet copied over.
+ *
+ *   - STAGED-NEW: A `.md.new` or `.json.new` left over from a crashed
+ *     atomic save (see AgentMdAtomicSave). Issues-card "Apply" /
+ *     "Discard" actions apply.
+ *
+ *   - CASE-COLLISION: Two slug files differ only by case (NFC normalized)
+ *     in the same directory. Both are excluded from jobs[] by the
+ *     loader; this row surfaces them together.
+ *
+ * Pure function — reads the file system, returns a structured report.
+ * The caller (boot lifecycle in JobLoader; Phase 4 Dashboard read
+ * endpoint) decides how to present the rows.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Local scanner for `.new` staged files. Will be replaced with the
+ *  shared `listStagedNewFiles()` export from `AgentMdAtomicSave.ts`
+ *  once that PR merges (echo/two-rename-atomicity). */
+function scanStagedFiles(jobsRoot: string): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    if (!fs.existsSync(dir)) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.isFile() && (p.endsWith('.md.new') || p.endsWith('.json.new'))) {
+        found.push(p);
+      }
+    }
+  };
+  walk(jobsRoot);
+  return found;
+}
+
+export type ReconcileFindingKind =
+  | 'orphan-manifest'
+  | 'shadow-md'
+  | 'missing-from-jobs-json'
+  | 'staged-new'
+  | 'case-collision';
+
+export interface ReconcileFinding {
+  kind: ReconcileFindingKind;
+  /** Affected slug (when computable). */
+  slug?: string;
+  /** Affected file path (absolute). */
+  filePath?: string;
+  /** Two-pane comparison: for case-collision, both paths. */
+  conflictingPaths?: string[];
+  /** One-line operator-facing summary. */
+  summary: string;
+  /** Stable severity ordering for the Issues card. */
+  severity: 'info' | 'warning' | 'error';
+}
+
+export interface ReconcileReport {
+  findings: ReconcileFinding[];
+  summary: {
+    total: number;
+    byKind: Record<ReconcileFindingKind, number>;
+  };
+}
+
+export interface ReconcileOptions {
+  /** State directory root (e.g., `<projectDir>/.instar/`). */
+  stateDir: string;
+}
+
+const EMPTY_BY_KIND: Record<ReconcileFindingKind, number> = {
+  'orphan-manifest': 0,
+  'shadow-md': 0,
+  'missing-from-jobs-json': 0,
+  'staged-new': 0,
+  'case-collision': 0,
+};
+
+export function reconcileAgentMdTree(opts: ReconcileOptions): ReconcileReport {
+  const { stateDir } = opts;
+  const jobsRoot = path.join(stateDir, 'jobs');
+  const scheduleDir = path.join(jobsRoot, 'schedule');
+  const instarDir = path.join(jobsRoot, 'instar');
+  const userDir = path.join(jobsRoot, 'user');
+  const jobsJsonPath = path.join(stateDir, 'jobs.json');
+
+  const findings: ReconcileFinding[] = [];
+  const byKind: Record<ReconcileFindingKind, number> = { ...EMPTY_BY_KIND };
+
+  // ── Index the per-slug manifests ─────────────────────────────────
+  const manifestSlugs = new Map<string, { path: string; origin?: string }>();
+  if (fs.existsSync(scheduleDir)) {
+    for (const f of fs.readdirSync(scheduleDir)) {
+      if (!f.endsWith('.json')) continue;
+      const slug = path.basename(f, '.json');
+      const p = path.join(scheduleDir, f);
+      let origin: string | undefined;
+      try {
+        const parsed = JSON.parse(fs.readFileSync(p, 'utf-8'));
+        origin = typeof parsed?.origin === 'string' ? parsed.origin : undefined;
+      } catch {
+        // Surface as orphan + add to find later.
+      }
+      manifestSlugs.set(slug, { path: p, origin });
+    }
+  }
+
+  // ── Index the .md files under instar/ and user/ ──────────────────
+  const mdSlugs = new Map<string, { path: string; namespace: 'instar' | 'user' }>();
+  for (const [dir, ns] of [
+    [instarDir, 'instar'],
+    [userDir, 'user'],
+  ] as const) {
+    if (!fs.existsSync(dir)) continue;
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith('.md') || f.startsWith('.')) continue;
+      const slug = path.basename(f, '.md');
+      const p = path.join(dir, f);
+      mdSlugs.set(slug, { path: p, namespace: ns });
+    }
+  }
+
+  // ── Orphan manifests: manifest exists, no .md ────────────────────
+  for (const [slug, info] of manifestSlugs.entries()) {
+    if (!mdSlugs.has(slug)) {
+      findings.push({
+        kind: 'orphan-manifest',
+        slug,
+        filePath: info.path,
+        summary: `Manifest "${slug}.json" exists but no matching .md under ${info.origin === 'instar' ? 'instar/' : info.origin === 'user' ? 'user/' : 'instar/ or user/'}.`,
+        severity: 'error',
+      });
+      byKind['orphan-manifest']++;
+    }
+  }
+
+  // ── Shadow .md: .md exists, no manifest ───────────────────────────
+  for (const [slug, info] of mdSlugs.entries()) {
+    if (!manifestSlugs.has(slug)) {
+      findings.push({
+        kind: 'shadow-md',
+        slug,
+        filePath: info.path,
+        summary: `Body file "${slug}.md" exists under ${info.namespace}/ but no per-slug manifest at schedule/${slug}.json.`,
+        severity: 'warning',
+      });
+      byKind['shadow-md']++;
+    }
+  }
+
+  // ── Missing from jobs.json: legacy entry not yet copied ──────────
+  if (fs.existsSync(jobsJsonPath)) {
+    try {
+      const entries = JSON.parse(fs.readFileSync(jobsJsonPath, 'utf-8'));
+      if (Array.isArray(entries)) {
+        for (const e of entries) {
+          if (!e || typeof e !== 'object' || typeof e.slug !== 'string') continue;
+          if (e.execute?.type !== 'prompt') continue;
+          if (!manifestSlugs.has(e.slug) && !mdSlugs.has(e.slug)) {
+            findings.push({
+              kind: 'missing-from-jobs-json',
+              slug: e.slug,
+              summary: `Legacy jobs.json entry "${e.slug}" has no per-slug manifest and no body file. Migration may have partially run.`,
+              severity: 'warning',
+            });
+            byKind['missing-from-jobs-json']++;
+          }
+        }
+      }
+    } catch {
+      // jobs.json malformed — separate concern, not surfaced here.
+    }
+  }
+
+  // ── Staged .new files from interrupted atomic save ───────────────
+  for (const staged of scanStagedFiles(jobsRoot)) {
+    findings.push({
+      kind: 'staged-new',
+      filePath: staged,
+      summary: `Staged file from interrupted save: ${path.relative(stateDir, staged)}. Operator can apply or discard via Dashboard.`,
+      severity: 'info',
+    });
+    byKind['staged-new']++;
+  }
+
+  // ── Case collisions: two .md or .json files differ only by case ──
+  detectCaseCollisions(instarDir, '.md', findings, byKind);
+  detectCaseCollisions(userDir, '.md', findings, byKind);
+  detectCaseCollisions(scheduleDir, '.json', findings, byKind);
+
+  return {
+    findings,
+    summary: { total: findings.length, byKind },
+  };
+}
+
+function detectCaseCollisions(
+  dir: string,
+  ext: string,
+  findings: ReconcileFinding[],
+  byKind: Record<ReconcileFindingKind, number>,
+): void {
+  if (!fs.existsSync(dir)) return;
+  const seen = new Map<string, string[]>();
+  for (const f of fs.readdirSync(dir)) {
+    if (!f.endsWith(ext) || f.startsWith('.')) continue;
+    const slug = path.basename(f, ext);
+    const normalized = slug.normalize('NFC').toLowerCase();
+    if (!seen.has(normalized)) seen.set(normalized, []);
+    seen.get(normalized)!.push(path.join(dir, f));
+  }
+  for (const [, paths] of seen) {
+    if (paths.length > 1) {
+      findings.push({
+        kind: 'case-collision',
+        conflictingPaths: paths,
+        summary: `Case-only filename collision in ${path.basename(dir)}/: ${paths.map((p) => path.basename(p)).join(' vs ')}. Both excluded from jobs[]; manual resolution required.`,
+        severity: 'error',
+      });
+      byKind['case-collision']++;
+    }
+  }
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -4403,6 +4403,31 @@ export function createRoutes(ctx: RouteContext): Router {
    *   - canAbandon: boolean (schedule/ exists, no completion marker)
    *   - scheduleEntryCount: number
    */
+  /**
+   * GET /jobs/reconcile
+   *
+   * Boot-time consistency check for the agentmd job tree. Surfaces
+   * orphan manifests, shadow .md files, missing-from-jobs.json entries,
+   * staged .new files from interrupted saves, and case-collisions per
+   * INSTAR-JOBS-AS-AGENTMD spec §Runtime "Load lifecycle (boot)".
+   *
+   * Dashboard Issues-card consumes the returned `findings` array.
+   */
+  router.get('/jobs/reconcile', async (_req, res) => {
+    try {
+      const stateDir = ctx.config.stateDir;
+      if (!stateDir) {
+        res.status(503).json({ error: 'state dir not configured' });
+        return;
+      }
+      const { reconcileAgentMdTree } = await import('../scheduler/AgentMdReconcile.js');
+      const report = reconcileAgentMdTree({ stateDir });
+      res.json(report);
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
   router.get('/jobs/migration-status', (_req, res) => {
     try {
       const stateDir = ctx.config.stateDir;

--- a/tests/unit/scheduler/AgentMdReconcile.test.ts
+++ b/tests/unit/scheduler/AgentMdReconcile.test.ts
@@ -1,0 +1,174 @@
+/**
+ * AgentMdReconcile — boot-time consistency check tests.
+ *
+ * Per INSTAR-JOBS-AS-AGENTMD spec §Runtime "Load lifecycle (boot)".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { reconcileAgentMdTree } from '../../../src/scheduler/AgentMdReconcile.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+describe('AgentMdReconcile', () => {
+  let workspace: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-rec-'));
+    stateDir = path.join(workspace, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(workspace, { recursive: true, force: true, operation: 'AgentMdReconcile.test cleanup' });
+  });
+
+  function writeManifest(slug: string, origin: 'instar' | 'user' = 'user'): void {
+    const dir = path.join(stateDir, 'jobs', 'schedule');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${slug}.json`), JSON.stringify({ slug, origin, schedule: '*/5 * * * *', enabled: true, execute: { type: 'agentmd' } }));
+  }
+
+  function writeMd(slug: string, namespace: 'instar' | 'user'): void {
+    const dir = path.join(stateDir, 'jobs', namespace);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${slug}.md`), `---\nname: ${slug}\n---\nbody\n`);
+  }
+
+  function writeJobsJson(entries: any[]): void {
+    fs.writeFileSync(path.join(stateDir, 'jobs.json'), JSON.stringify(entries, null, 2));
+  }
+
+  it('clean tree produces zero findings', () => {
+    writeManifest('alpha', 'user');
+    writeMd('alpha', 'user');
+
+    const report = reconcileAgentMdTree({ stateDir });
+    expect(report.findings).toEqual([]);
+    expect(report.summary.total).toBe(0);
+  });
+
+  it('orphan-manifest surfaces when manifest exists with no matching .md', () => {
+    writeManifest('orphan-slug', 'user');
+    // No corresponding .md.
+
+    const report = reconcileAgentMdTree({ stateDir });
+
+    const orphans = report.findings.filter((f) => f.kind === 'orphan-manifest');
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].slug).toBe('orphan-slug');
+    expect(orphans[0].severity).toBe('error');
+    expect(report.summary.byKind['orphan-manifest']).toBe(1);
+  });
+
+  it('shadow-md surfaces when .md exists with no matching manifest', () => {
+    writeMd('shadow-slug', 'user');
+    // No corresponding manifest.
+
+    const report = reconcileAgentMdTree({ stateDir });
+
+    const shadows = report.findings.filter((f) => f.kind === 'shadow-md');
+    expect(shadows).toHaveLength(1);
+    expect(shadows[0].slug).toBe('shadow-slug');
+    expect(shadows[0].severity).toBe('warning');
+    expect(report.summary.byKind['shadow-md']).toBe(1);
+  });
+
+  it('missing-from-jobs-json surfaces when a legacy prompt entry has neither manifest nor .md', () => {
+    writeJobsJson([
+      { slug: 'legacy-prompt', execute: { type: 'prompt', value: 'do thing' }, schedule: '*/5 * * * *' },
+      { slug: 'migrated-already', execute: { type: 'prompt', value: 'old' }, schedule: '*/5 * * * *' },
+    ]);
+    writeManifest('migrated-already', 'user');
+    writeMd('migrated-already', 'user');
+
+    const report = reconcileAgentMdTree({ stateDir });
+
+    const missing = report.findings.filter((f) => f.kind === 'missing-from-jobs-json');
+    expect(missing).toHaveLength(1);
+    expect(missing[0].slug).toBe('legacy-prompt');
+  });
+
+  it('staged-new surfaces .new files from interrupted atomic save', () => {
+    fs.mkdirSync(path.join(stateDir, 'jobs', 'user'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'jobs', 'user', 'crashy.md.new'), 'staged body');
+    fs.mkdirSync(path.join(stateDir, 'jobs', 'schedule'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'jobs', 'schedule', 'crashy.json.new'), '{}');
+
+    const report = reconcileAgentMdTree({ stateDir });
+
+    const staged = report.findings.filter((f) => f.kind === 'staged-new');
+    expect(staged).toHaveLength(2);
+    expect(staged.every((s) => s.severity === 'info')).toBe(true);
+  });
+
+  it('case-collision surfaces two .md files differing only in case (case-sensitive FS only)', () => {
+    // macOS APFS and Windows NTFS are case-insensitive by default; this
+    // test only exercises the detection on case-sensitive filesystems
+    // (Linux ext4, etc.). On case-insensitive filesystems, the second
+    // write replaces the first via inode-equivalence, so there's no
+    // actual collision to detect.
+    const dir = path.join(stateDir, 'jobs', 'user');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'Health-Check.md'), 'a');
+    fs.writeFileSync(path.join(dir, 'health-check.md'), 'b');
+
+    const listing = fs.readdirSync(dir);
+    if (listing.length < 2) {
+      // Case-insensitive FS: both writes landed on the same path.
+      // Skip this test variant — the detection logic is correct, the
+      // OS just can't reproduce the collision here.
+      return;
+    }
+
+    const report = reconcileAgentMdTree({ stateDir });
+
+    const collisions = report.findings.filter((f) => f.kind === 'case-collision');
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0].severity).toBe('error');
+    expect(collisions[0].conflictingPaths).toHaveLength(2);
+  });
+
+  it('non-prompt legacy entries (script/skill) do NOT surface as missing-from-jobs-json', () => {
+    writeJobsJson([
+      { slug: 'script-job', execute: { type: 'script', value: 'echo' }, schedule: '*/5 * * * *' },
+      { slug: 'skill-job', execute: { type: 'skill', value: 'my-skill' }, schedule: '*/5 * * * *' },
+    ]);
+
+    const report = reconcileAgentMdTree({ stateDir });
+
+    expect(report.findings.filter((f) => f.kind === 'missing-from-jobs-json')).toHaveLength(0);
+  });
+
+  it('reports multiple findings simultaneously with correct counts', () => {
+    writeManifest('orphan-1', 'user');
+    writeManifest('orphan-2', 'user');
+    writeMd('shadow-1', 'instar');
+    fs.mkdirSync(path.join(stateDir, 'jobs', 'user'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'jobs', 'user', 'staged.md.new'), 's');
+
+    const report = reconcileAgentMdTree({ stateDir });
+
+    expect(report.summary.byKind['orphan-manifest']).toBe(2);
+    expect(report.summary.byKind['shadow-md']).toBe(1);
+    expect(report.summary.byKind['staged-new']).toBe(1);
+    expect(report.summary.total).toBe(4);
+  });
+
+  it('empty state directory produces zero findings (fresh install)', () => {
+    const report = reconcileAgentMdTree({ stateDir });
+    expect(report.summary.total).toBe(0);
+  });
+
+  it('reconcileAgentMdTree is pure — calling it twice produces identical output', () => {
+    writeManifest('a', 'user');
+    writeMd('a', 'user');
+    writeManifest('orphan', 'user');
+
+    const r1 = reconcileAgentMdTree({ stateDir });
+    const r2 = reconcileAgentMdTree({ stateDir });
+    expect(JSON.stringify(r2)).toBe(JSON.stringify(r1));
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -8,6 +8,9 @@ note (`upgrades/<version>.md`) at release-cut time.
 ### feat(scheduler): agentmd two-rename atomic save helper
 
 New `src/scheduler/AgentMdAtomicSave.ts` ships the canonical "md-first, manifest-last" two-rename commit sequence per INSTAR-JOBS-AS-AGENTMD spec §Design Principle 2. SIGKILL between rename A (body) and rename B (manifest) leaves a consistent strictly-progressed state. The helper returns structured failure info for each stage so a Phase 4 Dashboard UI consumer can drive recovery. Companion `listStagedNewFiles()` + `discardStagedFile()` are sized for the future reconcile() boot lifecycle. 8 unit tests pass. No caller wired yet — Phase 4 Dashboard UI rewrite is the consumer.
+### feat(scheduler): reconcile() boot lifecycle + GET /jobs/reconcile endpoint
+
+New `src/scheduler/AgentMdReconcile.ts` exports `reconcileAgentMdTree()` — boot-time consistency check that surfaces five finding kinds per INSTAR-JOBS-AS-AGENTMD spec §Runtime: orphan manifests, shadow .md files, missing-from-jobs.json entries, staged .new files (from interrupted atomic saves), and case-collisions. New `GET /jobs/reconcile` HTTP endpoint returns the structured report for Dashboard Issues-card consumption. 10 unit tests. Pure function — no auto-remediation; the operator decides what to do via Dashboard actions.
 
 ### fix(server): File Viewer extends never-editable to .instar/jobs/instar/
 

--- a/upgrades/side-effects/agentmd-reconcile-boot-lifecycle.md
+++ b/upgrades/side-effects/agentmd-reconcile-boot-lifecycle.md
@@ -1,0 +1,66 @@
+# Side-effects review — agentmd reconcile() boot lifecycle
+
+## What changed
+
+Implements INSTAR-JOBS-AS-AGENTMD spec §Runtime "Load lifecycle (boot)":
+> reconcile() runs at boot, surfaces orphan/shadow/missing on boot. Output goes to Dashboard Issues card.
+
+New module `src/scheduler/AgentMdReconcile.ts` exports `reconcileAgentMdTree({ stateDir })` returning a structured `ReconcileReport`. Five finding kinds:
+
+- **orphan-manifest** (severity: error) — `<slug>.json` exists but no matching `.md`.
+- **shadow-md** (severity: warning) — `<slug>.md` exists but no per-slug manifest.
+- **missing-from-jobs-json** (severity: warning) — legacy `jobs.json` prompt entry has neither manifest nor `.md` (mid-migration).
+- **staged-new** (severity: info) — `.md.new` or `.json.new` left over from a crashed atomic save (matches the helper landed in #211 echo/two-rename-atomicity, with a local-inlined scanner to avoid cross-PR dependency).
+- **case-collision** (severity: error) — two slug files differ only by case under NFC normalization (matches the spec §Security Model "Case-collision" threat row).
+
+New HTTP endpoint `GET /jobs/reconcile` returns the report. Dashboard Issues-card UI (Phase 4 rewrite, future) consumes the findings array.
+
+## Side-effects review
+
+### 1. Over-block / under-block
+
+- **Over-block:** none. The reconciler is a read-only pure function. No state is modified.
+- **Under-block:** the reconciler does NOT auto-remediate. It surfaces findings; the operator (via Dashboard Issues-card) decides whether to "Restore from git" / "Delete file" / "Add to schedule (disabled)" / "Apply staged" / etc. Per spec §Dashboard Error Surfaces.
+
+### 2. Level-of-abstraction fit
+
+Pure function. Reads the file system, returns structured findings. Severity is encoded in the data so the Dashboard's sort-by-severity rendering is one-line consumer code.
+
+### 3. Signal-vs-authority compliance
+
+The reconciler is purely a signal generator. It surfaces problems; it never decides what to do about them. Authority for remediation lives at the Dashboard layer (operator-confirmed actions) and at the loader (which already excludes orphan-manifest and case-collision entries from `jobs[]`).
+
+### 4. Interactions
+
+- **Phase 1a JobLoader** — already excludes case-collision entries from `jobs[]` (spec §Slug rules) and orphan-manifest entries (resolver fails). The reconciler surfaces these so the operator knows about excluded entries; the loader's exclusion behavior is unchanged.
+- **AgentMdAtomicSave** (PR #211, in flight) — emits `.md.new` / `.json.new` files when SIGKILL'd mid-save; this PR's `staged-new` finding kind surfaces them. The scanner is inlined here pending #211 merge; a future cleanup PR can swap to the shared `listStagedNewFiles()` import.
+- **Phase 4 Dashboard backend endpoints (PR #195)** — `/jobs/reconcile` is the third migration-state endpoint after `/jobs/migration-status`, `/jobs/migration-confirm`, `/jobs/migration-abandon`. Same auth surface (currently unauthenticated; #19 follow-up adds bearer-token gate).
+- **Phase 4 Dashboard UI rewrite (future)** — consumes the findings array directly into the Issues card. Per spec §Dashboard Error Surfaces.
+
+### 5. Rollback cost
+
+Trivial. Pure function + thin HTTP wrapper. Removing both is one revert.
+
+## Test coverage
+
+10 cases in `tests/unit/scheduler/AgentMdReconcile.test.ts`:
+
+1. Clean tree → zero findings
+2. orphan-manifest detection (severity: error)
+3. shadow-md detection (severity: warning)
+4. missing-from-jobs-json detection (legacy mid-migration)
+5. staged-new detection from interrupted atomic save
+6. case-collision detection (case-sensitive FS only — gracefully skipped on macOS/Windows)
+7. Non-prompt legacy entries (script/skill) excluded from missing-from-jobs-json
+8. Multiple findings simultaneously with correct counts
+9. Empty state directory → zero findings (fresh install)
+10. Pure: calling twice produces identical output
+
+All 10 pass locally. Lint + type-check pass.
+
+## What is NOT in this PR
+
+- Dashboard Issues-card UI (Phase 4 rewrite — separate effort).
+- Auto-remediation actions (operator-confirmed only per spec).
+- Bearer-token auth on `/jobs/reconcile` (follow-up task #19).
+- Wiring reconcile into JobLoader's boot path to emit Dashboard events automatically (the HTTP endpoint serves the same data on-demand; a boot-time event emission is incremental polish).


### PR DESCRIPTION
## Summary

Implements INSTAR-JOBS-AS-AGENTMD spec §Runtime "Load lifecycle (boot)". New `reconcileAgentMdTree()` pure function surfaces 5 finding kinds (orphan-manifest, shadow-md, missing-from-jobs-json, staged-new, case-collision). New `GET /jobs/reconcile` HTTP endpoint serves the report.

10 unit tests pass.

## Test plan

- [x] 10 cases pass
- [x] Lint + type-check pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)