### PR TITLE
fix(setup-wizard): Telegram-native flow + add-user cwd + choice echo (v1.2.15)

### DIFF
--- a/.instar/instar-dev-traces/20260521T235610Z-wizard-telegram-native.json
+++ b/.instar/instar-dev-traces/20260521T235610Z-wizard-telegram-native.json
@@ -1,0 +1,19 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/wizard-telegram-native.md",
+  "artifactPath": "upgrades/side-effects/fix-wizard-telegram-native.md",
+  "artifactSha256": "609d9b6d5148f5cb146757ea82ba1a5f60068576313fe3b8ef98fa105adc6675",
+  "coveredFiles": [
+    "src/commands/setup-wizard/codex-driver.ts",
+    "tests/unit/wizard-telegram-native.test.ts",
+    "tests/unit/setup-codex-model-canary.test.ts",
+    "specs/dev-infrastructure/wizard-telegram-native.md",
+    "specs/dev-infrastructure/wizard-telegram-native.eli16.md",
+    "docs/specs/reports/wizard-telegram-native-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/fix-wizard-telegram-native.md"
+  ],
+  "writtenAt": "2026-05-21T23:56:10Z",
+  "agent": "echo",
+  "summary": "Three real-user UX fixes from the v1.2.14 Codex install log: (1) drop -d on user-add spawn, use cwd; (2) echo choice label after validation; (3) rewrite Telegram setup as instar-native readline + Telegram Bot API flow. The Telegram rewrite replaces a broken codex-exec spawn that couldn't wait for user input and was silently marking the channel as configured. 6 new tests + updated canary. Ships v1.2.15."
+}

--- a/docs/specs/reports/wizard-telegram-native-convergence.md
+++ b/docs/specs/reports/wizard-telegram-native-convergence.md
@@ -1,0 +1,80 @@
+# Convergence Report — Telegram-native wizard + add-user cwd + choice echo
+
+## ELI10 Overview
+
+Justin's second real test of the hybrid wizard surfaced three bugs.
+The user-profile-creation call passed a flag the CLI doesn't accept
+("error: unknown option '-d'"). The multi-choice prompts silently
+accepted text answers without showing what got picked. And the
+Telegram setup spawned a Codex session that couldn't actually wait
+for the user to paste a bot token — so it printed instructions, ended,
+and the wizard recorded "Telegram is configured!" without anything
+being configured.
+
+This PR fixes all three. The user-add fix swaps `-d` for cwd. The
+choice prompts now echo `→ Proactive` after the wizard interprets
+the answer. And the Telegram setup is rewritten as an instar-native
+readline flow that calls the Telegram Bot API directly to validate
+tokens and discover chat IDs — no LLM session in the loop at all.
+
+## Original vs Converged
+
+The fix went straight to the right shape. One alternative was
+considered and rejected for the Telegram path:
+
+- **Keep Codex in the Telegram setup but make it interactive (codex
+  REPL mode instead of `codex exec`)**: rejected because that takes
+  over the terminal in a way the state machine can't coordinate
+  with — the user would then be talking to Codex directly, not to
+  the wizard, with no clean handoff back. The instar-native flow
+  using readline + the Telegram Bot API is more reliable and gives
+  the same end-user experience (clear instructions, automated
+  validation, automated chat-ID discovery).
+
+The "intelligence" angle Justin emphasized in the earlier PR
+guidance is preserved: per-step Codex narrative still introduces
+each conversational step warmly. Only the EXECUTION halves (running
+CLI commands, calling the Telegram API) are instar-native — which
+is the right shape for executions that need predictable success/
+failure semantics.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1         | self + Justin's real-user log | 3 | Telegram rewrite, cwd fix, echo helper |
+| 2         | (converged)           | 0                 | none |
+
+## Full Findings Catalog
+
+**Finding 1 — `instar user add -d` rejected by CLI.**
+
+- Severity: medium (silent failure of user-profile creation step).
+- Resolution: drop `-d` from argv; set spawn `cwd:
+  options.projectDir`. Same fix applied to start-server and
+  install-autostart for consistency.
+
+**Finding 2 — Choice prompts accepted text input silently.**
+
+- Severity: medium (user couldn't tell whether their text input was
+  understood).
+- Resolution: new `echoChoice(state, answer)` helper called from
+  the renderNarrativeState retry loop. Prints `→ {label}` after the
+  validator accepts.
+
+**Finding 3 — Telegram setup spawned non-interactive Codex
+session.**
+
+- Severity: high (most-requested messaging channel silently failed).
+- Resolution: full rewrite of runTelegramSetup as instar-native
+  readline + Telegram Bot API. Three new private helpers
+  (telegramGetMe, telegramGetUpdates, writeTelegramConfig). Never
+  returns `telegramConfigured: true` unless the config write
+  succeeded.
+
+## Convergence verdict
+
+Converged at iteration 2. Three scoped fixes; no new abstraction
+layers; existing primitives only. The Telegram rewrite is the bulk
+of the change but lives entirely in one function + three helpers
+inside the same module. Spec is ready.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.2.14",
+      "version": "1.2.15",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/wizard-telegram-native.eli16.md
+++ b/specs/dev-infrastructure/wizard-telegram-native.eli16.md
@@ -1,0 +1,82 @@
+# What this PR does — in plain English
+
+## Three bugs from Justin's second real test
+
+He re-ran the wizard on `instar-codey` against v1.2.14 (which had
+the buffered-Enter fix). New problems showed up:
+
+1. **The wizard tried to create his user profile but the command
+   errored.** I had it calling `npx instar user add -d <dir> ...`
+   but `user add` doesn't accept a `-d` flag. It reads the project
+   from the current working directory. Result: silent failure, no
+   user profile created.
+
+2. **When he typed "Proactive" and "Telegram" as answers (instead
+   of "2" and "1"), the wizard accepted them silently** without
+   showing him what it picked. The interpreter DID work — both got
+   matched correctly — but he had no visual confirmation, so he
+   wasn't sure whether the wizard understood his words or was
+   about to default to something else.
+
+3. **Telegram setup was completely broken.** The wizard handed off
+   to a Codex session that was supposed to walk him through
+   creating a bot. But the way Codex's `exec` mode works, the
+   session can't actually wait for the user to paste a bot token —
+   it's a single-shot, "here's a prompt, generate a response, end".
+   So Codex correctly printed manual BotFather instructions and
+   asked for the token, then immediately ended. The wizard saw the
+   session end successfully and recorded "Telegram is configured!"
+   when nothing was actually configured.
+
+## What this PR fixes
+
+### Fix 1: User profile creation
+
+Drop the `-d` flag and just set the spawn's cwd to the project
+directory. Same outcome, but uses the flag set the CLI actually
+accepts.
+
+### Fix 2: Echo the selected choice
+
+After the wizard validates a multiple-choice answer, it prints
+"→ Proactive" (or whatever the resolved label is). The user sees
+what got picked. If the wizard misinterpreted, they can Ctrl-C and
+restart. No more silent acceptance of word answers.
+
+### Fix 3: Instar-native Telegram setup
+
+The whole Telegram action is rewritten. No more spawning Codex for
+it. Now instar walks the user through it directly:
+
+1. Print clear BotFather instructions.
+2. Read the bot token via readline. Verify it by calling Telegram's
+   `getMe` API. If invalid, ask again (up to 5 times).
+3. Print clear "add the bot to a group and send a message"
+   instructions. Wait for them to press Enter.
+4. Call Telegram's `getUpdates` API to find the chat they were in.
+   Extract the chat ID automatically. If nothing comes back, try
+   again (up to 4 times).
+5. Write the token + chat ID into `.instar/config.json` under
+   `messaging[].config`.
+
+Importantly: if ANY of those steps fails, the action records
+"Telegram NOT configured" rather than silently lying. The user
+gets a clear "you can finish setup later by chatting your agent"
+message.
+
+## Why this is more robust
+
+No "session that can't wait for input" failure mode. No dependency
+on Playwright being available. No reliance on Codex correctly
+interpreting a complex multi-step instruction. Just clear prompts,
+direct API calls, and explicit success/failure paths.
+
+## What doesn't change
+
+- The hybrid wizard architecture is the same. State machine still
+  owns the flow. Codex still generates the warm narrative paragraphs
+  for the conversational steps.
+- The Claude wizard path is untouched.
+- WhatsApp and Slack still print a "configure later" pointer; their
+  native flows come in a follow-up.
+- The agent's runtime is still whatever the user picked.

