### PR TITLE
fix(parity): hookParityRule alwaysOverwrite — restore Migration Parity §4

### DIFF
--- a/.instar/instar-dev-traces/20260519T060000Z-hook-always-overwrite.json
+++ b/.instar/instar-dev-traces/20260519T060000Z-hook-always-overwrite.json
@@ -1,0 +1,20 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/hook-always-overwrite.md",
+  "artifactPath": "upgrades/side-effects/fix-hook-stamp-migration-parity.md",
+  "artifactSha256": "25d47afa041deaf8275c29fc7099082ed4a508ef65b931408a14a6218b65a712",
+  "coveredFiles": [
+    "src/providers/parity/types.ts",
+    "src/providers/parity/rules/hookParityRule.ts",
+    "src/monitoring/FrameworkParitySentinel.ts",
+    "tests/unit/providers/parity/hookParityRule.test.ts",
+    "tests/unit/monitoring/FrameworkParitySentinel.test.ts",
+    "specs/dev-infrastructure/hook-always-overwrite.md",
+    "specs/dev-infrastructure/hook-always-overwrite.eli16.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/fix-hook-stamp-migration-parity.md"
+  ],
+  "writtenAt": "2026-05-19T06:00:00Z",
+  "agent": "echo",
+  "summary": "Restore Migration Parity §4 (built-in hooks always overwritten) by adding alwaysOverwrite field to ParityRule, setting it true on hookParityRule, and routing the user-edit-conflict signal through a new parity:user-edit-overwritten audit event in FrameworkParitySentinel. Tests inverted and added. Audit-identified critical backtrack from PR #253."
+}

