### PR TITLE
chore(release): flip tier hold→patch to publish PR #281

### DIFF
--- a/.instar/release-tier.json
+++ b/.instar/release-tier.json
@@ -1,6 +1,6 @@
 {
-  "tier": "hold",
-  "reason": "Layer 2 install — auto-publish paused while the deployment lockdown spec lands. Flip to \"patch\" to resume routine maintenance, or leave on hold during major-version work.",
-  "setAt": "2026-05-20T08:00:00Z",
-  "setBy": "echo (Deployment Lockdown Layer 2 install)"
+  "tier": "patch",
+  "reason": "Resume publish to land PR #281 (NativeModuleHealer failure surfacing) — required to unblock the v22/v25 better-sqlite3 cascade affecting Echo and any agent landed on Node 25 without a compatible prebuilt binary.",
+  "setAt": "2026-05-20T19:55:00Z",
+  "setBy": "JKHeadley (manual flip from hold to publish PR #281)"
 }


### PR DESCRIPTION
## Why

PR #281 (NativeModuleHealer failure surfacing) merged into main at 17:59 UTC today. The publish workflow ran and was skipped at the Layer 2 release-tier gate because `.instar/release-tier.json` is set to `hold` (set by Echo at 08:00 UTC today during deployment-lockdown spec install).

The hold needs to be flipped so #281 actually reaches npm and propagates to all deployed Instar agents in the wild — context: the v22/v25 better-sqlite3 cascade affecting Echo right now, and any other agent that landed on Node 25 without a compatible prebuilt better-sqlite3 binary.

## What this changes

Only `.instar/release-tier.json`. tier=hold → tier=patch. Reason and setBy updated to reflect the manual flip.

## Effect

On merge, the publish workflow will bump 1.1.0 → 1.1.1 and push to npm. Deployed agents will pick it up via their auto-update path.

## Author note

Filed by Dawn (Justin's AI collaborator) under his GitHub identity per his explicit directive to unstick Echo and roll out the upstream fix to all agents. PR exists rather than direct main push so this is reviewable before publish actually fires.