### PR TITLE
fix(codex): scaffolder writes skills to .agents/skills/ (where Codex 0.130 looks)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/providers/adapters/openai-codex/integration/providerScaffolder.ts
+++ b/src/providers/adapters/openai-codex/integration/providerScaffolder.ts
@@ -1,14 +1,29 @@
 /**
  * ProviderScaffolder implementation for openai-codex.
  *
- * Installs Codex-flavor scaffolding under a project root:
- *   - `.agent/openai/AGENTS.md` (the canonical instructions file)
- *   - `.agent/openai/config.toml` (per-project codex overrides)
- *   - `.agent/openai/hooks.json` (hook script registrations)
- *   - `.agent/openai/skills/` (codex-format skill bundles)
+ * Installs Codex-flavor scaffolding under a project root.
  *
- * Idempotent. The `.agent/<provider>/` convention is the v1.0.0
- * standardization — replaces the `.claude/` direct layout.
+ * Two distinct on-disk locations are involved:
+ *
+ *   1. `.agent/openai/` — Instar's standardized per-provider config bucket.
+ *      Holds AGENTS.md (instruction file), config.toml (per-project codex
+ *      overrides), and hooks.json (hook script registrations).
+ *
+ *   2. `.agents/skills/` — Codex 0.130's documented project-scope skill
+ *      discovery path. Each skill is a directory at
+ *      `.agents/skills/<name>/` with:
+ *        - SKILL.md (required) — frontmatter (name, description) + body
+ *        - agents/openai.yaml (recommended) — UI-facing metadata
+ *          (display_name, short_description), per Codex's documented format.
+ *
+ * The two paths intentionally differ: `.agent/openai/` is the Instar
+ * provider-config convention; `.agents/skills/` is the Codex-defined project
+ * skill discovery path that Codex itself walks. Co-locating skills under
+ * `.agent/openai/` (the prior layout) silently fails — Codex does not look
+ * there.
+ *
+ * Idempotent. Re-installing leaves existing files untouched unless
+ * `options.force` is set.
  */
 
 import { promises as fs } from 'node:fs';
@@ -17,13 +32,76 @@ import type { CancellationOptions } from '../../../types.js';
 import type {
   ProviderScaffolder,
   ProviderScaffoldOptions,
+  ScaffoldAsset,
   ScaffoldResult,
   ScaffoldVerification,
 } from '../../../primitives/integration/providerScaffolder.js';
 import { CapabilityFlag } from '../../../capabilities.js';
 
 const PROVIDER_DIR = '.agent/openai';
+const SKILLS_DIR = '.agents/skills';
 const REQUIRED_FILES = ['AGENTS.md', 'config.toml', 'hooks.json'];
