### PR TITLE
feat(remediation): S-3 commit-time promotion gate for proposal-derived runbooks

### DIFF
--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -29,6 +29,7 @@ import crypto from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { checkEli16Overview } from './eli16-overview-check.mjs';
+import { verifyProposalDerivedRunbooks } from '../skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -329,10 +330,39 @@ if (staged.includes(spec) && !staged.includes(eli16Rel)) {
   );
 }
 
+// ─── Step 8: proposal-derived runbook gate (S-3) ─────────────────────────
+// Per SELF-HEALING-REMEDIATOR-V2-SPEC §A11/§A22/§A32, runbook source files
+// emitted by the SystemReviewer proposal pipeline must:
+//   1. Reference a proposal that actually exists in
+//      .instar/remediation/proposals-*/<id>.json on this checkout, AND
+//   2. Carry a __producingAgentId const matching the proposal's
+//      producingAgentId field.
+// The CI gate (C-1) re-verifies at PR-merge time with full fleet visibility.
+// This commit-time gate catches author mistakes before the PR is pushed.
+
+const promotionGateResult = verifyProposalDerivedRunbooks({
+  repoRoot: ROOT,
+  files: staged,
+});
+if (!promotionGateResult.ok) {
+  blockCommit(
+    inScopeFiles,
+    [
+      'Proposal-derived runbook gate refused this commit:',
+      `  ${promotionGateResult.reason}`,
+      '',
+      'See SELF-HEALING-REMEDIATOR-V2-SPEC.md §A11, §A22, §A32 for the rationale.',
+      'The proposal pipeline (Tier-3 S-1) must emit __proposalDerivedFrom +',
+      '__producingAgentId together, and the matching proposal JSON must be',
+      'present at .instar/remediation/proposals-<machineId>/<id>.json.',
+    ].join('\n'),
+  );
+}
+
 // ─── Pass ────────────────────────────────────────────────────────────────
 
 console.error(
-  `[instar-dev-precommit] OK — trace ${path.basename(validTrace.entry.file)} covers ${inScopeFiles.length} in-scope file(s), artifact ${validTrace.trace.artifactPath} verified, spec ${spec} is converged + approved, ELI16 overview ${eli16Rel} present (${eli16Result.charCount} chars).`,
+  `[instar-dev-precommit] OK — trace ${path.basename(validTrace.entry.file)} covers ${inScopeFiles.length} in-scope file(s), artifact ${validTrace.trace.artifactPath} verified, spec ${spec} is converged + approved, ELI16 overview ${eli16Rel} present (${eli16Result.charCount} chars), promotion-gate: ${promotionGateResult.reason}.`,
 );
 process.exit(0);
 

--- a/skills/instar-dev/SKILL.md
+++ b/skills/instar-dev/SKILL.md
@@ -47,6 +47,15 @@ If the spec is missing, not converged, not approved, or lacks an ELI16 overview,
 
 The ELI16 overview is the entry point for any reader who has to make a real decision against the spec — the dense technical spec is for reviewers, not deciders. It leads with what the change actually is in plain English, what already exists, what's new, the safeguards in plain terms, and what the reader actually needs to decide.
 
+**Proposal-derived runbook gate (S-3).** Per `SELF-HEALING-REMEDIATOR-V2-SPEC.md` §A11/§A22/§A32, any staged file under `src/remediation/runbooks/*.{ts,js}` that carries a `__proposalDerivedFrom = '<proposalId>'` const must also:
+
+- Carry a matching `__producingAgentId = '<agentId>'` const, AND
+- Have a proposal JSON at `.instar/remediation/proposals-<machineId>/<proposalId>.json` whose `producingAgentId` field matches the runbook's annotation.
+
+If a `producingAgentIdSignature` is present in the proposal AND the corresponding pubkey is bundled at `.instar/remediation/agent-pubkeys/<agentId>.pem`, the signature is verified before the commit lands. The pre-commit hook calls `skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs` as Step 8 of its checks. This is the **commit-time** half of the promotion gate; the CI workflow at `.github/workflows/runbook-pr-gate.yml` (C-1) does the **PR-merge-time** half (different-principal verification + Telegram countersignature). Both are required by the spec — the commit-time gate catches author mistakes before a PR is pushed; the merge-time gate is the authoritative check.
+
+Human-authored changes that don't touch `src/remediation/runbooks/` (or that touch runbooks without the `__proposalDerivedFrom` const) pass straight through this gate.
+
 ### Phase 1 — Principle check
 
 Before writing any code, the instar-dev agent reads:

