### PR TITLE
fix(sessions): preempt paste-end Enter race with belt-and-suspenders double-Enter

### DIFF
--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -1999,7 +1999,18 @@ rm()  { "${shimRunner}" rm  "$@"; }
           // sequence and buffer the content before Enter can submit it.
           // 500ms is conservative but prevents the "[Pasted text #1]" stuck state.
           execFileSync('/bin/sleep', ['0.5'], { timeout: 2000 });
-          // Send Enter to submit
+          // Send Enter to submit.
+          // Belt-and-suspenders: on Claude Code v2.1.105+ the first Enter is
+          // occasionally eaten by the same race that's still consuming the
+          // paste-end (\e[201~) sequence. Sending a second Enter after a brief
+          // gap closes that race preemptively. If the first Enter submitted
+          // successfully, the second arrives at an empty input prompt and is a
+          // no-op in the Claude Code TUI. verifyInjection remains as the
+          // last-resort safety net for the rare case both Enters miss.
+          execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, 'Enter'], {
+            encoding: 'utf-8', timeout: 5000,
+          });
+          execFileSync('/bin/sleep', ['0.1'], { timeout: 2000 });
           execFileSync(this.config.tmuxPath, ['send-keys', '-t', exactTarget, 'Enter'], {
             encoding: 'utf-8', timeout: 5000,
           });
@@ -2052,6 +2063,10 @@ rm()  { "${shimRunner}" rm  "$@"; }
    * bracketed-paste-end is occasionally eaten by a race with the paste-end
    * sequence — and the recovery Enter can be eaten by the same race. Single-
    * shot verification leaves the user stuck when recovery also misses.
+   *
+   * The injection primary path already sends a belt-and-suspenders double-Enter
+   * (see rawInject), which collapses the race in the common case. This method
+   * remains as the last-resort safety net for the rare case both Enters miss.
    *
    * Polls at 500/1500/3500/6500ms from injection (markerCheckSchedule),
    * stops as soon as the marker is no longer at ❯, and escalates the

--- a/tests/unit/SessionManager-injection.test.ts
+++ b/tests/unit/SessionManager-injection.test.ts
@@ -85,3 +85,35 @@ describe('SessionManager — cleanupStaleSessions hard cap', () => {
     expect(method).toContain('slice(0, completed.length - MAX_COMPLETED)');
   });
 });
+
+describe('SessionManager — paste-end Enter race preemption', () => {
+  it('sends a belt-and-suspenders second Enter after the bracketed paste', () => {
+    const source = fs.readFileSync(SESSION_MANAGER_SRC, 'utf-8');
+    const methodStart = source.indexOf('private rawInject(');
+    const methodEnd = source.indexOf('\n  /**', methodStart + 1);
+    const method = source.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    // Locate the bracketed-paste branch (multi-line text path)
+    const pasteBranch = method.slice(method.indexOf('\\x1b[200~'));
+
+    // The paste-end sequence must be followed by sleep, Enter, brief sleep, Enter.
+    const pasteEndIdx = pasteBranch.indexOf('\\x1b[201~');
+    expect(pasteEndIdx).toBeGreaterThan(-1);
+
+    const tail = pasteBranch.slice(pasteEndIdx);
+    // Two Enter send-keys after paste-end (the primary + the safety Enter)
+    const enterMatches = tail.match(/'send-keys', '-t', exactTarget, 'Enter'/g) ?? [];
+    expect(enterMatches.length).toBeGreaterThanOrEqual(2);
+
+    // A short sleep between the two Enters (closes the race window)
+    expect(tail).toMatch(/sleep['\s,\[]+0\.1/);
+  });
+
+  it('verifyInjection comment acknowledges the primary path now double-Enters', () => {
+    const source = fs.readFileSync(SESSION_MANAGER_SRC, 'utf-8');
+    const docStart = source.indexOf('Verify an injection actually submitted by polling');
+    const docEnd = source.indexOf('private verifyInjection(', docStart);
+    const doc = source.slice(docStart, docEnd);
+    expect(doc).toMatch(/double-Enter|belt-and-suspenders/i);
+  });
+});


### PR DESCRIPTION
## Summary

The Enter after bracketed-paste-end is occasionally eaten by a race with the paste-end (`\e[201~`) sequence on Claude Code v2.1.105+ TUIs. Today this is recovered asynchronously by `verifyInjection`, but in practice the recovery fires routinely (12 events in 48h on one production host) rather than rarely — meaning the "fallback" has become the de-facto primary path.

This adds a preemptive second `Enter` ~100ms after the primary `Enter` in the bracketed-paste branch of `rawInject`. The mechanism:

- If the first `Enter` was eaten by the race → the second submits the input.
- If the first `Enter` succeeded → the second arrives at an empty input prompt and is a no-op in the Claude Code TUI.

`verifyInjection` stays in place as the last-resort safety net for the rare case both Enters miss.

## Test plan

- [x] Added two unit tests in `tests/unit/SessionManager-injection.test.ts`:
  - asserts two `send-keys Enter` calls follow the paste-end sequence
  - asserts the inter-Enter sleep is present (~100ms)
  - asserts the `verifyInjection` doc acknowledges the new primary-path layering
- [x] `npx vitest run tests/unit/SessionManager-injection.test.ts` — 8/8 passing
- [x] Diff is contained to the multi-line bracketed-paste branch — single-line injection path untouched
- [ ] In-the-wild verification on the production host that produced the 12 events (will report back after merge)

## Risk

Low. The second `Enter` is sent ~100ms after the first; if it ever fires when the input box is non-empty, that would be due to a separate ordering bug already present today — and `verifyInjection` would still cover the recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)