### PR TITLE
feat(monitoring): burn-detection Phase 2 — AttributionResolver

### DIFF
--- a/docs/specs/token-burn-detection-phase-2.eli16.md
+++ b/docs/specs/token-burn-detection-phase-2.eli16.md
@@ -1,0 +1,33 @@
+# Token-Burn Detection — Phase 2 ELI16
+
+## What this ships
+
+The second piece of the bleeding-detector. Still no user-visible change — phase three is where the watcher actually starts watching.
+
+What this phase adds is the piece that figures out, after the fact, which component made an LLM call. The Claude CLI's session files (the JSONL log that the token ledger already reads) record every LLM call, but they do not say "this call came from InputDetector" or "this came from MessagingToneGate." The Phase 1 chokepoint can tag the few calls it makes directly, but the dominant case is the CLI path, and that path's logs do not carry our component label.
+
+Phase 2 closes that gap with two small pieces:
+
+1. **A short list of patterns** that match the prompt shapes the agent's internal components use. Today the list has nine entries — the InputDetector bleed shape (the very prompt that burned 3B tokens), MessagingToneGate, CommitmentSentinel, MessageSentinel, StallTriageNurse, CoherenceReviewer, ProjectDriftChecker, ResumeValidator, and TopicLinkageHandler. Adding more entries is easy and does not need any spec change — they are inference rules, not authority.
+
+2. **A pure function** that takes one log entry and returns a stable "attribution key" like InputDetector::a1b2c3d4. The function tries prompt-pattern matching first, then falls back to working-directory inference (a path under `.instar/jobs/foo` becomes "user-job:foo"; a hook file becomes "user-hook:<file>"), and finally falls back to "unknown::<short session id>" so a single misbehaving session still groups into one key.
+
+The function is pure: no files read, no clocks, no side effects. Same input always gives the same output. The bleed detector in phase three will lean on that determinism heavily.
+
+## What you'd notice if it went wrong
+
+Nothing on its own — the function is not called by anything in production yet. Worst case: a prompt that matches multiple manifest entries attributes to the first-listed one. The test suite documents this behavior with a specific test (the bleed pattern matches before the generic stall pattern, by design).
+
+If a manifest entry is incorrect, the worst outcome is a misattributed key — the bleeding event would still be observed under the wrong component name, and the user would see "I think this is InputDetector burning, but I'm not sure" in phase three's alert. The umbrella spec's "attribution-key mismatch" mitigation handles that case in phase six (verification step re-samples and flags it).
+
+## How we know it works
+
+Twenty-two tests in `tests/unit/burn-detection-phase-2.test.ts`. They cover: every manifest entry resolves to its component on a representative prompt; the 2026-05-15 bleed shape resolves to InputDetector; scheduled-job paths resolve to user-job; hook paths resolve to user-hook; Windows-style backslash paths work; empty / unknown events fall back cleanly; first-match-wins is preserved.
+
+The manifest itself has integrity tests: no duplicate component names, every entry has at least one matcher, no empty component names.
+
+## What's next
+
+Phase 3 is the actual detector. It polls the token ledger every 60 seconds, calls this attribution resolver on each event, computes per-key rates over rolling windows, and emits a signal when a single key crosses 25% of the 24-hour budget or doubles its 7-day baseline rate. That signal feeds the existing Remediator V2 dispatch — no new authority surface gets added.
+
+Phase 3 will be the first phase where you, Justin, see something visible: the new signal will land in the existing degradation log, which is dashboard-visible. Still no Telegram alerts yet — those land in phase five with the principal-bound buttons.

