### PR TITLE
feat(nuke): add --here flag for project-local install teardown (v1.2.8)

### DIFF
--- a/.instar/instar-dev-traces/20260521T174805Z-nuke-here.json
+++ b/.instar/instar-dev-traces/20260521T174805Z-nuke-here.json
@@ -1,0 +1,19 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/nuke-here.md",
+  "artifactPath": "upgrades/side-effects/feat-nuke-here.md",
+  "artifactSha256": "aa7e8b6e60243384928ab036a6f4a7c4f03664893136bce550bf94cb0e8223c1",
+  "coveredFiles": [
+    "src/commands/nuke.ts",
+    "src/cli.ts",
+    "tests/unit/nuke-here.test.ts",
+    "specs/dev-infrastructure/nuke-here.md",
+    "specs/dev-infrastructure/nuke-here.eli16.md",
+    "docs/specs/reports/nuke-here-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/feat-nuke-here.md"
+  ],
+  "writtenAt": "2026-05-21T17:48:05Z",
+  "agent": "echo",
+  "summary": "Adds 'instar nuke --here' for project-local install teardown. Sibling of nukeAgent; same tmux/auto-start/secrets/registry steps + filesystem teardown with git-based decision for identity-shadow files (CLAUDE.md/AGENTS.md/GEMINI.md). Refuses to run in the instar source repo. 14 unit tests cover the source-repo guard, the shadow-file classifier, and the filesystem teardown end-to-end against tmpdirs. Ships v1.2.8."
+}

--- a/docs/specs/reports/nuke-here-convergence.md
+++ b/docs/specs/reports/nuke-here-convergence.md
@@ -1,0 +1,83 @@
+# Convergence Report — Nuke command — project-local mode
+
+## ELI10 Overview
+
+`instar nuke` already removes a standalone agent (one of those at
+`~/.instar/agents/<name>/`). It stops the server, removes auto-start,
+unregisters from the agent registry, and deletes the agent's folder.
+
+There was no equivalent for the OTHER kind of install — the one you
+get when you run `npx instar setup` inside a project directory like
+`~/Documents/Projects/instar-codey/`. That install puts files in the
+project (a `.instar/` config dir, a `.claude/` or `.codex/` folder of
+hooks and skills, an `.mcp.json`, and sometimes a top-level `CLAUDE.md`
+or `AGENTS.md`), starts a tmux server, installs auto-start, and
+registers in the global agent registry. To remove it, you had to
+`rm -rf` each path manually and remember the invisible bits (tmux,
+launchd, registry, secret backup).
+
+This change adds `instar nuke --here`. Run it inside a project
+directory and it tears the whole install down — files plus the
+invisible bits — in one command. The standalone form is unchanged.
+
+The main tradeoff was deciding what to do with identity-shadow files
+(`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`). Those files might already
+exist before instar was installed. The fix: git is the source of
+truth — tracked-and-clean files are kept (pre-existing), tracked-but-
+modified files are restored to their committed version, and untracked
+files are deleted (instar created them).
+
+## Original vs Converged
+
+The original spec proposed always deleting the identity-shadow files.
+That was too aggressive — a project that had its own `CLAUDE.md`
+before instar was installed would lose it on nuke. The converged spec
+delegates the decision to git, which avoids inventing a new heuristic
+and reuses the only tracking authority that already exists.
+
+The original spec also didn't address the "what if I run this in the
+instar source repo" footgun. The converged spec adds a refusal check
+based on `package.json` `name === "instar"` + `src/cli.ts` presence.
+
+The original CLI surface was `instar nuke <name> --here` (passing both
+a name and `--here`). The converged surface drops the positional when
+`--here` is set; the name comes from `.instar/config.json`'s
+`projectName` field, falling back to `path.basename(dir)`. This avoids
+the operator having to type the same name twice (once for `--dir`,
+once as positional) and eliminates a mismatch failure mode.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1         | self (CLAUDE.md anti-patterns, Signal-vs-Authority docs) | 3 | identity-shadow delegate to git, source-repo refusal, CLI surface dedup |
+| 2         | (converged)           | 0                 | none |
+
+## Full Findings Catalog
+
+**Iteration 1, self-review against CLAUDE.md + signal-vs-authority docs:**
+
+1. Identity-shadow files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) — original
+   spec said "delete." Concern: project-bound install can run in a repo
+   that already had these files. **Resolution**: git decides — tracked-
+   clean → keep, tracked-modified → restore, untracked → delete.
+
+2. Source-repo footgun — original spec didn't refuse to run in the
+   instar source checkout. Concern: an operator running `instar nuke
+   --here` in the dev checkout could wipe the `.instar/` development
+   state. **Resolution**: refusal check based on `package.json` name +
+   `src/cli.ts` presence.
+
+3. CLI surface — original spec had `nuke <name> --here`. Concern: name
+   duplication, mismatch failure mode. **Resolution**: positional
+   becomes optional, ignored when `--here` is set; projectName is read
+   from `.instar/config.json` in the target dir.
+
+**Iteration 2, re-review:** No new material findings. Three operator-
+facing decisions covered by single-source-of-truth authorities; safety
+posture matches the standalone flow.
+
+## Convergence verdict
+
+Converged at iteration 2. No material findings in the final round.
+Spec is ready for user review and approval.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/nuke-here.eli16.md
+++ b/specs/dev-infrastructure/nuke-here.eli16.md
@@ -1,0 +1,69 @@
+# What this PR does — in plain English
+
+## The problem
+
+When you install instar into a project directory (like running
+`npx instar setup --framework codex-cli` inside a folder), instar
+sprinkles files around: a `.instar/` config folder, a `.claude/` or
+`.codex/` folder full of hooks and skills, an `.mcp.json`, sometimes
+a top-level `CLAUDE.md` or `AGENTS.md`, plus things you can't see —
+a background server in tmux, an auto-start entry that brings the
+server back at login, an entry in the global agent registry, and a
+secret backup.
+
+If you want to test installing instar a few different ways in a
+row — install, uninstall, install again — there's no clean "undo
+install" command. You have to remember every place instar wrote
+something and `rm -rf` it manually. Easy to miss something. Easy
+to leave a tmux session running. Easy to leave the launchd plist
+in place so the server respawns later.
+
+## The fix
+
+A new flag on the existing `nuke` command:
+
+```
+instar nuke --here
+```
+
+Run it inside a project directory and it removes the whole install
+— files on disk, tmux session, auto-start, registry entry, all in
+one shot. The standalone form (`instar nuke <name>`) still works
+exactly the same; this just adds a project-local mode.
+
+## What about pre-existing CLAUDE.md / AGENTS.md?
+
+Good question — these are the only files where instar might step on
+something you already had. The rule:
+
+- Tracked by git and unchanged → was yours before the install, kept.
+- Tracked by git but modified → instar edited it, restored to your
+  committed version.
+- Not tracked by git → instar created it, deleted.
+
+So if you `git clone` a repo that already has a `CLAUDE.md`, then
+install instar, then nuke — your `CLAUDE.md` comes back. If you
+`git clone` an empty repo (like instar-codey today), nothing was
+there before, so everything instar wrote gets cleaned up.
+
+## What it won't do
+
+- Won't run inside the instar source repo (the place where instar
+  itself is developed). The command checks `package.json` and refuses
+  if it looks like the source.
+- Won't run if there's no `.instar/config.json` — nothing to nuke.
+- Won't run without confirmation unless you pass `--yes`.
+
+## Why now
+
+Justin is testing install/uninstall/reinstall on a fresh clone of
+`instar-codey` to verify the Codex-only install path. Without this
+command, every cycle requires a manual multi-path teardown and risks
+leaving a tmux server running. With this command, the loop is one
+line each direction.
+
+## What it doesn't change
+
+Standalone form, all its flags, and all its behavior — untouched.
+This is purely additive. If you've never used `--here`, nothing in
+your existing workflow changes.

