### PR TITLE
fix(setup-wizard): Codex creates only Lifeline topic (v1.2.29)

### DIFF
--- a/.instar/instar-dev-traces/20260522T175020Z-codex-only-lifeline-topic.json
+++ b/.instar/instar-dev-traces/20260522T175020Z-codex-only-lifeline-topic.json
@@ -1,0 +1,18 @@
+{
+  "phase": "complete",
+  "specPath": "specs/dev-infrastructure/codex-only-lifeline-topic.md",
+  "artifactPath": "upgrades/side-effects/fix-codex-only-lifeline-topic.md",
+  "artifactSha256": "ff51f16cd3cd1519155338da6144c5dcc7ceefb6d15d36723c0a5ef84ca1f3f1",
+  "coveredFiles": [
+    "src/commands/setup-wizard/codex-driver.ts",
+    "tests/unit/codex-playwright-telegram.test.ts",
+    "specs/dev-infrastructure/codex-only-lifeline-topic.md",
+    "specs/dev-infrastructure/codex-only-lifeline-topic.eli16.md",
+    "docs/specs/reports/codex-only-lifeline-topic-convergence.md",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/fix-codex-only-lifeline-topic.md"
+  ],
+  "writtenAt": "2026-05-22T17:50:20Z",
+  "agent": "echo",
+  "summary": "Fixes duplicate Dashboard topic: Codex agentic flow now creates + seeds + persists ONLY Lifeline; server owns Dashboard/Updates/Attention on boot. Prompt steps 13+14 rewritten. Lifeline orientation message tells user the rest appear on server boot. 81 wizard tests pass. The missing-dashboard-link issue was a Cloudflare 429 rate-limit (not a code bug); two follow-ups tracked (tunnel-failure notification + backup tunnel pool). Ships v1.2.29."
+}

