### PR TITLE
fix(portability): framework-aware Threadline MCP registration (audit Gap 2) — v1.0.13

### DIFF
--- a/.instar/instar-dev-traces/20260519T213000Z-portability-codex-mcp.json
+++ b/.instar/instar-dev-traces/20260519T213000Z-portability-codex-mcp.json
@@ -1,0 +1,19 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/portability-codex-mcp.md",
+  "artifactPath": "upgrades/side-effects/feat-portability-codex-mcp.md",
+  "artifactSha256": "3bbe68a304d685f6e85a1620a5df1419dc2eca6a2100e13d7c1c7d3737da6239",
+  "coveredFiles": [
+    "src/threadline/ThreadlineBootstrap.ts",
+    "src/data/builtin-manifest.json",
+    "tests/unit/threadline-codex-mcp-registration.test.ts",
+    "specs/dev-infrastructure/portability-codex-mcp.md",
+    "specs/dev-infrastructure/portability-codex-mcp.eli16.md",
+    "docs/specs/reports/portability-codex-mcp-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/feat-portability-codex-mcp.md"
+  ],
+  "writtenAt": "2026-05-19T21:30:00Z",
+  "agent": "echo",
+  "summary": "Portability audit Gap 2 (final code gap): ThreadlineBootstrap.registerThreadlineMcp is now async and, after the unchanged Claude ~/.claude.json + .mcp.json blocks, also registers the threadline stdio server into Codex's ~/.codex/config.toml when ~/.codex/ exists. Reuses the existing OpenAiCodexMcpToolRegistry (no duplicate TOML writer), idempotent remove-then-append, preserves operator content, non-fatal. Codex format/path empirically verified from live ~/.codex/ (Codex CLI 0.78.0) + our own mcpToolRegistry.ts docs. 4-case test + ThreadlineBootstrap regression green. Ships v1.0.13. Only Gap 6 (architecture decision) remains, deferred to operator review by design."
+}

--- a/docs/specs/reports/portability-codex-mcp-convergence.md
+++ b/docs/specs/reports/portability-codex-mcp-convergence.md
@@ -1,0 +1,43 @@
+# Convergence Report — Framework-aware Threadline MCP registration
+
+## ELI10 Overview
+
+When an agent joins the agent-to-agent network it advertises tools. Setup only
+told Claude Code; a Codex agent had the connection but no usable tools. This
+adds Codex registration too, using Codex's real config format (verified, not
+guessed), only when Codex is installed.
+
+## Original vs Converged
+
+Audit Gap 2 ("ThreadlineBootstrap framework-aware MCP registration") was
+initially flagged as blocked on an external Codex spec. Per Justin's
+direction, empirical inspection of the live ~/.codex/ plus our own codebase
+docs gave the exact format. Converged: reuse the existing tested
+OpenAiCodexMcpToolRegistry rather than hand-roll TOML, gate on ~/.codex/
+presence, keep both Claude blocks byte-identical.
+
+## Iteration Summary
+
+| Iteration | Reviewers run | Material findings | Spec changes |
+|-----------|---------------|-------------------|--------------|
+| 1 | Manual lessons-check + empirical ~/.codex/ + codebase-doc cross-check + regression | 0 | None |
+
+## Manual lessons-aware findings
+
+Engaged P1, P4 (4 cases incl. idempotency + operator-content preservation),
+P6, P10 (registry reuse, no duplication), Trust-Verify-Improve (format
+verified live + in-codebase), L6/L9/L10. No contradictions. No fabrication.
+
+## Convergence verdict
+
+Converged at iteration 1. The final code-level portability gap. Empirically
+grounded, reuses a tested writer, default-safe (gated on Codex presence).
+Sixth shipped of the v1.0.9–v1.0.14 series (1.0.13). Gap 6 (migrator/identity
+unification) intentionally remains for operator architecture review.
+
+## Deviation note
+
+Autonomous-mode pre-authorization. Second "external-spec-unknown" resolved by
+empirical inspection per Justin's earlier correction, not deferred or
+fabricated. Gap 6 is the only remaining item and is a genuine design
+decision, not a deferral of doable work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/portability-codex-mcp.eli16.md
+++ b/specs/dev-infrastructure/portability-codex-mcp.eli16.md
@@ -1,0 +1,39 @@
+---
+title: "Codex MCP registration — ELI16"
+slug: "portability-codex-mcp-eli16"
+parent: "portability-codex-mcp.md"
+---
+
+# Codex MCP registration — explained simply
+
+## The problem
+
+When an agent joins the agent-to-agent network (Threadline), it advertises a
+small set of tools so other agents can reach it. The setup code only told
+Claude Code about those tools. A Codex agent could join the network and have
+the connection running, but Codex itself never knew the tools existed — so
+from Codex you couldn't actually use them.
+
+## How we found Codex's format
+
+Not guessed. Codex lists its tool servers as `[mcp_servers."name"]` blocks in
+`~/.codex/config.toml`. Confirmed two ways: our own code already documented
+this, and we checked the real `~/.codex/config.toml` on the machine.
+
+## The fix
+
+After registering with Claude Code (unchanged), the setup now also adds the
+`[mcp_servers."threadline"]` block to Codex's config file — but only if Codex
+is actually installed on the machine, so a Claude-only computer never gets a
+Codex config it doesn't use. It reuses the Codex config writer we already had
+and tested, so there's no second copy of that logic to drift.
+
+## Why it's safe
+
+It only runs when Codex is present, it's wrapped so a failure can't break the
+Claude setup or the network connection, it replaces rather than duplicates its
+own block on repeat runs, and it leaves any other settings in your Codex
+config untouched. Four tests check the format, the no-duplicate behavior,
+preserving unrelated config, and the "is it registered" check. This is the
+last of the six code-level portability gaps; only one architecture question
+remains for operator review.

