### PR TITLE
feat(scheduler): disabledAtBodyHash drift-detection helpers

### DIFF
--- a/src/scheduler/DisabledBodyDrift.ts
+++ b/src/scheduler/DisabledBodyDrift.ts
@@ -1,0 +1,170 @@
+/**
+ * DisabledBodyDrift — detect whether an operator-disabled default has had
+ * its body change since the operator disabled it.
+ *
+ * Per INSTAR-JOBS-AS-AGENTMD spec §Dashboard UX:
+ *   row per job: status dot, name + description, schedule, last run + bodyHash link,
+ *   enabled toggle (records disabledAtBodyHash), namespace badge
+ *
+ * The manifest field `disabledAtBodyHash` is captured by the Dashboard
+ * when the operator flips the enabled toggle to false. It records the
+ * normalized SHA-256 of the body at disable-time. On every subsequent
+ * `instar update`, the body may change; `bodyDriftedSinceDisable(...)`
+ * returns true when the current body hash no longer matches what was
+ * captured. The Dashboard surfaces a "default has changed since you
+ * disabled it — consider reviewing" badge in response.
+ *
+ * Pure function — reads the manifest + the .md file. No state, no
+ * side-effects.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { hashBody, normalize } from './AgentMdLockFile.js';
+
+export interface BodyDriftCheckOptions {
+  /** Agent state directory root (e.g., `<projectDir>/.instar/`). */
+  stateDir: string;
+  /** Job slug to check. */
+  slug: string;
+}
+
+export type BodyDriftStatus =
+  | { kind: 'no-drift' }
+  | { kind: 'drifted'; disabledAtBodyHash: string; currentBodyHash: string }
+  | { kind: 'manifest-missing' }
+  | { kind: 'body-missing'; expectedPath: string }
+  | { kind: 'not-disabled'; note: string }
+  | { kind: 'no-disable-record'; note: string };
+
+export function bodyDriftedSinceDisable(opts: BodyDriftCheckOptions): BodyDriftStatus {
+  const { stateDir, slug } = opts;
+  const manifestPath = path.join(stateDir, 'jobs', 'schedule', `${slug}.json`);
+
+  if (!fs.existsSync(manifestPath)) {
+    return { kind: 'manifest-missing' };
+  }
+
+  let manifest: any;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  } catch {
+    return { kind: 'manifest-missing' };
+  }
+
+  if (manifest.enabled !== false) {
+    return { kind: 'not-disabled', note: `Slug "${slug}" is enabled; drift check applies only to operator-disabled defaults.` };
+  }
+  if (typeof manifest.disabledAtBodyHash !== 'string' || !manifest.disabledAtBodyHash.startsWith('sha256:')) {
+    return { kind: 'no-disable-record', note: `Slug "${slug}" is disabled but has no disabledAtBodyHash captured. Pre-spec disable, or manifest manually edited.` };
+  }
+
+  // Resolve the body file — try instar/ first (origin:instar) then user/.
+  const namespace: 'instar' | 'user' = manifest.origin === 'instar' ? 'instar' : 'user';
+  const expectedPath = path.join(stateDir, 'jobs', namespace, `${slug}.md`);
+  if (!fs.existsSync(expectedPath)) {
+    return { kind: 'body-missing', expectedPath };
+  }
+
+  let bodyText: string;
+  try {
+    const raw = fs.readFileSync(expectedPath, 'utf-8');
+    const match = raw.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+    bodyText = match ? match[1] : raw;
+  } catch {
+    return { kind: 'body-missing', expectedPath };
+  }
+
+  const currentBodyHash = hashBody(bodyText);
+  if (currentBodyHash === manifest.disabledAtBodyHash) {
+    return { kind: 'no-drift' };
+  }
+
+  return {
+    kind: 'drifted',
+    disabledAtBodyHash: manifest.disabledAtBodyHash,
+    currentBodyHash,
+  };
+}
+
+/**
+ * Convenience helper: list every slug whose disabled-state has drifted
+ * since the operator disabled it. Used by the Dashboard's status feed and
+ * by the drift digest.
+ */
+export function listDriftedDisabledSlugs(stateDir: string): Array<{ slug: string; status: BodyDriftStatus }> {
+  const scheduleDir = path.join(stateDir, 'jobs', 'schedule');
+  if (!fs.existsSync(scheduleDir)) return [];
+  const results: Array<{ slug: string; status: BodyDriftStatus }> = [];
+  for (const f of fs.readdirSync(scheduleDir)) {
+    if (!f.endsWith('.json') || f.startsWith('.')) continue;
+    const slug = path.basename(f, '.json');
+    const status = bodyDriftedSinceDisable({ stateDir, slug });
+    if (status.kind === 'drifted') {
+      results.push({ slug, status });
+    }
+  }
+  return results;
+}
+
+/**
+ * Stamp the disabledAtBodyHash field on a manifest. Used by the Dashboard
+ * "disable" action and by the future CLI `instar job disable <slug>`
+ * command. Idempotent: re-stamping with the same body produces the same
+ * hash. Re-disabling after a body change produces a fresh hash.
+ *
+ * Returns the captured hash or null if the body cannot be read.
+ */
+export function stampDisabledAtBodyHash(stateDir: string, slug: string): string | null {
+  const manifestPath = path.join(stateDir, 'jobs', 'schedule', `${slug}.json`);
+  if (!fs.existsSync(manifestPath)) return null;
+
+  let manifest: any;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  const namespace: 'instar' | 'user' = manifest.origin === 'instar' ? 'instar' : 'user';
+  const bodyPath = path.join(stateDir, 'jobs', namespace, `${slug}.md`);
+  if (!fs.existsSync(bodyPath)) return null;
+
+  let bodyText: string;
+  try {
+    const raw = fs.readFileSync(bodyPath, 'utf-8');
+    const match = raw.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+    bodyText = match ? match[1] : raw;
+  } catch {
+    return null;
+  }
+
+  const hash = hashBody(bodyText);
+  manifest.disabledAtBodyHash = hash;
+  manifest.enabled = false;
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+  return hash;
+}
+
+/**
+ * Clear the disabledAtBodyHash when an operator re-enables a job.
+ * Idempotent.
+ */
+export function clearDisabledAtBodyHash(stateDir: string, slug: string): void {
+  const manifestPath = path.join(stateDir, 'jobs', 'schedule', `${slug}.json`);
+  if (!fs.existsSync(manifestPath)) return;
+  let manifest: any;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  } catch {
+    return;
+  }
+  delete manifest.disabledAtBodyHash;
+  manifest.enabled = true;
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+}
+
+// Re-export the canonical normalize from AgentMdLockFile so callers can
+// inspect what the hash is computed over without having to know which
+// module owns it.
+export { normalize };

