### PR TITLE
fix(lifeline): self-heal Telegram.Lifeline degradations on successful send

### DIFF
--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -4085,6 +4085,18 @@ export class TelegramAdapter implements MessagingAdapter {
       throw new Error(`Telegram API returned not ok: ${JSON.stringify(data)}`);
     }
 
+    // Self-heal: a successful send/action to the lifeline topic is positive
+    // proof the lifeline is reachable — clear any stale Telegram.Lifeline
+    // degradation events so they don't linger after recovery.
+    try {
+      const lifelineId = this.config?.lifelineTopicId;
+      const threadId = params?.message_thread_id;
+      const isLifelineMethod = method === 'sendMessage' || method === 'sendChatAction';
+      if (isLifelineMethod && lifelineId != null && threadId === lifelineId) {
+        DegradationReporter.getInstance().clearByFeature('Telegram.Lifeline');
+      }
+    } catch { /* self-heal best-effort */ }
+
     return data.result;
   }
 }

--- a/src/monitoring/DegradationReporter.ts
+++ b/src/monitoring/DegradationReporter.ts
@@ -513,7 +513,8 @@ export class DegradationReporter {
     // Strip parenthetical caveats — the user doesn't need "(no search, no summary updates)"
     fallback = fallback.replace(/\s*\([^)]*\)\s*/g, ' ').trim();
 
