### PR TITLE
fix(setup): wizard always runs on Claude regardless of host framework (v1.2.12)

### DIFF
--- a/.instar/instar-dev-traces/20260521T195912Z-wizard-via-claude.json
+++ b/.instar/instar-dev-traces/20260521T195912Z-wizard-via-claude.json
@@ -1,0 +1,18 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/wizard-via-claude.md",
+  "artifactPath": "upgrades/side-effects/fix-wizard-via-claude.md",
+  "artifactSha256": "29cabe43916c054a91fcabc805aa3f2e76785c6ad71c9bfc8ed97fde9ba76374",
+  "coveredFiles": [
+    "src/commands/setup.ts",
+    "tests/unit/setup-codex-model-canary.test.ts",
+    "specs/dev-infrastructure/wizard-via-claude.md",
+    "specs/dev-infrastructure/wizard-via-claude.eli16.md",
+    "docs/specs/reports/wizard-via-claude-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/fix-wizard-via-claude.md"
+  ],
+  "writtenAt": "2026-05-21T19:59:12Z",
+  "agent": "echo",
+  "summary": "Routes both setup.ts wizard spawns (main wizard + secret-setup micro-session) through Claude unconditionally, regardless of host framework. Closes the broken Codex install UX where Codex ignored the wizard skill's conversational contract and executed the entire setup non-interactively. Agent runtime (enabledFrameworks) is unchanged — only the interactive onboarding binary is forced to Claude. Canary from PR #299 inverted to assert no codex spawns in setup.ts. Ships v1.2.12."
+}

