### PR TITLE
feat(tunnel): TunnelManager rewrite — single owner of lifecycle + providers + notifier (PR 2 of chain)

### DIFF
--- a/specs/dev-infrastructure/tunnel-failure-resilience.eli16.md
+++ b/specs/dev-infrastructure/tunnel-failure-resilience.eli16.md
@@ -75,3 +75,4 @@ round confirmed convergence — no new material issues.
 
 The full technical spec lives in the parent document; this companion
 is what you read.
+

--- a/specs/dev-infrastructure/tunnel-failure-resilience.md
+++ b/specs/dev-infrastructure/tunnel-failure-resilience.md
@@ -7,7 +7,7 @@ review-convergence: "2026-05-22T20:30:00Z"
 review-completed-at: "2026-05-22T20:30:00Z"
 review-report: "docs/specs/reports/tunnel-failure-resilience-convergence.md"
 review-status: "converged at iteration 4 (internal iter1 + GPT iter2 + GPT verification iter3 + GPT verification iter4 returned CONVERGED — no new material issues). External Gemini round skipped per operator (local OAuth not viable in this env; Grok unavailable). eli16-overview embedded as the ELI16 Overview section at the top of the convergence report."
-eli16-overview: "specs/dev-infrastructure/tunnel-failure-resilience.eli16.md"
+eli16-overview: "tunnel-failure-resilience.eli16.md"
 approved: true
 ---
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7297,72 +7297,27 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log('[Housekeeping] Periodic cleanup completed');
     }, HOUSEKEEPING_INTERVAL_MS);
 
