### PR TITLE
fix(telegram): truthful delivery confirmation — save and notify on injection failure

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -906,6 +906,7 @@ function messageToPipeline(msg: Message, topicName?: string): PipelineMessage {
 function wireTelegramRouting(
   telegram: TelegramAdapter,
   sessionManager: SessionManager,
+  stateDir: string,
   quotaTracker?: QuotaTracker,
   topicMemory?: TopicMemory,
   userManager?: UserManager,
@@ -1009,13 +1010,25 @@ function wireTelegramRouting(
         // Use toInjection() — types guarantee sender identity is included in the tag
         const injection = toInjection(pipeline, targetSession);
         console.log(`[telegram→session] Injecting into ${targetSession}: "${text.slice(0, 80)}"`);
-        sessionManager.injectTelegramMessage(
+        const injected = sessionManager.injectTelegramMessage(
           targetSession, topicId, text, pipeline.topicName, pipeline.sender.firstName, pipeline.sender.telegramUserId,
         );
-        // Delivery confirmation — only when WE own polling. When lifeline owns
-        // polling (--no-telegram / standby), it already sends its own confirmation.
-        if (telegram.isPolling) {
-          telegram.sendToTopic(topicId, `✓ Delivered`).catch(() => {});
+        if (injected === false) {
+          // Injection failed — save message under stateDir (not /tmp) to avoid world-readable exposure
+          const failDir = path.join(stateDir, 'state', 'failed-messages');
+          fs.mkdirSync(failDir, { recursive: true });
+          const failFile = path.join(failDir, `failed-${topicId}-${Date.now()}.txt`);
+          fs.writeFileSync(failFile, text);
+          console.error(`[telegram→session] Injection FAILED for topic ${topicId} into ${targetSession}. Message saved to ${failFile}`);
+          if (telegram.isPolling) {
+            telegram.sendToTopic(topicId, `⚠️ Message delivery failed — your message did not reach the session. It has been saved and you can resend it. Try again in a moment.`).catch(() => {});
+          }
+        } else {
+          // Delivery confirmation — only when WE own polling. When lifeline owns
+          // polling (--no-telegram / standby), it already sends its own confirmation.
+          if (telegram.isPolling) {
+            telegram.sendToTopic(topicId, `✓ Delivered`).catch(() => {});
+          }
         }
         // Track for stall detection
         telegram.trackMessageInjection(topicId, targetSession, text);
@@ -2652,7 +2665,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       };
 
       // Wire up topic → session routing and session management callbacks
-      wireTelegramRouting(telegram, sessionManager, quotaTracker, topicMemory, userManager,
+      wireTelegramRouting(telegram, sessionManager, config.stateDir, quotaTracker, topicMemory, userManager,
         (topicId, text) => handleFixCommand(topicId, text, _fixDeps!));
       wireTelegramCallbacks(telegram, sessionManager, state, quotaTracker, accountSwitcher, config.sessions.claudePath, topicMemory);
 

--- a/tests/unit/SessionManager-injection.test.ts
+++ b/tests/unit/SessionManager-injection.test.ts
@@ -3,6 +3,12 @@
  * - rawInject retry logic (≤2 attempts before giving up)
  * - Failed message persistence to stateDir (not world-readable /tmp)
  * - cleanupStaleSessions hard cap prunes oldest completed sessions first
+ *
+ * Also tests the truthful delivery confirmation fix (this PR):
+ * - server.ts wireTelegramRouting checks injectTelegramMessage return value
+ * - On failure: saves message under <stateDir>/state/failed-messages/ (not /tmp)
+ * - On failure: sends user-visible warning via telegram.sendToTopic
+ * - On success: ✓ Delivered confirmation is preserved
  */
 
 import { describe, it, expect } from 'vitest';
@@ -11,6 +17,7 @@ import path from 'node:path';
 
 const SESSION_MANAGER_SRC = path.join(process.cwd(), 'src/core/SessionManager.ts');
 const ROUTES_SRC = path.join(process.cwd(), 'src/server/routes.ts');
+const SERVER_SRC = path.join(process.cwd(), 'src/commands/server.ts');
 
 describe('SessionManager — rawInject retry logic', () => {
   it('retries at most once (maxAttempts = 2)', () => {
@@ -64,6 +71,47 @@ describe('routes.ts — failed message persistence', () => {
   it('stores under state/failed-messages subdirectory', () => {
     const source = fs.readFileSync(ROUTES_SRC, 'utf-8');
     expect(source).toContain("'state', 'failed-messages'");
+  });
+});
+
+describe('server.ts — wireTelegramRouting truthful delivery confirmation', () => {
+  // Extract the injection block from wireTelegramRouting in server.ts.
+  // We anchor on the const injected = ... line and take a generous slice
+  // so we can assert the full failure and success branches.
+  function getInjectionBlock(source: string): string {
+    const anchor = source.indexOf('const injected = sessionManager.injectTelegramMessage(');
+    if (anchor === -1) throw new Error('Could not find injection anchor in server.ts');
+    // Grab enough characters to cover the if/else block that follows
+    return source.slice(anchor, anchor + 1600);
+  }
+
+  it('checks the return value of injectTelegramMessage (injected === false)', () => {
+    const source = fs.readFileSync(SERVER_SRC, 'utf-8');
+    const block = getInjectionBlock(source);
+    expect(block).toContain('injected === false');
+  });
+
+  it('on failure, saves message under state/failed-messages — not /tmp', () => {
+    const source = fs.readFileSync(SERVER_SRC, 'utf-8');
+    const block = getInjectionBlock(source);
+    // Must reference the stateDir parameter (not a hardcoded /tmp path)
+    expect(block).toContain("'state', 'failed-messages'");
+    expect(block).not.toContain("path.join('/tmp'");
+  });
+
+  it('on failure, sends user-visible warning via telegram.sendToTopic', () => {
+    const source = fs.readFileSync(SERVER_SRC, 'utf-8');
+    const block = getInjectionBlock(source);
+    // The failure branch must call sendToTopic with a warning (not ✓ Delivered)
+    expect(block).toContain('Message delivery failed');
+    expect(block).toContain('telegram.sendToTopic');
+  });
+
+  it('on success, preserves the ✓ Delivered confirmation', () => {
+    const source = fs.readFileSync(SERVER_SRC, 'utf-8');
+    const block = getInjectionBlock(source);
+    // The success (else) branch must still send ✓ Delivered
+    expect(block).toContain('✓ Delivered');
   });
 });
 


### PR DESCRIPTION
## Summary

The Telegram→session route currently sends \`✓ Delivered\` unconditionally after calling \`SessionManager.injectTelegramMessage\`. When injection fails (returns \`false\`), the user gets a misleading success confirmation while their message is silently dropped.

This:
- Checks the return value of \`injectTelegramMessage\`
- **On failure**: saves the failed message text under \`<stateDir>/state/failed-messages/failed-<topicId>-<timestamp>.txt\` (not \`/tmp\` — keeps failed messages out of world-readable temp space)
- **On failure**: sends a user-visible warning instead of the success confirmation
- **On success**: behavior unchanged (\`✓ Delivered\` confirmation if polling)

Matches the secure-state-dir pattern established in PR #32.

## Test plan

- [x] Test asserts the failure branch checks \`injected === false\`
- [x] Test asserts the failed-message path includes \`state\` and \`failed-messages\` (not \`/tmp\`)
- [x] Test asserts the user-facing warning string is sent via \`telegram.sendToTopic\`
- [x] Test asserts success path still sends \`✓ Delivered\`
- [x] \`npx tsc --noEmit\` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)