### PR TITLE
feat(tunnel): self-heal stability gate — switch back to Tier-1 on recovery (PR 8 of tunnel-failure-resilience)

### DIFF
--- a/src/tunnel/TunnelManager.ts
+++ b/src/tunnel/TunnelManager.ts
@@ -48,6 +48,7 @@ import {
   generateNonce,
   type PersistedTunnelState,
   type TransitionEvent,
+  type TunnelLifecycleState,
 } from './TunnelLifecycle.js';
 import type {
   TunnelProvider,
@@ -147,6 +148,16 @@ const REACHABILITY_TIMEOUT_MS = 8_000;
 const POST_EXHAUSTED_RETRY_INTERVAL_MS = 15 * 60_000;
 /** Per-episode consent prompt timeout — matches spec Part 4 default (15 min). */
 const CONSENT_TIMEOUT_MS = 15 * 60_000;
+/**
+ * Self-heal stability gate (spec Part 5). While a relay is active, an
+ * unbounded low-frequency probe tests whether Tier-1 (Cloudflare) can
+ * come back. Migrate back only after N consecutive successful Tier-1
+ * establishments — a single success during Cloudflare flapping must NOT
+ * trigger a switch (the URL-thrashing HIGH from review). With the
+ * default cadence, 3 consecutive successes span ~5 minutes.
+ */
+const SELF_HEAL_PROBE_INTERVAL_MS = 100_000;
+const SELF_HEAL_REQUIRED_SUCCESSES = 3;
 
 // ── Manager ────────────────────────────────────────────────────────
 
@@ -168,6 +179,11 @@ export class TunnelManager extends EventEmitter {
   private _backoffAttempt = 0;
   private _backoffTimer: ReturnType<typeof setTimeout> | null = null;
   private _postExhaustedTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Self-heal probe (Part 5): runs while relay-active to detect Tier-1 recovery. */
+  private _selfHealTimer: ReturnType<typeof setInterval> | null = null;
+  private _selfHealSuccesses = 0;
+  /** Guards performSwitchBack against re-entrancy (probe tick vs. stop). */
+  private _switchingBack = false;
   /**
    * Pending consent record — populated when the manager enters
    * `awaiting-consent` and cleared on grant / decline / timeout / stop.
@@ -255,6 +271,7 @@ export class TunnelManager extends EventEmitter {
     this._stopped = true;
     this.clearBackoffTimer();
     this.clearPostExhaustedTimer();
+    this.stopSelfHealProbe();
     this.clearPendingConsent();
     this._startPromise = null;
 
@@ -580,6 +597,155 @@ export class TunnelManager extends EventEmitter {
     return null;
   }
 
+  // ── Self-heal (Part 5): switch back to Tier-1 when it recovers ──────
+
+  /** First Tier-1 provider (Cloudflare named/quick), or null. */
+  private firstTier1Provider(): TunnelProvider | null {
+    for (const p of this.providers) {
+      if (p.tier === 1) return p;
+    }
+    return null;
+  }
+
+  private startSelfHealProbe(): void {
+    if (this._selfHealTimer) return;
+    this._selfHealSuccesses = 0;
+    this._selfHealTimer = setInterval(() => {
+      void this.runSelfHealCheck().catch(() => { /* probe is best-effort */ });
+    }, SELF_HEAL_PROBE_INTERVAL_MS);
+    this._selfHealTimer.unref?.();
+  }
+
+  private stopSelfHealProbe(): void {
+    if (this._selfHealTimer) {
+      clearInterval(this._selfHealTimer);
+      this._selfHealTimer = null;
+    }
+    this._selfHealSuccesses = 0;
+  }
+
+  /**
+   * One self-heal probe tick. Public so tests can drive the stability
+   * gate deterministically (no real multi-minute waits — the spec's
+   * Part 8 testability requirement). The production timer calls this on
+   * a fixed cadence.
+   *
+   * Each tick attempts to establish a Tier-1 tunnel and verify
+   * reachability. Consecutive successes accrue; a single failure resets
+   * the counter (so Cloudflare flapping never triggers a premature
+   * switch). On the Nth consecutive success the freshly-verified handle
+   * is PROMOTED via an atomic new-then-old switch-back — so the public
+   * URL never points at a dead tunnel mid-switch.
+   *
+   * Returns the outcome for assertions/telemetry.
+   */
+  async runSelfHealCheck(): Promise<'switched' | 'progress' | 'reset' | 'inactive'> {
+    if (this._stopped || this.lifecycle.state !== 'relay-active' || this._switchingBack) {
+      if (this.lifecycle.state !== 'relay-active') this.stopSelfHealProbe();
+      return 'inactive';
+    }
+    const tier1 = this.firstTier1Provider();
+    if (!tier1) return 'inactive';
+
+    let handle: TunnelProviderHandle | null = null;
+    let ok = false;
+    try {
+      handle = await tier1.start(this.config.port);
+      ok = await this.probeReachability(handle.url).catch(() => false);
+    } catch {
+      ok = false;
+    }
+
+    if (!ok) {
+      if (handle) { try { await handle.stop(); } catch { /* best effort */ } }
+      this._selfHealSuccesses = 0;
+      return 'reset';
+    }
+
+    this._selfHealSuccesses += 1;
+    if (this._selfHealSuccesses >= SELF_HEAL_REQUIRED_SUCCESSES && handle) {
+      // Promote THIS already-up, already-verified handle — no second start.
+      const did = await this.performSwitchBack(tier1, handle);
+      return did ? 'switched' : 'reset';
+    }
+
+    // Not enough consecutive successes yet — release the throwaway probe
+    // tunnel; the relay keeps serving.
+    if (handle) { try { await handle.stop(); } catch { /* best effort */ } }
+    return 'progress';
+  }
+
+  /**
+   * Atomic switch-back from a Tier-2 relay to a recovered Tier-1 tunnel.
+   * `newHandle` is already started AND reachability-verified by the
+   * probe. Order (spec Part 5): swap `_state.url` to the new URL in one
+   * synchronous assignment and emit 'url' BEFORE tearing the relay down,
+   * so getExternalUrl() never returns a dead URL. Relay teardown is the
+   * provider's stop() (forceful escalation is the provider contract).
+   * On reaching `active`, the relay episode has terminally ended → rotate
+   * credentials (PR 7), since the relay operator saw the old PIN/links.
+   */
+  private async performSwitchBack(provider: TunnelProvider, newHandle: TunnelProviderHandle): Promise<boolean> {
+    if (this._switchingBack) return false;
+    const entryState: TunnelLifecycleState = this.lifecycle.state;
+    if (entryState !== 'relay-active') {
+      try { await newHandle.stop(); } catch { /* best effort */ }
+      return false;
+    }
+    this._switchingBack = true;
+    const oldHandle = this.currentHandle;
+    const oldProviderName = this.currentProviderName;
+    const oldUrl = this._legacyState.url;
+    try {
+      this.lifecycle.transition('relay-active', 'self-healing', { activeProvider: null });
+
+      // new-then-old: the new Tier-1 handle is already up + verified.
+      this.currentHandle = newHandle;
+      this.currentProviderName = provider.name;
+      this._legacyState.url = newHandle.url;
+      this._legacyState.startedAt = new Date().toISOString();
+      this.emit('url', newHandle.url);
+
+      // Now tear down the relay — confirm it's gone before declaring
+      // recovery, so private traffic can't keep flowing through the third
+      // party.
+      if (oldHandle && oldHandle !== newHandle) {
+        try { await oldHandle.stop(); } catch { /* provider escalates SIGINT→SIGKILL internally */ }
+      }
+
+      this.lifecycle.transition('self-healing', 'active', {
+        activeProvider: provider.name,
+        lastFailureReason: null,
+      });
+      this.persist();
+      this.stopSelfHealProbe();
+      this.emit('self-healed', { provider: provider.name, url: newHandle.url });
+
+      // Terminal exit from the relay episode → mandatory credential
+      // rotation (rotationPending was set on relay-active entry).
+      await this.runCredentialRotation('self-heal');
+      return true;
+    } catch {
+      // Switch failed — try to stay on the relay rather than go dark.
+      this.currentHandle = oldHandle;
+      this.currentProviderName = oldProviderName;
+      this._legacyState.url = oldUrl;
+      const stateNow: TunnelLifecycleState = this.lifecycle.state;
+      if (stateNow === 'self-healing') {
+        try {
+          this.lifecycle.transition('self-healing', 'relay-active', {
+            activeProvider: oldProviderName,
+          });
+        } catch { /* best effort */ }
+      }
+      this._selfHealSuccesses = 0;
+      try { await newHandle.stop(); } catch { /* best effort */ }
+      return false;
+    } finally {
+      this._switchingBack = false;
+    }
+  }
+
   /**
    * Internal — called after the lifecycle transitions to
    * `awaiting-consent`. Generates the one-time nonce, stores the
@@ -692,6 +858,9 @@ export class TunnelManager extends EventEmitter {
       });
       this.persist();
       this.emit('url', handle.url);
+      // Begin watching for Tier-1 recovery so we can switch back off the
+      // third-party relay automatically (spec Part 5).
+      this.startSelfHealProbe();
       return true;
     } catch (err) {
       this.lifecycle.recordAttempt(provider.name, classifyFailure(err));

--- a/tests/unit/tunnel-self-heal.test.ts
+++ b/tests/unit/tunnel-self-heal.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the self-heal stability gate (PR 8 of the
+ * tunnel-failure-resilience chain).
+ *
+ * Spec: specs/dev-infrastructure/tunnel-failure-resilience.md Part 5.
+ *
+ * While a relay is active, a low-frequency probe tests Tier-1 recovery.
+ * The manager migrates back only after N CONSECUTIVE successful Tier-1
+ * establishments (a single success during flapping must NOT switch), via
+ * an atomic new-then-old switch-back, and rotates credentials on the way
+ * to `active` (the relay episode terminally ended).
+ *
+ * Tests drive `runSelfHealCheck()` directly (the production timer calls
+ * it on a cadence) so the stability gate is exercised without real waits.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TunnelManager, type TunnelMessagingAdapter } from '../../src/tunnel/TunnelManager.js';
+import type { TunnelProvider, TunnelProviderHandle, ProviderName, ProviderTier } from '../../src/tunnel/TunnelProvider.js';
+
+/** A Tier-1 provider whose start() behavior is switchable across calls. */
+function controllableTier1() {
+  let mode: 'fail' | 'ok' = 'fail';
+  const relayStops: number[] = [];
+  void relayStops;
+  const provider: TunnelProvider = {
+    name: 'cloudflare-quick',
+    tier: 1,
+    isAvailable: vi.fn(async () => true),
+    start: vi.fn(async (): Promise<TunnelProviderHandle> => {
+      if (mode === 'fail') throw new Error('rate-limited: 1015');
+      return { url: 'https://cf-recovered.example', stop: vi.fn(async () => undefined) };
+    }),
+  };
+  return { provider, setMode: (m: 'fail' | 'ok') => { mode = m; } };
+}
+
+/** A Tier-2 relay whose handle.stop is spyable (to assert teardown). */
+function spyableTier2(): { provider: TunnelProvider; stop: ReturnType<typeof vi.fn> } {
+  const stop = vi.fn(async () => undefined);
+  const provider: TunnelProvider = {
+    name: 'localtunnel',
+    tier: 2,
+    isAvailable: vi.fn(async () => true),
+    start: vi.fn(async (): Promise<TunnelProviderHandle> => ({ url: 'https://relay.loca.lt', stop })),
+  };
+  return { provider, stop };
+}
+
+function mockAdapter(): { adapter: TunnelMessagingAdapter; invoke: (a: 'grant' | 'decline', n: string) => Promise<string> } {
+  let h: ((action: 'grant' | 'decline', nonce: string) => Promise<string>) | null = null;
+  const adapter: TunnelMessagingAdapter = {
+    sendToTopic: vi.fn(async () => undefined),
+    sendToOwnerDM: vi.fn(async () => undefined),
+    getDashboardTopicId: () => 42,
+    getLifelineTopicId: () => 43,
+    sendOwnerConsentPrompt: vi.fn(async () => 1001),
+    setTunnelConsentHandler: (fn) => { h = fn; },
+  };
+  return { adapter, invoke: (a, n) => h!(a, n) };
+}
+
+const okFetch = vi.fn(async () => new Response('ok', { status: 200 }));
+const baseConfig = { enabled: true, type: 'quick' as const, port: 4040, stateDir: '' };
+
+let stateDir: string;
+beforeEach(() => { stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tunnel-selfheal-')); });
+afterEach(() => {
+  try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/tunnel-self-heal.test.ts:cleanup' }); } catch { /* ignore */ }
+});
+
+/** Drive a manager to relay-active with a controllable Tier-1 + spyable relay. */
+async function inRelayActive(rotate: () => Promise<void>) {
+  const t1 = controllableTier1();
+  const t2 = spyableTier2();
+  const m = mockAdapter();
+  const mgr = new TunnelManager({ ...baseConfig, stateDir }, { providers: [t1.provider, t2.provider], fetch: okFetch });
+  mgr.setCredentialRotator(rotate);
+  mgr.attachTelegram(m.adapter, () => '123456');
+  await expect(mgr.start()).rejects.toBeInstanceOf(Error); // Tier-1 fails → awaiting-consent
+  await m.invoke('grant', mgr.pendingConsent!.nonce);       // → relay-active
+  expect(mgr.lifecycleState.lastState).toBe('relay-active');
+  expect(mgr.url).toBe('https://relay.loca.lt');
+  return { mgr, t1, t2 };
+}
+
+describe('TunnelManager self-heal stability gate', () => {
+  it('migrates back only after N CONSECUTIVE Tier-1 successes (atomic switch + rotation)', async () => {
+    const rotate = vi.fn(async () => undefined);
+    const { mgr, t1, t2 } = await inRelayActive(rotate);
+    t1.setMode('ok'); // Cloudflare has recovered
+
+    expect(await mgr.runSelfHealCheck()).toBe('progress'); // 1
+    expect(await mgr.runSelfHealCheck()).toBe('progress'); // 2
+    expect(mgr.lifecycleState.lastState).toBe('relay-active'); // still on relay
+    expect(t2.stop).not.toHaveBeenCalled();
+
+    expect(await mgr.runSelfHealCheck()).toBe('switched');  // 3 → switch back
+
+    // Atomic new-then-old: URL is the recovered Cloudflare URL, state active.
+    expect(mgr.url).toBe('https://cf-recovered.example');
+    expect(mgr.lifecycleState.lastState).toBe('active');
+    // The relay was torn down…
+    expect(t2.stop).toHaveBeenCalled();
+    // …and credentials were rotated (terminal exit from relay-active).
+    expect(rotate).toHaveBeenCalledTimes(1);
+    expect(mgr.lifecycleState.rotationPending).toBe(false);
+  });
+
+  it('a single success during flapping does NOT accumulate — the counter resets on failure', async () => {
+    const rotate = vi.fn(async () => undefined);
+    const { mgr, t1, t2 } = await inRelayActive(rotate);
+
+    t1.setMode('ok');
+    expect(await mgr.runSelfHealCheck()).toBe('progress'); // 1
+    expect(await mgr.runSelfHealCheck()).toBe('progress'); // 2
+
+    t1.setMode('fail'); // Cloudflare flaps back down
+    expect(await mgr.runSelfHealCheck()).toBe('reset');    // counter → 0, stay on relay
+    expect(mgr.lifecycleState.lastState).toBe('relay-active');
+    expect(t2.stop).not.toHaveBeenCalled();
+
+    // Now it takes a FRESH run of 3 consecutive successes to switch.
+    t1.setMode('ok');
+    expect(await mgr.runSelfHealCheck()).toBe('progress'); // 1
+    expect(await mgr.runSelfHealCheck()).toBe('progress'); // 2
+    expect(mgr.lifecycleState.lastState).toBe('relay-active');
+    expect(await mgr.runSelfHealCheck()).toBe('switched'); // 3
+    expect(mgr.lifecycleState.lastState).toBe('active');
+    expect(rotate).toHaveBeenCalledTimes(1);
+  });
+
+  it('runSelfHealCheck is inactive (and stops the probe) once not relay-active', async () => {
+    const { mgr } = await inRelayActive(async () => undefined);
+    await mgr.stop();
+    expect(await mgr.runSelfHealCheck()).toBe('inactive');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,34 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+PR 8 of the tunnel-failure-resilience chain. This is the self-heal piece: once you've been moved onto a backup tunnel because Cloudflare was down, the agent now watches for Cloudflare to come back and automatically switches you off the backup — without leaving your dashboard link dead for even a moment.
+
+**Patient, not twitchy.** The hard part of switching back is doing it at the right time. A flaky network can let one Cloudflare check succeed and then fail again seconds later; switching on that single success would thrash your link back and forth. So the agent waits for several healthy checks in a row (3 by default, spanning about five minutes) before deciding Cloudflare is genuinely back. A single failure resets the count.
+
+**Seamless, not jarring.** When it does switch, it brings the real Cloudflare link fully up and verifies it actually serves before touching the backup. Only then does it point your dashboard at the new link and tear the backup down. Your link never goes dead in the gap. As the switch completes — the backup is now gone — the credential rotation from the previous release kicks in, so the backup operator can't reuse anything they saw.
+
+## What to Tell Your User
+
+- If you ever got moved onto a backup link, you don't have to do anything to get back to normal — the agent will switch you back to your regular Cloudflare link on its own once Cloudflare is reliably healthy again.
+- It won't flip back and forth on a flaky connection; it waits for a steady run of healthy checks first.
+- When it switches back, your dashboard PIN gets refreshed (from the previous release's security cleanup), so an open tab will ask you to sign in again.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Automatic switch-back to Cloudflare | Automatic — fires after 3 consecutive healthy Tier-1 checks while on a backup relay |
+| Atomic new-then-old switch | Automatic — the recovered link is verified and live before the backup is torn down, so the dashboard link never goes dead mid-switch |
+
+## Evidence
+
+- Spec: `specs/dev-infrastructure/tunnel-failure-resilience.md` Part 5. Side-effects: `upgrades/side-effects/tunnel-self-heal.md`.
+- Tests: `tests/unit/tunnel-self-heal.test.ts` (3) drive the probe tick-by-tick: it asserts a switch fires only on the 3rd consecutive success (the relay is still serving after 2), that the switch points the URL at the recovered Cloudflare link, tears the relay down, and rotates credentials; that a failure mid-run resets the counter so it takes a fresh run of 3 (no thrashing on a single lucky check); and that the probe goes inactive once the tunnel is stopped.
+- No regression: 101 tunnel tests pass.
+
+## Rollback
+
+Additive. Revert = drop the self-heal methods/fields/constants in `TunnelManager` and the two wire points (the probe start on relay-active entry, the probe stop in `stop()`). No config or persisted-state change — the `self-healing` lifecycle state already existed.

--- a/upgrades/side-effects/tunnel-self-heal.md
+++ b/upgrades/side-effects/tunnel-self-heal.md
@@ -1,0 +1,78 @@
+# Side-effects review — self-heal stability gate (PR 8 of tunnel-failure-resilience chain)
+
+**Scope (PR 8 of the chain):** While a Tier-2 relay is active, run an
+unbounded low-frequency probe for Tier-1 (Cloudflare) recovery. Migrate
+back only after **N consecutive** successful Tier-1 establishments
+(default 3, ~5 min) via an atomic new-then-old switch-back, then rotate
+credentials (PR 7) because the relay episode has terminally ended. Spec
+Part 5.
+
+**Files touched:**
+- `src/tunnel/TunnelManager.ts` — `SELF_HEAL_PROBE_INTERVAL_MS` +
+  `SELF_HEAL_REQUIRED_SUCCESSES` constants; `_selfHealTimer`,
+  `_selfHealSuccesses`, `_switchingBack` fields; `startSelfHealProbe`,
+  `stopSelfHealProbe`, `runSelfHealCheck` (public, for deterministic
+  tests), `performSwitchBack`, `firstTier1Provider`. Wired: probe starts
+  on `relay-active` entry (grantConsent) and stops in `stop()`.
+- `tests/unit/tunnel-self-heal.test.ts` — 3 tests.
+
+**Over-block:** None. The probe only runs while `relay-active`; every
+other state (active/retrying/exhausted/awaiting-consent) is untouched.
+The bounded startup-reconnect ladder and the post-exhausted retry are a
+separate counter — self-heal does not interfere with them (spec's
+"separate counter so it never goes silent after the ceiling").
+
+**Under-block (the URL-thrashing HIGH):** A single Tier-1 success does
+NOT switch — `_selfHealSuccesses` must reach N consecutively, and any
+failed probe resets it to 0 (tested with a flapping sequence). The
+switch-back is atomic new-then-old: the recovered Cloudflare handle is
+started AND reachability-verified by the probe, then `_state.url` is
+assigned and `'url'` emitted BEFORE the relay is torn down — so
+`getExternalUrl()`/`url` never returns a dead URL mid-switch (tested:
+post-switch url is the recovered CF url and the relay handle's stop was
+called).
+
+**Level-of-abstraction fit:** The manager owns the stability gate +
+state-machine transitions (`relay-active → self-healing → active`); the
+relay provider's `stop()` owns forceful teardown (SIGINT→SIGKILL +
+PID-verify is the provider contract — localtunnel is in-process per PR 4,
+so its stop() is a best-effort close; a future child-process relay
+escalates inside its own stop()); credential rotation is reused from
+PR 7. The manager never reaches into provider internals.
+
+**Signal vs authority:** A probe result is a low-context signal. The
+N-consecutive gate + the single-writer lifecycle transition is the
+authority — one lucky ping during flapping can never trigger a switch.
+
+**Interactions:**
+- The probe starts a Tier-1 tunnel each tick. Both tunnels forward to the
+  same local port (no conflict). On a non-final success the throwaway
+  probe tunnel is stopped immediately; on the Nth success that
+  already-verified handle is PROMOTED (no redundant second start).
+- `performSwitchBack` is re-entrancy-guarded (`_switchingBack`) and
+  bails if state isn't `relay-active` at entry. On failure it restores
+  the relay handle/provider/url and transitions back to `relay-active`,
+  resetting the counter — the agent stays on the relay rather than going
+  dark.
+- On reaching `active`, `runCredentialRotation('self-heal')` fires
+  (rotationPending was set on relay-active entry) → PIN + authToken
+  rotation, exactly as PR 7's stop-path does.
+- The probe timer is `unref()`'d so it never blocks process exit; `stop()`
+  clears it.
+
+**Performance note:** while on a relay, the probe establishes a real
+Cloudflare tunnel every ~100s to detect recovery (the only reliable
+signal that quick-tunnel rate-limiting has cleared). This is a degraded
+recovery path, not steady state; the throwaway tunnels are torn down
+immediately.
+
+**Tier-2/Tier-3:** No HTTP route in this PR — per spec Part 8 the
+HTTP-assertable surface is the `/tunnel` route in PR 9. Self-heal is
+event-driven and is covered deterministically via `runSelfHealCheck()`
+(stability gate + atomic switch + rotation). Wiring verified: the probe
+is started from the `relay-active` entry in `grantConsent`.
+
+**Rollback cost:** Low/additive. Revert = drop the self-heal
+methods/fields/constants + the two wire points (grantConsent entry,
+`stop()`). The `self-healing` lifecycle state predates this PR. No config
+or persisted-schema change.


### PR DESCRIPTION
## Summary

PR 8 of the tunnel-failure-resilience chain. While a Tier-2 relay is active, an unbounded low-frequency probe watches for Tier-1 (Cloudflare) recovery and switches back automatically — patiently and seamlessly (spec Part 5).

- **Stability gate (no URL-thrashing)**: migrate back only after **N consecutive** successful Tier-1 establishments (default 3, ~5 min). A single success during Cloudflare flapping does NOT switch — any failed probe resets the counter to 0.
- **Atomic new-then-old switch**: the recovered Cloudflare handle is started AND reachability-verified by the probe, then `_state.url` is assigned and `'url'` emitted **before** the relay is torn down — so `url`/`getExternalUrl()` never returns a dead URL mid-switch.
- **Rotation on switch-back**: reaching `active` is a terminal exit from the relay episode, so `runCredentialRotation('self-heal')` (PR 7) fires — the PIN + auth token rotate, invalidating anything the relay operator saw.
- **Safety**: probe starts on `relay-active` entry, stops in `stop()`, timer is `unref()`'d; `performSwitchBack` is re-entrancy-guarded and, on failure, restores the relay (handle/provider/url) and transitions back to `relay-active` rather than going dark.

## Tests (3)

`tests/unit/tunnel-self-heal.test.ts` drives `runSelfHealCheck()` tick-by-tick: a switch fires only on the **3rd** consecutive success (relay still serving after 2; URL becomes the recovered CF URL; relay handle torn down; credentials rotated); a failure mid-run resets the counter so it takes a fresh run of 3 (no thrashing); the probe goes `inactive` once stopped. **101 tunnel tests pass** (no regression).

## Notes

`runSelfHealCheck()` is public so tests drive the gate deterministically (spec Part 8 — no real multi-minute waits); the production timer calls it on a ~100s cadence. No HTTP route here — per spec Part 8 the HTTP-assertable surface is the `/tunnel` route in PR 9. The forceful SIGINT→SIGKILL relay teardown is the provider's `stop()` contract (localtunnel is in-process per PR 4, so its stop is a best-effort close).

## Evidence / docs

- Spec: `specs/dev-infrastructure/tunnel-failure-resilience.md` Part 5. Upgrade guide: `upgrades/NEXT.md`. Side-effects: `upgrades/side-effects/tunnel-self-heal.md`.

## Rollback

Additive. Revert = drop the self-heal methods/fields/constants + the two wire points (probe start on relay-active entry, probe stop in `stop()`). No config/persisted-state change — the `self-healing` lifecycle state predates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)