### PR TITLE
feat(build): /build methodology bundle — 4 GSD cherry-picks + defense-in-depth doc

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -76,11 +76,12 @@ if not any('build-stop-hook' in str(h) for h in hooks):
 
 ```
 Phase 0: CLARIFY (optional)    Score ambiguity, ask questions
+Phase 0.5: MUST-HAVES          Goal-backward truths + artifacts + key_links (+ STRIDE on LARGE)
 Phase 1: PLAN                  Architecture + test strategy
-Phase 2: EXECUTE               Build incrementally with tests at every step
+Phase 2: EXECUTE               Build incrementally with tests + atomic per-task commits
 Phase 3: VERIFY                Independent review + real-world testing
 Phase 4: HARDEN                Observability + self-improvement
-Phase 5: COMPLETE              Merge worktree, deploy, capture learnings
+Phase 5: COMPLETE              Merge worktree, deploy, capture learnings + SUMMARY deviations
 ```
 
 Advance phases with: `python3 playbook-scripts/build-state.py transition <phase> --evidence "reason"`
@@ -92,6 +93,43 @@ Advance phases with: `python3 playbook-scripts/build-state.py transition <phase>
 Score ambiguity across 5 dimensions (scope 30%, requirements 25%, architecture 20%, success criteria 15%, dependencies 10%).
 
 If weighted score > 0.20: Ask ONE clarifying question targeting the weakest dimension.
+
+---
+
+## Phase 0.5: MUST-HAVES (goal-backward) — cherry-picked from GSD planner
+
+Before planning HOW, state WHAT must be observably true. Goal-backward beats jumping straight to a task list — it surfaces the verification gates and the wiring checks that ad-hoc planning forgets.
+
+Write a `must_haves` block to `.instar/state/build/must-haves.md`:
+
+```markdown
+## Truths (observable, from the consumer's perspective)
+- "<thing that must be TRUE when this is done — e.g. GET /x returns 200 with real data, not 503>"
+- "<another truth — e.g. component Y is constructed AND started in the boot path>"
+
+## Artifacts (what must exist + be substantive + be wired)
+- path: src/...    provides: "<what>"    contains: "<grep-able signature>"
+
+## Key links (the WIRED check — grep patterns proving real wiring, not just file existence)
+- from: src/server/routes.ts  to: src/server/xRoutes.ts  via: "createXRoutes mounted"  pattern: "createXRoutes"
+- from: src/commands/server.ts  to: src/core/X.ts  via: "new X(...) constructed at boot"  pattern: "new X"
+```
+
+Each truth becomes a Phase 3 verification gate. Each key_link's grep pattern becomes the WIRED check (run `/verify-claim` against it). This is what prevents shipping a component that compiles + passes unit tests but is never instantiated (the dead-code failure).
+
+### STRIDE threat pass (LARGE builds only; optional for STANDARD)
+
+For LARGE builds, also enumerate threats. Output a small register to `.instar/state/build/threats.md`:
+
+```markdown
+| ID | STRIDE category | Threat | Mitigation | Bound test |
+|----|-----------------|--------|------------|-----------|
+| T-01 | Information disclosure | <e.g. diagnostics endpoint leaks raw user content> | <allowlist filter> | tests/.../x-pii.test.ts |
+```
+
+STRIDE = Spoofing, Tampering, Repudiation, Information disclosure, Denial of service, Elevation of privilege. Most rows for a given build are empty — that's fine; the value is the one or two real threats it surfaces. Each mitigation binds to a specific test (no hand-waving). Skip the table entirely for SMALL builds.
+
+**Quality Gate**: must-haves.md exists before Phase 1. On LARGE, threats.md exists too.
 
 ---
 
@@ -136,6 +174,16 @@ Write Code -> Write Tests -> Run Tests -> Fix -> Verify Full Suite
 **NEVER** move to the next step with failing tests.
 
 Max 3 fix cycles per step before escalation.
+
+### Atomic-commit discipline (cherry-picked from GSD executor)
+
+Commit per-task, not in one mega-commit at the end. A single 3000-line commit is unreviewable; per-task commits give a readable history and a clean revert surface.
+
+- **One commit per plan step** once its tests pass — not one commit for the whole build.
+- **Stage specific files by name** — `git add src/x.ts tests/unit/x.test.ts`. NEVER `git add -A` / `git add .` (sweeps in unrelated WIP, secrets, build residue).
+- **Commit-message format**: `{type}({scope}): {summary}` — e.g. `feat(topic-intent): add EvidenceEvent projection`. Types: feat / fix / refactor / test / docs / chore.
+- **Verify no accidental deletions**: `git diff --diff-filter=D HEAD~1 HEAD` after each commit.
+- Track each commit's short SHA for the Phase 5 SUMMARY.
 
 ---
 
@@ -183,11 +231,33 @@ If verification fails: transition to fixing, max 3 cycles.
 ## Phase 5: COMPLETE
 
 1. **Final test run** — Full suite in worktree: `npm run test:all`
-2. **Merge worktree** — Commit all changes, merge back to source branch:
+2. **Write SUMMARY.md with tracked deviations** (cherry-picked from GSD executor) — before merging, write `.instar/state/build/SUMMARY.md`:
+
+```markdown
+## What shipped
+- <one line per plan step + its commit SHA>
+
+## Deviations from plan (categorized)
+- [Rule 1 - auto-fixed bug] <what + why>
+- [Rule 2 - added critical missing functionality] <what + why — e.g. atomic-write, input validation>
+- [Rule 3 - auto-fixed blocking issue] <what>
+- [Rule 4 - architectural decision deferred/changed] <what + whether it needs user confirmation>
+
+## Must-haves verification (from Phase 0.5)
+- <each truth> → VERIFIED / HOLLOW / ORPHANED (run /verify-claim per key_link)
+
+## Deferred (with backing infrastructure, NOT orphan TODOs)
+- <item> → tracked via <scheduled job / commit-action / same-branch follow-up>
+```
+
+The deviation log is the antidote to "I changed a bunch of stuff during the build and don't remember what diverged from the plan." Empty sections are fine; the discipline is enumerating, not padding.
+
+3. **Merge worktree** — commit any remaining changes with atomic per-file staging (NEVER `git add -A`), then merge back:
 
 ```bash
