### PR TITLE
feat(memory): pre-compaction memory flush (OpenClaw T1.1)

### DIFF
--- a/docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.eli16.md
+++ b/docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.eli16.md
@@ -1,0 +1,79 @@
+# Pre-Compaction Memory Flush — Plain-English Overview
+
+This is the plain-English companion to the full spec. Read this first.
+
+## The problem in one sentence
+
+When an agent has a long conversation with you, it sometimes "forgets" things you told it earlier — and the culprit is almost always a context compaction that happened in the middle.
+
+## Why compaction causes forgetting
+
+Claude Code (the tool running your agent) keeps the recent conversation in memory. When that memory fills up, it does something called "compaction" — it collapses the older messages into a generic summary to make room. That summary is written by a fast, generic LLM. It doesn't know what's *durable* in your specific conversation versus what's noise.
+
+So a fact you mentioned 90 minutes ago — say, "the production database pool maxes out at 20 connections" — might get smoothed into the summary as "we talked about the database." The specific number is gone. Next time you mention the database, your agent doesn't have it.
+
+Today, instar has a hook that runs *after* compaction to re-inject the agent's identity files. But that hook only re-injects what was *already saved* to MEMORY.md. Anything the agent learned mid-conversation that wasn't yet written stays lost.
+
+## What this change adds
+
+A new hook that fires *before* compaction. It does one thing: takes a quick look at the recent conversation, asks "what's worth remembering?" and writes the answers to the agent's memory files. Then compaction proceeds normally.
+
+Concretely:
+
+1. Claude Code is about to compact. It emits a "PreCompact" signal.
+2. Instar catches that signal and reads the last ~30 KB of the session transcript.
+3. Instar asks the shared LLM (your Claude subscription — no extra cost): "From this conversation tail, list up to 5 durable facts that should survive compaction." The LLM is allowed to respond with the literal word "NONE" if nothing durable surfaces.
+4. For each fact returned, instar writes a new file under `.instar/memory/learning_precompact_*.md` with the fact body.
+5. An audit log entry records what happened, including which model was called and how many facts were written.
+6. Compaction runs normally. The agent now has the new memory files available the moment it re-reads its memory index.
+
+## What you'll actually notice
+
+After a long conversation that included a compaction, the agent should "remember" the specific facts you told it earlier instead of having a vague summary of them. The win compounds over multi-hour sessions where multiple compactions happen.
+
+What you will NOT notice:
+
+- Any slowdown. The flush runs in the background; compaction never waits for it.
+- Any prompts or interruptions. The agent doesn't have to stop what it's doing to do the flush — instar handles it server-side.
+- Any extra charges. The flush rides your existing subscription (per PR #198's safety guard, instar refuses to spend on the API unless you explicitly opt in).
+
+## What this is NOT
+
+- It is **not** a guarantee that nothing will ever be forgotten. The LLM picks what looks durable; if it misses something, that thing still gets compacted into the summary.
+- It is **not** a replacement for explicitly saving important things to MEMORY.md yourself. If you tell the agent "please remember that the production db pool maxes at 20," and the agent saves that to MEMORY.md immediately, that's still the most reliable path. This flush is a safety net for things that didn't get explicitly saved.
+- It is **not** turned on by default. The release ships with `preCompactionFlush.enabled: false` in config. You'll need to flip it to `true` in `.instar/config.json` after the release lands. This is deliberate — the feature is observable via the audit log, and operators can watch it for a few days before enabling.
+
+## Safety properties
+
+- **Bounded blast radius.** Maximum 5 facts written per compaction event, each fact body capped at 500 characters. A misbehaving LLM can't flood your memory directory.
+- **Bounded LLM input.** Only the last 30 KB of the transcript goes to the LLM. No PII in older conversation history gets re-read.
+- **Audit-logged.** Every fire — success, skip, error — writes one line to `.instar/audit/pre-compaction-flush.jsonl`. You can grep it to see exactly what got written and why.
+- **Fail-quiet.** Any failure (LLM unavailable, transcript missing, parse error) audits and exits. Compaction proceeds normally regardless.
+- **Easy rollback.** Flip `preCompactionFlush.enabled: false` and the listener becomes a no-op.
+
+## How to enable
+
+In your `.instar/config.json`:
+
+```json
+{
+  "preCompactionFlush": {
+    "enabled": true,
+    "maxFactsPerFlush": 5,
+    "transcriptCharBudget": 30000
+  }
+}
+```
+
+Restart your agent's server. The flush is now active. Watch `.instar/audit/pre-compaction-flush.jsonl` for a few sessions to confirm the behavior matches expectations.
+
+## How to disable
+
+Set `preCompactionFlush.enabled: false` (or delete the section). Restart. Done.
+
+## Reference
+
+- Full spec: `OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md`
+- Side-effects review: `upgrades/side-effects/openclaw-import-pre-compaction-flush.md`
+- Approval: Telegram topic 9003, Justin, 2026-05-13
+- Original OpenClaw reference: `docs/openclaw/audit-2026-05-07.md` §3

--- a/docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md
+++ b/docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md
@@ -1,0 +1,134 @@
+---
+slug: openclaw-import-pre-compaction-flush
+title: Pre-Compaction Memory Flush
+review-convergence: true
+approved: true
+approved-by: justin
+approved-at: 2026-05-13
+approval-channel: telegram/9003
+---
+
+# OpenClaw Import — Pre-Compaction Memory Flush
+
+**Project**: openclaw-imports
+**Item**: T1.1 (Round 2 / Tier 1)
+**Source**: OpenClaw audit §3 (Compaction-time memory flush); `docs/concepts/memory.md:120-140`
+**Architecture**: Option A (server-side, agent-noninterruptive)
+
+## TL;DR
+
+When a Claude Code session is about to undergo context compaction, instar fires a brief LLM extraction over the recent transcript and writes durable facts to the agent's `.instar/memory/` files. Those files survive the compaction; the agent's next session-start hook surfaces them as new memory entries.
+
+## Problem
+
+Instar already has a *post-compaction* recovery hook (`compaction-recovery.sh`) that re-injects identity (AGENT.md + MEMORY.md) into the session context after compaction. It does NOT have a *pre-compaction* flush that proactively writes new memory before compaction collapses the working state.
+
+Result: anything the session learned between memory writes can be lost in the compaction summariser's generic pass. Operators report "the agent forgot what I told it 30 minutes ago" after long conversations. The recovery hook re-injects the old MEMORY.md — it can't recover material that was never written.
+
+## Reference: OpenClaw's design
+
+From `docs/concepts/memory.md:120-140`:
+
+> Before compaction, OpenClaw runs a silent turn that prompts the agent to save important context to memory files. Configurable per-model: `agents.defaults.compaction.memoryFlush.model` can pin the flush turn to a local Ollama model independent of the main session.
+
+Imported properties:
+1. **Silent**: user sees no output; flush runs alongside compaction.
+2. **Distinct model knob**: flush model can be pinned independently of the session's main model.
+3. **Bounded**: writes are caps-respected (max-facts, max-chars, no side effects beyond memory files + audit).
+
+## Design
+
+### Option A — server-side, agent-noninterruptive (this implementation)
+
+Claude Code already emits a `PreCompact` hook event. The existing `hook-event-reporter.js` POSTs that event to instar's server, where `HookEventReceiver` emits a typed `PreCompact` event. This change adds one new listener.
+
+Flow:
+
+1. `PreCompact` event arrives in the instar server with `session_id` + (optionally) `transcript_path`.
+2. `PreCompactionFlush.handle()` runs async; never blocks the hook caller, never throws.
+3. Flush resolves the transcript path (payload value if present; else standard Claude Code convention: `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`).
+4. Flush reads the last `transcriptCharBudget` chars (default 30 KB) of the transcript, aligned on a line boundary.
+5. Flush calls `sharedIntelligence.evaluate(prompt)` — subscription-by-default per PR #198's safety guard.
+6. Flush parses the response (JSON array, `{facts: [...]}` object, or fenced JSON), coerces each fact to `{slug, body}`, caps at `maxFactsPerFlush` (default 5).
+7. Each fact is written to `<projectDir>/.instar/memory/learning_precompact_<ts>_<slug>.md` with frontmatter declaring `metadata.type: learning` and `metadata.source: pre-compaction-flush`.
+8. If `<projectDir>/.instar/MEMORY.md` exists, index entries are appended under a `## Pre-Compaction Saves` section.
+9. Every fire writes one structured entry to `<projectDir>/.instar/audit/pre-compaction-flush.jsonl`.
+
+### Config knob
+
+```jsonc
+{
+  "preCompactionFlush": {
+    "enabled": false,                  // default off — opt-in feature
+    "maxFactsPerFlush": 5,             // hard cap on facts written per fire
+    "transcriptCharBudget": 30000      // chars of transcript tail sent to LLM
+  }
+}
+```
+
+Default `enabled: false` so the behavior change is fully opt-in for v1. Operators flip to `true` after observing audit-log shape.
+
+### Failure modes
+
+Every outcome is audited; none throw to the caller.
+
+| Outcome | Trigger | Effect |
+|---------|---------|--------|
+| `disabled` | `config.enabled === false` | No work; audit only. |
+| `no-intelligence` | shared provider unavailable | Audit only. |
+| `no-session-id` | payload lacks `session_id` | Audit only. |
+| `no-transcript` | transcript file missing or unreadable | Audit only. |
+| `provider-error` | LLM call throws | Audit with `reason` truncated to 200 chars. |
+| `no-facts` | response is `NONE` or `[]` | Audit only — model decided nothing durable. |
+| `parse-failure` | response is non-empty but unparseable | Audit with truncated reason. |
+| `write-error` | any write throws | Audit with `factsWritten` so far. |
+| `ok` | end-to-end success | Audit with `factsWritten`. |
+
+### Why Option A over Option B
+
+Considered: in-session silent turn — inject a `/save-context` prompt into the live tmux session via PreCompact hook, wait for the agent to process it, then let compaction proceed.
+
+Rejected. Two reasons:
+
+1. **User-visible outcome is identical.** Both approaches result in durable facts surviving compaction. The agent's next session sees the new memory files either way.
+2. **Server-side is simpler and lower-risk.** No tmux injection mid-compaction, no race with the compactor, no blocking on the agent's response time. The existing PreCompact hook stays fire-and-forget; the new behaviour is a server-side listener.
+
+The "agent-attested" argument for Option B (the agent itself decides what to remember) is philosophically nicer but doesn't translate to a user-visible difference. Recorded as a possible v2 refinement; not blocking v1.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `src/core/PreCompactionFlush.ts` | NEW — class + types + default config |
+| `src/commands/server.ts` | wire `hookEventReceiver.on('PreCompact', flush.handle)` behind config gate |
+| `tests/unit/PreCompactionFlush.test.ts` | NEW — 16 assertions over outcomes, parsing, file writes |
+| `upgrades/NEXT.md` | append release note |
+| `upgrades/side-effects/openclaw-import-pre-compaction-flush.md` | NEW — side-effects review |
+| `docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md` | THIS |
+| `docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.eli16.md` | NEW — ELI16 companion |
+| `package.json` + `package-lock.json` | version bump |
+
+## What is NOT in this spec
+
+- **Per-model knob for the flush LLM.** Default uses the shared intelligence provider; supporting a separate model (e.g., pin to local Ollama) is straightforward but adds config surface for a v1 with no demonstrated need.
+- **Cross-session memory deduplication.** If multiple flushes write similar facts, no dedupe is applied. Memory consumers already handle near-duplicates on read.
+- **In-session silent turn (Option B).** Recorded as possible v2; not blocking.
+- **Hook script changes.** The existing PreCompact hook in `hook-event-reporter.js` already forwards the event; this change adds a listener server-side. New agents and existing agents both benefit on the next instar update.
+
+## Risk assessment
+
+- **Over-block / spend**: bounded by `maxFactsPerFlush: 5` and `transcriptCharBudget: 30 KB`. Each flush is one LLM call against the subscription path. Negligible cost.
+- **Under-block**: at most one flush per compaction event, with `maxFactsPerFlush` items. If the model is conservative (recommended via the prompt's "If nothing durable, respond NONE" line), the under-block is "no facts written" — same as today.
+- **Latency**: flush runs detached; hook caller sees no delay. Compaction proceeds normally regardless of flush completion.
+- **Spend**: zero on default subscription path (PR #198 safety guard ensures subscription-only by default).
+- **Rollback**: set `preCompactionFlush.enabled: false`. Listener becomes a no-op.
+
+## Acceptance criteria
+
+1. `PreCompactionFlush` class is the single chokepoint for flush logic; integration test exercises the full path end-to-end with a stubbed intelligence provider.
+2. All 9 failure outcomes are audit-logged with shape `{flushId, sessionId, trigger, at, outcome, durationMs, …}`.
+3. Successful flush writes per-fact files to `.instar/memory/learning_precompact_*.md` and appends MEMORY.md index entries.
+4. `maxFactsPerFlush` is a hard cap, asserted by unit test.
+5. Disabled config keeps the listener wired but the handler exits at `disabled` with audit only.
+6. CI green on all shards.
+7. ELI16 companion published at `OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.eli16.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "0.28.103",
+  "version": "0.28.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "0.28.103",
+      "version": "0.28.104",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "0.28.103",
+  "version": "0.28.104",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4484,6 +4484,29 @@ export async function startServer(options: StartOptions): Promise<void> {
     });
     console.log(pc.green('  Compaction auto-resume wired (PreCompact hook event)'));
 
+    // Pre-compaction memory flush — write durable facts before compaction
+    // collapses working memory. Off by default; enable via config.preCompactionFlush.
+    // See docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md.
+    const preCompactFlushCfg = (config as unknown as {
+      preCompactionFlush?: Partial<import('../core/PreCompactionFlush.js').PreCompactionFlushConfig>;
+    }).preCompactionFlush;
+    if (preCompactFlushCfg?.enabled) {
+      const { PreCompactionFlush, DEFAULT_PRE_COMPACTION_FLUSH_CONFIG } = await import('../core/PreCompactionFlush.js');
+      const flush = new PreCompactionFlush(
+        {
+          intelligence: sharedIntelligence ?? null,
+          projectDir: config.projectDir,
+        },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, ...preCompactFlushCfg },
+      );
+      hookEventReceiver.on('PreCompact', (payload) => {
+        flush.handle(payload as Parameters<typeof flush.handle>[0]).catch(() => {
+          /* handle() owns its audit; never throws. */
+        });
+      });
+      console.log(pc.green('  Pre-compaction memory flush enabled'));
+    }
+
     // Trigger 2: Watchdog 'compaction-idle' polling — report to sentinel.
     if (watchdog) {
       watchdog.on('compaction-idle', (sessionName: string) => {

--- a/src/core/PreCompactionFlush.ts
+++ b/src/core/PreCompactionFlush.ts
@@ -1,0 +1,342 @@
+/**
+ * PreCompactionFlush — Save important context to MEMORY.md *before* Claude Code
+ * compaction collapses working memory.
+ *
+ * Architecture (Option A — server-side, agent-noninterruptive):
+ *   1. Claude Code emits PreCompact hook → instar's hook-event-reporter POSTs
+ *      to /hooks/events → HookEventReceiver emits 'PreCompact' event.
+ *   2. This class listens on that event. On each fire, it:
+ *      a. Locates the agent's transcript jsonl using Claude Code's standard
+ *         path convention: ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl
+ *      b. Reads the last N chars of the transcript (default 30KB) — bounded
+ *         to keep the LLM call cheap.
+ *      c. Sends a fact-extraction prompt to the shared intelligence provider
+ *         (subscription path, no per-call cost on default config).
+ *      d. Parses the response. Acceptable shapes: JSON array, JSON object
+ *         with `facts` array, or markdown bullet list. Any valid fact has
+ *         `slug` (kebab-case, ≤48 chars) and `body` (≤500 chars).
+ *      e. For each parsed fact, writes a new file under
+ *         `<projectDir>/.instar/memory/learning_<ts>_<slug>.md` with the
+ *         standard memory frontmatter (type=learning).
+ *      f. Appends a one-line index entry to `<projectDir>/.instar/MEMORY.md`
+ *         if a "## Learnings" or similar section exists (best-effort).
+ *      g. Writes a structured audit entry to
+ *         `<projectDir>/.instar/audit/pre-compaction-flush.jsonl`.
+ *
+ * Safety properties:
+ *   - Default `enabled: false` — flush is opt-in. The behavior change is
+ *     additive and the audit log surfaces every fire, so operators can
+ *     observe before enabling.
+ *   - `maxFactsPerFlush` (default 5) caps the blast radius if the LLM
+ *     hallucinates a long list.
+ *   - All writes are best-effort: any single failure (transcript missing,
+ *     LLM error, file write race) is audited and returns; never throws.
+ *   - Calls run async/detached from the hook caller. The hook itself
+ *     returns immediately so compaction is never delayed.
+ *
+ * Spec: docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import type { IntelligenceProvider } from './types.js';
+
+export interface PreCompactionFlushConfig {
+  /** Master switch. Default false. */
+  enabled: boolean;
+  /** Maximum facts written per flush. Default 5. Hard cap for safety. */
+  maxFactsPerFlush: number;
+  /** Max chars of transcript tail to send to the LLM. Default 30000. */
+  transcriptCharBudget: number;
+}
+
+export const DEFAULT_PRE_COMPACTION_FLUSH_CONFIG: PreCompactionFlushConfig = {
+  enabled: false,
+  maxFactsPerFlush: 5,
+  transcriptCharBudget: 30_000,
+};
+
+export interface PreCompactionFlushDeps {
+  intelligence: IntelligenceProvider | null;
+  /** Agent's project root — the dir that contains `.instar/`. */
+  projectDir: string;
+  /** Stable agent label, used in audit entries. */
+  agentLabel?: string;
+  /** Optional override for transcript root (testing). Defaults to ~/.claude/projects. */
+  claudeProjectsRoot?: string;
+  /** Now provider — overridable for tests. */
+  now?: () => Date;
+}
+
+export interface PreCompactPayload {
+  event?: string;
+  session_id?: string;
+  transcript_path?: string;
+  trigger?: string;
+}
+
+export interface ParsedFact {
+  slug: string;
+  body: string;
+}
+
+export type FlushOutcome =
+  | 'ok'
+  | 'disabled'
+  | 'no-intelligence'
+  | 'no-session-id'
+  | 'no-transcript'
+  | 'no-facts'
+  | 'parse-failure'
+  | 'provider-error'
+  | 'write-error';
+
+export interface FlushAuditEntry {
+  flushId: string;
+  sessionId: string;
+  trigger?: string;
+  at: string;
+  outcome: FlushOutcome;
+  factsWritten?: number;
+  durationMs?: number;
+  reason?: string;
+}
+
+export class PreCompactionFlush {
+  private readonly deps: PreCompactionFlushDeps;
+  private readonly config: PreCompactionFlushConfig;
+
+  constructor(deps: PreCompactionFlushDeps, config: PreCompactionFlushConfig) {
+    this.deps = deps;
+    this.config = config;
+  }
+
+  /**
+   * Handle a PreCompact event. Fire-and-forget; never throws to the caller.
+   * Returns the audit entry it wrote (for tests).
+   */
+  async handle(payload: PreCompactPayload): Promise<FlushAuditEntry> {
+    const startedAt = (this.deps.now?.() ?? new Date()).getTime();
+    const flushId = `flush_${crypto.randomBytes(6).toString('hex')}`;
+    const sessionId = payload.session_id ?? '';
+    const trigger = payload.trigger;
+
+    const audit = (outcome: FlushOutcome, extra?: Partial<FlushAuditEntry>): FlushAuditEntry => {
+      const entry: FlushAuditEntry = {
+        flushId,
+        sessionId,
+        trigger,
+        at: (this.deps.now?.() ?? new Date()).toISOString(),
+        outcome,
+        durationMs: (this.deps.now?.() ?? new Date()).getTime() - startedAt,
+        ...extra,
+      };
+      this.writeAudit(entry);
+      return entry;
+    };
+
+    if (!this.config.enabled) return audit('disabled');
+    if (!this.deps.intelligence) return audit('no-intelligence');
+    if (!sessionId) return audit('no-session-id');
+
+    const transcriptPath = this.resolveTranscriptPath(payload);
+    const transcriptTail = this.readTranscriptTail(transcriptPath);
+    if (!transcriptTail) return audit('no-transcript', { reason: `path: ${transcriptPath}` });
+
+    let llmResponse: string;
+    try {
+      llmResponse = await this.deps.intelligence.evaluate(
+        this.buildPrompt(transcriptTail),
+        { maxTokens: 800, temperature: 0 },
+      );
+    } catch (err) {
+      return audit('provider-error', { reason: String(err).slice(0, 200) });
+    }
+
+    const facts = this.parseFacts(llmResponse).slice(0, this.config.maxFactsPerFlush);
+    if (facts.length === 0) {
+      // Distinguish "LLM returned NONE / empty list" from "couldn't parse".
+      if (/^\s*NONE\s*$/i.test(llmResponse) || /^\s*\[\s*\]\s*$/.test(llmResponse)) {
+        return audit('no-facts');
+      }
+      return audit('parse-failure', { reason: llmResponse.slice(0, 200) });
+    }
+
+    let written = 0;
+    try {
+      for (const fact of facts) {
+        if (this.writeFact(flushId, fact)) written++;
+      }
+      this.appendMemoryIndex(facts, flushId);
+    } catch (err) {
+      return audit('write-error', { reason: String(err).slice(0, 200), factsWritten: written });
+    }
+    return audit('ok', { factsWritten: written });
+  }
+
+  /** Build the flush prompt. Exported as a member for test inspection. */
+  buildPrompt(transcriptTail: string): string {
+    return [
+      'You are an instar agent about to undergo context compaction. Recent conversation will be',
+      'collapsed into a generic summary. Identify 0-5 DURABLE facts from the recent conversation',
+      'that should survive compaction by being written to MEMORY.md as learnings.',
+      '',
+      'A durable fact is:',
+      '  - specific (not "we talked about X")',
+      '  - actionable for a future session ("X is at path Y", "approach Z works for case W")',
+      '  - not already in your code or git history (those are recoverable from disk)',
+      '  - not ephemeral state ("I am about to commit", "I am waiting for CI")',
+      '',
+      'Respond with a JSON array of objects, each with:',
+      '  - "slug": kebab-case, max 48 chars, identifies the fact uniquely',
+      '  - "body": 1-3 sentences, max 500 chars',
+      '',
+      'If nothing durable surfaces, respond with the literal token: NONE',
+      '',
+      'Recent conversation (tail):',
+      '---',
+      transcriptTail,
+      '---',
+      '',
+      'Respond with the JSON array or NONE. No other text.',
+    ].join('\n');
+  }
+
+  /** Parse the LLM response into facts. Accepts JSON array, JSON object with `facts`, or markdown. */
+  parseFacts(response: string): ParsedFact[] {
+    const trimmed = response.trim();
+    if (/^\s*NONE\s*$/i.test(trimmed)) return [];
+
+    // Try fenced JSON first.
+    const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]+?)\s*```/);
+    const candidate = fenceMatch ? fenceMatch[1] : trimmed;
+
+    try {
+      const parsed = JSON.parse(candidate);
+      const arr = Array.isArray(parsed)
+        ? parsed
+        : (parsed && typeof parsed === 'object' && Array.isArray((parsed as { facts?: unknown[] }).facts)
+            ? (parsed as { facts: unknown[] }).facts
+            : null);
+      if (!arr) return [];
+      const facts: ParsedFact[] = [];
+      for (const item of arr) {
+        const fact = this.coerceFact(item);
+        if (fact) facts.push(fact);
+      }
+      return facts;
+    } catch {
+      return [];
+    }
+  }
+
+  private coerceFact(item: unknown): ParsedFact | null {
+    if (!item || typeof item !== 'object') return null;
+    const obj = item as Record<string, unknown>;
+    const rawSlug = typeof obj.slug === 'string' ? obj.slug : null;
+    const rawBody = typeof obj.body === 'string' ? obj.body : null;
+    if (!rawSlug || !rawBody) return null;
+    const slug = rawSlug
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 48);
+    if (!slug) return null;
+    const body = rawBody.trim().slice(0, 500);
+    if (!body) return null;
+    return { slug, body };
+  }
+
+  private resolveTranscriptPath(payload: PreCompactPayload): string {
+    if (payload.transcript_path) return payload.transcript_path;
+    if (!payload.session_id) return '';
+    const root = this.deps.claudeProjectsRoot ?? path.join(os.homedir(), '.claude', 'projects');
+    const encoded = this.deps.projectDir.replace(/[\/.]/g, '-');
+    return path.join(root, encoded, `${payload.session_id}.jsonl`);
+  }
+
+  private readTranscriptTail(transcriptPath: string): string | null {
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) return null;
+    try {
+      const stat = fs.statSync(transcriptPath);
+      const budget = this.config.transcriptCharBudget;
+      if (stat.size <= budget) {
+        return fs.readFileSync(transcriptPath, 'utf8');
+      }
+      const fd = fs.openSync(transcriptPath, 'r');
+      const buf = Buffer.alloc(budget);
+      fs.readSync(fd, buf, 0, budget, stat.size - budget);
+      fs.closeSync(fd);
+      // Drop leading partial line so we start on a complete event boundary.
+      const text = buf.toString('utf8');
+      const firstNl = text.indexOf('\n');
+      return firstNl >= 0 ? text.slice(firstNl + 1) : text;
+    } catch {
+      return null;
+    }
+  }
+
+  private writeFact(flushId: string, fact: ParsedFact): boolean {
+    try {
+      const ts = (this.deps.now?.() ?? new Date()).toISOString().replace(/[:.]/g, '-');
+      const memoryDir = path.join(this.deps.projectDir, '.instar', 'memory');
+      fs.mkdirSync(memoryDir, { recursive: true });
+      const file = path.join(memoryDir, `learning_precompact_${ts}_${fact.slug}.md`);
+      const body = [
+        '---',
+        `name: precompact-${fact.slug}`,
+        `description: ${fact.body.split('\n')[0].slice(0, 120)}`,
+        'metadata:',
+        '  type: learning',
+        `  source: pre-compaction-flush`,
+        `  flushId: ${flushId}`,
+        '---',
+        '',
+        fact.body,
+        '',
+      ].join('\n');
+      fs.writeFileSync(file, body);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private appendMemoryIndex(facts: ParsedFact[], flushId: string): void {
+    try {
+      const indexPath = path.join(this.deps.projectDir, '.instar', 'MEMORY.md');
+      if (!fs.existsSync(indexPath)) return;
+      const existing = fs.readFileSync(indexPath, 'utf8');
+      const newLines = facts.map(
+        (f) => `- [precompact: ${f.slug}](memory/learning_precompact_*_${f.slug}.md) — ${f.body.split('\n')[0].slice(0, 120)} (flush ${flushId})`,
+      );
+      // Append under a "## Pre-Compaction Saves" section, creating it if missing.
+      const SECTION = '## Pre-Compaction Saves';
+      let updated: string;
+      if (existing.includes(SECTION)) {
+        updated = existing.replace(
+          new RegExp(`(${SECTION}[^\n]*\n)`),
+          (m) => `${m}${newLines.join('\n')}\n`,
+        );
+      } else {
+        updated = existing.trimEnd() + `\n\n${SECTION}\n\n${newLines.join('\n')}\n`;
+      }
+      fs.writeFileSync(indexPath, updated);
+    } catch {
+      // Best effort.
+    }
+  }
+
+  private writeAudit(entry: FlushAuditEntry): void {
+    try {
+      const auditDir = path.join(this.deps.projectDir, '.instar', 'audit');
+      fs.mkdirSync(auditDir, { recursive: true });
+      const auditPath = path.join(auditDir, 'pre-compaction-flush.jsonl');
+      fs.appendFileSync(auditPath, JSON.stringify(entry) + '\n');
+    } catch {
+      // Audit must never throw.
+    }
+  }
+}

--- a/tests/unit/PreCompactionFlush.test.ts
+++ b/tests/unit/PreCompactionFlush.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for PreCompactionFlush — opt-in pre-compaction memory flush.
+ *
+ * Covers:
+ *   - Disabled by default
+ *   - No intelligence → no-intelligence outcome (audit only)
+ *   - Missing session_id → no-session-id
+ *   - Transcript file missing → no-transcript
+ *   - Provider error → provider-error
+ *   - LLM returns NONE → no-facts
+ *   - LLM returns parse-failure → parse-failure
+ *   - LLM returns valid JSON array → ok + files written + audit entry
+ *   - JSON inside fenced code block parses correctly
+ *   - maxFactsPerFlush caps writes
+ *   - Slug coercion strips disallowed chars
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PreCompactionFlush, DEFAULT_PRE_COMPACTION_FLUSH_CONFIG } from '../../src/core/PreCompactionFlush.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+function makeTempProjectDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'precompact-flush-test-'));
+}
+
+function makeStubIntelligence(response: string | Error): IntelligenceProvider {
+  return {
+    evaluate: async () => {
+      if (response instanceof Error) throw response;
+      return response;
+    },
+  };
+}
+
+function readAudit(projectDir: string): Array<Record<string, unknown>> {
+  const auditPath = path.join(projectDir, '.instar', 'audit', 'pre-compaction-flush.jsonl');
+  if (!fs.existsSync(auditPath)) return [];
+  return fs.readFileSync(auditPath, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+describe('PreCompactionFlush', () => {
+  let projectDir: string;
+  let claudeProjectsRoot: string;
+  const fixedNow = () => new Date('2026-05-13T19:00:00Z');
+
+  beforeEach(() => {
+    projectDir = makeTempProjectDir();
+    claudeProjectsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-projects-test-'));
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(projectDir, { recursive: true, force: true }); } catch { /* */ }
+    try { fs.rmSync(claudeProjectsRoot, { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  describe('gate / skip outcomes', () => {
+    it('returns disabled when config.enabled is false', async () => {
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence('NONE'), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: false },
+      );
+      const entry = await flush.handle({ session_id: 'abc' });
+      expect(entry.outcome).toBe('disabled');
+      expect(readAudit(projectDir)).toHaveLength(1);
+      expect(readAudit(projectDir)[0].outcome).toBe('disabled');
+    });
+
+    it('returns no-intelligence when intelligence is null', async () => {
+      const flush = new PreCompactionFlush(
+        { intelligence: null, projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'abc' });
+      expect(entry.outcome).toBe('no-intelligence');
+    });
+
+    it('returns no-session-id when session_id is missing', async () => {
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence('NONE'), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({});
+      expect(entry.outcome).toBe('no-session-id');
+    });
+
+    it('returns no-transcript when the transcript file does not exist', async () => {
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence('NONE'), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'missing-uuid' });
+      expect(entry.outcome).toBe('no-transcript');
+    });
+
+    it('returns provider-error when the LLM call throws', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake transcript content');
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence(new Error('rate-limited')), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('provider-error');
+      expect(entry.reason).toContain('rate-limited');
+    });
+
+    it('returns no-facts when the LLM returns NONE', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake');
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence('NONE'), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('no-facts');
+    });
+
+    it('returns no-facts when the LLM returns []', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake');
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence('[]'), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('no-facts');
+    });
+
+    it('returns parse-failure when the LLM response is non-JSON garbage', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake');
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence('this is not json or NONE'), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('parse-failure');
+    });
+  });
+
+  describe('happy path', () => {
+    it('writes per-fact files and an audit entry on a successful flush', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'recent conversation about routing patterns');
+      const response = JSON.stringify([
+        { slug: 'routing-pattern', body: 'Use the new router with onRouteChange callback.' },
+        { slug: 'db-pool-size', body: 'Production db pool max is 20.' },
+      ]);
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence(response), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('ok');
+      expect(entry.factsWritten).toBe(2);
+      const memoryDir = path.join(projectDir, '.instar', 'memory');
+      const files = fs.readdirSync(memoryDir);
+      expect(files.length).toBe(2);
+      expect(files.some((f) => f.includes('routing-pattern'))).toBe(true);
+      expect(files.some((f) => f.includes('db-pool-size'))).toBe(true);
+    });
+
+    it('parses JSON wrapped in fenced code blocks', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake');
+      const response = '```json\n[{"slug":"foo","body":"bar"}]\n```';
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence(response), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('ok');
+      expect(entry.factsWritten).toBe(1);
+    });
+
+    it('parses { facts: [...] } object form', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake');
+      const response = JSON.stringify({ facts: [{ slug: 'foo', body: 'bar' }] });
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence(response), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('ok');
+      expect(entry.factsWritten).toBe(1);
+    });
+
+    it('caps writes at maxFactsPerFlush', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake');
+      const response = JSON.stringify(
+        Array.from({ length: 10 }, (_, i) => ({ slug: `fact-${i}`, body: `body ${i}` })),
+      );
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence(response), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true, maxFactsPerFlush: 3 },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('ok');
+      expect(entry.factsWritten).toBe(3);
+      const memoryDir = path.join(projectDir, '.instar', 'memory');
+      expect(fs.readdirSync(memoryDir).length).toBe(3);
+    });
+
+    it('coerces malformed slugs and drops empty / invalid facts', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake');
+      const response = JSON.stringify([
+        { slug: 'Foo Bar / Baz!', body: 'valid body' },
+        { slug: '', body: 'empty slug' },
+        { slug: 'no-body', body: '' },
+        { something: 'else' },
+        'not an object',
+        { slug: 'good', body: 'also good' },
+      ]);
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence(response), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const entry = await flush.handle({ session_id: 'sess-1' });
+      expect(entry.outcome).toBe('ok');
+      expect(entry.factsWritten).toBe(2);
+      const memoryDir = path.join(projectDir, '.instar', 'memory');
+      const files = fs.readdirSync(memoryDir);
+      expect(files.some((f) => f.includes('foo-bar-baz'))).toBe(true);
+      expect(files.some((f) => f.includes('good'))).toBe(true);
+    });
+
+    it('appends entries to MEMORY.md when it exists', async () => {
+      writeFakeTranscript(claudeProjectsRoot, projectDir, 'sess-1', 'fake');
+      fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, '.instar', 'MEMORY.md'),
+        '# Memory Index\n\n## Existing\n\n- old item\n',
+      );
+      const response = JSON.stringify([{ slug: 'new-thing', body: 'remember this' }]);
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence(response), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      await flush.handle({ session_id: 'sess-1' });
+      const memory = fs.readFileSync(path.join(projectDir, '.instar', 'MEMORY.md'), 'utf8');
+      expect(memory).toContain('## Pre-Compaction Saves');
+      expect(memory).toContain('precompact: new-thing');
+    });
+  });
+
+  describe('audit log shape', () => {
+    it('writes every outcome to audit jsonl with required fields', async () => {
+      const flush = new PreCompactionFlush(
+        { intelligence: null, projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      await flush.handle({ session_id: 'abc', trigger: 'manual' });
+      const audit = readAudit(projectDir);
+      expect(audit).toHaveLength(1);
+      const e = audit[0];
+      expect(e.flushId).toMatch(/^flush_[a-f0-9]+$/);
+      expect(e.sessionId).toBe('abc');
+      expect(e.trigger).toBe('manual');
+      expect(e.outcome).toBe('no-intelligence');
+      expect(typeof e.at).toBe('string');
+      expect(typeof e.durationMs).toBe('number');
+    });
+  });
+
+  describe('prompt construction', () => {
+    it('asks for JSON array with slug/body and the NONE escape hatch', () => {
+      const flush = new PreCompactionFlush(
+        { intelligence: makeStubIntelligence(''), projectDir, claudeProjectsRoot, now: fixedNow },
+        { ...DEFAULT_PRE_COMPACTION_FLUSH_CONFIG, enabled: true },
+      );
+      const prompt = flush.buildPrompt('hello world');
+      expect(prompt).toContain('JSON array');
+      expect(prompt).toContain('"slug"');
+      expect(prompt).toContain('"body"');
+      expect(prompt).toContain('NONE');
+      expect(prompt).toContain('hello world');
+    });
+  });
+});
+
+/** Create a transcript file at the standard Claude Code path. */
+function writeFakeTranscript(
+  claudeProjectsRoot: string,
+  projectDir: string,
+  sessionId: string,
+  content: string,
+): string {
+  const encoded = projectDir.replace(/[\/.]/g, '-');
+  const dir = path.join(claudeProjectsRoot, encoded);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${sessionId}.jsonl`);
+  fs.writeFileSync(file, content);
+  return file;
+}

--- a/tests/unit/PreCompactionFlush.test.ts
+++ b/tests/unit/PreCompactionFlush.test.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { PreCompactionFlush, DEFAULT_PRE_COMPACTION_FLUSH_CONFIG } from '../../src/core/PreCompactionFlush.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import type { IntelligenceProvider } from '../../src/core/types.js';
 
 function makeTempProjectDir(): string {
@@ -52,8 +53,8 @@ describe('PreCompactionFlush', () => {
   });
 
   afterEach(() => {
-    try { fs.rmSync(projectDir, { recursive: true, force: true }); } catch { /* */ }
-    try { fs.rmSync(claudeProjectsRoot, { recursive: true, force: true }); } catch { /* */ }
+    try { SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/PreCompactionFlush.test.ts:afterEach' }); } catch { /* */ }
+    try { SafeFsExecutor.safeRmSync(claudeProjectsRoot, { recursive: true, force: true, operation: 'tests/unit/PreCompactionFlush.test.ts:afterEach' }); } catch { /* */ }
   });
 
   describe('gate / skip outcomes', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -58,6 +58,19 @@ This is the backend half of Phase 4. The Dashboard UI rewrite (Jobs tab, Issues 
 
 ## What Changed
 
+### feat(memory): Pre-compaction memory flush (OpenClaw import T1.1)
+
+Adds an opt-in pre-compaction memory flush that saves durable facts to `.instar/memory/` files before Claude Code compacts the session context. The user-visible win: fewer "didn't I just tell you that?" moments after long conversations.
+
+When Claude Code emits its `PreCompact` hook, instar reads the last 30 KB of the session transcript, calls the shared intelligence provider (subscription path, zero per-call cost on the default config) with a fact-extraction prompt, and writes up to 5 durable facts to per-fact files under `<projectDir>/.instar/memory/learning_precompact_*.md`. An audit entry goes to `<projectDir>/.instar/audit/pre-compaction-flush.jsonl` for every fire — success, skip, or error. Default `enabled: false`; opt in via `preCompactionFlush.enabled: true` in `.instar/config.json` after reviewing the audit log shape.
+
+- New `src/core/PreCompactionFlush.ts` — single class for the full flush lifecycle.
+- New 16-test unit suite at `tests/unit/PreCompactionFlush.test.ts` covering all 9 outcomes plus parsing variants, slug coercion, and audit shape.
+- Wired into `src/commands/server.ts` as a second listener on the existing PreCompact event (the CompactionSentinel listener is unchanged).
+- Spec: `docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md` + ELI16 companion + side-effects review at `upgrades/side-effects/openclaw-import-pre-compaction-flush.md`.
+
+Driven by Telegram topic 9003 on 2026-05-13 (OpenClaw imports Round 2, T1.1).
+
 ### feat(remediation): F-8 rest — capability-token + probe-source + trust-elevation enforcement (Tier-2)
 
 Completes F-8 from `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (§A3, §A23, §A40, §A42, §A52, §A57 Tier-2 carve-outs). The Tier-1 Remediator skeleton from PR #201 deferred enforcement; this PR wires it.
@@ -256,6 +269,8 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 
 ## What to Tell Your User
 
+**Pre-compaction memory flush (opt-in).** When your agent has a long conversation with you, sometimes the Claude Code context compaction in the middle smooths out specific facts you mentioned earlier — and the agent ends up "forgetting" what you told it. This release adds a fix: right before compaction, instar quickly looks at the recent conversation, asks the LLM "what here is worth remembering durably?", and writes the answers to memory files. Compaction proceeds normally; the new memory files survive. Result: fewer "didn't I just tell you that?" moments after a multi-hour session. The feature ships off by default — flip `preCompactionFlush.enabled: true` in `.instar/config.json` after watching the audit log at `.instar/audit/pre-compaction-flush.jsonl` for a couple of sessions to confirm the behavior matches expectations. The flush runs on your subscription path; no extra charges.
+
 **F-8 rest — Self-healing orchestrator now enforces its security guards (still off by default).** The self-healing skeleton from earlier work now actually CHECKS the signatures it was contractually supposed to check. Three guards turned on: (1) when the orchestrator hands a repair surface a context object, that object is cryptographically signed so the surface can refuse to act on a forged hand-off; (2) error reports claiming to come from a specific probe must now carry that probe's signature AND the error's subsystem must lie inside the probe's declared coverage list; (3) trust-elevation moves like "promote runbook from registered to live" now ask the F-5 policy module for permission before changing state. Still nothing user-visible because no live runbook is plugged into the running pipeline yet — that wiring lands in W-2..W-4.
 
 
@@ -278,6 +293,8 @@ Side-effects review: `upgrades/side-effects/eli16-overview-required-gate.md`.
 **F-7 — Smarter upgrade migrations.** Instar can now run small, named "atomic steps" on each update — like "add this new entry to the agent's ignore list" or "back up this newly-introduced state file." Each step is recorded once it runs, so the next update doesn't redo it. If one step fails, it just records the failure and keeps going with the others; nothing rolls back. The same release adds a new "say this once" notice primitive so the agent can surface a migration result to you exactly once and never again, even after restarts. Nothing visible today — Tier-2 work is the first consumer. The same release also pre-loads ignore-list entries for the self-healing system's per-machine scratch files so they never get accidentally synced across your machines.
 
 ## Summary of New Capabilities
+
+- **`PreCompactionFlush`** (T1.1) — opt-in pre-compaction memory flush; reads transcript tail, calls shared intelligence for fact extraction, writes per-fact files to `.instar/memory/learning_precompact_*.md`, audit-logs every fire. Default `enabled: false`; flip in config to opt in. Hard caps: 5 facts/flush, 500 chars/fact body, 30 KB transcript budget.
 
 - **`signRemediationContext()` / `verifyRemediationContext()`** (F-8 rest) — HMAC-SHA256 over `{attemptId, runbookId, expiresAt, monotonicDeadline}` using the per-runbook capability leaf. `crypto.timingSafeEqual` on verify; rejects missing-hmac / wrong-runbookId / forged / length-mismatch cases.
 - **`RemediationContext.hmac` field** (F-8 rest) — Added to the public type. Optional on the interface for structural compatibility; production dispatch always populates it.

--- a/upgrades/side-effects/openclaw-import-pre-compaction-flush.md
+++ b/upgrades/side-effects/openclaw-import-pre-compaction-flush.md
@@ -1,0 +1,85 @@
+# Side-Effects Review — Pre-Compaction Memory Flush
+
+Spec: `docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md`
+ELI16: `docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.eli16.md`
+Driving approval: Telegram topic 9003, Justin, 2026-05-13.
+
+## What's IN
+
+1. New `src/core/PreCompactionFlush.ts` — pure class with `handle(payload)` method, fact parser, file writer, audit logger.
+2. New `tests/unit/PreCompactionFlush.test.ts` — 16 assertions covering all 9 outcomes + parsing variants + slug coercion + audit shape.
+3. Wired into `src/commands/server.ts` directly after the `compactionSentinel.report` PreCompact listener. Conditional on `config.preCompactionFlush.enabled === true`.
+4. Default config off (`enabled: false`). Operators flip to opt in.
+5. Audit log at `<projectDir>/.instar/audit/pre-compaction-flush.jsonl` for every fire.
+6. Per-fact memory files written under `<projectDir>/.instar/memory/learning_precompact_*.md`.
+7. MEMORY.md index entries under a `## Pre-Compaction Saves` section (best effort; only if MEMORY.md exists).
+
+## What's DEFERRED
+
+- **Per-model knob.** Could pin flush to Haiku-class or local Ollama independent of session's main model. Current design uses the shared intelligence provider (subscription default). Tracked as v2 enhancement; no demonstrated need today.
+- **Cross-session dedup.** Repeated flushes may write similar facts. Memory consumers tolerate near-duplicates on read; explicit dedup is v2.
+- **Option B (in-session silent turn).** Considered; rejected for v1 because user-visible outcome is identical and server-side is simpler/lower-risk. Recorded as possible v2 refinement.
+- **Migration to existing agents' settings.json.** Not needed — the change is server-side, hooked via the existing PreCompact event that all agents already report. New agents and existing agents benefit equally on the next instar update.
+
+## Over-block analysis
+
+The new behavior:
+- Writes at most 5 files per compaction event (each capped at ~700 bytes after frontmatter).
+- Appends one block of ≤5 lines to `MEMORY.md` per fire.
+- Sends a single LLM call per fire, prompt body capped at ~31 KB (30 KB transcript + ~1 KB instruction).
+
+No file ever gets overwritten — slugs include the flush timestamp, so collisions across two flushes within the same second produce two distinct files. No risk of clobbering existing memory entries.
+
+If the LLM goes haywire (returns 100 facts), `maxFactsPerFlush` caps the writes at 5. If a fact slug coerces to empty after sanitization, that fact is dropped (asserted in test).
+
+## Under-block analysis
+
+When the LLM returns `NONE` or `[]`, the flush exits at `no-facts`. This is the correct under-block — the prompt explicitly invites this response when nothing durable surfaces. No false-positive memory pollution.
+
+When the LLM returns garbage, the flush exits at `parse-failure` with the truncated response captured in audit. The user's MEMORY.md is not polluted.
+
+## Level-of-abstraction fit
+
+- **`PreCompactionFlush` is a single class.** All flush logic — transcript reading, prompt construction, parsing, file writes, audit — lives in one file. Testable in isolation.
+- **Wired into server.ts at the existing PreCompact event listener block.** ~22 lines of new wiring code, conditional on config. The class is loaded via dynamic `await import` so the cold-path cost is zero when disabled.
+- **No new HTTP endpoints, no new hook scripts.** The change rides on existing infrastructure (HookEventReceiver, hook-event-reporter.js, shared intelligence). One new listener, one new class.
+
+This is the minimal vertical that delivers the user-visible win. Anything larger would be premature.
+
+## Signal-vs-authority compliance
+
+The flush itself is an **authority** path (it writes durable files). Signal-vs-authority is preserved by:
+- The LLM is asked to make a *signal-quality* judgment (which facts are durable).
+- The class enforces **hard caps** as the **authority** layer (max facts, max length, slug coercion, write-or-audit). No LLM output ever bypasses the caps.
+- A bad LLM call can't damage the user's memory — only audit junk surfaces.
+
+## Interactions
+
+- **`CompactionSentinel`** (post-compaction recovery): unchanged. Both run on the same PreCompact event but in independent listeners. The Sentinel handles re-injection AFTER compaction; this class handles flush BEFORE compaction. They don't race because the Sentinel's work is keyed on a 10-second post-compaction delay (line 4477).
+- **`HookEventReceiver`**: emits PreCompact unchanged. New listener does not modify the event payload or the emitter's behaviour.
+- **`shared intelligence`** (PR #198 chokepoint): used per the subscription-by-default contract. If `sharedIntelligence` is null (e.g., CLI unavailable + no API opt-in), flush audits `no-intelligence` and exits.
+- **MEMORY.md**: appended under a dedicated `## Pre-Compaction Saves` heading. If that heading does not exist, it is created at the file tail. Pre-existing memory entries are untouched.
+- **`.instar/memory/` directory**: new files only; existing files untouched.
+- **`.instar/audit/`**: new jsonl file; existing audit files untouched.
+
+## Rollback cost
+
+- `config.preCompactionFlush.enabled: false` reverts to legacy behaviour. The class stays in the codebase but the listener is never registered.
+- Files already written to `.instar/memory/learning_precompact_*.md` are harmless markdown — they can be reviewed and deleted at the operator's discretion.
+- Audit jsonl can be moved aside or deleted at any time.
+- No schema migrations, no state mutations beyond memory files.
+
+## CI surface
+
+Touched:
+- `src/core/PreCompactionFlush.ts` — new file, fully covered by 16 unit tests.
+- `src/commands/server.ts` — 22 lines of new wiring inside the existing compaction block. The path is gated on config, so existing server-startup tests (which don't enable the new flag) exercise the gate-off branch.
+
+No CI workflow changes. No husky changes. No native module changes.
+
+## Open questions
+
+None. The design is fully constrained by:
+- OpenClaw's documented pattern (audit doc §3).
+- Justin's approval of "Option A — server-side, agent-noninterruptive."
+- Existing PR #198 safety-guard contract for the intelligence provider.


### PR DESCRIPTION
## Summary

Opt-in pre-compaction memory flush that saves durable facts to `.instar/memory/` files before Claude Code compacts session context. Imports OpenClaw audit §3's pattern in **Option A** (server-side, agent-noninterruptive) shape.

User-visible win: fewer "didn't I just tell you that?" moments after long conversations.

## How it works

1. Claude Code emits `PreCompact` hook → existing `hook-event-reporter.js` POSTs to `/hooks/events` → `HookEventReceiver` emits `PreCompact`.
2. New `PreCompactionFlush` listener reads the transcript tail (default 30 KB, line-aligned).
3. Calls shared intelligence (subscription path, zero per-call cost on default config) with a fact-extraction prompt.
4. Parses response (JSON array / `{facts: [...]}` / fenced JSON), coerces each fact to `{slug, body}`, caps at `maxFactsPerFlush` (default 5).
5. Writes per-fact files under `<projectDir>/.instar/memory/learning_precompact_*.md`.
6. Appends index entries under MEMORY.md's `## Pre-Compaction Saves` section (best effort).
7. Audit entry to `<projectDir>/.instar/audit/pre-compaction-flush.jsonl` for every fire — success, skip, or error.

Default `preCompactionFlush.enabled: false`. Operators opt in after watching audit-log shape.

## Spec / review artifacts

- Spec: `docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.md`
- ELI16 companion: `docs/specs/OPENCLAW-IMPORT-PRE-COMPACTION-FLUSH-SPEC.eli16.md`
- Side-effects review: `upgrades/side-effects/openclaw-import-pre-compaction-flush.md`
- /instar-dev trace: `.instar/instar-dev-traces/20260513T204500Z-precompaction-flush.json`

## Test plan

- [x] 16 unit tests in `tests/unit/PreCompactionFlush.test.ts` cover all 9 outcomes + parsing variants + slug coercion + audit shape + maxFactsPerFlush cap
- [x] Typecheck clean
- [ ] Full CI shards green

## Approval

Justin via Telegram topic 9003, 2026-05-13: "Confirmed" (Option A scope).