--- a/docs/specs/reports/wizard-via-claude-convergence.md
+++ b/docs/specs/reports/wizard-via-claude-convergence.md
@@ -1,0 +1,89 @@
+# Convergence Report — Setup wizard always runs on Claude
+
+## ELI10 Overview
+
+A few releases back I added a "Which AI runtime?" prompt to `npx
+instar`. Yesterday's first real Codex install path test hit a model-
+selection bug, fixed in v1.2.11. The next test confirmed Codex spawned
+with the right model — but ignored the wizard skill's "be
+conversational, wait for the user" rules entirely. Codex treated the
+skill as a task description and ran the whole setup non-interactively,
+leaving the user with a generic agent identity they never got to
+shape.
+
+This PR routes the setup wizard through Claude unconditionally,
+regardless of which runtime the user picks for their agent. The
+agent's runtime is unchanged (a Codex agent stays a Codex agent); only
+the conversational onboarding tool is forced to the one that reliably
+honors conversational instructions.
+
+The fix is small: two argv ternaries collapse to constants, one
+binary-selection ternary collapses to a const with a refusal upstream,
+the canary test from PR #299 inverts (no codex spawns instead of
+codex-spawns-with-model-flag). Trivial rollback.
+
+## Original vs Converged
+
+The fix went straight to the right shape. Two alternatives were
+considered and rejected during single-iteration self-review:
+
+1. **Patch the wizard SKILL.md with more aggressive PAUSE-HERE
+   markers** — rejected because Codex routinely ignores those too.
+   The training pull toward execution can't be reliably overridden
+   with prompt text.
+
+2. **Build a Codex-only wizard as a separate state-machine driver**
+   — rejected as scope. Today's failure mode is "Codex doesn't honor
+   the wizard skill", and Claude is already required at install time
+   (`ensurePrerequisites` checks it unconditionally). Using Claude
+   for the wizard is the smallest possible fix. A Codex-only wizard
+   becomes worth building if/when a user reports needing instar on a
+   host without Claude installed.
+
+3. **Keep `WIZARD_CODEX_MODEL` constant exported** — accepted. The
+   constant was just shipped in v1.2.10 as public API. Removing it
+   in the next patch release would be SemVer-affecting for no
+   incremental win. Future PR can drop it on a minor bump.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1         | self                  | 0 (fix matches root cause) | none |
+
+## Full Findings Catalog
+
+**Finding 1 — Codex doesn't follow the wizard's conversational
+contract.**
+
+- Severity: high (broken UX for the primary Codex-runtime audience).
+- Resolution: route wizard to Claude unconditionally.
+- Source: end-to-end log from the v1.2.11 install on instar-codey
+  (`/Users/justin/Documents/Projects/instar-codey/setup-logs.md`).
+  Codex executed `npx instar init`, `npx instar user add`, `npx
+  instar server start`, `npx instar autostart install`, `npx instar
+  status` without asking the user any of the wizard's identity
+  questions.
+
+**Finding 2 — Same bug applies to the secret-setup micro-session.**
+
+- Both setup.ts spawns were ternary on `framework`. Same root cause,
+  same fix needed.
+- Resolution: collapse both ternaries to the unconditional Claude
+  form.
+
+**Finding 3 — PR #299's canary needs to invert.**
+
+- The previous canary asserted every codex exec block in setup.ts
+  passes `-m WIZARD_CODEX_MODEL`. With no codex exec blocks
+  remaining, that assertion becomes vacuous.
+- Resolution: invert the canary to assert NO codex exec blocks in
+  setup.ts (the wizard always uses Claude). The
+  `WIZARD_CODEX_MODEL`-validity test remains as a public-API
+  contract.
+
+## Convergence verdict
+
+Converged at iteration 1. Two-line binary-selection change in
+setup.ts; canary inverted; no new abstraction or authority.
+Spec is ready.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.2.11",
+      "version": "1.2.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/wizard-via-claude.eli16.md
+++ b/specs/dev-infrastructure/wizard-via-claude.eli16.md
@@ -1,0 +1,69 @@
+# What this PR does — in plain English
+
+## The story so far
+
+A few releases back I added a "Which AI runtime?" prompt to `npx
+instar` so a fresh user could pick Claude Code or Codex CLI as the
+agent's runtime. Yesterday's first real test of the Codex path failed
+on a model error, which I fixed in v1.2.11. The model fix worked —
+Codex now spawned with the right model.
+
+But the very next test showed an even uglier problem: when Codex
+spawned with the wizard skill, it ignored everything the skill said
+about being conversational. Instead of walking the user through
+identity, autonomy, personality, and messaging — the whole point of
+the wizard — Codex saw the skill as a task description and just
+**executed the setup**. Ran `npx instar init` itself. Made up the
+user's name from shell context. Started the server. Installed
+autostart. The user watched a stream of shell commands and ended up
+with a generic agent they never got to shape.
+
+## The root cause
+
+Claude follows behavioral instructions like "speak conversationally"
+and "wait for the user". Codex's training pulls toward execution —
+when given the same skill, it does the work instead of leading a
+conversation. This isn't a bug we can fix by tweaking the skill text;
+adding more "PAUSE HERE" markers doesn't reliably change Codex's
+behavior.
+
+## The fix
+
+The wizard always runs on Claude now. The agent the user is setting
+up can still be a Codex agent — that hasn't changed. But the
+onboarding wizard itself, the one that asks "what's your agent's
+name" and "how autonomous should it be", always uses Claude. Same
+goes for the smaller wizard that helps you set up a secret store
+(Bitwarden, 1Password) at the start of setup.
+
+Both Claude and Codex are already required prerequisites today, so
+no new dependency. The wizard runs on Claude; the resulting agent
+runs on whatever the user picked.
+
+## Why this works long-term
+
+It's a separation of concerns: Claude is good at conversational
+onboarding (and the skills were written for it). Codex is good at
+execution (and that's what the agent does after setup). Each tool
+gets the job it's good at. The runtime prompt during install still
+matters — it determines which framework the AGENT runs on. But the
+SETUP wizard is its own thing, and it picks the best tool for its
+job every time.
+
+## The test
+
+A canary in the unit suite refuses any future PR that re-introduces
+a Codex spawn for the wizard or the secret-setup micro-session. If
+someone later tries to "give Codex another chance" by re-wiring the
+spawn, CI catches it before users do.
+
+## What it doesn't change
+
+- The runtime prompt during install: still asks the user.
+- The agent's actual runtime: still whatever the user picks.
+- The Claude path: unchanged.
+- The CLI surface: unchanged.
+
+The only thing different is that the wizard's tool is no longer a
+function of the user's runtime choice. The wizard always uses
+Claude. The agent uses whatever you wanted.

--- a/specs/dev-infrastructure/wizard-via-claude.md
+++ b/specs/dev-infrastructure/wizard-via-claude.md
@@ -1,0 +1,171 @@
+---
+title: "Setup wizard always runs on Claude"
+slug: "wizard-via-claude"
+author: "echo"
+eli16-overview: "wizard-via-claude.eli16.md"
+review-convergence: "2026-05-21T20:00:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-21T20:00:00Z"
+review-report: "docs/specs/reports/wizard-via-claude-convergence.md"
+approved: true
+---
+
+# Setup wizard always runs on Claude
+
+## Problem statement
+
+First real end-to-end test of `npx instar` → "Codex CLI" runtime
+prompt → wizard launch (against v1.2.11, which fixed the model-pin
+issue in PR #299) confirmed that the model flag now flows through
+correctly. Codex was spawned with `model: gpt-5.3-codex`,
+received the wizard skill prompt, and the wizard skill was loaded.
+
+But the user experience was still broken in a different, deeper way:
+**Codex did not follow the wizard's conversational contract.** The
+`.claude/skills/setup-wizard/SKILL.md` says, in capitals at the top:
+
+> CRITICAL: No Commands in User-Facing Text — NEVER show CLI commands,
+> file paths, or code to the user unless they explicitly ask. Speak
+> conversationally.
+
+> CRITICAL: NEVER Use AskUserQuestion — Always present choices as
+> inline numbered options in your text output, then wait for the user
+> to type their choice.
+
+> Display the AGENT SUMMARY block verbatim … and wait for the user to
+> type their choice.
+
+Codex parsed the JSON context, noticed `entryPoint: "restore"`,
+internally resolved a scenario, and **executed the entire setup
+non-interactively** before showing the user anything resembling a
+walkthrough:
+
+```
+exec: /bin/zsh -lc 'pwd && ls -la …'
+exec: /bin/zsh -lc 'git rev-parse --show-toplevel && git remote -v'
+exec: /bin/zsh -lc 'npx instar --help'
+exec: /bin/zsh -lc 'npx instar init --help'
+exec: /bin/zsh -lc 'npx instar init --dir /Users/justin/Documents/Projects/instar-codey'
+exec: /bin/zsh -lc 'sed -n "1,220p" .instar/AGENT.md'
+exec: /bin/zsh -lc 'cat .instar/config.json'
+exec: /bin/zsh -lc 'npx instar user add --id justin --name Justin'
+exec: /bin/zsh -lc 'npx instar server start'
+exec: /bin/zsh -lc 'npx instar autostart install --dir …'
+exec: /bin/zsh -lc 'npx instar status'
+```
+
+The user never picked a name, an autonomy level, a personality, a
+communication style. The agent was assigned a generic identity
+(`Instar-codey`, generic principles) and a user identity invented from
+shell context (`justin`). Only at the very end did Codex offer one
+multiple-choice prompt — for messaging selection.
+
+The wizard's stated job — "helping their agent come to life with a
+real identity" — never happened. The skill's behavioral instructions
+were treated as a task description by Codex's training, not as a
+behavioral contract.
+
+## Proposed design
+
+Always spawn Claude for the setup wizard, regardless of which host
+framework the user picked at the runtime prompt. This applies to both
+interactive micro-sessions in `src/commands/setup.ts`:
+
+1. The main wizard launch (after agent discovery + scenario resolution).
+2. The Phase 2.5 secret-setup micro-session (Bitwarden / 1Password
+   choice + install + unlock).
+
+The `framework` variable still controls everything else: the agent's
+`enabledFrameworks` in config.json, the framework-specific scaffold
+gates (`.claude/` vs no-`.claude/`, `.codex/` overlay, AGENTS.md vs
+CLAUDE.md, etc.), and post-setup runtime behavior. Only the interactive
+wizard binary is forced to Claude.
+
+### The justification
+
+- The wizard's job is **conversational onboarding** — walk a fresh user
+  through identity, personality, autonomy preferences, communication
+  style, messaging setup. Claude reliably follows the skill's behavioral
+  contract: pause for input, present inline numbered choices, never
+  show CLI commands, speak in plain English.
+- Codex's training pulls toward **execution**. When given the same
+  skill prompt, Codex treats it as a task description and runs the
+  setup non-interactively. Adding more "PAUSE HERE" markers won't
+  fix it — Codex routinely ignores those too.
+- Once setup is done, the **agent's runtime** continues to be whatever
+  framework the user picked. Codex agents run on Codex. Claude agents
+  run on Claude. The wizard is just the onboarding tool.
+
+### Prerequisite
+
+Claude must be installed even on hosts whose agent will run on Codex.
+This is already required today: `ensurePrerequisites` checks Claude
+unconditionally and the prerequisites check passes only when Claude is
+present (per the v1.2.11 install log, line 12: `✓ Claude CLI`). If
+Claude is missing, the wizard now surfaces a clean refusal explaining
+that Claude is the conversational onboarding tool, and the agent can
+still run on Codex once setup is complete.
+
+A future PR may add a true Codex-only-host wizard if/when a user reports
+needing it. Out of scope for this fix.
+
+### Concrete changes
+
+In `src/commands/setup.ts`:
+
+- Replace `const binaryPath = framework === 'codex-cli' ? codexPath! :
+  claudePath!;` with a refusal check + `const wizardBinary =
+  claudePath;` (always Claude).
+- Replace the wizard launch's framework-conditional `launchArgs`
+  ternary with the unconditional Claude form (`['--dangerously-skip-
+  permissions', '/setup-wizard …']`).
+- Replace the secret-setup spawn's framework-conditional `secretArgs`
+  ternary with the unconditional Claude form (`['--dangerously-skip-
+  permissions', '/secret-setup']`).
+- Update the spawn error message to explain that the wizard runs on
+  Claude.
+
+The `WIZARD_CODEX_MODEL` constant from PR #299 remains exported as a
+public symbol — it's no longer used inside setup.ts but external
+callers may consume it, and removing public API would be a SemVer
+breaking change for a non-blocking concern.
+
+### Test contract
+
+Update `tests/unit/setup-codex-model-canary.test.ts` to assert the
+v1.2.12 contract:
+
+- No `'-m' WIZARD_CODEX_MODEL` literal in setup.ts (no codex spawns
+  remain there).
+- No `codex exec` argv string in setup.ts.
+- The `wizardBinary` assignment references `claudePath` and is NOT
+  conditional on `framework`.
+- The retired `gpt-5.2-codex` literal still never appears.
+
+If a future PR re-introduces a Codex spawn for the wizard or secret-
+setup, the test fails in CI before the change ships.
+
+## Decision points touched
+
+- Removes one operator-intent SIGNAL (the `framework` value's
+  influence on `wizardBinary`).
+- Does NOT add a new authority. The new refusal check (Claude must be
+  installed) reuses `detectClaudePath`'s existing result.
+- The agent's runtime behavior (post-setup) is unchanged.
+
+## Open questions
+
+None. The fix is a binary-selection change in two spawn callsites,
+plus an updated canary.
+
+## Out of scope
+
+- Wizard support for hosts without Claude installed. Today
+  `ensurePrerequisites` requires Claude regardless of framework, so
+  the assumption holds. If a Codex-only-host install requirement
+  arises, a separate spec can design the codex-only wizard variant
+  (likely a state-machine driver rather than a free-form LLM prompt).
+- Reusing the SKILL.md to drive a hand-rolled conversation manager
+  for Codex. Possible but heavier; deferred.
+- Deprecation of `WIZARD_CODEX_MODEL`. Kept exported as a public
+  symbol; no breaking change in this PR.

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -167,9 +167,36 @@ export async function runSetup(opts?: { framework?: 'claude-code' | 'codex-cli' 
   }
 
   // The binary the wizard will spawn for both the secret-setup micro-session
-  // and the main wizard. checkFrameworkPrerequisite has already guaranteed
-  // the chosen framework's binary was detected.
-  const binaryPath = framework === 'codex-cli' ? codexPath! : claudePath!;
+  // and the main wizard. We ALWAYS use Claude for these two interactive
+  // micro-sessions, regardless of the host framework choice. Reason:
+  // Codex's training pulls toward execution — when given the wizard's
+  // skill prompt ("speak conversationally / wait for the user / never
+  // show CLI commands"), it routinely ignores the conversational
+  // instructions and runs the whole setup non-interactively, leaving the
+  // user with a generic agent identity they never got to shape. Claude
+  // reliably follows the conversational contract.
+  //
+  // `framework` still gates the resulting agent's runtime
+  // (enabledFrameworks in config.json) and the install-time scaffolding
+  // gates downstream of this point. Only the interactive wizard binaries
+  // are forced to Claude.
+  //
+  // Prerequisite: Claude must be installed even on Codex-only-target
+  // hosts. The top-level prerequisite check (ensurePrerequisites)
+  // already requires it, so this is consistent with shipped behavior.
+  // A future PR can add a true Codex-only wizard if/when a user reports
+  // wanting to install without Claude present.
+  if (!claudePath) {
+    console.log();
+    console.log(pc.red('  The setup wizard requires Claude CLI to be installed.'));
+    console.log(pc.dim('  Claude is the conversational onboarding tool. The agent itself can still run on Codex'));
+    console.log(pc.dim('  if you picked codex-cli at the runtime prompt — only setup needs Claude.'));
+    console.log();
+    console.log(pc.dim('  Install: npm install -g @anthropic-ai/claude-code'));
+    console.log();
+    process.exit(1);
+  }
+  const wizardBinary = claudePath;
 
   if (!prereqs.allMet) {
     console.log(pc.red('  Some prerequisites are still missing. Please install them and try again.'));
@@ -325,9 +352,10 @@ ${agentSummary}
 
   // ── Phase Gate: Secret Management ──────────────────────────────────
   // Structure > Willpower: secret management MUST be configured before the
-  // main wizard. Uses a framework-native micro-session for a conversational
-  // experience. Gate: main wizard won't start without backend.json.
-  const secretContext = await ensureSecretBackend(binaryPath, framework, instarRoot);
+  // main wizard. Uses a Claude micro-session for a conversational
+  // experience regardless of host framework. Gate: main wizard won't
+  // start without backend.json.
+  const secretContext = await ensureSecretBackend(wizardBinary, framework, instarRoot);
 
   // If Bitwarden session was saved by the secret-setup micro-session, pass it
   // as an env var so the main wizard can use it for credential restoration.
@@ -340,30 +368,16 @@ ${agentSummary}
     }
   }
 
-  // Launch the chosen runtime from the instar package root (where
-  // .claude/skills/ lives — both Claude and Codex can read the skill file
-  // from there). The wizard's slash-command works as a Claude SKILL; for
-  // Codex, point it at the SKILL.md content via prose since Codex has no
-  // slash-command equivalent.
+  // Launch Claude from the instar package root (where .claude/skills/ lives)
+  // and invoke the wizard via its slash-command. Even when the host
+  // framework is codex-cli, the wizard itself runs on Claude — see the
+  // wizardBinary comment above for the rationale.
   const wizardPrompt = `The project to set up is at: ${projectDir}.${gitContext}${detectionContext}${secretContext}`;
-  const wizardSkillPath = path.join(instarRoot, '.claude', 'skills', 'setup-wizard', 'SKILL.md');
-  const launchArgs: string[] = framework === 'codex-cli'
-    ? [
-        'exec',
-        '--dangerously-bypass-approvals-and-sandbox',
-        // Pass an explicit model. Codex CLI's default is gpt-5.2-codex which
-        // OpenAI retired from ChatGPT-subscription accounts on 2026-04-14
-        // (API-only since). The wizard targets the subscription path by
-        // default, so we pin to gpt-5.3-codex — confirmed-working on
-        // ChatGPT auth (see src/providers/adapters/openai-codex/models.ts).
-        '-m', WIZARD_CODEX_MODEL,
-        `Read ${wizardSkillPath} and follow its instructions as the setup wizard. ${wizardPrompt}`,
-      ]
-    : [
-        '--dangerously-skip-permissions',
-        `/setup-wizard ${wizardPrompt}`,
-      ];
-  const child = spawn(binaryPath, launchArgs, {
+  const launchArgs: string[] = [
+    '--dangerously-skip-permissions',
+    `/setup-wizard ${wizardPrompt}`,
+  ];
+  const child = spawn(wizardBinary, launchArgs, {
     cwd: instarRoot,
     stdio: 'inherit',
     env: spawnEnv,
@@ -375,12 +389,9 @@ ${agentSummary}
     });
     child.on('error', (err) => {
       console.log();
-      console.log(pc.red(`  Could not launch ${framework}: ${err.message}`));
-      console.log(pc.dim(`  Make sure ${framework} is installed and accessible:`));
-      const installCmd = framework === 'codex-cli'
-        ? 'npm install -g @openai/codex'
-        : 'npm install -g @anthropic-ai/claude-code';
-      console.log(`    ${pc.cyan(installCmd)}`);
+      console.log(pc.red(`  Could not launch the setup wizard: ${err.message}`));
+      console.log(pc.dim('  The wizard runs on Claude. Make sure Claude is installed and accessible:'));
+      console.log(`    ${pc.cyan('npm install -g @anthropic-ai/claude-code')}`);
       console.log();
       process.exit(1);
     });
@@ -406,7 +417,10 @@ ${agentSummary}
  */
 async function ensureSecretBackend(
   binaryPath: string,
-  framework: 'claude-code' | 'codex-cli',
+  // framework no longer affects secret-setup spawn (always Claude); kept
+  // in the signature for backwards-compat of any internal caller that
+  // still passes it. Will be removed in a future tidy-up PR.
+  _framework: 'claude-code' | 'codex-cli',
   instarRoot: string,
 ): Promise<string> {
   const backendFile = path.join(os.homedir(), '.instar', 'secrets', 'backend.json');
@@ -443,19 +457,13 @@ async function ensureSecretBackend(
   console.log(pc.dim('  Let me walk you through the options...'));
   console.log();
 
-  // Spawn a focused micro-session for secret setup. For Claude, this is the
-  // /secret-setup slash-command on the SKILL. For Codex (no slash commands),
-  // point at the skill file content via prose so the wizard reads and
-  // executes the same instructions.
-  const secretSkillPath = path.join(instarRoot, '.claude', 'skills', 'secret-setup', 'SKILL.md');
-  const secretArgs: string[] = framework === 'codex-cli'
-    ? [
-        'exec',
-        '--dangerously-bypass-approvals-and-sandbox',
-        '-m', WIZARD_CODEX_MODEL,
-        `Read ${secretSkillPath} and follow its instructions to configure a secret backend for this user.`,
-      ]
-    : ['--dangerously-skip-permissions', '/secret-setup'];
+  // Spawn a focused Claude micro-session for secret setup. We always use
+  // Claude here regardless of host framework — same rationale as the main
+  // wizard launch (see WIZARD_BINARY_RATIONALE in runSetup). The secret-
+  // setup skill is also conversational ("explain options, ask questions,
+  // install Bitwarden"), which Claude follows reliably and Codex routinely
+  // ignores in favor of execution.
+  const secretArgs: string[] = ['--dangerously-skip-permissions', '/secret-setup'];
   const child = spawn(binaryPath, secretArgs, {
     cwd: instarRoot,
     stdio: 'inherit',

--- a/tests/unit/setup-codex-model-canary.test.ts
+++ b/tests/unit/setup-codex-model-canary.test.ts
@@ -1,25 +1,30 @@
 /**
- * Canary test for the codex `--model` flag on setup.ts spawns.
+ * Canary tests for the setup-wizard spawn discipline in setup.ts.
  *
- * Background: v1.2.1 added a runtime prompt that lets the user pick the
- * codex-cli framework at install time, and v1.0.x had already wired
- * `instar setup --framework codex-cli` to spawn the wizard inside a
- * Codex session. Both code paths called `codex exec ...` without a
- * `-m`/`--model` flag, so Codex used its default model
- * `gpt-5.2-codex` — which OpenAI retired from ChatGPT-subscription
- * accounts on 2026-04-14. The first real end-to-end install attempt by
- * a ChatGPT-subscription user (the primary audience) hit
- * `The 'gpt-5.2-codex' model is not supported when using Codex with a
- * ChatGPT account.` and aborted before the wizard could render.
+ * Two historical bugs are pinned here:
  *
- * The fix: define a `WIZARD_CODEX_MODEL` constant (gpt-5.3-codex) and
- * pass `-m WIZARD_CODEX_MODEL` to every `codex exec` spawn in
- * setup.ts.
+ * 1. **v1.2.10 model-pin gap** (now obsolete after v1.2.12): setup.ts
+ *    used to spawn `codex exec` for the wizard, but did not pass a
+ *    `-m`/`--model` flag. Codex CLI's default model (`gpt-5.2-codex`)
+ *    was retired from ChatGPT-subscription accounts on 2026-04-14, so
+ *    the spawn returned a 400 before the wizard could render. v1.2.10
+ *    added `-m WIZARD_CODEX_MODEL`.
  *
- * This test pins the fix as a structural contract: if any future PR
- * removes the `-m` flag from a codex spawn in setup.ts, the test
- * fails, surfacing the regression in CI instead of on a user's
- * machine.
+ * 2. **v1.2.12 wizard-via-claude pin**: the first end-to-end test of
+ *    the Codex install path showed that even with the correct model,
+ *    Codex ignores the wizard skill's conversational instructions —
+ *    it executes the setup non-interactively instead of leading the
+ *    user through identity, autonomy, and messaging questions. v1.2.12
+ *    routes the wizard ALWAYS through Claude, regardless of which
+ *    framework the user picked at the runtime prompt. The host
+ *    framework still gates the agent's runtime (enabledFrameworks); it
+ *    just no longer gates the conversational onboarding tool.
+ *
+ * The canary asserts the v1.2.12 contract: no codex spawns remain in
+ * setup.ts for the interactive wizard or secret-setup phases. The
+ * WIZARD_CODEX_MODEL constant remains exported as a deprecated public
+ * symbol so any future codex spawn that DOES land in setup.ts uses the
+ * subscription-supported model.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -32,38 +37,43 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const SETUP_SRC = path.resolve(__dirname, '../../src/commands/setup.ts');
 
-describe('setup.ts codex spawn canary', () => {
+describe('setup.ts wizard spawn canary', () => {
   const source = fs.readFileSync(SETUP_SRC, 'utf-8');
 
-  it('exports WIZARD_CODEX_MODEL pinned to a ChatGPT-subscription-supported model', () => {
-    // gpt-5.2-codex was Codex CLI's default and is API-only since 2026-04-14
-    // (rejected on ChatGPT accounts).
+  it('keeps WIZARD_CODEX_MODEL pinned to a ChatGPT-subscription-supported model', () => {
+    // gpt-5.2-codex was Codex CLI's default and is API-only since
+    // 2026-04-14 (rejected on ChatGPT accounts). Even though setup.ts
+    // no longer spawns codex directly, the constant remains exported
+    // as the canonical name in case a future code path needs it.
     expect(WIZARD_CODEX_MODEL).not.toBe('gpt-5.2-codex');
     // Empirically confirmed-working on ChatGPT auth per
     // src/providers/adapters/openai-codex/models.ts (probed 2026-05-15).
     expect(WIZARD_CODEX_MODEL).toMatch(/^gpt-5\.(2|3-codex|4)$/);
   });
 
-  it('every codex exec spawn in setup.ts passes -m WIZARD_CODEX_MODEL', () => {
-    // Match each `framework === 'codex-cli'` branch in setup.ts that
-    // builds a `codex exec` argv. There are two as of this fix: the
-    // wizard launch and the secret-setup micro-session. Both must
-    // include `-m` followed by WIZARD_CODEX_MODEL (or its literal
-    // value) before the freeform prompt.
-    const execBlocks = source.match(
-      /framework === 'codex-cli'[\s\S]*?\[[\s\S]*?'exec',[\s\S]*?\]/g,
-    ) ?? [];
-    expect(execBlocks.length).toBeGreaterThanOrEqual(2);
-    for (const block of execBlocks) {
-      expect(block).toMatch(/'-m'\s*,\s*WIZARD_CODEX_MODEL/);
-    }
+  it('setup.ts has no `codex exec` spawn — wizard always runs on Claude', () => {
+    // The v1.2.12 contract: every interactive micro-session in setup.ts
+    // (the main wizard launch and the secret-setup micro-session) goes
+    // through Claude, not Codex. Codex's training pulls toward execution
+    // and it routinely ignores the wizard skill's conversational
+    // contract. If a future PR adds a `codex exec` argv string back
+    // into setup.ts, this test fails — surfacing the regression to the
+    // author before it ships.
+    expect(source).not.toMatch(/'exec'\s*,\s*[\s\S]{0,200}'-m'/);
+    expect(source).not.toMatch(/'-m'\s*,\s*WIZARD_CODEX_MODEL/);
+  });
+
+  it('the wizard binary is the detected Claude path, not a framework conditional', () => {
+    // The wizardBinary assignment must not be ternary on `framework`.
+    // It should resolve to claudePath unconditionally (with a hard
+    // refusal upstream if claudePath is null).
+    const wizardBinaryAssign = source.match(/const wizardBinary = [^;]+;/);
+    expect(wizardBinaryAssign).not.toBeNull();
+    expect(wizardBinaryAssign![0]).not.toMatch(/framework\s*===\s*'codex-cli'/);
+    expect(wizardBinaryAssign![0]).toContain('claudePath');
   });
 
   it('no string literal in setup.ts hardcodes the retired gpt-5.2-codex model name', () => {
-    // Comments referencing the retired model are fine (this file has them
-    // to explain the fix). What's NOT fine is the literal name appearing
-    // inside a single- or double-quoted string, which would be a code
-    // path passing it to codex.
     expect(source).not.toMatch(/['"]gpt-5\.2-codex['"]/);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,72 @@
+# Upgrade Guide — v1.2.12 (setup wizard always uses Claude)
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**Fix: the setup wizard now always runs on Claude, regardless of
+which framework the user picked at the runtime prompt.**
+
+The first real end-to-end test of the Codex install path (v1.2.11)
+confirmed the model-pin fix from PR #299 worked — Codex spawned with
+`model: gpt-5.3-codex` and the wizard skill loaded correctly. But
+the wizard skill's behavioral contract was ignored. The skill says,
+in capitals at the top, "speak conversationally", "never show CLI
+commands", "display this text and wait for user input". Codex's
+training pulls toward execution: it parsed the wizard's JSON
+context, picked the restore-flow entry point, then ran the entire
+setup non-interactively — `npx instar init`, `user add`, `server
+start`, `autostart install`, all without asking the user a single
+identity question. The user ended up with a generic
+"Instar-codey" agent identity they never got to shape.
+
+Adding more PAUSE-HERE markers to the skill won't reliably fix this;
+the execution-pull is a training-level behavior. So the wizard
+binary is now always Claude, regardless of host framework choice.
+
+The agent's runtime is unchanged: a Codex agent stays a Codex agent
+(`enabledFrameworks: ['codex-cli']`). The framework choice still
+gates the scaffold (.codex vs .claude, AGENTS.md vs CLAUDE.md, etc).
+Only the interactive wizard binary itself is forced to Claude — the
+one tool whose entire job is conversational onboarding.
+
+Same fix applies to the Phase 2.5 secret-setup micro-session, which
+had the same framework-conditional spawn.
+
+A new refusal at the wizard binary check catches hosts without
+Claude installed and explains that Claude is the conversational
+onboarding tool — the agent itself can still run on Codex.
+
+The previous canary test from PR #299 (asserting every codex spawn
+in setup.ts carries `-m WIZARD_CODEX_MODEL`) is inverted: the
+v1.2.12 canary asserts no codex spawns remain in setup.ts at all.
+
+Spec: `specs/dev-infrastructure/wizard-via-claude.md`.
+ELI16: `specs/dev-infrastructure/wizard-via-claude.eli16.md`.
+Side-effects review: `upgrades/side-effects/fix-wizard-via-claude.md`.
+
+## What to Tell Your User
+
+Installing instar and picking Codex CLI as your agent's runtime now
+walks you through identity, autonomy, and messaging setup
+conversationally — the same way the Claude install path always has.
+Your agent still runs on Codex once setup is done. Only the
+onboarding wizard itself uses Claude.
+
+## Summary of New Capabilities
+
+No new capabilities. Behavior fix on top of v1.2.11.
+
+## Evidence
+
+Reproduction prior to fix: ran v1.2.11 install via `npx instar`
+bareword → picked Codex at runtime prompt. Codex received the
+wizard skill prompt, parsed the JSON, then executed the entire
+setup non-interactively. Full log captured at
+`/Users/justin/Documents/Projects/instar-codey/setup-logs.md` —
+2940 lines, zero conversational walkthrough, one multi-choice
+question at the very end (messaging setup).
+
+After fix: the canary unit test passes. End-to-end re-test on the
+Codex install path pending on publish.

--- a/upgrades/side-effects/fix-wizard-via-claude.md
+++ b/upgrades/side-effects/fix-wizard-via-claude.md
@@ -1,0 +1,116 @@
+# Side-effects review — Wizard always via Claude
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: UNDER. The bareword runtime prompt let the user pick Codex,
+which then spawned Codex for the wizard. Codex ignored the wizard
+skill's conversational contract and executed the setup non-
+interactively — generic agent identity, made-up user, no questions
+asked. Real failure mode observed on `instar-codey` on 2026-05-21.
+
+After: precisely targeted. The wizard ALWAYS runs on Claude. The host
+framework choice still gates everything else (enabledFrameworks,
+scaffold contents, runtime behavior). No over-block: a user who
+selected Codex still gets a Codex agent — they just go through a
+Claude-driven onboarding wizard first.
+
+A new refusal path catches the case where Claude is missing on a
+Codex-target host (Claude is already a top-level prerequisite per
+`ensurePrerequisites`, so this is a defense-in-depth check, not a
+new blocker).
+
+## 2. Level-of-abstraction fit
+
+Two argv builders in `setup.ts` were ternary on `framework`. Both
+collapse to the unconditional Claude form. The `wizardBinary`
+assignment moves from a ternary to a single `const = claudePath`
+with an upstream null-check. The function signature of
+`ensureSecretBackend` keeps the `framework` parameter (renamed to
+`_framework` to mark unused) for ABI stability with internal callers
+during the transition; future tidy-up PR can drop it.
+
+The `WIZARD_CODEX_MODEL` exported constant from PR #299 is kept as a
+deprecated public symbol — it's no longer consumed by setup.ts, but
+removing public API would be a SemVer-affecting breaking change for
+a non-blocking concern. Future PR can remove it on a minor bump.
+
+## 3. Signal vs Authority compliance
+
+- The user-runtime SIGNAL (from the v1.2.1 runtime prompt) still
+  reaches the agent's `enabledFrameworks` config and downstream
+  scaffolding decisions. It just no longer governs the interactive
+  wizard binary choice.
+- The wizard binary is now a constant choice — Claude — based on a
+  capability AUTHORITY: Claude reliably honors the wizard skill's
+  conversational contract, Codex empirically does not.
+- The runtime check `if (!claudePath) { … process.exit(1); }` is a
+  hard refusal at the gate, not an inference. The detection result is
+  the AUTHORITY.
+
+## 4. Interactions with adjacent systems
+
+- **v1.2.1 runtime prompt** (`promptForFramework` in setup.ts) —
+  unchanged. The prompt still asks which runtime the user wants;
+  that choice still flows into `enabledFrameworks`. Only the wizard
+  binary downstream of that prompt is forced to Claude.
+- **`checkFrameworkPrerequisite`** — unchanged. It still validates the
+  user's framework choice has its CLI installed.
+- **`ensurePrerequisites`** — unchanged. Top-level prerequisites still
+  require Claude regardless of framework, so the new refusal in
+  setup.ts is a defense-in-depth check rather than a new blocker.
+- **`ensureSecretBackend`** — internal change. The function still
+  accepts a `framework` parameter (renamed `_framework`) for caller
+  stability; the body no longer uses it.
+- **`/setup-wizard` slash-command** (`.claude/skills/setup-wizard/
+  SKILL.md`) — unchanged. The wizard skill text remains authored for
+  Claude-style behavioral contracts, which is now consistent with the
+  binary that runs it.
+- **`/secret-setup` slash-command** (`.claude/skills/secret-setup/
+  SKILL.md`) — unchanged.
+- **PR #299 canary** — replaced. The previous canary asserted every
+  codex exec block in setup.ts carries `-m WIZARD_CODEX_MODEL`. The
+  v1.2.12 canary asserts there are NO codex exec blocks in setup.ts.
+
+## 5. Rollback cost
+
+Trivial. One ternary becomes a const, two ternaries become constant
+arrays, one new refusal block. `git revert` restores the v1.2.11
+behavior (which is functional but produces the broken Codex wizard
+UX). No state migration needed.
+
+## 6. Backwards compatibility / drift surface
+
+Fully backwards-compatible for users.
+
+- A user who selected Claude at the runtime prompt: zero behavior
+  change.
+- A user who selected Codex: now gets a working conversational wizard
+  before their Codex agent is set up. Previously got a broken
+  experience; now gets a good one.
+- A user on a host without Claude installed: was blocked by
+  `ensurePrerequisites` before; now blocked there AND defensively at
+  the wizard binary check. No new install path opened or closed.
+- API-key Codex users: the wizard runs on Claude, so OPENAI_API_KEY
+  is not consulted during setup. Their auth posture is unchanged.
+
+No `PostUpdateMigrator` work needed (no agent-installed-files
+change, no config schema change, no hook change).
+
+## 7. Authorization / Trust posture
+
+No new authority. The wizard already ran with
+`--dangerously-skip-permissions` on Claude (per the existing
+launchArgs); the only change is that this is now ALWAYS the spawn
+shape, not framework-conditional. No new sandbox bypass, no new
+auth, no new privilege.
+
+## Outcome
+
+Ship. Closes the broken-from-the-jump Codex install UX. Closes the
+class of "wizard skill not honored on non-Claude framework" bug
+structurally — both interactive micro-sessions in setup.ts now use
+the runtime that's known to honor the skill's contract. Canary
+prevents regression. Single-purpose change, two callsites,
+trivial rollback.


### PR DESCRIPTION
## Summary
v1.2.11 fixed the Codex model-pin bug — Codex now spawns with `gpt-5.3-codex` and reaches the wizard. But end-to-end testing showed the wizard skill's conversational contract is ignored by Codex entirely. It parsed the JSON context, picked the restore entry point internally, and executed the whole setup non-interactively (`npx instar init`, `user add`, `server start`, `autostart install`). The user got a generic agent identity, watched a stream of shell commands, and was offered exactly one multi-choice question — for messaging — at the very end.

Adding more "PAUSE HERE" markers to the skill won't fix it; the execution-pull is at training level, not prompt level.

**Fix**: route the wizard binary to Claude unconditionally, regardless of host framework. The agent's runtime (`enabledFrameworks`) is unchanged — Codex agents stay Codex agents. Only the interactive onboarding tool is forced to Claude.

## Changes in setup.ts
- `binaryPath` ternary → `const wizardBinary = claudePath` with a hard refusal upstream.
- Wizard `launchArgs` ternary → unconditional Claude form.
- Secret-setup `secretArgs` ternary → unconditional Claude form.
- `ensureSecretBackend`'s `framework` param renamed `_framework` (no longer consumed).

## Test canary
PR #299's canary (asserting every codex exec block in setup.ts carries `-m WIZARD_CODEX_MODEL`) is inverted: the v1.2.12 canary asserts no codex exec blocks remain in setup.ts at all, and that `wizardBinary` resolves to `claudePath` non-conditionally.

`WIZARD_CODEX_MODEL` stays exported as a deprecated public symbol — no SemVer break in a patch release.

## Prerequisites
Claude is already required at install time (`ensurePrerequisites` checks it unconditionally), so this is consistent with shipped behavior. The new refusal check at the wizard binary gate is defense-in-depth, not a new blocker.

## Evidence
Reproduction log on v1.2.11 install of instar-codey is in Justin's project at `setup-logs.md` — 2940 lines, zero conversational walkthrough.

## Spec bundle
- Spec: `specs/dev-infrastructure/wizard-via-claude.md`
- ELI16: `specs/dev-infrastructure/wizard-via-claude.eli16.md`
- Convergence: `docs/specs/reports/wizard-via-claude-convergence.md`
- Side-effects: `upgrades/side-effects/fix-wizard-via-claude.md`
- Trace: `.instar/instar-dev-traces/20260521T195912Z-wizard-via-claude.json`

## Test plan
- [x] Canary tests pass locally (4 tests)
- [x] tsc --noEmit clean
- [ ] CI green
- [ ] Manual: re-run `npx instar@1.2.12` → pick Codex → wizard renders conversationally, walks through identity / autonomy / messaging on Claude, agent ends up with `enabledFrameworks: ['codex-cli']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)