### PR TITLE
fix(SemanticMemory): pre-load sqlite-vec before probe to stop vec0-table quarantine loop

### DIFF
--- a/src/memory/SemanticMemory.ts
+++ b/src/memory/SemanticMemory.ts
@@ -567,6 +567,25 @@ export class SemanticMemory {
 
     this.db = constructor(this.config.dbPath) as Database;
 
+    // Pre-load sqlite-vec so vec0 virtual tables are queryable during the probe
+    // below. Without this, an existing entity_embeddings (vec0) table — which is
+    // recreated asynchronously by initializeVectorSearch() the first time vector
+    // search runs — causes the probe to throw "no such module: vec0" and triggers
+    // false-positive corruption quarantine. The probe runs synchronously in open()
+    // before the async vector-search init has a chance to load the extension.
+    //
+    // Loading here uses sqlite-vec directly (not via EmbeddingProvider) because:
+    //   1. EmbeddingProvider may not be attached at open() time.
+    //   2. The probe must succeed regardless of whether vector search is wired up,
+    //      since the on-disk DB schema doesn't know about that runtime choice.
+    //
+    // Failure is non-fatal: the probe loop below has its own missing-module guard
+    // that skips virtual tables whose extension isn't available.
+    try {
+      const vec = await import('sqlite-vec');
+      vec.load(this.db);
+    } catch { /* @silent-fallback-ok: sqlite-vec unavailable — probe will skip vec0 tables */ }
+
     // Integrity check — auto-recover from corruption (JSONL is source of truth).
     // Corrupt DBs are quarantined (renamed) not deleted, and a marker file is written
     // so operators can notice the recovery after the fact.
@@ -589,9 +608,23 @@ export class SemanticMemory {
       if (!this._needsRebuild) {
         try {
           const tables = this.db!.prepare(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'fts%' AND name NOT LIKE 'sqlite%'"
-          ).all() as Array<{ name: string }>;
+            "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'fts%' AND name NOT LIKE 'sqlite%'"
+          ).all() as Array<{ name: string; sql: string | null }>;
           for (const t of tables) {
+            // Virtual tables require their module to be loaded into the connection.
+            // If a virtual-table probe throws "no such module", the table isn't
+            // corrupt — its extension just isn't available (sqlite-vec missing,
+            // a custom module not yet registered, etc.). Treating that as
+            // corruption produces an infinite quarantine loop on every open.
+            if (t.sql && /^\s*CREATE\s+VIRTUAL\s+TABLE/i.test(t.sql)) {
+              try {
+                this.db!.prepare(`SELECT * FROM "${t.name}" LIMIT 100`).all();
+              } catch (vErr) {
+                if (/no such module/i.test((vErr as Error).message)) continue;
+                throw vErr;
+              }
+              continue;
+            }
             this.db!.prepare(`SELECT * FROM "${t.name}" LIMIT 100`).all();
           }
         } catch (err) {

--- a/tests/unit/semantic-memory-corruption-recovery.test.ts
+++ b/tests/unit/semantic-memory-corruption-recovery.test.ts
@@ -22,6 +22,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { SemanticMemory } from '../../src/memory/SemanticMemory.js';
+import { EmbeddingProvider } from '../../src/memory/EmbeddingProvider.js';
 
 interface Setup {
   dir: string;
@@ -308,5 +309,108 @@ describe('SemanticMemory corruption auto-recovery', () => {
     const afterSecond = listCorruptArtifacts(setup.dir);
     expect(afterSecond.markerFiles.length).toBe(beforeSecond.markerFiles.length);
     expect(afterSecond.corruptFiles.length).toBe(beforeSecond.corruptFiles.length);
+  });
+});
+
+/**
+ * Virtual-table probe load-order tests.
+ *
+ * Contract:
+ *   The secondary probe-read MUST NOT treat "no such module: <name>" on a
+ *   virtual table as corruption. Virtual tables require their extension to be
+ *   loaded into the connection before they're queryable, and the probe runs
+ *   synchronously in open() before any deferred extension load could happen.
+ *   Treating a missing-module error as corruption produces an infinite
+ *   quarantine loop on every reopen (see the upstream gap report).
+ *
+ *   Concretely for sqlite-vec: open() pre-loads the extension when available,
+ *   so a healthy DB with an `entity_embeddings` (vec0) virtual table opens
+ *   without quarantine.
+ */
+describe('SemanticMemory probe — virtual tables and load order', () => {
+  let setup: Setup;
+  beforeEach(() => { setup = makeSetup(); });
+  afterEach(() => setup.cleanup());
+
+  async function seedDbWithVec0VirtualTable(dbPath: string): Promise<void> {
+    // Seed the DB exactly the way SemanticMemory's hybrid-search path does: open
+    // through SemanticMemory with an EmbeddingProvider attached, initialize vector
+    // search (which loads sqlite-vec and creates the `entity_embeddings` vec0
+    // virtual table via VectorSearch.createTable), then close. The on-disk schema
+    // now has a vec0 virtual table that requires the sqlite-vec module to query.
+    const memory = new SemanticMemory({ dbPath, decayHalfLifeDays: 30, lessonDecayHalfLifeDays: 90, staleThreshold: 0.2 });
+    memory.setEmbeddingProvider(new EmbeddingProvider());
+    await memory.open();
+    await memory.initializeVectorSearch();
+    memory.close();
+  }
+
+  it('does not quarantine a healthy DB that contains a vec0 virtual table', async () => {
+    await seedDbWithVec0VirtualTable(setup.dbPath);
+
+    // Sanity: schema actually contains a CREATE VIRTUAL TABLE for entity_embeddings.
+    const BetterSqlite3 = (await import('better-sqlite3')).default;
+    const inspect = new BetterSqlite3(setup.dbPath, { readonly: true });
+    const row = inspect.prepare(
+      "SELECT name, sql FROM sqlite_master WHERE name='entity_embeddings'"
+    ).get() as { name: string; sql: string } | undefined;
+    inspect.close();
+    expect(row).toBeDefined();
+    expect(row!.sql).toMatch(/CREATE\s+VIRTUAL\s+TABLE/i);
+
+    // Reopen via SemanticMemory — must not throw and must not quarantine.
+    const mem = new SemanticMemory({ dbPath: setup.dbPath, decayHalfLifeDays: 30, lessonDecayHalfLifeDays: 90, staleThreshold: 0.2 });
+    await expect(mem.open()).resolves.not.toThrow();
+    mem.close();
+
+    const { corruptFiles, markerFiles } = listCorruptArtifacts(setup.dir);
+    expect(corruptFiles).toEqual([]);
+    expect(markerFiles).toEqual([]);
+  });
+
+  it('opening repeatedly does not accumulate quarantine artifacts (no probe-loop regression)', async () => {
+    await seedDbWithVec0VirtualTable(setup.dbPath);
+
+    for (let i = 0; i < 3; i++) {
+      const mem = new SemanticMemory({ dbPath: setup.dbPath, decayHalfLifeDays: 30, lessonDecayHalfLifeDays: 90, staleThreshold: 0.2 });
+      await mem.open();
+      mem.close();
+    }
+
+    const { corruptFiles, markerFiles } = listCorruptArtifacts(setup.dir);
+    expect(corruptFiles).toEqual([]);
+    expect(markerFiles).toEqual([]);
+  });
+
+  it('opens cleanly with no embedding provider attached (probe still survives the vec0 schema)', async () => {
+    // The deferred-attachment shape: vector search may not be wired up on every
+    // reopen, but the on-disk schema still contains the vec0 virtual table from
+    // a previous run. The pre-load + per-table missing-module guard must cover
+    // this path so we don't quarantine.
+    await seedDbWithVec0VirtualTable(setup.dbPath);
+
+    const mem = new SemanticMemory({ dbPath: setup.dbPath, decayHalfLifeDays: 30, lessonDecayHalfLifeDays: 90, staleThreshold: 0.2 });
+    // Intentionally no setEmbeddingProvider() — exercise the "vec0 table exists
+    // on disk but caller hasn't asked for vector search" reopen path.
+    await mem.open();
+    mem.close();
+
+    const { corruptFiles, markerFiles } = listCorruptArtifacts(setup.dir);
+    expect(corruptFiles).toEqual([]);
+    expect(markerFiles).toEqual([]);
+  });
+
+  it('genuine probe-detected corruption still quarantines (regression guard for the virtual-table carve-out)', async () => {
+    // Make sure the virtual-table skip didn't accidentally widen the probe's
+    // tolerance for actual corruption in non-virtual tables.
+    await writePartiallyCorruptDb(setup.dbPath);
+
+    const mem = new SemanticMemory({ dbPath: setup.dbPath, decayHalfLifeDays: 30, lessonDecayHalfLifeDays: 90, staleThreshold: 0.2 });
+    await mem.open();
+    mem.close();
+
+    const { corruptFiles, markerFiles } = listCorruptArtifacts(setup.dir);
+    expect(corruptFiles.length).toBeGreaterThanOrEqual(1);
+    expect(markerFiles.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Problem

`SemanticMemory.open()` runs a synchronous probe-read on every existing user table after the `integrity_check` pragma. When the on-disk schema contains the `entity_embeddings` vec0 virtual table — which is the steady-state shape for any deployment that's ever attached an `EmbeddingProvider` and called `initializeVectorSearch()` — the probe throws `SqliteError: no such module: vec0`. The catch arm dispatches that as corruption, quarantines the DB, creates a marker file, and reopens a fresh empty DB. On the next `open()` the schema is regenerated, the vec0 table comes back asynchronously via `initializeVectorSearch`, and the cycle repeats.

Observed in production (long-running WSL/Linux deployment, instar 0.28.x):

- Quarantine cadence: every ~60s. ~1,400 marker files/day.
- Peak accumulation: 4,902 quarantined DB copies + matching marker files ≈ 610 MB on disk.
- Symptom from the agent's view: \"vec0 missing\" health-check pings every 30 minutes. Health remained \"degraded\" continuously for 18+ hours before someone deleted the marker files; deletion does nothing because the loop runs forever and the markers regenerate within minutes.

The misleading framing is that sqlite-vec is missing. It isn't — the package is installed and `vec.load(db)` succeeds when called. The bug is load-order: the probe runs before any path inside `SemanticMemory` has loaded the extension into the connection.

## Approach

Two changes inside `SemanticMemory.open()`:

1. **Pre-load `sqlite-vec` directly after constructing the DB**, before the integrity / probe block. Uses `await import('sqlite-vec')` and `vec.load(this.db)` inline rather than going through `EmbeddingProvider.loadVecModule/loadVecExtension` because:
   - `EmbeddingProvider` may not be attached at `open()` time (it's set via `setEmbeddingProvider()`, which can happen before or after open per the existing dual-path).
   - The probe needs vec0 queryable regardless of whether vector search is wired up for this session — the on-disk schema doesn't know about that runtime choice.
   - Failure is non-fatal (wrapped in a quiet try/catch with `@silent-fallback-ok`); if sqlite-vec is genuinely not installed, the per-table guard below handles it.

2. **Per-table missing-module guard inside the probe loop.** The probe now also selects `sql` from `sqlite_master` and, when a row is a `CREATE VIRTUAL TABLE`, wraps its read in a try/catch that skips on `/no such module/i`. Other errors from a virtual table still propagate to the outer quarantine path — the carve-out is specifically scoped to \"the module isn't loaded into this connection,\" which is not a corruption signal.

Both changes are independently sufficient for the vec0 case. Together they're defense-in-depth: if a future deployment has sqlite-vec uninstalled but an old `entity_embeddings` table still on disk, the guard prevents quarantine; if the extension is available, the pre-load makes the probe actually exercise the virtual table.

## Files changed

- `src/memory/SemanticMemory.ts` — pre-load + per-table guard, ~30 lines added inside `open()`
- `tests/unit/semantic-memory-corruption-recovery.test.ts` — new \`describe\` block with four tests for the load-order contract

## Tests

Four new tests in the existing corruption-recovery file:

- **does not quarantine a healthy DB that contains a vec0 virtual table** — seeds a DB via the normal `setEmbeddingProvider` + `initializeVectorSearch` path (so the on-disk schema has a real `CREATE VIRTUAL TABLE entity_embeddings USING vec0(...)` row), closes, reopens, asserts no marker / corrupt files.
- **opening repeatedly does not accumulate quarantine artifacts (no probe-loop regression)** — opens the seeded DB three times in succession, asserts zero accumulation. This is the regression test for the production symptom.
- **opens cleanly with no embedding provider attached** — exercises the deferred-attachment shape: a session opens the DB without ever calling `setEmbeddingProvider`, but the on-disk schema still has the vec0 table from a previous run. The pre-load + per-table guard must cover this.
- **genuine probe-detected corruption still quarantines** — regression guard for the carve-out. A partially corrupt DB (valid header, bad interior page on a normal table) must still be quarantined. Verifies we didn't accidentally widen the probe's tolerance.

Red-green verified: with the source change stashed but the new tests applied, the three load-order tests fail (\"promise rejected SqliteError\" / probe throws \"no such module: vec0\"). With the source change applied, all 16 tests in the file pass (13 existing + 3 new affirmative + the regression guard which passes in both states).

Broader semantic-memory unit suite (114 tests across `semantic-memory.test.ts`, `semantic-memory-privacy.test.ts`, `semantic-memory-evidence.test.ts`, `SemanticMemory-invokeFromRemediator.test.ts`): all pass with the change applied.

## Concerns I'd raise on my own PR

- **Async import on every open.** `await import('sqlite-vec')` happens on every `open()`, even though Node caches the module after the first resolution. Cost is dominated by the first call. Acceptable, but a `private _vecModulePreloaded` cache parallel to `EmbeddingProvider._sqliteVecModule` would shave a microsecond if it ever matters.
- **Pre-load swallows non-missing-module errors silently.** A genuine load failure (corrupted sqlite-vec install, ABI mismatch) is swallowed by the outer try/catch. The per-table guard inside the probe will then take the hit and skip the vec0 table, which is the right behavior for the probe but means the operator gets no signal that vector search is broken. The existing `initVectorSearch` / `initializeVectorSearch` paths already surface this via `_vectorAvailable`; the open-time pre-load doesn't need to duplicate that signaling, but documenting the asymmetry inline might help the next reader.
- **The per-table missing-module guard catches the symptom, not the cause.** If a future change adds another async-loaded virtual-table module (e.g. someone wires up an SQLite FTS plugin that isn't built into the linked SQLite), they'll either need to add another pre-load here or rely on the guard to silently skip the table. The guard is correct but quietly grows the surface of \"things that look like missing modules.\" Not a blocker; flagged because it's the kind of thing Echo's reviews tend to surface in concerns #2.

## Notes

- Running on WSL2 / Linux, same environment as my previous PRs (#107, #109, #133, #32).
- I have a hot-patch installed locally that mirrors this exact source change for the running server. Once this merges I'll remove it.
- Companion gap tracker entry: GAP-025 in my deployment's gaps registry.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>