### PR TITLE
feat(capabilities): surface Secret Drop + 5 more primitives, lint locks discoverability

### DIFF
--- a/docs/specs/capabilities-discoverability.eli16.md
+++ b/docs/specs/capabilities-discoverability.eli16.md
@@ -1,0 +1,46 @@
+# Capabilities Discoverability — Plain-English Overview
+
+> The one-line version: the endpoint that's supposed to tell every agent what it can do was lying about Secret Drop (and five other primitives), and we're fixing it plus locking the promise structurally.
+
+## The problem in one breath
+
+Every instar agent is told, in its onboarding file, to call `GET /capabilities` whenever it's not sure what tools it has. That endpoint was supposed to be the agent's "honest mirror" — a live list of every primitive the server can do. It wasn't honest: it left out Secret Drop, the commitment tracker, the token ledger, the semantic memory, and the listing-side endpoints for private views and Telegraph publishing. When an agent asked the mirror "do you have a safe way to collect a password from the user?" the mirror said no — even though the safe way (Secret Drop) was right there in the codebase. The agent then reached for an unsafe workaround.
+
+## What already exists
+
+- **The `/capabilities` endpoint.** A live JSON response listing the agent's available tools. The agent's standard onboarding (CLAUDE.md) tells it to trust this endpoint as the source of truth.
+- **Secret Drop.** A safe channel for collecting credentials from users — the user types the password into a one-time web form, never into chat, and the agent retrieves it through a hardened path. The routes are all live: `POST /secrets/request`, `POST /secrets/retrieve/:token`, `GET /secrets/pending`, `DELETE /secrets/pending/:token`.
+- **CommitmentTracker, TokenLedger, SemanticMemory.** Three other agent-facing primitives that are fully wired up in the server but were never listed in the `/capabilities` response.
+- **The `BUILTIN_FEATURES` registry.** A separate list of opt-in features (with consent flows). Secret Drop is not opt-in — it's always-on infrastructure — so this isn't the right home for it. The discoverability fix has to live in `/capabilities`, not in the registry.
+
+## What this adds
+
+The `/capabilities` response now includes a `secrets` block — same shape as the existing blocks for Telegram, scheduler, etc. — listing every Secret Drop endpoint plus a one-line hardening note pointing at the safe retrieval helper. Four other primitives that were silently missing get the same treatment (`commitments`, `tokens`, `semantic`), and two blocks that previously surfaced only counts (`publishing`, `privateViewer`) gain explicit endpoint arrays.
+
+Secondary change: a new lint test enumerates every top-level route prefix in the server and refuses CI if any prefix isn't either surfaced in the `/capabilities` response or explicitly allowlisted as an internal/operator-only endpoint. The lint is the structural guarantee that the next primitive can't slip through silently.
+
+## The new pieces
+
+- **The new blocks in `/capabilities`.** Plain JSON objects with `enabled`, `endpoints`, and (for Secret Drop) a `retrievalHint` warning against the unsafe pattern. They are pure data — they do not gate anything, they just describe what's available.
+- **`tests/unit/capabilities-discoverability.test.ts`.** Walks `src/server/routes.ts` for every `router.get('/<prefix>...')` style registration, builds the set of all top-level prefixes, and asserts each is discoverable. Has an `INTERNAL_ALLOWLIST` for endpoints that should NOT appear (health checks, the capabilities endpoint itself, operator-only routes) — each entry needs a one-line reason.
+
+## The safeguards
+
+**Prevents future primitives from being invisible.** Today the failure happened because a primitive shipped without a corresponding `/capabilities` entry. The new lint enumerates every route prefix at test time and refuses the build if any prefix is unaccounted for. Adding a new primitive now means either adding it to the response or making a deliberate choice to allowlist it.
+
+**Prevents the response shape from changing in a way that breaks existing consumers.** All changes are additive. The existing `publishing.pageCount` and `privateViewer.viewCount` fields are preserved; the new `endpoints` arrays are added alongside. Existing integration tests pass without modification.
+
+**Prevents agents from learning the unsafe retrieval pattern.** The new `secrets.retrievalHint` field in the response includes a one-line warning that the raw `curl` pattern leaks the secret into the Bash transcript and points at the hardened retrieval script. The hardening note rides along with the discoverability fix so agents see it the moment they discover Secret Drop.
+
+## What ships when
+
+This is a single PR. Two interleaved fixes ship together: the response-body additions and the lint that locks them.
+
+Two follow-ups are explicitly out of scope and tracked separately:
+
+1. Ship the hardened retrieve script as an `src/templates/scripts/` template so every agent gets it on install. This fixes the second layer of the case-study failure (the workaround-reflex / unsafe retrieve pattern).
+2. Refactor `/capabilities` to introspect from `FeatureRegistry` + the live router instead of being a hand-curated object literal. This removes the third manual edit point and makes the registry the single source of truth.
+
+## What you actually need to decide
+
+This PR closes the discoverability gap that started the case study. Two follow-ups remain (hardened retrieve script + introspecting `/capabilities`) — should they ship as separate PRs or be bundled into a single sequel?

