### PR TITLE
fix(monitoring): surface NativeModuleHealer failures via DegradationReporter

### DIFF
--- a/.instar/instar-dev-traces/20260520T171823Z-native-heal-degradation-bridge.json
+++ b/.instar/instar-dev-traces/20260520T171823Z-native-heal-degradation-bridge.json
@@ -1,0 +1,19 @@
+{
+  "sessionId": "7cce523c-1376-4ff3-bc56-98a4cc19f4db",
+  "timestamp": "2026-05-20T17:19:00Z",
+  "artifactPath": "upgrades/side-effects/native-heal-degradation-bridge.md",
+  "specPath": "docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md",
+  "specRationale": "DegradationReporter is the v1 signal producer per §A28 / §A33; the spec's go-forward path treats it as the canonical alert surface for caught-exception flows. NativeModuleHealer's jsdoc explicitly names it as a consumer of HealEvents but no consumer was wired. This change adds the missing emit-site: heal-failure HealEvent → legacy DegradationReporter.report(...) → normalize() → no-matching-runbook routing per the spec's outcome matrix (line 590, 854). Pure additive observability — does not change the W-1 dispatch path, the Remediator surface, or the alert pipeline.",
+  "coveredFiles": [
+    "src/memory/NativeModuleHealer.ts",
+    "src/monitoring/NativeHealDegradationBridge.ts",
+    "src/server/AgentServer.ts",
+    "tests/unit/NativeHealDegradationBridge.test.ts",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/native-heal-degradation-bridge.md",
+    "src/data/builtin-manifest.json"
+  ],
+  "phase": "complete",
+  "secondPass": true,
+  "reviewerConcurred": true
+}

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-20T05:13:03.722Z",
+  "generatedAt": "2026-05-20T17:09:43.839Z",
   "instarVersion": "1.1.0",
   "entryCount": 190,
   "entries": {
@@ -1432,7 +1432,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "510f556002273a0ba882a9db9cb99a22b5d96eeb1362570d5e23e12de23bb55f",
+      "contentHash": "6e996e6ea45338ffe019e539eaa738af05d5ad9a1ca35c9d93a8ba198599f759",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {

--- a/src/memory/NativeModuleHealer.ts
+++ b/src/memory/NativeModuleHealer.ts
@@ -95,6 +95,14 @@ export interface HealEvent {
 const HEAL_LOG_FILENAME = 'native-module-heals.jsonl';
 
 /**
+ * Listener fired after every persisted HealEvent (success or failure).
+ * Used by the DegradationReporter bridge so heal failures surface on the
+ * user-visible alert path, not just in the jsonl observability log.
+ * Listener errors are swallowed — observability never breaks the heal.
+ */
+export type HealEventListener = (event: HealEvent) => void;
+
+/**
  * NativeModuleHealer is a process-singleton. Stateful members track
  * whether a heal has already been attempted this process so the
  * expensive rebuild doesn't run on every open() retry.
@@ -103,10 +111,24 @@ class NativeModuleHealerImpl {
   private healAttempted = false;
   private lastResult: HealEvent | null = null;
   private stateDir: string | null = null;
+  private listeners: Set<HealEventListener> = new Set();
 
   /** Configure where heal events are persisted. Optional. */
   configure(opts: { stateDir?: string | null }): void {
     if (opts.stateDir) this.stateDir = opts.stateDir;
+  }
+
+  /**
+   * Subscribe to HealEvents. Listener fires after every persisted event
+   * (both success and failure — the bridge filters on success internally
+   * so a future health-info consumer can also subscribe without
+   * duplicating the dispatch). Returns an unsubscribe function.
+   */
+  onHealEvent(listener: HealEventListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
   }
 
   /** Reset for testing. */
@@ -114,6 +136,7 @@ class NativeModuleHealerImpl {
     this.healAttempted = false;
     this.lastResult = null;
     this.stateDir = null;
+    this.listeners.clear();
   }
 
   /**
@@ -821,6 +844,14 @@ class NativeModuleHealerImpl {
       fs.appendFileSync(logPath, JSON.stringify(event) + '\n');
     } catch {
       /* ignore — observability shouldn't break the heal */
+    }
+
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        /* ignore — listener failures must not break the heal path */
+      }
     }
   }
 }