-    // Start tunnel AFTER server is listening (with retry on failure)
+    // Start tunnel AFTER server is listening.
+    //
+    // The TunnelManager is now the single owner of the detect → attempt →
+    // fall-back → notify lifecycle (per
+    // specs/dev-infrastructure/tunnel-failure-resilience.md). The old
+    // startup-retry ladder + background-retry scheduler + Lifeline
+    // failure message that used to live here are RETIRED; the manager
+    // handles backoff internally, schedules the post-exhausted self-heal
+    // retry, and (once the notifier sink is wired in the next PR of the
+    // chain) emits user-facing messages via the two-channel notifier.
+    //
+    // Failure on initial start is non-fatal: the manager keeps trying
+    // in the background, and the post-exhausted retry timer keeps the
+    // agent recoverable without requiring a server restart.
     if (tunnel) {
-      tunnel.enableAutoReconnect();
-      const maxRetries = 5;
-      let tunnelStarted = false;
-      for (let attempt = 1; attempt <= maxRetries; attempt++) {
-        try {
-          const tunnelUrl = await tunnel.start();
-          console.log(pc.green(`  Tunnel active: ${pc.bold(tunnelUrl)}`));
-          tunnelStarted = true;
-          break;
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (attempt < maxRetries) {
-            const delay = Math.min(15_000 * Math.pow(2, attempt - 1), 120_000); // 15s, 30s, 60s, 120s
-            console.log(pc.yellow(`  Tunnel failed (attempt ${attempt}/${maxRetries}): ${msg}`));
-            console.log(pc.yellow(`  Retrying in ${delay / 1000}s...`));
-            await new Promise(r => setTimeout(r, delay));
-          } else {
-            console.error(pc.red(`  Tunnel failed after ${maxRetries} attempts: ${msg}`));
-          }
-        }
-      }
-      // If tunnel didn't start, schedule background retries
-      if (!tunnelStarted) {
-        const retryIntervals = [5, 10, 20]; // minutes
-        console.log(pc.yellow(`  Will retry tunnel in ${retryIntervals[0]} minutes...`));
-        const scheduleRetry = (index: number) => {
-          if (index >= retryIntervals.length) return;
-          setTimeout(async () => {
-            try {
-              const tunnelUrl = await tunnel!.start();
-              console.log(pc.green(`[tunnel] Connected: ${tunnelUrl}`));
-              if (tunnelUrl) {
-                const tunnelType = (config.tunnel?.type || 'quick') as 'quick' | 'named';
-                if (telegram) {
-                  await telegram.broadcastDashboardUrl(tunnelUrl, tunnelType).catch(() => {});
-                }
-                if (_slackAdapter) {
-                  await _slackAdapter.broadcastDashboardUrl(tunnelUrl).catch(() => {});
-                }
-              }
-            } catch (retryErr) {
-              const msg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-              console.error(`[tunnel] Retry failed: ${msg}`);
-              if (index + 1 < retryIntervals.length) {
-                console.log(`[tunnel] Will retry in ${retryIntervals[index + 1]} minutes...`);
-                scheduleRetry(index + 1);
-              } else {
-                console.error('[tunnel] All retries exhausted. Tunnel unavailable until server restart.');
-                if (telegram) {
-                  try {
-                    const lifelineId = telegram.getLifelineTopicId?.();
-                    if (lifelineId) {
-                      await telegram.sendToTopic(
-                        lifelineId,
-                        '⚠️ Tunnel failed after all retries. Dashboard link is unavailable until the server is restarted.',
-                      ).catch(() => {});
-                    }
-                  } catch { /* best-effort notification */ }
-                }
-              }
-            }
-          }, retryIntervals[index] * 60_000);
-        };
-        scheduleRetry(0);
+      try {
+        const tunnelUrl = await tunnel.start();
+        console.log(pc.green(`  Tunnel active: ${pc.bold(tunnelUrl)}`));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(pc.red(`  Tunnel start failed (manager will keep retrying in background): ${msg}`));
       }
     }
 

--- a/src/tunnel/TunnelManager.ts
+++ b/src/tunnel/TunnelManager.ts
@@ -1,55 +1,88 @@
 /**
- * Cloudflare Tunnel manager for Instar agents.
+ * TunnelManager — single owner of the tunnel lifecycle.
  *
- * Manages cloudflared tunnel lifecycle — quick tunnels (zero-config,
- * ephemeral) and named tunnels (persistent, custom domain).
+ * Per spec specs/dev-infrastructure/tunnel-failure-resilience.md.
  *
- * Quick tunnels require no Cloudflare account. Named tunnels require
- * a tunnel token from the Cloudflare dashboard.
+ * Rewritten on top of the foundation modules:
+ *   - TunnelProvider — backend abstraction; concrete providers under
+ *     src/tunnel/Cloudflare*Provider.ts.
+ *   - TunnelLifecycle — single-writer CAS-guarded state machine.
+ *   - TunnelNotifier — two-channel routing (group / owner-DM) of
+ *     transition events.
  *
- * The tunnel exposes the agent's local HTTP server to the internet,
- * enabling:
- *   - Private content viewing (auth-gated rendered markdown)
- *   - Remote API access from anywhere
- *   - File serving (logs, reports, exports)
- *   - Webhook endpoints for external integrations
+ * The manager is the SOLE owner of the detect → attempt → fall-back →
+ * notify → self-heal lifecycle. The previous server.ts startup-retry
+ * ladder + background-retry ladder + Lifeline failure message are
+ * retired in favor of routing all retry through here (one backoff
+ * engine, not two).
+ *
+ * Scope of this rewrite (PR 2 of the chain):
+ *   - Tier-1 provider pool (Cloudflare named → quick) with internal
+ *     backoff between retries within an episode.
+ *   - Post-start reachability probe (HTTP /health through the public
+ *     URL) before declaring `active` — prevents broadcasting a "back
+ *     online" link that doesn't actually serve traffic.
+ *   - Backward-compatible public API: start(), stop(), forceStop(),
+ *     enableAutoReconnect(), disableAutoReconnect(), getExternalUrl(),
+ *     url/isRunning/state. Plus the existing events.
+ *   - Notifier sink optional; when telegram adapter is plumbed,
+ *     transition events route to the group topic.
+ *
+ * Out of scope for THIS PR (future PRs in the chain):
+ *   - Tier-2 consent flow + relay providers (PR 4).
+ *   - Owner-DM channel + inline-button consent UX (PR 3).
+ *   - authToken/PIN rotation + boot recovery (PR 5).
+ *   - Self-heal probe with N-consecutive-success stability gate (PR 6).
+ *   - The /tunnel route (PR 7).
+ *
+ * The lifecycle state machine already supports these states; the
+ * manager simply doesn't transition into them yet in PR 2.
  */
 
 import { EventEmitter } from 'node:events';
-import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { bin, install, Tunnel } from 'cloudflared';
+import {
+  TunnelLifecycle,
+  classifyFailure,
+  type PersistedTunnelState,
+  type TransitionEvent,
+} from './TunnelLifecycle.js';
+import type {
+  TunnelProvider,
+  TunnelProviderHandle,
+  ProviderName,
+  ProviderFailureReason,
+} from './TunnelProvider.js';
+import { CloudflareQuickProvider } from './CloudflareQuickProvider.js';
+import { CloudflareNamedProvider } from './CloudflareNamedProvider.js';
+import type { NotifierSink } from './TunnelNotifier.js';
+import { TunnelNotifier } from './TunnelNotifier.js';
 
-// ── Types ──────────────────────────────────────────────────────────
+// ── Types (back-compat) ─────────────────────────────────────────────
 
 export interface TunnelConfig {
-  /** Whether tunnel is enabled */
+  /** Whether tunnel is enabled. */
   enabled: boolean;
-  /** Tunnel type: 'quick' (ephemeral, no account) or 'named' (persistent, requires token) */
+  /** Tunnel type: 'quick' (ephemeral, no account) or 'named' (persistent, requires token). */
   type: 'quick' | 'named';
-  /** Cloudflare tunnel token (required for named tunnels using token auth) */
+  /** Cloudflare tunnel token (named, token-auth). */
   token?: string;
-  /** Config file path for named tunnels using credentials file auth */
+  /** Config file path (named, config-file-auth). */
   configFile?: string;
-  /** Public hostname for named tunnels (e.g., echo.dawn-tunnel.dev) */
+  /** Public hostname for named tunnels. */
   hostname?: string;
-  /** Local port to tunnel to */
+  /** Local port to tunnel to. */
   port: number;
-  /** State directory for persisting tunnel info */
+  /** State directory for persisting tunnel.json. */
   stateDir: string;
 }
 
 export interface TunnelState {
-  /** Current tunnel URL (null if not connected) */
   url: string | null;
-  /** Tunnel type */
   type: 'quick' | 'named';
-  /** When the tunnel was started */
   startedAt: string | null;
-  /** Connection info from cloudflared */
   connectionId?: string;
-  /** Connection location */
   connectionLocation?: string;
 }
 
@@ -61,488 +94,403 @@ export interface TunnelEvents {
   stopped: () => void;
 }
 
+/** Optional injections for testability. */
+export interface TunnelManagerInjections {
+  providers?: TunnelProvider[];
+  notifierSink?: NotifierSink;
+  fetch?: typeof fetch;
+}
+
+// ── Constants ───────────────────────────────────────────────────────
+
+const BASE_BACKOFF_MS = 5_000;
+const MAX_BACKOFF_MS = 5 * 60_000;
+const MAX_BACKOFF_ATTEMPTS = 10;
+const REACHABILITY_TIMEOUT_MS = 8_000;
+/**
+ * Post-exhausted retry cadence — the minimum-viable "self-heal"
+ * placeholder for PR 2. After the bounded startup-reconnect ladder
+ * exhausts (MAX_BACKOFF_ATTEMPTS), the manager keeps probing the
+ * Tier-1 pool at this cadence indefinitely. This is intentionally
+ * crude; PR 6 replaces it with the spec's N-consecutive-success
+ * stability-gate probe per Part 5. Without this placeholder, the
+ * agent stays link-less after exhaustion until restart — which is
+ * the regression we explicitly need to avoid in the PR chain.
+ */
+const POST_EXHAUSTED_RETRY_INTERVAL_MS = 15 * 60_000;
+
 // ── Manager ────────────────────────────────────────────────────────
 
 export class TunnelManager extends EventEmitter {
-  private config: TunnelConfig;
-  private tunnel: Tunnel | null = null;
-  private stateFile: string;
-  private _state: TunnelState;
-  private _stopped = false;
-  private _autoReconnect = false;
-  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private _reconnectAttempt = 0;
-  private _startPromise: Promise<string> | null = null; // Mutex: prevents concurrent start()
-  private static readonly MAX_RECONNECT_ATTEMPTS = 10;
-  private static readonly BASE_RECONNECT_DELAY_MS = 5_000;
-  private static readonly MAX_RECONNECT_DELAY_MS = 5 * 60_000;
+  private readonly config: TunnelConfig;
+  private readonly stateFile: string;
 
-  constructor(config: TunnelConfig) {
+  private readonly lifecycle: TunnelLifecycle;
+  private readonly providers: TunnelProvider[];
+  private readonly notifier: TunnelNotifier | null;
+  private readonly fetcher: typeof fetch;
+
+  private currentHandle: TunnelProviderHandle | null = null;
+  private currentProviderName: ProviderName | null = null;
+  private _legacyState: TunnelState;
+  private _autoReconnect = true; // always-on under the new design
+  private _stopped = false;
+  private _startPromise: Promise<string> | null = null;
+  private _backoffAttempt = 0;
+  private _backoffTimer: ReturnType<typeof setTimeout> | null = null;
+  private _postExhaustedTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(config: TunnelConfig, injections?: TunnelManagerInjections) {
     super();
     this.config = config;
     this.stateFile = path.join(config.stateDir, 'tunnel.json');
-    this._state = {
+    this.lifecycle = new TunnelLifecycle();
+    this.providers = injections?.providers ?? this.buildDefaultPool(config);
+    this.notifier = injections?.notifierSink
+      ? new TunnelNotifier({ sink: injections.notifierSink })
+      : null;
+    this.fetcher = injections?.fetch ?? globalThis.fetch.bind(globalThis);
+
+    this._legacyState = {
       url: null,
       type: config.type,
       startedAt: null,
     };
+
+    // Route lifecycle transitions through the notifier.
+    this.lifecycle.on('transition', (e: TransitionEvent) => {
+      if (this.notifier) void this.notifier.onTransition(e);
+    });
+
+    // Restore persisted snapshot (rotation-pending flag + consent cooldown).
+    this.restorePersisted();
   }
 
-  /** Current tunnel URL, or null if not connected */
-  get url(): string | null {
-    return this._state.url;
-  }
+  // ── Public API (back-compat with the legacy manager) ────────────
 
-  /** Whether the tunnel is currently running */
-  get isRunning(): boolean {
-    return this.tunnel !== null && !this._stopped;
-  }
+  get url(): string | null { return this._legacyState.url; }
 
-  /** Current tunnel state */
-  get state(): TunnelState {
-    return { ...this._state };
+  get isRunning(): boolean { return this.currentHandle !== null && !this._stopped; }
+
+  get state(): TunnelState { return { ...this._legacyState }; }
+
+  /** Additive new accessor — lifecycle snapshot. */
+  get lifecycleState(): PersistedTunnelState {
+    const snap = this.lifecycle.snapshot();
+    snap.lastUrl = this._legacyState.url;
+    return snap;
   }
 
   /**
-   * Start the tunnel. Ensures the cloudflared binary is installed,
-   * then starts the appropriate tunnel type.
+   * Start the tunnel. Drives the full Tier-1 ladder internally — the
+   * caller does NOT wrap with its own retry loop (the old server.ts
+   * startup ladder is RETIRED).
+   *
+   * Resolves with the URL of the first provider that reaches `active`.
+   * Rejects when all Tier-1 providers fail and backoff is exhausted.
    */
   async start(): Promise<string> {
-    // Mutex: if a start is already in progress, return the same promise
-    // This prevents concurrent start() calls from the SleepWake handler
-    // and auto-reconnect racing each other.
-    if (this._startPromise) {
-      return this._startPromise;
-    }
-
-    // If tunnel is already running, return the current URL
-    if (this.tunnel && this._state.url) {
-      return this._state.url;
-    }
-
+    if (this._startPromise) return this._startPromise;
+    if (this.currentHandle && this._legacyState.url) return this._legacyState.url;
     this._stopped = false;
-
-    const doStart = async (): Promise<string> => {
-      try {
-        // Ensure cloudflared binary is installed
-        await this.ensureBinary();
-
-        // Start the appropriate tunnel type
-        if (this.config.type === 'named') {
-          if (!this.config.token && !this.config.configFile) {
-            throw new Error('Named tunnel requires either a token or a configFile. Set tunnel.token or tunnel.configFile in config.');
-          }
-          if (this.config.configFile) {
-            return await this.startConfigFileTunnel();
-          }
-          return await this.startNamedTunnel();
-        } else {
-          return await this.startQuickTunnel();
-        }
-      } finally {
-        this._startPromise = null;
-      }
-    };
-
-    this._startPromise = doStart();
+    this._startPromise = this.doStart().finally(() => { this._startPromise = null; });
     return this._startPromise;
   }
 
-  /**
-   * Stop the tunnel gracefully. Intentional stops disable auto-reconnect.
-   */
   async stop(): Promise<void> {
     this._stopped = true;
-    this._startPromise = null; // Cancel any in-flight start
-    if (this._reconnectTimer) {
-      clearTimeout(this._reconnectTimer);
-      this._reconnectTimer = null;
+    this.clearBackoffTimer();
+    this.clearPostExhaustedTimer();
+    this._startPromise = null;
+
+    if (this.currentHandle) {
+      try { await this.currentHandle.stop(); } catch { /* handle may be dead */ }
+      this.currentHandle = null;
     }
-    this._reconnectAttempt = 0;
-    if (this.tunnel) {
-      this.tunnel.stop();
-      this.tunnel = null;
+
+    this._legacyState.url = null;
+    this._legacyState.startedAt = null;
+    this.currentProviderName = null;
+
+    const from = this.lifecycle.state;
+    if (from !== 'idle') {
+      try { this.lifecycle.transition(from, 'idle', { activeProvider: null }); }
+      catch { /* invalid pair — best-effort */ }
     }
-    this._state.url = null;
-    this._state.startedAt = null;
-    this.saveState();
+
+    this.persist();
     this.emit('stopped');
   }
 
-  /**
-   * Force-stop the tunnel with a timeout. If cloudflared doesn't respond to
-   * SIGINT within `timeoutMs`, escalate to SIGKILL. Essential for sleep/wake
-   * recovery where cloudflared may be a zombie process.
-   */
-  async forceStop(timeoutMs = 5000): Promise<void> {
-    this._stopped = true;
-    this._startPromise = null; // Cancel any in-flight start
-    if (this._reconnectTimer) {
-      clearTimeout(this._reconnectTimer);
-      this._reconnectTimer = null;
-    }
-    this._reconnectAttempt = 0;
-
-    if (this.tunnel) {
-      const tunnelProcess = this.tunnel.process;
-      const pid = tunnelProcess?.pid;
-
-      // Send SIGINT (graceful)
-      try { this.tunnel.stop(); } catch { /* may already be dead */ }
-
-      if (pid) {
-        // Wait for process to exit, escalate to SIGKILL if it doesn't
-        const exited = await new Promise<boolean>((resolve) => {
-          const timer = setTimeout(() => resolve(false), timeoutMs);
-          // Check if process is already dead
-          try {
-            process.kill(pid, 0);
-          } catch {
-            clearTimeout(timer);
-            resolve(true);
-            return;
-          }
-          // Poll for exit
-          const poll = setInterval(() => {
-            try {
-              process.kill(pid, 0);
-            } catch {
-              clearInterval(poll);
-              clearTimeout(timer);
-              resolve(true);
-            }
-          }, 200);
-        });
-
-        if (!exited) {
-          console.warn(`[Tunnel] cloudflared (PID ${pid}) didn't exit after ${timeoutMs}ms SIGINT — sending SIGKILL`);
-          try { process.kill(pid, 'SIGKILL'); } catch { /* already dead */ }
-        }
-      }
-
-      this.tunnel = null;
-    }
-
-    this._state.url = null;
-    this._state.startedAt = null;
-    this.saveState();
-    this.emit('stopped');
+  /** Force-stop with escalation. Providers internally do SIGINT → SIGKILL. */
+  async forceStop(_timeoutMs?: number): Promise<void> {
+    await this.stop();
   }
 
-  /**
-   * Enable automatic reconnection when the tunnel disconnects unexpectedly.
-   * Uses exponential backoff: 5s, 10s, 20s, ... up to 5 minutes, max 10 attempts.
-   */
-  enableAutoReconnect(): void {
-    this._autoReconnect = true;
-  }
+  enableAutoReconnect(): void { this._autoReconnect = true; }
 
   disableAutoReconnect(): void {
     this._autoReconnect = false;
-    if (this._reconnectTimer) {
-      clearTimeout(this._reconnectTimer);
-      this._reconnectTimer = null;
-    }
-    this._reconnectAttempt = 0;
+    this.clearBackoffTimer();
   }
 
-  /**
-   * Attempt to reconnect the tunnel with exponential backoff.
-   */
-  private attemptReconnect(): void {
-    if (!this._autoReconnect || this._stopped) return;
-    // Skip if a start is already in progress (e.g., SleepWake handler is restarting)
-    if (this._startPromise) return;
-    if (this._reconnectAttempt >= TunnelManager.MAX_RECONNECT_ATTEMPTS) {
-      console.error(`[Tunnel] Auto-reconnect gave up after ${this._reconnectAttempt} attempts`);
-      this.emit('error', new Error(`Tunnel auto-reconnect failed after ${this._reconnectAttempt} attempts`));
-      return;
-    }
-
-    const delay = Math.min(
-      TunnelManager.BASE_RECONNECT_DELAY_MS * Math.pow(2, this._reconnectAttempt),
-      TunnelManager.MAX_RECONNECT_DELAY_MS,
-    );
-    this._reconnectAttempt++;
-
-    console.log(`[Tunnel] Auto-reconnect attempt ${this._reconnectAttempt}/${TunnelManager.MAX_RECONNECT_ATTEMPTS} in ${delay / 1000}s`);
-
-    this._reconnectTimer = setTimeout(async () => {
-      if (this._stopped) return;
-      try {
-        const url = await this.start();
-        console.log(`[Tunnel] Auto-reconnected: ${url}`);
-        this._reconnectAttempt = 0;
-      } catch (err) {
-        console.error(`[Tunnel] Auto-reconnect failed:`, err instanceof Error ? err.message : err);
-        this.attemptReconnect();
-      }
-    }, delay);
-  }
-
-  /**
-   * Get the full external URL for a local path.
-   * Returns null if tunnel is not connected.
-   */
   getExternalUrl(localPath: string): string | null {
-    if (!this._state.url) return null;
-    const base = this._state.url.replace(/\/$/, '');
+    if (!this._legacyState.url) return null;
+    const base = this._legacyState.url.replace(/\/$/, '');
     const p = localPath.startsWith('/') ? localPath : `/${localPath}`;
     return `${base}${p}`;
   }
 
-  // ── Internal ───────────────────────────────────────────────────
+  // ── Internals ──────────────────────────────────────────────────
 
-  private async ensureBinary(): Promise<void> {
-    if (!fs.existsSync(bin)) {
-      await install(bin);
+  private buildDefaultPool(config: TunnelConfig): TunnelProvider[] {
+    const pool: TunnelProvider[] = [];
+    if (config.token || config.configFile) {
+      pool.push(new CloudflareNamedProvider({
+        token: config.token,
+        configFile: config.configFile,
+        hostname: config.hostname,
+      }));
+    }
+    pool.push(new CloudflareQuickProvider({ port: config.port, stateDir: config.stateDir }));
+    return pool;
+  }
+
+  private async doStart(): Promise<string> {
+    if (!this.config.enabled) throw new Error('tunnel.enabled is false');
+
+    if (this.lifecycle.state === 'idle' || this.lifecycle.state === 'active') {
+      this.lifecycle.startEpisode();
+    }
+
+    if (!this.lifecycle.transition('idle', 'starting')) {
+      if (this.lifecycle.state === 'starting' || this.lifecycle.state === 'active') {
+        if (this._legacyState.url) return this._legacyState.url;
+      }
+      throw new Error(`cannot start: lifecycle in state ${this.lifecycle.state}`);
+    }
+
+    return this.driveTier1();
+  }
+
+  private async driveTier1(): Promise<string> {
+    let lastErr: Error | null = null;
+
+    for (let i = 0; i < this.providers.length; i++) {
+      if (this._stopped) throw new Error('tunnel start aborted: stopped');
+      const provider = this.providers[i];
+      if (!provider) continue;
+      if (provider.tier !== 1) continue; // Tier-2 deferred to PR 4
+
+      const available = await provider.isAvailable().catch(() => false);
+      if (!available) continue;
+
+      try {
+        const handle = await provider.start(this.config.port);
+
+        // Reachability probe BEFORE declaring active.
+        const reachable = await this.probeReachability(handle.url).catch(() => false);
+        if (!reachable) {
+          try { await handle.stop(); } catch { /* best effort */ }
+          this.lifecycle.recordAttempt(provider.name, 'reachability-failed');
+          lastErr = new Error(`reachability-failed: ${provider.name} URL did not respond to /health`);
+          continue;
+        }
+
+        // Success.
+        this.currentHandle = handle;
+        this.currentProviderName = provider.name;
+        this._legacyState.url = handle.url;
+        this._legacyState.startedAt = new Date().toISOString();
+
+        const from = this.lifecycle.state;
+        if (from === 'starting' || from === 'retrying') {
+          this.lifecycle.transition(from, 'active', {
+            activeProvider: provider.name,
+            lastFailureReason: null,
+          });
+        }
+
+        // Persist AFTER the transition so the snapshot reflects 'active'.
+        this.persist();
+
+        this.emit('url', handle.url);
+        this._backoffAttempt = 0;
+        return handle.url;
+      } catch (err) {
+        const reason = classifyFailure(err);
+        this.lifecycle.recordAttempt(provider.name, reason);
+        lastErr = err instanceof Error ? err : new Error(String(err));
+
+        if (this.lifecycle.state === 'starting') {
+          this.lifecycle.transition('starting', 'retrying', {
+            activeProvider: null,
+            lastFailureReason: reason,
+          });
+        }
+      }
+    }
+
+    // All Tier-1 providers exhausted in this attempt round.
+    return this.exhaustedOrBackoff(lastErr);
+  }
+
+  private async exhaustedOrBackoff(lastErr: Error | null): Promise<string> {
+    // Matches the legacy semantics: start() rejects after the FIRST
+    // round of provider attempts fails. The backoff retry runs in the
+    // background — the manager keeps trying without blocking the
+    // caller, and emits 'url' when a later attempt succeeds. This
+    // prevents start() from blocking server.ts boot for the full
+    // 25-minute worst-case exponential window. The original failing
+    // E2E (tests/e2e/tunnel-private-view.test.ts) timed out at the
+    // beforeAll 60s budget because the old draft kept retrying inside
+    // start().
+    const from = this.lifecycle.state;
+    if (from === 'retrying' || from === 'starting') {
+      this.lifecycle.transition(from, 'exhausted', { activeProvider: null });
+    }
+
+    const err = lastErr ?? new Error('all Tier-1 providers failed');
+
+    // Schedule background retry (bounded exponential ladder, then the
+    // indefinite post-exhausted placeholder once the ladder runs out).
+    // Fire-and-forget; if a later attempt succeeds, the 'url' event
+    // fires and downstream subscribers (notifier, dashboard
+    // broadcaster, log line) catch up.
+    if (this._autoReconnect && !this._stopped) {
+      this.scheduleBackgroundRetry();
+    }
+
+    this.emit('error', err);
+    throw err;
+  }
+
+  /**
+   * Background retry — runs the bounded exponential ladder off the
+   * start() promise so initial start() resolves/rejects fast. After
+   * the ladder exhausts, hands off to the indefinite post-exhausted
+   * placeholder (the PR 2 self-heal; PR 6 replaces with the spec's
+   * N-consecutive-success probe).
+   */
+  private scheduleBackgroundRetry(): void {
+    if (this._stopped || !this._autoReconnect) return;
+    if (this._backoffTimer) return; // already scheduled
+
+    if (this._backoffAttempt >= MAX_BACKOFF_ATTEMPTS) {
+      this.schedulePostExhaustedRetry();
+      return;
+    }
+
+    const delay = Math.min(BASE_BACKOFF_MS * Math.pow(2, this._backoffAttempt), MAX_BACKOFF_MS);
+    this._backoffAttempt += 1;
+
+    this._backoffTimer = setTimeout(() => {
+      this._backoffTimer = null;
+      if (this._stopped || !this._autoReconnect) return;
+      const from = this.lifecycle.state;
+      try {
+        if (from === 'exhausted') {
+          this.lifecycle.transition('exhausted', 'starting');
+        } else if (from === 'idle') {
+          this.lifecycle.transition('idle', 'starting');
+        } else if (from === 'retrying') {
+          this.lifecycle.transition('retrying', 'starting');
+        } else {
+          return; // unexpected state; bail
+        }
+      } catch {
+        return; // invalid transition; bail
+      }
+      void this.driveTier1().catch(() => { /* scheduleBackgroundRetry already chained */ });
+    }, delay);
+  }
+
+  private clearBackoffTimer(): void {
+    if (this._backoffTimer) {
+      clearTimeout(this._backoffTimer);
+      this._backoffTimer = null;
+    }
+    this._backoffAttempt = 0;
+  }
+
+  private clearPostExhaustedTimer(): void {
+    if (this._postExhaustedTimer) {
+      clearTimeout(this._postExhaustedTimer);
+      this._postExhaustedTimer = null;
     }
   }
 
-  private startQuickTunnel(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const localUrl = `http://127.0.0.1:${this.config.port}`;
-
-      try {
-        // Write an empty config to prevent cloudflared from loading
-        // ~/.cloudflared/config.yml, which may contain named tunnel
-        // ingress rules that override the quick tunnel's --url proxy.
-        const emptyConfig = path.join(this.config.stateDir, 'cloudflared-quick.yml');
-        const dir = path.dirname(emptyConfig);
-        if (!fs.existsSync(dir)) {
-          fs.mkdirSync(dir, { recursive: true });
-        }
-        fs.writeFileSync(emptyConfig, '# Quick tunnel — no ingress rules\n');
-        this.tunnel = Tunnel.quick(localUrl, { '--config': emptyConfig });
-      } catch (err) {
-        reject(new Error(`Failed to start quick tunnel: ${err instanceof Error ? err.message : String(err)}`));
+  /**
+   * Minimum-viable post-exhausted retry (PR 2 self-heal placeholder).
+   * Schedules a single low-frequency probe; on completion (success or
+   * failure) it re-arms itself, so the agent keeps trying to recover
+   * even after the bounded startup-reconnect ladder gives up. PR 6
+   * replaces this with the spec's N-consecutive-success stability gate.
+   */
+  private schedulePostExhaustedRetry(): void {
+    if (this._stopped || !this._autoReconnect) return;
+    if (this._postExhaustedTimer) return; // already scheduled
+    this._postExhaustedTimer = setTimeout(async () => {
+      this._postExhaustedTimer = null;
+      if (this._stopped || !this._autoReconnect) return;
+      // Re-enter from exhausted → starting.
+      const from = this.lifecycle.state;
+      if (from === 'exhausted') {
+        try { this.lifecycle.transition('exhausted', 'starting'); }
+        catch { /* invalid transition — bail */ return; }
+      } else if (from !== 'starting' && from !== 'idle') {
+        // State moved beyond our reach; let the active path handle it.
         return;
       }
-
-      let resolved = false;
-      const timeout = setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          reject(new Error('Tunnel connection timed out after 30 seconds'));
-        }
-      }, 30_000);
-
-      this.tunnel.once('url', (url: string) => {
-        if (resolved) return;
-        resolved = true;
-        clearTimeout(timeout);
-
-        this._state.url = url;
-        this._state.startedAt = new Date().toISOString();
-        this.saveState();
-        this.emit('url', url);
-        resolve(url);
-      });
-
-      this.tunnel.once('connected', (info: { id: string; ip: string; location: string }) => {
-        this._state.connectionId = info.id;
-        this._state.connectionLocation = info.location;
-        this.saveState();
-        this.emit('connected', info);
-      });
-
-      this.tunnel.on('error', (err: Error) => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeout);
-          reject(err);
-        }
-        this.emit('error', err);
-      });
-
-      this.tunnel.on('exit', (code: number | null) => {
-        if (!this._stopped) {
-          this.tunnel = null;
-          this._state.url = null;
-          this.saveState();
-          this.emit('disconnected');
-          if (!resolved) {
-            resolved = true;
-            clearTimeout(timeout);
-            reject(new Error(`Tunnel process exited with code ${code}`));
-          } else {
-            // Tunnel was running and disconnected unexpectedly — try to reconnect
-            this.attemptReconnect();
-          }
-        }
-      });
-    });
+      this._backoffAttempt = 0;
+      this.driveTier1().then(
+        () => { /* success — 'url' event already fired */ },
+        () => { /* fail — driveTier1 already re-scheduled via this same path */ },
+      );
+    }, POST_EXHAUSTED_RETRY_INTERVAL_MS);
   }
 
-  private startNamedTunnel(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      try {
-        this.tunnel = Tunnel.withToken(this.config.token!);
-      } catch (err) {
-        reject(new Error(`Failed to start named tunnel: ${err instanceof Error ? err.message : String(err)}`));
-        return;
-      }
-
-      let resolved = false;
-      const timeout = setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          reject(new Error('Named tunnel connection timed out after 30 seconds'));
-        }
-      }, 30_000);
-
-      this.tunnel.once('url', (url: string) => {
-        if (resolved) return;
-        resolved = true;
-        clearTimeout(timeout);
-
-        this._state.url = url;
-        this._state.startedAt = new Date().toISOString();
-        this.saveState();
-        this.emit('url', url);
-        resolve(url);
+  /** HTTP probe through the public URL — confirms the link actually serves. */
+  private async probeReachability(url: string): Promise<boolean> {
+    try {
+      const controller = new AbortController();
+      const t = setTimeout(() => controller.abort(), REACHABILITY_TIMEOUT_MS);
+      const res = await this.fetcher(`${url.replace(/\/$/, '')}/health`, {
+        signal: controller.signal,
       });
-
-      this.tunnel.once('connected', (info: { id: string; ip: string; location: string }) => {
-        this._state.connectionId = info.id;
-        this._state.connectionLocation = info.location;
-        this.saveState();
-        this.emit('connected', info);
-
-        // For named tunnels, the URL may come from the connection info
-        // rather than the 'url' event, since the URL is pre-configured
-        if (!resolved && this._state.url) {
-          resolved = true;
-          clearTimeout(timeout);
-          resolve(this._state.url);
-        }
-      });
-
-      this.tunnel.on('error', (err: Error) => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeout);
-          reject(err);
-        }
-        this.emit('error', err);
-      });
-
-      this.tunnel.on('exit', (code: number | null) => {
-        if (!this._stopped) {
-          this.tunnel = null;
-          this._state.url = null;
-          this.saveState();
-          this.emit('disconnected');
-          if (!resolved) {
-            resolved = true;
-            clearTimeout(timeout);
-            reject(new Error(`Named tunnel process exited with code ${code}`));
-          } else {
-            this.attemptReconnect();
-          }
-        }
-      });
-    });
+      clearTimeout(t);
+      return res.ok;
+    } catch {
+      return false;
+    }
   }
 
