### PR TITLE
feat(tunnel): credential rotation on relay-episode end + boot-recovery (PR 7 of tunnel-failure-resilience)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4842,6 +4842,38 @@ export async function startServer(options: StartOptions): Promise<void> {
         port: config.port,
         stateDir: config.stateDir,
       });
+
+      // Wire credential rotation (tunnel-failure-resilience spec Part 6).
+      // The manager owns WHEN to rotate (every terminal exit from
+      // relay-active + boot-recovery); this closure owns WHAT: regenerate
+      // the dashboard PIN + authToken, persist them, and DM the owner the
+      // new PIN. Rotating authToken invalidates every previously-signed
+      // view URL and the dashboard session — the documented UX cost of
+      // having briefly routed private traffic through a third-party relay.
+      tunnel.setCredentialRotator(async () => {
+        const { randomUUID } = await import('node:crypto');
+        const newPin = String(Math.floor(100000 + Math.random() * 900000)); // 6-digit, matches startup gen
+        const newToken = randomUUID();
+        // Persist to config.json (survives restart; boot reads the new token)…
+        liveConfig.set('authToken', newToken);
+        liveConfig.set('dashboardPin', newPin);
+        // …and mutate the in-memory config the running server reads live,
+        // so the auth middleware + view-URL signing reject the old token
+        // and old signed links immediately, without a restart.
+        config.authToken = newToken;
+        config.dashboardPin = newPin;
+        console.log(pc.yellow('  [tunnel] rotated dashboard PIN + auth token after relay episode'));
+        if (telegram) {
+          const msg = [
+            `Security cleanup after the backup tunnel: I've rotated your dashboard PIN and access token.`,
+            ``,
+            `New dashboard PIN: ${newPin}`,
+            ``,
+            `Heads up: any dashboard tab you had open will need to sign in again with this new PIN, and any private view links you shared earlier no longer work. That's deliberate — it makes sure the backup operator can't reuse anything they may have seen while the backup was running.`,
+          ].join('\n');
+          await telegram.sendToOwnerDM(msg).catch(() => { /* best-effort; adapter logs its own failures */ });
+        }
+      });
     }
 
     // Set up evolution system (always enabled — the feedback loop infrastructure)
@@ -7270,6 +7302,16 @@ export async function startServer(options: StartOptions): Promise<void> {
     }
 
     const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge });
+    // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
+    // died mid-relay-episode, the persisted tunnel.json carries
+    // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE
+    // the server starts accepting API traffic, so a relay operator who saw
+    // the old credentials can't use them against the freshly-booted server.
+    if (tunnel && tunnel.lifecycleState.rotationPending) {
+      console.log(pc.yellow('  [tunnel] boot-recovery: relay episode was in flight at last shutdown — rotating credentials before serving'));
+      await tunnel.recoverPendingRotation();
+    }
+
     await server.start();
     void taskFlowSweeper; void taskFlowDueWaker; void divergenceChecker;
 

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -349,7 +349,12 @@ export class AgentServer {
     // structurally reject tokens sent to the wrong agent's server BEFORE
     // any token comparison runs. This closes the cross-tenant misroute
     // class proven by the Inspec/cheryl 2026-04-27 incident.
-    this.app.use(authMiddleware(options.config.authToken, options.config.projectName));
+    // Resolve the token live (via a getter over the shared config object)
+    // so tunnel credential rotation (Part 6 of the tunnel-failure-resilience
+    // spec) takes effect on the running server — rotating authToken
+    // immediately invalidates old bearer tokens AND old HMAC-signed view
+    // URLs without a restart.
+    this.app.use(authMiddleware(() => this.config.authToken, options.config.projectName));
     // Outbound messaging routes are intentionally LLM-backed (tone gate review)
     // and involve third-party API calls (Telegram/Slack/WhatsApp Bot APIs) whose
     // latency we don't control. The default 30s budget is routinely exceeded

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -57,8 +57,14 @@ export function _resetDeprecationLogCache(): void {
  * Auth middleware — enforces Bearer token on API endpoints.
  * Health endpoint is exempt (used for external monitoring).
  *
- * @param authToken  The configured server bearer token. If omitted, all
- *   requests pass through (used in tests and unauthenticated dev runs).
+ * @param authToken  The configured server bearer token, or a getter that
+ *   returns it. A getter is resolved on EVERY request so the token can be
+ *   rotated at runtime (tunnel credential rotation, Part 6 of the
+ *   tunnel-failure-resilience spec) and take effect immediately — old
+ *   bearer tokens and old HMAC-signed view URLs are rejected the moment
+ *   rotation completes, without a server restart. If omitted (or the
+ *   getter returns undefined), all requests pass through (used in tests
+ *   and unauthenticated dev runs).
  * @param agentId    The configured server agent identity (e.g. projectName).
  *   When set, the middleware additionally validates the
  *   `X-Instar-AgentId` request header BEFORE comparing the bearer
@@ -68,10 +74,14 @@ export function _resetDeprecationLogCache(): void {
  *   the backward-compatibility deprecation window with a deduped log
  *   line. See spec docs/specs/telegram-delivery-robustness.md § Layer 1b.
  */
-export function authMiddleware(authToken?: string, agentId?: string) {
+export function authMiddleware(authToken?: string | (() => string | undefined), agentId?: string) {
   return (req: Request, res: Response, next: NextFunction): void => {
+    // Resolve the token per-request so runtime rotation takes effect
+    // immediately (a getter is re-read on every request).
+    const resolvedToken = typeof authToken === 'function' ? authToken() : authToken;
+
     // Skip auth if no token configured
-    if (!authToken) {
+    if (!resolvedToken) {
       next();
       return;
     }
@@ -153,7 +163,7 @@ export function authMiddleware(authToken?: string, agentId?: string) {
     // View routes support signed URLs for browser access (see ?sig= below)
     if (req.path.startsWith('/view/') && req.method === 'GET') {
       const sig = typeof req.query.sig === 'string' ? req.query.sig : null;
-      if (sig && verifyViewSignature(req.path, sig, authToken)) {
+      if (sig && verifyViewSignature(req.path, sig, resolvedToken)) {
         next();
         return;
       }
@@ -208,7 +218,7 @@ export function authMiddleware(authToken?: string, agentId?: string) {
     const token = header.slice(7);
     // Hash both sides so lengths are always equal — prevents timing leak of token length
     const ha = createHash('sha256').update(token).digest();
-    const hb = createHash('sha256').update(authToken).digest();
+    const hb = createHash('sha256').update(resolvedToken).digest();
     if (!timingSafeEqual(ha, hb)) {
       res.status(403).json({ error: 'Invalid auth token' });
       return;

--- a/src/tunnel/TunnelManager.ts
+++ b/src/tunnel/TunnelManager.ts
@@ -183,6 +183,16 @@ export class TunnelManager extends EventEmitter {
   } | null = null;
   /** Adapter ref captured by attachTelegram — used to send the button prompt. */
   private _consentAdapter: TunnelMessagingAdapter | null = null;
+  /**
+   * Credential-rotation callback (wired by server.ts via
+   * setCredentialRotator). Owns the WHAT of rotation — regenerate the
+   * dashboard PIN + authToken, persist them, and DM the owner the new
+   * PIN — while the manager owns the WHEN (every terminal exit from
+   * relay-active + boot-recovery). Decoupled from config/messaging so
+   * this module stays free of those imports. See
+   * specs/dev-infrastructure/tunnel-failure-resilience.md Part 6.
+   */
+  private _rotateCredentials: (() => Promise<void>) | null = null;
 
   constructor(config: TunnelConfig, injections?: TunnelManagerInjections) {
     super();
@@ -264,12 +274,89 @@ export class TunnelManager extends EventEmitter {
     }
 
     this.persist();
+
+    // Terminal exit from a relay episode (relay-active → idle via
+    // stop/forceStop/shutdown) MUST rotate credentials — the third-party
+    // relay operator may have observed the PIN + signed view links while
+    // the relay was up. rotationPending (set on relay-active entry) gates
+    // this so non-relay stops are no-ops. See spec Part 6.
+    await this.runCredentialRotation('stop');
+
     this.emit('stopped');
   }
 
   /** Force-stop with escalation. Providers internally do SIGINT → SIGKILL. */
   async forceStop(_timeoutMs?: number): Promise<void> {
     await this.stop();
+  }
+
+  /**
+   * Wire the credential-rotation callback (called by server.ts). The
+   * callback regenerates the dashboard PIN + authToken, persists them,
+   * and DMs the owner the new PIN. Wired early in startup so both
+   * boot-recovery and runtime relay-episode-end can rotate.
+   */
+  setCredentialRotator(fn: (() => Promise<void>) | null): void {
+    this._rotateCredentials = fn;
+  }
+
+  /**
+   * Rotate credentials if a rotation is pending. Idempotent and safe to
+   * call on any stop; the `rotationPending` flag (set on relay-active
+   * entry, persisted to tunnel.json) gates it so non-relay stops are
+   * no-ops. Returns true iff a rotation was actually performed.
+   *
+   * Called from:
+   *   - `stop()` — relay-active → idle (operator stop / shutdown).
+   *   - boot-recovery (`recoverPendingRotation`) — the agent died
+   *     mid-relay-episode; rotate before the server accepts traffic.
+   *   - self-heal switch-back (PR 8) — relay-active → active.
+   *
+   * Mandatory-rotation invariant (spec Part 6): the flag is cleared
+   * ONLY after the rotator resolves, so a crash mid-rotation re-attempts
+   * on next boot. If no rotator is wired (misconfiguration), we log
+   * loudly and clear the flag rather than loop forever — but this path
+   * should never happen in a correctly-wired server.
+   */
+  async runCredentialRotation(reason: string): Promise<boolean> {
+    if (!this.lifecycle.rotationPending) return false;
+
+    if (!this._rotateCredentials) {
+      console.warn(
+        `[tunnel] credential rotation pending (${reason}) but no rotator ` +
+        `is wired — clearing the flag to avoid a permanent-pending loop. ` +
+        `This is a wiring bug: PIN/authToken were NOT rotated.`,
+      );
+      this.lifecycle.setRotationPending(false);
+      this.persist();
+      return false;
+    }
+
+    try {
+      await this._rotateCredentials();
+    } catch (err) {
+      // Rotation failed — leave rotationPending set so the next stop or
+      // next boot retries. Do NOT clear the flag on failure.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[tunnel] credential rotation (${reason}) failed: ${msg} — will retry`);
+      this.emit('rotation-failed', { reason, error: err });
+      return false;
+    }
+
+    this.lifecycle.setRotationPending(false);
+    this.persist();
+    this.emit('credentials-rotated', { reason });
+    return true;
+  }
+
+  /**
+   * Boot-recovery: if the persisted state shows a relay episode was in
+   * flight when the agent last died (rotationPending restored from
+   * tunnel.json), rotate BEFORE the server accepts any API traffic.
+   * server.ts awaits this before `server.start()`.
+   */
+  async recoverPendingRotation(): Promise<boolean> {
+    return this.runCredentialRotation('boot-recovery');
   }
 
   enableAutoReconnect(): void { this._autoReconnect = true; }

--- a/tests/unit/auth-middleware-live-token.test.ts
+++ b/tests/unit/auth-middleware-live-token.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the auth middleware's live-token resolution (PR 7 of the
+ * tunnel-failure-resilience chain).
+ *
+ * Spec: specs/dev-infrastructure/tunnel-failure-resilience.md Part 6.
+ *
+ * authMiddleware now accepts a getter so the bearer token can be rotated
+ * at runtime (tunnel credential rotation) and take effect IMMEDIATELY —
+ * the security guarantee is that the moment rotation completes, the old
+ * bearer token AND old HMAC-signed view URLs are rejected, without a
+ * server restart. These tests assert both sides of that boundary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { authMiddleware, signViewPath } from '../../src/server/middleware.js';
+
+function mockReq(opts: { path?: string; method?: string; auth?: string; sig?: string }): Request {
+  const headers: Record<string, unknown> = {};
+  if (opts.auth) headers.authorization = `Bearer ${opts.auth}`;
+  return {
+    path: opts.path ?? '/status',
+    method: opts.method ?? 'GET',
+    headers,
+    query: opts.sig ? { sig: opts.sig } : {},
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as Request;
+}
+
+function mockRes(): Response & { statusCode: number } {
+  const res = { statusCode: 0 } as Response & { statusCode: number };
+  res.status = ((n: number) => { res.statusCode = n; return res; }) as Response['status'];
+  res.json = (() => res) as Response['json'];
+  return res;
+}
+
+/** Run the middleware against a request; returns whether next() was called. */
+function run(mw: ReturnType<typeof authMiddleware>, req: Request, res: Response): boolean {
+  let nexted = false;
+  const next: NextFunction = () => { nexted = true; };
+  mw(req, res, next);
+  return nexted;
+}
+
+describe('authMiddleware live-token resolution', () => {
+  it('string form (back-compat): valid token passes, wrong token 403s', () => {
+    const mw = authMiddleware('static-token');
+    expect(run(mw, mockReq({ auth: 'static-token' }), mockRes())).toBe(true);
+
+    const res = mockRes();
+    expect(run(mw, mockReq({ auth: 'wrong' }), res)).toBe(false);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('getter form: resolves the token per request', () => {
+    const mw = authMiddleware(() => 'tok-A');
+    expect(run(mw, mockReq({ auth: 'tok-A' }), mockRes())).toBe(true);
+
+    const res = mockRes();
+    expect(run(mw, mockReq({ auth: 'nope' }), res)).toBe(false);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('ROTATION: the same middleware instance honors a token change immediately', () => {
+    let token = 'tok-OLD';
+    const mw = authMiddleware(() => token);
+
+    // Before rotation: OLD passes.
+    expect(run(mw, mockReq({ auth: 'tok-OLD' }), mockRes())).toBe(true);
+
+    // Rotate the live token.
+    token = 'tok-NEW';
+
+    // After rotation: OLD is rejected, NEW passes — no new middleware, no restart.
+    const resOld = mockRes();
+    expect(run(mw, mockReq({ auth: 'tok-OLD' }), resOld)).toBe(false);
+    expect(resOld.statusCode).toBe(403);
+    expect(run(mw, mockReq({ auth: 'tok-NEW' }), mockRes())).toBe(true);
+  });
+
+  it('ROTATION invalidates previously-signed view URLs', () => {
+    let token = 'tok-OLD';
+    const mw = authMiddleware(() => token);
+    const viewPath = '/view/abc123';
+    const sig = signViewPath(viewPath, 'tok-OLD');
+
+    // Old signed URL works while the token is current.
+    expect(run(mw, mockReq({ path: viewPath, sig }), mockRes())).toBe(true);
+
+    // After rotation, the HMAC no longer matches (verification uses the
+    // live token) → the signed URL is rejected (falls through to the
+    // bearer check, which 401s with no header).
+    token = 'tok-NEW';
+    const res = mockRes();
+    expect(run(mw, mockReq({ path: viewPath, sig }), res)).toBe(false);
+    expect(res.statusCode).toBe(401);
+
+    // A URL signed with the NEW token works.
+    const newSig = signViewPath(viewPath, 'tok-NEW');
+    expect(run(mw, mockReq({ path: viewPath, sig: newSig }), mockRes())).toBe(true);
+  });
+
+  it('getter returning undefined → open (test/dev passthrough)', () => {
+    const mw = authMiddleware(() => undefined);
+    expect(run(mw, mockReq({ path: '/status' }), mockRes())).toBe(true);
+  });
+});

--- a/tests/unit/tunnel-credential-rotation.test.ts
+++ b/tests/unit/tunnel-credential-rotation.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for tunnel credential rotation (PR 7 of the
+ * tunnel-failure-resilience chain).
+ *
+ * Spec: specs/dev-infrastructure/tunnel-failure-resilience.md Part 6.
+ *
+ * Covers the manager's WHEN of rotation — the lifecycle triggers and the
+ * mandatory-rotation invariant (flag set on relay-active entry, cleared
+ * only after the rotator resolves):
+ *   - relay-active → idle (stop) rotates; non-relay stop does not.
+ *   - boot-recovery rotates when the persisted flag is set.
+ *   - a thrown rotator leaves the flag set so the next stop/boot retries.
+ *   - no rotator wired → flag cleared with a loud warning (no infinite loop).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TunnelManager, type TunnelMessagingAdapter } from '../../src/tunnel/TunnelManager.js';
+import type {
+  TunnelProvider,
+  TunnelProviderHandle,
+  ProviderName,
+  ProviderTier,
+} from '../../src/tunnel/TunnelProvider.js';
+
+function mockProvider(opts: { name: ProviderName; tier?: ProviderTier; available?: boolean; startResult?: 'success' | { error: string }; url?: string }): TunnelProvider {
+  return {
+    name: opts.name,
+    tier: opts.tier ?? 1,
+    isAvailable: vi.fn(async () => opts.available !== false),
+    start: vi.fn(async (): Promise<TunnelProviderHandle> => {
+      if (opts.startResult && typeof opts.startResult === 'object') throw new Error(opts.startResult.error);
+      return { url: opts.url ?? `https://${opts.name}.example`, stop: async () => undefined };
+    }),
+  };
+}
+
+function mockAdapter() {
+  let consentHandler: ((action: 'grant' | 'decline', nonce: string) => Promise<string>) | null = null;
+  const adapter: TunnelMessagingAdapter = {
+    sendToTopic: vi.fn(async () => undefined),
+    sendToOwnerDM: vi.fn(async () => undefined),
+    getDashboardTopicId: () => 42,
+    getLifelineTopicId: () => 43,
+    sendOwnerConsentPrompt: vi.fn(async () => 1001),
+    setTunnelConsentHandler: (fn) => { consentHandler = fn; },
+  };
+  return { adapter, invoke: (a: 'grant' | 'decline', n: string) => consentHandler!(a, n) };
+}
+
+const okFetch = vi.fn(async () => new Response('ok', { status: 200 }));
+const baseConfig = { enabled: true, type: 'quick' as const, port: 4040, stateDir: '' };
+
+let stateDir: string;
+beforeEach(() => { stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tunnel-rotate-')); });
+afterEach(() => {
+  try {
+    SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/tunnel-credential-rotation.test.ts:cleanup' });
+  } catch { /* ignore */ }
+});
+
+/** Build a manager, drive Tier-1 exhaustion → grant → relay-active. */
+async function managerInRelayActive(rotator: () => Promise<void>) {
+  const m = mockAdapter();
+  const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited: 1015' } });
+  const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true, url: 'https://relay.loca.lt' });
+  const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [tier1, tier2], fetch: okFetch });
+  mgr.setCredentialRotator(rotator);
+  mgr.attachTelegram(m.adapter, () => '123456');
+  await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+  const nonce = mgr.pendingConsent!.nonce;
+  await m.invoke('grant', nonce);
+  expect(mgr.lifecycleState.lastState).toBe('relay-active');
+  expect(mgr.lifecycleState.rotationPending).toBe(true);
+  return mgr;
+}
+
+describe('TunnelManager credential rotation', () => {
+  it('stop() from relay-active rotates credentials and clears rotationPending', async () => {
+    const rotate = vi.fn(async () => undefined);
+    const mgr = await managerInRelayActive(rotate);
+
+    await mgr.stop();
+
+    expect(rotate).toHaveBeenCalledTimes(1);
+    expect(mgr.lifecycleState.rotationPending).toBe(false);
+  });
+
+  it('stop() from a non-relay state does NOT rotate', async () => {
+    const rotate = vi.fn(async () => undefined);
+    const tier1 = mockProvider({ name: 'cloudflare-quick', url: 'https://q.example' });
+    const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [tier1], fetch: okFetch });
+    mgr.setCredentialRotator(rotate);
+    await mgr.start();
+    expect(mgr.lifecycleState.rotationPending).toBe(false);
+
+    await mgr.stop();
+
+    expect(rotate).not.toHaveBeenCalled();
+  });
+
+  it('runCredentialRotation is a no-op when nothing is pending', async () => {
+    const rotate = vi.fn(async () => undefined);
+    const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [mockProvider({ name: 'cloudflare-quick' })], fetch: okFetch });
+    mgr.setCredentialRotator(rotate);
+
+    const did = await mgr.runCredentialRotation('test');
+
+    expect(did).toBe(false);
+    expect(rotate).not.toHaveBeenCalled();
+  });
+
+  it('a thrown rotator leaves rotationPending SET so the next attempt retries', async () => {
+    const rotate = vi.fn(async () => { throw new Error('config write failed'); });
+    const mgr = await managerInRelayActive(rotate);
+
+    const did = await mgr.runCredentialRotation('stop');
+
+    expect(did).toBe(false);
+    expect(rotate).toHaveBeenCalledTimes(1);
+    // Invariant: the mandatory-rotation flag must NOT be cleared on failure.
+    expect(mgr.lifecycleState.rotationPending).toBe(true);
+  });
+
+  it('no rotator wired → clears the flag with a warning (no permanent-pending loop)', async () => {
+    const mgr = await managerInRelayActive(async () => undefined);
+    mgr.setCredentialRotator(null); // simulate misconfiguration
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const did = await mgr.runCredentialRotation('stop');
+
+    expect(did).toBe(false);
+    expect(mgr.lifecycleState.rotationPending).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('boot-recovery: a fresh manager restores rotationPending and rotates before serving', async () => {
+    // First manager reaches relay-active (persists rotationPending=true), then
+    // the process "dies" without a clean stop (no rotation).
+    await managerInRelayActive(async () => undefined);
+
+    // A new manager over the SAME stateDir restores the persisted flag.
+    const rotate = vi.fn(async () => undefined);
+    const mgr2 = new TunnelManager({ ...baseConfig, stateDir }, { providers: [mockProvider({ name: 'cloudflare-quick' })], fetch: okFetch });
+    mgr2.setCredentialRotator(rotate);
+    expect(mgr2.lifecycleState.rotationPending).toBe(true);
+
+    const did = await mgr2.recoverPendingRotation();
+
+    expect(did).toBe(true);
+    expect(rotate).toHaveBeenCalledTimes(1);
+    expect(mgr2.lifecycleState.rotationPending).toBe(false);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,36 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+PR 7 of the tunnel-failure-resilience chain. This is the security cleanup that makes the backup-tunnel feature safe to use: whenever a backup relay episode ends, the agent now rotates your dashboard PIN and access token.
+
+**Why it matters.** While a backup relay is active, your dashboard traffic — including the PIN and any private view links — briefly passes through a third-party operator's machines. PIN rotation alone is not enough: the private view links are signed with your access token, so a copied link would keep working forever unless the token itself changes. This release rotates both. The moment the backup ends, the old PIN stops working and every previously-shared private view link becomes invalid.
+
+**Where it triggers.** Every terminal exit from a backup relay episode rotates: an operator stop/shutdown while the relay was up, and — most importantly — boot-recovery. If the agent died mid-relay-episode, a flag persisted to disk causes rotation to run on the next boot **before the server accepts any API traffic**, so a relay operator who saw the old credentials can't use them against the freshly-started server.
+
+**How it takes effect immediately.** The auth layer now reads the token live on every request instead of capturing it once at startup. So rotation invalidates the old token and old signed URLs instantly, with no restart. Existing behavior is unchanged when no rotation happens.
+
+## What to Tell Your User
+
+- If a backup tunnel was ever used, you'll get a private message with a fresh dashboard PIN once it's no longer needed. Any open dashboard tab will ask you to sign in again with the new PIN.
+- Any private view link you shared while the backup was active will stop working — that's deliberate, so the backup operator can't reuse it.
+- If nothing ever falls back to a backup, you'll never see any of this; normal operation is unchanged.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Credential rotation on relay-episode end | Automatic — fires on stop/shutdown and boot-recovery whenever a backup relay was in use; new PIN arrives in the owner DM |
+| Live auth-token resolution | Automatic — the server now honors a rotated token immediately, no restart |
+
+## Evidence
+
+- Spec: `specs/dev-infrastructure/tunnel-failure-resilience.md` Part 6. Side-effects: `upgrades/side-effects/tunnel-credential-rotation.md`.
+- Tests: `tests/unit/auth-middleware-live-token.test.ts` (5) asserts both sides of the rotation boundary — the old bearer token AND an old HMAC-signed view URL are rejected the instant the live token changes, and a URL signed with the new token works. `tests/unit/tunnel-credential-rotation.test.ts` (6) asserts the lifecycle: relay-active→idle rotates, a non-relay stop does not, a thrown rotator leaves the pending flag set for retry, and a fresh manager restores the flag and rotates on boot-recovery.
+- No regression: 75 auth + tunnel tests pass, including the existing string-form auth-middleware suites (the refactor is backward compatible).
+
+## Rollback
+
+The middleware change is backward compatible (it still accepts a plain string). Revert = restore the string argument at the AgentServer auth callsite, drop the manager rotation methods and the `stop()` trigger, and remove the server.ts rotator closure + boot-recovery call. No config schema or persistent-state migration — a rotated PIN/token is just a new value.

--- a/upgrades/side-effects/tunnel-credential-rotation.md
+++ b/upgrades/side-effects/tunnel-credential-rotation.md
@@ -1,0 +1,88 @@
+# Side-effects review — credential rotation (PR 7 of tunnel-failure-resilience chain)
+
+**Scope (PR 7 of the chain):** Make `authToken` + `dashboardPin`
+rotation real on every terminal exit from `relay-active`, plus
+boot-recovery. The `rotationPending` flag (set on relay-active entry in
+PR 5, persisted to `tunnel.json`) is now consumed: rotating the
+authToken invalidates every previously-signed view URL and the dashboard
+session — the documented UX cost of having briefly routed private
+traffic through a third-party relay. Spec Part 6.
+
+**Files touched:**
+- `src/server/middleware.ts` — `authMiddleware` accepts `string | (() =>
+  string | undefined)` and resolves the token **per request**, so a
+  runtime rotation takes effect immediately (no restart). Backward
+  compatible: the string form is byte-identical to before.
+- `src/server/AgentServer.ts` — wires the live getter
+  `authMiddleware(() => this.config.authToken, …)`. `this.config` is set
+  in the constructor and never reassigned, so the getter always reads the
+  shared, mutable config object.
+- `src/tunnel/TunnelManager.ts` — `setCredentialRotator(fn)`,
+  `runCredentialRotation(reason)` (gated on `rotationPending`,
+  clears-only-after-success), `recoverPendingRotation()` (boot path), and
+  a rotation trigger at the end of `stop()`.
+- `src/commands/server.ts` — the rotator closure (regen PIN + authToken →
+  `liveConfig.set` + mutate the in-memory `config` → owner DM with the new
+  PIN), wired right after tunnel construction; boot-recovery awaited
+  **before** `server.start()`.
+- Tests: `tests/unit/tunnel-credential-rotation.test.ts` (6),
+  `tests/unit/auth-middleware-live-token.test.ts` (5).
+
+**Over-block:** None. The middleware resolves `string → itself`, so all
+existing string callers and the 75 auth/tunnel tests are unchanged.
+
+**Under-block:** The getter returning `undefined` means "open" (the
+documented test/dev passthrough), same as the old `authToken === undefined`
+behavior. In production `authToken` is always set (init generates it;
+rotation always assigns a fresh non-empty UUID). The rotator does
+`config.authToken = newToken` as a single synchronous assignment after
+the `liveConfig.set` calls — there is no window where the live token is
+`undefined`; a concurrent in-flight request reads either the old or the
+new token, never empty. The instant the assignment lands, the old bearer
+token and old signed URLs are rejected (asserted by the rotation tests).
+
+**Level-of-abstraction fit:** The manager owns the WHEN (lifecycle
+triggers + the `rotationPending` invariant); the injected closure owns
+the WHAT (regenerate/persist/notify). The manager never imports config or
+messaging. Mirrors the PR 6 `attachTelegram` seam.
+
+**Signal vs authority:** `rotationPending` is the single-writer
+authoritative marker owned by `TunnelLifecycle`. `runCredentialRotation`
+clears it **only after** the rotator resolves; a thrown rotator leaves it
+set so the next `stop()` or next boot retries (tested). No abstraction
+treats a low-context signal as authority.
+
+**Interactions:**
+- Boot-recovery runs before `server.start()` (verified ordering:
+  rotator wired at tunnel-construction ~L4846 → boot-recovery at L7305 →
+  listen inside `server.start()`). The owner DM uses `sendToOwnerDM`
+  (private chat), so it does not depend on the Dashboard topic being
+  ensured yet.
+- The startup `dashboardPin` auto-gen (`if (!config.dashboardPin)`) runs
+  after boot-recovery, so a boot-recovery rotation is not clobbered.
+- `signViewPath` (routes.ts) and `verifyViewSignature` (middleware) both
+  read the live token, so post-rotation: new view URLs are signed with
+  the new token and old shared URLs fail verification — the intended
+  invalidation (tested).
+- The 6-digit PIN keeps the existing `Math.random` generator (a
+  convenience factor, not the primary secret); `authToken` is
+  `randomUUID()` and is the HMAC key. No change to the secret model.
+
+**Migration parity:** No agent-installed files change. The rotation is
+runtime behavior in `server.ts` (every agent runs the new server after
+update) and an internal middleware refactor; no new config field, no
+CLAUDE.md/hook change (those land in PR 9). `rotationPending` already
+existed in the persisted schema since PR 5.
+
+**Tier-2/Tier-3 note:** PR 7 adds no HTTP route — per spec Part 8 the
+HTTP-assertable "feature is alive" surface is the `/tunnel` route in
+PR 9. PR 7's security guarantee is covered by the live-token middleware
+unit tests (both sides of the boundary + view-URL invalidation) and the
+manager rotation-lifecycle tests; the boot-recovery wiring is verified at
+the `server.ts` call site.
+
+**Rollback cost:** Low. The middleware change is backward compatible;
+revert = restore the string arg at the AgentServer callsite, drop the
+manager rotation methods + `stop()` trigger, and remove the server.ts
+rotator closure + boot-recovery call. No schema or persistent-state
+migration (rotated PIN/token are just new values).


### PR DESCRIPTION
## Summary

PR 7 of the tunnel-failure-resilience chain. Makes `authToken` + `dashboardPin` rotation real, consuming the `rotationPending` flag that PR 5 (#336) set on `relay-active` entry. Rotating the authToken invalidates every previously-signed view URL and the dashboard session — the documented UX cost of having briefly routed private dashboard traffic through a third-party relay (spec Part 6).

- **Live auth token**: `authMiddleware` now accepts `string | (() => string | undefined)` and resolves the token **per request**, so rotation takes effect immediately with no restart. Backward compatible — the string form is byte-identical (75 existing auth/tunnel tests still green). `AgentServer` wires the live getter `() => this.config.authToken`.
- **Manager (WHEN)**: `setCredentialRotator(fn)` + `runCredentialRotation(reason)` (gated on `rotationPending`, clears the flag **only after** the rotator resolves; a thrown rotator leaves it set so the next `stop()`/boot retries) + `recoverPendingRotation()`. `stop()` triggers rotation when leaving `relay-active`.
- **server.ts (WHAT)**: the rotator closure regenerates the 6-digit PIN + a `randomUUID` authToken, persists via `liveConfig.set` (survives restart), mutates the in-memory `config` the running server reads live, and DMs the owner the new PIN + the explicit "old tabs/links no longer work" notice. Boot-recovery is awaited **before** `server.start()` — if the agent died mid-relay-episode, the persisted flag forces rotation before any API traffic is accepted.

## Security boundary

After rotation: the old bearer token 403s, an old HMAC-signed view URL fails verification (falls through to a 401), and only the new token / a URL signed with the new token work. Asserted directly.

## Tests (11)

- `tests/unit/auth-middleware-live-token.test.ts` (5): string-form back-compat; getter resolves per request; **rotation** — same middleware instance rejects the old token + old signed URL and accepts the new immediately.
- `tests/unit/tunnel-credential-rotation.test.ts` (6): relay-active→idle rotates; non-relay stop does not; no-op when nothing pending; thrown rotator leaves the flag set; no-rotator clears with a warning; boot-recovery restores the flag and rotates.

## Notes

PR 7 adds no HTTP route — per spec Part 8 the HTTP-assertable "feature is alive" surface is the `/tunnel` route in PR 9. Boot-recovery wiring is verified at the `server.ts` call site (ordering: rotator wired at tunnel construction → boot-recovery → listen). No agent-installed file changes, so no migration-parity work (PR 9 owns config defaults + CLAUDE.md).

## Evidence / docs

- Spec: `specs/dev-infrastructure/tunnel-failure-resilience.md` Part 6. Upgrade guide: `upgrades/NEXT.md`. Side-effects: `upgrades/side-effects/tunnel-credential-rotation.md`.

## Rollback

Backward compatible. Revert = restore the string arg at the AgentServer callsite, drop the manager rotation methods + `stop()` trigger, remove the server.ts rotator closure + boot-recovery call. No schema/persistent-state migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)