--- a/docs/specs/reports/hook-always-overwrite-convergence.md
+++ b/docs/specs/reports/hook-always-overwrite-convergence.md
@@ -1,0 +1,29 @@
+# Convergence Report — hookParityRule alwaysOverwrite amendment
+
+## ELI10 Overview
+
+Instar ships built-in hooks (scripts that fire at lifecycle moments like session-start). The policy is clear: when Instar updates, the canonical version of a built-in hook always wins. Always. The Hook primitive that landed last week accidentally broke this policy with a clever-but-wrong stamp pattern — it noticed when a user had edited the rendered hook and refused to overwrite. The protective intent was inverted: silent stuck-on-broken-template is exactly the failure §4 was written to prevent. This release inverts the policy back: always overwrite, but emit an audit signal so any clobbered user edit is recoverable from git.
+
+## Original vs Converged
+
+The amendment doesn't redesign the parity primitive; it restores the documented Migration Parity §4 invariant that the v0.1 implementation broke. The original implementation had verify() flag user-edits AND remediate() refuse to write. The converged shape: verify() still flags, remediate() always overwrites (for rules opting into alwaysOverwrite), and the sentinel emits a new parity:user-edit-overwritten event for audit.
+
+The cleanest abstraction is per-rule: each ParityRule declares its applicable Migration Parity policy. Hooks set alwaysOverwrite=true (§4). Skills leave it undefined (§5 — refuse-on-conflict, dedicated migrations override).
+
+## Iteration Summary
+
+| Iteration | Reviewers run | Material findings | Spec changes |
+|-----------|---------------|-------------------|--------------|
+| 1 | Manual lessons-check (against canonical principles index) | 0 contradictions; 0 deferrals | None |
+
+## Manual lessons-aware findings
+
+See the lessons-engaged frontmatter and the manual lessons-check table in the spec body. Every Part 1 principle (P1-P10) plus relevant Part 2 architectural lessons walked. The amendment is itself a direct fix for the recurrence pattern catalogued at B28 (Spec-converge pre-auth circular). No contradictions, no deferrals.
+
+## Convergence verdict
+
+Converged at iteration 1. This is a tactical amendment to a merged primitive; the lessons-aware reviewer (PR #258) is the structural defense going forward, and this amendment is the corrective for the case already on main when the audit caught it.
+
+## Deviation note
+
+Tactical amendment to merged primitive. Lessons-aware reviewer (PR #258) just merged to its branch but is awaiting re-land to main (the gh PR auto-merge target-rewrite mishap closed it without the changes propagating). Manual lessons-check applied transparently in the spec body against the canonical principles index — same bootstrap pattern PR #258 used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3063,7 +3063,7 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/hook-always-overwrite.eli16.md
+++ b/specs/dev-infrastructure/hook-always-overwrite.eli16.md
@@ -1,0 +1,39 @@
+---
+title: "Hook always-overwrite amendment — ELI16"
+slug: "hook-always-overwrite-eli16"
+parent: "hook-always-overwrite.md"
+---
+
+# Hook always-overwrite amendment — explained simply
+
+## What this fixes
+
+When Instar ships a built-in hook script (the bits of code that fire when a Claude Code session starts, when a tool is used, when a stop happens, etc.), the rule is: the canonical version Instar ships ALWAYS wins. On every `instar update`, every built-in hook gets re-rendered from the canonical source, overwriting whatever was on disk.
+
+This rule has a name: **Migration Parity §4**. It was written after a real incident — `hook-event-reporter.js` was install-if-missing, so agents whose host environment was ESM got stuck with a broken CJS `require('http')` version forever. The fix at the time was: built-in hooks always overwrite, no install-if-missing wedge.
+
+The Hook primitive that shipped in PR #253 (a few days ago) accidentally resurrected the wedge in a more subtle form: it added a stamp comment to the rendered hook (`# x-instar-stamp: <hash>`), and if the rendered file was edited by a user (stamp still matches the canonical hash but body differs), the parity rule REFUSED to overwrite. The intent was protective — "don't clobber the user's edit." The effect was the same broken-template-stuck-forever pattern §4 was written to prevent.
+
+## What changed
+
+Three small changes:
+
+1. The `ParityRule` interface gained an optional `alwaysOverwrite` flag.
+2. The Hook parity rule sets `alwaysOverwrite: true`.
+3. When the parity sentinel sees a user-edited canonical hook, it still calls `remediate()` (which now overwrites), and emits a new audit event `parity:user-edit-overwritten` so the operator has a paper trail. Any edit a user made can still be recovered from git history.
+
+The detection of "user edited this" stays — that's the signal. The decision to overwrite anyway is the authority, and §4 is that authority for built-in hooks.
+
+## Why this is the right shape
+
+This is the **signal vs authority** pattern in action. The stamp comment is brittle, low-context detection — it flags that something changed. Whether to overwrite isn't its decision; that decision belongs to the higher-context Migration Parity policy. For built-in hooks (§4), overwrite. For built-in skills (§5), refuse and let `PostUpdateMigrator` decide. The `alwaysOverwrite` field lets each rule express its policy declaratively.
+
+## What changes for agents and users
+
+For deployed Instar agents: on the next `instar update` after this lands, any user-edited built-in hook gets re-rendered from canonical. If the user wanted a different behavior, they can put their version in `.claude/hooks/custom/` (which is never touched) or fork the canonical source in `.instar/hooks/canonical/`.
+
+For Justin: this is the structural fix for the second of two critical backtracks the audit surfaced. The first (Conversational-action inlining a catalog into AGENT.md) was fixed in PR #256 pre-merge. This one was already on main, so it ships as an amendment.
+
+## What this is NOT
+
+Not a change to skill behavior. Skills are governed by Migration Parity §5 (refuse-on-conflict is correct, dedicated migrations override). Not a change to custom hooks. Not a change to the parity rule's verify() behavior — drift detection is unchanged. Just the remediate() decision for canonical hooks.

--- a/specs/dev-infrastructure/hook-always-overwrite.md
+++ b/specs/dev-infrastructure/hook-always-overwrite.md
@@ -1,0 +1,120 @@
+---
+title: "hookParityRule alwaysOverwrite — amendment per Migration Parity §4"
+slug: "hook-always-overwrite"
+author: "echo"
+status: "converged"
+type: "amendment-spec"
+eli16-overview: "hook-always-overwrite.eli16.md"
+review-convergence: "2026-05-19T05:30:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-19T05:30:00Z"
+review-report: "docs/specs/reports/hook-always-overwrite-convergence.md"
+review-deviation: "Tactical amendment to merged primitive (PR #253). Lessons-aware reviewer (PR #258) just merged and is not yet rolled out to deployed agents — manual lessons-check applied transparently in spec body against the canonical principles index."
+approved: true
+approved-by: "Justin (pre-authorized 2026-05-18, autonomous-mode hybrid C, with explicit 2026-05-19 acknowledgment + audit-driven amendment scope)"
+approved-date: "2026-05-19"
+approval-note: "Audit-identified critical backtrack: hookParityRule shipped refuse-on-user-edit-conflict for canonical (built-in) hooks, contradicting Migration Parity §4 (built-in hooks always overwritten on every migration run — never install-if-missing). This is the structural fix."
+lessons-engaged:
+  - "P1 (Structure>Willpower): contract change at the ParityRule interface enforces alwaysOverwrite structurally; not a per-rule docs request."
+  - "P2 (Signal vs Authority): user-edit-conflict remains a signal (verify() emits it; sentinel emits parity:user-edit-overwritten for audit); refuse-to-write authority is removed for canonical hooks."
+  - "P3 (Migration Parity §4): direct fix — built-in hooks always overwritten per the documented policy."
+  - "P4 (Testing Integrity): tier-1 unit tests updated; remediate-always-overwrites test added; sentinel test added for new event; existing test inverted."
+  - "P10 (Comprehensive-First): full fix in v0.1 (interface change + rule change + sentinel change + tests). No deferred recurrence-risk."
+  - "L1 (AGENT.md bloat): N/A — no AGENT.md changes."
+  - "L6 (Side-effects review): seven-dimension review at upgrades/side-effects/fix-hook-stamp-migration-parity.md."
+  - "L9 (ELI16 required): hook-always-overwrite.eli16.md sibling."
+  - "L10 (Release notes in same PR): upgrades/NEXT.md in this PR."
+  - "B28 (Spec-converge pre-auth circular): this amendment is the second case caught by the audit — first was the Conversational-action AGENT.md inlining."
+---
+
+# hookParityRule alwaysOverwrite — amendment per Migration Parity §4
+
+## What changed
+
+`src/providers/parity/rules/hookParityRule.ts` `remediate()` previously threw `CanonicalHookError` when the rendered hook had a `user-edit-conflict` (stamp matches canonical hash, but body differs — user edited the rendering). That refuse-on-conflict for built-in hooks contradicts Migration Parity §4:
+
+> **Built-in hooks (`instar/` directory) are always overwritten on every migration run — never install-if-missing.** This ensures agents can't get stuck on broken templates (lesson from `hook-event-reporter.js`: it was install-if-missing, so agents with ESM hosts got stuck on a broken CJS `require('http')` — fixed by switching to always-overwrite). Custom hooks (`custom/` directory) are never touched.
+
+The fix:
+
+1. **`src/providers/parity/types.ts`** — added optional `alwaysOverwrite?: boolean` field to the `ParityRule` interface. Updated `remediate()` contract docstring: "Throws if the current rendering has a `user-edit-conflict` AND the rule is not marked `alwaysOverwrite: true`."
+2. **`src/providers/parity/rules/hookParityRule.ts`** — set `alwaysOverwrite: true` on `hookParityRule`; removed the refuse-on-conflict throw in `remediate()`. The `verify()` behavior is unchanged — it still flags `user-edit-conflict` as a mismatch (the signal).
+3. **`src/monitoring/FrameworkParitySentinel.ts`** — when verifying a rule with `alwaysOverwrite: true`, a `user-edit-conflict` mismatch is treated as drift (remediation proceeds), and the sentinel emits a new `parity:user-edit-overwritten` event for audit. Operators can recover any clobbered user edit via git.
+4. **Tests** — `tests/unit/providers/parity/hookParityRule.test.ts`: inverted the prior "remediate refuses on user-edit-conflict" test into "remediate ALWAYS OVERWRITES user-edits per Migration Parity §4" + added "advertises `alwaysOverwrite=true`". `tests/unit/monitoring/FrameworkParitySentinel.test.ts`: added "alwaysOverwrite=true rule REMEDIATES through user-edit-conflict and emits parity:user-edit-overwritten".
+
+## Why this ships now
+
+Audit-identified critical backtrack. The Hook primitive (PR #253) shipped with a stamp-and-refuse-on-conflict pattern that resurrects exactly the "install-if-missing wedge" Migration Parity §4 was written to prevent.
+
+The recurrence path: in PR #253's convergence, the author wrote both the spec and ran the convergence with internal reviewers focused on security/scalability/adversarial/integration — none of them carried the brief "does this contradict a documented Migration Parity rule." The lessons-aware reviewer (PR #258, just merged) is the structural fix going forward; this amendment is the corrective for the case already shipped.
+
+The skillParityRule keeps refuse-on-conflict because Migration Parity §5 explicitly carves out skills: `installBuiltinSkills()` is non-destructive, and dedicated `PostUpdateMigrator` migrations are the path for skill content updates. So the `alwaysOverwrite` field is opt-in, not the new default.
+
+## Design
+
+### Per-rule policy
+
+The cleanest separation is at the rule level. Each `ParityRule` declares whether it follows §4 (always overwrite) or §5 (refuse on conflict, dedicated migration overrides). The `ParityRule.alwaysOverwrite` field expresses this.
+
+- `hookParityRule.alwaysOverwrite = true` — canonical built-in hooks, §4 applies
+- `skillParityRule.alwaysOverwrite = undefined` (defaults to false) — §5 applies
+- Future canonical-built-in primitives (e.g., agent/tool/memory if they enter §4 territory) can opt in per their applicable policy
+
+### Sentinel routing
+
+The sentinel uses `rule.alwaysOverwrite` to decide whether `user-edit-conflict` blocks remediation:
+
+```ts
+const conflictBlocksRemediation = hasConflict && !rule.alwaysOverwrite;
+result = conflictBlocksRemediation ? 'conflict' : 'drift';
+```
+
+When `alwaysOverwrite=true` AND the mismatch is user-edit-conflict, the sentinel emits `parity:user-edit-overwritten` (audit signal) in addition to the standard `parity:gap-found`. This gives operators a paper trail for any clobbered user edit.
+
+### Signal vs Authority
+
+`user-edit-conflict` is preserved as a *signal* (the brittle stamp comparison detects user edits). The blocking *authority* (refuse to remediate) is removed for `alwaysOverwrite` rules — Migration Parity §4 is the higher-context policy that says "overwrite anyway, log it for recovery." This matches the signal-vs-authority pattern (B11) exactly: the detector emits, the higher policy decides.
+
+### Migration
+
+No `PostUpdateMigrator` entry needed for this change. The parity rule and sentinel are pure code paths used by Instar internally; they don't write per-agent state files that need backfilling. The contract change (`alwaysOverwrite` field) is additive and optional, so existing rules and tests don't need to be touched (only `hookParityRule` opts in).
+
+The behavioral change for deployed agents: on the next `instar update` + parity scan, any user-edited canonical hook gets overwritten and audit-logged. This is the intended Migration Parity §4 behavior — agents stuck on broken templates get unstuck.
+
+## Bootstrap exception
+
+The lessons-aware reviewer (PR #258) just merged. Built-in skill content updates require a `PostUpdateMigrator` migration to propagate (Migration Parity §5 for skills), so deployed agents will only run the new reviewer after `instar update`. This amendment was drafted in the gap. **Manual lessons-aware check applied** below — same bootstrap pattern the lessons-aware reviewer itself used (PR #258).
+
+### Manual lessons-aware check (vs `docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md`)
+
+| Principle/Lesson | Engagement |
+|---|---|
+| P1 Structure>Willpower | ✓ Engaged — the `alwaysOverwrite` field is structural, not a per-rule docs request |
+| P2 Signal vs Authority | ✓ Engaged — user-edit-conflict remains a signal; refuse-to-write authority removed for canonical hooks |
+| P3 Migration Parity §4 | ✓ Direct fix — built-in hooks always overwritten per the documented policy |
+| P4 Testing Integrity | ✓ Engaged — unit tests inverted to assert always-overwrite; sentinel test added for new event |
+| P5 Agent Awareness | N/A — internal code path; no agent-facing surface |
+| P6 Zero-Failure | ✓ Engaged — full unit suite runs green after change |
+| P7 LLM-Supervised Execution | N/A — pure deterministic code path |
+| P8 UX & Agent Agency | N/A — no user-facing surface |
+| P9 Intent Engineering | N/A |
+| P10 Comprehensive-First | ✓ Engaged — full fix in v0.1, no deferred follow-ups |
+| L1 AGENT.md bloat | N/A — no AGENT.md changes |
+| L4 External cross-model review | Skipped (tactical amendment); lessons-check is the structural compensation |
+| L6 Side-effects review | ✓ Engaged — `upgrades/side-effects/fix-hook-stamp-migration-parity.md` |
+| L9 ELI16 required | ✓ Engaged — `hook-always-overwrite.eli16.md` sibling |
+| L10 Release notes in same PR | ✓ Engaged — `upgrades/NEXT.md` in this PR |
+| B28 Spec-converge pre-auth circular | ✓ Engaged — this amendment IS the audit-driven corrective |
+
+No contradictions found. Zero deferrals.
+
+## Implementation slice for this PR
+
+1. This spec + ELI16 + convergence report (with the manual lessons-aware check above).
+2. `src/providers/parity/types.ts` — `alwaysOverwrite?: boolean` field on ParityRule; remediate() docstring updated.
+3. `src/providers/parity/rules/hookParityRule.ts` — `alwaysOverwrite: true` set; refuse-on-conflict throw removed.
+4. `src/monitoring/FrameworkParitySentinel.ts` — sentinel honors `alwaysOverwrite` and emits `parity:user-edit-overwritten`.
+5. `tests/unit/providers/parity/hookParityRule.test.ts` — test inverted + added.
+6. `tests/unit/monitoring/FrameworkParitySentinel.test.ts` — new test for alwaysOverwrite path.
+7. `upgrades/NEXT.md` + `upgrades/side-effects/fix-hook-stamp-migration-parity.md`.
+8. Package.json version bump.

--- a/src/monitoring/FrameworkParitySentinel.ts
+++ b/src/monitoring/FrameworkParitySentinel.ts
@@ -225,11 +225,19 @@ export class FrameworkParitySentinel extends EventEmitter {
           const hasConflict = verifyResult.mismatches.some(
             (m) => m.reasonCode === 'user-edit-conflict',
           );
-          result = hasConflict ? 'conflict' : 'drift';
+          // Per Migration Parity §4, rules with alwaysOverwrite=true (e.g.
+          // hookParityRule for built-in hooks) treat user-edit-conflict as a
+          // signal-only — remediation proceeds, and we emit
+          // parity:user-edit-overwritten so operators can recover via git.
+          const conflictBlocksRemediation = hasConflict && !rule.alwaysOverwrite;
+          result = conflictBlocksRemediation ? 'conflict' : 'drift';
           detail = verifyResult.mismatches.map((m) => `${m.framework}: ${m.detail}`).join('; ');
 
           for (const m of verifyResult.mismatches) {
             this.emit('parity:gap-found', m);
+            if (m.reasonCode === 'user-edit-conflict' && rule.alwaysOverwrite) {
+              this.emit('parity:user-edit-overwritten', m);
+            }
           }
 
           if (result === 'drift' && this.shouldRemediate(rule)) {

--- a/src/providers/parity/rules/hookParityRule.ts
+++ b/src/providers/parity/rules/hookParityRule.ts
@@ -468,6 +468,13 @@ export const hookParityRule: ParityRule = {
   primitive: 'hook',
   frameworks: ['claude-code', 'codex-cli'],
   remediationPolicy: 'mirror-trust',
+  // Per Migration Parity §4 (built-in hooks always overwritten on every
+  // migration run — never install-if-missing). The user-edit-conflict
+  // detection in verify() is a signal for the audit log, not blocking
+  // authority for remediation. Sentinel emits parity:user-edit-overwritten
+  // when overwriting a user-edited rendering so operators can recover via
+  // git history if needed.
+  alwaysOverwrite: true,
 
   async listInstances(projectRoot) {
     return listCanonicalHookInstances(projectRoot);
@@ -511,16 +518,12 @@ export const hookParityRule: ParityRule = {
 
   async remediate(projectRoot, instanceName, framework) {
     const hook = await readCanonicalHook(projectRoot, instanceName);
-    // Refuse on user-edit-conflict.
-    const issues = framework === 'claude-code'
-      ? await verifyClaudeHook(projectRoot, hook)
-      : await verifyCodexHook(projectRoot, hook);
-    const conflict = issues.find((i) => i.reasonCode === 'user-edit-conflict');
-    if (conflict) {
-      throw new CanonicalHookError(
-        `refused to remediate ${instanceName} on ${framework} due to user-edit-conflict: ${conflict.detail}`,
-      );
-    }
+    // Per Migration Parity §4: built-in hooks ALWAYS overwritten on every
+    // migration run. user-edit-conflict is a signal (recorded in verify()
+    // output and emitted by the sentinel as parity:user-edit-overwritten),
+    // not blocking authority. No refuse-on-conflict for canonical hooks —
+    // the install-if-missing wedge is what gets agents stuck on broken
+    // templates (see hook-event-reporter.js incident).
     if (framework === 'claude-code') {
       await renderClaudeHook(projectRoot, hook);
     } else {

--- a/src/providers/parity/types.ts
+++ b/src/providers/parity/types.ts
@@ -92,6 +92,17 @@ export interface ParityRule {
   readonly frameworks: ReadonlyArray<IntelligenceFramework>;
   /** How the sentinel handles detected drift. */
   readonly remediationPolicy: RemediationPolicy;
+  /**
+   * When true, user-edit-conflict is treated as a signal (not blocking
+   * authority) and remediate() always overwrites. Required for primitives
+   * covered by Migration Parity §4 (built-in hooks "always overwritten on
+   * every migration run — never install-if-missing"). The sentinel emits
+   * `parity:user-edit-overwritten` for any overwrite that clobbered a
+   * detected user edit so operators can recover via audit log + git.
+   *
+   * Default: false (refuse-on-conflict — operator-action required).
+   */
+  readonly alwaysOverwrite?: boolean;
 
   /**
    * Verify the rendering for ONE specific instance (e.g., one skill name)
@@ -114,8 +125,10 @@ export interface ParityRule {
    * (the verify() should return ok:true after remediation; calling again
    * doesn't break anything).
    *
-   * Throws if the current rendering has a `user-edit-conflict` — operator
-   * must resolve before automated remediation is allowed.
+   * Throws if the current rendering has a `user-edit-conflict` AND the rule
+   * is not marked `alwaysOverwrite: true`. Rules with `alwaysOverwrite: true`
+   * (e.g., hookParityRule per Migration Parity §4) overwrite unconditionally
+   * and the sentinel emits an audit event recording the clobber.
    */
   remediate(projectRoot: string, instanceName: string, framework: IntelligenceFramework): Promise<void>;
 

--- a/tests/unit/monitoring/FrameworkParitySentinel.test.ts
+++ b/tests/unit/monitoring/FrameworkParitySentinel.test.ts
@@ -47,6 +47,7 @@ function makeStubRule(opts: {
   instances?: string[];
   verifyResults?: Record<string, VerifyResult>;
   remediationPolicy?: 'mirror-trust' | 'flag-only';
+  alwaysOverwrite?: boolean;
   orphans?: ParityMismatch[];
   remediateImpl?: (instance: string, framework: string) => Promise<void>;
 }): ParityRule {
@@ -55,6 +56,7 @@ function makeStubRule(opts: {
     ...NOOP_RULE,
     primitive: 'skill',
     remediationPolicy: opts.remediationPolicy ?? 'mirror-trust',
+    alwaysOverwrite: opts.alwaysOverwrite,
     async verify(_root, instance) {
       return opts.verifyResults?.[instance] ?? { ok: true, mismatches: [] };
     },
@@ -235,6 +237,50 @@ describe('FrameworkParitySentinel', () => {
       const report = await sentinel.scan();
       expect(calls).toEqual([]);
       expect(report.remediated).toBe(0);
+    });
+
+    it('alwaysOverwrite=true rule REMEDIATES through user-edit-conflict and emits parity:user-edit-overwritten', async () => {
+      const remediateCalls: string[] = [];
+      restoreRule = isolateToOneRule(makeStubRule({
+          instances: ['foo'],
+          remediationPolicy: 'mirror-trust',
+          alwaysOverwrite: true,
+          verifyResults: {
+            foo: {
+              ok: false,
+              mismatches: [
+                {
+                  primitive: 'hook',
+                  instanceName: 'foo',
+                  framework: 'claude-code',
+                  reasonCode: 'user-edit-conflict',
+                  detail: 'user edited',
+                },
+              ],
+            },
+          },
+          remediateImpl: async (instance) => {
+            remediateCalls.push(instance);
+          },
+        }),
+      );
+      const sentinel = new FrameworkParitySentinel({
+        projectRoot,
+        stateDir: projectRoot,
+        enabledFrameworks: ['claude-code'],
+      });
+      const overwritten: unknown[] = [];
+      const refused: unknown[] = [];
+      sentinel.on('parity:user-edit-overwritten', (m) => overwritten.push(m));
+      sentinel.on('parity:remediation-refused', (m) => refused.push(m));
+      const report = await sentinel.scan();
+      // Per Migration Parity §4: alwaysOverwrite=true rules remediate through
+      // the conflict and emit the audit signal.
+      expect(remediateCalls).toEqual(['foo']);
+      expect(overwritten.length).toBeGreaterThanOrEqual(1);
+      expect(refused.length).toBe(0);
+      expect(report.remediated).toBe(1);
+      expect(report.remediationRefused).toBe(0);
     });
 
     it('refuses remediation on user-edit-conflict and emits the event', async () => {

--- a/tests/unit/providers/parity/hookParityRule.test.ts
+++ b/tests/unit/providers/parity/hookParityRule.test.ts
@@ -211,15 +211,33 @@ describe('hookParityRule', () => {
       expect(conflict).toBeDefined();
     });
 
-    it('remediate refuses on user-edit-conflict', async () => {
+    it('remediate ALWAYS OVERWRITES user-edits per Migration Parity §4', async () => {
+      // Built-in hooks (canonical) are always overwritten on every migration
+      // run — never install-if-missing. user-edit-conflict in verify() is a
+      // signal for audit (sentinel emits parity:user-edit-overwritten);
+      // remediate() proceeds regardless. Operator recovery is via git, not
+      // refusal-to-write.
       await writeCanonicalHook(projectRoot, 'session-start', 'inject.sh');
       await hookParityRule.remediate(projectRoot, 'session-start/inject.sh', 'claude-code');
       const scriptPath = path.join(projectRoot, '.claude/hooks/session-start/inject.sh');
       const raw = await fs.readFile(scriptPath, 'utf-8');
-      await fs.writeFile(scriptPath, raw + '\necho "user"\n');
-      await expect(
-        hookParityRule.remediate(projectRoot, 'session-start/inject.sh', 'claude-code'),
-      ).rejects.toThrow(/user-edit-conflict/);
+      const userEdited = raw + '\necho "user"\n';
+      await fs.writeFile(scriptPath, userEdited);
+      // Should NOT throw — alwaysOverwrite is true for hookParityRule.
+      await hookParityRule.remediate(projectRoot, 'session-start/inject.sh', 'claude-code');
+      const after = await fs.readFile(scriptPath, 'utf-8');
+      expect(after).not.toBe(userEdited); // user edit clobbered
+      expect(after).not.toContain('echo "user"'); // user line gone
+      // Subsequent verify on the claude side should be clean (no conflict,
+      // no body-mismatch). Codex side will be missing-rendered-file in this
+      // fixture (we never rendered codex), which is expected.
+      const r = await hookParityRule.verify(projectRoot, 'session-start/inject.sh');
+      const claudeIssues = r.mismatches.filter((m) => m.framework === 'claude-code');
+      expect(claudeIssues).toEqual([]);
+    });
+
+    it('hookParityRule advertises alwaysOverwrite=true per Migration Parity §4', () => {
+      expect(hookParityRule.alwaysOverwrite).toBe(true);
     });
   });
 

--- a/upgrades/1.0.7.md
+++ b/upgrades/1.0.7.md
@@ -1,0 +1,31 @@
+# Upgrade Guide — v1.0.7
+
+<!-- bump: patch -->
+
+## What Changed
+
+Lands the canonical Instar Design Principles + Lessons Learned index at docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md.
+
+This is the structured catalog every Instar agent and the upcoming /spec-converge lessons-aware reviewer (8th reviewer, separate PR) consult before drafting a new spec or approving one. 10 foundational principles (Structure>Willpower, Signal-vs-Authority, Migration Parity, Testing Integrity, Agent Awareness, Zero-Failure, LLM-Supervised Execution, UX & Agent Agency, Intent Engineering, Comprehensive-First). 17 architectural lessons (AGENT.md bloat, context-death, topology check, external cross-model review, state-detection robustness, side-effects review, bug-fix evidence, active follow-through, ELI16 required, release notes in same PR, External Operation Safety, Destructive-Tool Containment, Parallel Dev Isolation, PR Review Hardening, Authorization Policy, Project Scope, Integrated-Being Ledger). 39 behavioral lessons across communication, lifecycle, testing, autonomy, and platform-specific patterns.
+
+Sourced from CLAUDE.md Standards, 45 .instar/memory/feedback_*.md entries, docs/specs/ (TESTING-INTEGRITY-SPEC, EXTERNAL-OPERATION-SAFETY-SPEC, COMPREHENSIVE-DESTRUCTIVE-TOOL-CONTAINMENT-SPEC, PARALLEL-DEV-ISOLATION-SPEC, PR-REVIEW-HARDENING-SPEC, AUTHORIZATION-POLICY-SPEC, PROJECT-SCOPE-SPEC, INTENT-ENGINEERING-SPEC, integrated-being-ledger-v2), docs/UX-AND-AGENT-AGENCY-STANDARD.md, docs/LLM-SUPERVISED-EXECUTION.md, docs/E2E-TESTING-STANDARD.md, docs/signal-vs-authority.md, and the Echo AGENT.md + USER.md identity files.
+
+Compiled in response to a real backtrack: the conversational-action primitive draft inlined a catalog block into AGENT.md, violating three already-built defenses against AGENT.md bloat (ContextHierarchy, Playbook, Self-Knowledge Tree) plus the Structure-over-Willpower principle. The compromise to use abbreviated convergence under hybrid-C pre-authorization made the failure structural — the "self-verify against foundational specs" step is circular when the same author writes both the spec and the foundational reference. This index closes that gap by giving the lessons-aware reviewer (next PR) a single source of truth to check against.
+
+## What to Tell Your User
+
+- "The full list of every Instar principle, standard, and lesson is now in one place. The spec-converge reviewer will read it before approving any new spec, so we stop forgetting hard-earned lessons every time we design something new."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Canonical principles + lessons index | Read docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md before drafting any new spec. Cite engaged principles in spec frontmatter under lessons-engaged. |
+| Lookup by category | Part 1 = principles (P1-P10), Part 2 = architectural lessons (L1-L17), Part 3 = behavioral lessons (B1-B39). |
+| Maintenance pattern | Append-only catalog; old lessons stay even after infrastructure absorbs them, because new contributors need the why. |
+
+## Deferred (Tracked Follow-ups)
+
+- Lessons-aware reviewer (8th /spec-converge reviewer that consumes this index) — separate PR, next.
+- Re-audit of 6 already-merged PRs (#252-#255 + foundationals) using the new reviewer; amendment PRs for critical findings (Hook stamp vs Migration Parity §4, Sentinel ship-order vs backfill).
+- Migration Parity backfills across five primitives that deferred their PostUpdateMigrator entries.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,31 +1,40 @@
-# Upgrade Guide — v1.0.7
+# Upgrade Guide — v1.0.8
 
 <!-- bump: patch -->
 
 ## What Changed
 
-Lands the canonical Instar Design Principles + Lessons Learned index at docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md.
+Restores Migration Parity §4 conformance for canonical (built-in) hooks. The Hook primitive shipped in PR #253 with a stamp-and-refuse-on-conflict pattern that resurrected the install-if-missing wedge §4 was written to prevent. This release inverts the policy so that built-in hooks are once again always overwritten on every migration run.
 
-This is the structured catalog every Instar agent and the upcoming /spec-converge lessons-aware reviewer (8th reviewer, separate PR) consult before drafting a new spec or approving one. 10 foundational principles (Structure>Willpower, Signal-vs-Authority, Migration Parity, Testing Integrity, Agent Awareness, Zero-Failure, LLM-Supervised Execution, UX & Agent Agency, Intent Engineering, Comprehensive-First). 17 architectural lessons (AGENT.md bloat, context-death, topology check, external cross-model review, state-detection robustness, side-effects review, bug-fix evidence, active follow-through, ELI16 required, release notes in same PR, External Operation Safety, Destructive-Tool Containment, Parallel Dev Isolation, PR Review Hardening, Authorization Policy, Project Scope, Integrated-Being Ledger). 39 behavioral lessons across communication, lifecycle, testing, autonomy, and platform-specific patterns.
+Three small code changes:
 
-Sourced from CLAUDE.md Standards, 45 .instar/memory/feedback_*.md entries, docs/specs/ (TESTING-INTEGRITY-SPEC, EXTERNAL-OPERATION-SAFETY-SPEC, COMPREHENSIVE-DESTRUCTIVE-TOOL-CONTAINMENT-SPEC, PARALLEL-DEV-ISOLATION-SPEC, PR-REVIEW-HARDENING-SPEC, AUTHORIZATION-POLICY-SPEC, PROJECT-SCOPE-SPEC, INTENT-ENGINEERING-SPEC, integrated-being-ledger-v2), docs/UX-AND-AGENT-AGENCY-STANDARD.md, docs/LLM-SUPERVISED-EXECUTION.md, docs/E2E-TESTING-STANDARD.md, docs/signal-vs-authority.md, and the Echo AGENT.md + USER.md identity files.
+- The ParityRule interface gained an optional alwaysOverwrite field.
+- hookParityRule sets alwaysOverwrite to true.
+- FrameworkParitySentinel honors alwaysOverwrite and emits a new parity:user-edit-overwritten audit event when overwriting a user-edited rendering.
 
-Compiled in response to a real backtrack: the conversational-action primitive draft inlined a catalog block into AGENT.md, violating three already-built defenses against AGENT.md bloat (ContextHierarchy, Playbook, Self-Knowledge Tree) plus the Structure-over-Willpower principle. The compromise to use abbreviated convergence under hybrid-C pre-authorization made the failure structural — the "self-verify against foundational specs" step is circular when the same author writes both the spec and the foundational reference. This index closes that gap by giving the lessons-aware reviewer (next PR) a single source of truth to check against.
+The user-edit detection stays as a signal in verify output; only the blocking authority moves from the rule to the higher-context Migration Parity policy. skillParityRule does NOT opt in because Migration Parity §5 explicitly carves out skills as refuse-on-conflict with PostUpdateMigrator override.
+
+## Evidence
+
+Reproduction prior to this release: render a canonical hook to .claude/hooks/session-start/inject.sh, append a user edit (e.g. echo "user added"), then run the parity scan. The verify pass reports user-edit-conflict, and the sentinel skips remediation. On the next instar update where the canonical hook source changes (the typical fix-broken-template scenario), the agent stays stuck on the user-edited stale rendering.
+
+Observed after this release: same setup, same parity scan, the sentinel now calls remediate, the rendering is overwritten with the new canonical body, and the operator sees parity:user-edit-overwritten in the audit stream. Recovery of the user edit is available via git history if needed.
+
+Unit-test verification: tests/unit/providers/parity/hookParityRule.test.ts now asserts remediate ALWAYS OVERWRITES user-edits per Migration Parity §4. tests/unit/monitoring/FrameworkParitySentinel.test.ts asserts the new audit event fires for alwaysOverwrite rules.
 
 ## What to Tell Your User
 
-- "The full list of every Instar principle, standard, and lesson is now in one place. The spec-converge reviewer will read it before approving any new spec, so we stop forgetting hard-earned lessons every time we design something new."
+- "When Instar ships a built-in hook, the canonical version always wins on the next update. A subtle regression in the Hook primitive was making us refuse to overwrite hooks that anyone had edited locally — which is exactly the pattern that left us stuck on a broken template once before. This release puts the always-overwrite policy back in place, and adds an audit signal so any clobbered edit is visible and recoverable from git."
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Canonical principles + lessons index | Read docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md before drafting any new spec. Cite engaged principles in spec frontmatter under lessons-engaged. |
-| Lookup by category | Part 1 = principles (P1-P10), Part 2 = architectural lessons (L1-L17), Part 3 = behavioral lessons (B1-B39). |
-| Maintenance pattern | Append-only catalog; old lessons stay even after infrastructure absorbs them, because new contributors need the why. |
+| ParityRule alwaysOverwrite field | Set alwaysOverwrite to true on rules covered by Migration Parity §4. Defaults to false (refuse-on-conflict for §5 rules like skills). |
+| parity:user-edit-overwritten audit event | Sentinel emits this whenever an alwaysOverwrite rule clobbers a user-edited rendering. Listen via FrameworkParitySentinel events. |
+| Canonical hook always-overwrite restored | No action required; built-in hooks are now once again always overwritten on every migration cycle. Custom hooks in .claude/hooks/custom/ continue to be untouched. |
 
 ## Deferred (Tracked Follow-ups)
 
-- Lessons-aware reviewer (8th /spec-converge reviewer that consumes this index) — separate PR, next.
-- Re-audit of 6 already-merged PRs (#252-#255 + foundationals) using the new reviewer; amendment PRs for critical findings (Hook stamp vs Migration Parity §4, Sentinel ship-order vs backfill).
-- Migration Parity backfills across five primitives that deferred their PostUpdateMigrator entries.
+- Wire parity:user-edit-overwritten into a Dashboard view so operators see clobber events without grepping logs.
+- Audit the remaining merged primitive PRs (#254 Agent/Tool/Memory and #255 Sentinel ship-order) using the lessons-aware reviewer; corrective amendments per finding.

--- a/upgrades/side-effects/fix-hook-stamp-migration-parity.md
+++ b/upgrades/side-effects/fix-hook-stamp-migration-parity.md
@@ -1,0 +1,64 @@
+# Side-effects review — hookParityRule alwaysOverwrite amendment
+
+Per L6 (Side-effects review gate). Seven dimensions.
+
+## 1. Over-block / under-block
+
+**Under-block risk before this change.** The hookParityRule.remediate() refused on user-edit-conflict for canonical built-in hooks. This UNDER-blocked the broken-template-stuck-forever scenario: agents whose canonical hook was buggy and got edited (even accidentally — adding a trailing newline counts as a body diff) would be locked into the broken version. Migration Parity §4 exists exactly because this happened with `hook-event-reporter.js`.
+
+**Over-block risk after this change.** Now built-in hook user edits get clobbered on next remediation cycle. A user who intentionally customized a built-in hook in `.claude/hooks/` (not `custom/`) loses their changes. Mitigation: the sentinel emits `parity:user-edit-overwritten` for every clobber so the operator has an audit trail; the edit itself is recoverable from git history; the documented pattern for user customization is `.claude/hooks/custom/` (always-untouched per Migration Parity §4).
+
+The over-block trade is correct per §4: the broken-template scenario is silent and unrecoverable; the user-edit-clobber scenario is logged, audit-traced, and git-recoverable. Asymmetric reversibility favors §4.
+
+## 2. Level-of-abstraction fit
+
+The fix lives at three levels:
+- **Interface** (`src/providers/parity/types.ts`) — `alwaysOverwrite` field added to `ParityRule`. Right level: each rule declares its policy.
+- **Rule** (`src/providers/parity/rules/hookParityRule.ts`) — sets `alwaysOverwrite: true` and removes the throw. Right level: hook-specific policy.
+- **Sentinel** (`src/monitoring/FrameworkParitySentinel.ts`) — honors `alwaysOverwrite` and emits new audit event. Right level: the orchestrator is the place that knows when to call remediate.
+
+The fix does NOT live in `PostUpdateMigrator` because the parity rule + sentinel are the live execution path during normal operation; the migrator is the per-update batch. Right separation.
+
+The fix is NOT in the canonical hook source files (`.instar/hooks/canonical/`) because the policy is per-rule, not per-script.
+
+## 3. Signal vs Authority compliance
+
+Textbook signal-vs-authority alignment (per B11). Before this change: the stamp comparison (brittle, low-context detector) had blocking authority over remediation. That's exactly the inversion B11 warns against. After this change: the stamp comparison emits a signal (user-edit-conflict in verify() output + parity:user-edit-overwritten event from sentinel); Migration Parity §4 (higher-context policy) decides what to do with the signal.
+
+`alwaysOverwrite: true` is the rule's way of saying "the higher policy applies to me — don't let the signal block me." For skills, `alwaysOverwrite` stays false because §5 says signals from skills CAN block (with `PostUpdateMigrator` as the bypass mechanism). Each rule expresses its applicable §-policy.
+
+## 4. Interactions with adjacent systems
+
+**`PostUpdateMigrator`.** Unchanged. The skill always-overwrite carve-out in §5 is unaffected (`skillParityRule.alwaysOverwrite` is undefined → defaults to false → refuse-on-conflict preserved). Hook-specific migrations in `PostUpdateMigrator` continue to work the same way — they still trigger remediation, which now actually completes for user-edited canonical hooks.
+
+**FrameworkParitySentinel orchestration.** The new event `parity:user-edit-overwritten` is additive — existing listeners on `parity:gap-found` and `parity:remediated` keep firing as before. The sentinel's degradation reporter (3-strikes-unresolved) still triggers if remediation keeps failing, which it shouldn't for the alwaysOverwrite case (since now it succeeds).
+
+**`/instar-dev` pre-commit gate.** Unaffected. The gate checks spec frontmatter tags, not parity rule internals.
+
+**Existing canonical hooks.** All currently-installed canonical hooks were rendered before this change, so they have the stamp comment + match the canonical body. They keep matching → verify ok → no remediation needed. The first time the change shows behavior is when a canonical hook is updated AND a user edited the prior rendering. That's the exact scenario §4 targets.
+
+**`SourceTreeGuard` / `SafeFsExecutor`.** The remediation path writes via `fs.writeFile` directly (not through SafeFsExecutor — see hookParityRule.ts:251, 277). That's a separate concern (consistency with other destructive-tool containment); not introduced by this change.
+
+## 5. Rollback cost
+
+Low. Three files changed (1 interface addition, 1 rule field, 1 sentinel field + emit). Revert is `git revert`. No data migration, no per-agent state change. The `alwaysOverwrite` field is optional with a sensible default (false → preserves old behavior).
+
+## 6. Backwards compatibility / drift surface
+
+Backwards-compatible. Any third-party `ParityRule` implementation (none exist currently — all rules are in this repo) that doesn't set `alwaysOverwrite` keeps the old refuse-on-conflict behavior. No interface break.
+
+**Drift surface.** The new event `parity:user-edit-overwritten` is not yet wired to telemetry or the dashboard. v0.2 follow-up could add a Dashboard tab entry. Not blocking: the event is captured in the audit log already (sentinel passes mismatches through).
+
+**Documentation drift.** CLAUDE.md Migration Parity §4 already documents the always-overwrite policy. No docs change needed; the code now matches what was already documented.
+
+## 7. Authorization / Trust posture
+
+No new permissions surfaced. The remediate path was already authorized to write to `.claude/hooks/` and `.agent/openai/hooks/`. The change is "the same authorized path now completes more often"; it's not a new authority claim.
+
+Trust-floor mirroring (the sentinel's `remediationPolicy: 'mirror-trust'`) remains the gate on whether remediation runs at all. The `alwaysOverwrite` field is a per-rule sub-policy that only kicks in when the trust-floor gate has already allowed remediation.
+
+## Outcome
+
+Ship. The fix is minimal, surgical, and reverses an unintentional regression that contradicted documented Instar policy.
+
+No items rise to "block ship for v0.1." One follow-up worth tracking: wire `parity:user-edit-overwritten` into a Dashboard view so operators see clobber events without grepping logs. Not recurrence-risking; tracked as v0.2.


### PR DESCRIPTION
## Summary

Audit-identified critical backtrack from PR #253. The Hook primitive shipped with a stamp-and-refuse-on-`user-edit-conflict` pattern that resurrected the install-if-missing wedge for built-in hooks — contradicting **Migration Parity §4** ("Built-in hooks always overwritten on every migration run — never install-if-missing").

This amendment restores the documented policy. Three small changes:

1. `ParityRule.alwaysOverwrite?: boolean` added to the interface
2. `hookParityRule` sets `alwaysOverwrite: true`; removes the refuse-on-conflict throw
3. `FrameworkParitySentinel` honors `alwaysOverwrite` and emits a new `parity:user-edit-overwritten` audit event when overwriting a user-edited rendering

The user-edit-conflict detection in `verify()` is preserved as a signal. The blocking authority moves from the rule to the higher-context Migration Parity policy — textbook signal-vs-authority (B11). `skillParityRule` does NOT opt in because Migration Parity §5 explicitly carves out skills as refuse-on-conflict with `PostUpdateMigrator` override.

## Why it was missed

PR #253's convergence had four internal reviewers (security, scalability, adversarial, integration) plus three externals — none carried the brief "does this contradict a documented Migration Parity rule." The lessons-aware reviewer (PR #258) is the structural fix going forward; this amendment is the corrective for the case already on main when the audit caught it.

## Evidence (per L7 bug-fix evidence bar)

**Reproduction prior to this PR:** render a canonical hook to `.claude/hooks/session-start/inject.sh`, append a user edit, run the parity scan. `verify()` reports `user-edit-conflict`, sentinel skips remediation. On next `instar update` with a changed canonical body (the fix-broken-template scenario), the agent stays stuck.

**Observed after this PR:** same setup, sentinel calls `remediate()`, rendering overwritten with canonical body, operator sees `parity:user-edit-overwritten` in audit stream. Recovery via git.

**Unit-test verification:** new test "remediate ALWAYS OVERWRITES user-edits per Migration Parity §4" passes; new sentinel test "alwaysOverwrite=true rule REMEDIATES through user-edit-conflict and emits parity:user-edit-overwritten" passes. 41/41 in target test files green.

## Artifacts

- `src/providers/parity/types.ts` — interface change
- `src/providers/parity/rules/hookParityRule.ts` — policy opt-in + throw removed
- `src/monitoring/FrameworkParitySentinel.ts` — sentinel routing + new event
- `tests/unit/providers/parity/hookParityRule.test.ts` — test inverted + added
- `tests/unit/monitoring/FrameworkParitySentinel.test.ts` — new test for alwaysOverwrite path
- `specs/dev-infrastructure/hook-always-overwrite.md` + `.eli16.md` — spec + ELI16
- `docs/specs/reports/hook-always-overwrite-convergence.md` — convergence report
- `upgrades/side-effects/fix-hook-stamp-migration-parity.md` — seven-dimension side-effects review per L6
- `upgrades/NEXT.md` — v1.0.8 upgrade guide (with Evidence section per L7)
- `upgrades/1.0.7.md` — preserved previous NEXT content (principles index) which was awaiting auto-release

## Bootstrap exception

Lessons-aware reviewer (PR #258) merged to its branch but its content didn't propagate to main due to a base-branch retargeting mishap (need to re-land separately). Manual lessons-check applied transparently in the spec body against the canonical principles index — same bootstrap pattern PR #258 used.

## Test plan

- [x] Typecheck clean
- [x] Unit tests for parity + monitoring + core all pass
- [x] Spec + ELI16 + convergence report + side-effects review present
- [x] Trace record present at `.instar/instar-dev-traces/`
- [ ] Pre-push gate clears (NEXT.md tone gate + version bump)
- [ ] CI green on PR
- [ ] After merge, agents updating in place will get the always-overwrite restoration on next remediation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)