### PR TITLE
fix(monitoring): cache NO_PROMPT verdicts to stop idle-session token-burn

### DIFF
--- a/docs/specs/prompt-gate-no-prompt-cache.eli16.md
+++ b/docs/specs/prompt-gate-no-prompt-cache.eli16.md
@@ -1,0 +1,33 @@
+# PromptGate NO_PROMPT Cache — ELI16 overview
+
+## The short version
+
+Every instar agent quietly watches its own terminal output to notice when Claude Code is stuck waiting for the user to answer a yes/no question. Most of that watching is done by simple text-matching rules that look for the obvious shapes (a "y/n" prompt, a numbered "1. Yes 2. No" menu, an "Esc to cancel" footer). When those rules can't tell, the watcher asks a small LLM (Haiku) to make the final call. That LLM call is what got expensive.
+
+The problem: when a session is sitting idle, the agent's terminal shows the same `❯` prompt forever. The watcher was supposed to stop asking the LLM the same question over and over, but the part that stopped it was wired wrong — it only kicked in *after* the LLM said "yes, this is a real prompt," not after the LLM said "no, nothing's stuck." So idle sessions kept asking the LLM "is this stuck?" every 5 seconds, got "no" every time, and burned tokens forever.
+
+On 2026-05-15 that one bug accounted for ~108,000 LLM calls and ~3 billion tokens in a single day across all agents on this machine — more than the rest of the machine's usage combined.
+
+## What this change does
+
+It adds a small "I already asked about this" notepad to each session's watcher. Every time the LLM says "no, this output is not a real prompt," the watcher writes down a fingerprint of that exact terminal output. Next time the same output shows up (which on an idle session is constantly), the watcher checks the notepad first: if the fingerprint is there, skip the LLM entirely and trust the prior answer.
+
+The notepad has a cap of 32 fingerprints per session and uses oldest-first eviction, so it can't grow unbounded. The notepad is also wiped clean whenever the session receives any input (so post-input output is freshly checked) and whenever the session is cleaned up (so dead sessions don't leave stale entries).
+
+## Why it's safe
+
+The LLM is still the boss of every real decision. The notepad just records what the LLM already said. If the session shows new terminal output (anything different at all), the fingerprint won't match, the notepad is bypassed, and the LLM gets asked normally. There's no scenario where a real prompt gets missed because of the cache — a real prompt produces different output, which produces a different fingerprint, which misses the cache, which falls through to the LLM.
+
+The worst-case failure mode would be: the LLM made a *wrong* "no, nothing's stuck" call on a specific output, that same exact output recurs, and the wrong answer gets reused for up to 32 cycles before being evicted. That's bounded, and the alternative (without the cache) was paying to repeatedly get the same wrong answer at full price.
+
+## Why this matters
+
+This is structural. Every agent that runs instar inherits this watcher. Without the cache, every agent on every machine burns tokens at this rate around the clock. With the cache, idle agents are nearly free — the LLM gets consulted only when the terminal output actually changes, which on a quiet session is a small number of times per hour rather than ~720.
+
+## What you'd see if it goes wrong
+
+A prompt that should have been forwarded to the user via Telegram either doesn't get forwarded (cache locked in a wrong "no, nothing's stuck" verdict) or gets forwarded later than expected. The rollback is a two-file revert. No data is stored anywhere — the cache is purely in-memory and disappears when the agent restarts. Nothing else changes about the rest of instar.
+
+## How we know it works
+
+The fix ships with nine regression tests that prove: idle sessions stop re-asking the LLM, different output still triggers a fresh LLM call, the cache clears on input and cleanup, the cache size is bounded, real prompts are still detected on first sight, mid-flight LLM answers don't repopulate a just-cleared cache, and ambiguous LLM responses aren't memoized. All 42 prompt-gate tests pass.

