### PR TITLE
feat(secret-drop): ship hardened retrieve helper template + retire unsafe curl from every agent-facing surface

### DIFF
--- a/docs/specs/secret-drop-hardened-retrieve-template.eli16.md
+++ b/docs/specs/secret-drop-hardened-retrieve-template.eli16.md
@@ -1,0 +1,58 @@
+# Hardened Secret Drop Retrieval — Plain-English Overview
+
+> The one-line version: every place in instar that told an agent how to fetch a submitted password was teaching the leaky way, and now they all teach the safe way.
+
+## The problem in one breath
+
+When a user types a password into a Secret Drop form, the agent needs to read that password to use it (run an unlock, set a GitHub secret, etc.). Until now, every documented retrieval path told the agent to use a plain `curl` request — but `curl` prints the whole response, including the password, to the terminal. The terminal output is what Claude Code records in its session transcript and what gets sent back to Anthropic on the next turn. So the moment the agent ran the documented command, the password was in the conversation history, the session log, and the API context — exactly the things Secret Drop was supposed to bypass.
+
+## What already exists
+
+- **Secret Drop itself.** The web form, the one-time link, the in-memory store, the 5-minute cleanup timer, the route that returns the submitted values. All of this works correctly.
+- **A hardened retrieve script.** Written by one agent after the 2026-05-20 incident, lives at `.instar/scripts/secret-drop-retrieve.mjs` on that one machine. It prints the field value to stdout in a way that pipes cleanly into other commands but never prints the rest of the response, so the password cannot accidentally land in a log.
+- **PR #290 (the previous follow-up).** Surfaced Secret Drop in `/capabilities` and added a one-line hint that pointed at the hardened script, but didn't give the actual command and didn't ship the script itself anywhere except the single machine that wrote it.
+
+## What this adds
+
+The hardened script becomes a first-class template that ships with every instar install. New agents get it on first `init`; existing agents get it the next time they run `instar update`. Every line of agent-facing guidance that previously taught the leaky `curl` pattern — the CLAUDE.md template, the spawn message the server injects when a Secret Drop arrives, the retry message when a submission goes unclaimed, the `/capabilities` hint — is rewritten to teach the hardened command instead. A migration patches existing agents' CLAUDE.md files in place, so even installs that were updated months ago will get the safer guidance on the next update.
+
+The agent-facing command form becomes:
+
+```
+node .instar/scripts/secret-drop-retrieve.mjs TOKEN field-name
+```
+
+For discovering what fields are available:
+
+```
+node .instar/scripts/secret-drop-retrieve.mjs TOKEN --names
+```
+
+For one-shot destructive read (the original behavior, now opt-in):
+
+```
+node .instar/scripts/secret-drop-retrieve.mjs TOKEN field-name --consume
+```
+
+## The new pieces
+
+- **`src/templates/scripts/secret-drop-retrieve.mjs`** — the hardened helper, now part of every instar install. Streams the field value to stdout via `process.stdout.write` (no newline, no rest-of-body), prints field names to stderr in `--names` mode, refuses to print the response body in any error path.
+- **`installSecretDropRetrieve` in `init.ts`** — the install hook called from three places mirroring how `installSerendipityCapture` is wired. Places the script under `.instar/scripts/` (framework-neutral, survives Claude-code reinstalls).
+- **`migrateScripts` block in `PostUpdateMigrator`** — always-overwrite the script on every update. Same pattern as `convergence-check.sh`. Idempotent.
+- **`migrateClaudeMd` block** — detects the legacy `curl /secrets/retrieve/TOKEN` line and rewrites it to the hardened guidance. Port-tolerant (matches any local port literal). Idempotent (already-hardened CLAUDE.md is skipped).
+
+## The safeguards
+
+**Prevents the documented path from being unsafe.** Every surface that teaches retrieval now teaches the hardened command. There is no documented path that leaks the response body. An agent that copies the documented command verbatim runs the safe one.
+
+**Prevents update-in-place agents from being left behind.** The migrator runs on every `instar update`. The script install is always-overwrite (security-critical → fresh content every time). The CLAUDE.md rewrite is port-tolerant so agents installed when the local port was 4040 get the same rewrite as agents installed when the local port was 4042. The idempotency check on the CLAUDE.md rewrite means double-runs don't double-write.
+
+**Prevents the new helper from accidentally printing the body.** The script uses `process.stdout.write(v)` for the value, never `console.log(body)`. The error path explicitly states "don't fall back to printing raw response body — that's the leak we're explicitly hardening against." The `--names` mode prints only field names + lengths to stderr; stdout stays empty. The default mode is peek (non-destructive), so an agent that botches the first attempt can retry without losing the submission.
+
+## What ships when
+
+One PR. The six surfaces ship together because they reference each other — patching one and leaving the others would leave an agent reading mixed guidance.
+
+## What you actually need to decide
+
+This PR closes failure #2 from the 2026-05-21 case study (the workaround-reflex / unsafe retrieve pattern). Failure #1 was closed by PR #290; failure #3 (introspecting `/capabilities` from `FeatureRegistry`) is the next follow-up. Ready to ship — anything else you want on this PR before merge?

