### PR TITLE
feat(org-intent-runtime): session-start injection of ORG-INTENT.md (Phase 2)

### DIFF
--- a/docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.eli16.md
+++ b/docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.eli16.md
@@ -1,0 +1,54 @@
+# ORG-INTENT Session-Start Injection — ELI16
+
+> Plain-English companion to `ORG-INTENT-SESSION-START-INJECTION-SPEC.md`. Read this first.
+
+## What's the problem
+
+We just shipped a change (Phase 1) that lets `ORG-INTENT.md` actually block outbound agent messages that violate the organization's constraints. That works — the gate that reviews every message now reads the file and refuses messages that contradict the constraints.
+
+But there's still a gap: the agent doesn't *know* about the constraints when it's writing the message. It just gets blocked after the fact. So the agent might draft something thoughtful, hit "send," and only then learn that what it wrote violated a constraint. The block is correct, but the agent burned tokens drafting a doomed response.
+
+We can do better. If the agent has the organizational intent in its working context from the start of every session, it can write the right thing the first time. The gate becomes a safety net for the edge cases, not the primary teacher.
+
+## What this change does
+
+We added one new HTTP route and one line in the session-start hook.
+
+1. The route `GET /intent/org/session-context` returns the parsed contents of `ORG-INTENT.md` formatted as a clean text block: constraints first, then goals, then values, then the tradeoff hierarchy. Empty sections are dropped. If the file doesn't exist or is just a template placeholder, the route returns `{ present: false }` and the hook injects nothing.
+
+2. The session-start hook (the script that runs every time a new agent session starts) now fetches that route and prints the block right alongside identity, topic context, and integrated-being. So when the agent reads its first message of the session, it has already seen the organizational contract.
+
+Together with Phase 1, you now have a two-layer system: the agent *knows* the constraints as it drafts (Phase 2), and the gate *enforces* them at delivery time (Phase 1).
+
+## What's deferred
+
+Two more phases coming after this one:
+
+- **Phase 3 — Tradeoff helper**: when two values pull in opposite directions, any part of the code (not just the message reviewer) can ask the hierarchy for the answer.
+- **Phase 4 — Drift detection job**: a periodic background check that samples the agent's recent outbound actions and flags accumulated drift even when no single message violates anything.
+
+## What you'll notice
+
+- If you have an `ORG-INTENT.md` authored: every new agent session will print a clean `=== ORGANIZATIONAL INTENT ===` block at the top of its context, showing the four sections. The agent will reference these constraints, goals, values, and tradeoff hierarchy as it works.
+- If you don't have an `ORG-INTENT.md`: no change. Zero-cost upgrade.
+- The existing offline tools (`instar intent org-init`, `instar intent validate`) work the same way.
+- The migrator updates your CLAUDE.md so the agent learns about the new session-start surface — both surfaces (Phase 1 + Phase 2) are now described in one subsection.
+
+## How to roll back
+
+The change is non-destructive. The route can stay; the session-start hook just fetches it. To revert: remove the ORG-INTENT block from the session-start hook (it's a single curl + python3 stanza in `PostUpdateMigrator.getSessionStartHook()`). The gate (Phase 1) keeps working regardless.
+
+## Tests
+
+Three tiers, all passing:
+
+- Unit tests pin the formatter shape (bullet indentation, section order, empty-bucket omission, tradeoff numbering).
+- Integration tests prove the HTTP route returns the right body for absent / template-only / populated / partial-bucket ORG-INTENT.md cases.
+- E2E tests prove the wiring through `AgentServer` and `createRoutes` — the route returns 200, not 503, in the production boot path.
+
+## Where to look next
+
+- Spec: `docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.md`
+- Side-effects review: `upgrades/side-effects/org-intent-session-start-injection.md`
+- Phase 1 (gate): `docs/specs/ORG-INTENT-RUNTIME-GATE-SPEC.md` (already shipped as v1.2.23)
+- Original intent engineering spec: `docs/specs/INTENT-ENGINEERING-SPEC.md`

--- a/docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.md
+++ b/docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.md
@@ -1,0 +1,140 @@
+---
+title: ORG-INTENT Session-Start Injection — Phase 2
+status: approved
+approved: true
+approver: justin
+approved-at: "2026-05-22T04:55:00Z"
+approval-context: "Pre-authorized as Phase 2 of the four-phase org-intent runtime project. Justin's seed message (2026-05-21 15:50 PDT, topic 11378) requested recommendations; Justin approved the full four-phase scope (2026-05-21 21:54 PDT) with explicit \"Yes! Please proceed in an autonomous session.\""
+review-convergence: "2026-05-22T06:00:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-22T06:00:00Z"
+review-mode: "single-author, pre-authorized scope"
+lessons-checked:
+  - "feedback_signal_vs_authority — session-start injection is SIGNAL only (informs the agent before drafting). Authority remains with the gate (Phase 1)."
+  - "feedback_side_effects_review — full review at upgrades/side-effects/org-intent-session-start-injection.md."
+  - "feedback_release_notes_in_same_pr — NEXT.md filled in this same PR."
+  - "feedback_eli16_required_for_specs — companion at ORG-INTENT-SESSION-START-INJECTION-SPEC.eli16.md."
+  - "feedback_no_pr_fragmentation — Phase 2 ships as ONE PR; Phases 3-4 queue behind merge."
+  - "feedback_spec_converge_pre_auth_circular — Justin pre-authorized the full four-phase scope; /spec-converge would be circular."
+created: 2026-05-22
+owner: echo
+companion-eli16: ORG-INTENT-SESSION-START-INJECTION-SPEC.eli16.md
+eli16-overview: ORG-INTENT-SESSION-START-INJECTION-SPEC.eli16.md
+phase-of: ORG-INTENT-RUNTIME-GATE-SPEC.md
+---
+
+# ORG-INTENT Session-Start Injection — Phase 2 Spec
+
+> Inject parsed `ORG-INTENT.md` at session boot so the agent reasons with organizational intent from message one, not only when the Coherence Gate blocks them after the fact.
+
+**Status**: Implementation Complete (Phase 2)
+**Companion**: `ORG-INTENT-SESSION-START-INJECTION-SPEC.eli16.md`
+**Author**: Echo (autonomous build, supervised by Justin)
+**Origin**: Phase 2 of the four-phase ORG-INTENT runtime project. Phase 1 (`ORG-INTENT-RUNTIME-GATE-SPEC.md`) wired the gate; this phase wires the agent's own working context.
+
+---
+
+## Background
+
+Phase 1 shipped `OrgIntentManager.parse()` integration into the Coherence Gate. The structured three-rule contract (constraints mandatory, goals defaults, values shape, tradeoff hierarchy resolves ties) now drives the value-alignment reviewer at outbound-message review time. But the gate is reactive — it blocks messages after the agent has drafted them. The agent itself does not know about the contract while drafting.
+
+This phase closes that loop. By the time the agent composes a response, it has already seen the organizational intent in its session-start context. Most constraint violations should be prevented at the drafting stage, with the gate as the last-resort enforcement.
+
+## Goal
+
+Make `ORG-INTENT.md` part of the agent's working context from the first message of every session, the same way identity (`AGENT.md`), topic context, integrated-being state, and soul are already injected.
+
+Non-goals (deferred to later phases):
+- Phase 3: Standalone tradeoff helper consulted at decision points outside the reviewer.
+- Phase 4: Periodic drift detection job.
+
+## Design
+
+### HTTP route
+
+New endpoint `GET /intent/org/session-context`:
+
+```
+Request:  GET /intent/org/session-context
+Auth:     Bearer <authToken>
+Response: 200 OK
+          { "present": true,
+            "block":   "=== ORGANIZATIONAL INTENT === ...",
+            "name":    "Acme Co",
+            "counts":  { "constraints": N, "goals": N, "values": N, "tradeoffHierarchy": N } }
+          OR
+          200 OK
+          { "present": false }
+```
+
+When `ORG-INTENT.md` is absent, template-only (HTML-comments only), or unparseable, the route returns `{ present: false }` and the session-start hook injects nothing — same shape as the Phase 1 fall-through.
+
+### Formatter
+
+`formatOrgIntentForSessionStart()` exported from `src/core/OrgIntentManager.ts`. Deterministic, single-newline-joined text. Constraints first (most load-bearing), then goals, values, and tradeoff hierarchy. Empty buckets are omitted entirely.
+
+The format mirrors the existing session-start block style (`=== SECTION_NAME ===` ... `=== END SECTION_NAME ===`) so agents recognize the structure visually and the hook can inject it inline without further formatting.
+
+### Session-start hook update
+
+`PostUpdateMigrator.getSessionStartHook()` gains a new block that fetches `/intent/org/session-context` and prints the `block` field when `present: true`. Fail-open: route unreachable → silent skip. The Coherence Gate from Phase 1 still enforces the contract at message-review time, so missing the session-start injection never compromises constraint enforcement.
+
+### Surface changes
+
+| File | Change |
+|---|---|
+| `src/core/OrgIntentManager.ts` | Exported `formatOrgIntentForSessionStart()` function |
+| `src/server/routes.ts` | New `GET /intent/org/session-context` route |
+| `src/core/PostUpdateMigrator.ts` | `getSessionStartHook()` inline string adds ORG-INTENT fetch; `migrateClaudeMd()` updates ORG-INTENT subsection to mention Phase 2 |
+| `src/scaffold/templates.ts` | CLAUDE.md ORG-INTENT subsection updated for new agents |
+| Spec + ELI16 + side-effects | This file + companion + `upgrades/side-effects/org-intent-session-start-injection.md` |
+| NEXT.md | Filled |
+
+## Testing
+
+All three tiers per Testing Integrity Standard.
+
+### Tier 1 — Unit
+
+`tests/unit/OrgIntentManager-session-start-format.test.ts` (new file):
+- All four bucket sections render in expected order with preamble.
+- Empty buckets are omitted entirely.
+- Minimal intent (name only) renders preamble + framing only.
+- Tradeoff hierarchy entries are numbered starting at 1.
+- Two-space indentation for bullets.
+- Output is deterministic.
+
+`tests/unit/PostUpdateMigrator-org-intent-runtime.test.ts`:
+- Extended with two new tests: Phase-1-only subsection is upgraded to mention Phase 2; idempotent on Phase-2-upgraded CLAUDE.md.
+- Existing Phase 1 tests adjusted to match the new subsection wording.
+
+### Tier 2 — Integration
+
+`tests/integration/org-intent-routes.test.ts`:
+- Extended with four new tests for `GET /intent/org/session-context`: absent file, template-only file, populated file, partial-buckets file.
+
+### Tier 3 — E2E lifecycle
+
+`tests/e2e/org-intent-session-context-lifecycle.test.ts` (new file):
+- Phase 1: `/intent/org/session-context` returns 200, not 503 — the "feature is alive" check, mirroring production wiring through `AgentServer` and `createRoutes`.
+- Phase 2: Populated ORG-INTENT.md → all four bucket sections appear in the block.
+- Phase 3: Absent / template-only → `{ present: false }`.
+
+## Side effects
+
+See `upgrades/side-effects/org-intent-session-start-injection.md`.
+
+Summary: agents with an `ORG-INTENT.md` will see additional context at the start of every session (one new `=== ORGANIZATIONAL INTENT ===` block). Token cost is bounded by the file's own size (the parser only loads what's in the file). For agents without an `ORG-INTENT.md`, no change.
+
+## Migration
+
+- Existing agents: `PostUpdateMigrator.migrateClaudeMd()` upgrades the Phase 1 ORG-INTENT subsection to mention Phase 2 session-start injection. The session-start.sh hook itself is always-overwritten on every migration so the new fetch logic propagates automatically.
+- Fresh agents: `generateClaudeMd()` includes the combined Phase 1+2 subsection.
+- Idempotent: re-running migration is safe.
+
+## Open follow-ups (Phase 3+, NOT this PR)
+
+- Phase 3: `POST /intent/tradeoff-resolve` standalone helper.
+- Phase 4: periodic drift detection job sampling recent outbound actions vs intent.
+- Cache invalidation on `ORG-INTENT.md` mutation (currently the route reads from disk on every call — no cache, so edits propagate immediately at the cost of a tiny per-request fs.read).
+- Per-channel constraint scoping.