--- a/docs/specs/reports/codex-only-lifeline-topic-convergence.md
+++ b/docs/specs/reports/codex-only-lifeline-topic-convergence.md
@@ -1,0 +1,44 @@
+# Convergence Report — Codex creates only Lifeline
+
+## ELI10 Overview
+
+Last test install ended up with two "Dashboard" topics in the
+Telegram group. Cause: the Codex setup flow created all 4 system
+topics, and the instar server also creates 3 of them on boot.
+Lifeline didn't duplicate (Codex saves its ID, server reuses);
+the other three did, because Codex doesn't save their IDs.
+
+Fix: Codex creates only Lifeline. The server creates Dashboard,
+Updates, and Attention like it already does. One creator per
+topic. No duplicates.
+
+The missing dashboard link was a separate issue — Cloudflare was
+rate-limiting the quick tunnel (429), so there was no URL to post.
+Not a code bug. Two follow-up asks from Justin (notify the user on
+tunnel failure, keep a backup tunnel pool) are tracked separately.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec changes |
+|-----------|-----------------------|-------------------|--------------|
+| 1         | self + Justin's screenshot + live config probe | 1 | Codex creates only Lifeline |
+| 2         | (converged)           | 0                 | none |
+
+## Full Findings Catalog
+
+**Finding 1 — Duplicate Dashboard topic from dual creation.**
+
+- Verified via the live instar-codey config: `config.dashboardTopicId
+  = 14` (the server's "📢 Dashboard") and a separate Codex-created
+  "📊 Dashboard" with no config reference.
+- Severity: medium (confusing UX, orphan topic).
+- Resolution: Codex prompt steps 13 + 14 rewritten to create +
+  seed only Lifeline; explicit instruction not to create the
+  other three; orientation message tells the user the rest appear
+  on server boot.
+
+## Convergence verdict
+
+Converged at iteration 2. Prompt-content-only change; server-side
+topic ownership unchanged; reduces drift surface (Codex no longer
+hard-codes 3 topics' names/colors). 81 wizard tests pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.2.29",
+      "version": "1.2.30",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.29",
+  "version": "1.2.30",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/specs/dev-infrastructure/codex-only-lifeline-topic.eli16.md
+++ b/specs/dev-infrastructure/codex-only-lifeline-topic.eli16.md
@@ -1,0 +1,48 @@
+# What this PR does — in plain English
+
+## The bug
+
+On the last test install, the Telegram group ended up with TWO
+"Dashboard" topics — one with a 📊 icon, one with a 📢 icon.
+
+Here's why: the Codex setup flow creates four topics (Lifeline,
+Updates, Dashboard, Attention). But the instar server ALSO creates
+Dashboard, Updates, and Attention when it first starts up — that's
+its existing job, and it does it well (with proper intros and the
+dashboard-link wiring). The two creators didn't know about each
+other, so the Dashboard topic got made twice.
+
+Lifeline didn't duplicate because the Codex flow saves Lifeline's
+ID to the config, and the server reuses it. But it doesn't save
+the other three IDs, so the server made its own copies.
+
+## The fix
+
+Simple ownership split: the Codex flow creates ONLY Lifeline. The
+server creates Dashboard, Updates, and Attention on boot like it
+already does. No more duplicates.
+
+The Lifeline orientation message now also tells the user "a few
+more topics will appear automatically once my server starts," so
+the brief moment where only Lifeline exists doesn't look broken.
+
+## About the missing dashboard link
+
+That was a separate issue — not a bug in our code. When I checked,
+Cloudflare was rate-limiting the quick-tunnel service for your IP
+(error 429), almost certainly because we spun up a dozen+ tunnels
+across all today's test installs. No tunnel means no dashboard
+URL to post. The wiring is correct; the tunnel just couldn't get
+an address.
+
+Your two follow-up asks — (1) tell the user when the tunnel can't
+connect, and (2) keep a pool of backup tunnel providers — are
+tracked as separate work items. This PR is just the duplicate-
+Dashboard fix.
+
+## What doesn't change
+
+- The server's topic creation (Dashboard/Updates/Attention) is
+  untouched.
+- The post-server "agent comes alive" greeting still fires.
+- The Claude wizard path is untouched.

--- a/specs/dev-infrastructure/codex-only-lifeline-topic.md
+++ b/specs/dev-infrastructure/codex-only-lifeline-topic.md
@@ -1,0 +1,107 @@
+---
+title: "Codex creates only Lifeline — server owns the other topics"
+slug: "codex-only-lifeline-topic"
+author: "echo"
+eli16-overview: "codex-only-lifeline-topic.eli16.md"
+review-convergence: "2026-05-22T18:00:00Z"
+review-iterations: 1
+review-completed-at: "2026-05-22T18:00:00Z"
+review-report: "docs/specs/reports/codex-only-lifeline-topic-convergence.md"
+approved: true
+---
+
+# Codex creates only Lifeline — server owns the other topics
+
+## Problem statement
+
+Real-user retest of v1.2.20 (instar-codey on Codex) showed TWO
+Dashboard topics in the Telegram group:
+
+- "📊 Dashboard" created at 10:32 by the Codex agentic flow.
+- "📢 Dashboard" created at 10:34 by the instar server on boot.
+
+Root cause: the Codex agentic Telegram flow (v1.2.19+) creates
+all four system topics (Lifeline, Updates, Dashboard, Attention).
+But the instar SERVER also creates Dashboard / Updates / Attention
+on its first boot — that's its existing job, via
+`ensureDashboardTopic` (TelegramAdapter.ts, gated on
+`config.dashboardTopicId`), `ensureAgentUpdatesTopic` and
+`ensureAgentAttentionTopic` (server.ts, gated on state keys
+`agent-updates-topic` / `agent-attention-topic`).
+
+The two creators don't coordinate. The Codex flow persists ONLY
+`config.lifelineTopicId` — so the server's `ensureLifelineTopic`
+reuses the Codex Lifeline (no duplicate there). But the Codex
+flow does NOT persist `config.dashboardTopicId` or the state keys
+for Updates/Attention. So the server, seeing those unset, creates
+its own — yielding the duplicate Dashboard the user saw.
+
+(Why only Dashboard duplicated and not Updates/Attention in this
+particular run is a boot-ordering artifact — `ensureDashboardTopic`
+runs via the adapter poll-start while the server.ts ones run in a
+later block. The duplicate risk exists for all three; Dashboard
+is just the one that surfaced.)
+
+## Proposed design
+
+The cleanest fix follows the existing ownership boundary: the
+server already owns Dashboard / Updates / Attention with canonical
+intros, emojis, colors, and (critically) the dashboard-link
+broadcast wiring. The Codex flow should create only what the
+server reuses by persisted ID — Lifeline.
+
+Change `buildTelegramAgenticPrompt`'s step 13 + 14:
+
+- **Step 13**: create ONLY the Lifeline topic. Explicit
+  instruction NOT to create Dashboard/Updates/Attention, with the
+  reason (server creates them; duplicates otherwise). Lifeline is
+  the exception because the Codex flow persists its ID (step 15)
+  and the server's `ensureLifelineTopic` reuses it.
+
+- **Step 14**: seed only the Lifeline topic with the richer
+  orientation message. The message now tells the user that "a few
+  more topics (Updates, Dashboard, Attention) will appear
+  automatically once my server starts" — setting the expectation
+  that more topics are coming so the brief single-topic state
+  between Codex-done and server-boot doesn't look broken.
+
+The post-server greeting (step from the state machine's
+`send-greeting` action via `runSendLifelineGreeting`) is
+unchanged — still fires in Lifeline after server boot.
+
+The server's `ensureDashboardTopic` / `ensureAgentUpdatesTopic` /
+`ensureAgentAttentionTopic` are unchanged — they create their
+topics on boot exactly as before, now with no Codex-created
+duplicates to collide with.
+
+## Decision points touched
+
+- Removes 3 of 4 topic-creation SIGNALS from the Codex prompt;
+  the server's topic-ensure functions remain the single
+  AUTHORITY for Dashboard/Updates/Attention.
+- `config.lifelineTopicId` remains the coordination point between
+  the Codex flow and the server's `ensureLifelineTopic`.
+- No server-side change. The fix is entirely in the Codex prompt.
+
+## Open questions
+
+None for this fix.
+
+## Out of scope (Justin's two follow-up asks)
+
+1. **Inform the user when the tunnel can't connect** — when the
+   quick tunnel fails (e.g. Cloudflare 429 rate-limit), the
+   Dashboard topic should get a message explaining why there's no
+   link yet + what to do. Separate server-side change to the
+   tunnel-failure handler. Tracked for a follow-up.
+
+2. **Backup tunnel pool** — when the primary (Cloudflare quick)
+   tunnel fails, try alternate providers (named Cloudflare,
+   localtunnel, bore, etc.) so the dashboard link survives a
+   single-provider outage. Substantial feature; separate spec.
+
+This PR is the duplicate-Dashboard fix only. The
+no-dashboard-link issue Justin saw was a Cloudflare 429
+rate-limit (verified by running cloudflared manually — "429 Too
+Many Requests, error code 1015"), NOT a code bug. The two
+follow-ups above make that failure mode visible + recoverable.

--- a/src/commands/setup-wizard/codex-driver.ts
+++ b/src/commands/setup-wizard/codex-driver.ts
@@ -799,40 +799,35 @@ STEPS:
      — pinning and topic management may not work." This is
      NON-fatal — continue with the rest of setup. NOT AGENTIC_FAILED.
 
-13. Create the 4 system topics. Each via createForumTopic:
+13. Create ONLY the Lifeline topic. Do NOT create Dashboard,
+    Updates, or Attention topics here — the instar SERVER creates
+    those automatically on its first boot, with their own
+    canonical intros, emojis, colors, AND the dashboard-link
+    wiring. If you create them too, you get DUPLICATE topics: the
+    server tracks its own topics by stored IDs it doesn't know you
+    created, so it makes a second copy. Lifeline is the one
+    exception — you create it, persist its ID to config (step 15),
+    and the server reuses that ID instead of making a duplicate.
 
-    a. Lifeline (color 9367192 — green):
-       curl -s -X POST "https://api.telegram.org/bot<TOKEN>/createForumTopic" \\
-         -H 'Content-Type: application/json' \\
-         -d '{"chat_id": "<FORUM_CHAT_ID>",
-              "name": "🛡️ Lifeline",
-              "icon_color": 9367192}'
-       Capture result.message_thread_id as LIFELINE_TOPIC_ID.
+    Create Lifeline (color 9367192 — green):
+      curl -s -X POST "https://api.telegram.org/bot<TOKEN>/createForumTopic" \\
+        -H 'Content-Type: application/json' \\
+        -d '{"chat_id": "<FORUM_CHAT_ID>",
+             "name": "🛡️ Lifeline",
+             "icon_color": 9367192}'
+    Capture result.message_thread_id as LIFELINE_TOPIC_ID.
 
