### PR TITLE
feat(tunnel): consent state machine — awaiting-consent → relay-active (PR 5 of chain)

### DIFF
--- a/src/tunnel/TunnelManager.ts
+++ b/src/tunnel/TunnelManager.ts
@@ -45,6 +45,7 @@ import path from 'node:path';
 import {
   TunnelLifecycle,
   classifyFailure,
+  generateNonce,
   type PersistedTunnelState,
   type TransitionEvent,
 } from './TunnelLifecycle.js';
@@ -56,6 +57,7 @@ import type {
 } from './TunnelProvider.js';
 import { CloudflareQuickProvider } from './CloudflareQuickProvider.js';
 import { CloudflareNamedProvider } from './CloudflareNamedProvider.js';
+import { LocaltunnelProvider } from './LocaltunnelProvider.js';
 import type { NotifierSink } from './TunnelNotifier.js';
 import { TunnelNotifier } from './TunnelNotifier.js';
 
@@ -131,6 +133,8 @@ const REACHABILITY_TIMEOUT_MS = 8_000;
  * the regression we explicitly need to avoid in the PR chain.
  */
 const POST_EXHAUSTED_RETRY_INTERVAL_MS = 15 * 60_000;
+/** Per-episode consent prompt timeout — matches spec Part 4 default (15 min). */
+const CONSENT_TIMEOUT_MS = 15 * 60_000;
 
 // ── Manager ────────────────────────────────────────────────────────
 
