### PR TITLE
fix(setup-wizard): Telegram agentic prompt narrates to user (v1.2.18)

### DIFF
--- a/.instar/instar-dev-traces/20260522T020952Z-telegram-login-ux.json
+++ b/.instar/instar-dev-traces/20260522T020952Z-telegram-login-ux.json
@@ -1,0 +1,18 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/telegram-login-ux.md",
+  "artifactPath": "upgrades/side-effects/fix-telegram-login-ux.md",
+  "artifactSha256": "677607930d255972247e44a5874b31e68de3276f35fbc70d4e502a94eda3e1f9",
+  "coveredFiles": [
+    "src/commands/setup-wizard/codex-driver.ts",
+    "tests/unit/codex-playwright-telegram.test.ts",
+    "specs/dev-infrastructure/telegram-login-ux.md",
+    "specs/dev-infrastructure/telegram-login-ux.eli16.md",
+    "docs/specs/reports/telegram-login-ux-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/fix-telegram-login-ux.md"
+  ],
+  "writtenAt": "2026-05-22T02:09:52Z",
+  "agent": "echo",
+  "summary": "Rewrites buildTelegramAgenticPrompt with explicit conversational rules + step-by-step user narration. Codex now tells the user to open Telegram on their phone, walks through Settings→Devices→Link Desktop Device, prints periodic reminders during the 5-minute (was 120s) login wait. 2 new tests + existing 18 still pass. Ships v1.2.18."
+}