--- a/src/core/OrgIntentManager.ts
+++ b/src/core/OrgIntentManager.ts
@@ -183,6 +183,48 @@ function coresOverlap(core1: string, core2: string): boolean {
   return overlap >= 2 || (overlap > 0 && overlap / minSize >= 0.5);
 }
 
+// ── Session-Start Formatter (Phase 2) ───────────────────────────────
+
+/**
+ * Render a `ParsedOrgIntent` into a session-start text block. Constraints
+ * lead (most load-bearing), then goals, values, and tradeoff hierarchy.
+ * Empty buckets are omitted. Used by the session-start hook and exposed via
+ * `GET /intent/org/session-context`.
+ *
+ * Deterministic, single-newline-joined text — no LLM involvement — so it is
+ * safe to inject directly into agent context at session boot.
+ */
+export function formatOrgIntentForSessionStart(intent: ParsedOrgIntent): string {
+  const lines: string[] = [];
+  lines.push('=== ORGANIZATIONAL INTENT ===');
+  lines.push(`Organization: ${intent.name}`);
+  lines.push('');
+  lines.push('This is your operating contract. Constraints are mandatory; goals are organizational defaults; values shape representation; the tradeoff hierarchy resolves ties.');
+  if (intent.constraints.length > 0) {
+    lines.push('');
+    lines.push('CONSTRAINTS (mandatory — outbound messages that violate these are blocked at the Coherence Gate):');
+    for (const c of intent.constraints) lines.push(`  - ${c.text}`);
+  }
+  if (intent.goals.length > 0) {
+    lines.push('');
+    lines.push('GOALS (organizational defaults — specialize but never contradict):');
+    for (const g of intent.goals) lines.push(`  - ${g.text}`);
+  }
+  if (intent.values.length > 0) {
+    lines.push('');
+    lines.push('VALUES (representation — keep these visible in how you communicate):');
+    for (const v of intent.values) lines.push(`  - ${v}`);
+  }
+  if (intent.tradeoffHierarchy.length > 0) {
+    lines.push('');
+    lines.push('TRADEOFF HIERARCHY (when two values pull in opposite directions, the earlier entry wins):');
+    intent.tradeoffHierarchy.forEach((t, i) => lines.push(`  ${i + 1}. ${t}`));
+  }
+  lines.push('');
+  lines.push('=== END ORGANIZATIONAL INTENT ===');
+  return lines.join('\n');
+}
+
 // ── Main Class ───────────────────────────────────────────────────────
 
 export class OrgIntentManager {

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2162,12 +2162,13 @@ Strip the \`[telegram:N]\` prefix before interpreting the message. Respond natur
 
 #### ORG-INTENT.md (Organizational Intent at Runtime)
 
-If \`.instar/ORG-INTENT.md\` exists on disk, the Coherence Gate now reads it on every outbound message review and surfaces the three-rule contract to the value-alignment reviewer: **constraints** are mandatory (violations block), **goals** are organizational defaults (contradictions warn or block), **values** shape representation (drift warns), and the **tradeoff hierarchy** resolves ties when two values pull in opposite directions (earlier entry wins).
+If \`.instar/ORG-INTENT.md\` exists on disk, two runtime surfaces consume it: the Coherence Gate (Phase 1) reads it on every outbound message review, and the session-start hook (Phase 2) fetches it at session boot via \`GET /intent/org/session-context\` and injects the structured contract into your context. **Constraints** are mandatory (violations block), **goals** are organizational defaults (contradictions warn or block), **values** shape representation (drift warns), and the **tradeoff hierarchy** resolves ties when two values pull in opposite directions (earlier entry wins).
 
 Manage it:
 - Scaffold a starter: \`instar intent org-init "Your Org Name"\`
 - Static validation against agent intent: \`instar intent validate\`
 - Inspect parsed structure: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/org\`
+- Preview the session-start block: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/org/session-context\`
 
 **Topic-Project Bindings**: Each Telegram topic can be bound to a specific project. When switching topics, verify the binding matches your current working directory.
 - View bindings: \`GET http://localhost:${port}/topic-bindings\`
@@ -2195,12 +2196,13 @@ Manage it:
 
 #### ORG-INTENT.md (Organizational Intent at Runtime)
 
-If \`.instar/ORG-INTENT.md\` exists on disk, the Coherence Gate now reads it on every outbound message review and surfaces the three-rule contract to the value-alignment reviewer: **constraints** are mandatory (violations block), **goals** are organizational defaults (contradictions warn or block), **values** shape representation (drift warns), and the **tradeoff hierarchy** resolves ties when two values pull in opposite directions (earlier entry wins).
+If \`.instar/ORG-INTENT.md\` exists on disk, two runtime surfaces consume it: the Coherence Gate (Phase 1) reads it on every outbound message review, and the session-start hook (Phase 2) fetches it at session boot via \`GET /intent/org/session-context\` and injects the structured contract into your context. **Constraints** are mandatory (violations block), **goals** are organizational defaults (contradictions warn or block), **values** shape representation (drift warns), and the **tradeoff hierarchy** resolves ties when two values pull in opposite directions (earlier entry wins).
 
 Manage it:
 - Scaffold a starter: \`instar intent org-init "Your Org Name"\`
 - Static validation against agent intent: \`instar intent validate\`
 - Inspect parsed structure: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/org\`
+- Preview the session-start block: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/org/session-context\`
 `;
       // Anchor: insert after "Topic-Project Bindings" header so it lands inside
       // the Coherence Gate section but before the Project Map subsection.
@@ -2208,12 +2210,42 @@ Manage it:
       if (anchor >= 0) {
         content = content.slice(0, anchor) + subsection + '\n' + content.slice(anchor);
         patched = true;
-        result.upgraded.push('CLAUDE.md: added ORG-INTENT.md runtime subsection to Coherence Gate');
+        result.upgraded.push('CLAUDE.md: added ORG-INTENT.md runtime subsection (Phase 1+2) to Coherence Gate');
       } else {
         // Fallback: append at end if the Topic-Project Bindings anchor moved
         content += '\n' + subsection;
         patched = true;
         result.upgraded.push('CLAUDE.md: appended ORG-INTENT.md runtime subsection (anchor missing, fallback insert)');
+      }
+    } else if (
+      content.includes('ORG-INTENT.md (Organizational Intent at Runtime)')
+      && !content.includes('/intent/org/session-context')
+    ) {
+      // CLAUDE.md already has the Phase 1 ORG-INTENT runtime subsection but
+      // not the Phase 2 session-start injection mention. Rewrite the
+      // subsection in place so the agent learns about both surfaces.
+      // Match: from the heading line through the empty line before the next
+      // ### heading (typically "### External Operation Safety" or
+      // "## Agent Infrastructure").
+      const headingPattern = /(####? ORG-INTENT\.md \(Organizational Intent at Runtime\))[\s\S]*?(?=\n## |\n### |$)/;
+      const replacement = `$1
+
+If \`.instar/ORG-INTENT.md\` exists on disk, two runtime surfaces consume it: the Coherence Gate (Phase 1) reads it on every outbound message review, and the session-start hook (Phase 2) fetches it at session boot via \`GET /intent/org/session-context\` and injects the structured contract into your context. **Constraints** are mandatory (violations block), **goals** are organizational defaults (contradictions warn or block), **values** shape representation (drift warns), and the **tradeoff hierarchy** resolves ties when two values pull in opposite directions (earlier entry wins).
+
+Manage it:
+- Scaffold a starter: \`instar intent org-init "Your Org Name"\`
+- Static validation against agent intent: \`instar intent validate\`
+- Inspect parsed structure: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/org\`
+- Preview the session-start block: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/org/session-context\`
+
+`;
+      const before = content;
+      content = content.replace(headingPattern, replacement);
+      if (content !== before) {
+        patched = true;
+        result.upgraded.push('CLAUDE.md: upgraded ORG-INTENT.md subsection to mention Phase 2 session-start injection');
+      } else {
+        result.skipped.push('CLAUDE.md: ORG-INTENT.md subsection present but Phase 2 upgrade pattern did not match (skipping)');
       }
     } else {
       result.skipped.push('CLAUDE.md: Coherence Gate section already present');
@@ -3592,6 +3624,35 @@ if [ -f "$INSTAR_DIR/config.json" ]; then
       echo "--- INTEGRATED-BEING (cross-session observations) ---"
       echo "\$SHARED_STATE"
       echo "--- END INTEGRATED-BEING ---"
+      echo ""
+    fi
+  fi
+fi
+
+# ORG-INTENT injection — Phase 2 of the ORG-INTENT runtime project.
+# Fetches the parsed three-rule contract (constraints / goals / values /
+# tradeoff hierarchy) from /intent/org/session-context and injects it at
+# session-start so the agent reasons with the organizational intent from
+# message one. The Coherence Gate (Phase 1) still enforces the same contract
+# at outbound-message review time — this just brings the same intent into the
+# agent's working context up front. Fail-open: route unreachable / absent
+# ORG-INTENT.md / 503 → silent skip, session continues normally.
+if [ -n "\$PORT" ] && [ -n "\$TOKEN" ]; then
+  ORG_INTENT_RESPONSE=\$(curl -sf --max-time 4 -H "Authorization: Bearer \$TOKEN" \\
+    "http://localhost:\${PORT}/intent/org/session-context" 2>/dev/null)
+  if [ -n "\$ORG_INTENT_RESPONSE" ]; then
+    ORG_INTENT_BLOCK=\$(echo "\$ORG_INTENT_RESPONSE" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if d.get('present') and d.get('block'):
+        print(d['block'])
+except Exception:
+    pass
+" 2>/dev/null)
+    if [ -n "\$ORG_INTENT_BLOCK" ]; then
+      echo ""
+      echo "\$ORG_INTENT_BLOCK"
       echo ""
     fi
   fi

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -1484,19 +1484,25 @@ Before answering ANY question about my capabilities or architecture from memory 
 
 ### ORG-INTENT.md (Organizational Intent at Runtime)
 
-If \`.instar/ORG-INTENT.md\` exists on disk, the Coherence Gate now reads it on every outbound message review and surfaces the three-rule contract to the value-alignment reviewer:
+If \`.instar/ORG-INTENT.md\` exists on disk, two runtime surfaces consume it:
+
+1. **Coherence Gate** (Phase 1) — reads it on every outbound message review and surfaces the three-rule contract to the value-alignment reviewer.
+2. **Session-start hook** (Phase 2) — fetches it at session boot via \`GET /intent/org/session-context\` and injects the structured contract directly into your context, so you reason with the organizational intent from message one rather than only being blocked by it after the fact.
+
+The three-rule contract:
 
 - **Constraints** are mandatory — violations are flagged with severity \`block\` and the message is blocked.
 - **Goals** are organizational defaults — contradictions warn or block (depending on severity).
 - **Values** shape representation — drift warns.
 - **Tradeoff hierarchy** resolves ties when two values pull in opposite directions; the earlier entry wins.
 
-This means: writing an ORG-INTENT.md file actually changes how the agent's outbound messages are evaluated. Before this wiring, the file existed only as input to offline analyzers (\`instar intent validate\`, \`instar intent reflect\`).
+This means: writing an ORG-INTENT.md file both informs how you draft messages (session-start injection) AND enforces what gets sent (gate review). Before this wiring, the file existed only as input to offline analyzers (\`instar intent validate\`, \`instar intent reflect\`).
 
 Manage it:
 - Scaffold a starter: \`instar intent org-init "Your Org Name"\`
 - Validate agent intent against org intent (static analysis): \`instar intent validate\`
 - Inspect the parsed structure: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/org\`
+- Preview the session-start block: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/intent/org/session-context\`
 
 ## Agent Infrastructure
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -9593,6 +9593,39 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
+  // ORG-INTENT.md → session-start friendly text block.
+  // Used by the session-start hook to inject the three-rule contract at the
+  // start of every session, so the agent reasons with the intent from message
+  // one rather than only being blocked by it at gate-evaluate time. Phase 2
+  // of the ORG-INTENT runtime project. Returns:
+  //   { present: true, block: "...text...", name, counts }   when ORG-INTENT.md is present
+  //   { present: false }                                      when absent/template-only
+  router.get('/intent/org/session-context', async (_req, res) => {
+    try {
+      const { OrgIntentManager, formatOrgIntentForSessionStart } = await import('../core/OrgIntentManager.js');
+      const manager = new OrgIntentManager(ctx.config.stateDir);
+      const parsed = manager.parse();
+      if (!parsed) {
+        res.json({ present: false });
+        return;
+      }
+      const block = formatOrgIntentForSessionStart(parsed);
+      res.json({
+        present: true,
+        block,
+        name: parsed.name,
+        counts: {
+          constraints: parsed.constraints.length,
+          goals: parsed.goals.length,
+          values: parsed.values.length,
+          tradeoffHierarchy: parsed.tradeoffHierarchy.length,
+        },
+      });
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to read org intent' });
+    }
+  });
+
   router.get('/intent/validate', async (_req, res) => {
     try {
       const { OrgIntentManager } = await import('../core/OrgIntentManager.js');

--- a/tests/e2e/org-intent-session-context-lifecycle.test.ts
+++ b/tests/e2e/org-intent-session-context-lifecycle.test.ts
@@ -1,0 +1,169 @@
+/**
+ * E2E test — ORG-INTENT session-start injection (Phase 2) full lifecycle.
+ *
+ * Tests the complete PRODUCTION path:
+ *   1. Server starts; `/intent/org/session-context` is reachable (not 503).
+ *   2. With a real ORG-INTENT.md on disk, the route returns a parsed,
+ *      formatted block ready for the session-start hook to inject.
+ *   3. With ORG-INTENT.md absent / template-only, the route responds
+ *      `{ present: false }` and the session-start hook will inject nothing.
+ *   4. The format matches what the session-start hook (installed by
+ *      `PostUpdateMigrator.getSessionStartHook()`) expects to consume.
+ *
+ * WHY THIS TEST EXISTS:
+ * Tier-1 unit tests pin the formatter shape; Tier-2 integration tests
+ * pin the HTTP route. This Tier-3 test pins the wiring — the boot path
+ * from `AgentServer` through `createRoutes` to the response.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+describe('ORG-INTENT session-start injection E2E lifecycle', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+  const AUTH_TOKEN = 'test-e2e-session-context';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'org-intent-session-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({ port: 0, projectName: 'org-intent-session-e2e', agentName: 'E2E Agent' }),
+    );
+
+    fs.writeFileSync(
+      path.join(stateDir, 'AGENT.md'),
+      '# E2E Agent\n## Intent\n- Be helpful\n- Respect org intent\n',
+    );
+
+    fs.writeFileSync(
+      path.join(stateDir, 'ORG-INTENT.md'),
+      `# Organizational Intent: Acme Inc
+
+## Constraints (Mandatory)
+- Never quote internal pricing to external contacts
+- Always disclose AI nature on first interaction
+
+## Goals (Defaults)
+- Resolve customer questions on first contact when possible
+
+## Values
+- Honesty over expedience
+
+## Tradeoff Hierarchy
+- Customer trust over resolution speed
+- Compliance over convenience
+`,
+    );
+
+    const config: InstarConfig = {
+      projectName: 'org-intent-session-e2e',
+      agentName: 'E2E Agent',
+      projectDir: tmpDir,
+      stateDir,
+      port: 0,
+      authToken: AUTH_TOKEN,
+    } as InstarConfig;
+
+    const mockSM = createMockSessionManager();
+    const state = new StateManager(stateDir);
+
+    server = new AgentServer({
+      config,
+      sessionManager: mockSM as any,
+      state,
+    });
+
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    if (server) {
+      try { await (server as unknown as { stop?: () => Promise<void> }).stop?.(); } catch { /* ignore */ }
+    }
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/e2e/org-intent-session-context-lifecycle.test.ts:afterAll',
+    });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH_TOKEN}` });
+
+  describe('Phase 1: Feature is alive', () => {
+    it('returns 200 from /intent/org/session-context, not 503 — route is wired into production', async () => {
+      const res = await request(app)
+        .get('/intent/org/session-context')
+        .set(auth());
+
+      // The single most important assertion: route is wired through createRoutes()
+      // into AgentServer the same way production wires it.
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Phase 2: ORG-INTENT.md surfaces through the HTTP pipeline', () => {
+    it('returns a populated block with all four sections when ORG-INTENT.md is authored', async () => {
+      const res = await request(app)
+        .get('/intent/org/session-context')
+        .set(auth());
+
+      expect(res.status).toBe(200);
+      expect(res.body.present).toBe(true);
+      expect(res.body.name).toBe('Acme Inc');
+      expect(res.body.block).toContain('=== ORGANIZATIONAL INTENT ===');
+      expect(res.body.block).toContain('CONSTRAINTS (mandatory');
+      expect(res.body.block).toContain('GOALS (organizational defaults');
+      expect(res.body.block).toContain('VALUES (representation');
+      expect(res.body.block).toContain('TRADEOFF HIERARCHY (when two values pull in opposite directions');
+      expect(res.body.block).toContain('Never quote internal pricing to external contacts');
+      expect(res.body.block).toContain('Customer trust over resolution speed');
+      expect(res.body.block).toContain('=== END ORGANIZATIONAL INTENT ===');
+
+      // Counts mirror the bullets in the source file
+      expect(res.body.counts).toEqual({
+        constraints: 2,
+        goals: 1,
+        values: 1,
+        tradeoffHierarchy: 2,
+      });
+    });
+  });
+
+  describe('Phase 3: Absent / template-only ORG-INTENT.md', () => {
+    it('returns { present: false } and nothing more', async () => {
+      // Replace ORG-INTENT.md with a template-only (HTML-comments-only) version
+      fs.writeFileSync(
+        path.join(stateDir, 'ORG-INTENT.md'),
+        `# Organizational Intent: <!-- name -->
+
+<!-- This is a template placeholder. -->
+
+## Constraints (Mandatory)
+<!-- list constraints here -->
+`,
+      );
+
+      const res = await request(app)
+        .get('/intent/org/session-context')
+        .set(auth());
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ present: false });
+    });
+  });
+});

