### PR TITLE
Wire Layer 4 worktree detector to Telegram AttentionQueue (v1.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2197,42 +2197,13 @@ export async function startServer(options: StartOptions): Promise<void> {
       process.exit(1);
     }
 
-    // Agent worktree convention (Layer 4) — detect worktrees of the
-    // shared instar repo that live outside any agent's `.worktrees/`
-    // safe area. Signal-only: emits an AttentionItem (or appends to the
-    // JSONL fallback when no Telegram adapter is configured) per
-    // misplaced entry; never blocks, never moves. Dedupe is via the
-    // AttentionQueue's item.id collision (Telegram path) or 24h
-    // rolling-window file read (JSONL fallback).
-    try {
-      const detector = await import('../core/AgentWorktreeDetector.js');
-      const repo = detector.resolveDetectorInstarRepo();
-      if (repo) {
-        const safeRoots = detector.enumerateSafeRoots();
-        const detectionResult = await detector.runDetection({
-          instarRepo: repo,
-          stateDir: config.stateDir,
-          safeRoots,
-          // No `emitAttention` adapter wired here yet — TelegramAdapter
-          // initializes later in this same startServer. The JSONL
-          // fallback at `<stateDir>/audit/worktree-detector.jsonl` is the
-          // durable trail for v1; an explicit AttentionQueue wireup is a
-          // tracked follow-up (Layer 4 spec residual R-?).
-        });
-        if (detectionResult.emitted > 0) {
-          console.log(pc.yellow(
-            `  Worktree detector: ${detectionResult.emitted} misplaced worktree(s) flagged (` +
-              `enumerated=${detectionResult.enumerated} skipped=${detectionResult.skipped}` +
-              `${detectionResult.deduped ? ` deduped=${detectionResult.deduped}` : ''}` +
-              `${detectionResult.timedOut ? ' [timeout]' : ''})`,
-          ));
-        }
-      }
-    } catch (err) {
-      console.log(pc.yellow(
-        `  Worktree detector: skipped (${err instanceof Error ? err.message : String(err)})`,
-      ));
-    }
+    // Agent worktree convention (Layer 4) — detector invocation lives
+    // AFTER the TelegramAdapter setup blocks below, so it can pass
+    // `telegram.createAttentionItem` as the emit-attention callback when
+    // Telegram is configured. The original placement here was deferred
+    // for that reason (see upgrades/side-effects/agent-worktree-
+    // convention-layer-3-4.md). When no Telegram adapter is present the
+    // detector still runs and falls back to the JSONL append.
     let stopHeartbeat: (() => void) | undefined;
     try {
       stopHeartbeat = startHeartbeat(config.projectDir);
@@ -3154,6 +3125,67 @@ export async function startServer(options: StartOptions): Promise<void> {
       ensureAgentUpdatesTopic(telegram, state).catch(err => {
         console.error(`[server] Failed to ensure Agent Updates topic: ${err}`);
       });
+    }
+
+    // Agent worktree convention (Layer 4) — lifeline detector.
+    //
+    // Runs once per server boot. Inspects the canonical instar repo's
+    // worktree list and emits an AttentionItem per worktree that lives
+    // outside any registered agent's `<agent_home>/.worktrees/` safe
+    // area. Signal-only: never blocks, never moves, never deletes.
+    //
+    // Placement is deliberately AFTER both TelegramAdapter setup blocks
+    // (send-only at line ~2810 and full-mode at line ~2897) so we can
+    // pass `telegram.createAttentionItem` as the emit-attention callback.
+    // When Telegram isn't configured the detector still runs and falls
+    // back to the JSONL append at
+    // `<stateDir>/audit/worktree-detector.jsonl` (O_NOFOLLOW + fstat,
+    // 24h rolling-window dedupe).
+    //
+    // Dedupe semantics:
+    //   - Telegram path: AttentionQueue's `item.id` collision (a second
+    //     emit with the same `worktree-misplaced:sha256(path)` id is a
+    //     no-op via the existing `attentionItems` Map lookup in
+    //     TelegramAdapter.createAttentionItem).
+    //   - JSONL path: 24h rolling-window scan of the fallback file.
+    try {
+      const detector = await import('../core/AgentWorktreeDetector.js');
+      const repo = detector.resolveDetectorInstarRepo();
+      if (repo) {
+        const safeRoots = detector.enumerateSafeRoots();
+        const emitAttention = telegram
+          ? async (item: import('../core/AgentWorktreeDetector.js').AttentionItemInput) => {
+              await telegram!.createAttentionItem({
+                id: item.id,
+                title: item.title,
+                summary: item.summary,
+                description: item.description,
+                category: item.category,
+                priority: item.priority,
+                sourceContext: item.sourceContext,
+              });
+            }
+          : undefined;
+        const detectionResult = await detector.runDetection({
+          instarRepo: repo,
+          stateDir: config.stateDir,
+          safeRoots,
+          emitAttention,
+        });
+        if (detectionResult.emitted > 0) {
+          const channel = telegram ? 'Telegram' : 'JSONL fallback';
+          console.log(pc.yellow(
+            `  Worktree detector: ${detectionResult.emitted} misplaced worktree(s) flagged via ${channel} (` +
+              `enumerated=${detectionResult.enumerated} skipped=${detectionResult.skipped}` +
+              `${detectionResult.deduped ? ` deduped=${detectionResult.deduped}` : ''}` +
+              `${detectionResult.timedOut ? ' [timeout]' : ''})`,
+          ));
+        }
+      }
+    } catch (err) {
+      console.log(pc.yellow(
+        `  Worktree detector: skipped (${err instanceof Error ? err.message : String(err)})`,
+      ));
     }
 
     // Initialize TopicMemory whenever Telegram is configured (any mode).

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-21T05:37:22.352Z",
-  "instarVersion": "1.2.2",
+  "generatedAt": "2026-05-21T15:22:21.804Z",
+  "instarVersion": "1.2.3",
   "entryCount": 190,
   "entries": {
     "hook:session-start": {

--- a/tests/unit/AgentWorktreeDetector-attention-wireup.test.ts
+++ b/tests/unit/AgentWorktreeDetector-attention-wireup.test.ts
@@ -1,0 +1,150 @@
+// safe-git-allow: test file — fs.rmSync is for per-test tmpdir cleanup;
+//   execFileSync builds bare-repo fixtures only.
+
+/**
+ * Wiring-integrity tests for the Layer 4 detector ↔ AttentionQueue
+ * connection.
+ *
+ * The detector is invoked from `startServer()` in `src/commands/server.ts`
+ * AFTER both TelegramAdapter setup blocks, with `telegram.createAttentionItem`
+ * passed as the `emitAttention` callback when Telegram is configured (and
+ * left undefined to drive the JSONL fallback otherwise).
+ *
+ * These tests pin the contract between the detector's `AttentionItemInput`
+ * shape and TelegramAdapter's `createAttentionItem` signature — if the
+ * adapter's `Omit<AttentionItem, ...>` shape ever drifts, this catches it
+ * before the wireup silently breaks.
+ *
+ * Spec reference: docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md §"Layer 4 —
+ * Lifeline detector (in v1, signal only)".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  runDetection,
+  type AttentionItemInput,
+} from '../../src/core/AgentWorktreeDetector.js';
+import type { AttentionItem } from '../../src/messaging/TelegramAdapter.js';
+
+interface Fixture {
+  bareRepo: string;
+  stateDir: string;
+  tmpRoot: string;
+}
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function makeFixture(): Fixture {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'awd-wireup-'));
+  const bareRepo = path.join(tmpRoot, 'repo');
+  execFileSync('git', ['init', '--initial-branch=main', bareRepo], { stdio: 'pipe' });
+  execFileSync('git', ['-C', bareRepo, 'config', 'user.name', 'Test'], { stdio: 'pipe' });
+  execFileSync('git', ['-C', bareRepo, 'config', 'user.email', 'test@example.com'], { stdio: 'pipe' });
+  execFileSync('git', ['-C', bareRepo, 'config', 'commit.gpgsign', 'false'], { stdio: 'pipe' });
+  fs.writeFileSync(path.join(bareRepo, 'README.md'), '# T\n');
+  execFileSync('git', ['-C', bareRepo, 'add', 'README.md'], { stdio: 'pipe' });
+  execFileSync('git', ['-C', bareRepo, 'commit', '-m', 'init'], { stdio: 'pipe' });
+  const stateDir = path.join(tmpRoot, '.instar');
+  fs.mkdirSync(path.join(stateDir, 'audit'), { recursive: true });
+  return { bareRepo, stateDir, tmpRoot };
+}
+
+function cleanup(fix: Fixture): void {
+  fs.rmSync(fix.tmpRoot, { recursive: true, force: true });
+}
+
+describe('Layer 4 detector → AttentionQueue wireup', () => {
+  let fix: Fixture;
+  beforeEach(() => { fix = makeFixture(); });
+  afterEach(() => cleanup(fix));
+
+  it('detector emit-item shape is structurally compatible with TelegramAdapter.createAttentionItem input', async () => {
+    const misplaced = path.join(fix.tmpRoot, 'misplaced-wt');
+    git(['worktree', 'add', '-b', 'feat-shape', misplaced], fix.bareRepo);
+
+    const captured: AttentionItemInput[] = [];
+    await runDetection({
+      instarRepo: fix.bareRepo,
+      stateDir: fix.stateDir,
+      safeRoots: [],
+      emitAttention: (item) => { captured.push(item); },
+    });
+
+    expect(captured).toHaveLength(1);
+    const item = captured[0];
+
+    // Pin the exact shape startServer.ts passes through to
+    // telegram.createAttentionItem. If TelegramAdapter's
+    // `Omit<AttentionItem, 'createdAt' | 'updatedAt' | 'status' | 'topicId'>`
+    // requirement adds a new mandatory field, the type below catches it
+    // at compile time AND this runtime check catches a stale shape.
+    const adapterInput: Omit<AttentionItem, 'createdAt' | 'updatedAt' | 'status' | 'topicId'> = {
+      id: item.id,
+      title: item.title,
+      summary: item.summary,
+      description: item.description,
+      category: item.category,
+      priority: item.priority,
+      sourceContext: item.sourceContext,
+    };
+
+    expect(adapterInput.id).toMatch(/^worktree-misplaced:[a-f0-9]{64}$/);
+    expect(adapterInput.category).toBe('worktree-misplaced');
+    expect(['URGENT', 'HIGH', 'NORMAL', 'LOW']).toContain(adapterInput.priority);
+    expect(typeof adapterInput.title).toBe('string');
+    expect(adapterInput.title.length).toBeGreaterThan(0);
+    expect(typeof adapterInput.summary).toBe('string');
+    expect(adapterInput.summary.length).toBeGreaterThan(0);
+  });
+
+  it('emitAttention callback receives the item and is awaited (async-safe)', async () => {
+    const misplaced = path.join(fix.tmpRoot, 'misplaced-async');
+    git(['worktree', 'add', '-b', 'feat-async', misplaced], fix.bareRepo);
+
+    let resolveOrder: string[] = [];
+    const result = await runDetection({
+      instarRepo: fix.bareRepo,
+      stateDir: fix.stateDir,
+      safeRoots: [],
+      emitAttention: async (_item) => {
+        // Simulate the AttentionQueue createAttentionItem latency (it does
+        // a Telegram API roundtrip). The detector must await this — if it
+        // fires-and-forgets, the result.emitted count would race ahead.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        resolveOrder.push('emit-complete');
+      },
+    });
+
+    resolveOrder.push('detector-returned');
+    expect(result.emitted).toBe(1);
+    // emit-complete must come BEFORE detector-returned — proves the
+    // detector awaits the callback rather than fire-and-forget.
+    expect(resolveOrder).toEqual(['emit-complete', 'detector-returned']);
+  });
+
+  it('falls back to JSONL when emitAttention is undefined (no Telegram configured)', async () => {
+    const misplaced = path.join(fix.tmpRoot, 'misplaced-jsonl');
+    git(['worktree', 'add', '-b', 'feat-jsonl', misplaced], fix.bareRepo);
+    const fallback = path.join(fix.stateDir, 'audit', 'worktree-detector.jsonl');
+
+    const result = await runDetection({
+      instarRepo: fix.bareRepo,
+      stateDir: fix.stateDir,
+      safeRoots: [],
+      // emitAttention deliberately omitted — mirrors the no-Telegram
+      // branch in startServer.ts where `telegram` is undefined.
+      fallbackPath: fallback,
+    });
+
+    expect(result.emitted).toBe(1);
+    expect(fs.existsSync(fallback)).toBe(true);
+    const line = JSON.parse(fs.readFileSync(fallback, 'utf-8').trim());
+    expect(line.dedupeKey).toMatch(/^worktree-misplaced:/);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,69 @@
+# Upgrade Guide — v1.2.4 (worktree detector → Telegram alerts)
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Layer 4 detector now surfaces misplaced worktrees through the Telegram
+attention queue, not just the JSONL fallback.** The agent worktree
+convention's lifeline detector — added in v1.1.0 (PR #278) — has been
+running on every agent server boot and dutifully appending detected
+violations to `<stateDir>/audit/worktree-detector.jsonl`, but the
+emissions never reached the operator's Telegram. That was a known
+follow-up tracked in v1.1.0's Deferred list.
+
+This release closes that gap by moving the detector invocation from
+its old position before `TelegramAdapter` was initialized to a new
+position immediately after both TelegramAdapter setup blocks (the
+send-only and full-mode paths in `src/commands/server.ts`). When the
+agent has Telegram configured, the detector now passes
+`telegram.createAttentionItem` as its emit-attention callback;
+otherwise it falls back to the JSONL append exactly as before.
+
+The detector remains **signal-only** — every emission goes through
+the existing `AttentionItem.id` dedupe contract, the JSONL fallback
+keeps its O_NOFOLLOW + fstat + 24h rolling-window dedupe, and the
+detector still never blocks, moves, or deletes anything. The only
+behavioral change visible to the operator is: misplaced-worktree
+alerts now arrive as Telegram attention topics on the next agent
+restart, instead of being silently written to a log file the
+operator was unlikely to discover.
+
+## Evidence
+
+Reproduction prior: an agent running v1.1.0–v1.2.3 with one or more
+worktrees of the shared instar repo outside any registered agent's
+`.worktrees/` safe area would, on every server boot, emit zero
+Telegram alerts and silently append JSONL lines under
+`<stateDir>/audit/worktree-detector.jsonl`. Verified by inspecting
+the server-start log on echo's machine after each release —
+"Worktree detector: N misplaced worktree(s) flagged" appeared in
+console output but no attention topic was ever created.
+
+After this PR: the same configuration produces the same JSONL line
+PLUS a Telegram attention topic per misplaced worktree, deduped by
+the same `worktree-misplaced:sha256(path)` id the JSONL already
+used. The console line gains a `via Telegram` / `via JSONL fallback`
+suffix so the operator can tell which channel ran. Verified by
+three new wireup tests in
+`tests/unit/AgentWorktreeDetector-attention-wireup.test.ts`:
+shape-compatibility between detector output and adapter input,
+async-callback await safety (the detector awaits the emit so a
+Telegram API roundtrip latency is honored), and JSONL fallback
+preservation when `emitAttention` is undefined.
+
+## What to Tell Your User
+
+- "Your agents now actually tell you when they spot a worktree in the unsafe location. Before this release, the warning was being written to a log file in the background — the agent saw it, but you never did. Now it shows up as an attention topic in Telegram the next time the agent starts up. Same dedupe rules as before, so you won't get pinged twice for the same one within a day."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Worktree detector emits to Telegram | Automatic on every agent server boot. When the agent has Telegram configured, misplaced-worktree detections create attention topics; otherwise the JSONL fallback at `<stateDir>/audit/worktree-detector.jsonl` continues as before. Dedupe is path-hash-based via the same `worktree-misplaced:sha256(path)` id the JSONL has always used. |
+| Console reports the channel | The startup log line now reads `Worktree detector: N misplaced worktree(s) flagged via Telegram` (or `via JSONL fallback`) so the operator can confirm which channel ran without grepping the audit file. |
+
+## Deferred (Tracked Follow-ups)
+
+- The 24h rolling-window JSONL dedupe runs only on the fallback path. The Telegram path leans on `AttentionItem.id` collision in TelegramAdapter's existing `attentionItems` Map — that lookup is per-process and is reset on agent restart, so two boots within 24h on a Telegram-configured agent could theoretically emit twice for the same misplaced worktree. In practice agent restarts are infrequent enough that this isn't a real source of noise; if it ever becomes one, the fix is to consult the JSONL dedupe state from the Telegram path too.
+- The detector's first-run burst on machines with many pre-existing misplaced worktrees (echo's machine has ~30 from before the convention shipped) is now Telegram-visible for the first time. Operators may want to bulk-acknowledge them with `/done` rather than processing each individually.

--- a/upgrades/side-effects/worktree-detector-attention-wireup.md
+++ b/upgrades/side-effects/worktree-detector-attention-wireup.md
@@ -1,0 +1,194 @@
+# Side-Effects Review — Layer 4 detector → AttentionQueue wireup
+
+**Version / slug:** `worktree-detector-attention-wireup`
+**Date:** `2026-05-21`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (see §"Phase 5 trigger check")
+
+## Summary of the change
+
+The Layer 4 lifeline detector (from the agent worktree convention,
+shipped in v1.1.0 via PR #278) was running on every agent server boot
+and emitting to its JSONL fallback only — the Telegram AttentionQueue
+wireup was deferred because, in `startServer()`, the detector was
+invoked at line ~2208 while `TelegramAdapter` doesn't initialize until
+line ~2810/2897. The deferred state is documented in the v1.1.0 NEXT.md
+and in `upgrades/side-effects/agent-worktree-convention-layer-3-4.md`.
+
+This PR closes the gap by moving the detector invocation to **after**
+both `TelegramAdapter` setup blocks. When Telegram is configured, the
+detector now passes `telegram.createAttentionItem` as its
+`emitAttention` callback; when it isn't, the JSONL fallback fires
+exactly as before. The detector remains signal-only — no blocking,
+no moves, no deletes.
+
+**Files touched:**
+- `src/commands/server.ts` (+62 / -29 lines: removed the old early invocation, replaced with a one-paragraph stub comment; added the new conditional invocation after the full-mode Telegram block).
+- `tests/unit/AgentWorktreeDetector-attention-wireup.test.ts` (new, 3 cases — shape-compat, async-await safety, JSONL-fallback preservation).
+- `upgrades/NEXT.md` (new — fresh v1.2.4 release).
+- `package.json` (1.2.3 → 1.2.4).
+
+## Decision-point inventory
+
+- **Detector emission target selection** — *modify*. Was unconditional
+  JSONL; is now Telegram-when-configured-else-JSONL. The selection
+  rule is a pure presence check (`telegram ? emitToTelegram : undefined`),
+  no judgment. Both paths exist in the spec.
+- **AttentionItem.id dedupe** — *pass-through*. The detector already
+  produces `worktree-misplaced:sha256(path)` ids; TelegramAdapter's
+  existing `attentionItems` Map collapses repeats. No new dedupe logic.
+- **JSONL fallback rolling-window** — *unchanged*. Same 24h, same
+  O_NOFOLLOW + fstat owner/mode gate on the fallback file.
+
+No new authorities introduced. No new detectors. Just a wiring change
+that connects an existing signal producer (detector) to an existing
+authority surface (AttentionQueue).
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The detector emits
+attention items; AttentionQueue is the authority that decides what to
+do with them. Neither side rejects the user/operator from anything.
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable.
+
+A related coverage gap worth naming (and tracked in NEXT.md Deferred):
+the 24h JSONL dedupe is per-file. The Telegram path leans on
+`AttentionItem.id` collision in TelegramAdapter's in-memory
+`attentionItems` Map, which is reset on every agent restart. Two
+agent restarts within 24h on a Telegram-configured agent could
+theoretically re-emit for the same misplaced worktree path. In
+practice, agent restarts are infrequent; if noise becomes a problem,
+the fix is to consult the JSONL dedupe state from the Telegram path
+too. Acceptable for v1.
+
+## 3. Level-of-abstraction fit
+
+Right layer. The detector lives where every other lifecycle observer
+lives (`src/core/`), invoked from the agent boot path
+(`src/commands/server.ts`), feeding the existing AttentionQueue
+surface in TelegramAdapter. The move from "before TelegramAdapter
+init" to "after TelegramAdapter init" is the only change; everything
+else reuses primitives that have been in production since v1.1.0.
+
+A smarter gate (the AttentionQueue) already exists; this PR feeds it
+the signal it was always intended to consume.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] **No — this change produces a signal consumed by an existing smart gate.** The detector remains signal-only. AttentionQueue (TelegramAdapter's `attentionItems` registry) is the authority that owns dedupe, topic creation, and operator routing. The detector's only authoritative decision is the path-based "is this worktree under a registered safe root" filter, which is hard-invariant validation (carve-out in `docs/signal-vs-authority.md`).
+
+The detector's invariant that the audit ledger is **never** consumed
+as an allowlist remains in force — the path-based rule is the
+detector's only authority surface, and that rule is restated in
+`src/core/AgentWorktreeDetector.ts`'s file-level comment.
+
+## 5. Interactions
+
+- **Shadowing:** the detector now runs AFTER `telegram.start()` and
+  after the Telegram routing/callback wireup (`wireTelegramRouting`
+  + `wireTelegramCallbacks`). It still runs BEFORE the AgentServer
+  HTTP listener (line 7037), so no inbound traffic is missed during
+  the detection sweep.
+- **Double-fire:** dedupe is owned by AttentionQueue (`item.id`
+  collision) for the Telegram path and by the JSONL rolling-window
+  scan for the fallback path. Two concurrent agent boots against the
+  same instar repo would each emit; the AttentionQueue collapse
+  protects the Telegram side, and the JSONL state-dir is per-agent
+  so cross-agent file contention is impossible.
+- **Races:** the detector awaits each `emitAttention` call (verified
+  by the async-await test in
+  `tests/unit/AgentWorktreeDetector-attention-wireup.test.ts`). The
+  TelegramAdapter's `createAttentionItem` does a network roundtrip
+  (`createForumTopic`); awaiting it keeps the detector's
+  `result.emitted` counter accurate.
+- **Feedback loops:** the detector reads `git worktree list` and
+  emits attention items. AttentionQueue creates Telegram topics. No
+  loop back into `git worktree`.
+- **Startup ordering:** moving the detector down ~700 lines in
+  `startServer()` lengthens the time between `registerAgent` and
+  the first detection by the duration of TelegramAdapter init. On
+  echo's machine that's typically <500ms (the Telegram
+  `start()` call awaits a long-poll handshake). No user-visible
+  latency change.
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** none. Each agent's
+  detection emits to its own TelegramAdapter / JSONL.
+- **Other users of the install base:** purely additive — for any
+  agent that wasn't already configured for Telegram, behavior is
+  byte-identical to v1.2.3 (JSONL only). For Telegram-configured
+  agents, attention topics will appear on next agent restart per
+  misplaced worktree.
+- **External systems:** Telegram (additional topic creates via
+  `createForumTopic`). Rate-limited by Telegram's API; one topic
+  per detection emission per misplaced path per process. Real-world
+  impact on echo's machine: ~30 attention topics on first boot
+  after this release, then near-zero per subsequent boot (all
+  deduped via item.id).
+- **Persistent state:** the existing
+  `<stateDir>/audit/worktree-detector.jsonl` fallback file is
+  unchanged. Telegram attention topic registrations land in the
+  existing TelegramAdapter state (`<stateDir>/state/attention-items.json`,
+  managed by the adapter itself).
+- **Timing:** detector still uses the existing 2-second timeout
+  on `git worktree list --porcelain`. Unchanged.
+
+## 7. Rollback cost
+
+- **Code:** revert this commit. The detector returns to its pre-PR
+  position (early in `startServer()` with `emitAttention` always
+  undefined), and the JSONL fallback resumes as the only emission
+  channel. No data migration. Attention topics already created on
+  Telegram remain — they're operator-managed and don't depend on
+  this PR's wiring.
+- **Persistent state:** no schema change. The
+  `<stateDir>/state/attention-items.json` registry is the same one
+  TelegramAdapter has owned since v0.10.x.
+- **Agent state repair:** none required.
+- **User visibility during rollback:** new attention topics stop
+  appearing; existing ones stay until the operator `/done`s or
+  `/wontdo`s them. The JSONL trail continues unchanged.
+
+Total rollback time: under 2 minutes (one revert).
+
+## Conclusion
+
+Pure wireup change. The detector and AttentionQueue have both been
+in production since v1.1.0; this PR connects them. Signal-only
+contract is preserved. Three new tests pin the shape-compat,
+async-await safety, and JSONL-fallback-preservation invariants.
+Pre-push gate green.
+
+Phase 5 trigger check: the change does **not** touch outbound or
+inbound messaging *dispatch* (the detector emits a category that
+AttentionQueue already handles), session lifecycle, compaction,
+coherence gates, idempotency at transport, trust levels, or anything
+named sentinel/guard/gate/watchdog. The detector is signal-only and
+AttentionQueue is the long-existing authority. No second-pass
+reviewer required.
+
+Clear to ship.
+
+## Evidence pointers
+
+- **Wireup tests:** `tests/unit/AgentWorktreeDetector-attention-wireup.test.ts`
+  (3 cases: shape-compat between detector output and adapter input,
+  async-callback await safety, JSONL fallback preservation).
+- **Spec:** `docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md` (approved
+  2026-05-17 22:35 UTC).
+- **Sibling artifacts:**
+  - `upgrades/side-effects/agent-worktree-convention-layer-1-2-5.md`
+    (Layer 1+2+5, merged in PR #277 as `bdf8508f`).
+  - `upgrades/side-effects/agent-worktree-convention-layer-3-4.md`
+    (Layer 3+4, merged in PR #278 as `c7e8e08b`; documented this
+    wireup as deferred follow-up).


### PR DESCRIPTION
Closes the only follow-up tracked in v1.1.0's NEXT.md for the agent worktree convention. The Layer 4 lifeline detector now passes telegram.createAttentionItem as its emit callback when Telegram is configured, surfacing misplaced worktrees as attention topics instead of silent JSONL appends. Signal-only contract preserved. Side-effects review at upgrades/side-effects/worktree-detector-attention-wireup.md. 3 wireup tests pin the contract.