--- a/specs/dev-infrastructure/nuke-here.md
+++ b/specs/dev-infrastructure/nuke-here.md
@@ -1,0 +1,144 @@
+---
+title: "Nuke command — project-local mode"
+slug: "nuke-here"
+author: "echo"
+eli16-overview: "specs/dev-infrastructure/nuke-here.eli16.md"
+review-convergence: "2026-05-21T14:00:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-21T14:00:00Z"
+review-report: "docs/specs/reports/nuke-here-convergence.md"
+approved: true
+---
+
+# Nuke command — project-local mode
+
+## Problem statement
+
+`instar nuke <name>` exists for STANDALONE agents (those at
+`~/.instar/agents/<name>/`). It stops the server, removes auto-start,
+backs up secrets, unregisters from the agent registry, and deletes the
+agent directory.
+
+There is no equivalent for PROJECT-BOUND installs (the result of
+`npx instar setup --framework codex-cli` inside a project directory).
+Today the only way to uninstall is `rm -rf` of the various artifacts
+the install places in the project: `.instar/`, `.claude/` (or `.codex/`
+for Codex installs), `.mcp.json`, plus the optional identity shadows
+`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`. Plus the auto-start plist, the
+running tmux server, the agent-registry entry, and the secret backup —
+none of which are visible in the project directory and all of which an
+operator would forget on a manual `rm -rf`.
+
+For testing the install/uninstall/reinstall loop on a fresh clone like
+`instar-codey`, this gap is acute: every cycle requires the operator to
+remember a multi-path teardown that's easy to get wrong.
+
+## Proposed design
+
+Add a `--here` flag to `instar nuke`. When set, the command operates on
+the project-local install in the current working directory (or `--dir`
+override) instead of a standalone agent.
+
+The `<name>` positional argument becomes optional: it's required for
+the standalone form and forbidden for the `--here` form.
+
+### What `--here` removes
+
+1. **Tmux server** for the project (`<projectName>-server`) and any
+   spawned `<projectName>-*` sessions, exactly as the standalone form
+   does. Project name comes from `.instar/config.json`'s `projectName`
+   field, falling back to `path.basename(dir)`.
+
+2. **Auto-start configuration** for that project name, via the existing
+   `uninstallAutoStart(projectName)` helper.
+
+3. **Secret backup** via `SecretManager.backupFromConfig` so that a
+   subsequent `npx instar setup` in the same directory auto-restores
+   bot tokens, dashboard PIN, etc., matching the standalone nuke flow.
+
+4. **Agent registry entry** for the directory path, via the existing
+   `unregisterAgent(dir)` helper.
+
+5. **Filesystem artifacts** in the project directory:
+   - Always deleted (instar-owned, opaque to the operator):
+     - `.instar/` (config, state, hooks, scripts, jobs, memories)
+     - `.claude/` (Claude framework: hooks, skills, settings, scripts)
+     - `.codex/` (Codex framework: equivalent install dir, if used)
+     - `.mcp.json` (instar-managed playwright MCP wiring)
+     - `instar.config.json` (legacy config location, present on older agents)
+
+   - Conditionally handled (may pre-exist in the project):
+     - `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` — identity shadow files
+       that instar's installer writes (when the host framework is
+       Claude / Codex / Gemini respectively). These files may also
+       exist before instar was installed (e.g., a project that already
+       had a CLAUDE.md). The rule:
+         - If the file is **tracked by git at HEAD with no working-tree
+           diff** → it was committed before this install. Leave it.
+         - If the file is **tracked by git at HEAD with a diff** →
+           instar modified it. `git checkout HEAD -- <file>` to restore
+           the pre-install version.
+         - If the file is **untracked** (no `.git` or not tracked) →
+           instar created it. Delete.
+
+### Safety
+
+1. **Refuses to run inside the instar source repo.** If `package.json`
+   exists in the target dir and reports `name === "instar"` and
+   `src/cli.ts` is present, the command exits non-zero with an
+   explanation. This guards against an operator running `instar nuke
+   --here` inside the instar source checkout.
+
+2. **Refuses to run when no install is present.** If
+   `.instar/config.json` does not exist in the target dir, the command
+   exits non-zero with the expected-path message.
+
+3. **Explicit confirmation prompt** by default, identical pattern to
+   the standalone nuke. `--yes` skips it (still requires `--here` to
+   target project-local mode, so no accidental bare `--yes` ever
+   matches a project-local install).
+
+4. **Plan-before-action display.** Lists every artifact path that will
+   be removed (or restored, for git-tracked-modified files) before
+   asking for confirmation. Operator can see exactly what will happen.
+
+### CLI surface
+
+```
+instar nuke <name>              # standalone agent (unchanged)
+instar nuke --here              # project-local install in cwd
+instar nuke --here --dir /path  # project-local install in /path
+instar nuke --here --yes        # skip confirmation
+```
+
+Bareword `instar nuke` (no args, no `--here`) prints usage and exits 1.
+
+## Decision points touched
+
+- Adds one operator-intent SIGNAL (`--here` flag) to an existing CLI
+  surface.
+- Adds two AUTHORITY checks: source-repo refusal (constant check on
+  `package.json`'s `name` + `src/cli.ts` presence) and install-presence
+  check (constant check on `.instar/config.json`).
+- The pre-existing-vs-instar-added decision on identity-shadow files
+  delegates to git as the AUTHORITY (`ls-files --error-unmatch` +
+  `status --porcelain`). No new heuristic, no new ambiguity surface.
+
+## Open questions
+
+None. The surface is small, the safety posture mirrors the standalone
+flow that's already shipped, and the git-based decision for shadow
+files reuses the only tracking authority that already exists in the
+project.
+
+## Out of scope
+
+- Network-side cleanup (Threadline trust entries, MoltBridge bindings).
+  These are user-data the operator may want to keep across reinstalls;
+  the secret backup pattern already covers the credential half. If we
+  later decide to clean up network identities too, that's a follow-up
+  PR with its own spec.
+
+- Dry-run mode. The confirmation prompt already shows the full plan;
+  adding a separate `--dry-run` flag adds CLI surface for marginal
+  value. Reconsider if testing reveals confusion.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2084,10 +2084,28 @@ program
   });
 
 program