--- a/docs/specs/prompt-gate-no-prompt-cache.md
+++ b/docs/specs/prompt-gate-no-prompt-cache.md
@@ -1,0 +1,63 @@
+---
+slug: prompt-gate-no-prompt-cache
+review-convergence: converged
+approved: true
+approved-by: justin
+iterations: 1
+---
+
+# PromptGate NO_PROMPT Cache — Stop Idle-Session Token-Burn
+
+## Problem
+
+`InputDetector.llmDetect` in `src/monitoring/PromptGate.ts` is the LLM-backed authority that classifies terminal output as a blocking prompt versus background activity. On 2026-05-15 it accounted for ~108,782 LLM calls / ~3.03 billion tokens in 24 hours across all instar agents on this machine — by itself, 73% of the machine's entire 24h token spend.
+
+Root cause: the class has a 5-minute per-session rate limit (`llmRelayTimestamps` + `LLM_RELAY_COOLDOWN_MS = 300_000`) intended to cap re-classification. But the timestamp is **only set when the LLM detects a real prompt and emits it**, not when it returns NO_PROMPT. For idle sessions sitting at the same `❯` terminal output across many ticks, the LLM kept getting re-asked every ~5 seconds, returned NO_PROMPT every time, and the rate limit never engaged. The outer 5-second cooldown (`COOLDOWN_MS` on `lastEmissionTime`) has the same bug — it gates on emit, not attempt.
+
+Observed call rate over the most recent 8 hours: 3,400–5,000 LLM calls/hour, ~125M tokens/hour. Direct cause of Justin's "we're burning tokens very fast again" report on topic 8615.
+
+## Root Cause
+
+`src/monitoring/PromptGate.ts`, lines 269–278 (origin/main): `llmDetect` is fired whenever stableCount ≥ 2 and the 5-second outer cooldown allows. Inside `llmDetect`, line 333 gates on `llmRelayTimestamps`, which is only set inside `if (emitted)` at the very end of the function. NO_PROMPT classifications never touch the gate, so for sessions in the steady "no real prompt" state, the LLM is re-consulted on every tick.
+
+The historical evolution explains the bug: the rate limiter was originally named for its actual semantic — *throttle relays to the user* — and was correctly set only on emit. Later, the gate at the start of `llmDetect` was repurposed to also gate LLM calls (not just relays), but the set-site wasn't updated. The naming/semantics drift went unnoticed because the symptom (excessive cost) was diffuse and only became visible once the token ledger was running.
+
+## Fix
+
+Add a bounded per-session NO_PROMPT classification cache (`noPromptCache: Map<string, { set: Set<string>; order: string[] }>`) keyed on a SHA-256 fingerprint of the same 20-line context the LLM sees. Before calling the LLM, `llmDetect` checks the cache; on hit, it returns without consulting the LLM. On NO_PROMPT verdict, it adds the fingerprint to the cache. FIFO eviction at 32 entries per session.
+
+Hardening (added in response to second-pass review):
+
+- **Generation counter** (`cacheGeneration: Map<string, number>`) bumped on every `onInputSent()` and `cleanup()`. `llmDetect` captures the generation at call start and `recordNoPrompt` drops the write if it has advanced. Prevents a mid-flight stale verdict from repopulating the cache after the session has received input or been cleaned up.
+- **Strict NO_PROMPT cache write** — only the exact `trimmed === 'NO_PROMPT'` signal is cached. The permissive `startsWith('NO')` branch still returns from `llmDetect` (preserving existing behavior) but is not memoized, so transient confused LLM responses don't lock in.
+
+The cache is purely in-memory, lost on process restart, and adds no persistent state, no migration, no external API surface.
+
+## Acceptance Criteria
+
+1. Idle session showing the same terminal output across many monitor ticks produces at most 1 LLM call regardless of how many ticks occur.
+2. Different terminal output produces a fresh LLM call (cache is keyed on context, not session).
+3. After `onInputSent(sessionName)`, the same prior output triggers a fresh LLM call (cache cleared on input).
+4. Positive prompt detections are not cached — a real prompt is detected the first time it appears, on every session.
+5. Cache size is bounded per session (cap 32 with FIFO eviction).
+6. Mid-flight `llmDetect` that resolves after `onInputSent` or `cleanup` does not repopulate the cache.
+7. Permissive `startsWith('NO')` responses (e.g. "NOT SURE") do not enter the cache.
+8. Existing regex-pattern detection and per-session cooldown behavior is unchanged.
+
+All eight criteria are pinned by regression tests in `tests/unit/PromptGate.test.ts` (42 total, 9 new for this fix).
+
+## Decision Points (signal vs authority)
+
+The InputDetector's LLM classification is the authority for "is this session blocked on input." The cache is a memoization layer in front of that authority — it records prior LLM verdicts to avoid re-asking. On hit, the cache returns the LLM's *prior* verdict; on miss, the LLM runs unchanged. No new blocking surface, no brittle detector gaining authority. Compliant with `docs/signal-vs-authority.md`.
+
+## Rollback
+
+Revert two source files (`src/monitoring/PromptGate.ts`, `tests/unit/PromptGate.test.ts`) and ship a patch release. No persistent state, no migration, no external API change. Estimated 10 minutes from detection to revert.
+
+## Side-Effects Review
+
+`upgrades/side-effects/prompt-gate-no-prompt-cache.md` — full 7-question review with second-pass reviewer concurrence appended. Two hardening items raised in second-pass review were addressed in the same commit (see "Author response" section).
+
+## Convergence Notes
+
+Single-iteration convergence. The conversational alignment with Justin (Telegram topic 8615, 2026-05-15) covered: (1) measurement of the burn pattern — agreed; (2) root cause located in `PromptGate.ts` — confirmed by source read; (3) approval of the cache-based fix with focus on stopping the bleeding — explicit ("yes, please proceed with a focus on immediate steps to stop the bleeding"); (4) second-pass reviewer subagent verdict — concur with two hardening notes, both addressed in commit. No design alternatives required exploration — the bug location and fix shape were unambiguous from the source read.

--- a/src/monitoring/PromptGate.ts
+++ b/src/monitoring/PromptGate.ts
@@ -217,6 +217,29 @@ export class InputDetector extends EventEmitter {
   /** Track pending LLM detection calls to prevent overlap */
   private pendingLlmDetection = new Set<string>();
 
+  /**
+   * NO_PROMPT classification cache: session → bounded set of recent context
+   * fingerprints already classified by the LLM as not a blocking prompt.
+   *
+   * Without this, an idle session showing the same terminal output across every
+   * monitor tick re-asks the LLM "is this stuck?" every 5 seconds forever,
+   * because the existing rate limit (lastLlmRelay) is only updated on a
+   * successful emit. The cache short-circuits that loop: once we've classified
+   * a given context as NO_PROMPT, we don't re-classify the identical context.
+   * Cache is cleared in onInputSent() and cleanup().
+   */
+  private noPromptCache = new Map<string, { set: Set<string>; order: string[] }>();
+  private static readonly NO_PROMPT_CACHE_MAX = 32;
+
+  /**
+   * Per-session cache generation counter. Incremented whenever the cache is
+   * cleared for a session (onInputSent, cleanup). An in-flight llmDetect call
+   * captures the generation at start; if it changes before the call's
+   * recordNoPrompt write, the write is dropped — we don't want a stale
+   * pre-input verdict to repopulate the cache after a clear.
+   */
+  private cacheGeneration = new Map<string, number>();
+
   constructor(private config: InputDetectorConfig) {
     super();
   }
@@ -347,6 +370,19 @@ export class InputDetector extends EventEmitter {
     // Sanitize: take last 20 lines, strip any remaining ANSI
     const context = lines.slice(-20).join('\n').slice(0, 3000);
 
+    // Skip LLM call if we have already classified this exact context as
+    // NO_PROMPT for this session. Idle sessions show the same output across
+    // many ticks; without this cache they would re-burn ~720 LLM calls/hour
+    // each asking the same question and getting the same answer.
+    const contextFingerprint = createHash('sha256').update(context).digest('hex');
+    const cached = this.noPromptCache.get(sessionName);
+    if (cached && cached.set.has(contextFingerprint)) return;
+
+    // Capture cache generation at call start. If onInputSent or cleanup runs
+    // for this session before our verdict comes back, the generation will
+    // increment and recordNoPrompt below will drop the (now-stale) write.
+    const callGeneration = this.cacheGeneration.get(sessionName) ?? 0;
+
     const prompt = `You are analyzing terminal output from a Claude Code AI agent session. Your job is to determine if the session is BLOCKED at a system-level interactive prompt that prevents the agent from continuing.
 
 Terminal output (last 20 lines):
@@ -391,7 +427,15 @@ When in doubt, respond NO_PROMPT. False positives cause spam.`;
       });
 
       const trimmed = response.trim();
