### PR TITLE
fix(portability): shadow capability mirror (audit Gap 6 — minimal shim) — v1.0.14

### DIFF
--- a/.instar/instar-dev-traces/20260519T220000Z-portability-shadow-capabilities.json
+++ b/.instar/instar-dev-traces/20260519T220000Z-portability-shadow-capabilities.json
@@ -1,0 +1,19 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/portability-shadow-capabilities.md",
+  "artifactPath": "upgrades/side-effects/feat-portability-shadow-capabilities.md",
+  "artifactSha256": "8a569d590ad5d40be6e930d88eb03adbdbe13eeed0df1a380fc567e04933b8e6",
+  "coveredFiles": [
+    "src/core/PostUpdateMigrator.ts",
+    "src/data/builtin-manifest.json",
+    "tests/unit/PostUpdateMigrator-shadowCapabilities.test.ts",
+    "specs/dev-infrastructure/portability-shadow-capabilities.md",
+    "specs/dev-infrastructure/portability-shadow-capabilities.eli16.md",
+    "docs/specs/reports/portability-shadow-capabilities-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/feat-portability-shadow-capabilities.md"
+  ],
+  "writtenAt": "2026-05-19T22:00:00Z",
+  "agent": "echo",
+  "summary": "Portability audit Gap 6 (final code gap, operator-chosen minimal shim): new migrateFrameworkShadowCapabilities runs after migrateClaudeMd. For each existing non-Claude shadow (AGENTS.md, GEMINI.md), slices well-known capability sections out of the just-patched CLAUDE.md (Self-Discovery, Private Viewing, Cloudflare Tunnel, Dashboard, File Viewer, Coherence Gate, External Operation Safety, Playbook, Threadline) and appends any missing ones. Section bodies LITERALLY copied — never duplicated in source — so Claude/non-Claude cannot drift. Idempotent; no-op for Claude-only installs. 6-case test. Ships v1.0.14, closes the v1.0.0 cross-framework portability audit at 6/6."
+}

--- a/docs/specs/reports/portability-shadow-capabilities-convergence.md
+++ b/docs/specs/reports/portability-shadow-capabilities-convergence.md
@@ -1,0 +1,47 @@
+# Convergence Report — Shadow capability mirror (Gap 6 minimal shim)
+
+## ELI10 Overview
+
+Claude Code agents got both identity and "what you can do" sections in their
+big instructions file. Codex/Gemini agents got identity (from an earlier
+patch) but no capability sections. This adds a small mirror that copies the
+capability sections directly from the freshly-updated CLAUDE.md into
+AGENTS.md/GEMINI.md when those files exist — sections themselves are never
+duplicated in source code, so the two cannot drift.
+
+## Original vs Converged
+
+Audit Gap 6 said "unify migrateClaudeMd with IdentityRenderer." Verified
+against the code, that framing conflates identity (canonical-to-shadow
+render) with capability instructions (rich per-section content). After
+presenting four grounded options, the operator explicitly chose the
+minimal-shim approach — a sibling migrator that mirrors the SAME sections
+without re-architecting CLAUDE.md's role. Sections are sliced from the live
+CLAUDE.md at migration time rather than extracted into a shared source array
+(a deliberately rejected 360-line refactor).
+
+## Iteration Summary
+
+| Iteration | Reviewers run | Material findings | Spec changes |
+|-----------|---------------|-------------------|--------------|
+| 1 | Manual lessons-check + operator decision via AskUserQuestion + 6-case test | 0 | None |
+
+## Manual lessons-aware findings
+
+Engaged P1, P4 (6 cases incl. both decision sides), P6, Trust-Verify-Improve
+(bodies copied not duplicated), L1-equivalent (framing corrected),
+L6/L9/L10. No contradictions. Scope explicitly bounded by operator decision.
+
+## Convergence verdict
+
+Converged at iteration 1. Operator-chosen scope, no fabrication, source-of-
+truth preserved (CLAUDE.md is the live source the shim slices from).
+Seventh shipped of the v1.0.9–v1.0.14 series (1.0.14) — the final code gap.
+Closes the v1.0.0 cross-framework portability audit at 6/6.
+
+## Deviation note
+
+Operator explicitly chose the minimal-shim option from a four-option
+AskUserQuestion. The literal-audit option ("unify with IdentityRenderer")
+was acknowledged as conflating two different documents and was rejected by
+the operator with the agent's concurrence.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/portability-shadow-capabilities.eli16.md
+++ b/specs/dev-infrastructure/portability-shadow-capabilities.eli16.md
@@ -1,0 +1,37 @@
+---
+title: "Shadow capability mirror — ELI16"
+slug: "portability-shadow-capabilities-eli16"
+parent: "portability-shadow-capabilities.md"
+---
+
+# Shadow capability mirror — explained simply
+
+## The problem
+
+Claude Code agents read a big instructions file (CLAUDE.md) that, on top of
+identity, also has a "here's what you can do" section — discover capabilities,
+publish private views, check the coherence gate, use the agent network, and
+so on. Codex and Gemini agents read their own files (AGENTS.md, GEMINI.md),
+and an earlier patch (v1.0.9) gave those the right identity, but those files
+never got the "what you can do" parts. So a Codex agent knew who it was, but
+not what its toolbox was.
+
+## The fix
+
+Right after the migrator updates CLAUDE.md, it now also looks at AGENTS.md
+and GEMINI.md if they exist. For each of the well-known capability sections,
+if the section isn't already in the shadow file, it copies that section
+*directly out of the freshly-updated CLAUDE.md* and appends it. Nothing about
+the section's content is duplicated in our source code — it's literally
+copied at runtime, so the Claude and non-Claude versions stay in sync
+automatically.
+
+## Why it's safe
+
+Claude-only setups have no AGENTS.md/GEMINI.md so nothing happens — Claude
+behavior is byte-for-byte unchanged. The mirror skips sections that already
+exist in the shadow, so running it twice does nothing. Six tests cover the
+appended-correctly, idempotent, both-shadows, no-shadow no-op, no-CLAUDE.md
+no-op, and identity-preserved cases. This is the sixth and final code-level
+portability patch — the v1.0.0 cross-framework portability audit is now
+closed at 6/6.

