### PR TITLE
feat(setup): Codex+Playwright Telegram setup primary path (v1.2.17)

### DIFF
--- a/.instar/instar-dev-traces/20260522T012819Z-codex-playwright-telegram.json
+++ b/.instar/instar-dev-traces/20260522T012819Z-codex-playwright-telegram.json
@@ -1,0 +1,19 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/codex-playwright-telegram.md",
+  "artifactPath": "upgrades/side-effects/feat-codex-playwright-telegram.md",
+  "artifactSha256": "c3b6164d3381d8ead15b97246d0d3236820195fe38b59d308c560b23c1ba0e31",
+  "coveredFiles": [
+    "src/commands/setup.ts",
+    "src/commands/setup-wizard/codex-driver.ts",
+    "tests/unit/codex-playwright-telegram.test.ts",
+    "specs/dev-infrastructure/codex-playwright-telegram.md",
+    "specs/dev-infrastructure/codex-playwright-telegram.eli16.md",
+    "docs/specs/reports/codex-playwright-telegram-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/feat-codex-playwright-telegram.md"
+  ],
+  "writtenAt": "2026-05-22T01:28:19Z",
+  "agent": "echo",
+  "summary": "Restores Codex+Playwright as primary Telegram setup path. ensureCodexPlaywrightMcp appends [mcp_servers.playwright] to ~/.codex/config.toml (idempotent). runTelegramAgentic spawns Codex with Playwright-aware prompt; verifyTelegramConfig reads config.json after spawn to authoritatively confirm write happened. On verifier failure, dispatch falls through to v1.2.15 readline backstop. 18 new tests. Ships v1.2.17."
+}

--- a/docs/specs/reports/codex-playwright-telegram-convergence.md
+++ b/docs/specs/reports/codex-playwright-telegram-convergence.md
@@ -1,0 +1,53 @@
+# Convergence Report — Codex+Playwright Telegram primary path
+
+## ELI10 Overview
+
+v1.2.15 made the wizard's Telegram setup a manual readline flow
+because the previous Codex-driven attempt was broken — Codex didn't
+have Playwright available. Justin pushed back: surely Codex has
+the same browser-automation capabilities as Claude? Investigation
+confirmed: yes, but instar wasn't registering Playwright for Codex
+(only for Claude).
+
+This PR fixes both halves: registers Playwright in `~/.codex/config.toml`
+so Codex sessions can drive a browser, and restores the Codex-
+agentic Telegram setup as the primary path with the v1.2.15
+readline flow as a verified backstop. After the agentic Codex spawn
+returns, instar reads `.instar/config.json` directly to verify the
+write actually happened — never trusts Codex's exit code alone.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1         | self + Justin's "why manual" push | 2 | Codex MCP registration + agentic path with verifier |
+| 2         | (converged)           | 0                 | none |
+
+## Full Findings Catalog
+
+**Finding 1 — Codex couldn't see Playwright because the MCP wasn't
+registered in ~/.codex/config.toml.**
+
+- Severity: high (blocked the agentic Telegram path entirely).
+- Resolution: new `ensureCodexPlaywrightMcp` helper appends the
+  Playwright MCP section to ~/.codex/config.toml. Idempotent
+  (matches both quoted and unquoted TOML section forms). Skips
+  silently when Codex isn't installed.
+
+**Finding 2 — The v1.2.14 agentic path silently succeeded when it
+hadn't actually written config.**
+
+- Severity: high (silent-success class).
+- Resolution: `verifyTelegramConfig(projectDir)` reads
+  `.instar/config.json` after the agentic spawn ends and confirms
+  the messaging entry exists with both `token` and `chatId`
+  populated. The action only returns `telegramConfigured: true`
+  when the verifier passes. Otherwise dispatch falls through to
+  the v1.2.15 readline backstop.
+
+## Convergence verdict
+
+Converged at iteration 2. Two scoped additions; existing primitives
+only; no new abstraction layer; verifier-based success criterion
+prevents regression. 18 new unit tests cover the prompt shape, the
+verifier, and the Codex MCP registration helper.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.2.16",
+      "version": "1.2.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/codex-playwright-telegram.eli16.md
+++ b/specs/dev-infrastructure/codex-playwright-telegram.eli16.md
@@ -1,0 +1,74 @@
+# What this PR does — in plain English
+
+## The setup
+
+In v1.2.15 I replaced the Codex-driven Telegram setup with an
+instar-native flow because the original Codex attempt was broken —
+it printed manual instructions and quit. Justin pushed back: surely
+Codex has the same Playwright (browser-automation) capabilities as
+Claude does, so why are we making the user do it manually?
+
+Investigation answered that. Yes, Codex CLI supports Playwright.
+But instar's setup only registers Playwright for Claude — writes to
+`~/.claude.json` and creates a `.mcp.json` in the project — never
+to `~/.codex/config.toml` where Codex looks. So when v1.2.14 tried
+to use Codex for the Telegram flow, Codex had no browser tools and
+fell back to printing manual instructions.
+
+## The fix (two parts)
+
+### Part 1: register Playwright for Codex
+
+New helper `ensureCodexPlaywrightMcp` appends a section to
+`~/.codex/config.toml` that tells Codex how to launch the
+Playwright browser-automation MCP. The section looks like:
+
+  [mcp_servers."playwright"]
+  kind = "stdio"
+  command = "npx"
+  args = ["-y", "@playwright/mcp@latest"]
+
+(Same shape Justin's Codex already uses for Threadline.) Idempotent
+— re-running doesn't duplicate the section.
+
+### Part 2: try Codex+Playwright first, fall back to manual
+
+The wizard's Telegram step is now a two-stage flow:
+
+1. **Try Codex+Playwright first.** Spawn Codex with a very specific
+   prompt telling it to drive Telegram Web through BotFather,
+   capture the bot token, create a group, capture the chat ID, and
+   write everything to `.instar/config.json`. The prompt includes
+   explicit "if Playwright isn't reachable, output this sentinel
+   and exit" and "if anything fails, output this sentinel and exit"
+   instructions. Long timeout (10 minutes) for the QR-code login
+   step.
+
+2. **Verify the config write actually happened.** After Codex
+   exits, instar reads `.instar/config.json` directly and checks
+   that a telegram entry exists with both `token` and `chatId`
+   populated. We never trust Codex's exit code alone for "did this
+   succeed."
+
+3. **Fall through to manual on failure.** If verification fails for
+   any reason — sentinel output, exit code non-zero, missing config
+   entry — the wizard automatically drops into the v1.2.15
+   readline-based manual flow as a backstop. The user gets the
+   same end state either way.
+
+## Why this is the right shape
+
+Codex's strength is execution. Telegram setup IS execution (open
+browser, click buttons, capture text from the page). When Codex has
+Playwright, it's better at this than asking the user to do it
+manually. When Codex doesn't have Playwright (or fails for any
+reason), we don't get stuck — we drop straight into manual.
+
+## What doesn't change
+
+- The state machine is unchanged.
+- The conversational/identity steps still use the narrative-prompt
+  path from v1.2.12.
+- The Claude wizard path is untouched.
+- The instar-native manual Telegram flow stays exactly as it was in
+  v1.2.15 — now serving as the backstop instead of the primary.