--- a/tests/integration/org-intent-routes.test.ts
+++ b/tests/integration/org-intent-routes.test.ts
@@ -228,4 +228,84 @@ describe('Org Intent Routes (integration)', () => {
       expect(res.body.warnings.length).toBeGreaterThan(0);
     });
   });
+
+  // ── GET /intent/org/session-context (Phase 2 — session-start injection) ─
+
+  describe('GET /intent/org/session-context', () => {
+    it('returns { present: false } when no ORG-INTENT.md exists', async () => {
+      const res = await request(app).get('/intent/org/session-context');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ present: false });
+    });
+
+    it('returns { present: false } when ORG-INTENT.md is template-only', async () => {
+      fs.writeFileSync(path.join(stateDir, 'ORG-INTENT.md'), [
+        '# Organizational Intent: TemplateOnly',
+        '',
+        '<!-- nothing real yet -->',
+        '',
+        '## Constraints (Mandatory)',
+        '<!-- list constraints -->',
+      ].join('\n'));
+
+      const res = await request(app).get('/intent/org/session-context');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ present: false });
+    });
+
+    it('returns formatted block + counts when ORG-INTENT.md is populated', async () => {
+      fs.writeFileSync(path.join(stateDir, 'ORG-INTENT.md'), [
+        '# Organizational Intent: Acme Co',
+        '',
+        '## Constraints (Mandatory)',
+        '- Never quote internal pricing externally',
+        '- Always disclose AI nature',
+        '',
+        '## Goals (Defaults)',
+        '- Resolve on first contact when possible',
+        '',
+        '## Values',
+        '- Honesty over expedience',
+        '',
+        '## Tradeoff Hierarchy',
+        '- Customer trust over resolution speed',
+        '- Compliance over convenience',
+      ].join('\n'));
+
+      const res = await request(app).get('/intent/org/session-context');
+      expect(res.status).toBe(200);
+      expect(res.body.present).toBe(true);
+      expect(res.body.name).toBe('Acme Co');
+      expect(res.body.counts).toEqual({
+        constraints: 2,
+        goals: 1,
+        values: 1,
+        tradeoffHierarchy: 2,
+      });
+      expect(res.body.block).toContain('=== ORGANIZATIONAL INTENT ===');
+      expect(res.body.block).toContain('Never quote internal pricing externally');
+      expect(res.body.block).toContain('Customer trust over resolution speed');
+      expect(res.body.block).toContain('=== END ORGANIZATIONAL INTENT ===');
+    });
+
+    it('omits empty buckets in the rendered block', async () => {
+      fs.writeFileSync(path.join(stateDir, 'ORG-INTENT.md'), [
+        '# Organizational Intent: GoalsOnly',
+        '',
+        '## Goals (Defaults)',
+        '- Just one goal',
+      ].join('\n'));
+
+      const res = await request(app).get('/intent/org/session-context');
+      expect(res.status).toBe(200);
+      expect(res.body.present).toBe(true);
+      expect(res.body.counts.constraints).toBe(0);
+      expect(res.body.counts.values).toBe(0);
+      expect(res.body.counts.tradeoffHierarchy).toBe(0);
+      expect(res.body.block).toContain('GOALS (organizational defaults');
+      expect(res.body.block).not.toContain('CONSTRAINTS (mandatory');
+      expect(res.body.block).not.toContain('TRADEOFF HIERARCHY (earlier wins');
+    });
+  });
 });

