### PR TITLE
feat(remediation): W-3 — messaging-delivery-failed runbook + DeliveryRetryManager.runRecoveryCycle

### DIFF
--- a/src/messaging/DeliveryRetryManager.ts
+++ b/src/messaging/DeliveryRetryManager.ts
@@ -19,6 +19,7 @@ import type {
 } from './types.js';
 import type { MessageStore } from './MessageStore.js';
 import type { MessageDelivery } from './MessageDelivery.js';
+import type { RemediationContext, ExecutionResult } from '../remediation/Remediator.js';
 
 /** Layer 3 ACK timeout by message type (in minutes). null = no timeout (fire-and-forget) */
 const ACK_TIMEOUT: Record<MessageType, number | null> = {
@@ -64,6 +65,20 @@ export class DeliveryRetryManager {
   /** Track retry state: messageId → { attempts, firstAttemptAt } */
   private readonly retryState = new Map<string, { attempts: number; firstAttemptAt: number; lastAttemptAt: number }>();
 
+  /**
+   * §A34 R3 surface-alignment: in-flight latch for `tick()` /
+   * `runRecoveryCycle()` to guarantee idempotence against the running timer.
+   * When the timer-driven `tick()` is mid-cycle and the Remediator-driven
+   * `runRecoveryCycle()` (or another `tick()`) arrives, the second caller
+   * returns early instead of double-processing the inbox.
+   *
+   * This is a single-process latch (not a cross-process lock) — the
+   * Remediator's MachineLock handles cross-process exclusion at the dispatch
+   * layer. Inside one process, two timer callbacks (or timer + Remediator
+   * call) racing the same inbox is prevented here.
+   */
+  private cycleInFlight = false;
+
   constructor(store: MessageStore, delivery: MessageDelivery, config: DeliveryRetryManagerConfig) {
     this.store = store;
     this.delivery = delivery;
@@ -84,6 +99,11 @@ export class DeliveryRetryManager {
     }
     this.watchdogTargets.clear();
     this.retryState.clear();
+    // Reset the in-flight latch on stop. If a cycle is genuinely mid-flight
+    // when stop() is called, the latch clears on the cycle's own finally
+    // block anyway — this is belt-and-suspenders for the case where the
+    // manager is recycled mid-test.
+    this.cycleInFlight = false;
   }
 
   /** Register a message for post-injection watchdog monitoring */
@@ -92,7 +112,93 @@ export class DeliveryRetryManager {
   }
 
   /** Main tick — runs every 15 seconds */
-  async tick(): Promise<{ retried: number; expired: number; escalated: number }> {
+  async tick(): Promise<{ retried: number; expired: number; escalated: number; skipped?: boolean }> {
+    // §A34 R3: idempotence against the running timer. If another `tick()` or
+    // `runRecoveryCycle()` is mid-cycle, return early with a structured skip
+    // marker — the in-flight cycle will sweep the queue, no work is lost.
+    if (this.cycleInFlight) {
+      return { retried: 0, expired: 0, escalated: 0, skipped: true };
+    }
+    this.cycleInFlight = true;
+    try {
+      return await this.doCycle();
+    } finally {
+      this.cycleInFlight = false;
+    }
+  }
+
+  /**
+   * §A34 R3 — Remediator-orchestrated recovery cycle.
+   *
+   * Distinct entry-point from the timer-driven `tick()` but shares the same
+   * internal lock (`cycleInFlight`). If `tick()` is mid-flight when the
+   * Remediator dispatches, this returns early with `skipped: true` rather
+   * than racing the same inbox.
+   *
+   * Behaviorally equivalent to `tick()` once it enters `doCycle()`; the
+   * distinction exists so the audit trail can distinguish timer-driven from
+   * Remediator-driven recoveries.
+   *
+   * Idempotence proof: both entry-points share `cycleInFlight`; whichever
+   * arrives second short-circuits. The first caller's `doCycle()` sweeps
+   * every queued / undelivered / expired message in the inbox, so the
+   * second caller would have done identical work on the same items.
+   */
+  async runRecoveryCycle(): Promise<{ retried: number; expired: number; escalated: number; skipped?: boolean }> {
+    if (this.cycleInFlight) {
+      return { retried: 0, expired: 0, escalated: 0, skipped: true };
+    }
+    this.cycleInFlight = true;
+    try {
+      return await this.doCycle();
+    } finally {
+      this.cycleInFlight = false;
+    }
+  }
+
+  /**
+   * §A34 R3 — Remediator surface entry point.
+   *
+   * Mirrors the `invokeFromRemediator(ctx)` convention from W-1's
+   * `NativeModuleHealer`. Wraps `runRecoveryCycle()` and translates the
+   * structured result into a `ExecutionResult` so the runbook's
+   * `surfaceCallable` can forward it. The Tier-1 skeleton in
+   * `src/remediation/Remediator.ts` runs `verify(ctx)` after a `success`
+   * outcome — the runbook's verify probe asserts inbox-drain durability
+   * (§A9), independent of this surface call's return value.
+   *
+   * The `ctx.abortSignal` is informational — Layer 2 / TTL / watchdog
+   * operations are short, atomic, and durable. We don't pre-empt mid-cycle.
+   * If the deadline trips, the Remediator's `aborted-deadline` branch
+   * supersedes anything we return.
+   */
+  async invokeFromRemediator(_ctx: RemediationContext): Promise<ExecutionResult> {
+    try {
+      const result = await this.runRecoveryCycle();
+      return {
+        outcome: 'success',
+        details: {
+          retried: result.retried,
+          expired: result.expired,
+          escalated: result.escalated,
+          skipped: result.skipped ?? false,
+        },
+      };
+    } catch (err) {
+      return {
+        outcome: 'failure',
+        details: {
+          error: err instanceof Error ? err.message : String(err),
+        },
+      };
+    }
+  }
+
+  /**
+   * Inner cycle body extracted so `tick()` and `runRecoveryCycle()` share
+   * one implementation under one in-flight latch.
+   */
+  private async doCycle(): Promise<{ retried: number; expired: number; escalated: number }> {
     let retried = 0;
     let expired = 0;
     let escalated = 0;

--- a/src/remediation/runbooks/messaging-delivery-failed.ts
+++ b/src/remediation/runbooks/messaging-delivery-failed.ts
@@ -1,0 +1,216 @@
+/**
+ * messaging-delivery-failed — Tier-2 W-3 runbook.
+ *
+ * SELF-HEALING-REMEDIATOR-V2-SPEC §A1 W-3, §A6 (structured provenance only),
+ * §A9 (durable verify — drain ALL stuck messages, not just one), §A34 R3
+ * (surface-alignment: `DeliveryRetryManager.runRecoveryCycle()` is a new
+ * public method distinct from timer-driven `tick()`, idempotent against the
+ * running timer via a shared in-flight latch), §A57 (Tier-2 W-3).
+ *
+ * Surface: `DeliveryRetryManager.invokeFromRemediator(ctx)` (added by W-3).
+ * The legacy `tick()` timer entry-point on `start()` stays unchanged — it
+ * remains the steady-state cadence; this runbook is the parallel,
+ * Remediator-orchestrated path for when degradation events fire (Telegram
+ * 429/500, generic DELIVERY_FAILURE).
+ *
+ * Match contract:
+ *   eventPrefilter.errorCode    = ['DELIVERY_FAILURE','TELEGRAM_429','TELEGRAM_500']
+ *   eventPrefilter.provenance   = ['subsystem-explicit','probe-id']
+ *
+ * `'free-text'` is intentionally NOT in the prefilter — §A6 mandates
+ * structured-provenance only.
+ *
+ * Verify (A9 — durable, not just live):
+ *   The verify step queries the durable inbox (via the messaging adapter
+ *   injected for testing, or the manager's own store) and asserts that
+ *   NO messages remain in `queued` or `undelivered` phase for the manager's
+ *   agent. A clean inbox → `verified-healthy`. Any stuck messages →
+ *   `verify-failed` (durability not restored). A probe error (cannot read
+ *   the store) → `verify-inconclusive` per §A21.
+ *
+ *   This is a stronger assertion than "the cycle ran" — a single retry
+ *   could succeed for one message and leave nine others stuck. Durable
+ *   drain is the spec's bar.
+ *
+ * essential:
+ *   This runbook is `essential: false`. Messaging downtime is recoverable
+ *   via the standard 15s timer cadence — the Remediator-orchestrated path
+ *   is desirable (faster recovery + audit-tracked) but not load-bearing
+ *   for agent survival. blastRadius is 'process' (the cycle touches
+ *   only in-process state + the on-disk message store), and §A36 forbids
+ *   essential=true on non-machine blast-radius.
+ */
+
+import type { ApprovedRunbook, RemediationContext, ExecutionResult, VerifyOutcome } from '../Remediator.js';
+import type { DeliveryRetryManager } from '../../messaging/DeliveryRetryManager.js';
+import type { MessageStore } from '../../messaging/MessageStore.js';
+
+/**
+ * Dependencies the runbook resolves at dispatch time. Production wires the
+ * live `DeliveryRetryManager` + its `MessageStore`; tests inject fakes.
+ *
+ * Late-bound via a registry function rather than a constant so the runbook
+ * module doesn't have to import the messaging singleton at module-load
+ * time (which would create a circular import path through the server).
+ */
+export interface MessagingDeliveryDeps {
+  /** Returns the live manager, or null if messaging is not initialized. */
+  getManager: () => DeliveryRetryManager | null;
+  /**
+   * Returns the live message store + the agent name to scope inbox queries
+   * to. The verify probe uses this to assert durable drain.
+   */
+  getStoreScope: () => { store: MessageStore; agentName: string } | null;
+}
+
+let _deps: MessagingDeliveryDeps | null = null;
+
+/**
+ * Production wires the live manager + store at boot via this setter. Tests
+ * inject fakes. Setting to `null` resets — the surfaceCallable + verify
+ * report `verify-inconclusive` (probe error) until re-wired.
+ */
+export function setMessagingDeliveryDeps(deps: MessagingDeliveryDeps | null): void {
+  _deps = deps;
+}
+
+/**
+ * §A9 durable verify probe. Returns a structured kind so the runbook's
+ * verify() can map to the {verified-healthy | verify-failed | verify-inconclusive}
+ * taxonomy without ambiguity.
+ *
+ * "Durable" means the on-disk inbox query, not the in-memory retry-state
+ * map. The store is the source of truth — retryState is a transient
+ * scheduling hint that resets on process restart.
+ */
+async function probeDurableDrain(
+  deps: MessagingDeliveryDeps | null,
+): Promise<
+  | { kind: 'ok' }
+  | { kind: 'stuck'; stuckCount: number; sampleIds: string[] }
+  | { kind: 'inconclusive'; reason: string }
+> {
+  if (!deps) {
+    return { kind: 'inconclusive', reason: 'messaging-delivery deps not wired' };
+  }
+  const scope = deps.getStoreScope();
+  if (!scope) {
+    return { kind: 'inconclusive', reason: 'messaging store-scope unavailable' };
+  }
+  try {
+    const inbox = await scope.store.queryInbox(scope.agentName);
+    const stuck = inbox.filter(
+      (e) => e.delivery.phase === 'queued' || e.delivery.phase === 'undelivered',
+    );
+    if (stuck.length === 0) {
+      return { kind: 'ok' };
+    }
+    return {
+      kind: 'stuck',
+      stuckCount: stuck.length,
+      sampleIds: stuck.slice(0, 5).map((e) => e.message.id),
+    };
+  } catch (err) {
+    return {
+      kind: 'inconclusive',
+      reason: `queryInbox threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
+ * Allow tests to inject a deterministic verify probe. Production always
+ * uses `probeDurableDrain` against the wired deps.
+ */
+type VerifyFn = (deps: MessagingDeliveryDeps | null) => Promise<
+  | { kind: 'ok' }
+  | { kind: 'stuck'; stuckCount: number; sampleIds: string[] }
+  | { kind: 'inconclusive'; reason: string }
+>;
+let _verifyImpl: VerifyFn = probeDurableDrain;
+export function _setVerifyImplForTesting(fn: VerifyFn | null): void {
+  _verifyImpl = fn ?? probeDurableDrain;
+}
+
+async function callSurface(ctx: RemediationContext): Promise<ExecutionResult> {
+  if (!_deps) {
+    return {
+      outcome: 'failure',
+      details: { error: 'messaging-delivery deps not wired' },
+    };
+  }
+  const mgr = _deps.getManager();
+  if (!mgr) {
+    return {
+      outcome: 'failure',
+      details: { error: 'DeliveryRetryManager not initialized' },
+    };
+  }
+  return mgr.invokeFromRemediator(ctx);
+}
+
+export const messagingDeliveryFailedRunbook: ApprovedRunbook = {
+  id: 'messaging-delivery-failed',
+  priority: 80,
+  surface: 'delivery-retry',
+  eventPrefilter: {
+    // Three structured errorCodes the messaging subsystem emits. Telegram
+    // 429 (rate-limit) and 500 (upstream error) are the dominant
+    // failure-mode classes; generic DELIVERY_FAILURE catches the long
+    // tail (tmux session unreachable, ack-timeout escalation, etc.).
+    errorCode: ['DELIVERY_FAILURE', 'TELEGRAM_429', 'TELEGRAM_500'],
+    // §A6: NOT free-text. Probe-id is allowed because future messaging
+    // probes (e.g., a periodic queue-depth probe) will emit signed events.
+    provenance: ['subsystem-explicit', 'probe-id'],
+  },
+  match: (event) => {
+    // Match anything that came from the messaging subsystem. The errorCode
+    // prefilter is already narrow; the match() callback is defence-in-depth
+    // against an unrelated subsystem that happens to ship one of these
+    // generic codes (e.g., a future HTTP client emitting a generic 429).
+    return event.subsystem === 'messaging' || event.subsystem === 'delivery-retry';
+  },
+  preconditions: async (_event) => {
+    // Deps must be wired AND the manager must be live. Without either,
+    // calling the surface is meaningless — short-circuit at precondition
+    // time so the audit trail records the right reason.
+    if (!_deps) return false;
+    return _deps.getManager() !== null;
+  },
+  surfaceCallable: callSurface,
+  verify: async (_ctx) => {
+    const result = await _verifyImpl(_deps);
+    const v: VerifyOutcome = (() => {
+      switch (result.kind) {
+        case 'ok':
+          return {
+            outcome: 'verified-healthy',
+            reason: 'inbox drained — 0 queued/undelivered messages',
+          };
+        case 'stuck':
+          return {
+            outcome: 'verify-failed',
+            reason:
+              `${result.stuckCount} messages still queued/undelivered after recovery cycle ` +
+              `(sample: ${result.sampleIds.join(', ')})`,
+          };
+        case 'inconclusive':
+          return {
+            outcome: 'verify-inconclusive',
+            reason: result.reason,
+          };
+      }
+    })();
+    return v;
+  },
+  blastRadius: 'process',
+  reversibility: 'reversible',
+  expectedRuntimeMs: 60_000,
+  // §A36: essential=true requires blastRadius='machine'. Messaging downtime
+  // is recoverable via the timer cadence (15s tick), so the Remediator-
+  // orchestrated path is desirable-not-required — essential stays false.
+  essential: false,
+};
+
+// Re-export the verify probe for tests / consumers that want it raw.
+export { probeDurableDrain };

--- a/tests/unit/DeliveryRetryManager-runRecoveryCycle.test.ts
+++ b/tests/unit/DeliveryRetryManager-runRecoveryCycle.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for DeliveryRetryManager.runRecoveryCycle + invokeFromRemediator
+ * (W-3 surface entry-point).
+ *
+ * Covers SELF-HEALING-REMEDIATOR-V2-SPEC §A34 R3 surface-alignment:
+ *   - `runRecoveryCycle()` exists as a public method distinct from `tick()`.
+ *   - It is idempotent against the running timer (shared in-flight latch).
+ *   - `invokeFromRemediator(ctx)` wraps it and returns ExecutionResult.
+ *
+ * Strategy: real MessageStore + MessageDelivery, controlled tmux fakes.
+ * The latch-against-tick test deliberately reaches into a slow store impl
+ * to keep one cycle in-flight while a second call races it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { MessageStore } from '../../src/messaging/MessageStore.js';
+import { MessageDelivery, type TmuxOperations } from '../../src/messaging/MessageDelivery.js';
+import { MessageFormatter } from '../../src/messaging/MessageFormatter.js';
+import { DeliveryRetryManager } from '../../src/messaging/DeliveryRetryManager.js';
+import type { MessageEnvelope, AgentMessage } from '../../src/messaging/types.js';
+import type { RemediationContext } from '../../src/remediation/Remediator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'instar-w3-runcycle-'));
+}
+
+function makeMessage(overrides?: Partial<AgentMessage>): AgentMessage {
+  return {
+    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    from: { agent: 'sender', session: 'session-1', machine: 'test-machine' },
+    to: { agent: 'test-agent', session: 'target-session', machine: 'local' },
+    type: 'info',
+    priority: 'medium',
+    subject: 'Test',
+    body: 'Hello',
+    createdAt: new Date().toISOString(),
+    ttlMinutes: 30,
+    ...overrides,
+  };
+}
+
+function makeEnvelope(overrides?: Partial<AgentMessage>): MessageEnvelope {
+  return {
+    schemaVersion: 1,
+    message: makeMessage(overrides),
+    transport: {
+      relayChain: [],
+      originServer: 'http://localhost:3000',
+      nonce: `${crypto.randomUUID()}:${new Date().toISOString()}`,
+      timestamp: new Date().toISOString(),
+    },
+    delivery: {
+      phase: 'queued',
+      transitions: [
+        { from: 'created', to: 'sent', at: new Date().toISOString() },
+        { from: 'sent', to: 'queued', at: new Date().toISOString() },
+      ],
+      attempts: 0,
+    },
+  };
+}
+
+function makeTmux(overrides?: Partial<TmuxOperations>): TmuxOperations {
+  return {
+    getForegroundProcess: () => 'bash',
+    isSessionAlive: () => true,
+    hasActiveHumanInput: () => false,
+    sendKeys: () => true,
+    getOutputLineCount: () => 100,
+    ...overrides,
+  };
+}
+
+function makeCtx(): RemediationContext {
+  return {
+    attemptId: 'test-attempt-' + Math.random().toString(36).slice(2),
+    runbookId: 'messaging-delivery-failed',
+    lockHandle: {} as never,
+    auditToken: Buffer.from('test-token'),
+    abortSignal: new AbortController().signal,
+    expiresAt: Date.now() + 60_000,
+    monotonicDeadline: process.hrtime.bigint() + 60_000_000_000n,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('DeliveryRetryManager.runRecoveryCycle / invokeFromRemediator (W-3)', () => {
+  let tmpDir: string;
+  let store: MessageStore;
+  let delivery: MessageDelivery;
+  let manager: DeliveryRetryManager;
+
+  beforeEach(async () => {
+    tmpDir = createTempDir();
+    store = new MessageStore(tmpDir);
+    await store.initialize();
+    delivery = new MessageDelivery(new MessageFormatter(), makeTmux());
+    manager = new DeliveryRetryManager(store, delivery, {
+      agentName: 'test-agent',
+    });
+  });
+
+  afterEach(() => {
+    manager.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/DeliveryRetryManager-runRecoveryCycle.test.ts:afterEach',
+    });
+  });
+
+  it('exposes runRecoveryCycle as a distinct public method from tick (§A34 R3)', () => {
+    expect(typeof manager.runRecoveryCycle).toBe('function');
+    expect(typeof manager.tick).toBe('function');
+    // They are different function references.
+    expect(manager.runRecoveryCycle).not.toBe(manager.tick);
+  });
+
+  it('runRecoveryCycle returns the same shape as tick when inbox is empty', async () => {
+    const result = await manager.runRecoveryCycle();
+    expect(result.retried).toBe(0);
+    expect(result.expired).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeFalsy();
+  });
+
+  it('runRecoveryCycle processes queued messages identically to tick', async () => {
+    // Add an expired envelope so runRecoveryCycle will dead-letter it.
+    const envelope = makeEnvelope({
+      ttlMinutes: 0, // already expired
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    await store.save(envelope);
+
+    const result = await manager.runRecoveryCycle();
+    expect(result.expired).toBeGreaterThanOrEqual(1);
+  });
+
+  it('runRecoveryCycle is idempotent against an in-flight tick (shared latch)', async () => {
+    // Drive the manager into a long cycle by stubbing the store's queryInbox
+    // to never resolve until we let it.
+    let releaseFirst: (() => void) | null = null;
+    const realQuery = store.queryInbox.bind(store);
+    let callCount = 0;
+    store.queryInbox = async (agentName: string) => {
+      callCount++;
+      if (callCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return realQuery(agentName);
+    };
+
+    // Kick off tick(); it will block waiting on the stub.
+    const tickPromise = manager.tick();
+
+    // Wait a tick to ensure tick() has entered the latch.
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Now call runRecoveryCycle — it MUST short-circuit with skipped:true.
+    const concurrent = await manager.runRecoveryCycle();
+    expect(concurrent).toEqual({
+      retried: 0,
+      expired: 0,
+      escalated: 0,
+      skipped: true,
+    });
+
+    // Release the first cycle.
+    releaseFirst!();
+    const tickResult = await tickPromise;
+    expect(tickResult.skipped).toBeFalsy();
+  });
+
+  it('tick is idempotent against an in-flight runRecoveryCycle (same latch)', async () => {
+    // Symmetric test: runRecoveryCycle in-flight blocks tick.
+    let releaseFirst: (() => void) | null = null;
+    const realQuery = store.queryInbox.bind(store);
+    let callCount = 0;
+    store.queryInbox = async (agentName: string) => {
+      callCount++;
+      if (callCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return realQuery(agentName);
+    };
+
+    const cyclePromise = manager.runRecoveryCycle();
+    await new Promise((r) => setTimeout(r, 5));
+
+    const tickResult = await manager.tick();
+    expect(tickResult).toEqual({
+      retried: 0,
+      expired: 0,
+      escalated: 0,
+      skipped: true,
+    });
+
+    releaseFirst!();
+    const cycleResult = await cyclePromise;
+    expect(cycleResult.skipped).toBeFalsy();
+  });
+
+  it('latch resets after cycle completes — subsequent calls run normally', async () => {
+    const first = await manager.runRecoveryCycle();
+    expect(first.skipped).toBeFalsy();
+    const second = await manager.runRecoveryCycle();
+    expect(second.skipped).toBeFalsy();
+    const third = await manager.tick();
+    expect(third.skipped).toBeFalsy();
+  });
+
+  it('invokeFromRemediator wraps runRecoveryCycle and returns ExecutionResult success', async () => {
+    const ctx = makeCtx();
+    const result = await manager.invokeFromRemediator(ctx);
+    expect(result.outcome).toBe('success');
+    expect(result.details).toMatchObject({
+      retried: 0,
+      expired: 0,
+      escalated: 0,
+      skipped: false,
+    });
+  });
+
+  it('invokeFromRemediator returns failure when runRecoveryCycle throws', async () => {
+    // Force queryInbox to throw.
+    store.queryInbox = async () => {
+      throw new Error('synthetic store failure');
+    };
+    const ctx = makeCtx();
+    const result = await manager.invokeFromRemediator(ctx);
+    expect(result.outcome).toBe('failure');
+    expect((result.details as { error?: string }).error).toMatch(/synthetic/);
+  });
+
+  it('invokeFromRemediator reports skipped:true when cycle is already in-flight', async () => {
+    let releaseFirst: (() => void) | null = null;
+    let callCount = 0;
+    const realQuery = store.queryInbox.bind(store);
+    store.queryInbox = async (agentName: string) => {
+      callCount++;
+      if (callCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return realQuery(agentName);
+    };
+
+    const inFlight = manager.tick();
+    await new Promise((r) => setTimeout(r, 5));
+
+    const ctx = makeCtx();
+    const result = await manager.invokeFromRemediator(ctx);
+    expect(result.outcome).toBe('success');
+    expect((result.details as { skipped?: boolean }).skipped).toBe(true);
+
+    releaseFirst!();
+    await inFlight;
+  });
+
+  it('stop() clears the in-flight latch (recycle-safe)', async () => {
+    // Manually set the latch — simulating a stuck flag from a crashed cycle.
+    (manager as unknown as { cycleInFlight: boolean }).cycleInFlight = true;
+    manager.stop();
+    const result = await manager.runRecoveryCycle();
+    expect(result.skipped).toBeFalsy();
+  });
+
+  it('existing tick() return shape unchanged (no skipped key) when cycle runs normally', async () => {
+    const result = await manager.tick();
+    expect(result.retried).toBe(0);
+    expect(result.expired).toBe(0);
+    expect(result.escalated).toBe(0);
+    // skipped is optional; missing/falsy when the cycle actually ran.
+    expect(result.skipped).toBeFalsy();
+  });
+});

--- a/tests/unit/runbooks/messaging-delivery-failed.test.ts
+++ b/tests/unit/runbooks/messaging-delivery-failed.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Unit tests for the messaging-delivery-failed runbook (W-3).
+ *
+ * Covers SELF-HEALING-REMEDIATOR-V2-SPEC §A1 W-3, §A6 (structured
+ * provenance), §A9 (durable verify — full inbox drain), §A21 (verify
+ * outcome taxonomy), §A34 R3 (surface alignment via invokeFromRemediator),
+ * §A36 (essential=false on process-blast-radius runbook).
+ *
+ * Strategy: real `Remediator` + real F-4 primitives (tmpdir-backed),
+ * real `DeliveryRetryManager` against a real `MessageStore`. We inject
+ * deps via `setMessagingDeliveryDeps()` so the runbook resolves to our
+ * test instances without touching production singletons.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import { Remediator } from '../../../src/remediation/Remediator.js';
+import {
+  messagingDeliveryFailedRunbook,
+  setMessagingDeliveryDeps,
+  _setVerifyImplForTesting,
+} from '../../../src/remediation/runbooks/messaging-delivery-failed.js';
+import { MachineLock } from '../../../src/remediation/MachineLock.js';
+import { IntentJournal } from '../../../src/remediation/IntentJournal.js';
+import {
+  AuditWriter,
+  deserializeAuditEntry,
+  type AuditEntry,
+} from '../../../src/remediation/audit/AuditWriter.js';
+import { MessageStore } from '../../../src/messaging/MessageStore.js';
+import { MessageDelivery, type TmuxOperations } from '../../../src/messaging/MessageDelivery.js';
+import { MessageFormatter } from '../../../src/messaging/MessageFormatter.js';
+import { DeliveryRetryManager } from '../../../src/messaging/DeliveryRetryManager.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+import type { NormalizedDegradationEvent } from '../../../src/monitoring/DegradationReporter.js';
+import type { MessageEnvelope, AgentMessage } from '../../../src/messaging/types.js';
+
+// ── Fakes ────────────────────────────────────────────────────────────────
+
+class FakeKeyVault {
+  private readonly master = crypto.randomBytes(32);
+  private readonly nonce = crypto.randomBytes(32);
+  deriveLeafKey(context: string, scopeId: string | null): Buffer {
+    const info = Buffer.from(`${context}:${scopeId ?? ''}`);
+    return Buffer.from(
+      crypto.hkdfSync('sha256', this.master, this.nonce, info, 32)
+    );
+  }
+}
+
+function makeSignerPair(): {
+  signer: (payload: Buffer) => Buffer;
+  verifier: (payload: Buffer, signature: Buffer) => boolean;
+} {
+  const key = crypto.randomBytes(32);
+  return {
+    signer: (payload) =>
+      crypto.createHmac('sha256', key).update(payload).digest(),
+    verifier: (payload, signature) => {
+      const expected = crypto
+        .createHmac('sha256', key)
+        .update(payload)
+        .digest();
+      if (expected.length !== signature.length) return false;
+      return crypto.timingSafeEqual(expected, signature);
+    },
+  };
+}
+
+function makeEvent(
+  overrides?: Partial<NormalizedDegradationEvent>
+): NormalizedDegradationEvent {
+  return {
+    subsystem: overrides?.subsystem ?? 'messaging',
+    errorCode: overrides?.errorCode ?? 'DELIVERY_FAILURE',
+    provenance: overrides?.provenance ?? 'subsystem-explicit',
+    reason: overrides?.reason ?? {
+      redacted: 'delivery failure (redacted)',
+      full: 'tmux session unreachable after 10 retries',
+    },
+    timestamp: overrides?.timestamp ?? new Date().toISOString(),
+    monotonicTs: overrides?.monotonicTs ?? performance.now(),
+  };
+}
+
+function makeMessage(overrides?: Partial<AgentMessage>): AgentMessage {
+  return {
+    id: `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    from: { agent: 'sender', session: 'session-1', machine: 'test-machine' },
+    to: { agent: 'test-agent', session: 'target-session', machine: 'local' },
+    type: 'info',
+    priority: 'medium',
+    subject: 'Test',
+    body: 'Hello',
+    createdAt: new Date().toISOString(),
+    ttlMinutes: 30,
+    ...overrides,
+  };
+}
+
+function makeEnvelope(overrides?: Partial<AgentMessage>): MessageEnvelope {
+  return {
+    schemaVersion: 1,
+    message: makeMessage(overrides),
+    transport: {
+      relayChain: [],
+      originServer: 'http://localhost:3000',
+      nonce: `${crypto.randomUUID()}:${new Date().toISOString()}`,
+      timestamp: new Date().toISOString(),
+    },
+    delivery: {
+      phase: 'queued',
+      transitions: [
+        { from: 'created', to: 'sent', at: new Date().toISOString() },
+        { from: 'sent', to: 'queued', at: new Date().toISOString() },
+      ],
+      attempts: 0,
+    },
+  };
+}
+
+function makeTmux(overrides?: Partial<TmuxOperations>): TmuxOperations {
+  return {
+    getForegroundProcess: () => 'bash',
+    isSessionAlive: () => true,
+    hasActiveHumanInput: () => false,
+    sendKeys: () => true,
+    getOutputLineCount: () => 100,
+    ...overrides,
+  };
+}
+
+interface Fixture {
+  tmpDir: string;
+  remediator: Remediator;
+  machineLock: MachineLock;
+  intentJournal: IntentJournal;
+  auditWriter: AuditWriter;
+  machineId: string;
+  store: MessageStore;
+  manager: DeliveryRetryManager;
+}
+
+async function makeFixture(): Promise<Fixture> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'w3-runbook-'));
+  const machineId = 'm-test';
+  const machineLock = new MachineLock(tmpDir);
+  const intentJournal = new IntentJournal(tmpDir, { machineId });
+  const auditWriter = new AuditWriter(tmpDir, {
+    machineId,
+    tokenVerifier: (e: AuditEntry) => e.auditToken.length > 0,
+  });
+  const keyVault = new FakeKeyVault();
+  const signerPair = makeSignerPair();
+  const remediator = new Remediator({
+    stateDir: tmpDir,
+    keyVault: keyVault as unknown as Parameters<
+      typeof Remediator.prototype.constructor
+    >[0]['keyVault'],
+    machineLock,
+    intentJournal,
+    auditWriter,
+    lockSigner: signerPair.signer,
+    lockVerifier: signerPair.verifier,
+  });
+
+  const storeDir = path.join(tmpDir, 'messaging');
+  fs.mkdirSync(storeDir, { recursive: true });
+  const store = new MessageStore(storeDir);
+  await store.initialize();
+  const delivery = new MessageDelivery(new MessageFormatter(), makeTmux());
+  const manager = new DeliveryRetryManager(store, delivery, {
+    agentName: 'test-agent',
+  });
+
+  setMessagingDeliveryDeps({
+    getManager: () => manager,
+    getStoreScope: () => ({ store, agentName: 'test-agent' }),
+  });
+
+  return {
+    tmpDir,
+    remediator,
+    machineLock,
+    intentJournal,
+    auditWriter,
+    machineId,
+    store,
+    manager,
+  };
+}
+
+function cleanup(fx: Fixture): void {
+  fx.manager.stop();
+  setMessagingDeliveryDeps(null);
+  SafeFsExecutor.safeRmSync(fx.tmpDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/runbooks/messaging-delivery-failed.test.ts:cleanup',
+  });
+}
+
+function readProjection(tmpDir: string, machineId: string): AuditEntry[] {
+  const p = path.join(
+    tmpDir,
+    'remediation',
+    `audit-projection-${machineId}.jsonl`
+  );
+  if (!fs.existsSync(p)) return [];
+  return fs
+    .readFileSync(p, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(deserializeAuditEntry);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('messaging-delivery-failed runbook (W-3)', () => {
+  let fx: Fixture;
+
+  beforeEach(async () => {
+    fx = await makeFixture();
+    _setVerifyImplForTesting(null);
+  });
+
+  afterEach(() => {
+    cleanup(fx);
+    _setVerifyImplForTesting(null);
+    vi.restoreAllMocks();
+  });
+
+  it('matches messaging-subsystem events with structured errorCodes', () => {
+    expect(() =>
+      fx.remediator.registerRunbook(messagingDeliveryFailedRunbook)
+    ).not.toThrow();
+
+    expect(
+      messagingDeliveryFailedRunbook.match(makeEvent({ errorCode: 'DELIVERY_FAILURE' }))
+    ).toBe(true);
+    expect(
+      messagingDeliveryFailedRunbook.match(makeEvent({ errorCode: 'TELEGRAM_429' }))
+    ).toBe(true);
+    expect(
+      messagingDeliveryFailedRunbook.match(makeEvent({ errorCode: 'TELEGRAM_500' }))
+    ).toBe(true);
+  });
+
+  it('does NOT include free-text in eventPrefilter.provenance (§A6)', () => {
+    expect(messagingDeliveryFailedRunbook.eventPrefilter.provenance).not.toContain(
+      'free-text'
+    );
+  });
+
+  it('match() rejects events from other subsystems', () => {
+    const ev = makeEvent({ subsystem: 'memory' });
+    expect(messagingDeliveryFailedRunbook.match(ev)).toBe(false);
+  });
+
+  it('Remediator.registerRunbook ACCEPTS this runbook (essential=false, process radius, no free-text)', () => {
+    expect(() =>
+      fx.remediator.registerRunbook(messagingDeliveryFailedRunbook)
+    ).not.toThrow();
+  });
+
+  it('essential=false honors §A36 (process radius forbids essential=true)', () => {
+    expect(messagingDeliveryFailedRunbook.essential).toBe(false);
+    expect(messagingDeliveryFailedRunbook.blastRadius).toBe('process');
+  });
+
+  it('has priority=80, surface=delivery-retry, expectedRuntimeMs=60_000 per A1 manifest', () => {
+    expect(messagingDeliveryFailedRunbook.id).toBe('messaging-delivery-failed');
+    expect(messagingDeliveryFailedRunbook.priority).toBe(80);
+    expect(messagingDeliveryFailedRunbook.surface).toBe('delivery-retry');
+    expect(messagingDeliveryFailedRunbook.expectedRuntimeMs).toBe(60_000);
+    expect(messagingDeliveryFailedRunbook.reversibility).toBe('reversible');
+  });
+
+  it('preconditions fail when deps are not wired', async () => {
+    setMessagingDeliveryDeps(null);
+    const ok = await messagingDeliveryFailedRunbook.preconditions(makeEvent());
+    expect(ok).toBe(false);
+  });
+
+  it('preconditions succeed when manager is wired', async () => {
+    const ok = await messagingDeliveryFailedRunbook.preconditions(makeEvent());
+    expect(ok).toBe(true);
+  });
+
+  it('surfaceCallable invokes manager.invokeFromRemediator with ctx', async () => {
+    const spy = vi.spyOn(fx.manager, 'invokeFromRemediator').mockResolvedValue({
+      outcome: 'success',
+      details: { retried: 1, expired: 0, escalated: 0, skipped: false },
+    });
+
+    const ctx = {
+      attemptId: 'test-attempt',
+      runbookId: 'messaging-delivery-failed',
+      lockHandle: {} as never,
+      auditToken: Buffer.from('test'),
+      abortSignal: new AbortController().signal,
+      expiresAt: Date.now() + 60_000,
+      monotonicDeadline: process.hrtime.bigint() + 60_000_000_000n,
+    };
+
+    const result = await messagingDeliveryFailedRunbook.surfaceCallable(ctx);
+    expect(result.outcome).toBe('success');
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0]![0]).toBe(ctx);
+  });
+
+  it('verify() returns verified-healthy when inbox is drained (§A9)', async () => {
+    _setVerifyImplForTesting(async () => ({ kind: 'ok' }));
+    const result = await messagingDeliveryFailedRunbook.verify({} as never);
+    expect(result.outcome).toBe('verified-healthy');
+    expect(result.reason).toMatch(/drained/);
+  });
+
+  it('verify() returns verify-failed when messages are still stuck (§A9 durable)', async () => {
+    _setVerifyImplForTesting(async () => ({
+      kind: 'stuck',
+      stuckCount: 3,
+      sampleIds: ['msg-1', 'msg-2', 'msg-3'],
+    }));
+    const result = await messagingDeliveryFailedRunbook.verify({} as never);
+    expect(result.outcome).toBe('verify-failed');
+    expect(result.reason).toMatch(/3 messages still queued/);
+    expect(result.reason).toMatch(/msg-1/);
+  });
+
+  it('verify() returns verify-inconclusive when store probe errors (§A21)', async () => {
+    _setVerifyImplForTesting(async () => ({
+      kind: 'inconclusive',
+      reason: 'queryInbox threw: ENOENT',
+    }));
+    const result = await messagingDeliveryFailedRunbook.verify({} as never);
+    expect(result.outcome).toBe('verify-inconclusive');
+    expect(result.reason).toMatch(/ENOENT/);
+  });
+
+  it('verify() against real store: queued message → verify-failed (durable assertion, not live)', async () => {
+    // Persist a queued envelope. Manager's invokeFromRemediator won't be
+    // able to deliver because tmux says session changed mid-flight... but
+    // the verify probe just looks at the store state.
+    const stuck = makeEnvelope();
+    await fx.store.save(stuck);
+
+    // Default verify impl runs against the wired deps.
+    const result = await messagingDeliveryFailedRunbook.verify({} as never);
+    expect(result.outcome).toBe('verify-failed');
+    expect(result.reason).toMatch(/1 messages still queued/);
+  });
+
+  it('verify() against real store: empty inbox → verified-healthy', async () => {
+    const result = await messagingDeliveryFailedRunbook.verify({} as never);
+    expect(result.outcome).toBe('verified-healthy');
+  });
+
+  it('end-to-end dispatch on TELEGRAM_429 → invokes manager → verifies durable drain', async () => {
+    // Empty inbox at start → after dispatch verify should see clean drain.
+    const invokeSpy = vi.spyOn(fx.manager, 'invokeFromRemediator');
+
+    fx.remediator.registerRunbook(messagingDeliveryFailedRunbook);
+    const ev = makeEvent({ errorCode: 'TELEGRAM_429' });
+    const result = await fx.remediator.dispatch(ev);
+
+    expect(result.outcome).toBe('verified-healthy');
+    expect(invokeSpy).toHaveBeenCalledOnce();
+
+    const entries = readProjection(fx.tmpDir, fx.machineId);
+    expect(entries.map((e) => e.outcome)).toEqual([
+      'started',
+      'verified-healthy',
+    ]);
+    for (const entry of entries) {
+      expect(entry.runbookId).toBe('messaging-delivery-failed');
+    }
+  });
+
+  it('end-to-end dispatch with stuck messages → verify-failed audited', async () => {
+    // Two stuck queued envelopes. Manager surface call returns success
+    // (it processed what it could), but verify durably sees the stuck
+    // state and reports verify-failed per §A9.
+    await fx.store.save(makeEnvelope());
+    await fx.store.save(makeEnvelope());
+
+    // Stub deliverToSession via the manager's delivery to fail, so the
+    // retry leaves them in queued state.
+    vi.spyOn(
+      (fx.manager as unknown as { delivery: { deliverToSession: () => unknown } })
+        .delivery,
+      'deliverToSession'
+    ).mockResolvedValue({
+      success: false,
+      reason: 'synthetic test failure',
+      action: 'queued',
+    } as never);
+
+    fx.remediator.registerRunbook(messagingDeliveryFailedRunbook);
+    const ev = makeEvent({ errorCode: 'DELIVERY_FAILURE' });
+    const result = await fx.remediator.dispatch(ev);
+
+    expect(result.outcome).toBe('verify-failed');
+    const entries = readProjection(fx.tmpDir, fx.machineId);
+    const outcomes = entries.map((e) => e.outcome);
+    expect(outcomes).toContain('verify-failed');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -5,6 +5,10 @@ note (`upgrades/<version>.md`) at release-cut time.
 
 ---
 
+### feat(remediation): W-3 — messaging-delivery-failed runbook + DeliveryRetryManager.runRecoveryCycle
+
+New Tier-2 wrapper PR. `DeliveryRetryManager` gains two additive public methods per SELF-HEALING-REMEDIATOR-V2-SPEC §A34 R3 surface-alignment: `runRecoveryCycle()` (idempotent against the running 15s timer via a shared in-flight latch) and `invokeFromRemediator(ctx)` (Remediator surface entry-point returning ExecutionResult). The legacy timer-driven `tick()` is unchanged — same behavior, same return shape, plus an optional `skipped:true` marker when the latch short-circuits a concurrent caller. New `src/remediation/runbooks/messaging-delivery-failed.ts` runbook fires on `DELIVERY_FAILURE | TELEGRAM_429 | TELEGRAM_500` with structured provenance (§A6 — no free-text); priority 80; blastRadius `process`; essential `false` (messaging downtime is recoverable via the standard timer cadence, §A36 forbids essential=true on non-machine radius). Verify is a durable assertion per §A9 — queries the on-disk inbox and asserts ALL queued/undelivered messages have drained, not just one. 27 new tests (16 runbook + 11 manager) cover idempotence-against-timer (both directions), latch reset after cycle, durable-vs-live verify, end-to-end dispatch on TELEGRAM_429, and verify-failed audit trail when messages remain stuck.
+
 ### test(server): bearer-token auth verification on jobs endpoints
 
 New integration test pins the existing `authMiddleware` gate on the four Phase 4 jobs endpoints (`/jobs/migration-status`, `/jobs/migration-confirm`, `/jobs/migration-abandon`, `/jobs/reconcile`). 15 cases cover unauthenticated, wrong-token, off-by-one near-miss, malformed header, non-Bearer scheme, and authenticated paths. Asserts INSTAR-JOBS-AS-AGENTMD spec §Decision Points "Dashboard write authorization — bearer auth extended to job-edit endpoints." Auth was already in place via global middleware; this test pins the property so a future refactor cannot weaken it silently.

--- a/upgrades/side-effects/w3-messaging-delivery-failed-runbook.md
+++ b/upgrades/side-effects/w3-messaging-delivery-failed-runbook.md
@@ -1,0 +1,185 @@
+# Side-Effects Review — W-3: messaging-delivery-failed runbook + DeliveryRetryManager.runRecoveryCycle
+
+**Version / slug:** `w3-messaging-delivery-failed-runbook`
+**Date:** `2026-05-13`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Ships Tier-2 wrapper W-3 per `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A1 (W-3 row), §A6 (structured provenance), §A9 (durable verify), §A21 (verify outcome taxonomy), §A34 R3 (surface-alignment correction — new `runRecoveryCycle()` public method distinct from timer-driven `tick()`), §A36 (essential validator), §A57 (Tier-2 W-3).
+
+Two new modules / extensions:
+
+- `src/remediation/runbooks/messaging-delivery-failed.ts` — the runbook. Matches structured-provenance events with `errorCode ∈ {DELIVERY_FAILURE, TELEGRAM_429, TELEGRAM_500}` and `provenance ∈ {subsystem-explicit, probe-id}` (per §A6: explicitly NO `free-text`). surfaceCallable delegates to `DeliveryRetryManager.invokeFromRemediator`. verify() queries the durable on-disk inbox and asserts ALL queued/undelivered messages have drained per §A9 (not just "the cycle ran"). priority 80; blastRadius `process`; essential `false` per §A36 (essential=true would require blastRadius='machine').
+- `src/messaging/DeliveryRetryManager.ts` (extended) — adds `runRecoveryCycle()` and `invokeFromRemediator(ctx)` as additive public methods per §A34 R3. The existing timer-driven `tick()` is unchanged in behavior but now wraps a shared `cycleInFlight` latch so two concurrent callers (e.g. timer + Remediator) cannot double-process the inbox. The latch is a single-process boundary; cross-process exclusion remains the Remediator MachineLock's job. `tick()`'s return shape is unchanged except for an optional `skipped: true` marker when the second caller short-circuits.
+
+Files touched:
+- `src/remediation/runbooks/messaging-delivery-failed.ts` (new)
+- `src/messaging/DeliveryRetryManager.ts` (extended — runRecoveryCycle + invokeFromRemediator + shared latch)
+- `tests/unit/runbooks/messaging-delivery-failed.test.ts` (new — 16 cases)
+- `tests/unit/DeliveryRetryManager-runRecoveryCycle.test.ts` (new — 11 cases)
+- `upgrades/NEXT.md` (W-3 entry added; existing F-1..F-7, F-8, W-1, scheduler, drift-classifier entries preserved verbatim)
+- `upgrades/side-effects/w3-messaging-delivery-failed-runbook.md` (this artifact)
+
+## Decision-point inventory
+
+- `messagingDeliveryFailedRunbook.match(event)` — **add** — narrow filter: returns true only when `event.subsystem ∈ {messaging, delivery-retry}`. Pure structural equality; no LLM, no regex over free-form text.
+- `messagingDeliveryFailedRunbook.preconditions(event)` — **add** — `_deps` wired AND `getManager()` returns non-null. Refuses to fire when messaging is not initialized (e.g. unit-test boot or pre-server-up).
+- `messagingDeliveryFailedRunbook.verify(ctx)` — **add** — opens an inbox query against the wired `MessageStore` and counts queued/undelivered messages. Returns one of three §A21 outcomes; in particular probe error (queryInbox throws) → verify-inconclusive, not verify-failed.
+- `DeliveryRetryManager.runRecoveryCycle()` — **add** — Remediator-orchestrated parallel entry point. Idempotent against the running timer via `cycleInFlight` latch.
+- `DeliveryRetryManager.invokeFromRemediator(ctx)` — **add** — surface entry-point. Wraps `runRecoveryCycle` and returns `ExecutionResult` with structured details (retried/expired/escalated/skipped).
+- `DeliveryRetryManager.tick()` — **modify** (wrap) — now acquires the same `cycleInFlight` latch as `runRecoveryCycle`. Inner body extracted unchanged into `doCycle()`. No behavior change for existing callers; the optional `skipped` field is additive.
+- `setMessagingDeliveryDeps(deps)` — **add** — production wires the live manager + store; tests inject fakes. Setting to `null` puts the runbook into a "deps unwired" state where surface/verify return inconclusive.
+
+The legacy `tick()` entry-point and the `start()` timer are **pass-through** (existing behavior preserved). The shared latch means a 15s timer tick and a Remediator-dispatch arriving in the same ~ms window won't double-sweep the inbox — first caller wins, second short-circuits with `skipped: true`. This is the §A34 R3 invariant.
+
+No new HTTP routes. No new persistent files. The runbook module exports `setMessagingDeliveryDeps` for late-binding so the messaging singleton doesn't need to be imported at module-load time (avoids a circular import path through the server). Production wiring of `setMessagingDeliveryDeps` is deferred to a separate Tier-2 PR alongside `DegradationReporter.setRemediator()` — this PR ships the unit-testable surface only, matching how W-1 left `NativeModuleHealer.invokeFromRemediator` constructible-but-unwired.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+- **Free-text-provenance delivery failures** are NOT matched by this runbook. This is by design (§A6). Legacy `.report(...)` callers in `src/messaging/` that normalize to `provenance: 'free-text'` cannot trigger the recovery cycle — they route to `no-matching-runbook` and feed NovelFailureReviewer's clustering pipeline. Operators who hit delivery failures via the timer cadence STILL get retries because the 15s `tick()` cadence is unchanged. The structural defense costs no functionality.
+- **Events about non-messaging subsystems** are rejected by `match()`. Intended — `DeliveryRetryManager` only knows how to drain its own message store. A different subsystem's delivery failure (e.g. webhook delivery, if that subsystem existed) would need its own runbook.
+- **Events arriving while a tick is mid-flight** are returned `skipped: true` and produce zero work via this dispatch. NOT a rejection — the in-flight cycle WILL sweep the same inbox, so the work is not lost. The Remediator's `verify-failed` taxonomy correctly reports "drain succeeded" or "drain incomplete" regardless of which entry-point did the sweep.
+
+No legitimate input is rejected that should have been accepted.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **No cross-process deduplication.** Two agent processes on the same machine racing the same on-disk inbox would each acquire the shared latch within their OWN process and proceed; cross-process exclusion is the Remediator's MachineLock job (F-4). This runbook is layered on top of that — the in-process latch is the second line of defense, not the first. The single-agent-per-stateDir invariant (already enforced by the agent server's lifeline lock) makes the cross-process race extremely narrow in practice.
+- **Verify counts queued + undelivered only.** Messages in `delivered` phase awaiting ACK timeout are not counted as "stuck" for §A9 purposes. Intended — Layer 3 ACK timeouts are NOT a delivery failure; they're an upstream agent-not-responding signal. A `verified-healthy` result here means delivery has been re-attempted; it does NOT mean every message has been ACKed.
+- **No deadline enforcement on verify() separately.** The Remediator's §A4 AbortController fires around the whole `surfaceCallable + verify` chain (60s budget per `expectedRuntimeMs`). The verify probe is a single on-disk inbox read; under load it stays well under that budget.
+- **`runRecoveryCycle` does not pre-empt mid-flight on `ctx.abortSignal`.** The cycle body is a loop over inbox entries with short, atomic store operations per entry. We don't check the abort signal mid-loop. Acceptable because: the deadline is 60s, each iteration is a single fs read + fs write, and pre-empting mid-iteration could leave the retryState map inconsistent. If the deadline trips, the dispatcher's `aborted-deadline` branch supersedes whatever we return anyway.
+- **The shared latch is not fair.** If a tick is in-flight and 20 Remediator dispatches arrive in 200ms, all 20 short-circuit with `skipped: true` and the single in-flight cycle handles every message. Acceptable — the inbox is a shared queue, "drain everything you can" is idempotent across callers.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. Each piece sits where the spec mandates:
+
+- **Runbook (`src/remediation/runbooks/messaging-delivery-failed.ts`)** is the policy layer — declares the match contract, verify semantics, blast-radius, and surfaceCallable wiring. Pure data plus a thin verify wrapper; no orchestration, no key material, no audit-write concerns.
+- **`DeliveryRetryManager.invokeFromRemediator`** is the surface layer — owns translating `RemediationContext` into a recovery cycle invocation, returning structured `ExecutionResult` details. No knowledge of the Remediator's lock / intent / audit primitives.
+- **`DeliveryRetryManager.runRecoveryCycle`** is the operation layer — owns the §A34 R3 "idempotent against running timer" rule via the shared latch. Independent of who called it.
+- **Verify helper (`probeDurableDrain`)** is the durability probe — owns the §A9 "assert durable, not just live" rule. Cleanly separated from the recovery step so verify can run independently.
+
+No higher-level smart gate is shadowed. The Remediator's `registerRunbook()` validator (§A6, §A36) is the gate that accepts/rejects this runbook at boot; the runbook itself doesn't contain blocking authority beyond the structural match contract.
+
+The signal-vs-authority principle (`docs/signal-vs-authority.md`) is honoured: the match is precise structural code (errorCode enum membership + provenance enum membership + subsystem string equality), not a heuristic content classifier. The authority to "trigger a recovery cycle" is the manager's own; the runbook merely calls into it.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no brittle-logic blocking authority. Match is precise structural code over enum-typed fields; verify is a deterministic on-disk inbox count; the only block surface (§A36 essential-on-machine) is enforced by the F-8 dispatcher's validator, not by this runbook.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic — STOP.
+
+The runbook's structural decisions:
+- §A6 prefilter (errorCode + provenance enum equality) — precise.
+- §A36 essential=false enforced by F-8 validator (no claim to essential here).
+- §A9 verify (queued + undelivered count == 0) — deterministic.
+- §A34 R3 idempotence (single-process latch, first-wins) — deterministic.
+- §A21 verify taxonomy — derived from inbox-count probe result kind.
+
+No brittle string-matching, no LLM judgement, no content classifier. The match callback's subsystem string equality is the same shape as W-1's better-sqlite3 narrowing.
+
+---
+
+## 5. Interactions
+
+**What other components is this change touching, even indirectly?**
+
+- **F-8 dispatcher (`Remediator.dispatch`)** — registers and dispatches this runbook. Existing dispatch path is generic; no modification needed. The dispatcher's §A6 / §A36 validators accept the runbook (verified by unit test).
+- **F-3 `DegradationReporter`** — emit-sites in `src/messaging/` will eventually call the structured emit helper to produce DELIVERY_FAILURE / TELEGRAM_429 / TELEGRAM_500 events with `provenance: 'subsystem-explicit'`. The migration is incremental; until then, legacy callers route to `no-matching-runbook` via `provenance: 'free-text'` (intended A33 steady-state).
+- **`DeliveryRetryManager` consumers** — `AgentServer` constructs and `start()`s the manager. The wrap of `tick()` is a no-op for the timer caller (it still returns the same shape, just with an optional `skipped` field that's `undefined`/falsy under normal operation).
+- **`MessageStore.queryInbox`** — the verify probe calls this. It's a stable public method used by many other consumers; the additional read load is one inbox scan per dispatch attempt, well below the per-cycle scan rate.
+- **F-4 `MachineLock`** — the runbook acquires the same in-flight tuple lock the dispatcher acquires for any runbook. No new lock surface.
+- **`AgentServer` boot wiring** — NOT modified in this PR. Production wiring of `setMessagingDeliveryDeps(...)` is deferred to the same future PR that wires `DegradationReporter.setRemediator(...)`. Both must be wired together so the runbook actually receives events.
+
+The wrap of `tick()`'s body into `doCycle()` is the only behavior change to existing code. Verified by running the existing `delivery-retry-manager.test.ts` (21 cases, all pass unchanged).
+
+---
+
+## 6. Rollback cost
+
+**If this change is reverted, what breaks?**
+
+Low — additive. The legacy `tick()` and `start()` are unchanged in behavior; reverting deletes the new runbook module + the two new public methods + the shared latch wrap on `tick()`. No data-model migration. No persistent state ships with this PR. The shared latch is a `boolean` field; deleting it removes the additional idempotence guarantee but does not corrupt any state. Existing F-1..F-7 + W-1 modules are unaffected.
+
+A revert leaves messaging recovery on the pre-existing 15s timer cadence — the Remediator-orchestrated faster-recovery + audit-tracked path is the gain that's lost on revert, not a load-bearing capability.
+
+---
+
+## 7. Spec compliance
+
+- §A1 W-3 manifest — runbook id `messaging-delivery-failed`, surface `delivery-retry`. Matches the spec table row.
+- §A6 — `provenance: ['subsystem-explicit', 'probe-id']`; explicitly NO `free-text`. Registry validator (F-8) accepts this at registry-load.
+- §A9 — verify queries the durable on-disk inbox (not the in-memory retryState map), counts ALL queued+undelivered, requires zero. "Drain ALL stuck messages (not just one)" matches the spec language verbatim.
+- §A21 — verify taxonomy: ok → verified-healthy; stuck (count > 0) → verify-failed; probe error → verify-inconclusive.
+- §A34 R3 — `runRecoveryCycle()` is a NEW public method, distinct from timer-driven `tick()`. Idempotent against the running timer via the shared `cycleInFlight` latch. Spec docstring captures this.
+- §A36 — essential=false validated against blastRadius=process. F-8 validator accepts.
+- §A57 — Tier-2 W-3 row. Foundation dependency on W-1 (in main as PR #202) and F-8 (in main as PR #201 + #217). W-2 is parallel work; this PR does not block on it.
+- §A15 (note from prompt) — lag rule is documented in the runbook expectedRuntimeMs (60s). The recovery cycle is short-lived; lag-detection escalation is the Remediator's concern, not this runbook's. Build proceeds per W-2's pattern.
+
+---
+
+## 8. Test coverage
+
+27 new tests across two files. Pass: 27/27.
+
+`tests/unit/DeliveryRetryManager-runRecoveryCycle.test.ts` (11):
+- runRecoveryCycle is a distinct public method from tick.
+- runRecoveryCycle return shape matches tick on empty inbox.
+- runRecoveryCycle processes queued messages identically to tick (TTL-expired envelope dead-lettered).
+- Idempotence: runRecoveryCycle short-circuits while tick is in-flight.
+- Idempotence: tick short-circuits while runRecoveryCycle is in-flight (symmetric).
+- Latch resets after cycle completes; subsequent calls run normally.
+- invokeFromRemediator wraps runRecoveryCycle and returns ExecutionResult success.
+- invokeFromRemediator returns failure when runRecoveryCycle throws (synthetic store error).
+- invokeFromRemediator reports skipped:true when cycle is in-flight.
+- stop() clears the in-flight latch (recycle-safe).
+- Existing tick() return shape unchanged when cycle runs normally.
+
+`tests/unit/runbooks/messaging-delivery-failed.test.ts` (16):
+- Matches all three structured errorCodes.
+- §A6: free-text excluded from prefilter.
+- match() rejects non-messaging subsystems.
+- Remediator.registerRunbook accepts the runbook (essential=false, process radius).
+- §A36 honored: essential=false, blastRadius=process.
+- Manifest fields verified (id, priority=80, surface=delivery-retry, expectedRuntimeMs=60_000, reversibility=reversible).
+- preconditions fail when deps not wired.
+- preconditions succeed when manager is wired.
+- surfaceCallable invokes manager.invokeFromRemediator with ctx (mocked).
+- verify() returns verified-healthy on drained inbox.
+- verify() returns verify-failed on stuck messages (with stuck count + sample IDs).
+- verify() returns verify-inconclusive on store probe error.
+- verify() against real store: queued message → verify-failed (durable assertion).
+- verify() against real store: empty inbox → verified-healthy.
+- End-to-end dispatch on TELEGRAM_429: invoked → verified-healthy → audited.
+- End-to-end dispatch with stuck messages: verify-failed audited (synthetic deliverToSession failure).
+
+Existing `tests/unit/delivery-retry-manager.test.ts` (21) and `tests/unit/runbooks/node-abi-mismatch.test.ts` (12) re-verified — unchanged behavior. Existing `tests/unit/Remediator.test.ts` (12) re-verified — unchanged behavior.
+
+---
+
+## 9. Open follow-ups
+
+- **Production wiring** of `setMessagingDeliveryDeps(...)` and `DegradationReporter.setRemediator(...)` is deferred to a coordinated Tier-2 PR. This PR ships the unit-testable surface; production registration is a single-PR follow-up.
+- **F-3 emit-site migration** in `src/messaging/` — the structured errorCodes DELIVERY_FAILURE / TELEGRAM_429 / TELEGRAM_500 need to flow through `reportStructured(...)`. Until then, the runbook is dormant in production (intended A33 incremental migration).
+- **W-2** (`supervisor-preflight`) and **W-4** (`db-corruption`) — parallel wrapper work; this PR does not depend on either.


### PR DESCRIPTION
## Summary

Tier-2 wrapper W-3 per `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A1 (W-3 row), §A6 (structured provenance), §A9 (durable verify), §A21 (verify outcome taxonomy), §A34 R3 (surface-alignment correction: new `runRecoveryCycle()` public method distinct from timer-driven `tick()`), §A36 (essential validator), §A57 (Tier-2 W-3).

- **`DeliveryRetryManager`** gains two additive public methods: `runRecoveryCycle()` (idempotent against the running 15s timer via a shared in-flight latch) and `invokeFromRemediator(ctx)` (Remediator surface entry-point returning `ExecutionResult`). Existing `tick()` is wrapped to share the same latch; behavior unchanged for existing callers (timer + tests).
- **`src/remediation/runbooks/messaging-delivery-failed.ts`** — new runbook. Fires on `DELIVERY_FAILURE | TELEGRAM_429 | TELEGRAM_500` with structured provenance (no `free-text` per §A6). priority 80; blastRadius `process`; essential `false` (§A36 forbids essential=true on non-machine radius). Verify is a durable assertion per §A9 — queries the on-disk inbox and asserts ALL queued/undelivered messages have drained, not just one.
- Late-bound deps via `setMessagingDeliveryDeps()` so the runbook module doesn't import the messaging singleton at module-load time. Production wiring is deferred to a coordinated follow-up PR alongside `DegradationReporter.setRemediator()`.

## Test plan
- [x] 11 new tests in `tests/unit/DeliveryRetryManager-runRecoveryCycle.test.ts`: distinct-public-method, idempotence-against-timer (both directions), latch reset, invokeFromRemediator success/failure/skipped, stop() clears latch, tick() return shape unchanged.
- [x] 16 new tests in `tests/unit/runbooks/messaging-delivery-failed.test.ts`: match contract for all three errorCodes, §A6 free-text excluded, §A36 essential=false / process radius accepted, preconditions wired/unwired, surfaceCallable mock, verify taxonomy (healthy/failed/inconclusive), verify against real store, end-to-end dispatch on TELEGRAM_429 → verified-healthy + audit trail, end-to-end with stuck messages → verify-failed audit trail.
- [x] Existing 21 delivery-retry-manager tests pass unchanged (tick() behavior preserved).
- [x] Existing 12 node-abi-mismatch + 12 Remediator + 6 MachineLock + 12 message-delivery + 4 AuditWriter + 3 IntentJournal tests pass unchanged.
- [x] `npm run lint` clean.
- [ ] CI green on PR.

## Spec reference
- `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (review-convergence + approved)
- Side-effects review: `upgrades/side-effects/w3-messaging-delivery-failed-runbook.md`
- Trace: `.instar/instar-dev-traces/2026-05-14T03-45-26-394Z-w3-messaging-delivery-failed-runbook-583d50b9.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)