### PR TITLE
test(scheduler): 200-job loader cold/warm boot perf benchmark

### DIFF
--- a/tests/integration/agentmd-loader-200jobs-perf.test.ts
+++ b/tests/integration/agentmd-loader-200jobs-perf.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Loader cold-boot performance benchmark — 200-job synthetic fixture.
+ *
+ * Per INSTAR-JOBS-AS-AGENTMD spec §Performance Budgets:
+ *   - Loader cold-boot @ 200 jobs: <1500 ms (CI benchmark fixture asserts this)
+ *   - Loader warm-boot @ 200 jobs: <500 ms
+ *
+ * The fixture is generated at test-setup time (not committed) — the
+ * generator is deterministic so the fixture content is stable across
+ * runs. This avoids bloating the repo with 200 markdown files while
+ * preserving the spec's CI-time assertion.
+ *
+ * "Cold-boot" here means the first loadJobs() call after fresh fixture
+ * generation; "warm-boot" is a second call against the same fixture
+ * (filesystem cache primed).
+ *
+ * The budget is intentionally generous (1500ms cold) — CI runners vary
+ * in IO speed. If this benchmark becomes flaky on slow runners, the
+ * remediation is to:
+ *   1. Profile and identify the slow step.
+ *   2. Optimize the loader's IO pattern.
+ *   3. NOT to raise the budget — the spec's number is the contract.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { loadJobs } from '../../src/scheduler/JobLoader.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const NUM_JOBS = 200;
+const COLD_BOOT_BUDGET_MS = 1500;
+const WARM_BOOT_BUDGET_MS = 500;
+
+describe('agentmd loader — 200-job cold-boot perf', () => {
+  let workspace: string;
+  let stateDir: string;
+
+  beforeAll(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-perf-'));
+    stateDir = path.join(workspace, '.instar');
+    generate200JobFixture(stateDir);
+  });
+
+  afterAll(() => {
+    SafeFsExecutor.safeRmSync(workspace, { recursive: true, force: true, operation: 'agentmd-loader-200jobs-perf.test cleanup' });
+  });
+
+  it(`cold-boot loads ${NUM_JOBS} per-slug manifests in <${COLD_BOOT_BUDGET_MS}ms`, () => {
+    const jobsFile = path.join(stateDir, 'jobs.json');
+    const t0 = process.hrtime.bigint();
+    const result = loadJobs(jobsFile);
+    const elapsedMs = Number(process.hrtime.bigint() - t0) / 1_000_000;
+
+    expect(result.length).toBeGreaterThanOrEqual(NUM_JOBS);
+    expect(elapsedMs).toBeLessThan(COLD_BOOT_BUDGET_MS);
+
+    // Informational: print measured time so CI logs show the actual cost.
+    console.log(`[perf-benchmark] cold-boot loaded ${result.length} jobs in ${elapsedMs.toFixed(1)}ms (budget ${COLD_BOOT_BUDGET_MS}ms)`);
+  });
+
+  it(`warm-boot loads ${NUM_JOBS} per-slug manifests in <${WARM_BOOT_BUDGET_MS}ms`, () => {
+    const jobsFile = path.join(stateDir, 'jobs.json');
+    // Warm: filesystem cache is hot from the cold-boot test.
+    const t0 = process.hrtime.bigint();
+    const result = loadJobs(jobsFile);
+    const elapsedMs = Number(process.hrtime.bigint() - t0) / 1_000_000;
+
+    expect(result.length).toBeGreaterThanOrEqual(NUM_JOBS);
+    expect(elapsedMs).toBeLessThan(WARM_BOOT_BUDGET_MS);
+
+    console.log(`[perf-benchmark] warm-boot loaded ${result.length} jobs in ${elapsedMs.toFixed(1)}ms (budget ${WARM_BOOT_BUDGET_MS}ms)`);
+  });
+});
+
+/**
+ * Deterministic generator for the 200-job fixture. Produces:
+ *   - `.instar/jobs/user/<slug>.md` × 200 with realistic-shaped bodies
+ *   - `.instar/jobs/schedule/<slug>.json` × 200 with valid manifests
+ *   - `.instar/jobs.json` empty array (the per-slug manifests are the source of truth)
+ *
+ * Bodies are sized in the 200–600 char range to mirror the typical
+ * default-job prompt distribution.
+ */
+function generate200JobFixture(stateDir: string): void {
+  const userDir = path.join(stateDir, 'jobs', 'user');
+  const scheduleDir = path.join(stateDir, 'jobs', 'schedule');
+  fs.mkdirSync(userDir, { recursive: true });
+  fs.mkdirSync(scheduleDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, 'jobs.json'), '[]', 'utf-8');
+
+  const bodyFragments = [
+    'Check the health endpoint. Report any anomalies in plain English.',
+    'Summarize the last 24 hours of activity. Highlight unusual patterns.',
+    'Review recent commits for security implications. List concerns with severity.',
+    'Audit the relationship registry. Flag stale entries.',
+    'Scan the degradation digest. Surface any new escalations.',
+  ];
+
+  for (let i = 0; i < NUM_JOBS; i++) {
+    const slug = `perf-job-${String(i).padStart(3, '0')}`;
+    const bodyBase = bodyFragments[i % bodyFragments.length];
+    const body = `# ${slug}\n\n${bodyBase}\n\nJob index: ${i}. Synthetic fixture for perf benchmark.\n`;
+    const frontmatter = [
+      `name: "${slug}"`,
+      'description: "synthetic perf fixture job"',
+      'toolAllowlist: ["Read"]',
+    ].join('\n');
+    fs.writeFileSync(path.join(userDir, `${slug}.md`), `---\n${frontmatter}\n---\n${body}`, 'utf-8');
+
+    fs.writeFileSync(
+      path.join(scheduleDir, `${slug}.json`),
+      JSON.stringify({
+        slug,
+        origin: 'user',
+        schedule: `${i % 60} * * * *`,
+        priority: 'low',
+        expectedDurationMinutes: 1,
+        model: 'haiku',
+        enabled: true,
+        execute: { type: 'agentmd' },
+        manifestVersion: 1,
+      }, null, 2),
+      'utf-8',
+    );
+  }
+}

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -15,6 +15,9 @@ New `src/scheduler/AgentMdAtomicSave.ts` ships the canonical "md-first, manifest
 ### feat(scheduler): reconcile() boot lifecycle + GET /jobs/reconcile endpoint
 
 New `src/scheduler/AgentMdReconcile.ts` exports `reconcileAgentMdTree()` — boot-time consistency check that surfaces five finding kinds per INSTAR-JOBS-AS-AGENTMD spec §Runtime: orphan manifests, shadow .md files, missing-from-jobs.json entries, staged .new files (from interrupted atomic saves), and case-collisions. New `GET /jobs/reconcile` HTTP endpoint returns the structured report for Dashboard Issues-card consumption. 10 unit tests. Pure function — no auto-remediation; the operator decides what to do via Dashboard actions.
