### PR TITLE
fix(packaging): ship dist/cli.js with executable bit set

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "generate:manifest": "node scripts/generate-builtin-manifest.cjs",
-    "build": "node scripts/generate-builtin-manifest.cjs && tsc && node scripts/sign-instar-lockfile.mjs",
+    "build": "node scripts/generate-builtin-manifest.cjs && tsc && chmod 0755 dist/cli.js && node scripts/sign-instar-lockfile.mjs",
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:push": "vitest run --config vitest.push.config.ts",

--- a/tests/unit/package-completeness.test.ts
+++ b/tests/unit/package-completeness.test.ts
@@ -302,6 +302,16 @@ describe('Package completeness', () => {
     const binPaths: string[] =
       typeof binField === 'string' ? [binField] : Object.values(binField);
 
+    // Ensure dist/ exists. CI's unit-test job runs `npm ci` then tests
+    // directly (no separate build step), so dist/ may be empty. We invoke
+    // tsc + the chmod step directly instead of `npm run build` because
+    // the full build also regenerates src/data/builtin-manifest.json,
+    // which mutates the working tree and trips ci.yml's integrity check.
+    const needsBuild = binPaths.some(b => !fsDyn.existsSync(path.join(ROOT, b)));
+    if (needsBuild) {
+      execSync('npx tsc && chmod 0755 dist/cli.js', { cwd: ROOT, stdio: 'pipe' });
+    }
+
     const tmpDir = fsDyn.mkdtempSync(path.join(os.tmpdir(), 'instar-pack-mode-'));
     try {
       const packOut = execSync('npm pack --silent --pack-destination ' + JSON.stringify(tmpDir), {

--- a/tests/unit/package-completeness.test.ts
+++ b/tests/unit/package-completeness.test.ts
@@ -275,4 +275,73 @@ describe('Package completeness', () => {
       expect(malformed, `Malformed upgrade guides:\n${malformed.join('\n')}`).toEqual([]);
     }
   });
+
+  /**
+   * Every file listed in package.json `bin` must ship with the executable bit
+   * set inside the tarball.
+   *
+   * Born from a real failure (2026-05-21): `tsc` writes dist/cli.js at mode
+   * 0644. `npm install` chmods bin targets to 0755 at link time, so fresh
+   * installs work. But `npx`'s cache reuses an existing symlink across
+   * version upgrades and silently skips the re-chmod — so users who had
+   * previously run `npx instar` got "Permission denied" on the bin script
+   * after a version bump. The durable fix is to ship the tarball with
+   * the exec bit already set, instead of relying on npm's install-time
+   * chmod. This test pins that invariant.
+   *
+   * Implementation: pack a real tarball and inspect tar entry modes via
+   * `tar -tvf`. `npm pack --dry-run --json` does not expose file modes.
+   */
+  it('all package.json bin files ship with the executable bit set', async () => {
+    const fsDyn = await import('node:fs');
+    const os = await import('node:os');
+    const pkg = JSON.parse(fsDyn.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+    const binField = pkg.bin;
+    if (!binField) return;
+
+    const binPaths: string[] =
+      typeof binField === 'string' ? [binField] : Object.values(binField);
+
+    const tmpDir = fsDyn.mkdtempSync(path.join(os.tmpdir(), 'instar-pack-mode-'));
+    try {
+      const packOut = execSync('npm pack --silent --pack-destination ' + JSON.stringify(tmpDir), {
+        cwd: ROOT,
+        encoding: 'utf-8',
+      }).trim();
+      const tarballName = packOut.split('\n').pop() as string;
+      const tarballPath = path.join(tmpDir, tarballName);
+      expect(fsDyn.existsSync(tarballPath), `tarball not produced: ${tarballPath}`).toBe(true);
+
+      const listing = execSync(`tar -tvf ${JSON.stringify(tarballPath)}`, { encoding: 'utf-8' });
+      const lines = listing.split('\n');
+
+      const missingExec: string[] = [];
+      for (const binPath of binPaths) {
+        const expectedInTar = `package/${binPath}`;
+        const entry = lines.find(l => l.endsWith(' ' + expectedInTar));
+        if (!entry) {
+          missingExec.push(`${binPath}: NOT FOUND in tarball`);
+          continue;
+        }
+        // tar -tvf output starts with a mode string like "-rwxr-xr-x"
+        const mode = entry.trim().split(/\s+/)[0];
+        if (!mode.includes('x')) {
+          missingExec.push(`${binPath}: ships at "${mode}" (no exec bit)`);
+        }
+      }
+
+      if (missingExec.length > 0) {
+        const message = [
+          'package.json bin files must ship with the executable bit set.',
+          'tsc outputs files at 0644 by default — add `&& chmod 0755 <path>`',
+          'to the build script for each bin target.',
+          '',
+          ...missingExec,
+        ].join('\n');
+        expect(missingExec, message).toEqual([]);
+      }
+    } finally {
+      fsDyn.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,59 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+<!-- patch = bug fix with regression test, no new surface -->
+
+## What Changed
+
+**fix(packaging): `dist/cli.js` now ships with the executable bit set in the published npm tarball.**
+
+`tsc` writes compiled output at mode 0644 by default. The build script previously did not chmod the bin target, so every published instar tarball from 1.0.13 onward shipped `dist/cli.js` at `-rw-r--r--`.
+
+Normally `npm install` papers over this by chmodding bin targets to 0755 at link time, so fresh installs work. But `npx`'s package cache reuses the bin symlink across version upgrades and skips re-chmodding the underlying target file on subsequent installs — so users who had previously run `npx instar` could hit `sh: .../instar: Permission denied` after a version bump, even though the symlink itself looked correct. The mode on the target file stayed at 0644 from a previous install while new file bytes were written in place.
+
+After this release:
+- `package.json` `build` script ends with `chmod 0755 dist/cli.js`, so the file is mode 0755 before `npm publish` packs it.
+- The tarball entry for `dist/cli.js` ships at `-rwxr-xr-x` regardless of npm's install-time behavior.
+- `tests/unit/package-completeness.test.ts` adds a regression test that packs a real tarball, lists it with `tar -tvf`, and asserts every entry referenced by `package.json` `bin` has the exec bit. The test fails if the chmod step is removed.
+
+## What to Tell Your User
+
+No user action needed. If you had previously seen the npx instar command fail with a permission-denied error after a version bump, that path is now fixed — the next published version will run cleanly. If a stale copy is still cached, clearing the npx cache picks up the corrected bytes.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| npx instar works across version bumps even when npm's bin chmod is skipped | Automatic — published tarball now ships dist/cli.js with the exec bit |
+
+## Evidence
+
+**Reproduction (before the fix):**
+
+```
+$ npm pack
+$ tar -tzvf instar-*.tgz package/dist/cli.js
+-rw-r--r--  0 0  0  90101 Oct 26  1985 package/dist/cli.js
+```
+
+The tarball entry has no `x` in the mode — confirms the published 1.2.7 (and every earlier version back to 1.0.13) shipped without the exec bit.
+
+**After the fix:**
+
+```
+$ npm run build
+$ npm pack
+$ tar -tzvf instar-*.tgz package/dist/cli.js
+-rwxr-xr-x  0 0  0  90101 Oct 26  1985 package/dist/cli.js
+```
+
+**Regression test:**
+
+`tests/unit/package-completeness.test.ts > all package.json bin files ship with the executable bit set` — runs `npm pack` into a temp dir, inspects the tarball with `tar -tvf`, asserts each bin entry has `x` in its mode string. Verified to fail when the `chmod 0755` step is removed from the build script — output: `dist/cli.js: ships at "-rw-r--r--" (no exec bit)`.
+
+**Original failure observed in the field:**
+
+```
+$ npx instar@latest
+sh: /Users/.../node_modules/.bin/instar: Permission denied
+```


### PR DESCRIPTION
## Summary

- `dist/cli.js` ships in every published instar tarball back to 1.0.13 at mode `-rw-r--r--`. `npm install` chmods bin targets to 0755 at link time so fresh installs work, but `npx`'s package cache silently skips re-chmodding on version upgrades — users hit `Permission denied` on the bin after bumping versions.
- Chain `chmod 0755 dist/cli.js` onto the build script so the tarball ships at `-rwxr-xr-x` regardless of npm's install-time behavior.
- Add regression test in `tests/unit/package-completeness.test.ts` that packs a real tarball, lists it with `tar -tvf`, and asserts every `package.json` `bin` entry has the exec bit. Verified to fail when the chmod step is removed.

## Repro (before)

```
$ tar -tzvf instar-1.2.7.tgz package/dist/cli.js
-rw-r--r-- ... package/dist/cli.js

$ npx instar@latest
sh: /Users/.../node_modules/.bin/instar: Permission denied
```

## After

```
$ npm run build && npm pack
$ tar -tzvf instar-*.tgz package/dist/cli.js
-rwxr-xr-x ... package/dist/cli.js
```

## Test plan

- [x] New regression test passes with fix applied
- [x] New regression test fails when `chmod 0755 dist/cli.js` is reverted — confirms it catches the bug
- [x] Local pre-push lint + smoke gates pass
- [x] Manually reproduced the original "Permission denied" failure in the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)