--- a/specs/dev-infrastructure/codex-playwright-telegram.md
+++ b/specs/dev-infrastructure/codex-playwright-telegram.md
@@ -1,0 +1,142 @@
+---
+title: "Codex+Playwright Telegram setup (primary path)"
+slug: "codex-playwright-telegram"
+author: "echo"
+eli16-overview: "codex-playwright-telegram.eli16.md"
+review-convergence: "2026-05-22T01:30:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-22T01:30:00Z"
+review-report: "docs/specs/reports/codex-playwright-telegram-convergence.md"
+approved: true
+---
+
+# Codex+Playwright Telegram setup (primary path)
+
+## Problem statement
+
+v1.2.15 rewrote the wizard's Telegram setup as an instar-native
+readline flow because the previous codex-exec attempt was broken
+(Codex printed manual instructions and ended, leaving the channel
+silently unconfigured). Justin pushed back on shipping that as the
+default: *"surely codex has the same playwright capabilities as
+claude code?"*
+
+Investigation: yes, Codex CLI supports MCP tools (including
+Playwright), but instar's `ensurePlaywrightMcp` only registered
+Playwright in `~/.claude.json` and a project-local `.mcp.json` —
+NEVER in `~/.codex/config.toml`. So the v1.2.14 codex-exec attempt
+spawned with no Playwright reachable, fell back to printing manual
+instructions, and ended.
+
+The right shape: Codex+Playwright is the PRIMARY path; the v1.2.15
+instar-native readline flow is the BACKSTOP.
+
+## Proposed design
+
+Two pieces, both in this PR.
+
+### Fix 1: extend `ensurePlaywrightMcp` to cover Codex
+
+New helper `ensureCodexPlaywrightMcp()` (exported for unit testing)
+appended to `src/commands/setup.ts`'s ensurePlaywrightMcp flow:
+
+```ts
+function ensureCodexPlaywrightMcp(): void {
+  const codexConfigPath = path.join(os.homedir(), '.codex', 'config.toml');
+  if (!fs.existsSync(path.dirname(codexConfigPath))) return;  // Codex not installed
+  // Idempotent check: skip if [mcp_servers."playwright"] already present
+  // (matches both quoted and unquoted TOML forms).
+  // Append the section atomically (tmp + rename).
+}
+```
+
+Section appended:
+
+```toml
+[mcp_servers."playwright"]
+kind = "stdio"
+command = "npx"
+args = ["-y", "@playwright/mcp@latest"]
+```
+
+This is the same shape Codex already uses for the Threadline MCP
+that's registered on Justin's `~/.codex/config.toml` today (verified
+by reading his config). TOML is appended hand-rolled rather than
+parsed: we just check for the section header presence and append if
+missing. Codex's config is regular TOML and an extra section at EOF
+is a no-op for unrelated values.
+
+### Fix 2: restore Codex-agentic Telegram setup as primary
+
+New `runTelegramAgentic` in `src/commands/setup-wizard/codex-driver.ts`:
+
+```ts
+async function runTelegramAgentic(options): Promise<Partial<WizardAnswers>> {
+  // Spawn `codex exec` with the Playwright-aware prompt.
+  // 10-minute timeout (human-in-the-loop login).
+  // After spawn returns, VERIFY config write via verifyTelegramConfig.
+  // Only return telegramConfigured: true if verification passes.
+}
+```
+
+The action's prompt (`buildTelegramAgenticPrompt`) is structured as:
+
+1. Verify Playwright is reachable. If not, output the sentinel
+   `PLAYWRIGHT_UNAVAILABLE` and exit. (Caller's fallback kicks in.)
+2. Drive Telegram Web through QR-code login (snapshots every ~5s,
+   120s timeout).
+3. Open BotFather, `/newbot`, capture token from the reply.
+4. Validate token via `curl /bot<TOKEN>/getMe`.
+5. Create a new group, add the bot, send a first message.
+6. Fetch chat ID via `curl /bot<TOKEN>/getUpdates`.
+7. Write the canonical `{ type: 'telegram', enabled: true, config:
+   { token, chatId, pollIntervalMs, stallTimeoutMinutes } }` to
+   `.instar/config.json`.
+8. On any unrecoverable failure, output `AGENTIC_FAILED: <reason>`
+   and exit fast — fast-fail is what enables the fallback.
+
+`verifyTelegramConfig(projectDir)` reads `.instar/config.json` and
+returns true only when `messaging[]` contains a telegram entry with
+both `token` and `chatId` populated. The action calls this AFTER
+the spawn ends — never trusts Codex's exit code alone.
+
+The dispatch in `runAction` becomes:
+
+```ts
+case 'setup-telegram-agentic': {
+  const agentic = await runTelegramAgentic(options);
+  if (agentic.telegramConfigured) return agentic;
+  console.log(pc.dim('  Browser automation didn\'t finish — switching to manual setup.'));
+  return await runTelegramSetup(options);  // v1.2.15 readline backstop
+}
+```
+
+Both paths end at the same config state — the verifier guarantees
+no silent-success on the agentic side.
+
+## Decision points touched
+
+- Adds one operator-intent SIGNAL (the choice to attempt agentic
+  first). The state machine's `setup-telegram-agentic` action name
+  is unchanged.
+- AUTHORITY for "is Telegram actually configured" is now
+  `verifyTelegramConfig` reading the on-disk config. The agentic
+  spawn's exit code is necessary but not sufficient.
+- No new permissions. Codex's spawn uses the same
+  `--dangerously-bypass-approvals-and-sandbox` posture the agent's
+  runtime uses (per `frameworkSessionLaunch.ts`); Playwright runs
+  in its own browser sandbox.
+
+## Open questions
+
+None for this PR's scope.
+
+## Out of scope
+
+- WhatsApp + Slack agentic flows (still emit "configure later"
+  pointers).
+- A retry layer that re-attempts the agentic path on
+  AGENTIC_FAILED with a different bot-username strategy. Today we
+  fast-fail to the readline fallback after one agentic attempt.
+- Validating that the user's Codex auth is configured (the spawn
+  inherits the existing auth state; failures surface naturally).

