### PR TITLE
docs(openclaw-t22): document codex framework limitation

### DIFF
--- a/docs/specs/OPENCLAW-IMPORT-BEFORE-PROMPT-BUILD-SPEC.eli16.md
+++ b/docs/specs/OPENCLAW-IMPORT-BEFORE-PROMPT-BUILD-SPEC.eli16.md
@@ -38,6 +38,12 @@ This change adds a single bounded recall pass that runs before EVERY reply, so t
 - Any change when memory is sparse. If SemanticMemory has nothing relevant to your message, the recall returns empty and Claude Code sees no injected context. The reply is identical to today.
 - Any disruption to existing grounding skills. Skills that already check memory continue to do so. This adds a layer; it doesn't replace anything.
 
+## Heads up — Claude Code only
+
+This feature only fires on Claude Code sessions, not Codex. Codex CLI doesn't have a pre-prompt hook the way Claude Code does, so there's nowhere for instar to inject the recall block before a codex turn. If you've configured a topic to run on codex, the agent's replies on that topic will not benefit from this bounded recall pass — your other grounding skills still work normally.
+
+This is a documented v1 limitation, not a bug. If codex usage grows enough that the gap matters, a session-start trigger (recall once at the start of a codex conversation, not per turn) is a small follow-up. For now: the asymmetry is honest, and Claude Code is where most agent traffic lives anyway.
+
 ## Safety properties
 
 - **Bounded.** Max 5 entries, max 1200 chars of injected text, max 2-second search.

--- a/docs/specs/OPENCLAW-IMPORT-BEFORE-PROMPT-BUILD-SPEC.md
+++ b/docs/specs/OPENCLAW-IMPORT-BEFORE-PROMPT-BUILD-SPEC.md
@@ -100,6 +100,20 @@ All recall outcomes return a typed `source` so the caller can observe:
 | `circuit-open` | Breaker is open; recall short-circuits to empty. |
 | `error` | Search threw. Increments circuit counter. |
 
+## Framework coverage — known limitation
+
+**Claude Code only as of v1.0.x.** This feature triggers via Claude Code's `UserPromptSubmit` hook. Codex CLI (the other v1.0 framework option) does not expose an equivalent per-prompt hook surface, so on codex sessions the pre-prompt memory recall does not fire.
+
+This is a deliberate v1 scope choice surfaced by the 2026-05-21 OpenClaw v1.0 re-audit (topic 9003). Three options were considered:
+
+1. Accept Claude-Code-only as v1 scope (selected). Document the limitation. Reversible if codex usage grows.
+2. Wire codex-side trigger via a session-start hook — coarser (recall once per session, not per turn) but available.
+3. Defer entirely until codex usage warrants the design work.
+
+**Why option (1).** The server-side `PromptBuildRecall` primitive itself is framework-agnostic — if codex ever gains a pre-prompt hook (or a session-start trigger becomes acceptable), wiring it is a small follow-up. The asymmetry is honest, documented, and reversible.
+
+**Operator note.** On a topic configured to run codex (`topicFrameworks: { "<topicId>": "codex-cli" }`), the agent's responses on that topic will not benefit from the bounded recall pass. The existing in-skill grounding patterns (`relationship-grounding`, etc.) continue to function as before. SemanticMemory search remains available via direct API call if a codex agent wants to invoke it explicitly.
+
 ## What is NOT in this spec
 
 - **Six prompt styles** (`balanced`, `strict`, etc.). One bias setting (`minConfidence`) is enough for v1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.2.22",
+      "version": "1.2.23",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,24 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**docs(openclaw-t22): document codex framework limitation on pre-prompt memory recall.**
+
+Spec note added to `docs/specs/OPENCLAW-IMPORT-BEFORE-PROMPT-BUILD-SPEC.md` acknowledging that the pre-prompt memory recall feature (T2.2) only fires on Claude Code sessions. Codex CLI does not expose an equivalent per-prompt hook, so on codex-configured topics the recall pass does not run. This is a documented v1 scope choice surfaced by the 2026-05-21 OpenClaw v1.0 re-audit in topic 9003.
+
+The server-side `PromptBuildRecall` primitive remains framework-agnostic — if codex later gains a pre-prompt hook (or a session-start trigger becomes acceptable), wiring it is a small follow-up. The asymmetry is honest, documented, and reversible.
+
+The ELI16 companion at `OPENCLAW-IMPORT-BEFORE-PROMPT-BUILD-SPEC.eli16.md` was updated in plain language so operators understand the limitation before enabling the feature on a codex-configured topic.
+
+No code changes; spec + ELI16 only.
+
+## What to Tell Your User
+
+If you have a Telegram topic configured to run on the Codex CLI framework (via `topicFrameworks` in `.instar/config.json`), the pre-prompt memory recall feature does not fire on that topic — your other grounding behaviors continue to work normally. This is a documented limitation, not a bug. Claude Code topics work the same as before. If codex usage matters more later, a session-start variant of the recall pass is a small follow-up.
+
+## Summary of New Capabilities
+
+No new capabilities. Documentation-only release surfacing an existing v1 limitation.


### PR DESCRIPTION
## Summary

Add explicit "Framework coverage — known limitation" section to the T2.2 pre-prompt memory recall spec acknowledging that the feature only fires on Claude Code sessions. Codex CLI lacks an equivalent per-prompt hook surface, so on codex-configured topics the recall pass does not run.

The server-side `PromptBuildRecall` primitive remains framework-agnostic — if codex later gains a pre-prompt hook (or a session-start trigger becomes acceptable), wiring it is a small follow-up.

## Context

Surfaced by the 2026-05-21 OpenClaw v1.0 re-audit (Telegram topic 9003). Justin approved the "document limitation, defer codex parity until demand surfaces" choice over a deeper redesign.

Spec + ELI16 only; no code changes.

## Test plan

- [x] Spec edit visible to reviewers
- [x] ELI16 companion updated in plain language
- [x] NEXT.md entry surfaces the limitation
- [x] Pre-push gate passes (NEXT.md present + version bumped)
- [ ] Full CI shards green