### PR TITLE
feat(memory): periodic SessionActivitySentinel scan digests long sessions mid-flight

### DIFF
--- a/docs/specs/periodic-sentinel-scan.eli16.md
+++ b/docs/specs/periodic-sentinel-scan.eli16.md
@@ -1,0 +1,25 @@
+# Periodic activity-digest scan — ELI16
+
+## The short version
+
+Your agent already does two things automatically: it writes short summaries of chunks of its work, and it pulls the durable facts out of those summaries into a searchable memory graph. The catch: until now it only did this when a conversation ENDED.
+
+Long conversations — the ones that run for hours, span days, or never cleanly finish because of a restart — never got summarized. All that work, all those decisions, never reached the memory graph. Which is backwards, because the long important conversations are exactly the ones worth remembering.
+
+This change adds a timer. Every 30 minutes, the agent summarizes whatever in-progress conversations have new activity and feeds the durable facts into its memory graph. The graph now grows throughout a long conversation, not just at the very end.
+
+## Why it matters
+
+The whole point of the recent memory work is to stop the agent's knowledge graph from sitting empty. The previous change taught the agent to extract facts from its work. But that extraction only ran at the end of a conversation. For a months-long client engagement (the kind of conversation that started this whole effort), "the end" might be never. So the extraction never ran for the conversations that needed it most.
+
+The timer fixes that. It's the last piece of getting the graph populated before the bigger feature (keeping the agent aware of the big picture in a long conversation) gets built on top.
+
+## What you'll notice
+
+Nothing immediately. The scan runs quietly in the background every 30 minutes. Over a long conversation you'll see the agent's memory of that conversation get richer — it'll recall decisions and facts from earlier in the same conversation without you having to remind it.
+
+It's on by default. If you ever wanted it off or on a different schedule, that's a one-line setting, but the default (every 30 minutes, on) is right for almost everyone.
+
+## Safety
+
+The scan is careful about cost: it skips conversations with no new activity, and it won't summarize a conversation that has too little new content to be worth it. On a multi-machine setup, only the active machine runs the scan, so you never pay for the same work twice. And if a scan ever fails, it's logged and the agent keeps running — a failed summary never takes the agent down.