--- a/specs/dev-infrastructure/portability-shadow-capabilities.md
+++ b/specs/dev-infrastructure/portability-shadow-capabilities.md
@@ -1,0 +1,106 @@
+---
+title: "Shadow capability mirror (portability Gap 6 — minimal shim)"
+slug: "portability-shadow-capabilities"
+author: "echo"
+status: "converged"
+type: "dev-infrastructure-spec"
+eli16-overview: "portability-shadow-capabilities.eli16.md"
+review-convergence: "2026-05-19T22:00:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-19T22:00:00Z"
+review-report: "docs/specs/reports/portability-shadow-capabilities-convergence.md"
+approved: true
+approved-by: "Justin (2026-05-19, explicit choice via AskUserQuestion: 'Minimal Codex/Gemini shim')"
+approved-date: "2026-05-19"
+approval-note: "Gap 6 — final audit gap. Operator explicitly chose the 'minimal shim' approach over canonical-doc / pure-renderer / literal-audit options. Ships v1.0.14, closes the v1.0.0 cross-framework portability audit at 6/6 code gaps."
+lessons-engaged:
+  - "P1 (Structure>Willpower): the migrator mirrors sections structurally; not a doc telling operators to copy them."
+  - "P4 (Testing Integrity): 6-case test — appends, idempotent, both shadows, no-op no-shadow, no-op no-CLAUDE.md, identity preserved."
+  - "Trust-Verify-Improve: bodies are LITERALLY copied from the just-patched CLAUDE.md; no duplicated section bodies in source, so the two cannot drift."
+  - "L1-equivalent (audit-driven, framing corrected): the audit's 'unify with IdentityRenderer' conflated identity and capability docs; the operator-chosen minimal shim resolves it without conflating them or doing a 360-line refactor."
+  - "L6/L9/L10: siblings."
+---
+
+# Shadow capability mirror (Gap 6 — minimal shim)
+
+## Problem
+
+`generateClaudeMd` + `migrateClaudeMd` produce a rich capability/instructions
+document for Claude Code (Self-Discovery, Private Viewing, Dashboard,
+Coherence Gate, External Operation Safety, Playbook, Threadline Network, …)
+— but Codex/Gemini shadows had no equivalent. Gap 1 (shipped v1.0.9) gives
+non-Claude shadows their canonical identity; this closes the capability-
+instructions gap so an agent on Codex/Gemini knows the same set of things it
+can *do* as a Claude Code agent does.
+
+## Why "minimal shim" — operator decision
+
+The audit said "unify migrateClaudeMd with IdentityRenderer." Verified
+against the code, that framing conflates two different things: identity
+(canonical AGENT.md → shadow filename) and capability instructions (rich
+per-section content). After presenting four grounded options
+(minimal-shim / canonical-doc / defer / literal-audit) the operator chose
+the minimal-shim approach: a sibling migrator that mirrors the SAME sections
+into non-Claude shadows when they exist, without re-architecting CLAUDE.md's
+role.
+
+## Change
+
+New `migrateFrameworkShadowCapabilities` runs immediately after
+`migrateClaudeMd`. For each non-Claude shadow that exists (AGENTS.md,
+GEMINI.md), it:
+
+1. Reads the just-patched CLAUDE.md (the authoritative source of currently-
+   shipped capability sections).
+2. For each well-known section marker (`### Self-Discovery`, `**Private
+   Viewing**`, `**Cloudflare Tunnel**`, `**Dashboard**`, `**File Viewer`,
+   `### Coherence Gate`, `### External Operation Safety`, `### Playbook`,
+   `## Threadline Network`):
+   - If absent from the shadow, slice the section out of CLAUDE.md (from
+     the marker through the start of the next `##`/`###` heading or EOF)
+     and append it to the shadow.
+3. Writes the shadow only when something was appended.
+
+Section bodies are LITERALLY copied from CLAUDE.md — they are NOT duplicated
+in source, so the Claude and non-Claude shadows cannot drift. The full
+extraction of `migrateClaudeMd`'s ~360 lines of inline section content into
+a shared array was deliberately NOT done — that would have been high-risk
+for low marginal benefit per the operator's minimal-shim choice.
+
+## What this is NOT
+
+- Not a touch on `migrateClaudeMd` itself — Claude Code behavior is
+  byte-identical.
+- Not an IdentityRenderer change — identity render (Gap 1, shipped) is the
+  separate concern; this only mirrors capability sections.
+- Not a Claude-only-install impact — no shadow exists there, no-op.
+- Not a v1.1 deferral — the operator explicitly chose to ship this in v1.0.
+
+## Testing
+
+`tests/unit/PostUpdateMigrator-shadowCapabilities.test.ts` — 6 cases:
+appends missing sections to AGENTS.md from a fixture CLAUDE.md; idempotent
+on re-run; mirrors into BOTH AGENTS.md and GEMINI.md; no-op when no shadow
+exists; no-op (with note) when CLAUDE.md is absent; identity content above
+the appended sections is preserved.
+
+## Manual lessons-aware check
+
+| Principle/Lesson | Engagement |
+|---|---|
+| P1 Structure>Willpower | ✓ structural mirror |
+| P4 Testing Integrity | ✓ 6 cases, both decision sides |
+| P6 Zero-Failure | ✓ suite green |
+| Trust-Verify-Improve | ✓ bodies LITERALLY copied; cannot drift |
+| L1 (audit-framing corrected) | ✓ identity vs capability disentangled |
+| L6/L9/L10 | ✓ siblings |
+
+No contradictions. Operator-chosen scope explicit.
+
+## Implementation slice
+
+1. This spec + ELI16 + convergence report.
+2. `src/core/PostUpdateMigrator.ts` — new `migrateFrameworkShadowCapabilities`
+   + call after `migrateClaudeMd`.
+3. `tests/unit/PostUpdateMigrator-shadowCapabilities.test.ts` (NEW, 6 tests).
+4. `upgrades/NEXT.md` + `upgrades/side-effects/feat-portability-shadow-capabilities.md`.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -172,6 +172,7 @@ export class PostUpdateMigrator {
 
     this.migrateHooks(result);
     this.migrateClaudeMd(result);
+    this.migrateFrameworkShadowCapabilities(result);
     this.migrateScripts(result);
     this.migrateSettings(result);
     this.migrateConfig(result);
@@ -2146,6 +2147,107 @@ The user has been talking to you (possibly for days). A generic greeting like "H
         fs.writeFileSync(claudeMdPath, content);
       } catch (err) {
         result.errors.push(`CLAUDE.md write: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
+  /**
+   * Mirror capability-instruction sections from the freshly-patched CLAUDE.md
+   * into any non-Claude framework shadows (AGENTS.md, GEMINI.md) that exist
+   * on disk. Portability audit Gap 6 minimal-shim implementation:
+   * `generateClaudeMd` + `migrateClaudeMd` produce a rich capability/
+   * instructions document for Claude Code, but Codex/Gemini shadows had no
+   * equivalent — agents on those runtimes received the canonical identity
+   * (Gap 1, shipped) but none of the "here's what you can do" sections.
+   *
+   * The shim slices each known capability section out of CLAUDE.md (from its
+   * marker through the start of the next top-level heading) and appends any
+   * section missing from the shadow. The section bodies are NOT duplicated
+   * — they are literally copied from the just-patched CLAUDE.md, so the two
+   * cannot drift. Runs AFTER `migrateClaudeMd` so the source is current.
+   *
+   * Idempotent: each section is only appended when its marker is absent from
+   * the shadow. No-op when CLAUDE.md is absent or no shadow exists. Safe for
+   * Claude-only installs (they have no AGENTS.md/GEMINI.md so nothing
+   * happens). A full refactor that extracts the section *bodies* into a
+   * shared array is deliberately NOT done here per the operator's
+   * "minimal shim" decision — that would touch ~360 lines of inline content
+   * in `migrateClaudeMd` and is high-risk for low marginal benefit.
+   */
+  private migrateFrameworkShadowCapabilities(result: MigrationResult): void {
+    const claudeMdPath = path.join(this.config.projectDir, 'CLAUDE.md');
+    if (!fs.existsSync(claudeMdPath)) {
+      result.skipped.push('shadow capabilities (CLAUDE.md absent — nothing to mirror)');
+      return;
+    }
+    let claudeMd: string;
+    try {
+      claudeMd = fs.readFileSync(claudeMdPath, 'utf-8');
+    } catch (err) {
+      result.errors.push(`shadow capabilities: CLAUDE.md read failed: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    // Markers identifying each capability section migrateClaudeMd may have
+    // ensured exists in CLAUDE.md. Kept in document order so appended
+    // sections preserve narrative ordering in the shadow.
+    const markers = [
+      '### Self-Discovery',
+      '**Private Viewing**',
+      '**Cloudflare Tunnel**',
+      '**Dashboard**',
+      '**File Viewer',
+      '### Coherence Gate',
+      '### External Operation Safety',
+      '### Playbook — Adaptive Context Engineering',
+      '## Threadline Network (Agent-to-Agent Communication)',
+    ];
+
+    for (const shadowName of ['AGENTS.md', 'GEMINI.md']) {
+      const shadowPath = path.join(this.config.projectDir, shadowName);
+      if (!fs.existsSync(shadowPath)) continue;
+
+      let shadowContent: string;
+      try {
+        shadowContent = fs.readFileSync(shadowPath, 'utf-8');
+      } catch (err) {
+        result.errors.push(`${shadowName} read: ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+
+      let appended = shadowContent;
+      let mirrored = 0;
+      for (const marker of markers) {
+        if (appended.includes(marker)) continue;
+        const start = claudeMd.indexOf(marker);
+        if (start < 0) continue;
+        // Slice from the marker through the start of the next top-level
+        // heading (##/### line) or EOF. The leading "\n" guard avoids
+        // matching headings inside fenced code blocks at column 0 only
+        // when they begin a line.
+        const after = claudeMd.slice(start);
+        // Skip past the marker's own header line, then look for the next
+        // heading. Without this, a marker that itself starts with "###"
+        // would zero-length match.
+        const nlAfterMarker = after.indexOf('\n');
+        const searchFrom = nlAfterMarker >= 0 ? nlAfterMarker + 1 : 0;
+        const tail = after.slice(searchFrom);
+        const nextRel = tail.search(/(^|\n)(##|###) [^#\n]/);
+        const sectionEnd = nextRel >= 0 ? searchFrom + nextRel : after.length;
+        const section = after.slice(0, sectionEnd).trimEnd();
+        appended = appended.trimEnd() + '\n\n' + section + '\n';
+        mirrored++;
+      }
+
+      if (mirrored > 0) {
+        try {
+          fs.writeFileSync(shadowPath, appended);
+          result.upgraded.push(`${shadowName}: mirrored ${mirrored} capability section(s) from CLAUDE.md`);
+        } catch (err) {
+          result.errors.push(`${shadowName} write: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      } else {
+        result.skipped.push(`${shadowName}: capability sections already present`);
       }
     }
   }

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-19T20:58:06.007Z",
-  "instarVersion": "1.0.13",
+  "generatedAt": "2026-05-19T21:14:50.059Z",
+  "instarVersion": "1.0.14",
   "entryCount": 189,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -1456,7 +1456,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "5ddc7a551c4e996307288ce70f6faf60337f8571a5e8f1825added7993cd48ce",
+      "contentHash": "3ced7927de3ae3dd8ddbe9c3c154fa7e3edf8bff1572e4a17b00c2877ec14e5b",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/tests/unit/PostUpdateMigrator-shadowCapabilities.test.ts
+++ b/tests/unit/PostUpdateMigrator-shadowCapabilities.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Verifies the migrateFrameworkShadowCapabilities shim added for the
+ * cross-framework portability audit (Gap 6 — operator-chosen "minimal shim"
+ * approach). The shim mirrors capability-instruction sections from the
+ * patched CLAUDE.md into AGENTS.md/GEMINI.md when those shadows exist,
+ * so Codex/Gemini agents get the same "here's what you can do" instructions
+ * as Claude Code (identity is already mirrored by Gap 1).
+ *
+ * Bodies are literally copied from CLAUDE.md, never duplicated in source,
+ * so the two cannot drift.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function migrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test-agent',
+  });
+}
+
+function runShadowCaps(m: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (m as unknown as { migrateFrameworkShadowCapabilities(r: MigrationResult): void }).migrateFrameworkShadowCapabilities(result);
+  return result;
+}
+
+const CLAUDE_MD_FIXTURE = `# CLAUDE.md — instar
+
+## What This Project Is
+
+Intro text.
+
+### Self-Discovery (Know Before You Claim)
+
+Before claiming a missing capability, curl the live capabilities endpoint.
+
+**Private Viewing** — Render markdown as auth-gated HTML.
+Inline body.
+
+**Dashboard** — Visual web interface.
+More inline body.
+
+### Coherence Gate (Pre-Action Verification)
+
+Check coherence before high-risk actions.
+
+## Threadline Network (Agent-to-Agent Communication)
+
+Encrypted agent-to-agent messaging.
+`;
+
+describe('PostUpdateMigrator — migrateFrameworkShadowCapabilities (Gap 6 minimal shim)', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-shadow-cap-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-shadowCapabilities.test.ts',
+    });
+  });
+
+  it('appends missing capability sections to AGENTS.md from CLAUDE.md', () => {
+    fs.writeFileSync(path.join(projectDir, 'CLAUDE.md'), CLAUDE_MD_FIXTURE);
+    fs.writeFileSync(
+      path.join(projectDir, 'AGENTS.md'),
+      '# Echo\n\nCanonical identity body (no capability sections yet).\n',
+    );
+
+    const result = runShadowCaps(migrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some(u => u.startsWith('AGENTS.md:'))).toBe(true);
+
+    const agents = fs.readFileSync(path.join(projectDir, 'AGENTS.md'), 'utf-8');
+    expect(agents).toContain('### Self-Discovery');
+    expect(agents).toContain('**Private Viewing**');
+    expect(agents).toContain('**Dashboard**');
+    expect(agents).toContain('### Coherence Gate');
+    expect(agents).toContain('## Threadline Network');
+    // canonical identity preserved
+    expect(agents).toContain('Canonical identity body');
+  });
+
+  it('is idempotent — second run does not re-append', () => {
+    fs.writeFileSync(path.join(projectDir, 'CLAUDE.md'), CLAUDE_MD_FIXTURE);
+    fs.writeFileSync(path.join(projectDir, 'AGENTS.md'), '# Echo\n\nidentity\n');
+
+    runShadowCaps(migrator(projectDir));
+    const first = fs.readFileSync(path.join(projectDir, 'AGENTS.md'), 'utf-8');
+    const result2 = runShadowCaps(migrator(projectDir));
+    const second = fs.readFileSync(path.join(projectDir, 'AGENTS.md'), 'utf-8');
+
+    expect(second).toBe(first);
+    expect(result2.upgraded.some(u => u.startsWith('AGENTS.md:'))).toBe(false);
+    expect(result2.skipped.some(s => s.includes('already present'))).toBe(true);
+  });
+
+  it('mirrors into BOTH AGENTS.md and GEMINI.md when both exist', () => {
+    fs.writeFileSync(path.join(projectDir, 'CLAUDE.md'), CLAUDE_MD_FIXTURE);
+    fs.writeFileSync(path.join(projectDir, 'AGENTS.md'), '# id\n');
+    fs.writeFileSync(path.join(projectDir, 'GEMINI.md'), '# id\n');
+
+    const result = runShadowCaps(migrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    expect(fs.readFileSync(path.join(projectDir, 'AGENTS.md'), 'utf-8')).toContain('### Self-Discovery');
+    expect(fs.readFileSync(path.join(projectDir, 'GEMINI.md'), 'utf-8')).toContain('### Self-Discovery');
+  });
+
+  it('no-op when no shadow exists (Claude-only install)', () => {
+    fs.writeFileSync(path.join(projectDir, 'CLAUDE.md'), CLAUDE_MD_FIXTURE);
+
+    const result = runShadowCaps(migrator(projectDir));
+
+    expect(result.upgraded).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('no-op (with note) when CLAUDE.md is absent', () => {
+    fs.writeFileSync(path.join(projectDir, 'AGENTS.md'), '# id\n');
+
+    const result = runShadowCaps(migrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    expect(result.skipped.some(s => s.includes('CLAUDE.md absent'))).toBe(true);
+  });
+
+  it('preserves identity content above the appended sections', () => {
+    fs.writeFileSync(path.join(projectDir, 'CLAUDE.md'), CLAUDE_MD_FIXTURE);
+    const identity = '# Echo identity\n\n## Who I am\n\nThe Echo agent.\n';
+    fs.writeFileSync(path.join(projectDir, 'AGENTS.md'), identity);
+
+    runShadowCaps(migrator(projectDir));
+
+    const agents = fs.readFileSync(path.join(projectDir, 'AGENTS.md'), 'utf-8');
+    expect(agents.startsWith(identity.trimEnd())).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,63 @@
+# Upgrade Guide — v1.0.14 (final portability hardening 6 of 6)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Final shipped patch of the six cross-framework portability hardening items
+the v1.0.8 release notes committed to. Closes the v1.0.0 audit at 6/6 code
+gaps.
+
+The Claude Code instructions document includes a set of capability sections
+(Self-Discovery, Private Viewing, Cloudflare Tunnel, Dashboard, File Viewer,
+Coherence Gate, External Operation Safety, Playbook, Threadline Network).
+Codex and Gemini shadows had no equivalent — an earlier patch (v1.0.9) gave
+them their canonical identity, but not the capability instructions. Setup
+and updates now mirror those same capability sections into AGENTS.md and
+GEMINI.md when those shadows exist.
+
+The implementation deliberately copies sections directly from the
+just-updated Claude file rather than duplicating their content in source.
+The two cannot drift, and there is no large refactor of inline section
+content.
+
+## Evidence
+
+Reproduction prior to this change: run a Codex agent after setup. Its
+AGENTS.md contains the canonical identity but none of the "here's what you
+can do" sections that Claude Code's CLAUDE.md has. The agent has no
+structural prompt telling it about the live capabilities endpoint, private
+view publishing, the coherence gate, the agent network, and so on.
+
+Observed after this change: on the next update, AGENTS.md and GEMINI.md (if
+present) gain the same capability sections that Claude Code's CLAUDE.md
+carries, sliced directly from the just-updated CLAUDE.md so the content is
+identical, not paraphrased. Running update again does nothing — each section
+is only appended when its marker is absent from the shadow. Claude-only
+installs (no AGENTS.md/GEMINI.md present) are byte-for-byte unchanged.
+
+Unit verification:
+`tests/unit/PostUpdateMigrator-shadowCapabilities.test.ts` — six cases:
+appends missing sections; idempotent; mirrors into both shadows when both
+exist; no-op when no shadow exists (Claude-only install); no-op (with note)
+when CLAUDE.md is absent; identity content above the appended sections is
+preserved.
+
+## What to Tell Your User
+
+- "Codex and Gemini agents now get the same capability instructions Claude Code agents have — discover, private views, coherence gate, agent network, and so on. Claude Code agents are unaffected. This is the last of six small portability patches we promised; the v1.0 portability arc is now closed."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Shadow capability mirror | Automatic on update. The migrator copies capability sections from CLAUDE.md into AGENTS.md and GEMINI.md when those shadows exist. |
+| No-duplication source | The section bodies live in exactly one place (CLAUDE.md) and are sliced into shadows at migration time; Claude and non-Claude cannot drift. |
+
+## Deferred (Tracked Follow-ups)
+
+- None for the cross-framework portability audit. All six audit-flagged code
+  gaps are now shipped; the broader deployment-lockdown work continues in
+  its own track. A future v1.x may revisit how CLAUDE.md relates to the
+  canonical identity render (a larger architectural question explicitly
+  out of scope of this minimal shim per the operator's decision).

--- a/upgrades/side-effects/feat-portability-shadow-capabilities.md
+++ b/upgrades/side-effects/feat-portability-shadow-capabilities.md
@@ -1,0 +1,63 @@
+# Side-effects review — Shadow capability mirror (Gap 6)
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: UNDER — Codex/Gemini agents lacked capability instructions. After:
+no over-block. Mirror runs only when a non-Claude shadow exists; appends
+only sections absent from the shadow; never modifies CLAUDE.md.
+
+## 2. Level-of-abstraction fit
+
+Sits alongside `migrateClaudeMd` in PostUpdateMigrator, runs immediately
+after it. Same altitude. Slices from the live CLAUDE.md rather than
+extracting section bodies into a shared array — a deliberate scope choice
+per the operator's "minimal shim" decision.
+
+## 3. Signal vs Authority compliance
+
+CLAUDE.md (just patched by `migrateClaudeMd`) is the AUTHORITY for section
+content; the marker list is the SIGNAL of which sections exist. The shim
+never invents content — it copies bytes from CLAUDE.md.
+
+## 4. Interactions with adjacent systems
+
+- **migrateClaudeMd** — untouched; runs first, the shim reads what it
+  produced.
+- **IdentityRenderer** (Gap 1) — untouched; runs at a different layer
+  (identity vs capability). The shim appends only capability sections, so
+  the AGENT.md-derived identity content at the top of AGENTS.md/GEMINI.md
+  is preserved (tested).
+- **migrateFrameworkShadowCapabilities ordering** — runs before
+  migrateScripts and others; section appending is pure file I/O on the
+  shadows and does not block downstream steps.
+- **Claude-only installs** — no shadow exists, no-op. Verified.
+
+## 5. Rollback cost
+
+Low. One new private method + one new call site + one new test. `git
+revert` restores prior behavior; on-disk shadows keep the appended
+sections (inert; they'd just look like extra documentation). No state
+migration.
+
+## 6. Backwards compatibility / drift surface
+
+Claude installs: byte-identical. Non-Claude shadows: strictly better (now
+have capability instructions). Drift surface: **reduced** — section
+bodies live in exactly one place (CLAUDE.md, written by migrateClaudeMd)
+and are sliced from there into shadows; there is no separate source array
+to drift.
+
+## 7. Authorization / Trust posture
+
+No new authority. Reads CLAUDE.md and the existing shadows the migrator
+already owns. Writes only when appending material that came from
+CLAUDE.md. Failure paths surface as captured errors in the MigrationResult,
+never throw out of migrate().
+
+## Outcome
+
+Ship. Operator-scoped, source-of-truth preserved (no duplicated section
+bodies), idempotent, identity-preserving, Claude-only-safe, six-case
+tested. Closes the v1.0.0 cross-framework portability audit at 6/6.


### PR DESCRIPTION
Final code-level portability hardening patch (operator-chosen minimal shim). Closes audit Gap 6 and the v1.0.0 cross-framework portability audit at 6/6. New migrateFrameworkShadowCapabilities mirrors the same capability sections from the just-patched CLAUDE.md into AGENTS.md/GEMINI.md when those shadows exist. Section bodies LITERALLY sliced from CLAUDE.md — never duplicated in source — so Claude and non-Claude cannot drift. Idempotent, identity-preserving, no-op for Claude-only installs. 6 tests. 🤖 Generated with Claude Code