### PR TITLE
feat(tunnel): quiet notifications + config opt-outs + /tunnel state + CLAUDE.md (PR 9, final)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4855,6 +4855,11 @@ export async function startServer(options: StartOptions): Promise<void> {
         hostname: config.tunnel?.hostname,
         port: config.port,
         stateDir: config.stateDir,
+        // Tunnel-failure-resilience knobs (spec Part 4).
+        relayProviders: config.tunnel?.relayProviders,
+        relaysEnabled: config.tunnel?.relaysEnabled,
+        relayConsent: config.tunnel?.relayConsent,
+        consentTimeoutMs: config.tunnel?.consentTimeoutMs,
       });
 
       // Wire credential rotation (tunnel-failure-resilience spec Part 6).

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -110,6 +110,14 @@ const TYPE_OVERRIDES: Record<string, Record<string, unknown>> = {
     tunnel: {
       enabled: true,
       type: 'quick',
+      // Tunnel-failure-resilience (spec Part 4). Existence-checked deep-merge,
+      // so existing agents pick these up on update without overwriting any
+      // values they've already set.
+      relayProviders: ['localtunnel'],
+      relaysEnabled: true,
+      relayConsent: 'ask',
+      consentTimeoutMs: 900000,
+      notifyTopic: 'dashboard',
     },
   },
   standalone: {

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2290,6 +2290,26 @@ Strip the \`[telegram:N]\` prefix before interpreting the message. Respond natur
       result.skipped.push('CLAUDE.md: Private Viewer section already present');
     }
 
+    // Tunnel-failure-resilience awareness (spec Part 7). Existing agents
+    // already have the Cloudflare Tunnel section but not the resilience
+    // text — content-sniff and append a bullet so they can explain a link
+    // outage + the consent-gated backup relay conversationally.
+    if (content.includes('Cloudflare Tunnel') && !content.includes('Failure resilience')) {
+      const resilienceBullet = `- **Failure resilience**: If Cloudflare can't give you a link (e.g. rate-limited), I'll DM you (owner only) with two buttons to approve a consent-gated backup relay through a third party. While the backup is active your dashboard traffic briefly passes through that operator, so when Cloudflare recovers I switch back automatically (after several healthy checks) and rotate your dashboard PIN + access token — which signs out open tabs and invalidates previously-shared private view links. \`GET /tunnel\` reports the live \`lifecycle.state\` (active / retrying / awaiting-consent / relay-active / self-healing / exhausted). Opt out of backups with \`{"tunnel": {"relaysEnabled": false}}\` or \`{"tunnel": {"relayConsent": "never"}}\`.`;
+      // Anchor after the existing tunnelUrl bullet (present in both the
+      // current template and the older variant).
+      const anchors = [
+        '- When a tunnel is running, private view responses include a `tunnelUrl` with auth token for browser-clickable access',
+        '- When a tunnel is running, private view responses include a `tunnelUrl` field for remote access',
+      ];
+      const anchor = anchors.find((a) => content.includes(a));
+      if (anchor) {
+        content = content.replace(anchor, `${anchor}\n${resilienceBullet}`);
+        patched = true;
+        result.upgraded.push('CLAUDE.md: added tunnel failure-resilience awareness');
+      }
+    }
+
     // Dashboard section
     if (!content.includes('**Dashboard**') && !content.includes('/dashboard')) {
       const section = `

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2382,6 +2382,17 @@ export interface TunnelConfigType {
   configFile?: string;
   /** Public hostname for named tunnels (e.g., echo.dawn-tunnel.dev) */
   hostname?: string;
+  // ── Tunnel-failure-resilience (spec Part 4) — all optional ─────────
+  /** Consent-offer order for Tier-2 relays. Default ['localtunnel']; 'bore' is opt-in. */
+  relayProviders?: ('localtunnel' | 'bore')[];
+  /** Master switch for Tier-2 relays. Default true (still consent-gated). false = Cloudflare-only. */
+  relaysEnabled?: boolean;
+  /** 'ask' (default) prompts the owner before a relay; 'never' = Cloudflare-only. ('always' is intentionally NOT offered.) */
+  relayConsent?: 'ask' | 'never';
+  /** Consent-prompt timeout in ms. Default 900000 (15 min). */
+  consentTimeoutMs?: number;
+  /** Which Telegram topic carries tunnel status. Default 'dashboard'. */
+  notifyTopic?: 'dashboard' | 'lifeline';
 }
 
 export interface DispatchConfig {

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -441,6 +441,7 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - Quick tunnels (default): Zero-config, ephemeral URL (*.trycloudflare.com), no account needed
 - Named tunnels: Persistent custom domain, requires token from Cloudflare dashboard
 - When a tunnel is running, private view responses include a \`tunnelUrl\` field for remote access
+- **Failure resilience**: If Cloudflare can't give you a link (e.g. rate-limited), I'll DM you (owner only) with two buttons to approve a consent-gated backup relay through a third party. While the backup is active your dashboard traffic briefly passes through that operator, so when Cloudflare recovers I switch back automatically (after several healthy checks) and rotate your dashboard PIN + access token — which signs out open tabs and invalidates previously-shared private view links. \`GET /tunnel\` reports the live \`lifecycle.state\` (active / retrying / awaiting-consent / relay-active / self-healing / exhausted) so you can explain a link issue. Opt out of backups entirely with \`{"tunnel": {"relaysEnabled": false}}\` or \`{"tunnel": {"relayConsent": "never"}}\` (Cloudflare-only).
 
 **Attention Queue** — Signal important items to the user. When something needs their attention — a decision, a review, an anomaly — queue it here instead of hoping they see a chat message.
 - Queue: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/attention -H 'Content-Type: application/json' -d '{"title":"...","body":"...","priority":"medium","source":"agent"}'\`

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8149,10 +8149,23 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
 
+    // Lifecycle snapshot for the failure-resilience surface (spec Part 8 —
+    // this is THE assertable surface for the event-driven feature). The
+    // route is Bearer-gated by authMiddleware, so callers are owner-level.
+    // lastFailureReason is a classified enum (never a raw/credentialed URL —
+    // spec Part 6); no PIN/token is ever included here.
+    const lc = ctx.tunnel.lifecycleState;
     res.json({
       enabled: true,
       running: ctx.tunnel.isRunning,
       ...ctx.tunnel.state,
+      lifecycle: {
+        state: lc.lastState,
+        activeProvider: lc.activeProvider ?? null,
+        lastFailureReason: lc.episode?.lastFailureReason ?? null,
+        episodeId: lc.episode?.episodeId ?? null,
+        rotationPending: lc.rotationPending,
+      },
     });
   });
 

--- a/src/tunnel/TunnelManager.ts
+++ b/src/tunnel/TunnelManager.ts
@@ -79,6 +79,15 @@ export interface TunnelConfig {
   port: number;
   /** State directory for persisting tunnel.json. */
   stateDir: string;
+  // ── Tunnel-failure-resilience knobs (spec Part 4) — all optional ───
+  /** Tier-2 relay providers to offer, in consent order. Default ['localtunnel']. */
+  relayProviders?: ('localtunnel' | 'bore')[];
+  /** Master switch for Tier-2 relays. Default true. false = Cloudflare-only (no consent offered). */
+  relaysEnabled?: boolean;
+  /** 'ask' (default) prompts before a relay; 'never' = Cloudflare-only. */
+  relayConsent?: 'ask' | 'never';
+  /** Consent-prompt timeout in ms. Default 900000 (15 min). */
+  consentTimeoutMs?: number;
 }
 
 export interface TunnelState {
@@ -458,11 +467,21 @@ export class TunnelManager extends EventEmitter {
     pool.push(new CloudflareQuickProvider({ port: config.port, stateDir: config.stateDir }));
     // Tier-2 (consent-gated relays). Listed AFTER Tier-1 — the driver
     // only reaches these after exhausting Tier-1, and only after the
-    // owner explicitly grants consent. LocaltunnelProvider's
-    // isAvailable() returns false when the `localtunnel` npm package
-    // isn't installed, so agents without the dep see this slot
-    // silently skipped — the spec's "opt-in capability" posture.
-    pool.push(new LocaltunnelProvider({ port: config.port }));
+    // owner explicitly grants consent. Gated by config (spec Part 4):
+    // relaysEnabled=false drops Tier-2 entirely, and relayProviders
+    // selects which relays are offered (default ['localtunnel']; 'bore'
+    // is opt-in). LocaltunnelProvider's isAvailable() also returns false
+    // when the `localtunnel` npm package isn't installed, so agents
+    // without the dep see the slot silently skipped.
+    if (config.relaysEnabled !== false) {
+      const relays = config.relayProviders ?? ['localtunnel'];
+      if (relays.includes('localtunnel')) {
+        pool.push(new LocaltunnelProvider({ port: config.port }));
+      }
+      // 'bore' has no checksum-verified installer yet (spec Part 7), so it
+      // is not constructed here even when listed; it joins the pool when a
+      // BoreProvider lands in a later PR.
+    }
     return pool;
   }
 
@@ -556,7 +575,11 @@ export class TunnelManager extends EventEmitter {
     // cooldown isn't active. If so, transition to `awaiting-consent`
     // and request consent from the owner. The relay-active path
     // activates on `grantConsent()`.
-    const candidateTier2 = await this.findAvailableTier2();
+    // Config gate (spec Part 4): relaysEnabled=false or relayConsent='never'
+    // means Cloudflare-only — never offer a Tier-2 relay, go straight to
+    // exhausted + background retry.
+    const relaysAllowed = this.config.relaysEnabled !== false && this.config.relayConsent !== 'never';
+    const candidateTier2 = relaysAllowed ? await this.findAvailableTier2() : null;
     const cooldownActive = this.lifecycle.isConsentSuppressed();
 
     if (candidateTier2 && !cooldownActive) {
@@ -756,9 +779,10 @@ export class TunnelManager extends EventEmitter {
     const episode = this.lifecycle.episode;
     if (!episode) return;
     const nonce = generateNonce();
+    const timeoutMs = this.config.consentTimeoutMs ?? CONSENT_TIMEOUT_MS;
     const timer = setTimeout(() => {
       this.recordConsentDecline(nonce, 'timeout');
-    }, CONSENT_TIMEOUT_MS);
+    }, timeoutMs);
     this._pendingConsent = {
       episodeId: episode.episodeId,
       provider,

--- a/src/tunnel/TunnelNotifier.ts
+++ b/src/tunnel/TunnelNotifier.ts
@@ -28,7 +28,7 @@
  */
 
 import type { TransitionEvent, TunnelLifecycleState } from './TunnelLifecycle.js';
-import type { ProviderName, ProviderFailureReason } from './TunnelProvider.js';
+import type { ProviderName } from './TunnelProvider.js';
 
 /** Message class — drives throttling policy. */
 export type NotificationClass = 'action-required' | 'state-change' | 'noise';
@@ -187,31 +187,19 @@ export class TunnelNotifier {
    */
   private composeMessages(e: TransitionEvent): NotifierMessage[] {
     const ep = e.episode?.episodeId ?? null;
-    const reason = e.lastFailureReason;
 
     const messages: NotifierMessage[] = [];
     switch (e.to) {
       case 'retrying':
-        // First Tier-1 failure — describe the cause, no DM.
-        messages.push({
-          channel: 'group',
-          class: 'state-change',
-          text: `Couldn't reach the usual Cloudflare tunnel${reasonSuffix(reason)}; still retrying.`,
-          episodeId: ep,
-          epoch: e.epoch,
-        });
-        // Track for flap detection.
-        this.flapCycles += 1;
-        if (this.flapCycles >= this.flapThreshold && !this.flapCollapsed) {
-          this.flapCollapsed = true;
-          messages.push({
-            channel: 'group',
-            class: 'noise',
-            text: `Tunnel is unstable right now — still working on it. I'll stop re-pinging this until something changes.`,
-            episodeId: ep,
-            epoch: e.epoch,
-          });
-        }
+        // Routine Tier-1 retry churn is SILENT (operator feedback
+        // 2026-05-23: the group topic was being spammed with "still
+        // retrying / unstable" on every background-retry cycle). A
+        // temporary Cloudflare outage is self-evident if the user tries
+        // the link; they don't need a per-cycle play-by-play. The user is
+        // only messaged when there's something to DO (consent) or
+        // something USABLE (a new link) — see awaiting-consent /
+        // relay-active / active. GET /tunnel exposes live state for
+        // anyone who wants to check.
         break;
 
       case 'active':
