### PR TITLE
fix(portability): real enabledFrameworks field + migrator gate (audit Gap 5) — v1.0.11

### DIFF
--- a/.instar/instar-dev-traces/20260519T203000Z-portability-framework-gate.json
+++ b/.instar/instar-dev-traces/20260519T203000Z-portability-framework-gate.json
@@ -1,0 +1,20 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/portability-framework-gate.md",
+  "artifactPath": "upgrades/side-effects/feat-portability-framework-gate.md",
+  "artifactSha256": "fe53efd4a38b3eda0f62e021980aa5c3280b743b48aebd2d97cffb0e3b16da18",
+  "coveredFiles": [
+    "src/core/types.ts",
+    "src/core/PostUpdateMigrator.ts",
+    "src/data/builtin-manifest.json",
+    "tests/unit/PostUpdateMigrator-frameworkGate.test.ts",
+    "specs/dev-infrastructure/portability-framework-gate.md",
+    "specs/dev-infrastructure/portability-framework-gate.eli16.md",
+    "docs/specs/reports/portability-framework-gate-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/feat-portability-framework-gate.md"
+  ],
+  "writtenAt": "2026-05-19T20:30:00Z",
+  "agent": "echo",
+  "summary": "Portability audit Gap 5: the audit's 'wrap legacy steps in enabledFrameworks guards' would have been INERT (enabledFrameworks was read defensively but was never a real settable InstarConfig field). Fix makes it a real field, adds getEnabledFrameworks() single-source helper (default ['claude-code']), DRY-refactors the duplicate inline logic in migrateParityRenderings, and gates migrateSettings (Claude-only .claude/settings.json) to skip for codex-only installs. 6-case test proves the gate is reachable AND the default does not skip; 11 parity-renderings tests pass unchanged. Ships v1.0.11."
+}

--- a/docs/specs/reports/portability-framework-gate-convergence.md
+++ b/docs/specs/reports/portability-framework-gate-convergence.md
@@ -1,0 +1,44 @@
+# Convergence Report — Real enabledFrameworks field + migrator framework gate
+
+## ELI10 Overview
+
+A migrator step sets up Claude-only files even for non-Claude agents. The
+audit said "add a skip-if-not-Claude check," but the setting that check needed
+never actually existed, so the check would have been a no-op. This change
+makes the setting a real config option first, then adds one proven gate.
+
+## Original vs Converged
+
+The audit's framing ("wrap legacy steps in enabledFrameworks guards") was
+inert as written — verified by grepping: `enabledFrameworks` was read in one
+place defensively but was never an InstarConfig field, never settable, always
+undefined. Converged scope: make the field real + a single-source helper +
+DRY the duplicate inline logic + one fully-tested guarded step that proves the
+gate is reachable. Sweeping all 49 `.claude/` refs in one PR was explicitly
+rejected as regression-prone; the helper lets remaining steps adopt the gate
+incrementally.
+
+## Iteration Summary
+
+| Iteration | Reviewers run | Material findings | Spec changes |
+|-----------|---------------|-------------------|--------------|
+| 1 | Manual lessons-check + direct code verification (inert-guard catch) | 0 | None |
+
+## Manual lessons-aware findings
+
+Engaged P1, P4 (6 cases incl. reachability + negative side), P6
+(parity-renderings regression green after DRY refactor), P10, L1-equivalent
+(framing corrected — avoided shipping theater), L6/L9/L10. No contradictions.
+
+## Convergence verdict
+
+Converged at iteration 1. The key value is catching that the audit's fix
+would have been inert and shipping the real mechanism instead, with tests
+that specifically prove the gate triggers. Fifth of the v1.0.9–v1.0.14
+series.
+
+## Deviation note
+
+Autonomous-mode pre-authorization. Scope materially corrected from the
+audit's framing after code verification — the headline of this PR is "make
+the guard real, not decorative."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/portability-framework-gate.eli16.md
+++ b/specs/dev-infrastructure/portability-framework-gate.eli16.md
@@ -1,0 +1,35 @@
+---
+title: "Framework gate — ELI16"
+slug: "portability-framework-gate-eli16"
+parent: "portability-framework-gate.md"
+---
+
+# Framework gate — explained simply
+
+## The problem
+
+When an agent updates, a migrator runs steps that set up files. Some of those
+steps create Claude-Code-only files (like `.claude/settings.json`) that a
+Codex agent would never read. The audit said "just add a check: skip the
+Claude-only steps if Claude isn't in use." But the setting that check would
+read didn't actually exist as a real option anywhere — it was always blank,
+so the check would have always said "Claude is in use" and never skipped
+anything. A check that can never trigger isn't a fix; it's decoration.
+
+## The fix
+
+First make the setting real: `enabledFrameworks` is now a genuine option you
+can put in the config (e.g. `["codex-cli"]` for a Codex-only agent). Then add
+one well-tested gate: the step that writes Claude's settings file now actually
+skips when Claude isn't in the enabled list. Tests prove it both ways — it
+skips for a Codex-only agent, and it does NOT skip for a normal (default)
+agent.
+
+## Why it's safe
+
+If you don't set the option, it defaults to "Claude Code" — exactly today's
+behavior, so every existing agent is unaffected. Only someone who explicitly
+says "this is Codex-only" sees the new skipping. One shared helper now answers
+"which runtimes does this install use?", and the older duplicate copy of that
+logic was replaced by it, so they can't drift apart. This is the fifth of six
+small portability patches.