+### test(scheduler): 200-job loader cold/warm boot perf benchmark
+
+New integration test asserts INSTAR-JOBS-AS-AGENTMD spec §Performance Budgets at 200 jobs: cold-boot <1500ms, warm-boot <500ms. Fixture generated deterministically at test-setup time (no fixture files committed to the repo). Measured times logged to stdout for CI runner debuggability. Currently observed: cold ~15ms, warm ~16ms — orders of magnitude under budget; spec's ceilings give substantial headroom for slower CI hardware.
 
 ### fix(server): File Viewer extends never-editable to .instar/jobs/instar/
 

--- a/upgrades/side-effects/agentmd-loader-200jobs-perf-benchmark.md
+++ b/upgrades/side-effects/agentmd-loader-200jobs-perf-benchmark.md
@@ -1,0 +1,50 @@
+# Side-effects review — agentmd 200-job loader perf benchmark
+
+## What changed
+
+New CI-time integration test `tests/integration/agentmd-loader-200jobs-perf.test.ts` exercises the spec §Performance Budgets contract:
+
+- Cold-boot @ 200 per-slug manifests: <1500ms
+- Warm-boot @ 200 per-slug manifests: <500ms
+
+The fixture is generated deterministically at test-setup time (`generate200JobFixture(stateDir)`) — 200 `.md` bodies + 200 manifests in a synthetic workspace. The generator stays out of the repo (no 400 fixture files committed) but the bytes it produces are stable across runs.
+
+## Side-effects review
+
+### 1. Over-block / under-block
+
+- **Over-block:** the test fails the build only when the loader actually exceeds the budget. The cold-boot budget (1500ms) is intentionally generous for CI runners with variable IO speed; if it becomes flaky, the remediation is to profile + optimize the loader, NOT to raise the budget (the spec's number is the contract).
+- **Under-block:** the benchmark only measures `loadJobs()` itself — not server boot, not migrator, not session spawn. A regression elsewhere in the boot path would not surface here. Adding boot-level benchmarks is a separate effort if needed.
+
+### 2. Level-of-abstraction fit
+
+Pure consumer of `loadJobs()`. The fixture generator is co-located in the test file (small enough to live there). No new runtime code paths.
+
+### 3. Signal-vs-authority compliance
+
+The test produces a signal ("budget exceeded"). The CI pipeline is the authority that fails the build on that signal. Both budgets are encoded as constants in the test, so any change to them is visible in the diff.
+
+### 4. Interactions
+
+- **Phase 1a JobLoader** — exercised directly. Any optimization to the per-slug fanout, YAML parse, or Zod validation will show up here.
+- **Phase 1c-runtime lock-file consumer** — runs as part of `loadJobs` for `origin:instar` entries. The fixture uses `origin:user` to keep the benchmark focused on the loader fanout path; lock-file verification has its own dedicated tests.
+- **CI runner stability** — measurements log to stdout so flakes are debuggable. If the budget becomes a problem on a specific runner shard, the log output identifies which step is slow.
+
+### 5. Rollback cost
+
+Trivial. Single test file. Delete to revert.
+
+## Test coverage
+
+2 cases in `tests/integration/agentmd-loader-200jobs-perf.test.ts`:
+
+1. Cold-boot @ 200 jobs <1500ms (per spec)
+2. Warm-boot @ 200 jobs <500ms (per spec)
+
+Locally observed: cold ~15ms, warm ~16ms — orders of magnitude under budget. CI runners are slower; the 1500ms ceiling gives substantial headroom.
+
+## What is NOT in this PR
+
+- Reconcile + dispatch + spawn-time benchmarks (separate concerns).
+- Per-step profiling (only end-to-end loader latency is asserted).
+- Memory benchmarks (the spec's budgets are time-bounded only).


### PR DESCRIPTION
## Summary

New integration test asserts INSTAR-JOBS-AS-AGENTMD spec §Performance Budgets at 200 jobs: cold-boot <1500ms, warm-boot <500ms. Fixture generated deterministically at test-setup time. Locally measured: cold ~15ms, warm ~16ms.

## Test plan

- [x] 2 cases pass
- [x] Lint + type-check pass
- [ ] CI green (budget gives substantial headroom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)