### PR TITLE
feat(secret-drop): non-destructive retrieve + stuck-consumer event

### DIFF
--- a/docs/specs/SECRET-DROP-HARDENING-SPEC.eli16.md
+++ b/docs/specs/SECRET-DROP-HARDENING-SPEC.eli16.md
@@ -1,0 +1,55 @@
+# Secret Drop Hardening — ELI16 Companion
+
+**Who this is for:** Justin (and any operator reading this for the first time)
+**Reads in:** ~2 minutes
+**Companion to:** SECRET-DROP-HARDENING-SPEC.md (technical)
+
+---
+
+## What happened, in one paragraph
+
+Earlier today you typed a one-time SMS code into a secure web form. My server stored the code in a small in-memory inbox and notified my agent process to pick it up. The pickup code had a parsing bug — it asked for the code, the server handed it over, and the pickup code dropped it on the floor. The server had already deleted the code from the inbox the moment it handed it over, so when I noticed the value was missing, there was nothing to retry. We had to ask Telegram for a fresh code. This PR makes that whole class of failure impossible: a fumbled handoff is now recoverable instead of terminal.
+
+---
+
+## What changes (three pieces)
+
+1. **The server stops deleting on read.** When my agent asks for a submitted secret, the server returns it but keeps a copy in the inbox until either (a) my agent explicitly says "I have it, you can throw it away," or (b) the existing 5-minute cleanup timer fires. So if my agent fumbles the handoff, it can ask again and get the same value.
+
+2. **An explicit "consume" path for callers that want it.** Some callers genuinely want one-shot semantics — they're confident they've handed off the value and a stale re-read would be wrong. Those callers pass `?consume=true` on the request URL. Same outcome as before, but now opt-in instead of the default trap.
+
+3. **A "stuck consumer" alert.** If a code gets submitted to the form and 60 seconds pass without any agent actually consuming it, the server sends a system message to the bound Telegram topic saying "hey, a secret you submitted is sitting unread — the consumer probably has a bug, it'll auto-clean in N minutes." That way the failure has a visible cue instead of just silently waiting for an SMS that won't arrive.
+
+---
+
+## Why this matters
+
+The bug that hit us today on a recoverable SMS code is the **gentlest possible failure mode** for this class of failure. If the same bug had hit on a higher-stakes secret (a long-lived API key, a database password, a service-account token), the failure could have been:
+
+- The secret is lost in transit — the operator has to revoke and reissue.
+- The downstream system that needed the secret is left half-configured.
+- The operator has no way to know the consumer dropped it, because the server's response said "200 OK, here's the secret."
+
+After this PR, all three of those become visible and recoverable.
+
+---
+
+## What I'm carrying through to my own bridge code
+
+The bridge script that lost your code today is in a separate worktree (the Telegram backfill PR). After the SecretDrop hardening lands, I'll also update that bridge to use the new pattern: read non-destructively, parse, only mark as consumed after the parse succeeds. That makes the bridge itself robust on top of the server-side improvement.
+
+---
+
+## What I'm NOT changing
+
+- The form-side workflow. You still see the same form, you still type the secret, you still submit. Nothing on the operator-facing side is different.
+- The CSRF protection, rate-limiting, in-memory-only storage. All intact.
+- The existing 5-minute cleanup window. Still there as the safety net.
+
+---
+
+## The single thing to remember
+
+**Default behavior is now safer.** Callers that don't opt in to one-shot retrieval (which is almost everyone, including all of mine) get retry-safe reads. The opt-in `?consume=true` is for the rare case where one-shot semantics are actually required.
+
+That's the entire change. Smaller than it sounds; meaningfully harder to misuse.