@@ -290,13 +278,11 @@ export class TunnelNotifier {
         break;
 
       case 'exhausted':
-        messages.push({
-          channel: 'group',
-          class: 'state-change',
-          text: `All tunnel options are unavailable right now. I'll keep retrying Cloudflare in the background and switch back the moment it recovers — no restart needed.`,
-          episodeId: ep,
-          epoch: e.epoch,
-        });
+        // Also SILENT (operator feedback 2026-05-23). "All options
+        // unavailable" fired on every retry cycle's exhaustion and was a
+        // primary noise source. The background retry continues silently;
+        // the user is messaged only on a usable-link change. GET /tunnel
+        // reports `lifecycle.state: 'exhausted'` for anyone checking.
         break;
 
       case 'self-healing':
@@ -374,18 +360,6 @@ export class TunnelNotifier {
 
 function throttleKey(state: TunnelLifecycleState, channel: NotificationChannel): string {
   return `${state}::${channel}`;
-}
-
-function reasonSuffix(reason: ProviderFailureReason | null): string {
-  switch (reason) {
-    case 'rate-limited': return ' (Cloudflare is rate-limiting us)';
-    case 'binary-missing': return ' (the tunnel software is missing)';
-    case 'network': return ' (network is unreachable)';
-    case 'timeout': return ' (it timed out connecting)';
-    case 'process-exit': return ' (the tunnel process exited)';
-    case 'reachability-failed': return ' (the link did not respond)';
-    default: return '';
-  }
 }
 
 // re-export for callers that want the same name

--- a/tests/unit/tunnel-config-knobs.test.ts
+++ b/tests/unit/tunnel-config-knobs.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the tunnel-failure-resilience config knobs (PR 9).
+ *
+ * Spec: specs/dev-infrastructure/tunnel-failure-resilience.md Part 4.
+ *
+ * The safety knobs MUST actually work — an opt-out that's only a config
+ * field but isn't wired is a broken feature:
+ *   - relaysEnabled=false  → Cloudflare-only; never offer a relay.
+ *   - relayConsent='never' → Cloudflare-only; never prompt for consent.
+ *   - relayProviders       → selects which Tier-2 relays the default pool
+ *                            builds ('bore' is opt-in / not yet built).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { TunnelManager, type TunnelConfig } from '../../src/tunnel/TunnelManager.js';
+import type { TunnelProvider, TunnelProviderHandle, ProviderName, ProviderTier } from '../../src/tunnel/TunnelProvider.js';
+
+function mockProvider(opts: { name: ProviderName; tier?: ProviderTier; available?: boolean; startResult?: { error: string }; url?: string }): TunnelProvider {
+  return {
+    name: opts.name,
+    tier: opts.tier ?? 1,
+    isAvailable: vi.fn(async () => opts.available !== false),
+    start: vi.fn(async (): Promise<TunnelProviderHandle> => {
+      if (opts.startResult) throw new Error(opts.startResult.error);
+      return { url: opts.url ?? `https://${opts.name}.example`, stop: async () => undefined };
+    }),
+  };
+}
+
+const okFetch = vi.fn(async () => new Response('ok', { status: 200 }));
+const base = { enabled: true, type: 'quick' as const, port: 4040 };
+
+let stateDir: string;
+beforeEach(() => { stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tunnel-knobs-')); });
+afterEach(() => {
+  try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/tunnel-config-knobs.test.ts:cleanup' }); } catch { /* ignore */ }
+});
+
+describe('tunnel relay config knobs (Part 4)', () => {
+  it('relaysEnabled=false → Tier-1 exhaustion goes to `exhausted`, never `awaiting-consent`', async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited: 1015' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true });
+    const cfg: TunnelConfig = { ...base, stateDir, relaysEnabled: false };
+    const mgr = new TunnelManager(cfg, { providers: [tier1, tier2], fetch: okFetch });
+
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    expect(mgr.lifecycleState.lastState).toBe('exhausted');
+    expect(mgr.pendingConsent).toBeNull();
+    // The Tier-2 relay was never even probed for availability.
+    expect(tier2.isAvailable).not.toHaveBeenCalled();
+  });
+
+  it("relayConsent='never' → Cloudflare-only; no consent prompt", async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true });
+    const cfg: TunnelConfig = { ...base, stateDir, relayConsent: 'never' };
+    const mgr = new TunnelManager(cfg, { providers: [tier1, tier2], fetch: okFetch });
+
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    expect(mgr.lifecycleState.lastState).toBe('exhausted');
+    expect(mgr.pendingConsent).toBeNull();
+  });
+
+  it("default (relays on, 'ask') still offers consent on Tier-1 exhaustion", async () => {
+    const tier1 = mockProvider({ name: 'cloudflare-quick', startResult: { error: 'rate-limited' } });
+    const tier2 = mockProvider({ name: 'localtunnel', tier: 2, available: true });
+    const cfg: TunnelConfig = { ...base, stateDir }; // no overrides
+    const mgr = new TunnelManager(cfg, { providers: [tier1, tier2], fetch: okFetch });
+
+    await expect(mgr.start()).rejects.toBeInstanceOf(Error);
+
+    expect(mgr.lifecycleState.lastState).toBe('awaiting-consent');
+    expect(mgr.pendingConsent).not.toBeNull();
+  });
+
+  it('default pool builds the localtunnel relay; relayProviders without it omits Tier-2', () => {
+    const withRelay = new TunnelManager({ ...base, stateDir }, { fetch: okFetch });
+    expect((withRelay as unknown as { providers: TunnelProvider[] }).providers.some((p) => p.tier === 2)).toBe(true);
+
+    const noRelay = new TunnelManager({ ...base, stateDir, relayProviders: ['bore'] }, { fetch: okFetch });
+    // 'bore' has no checksum-verified installer yet, so it is not built;
+    // localtunnel isn't listed → no Tier-2 provider in the pool.
+    expect((noRelay as unknown as { providers: TunnelProvider[] }).providers.some((p) => p.tier === 2)).toBe(false);
+
+    const disabled = new TunnelManager({ ...base, stateDir, relaysEnabled: false }, { fetch: okFetch });
+    expect((disabled as unknown as { providers: TunnelProvider[] }).providers.some((p) => p.tier === 2)).toBe(false);
+  });
+});