-    b. Updates (color 7322096 — blue):
-       Same call with name "📢 Updates", icon_color 7322096.
-       Capture as UPDATES_TOPIC_ID.
+    If the call returns !ok, tell the user "Couldn't create the
+    Lifeline topic — switching to manual." Output
+    AGENTIC_FAILED: topics-create-failed and exit.
 
-    c. Dashboard (color 7322096 — blue):
-       Same with name "📊 Dashboard". Capture as DASHBOARD_TOPIC_ID.
-
-    d. Attention (color 16766590 — yellow):
-       Same with name "🔔 Attention". Capture as ATTENTION_TOPIC_ID.
-
-    If any createForumTopic call returns !ok, tell the user
-    "Couldn't create the system topics — switching to manual."
-    Output AGENTIC_FAILED: topics-create-failed and exit.
-
-14. Seed each topic with one orienting message via sendMessage +
-    message_thread_id. These are NEUTRAL channel-purpose blurbs,
-    not the agent's personal greeting (that's a separate step
-    after server start — see Phase 5 of the wizard). Use the
-    agent's first-person voice in plain text. Adapt wording as
-    needed for the agent's personality, but keep meaning intact.
-
-    a. Lifeline (LIFELINE_TOPIC_ID) — this one is RICHER because
-       new users see it first and need to understand how topics
-       work:
+14. Seed the Lifeline topic with one orienting message via
+    sendMessage + message_thread_id. This is a NEUTRAL channel-
+    purpose blurb, not the agent's personal greeting (that's a
+    separate step after server start — see Phase 5 of the wizard).
+    Use the agent's first-person voice. This message is RICHER
+    than a plain label because new users see it first and need to
+    understand how topics work:
 
        text: |
          Hey ${userName} — I'm ${agentName}. This is the **Lifeline** topic.