-      if (trimmed === 'NO_PROMPT' || trimmed.startsWith('NO')) return;
+      if (trimmed === 'NO_PROMPT' || trimmed.startsWith('NO')) {
+        // Cache only on the strict NO_PROMPT signal. The permissive
+        // startsWith('NO') branch covers transient responses like "No idea"
+        // that we don't want to memoize across the next 32 cycles.
+        if (trimmed === 'NO_PROMPT') {
+          this.recordNoPrompt(sessionName, contextFingerprint, callGeneration);
+        }
+        return;
+      }
 
       // Parse JSON response
       let parsed: { type: PromptType; summary: string; options?: Array<{ key: string; label: string }> };
@@ -436,6 +480,9 @@ When in doubt, respond NO_PROMPT. False positives cause spam.`;
     this.stableCount.delete(sessionName);
     this.lastOutput.delete(sessionName);
     this.lastEmissionTime.delete(sessionName); // Clear cooldown so new prompts can fire
+    this.noPromptCache.delete(sessionName); // Cleared so post-input output gets re-classified
+    // Bump generation so any mid-flight llmDetect drops its NO_PROMPT write.
+    this.cacheGeneration.set(sessionName, (this.cacheGeneration.get(sessionName) ?? 0) + 1);
   }
 
   /**
@@ -456,6 +503,42 @@ When in doubt, respond NO_PROMPT. False positives cause spam.`;
     this.lastEmissionTime.delete(sessionName);
     this.llmRelayTimestamps.delete(sessionName);
     this.pendingLlmDetection.delete(sessionName);