--- a/specs/dev-infrastructure/wizard-telegram-native.md
+++ b/specs/dev-infrastructure/wizard-telegram-native.md
@@ -1,0 +1,162 @@
+---
+title: "Wizard fixes — Telegram-native flow, user-add cwd, choice echo"
+slug: "wizard-telegram-native"
+author: "echo"
+eli16-overview: "wizard-telegram-native.eli16.md"
+review-convergence: "2026-05-21T23:55:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-21T23:55:00Z"
+review-report: "docs/specs/reports/wizard-telegram-native-convergence.md"
+approved: true
+---
+
+# Wizard fixes — Telegram-native flow, user-add cwd, choice echo
+
+## Problem statement
+
+Second real-user log of the hybrid wizard on Codex (v1.2.14, after
+the buffered-Enter fix) surfaced three more issues. Reviewed
+chronologically:
+
+1. **`instar user add` errored with "unknown option '-d'"** during
+   the add-user action. The codex-driver was passing
+   `-d <projectDir>` but the `user add` CLI does NOT accept that
+   flag — it reads project state from cwd. The user profile got
+   created in the parent `~/.instar/agents/echo/.worktrees/...`
+   process cwd as a side effect that nobody actually wanted, or
+   silently failed. Either way the new agent's `users.json` stayed
+   empty.
+
+2. **Choice prompts silently accepted text input without
+   confirmation.** Justin typed "Proactive" at the autonomy prompt
+   and "Telegram" at the messaging prompt. `resolveChoice` correctly
+   matched both by label-prefix and returned the right values. But
+   the wizard never echoed back the selection, so the user couldn't
+   tell whether the input had been understood or whether it was
+   about to bail with the fallback.
+
+3. **Telegram setup spawned `codex exec` which can't wait for user
+   input.** The action handed off to a Codex agentic session with a
+   "walk the user through BotFather" prompt. Codex correctly noted
+   Playwright wasn't available and printed manual instructions:
+   "send me the bot token and chat ID and I'll write the config."
+   But `codex exec` is non-interactive single-turn — there was no
+   way for the user to actually send the token because the exec call
+   had already consumed stdin and was already terminating. Codex
+   printed the request, ended successfully, and the wizard recorded
+   `telegramConfigured: true` without anything actually configured.
+
+Justin's verdict: *"telegram setup with playwright failed. we need
+to make sure this is extremely robust and will always work."*
+
+## Proposed design
+
+Three scoped fixes in `src/commands/setup-wizard/codex-driver.ts`.
+
+### Fix 1: user-add cwd (not -d)
+
+The `add-user` action's argv changes from:
+
+```ts
+['instar', 'user', 'add', '-d', options.projectDir, '--id', id, '--name', name]
+```
+
+to:
+
+```ts
+['instar', 'user', 'add', '--id', id, '--name', name]
+// + spawn option: { cwd: options.projectDir }
+```
+
+`server start` and `autostart install` already accept `-d` and they
+keep it for explicitness; their spawn options now ALSO set cwd so
+all action subprocesses run in the project directory consistently.
+
+### Fix 2: Choice echo after validation
+
+A new `echoChoice(state, answer)` helper, called from
+`renderNarrativeState` after the validator accepts the answer. For
+`kind: 'choice'` prompts, it prints `  → {choice.label}` (e.g.
+"→ Proactive") so the user sees the wizard's interpretation of
+their text input. For `kind: 'text'` prompts it's a no-op (the
+answer is the answer).
+
+The echo also catches cases where the user types a partial label
+prefix and gets matched to something they didn't intend — they see
+the resolved label and can interrupt before the action runs.
+
+### Fix 3: Telegram-native setup flow
+
+`runTelegramSetup` is rewritten end-to-end. The codex exec spawn is
+gone. The new flow:
+
+```
+Step 1 of 3 — Create a bot
+  ↳ Print BotFather instructions verbatim.
+  ↳ readline → token input.
+  ↳ Verify via GET https://api.telegram.org/bot<TOKEN>/getMe.
+  ↳ Loop up to 5 attempts on bad token; "skip" exits with a
+    "configure later" pointer (does NOT mark as configured).
+
+Step 2 of 3 — Connect a chat
+  ↳ Print "add the bot to a group, send a message" instructions.
+  ↳ Press-Enter prompt while user does it.
+  ↳ GET https://api.telegram.org/bot<TOKEN>/getUpdates.
+  ↳ Find a group/supergroup chat in the result (fall back to most
+    recent chat of any type). Extract id + name.
+  ↳ Loop up to 4 attempts with "skip" option.
+
+Step 3 of 3 — Save config
+  ↳ Read .instar/config.json.
+  ↳ Strip any existing { type: 'telegram' } entry (idempotent).
+  ↳ Push { type: 'telegram', enabled: true, config: { token, chatId,
+    pollIntervalMs: 2000, stallTimeoutMinutes: 5 } }.
+  ↳ Write back.
+```
+
+Failure modes:
+- Token validation fails 5 times → skip, `telegramConfigured: false`,
+  user can run `instar add telegram` later.
+- getUpdates discovery fails 4 times → save partial config (token
+  only), `telegramConfigured: false`, agent's first chat from the
+  user fills in the chat ID.
+- Network unreachable → skip with clear "try again later" pointer.
+- `.instar/config.json` write fails → `telegramConfigured: false`,
+  user gets a clear message that the bot is created but not wired up.
+
+Critically, the action NEVER returns `telegramConfigured: true` when
+the config wasn't actually written — closing the v1.2.14 silent-
+success failure mode.
+
+## Decision points touched
+
+- The wizard's `setup-telegram-agentic` action moves from
+  framework-as-agent to instar-native. The action name stays
+  unchanged (still describes the user-visible behavior) but the
+  implementation is structural.
+- No new authority. The flow uses `node:fetch` (Node 22+ builtin)
+  for Telegram API calls and existing `fs.readFileSync` /
+  `fs.writeFileSync` for config persistence. Both are routine.
+- The action's contract with the state machine is unchanged:
+  returns `{ telegramConfigured: true | false }` for downstream
+  consumers (e.g., the lifeline-greeting action).
+
+## Open questions
+
+None for this PR's scope.
+
+## Out of scope
+
+- WhatsApp + Slack agentic flows. Today the wizard emits a
+  "configure later" pointer for those; porting them to instar-
+  native flows is a separate spec.
+- A Codex agentic Telegram-via-Playwright path. If/when Playwright
+  MCP tools land for Codex installs, a follow-up spec can add an
+  agentic variant of the setup that runs in PARALLEL with the
+  manual flow (user picks which). Today the manual + API flow is
+  reliable enough on its own and works across all environments.
+- LLM-driven input interpretation for choice prompts ("the user
+  said 'I'd rather just have it ask me', interpret that as Guided").
+  Out of scope for v1.2.15; the validator + echo pattern handles
+  the failure mode this real-user log surfaced (Justin's actual
+  inputs DID get interpreted correctly — they just weren't echoed).

--- a/src/commands/setup-wizard/codex-driver.ts
+++ b/src/commands/setup-wizard/codex-driver.ts
@@ -18,13 +18,15 @@
  * driving the browser, that's its strength).
  */
 
-import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
 import pc from 'picocolors';
 import {
   buildFreshProjectInstall,
   INITIAL_STATE,
+  resolveChoice,
   type WizardAnswers,
   type WizardState,
   type WizardAction,
@@ -291,16 +293,45 @@ async function renderNarrativeState(
   // resolveChoice fallback so the wizard doesn't crash.
   for (let attempt = 0; attempt < 5; attempt++) {
     const answer = await askUser('  > ');
-    if (!state.validate) return answer;
+    if (!state.validate) {
+      echoChoice(state, answer);
+      return answer;
+    }
     const validationMsg = state.validate(answer);
-    if (validationMsg === null) return answer;
+    if (validationMsg === null) {
+      echoChoice(state, answer);
+      return answer;
+    }
     console.log();
     console.log(pc.yellow(`  ${validationMsg}`));
     console.log();
   }
   // Last-resort: take whatever was last typed even if invalid. The
   // state machine's `next` should still produce a usable transition.
-  return askUser('  > ');
+  const answer = await askUser('  > ');
+  echoChoice(state, answer);
+  return answer;
+}
+
+/**
+ * For choice prompts, echo the resolved label back to the user as a
+ * confirmation line ("→ Proactive"). For text prompts, no-op — the
+ * answer is the answer.
+ *
+ * This closes the v1.2.14 confusion where typing "Proactive" or
+ * "Telegram" got correctly interpreted by resolveChoice but the
+ * wizard never showed the user what selection it understood.
+ */
+function echoChoice(
+  state: Extract<WizardState, { kind: 'narrative-then-prompt' }>,
+  answer: string,
+): void {
+  if (state.input.kind !== 'choice') return;
+  const matched = resolveChoice(answer, state.input.choices);
+  if (!matched) return;
+  const choice = state.input.choices.find((c) => c.value === matched);
+  if (!choice) return;
+  console.log(pc.dim(`  → ${choice.label}`));
 }
 
 /**
@@ -337,13 +368,16 @@ async function runAction(
     }
 
     case 'add-user': {
-      const id = (answers.userName || 'user').toLowerCase().replace(/[^a-z0-9]/g, '');
+      const id = (answers.userName || 'user').toLowerCase().replace(/[^a-z0-9]/g, '') || 'user';
       const name = answers.userName || 'User';
       try {
+        // `instar user add` reads project from cwd — does NOT accept
+        // -d/--dir (pre-fix passed it and the CLI errored "unknown
+        // option '-d'"). Set cwd on the spawn instead.
         execFileSync(
           'npx',
-          ['instar', 'user', 'add', '-d', options.projectDir, '--id', id, '--name', name],
-          { stdio: 'inherit' },
+          ['instar', 'user', 'add', '--id', id, '--name', name],
+          { stdio: 'inherit', cwd: options.projectDir },
         );
       } catch {
         // non-fatal
@@ -353,7 +387,12 @@ async function runAction(
 
     case 'start-server': {
       try {
-        execFileSync('npx', ['instar', 'server', 'start', '-d', options.projectDir], { stdio: 'inherit' });
+        // server start accepts -d, but pass cwd too for consistency.
+        execFileSync(
+          'npx',
+          ['instar', 'server', 'start', '-d', options.projectDir],
+          { stdio: 'inherit', cwd: options.projectDir },
+        );
         return { serverStarted: true };
       } catch {
         return { serverStarted: false };
@@ -362,7 +401,11 @@ async function runAction(
 
     case 'install-autostart': {
       try {
-        execFileSync('npx', ['instar', 'autostart', 'install', '-d', options.projectDir], { stdio: 'inherit' });
+        execFileSync(
+          'npx',
+          ['instar', 'autostart', 'install', '-d', options.projectDir],
+          { stdio: 'inherit', cwd: options.projectDir },
+        );
       } catch {
         // non-fatal
       }
@@ -398,62 +441,199 @@ async function runAction(
 }
 
 /**
- * Telegram setup — the agentic phase. Spawns Codex with a tight
- * Telegram-specific prompt and Playwright access. Codex's
- * execution-orientation is an asset here.
+ * Telegram setup — instar-native flow.
+ *
+ * Previously this spawned `codex exec` and asked it to walk the user
+ * through BotFather. But `codex exec` is non-interactive (single-turn,
+ * stdin already consumed by the prompt), so it couldn't wait for the
+ * user to paste a token. The spawned session printed manual
+ * instructions, ended, and the wizard recorded "telegramConfigured:
+ * true" without anything actually configured.
+ *
+ * The fix: drive the entire Telegram setup from instar with readline +
+ * the Telegram Bot API. No LLM session is involved. We:
+ *
+ *  1. Print clear BotFather instructions.
+ *  2. Prompt the user for the bot token, validate via getMe.
+ *  3. Prompt the user to add the bot to a group and send a message,
+ *     then call getUpdates to extract the chat ID.
+ *  4. Write the token + chat ID into .instar/config.json's messaging[].
+ *
+ * Failure modes (network down, user can't paste, etc.) gracefully
+ * skip with a clear "you can finish setup later" pointer, but never
+ * silently mark the channel as configured when it isn't.
  */
 async function runTelegramSetup(options: CodexDriverOptions): Promise<Partial<WizardAnswers>> {
-  const skillPath = path.join(
-    options.instarRoot,
-    '.claude',
-    'skills',
-    'setup-wizard',
-    'SKILL.md',
-  );
-  // Inline Codex-specific Telegram-only prompt. The skill text isn't
-  // perfect for Codex but the Telegram-via-Playwright phase is
-  // primarily execution (open browser, click buttons, capture token),
-  // which Codex handles well.
-  const telegramPrompt = `
-You are completing the Telegram messaging setup for an instar agent
-already initialized at ${options.projectDir}.
+  console.log();
+  console.log(pc.bold('  Telegram setup'));
+  console.log(pc.dim('  This takes about 2 minutes. I\'ll walk you through each step.'));
+  console.log();
+  console.log(pc.bold('  Step 1 of 3 — Create a bot'));
+  console.log('  • Open https://web.telegram.org/a/ in your browser');
+  console.log('  • Search for @BotFather and start a chat');
+  console.log('  • Send /newbot and follow the prompts:');
+  console.log('      – Display name (e.g. "Instar Codey")');
+  console.log('      – Username (must end with "bot", e.g. "instar_codey_bot")');
+  console.log('  • BotFather will reply with a token like 1234567890:AAH...');
+  console.log();
 
-Your task is OPERATIONAL and BOUNDED:
-1. Open Telegram Web in a browser via Playwright (if Playwright MCP
-   tools are available; otherwise fall back to printing manual steps).
-2. Help the user create a bot via BotFather.
-3. Capture the bot token and chat ID.
-4. Write them to .instar/config.json under messaging[].config.
+  let token = '';
+  let botUsername = '';
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const input = (await askUser('  Paste the bot token here: ')).trim();
+    if (!input) {
+      console.log(pc.yellow('  That looked blank — paste the token from BotFather (the long string).'));
+      continue;
+    }
+    console.log(pc.dim('  Verifying token with Telegram…'));
+    const verified = await telegramGetMe(input);
+    if (!verified.ok) {
+      console.log(pc.yellow(`  Telegram rejected that token: ${verified.error}. Try pasting it again.`));
+      continue;
+    }
+    token = input;
+    botUsername = verified.username;
+    console.log(pc.green(`  ✓ Bot verified: @${botUsername}`));
+    break;
+  }
+  if (!token) {
+    console.log(pc.yellow('  Skipping Telegram for now. You can finish setup by chatting your agent later.'));
+    return { telegramConfigured: false };
+  }
 
-When you have the token + chat ID and have written them, exit. Do NOT
-proceed past Telegram setup — the rest of the wizard is owned by
-instar's state machine.
+  console.log();
+  console.log(pc.bold('  Step 2 of 3 — Connect a chat'));
+  console.log(`  • In Telegram, create a new group (or open an existing one)`);
+  console.log(`  • Add @${botUsername} as a member`);
+  console.log('  • Send any message in the group ("hi" works)');
+  console.log();
+  await askUser('  Press Enter once you\'ve done that > ');
 
-If Playwright is not available, print clear manual steps (open
-t.me/BotFather, type /newbot, etc.) and prompt the user for the token
-and chat ID. Then write them to config.
+  let chatId = '';
+  let chatName = '';
+  for (let attempt = 0; attempt < 4; attempt++) {
+    console.log(pc.dim('  Fetching the chat ID from Telegram…'));
+    const updates = await telegramGetUpdates(token);
+    if (!updates.ok) {
+      console.log(pc.yellow(`  Couldn't reach Telegram: ${updates.error}.`));
+      const retry = (await askUser('  Press Enter to try again, type "skip" to skip > ')).toLowerCase().trim();
+      if (retry === 'skip') break;
+      continue;
+    }
+    // Prefer group/supergroup chats. Fall back to most recent chat
+    // of any type — that's still useful (private DM with the bot
+    // works too).
+    const groupHit = updates.chats.find((c) => c.type === 'group' || c.type === 'supergroup');
+    const hit = groupHit ?? updates.chats[updates.chats.length - 1];
+    if (hit) {
+      chatId = hit.id;
+      chatName = hit.name;
+      console.log(pc.green(`  ✓ Chat found: "${chatName}" (id ${chatId})`));
+      break;
+    }
+    console.log(pc.yellow('  No recent messages found yet. Make sure you sent a message in the group AFTER adding the bot.'));
+    const retry = (await askUser('  Press Enter to try again, type "skip" to skip > ')).toLowerCase().trim();
+    if (retry === 'skip') break;
+  }
+  if (!chatId) {
+    console.log(pc.yellow('  Skipping chat-ID detection. Your bot token is saved; you can add the chat ID later.'));
+    // Still save the token — partial config is better than none.
+    writeTelegramConfig(options.projectDir, { token, chatId: '' });
+    return { telegramConfigured: false };
+  }
 
-Reference skill (for the wizard sections about Telegram if you need
-detail): ${skillPath}
-`.trim();
+  console.log();
+  console.log(pc.bold('  Step 3 of 3 — Saving config'));
+  const written = writeTelegramConfig(options.projectDir, { token, chatId });
+  if (!written) {
+    console.log(pc.red('  Couldn\'t write to .instar/config.json. Your bot is created but not wired up yet.'));
+    return { telegramConfigured: false };
+  }
+  console.log(pc.green('  ✓ Telegram is set up.'));
+  console.log(pc.dim(`  Your agent will message you in "${chatName}" once the server starts.`));
+  return { telegramConfigured: true };
+}
 
-  return new Promise((resolve) => {
-    const child = spawn(
-      options.codexPath,
-      [
-        'exec',
-        '--dangerously-bypass-approvals-and-sandbox',
-        '-m', WIZARD_CODEX_MODEL,
-        telegramPrompt,
-      ],
-      {
-        cwd: options.projectDir,
-        stdio: 'inherit',
+interface TelegramVerifyResult {
+  ok: boolean;
+  username: string;
+  error: string;
+}
+
+async function telegramGetMe(token: string): Promise<TelegramVerifyResult> {
+  try {
+    const url = `https://api.telegram.org/bot${encodeURIComponent(token)}/getMe`;
+    const res = await fetch(url);
+    const data = (await res.json()) as { ok: boolean; description?: string; result?: { username?: string } };
+    if (!data.ok) return { ok: false, username: '', error: data.description || 'invalid token' };
+    return { ok: true, username: data.result?.username || 'unknown', error: '' };
+  } catch (err) {
+    return { ok: false, username: '', error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+interface TelegramChat {
+  id: string;
+  type: string;
+  name: string;
+}
+
+interface TelegramUpdatesResult {
+  ok: boolean;
+  chats: TelegramChat[];
+  error: string;
+}
+
+async function telegramGetUpdates(token: string): Promise<TelegramUpdatesResult> {
+  try {
+    const url = `https://api.telegram.org/bot${encodeURIComponent(token)}/getUpdates`;
+    const res = await fetch(url);
+    const data = (await res.json()) as {
+      ok: boolean;
+      description?: string;
+      result?: Array<{ message?: { chat?: { id?: number; type?: string; title?: string; first_name?: string; username?: string } } }>;
+    };
+    if (!data.ok) return { ok: false, chats: [], error: data.description || 'getUpdates failed' };
+    const chats: TelegramChat[] = (data.result || [])
+      .map((u) => u.message?.chat)
+      .filter((c): c is NonNullable<typeof c> => !!c && typeof c.id === 'number')
+      .map((c) => ({
+        id: String(c.id!),
+        type: c.type || 'private',
+        name: c.title || c.first_name || c.username || `chat ${c.id}`,
+      }));
+    return { ok: true, chats, error: '' };
+  } catch (err) {
+    return { ok: false, chats: [], error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Persist a Telegram messaging entry into .instar/config.json's
+ * messaging[]. Replaces any existing telegram entry. Returns true on
+ * success.
+ */
+function writeTelegramConfig(projectDir: string, params: { token: string; chatId: string }): boolean {
+  const configPath = path.join(projectDir, '.instar', 'config.json');
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const config = JSON.parse(raw) as { messaging?: Array<{ type: string; enabled?: boolean; config?: Record<string, unknown> }> };
+    config.messaging = (config.messaging || []).filter((m) => m.type !== 'telegram');
+    config.messaging.push({
+      type: 'telegram',
+      enabled: true,
+      config: {
+        token: params.token,
+        chatId: params.chatId,
+        pollIntervalMs: 2000,
+        stallTimeoutMinutes: 5,
       },
-    );
-    child.on('close', () => resolve({ telegramConfigured: true }));
-    child.on('error', () => resolve({ telegramConfigured: false }));
-  });
+    });
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/tests/unit/setup-codex-model-canary.test.ts
+++ b/tests/unit/setup-codex-model-canary.test.ts
@@ -70,8 +70,13 @@ describe('setup.ts wizard dispatch canary', () => {
   });
 
   it('the codex driver passes -m WIZARD_CODEX_MODEL on every codex exec spawn', () => {
+    // v1.2.12: there were 2 codex exec spawns in the driver (narrative
+    // + Telegram-agentic). v1.2.15 replaced the Telegram one with an
+    // instar-native readline + Telegram Bot API flow, so the driver
+    // now has exactly ONE codex exec spawn — the per-turn narrative
+    // generation. That one must still pass -m WIZARD_CODEX_MODEL.
     const execBlocks = driverSrc.match(/'exec'[\s\S]*?\]/g) ?? [];
-    expect(execBlocks.length).toBeGreaterThanOrEqual(2);
+    expect(execBlocks.length).toBeGreaterThanOrEqual(1);
     for (const block of execBlocks) {
       expect(block).toMatch(/'-m'\s*,\s*WIZARD_CODEX_MODEL/);
     }

--- a/tests/unit/wizard-telegram-native.test.ts
+++ b/tests/unit/wizard-telegram-native.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the v1.2.15 Telegram-native wizard flow.
+ *
+ * The previous Telegram action spawned `codex exec` and asked it to
+ * walk the user through BotFather. But `codex exec` is non-interactive
+ * (single-turn), so the spawned session printed instructions and
+ * ended, and the wizard moved on with no token captured. The replacement
+ * drives the entire flow from instar with readline + the Telegram Bot
+ * API (validating tokens via getMe, auto-discovering chat IDs via
+ * getUpdates).
+ *
+ * These tests pin the SHAPE of the new flow without making real
+ * Telegram API calls. We import the driver module to verify symbol
+ * shapes, and assert via source-level inspection that the code is no
+ * longer spawning Codex for Telegram setup.
+ *
+ * End-to-end verification (a real Telegram bot + chat) is manual,
+ * documented in the PR description.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DRIVER_SRC = path.resolve(
+  __dirname,
+  '../../src/commands/setup-wizard/codex-driver.ts',
+);
+
+describe('Telegram-native wizard flow (v1.2.15)', () => {
+  const source = fs.readFileSync(DRIVER_SRC, 'utf-8');
+
+  it('no longer spawns codex exec for the Telegram setup action', () => {
+    // Pre-v1.2.15: runTelegramSetup built a `codex exec` argv with a
+    // BotFather-walkthrough prompt and spawned it. v1.2.15: the
+    // function body is instar-native readline + Telegram Bot API. No
+    // codex exec, no dangerously-bypass sandbox in the codex-driver.
+    expect(source).not.toMatch(/'dangerously-bypass-approvals-and-sandbox'/);
+    // The 'spawn(' import was for the codex exec; gone now.
+    expect(source).not.toMatch(/^import \{[^}]*\bspawn\b/);
+  });
+
+  it('source references the Telegram Bot API + the helper functions', () => {
+    expect(source).toMatch(/api\.telegram\.org/);
+    expect(source).toMatch(/telegramGetMe/);
+    expect(source).toMatch(/telegramGetUpdates/);
+    expect(source).toMatch(/writeTelegramConfig/);
+    // Validates token via getMe.
+    expect(source).toMatch(/\/getMe/);
+    // Auto-discovers chat ID via getUpdates.
+    expect(source).toMatch(/\/getUpdates/);
+  });
+
+  it('telegramGetMe + telegramGetUpdates are defined as async functions', () => {
+    expect(source).toMatch(/async function telegramGetMe/);
+    expect(source).toMatch(/async function telegramGetUpdates/);
+  });
+
+  it('writeTelegramConfig persists a telegram messaging entry', () => {
+    expect(source).toMatch(/function writeTelegramConfig/);
+    // The writer replaces any existing telegram entry rather than
+    // duplicating.
+    expect(source).toMatch(/m\.type !== 'telegram'/);
+    // Writes the canonical messaging schema (type/enabled/config).
+    expect(source).toMatch(/type:\s*'telegram'/);
+    expect(source).toMatch(/pollIntervalMs/);
+  });
+});
+
+describe('user-add action no longer passes -d (v1.2.15 fix)', () => {
+  const source = fs.readFileSync(DRIVER_SRC, 'utf-8');
+
+  it('add-user action spawns `npx instar user add` WITHOUT -d/--dir', () => {
+    // Lazy regex: stop at the FIRST closing `}` after the inner `]`
+    // of execFileSync's argv. We only care that the argv array
+    // doesn't contain -d/--dir.
+    const userAddArgvMatch = source.match(/case 'add-user'[\s\S]*?execFileSync\(\s*'npx',\s*(\[[\s\S]*?\])/);
+    expect(userAddArgvMatch).not.toBeNull();
+    const argvBlock = userAddArgvMatch![1];
+    expect(argvBlock).toMatch(/'instar',\s*'user',\s*'add'/);
+    expect(argvBlock).not.toMatch(/'-d'/);
+    expect(argvBlock).not.toMatch(/'--dir'/);
+    // The spawn options for user-add MUST set cwd to options.projectDir.
+    const cwdMatch = source.match(/case 'add-user'[\s\S]*?cwd:\s*options\.projectDir/);
+    expect(cwdMatch).not.toBeNull();
+  });
+});
+
+describe('choice echo after validation (v1.2.15 fix)', () => {
+  const source = fs.readFileSync(DRIVER_SRC, 'utf-8');
+
+  it('defines an echoChoice helper that uses resolveChoice + choice.label', () => {
+    expect(source).toMatch(/function echoChoice/);
+    expect(source).toMatch(/echoChoice\(state, answer\)/);
+    expect(source).toMatch(/resolveChoice\(answer, state\.input\.choices\)/);
+    expect(source).toMatch(/choice\.label/);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,87 @@
+# Upgrade Guide — v1.2.15 (Telegram-native wizard + UX fixes)
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**Fix: three real-user UX bugs from the v1.2.14 Codex install test.**
+
+End-to-end testing on instar-codey caught three issues, all in the
+hybrid wizard's Codex path:
+
+1. **`instar user add -d ...` errored** with "unknown option '-d'".
+   The user-profile creation step silently failed. Fix: drop the
+   `-d` flag and set `cwd: options.projectDir` on the spawn. Same
+   prophylactic edit applied to the server-start and
+   autostart-install actions.
+
+2. **Choice prompts silently accepted text input** ("Proactive",
+   "Telegram") without echoing what got picked. The interpreter
+   worked correctly via `resolveChoice`, but the user had no
+   visual confirmation. Fix: new `echoChoice` helper called from
+   the validator retry loop prints `→ {label}` after the answer
+   is accepted.
+
+3. **Telegram setup silently failed** because it spawned a
+   `codex exec` session that couldn't actually wait for the user
+   to paste a bot token. Codex printed manual BotFather
+   instructions, ended successfully, and the wizard recorded
+   "Telegram is configured!" without anything being configured.
+   Fix: complete rewrite of the Telegram action as an instar-
+   native readline + Telegram Bot API flow. No LLM session in the
+   loop. Three steps:
+
+   - **Step 1 of 3**: print BotFather instructions, prompt for
+     token, validate via `GET /bot<TOKEN>/getMe`. Up to 5 retries
+     on invalid tokens; "skip" exits without marking configured.
+   - **Step 2 of 3**: prompt user to add bot to a group + send
+     a message, then call `GET /bot<TOKEN>/getUpdates` to auto-
+     discover the chat ID. Up to 4 retries.
+   - **Step 3 of 3**: write `{ type: 'telegram', enabled: true,
+     config: { token, chatId, pollIntervalMs, stallTimeoutMinutes
+     } }` to `.instar/config.json`'s messaging array, replacing
+     any existing telegram entry.
+
+   The action NEVER returns `telegramConfigured: true` unless the
+   config write actually succeeds — closing the silent-success
+   class of failure.
+
+Spec: `specs/dev-infrastructure/wizard-telegram-native.md`.
+ELI16: `specs/dev-infrastructure/wizard-telegram-native.eli16.md`.
+Side-effects review: `upgrades/side-effects/fix-wizard-telegram-native.md`.
+
+## What to Tell Your User
+
+The wizard's Telegram setup now works end-to-end on any host — no
+browser automation dependency, no LLM session involved. You'll see
+clear instructions, paste your bot token, add the bot to a group,
+press Enter, and the wizard writes everything for you. If anything
+fails along the way, it'll tell you exactly what happened and how
+to finish setup later by chatting your agent.
+
+## Summary of New Capabilities
+
+No new capabilities. Three UX hardening fixes on top of v1.2.14.
+
+## Evidence
+
+Reproduction prior to fix: v1.2.14 install on `instar-codey` (real
+Codex install, ChatGPT-subscription auth):
+- user-add action printed `error: unknown option '-d'`.
+- Autonomy choice "Proactive" was accepted with no echo.
+- Messaging choice "Telegram" was accepted with no echo.
+- Telegram action spawned Codex; Codex printed manual BotFather
+  instructions; wizard immediately marked Telegram configured;
+  config.json's `messaging` array was empty.
+
+After fix:
+- 6 new unit tests cover the Telegram-native flow shape, the
+  add-user cwd fix, and the choice echo helper.
+- Existing 26 state-machine tests still pass.
+- Existing 5 dispatch canary tests still pass (updated to
+  reflect that the driver now has 1 codex exec spawn instead of 2,
+  since the Telegram one was replaced).
+- Total: 37 wizard-related tests, all green.
+- Manual end-to-end re-test on Codex install path pending on
+  publish.

--- a/upgrades/side-effects/fix-wizard-telegram-native.md
+++ b/upgrades/side-effects/fix-wizard-telegram-native.md
@@ -1,0 +1,112 @@
+# Side-effects review — Telegram-native wizard + add-user cwd + choice echo
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: UNDER on three counts.
+- `add-user` action passed `-d` to a CLI that doesn't accept it →
+  silent profile-creation failure.
+- Choice prompts silently accepted text input without echoing what
+  got resolved → user couldn't tell whether their input was
+  understood.
+- Telegram action spawned `codex exec` (non-interactive) and then
+  marked the channel configured even though no token was captured.
+
+After: precisely targeted.
+- `add-user` uses cwd consistently with how `instar user add`
+  actually resolves project context.
+- Choice prompts echo `→ {label}` after validation passes (no-op for
+  text prompts).
+- Telegram action is instar-native readline + Telegram Bot API; only
+  marks the channel configured when the config write succeeds.
+
+No over-block: the Claude wizard path is untouched, WhatsApp + Slack
+flows are unchanged, the state machine's flow is unchanged.
+
+## 2. Level-of-abstraction fit
+
+Three small, scoped changes inside the existing codex-driver module:
+
+- One spawn-options edit on the `add-user` action (drop `-d`, add
+  cwd). Same pattern applied prophylactically to `start-server`
+  and `install-autostart` for consistency.
+- One helper function `echoChoice(state, answer)` called from the
+  existing `renderNarrativeState` retry loop. Pure render concern,
+  no state-machine API change.
+- `runTelegramSetup` rewritten as a 100-line instar-native flow
+  plus three small private helpers (`telegramGetMe`,
+  `telegramGetUpdates`, `writeTelegramConfig`). Replaces a 50-line
+  codex-spawn helper. Net code size grew by ~150 LOC for a more
+  reliable result.
+
+No new module, no new abstraction. The driver remains the single
+home for codex-cli wizard implementation.
+
+## 3. Signal vs Authority compliance
+
+- The Telegram API's `getMe` response is the AUTHORITY for "is this
+  a valid bot token." Pre-fix, the wizard never validated.
+- The Telegram API's `getUpdates` response is the AUTHORITY for
+  "what chat IDs has this bot seen." We extract from there rather
+  than inventing.
+- The wizard's `choice` resolver remains the AUTHORITY for "what
+  did the user mean by their text input." Echo just surfaces the
+  AUTHORITY's decision to the user.
+- The `add-user` cwd change makes process-directory the SIGNAL the
+  CLI was always reading; the prior `-d` flag was a wrong-signal
+  attempt that the CLI rejected outright.
+
+## 4. Interactions with adjacent systems
+
+- **State machine `setup-telegram-agentic` action**: name unchanged
+  (still describes the user-visible intent). Implementation moved
+  from codex-spawn to instar-native. Downstream consumers
+  (`send-greeting` action, future Telegram-dependent steps) see the
+  same `{ telegramConfigured: boolean }` return shape.
+- **`writeTelegramConfig`**: writes the exact messaging schema the
+  agent server already consumes (`type/enabled/config.token/chatId/
+  pollIntervalMs/stallTimeoutMinutes`). No change to consumers.
+- **`renderNarrativeState`**: gains one `echoChoice(state, answer)`
+  call after the validator accepts. Wraps the existing return path,
+  doesn't change it.
+- **`add-user` action**: cwd change is invisible to the CLI; same
+  outcome via the correct flag set.
+- **Existing v1.2.14 validators + spinner**: untouched.
+- **Claude wizard path**: untouched.
+
+## 5. Rollback cost
+
+Low-medium. `runTelegramSetup` is fully replaced (not patched), so
+revert restores the broken codex-spawn version. The other two fixes
+are small enough to revert independently if needed.
+
+## 6. Backwards compatibility / drift surface
+
+Fully backwards-compatible.
+
+- Codex-runtime users: get a working Telegram setup. Previously
+  got broken silent-success.
+- Claude-runtime users: zero change.
+- Existing `instar add telegram` CLI command (the post-setup
+  fallback): unchanged. If the wizard skips Telegram, the user can
+  still run `instar add telegram` later — and the `writeTelegram
+  Config` helper writes the EXACT same schema, so the two flows
+  produce identical config.
+- No config schema change. No agent-installed-files change. No
+  `PostUpdateMigrator` work.
+
+## 7. Authorization / Trust posture
+
+No new authority. `fetch` calls to api.telegram.org happen with the
+user's bot token (which they paste into the wizard). The wizard
+runs in-process, same trust level as everything else in setup.
+
+## Outcome
+
+Ship. Closes three real-user bugs surfaced on the v1.2.14 install
+test. Replaces the broken codex-spawn Telegram setup with an
+instar-native flow that's robust across all environments
+(Playwright available or not, Codex behavior aside). Echo and
+add-user fixes are small companions that round out the v1.2.15
+delivery.


### PR DESCRIPTION
## Summary
Three real-user UX bugs from the v1.2.14 install test on instar-codey:

1. **`instar user add -d ...` errored** with "unknown option '-d'" — user profile silently never created. Fix: drop `-d`, set `cwd: options.projectDir` on the spawn.

2. **Choice prompts (autonomy, messaging) silently accepted text input** ("Proactive", "Telegram") without echoing what got picked. Fix: new `echoChoice` helper prints `→ {label}` after the validator accepts.

3. **Telegram setup silently failed** because it spawned `codex exec` (non-interactive single-turn) — Codex printed manual BotFather instructions, ended, and the wizard recorded `telegramConfigured: true` with empty messaging array. Fix: complete rewrite of `runTelegramSetup` as instar-native readline + Telegram Bot API flow.

## Telegram rewrite (the bulk of this PR)

3 steps, all driven by instar:
- **Step 1**: print BotFather instructions, prompt for token, validate via `GET /bot<TOKEN>/getMe`. 5 retries.
- **Step 2**: prompt user to add bot to a group + send a message, call `GET /bot<TOKEN>/getUpdates`, auto-discover chat ID. 4 retries, "skip" option.
- **Step 3**: write the canonical `{ type: 'telegram', enabled: true, config: { token, chatId, pollIntervalMs, stallTimeoutMinutes } }` into `.instar/config.json`.

**Never returns `telegramConfigured: true` unless the config write succeeds** — closes the silent-success class. Partial states (token only, network failure, etc.) return `telegramConfigured: false` with a clear "finish later" pointer.

3 new private helpers: `telegramGetMe`, `telegramGetUpdates`, `writeTelegramConfig`.

## Tests
- 6 new unit tests cover Telegram-native flow shape, add-user cwd fix, choice echo helper.
- Existing 26 state-machine tests still pass.
- Existing 5 dispatch canary tests still pass (lower bound on driver codex-exec count updated from >=2 to >=1 since the Telegram one was replaced).
- **37 total wizard tests, all green.**

## Spec bundle
- Spec: `specs/dev-infrastructure/wizard-telegram-native.md`
- ELI16: `specs/dev-infrastructure/wizard-telegram-native.eli16.md`
- Convergence: `docs/specs/reports/wizard-telegram-native-convergence.md`
- Side-effects: `upgrades/side-effects/fix-wizard-telegram-native.md`
- Trace: `.instar/instar-dev-traces/20260521T235610Z-wizard-telegram-native.json`

## Test plan
- [x] 37 wizard unit tests pass locally
- [x] tsc + lint clean
- [ ] CI green
- [ ] Manual end-to-end: `npx instar@1.2.15` on instar-codey → pick Codex → walk through with `Proactive`/`Telegram` text answers → verify echo, verify Telegram bot creation succeeds, verify `.instar/config.json` has populated `messaging[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)