@@ -152,6 +156,19 @@ export class TunnelManager extends EventEmitter {
   private _backoffAttempt = 0;
   private _backoffTimer: ReturnType<typeof setTimeout> | null = null;
   private _postExhaustedTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Pending consent record — populated when the manager enters
+   * `awaiting-consent` and cleared on grant / decline / timeout / stop.
+   * The nonce is the CSPRNG token sent to the owner; matching it on
+   * `grantConsent()` is the security-load-bearing check.
+   */
+  private _pendingConsent: {
+    episodeId: string;
+    provider: TunnelProvider;
+    nonce: string;
+    issuedAt: number;
+    timer: ReturnType<typeof setTimeout>;
+  } | null = null;
 
   constructor(config: TunnelConfig, injections?: TunnelManagerInjections) {
     super();
@@ -214,6 +231,7 @@ export class TunnelManager extends EventEmitter {
     this._stopped = true;
     this.clearBackoffTimer();
     this.clearPostExhaustedTimer();
+    this.clearPendingConsent();
     this._startPromise = null;
 
     if (this.currentHandle) {
@@ -294,6 +312,8 @@ export class TunnelManager extends EventEmitter {
 
   private buildDefaultPool(config: TunnelConfig): TunnelProvider[] {
     const pool: TunnelProvider[] = [];
+    // Tier-1 (automatic, secure). Cloudflare named first when configured,
+    // then quick as the zero-config default.
     if (config.token || config.configFile) {
       pool.push(new CloudflareNamedProvider({
         token: config.token,
@@ -302,6 +322,13 @@ export class TunnelManager extends EventEmitter {
       }));
     }
     pool.push(new CloudflareQuickProvider({ port: config.port, stateDir: config.stateDir }));
+    // Tier-2 (consent-gated relays). Listed AFTER Tier-1 — the driver
+    // only reaches these after exhausting Tier-1, and only after the
+    // owner explicitly grants consent. LocaltunnelProvider's
+    // isAvailable() returns false when the `localtunnel` npm package
+    // isn't installed, so agents without the dep see this slot
+    // silently skipped — the spec's "opt-in capability" posture.
+    pool.push(new LocaltunnelProvider({ port: config.port }));
     return pool;
   }
 
@@ -385,33 +412,194 @@ export class TunnelManager extends EventEmitter {
   }
 
   private async exhaustedOrBackoff(lastErr: Error | null): Promise<string> {
-    // Matches the legacy semantics: start() rejects after the FIRST
-    // round of provider attempts fails. The backoff retry runs in the
-    // background — the manager keeps trying without blocking the
-    // caller, and emits 'url' when a later attempt succeeds. This
-    // prevents start() from blocking server.ts boot for the full
-    // 25-minute worst-case exponential window. The original failing
-    // E2E (tests/e2e/tunnel-private-view.test.ts) timed out at the
-    // beforeAll 60s budget because the old draft kept retrying inside
-    // start().
+    // start() rejects after the FIRST round of provider attempts
+    // fails (matches the legacy semantics). The backoff retry runs in
+    // the background — the manager keeps trying without blocking the
+    // caller, and emits 'url' when a later attempt succeeds.
+    //
+    // PR 5 addition: BEFORE transitioning to exhausted, check if any
+    // Tier-2 providers are available and the cross-episode consent
+    // cooldown isn't active. If so, transition to `awaiting-consent`
+    // and request consent from the owner. The relay-active path
+    // activates on `grantConsent()`.
+    const candidateTier2 = await this.findAvailableTier2();
+    const cooldownActive = this.lifecycle.isConsentSuppressed();
+
+    if (candidateTier2 && !cooldownActive) {
+      const from = this.lifecycle.state;
+      if (from === 'retrying' || from === 'starting') {
+        if (this.lifecycle.transition(from, 'awaiting-consent', {
+          activeProvider: null,
+          lastFailureReason: classifyFailure(lastErr),
+        })) {
+          this.requestConsent(candidateTier2);
+        }
+      }
+      const err = lastErr ?? new Error('Tier-1 exhausted; awaiting owner consent for backup relay');
+      this.emit('error', err);
+      throw err;
+    }
+
     const from = this.lifecycle.state;
     if (from === 'retrying' || from === 'starting') {
       this.lifecycle.transition(from, 'exhausted', { activeProvider: null });
     }
 
     const err = lastErr ?? new Error('all Tier-1 providers failed');
-
-    // Schedule background retry (bounded exponential ladder, then the
-    // indefinite post-exhausted placeholder once the ladder runs out).
-    // Fire-and-forget; if a later attempt succeeds, the 'url' event
-    // fires and downstream subscribers (notifier, dashboard
-    // broadcaster, log line) catch up.
     if (this._autoReconnect && !this._stopped) {
       this.scheduleBackgroundRetry();
     }
-
     this.emit('error', err);
     throw err;
+  }
+
+  /** First Tier-2 provider that reports available, or null. */
+  private async findAvailableTier2(): Promise<TunnelProvider | null> {
+    for (const p of this.providers) {
+      if (p.tier !== 2) continue;
+      const avail = await p.isAvailable().catch(() => false);
+      if (avail) return p;
+    }
+    return null;
+  }
+
+  /**
+   * Internal — called after the lifecycle transitions to
+   * `awaiting-consent`. Generates the one-time nonce, stores the
+   * pending consent record, and arms the timeout.
+   */
+  private requestConsent(provider: TunnelProvider): void {
+    this.clearPendingConsent();
+    const episode = this.lifecycle.episode;
+    if (!episode) return;
+    const nonce = generateNonce();
+    const timer = setTimeout(() => {
+      this.recordConsentDecline(nonce, 'timeout');
+    }, CONSENT_TIMEOUT_MS);
+    this._pendingConsent = {
+      episodeId: episode.episodeId,
+      provider,
+      nonce,
+      issuedAt: Date.now(),
+      timer,
+    };
+  }
+
+  private clearPendingConsent(): void {
+    if (this._pendingConsent) {
+      clearTimeout(this._pendingConsent.timer);
+      this._pendingConsent = null;
+    }
+  }
+
+  /**
+   * Public — called by the consent UX layer (Telegram callback handler
+   * in PR 6) after the owner approves. Validates the nonce matches the
+   * pending consent record, starts the Tier-2 provider, and transitions
+   * to `relay-active`. Returns true on success, false if the nonce
+   * didn't match (replay, race, stale click) or the state moved beyond
+   * awaiting-consent.
+   */
+  async grantConsent(nonce: string): Promise<boolean> {
+    if (!this._pendingConsent) return false;
+    if (this._pendingConsent.nonce !== nonce) return false;
+    if (this.lifecycle.state !== 'awaiting-consent') {
+      this.clearPendingConsent();
+      return false;
+    }
+    const { provider, episodeId } = this._pendingConsent;
+    if (this.lifecycle.episode?.episodeId !== episodeId) {
+      this.clearPendingConsent();
+      return false;
+    }
+    // Single-use: clear BEFORE starting so a replay loses cleanly.
+    this.clearPendingConsent();
+
+    try {
+      const handle = await provider.start(this.config.port);
+      const reachable = await this.probeReachability(handle.url).catch(() => false);
+      if (!reachable) {
+        try { await handle.stop(); } catch { /* best effort */ }
+        this.lifecycle.recordAttempt(provider.name, 'reachability-failed');
+        this.lifecycle.recordConsentRefusal();
+        const from = this.lifecycle.state;
+        if (from === 'awaiting-consent') {
+          this.lifecycle.transition('awaiting-consent', 'exhausted', { activeProvider: null });
+        }
+        if (this._autoReconnect && !this._stopped) {
+          this.scheduleBackgroundRetry();
+        }
+        return false;
+      }
+
+      this.currentHandle = handle;
+      this.currentProviderName = provider.name;
+      this._legacyState.url = handle.url;
+      this._legacyState.startedAt = new Date().toISOString();
+      // Set rotation-pending — entering relay-active is the persisted
+      // marker that says "credentials must rotate when this episode
+      // ends" (per spec Part 6 / verification finding V1).
+      this.lifecycle.setRotationPending(true);
+      this.lifecycle.transition('awaiting-consent', 'relay-active', {
+        activeProvider: provider.name,
+        lastFailureReason: null,
+        rotationPending: true,
+      });
+      this.persist();
+      this.emit('url', handle.url);
+      return true;
+    } catch (err) {
+      this.lifecycle.recordAttempt(provider.name, classifyFailure(err));
+      this.lifecycle.recordConsentRefusal();
+      const from = this.lifecycle.state;
+      if (from === 'awaiting-consent') {
+        this.lifecycle.transition('awaiting-consent', 'exhausted', { activeProvider: null });
+      }
+      if (this._autoReconnect && !this._stopped) {
+        this.scheduleBackgroundRetry();
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Public — called by the consent UX layer when the owner declines.
+   * Validates the nonce, applies the cross-episode cooldown, and
+   * transitions to `exhausted` + background retry.
+   */
+  declineConsent(nonce: string): boolean {
+    return this.recordConsentDecline(nonce, 'decline');
+  }
+
+  private recordConsentDecline(nonce: string, _reason: 'decline' | 'timeout'): boolean {
+    if (!this._pendingConsent) return false;
+    if (this._pendingConsent.nonce !== nonce) return false;
+    if (this.lifecycle.state !== 'awaiting-consent') {
+      this.clearPendingConsent();
+      return false;
+    }
+    this.clearPendingConsent();
+    this.lifecycle.recordConsentRefusal();
+    this.lifecycle.transition('awaiting-consent', 'exhausted', { activeProvider: null });
+    if (this._autoReconnect && !this._stopped) {
+      this.scheduleBackgroundRetry();
+    }
+    return true;
+  }
+
+  /**
+   * Public — the active pending-consent record (or null). Used by the
+   * consent UX layer (PR 6) to know what nonce to embed in the inline
+   * button.
+   */
+  get pendingConsent(): { episodeId: string; provider: ProviderName; nonce: string; issuedAt: number } | null {
+    if (!this._pendingConsent) return null;
+    return {
+      episodeId: this._pendingConsent.episodeId,
+      provider: this._pendingConsent.provider.name,
+      nonce: this._pendingConsent.nonce,
+      issuedAt: this._pendingConsent.issuedAt,
+    };
   }
 
   /**

--- a/tests/unit/tunnel-consent-state-machine.test.ts
+++ b/tests/unit/tunnel-consent-state-machine.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for the consent state machine (PR 5 of the
+ * tunnel-failure-resilience chain).
+ *
+ * Spec: specs/dev-infrastructure/tunnel-failure-resilience.md Part 2,
+ * Part 3, Part 6.
+ *
+ * The security-load-bearing surface:
+ *   - Tier-1 exhaustion transitions to `awaiting-consent` ONLY when a
+ *     Tier-2 provider is available AND the cross-episode cooldown
+ *     isn't active. Otherwise → `exhausted` directly (the no-relay
+ *     path).
+ *   - The pending-consent nonce is a 128-bit CSPRNG token. `grantConsent`
+ *     accepts ONLY a matching nonce and ONLY while the state is
+ *     `awaiting-consent` (single-use; replay-safe).
+ *   - On grant: provider starts, URL is probed for reachability,
+ *     transition to `relay-active` with rotationPending=true (the
+ *     mandatory PIN+authToken rotation marker per spec Part 6).
+ *   - On decline / timeout: transition to `exhausted` with cooldown
+ *     advanced (cross-episode rate-limit per verification finding V2).
+ *   - `stop()` clears the pending consent, preventing late-firing
+ *     timers from acting on a torn-down manager.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TunnelManager } from '../../src/tunnel/TunnelManager.js';
+import type {
+  TunnelProvider,
+  TunnelProviderHandle,
+  ProviderName,
+  ProviderTier,
+} from '../../src/tunnel/TunnelProvider.js';
+
+function tmpStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tunnel-consent-'));
+}
+
+interface MockOpts {
+  name: ProviderName;
+  tier?: ProviderTier;
+  available?: boolean;
+  startResult?: 'success' | { error: string };
+  url?: string;
+  stop?: () => Promise<void>;
+}
+
+function mockProvider(opts: MockOpts): TunnelProvider {
+  const tier: ProviderTier = opts.tier ?? 1;
+  return {
+    name: opts.name,
+    tier,
+    isAvailable: vi.fn(async () => opts.available !== false),
+    start: vi.fn(async (): Promise<TunnelProviderHandle> => {
+      if (opts.startResult && typeof opts.startResult === 'object') {
+        throw new Error(opts.startResult.error);
+      }
+      return {
+        url: opts.url ?? `https://${opts.name}.example`,
+        stop: opts.stop ?? (async () => undefined),
+      };
+    }),
+  };
+}
+
+const okFetch = vi.fn(async () => new Response('ok', { status: 200 }));
+const badFetch = vi.fn(async () => new Response('bad', { status: 500 }));
+
+const baseConfig = { enabled: true, type: 'quick' as const, port: 4040, stateDir: '' };
+
+let stateDir: string;
+beforeEach(() => { stateDir = tmpStateDir(); });
+afterEach(() => {
+  try {
+    SafeFsExecutor.safeRmSync(stateDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/tunnel-consent-state-machine.test.ts:cleanup',
+    });
+  } catch { /* ignore */ }
+});
+
+describe('TunnelManager — Tier-1 exhaustion → awaiting-consent (when Tier-2 available)', () => {
+  it('transitions to awaiting-consent when Tier-1 fails AND a Tier-2 provider is available', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited: 1015' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+
+    // start() rejects because Tier-1 failed; meanwhile the manager
+    // transitioned to awaiting-consent and populated pendingConsent.
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+    expect(mgr.lifecycleState.lastState).toBe('awaiting-consent');
+    const pc = mgr.pendingConsent;
+    expect(pc).not.toBeNull();
+    expect(pc?.provider).toBe('localtunnel');
+    expect(pc?.nonce).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('falls through to exhausted when NO Tier-2 provider is available', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'network: ECONNREFUSED' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: false });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+    expect(mgr.lifecycleState.lastState).toBe('exhausted');
+    expect(mgr.pendingConsent).toBeNull();
+  });
+
+  it('falls through to exhausted when consent cooldown is active', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+
+    // Pre-seed a tunnel.json with cooldown active.
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'tunnel.json'), JSON.stringify({
+      version: 1,
+      lastState: 'idle',
+      lastUrl: null,
+      activeProvider: null,
+      rotationPending: false,
+      consentCooldown: { consecutiveRefusals: 3, lastExtendedAt: Date.now(), activeUntil: Date.now() + 60 * 60_000 },
+      episode: null,
+      savedAt: new Date().toISOString(),
+    }));
+
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+    expect(mgr.lifecycleState.lastState).toBe('exhausted');
+    expect(mgr.pendingConsent).toBeNull();
+  });
+});
+
+describe('TunnelManager — grantConsent', () => {
+  it('starts the Tier-2 provider and transitions to relay-active on matching nonce', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const pc = mgr.pendingConsent;
+    expect(pc).not.toBeNull();
+    const granted = await mgr.grantConsent(pc!.nonce);
+    expect(granted).toBe(true);
+    expect(mgr.lifecycleState.lastState).toBe('relay-active');
+    expect(mgr.url).toBe('https://relay.loca.lt');
+    expect(mgr.lifecycleState.activeProvider).toBe('localtunnel');
+    expect(mgr.lifecycleState.rotationPending).toBe(true);
+    expect(tier2.start).toHaveBeenCalledTimes(1);
+    expect(mgr.pendingConsent).toBeNull(); // single-use — cleared on grant
+  });
+
+  it('rejects a wrong nonce without mutating state', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const granted = await mgr.grantConsent('ffffffffffffffffffffffffffffffff');
+    expect(granted).toBe(false);
+    expect(mgr.lifecycleState.lastState).toBe('awaiting-consent');
+    expect(mgr.pendingConsent).not.toBeNull(); // still pending
+    expect(tier2.start).not.toHaveBeenCalled();
+  });
+
+  it('rejects a replay of the same nonce after a successful grant (single-use)', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const pc = mgr.pendingConsent;
+    expect(await mgr.grantConsent(pc!.nonce)).toBe(true);
+    // Replay attempt — should fail without affecting state.
+    expect(await mgr.grantConsent(pc!.nonce)).toBe(false);
+    expect(mgr.lifecycleState.lastState).toBe('relay-active');
+    expect(tier2.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to exhausted + cooldown when the relay starts but is unreachable', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://broken.example' });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: badFetch },
+    );
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const pc = mgr.pendingConsent;
+    const granted = await mgr.grantConsent(pc!.nonce);
+    expect(granted).toBe(false);
+    expect(mgr.lifecycleState.lastState).toBe('exhausted');
+    expect(mgr.lifecycleState.consentCooldown.consecutiveRefusals).toBeGreaterThanOrEqual(1);
+    expect(mgr.url).toBeNull();
+  });
+
+  it('falls back to exhausted when the relay provider.start() throws', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, startResult: { error: 'process-exit code 1' } });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const pc = mgr.pendingConsent;
+    const granted = await mgr.grantConsent(pc!.nonce);
+    expect(granted).toBe(false);
+    expect(mgr.lifecycleState.lastState).toBe('exhausted');
+    expect(mgr.lifecycleState.consentCooldown.consecutiveRefusals).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('TunnelManager — declineConsent', () => {
+  it('transitions to exhausted + advances cooldown on matching nonce', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const pc = mgr.pendingConsent;
+    const declined = mgr.declineConsent(pc!.nonce);
+    expect(declined).toBe(true);
+    expect(mgr.lifecycleState.lastState).toBe('exhausted');
+    expect(mgr.lifecycleState.consentCooldown.consecutiveRefusals).toBe(1);
+    expect(mgr.pendingConsent).toBeNull();
+  });
+
+  it('rejects a wrong nonce without mutating state', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const declined = mgr.declineConsent('00000000000000000000000000000000');
+    expect(declined).toBe(false);
+    expect(mgr.lifecycleState.lastState).toBe('awaiting-consent');
+    expect(mgr.lifecycleState.consentCooldown.consecutiveRefusals).toBe(0);
+  });
+});
+
+describe('TunnelManager — stop() clears pending consent', () => {
+  it('clears pendingConsent on stop() so timeouts cannot fire afterwards', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true });
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [tier1, tier2], fetch: okFetch },
+    );
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+    expect(mgr.pendingConsent).not.toBeNull();
+
+    await mgr.stop();
+    expect(mgr.pendingConsent).toBeNull();
+    expect(mgr.lifecycleState.lastState).toBe('idle');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,94 +1,119 @@
 # Upgrade Guide — vNEXT
 
 <!-- bump: patch -->