--- a/src/commands/setup-wizard/codex-driver.ts
+++ b/src/commands/setup-wizard/codex-driver.ts
@@ -413,6 +413,16 @@ async function runAction(
     }
 
     case 'setup-telegram-agentic': {
+      // Try Codex+Playwright agentic path first (the experience
+      // Justin asked for: "surely codex has the same playwright
+      // capabilities as claude code?"). Falls through to the
+      // instar-native readline flow when Codex returns the
+      // PLAYWRIGHT_UNAVAILABLE sentinel, when the spawn fails, or
+      // when the config write didn't actually land.
+      const agentic = await runTelegramAgentic(options);
+      if (agentic.telegramConfigured) return agentic;
+      console.log();
+      console.log(pc.dim('  Browser automation didn\'t finish — switching to manual setup.'));
       return await runTelegramSetup(options);
     }
 
@@ -441,27 +451,193 @@ async function runAction(
 }
 
 /**
- * Telegram setup — instar-native flow.
+ * Telegram setup — Codex+Playwright agentic path (v1.2.17, primary).
  *
- * Previously this spawned `codex exec` and asked it to walk the user
- * through BotFather. But `codex exec` is non-interactive (single-turn,
- * stdin already consumed by the prompt), so it couldn't wait for the
- * user to paste a token. The spawned session printed manual
- * instructions, ended, and the wizard recorded "telegramConfigured:
- * true" without anything actually configured.
+ * Spawns Codex with the Playwright MCP available (registered into
+ * ~/.codex/config.toml by ensureCodexPlaywrightMcp in setup.ts).
+ * Codex drives Telegram Web through the BotFather flow, captures
+ * the bot token + chat ID, and writes them into
+ * `.instar/config.json` directly.
  *
- * The fix: drive the entire Telegram setup from instar with readline +
- * the Telegram Bot API. No LLM session is involved. We:
+ * After the spawn returns, instar VERIFIES the config write by
+ * reading the file and confirming `messaging[]` contains a telegram
+ * entry with non-empty token + chatId. If verification fails — for
+ * any reason (Codex output PLAYWRIGHT_UNAVAILABLE, user couldn't
+ * complete login, BotFather rejected the username repeatedly,
+ * config write didn't happen) — the action returns
+ * `telegramConfigured: false` and the dispatch falls through to
+ * `runTelegramSetup` (the instar-native readline backstop).
  *
- *  1. Print clear BotFather instructions.
- *  2. Prompt the user for the bot token, validate via getMe.
- *  3. Prompt the user to add the bot to a group and send a message,
- *     then call getUpdates to extract the chat ID.
- *  4. Write the token + chat ID into .instar/config.json's messaging[].
+ * This is the structural answer to Justin's question "surely codex
+ * has the same playwright capabilities as claude code?" — yes, but
+ * only if Playwright MCP is registered for Codex. Pre-v1.2.17,
+ * ensurePlaywrightMcp only wrote to ~/.claude.json + .mcp.json,
+ * never to ~/.codex/config.toml. With v1.2.17 it does both, and
+ * this action exercises the Codex side of that registration.
+ */
+async function runTelegramAgentic(options: CodexDriverOptions): Promise<Partial<WizardAnswers>> {
+  console.log();
+  console.log(pc.bold('  Telegram setup'));
+  console.log(pc.dim('  Starting browser-driven bot creation via Codex + Playwright.'));
+  console.log(pc.dim('  This opens a browser window; you may need to scan a QR code from your phone to log into Telegram Web.'));
+  console.log();
+
+  const prompt = buildTelegramAgenticPrompt(options.projectDir);
+  // Long timeout — the human-in-the-loop login can take a couple
+  // minutes if the user has to grab their phone.
+  const result = spawnSync(
+    options.codexPath,
+    [
+      'exec',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '-m', WIZARD_CODEX_MODEL,
+      '--skip-git-repo-check',
+      prompt,
+    ],
+    {
+      cwd: options.projectDir,
+      stdio: 'inherit',
+      timeout: 600_000, // 10 minutes
+    },
+  );
+  if (result.status !== 0 && result.status !== null) {
+    return { telegramConfigured: false };
+  }
+  // Verify config write — the agentic path is only "successful"
+  // when .instar/config.json actually has a telegram entry with
+  // non-empty token + chatId after the spawn ends.
+  const verified = verifyTelegramConfig(options.projectDir);
+  if (!verified) {
+    return { telegramConfigured: false };
+  }
+  console.log();
+  console.log(pc.green('  ✓ Telegram is set up (via Codex + Playwright).'));
+  return { telegramConfigured: true };
+}
+
+/**
+ * Build the prompt for Codex's Playwright-driven Telegram setup.
+ * Exported for testing (we can assert the prompt's shape includes
+ * the verification sentinels and the success criterion).
+ */
+export function buildTelegramAgenticPrompt(projectDir: string): string {
+  return `
+You have Playwright browser-automation MCP tools available
+(mcp__playwright__browser_navigate, browser_snapshot, browser_click,
+browser_type, browser_press_key, browser_wait_for, etc).
+
+TASK: Set up a Telegram bot for an instar agent at ${projectDir}.
+
+SUCCESS CRITERION (verified by the caller after you exit):
+  .instar/config.json's messaging[] contains exactly one entry
+  shaped as:
+    { type: "telegram", enabled: true,
+      config: { token: "<bot-token>", chatId: "<chat-id>",
+                pollIntervalMs: 2000, stallTimeoutMinutes: 5 } }
+
+STEPS:
+
+1. Verify Playwright is reachable. Call mcp__playwright__browser_navigate
+   with URL "https://web.telegram.org/a/". If the tool call fails or
+   the tool is not present, output EXACTLY this string and exit:
+     PLAYWRIGHT_UNAVAILABLE
+   (Do NOT print any manual instructions; the caller has its own
+   manual fallback.)
+
+2. The user may need to scan a QR code from their phone to log in.
+   Take snapshots periodically (every ~5 seconds, up to ~120 seconds
+   total). The page is "logged in" when the left rail shows a chat
+   list (search bar + chats) rather than the QR code or phone-number
+   form. If still on login after 120s, output:
+     AGENTIC_FAILED: telegram-login-timeout
+   and exit.
+
+3. Once logged in, use the search bar to find "BotFather". Click
+   the verified @BotFather result.
+
+4. Send /newbot. Wait for the reply.
+
+5. When BotFather asks for the bot's display name, type:
+   "Instar Agent"
+
+6. When BotFather asks for the bot's username, generate one ending
+   in "bot" (use the basename of the project dir, lower-case,
+   ASCII-only, with "_instar_bot" appended; if taken, append random
+   digits and retry up to 5 times).
+
+7. Read BotFather's reply containing the token. Extract the token
+   from the message body. Token format: \\d+:[A-Za-z0-9_-]+
+   Store it in a local variable.
+
+8. Validate the token via the Telegram Bot API (Bash):
+     curl -s "https://api.telegram.org/bot<TOKEN>/getMe"
+   If response.ok is not true, output:
+     AGENTIC_FAILED: token-invalid
+   and exit.
+
+9. Create a new group chat:
+   a. Click the "new message" / pencil icon.
+   b. Choose "New Group".
+   c. Search for and add the bot you just created.
+   d. Name the group "<basename> + instar".
+   e. Create the group.
+   f. Send a message inside the group: "first contact".
+
+10. Fetch the chat ID:
+      curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates"
+    Pick the result where message.chat.type is "group" or
+    "supergroup". Extract message.chat.id as a string.
+
+11. Write the config. Read the existing .instar/config.json. Filter
+    out any existing { type: "telegram" } entries. Push:
+      { type: "telegram", enabled: true,
+        config: { token: "<TOKEN>", chatId: "<CHAT_ID>",
+                  pollIntervalMs: 2000, stallTimeoutMinutes: 5 } }
+    Write the file back (atomic-ish: tmp file + rename is fine).
+
+12. Verify your write succeeded by re-reading the file and confirming
+    the messaging entry is present with both fields populated. If
+    not, output:
+      AGENTIC_FAILED: config-write-failed
+    and exit.
+
+13. Exit cleanly. Do NOT print summary text — the caller will verify
+    the config and report to the user.
+
+FAILURE MODE: at ANY step you cannot recover from, output exactly
+"AGENTIC_FAILED: <one-line reason>" and exit. The caller will fall
+through to a readline-based manual setup. Do NOT try to be clever —
+fast-fail is what enables the fallback to work.
+`.trim();
+}
+
+/**
+ * Verify that .instar/config.json has a fully-populated Telegram
+ * messaging entry. Used by runTelegramAgentic to confirm the
+ * agentic path actually wrote what it was supposed to before
+ * declaring success. Exported for testing.
+ */
+export function verifyTelegramConfig(projectDir: string): boolean {
+  const configPath = path.join(projectDir, '.instar', 'config.json');
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const config = JSON.parse(raw) as { messaging?: Array<{ type: string; enabled?: boolean; config?: { token?: string; chatId?: string } }> };
+    const tg = (config.messaging || []).find((m) => m.type === 'telegram');
+    if (!tg) return false;
+    if (!tg.config?.token || !tg.config?.chatId) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Telegram setup — instar-native readline backstop (v1.2.15 flow).
  *
- * Failure modes (network down, user can't paste, etc.) gracefully
- * skip with a clear "you can finish setup later" pointer, but never
- * silently mark the channel as configured when it isn't.
+ * Reached only if runTelegramAgentic returns
+ * `telegramConfigured: false`. Drives the entire setup from instar
+ * with readline + the Telegram Bot API. No LLM session is involved.
+ * See spec wizard-telegram-native.md for the original rationale.
  */
 async function runTelegramSetup(options: CodexDriverOptions): Promise<Partial<WizardAnswers>> {
   console.log();

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -658,6 +658,45 @@ function ensurePlaywrightMcp(dir: string): void {
       // Non-fatal
     }
   }
+
+  // ── 3. Register in ~/.codex/config.toml (for Codex-runtime agents) ──
+  // Codex reads MCP servers from ~/.codex/config.toml under
+  // [mcp_servers."<name>"] sections. We append a Playwright section
+  // if one doesn't already exist. Idempotent — re-runs are safe.
+  ensureCodexPlaywrightMcp();
+}
+
+/**
+ * Idempotently register the Playwright MCP server in
+ * ~/.codex/config.toml so codex-runtime agentic sessions can drive
+ * browser automation (used by the v1.2.17 Telegram setup primary
+ * path). Skips silently if Codex isn't installed (no config dir).
+ *
+ * TOML is appended hand-rolled rather than parsed: we just check
+ * for the section header and add it if missing. Codex's config is
+ * regular TOML; an extra section at EOF is a no-op for unrelated
+ * config values.
+ *
+ * Exported for unit testing.
+ */
+export function ensureCodexPlaywrightMcp(): void {
+  const codexConfigPath = path.join(os.homedir(), '.codex', 'config.toml');
+  if (!fs.existsSync(path.dirname(codexConfigPath))) return;
+  try {
+    let content = '';
+    if (fs.existsSync(codexConfigPath)) {
+      content = fs.readFileSync(codexConfigPath, 'utf-8');
+      if (/\[mcp_servers\.(?:"playwright"|playwright)\]/.test(content)) return;
+    }
+    const block = `\n[mcp_servers."playwright"]\nkind = "stdio"\ncommand = "npx"\nargs = ["-y", "@playwright/mcp@latest"]\n`;
+    const next = content + (content.length > 0 && !content.endsWith('\n') ? '\n' : '') + block;
+    const tmpPath = `${codexConfigPath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, next);
+    fs.renameSync(tmpPath, codexConfigPath);
+  } catch {
+    // Non-fatal — Codex-agentic Telegram will fall back to manual
+    // setup if Playwright isn't reachable from the codex session.
+  }
 }
 
 /**

--- a/tests/unit/codex-playwright-telegram.test.ts
+++ b/tests/unit/codex-playwright-telegram.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the v1.2.17 Codex+Playwright Telegram setup primary path.
+ *
+ * v1.2.15 removed the codex-exec Telegram action because Playwright
+ * wasn't registered for Codex (ensurePlaywrightMcp only wrote to
+ * ~/.claude.json and .mcp.json, never ~/.codex/config.toml), so
+ * Codex couldn't drive the browser. v1.2.17 restores it as the
+ * primary path:
+ *
+ *   1. ensureCodexPlaywrightMcp now writes [mcp_servers."playwright"]
+ *      to ~/.codex/config.toml when not already present.
+ *   2. runTelegramAgentic spawns Codex with Playwright available,
+ *      lets it drive Telegram Web → BotFather → token + chatId
+ *      capture → config write.
+ *   3. verifyTelegramConfig checks the config write actually
+ *      happened; if not, the dispatch falls through to
+ *      runTelegramSetup (the v1.2.15 instar-native readline
+ *      backstop).
+ *
+ * These tests pin the SHAPE of the new primary path without making
+ * real Codex/Telegram calls.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  buildTelegramAgenticPrompt,
+  verifyTelegramConfig,
+} from '../../src/commands/setup-wizard/codex-driver.js';
+import { ensureCodexPlaywrightMcp } from '../../src/commands/setup.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function mktmp(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function tmpRm(dir: string): void {
+  SafeFsExecutor.safeRmSync(dir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/codex-playwright-telegram.test.ts:tmpRm',
+  });
+}
+
+describe('buildTelegramAgenticPrompt', () => {
+  const prompt = buildTelegramAgenticPrompt('/tmp/fake-project');
+
+  it('names the project dir for the agent', () => {
+    expect(prompt).toContain('/tmp/fake-project');
+  });
+
+  it('lists the Playwright tool surface the agent should reach for', () => {
+    expect(prompt).toMatch(/mcp__playwright__browser_navigate/);
+    expect(prompt).toMatch(/browser_snapshot/);
+    expect(prompt).toMatch(/browser_click/);
+    expect(prompt).toMatch(/browser_type/);
+  });
+
+  it('declares the structural success criterion (config-write shape)', () => {
+    expect(prompt).toMatch(/SUCCESS CRITERION/);
+    expect(prompt).toMatch(/type:\s*"telegram"/);
+    expect(prompt).toMatch(/token/);
+    expect(prompt).toMatch(/chatId/);
+    expect(prompt).toMatch(/pollIntervalMs/);
+  });
+
+  it('demands a PLAYWRIGHT_UNAVAILABLE sentinel on missing tools', () => {
+    expect(prompt).toMatch(/PLAYWRIGHT_UNAVAILABLE/);
+  });
+
+  it('demands an AGENTIC_FAILED sentinel on recoverable failures', () => {
+    expect(prompt).toMatch(/AGENTIC_FAILED/);
+  });
+
+  it('uses Telegram Bot API for token validation + chat ID discovery', () => {
+    expect(prompt).toMatch(/api\.telegram\.org/);
+    expect(prompt).toMatch(/getMe/);
+    expect(prompt).toMatch(/getUpdates/);
+  });
+});
+
+describe('verifyTelegramConfig', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mktmp('verifytg-'); });
+  afterEach(() => { tmpRm(tmp); });
+
+  function writeConfig(messaging: unknown[]): void {
+    fs.mkdirSync(path.join(tmp, '.instar'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, '.instar', 'config.json'),
+      JSON.stringify({ messaging }),
+    );
+  }
+
+  it('returns false when .instar/config.json is missing', () => {
+    expect(verifyTelegramConfig(tmp)).toBe(false);
+  });
+
+  it('returns false when messaging array is empty', () => {
+    writeConfig([]);
+    expect(verifyTelegramConfig(tmp)).toBe(false);
+  });
+
+  it('returns false when telegram entry has empty token', () => {
+    writeConfig([{ type: 'telegram', enabled: true, config: { token: '', chatId: '-100123' } }]);
+    expect(verifyTelegramConfig(tmp)).toBe(false);
+  });
+
+  it('returns false when telegram entry has empty chatId', () => {
+    writeConfig([{ type: 'telegram', enabled: true, config: { token: 'abc:def', chatId: '' } }]);
+    expect(verifyTelegramConfig(tmp)).toBe(false);
+  });
+
+  it('returns true when telegram entry has both token and chatId populated', () => {
+    writeConfig([
+      { type: 'telegram', enabled: true, config: { token: '123:abc', chatId: '-100456' } },
+    ]);
+    expect(verifyTelegramConfig(tmp)).toBe(true);
+  });
+
+  it('ignores non-telegram messaging entries', () => {
+    writeConfig([
+      { type: 'whatsapp', enabled: true, config: { backend: 'baileys' } },
+      { type: 'telegram', enabled: true, config: { token: '123:abc', chatId: '-100456' } },
+    ]);
+    expect(verifyTelegramConfig(tmp)).toBe(true);
+  });
+});
+
+describe('ensureCodexPlaywrightMcp', () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mktmp('codexmcp-');
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    // Re-import os to pick up new HOME — but os.homedir() reads HOME
+    // at call time on POSIX, so the next call inside the function
+    // will see our override.
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    tmpRm(tmpHome);
+  });
+
+  it('skips silently when ~/.codex/ does not exist (Codex not installed)', () => {
+    // No .codex dir created. Should no-op without throwing.
+    expect(() => ensureCodexPlaywrightMcp()).not.toThrow();
+    expect(fs.existsSync(path.join(tmpHome, '.codex'))).toBe(false);
+  });
+
+  it('appends the playwright MCP block when ~/.codex/config.toml exists without it', () => {
+    fs.mkdirSync(path.join(tmpHome, '.codex'), { recursive: true });
+    const cfgPath = path.join(tmpHome, '.codex', 'config.toml');
+    fs.writeFileSync(cfgPath, 'model = "gpt-5.2-codex"\n\n[mcp_servers."other"]\nkind = "stdio"\ncommand = "/bin/true"\nargs = []\n');
+    ensureCodexPlaywrightMcp();
+    const after = fs.readFileSync(cfgPath, 'utf-8');
+    expect(after).toContain('[mcp_servers."playwright"]');
+    expect(after).toContain('command = "npx"');
+    expect(after).toContain('@playwright/mcp@latest');
+    // Original sections preserved.
+    expect(after).toContain('model = "gpt-5.2-codex"');
+    expect(after).toContain('[mcp_servers."other"]');
+  });
+
+  it('is idempotent — re-running does NOT duplicate the block', () => {
+    fs.mkdirSync(path.join(tmpHome, '.codex'), { recursive: true });
+    const cfgPath = path.join(tmpHome, '.codex', 'config.toml');
+    fs.writeFileSync(cfgPath, 'model = "gpt-5.2-codex"\n');
+    ensureCodexPlaywrightMcp();
+    ensureCodexPlaywrightMcp();
+    ensureCodexPlaywrightMcp();
+    const after = fs.readFileSync(cfgPath, 'utf-8');
+    const matches = after.match(/\[mcp_servers\."playwright"\]/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('matches BOTH quoted and unquoted TOML section forms', () => {
+    fs.mkdirSync(path.join(tmpHome, '.codex'), { recursive: true });
+    const cfgPath = path.join(tmpHome, '.codex', 'config.toml');
+    // Pre-existing unquoted form.
+    fs.writeFileSync(cfgPath, '[mcp_servers.playwright]\nkind = "stdio"\ncommand = "npx"\nargs = []\n');
+    ensureCodexPlaywrightMcp();
+    const after = fs.readFileSync(cfgPath, 'utf-8');
+    // Should NOT have added a duplicate quoted form.
+    expect(after).not.toMatch(/\[mcp_servers\."playwright"\]/);
+    expect(after).toMatch(/\[mcp_servers\.playwright\]/);
+  });
+});
+
+describe('codex driver dispatches telegram-agentic before native fallback', () => {
+  const src = fs.readFileSync(
+    path.resolve(__dirname, '../../src/commands/setup-wizard/codex-driver.ts'),
+    'utf-8',
+  );
+
+  it('setup-telegram-agentic action tries runTelegramAgentic first', () => {
+    expect(src).toMatch(/case 'setup-telegram-agentic':[\s\S]*?runTelegramAgentic/);
+  });
+
+  it('falls through to runTelegramSetup when the agentic path reports not configured', () => {
+    expect(src).toMatch(
+      /case 'setup-telegram-agentic':[\s\S]*?if \(agentic\.telegramConfigured\) return agentic;[\s\S]*?runTelegramSetup\(options\)/,
+    );
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,85 @@
+# Upgrade Guide — v1.2.17 (Codex+Playwright Telegram primary path)
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**Fix: the wizard's Telegram setup now uses Codex+Playwright as
+the primary path, with the v1.2.15 readline flow as a verified
+backstop.**
+
+Background: v1.2.15 made Telegram setup an instar-native readline
+flow because the prior Codex-driven attempt was broken — Codex
+couldn't see Playwright. Investigation: instar was only
+registering Playwright for Claude (in `~/.claude.json` and
+`.mcp.json`), never for Codex. v1.2.17 closes that and restores
+the Codex agentic path as primary.
+
+Two pieces:
+
+1. **`ensureCodexPlaywrightMcp`** appends a
+   `[mcp_servers."playwright"]` section to `~/.codex/config.toml`
+   so Codex sessions can use the Playwright browser-automation
+   MCP. Same shape Codex already uses for the Threadline MCP.
+   Idempotent — re-runs don't duplicate.
+
+2. **`runTelegramAgentic`** spawns Codex with a Playwright-aware
+   prompt that drives Telegram Web → BotFather → token capture →
+   group creation → chat ID capture → config write. Long timeout
+   (10 minutes) for the QR-code login. After the spawn ends,
+   `verifyTelegramConfig` reads `.instar/config.json` directly
+   and confirms `messaging[]` contains a telegram entry with both
+   `token` and `chatId` populated. The action only returns
+   `telegramConfigured: true` when the verifier passes.
+
+The wizard's `setup-telegram-agentic` action now dispatches:
+
+  try runTelegramAgentic →
+    if verified: done
+    else: dispatch falls through to runTelegramSetup
+          (v1.2.15 readline backstop)
+
+Both paths end at the same config state. The verifier prevents
+the silent-success class of failure that broke v1.2.14.
+
+Spec: `specs/dev-infrastructure/codex-playwright-telegram.md`.
+ELI16: `specs/dev-infrastructure/codex-playwright-telegram.eli16.md`.
+Side-effects: `upgrades/side-effects/feat-codex-playwright-telegram.md`.
+
+## What to Tell Your User
+
+The wizard's Telegram setup now tries to drive the bot creation
+through a browser automatically when you're on the Codex runtime.
+You'll see a browser window pop up; you may need to scan a QR code
+from your phone to log into Telegram Web; then the wizard handles
+BotFather, the bot token, the group creation, and the config
+write. If anything along the way fails, the wizard drops to the
+manual readline flow you saw in v1.2.15 — same end state, just
+with you doing a couple of copy-pastes.
+
+## Summary of New Capabilities
+
+- Codex sessions now have Playwright MCP available (after running
+  the wizard once or after an `instar setup` re-run).
+- The Telegram setup step in the wizard automates more of itself
+  on the Codex runtime.
+
+## Evidence
+
+Reproduction of the v1.2.14 silent-success class: ran v1.2.14
+install, picked Codex, Telegram step recorded
+`telegramConfigured: true` with empty messaging array. v1.2.15
+fixed the silent success by switching to instar-native readline.
+v1.2.17 restores the agentic path WITH the verifier, so the
+silent-success class can't recur — `telegramConfigured: true`
+requires the verifier to confirm the on-disk config write.
+
+After fix:
+- 18 new unit tests cover `buildTelegramAgenticPrompt`,
+  `verifyTelegramConfig`, `ensureCodexPlaywrightMcp` (4 cases
+  including idempotence + skip-when-codex-absent), and the
+  dispatch order in `runAction`.
+- Existing 37 wizard tests still pass.
+- Manual end-to-end re-test on Codex install path pending on
+  publish.

--- a/upgrades/side-effects/feat-codex-playwright-telegram.md
+++ b/upgrades/side-effects/feat-codex-playwright-telegram.md
@@ -1,0 +1,122 @@
+# Side-effects review — Codex+Playwright Telegram primary path
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: UNDER. v1.2.15 only offered the instar-native readline
+Telegram flow because Codex+Playwright was demonstrably broken.
+That worked but felt manual to users on a runtime designed to
+automate.
+
+After: precisely targeted. Codex+Playwright is the primary path;
+the readline flow is the backstop. Users on Codex runtime get
+automated bot creation when Playwright is reachable; everyone
+falls back to manual when it isn't.
+
+No over-block: the readline flow is unchanged (still serves as
+backstop), Claude wizard untouched, WhatsApp/Slack untouched.
+
+## 2. Level-of-abstraction fit
+
+Two scoped additions:
+
+- `ensureCodexPlaywrightMcp()` in `src/commands/setup.ts` — a
+  sibling of the existing claude/.mcp.json registrations. Same
+  abstraction layer (idempotent file writers for MCP config).
+- `runTelegramAgentic` + `buildTelegramAgenticPrompt` +
+  `verifyTelegramConfig` in `src/commands/setup-wizard/codex-
+  driver.ts` — sit alongside the existing `runTelegramSetup`
+  (instar-native flow). Both are private to the driver module.
+
+The dispatch in the setup-telegram-agentic action case is the
+single coordination point: agentic first, native backstop on
+verification failure.
+
+## 3. Signal vs Authority compliance
+
+- The agentic spawn's exit code is a SIGNAL.
+- `verifyTelegramConfig` reading `.instar/config.json` is the
+  AUTHORITY. The action only returns `telegramConfigured: true`
+  when the AUTHORITY confirms the on-disk state.
+- `PLAYWRIGHT_UNAVAILABLE` / `AGENTIC_FAILED: <reason>` are
+  conventional sentinels the Codex prompt emits — the dispatch
+  doesn't parse them programmatically (the verifier does the
+  authoritative check) but they help the operator debug.
+- TOML section presence in `~/.codex/config.toml` is the
+  AUTHORITY for "is Playwright registered for Codex." The
+  idempotence check looks for the literal section header.
+
+## 4. Interactions with adjacent systems
+
+- **`ensurePlaywrightMcp`**: extended (not replaced). The new
+  `ensureCodexPlaywrightMcp` is called at the end of its body. The
+  Claude-side registration is unchanged.
+- **`~/.codex/config.toml`**: appended to (idempotent). Other
+  sections preserved verbatim. The new section follows the same
+  shape Codex uses for Threadline.
+- **`runTelegramSetup` (v1.2.15)**: unchanged. Now serves as the
+  backstop reached on verification failure.
+- **State machine `setup-telegram-agentic` action**: name
+  unchanged. Dispatch handler in `runAction` is the only edited
+  case.
+- **Codex spawn flags**: the agentic spawn uses
+  `--dangerously-bypass-approvals-and-sandbox` (matches the
+  agent's runtime spawn in `frameworkSessionLaunch.ts`),
+  `-m WIZARD_CODEX_MODEL` (matches the narrative spawn), and
+  `--skip-git-repo-check` (allows running outside a git repo).
+- **Existing dispatch canary test**: still asserts every codex
+  exec spawn in the driver carries `-m WIZARD_CODEX_MODEL`. The
+  new agentic spawn obeys this.
+- **`PostUpdateMigrator`**: not touched. `ensurePlaywrightMcp` is
+  called by `runSetup` (Phase 2.5 in the wizard), not by the
+  installer. Existing agents that re-run `npx instar setup` pick
+  up the Codex registration automatically.
+
+## 5. Rollback cost
+
+Low. Revert restores v1.2.16 (agentic Telegram path removed,
+readline flow as sole option). The Codex MCP registration block
+appended to `~/.codex/config.toml` is harmless if left in place
+after rollback (no one will spawn the agentic path).
+
+## 6. Backwards compatibility / drift surface
+
+Fully backwards-compatible.
+
+- Codex-runtime users: get automated bot creation if Playwright
+  works, manual flow if not. Strictly better than v1.2.15's
+  manual-only.
+- Claude-runtime users: zero change.
+- Codex users without Codex installed at MCP-registration time:
+  `ensureCodexPlaywrightMcp` skips silently (no
+  `~/.codex/` directory).
+- API-key Codex users: same auth posture (no new env vars, no new
+  flags).
+- No config schema change. No agent-installed-files change. No
+  `PostUpdateMigrator` work needed (`ensurePlaywrightMcp` runs in
+  the wizard, not the installer).
+
+Drift surface: the Codex MCP TOML format. Verified against
+Justin's live `~/.codex/config.toml` (Threadline registration uses
+exactly the same shape). If Codex changes the format, the
+idempotence check + append both need updates. Captured in the
+spec's "out of scope" — a v2 of this PR could swap the hand-rolled
+TOML for a proper parser.
+
+## 7. Authorization / Trust posture
+
+No new authority. The Codex agentic spawn uses the same sandbox-
+bypass posture the agent's runtime already uses (per
+frameworkSessionLaunch.ts). Playwright operates in its own
+browser sandbox via MCP. The Telegram Bot API calls happen with
+the user's bot token (same as the v1.2.15 readline flow).
+
+## Outcome
+
+Ship. Restores Codex+Playwright as the primary Telegram setup
+path while keeping the v1.2.15 readline flow as a verified
+backstop. Closes Justin's concern about why we were making the
+user do this manually on a runtime designed to automate.
+Verifier-based success criterion prevents any silent-success
+regression of the v1.2.14 class.


### PR DESCRIPTION
## Summary
Restores Codex+Playwright as the primary Telegram setup path. The v1.2.15 instar-native readline flow stays in place as a verified backstop.

## Why
Justin's question: *"surely codex has the same playwright capabilities as claude code?"* — Yes, but instar wasn't registering Playwright for Codex. `ensurePlaywrightMcp` only wrote to `~/.claude.json` + `.mcp.json`, never to `~/.codex/config.toml`. So the v1.2.14 codex agentic Telegram attempt spawned with no Playwright reachable and fell back to printing manual instructions.

## Two fixes

### 1. Register Playwright for Codex
New `ensureCodexPlaywrightMcp()` appends to `~/.codex/config.toml`:
```toml
[mcp_servers."playwright"]
kind = "stdio"
command = "npx"
args = ["-y", "@playwright/mcp@latest"]
```
Idempotent (handles both quoted and unquoted TOML section forms). Skips silently when `~/.codex/` is absent. Atomic write.

### 2. Restore agentic Telegram setup with verifier
`runTelegramAgentic` spawns Codex with a Playwright-aware prompt (10-min timeout, covers QR-code human-in-the-loop login). After the spawn ends, `verifyTelegramConfig` reads `.instar/config.json` directly to authoritatively confirm the messaging entry has both `token` and `chatId` populated. The action only returns `telegramConfigured: true` when the verifier passes.

The dispatch:
```ts
case 'setup-telegram-agentic': {
  const agentic = await runTelegramAgentic(options);
  if (agentic.telegramConfigured) return agentic;
  console.log('  Browser automation didn\'t finish — switching to manual setup.');
  return await runTelegramSetup(options);  // v1.2.15 readline backstop
}
```

The verifier prevents any silent-success regression of the v1.2.14 class.

## Codex prompt
Includes explicit `PLAYWRIGHT_UNAVAILABLE` and `AGENTIC_FAILED: <reason>` sentinels for fast-fail behavior, the success criterion (config-write shape), the structural steps (login → BotFather → token → group → chat ID → config write).

## Tests
- 18 new unit tests in `tests/unit/codex-playwright-telegram.test.ts` covering the prompt shape, the verifier (6 cases), the MCP registration (4 cases incl. idempotence + skip-when-absent), and dispatch order.
- Existing 37 wizard tests still pass.

## Spec bundle
- Spec: `specs/dev-infrastructure/codex-playwright-telegram.md`
- ELI16: `specs/dev-infrastructure/codex-playwright-telegram.eli16.md`
- Convergence: `docs/specs/reports/codex-playwright-telegram-convergence.md`
- Side-effects: `upgrades/side-effects/feat-codex-playwright-telegram.md`
- Trace: `.instar/instar-dev-traces/20260522T012819Z-codex-playwright-telegram.json`

## Test plan
- [x] 18 new unit tests pass
- [x] Existing 37 wizard tests pass
- [x] tsc --noEmit clean
- [x] lint clean
- [ ] CI green
- [ ] Manual end-to-end: re-run install on instar-codey after publish, verify the browser opens, BotFather flow completes, config.json has populated messaging entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)