+    this.noPromptCache.delete(sessionName);
+    // Bump generation so any in-flight llmDetect for this session drops
+    // its NO_PROMPT write. The generation entry itself is left in place —
+    // it is tiny and a future llmDetect on the same session name (e.g. a
+    // session restart that reuses the name) will pick up from here.
+    this.cacheGeneration.set(sessionName, (this.cacheGeneration.get(sessionName) ?? 0) + 1);
+  }
+
+  /**
+   * Record a NO_PROMPT classification for the given session and context
+   * fingerprint, evicting the oldest entry if the per-session cache exceeds
+   * NO_PROMPT_CACHE_MAX. FIFO is sufficient — these are pure memoizations of
+   * an LLM verdict on a specific terminal-output snapshot.
+   *
+   * Drops the write if the cache generation has advanced since llmDetect
+   * started — that means onInputSent or cleanup fired during the LLM call,
+   * and our verdict was computed against output the session has now moved
+   * past. Without this guard, the post-input cache could get repopulated
+   * with a stale pre-input verdict.
+   */
+  private recordNoPrompt(sessionName: string, fingerprint: string, callGeneration: number): void {
+    const currentGen = this.cacheGeneration.get(sessionName) ?? 0;
+    if (currentGen !== callGeneration) return;
+
+    let entry = this.noPromptCache.get(sessionName);
+    if (!entry) {
+      entry = { set: new Set(), order: [] };
+      this.noPromptCache.set(sessionName, entry);
+    }
+    if (entry.set.has(fingerprint)) return;
+    entry.set.add(fingerprint);
+    entry.order.push(fingerprint);
+    while (entry.order.length > InputDetector.NO_PROMPT_CACHE_MAX) {
+      const evicted = entry.order.shift();
+      if (evicted) entry.set.delete(evicted);
+    }
   }
 
   /**

--- a/tests/unit/PromptGate.test.ts
+++ b/tests/unit/PromptGate.test.ts
@@ -431,3 +431,237 @@ describe('InputDetector.pruneRejected', () => {
     expect((detector as any).rejectedFingerprints.size).toBe(0);
   });
 });
+
+// ── NO_PROMPT cache (token-burn regression) ────────────────────────
+//
+// Regression for the 3B-tokens/day bleed observed 2026-05-15: idle sessions
+// were re-asking Haiku "is this output stuck?" on every monitor tick (~5s)
+// forever, because the existing 5-minute rate limit (llmRelayTimestamps) is
+// only updated on a successful prompt emit. NO_PROMPT classifications never
+// touched the gate, so a session sitting idle with the same output would
+// burn ~720 LLM calls/hour forever. Fix: cache NO_PROMPT verdicts per session
+// keyed on a fingerprint of the LLM-context; identical contexts short-circuit.
+
+describe('InputDetector.noPromptCache', () => {
+  /**
+   * Build a stubbed IntelligenceProvider that records every call and lets the
+   * test control the response.
+   */
+  function makeIntelligence(response: string) {
+    let calls = 0;
+    return {
+      evaluate: async (_prompt: string): Promise<string> => {
+        calls += 1;
+        return response;
+      },
+      get calls() { return calls; },
+    };
+  }
+
+  /**
+   * Drive enough captures through the detector to satisfy debounce
+   * (stableCount >= 2 — needs 3 identical captures) and fully flush the
+   * async LLM detection promise. Returns after the LLM call has resolved.
+   */
+  async function fireLlmDetect(detector: InputDetector, session: string, output: string): Promise<void> {
+    detector.onCapture(session, output);
+    detector.onCapture(session, output);
+    detector.onCapture(session, output);
+    // Flush a few microtask/macrotask turns to let the awaited LLM evaluate
+    // promise settle and the .finally() cleanup run.
+    for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r));
+  }
+
+  /**
+   * Drive a no-LLM-flush capture cycle — used after the first fireLlmDetect()
+   * to test the cache path. Identical output across these captures should hit
+   * the NO_PROMPT cache before the LLM call gate.
+   */
+  async function pumpCached(detector: InputDetector, session: string, output: string, n = 1): Promise<void> {
+    for (let i = 0; i < n; i++) {
+      detector.onCapture(session, output);
+      await new Promise(r => setImmediate(r));
+    }
+  }
+
+  // Idle session: same NO_PROMPT context shown over and over should produce
+  // exactly one LLM call total — first one classifies, all later ones hit cache.
+  it('skips LLM re-classification for identical NO_PROMPT context', async () => {
+    const intel = makeIntelligence('NO_PROMPT');
+    const detector = makeDetector({ intelligence: intel as any });
+
+    const output = 'Some session output\n❯ \n';
+
+    // First two captures = debounce, llmDetect fires async on the 2nd
+    await fireLlmDetect(detector, 's1', output);
+    expect(intel.calls).toBe(1);
+
+    // 50 more identical captures — fingerprint matches the cached NO_PROMPT
+    // verdict, so the LLM is not consulted again.
+    await pumpCached(detector, 's1', output, 50);
+
+    expect(intel.calls).toBe(1);
+  });
+
+  // Different context → new LLM call (cache is keyed on context, not session)
+  it('still calls LLM when context fingerprint changes', async () => {
+    const intel = makeIntelligence('NO_PROMPT');
+    const detector = makeDetector({ intelligence: intel as any });
+
+    const outputA = 'Idle prompt A\n❯ \n';
+    const outputB = 'Idle prompt B with different tail\n❯ \n';
+
+    await fireLlmDetect(detector, 's1', outputA);
+    expect(intel.calls).toBe(1);
+
+    // Different output produces a different fingerprint — cache miss, LLM called
+    await fireLlmDetect(detector, 's1', outputB);
+    expect(intel.calls).toBe(2);
+  });
+
+  // Cache is per-session: outputs cached on session A should not block LLM on session B
+  it('is per-session', async () => {
+    const intel = makeIntelligence('NO_PROMPT');
+    const detector = makeDetector({ intelligence: intel as any });
+    const output = 'Identical output\n❯ \n';
+
+    await fireLlmDetect(detector, 'sessionA', output);
+    expect(intel.calls).toBe(1);
+
+    await fireLlmDetect(detector, 'sessionB', output);
+    // sessionB has its own empty cache, so this output IS re-classified
+    expect(intel.calls).toBe(2);
+  });
+
+  // onInputSent clears the cache — after the user answers a prompt, post-input
+  // output should be re-classified rather than blindly trusting the prior verdict.
+  it('clears cache on onInputSent', async () => {
+    const intel = makeIntelligence('NO_PROMPT');
+    const detector = makeDetector({ intelligence: intel as any });
+    const output = 'Cleared-cache test output\n❯ \n';
+
+    await fireLlmDetect(detector, 's1', output);
+    expect(intel.calls).toBe(1);
+
+    detector.onInputSent('s1');
+
+    // Same context after onInputSent — cache was cleared, so LLM is consulted again
+    await fireLlmDetect(detector, 's1', output);
+    expect(intel.calls).toBe(2);
+  });
+
+  // cleanup also drops the cache (covers session-ended path)
+  it('clears cache on cleanup', async () => {
+    const intel = makeIntelligence('NO_PROMPT');
+    const detector = makeDetector({ intelligence: intel as any });
+    const output = 'Cleanup test\n❯ \n';
+
+    await fireLlmDetect(detector, 's1', output);
+    expect((detector as any).noPromptCache.has('s1')).toBe(true);
+
+    detector.cleanup('s1');
+    expect((detector as any).noPromptCache.has('s1')).toBe(false);
+  });
+
+  // Cache size is bounded — must not grow unbounded for a flapping session
+  it('caps per-session cache at NO_PROMPT_CACHE_MAX entries', async () => {
+    const intel = makeIntelligence('NO_PROMPT');
+    const detector = makeDetector({ intelligence: intel as any });
+
+    // Drive 50 distinct outputs through the same session; each gets classified
+    // and cached. Cache should grow but not exceed the cap.
+    for (let i = 0; i < 50; i++) {
+      await fireLlmDetect(detector, 's1', `Distinct output ${i}\n❯ \n`);
+    }
+
+    const cap = (InputDetector as any).NO_PROMPT_CACHE_MAX as number;
+    const entry = (detector as any).noPromptCache.get('s1');
+    expect(entry.order.length).toBeLessThanOrEqual(cap);
+    expect(entry.set.size).toBeLessThanOrEqual(cap);
+    expect(entry.order.length).toBe(entry.set.size); // No drift between order/set
+  });
+
+  // Only the strict NO_PROMPT signal gets cached. A permissive "NO..."
+  // prefix response (e.g. "No idea, can't tell") is treated as a non-detect
+  // for THIS call but not memoized — otherwise a transient confused LLM
+  // answer would lock in for up to 32 cycles.
+  it('does not cache permissive non-strict NO responses', async () => {
+    const intel = makeIntelligence('No idea, the output is ambiguous');
+    const detector = makeDetector({ intelligence: intel as any });
+
+    const output = 'Ambiguous output\n❯ \n';
+    await fireLlmDetect(detector, 's1', output);
+    expect(intel.calls).toBe(1);
+
+    // Same output again — cache should be empty because the response was
+    // not the strict NO_PROMPT signal. LLM gets re-asked.
+    const entry = (detector as any).noPromptCache.get('s1');
+    expect(entry === undefined || entry.set.size === 0).toBe(true);
+  });
+
+  // In-flight clear-race: if onInputSent runs while llmDetect is mid-call,
+  // the late NO_PROMPT verdict must NOT repopulate the just-cleared cache.
+  // This protects post-input output from being shadowed by a stale verdict.
+  it('drops mid-flight NO_PROMPT write when cache generation bumps', async () => {
+    let resolveLlm: (v: string) => void = () => {};
+    const evaluate = async (_p: string) => new Promise<string>(r => {
+      resolveLlm = r;
+    });
+    const intel = { evaluate, calls: 0 };
+    // Wrap to count
+    const counter = {
+      evaluate: async (p: string): Promise<string> => {
+        intel.calls += 1;
+        return evaluate(p);
+      },
+    };
+    const detector = makeDetector({ intelligence: counter as any });
+    const output = 'Mid-flight race output\n❯ \n';
+
+    // Kick the LLM call — it hangs on `resolveLlm`
+    detector.onCapture('s1', output);
+    detector.onCapture('s1', output);
+    detector.onCapture('s1', output);
+    await new Promise(r => setImmediate(r));
+    expect(intel.calls).toBe(1);
+
+    // Session receives input — cache clear + generation bump should drop
+    // the in-flight verdict
+    detector.onInputSent('s1');
+
+    // Now resolve the LLM with NO_PROMPT
+    resolveLlm('NO_PROMPT');
+    for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r));
+
+    // Cache should still be empty — the late verdict was dropped because
+    // its generation no longer matches.
+    const entry = (detector as any).noPromptCache.get('s1');
+    expect(entry === undefined || entry.set.size === 0).toBe(true);
+  });
+
+  // Defensive: ensure the cache miss path still works when the LLM returns a
+  // genuine prompt (positive result). The fingerprint is NOT cached on emit —
+  // only on NO_PROMPT — so a real prompt is detected normally on first sight.
+  it('does not cache positive LLM detections', async () => {
+    const intel = makeIntelligence(JSON.stringify({
+      type: 'permission',
+      summary: 'Real prompt detected',
+      options: [{ key: '1', label: 'Yes' }, { key: '2', label: 'No' }],
+    }));
+    const detector = makeDetector({ intelligence: intel as any });
+    let emitted: DetectedPrompt | null = null;
+    detector.on('prompt', (p: DetectedPrompt) => { emitted = p; });
+
+    const output = 'Real prompt scenario\n❯ \n';
+    await fireLlmDetect(detector, 's1', output);
+
+    expect(intel.calls).toBe(1);
+    expect(emitted).not.toBeNull();
+
+    // The positive verdict produced an emit, not a cache entry. If the same
+    // context recurs after the 5-minute relay cooldown expires, llmDetect
+    // would re-classify. This test only asserts no cache leakage.
+    const entry = (detector as any).noPromptCache.get('s1');
+    expect(entry === undefined || entry.set.size === 0).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -5,6 +5,46 @@ note (`upgrades/<version>.md`) at release-cut time.
 
 ---
 
+### fix(monitoring): PromptGate token-burn — cache NO_PROMPT verdicts to stop idle-session re-classification loop
+
+**What this fixes (plain English).** Every instar agent quietly watches its
+own terminal output to detect when Claude Code is stuck at an interactive
+prompt that only the user can answer. Part of that watcher uses Haiku to make
+a final judgment call on output the simple regex filters can't classify. The
+watcher was meant to make at most one of those Haiku calls per session every
+5 minutes — but the rate-limit only kicked in *after* a real prompt was found.
+For idle sessions sitting at the same "❯" output forever, the watcher kept
+re-asking Haiku "is this session stuck?" every 5 seconds, got "no" every
+time, and never updated the rate-limit. Across all agents on a single
+machine, that was ~108,000 Haiku calls and ~3 billion tokens per day — more
+than the rest of the machine's spend combined.
+
+**What changes.** `InputDetector` now caches each NO_PROMPT verdict by a
+SHA-256 fingerprint of the exact 20-line context the LLM saw. Same context
+recurs → cache hit → no LLM call. Different context → cache miss → LLM is
+consulted normally. Per-session cap of 32 fingerprints (FIFO eviction); cache
+is cleared whenever input is sent to the session or the session is cleaned
+up. Positive prompt detections are not cached (real prompts always get
+fresh evaluation).
+
+**Why this is safe.** Pure memoization in front of an existing LLM
+authority — no new blocking surface, no new decision logic, no persistent
+state. Worst-case failure mode is a wrong Haiku verdict on a specific
+output snapshot being remembered for up to 32 subsequent outputs (mitigated
+by FIFO eviction and `onInputSent` clearing). The cache is in-memory only,
+disappears on restart, and the rollback is a two-file revert with no
+migration cost. Side-effects review:
+`upgrades/side-effects/prompt-gate-no-prompt-cache.md`. Signal-vs-authority
+compliance: the LLM remains the authority; the cache only records its
+previous output to avoid asking the same question twice. 7 new regression
+tests pin the behavior (`tests/unit/PromptGate.test.ts`).
+
+**Evidence.** Measurement before fix on 2026-05-15: 108,782 LLM calls /
+3.03 billion tokens in 24h from the `InputDetector.llmDetect` path,
+representing 73% of the machine's entire 24h token spend. Expected after
+fix: one LLM call per distinct output snapshot per session, with idle
+sessions producing one classification at most.
+
 ### feat(remediation): A47 — PrimaryAggregatorLease + failover (Tier-3 coordination scaffold)
 
 New `src/remediation/PrimaryAggregatorLease.ts` implements the cross-machine primary-aggregator lease specified in SELF-HEALING-REMEDIATOR-V2-SPEC §A47 with the §A60 fencing-token hardening. Lease file at `.instar/remediation/primary-lease.json` carries `{leaderId, fencingToken (128-bit per A60), leaseExpiresAt, acquiredAt, hmac}` with the HMAC computed over a canonical-ordered body using the `audit-v1` leaf key from `RemediationKeyVault` (§A20). Default TTL 15 min, recommended renew cadence 5 min (§A47). Tiebreak on empty/expired state is deterministic by `sha256(machineId)` lex-min — the candidate with the lowest hash wins, so two simultaneous claims always converge to a single leader without coordination. Multi-write detection: if the on-disk fencing token diverges from the one this instance last issued, an entry is appended to `audit-anomaly.jsonl` and the instance fail-closes — `tryAcquire` and `renew` refuse until operator reset (per §A47 split-brain handling). Leader transitions emit `remediation.primary-aggregator.changed` on the lease's EventEmitter so consumers can drive role-switch. Forged lease files (HMAC mismatch) are treated as absent so the next `tryAcquire` re-establishes a signed lease without trusting the tamper. 14 unit tests cover empty-state acquire, held-by-other refusal, expired-lease takeover, renew extension, stolen-lease split-brain, fencing-token verify (positive + stale + wrong-length), deterministic tiebreak, forged-HMAC rejection, failover event, malformed-JSON handling, and split-brain reset. Coordination scaffold only — wiring into `NovelFailureReviewer` for actual cross-machine clustering ownership ships in a follow-up Tier-3 PR.

--- a/upgrades/side-effects/prompt-gate-no-prompt-cache.md
+++ b/upgrades/side-effects/prompt-gate-no-prompt-cache.md
@@ -1,0 +1,258 @@
+# Side-Effects Review — PromptGate NO_PROMPT cache (token-burn fix)
+
+**Version / slug:** `prompt-gate-no-prompt-cache`
+**Date:** `2026-05-15`
+**Author:** Echo (instar developer agent)
+**Second-pass reviewer:** required (touches a monitoring sentinel decision point)
+
+## Summary of the change
+
+`src/monitoring/PromptGate.ts` — adds a bounded per-session NO_PROMPT
+classification cache to `InputDetector.llmDetect()`. Once the LLM has
+classified a specific terminal-output snapshot for a session as "not a
+blocking prompt," the same snapshot will short-circuit the LLM call instead
+of re-asking on every monitor tick. Cache is keyed on a SHA-256 fingerprint
+of the 20-line context the LLM actually sees, capped at 32 entries per session
+(FIFO eviction), cleared in `onInputSent()` and `cleanup()`.
+
+Files touched:
+- `src/monitoring/PromptGate.ts` — adds `noPromptCache` field, cache lookup
+  before LLM call, cache write on NO_PROMPT, clear in `onInputSent`/`cleanup`,
+  helper `recordNoPrompt()`.
+- `tests/unit/PromptGate.test.ts` — 7 new regression tests covering
+  idle-session short-circuit, per-session isolation, distinct-context still
+  calls LLM, `onInputSent` clears cache, `cleanup` clears cache, cache cap
+  bounded, positive detections are not cached.
+
+Decision points the change interacts with: only one — `InputDetector.llmDetect`,
+which uses Haiku to classify terminal output as a blocking prompt or not.
+The change is a memoization layer in front of that authority. The authority
+itself is untouched.
+
+## Decision-point inventory
+
+- `InputDetector.llmDetect` (LLM-backed authority that classifies terminal
+  output as blocking prompt vs. not) — **modify** — adds a memoization step
+  before the LLM call. The authority's verdicts are unchanged; we just stop
+  re-asking it the same question with the same input.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+The change cannot over-block prompt detection in the conventional sense
+(rejecting a legitimate user input). But it could *over-suppress* LLM
+re-classification, leading to a missed real prompt. Concrete failure mode:
+
+- A session's terminal output is classified NO_PROMPT for snapshot X.
+- Later, the agent prints a real blocking prompt, producing snapshot Y.
+- Snapshot Y is a *different* fingerprint (X ≠ Y) → cache misses → LLM is
+  called normally → real prompt detected.
+
+So the cache only suppresses LLM calls when the *exact same 20-line context*
+recurs. A real prompt would necessarily produce different output. No false
+suppression of real prompts is introduced.
+
+The one edge case worth naming: if the LLM made a wrong classification (false
+NO_PROMPT verdict on an actual prompt) and that *exact* output recurs, the
+cache amplifies the LLM error by preventing re-classification. Mitigation:
+the cache is bounded (32 entries) and cleared on `onInputSent()`, so the
+amplification window is short. Tradeoff is acceptable: a wrong LLM verdict
+gets re-asked at most 32 outputs later anyway, and the alternative was
+burning 3B tokens/day to repeatedly get the same wrong answer.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **Subtle output noise that defeats fingerprinting.** A session showing a
+  spinner, timer, or animated counter will produce slightly different
+  fingerprints each tick. Each variant gets one LLM call before being cached.
+  Existing pre-filters (`/Scampering|Thinking|Reading \d+ file/i`) already
+  catch the most common animated-output cases. Residual noise from
+  not-yet-cataloged spinners would still call the LLM once per variant.
+- **Cache size cap (32).** A truly flapping session with > 32 distinct
+  recurring outputs would evict and re-classify. This is a deliberate
+  bounded-memory tradeoff; the cost is small (~32 SHA-256 calls per
+  flapping session per cycle) compared to the alternative of unbounded
+  growth. The existing 5-second outer cooldown still gates burst rates.
+
+Neither of these is a regression — both were always true. The fix is purely
+additive: same behavior on cache misses, suppressed re-classification on
+cache hits.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. This is a pure memoization at the same layer as the existing
+`llmRelayTimestamps` rate limiter. Both are private to `InputDetector` and
+gate the same LLM call. The cache is a *signal-level* optimization: it
+records which contexts have already been ruled out, so the authority
+(LLM) is not re-consulted unnecessarily. The authority (Haiku via
+`IntelligenceProvider.evaluate`) keeps full responsibility for the actual
+classification — the cache only suppresses redundant calls.
+
+No higher-level gate exists that this should feed instead. No lower-level
+primitive exists that already does this. The change sits in the natural home.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface.
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [ ] ⚠️ Yes, with brittle logic.
+
+The cache does not make any classification decisions. It memoizes verdicts
+already produced by the LLM authority (`IntelligenceProvider.evaluate`). On
+a cache hit, the *previous LLM verdict* is what determines behavior —
+specifically, "the LLM said NO_PROMPT for this exact context, so we honor
+that verdict without re-asking." That is identical to what the LLM would
+return if re-asked on identical input (Haiku at temperature 0 with the same
+prompt is deterministic to within margin). No brittle logic gains blocking
+authority; the authority remains the LLM, the cache just records its prior
+output to avoid redundant calls.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing**: the cache check sits *after* the existing pre-filters (regex
+  rejects for status bar / "Thinking" / etc.) and *after* the existing
+  5-minute `llmRelayTimestamps` rate limiter. It runs *before* the LLM call.
+  If the existing rate limiter triggers, the cache is never consulted —
+  correct behavior, no shadowing.
+- **Double-fire**: the cache write happens once per LLM call (`recordNoPrompt`
+  is only invoked from the NO_PROMPT response path inside `llmDetect`, and
+  `pendingLlmDetection` prevents overlapping calls per session). No
+  double-fire surface.
+- **Races**: cache reads and writes happen on the same async path
+  (`llmDetect`). The `pendingLlmDetection` set already prevents concurrent
+  `llmDetect` calls per session. `onInputSent()`, `cleanup()`, and the LLM
+  response handler all touch `noPromptCache` from the same event loop. No
+  cross-thread / cross-process state — Node single-threaded, no race.
+- **Feedback loops**: the cache feeds back into its own check (cache hit →
+  skip LLM → no new cache entry). This is the desired loop — it converges,
+  not diverges. Counter-direction (real prompt appears → different
+  fingerprint → cache miss → LLM called → emit) is also stable.
+- **Adjacent cleanups**: `cleanup(sessionName)` already drops
+  `lastOutput`, `stableCount`, `emittedPrompts`, `lastEmissionTime`,
+  `llmRelayTimestamps`, `pendingLlmDetection`. We add `noPromptCache.delete`
+  to the same list. `onInputSent` similarly clears the cache so post-input
+  output gets re-classified.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Other agents on the same machine** — yes, indirectly: every instar agent
+  embeds the same `InputDetector`, so every agent's LLM burn rate for prompt
+  detection drops once the new code is installed. Behavior visible only as
+  reduced Haiku usage on the API side; no functional change in detection
+  behavior.
+- **Other users of the install base** — same: all agents inherit the fix
+  on upgrade. Strictly cost-positive.
+- **External systems** — Anthropic API usage drops materially. No format
+  change to any externally-visible message or event.
+- **Persistent state** — none. Cache is purely in-memory, lost on process
+  restart. No DB schema change, no file written, no migration.
+- **Timing / runtime conditions we don't fully control** — the cache assumes
+  Haiku's NO_PROMPT verdict on a specific input is stable enough to memoize.
+  At `temperature: 0` this is true to within stochastic noise; even if Haiku
+  flickered between NO_PROMPT and a positive response on the same input, the
+  cache would just lock in whichever came first for at most 32 outputs and
+  then evict. Acceptable.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+- **Hot-fix release**: revert two files (`src/monitoring/PromptGate.ts`,
+  `tests/unit/PromptGate.test.ts`), ship a patch release. Estimated 10
+  minutes once issue is detected.
+- **Data migration**: none. No persistent state introduced.
+- **Agent state repair**: none. Cache is per-process, in-memory; restarting
+  the agent server drops it instantly.
+- **User visibility**: zero. The only user-visible behavior change is
+  reduced Telegram-relay duplicate-prompt spam, and the existing detection
+  behavior is preserved for first-time-seen outputs.
+
+Lowest possible rollback cost: pure code change, no migrations, no state.
+
+---
+
+## Conclusion
+
+The change is a bounded in-memory memoization layer in front of an LLM-backed
+authority. It introduces no new decision logic, no new blocking surface, no
+persistent state, and no external API changes. Worst-case failure mode is
+under-detection of a single class of recurring prompts (same exact 20-line
+output as a prior NO_PROMPT verdict), which is mitigated by `onInputSent`
+clearing the cache. The fix targets a specific, measured token-burn pattern
+(108k LLM calls / 3B tokens per 24h on this machine, 2026-05-15) caused by
+the existing 5-minute rate limit being incorrectly gated on emit. With the
+cache, idle sessions burn one LLM call per distinct output instead of one
+per monitor tick. Clear to ship pending second-pass concurrence.
+
+---
+
+## Second-pass review
+
+**Reviewer:** general-purpose subagent (Echo's review subagent)
+**Independent read of the artifact: concur**
+
+The cache is a textbook memoization layer in front of an LLM authority. On hit it short-circuits with the same behavior the LLM would have produced (`return` from NO_PROMPT branch); on miss it falls through to the unchanged authority. No new blocking surface, no decision logic, no persistent state. Signal-vs-authority compliance is clean. Worst-case under-suppression is bounded by a recurring-identical-context window of at most 32 outputs, after which FIFO eviction forces re-classification. Token spend in the degenerate >32-distinct-cyclic-context case is no worse than baseline.
+
+Minor notes (do not block ship, but worth tracking):
+
+- **In-flight `llmDetect` vs `onInputSent` race.** `onInputSent()` clears `noPromptCache` synchronously, but if an `llmDetect` is mid-flight for the same session (`pendingLlmDetection` set), its awaited `recordNoPrompt(...)` will land *after* the clear and repopulate the cache with a verdict computed against pre-input output. The stale entry only fires on a future byte-identical context (unlikely post-input) and would be evicted within 32 outputs or on the next `onInputSent`. Consider: capture a generation counter in `llmDetect` at start and skip `recordNoPrompt` if it doesn't match the current generation. Not urgent — failure mode is "one redundant cache entry," not "missed prompt."
+
+- **`startsWith('NO')` permissiveness amplified by cache.** Line 416 treats any LLM response starting with `NO` (e.g. "NOT SURE", "NOW WAITING") as NO_PROMPT and now caches it. Pre-cache this was a per-call leniency; post-cache it locks in for up to 32 cycles. Consider tightening to exact-match `NO_PROMPT` or `^NO_PROMPT\b`. Tracked as a hardening followup, not a blocker.
+
+- **Cleanup vs in-flight `llmDetect` (same race as above for terminated sessions).** `cleanup()` clears `pendingLlmDetection` and `noPromptCache`, but a mid-flight `llmDetect` whose `.finally()` has not yet run will still call `recordNoPrompt(sessionName, ...)`, creating a cache entry for a dead session. Pure memory leak (one entry per dead session per race window) until process restart. Bounded and minor.
+
+- **Test coverage gaps.** No regression test exists for: (a) the in-flight-vs-cleanup race, (b) the `startsWith('NO')` permissiveness path (e.g. asserting that `"NOT SURE"` is cached and impacts subsequent calls), (c) lack of interaction between `onPromptRejected` and `noPromptCache` (currently fine because rejection only applies to positive emits, but worth a defensive test if those branches ever cross). Add when the followups land.
+
+None of these break the ship criteria. The change is correct under the assumptions it states, and the failure modes I found degrade to at most "one extra LLM call" or "one stranded cache entry," never to a missed prompt. Clear to commit.
+
+**Author response to reviewer notes (addressed before commit):**
+
+- **In-flight race + `startsWith('NO')` permissiveness** — addressed in the
+  same commit. Added `cacheGeneration: Map<sessionName, number>` bumped by
+  `onInputSent()` and `cleanup()`. `llmDetect` captures the generation at
+  call start; `recordNoPrompt()` now drops the write if the generation has
+  advanced (covers both the input-during-flight and cleanup-during-flight
+  cases). Also tightened cache write to require strict `trimmed === 'NO_PROMPT'`;
+  the permissive `startsWith('NO')` branch still returns from `llmDetect` but
+  no longer memoizes, so a transient "NOT SURE" reply doesn't lock in.
+- **Test coverage** — two new tests added: one for the in-flight clear race
+  (asserts no cache entry after `onInputSent` mid-flight), one for permissive
+  non-strict-NO responses (asserts they are not cached). Total NO_PROMPT-cache
+  regression tests now 9; full PromptGate suite 42/42 passing.
+
+---
+
+## Evidence pointers
+
+- Original measurement (108,782 calls / 3.03B tokens / 24h):
+  `/private/tmp/claude-501/-Users-justin--instar-agents-echo/fb63ccb9-b8ab-4b63-8f49-55d3d6427255/tasks/bwgzdb1bf.output`
+- Unit-test verification: `npx vitest run tests/unit/PromptGate.test.ts`
+  → 40/40 passed, 7 new NO_PROMPT-cache regression tests included.


### PR DESCRIPTION
## Summary

- Stops ~3B tokens/day / ~108k Haiku calls burned by `InputDetector.llmDetect` on idle sessions — the 5-minute rate limit was wired to fire only on prompt-emit, never on NO_PROMPT, so idle sessions kept re-asking the LLM the same question every ~5 seconds forever.
- Adds a bounded per-session NO_PROMPT classification cache keyed on a SHA-256 fingerprint of the 20-line LLM context. Same context → cache hit → skip LLM. Different context → fall through to the LLM unchanged.
- Pure memoization in front of an existing LLM authority. No new blocking surface, no persistent state, no migration, no external API change.

## Spec

`docs/specs/prompt-gate-no-prompt-cache.md` — converged + approved. ELI16 companion: `docs/specs/prompt-gate-no-prompt-cache.eli16.md`.

## Side-effects review

`upgrades/side-effects/prompt-gate-no-prompt-cache.md` — full 7-question review with second-pass reviewer concurrence. Two hardening items from the reviewer (in-flight clear race + permissive `startsWith('NO')` cache amplification) were addressed in the same commit:

- `cacheGeneration` counter bumped on every `onInputSent` / `cleanup`; `recordNoPrompt` drops writes whose generation has advanced. Prevents a mid-flight stale verdict from repopulating a just-cleared cache.
- Cache write tightened to strict `trimmed === 'NO_PROMPT'`. Permissive `startsWith('NO')` responses still return early but are not memoized.

## Test plan

- [x] 42/42 PromptGate unit tests pass (9 new regression tests for the cache).
- [x] CI typecheck + 8 unit-test shards + integration + e2e + build + verify.
- [ ] After merge + publish + Echo upgrade: sample 30 min of `~/.claude/projects/` JSONLs and confirm the "analyzing terminal output" call rate drops dramatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)