-<!-- patch = adds the LocaltunnelProvider class — Tier-2 relay backend, not yet wired into the active pool -->
+<!-- patch = consent state machine + grantConsent/declineConsent API; no Telegram wire-up yet -->
 
 ## What Changed
 
-**feat(tunnel): add LocaltunnelProvider — Tier-2 consent-gated relay backend.**
+**feat(tunnel): consent state machine — Tier-1 exhaustion → awaiting-consent → relay-active.**
 
-PR 4 of the tunnel-failure-resilience chain. Adds the
-`LocaltunnelProvider` implementation of the `TunnelProvider` interface
-from PR 1. This is the relay backend the upcoming consent state
-machine (PR 5) will activate when Cloudflare is unavailable and the
-owner approves.
+PR 5 of the tunnel-failure-resilience chain. Lands the consent state
+machine inside `TunnelManager` so an exhausted Tier-1 path can offer
+the Tier-2 relay (LocaltunnelProvider from PR 4) behind an
+owner-approval gate.
 
 What's new:
 
-- `src/tunnel/LocaltunnelProvider.ts` — implements `TunnelProvider`
-  with `name: 'localtunnel'`, `tier: 2`. `isAvailable()` returns true
-  only when the `localtunnel` npm package is installed (dynamic-import
-  with graceful degradation when absent — agents without the dep see
-  the provider report unavailable and the manager skips it). `start()`
-  spawns the localtunnel client and surfaces the `.loca.lt` URL.
-  `stop()` closes the client cleanly.
-- Failure classification matches the existing
-  `ProviderFailureReason` enum: rate-limit responses surface as
-  `rate-limited`, network failures as `network`, anything else as
-  `process-exit`.
-
-Behavior is unchanged for users today: the manager's provider pool is
-still Tier-1 only. The provider class is added to the codebase so the
-next PR can wire it into the pool behind the consent gate without
-touching the underlying provider implementation again.
+- `TunnelManager.buildDefaultPool` now appends a `LocaltunnelProvider`
+  as the Tier-2 slot. `isAvailable()` returns false when the
+  `localtunnel` npm package isn't installed (per the spec's opt-in
+  posture), so the slot is silently skipped on agents without the
+  dep — behavior is unchanged for them.
+- `TunnelManager.exhaustedOrBackoff` now checks for an available
+  Tier-2 provider AND that the cross-episode consent cooldown isn't
+  active before deciding between `exhausted` and `awaiting-consent`.
+  When both conditions hold, the manager transitions to
+  `awaiting-consent` and generates a one-time CSPRNG nonce stored in
+  a new `_pendingConsent` record.
+- `TunnelManager.grantConsent(nonce)` — public API. Validates the
+  nonce matches the pending record AND the state is still
+  `awaiting-consent` (replay-safe single-use), starts the Tier-2
+  provider, runs the post-start reachability probe, and transitions
+  to `relay-active` with `rotationPending=true` (the persisted
+  marker for the upcoming mandatory PIN+authToken rotation in PR 6).
+  Returns true on success; false on any validation failure or
+  start/probe failure.
+- `TunnelManager.declineConsent(nonce)` — public API. Validates the
+  nonce, advances the cross-episode cooldown counter, and
+  transitions to `exhausted` + background retry.
+- Consent timeout (15 min, per spec Part 4 default) — fires
+  automatically; same effect as decline.
+- `stop()` clears the pending consent + its timer so a torn-down
+  manager can't have a stale timeout fire.
+- `TunnelManager.pendingConsent` accessor — returns a defensive
+  snapshot (episodeId, provider name, nonce, issuedAt) for the
+  upcoming Telegram callback handler (PR 6) to embed the nonce in
+  the inline-button payload.
 
 What's NOT new yet (deliberate, future PRs in the chain):
 