--- a/docs/specs/periodic-sentinel-scan.md
+++ b/docs/specs/periodic-sentinel-scan.md
@@ -1,0 +1,119 @@
+---
+title: "Periodic SessionActivitySentinel scan — digest long-running sessions mid-flight"
+slug: "periodic-sentinel-scan"
+author: "echo"
+review-convergence: "single-iteration"
+review-iterations: 1
+convergence-note: "Retrospective single-iteration convergence: mechanically narrow (one config field + one setInterval wire + one extracted pure helper), rollback is a single revert that returns the sessionComplete-only behaviour, and scan() already ships with idempotency / dormant-skip / minimum-activity guards so the cadence cannot misbehave. Lower-risk than the 5-iteration target — same standard applied to the Initiative Tracker (2026-04-18), heal-execpath-staleness (2026-05-21), and activity-digest-entity-extraction (2026-05-22) specs."
+approved: true
+approved-by: "Justin (JKHeadley)"
+approved-date: "2026-05-22"
+approval-note: "Approved via Telegram topic 9976 (topic-intent-layer): 'I agree with all recommendations. Please proceed' (2026-05-21, covering the Phase 0 sequencing including 0b) and 'please enter autonomous mode and continue through' (2026-05-22, authorizing autonomous execution of the remaining Phase 0 + Phase 1 work). Phase 0b — wiring the periodic sentinel scan — is the last foundation piece before Phase 1."
+---
+
+# Periodic SessionActivitySentinel scan
+
+## ELI10 version
+
+The agent already writes short summaries of its work and pulls durable facts out of them into its memory graph. But until now it only did this when a conversation FINISHED. Long conversations that run for hours or days — or never cleanly end because of a restart — never got summarized, so all that work never reached the memory graph.
+
+This change makes the agent summarize in-progress conversations on a timer (every 30 minutes by default). Now the memory graph grows throughout a long conversation, not just at the end.
+
+## Problem
+
+`SessionActivitySentinel` digests session activity into mini-digests and (since Phase 0d) extracts typed entities from those digests into SemanticMemory. But the only trigger wired in `server.ts` was the `sessionComplete` event → `synthesizeSession`. The periodic `scan()` method — which PROP-memory-architecture Phase 3 specifies should run "every 30-60 min" — existed but was never scheduled.
+
+Consequence: a long-running Telegram topic (the exact shape of the GCI case that started this whole thread — 326 messages over two months) accumulates hours of activity that is never digested mid-flight. The entity-extraction pipeline shipped in Phase 0d only fires at `sessionComplete`, which for a long-lived interactive topic may be days away or may never happen cleanly (compaction, machine restart, watchdog kill). The knowledge graph the Topic Intent Layer will read from stays sparse precisely for the topics that need it most.
+
+## Solution
+
+Wire a periodic in-process scan interval next to the existing `sessionComplete` handler in `server.ts`.
+
+### Interval resolution
+
+A new pure helper `resolveSentinelScanIntervalMs(cfg)` in `SessionActivitySentinel.ts`:
+
+- Returns `null` when `cfg.enabled === false` (periodic scan disabled; sessionComplete synthesis still runs).
+- Otherwise returns `max(5, cfg.scanIntervalMinutes ?? 30) * 60_000`.
+- 30-minute default; 5-minute floor (a faster cadence wastes LLM budget — `scan()` skips dormant sessions and enforces a minimum-activity threshold internally, so there's no value scanning more often).
+
+Extracted as a pure function so the clamp / default / disabled policy is unit-testable without standing up the full server bootstrap.
+
+### Config
+
+New optional `MonitoringConfig.episodicSentinel`:
+
+```
+episodicSentinel?: {
+  enabled?: boolean;            // default true
+  scanIntervalMinutes?: number; // default 30, floored at 5
+}
+```
+
+Optional and absent by default — existing agents get the 30-minute scan automatically (default-on), matching the Phase 0 decision to default-on memory-graph population. Operators who want it off set `enabled: false`.
+
+### Wiring
+
+In `server.ts`, after the `sessionComplete` synthesis handler:
+
+```
+const scanIntervalMs = resolveSentinelScanIntervalMs(config.monitoring.episodicSentinel);
+if (scanIntervalMs !== null) {
+  const activityScanTimer = setInterval(() => {
+    if (coordinator.enabled && !coordinator.isAwake) return; // awake-machine only
+    activitySentinel.scan().then(...).catch(...);
+  }, scanIntervalMs);
+  if (activityScanTimer.unref) activityScanTimer.unref();
+}
+```
+
+- `unref()` so the timer never blocks process exit.
+- Awake-machine gating mirrors the scheduler gating (`config.scheduler.enabled && coordinator.isAwake`) so a standby machine in a multi-machine setup doesn't double-digest the same sessions.
+- Errors are caught and logged, never thrown — a failing scan must not crash the server.
+
+## Decision-point inventory
+
+1. **In-process setInterval vs cron job.** `scan()` is an in-process LLM operation against live session state (tmux capture + Telegram log), not an agent-prompt job. The `setInterval` + `unref` pattern (used by relayPruneTimer, resumeHeartbeat) is the right analog, not the jobs.json cron pattern (used by memory-hygiene, which spawns an agent session). Chose setInterval.
+
+2. **Default cadence.** 30 min. PROP-memory-architecture says "30-60 min." 30 captures more granular activity boundaries; the dormant-skip + min-activity guards mean idle sessions cost nothing. Operators can widen via config.
+
+3. **Default on vs off.** On. Matches the Phase 0 graph-population decision. The whole point of Phase 0 is to stop the graph being empty; shipping the scan disabled-by-default would defeat that.
+
+4. **Awake-machine gating.** Required. Without it, every machine in a multi-machine setup scans the same sessions, double-spending LLM budget and racing on digest writes (idempotency would dedup the writes, but the LLM spend is wasted). Gate mirrors the scheduler.
+
+5. **Initial immediate scan on startup?** No. The first scan fires after one interval. An immediate scan on every restart would re-digest recently-active sessions on restart loops. The interval delay is the safer default; sessions accumulate activity by the first tick.
+
+## Tests
+
+`tests/unit/sentinel-scan-interval.test.ts` — 6 tests on the resolver:
+- default 30 min (no config / empty config)
+- null when disabled (and disabled overrides a set interval)
+- enabled:true / enabled:undefined both on
+- honors custom interval
+- clamps below the 5-min floor (1, 0, negative)
+- allows exactly the floor
+
+The 21 existing `session-activity-sentinel.test.ts` and 7 `SessionActivitySentinel-entity-extraction.test.ts` tests confirm `scan()` itself (idempotency, dormant-skip, digest creation, entity extraction) is unchanged.
+
+## Acceptance evidence
+
+Per the bug-fix-evidence memory: the failure mode is "long sessions never get mid-flight digests." Pre-change, `grep` of `server.ts` shows the only `activitySentinel` trigger is `sessionComplete`. Post-change, the periodic interval is wired and gated. The resolver tests verify the cadence policy; the existing sentinel tests verify scan() does the right thing when called. Together: the scan now runs on a cadence AND does the right thing each time.
+
+Live verification (manual, post-merge): set `scanIntervalMinutes: 5` on a test agent, start a session, send 10+ messages, wait one interval, confirm a digest appears and (with SemanticMemory wired) entity count rises — without ending the session. This is a runtime check the autonomous run notes for follow-up since it requires a live multi-message session.
+
+## Cross-framework portability (v1.0+)
+
+The scan path is framework-agnostic: it reads tmux capture + Telegram JSONL and calls the framework-aware `sharedIntelligence` for digestion. No `INSTAR_FRAMEWORK` branching. Codex agents with a different session-output shape see the same cadence; extraction quality varies with output shape but the wiring is identical.
+
+## Rollback
+
+Single-commit revert removes the interval wire, the config field, and the helper. Reverts to sessionComplete-only digestion — the pre-change behaviour, not a worse state. No data migration; no config migration (the field is optional and absent by default).
+
+## Out of scope (intentional)
+
+- Adaptive cadence (scan more often when sessions are active, less when idle). The dormant-skip already makes idle scans cheap; adaptive timing is a future optimization.
+- Backfilling digests for sessions that ran before this shipped. Those are captured at their sessionComplete (or already missed); no retroactive scan.
+
+## Origin
+
+Topic 9976 (topic-intent-layer), 2026-05-22. Phase 0b — the last foundation piece. Phase 0a's investigation found the periodic scan unwired; Phase 0d shipped the entity extraction that this scan now drives mid-session. Together they make the knowledge graph grow throughout long sessions, which is the prerequisite for the Topic Intent Layer (Phase 1) to have a populated graph to read from.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4124,7 +4124,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // Creates mid-session mini-digests via LLM, and session syntheses on completion.
     let activitySentinel: import('../monitoring/SessionActivitySentinel.js').SessionActivitySentinel | undefined;
     if (sharedIntelligence) {
-      const { SessionActivitySentinel } = await import('../monitoring/SessionActivitySentinel.js');
+      const { SessionActivitySentinel, resolveSentinelScanIntervalMs } = await import('../monitoring/SessionActivitySentinel.js');
       activitySentinel = new SessionActivitySentinel({
         stateDir: config.stateDir,
         intelligence: sharedIntelligence,
@@ -4156,6 +4156,34 @@ export async function startServer(options: StartOptions): Promise<void> {
           console.error(`[ActivitySentinel] Synthesis failed for ${session.name}: ${err instanceof Error ? err.message : err}`);
         });
       });
+
+      // Periodic mid-session scan. Without this, the sentinel only digests on
+      // sessionComplete — so a long-running Telegram session that never cleanly
+      // ends (compaction, multi-day topic, machine restart) accumulates hours
+      // of activity that is never digested, and the entities within it never
+      // reach SemanticMemory. The periodic scan digests in-flight activity on a
+      // cadence so the knowledge graph grows throughout long sessions, not just
+      // at the end. scan() is internally idempotent (hash-keyed digests),
+      // skips dormant sessions, and enforces a minimum-activity threshold, so a
+      // frequent cadence is safe.
+      const scanIntervalMs = resolveSentinelScanIntervalMs(config.monitoring.episodicSentinel);
+      if (scanIntervalMs !== null) {
+        const scanMinutes = Math.round(scanIntervalMs / 60_000);
+        const activityScanTimer = setInterval(() => {
+          // Only the awake machine scans — mirrors the scheduler gating so
+          // standby machines in a multi-machine setup don't double-digest.
+          if (coordinator.enabled && !coordinator.isAwake) return;
+          activitySentinel!.scan().then((report) => {
+            if (report.digestsCreated > 0) {
+              console.log(`[ActivitySentinel] Periodic scan: ${report.digestsCreated} digest(s) across ${report.sessionsScanned} session(s)`);
+            }
+          }).catch((err) => {
+            console.error(`[ActivitySentinel] Periodic scan failed: ${err instanceof Error ? err.message : err}`);
+          });
+        }, scanIntervalMs);
+        if (activityScanTimer.unref) activityScanTimer.unref();
+        console.log(pc.dim(`  Episodic memory sentinel: periodic scan every ${scanMinutes}min`));
+      }
 
       const semStatus = semanticMemory ? 'with entity extraction' : 'digests only (no SemanticMemory)';
       console.log(pc.green(`  Episodic memory sentinel enabled (LLM-powered digestion, ${semStatus})`));

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2497,6 +2497,18 @@ export interface MonitoringConfig {
     /** Relay timeout in seconds (default: 300) */
     relayTimeoutSeconds?: number;
   };
+  /**
+   * Episodic memory sentinel — periodic mid-session activity digestion.
+   * The sentinel digests long-running sessions on a cadence so activity
+   * (and the entities extracted from it) is captured before sessions end,
+   * not only at sessionComplete.
+   */
+  episodicSentinel?: {
+    /** Enable the periodic scan (default: true when the sentinel is built). */
+    enabled?: boolean;
+    /** Minutes between periodic scans (default: 30). Clamped to >= 5. */
+    scanIntervalMinutes?: number;
+  };
 }
 
 export type TelemetryLevel = 'basic' | 'usage';