-  private startConfigFileTunnel(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const configFile = this.config.configFile!;
-      const hostname = this.config.hostname;
+  // ── Persistence ──────────────────────────────────────────────────
 
-      if (!fs.existsSync(configFile)) {
-        reject(new Error(`Tunnel config file not found: ${configFile}`));
-        return;
-      }
-
-      // Spawn cloudflared directly with the config file
-      const child = spawn(bin, ['tunnel', '--config', configFile, 'run'], {
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-
-      let resolved = false;
-      let stderrBuffer = '';
-      const timeout = setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          // Named tunnels with config files don't emit a URL — the URL is the hostname
-          if (hostname) {
-            const url = `https://${hostname}`;
-            this._state.url = url;
-            this._state.startedAt = new Date().toISOString();
-            this.saveState();
-            this.emit('url', url);
-            resolve(url);
-          } else {
-            reject(new Error('Named tunnel timed out and no hostname configured'));
-          }
-        }
-      }, 15_000);
-
-      // Watch stderr for connection established messages
-      child.stderr.on('data', (data: Buffer) => {
-        const line = data.toString();
-        stderrBuffer += line;
-
-        // cloudflared logs connection info to stderr
-        if (line.includes('Registered tunnel connection') || line.includes('Connection registered')) {
-          if (!resolved && hostname) {
-            resolved = true;
-            clearTimeout(timeout);
-            const url = `https://${hostname}`;
-            this._state.url = url;
-            this._state.startedAt = new Date().toISOString();
-            this.saveState();
-            this.emit('url', url);
-            resolve(url);
-          }
-        }
-      });
-
-      child.on('error', (err: Error) => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeout);
-          reject(new Error(`Failed to start config-file tunnel: ${err.message}`));
-        }
-      });
-
-      child.on('exit', (code: number | null) => {
-        if (!this._stopped) {
-          this.tunnel = null;
-          this._state.url = null;
-          this.saveState();
-          this.emit('disconnected');
-          if (!resolved) {
-            resolved = true;
-            clearTimeout(timeout);
-            const errContext = stderrBuffer.slice(-500);
-            reject(new Error(`Config-file tunnel exited with code ${code}: ${errContext}`));
-          } else {
-            this.attemptReconnect();
-          }
-        }
-      });
-
-      // Store reference for cleanup — wrap in a Tunnel-like interface
-      this.tunnel = {
-        stop: () => { child.kill('SIGTERM'); },
-        once: () => {},
-        on: () => {},
-        emit: () => false,
-      } as unknown as Tunnel;
-    });
-  }
-
-  private saveState(): void {
+  private persist(): void {
     try {
       const dir = path.dirname(this.stateFile);
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
-      }
-      fs.writeFileSync(this.stateFile, JSON.stringify(this._state, null, 2));
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const snap = this.lifecycle.snapshot();
+      snap.lastUrl = this._legacyState.url;
+      fs.writeFileSync(this.stateFile, JSON.stringify(snap, null, 2));
     } catch {
-      // Non-critical — don't crash if state save fails
+      // Non-critical.
+    }
+  }
+
+  private restorePersisted(): void {
+    try {
+      if (!fs.existsSync(this.stateFile)) return;
+      const raw = fs.readFileSync(this.stateFile, 'utf-8');
+      const snap = JSON.parse(raw) as PersistedTunnelState;
+      if (snap && typeof snap === 'object') {
+        this.lifecycle.restoreFrom(snap);
+      }
+    } catch {
+      // Corrupted state file — start fresh.
     }
   }
 }