--- a/docs/specs/reports/telegram-login-ux-convergence.md
+++ b/docs/specs/reports/telegram-login-ux-convergence.md
@@ -1,0 +1,62 @@
+# Convergence Report — Telegram login UX narrative-driven prompt
+
+## ELI10 Overview
+
+v1.2.17 made Codex+Playwright the primary Telegram setup path. It
+worked technically — Codex opened the browser and started watching
+for login. But the user saw a QR code with no on-screen guidance.
+The Claude version of this flow doesn't have this problem because
+the wizard skill explicitly tells Claude to narrate to the user.
+The Codex prompt I wrote for v1.2.17 didn't.
+
+This PR rewrites the Codex prompt with explicit conversational
+rules at the top + step-by-step instructions to print user-facing
+narration. Also bumps the login-wait from 2 minutes to 5 minutes
+for fresh users who need to install Telegram on their phone first.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1         | self + Justin's log + "why pre-spawn?" pushback | 2 | conversational-rules preamble + step narration |
+| 2         | (converged)           | 0                 | none |
+
+## Original vs Converged
+
+The original draft of this fix proposed scaffolding the instructions
+from instar BEFORE the spawn (pre-spawn console.log block).
+Justin's pushback: *"why cant the codex agent know to stop just
+like the claude code agent does?"* — same way Claude follows the
+wizard SKILL.md's behavioral instructions, Codex can follow
+prompt instructions, if the prompt actually asks for it. The
+right fix is prompt content, not pre-spawn scaffolding.
+
+The converged design moves all user-facing narration INTO the
+prompt with explicit "you are talking to a real person sitting at
+the terminal RIGHT NOW" framing. No pre-spawn scaffolding.
+
+## Full Findings Catalog
+
+**Finding 1 — Codex silently polled because the prompt didn't ask
+for user narration.**
+
+- Severity: high (real user, real install, real failure).
+- Resolution: new "CRITICAL CONVERSATIONAL RULES" section at the
+  top of the prompt + step-2 prints an explicit instruction block
+  + step-3 prints reminder messages every 25-30s during the wait.
+
+**Finding 2 — 120s login window was too short for fresh users.**
+
+- Severity: medium (some users will need to install Telegram on
+  their phone first; 2 min isn't enough).
+- Resolution: prompt now specifies 5-minute window (300s) with
+  60 poll attempts at 5-second cadence. Outer spawn timeout
+  remains 10 minutes in case Codex hangs.
+
+## Convergence verdict
+
+Converged at iteration 2. Pure prompt-content change; no new
+modules, abstractions, or authorities. The verifier still
+authoritatively decides whether the agentic path succeeded. 20
+unit tests (18 from v1.2.17 + 2 new for the conversational rules
+and 5-minute window).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.2.17",
+      "version": "1.2.18",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.17",
+  "version": "1.2.18",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/telegram-login-ux.eli16.md
+++ b/specs/dev-infrastructure/telegram-login-ux.eli16.md
@@ -1,0 +1,64 @@
+# What this PR does — in plain English
+
+## The story
+
+v1.2.17 made Codex+Playwright the primary path for setting up
+Telegram. It actually worked — Codex opened a browser to Telegram
+Web and started watching for the login to complete. Good.
+
+But the user just stared at a QR code with no idea what to do.
+Justin's first install attempt timed out at 2 minutes with zero
+on-screen guidance about scanning the code with his phone.
+
+The Claude version of this same flow doesn't have this problem.
+When Claude opens Telegram Web, Claude tells the user "I see the
+login screen — please scan the QR code with your phone's Telegram
+app (Settings → Devices → Link Desktop Device)". Claude does this
+naturally because Claude follows the wizard skill's "speak
+conversationally" instructions.
+
+Codex, by default, treats prompts as task descriptions. So when I
+told Codex "take snapshots and wait for the login transition",
+Codex did exactly that — silently. No user-facing narration.
+
+## The fix
+
+Rewrite the Codex prompt to tell it, explicitly:
+
+- You're talking to a real person sitting at the terminal RIGHT
+  NOW.
+- They can only see what you print as prose. Snapshot results and
+  tool calls are invisible to them.
+- BEFORE you act on something, tell them what's about to happen.
+- DURING a wait (like the QR code login), print real instructions
+  every 25-30 seconds — not "still polling" status.
+- When you hit a failure, tell them in plain English first, THEN
+  output the failure sentinel.
+
+The prompt also specifies the exact instruction block to print
+right after the browser opens — what to do, where to go on the
+phone, that it's OK if Telegram isn't installed yet (just grab
+it from the app store), and how long the wizard will wait.
+
+And the wait window goes from 2 minutes to 5 minutes, because 2
+minutes isn't enough for a fresh user who has to install Telegram
+on their phone first.
+
+## Why this should work
+
+The Codex prompt I wrote for v1.2.17 was implicit about
+conversation — it described actions, not narration. v1.2.18 is
+explicit. Codex's training does respond to clear "you are a
+guide, narrate to the user" framing; the failure mode was that I
+hadn't asked for it.
+
+## What doesn't change
+
+- The agentic-first, manual-backstop dispatch is unchanged.
+- The verifier (`verifyTelegramConfig`) is unchanged.
+- The Playwright registration in `~/.codex/config.toml` from
+  v1.2.17 is unchanged.
+- The Claude wizard path is untouched.
+
+This PR is purely about making the Codex agentic path's UX match
+the Claude one.

--- a/specs/dev-infrastructure/telegram-login-ux.md
+++ b/specs/dev-infrastructure/telegram-login-ux.md
@@ -1,0 +1,132 @@
+---
+title: "Telegram login UX — narrative-driven Codex prompt"
+slug: "telegram-login-ux"
+author: "echo"
+eli16-overview: "telegram-login-ux.eli16.md"
+review-convergence: "2026-05-22T02:10:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-22T02:10:00Z"
+review-report: "docs/specs/reports/telegram-login-ux-convergence.md"
+approved: true
+---
+
+# Telegram login UX — narrative-driven Codex prompt
+
+## Problem statement
+
+End-to-end Codex install attempt on instar-codey (v1.2.17) showed
+the agentic Telegram path actually worked: Playwright opened
+Telegram Web, Codex started polling the page. But the user-facing
+experience was bad:
+
+- One single one-line aside before the spawn ("you may need to scan
+  a QR code from your phone to log into Telegram Web").
+- Then Codex polled silently every 5 seconds for 120 seconds.
+- The only thing on screen during the wait was Codex's internal
+  status: "Telegram Web is still on the QR login screen. I'm
+  continuing 5-second snapshot polling..."
+- After 120s, AGENTIC_FAILED: telegram-login-timeout, fall through
+  to manual setup.
+
+Two failures in one:
+
+1. **The user wasn't told what to do.** No on-screen instructions
+   about opening Telegram on their phone, the path
+   (Settings → Devices → Link Desktop Device), what to scan, or
+   that they might need to install Telegram first.
+2. **120 seconds isn't enough** for a fresh user who hasn't
+   installed Telegram on their phone yet.
+
+Justin's framing of the right fix: *"why a pre-spawn instruction?
+Why cant the codex agent know to stop just like the claude code
+agent does?"* — i.e., don't scaffold from instar; make the Codex
+prompt do it. Claude follows the wizard skill's narrative
+instructions natively; Codex needs the same kind of explicit
+"speak to the user" language in its prompt.
+
+## Proposed design
+
+Rewrite `buildTelegramAgenticPrompt` to make the conversational
+behavior explicit. Three structural changes:
+
+### 1. Explicit "you are talking to a real person" preamble
+
+A new "CRITICAL CONVERSATIONAL RULES" section at the top of the
+prompt:
+
+- The user is sitting at the terminal RIGHT NOW.
+- Only the prose Codex prints reaches them — snapshot results,
+  tool calls, internal reasoning are invisible.
+- Tell the user what's about to happen BEFORE acting.
+- During waits, print real instructions, not internal status.
+
+This is the equivalent of the wizard SKILL.md's "speak
+conversationally / never show CLI commands / NEVER use
+AskUserQuestion" rules — but framed for Codex's execution-pull
+training.
+
+### 2. Step 2 (post-navigate) prints a clear instruction block
+
+The prompt now specifies the EXACT text to print after Playwright
+loads Telegram Web. The user sees a multi-bullet block:
+
+> A browser window just opened with Telegram Web. To log in:
+>   • Open Telegram on your phone (if you don't have it yet,
+>     install it from your phone's app store — it's free and
+>     takes about 30 seconds)
+>   • In Telegram, open Settings → Devices → Link Desktop Device
+>   • Point your phone at the QR code in the browser window
+>
+> I'll wait up to 5 minutes for the login. Take your time — I'll
+> remind you periodically.
+
+The prompt notes that Codex should adjust the wording to match
+the actual UI it sees in the snapshot — the goal is correctness,
+not parroting fixed text.
+
+### 3. Periodic reminders during the login wait + 5-min timeout
+
+- Poll for login transition for up to 5 minutes (was 120 seconds).
+- Every ~25-30 seconds during the wait, print a short user-facing
+  reminder (not internal status). Vary the wording.
+- After 5 minutes, print a clear "switching to manual" line, THEN
+  the AGENTIC_FAILED sentinel.
+
+The remaining steps (BotFather, group creation, token capture,
+config write) also gain brief user-facing narrations between
+sub-steps — "Bot's ready. Creating a group chat now and adding
+the bot."
+
+## Decision points touched
+
+- The prompt now carries a behavioral contract for conversation.
+  Same approach as the Claude wizard's SKILL.md, just authored
+  with Codex's training-pull in mind (explicit "real person",
+  "what they see").
+- No new authority. No new spawn flags. No new sandbox posture.
+  Just prompt content.
+- The verifier (`verifyTelegramConfig`) still authoritatively
+  decides whether the agentic path succeeded; nothing about the
+  prompt changes the success contract.
+
+## Open questions
+
+None.
+
+## Out of scope
+
+- Codex-side periodic-reminder enforcement beyond what the prompt
+  asks for. We trust Codex to follow the explicit
+  every-25-30-seconds instruction. If a future log shows Codex
+  ignoring it, we revisit with structural enforcement (e.g.
+  instar prints the reminder via a parallel timer outside the
+  spawn).
+- An interactive "press Enter when you've logged in" Ctrl-style
+  signal. Adds complexity and would conflict with the spawn's
+  stdio:'inherit' setup. The 5-minute window is generous enough
+  for the vast majority of users; the manual backstop covers the
+  tail.
+- Telling Codex to also print progress for the BotFather flow.
+  The prompt now does this in steps 4, 10, 14 ("You're in.",
+  "Bot's ready.", "Telegram is connected."). Lightweight; users
+  see progress without being overwhelmed.

--- a/src/commands/setup-wizard/codex-driver.ts
+++ b/src/commands/setup-wizard/codex-driver.ts
@@ -478,13 +478,14 @@ async function runAction(
 async function runTelegramAgentic(options: CodexDriverOptions): Promise<Partial<WizardAnswers>> {
   console.log();
   console.log(pc.bold('  Telegram setup'));
-  console.log(pc.dim('  Starting browser-driven bot creation via Codex + Playwright.'));
-  console.log(pc.dim('  This opens a browser window; you may need to scan a QR code from your phone to log into Telegram Web.'));
   console.log();
 
   const prompt = buildTelegramAgenticPrompt(options.projectDir);
-  // Long timeout — the human-in-the-loop login can take a couple
-  // minutes if the user has to grab their phone.
+  // 10-minute spawn timeout — the first-time user might need to
+  // install Telegram on their phone before they can scan the QR.
+  // Codex itself enforces a tighter login-wait via the prompt
+  // (it prints user-facing instructions and polls for the login
+  // transition); this is the outer wall in case Codex hangs.
   const result = spawnSync(
     options.codexPath,
     [
@@ -497,7 +498,7 @@ async function runTelegramAgentic(options: CodexDriverOptions): Promise<Partial<
     {
       cwd: options.projectDir,
       stdio: 'inherit',
-      timeout: 600_000, // 10 minutes
+      timeout: 600_000,
     },
   );
   if (result.status !== 0 && result.status !== null) {
@@ -522,11 +523,28 @@ async function runTelegramAgentic(options: CodexDriverOptions): Promise<Partial<
  */
 export function buildTelegramAgenticPrompt(projectDir: string): string {
   return `
-You have Playwright browser-automation MCP tools available
+You are the instar setup wizard's Telegram phase. The user is sitting
+at the terminal RIGHT NOW reading what you print. You also have
+Playwright browser-automation MCP tools available
 (mcp__playwright__browser_navigate, browser_snapshot, browser_click,
 browser_type, browser_press_key, browser_wait_for, etc).
 
 TASK: Set up a Telegram bot for an instar agent at ${projectDir}.
+
+CRITICAL CONVERSATIONAL RULES:
+  - You are talking to a real person, not running a job. Speak to
+    them warmly and clearly at every step. They cannot see your
+    snapshot results, your tool calls, or your internal reasoning.
+    Only the prose you print appears on their terminal.
+  - When you start a step, TELL THE USER what's about to happen and
+    what they need to do (if anything) before you do it. Like a
+    helpful guide narrating their experience.
+  - When you're waiting on the user (e.g. QR-code login), print
+    reminder text every ~25-30 seconds — not internal status, but
+    REAL instructions they can act on right now.
+  - Never print "still polling" or "no transition detected" or
+    other internal-state language. The user doesn't care about your
+    polling cadence; they care about what to do.
 
 SUCCESS CRITERION (verified by the caller after you exit):
   .instar/config.json's messaging[] contains exactly one entry
@@ -544,70 +562,112 @@ STEPS:
    (Do NOT print any manual instructions; the caller has its own
    manual fallback.)
 
-2. The user may need to scan a QR code from their phone to log in.
-   Take snapshots periodically (every ~5 seconds, up to ~120 seconds
-   total). The page is "logged in" when the left rail shows a chat
-   list (search bar + chats) rather than the QR code or phone-number
-   form. If still on login after 120s, output:
+2. After Playwright loads the page, IMMEDIATELY print to the user
+   a clear, friendly instruction block like:
+
+   > A browser window just opened with Telegram Web. To log in:
+   >   • Open Telegram on your phone (if you don't have it yet,
+   >     install it from your phone's app store — it's free and
+   >     takes about 30 seconds)
+   >   • In Telegram, open Settings → Devices → Link Desktop Device
+   >   • Point your phone at the QR code in the browser window
+   >
+   > I'll wait up to 5 minutes for the login. Take your time — I'll
+   > remind you periodically.
+
+   (Adjust the wording to match the actual UI you see in the
+   snapshot if Telegram Web's options/copy differs from this.)
+
+3. Poll for login transition every ~5 seconds via browser_snapshot.
+   Up to 5 MINUTES total (60 attempts). The page is "logged in"
+   when the left rail shows a chat list rather than the QR/phone-
+   number form.
+
+   While polling, EVERY ~25-30 seconds print a short user-facing
+   reminder (vary the wording so it doesn't feel robotic):
+     "Still waiting for the QR scan — once you've logged in on
+     your phone, the browser will update automatically and I'll
+     keep going."
+
+   If still on login after 5 minutes, print to the user:
+     "I didn't see the login complete after 5 minutes. I'll switch
+     us to a manual setup — same end result, just a couple of
+     copy-pastes."
+   Then output:
      AGENTIC_FAILED: telegram-login-timeout
    and exit.
 
-3. Once logged in, use the search bar to find "BotFather". Click
-   the verified @BotFather result.
+4. Once logged in, tell the user briefly:
+   "You're in. I'll create the bot and the group for us — give me
+   a moment."
+   Then use the search bar to find "BotFather". Click the verified
+   @BotFather result.
 
-4. Send /newbot. Wait for the reply.
+5. Send /newbot. Wait for the reply.
 
-5. When BotFather asks for the bot's display name, type:
+6. When BotFather asks for the bot's display name, type:
    "Instar Agent"
 
-6. When BotFather asks for the bot's username, generate one ending
+7. When BotFather asks for the bot's username, generate one ending
    in "bot" (use the basename of the project dir, lower-case,
    ASCII-only, with "_instar_bot" appended; if taken, append random
    digits and retry up to 5 times).
 
-7. Read BotFather's reply containing the token. Extract the token
+8. Read BotFather's reply containing the token. Extract the token
    from the message body. Token format: \\d+:[A-Za-z0-9_-]+
-   Store it in a local variable.
+   Store it in a local variable. (Do NOT print the token to the
+   terminal — it's a credential.)
 
-8. Validate the token via the Telegram Bot API (Bash):
+9. Validate the token via the Telegram Bot API (Bash):
      curl -s "https://api.telegram.org/bot<TOKEN>/getMe"
-   If response.ok is not true, output:
+   If response.ok is not true, tell the user:
+     "Something went wrong with the bot creation. Switching to
+     manual setup."
+   Then output:
      AGENTIC_FAILED: token-invalid
    and exit.
 
-9. Create a new group chat:
-   a. Click the "new message" / pencil icon.
-   b. Choose "New Group".
-   c. Search for and add the bot you just created.
-   d. Name the group "<basename> + instar".
-   e. Create the group.
-   f. Send a message inside the group: "first contact".
+10. Tell the user briefly:
+    "Bot's ready. Creating a group chat now and adding the bot."
+    Then create a new group chat:
+    a. Click the "new message" / pencil icon.
+    b. Choose "New Group".
+    c. Search for and add the bot you just created.
+    d. Name the group "<basename> + instar".
+    e. Create the group.
+    f. Send a message inside the group: "first contact".
 
-10. Fetch the chat ID:
+11. Fetch the chat ID:
       curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates"
     Pick the result where message.chat.type is "group" or
     "supergroup". Extract message.chat.id as a string.
 
-11. Write the config. Read the existing .instar/config.json. Filter
+12. Write the config. Read the existing .instar/config.json. Filter
     out any existing { type: "telegram" } entries. Push:
       { type: "telegram", enabled: true,
         config: { token: "<TOKEN>", chatId: "<CHAT_ID>",
                   pollIntervalMs: 2000, stallTimeoutMinutes: 5 } }
     Write the file back (atomic-ish: tmp file + rename is fine).
 
-12. Verify your write succeeded by re-reading the file and confirming
+13. Verify your write succeeded by re-reading the file and confirming
     the messaging entry is present with both fields populated. If
-    not, output:
+    not, tell the user briefly:
+      "Couldn't save the Telegram config — switching to manual."
+    Then output:
       AGENTIC_FAILED: config-write-failed
     and exit.
 
-13. Exit cleanly. Do NOT print summary text — the caller will verify
-    the config and report to the user.
+14. Tell the user briefly:
+    "Telegram is connected. From here on, your agent will message
+    you in that group."
+    Then exit cleanly. The caller will verify the config and
+    proceed with the rest of the wizard.
 
-FAILURE MODE: at ANY step you cannot recover from, output exactly
-"AGENTIC_FAILED: <one-line reason>" and exit. The caller will fall
-through to a readline-based manual setup. Do NOT try to be clever —
-fast-fail is what enables the fallback to work.
+FAILURE MODE: at ANY step you cannot recover from, FIRST tell the
+user in plain English what happened (one sentence, no jargon), THEN
+output "AGENTIC_FAILED: <one-line reason>" and exit. The caller
+will fall through to a readline-based manual setup. Do NOT try to
+be clever — fast-fail is what enables the fallback to work.
 `.trim();
 }
 

--- a/tests/unit/codex-playwright-telegram.test.ts
+++ b/tests/unit/codex-playwright-telegram.test.ts
@@ -83,6 +83,29 @@ describe('buildTelegramAgenticPrompt', () => {
     expect(prompt).toMatch(/getMe/);
     expect(prompt).toMatch(/getUpdates/);
   });
+
+  it('tells Codex to surface user-facing instructions (v1.2.18 fix)', () => {
+    // The v1.2.17 prompt only told Codex to "take snapshots" — no
+    // user-facing language. Real user (Justin) sat looking at a QR
+    // code with no on-screen guidance. v1.2.18 explicitly tells
+    // Codex to narrate to the user.
+    expect(prompt).toMatch(/CONVERSATIONAL RULES/i);
+    expect(prompt).toMatch(/real person/i);
+    expect(prompt).toMatch(/Telegram on your phone/);
+    expect(prompt).toMatch(/Link Desktop Device/);
+    // Install hint for first-time users.
+    expect(prompt).toMatch(/install.*app store/i);
+    // Periodic reminder pattern during the wait.
+    expect(prompt).toMatch(/every ~25-30 seconds/);
+  });
+
+  it('uses a 5-minute (not 2-minute) login-wait window', () => {
+    // v1.2.17 had "up to ~120 seconds". v1.2.18 bumps to 5 minutes
+    // so a fresh user who has to install Telegram on their phone
+    // first doesn't time out.
+    expect(prompt).not.toMatch(/up to ~120 seconds/);
+    expect(prompt).toMatch(/5 MINUTES|5 minutes/);
+  });
 });
 
 describe('verifyTelegramConfig', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,81 @@
+# Upgrade Guide — v1.2.18 (Telegram login UX — narrative-driven prompt)
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**Fix: the Codex agentic Telegram path now narrates to the user
+the way the Claude wizard does.**
+
+v1.2.17 made Codex+Playwright the primary Telegram setup path,
+and it worked technically — Playwright opened Telegram Web, Codex
+started polling for login. But the user saw a QR code with no
+on-screen guidance about scanning it. After 120 seconds of
+silence Codex timed out and the wizard fell to the manual readline
+backstop.
+
+Root cause: my v1.2.17 prompt told Codex to "take snapshots" but
+never told it to tell the user what was happening. The Claude
+wizard skill has the equivalent narration ("I see the Telegram
+login screen — please scan the QR code with your phone's Telegram
+app, Settings → Devices → Link Desktop Device"). My Codex prompt
+didn't.
+
+v1.2.18 rewrites the prompt with:
+
+- A new "CRITICAL CONVERSATIONAL RULES" preamble explicitly framing
+  the user as someone sitting at the terminal RIGHT NOW, only
+  seeing prose Codex prints (not snapshots, not tool calls, not
+  internal reasoning).
+- Step-2 specifies the exact instruction block to print after the
+  browser opens — what's on screen, how to open Telegram on the
+  user's phone (with an "install from app store if you don't have
+  it yet" note), the menu path (Settings → Devices → Link Desktop
+  Device), and how long the wizard will wait.
+- Step-3 polls for the login transition for up to **5 MINUTES**
+  (was 120 seconds) with periodic 25-30s user-facing reminders
+  about what they need to do.
+- Brief narrations between BotFather sub-steps ("Bot's ready.
+  Creating a group chat now and adding the bot.", "Telegram is
+  connected.").
+
+The verifier (`verifyTelegramConfig`) still authoritatively
+decides whether the agentic path succeeded. No new authority, no
+new abstraction, no new scaffolding from instar — just better
+prompt content that makes Codex behave like the Claude wizard
+does.
+
+Spec: `specs/dev-infrastructure/telegram-login-ux.md`.
+ELI16: `specs/dev-infrastructure/telegram-login-ux.eli16.md`.
+Side-effects: `upgrades/side-effects/fix-telegram-login-ux.md`.
+
+## What to Tell Your User
+
+The Telegram setup step now tells you exactly what to do when the
+browser opens — open Telegram on your phone, go to Settings →
+Devices → Link Desktop Device, scan the QR code in the browser
+window. If you don't have Telegram on your phone yet, it'll tell
+you to grab it from the app store first. You have 5 minutes to
+complete the scan; the wizard reminds you periodically while it
+waits.
+
+## Summary of New Capabilities
+
+No new capabilities. Prompt-content UX fix on top of v1.2.17.
+
+## Evidence
+
+Reproduction prior: ran v1.2.17 install on instar-codey. Codex
+opened Telegram Web, printed "Telegram Web is still on the QR
+login screen. I'm continuing 5-second snapshot polling..." three
+times across 120 seconds with no user-actionable text, then
+AGENTIC_FAILED: telegram-login-timeout. User had to switch to
+manual.
+
+After fix:
+- 2 new unit tests cover the v1.2.18 prompt additions (the
+  conversational-rules section and the 5-minute window).
+- 18 existing prompt/verifier/MCP tests still pass.
+- Manual end-to-end re-test on Codex install path pending on
+  publish.

--- a/upgrades/side-effects/fix-telegram-login-ux.md
+++ b/upgrades/side-effects/fix-telegram-login-ux.md
@@ -1,0 +1,80 @@
+# Side-effects review — Telegram login UX (narrative-driven prompt)
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: UNDER. v1.2.17 Codex prompt only described internal actions
+("take snapshots", "look for login transition"). Codex did exactly
+that — silently. User stared at a QR code for 2 minutes with no
+on-screen guidance, hit the 120s timeout, fell to manual.
+
+After: precisely targeted. Prompt now explicitly demands user-facing
+narration at every step — before opening the browser, during the
+login wait (every 25-30s reminders), between BotFather sub-steps.
+Login window also bumped to 5 minutes for fresh users who haven't
+installed Telegram yet. No over-block: the wizard still falls
+through to the readline backstop on any failure.
+
+## 2. Level-of-abstraction fit
+
+Pure prompt-content change. No new functions, no new modules, no
+new abstraction. The prompt's conversational rules section is a
+direct translation of the wizard SKILL.md's "speak conversationally
+/ never show CLI" rules into Codex-training-aware language.
+
+## 3. Signal vs Authority compliance
+
+- The user's eyes are the AUTHORITY for "did this UX work." The
+  prompt content is a SIGNAL aimed at producing the right UX.
+- The verifier (`verifyTelegramConfig`) remains the AUTHORITY for
+  "did the agentic path succeed." Prompt content doesn't change
+  the success criterion.
+- The user-facing reminder cadence (~25-30s) is a SIGNAL the
+  prompt sends to Codex — not enforced structurally. If a future
+  log shows Codex ignoring the cadence, we revisit with an outside-
+  the-spawn timer.
+
+## 4. Interactions with adjacent systems
+
+- **`runTelegramAgentic`**: comment-only edits (removed the now-
+  redundant pre-spawn instruction lines that the prompt itself now
+  prints).
+- **Spawn timeout**: unchanged (10 min outer wall). The 5-min
+  login-wait is enforced inside the prompt by Codex.
+- **`verifyTelegramConfig`**: unchanged.
+- **`runTelegramSetup` (readline backstop)**: unchanged. Still
+  catches AGENTIC_FAILED via verifier check.
+- **Existing unit tests**: 18 still pass; 2 new tests cover the
+  v1.2.18 prompt additions (conversational rules + 5-min window).
+
+## 5. Rollback cost
+
+Trivial. Prompt content is the only meaningful change. `git revert`
+restores v1.2.17 prompt + the redundant pre-spawn lines.
+
+## 6. Backwards compatibility / drift surface
+
+Fully backwards-compatible.
+
+- Codex-runtime users with Playwright reachable: get a much better
+  conversational experience.
+- Codex-runtime users without Playwright: same fallback to
+  PLAYWRIGHT_UNAVAILABLE → manual flow.
+- Claude-runtime users: zero change.
+- Drift surface: the prompt's wording itself. If a future PR
+  weakens the conversational-rules section (or removes the
+  5-minute window), v1.2.18's tests will fail.
+
+## 7. Authorization / Trust posture
+
+No change. Same Codex spawn flags, same Playwright access, same
+sandbox bypass posture.
+
+## Outcome
+
+Ship. Restores the user-facing experience for the Codex agentic
+path to match the Claude wizard's quality. Prompt content is the
+right place to fix this — confirmed by Justin's pushback against
+scaffolding from instar ("why cant the codex agent know to stop
+just like the claude code agent does?").


### PR DESCRIPTION
## Summary
v1.2.17 made Codex+Playwright the primary Telegram path but the prompt told Codex to take snapshots silently — never to narrate to the user. Justin sat looking at a QR code for 120s with no on-screen guidance, hit AGENTIC_FAILED: telegram-login-timeout, fell to manual.

His framing of the right fix: *"why cant the codex agent know to stop just like the claude code agent does?"* — make the Codex prompt do the narration, same way Claude follows the wizard SKILL.md.

## Prompt rewrite
- New "CRITICAL CONVERSATIONAL RULES" preamble: user is sitting at the terminal RIGHT NOW, only sees prose, snapshot results and tool calls are invisible.
- Step-2 specifies the exact instruction block to print after navigate — open Telegram on phone (install from app store if needed), Settings → Devices → Link Desktop Device, scan QR.
- Step-3 polls for login for up to **5 MINUTES** (was 120s) with 25-30s user-facing reminder cadence.
- Brief narrations between BotFather sub-steps ("Bot's ready.", "Telegram is connected.").

## What didn't change
- Verifier (`verifyTelegramConfig`) still authoritatively decides success.
- Agentic-first, manual-backstop dispatch is unchanged.
- Playwright registration in `~/.codex/config.toml` from v1.2.17 unchanged.
- Claude wizard path untouched.

## Tests
- 20 unit tests pass (18 from v1.2.17 + 2 new for conversational rules + 5-min window).
- tsc + lint clean.

## Spec bundle
- Spec: `specs/dev-infrastructure/telegram-login-ux.md`
- ELI16: `specs/dev-infrastructure/telegram-login-ux.eli16.md`
- Convergence: `docs/specs/reports/telegram-login-ux-convergence.md`
- Side-effects: `upgrades/side-effects/fix-telegram-login-ux.md`
- Trace: `.instar/instar-dev-traces/20260522T020952Z-telegram-login-ux.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)