--- a/specs/dev-infrastructure/portability-codex-mcp.md
+++ b/specs/dev-infrastructure/portability-codex-mcp.md
@@ -1,0 +1,99 @@
+---
+title: "Framework-aware Threadline MCP registration (portability Gap 2)"
+slug: "portability-codex-mcp"
+author: "echo"
+status: "converged"
+type: "dev-infrastructure-spec"
+eli16-overview: "portability-codex-mcp.eli16.md"
+review-convergence: "2026-05-19T21:30:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-19T21:30:00Z"
+review-report: "docs/specs/reports/portability-codex-mcp-convergence.md"
+approved: true
+approved-by: "Justin (pre-authorized 2026-05-19, autonomous-mode; directed empirical discovery of Codex specs via the live ~/.codex/)"
+approved-date: "2026-05-19"
+approval-note: "Gap 2 of six — the final code gap. Codex MCP format/path empirically verified from live ~/.codex/ (config.toml, [mcp_servers.*]) and our own mcpToolRegistry.ts docs. Ships v1.0.13. Only Gap 6 (architecture decision) remains, deferred to operator review by design."
+lessons-engaged:
+  - "P1 (Structure>Willpower): registration writes the Codex config structurally; not a doc telling operators to add it."
+  - "P4 (Testing Integrity): 4-case test pinning the Codex TOML shape, idempotency, operator-content preservation, isRegistered."
+  - "P10 (Comprehensive-First): reuses the existing OpenAiCodexMcpToolRegistry — no duplicate TOML writer; both Claude paths preserved."
+  - "Trust-Verify-Improve: Codex MCP path/format verified from live ~/.codex/ AND our own codebase docs — no fabrication."
+  - "L1-equivalent (audit-driven): closes verified Gap 2."
+  - "L6/L9/L10: siblings."
+---
+
+# Framework-aware Threadline MCP registration (Gap 2)
+
+## Problem
+
+`ThreadlineBootstrap.registerThreadlineMcp` registered the Threadline MCP
+server only into Claude Code config (`~/.claude.json` + project `.mcp.json`).
+A Codex agent that joined the Threadline network had the relay running but
+**no MCP tools advertised to its runtime** — `threadline_discover`,
+`threadline_send`, etc. were unreachable from Codex.
+
+## Empirical grounding (not guessed)
+
+Codex MCP servers are `[mcp_servers."<id>"]` TOML tables in
+`~/.codex/config.toml` (project scope: `.codex/config.toml`). Verified two
+ways: (1) our own codebase already documents this in
+`src/providers/primitives/integration/mcpToolRegistry.ts:7`; (2) inspected
+against the live `~/.codex/config.toml` on disk (Codex CLI 0.78.0).
+
+## Change
+
+`registerThreadlineMcp` is now `async` (the one call site in
+`bootstrapThreadline` now awaits it). After the two unchanged Claude
+registration blocks, it adds a third: when `~/.codex/` exists (Codex
+installed on this host), it registers the same stdio spec via the
+**existing** `OpenAiCodexMcpToolRegistry` (`createMcpToolRegistry()`), which
+performs an idempotent remove-then-append of the `[mcp_servers."threadline"]`
+table in `~/.codex/config.toml`.
+
+Design decisions:
+
+- **Reuse, don't duplicate.** The Codex TOML writer already exists and is
+  tested; this PR calls it rather than hand-rolling TOML, so the two cannot
+  drift.
+- **Gated on `~/.codex/` existing.** A Claude-only host is never given a
+  Codex config it does not use (consistent with the lockdown ethos of not
+  writing configs an install doesn't need).
+- **Non-fatal.** Wrapped in try/catch like the existing Claude blocks — a
+  Codex registration failure never breaks Claude registration or bootstrap.
+- **Idempotent.** The registry removes any existing `threadline` table
+  before appending, and preserves unrelated operator content.
+
+## What this is NOT
+
+- Not a change to Claude registration — both Claude blocks are byte-identical.
+- Not an enabledFrameworks-gated change — Codex registration follows
+  Codex-installed-presence, which is the right signal for "does this host
+  have a Codex runtime to advertise tools to."
+
+## Testing
+
+`tests/unit/threadline-codex-mcp-registration.test.ts` — 4 cases against a
+`CODEX_HOME` override: writes the stdio table; idempotent (no duplicate
+table on re-register); preserves unrelated operator `config.toml` content;
+`isRegistered` reflects state. ThreadlineBootstrap regression suite green.
+
+## Manual lessons-aware check
+
+| Principle/Lesson | Engagement |
+|---|---|
+| P1 Structure>Willpower | ✓ structural registration |
+| P4 Testing Integrity | ✓ 4 cases, idempotency + operator-preservation |
+| P6 Zero-Failure | ✓ suite green |
+| P10 Comprehensive-First | ✓ reuses tested registry; no duplication |
+| Trust-Verify-Improve | ✓ format verified live + in-codebase |
+| L6/L9/L10 | ✓ siblings |
+
+No contradictions. No fabrication.
+
+## Implementation slice
+
+1. This spec + ELI16 + convergence report.
+2. `src/threadline/ThreadlineBootstrap.ts` — async registerThreadlineMcp +
+   Codex registration block + awaited call site.
+3. `tests/unit/threadline-codex-mcp-registration.test.ts` (NEW, 4 tests).
+4. `upgrades/NEXT.md` + `upgrades/side-effects/feat-portability-codex-mcp.md`.

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-19T20:39:31.435Z",
-  "instarVersion": "1.0.12",
+  "generatedAt": "2026-05-19T20:58:06.007Z",
+  "instarVersion": "1.0.13",
   "entryCount": 189,
   "entries": {
     "hook:session-start": {

--- a/src/threadline/ThreadlineBootstrap.ts
+++ b/src/threadline/ThreadlineBootstrap.ts
@@ -117,8 +117,8 @@ export async function bootstrapThreadline(
   // Start heartbeat for liveness detection
   const stopHeartbeat = discovery.startPresenceHeartbeat();
 
-  // ── 4. Register MCP server into Claude Code config ───────────────
-  registerThreadlineMcp(config.projectDir, config.agentName, config.stateDir);
+  // ── 4. Register MCP server into framework config(s) ──────────────
+  await registerThreadlineMcp(config.projectDir, config.agentName, config.stateDir);
 
   // ── 5. Cloud Relay Connection (opt-in) ─────────────────────────
   const relayEnabled = config.relayEnabled === true
@@ -370,14 +370,23 @@ function loadOrCreateIdentityKeys(threadlineDir: string): KeyPair {
 // ── MCP Registration ─────────────────────────────────────────────────
 
 /**
- * Register the Threadline MCP server into Claude Code's config.
+ * Register the Threadline MCP server into every framework config present.
  *
- * Uses the same pattern as ensurePlaywrightMcp() — registers in both
- * ~/.claude.json (local scope) and .mcp.json (project scope).
+ * Claude Code: ~/.claude.json (local scope) + .mcp.json (project scope).
+ * Codex CLI: `[mcp_servers."threadline"]` in ~/.codex/config.toml — added
+ *   for the cross-framework portability audit (Gap 2). Before this, a
+ *   Codex agent that joined the Threadline network had the relay running
+ *   but no MCP tools advertised to its runtime. The Codex TOML format and
+ *   path were empirically verified from a live ~/.codex/ (Codex CLI
+ *   0.78.0); registration reuses the existing, tested
+ *   OpenAiCodexMcpToolRegistry so the two writers cannot drift.
  *
- * The MCP server is a stdio process that Claude Code launches as a subprocess.
+ * The MCP server is a stdio process the framework launches as a subprocess.
+ * Codex registration is gated on ~/.codex/ existing (Codex installed on
+ * this machine) so a Claude-only host is never given a Codex config it
+ * does not use.
  */
-function registerThreadlineMcp(projectDir: string, agentName: string, stateDir: string): void {
+async function registerThreadlineMcp(projectDir: string, agentName: string, stateDir: string): Promise<void> {
   const absDir = path.resolve(projectDir);
 
   // The MCP server entry point — runs as a child process of Claude Code.
@@ -453,5 +462,31 @@ function registerThreadlineMcp(projectDir: string, agentName: string, stateDir: 
     fs.renameSync(tmpPath, mcpJsonPath);
   } catch {
     // Non-fatal
+  }
+
+  // ── 3. Also register in Codex's ~/.codex/config.toml (portability Gap 2) ──
+  // Gated on ~/.codex/ existing so a Claude-only host never gets a Codex
+  // config it does not use. Reuses the existing OpenAiCodexMcpToolRegistry
+  // (idempotent remove-then-append of the [mcp_servers."threadline"] table)
+  // so the TOML writer is never duplicated. Non-fatal, matching the Claude
+  // registration blocks above.
+  try {
+    const codexHome = process.env['CODEX_HOME'] || path.join(os.homedir(), '.codex');
+    if (fs.existsSync(codexHome)) {
+      const { createMcpToolRegistry } = await import(
+        '../providers/adapters/openai-codex/integration/mcpToolRegistry.js'
+      );
+      await createMcpToolRegistry().register(
+        {
+          kind: 'stdio',
+          name: 'threadline',
+          command: mcpEntry.command,
+          args: mcpEntry.args,
+        },
+        { scope: 'user' },
+      );
+    }
+  } catch {
+    // Non-fatal — Claude registration above is unaffected.
   }
 }

--- a/tests/unit/threadline-codex-mcp-registration.test.ts
+++ b/tests/unit/threadline-codex-mcp-registration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Verifies the Codex MCP registration path used by ThreadlineBootstrap
+ * (portability audit Gap 2). Before this, a Codex agent that joined the
+ * Threadline network had the relay running but no MCP tools advertised to
+ * its runtime, because registration only wrote Claude Code's
+ * ~/.claude.json / .mcp.json.
+ *
+ * ThreadlineBootstrap now also registers `[mcp_servers."threadline"]` into
+ * ~/.codex/config.toml by reusing the existing OpenAiCodexMcpToolRegistry.
+ * These tests exercise that exact registry against a CODEX_HOME override
+ * (the empirically-verified Codex config location, Codex CLI 0.78.0) so the
+ * TOML shape and idempotency are pinned.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createMcpToolRegistry } from '../../src/providers/adapters/openai-codex/integration/mcpToolRegistry.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('Threadline Codex MCP registration (Gap 2)', () => {
+  let tmpHome: string;
+  let prevCodexHome: string | undefined;
+  let configFile: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-codex-mcp-'));
+    prevCodexHome = process.env['CODEX_HOME'];
+    process.env['CODEX_HOME'] = tmpHome;
+    configFile = path.join(tmpHome, 'config.toml');
+  });
+
+  afterEach(() => {
+    if (prevCodexHome === undefined) delete process.env['CODEX_HOME'];
+    else process.env['CODEX_HOME'] = prevCodexHome;
+    SafeFsExecutor.safeRmSync(tmpHome, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/threadline-codex-mcp-registration.test.ts',
+    });
+  });
+
+  const threadlineSpec = {
+    kind: 'stdio' as const,
+    name: 'threadline',
+    command: 'node',
+    args: ['/abs/path/mcp-stdio-entry.js', '--state-dir', '/p/.instar', '--agent-name', 'echo'],
+  };
+
+  it('writes a [mcp_servers."threadline"] stdio table to config.toml', async () => {
+    await createMcpToolRegistry().register(threadlineSpec, { scope: 'user' });
+
+    const toml = fs.readFileSync(configFile, 'utf-8');
+    expect(toml).toContain('[mcp_servers."threadline"]');
+    expect(toml).toContain('kind = "stdio"');
+    expect(toml).toContain('command = "node"');
+    expect(toml).toContain('mcp-stdio-entry.js');
+    expect(toml).toContain('--agent-name');
+  });
+
+  it('is idempotent — re-registering replaces, does not duplicate the table', async () => {
+    const reg = createMcpToolRegistry();
+    await reg.register(threadlineSpec, { scope: 'user' });
+    await reg.register(threadlineSpec, { scope: 'user' });
+
+    const toml = fs.readFileSync(configFile, 'utf-8');
+    const occurrences = toml.split('[mcp_servers."threadline"]').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('preserves unrelated operator content in config.toml', async () => {
+    fs.writeFileSync(
+      configFile,
+      'model = "gpt-5.2-codex"\n\n[mcp_servers."other"]\nkind = "stdio"\ncommand = "foo"\n',
+    );
+    await createMcpToolRegistry().register(threadlineSpec, { scope: 'user' });
+
+    const toml = fs.readFileSync(configFile, 'utf-8');
+    expect(toml).toContain('model = "gpt-5.2-codex"');
+    expect(toml).toContain('[mcp_servers."other"]');
+    expect(toml).toContain('[mcp_servers."threadline"]');
+  });
+
+  it('isRegistered reports the threadline server after registration', async () => {
+    const reg = createMcpToolRegistry();
+    expect(await reg.isRegistered('threadline')).toBe(false);
+    await reg.register(threadlineSpec, { scope: 'user' });
+    expect(await reg.isRegistered('threadline')).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,57 @@
+# Upgrade Guide — v1.0.13 (portability hardening 6 of 6 code gaps)
+
+<!-- bump: patch -->
+
+## What Changed
+
+The final code-level cross-framework portability hardening patch. Five of the
+six audit gaps shipped as v1.0.9–v1.0.12; this is the sixth (Gap 2).
+
+When an agent joins the agent-to-agent Threadline network, the Threadline MCP
+server was registered only into Claude Code configuration. A Codex agent had
+the network connection running but its runtime never knew the Threadline
+tools existed. Setup now also registers the Threadline MCP server into Codex
+configuration when Codex is installed on the machine.
+
+The Codex configuration format and location were verified against a live
+Codex install, not assumed. Registration reuses the existing, already-tested
+Codex configuration writer, so there is no second copy of that logic to drift.
+
+## Evidence
+
+Reproduction prior to this change: run a Codex agent, join the Threadline
+network. The relay connects, but the Threadline MCP tools
+(discover/send/trust/relay) are absent from the Codex runtime because
+registration only wrote Claude Code's configuration files.
+
+Observed after this change: on a host where Codex is installed, the
+Threadline MCP server is also written as a `[mcp_servers."threadline"]` table
+in Codex's user configuration, so Codex launches it and the tools are
+reachable. On a Claude-only host (no Codex installed) nothing changes — the
+Codex step is skipped. Existing Claude Code configuration writes are
+byte-for-byte unchanged and still happen first.
+
+Unit verification: `tests/unit/threadline-codex-mcp-registration.test.ts` —
+four cases against an isolated Codex config location: the stdio server table
+is written; re-registration replaces rather than duplicates the table;
+unrelated operator configuration content is preserved; the registered state
+is reported correctly. The ThreadlineBootstrap regression suite passes.
+
+## What to Tell Your User
+
+- "If you run an agent on Codex and connect it to the agent network, its tools now actually work from Codex, not just from Claude Code. Claude-only setups are unchanged."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Codex MCP registration | Automatic when joining the Threadline network on a host with Codex installed. |
+| No-duplication guarantee | Re-running setup replaces the Threadline server entry rather than duplicating it, and leaves other Codex configuration intact. |
+
+## Deferred (Tracked Follow-ups)
+
+- One audit item remains: unifying the post-update migrator's identity
+  handling with the identity renderer (how the rich Claude capability
+  document relates to the canonical identity source). This is a genuine
+  architecture decision and is being reviewed with the operator rather than
+  refactored blind — it is not a deferral of doable work.

--- a/upgrades/side-effects/feat-portability-codex-mcp.md
+++ b/upgrades/side-effects/feat-portability-codex-mcp.md
@@ -1,0 +1,62 @@
+# Side-effects review — Framework-aware Threadline MCP registration (Gap 2)
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: UNDER — Codex agents on the network had no advertised MCP tools.
+After: no over-block. Codex registration only runs when `~/.codex/` exists;
+a Claude-only host is untouched. Both Claude registration blocks are
+byte-identical.
+
+## 2. Level-of-abstraction fit
+
+Reuses the existing `OpenAiCodexMcpToolRegistry` (the dedicated Codex TOML
+writer). ThreadlineBootstrap orchestrates; the registry owns the format. No
+TOML logic duplicated.
+
+## 3. Signal vs Authority compliance
+
+`~/.codex/` existence is the SIGNAL that a Codex runtime is present; the
+registry is the single AUTHORITY for the TOML shape. No brittle inline
+writer.
+
+## 4. Interactions with adjacent systems
+
+- **Claude registration (~/.claude.json, .mcp.json)** — unchanged,
+  byte-identical, still first.
+- **OpenAiCodexMcpToolRegistry** — used as-is; its existing tests plus 4 new
+  Gap-2 tests cover the path. No change to the registry itself.
+- **bootstrapThreadline** — the one call site now awaits the (now async)
+  registerThreadlineMcp; downstream steps already followed it sequentially,
+  so ordering is preserved.
+- **Operator config.toml** — idempotent remove-then-append of only the
+  `threadline` table; unrelated `[mcp_servers."other"]` / `model = ...`
+  content preserved (tested).
+
+## 5. Rollback cost
+
+Low. One function made async + one awaited call site + one appended block +
+one new test. `git revert` restores prior behavior. A leftover
+`[mcp_servers."threadline"]` in a Codex config after revert is inert (Codex
+just launches an MCP that isn't used).
+
+## 6. Backwards compatibility / drift surface
+
+Claude-only hosts: byte-identical behavior (Codex block gated out). Dual/
+Codex hosts: strictly better (tools now advertised). Drift surface: none —
+the TOML writer is the single existing registry, not a copy.
+
+## 7. Authorization / Trust posture
+
+No new authority. Writes only the `threadline` MCP table to a config the
+operator's Codex already owns, gated on Codex being installed. Non-fatal:
+failure cannot break Claude registration or bootstrap, cannot escalate.
+
+## Outcome
+
+Ship. Empirically grounded, reuses a tested writer (no duplication),
+default-safe (Codex-presence gated), idempotent, operator-content
+preserving, trivial rollback. Sixth shipped of the v1.0.9–v1.0.14 series
+(1.0.13) — the final code-level portability gap. Gap 6 remains for operator
+architecture review by design.


### PR DESCRIPTION
Final code-level portability gap (5 shipped as v1.0.9-v1.0.12). Closes audit Gap 2: registerThreadlineMcp registered only into Claude Code config, so a Codex agent on the Threadline network had no MCP tools advertised to its runtime. Now also registers [mcp_servers.threadline] into ~/.codex/config.toml when Codex is installed, reusing the existing tested OpenAiCodexMcpToolRegistry (no duplicate TOML writer). Codex format empirically verified from live ~/.codex/ + our own codebase docs. Idempotent, operator-content-preserving, non-fatal, gated on Codex presence. 4 new tests + regression green. Only Gap 6 (architecture decision) remains, deferred to operator review by design. 🤖 Generated with Claude Code