+
+export type { ProviderFailureReason };

--- a/tests/unit/tunnel-manager-rewrite.test.ts
+++ b/tests/unit/tunnel-manager-rewrite.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Unit tests for the rewritten TunnelManager (PR 2 of the
+ * tunnel-failure-resilience chain).
+ *
+ * Spec: specs/dev-infrastructure/tunnel-failure-resilience.md.
+ *
+ * Strategy: inject mock providers + mock fetch + mock notifier sink
+ * to drive the manager through its state transitions without
+ * spawning real cloudflared. The provider mocks return controllable
+ * URLs / errors; the fetch mock returns Response objects with the
+ * status the manager's reachability probe expects.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TunnelManager } from '../../src/tunnel/TunnelManager.js';
+import type {
+  TunnelProvider,
+  TunnelProviderHandle,
+  ProviderName,
+  ProviderTier,
+} from '../../src/tunnel/TunnelProvider.js';
+import type { NotifierSink } from '../../src/tunnel/TunnelNotifier.js';
+
+function tmpStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tunnel-mgr-'));
+}
+
+interface MockProviderOpts {
+  name: ProviderName;
+  tier?: ProviderTier;
+  available?: boolean;
+  startResult?: 'success' | { error: string };
+  url?: string;
+  stop?: () => Promise<void>;
+}
+
+function mockProvider(opts: MockProviderOpts): TunnelProvider {
+  const tier: ProviderTier = opts.tier ?? 1;
+  return {
+    name: opts.name,
+    tier,
+    isAvailable: vi.fn(async () => opts.available !== false),
+    start: vi.fn(async (): Promise<TunnelProviderHandle> => {
+      if (opts.startResult && typeof opts.startResult === 'object') {
+        throw new Error(opts.startResult.error);
+      }
+      return {
+        url: opts.url ?? `https://${opts.name}.example`,
+        stop: opts.stop ?? (async () => undefined),
+      };
+    }),
+  };
+}
+
+function okResponse(): Response {
+  return new Response('ok', { status: 200 });
+}
+
+function badResponse(): Response {
+  return new Response('bad', { status: 500 });
+}
+
+const baseConfig = {
+  enabled: true,
+  type: 'quick' as const,
+  port: 4040,
+  stateDir: '',
+};
+
+let stateDir: string;
+beforeEach(() => { stateDir = tmpStateDir(); });
+afterEach(() => {
+  try {
+    SafeFsExecutor.safeRmSync(stateDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/tunnel-manager-rewrite.test.ts:cleanup',
+    });
+  } catch { /* ignore */ }
+});
+
+describe('TunnelManager (rewrite) — Tier-1 happy path', () => {
+  it('drives the first available provider and resolves with its URL', async () => {
+    const named = mockProvider({ name: 'cloudflare-named', url: 'https://named.example' });
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [named, quick], fetch: vi.fn(async () => okResponse()) },
+    );
+    const url = await mgr.start();
+    expect(url).toBe('https://named.example');
+    expect(mgr.url).toBe('https://named.example');
+    expect(mgr.isRunning).toBe(true);
+    expect(named.start).toHaveBeenCalledTimes(1);
+    expect(quick.start).not.toHaveBeenCalled();
+  });
+
+  it('skips an unavailable provider and falls through to the next', async () => {
+    const named = mockProvider({ name: 'cloudflare-named', available: false });
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [named, quick], fetch: vi.fn(async () => okResponse()) },
+    );
+    const url = await mgr.start();
+    expect(url).toBe('https://quick.example');
+    expect(named.start).not.toHaveBeenCalled();
+    expect(quick.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists the lifecycle snapshot to tunnel.json on success', async () => {
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [quick], fetch: vi.fn(async () => okResponse()) },
+    );
+    await mgr.start();
+    const persisted = JSON.parse(fs.readFileSync(path.join(stateDir, 'tunnel.json'), 'utf-8'));
+    expect(persisted.lastUrl).toBe('https://quick.example');
+    expect(persisted.lastState).toBe('active');
+    expect(persisted.activeProvider).toBe('cloudflare-quick');
+  });
+});
+
+describe('TunnelManager (rewrite) — reachability probe', () => {
+  it('rejects a provider whose URL does not pass /health and falls through', async () => {
+    const named = mockProvider({ name: 'cloudflare-named', url: 'https://broken.example' });
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const fetch = vi.fn(async (req: string) => {
+      if (req.includes('broken.example')) return badResponse();
+      return okResponse();
+    });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [named, quick], fetch },
+    );
+    const url = await mgr.start();
+    expect(url).toBe('https://quick.example');
+    expect(named.start).toHaveBeenCalledTimes(1);
+    expect(quick.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down the failed provider before trying the next', async () => {
+    const stop = vi.fn(async () => undefined);
+    const named = mockProvider({ name: 'cloudflare-named', url: 'https://broken.example', stop });
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const fetch = vi.fn(async (req: string) =>
+      req.includes('broken.example') ? badResponse() : okResponse());
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [named, quick], fetch },
+    );
+    await mgr.start();
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TunnelManager (rewrite) — provider failure → next provider', () => {
+  it('classifies a rate-limit failure and tries the next provider', async () => {
+    const named = mockProvider({
+      name: 'cloudflare-named',
+      startResult: { error: 'rate-limited: 429 too many requests' },
+    });
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [named, quick], fetch: vi.fn(async () => okResponse()) },
+    );
+    const url = await mgr.start();
+    expect(url).toBe('https://quick.example');
+    const snap = mgr.lifecycleState;
+    expect(snap.episode?.attemptedProviders).toContain('cloudflare-named');
+  });
+
+  it('records each failed attempt against the current episode', async () => {
+    const a = mockProvider({ name: 'cloudflare-named', startResult: { error: 'rate-limited: 1015' } });
+    const b = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [a, b], fetch: vi.fn(async () => okResponse()) },
+    );
+    await mgr.start();
+    const snap = mgr.lifecycleState;
+    expect(snap.episode?.tier1Attempts).toBe(1);
+    expect(snap.episode?.lastFailureReason).toBe('rate-limited');
+  });
+});
+
+describe('TunnelManager (rewrite) — stop + back-compat surface', () => {
+  it('stop() transitions to idle and emits stopped', async () => {
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [quick], fetch: vi.fn(async () => okResponse()) },
+    );
+    await mgr.start();
+    const stopped = new Promise<void>((resolve) => mgr.once('stopped', () => resolve()));
+    await mgr.stop();
+    await stopped;
+    expect(mgr.isRunning).toBe(false);
+    expect(mgr.url).toBeNull();
+  });
+
+  it('forceStop() behaves like stop()', async () => {
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [quick], fetch: vi.fn(async () => okResponse()) },
+    );
+    await mgr.start();
+    await mgr.forceStop();
+    expect(mgr.isRunning).toBe(false);
+  });
+
+  it('getExternalUrl returns the absolute URL when up, null when down', async () => {
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [quick], fetch: vi.fn(async () => okResponse()) },
+    );
+    expect(mgr.getExternalUrl('/foo')).toBeNull();
+    await mgr.start();
+    expect(mgr.getExternalUrl('/foo')).toBe('https://quick.example/foo');
+    expect(mgr.getExternalUrl('bar')).toBe('https://quick.example/bar');
+  });
+
+  it('enableAutoReconnect / disableAutoReconnect retain back-compat behavior', () => {
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [quick] },
+    );
+    expect(() => mgr.enableAutoReconnect()).not.toThrow();
+    expect(() => mgr.disableAutoReconnect()).not.toThrow();
+  });
+
+  it('start() returns the same URL on repeat calls while running', async () => {
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [quick], fetch: vi.fn(async () => okResponse()) },
+    );
+    const a = await mgr.start();
+    const b = await mgr.start();
+    expect(a).toBe(b);
+    expect(quick.start).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TunnelManager (rewrite) — notifier wiring', () => {
+  it('emits a transition event to the notifier sink on successful start', async () => {
+    const sink: NotifierSink = {
+      sendGroup: vi.fn(async () => undefined),
+      sendOwnerDM: vi.fn(async () => undefined),
+    };
+    const quick = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [quick], fetch: vi.fn(async () => okResponse()), notifierSink: sink },
+    );
+    await mgr.start();
+    // The first 'starting' → 'active' transition is the initial startup; the
+    // notifier composes nothing user-visible for it (initial startup is a
+    // non-event from the user's perspective). No group/DM messages expected.
+    expect((sink.sendGroup as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+  });
+
+  it('emits a group message when an episode advances retrying after a failure', async () => {
+    const sink: NotifierSink = {
+      sendGroup: vi.fn(async () => undefined),
+      sendOwnerDM: vi.fn(async () => undefined),
+    };
+    const a = mockProvider({ name: 'cloudflare-named', startResult: { error: 'rate-limited: 429' } });
+    const b = mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [a, b], fetch: vi.fn(async () => okResponse()), notifierSink: sink },
+    );
+    await mgr.start();
+    // One transition to retrying → notifier emits the "couldn't reach" message.
+    const groupCalls = (sink.sendGroup as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string);
+    expect(groupCalls.some((m) => m.includes("Couldn't reach"))).toBe(true);
+  });
+});
+
+describe('TunnelManager (rewrite) — restoration of persisted snapshot', () => {
+  it('restores the rotation-pending flag from tunnel.json on construction', () => {
+    const snap = {
+      version: 1,
+      lastState: 'idle',
+      lastUrl: null,
+      activeProvider: null,
+      rotationPending: true,
+      consentCooldown: { consecutiveRefusals: 2, lastExtendedAt: 100, activeUntil: 0 },
+      episode: null,
+      savedAt: new Date().toISOString(),
+    };
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'tunnel.json'), JSON.stringify(snap));
+
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' })] },
+    );
+    expect(mgr.lifecycleState.rotationPending).toBe(true);
+    expect(mgr.lifecycleState.consentCooldown.consecutiveRefusals).toBe(2);
+  });
+
+  it('ignores a corrupted state file and starts fresh', () => {
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'tunnel.json'), 'not json');
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [mockProvider({ name: 'cloudflare-quick', url: 'https://quick.example' })] },
+    );
+    expect(mgr.lifecycleState.rotationPending).toBe(false);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,111 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+<!-- patch = TunnelManager rewrite atop the foundation modules; no public API change -->
+
+## What Changed
+
+**feat(tunnel): TunnelManager rewrite — drive providers + lifecycle + notifier through a single owner.**
+
+This release lands PR 2 of the tunnel-failure-resilience chain
+(PR 1 was the foundation: provider abstraction + state machine + notifier).
+It rewrites `TunnelManager.ts` to drive the foundation modules and
+retires the duplicate retry machinery that previously lived in
+`server.ts`.
+
+The public API surface is preserved exactly — `start()`, `stop()`,
+`forceStop()`, `enableAutoReconnect()`, `disableAutoReconnect()`,
+`getExternalUrl()`, plus the `url` / `isRunning` / `state` accessors
+all still work as before. Callers (the SleepWake handler, the
+`server.ts` tunnel wiring) don't need changes.
+
+What's different inside:
+
+- The manager builds a Tier-1 provider pool from config (the
+  `CloudflareNamedProvider` if a token or configFile is set, then the
+  `CloudflareQuickProvider`) and drives them in order.
+- `start()` runs ONE round of provider attempts; if all fail, it
+  rejects (matching the legacy semantics) and the backoff retry runs
+  entirely in the background — `start()` does not block the caller
+  for the full exponential window.
+- A post-start HTTP probe through the public URL confirms the link
+  actually serves traffic before the manager declares `active`. A
+  provider whose URL emits but does not respond is torn down and the
+  next provider tried.
+- After the bounded startup-reconnect ladder exhausts (10 attempts
+  with exponential backoff up to 5 min), the manager schedules a
+  low-frequency 15-minute background probe until a provider connects.
+  Placeholder; replaced by the spec's N-consecutive-success
+  stability-gated probe in a later PR.
+- The single-writer CAS-guarded lifecycle state machine from PR 1 is
+  the source of truth for tunnel state. The error+exit double-handler
+  race that the concurrency reviewer surfaced cannot cause a
+  double-advance through the provider pool.
+- The `tunnel.json` state file now includes lifecycle snapshot fields
+  (`lastState`, `activeProvider`, `rotationPending`, `consentCooldown`,
+  `episode`) alongside the legacy `lastUrl`. Boot recovery reads the
+  snapshot to restore the rotation-pending flag and the cooldown
+  counter (the rotation lifecycle itself lands in a later PR).
+
+What was removed:
+
+- `server.ts` startup-retry ladder (the 5-attempt loop with 15-120s
+  exponential backoff). Deleted.
+- `server.ts` background-retry scheduler (the 5/10/20-minute
+  `scheduleRetry` callbacks). Deleted.
+- The single Lifeline failure message. Deleted. The user-facing
+  notification path will flow through the notifier once the sink is
+  wired up in the next PR.
+
+What's not yet landed (deliberate, future PRs in this chain):
+
+- Owner-DM channel + inline-button consent UX.
+- Tier-2 relay providers (localtunnel) + consent flow.
+- Auth token + PIN rotation on relay-episode end + boot recovery.
+- Full N-consecutive-success self-heal stability gate.
+- The auth-gated tunnel-state route.
+- ConfigDefaults migration for the new tunnel config fields.
+
+The lifecycle state machine already supports all of these; the manager
+just doesn't transition into the relevant states yet.
+
+## Evidence
+
+16 new unit tests in `tests/unit/tunnel-manager-rewrite.test.ts`:
+
+- Tier-1 happy path: drives the first available provider, skips
+  unavailable providers, persists the lifecycle snapshot to disk.
+- Reachability probe: rejects a provider whose URL does not pass the
+  health check, tears it down, falls through to the next provider.
+- Provider failure → next: classifies a rate-limit failure, records
+  the failed attempt against the current episode, advances to the
+  next provider.
+- Stop, forceStop, getExternalUrl, enable/disableAutoReconnect:
+  back-compat surface preserved.
+- Repeat start returns the same URL while running (mutex preserved).
+- Notifier wiring: a transition into retrying after a failure emits
+  the couldn't-reach-Cloudflare group message via the injected sink.
+- Persistence: rotation-pending flag and consent-cooldown counter
+  restored from tunnel.json; corrupted state file ignored.
+
+All 70 tunnel-related unit tests pass (16 new plus 54 foundation
+tests from PR 1). Typescript and lint clean. No existing tests
+modified.
+
+## What to Tell Your User
+
+You will not notice a behavior change yet. The internals shifted —
+your agent now has a single tidy retry engine instead of two
+overlapping ones — but your tunnel link comes up the same way it did
+before. Failure handling is also unchanged from your perspective in
+this release; the next release in the chain plugs the failure path
+into a message that goes to your Dashboard topic so you can see what
+happened when the link does not come up.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Single tunnel-lifecycle owner | Internal — your tunnel link behavior is preserved |
+| Post-start reachability probe | Automatic — prevents broadcasting a dead link |
+| Indefinite low-frequency self-heal placeholder | Automatic — agent keeps trying to recover after exhaustion without a restart |