--- a/tests/unit/scheduler/DisabledBodyDrift.test.ts
+++ b/tests/unit/scheduler/DisabledBodyDrift.test.ts
@@ -1,0 +1,197 @@
+/**
+ * DisabledBodyDrift — tests for the disabledAtBodyHash drift-detection helper.
+ *
+ * Per INSTAR-JOBS-AS-AGENTMD spec §Dashboard UX (enabled toggle records
+ * disabledAtBodyHash) + §Operator Experience (drift digest semantics).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  bodyDriftedSinceDisable,
+  listDriftedDisabledSlugs,
+  stampDisabledAtBodyHash,
+  clearDisabledAtBodyHash,
+} from '../../../src/scheduler/DisabledBodyDrift.js';
+import { hashBody } from '../../../src/scheduler/AgentMdLockFile.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+describe('DisabledBodyDrift', () => {
+  let workspace: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-dbd-'));
+    stateDir = path.join(workspace, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(workspace, { recursive: true, force: true, operation: 'DisabledBodyDrift.test cleanup' });
+  });
+
+  function writeManifest(slug: string, fields: Record<string, unknown>): void {
+    const dir = path.join(stateDir, 'jobs', 'schedule');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${slug}.json`), JSON.stringify({
+      slug,
+      origin: 'user',
+      schedule: '*/5 * * * *',
+      enabled: true,
+      execute: { type: 'agentmd' },
+      manifestVersion: 1,
+      ...fields,
+    }, null, 2));
+  }
+
+  function writeMd(slug: string, body: string, namespace: 'instar' | 'user' = 'user'): void {
+    const dir = path.join(stateDir, 'jobs', namespace);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${slug}.md`), `---\nname: ${slug}\n---\n${body}`);
+  }
+
+  // ── bodyDriftedSinceDisable ────────────────────────────────────────
+
+  it('no-drift when current body hash matches captured disabledAtBodyHash', () => {
+    const body = 'do the thing\n';
+    const expectedHash = hashBody(body);
+    writeMd('alpha', body);
+    writeManifest('alpha', { enabled: false, disabledAtBodyHash: expectedHash });
+
+    const r = bodyDriftedSinceDisable({ stateDir, slug: 'alpha' });
+    expect(r.kind).toBe('no-drift');
+  });
+
+  it('drifted when body changed since disable', () => {
+    const originalBody = 'old body\n';
+    const originalHash = hashBody(originalBody);
+    writeManifest('alpha', { enabled: false, disabledAtBodyHash: originalHash });
+    writeMd('alpha', 'new body\n'); // body changed, hash captured at disable-time stays
+
+    const r = bodyDriftedSinceDisable({ stateDir, slug: 'alpha' });
+    expect(r.kind).toBe('drifted');
+    if (r.kind === 'drifted') {
+      expect(r.disabledAtBodyHash).toBe(originalHash);
+      expect(r.currentBodyHash).not.toBe(originalHash);
+    }
+  });
+
+  it('not-disabled when the manifest is enabled', () => {
+    writeManifest('alpha', { enabled: true });
+    writeMd('alpha', 'body\n');
+
+    const r = bodyDriftedSinceDisable({ stateDir, slug: 'alpha' });
+    expect(r.kind).toBe('not-disabled');
+  });
+
+  it('no-disable-record when disabled but no disabledAtBodyHash captured (pre-spec)', () => {
+    writeManifest('alpha', { enabled: false });
+    writeMd('alpha', 'body\n');
+
+    const r = bodyDriftedSinceDisable({ stateDir, slug: 'alpha' });
+    expect(r.kind).toBe('no-disable-record');
+  });
+
+  it('manifest-missing when the slug has no manifest', () => {
+    const r = bodyDriftedSinceDisable({ stateDir, slug: 'ghost-slug' });
+    expect(r.kind).toBe('manifest-missing');
+  });
+
+  it('body-missing when the manifest exists but the .md file is gone', () => {
+    writeManifest('alpha', { enabled: false, disabledAtBodyHash: hashBody('body') });
+    // No .md file written.
+
+    const r = bodyDriftedSinceDisable({ stateDir, slug: 'alpha' });
+    expect(r.kind).toBe('body-missing');
+  });
+
+  it('drift detection ignores frontmatter content; only the body bytes are hashed', () => {
+    const body = 'consistent body bytes\n';
+    const hash = hashBody(body);
+    writeManifest('alpha', { enabled: false, disabledAtBodyHash: hash });
+    // Write a .md whose frontmatter differs from a hypothetical earlier version
+    // but whose body matches. Frontmatter is NOT in the hash, so this is no-drift.
+    const dir = path.join(stateDir, 'jobs', 'user');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'alpha.md'), `---\nname: changed-name\ndescription: changed\n---\n${body}`);
+
+    const r = bodyDriftedSinceDisable({ stateDir, slug: 'alpha' });
+    expect(r.kind).toBe('no-drift');
+  });
+
+  // ── listDriftedDisabledSlugs ───────────────────────────────────────
+
+  it('listDriftedDisabledSlugs returns all slugs whose disabled body has drifted', () => {
+    writeManifest('drifted-1', { enabled: false, disabledAtBodyHash: hashBody('old') });
+    writeMd('drifted-1', 'new');
+    writeManifest('drifted-2', { enabled: false, disabledAtBodyHash: hashBody('old') });
+    writeMd('drifted-2', 'newer');
+    writeManifest('not-drifted', { enabled: false, disabledAtBodyHash: hashBody('same') });
+    writeMd('not-drifted', 'same');
+    writeManifest('enabled', { enabled: true });
+    writeMd('enabled', 'whatever');
+
+    const r = listDriftedDisabledSlugs(stateDir);
+    expect(r).toHaveLength(2);
+    expect(r.map((x) => x.slug).sort()).toEqual(['drifted-1', 'drifted-2']);
+  });
+
+  it('listDriftedDisabledSlugs returns empty when no manifests exist', () => {
+    expect(listDriftedDisabledSlugs(stateDir)).toEqual([]);
+  });
+
+  // ── stampDisabledAtBodyHash ────────────────────────────────────────
+
+  it('stampDisabledAtBodyHash writes the current body hash + sets enabled:false', () => {
+    writeManifest('alpha', { enabled: true });
+    writeMd('alpha', 'body content\n');
+
+    const hash = stampDisabledAtBodyHash(stateDir, 'alpha');
+    expect(hash).toBe(hashBody('body content\n'));
+
+    const re = JSON.parse(fs.readFileSync(path.join(stateDir, 'jobs', 'schedule', 'alpha.json'), 'utf-8'));
+    expect(re.enabled).toBe(false);
+    expect(re.disabledAtBodyHash).toBe(hash);
+  });
+
+  it('stampDisabledAtBodyHash returns null when the manifest is missing', () => {
+    expect(stampDisabledAtBodyHash(stateDir, 'ghost')).toBeNull();
+  });
+
+  it('stampDisabledAtBodyHash returns null when the body file is missing', () => {
+    writeManifest('alpha', { enabled: true });
+    expect(stampDisabledAtBodyHash(stateDir, 'alpha')).toBeNull();
+  });
+
+  // ── clearDisabledAtBodyHash ────────────────────────────────────────
+
+  it('clearDisabledAtBodyHash drops the field + flips enabled:true', () => {
+    writeManifest('alpha', { enabled: false, disabledAtBodyHash: 'sha256:fake' });
+    clearDisabledAtBodyHash(stateDir, 'alpha');
+
+    const re = JSON.parse(fs.readFileSync(path.join(stateDir, 'jobs', 'schedule', 'alpha.json'), 'utf-8'));
+    expect(re.enabled).toBe(true);
+    expect(re.disabledAtBodyHash).toBeUndefined();
+  });
+
+  it('clearDisabledAtBodyHash is a no-op when the manifest is missing', () => {
+    // Should not throw.
+    expect(() => clearDisabledAtBodyHash(stateDir, 'ghost')).not.toThrow();
+  });
+
+  // ── Roundtrip property ────────────────────────────────────────────
+
+  it('stamp → drift-check round-trip: stamping then checking returns no-drift; modifying body then re-checking returns drifted', () => {
+    writeManifest('rt', { enabled: true });
+    writeMd('rt', 'v1\n');
+
+    stampDisabledAtBodyHash(stateDir, 'rt');
+    expect(bodyDriftedSinceDisable({ stateDir, slug: 'rt' }).kind).toBe('no-drift');
+
+    // Modify the body.
+    writeMd('rt', 'v2\n');
+    expect(bodyDriftedSinceDisable({ stateDir, slug: 'rt' }).kind).toBe('drifted');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -8,6 +8,9 @@ note (`upgrades/<version>.md`) at release-cut time.
 ### test(server): bearer-token auth verification on jobs endpoints
 
 New integration test pins the existing `authMiddleware` gate on the four Phase 4 jobs endpoints (`/jobs/migration-status`, `/jobs/migration-confirm`, `/jobs/migration-abandon`, `/jobs/reconcile`). 15 cases cover unauthenticated, wrong-token, off-by-one near-miss, malformed header, non-Bearer scheme, and authenticated paths. Asserts INSTAR-JOBS-AS-AGENTMD spec §Decision Points "Dashboard write authorization — bearer auth extended to job-edit endpoints." Auth was already in place via global middleware; this test pins the property so a future refactor cannot weaken it silently.
+### feat(scheduler): disabledAtBodyHash drift-detection helpers
+
+New `src/scheduler/DisabledBodyDrift.ts` ships `bodyDriftedSinceDisable()`, `listDriftedDisabledSlugs()`, `stampDisabledAtBodyHash()`, `clearDisabledAtBodyHash()`. Surfaces "instar default has changed since you disabled it" indicators per INSTAR-JOBS-AS-AGENTMD spec §Dashboard UX. Reuses the same `hashBody()` from `AgentMdLockFile.ts` so disable-time hash semantics match lock-file body-hash semantics exactly. Pure helpers — Dashboard UI rewrite is the future consumer. 15 unit tests pass.
 
 ### feat(scheduler): agentmd two-rename atomic save helper
 

--- a/upgrades/side-effects/disabled-body-drift-detection.md
+++ b/upgrades/side-effects/disabled-body-drift-detection.md
@@ -1,0 +1,59 @@
+# Side-effects review — disabledAtBodyHash drift detection
+
+## What changed
+
+New module `src/scheduler/DisabledBodyDrift.ts` ships the runtime helpers the Dashboard needs to surface "instar default has changed since you disabled it — review?" indicators per INSTAR-JOBS-AS-AGENTMD spec §Dashboard UX:
+
+> row per job: status dot, name + description, schedule, last run + bodyHash link, enabled toggle (records disabledAtBodyHash), namespace badge
+
+Three exports:
+
+- `bodyDriftedSinceDisable({ stateDir, slug })` — returns a tagged-union status: `no-drift | drifted | manifest-missing | body-missing | not-disabled | no-disable-record`. The `drifted` case carries both the captured hash AND the current hash so the Dashboard can show a body-diff link.
+- `listDriftedDisabledSlugs(stateDir)` — scans every per-slug manifest and returns all slugs whose disabled body has drifted. Used by the future Dashboard status feed.
+- `stampDisabledAtBodyHash(stateDir, slug)` — captures the current body hash + flips enabled:false. Used by the Dashboard "disable" action and by a future CLI `instar job disable <slug>` command.
+- `clearDisabledAtBodyHash(stateDir, slug)` — drops the field + flips enabled:true. Used by the Dashboard "enable" action.
+
+No new HTTP endpoint yet — the Dashboard UI rewrite will consume these helpers when it lands.
+
+## Side-effects review
+
+### 1. Over-block / under-block
+
+- **Over-block:** none. The helpers are pure reads (drift check, list) or atomic single-file manifest writes (stamp, clear). No new gates, no new refusals.
+- **Under-block:** the `body-missing` and `manifest-missing` states are surfaced but not auto-remediated. The future Dashboard Issues-card surface drives operator-decided remediation.
+
+### 2. Level-of-abstraction fit
+
+Pure file-system helpers reusing `hashBody` + `normalize` from `AgentMdLockFile.ts` so the disable-time hash semantics match the lock-file's body-hash semantics exactly. Same hashing function = same body-equivalence rules.
+
+### 3. Signal-vs-authority compliance
+
+The helpers are signals — they report "drifted yes/no" and let the caller decide whether to surface it to the operator. The authority for what the operator should DO about drift lives at the Dashboard layer.
+
+### 4. Interactions
+
+- **Phase 2 installBuiltinJobs** — already preserves `disabledAtBodyHash` across updates (manifest read before overwrite). This PR adds the helpers that USE the field.
+- **Phase 4 Dashboard UI rewrite (future)** — will consume `stampDisabledAtBodyHash` on the disable toggle, `clearDisabledAtBodyHash` on the enable toggle, and `listDriftedDisabledSlugs` for the status feed.
+- **Phase 6 deprecation warning** — does not depend on this, but the future drift-digest aggregator (test #25 in spec) can use `listDriftedDisabledSlugs` as one of its inputs.
+
+### 5. Rollback cost
+
+Trivial. Single module file + test file.
+
+## Test coverage
+
+15 cases in `tests/unit/scheduler/DisabledBodyDrift.test.ts`:
+
+- `bodyDriftedSinceDisable`: no-drift, drifted, not-disabled, no-disable-record, manifest-missing, body-missing, frontmatter-changes-ignored
+- `listDriftedDisabledSlugs`: filters to drifted-only; empty-state safe
+- `stampDisabledAtBodyHash`: success path; manifest-missing; body-missing
+- `clearDisabledAtBodyHash`: success path; manifest-missing safe
+- Roundtrip property: stamp → no-drift → modify → drifted
+
+All 15 pass. Lint + type-check pass.
+
+## What is NOT in this PR
+
+- Dashboard UI consuming the helpers (Phase 4 rewrite).
+- `unfork-backup-prune` daily job — depends on the unfork flow shipping (Phase 4 Dashboard). Will be added in a follow-up alongside the unfork action.
+- HTTP endpoint surfacing `listDriftedDisabledSlugs` — the consolidated `GET /jobs` endpoint mentioned in §Dashboard UX would carry this; that endpoint is its own multi-feature effort.


### PR DESCRIPTION
## Summary

Four pure helpers ship the runtime side of the "instar default has changed since you disabled it" Dashboard indicator per spec §Dashboard UX. Reuses the canonical `hashBody()` from `AgentMdLockFile.ts`.

15 unit tests.

The companion `unfork-backup-prune` daily job is deferred — depends on the unfork flow which ships with the Phase 4 Dashboard UI rewrite.

## Test plan

- [x] 15 cases pass
- [x] Lint + type-check pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)