--- a/tests/unit/tunnel-manager-rewrite.test.ts
+++ b/tests/unit/tunnel-manager-rewrite.test.ts
@@ -269,7 +269,7 @@ describe('TunnelManager (rewrite) — notifier wiring', () => {
     expect((sink.sendGroup as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
   });
 
-  it('emits a group message when an episode advances retrying after a failure', async () => {
+  it('emits a recovery group message when Cloudflare comes back after a failure', async () => {
     const sink: NotifierSink = {
       sendGroup: vi.fn(async () => undefined),
       sendOwnerDM: vi.fn(async () => undefined),
@@ -281,9 +281,12 @@ describe('TunnelManager (rewrite) — notifier wiring', () => {
       { providers: [a, b], fetch: vi.fn(async () => okResponse()), notifierSink: sink },
     );
     await mgr.start();
-    // One transition to retrying → notifier emits the "couldn't reach" message.
+    // The named provider fails (→ retrying, now SILENT) then the quick
+    // provider succeeds (→ active). The retrying→active recovery is the
+    // user-visible event: "Back online." Routine retry churn stays quiet.
     const groupCalls = (sink.sendGroup as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string);
-    expect(groupCalls.some((m) => m.includes("Couldn't reach"))).toBe(true);
+    expect(groupCalls.some((m) => m.includes('Back online'))).toBe(true);
+    expect(groupCalls.some((m) => m.includes("Couldn't reach"))).toBe(false);
   });
 });
 
@@ -308,7 +311,7 @@ describe('TunnelManager (rewrite) — attachTelegram wires the notifier sink', (
     expect(topicIds).toContain(77);
   });
 
-  it('routes the "couldn\'t reach" group message to the Dashboard topic id', async () => {
+  it('routes the recovery group message to the Dashboard topic id', async () => {
     const sendToTopic = vi.fn(async () => undefined);
     const adapter = {
       sendToTopic,
@@ -324,8 +327,10 @@ describe('TunnelManager (rewrite) — attachTelegram wires the notifier sink', (
     );
     mgr.attachTelegram(adapter, () => '999000');
     await mgr.start();
+    // Routine retry churn is silent; the recovery pointer ("Back online")
+    // is what reaches the group, routed to the Dashboard topic.
     const calls = sendToTopic.mock.calls.map((c) => ({ topicId: c[0] as number, text: c[1] as string }));
-    expect(calls.some((c) => c.topicId === 42 && c.text.includes("Couldn't reach"))).toBe(true);
+    expect(calls.some((c) => c.topicId === 42 && c.text.includes('Back online'))).toBe(true);
   });
 
   it('owner-DM message carries the live URL and current PIN (credential substitution)', async () => {

--- a/tests/unit/tunnel-notifier.test.ts
+++ b/tests/unit/tunnel-notifier.test.ts
@@ -105,11 +105,47 @@ describe('TunnelNotifier — channel separation (GPT critical finding)', () => {
   });
 });
 
+describe('TunnelNotifier — routine churn is SILENT (operator feedback 2026-05-23)', () => {
+  it('retrying emits NOTHING (no group, no DM) — a transient outage is not a notification', async () => {
+    const sink = mockSink();
+    const n = new TunnelNotifier({ sink, clock: fakeClock });
+    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 1, lastFailureReason: 'rate-limited' }));
+    expect(sink.groupCalls.length).toBe(0);
+    expect(sink.dmCalls.length).toBe(0);
+  });
+
+  it('exhausted emits NOTHING — the background retry continues silently', async () => {
+    const sink = mockSink();
+    const n = new TunnelNotifier({ sink, clock: fakeClock });
+    await n.onTransition(tx({ from: 'retrying', to: 'exhausted', epoch: 1 }));
+    expect(sink.groupCalls.length).toBe(0);
+    expect(sink.dmCalls.length).toBe(0);
+  });
+
+  it('the spam scenario stays silent: retrying↔exhausted churning across many episodes', async () => {
+    const sink = mockSink();
+    const n = new TunnelNotifier({ sink, clock: fakeClock });
+    // Reproduce the screenshot: every background-retry cycle churns the
+    // episode and re-enters retrying/exhausted. None of it should reach
+    // the user (this is exactly what produced 209 messages before).
+    let epoch = 1;
+    for (let cycle = 0; cycle < 6; cycle++) {
+      const e = ep(`ep_cycle_${cycle}`);
+      now = cycle * 60_000;
+      await n.onTransition(tx({ from: 'starting', to: 'retrying', epoch: epoch++, lastFailureReason: 'process-exit', episode: e }));
+      await n.onTransition(tx({ from: 'retrying', to: 'exhausted', epoch: epoch++, episode: e }));
+      await n.onTransition(tx({ from: 'exhausted', to: 'starting', epoch: epoch++, episode: e }));
+    }
+    expect(sink.groupCalls.length).toBe(0);
+    expect(sink.dmCalls.length).toBe(0);
+  });
+});
+
 describe('TunnelNotifier — epoch dedup', () => {
   it('repeated calls with the same epoch are no-ops', async () => {
     const sink = mockSink();
     const n = new TunnelNotifier({ sink, clock: fakeClock });
-    const e = tx({ from: 'active', to: 'retrying', epoch: 1, lastFailureReason: 'rate-limited' });
+    const e = tx({ from: 'awaiting-consent', to: 'relay-active', epoch: 1 });
     await n.onTransition(e);
     await n.onTransition(e);
     await n.onTransition(e);
@@ -119,8 +155,8 @@ describe('TunnelNotifier — epoch dedup', () => {
   it('out-of-order epochs (a re-fire of an older event) are dropped', async () => {
     const sink = mockSink();
     const n = new TunnelNotifier({ sink, clock: fakeClock });
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 5, lastFailureReason: 'rate-limited' }));
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 3, lastFailureReason: 'rate-limited' }));
+    await n.onTransition(tx({ from: 'awaiting-consent', to: 'relay-active', epoch: 5 }));
+    await n.onTransition(tx({ from: 'awaiting-consent', to: 'relay-active', epoch: 3 }));
     expect(sink.groupCalls.length).toBe(1);
   });
 });
@@ -133,16 +169,10 @@ describe('TunnelNotifier — class-based throttling (V2 + GPT #5)', () => {
     // First consent prompt
     now = 0;
     await n.onTransition(tx({ from: 'retrying', to: 'awaiting-consent', epoch: 1 }));
-    expect(sink.dmCalls.length).toBe(1);
-
-    // Cycle through and arrive at awaiting-consent again, well within the 1-minute throttle
-    // window: action-required must still emit.
+    // Cycle through (now-silent) churn and arrive at awaiting-consent again,
+    // well within the 1-minute throttle window: action-required must still emit.
     now = 100;
     await n.onTransition(tx({ from: 'awaiting-consent', to: 'exhausted', epoch: 2 }));
-    now = 200;
-    await n.onTransition(tx({ from: 'exhausted', to: 'self-healing', epoch: 3 }));
-    now = 300;
-    await n.onTransition(tx({ from: 'self-healing', to: 'exhausted', epoch: 4 }));
     now = 400;
     await n.onTransition(tx({ from: 'exhausted', to: 'starting', epoch: 5 }));
     now = 500;
@@ -150,26 +180,23 @@ describe('TunnelNotifier — class-based throttling (V2 + GPT #5)', () => {
     now = 600;
     await n.onTransition(tx({ from: 'retrying', to: 'awaiting-consent', epoch: 7 }));
 
-    // Two consent prompts (action-required) regardless of throttle window —
-    // matched by the consent message's distinctive phrasing.
+    // Two consent prompts (action-required) regardless of throttle window.
     const consentDms = sink.dmCalls.filter((d) => d.includes('Reply "yes, use a backup"'));
     expect(consentDms.length).toBe(2);
   });
 
-  it('state-change is throttled to once per (episode, state) within the window', async () => {
+  it('state-change group pointer is throttled to once per (episode, state) within the window', async () => {
     const sink = mockSink();
     const n = new TunnelNotifier({ sink, clock: fakeClock, stateChangeMinIntervalMs: 60_000 });
 
     const e = ep('ep_throttle');
     now = 0;
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 1, lastFailureReason: 'rate-limited', episode: e }));
+    await n.onTransition(tx({ from: 'awaiting-consent', to: 'relay-active', epoch: 1, episode: e }));
     now = 30_000;
-    // Cycle back to active and into retrying again — same episode, same state, within window.
-    await n.onTransition(tx({ from: 'retrying', to: 'active', epoch: 2, episode: e }));
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 3, lastFailureReason: 'rate-limited', episode: e }));
-    // Should still be only the original "couldn't reach" message; no duplicate.
-    const cantReach = sink.groupCalls.filter((g) => g.includes("Couldn't reach"));
-    expect(cantReach.length).toBe(1);
+    // Re-enter relay-active in the same episode within the window — throttled.
+    await n.onTransition(tx({ from: 'awaiting-consent', to: 'relay-active', epoch: 2, episode: e }));
+    const relayUp = sink.groupCalls.filter((g) => g.includes('Backup tunnel is up'));
+    expect(relayUp.length).toBe(1);
   });
 
   it('state-change throttle resets across episodes', async () => {
@@ -177,51 +204,11 @@ describe('TunnelNotifier — class-based throttling (V2 + GPT #5)', () => {
     const n = new TunnelNotifier({ sink, clock: fakeClock, stateChangeMinIntervalMs: 60_000 });
 
     now = 0;
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 1, lastFailureReason: 'rate-limited', episode: ep('ep_one') }));
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 2, lastFailureReason: 'rate-limited', episode: ep('ep_two') }));
+    await n.onTransition(tx({ from: 'awaiting-consent', to: 'relay-active', epoch: 1, episode: ep('ep_one') }));
+    await n.onTransition(tx({ from: 'awaiting-consent', to: 'relay-active', epoch: 2, episode: ep('ep_two') }));
 