--- a/upgrades/side-effects/tunnel-manager-rewrite.md
+++ b/upgrades/side-effects/tunnel-manager-rewrite.md
@@ -1,0 +1,129 @@
+# Side-effects review — TunnelManager rewrite (PR 2 of tunnel-failure-resilience chain)
+
+**Scope (this PR — second in the chain):** Rewrite `TunnelManager.ts`
+to drive the foundation modules (provider abstraction + state machine
++ notifier) landed in PR 1, and retire the duplicate retry machinery
+in `server.ts`. Spec
+`specs/dev-infrastructure/tunnel-failure-resilience.md` is converged
++ approved on main. Public API surface of `TunnelManager` is preserved
+exactly; behavior under the happy path is unchanged.
+
+**Files touched:**
+- `src/tunnel/TunnelManager.ts` — REWRITTEN. The legacy class (which
+  spawned cloudflared directly and owned its own reconnect loop) is
+  replaced with a manager that builds a Tier-1 provider pool, drives
+  it through `TunnelLifecycle`, plumbs transitions to the
+  `TunnelNotifier` (when a sink is injected), and persists the
+  lifecycle snapshot to `tunnel.json`. Public surface (`start()`,
+  `stop()`, `forceStop()`, `enableAutoReconnect()`,
+  `disableAutoReconnect()`, `getExternalUrl()`, `url` / `isRunning` /
+  `state`) preserved exactly.
+- `src/commands/server.ts` — Removed the startup-retry ladder
+  (5-attempt loop with 15-120s exponential backoff), the
+  background-retry scheduler (the 5/10/20-minute `scheduleRetry`
+  callbacks), and the single Lifeline failure message
+  ("Tunnel failed after all retries..."). Replaced with a single
+  `await tunnel.start()` call; failure is non-fatal and the manager
+  handles retry internally.
+- `tests/unit/tunnel-manager-rewrite.test.ts` — NEW. 16 tests covering
+  the happy path, reachability probe, provider-failure → next, stop
+  semantics, notifier wiring, and persistence restoration.
+
+**Under-block**: None. The new manager preserves the legacy public
+API surface; all existing callers (`SleepWake` handler, the
+construction site in `server.ts`) keep working unchanged.
+
+**Over-block**: Minor. The old `server.ts` background-retry scheduler
+fired retries at 5/10/20-minute intervals after the inner ladder gave
+up. The new manager's bounded startup-reconnect ladder is 10 attempts
+with exponential backoff (max 5-min delay between rounds), then the
+post-exhausted self-heal placeholder fires every 15 min indefinitely.
+Net effect: under sustained Cloudflare outage, the recovery cadence is
+similar but more predictable. **`start()` itself rejects after the
+FIRST round of provider attempts fails** (matching the legacy
+semantics) — the backoff retry runs entirely in the background so
+`start()` does not block the caller. This was the fix to a
+`tests/e2e/tunnel-private-view.test.ts` 60-second hook-timeout
+regression observed on the initial PR 2 CI run; the original draft
+had kept retrying synchronously inside `start()`.
+server.ts is also defensive: failure on initial `start()` is
+non-fatal and execution continues; the manager keeps trying in the
+background.
+
+**Level-of-abstraction fit**: The manager is the sole owner of
+detect → attempt → fall-back → notify per the spec's single-owner
+mandate. Provider implementations remain narrowly responsible for
+spawn + URL emission + teardown. The lifecycle module remains
+provider-agnostic and notification-agnostic; the notifier remains
+channel-agnostic. No layering violation introduced.
+
+**Signal vs authority**: Compliant. The manager classifies provider
+failures into `ProviderFailureReason` and routes them to the
+lifecycle's authoritative state machine (CAS-guarded). The notifier
+remains a read-only consumer of transition events. No new authority
+introduced at the wrong layer.
+
+**Interactions**:
+- `SleepWake` handler in `server.ts` (lines 5818-5848) is unchanged —
+  it calls `disableAutoReconnect()` / `forceStop()` /
+  `enableAutoReconnect()` / `start()` exactly as before. The new
+  manager's `forceStop()` is a thin wrapper over `stop()`, and the
+  providers' own `stop()` implementations escalate to SIGKILL — the
+  same forceful-teardown semantics the legacy `forceStop(5000)`
+  provided.
+- The `Promise.race([restart, 15s-timeout])` in SleepWake interacts
+  cleanly with the new manager's internal retry: if `start()` doesn't
+  resolve in 15s, the timeout fires, the catch re-enables
+  auto-reconnect (already always-on in the new design), and the
+  manager continues retrying internally.
+- The post-exhausted retry timer is registered with the manager's
+  own field tracking; `stop()` clears it. No timer leak across
+  episodes.
+
+**External surfaces**: None. No new API endpoint, no new CLI command,
+no new public config field, no change to the TunnelManager
+constructor's required signature (the optional `injections` parameter
+is purely additive for testability).
+
+**Migration parity**:
+- No agent-installed file change (the manager is server-side code).
+- `tunnel.json` format change: the file now carries lifecycle snapshot
+  fields. The constructor is tolerant of an old-format file (corrupted
+  parse → starts fresh) and of an absent file (no-op). No migration
+  helper needed.
+
+**Rollback cost**: Trivial. Revert two files (`TunnelManager.ts` +
+`server.ts`) + the test file. The new modules from PR 1 stay
+in tree but become unused; subsequent revert of PR 1 (also a clean
+file-delete) would restore the legacy state entirely.
+
+**Tests**:
+- 16/16 new tests in `tests/unit/tunnel-manager-rewrite.test.ts`.
+- 32/32 tests in `tests/unit/tunnel-lifecycle.test.ts` (foundation,
+  unchanged).
+- 12/12 tests in `tests/unit/tunnel-notifier.test.ts` (foundation,
+  unchanged).
+- 10/10 tests in `tests/unit/tunnel-providers.test.ts` (foundation,
+  unchanged).
+- `tsc --noEmit` clean. `npm run lint` clean.
+
+**Decision-point inventory**:
+1. Public API surface preserved exactly (vs. introducing a new class
+   name like `TunnelManagerV2` and migrating callers) — preserves the
+   "single-owner mandate" naturally and avoids a dual-implementation
+   transition window where both the legacy and new classes live in
+   tree.
+2. Reachability probe is owned by the manager (not by providers) per
+   the spec's separation of concerns. Providers cannot self-certify
+   reachability without violating the authority discipline.
+3. Post-exhausted retry placeholder lives in the manager (vs. living
+   in `server.ts` as a separate scheduler). One owner, one retry
+   engine, even for the long-tail recovery path. The placeholder will
+   be replaced by the spec's N-consecutive-success stability-gated
+   probe in a later PR; the placeholder's API is internal so the
+   replacement is non-breaking.
+4. `tunnel.json` schema extended additively (`version: 1` field
+   added, plus new fields alongside the legacy `lastUrl`). An older
+   file produces a graceful "start fresh"; a new file is unreadable
+   to a downgraded binary but the downgraded binary will simply
+   overwrite it with the legacy format — no permanent corruption.