-- The state-machine transition into `awaiting-consent` when Tier-1
-  exhausts (PR 5).
-- The inline-button consent UX in the owner DM (PR 5).
-- The Telegram `callback_query` handler that grants consent on a
-  matching nonce (PR 5).
-- The `relay-active` activation path that actually starts the
-  LocaltunnelProvider after consent (PR 5).
-- `authToken` / PIN rotation on relay-episode end (PR 6).
+- Telegram `callback_query` handler that invokes `grantConsent` /
+  `declineConsent` on owner button clicks (PR 6).
+- Inline-button payload in the consent prompt (PR 6).
+- `authToken` / PIN rotation lifecycle on relay-episode end (PR 6+).
 - Full N-consecutive-success self-heal stability gate (PR 7).
-- The auth-gated `/tunnel` route + `ConfigDefaults` migration + agent-
-  awareness CLAUDE.md template (PR 8).
+- The auth-gated `/tunnel` route + `ConfigDefaults` migration +
+  CLAUDE.md template (PR 8).
+- The `localtunnel` npm dep itself (PR 6, alongside the consent
+  wire-up — keeps the capability opt-in until the gate is fully
+  live).
 
-The lifecycle state machine already supports all of these; the manager
-just doesn't transition into the relevant states yet. This PR is
-narrowly the relay backend.
+Behavior change for users today: **none** at runtime. Agents without
+the `localtunnel` dep installed continue exactly as before (Tier-2
+slot is unavailable, manager falls through to exhausted). The
+plumbing is in place; PR 6 makes it user-facing.
 
 ## Evidence
 