@@ -847,33 +842,19 @@ STEPS:
          proactively create topics when something's worth a
          dedicated thread.
 
-         I'll send my proper hello once the server's up — should
-         only be a few seconds.
+         A few more topics (Updates, Dashboard, Attention) will
+         appear automatically once my server starts. I'll send my
+         proper hello here in Lifeline a few seconds after that.
 
-    b. Updates (UPDATES_TOPIC_ID):
-       "Updates is where I'll post automated status — job runs,
-       sync notifications, anything informational that doesn't
-       need a response from you."
-
-    c. Dashboard (DASHBOARD_TOPIC_ID):
-       "Dashboard is where I'll post the link to my web dashboard
-       once a tunnel is up. You'll be able to monitor sessions
-       from your phone."
-
-    d. Attention (ATTENTION_TOPIC_ID):
-       "Attention is for things you need to look at — failed jobs,
-       missing credentials, anything urgent. I'll only post here
-       when something actually needs you."
-
-    All four via:
+    Via:
       curl -s -X POST "https://api.telegram.org/bot<TOKEN>/sendMessage" \\
         -H 'Content-Type: application/json' \\
         -d '{"chat_id": "<FORUM_CHAT_ID>",
-             "message_thread_id": <TOPIC_ID>,
+             "message_thread_id": <LIFELINE_TOPIC_ID>,
              "text": "<intro text>"}'
 
-    Capture the Lifeline intro's result.message_id as
-    LIFELINE_INTRO_MESSAGE_ID — used in 14b for pinning.
+    Capture result.message_id as LIFELINE_INTRO_MESSAGE_ID — used
+    in 14b for pinning.
 
 14b. Pin the Lifeline intro so users scrolling back later don't
      lose the orientation. Requires admin rights from step 12b;

--- a/tests/unit/codex-playwright-telegram.test.ts
+++ b/tests/unit/codex-playwright-telegram.test.ts
@@ -128,17 +128,22 @@ describe('buildTelegramAgenticPrompt', () => {
     expect(prompt).toMatch(/forum-mode-not-enabled/);
   });
 