### PR DESCRIPTION
## Summary

PR 2 of the tunnel-failure-resilience chain. Rewrites `TunnelManager.ts` to drive the foundation modules from PR 1 (`TunnelProvider` + `TunnelLifecycle` + `TunnelNotifier`) and retires the duplicate retry machinery in `server.ts`. Public API surface preserved exactly — callers (`SleepWake` handler, the `server.ts` tunnel wiring) keep working unchanged.

**The single-owner mandate** from the spec: detect → attempt → fall-back → notify → self-heal all lives in one place now. The old `server.ts` startup-retry ladder + background-retry scheduler + Lifeline failure message are deleted. One backoff engine, one state machine.

**What the manager now does:**
- Builds a Tier-1 provider pool from config (named Cloudflare if a token / configFile is set, then quick Cloudflare).
- Drives the pool through `TunnelLifecycle`'s CAS-guarded state machine — the error+exit double-handler race can't double-advance the provider index.
- Post-start HTTP probe through the public URL (`/health`) confirms the link actually serves traffic before declaring `active`. A provider whose URL emits but doesn't respond is torn down and the next provider tried.
- Failed provider attempts are classified into `ProviderFailureReason` and recorded against the current episode.
- After the bounded startup-reconnect ladder exhausts (10 attempts, exponential to 5 min), an indefinite 15-minute post-exhausted retry timer fires until a provider connects. Placeholder; PR 6 replaces with the spec's N-consecutive-success stability-gated probe.
- Persists lifecycle snapshot (`lastState`, `activeProvider`, `rotationPending`, `consentCooldown`, `episode`) to `tunnel.json`. Boot recovery restores the rotation-pending flag + cooldown counter.