--- a/specs/dev-infrastructure/portability-framework-gate.md
+++ b/specs/dev-infrastructure/portability-framework-gate.md
@@ -1,0 +1,94 @@
+---
+title: "Real enabledFrameworks config field + migrator framework gate (portability Gap 5)"
+slug: "portability-framework-gate"
+author: "echo"
+status: "converged"
+type: "dev-infrastructure-spec"
+eli16-overview: "portability-framework-gate.eli16.md"
+review-convergence: "2026-05-19T20:30:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-19T20:30:00Z"
+review-report: "docs/specs/reports/portability-framework-gate-convergence.md"
+approved: true
+approved-by: "Justin (pre-authorized 2026-05-19, autonomous-mode, 'finish making all the fixes based on the audit and get them deployed' + 'proceed as you best see fit')"
+approved-date: "2026-05-19"
+approval-note: "Gap 5 of six. Ships v1.0.11. The audit's framing would have been INERT (guard on a non-existent config field); this makes enabledFrameworks a real field first, then gates."
+lessons-engaged:
+  - "P1 (Structure>Willpower): a real persisted config field + a code gate, not a doc."
+  - "P4 (Testing Integrity): 6-case test proving the gate is REACHABLE (codex-only skips) and the default path does NOT skip — i.e. not inert."
+  - "P10 (Comprehensive-First): real field + helper + DRY refactor of the duplicate inline logic + one well-tested guarded step, establishing the pattern future steps reuse."
+  - "L1-equivalent (audit-driven, framing corrected): the audit's 'wrap legacy steps' would have been theater because enabledFrameworks was never settable; the real fix is the field itself."
+  - "L6/L9/L10: siblings."
+---
+
+# Real enabledFrameworks config field + migrator framework gate (Gap 5)
+
+## Problem
+
+The audit's Gap 5 was "wrap legacy `.claude/`-touching migrator steps in
+`enabledFrameworks` guards." Verified against the code, that framing would
+have been **inert**: `enabledFrameworks` was read defensively in exactly one
+place (`migrateParityRenderings`) as `(config as {...}).enabledFrameworks`,
+but it was never a real `InstarConfig` field, never settable, never written —
+so it was always `undefined`, always defaulted to `['claude-code']`, and any
+guard built on it would never skip anything. Guarding an unreachable
+condition is theater, not a fix.
+
+## Change
+
+1. **`enabledFrameworks?: ('claude-code'|'codex-cli')[]`** is now a real,
+   documented `InstarConfig` field (persisted in `.instar/config.json`).
+2. **`PostUpdateMigrator.getEnabledFrameworks()`** is the single source of
+   truth: reads the persisted field, filters to known values, defaults to
+   `['claude-code']` when unset/empty/unreadable. The pre-existing duplicate
+   inline logic in `migrateParityRenderings` is refactored to call it (DRY).
+3. **`migrateSettings` is gated**: it only touches `.claude/settings.json`
+   (Claude Code's hook/MCP config — zero meaning for Codex). It now
+   short-circuits with a skip note when `claude-code` is not in the enabled
+   set. This is the first guarded step and establishes the reusable pattern;
+   the helper is available for the remaining legacy `.claude/` steps to adopt
+   incrementally without re-deriving the framework set.
+
+Default behavior is unchanged: unset config → `['claude-code']` → nothing
+skips. Only an explicit `enabledFrameworks: ['codex-cli']` changes behavior.
+
+## What this is NOT
+
+- Not a sweep of all 49 `.claude/` references. That would be a large,
+  regression-prone single PR. This ships the *mechanism* (real field +
+  single-source helper) plus one fully-tested guarded step proving it is
+  reachable; remaining steps adopt `getEnabledFrameworks()` incrementally.
+- Not a default-behavior change. Existing/dual installs are byte-identical.
+
+## Testing
+
+`tests/unit/PostUpdateMigrator-frameworkGate.test.ts` — 6 cases: default
+when field absent; default when config.json absent; honors codex-only;
+honors dual; `migrateSettings` SKIPS for codex-only (gate reachable —
+proves not inert); `migrateSettings` does NOT skip on default (negative
+side). Plus the 11 `parity-renderings` tests pass unchanged, proving the DRY
+refactor preserved behavior.
+
+## Manual lessons-aware check
+
+| Principle/Lesson | Engagement |
+|---|---|
+| P1 Structure>Willpower | ✓ real field + code gate |
+| P4 Testing Integrity | ✓ 6 cases, both decision sides, reachability proven |
+| P6 Zero-Failure | ✓ suite green; parity-renderings regression green |
+| P10 Comprehensive-First | ✓ field + helper + DRY + guarded step + test |
+| L1 (audit framing corrected) | ✓ avoids the inert-guard trap |
+| L6/L9/L10 | ✓ siblings |
+
+No contradictions. The incremental adoption of the helper by remaining steps
+is explicitly NOT a deferral of *this* fix — the mechanism + a proven guarded
+step is the complete unit of work here.
+
+## Implementation slice
+
+1. This spec + ELI16 + convergence report.
+2. `src/core/types.ts` — real `enabledFrameworks` field on InstarConfig.
+3. `src/core/PostUpdateMigrator.ts` — `getEnabledFrameworks()` helper, DRY
+   refactor of the inline logic, `migrateSettings` gate.
+4. `tests/unit/PostUpdateMigrator-frameworkGate.test.ts` (NEW, 6 tests).
+5. `upgrades/NEXT.md` + `upgrades/side-effects/feat-portability-framework-gate.md`.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -88,6 +88,41 @@ export class PostUpdateMigrator {
   }
 
   /**
+   * Resolve the set of frameworks this install actively uses, read from
+   * the persisted `.instar/config.json` `enabledFrameworks` field.
+   *
+   * Default (unset / empty / unreadable): `['claude-code']` — the
+   * historical behavior, so existing and dual-framework installs are
+   * unaffected. A Codex-only install sets `enabledFrameworks:
+   * ['codex-cli']`, which makes framework-specific migration steps that
+   * scaffold `.claude/`-only artifacts skip cleanly instead of writing
+   * files that runtime will never read.
+   *
+   * Single source of truth for the migrator's framework gating — both
+   * the parity-renderings backfill and the legacy `.claude/`-specific
+   * steps consult this.
+   */
+  private getEnabledFrameworks(): ReadonlyArray<'claude-code' | 'codex-cli'> {
+    try {
+      const configPath = path.join(this.config.stateDir, 'config.json');
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+        enabledFrameworks?: unknown;
+      };
+      const enabled = config.enabledFrameworks;
+      if (Array.isArray(enabled) && enabled.length > 0) {
+        const filtered = enabled.filter(
+          (f): f is 'claude-code' | 'codex-cli' =>
+            f === 'claude-code' || f === 'codex-cli',
+        );
+        if (filtered.length > 0) return filtered;
+      }
+    } catch {
+      // fall through to default
+    }
+    return ['claude-code'];
+  }
+
+  /**
    * F-7 atomic-step primitive: register a step that will run once on
    * the release boundary where `step.version <= toVersion`. Idempotent
    * across runs — the engine records every step's outcome in
@@ -284,15 +319,8 @@ export class PostUpdateMigrator {
     // parity graph at startup for agents that never invoke migrate().
     const { listParityRules } = await import('../providers/parity/registry.js');
 
-    // Determine enabled frameworks from config — default to claude-code+codex-cli
-    // for portable agents, claude-code-only as a safe fallback.
-    const frameworks = ((): ReadonlyArray<'claude-code' | 'codex-cli'> => {
-      const enabled = (config as { enabledFrameworks?: string[] }).enabledFrameworks;
-      if (Array.isArray(enabled) && enabled.length > 0) {
-        return enabled.filter(f => f === 'claude-code' || f === 'codex-cli') as ('claude-code' | 'codex-cli')[];
-      }
-      return ['claude-code'];
-    })();
+    // Single source of truth for framework gating (see getEnabledFrameworks).
+    const frameworks = this.getEnabledFrameworks();
 
     const rules = listParityRules();
     let renderedCount = 0;
@@ -2251,6 +2279,17 @@ The user has been talking to you (possibly for days). A generic greeting like "H
    * Migrates legacy PostToolUse/Notification hooks to proper SessionStart type.
    */
   private migrateSettings(result: MigrationResult): void {
+    // Framework gate (portability audit Gap 5). `.claude/settings.json` is
+    // Claude Code's hook/MCP configuration — it has zero meaning for a
+    // Codex-only runtime. Skip the entire step when claude-code is not in
+    // the enabled set so a Codex-only install is not scaffolded with
+    // `.claude/` artifacts it will never read. Default (unset config) is
+    // ['claude-code'], so existing and dual-framework installs are
+    // unaffected.
+    if (!this.getEnabledFrameworks().includes('claude-code')) {
+      result.skipped.push('.claude/settings.json (skipped — claude-code not in enabledFrameworks)');
+      return;
+    }
     const settingsPath = path.join(this.config.projectDir, '.claude', 'settings.json');
     if (!fs.existsSync(settingsPath)) {
       result.skipped.push('.claude/settings.json (not found — will be created on next init)');

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1665,6 +1665,19 @@ export interface InstarConfig {
    * agent's framework.
    */
   topicFrameworks?: Record<string, 'claude-code' | 'codex-cli'>;
+  /**
+   * Agent-level set of frameworks this install actively uses. Drives
+   * which framework-specific migration steps run on update: a
+   * codex-cli-only install should not receive `.claude/`-specific
+   * scaffolding it will never use. When unset or empty, defaults to
+   * `['claude-code']` — the historical behavior, so existing and
+   * dual-framework installs are unaffected. Set to `['codex-cli']`
+   * for a Codex-only agent, or `['claude-code','codex-cli']` for a
+   * dual-runtime install. (Mirrors FrameworkParitySentinel's
+   * `enabledFrameworks`; this is the persisted, operator-settable
+   * source of truth the migrator reads.)
+   */
+  enabledFrameworks?: ('claude-code' | 'codex-cli')[];
   /** Job scheduler config */
   scheduler: JobSchedulerConfig;
   /** Registered users */

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-19T19:57:34.583Z",
-  "instarVersion": "1.0.10",
+  "generatedAt": "2026-05-19T20:15:56.241Z",
+  "instarVersion": "1.0.11",
   "entryCount": 189,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -1456,7 +1456,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "d8ba2811113c6f6417d5555bd5490d5169dd41d5774ff5af9e171693e4d140aa",
+      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/tests/unit/PostUpdateMigrator-frameworkGate.test.ts
+++ b/tests/unit/PostUpdateMigrator-frameworkGate.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Verifies the framework gate added for the cross-framework portability
+ * audit (Gap 5). `enabledFrameworks` is now a real, persisted config field;
+ * the migrator's getEnabledFrameworks() reads it (default ['claude-code'])
+ * and migrateSettings — which only touches Claude Code's .claude/settings.json
+ * — skips entirely for a Codex-only install.
+ *
+ * Critically: the audit's original "wrap legacy steps in a guard" framing
+ * would have been INERT, because enabledFrameworks was read defensively but
+ * was never a real settable field (always undefined → always defaulted to
+ * claude-code → guard never skipped). These tests prove the field is now
+ * genuine and the gate is reachable.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function migrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test-agent',
+  });
+}
+
+function writeConfig(stateDir: string, enabledFrameworks?: string[]): void {
+  const cfg: Record<string, unknown> = { projectName: 'test-agent' };
+  if (enabledFrameworks) cfg.enabledFrameworks = enabledFrameworks;
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify(cfg, null, 2));
+}
+
+function runMigrateSettings(m: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (m as unknown as { migrateSettings(r: MigrationResult): void }).migrateSettings(result);
+  return result;
+}
+
+function enabledFrameworksOf(m: PostUpdateMigrator): readonly string[] {
+  return (m as unknown as { getEnabledFrameworks(): readonly string[] }).getEnabledFrameworks();
+}
+
+describe('PostUpdateMigrator — framework gate (Gap 5)', () => {
+  let projectDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-fw-gate-'));
+    stateDir = path.join(projectDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-frameworkGate.test.ts',
+    });
+  });
+
+  it('getEnabledFrameworks defaults to [claude-code] when config has no field', () => {
+    writeConfig(stateDir);
+    expect(enabledFrameworksOf(migrator(projectDir))).toEqual(['claude-code']);
+  });
+
+  it('getEnabledFrameworks defaults to [claude-code] when config.json is absent', () => {
+    expect(enabledFrameworksOf(migrator(projectDir))).toEqual(['claude-code']);
+  });
+
+  it('getEnabledFrameworks honors an explicit codex-only config', () => {
+    writeConfig(stateDir, ['codex-cli']);
+    expect(enabledFrameworksOf(migrator(projectDir))).toEqual(['codex-cli']);
+  });
+
+  it('getEnabledFrameworks honors a dual-framework config', () => {
+    writeConfig(stateDir, ['claude-code', 'codex-cli']);
+    expect(enabledFrameworksOf(migrator(projectDir))).toEqual(['claude-code', 'codex-cli']);
+  });
+
+  it('migrateSettings SKIPS for a codex-only install (gate is reachable, not inert)', () => {
+    writeConfig(stateDir, ['codex-cli']);
+    // Even with a .claude/settings.json present, the gate must short-circuit.
+    fs.mkdirSync(path.join(projectDir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.claude', 'settings.json'), '{}');
+
+    const result = runMigrateSettings(migrator(projectDir));
+
+    expect(result.skipped.some(s => s.includes('claude-code not in enabledFrameworks'))).toBe(true);
+    expect(result.upgraded).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('migrateSettings does NOT skip on the default (claude-code) install', () => {
+    writeConfig(stateDir); // no enabledFrameworks → default ['claude-code']
+    // No .claude/settings.json → it reaches the normal not-found skip,
+    // proving the framework gate did NOT short-circuit first.
+    const result = runMigrateSettings(migrator(projectDir));
+
+    expect(result.skipped.some(s => s.includes('claude-code not in enabledFrameworks'))).toBe(false);
+    expect(result.skipped.some(s => s.includes('not found — will be created on next init'))).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,61 @@
+# Upgrade Guide — v1.0.11 (portability hardening 5 of 6)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Fifth of the six cross-framework portability hardening patches (v1.0.9–v1.0.14).
+
+`enabledFrameworks` is now a real, settable config field. The post-update
+migrator reads it through a single helper and skips Claude-Code-only
+scaffolding for a Codex-only install. Previously the migrator had only inert
+gating logic — the field it read was never a real config option, so the gate
+never triggered.
+
+The migrator step that maintains `.claude/settings.json` (Claude Code's
+hook/MCP configuration, meaningless to Codex) now skips for an install that
+does not list `claude-code` in `enabledFrameworks`. The default — when the
+field is unset — is `['claude-code']`, so existing and dual-runtime installs
+behave exactly as before.
+
+## Evidence
+
+Reproduction prior to this change: the migrator read `enabledFrameworks`
+defensively in one place, but it was never an actual config field — always
+undefined, always defaulting to Claude Code, so no Claude-only step could ever
+be skipped for a Codex-only install.
+
+Observed after this change: setting `enabledFrameworks` to `["codex-cli"]` in
+the config makes the `.claude/settings.json` migrator step skip with a clear
+note. Leaving the field unset keeps the default `["claude-code"]` and the step
+runs exactly as before. A single helper now resolves the framework set and the
+previously-duplicated inline logic was refactored to use it.
+
+Unit verification: `tests/unit/PostUpdateMigrator-frameworkGate.test.ts` — six
+cases: default when the field is absent; default when the config file is
+absent; honors a Codex-only config; honors a dual config; the settings step
+skips for a Codex-only install (proving the gate is reachable, not inert); the
+settings step does NOT skip on the default install (negative side). The eleven
+existing parity-renderings tests pass unchanged, confirming the refactor
+preserved behavior.
+
+## What to Tell Your User
+
+- "You can now mark an agent as Codex-only, and updates will stop scaffolding Claude-Code-only configuration it would never use. If you do not set this, nothing changes — every existing agent keeps behaving exactly as before."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| `enabledFrameworks` config field | Set it in the config to `["codex-cli"]`, `["claude-code"]`, or both. Unset defaults to `["claude-code"]`. |
+| Framework-gated migration | Automatic. Claude-Code-only migrator steps skip when `claude-code` is not enabled. |
+
+## Deferred (Tracked Follow-ups)
+
+- Remaining legacy `.claude/`-specific migrator steps can adopt the shared
+  framework helper incrementally; doing all of them in one change would be
+  regression-prone, so the mechanism plus one proven guarded step ships here.
+- Two cross-framework gaps remain (v1.0.x): framework-aware connector-server
+  registration and a framework session-transcript store. Both depend on
+  external Codex specifics and will ship as documented extension points rather
+  than guessed implementations.

--- a/upgrades/side-effects/feat-portability-framework-gate.md
+++ b/upgrades/side-effects/feat-portability-framework-gate.md
@@ -1,0 +1,62 @@
+# Side-effects review — Real enabledFrameworks field + framework gate (Gap 5)
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: UNDER (and inert) — no working way to skip Claude-only steps for a
+Codex install. After: precisely targeted. Default config → `['claude-code']`
+→ zero skips → byte-identical to today for every existing/dual install. Only
+an explicit `enabledFrameworks: ['codex-cli']` causes `migrateSettings` to
+skip — exactly the intended case. No over-block.
+
+## 2. Level-of-abstraction fit
+
+Framework resolution is now one private helper (`getEnabledFrameworks`) — the
+single source of truth. The previously-duplicated inline logic in
+`migrateParityRenderings` was refactored to call it, removing drift risk.
+
+## 3. Signal vs Authority compliance
+
+`enabledFrameworks` (persisted config) is the SIGNAL of operator intent;
+`getEnabledFrameworks()` is the one AUTHORITY that resolves it with a safe
+default. No brittle inline re-derivation remains.
+
+## 4. Interactions with adjacent systems
+
+- **migrateParityRenderings** — behavior preserved; the 11 existing
+  parity-renderings tests pass unchanged after the DRY refactor.
+- **FrameworkParitySentinel.enabledFrameworks** — separate config object
+  (sentinel's own interface); this PR adds the *persisted InstarConfig*
+  field the migrator reads. Names intentionally mirror; no shared mutable
+  state, no coupling introduced.
+- **migrateSettings** — only new behavior is the early skip for non-Claude;
+  all downstream `.claude/settings.json` logic is untouched for the default
+  path.
+- **Remaining 48 `.claude/` refs** — unchanged; they can adopt
+  `getEnabledFrameworks()` incrementally. Not touching them now is a
+  deliberate regression-risk decision, not an oversight.
+
+## 5. Rollback cost
+
+Low. One new optional type field + one helper + one DRY refactor + one early
+return + one test file. `git revert` restores prior behavior. The new config
+field is optional and ignored by older code, so a mixed-version fleet is safe.
+
+## 6. Backwards compatibility / drift surface
+
+Fully backward-compatible: optional field, safe default. Older instar
+versions ignore an `enabledFrameworks` they don't know about. Drift surface
+*reduced* — the duplicate inline framework logic is now a single helper.
+
+## 7. Authorization / Trust posture
+
+No new authority. The helper only reads config and returns a string array.
+The gate only *prevents* writes for non-Claude installs — it never grants a
+new write. Unreadable config fails safe to `['claude-code']` (status quo).
+
+## Outcome
+
+Ship. Corrects an inert audit finding into a real, reachable, tested gate;
+default-safe; drift-reducing; trivial rollback. Fifth of the v1.0.9–v1.0.14
+hardening series.


### PR DESCRIPTION
Fifth of six portability hardening patches. Audit Gap 5's framing would have been INERT — enabledFrameworks was read defensively but was never a real settable config field (always defaulted to claude-code, guard never triggered). This makes it a real InstarConfig field, adds a single-source getEnabledFrameworks() helper (DRY-refactoring the duplicate inline logic), and gates migrateSettings (Claude-only .claude/settings.json) to skip for codex-only installs. Default unchanged: unset → ['claude-code'] → nothing skips. 6-case test proves the gate is reachable AND the default does not skip; 11 parity-renderings tests pass unchanged. 🤖 Generated with Claude Code