--- a/docs/specs/capabilities-discoverability.md
+++ b/docs/specs/capabilities-discoverability.md
@@ -1,0 +1,65 @@
+---
+slug: capabilities-discoverability
+title: Capabilities Discoverability — close the gap between routes.ts and the self-discovery surface
+review-convergence: 2026-05-21T05:00:00Z
+approved: true
+eli16-overview: capabilities-discoverability.eli16.md
+---
+
+# Capabilities Discoverability
+
+## Problem
+
+The CLAUDE.md template — bundled with every instar agent — instructs:
+
+> Before EVER saying "I don't have", "I can't", or "this isn't available" — check what actually exists: `curl http://localhost:$INSTAR_PORT/capabilities`. This returns your full capability matrix. It is the source of truth about what you can do. Never hallucinate about missing capabilities — verify first.
+
+This is a hard architectural promise: `/capabilities` is the authoritative self-discovery surface. If a primitive exists in the server, an agent that consults `/capabilities` will learn it exists; if `/capabilities` is silent, the agent treats the primitive as absent.
+
+The promise was silently false. The handler at `src/server/routes.ts:GET /capabilities` is a hand-curated object literal that hand-lists ~25 subsystems by name. Several agent-facing primitives ship as registered routes (`POST /secrets/request`, `/secrets/retrieve/:token`, the full `/commitments/*` CRUD, `/tokens/*`, `/semantic/*`, the listing-side endpoints under `/views` and `/published`) but never appear in the response body.
+
+The downstream failure mode is documented in the case study seeded into topic 11141 ("🔍 Discoverability Secret Access") on 2026-05-20. When an agent needed to collect a Bitwarden master password, it consulted `/capabilities`, saw no `secrets` block, and reached for unsafe credential-intake workarounds (chat paste, env vars). The actual safe primitive — Secret Drop — existed, but the discovery surface lied about it. The leak that followed was a downstream symptom of a structural lie at the discovery layer.
+
+## Approach
+
+Two changes, one PR:
+
+**1. Fill the gaps in the response.** Add `secrets`, `commitments`, `tokens`, and `semantic` blocks to the `/capabilities` response. Expand the `publishing` and `privateViewer` blocks to include explicit endpoint arrays (they previously surfaced only counts). The `secrets` block includes a hardening note pointing at `.instar/scripts/secret-drop-retrieve.mjs` as the safe retrieval helper — the raw `curl` pattern leaks the secret value into the Bash tool transcript.
+
+**2. Lock the promise with a unit test.** A new `tests/unit/capabilities-discoverability.test.ts` walks `src/server/routes.ts` for every top-level route prefix and asserts each either appears in the literal `res.json({...})` body of the `GET /capabilities` handler or is on an explicit `INTERNAL_ALLOWLIST` with a one-line reason. Adding a new prefix that is neither surfaced nor allowlisted will fail CI until the author makes a deliberate choice.
+
+The `/capabilities` handler remains a hand-curated object literal in this PR. A follow-up (intentionally deferred) will refactor the handler to introspect from `FeatureRegistry` + the live Express router so the third manual edit point disappears entirely. The deferral is rational because the lint already enforces the invariant the refactor would automate.
+
+## Non-goals
+
+- Re-architect `/capabilities` to be self-introspecting. Deferred to a follow-up spec — out of scope here.
+- Ship a hardened retrieve script as an `src/templates/scripts/` template. Required for the second-layer fix from the case study (the workaround-reflex failure mode), but distinct from the discoverability fix. Tracked separately.
+- Update `routes.ts:5973` (the system message injected into spawned agents on Secret Drop submission). That instruction still teaches the raw-curl pattern. Same deferral as above.
+- Add a corresponding `secret-drop` entry to `BUILTIN_FEATURES`. That registry is for opt-in features with a consent flow; Secret Drop is an always-on primitive and doesn't fit the schema.
+
+## Acceptance criteria
+
+- `GET /capabilities` returns a `secrets` object with `enabled: true`, an `endpoints` array containing each of the four Secret Drop routes, and a `retrievalHint` warning against the raw-curl pattern.
+- `GET /capabilities` returns `commitments`, `tokens`, and `semantic` objects, each with `enabled: true` and an `endpoints` array.
+- The `publishing` and `privateViewer` blocks each carry an `endpoints` array.
+- `tests/unit/capabilities-discoverability.test.ts` enumerates every top-level route prefix in `src/server/routes.ts` and asserts each is either surfaced in the response body or in `INTERNAL_ALLOWLIST`.
+- No regressions in the existing integration tests that exercise the `/capabilities` response (`tests/integration/view-tunnel-routes.test.ts`, `tests/integration/publishing-routes.test.ts`).
+
+## Decision points touched
+
+- `GET /capabilities` response body — the agent's authoritative self-discovery surface.
+- The new lint test — fails CI on any route prefix that isn't either surfaced or explicitly allowlisted.
+
+Neither change introduces new block/allow authority. Both are additive observability/safety changes. The signal-vs-authority principle is preserved: the lint is a brittle detector that emits a signal (a CI failure) which an existing authority (the human reviewer + CI gate) acts on. The detector has no block authority of its own at runtime.
+
+## Migration
+
+No agent-installed file changes. The `/capabilities` response shape is purely additive — existing fields are preserved, new fields are added. No `PostUpdateMigrator` entries needed. The hardened Secret Drop retrieve script (`.instar/scripts/secret-drop-retrieve.mjs`) is tracked in a separate spec.
+
+## Rollback
+
+Pure code change. Revert the routes.ts diff and the lint test; the manifest hashes regenerate on the next build. No persistent state, no agent-state repair, no user-visible regression during the rollback window.
+
+## Origin
+
+Topic 11141 ("🔍 Discoverability Secret Access"), seeded 2026-05-20 17:00 UTC. Root-cause audit on 2026-05-21. The case study explicitly named the discoverability gap as failure #1 of three compounding failures; this spec addresses failure #1 only. Failures #2 (workaround-reflex / unsafe retrieve pattern) and #3 (brittle dependence on machine-local props) are tracked separately.

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-21T04:18:26.708Z",
-  "instarVersion": "1.1.4",
+  "generatedAt": "2026-05-21T05:37:22.352Z",
+  "instarVersion": "1.2.2",
   "entryCount": 190,
   "entries": {
     "hook:session-start": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -720,7 +720,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -728,7 +728,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -744,7 +744,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "2eccf8b9643cd244125cd69b2453db09ae642a2514e1237541e24086a17347bc",
+      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
       "since": "2025-01-01"
     },
     "cli:init": {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2983,10 +2983,22 @@ export function createRoutes(ctx: RouteContext): Router {
         enabled: !!ctx.publisher,
         pageCount: ctx.publisher?.listPages().length ?? 0,
         warning: 'Telegraph pages are PUBLIC — anyone with the URL can view them.',
+        endpoints: ctx.publisher ? [
+          'POST /publish — publish markdown as a public Telegraph page',
+          'GET /published — list all published pages',
+          'PUT /publish/:pagePath — edit a published page',
+        ] : [],
       },
       privateViewer: {
         enabled: !!ctx.viewer,
         viewCount: ctx.viewer?.list().length ?? 0,
+        endpoints: ctx.viewer ? [
+          'POST /view — create a private auth-gated HTML view',
+          'GET /views — list all private views',
+          'GET /view/:viewId — render a private view (HTML)',
+          'PUT /view/:viewId — update a view',
+          'DELETE /view/:viewId — delete a view',
+        ] : [],
       },
       tunnel: {
         enabled: !!ctx.tunnel,
@@ -2996,6 +3008,22 @@ export function createRoutes(ctx: RouteContext): Router {
       },
       users: {
         count: userCount,
+      },
+      secrets: {
+        // Secret Drop — secure one-time-link credential intake from users.
+        // Surfaced explicitly because /capabilities is the documented
+        // self-discovery primitive (per the Self-Discovery section of the
+        // CLAUDE.md template). Agents that don't see this block here will
+        // reach for unsafe channels (chat paste, env vars) instead.
+        enabled: true,
+        pending: secretDrop.listPending().length,
+        endpoints: [
+          'POST /secrets/request — create a one-time submission link',
+          'GET /secrets/pending — list pending submissions',
+          'POST /secrets/retrieve/:token — retrieve a submitted secret (one-time read)',
+          'DELETE /secrets/pending/:token — cancel a pending request',
+        ],
+        retrievalHint: 'When retrieving, ALWAYS use .instar/scripts/secret-drop-retrieve.mjs — it streams the value to stdout without ever printing the response body. The raw curl pattern leaks the secret into the Bash tool transcript.',
       },
       topicMemory: {
         enabled: !!ctx.topicMemory,
@@ -3102,6 +3130,50 @@ export function createRoutes(ctx: RouteContext): Router {
       attentionQueue: {
         enabled: true,
         hint: 'Use POST /attention to signal important items to the user.',
+      },
+      commitments: {
+        // CommitmentTracker — lifecycle for "I'll do X" promises. Used by
+        // PromiseBeacon for follow-through monitoring. Agent-facing.
+        enabled: true,
+        endpoints: [
+          'GET /commitments — list commitments (filterable)',
+          'GET /commitments/:id — fetch a single commitment',
+          'POST /commitments — open a new commitment',
+          'PATCH /commitments/:id — update status/details',
+          'POST /commitments/:id/deliver — mark delivered',
+          'POST /commitments/:id/withdraw — withdraw the commitment',
+          'POST /commitments/:id/resume — resume a paused commitment',
+          'GET /commitments/active-context — assemble active-commitment context',
+        ],
+      },
+      semantic: {
+        // SemanticMemory — successor to the deprecated /memory endpoint.
+        // Vector + graph store for episodic and structured memory.
+        enabled: true,
+        endpoints: [
+          'POST /semantic/remember — store a memory',
+          'GET /semantic/recall/:id — fetch a memory by id',
+          'GET /semantic/search?q=... — semantic search',
+          'GET /semantic/search/hybrid?q=... — hybrid (vector + keyword) search',
+          'POST /semantic/connect — link two memories',
+          'GET /semantic/explore/:id — graph traversal from a memory',
+          'POST /semantic/verify/:id — mark a memory verified',
+          'POST /semantic/supersede — replace one memory with another',
+          'GET /semantic/stale — list stale memories',
+          'GET /semantic/stats — store statistics',
+          'GET /semantic/context — assembled context for a prompt',
+        ],
+      },
+      tokens: {
+        // TokenLedger — read-only token-usage observability over Claude Code
+        // JSONL transcripts. Never gates or mutates source files.
+        enabled: true,
+        endpoints: [
+          'GET /tokens/summary — aggregate token usage',
+          'GET /tokens/sessions — per-session token usage',
+          'GET /tokens/by-project — usage grouped by project',
+          'GET /tokens/orphans — sessions with no project binding',
+        ],
       },
       skipLedger: {
         enabled: true,

--- a/tests/unit/capabilities-discoverability.test.ts
+++ b/tests/unit/capabilities-discoverability.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Capabilities Discoverability — every route prefix must be discoverable.
+ *
+ * The CLAUDE.md template instructs agents: "Before EVER saying 'I don't have'
+ * or 'this isn't available' — check what actually exists: curl /capabilities.
+ * It is the source of truth about what you can do."
+ *
+ * That promise is only true if /capabilities actually enumerates every
+ * primitive the server exposes. Without enforcement, primitives slip through:
+ * Secret Drop shipped with full routes (POST /secrets/request, /secrets/retrieve,
+ * /secrets/pending, DELETE /secrets/pending/:token), got documented in
+ * the CLAUDE.md template, but was never added to the /capabilities response
+ * body. Agents that trusted /capabilities as authoritative reached for unsafe
+ * credential-intake workarounds because the discovery primitive lied.
+ *
+ * This lint catches that class of regression structurally. It walks routes.ts
+ * for every top-level prefix (`/secrets`, `/views`, etc.) and asserts each
+ * either appears in the /capabilities response body or is on the explicit
+ * INTERNAL_ALLOWLIST below.
+ *
+ * Adding a new prefix that is neither surfaced nor allowlisted will fail this
+ * test until the author makes a deliberate choice about discoverability.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const routesSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/server/routes.ts'),
+  'utf-8',
+);
+
+/**
+ * Endpoints that are intentionally not surfaced in /capabilities. These are
+ * meta endpoints (health checks, the capabilities route itself), internal
+ * RPCs called only by other instar processes, or deprecated/internal-only
+ * routes. Adding to this list is a deliberate choice — every entry should
+ * have a one-line reason after it.
+ */
+const INTERNAL_ALLOWLIST: ReadonlyArray<string> = [
+  'health',          // basic liveness check, no auth
+  'ping',            // synchronous noop, used by tunnel/lifeline probes
+  'whoami',          // internal identity probe (sentinel/relay layer 1c)
+  'capabilities',    // the discovery endpoint itself — surfacing would recurse
+  'internal',        // internal-only IPC namespace
+  'pastes',          // internal Claude Code paste-callback receiver
+  'listener',        // internal heartbeat/listener wiring
+  'events',          // internal SSE/event-stream
+  'config',          // global config CRUD used by setup/migrator
+  'status',          // legacy status endpoint, superseded by /capabilities
+  'shared-state',    // legacy state primitive, superseded by canonicalState
+  'backups',         // backup listing is operator-only, not agent-facing
+  'episodes',        // legacy episode log, replaced by topicMemory
+  'reflection',      // legacy reflection log, replaced by topicMemory
+  'serendipity',     // operator review surface, not agent-facing
+  'system-review',   // legacy system review log, replaced by responseReview
+  'system-reviews',  // legacy system review log, replaced by responseReview
+  'systems',         // legacy systems registry, replaced by canonicalState.projects
+  'memory',          // deprecated (Deprecation/Sunset headers) → /semantic
+  'messaging',       // alternative surface for /telegram, /imessage, etc.
+  'messages',        // legacy direct message access
+  'providers',       // legacy provider registry, replaced by autonomy
+  'quota',           // operator-only quota observability
+  'watchdog',        // operator-only watchdog state
+  'telemetry',       // operator-only telemetry plumbing
+  'homeostasis',     // operator-only homeostasis state
+  'agents',          // surfaced via threadline discovery
+  'delivery-queue',  // operator-only relay queue observability
+  'prompt-gate',     // operator-only prompt-gate observability
+  'scope-coherence', // operator-only scope-coherence observability
+  'jobs',            // surfaced inside the `scheduler` block
+  'slack',           // surfaced via messaging adapters
+  'whatsapp',        // surfaced via messaging adapters
+  'flows',           // surfaced inside `evolution` subsystems
+  'initiatives',     // surfaced inside `evolution` subsystems
+  'triage',          // surfaced inside `evolution` subsystems
+  'intent',          // surfaced inside `evolution` subsystems
+  'self-knowledge',  // surfaced inside `capability-map`
+  'capability-map',  // separate self-knowledge surface, has its own discovery path
+  'projects',        // surfaced inside `canonicalState`
+  'build',           // operator-only build endpoint
+  'sessions',        // operator/dashboard-only session listing (no agent-facing API)
+];
+
+/**
+ * Extract all top-level path prefixes registered on `router.*('/<prefix>...')`.
+ * Top-level = the first path segment after the leading slash.
+ */
+function extractTopLevelPrefixes(source: string): Set<string> {
+  const prefixes = new Set<string>();
+  const pattern = /router\.(get|post|put|delete|patch)\s*\(\s*['"]\/([a-z][a-z0-9-]*)/g;
+  let match;
+  while ((match = pattern.exec(source)) !== null) {
+    prefixes.add(match[2]);
+  }
+  return prefixes;
+}
+
+/**
+ * Extract the literal /capabilities response body — the object passed to
+ * `res.json({...})` inside the GET /capabilities handler. Used as the source
+ * of truth for what /capabilities surfaces.
+ */
+function extractCapabilitiesBody(source: string): string {
+  const handlerStart = source.indexOf("router.get('/capabilities'");
+  if (handlerStart < 0) throw new Error('GET /capabilities handler not found');
+  const resJsonStart = source.indexOf('res.json(', handlerStart);
+  if (resJsonStart < 0) throw new Error('res.json call not found in /capabilities handler');
+  // Walk forward until the matching close paren (depth-1 in res.json call).
+  // The body is the {…} between res.json( and the matching ).
+  const openBrace = source.indexOf('{', resJsonStart);
+  if (openBrace < 0) throw new Error('Opening brace not found in /capabilities res.json');
+  let depth = 0;
+  for (let i = openBrace; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(openBrace, i + 1);
+    }
+  }
+  throw new Error('Could not find matching close brace for /capabilities res.json body');
+}
+
+describe('Capabilities Discoverability', () => {
+  const prefixes = extractTopLevelPrefixes(routesSource);
+  const capabilitiesBody = extractCapabilitiesBody(routesSource);
+
+  it('extracts a non-trivial set of route prefixes (sanity)', () => {
+    expect(prefixes.size).toBeGreaterThan(30);
+  });
+
+  it('Secret Drop (`/secrets`) is surfaced in /capabilities', () => {
+    // This is the regression that prompted the lint. It MUST stay green.
+    expect(capabilitiesBody).toMatch(/POST \/secrets\/(request|retrieve)/);
+  });
+
+  for (const prefix of [...prefixes].sort()) {
+    it(`prefix "/${prefix}" is either surfaced in /capabilities or in INTERNAL_ALLOWLIST`, () => {
+      if (INTERNAL_ALLOWLIST.includes(prefix)) {
+        // Allowlist hit — deliberate skip. Make sure the entry isn't dead by
+        // re-confirming the prefix is registered (which we already did when
+        // building `prefixes`).
+        expect(prefixes.has(prefix)).toBe(true);
+        return;
+      }
+      // Look for the prefix in the /capabilities response body. Three shapes
+      // count as "surfaced":
+      //   1. An explicit endpoint string ("GET /<prefix>") in any endpoints array
+      //   2. A JSON-style key ("<prefix>:") opening a discoverability block
+      //   3. ES shorthand reference ("\b<prefix>,") — e.g. `res.json({ telegram, ... })`
+      const escaped = prefix.replace(/-/g, '\\-');
+      const endpointPattern = new RegExp(
+        `(GET|POST|PUT|DELETE|PATCH)\\s+\\/${escaped}(\\b|/)`,
+      );
+      const keyPattern = new RegExp(`["']?${escaped}["']?\\s*:`);
+      const shorthandPattern = new RegExp(`(^|\\s)${escaped}\\s*,`, 'm');
+      const surfaced =
+        endpointPattern.test(capabilitiesBody) ||
+        keyPattern.test(capabilitiesBody) ||
+        shorthandPattern.test(capabilitiesBody);
+
+      expect(
+        surfaced,
+        `Route prefix "/${prefix}" is registered in routes.ts but is NOT surfaced in the /capabilities ` +
+          `response and is NOT on the INTERNAL_ALLOWLIST. Either add an endpoint entry inside the appropriate ` +
+          `block of res.json({...}) in the GET /capabilities handler, or add "${prefix}" to INTERNAL_ALLOWLIST ` +
+          `in tests/unit/capabilities-discoverability.test.ts with a one-line reason.`,
+      ).toBe(true);
+    });
+  }
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,43 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+<!-- minor = new agent-facing capability without breaking changes -->
+
+## What Changed
+
+**feat(server): `/capabilities` now actually enumerates the primitives it claims to know about — and a lint locks the promise structurally.**
+
+The agent CLAUDE.md template tells every new agent: *"Before EVER saying 'I don't have' or 'this isn't available' — check what actually exists: `curl /capabilities`. It is the source of truth about what you can do."* That promise was silently false. `GET /capabilities` is a hand-curated object literal in `routes.ts`, and several agent-facing primitives lived as registered routes without ever appearing in the response:
+
+- **Secret Drop** — the safe-channel credential intake (`POST /secrets/request`, `/secrets/retrieve/:token`, `/secrets/pending`, `DELETE /secrets/pending/:token`). Agents that trusted `/capabilities` as authoritative reached for chat-paste / env-var workarounds because the discovery primitive didn't list it.
+- **CommitmentTracker** — `/commitments/*` CRUD that feeds PromiseBeacon.
+- **TokenLedger** — `/tokens/{summary,sessions,by-project,orphans}` for token-usage observability.
+- **SemanticMemory** — `/semantic/*`, the successor to the deprecated `/memory` endpoint.
+- **Private Viewer endpoints** — `POST /view`, `GET /views`, `GET/PUT/DELETE /view/:viewId` were behind a block that only reported a count.
+- **Telegraph publishing endpoints** — `POST /publish`, `GET /published`, `PUT /publish/:pagePath` were behind a block that only reported a count and a warning.
+
+This release surfaces all of the above in `/capabilities` with full endpoint listings, including a hardening note on the `secrets` block pointing at `.instar/scripts/secret-drop-retrieve.mjs` as the safe retrieval helper (raw `curl` against `/secrets/retrieve` leaks the secret into the Bash transcript).
+
+The structural enforcement is a new unit test, `tests/unit/capabilities-discoverability.test.ts`, that walks `src/server/routes.ts` for every top-level route prefix and asserts each either appears in the `/capabilities` response body or is on an explicit `INTERNAL_ALLOWLIST` with a one-line reason. Adding a new route prefix that is neither surfaced nor allowlisted will fail CI until the author makes a deliberate choice about discoverability.
+
+## What to Tell Your User
+
+No user-visible behavior change. Agents will, however, become more accurate about what they can do: when asked "can you do X?" they will read their live self-discovery surface first, and that surface now actually lists the full picture. The most visible improvement is that agents will reach for Secret Drop when a user needs to share a credential, instead of falling back to "paste it in chat" or "put it in an env var."
+
+## Summary of New Capabilities
+
+For the agent: the same primitives existed before, but they were only discoverable by reading the CLAUDE.md template — a ~1500-line document that is easy to skim past. Now they are first-class entries in the live `/capabilities` response.
+
+Quick check from an agent session:
+
+```bash
+curl -s -H "Authorization: Bearer $AUTH" http://localhost:$INSTAR_PORT/capabilities | jq '.secrets, .commitments, .tokens, .semantic, .privateViewer.endpoints, .publishing.endpoints'
+```
+
+## Evidence
+
+The discoverability gap was reproduced before the fix: `curl /capabilities | jq 'keys'` on v1.1.4 returned a 25-key object with no `secrets`, `commitments`, `tokens`, or `semantic` blocks, and `.privateViewer` / `.publishing` exposed only counts. After the fix, the same call returns all six blocks with explicit endpoint listings.
+
+The new lint test was verified end-to-end: with the `secrets` block removed from the response, `npx vitest run tests/unit/capabilities-discoverability.test.ts` fails with a precise error pointing the author at the missing entry; with the block restored, all 81 tests pass.
+
+Origin: case study seeded into topic 11141 ("🔍 Discoverability Secret Access") on 2026-05-20, root-cause audit on 2026-05-21.

--- a/upgrades/side-effects/capabilities-discoverability.md
+++ b/upgrades/side-effects/capabilities-discoverability.md
@@ -1,0 +1,116 @@
+# Side-Effects Review — Capabilities Discoverability
+
+**Version / slug:** `capabilities-discoverability`
+**Date:** `2026-05-21`
+**Author:** `Echo (instar-developing agent)`
+**Second-pass reviewer:** `not required` (additive observability change with no decision-point surface)
+
+## Summary of the change
+
+Surfaces six previously-invisible primitives in the `GET /capabilities` response — `secrets`, `commitments`, `tokens`, `semantic`, plus explicit endpoint arrays on the existing `publishing` and `privateViewer` blocks. Adds a new unit test `tests/unit/capabilities-discoverability.test.ts` that walks `src/server/routes.ts` for every top-level route prefix and asserts each either appears in the `/capabilities` response body or is on an explicit `INTERNAL_ALLOWLIST` with a one-line reason.
+
+Files touched:
+
+- `src/server/routes.ts` — six additive blocks inside the existing `GET /capabilities` handler.
+- `src/data/builtin-manifest.json` — regenerated content hashes for the `route-group` entries that cover routes.ts.
+- `tests/unit/capabilities-discoverability.test.ts` — new lint test.
+- `upgrades/NEXT.md` — release notes.
+- `docs/specs/capabilities-discoverability.md` + `docs/specs/capabilities-discoverability.eli16.md` — spec + ELI16 companion.
+
+## Decision-point inventory
+
+- `GET /capabilities` response body — **modify (additive)** — the agent's authoritative self-discovery surface. Six new fields added; no existing field removed or shape-changed.
+- New lint test — **add** — fails CI if any route prefix isn't either surfaced or allowlisted. No runtime block authority.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. The runtime change is pure response-body enrichment. The lint test only blocks at CI when a new route prefix is registered without a discoverability decision being made; that's the intent.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The lint asserts each prefix appears *somewhere* in the response body. It does NOT verify the surfaced entries actually match the live routes — a typo in the endpoint listing string ("POST /secrtes/request") would slip through. This is the minimum-viable bar; a follow-up could compare the endpoint strings against the actual registered routes. Tracked but not blocking.
+
+The lint also does not catch the case where a route prefix exists, is allowlisted as "surfaced inside X block," but X block was later removed. The allowlist is comment-anchored, not code-anchored. Acceptable because each allowlist entry has a one-line reason; reviewer catches drift on the next PR that touches X.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+The runtime change is at the right layer: it enriches a response handler that already exists, no new module needed. The lint is at the right layer: a unit test that parses source, no server runtime needed, fast enough to run on every push.
+
+The deferred follow-up (introspecting `/capabilities` from `FeatureRegistry` + live router) would be a refactor at a higher layer — replacing the hand-curated object literal with a derivation. That's the right home for a future PR but would balloon scope here.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface at runtime.
+
+The lint test holds CI-time block authority (it can fail a build), but that authority is delegated to a human reviewer + branch-protection rules; the lint itself just emits a signal. The runtime change is pure observability — no decision point is gated on the new fields.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** the `/capabilities` response is consumed by agents, by the dashboard, by `feature-delivery-completeness.test.ts`, and by `SeedMigration.test.ts`. All consumers do field-presence checks, not exact-shape assertions; additive fields are safe. Verified by running the full unit suite — no new failures introduced.
+- **Double-fire:** no overlap with other checks; `/capabilities` is a single read endpoint.
+- **Races:** no shared state introduced.
+- **Feedback loops:** none. The response is read-only.
+
+The new lint test reads `src/server/routes.ts` and the `INTERNAL_ALLOWLIST` literal. Its only "interaction" is with future PRs that add route prefixes — the lint will fail loudly until those PRs either surface or allowlist the new prefix. That's the intent.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Agents on the same machine:** yes — agents will see additional fields in `/capabilities`. All new fields are nested under new keys (`secrets`, `commitments`, etc.) or are new keys (`endpoints`) on existing nested objects. No existing key changes shape. Agents that ignore unknown keys continue to work; agents that iterate keys now see more capabilities, which is the intended behavior.
+- **Other users / install base:** no behavioral change. The next release will publish the enlarged response.
+- **External systems:** no external surface touched.
+- **Persistent state:** none — `/capabilities` is a read endpoint, no writes.
+- **Timing / runtime conditions:** the new blocks include `secretDrop.listPending().length` and reads of `ctx.publisher?.listPages()`, `ctx.viewer?.list()`. All three are cheap in-memory reads that the response already touched. No new latency surface.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Pure code change. Revert the two files (`src/server/routes.ts` and the new test) and the manifest will regenerate on the next build. No persistent state, no agent-state repair needed.
+
+User-visible regression during rollback window: the new `/capabilities` fields would disappear, and any agent that had started relying on them in the meantime would see a temporary loss of discoverability for those primitives. The primitives themselves keep working — only the discovery surface contracts.
+
+Realistic rollback cost: under 5 minutes, single revert + patch release. No downtime.
+
+---
+
+## Conclusion
+
+This is a low-risk additive observability change. It closes a structural-honesty gap in the agent's self-discovery surface and locks the promise with a lint that catches future regressions. The runtime change is pure response enrichment with no decision-point surface; the lint is a signal-only test that delegates block authority to the CI gate. Two follow-ups are explicitly deferred and tracked in the spec. No second-pass review required.
+
+---
+
+## Evidence pointers
+
+- Spec: `docs/specs/capabilities-discoverability.md`
+- ELI16: `docs/specs/capabilities-discoverability.eli16.md`
+- Repro of the gap (pre-fix): `curl /capabilities | jq 'keys'` on v1.1.4 returns no `secrets`, `commitments`, `tokens`, or `semantic` blocks.
+- Repro of the fix: the new unit test passes 81/81 with the additions in place; removing the `secrets` block from the response makes the corresponding test fail with a precise error pointing the author at the missing entry.
+- Origin: topic 11141 ("🔍 Discoverability Secret Access"), case study seeded 2026-05-20.


### PR DESCRIPTION
## Summary

- The CLAUDE.md template tells every agent to trust `GET /capabilities` as the authoritative self-discovery surface. The promise was silently false — Secret Drop, CommitmentTracker, TokenLedger, SemanticMemory, and the Telegraph/PrivateViewer endpoint listings all existed as registered routes but were absent from the response body. When an agent needed credential intake in the 2026-05-20 incident, it reached for unsafe channels because the discovery primitive didn't list the safe one.
- Surfaces the missing primitives in `/capabilities` (with a hardening note on `secrets` pointing at the safe retrieval helper).
- Adds `tests/unit/capabilities-discoverability.test.ts` — a lint that walks every top-level route prefix in `routes.ts` and asserts each either appears in the response body or is on an explicit `INTERNAL_ALLOWLIST` with a one-line reason. Locks the promise structurally for future primitives.

Origin: topic 11141 ("🔍 Discoverability Secret Access"), seeded 2026-05-20, audit 2026-05-21.

Spec: `docs/specs/capabilities-discoverability.md` (converged + approved)
ELI16: `docs/specs/capabilities-discoverability.eli16.md`
Side-effects: `upgrades/side-effects/capabilities-discoverability.md`

## Test plan

- [x] `npx vitest run tests/unit/capabilities-discoverability.test.ts` — 81/81 pass (was 9 failing before the surfacing changes; lint catches the gap).
- [x] Pre-push smoke (821 test files / 16553 tests) passed.
- [x] `npx tsc --noEmit` clean.
- [x] Existing `/capabilities` integration tests (`tests/integration/view-tunnel-routes.test.ts`, `tests/integration/publishing-routes.test.ts`) unchanged and passing — additions are purely additive.
- [ ] CI green.

Two pre-existing test failures (`tests/unit/esm-compliance.test.ts`, `tests/unit/no-silent-fallbacks.test.ts`) exist on `upstream/main` and are unchanged by this PR. They are not in the pre-push smoke set; they are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)