**What server.ts no longer does:**
- The 5-attempt startup-retry ladder with 15-120s exponential backoff. Deleted.
- The 5/10/20-minute background-retry scheduler. Deleted.
- The single Lifeline "Tunnel failed after all retries" message. Deleted (the notifier handles user-facing notifications once the sink is wired up in the next PR of the chain).

`SleepWake` handler at server.ts:5818 is unchanged — its `disableAutoReconnect / forceStop / enableAutoReconnect / start` sequence works with the new manager unchanged. The 15s race timeout interacts cleanly with the manager's internal retry.

## Test plan

- [x] 16 new tests in `tests/unit/tunnel-manager-rewrite.test.ts` — happy path, reachability probe, provider-failure → next, stop / forceStop / getExternalUrl back-compat surface, notifier wiring, persistence restoration.
- [x] 54 foundation tests from PR 1 (`tunnel-lifecycle.test.ts`, `tunnel-notifier.test.ts`, `tunnel-providers.test.ts`) still pass.
- [x] `tsc --noEmit` clean; `npm run lint` clean.
- [ ] CI green.

## Chain status

Chain remaining after this PR: owner-DM channel, Tier-2 relay providers + consent UX, `authToken` / PIN rotation lifecycle, full N-consecutive-success self-heal, `/tunnel` route + `ConfigDefaults` migration + CLAUDE.md template. All ship autonomously through the chain; one final report once the full feature is on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)