--- a/src/monitoring/SessionActivitySentinel.ts
+++ b/src/monitoring/SessionActivitySentinel.ts
@@ -93,6 +93,26 @@ export interface SynthesisReport {
   error?: string;
 }
 
+/**
+ * Resolve the periodic-scan interval in milliseconds from config.
+ *
+ * Returns `null` when the periodic scan is disabled (enabled === false).
+ * Otherwise returns the interval clamped to a 5-minute floor (a faster
+ * cadence wastes LLM budget — scan() skips dormant sessions and enforces a
+ * minimum-activity threshold anyway, so there's no value in scanning more
+ * often than every few minutes). Default is 30 minutes.
+ *
+ * Extracted as a pure function so the clamp / default / disabled logic is
+ * unit-testable without standing up the full server bootstrap.
+ */
+export function resolveSentinelScanIntervalMs(
+  cfg?: { enabled?: boolean; scanIntervalMinutes?: number },
+): number | null {
+  if (cfg?.enabled === false) return null;
+  const minutes = Math.max(5, cfg?.scanIntervalMinutes ?? 30);
+  return minutes * 60_000;
+}
+
 // ─── SessionActivitySentinel ────────────────────────────────────────
 
 export class SessionActivitySentinel {

--- a/tests/unit/sentinel-scan-interval.test.ts
+++ b/tests/unit/sentinel-scan-interval.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for resolveSentinelScanIntervalMs — Phase 0b of the
+ * topic-intent-layer thread (Telegram 9976).
+ *
+ * The periodic SessionActivitySentinel scan is gated by this resolver:
+ * it computes the interval from config, applies the 5-minute floor, the
+ * 30-minute default, and the disabled signal. Server bootstrap can't be
+ * unit-tested directly, so the policy lives in this pure function.
+ */
+import { describe, expect, it } from 'vitest';
+import { resolveSentinelScanIntervalMs } from '../../src/monitoring/SessionActivitySentinel.js';
+
+describe('resolveSentinelScanIntervalMs', () => {
+  it('defaults to 30 minutes when no config is provided', () => {
+    expect(resolveSentinelScanIntervalMs()).toBe(30 * 60_000);
+    expect(resolveSentinelScanIntervalMs({})).toBe(30 * 60_000);
+  });
+
+  it('returns null when explicitly disabled', () => {
+    expect(resolveSentinelScanIntervalMs({ enabled: false })).toBeNull();
+    // enabled: false overrides any interval.
+    expect(resolveSentinelScanIntervalMs({ enabled: false, scanIntervalMinutes: 10 })).toBeNull();
+  });
+
+  it('treats enabled:true and enabled:undefined as on', () => {
+    expect(resolveSentinelScanIntervalMs({ enabled: true })).toBe(30 * 60_000);
+    expect(resolveSentinelScanIntervalMs({ scanIntervalMinutes: 45 })).toBe(45 * 60_000);
+  });
+
+  it('honors a custom interval', () => {
+    expect(resolveSentinelScanIntervalMs({ scanIntervalMinutes: 60 })).toBe(60 * 60_000);
+    expect(resolveSentinelScanIntervalMs({ scanIntervalMinutes: 15 })).toBe(15 * 60_000);
+  });
+
+  it('clamps below the 5-minute floor', () => {
+    // A too-frequent cadence wastes LLM budget; floor protects against it.
+    expect(resolveSentinelScanIntervalMs({ scanIntervalMinutes: 1 })).toBe(5 * 60_000);
+    expect(resolveSentinelScanIntervalMs({ scanIntervalMinutes: 0 })).toBe(5 * 60_000);
+    expect(resolveSentinelScanIntervalMs({ scanIntervalMinutes: -10 })).toBe(5 * 60_000);
+  });
+
+  it('allows exactly the floor', () => {
+    expect(resolveSentinelScanIntervalMs({ scanIntervalMinutes: 5 })).toBe(5 * 60_000);
+  });
+});

--- a/upgrades/1.2.29.md
+++ b/upgrades/1.2.29.md
@@ -52,3 +52,27 @@ Nothing is required from you. The graph builds quietly in the background through
 | Automatic entity extraction from session activity | Automatic — runs in every digest scan when SemanticMemory is enabled |
 | Cross-digest entity dedup | Automatic — same name + same type collapses to one entity |
 | Typed graph edges from intra-batch and cross-digest references | Automatic — emitted when target entity is in scope |
+
+---
+
+**feat(memory): periodic activity-digest scan — digest long-running sessions mid-flight.**
+
+The entity-extraction pipeline above only ran when a session reached `sessionComplete`. For a long-running Telegram topic that runs for hours or days, or never cleanly ends (compaction, machine restart, watchdog kill), that meant the activity was never digested mid-flight and the entities within it never reached SemanticMemory. The knowledge graph stayed sparse precisely for the longest, most context-rich topics — the exact shape this whole memory effort is meant to serve.
+
+This release wires the periodic `SessionActivitySentinel.scan()` (which already existed but was never scheduled) as an in-process timer. By default it runs every 30 minutes, digesting in-progress sessions that have accumulated new activity. Combined with the entity extraction above, the knowledge graph now grows throughout a long session, not only at its end.
+
+Details:
+
+1. New optional config `monitoring.episodicSentinel` with `enabled` (default true) and `scanIntervalMinutes` (default 30, floored at 5). Absent by default — existing agents get the 30-minute scan automatically.
+
+2. A new pure helper `resolveSentinelScanIntervalMs` computes the effective interval (default / floor / disabled), unit-tested independently of the server bootstrap.
+
+3. The scan timer is gated to the awake machine in a multi-machine setup (mirrors the scheduler gating), so standby machines don't double-digest. It `unref()`s so it never blocks process exit, and a failing scan is logged, never thrown.
+
+4. `scan()` itself is unchanged — it already enforces idempotency (hash-keyed digests), dormant-session skipping, and a minimum-activity threshold, so a 30-minute cadence is safe and idle sessions cost nothing.
+
+Tests: 6 new unit tests on the interval resolver (default, disabled, custom, floor-clamp). The 21 existing sentinel tests and 7 entity-extraction tests confirm scan() behaviour is unchanged.
+
+## What to Tell Your User (periodic scan)
+
+Your agent now keeps its memory current during long conversations, not just when they end. Every half hour it quietly reviews in-progress conversations that have new activity and files away the important facts. For a conversation that runs for days, this means the agent stays aware of decisions and facts from earlier in the same conversation instead of only catching up at the very end. It's on by default and costs nothing for idle conversations.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,37 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+<!-- minor = new agent-facing capability without breaking changes -->
+
+## What Changed
+
+**feat(memory): periodic activity-digest scan — digest long-running sessions mid-flight.**
+
+The activity-digest entity-extraction pipeline (shipped just prior) only ran when a session reached `sessionComplete`. For a long-running Telegram topic that runs for hours or days, or never cleanly ends (compaction, machine restart, watchdog kill), that meant the activity was never digested mid-flight and the entities within it never reached SemanticMemory. The knowledge graph stayed sparse precisely for the longest, most context-rich topics — the exact shape this memory effort is meant to serve.
+
+This release wires the periodic `SessionActivitySentinel.scan()` (which already existed but was never scheduled) as an in-process timer. By default it runs every 30 minutes, digesting in-progress sessions that have accumulated new activity. Combined with the entity extraction, the knowledge graph now grows throughout a long session, not only at its end.
+
+Details:
+
+1. New optional config `monitoring.episodicSentinel` with `enabled` (default true) and `scanIntervalMinutes` (default 30, floored at 5). Absent by default — existing agents get the 30-minute scan automatically.
+
+2. A new pure helper `resolveSentinelScanIntervalMs` computes the effective interval (default / floor / disabled), unit-tested independently of the server bootstrap.
+
+3. The scan timer is gated to the awake machine in a multi-machine setup (mirrors the scheduler gating), so standby machines don't double-digest. It `unref()`s so it never blocks process exit, and a failing scan is logged, never thrown.
+
+4. `scan()` itself is unchanged — it already enforces idempotency (hash-keyed digests), dormant-session skipping, and a minimum-activity threshold, so a 30-minute cadence is safe and idle sessions cost nothing.
+
+## Evidence
+
+6 new unit tests on the interval resolver (`tests/unit/sentinel-scan-interval.test.ts`): default 30 minutes, null when disabled, custom interval, 5-minute floor-clamp (at 1/0/negative), exact-floor. The 21 existing `session-activity-sentinel.test.ts` tests and 7 `SessionActivitySentinel-entity-extraction.test.ts` tests still pass — confirming `scan()` behaviour is unchanged. The wiring is in-process `setInterval` following the established relay-prune / resume-heartbeat timer pattern; `tsc --noEmit` clean.
+
+## What to Tell Your User
+
+Your agent now keeps its memory current during long conversations, not just when they end. Every half hour it quietly reviews in-progress conversations that have new activity and files away the important facts. For a conversation that runs for days, this means the agent stays aware of decisions and facts from earlier in the same conversation instead of only catching up at the very end. It's on by default and costs nothing for idle conversations.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Periodic mid-session activity digestion | Automatic — every 30 min (configurable via `monitoring.episodicSentinel.scanIntervalMinutes`) |
+| Disable / retune the cadence | Set `monitoring.episodicSentinel.enabled` false, or `scanIntervalMinutes` (floored at 5) |

--- a/upgrades/side-effects/feat-periodic-sentinel-scan.md
+++ b/upgrades/side-effects/feat-periodic-sentinel-scan.md
@@ -1,0 +1,65 @@
+# Side-Effects Review — feat(memory): periodic SessionActivitySentinel scan
+
+**Branch:** `echo/phase-0b-periodic-scan`
+**Origin:** Phase 0b of the topic-intent-layer thread (Telegram 9976). Last foundation piece before Phase 1.
+
+## Summary
+
+Wires the periodic `SessionActivitySentinel.scan()` (every 30 min default) as a `setInterval` in `server.ts`, gated to the awake machine. Previously the sentinel only fired on `sessionComplete`, so long-running sessions never got mid-flight digestion and the Phase 0d entity extraction never ran for them.
+
+## Files touched
+
+- `src/core/types.ts` — added optional `MonitoringConfig.episodicSentinel` ({ enabled?, scanIntervalMinutes? }).
+- `src/monitoring/SessionActivitySentinel.ts` — added pure helper `resolveSentinelScanIntervalMs`.
+- `src/commands/server.ts` — wired the periodic scan interval after the sessionComplete handler; imports the new helper.
+- `tests/unit/sentinel-scan-interval.test.ts` — 6 tests on the resolver.
+- `docs/specs/periodic-sentinel-scan.md` + `.eli16.md` — spec + ELI16.
+- `upgrades/NEXT.md` — release note.
+
+## Over-block check
+
+The scan only runs when `resolveSentinelScanIntervalMs` returns non-null (enabled !== false) AND (no coordinator OR the machine is awake). It does NOT run on standby machines. It does NOT add an immediate startup scan (first fire is one interval out), so restart loops don't trigger repeated digestion. No new behaviour in the disabled path — `enabled: false` returns null and no interval is created.
+
+## Under-block check
+
+Could a long session still be missed? Only if: the periodic scan is disabled by config AND the session never reaches sessionComplete. That's an explicit operator opt-out, not a silent gap. The default (on, 30 min) covers the case the spec targets.
+
+scan() itself enforces dormant-skip and minimum-activity internally, so an idle session that the timer visits costs nothing — no over-digestion of quiet sessions.
+
+## Level-of-abstraction fit
+
+The interval policy (default, floor, disabled) is a pure function on the sentinel module — testable in isolation, no server bootstrap needed. The actual `setInterval` lives in server.ts next to the existing sessionComplete wire and the other periodic timers (relayPrune, resumeHeartbeat), matching the established in-process-timer pattern. The sentinel class is unchanged — it already had scan(); we just call it on a cadence.
+
+## Signal-vs-authority compliance
+
+Not a gate — this is a scheduler wire, not a filter. The closest principle is the awake-machine gating: the coordinator (authority on which machine is active) decides whether this machine scans. The timer defers to `coordinator.isAwake` rather than making its own liveness call.
+
+## Interactions
+
+- **sessionComplete synthesis**: unchanged. The periodic scan and the completion synthesis are independent; scan()'s idempotency (hash-keyed digests) means a periodic scan immediately before sessionComplete won't double-digest the same activity window.
+- **scan() idempotency / dormant-skip / min-activity**: relied upon, unchanged. These guards are what make a 30-min cadence safe.
+- **SemanticMemory entity extraction (Phase 0d)**: this scan is what drives it mid-session. The two compose: scan → digestUnit → materializeEntities. No new coupling; the periodic scan just calls the same digestActivity path the sessionComplete handler already used.
+- **Multi-machine coordinator**: awake-gating added; mirrors `config.scheduler.enabled && coordinator.isAwake`. Standby machines skip.
+- **Scheduler / jobs.json**: untouched. This is an in-process timer, not a cron job, so it doesn't interact with quota-tracked job scheduling. (Note: the LLM spend of periodic digestion is NOT currently quota-gated the way scheduled jobs are — see follow-up.)
+
+## Telemetry / observability
+
+- A `console.log` fires on startup naming the cadence ("periodic scan every 30min").
+- Each scan that creates digests logs the count.
+- Failures log via console.error, never throw.
+- `SemanticMemory.stats()` entity/edge growth is the downstream signal that the pipeline is working end-to-end.
+
+## Rollback
+
+Single-commit revert removes the interval, the config field, and the helper. Reverts to sessionComplete-only — the pre-change behaviour. No data/config migration (the field is optional and absent by default).
+
+## Cross-framework portability (v1.0+)
+
+Framework-agnostic: the scan reads tmux capture + Telegram JSONL and digests via `sharedIntelligence`. No INSTAR_FRAMEWORK branching. Same cadence on Claude and Codex.
+
+## Follow-ups (tracked, not orphaned)
+
+1. **Quota-awareness for periodic digestion LLM spend.** Scheduled jobs route through QuotaTracker; this in-process timer does not. On a quota-constrained agent, periodic digestion competes with foreground work for the same budget. A future enhancement could check `quotaTracker.canRunJob` before each scan. Lower priority — digestion uses the cheap `fast` tier and dormant-skip keeps volume low.
+2. **Live runtime verification.** The spec's acceptance includes a manual live check (set 5-min cadence, send messages, confirm a digest appears mid-session). Requires a live multi-message session; noted for the next live-agent session.
+
+Both tracked as initiatives, intentionally out of scope here.


### PR DESCRIPTION
## Summary

Phase 0b of the topic-intent-layer thread. `SessionActivitySentinel.scan()` existed but was never scheduled — only `sessionComplete` triggered digestion. So long-running Telegram topics never got mid-flight digestion, and the Phase 0d entity extraction never ran for them. The knowledge graph stayed sparse precisely for the longest, most context-rich topics.

This wires the periodic scan as an in-process `setInterval` (default 30 min, awake-machine gated, `unref`'d, errors caught). A new pure helper `resolveSentinelScanIntervalMs` makes the cadence policy unit-testable. New optional `monitoring.episodicSentinel` config, default-on. `scan()` itself is unchanged — its idempotency / dormant-skip / minimum-activity guards make the cadence safe.

Composes with Phase 0d: scan → digestUnit → materializeEntities, so the knowledge graph now grows throughout a long session, not only at its end.

## Spec + ELI16
- Spec: `docs/specs/periodic-sentinel-scan.md` (single-iteration convergence; approved via Telegram 9976)
- ELI16: `docs/specs/periodic-sentinel-scan.eli16.md`
- Side-effects review: `upgrades/side-effects/feat-periodic-sentinel-scan.md`

## Test plan
- [x] 6 new unit tests on the interval resolver (default, disabled, custom, floor-clamp)
- [x] 21 existing sentinel + 7 entity-extraction tests pass
- [x] tsc clean; full pre-push suite passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)