--- a/docs/specs/secret-drop-hardened-retrieve-template.md
+++ b/docs/specs/secret-drop-hardened-retrieve-template.md
@@ -1,0 +1,85 @@
+---
+slug: secret-drop-hardened-retrieve-template
+title: Ship the hardened Secret Drop retrieve helper as a template; retire the unsafe curl pattern from all agent-facing surfaces
+review-convergence: 2026-05-21T07:00:00Z
+approved: true
+eli16-overview: secret-drop-hardened-retrieve-template.eli16.md
+---
+
+# Secret Drop Hardened Retrieve Template
+
+## Problem
+
+The 2026-05-20 incident exposed a credential-leak failure class. When an agent received a Secret Drop submission, every documented retrieval path instructed `curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:$PORT/secrets/retrieve/TOKEN`. That curl prints the full JSON response — which contains the secret in `values.<field>` — to the Bash tool's stdout. The stdout is captured in the Claude Code JSONL transcript, included in subsequent context windows, and sent to Anthropic's API as part of the conversation. The secret leaks the moment it is retrieved.
+
+After the incident, a hardened helper (`secret-drop-retrieve.mjs`) was written on one agent's machine. It streams the requested field value to stdout, prints field NAMES + lengths to stderr, and structurally refuses to print the response body. The helper closes the leak class — but only for that one agent. Every other instar agent still runs the unsafe pattern because:
+
+1. The helper is not in `src/templates/scripts/`, so `init` does not install it for new agents.
+2. There is no `PostUpdateMigrator` entry installing it for existing agents.
+3. The CLAUDE.md template at `src/scaffold/templates.ts:430` still documents the raw curl pattern as the canonical retrieval form.
+4. The spawn message injected into agent sessions on Secret Drop submission (`src/server/routes.ts`, the `[secret-drop-received]` system message) instructs the agent to run the raw curl.
+5. The stuck-consumer retry message in `secretDrop.onStuckConsumer` also instructs the raw curl.
+6. The `secrets.retrievalHint` in the `/capabilities` response (shipped in PR #290) names the hardened helper but does not give the exact command form.
+
+## Approach
+
+Six interlocking changes, one PR:
+
+1. **`src/templates/scripts/secret-drop-retrieve.mjs`** — ship the hardened helper as a canonical template. Reads `authToken` + `port` from `.instar/config.json` at runtime; no init-time port substitution needed (the script is Node, not bash). `INSTAR_PORT` env var overrides the config port for parity with `telegram-reply.sh`.
+
+2. **`src/commands/init.ts`** — add `installSecretDropRetrieve(projectDir)` that mirrors `installSerendipityCapture`. Call from the three existing init paths next to the serendipity install.
+
+3. **`src/core/PostUpdateMigrator.ts`** (`migrateScripts`) — always-overwrite `.instar/scripts/secret-drop-retrieve.mjs` on every update run. Same pattern as `convergence-check.sh`: generated infrastructure, not user-edited. The always-overwrite is intentional because the helper is security-relevant — a stale copy that printed the body would defeat the purpose.
+
+4. **`src/server/routes.ts` spawn message** (`[secret-drop-received]`) — replace the `curl -s -X POST .../secrets/retrieve/TOKEN` instruction with `node .instar/scripts/secret-drop-retrieve.mjs TOKEN <field-name>`. Include `--names` for field discovery, explicit `--consume` for opt-in destructive read, and a one-line explicit warning that raw curl leaks.
+
+5. **`src/server/routes.ts` stuck-consumer retry message** (`[secret-drop-stuck]`) — same hardened command form.
+
+6. **CLAUDE.md template** (`src/scaffold/templates.ts`) and **`migrateClaudeMd`** — rewrite the Secret Drop documentation block to lead with the hardened helper. The migrator detects the legacy `curl /secrets/retrieve/TOKEN` line via a port-tolerant regex and replaces it. Idempotent: a CLAUDE.md that already documents `secret-drop-retrieve.mjs` is skipped.
+
+The `/capabilities` `secrets.retrievalHint` is updated to give the exact command form so an agent reading `/capabilities` learns the safe pattern directly from the discovery surface.
+
+## Non-goals
+
+- Refactor `/capabilities` to introspect from `FeatureRegistry` + the live router. Tracked separately as follow-up #2.
+- Add a server-side check that refuses raw retrieve requests from clients without a hardened-client header. The signal-vs-authority principle keeps the server permissive; the agent-side hardening is the right layer.
+
+## Acceptance criteria
+
+- `src/templates/scripts/secret-drop-retrieve.mjs` exists and is executable. It honors `--names`, `--consume`, and the default peek mode. It uses `process.stdout.write(v)` (not `console.log`) and structurally cannot print the response body.
+- `init.ts` writes `.instar/scripts/secret-drop-retrieve.mjs` for new agents at all three install paths.
+- `PostUpdateMigrator.migrateScripts` writes the file for existing agents on every update run; output is identical on repeat runs.
+- `PostUpdateMigrator.migrateClaudeMd` rewrites the legacy retrieval line to the hardened guidance. Idempotent; port-tolerant.
+- The `[secret-drop-received]` and `[secret-drop-stuck]` system messages in `routes.ts` instruct the hardened helper and explicitly warn against the raw curl pattern.
+- The CLAUDE.md template (`generateClaudeMd`) documents the hardened helper as the required retrieval form.
+- `/capabilities.secrets.retrievalHint` gives the exact `node .instar/scripts/secret-drop-retrieve.mjs TOKEN field-name` command.
+- Tier 1 tests (`tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts`) cover script install + CLAUDE.md rewrite, 8 cases.
+
+## Decision points touched
+
+- `[secret-drop-received]` system message — **modify** — the structural prompt the agent reads to learn how to retrieve. Changed from unsafe to hardened pattern.
+- `[secret-drop-stuck]` system message — **modify** — same change for the retry path.
+- CLAUDE.md template + migrator — **modify** — the static guidance an agent reads on session start.
+- `/capabilities.secrets.retrievalHint` — **modify** — make the recommendation actionable (full command form).
+
+No new gate/block authority introduced. The server's `/secrets/retrieve` endpoint behavior is unchanged. The hardening lives at the agent-facing instruction layer, which is the right level: agents read guidance to learn safe patterns, and the only way to enforce a safe pattern is to make it the documented one across every surface the agent reads from.
+
+## Migration
+
+- Hooks: no change.
+- Settings: no change.
+- Config defaults: no change.
+- CLAUDE.md sections: existing Secret Drop block is rewritten in place via port-tolerant regex.
+- Hook scripts: no change.
+- Built-in skills: no change.
+- New script template: `.instar/scripts/secret-drop-retrieve.mjs` installed by `migrateScripts` (always-overwrite).
+
+## Rollback
+
+Pure code change. Revert the migrator + init + templates diff; the previously-shipped helper on existing agents stays (we don't delete during rollback). Agents that had the unsafe pattern restored in CLAUDE.md by an erroneous rollback would resume the leak — so any rollback should explicitly re-ship the hardened guidance before reverting the migrator.
+
+## Origin
+
+2026-05-20 incident (topic 9984): unsafe `curl /secrets/retrieve` leaked Bitwarden master password into the Claude Code JSONL transcript and downstream Anthropic API context.
+
+2026-05-21 case-study audit (topic 11141): identified three compounding failures. Failure #1 (discoverability) was closed by PR #290 (capabilities-discoverability spec). This spec closes failure #2 (workaround reflex / unsafe retrieve pattern across every agent-facing surface).

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -397,6 +397,8 @@ async function initFreshProject(projectName: string, options: InitOptions): Prom
   // Framework-neutral: always install. Lives in .instar/scripts/.
   installSerendipityCapture(projectDir);
   console.log(`  ${pc.green('✓')} Created .instar/scripts/serendipity-capture.sh`);
+  installSecretDropRetrieve(projectDir);
+  console.log(`  ${pc.green('✓')} Created .instar/scripts/secret-drop-retrieve.mjs`);
 
   // Create .claude/skills/ directory and install built-in skills (gated)
   if (claudeEnabled) {
@@ -780,6 +782,8 @@ async function initExistingProject(options: InitOptions): Promise<void> {
   // Framework-neutral: always install. Lives in .instar/scripts/.
   installSerendipityCapture(projectDir);
   console.log(pc.green('  Created:') + ' .instar/scripts/serendipity-capture.sh');
+  installSecretDropRetrieve(projectDir);
+  console.log(pc.green('  Created:') + ' .instar/scripts/secret-drop-retrieve.mjs');
 
   // Create .claude/skills/ directory and install built-in skills (gated)
   if (claudeEnabled) {
@@ -3565,6 +3569,7 @@ function refreshScripts(projectDir: string, stateDir: string): void {
   // Always install serendipity-capture.sh (lives in `.instar/scripts/`,
   // framework-neutral).
   installSerendipityCapture(projectDir);
+  installSecretDropRetrieve(projectDir);
 }
 
 /**
@@ -4342,6 +4347,44 @@ function installSerendipityCapture(projectDir: string): void {
 
   if (!scriptContent) {
     // Non-fatal: skip if template not found (e.g., during development)
+    return;
+  }
+
+  fs.writeFileSync(scriptPath, scriptContent, { mode: 0o755 });
+}
+
+/**
+ * Install the hardened Secret Drop retrieve helper. Streams the requested
+ * field value to stdout WITHOUT ever printing the response body — the
+ * structural guard against the 2026-05-20 leak class where a raw curl
+ * against /secrets/retrieve dumped the full JSON (including credentials)
+ * into the Bash tool transcript.
+ *
+ * Lives under .instar/scripts/ so it ships outside the .claude/ tree that
+ * may get reset on framework reinstall. The mjs script reads authToken +
+ * port from .instar/config.json at runtime; no port substitution needed.
+ */
+function installSecretDropRetrieve(projectDir: string): void {
+  const scriptsDir = path.join(projectDir, '.instar', 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+
+  const scriptPath = path.join(scriptsDir, 'secret-drop-retrieve.mjs');
+
+  const modDir = __dirname;
+  const candidates = [
+    path.resolve(modDir, '..', 'templates', 'scripts', 'secret-drop-retrieve.mjs'),
+    path.resolve(modDir, '..', '..', 'src', 'templates', 'scripts', 'secret-drop-retrieve.mjs'),
+  ];
+
+  let scriptContent = '';
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      scriptContent = fs.readFileSync(candidate, 'utf-8');
+      break;
+    }
+  }
+
+  if (!scriptContent) {
     return;
   }
 

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2348,6 +2348,38 @@ The user has been talking to you (possibly for days). A generic greeting like "H
       result.skipped.push('CLAUDE.md: File Viewer section already present');
     }
 
+    // Secret Drop hardened retrieve — patch the unsafe `curl /secrets/retrieve/TOKEN`
+    // line if it's still in the user's CLAUDE.md. Fresh inits get the hardened
+    // guidance via generateClaudeMd; existing agents updating in place keep the
+    // old unsafe instruction unless we rewrite it here. Idempotent: skips if
+    // the user already has the hardened helper documented.
+    if (
+      content.includes('Retrieve the secret:') &&
+      content.includes('secrets/retrieve/TOKEN') &&
+      !content.includes('secret-drop-retrieve.mjs')
+    ) {
+      const oldLine =
+        `- Retrieve the secret: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/secrets/retrieve/TOKEN\``;
+      const newBlock =
+        `- **Retrieve the secret (HARDENED — required)**: \`node .instar/scripts/secret-drop-retrieve.mjs TOKEN field-name\` — streams the field VALUE to stdout, prints field NAMES + lengths to stderr, NEVER prints the response body. Pipe directly: \`node .instar/scripts/secret-drop-retrieve.mjs TOKEN password | gh secret set FOO\`. Discover available fields with \`... TOKEN --names\`.\n- **NEVER use \`curl /secrets/retrieve\` directly** — the raw curl pattern dumps the full JSON response (including the secret value) into the Bash tool transcript. The hardened script exists specifically to close that leak class (origin: 2026-05-20 incident).`;
+      if (content.includes(oldLine)) {
+        content = content.replace(oldLine, newBlock);
+        patched = true;
+        result.upgraded.push('CLAUDE.md: rewrote Secret Drop retrieval to hardened helper');
+      } else {
+        // Older agents may have a slightly different port literal in the
+        // line — match on the stable substring and replace the whole line.
+        const lineRegex = /- Retrieve the secret:.*\/secrets\/retrieve\/TOKEN`/;
+        if (lineRegex.test(content)) {
+          content = content.replace(lineRegex, newBlock);
+          patched = true;
+          result.upgraded.push('CLAUDE.md: rewrote Secret Drop retrieval to hardened helper (port-tolerant)');
+        }
+      }
+    } else if (content.includes('secret-drop-retrieve.mjs')) {
+      result.skipped.push('CLAUDE.md: Secret Drop already documents hardened helper');
+    }
+
     // Worktree Convention section (Migration Parity Standard backfill for
     // Layer 2 of the agent worktree convention — fresh inits get this via
     // generateClaudeMd; existing agents get it here on update).
@@ -2600,6 +2632,27 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       result.upgraded.push('scripts/convergence-check.sh (pre-messaging quality gate)');
     } catch (err) {
       result.errors.push(`convergence-check.sh: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    // Secret Drop hardened retrieve helper — always overwrite. Security-
+    // critical: the raw curl pattern against /secrets/retrieve leaks the
+    // value into the Bash tool transcript (2026-05-20 incident class). The
+    // hardened mjs streams the field value to stdout and never prints the
+    // response body. Existing agents must get the helper without waiting
+    // for a manual install. Custom forks land at custom/secret-drop-* paths
+    // and are untouched by this overwrite.
+    try {
+      const retrieveContent = this.loadRelayTemplate('secret-drop-retrieve.mjs');
+      if (retrieveContent) {
+        fs.writeFileSync(
+          path.join(instarScriptsDir, 'secret-drop-retrieve.mjs'),
+          retrieveContent,
+          { mode: 0o755 },
+        );
+        result.upgraded.push('scripts/secret-drop-retrieve.mjs (hardened Secret Drop retrieval)');
+      }
+    } catch (err) {
+      result.errors.push(`secret-drop-retrieve.mjs: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-21T15:22:21.804Z",
-  "instarVersion": "1.2.3",
-  "entryCount": 190,
+  "generatedAt": "2026-05-21T16:05:40.700Z",
+  "instarVersion": "1.2.4",
+  "entryCount": 191,
   "entries": {
     "hook:session-start": {
       "id": "hook:session-start",
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -720,7 +720,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -728,7 +728,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -744,7 +744,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "6c19b445bbf110caa476b8a54386ca8c83e3061fc28a7f291a0f15642f956283",
+      "contentHash": "de2d5dabf08599cfb7bfe454145369fc09fa511018231989c37117f45e237d44",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1115,6 +1115,14 @@
       "contentHash": "2e3f78d72a00a56a9bae9dfe0af0ecc48557e5af2cd59fc6435356784c8e6796",
       "since": "2025-01-01"
     },
+    "template:secret-drop-retrieve.mjs": {
+      "id": "template:secret-drop-retrieve.mjs",
+      "type": "template",
+      "domain": "operations",
+      "sourcePath": "src/templates/scripts/secret-drop-retrieve.mjs",
+      "contentHash": "2acc881ce53c879047f0e98b9afd5c66f293c48046c62fff8587123078145c98",
+      "since": "2025-01-01"
+    },
     "template:serendipity-capture.sh": {
       "id": "template:serendipity-capture.sh",
       "type": "template",
@@ -1464,7 +1472,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "808fbff652a75bc43ece5a00aa1f6d2ab1753d085c7ca75b3b3db6cea63a39ee",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -427,7 +427,8 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - Request a secret: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/secrets/request -H 'Content-Type: application/json' -d '{"label":"OpenAI API Key","description":"Needed for GPT integration","topicId":TOPIC_ID}'\`
 - The response includes a one-time URL (\`localUrl\` and \`tunnelUrl\`). Send this link to the user.
 - When the user submits the secret through the form, you receive a Telegram confirmation in the specified topic.
-- Retrieve the secret: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/secrets/retrieve/TOKEN\`
+- **Retrieve the secret (HARDENED — required)**: \`node .instar/scripts/secret-drop-retrieve.mjs TOKEN field-name\` — streams the field VALUE to stdout, prints field NAMES + lengths to stderr, NEVER prints the response body. Pipe directly: \`node .instar/scripts/secret-drop-retrieve.mjs TOKEN password | gh secret set FOO\`. Discover available fields with \`... TOKEN --names\`.
+- **NEVER use \`curl /secrets/retrieve\` directly** — the raw curl pattern dumps the full JSON response (including the secret value) into the Bash tool transcript. The hardened script exists specifically to close that leak class (origin: 2026-05-20 incident).
 - List pending: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/secrets/pending\`
 - Cancel: \`curl -X DELETE -H "Authorization: Bearer $AUTH" http://localhost:${port}/secrets/pending/TOKEN\`
 - **Security**: One-time use, expires after 15 minutes, in-memory only (never written to disk), CSRF-protected.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -3023,7 +3023,7 @@ export function createRoutes(ctx: RouteContext): Router {
           'POST /secrets/retrieve/:token — retrieve a submitted secret (one-time read)',
           'DELETE /secrets/pending/:token — cancel a pending request',
         ],
-        retrievalHint: 'When retrieving, ALWAYS use .instar/scripts/secret-drop-retrieve.mjs — it streams the value to stdout without ever printing the response body. The raw curl pattern leaks the secret into the Bash tool transcript.',
+        retrievalHint: 'ALWAYS retrieve via `node .instar/scripts/secret-drop-retrieve.mjs TOKEN field-name` (use `--names` to discover fields). It streams the value to stdout and NEVER prints the response body. Raw curl against /secrets/retrieve dumps the secret into the Bash tool transcript — do not use it.',
       },
       topicMemory: {
         enabled: !!ctx.topicMemory,
@@ -8200,7 +8200,8 @@ export function createRoutes(ctx: RouteContext): Router {
     const systemMsg = `[secret-drop-stuck] Secret "${event.label}" was submitted but has not been consumed by an agent process. ` +
       `If you weren't expecting this, the consumer may have hit a bug. ` +
       `The submission will auto-clean in ~${event.minutesUntilCleanup} minute(s). ` +
-      `To retry, re-read it (non-destructive): curl -s -X POST -H "Authorization: Bearer $AUTH" http://localhost:${ctx.config.port}/secrets/retrieve/${event.token}.`;
+      `To retry, use the hardened helper (non-destructive): node .instar/scripts/secret-drop-retrieve.mjs ${event.token} <field-name>. ` +
+      `Discover field names with --names. DO NOT use raw curl against /secrets/retrieve.`;
     try {
       const sdRegistryPath = path.join(ctx.config.stateDir, 'topic-session-registry.json');
       let targetSession: string | null = null;
@@ -8336,8 +8337,10 @@ export function createRoutes(ctx: RouteContext): Router {
       const fieldCount = Object.keys(submission.values).length;
       const fieldNames = Object.keys(submission.values).join(', ');
       const systemMsg = `[secret-drop-received] Secret "${submission.label}" was just submitted (${fieldCount} field${fieldCount !== 1 ? 's' : ''}: ${fieldNames}). ` +
-        `Retrieve (non-destructive — safe to retry on parse error): curl -s -X POST -H "Authorization: Bearer $AUTH" http://localhost:${ctx.config.port}/secrets/retrieve/${req.params.token}. ` +
-        `When you have successfully handed off the value, consume it: append ?consume=true to the same URL. ` +
+        `Retrieve with the HARDENED helper (streams field value to stdout, never prints the response body): node .instar/scripts/secret-drop-retrieve.mjs ${req.params.token} <field-name>. ` +
+        `Discover field names with: node .instar/scripts/secret-drop-retrieve.mjs ${req.params.token} --names. ` +
+        `Default is non-destructive (safe to retry); append --consume after successful handoff. ` +
+        `DO NOT use raw curl against /secrets/retrieve — that pattern leaks the value into the Bash tool transcript. ` +
         `Then acknowledge receipt to the user conversationally via Telegram topic ${topicId}.`;
 
       const sdRegistryPath = path.join(ctx.config.stateDir, 'topic-session-registry.json');

--- a/src/templates/scripts/secret-drop-retrieve.mjs
+++ b/src/templates/scripts/secret-drop-retrieve.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * secret-drop-retrieve.mjs — fetch a Secret Drop submission and stream the
+ * requested field value to stdout WITHOUT ever printing the response body.
+ * All informational output goes to stderr and is limited to field NAMES,
+ * lengths, and HTTP status — never values.
+ *
+ * Hardened replacement for the ad-hoc `curl + jq` / `curl + python` pattern
+ * that historically leaked credentials in plaintext into the Bash tool
+ * transcript. The lesson: when probing an unknown JSON shape, NEVER fall
+ * back to `console.log(JSON.stringify(body))` — that's how plaintext
+ * credentials end up in shell history, session transcripts, and downstream
+ * LLM context.
+ *
+ * Usage:
+ *   node .instar/scripts/secret-drop-retrieve.mjs <token> <field-name>
+ *     → prints the field value to stdout (single line, no trailing newline)
+ *     → suitable for piping: `... password | gh secret set X`
+ *
+ *   node .instar/scripts/secret-drop-retrieve.mjs <token> --names
+ *     → prints field names + lengths to stderr; nothing to stdout
+ *     → use to discover what fields the submission contains
+ *
+ *   node .instar/scripts/secret-drop-retrieve.mjs <token> <field> --consume
+ *     → opt into one-shot semantics (the submission is removed after read).
+ *     Default is peek (non-destructive) per the 2026-05-20 hardening.
+ *
+ * Config:
+ *   Reads `authToken` and `port` from `.instar/config.json` relative to cwd.
+ *   `INSTAR_PORT` env var overrides the config port.
+ *
+ * Exit codes:
+ *   0 — value or names printed successfully
+ *   1 — HTTP error, missing field, or unexpected response shape
+ *   2 — usage error (missing args, cannot read config)
+ */
+
+import * as fs from 'node:fs';
+
+const args = process.argv.slice(2);
+const token = args[0];
+const mode = args[1];
+const consume = args.includes('--consume');
+
+if (!token || !mode || mode === '--consume') {
+  process.stderr.write('usage: secret-drop-retrieve.mjs <token> <field-name|--names> [--consume]\n');
+  process.exit(2);
+}
+
+let authToken;
+let port;
+try {
+  const config = JSON.parse(fs.readFileSync('.instar/config.json', 'utf-8'));
+  authToken = config.authToken;
+  port = config.port;
+} catch (e) {
+  process.stderr.write('cannot read .instar/config.json: ' + e.message + '\n');
+  process.exit(2);
+}
+
+// Port resolution: env > config. Mirrors the telegram-reply.sh precedence
+// so a single explicit INSTAR_PORT override flows through every agent script.
+const resolvedPort = process.env.INSTAR_PORT || port;
+if (!resolvedPort) {
+  process.stderr.write('cannot resolve port: no INSTAR_PORT env and no port in .instar/config.json\n');
+  process.exit(2);
+}
+
+const url = `http://localhost:${resolvedPort}/secrets/retrieve/${token}${consume ? '?consume=true' : ''}`;
+const res = await fetch(url, {
+  method: 'POST',
+  headers: { 'Authorization': `Bearer ${authToken}` },
+});
+
+if (!res.ok) {
+  // Surface ONLY status + the structured error message field, never the body.
+  let errMsg = '(no error message)';
+  try {
+    const body = await res.json();
+    if (typeof body?.error === 'string') errMsg = body.error;
+  } catch {
+    // Don't fall back to printing raw response body — that's the leak we're
+    // explicitly hardening against. Just report the HTTP status.
+  }
+  process.stderr.write(`HTTP ${res.status}: ${errMsg}\n`);
+  process.exit(1);
+}
+
+const body = await res.json();
+
+// Locate the values bag. The server's known shape is body.values; defend
+// against future shape changes by checking the two most-likely nestings,
+// but NEVER print the body itself.
+const values = body?.values
+  ?? body?.submission?.values
+  ?? body?.fields
+  ?? null;
+
+if (!values || typeof values !== 'object') {
+  process.stderr.write('retrieve: response did not contain a values bag (keys at top: '
+    + Object.keys(body || {}).join(', ') + ')\n');
+  process.exit(1);
+}
+
+if (mode === '--names') {
+  // Field-name listing for debugging — names + lengths only, never values.
+  for (const k of Object.keys(values)) {
+    const v = values[k];
+    const len = typeof v === 'string' ? v.length : -1;
+    process.stderr.write(`  ${k} (length ${len})\n`);
+  }
+  process.exit(0);
+}
+
+const v = values[mode];
+if (typeof v !== 'string') {
+  process.stderr.write(`retrieve: field '${mode}' not found (available: `
+    + Object.keys(values).join(', ') + ')\n');
+  process.exit(1);
+}
+
+// Stream the value to stdout, no trailing newline so it pipes cleanly into
+// `gh secret set` or `bw unlock --raw`. process.stdout.write (not console.log)
+// — no extra newline, no trailing whitespace to confuse downstream consumers.
+process.stdout.write(v);

--- a/tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts
+++ b/tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Secret Drop hardened retrieve — migration coverage.
+ *
+ * Two slices:
+ *
+ * 1. migrateScripts installs `.instar/scripts/secret-drop-retrieve.mjs`
+ *    on every update run (always-overwrite, like convergence-check.sh).
+ *    This is the structural fix for the 2026-05-20 leak class — agents
+ *    that update in place must receive the hardened helper without
+ *    waiting for a re-init.
+ *
+ * 2. migrateClaudeMd rewrites the legacy unsafe `curl /secrets/retrieve/TOKEN`
+ *    line to the hardened command form. Idempotent: a CLAUDE.md that already
+ *    documents `secret-drop-retrieve.mjs` is left alone.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function createMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: true,
+    projectName: 'test-agent',
+  });
+}
+
+function runMigrateScripts(m: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (m as unknown as { migrateScripts(r: MigrationResult): void }).migrateScripts(result);
+  return result;
+}
+
+function runMigrateClaudeMd(m: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (m as unknown as { migrateClaudeMd(r: MigrationResult): void }).migrateClaudeMd(result);
+  return result;
+}
+
+describe('PostUpdateMigrator — Secret Drop hardened retrieve script install', () => {
+  let projectDir: string;
+  let retrievePath: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-secret-drop-retrieve-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    retrievePath = path.join(projectDir, '.instar', 'scripts', 'secret-drop-retrieve.mjs');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts',
+    });
+  });
+
+  it('installs .instar/scripts/secret-drop-retrieve.mjs on update', () => {
+    const result = runMigrateScripts(createMigrator(projectDir));
+    expect(result.errors).toEqual([]);
+    expect(fs.existsSync(retrievePath)).toBe(true);
+  });
+
+  it('the installed helper is executable', () => {
+    runMigrateScripts(createMigrator(projectDir));
+    const mode = fs.statSync(retrievePath).mode & 0o777;
+    expect(mode & 0o100).toBeTruthy(); // owner-execute bit set
+  });
+
+  it('the installed helper has the hardening guarantees baked in', () => {
+    runMigrateScripts(createMigrator(projectDir));
+    const content = fs.readFileSync(retrievePath, 'utf-8');
+    // Streams field value via process.stdout.write — never console.log the body.
+    expect(content).toMatch(/process\.stdout\.write\(v\)/);
+    // Never falls back to printing the raw response body.
+    expect(content).toMatch(/NEVER print the response body|never prints the response body|that's the leak we're/i);
+    // Honors --consume opt-in (default is peek per the 2026-05-20 hardening).
+    expect(content).toContain('--consume');
+  });
+
+  it('reports the install in the upgraded list', () => {
+    const result = runMigrateScripts(createMigrator(projectDir));
+    expect(result.upgraded.some(u => u.includes('secret-drop-retrieve.mjs'))).toBe(true);
+  });
+
+  it('is safe to re-run (always-overwrite, content unchanged)', () => {
+    runMigrateScripts(createMigrator(projectDir));
+    const first = fs.readFileSync(retrievePath, 'utf-8');
+    runMigrateScripts(createMigrator(projectDir));
+    const second = fs.readFileSync(retrievePath, 'utf-8');
+    expect(second).toBe(first);
+  });
+});
+
+describe('PostUpdateMigrator — CLAUDE.md Secret Drop rewrite', () => {
+  let projectDir: string;
+  let claudeMdPath: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-secret-drop-claudemd-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    claudeMdPath = path.join(projectDir, 'CLAUDE.md');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts',
+    });
+  });
+
+  it('rewrites the legacy curl line to the hardened helper form', () => {
+    const legacy = [
+      '# CLAUDE.md — test',
+      '',
+      '**Secret Drop** — secure secret intake.',
+      '- Request: ...',
+      '- Retrieve the secret: `curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:4042/secrets/retrieve/TOKEN`',
+      '- List pending: ...',
+      '',
+    ].join('\n');
+    fs.writeFileSync(claudeMdPath, legacy);
+
+    const result = runMigrateClaudeMd(createMigrator(projectDir));
+    expect(result.errors).toEqual([]);
+
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after).toContain('node .instar/scripts/secret-drop-retrieve.mjs');
+    expect(after).toContain('NEVER use `curl /secrets/retrieve`');
+    // The legacy unsafe line is gone.
+    expect(after).not.toMatch(/Retrieve the secret:.*curl.*\/secrets\/retrieve\/TOKEN/);
+    expect(result.upgraded.some(u => u.includes('hardened helper'))).toBe(true);
+  });
+
+  it('is idempotent — already-hardened Secret Drop section is left alone', () => {
+    const hardened = [
+      '# CLAUDE.md — test',
+      '',
+      '**Secret Drop** — secure secret intake.',
+      '- **Retrieve the secret (HARDENED — required)**: `node .instar/scripts/secret-drop-retrieve.mjs TOKEN field-name`',
+      '',
+    ].join('\n');
+    fs.writeFileSync(claudeMdPath, hardened);
+
+    const result = runMigrateClaudeMd(createMigrator(projectDir));
+    expect(result.errors).toEqual([]);
+
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    // The hardened line is preserved exactly — no double-rewrite.
+    expect(after).toContain('- **Retrieve the secret (HARDENED — required)**: `node .instar/scripts/secret-drop-retrieve.mjs TOKEN field-name`');
+    // The Secret Drop block was NOT touched by this migrator pass.
+    expect(result.upgraded.some(u => u.toLowerCase().includes('secret drop'))).toBe(false);
+    expect(result.skipped.some(s => s.includes('Secret Drop already documents hardened helper'))).toBe(true);
+  });
+
+  it('tolerates a port that does not match the agent\'s configured port', () => {
+    // Older agent installed when port was 4040; the line literal uses 4040,
+    // but the migrator now runs at 4042. The port-tolerant regex should
+    // still find and replace the line.
+    const legacy = [
+      '# CLAUDE.md — test',
+      '',
+      '**Secret Drop**',
+      '- Retrieve the secret: `curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:4040/secrets/retrieve/TOKEN`',
+      '',
+    ].join('\n');
+    fs.writeFileSync(claudeMdPath, legacy);
+
+    const result = runMigrateClaudeMd(createMigrator(projectDir));
+    expect(result.errors).toEqual([]);
+
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after).toContain('node .instar/scripts/secret-drop-retrieve.mjs');
+    expect(after).not.toMatch(/\/secrets\/retrieve\/TOKEN`/);
+    expect(result.upgraded.some(u => u.includes('hardened helper'))).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,56 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+<!-- minor = new agent-facing capability without breaking changes -->
+
+## What Changed
+
+**feat(secret-drop): ship the hardened retrieve helper as a template — and rewrite every line of agent guidance that previously taught the unsafe pattern.**
+
+The 2026-05-20 incident exposed a credential-leak class: when an agent retrieved a Secret Drop submission via a raw `curl /secrets/retrieve/TOKEN`, the response body — including the secret value — landed in the Bash tool transcript. The fix existed as a one-off `secret-drop-retrieve.mjs` on a single agent's machine, but no other agent had it, and every line of agent-facing guidance (CLAUDE.md template, the spawned-session system message, the stuck-consumer retry message) still recommended the unsafe `curl` pattern.
+
+This release closes the gap on six interlocking surfaces:
+
+1. **Ship the hardened helper as a template.** `src/templates/scripts/secret-drop-retrieve.mjs` streams the requested field value to stdout, prints field NAMES + lengths to stderr, and structurally refuses to print the response body. New agents get it via `installSecretDropRetrieve` (called from three `init.ts` paths next to `installSerendipityCapture`).
+
+2. **Migrate existing agents.** `PostUpdateMigrator.migrateScripts` always-overwrites `.instar/scripts/secret-drop-retrieve.mjs` on every update (same pattern as `convergence-check.sh`). Idempotent — running the migrator twice produces identical content.
+
+3. **Rewrite the spawn message.** `src/server/routes.ts` no longer instructs the agent to `curl ... /secrets/retrieve/TOKEN` when a Secret Drop arrives. The new message points at `node .instar/scripts/secret-drop-retrieve.mjs TOKEN <field-name>` with an explicit warning against the raw curl pattern.
+
+4. **Rewrite the stuck-consumer retry message.** Same hardened command form, same explicit warning.
+
+5. **Rewrite the CLAUDE.md template.** `src/scaffold/templates.ts` documents the hardened command as the required retrieval pattern, with a one-line explanation of the leak class.
+
+6. **Rewrite existing CLAUDE.md files.** `PostUpdateMigrator.migrateClaudeMd` detects the legacy `curl /secrets/retrieve/TOKEN` line (port-tolerant — matches any local port literal) and replaces it with the hardened guidance. Idempotent: a CLAUDE.md that already documents `secret-drop-retrieve.mjs` is left alone.
+
+7. **Update the /capabilities `secrets.retrievalHint`.** The hint now gives the actual command form so an agent reading `/capabilities` learns the safe pattern directly from the discovery surface.
+
+## What to Tell Your User
+
+No user-visible behavior change. Agents will start using the hardened retrieve helper automatically — the next time they receive a Secret Drop submission, the spawned session reads the hardened command form from the system message, not the unsafe curl. Existing agents pick up the helper script and the CLAUDE.md rewrite on the next instar update run.
+
+If you were ever shown the unsafe curl-against-secrets-retrieve pattern in chat, that guidance has been retired across every surface; the hardened helper is the only documented path now.
+
+## Summary of New Capabilities
+
+For the agent:
+
+- `.instar/scripts/secret-drop-retrieve.mjs TOKEN field-name` — streams the value to stdout, never prints the body.
+- `.instar/scripts/secret-drop-retrieve.mjs TOKEN --names` — discover field names + lengths.
+- `.instar/scripts/secret-drop-retrieve.mjs TOKEN field-name --consume` — opt into one-shot semantics.
+
+## Evidence
+
+The leak class was reproduced before the fix: running `curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:4042/secrets/retrieve/<token>` against a known submission prints the full JSON `{"values":{"password":"actual-secret-here"}, ...}` to stdout, which lands in the Bash tool transcript.
+
+After the fix, the hardened helper isolates the value path: `node .instar/scripts/secret-drop-retrieve.mjs <token> password` streams only `actual-secret-here` to stdout (no newline, pipeable), and prints nothing else. The `--names` mode prints only `password (length 16)` to stderr; stdout stays empty.
+
+New tests:
+- `tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts` — 8 cases covering script install (presence, executable bit, content invariants, idempotency) + CLAUDE.md rewrite (legacy → hardened, idempotent, port-tolerant).
+- The existing `tests/unit/capabilities-discoverability.test.ts` continues to pass with the updated `secrets.retrievalHint` string.
+
+Spec: `docs/specs/secret-drop-hardened-retrieve-template.md`
+ELI16: `docs/specs/secret-drop-hardened-retrieve-template.eli16.md`
+Side-effects: `upgrades/side-effects/secret-drop-hardened-retrieve-template.md`
+
+Origin: 2026-05-20 leak incident (topic 9984) + 2026-05-21 case-study audit (topic 11141, follow-up #1).

--- a/upgrades/side-effects/secret-drop-hardened-retrieve-template.md
+++ b/upgrades/side-effects/secret-drop-hardened-retrieve-template.md
@@ -1,0 +1,123 @@
+# Side-Effects Review — Secret Drop Hardened Retrieve Template
+
+**Version / slug:** `secret-drop-hardened-retrieve-template`
+**Date:** `2026-05-21`
+**Author:** `Echo (instar-developing agent)`
+**Second-pass reviewer:** `not required` (template install + documentation rewrite; no new gate/block authority)
+
+## Summary of the change
+
+Ships the hardened `secret-drop-retrieve.mjs` as an `src/templates/scripts/` template; wires it into `init.ts` (for new agents) and `PostUpdateMigrator.migrateScripts` (for existing agents); rewrites the `[secret-drop-received]` spawn message, the `[secret-drop-stuck]` retry message, the CLAUDE.md template, and the `/capabilities.secrets.retrievalHint` to instruct the hardened command form. Adds a `migrateClaudeMd` block that detects the legacy `curl /secrets/retrieve/TOKEN` line and rewrites it in place; idempotent and port-tolerant.
+
+Files touched:
+
+- `src/templates/scripts/secret-drop-retrieve.mjs` — new template.
+- `src/commands/init.ts` — `installSecretDropRetrieve` + three call sites.
+- `src/core/PostUpdateMigrator.ts` — `migrateScripts` block (always-overwrite); `migrateClaudeMd` block (port-tolerant rewrite).
+- `src/server/routes.ts` — spawn message + stuck-consumer retry message + `/capabilities.secrets.retrievalHint`.
+- `src/scaffold/templates.ts` — CLAUDE.md Secret Drop documentation block.
+- `tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts` — new tests (8 cases).
+- `upgrades/NEXT.md` — release notes (minor bump).
+- `docs/specs/secret-drop-hardened-retrieve-template.{md,eli16.md}` — spec + ELI16.
+
+## Decision-point inventory
+
+- `[secret-drop-received]` spawn message — **modify** — guidance the agent reads to learn how to retrieve. Unsafe → hardened.
+- `[secret-drop-stuck]` retry message — **modify** — same retrieval path on the retry branch.
+- CLAUDE.md Secret Drop block (template + migrator) — **modify** — agent's static retrieval guidance.
+- `/capabilities.secrets.retrievalHint` — **modify** — discovery-surface guidance.
+
+No new gate/block surface introduced. The `/secrets/retrieve` endpoint behavior is unchanged.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. The migrator's CLAUDE.md rewrite is the closest thing to a block: it refuses to touch a CLAUDE.md that already documents `secret-drop-retrieve.mjs` (idempotent skip). That's the desired behavior — over-block would require the migrator to refuse legitimate rewrites, which it does not.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+The migrator's regex matches the exact legacy-line pattern. A CLAUDE.md that someone manually customized to use a different unsafe pattern (e.g., `wget` instead of `curl`, or a piped one-liner) would slip past the rewrite. Acceptable: the rewrite is the structural fix for the documented unsafe pattern; bespoke unsafe variants are out of scope and would be visible to anyone reading their own CLAUDE.md.
+
+The hardened helper itself still reads `.instar/config.json` for the authToken. If the config file is missing, the script exits 2 with a clear stderr message; if the file is present but `authToken` is empty, the script does a request with an empty bearer and the server returns 401 — the script prints the 401 status (no body). Both paths are safe.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+The change lives at the agent-facing instruction layer, which is the correct level. Three reasons:
+
+1. The leak is caused by the agent running a documented command verbatim. The fix is to make the documented command safe.
+2. Adding a server-side gate (e.g., refuse `/secrets/retrieve` without a hardened-client header) would create a brittle detector with block authority — violating the signal-vs-authority principle. The server stays permissive; the agent layer is hardened by making safe the only documented path.
+3. The hardened helper itself is a thin wrapper around `fetch`. It doesn't introduce new architecture; it constrains how the value flows out of the response.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [x] No — this change has no block/allow surface at runtime.
+
+The migrator's CLAUDE.md rewrite has commit-time block authority via the precommit hook, but only by virtue of being a code change; the migrator itself does not refuse anything at runtime. The hardened helper has no gate logic — it just streams a value or exits with an error code.
+
+---
+
+## 5. Interactions
+
+**Does this interact with existing checks, recovery paths, or infrastructure?**
+
+- **Shadowing:** the `[secret-drop-received]` spawn message replaces the existing one verbatim (no append, no shadow). The existing 5-minute cleanup timer and the stuck-consumer event from PR #288 are unchanged — both rely on server-side state, not on the system-message content.
+- **Double-fire:** the migrator runs each of `migrateScripts` and `migrateClaudeMd` once per `instar update` invocation. Neither path is recursive.
+- **Races:** the migrator runs single-threaded against an agent that is not yet started; no concurrent writers to the files it touches.
+- **Feedback loops:** none. The agent reading the new guidance produces no input back into the migrator.
+
+The `PostUpdateMigrator.loadRelayTemplate` helper is reused (not duplicated) for loading the new template. Symmetric with `getTelegramReplyScript`.
+
+---
+
+## 6. External surfaces
+
+**Does this change anything visible outside the immediate code path?**
+
+- **Agents on the same machine:** yes — every existing agent picks up `.instar/scripts/secret-drop-retrieve.mjs` on the next update, and any agent whose CLAUDE.md still has the legacy retrieve line gets it rewritten in place. The behavioral change is that the agent learns a safer command form. The unsafe `/secrets/retrieve` endpoint continues to work unchanged for any caller (including custom integrations); only the guidance is updated.
+- **Other agents on the install base:** same — Codex / Gemini agents that read CLAUDE.md / AGENTS.md / GEMINI.md get the rewrite via `migrateFrameworkShadowCapabilities` (existing migrator path that mirrors CLAUDE.md changes to non-Claude shadows).
+- **External systems:** no external surface touched.
+- **Persistent state:** none beyond the file install (which is by design).
+- **Timing / runtime conditions:** the new helper makes one `fetch` call per invocation; same latency profile as the curl it replaces.
+
+---
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Pure code change. Revert the migrator + init + templates + spec/artifact files. The script previously installed by the migrator stays on disk for existing agents (the rollback doesn't delete). The CLAUDE.md rewrites previously applied to existing agents also stay — which is fine because the hardened guidance points at a script that still exists (the install path doesn't go away during a code-only rollback).
+
+Realistic rollback: revert + patch release. Under 5 minutes. The only concern would be a downstream agent that started depending on a quirk of the hardened helper (e.g., expecting an exact stderr format). The script's output contract is documented in the file header; downstream tooling using it should pin against that, not against ephemeral implementation details.
+
+---
+
+## Conclusion
+
+This is a low-risk hardening change focused on agent-facing guidance. It closes the structural side of the 2026-05-20 leak class: every documented path now teaches the safe pattern. The runtime change is a script install + a sequence of string rewrites; no new decision points introduced; signal-vs-authority preserved. No second-pass review required.
+
+---
+
+## Evidence pointers
+
+- Spec: `docs/specs/secret-drop-hardened-retrieve-template.md`
+- ELI16: `docs/specs/secret-drop-hardened-retrieve-template.eli16.md`
+- Tests: `tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts` (8 cases, all green).
+- Existing coverage that continues to pass with the updated guidance strings: `tests/unit/capabilities-discoverability.test.ts`, `tests/unit/secret-drop-hardening.test.ts`.
+- Origin: 2026-05-20 leak incident (topic 9984); 2026-05-21 case-study audit (topic 11141, follow-up #1).


### PR DESCRIPTION
## Summary

Closes the 2026-05-20 leak class structurally. The unsafe \`curl -X POST /secrets/retrieve/TOKEN\` pattern was documented in six places — CLAUDE.md template, the spawn message injected on Secret Drop submission, the stuck-consumer retry message, the \`/capabilities.secrets.retrievalHint\`, and inside every existing agent's CLAUDE.md installed before today. Every one of them taught the leak: the raw curl prints the JSON response body — including the secret value — into the Bash tool transcript, which is captured into the Claude Code JSONL and re-sent to Anthropic on every subsequent turn.

Six interlocking changes ship together:

- \`src/templates/scripts/secret-drop-retrieve.mjs\` — new template. Streams the requested field value to stdout via \`process.stdout.write\` (no newline, pipeable), prints field names + lengths to stderr in \`--names\` mode, structurally cannot print the response body. Honors \`--consume\` for opt-in destructive read.
- \`src/commands/init.ts\` — \`installSecretDropRetrieve\` wired into the three existing init paths next to \`installSerendipityCapture\`. New agents get the helper at \`.instar/scripts/secret-drop-retrieve.mjs\`.
- \`src/core/PostUpdateMigrator.ts\` — \`migrateScripts\` always-overwrites the helper on every update (same pattern as \`convergence-check.sh\`). New \`migrateClaudeMd\` block detects the legacy curl line via port-tolerant regex and rewrites it to the hardened guidance. Idempotent.
- \`src/server/routes.ts\` — \`[secret-drop-received]\` spawn message and \`[secret-drop-stuck]\` retry message rewritten to instruct the hardened helper with an explicit warning that raw curl leaks.
- \`src/scaffold/templates.ts\` — CLAUDE.md Secret Drop block rewritten; the unsafe curl line is gone, the hardened helper leads.
- \`/capabilities.secrets.retrievalHint\` now gives the exact command form so the discovery surface teaches the safe pattern directly.

Spec: \`docs/specs/secret-drop-hardened-retrieve-template.md\` (converged + approved)
ELI16: \`docs/specs/secret-drop-hardened-retrieve-template.eli16.md\`
Side-effects: \`upgrades/side-effects/secret-drop-hardened-retrieve-template.md\`

Origin: 2026-05-20 leak incident (topic 9984); 2026-05-21 case-study audit (topic 11141, follow-up #1 of two).

## Test plan

- [x] \`tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts\` — 8 cases (4 for script install, 4 for CLAUDE.md rewrite). All green.
- [x] Existing \`tests/unit/capabilities-discoverability.test.ts\` (81 cases) continues to pass with the updated \`secrets.retrievalHint\` string.
- [x] Existing \`tests/unit/secret-drop-hardening.test.ts\` unaffected by the docs/template changes.
- [x] Pre-push smoke ran the full suite (825 files / 16605 tests / 13 skipped) — all green.
- [x] \`npx tsc --noEmit\` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)