### PR TITLE
fix(hooks): inject current wall-clock time at session-start + every user prompt

### DIFF
--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -3486,6 +3486,19 @@ fi
 # For startup/resume/clear — output a compact orientation
 echo "=== SESSION START ==="
 
+# Current wall-clock time — addresses Claude Code's "harness injects date, not
+# time of day" blind spot. Without this, agents say things like "it's 2am" when
+# it's actually 5:45am because they carry stale clock context from session
+# history. Always fired, always fresh.
+NOW=\$(date +'%Y-%m-%d %H:%M:%S %z (%Z)' 2>/dev/null)
+if [ -n "\$NOW" ]; then
+  echo ""
+  echo "--- CURRENT TIME ---"
+  echo "\$NOW"
+  echo "Wall-clock at hook fire. Quote this — do not carry stale clock times from prior context."
+  echo "--- END CURRENT TIME ---"
+fi
+
 # TOPIC CONTEXT (loaded FIRST — highest priority context)
 if [ -n "\$INSTAR_TELEGRAM_TOPIC" ]; then
   TOPIC_ID="\$INSTAR_TELEGRAM_TOPIC"
@@ -4051,6 +4064,21 @@ fi
 # This prevents the "what are we talking about?" failure after compaction
 # or session restart — where the agent receives a message without
 # conversation context and responds with a generic greeting.
