### PR TITLE
fix(scheduler): detect auth-failure markers in session output

### DIFF
--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -42,6 +42,25 @@ import type { TopicMemory } from '../memory/TopicMemory.js';
  */
 const DEFAULT_EXPECTED_MINUTES = 30;
 
+/**
+ * Auth-failure landmarks to scan for in session output.
+ *
+ * Claude Code exits cleanly (status = 'completed', exit code 0) on a
+ * 401 / invalid-auth response. Without scanning the output the scheduler
+ * records these silent failures as successes — the job appears healthy
+ * while authentication is actually broken. Match any of these patterns
+ * and the completion handler reclassifies the session as a failure.
+ */
+const AUTH_FAILURE_PATTERNS: readonly RegExp[] = [
+  /\b401\b[\s\S]{0,60}\b(?:Unauthorized|Invalid|authentication)\b/i,
+  /Invalid (?:authentication|API key|bearer token|x-api-key)/i,
+  /authentication[_ -]?(?:failed|error)/i,
+  /\bUnauthorized\b/,
+  /OAuth token (?:has expired|is invalid|expired|missing)/i,
+  /API key not (?:valid|found|provided)/i,
+  /Please (?:re-?)?authenticate/i,
+];
+
 interface QueuedJob {
   slug: string;
   reason: string;
@@ -939,7 +958,8 @@ export class JobScheduler {
     if (!job) return;
 
     // Update job state with completion result
-    const failed = session.status === 'failed' || session.status === 'killed';
+    let authFailureReason: string | null = null;
+    let failed = session.status === 'failed' || session.status === 'killed';
 
     // Capture session output FIRST — needed for both history and notifications
     let output = '';
@@ -949,13 +969,29 @@ export class JobScheduler {
       // Session may already be dead — that's fine
     }
 
+    // Claude Code exits cleanly on 401 / invalid-auth responses, leaving
+    // session.status = 'completed'. Scan the last 4 KB of output against
+    // well-known auth-failure landmarks and reclassify as a failure on hit.
+    if (!failed && output) {
+      const recent = output.slice(-4000);
+      for (const pattern of AUTH_FAILURE_PATTERNS) {
+        const match = recent.match(pattern);
+        if (match) {
+          authFailureReason = `Auth failure in output: ${match[0].trim().slice(0, 120)}`;
+          failed = true;
+          console.error(`[scheduler] auth failure detected in "${job.slug}" — flagging session ${session.name} as failure`);
+          break;
+        }
+      }
+    }
+
     // Record completion in run history (with output summary)
     const runId = this.activeRunIds.get(session.name);
     if (runId) {
       this.runHistory.recordCompletion({
         runId,
         result: session.status === 'killed' ? 'timeout' : (failed ? 'failure' : 'success'),
-        error: failed ? `Session ${session.status} (${session.name})` : undefined,
+        error: failed ? (authFailureReason ?? `Session ${session.status} (${session.name})`) : undefined,
         outputSummary: output ? output.slice(-1000) : undefined,
       });
 
@@ -985,7 +1021,7 @@ export class JobScheduler {
       slug: job.slug,
       lastRun: existingState?.lastRun ?? new Date().toISOString(),
       lastResult: failed ? 'failure' : 'success',
-      lastError: failed ? `Session ${session.status} (${session.name})` : undefined,
+      lastError: failed ? (authFailureReason ?? `Session ${session.status} (${session.name})`) : undefined,
       consecutiveFailures: failed ? (existingState?.consecutiveFailures ?? 0) + 1 : 0,
       nextScheduled: this.getNextRun(job.slug),
     };

--- a/tests/unit/JobScheduler-auth-failure.test.ts
+++ b/tests/unit/JobScheduler-auth-failure.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for auth-failure detection in the scheduler completion handler.
+ *
+ * Claude Code exits cleanly (status = 'completed', exit code 0) on a
+ * 401 / invalid-auth response. Without scanning the captured session output
+ * the scheduler records these silent failures as successes. This patch
+ * adds a post-completion scan and reclassifies the session as a failure
+ * when a known auth-failure landmark is matched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SCHEDULER_SRC = path.join(process.cwd(), 'src/scheduler/JobScheduler.ts');
+
+function readSource(): string {
+  return fs.readFileSync(SCHEDULER_SRC, 'utf-8');
+}
+
+describe('JobScheduler — AUTH_FAILURE_PATTERNS constant', () => {
+  it('exists at module scope (not inside a function)', () => {
+    const source = readSource();
+    // The const must appear before the class definition
+    const constIdx = source.indexOf('const AUTH_FAILURE_PATTERNS');
+    const classIdx = source.indexOf('export class JobScheduler');
+    expect(constIdx).toBeGreaterThan(-1);
+    expect(classIdx).toBeGreaterThan(-1);
+    expect(constIdx).toBeLessThan(classIdx);
+  });
+
+  it('is typed as readonly RegExp[]', () => {
+    const source = readSource();
+    expect(source).toContain('const AUTH_FAILURE_PATTERNS: readonly RegExp[]');
+  });
+
+  it('includes a 401 pattern', () => {
+    const source = readSource();
+    const blockStart = source.indexOf('const AUTH_FAILURE_PATTERNS');
+    const blockEnd = source.indexOf('];', blockStart);
+    const block = source.slice(blockStart, blockEnd + 2);
+    expect(block).toContain('401');
+  });
+
+  it('includes an Unauthorized pattern', () => {
+    const source = readSource();
+    const blockStart = source.indexOf('const AUTH_FAILURE_PATTERNS');
+    const blockEnd = source.indexOf('];', blockStart);
+    const block = source.slice(blockStart, blockEnd + 2);
+    expect(block).toContain('Unauthorized');
+  });
+
+  it('includes an Invalid API key pattern', () => {
+    const source = readSource();
+    const blockStart = source.indexOf('const AUTH_FAILURE_PATTERNS');
+    const blockEnd = source.indexOf('];', blockStart);
+    const block = source.slice(blockStart, blockEnd + 2);
+    expect(block).toMatch(/Invalid.*API key/);
+  });
+
+  it('includes a Please re-authenticate pattern', () => {
+    const source = readSource();
+    const blockStart = source.indexOf('const AUTH_FAILURE_PATTERNS');
+    const blockEnd = source.indexOf('];', blockStart);
+    const block = source.slice(blockStart, blockEnd + 2);
+    expect(block).toContain('authenticate');
+  });
+
+  it('includes an OAuth token pattern', () => {
+    const source = readSource();
+    const blockStart = source.indexOf('const AUTH_FAILURE_PATTERNS');
+    const blockEnd = source.indexOf('];', blockStart);
+    const block = source.slice(blockStart, blockEnd + 2);
+    expect(block).toContain('OAuth token');
+  });
+});
+
+describe('JobScheduler — completion handler uses let failed', () => {
+  it('declares failed with let so the auth-failure override is possible', () => {
+    const source = readSource();
+    // Must use `let`, not `const`
+    expect(source).toContain("let failed = session.status === 'failed' || session.status === 'killed'");
+    expect(source).not.toContain("const failed = session.status === 'failed' || session.status === 'killed'");
+  });
+});
+
+describe('JobScheduler — auth-failure scan reads last 4 KB of output', () => {
+  it('slices the last 4000 bytes of output before pattern matching', () => {
+    const source = readSource();
+    // Find the scan block — the second occurrence of AUTH_FAILURE_PATTERNS is
+    // inside the for-loop in the completion handler (first is the const def)
+    const firstIdx = source.indexOf('AUTH_FAILURE_PATTERNS');
+    const scanIdx = source.indexOf('AUTH_FAILURE_PATTERNS', firstIdx + 1);
+    expect(scanIdx).toBeGreaterThan(-1);
+
+    // The nearby context (look back far enough to see the slice call) must
+    // reference slice(-4000)
+    const scanBlock = source.slice(scanIdx - 400, scanIdx + 300);
+    expect(scanBlock).toContain('slice(-4000)');
+  });
+});
+
+describe('JobScheduler — authFailureReason flows into error fields', () => {
+  it('authFailureReason is declared in the completion handler', () => {
+    const source = readSource();
+    expect(source).toContain('let authFailureReason: string | null = null');
+  });
+
+  it('authFailureReason flows into recordCompletion error field', () => {
+    const source = readSource();
+    // Find recordCompletion call in notifyJobComplete
+    const recordIdx = source.indexOf('this.runHistory.recordCompletion({', source.indexOf('notifyJobComplete'));
+    const recordBlock = source.slice(recordIdx, recordIdx + 400);
+    expect(recordBlock).toContain('authFailureReason');
+    expect(recordBlock).toContain('error:');
+  });
+
+  it('authFailureReason flows into persisted lastError field', () => {
+    const source = readSource();
+    // Find the JobState object literal in notifyJobComplete
+    const jobStateIdx = source.indexOf('const jobState: JobState = {', source.indexOf('notifyJobComplete'));
+    const jobStateBlock = source.slice(jobStateIdx, jobStateIdx + 400);
+    expect(jobStateBlock).toContain('authFailureReason');
+    expect(jobStateBlock).toContain('lastError:');
+  });
+
+  it('uses nullish coalescing to fall back to session-status string when no auth failure', () => {
+    const source = readSource();
+    // Both usages should follow the pattern: authFailureReason ?? `Session ...`
+    const matches = source.match(/authFailureReason \?\? `Session/g);
+    expect(matches).not.toBeNull();
+    // Should appear in both recordCompletion and lastError
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary

Claude Code exits cleanly (status `completed`, exit code 0) on a 401 / invalid-auth response. Without scanning the captured session output, the scheduler records these silent auth failures as **successes** — the job appears healthy while authentication is actually broken.

This adds a post-completion scan of the last 4 KB of session output against well-known auth-failure regex landmarks:

- `401 Unauthorized` / `401 ... authentication`
- `Invalid (authentication|API key|bearer token|x-api-key)`
- `Unauthorized`
- `OAuth token has expired / is invalid / expired / missing`
- `API key not valid / found / provided`
- `Please (re-)?authenticate`

On hit:
- Override `failed = true`
- Surface the matched fragment as the error reason in `runHistory.recordCompletion`'s `error` field
- Same reason flows into the persisted `lastError` for the job

## Test plan

- [x] Test asserts the `AUTH_FAILURE_PATTERNS` const exists at module scope with expected regex landmarks
- [x] Test asserts the completion handler uses `let failed` so the override is possible  
- [x] Test asserts the scan reads only the last 4 KB of output
- [x] Test asserts the auth-failure reason flows into both `error` and `lastError`
- [x] `npx tsc --noEmit` — no new errors (9 pre-existing errors unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)