### PR TITLE
fix(prompt-gate): auto-dismiss Claude Code session survey + reset detector state

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2574,6 +2574,7 @@ export async function startServer(options: StartOptions): Promise<void> {
 
     // ── Prompt Gate: detect and handle interactive prompts in sessions ──
     const promptGateConfig = config.monitoring?.promptGate;
+    let promptDetector: import('../monitoring/PromptGate.js').InputDetector | undefined;
     if (promptGateConfig?.enabled) {
       const { InputDetector } = await import('../monitoring/PromptGate.js');
       const { InputClassifier } = await import('../monitoring/InputClassifier.js');
@@ -2584,6 +2585,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         enabled: true,
         intelligence: sharedIntelligence ?? undefined,
       });
+      promptDetector = detector;
 
       const classifier = new InputClassifier({
         projectDir: config.sessions.projectDir,
@@ -2610,6 +2612,22 @@ export async function startServer(options: StartOptions): Promise<void> {
       // Handle detected prompts: classify → auto-approve or relay to Telegram
       detector.on('prompt', async (prompt: import('../monitoring/PromptGate.js').DetectedPrompt) => {
         try {
+          // Non-blocking system prompts (e.g. Claude Code's optional session
+          // feedback survey) carry an autoDismissKey directive. Send the key
+          // and skip the classify/relay pipeline entirely to avoid Telegram
+          // spam on prompts that don't actually block the session.
+          if (prompt.autoDismissKey) {
+            const dismissed = sessionManager.sendKey(prompt.sessionName, prompt.autoDismissKey);
+            console.log(
+              `[PromptGate] Auto-dismissed non-blocking prompt for ${prompt.sessionName} ` +
+              `(key="${prompt.autoDismissKey}", sent=${dismissed}): ${prompt.summary}`
+            );
+            // Reset detector state so the next genuine prompt isn't blocked
+            // by the per-session cooldown.
+            detector.onInputSent(prompt.sessionName);
+            return;
+          }
+
           const classification = await classifier.classify(prompt);
 
           if (classification.action === 'auto-approve') {
@@ -2827,14 +2845,20 @@ export async function startServer(options: StartOptions): Promise<void> {
           }
           // Also resolve any pending plan prompt for this session (unblocks the hook)
           resolvePlanPromptForSession(sessionName, key);
-          return sessionManager.sendKey(sessionName, key);
+          const sent = sessionManager.sendKey(sessionName, key);
+          // Reset detector dedup / cooldown so the NEXT prompt in a multi-step
+          // form (or a fresh prompt that follows) can be detected immediately.
+          if (sent) promptDetector?.onInputSent(sessionName);
+          return sent;
         };
         telegram.onPromptTextResponse = (sessionName, text) => {
           if (!sessionManager.isSessionAlive(sessionName)) {
             console.warn(`[PromptGate] Skipping text injection — session "${sessionName}" is no longer alive`);
             return false;
           }
-          return sessionManager.sendInput(sessionName, text);
+          const sent = sessionManager.sendInput(sessionName, text);
+          if (sent) promptDetector?.onInputSent(sessionName);
+          return sent;
         };
         telegram.onRelayLeaseStart = (sessionName) => {
           const sessions = sessionManager.listRunningSessions();
@@ -2914,7 +2938,11 @@ export async function startServer(options: StartOptions): Promise<void> {
           }
           // Also resolve any pending plan prompt for this session (unblocks the hook)
           resolvePlanPromptForSession(sessionName, key);
-          return sessionManager.sendKey(sessionName, key);
+          const sent = sessionManager.sendKey(sessionName, key);
+          // Reset detector dedup / cooldown so a follow-up prompt isn't
+          // blocked by the per-session 5-minute LLM relay cooldown.
+          if (sent) promptDetector?.onInputSent(sessionName);
+          return sent;
         };
         telegram.onPromptTextResponse = (sessionName, text) => {
           // Pre-injection verification: confirm session is still alive
@@ -2922,7 +2950,9 @@ export async function startServer(options: StartOptions): Promise<void> {
             console.warn(`[PromptGate] Skipping text injection — session "${sessionName}" is no longer alive`);
             return false;
           }
-          return sessionManager.sendInput(sessionName, text);
+          const sent = sessionManager.sendInput(sessionName, text);
+          if (sent) promptDetector?.onInputSent(sessionName);
+          return sent;
         };
         telegram.onRelayLeaseStart = (sessionName) => {
           // Find the session by tmux name and grant a relay lease

--- a/src/monitoring/PromptGate.ts
+++ b/src/monitoring/PromptGate.ts
@@ -24,6 +24,13 @@ export interface DetectedPrompt {
   sessionName: string;
   detectedAt: number;
   id: string;               // Unique prompt ID (12-char CSPRNG)
+  /**
+   * Optional auto-dismiss directive for non-blocking system prompts
+   * (e.g. Claude Code's "How is Claude doing this session?" optional survey).
+   * When set, the consumer should send `autoDismissKey` to the session and
+   * SKIP the relay/classify pipeline entirely.
+   */
+  autoDismissKey?: string;
 }
 
 export interface PromptOption {
@@ -67,6 +74,7 @@ interface PatternMatch {
   type: PromptType;
   summary: string;
   options?: PromptOption[];
+  autoDismissKey?: string;
 }
 
 /**
@@ -77,6 +85,36 @@ const PROMPT_PATTERNS: Array<{
   type: PromptType;
   test: (lines: string[], fullWindow?: string[]) => PatternMatch | null;
 }> = [
+  // Claude Code OPTIONAL session feedback survey — non-blocking.
+  // Shape: "How is Claude doing this session? (optional)" followed by
+  //        "1: Bad  2: Fine  3: Good  0: Dismiss" on one line.
+  // The session is NOT blocked — Claude continues working — so we
+  // auto-dismiss (send "0") and skip relay to avoid Telegram spam.
+  // Must run BEFORE the broad "question" pattern.
+  {
+    type: 'selection',
+    test(lines, fullWindow) {
+      const haystack = (fullWindow ?? lines).join('\n');
+      if (!/How is Claude doing this session\?/i.test(haystack)) return null;
+      // Confirm the canonical option row to avoid matching paraphrases
+      // in normal agent output.
+      const hasOptionRow = /\b0\s*[:.)]\s*Dismiss\b/i.test(haystack)
+        && /\b1\s*[:.)]\s*Bad\b/i.test(haystack);
+      if (!hasOptionRow) return null;
+      return {
+        type: 'selection',
+        summary: 'Claude Code session-feedback survey (auto-dismiss — non-blocking)',
+        options: [
+          { key: '1', label: 'Bad' },
+          { key: '2', label: 'Fine' },
+          { key: '3', label: 'Good' },
+          { key: '0', label: 'Dismiss' },
+        ],
+        autoDismissKey: '0',
+      };
+    },
+  },
+
   // File creation/edit permission: "Do you want to create <path>?" with numbered options
   {
     type: 'permission',
@@ -339,6 +377,7 @@ export class InputDetector extends EventEmitter {
       sessionName,
       detectedAt: Date.now(),
       id: randomBytes(6).toString('base64url'),
+      autoDismissKey: match.autoDismissKey,
     };
 
     emitted.add(fingerprint);
@@ -369,6 +408,11 @@ export class InputDetector extends EventEmitter {
     // Pre-filter: skip if terminal shows Claude Code's standard status bar UI
     // These are persistent UI elements, NOT interactive prompts
     const tailText = lines.slice(-3).join('\n');
+    // Optional session-feedback survey is non-blocking; the structural pattern
+    // above (PROMPT_PATTERNS) already handles auto-dismiss. Skip LLM here so
+    // the 5-min cooldown isn't burned on a prompt that doesn't block anything.
+    const llmHaystack = lines.slice(-20).join('\n');
+    if (/How is Claude doing this session\?/i.test(llmHaystack)) return;
     if (/bypass permissions on/i.test(tailText)) return;
     if (/esc to interrupt/i.test(tailText) && !/Do you want|Would you like|proceed\?/i.test(tailText)) return;
     if (/shift\+tab to cycle/i.test(tailText) && !/proceed\?|approve/i.test(tailText)) return;
@@ -485,12 +529,18 @@ When in doubt, respond NO_PROMPT. False positives cause spam.`;
   /**
    * Called when input is sent to a session — clears dedup cache
    * since the prompt has been answered.
+   *
+   * Also clears the per-session 5-minute LLM relay cooldown so that
+   * a follow-up prompt (e.g. the next question in a multi-question form)
+   * isn't silently blocked. Rate-limiting on the LLM call is still
+   * provided by stableCount + post-emission cooldown.
    */
   onInputSent(sessionName: string): void {
     this.emittedPrompts.delete(sessionName);
     this.stableCount.delete(sessionName);
     this.lastOutput.delete(sessionName);
     this.lastEmissionTime.delete(sessionName); // Clear cooldown so new prompts can fire
+    this.llmRelayTimestamps.delete(sessionName); // Allow LLM to fire for follow-up prompts
     this.noPromptCache.delete(sessionName); // Cleared so post-input output gets re-classified
     // Bump generation so any mid-flight llmDetect drops its NO_PROMPT write.
     this.cacheGeneration.set(sessionName, (this.cacheGeneration.get(sessionName) ?? 0) + 1);

--- a/tests/unit/PromptGate.test.ts
+++ b/tests/unit/PromptGate.test.ts
@@ -217,6 +217,81 @@ describe('InputDetector.pattern', () => {
   });
 });
 
+// ── Claude Code session-feedback survey (auto-dismiss) ────────────
+
+describe('InputDetector.pattern.sessionFeedbackSurvey', () => {
+  it('detects the optional "How is Claude doing this session?" survey and emits an autoDismissKey', () => {
+    const detector = makeDetector();
+    // Window > 5 lines so the survey lives in the larger fullWindow we pass
+    // to patterns. The structural pattern reads from the full window because
+    // the option row can be far from the tail in a busy session.
+    const output = [
+      '✻ Cooked for 2m 46s · 3 shells still running',
+      '',
+      '16 tasks (15 done, 1 open)',
+      '  ☐ Final report to topics 9984 + 10873',
+      '  ✔ Gap 1: init.ts routes through IdentityRenderer',
+      '  ✔ Gap 2: ThreadlineBootstrap framework-aware MCP registration',
+      '  … +11 completed',
+      '',
+      '● How is Claude doing this session? (optional)',
+      '  1: Bad  2: Fine  3: Good  0: Dismiss',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'sess', output);
+    expect(prompt).not.toBeNull();
+    expect(prompt!.type).toBe('selection');
+    expect(prompt!.autoDismissKey).toBe('0');
+    expect(prompt!.summary).toMatch(/session-feedback survey/i);
+  });
+
+  it('does NOT match when only the question text is present (no canonical option row)', () => {
+    const detector = makeDetector();
+    const output = [
+      'Some agent output discussing the question.',
+      'The user asked: How is Claude doing this session?',
+      'Followed by more agent text.',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'sess', output);
+    // Either null, OR matched by a different pattern — but must NOT carry
+    // the autoDismissKey directive.
+    if (prompt) expect(prompt.autoDismissKey).toBeUndefined();
+  });
+
+  it('does NOT match unrelated numbered prompts as the survey', () => {
+    const detector = makeDetector();
+    const output = [
+      'Pick a flavor:',
+      '1: Chocolate',
+      '2: Vanilla',
+      '3: Strawberry',
+      '',
+    ].join('\n');
+
+    const prompt = detectWithDebounce(detector, 'sess', output);
+    if (prompt) {
+      expect(prompt.summary).not.toMatch(/session-feedback survey/i);
+      expect(prompt.autoDismissKey).toBeUndefined();
+    }
+  });
+});
+
+// ── onInputSent clears LLM relay cooldown ──────────────────────────
+
+describe('InputDetector.onInputSent', () => {
+  it('clears the per-session LLM relay cooldown so follow-up prompts can fire', () => {
+    const detector = makeDetector();
+    // Seed the LLM cooldown as if a prompt was just LLM-relayed
+    (detector as any).llmRelayTimestamps.set('sess', Date.now());
+    expect((detector as any).llmRelayTimestamps.has('sess')).toBe(true);
+
+    detector.onInputSent('sess');
+    expect((detector as any).llmRelayTimestamps.has('sess')).toBe(false);
+  });
+});
+
 // ── Debounce ───────────────────────────────────────────────────────
 
 describe('InputDetector.debounce', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -123,6 +123,29 @@ detector (Layer 4) ships in the same follow-up release. Spec:
 Side-effects review:
 `upgrades/side-effects/agent-worktree-convention-layer-1-2-5.md`.
 
+**6. Prompt Gate — auto-dismiss Claude Code's optional session-feedback survey, and reset detector state after every Telegram response.**
+Two related fixes to the Prompt Gate detector and relay path, both
+reported live in Echo's Telegram topic 9029 on 2026-05-20 with screenshots
+showing the same survey re-relayed every 25–50 minutes across multiple
+hours. (a) Claude Code's optional "How is Claude doing this session?"
+widget is non-blocking — the session continues working whether or not
+the operator answers — but the LLM-based detector was classifying it as
+a `selection` prompt and re-relaying to Telegram on every 5-minute LLM
+cooldown expiry. A new structural pattern in `PROMPT_PATTERNS` matches
+the survey by both its question text and its canonical option row
+(`1: Bad / 0: Dismiss`), tags the prompt with a new `autoDismissKey`
+directive on `DetectedPrompt`, and the detected-prompt handler in
+`server.ts` honours the directive: sends the dismiss key, resets
+detector state, skips the classify/relay pipeline entirely. A second
+pre-filter in `llmDetect()` short-circuits the survey before any LLM
+tokens are spent. (b) When a user clicked a Telegram button,
+`telegram.onPromptResponse` called `sessionManager.sendKey()` but did
+not call `InputDetector.onInputSent()`, so the per-session 5-minute
+LLM relay cooldown could silently swallow the next prompt in a
+multi-question form. `onInputSent` now also clears
+`llmRelayTimestamps`, and both `onPromptResponse` and
+`onPromptTextResponse` invoke it after a successful send.
+
 **3. Fleet-watchdog bind-failure probe.**
 The watchdog now catches the failure mode where a lifeline reports healthy
 to launchd but its server is locked out of its configured port (typically a
@@ -174,6 +197,35 @@ sections, sliced directly from CLAUDE.md so the content is identical.
 Verified by six unit tests covering append, idempotent re-run, both shadows,
 no-shadow no-op, no-CLAUDE.md no-op, identity preservation.
 
+Prompt Gate survey-spam reproduction prior: Telegram topic 9029
+screenshots dated 6:23 AM through 8:31 AM (2026-05-20, single tmux
+session) show identical "Your agent needs you to choose" relay messages
+re-posted at 6:23, 6:51, 7:16, 7:38, 8:31 — the cadence matches the
+5-minute LLM relay cooldown re-firing on the persistent survey text.
+The relayed `summary` strings ("Framework is asking for user feedback
+rating on Claude's performance this session", "System feedback question:
+How is Claude doing this session?", "Claude Code feedback prompt asking
+for session quality rating", "Claude Code is asking for session quality
+feedback with options to rate or dismiss", "Session quality feedback
+prompt asking user to rate how the agent is performing") all paraphrase
+the same underlying Claude Code prompt and all carry the same
+`1: Bad / 2: Fine / 3: Good` options — confirming the LLM-detection
+path was the entry point and the fingerprint kept rotating because
+surrounding terminal context (task counts, elapsed time) shifted between
+captures. Prompt Gate survey-spam evidence after: new unit test
+`InputDetector.pattern.sessionFeedbackSurvey` in
+`tests/unit/PromptGate.test.ts` pins all three behaviours: (1) the
+canonical survey block emits a `selection` prompt with
+`autoDismissKey: '0'`; (2) the question text alone (without the
+canonical option row) is NOT misclassified as a survey; (3) unrelated
+numbered prompts are not labelled as the survey. A second unit test
+`InputDetector.onInputSent` pins the `llmRelayTimestamps` clear-on-response
+behaviour. Live verification cannot be exercised in dev because the
+survey is fired by Claude Code itself on an opaque internal cadence;
+post-deploy on Echo's host, the Telegram relay history for topic 9029
+should show zero "Claude Code session-feedback survey" relays even as
+agent sessions cross multi-hour durations.
+
 Bind-failure probe evidence: today's AI Guy outage
 (`~/Documents/Projects/ai-guy/.instar/logs/lifeline-launchd.log` records
 "Suppressing duplicate server down notification (4163 suppressed this
@@ -203,6 +255,7 @@ guarantee the spec promises.
 - "You can now pick which AI runtime to use when you set up an Instar agent. Pass the framework flag to instar init for a Codex-only install. Default behavior is unchanged for everyone else. The framework flag is the first piece of a four-part install upgrade — the next three pieces add the same choice to setup, gate Claude-Code-only files behind the choice, and route the setup wizard through whichever runtime you pick."
 - "Codex and Gemini agents now also get the same capability instructions Claude agents have — discover, private views, coherence gate, agent network. This closes the v1.0 cross-framework portability arc."
 - "If two instar agents end up configured for the same port (configuration drift, leftover smoke-test fixtures, etc.), you'll now get a clear Telegram alert within about 15 minutes naming both agents involved. Previously the lifeline could spin silently for days while the supervisor suppressed its own server-down notifications as duplicates."
+- "Prompt Gate is quieter now. It used to keep pinging you about Claude's optional session-feedback survey every twenty-something minutes — I just dismiss that one for you since it doesn't actually block anything. And when you answer a real Telegram prompt, the next prompt in a multi-step form will reach you immediately instead of getting swallowed by a five-minute cooldown."
 - "Your instar agents have a new way to create git worktrees that the macOS sandbox can't kick them out of mid-session. There's a new instar worktree create command that places the worktree inside the agent's own home directory — the only place the sandbox can't revoke access to. Agents you create from now on will know about this convention out of the box. Agents already on your machine pick it up via the next update tick — the wrapper script is installed automatically, the worktree-convention section is backfilled into their CLAUDE.md, and the worktrees-directory is created with secure permissions, no operator action needed. On every agent startup, a lightweight detector also checks the shared instar repo for any worktrees that ended up in unsafe locations (created via raw git commands before this convention existed, for example) and surfaces them as a low-priority attention item so you can decide whether to relocate them with git worktree move."
 - "I have a new way to physically pause all auto-publishing to npm — a small file at the top of the instar repo that says what release line we're on. If we're working on a major feature, I can set it to hold and the publisher will refuse to ship anything until we deliberately flip it back. This release ships with that switch already in the hold position, so no further auto-publishes happen until we choose to resume. This is the second of seven locks designed after the v1.0.0 deployment misalignment in May."
 
@@ -220,6 +273,8 @@ guarantee the spec promises.
 | Authoritative reference doc | `docs/self-knowledge/worktrees.md` — the "how do I create a worktree?" answer any future agent gets pointed at via the seed CLAUDE.md mention. |
 | Existing agents pick up the worktree convention on update | Automatic on next `instar` update tick. `PostUpdateMigrator.migrateWorktreeConvention` installs `<agent_home>/.bin/instar-worktree-create.sh` (wrapper that `exec`s into `instar worktree create`), ensures the `.gitignore` entry, creates `<agent_home>/.worktrees/` with mode `0700`. Idempotent. Refuses if `<agent_home>/.bin` is a symlink. Silently skips agents whose home isn't under `~/.instar/agents/<name>/`. |
 | Existing agents pick up the Worktree Convention CLAUDE.md section on update | Automatic on next update tick (Migration Parity Standard backfill in `migrateClaudeMd`). Section is mirrored through to AGENTS.md / GEMINI.md for Codex/Gemini agents via the shadow-capability mirror. |
+| Auto-dismiss Claude Code's optional session-feedback survey | Automatic. The Prompt Gate recognises the survey by its canonical option row and sends `0` (Dismiss) without relaying. |
+| Detector state reset after every Telegram prompt response | Automatic. `onPromptResponse`/`onPromptTextResponse` now invoke `InputDetector.onInputSent()`, which clears `emittedPrompts`, `stableCount`, `lastOutput`, `lastEmissionTime`, `llmRelayTimestamps`, and the `noPromptCache` (with a generation bump). |
 | Lifeline detector for misplaced worktrees | Automatic on every agent server boot. Resolves the canonical instar repo deterministically (`worktree.repoPath` config or default fallback chain), runs `git worktree list --porcelain` with a 2-second timeout, skips the main checkout and bare entries, and emits an attention-queue-shaped record (or JSONL fallback at `<stateDir>/audit/worktree-detector.jsonl` when no Telegram adapter) for every misplaced worktree. Signal-only — never blocks, never moves, never deletes. Dedupe via `worktree-misplaced:sha256(path)`. |
 | `.instar/release-tier.json` | Committed file. Set `tier` to `patch`, `minor`, `major`, or `hold` to declare the active release line. The publish workflow honors the tier before any side-effectful step. |
 | Tier `hold` engaged on release | Initial value committed as `hold`. To resume routine maintenance, edit `tier` to `patch`. |


### PR DESCRIPTION
## Summary

Fixes two related Prompt Gate bugs reported in Echo's Telegram topic 9029:

1. **Survey spam**: Claude Code's optional "How is Claude doing this session?" widget was being LLM-detected as a `selection` prompt and relayed to Telegram on every 5-minute cooldown expiry. Five identical relays over two hours (6:23 / 6:51 / 7:16 / 7:38 / 8:31) for the same underlying survey, even after the user answered each one — because the survey is non-blocking and Claude Code keeps it on screen.

2. **Multi-step form silently swallowed**: After the user clicked a Telegram button, the response was injected via `sendKey()` but `InputDetector.onInputSent()` was never called. The per-session 5-minute `llmRelayTimestamps` cooldown then blocked the next prompt in a multi-question form.

## Fix

- New structural pattern in `PROMPT_PATTERNS` matches the survey by its question text AND canonical option row (`1: Bad / 0: Dismiss`) — tight enough not to catch paraphrases. The pattern tags the prompt with a new `autoDismissKey` directive on `DetectedPrompt`.
- The prompt handler in `server.ts` honours `autoDismissKey`: sends the key, resets detector state, skips classify/relay entirely.
- LLM pre-filter in `llmDetect()` short-circuits the survey before any token is spent (defence in depth — pattern already caught it structurally).
- `telegram.onPromptResponse` and `telegram.onPromptTextResponse` now call `detector.onInputSent()` after a successful send. `onInputSent()` now also clears `llmRelayTimestamps`.

## Test plan

- [x] `tests/unit/PromptGate.test.ts` — `InputDetector.pattern.sessionFeedbackSurvey` (3 cases) and `InputDetector.onInputSent` pin the behaviour.
- [x] `npx vitest run tests/unit/PromptGate.test.ts tests/unit/InputClassifier.test.ts tests/unit/AutoApprover.test.ts` — all green (79 tests).
- [x] `npx tsc --noEmit` — clean.
- [ ] Live verification: post-deploy on Echo's host, Telegram topic 9029 should show zero "Claude Code session-feedback survey" relays even as sessions cross multi-hour durations. If the survey reappears, the structural pattern needs to be widened for the new wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)