### PR TITLE
feat(hooks): slopcheck-guard — package-legitimacy check on installs (GSD cherry-pick)

### DIFF
--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1376,6 +1376,13 @@ export class PostUpdateMigrator {
     }
 
     try {
+      fs.writeFileSync(path.join(instarHooksDir, 'slopcheck-guard.js'), this.getSlopcheckGuardHook(), { mode: 0o755 });
+      result.upgraded.push('hooks/instar/slopcheck-guard.js (package-legitimacy check on installs)');
+    } catch (err) {
+      result.errors.push(`slopcheck-guard.js: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    try {
       fs.writeFileSync(path.join(instarHooksDir, 'post-action-reflection.js'), this.getPostActionReflectionHook(), { mode: 0o755 });
       result.upgraded.push('hooks/instar/post-action-reflection.js (evolution awareness)');
     } catch (err) {
@@ -1540,6 +1547,7 @@ export class PostUpdateMigrator {
     const builtinHooks = [
       'session-start.sh', 'dangerous-command-guard.sh', 'grounding-before-messaging.sh',
       'compaction-recovery.sh', 'external-operation-gate.js', 'deferral-detector.js',
+      'slopcheck-guard.js',
       'post-action-reflection.js', 'external-communication-guard.js',
       'scope-coherence-collector.js', 'scope-coherence-checkpoint.js',
       'instructions-loaded-tracker.js', 'subagent-start-tracker.js',
@@ -3031,6 +3039,38 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       }
     }
 
+    // Ensure PreToolUse Bash slopcheck-guard hook exists (cherry-pick 2026-05-23).
+    // Existing agents only get new Bash-matcher hooks through an explicit ensure
+    // block here — there is no wholesale settings-template refresh on migration.
+    {
+      const bashEntry = preToolUse.find(e => e.matcher === 'Bash') as
+        { matcher?: string; hooks?: Array<{ command?: string; type?: string; timeout?: number }> } | undefined;
+      const hasSlopcheck = bashEntry?.hooks?.some(h => h.command?.includes('slopcheck-guard'));
+      if (bashEntry && !hasSlopcheck) {
+        bashEntry.hooks = bashEntry.hooks ?? [];
+        bashEntry.hooks.push({
+          type: 'command',
+          command: 'node ${CLAUDE_PROJECT_DIR}/.instar/hooks/instar/slopcheck-guard.js',
+          timeout: 5000,
+        });
+        patched = true;
+        result.upgraded.push('.claude/settings.json: added PreToolUse slopcheck-guard hook');
+      } else if (!bashEntry) {
+        // No Bash matcher at all — create one with just slopcheck (rare; most
+        // agents already have a Bash matcher with dangerous-command-guard).
+        preToolUse.push({
+          matcher: 'Bash',
+          hooks: [{
+            type: 'command',
+            command: 'node ${CLAUDE_PROJECT_DIR}/.instar/hooks/instar/slopcheck-guard.js',
+            timeout: 5000,
+          }] as never,
+        });
+        patched = true;
+        result.upgraded.push('.claude/settings.json: created PreToolUse Bash matcher with slopcheck-guard');
+      }
+    }
+
     // Ensure PostToolUse skill-usage-telemetry hook exists
     {
       const postToolUse = (hooks.PostToolUse || []) as Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>;
@@ -3652,12 +3692,13 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
    * Get the content of a named hook template.
    * Used by init.ts to share canonical hook content without duplication.
    */
-  getHookContent(name: 'session-start' | 'compaction-recovery' | 'external-operation-gate' | 'deferral-detector' | 'post-action-reflection' | 'external-communication-guard' | 'scope-coherence-collector' | 'scope-coherence-checkpoint' | 'claim-intercept' | 'claim-intercept-response' | 'telegram-topic-context' | 'response-review' | 'auto-approve-permissions' | 'skill-usage-telemetry' | 'build-stop-hook'): string {
+  getHookContent(name: 'session-start' | 'compaction-recovery' | 'external-operation-gate' | 'deferral-detector' | 'slopcheck-guard' | 'post-action-reflection' | 'external-communication-guard' | 'scope-coherence-collector' | 'scope-coherence-checkpoint' | 'claim-intercept' | 'claim-intercept-response' | 'telegram-topic-context' | 'response-review' | 'auto-approve-permissions' | 'skill-usage-telemetry' | 'build-stop-hook'): string {
     switch (name) {
       case 'session-start': return this.getSessionStartHook();
       case 'compaction-recovery': return this.getCompactionRecovery();
       case 'external-operation-gate': return this.getExternalOperationGateHook();
       case 'deferral-detector': return this.getDeferralDetectorHook();
+      case 'slopcheck-guard': return this.getSlopcheckGuardHook();
       case 'post-action-reflection': return this.getPostActionReflectionHook();
       case 'external-communication-guard': return this.getExternalCommunicationGuardHook();
       case 'scope-coherence-collector': return this.getScopeCoherenceCollectorHook();
@@ -4796,6 +4837,124 @@ process.stdin.on('end', () => {
 
     process.stdout.write(JSON.stringify({ decision: 'approve', additionalContext: checklist.join('\\n') }));
   } catch { /* don't break on errors */ }
+  process.exit(0);
+});
+`;
+  }
+
+  private getSlopcheckGuardHook(): string {
+    return `#!/usr/bin/env node
+// Slopcheck guard — package-legitimacy check on install commands.
+// PreToolUse hook for Bash. When the command is a package install
+// (npm/pnpm/yarn/pip/cargo), it extracts the package names and checks
+// whether each is already known to the project (present in a lockfile
+// or manifest). Unfamiliar packages get a confirmation nudge — does NOT
+// block, just surfaces the legitimacy question before a slopsquatted or
+// hallucinated package gets installed.
+//
+// Cherry-picked into Instar 2026-05-23 from the GSD-Instar integration
+// spike (gsd-executor Rule 3 exclusion: package installs are NOT
+// auto-fixable because a failed/typo'd install may be a slopsquat).
+// Signal-only — decision: approve + additionalContext. The agent decides.
+
+const fs = require('fs');
+const path = require('path');
+
+// Install-command patterns → capture the args portion after the verb.
+const INSTALL_PATTERNS = [
+  { re: /\\bnpm\\s+(?:i|install|add)\\s+([^&|;]+)/i, mgr: 'npm' },
+  { re: /\\bpnpm\\s+(?:i|install|add)\\s+([^&|;]+)/i, mgr: 'pnpm' },
+  { re: /\\byarn\\s+add\\s+([^&|;]+)/i, mgr: 'yarn' },
+  { re: /\\bpip3?\\s+install\\s+([^&|;]+)/i, mgr: 'pip' },
+  { re: /\\bcargo\\s+add\\s+([^&|;]+)/i, mgr: 'cargo' },
+];
+
+// Flags to strip when extracting package names.
+const FLAG_RE = /^-/;
+
+function parsePackages(argStr) {
+  return argStr
+    .trim()
+    .split(/\\s+/)
+    .filter(tok => tok && !FLAG_RE.test(tok))
+    // Strip version specifiers: pkg@1.2.3, pkg==1.2.3, pkg~=1.0
+    .map(tok => tok.replace(/[@=~<>!].*$/, '').replace(/\\[.*$/, ''))
+    .filter(Boolean);
+}
+
+// Returns the set of package names already known to the project from
+// any manifest/lockfile present in the project dir.
+function knownPackages(projectDir) {
+  const known = new Set();
+  const add = (name) => { if (name && typeof name === 'string') known.add(name.toLowerCase()); };
+
+  // package.json deps + devDeps + lock
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf-8'));
+    for (const k of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+      if (pkg[k]) Object.keys(pkg[k]).forEach(add);
+    }
+  } catch { /* no package.json */ }
+  // package-lock.json — names appear as keys; cheap substring presence check via raw read
+  let lockRaw = '';
+  for (const lf of ['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock', 'requirements.txt', 'Cargo.toml', 'Cargo.lock', 'Pipfile', 'pyproject.toml']) {
+    try { lockRaw += '\\n' + fs.readFileSync(path.join(projectDir, lf), 'utf-8'); } catch { /* absent */ }
+  }
+  return { known, lockRaw: lockRaw.toLowerCase() };
+}
+
+let data = '';
+process.stdin.on('data', chunk => data += chunk);
+process.stdin.on('end', () => {
+  try {
+    const input = JSON.parse(data);
+    if (input.tool_name !== 'Bash') process.exit(0);
+    const command = (input.tool_input || {}).command || '';
+    if (!command) process.exit(0);
+
+    let matched = null;
+    for (const p of INSTALL_PATTERNS) {
+      const m = command.match(p.re);
+      if (m) { matched = { mgr: p.mgr, args: m[1] }; break; }
+    }
+    if (!matched) process.exit(0);
+
+    const pkgs = parsePackages(matched.args);
+    if (pkgs.length === 0) process.exit(0);
+
+    const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+    const { known, lockRaw } = knownPackages(projectDir);
+
+    // A package is "familiar" if it's in the manifest deps OR appears as a
+    // token in any lockfile (covers transitive + already-installed).
+    const unfamiliar = pkgs.filter(pkg => {
+      const low = pkg.toLowerCase();
+      if (known.has(low)) return false;
+      // Word-boundary-ish presence in lockfiles (quoted or pathed)
+      if (lockRaw.includes('"' + low + '"') || lockRaw.includes('/' + low) ||
+          lockRaw.includes(low + '@') || lockRaw.includes(low + ' ') || lockRaw.includes(low + '==')) return false;
+      return true;
+    });
+
+    if (unfamiliar.length === 0) process.exit(0);
+
+    const checklist = [
+      'SLOPCHECK — installing package(s) not already known to this project: ' + unfamiliar.join(', '),
+      '',
+      'Before installing an unfamiliar package, confirm it is legitimate (not a',
+      'slopsquat or a hallucinated name):',
+      '',
+      '1. Is the spelling exactly right? Typosquats differ by one or two characters.',
+      '2. Does the package actually exist on its registry, with real download counts',
+      '   and a credible publisher? (npmjs.com / pypi.org / crates.io)',
+      '3. Did YOU choose this package deliberately, or did it come from an LLM',
+      '   suggestion that might be hallucinated?',
+      '4. Is there a more-established alternative you already trust?',
+      '',
+      'This is a nudge, not a block. If the package is legitimate, proceed.',
+    ];
+    process.stdout.write(JSON.stringify({ decision: 'approve', additionalContext: checklist.join('\\n') }));
+  } catch { /* never block on errors */ }
   process.exit(0);
 });
 `;

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -59,6 +59,15 @@
       "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
       "since": "2025-01-01"
     },
+    "hook:slopcheck-guard": {
+      "id": "hook:slopcheck-guard",
+      "type": "hook",
+      "domain": "safety",
+      "sourcePath": "src/core/PostUpdateMigrator.ts",
+      "installedPath": ".instar/hooks/instar/slopcheck-guard.js",
+      "contentHash": "e32c85f03cb2d4d440172949fb5f7654c7c224a7cd64c78ed1c7b83759e1c2c9",
+      "since": "2026-05-23"
+    },
     "hook:post-action-reflection": {
       "id": "hook:post-action-reflection",
       "type": "hook",

--- a/src/templates/hooks/settings-template.json
+++ b/src/templates/hooks/settings-template.json
@@ -33,6 +33,11 @@
           },
           {
             "type": "command",
+            "command": "node .instar/hooks/instar/slopcheck-guard.js",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
             "command": "node .instar/hooks/instar/external-communication-guard.js",
             "timeout": 5000
           }

--- a/tests/unit/slopcheck-guard.test.ts
+++ b/tests/unit/slopcheck-guard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the slopcheck-guard PreToolUse hook.
+ *
+ * Materializes the hook from PostUpdateMigrator.getSlopcheckGuardHook(),
+ * pipes Bash tool-call payloads, and asserts the nudge fires only for
+ * unfamiliar packages on real install commands.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let projectDir: string;
+let hookPath: string;
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slopcheck-test-'));
+  const migrator = new PostUpdateMigrator(projectDir);
+  hookPath = path.join(projectDir, 'slopcheck-guard.js');
+  fs.writeFileSync(hookPath, migrator.getHookContent('slopcheck-guard'), { mode: 0o755 });
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/slopcheck-guard.test.ts' });
+});
+
+function runHook(command: string): { decision?: string; additionalContext?: string } {
+  const r = spawnSync('node', [hookPath], {
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command } }),
+    encoding: 'utf-8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+  });
+  if (!r.stdout.trim()) return {};
+  try { return JSON.parse(r.stdout); } catch { return {}; }
+}
+
+function writePackageJson(deps: Record<string, string>) {
+  fs.writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify({ name: 't', dependencies: deps }, null, 2));
+}
+
+describe('slopcheck-guard hook', () => {
+  it('non-install Bash commands pass through silently', () => {
+    expect(runHook('ls -la').additionalContext).toBeUndefined();
+    expect(runHook('git status').additionalContext).toBeUndefined();
+    expect(runHook('npm run build').additionalContext).toBeUndefined();
+    expect(runHook('npm test').additionalContext).toBeUndefined();
+  });
+
+  it('npm install of an unfamiliar package fires the nudge', () => {
+    writePackageJson({ express: '^4.0.0' });
+    const dec = runHook('npm install left-pad-typosquat');
+    expect(dec.decision).toBe('approve');
+    expect(dec.additionalContext).toContain('SLOPCHECK');
+    expect(dec.additionalContext).toContain('left-pad-typosquat');
+  });
+
+  it('npm install of a package already in package.json does NOT fire', () => {
+    writePackageJson({ express: '^4.0.0' });
+    const dec = runHook('npm install express');
+    expect(dec.additionalContext).toBeUndefined();
+  });
+
+  it('strips version specifiers when matching', () => {
+    writePackageJson({ express: '^4.0.0' });
+    expect(runHook('npm install express@4.18.2').additionalContext).toBeUndefined();
+    expect(runHook('pip install requests==2.31.0').additionalContext).toContain('requests');
+  });
+
+  it('recognizes pnpm / yarn / pip / cargo install verbs', () => {
+    expect(runHook('pnpm add some-new-pkg').additionalContext).toContain('some-new-pkg');
+    expect(runHook('yarn add another-new-pkg').additionalContext).toContain('another-new-pkg');
+    expect(runHook('pip install brand-new-py').additionalContext).toContain('brand-new-py');
+    expect(runHook('cargo add brand-new-crate').additionalContext).toContain('brand-new-crate');
+  });
+
+  it('packages present in a lockfile are treated as familiar', () => {
+    fs.writeFileSync(path.join(projectDir, 'package-lock.json'), JSON.stringify({
+      packages: { 'node_modules/lodash': { version: '4.17.21' } },
+    }));
+    // raw lockfile contains "lodash" — treated as known
+    expect(runHook('npm install lodash').additionalContext).toBeUndefined();
+  });
+
+  it('multiple packages — only unfamiliar ones are flagged', () => {
+    writePackageJson({ express: '^4.0.0' });
+    const dec = runHook('npm install express brand-new-thing');
+    expect(dec.additionalContext).toContain('brand-new-thing');
+    expect(dec.additionalContext).not.toContain('express,'); // express is familiar, not listed
+  });
+
+  it('flags are stripped, not treated as packages', () => {
+    writePackageJson({});
+    const dec = runHook('npm install --save-dev newpkg');
+    expect(dec.additionalContext).toContain('newpkg');
+    expect(dec.additionalContext).not.toContain('--save-dev');
+  });
+
+  it('malformed input never blocks', () => {
+    const r = spawnSync('node', [hookPath], {
+      input: 'garbage',
+      encoding: 'utf-8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+  });
+
+  it('is signal-only — never emits a block decision', () => {
+    writePackageJson({});
+    const dec = runHook('npm install something-unfamiliar');
+    expect(dec.decision).toBe('approve');
+    expect((dec as Record<string, unknown>).block).toBeUndefined();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,33 +1,29 @@
 # Upgrade Guide — vNEXT
 
-<!-- bump: minor -->
+<!-- bump: patch -->
 
 ## What Changed
 
-**feat(skill): /verify-claim — 4-tier verification protocol (GSD cherry-pick).**
+**feat(hooks): slopcheck-guard — package-legitimacy check on installs (GSD cherry-pick).**
 
-New user-invocable skill that runs goal-backward verification of a claim that something is built/wired/working. Cherry-picked from the GSD verifier methodology — the spike's highest-leverage finding.
+New PreToolUse hook that catches install commands (npm/pnpm/yarn/pip/cargo) for packages not already known to the project, and nudges the agent to confirm the package is legitimate before installing. Defends against slopsquatted and hallucinated package names.
 
-Four levels, run in order, stop at the first failure:
-- EXISTENCE — does the artifact exist?
-- SUBSTANTIVE — is it real, not a stub?
-- WIRED — is it imported AND invoked from the real path? (the level green tests most often skip — a component can compile + pass unit tests yet never be instantiated in the boot path)
-- DATA-FLOW — does real data actually flow through it (not 503/empty/hardcoded)?
+When the staged Bash command is a package install, the hook extracts the package names, checks each against the project's manifests and lockfiles (package.json, package-lock.json, requirements.txt, Cargo.toml, etc.), and for any unfamiliar package injects a confirmation checklist (spelling, registry existence, deliberate-vs-hallucinated, established-alternative).
 
-Reports a status: VERIFIED / HOLLOW / ORPHANED / STUB / MISSING. Use before any "shipped" / "wired in" / "running" / "it works" message — directly addresses the "verify a component is actually wired" lesson (PR #334 shipped sentinels as dead code with a false wired-into-startup claim).
+Signal-only — never blocks. Borrowed from gsd-executor's Rule 3 exclusion (package installs are NOT auto-fixable precisely because a failed/typo'd install may be a slopsquat).
 
 ## Evidence
 
-6 unit tests, all green: installs SKILL.md, valid frontmatter, user-invocable, documents all four levels + the full status taxonomy, idempotent (does not overwrite a user-customized copy). TypeScript clean.
+10 unit tests, all green: non-install commands pass silently, unfamiliar npm install fires the nudge, packages in package.json/lockfile are familiar, version specifiers stripped, all five package managers recognized, multi-package commands flag only unfamiliar ones, flags stripped, malformed input never blocks, signal-only (never emits block). TypeScript clean.
 
-Migration parity: adding a new skill needs no migration — installBuiltinSkills() runs on every update and is non-destructive (writes missing SKILL.md only). Verified idempotency in the test.
+Migration parity verified: new agents get it via settings-template.json; existing agents get it via an explicit ensure-block in `migrateSettings()` (added the Bash-matcher slopcheck entry if absent). Hook script always-overwritten by `migrateHooks()`. Registered in builtin-manifest.json + known-builtin-hooks list.
 
-Side-effects review: `upgrades/side-effects/verify-claim-skill.md`.
+Side-effects review: `upgrades/side-effects/slopcheck-guard.md`.
 
 ## What to Tell Your User
 
-You have a new /verify-claim skill. When you want to be sure something is actually done — not just compiles, not just passes unit tests, but actually wired into the running system and carrying real data — invoke /verify-claim. It runs a four-step check and tells you plainly whether the thing is VERIFIED or only half-done.
+Nothing user-visible. The hook fires silently and only the agent sees the nudge, only when installing an unfamiliar package. Existing agents pick it up on next `instar upgrade`.
 
 ## Summary of New Capabilities
 
-One new user-invocable skill. The 4-tier protocol becomes a callable primitive any agent can run before claiming completion, and /build Phase 3 VERIFY can invoke it per must-have. Framework-agnostic (pure prompt skill, no code).
+One new PreToolUse hook on the Bash matcher. Catches the supply-chain risk that a hallucinated or typosquatted package name slips into an install. Framework-agnostic (pure Node, no Claude/Codex specifics).

--- a/upgrades/side-effects/slopcheck-guard.md
+++ b/upgrades/side-effects/slopcheck-guard.md
@@ -1,0 +1,36 @@
+# Side-Effects Review — Slopcheck Guard Hook
+
+**Source:** Cherry-pick from GSD-Instar spike (gsd-executor Rule 3 exclusion)
+**Author:** Echo · autonomous run · 2026-05-23
+
+## 1. Over-block
+Could over-fire on legitimate installs of new-but-real packages. Mitigation: NEVER blocks — signal-only nudge. Worst case is one extra checklist the agent reads and proceeds past. Familiar packages (in any manifest/lockfile) are silently skipped.
+
+## 2. Under-block
+Could miss a slopsquat if it happens to share a token with something in a lockfile. Mitigation: the lockfile presence check is deliberately loose (favors NOT nagging on known-safe). The nudge is a backstop, not the only defense — the agent still reasons about each install. Acceptable: under-block here means "no extra nudge", not "install proceeds unchecked" (the agent always sees the command).
+
+## 3. Level-of-abstraction fit
+PreToolUse Bash hook alongside dangerous-command-guard, deferral-detector, grounding-before-messaging. Same layer, same idiom, same generator pattern (PostUpdateMigrator getter).
+
+## 4. Signal-vs-authority compliance
+Compliant. Pure pattern-match + lockfile lookup = low-context filter emitting a signal (additionalContext). The agent (full-context authority) decides whether to install. Never blocks.
+
+## 5. Cross-feature interactions
+- dangerous-command-guard (PreToolUse Bash, blocking) runs first and independently — no overlap (it blocks destructive commands; slopcheck nudges on installs).
+- deferral-detector (PreToolUse Bash) matches communication commands — no overlap with install commands.
+- The hook reads project manifests read-only; no mutation, no shared state.
+- Edge: `echo npm install foo` would trigger the nudge (regex matches anywhere). Harmless — signal-only, rare, and erring toward caution on anything that looks like an install is the safe direction.
+
+## 6. Rollback cost
+Trivial. One generator method, one settings-template entry, one migrateSettings ensure-block, one manifest entry, one known-list entry, one test file. Revert the commit; the hook stops generating and existing copies become inert.
+
+## 7. Migration parity
+Full coverage:
+- New agents: settings-template.json PreToolUse Bash entry.
+- Existing agents: explicit ensure-block in migrateSettings() adds the slopcheck entry to the Bash matcher if absent (idempotent — checks `hasSlopcheck` first).
+- Hook script: always-overwritten by migrateHooks() (built-in hook).
+- builtin-manifest.json: registered.
+- known-builtin-hooks list: registered (orphan-cleanup safe).
+
+## Conclusion
+Ship. Real supply-chain defense Instar lacked. Signal-only, trivial rollback, full migration parity. Seven-dimension review clean.


### PR DESCRIPTION
## Summary
Cherry-pick from the GSD-Instar spike (gsd-executor Rule 3 exclusion). New PreToolUse Bash hook that nudges the agent to confirm legitimacy before installing unfamiliar packages — defends against slopsquats and hallucinated package names.

## Behavior
On a package install command (npm/pnpm/yarn/pip/cargo), extracts package names, checks each against the project's manifests + lockfiles, and injects a confirmation checklist for any unfamiliar one. Signal-only — never blocks.

## Tests
10 unit tests, all green. TypeScript clean.

## Migration parity
- New agents: settings-template.json Bash matcher entry
- Existing agents: explicit ensure-block in `migrateSettings()` (idempotent)
- Always-overwritten hook via `migrateHooks()`; registered in builtin-manifest + known-builtin-hooks list

## Side-effects
`upgrades/side-effects/slopcheck-guard.md` — seven-dimension review clean, signal-only, trivial rollback, full migration parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)