--- a/docs/specs/SECRET-DROP-HARDENING-SPEC.md
+++ b/docs/specs/SECRET-DROP-HARDENING-SPEC.md
@@ -1,0 +1,120 @@
+---
+review-convergence: "rev-1 — operator-driven incident response. Three independent changes: non-destructive retrieve by default, explicit consume parameter, stuck-consumer event. Designed and discussed in topic 10873 immediately after the lost-SMS-code failure; design published as a private view + acknowledged by operator before implementation."
+approved: true
+approved-by: "operator (Justin) via Telegram topic 10873 — 2026-05-20T21:11Z (\"Approved, proceed as you best see fit\")"
+approved-at: "2026-05-20T21:11:00Z"
+---
+
+# Secret Drop Hardening — Spec
+
+**Status:** Approved 2026-05-20. Implementing now.
+**Author:** Echo
+**Companion:** SECRET-DROP-HARDENING-SPEC.eli16.md
+**Trigger:** 2026-05-20 incident in topic 10873 — the in-memory Secret Drop submission was consumed by a buggy bridge consumer that failed to extract the value, losing the SMS code and forcing a second auth round.
+
+---
+
+## Failure being addressed
+
+The `/secrets/retrieve/<token>` endpoint previously performed an **atomic retrieve-and-delete**: the submission was returned in the response and the same call removed it from the in-memory `received` map. Any consumer that dropped the response value (parse bug, network error after read, unhandled exception in the callback that writes the value to its destination) lost the secret with no recovery path.
+
+The cost on 2026-05-20: one SMS code was burned. The cost in a worse failure mode: a more sensitive secret could be lost AND a downstream system could be left in an inconsistent state (e.g. auth half-completed, retry impossible without a fresh operator action).
+
+A separate 5-minute server-side cleanup timer already existed. **The aggressive deletion-on-retrieve provided no additional safety beyond that timer** — the cleanup caught what the explicit delete caught, just on a longer horizon.
+
+---
+
+## Three changes (all ship in this PR)
+
+### 1. `getReceived` becomes non-destructive by default
+
+Two new methods on `SecretDrop`:
+
+- `peekReceived(token)` — returns the submission without removing it. Safe to call repeatedly. Used by polling consumers that want retry semantics.
+- `consumeReceived(token)` — returns the submission AND removes it before returning. Used when the caller is confident the value has been successfully handed off and a re-read would be wrong.
+
+`getReceived(token)` is preserved as a back-compat alias for `consumeReceived(token)` so existing callers do not break.
+
+The existing 5-minute auto-cleanup timer remains the only path through which submissions vanish without operator action.
+
+### 2. The route honors a `consume` query parameter
+
+```ts
+router.post('/secrets/retrieve/:token', (req, res) => {
+  const consume = req.query.consume === 'true' || req.query.consume === '1';
+  const submission = consume
+    ? secretDrop.consumeReceived(req.params.token)
+    : secretDrop.peekReceived(req.params.token);
+  if (!submission) {
+    res.status(404).json({ error: 'No submission found for this token' });
+    return;
+  }
+  res.json({ ...submission, consumed: consume });
+});
+```
+
+**Default is non-destructive.** Callers must opt into consumption with `?consume=true`. The response includes a `consumed: boolean` so callers can self-check.
+
+This is a backward-compatible change at the call-site level — existing callers that don't pass `?consume=true` retain the value across multiple retrieves (the safer behavior). Callers that depend on one-shot semantics opt in.
+
+### 3. Stuck-consumer event
+
+`SecretDrop.onStuckConsumer(listener)` registers a listener. If a submission lingers in `received` for >60 seconds without being explicitly consumed, every registered listener is invoked with a `StuckConsumerEvent`:
+
+```ts
+interface StuckConsumerEvent {
+  token: string;
+  label: string;
+  topicId?: number;
+  receivedAt: string;
+  minutesUntilCleanup: number;
+}
+```
+
+The `routes.ts` wiring registers a default listener that, when the bound topic and session manager are available, routes a `[secret-drop-stuck]` system message to the bound topic's agent session — giving the operator a visible cue that the consumer chain broke instead of silently waiting for a value that's already lost.
+
+The grace period is fixed at 60 seconds (the operator decided "60s is the right default" during the design review).
+
+---
+
+## Test plan
+
+`tests/unit/secret-drop-hardening.test.ts` — 13 cases:
+
+1. `peekReceived` returns the submission without removing it.
+2. `peekReceived` returns null for unknown tokens.
+3. `consumeReceived` returns and removes.
+4. Peek-then-consume: peek leaves, consume removes.
+5. Legacy `getReceived` behaves like `consumeReceived` (back-compat).
+6. **Regression — 2026-05-20 lost-SMS-code scenario:** a buggy consumer can retry after dropping the value on first call.
+7. Stuck-consumer event fires after 60s grace when nobody consumes.
+8. Stuck-consumer event does NOT fire when the submission was consumed before the grace ended.
+9. Stuck-consumer fires once at 60s even when cleanup runs later.
+10. Multiple listeners: one bad listener does not block others.
+11. Submission disappears after 5 minutes even if never consumed.
+12. Cleanup timer does not double-fire if consume happened first.
+13. `submit()` still consumes the pending request (existing behavior unchanged).
+
+The existing `tests/unit/SecretDrop.test.ts` suite remains untouched and all 25 cases continue to pass.
+
+---
+
+## Rollback
+
+Single-PR revert. The route falls back to the pre-change atomic retrieve-and-delete (via the back-compat `getReceived` path that is now an alias for `consumeReceived`). Callers that adopted `?consume=true` continue to work (the parameter becomes a no-op on the pre-change code, since deletion happens unconditionally there). The stuck-consumer event simply stops firing.
+
+---
+
+## What this does NOT do
+
+- It does not encrypt submissions at rest. They remain in-memory only (per the existing design).
+- It does not change the CSRF or rate-limit posture.
+- It does not address consumer-side bugs directly — but it makes them recoverable rather than terminal.
+- It does not modify the form-rendering surface or the `/secrets/request` route. Operator workflow on the form side is unchanged.
+
+---
+
+## Operator decisions captured in the design review
+
+1. **Grace period: 60 seconds.** (Operator approved the default.)
+2. **Stuck-consumer event: always-on.** (Operator approved; no per-request opt-in needed for the v1 ship.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/server/SecretDrop.ts
+++ b/src/server/SecretDrop.ts
@@ -85,10 +85,35 @@ export interface CreateSecretRequestOptions {
 const DEFAULT_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const MAX_PENDING = 20;
 const TOKEN_BYTES = 32; // 256-bit
+const RECEIVED_TTL_MS = 5 * 60 * 1000; // 5 minutes — auto-cleanup window for stored submissions
+const STUCK_CONSUMER_GRACE_MS = 60 * 1000; // 60 seconds — emit a warning if a submission sits unconsumed past this
+
+/**
+ * Event emitted when a submission has been sitting in `received` for longer
+ * than {@link STUCK_CONSUMER_GRACE_MS} without being explicitly consumed.
+ * Consumers register a listener via {@link SecretDrop.onStuckConsumer}.
+ *
+ * Added 2026-05-20 after the topic-10873 incident: a buggy bridge consumer
+ * called the (then-destructive) retrieve endpoint, failed to extract the
+ * value, and lost the secret silently. The hardening makes retrieval
+ * non-destructive by default; this event surfaces the case where a
+ * non-destructive retrieve never reaches an explicit consume — a visible
+ * cue that the consumer chain broke.
+ */
+export interface StuckConsumerEvent {
+  token: string;
+  label: string;
+  topicId?: number;
+  receivedAt: string;
+  minutesUntilCleanup: number;
+}
 
 export class SecretDrop {
   private pending = new Map<string, SecretRequest>();
   private received = new Map<string, SecretSubmission>();
+  private receivedTimers = new Map<string, NodeJS.Timeout>();
+  private stuckTimers = new Map<string, NodeJS.Timeout>();
+  private stuckConsumerListeners: Array<(event: StuckConsumerEvent) => void> = [];
   private cleanupTimer: NodeJS.Timeout;
   private agentName: string;
 
@@ -98,6 +123,17 @@ export class SecretDrop {
     // Periodic cleanup of expired requests
     this.cleanupTimer = setInterval(() => this.cleanup(), 60_000);
     this.cleanupTimer.unref();
+  }
+
+  /**
+   * Register a listener for stuck-consumer events. Listeners are invoked
+   * when a submission has been in `received` longer than the grace period
+   * (60s) without being explicitly consumed. Multiple listeners may
+   * register — all are invoked. Listener errors are caught and logged so
+   * a single bad listener cannot block the others.
+   */
+  onStuckConsumer(listener: (event: StuckConsumerEvent) => void): void {
+    this.stuckConsumerListeners.push(listener);
   }
 
   /**
@@ -194,9 +230,59 @@ export class SecretDrop {
       topicId: request.topicId,
     };
 
-    // Store submission briefly for retrieval (auto-cleanup in 5 minutes)
+    // Store submission briefly for retrieval (auto-cleanup window).
+    // The submission is NOT removed on first retrieve — callers must
+    // either explicitly consume it via `consumeReceived` (or the
+    // `?consume=true` route parameter) or wait for the cleanup timer.
+    // Rationale: a buggy consumer that drops the response (parse error,
+    // exception in the writer step, etc.) historically lost the value
+    // with no recovery path; non-destructive retrieval lets the same
+    // caller retry within the 5-minute window.
     this.received.set(token, submission);
-    setTimeout(() => this.received.delete(token), 5 * 60 * 1000).unref();
+    const cleanupTimer = setTimeout(() => {
+      this.received.delete(token);
+      this.receivedTimers.delete(token);
+      const stuck = this.stuckTimers.get(token);
+      if (stuck) {
+        clearTimeout(stuck);
+        this.stuckTimers.delete(token);
+      }
+    }, RECEIVED_TTL_MS);
+    cleanupTimer.unref();
+    this.receivedTimers.set(token, cleanupTimer);
+
+    // Schedule a stuck-consumer signal: if the submission has not been
+    // explicitly consumed within the grace period, emit a structured
+    // event to every registered listener. This is the visible-cue half
+    // of the silent-loss fix — agents that bind to topics can mirror
+    // the event back to the operator who submitted the secret.
+    const stuckTimer = setTimeout(() => {
+      this.stuckTimers.delete(token);
+      // Only fire if the submission is still in `received` (i.e. nobody
+      // consumed it during the grace window).
+      const stillPresent = this.received.get(token);
+      if (!stillPresent) return;
+      const cleanupAt = submission.receivedAt
+        ? new Date(submission.receivedAt).getTime() + RECEIVED_TTL_MS
+        : Date.now() + RECEIVED_TTL_MS;
+      const event: StuckConsumerEvent = {
+        token,
+        label: stillPresent.label,
+        topicId: stillPresent.topicId,
+        receivedAt: stillPresent.receivedAt,
+        minutesUntilCleanup: Math.max(0, Math.ceil((cleanupAt - Date.now()) / 60_000)),
+      };
+      for (const listener of this.stuckConsumerListeners) {
+        try {
+          listener(event);
+        } catch (err) {
+          // @silent-fallback-ok — listener errors must not break the SecretDrop service
+          console.error('[secret-drop] stuck-consumer listener error:', err instanceof Error ? err.message : String(err));
+        }
+      }
+    }, STUCK_CONSUMER_GRACE_MS);
+    stuckTimer.unref();
+    this.stuckTimers.set(token, stuckTimer);
 
     // Fire callback if provided
     if (request.onReceive) {
@@ -212,14 +298,53 @@ export class SecretDrop {
   }
 
   /**
-   * Retrieve a received submission (for polling-based retrieval).
-   * Returns and removes the submission.
+   * Retrieve a received submission WITHOUT consuming it. The submission
+   * remains in the store until explicitly consumed via
+   * {@link consumeReceived} or until the {@link RECEIVED_TTL_MS} timer
+   * fires. Safe to call repeatedly — used by polling consumers that
+   * want retry semantics on top of the natural cleanup window.
+   *
+   * @returns the submission or null if not present (never seen, already
+   *   consumed, or already cleaned up by the TTL).
    */
-  getReceived(token: string): SecretSubmission | null {
+  peekReceived(token: string): SecretSubmission | null {
+    return this.received.get(token) ?? null;
+  }
+
+  /**
+   * Retrieve AND consume a submission. The submission is removed from
+   * the store before the function returns. Use this when the caller is
+   * confident the value has been successfully handed off (parsed, stored,
+   * forwarded, etc.) and a re-read would be wrong.
+   *
+   * @returns the submission or null if not present.
+   */
+  consumeReceived(token: string): SecretSubmission | null {
     const submission = this.received.get(token);
     if (!submission) return null;
     this.received.delete(token);
+    const tCleanup = this.receivedTimers.get(token);
+    if (tCleanup) {
+      clearTimeout(tCleanup);
+      this.receivedTimers.delete(token);
+    }
+    const tStuck = this.stuckTimers.get(token);
+    if (tStuck) {
+      clearTimeout(tStuck);
+      this.stuckTimers.delete(token);
+    }
     return submission;
+  }
+
+  /**
+   * @deprecated Use {@link peekReceived} for non-destructive reads or
+   * {@link consumeReceived} for one-shot semantics. Preserved on the
+   * public surface for callers that have not yet migrated; behaves
+   * identically to {@link consumeReceived} so existing code keeps
+   * working until migrated.
+   */
+  getReceived(token: string): SecretSubmission | null {
+    return this.consumeReceived(token);
   }
 
   /**
@@ -535,10 +660,15 @@ export class SecretDrop {
   }
 
   /**
-   * Shutdown — clean up timer.
+   * Shutdown — clean up timers and listeners.
    */
   shutdown(): void {
     clearInterval(this.cleanupTimer);
+    for (const t of this.receivedTimers.values()) clearTimeout(t);
+    for (const t of this.stuckTimers.values()) clearTimeout(t);
+    this.receivedTimers.clear();
+    this.stuckTimers.clear();
+    this.stuckConsumerListeners.length = 0;
     this.pending.clear();
     this.received.clear();
   }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8117,6 +8117,37 @@ export function createRoutes(ctx: RouteContext): Router {
 
   const secretDrop = new SecretDrop(ctx.config.projectName || 'Agent');
 
+  // Stuck-consumer hardening: when an agent's consumer chain fails to
+  // claim a submitted secret within the grace window, route a visible
+  // cue to the bound topic so the operator hears about the failure
+  // instead of silently waiting on a value that never arrives. Added
+  // 2026-05-20 in response to the topic-10873 lost-SMS-code incident.
+  secretDrop.onStuckConsumer((event) => {
+    if (!event.topicId || !ctx.sessionManager) return;
+    const topicId = event.topicId;
+    const systemMsg = `[secret-drop-stuck] Secret "${event.label}" was submitted but has not been consumed by an agent process. ` +
+      `If you weren't expecting this, the consumer may have hit a bug. ` +
+      `The submission will auto-clean in ~${event.minutesUntilCleanup} minute(s). ` +
+      `To retry, re-read it (non-destructive): curl -s -X POST -H "Authorization: Bearer $AUTH" http://localhost:${ctx.config.port}/secrets/retrieve/${event.token}.`;
+    try {
+      const sdRegistryPath = path.join(ctx.config.stateDir, 'topic-session-registry.json');
+      let targetSession: string | null = null;
+      if (fs.existsSync(sdRegistryPath)) {
+        const registry = JSON.parse(fs.readFileSync(sdRegistryPath, 'utf-8'));
+        targetSession = registry.topicToSession?.[String(topicId)] ?? null;
+      }
+      if (targetSession && ctx.sessionManager.isSessionAlive(targetSession)) {
+        ctx.sessionManager.injectPasteNotification(
+          targetSession,
+          `<system-reminder>${systemMsg}</system-reminder>`,
+        );
+      }
+    } catch (err) {
+      // @silent-fallback-ok — the stuck-consumer signal is best-effort
+      console.error('[secret-drop] stuck-consumer notify failed:', err instanceof Error ? err.message : String(err));
+    }
+  });
+
   /** Build a browser-clickable tunnel URL for a secret drop */
   function secretDropUrl(token: string): { localUrl: string; tunnelUrl: string | null } {
     const localUrl = `/secrets/drop/${token}`;
@@ -8233,7 +8264,9 @@ export function createRoutes(ctx: RouteContext): Router {
       const fieldCount = Object.keys(submission.values).length;
       const fieldNames = Object.keys(submission.values).join(', ');
       const systemMsg = `[secret-drop-received] Secret "${submission.label}" was just submitted (${fieldCount} field${fieldCount !== 1 ? 's' : ''}: ${fieldNames}). ` +
-        `Retrieve it with: curl -s -X POST -H "Authorization: Bearer $AUTH" http://localhost:${ctx.config.port}/secrets/retrieve/${req.params.token} | Then acknowledge receipt to the user conversationally via Telegram topic ${topicId}.`;
+        `Retrieve (non-destructive — safe to retry on parse error): curl -s -X POST -H "Authorization: Bearer $AUTH" http://localhost:${ctx.config.port}/secrets/retrieve/${req.params.token}. ` +
+        `When you have successfully handed off the value, consume it: append ?consume=true to the same URL. ` +
+        `Then acknowledge receipt to the user conversationally via Telegram topic ${topicId}.`;
 
       const sdRegistryPath = path.join(ctx.config.stateDir, 'topic-session-registry.json');
       let targetSession: string | null = null;
@@ -8373,15 +8406,25 @@ export function createRoutes(ctx: RouteContext): Router {
     res.json({ ok: true });
   });
 
-  // Retrieve a received secret (agent-facing, requires auth)
-  // This is for polling-based retrieval — the secret is returned once and deleted.
+  // Retrieve a received secret (agent-facing, requires auth).
+  //
+  // Non-destructive by default — repeated calls return the same value
+  // until the in-memory cleanup timer fires (~5 min). Pass `?consume=true`
+  // for the legacy one-shot semantics. Rationale: a buggy consumer that
+  // dropped the response value used to lose the secret with no recovery;
+  // non-destructive default lets the caller retry. See
+  // docs/specs/secret-drop-hardening.md for the full rationale.
   router.post('/secrets/retrieve/:token', (req, res) => {
-    const submission = secretDrop.getReceived(req.params.token);
+    const consumeFlag = req.query.consume;
+    const consume = consumeFlag === 'true' || consumeFlag === '1';
+    const submission = consume
+      ? secretDrop.consumeReceived(req.params.token)
+      : secretDrop.peekReceived(req.params.token);
     if (!submission) {
       res.status(404).json({ error: 'No submission found for this token' });
       return;
     }
-    res.json(submission);
+    res.json({ ...submission, consumed: consume });
   });
 
   // ── Tunnel Status ──────────────────────────────────────────────

--- a/tests/unit/secret-drop-hardening.test.ts
+++ b/tests/unit/secret-drop-hardening.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Verifies the Secret Drop hardening added after the 2026-05-20
+ * topic-10873 incident. A buggy bridge consumer called the (then
+ * destructive) `/secrets/retrieve/<token>` endpoint, failed to extract
+ * the value, and silently lost the SMS code. The hardening makes
+ * retrieval non-destructive by default, adds an explicit consume path,
+ * and emits a stuck-consumer event when a submission lingers
+ * unconsumed past the grace window.
+ *
+ * The tests below pin each part of that contract.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SecretDrop, type StuckConsumerEvent } from '../../src/server/SecretDrop.js';
+
+function submitOne(drop: SecretDrop, label = 'Test Secret') {
+  const { token } = drop.create({
+    label,
+    fields: [{ name: 'code', label: 'Code' }],
+    topicId: 10873,
+  });
+  const pending = drop.getPending(token);
+  if (!pending) throw new Error('pending missing — test setup wrong');
+  const submission = drop.submit(token, pending.csrfToken, { code: '12345' });
+  if (!submission) throw new Error('submit returned null — test setup wrong');
+  return { token, submission };
+}
+
+describe('SecretDrop — non-destructive default retrieval', () => {
+  let drop: SecretDrop;
+
+  beforeEach(() => {
+    drop = new SecretDrop('test-agent');
+  });
+
+  afterEach(() => {
+    drop.shutdown();
+  });
+
+  it('peekReceived returns the submission without removing it', () => {
+    const { token } = submitOne(drop);
+    const first = drop.peekReceived(token);
+    expect(first).not.toBeNull();
+    expect(first!.values.code).toBe('12345');
+    // Calling again must return the same submission, not null.
+    const second = drop.peekReceived(token);
+    expect(second).not.toBeNull();
+    expect(second!.values.code).toBe('12345');
+  });
+
+  it('peekReceived returns null for an unknown token', () => {
+    expect(drop.peekReceived('does-not-exist')).toBeNull();
+  });
+
+  it('consumeReceived returns the submission and removes it on first call', () => {
+    const { token } = submitOne(drop);
+    const first = drop.consumeReceived(token);
+    expect(first).not.toBeNull();
+    expect(first!.values.code).toBe('12345');
+    // Now it's gone.
+    expect(drop.consumeReceived(token)).toBeNull();
+    expect(drop.peekReceived(token)).toBeNull();
+  });
+
+  it('peek then consume: peek leaves the submission, consume removes it', () => {
+    const { token } = submitOne(drop);
+    expect(drop.peekReceived(token)).not.toBeNull();
+    expect(drop.peekReceived(token)).not.toBeNull();
+    const consumed = drop.consumeReceived(token);
+    expect(consumed).not.toBeNull();
+    // After consume, peek returns null.
+    expect(drop.peekReceived(token)).toBeNull();
+  });
+
+  it('legacy getReceived behaves like consumeReceived (back-compat)', () => {
+    const { token } = submitOne(drop);
+    const first = drop.getReceived(token);
+    expect(first).not.toBeNull();
+    // Legacy semantics: deleted on first read.
+    expect(drop.getReceived(token)).toBeNull();
+    expect(drop.peekReceived(token)).toBeNull();
+  });
+});
+
+describe('SecretDrop — regression: 2026-05-20 lost-SMS-code scenario', () => {
+  let drop: SecretDrop;
+
+  beforeEach(() => {
+    drop = new SecretDrop('echo');
+  });
+
+  afterEach(() => {
+    drop.shutdown();
+  });
+
+  it('a buggy consumer can retry after dropping the value on first call', () => {
+    // Submit a code, then simulate the original failure: the bridge
+    // consumer "reads" the value via the non-destructive endpoint, then
+    // its parser fails and it drops the value. Under the old code, the
+    // submission would now be gone. Under the new code, it can retry.
+    const { token } = submitOne(drop, 'Telegram MTProto SMS code');
+
+    // First read: buggy parser drops it.
+    const firstRead = drop.peekReceived(token);
+    expect(firstRead).not.toBeNull();
+    // Bug: parser fails, value is dropped on the caller side.
+
+    // Second read: retry succeeds because the submission is still there.
+    const secondRead = drop.peekReceived(token);
+    expect(secondRead).not.toBeNull();
+    expect(secondRead!.values.code).toBe('12345');
+
+    // Caller eventually fixes the parse and consumes explicitly.
+    const consumed = drop.consumeReceived(token);
+    expect(consumed).not.toBeNull();
+    expect(consumed!.values.code).toBe('12345');
+  });
+});
+
+describe('SecretDrop — stuck-consumer event', () => {
+  let drop: SecretDrop;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    drop = new SecretDrop('test-agent');
+  });
+
+  afterEach(() => {
+    drop.shutdown();
+    vi.useRealTimers();
+  });
+
+  it('fires after the 60s grace period when nobody consumes', () => {
+    const events: StuckConsumerEvent[] = [];
+    drop.onStuckConsumer((e) => events.push(e));
+    const { token } = submitOne(drop, 'Stuck Test');
+
+    // No consume — advance past the 60s grace period.
+    vi.advanceTimersByTime(60_000 + 100);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].token).toBe(token);
+    expect(events[0].label).toBe('Stuck Test');
+    expect(events[0].topicId).toBe(10873);
+    expect(events[0].minutesUntilCleanup).toBeGreaterThanOrEqual(3);
+  });
+
+  it('does NOT fire when the submission was explicitly consumed before the grace ends', () => {
+    const events: StuckConsumerEvent[] = [];
+    drop.onStuckConsumer((e) => events.push(e));
+    const { token } = submitOne(drop);
+
+    // Consumer claims the value at 30s — well before the grace expires.
+    vi.advanceTimersByTime(30_000);
+    drop.consumeReceived(token);
+
+    // Now advance past the grace boundary.
+    vi.advanceTimersByTime(60_000);
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('fires once at 60s, even when the cleanup timer runs later', () => {
+    // The 60s stuck timer fires first; the 5-minute cleanup timer fires
+    // later. The listener should see exactly one event, not two.
+    const events: StuckConsumerEvent[] = [];
+    drop.onStuckConsumer((e) => events.push(e));
+    const { token } = submitOne(drop);
+
+    vi.advanceTimersByTime(5 * 60_000 + 100);
+
+    expect(drop.peekReceived(token)).toBeNull();
+    expect(events).toHaveLength(1);
+  });
+
+  it('invokes every registered listener; one bad listener does not block others', () => {
+    const seenA: StuckConsumerEvent[] = [];
+    const seenB: StuckConsumerEvent[] = [];
+    drop.onStuckConsumer(() => {
+      throw new Error('boom from listener A');
+    });
+    drop.onStuckConsumer((e) => seenA.push(e));
+    drop.onStuckConsumer((e) => seenB.push(e));
+
+    submitOne(drop);
+    vi.advanceTimersByTime(60_000 + 100);
+
+    expect(seenA).toHaveLength(1);
+    expect(seenB).toHaveLength(1);
+  });
+});
+
+describe('SecretDrop — auto-cleanup timer interactions', () => {
+  let drop: SecretDrop;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    drop = new SecretDrop('test-agent');
+  });
+
+  afterEach(() => {
+    drop.shutdown();
+    vi.useRealTimers();
+  });
+
+  it('submission disappears after 5 minutes even if never consumed', () => {
+    const { token } = submitOne(drop);
+    expect(drop.peekReceived(token)).not.toBeNull();
+    vi.advanceTimersByTime(5 * 60_000 + 100);
+    expect(drop.peekReceived(token)).toBeNull();
+  });
+
+  it('cleanup timer does not double-fire if consume happened first', () => {
+    const { token } = submitOne(drop);
+    drop.consumeReceived(token);
+    // Advance past cleanup — nothing should throw.
+    vi.advanceTimersByTime(5 * 60_000 + 100);
+    expect(drop.peekReceived(token)).toBeNull();
+  });
+});
+
+describe('SecretDrop — submit still consumes the pending request (unchanged)', () => {
+  let drop: SecretDrop;
+
+  beforeEach(() => {
+    drop = new SecretDrop('test-agent');
+  });
+  afterEach(() => {
+    drop.shutdown();
+  });
+
+  it('a second submit attempt for the same token returns null', () => {
+    const { token } = drop.create({
+      label: 'one-time',
+      fields: [{ name: 'code', label: 'Code' }],
+      topicId: 10873,
+    });
+    const pending = drop.getPending(token)!;
+    const first = drop.submit(token, pending.csrfToken, { code: 'A' });
+    expect(first).not.toBeNull();
+    const second = drop.submit(token, pending.csrfToken, { code: 'B' });
+    expect(second).toBeNull();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,71 @@
+# Upgrade Guide — v1.2.1 (Secret Drop hardening — non-destructive retrieve + stuck-consumer event)
+
+<!-- bump: patch -->
+
+## What Changed
+
+The `/secrets/retrieve/<token>` endpoint is now **non-destructive by
+default**. Repeated calls return the same value until the in-memory
+5-minute cleanup timer fires. Callers that need one-shot semantics opt
+in by appending `?consume=true` to the URL.
+
+Three concrete surface changes in `src/server/SecretDrop.ts` and
+`src/server/routes.ts`:
+
+1. **Two new methods on `SecretDrop`.** `peekReceived(token)` returns
+   the submission without removing it; `consumeReceived(token)` returns
+   AND removes it. The existing `getReceived(token)` is preserved as a
+   back-compat alias for `consumeReceived(token)` so no caller breaks.
+
+2. **The retrieve route honors `?consume=true`.** Default behavior is
+   `peek`. The response includes a `consumed: boolean` field so callers
+   can self-check which path ran.
+
+3. **Stuck-consumer event.** If a submission lingers in the in-memory
+   store for >60 seconds without being explicitly consumed, every
+   registered listener is invoked with a `StuckConsumerEvent`. The
+   default route-layer listener routes a `[secret-drop-stuck]` system
+   message to the bound topic's agent session, giving the operator a
+   visible cue that the consumer chain broke.
+
+## Evidence
+
+Reproduction prior: on 2026-05-20 in topic 10873, a bridge script
+called `/secrets/retrieve/<token>`, the server returned the submitted
+SMS code AND deleted it atomically, and the bridge's parser dropped
+the value on the way to disk. The code was lost; Telegram had to send
+a fresh one. Pattern verified end-to-end in
+`tests/unit/secret-drop-hardening.test.ts` ("regression: 2026-05-20
+lost-SMS-code scenario"): the test reproduces the buggy-consumer drop
+and asserts that under the hardening a retry succeeds because the
+submission is still in the store.
+
+Reproduction after: same buggy-consumer flow. First call returns the
+value AND it stays in the store. The buggy parser fails. Second call
+returns the value again. Caller fixes the parse and explicitly
+consumes. No code is lost.
+
+Idempotency, grace-period, and listener-isolation contracts verified
+by 13 unit cases. The pre-existing `tests/unit/SecretDrop.test.ts`
+suite (25 cases) continues to pass — no back-compat regressions.
+
+## What to Tell Your User
+
+- "I made my own secret-handling more forgiving. The bug that lost your one-time code earlier today can't repeat without a deliberate opt-in — my pickup process can now retry a failed handoff inside the 5-minute window instead of losing the value on the first attempt. And if something does sit unread for more than a minute, I now get a visible alert telling me to look at it, rather than silently waiting on a value that's already gone."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Non-destructive retrieve (default) | Agent calls `POST /secrets/retrieve/<token>`. Same call repeated within ~5 min returns the same value. |
+| Explicit consume path | Agent appends `?consume=true` to commit a one-shot read. Response includes `consumed: true`. |
+| Stuck-consumer event | Automatic. If a submission isn't consumed within 60s, a `[secret-drop-stuck]` system message routes to the bound topic's agent session. |
+
+## Deferred (Tracked Follow-ups)
+
+- Configurable grace period per-request (currently a hard-coded 60s
+  constant). Will be added when a real need surfaces.
+- Updating the bridge script in the parallel
+  `scripts/telegram-history-backfill.mjs` PR to read non-destructively
+  by default, parse first, and only consume after a successful parse.
+  That refactor lives in a separate commit after this PR lands.

--- a/upgrades/side-effects/secret-drop-hardening.md
+++ b/upgrades/side-effects/secret-drop-hardening.md
@@ -1,0 +1,64 @@
+# Side-effects review — Secret Drop hardening
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+**Before.** UNDER-block: a buggy consumer that called `/secrets/retrieve/<token>` once and dropped the response (parse error, exception in the writer step) lost the secret with no recovery path. The aggressive deletion-on-retrieve looked like a tight one-shot guarantee but actually created a silent-loss footgun, because the same 5-minute cleanup timer was already handling memory hygiene.
+
+**After.** No new over-block: the default retrieval shape returns the same value the previous code did. Existing callers that don't pass `?consume=true` simply gain the ability to retry within the cleanup window — a safer state, not a different one. Callers that genuinely need one-shot semantics opt in with the query parameter.
+
+The new stuck-consumer event closes the silent-failure gap: a submission that lingers unconsumed for 60s now produces a visible cue to the bound topic. Operators see the failure instead of waiting on a value that's already lost.
+
+## 2. Level-of-abstraction fit
+
+Three changes at deliberately different altitudes:
+
+- `SecretDrop.ts`: new methods (`peekReceived`, `consumeReceived`, `onStuckConsumer`) and the stuck-timer state machine. Pure logic, unit-tested.
+- `routes.ts`: the route honors `?consume=true`; one default listener wires the stuck-consumer event to the topic-bound session via `injectPasteNotification`. Thin orchestration only.
+- Back-compat alias: `getReceived` is kept as `consumeReceived`'s legacy synonym so no caller has to migrate in this PR. Callers migrate at their own pace by switching to `peekReceived` + `consumeReceived` explicitly.
+
+## 3. Signal vs Authority compliance
+
+The Secret Drop request remains the authoritative declaration that this token may receive a submission (operator-issued via `/secrets/request`). The submission, once made, remains the authoritative payload — no agent code can mint a fake submission. The new methods change only the lifecycle of an already-authorized value:
+
+- `peekReceived`: read-only, idempotent, returns the existing authority.
+- `consumeReceived`: terminates the authority's lifetime explicitly.
+- `onStuckConsumer`: signal-only emission to listeners; no listener gains write access to the submission.
+
+No new authority is created. Existing CSRF, rate-limit, expiry, and one-time submission semantics are unchanged.
+
+## 4. Interactions with adjacent systems
+
+- **The `/secrets/retrieve/<token>` route.** Default behavior shifts from destructive to non-destructive. Existing callers that don't add `?consume=true` retain the value across multiple calls — strictly safer; no callers depend on "second call returns 404" except as a footgun.
+- **The `/secrets/drop/<token>` form-side route.** Untouched. Operator-facing flow is byte-identical.
+- **`onReceive` callback on the request.** Untouched. Still fires once on submit.
+- **Existing 5-minute auto-cleanup.** Untouched. Still the safety net.
+- **System-message routing via `injectPasteNotification`.** Reused for the new stuck-consumer system message. Same pattern as `secret-drop-received`.
+- **Existing `SecretDrop.test.ts` suite.** All 25 cases continue to pass. The new test file adds 13 cases for the new surface.
+
+## 5. Rollback cost
+
+Low. Three files modified (`SecretDrop.ts`, `routes.ts`, one test file added). `git revert <merge-sha>` restores the pre-change atomic retrieve-and-delete behavior. Callers that adopted `?consume=true` continue to work after a revert (the parameter becomes a no-op against the pre-change atomic-delete path). The stuck-consumer event simply stops firing.
+
+No state migration, no deployed-agent impact, no schema change. In-memory only.
+
+## 6. Backwards compatibility / drift surface
+
+Fully backwards-compatible at the call-site level:
+
+- `getReceived(token)` is preserved as an alias for `consumeReceived(token)`.
+- The route default is non-destructive — strictly safer for existing callers.
+- Callers that depend on one-shot semantics (the bridge script in the parallel telegram-history-backfill PR being one example) opt in via `?consume=true` explicitly.
+
+Drift surface: small. Two new methods on `SecretDrop`. One new event interface. One new constant for the grace period. The grace period is a hard-coded constant for v1 ship; a future PR can make it configurable per-request if a real need surfaces.
+
+## 7. Authorization / Trust posture
+
+No new authority. The two new methods read/write the same in-memory `received` map the previous code touched. The new listener-registration surface (`onStuckConsumer`) accepts callbacks from the route layer only — there is no external API to register a listener over HTTP. The route layer's default listener routes only to the topic-bound session (the same authority the `secret-drop-received` path already uses).
+
+Trust ramifications: the operator gains a new visible signal (the stuck-consumer system message), which strengthens their ability to detect consumer-side failures. The agent gains a new structural primitive for safe-by-default retrieval, which reduces the surface for silent-loss bugs. Both directions of trust move in the safer direction.
+
+## Outcome
+
+Ship. Incident-driven, three independent changes, fully unit-tested, fully backwards-compatible at the call-site level. The single highest-impact change is the default-non-destructive retrieve — that alone makes the 2026-05-20 lost-SMS-code failure mode structurally impossible to repeat without an explicit `?consume=true` from the buggy consumer.


### PR DESCRIPTION
## Summary

Closes the silent-loss class exposed by topic 10873 on 2026-05-20: a bridge consumer called the (then-atomic) `/secrets/retrieve/<token>` endpoint, the server returned the SMS code AND deleted it in one step, the consumer's parser dropped the value, and the code was lost with no retry path.

Three independently shippable changes, all fully back-compat:

1. **Non-destructive retrieve by default.** `SecretDrop.peekReceived(token)` returns the submission without removing it. `consumeReceived(token)` returns AND removes. The existing `getReceived(token)` is preserved as an alias for `consumeReceived` so no caller breaks.
2. **Explicit consume parameter on the route.** `POST /secrets/retrieve/<token>` defaults to peek. Append `?consume=true` to opt into one-shot semantics. Response includes `consumed: boolean` so callers can self-check.
3. **Stuck-consumer event.** `SecretDrop.onStuckConsumer(listener)` registers a listener. If a submission lingers unclaimed past the 60s grace, every listener fires with a `StuckConsumerEvent`. Default route-layer listener routes a `[secret-drop-stuck]` system message to the bound topic's agent session — visible cue instead of silent waiting.

The 5-minute in-memory cleanup timer is unchanged — it remains the safety net for unconsumed submissions.

## Why this matters

The 2026-05-20 incident lost a recoverable SMS code (Telegram simply sent another). The same bug class on a higher-stakes secret (long-lived API key, database password, service-account token) would have produced: the secret lost in transit, the downstream system left half-configured, and no operator-visible signal because the server's response said "200 OK." After this PR all three become visible and recoverable.

## What ships

- **`src/server/SecretDrop.ts`** — three new methods (`peekReceived`, `consumeReceived`, `onStuckConsumer`), one new event interface (`StuckConsumerEvent`), and the stuck-timer state machine. `getReceived` preserved as legacy alias.
- **`src/server/routes.ts`** — `POST /secrets/retrieve/:token` honors `?consume=true`. Default route-layer `onStuckConsumer` listener routes system messages to bound topics. The `secret-drop-received` system-message text now demonstrates the safe pattern (peek first, then `?consume=true` after successful handoff).
- **`tests/unit/secret-drop-hardening.test.ts`** — 13 cases covering each branch of the new contract. Includes an explicit "regression: 2026-05-20 lost-SMS-code scenario" case that simulates the buggy-consumer drop and proves retry succeeds.
- **`docs/specs/SECRET-DROP-HARDENING-SPEC.md` + `.eli16.md`** — rev-1 spec approved 2026-05-20 by operator via Telegram topic 10873.
- **`upgrades/side-effects/secret-drop-hardening.md`** — L6 review.
- **`upgrades/NEXT.md`** — v1.1.5 release notes (patch bump; additive hardening with no breaking changes).

## Test plan

- [x] 13 new unit cases pass
- [x] Existing 25-case `tests/unit/SecretDrop.test.ts` suite continues to pass — no back-compat regressions
- [x] Pre-push gate green (lint, codex-rule1-drift)
- [x] /instar-dev precommit gate green (trace + side-effects review + spec + ELI16 verified)
- [x] `npx tsc --noEmit` clean
- [ ] CI green

## Rollback

`git revert <merge-sha>` restores the pre-change atomic retrieve-and-delete. Callers that adopted `?consume=true` keep working (the param becomes a no-op against the pre-change path). The stuck-consumer event simply stops firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)