--- a/docs/specs/token-burn-detection-phase-2.md
+++ b/docs/specs/token-burn-detection-phase-2.md
@@ -1,0 +1,61 @@
+---
+slug: token-burn-detection-phase-2
+parent-spec: docs/specs/token-burn-detection-and-self-heal.md
+review-convergence: "derived-from-umbrella"
+review-iterations: 1
+review-completed-at: "2026-05-15T20:25:00Z"
+review-report: docs/specs/reports/token-burn-detection-and-self-heal-convergence.md
+approved: true
+approved-by: justin
+approved-at: "2026-05-15T20:35:00Z"
+approved-via: "Telegram topic 8615 — umbrella approval covers this phase"
+eli16-overview: docs/specs/token-burn-detection-phase-2.eli16.md
+---
+
+# Token-Burn Detection — Phase 2 Spec
+
+**Parent**: `docs/specs/token-burn-detection-and-self-heal.md` (umbrella, approved by Justin 2026-05-15).
+
+Phase 2 of six. Implements the **read-side AttributionResolver** — a pure function that maps an existing TokenLedger event (with no chokepoint-written attribution) to a stable `attribution_key`. Phase 3 (BurnDetector) wires it; Phase 2 only builds the function plus the static manifest.
+
+## Scope (Phase 2)
+
+1. `src/monitoring/attribution-manifest.ts` — static mapping of known instar-internal LLM call patterns (InputDetector's bleed shape, MessagingToneGate, CommitmentSentinel, MessageSentinel, StallTriageNurse, CoherenceReviewer, ProjectDriftChecker, ResumeValidator, TopicLinkageHandler). Order-significant, first-match wins.
+2. `src/monitoring/AttributionResolver.ts` — `resolveAttribution(event)` pure function:
+    - Tries manifest-based prompt match first (the most informative signal for the bleed-detection case).
+    - Falls back to cwd-based inference for scheduled jobs (`.instar/jobs/<name>`) and hooks (`.claude/hooks/<file>` and `.instar/hooks/<file>`).
+    - Otherwise returns `unknown::<sessionId-prefix>` so a single misbehaving session shows up as one key.
+3. 22 unit tests in `tests/unit/burn-detection-phase-2.test.ts` covering manifest hits, cwd-inference (Posix + Windows-style backslash paths), fallback shape, manifest integrity (uniqueness, non-empty components, every entry has a matcher).
+
+## Out of scope
+
+- **Wiring the resolver into TokenLedger ingest.** Phase 3 BurnDetector consumes the resolver on its read path; Phase 2 is the pure function only.
+- **Backfilling existing rows.** Existing rows keep their `unknown::pre-attribution` default until Phase 3 resolves them on read.
+- **User-prompt extraction from JSONL.** Phase 3 will pair user lines with their assistant counterparts; Phase 2's resolver simply accepts a `prompt` argument.
+
+## Files touched
+
+```
+src/monitoring/attribution-manifest.ts                  (NEW — static manifest)
+src/monitoring/AttributionResolver.ts                   (NEW — pure resolver)
+tests/unit/burn-detection-phase-2.test.ts               (NEW — 22 tests)
+docs/specs/token-burn-detection-phase-2.md              (this file)
+docs/specs/token-burn-detection-phase-2.eli16.md        (NEW — Phase 2 ELI16)
+upgrades/side-effects/token-burn-detection-phase-2.md   (NEW)
+upgrades/NEXT.md                                        (release notes)
+```
+
+## Acceptance criteria (Phase 2)
+
+1. `resolveAttribution({prompt: 'analyzing terminal output'})` returns `InputDetector::<8hex>` — the 2026-05-15 bleed shape.
+2. Each of the nine manifest entries resolves to its component name on a representative prompt.
+3. `cwd` containing `.instar/jobs/<name>` resolves to `user-job:<name>::<fp>`.
+4. `cwd` containing `.claude/hooks/<file>` resolves to `user-hook:<file>::<fp>`.
+5. Windows-style backslash paths resolve identically (regex covers `[/\\]`).
+6. Empty / unknown event resolves to `unknown::<8-char-session-prefix>` (or `unknown::no-session` if sessionId is empty).
+7. First-match-wins for ordered manifest entries.
+8. Manifest integrity tests pass (uniqueness of component names, non-empty, every entry has a matcher).
+
+## Rollback
+
+The phase ships two pure modules with no I/O. Backout is a delete of both files plus the test file. No production caller depends on the resolver until Phase 3.

--- a/src/monitoring/AttributionResolver.ts
+++ b/src/monitoring/AttributionResolver.ts
@@ -1,0 +1,115 @@
+/**
+ * AttributionResolver — read-side resolver for the burn-detection system.
+ *
+ * Phase 2 of docs/specs/token-burn-detection-and-self-heal.md.
+ *
+ * Pure function: given the shape of a TokenLedger event (sessionId, cwd,
+ * prompt text, model) returns an attribution_key suitable for grouping
+ * "calls of the same structural origin." Used by the Phase 3 BurnDetector
+ * to populate attribution_key for events the Phase 1 chokepoint did NOT
+ * write directly — chiefly the dominant Claude-CLI path where the JSONL
+ * trail carries the prompt and cwd but no source-side label.
+ *
+ * Authority shape: this is signal-only. It does not gate, throttle, or
+ * decide anything. It maps event → key. The detector emits, the
+ * Remediator decides. See umbrella spec §"Signal-vs-Authority Decomposition".
+ *
+ * No I/O, no time-dependent behavior — deterministic for tests + reasoning.
+ */
+
+import { buildAttributionKey } from './attributionKey.js';
+import { ATTRIBUTION_MANIFEST, type AttributionPattern } from './attribution-manifest.js';
+
+export interface AttributionEvent {
+  sessionId: string;
+  /** cwd / projectPath field from the JSONL line. */
+  projectPath?: string | null;
+  /** The user prompt that triggered the assistant response. Optional — when missing, resolver falls back to cwd / unknown. */
+  prompt?: string | null;
+  /** Model string from the JSONL line (`message.model`). */
+  model?: string | null;
+}
+
+/**
+ * Resolve an attribution_key for an event.
+ *
+ * Resolution order:
+ *   1. Manifest entry that matches the prompt (with optional cwd / model
+ *      narrowing) → `<component>::<promptFingerprint>`.
+ *   2. cwd-based scheduled-job inference — if the cwd contains a path
+ *      segment like `.instar/jobs/<name>`, return `user-job:<name>`.
+ *   3. cwd-based user-extension inference — if the cwd contains
+ *      `.claude/hooks/` or `.instar/hooks/`, return the hook filename.
+ *   4. Fallback: `unknown::<sessionId-prefix>`.
+ *
+ * The prompt-based check is intentionally first: it's the most informative
+ * signal for the bleed-detection use case (one prompt shape running tens
+ * of thousands of times). cwd-based inference is the secondary signal for
+ * cases where the prompt is variable but the source is recognisable.
+ */
+export function resolveAttribution(event: AttributionEvent): string {
+  // 1. Manifest-based prompt match (with optional cwd/model narrowing).
+  if (event.prompt && event.prompt.length > 0) {
+    for (const entry of ATTRIBUTION_MANIFEST) {
+      if (matchesEntry(entry, event)) {
+        return buildAttributionKey(entry.component, event.prompt);
+      }
+    }
+  }
+
+  // 2. Scheduled-job inference: a path segment of the cwd is the job name.
+  //    e.g. /Users/x/.instar/jobs/daily-summary → user-job:daily-summary
+  if (event.projectPath) {
+    const jobMatch = event.projectPath.match(/[/\\]\.instar[/\\]jobs[/\\]([^/\\]+)/);
+    if (jobMatch && jobMatch[1]) {
+      return `user-job:${jobMatch[1]}::${shortPromptFp(event.prompt)}`;
+    }
+
+    // 3. Hook / extension inference.
+    const hookMatch = event.projectPath.match(/[/\\](?:\.claude|\.instar)[/\\]hooks[/\\]([^/\\]+)/);
+    if (hookMatch && hookMatch[1]) {
+      return `user-hook:${hookMatch[1]}::${shortPromptFp(event.prompt)}`;
+    }
+  }
+
+  // 4. Fallback. Use a stable session-id prefix so a single misbehaving
+  //    session shows as one key (and not exploded by per-prompt fingerprint).
+  if (!event.sessionId || event.sessionId.length === 0) {
+    return 'unknown::no-session';
+  }
+  const sidPrefix = event.sessionId.slice(0, 8);
+  return `unknown::${sidPrefix}`;
+}
+
+function matchesEntry(entry: AttributionPattern, event: AttributionEvent): boolean {
+  // Prompt must match if patterns are defined (Phase 2 always defines them).
+  if (entry.promptPatterns && entry.promptPatterns.length > 0) {
+    if (!event.prompt) return false;
+    const hit = entry.promptPatterns.some((re) => re.test(event.prompt!));
+    if (!hit) return false;
+  }
+  // Optional cwd narrowing.
+  if (entry.cwdPatterns && entry.cwdPatterns.length > 0) {
+    if (!event.projectPath) return false;
+    const hit = entry.cwdPatterns.some((re) => re.test(event.projectPath!));
+    if (!hit) return false;
+  }
+  // Optional model narrowing.
+  if (entry.modelHints && entry.modelHints.length > 0) {
+    if (!event.model) return false;
+    const hit = entry.modelHints.some((m) => event.model!.includes(m));
+    if (!hit) return false;
+  }
+  return true;
+}
+
+function shortPromptFp(prompt: string | null | undefined): string {
+  if (!prompt || prompt.length === 0) return 'nonprompt';
+  // Cheap deterministic fingerprint without importing crypto on every call.
+  // Phase 1's buildAttributionKey covers the cryptographic case; here we
+  // only need to disambiguate prompts at the user-job / user-hook level.
+  let h = 0;
+  const slice = prompt.slice(0, 128);
+  for (let i = 0; i < slice.length; i++) h = ((h << 5) - h + slice.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(16).padStart(8, '0').slice(0, 8);
+}

--- a/src/monitoring/attribution-manifest.ts
+++ b/src/monitoring/attribution-manifest.ts
@@ -1,0 +1,94 @@
+/**
+ * Static attribution manifest for the burn-detection-and-self-heal system.
+ *
+ * Phase 2 of docs/specs/token-burn-detection-and-self-heal.md. Maps known
+ * instar-internal LLM call patterns to stable component names so the
+ * BurnDetector (Phase 3) can group calls of the same shape.
+ *
+ * Adding entries does not require a spec change — they are inference rules
+ * for an observation system, not authority. The manifest is a hint store,
+ * not a gate.
+ *
+ * Pattern semantics (per docs/specs/token-burn-detection-and-self-heal.md
+ * §"Attribution key", §"Capture surface"):
+ *   - `promptPatterns`: regex on the user prompt that prompted the
+ *     assistant response. First-match wins. Order matters — list more
+ *     specific patterns first.
+ *   - `cwdPatterns`: optional regex on the `cwd` field of the JSONL line.
+ *     Useful when a component is recognisable by its working directory
+ *     but its prompt varies.
+ *   - `modelHints`: optional list of model substrings; narrows the match
+ *     when the same prompt could come from multiple components but only
+ *     one of them uses a specific model.
+ */
+
+export interface AttributionPattern {
+  /** Stable component name written into attribution_key. */
+  component: string;
+  /** Regex matched against the user prompt. */
+  promptPatterns?: RegExp[];
+  /** Regex matched against the cwd / projectPath field. */
+  cwdPatterns?: RegExp[];
+  /** Substrings narrowing the match to specific models. */
+  modelHints?: string[];
+}
+
+/**
+ * The manifest. Order is significant — first-match wins. Add more specific
+ * entries before broader ones.
+ */
+export const ATTRIBUTION_MANIFEST: AttributionPattern[] = [
+  // The 2026-05-15 bleed: the InputDetector's NO_PROMPT classifier asked
+  // the LLM "is this stuck?" every 5s on every idle session, burning
+  // ~3B tokens/day. This pattern catches that exact prompt shape.
+  {
+    component: 'InputDetector',
+    promptPatterns: [/analyzing terminal output/i, /is this stuck/i, /stalled session detection/i],
+  },
+  // MessagingToneGate evaluates outbound user-facing messages for tone +
+  // banned-content compliance (ELI16, no inline code, etc).
+  {
+    component: 'MessagingToneGate',
+    promptPatterns: [/evaluate this outbound message/i, /tone gate/i, /eli16/i],
+  },
+  // CommitmentSentinel watches for commitments the agent made that lack
+  // follow-through.
+  {
+    component: 'CommitmentSentinel',
+    promptPatterns: [/commitment.*follow.through/i, /unfulfilled commitment/i],
+  },
+  // MessageSentinel classifies inbound messages (emergency stop, etc).
+  {
+    component: 'MessageSentinel',
+    promptPatterns: [/classify.*inbound message/i, /emergency stop classifier/i],
+  },
+  // StallTriageNurse — the LLM-powered session-recovery classifier.
+  {
+    component: 'StallTriageNurse',
+    promptPatterns: [/triage.*stalled session/i, /session.*stall.*classifier/i],
+  },
+  // CoherenceReviewer — the deeper "is this agent acting coherently"
+  // check, invoked by the coherence-gate path.
+  {
+    component: 'CoherenceReviewer',
+    promptPatterns: [/coherence review/i, /agent coherence/i],
+  },
+  // ProjectDriftChecker — round-start signal that the project context
+  // has drifted from what was loaded.
+  {
+    component: 'ProjectDriftChecker',
+    promptPatterns: [/project drift/i, /context drift detection/i],
+  },
+  // ResumeValidator — verifies a Claude Code resume payload before
+  // letting a session pick back up.
+  {
+    component: 'ResumeValidator',
+    promptPatterns: [/validate.*resume payload/i, /resume validation/i],
+  },
+  // TopicLinkageHandler — figures out which existing thread a new
+  // Telegram message belongs to.
+  {
+    component: 'TopicLinkageHandler',
+    promptPatterns: [/topic linkage/i, /thread linking/i],
+  },
+];

--- a/tests/unit/burn-detection-phase-2.test.ts
+++ b/tests/unit/burn-detection-phase-2.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests — Burn-detection Phase 2 (AttributionResolver).
+ *
+ * Covers the Phase 2 deliverables from docs/specs/token-burn-detection-and-self-heal.md:
+ *   - resolveAttribution maps each manifest entry to a component::<fp> key
+ *   - scheduled-job cwd produces user-job:<name>::<fp>
+ *   - user-hook cwd produces user-hook:<name>::<fp>
+ *   - unknown events fall back to unknown::<sessionPrefix>
+ *   - prompt-match precedence over cwd-match (manifest first)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveAttribution } from '../../src/monitoring/AttributionResolver.js';
+import { ATTRIBUTION_MANIFEST } from '../../src/monitoring/attribution-manifest.js';
+
+describe('AttributionResolver — manifest hits', () => {
+  it('catches today\'s bleed: InputDetector "analyzing terminal output"', () => {
+    const key = resolveAttribution({
+      sessionId: 'sess-abc',
+      prompt: 'analyzing terminal output from a Claude Code AI agent session',
+    });
+    expect(key).toMatch(/^InputDetector::[0-9a-f]{8}$/);
+  });
+
+  it('catches the alternate InputDetector phrasing ("is this stuck")', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'is this stuck?' });
+    expect(key).toMatch(/^InputDetector::[0-9a-f]{8}$/);
+  });
+
+  it('maps MessagingToneGate prompts', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'Evaluate this outbound message for ELI16 compliance' });
+    expect(key.startsWith('MessagingToneGate::')).toBe(true);
+  });
+
+  it('maps CommitmentSentinel prompts', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'unfulfilled commitment detected' });
+    expect(key.startsWith('CommitmentSentinel::')).toBe(true);
+  });
+
+  it('maps MessageSentinel prompts', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'classify this inbound message' });
+    expect(key.startsWith('MessageSentinel::')).toBe(true);
+  });
+
+  it('maps StallTriageNurse prompts', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'session stall classifier' });
+    expect(key.startsWith('StallTriageNurse::')).toBe(true);
+  });
+
+  it('maps CoherenceReviewer prompts', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'agent coherence assessment' });
+    expect(key.startsWith('CoherenceReviewer::')).toBe(true);
+  });
+
+  it('maps ProjectDriftChecker prompts', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'project drift detection' });
+    expect(key.startsWith('ProjectDriftChecker::')).toBe(true);
+  });
+
+  it('maps ResumeValidator prompts', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'validate the resume payload' });
+    expect(key.startsWith('ResumeValidator::')).toBe(true);
+  });
+
+  it('maps TopicLinkageHandler prompts', () => {
+    const key = resolveAttribution({ sessionId: 's', prompt: 'topic linkage decision' });
+    expect(key.startsWith('TopicLinkageHandler::')).toBe(true);
+  });
+
+  it('first-match wins — bleeding pattern caught before generic stall pattern', () => {
+    // InputDetector listed before StallTriageNurse in manifest, so a prompt
+    // that matches both should attribute to InputDetector.
+    const key = resolveAttribution({
+      sessionId: 's',
+      prompt: 'analyzing terminal output to triage stalled session',
+    });
+    expect(key.startsWith('InputDetector::')).toBe(true);
+  });
+});
+
+describe('AttributionResolver — cwd-based inference', () => {
+  it('scheduled-job cwd produces user-job:<name>', () => {
+    const key = resolveAttribution({
+      sessionId: 's',
+      projectPath: '/Users/x/.instar/jobs/daily-summary',
+      prompt: 'any prompt that does not match a manifest entry',
+    });
+    expect(key.startsWith('user-job:daily-summary::')).toBe(true);
+  });
+
+  it('windows-style backslash paths also resolve', () => {
+    const key = resolveAttribution({
+      sessionId: 's',
+      projectPath: 'C:\\Users\\x\\.instar\\jobs\\nightly-poll',
+      prompt: 'something unrelated',
+    });
+    expect(key.startsWith('user-job:nightly-poll::')).toBe(true);
+  });
+
+  it('hook cwd under .claude/hooks/ produces user-hook:<filename>', () => {
+    const key = resolveAttribution({
+      sessionId: 's',
+      projectPath: '/Users/x/project/.claude/hooks/SessionStart',
+      prompt: 'some hook prompt',
+    });
+    expect(key.startsWith('user-hook:SessionStart::')).toBe(true);
+  });
+
+  it('hook cwd under .instar/hooks/ produces user-hook:<filename>', () => {
+    const key = resolveAttribution({
+      sessionId: 's',
+      projectPath: '/Users/x/agent/.instar/hooks/foo.js',
+      prompt: 'hook firing',
+    });
+    expect(key.startsWith('user-hook:foo.js::')).toBe(true);
+  });
+});
+
+describe('AttributionResolver — fallback', () => {
+  it('unknown session falls back to unknown::<sessionPrefix> (8-char prefix)', () => {
+    const key = resolveAttribution({ sessionId: 'session-abc-12345', prompt: 'something nobody recognises' });
+    expect(key).toBe('unknown::session-');
+  });
+
+  it('missing sessionId falls back to unknown::no-session', () => {
+    const key = resolveAttribution({ sessionId: '', prompt: 'unknown' });
+    expect(key).toBe('unknown::no-session');
+  });
+
+  it('no prompt + no cwd → unknown::<sessionPrefix>', () => {
+    const key = resolveAttribution({ sessionId: 'xyz123abc' });
+    expect(key).toBe('unknown::xyz123ab');
+  });
+
+  it('prompt that matches no manifest entry falls back to cwd / unknown', () => {
+    const key = resolveAttribution({
+      sessionId: 'sxxx',
+      prompt: 'this is a free-form prompt that does not match anything',
+    });
+    expect(key).toBe('unknown::sxxx');
+  });
+});
+
+describe('AttributionResolver — manifest integrity', () => {
+  it('every manifest entry has a non-empty component name', () => {
+    for (const entry of ATTRIBUTION_MANIFEST) {
+      expect(entry.component.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every manifest entry has at least one matcher (prompt, cwd, or model)', () => {
+    for (const entry of ATTRIBUTION_MANIFEST) {
+      const hasMatcher =
+        (entry.promptPatterns && entry.promptPatterns.length > 0) ||
+        (entry.cwdPatterns && entry.cwdPatterns.length > 0) ||
+        (entry.modelHints && entry.modelHints.length > 0);
+      expect(hasMatcher).toBe(true);
+    }
+  });
+
+  it('component names are unique', () => {
+    const names = ATTRIBUTION_MANIFEST.map((e) => e.component);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,35 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Phase two of the token-burn-detection-and-self-heal system. Still observation-only — no alerts, no auto-throttling, no new dashboard. This phase adds the piece that figures out which component made each LLM call after the fact.
+
+What lands today:
+
+- A short list of patterns that match the prompt shapes the agent's internal components produce.
+- A pure function that takes a token-ledger event and returns a stable attribution identifier.
+
+The detector in phase three will use this function to group calls by where they came from. Nothing in production calls the new function yet.
+
+## What to Tell Your User
+
+Your agent picked up the second of six pieces of the new self-watch system. Like the first piece, nothing changes about how your agent behaves today. The watcher you approved is being built in stages so each piece can be reviewed on its own.
+
+For now, no action needed. The third piece is the one that will start actually noticing things.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Read-side attribution resolver | Internal — no surface yet. |
+| Static attribution manifest | Internal — covers nine known components. |
+
+## Evidence
+
+Twenty-two new tests in `tests/unit/burn-detection-phase-2.test.ts` all pass. The resolver is a pure function with no I/O and no dependency on time, so the test suite is deterministic. Manifest integrity tests cover uniqueness of component names, non-empty entries, and at-least-one-matcher per entry.
+
+The existing token-ledger and selectIntelligenceProvider unit suites still pass — no regression on the parts not touched by this phase.
+
+Side-effects review for this phase is in `upgrades/side-effects/token-burn-detection-phase-2.md`. The reviewer identified zero blocking concerns; phase two ships pure inference with no runtime decision authority, so second-pass review is not required per the instar-dev skill criteria.

--- a/upgrades/side-effects/token-burn-detection-phase-2.md
+++ b/upgrades/side-effects/token-burn-detection-phase-2.md
@@ -1,0 +1,44 @@
+# Side-Effects Review — Token-Burn Detection Phase 2
+
+**Spec**: `docs/specs/token-burn-detection-phase-2.md` (parent: `docs/specs/token-burn-detection-and-self-heal.md`, approved by Justin 2026-05-15).
+
+## 1. Over-block
+
+Phase 2 cannot block anything — it's a pure function with no caller in production yet. Worst case "over-block" is a wrong attribution: a prompt that should have been labeled `InputDetector` ends up under `unknown::<sessionPrefix>`. Phase 3's detector treats unknown-keyed spend as alert-only-on-unknown (per umbrella §"Auto-throttle mechanism"), so even a wrong attribution still produces a usable alert — just less informative.
+
+## 2. Under-block
+
+The pattern manifest covers nine known instar-internal components. New components added in unrelated PRs do not appear in the manifest until someone adds them. They fall through to `unknown::<sessionPrefix>` and are still observable — just not labeled by name. Adding manifest entries is the right discipline going forward; the lint from Phase 1 catches new direct-LLM-HTTP callers, but it does not catch new components calling through the chokepoint without a manifest entry. This is a known and accepted gap.
+
+## 3. Level-of-abstraction fit
+
+`AttributionResolver` and the manifest sit in `src/monitoring/`, next to `TokenLedger` and `LlmRateGate`. Correct layer: it's part of the observability surface, not a piece of the core LLM-call path or a decision-maker.
+
+The resolver is a pure function — no I/O, no time-dependent behavior. That's the right abstraction; Phase 3's read path can call it in a tight loop without worrying about side effects.
+
+## 4. Signal-vs-authority compliance
+
+The resolver is signal-only. It produces an attribution key; it does not decide whether anything happens. The umbrella spec's §"Signal-vs-Authority Decomposition" places AttributionResolver in the "no authority" row, and Phase 2 matches that placement.
+
+**Compliant.**
+
+## 5. Interactions
+
+- **TokenLedger.** No interaction in Phase 2 — the resolver does not read or write the ledger. Phase 3 will pair them.
+- **LlmRateGate.** No interaction. The gate enforces decisions; the resolver produces keys those decisions reference.
+- **AnthropicIntelligenceProvider chokepoint path.** No interaction — when the chokepoint writes attribution_key, Phase 3's read path passes it through unchanged and skips the resolver call.
+- **Other manifests.** No other manifest in the tree has overlapping responsibility; this is a new file.
+
+No shadowing, no double-fire, no race.
+
+## 6. External surfaces
+
+No external surface change. Phase 2 is internal pure code with no callers in production.
+
+## 7. Rollback cost
+
+Three new files (`AttributionResolver.ts`, `attribution-manifest.ts`, test). Backout = delete the three files. No persistent state, no schema change, no caller dependency until Phase 3.
+
+## Second-pass review
+
+Phase 2 ships pure observability inference with no runtime decision authority. It does NOT touch any of the high-risk surfaces listed in `/instar-dev` Phase 5 (no block/allow, no session lifecycle, no coherence gate, no sentinel/guard/gate/watchdog with authority). Second-pass review is **not required** per the skill's criteria.


### PR DESCRIPTION
## Summary
- Phase 2 of token-burn-detection-and-self-heal. Pure read-side resolver + static manifest.
- Umbrella spec approved by Justin 2026-05-15 (Telegram topic 8615).

## What ships
- `src/monitoring/attribution-manifest.ts` — nine known instar-internal prompt patterns (InputDetector's 2026-05-15 bleed shape first).
- `src/monitoring/AttributionResolver.ts` — pure `resolveAttribution(event)`. Manifest match → cwd inference → fallback.
- 22 new tests; existing token-ledger and selectIntelligenceProvider suites unaffected.

## Test plan
- [ ] CI green
- [ ] All 22 Phase 2 tests pass
- [ ] No regression in existing suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)