--- a/tests/unit/OrgIntentManager-session-start-format.test.ts
+++ b/tests/unit/OrgIntentManager-session-start-format.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests — `formatOrgIntentForSessionStart`.
+ *
+ * Tier 1 of the Testing Integrity Standard for Phase 2 of the ORG-INTENT
+ * runtime project (session-start injection). The formatter is pure and
+ * deterministic; these tests pin the exact output structure so a future
+ * refactor cannot silently change what the agent sees at session boot.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatOrgIntentForSessionStart, type ParsedOrgIntent } from '../../src/core/OrgIntentManager.js';
+
+function makeIntent(overrides: Partial<ParsedOrgIntent> = {}): ParsedOrgIntent {
+  return {
+    name: 'Test Org',
+    constraints: [],
+    goals: [],
+    values: [],
+    tradeoffHierarchy: [],
+    raw: '',
+    ...overrides,
+  };
+}
+
+describe('formatOrgIntentForSessionStart', () => {
+  it('renders all four buckets in the expected order with the contract preamble', () => {
+    const intent = makeIntent({
+      name: 'Acme Co',
+      constraints: [
+        { text: 'Never quote internal pricing', source: 'org-intent' },
+        { text: 'Always disclose AI nature', source: 'org-intent' },
+      ],
+      goals: [{ text: 'Resolve on first contact', source: 'org-intent', specializable: true }],
+      values: ['Honesty over expedience'],
+      tradeoffHierarchy: ['Customer trust over speed', 'Compliance over convenience'],
+    });
+
+    const block = formatOrgIntentForSessionStart(intent);
+
+    expect(block).toContain('=== ORGANIZATIONAL INTENT ===');
+    expect(block).toContain('Organization: Acme Co');
+    expect(block).toContain('This is your operating contract');
+    expect(block).toContain('CONSTRAINTS (mandatory');
+    expect(block).toContain('Never quote internal pricing');
+    expect(block).toContain('Always disclose AI nature');
+    expect(block).toContain('GOALS (organizational defaults');
+    expect(block).toContain('Resolve on first contact');
+    expect(block).toContain('VALUES (representation');
+    expect(block).toContain('Honesty over expedience');
+    expect(block).toContain('TRADEOFF HIERARCHY');
+    expect(block).toContain('1. Customer trust over speed');
+    expect(block).toContain('2. Compliance over convenience');
+    expect(block).toContain('=== END ORGANIZATIONAL INTENT ===');
+
+    // Bucket order: CONSTRAINTS first, then GOALS, VALUES, TRADEOFF HIERARCHY
+    const cIdx = block.indexOf('CONSTRAINTS');
+    const gIdx = block.indexOf('GOALS');
+    const vIdx = block.indexOf('VALUES');
+    const tIdx = block.indexOf('TRADEOFF HIERARCHY');
+    expect(cIdx).toBeGreaterThan(0);
+    expect(cIdx).toBeLessThan(gIdx);
+    expect(gIdx).toBeLessThan(vIdx);
+    expect(vIdx).toBeLessThan(tIdx);
+  });
+
+  it('omits empty buckets entirely (no empty section headers)', () => {
+    const intent = makeIntent({
+      name: 'GoalsOnly Inc',
+      goals: [{ text: 'Be friendly', source: 'org-intent', specializable: true }],
+    });
+
+    const block = formatOrgIntentForSessionStart(intent);
+    expect(block).toContain('GOALS (organizational defaults');
+    expect(block).toContain('Be friendly');
+    expect(block).not.toContain('CONSTRAINTS (mandatory');
+    expect(block).not.toContain('VALUES (representation');
+    expect(block).not.toContain('TRADEOFF HIERARCHY');
+  });
+
+  it('renders a minimal intent (name only) with just preamble + framing', () => {
+    const intent = makeIntent({ name: 'Minimal Org' });
+    const block = formatOrgIntentForSessionStart(intent);
+
+    expect(block).toContain('Organization: Minimal Org');
+    expect(block).toContain('=== ORGANIZATIONAL INTENT ===');
+    expect(block).toContain('=== END ORGANIZATIONAL INTENT ===');
+    expect(block).not.toContain('CONSTRAINTS (mandatory');
+    expect(block).not.toContain('GOALS (organizational defaults');
+  });
+
+  it('numbers tradeoff hierarchy entries starting at 1', () => {
+    const intent = makeIntent({
+      tradeoffHierarchy: ['Alpha', 'Beta', 'Gamma'],
+    });
+    const block = formatOrgIntentForSessionStart(intent);
+    expect(block).toContain('  1. Alpha');
+    expect(block).toContain('  2. Beta');
+    expect(block).toContain('  3. Gamma');
+  });
+
+  it('uses two-space indent for bullet items (consistent with other session-start blocks)', () => {
+    const intent = makeIntent({
+      constraints: [{ text: 'Item one', source: 'org-intent' }],
+    });
+    const block = formatOrgIntentForSessionStart(intent);
+    expect(block).toContain('  - Item one');
+  });
+
+  it('output is deterministic — same input produces same string', () => {
+    const intent = makeIntent({
+      name: 'Determ Inc',
+      constraints: [{ text: 'X', source: 'org-intent' }],
+      goals: [{ text: 'Y', source: 'org-intent', specializable: true }],
+    });
+    const block1 = formatOrgIntentForSessionStart(intent);
+    const block2 = formatOrgIntentForSessionStart(intent);
+    expect(block1).toBe(block2);
+  });
+});