-7 new unit tests in `tests/unit/localtunnel-provider.test.ts`:
+11 new unit tests in `tests/unit/tunnel-consent-state-machine.test.ts`:
 
-- Surface: `name === 'localtunnel'`, `tier === 2`, exposes the
-  `TunnelProvider` interface.
-- Graceful degradation: `isAvailable()` returns false when the
-  `localtunnel` npm package is not installed; `start()` rejects with
-  the `binary-missing` classification under the same condition; the
-  "unavailable" verdict is cached across calls.
-- Constructor options: accepts a custom start timeout and an optional
-  subdomain hint.
+- Tier-1 exhausts + Tier-2 available + cooldown inactive →
+  `awaiting-consent` + pendingConsent populated with 128-bit hex nonce.
+- Tier-1 exhausts + NO Tier-2 available → `exhausted` (baseline path).
+- Tier-1 exhausts + consent cooldown active → `exhausted` (cooldown
+  wins).
+- `grantConsent` with matching nonce → `relay-active` + URL emitted +
+  rotationPending=true + pendingConsent cleared (single-use).
+- `grantConsent` with wrong nonce → returns false, state unchanged,
+  provider.start NOT called.
+- `grantConsent` replay of a used nonce → returns false, state
+  unchanged.
+- `grantConsent` + reachability probe fails → `exhausted` + cooldown
+  advanced.
+- `grantConsent` + provider.start throws → `exhausted` + cooldown
+  advanced.
+- `declineConsent` with matching nonce → `exhausted` + cooldown
+  advanced + pendingConsent cleared.
+- `declineConsent` with wrong nonce → returns false, state unchanged,
+  no cooldown change.
+- `stop()` clears pendingConsent + the timeout timer.
 
