### PR TITLE
docs(specs): land framework-functional-parity foundational specs

### DIFF
--- a/specs/instar-foundations/framework-functional-parity.md
+++ b/specs/instar-foundations/framework-functional-parity.md
@@ -1,0 +1,260 @@
+---
+status: foundational-draft
+date: 2026-05-18
+author: echo
+audience: justin
+type: foundational-spec
+revision: 5
+---
+
+# Framework Functional Parity — Instar's foundational compatibility principle
+
+## What this is
+
+A foundational design principle for Instar: every required functional capability works equivalently across every supported agent framework. The user feels framework "flavor" — different model voices, different speeds, different costs — but never feels Instar itself is less capable on one framework than another. When a framework offers bonus capabilities others lack, Instar opportunistically uses them on that framework without making them dependencies elsewhere.
+
+This document defines what functional parity means for Instar, why Instar commits to it, how it's structured, and what the long-term implications are for Instar's identity as a system.
+
+## Why this matters
+
+Instar's value proposition is **persistent autonomy infrastructure** that survives the underlying agent framework. The framework is the substrate; Instar is the persistence layer on top. If Instar's capabilities depend on the substrate, every framework swap regresses functionality and the value proposition leaks. So the substrate must be commoditized at the level of Instar's REQUIRED primitives — gaps in any framework's native implementation are filled by Instar's own native implementations.
+
+Three downstream consequences make this commitment load-bearing:
+
+- **Vendor independence.** When a framework provider changes pricing, deprecates a feature, or sunsets a CLI, Instar agents keep working under any other supported framework with full required-primitive coverage. The 2026-06 Anthropic Agent SDK repricing is exactly this scenario; provider portability v1.0.0 solved it for the cost dimension, this spec extends it to capability.
+
+- **Optimal framework leverage.** Frameworks have framework-specific strengths. Functional parity does NOT mean reducing to the lowest common denominator — it means Instar invests in framework-specific rendering so each substrate is used optimally, AND Instar opportunistically uses framework-bonus capabilities where they exist without making them required.
+
+- **Future identity.** Once every required primitive has an Instar-native implementation (as the fallback for frameworks that lack it natively), Instar has, in fact, become its own agent framework. The functional parity work is the on-ramp to Instar-as-framework, powered by any model (cloud frontier, OSS, local) directly.
+
+## What is NOT a functional primitive
+
+A capability earns "functional primitive" status only when it's a contract Instar promises across frameworks — something a user/agent can name, request, and expect uniformly. Several adjacent things are *not* primitives and live one layer down:
+
+- **Context-engineering strategies.** Recursive tree structures (self-knowledge tree), recursive LLM-driven search, knowledge graphs, semantic search, the playbook scoring system, per-topic memory shards. These are *how Memory's internals are organized* — they decide what content surfaces for a given session and in what shape. They sit below the Memory primitive's contract; the framework only sees the rendered output. A future redesign of any of these strategies leaves the Memory primitive unchanged from the framework's perspective.
+
+- **Rendering / loading mechanics.** IdentityRenderer's logic for turning `.instar/AGENT.md` into `CLAUDE.md` or `AGENTS.md` is implementation of the Instruction-file primitive, not a separate primitive. Same with telegram-relay.sh's bash code.
+
+- **Substrate primitives.** `oneShotCompletion`, `structuredCompletion`, `agenticSession`, etc. — these are Layer 2 (see "Layer relationships" below), not Layer 3 functional primitives. They're the contracts adapters satisfy, not the contracts users invoke.
+
+The distinction matters because it stops the primitive catalog from inflating. Every active area of context-engineering research could otherwise look like a candidate primitive, and the parity sentinel would chase contracts that don't actually need cross-framework guarantees.
+
+When context-engineering strategies *would* graduate to first-class concerns: in the Instar-native-runtime future, where Instar itself is assembling the prompt directly rather than handing the framework a pre-rendered file. At that point context-assembly becomes substrate work, not Memory-internals work. Until then, these strategies are Memory's business.
+
+## What functional parity is NOT
+
+- **Not feature equivalence to the most capable framework.** Bonus capabilities one framework has and others don't are NOT promoted to required just because they exist.
+
+- **Not behavioral identity.** Same prompt across two frameworks produces different output. That's framework flavor; Instar doesn't hide it.
+
+- **Not a lowest-common-denominator policy.** When framework A has a bonus B lacks, Instar still uses A's bonus on A. It doesn't refuse to use it just because B can't.
+
+- **Not "every framework must natively support every primitive."** Frameworks vary. The commitment is that Instar fills any gap with its own native implementation so the agent experience is uniform across required primitives.
+
+## Layer relationships — functional primitives, substrate primitives, framework adapters
+
+The required functional primitives in this doc are NOT the only primitive layer in Instar. They sit on top of an older, lower-level inventory: the **substrate primitives** catalogued during v1.0 provider-portability work (`specs/provider-portability/01-primitives-inventory.md`).
+
+A clean three-layer model:
+
+- **Layer 3 — Functional primitives** (this doc). User-facing capabilities Instar promises: Skill, Hook, Agent, Memory, Instruction-file, Session-resume, Slash-command, Outbound-relay, Conversational-action, Tool, MCP-server. These are what the user/agent talk about ("add a skill", "fire a hook on compaction"). Required uniform across frameworks.
+
+- **Layer 2 — Substrate primitives** (v1.0 inventory). Transport / capability / observability / control patterns Instar relies on under the hood: `oneShotCompletion`, `structuredCompletion`, `agenticSessionHeadless`, `agenticSessionInteractive`, `toolAllowlist`, `pathAllowlist`, `outputStream`, `eventHooks`, `usageMeter`, `inputInjection`, `hardKill`, `authCredentialInjection`, etc. (~51 entries total.) Framework-agnostic contracts; each adapter must satisfy them.
+
+- **Layer 1 — Framework adapters**. Concrete implementations that satisfy Layer 2 contracts on a specific runtime: `anthropic-headless` (Claude Code CLI), `openai-codex` (Codex CLI), future `free-claude-code`, future Instar-native runtime.
+
+### Worked example — StallTriageNurse
+
+Walks the layers cleanly:
+
+- **Layer 3.** StallTriageNurse is a **Hook** (required functional primitive #2) — it fires on a stall-detection lifecycle event. Users perceive "the agent noticed I'm stuck and tried to recover."
+- **Layer 2.** Its diagnosis step needs `structuredCompletion` (a substrate primitive — schema-constrained JSON) plus `outputStream` (to read the stuck session's tmux capture). It does NOT need `agenticSession` or `toolAccess`.
+- **Layer 1.** A configured `IntelligenceProvider` adapter satisfies `structuredCompletion`. On Claude that's `ClaudeCliIntelligenceProvider` (CLI passthrough) or `AnthropicIntelligenceProvider` (direct API). On Codex it's a Codex adapter implementing the same contract. On a local model it could be Ollama-via-OpenAI-compat.
+
+So when Justin asks "what powers a sentinel that needs an LLM?" the answer is: the sentinel is a Layer-3 Hook; it acquires LLM access by requesting a Layer-2 substrate primitive (`structuredCompletion` or `oneShotCompletion`); the configured Layer-1 framework adapter satisfies that request. None of the three layers is "the" power source — they're stacked.
+
+### Why both layers are required
+
+- Layer 2 alone is too low to be useful to users — they don't think in `oneShotCompletion`-shaped contracts. They think "add a skill."
+- Layer 3 alone has no implementation — there has to be a contract for *how* a Hook gets an LLM call, otherwise "Hook" is just a name.
+- Layer 1 is the substitutable part. Vendor portability lives here: every Layer-1 adapter is replaceable as long as it satisfies the Layer-2 contracts the Layer-3 primitives consume.
+
+### Architectural promise
+
+**Any framework that satisfies the v1.0 substrate primitive set automatically supports all required Layer-3 functional primitives.** New framework support is therefore a Layer-1 effort: prove the adapter satisfies Layer 2; Layer 3 falls out for free. This is why `free-claude-code` and an eventual Instar-native runtime are tractable additions, not rewrites.
+
+The Required Primitives Inventory (`required-primitives-inventory.md`) records, per functional primitive, which substrate primitives it depends on — making the dependency explicit instead of implied.
+
+## Two classes of primitives
+
+### Required primitives
+
+The foundational capabilities every Instar agent depends on. Instar defines what this set is. Examples (full catalog in the companion inventory doc): skill, agent, hook, tool, memory, instruction-file, session-resume, slash-command-or-equivalent, outbound-relay, conversational-action.
+
+For every (required-primitive × supported-framework) pair, the implementation comes from one of two sources:
+
+- **Framework-native** — the framework already provides the primitive. Instar wraps it, uses framework-specific rendering, gets the framework's optimizations.
+- **Instar-native fallback** — the framework lacks the primitive. Instar substitutes its own implementation. The agent and user feel no difference; the primitive Just Works.
+
+This is the gap-fill principle: a framework's lack of a required primitive is NEVER a reason to refuse support. Instar simply fills the gap.
+
+### Bonus primitives
+
+Capabilities that one framework offers but others don't, AND Instar isn't going to commit to as required. Examples might be: a framework's specific parallel-subagent execution model, a particular advanced sandbox mode, the `--oss --local-provider` flag in Codex CLI.
+
+For bonus primitives:
+
+- Instar is AWARE of them via the per-framework specs.
+- Instar OPPORTUNISTICALLY USES them when running on a framework that has them — extracts the optimal-leverage value.
+- On frameworks that lack them, the bonus simply doesn't apply (no promise, no emulation expected).
+- Agent self-awareness surfaces them: when the agent is on a framework that has a bonus capability relevant to the user's intent, it knows about it and can suggest using it.
+
+The reason bonus primitives exist as a separate class is honesty: not everything one framework can do should become Instar's universal commitment. Bonus is "Instar will leverage when available," not "Instar will guarantee everywhere."
+
+## The structural design
+
+### Layer 1 — Functional Components (Required + Bonus)
+
+Each component is an Instar-recognized abstraction. The catalog is the source of truth for what Instar treats as a primitive. Each entry has:
+
+- A definition (what it is, what it does).
+- Required-or-bonus classification.
+- A canonical source shape (framework-agnostic master representation, for required components).
+- A capability matrix entry per framework.
+- A rendering rule per supporting framework.
+- A parity invariant (what "in-sync" means for the parity sentinel).
+- For required components only: an Instar-native fallback implementation (the gap-filler).
+
+Required primitive catalog (initial draft — to refine):
+
+| Primitive | One-line definition |
+|---|---|
+| **Skill** | A reusable behavioral capability — markdown + scripts — discoverable as `/<name>` and triggerable by natural language. |
+| **Agent** | A spawnable persona with its own session state, identity, and instruction file. |
+| **Hook** | A program-defined response to a lifecycle event (session-start, pre-compact, file-change, etc.). |
+| **Tool** | A capability the agent can invoke during a turn (bash, file edit, web fetch, MCP server, etc.). |
+| **Memory** | Persistent state that survives session restarts (AGENT.md / MEMORY.md / USER.md / topic memory). |
+| **Instruction file** | Framework-loaded markdown that defines the agent's identity + system prompt augmentation. |
+| **Session-resume** | The mechanism for restoring a paused conversation. |
+| **Slash-command or equivalent** | The user-side textual invocation surface. |
+| **Messaging-platform integration** | Bidirectional, history-aware integration with the user-side messaging surface (Telegram, Slack, iMessage, WhatsApp). Covers outbound (agent → user), inbound (user → agent), and historical access (read prior conversation history scoped to platform-native containers — Telegram topic, Slack thread, iMessage chat). Consumed by session-resume and memory subsystems that need cross-platform history. |
+| **Conversational action** | The agent's ability to interpret natural-language config intent → clarify → execute. |
+| **MCP server registration** | Attaching external tool-server capability to the agent. |
+
+Bonus primitive catalog (examples — discovered as we research each framework):
+
+| Primitive | Framework | Definition |
+|---|---|---|
+| **Codex --oss local-provider** | Codex CLI | Direct flag for routing the model through Ollama / LM Studio without an external proxy. |
+| (more added as discovered) | | |
+
+### Layer 2 — Per-framework specs
+
+For each component supported by a framework, a spec lives at `specs/frameworks/<framework>/<component>.md`. Captures:
+
+- How that framework natively represents the component (filename, path, format, frontmatter, sibling files).
+- What the framework discovers / loads / surfaces and how.
+- Any pre-conditions (trust level, environment, version).
+- Known quirks, version notes, observed-not-documented behaviors.
+- For required primitives: whether this framework satisfies it natively or relies on Instar-native fallback.
+- For bonus primitives: when and how Instar leverages them.
+
+Updates on every new finding or framework version bump. These docs are the SOURCE OF TRUTH about that framework's specifics.
+
+### Layer 3 — Capability matrix
+
+A single `specs/instar-foundations/framework-capability-matrix.md` cross-references components × frameworks. Each cell is one of:
+
+- **native** — the framework has it; Instar wraps.
+- **instar-native** — the framework lacks it; Instar's own implementation fills the gap (required primitives only).
+- **augmented** — the framework has a partial implementation; Instar's native fills the missing pieces.
+- **bonus-available** — bonus primitive present in this framework; Instar opportunistically uses.
+- **n/a** — bonus primitive absent; not promised.
+
+When this cell changes (framework adds a feature, framework version regresses), the matrix updates. The parity sentinel reads the matrix to decide what to render vs what to flag.
+
+"Impossible" is no longer a category for required primitives — Instar's native fallback ensures every required primitive is always satisfied. The category remains conceptually for bonus primitives a framework simply doesn't have, but that's marked `n/a`, not `impossible`.
+
+### Layer 4 — The Parity Sentinel
+
+The runtime enforcer. Reads the component registry + per-framework specs + capability matrix. For every (required-primitive × enabled-framework) pair, verifies the rendering exists and matches the canonical source (whether via framework-native wrap or Instar-native fallback). Emits events on drift; takes remediation action per the policy locked earlier (trust-level-mirrored auto-fix; conflict-surfacing for manual edits; sibling-file rendering for framework-specific extras).
+
+Bonus primitives are also tracked but not "remediated" — the sentinel just maintains awareness of which are available where.
+
+Already designed in detail in `specs/provider-portability/13-framework-parity-sentinel.md`.
+
+### Layer 5 — Agent self-awareness
+
+Every Instar agent's instruction file (CLAUDE.md / AGENTS.md / GEMINI.md) auto-renders two sections:
+
+- **Required Capabilities** — every required primitive with one-line description + how to invoke. Identical content across frameworks; the rendering uses framework-appropriate examples.
+- **Framework Bonuses** — bonus primitives currently available in this framework with one-line description + when to suggest them.
+
+The agent uses this to: answer "what can I do" accurately, recognize natural-language intents that map to primitives, suggest creating new primitives ("you mentioned this twice — want me to make it a skill?"), and opportunistically leverage bonuses ("you're on Codex so we can use --oss for this private experiment").
+
+Rendered by IdentityRenderer from the same registry the sentinel uses. Single source, multiple consumers.
+
+## The long-term implication: Instar as framework
+
+Once every required primitive has:
+
+- An Instar-native fallback implementation (the gap-filler that runs when a framework lacks the primitive).
+- At least one framework-native rendering for at least one supported framework.
+
+…Instar IS, in fact, a generic agent framework. The substrate becomes optional: any model that can do basic tool-calling and instruction-following can power an Instar agent through the accumulated Instar-native fallback implementations.
+
+Four paths to running Instar coexist in this future:
+
+1. **Substrate passthrough** (today). Instar drives Claude Code or Codex CLI; the substrate handles model interaction.
+
+2. **Codex --oss passthrough** (v1.0.0). Local models via Codex's open-model flag. Shipping.
+
+3. **Free-claude-code passthrough** (next). Community project re-implementing Claude Code's flow on open models. Alternative substrate; same Instar abstractions.
+
+4. **Instar-native runtime** (eventual, naturally emerges from completing all Instar-native fallbacks). Instar drives the model directly — no substrate framework.
+
+Each path has its tradeoffs. Functional parity is the architecture that lets ALL of them coexist with consistent agent experience.
+
+## Sentinel-specific implications
+
+The Parity Sentinel (already designed) reads from this layered registry and:
+
+- Validates every required (primitive × enabled-framework) cell is properly rendered.
+- Detects drift between canonical source and rendered output.
+- Renders missing framework-native or Instar-native fallback implementations on framework-enable.
+- Mirrors user-initiated changes (new skill, edited memory) across all enabled frameworks.
+- Surfaces bonus primitives to the agent self-awareness layer without enforcing them.
+
+When a new framework is researched and added, the work is exactly: write per-framework specs for each required primitive + classify each bonus they offer + add their entries to the capability matrix. Zero changes to the abstract registry; zero changes to other frameworks' renderings.
+
+## Pacing proposal
+
+1. Lock the foundational principle (this doc, revision 2).
+2. Refine the required-primitive catalog (one round of input).
+3. Write the Skill prototype end-to-end (instar-concepts/skill.md + frameworks/claude-code/skills.md + frameworks/codex-cli/skills.md + parity-rule + e2e tests). Validate the shape.
+4. Instantiate remaining required primitives in priority order — Hook next (since the Codex hooks correction means it's worth establishing the pattern cleanly), then Agent, Tool, Memory.
+5. Build the parity sentinel as designed once 3+ primitives have rules; reuses the registry.
+6. Layer agent self-awareness on top.
+
+## Companion docs
+
+- `specs/instar-foundations/required-primitives-inventory.md` — the formal Required Primitives list with Instar-native fallback implementation status for each (already-built / partial / not-yet-built).
+- `specs/provider-portability/13-framework-parity-sentinel.md` — detailed sentinel design.
+
+## Corrections to revision 4
+
+- **Locked the required-primitive catalog** based on Justin's 2026-05-18 weigh-in. Hook is required. MCP-server registration is bonus for now. Conversational-action is its own primitive (locked the foundational stance: users explore + change every aspect of Instar conversationally; agent has high self-awareness + active guidance responsibility). Memory stays as one primitive but is flagged as a watch item. Session-resume stays as its own primitive.
+- **Renamed primitive #9 from "Outbound relay" to "Messaging-platform integration"** with expanded scope covering outbound + inbound + historical access. The reframe closes a quiet implicit dependency from session-resume (needs to read prior conversation context from the right platform/topic) and from memory subsystems (e.g., rolling-topic-summary sentinels that consume per-platform message history). Cross-primitive references added to entries #5 (Memory) and #7 (Session-resume).
+
+## Corrections to revision 2
+
+- Added the explicit **three-layer model** (Layer 3 functional primitives ↔ Layer 2 substrate primitives ↔ Layer 1 framework adapters) so the relationship between this doc and the v1.0 provider-portability primitives inventory is no longer implicit.
+- Added the **StallTriageNurse worked example** showing how a sentinel's LLM access is sourced — Layer-3 Hook requests a Layer-2 substrate primitive which is satisfied by the configured Layer-1 adapter.
+- Stated the **architectural promise**: any framework satisfying the v1.0 substrate primitive set automatically supports all required Layer-3 functional primitives. New framework adoption is a Layer-1 effort, not a rewrite.
+- Added a **"What is NOT a functional primitive"** section drawing the line between Layer-3 primitives and the context-engineering strategies that live *inside* the Memory primitive (recursive trees, knowledge graphs, semantic search, playbook). Stops primitive-catalog inflation and clarifies why those strategies are independent of the parity discussion.
+
+## Corrections to revision 1
+
+- Removed the incorrect claim that Codex lacks lifecycle hooks. Codex 0.130 has its own hooks system (configured via `hooks.json` in the project's `.agent/openai/` directory). Hook is a required primitive that both frameworks satisfy natively, with different file shapes.
+- Replaced "feature equivalence to most capable framework" framing with the cleaner required-vs-bonus distinction. Required primitives are uniform; bonuses are framework-specific opportunism.
+- Clarified that "impossible" is no longer a capability-matrix category for required primitives — Instar-native fallback always exists by definition for required primitives.

--- a/specs/instar-foundations/required-primitives-inventory.md
+++ b/specs/instar-foundations/required-primitives-inventory.md
@@ -1,0 +1,289 @@
+---
+status: draft
+date: 2026-05-18
+author: echo
+audience: justin
+type: companion-inventory
+parent: framework-functional-parity.md
+revision: 4
+---
+
+# Required Primitives — Inventory and Instar-Native Fallback Status
+
+## What this is
+
+The formal list of capabilities Instar treats as REQUIRED for any supported framework. For each primitive: a definition, current native support per framework, and the status of Instar's own native implementation that fills the gap when a framework lacks the primitive.
+
+This is the inventory that drives the parity sentinel's "required" cells in the capability matrix. Bonus primitives (framework-specific extras Instar uses opportunistically but doesn't require) live in `framework-functional-parity.md` and the per-framework specs.
+
+## Layer relationship — functional ↔ substrate ↔ adapter
+
+Every required functional primitive in this doc is **Layer 3** in Instar's three-layer model (see `framework-functional-parity.md` → "Layer relationships"). Each entry below now lists its **substrate dependencies** — the **Layer 2** primitives from the v1.0 provider-portability inventory (`specs/provider-portability/01-primitives-inventory.md`) that the functional primitive consumes under the hood.
+
+The chain is: Layer-3 functional primitive → declares which Layer-2 substrate primitives it needs → a Layer-1 framework adapter satisfies those substrate primitives.
+
+**Architectural promise**: any framework whose adapter satisfies the v1.0 substrate primitive set automatically supports all 11 required functional primitives in this inventory.
+
+## How to read the status columns
+
+For each (primitive × framework) cell:
+
+- **native ✓** — framework provides this; Instar wraps and uses the framework-native form. Rendering happens via Instar's framework-specific renderer.
+- **partial ⚠️** — framework provides part of the primitive but not all of it; Instar augments with its own implementation to cover the missing pieces.
+- **instar-native 🔧** — framework lacks the primitive; Instar's own implementation supplies the capability. The agent feels no difference.
+- **not yet built ⏳** — framework lacks the primitive AND Instar's own implementation hasn't been built yet; this is a current gap that the parity layer would fail.
+- **wrap exists, not generic 🟡** — Instar has a working implementation but it's tied to one specific framework's runtime; needs extraction into a framework-agnostic Instar-native form before becoming a real fallback.
+
+The principle: every required primitive must reach `native ✓` OR `instar-native 🔧` (or `partial ⚠️` with documented gap coverage) for every supported framework. `not yet built ⏳` cells are work items.
+
+## A primitive is a capability, not a file
+
+Several primitives below name the same on-disk artifact (notably `.instar/AGENT.md`, which is referenced by both **Memory** and **Instruction file**). This is intentional and not a primitive-boundary failure. The primitives are *capabilities*, not files:
+
+- **Memory** is the capability of identity/learning/relationship state surviving across sessions, being backed up, and syncing across machines. AGENT.md, USER.md, MEMORY.md, topic-memory.sqlite, and the knowledge-graph store are all *content artifacts* the Memory capability operates on.
+- **Instruction file** is the capability of the framework auto-loading a content blob into the session's system prompt at startup. AGENT.md is the content blob in question; the capability is the auto-loading contract with the framework.
+
+The two capabilities are orthogonal — one is about persistence/sync, the other is about framework-side context loading — and they happen to share a content artifact (AGENT.md) because identity is both "the persistent thing we remember about ourselves" AND "the thing we want loaded at every session start." A future Memory implementation that stored identity in a database row instead of a markdown file would still satisfy the Memory primitive; an Instruction-file implementation that loaded a different blob (say, a per-topic prompt fragment) would still satisfy the Instruction-file primitive. The primitives are independent; the *artifact reuse* is an implementation convenience.
+
+## The required primitives
+
+### 1. Skill
+
+**Definition.** A reusable behavioral capability — markdown + scripts — discoverable as `/<name>` and triggerable by natural-language intent that matches the skill's description.
+
+**Canonical source.** `skills/<name>/SKILL.md` at repo root (framework-agnostic master).
+
+**Substrate dependencies.** `agenticSession` (a skill runs inside one — the framework recognizes the slash command and the session executes the skill body), `toolAccess` (skills need tools to do anything), `toolAllowlist` (per-skill `allowed-tools` frontmatter restricts which tools are callable). Instar-native fallback would also need a discovery-and-dispatch layer Instar doesn't yet own.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ | Renders to `.claude/skills/<name>/SKILL.md`. Frontmatter: top-level `user-invocable`, `allowed-tools`, etc. |
+| Codex CLI 0.130 | partial ⚠️ | Native discovery works at `.agents/skills/<name>/SKILL.md` BUT requires sibling `agents/openai.yaml` with `interface.display_name` + `short_description`. Instar's current scaffolder writes to `.agent/openai/skills/` (wrong) and doesn't emit the YAML — both fixable in Phase 0. |
+| Instar-native fallback | not yet built ⏳ | If a future framework lacked skill discovery entirely, Instar would need to provide a skill-runtime that interprets SKILL.md content and surfaces invocation directly. Not built; not yet needed for currently-supported frameworks. |
+
+**Verification status.** Codex behavior verified via live test on 2026-05-18. See Phase 0 results.
+
+### 2. Hook
+
+**Definition.** A program-defined response to a lifecycle event — session-start, pre-compact, file-edit, session-stop, telegram-message, etc.
+
+**Canonical source.** TBD. Probably `hooks/<event>/<name>.sh` with a manifest.
+
+**Substrate dependencies.** `eventHooks` (the substrate-level callback-on-lifecycle-event pattern), plus — when a hook body needs LLM intelligence — `structuredCompletion` or `oneShotCompletion`. StallTriageNurse is the canonical worked example: it's a Hook whose body calls `structuredCompletion` to diagnose, then `inputInjection` to remediate.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ | `.claude/settings.json` configures hook scripts at `.claude/hooks/<event>/<name>.sh`. Extensive event vocabulary. |
+| Codex CLI 0.130 | native ✓ (different shape) | `hooks.json` in `.agent/openai/` (per scaffolder). Different event vocabulary — needs cross-framework mapping. |
+| Instar-native fallback | partial ⚠️ | Instar runs its own event-driven sentinels (CompactionSentinel, SessionWatchdog) but they're not user-defined hooks. A generic "user-defined-hooks-for-Instar-managed-events" layer would be the fallback. |
+
+**Open question.** Does the canonical hook source format need to encode framework-mapping (event name `session-start` maps to Claude's `SessionStart` and Codex's equivalent)? Or are events Instar-defined and frameworks-as-source emit them through observers we run?
+
+### 3. Agent
+
+**Definition.** A spawnable persona with its own session state, identity, and instruction file. (Claude calls these "subagents"; Codex has its own model.)
+
+**Canonical source.** TBD. Could be `agents/<name>/AGENT.md` + scripts + spec.
+
+**Substrate dependencies.** `agenticSession` (the persona runs as a multi-turn tool-using session), `sessionId` + `processLifecycle` (so the parent can track it), `authCredentialInjection` (per-agent identity). Sub-agents fired from an outer session additionally need `outputStream` and `hardKill` from the parent's perspective.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ | Subagents via Task tool or programmatic spawn; share state via Instar's session manager. |
+| Codex CLI 0.130 | needs research | Codex's subagent model needs documentation pass — research item. |
+| Instar-native fallback | wrap exists, not generic 🟡 | Instar's SessionManager.spawnInteractiveSession spawns sessions, which IS the agent primitive when framework-natively supported. Generic Instar-native version (running an agent without a framework) is the Instar-native-runtime future-state work. |
+
+### 4. Tool
+
+**Definition.** A capability the agent can invoke during a turn — bash, file edit, web fetch, MCP server, etc.
+
+**Canonical source.** Generally framework-provided; tools are part of framework runtime.
+
+**Substrate dependencies.** `toolAccess` (the bare ability for the model to call tools), `toolAllowlist` (restrict which tools), `fileSystemAccess` + `pathAllowlist` (file-touching tools), `bashExecution`, `webAccess`. Tool is the functional primitive most directly mapped onto the substrate capability layer.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ | Built-in tools (Read, Edit, Bash, Grep, ...) + MCP servers. |
+| Codex CLI 0.130 | native ✓ | Built-in tools (different names) + MCP servers via different config. |
+| Instar-native fallback | not yet built ⏳ | An Instar-native runtime would need its own tool-dispatch layer. Significant work; future-state. |
+
+**Note.** Tools are the primitive most closely bound to the substrate. Instar-native-runtime for tools = essentially building an agent harness from scratch.
+
+### 5. Memory
+
+**Definition.** Persistent state that survives session restarts: identity, learning, relationships, topic conversation history, and per-session continuity. A *capability*, not a file.
+
+**Canonical artifact set.** Currently: `.instar/AGENT.md` + `.instar/USER.md` + `.instar/MEMORY.md` + `.instar/state/topic-memory.sqlite` + the knowledge-graph store. The artifact set is implementation; the primitive is the persistence-and-retrieval semantic.
+
+**Internal organization strategies (below the primitive contract).** Memory's *internals* are an active area of design work: recursive tree structures (self-knowledge tree), recursive LLM-driven search, knowledge graphs, semantic search, the playbook scoring system, per-topic memory shards. These are how Memory chooses *what content* to surface for a given session and *how* it's organized — but they sit below the functional-primitive contract. The framework only sees the rendered output (e.g., the assembled AGENT.md blob). It doesn't know or care whether the content was hand-edited, tree-walked, semantic-search-assembled, or generated by recursive LLM summarization. This is why context-engineering strategies are largely *independent* of the parity discussion: they're Memory's internals, not separate primitives. They'd become more visible if/when the Instar-native runtime takes over context assembly directly (see foundational spec → Long-term implication).
+
+**Cross-primitive dependency.** Memory subsystems that need conversation history (e.g., a rolling-topic-summary sentinel, a relationship-tracker reading prior messages) consume **Messaging-platform integration's (#9) historical-access leg** to read message history scoped by platform-native conversation containers (Telegram topic, Slack thread, iMessage chat).
+
+**Watch item.** Memory is intentionally kept as one primitive *for now*, but Justin and Echo flagged 2026-05-18 that it's "broad AND critical" enough to revisit. Likely future split candidates: identity-memory (AGENT.md / MEMORY.md / USER.md) vs topic-memory (per-conversation rolling state) vs relationship-memory (knowledge graph). Tracked here so the next time Memory's internals grow significantly, the split question gets reopened.
+
+**Substrate dependencies.** `contextScopeControl` (which memory files the session is allowed to read at boot), `eventHooks` (session-start hook injects memory; pre-compact hook persists topic memory). Memory itself lives in Instar's own SQLite + flat files; substrate primitives only carry it into and out of sessions.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | partial ⚠️ | Reads CLAUDE.md as system-prompt augmentation. No framework-native session-restoration of arbitrary state — Instar provides that. |
+| Codex CLI 0.130 | partial ⚠️ | Reads AGENTS.md similarly. Same story — Instar provides the actual persistence. |
+| Instar-native | native ✓ | Memory IS an Instar-native primitive already. The framework's job is just to load the rendered instruction file at session start; the rest is Instar's. |
+
+Memory is the cleanest example of an Instar-native-required primitive: frameworks don't really do this; Instar always does.
+
+### 6. Instruction file
+
+**Definition.** The capability of the framework auto-loading a content blob into the session's system prompt at session start. A *loading mechanism*, not a file.
+
+**Canonical artifact (today).** `.instar/AGENT.md` is the content blob in current use. A future implementation could load a per-topic blob, a tree-assembled blob, or a model-rendered blob; the primitive contract is unchanged.
+
+**Substrate dependencies.** `contextScopeControl` (the substrate has to load this file into the session's prompt scope). Closely linked to Memory above — the instruction file is the entry point through which memory reaches the session.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ | Reads `CLAUDE.md` from project root. Rendered by IdentityRenderer. |
+| Codex CLI 0.130 | native ✓ | Reads `AGENTS.md` from project root. Rendered by IdentityRenderer. |
+| Instar-native fallback | not yet built ⏳ | An Instar-native runtime would read AGENT.md directly without framework rendering. Trivial when needed; not built yet because all current substrates have native support. |
+
+### 7. Session-resume
+
+**Definition.** Mechanism for restoring a paused conversation — agent picks up where it left off after a kill/restart. Has two coupled aspects: (a) restoring the framework-side model-session state (Claude `--resume <uuid>`, Codex `resume` subcommand), and (b) restoring the user-side conversation context by reading prior message history from whichever messaging-platform the conversation lives on. Both aspects must be intact for resume to feel seamless to the user.
+
+**Substrate dependencies.** `sessionId` (so we know which past session to resume), `agenticSession` (to re-attach to it), `processLifecycle` (to know if it actually came back up).
+
+**Cross-primitive dependency.** Consumes **Messaging-platform integration's (#9) historical-access leg** to read prior conversation context per platform-native container (Telegram topic, Slack thread, iMessage chat). Without this, resume restores the model but loses the conversational thread the user is actually living in.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ | `claude --resume <UUID>`. Instar uses TopicResumeMap to track. |
+| Codex CLI 0.130 | partial ⚠️ | `codex resume` exists as a subcommand. Instar's spawn path currently warns "codex CLI's 'resume' is a subcommand, not a flag — starting fresh" — needs integration. |
+| Instar-native fallback | partial ⚠️ | Instar's CompactionSentinel handles compaction-recovery (a form of session-resume), but full state-restoration on cold-start without framework support isn't built. |
+
+### 8. Slash-command or equivalent
+
+**Definition.** User-side textual invocation surface — `/route`, `/local-model`, etc.
+
+**Canonical source.** Each slash command is its own definition; usually tied to a skill OR to a server route + Telegram parser.
+
+**Substrate dependencies.** None at the substrate-call layer when handled by Instar's own Telegram parser (the slash command resolves to an HTTP route on Instar's server, no LLM involved). When the slash command auto-registers from a skill, dependencies are whatever the skill needs (see Skill above).
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ | Skills auto-register as `/<name>`. Plus Instar's Telegram parser handles `/route`, `/local-model`, etc. |
+| Codex CLI 0.130 | native ✓ | Same auto-register pattern from skills + Instar's Telegram parser. |
+| Instar-native | native ✓ | Instar's TelegramAdapter parses slash commands independently of the framework. |
+
+Slash-commands have a hybrid story: framework-side auto-registration from skills + Instar-native Telegram parsing. Both layers coexist.
+
+### 9. Messaging-platform integration
+
+**Definition.** The bidirectional, history-aware integration between an Instar agent and a user-side messaging surface (Telegram, Slack, iMessage, WhatsApp, etc.). Covers three coupled responsibilities:
+
+- **Outbound** — agent → user message delivery (currently the relay-script pattern on Telegram).
+- **Inbound** — user → agent message ingestion (long-poll / webhook / adapter-specific).
+- **Historical access** — reading prior conversation history scoped by platform-native conversation containers (Telegram topic, Slack channel/thread, iMessage chat). Consumed by session-resume (to know where the conversation left off) and by memory subsystems (e.g., a rolling-topic-summary sentinel that needs to read a topic's recent messages).
+
+**Why one primitive covers all three.** All three responsibilities are platform-shaped — Telegram topics, Slack threads, and iMessage chats have different containers, different ID schemes, and different read APIs. An adapter that handles one direction without the others is incomplete from an Instar perspective. Bundling them keeps the parity contract honest: "Instar supports messaging-platform X" means all three work uniformly.
+
+**Substrate dependencies.** `bashExecution` and `contextScopeControl` for the outbound relay-script pattern (currently). Inbound + historical access live in the messaging adapter layer (`src/messaging/`) and don't go through model-call substrate primitives — they're framework-independent infra reachable from any session.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ (with Instar config) | Outbound: SessionStart hook injects "MANDATORY: relay back" + relay script. Inbound + history: TelegramAdapter / SlackAdapter (Instar-native, platform-agnostic). |
+| Codex CLI 0.130 | instar-native 🔧 (post-PR #247) | Codex doesn't have an equivalent session-start hook for outbound; Instar fills the gap by inlining the relay block in every bootstrap message + auto-rendering it into AGENTS.md via IdentityRenderer. Inbound + history paths are identical to Claude (framework-independent). |
+| Instar-native | native ✓ | The relay route, inbound adapters, and history APIs are all Instar-native already. Frameworks only participate in the outbound-from-session leg. |
+
+**Note on cross-primitive references.** Session-resume (#7) consumes this primitive's historical-access leg to restore conversation context after a kill/restart. Memory (#5) consumes it for any subsystem that needs platform-aware history (rolling topic summaries, relationship-tracking against message history, etc.). These references are why messaging-platform integration is a *primitive*, not just an adapter-layer concern: other primitives depend on its contract.
+
+This was the cleanest "Instar filled a framework gap" case shipped this week (Codex outbound relay). Expansion to formally include inbound + history as one primitive — per Justin's 2026-05-18 reframe — closes a quiet implicit dependency from session-resume and memory subsystems.
+
+### 10. Conversational action
+
+**Definition.** The agent's ability to interpret natural-language config intent ("can we switch to a local model?"), ask clarifying questions if needed, and execute via an authed action endpoint. **Foundational stance** (locked 2026-05-18, per Justin): Instar users should not need to know ANY Instar internals. Every aspect of Instar's functionality must be explorable conversationally, and every config change must be doable conversationally on multiple levels. The agent maintains a very high degree of self-awareness of its own architecture AND a responsibility to actively guide the user — suggesting config changes from stated needs, recognizing when a stated need maps to "you want a hook here" or "you want a new skill" without the user having to know hook/skill exist. The slash-command surface is a backstop, not the primary path. Conversational is the default.
+
+**Canonical source.** Skills + AGENT.md self-awareness section + authed POST endpoints.
+
+**Substrate dependencies.** `oneShotCompletion` or `structuredCompletion` (intent classification + clarification phrasing — the same primitive StallTriageNurse uses), `agenticSession` (the in-flight session that hears the user and dispatches), `contextScopeControl` (so the self-awareness section reaches the agent). This primitive is the densest user of substrate-LLM access in the inventory.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | not yet built ⏳ | Self-awareness section in CLAUDE.md not yet auto-rendered; conversational-action API endpoints not yet exposed. Designed in `13-framework-parity-sentinel.md`. |
+| Codex CLI 0.130 | not yet built ⏳ | Same status. |
+| Instar-native | not yet built ⏳ | The endpoints + the registry + the renderer integration are the work. |
+
+This is the design layer Justin asked for after `/local-model` shipped. It depends on the parity sentinel + functional-component registry being in place.
+
+### 11. MCP server registration
+
+**Definition.** Attaching external tool-server capability to the agent.
+
+**Substrate dependencies.** Extends `toolAccess` (MCP servers expand the tool set). Configuration is framework-local (per-machine), so there's no Instar-side substrate call — registration happens at framework-config layer, not at session-call layer.
+
+| Framework | Status | Notes |
+|---|---|---|
+| Claude Code | native ✓ | `claude mcp add` writes to `~/.claude.json`. Per-machine, NOT synced by Instar — known constraint. |
+| Codex CLI 0.130 | native ✓ | Codex has its own MCP config format. Per-machine. |
+| Instar-native fallback | not yet built ⏳ | Instar could provide its own MCP-client layer for an Instar-native runtime. Not currently needed; per-machine framework-native is fine for both supported frameworks. |
+
+## Summary: Status snapshot
+
+Among 11 required primitives × 2 currently-supported frameworks = 22 cells, plus Instar-native fallback column:
+
+- 12 cells `native ✓` (framework natively satisfies the primitive)
+- 6 cells `partial ⚠️` (framework partially satisfies; Instar augments)
+- 1 cell `instar-native 🔧` (framework gap, Instar's own fills — currently only Codex outbound-relay)
+- 3 cells `not yet built ⏳` (in the conversational-action row — work items)
+- Plus 4 Instar-native fallback rows marked `not yet built ⏳` (skill, instruction-file, tool, MCP) — these are future-work for the Instar-native-runtime path, not blockers today.
+
+## Priority order for filling gaps
+
+1. **Codex skill rendering correction.** Phase 0 work: fix `.agent/openai/skills/` → `.agents/skills/`; emit `agents/openai.yaml` sibling. Shifts Skill on Codex from `partial ⚠️` to `native ✓`. Smallest gap, highest verified impact.
+
+2. **Codex session-resume integration.** Use `codex resume` subcommand when a session has a tracked Codex session id. Shifts session-resume on Codex from `partial ⚠️` to `native ✓`.
+
+3. **Conversational-action layer.** All three `not yet built ⏳` cells in row 10. This is the spec we discussed — endpoints + registry + renderer integration.
+
+4. **Hook canonical-source format + cross-framework mapping.** Lets users author hooks once and Instar renders them for both Claude and Codex correctly.
+
+5. **Agent primitive research + canonical-source format.** Establishes the pattern for "spawnable persona."
+
+Lower-priority (Instar-native-runtime future-state work):
+
+6. Tool dispatch (Instar-native).
+7. MCP-client (Instar-native).
+8. Instruction-file loading (Instar-native).
+9. Skill discovery (Instar-native).
+
+## Revision history
+
+- **rev 4 (2026-05-18)** — Locked the catalog from Justin's weigh-in: Hook=required, MCP=bonus, Conversational-action=required (with foundational stance on conversational discoverability + agent self-awareness + active user guidance baked into the definition), Memory=one-for-now-watch-closely, Session-resume=own primitive. Renamed primitive #9 from "Outbound relay" to "Messaging-platform integration" — bidirectional + history-aware — and added cross-primitive references to Memory (#5) and Session-resume (#7). Resolved-questions block records each call; new-questions block captures the next layer (Memory-split trigger, hook-event vocabulary, self-awareness granularity, messaging-adapter contract shape).
+- **rev 3 (2026-05-18)** — Re-anchored Memory and Instruction-file entries to *capabilities* rather than file paths to resolve the apparent double-listing of `.instar/AGENT.md`. Added "A primitive is a capability, not a file" framing section explaining why artifact overlap between primitives is intentional. Added an "Internal organization strategies" note to Memory explicitly placing context-engineering strategies (recursive trees, knowledge graphs, semantic search, playbook) below the primitive contract.
+- **rev 2 (2026-05-18)** — Added "Substrate dependencies" field to every primitive entry naming which Layer-2 substrate primitives (from `specs/provider-portability/01-primitives-inventory.md`) each Layer-3 functional primitive consumes. Added the "Layer relationship" framing section explaining how this inventory sits on top of the v1.0 substrate primitives catalog and the architectural promise: satisfying the v1.0 substrate set automatically satisfies all 11 functional primitives.
+- **rev 1 (2026-05-18)** — Initial inventory.
+
+## Resolved questions (2026-05-18)
+
+All four original open questions were resolved with Justin in conversation. Recording the calls so the parity sentinel and downstream specs can rely on them:
+
+- **Q1. Conversational action — separate primitive?** **Yes, primitive.** Drives the foundational stance: users explore + change every aspect of Instar conversationally; agent maintains very high self-awareness; agent guides user. Inlined into primitive #10's definition above.
+
+- **Q2. Hook — required or bonus?** **Required.** Too much load-bearing Instar infrastructure (session-start identity injection, compaction recovery, telegram-message dispatch) depends on lifecycle events. If a framework lacked hooks, Instar would emulate. Tied to a refinement on Q5 below — users don't "request a hook"; the agent recognizes when a stated need calls for one.
+
+- **Q3. MCP server registration — required or bonus?** **Bonus (for now).** Useful when present; Instar doesn't depend on it. Promoting it to required would force an MCP-client shim for any framework that lacked it. Reopen if a future Instar capability becomes structurally dependent on MCP.
+
+- **Q4. Memory — one primitive or several?** **One, for now.** Shared contract is "persists across sessions, survives restarts, syncs across machines." Internal organization (tree / graph / search / playbook) stays below the primitive line. Flagged as a watch item in the Memory entry — broad enough that the split question stays live for next time Memory's internals grow.
+
+- **Q5. Hook canonical-source format — Instar-defined events vs canonical mapping?** **Hybrid.** Instar-defined events for things only Instar sees (compaction, telegram-message). Framework-event mapping for things only the framework sees (file-edit, pre-tool-use). Each event has one canonical owner. Important refinement from Justin: users don't "request a hook" — they state a need and the agent recognizes hook is the right fit. The hook-authoring surface is internal; the user-facing surface is conversational (see primitive #10).
+
+- **Q6. Session-resume — own primitive or parameter of Agent?** **Own primitive.** Resume has distinct failure modes (state corruption, ID-not-found, partial restore) and distinct observability needs from cold-spawn. Also: resume now formally depends on the Messaging-platform integration primitive's historical-access leg (see entry #7).
+
+## New open questions (post-2026-05-18 lock)
+
+- **When does Memory split?** No trigger criterion defined. Probably: when topic-memory and identity-memory grow divergent failure/observability characteristics. Until then, watched.
+
+- **What's the right canonical hook-event vocabulary?** Need a concrete list of Instar-defined events (and which framework-side events get mirrored). Pre-work for the Hook concept spec.
+
+- **How granular should the agent's self-awareness section be?** Every skill listed? Every config knob? Every endpoint? Affects how Conversational-action (#10) is rendered into instruction files. Probably: skills + capability index by default; deeper docs queried on demand via the existing self-knowledge tree.
+
+- **What's the right messaging-platform abstraction shape?** Now that messaging-platform integration is one bidirectional+history primitive, what does the canonical "adapter contract" look like? Affects future Slack/iMessage/WhatsApp parity work.
+

--- a/specs/provider-portability/13-framework-parity-sentinel.md
+++ b/specs/provider-portability/13-framework-parity-sentinel.md
@@ -1,0 +1,151 @@
+---
+status: proposal
+date: 2026-05-18
+author: echo
+audience: justin
+---
+
+# Framework Parity Sentinel — design proposal
+
+## What this is
+
+A sentinel that keeps Instar maximally compatible across frameworks (Claude Code, Codex CLI, future: Gemini CLI, etc.) by detecting drift between framework-specific representations of the same logical resource and either fixing it or surfacing it to the operator.
+
+Concretely: when a user installs Instar with Claude Code, then enables Codex, the sentinel automatically renders the Codex-side mirrors (AGENTS.md, `.agents/skills/`, etc.) so the agent works equivalently in both. When the user adds a skill under one framework, the sentinel mirrors it to the others. When framework-specific files drift apart from their canonical source, the sentinel detects it.
+
+## Research foundation
+
+Three parallel research passes underpin this proposal:
+
+1. **Skill protocol comparison (web research, authoritative docs)** — what does Anthropic's Claude Code spec say, what does Codex CLI 0.130 actually load, where do they diverge?
+2. **Substrate gap inventory (in-repo scan)** — every file in Instar that's framework-aware vs the (much larger) set of files that assume Claude conventions silently.
+3. **Cartographer + existing sentinel patterns** — so the new sentinel inherits the established shape rather than reinventing.
+
+## Findings that change the design
+
+### Finding 1: Instar's Codex skill path is wrong
+
+- **Instar currently writes:** `.agent/openai/skills/<n>/SKILL.md` (singular `.agent`, provider-namespaced).
+- **Codex 0.130 documented path:** `.agents/skills/<n>/SKILL.md` (plural `.agents`, shared across providers).
+- **Codex 0.130's actual behavior on `.agent/openai/skills/`:** unverified. Likely loaded as nothing, since Codex's discovery walks the documented path.
+
+Instar may be writing skills Codex never reads. This is the highest-confidence drift in the codebase and it should be confirmed and fixed *before* building the sentinel — otherwise the sentinel's first rule will be encoding a bug.
+
+### Finding 2: Instar's skill frontmatter is silently wrong for both frameworks
+
+- Instar emits `metadata.user_invocable: "true"` (nested under `metadata`, string-valued).
+- Claude Code's spec: `user-invocable: true` (top-level, hyphenated, boolean).
+- Codex's spec: doesn't surface a `user-invocable` field at all — uses different metadata.
+
+Today's emitter writes a key neither side parses. Fixable independent of the sentinel.
+
+### Finding 3: ~20 places assume `.claude/` without checking framework
+
+Concentrated in: transcript path readers (PreCompactionFlush, TokenLedger, SessionResumeIndex), bootstrap commands (init, setup, CapabilityMapper, scaffold/templates), monitoring scopes (CompactionSentinel, TemplatesDriftVerifier, ScopeCoherenceTracker), user-facing paths (TelegramMarkdownFormatter, telegramRelayPrompt). Most are *latent* — they wouldn't fire on a pure-Claude install but would silently no-op on a Codex install.
+
+Full inventory: 9 framework-aware files (good), ~20 Claude-leaning files (drift candidates), 6 sentinels framework-aware vs 8 not, 3 CLI commands framework-aware vs 7 not.
+
+### Finding 4: The existing cartographer is full-scan, not incremental
+
+`src/core/ProjectMapper.ts` regenerates from scratch on demand; no per-file mtime/sha tracking. Sentinels that need incremental scanning maintain their *own* high-water marks (CommitmentSentinel uses `topicHighWaterMark: Record<topic, lastMid>`; SessionActivitySentinel uses `lastDigestedAt`).
+
+So: the cartographer is the right CONSUMER, not the right STORAGE for staleness. The new sentinel stores its own scan-cursor state.
+
+## The proposal
+
+### Layer 1: Parity Rules (declarative registry)
+
+A new file `src/monitoring/parity/parityRules.ts` exports a static array. Each rule:
+
+```typescript
+interface ParityRule {
+  id: string;                            // 'identity-shadow', 'skill-mirror', 'hook-mirror'…
+  appliesTo: IntelligenceFramework[];    // which frameworks this rule cares about
+  source: {
+    path: string;                        // canonical or first-discovered path
+    discovery: 'canonical' | 'glob';     // single file vs pattern
+  };
+  targets: Array<{
+    framework: IntelligenceFramework;
+    path: string;                        // mirror path under that framework
+    render: 'identity' | 'rename' | 'transform'; // how source becomes target
+  }>;
+  validate: (sourcePath, targetPath) => 'in-sync' | 'drift' | 'missing-target';
+  remediate: (sourcePath, targetPath) => Promise<void>;
+  expectedFrequency: 'on-enable' | 'on-source-change' | 'interval-only';
+}
+```
+
+Examples:
+
+- **identity-shadow** — source `.instar/AGENT.md`, targets `CLAUDE.md` + `AGENTS.md` + `GEMINI.md`. Already handled by `IdentityRenderer` — rule wraps that for sentinel consumption.
+- **skill-mirror** — source `skills/<n>/SKILL.md` (canonical), targets `.claude/skills/<n>/SKILL.md` + `.agents/skills/<n>/SKILL.md`. Skill body is identical; frontmatter renders per-framework (Claude-friendly vs Codex-friendly fields).
+- **scripts-mirror** — source `.claude/scripts/<x>` (legacy canonical), targets to confirm under `.codex/scripts/` or whichever convention Codex actually wants.
+- **conversational-action-catalog** — when a new SKILL.md mentions a /command, the sentinel appends a one-line entry to AGENTS.md/CLAUDE.md's "Conversational Skills Index" section. This is the higher-layer Justin asked about earlier.
+
+Rules are the GAP MAP. Adding a rule is how operators declare a new parity invariant. The registry is small and reviewable — order of 10–20 rules covers the substrate.
+
+### Layer 2: The Sentinel itself
+
+`src/monitoring/FrameworkParitySentinel.ts`. Inherits the standard pattern (EventEmitter + state file + dedup by territory):
+
+- **Construction**: deps include `projectDir`, `stateDir`, `enabledFrameworks` (from config), `parityRules` (the registry).
+- **Triggers**:
+  1. **On framework-enable** — invoked by `instar route` / config change / new framework binary detected. Runs full scan + remediates.
+  2. **On source-change** — chokidar-style filesystem watcher on the rule source paths. Fires the rule's `remediate`. (Skill add → mirror to others.)
+  3. **On interval** — every 30 min, scan rules whose `expectedFrequency` includes `'interval-only'`. Catches drift from manual edits.
+- **State persistence**: `.instar/state/framework-parity-sentinel.json` with `{ rulesScanned: Record<ruleId, { lastScanAt, lastSourceMtime, lastResult }> }`. Survives restart.
+- **Output**:
+  - EventEmitter: `parity:gap-found`, `parity:remediated`, `parity:conflict`.
+  - DegradationReporter on rule failures.
+  - HTTP API: `GET /api/framework-parity/status` (current rule state), `POST /api/framework-parity/scan` (force a full pass).
+- **Staleness model** (Justin's "stale" / "new" / "scanned recently" classification):
+  - `new`: rule.source matches files the sentinel has never seen.
+  - `stale`: source mtime > `lastSourceMtime` recorded in state.
+  - `fresh`: source mtime ≤ `lastSourceMtime`. Skip.
+  - On interval scans, only `new` and `stale` rules execute.
+
+### Layer 3: Self-knowledge integration
+
+The agent (when receiving a natural-language config request) should be able to *ask* the sentinel about parity state. Two endpoints make this conversational:
+
+- `GET /api/framework-parity/status` returns "what's installed, what's missing, what drifted." Agent uses this when user asks "are we set up for Codex?" or "can I switch to local model" (which requires Codex framework + skill mirrors).
+- `POST /api/framework-parity/remediate?rule=skill-mirror` — explicit, auditable, scoped. Agent calls this when user says "fix it" / "set up Codex too."
+
+This is the same shape as `/local-model` — it's the conversational-action substrate Justin asked for, just generalized.
+
+## What ships in phase 1 (verify-first)
+
+Before building the sentinel:
+
+1. **Empirically verify Codex 0.130 path.** Install a skill at `.agents/skills/test/SKILL.md` (Codex documented path) AND `.agent/openai/skills/test/SKILL.md` (Instar's current path). Drive a Codex session that runs `/test`. See which one loads.
+2. **Empirically verify Claude frontmatter.** Install a skill with `user-invocable: true` (top-level) and one with `metadata.user_invocable: "true"` (nested). Check which Claude auto-discovers.
+
+Both verifications are 10 minutes each. They lock the FIRST TWO parity rules before any sentinel code lands.
+
+## Phased rollout
+
+| Phase | Scope |
+|---|---|
+| 0 | Verify Codex skill path + Claude frontmatter via live tests. Fix the silent emitter drift (one PR). |
+| 1 | Parity registry + 4 seed rules (identity-shadow, skill-mirror, scripts-mirror, hook-mirror). No sentinel yet — just `npm run parity:scan` CLI that consumes the registry. |
+| 2 | FrameworkParitySentinel: on-enable + interval trigger. State file + EventEmitter. `/api/framework-parity/status`. |
+| 3 | Filesystem watcher for source-change trigger (skill added under one framework → mirrored to others). |
+| 4 | Generalize: agent gains the "conversational-action catalog" appendix; new SKILL.md auto-indexes itself in AGENTS.md/CLAUDE.md. |
+
+## Open questions / where I'd like your input
+
+- **Mirror direction asymmetry.** When skill is added under `.claude/skills/`, do we mirror to `.agents/skills/`? Or treat the canonical source as `skills/<n>/SKILL.md` (already shipping in the repo) and mirror BOTH framework outputs from there? The repo-root `skills/` directory exists today — leaning toward making that the source-of-truth and treating the framework dirs as renderings.
+- **Conflict resolution.** Operator edits `.claude/skills/X/SKILL.md` directly. Source-of-truth is `skills/X/SKILL.md`. Sentinel sees drift. Does it (a) overwrite the operator's edit with re-render, (b) overwrite source with operator's edit, or (c) emit conflict + leave both for resolution? Leaning toward (c) — never silently overwrite operator intent.
+- **Codex-specific rendering of skill frontmatter.** If Codex needs a sibling `agents/openai.yaml` for tool dependencies, do we encode that in the skill markdown as a special section and have the sentinel extract it? Or keep it framework-specific outside the canonical skill?
+- **How autonomous to make remediation.** On framework-enable, should the sentinel auto-fix without asking? Or surface "I detected 4 gaps, want me to fix?" Leaning toward auto-fix for trivially-derivable mirrors (identity shadow, skill mirror) and operator-confirm for anything involving content transformation.
+
+## Estimate
+
+Phase 0: 1 hour (verification + emitter fix).
+Phase 1: 3-4 hours (registry + scan CLI + 4 rules + tests).
+Phase 2: 4-6 hours (sentinel + state + routes + tests).
+Phase 3: 2-3 hours (chokidar watcher).
+Phase 4: 2-3 hours (conversational-action layer using the registry).
+
+Total: ~half a day to a full day, gated on Phase 0 verification.


### PR DESCRIPTION
## Summary

- Lands the three foundational design artifacts that motivated PR #249's scaffolder fix and seed every subsequent framework-parity PR.
- `specs/instar-foundations/framework-functional-parity.md` (rev 5) — the parity principle + 3-layer model + locked primitive catalog + "what is NOT a primitive" bound.
- `specs/instar-foundations/required-primitives-inventory.md` (rev 4) — 11 required primitives with substrate dependencies, per-framework status, cross-primitive references, resolved/open questions, revision history.
- `specs/provider-portability/13-framework-parity-sentinel.md` — sentinel design that consumes the inventory.

Pure docs — no behavior change. NEXT.md extended with a note referencing the foundational docs landing alongside the v1.0.1 scaffolder fix.

## Test plan

- [x] No source code touched — pre-commit gate passes (specs/ + upgrades/ out of scope)
- [x] Pre-push smoke clean
- [x] Visible in `specs/` tree on the PR

## Process

`/instar-dev` pre-commit gate did NOT block — `specs/` is not in scope for the gate. No bypass needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)