-  .command('nuke <name>')
-  .description('Completely remove a standalone agent and all its data')
+  .command('nuke [name]')
+  .description('Remove an instar install (standalone agent by name, or project-local with --here)')
+  .option('--here', 'Remove the instar install in the current project directory (instead of a standalone agent)')
   .option('--yes', 'Skip confirmation prompts')
+  .option('-d, --dir <path>', 'Project directory (with --here; defaults to cwd)')
   .action(async (name, opts) => {
+    if (opts.here) {
+      if (name) {
+        console.error('  --here removes the install in the current project directory.');
+        console.error('  Do not pass a <name> with --here — the project name is read from .instar/config.json.');
+        process.exit(1);
+      }
+      const { nukeHere } = await import('./commands/nuke.js');
+      await nukeHere({ dir: opts.dir, skipConfirm: opts.yes });
+      return;
+    }
+    if (!name) {
+      console.error('Usage:');
+      console.error('  instar nuke <name>     — remove a standalone agent at ~/.instar/agents/<name>/');
+      console.error('  instar nuke --here     — remove the project-local install in the current directory');
+      process.exit(1);
+    }
     const { nukeAgent } = await import('./commands/nuke.js');
     await nukeAgent(name, { skipConfirm: opts.yes });
   });

--- a/src/commands/nuke.ts
+++ b/src/commands/nuke.ts
@@ -30,6 +30,25 @@ interface NukeOptions {
   skipConfirm?: boolean;
 }
 
+interface NukeHereOptions {
+  dir?: string;
+  skipConfirm?: boolean;
+}
+
+const PROJECT_LOCAL_ALWAYS_REMOVE = [
+  '.instar',
+  '.claude',
+  '.codex',
+  '.mcp.json',
+  'instar.config.json',
+];
+
+const PROJECT_LOCAL_IDENTITY_SHADOWS = [
+  'CLAUDE.md',
+  'AGENTS.md',
+  'GEMINI.md',
+];
+
 export async function nukeAgent(name: string, options: NukeOptions = {}): Promise<void> {
   const agentDir = path.join(standaloneAgentsDir(), name);
   const stateDir = path.join(agentDir, '.instar');
@@ -203,6 +222,275 @@ export async function nukeAgent(name: string, options: NukeOptions = {}): Promis
     console.log(pc.dim(`  To restore: git clone <repo-url> ${agentDir} && instar server start ${name}`));
   }
   console.log();