-`tsc --noEmit` clean. `npm run lint` clean. No existing tests modified.
-
-The actual relay-active flow (manager driving the provider after
-consent) is exercised end-to-end in the integration tests landing in
-PR 5; this PR ships the provider class in isolation so security review
-can focus on the surface.
+All 92 tunnel-related unit tests pass (11 new + 81 from PRs 1–4).
+`tsc --noEmit` clean. `npm run lint` clean.
 
 ## What to Tell Your User
 
-This release adds plumbing for a backup tunnel option that the
-upcoming release will activate. Nothing visible to you yet — the
-backup is offered only when Cloudflare is fully unavailable, and only
-after you tap an approval button in your DM. This release just puts
-the backup capability in the codebase; the next release wires it into
-the failure path.
+This release puts the security gate for backup tunnels into place.
+Nothing visible to you yet — the gate needs a button to click, and
+that's the next release. Once that lands, when Cloudflare goes fully
+down, you'll get a private message from your agent asking permission
+to use a backup. Until you approve, the agent stays link-less and
+keeps retrying Cloudflare. If you decline or don't reply, the agent
+won't ask again for a while (the wait window grows the more you
+decline, so the agent stops bothering you about something you've
+already decided).
 
-If you want the backup capability to be available when the next
-release lands, install the `localtunnel` npm package alongside your
-agent. Without it the backup option will silently be unavailable and
-the agent will continue retrying Cloudflare. Details on how to do
-this safely (exact-version pin, etc.) will land in the next release's
-guide.
+If you want the backup capability to actually work when the next
+release lands, install the localtunnel npm package alongside your
+agent. Without it the backup option is silently skipped and the
+agent continues with Cloudflare only — which is fine if that's your
+preference.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| LocaltunnelProvider class | Internal — wired into the active pool in the next release |
-| Graceful degradation when `localtunnel` npm dep is absent | Automatic — provider reports unavailable, manager skips it |
+| Consent state machine (Tier-1 → awaiting-consent → relay-active) | Internal — exposed via grantConsent / declineConsent APIs that the upcoming Telegram callback handler will call |
+| Single-use CSPRNG nonce binding | Automatic — pendingConsent.nonce embeds in the inline button in the next release |
+| Cross-episode consent cooldown | Automatic — exponential back-off on decline/timeout (1h → 4h → 24h) |
+| Mandatory rotation marker on relay-active entry | Automatic — rotationPending=true is the crash-safe flag the upcoming rotation lifecycle reads |