+#
+# Time injection: fires on every UserPromptSubmit regardless of [telegram:N]
+# prefix so the agent always sees current wall-clock time. Addresses the
+# Claude Code "harness injects date, not time of day" blind spot that caused
+# agents to hallucinate clock times in long sessions.
+
+# Current wall-clock time — always emitted, BEFORE the [telegram:N] early-exit.
+NOW=\$(date +'%Y-%m-%d %H:%M:%S %z (%Z)' 2>/dev/null)
+if [ -n "\$NOW" ]; then
+  echo "--- CURRENT TIME ---"
+  echo "\$NOW"
+  echo "Wall-clock at user-prompt submit. Quote this — do not carry stale clock times from prior context."
+  echo "--- END CURRENT TIME ---"
+  echo ""
+fi
 
 # Read the user prompt from stdin (Claude Code pipes JSON with { prompt: "..." })
 USER_PROMPT=\$(python3 -c "

--- a/tests/unit/PostUpdateMigrator-time-injection.test.ts
+++ b/tests/unit/PostUpdateMigrator-time-injection.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Verifies that PostUpdateMigrator inlines a current-time injection block
+ * into both the SessionStart hook and the UserPromptSubmit (telegram-topic-
+ * context) hook.
+ *
+ * Why this exists: Claude Code's harness injects currentDate (e.g.
+ * "2026-05-21") into the agent's system prompt, but NOT current time of day.
+ * Agents in long sessions then hallucinate clock times ("it's 2am" when it's
+ * actually 5:45am) because they carry stale clock context. The structural
+ * fix is to emit `date` output at session start and on every user prompt,
+ * so the agent always has a fresh wall-clock anchor.
+ *
+ * These tests assert the inlined bash templates produce that block when
+ * executed. Anything that quietly drops the block — e.g. a future refactor
+ * that rewrites the hooks — should turn this test red.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+
+const migrator = new PostUpdateMigrator({
+  projectDir: '/tmp',
+  stateDir: '/tmp/.instar',
+  port: 4042,
+  hasTelegram: false,
+  projectName: 'test',
+});
+
+interface PrivateAccess {
+  getSessionStartHook(): string;
+  getTelegramTopicContextHook(): string;
+}
+const priv = migrator as unknown as PrivateAccess;
+
+function runHookScript(script: string, opts: { stdin?: string; env?: Record<string, string> } = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'instar-hook-test-'));
+  const file = join(dir, 'hook.sh');
+  writeFileSync(file, script, { mode: 0o755 });
+  chmodSync(file, 0o755);
+  const env = { ...process.env, CLAUDE_PROJECT_DIR: dir, ...opts.env };
+  const out = execFileSync('bash', [file], {
+    input: opts.stdin ?? '',
+    env,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return out;
+}
+
+describe('PostUpdateMigrator — current-time injection in session-start hook', () => {
+  const hook = priv.getSessionStartHook();
+
+  it('inlines a date(1) call so the hook emits wall-clock time', () => {
+    expect(hook).toMatch(/NOW=\$\(date \+/);
+  });
+
+  it('uses an ISO-style format string with timezone offset and abbreviation', () => {
+    expect(hook).toContain("'%Y-%m-%d %H:%M:%S %z (%Z)'");
+  });
+
+  it('wraps the emission in a non-empty guard so a broken date(1) never injects "--- CURRENT TIME ---" with no value', () => {
+    expect(hook).toMatch(/if \[ -n "\$NOW" \]/);
+  });
+
+  it('uses --- CURRENT TIME --- delimiters consistent with the rest of session-start', () => {
+    expect(hook).toContain('--- CURRENT TIME ---');
+    expect(hook).toContain('--- END CURRENT TIME ---');
+  });
+
+  it('instructs the agent to quote the wall-clock and not carry stale times', () => {
+    expect(hook).toMatch(/do not carry stale clock times/i);
+  });
+
+  it('places the time block after === SESSION START === so it lands inside the session-start frame', () => {
+    const sessionStart = hook.indexOf('=== SESSION START ===');
+    const timeBlock = hook.indexOf('--- CURRENT TIME ---');
+    expect(sessionStart).toBeGreaterThan(-1);
+    expect(timeBlock).toBeGreaterThan(sessionStart);
+  });
+
+  it('places the time block BEFORE the TOPIC CONTEXT block so it appears near the top of the injected output', () => {
+    const timeBlock = hook.indexOf('--- CURRENT TIME ---');
+    const topicContext = hook.indexOf('TOPIC CONTEXT (loaded FIRST');
+    expect(timeBlock).toBeGreaterThan(-1);
+    expect(topicContext).toBeGreaterThan(-1);
+    expect(timeBlock).toBeLessThan(topicContext);
+  });
+
+  it('executes end-to-end and emits a current-time block matching the expected shape', () => {
+    const out = runHookScript(hook);
+    expect(out).toContain('--- CURRENT TIME ---');
+    expect(out).toContain('--- END CURRENT TIME ---');
+    // Body line: ISO date + time + signed offset + (TZ abbrev)
+    expect(out).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+-]\d{4} \([A-Z]{2,5}\)/);
+  });
+});
+
+describe('PostUpdateMigrator — current-time injection in telegram-topic-context hook', () => {
+  const hook = priv.getTelegramTopicContextHook();
+
+  it('inlines a date(1) call so the hook emits wall-clock time on every user prompt', () => {
+    expect(hook).toMatch(/NOW=\$\(date \+/);
+  });
+
+  it('uses the same ISO format as session-start for consistency', () => {
+    expect(hook).toContain("'%Y-%m-%d %H:%M:%S %z (%Z)'");
+  });
+
+  it('emits the time block BEFORE the [telegram:N] early-exit so it fires for every UserPromptSubmit, not just telegram prompts', () => {
+    const timeBlock = hook.indexOf('--- CURRENT TIME ---');
+    const earlyExit = hook.indexOf('if [ -z "$TOPIC_ID" ]; then\n  exit 0');
+    expect(timeBlock).toBeGreaterThan(-1);
+    expect(earlyExit).toBeGreaterThan(-1);
+    expect(timeBlock).toBeLessThan(earlyExit);
+  });
+
+  it('executes against a non-telegram prompt (no prefix) and still emits the time block', () => {
+    const out = runHookScript(hook, { stdin: JSON.stringify({ prompt: 'plain CLI prompt with no telegram prefix' }) });
+    expect(out).toContain('--- CURRENT TIME ---');
+    expect(out).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+-]\d{4} \([A-Z]{2,5}\)/);
+  });
+
+  it('executes against a telegram-prefixed prompt and still emits the time block before bailing on missing config', () => {
+    const out = runHookScript(hook, { stdin: JSON.stringify({ prompt: '[telegram:123] hello' }) });
+    expect(out).toContain('--- CURRENT TIME ---');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,42 @@
+# Upgrade Guide — vNEXT (current-time injection in agent hooks)
+
+<!-- bump: patch -->
+<!-- patch = behavior fix that closes a recurring failure mode, no new surface -->
+
+## What Changed
+
+**Fix: every instar agent now sees the current wall-clock time at session start AND on every user prompt.**
+
+Claude Code's harness injects `currentDate: YYYY-MM-DD` into the agent's system prompt — but NOT the current time of day. In long-running sessions (hours, days), agents that try to say "it's 2am" or "you've been up X hours" or "we just talked an hour ago" were either hallucinating clock times outright or pulling stale time strings from earlier conversation context. Iris hit this on 2026-05-21: she told a user "it's 2am" when it was actually 5:45am, and only realized it after the user contradicted her with a timestamped screenshot.
+
+The fix is structural, not behavioral. Two existing hooks every instar agent already runs now emit a `--- CURRENT TIME ---` block backed by a live `date(1)` call:
+
+- **`session-start.sh`** (SessionStart hook, startup / resume / clear) — emits the time block immediately after `=== SESSION START ===`, before any other context. Refreshed on every session lifecycle event including post-compaction resume.
+- **`telegram-topic-context.sh`** (UserPromptSubmit hook) — emits the time block on **every** user prompt, BEFORE the `[telegram:N]` prefix early-exit. So agents get a fresh wall-clock anchor on every turn, not just at session start, regardless of whether the prompt arrived via Telegram or direct CLI use.
+
+Format: `2026-05-21 14:15:29 -0500 (CDT)` — ISO date + 24h time + signed offset + tz abbreviation. Same line every time. Agents are told explicitly: "Quote this — do not carry stale clock times from prior context."
+
+The hook content lives inline in `src/core/PostUpdateMigrator.ts` (functions `getSessionStartHook()` and `getTelegramTopicContextHook()`), which is the source of truth that both `init` (new agents) and `migrate` (existing agents) write to disk. Built-in hooks are unconditionally overwritten on every migration run, so existing agents pick up the fix automatically on their next `npx instar` invocation — no manual migration required.
+
+## What to Tell Your User
+
+If your agent has ever made a clock-time claim that turned out to be wrong (saying it's the middle of the night when it isn't, miscalculating "how long ago" something happened, mismatching AM/PM), that failure mode is closed after this release. Your agent now sees the actual current time on every interaction and is structurally instructed to quote it rather than guess.
+
+No action needed from you. The next time your agent updates, the fix lands.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Wall-clock time injected at session start | Automatic — `--- CURRENT TIME ---` block at the top of session-start output |
+| Wall-clock time refreshed on every user prompt | Automatic — same block emitted ahead of telegram-topic-context every UserPromptSubmit |
+
+## Evidence
+
+- New test: `tests/unit/PostUpdateMigrator-time-injection.test.ts` — 13 cases. Static assertions on the inlined bash (date format, guard, delimiters, ordering) PLUS end-to-end execution of both hook scripts against a fresh sandboxed temp dir, asserting the actual emitted output matches the expected `YYYY-MM-DD HH:MM:SS +ZZZZ (TZ)` shape.
+- Existing tests still pass: `tests/unit/PostUpdateMigrator-sharedState.test.ts` (Integrated-Being session-start regression) and `tests/unit/scaffold-identity-hooks.test.ts` (scaffold integrity) verified green against the patched migrator.
+- Side-effects review: `upgrades/side-effects/inject-current-time-into-hooks.md`.
+
+## Original Incident
+
+Iris session, Business Plan topic, 2026-05-21 ~5:45am CDT. Agent said "It's 2am. The laptop can wait. Goodnight." User's actual local time was 5:45am Central. Memory note `feedback_clock_time_must_call_date.md` captured the rule per-agent; this release lifts the fix to the framework so every instar agent benefits without each agent having to learn the lesson independently.

--- a/upgrades/side-effects/inject-current-time-into-hooks.md
+++ b/upgrades/side-effects/inject-current-time-into-hooks.md
@@ -1,0 +1,63 @@
+# Side-Effects Review — inject current time into agent hooks
+
+**Version / slug:** `inject-current-time-into-hooks`
+**Date:** `2026-05-21`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (Layer 1 hook-template content change, signal-only, no gate authority — Phase 5 trigger inventory below)
+
+## Summary of the change
+
+`PostUpdateMigrator.getSessionStartHook()` and `getTelegramTopicContextHook()` (the inlined bash templates that get unconditionally overwritten onto every agent's disk on update) now each emit a `--- CURRENT TIME ---` block backed by a fresh `date(1)` invocation. The block contains an ISO-formatted wall-clock timestamp with signed offset and timezone abbreviation, plus a one-line instruction to the agent: "Quote this — do not carry stale clock times from prior context."
+
+**Files touched:**
+- `src/core/PostUpdateMigrator.ts` — 14 lines added to `getSessionStartHook()` (after the `=== SESSION START ===` echo, before the TOPIC CONTEXT block); 14 lines added to `getTelegramTopicContextHook()` (immediately before the [telegram:N] early-exit, so the block fires on every UserPromptSubmit regardless of prefix).
+- `tests/unit/PostUpdateMigrator-time-injection.test.ts` — new file, 13 test cases. Static assertions on the inlined bash (date format string, non-empty guard, delimiter strings, relative ordering within each hook) PLUS end-to-end `execFileSync` of each hook script against a fresh temp dir, asserting the actual emitted output matches the expected `YYYY-MM-DD HH:MM:SS +ZZZZ (TZ)` shape on a non-telegram prompt, a telegram-prefixed prompt, and a session-start invocation.
+- `upgrades/NEXT.md` — new vNEXT entry, classified `patch` (behavior fix, no new surface).
+
+## Decision-point inventory
+
+- **Where the time block lands in session-start output** — *modify*. Placed AFTER `=== SESSION START ===` and BEFORE the TOPIC CONTEXT block. Rationale: the wall-clock is generic orientation, not topic-specific — it belongs at the top of the orientation frame, ahead of the per-conversation context. Asserted by test `places the time block BEFORE the TOPIC CONTEXT block`.
+- **Where the time block lands in UserPromptSubmit** — *modify*. Placed BEFORE the `[telegram:N]` early-exit. Rationale: the script's filename suggests telegram-only, but UserPromptSubmit fires on every prompt — emitting the time block before the early-exit makes the fix universal (Telegram and direct-CLI sessions both get it). Asserted by test `emits the time block BEFORE the [telegram:N] early-exit`.
+- **Output guard against a broken `date(1)`** — *new*. Wrap the emission in `if [ -n "$NOW" ]; then ... fi` so a hypothetical environment where `date(1)` returns empty (extremely unlikely on macOS/Linux) doesn't produce a `--- CURRENT TIME ---` header with no value. Asserted by test `wraps the emission in a non-empty guard`.
+- **Date format choice** — *new*. `'%Y-%m-%d %H:%M:%S %z (%Z)'`. Portable across BSD date (macOS) and GNU date (Linux); produces both machine-parseable (`%z`) and human-readable (`%Z`) timezone forms. Verified by the end-to-end test which `execFileSync`s the hook and regex-matches the emitted body.
+- **Delimiter style** — *match existing*. `--- CURRENT TIME ---` / `--- END CURRENT TIME ---` mirrors the dashed delimiters already used in session-start for other blocks (`--- CONVERSATION CONTEXT ---`, `--- INTEGRATED-BEING ---`, `--- PROJECT CONTEXT ---`). No new visual convention introduced.
+
+## Level-of-abstraction fit
+
+This is a Layer 1 (hook content) change. It belongs at the migrator level — both because the migrator is the source of truth for hook content (init and update both write from `getSessionStartHook()` / `getTelegramTopicContextHook()`) and because the failure mode (stale clock in long agent sessions) is a cross-cutting infrastructure gap, not a per-agent or per-feature concern. Solving it per-agent (e.g. Iris's memory file `feedback_clock_time_must_call_date.md`) closed the gap for one agent. Lifting it to the framework means every instar agent gets the same anchor without each one having to learn the lesson independently — which matches the **Structure > Willpower** principle stated in CLAUDE.md.
+
+## Signal-vs-authority compliance
+
+The hook injection emits text. It does not gate, block, modify, or veto any agent action. It is pure signal — the agent reads the wall-clock and is told to quote it. Authority over whether to use the time, what time to claim, or whether to call `date` again later remains entirely with the agent. No new blocking authority introduced.
+
+## Interactions
+
+- **Compaction recovery** (`compaction-recovery.sh`): On `compact` event, `session-start.sh` `exec`s away to `compaction-recovery.sh` BEFORE the time block is reached. So the time block does not run during compact-recovery. Compaction-recovery's own injection pipeline is separate and is not regressed by this change. The block DOES run on resume, which fires after compaction completes. No double-emission.
+- **Telegram early-exit**: Adding output BEFORE the `[telegram:N]` early-exit means the hook now produces output on every UserPromptSubmit, including non-telegram prompts. This is intentional — direct-CLI sessions need the time anchor too. Effect on Claude Code: an additional ~3-line block in the agent's prompt buffer per turn. Token cost negligible (~30 tokens).
+- **Integrated-Being v2 session-bind**: The session-bind block in `session-start.sh` lives AFTER the time block but runs independently. Time injection produces output via stdout; session-bind makes HTTP calls and writes a token file. No shared variables, no ordering dependency.
+- **Existing PostUpdateMigrator-sharedState test**: Asserts the integrated-being injection survives in `getSessionStartHook()`. The new time block sits BEFORE the integrated-being block; the existing assertion (`expect(hook).toContain('/shared-state/render?limit=50')`) continues to pass — verified in test run.
+
+## Over/under-block check
+
+- **Under-block**: Could the fix miss any cases where an agent says a clock time?
+  - **Mid-session tool-result handoffs**: If an agent receives a Claude Code tool result and immediately replies with a time claim, the most recent time anchor is the previous UserPromptSubmit. Up to 5 minutes stale in fast back-and-forths, less for slow ones. Acceptable — within a single turn, ±a-few-minutes is fine. Worst-case would be a multi-hour autonomous-mode tool loop without user prompts, in which case the agent could go stale. Mitigated separately by autonomous-mode's existing periodic re-orientation; not in scope here.
+  - **Subagent invocations**: Sub-agents started via the `Agent` tool inherit the parent's prompt context, not the live hook output. So a subagent's time anchor is the parent's at-spawn time. Acceptable — subagents are short-lived and rarely make wall-clock claims; their job is task execution.
+- **Over-block**: Could the fix cause an unintended block, refusal, or behavior change elsewhere?
+  - **Hook timeout (5s budget for UserPromptSubmit)**: Adding a `date` call adds <1ms. No timeout risk.
+  - **Token bloat in long sessions**: ~30 tokens per turn × thousands of turns = a few hundred-K tokens over a long session. Compared to the existing telegram-topic-context block (~500 tokens / turn for recent history), this is a rounding error.
+  - **Test pollution**: The end-to-end test uses `mkdtempSync` + per-test env var override, no persistent state. No effect on parallel test runs.
+
+## Rollback cost
+
+Two-line `git revert` of the migrator edit, plus deleting the new test file. Hooks are unconditionally overwritten on next migration run, so a revert propagates to all deployed agents on their next `npx instar`. No data migration, no persistent state, no fan-out — zero rollback friction.
+
+## Phase 5 trigger check
+
+Was a second-pass reviewer required? No.
+
+- **Not a gate change**: No new authority, no blocking, no veto, no permission alteration. Signal-only.
+- **Not a security-sensitive surface**: No new file reads outside the hook's existing scope (it only adds a `date` call); no new network calls; no new credential or token handling.
+- **No new persistent state**: Output flows to stdout, consumed by Claude Code's prompt injector. No disk writes, no SQLite, no JSONL.
+- **No cross-agent or cross-machine effect**: Per-agent hook content. No threadline message, no shared state, no remote operation.
+
+The change crosses **none** of the second-pass triggers from the side-effects review standard. A single-pass review by the author with this written record is sufficient.


### PR DESCRIPTION
## Summary

- Both hooks every instar agent already runs (`session-start.sh` + `telegram-topic-context.sh`) now emit a `--- CURRENT TIME ---` block backed by a live `date(1)` call so agents always have a fresh wall-clock anchor.
- Closes the failure mode where Iris (and almost certainly other long-running agents) told users it was "2am" when it was actually 5:45am, because Claude Code's harness injects `currentDate` but not time of day.
- Built-in hooks are unconditionally overwritten on every migration run, so deployed agents pick this up automatically on their next `npx instar`.

## What changed

| Hook | Where the block fires | Why there |
|---|---|---|
| `getSessionStartHook()` | After `=== SESSION START ===`, before TOPIC CONTEXT | Top of every session-start orientation frame |
| `getTelegramTopicContextHook()` | Before the `[telegram:N]` early-exit | Fires on every UserPromptSubmit — Telegram and direct-CLI sessions both get a fresh anchor per turn |

Format: `YYYY-MM-DD HH:MM:SS +ZZZZ (TZ)` — portable across BSD/GNU date, machine-parseable + human-readable, instructs the agent: "Quote this — do not carry stale clock times from prior context."

## Test plan

- [x] `tests/unit/PostUpdateMigrator-time-injection.test.ts` — 13 new cases. Static assertions on the inlined bash + end-to-end `execFileSync` of each hook against a temp dir, asserting the actual emitted output matches the expected timestamp shape on non-telegram prompts, telegram-prefixed prompts, and session-start invocations.
- [x] `tests/unit/PostUpdateMigrator-sharedState.test.ts` (existing Integrated-Being regression) — verified still green.
- [x] `tests/unit/scaffold-identity-hooks.test.ts` (existing scaffold integrity) — verified still green.
- [x] Typecheck clean (`tsc --noEmit`).
- [x] Side-effects review: `upgrades/side-effects/inject-current-time-into-hooks.md` — signal-only, no gate authority, no second-pass reviewer triggers crossed.
- [x] Release note: `upgrades/NEXT.md` — patch bump.

## Original incident

Iris, Business Plan topic, 2026-05-21 ~5:45am CDT: "It's 2am. The laptop can wait. Goodnight." User contradicted with a timestamped screenshot. Per-agent memory note captured the rule (`feedback_clock_time_must_call_date.md`); this PR lifts the fix to the framework so every instar agent benefits without each one having to learn the lesson independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)