+
+interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+  shortDescription?: string;
+}
+
+function parseSkillFrontmatter(content: string): SkillFrontmatter {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const block = match[1];
+  const result: SkillFrontmatter = {};
+  for (const line of block.split('\n')) {
+    // Accept top-level keys (e.g. `name:`) and one-level-indented keys
+    // (e.g. `  short-description:` under a `metadata:` parent). The canonical
+    // skill format nests `short-description` under `metadata:`.
+    const m = line.match(/^\s*([a-zA-Z][\w-]*):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, rawValue] = m;
+    if (!rawValue) continue;
+    const value = rawValue.replace(/^['"]|['"]$/g, '').trim();
+    if (key === 'name' && !result.name) result.name = value;
+    else if (key === 'description' && !result.description) result.description = value;
+    else if (key === 'short-description' || key === 'short_description') {
+      result.shortDescription = value;
+    }
+  }
+  return result;
+}
+
+function yamlEscape(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function deriveDisplayName(name: string): string {
+  return name
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+function truncateForShortDescription(text: string): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  if (oneLine.length <= 64) return oneLine;
+  return oneLine.slice(0, 61).trimEnd() + '...';
+}
+
+function buildOpenAiYaml(asset: ScaffoldAsset): string {
+  const fm = parseSkillFrontmatter(asset.content);
+  const displayName = deriveDisplayName(fm.name ?? asset.name);
+  const shortDescription = truncateForShortDescription(
+    fm.shortDescription ?? fm.description ?? `${displayName} skill`,
+  );
+  return [
+    'interface:',
+    `  display_name: "${yamlEscape(displayName)}"`,
+    `  short_description: "${yamlEscape(shortDescription)}"`,
+    '',
+  ].join('\n');
+}
 
 class OpenAiCodexProviderScaffolder implements ProviderScaffolder {
   readonly capability = CapabilityFlag.ProviderScaffolder;
@@ -65,15 +143,26 @@ class OpenAiCodexProviderScaffolder implements ProviderScaffolder {
     }
 
     if (options?.bundledAssets) {
-      const skillsDir = path.join(baseDir, 'skills');
-      await fs.mkdir(skillsDir, { recursive: true });
+      const skillsDir = path.join(projectRoot, SKILLS_DIR);
+      let skillsDirCreated = false;
       for (const asset of options.bundledAssets) {
         if (asset.kind === 'skill') {
+          if (!skillsDirCreated) {
+            await fs.mkdir(skillsDir, { recursive: true });
+            skillsDirCreated = true;
+          }
           const skillDir = path.join(skillsDir, asset.name);
           await fs.mkdir(skillDir, { recursive: true });
-          const dest = path.join(skillDir, 'SKILL.md');
-          await fs.writeFile(dest, asset.content, 'utf-8');
-          created.push(dest);
+
+          const skillMd = path.join(skillDir, 'SKILL.md');
+          await fs.writeFile(skillMd, asset.content, 'utf-8');
+          created.push(skillMd);
+
+          const metaDir = path.join(skillDir, 'agents');
+          await fs.mkdir(metaDir, { recursive: true });
+          const yamlPath = path.join(metaDir, 'openai.yaml');
+          await fs.writeFile(yamlPath, buildOpenAiYaml(asset), 'utf-8');
+          created.push(yamlPath);
         } else if (asset.kind === 'instruction-file') {
           const dest = path.join(baseDir, asset.name);
           await fs.writeFile(dest, asset.content, 'utf-8');
@@ -106,6 +195,7 @@ class OpenAiCodexProviderScaffolder implements ProviderScaffolder {
 
   async uninstall(projectRoot: string, _options?: ProviderScaffoldOptions): Promise<void> {
     await fs.rm(path.join(projectRoot, PROVIDER_DIR), { recursive: true, force: true });
+    await fs.rm(path.join(projectRoot, SKILLS_DIR), { recursive: true, force: true });
   }
 }
 

--- a/tests/unit/providers/adapters/openai-codex/providerScaffolder.test.ts
+++ b/tests/unit/providers/adapters/openai-codex/providerScaffolder.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for openai-codex ProviderScaffolder skill discovery layout.
+ *
+ * Phase 0 fix: skills must be written to `.agents/skills/<name>/` with a
+ * sibling `agents/openai.yaml` per Codex 0.130's project-scope discovery
+ * contract. The prior implementation wrote skills under `.agent/openai/skills/`
+ * which Codex silently ignores.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createProviderScaffolder } from '../../../../../src/providers/adapters/openai-codex/integration/providerScaffolder.js';
+import type { ScaffoldAsset } from '../../../../../src/providers/primitives/integration/providerScaffolder.js';
+
+async function makeProject(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'codex-scaffolder-test-'));
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const SAMPLE_SKILL: ScaffoldAsset = {
+  kind: 'skill',
+  name: 'hello-instar',
+  content: [
+    '---',
+    'name: hello-instar',
+    'description: A test skill used to verify scaffolder behaviour.',
+    'metadata:',
+    '  short-description: Test skill',
+    '---',
+    '',
+    '# Hello Instar',
+    '',
+    'Reply with PHASE0-SKILL-OK when invoked.',
+    '',
+  ].join('\n'),
+};
+
+describe('OpenAiCodexProviderScaffolder — skill discovery layout', () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await makeProject();
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it('writes skills to .agents/skills/<name>/SKILL.md (not .agent/openai/skills/)', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+
+    const correctPath = path.join(projectRoot, '.agents/skills/hello-instar/SKILL.md');
+    const legacyWrongPath = path.join(projectRoot, '.agent/openai/skills/hello-instar/SKILL.md');
+
+    expect(await exists(correctPath)).toBe(true);
+    expect(await exists(legacyWrongPath)).toBe(false);
+  });
+
+  it('emits sibling agents/openai.yaml inside each skill directory', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+
+    const yamlPath = path.join(projectRoot, '.agents/skills/hello-instar/agents/openai.yaml');
+    expect(await exists(yamlPath)).toBe(true);
+
+    const yaml = await fs.readFile(yamlPath, 'utf-8');
+    expect(yaml).toContain('interface:');
+    expect(yaml).toMatch(/display_name:\s*".+"/);
+    expect(yaml).toMatch(/short_description:\s*".+"/);
+  });
+
+  it('derives display_name from skill name when frontmatter omits it', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+
+    const yaml = await fs.readFile(
+      path.join(projectRoot, '.agents/skills/hello-instar/agents/openai.yaml'),
+      'utf-8',
+    );
+
+    expect(yaml).toContain('display_name: "Hello Instar"');
+  });
+
+  it('uses frontmatter short-description for openai.yaml short_description', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+
+    const yaml = await fs.readFile(
+      path.join(projectRoot, '.agents/skills/hello-instar/agents/openai.yaml'),
+      'utf-8',
+    );
+
+    expect(yaml).toContain('short_description: "Test skill"');
+  });
+
+  it('falls back to frontmatter description when short-description is absent', async () => {
+    const scaffolder = createProviderScaffolder();
+    const asset: ScaffoldAsset = {
+      kind: 'skill',
+      name: 'fallback-test',
+      content: [
+        '---',
+        'name: fallback-test',
+        'description: Some description here.',
+        '---',
+        '',
+        '# Body',
+      ].join('\n'),
+    };
+
+    await scaffolder.install(projectRoot, { bundledAssets: [asset] });
+
+    const yaml = await fs.readFile(
+      path.join(projectRoot, '.agents/skills/fallback-test/agents/openai.yaml'),
+      'utf-8',
+    );
+
+    expect(yaml).toContain('short_description: "Some description here."');
+  });
+
+  it('truncates long short_description to 64 chars with ellipsis', async () => {
+    const scaffolder = createProviderScaffolder();
+    const longDescription = 'A'.repeat(200);
+    const asset: ScaffoldAsset = {
+      kind: 'skill',
+      name: 'long-desc',
+      content: [
+        '---',
+        'name: long-desc',
+        `description: ${longDescription}`,
+        '---',
+        '',
+        '# Body',
+      ].join('\n'),
+    };
+
+    await scaffolder.install(projectRoot, { bundledAssets: [asset] });
+
+    const yaml = await fs.readFile(
+      path.join(projectRoot, '.agents/skills/long-desc/agents/openai.yaml'),
+      'utf-8',
+    );
+
+    const match = yaml.match(/short_description:\s*"([^"]+)"/);
+    expect(match).not.toBeNull();
+    const value = match![1];
+    expect(value.length).toBeLessThanOrEqual(64);
+    expect(value.endsWith('...')).toBe(true);
+  });
+
+  it('writes SKILL.md content verbatim (no template substitution)', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+
+    const skillMd = await fs.readFile(
+      path.join(projectRoot, '.agents/skills/hello-instar/SKILL.md'),
+      'utf-8',
+    );
+
+    expect(skillMd).toBe(SAMPLE_SKILL.content);
+  });
+
+  it('still creates .agent/openai/ provider-config files alongside skills', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+
+    expect(await exists(path.join(projectRoot, '.agent/openai/AGENTS.md'))).toBe(true);
+    expect(await exists(path.join(projectRoot, '.agent/openai/config.toml'))).toBe(true);
+    expect(await exists(path.join(projectRoot, '.agent/openai/hooks.json'))).toBe(true);
+  });
+
+  it('does NOT create .agents/skills/ when no skill assets are bundled', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [] });
+
+    expect(await exists(path.join(projectRoot, '.agents'))).toBe(false);
+    expect(await exists(path.join(projectRoot, '.agent/openai'))).toBe(true);
+  });
+
+  it('reports both SKILL.md and openai.yaml in created[]', async () => {
+    const scaffolder = createProviderScaffolder();
+    const result = await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+
+    const skillMdPath = path.join(projectRoot, '.agents/skills/hello-instar/SKILL.md');
+    const yamlPath = path.join(projectRoot, '.agents/skills/hello-instar/agents/openai.yaml');
+
+    expect(result.created).toContain(skillMdPath);
+    expect(result.created).toContain(yamlPath);
+  });
+
+  it('handles multiple skills in one install call', async () => {
+    const scaffolder = createProviderScaffolder();
+    const skills: ScaffoldAsset[] = [
+      { ...SAMPLE_SKILL, name: 'skill-a' },
+      { ...SAMPLE_SKILL, name: 'skill-b' },
+      { ...SAMPLE_SKILL, name: 'skill-c' },
+    ];
+
+    await scaffolder.install(projectRoot, { bundledAssets: skills });
+
+    for (const s of skills) {
+      expect(await exists(path.join(projectRoot, `.agents/skills/${s.name}/SKILL.md`))).toBe(true);
+      expect(
+        await exists(path.join(projectRoot, `.agents/skills/${s.name}/agents/openai.yaml`)),
+      ).toBe(true);
+    }
+  });
+
+  it('uninstall removes both .agent/openai/ and .agents/skills/', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+    await scaffolder.uninstall(projectRoot);
+
+    expect(await exists(path.join(projectRoot, '.agent/openai'))).toBe(false);
+    expect(await exists(path.join(projectRoot, '.agents/skills'))).toBe(false);
+  });
+
+  it('install is idempotent — re-running with same skills does not throw', async () => {
+    const scaffolder = createProviderScaffolder();
+    await scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] });
+    await expect(
+      scaffolder.install(projectRoot, { bundledAssets: [SAMPLE_SKILL] }),
+    ).resolves.toBeDefined();
+
+    expect(
+      await exists(path.join(projectRoot, '.agents/skills/hello-instar/SKILL.md')),
+    ).toBe(true);
+  });
+
+  it('escapes double quotes in YAML string values', async () => {
+    const scaffolder = createProviderScaffolder();
+    const asset: ScaffoldAsset = {
+      kind: 'skill',
+      name: 'quote-test',
+      content: [
+        '---',
+        'name: quote-test',
+        'description: A "quoted" word inside.',
+        '---',
+        '',
+        '# Body',
+      ].join('\n'),
+    };
+
+    await scaffolder.install(projectRoot, { bundledAssets: [asset] });
+
+    const yaml = await fs.readFile(
+      path.join(projectRoot, '.agents/skills/quote-test/agents/openai.yaml'),
+      'utf-8',
+    );
+
+    expect(yaml).toContain('short_description: "A \\"quoted\\" word inside."');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,44 @@
+# Upgrade Guide — v1.0.1
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Codex provider-scaffolder now writes bundled skills to the path Codex 0.130 actually walks for project-scope discovery. The old layout silently failed — Codex never saw any of the skills the scaffolder installed.
+
+Two related changes in `src/providers/adapters/openai-codex/integration/providerScaffolder.ts`:
+
+1. Skill installation moved from `.agent/openai/skills/<name>/` to `.agents/skills/<name>/`. The plural `.agents/` (with a trailing `s`) is Codex 0.130's documented project-scope skill discovery path. The prior path (`.agent/openai/...`) was a co-location guess that Codex never looked at — every bundled skill we installed under it was invisible to the agent.
+
+2. Each installed skill now also gets a sibling `agents/openai.yaml` inside its own directory (`.agents/skills/<name>/agents/openai.yaml`), generated from the skill's frontmatter. The YAML carries `interface.display_name` and `interface.short_description`. Codex requires this sibling to surface the skill in UI lists and chips; without it the skill loads but is undiscoverable.
+
+The provider-config tree at `.agent/openai/` (AGENTS.md, config.toml, hooks.json) is unchanged — that's the Instar-standardized per-provider config bucket and Codex doesn't walk it for skills.
+
+`uninstall()` now removes both `.agent/openai/` and `.agents/skills/` to match the install footprint.
+
+This is the first concrete fix landing from the framework-functional-parity foundational work. Future framework-parity work will follow the same pattern: align scaffolder output to what each framework actually loads at the file-discovery layer.
+
+## What to Tell Your User
+
+- "Skills you bundle for Codex sessions are now actually visible to Codex. Before this fix they were being written to a location Codex doesn't look at, so they loaded but never appeared in skill lists."
+- "No action needed on your end. Existing scaffolds will pick up the correct layout the next time the scaffolder installs."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Codex skill discovery (project-scope) | Automatic — scaffolder writes `.agents/skills/<name>/SKILL.md` + sibling `agents/openai.yaml` |
+| Codex skill UI metadata | Automatic — generated from each skill's frontmatter (`name`, `description`, `metadata.short-description`) |
+
+## Evidence
+
+The bug was reproducible against Codex 0.130 with the prior layout:
+
+- **Before**: `.agent/openai/skills/hello-instar/SKILL.md` created by the scaffolder. Running `codex` in the project directory and asking "what skills are available?" returned no project-scope skills. Direct filesystem inspection confirmed the file existed; Codex was not walking that path.
+- **After**: `.agents/skills/hello-instar/SKILL.md` + `.agents/skills/hello-instar/agents/openai.yaml` created by the scaffolder. Layout matches the on-disk format of Codex's own installed skills under `~/.codex/skills/.system/<name>/` — `SKILL.md` at the root, `agents/openai.yaml` as a sibling subdirectory.
+
+YAML format anchored to Codex's documented spec at `~/.codex/skills/.system/skill-creator/references/openai_yaml.md` — `interface.display_name` and `interface.short_description` are the documented required fields; we generate both from frontmatter.
+
+Unit tests cover: correct path written, legacy wrong path not written, YAML sibling emitted at correct location, display_name derived from skill name when frontmatter omits it, short_description sourced from `metadata.short-description` (canonical Codex skill format) with fallback to top-level `description`, long descriptions truncated to 64 chars per spec, `uninstall()` removes both trees, multiple skills handled in one install call, YAML escapes double quotes in string values.
+
+Test file: `tests/unit/providers/adapters/openai-codex/providerScaffolder.test.ts` (14 tests, all passing). Full openai-codex adapter suite: 78/78 passing. Typecheck: clean.

--- a/upgrades/side-effects/fix-codex-skill-scaffold-path.md
+++ b/upgrades/side-effects/fix-codex-skill-scaffold-path.md
@@ -1,0 +1,86 @@
+# Side-Effects Review — Codex skill scaffold path correction
+
+**Version / slug:** `fix-codex-skill-scaffold-path` (v1.0.1)
+**Date:** 2026-05-18
+**Author:** Echo
+
+## Summary of the change
+
+Two corrections to `src/providers/adapters/openai-codex/integration/providerScaffolder.ts`:
+
+1. Skill bundles installed under `.agents/skills/<name>/` (Codex 0.130's project-scope discovery path) instead of `.agent/openai/skills/<name>/` (the prior path, which Codex never walked).
+2. Each installed skill now also gets a sibling `agents/openai.yaml` file inside its own directory, generated from skill frontmatter (`display_name` derived from `name`, `short_description` sourced from `metadata.short-description` with fallback to `description`, truncated to 64 chars). This file is required by Codex to surface the skill in UI lists.
+
+Provider-config tree (`AGENTS.md`, `config.toml`, `hooks.json` under `.agent/openai/`) is unchanged. `uninstall()` now removes both trees to match install footprint.
+
+**Files changed (source):**
+- `src/providers/adapters/openai-codex/integration/providerScaffolder.ts` — skill-path correction + YAML sibling emission + frontmatter parser
+
+**Files changed (tests):**
+- `tests/unit/providers/adapters/openai-codex/providerScaffolder.test.ts` — 14 new tests
+
+**Files changed (release notes):**
+- `upgrades/NEXT.md` — v1.0.1 release notes
+- `package.json` — version bump 1.0.0 → 1.0.1
+
+## Decision-point inventory
+
+- **Skill path: `.agents/skills/<name>/` vs `.agent/openai/skills/<name>/`** — fix (move to the path Codex 0.130 actually walks). Verified against Codex's on-disk skill layout at `~/.codex/skills/.system/<name>/` and Codex's own `skill-creator` documentation at `~/.codex/skills/.system/skill-creator/references/openai_yaml.md`.
+- **YAML sibling location: `agents/openai.yaml` inside each skill dir vs at project root** — fix as per-skill sibling (matches Codex's installed-skill layout; the prior summary that said "project root" was wrong).
+- **YAML format: minimal vs full** — minimal. Only `interface.display_name` and `interface.short_description` are emitted. Optional fields (icons, brand color, default_prompt, dependencies, policy) are NOT emitted — they require per-skill content the scaffolder doesn't have. Skills can override by including their own `agents/openai.yaml` in their bundle (current scaffolder always overwrites; a follow-up could respect an asset-provided yaml).
+- **`trust_level="trusted"` in the YAML** — NOT emitted. Despite earlier verification notes suggesting it was required, inspection of real installed Codex skills shows no `trust_level` field in `agents/openai.yaml` (it's a project-level config in `~/.codex/config.toml`, not skill-level). Emitting it from the scaffolder would be incorrect.
+- **Provider-config tree path** — unchanged. `.agent/openai/AGENTS.md`/`config.toml`/`hooks.json` continues to live where Instar puts it. Whether Codex reads `AGENTS.md` from project root vs from `.agent/openai/` is a separate question not in scope for this fix.
+
+---
+
+## 1. Over-block
+
+None. The change is additive at the new location and silent-removal at the wrong location. No previously-working behavior is blocked.
+
+## 2. Under-block
+
+None. The scaffolder is not a gate — it's an installer. There is no decision boundary being widened or narrowed.
+
+## 3. Level-of-abstraction fit
+
+Correct. The fix lives entirely in the `ProviderScaffolder` adapter layer for openai-codex. Generic `ProviderScaffolder` contract is unchanged; only the codex-specific implementation's on-disk layout is corrected. Other framework adapters (anthropic-headless) are untouched.
+
+## 4. Signal vs authority
+
+Not applicable — no LLM gate, no policy decision. Pure scaffolding logic.
+
+## 5. Interactions
+
+- **Consumers of `bundledAssets`** (instar init, setup wizard, migration code): No interface change. Same `ScaffoldAsset` input; output paths change. Callers that hard-coded the old path would break — `grep` confirms no such callers in src/ or tests/.
+- **Other adapters**: Anthropic-headless ProviderScaffolder is unchanged. Its `.agent/anthropic/` tree is unaffected.
+- **Conformance suite**: Shape-only; not affected by path changes.
+- **IdentityRenderer**: Renders AGENTS.md to project root for Codex sessions independently of scaffolder; not affected.
+
+## 6. External surfaces
+
+- **Public API**: `ProviderScaffolder` interface unchanged.
+- **CLI surface**: None directly. Scaffolder is invoked programmatically.
+- **On-disk surface (the actual side-effect)**: Two paths change for Codex-using agents installing skills via the scaffolder:
+  - Created: `.agents/skills/<name>/SKILL.md` (+ `agents/openai.yaml`)
+  - Not created: `.agent/openai/skills/<name>/SKILL.md`
+
+No agent today depends on the wrong-path skills being present (Codex never saw them), so no migration is needed for skills that were "installed" under the bad path — they were dead files. Operators may want to manually delete any leftover `.agent/openai/skills/` directories in existing projects. Documented as a follow-up; not blocking this PR.
+
+## 7. Rollback cost
+
+Trivial. Revert the commit:
+- `git revert` brings back the old (broken) path.
+- Existing `.agents/skills/<name>/` directories created post-fix would remain on disk but become orphaned (Codex's auto-cleanup or operator action handles).
+- No data loss; SKILL.md content is identical, only location differs.
+
+## Tests
+
+- New: `tests/unit/providers/adapters/openai-codex/providerScaffolder.test.ts` — 14 tests covering correct path, legacy wrong path absence, YAML sibling location, display_name derivation, short_description sourcing + fallback + truncation, SKILL.md verbatim writing, provider-config tree coexistence, no `.agents/` dir when no skills bundled, `created[]` reporting, multi-skill install, uninstall removing both trees, install idempotency, YAML escape of double quotes in string values.
+- Full openai-codex adapter suite: 78/78 passing.
+- Typecheck (`tsc --noEmit`): clean.
+
+## Evidence
+
+The bug was reproducible: bundling a skill via the scaffolder produced a `.agent/openai/skills/<name>/SKILL.md` file that no Codex session could see. The on-disk layout of Codex's own installed skills at `~/.codex/skills/.system/<name>/` was confirmed to follow the corrected layout (SKILL.md + agents/openai.yaml as a sibling subdirectory). YAML format anchored to Codex's documented spec (`~/.codex/skills/.system/skill-creator/references/openai_yaml.md`).
+
+Live end-to-end verification with a running Codex agent is queued as a follow-up — local `codex exec` smoke tests against ChatGPT-subscription auth failed with model-availability errors unrelated to this fix. The unit tests + on-disk format match against real installed skills + adherence to documented YAML spec provide structural confidence; full end-to-end depends on a healthy Codex session.


### PR DESCRIPTION
## Summary

- Codex 0.130 walks `.agents/skills/<name>/` for project-scope skill discovery; scaffolder was writing to `.agent/openai/skills/<name>/` (which Codex never looks at). Every bundled skill was invisible to the agent.
- Each installed skill now also emits a sibling `agents/openai.yaml` inside its own directory, generated from skill frontmatter. Required for skills to surface in Codex UI lists.
- `.agent/openai/` provider-config tree (AGENTS.md, config.toml, hooks.json) is unchanged. `uninstall()` now removes both trees.

## Test plan

- [x] Unit: `tests/unit/providers/adapters/openai-codex/providerScaffolder.test.ts` — 14 tests, all green
- [x] Full openai-codex adapter suite: 78/78 passing
- [x] Typecheck (`tsc --noEmit`): clean
- [x] Pre-push smoke (affected tests only): clean
- [ ] Live verify against a real Codex agent — `codex exec` smoke locally hit ChatGPT model-availability errors unrelated to this fix; full E2E will happen when a Codex-routed Echo session installs a skill

## Driver

First concrete code change landing from the framework-functional-parity foundational work. Spec docs (foundational + inventory) are in-flight on a sibling branch and will land separately. Path correction here aligns scaffolder output to documented Codex 0.130 behavior — the inventory rates Skill on Codex as `partial ⚠️` because of this exact gap.

## Process note

Pre-commit `/instar-dev` gate bypassed with `--no-verify` per explicit operator authorization (Telegram, 2026-05-18). Rationale: documented-behavior correction (path the framework walks vs the prior co-location guess), not a design decision warranting 7-reviewer spec convergence. Side-effects review at `upgrades/side-effects/fix-codex-skill-scaffold-path.md` and `upgrades/NEXT.md` (v1.0.1) both ship in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)