--- a/upgrades/side-effects/consent-state-machine.md
+++ b/upgrades/side-effects/consent-state-machine.md
@@ -1,0 +1,135 @@
+# Side-effects review — consent state machine (PR 5 of tunnel-failure-resilience chain)
+
+**Scope (PR 5 of the chain):** Land the consent state machine inside
+`TunnelManager` and append `LocaltunnelProvider` (from PR 4) to the
+default Tier-2 slot. Adds public `grantConsent` / `declineConsent`
+methods so the upcoming Telegram callback handler (PR 6) can drive the
+owner-approval gate. Spec
+`specs/dev-infrastructure/tunnel-failure-resilience.md` is converged
++ approved on main.
+
+**Files touched:**
+- `src/tunnel/TunnelManager.ts` — adds Tier-2 to `buildDefaultPool`;
+  modifies `exhaustedOrBackoff` to branch on Tier-2 availability +
+  consent cooldown; adds `findAvailableTier2`, `requestConsent`,
+  `clearPendingConsent`, `grantConsent`, `declineConsent`,
+  `recordConsentDecline`, and the `pendingConsent` accessor; updates
+  `stop()` to clear the pending consent.
+- `tests/unit/tunnel-consent-state-machine.test.ts` — 11 tests covering
+  the awaiting-consent transition (and its negative cases — no Tier-2
+  available, cooldown active), grantConsent happy path, nonce
+  rejection (wrong nonce, replay), grant-failure paths (unreachable
+  relay, provider.start throws), declineConsent happy path + wrong
+  nonce, stop() clearing pendingConsent.
+
+**Under-block**: None at user-visible runtime. Agents without the
+`localtunnel` npm dep installed continue to fall through to
+`exhausted` exactly as before (the Tier-2 slot's `isAvailable()`
+returns false; `findAvailableTier2` returns null; the branch picks
+the existing `exhausted` path). This is the spec's opt-in posture —
+PR 4's side-effects review documented it explicitly.
+
+**Over-block**: Minimal. Agents that DO have `localtunnel` installed
+WILL see the new `awaiting-consent` transition fire instead of going
+straight to `exhausted` — but the manager has no UX layer to surface
+the prompt yet (PR 6 lands the Telegram callback handler that
+actually calls `grantConsent` / `declineConsent`). For now the
+manager sits in `awaiting-consent` for the 15-minute timeout, then
+auto-declines and falls through to exhausted with the cooldown
+advanced. From the user's perspective this looks identical to
+"exhausted" today — there's just a 15-min delay before the cooldown
+counter ticks the first time.
+
+To explicitly avoid this UX gap during the interim window between
+PR 5 and PR 6, operators who don't want the awaiting-consent state
+can simply not install `localtunnel`. The default ships without it.
+
+**Level-of-abstraction fit**:
+- The state machine lives in `TunnelLifecycle` (PR 1); the manager
+  drives state through the existing CAS-guarded transitions.
+- `_pendingConsent` is private state on the manager (binds nonce +
+  episode + provider). Exposed read-only via the `pendingConsent`
+  accessor that returns a snapshot — callers cannot mutate the
+  manager's state from outside.
+- `grantConsent` / `declineConsent` are the AUTHORITY surface for
+  consent decisions. The Telegram callback handler (PR 6) will be
+  the SIGNAL layer — it validates the click came from the owner and
+  the message id matches, then calls these methods.
+
+**Signal vs authority**: Compliant. The manager is the authority for
+state transitions and the consent record's lifecycle; external
+callers can only ask for grant/decline by presenting the nonce, and
+the manager validates+decides. The Telegram callback handler in PR 6
+will be a thin signal layer above this; it cannot bypass the nonce
+check.
+
+**Interactions**:
+- `_pendingConsent` is single-flight per manager instance — only one
+  consent record can be active at a time (the lifecycle's `episode`
+  invariant: one episode = one consent prompt = one nonce).
+- `clearPendingConsent` is called on every terminal path (grant
+  success, decline, timeout, stop, episode change). The timer is
+  cleared atomically with the record so no stale callback can fire.
+- The consent timeout uses the lifecycle's `recordConsentRefusal`
+  to advance the cross-episode cooldown — same path as a manual
+  decline. The cooldown progression is exponential (1h → 4h → 24h)
+  per PR 1's lifecycle implementation.
+- `rotationPending=true` is set on entering `relay-active` (the
+  crash-safe persisted marker for the upcoming rotation lifecycle
+  in PR 6). The actual rotation work is NOT in this PR — only the
+  marker.
+- Reachability probe on the granted Tier-2 provider follows the
+  same `/health` semantics as Tier-1 — a relay that emits a URL
+  but doesn't actually serve traffic falls through to exhausted +
+  cooldown (so the owner isn't asked again immediately).
+
+**External surfaces**:
+- New public methods: `grantConsent(nonce)`, `declineConsent(nonce)`,
+  `pendingConsent` getter on `TunnelManager`. All require the
+  caller to have the current pending nonce, which is itself only
+  accessible via `pendingConsent.nonce` — there's no broader
+  exposure.
+- No new API endpoint, no new CLI command, no new config field.
+- The default tunnel pool now includes a `LocaltunnelProvider`
+  slot, but the manager only activates it after Tier-1 exhausts +
+  consent is granted, so users who never hit a Tier-1 exhaustion
+  never see Tier-2 attempted.
+
+**Migration parity**: N/A. Server-side code only.
+
+**Rollback cost**: Trivial. Revert `TunnelManager.ts` + the test file.
+The new methods become unused (they're not called from anywhere
+outside the manager + tests yet). LocaltunnelProvider stays in tree
+from PR 4 but is no longer in the default pool.
+
+**Tests**:
+- 11/11 new tests in `tests/unit/tunnel-consent-state-machine.test.ts`.
+- 19/19 tests in `tests/unit/tunnel-manager-rewrite.test.ts` (from
+  PR 2 + 3) still pass.
+- 32/32 lifecycle, 13/13 notifier, 10/10 providers, 7/7 localtunnel-
+  provider — all still pass.
+- `tsc --noEmit` clean. `npm run lint` clean. No existing tests
+  modified.
+
+**Decision-point inventory**:
+1. `_pendingConsent` stores the provider directly (vs. a provider-name
+   key into the pool) — keeps the grant path independent of the pool
+   ordering, and ensures a provider that becomes "unavailable"
+   between request and grant is still the one we attempt (failure
+   surfaces cleanly).
+2. Nonce is 128-bit CSPRNG via `generateNonce` from PR 1 — meets the
+   GPT external review's spec for entropy + atomic compare-and-delete.
+3. Single-use enforced by `clearPendingConsent` BEFORE the provider
+   starts — a replay of the same nonce loses cleanly even if the
+   start is in flight.
+4. Timeout = 15 min (spec Part 4 default, staggered off the 10-min
+   reconnect window per verification finding V1).
+5. Reachability failure on a granted relay → cooldown advanced.
+   Reason: the relay started but doesn't serve; bothering the owner
+   again immediately wouldn't help. The cooldown gates the next ask.
+6. State machine transitions `awaiting-consent → exhausted` directly
+   on decline/timeout/start-failure — same transition the cooldown
+   path uses, so background retry semantics are uniform.
+7. `pendingConsent` accessor returns a defensive snapshot — mutating
+   it does NOT affect the manager. External callers cannot inject
+   their own nonce or change the bound provider.


### PR DESCRIPTION
## Summary

PR 5 of the tunnel-failure-resilience chain. Adds the consent state machine inside `TunnelManager` so an exhausted Tier-1 path can offer the Tier-2 relay (LocaltunnelProvider from PR 4) behind an owner-approval gate.

**What's new:**
- LocaltunnelProvider appended to the default Tier-2 slot in `buildDefaultPool`. Silently skipped on agents without the `localtunnel` npm dep installed.
- `exhaustedOrBackoff` branches on Tier-2 availability + cross-episode consent cooldown — transitions to `awaiting-consent` when both green, otherwise falls through to `exhausted`.
- `grantConsent(nonce)` — validates + starts Tier-2 + reachability-probes + transitions to `relay-active` with `rotationPending=true`. Replay-safe single-use.
- `declineConsent(nonce)` — validates + advances cross-episode cooldown + transitions to `exhausted`.
- 15-min auto-timeout = same effect as decline.
- `stop()` clears pendingConsent + timer.
- `pendingConsent` accessor returns a defensive snapshot for PR 6's Telegram callback handler to embed the nonce in the inline-button payload.

**Behavior change for users today: none at runtime.** Agents without `localtunnel` installed continue exactly as before.

## Test plan

- [x] 11 new tests in `tunnel-consent-state-machine.test.ts` — awaiting-consent transition (and negative cases), grant happy path, nonce rejection (wrong nonce, replay), grant-failure paths (unreachable, throws), decline happy path + wrong nonce, stop() clears.
- [x] 92 tunnel-related tests pass total (81 from PRs 1–4 + 11 new).
- [x] `tsc --noEmit` clean; `npm run lint` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)