-    return `${impact}. Using ${fallback} in the meantime — everything else is working fine.`;
+    const fallbackPhrase = /^using\s/i.test(fallback) ? fallback : `Using ${fallback}`;
+    return `${impact}. ${fallbackPhrase} in the meantime — everything else is working fine.`;
   }
 
   /**
@@ -549,6 +550,45 @@ export class DegradationReporter {
       }
     }
     return flipped;
+  }
+
+  /**
+   * Remove all degradation events for a given feature, both in-memory and on
+   * disk. Returns the number of events cleared.
+   *
+   * Use this when positive proof of recovery makes existing events stale —
+   * for example, a successful Telegram send to the lifeline topic proves the
+   * lifeline is reachable, so any `Telegram.Lifeline` degradation events can
+   * be discarded rather than left to expire on their own.
+   *
+   * Disk persistence is best-effort (same policy as `persistToDisk`): a write
+   * failure is swallowed so the caller is never interrupted by storage errors.
+   */
+  clearByFeature(feature: string): number {
+    const before = this.events.length;
+    this.events = this.events.filter(e => e.feature !== feature);
+    const cleared = before - this.events.length;
+
+    if (cleared > 0) {
+      this.lastAlertTime.delete(feature);
+
+      try {
+        if (this.stateDir) {
+          const filePath = path.join(this.stateDir, 'degradations.json');
+          if (fs.existsSync(filePath)) {
+            const existing = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as DegradationEvent[];
+            const filtered = existing.filter(e => e.feature !== feature);
+            if (filtered.length !== existing.length) {
+              fs.writeFileSync(filePath, JSON.stringify(filtered, null, 2));
+            }
+          }
+        }
+      } catch { /* best-effort */ }
+
+      console.log(`[DEGRADATION] Cleared ${cleared} event(s) for feature: ${feature}`);
+    }
+
+    return cleared;
   }
 
   /**

--- a/tests/unit/degradation-reporter-lifeline-self-heal.test.ts
+++ b/tests/unit/degradation-reporter-lifeline-self-heal.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for the Telegram.Lifeline self-heal pathway.
+ *
+ * Covers two paired files:
+ *  1. DegradationReporter.clearByFeature — new method that removes events
+ *     in-memory and from degradations.json on disk, returning the count cleared.
+ *  2. TelegramAdapter.apiCall — self-heal block calls clearByFeature after a
+ *     successful sendMessage/sendChatAction to lifelineTopicId.
+ *
+ * The static-analysis tests read the TS source as a string so they remain
+ * fast and require no live Telegram credentials. Behavioral tests use the
+ * real DegradationReporter class with a temp directory.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { DegradationReporter } from '../../src/monitoring/DegradationReporter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const DEGRADATION_REPORTER_SRC = path.join(process.cwd(), 'src/monitoring/DegradationReporter.ts');
+const TELEGRAM_ADAPTER_SRC = path.join(process.cwd(), 'src/messaging/TelegramAdapter.ts');
+
+// ── Static analysis: DegradationReporter ─────────────────────────────────────
+
+describe('DegradationReporter — clearByFeature (static analysis)', () => {
+  const src = fs.readFileSync(DEGRADATION_REPORTER_SRC, 'utf-8');
+
+  it('exports a public clearByFeature method with the right signature', () => {
+    expect(src).toMatch(/clearByFeature\(feature:\s*string\):\s*number/);
+  });
+
+  it('filters this.events by feature', () => {
+    const methodStart = src.indexOf('clearByFeature(feature: string)');
+    const methodEnd = src.indexOf('\n  /**', methodStart + 1);
+    const method = src.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    expect(method).toContain('this.events.filter');
+    expect(method).toContain('e.feature !== feature');
+  });
+
+  it('deletes from lastAlertTime when events are cleared', () => {
+    const methodStart = src.indexOf('clearByFeature(feature: string)');
+    const methodEnd = src.indexOf('\n  /**', methodStart + 1);
+    const method = src.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    expect(method).toContain('this.lastAlertTime.delete(feature)');
+  });
+
+  it('persists the filtered array to degradations.json', () => {
+    const methodStart = src.indexOf('clearByFeature(feature: string)');
+    const methodEnd = src.indexOf('\n  /**', methodStart + 1);
+    const method = src.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    expect(method).toContain('degradations.json');
+    expect(method).toContain('fs.writeFileSync');
+    expect(method).toContain('e.feature !== feature');
+  });
+
+  it('returns the count of cleared events', () => {
+    const methodStart = src.indexOf('clearByFeature(feature: string)');
+    const methodEnd = src.indexOf('\n  /**', methodStart + 1);
+    const method = src.slice(methodStart, methodEnd > -1 ? methodEnd : undefined);
+
+    expect(method).toContain('return cleared');
+  });
+
+  it('contains the render dedupe regex that prevents "Using Using ..."', () => {
+    // The narrativeFor static method should check whether the fallback string
+    // already starts with "Using " before prepending it.
+    const narrativeStart = src.indexOf('static narrativeFor(');
+    const narrativeEnd = src.indexOf('\n  /**', narrativeStart + 1);
+    const narrative = src.slice(narrativeStart, narrativeEnd > -1 ? narrativeEnd : undefined);
+
+    expect(narrative).toMatch(/\/\^using\\s\/i\.test/);
+  });
+});
+
+// ── Static analysis: TelegramAdapter ─────────────────────────────────────────
+
+describe('TelegramAdapter — apiCall lifeline self-heal (static analysis)', () => {
+  const src = fs.readFileSync(TELEGRAM_ADAPTER_SRC, 'utf-8');
+
+  it('calls clearByFeature in the apiCall success path', () => {
+    // The call must appear after `if (!data.ok)` and before the final `return data.result`
+    const apiCallStart = src.lastIndexOf('private async apiCall(');
+    const apiCallEnd = src.indexOf('\n}', apiCallStart);
+    const method = src.slice(apiCallStart, apiCallEnd > -1 ? apiCallEnd : undefined);
+
+    expect(method).toContain("clearByFeature('Telegram.Lifeline')");
+  });
+
+  it("only triggers for sendMessage and sendChatAction methods", () => {
+    const apiCallStart = src.lastIndexOf('private async apiCall(');
+    const apiCallEnd = src.indexOf('\n}', apiCallStart);
+    const method = src.slice(apiCallStart, apiCallEnd > -1 ? apiCallEnd : undefined);
+
+    expect(method).toContain("method === 'sendMessage' || method === 'sendChatAction'");
+  });
+
+  it('guards on lifelineTopicId being non-null', () => {
+    const apiCallStart = src.lastIndexOf('private async apiCall(');
+    const apiCallEnd = src.indexOf('\n}', apiCallStart);
+    const method = src.slice(apiCallStart, apiCallEnd > -1 ? apiCallEnd : undefined);
+
+    expect(method).toContain('lifelineId != null');
+  });
+
+  it('checks that the thread ID matches the lifeline topic', () => {
+    const apiCallStart = src.lastIndexOf('private async apiCall(');
+    const apiCallEnd = src.indexOf('\n}', apiCallStart);
+    const method = src.slice(apiCallStart, apiCallEnd > -1 ? apiCallEnd : undefined);
+
+    expect(method).toContain('threadId === lifelineId');
+  });
+
+  it('wraps the self-heal block in try/catch for best-effort semantics', () => {
+    const apiCallStart = src.lastIndexOf('private async apiCall(');
+    const apiCallEnd = src.indexOf('\n}', apiCallStart);
+    const method = src.slice(apiCallStart, apiCallEnd > -1 ? apiCallEnd : undefined);
+
+    expect(method).toMatch(/self-heal best-effort/);
+  });
+
+  it('uses DegradationReporter already imported at top of file (no dynamic import)', () => {
+    // DegradationReporter must be a static import
+    const importSection = src.slice(0, src.indexOf('export class TelegramAdapter'));
+    expect(importSection).toContain("import { DegradationReporter }");
+    // And no dynamic import inside apiCall
+    const apiCallStart = src.lastIndexOf('private async apiCall(');
+    const apiCallEnd = src.indexOf('\n}', apiCallStart);
+    const method = src.slice(apiCallStart, apiCallEnd > -1 ? apiCallEnd : undefined);
+    expect(method).not.toContain('await import(');
+  });
+});
+
+// ── Behavioral: clearByFeature ────────────────────────────────────────────────
+
+describe('DegradationReporter.clearByFeature — behavior', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    DegradationReporter.resetForTesting();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'degradation-clear-'));
+  });
+
+  afterEach(() => {
+    DegradationReporter.resetForTesting();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/degradation-reporter-lifeline-self-heal.test.ts' });
+  });
+
+  it('returns 0 when no events match', () => {
+    const reporter = DegradationReporter.getInstance();
+    reporter.configure({ stateDir: tmpDir, agentName: 'test', instarVersion: '0.0.0' });
+
+    const cleared = reporter.clearByFeature('Telegram.Lifeline');
+    expect(cleared).toBe(0);
+  });
+
+  it('removes matching events from memory and returns count', () => {
+    const reporter = DegradationReporter.getInstance();
+    reporter.configure({ stateDir: tmpDir, agentName: 'test', instarVersion: '0.0.0' });
+
+    reporter.report({
+      feature: 'Telegram.Lifeline',
+      primary: 'Lifeline topic',
+      fallback: 'No fallback available',
+      reason: 'Topic unreachable',
+      impact: 'Lifeline degraded',
+    });
+    reporter.report({
+      feature: 'OtherFeature',
+      primary: 'Something else',
+      fallback: 'Something else fallback',
+      reason: 'Other reason',
+      impact: 'Other impact',
+    });
+
+    expect(reporter.getEvents()).toHaveLength(2);
+
+    const cleared = reporter.clearByFeature('Telegram.Lifeline');
+    expect(cleared).toBe(1);
+    expect(reporter.getEvents()).toHaveLength(1);
+    expect(reporter.getEvents()[0]!.feature).toBe('OtherFeature');
+  });
+
+  it('removes cleared feature events from degradations.json on disk', () => {
+    const reporter = DegradationReporter.getInstance();
+    reporter.configure({ stateDir: tmpDir, agentName: 'test', instarVersion: '0.0.0' });
+
+    reporter.report({
+      feature: 'Telegram.Lifeline',
+      primary: 'Lifeline topic',
+      fallback: 'No fallback available',
+      reason: 'Unreachable',
+      impact: 'Lifeline degraded',
+    });
+
+    const filePath = path.join(tmpDir, 'degradations.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+
+    const before = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Array<{ feature: string }>;
+    expect(before.some(e => e.feature === 'Telegram.Lifeline')).toBe(true);
+
+    reporter.clearByFeature('Telegram.Lifeline');
+
+    const after = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as Array<{ feature: string }>;
+    expect(after.some(e => e.feature === 'Telegram.Lifeline')).toBe(false);
+  });
+
+  it('is idempotent — second clear on the same feature returns 0', () => {
+    const reporter = DegradationReporter.getInstance();
+    reporter.configure({ stateDir: tmpDir, agentName: 'test', instarVersion: '0.0.0' });
+
+    reporter.report({
+      feature: 'Telegram.Lifeline',
+      primary: 'Lifeline topic',
+      fallback: 'No fallback',
+      reason: 'Down',
+      impact: 'Lifeline degraded',
+    });
+
+    reporter.clearByFeature('Telegram.Lifeline');
+    const second = reporter.clearByFeature('Telegram.Lifeline');
+    expect(second).toBe(0);
+  });
+});
+
+// ── narrativeFor dedupe ───────────────────────────────────────────────────────
+
+describe('DegradationReporter.narrativeFor — render dedupe', () => {
+  it('does not prepend "Using" when fallback already starts with "Using"', () => {
+    const narrative = DegradationReporter.narrativeFor({
+      feature: 'Test',
+      primary: 'Primary',
+      fallback: 'Using the backup channel',
+      reason: 'Primary unavailable',
+      impact: 'Slightly delayed delivery',
+      timestamp: new Date().toISOString(),
+      reported: false,
+      alerted: false,
+    });
+
+    expect(narrative).not.toMatch(/using using/i);
+    expect(narrative).toContain('Using the backup channel');
+  });
+
+  it('prepends "Using" when fallback does not start with "Using"', () => {
+    const narrative = DegradationReporter.narrativeFor({
+      feature: 'Test',
+      primary: 'Primary',
+      fallback: 'the backup channel',
+      reason: 'Primary unavailable',
+      impact: 'Slightly delayed delivery',
+      timestamp: new Date().toISOString(),
+      reported: false,
+      alerted: false,
+    });
+
+    expect(narrative).toMatch(/Using the backup channel/);
+  });
+});


### PR DESCRIPTION
## Summary

When the agent successfully sends a message to its configured lifeline topic, that's positive proof the lifeline is reachable. Today `Telegram.Lifeline` degradation events get reported on first failure but never cleared automatically — they sit stale even after the lifeline recovers.

This adds a self-heal pathway:
- `DegradationReporter` gains a public `clearByFeature(feature: string): number` method that removes events in-memory and from `degradations.json` on disk.
- `TelegramAdapter.apiCall` calls `clearByFeature('Telegram.Lifeline')` after a successful `sendMessage`/`sendChatAction` to `lifelineTopicId`.
- Drive-by fix in `DegradationReporter.render`: dedupe leading "Using" so a fallback string that already starts with "Using" doesn't render as "Using Using ...".

## Test plan

- [x] Unit tests assert `clearByFeature` exists, filters events, persists to disk
- [x] Test asserts `TelegramAdapter.apiCall` calls `clearByFeature('Telegram.Lifeline')` in its success path  
- [x] Test asserts the render dedupe regex is present
- [x] `npx tsc --noEmit` — no new errors (9 pre-existing errors remain, all from missing optional deps: js-yaml, @scure/bip39, moltbridge, marked, AgentMdJobLoader implicit any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)