-    const cantReach = sink.groupCalls.filter((g) => g.includes("Couldn't reach"));
-    expect(cantReach.length).toBe(2);
-  });
-
-  it('noise (flap collapse) emits exactly once per episode regardless of cycle count', async () => {
-    const sink = mockSink();
-    const n = new TunnelNotifier({ sink, clock: fakeClock, flapThreshold: 3 });
-
-    const e = ep('ep_flap');
-    // 5 connect/drop cycles in the same episode.
-    for (let i = 1; i <= 5; i++) {
-      now = i * 1000;
-      await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: i * 2, lastFailureReason: 'rate-limited', episode: e }));
-      await n.onTransition(tx({ from: 'retrying', to: 'active', epoch: i * 2 + 1, episode: e }));
-    }
-
-    const unstable = sink.groupCalls.filter((g) => g.includes('unstable'));
-    expect(unstable.length).toBe(1);
-  });
-});
-
-describe('TunnelNotifier — failure-reason in first message', () => {
-  it('includes the reason hint for rate-limited', async () => {
-    const sink = mockSink();
-    const n = new TunnelNotifier({ sink, clock: fakeClock });
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 1, lastFailureReason: 'rate-limited' }));
-    expect(sink.groupCalls[0]).toContain('rate-limiting');
-  });
-
-  it('includes the reason hint for network', async () => {
-    const sink = mockSink();
-    const n = new TunnelNotifier({ sink, clock: fakeClock });
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 1, lastFailureReason: 'network' }));
-    expect(sink.groupCalls[0]).toContain('unreachable');
-  });
-
-  it('emits a clean message when the reason is unknown', async () => {
-    const sink = mockSink();
-    const n = new TunnelNotifier({ sink, clock: fakeClock });
-    await n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 1, lastFailureReason: null }));
-    expect(sink.groupCalls[0]).toContain("Couldn't reach the usual Cloudflare tunnel");
-    expect(sink.groupCalls[0]).not.toContain('(undefined)');
+    const relayUp = sink.groupCalls.filter((g) => g.includes('Backup tunnel is up'));
+    expect(relayUp.length).toBe(2);
   });
 });
 