--- a/src/monitoring/NativeHealDegradationBridge.ts
+++ b/src/monitoring/NativeHealDegradationBridge.ts
@@ -1,0 +1,71 @@
+/**
+ * NativeHealDegradationBridge — surface NativeModuleHealer failures on the
+ * user-visible DegradationReporter path.
+ *
+ * Without this bridge, a failed better-sqlite3 rebuild only lands in
+ * <stateDir>/native-module-heals.jsonl and console.error. The agent then
+ * silently runs with SemanticMemory / TopicMemory / MemoryIndex / TokenLedger
+ * degraded and no Telegram alert ever fires. DegradationReporter is the
+ * canonical path for "the primary failed, the user should know" — this
+ * bridge connects the two.
+ *
+ * Scope: failure events only. Successful heals are silent on purpose —
+ * the feature recovered, no user action is required. The listener still
+ * fires on success so future health-info consumers can subscribe without
+ * a parallel dispatch surface.
+ *
+ * Dedupe: one degradation event per component per process. Heals are
+ * already once-per-process via NativeModuleHealer.healAttempted, but the
+ * Set in here defends against future surface-area changes (e.g. per-module
+ * heal retries) that would otherwise spam the alert path.
+ */
+
+import { NativeModuleHealer, type HealEvent } from '../memory/NativeModuleHealer.js';
+import { DegradationReporter } from './DegradationReporter.js';
+
+const FALLBACK_IMPACT =
+  'Feature unavailable until better-sqlite3 is rebuilt. Restart the agent or run `npm rebuild better-sqlite3 --prefix <install_prefix>` to retry.';
+
+const COMPONENT_IMPACTS: Record<string, string> = {
+  SemanticMemory:
+    'Persistent knowledge graph unavailable; new entities and evidence will not be retained across sessions.',
+  TopicMemory:
+    'Conversation summaries unavailable; sessions start without prior-thread context.',
+  MemoryIndex:
+    'Memory search unavailable; queries against the memory index will return empty results.',
+  TokenLedger:
+    'Token-usage telemetry unavailable; /tokens/summary and /tokens/sessions endpoints will return 503.',
+};
+
+function buildDegradationReason(event: HealEvent): string {
+  const prefix = event.installPrefix ? ` (prefix=${event.installPrefix})` : '';
+  const tail = event.errorTail ? `: ${event.errorTail}` : '';
+  return `NativeModuleHealer rebuild failed on Node ${event.nodeVersion}${prefix}${tail}`;
+}
+
+/**
+ * Subscribe a DegradationReporter to NativeModuleHealer heal events.
+ * Returns the unsubscribe function from NativeModuleHealer.onHealEvent
+ * so tests (or future hot-reload code) can detach the bridge.
+ *
+ * The `reporter` parameter is exposed primarily for tests; production
+ * callers should rely on the DegradationReporter singleton default.
+ */
+export function bridgeNativeHealToDegradation(
+  reporter: DegradationReporter = DegradationReporter.getInstance(),
+): () => void {
+  const reported = new Set<string>();
+  return NativeModuleHealer.onHealEvent((event) => {
+    if (event.success) return;
+    if (reported.has(event.component)) return;
+    reported.add(event.component);
+
+    reporter.report({
+      feature: event.component,
+      primary: 'native SQLite via better-sqlite3',
+      fallback: `${event.component} unavailable — better-sqlite3 ABI mismatch could not be healed automatically`,
+      reason: buildDegradationReason(event),
+      impact: COMPONENT_IMPACTS[event.component] ?? FALLBACK_IMPACT,
+    });
+  });
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -59,6 +59,7 @@ import { LlmRateGate } from '../monitoring/LlmRateGate.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import { registerBurnDetectionSubscriber } from '../monitoring/BurnDetectionSubscriber.js';
 import { NativeModuleHealer } from '../memory/NativeModuleHealer.js';
+import { bridgeNativeHealToDegradation } from '../monitoring/NativeHealDegradationBridge.js';
 
 export class AgentServer {
   private app: Express;
@@ -375,6 +376,11 @@ export class AgentServer {
         // a NODE_MODULE_VERSION mismatch would still get healed but its
         // observability log would be hard to find.
         NativeModuleHealer.configure({ stateDir: options.config.stateDir });
+        // Surface heal failures on the DegradationReporter alert path so a
+        // failed better-sqlite3 rebuild produces a Telegram alert instead of
+        // silently leaving SemanticMemory / TopicMemory / MemoryIndex /
+        // TokenLedger unavailable.
+        bridgeNativeHealToDegradation();
         const dbPath = path.join(serverDataDir, 'token-ledger.db');
         const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects');
         // Bound the first-boot scan: with deep history (eg one local agent

--- a/tests/unit/NativeHealDegradationBridge.test.ts
+++ b/tests/unit/NativeHealDegradationBridge.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for NativeHealDegradationBridge — translates
+ * NativeModuleHealer HealEvents into DegradationReporter.report()
+ * calls so heal failures surface on the user-visible alert path.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import {
+  NativeModuleHealer,
+  type HealEventListener,
+  type HealEvent,
+} from '../../src/memory/NativeModuleHealer.js';
+import { DegradationReporter } from '../../src/monitoring/DegradationReporter.js';
+import { bridgeNativeHealToDegradation } from '../../src/monitoring/NativeHealDegradationBridge.js';
+
+function makeHealEvent(overrides: Partial<HealEvent> = {}): HealEvent {
+  return {
+    component: 'SemanticMemory',
+    timestamp: new Date().toISOString(),
+    success: false,
+    nodeVersion: 'v22.11.0',
+    installPrefix: '/opt/instar/shadow-install',
+    errorTail: 'npm exited 1',
+    ...overrides,
+  };
+}
+
+/** Fanout helper: trigger every registered listener with a synthesized event. */
+function fanout(event: HealEvent): void {
+  const listeners = (NativeModuleHealer as unknown as {
+    listeners: Set<HealEventListener>;
+  }).listeners;
+  for (const l of listeners) l(event);
+}
+
+describe('NativeHealDegradationBridge', () => {
+  let tmpDir: string;
+  let reporter: DegradationReporter;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'native-heal-bridge-test-'));
+    NativeModuleHealer.resetForTesting();
+    NativeModuleHealer.configure({ stateDir: tmpDir });
+    DegradationReporter.resetForTesting();
+    reporter = DegradationReporter.getInstance();
+    reporter.configure({
+      stateDir: tmpDir,
+      agentName: 'test-agent',
+      instarVersion: '0.0.0-test',
+    });
+  });
+
+  it('reports a degradation when the healer emits a failure event', () => {
+    const reportSpy = vi.spyOn(reporter, 'report');
+    bridgeNativeHealToDegradation(reporter);
+
+    fanout(makeHealEvent({ success: false }));
+
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+    const arg = reportSpy.mock.calls[0][0];
+    expect(arg.feature).toBe('SemanticMemory');
+    expect(arg.primary).toContain('better-sqlite3');
+    expect(arg.fallback).toContain('SemanticMemory');
+    expect(arg.reason).toContain('v22.11.0');
+    expect(arg.reason).toContain('/opt/instar/shadow-install');
+    expect(arg.reason).toContain('npm exited 1');
+    expect(arg.impact).toContain('knowledge graph');
+  });
+
+  it('does not report on a successful heal', () => {
+    const reportSpy = vi.spyOn(reporter, 'report');
+    bridgeNativeHealToDegradation(reporter);
+
+    fanout(makeHealEvent({ success: true, errorTail: undefined }));
+
+    expect(reportSpy).not.toHaveBeenCalled();
+  });
+
+  it('dedupes by component within a single process', () => {
+    const reportSpy = vi.spyOn(reporter, 'report');
+    bridgeNativeHealToDegradation(reporter);
+
+    fanout(makeHealEvent({ component: 'SemanticMemory' }));
+    fanout(makeHealEvent({ component: 'SemanticMemory', errorTail: 'second failure' }));
+    fanout(makeHealEvent({ component: 'TopicMemory' }));
+
+    expect(reportSpy).toHaveBeenCalledTimes(2);
+    expect(reportSpy.mock.calls[0][0].feature).toBe('SemanticMemory');
+    expect(reportSpy.mock.calls[1][0].feature).toBe('TopicMemory');
+  });
+
+  it('uses a generic impact line for unknown components', () => {
+    const reportSpy = vi.spyOn(reporter, 'report');
+    bridgeNativeHealToDegradation(reporter);
+
+    fanout(makeHealEvent({ component: 'SomeFutureFeature' }));
+
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+    expect(reportSpy.mock.calls[0][0].impact).toContain('npm rebuild better-sqlite3');
+  });
+
+  it('omits prefix and tail gracefully when fields are missing', () => {
+    const reportSpy = vi.spyOn(reporter, 'report');
+    bridgeNativeHealToDegradation(reporter);
+
+    fanout(makeHealEvent({ installPrefix: undefined, errorTail: undefined }));
+
+    expect(reportSpy).toHaveBeenCalledTimes(1);
+    expect(reportSpy.mock.calls[0][0].reason).not.toContain('prefix=');
+    expect(reportSpy.mock.calls[0][0].reason).not.toContain('undefined');
+  });
+
+  it('returns an unsubscribe function that detaches the listener', () => {
+    const reportSpy = vi.spyOn(reporter, 'report');
+    const unsubscribe = bridgeNativeHealToDegradation(reporter);
+    unsubscribe();
+
+    fanout(makeHealEvent());
+
+    expect(reportSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('NativeModuleHealer.onHealEvent', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'native-heal-listener-test-'));
+    NativeModuleHealer.resetForTesting();
+    NativeModuleHealer.configure({ stateDir: tmpDir });
+  });
+
+  it('invokes registered listeners after persisting a heal event', () => {
+    const listener = vi.fn();
+    NativeModuleHealer.onHealEvent(listener);
+
+    // Force the early-exit "no install prefix" branch so we get a real
+    // HealEvent without spawning npm. Spy on the private resolver and
+    // make it return null — heal then logs the failure event and notifies
+    // listeners through the production code path.
+    const spy = vi
+      .spyOn(NativeModuleHealer as unknown as { findBetterSqlite3InstallPrefix: () => string | null }, 'findBetterSqlite3InstallPrefix')
+      .mockReturnValue(null);
+    try {
+      NativeModuleHealer.healBetterSqlite3Sync('UnitTestComponent');
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0][0];
+    expect(event.component).toBe('UnitTestComponent');
+    expect(event.success).toBe(false);
+    expect(event.errorTail).toContain('install prefix');
+  });
+
+  it('swallows listener errors so the heal path is not broken', () => {
+    const throwing = vi.fn(() => {
+      throw new Error('listener boom');
+    });
+    const safe = vi.fn();
+    NativeModuleHealer.onHealEvent(throwing);
+    NativeModuleHealer.onHealEvent(safe);
+
+    const spy = vi
+      .spyOn(NativeModuleHealer as unknown as { findBetterSqlite3InstallPrefix: () => string | null }, 'findBetterSqlite3InstallPrefix')
+      .mockReturnValue(null);
+    try {
+      expect(() => NativeModuleHealer.healBetterSqlite3Sync('SafetyTest')).not.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(safe).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribes cleanly', () => {
+    const listener = vi.fn();
+    const unsubscribe = NativeModuleHealer.onHealEvent(listener);
+    unsubscribe();
+
+    const spy = vi
+      .spyOn(NativeModuleHealer as unknown as { findBetterSqlite3InstallPrefix: () => string | null }, 'findBetterSqlite3InstallPrefix')
+      .mockReturnValue(null);
+    try {
+      NativeModuleHealer.healBetterSqlite3Sync('UnsubscribeTest');
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,58 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**fix(monitoring): native-module heal failures now surface on the DegradationReporter alert path.**
+`NativeModuleHealer` already rebuilds better-sqlite3 when a NODE_MODULE_VERSION
+mismatch breaks `SemanticMemory` / `TopicMemory` / `MemoryIndex` / `TokenLedger`,
+but a *failed* rebuild only landed in `<stateDir>/native-module-heals.jsonl`
+and a `console.error` line — the agent then silently ran with the affected
+feature unavailable and no Telegram alert ever fired. The healer's own jsdoc
+already named `DegradationReporter` as a consumer ("consumed by health checks
+and DegradationReporter") but no consumer was wired. This PR adds the missing
+bridge: a tiny `onHealEvent(listener)` registration surface on the healer
+and a `NativeHealDegradationBridge` subscriber wired in `AgentServer` boot
+that translates failure events into `DegradationReporter.report(...)` calls
+with component-specific impact lines (per-component dedupe; success events
+intentionally silent). No change to the heal path itself, no change to the
+jsonl log, no new dependencies.
+
+## Evidence
+
+Prior to this PR, `src/memory/NativeModuleHealer.ts` writes a `HealEvent`
+row to `<stateDir>/native-module-heals.jsonl` and `console.error`s on
+failure, but `grep -rn "DegradationReporter\|degradation"` against
+`src/memory/NativeModuleHealer.ts` and
+`src/remediation/runbooks/node-abi-mismatch.ts` returns zero call sites
+— the heal-failure event never reached the existing Telegram alert path.
+After this PR, nine new unit tests in
+`tests/unit/NativeHealDegradationBridge.test.ts` pin the wiring (reports
+on failure, silent on success, dedupes per component, returns an
+unsubscribe handle that detaches the listener, swallows listener errors,
+and exercises `NativeModuleHealer.onHealEvent` through the real
+`healBetterSqlite3Sync` early-exit path with a mocked install-prefix
+resolver) and `AgentServer` calls `bridgeNativeHealToDegradation()` next
+to the existing `NativeModuleHealer.configure(...)` call so every
+server boot gets the subscriber. Pre-existing `NativeModuleHealer`
+(17 tests) and `degradation-reporter*` (22 tests) suites pass
+unchanged.
+
+Spec: `docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` (DegradationReporter
+is the v1 signal producer per §A28 / §A33; this PR adds the missing
+emit-site for heal-failure events the W-1 runbook already implied).
+Side-effects review:
+`upgrades/side-effects/native-heal-degradation-bridge.md` with
+second-pass independent audit appended (concurred).
+
+## What to Tell Your User
+
+- "When the agent's database driver gets out of sync with your Node version and can't repair itself, you now get a Telegram alert telling you what broke. Previously the agent quietly kept running with persistent memory turned off and you only found out by noticing things weren't sticking."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Native-module heal failures alert the user | Automatic. `AgentServer` wires `NativeHealDegradationBridge` at boot; any `NativeModuleHealer` rebuild that fails surfaces as a `DegradationReporter` event (Telegram alert via the agent-attention path, structured row in `<stateDir>/degradations.json`). Success heals stay silent. |
+| `NativeModuleHealer.onHealEvent(listener)` | New public registration point on the healer singleton — listener fires after every persisted heal event. Returns an unsubscribe function. Errors thrown by a listener are swallowed so observability cannot break the heal path. |

--- a/upgrades/side-effects/native-heal-degradation-bridge.md
+++ b/upgrades/side-effects/native-heal-degradation-bridge.md
@@ -1,0 +1,206 @@
+# Side-Effects Review — Native-Module Heal → DegradationReporter bridge
+
+**Version / slug:** `native-heal-degradation-bridge`
+**Date:** `2026-05-20`
+**Author:** Echo (instar developer agent)
+**Second-pass reviewer:** voluntary independent audit run despite the
+change not falling under the mandatory-review categories — the bridge
+emits into the outbound-messaging path (via DegradationReporter), which
+is adjacent enough to warrant a second opinion.
+
+**Second-pass result:** *Concur with the review.* Reviewer independently
+verified:
+- `listeners` Set is effectively process-global (healer is a module-level
+  singleton); per-bridge `Set` dedupe is the right second layer for
+  future per-module retries.
+- F-8 Remediator `invokeFromRemediator` and legacy `openWithHeal` both
+  route through `logHealEvent` and share the `healAttempted` one-shot
+  guard, so no double-fire is possible today.
+- Listener-error swallow is bounded to the observability-consumer call
+  site and does not hide heal exceptions (those remain thrown by
+  `healBetterSqlite3Sync`).
+- Tests 7–9 exercise the real production listener-dispatch path via
+  `healBetterSqlite3Sync` with a mocked install-prefix resolver; tests
+  1–6 use a synthetic fanout helper appropriate for unit-isolating the
+  bridge translation logic.
+- Forward-looking note (not blocking): if per-module heal retries are
+  added later, success events should clear the dedupe entry and emit a
+  "recovered" degradation so a retry-success-after-failure sequence
+  doesn't leave the user with a stale failure alert. Today's one-shot
+  semantics make this impossible to hit, so the bridge is correct as
+  written; the comment in the bridge already anticipates the future
+  surface.
+
+## Summary of the change
+
+`NativeModuleHealer` already writes `HealEvent`s to
+`<stateDir>/native-module-heals.jsonl` and `console.error`s on failure. Its
+own jsdoc names `DegradationReporter` as a consumer ("consumed by health
+checks and DegradationReporter") but no consumer was ever wired. This PR
+fills the gap with the minimum surface area required:
+
+1. `NativeModuleHealer.onHealEvent(listener)` — public listener
+   registration on the existing singleton. Listener fires after every
+   persisted `HealEvent` (success and failure). Returns an unsubscribe
+   function. Listener errors are swallowed inside the dispatch loop so
+   observability cannot break the heal path itself.
+2. `src/monitoring/NativeHealDegradationBridge.ts` — new ~70-line module.
+   Subscribes to the healer; on a failure event, calls
+   `DegradationReporter.report(...)` with a component-specific impact
+   line. Successful heals are silent on purpose (the feature recovered,
+   no user action required). Dedupes per component within the process
+   life so a future heal-retry surface cannot spam the alert path.
+3. `AgentServer` — one new import + one new call (`bridgeNativeHealToDegradation()`)
+   placed immediately after the existing `NativeModuleHealer.configure(...)`
+   line, inside the same `if (options.config.stateDir)` block.
+
+Files touched:
+- `src/memory/NativeModuleHealer.ts` — adds `HealEventListener` export,
+  `listeners` Set, `onHealEvent()` method, listener-clear in
+  `resetForTesting()`, listener-dispatch in `logHealEvent()`.
+- `src/monitoring/NativeHealDegradationBridge.ts` — new module.
+- `src/server/AgentServer.ts` — one import + one call.
+- `tests/unit/NativeHealDegradationBridge.test.ts` — 9 new tests covering
+  failure→report, success-silent, per-component dedupe, unknown-component
+  fallback impact, missing-field reason fallback, unsubscribe, real
+  listener dispatch through `healBetterSqlite3Sync` with a mocked install
+  prefix, listener-error isolation, and listener cleanup.
+- `upgrades/NEXT.md` — entry, evidence paragraph, user message, two
+  capability-table rows.
+
+## Decision-point inventory
+
+- `NativeModuleHealer.logHealEvent` (deterministic authority over heal
+  persistence) — **extend** — adds a listener-dispatch step after the
+  existing jsonl write. Listener errors are swallowed; the heal contract
+  is unchanged.
+- `AgentServer` startup (composition root) — **extend** — adds a single
+  subscriber registration call. No new state.
+- `DegradationReporter.report` — **consume only**, no surface change.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+None. No new gating, no new filtering, no rejection logic. The bridge
+adds a degradation event on heal *failure* and stays silent on heal
+*success*. Successful heals continue to behave identically to today
+(the feature opens, the user sees nothing).
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- **CLI commands that hit the healer outside the server process.** A
+  user running `instar memory ...` against an ABI-mismatched
+  better-sqlite3 will get the existing `console.error` and a thrown error
+  but no Telegram alert — `AgentServer` is the only registration site.
+  This is the same scope as the existing DegradationReporter wiring
+  (CLI commands never had the Telegram alert path anyway). The CLI user
+  sees the error on stdout, which is the appropriate surface for a
+  foreground command.
+- **Multiple AgentServer instantiations in one process.** Each
+  `bridgeNativeHealToDegradation()` call adds a new listener with a
+  fresh dedupe Set. In production AgentServer is a singleton; in tests
+  callers pass an explicit reporter. Not a real risk; documented as a
+  YAGNI in the bridge module.
+- **Build manifest / pre-load drift detection.** Out of scope — covered
+  in topic 11013's earlier design proposal as a separate (lower
+  priority) item. The heal works without it.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The healer is the existing authority over native-module rebuilds
+and the canonical producer of `HealEvent`s. DegradationReporter is the
+existing authority over "feature-fallback → user-visible alert."
+Bridging them in a third file keeps each side single-responsibility:
+the healer doesn't import the reporter (no `src/memory/*` →
+`src/monitoring/*` coupling beyond the bridge), the reporter doesn't
+know about the healer at all, and the bridge is a pure subscriber that
+can be unit-tested with a synthesized `HealEvent`.
+
+`AgentServer` is the correct composition root for the registration —
+it's where `NativeModuleHealer.configure(...)` already happens, so the
+two lines stay co-located.
+
+## 4. Signal vs authority compliance
+
+**Reference:** the principle in MEMORY.md (`feedback_signal_vs_authority`):
+"Brittle/low-context filters detect and emit signals. Only a higher-level
+intelligent gate with full context has blocking authority."
+
+- The **healer** is the deterministic authority over native-module
+  rebuilds. Unchanged.
+- The **bridge** is a pure signal transducer — `HealEvent` (signal) →
+  `DegradationEvent` (signal). It has no blocking authority, no decision
+  surface, no LLM call.
+- `DegradationReporter` is the higher-level alert authority. Its
+  existing dispatch logic (Remediator routing, tone-gate, alert
+  cooldown) is unchanged. The bridge is just a new emitter feeding the
+  same authority.
+
+## 5. Interactions / cross-component effects
+
+- **Existing W-1 Remediator path.** When `NativeModuleHealer.invokeFromRemediator(ctx)`
+  is the entry point, it still calls `healBetterSqlite3Sync` →
+  `logHealEvent` → listener dispatch. The bridge fires once for the
+  same component just as it does for the legacy `openWithHeal` path —
+  per-component dedupe absorbs both paths. No double-alert risk.
+- **DegradationReporter remediator-routing.** Reports flow through
+  `_normalize()` like any other legacy `.report(...)` call. They will be
+  tagged `provenance: 'free-text'` and (per §A6) won't match any runbook
+  prefilter — they route to `no-matching-runbook` and feed
+  NovelFailureReviewer's clustering pipeline, which is appropriate for
+  "the W-1 heal couldn't repair its own target" alerts.
+- **Telegram tone-gate.** Goes through the existing pipeline; the
+  default safe fallback template applies if the candidate text is
+  rejected.
+- **Persistence.** `degradations.json` (existing) gains entries for
+  heal failures. Bounded to last 100 events per existing rotation.
+
+## 6. Rollback cost
+
+Trivial. Revert is 5 file edits (3 modifications + 2 deletions). No
+schema, no config, no migration, no on-disk format change. The
+`native-module-heals.jsonl` log and `console.error` path are unchanged,
+so observability survives a revert.
+
+## 7. Migration parity check
+
+Not applicable. The change is server-internal. No agent-installed file
+changes (no `.claude/settings.json`, no `.instar/config.json`, no
+CLAUDE.md template, no hook scripts, no built-in skills) — existing
+agents pick this up automatically when they restart against the new
+`instar` binary, which is the normal update path. The Migration Parity
+Standard's enumerated trigger list does not include `src/server/*`.
+
+## 8. Test integrity
+
+Per the Testing Integrity Standard (`docs/specs/TESTING-INTEGRITY-SPEC.md`):
+
+- **Tier 1 (unit).** 9 tests in
+  `tests/unit/NativeHealDegradationBridge.test.ts` — listener-dispatch,
+  failure-reports / success-silent / per-component-dedupe / unknown-component-fallback /
+  missing-field reason / unsubscribe; plus three on
+  `NativeModuleHealer.onHealEvent` exercising the real
+  `healBetterSqlite3Sync` early-exit path with a mocked install-prefix
+  resolver (listener invocation, listener-error isolation, unsubscribe).
+- **Tier 2 (integration).** Not added — the bridge is a process-internal
+  subscriber with no HTTP surface. The existing
+  `tests/integration/degradation-reporter-*` suites continue to cover
+  the reporter's HTTP-visible behavior; this PR adds one more emitter
+  to that same path, no new routes.
+- **Tier 3 (E2E lifecycle).** Not added — the wiring lives inside the
+  same `if (options.config.stateDir)` block that already conditions
+  `NativeModuleHealer.configure(...)` and `TokenLedger` construction
+  (which both have Tier-3 coverage). Adding a parallel boot-time
+  bridge-presence test would only restate that block's existing E2E
+  guarantee.
+
+Pre-existing related suites (`NativeModuleHealer.test.ts` 17 tests,
+`NativeModuleHealer-invokeFromRemediator.test.ts`, `degradation-reporter*`
+22 tests) pass unchanged after this PR.


### PR DESCRIPTION
## Summary

`NativeModuleHealer` already rebuilds better-sqlite3 when a `NODE_MODULE_VERSION` mismatch breaks `SemanticMemory` / `TopicMemory` / `MemoryIndex` / `TokenLedger`, but a **failed** rebuild only landed in `<stateDir>/native-module-heals.jsonl` and a `console.error` line — the agent then silently ran with the affected feature unavailable and no Telegram alert ever fired. The healer's own jsdoc named `DegradationReporter` as a consumer ("consumed by health checks and DegradationReporter") but no consumer was wired.

This PR adds the missing bridge with the smallest possible surface:

- **`NativeModuleHealer.onHealEvent(listener)`** — public listener registration on the existing singleton. Returns an unsubscribe function. Listener errors are swallowed inside the dispatch loop so observability cannot break the heal path.
- **`src/monitoring/NativeHealDegradationBridge.ts`** — ~70-line subscriber that translates failure events into `DegradationReporter.report(...)` calls with component-specific impact lines. Successful heals are silent on purpose. Per-component dedupe defends against future per-module heal retry surface.
- **`AgentServer`** wires `bridgeNativeHealToDegradation()` immediately after the existing `NativeModuleHealer.configure(...)` call inside the same `if (options.config.stateDir)` block.

## Test plan

- [x] 9 new unit tests in `tests/unit/NativeHealDegradationBridge.test.ts` — failure→report, success-silent, per-component dedupe, unknown-component fallback impact, missing-field reason fallback, unsubscribe, plus three on `NativeModuleHealer.onHealEvent` exercising the real `healBetterSqlite3Sync` early-exit path with a mocked install-prefix resolver. All pass.
- [x] Pre-existing `NativeModuleHealer` (17 tests) and `degradation-reporter*` (22 tests) suites pass unchanged.
- [x] `pnpm test:smoke` (pre-push tier) green — 995/995.
- [x] Side-effects review at `upgrades/side-effects/native-heal-degradation-bridge.md` with second-pass independent audit appended (concurred).
- [x] `upgrades/NEXT.md` updated with entry, evidence paragraph, user-facing message, and two capability rows.

## Spec

`docs/specs/SELF-HEALING-REMEDIATOR-V2-SPEC.md` — `DegradationReporter` is the v1 signal producer per §A28 / §A33. The W-1 runbook already healed; this PR adds the missing emit-site for heal-failure events that the spec's outcome matrix (line 590, 854) implies should route to the legacy alert path via `no-matching-runbook`. Pure additive observability — does not change the W-1 dispatch path, the Remediator surface, or the alert pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)