-  it('creates the 4 canonical system topics with TOPIC_STYLE colors', () => {
+  it('creates ONLY the Lifeline topic (v1.2.21 — server owns the other 3)', () => {
+    // Pre-v1.2.21 the Codex flow created all 4 topics, which
+    // duplicated the server's own Dashboard/Updates/Attention on
+    // boot. v1.2.21: Codex creates only Lifeline (+persists its id);
+    // the server creates Dashboard/Updates/Attention.
     expect(prompt).toMatch(/Lifeline/);
-    expect(prompt).toMatch(/Updates/);
-    expect(prompt).toMatch(/Dashboard/);
-    expect(prompt).toMatch(/Attention/);
-    // Canonical colors from src/messaging/TelegramAdapter.ts TOPIC_STYLE.
     expect(prompt).toMatch(/9367192/);  // SYSTEM (Lifeline) — green
-    expect(prompt).toMatch(/7322096/);  // INFO (Updates, Dashboard) — blue
-    expect(prompt).toMatch(/16766590/); // ALERT (Attention) — yellow
     expect(prompt).toMatch(/createForumTopic/);
     expect(prompt).toMatch(/topics-create-failed/);
+    // It must explicitly tell Codex NOT to create the other three.
+    // (whitespace-flexible — the phrase wraps across lines in the prompt)
+    expect(prompt).toMatch(/Do NOT create Dashboard,\s+Updates, or\s+Attention/i);
+    expect(prompt).toMatch(/DUPLICATE/);
+    // The other-topic colors should NOT be hard-coded as create
+    // instructions anymore (the only colour referenced is Lifeline's).
+    expect(prompt).not.toMatch(/16766590/); // Attention yellow — gone
   });
 
   it('seeds each topic with an orienting message via sendMessage + message_thread_id', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,4 +1,4 @@
-# Upgrade Guide — v1.2.29 (Codex creates only Lifeline topic)
+# Upgrade Guide — v1.2.30 (Codex creates only Lifeline topic)
 
 <!-- bump: patch -->
 <!-- patch = bug fixes, refactors, test additions, doc updates -->

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,60 @@
+# Upgrade Guide — v1.2.29 (Codex creates only Lifeline topic)
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**Fix: duplicate Dashboard topic in the Codex Telegram setup.**
+
+Real-user retest showed two "Dashboard" topics in the Telegram
+group — one created by the Codex agentic flow (📊), one by the
+instar server on boot (📢). The Codex flow was creating all four
+system topics (Lifeline, Updates, Dashboard, Attention), but the
+server ALSO creates Dashboard / Updates / Attention on its first
+boot. They didn't coordinate, so Dashboard got made twice.
+
+Lifeline never duplicated because the Codex flow persists its ID
+and the server reuses it. The fix extends that pattern: the Codex
+flow now creates ONLY Lifeline. The server creates Dashboard,
+Updates, and Attention like it always has — with its own
+canonical intros, emojis, colors, and the dashboard-link wiring.
+
+The Lifeline orientation message now tells the user that "a few
+more topics will appear automatically once my server starts," so
+the brief single-topic state between Codex-done and server-boot
+doesn't look incomplete.
+
+Spec: `specs/dev-infrastructure/codex-only-lifeline-topic.md`.
+ELI16: `specs/dev-infrastructure/codex-only-lifeline-topic.eli16.md`.
+Side-effects: `upgrades/side-effects/fix-codex-only-lifeline-topic.md`.
+
+## What to Tell Your User
+
+The setup no longer creates a duplicate Dashboard topic. You'll
+get one of each system topic, created by the part of instar that
+owns it. The Lifeline topic now mentions that the other topics
+appear automatically once your agent's server starts.
+
+(Separately: if your dashboard link is missing, it's usually
+because the Cloudflare tunnel can't connect — often a temporary
+rate limit. Two follow-up improvements are planned: a clear
+"tunnel couldn't connect" message in the Dashboard topic, and a
+pool of backup tunnel providers.)
+
+## Summary of New Capabilities
+
+No new capabilities. Duplicate-topic bug fix.
+
+## Evidence
+
+Reproduction prior: live instar-codey config showed
+`config.dashboardTopicId = 14` (server's "📢 Dashboard") plus a
+separate Codex-created "📊 Dashboard" with no config reference.
+The user's screenshot showed both in the chat list.
+
+After fix: 81 wizard tests pass; the topic-creation canary now
+asserts the prompt creates ONLY Lifeline and explicitly forbids
+creating the other three. The retired Attention/Updates/Dashboard
+color codes are no longer hard-coded in the prompt (only
+Lifeline's remains).

--- a/upgrades/side-effects/fix-codex-only-lifeline-topic.md
+++ b/upgrades/side-effects/fix-codex-only-lifeline-topic.md
@@ -1,0 +1,83 @@
+# Side-effects review — Codex creates only Lifeline
+
+Per L6. Seven dimensions.
+
+## 1. Over-block / under-block
+
+Before: OVER-creation. The Codex flow created all 4 system topics
+AND the server created 3 of them on boot, yielding duplicate
+Dashboard (and latent duplicate risk for Updates/Attention).
+
+After: precisely scoped. Codex creates only Lifeline (which the
+server reuses by persisted ID). Server creates the other 3.
+Single creator per topic. No duplicates.
+
+## 2. Level-of-abstraction fit
+
+Prompt-content change only — steps 13 + 14 of
+`buildTelegramAgenticPrompt`. No new functions, no signature
+change, no server-side change. Follows the existing ownership
+boundary (server owns Dashboard/Updates/Attention; Lifeline is
+shared via `config.lifelineTopicId`).
+
+## 3. Signal vs Authority compliance
+
+- The server's `ensureDashboardTopic` / `ensureAgentUpdatesTopic`
+  / `ensureAgentAttentionTopic` remain the single AUTHORITY for
+  those three topics.
+- `config.lifelineTopicId` remains the coordination AUTHORITY
+  between the Codex flow and the server's `ensureLifelineTopic`.
+- The Codex flow no longer emits create-SIGNALS for the three
+  server-owned topics.
+
+## 4. Interactions with adjacent systems
+
+- **Server `ensureDashboardTopic` / `ensureAgentUpdatesTopic` /
+  `ensureAgentAttentionTopic`**: unchanged. They now run without
+  a Codex-created duplicate to collide with.
+- **Server `ensureLifelineTopic`**: unchanged. Still reuses
+  `config.lifelineTopicId` written by the Codex flow.
+- **`runSendLifelineGreeting`** (post-server greeting): unchanged.
+  Still reads `lifelineTopicId` from config and posts the
+  agent's first hello.
+- **`broadcastDashboardUrl`**: unchanged. Posts the dashboard
+  link to `config.dashboardTopicId` (set by the server's
+  `ensureDashboardTopic`) once a tunnel is up.
+- **Tests**: one test rewritten (was "creates the 4 canonical
+  system topics" → now "creates ONLY the Lifeline topic"); the
+  other 80 wizard tests unchanged.
+
+## 5. Rollback cost
+
+Trivial. Prompt-content change in two steps. `git revert`
+restores the 4-topic creation (and the duplicate).
+
+## 6. Backwards compatibility / drift surface
+
+Fully backwards-compatible.
+
+- Existing agents already set up: unaffected — their topics
+  already exist; the server's ensure functions are idempotent on
+  their stored IDs.
+- New Codex installs: get exactly 4 topics, one creator each, no
+  duplicates.
+- Claude wizard path: untouched.
+- No config schema change. No agent-installed-files change.
+
+Drift surface reduced: the Codex prompt no longer hard-codes the
+Dashboard/Updates/Attention names + colors, so it can't drift
+from the server's TOPIC_STYLE constants. Only Lifeline's color
+(9367192) remains in the prompt, matching SYSTEM.
+
+## 7. Authorization / Trust posture
+
+No change. Same Codex spawn flags, same Bot API access.
+
+## Outcome
+
+Ship. Closes the duplicate-Dashboard bug by restoring the natural
+ownership boundary: server owns its three system topics; Codex
+owns only Lifeline (the shared coordination point). The
+no-dashboard-link issue is separate (Cloudflare rate-limit) and
+addressed by two tracked follow-ups (tunnel-failure user
+notification + backup tunnel pool).


### PR DESCRIPTION
## Summary
Real-user retest showed two Dashboard topics in the group — "📊 Dashboard" (Codex flow) and "📢 Dashboard" (server boot). The Codex agentic flow created all 4 system topics; the instar server ALSO creates Dashboard/Updates/Attention on boot. They didn't coordinate.

## Fix
Codex creates + seeds + persists ONLY Lifeline (which the server reuses via `config.lifelineTopicId`). The server creates Dashboard/Updates/Attention like it always has — with its own canonical intros + dashboard-link wiring. One creator per topic, no duplicates.

The Lifeline orientation message now tells the user "a few more topics will appear automatically once my server starts."

Prompt-content-only change. Reduces drift surface (Codex no longer hard-codes 3 topics' names/colors).

## The missing-dashboard-link issue (separate, not a code bug)
Verified by running cloudflared manually: **429 Too Many Requests, error code 1015** from trycloudflare.com — Cloudflare is rate-limiting the quick tunnel for this IP (we spun up a dozen+ tunnels today). No tunnel → no URL → no link. The wiring is correct.

Two follow-ups tracked from Justin's asks:
1. Notify the user in the Dashboard topic when the tunnel can't connect.
2. Backup tunnel provider pool.

## Tests
81 wizard tests pass. Topic-creation canary rewritten to assert ONLY Lifeline is created + the other three are explicitly forbidden + their color codes removed from the prompt.

## Spec bundle
- Spec: `specs/dev-infrastructure/codex-only-lifeline-topic.md`
- ELI16: `specs/dev-infrastructure/codex-only-lifeline-topic.eli16.md`
- Convergence: `docs/specs/reports/codex-only-lifeline-topic-convergence.md`
- Side-effects: `upgrades/side-effects/fix-codex-only-lifeline-topic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)