--- a/tests/unit/PostUpdateMigrator-org-intent-runtime.test.ts
+++ b/tests/unit/PostUpdateMigrator-org-intent-runtime.test.ts
@@ -79,7 +79,7 @@ describe('PostUpdateMigrator — ORG-INTENT runtime CLAUDE.md migration', () => 
 
     const content = fs.readFileSync(home.claudeMd, 'utf-8');
     expect(content).toContain('ORG-INTENT.md (Organizational Intent at Runtime)');
-    expect(content).toContain('the three-rule contract');
+    expect(content).toContain('Constraints** are mandatory');
     expect(content).toContain('instar intent org-init');
     // Subsection lands inside the Coherence Gate block, before Topic-Project Bindings
     const orgIntentIdx = content.indexOf('ORG-INTENT.md (Organizational Intent at Runtime)');
@@ -111,7 +111,7 @@ describe('PostUpdateMigrator — ORG-INTENT runtime CLAUDE.md migration', () => 
     const content = fs.readFileSync(home.claudeMd, 'utf-8');
     expect(content).toContain('### Coherence Gate (Pre-Action Verification)');
     expect(content).toContain('ORG-INTENT.md (Organizational Intent at Runtime)');
-    expect(content).toContain('the three-rule contract');
+    expect(content).toContain('Constraints** are mandatory');
   });
 
   it('skips cleanly when CLAUDE.md is missing', () => {
@@ -119,6 +119,58 @@ describe('PostUpdateMigrator — ORG-INTENT runtime CLAUDE.md migration', () => 
     const migrator = buildMigrator(home.projectDir, home.stateDir);
     expect(() => migrator.migrate()).not.toThrow();
     expect(fs.existsSync(home.claudeMd)).toBe(false);
+  });
+
+  it('upgrades the Phase-1-only subsection to mention Phase 2 session-start injection', () => {
+    // A CLAUDE.md that has the Phase 1 ORG-INTENT runtime subsection (from
+    // the first ORG-INTENT runtime PR) but no Phase 2 session-context route
+    // mention — the agent state right before this PR lands.
+    const phase1Only = PREEXISTING_COHERENCE_GATE_SECTION.replace(
+      '**Topic-Project Bindings**',
+      `#### ORG-INTENT.md (Organizational Intent at Runtime)
+
+If \`.instar/ORG-INTENT.md\` exists on disk, the Coherence Gate now reads it on every outbound message review and surfaces the three-rule contract to the value-alignment reviewer: **constraints** are mandatory (violations block), **goals** are organizational defaults (contradictions warn or block), **values** shape representation (drift warns), and the **tradeoff hierarchy** resolves ties when two values pull in opposite directions (earlier entry wins).
+
+Manage it:
+- Scaffold a starter: \`instar intent org-init "Your Org Name"\`
+- Static validation against agent intent: \`instar intent validate\`
+- Inspect parsed structure: \`curl -H "Authorization: Bearer $AUTH" http://localhost:4042/intent/org\`
+
+**Topic-Project Bindings**`,
+    );
+    fs.writeFileSync(home.claudeMd, phase1Only);
+
+    const migrator = buildMigrator(home.projectDir, home.stateDir);
+    migrator.migrate();
+
+    const content = fs.readFileSync(home.claudeMd, 'utf-8');
+    // Phase 2 mention now present
+    expect(content).toContain('session-start hook (Phase 2)');
+    expect(content).toContain('/intent/org/session-context');
+    expect(content).toContain('Preview the session-start block');
+    // Still only one ORG-INTENT subsection (replacement, not duplication)
+    const matches = content.match(/ORG-INTENT\.md \(Organizational Intent at Runtime\)/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('is idempotent on Phase-2-upgraded CLAUDE.md (re-running does not re-modify)', () => {
+    // A CLAUDE.md already with the Phase 2 subsection — the post-migration state.
+    const phase2Done = PREEXISTING_COHERENCE_GATE_SECTION.replace(
+      '**Topic-Project Bindings**',
+      `#### ORG-INTENT.md (Organizational Intent at Runtime)
+
+If \`.instar/ORG-INTENT.md\` exists on disk, two runtime surfaces consume it: the Coherence Gate (Phase 1) reads it on every outbound message review, and the session-start hook (Phase 2) fetches it at session boot via \`GET /intent/org/session-context\`.
+
+**Topic-Project Bindings**`,
+    );
+    fs.writeFileSync(home.claudeMd, phase2Done);
+
+    const migrator = buildMigrator(home.projectDir, home.stateDir);
+    migrator.migrate();
+    const afterFirst = fs.readFileSync(home.claudeMd, 'utf-8');
+    migrator.migrate();
+    const afterSecond = fs.readFileSync(home.claudeMd, 'utf-8');
+    expect(afterSecond).toBe(afterFirst);
   });
 
   it('does not double-insert when CLAUDE.md already contains the subsection', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,44 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+<!-- minor = new capability (ORG-INTENT session-start injection — Phase 2). -->
+
+## What Changed
+
+**feat(org-intent-runtime): inject `ORG-INTENT.md` at session-start so the agent reasons with organizational intent from message one (Phase 2 of 4).**
+
+Phase 1 (shipped in v1.2.23) wired ORG-INTENT.md into the Coherence Gate so constraint violations are blocked at outbound-message review time. Phase 2 closes the other half of the loop: the agent now sees the structured three-rule contract in its working context at the start of every session, so it reasons with the constraints, goals, values, and tradeoff hierarchy as it drafts — instead of just being blocked after the fact.
+
+Two delivery surfaces, both light:
+
+1. **New HTTP route** — `GET /intent/org/session-context` returns the parsed three-rule contract formatted as a session-start text block. Returns `{ present: false }` when ORG-INTENT.md is absent, template-only, or unparseable.
+
+2. **Session-start hook** — the canonical session-start hook (installed by `PostUpdateMigrator.getSessionStartHook()`) now fetches that route and injects the labeled block alongside identity, topic context, and other grounding sections. Fail-open: route unreachable / 503 / timeout → silent skip; the Coherence Gate (Phase 1) still enforces the contract at message-review time.
+
+The new formatter is also exported (`formatOrgIntentForSessionStart()` from `src/core/OrgIntentManager.ts`) for any future callsite that wants the same labeled rendering.
+
+Phase 3 (tradeoff helper) and Phase 4 (drift detection job) remain queued.
+
+Spec: `docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.md`. ELI16 companion: `docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.eli16.md`. Side-effects review: `upgrades/side-effects/org-intent-session-start-injection.md`.
+
+## What to Tell Your User
+
+If your agent already has an organizational intent file (ORG-INTENT.md in the .instar directory), this release makes the agent see it at the start of every session — not just get blocked by it afterward. Practically: the agent now drafts responses with the organization's constraints, goals, values, and tradeoff hierarchy already in mind. Most constraint violations will never be drafted in the first place. The gate from the previous release remains the safety net for edge cases.
+
+If you have not authored an ORG-INTENT.md, nothing changes. This is a zero-cost upgrade for those agents.
+
+## Summary of New Capabilities
+
+- **GET /intent/org/session-context** — new HTTP route returning a session-start-ready text block parsed from ORG-INTENT.md.
+- **Session-start injection** — the canonical session-start hook now surfaces the three-rule contract alongside identity, topic context, soul, and working memory.
+- **Exported `formatOrgIntentForSessionStart()`** — pure formatter usable by any new callsite that wants the same labeled rendering.
+- **Migration parity** — existing agents' CLAUDE.md ORG-INTENT subsection is upgraded automatically to mention both surfaces (Phase 1 gate + Phase 2 session-start injection).
+
+## Evidence
+
+- Tier 1 unit tests: `tests/unit/OrgIntentManager-session-start-format.test.ts` (6 new tests, all passing). `tests/unit/PostUpdateMigrator-org-intent-runtime.test.ts` extended with 2 new tests for Phase 2 migration (7 total tests, all passing).
+- Tier 2 integration tests: `tests/integration/org-intent-routes.test.ts` extended with 4 new tests for the session-context route (11 total tests, all passing).
+- Tier 3 E2E lifecycle tests: `tests/e2e/org-intent-session-context-lifecycle.test.ts` (3 tests mirroring production wiring through `AgentServer` and `createRoutes`, all passing — including the "feature is alive" 200-not-503 check).
+- Type-check: `npx tsc --noEmit` clean.
+- Lint: clean.
+- The full test suite must remain green before merge per Zero-Failure Standard.

--- a/upgrades/side-effects/org-intent-session-start-injection.md
+++ b/upgrades/side-effects/org-intent-session-start-injection.md
@@ -1,0 +1,87 @@
+# Side-effects review — org-intent session-start injection (Phase 2)
+
+Spec: `docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.md`
+ELI16: `docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.eli16.md`
+Phase: 2 of 4. Phase 1 (gate wiring) shipped as v1.2.23 (PR #315). Phase 3 (tradeoff helper) and Phase 4 (drift detection job) are queued.
+
+## Surface map
+
+| Change | File | Type |
+|---|---|---|
+| Exported `formatOrgIntentForSessionStart()` formatter | `src/core/OrgIntentManager.ts` | Additive function export |
+| New `GET /intent/org/session-context` HTTP route | `src/server/routes.ts` | Additive route |
+| Session-start hook fetches + injects parsed ORG-INTENT block | `src/core/PostUpdateMigrator.ts` (`getSessionStartHook`) | Behavior change to agent-installed hook script |
+| CLAUDE.md ORG-INTENT subsection updated (mentions Phase 2) | `src/scaffold/templates.ts` + `PostUpdateMigrator.migrateClaudeMd()` | Doc + migration |
+| Tier 1 unit tests (formatter + migration) | `tests/unit/OrgIntentManager-session-start-format.test.ts`, extended `PostUpdateMigrator-org-intent-runtime.test.ts` | Test addition |
+| Tier 2 integration tests | Extended `tests/integration/org-intent-routes.test.ts` | Test addition |
+| Tier 3 E2E test | `tests/e2e/org-intent-session-context-lifecycle.test.ts` | Test addition |
+
+## Over-block analysis
+
+**Could the injection push the agent's context over a token budget?**
+
+The block size scales with the `ORG-INTENT.md` file size — the formatter doesn't add content; it just labels and structures what's already there. A typical authored `ORG-INTENT.md` is dozens of bullets across four sections — comfortably under 500 tokens. The cap is the source file itself; an organization with a 10-page ORG-INTENT.md will see 10 pages injected. That's a feature, not a bug — but operators should be aware that very large intent files consume context.
+
+**Could the hook fail in a way that disrupts session start?**
+
+No. The hook uses `curl -sf --max-time 4` and a wrapping `if [ -n "$ORG_INTENT_RESPONSE" ]; then ... fi`. Any failure path (route unreachable, 503, network timeout, malformed JSON) results in silent skip. The session continues normally. The Coherence Gate from Phase 1 still enforces the contract at outbound message time, so missing the session-start injection never compromises constraint enforcement.
+
+**Could the new route be abused / DoS'd?**
+
+The route reads `ORG-INTENT.md` from the agent's state dir on every request — bounded local disk read, no LLM call, no DB query. The auth middleware enforces Bearer-token gating. Rate at which an attacker could call it is also bounded by the same auth gate. No new abuse surface beyond `GET /intent/org` (which already existed).
+
+## Under-block analysis
+
+**What does the injection NOT catch?**
+
+- A subtle constraint violation the agent doesn't recognize when drafting. The injection helps the agent *understand* the constraints; the gate is what actually *enforces* them. If the agent's reasoning misses a constraint applicability, the gate catches it.
+- Constraint applicability scoping. A constraint like "never quote internal pricing externally" depends on knowing if the recipient is external. The injection surfaces the constraint; the agent must reason about applicability. Phase 3+ may add scoping metadata to constraints.
+- Mid-session ORG-INTENT.md changes. The injection happens at session start. Edits during a session do not propagate until next session.
+
+## Level-of-abstraction fit
+
+The formatter lives in `src/core/OrgIntentManager.ts` alongside the parser — the right place for a pure rendering function. The HTTP route lives in `src/server/routes.ts` next to `GET /intent/org`. The hook update lives in `PostUpdateMigrator.getSessionStartHook()`, the canonical source for session-start hook content. No new abstractions introduced.
+
+## Signal-vs-authority compliance
+
+The session-start injection is **SIGNAL** — it informs the agent's reasoning but has no authority to refuse or modify outbound messages. The Coherence Gate (Phase 1) remains the **AUTHORITY**: constraint violations are blocked at outbound-message review time regardless of whether the agent saw the injection at session start.
+
+This separation is intentional. A signal-only injection is robust to malformed `ORG-INTENT.md`, route failures, and hook timeouts — the worst case is "the agent doesn't see the contract this session," not "the agent ignores the contract." The authority layer (the gate) catches what the signal misses.
+
+## Interactions with existing systems
+
+| System | Interaction | Risk |
+|---|---|---|
+| Coherence Gate (Phase 1) | None — different layer, different lifecycle | None |
+| `GET /intent/org` | Sibling route — same data, different formatting | None |
+| Session-start hook (existing) | Adds one new fetch + inject block alongside identity, topic, integrated-being, soul, working-memory, etc. | Low — fail-open, bounded by curl --max-time 4 |
+| Working memory injection | Independent — both contribute to session-start context | Token cost is additive but bounded |
+| PostUpdateMigrator other migrations | New migration path operates on an isolated content region | Low — content-sniff guards |
+| Existing `getSessionStartHook()` content | Added inline block; rest unchanged | Low — verified by template parity test pattern |
+
+## Rollback cost
+
+Low. Three options:
+
+1. **Code revert**: `git revert <PR-merge-sha>` removes route + hook block + format function. Tests would need removal too.
+2. **Soft revert via hook bypass**: edit installed `session-start.sh` to remove the curl/python3 block. The route remains but is just an unused HTTP endpoint.
+3. **Soft revert via empty file**: replace `ORG-INTENT.md` with template-only content; the route returns `{ present: false }` and no injection happens. The Phase 1 gate also gracefully degrades on template-only.
+
+No data migration to roll back. No file format changes. The Phase 1 wiring is unaffected by this change.
+
+## Test coverage summary
+
+| Tier | File | Tests | Status |
+|---|---|---|---|
+| 1 (unit) | `tests/unit/OrgIntentManager-session-start-format.test.ts` | 6 | ✓ passing |
+| 1 (unit) | `tests/unit/PostUpdateMigrator-org-intent-runtime.test.ts` (extended) | 7 (2 new for Phase 2) | ✓ passing |
+| 2 (integration) | `tests/integration/org-intent-routes.test.ts` (extended) | 11 (4 new for Phase 2) | ✓ passing |
+| 3 (E2E lifecycle) | `tests/e2e/org-intent-session-context-lifecycle.test.ts` | 3 | ✓ passing |
+
+## Open follow-ups (deferred to later phases, NOT this PR)
+
+- Phase 3: `POST /intent/tradeoff-resolve` standalone helper.
+- Phase 4: periodic drift detection job sampling recent outbound actions vs intent.
+- Mid-session ORG-INTENT.md change propagation (fs.watch or signal-based reinject).
+- Per-channel constraint scoping (some constraints external-only, others universal).
+- Cache layer in front of the route if call rate becomes notable (currently bounded by session-start frequency, which is ~1 per session).


### PR DESCRIPTION
## Summary

- Wires `ORG-INTENT.md` into the session-start hook so the agent sees the structured three-rule contract (constraints / goals / values / tradeoff hierarchy) in its working context from message one, instead of only being blocked by it at outbound-message review time.
- Adds `GET /intent/org/session-context` route returning the parsed contract as a session-start-ready text block. Returns `{ present: false }` when ORG-INTENT.md is absent / template-only / unparseable.
- Updates `PostUpdateMigrator.getSessionStartHook()` to fetch the route and inject the block alongside identity, topic context, integrated-being, soul, and working memory.
- Exports `formatOrgIntentForSessionStart()` from `src/core/OrgIntentManager.ts` for any future callsite.
- Idempotent CLAUDE.md migration upgrades the Phase 1 ORG-INTENT subsection to mention Phase 2.

This is Phase 2 of 4. Phase 1 shipped as v1.2.23 (PR #315). Phase 3 (tradeoff helper) and Phase 4 (drift detection job) are queued behind merge.

## Why now

Phase 1 made `ORG-INTENT.md` actually block outbound messages that violate organizational constraints — a big win, but reactive. The agent didn't *know* about the contract while drafting; it just got blocked after the fact. With Phase 2, the agent now reasons with the structured contract from the start of every session. Most constraint violations are never drafted; the gate from Phase 1 catches the edge cases.

Signal/authority separation: session-start injection is SIGNAL (informs reasoning). The Coherence Gate from Phase 1 remains AUTHORITY (enforces at delivery). Per `feedback_signal_vs_authority`.

## Surface changes

| File | Change |
|---|---|
| `src/core/OrgIntentManager.ts` | Exported `formatOrgIntentForSessionStart()` formatter |
| `src/server/routes.ts` | New `GET /intent/org/session-context` route |
| `src/core/PostUpdateMigrator.ts` | `getSessionStartHook()` inline string adds ORG-INTENT fetch + inject; `migrateClaudeMd()` upgrades Phase 1 ORG-INTENT subsection to mention Phase 2 |
| `src/scaffold/templates.ts` | CLAUDE.md template ORG-INTENT subsection updated for new agents |
| Spec + ELI16 + side-effects | `docs/specs/ORG-INTENT-SESSION-START-INJECTION-SPEC.{md,eli16.md}`, `upgrades/side-effects/org-intent-session-start-injection.md` |
| NEXT.md | Filled with `<!-- bump: minor -->` |

## Tests

All three tiers per Testing Integrity Standard. 30+ tests across all suites green locally:

- **Tier 1 (unit)**: `tests/unit/OrgIntentManager-session-start-format.test.ts` (6 new). `tests/unit/PostUpdateMigrator-org-intent-runtime.test.ts` extended (7 total — 2 new for Phase 2).
- **Tier 2 (integration)**: `tests/integration/org-intent-routes.test.ts` extended (11 total — 4 new for Phase 2).
- **Tier 3 (E2E lifecycle)**: `tests/e2e/org-intent-session-context-lifecycle.test.ts` (3 tests, including 200-not-503 alive check).

## Test plan

- [ ] CI runs unit + integration + E2E suites (local Node v25 has a known better-sqlite3 incompatibility unrelated to this change — CI runs on Node 20/22 where it works).
- [ ] Lint clean (`npm run lint`) — verified locally.
- [ ] `npx tsc --noEmit` clean — verified locally.
- [ ] Side-effects review present at `upgrades/side-effects/org-intent-session-start-injection.md`.
- [ ] ELI16 companion present.
- [ ] NEXT.md `<!-- bump: minor -->` filled.

## Observable behavior change

**Agents with ORG-INTENT.md authored** will see a new `=== ORGANIZATIONAL INTENT ===` block at the top of every new session's context, showing the four labeled sections from the file. Most constraint violations should be prevented at the drafting stage; the gate becomes the safety net for edge cases.

**Agents without ORG-INTENT.md** see no change. Zero-cost upgrade.

## Rollback cost

Low. Three options documented in the side-effects review: code revert, soft revert via hook edit (route remains, no injection), or soft revert via template-only ORG-INTENT.md (graceful degrade through both Phase 1 and Phase 2 paths).

## Queued

- **Phase 3 — Tradeoff helper**: `POST /intent/tradeoff-resolve` standalone helper consulted by non-reviewer code paths.
- **Phase 4 — Drift detection job**: periodic cron job sampling recent outbound actions vs intent, non-blocking digest signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)