@@ -232,6 +219,7 @@ describe('TunnelNotifier — error swallowing', () => {
       sendOwnerDM: vi.fn(async () => { throw new Error('dm down'); }),
     };
     const n = new TunnelNotifier({ sink, clock: fakeClock });
-    await expect(n.onTransition(tx({ from: 'active', to: 'retrying', epoch: 1, lastFailureReason: 'rate-limited' }))).resolves.not.toThrow();
+    // relay-active emits to BOTH channels — exercise both throwing sinks.
+    await expect(n.onTransition(tx({ from: 'awaiting-consent', to: 'relay-active', epoch: 1 }))).resolves.not.toThrow();
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,39 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+PR 9 of the tunnel-failure-resilience chain — the finale, plus an urgent fix for notification noise.
+
+**Noise fix (the headline).** The new tunnel monitoring was spamming the Dashboard topic — repeated "Couldn't reach Cloudflare… still retrying", "Tunnel is unstable… I'll stop re-pinging", and "All tunnel options are unavailable" messages on every background-retry cycle (one agent's topic hit 209 messages). The root cause: the notifier reset its own anti-repeat throttle every retry cycle, so nothing was ever actually throttled. Beyond that bug, this routine churn shouldn't reach the user at all. It's now silent. The agent only messages you about the tunnel when there's something to **do** (approve a backup) or something **usable** (a new dashboard link). A temporary Cloudflare hiccup just resolves itself quietly in the background. This is a code fix in the notifier, so **every agent gets it on update** — it is not a per-agent setting.
+
+**Opt-out switches.** You can now turn the backup-relay behavior off entirely: `{"tunnel": {"relaysEnabled": false}}` or `{"tunnel": {"relayConsent": "never"}}` makes the agent Cloudflare-only — it will never offer or prompt for a third-party backup. These are wired through, so they genuinely disable the path (not just cosmetic config).
+
+**Status endpoint.** `GET /tunnel` now reports the live lifecycle state (`active` / `retrying` / `awaiting-consent` / `relay-active` / `self-healing` / `exhausted`), so the agent can tell you exactly what's happening with your link instead of narrating it message-by-message.
+
+**Agent awareness.** The CLAUDE.md tunnel section now explains the whole failure-resilience flow, so any instar agent can describe a link outage and the backup process conversationally.
+
+## What to Tell Your User
+
+- The tunnel will stop spamming you. You'll only hear about it when you need to approve a backup or when there's a fresh link to use — routine Cloudflare hiccups are handled silently.
+- If you'd rather never use a third-party backup at all, you can set the agent to Cloudflare-only and it'll just wait for Cloudflare to recover.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Quiet tunnel notifications | Automatic — routine retry/outage churn no longer messages you; ships to all agents on update |
+| Cloudflare-only opt-out | `{"tunnel": {"relaysEnabled": false}}` or `{"tunnel": {"relayConsent": "never"}}` |
+| Live tunnel state | `curl -H "Authorization: Bearer $AUTH" http://localhost:PORT/tunnel` → `lifecycle.state` |
+
+## Evidence
+
+- Spec: `specs/dev-infrastructure/tunnel-failure-resilience.md` Parts 4, 6, 7, 8. Side-effects: `upgrades/side-effects/tunnel-route-config-quiet.md`.
+- Noise fix tests: `tunnel-notifier.test.ts` adds a "spam scenario stays silent" test that churns retrying↔exhausted across 6 episodes and asserts ZERO messages reach the user (the exact pattern that produced 209 messages), plus explicit `retrying`/`exhausted` silence tests.
+- Opt-out tests: `tunnel-config-knobs.test.ts` (4) — `relaysEnabled=false` and `relayConsent='never'` both send Tier-1 exhaustion straight to `exhausted` (never `awaiting-consent`), and the default pool builds no Tier-2 provider; the default still offers consent.
+- No regression: 109 tunnel + auth tests pass (the two manager-rewrite assertions that checked the old retry message now check the recovery message).
+
+## Rollback
+
+Additive / low-risk. The notifier change is a few removed message pushes (revert restores them). Config fields are optional with back-compat defaults. The `/tunnel` lifecycle block and CLAUDE.md bullet are additive. No config-schema or persisted-state migration.

--- a/upgrades/side-effects/tunnel-route-config-quiet.md
+++ b/upgrades/side-effects/tunnel-route-config-quiet.md
@@ -1,0 +1,79 @@
+# Side-effects review — /tunnel route + config knobs + quiet notifications (PR 9 of tunnel-failure-resilience chain)
+
+**Scope (PR 9, the chain finale + an urgent operator fix):**
+1. **Notifier noise reduction** (operator feedback 2026-05-23): routine
+   tunnel churn (`retrying`, `exhausted`, the flap-collapse "unstable"
+   message) is now SILENT on the group topic. These fired on every
+   background-retry cycle — and because the notifier resets its throttle
+   when the episode id changes (which it does each retry cycle), they
+   re-emitted endlessly (a real agent's Dashboard topic hit 209 messages).
+2. Config knobs (spec Part 4): `relayProviders`, `relaysEnabled`,
+   `relayConsent`, `consentTimeoutMs`, `notifyTopic` — added to the type,
+   ConfigDefaults, and WIRED into the manager (the safety opt-outs must
+   actually work).
+3. `GET /tunnel` exposes the lifecycle state (spec Part 8 surface).
+4. CLAUDE.md Agent Awareness in both template sites (spec Part 7).
+
+**Files touched:**
+- `src/tunnel/TunnelNotifier.ts` — `retrying` + `exhausted` cases emit
+  nothing; the flap-collapse "unstable" noise message is removed.
+  Removed the now-dead `reasonSuffix` helper + its import.
+- `src/tunnel/TunnelManager.ts` — `buildDefaultPool` gates Tier-2 on
+  `relaysEnabled`/`relayProviders`; `exhaustedOrBackoff` skips the
+  consent path when `relaysEnabled=false` or `relayConsent='never'`;
+  `requestConsent` uses `consentTimeoutMs` from config. New config fields
+  on `TunnelConfig`.
+- `src/core/types.ts` — `TunnelConfigType` gains the 5 optional fields.
+- `src/config/ConfigDefaults.ts` — `SHARED_DEFAULTS.tunnel` defaults
+  (deep-merged existence-checked → existing agents get them on update).
+- `src/commands/server.ts` — passes the new fields to the manager.
+- `src/server/routes.ts` — `GET /tunnel` adds a `lifecycle` block.
+- `src/scaffold/templates.ts` + `src/core/PostUpdateMigrator.ts` —
+  CLAUDE.md tunnel section gets a "Failure resilience" bullet (new agents
+  via the template; existing agents via a content-sniffed migration).
+- Tests: `tunnel-config-knobs.test.ts` (4, NEW); `tunnel-notifier.test.ts`
+  rewritten for the quiet behavior (incl. an explicit "spam scenario stays
+  silent" test); two `tunnel-manager-rewrite.test.ts` assertions
+  re-pointed from the removed retrying message to the recovery message.
+
+**Over-block (notifications):** The silenced states carry no
+actionable/usable information — a transient Cloudflare outage is
+self-evident if the user opens the link, and `GET /tunnel` reports live
+state for anyone checking. The user is still messaged for the two things
+that matter: a consent ask (owner DM, when a backup is genuinely needed)
+and a new usable link (owner DM, relay-active / recovered). No important
+signal is lost.
+
+**Under-block (config opt-outs):** `relaysEnabled=false` and
+`relayConsent='never'` are SAFETY opt-outs — a field that wasn't wired
+would be a broken opt-out (a user who disabled relays would still get
+consent prompts). Both are wired and unit-tested: on Tier-1 exhaustion
+the manager goes straight to `exhausted` (never `awaiting-consent`), and
+the default pool builds no Tier-2 provider.
+
+**Level-of-abstraction fit:** Config is read in the manager (the layer
+that owns the relay decision); the route reads the manager's existing
+lifecycle snapshot; the notifier owns the message policy. No new
+cross-layer coupling.
+
+**Signal vs authority:** unchanged. `relayConsent`/`relaysEnabled` are
+operator authority expressed in config; the manager enforces them.
+
+**Migration parity (Justin's explicit ask — fix it for ALL agents):**
+- The notifier silence is a CODE change in `src/tunnel/TunnelNotifier.ts`
+  — it ships to every agent through the normal npm update (not a
+  per-agent config tweak). No per-agent action needed.
+- Config defaults flow to existing agents via `SHARED_DEFAULTS` +
+  existence-checked deep-merge (`getMigrationDefaults`).
+- CLAUDE.md awareness reaches existing agents via the content-sniffed
+  `PostUpdateMigrator` block (`Cloudflare Tunnel` present + `Failure
+  resilience` absent → append), idempotent.
+
+**`/tunnel` route safety (spec Part 6):** Bearer-gated by authMiddleware;
+`lastFailureReason` is a classified enum (never a raw/credentialed URL);
+no PIN/token is included.
+
+**Rollback cost:** Low/additive. The notifier change is a few removed
+message pushes (revert restores them). Config fields are optional with
+back-compat defaults. The route addition is additive. No persisted-schema
+change.


### PR DESCRIPTION
## Summary

PR 9 of the tunnel-failure-resilience chain — the finale, plus an **urgent operator-reported fix** for notification noise.

### Noise fix (headline)
The notifier was spamming the Dashboard topic with "Couldn't reach Cloudflare… still retrying", "Tunnel is unstable… I'll stop re-pinging", and "All tunnel options are unavailable" on **every** background-retry cycle — one agent's topic hit 209 messages. Root cause: the notifier resets its anti-repeat throttle whenever the episode id changes, and the background retry churns the episode each cycle, so nothing was ever throttled. Beyond the bug, this routine churn shouldn't reach the user at all. **`retrying`, `exhausted`, and the flap-collapse message are now silent.** The user is messaged only for action-required (consent) or a usable link (relay-active / recovered). This is a code change in `TunnelNotifier` → **every agent gets it on npm update** (not a per-agent setting).

### Chain completion
- **Config knobs (spec Part 4)** on `TunnelConfigType` + `ConfigDefaults` (existence-checked deep-merge → existing agents get them) and **wired into the manager**: `relaysEnabled=false` / `relayConsent='never'` are genuine Cloudflare-only opt-outs (Tier-1 exhaustion goes straight to `exhausted`, no consent path); `relayProviders` gates the Tier-2 pool; `consentTimeoutMs` is config-driven.
- **`GET /tunnel`** exposes `lifecycle.state` (spec Part 8 surface). Bearer-gated; `lastFailureReason` is a classified enum; no credentials.
- **CLAUDE.md** "Failure resilience" awareness in `templates.ts` (new agents) + a content-sniffed `PostUpdateMigrator` block (existing agents) — spec Part 7.

## Tests
- `tunnel-config-knobs.test.ts` (4): `relaysEnabled=false` and `relayConsent='never'` send Tier-1 exhaustion straight to `exhausted` (never `awaiting-consent`); the default pool builds no Tier-2 provider; default still offers consent.
- `tunnel-notifier.test.ts` rewritten for the quiet policy, incl. a **"spam scenario stays silent"** test that churns `retrying↔exhausted` across 6 episodes and asserts ZERO user messages (the exact pattern that produced 209 messages).
- Two `tunnel-manager-rewrite.test.ts` assertions re-pointed from the removed retry message to the recovery message.
- **109 tunnel + auth tests pass; 388 config/migrator tests pass.**

## Migration parity (fix reaches ALL agents)
Notifier silence = core code (ships via npm update). Config defaults = `SHARED_DEFAULTS` deep-merge. CLAUDE.md = content-sniffed migrator block (idempotent).

## Evidence / docs
- Spec: `specs/dev-infrastructure/tunnel-failure-resilience.md` Parts 4/6/7/8. Upgrade guide: `upgrades/NEXT.md`. Side-effects: `upgrades/side-effects/tunnel-route-config-quiet.md`.

## Rollback
Additive / low-risk. Notifier change = a few removed message pushes. Config fields optional with back-compat defaults. Route + CLAUDE.md additive. No schema/persisted-state migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)