--- a/skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs
+++ b/skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+/**
+ * verify-proposal-derived-runbook.mjs — S-3 commit-time promotion-gate.
+ *
+ * Implements SELF-HEALING-REMEDIATOR-V2-SPEC.md §A11, §A22, §A32, §A41, §A48,
+ * and §A57 Tier-3 (S-3): the /instar-dev side of the proposal-derived runbook
+ * promotion gate. Pairs with C-1's PR-merge-time CI gate.
+ *
+ * Scope:
+ *   - Operates on a list of files (--files <csv>) presumed to be staged in
+ *     the current commit, OR on a comma-separated list passed to the API.
+ *   - Looks at `src/remediation/runbooks/*.{ts,js}` ONLY. All other paths
+ *     pass through.
+ *
+ * Decision tree (short-circuits on first failure):
+ *   1. Runbook has no `__proposalDerivedFrom` const → pass through.
+ *   2. Runbook declares `__proposalDerivedFrom = '<id>'` but no proposal JSON
+ *      exists at `.instar/remediation/proposals-*\/<id>.json` → BLOCK
+ *      (`proposal-not-found`).
+ *   3. Runbook has `__proposalDerivedFrom` but no matching
+ *      `__producingAgentId` const → BLOCK (`missing-producing-agent-id`).
+ *   4. Proposal JSON's `producingAgentId` differs from the runbook's
+ *      `__producingAgentId` → BLOCK (`producing-agent-id-mismatch`).
+ *   5. Proposal carries a `producingAgentIdSignature` field whose Ed25519
+ *      signature does not verify against the bundled public key at
+ *      `.instar/remediation/agent-pubkeys/<agentId>.pem` → BLOCK
+ *      (`signature-verify-failed`).
+ *      (If the pubkey file is absent, the gate defers to C-1's pre-merge
+ *      check rather than block — proposal-pubkey distribution is fleet
+ *      infrastructure that may post-date this commit. Other fields are
+ *      still validated.)
+ *
+ * Why commit-time AND PR-merge-time?
+ *   The CI gate (C-1) is the authoritative check. This S-3 gate catches
+ *   author mistakes BEFORE a PR is pushed — runbook source that names a
+ *   non-existent proposal, source emitted without the producing-agent-id
+ *   annotation, etc. The check is fast, local, and pure-Node.
+ *
+ * Pure Node, zero deps beyond `node:crypto` / `node:fs` / `node:path`.
+ *
+ * CLI:
+ *   node skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs \
+ *       --files src/remediation/runbooks/foo.ts,src/remediation/runbooks/bar.ts
+ *
+ *   Exit 0 — pass (no proposal-derived runbooks, or all checks passed).
+ *   Exit 1 — block; reason printed to stderr.
+ *
+ * API:
+ *   import { verifyProposalDerivedRunbooks } from './verify-proposal-derived-runbook.mjs';
+ *   const result = verifyProposalDerivedRunbooks({
+ *     repoRoot: '/path/to/repo',
+ *     files: ['src/remediation/runbooks/foo.ts', ...],
+ *   });
+ *   // → { ok: true, reason: '...' } | { ok: false, reason: '...', file?: string }
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const RUNBOOK_PATH_PREFIX = 'src/remediation/runbooks/';
+const PROPOSAL_MARKER = '__proposalDerivedFrom';
+const AGENT_ID_MARKER = '__producingAgentId';
+
+const PROPOSAL_ID_RE = new RegExp(
+  `(?:const|let|var|export\\s+const|export\\s+let|export\\s+var)\\s+${PROPOSAL_MARKER}\\s*=\\s*['"\`]([^'"\`]+)['"\`]`,
+);
+const AGENT_ID_RE = new RegExp(
+  `(?:const|let|var|export\\s+const|export\\s+let|export\\s+var)\\s+${AGENT_ID_MARKER}\\s*=\\s*['"\`]([^'"\`]+)['"\`]`,
+);
+
+/**
+ * Extract the proposalId and producingAgentId (if any) from a runbook
+ * source file. Returns null when the file isn't proposal-derived.
+ */
+export function inspectRunbook(repoRoot, relPath) {
+  const abs = path.join(repoRoot, relPath);
+  let content;
+  try {
+    content = fs.readFileSync(abs, 'utf8');
+  } catch {
+    return null;
+  }
+  const propMatch = content.match(PROPOSAL_ID_RE);
+  if (!propMatch) return null;
+  const agentMatch = content.match(AGENT_ID_RE);
+  return {
+    file: relPath,
+    proposalId: propMatch[1],
+    producingAgentId: agentMatch ? agentMatch[1] : null,
+  };
+}
+
+/**
+ * Find the on-disk proposal JSON for a given proposalId. Per A14, proposals
+ * live at `.instar/remediation/proposals-<machineId>/<proposalId>.json`.
+ * Machine IDs are not known a priori at gate time, so we scan all
+ * `proposals-*` directories. Returns the parsed JSON + the on-disk path,
+ * or null when no proposal file is found.
+ */
+export function findProposalJson(repoRoot, proposalId) {
+  const baseDir = path.join(repoRoot, '.instar/remediation');
+  let entries;
+  try {
+    entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!entry.name.startsWith('proposals-')) continue;
+    const candidate = path.join(baseDir, entry.name, `${proposalId}.json`);
+    if (fs.existsSync(candidate)) {
+      try {
+        const raw = fs.readFileSync(candidate, 'utf8');
+        const parsed = JSON.parse(raw);
+        return { proposal: parsed, path: candidate, machineDir: entry.name };
+      } catch {
+        // Malformed JSON — treat as not-found; the C-1 CI gate will reject
+        // on its own pull-path. Authors should reproduce the proposal.
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Verify the Ed25519 signature on a proposal's producingAgentId field.
+ * The signature covers the canonical payload:
+ *   `proposalId=<id>\nproducingAgentId=<agentId>\nemittedAt=<iso>`
+ * (declared order; only the three fields the signature binds).
+ *
+ * Returns:
+ *   - 'ok' — signature verified
+ *   - 'no-signature' — proposal has no signature field (caller decides)
+ *   - 'no-pubkey' — bundled pubkey file is absent (caller defers to CI)
+ *   - 'invalid' — signature does not verify
+ */
+export function verifyProposalSignature(repoRoot, proposal) {
+  const sigB64 = proposal.producingAgentIdSignature;
+  if (!sigB64) return 'no-signature';
+  const agentId = proposal.producingAgentId;
+  if (!agentId) return 'invalid';
+
+  const pubkeyPath = path.join(
+    repoRoot,
+    '.instar/remediation/agent-pubkeys',
+    `${sanitizeAgentId(agentId)}.pem`,
+  );
+  if (!fs.existsSync(pubkeyPath)) {
+    return 'no-pubkey';
+  }
+  let pem;
+  try {
+    pem = fs.readFileSync(pubkeyPath, 'utf8');
+  } catch {
+    return 'no-pubkey';
+  }
+  if (!pem.includes('BEGIN PUBLIC KEY')) return 'no-pubkey';
+
+  let pubKey;
+  try {
+    pubKey = crypto.createPublicKey(pem);
+  } catch {
+    return 'invalid';
+  }
+
+  const canonical = [
+    `proposalId=${proposal.proposalId ?? ''}`,
+    `producingAgentId=${agentId}`,
+    `emittedAt=${proposal.emittedAt ?? ''}`,
+  ].join('\n');
+
+  let sigBuf;
+  try {
+    sigBuf = Buffer.from(sigB64, 'base64');
+  } catch {
+    return 'invalid';
+  }
+  try {
+    const ok = crypto.verify(null, Buffer.from(canonical, 'utf8'), pubKey, sigBuf);
+    return ok ? 'ok' : 'invalid';
+  } catch {
+    return 'invalid';
+  }
+}
+
+function sanitizeAgentId(agentId) {
+  // Defensive: agent IDs are typed but we're touching the filesystem.
+  // Strip anything that isn't an alphanumeric, dash, underscore, dot.
+  return String(agentId).replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/**
+ * Main entry. Iterates the file list, short-circuits on first failure.
+ */
+export function verifyProposalDerivedRunbooks(input) {
+  const { repoRoot, files = [] } = input;
+
+  for (const rel of files) {
+    if (!rel.startsWith(RUNBOOK_PATH_PREFIX)) continue;
+    if (!rel.endsWith('.ts') && !rel.endsWith('.js')) continue;
+
+    const inspection = inspectRunbook(repoRoot, rel);
+    if (!inspection) continue; // Not proposal-derived — pass through.
+
+    // Check 1: producing-agent-id annotation present?
+    if (!inspection.producingAgentId) {
+      return {
+        ok: false,
+        reason: `missing-producing-agent-id: runbook ${rel} declares ${PROPOSAL_MARKER}='${inspection.proposalId}' but no ${AGENT_ID_MARKER} const. The proposal pipeline must emit both consts together.`,
+        file: rel,
+      };
+    }
+
+    // Check 2: proposal JSON exists?
+    const found = findProposalJson(repoRoot, inspection.proposalId);
+    if (!found) {
+      return {
+        ok: false,
+        reason: `proposal-not-found: runbook ${rel} claims derivation from proposal '${inspection.proposalId}', but no matching .instar/remediation/proposals-*/${inspection.proposalId}.json exists in this checkout. Either the proposal was deleted, or this runbook is fabricating a proposal reference.`,
+        file: rel,
+      };
+    }
+
+    // Check 3: producing-agent-id matches between proposal + runbook?
+    const proposalAgent = found.proposal.producingAgentId;
+    if (!proposalAgent) {
+      return {
+        ok: false,
+        reason: `proposal-missing-agent-id: proposal '${inspection.proposalId}' (at ${path.relative(repoRoot, found.path)}) has no producingAgentId field. Proposals must record which agent emitted them.`,
+        file: rel,
+      };
+    }
+    if (proposalAgent !== inspection.producingAgentId) {
+      return {
+        ok: false,
+        reason: `producing-agent-id-mismatch: runbook ${rel} declares ${AGENT_ID_MARKER}='${inspection.producingAgentId}' but proposal '${inspection.proposalId}' was emitted by '${proposalAgent}'.`,
+        file: rel,
+      };
+    }
+
+    // Check 4: proposal signature verifies?
+    const sigResult = verifyProposalSignature(repoRoot, found.proposal);
+    if (sigResult === 'invalid') {
+      return {
+        ok: false,
+        reason: `signature-verify-failed: proposal '${inspection.proposalId}' carries a producingAgentIdSignature that does not verify against the bundled pubkey for agent '${proposalAgent}'.`,
+        file: rel,
+      };
+    }
+    // 'ok', 'no-signature', 'no-pubkey' all pass at commit-time:
+    //   • 'ok' — strict pass.
+    //   • 'no-signature' — proposal pipeline pre-dates signing; C-1 will
+    //      enforce at PR-merge time once the proposal pipeline lands.
+    //   • 'no-pubkey' — pubkey distribution is post-S-3 infrastructure;
+    //      C-1 has fleet-wide visibility we lack here.
+  }
+
+  return { ok: true, reason: 'no-proposal-derived-runbooks-or-all-verified' };
+}
+
+// ─── CLI ────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { files: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--files') {
+      const val = argv[++i];
+      if (val) args.files = val.split(',').map((s) => s.trim()).filter(Boolean);
+    } else if (a.startsWith('--files=')) {
+      args.files = a.slice('--files='.length).split(',').map((s) => s.trim()).filter(Boolean);
+    } else if (a === '--repo-root') {
+      args.repoRoot = argv[++i];
+    } else if (a.startsWith('--repo-root=')) {
+      args.repoRoot = a.slice('--repo-root='.length);
+    }
+  }
+  return args;
+}
+
+const isMain = (() => {
+  try {
+    const here = fileURLToPath(import.meta.url);
+    const argv1 = process.argv[1] ? path.resolve(process.argv[1]) : '';
+    return here === argv1;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = args.repoRoot ? path.resolve(args.repoRoot) : process.cwd();
+  if (args.files.length === 0) {
+    // No files passed — nothing to check.
+    console.log('[promotion-gate] PASS: no files provided');
+    process.exit(0);
+  }
+  const result = verifyProposalDerivedRunbooks({ repoRoot, files: args.files });
+  if (result.ok) {
+    console.log(`[promotion-gate] PASS: ${result.reason}`);
+    process.exit(0);
+  }
+  console.error('');
+  console.error('╔════════════════════════════════════════════════════════════════════╗');
+  console.error('║  /instar-dev promotion-gate — commit BLOCKED                       ║');
+  console.error('╚════════════════════════════════════════════════════════════════════╝');
+  console.error('');
+  console.error(`Reason: ${result.reason}`);
+  if (result.file) console.error(`File:   ${result.file}`);
+  console.error('');
+  console.error('See SELF-HEALING-REMEDIATOR-V2-SPEC.md §A11, §A22, §A32 for the gate rationale.');
+  console.error('');
+  process.exit(1);
+}

--- a/tests/unit/verify-proposal-derived-runbook.test.ts
+++ b/tests/unit/verify-proposal-derived-runbook.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Unit tests for the S-3 commit-time promotion gate
+ * (`skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs`).
+ *
+ * Covers SELF-HEALING-REMEDIATOR-V2-SPEC §A11, §A22, §A32, §A41, §A48,
+ * §A57 Tier-3 (S-3).
+ *
+ * Strategy: pure-Node fs scaffolding in an OS tmpdir, real Ed25519
+ * keypairs generated in-test, ESM dynamic import of the script. No
+ * shell-out, no git invocation — the gate operates on a file list, so
+ * the test injects file lists directly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const MOD_REL = '../../skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs';
+
+type Verifier = (input: { repoRoot: string; files: string[] }) => {
+  ok: boolean;
+  reason?: string;
+  file?: string;
+};
+
+let verifyProposalDerivedRunbooks: Verifier;
+
+beforeEach(async () => {
+  const mod = await import(MOD_REL);
+  verifyProposalDerivedRunbooks = mod.verifyProposalDerivedRunbooks;
+});
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Helpers
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function makeTmpRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'promotion-gate-test-'));
+  fs.mkdirSync(path.join(dir, 'src/remediation/runbooks'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.instar/remediation'), { recursive: true });
+  return dir;
+}
+
+interface RunbookOpts {
+  proposalId?: string;
+  producingAgentId?: string;
+}
+
+function writeRunbook(repoRoot: string, name: string, opts: RunbookOpts = {}): string {
+  const rel = `src/remediation/runbooks/${name}.ts`;
+  const lines: string[] = [];
+  if (opts.proposalId) {
+    lines.push(`export const __proposalDerivedFrom = '${opts.proposalId}';`);
+  }
+  if (opts.producingAgentId) {
+    lines.push(`export const __producingAgentId = '${opts.producingAgentId}';`);
+  }
+  lines.push('export const runbook = { id: "test" };');
+  fs.writeFileSync(path.join(repoRoot, rel), lines.join('\n'));
+  return rel;
+}
+
+interface ProposalOpts {
+  proposalId: string;
+  producingAgentId: string;
+  emittedAt?: string;
+  privateKey?: crypto.KeyObject; // when present, signs the canonical payload
+  forceSignature?: string; // override the signature with a bad one
+}
+
+function writeProposal(
+  repoRoot: string,
+  machineId: string,
+  opts: ProposalOpts,
+): string {
+  const dir = path.join(repoRoot, `.instar/remediation/proposals-${machineId}`);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const emittedAt = opts.emittedAt ?? '2026-05-13T18:00:00.000Z';
+  const proposal: Record<string, unknown> = {
+    proposalId: opts.proposalId,
+    producingAgentId: opts.producingAgentId,
+    emittedAt,
+    clusterSignature: 'sig-abc',
+    fleetScope: 'machine',
+  };
+
+  let signature: string | undefined;
+  if (opts.privateKey) {
+    const canonical = [
+      `proposalId=${opts.proposalId}`,
+      `producingAgentId=${opts.producingAgentId}`,
+      `emittedAt=${emittedAt}`,
+    ].join('\n');
+    signature = crypto.sign(null, Buffer.from(canonical, 'utf8'), opts.privateKey).toString('base64');
+  }
+  if (opts.forceSignature !== undefined) {
+    signature = opts.forceSignature;
+  }
+  if (signature !== undefined) {
+    proposal.producingAgentIdSignature = signature;
+  }
+
+  const filePath = path.join(dir, `${opts.proposalId}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(proposal, null, 2));
+  return filePath;
+}
+
+function writePubkey(repoRoot: string, agentId: string, publicKey: crypto.KeyObject): void {
+  const dir = path.join(repoRoot, '.instar/remediation/agent-pubkeys');
+  fs.mkdirSync(dir, { recursive: true });
+  const pem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+  fs.writeFileSync(path.join(dir, `${agentId}.pem`), pem);
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Cases
+ * ──────────────────────────────────────────────────────────────────────── */
+
+describe('verifyProposalDerivedRunbooks — S-3 commit-time promotion gate', () => {
+  let repoRoot: string;
+
+  beforeEach(() => {
+    repoRoot = makeTmpRepo();
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(repoRoot, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/verify-proposal-derived-runbook.test.ts:afterEach',
+    });
+  });
+
+  it('1. runbook without __proposalDerivedFrom → passes through', () => {
+    const rel = writeRunbook(repoRoot, 'plain-runbook'); // no consts
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(true);
+    expect(r.reason).toMatch(/no-proposal-derived-runbooks-or-all-verified/);
+  });
+
+  it('2. runbook with __proposalDerivedFrom matching existing proposal + agent id → passes', () => {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+    const proposalId = 'prop-aaa';
+    const agentId = 'echo';
+    writeProposal(repoRoot, 'machine-1', { proposalId, producingAgentId: agentId, privateKey });
+    writePubkey(repoRoot, agentId, publicKey);
+    const rel = writeRunbook(repoRoot, 'derived-ok', {
+      proposalId,
+      producingAgentId: agentId,
+    });
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(true);
+  });
+
+  it('3. runbook with __proposalDerivedFrom but no __producingAgentId → fails', () => {
+    const proposalId = 'prop-bbb';
+    writeProposal(repoRoot, 'machine-1', { proposalId, producingAgentId: 'echo' });
+    const rel = writeRunbook(repoRoot, 'no-agent-id', { proposalId });
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/missing-producing-agent-id/);
+    expect(r.file).toBe(rel);
+  });
+
+  it('4. runbook with __proposalDerivedFrom pointing to non-existent proposal → fails', () => {
+    const rel = writeRunbook(repoRoot, 'phantom-proposal', {
+      proposalId: 'prop-ghost',
+      producingAgentId: 'echo',
+    });
+    // No proposal JSON written.
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/proposal-not-found/);
+    expect(r.file).toBe(rel);
+  });
+
+  it('5. runbook with __producingAgentId whose signature doesn\'t verify against the proposal → fails', () => {
+    const { privateKey: wrongKey } = crypto.generateKeyPairSync('ed25519');
+    const { publicKey: realPub } = crypto.generateKeyPairSync('ed25519');
+    const proposalId = 'prop-ccc';
+    const agentId = 'echo';
+    // Sign the canonical payload with WRONG key — pubkey on disk won't verify.
+    writeProposal(repoRoot, 'machine-1', {
+      proposalId,
+      producingAgentId: agentId,
+      privateKey: wrongKey,
+    });
+    writePubkey(repoRoot, agentId, realPub);
+    const rel = writeRunbook(repoRoot, 'bad-sig', {
+      proposalId,
+      producingAgentId: agentId,
+    });
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/signature-verify-failed/);
+    expect(r.file).toBe(rel);
+  });
+
+  it('6. multiple runbooks, first proposal-derived failure short-circuits', () => {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+    const proposalIdOk = 'prop-good';
+    const agentId = 'echo';
+    writeProposal(repoRoot, 'machine-1', {
+      proposalId: proposalIdOk,
+      producingAgentId: agentId,
+      privateKey,
+    });
+    writePubkey(repoRoot, agentId, publicKey);
+
+    const passingRel = writeRunbook(repoRoot, 'ok-one', {
+      proposalId: proposalIdOk,
+      producingAgentId: agentId,
+    });
+    const failingRel = writeRunbook(repoRoot, 'bad-two', {
+      proposalId: 'prop-missing',
+      producingAgentId: agentId,
+    });
+    const trailingRel = writeRunbook(repoRoot, 'never-checked'); // would pass
+
+    const r = verifyProposalDerivedRunbooks({
+      repoRoot,
+      files: [passingRel, failingRel, trailingRel],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/proposal-not-found/);
+    expect(r.file).toBe(failingRel);
+  });
+
+  it('producing-agent-id mismatch between runbook and proposal → fails', () => {
+    const proposalId = 'prop-mismatch';
+    writeProposal(repoRoot, 'machine-1', {
+      proposalId,
+      producingAgentId: 'echo',
+    });
+    const rel = writeRunbook(repoRoot, 'mismatch', {
+      proposalId,
+      producingAgentId: 'imposter',
+    });
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/producing-agent-id-mismatch/);
+  });
+
+  it('proposal exists but lacks producingAgentId field → fails', () => {
+    const proposalId = 'prop-no-agent';
+    // Write proposal JSON manually without producingAgentId.
+    const dir = path.join(repoRoot, '.instar/remediation/proposals-machine-1');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `${proposalId}.json`),
+      JSON.stringify({ proposalId, emittedAt: '2026-05-13T18:00:00.000Z' }, null, 2),
+    );
+    const rel = writeRunbook(repoRoot, 'agent-missing-in-proposal', {
+      proposalId,
+      producingAgentId: 'echo',
+    });
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/proposal-missing-agent-id/);
+  });
+
+  it('no-pubkey on disk → passes (defers to CI gate) even when signature is present', () => {
+    const { privateKey } = crypto.generateKeyPairSync('ed25519');
+    const proposalId = 'prop-no-pubkey';
+    const agentId = 'echo';
+    writeProposal(repoRoot, 'machine-1', {
+      proposalId,
+      producingAgentId: agentId,
+      privateKey,
+    });
+    // NO pubkey written.
+    const rel = writeRunbook(repoRoot, 'no-pubkey', {
+      proposalId,
+      producingAgentId: agentId,
+    });
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(true);
+  });
+
+  it('proposal without signature field → passes (signature is optional at commit-time)', () => {
+    const proposalId = 'prop-unsigned';
+    const agentId = 'echo';
+    writeProposal(repoRoot, 'machine-1', {
+      proposalId,
+      producingAgentId: agentId,
+    });
+    const rel = writeRunbook(repoRoot, 'unsigned', {
+      proposalId,
+      producingAgentId: agentId,
+    });
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(true);
+  });
+
+  it('non-runbook paths in file list are ignored', () => {
+    const rel = writeRunbook(repoRoot, 'ok-one'); // plain
+    const r = verifyProposalDerivedRunbooks({
+      repoRoot,
+      files: [rel, 'src/server/foo.ts', 'docs/README.md', 'scripts/bar.js'],
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('proposal stored under a different machineId directory still resolves', () => {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+    const proposalId = 'prop-other-machine';
+    const agentId = 'echo';
+    // Two unrelated proposal dirs to confirm scanning works.
+    fs.mkdirSync(path.join(repoRoot, '.instar/remediation/proposals-unused-machine'), { recursive: true });
+    writeProposal(repoRoot, 'second-machine-xyz', {
+      proposalId,
+      producingAgentId: agentId,
+      privateKey,
+    });
+    writePubkey(repoRoot, agentId, publicKey);
+    const rel = writeRunbook(repoRoot, 'cross-machine', {
+      proposalId,
+      producingAgentId: agentId,
+    });
+
+    const r = verifyProposalDerivedRunbooks({ repoRoot, files: [rel] });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,28 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Ships S-3 of Tier-3 from the self-healing remediator spec — the **commit-time** half of the promotion gate that pairs with the **PR-merge-time** half shipped in C-1 (PR #204).
+
+A "proposal-derived runbook" is a runbook source file that the SystemReviewer's clustering pipeline (Tier-3 S-1, not yet shipped) emits when it spots a repeating failure pattern that warrants a new automated remediation. Those files carry two special markers: `__proposalDerivedFrom = '<proposalId>'` and `__producingAgentId = '<agentId>'`. Before this release, nothing checked those markers locally — the only enforcement happened in CI at PR review.
+
+This release adds a second check at commit time, inside the `/instar-dev` skill's pre-commit hook:
+
+- If you stage a runbook source under `src/remediation/runbooks/` that carries `__proposalDerivedFrom`, the hook reads the proposal JSON at `.instar/remediation/proposals-<machineId>/<proposalId>.json`, verifies the agent IDs match, and (if a signature and pubkey are present) verifies the Ed25519 signature.
+- If anything is missing or mismatched, the commit is refused with a structured message pointing at the proposal pipeline as the responsible surface.
+- Runbooks without the markers — every runbook on main today — pass through with no work.
+
+This catches author mistakes before a PR is pushed. The CI gate (C-1) remains the authoritative check at PR-merge time because only CI can verify signing identity for the different-principal rule.
+
+## What to Tell Your User
+
+No behavior change for users. This is a developer-side guardrail that prevents a malformed runbook from being committed in the first place. The user-visible promotion flow (proposal review and approval via the dashboard or Telegram) still works the same way.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Commit-time promotion gate for proposal-derived runbooks | Automatic; runs inside `/instar-dev` pre-commit |
+| `verify-proposal-derived-runbook.mjs` CLI | `node skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs --files <csv>` |

--- a/upgrades/side-effects/s3-promotion-gate.md
+++ b/upgrades/side-effects/s3-promotion-gate.md
@@ -1,0 +1,111 @@
+# Side-Effects Review — S-3: Commit-time promotion gate for proposal-derived runbooks
+
+**Version / slug:** `s3-promotion-gate`
+**Date:** `2026-05-16`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Ships S-3 of Tier-3 from `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` — the **commit-time** promotion gate that pairs with C-1's PR-merge-time CI gate.
+
+Per A11 / A22 / A32 / A41 / A48 / A57 Tier-3, when the `/instar-dev` skill commits a runbook source file under `src/remediation/runbooks/*.{ts,js}` that declares `__proposalDerivedFrom = '<proposalId>'`, the commit MUST:
+
+1. Carry a matching `__producingAgentId = '<agentId>'` const in the same source file.
+2. Reference a proposal that exists at `.instar/remediation/proposals-<machineId>/<proposalId>.json` in the current checkout.
+3. Have a proposal whose `producingAgentId` field matches the runbook's `__producingAgentId` annotation.
+4. (When pubkey is bundled and proposal carries a signature) verify the proposal's `producingAgentIdSignature` against `.instar/remediation/agent-pubkeys/<agentId>.pem`.
+
+Otherwise the pre-commit hook refuses the commit with a structured error.
+
+The gate is **additive** — runbook source files without `__proposalDerivedFrom` (i.e., the existing hand-authored runbooks W-1..W-7) pass through with zero work. Files outside `src/remediation/runbooks/` are not inspected.
+
+This is the **commit-time** half. C-1 (shipped in PR #204, SHA `780b2659`) is the **PR-merge-time** half — it adds different-principal verification (GPG/sigstore OR Telegram countersignature) at PR review. Both are required per spec: this catches author mistakes before the PR is pushed; C-1 is authoritative because it has fleet-wide visibility.
+
+Files touched:
+- `skills/instar-dev/scripts/verify-proposal-derived-runbook.mjs` (new) — pure-Node verifier (no deps beyond `node:crypto`/`node:fs`/`node:path`). Exports `verifyProposalDerivedRunbooks`, `inspectRunbook`, `findProposalJson`, `verifyProposalSignature`. CLI mode at `--files <csv>`.
+- `scripts/instar-dev-precommit.js` — adds Step 8 calling the verifier on the staged file list. Existing Steps 0–7 (merge skip, staged inspect, classify, bootstrap, fresh-trace, trace validation, spec tags, ELI16) unchanged.
+- `skills/instar-dev/SKILL.md` — Phase 0 documentation extended with the new gate's preconditions.
+- `tests/unit/verify-proposal-derived-runbook.test.ts` (new) — 12 cases covering the 6 spec scenarios plus edge cases.
+- `upgrades/NEXT.md` — S-3 entry appended; existing release-notes preserved.
+
+## Decision-point inventory
+
+- `inspectRunbook(repoRoot, relPath)` — **add** — reads each touched runbook source, regex-detects `__proposalDerivedFrom` and `__producingAgentId` consts. Pure structural detection (single regex per marker). Not a content classifier; it does not parse arbitrary TypeScript.
+- `findProposalJson(repoRoot, proposalId)` — **add** — scans `.instar/remediation/proposals-*` directories for `<proposalId>.json`. Reads via `fs.readdirSync` + `fs.existsSync` to avoid pulling unrelated history (A48). Malformed JSON treated as not-found.
+- `verifyProposalSignature(repoRoot, proposal)` — **add** — Ed25519 verify over canonical `proposalId=...\nproducingAgentId=...\nemittedAt=...` payload. Returns `'ok' | 'no-signature' | 'no-pubkey' | 'invalid'`. Only `'invalid'` blocks the commit; `'no-signature'` and `'no-pubkey'` defer to C-1 (proposal pipeline and pubkey distribution are downstream infra).
+- `verifyProposalDerivedRunbooks({repoRoot, files})` — **add** — top-level decision tree: filter to runbook source paths → inspect each → presence checks → proposal lookup → agent-id match → signature verify. Short-circuits on first failure.
+- `scripts/instar-dev-precommit.js` Step 8 — **add** — calls the verifier on the full staged file list (not just `inScopeFiles`, because runbooks under `src/remediation/runbooks/` are already in scope; passing the full list is a no-op for non-runbook files).
+- `SKILL.md` Phase 0 — **extend** — documents the new gate's preconditions so the agent knows the contract before producing a runbook.
+
+## Over-block / under-block analysis
+
+**Under-block risks (false PASS):**
+- An author hand-writes `__proposalDerivedFrom = 'real-proposal'` + `__producingAgentId = 'self'` matching a legitimate-on-disk proposal that they themselves authored. The S-3 gate passes (the proposal exists, IDs match). The defense-in-depth is C-1: at PR-merge time the different-principal check refuses a PR whose signing identity matches the proposal's `producingAgentId`. This is the spec-intended layering — S-3 catches typos; C-1 catches collusion.
+- A proposal without a `producingAgentIdSignature` field passes the signature step. This is by design — early proposals predate signing infra; the C-1 CI gate will surface this at PR time once the proposal pipeline lands (Tier-3 S-1).
+- A proposal with a signature but no bundled pubkey at `.instar/remediation/agent-pubkeys/<agentId>.pem` passes locally. Pubkey distribution is fleet infrastructure that ships separately; C-1 has the authoritative pubkey set.
+
+**Over-block risks (false BLOCK):**
+- A hand-authored runbook (W-1..W-7) that gains a `__proposalDerivedFrom` annotation in the future without a matching proposal would block at commit-time. Mitigation: the annotation is only ever emitted by the SystemReviewer proposal pipeline (S-1, not yet shipped). Hand-authored runbooks never carry the const.
+- Renaming or relocating proposals (e.g., archival to `proposals-archived-<machineId>/` per the spec's rollback line 5) would orphan the runbook reference. Mitigation: archival happens during nuclear uninstall only; runbook source is also archived in the same rollback step.
+- File-encoding edge cases (BOMs, CRLF, unusual quoting) could make the regex miss the const. Mitigation: the regex tolerates single/double/backtick quoting and any of `const|let|var` with optional `export`; tests pin the byte shape.
+
+**Bootstrap exception not needed.** The existing `BOOTSTRAP_TRIGGERS` list (`scripts/instar-dev-precommit.js:105`) covers the precommit script's own first-ship and `/spec-converge`. The new gate is additive — staged files with no `__proposalDerivedFrom` (which includes everything in this S-3 PR) pass through harmlessly.
+
+## Level-of-abstraction fit
+
+- The verifier sits in `skills/instar-dev/scripts/` because it is part of the `/instar-dev` skill's enforcement surface — it has no caller outside the precommit hook. Co-locating it with `write-trace.mjs` keeps the skill's structural pieces together.
+- The precommit hook adds Step 8 (after spec-tag + ELI16 checks) because the proposal-derivation check is the most expensive (fs scan of `.instar/remediation/proposals-*`). Running it last means cheap structural checks reject first.
+- C-1 lives in CI because PR-merge-time needs different-principal verification (commit signing identity), which only the CI environment can determine authoritatively. S-3 doesn't need that — it only verifies the runbook + proposal shape.
+
+## Signal vs authority compliance
+
+- The verifier is a **signal-producer with structural authority** — it makes a deterministic, byte-level structural check (regex match + JSON parse + Ed25519 verify), not a content judgment. Signal-vs-authority's "brittle filters don't get blocking authority" rule is for content classifiers (NLP, heuristics). Structural pre-commit gates are the canonical pattern for authority bound to verifiable invariants — same shape as the existing spec-tag and ELI16 checks.
+- The "intelligent gate" layer above this is the user reviewing the side-effects artifact and PR diff. The structural gate ensures runbook source carries the metadata the intelligent gate needs to make its decision.
+
+## Interactions
+
+- **Existing precommit Steps 0–7:** the new Step 8 runs AFTER trace validation, AFTER spec-tag verification, AFTER ELI16. It uses `staged` (not `inScopeFiles`) because runbooks under `src/remediation/runbooks/` are already in `inScopeFiles` per `inScope()`; passing `staged` keeps the API caller-agnostic.
+- **C-1 CI gate:** complementary. S-3 verifies the runbook↔proposal binding locally; C-1 verifies signer-identity + Telegram countersignature at PR-merge time. They share the `__proposalDerivedFrom` const as the trigger marker.
+- **F-5 TrustElevationSource (PR #203):** the trust-elevation logic at the API layer decides whether a high-blast-radius runbook may run. S-3 is at a different layer (source-control), so no interaction.
+- **F-7 PostUpdateMigrator + AnnouncementManager (PR #210):** unaffected. Promotion events aren't yet wired into AnnouncementManager (deferred to a follow-up that ships once S-1's proposal pipeline lands).
+- **Bootstrap exception list:** unchanged. The new gate's own first-ship doesn't add a runbook with `__proposalDerivedFrom`, so it passes through Step 8 naturally.
+
+## External surfaces
+
+- New filesystem paths read (none written): `.instar/remediation/proposals-*/<id>.json`, `.instar/remediation/agent-pubkeys/<agentId>.pem`. Both are spec-mandated locations from §A14 / §A20.
+- No new network calls, no new env-var reads, no new IPC.
+- The script is pure-Node ESM — same runtime as the precommit hook. No new runtime dependency.
+- CLI surface: `--files <csv>` + `--repo-root <path>` only. No interactive prompts.
+
+## Rollback cost
+
+If S-3 turns out wrong in production:
+
+- **Hot-fix path:** revert the import in `scripts/instar-dev-precommit.js` (one line). The verifier script and tests can stay; they're inert without the precommit wire-up.
+- **Full revert:** remove the new script, the test file, the SKILL.md addendum, the precommit import + Step 8 block. `git revert` is sufficient; no data migration.
+- **In-flight runbook PRs:** zero impact. The gate is additive; runbooks without `__proposalDerivedFrom` (every runbook on main today) pass through.
+- **No agent-state repair needed.** The gate writes no state.
+
+## Test coverage
+
+`tests/unit/verify-proposal-derived-runbook.test.ts` — 12 cases:
+
+1. Runbook without `__proposalDerivedFrom` → passes through.
+2. Runbook with `__proposalDerivedFrom` matching existing proposal + agent id → passes.
+3. Runbook with `__proposalDerivedFrom` but no `__producingAgentId` → fails.
+4. Runbook with `__proposalDerivedFrom` pointing to non-existent proposal → fails.
+5. Runbook with `__producingAgentId` whose signature doesn't verify → fails.
+6. Multiple runbooks, first failure short-circuits.
+7. Producing-agent-id mismatch between runbook and proposal → fails.
+8. Proposal exists but lacks `producingAgentId` field → fails.
+9. No pubkey on disk → passes (defers to CI gate).
+10. Proposal without signature field → passes (signature optional at commit-time).
+11. Non-runbook paths in file list are ignored.
+12. Proposal stored under a different `machineId` directory still resolves.
+
+Tests use real Ed25519 keypairs (`crypto.generateKeyPairSync`), real fs scaffolding in `os.tmpdir()`, and `SafeFsExecutor.safeRmSync` for teardown.
+
+## Concur or concern
+
+No second-pass required: the change is purely additive, structural, and dual-gated (S-3 here + C-1 in CI). The 12-test suite pins the byte-shape and decision tree.


### PR DESCRIPTION
## Summary

Ships S-3 of Tier-3 from `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` — the **commit-time** half of the proposal-derived runbook promotion gate. Pairs with C-1 (#204, `780b2659`) which shipped the **PR-merge-time** half.

Covers spec amendments §A11, §A22, §A32, §A41, §A48, §A57 Tier-3.

- When `/instar-dev` commits a runbook source under `src/remediation/runbooks/` carrying `__proposalDerivedFrom = '<proposalId>'`, the pre-commit hook verifies:
  - a matching `__producingAgentId = '<agentId>'` const is present in the same source file,
  - the proposal JSON exists at `.instar/remediation/proposals-<machineId>/<proposalId>.json`,
  - the proposal's `producingAgentId` matches the runbook's annotation,
  - when a `producingAgentIdSignature` is present and the corresponding pubkey is bundled at `.instar/remediation/agent-pubkeys/<agentId>.pem`, the Ed25519 signature verifies.
- Failures short-circuit with a structured error. Runbooks without the markers (every runbook on main today) pass through with zero work.

Pure-Node ESM, no new deps. The commit-time gate catches author mistakes before a PR is pushed; C-1's CI gate remains the authoritative check at PR-merge time because only CI has the signing-identity visibility the different-principal rule requires.

## Test plan

- [x] `tests/unit/verify-proposal-derived-runbook.test.ts` — 12 cases covering the 6 spec scenarios plus edge cases (signature deferral when pubkey absent, multi-machine proposal dirs, file-list short-circuit, non-runbook paths ignored, mismatched agent IDs)
- [x] Local pre-commit gate passes on this PR (S-3's own files don't trigger the new check because they carry no `__proposalDerivedFrom` const)
- [ ] CI green

## Side-effects review

`upgrades/side-effects/s3-promotion-gate.md` — comprehensive review covering over/under-block, level-of-abstraction fit, signal-vs-authority compliance, interactions with C-1 / F-5 / F-7, external surfaces, and rollback cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)