### PR TITLE
feat(tunnel): Telegram inline-button consent UX (PR 6 of tunnel-failure-resilience)

### DIFF
--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -440,6 +440,54 @@ export class TelegramAdapter implements MessagingAdapter {
   private pendingPromptReply = new Map<number, PendingPromptReply>(); // topicId → pending
   private promptGateDisclosureSent = new Set<number>(); // topicIds that have seen the disclosure
 
+  /**
+   * Tunnel-consent callback handler. Registered by TunnelManager via
+   * `setTunnelConsentHandler`. Receives the parsed action ('grant' |
+   * 'decline') + the nonce; returns a short status string for the
+   * answerCallbackQuery toast. The owner-principal check happens in
+   * processCallbackQuery BEFORE this is invoked, so the handler can
+   * trust the click came from the owner.
+   */
+  private tunnelConsentHandler: ((action: 'grant' | 'decline', nonce: string) => Promise<string>) | null = null;
+
+  /** Wire the tunnel-consent callback handler (called by TunnelManager). */
+  setTunnelConsentHandler(fn: ((action: 'grant' | 'decline', nonce: string) => Promise<string>) | null): void {
+    this.tunnelConsentHandler = fn;
+  }
+
+  /**
+   * Send a consent prompt to the owner DM with two inline buttons
+   * (approve / decline). The buttons carry callback_data of the form
+   * `tc:g:<nonce>` / `tc:d:<nonce>` (well under Telegram's 64-byte
+   * callback_data limit — `tc:g:` is 5 chars + a 32-hex nonce = 37).
+   * Returns the message id on success, null on failure (no owner,
+   * owner hasn't DM'd the bot, network error) — fire-and-forget.
+   */
+  async sendOwnerConsentPrompt(text: string, nonce: string): Promise<number | null> {
+    const owner = this.getOwnerUserId();
+    if (!owner) {
+      console.warn('[telegram] sendOwnerConsentPrompt called but no ownerUserId is configured');
+      return null;
+    }
+    try {
+      const result = await this.apiCall('sendMessage', {
+        chat_id: owner,
+        text,
+        reply_markup: {
+          inline_keyboard: [[
+            { text: 'Yes, use a backup', callback_data: `tc:g:${nonce}` },
+            { text: 'No, keep waiting', callback_data: `tc:d:${nonce}` },
+          ]],
+        },
+      }) as { message_id: number };
+      return result.message_id;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[telegram] sendOwnerConsentPrompt failed: ${msg}`);
+      return null;
+    }
+  }
+
   /** Callback to inject a response into a tmux session. Wired by server.ts. */
   public onPromptResponse: ((sessionName: string, key: string) => boolean) | null = null;
   /** Callback to inject text input into a tmux session. Wired by server.ts. */
@@ -3901,6 +3949,60 @@ export class TelegramAdapter implements MessagingAdapter {
       return;
     }
 
+    // ── Tunnel-consent buttons (separate, security-sensitive path) ────
+    // callback_data shape: `tc:g:<nonce>` (grant) | `tc:d:<nonce>`
+    // (decline). The owner-principal check is MANDATORY here — the
+    // GPT external review's CRITICAL finding is that only the owner
+    // may approve routing private traffic through a third-party relay.
+    // We use getOwnerUserId() (the explicit owner principal), NOT the
+    // broader authorizedUserIds set.
+    if (query.data.startsWith('tc:')) {
+      const owner = this.getOwnerUserId();
+      if (owner && query.from.id !== owner) {
+        await this.apiCall('answerCallbackQuery', {
+          callback_query_id: query.id,
+          text: 'Only the owner can approve this',
+        }).catch(() => {});
+        return; // do NOT consume — preserve for the real owner
+      }
+      const m = /^tc:([gd]):([0-9a-f]{32})$/.exec(query.data);
+      if (!m) {
+        await this.apiCall('answerCallbackQuery', {
+          callback_query_id: query.id,
+          text: 'Invalid consent button',
+        }).catch(() => {});
+        return;
+      }
+      const action: 'grant' | 'decline' = m[1] === 'g' ? 'grant' : 'decline';
+      const nonce = m[2]!;
+      let statusText = 'Got it';
+      if (this.tunnelConsentHandler) {
+        try {
+          statusText = await this.tunnelConsentHandler(action, nonce);
+        } catch {
+          statusText = 'Could not process — try the dashboard';
+        }
+      }
+      await this.apiCall('answerCallbackQuery', {
+        callback_query_id: query.id,
+        text: statusText,
+      }).catch(() => {});
+      // Clear the inline keyboard so the (now-consumed) button can't be
+      // tapped again — the consent nonce is single-use on the manager
+      // side, but removing the keyboard is the visible confirmation.
+      // The prompt lives in the owner's private DM, so the edit must
+      // target that chat — NOT config.chatId (the group/supergroup).
+      if (query.message) {
+        await this.editMessageWithRetry(
+          query.message.message_id,
+          action === 'grant' ? '✅ Backup approved.' : '❌ Backup declined.',
+          3,
+          query.message.chat?.id,
+        ).catch(() => {});
+      }
+      return;
+    }
+
     // Authorization check: verify sender is the configured owner
     const ownerId = this.config.promptGate?.ownerId;
     if (ownerId && query.from.id !== ownerId) {
@@ -4069,11 +4171,11 @@ export class TelegramAdapter implements MessagingAdapter {
    * Edit a Telegram message with retry on failure.
    * Uses exponential backoff (1s, 2s, 4s) for up to 3 attempts.
    */
-  private async editMessageWithRetry(messageId: number, text: string, retries = 3): Promise<void> {
+  private async editMessageWithRetry(messageId: number, text: string, retries = 3, chatId?: number | string): Promise<void> {
     for (let attempt = 0; attempt < retries; attempt++) {
       try {
         await this.apiCall('editMessageText', {
-          chat_id: this.config.chatId,
+          chat_id: chatId ?? this.config.chatId,
           message_id: messageId,
           text,
         });

--- a/src/tunnel/TunnelManager.ts
+++ b/src/tunnel/TunnelManager.ts
@@ -114,6 +114,18 @@ export interface TunnelMessagingAdapter {
   sendToOwnerDM(text: string): Promise<unknown>;
   getDashboardTopicId(): number | undefined;
   getLifelineTopicId(): number | undefined;
+  /**
+   * Send the consent prompt to the owner with approve/decline inline
+   * buttons carrying the nonce. Returns the message id or null on
+   * failure. Optional — when the adapter doesn't implement it, the
+   * manager falls back to sending the consent prompt as plain text
+   * via sendToOwnerDM (degraded: the owner would reply in words,
+   * which PR 6 doesn't wire — so the button path is the supported
+   * one).
+   */
+  sendOwnerConsentPrompt?(text: string, nonce: string): Promise<number | null>;
+  /** Register the grant/decline callback handler (inline-button clicks). */
+  setTunnelConsentHandler?(fn: ((action: 'grant' | 'decline', nonce: string) => Promise<string>) | null): void;
 }
 
 // ── Constants ───────────────────────────────────────────────────────
@@ -169,6 +181,8 @@ export class TunnelManager extends EventEmitter {
     issuedAt: number;
     timer: ReturnType<typeof setTimeout>;
   } | null = null;
+  /** Adapter ref captured by attachTelegram — used to send the button prompt. */
+  private _consentAdapter: TunnelMessagingAdapter | null = null;
 
   constructor(config: TunnelConfig, injections?: TunnelManagerInjections) {
     super();
@@ -291,6 +305,7 @@ export class TunnelManager extends EventEmitter {
    * messages; the credentials NEVER appear in group messages.
    */
   attachTelegram(adapter: TunnelMessagingAdapter, dashboardPin: () => string | undefined): void {
+    this._consentAdapter = adapter;
     const sink: NotifierSink = {
       sendGroup: async (text: string) => {
         const topicId = adapter.getDashboardTopicId() ?? adapter.getLifelineTopicId();
@@ -305,7 +320,22 @@ export class TunnelManager extends EventEmitter {
       url: this._legacyState.url,
       pin: dashboardPin(),
     });
-    this.notifier = new TunnelNotifier({ sink, credentialProvider });
+    // The notifier handles the GROUP pointer for awaiting-consent; the
+    // owner-DM consent PROMPT (with buttons) is sent by the manager
+    // directly in requestConsent so it can carry the nonce + inline
+    // keyboard. Suppress the notifier's plain-text consent DM to avoid
+    // a double send.
+    this.notifier = new TunnelNotifier({ sink, credentialProvider, suppressConsentDM: true });
+
+    // Register the grant/decline callback handler for inline-button clicks.
+    adapter.setTunnelConsentHandler?.(async (action, nonce) => {
+      if (action === 'grant') {
+        const ok = await this.grantConsent(nonce);
+        return ok ? 'Backup approved — bringing it up now' : 'That request is no longer active';
+      }
+      const ok = this.declineConsent(nonce);
+      return ok ? 'Okay — staying on Cloudflare' : 'That request is no longer active';
+    });
   }
 
   // ── Internals ──────────────────────────────────────────────────
@@ -483,6 +513,34 @@ export class TunnelManager extends EventEmitter {
       issuedAt: Date.now(),
       timer,
     };
+
+    // Send the button-bearing consent prompt to the owner DM (the
+    // notifier sends only the group pointer for awaiting-consent;
+    // suppressConsentDM avoids a double owner-DM). Fire-and-forget.
+    if (this._consentAdapter?.sendOwnerConsentPrompt) {
+      void this._consentAdapter.sendOwnerConsentPrompt(
+        this.consentPromptText(provider.name),
+        nonce,
+      ).catch(() => { /* adapter logs its own failures */ });
+    } else if (this._consentAdapter?.sendToOwnerDM) {
+      // Degraded: no inline-button support — send the text only.
+      void this._consentAdapter.sendToOwnerDM(this.consentPromptText(provider.name))
+        .catch(() => { /* best effort */ });
+    }
+  }
+
+  /** Owner-facing consent prompt text. Honest about third-party exposure + rotation cost. */
+  private consentPromptText(provider: ProviderName): string {
+    const relayDesc = provider === 'bore'
+      ? 'an unencrypted third-party relay (its operator and the network path can see your traffic)'
+      : 'a third-party relay (its operator can see your dashboard traffic while it is in use)';
+    return [
+      `Cloudflare is unavailable and I can't get you a dashboard link the usual way.`,
+      ``,
+      `I can bring up a backup through ${relayDesc}. Your dashboard PIN and any private view links would be visible to that operator while the backup is active. After the backup is no longer needed, I'll rotate your PIN and access token — that signs you out of any open dashboard tabs and invalidates any private view links you've already shared.`,
+      ``,
+      `Tap a button below. If you don't respond, I'll keep waiting for Cloudflare and won't use a backup.`,
+    ].join('\n');
   }
 
   private clearPendingConsent(): void {

--- a/src/tunnel/TunnelNotifier.ts
+++ b/src/tunnel/TunnelNotifier.ts
@@ -85,12 +85,22 @@ export interface TunnelNotifierOptions {
   stateChangeMinIntervalMs?: number;
   /** Flap threshold — N connect/drop cycles within an episode → noise-collapse. */
   flapThreshold?: number;
+  /**
+   * When true, the notifier does NOT emit the owner-DM consent PROMPT
+   * for the awaiting-consent transition (the group pointer still
+   * fires). Set by the manager when an adapter capable of sending the
+   * button-bearing prompt is attached — the manager sends that prompt
+   * itself (with the nonce + inline keyboard) so the notifier's plain-
+   * text version would be a duplicate.
+   */
+  suppressConsentDM?: boolean;
 }
 
 export class TunnelNotifier {
   private readonly sink: NotifierSink;
   private readonly clock: NotifierClock;
   private readonly credentialProvider: (() => CredentialSnapshot) | undefined;
+  private readonly suppressConsentDM: boolean;
   private readonly stateChangeMinIntervalMs: number;
   private readonly flapThreshold: number;
 
@@ -115,6 +125,7 @@ export class TunnelNotifier {
     this.sink = opts.sink;
     this.clock = opts.clock ?? { now: () => Date.now() };
     this.credentialProvider = opts.credentialProvider;
+    this.suppressConsentDM = opts.suppressConsentDM ?? false;
     this.stateChangeMinIntervalMs = opts.stateChangeMinIntervalMs ?? 15 * 60_000;
     this.flapThreshold = opts.flapThreshold ?? 3;
   }
@@ -249,13 +260,15 @@ export class TunnelNotifier {
           episodeId: ep,
           epoch: e.epoch,
         });
-        messages.push({
-          channel: 'owner-dm',
-          class: 'action-required',
-          text: this.composeConsentPromptDM(),
-          episodeId: ep,
-          epoch: e.epoch,
-        });
+        if (!this.suppressConsentDM) {
+          messages.push({
+            channel: 'owner-dm',
+            class: 'action-required',
+            text: this.composeConsentPromptDM(),
+            episodeId: ep,
+            epoch: e.epoch,
+          });
+        }
         break;
 
       case 'relay-active':

--- a/tests/unit/tunnel-consent-telegram.test.ts
+++ b/tests/unit/tunnel-consent-telegram.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for the Telegram consent wire-up (PR 6 of the
+ * tunnel-failure-resilience chain).
+ *
+ * Spec: specs/dev-failure-resilience.md Part 3 (consent UX).
+ *
+ * Covers the integration seam between TunnelManager's consent state
+ * machine (PR 5) and the Telegram inline-button UX:
+ *   - attachTelegram registers a tunnel-consent handler with the
+ *     adapter and (when an adapter capable of sendOwnerConsentPrompt
+ *     is present) routes the consent prompt through the button path.
+ *   - On Tier-1 exhaustion → awaiting-consent, the manager calls
+ *     adapter.sendOwnerConsentPrompt(text, nonce) with the live nonce.
+ *   - The registered handler, invoked with ('grant', nonce), drives
+ *     grantConsent → relay-active. With ('decline', nonce) → exhausted.
+ *   - The consent prompt is suppressed from the notifier's owner-DM
+ *     path (no double send).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { TunnelManager, type TunnelMessagingAdapter } from '../../src/tunnel/TunnelManager.js';
+import type {
+  TunnelProvider,
+  TunnelProviderHandle,
+  ProviderName,
+  ProviderTier,
+} from '../../src/tunnel/TunnelProvider.js';
+
+function tmpStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tunnel-consent-tg-'));
+}
+
+function mockProvider(opts: { name: ProviderName; tier?: ProviderTier; available?: boolean; startResult?: 'success' | { error: string }; url?: string }): TunnelProvider {
+  return {
+    name: opts.name,
+    tier: opts.tier ?? 1,
+    isAvailable: vi.fn(async () => opts.available !== false),
+    start: vi.fn(async (): Promise<TunnelProviderHandle> => {
+      if (opts.startResult && typeof opts.startResult === 'object') throw new Error(opts.startResult.error);
+      return { url: opts.url ?? `https://${opts.name}.example`, stop: async () => undefined };
+    }),
+  };
+}
+
+/** Mock adapter that captures the consent prompt + the registered handler. */
+function mockAdapter() {
+  let consentHandler: ((action: 'grant' | 'decline', nonce: string) => Promise<string>) | null = null;
+  const consentPrompts: { text: string; nonce: string }[] = [];
+  const ownerDms: string[] = [];
+  const groupMsgs: { topicId: number; text: string }[] = [];
+  const adapter: TunnelMessagingAdapter = {
+    sendToTopic: vi.fn(async (topicId: number, text: string) => { groupMsgs.push({ topicId, text }); }),
+    sendToOwnerDM: vi.fn(async (text: string) => { ownerDms.push(text); }),
+    getDashboardTopicId: () => 42,
+    getLifelineTopicId: () => 43,
+    sendOwnerConsentPrompt: vi.fn(async (text: string, nonce: string) => {
+      consentPrompts.push({ text, nonce });
+      return 1001;
+    }),
+    setTunnelConsentHandler: (fn) => { consentHandler = fn; },
+  };
+  return {
+    adapter,
+    consentPrompts,
+    ownerDms,
+    groupMsgs,
+    invoke: (action: 'grant' | 'decline', nonce: string) => {
+      if (!consentHandler) throw new Error('handler not registered');
+      return consentHandler(action, nonce);
+    },
+    hasHandler: () => consentHandler !== null,
+  };
+}
+
+const okFetch = vi.fn(async () => new Response('ok', { status: 200 }));
+const baseConfig = { enabled: true, type: 'quick' as const, port: 4040, stateDir: '' };
+
+let stateDir: string;
+beforeEach(() => { stateDir = tmpStateDir(); });
+afterEach(() => {
+  try {
+    SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/tunnel-consent-telegram.test.ts:cleanup' });
+  } catch { /* ignore */ }
+});
+
+describe('TunnelManager + Telegram consent wire-up', () => {
+  it('attachTelegram registers a tunnel-consent handler with the adapter', () => {
+    const m = mockAdapter();
+    const mgr = new TunnelManager(
+      { ...baseConfig, stateDir },
+      { providers: [mockProvider({ name: 'cloudflare-quick', url: 'https://q.example' })], fetch: okFetch },
+    );
+    mgr.attachTelegram(m.adapter, () => '123456');
+    expect(m.hasHandler()).toBe(true);
+  });
+
+  it('sends the button-bearing consent prompt with the live nonce on awaiting-consent', async () => {
+    const m = mockAdapter();
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited: 1015' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+    const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [tier1, tier2], fetch: okFetch });
+    mgr.attachTelegram(m.adapter, () => '123456');
+
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    expect(m.consentPrompts.length).toBe(1);
+    const pc = mgr.pendingConsent;
+    expect(pc).not.toBeNull();
+    expect(m.consentPrompts[0]!.nonce).toBe(pc!.nonce);
+    // The prompt text is honest about third-party exposure + rotation.
+    expect(m.consentPrompts[0]!.text).toMatch(/third-party relay/);
+    expect(m.consentPrompts[0]!.text).toMatch(/rotate your PIN/);
+  });
+
+  it('does NOT double-send the consent prompt via the owner-DM text path', async () => {
+    const m = mockAdapter();
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true });
+    const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [tier1, tier2], fetch: okFetch });
+    mgr.attachTelegram(m.adapter, () => '123456');
+
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    // The button prompt went out once; the plain-text owner DM (the
+    // notifier's consent message) was suppressed.
+    expect(m.consentPrompts.length).toBe(1);
+    const consentTextDms = m.ownerDms.filter((d) => d.includes('third-party relay'));
+    expect(consentTextDms.length).toBe(0);
+  });
+
+  it('the registered handler grants consent → relay-active', async () => {
+    const m = mockAdapter();
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+    const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [tier1, tier2], fetch: okFetch });
+    mgr.attachTelegram(m.adapter, () => '123456');
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const nonce = mgr.pendingConsent!.nonce;
+    const status = await m.invoke('grant', nonce);
+    expect(status).toMatch(/approved/i);
+    expect(mgr.lifecycleState.lastState).toBe('relay-active');
+    expect(mgr.url).toBe('https://relay.loca.lt');
+  });
+
+  it('the registered handler declines consent → exhausted', async () => {
+    const m = mockAdapter();
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true });
+    const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [tier1, tier2], fetch: okFetch });
+    mgr.attachTelegram(m.adapter, () => '123456');
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const nonce = mgr.pendingConsent!.nonce;
+    const status = await m.invoke('decline', nonce);
+    expect(status).toMatch(/cloudflare/i);
+    expect(mgr.lifecycleState.lastState).toBe('exhausted');
+    expect(mgr.lifecycleState.consentCooldown.consecutiveRefusals).toBe(1);
+  });
+
+  it('the handler reports "no longer active" for a stale nonce', async () => {
+    const m = mockAdapter();
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+    const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [tier1, tier2], fetch: okFetch });
+    mgr.attachTelegram(m.adapter, () => '123456');
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    const status = await m.invoke('grant', 'ffffffffffffffffffffffffffffffff');
+    expect(status).toMatch(/no longer active/i);
+    expect(mgr.lifecycleState.lastState).toBe('awaiting-consent'); // unchanged
+  });
+});
+
+/**
+ * Adapter-side coverage of the security-load-bearing callback path in
+ * TelegramAdapter.processCallbackQuery (reached in production via the
+ * poll loop AND via handleForwardedCallback when the Lifeline forwards
+ * callbacks in send-only mode — which is exactly the tunnel-down case).
+ *
+ * The GPT external review's CRITICAL finding: only the OWNER principal
+ * may approve routing private traffic through a third-party relay. These
+ * tests cover both sides of that boundary plus malformed callback_data.
+ */
+describe('TelegramAdapter tunnel-consent callback (owner-principal gate)', () => {
+  const OWNER = 777;
+  const NONCE = 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'; // 32 hex
+  let adapter: TelegramAdapter;
+  let tmpDir: string;
+  let calls: { method: string; body: Record<string, unknown> }[];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tunnel-consent-cbq-'));
+    adapter = new TelegramAdapter(
+      { token: 'test-token', chatId: '-100999', ownerUserId: OWNER },
+      tmpDir,
+    );
+    calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, opts: { body: string }) => {
+      calls.push({ method: String(url).split('/').pop()!, body: JSON.parse(opts.body) });
+      return { ok: true, json: async () => ({ ok: true, result: { message_id: 1 } }) } as unknown as Response;
+    }));
+  });
+
+  afterEach(async () => {
+    await adapter.stop();
+    vi.unstubAllGlobals();
+    try {
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/tunnel-consent-telegram.test.ts:cbq-cleanup' });
+    } catch { /* ignore */ }
+  });
+
+  const answerText = () => calls.find((c) => c.method === 'answerCallbackQuery')?.body.text;
+  const editCall = () => calls.find((c) => c.method === 'editMessageText');
+
+  it('owner grant click → handler invoked with (grant, nonce), keyboard cleared in the OWNER DM chat', async () => {
+    const handler = vi.fn(async () => 'Backup approved — bringing it up now');
+    adapter.setTunnelConsentHandler(handler);
+
+    await adapter.handleForwardedCallback({
+      id: 'cbq-1', from: { id: OWNER }, data: `tc:g:${NONCE}`, message: { message_id: 555, chat: { id: OWNER } },
+    });
+
+    expect(handler).toHaveBeenCalledWith('grant', NONCE);
+    expect(answerText()).toBe('Backup approved — bringing it up now');
+    expect(editCall()?.body.text).toBe('✅ Backup approved.');
+    // The edit must target the owner's private chat (where the buttons
+    // live), NOT config.chatId (the group). Regression guard for the
+    // hardcoded-chat_id bug.
+    expect(editCall()?.body.chat_id).toBe(OWNER);
+  });
+
+  it('owner decline click → handler invoked with (decline, nonce)', async () => {
+    const handler = vi.fn(async () => 'Okay — staying on Cloudflare');
+    adapter.setTunnelConsentHandler(handler);
+
+    await adapter.handleForwardedCallback({
+      id: 'cbq-2', from: { id: OWNER }, data: `tc:d:${NONCE}`, message: { message_id: 556, chat: { id: OWNER } },
+    });
+
+    expect(handler).toHaveBeenCalledWith('decline', NONCE);
+    expect(editCall()?.body.text).toBe('❌ Backup declined.');
+  });
+
+  it('NON-owner click → handler NOT invoked, callback preserved for the real owner', async () => {
+    const handler = vi.fn(async () => 'should not run');
+    adapter.setTunnelConsentHandler(handler);
+
+    await adapter.handleForwardedCallback({
+      id: 'cbq-3', from: { id: 999 }, data: `tc:g:${NONCE}`, message: { message_id: 557, chat: { id: OWNER } },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(answerText()).toBe('Only the owner can approve this');
+    // The button is NOT consumed (no keyboard edit) — the real owner can still tap it.
+    expect(calls.some((c) => c.method === 'editMessageText')).toBe(false);
+  });
+
+  it('malformed tc: callback_data → rejected without invoking the handler', async () => {
+    const handler = vi.fn(async () => 'should not run');
+    adapter.setTunnelConsentHandler(handler);
+
+    await adapter.handleForwardedCallback({
+      id: 'cbq-4', from: { id: OWNER }, data: 'tc:x:not-a-valid-nonce', message: { message_id: 558 },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(answerText()).toBe('Invalid consent button');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,34 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+PR 6 of the tunnel-failure-resilience chain. The previous releases built the machinery for a consent-gated backup tunnel: when Cloudflare can't give you a dashboard link, the agent can fall back to a third-party relay — but only after the owner explicitly approves, because that relay's operator can briefly see your dashboard traffic. Until now that approval had no actual user interface; the state machine existed but nothing asked you.
+
+**The gap.** When Tier-1 (Cloudflare) was exhausted and a Tier-2 relay was available, the manager moved to `awaiting-consent` and waited — but the only owner-facing message was a plain-text DM with no way to act on it. There was no wired path from "owner taps a button" back to `grantConsent`/`declineConsent`.
+
+**The fix.** The owner now gets a private DM with two inline buttons — "Yes, use a backup" / "No, keep waiting." Tapping one drives the consent state machine directly. The button click is gated to the **owner principal only** (not the broader authorized-users set — a deliberate, externally-reviewed security boundary, since approving a relay exposes private traffic), and each prompt carries a single-use random token so a stale or replayed tap can't activate anything. The plain-text consent DM is suppressed when buttons are available, so you never get a double message. The whole path also works when the agent is in send-only mode and the Lifeline is forwarding callbacks — which is exactly the situation a tunnel outage tends to create.
+
+## What to Tell Your User
+
+- If your dashboard link ever goes down and the agent has a backup option, it will now DM you two buttons instead of leaving you with an un-actionable message.
+- Only you (the owner) can approve a backup — taps from anyone else are refused, and the prompt explains plainly that a backup briefly routes your dashboard traffic through someone else's server and that your PIN/token will be rotated afterward.
+- Nothing changes for the normal case where Cloudflare is healthy — you won't see any of this unless the primary tunnel fails.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Owner consent buttons on tunnel fallback | Automatic — fires only when Tier-1 is exhausted and a Tier-2 relay is available; tap a button in the owner DM |
+| Owner-principal gate on consent | Automatic — only `ownerUserId` (falls back to `promptGate.ownerId`) may approve; others are refused |
+
+## Evidence
+
+- Spec: `specs/dev-infrastructure/tunnel-failure-resilience.md` Part 3 (consent UX). Side-effects: `upgrades/side-effects/consent-telegram-buttons.md`.
+- Tests: 10 unit tests in `tests/unit/tunnel-consent-telegram.test.ts` — 6 on the manager↔adapter seam (handler registration, prompt carries the live nonce, no double-send, grant→relay-active, decline→exhausted+cooldown, stale-nonce no-op) and 4 on the security-critical adapter callback gate (owner grant/decline, NON-owner rejected without invoking the handler, malformed `tc:` data refused).
+- Wiring verified: the production call site `tunnel.attachTelegram(telegram, …)` exists in `src/commands/server.ts`, and a unit test asserts `attachTelegram` registers the consent handler — not dead code.
+
+## Rollback
+
+Purely additive. Revert the three method additions in `TelegramAdapter`, the `attachTelegram` handler-registration + `suppressConsentDM` wiring in `TunnelManager`, and the `suppressConsentDM` flag in `TunnelNotifier`. No config schema, migration, or persistent state to clean up; `suppressConsentDM` defaults false.

--- a/upgrades/side-effects/consent-telegram-buttons.md
+++ b/upgrades/side-effects/consent-telegram-buttons.md
@@ -1,0 +1,77 @@
+# Side-effects review — Telegram consent buttons (PR 6 of tunnel-failure-resilience chain)
+
+**Scope (PR 6 of the chain):** Wire the consent state machine (PR 5)
+to a real Telegram inline-button UX. When Tier-1 is exhausted and a
+Tier-2 relay is available, the owner gets a DM with two buttons —
+"Yes, use a backup" / "No, keep waiting" — and tapping one drives
+`grantConsent` / `declineConsent` on the manager. Spec
+`specs/dev-infrastructure/tunnel-failure-resilience.md` Part 3.
+
+**Files touched:**
+- `src/messaging/TelegramAdapter.ts` — adds `setTunnelConsentHandler`
+  (handler injection), `sendOwnerConsentPrompt(text, nonce)` (DM with
+  inline buttons carrying `tc:g:<nonce>` / `tc:d:<nonce>`), and a new
+  `tc:`-prefixed early-return branch in `processCallbackQuery` that
+  enforces the owner-principal check, validates the nonce shape, calls
+  the injected handler, and clears the keyboard. `editMessageWithRetry`
+  gains an optional `chatId` param (defaults to `config.chatId`) so the
+  keyboard-clear edit can target the owner's private DM rather than the
+  group — without disturbing the existing prompt-gate callers.
+- `src/tunnel/TunnelManager.ts` — `attachTelegram` captures the adapter
+  ref, registers the grant/decline handler, and passes
+  `suppressConsentDM: true` to the notifier; `requestConsent` sends the
+  button prompt (degrading to plain-text `sendToOwnerDM` when an adapter
+  lacks button support). Adds `consentPromptText`. The
+  `TunnelMessagingAdapter` interface gains two optional methods.
+- `src/tunnel/TunnelNotifier.ts` — adds `suppressConsentDM` option so
+  the manager-sent button prompt isn't duplicated by the notifier's
+  plain-text owner-DM.
+- `tests/unit/tunnel-consent-telegram.test.ts` — NEW. 10 tests: 6 on
+  the manager↔adapter seam (handler registration, button prompt carries
+  the live nonce, no double-send, grant→relay-active, decline→exhausted
+  +cooldown, stale-nonce no-op) and 4 on the adapter-side callback gate
+  (owner grant/decline, NON-owner rejection, malformed `tc:` data).
+
+**Over-block:** None. The `tc:` prefix is unique in the codebase (a grep
+for `callback_data:` literals returns only PR 6's two buttons), the
+regex is strict (`^tc:([gd]):([0-9a-f]{32})$`), and any non-`tc:`
+callback falls through unchanged to the existing prompt-gate handler
+below. Malformed `tc:` data is answered with "Invalid consent button"
+and consumed, never forwarded.
+
+**Under-block:** One edge worth naming. The owner gate is
+`if (owner && query.from.id !== owner) reject`. When **no** owner is
+configured (`ownerUserId` and `promptGate.ownerId` both unset), the gate
+is skipped. This is benign by construction: with no owner there is no DM
+target, so `sendOwnerConsentPrompt` returns null and **no button is ever
+sent** — there is nothing to click. Even a hand-crafted callback can't
+activate a relay, because `grantConsent` requires a single-use CSPRNG
+nonce that matches the live pending-consent record (cleared-before-start
+so a replay loses). Security is layered: owner-principal check **and**
+nonce match. The adapter regex is only a low-level validator (signal);
+the manager's `grantConsent` holds the blocking authority.
+
+**Level-of-abstraction fit:** Clean. The adapter owns the Telegram
+protocol (parse, owner check, answer toast, keyboard clear); the manager
+owns the tunnel-state transition via the injected handler. The adapter
+never imports tunnel types and the manager never imports Telegram types
+(the duck-typed `TunnelMessagingAdapter` interface is the seam).
+
+**Interactions:**
+- `query.data` is guarded (`if (!query.data) return`) immediately above
+  the `tc:` block, so `.startsWith` can't throw.
+- The path is reached both by the poll loop and by
+  `handleForwardedCallback` — the Lifeline forwards callbacks in
+  send-only mode, which is exactly the tunnel-down scenario this feature
+  exists for.
+- `suppressConsentDM` prevents a double owner-DM (button prompt from the
+  manager + plain-text prompt from the notifier).
+- No HTTP surface in this PR, so the Tier-2/Tier-3 "feature is alive"
+  HTTP tests are N/A. Wiring is verified two ways: the unit test asserts
+  `attachTelegram` registers the handler, and the production call site
+  exists at `src/commands/server.ts` (`tunnel.attachTelegram(telegram, …)`).
+
+**Rollback cost:** Low. Purely additive; `suppressConsentDM` defaults
+false (back-compat for existing notifier callers). No config schema,
+migration, or persistent state. Revert = drop the three method additions
++ the `tc:` block + the `attachTelegram` handler-registration lines.


### PR DESCRIPTION
## Summary

PR 6 of the tunnel-failure-resilience chain. Wires the consent state machine (PR 5, #336) to a real owner-facing UX. When Tier-1 (Cloudflare) is exhausted and a Tier-2 relay is available, the owner gets a private DM with two inline buttons — **Yes, use a backup** / **No, keep waiting** — and tapping one drives `grantConsent` / `declineConsent` on the manager.

- **TelegramAdapter**: `setTunnelConsentHandler` (handler injection) + `sendOwnerConsentPrompt(text, nonce)` (DM with inline buttons; `callback_data` `tc:g:<nonce>` / `tc:d:<nonce>`) + a security-gated `tc:` branch in `processCallbackQuery`. The owner-principal check is mandatory there (the GPT external review's CRITICAL finding: only the owner — not the broader `authorizedUserIds` set — may approve routing private traffic through a third-party relay). `editMessageWithRetry` gains an optional `chatId` so the keyboard-clear edits the **owner DM**, not the group.
- **TunnelManager**: `attachTelegram` captures the adapter, registers the grant/decline handler, and passes `suppressConsentDM: true` to the notifier; `requestConsent` sends the button prompt (degrading to plain-text `sendToOwnerDM` when an adapter lacks button support). Works via the poll loop **and** `handleForwardedCallback` (Lifeline-forwarded callbacks in send-only mode — the tunnel-down case).
- **TunnelNotifier**: `suppressConsentDM` option (defaults false) so the manager-sent button prompt isn't duplicated.

## Security boundary

The owner gate (`getOwnerUserId`) + the single-use CSPRNG nonce match in `grantConsent` are layered: the adapter regex is a low-level validator (signal); the manager holds blocking authority. A stale/replayed/non-owner tap cannot activate a relay.

## Tests

10 unit tests in `tests/unit/tunnel-consent-telegram.test.ts`:
- 6 on the manager↔adapter seam: handler registration, prompt carries the live nonce, no double-send (suppressConsentDM), grant→relay-active, decline→exhausted+cooldown, stale-nonce no-op.
- 4 on the adapter-side callback gate: owner grant/decline (incl. keyboard-clear targets the owner chat — regression guard for the hardcoded-chat_id bug), **NON-owner rejected without invoking the handler**, malformed `tc:` data refused.

Wiring verified: production call site `tunnel.attachTelegram(telegram, …)` exists in `src/commands/server.ts`; a unit test asserts `attachTelegram` registers the handler — not dead code.

## Evidence / docs

- Spec: `specs/dev-infrastructure/tunnel-failure-resilience.md` Part 3.
- Upgrade guide: `upgrades/NEXT.md`. Side-effects review: `upgrades/side-effects/consent-telegram-buttons.md`.

## Rollback

Purely additive. `suppressConsentDM` defaults false; no config schema, migration, or persistent state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)