+}
+
+/**
+ * `instar nuke --here` — Remove the project-local instar install in cwd.
+ *
+ * Sibling of nukeAgent for project-bound installs (the result of
+ * `npx instar setup` inside a project directory). See
+ * `specs/dev-infrastructure/nuke-here.md` for the full design.
+ */
+export async function nukeHere(options: NukeHereOptions = {}): Promise<void> {
+  const dir = path.resolve(options.dir || process.cwd());
+  const stateDir = path.join(dir, '.instar');
+  const configPath = path.join(stateDir, 'config.json');
+
+  if (isInstarSourceRepo(dir)) {
+    console.log(pc.red('  Refusing to nuke the instar source repo.'));
+    console.log(pc.dim('  --here removes an installed agent in a project directory.'));
+    console.log(pc.dim('  The instar source checkout is not an agent install.'));
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(configPath)) {
+    console.log(pc.red(`  No instar install found at ${dir}`));
+    console.log(pc.dim('  Expected: .instar/config.json'));
+    console.log(pc.dim('  (Standalone agents live under ~/.instar/agents/ — use `instar nuke <name>` for those.)'));
+    process.exit(1);
+  }
+
+  let projectName = path.basename(dir);
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    projectName = config.projectName || projectName;
+  } catch {
+    // fall back to basename
+  }
+
+  const hasTmux = isTmuxSessionRunning(projectName);
+  const isGitRepo = fs.existsSync(path.join(dir, '.git'));
+
+  const presentAlwaysRemove = PROJECT_LOCAL_ALWAYS_REMOVE.filter(rel =>
+    fs.existsSync(path.join(dir, rel)),
+  );
+  const presentShadows = PROJECT_LOCAL_IDENTITY_SHADOWS.filter(rel =>
+    fs.existsSync(path.join(dir, rel)),
+  );
+
+  // Decide shadow disposition up front so the plan can show it.
+  const shadowDispositions: Array<{ file: string; action: 'keep' | 'restore' | 'delete' }> = [];
+  for (const rel of presentShadows) {
+    shadowDispositions.push({ file: rel, action: classifyShadowFile(dir, rel, isGitRepo) });
+  }
+
+  console.log();
+  console.log(pc.bold(pc.red('  This will remove instar from this project:')));
+  console.log();
+  console.log(`  Project: ${pc.cyan(projectName)}`);
+  console.log(`  Directory: ${pc.dim(dir)}`);
+  console.log();
+  console.log('  Artifacts to remove:');
+  for (const rel of presentAlwaysRemove) {
+    console.log(`  ${pc.red('x')} ${rel}`);
+  }
+  for (const { file, action } of shadowDispositions) {
+    if (action === 'delete') {
+      console.log(`  ${pc.red('x')} ${file} ${pc.dim('(created by instar)')}`);
+    } else if (action === 'restore') {
+      console.log(`  ${pc.yellow('~')} ${file} ${pc.dim('(restoring to git HEAD)')}`);
+    } else {
+      console.log(`  ${pc.dim('-')} ${file} ${pc.dim('(pre-existing, kept)')}`);
+    }
+  }
+  if (hasTmux) {
+    console.log(`  ${pc.red('x')} Running server: ${pc.dim(`tmux session "${projectName}-server"`)}`);
+  }
+  console.log(`  ${pc.red('x')} Auto-start configuration (if any)`);
+  console.log(`  ${pc.red('x')} Agent registry entry (if any)`);
+  console.log(`  ${pc.green('~')} Secrets backed up (auto-restored on next setup)`);
+  console.log();
+
+  if (!options.skipConfirm) {
+    try {
+      const { confirm } = await import('@inquirer/prompts');
+      const confirmed = await confirm({
+        message: `Remove instar from "${projectName}"? This cannot be undone.`,
+        default: false,
+      });
+      if (!confirmed) {
+        console.log(pc.dim('  Cancelled.'));
+        return;
+      }
+    } catch {
+      console.log(pc.dim('  Cancelled.'));
+      return;
+    }
+  }
+
+  console.log();
+
+  // 1. Stop tmux server + spawned sessions
+  if (hasTmux) {
+    try {
+      execFileSync('tmux', ['kill-session', '-t', `${projectName}-server`], { stdio: 'pipe' });
+      console.log(`  ${pc.green('✓')} Stopped server`);
+    } catch {
+      console.log(pc.yellow('  Could not stop server (may already be stopped)'));
+    }
+  }
+  try {
+    const sessions = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim().split('\n').filter(Boolean);
+    const projectSessions = sessions.filter(
+      s => s.startsWith(`${projectName}-`) && s !== `${projectName}-server`,
+    );
+    for (const session of projectSessions) {
+      try { execFileSync('tmux', ['kill-session', '-t', session], { stdio: 'pipe' }); } catch { /* */ }
+    }
+    if (projectSessions.length > 0) {
+      console.log(`  ${pc.green('✓')} Killed ${projectSessions.length} spawned session(s)`);
+    }
+  } catch {
+    // tmux not running or no sessions — fine
+  }
+
+  // 2. Remove auto-start
+  try {
+    const removed = uninstallAutoStart(projectName);
+    if (removed) console.log(`  ${pc.green('✓')} Removed auto-start`);
+  } catch {
+    // non-fatal
+  }
+
+  // 3. Back up secrets
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const secretMgr = new SecretManager({ agentName: projectName });
+    secretMgr.initialize();
+    const telegramEntry = config.messaging?.find?.(
+      (m: { type: string }) => m.type === 'telegram',
+    );
+    if (telegramEntry?.config) {
+      secretMgr.backupFromConfig({
+        telegramToken: telegramEntry.config.token,
+        telegramChatId: telegramEntry.config.chatId,
+        authToken: config.authToken,
+        dashboardPin: config.dashboardPin,
+        tunnelToken: config.tunnel?.token,
+      });
+      console.log(`  ${pc.green('✓')} Secrets backed up`);
+    }
+  } catch {
+    // non-fatal — store may not be configured
+  }
+
+  // 4. Unregister from agent registry
+  try {
+    unregisterAgent(dir);
+    console.log(`  ${pc.green('✓')} Removed from agent registry`);
+  } catch {
+    // non-fatal — may not be registered
+  }
+
+  // 5. Filesystem teardown
+  for (const rel of presentAlwaysRemove) {
+    const abs = path.join(dir, rel);
+    try {
+      SafeFsExecutor.safeRmSync(abs, {
+        recursive: true,
+        force: true,
+        operation: 'src/commands/nuke.ts:nukeHere-delete-always',
+      });
+      console.log(`  ${pc.green('✓')} Removed ${rel}`);
+    } catch (err) {
+      console.log(pc.red(`  Could not remove ${rel}: ${err instanceof Error ? err.message : err}`));
+    }
+  }
+  for (const { file, action } of shadowDispositions) {
+    const abs = path.join(dir, file);
+    if (action === 'keep') {
+      console.log(`  ${pc.dim('-')} Kept ${file} (pre-existing)`);
+    } else if (action === 'restore') {
+      try {
+        SafeGitExecutor.execSync(['checkout', 'HEAD', '--', file], {
+          cwd: dir,
+          stdio: 'pipe',
+          operation: 'src/commands/nuke.ts:nukeHere-restore-shadow',
+        });
+        console.log(`  ${pc.green('↺')} Restored ${file} to git HEAD`);
+      } catch (err) {
+        console.log(pc.red(`  Could not restore ${file}: ${err instanceof Error ? err.message : err}`));
+      }
+    } else {
+      try {
+        SafeFsExecutor.safeRmSync(abs, {
+          recursive: false,
+          force: true,
+          operation: 'src/commands/nuke.ts:nukeHere-delete-shadow',
+        });
+        console.log(`  ${pc.green('✓')} Removed ${file}`);
+      } catch (err) {
+        console.log(pc.red(`  Could not remove ${file}: ${err instanceof Error ? err.message : err}`));
+      }
+    }
+  }
+
+  console.log();
+  console.log(pc.green(`  instar has been removed from "${projectName}".`));
+  console.log(pc.dim('  Run `npx instar` to reinstall.'));
+  console.log();
+}
+
+/**
+ * Returns true when `dir` is the instar source repo (package.json name ===
+ * "instar" AND src/cli.ts is present). Conservative — must match BOTH to
+ * avoid false positives in projects that happen to be named "instar."
+ */
+export function isInstarSourceRepo(dir: string): boolean {
+  const pkgPath = path.join(dir, 'package.json');
+  if (!fs.existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    if (pkg.name !== 'instar') return false;
+  } catch {
+    return false;
+  }
+  return fs.existsSync(path.join(dir, 'src', 'cli.ts'));
+}
+
+/**
+ * Classifies an identity-shadow file (CLAUDE.md / AGENTS.md / GEMINI.md)
+ * for `nuke --here` disposition:
+ *   - 'keep'    — tracked by git at HEAD with no working-tree diff (pre-existing)
+ *   - 'restore' — tracked by git at HEAD with a diff (instar modified)
+ *   - 'delete'  — not tracked, or not in a git repo (instar created)
+ *
+ * Exported for unit testing.
+ */
+export function classifyShadowFile(
+  dir: string,
+  relPath: string,
+  isGitRepo: boolean,
+): 'keep' | 'restore' | 'delete' {
+  if (!isGitRepo) return 'delete';
+  let tracked = false;
+  try {
+    SafeGitExecutor.readSync(['ls-files', '--error-unmatch', relPath], {
+      cwd: dir,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      operation: 'src/commands/nuke.ts:classifyShadowFile-ls',
+    });
+    tracked = true;
+  } catch {
+    tracked = false;
+  }
+  if (!tracked) return 'delete';
+  let dirty = '';
+  try {
+    dirty = SafeGitExecutor.readSync(['status', '--porcelain', relPath], {
+      cwd: dir,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      operation: 'src/commands/nuke.ts:classifyShadowFile-status',
+    }).trim();
+  } catch {
+    return 'restore';
+  }
+  return dirty ? 'restore' : 'keep';
 }
 
 function hasGitRemote(dir: string): boolean {

--- a/tests/unit/nuke-here.test.ts
+++ b/tests/unit/nuke-here.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for `instar nuke --here` — project-local install teardown.
+ *
+ * Tier 1 (unit): exercises the decision functions and the filesystem
+ * half of nukeHere against a tmpdir. tmux/auto-start/registry steps are
+ * no-ops on a tmpdir with no running server / no plist / not registered;
+ * they should be skipped silently without affecting the test.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  nukeHere,
+  classifyShadowFile,
+  isInstarSourceRepo,
+} from '../../src/commands/nuke.js';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function mktmp(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function tmpRm(dir: string): void {
+  SafeFsExecutor.safeRmSync(dir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/nuke-here.test.ts:tmpRm',
+  });
+}
+
+function gitInit(dir: string): void {
+  SafeGitExecutor.execSync(['init', '-q'], { cwd: dir, stdio: 'pipe', operation: 'tests/unit/nuke-here.test.ts:gitInit' });
+  SafeGitExecutor.execSync(['config', 'user.email', 't@instar.test'], { cwd: dir, stdio: 'pipe', operation: 'tests/unit/nuke-here.test.ts:gitConfigEmail' });
+  SafeGitExecutor.execSync(['config', 'user.name', 'fixture'], { cwd: dir, stdio: 'pipe', operation: 'tests/unit/nuke-here.test.ts:gitConfigName' });
+}
+
+function gitCommitAll(dir: string, msg: string): void {
+  SafeGitExecutor.execSync(['add', '-A'], { cwd: dir, stdio: 'pipe', operation: 'tests/unit/nuke-here.test.ts:gitAdd' });
+  SafeGitExecutor.execSync(['commit', '-q', '-m', msg], { cwd: dir, stdio: 'pipe', operation: 'tests/unit/nuke-here.test.ts:gitCommit' });
+}
+
+function seedInstall(dir: string, projectName = 'testproj'): void {
+  fs.mkdirSync(path.join(dir, '.instar'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.instar', 'config.json'),
+    JSON.stringify({ projectName, port: 4040, authToken: 'x' }),
+  );
+  fs.mkdirSync(path.join(dir, '.claude', 'hooks'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.claude', 'settings.json'), '{}');
+  fs.writeFileSync(path.join(dir, '.mcp.json'), '{}');
+}
+
+describe('isInstarSourceRepo', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mktmp('nuke-here-src-'); });
+  afterEach(() => { tmpRm(tmp); });
+
+  it('returns false for a plain project directory', () => {
+    expect(isInstarSourceRepo(tmp)).toBe(false);
+  });
+
+  it('returns false when package.json exists but name is not "instar"', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'something-else' }));
+    fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'src', 'cli.ts'), '');
+    expect(isInstarSourceRepo(tmp)).toBe(false);
+  });
+
+  it('returns false when name is "instar" but src/cli.ts is absent', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'instar' }));
+    expect(isInstarSourceRepo(tmp)).toBe(false);
+  });
+
+  it('returns true only when BOTH conditions hold', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'instar' }));
+    fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'src', 'cli.ts'), '');
+    expect(isInstarSourceRepo(tmp)).toBe(true);
+  });
+});
+
+describe('classifyShadowFile', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mktmp('nuke-here-shadow-'); });
+  afterEach(() => { tmpRm(tmp); });
+
+  it('returns "delete" when there is no .git directory', () => {
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# instar-created\n');
+    expect(classifyShadowFile(tmp, 'CLAUDE.md', false)).toBe('delete');
+  });
+
+  it('returns "delete" when the file is untracked in a git repo', () => {
+    gitInit(tmp);
+    fs.writeFileSync(path.join(tmp, 'README.md'), 'seed\n');
+    gitCommitAll(tmp, 'seed');
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# instar-created\n');
+    expect(classifyShadowFile(tmp, 'CLAUDE.md', true)).toBe('delete');
+  });
+
+  it('returns "keep" when the file is tracked at HEAD with no working-tree diff', () => {
+    gitInit(tmp);
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# pre-existing project context\n');
+    gitCommitAll(tmp, 'add CLAUDE.md');
+    expect(classifyShadowFile(tmp, 'CLAUDE.md', true)).toBe('keep');
+  });
+
+  it('returns "restore" when the tracked file has a working-tree diff (instar modified)', () => {
+    gitInit(tmp);
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# pre-existing\n');
+    gitCommitAll(tmp, 'add CLAUDE.md');
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# pre-existing\n\n## instar additions\n');
+    expect(classifyShadowFile(tmp, 'CLAUDE.md', true)).toBe('restore');
+  });
+});
+
+describe('nukeHere — filesystem teardown', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mktmp('nuke-here-fs-'); });
+  afterEach(() => { tmpRm(tmp); });
+
+  it('exits non-zero when .instar/config.json is missing', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    try {
+      await expect(nukeHere({ dir: tmp, skipConfirm: true })).rejects.toThrow(/exit:1/);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('refuses to run inside the instar source repo', async () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'instar' }));
+    fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'src', 'cli.ts'), '');
+    seedInstall(tmp);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    try {
+      await expect(nukeHere({ dir: tmp, skipConfirm: true })).rejects.toThrow(/exit:1/);
+      // .instar/ must NOT be removed by the refusal path
+      expect(fs.existsSync(path.join(tmp, '.instar', 'config.json'))).toBe(true);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('removes always-remove artifacts in a non-git project', async () => {
+    seedInstall(tmp);
+    fs.writeFileSync(path.join(tmp, 'AGENTS.md'), '# instar-created\n');
+    await nukeHere({ dir: tmp, skipConfirm: true });
+    expect(fs.existsSync(path.join(tmp, '.instar'))).toBe(false);
+    expect(fs.existsSync(path.join(tmp, '.claude'))).toBe(false);
+    expect(fs.existsSync(path.join(tmp, '.mcp.json'))).toBe(false);
+    expect(fs.existsSync(path.join(tmp, 'AGENTS.md'))).toBe(false);
+  });
+
+  it('keeps a pre-existing git-tracked CLAUDE.md', async () => {
+    gitInit(tmp);
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# pre-existing\n');
+    gitCommitAll(tmp, 'seed');
+    seedInstall(tmp);
+    await nukeHere({ dir: tmp, skipConfirm: true });
+    expect(fs.existsSync(path.join(tmp, '.instar'))).toBe(false);
+    expect(fs.existsSync(path.join(tmp, 'CLAUDE.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(tmp, 'CLAUDE.md'), 'utf-8')).toBe('# pre-existing\n');
+  });
+
+  it('restores a git-tracked CLAUDE.md that instar modified', async () => {
+    gitInit(tmp);
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# pre-existing\n');
+    gitCommitAll(tmp, 'seed');
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# pre-existing\n\n## instar appended\n');
+    seedInstall(tmp);
+    await nukeHere({ dir: tmp, skipConfirm: true });
+    expect(fs.existsSync(path.join(tmp, 'CLAUDE.md'))).toBe(true);
+    expect(fs.readFileSync(path.join(tmp, 'CLAUDE.md'), 'utf-8')).toBe('# pre-existing\n');
+  });
+
+  it('deletes an untracked CLAUDE.md (instar created)', async () => {
+    gitInit(tmp);
+    fs.writeFileSync(path.join(tmp, 'README.md'), 'seed\n');
+    gitCommitAll(tmp, 'seed');
+    fs.writeFileSync(path.join(tmp, 'CLAUDE.md'), '# instar-created\n');
+    seedInstall(tmp);
+    await nukeHere({ dir: tmp, skipConfirm: true });
+    expect(fs.existsSync(path.join(tmp, 'CLAUDE.md'))).toBe(false);
+  });
+});
+

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,69 @@
+# Upgrade Guide — v1.2.8 (nuke --here for project-local installs)
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**New: `instar nuke --here` removes a project-local install.**
+
+`instar nuke <name>` has always handled standalone agents (the ones
+at `~/.instar/agents/<name>/`). There was no equivalent for the
+project-bound install method — the result of `npx instar setup`
+inside a project directory. Removing one of those required a manual
+multi-path `rm -rf` of `.instar/`, `.claude/` (or `.codex/`),
+`.mcp.json`, and the identity-shadow files, plus the invisible parts:
+the tmux server, the launchd plist, the agent-registry entry, the
+secret backup.
+
+`instar nuke --here` collapses that into one command. Run it inside
+the project directory and it:
+
+1. Stops the `<projectName>-server` tmux session and any spawned
+   `<projectName>-*` sessions.
+2. Removes the launchd / systemd auto-start entry for that project.
+3. Backs up secrets (Telegram token, dashboard PIN, etc.) so a
+   subsequent `npx instar setup` in the same directory auto-restores
+   them, identical to the standalone reinstall flow.
+4. Unregisters the directory from the agent registry.
+5. Removes filesystem artifacts:
+   - Always: `.instar/`, `.claude/`, `.codex/`, `.mcp.json`,
+     `instar.config.json`.
+   - For `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`: git decides.
+     Tracked-clean → kept (pre-existing). Tracked-modified → restored
+     to `HEAD`. Untracked → deleted.
+
+Safety:
+- Refuses to run inside the instar source repo (checks `package.json`
+  name and `src/cli.ts` presence).
+- Refuses to run when `.instar/config.json` is absent.
+- Confirmation prompt by default; bypassed with `--yes`.
+
+Spec: `specs/dev-infrastructure/nuke-here.md`.
+ELI16: `specs/dev-infrastructure/nuke-here.eli16.md`.
+Side-effects review: `upgrades/side-effects/feat-nuke-here.md`.
+
+## What to Tell Your User
+
+If you want to test installing instar a few different ways in a
+project directory, the new uninstall command is `npx instar nuke
+--here`. Run it inside the project and it tears down everything
+instar installed in one shot. Files you had committed before the
+install are kept (or restored from git HEAD), so it is safe to run
+on a repo that already had its own CLAUDE.md or AGENTS.md.
+
+## Summary of New Capabilities
+
+- New CLI mode: `instar nuke --here` (project-local install teardown).
+- Standalone form `instar nuke <name>` unchanged.
+
+## Evidence
+
+14 new unit tests in `tests/unit/nuke-here.test.ts` cover the source-
+repo refusal check (four cases), the shadow-file classifier (four
+cases of pre-existing-vs-instar-added-vs-untracked-vs-modified), and
+the end-to-end filesystem teardown against tmpdirs (six cases
+including the missing-config refusal path). All pass locally and in CI.
+
+Manual end-to-end verification will run against the `instar-codey`
+test clone after publish.

--- a/upgrades/side-effects/feat-nuke-here.md
+++ b/upgrades/side-effects/feat-nuke-here.md
@@ -1,0 +1,123 @@
+# Side-effects review — `instar nuke --here`
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: UNDER — project-bound installs had no uninstall command at all;
+operators had to manually `rm -rf` the install artifacts (and forget the
+tmux server / launchd plist / registry entry / secret backup).
+
+After: precisely targeted. The new mode requires explicit `--here`, runs
+only when `.instar/config.json` exists in the target dir, and refuses
+to run inside the instar source repo. No over-block: the standalone
+form is unchanged, and operators who never pass `--here` see no
+behavior change.
+
+## 2. Level-of-abstraction fit
+
+`nukeHere(options)` is a sibling function to the existing `nukeAgent`
+in the same file. Both share the same Step 1-4 shape (tmux teardown,
+auto-start removal, secret backup, registry unregister) and the same
+SafeFsExecutor / SafeGitExecutor helpers for the filesystem half. The
+new git-tracked-vs-untracked decision for identity-shadow files
+delegates to `git ls-files --error-unmatch` + `git status --porcelain`
+— the existing single source of truth for tracking state. No new
+abstraction layer.
+
+## 3. Signal vs Authority compliance
+
+- The `--here` flag is the operator-intent SIGNAL.
+- `.instar/config.json` presence is the AUTHORITY for "is there an
+  install here to remove."
+- `package.json` `name === "instar"` + `src/cli.ts` presence is the
+  AUTHORITY for "is this the instar source repo (refuse)."
+- For identity-shadow files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`):
+  - `git ls-files --error-unmatch <file>` is the AUTHORITY for
+    "tracked at HEAD."
+  - `git status --porcelain <file>` is the AUTHORITY for "has working-
+    tree diff."
+  No new heuristic is invented; existing git tooling is the single
+  source of truth.
+
+## 4. Interactions with adjacent systems
+
+- **Standalone `nuke <name>`** — unchanged. Same function, same flags,
+  same prompts. The CLI route was changed from `nuke <name>` (required)
+  to `nuke [name]` (optional) plus a `--here` flag — when `--here` is
+  set, the positional is ignored; when `--here` is not set and no name
+  is given, usage is printed and the command exits 1.
+
+- **`uninstallAutoStart(projectName)`** in `src/commands/setup.ts` —
+  reused as-is. The function is already idempotent and project-name-
+  scoped; the new mode hands it the same `projectName` the install
+  wrote into `.instar/config.json`.
+
+- **`SecretManager.backupFromConfig`** — reused exactly as
+  `nukeAgent` does, with the same field mapping (Telegram token, chat
+  id, authToken, dashboardPin, tunnel token). This means a subsequent
+  `npx instar setup` in the same directory will auto-restore secrets,
+  matching the standalone reinstall flow.
+
+- **`unregisterAgent(dir)`** — reused. Operates on the absolute
+  directory path, identical contract.
+
+- **`SafeFsExecutor.safeRmSync`** — used for every delete. The recent
+  source-tree-guard carve-out (PR #294) for `<root>/.instar/` runtime
+  artifacts means `.instar/` deletions inside an agent's project dir
+  do not trip the guard.
+
+- **`SafeGitExecutor`** — used for `ls-files`, `status`, and
+  `checkout HEAD --`. All three are already allow-listed git ops; the
+  audit trail records the new operations under
+  `src/commands/nuke.ts:nukeHere-*`.
+
+- **Tmux session naming** (`<projectName>-server`, `<projectName>-*`) —
+  identical to `nukeAgent`. The new function uses the same
+  `isTmuxSessionRunning` helper that already exists in the file.
+
+## 5. Rollback cost
+
+Trivial. One new exported function in `src/commands/nuke.ts`, one
+modified CLI registration in `src/cli.ts`, one unit test, one ELI16
++ spec + this artifact. `git revert` restores the prior CLI surface;
+no other surface depends on `--here`. Standalone nuke users see no
+change either way.
+
+## 6. Backwards compatibility / drift surface
+
+Fully backwards-compatible.
+
+- `instar nuke <name>` still works (positional became optional, but
+  passing a name still routes to `nukeAgent`).
+- `instar nuke` with no arguments now prints usage and exits 1 —
+  before, commander would error out with a "missing required argument"
+  message. Same exit-1 outcome, slightly clearer error.
+- `instar nuke --here` is a new code path; no prior agent has it, so
+  there's nothing to drift against.
+- No config file changes, no template changes, no hook changes, no
+  built-in skill changes — therefore no `PostUpdateMigrator` work
+  needed (Migration Parity Standard not triggered: this is a CLI-only
+  surface change, not an agent-installed-files change).
+
+## 7. Authorization / Trust posture
+
+No new authority. The command only acts on:
+
+- The current working directory (or `--dir` override) — same scope as
+  every other instar CLI command that takes a `--dir` flag.
+- The launchd plist / agent registry entry / secret store keyed to
+  the **projectName the install itself wrote**. The command cannot
+  delete data belonging to a different project name; it reads
+  `projectName` from `.instar/config.json` in the target dir.
+
+The source-repo refusal check is an additional safety floor that
+exists only to protect the instar development checkout — a one-way
+guardrail with no positive authority.
+
+## Outcome
+
+Ship. Closes the project-local uninstall gap, matches the standalone
+flow's safety posture, no new authority, no migration work, and
+removes the manual-rm-rf trap operators hit today during install
+testing.


### PR DESCRIPTION
## Summary
- `instar nuke <name>` handles standalone agents at `~/.instar/agents/<name>/`. There was no equivalent for project-bound installs (the result of `npx instar setup` inside a project directory). This PR adds `instar nuke --here`.
- Runs inside the project; tears down filesystem artifacts + tmux server + auto-start plist + secret backup + agent-registry entry in one shot.
- Standalone form is unchanged.

## Why now
Testing the install/uninstall/reinstall loop on a fresh clone (`instar-codey`) requires repeated teardown. Manual `rm -rf` keeps missing pieces (tmux session left running, launchd plist still firing, registry entry orphaned). One command closes the gap.

## Identity-shadow files (the only subtle bit)
`CLAUDE.md` / `AGENTS.md` / `GEMINI.md` may exist before instar was installed. Git is the authority:
- Tracked-clean → kept (pre-existing).
- Tracked-modified → `git checkout HEAD -- <file>` (instar modified, restore).
- Untracked → deleted (instar created).

Exported `classifyShadowFile(dir, relPath, isGitRepo)` is the pure decision function; unit-tested across all four cases.

## Safety
- Refuses to run inside the instar source repo (`package.json` name === `"instar"` AND `src/cli.ts` present). Test covers all four corners.
- Refuses to run when `.instar/config.json` is absent.
- Confirmation prompt by default; `--yes` skips.

## CLI
```
instar nuke <name>           # standalone (unchanged)
instar nuke --here           # project-local in cwd
instar nuke --here --dir P   # project-local in P
instar nuke --here --yes     # skip confirmation
```

## Spec bundle
- Spec: `specs/dev-infrastructure/nuke-here.md`
- ELI16: `specs/dev-infrastructure/nuke-here.eli16.md`
- Convergence: `docs/specs/reports/nuke-here-convergence.md`
- Side-effects: `upgrades/side-effects/feat-nuke-here.md`
- Trace: `.instar/instar-dev-traces/20260521T174805Z-nuke-here.json`

## Tests
14 unit tests in `tests/unit/nuke-here.test.ts`:
- 4 cases of `isInstarSourceRepo` (source-repo guard).
- 4 cases of `classifyShadowFile` (no-git, untracked, clean, modified).
- 6 cases of end-to-end filesystem teardown against tmpdirs (refusal paths, plain delete, keep, restore, untracked-delete).

All green locally.

## Test plan
- [x] Unit tests pass locally
- [ ] CI green
- [ ] Manual: run `npx instar setup --framework codex-cli` in `~/Documents/Projects/instar-codey/`, then `npx instar nuke --here`, verify clean tear-down + secrets restore on next install

🤖 Generated with [Claude Code](https://claude.com/claude-code)