-# In worktree: commit all changes
-git add -A && git commit -m "feat: DESCRIPTION"
+# In worktree: stage specific files, commit with {type}({scope}): {summary}
+git add <specific files>
+git commit -m "feat(scope): final integration"
 
 # Back in main directory
 cd /path/to/project
@@ -195,9 +265,9 @@ python3 playbook-scripts/build-state.py worktree-merge
 python3 playbook-scripts/build-state.py worktree-cleanup
 ```
 
-3. **Build & verify** — `npm run build` from main directory, verify zero errors
-4. **Capture learnings** — Write to MEMORY.md if significant
-5. **Generate report**:
+4. **Build & verify** — `npm run build` from main directory, verify zero errors
+5. **Capture learnings** — Write to MEMORY.md if significant
+6. **Generate report**:
 
 ```bash
 python3 playbook-scripts/build-state.py report

--- a/docs/patterns/defense-in-depth-insert-and-projection.md
+++ b/docs/patterns/defense-in-depth-insert-and-projection.md
@@ -1,0 +1,43 @@
+# Pattern — Insert-Time + Projection-Time Defense-in-Depth
+
+**Status:** pattern doc · cherry-picked from the GSD-Instar integration spike (2026-05-23)
+
+## The pattern
+
+When a constraint can be enforced at more than one layer, enforce it at both — the cheap deterministic layer AND the authoritative computed layer. A single-layer guarantee silently degrades when the un-guarded layer is reached by a path you didn't anticipate.
+
+The canonical shape:
+
+- **Insert-time check** — runs when data enters the system. Cheap, local, catches the common case immediately, and keeps bad data from accumulating.
+- **Projection/read-time check** — runs when the truth is computed from accumulated data. Authoritative, sees the whole picture, and is the final word.
+
+Neither alone is sufficient:
+
+- Insert-time alone misses anything that arrives through a path that skips the insert guard (a migration, a backfill, a second writer, a future caller).
+- Projection-time alone lets bad data pile up in storage and pay the recompute cost on every read; it also can't stop a caller that reads raw storage instead of going through the projection.
+
+## Worked example — the Topic Intent Layer affirmation cap
+
+The Topic Intent Layer (Layer 1) caps how much a single user affirmation can raise confidence in a tracked decision: one affirmation bonus per refId per 24h.
+
+- **Projection-time** (`projectConfidence`): when computing confidence on read, the projection groups affirmation events by day and counts only the first per 24h window. This is the authoritative cap — even if extra affirmation events exist in storage, the computed confidence respects the limit.
+- **Insert-time** (the extractor / the path that appends evidence): SHOULD also refuse to append a second affirmation event for the same refId within 24h. This keeps the event log clean, makes the projection cheaper, and — critically — defends the invariant even if some future caller computes confidence by a different path or reads a partial projection.
+
+The spike's gsd-executor methodology pass flagged that the Topic Intent Layer shipped with the projection-time cap only. That's correct and authoritative for the confidence value, but it leaves the event log able to accumulate redundant affirmation events, and it assumes every confidence read goes through the one projection function. Adding the insert-time cap closes both gaps. (Tracked as a Layer 1 follow-up.)
+
+## When to apply
+
+Reach for this pattern whenever:
+
+- A cap, quota, or invariant is computed from accumulated state (event logs, counters, ledgers).
+- More than one code path can write the underlying data.
+- The constraint protects against a corruption-class failure (silent authority laundering, quota bypass, unbounded growth).
+
+## When NOT to apply
+
+- The constraint is purely cosmetic or easily recovered — one layer is fine.
+- There is genuinely a single, guaranteed-sole write path AND a single read path — though "guaranteed sole" is a strong claim that tends to erode as the system grows, so bias toward both layers when the cost is low.
+
+## Relationship to signal-vs-authority
+
+This is compatible with `docs/signal-vs-authority.md`, not in tension with it. The insert-time check is a low-context SIGNAL/filter; the projection-time check is the AUTHORITY. Defense-in-depth says: run the cheap signal early AND keep the authoritative computation as the final word. The signal never overrides the authority — it just stops the common case before it accumulates.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -186,6 +186,7 @@ export class PostUpdateMigrator {
     this.migrateBuiltinJobs(result);
     this.autoMigrateLegacyJobsJson(result);
     this.migrateSkillPortHardcoding(result);
+    this.migrateBuildSkillMethodology(result);
     this.migrateSelfKnowledgeTree(result);
     this.migrateSoulMd(result);
     this.migrateAgentMdSections(result);
@@ -1083,6 +1084,42 @@ export class PostUpdateMigrator {
       } catch (err) {
         result.errors.push(`skills/${name}/SKILL.md port migration: ${err instanceof Error ? err.message : String(err)}`);
       }
+    }
+  }
+
+  /**
+   * Update the /build skill with the GSD-cherry-pick methodology sections
+   * (Phase 0.5 must-haves + STRIDE, atomic-commit discipline, SUMMARY
+   * deviation-tracking). installBuildSkill is install-if-missing, so existing
+   * agents need an explicit content-update migration.
+   *
+   * Idempotent + conservative: only re-copies the bundled SKILL.md when the
+   * installed copy (a) lacks the new "Phase 0.5: MUST-HAVES" marker AND
+   * (b) still looks like the stock /build skill (contains "Rigorous Build
+   * Skill" + "Phase 5: COMPLETE"). A heavily-customized /build skill that no
+   * longer matches the stock fingerprint is left untouched.
+   */
+  private migrateBuildSkillMethodology(result: MigrationResult): void {
+    try {
+      const skillFile = path.join(this.config.projectDir, '.claude', 'skills', 'build', 'SKILL.md');
+      if (!fs.existsSync(skillFile)) return; // installBuildSkill handles fresh installs
+      const current = fs.readFileSync(skillFile, 'utf8');
+      if (current.includes('Phase 0.5: MUST-HAVES')) return; // already updated — idempotent
+      // Stock-fingerprint guard: don't clobber a customized /build skill.
+      if (!current.includes('Rigorous Build Skill') || !current.includes('Phase 5: COMPLETE')) {
+        result.skipped.push('skills/build/SKILL.md: customized — left untouched (no methodology update)');
+        return;
+      }
+      // Re-copy the bundled SKILL.md (which carries the new sections).
+      const bundled = path.join(__dirname, '..', '..', '.claude', 'skills', 'build', 'SKILL.md');
+      if (!fs.existsSync(bundled)) return;
+      const next = fs.readFileSync(bundled, 'utf8');
+      if (next.includes('Phase 0.5: MUST-HAVES')) {
+        fs.writeFileSync(skillFile, next);
+        result.upgraded.push('skills/build/SKILL.md (GSD methodology: must-haves + atomic-commit + SUMMARY deviations)');
+      }
+    } catch (err) {
+      result.errors.push(`skills/build/SKILL.md methodology migration: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/unit/migrate-build-skill-methodology.test.ts
+++ b/tests/unit/migrate-build-skill-methodology.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for migrateBuildSkillMethodology — updates the /build skill
+ * with the GSD cherry-pick methodology sections for existing agents.
+ *
+ * installBuildSkill is install-if-missing, so existing agents need this
+ * content-update migration. Tests cover: stock skill gets updated,
+ * idempotency, and customized skills left untouched.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let projectDir: string;
+
+function makeMigrator(): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function emptyResult() {
+  return { upgraded: [] as string[], skipped: [] as string[], errors: [] as string[] };
+}
+
+function writeBuildSkill(content: string): string {
+  const dir = path.join(projectDir, '.claude', 'skills', 'build');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'SKILL.md');
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+// A stock /build skill missing the new methodology sections.
+const STOCK_OLD = `---
+name: build
+---
+
+# /build — Rigorous Build Skill
+
+## Phase 2: EXECUTE
+do work
+
+## Phase 5: COMPLETE
+merge
+`;
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'build-skill-migration-'));
+});
+
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/migrate-build-skill-methodology.test.ts' });
+});
+
+describe('migrateBuildSkillMethodology', () => {
+  it('updates a stock /build skill missing the Phase 0.5 marker', () => {
+    const file = writeBuildSkill(STOCK_OLD);
+    const result = emptyResult();
+    (makeMigrator() as unknown as { migrateBuildSkillMethodology: (r: typeof result) => void })
+      .migrateBuildSkillMethodology(result);
+    const updated = fs.readFileSync(file, 'utf8');
+    // The bundled source has the new sections — after migration the marker is present.
+    expect(updated).toContain('Phase 0.5: MUST-HAVES');
+    expect(result.upgraded.some(u => u.includes('skills/build/SKILL.md'))).toBe(true);
+  });
+
+  it('is idempotent — a skill that already has the marker is left unchanged', () => {
+    const alreadyUpdated = STOCK_OLD.replace('## Phase 2: EXECUTE', '## Phase 0.5: MUST-HAVES\nstuff\n\n## Phase 2: EXECUTE');
+    const file = writeBuildSkill(alreadyUpdated);
+    const before = fs.readFileSync(file, 'utf8');
+    const result = emptyResult();
+    (makeMigrator() as unknown as { migrateBuildSkillMethodology: (r: typeof result) => void })
+      .migrateBuildSkillMethodology(result);
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+    expect(result.upgraded).toEqual([]);
+  });
+
+  it('leaves a heavily-customized /build skill untouched (no stock fingerprint)', () => {
+    const customized = `---\nname: build\n---\n\n# My Totally Custom Build Flow\n\nnothing stock here\n`;
+    const file = writeBuildSkill(customized);
+    const result = emptyResult();
+    (makeMigrator() as unknown as { migrateBuildSkillMethodology: (r: typeof result) => void })
+      .migrateBuildSkillMethodology(result);
+    expect(fs.readFileSync(file, 'utf8')).toBe(customized);
+    expect(result.skipped.some(s => s.includes('customized'))).toBe(true);
+  });
+
+  it('does nothing when no /build skill is installed (fresh-install path handles it)', () => {
+    const result = emptyResult();
+    expect(() =>
+      (makeMigrator() as unknown as { migrateBuildSkillMethodology: (r: typeof result) => void })
+        .migrateBuildSkillMethodology(result)
+    ).not.toThrow();
+    expect(result.upgraded).toEqual([]);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,29 +1,32 @@
 # Upgrade Guide — vNEXT
 
-<!-- bump: patch -->
+<!-- bump: minor -->
 
 ## What Changed
 
-**feat(hooks): slopcheck-guard — package-legitimacy check on installs (GSD cherry-pick).**
+**feat(build): /build methodology bundle — four GSD cherry-picks + defense-in-depth doc.**
 
-New PreToolUse hook that catches install commands (npm/pnpm/yarn/pip/cargo) for packages not already known to the project, and nudges the agent to confirm the package is legitimate before installing. Defends against slopsquatted and hallucinated package names.
+Four enhancements to the /build skill, all from the GSD-Instar spike, bundled in one PR because they all touch the /build SKILL.md:
 
-When the staged Bash command is a package install, the hook extracts the package names, checks each against the project's manifests and lockfiles (package.json, package-lock.json, requirements.txt, Cargo.toml, etc.), and for any unfamiliar package injects a confirmation checklist (spelling, registry existence, deliberate-vs-hallucinated, established-alternative).
+- **Phase 0.5: MUST-HAVES (goal-backward)** — before planning HOW, state WHAT must be observably true: truths (consumer-perspective), artifacts (exist + substantive + wired), and key_links (grep patterns proving real wiring). Each truth becomes a Phase 3 verification gate. Prevents shipping a component that compiles + passes unit tests but is never instantiated.
+- **STRIDE threat pass** (LARGE builds only) — a small threat register where each mitigation binds to a specific test. Skipped for SMALL builds.
+- **Atomic-commit discipline** in Phase 2 EXECUTE — one commit per plan step, stage specific files by name (never `git add -A`), `{type}({scope}): {summary}` format, verify no accidental deletions. Replaces the old single-mega-commit guidance (which was unreviewable).
+- **SUMMARY.md deviation-tracking** in Phase 5 COMPLETE — enumerate deviations from plan, categorized by the executor Rule 1/2/3/4, plus the must-haves verification result and any infrastructure-backed deferrals.
 
-Signal-only — never blocks. Borrowed from gsd-executor's Rule 3 exclusion (package installs are NOT auto-fixable precisely because a failed/typo'd install may be a slopsquat).
+Also adds `docs/patterns/defense-in-depth-insert-and-projection.md` — the insert-time + projection-time pattern the spike surfaced (with the Topic Intent Layer affirmation cap as the worked example).
 
 ## Evidence
 
-10 unit tests, all green: non-install commands pass silently, unfamiliar npm install fires the nudge, packages in package.json/lockfile are familiar, version specifiers stripped, all five package managers recognized, multi-package commands flag only unfamiliar ones, flags stripped, malformed input never blocks, signal-only (never emits block). TypeScript clean.
+4 unit tests for the migration (migrateBuildSkillMethodology): stock skill updated, idempotent, customized skill untouched, no-throw on missing. TypeScript clean.
 
-Migration parity verified: new agents get it via settings-template.json; existing agents get it via an explicit ensure-block in `migrateSettings()` (added the Bash-matcher slopcheck entry if absent). Hook script always-overwritten by `migrateHooks()`. Registered in builtin-manifest.json + known-builtin-hooks list.
+Migration parity: installBuildSkill is install-if-missing, so existing agents get the methodology via a content-sniffed idempotent migration (only updates a stock /build skill lacking the "Phase 0.5: MUST-HAVES" marker; leaves customized skills alone).
 
-Side-effects review: `upgrades/side-effects/slopcheck-guard.md`.
+Side-effects review: `upgrades/side-effects/build-methodology-bundle.md`.
 
 ## What to Tell Your User
 
-Nothing user-visible. The hook fires silently and only the agent sees the nudge, only when installing an unfamiliar package. Existing agents pick it up on next `instar upgrade`.
+Your /build skill got sharper. It now asks "what must be true when this is done?" before planning, commits work in reviewable per-task chunks instead of one giant commit, and writes a short deviation log at the end so you can see exactly what changed from the original plan. On big builds it also does a quick threat pass. Nothing you have to do differently — /build just does more of the right thing automatically.
 
 ## Summary of New Capabilities
 
-One new PreToolUse hook on the Bash matcher. Catches the supply-chain risk that a hallucinated or typosquatted package name slips into an install. Framework-agnostic (pure Node, no Claude/Codex specifics).
+Four /build methodology sections + one pattern doc + one content-update migration + 4 migration tests. Framework-agnostic (prompt-skill content + a migration). The methodology is the GSD planner/executor discipline imported as Instar's own.

--- a/upgrades/side-effects/build-methodology-bundle.md
+++ b/upgrades/side-effects/build-methodology-bundle.md
@@ -1,0 +1,34 @@
+# Side-Effects Review — /build Methodology Bundle
+
+**Source:** Cherry-picks from GSD-Instar spike (gsd-planner + gsd-executor methodology)
+**Author:** Echo · autonomous run · 2026-05-23
+
+## 1. Over-block
+None — these are prompt-skill methodology sections, not gates. They add steps the agent runs, not blocks. The Phase 0.5 "quality gate" (must-haves.md exists before Phase 1) is a soft self-check inside the skill, not an external block.
+
+## 2. Under-block
+The methodology is advisory within /build. An agent could skip Phase 0.5. Enforcement of the spirit lives elsewhere (e2e-pairing pre-commit gate, /verify-claim, response-review). This bundle imports the DISCIPLINE; the structural gates are separate cherry-picks.
+
+## 3. Level-of-abstraction fit
+All four changes are content edits to the /build SKILL.md — the natural home for build methodology. The defense-in-depth doc lives in docs/patterns/ alongside other pattern docs. The migration follows the existing migrateSkillPortHardcoding content-sniff pattern.
+
+## 4. Signal-vs-authority compliance
+Compatible. Phase 0.5 must-haves PRODUCE the verification signals that Phase 3 (authority: the agent + reviewers) acts on. STRIDE mitigations bind to tests (the authority). The defense-in-depth doc explicitly reconciles itself with signal-vs-authority. No brittle filter is given blocking authority.
+
+## 5. Cross-feature interactions
+- Phase 0.5 key_links + /verify-claim (separate PR) compose: must-haves define the wiring; /verify-claim checks it.
+- Atomic-commit discipline aligns with the e2e-pairing pre-commit gate (per-task commits make the gate's per-commit check meaningful).
+- SUMMARY deviation-tracking references the executor Rule 1/2/3/4 vocabulary (consistent with the deferral-detector + the GSD methodology framing).
+- The old Phase 5 `git add -A` guidance is REPLACED (it contradicted the new atomic-commit discipline) — a deliberate fix, not just an addition.
+- Migration only touches a stock /build skill; customized skills are fingerprint-guarded.
+
+## 6. Rollback cost
+Moderate-low. Revert the SKILL.md edits + the migration method + the doc + the migration test. Existing agents that already ran the migration would keep the updated SKILL.md (harmless — the new sections are additive guidance). The migration is idempotent and conservative, so a revert-then-re-apply is safe.
+
+## 7. Migration parity
+- New agents: bundled SKILL.md (copied by installBuildSkill on fresh init) carries the sections.
+- Existing agents: migrateBuildSkillMethodology() content-sniffs for the Phase 0.5 marker and re-copies the bundled SKILL.md if absent AND the file matches the stock fingerprint. Wired into the migration sequence after migrateSkillPortHardcoding. Idempotent + fingerprint-guarded (verified by 4 tests).
+- The defense-in-depth doc is a repo doc, not an agent-installed file — ships with the package, no migration needed.
+
+## Conclusion
+Ship. Bundling the four /build-touching items into one PR is correct (separate PRs would self-conflict on SKILL.md). The methodology is the spike's planner+executor discipline imported as Instar's own. Migration parity covered with a conservative content-sniff migration + 4 tests. Seven-dimension review clean.


### PR DESCRIPTION
## Summary
Final cherry-pick PR from the GSD-Instar spike. Four /build SKILL.md enhancements bundled (they all touch the same file, so separate PRs would self-conflict):

1. **Phase 0.5 MUST-HAVES** (goal-backward): truths + artifacts + key_links with grep patterns. Each truth → Phase 3 gate; each key_link → WIRED check.
2. **STRIDE threat pass** (LARGE builds only): small register, mitigations bound to tests.
3. **Atomic-commit discipline** (Phase 2): per-task commits, stage by name (never `git add -A`), `{type}({scope}): {summary}`. Replaces the old single-mega-commit guidance.
4. **SUMMARY.md deviation-tracking** (Phase 5): Rule 1/2/3/4 deviations + must-haves verification + infra-backed deferrals.

Plus `docs/patterns/defense-in-depth-insert-and-projection.md`.

## Tests
4 migration tests, all green. TypeScript clean.

## Migration parity
installBuildSkill is install-if-missing → existing agents get the methodology via `migrateBuildSkillMethodology()`: content-sniffed, idempotent, fingerprint-guarded (customized skills untouched). Verified by tests.

## Side-effects
`upgrades/side-effects/build-methodology-bundle.md` — seven-dimension review clean.

## Spike close-out
This completes all 9 remaining cherry-pick items (analysis-paralysis-guard shipped earlier in #335). PRs: #341 atomic-write, #342 slopcheck, #343 e2e-pairing, #344 /verify-claim, this one for the /build bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)