### PR TITLE
fix(autonomous): topic-keyed session identity so restarts don't silently kill autonomy

### DIFF
--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -4,53 +4,62 @@
 # Prevents session exit when autonomous mode is active.
 # Feeds the goal and task list back to continue working.
 #
-# SESSION-SCOPED: Only blocks the session that activated autonomous mode.
-# Other sessions on the same machine pass through unaffected.
+# TOPIC-KEYED OWNERSHIP (primary): the autonomous job is identified by the
+# TOPIC it serves, not by the Claude session UUID. The topic is a stable
+# "street address" — when a session hits the memory limit and restarts, its
+# UUID rotates (a new badge) but instar respawns it into the SAME tmux session
+# name, and the topic-session registry still maps that name to the same topic.
+# So whoever is running in the topic's session is recognized as continuing the
+# job, restart or no restart. This fixes the silent-failure bug where a restart
+# rotated the UUID, mismatched the state file, and let autonomy die unnoticed.
 #
-# RESPECTS:
-# - Session isolation (only blocks the autonomous session)
-# - Emergency stop signals (user says "stop everything")
-# - Duration expiry
-# - Genuine completion (all tasks done, promise output)
+# LIVENESS-GATED BACKSTOP (rare): when topic resolution is unavailable (no tmux,
+# or the topic isn't in the registry) the hook falls back to session-id matching.
+# A session-id mismatch is then gated by a liveness check on the recorded owner
+# (is its transcript still growing?) — a dead owner is adopted, a live one is
+# left alone. This is the demoted role of the old liveness idea: a thin edge
+# guard, not the main mechanism.
+#
+# RECOVERY NOTE: on an actual restart-and-resume (topic verified, but the
+# session UUID changed) the hook emits ONE user-facing one-line note and an
+# audit record, then records the new UUID so the note never repeats.
+#
+# RESPECTS: emergency stop, duration expiry, genuine completion (promise).
 
-set -euo pipefail
+set -uo pipefail   # NOTE: -e intentionally omitted; field lookups for optional
+                   # frontmatter keys are expected to "fail" (grep finds nothing)
+                   # and must not abort the hook. Each critical step guards itself.
 
 # Read hook input from stdin
 HOOK_INPUT=$(cat)
 
-# Check if autonomous mode is active
 STATE_FILE=".instar/autonomous-state.local.md"
+REGISTRY_FILE=".instar/topic-session-registry.json"
+RECOVERY_AUDIT=".instar/autonomous-recovery.jsonl"
+LIVENESS_SECS="${INSTAR_AUTONOMOUS_LIVENESS_SECS:-120}"
 
 if [[ ! -f "$STATE_FILE" ]]; then
   # No active autonomous session — allow exit
   exit 0
 fi
 
-# Parse YAML frontmatter
+# Parse YAML frontmatter (between the first two --- lines)
 FRONTMATTER=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$STATE_FILE")
 
-ACTIVE=$(echo "$FRONTMATTER" | grep '^active:' | sed 's/active: *//')
+# Safe frontmatter field reader — never trips pipefail when a key is absent.
+fm_get() {
+  local key="$1"
+  printf '%s\n' "$FRONTMATTER" | grep "^${key}:" | head -1 | sed "s/^${key}: *//" | tr -d '"' || true
+}
+
+ACTIVE=$(fm_get active)
 if [[ "$ACTIVE" != "true" ]]; then
   exit 0
 fi
 
-# SESSION ISOLATION: Only block the session that started autonomous mode.
-# Uses self-bootstrapping: if no session_id in state file yet, the FIRST
-# session to trigger the hook claims it. All other sessions see a mismatch.
-STATE_SESSION=$(echo "$FRONTMATTER" | grep '^session_id:' | sed 's/^session_id: *//' | tr -d '"' || true)
-
-# VALIDATE: If state has a session_id but it's not a valid UUID, treat as empty.
-# Claude sometimes writes a custom string instead of the real $CLAUDE_CODE_SESSION_ID.
-# Non-UUID values will never match the real hook session_id, causing the hook to
-# fail-open and allow premature exit. By clearing invalid values, we fall through
-# to self-bootstrap, which captures the REAL session_id from the first hook call.
-UUID_REGEX='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-if [[ -n "$STATE_SESSION" ]] && ! [[ "$STATE_SESSION" =~ $UUID_REGEX ]]; then
-  echo "[autonomous] Invalid session_id in state file (not UUID): '$STATE_SESSION' — falling back to self-bootstrap" >&2
-  STATE_SESSION=""
-fi
-
-HOOK_SESSION=$(echo "$HOOK_INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")
+# ── Inputs from the hook ──────────────────────────────────────────────
+HOOK_SESSION=$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")
+TRANSCRIPT_PATH=$(printf '%s' "$HOOK_INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")
 
 # If hook has no session_id → fail OPEN (unknown context, don't trap)
 if [[ -z "$HOOK_SESSION" ]]; then
@@ -58,113 +67,209 @@ if [[ -z "$HOOK_SESSION" ]]; then
   exit 0
 fi
 
-# SELF-BOOTSTRAP: If state has no session_id yet, claim it from this hook call.
-# The first session to fire the hook becomes the autonomous session.
-if [[ -z "$STATE_SESSION" ]]; then
-  # Atomic claim: write session_id to state file
-  TEMP_FILE="${STATE_FILE}.claim.$$"
-  sed "s/^session_id:.*/session_id: \"${HOOK_SESSION}\"/" "$STATE_FILE" > "$TEMP_FILE"
-  mv "$TEMP_FILE" "$STATE_FILE"
-  STATE_SESSION="$HOOK_SESSION"
-  echo "[autonomous] Session $HOOK_SESSION claimed autonomous mode" >&2
+# ── State fields ──────────────────────────────────────────────────────
+REPORT_TOPIC=$(fm_get report_topic)
+STATE_SESSION=$(fm_get session_id)
+ITERATION=$(fm_get iteration)
+DURATION_SECONDS=$(fm_get duration_seconds)
+STARTED_AT=$(fm_get started_at)
+COMPLETION_PROMISE=$(fm_get completion_promise)
+
+# Validate recorded session_id is a real UUID. Claude sometimes writes a custom
+# string instead of $CLAUDE_CODE_SESSION_ID; non-UUID values are treated as
+# empty so the session-match backstop self-bootstraps from the real UUID.
+UUID_REGEX='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+if [[ -n "$STATE_SESSION" ]] && ! [[ "$STATE_SESSION" =~ $UUID_REGEX ]]; then
+  echo "[autonomous] Invalid session_id in state file (not UUID): '$STATE_SESSION' — clearing" >&2
+  STATE_SESSION=""
 fi
 
-# Different session → allow exit (fail-open for non-autonomous sessions)
-if [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
+# ── Resolve MY topic (the stable address) ─────────────────────────────
+# Test/override seam: INSTAR_HOOK_TMUX_SESSION (if the var is set at all, even
+# empty, it wins — empty means "no tmux"). INSTAR_HOOK_NO_TMUX=1 forces empty.
+resolve_my_tmux() {
+  if [[ "${INSTAR_HOOK_NO_TMUX:-}" == "1" ]]; then
+    echo ""
+    return
+  fi
+  if [[ -n "${INSTAR_HOOK_TMUX_SESSION+x}" ]]; then
+    echo "${INSTAR_HOOK_TMUX_SESSION}"
+    return
+  fi
+  tmux display-message -p '#S' 2>/dev/null || echo ""
+}
+MY_TMUX=$(resolve_my_tmux)
+
+# Reverse-lookup: which tmux session owns REPORT_TOPIC per the registry?
+OWNER_TMUX=""
+if [[ -n "$REPORT_TOPIC" ]] && [[ -f "$REGISTRY_FILE" ]]; then
+  OWNER_TMUX=$(REPORT_TOPIC="$REPORT_TOPIC" python3 -c "
+import json, os
+try:
+    reg = json.load(open('$REGISTRY_FILE'))
+    print((reg.get('topicToSession') or {}).get(os.environ['REPORT_TOPIC'], ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+fi
+
+# ── Ownership decision ────────────────────────────────────────────────
+# OWNER=true means: this session IS the autonomous worker; block its exit.
+# OWNER_METHOD records how we decided (topic | session | bootstrap | adopt-dead).
+OWNER="false"
+OWNER_METHOD=""
+RESTART_DETECTED="false"
+
+if [[ -n "$MY_TMUX" ]] && [[ -n "$OWNER_TMUX" ]]; then
+  # Topic resolution is conclusive.
+  if [[ "$MY_TMUX" == "$OWNER_TMUX" ]]; then
+    OWNER="true"; OWNER_METHOD="topic"
+    # Restart? Recorded UUID is a real UUID but differs from the live one.
+    if [[ -n "$STATE_SESSION" ]] && [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
+      RESTART_DETECTED="true"
+    fi
+  else
+    # Registry says topic T is served by a different session → not me.
+    exit 0
+  fi
+else
+  # ── Backstop: topic unresolved (no tmux, or topic not in registry) ──
+  if [[ -z "$STATE_SESSION" ]]; then
+    # Self-bootstrap: first session to fire claims the job.
+    OWNER="true"; OWNER_METHOD="bootstrap"
+  elif [[ "$STATE_SESSION" == "$HOOK_SESSION" ]]; then
+    OWNER="true"; OWNER_METHOD="session"
+  else
+    # Session-id mismatch with no topic signal. Gate on recorded owner liveness.
+    OWNER_ALIVE="false"
+    if [[ -n "$TRANSCRIPT_PATH" ]]; then
+      OWNER_TRANSCRIPT="$(dirname "$TRANSCRIPT_PATH")/${STATE_SESSION}.jsonl"
+      if [[ -f "$OWNER_TRANSCRIPT" ]]; then
+        NOW_E=$(date +%s)
+        MTIME=$(stat -f %m "$OWNER_TRANSCRIPT" 2>/dev/null || stat -c %Y "$OWNER_TRANSCRIPT" 2>/dev/null || echo 0)
+        AGE=$(( NOW_E - MTIME ))
+        if [[ $AGE -lt $LIVENESS_SECS ]]; then
+          OWNER_ALIVE="true"
+        fi
+      fi
+    fi
+    if [[ "$OWNER_ALIVE" == "true" ]]; then
+      # A genuinely different, live session owns this — don't steal.
+      exit 0
+    fi
+    # Recorded owner is dead/unknown → adopt the job.
+    OWNER="true"; OWNER_METHOD="adopt-dead"; RESTART_DETECTED="true"
+  fi
+fi
+
+if [[ "$OWNER" != "true" ]]; then
   exit 0
 fi
 
-# Same session — this IS the autonomous session, proceed with block logic
-
-ITERATION=$(echo "$FRONTMATTER" | grep '^iteration:' | sed 's/iteration: *//')
-DURATION_SECONDS=$(echo "$FRONTMATTER" | grep '^duration_seconds:' | sed 's/duration_seconds: *//')
-STARTED_AT=$(echo "$FRONTMATTER" | grep '^started_at:' | sed 's/started_at: *//' | tr -d '"')
-COMPLETION_PROMISE=$(echo "$FRONTMATTER" | grep '^completion_promise:' | sed 's/completion_promise: *//' | tr -d '"')
-REPORT_TOPIC=$(echo "$FRONTMATTER" | grep '^report_topic:' | sed 's/report_topic: *//' | tr -d '"')
+# ── This IS the autonomous session. Terminal checks first. ────────────
 
 # Validate iteration
 if [[ ! "$ITERATION" =~ ^[0-9]+$ ]]; then
   echo "⚠️  Autonomous mode: State file corrupted (bad iteration)" >&2
-  rm "$STATE_FILE"
+  rm -f "$STATE_FILE"
   exit 0
 fi
 
-# Check duration expiry
+# Duration expiry
+REMAINING_MIN=""
 if [[ "$DURATION_SECONDS" =~ ^[0-9]+$ ]] && [[ $DURATION_SECONDS -gt 0 ]]; then
-  START_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
+  START_EPOCH=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
   NOW_EPOCH=$(date +%s)
   ELAPSED=$(( NOW_EPOCH - START_EPOCH ))
   if [[ $ELAPSED -ge $DURATION_SECONDS ]]; then
     echo "⏰ Autonomous mode: Duration expired ($ELAPSED seconds elapsed)."
     echo "   Session is free to exit."
-    rm "$STATE_FILE"
+    rm -f "$STATE_FILE"
     exit 0
   fi
   REMAINING=$(( DURATION_SECONDS - ELAPSED ))
   REMAINING_MIN=$(( REMAINING / 60 ))
 fi
 
-# Check for emergency stop (look in recent messages)
-# The MessageSentinel handles this at the messaging layer, but also check here
+# Emergency stop
 if [[ -f ".instar/autonomous-emergency-stop" ]]; then
   echo "🛑 Autonomous mode: Emergency stop detected."
-  rm "$STATE_FILE"
+  rm -f "$STATE_FILE"
   rm -f ".instar/autonomous-emergency-stop"
   exit 0
 fi
 
-# Get transcript and check for completion promise
-TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path' 2>/dev/null || echo "")
-
+# Completion promise (genuine completion)
 if [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TRANSCRIPT_PATH" ]]; then
-  # Check last assistant message for completion promise
   LAST_LINE=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1 || echo "")
-
   if [[ -n "$LAST_LINE" ]]; then
-    LAST_OUTPUT=$(echo "$LAST_LINE" | jq -r '
-      .message.content |
-      map(select(.type == "text")) |
-      map(.text) |
-      join("\n")
+    LAST_OUTPUT=$(printf '%s' "$LAST_LINE" | jq -r '
+      .message.content | map(select(.type == "text")) | map(.text) | join("\n")
     ' 2>/dev/null || echo "")
-
-    # Check for completion promise in <promise> tags
     if [[ -n "$COMPLETION_PROMISE" ]] && [[ "$COMPLETION_PROMISE" != "null" ]]; then
-      PROMISE_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
-
+      PROMISE_TEXT=$(printf '%s' "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
       if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
         echo "✅ Autonomous mode: Completion promise detected — <promise>$COMPLETION_PROMISE</promise>"
         echo "   Session is free to exit. Good work!"
-        rm "$STATE_FILE"
+        rm -f "$STATE_FILE"
         exit 0
       fi
     fi
   fi
 fi
 
-# Not complete — block exit and feed task list back
+# ── Not terminal: we are continuing. Handle restart-resume recovery note. ──
+# Always reconcile the recorded session_id to the live one (so the backstop and
+# restart-detection stay accurate). Emit the one-line note exactly once, only
+# when a real restart was detected (topic-verified or dead-owner adoption).
+record_session_id() {
+  local new_id="$1"
+  local tmp="${STATE_FILE}.sid.$$"
+  if grep -q '^session_id:' "$STATE_FILE"; then
+    sed "s/^session_id:.*/session_id: \"${new_id}\"/" "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+  fi
+}
+
+if [[ "$RESTART_DETECTED" == "true" ]] && [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
+  ITER_LABEL="${ITERATION:-?}"
+  NOTE="Heads up — my session restarted mid-run and I've picked the autonomous job back up (topic ${REPORT_TOPIC:-?}, iteration ${ITER_LABEL}). No action needed."
+  # Durable audit record (always).
+  TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"ts":"%s","event":"restart-resume","topic":"%s","oldSession":"%s","newSession":"%s","method":"%s","iteration":"%s"}\n' \
+    "$TS" "${REPORT_TOPIC:-}" "$STATE_SESSION" "$HOOK_SESSION" "$OWNER_METHOD" "$ITER_LABEL" >> "$RECOVERY_AUDIT" 2>/dev/null || true
+  # Best-effort user-facing delivery (structural — the hook sends, not the agent).
+  if [[ -n "$REPORT_TOPIC" ]]; then
+    if [[ -x ".instar/scripts/telegram-reply.sh" ]]; then
+      printf '%s\n' "$NOTE" | .instar/scripts/telegram-reply.sh "$REPORT_TOPIC" >/dev/null 2>&1 || true
+    elif [[ -x ".claude/scripts/telegram-reply.sh" ]]; then
+      printf '%s\n' "$NOTE" | .claude/scripts/telegram-reply.sh "$REPORT_TOPIC" >/dev/null 2>&1 || true
+    fi
+  fi
+  echo "[autonomous] restart-resume: topic=${REPORT_TOPIC:-?} old=$STATE_SESSION new=$HOOK_SESSION method=$OWNER_METHOD" >&2
+fi
+
+# Reconcile recorded session_id to live (covers restart, bootstrap, adopt).
+if [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
+  record_session_id "$HOOK_SESSION"
+fi
+
+# ── Continue the job: increment iteration, feed the task back. ────────
 NEXT_ITERATION=$((ITERATION + 1))
 
-# Extract prompt (everything after closing ---)
 PROMPT_TEXT=$(awk '/^---$/{i++; next} i>=2' "$STATE_FILE")
-
 if [[ -z "$PROMPT_TEXT" ]]; then
   echo "⚠️  Autonomous mode: State file has no task content" >&2
-  rm "$STATE_FILE"
+  rm -f "$STATE_FILE"
   exit 0
 fi
 
-# Update iteration counter
-TEMP_FILE="${STATE_FILE}.tmp.$$"
-sed "s/^iteration: .*/iteration: $NEXT_ITERATION/" "$STATE_FILE" > "$TEMP_FILE"
-mv "$TEMP_FILE" "$STATE_FILE"
+TEMP_FILE="${STATE_FILE}.iter.$$"
+sed "s/^iteration: .*/iteration: $NEXT_ITERATION/" "$STATE_FILE" > "$TEMP_FILE" && mv "$TEMP_FILE" "$STATE_FILE"
 
 # ── Progress Report Check ──
-# Check if it's time to send a progress report
-REPORT_INTERVAL=$(echo "$FRONTMATTER" | grep '^report_interval:' | sed 's/report_interval: *//' | tr -d '"')
-LAST_REPORT_AT=$(echo "$FRONTMATTER" | grep '^last_report_at:' | sed 's/last_report_at: *//' | tr -d '"')
+REPORT_INTERVAL=$(fm_get report_interval)
+LAST_REPORT_AT=$(fm_get last_report_at)
 
-# Convert report interval to seconds
 REPORT_INTERVAL_SECS=1800  # default 30 minutes
 if [[ "$REPORT_INTERVAL" =~ ^([0-9]+)m$ ]]; then
   REPORT_INTERVAL_SECS=$(( ${BASH_REMATCH[1]} * 60 ))
@@ -174,37 +279,30 @@ fi
 
 REPORT_DUE="false"
 NOW_EPOCH=$(date +%s)
-
-if [[ -z "$LAST_REPORT_AT" ]] || [[ "$LAST_REPORT_AT" == "null" ]] || [[ "$LAST_REPORT_AT" == '""' ]]; then
-  # No report sent yet — due if we've been running for at least one interval
+if [[ -z "$LAST_REPORT_AT" ]] || [[ "$LAST_REPORT_AT" == "null" ]]; then
   if [[ -n "$STARTED_AT" ]]; then
-    START_EPOCH_R=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
+    START_EPOCH_R=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
     ELAPSED_SINCE_START=$(( NOW_EPOCH - START_EPOCH_R ))
     if [[ $ELAPSED_SINCE_START -ge $REPORT_INTERVAL_SECS ]]; then
       REPORT_DUE="true"
     fi
   fi
 else
-  # Check time since last report
-  LAST_REPORT_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$LAST_REPORT_AT" +%s 2>/dev/null || date -d "$LAST_REPORT_AT" +%s 2>/dev/null || echo "0")
+  LAST_REPORT_EPOCH=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$LAST_REPORT_AT" +%s 2>/dev/null || date -d "$LAST_REPORT_AT" +%s 2>/dev/null || echo "0")
   ELAPSED_SINCE_REPORT=$(( NOW_EPOCH - LAST_REPORT_EPOCH ))
   if [[ $ELAPSED_SINCE_REPORT -ge $REPORT_INTERVAL_SECS ]]; then
     REPORT_DUE="true"
   fi
 fi
 
-# If report is due, update last_report_at in state file
 REPORT_DIRECTIVE=""
 if [[ "$REPORT_DUE" == "true" ]]; then
   REPORT_NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  # Update or add last_report_at in frontmatter
   if grep -q '^last_report_at:' "$STATE_FILE"; then
-    TEMP_FILE2="${STATE_FILE}.tmp2.$$"
-    sed "s/^last_report_at: .*/last_report_at: \"$REPORT_NOW\"/" "$STATE_FILE" > "$TEMP_FILE2"
-    mv "$TEMP_FILE2" "$STATE_FILE"
+    TEMP_FILE2="${STATE_FILE}.rpt.$$"
+    sed "s/^last_report_at: .*/last_report_at: \"$REPORT_NOW\"/" "$STATE_FILE" > "$TEMP_FILE2" && mv "$TEMP_FILE2" "$STATE_FILE"
   else
-    # Add last_report_at before the closing ---
-    TEMP_FILE2="${STATE_FILE}.tmp2.$$"
+    TEMP_FILE2="${STATE_FILE}.rpt.$$"
     sed "0,/^---$/! { /^---$/i\\
 last_report_at: \"$REPORT_NOW\"
 }" "$STATE_FILE" > "$TEMP_FILE2" 2>/dev/null && mv "$TEMP_FILE2" "$STATE_FILE" || true

--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -175,20 +175,26 @@ if [[ ! "$ITERATION" =~ ^[0-9]+$ ]]; then
   exit 0
 fi
 
-# Duration expiry
+# Duration expiry. Fail-SAFE: if started_at can't be parsed (START_EPOCH falls
+# back to 0/empty), do NOT expire — an unparseable timestamp must never cause a
+# premature exit (that is the very failure class this hook exists to prevent).
 REMAINING_MIN=""
 if [[ "$DURATION_SECONDS" =~ ^[0-9]+$ ]] && [[ $DURATION_SECONDS -gt 0 ]]; then
   START_EPOCH=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo "0")
-  NOW_EPOCH=$(date +%s)
-  ELAPSED=$(( NOW_EPOCH - START_EPOCH ))
-  if [[ $ELAPSED -ge $DURATION_SECONDS ]]; then
-    echo "⏰ Autonomous mode: Duration expired ($ELAPSED seconds elapsed)."
-    echo "   Session is free to exit."
-    rm -f "$STATE_FILE"
-    exit 0
+  if [[ "$START_EPOCH" =~ ^[0-9]+$ ]] && [[ $START_EPOCH -gt 0 ]]; then
+    NOW_EPOCH=$(date +%s)
+    ELAPSED=$(( NOW_EPOCH - START_EPOCH ))
+    if [[ $ELAPSED -ge $DURATION_SECONDS ]]; then
+      echo "⏰ Autonomous mode: Duration expired ($ELAPSED seconds elapsed)."
+      echo "   Session is free to exit."
+      rm -f "$STATE_FILE"
+      exit 0
+    fi
+    REMAINING=$(( DURATION_SECONDS - ELAPSED ))
+    REMAINING_MIN=$(( REMAINING / 60 ))
+  else
+    echo "[autonomous] started_at unparseable ('$STARTED_AT') — skipping duration-expiry check (fail-safe: keep running)" >&2
   fi
-  REMAINING=$(( DURATION_SECONDS - ELAPSED ))
-  REMAINING_MIN=$(( REMAINING / 60 ))
 fi
 
 # Emergency stop

--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -150,9 +150,15 @@ else
       OWNER_TRANSCRIPT="$(dirname "$TRANSCRIPT_PATH")/${STATE_SESSION}.jsonl"
       if [[ -f "$OWNER_TRANSCRIPT" ]]; then
         NOW_E=$(date +%s)
-        MTIME=$(stat -f %m "$OWNER_TRANSCRIPT" 2>/dev/null || stat -c %Y "$OWNER_TRANSCRIPT" 2>/dev/null || echo 0)
+        # GNU stat (-c %Y) first — Linux is the common host (and CI). BSD stat
+        # (-f %m) second for macOS. NOTE: GNU `stat -f` is filesystem mode and
+        # SUCCEEDS with non-numeric output, so BSD-first would mask the GNU path
+        # on Linux and feed garbage into the arithmetic below. The numeric guard
+        # is the backstop: a non-numeric mtime is treated as 0 (very old → dead).
+        MTIME=$(stat -c %Y "$OWNER_TRANSCRIPT" 2>/dev/null || stat -f %m "$OWNER_TRANSCRIPT" 2>/dev/null || echo 0)
+        [[ "$MTIME" =~ ^[0-9]+$ ]] || MTIME=0
         AGE=$(( NOW_E - MTIME ))
-        if [[ $AGE -lt $LIVENESS_SECS ]]; then
+        if [[ $MTIME -gt 0 ]] && [[ $AGE -lt $LIVENESS_SECS ]]; then
           OWNER_ALIVE="true"
         fi
       fi

--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -69,6 +69,10 @@ fi
 
 # ── State fields ──────────────────────────────────────────────────────
 REPORT_TOPIC=$(fm_get report_topic)
+# Channel that owns this job — recovery note routes here. Default telegram for
+# back-compat (state files written before channel-neutral delivery existed).
+REPORT_CHANNEL=$(fm_get report_channel)
+[[ -z "$REPORT_CHANNEL" ]] && REPORT_CHANNEL="telegram"
 STATE_SESSION=$(fm_get session_id)
 ITERATION=$(fm_get iteration)
 DURATION_SECONDS=$(fm_get duration_seconds)
@@ -236,22 +240,40 @@ record_session_id() {
   fi
 }
 
+# Channel-neutral delivery seam. The hook does NOT assume Telegram — it routes
+# the note to whatever channel owns the job. Telegram is wired here; the other
+# channels are owned by the unified notification layer tracked in the Channel
+# Parity initiative. Either way the durable audit record below is the source of
+# truth, so a not-yet-wired channel never silently misfires to Telegram.
+deliver_recovery_note() {
+  local channel="$1" target="$2" text="$3"
+  [[ -z "$target" ]] && return 0
+  case "$channel" in
+    telegram)
+      if [[ -x ".instar/scripts/telegram-reply.sh" ]]; then
+        printf '%s\n' "$text" | .instar/scripts/telegram-reply.sh "$target" >/dev/null 2>&1 || true
+      elif [[ -x ".claude/scripts/telegram-reply.sh" ]]; then
+        printf '%s\n' "$text" | .claude/scripts/telegram-reply.sh "$target" >/dev/null 2>&1 || true
+      fi
+      ;;
+    *)
+      # slack | whatsapp | imessage | future — delivered by the unified notify
+      # layer (Channel Parity initiative). Recorded to the audit trail above.
+      echo "[autonomous] recovery note for channel '$channel' recorded to audit; live delivery pending the Channel Parity initiative" >&2
+      ;;
+  esac
+}
+
 if [[ "$RESTART_DETECTED" == "true" ]] && [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
   ITER_LABEL="${ITERATION:-?}"
   NOTE="Heads up — my session restarted mid-run and I've picked the autonomous job back up (topic ${REPORT_TOPIC:-?}, iteration ${ITER_LABEL}). No action needed."
-  # Durable audit record (always).
+  # Durable, channel-neutral audit record (always).
   TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  printf '{"ts":"%s","event":"restart-resume","topic":"%s","oldSession":"%s","newSession":"%s","method":"%s","iteration":"%s"}\n' \
-    "$TS" "${REPORT_TOPIC:-}" "$STATE_SESSION" "$HOOK_SESSION" "$OWNER_METHOD" "$ITER_LABEL" >> "$RECOVERY_AUDIT" 2>/dev/null || true
-  # Best-effort user-facing delivery (structural — the hook sends, not the agent).
-  if [[ -n "$REPORT_TOPIC" ]]; then
-    if [[ -x ".instar/scripts/telegram-reply.sh" ]]; then
-      printf '%s\n' "$NOTE" | .instar/scripts/telegram-reply.sh "$REPORT_TOPIC" >/dev/null 2>&1 || true
-    elif [[ -x ".claude/scripts/telegram-reply.sh" ]]; then
-      printf '%s\n' "$NOTE" | .claude/scripts/telegram-reply.sh "$REPORT_TOPIC" >/dev/null 2>&1 || true
-    fi
-  fi
-  echo "[autonomous] restart-resume: topic=${REPORT_TOPIC:-?} old=$STATE_SESSION new=$HOOK_SESSION method=$OWNER_METHOD" >&2
+  printf '{"ts":"%s","event":"restart-resume","channel":"%s","topic":"%s","oldSession":"%s","newSession":"%s","method":"%s","iteration":"%s"}\n' \
+    "$TS" "$REPORT_CHANNEL" "${REPORT_TOPIC:-}" "$STATE_SESSION" "$HOOK_SESSION" "$OWNER_METHOD" "$ITER_LABEL" >> "$RECOVERY_AUDIT" 2>/dev/null || true
+  # Best-effort user-facing delivery via the channel that owns the job.
+  deliver_recovery_note "$REPORT_CHANNEL" "$REPORT_TOPIC" "$NOTE"
+  echo "[autonomous] restart-resume: channel=$REPORT_CHANNEL topic=${REPORT_TOPIC:-?} old=$STATE_SESSION new=$HOOK_SESSION method=$OWNER_METHOD" >&2
 fi
 
 # Reconcile recorded session_id to live (covers restart, bootstrap, adopt).

--- a/.claude/skills/autonomous/scripts/setup-autonomous.sh
+++ b/.claude/skills/autonomous/scripts/setup-autonomous.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 GOAL=""
 DURATION="4h"
 REPORT_TOPIC=""
+REPORT_CHANNEL="telegram"   # channel that owns this job; recovery note routes here (telegram|slack|whatsapp|imessage)
 LEVEL_UP="false"
 TASKS=""
 COMPLETION_PROMISE=""
@@ -27,6 +28,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --report-topic)
       REPORT_TOPIC="$2"
+      shift 2
+      ;;
+    --report-channel)
+      REPORT_CHANNEL="$2"
       shift 2
       ;;
     --level-up)
@@ -102,6 +107,7 @@ duration_seconds: $DURATION_SECONDS
 started_at: "$STARTED_AT"
 end_at: "$END_AT"
 report_topic: "$REPORT_TOPIC"
+report_channel: "$REPORT_CHANNEL"
 report_interval: "$REPORT_INTERVAL"
 last_report_at: ""
 level_up: $LEVEL_UP

--- a/docs/specs/autonomous-topic-keyed-identity.eli16.md
+++ b/docs/specs/autonomous-topic-keyed-identity.eli16.md
@@ -1,0 +1,47 @@
+# Topic-keyed autonomous-mode session identity — Plain-English Overview
+
+> The one-line version: stop recognizing a long-running autonomous job by the worker's badge number (which changes when the worker restarts) and start recognizing it by the address of the house it's working on (which doesn't).
+
+## The problem in one breath
+
+Autonomous mode is supposed to let you walk away while I keep working for hours, never stopping until the job's done. A safety latch enforces that. But when a long run hits the memory limit and restarts, it comes back as a "new" session — and the latch stopped recognizing it as the same worker, quietly let it wander off, and autonomy died for hours with no signal. That actually happened today.
+
+## What already exists
+
+- **Autonomous mode + its stop latch** — while a job is active, the latch refuses to let the session quit and feeds the task back; it only lets go on a time limit, an emergency stop, or a "done" signal. That part works.
+- **The topic-to-session address book** — instar already keeps a little registry mapping each chat topic to a fixed work-session name, and when it restarts a crashed session it reuses that same name. So the "address" of a job is already stable and already written down.
+- **The job's own notes** — the autonomous job already records which topic it belongs to.
+
+## What this adds
+
+The latch now decides "is this the worker for this job?" by the **topic** (the stable address) instead of the **session ID** (the badge that changes on restart). Because a restarted session comes back at the same address, the latch keeps recognizing it — so autonomy survives the restart instead of silently dying.
+
+- The old badge-matching still exists, but only as a thin backup for the rare case where the address can't be read.
+- That backup no longer guesses; it checks whether the previous worker is actually still alive (is its log still growing?) before deciding anything — so it never steals a job from a session that's just busy.
+- When a real restart-and-resume happens, you get **one** short heads-up message: "I restarted mid-run and picked the job back up. No action needed." Just once, never repeated.
+
+## The new pieces
+
+- **Topic-keyed ownership** — reads the work-session's name, looks up which topic it serves, and matches that against the job's recorded topic. Match = "I'm the worker, keep going." It is not allowed to trap a session that's working a *different* topic.
+- **Liveness backup** — only runs when the address can't be resolved. It checks the previous worker's log freshness; a dead worker's job gets adopted, a live worker's job is left alone.
+- **The recovery note** — a one-line, send-once heads-up plus a durable audit record, so a clean recovery is distinguishable from a real death (the exact blind spot that bit us).
+
+## The safeguards
+
+**Prevents the silent death.** A restart no longer looks like a stranger; the job continues.
+
+**Prevents stealing a busy session's work.** The backup only adopts a job whose previous owner is provably stale, and it's only consulted in the rare no-address case.
+
+**Prevents notification spam.** Exactly one recovery note per restart, deduped by recording the new session ID.
+
+**Prevents two old bugs I found in the same latch while I was in there.** One read your UTC timestamps as local time (throwing off the timer math by your clock offset); the other could crash the whole latch if one optional field was missing. Both fixed, with a new fail-safe: if a timestamp is unreadable, the latch keeps the session running rather than risk a premature exit.
+
+**Doesn't assume Telegram.** The recovery note routes to whichever channel the job actually lives on — Telegram is just the one wired option behind a channel-neutral seam, so the design doesn't quietly bake in "Telegram is the only channel." Wiring the other channels (Slack, etc.) for parity is its own dedicated initiative (its own topic), not half-done here.
+
+## What ships when
+
+It's one change, shipped together: the rewritten latch, the safety-net update so existing agents actually receive it, and all three layers of tests (unit, the update path, and a full end-to-end restart-and-resume run). Nothing lands on your live setup until the in-flight overnight run finishes and you say go.
+
+## The decision (settled)
+
+Approved 2026-05-23: recognize the job by its topic, keep the liveness check as a backup, send one recovery note on restart — and route that note channel-neutrally (Telegram wired, no Telegram assumption baked in), with channel parity across all channels split out into its own initiative.

--- a/docs/specs/autonomous-topic-keyed-identity.md
+++ b/docs/specs/autonomous-topic-keyed-identity.md
@@ -1,0 +1,173 @@
+---
+title: Topic-keyed autonomous-mode session identity
+date: 2026-05-23
+author: echo
+review-convergence: internal-plus-second-pass-2026-05-23
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 12143 ("Yes, I approve of this with one caveat" 2026-05-23, caveat resolved via channel-neutral delivery seam + Channel Parity initiative topic 12270; "Yes, lets go for A" confirming scope)
+eli16-overview: autonomous-topic-keyed-identity.eli16.md
+---
+
+# Topic-keyed autonomous-mode session identity
+
+## Problem
+
+Autonomous mode keeps a Claude Code session working until its job is done, enforced
+structurally by `autonomous-stop-hook.sh` (Stop hook): while the job is active the
+hook returns `{"decision":"block"}` and feeds the task back; it only allows exit on
+duration expiry, emergency stop, or a matched completion promise.
+
+Ownership of the job — "is THIS session the autonomous worker?" — was keyed on the
+Claude **session UUID**, recorded in `.instar/autonomous-state.local.md` as
+`session_id`. A long autonomous run hits the context/memory limit and is restarted;
+each restart gets a **new** session UUID, but the state file still held the **old**
+one. On the resulting mismatch the hook concluded "this is some other session" and
+**failed open** — it allowed exit. From the first restart onward, every turn-end was
+permitted, the session went idle, and autonomy was silently dead until the user
+poked it. (Observed: a full session lost this way on 2026-05-23.)
+
+A naive fix ("owner went quiet → take over") cannot distinguish a crashed session
+from one legitimately deep in a long task — that is the identity-swap hazard that has
+bitten this system before.
+
+## Key insight
+
+"Quiet for a while" ≠ "dead." The robust identity signal is not elapsed time and not
+the volatile session UUID — it is the **topic** the session serves. instar already
+binds each Telegram topic to a stable **tmux session name** (`.instar/topic-session-registry.json`,
+`topicToSession`), and `SessionRecovery.respawnSession(topicId, sessionName, …)`
+**reuses that same tmux name** when it restarts a session. The tmux name is therefore
+a stable "street address" that survives restarts, while the session UUID is a
+"worker's badge" that rotates. Key on the address, not the badge.
+
+## Design
+
+The stop hook resolves ownership in this order:
+
+### 1. Topic-keyed ownership (primary)
+
+- Resolve the hook's own tmux session name: `tmux display-message -p '#S'`
+  (overridable for tests via `INSTAR_HOOK_TMUX_SESSION`; `INSTAR_HOOK_NO_TMUX=1`
+  forces "no tmux").
+- Read `report_topic` from the state file (already persisted with the job).
+- Reverse-look-up the registry: `OWNER_TMUX = topicToSession[report_topic]`.
+- If `MY_TMUX == OWNER_TMUX` → **this is the autonomous session** → block.
+  This holds across restarts: the new UUID is irrelevant, the address matches.
+- If `OWNER_TMUX` is non-empty but `!= MY_TMUX` → the topic is served by a different
+  session → **allow exit** (never trap a foreign session).
+
+### 2. Liveness-gated backstop (rare)
+
+Reached only when topic resolution is unavailable (no tmux, or `report_topic` not in
+the registry — e.g. older runs, or a registry reconfigured mid-run):
+
+- Recorded `session_id` empty/invalid → self-bootstrap (first fire claims the job).
+- Recorded `session_id` == hook session → block (session match).
+- Recorded `session_id` != hook session → gate on the **recorded owner's liveness**:
+  derive its transcript path (`dirname(hook transcript)/<recorded_uuid>.jsonl`) and
+  compare mtime against `INSTAR_AUTONOMOUS_LIVENESS_SECS` (default 120s).
+  - Owner alive (fresh transcript) → a genuinely different live session → allow exit
+    (no steal).
+  - Owner dead/unknown → adopt the job → block (and treat as a restart-resume).
+
+This is the demoted role of the liveness idea from the original brief: a thin edge
+guard, not the main mechanism. With topic resolution available (the normal case for
+instar-spawned autonomous sessions, which always run in tmux), the backstop is never
+consulted and collisions are structurally impossible (the registry maps one topic to
+exactly one tmux name).
+
+### 3. One-line recovery note
+
+On a genuine restart-and-resume (topic-verified ownership OR dead-owner adoption,
+AND the recorded UUID differs from the live one), the hook:
+
+- appends one audit record to `.instar/autonomous-recovery.jsonl`
+  (`{ts, event:"restart-resume", topic, oldSession, newSession, method, iteration}`),
+- best-effort delivers a single user-facing line via `telegram-reply.sh` to
+  `report_topic`: *"Heads up — my session restarted mid-run and I've picked the
+  autonomous job back up (topic N, iteration M). No action needed."*,
+- reconciles the recorded `session_id` to the live one, so the note fires **exactly
+  once** per restart (subsequent fires see a match and stay silent).
+
+Delivery is structural (the hook sends; it does not rely on the agent remembering to).
+The audit record is the durable source of truth; live delivery is best-effort.
+
+### Channel-neutral delivery (no Telegram assumption)
+
+The recovery note routes to **whatever channel owns the job**, not Telegram by
+default. The autonomous state records `report_channel` (set by
+`setup-autonomous.sh`, default `telegram` for back-compat with older state files),
+and the hook dispatches through a `deliver_recovery_note` seam keyed on it:
+
+- `telegram` → wired now via `telegram-reply.sh`.
+- `slack | whatsapp | imessage | future` → owned by the unified notification layer
+  tracked in the **Channel Parity initiative** (Telegram topic 12270). Until that
+  lands, the channel-neutral audit record carries the event and the hook logs that
+  live delivery is pending — it never silently misfires to Telegram.
+
+The audit record includes the `channel`, so it is channel-neutral end to end. This
+is the "seam now, unification later" split agreed with the user (2026-05-23): the
+design no longer bakes in Telegram; wiring the remaining channels is the Channel
+Parity initiative's scope, not this hook's.
+
+## Collateral fixes (same hook, same change)
+
+- **Timezone bug:** `date -j -f "%Y-%m-%dT%H:%M:%SZ"` parsed UTC timestamps as
+  **local** time, skewing duration and report-interval math by the local offset.
+  Added `-u` to the three BSD date-parse callsites (GNU `date -d` already handles Z).
+- **Pipefail fragility:** under `set -uo pipefail`, a `grep` for an **absent** optional
+  frontmatter key (`last_report_at`) made the pipeline exit non-zero and aborted the
+  whole hook. Frontmatter reads now go through a `fm_get` helper that never trips
+  pipefail.
+- **Fail-safe expiry:** if `started_at` is unparseable, `date` falls back to epoch 0,
+  which would inflate elapsed time and prematurely expire the run. The duration-expiry
+  check now only fires when `started_at` parsed to a positive epoch; otherwise it logs
+  and keeps running (fail toward continuing, never toward a premature exit).
+
+## Migration (parity)
+
+`installAutonomousSkill()` is install-if-missing, so existing agents never receive
+hook updates via `init`. Per the Migration Parity Standard, `PostUpdateMigrator`
+gains an idempotent `migrateAutonomousStopHookTopicKeyed()`:
+
+- content-sniff on the `topic-session-registry` marker (skip if already topic-keyed),
+- stock-fingerprint guard on `Autonomous Mode Stop Hook` (leave customized hooks
+  untouched),
+- re-copy the bundled hook + `chmod 755`,
+- wired into `run()`. Mirrors `migrateBuildSkillMethodology`.
+
+## Signal-vs-authority
+
+The hook is a **consumer** of an existing detector (the topic-session registry +
+transcript liveness), not a new brittle check with blocking authority. Its blocking
+authority is exactly the pre-existing autonomous-mode authority — unchanged in scope,
+only made restart-correct. No new gate is introduced.
+
+## Test strategy (all three tiers)
+
+- **Unit (Tier 1):** `tests/unit/autonomous-stop-hook-topic-keyed.test.ts` executes the
+  real hook across every path — restart-survives (the regression), foreign-topic-exits,
+  liveness backstop both sides, recovery-note-once + dedup, preserved terminal exits,
+  and the fail-safe/robustness cases. Plus the updated source-analysis tests.
+- **Integration (Tier 2):** `tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts`
+  drives the real migrator + bundled file + filesystem: upgrades an old session-keyed
+  hook, idempotent on repeat, leaves customized hooks untouched, no-op when absent, and
+  asserts the migration is wired into `run()` (anti-dead-code). (No HTTP surface exists
+  for this feature, so the migrator integration test stands in for the HTTP tier.)
+- **E2E (Tier 3):** `tests/e2e/autonomous-restart-resume-lifecycle.test.ts` runs the real
+  hook through a production-shaped sequence with persisting state — bootstrap → restart
+  with rotated UUID → exactly one recovery note → dedup → completion — proving autonomy
+  survives a restart end to end.
+
+The bug was reproduced first (RED): the restart-survives assertion fails on the old
+session-keyed hook before the fix and passes after.
+
+## Acceptance criteria
+
+1. A restarted session (new UUID, same topic) blocks exit; autonomy survives.
+2. A foreign-topic session is never trapped.
+3. Exactly one recovery note per restart, durably audited, best-effort delivered.
+4. Duration / emergency-stop / completion-promise / progress-report paths unchanged.
+5. Existing agents receive the fix via the idempotent migration.
+6. All three test tiers green; full suite green at push.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -188,6 +188,7 @@ export class PostUpdateMigrator {
     this.autoMigrateLegacyJobsJson(result);
     this.migrateSkillPortHardcoding(result);
     this.migrateBuildSkillMethodology(result);
+    this.migrateAutonomousStopHookTopicKeyed(result);
     this.migrateSelfKnowledgeTree(result);
     this.migrateSoulMd(result);
     this.migrateAgentMdSections(result);
@@ -1166,6 +1167,51 @@ export class PostUpdateMigrator {
       }
     } catch (err) {
       result.errors.push(`skills/build/SKILL.md methodology migration: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Update the deployed autonomous stop hook to the topic-keyed version.
+   *
+   * The old hook keyed autonomous-session ownership on the Claude session UUID;
+   * a memory-limit restart rotated the UUID, mismatched the state file, and let
+   * the still-running session exit — autonomy died silently. The new hook keys
+   * on the TOPIC (a stable address that survives restarts), demotes session-id
+   * matching to a liveness-gated backstop, and emits a one-line recovery note.
+   *
+   * installAutonomousSkill() is install-if-missing, so existing agents never get
+   * this through init — a dedicated migration is the only path (Migration Parity
+   * Standard, "updating existing skill content").
+   *
+   * Idempotent + conservative: only re-copies the bundled hook when the installed
+   * copy (a) lacks the new "topic-session-registry" marker AND (b) still looks
+   * like the stock hook (contains "Autonomous Mode Stop Hook"). A customized hook
+   * that no longer matches the stock fingerprint is left untouched.
+   */
+  private migrateAutonomousStopHookTopicKeyed(result: MigrationResult): void {
+    try {
+      const deployed = path.join(
+        this.config.projectDir, '.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh',
+      );
+      if (!fs.existsSync(deployed)) return; // installAutonomousSkill handles fresh installs
+      const current = fs.readFileSync(deployed, 'utf8');
+      if (current.includes('topic-session-registry')) return; // already topic-keyed — idempotent
+      if (!current.includes('Autonomous Mode Stop Hook')) {
+        result.skipped.push('skills/autonomous/hooks/autonomous-stop-hook.sh: customized — left untouched');
+        return;
+      }
+      const bundled = path.join(
+        __dirname, '..', '..', '.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh',
+      );
+      if (!fs.existsSync(bundled)) return;
+      const next = fs.readFileSync(bundled, 'utf8');
+      if (next.includes('topic-session-registry')) {
+        fs.writeFileSync(deployed, next);
+        fs.chmodSync(deployed, 0o755);
+        result.upgraded.push('skills/autonomous/hooks/autonomous-stop-hook.sh (topic-keyed ownership + recovery note)');
+      }
+    } catch (err) {
+      result.errors.push(`autonomous stop hook topic-keying migration: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/e2e/autonomous-restart-resume-lifecycle.test.ts
+++ b/tests/e2e/autonomous-restart-resume-lifecycle.test.ts
@@ -1,0 +1,143 @@
+// safe-git-allow: test-tmpdir-cleanup — afterAll removes the per-test mkdtempSync home; SafeFsExecutor migration tracked separately.
+/**
+ * E2E — Autonomous restart-resume full lifecycle.
+ *
+ * Drives the REAL autonomous-stop-hook.sh through a production-shaped sequence
+ * against a temp agent home, with state PERSISTING across hook fires (unlike the
+ * per-scenario unit tests). This is the "feature alive" tier-3 check: it proves
+ * autonomy survives a memory-limit restart end to end.
+ *
+ *   1. session A fires (topic-owned)            → blocks, no recovery note
+ *   2. session A fires again                     → blocks, still no note
+ *   3. RESTART: session B (new UUID, same tmux)  → blocks + exactly ONE recovery note
+ *   4. session B fires again                     → blocks, no second note (dedup)
+ *   5. session B emits the completion promise    → exits, removes state file
+ *
+ * The whole point: between steps 2 and 3 the session UUID rotates (a restart),
+ * and the OLD hook would have allowed exit at step 3 — autonomy dies. Here it
+ * survives because ownership is keyed on the topic, and the user gets one note.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const HOOK_PATH = path.join(
+  process.cwd(), '.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh',
+);
+const TMUX = 'echo-claude-agent-sdk';
+const TOPIC = '9984';
+const SESSION_A = '04db2de7-8e82-4baf-9136-7a067bb2ec53';
+const SESSION_B = 'a13495fb-bbb5-4a90-8c72-aa1e0e9e395e';
+
+let home: string;
+let transcriptsDir: string;
+
+function statePath() {
+  return path.join(home, '.instar', 'autonomous-state.local.md');
+}
+function auditPath() {
+  return path.join(home, '.instar', 'autonomous-recovery.jsonl');
+}
+function recordedSessionId(): string {
+  const m = fs.readFileSync(statePath(), 'utf-8').match(/^session_id:\s*"([^"]*)"/m);
+  return m ? m[1] : '';
+}
+function auditCount(): number {
+  if (!fs.existsSync(auditPath())) return 0;
+  return fs.readFileSync(auditPath(), 'utf-8').trim().split('\n').filter(Boolean).length;
+}
+
+/** Write a transcript for a session; lastText lets us inject the completion promise. */
+function transcript(uuid: string, lastText = ''): string {
+  const p = path.join(transcriptsDir, `${uuid}.jsonl`);
+  fs.writeFileSync(
+    p,
+    JSON.stringify({ role: 'assistant', message: { content: [{ type: 'text', text: lastText }] } }) + '\n',
+  );
+  return p;
+}
+
+function fire(sessionId: string, lastText = ''): { decision: string | null; exit: number } {
+  const input = JSON.stringify({ session_id: sessionId, transcript_path: transcript(sessionId, lastText) });
+  let stdout = '';
+  let exit = 0;
+  try {
+    stdout = execFileSync('bash', [HOOK_PATH], {
+      cwd: home,
+      input,
+      env: { ...process.env, INSTAR_HOOK_TMUX_SESSION: TMUX },
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err: any) {
+    exit = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+  }
+  let decision: string | null = null;
+  try { decision = JSON.parse(stdout.trim()).decision ?? null; } catch { /* allow-exit path */ }
+  return { decision, exit };
+}
+
+describe('E2E: autonomous restart-resume lifecycle', () => {
+  beforeAll(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-restart-e2e-'));
+    fs.mkdirSync(path.join(home, '.instar'), { recursive: true });
+    transcriptsDir = path.join(home, 'transcripts');
+    fs.mkdirSync(transcriptsDir, { recursive: true });
+    // Topic 9984 is served by the TMUX session — the stable address.
+    fs.writeFileSync(
+      path.join(home, '.instar', 'topic-session-registry.json'),
+      JSON.stringify({ topicToSession: { [TOPIC]: TMUX }, topicToName: {} }),
+    );
+    // A live autonomous job, no time limit, recorded under session A.
+    const started = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+    fs.writeFileSync(
+      statePath(),
+      `---
+active: true
+iteration: 3
+session_id: "${SESSION_A}"
+goal: "ship the thing"
+duration_seconds: 0
+started_at: "${started}"
+report_topic: "${TOPIC}"
+report_interval: "2h"
+completion_promise: "SHIPPED_IT"
+---
+
+Keep shipping until done.
+`,
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('survives a restart end-to-end with exactly one recovery note, then completes', () => {
+    // 1 + 2: session A owns via topic, no restart → blocks, no recovery note.
+    expect(fire(SESSION_A).decision).toBe('block');
+    expect(fire(SESSION_A).decision).toBe('block');
+    expect(auditCount()).toBe(0);
+
+    // 3: RESTART — new UUID, same tmux/topic. Must block AND record one note.
+    const restart = fire(SESSION_B);
+    expect(restart.decision).toBe('block');
+    expect(auditCount()).toBe(1);
+    // State now reconciled to the live session.
+    expect(recordedSessionId()).toBe(SESSION_B);
+
+    // 4: session B fires again → blocks, NO second note (dedup).
+    expect(fire(SESSION_B).decision).toBe('block');
+    expect(auditCount()).toBe(1);
+
+    // 5: completion promise → hook lets the session exit and removes state.
+    const done = fire(SESSION_B, 'All finished. <promise>SHIPPED_IT</promise>');
+    expect(done.decision).not.toBe('block');
+    expect(done.exit).toBe(0);
+    expect(fs.existsSync(statePath())).toBe(false);
+  });
+});

--- a/tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts
+++ b/tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Verifies PostUpdateMigrator upgrades an already-deployed autonomous stop hook
+ * to the topic-keyed version on update.
+ *
+ * installAutonomousSkill() is install-if-missing, so existing agents never get
+ * hook updates through init. Without this migration, every agent deployed before
+ * the topic-keying fix would keep running the buggy session-UUID-keyed hook —
+ * the exact silent-failure this work fixes. The migration is the only path that
+ * reaches already-installed copies (Migration Parity Standard).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+const HOOK_REL = path.join('.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh');
+
+// A representative OLD (session-UUID-keyed) hook: carries the stock fingerprint
+// but lacks the topic-session-registry marker.
+const OLD_HOOK = `#!/bin/bash
+
+# Autonomous Mode Stop Hook
+# Prevents session exit when autonomous mode is active.
+
+STATE_FILE=".instar/autonomous-state.local.md"
+STATE_SESSION=$(echo "$FRONTMATTER" | grep '^session_id:')
+if [[ "$STATE_SESSION" != "$HOOK_SESSION" ]]; then
+  exit 0
+fi
+rm "$STATE_FILE"
+`;
+
+function newMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function runMigration(migrator: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (migrator as unknown as {
+    migrateAutonomousStopHookTopicKeyed(r: MigrationResult): void;
+  }).migrateAutonomousStopHookTopicKeyed(result);
+  return result;
+}
+
+function deployHook(projectDir: string, content: string): string {
+  const dst = path.join(projectDir, HOOK_REL);
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.writeFileSync(dst, content);
+  return dst;
+}
+
+describe('PostUpdateMigrator — autonomous stop hook topic-keying', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-auto-hook-mig-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true, force: true,
+      operation: 'tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts',
+    });
+  });
+
+  it('upgrades an old session-keyed hook to the topic-keyed version', () => {
+    const dst = deployHook(projectDir, OLD_HOOK);
+    expect(fs.readFileSync(dst, 'utf8')).not.toContain('topic-session-registry');
+
+    const result = runMigration(newMigrator(projectDir));
+
+    const updated = fs.readFileSync(dst, 'utf8');
+    expect(updated).toContain('topic-session-registry'); // now topic-keyed
+    expect(updated).toContain('TOPIC-KEYED OWNERSHIP');
+    expect((fs.statSync(dst).mode & 0o111)).not.toBe(0); // executable
+    expect(result.upgraded.some(u => u.includes('autonomous-stop-hook.sh'))).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('is idempotent — a second run makes no change and reports nothing', () => {
+    deployHook(projectDir, OLD_HOOK);
+    runMigration(newMigrator(projectDir)); // first run upgrades
+
+    const dst = path.join(projectDir, HOOK_REL);
+    const afterFirst = fs.readFileSync(dst, 'utf8');
+
+    const second = runMigration(newMigrator(projectDir));
+    expect(fs.readFileSync(dst, 'utf8')).toBe(afterFirst); // unchanged
+    expect(second.upgraded.some(u => u.includes('autonomous-stop-hook.sh'))).toBe(false);
+    expect(second.errors).toEqual([]);
+  });
+
+  it('leaves a customized hook untouched (no stock fingerprint)', () => {
+    const custom = '#!/bin/bash\n# My heavily customized hook\nexit 0\n';
+    const dst = deployHook(projectDir, custom);
+
+    const result = runMigration(newMigrator(projectDir));
+
+    expect(fs.readFileSync(dst, 'utf8')).toBe(custom); // untouched
+    expect(result.skipped.some(s => s.includes('customized'))).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('is a no-op when no hook is deployed (fresh installs handled by init)', () => {
+    const result = runMigration(newMigrator(projectDir));
+    expect(fs.existsSync(path.join(projectDir, HOOK_REL))).toBe(false);
+    expect(result.upgraded).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('is wired into the full migration run() sequence', () => {
+    // Guards against the migration existing but never being called (dead code).
+    const src = fs.readFileSync(
+      path.join(process.cwd(), 'src', 'core', 'PostUpdateMigrator.ts'), 'utf8',
+    );
+    expect(src).toContain('this.migrateAutonomousStopHookTopicKeyed(result);');
+  });
+});

--- a/tests/unit/autonomous-skill-deployment.test.ts
+++ b/tests/unit/autonomous-skill-deployment.test.ts
@@ -135,7 +135,7 @@ describe('Autonomous stop hook source analysis', () => {
     expect(content).toContain('duration_seconds');
     expect(content).toContain('ELAPSED');
     // Must remove state file on expiry
-    expect(content).toContain('rm "$STATE_FILE"');
+    expect(content).toContain('rm -f "$STATE_FILE"');
   });
 
   it('checks for completion promise', () => {

--- a/tests/unit/autonomous-stop-hook-session-validation.test.ts
+++ b/tests/unit/autonomous-stop-hook-session-validation.test.ts
@@ -48,20 +48,21 @@ describe('Stop hook session_id UUID validation (source analysis)', () => {
     expect(HOOK_SRC).toMatch(/Invalid session_id.*not UUID/);
   });
 
-  it('preserves the self-bootstrap path for empty session_id', () => {
-    // After clearing an invalid session_id, the self-bootstrap block should fire
+  it('preserves the self-bootstrap path for empty session_id (now the backstop)', () => {
+    // After clearing an invalid session_id, the topic-unresolved backstop
+    // self-bootstraps: the first session to fire claims the job.
     expect(HOOK_SRC).toContain('if [[ -z "$STATE_SESSION" ]]; then');
-    expect(HOOK_SRC).toContain('claimed autonomous mode');
+    expect(HOOK_SRC).toContain('OWNER_METHOD="bootstrap"');
   });
 
-  it('UUID validation runs BEFORE hook session_id parsing', () => {
-    // The validation must run before HOOK_SESSION is parsed,
-    // so that an invalid STATE_SESSION is cleared before comparison
+  it('UUID validation precedes the session-match backstop comparison', () => {
+    // The validation must run before STATE_SESSION is compared to HOOK_SESSION
+    // in the backstop, so an invalid recorded value is cleared first.
     const validationIdx = HOOK_SRC.indexOf('UUID_REGEX=');
-    const hookSessionIdx = HOOK_SRC.indexOf('HOOK_SESSION=');
+    const backstopCmpIdx = HOOK_SRC.indexOf('"$STATE_SESSION" == "$HOOK_SESSION"');
     expect(validationIdx).toBeGreaterThan(-1);
-    expect(hookSessionIdx).toBeGreaterThan(-1);
-    expect(validationIdx).toBeLessThan(hookSessionIdx);
+    expect(backstopCmpIdx).toBeGreaterThan(-1);
+    expect(validationIdx).toBeLessThan(backstopCmpIdx);
   });
 });
 

--- a/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
+++ b/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
@@ -277,4 +277,38 @@ describe('T3 — liveness-gated backstop when topic resolution unavailable', () 
     expect(r.decision).not.toBe('block');
     expect(r.exitCode).toBe(0);
   });
+
+  it('topic set but ABSENT from the registry degrades to the session backstop', () => {
+    // Registry exists with a tmux name but no entry for our report_topic.
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' });
+    writeRegistry({ '5555': 'some-other-session' }); // 9984 not present
+    // Same session id → backstop session-match → block (not a foreign exit).
+    const r = runHook({ sessionId: OLD_UUID, tmuxSession: 'echo-claude-agent-sdk' });
+    expect(r.decision).toBe('block');
+  });
+});
+
+describe('Robustness — fail-safe on bad inputs (review-driven)', () => {
+  it('does NOT prematurely expire when started_at is unparseable', () => {
+    // Malformed started_at must never cause a premature exit (review finding).
+    fs.writeFileSync(
+      path.join(tmpDir, '.instar', 'autonomous-state.local.md'),
+      `---\nactive: true\niteration: 1\nsession_id: "${OLD_UUID}"\nduration_seconds: 10\nstarted_at: "not-a-timestamp"\nreport_topic: "9984"\ncompletion_promise: "X"\n---\n\ntask\n`,
+    );
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+    const r = runHook({ sessionId: OLD_UUID, tmuxSession: 'echo-claude-agent-sdk' });
+    expect(r.decision).toBe('block'); // keeps running, not a false expiry
+  });
+
+  it('degrades to the backstop when the registry is malformed JSON', () => {
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' });
+    fs.writeFileSync(
+      path.join(tmpDir, '.instar', 'topic-session-registry.json'),
+      '{ this is not valid json',
+    );
+    // Topic unresolved → backstop; same session id → block (no crash, no foreign exit).
+    const r = runHook({ sessionId: OLD_UUID, tmuxSession: 'echo-claude-agent-sdk' });
+    expect(r.decision).toBe('block');
+    expect(r.exitCode).toBe(0);
+  });
 });

--- a/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
+++ b/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
@@ -51,6 +51,7 @@ function writeState(opts: {
   active?: boolean;
   sessionId?: string;
   reportTopic?: string;
+  reportChannel?: string;
   iteration?: number;
   durationSeconds?: number;
   completionPromise?: string;
@@ -61,6 +62,7 @@ function writeState(opts: {
     active = true,
     sessionId = OLD_UUID,
     reportTopic = '9984',
+    reportChannel,
     iteration = 1,
     durationSeconds = 0,
     completionPromise = 'ALL_DONE',
@@ -68,6 +70,7 @@ function writeState(opts: {
     task = 'Keep building the thing until done.',
   } = opts;
   const started = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  const channelLine = reportChannel ? `\nreport_channel: "${reportChannel}"` : '';
   const content = `---
 active: ${active}
 iteration: ${iteration}
@@ -75,7 +78,7 @@ session_id: "${sessionId}"
 goal: "test goal"
 duration_seconds: ${durationSeconds}
 started_at: "${started}"
-report_topic: "${reportTopic}"
+report_topic: "${reportTopic}"${channelLine}
 report_interval: "2h"
 completion_promise: "${completionPromise}"${extraFrontmatter ? '\n' + extraFrontmatter : ''}
 ---
@@ -215,6 +218,43 @@ describe('T4 — one-line recovery note, exactly once', () => {
     expect(r2.decision).toBe('block');
     const after2 = fs.readFileSync(auditPath, 'utf-8').trim().split('\n').filter(Boolean);
     expect(after2.length).toBe(1);
+  });
+});
+
+describe('Channel-neutral delivery seam (recovery note routes by channel)', () => {
+  function readAudit(): any[] {
+    const p = path.join(tmpDir, '.instar', 'autonomous-recovery.jsonl');
+    if (!fs.existsSync(p)) return [];
+    return fs.readFileSync(p, 'utf-8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  }
+
+  it('records channel=telegram by default (back-compat, no report_channel)', () => {
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' }); // no report_channel
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+    const r = runHook({
+      sessionId: NEW_UUID, tmuxSession: 'echo-claude-agent-sdk',
+      transcriptPath: writeTranscript(NEW_UUID, 0),
+    });
+    expect(r.decision).toBe('block');
+    const audit = readAudit();
+    expect(audit.length).toBe(1);
+    expect(audit[0].channel).toBe('telegram');
+  });
+
+  it('routes a non-Telegram channel without erroring and records that channel', () => {
+    // A Slack-owned job: the hook must NOT assume Telegram. It records channel=slack
+    // and continues (live Slack delivery is owned by the Channel Parity initiative).
+    writeState({ sessionId: OLD_UUID, reportTopic: 'C123', reportChannel: 'slack' });
+    writeRegistry({ C123: 'echo-claude-agent-sdk' });
+    const r = runHook({
+      sessionId: NEW_UUID, tmuxSession: 'echo-claude-agent-sdk',
+      transcriptPath: writeTranscript(NEW_UUID, 0),
+    });
+    expect(r.decision).toBe('block'); // autonomy still survives the restart
+    const audit = readAudit();
+    expect(audit.length).toBe(1);
+    expect(audit[0].channel).toBe('slack');
+    expect(audit[0].topic).toBe('C123');
   });
 });
 

--- a/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
+++ b/tests/unit/autonomous-stop-hook-topic-keyed.test.ts
@@ -1,0 +1,280 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir; SafeFsExecutor migration tracked separately.
+/**
+ * Autonomous stop hook — topic-keyed ownership (behavioral tests).
+ *
+ * Root cause of the bug this fixes: the hook keyed autonomous-session ownership
+ * on the Claude session UUID. A memory-limit restart rotates the UUID but the
+ * state file keeps the old one, so the hook saw a mismatch, failed open, and let
+ * the (still-running) restarted session exit. Autonomy died silently for hours.
+ *
+ * The fix keys ownership on the TOPIC the session is serving (resolved from the
+ * tmux session name via the topic-session registry — a stable "address" that
+ * survives restarts), demotes session-id matching to a liveness-gated backstop,
+ * and emits a one-line recovery note exactly once when a restart-resume happens.
+ *
+ * These tests EXECUTE the hook (unlike the older source-analysis test) against a
+ * temp working dir, driving it with crafted state, registry, and hook input.
+ *
+ * Test seam: the hook resolves its own tmux session name from
+ * `INSTAR_HOOK_TMUX_SESSION` when set, falling back to `tmux display-message`.
+ * This lets us simulate "which session am I" deterministically.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const HOOK_PATH = path.join(
+  process.cwd(),
+  '.claude',
+  'skills',
+  'autonomous',
+  'hooks',
+  'autonomous-stop-hook.sh',
+);
+
+const OLD_UUID = '04db2de7-8e82-4baf-9136-7a067bb2ec53';
+const NEW_UUID = 'a13495fb-bbb5-4a90-8c72-aa1e0e9e395e';
+
+interface RunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  decision: string | null;
+}
+
+let tmpDir: string;
+
+function writeState(opts: {
+  active?: boolean;
+  sessionId?: string;
+  reportTopic?: string;
+  iteration?: number;
+  durationSeconds?: number;
+  completionPromise?: string;
+  extraFrontmatter?: string;
+  task?: string;
+}): void {
+  const {
+    active = true,
+    sessionId = OLD_UUID,
+    reportTopic = '9984',
+    iteration = 1,
+    durationSeconds = 0,
+    completionPromise = 'ALL_DONE',
+    extraFrontmatter = '',
+    task = 'Keep building the thing until done.',
+  } = opts;
+  const started = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  const content = `---
+active: ${active}
+iteration: ${iteration}
+session_id: "${sessionId}"
+goal: "test goal"
+duration_seconds: ${durationSeconds}
+started_at: "${started}"
+report_topic: "${reportTopic}"
+report_interval: "2h"
+completion_promise: "${completionPromise}"${extraFrontmatter ? '\n' + extraFrontmatter : ''}
+---
+
+${task}
+`;
+  fs.writeFileSync(path.join(tmpDir, '.instar', 'autonomous-state.local.md'), content);
+}
+
+function writeRegistry(topicToSession: Record<string, string>): void {
+  fs.writeFileSync(
+    path.join(tmpDir, '.instar', 'topic-session-registry.json'),
+    JSON.stringify({ topicToSession, topicToName: {} }, null, 2),
+  );
+}
+
+/** Create a fake transcript jsonl for a given UUID under the claude projects layout
+ *  mirrored inside tmpDir, with a controllable mtime (seconds-ago). */
+function writeTranscript(uuid: string, secondsAgo: number, lastText = ''): string {
+  const projDir = path.join(tmpDir, 'claude-projects');
+  fs.mkdirSync(projDir, { recursive: true });
+  const p = path.join(projDir, `${uuid}.jsonl`);
+  const line = JSON.stringify({
+    role: 'assistant',
+    message: { content: [{ type: 'text', text: lastText }] },
+  });
+  fs.writeFileSync(p, line + '\n');
+  const when = Date.now() - secondsAgo * 1000;
+  fs.utimesSync(p, when / 1000, when / 1000);
+  return p;
+}
+
+function runHook(opts: {
+  sessionId: string;
+  transcriptPath?: string;
+  tmuxSession?: string;
+}): RunResult {
+  const input = JSON.stringify({
+    session_id: opts.sessionId,
+    transcript_path: opts.transcriptPath ?? '',
+  });
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (opts.tmuxSession !== undefined) {
+    env.INSTAR_HOOK_TMUX_SESSION = opts.tmuxSession;
+  } else {
+    // Force "no tmux" so tests don't accidentally resolve the real session.
+    env.INSTAR_HOOK_TMUX_SESSION = '';
+    env.INSTAR_HOOK_NO_TMUX = '1';
+  }
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync('bash', [HOOK_PATH], {
+      cwd: tmpDir,
+      input,
+      env,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err: any) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+    stderr = err.stderr?.toString() ?? '';
+  }
+  let decision: string | null = null;
+  try {
+    const parsed = JSON.parse(stdout.trim());
+    decision = parsed.decision ?? null;
+  } catch {
+    decision = null;
+  }
+  return { exitCode, stdout, stderr, decision };
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-topic-hook-'));
+  fs.mkdirSync(path.join(tmpDir, '.instar'), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('T1 — restart survives (the core regression)', () => {
+  it('BLOCKS exit when a restarted session (new UUID) still serves the job topic', () => {
+    // State recorded under the OLD uuid; registry maps topic 9984 -> our tmux name.
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' });
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+    // The hook fires with the NEW uuid but is running in the SAME tmux session.
+    const r = runHook({
+      sessionId: NEW_UUID,
+      tmuxSession: 'echo-claude-agent-sdk',
+      transcriptPath: writeTranscript(NEW_UUID, 0),
+    });
+    expect(r.decision).toBe('block');
+  });
+});
+
+describe('T2 — foreign topic is never trapped', () => {
+  it('ALLOWS exit when the session serves a different topic than the job', () => {
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' });
+    writeRegistry({ '9984': 'echo-claude-agent-sdk', '12143': 'echo-autonomous-mode-redesign' });
+    const r = runHook({
+      sessionId: NEW_UUID,
+      tmuxSession: 'echo-autonomous-mode-redesign', // topic 12143, not the job's 9984
+      transcriptPath: writeTranscript(NEW_UUID, 0),
+    });
+    expect(r.decision).not.toBe('block');
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe('T4 — one-line recovery note, exactly once', () => {
+  it('writes a recovery audit entry on restart-resume and dedupes on repeat', () => {
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' });
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+    const auditPath = path.join(tmpDir, '.instar', 'autonomous-recovery.jsonl');
+
+    // First fire after restart: should block AND record one recovery note.
+    const r1 = runHook({
+      sessionId: NEW_UUID,
+      tmuxSession: 'echo-claude-agent-sdk',
+      transcriptPath: writeTranscript(NEW_UUID, 0),
+    });
+    expect(r1.decision).toBe('block');
+    expect(fs.existsSync(auditPath)).toBe(true);
+    const after1 = fs.readFileSync(auditPath, 'utf-8').trim().split('\n').filter(Boolean);
+    expect(after1.length).toBe(1);
+
+    // Second fire, SAME (new) session id: still blocks, but NO new recovery note.
+    const r2 = runHook({
+      sessionId: NEW_UUID,
+      tmuxSession: 'echo-claude-agent-sdk',
+      transcriptPath: writeTranscript(NEW_UUID, 0),
+    });
+    expect(r2.decision).toBe('block');
+    const after2 = fs.readFileSync(auditPath, 'utf-8').trim().split('\n').filter(Boolean);
+    expect(after2.length).toBe(1);
+  });
+});
+
+describe('T5 — existing exit paths preserved', () => {
+  it('ALLOWS exit when autonomous mode is inactive', () => {
+    writeState({ active: false });
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+    const r = runHook({ sessionId: NEW_UUID, tmuxSession: 'echo-claude-agent-sdk' });
+    expect(r.decision).not.toBe('block');
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('ALLOWS exit when there is no state file at all', () => {
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+    const r = runHook({ sessionId: NEW_UUID, tmuxSession: 'echo-claude-agent-sdk' });
+    expect(r.decision).not.toBe('block');
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('ALLOWS exit when duration has expired', () => {
+    // started_at is "now" but duration is 1s and we backdate via a long-past start.
+    const past = new Date(Date.now() - 3600 * 1000).toISOString().replace(/\.\d+Z$/, 'Z');
+    fs.writeFileSync(
+      path.join(tmpDir, '.instar', 'autonomous-state.local.md'),
+      `---\nactive: true\niteration: 1\nsession_id: "${OLD_UUID}"\nduration_seconds: 10\nstarted_at: "${past}"\nreport_topic: "9984"\ncompletion_promise: "X"\n---\n\ntask\n`,
+    );
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+    const r = runHook({ sessionId: NEW_UUID, tmuxSession: 'echo-claude-agent-sdk' });
+    expect(r.decision).not.toBe('block');
+  });
+});
+
+describe('T3 — liveness-gated backstop when topic resolution unavailable', () => {
+  it('matching session id (no tmux) still BLOCKS', () => {
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' });
+    writeRegistry({ '9984': 'echo-claude-agent-sdk' });
+    const r = runHook({ sessionId: OLD_UUID }); // no tmux; session id matches state
+    expect(r.decision).toBe('block');
+  });
+
+  it('mismatched session id with a DEAD recorded owner adopts + BLOCKS', () => {
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' });
+    writeRegistry({}); // topic not resolvable
+    writeTranscript(OLD_UUID, 600); // recorded owner's transcript stale (10 min) => dead
+    const r = runHook({
+      sessionId: NEW_UUID,
+      transcriptPath: writeTranscript(NEW_UUID, 0),
+    });
+    expect(r.decision).toBe('block');
+  });
+
+  it('mismatched session id with a LIVE recorded owner allows exit (no steal)', () => {
+    writeState({ sessionId: OLD_UUID, reportTopic: '9984' });
+    writeRegistry({});
+    writeTranscript(OLD_UUID, 1); // recorded owner's transcript fresh => alive
+    const r = runHook({
+      sessionId: NEW_UUID,
+      transcriptPath: writeTranscript(NEW_UUID, 0),
+    });
+    expect(r.decision).not.toBe('block');
+    expect(r.exitCode).toBe(0);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -26,11 +26,18 @@ adopted, a live one is left alone.
 
 **New: one-line recovery note on restart-resume.** When a real restart-and-resume
 happens (topic verified, UUID changed), the hook writes one audit record to
-`.instar/autonomous-recovery.jsonl` and best-effort delivers a single Telegram line to
-the job's topic — *"Heads up — my session restarted mid-run and I've picked the
-autonomous job back up. No action needed."* — exactly once per restart. A silent
-self-heal would have left "recovered cleanly" indistinguishable from "died unnoticed";
-the note closes that blind spot.
+`.instar/autonomous-recovery.jsonl` and best-effort delivers a single line to the job's
+owner — *"Heads up — my session restarted mid-run and I've picked the autonomous job
+back up. No action needed."* — exactly once per restart. A silent self-heal would have
+left "recovered cleanly" indistinguishable from "died unnoticed"; the note closes that
+blind spot.
+
+**Channel-neutral delivery.** The recovery note routes to whichever channel owns the job
+(`report_channel` in the autonomous state, default `telegram`) via a `deliver_recovery_note`
+seam — the hook makes no Telegram assumption. Telegram is wired now; Slack/WhatsApp/iMessage
+delivery is owned by the Channel Parity initiative and is recorded to the channel-neutral
+audit trail until that lands (never a silent Telegram misfire). `setup-autonomous.sh` accepts
+`--report-channel`.
 
 **Collateral fixes in the same hook:**
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -62,3 +62,45 @@ guarded (leaves customized hooks untouched). No action required.
 New tuning knobs (env, optional): `INSTAR_AUTONOMOUS_LIVENESS_SECS` (backstop liveness
 threshold, default 120) and `INSTAR_HOOK_TMUX_SESSION` (test/override seam for the
 session's tmux name).
+
+## What to Tell Your User
+
+Autonomous mode used to go silently dead if a long run restarted mid-job — it would
+just stop working and you'd only notice when you poked it. That's fixed: a restarted
+session now keeps going on its own, and you get one short heads-up ("I restarted
+mid-run and picked the job back up — no action needed") only when it actually happens.
+Nothing to do; it's automatic, and existing agents get the fix on their next update.
+
+## Summary of New Capabilities
+
+- Autonomous-mode ownership is keyed on the job's **topic** (stable across restarts),
+  not the session UUID — restarts no longer silently kill autonomy.
+- Liveness-gated **backstop** for the rare case where topic resolution is unavailable.
+- One **channel-neutral recovery note** per restart (audit trail + best-effort delivery
+  to whatever channel owns the job; Telegram wired, others via the Channel Parity
+  initiative).
+- Idempotent migration so existing agents receive the new hook.
+- Collateral: timezone fix, pipefail-safe frontmatter parsing, fail-safe duration expiry.
+
+## Evidence
+
+**Reproduced before fixing (RED).** A behavioral test drives the *old* hook with a
+simulated memory-limit restart — state recorded under session UUID `04db2de7…`, hook
+fires with a new UUID `a13495fb…` while still serving the same topic (registry maps the
+topic to the session's tmux name). Observed: the old hook sees the UUID mismatch, fails
+open, and returns no block decision (exit 0) — i.e. it **allows the restarted autonomous
+session to exit**. That is the silent death, reproduced deterministically.
+
+**After the fix (GREEN).** Same inputs: the hook resolves the topic from the tmux name,
+matches it against the job's `report_topic`, and returns `{"decision":"block"}` — autonomy
+survives. The end-to-end lifecycle test (`tests/e2e/autonomous-restart-resume-lifecycle`)
+runs the real hook through bootstrap → restart (rotated UUID) → exactly one recovery note
+→ dedup → completion, asserting the audit trail has exactly one restart-resume entry.
+
+**Timezone bug** verified directly: `date -j -f "%Y-%m-%dT%H:%M:%SZ" "2026-05-23T23:44:25Z"`
+returned `1779605065` (parsed as local), vs `date -u -j -f …` → `1779579865`, matching
+Python's UTC epoch — a 7-hour (local-offset) skew, now corrected with `-u`.
+
+Test tiers: 14 unit (incl. the RED→GREEN restart case + channel-seam cases), 5 migrator
+integration (incl. a wiring/anti-dead-code guard), 1 e2e lifecycle — all green; 36
+PostUpdateMigrator-related tests green (no regression).

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,57 @@
+# Upgrade Guide — NEXT (topic-keyed autonomous-mode session identity)
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**Fix: autonomous mode no longer dies silently when a long run restarts.**
+
+Autonomous mode keeps a session working until its job is done, enforced by the
+`autonomous-stop-hook.sh` Stop hook. The hook decided "is THIS session the autonomous
+worker?" by the Claude **session UUID**. A long run hits the memory limit and restarts
+with a **new** UUID, but the state file still held the old one — so the hook saw a
+mismatch, failed open, and let the (still-running) restarted session exit. Autonomy was
+silently dead for hours until the user poked it.
+
+The hook now keys ownership on the **topic** the session serves — a stable "address"
+that survives restarts — resolved from the tmux session name via
+`.instar/topic-session-registry.json` (`topicToSession`). Because `SessionRecovery`
+respawns a restarted session into the **same** tmux name, the restarted session is
+still recognized as the job's owner. Session-UUID matching is demoted to a
+**liveness-gated backstop** for the rare case where topic resolution is unavailable
+(no tmux, or the topic isn't in the registry): a UUID mismatch is resolved by checking
+whether the recorded owner's transcript is still growing — a dead owner's job is
+adopted, a live one is left alone.
+
+**New: one-line recovery note on restart-resume.** When a real restart-and-resume
+happens (topic verified, UUID changed), the hook writes one audit record to
+`.instar/autonomous-recovery.jsonl` and best-effort delivers a single Telegram line to
+the job's topic — *"Heads up — my session restarted mid-run and I've picked the
+autonomous job back up. No action needed."* — exactly once per restart. A silent
+self-heal would have left "recovered cleanly" indistinguishable from "died unnoticed";
+the note closes that blind spot.
+
+**Collateral fixes in the same hook:**
+
+- **Timezone bug:** `date -j -f "...Z"` parsed UTC timestamps as local time, skewing
+  duration and report-interval math by the local offset. Added `-u` to the three BSD
+  date-parse callsites.
+- **Pipefail fragility:** under `set -uo pipefail`, a `grep` for an absent optional
+  frontmatter key (`last_report_at`) aborted the whole hook. Frontmatter reads now use a
+  pipefail-safe `fm_get` helper.
+- **Fail-safe expiry:** an unparseable `started_at` would inflate elapsed time and
+  prematurely expire the run. The duration-expiry check now only fires when `started_at`
+  parsed to a positive epoch; otherwise it logs and keeps running.
+
+## Migration Notes
+
+Existing agents receive the updated hook automatically. `installAutonomousSkill()` is
+install-if-missing, so a dedicated idempotent migration
+(`PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed`) re-copies the bundled hook on
+update — content-sniff guarded (skips if already topic-keyed) and stock-fingerprint
+guarded (leaves customized hooks untouched). No action required.
+
+New tuning knobs (env, optional): `INSTAR_AUTONOMOUS_LIVENESS_SECS` (backstop liveness
+threshold, default 120) and `INSTAR_HOOK_TMUX_SESSION` (test/override seam for the
+session's tmux name).

--- a/upgrades/side-effects/autonomous-topic-keyed-identity.md
+++ b/upgrades/side-effects/autonomous-topic-keyed-identity.md
@@ -1,0 +1,105 @@
+# Side-Effects Review — Topic-keyed autonomous-mode session identity
+
+**Version / slug:** `autonomous-topic-keyed-identity`
+**Date:** 2026-05-23
+**Author:** echo
+**Second-pass reviewer:** two Explore review agents (correctness + edge/race) — findings folded in below
+
+## Summary of the change
+
+Rewrites `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh` to key autonomous-job
+ownership on the **topic** the session serves (resolved from the tmux session name via
+`.instar/topic-session-registry.json`) instead of the volatile Claude session UUID, so a
+memory-limit restart no longer mismatches the state file and silently lets autonomy die.
+Session-id matching is demoted to a liveness-gated backstop. A one-line recovery note
+(durable audit + best-effort Telegram) fires exactly once per restart. Also fixes a
+timezone bug, a pipefail-on-absent-field fragility, and adds a fail-safe so an unparseable
+`started_at` cannot cause a premature exit. The only `src/` file touched is
+`src/core/PostUpdateMigrator.ts`, which gains an idempotent migration so existing agents
+receive the new hook (`installAutonomousSkill()` is install-if-missing).
+
+## Decision-point inventory
+
+- `autonomous-stop-hook.sh` — ownership decision (block vs allow exit) — **modify**: primary
+  key changed from session-UUID to topic; liveness-gated session backstop added.
+- `autonomous-stop-hook.sh` — recovery-note emission — **add**: once-per-restart side effect
+  (audit write + best-effort message).
+- `PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed` — **add**: idempotent content
+  migration, no decision/gating logic.
+
+## 1. Over-block (trapping a session that should be allowed to exit)
+
+- A foreign session (different topic) is explicitly allowed to exit when topic resolution is
+  conclusive — covered by test T2.
+- In the backstop, a session whose UUID mismatches a **live** recorded owner is allowed to
+  exit (no steal) — covered by T3.
+- Residual: if the registry maps `report_topic` to a tmux name that is NOT the current
+  session, the current session exits — correct (it's not the owner). The only way to wrongly
+  over-block is a stale registry pointing the topic at *this* session after the job moved;
+  that requires the registry itself to be wrong, which is outside this hook's authority.
+
+## 2. Under-block (allowing the real autonomous session to exit — the original bug)
+
+- The core regression is closed: a restarted session (new UUID, same topic) blocks — T1 + the
+  e2e lifecycle.
+- Fail-safe added so an unparseable `started_at` no longer inflates elapsed time into a false
+  duration-expiry exit (review finding; test added).
+- Backstop adopts a job whose recorded owner is provably stale (dead) rather than allowing
+  exit on a bare UUID mismatch (the old fail-open behavior).
+- Residual: in the no-tmux backstop, a genuinely busy live owner that has not written its
+  transcript for `>120s` could be judged stale and its job adopted by another fired session.
+  This only matters when topic resolution is unavailable (rare for instar-spawned autonomous
+  sessions, which always run in tmux), and the threshold is configurable
+  (`INSTAR_AUTONOMOUS_LIVENESS_SECS`). Accepted.
+
+## 3. Level-of-abstraction fit
+
+Correct. Ownership resolution reads the same `topic-session-registry.json` that
+`SessionManager.getTopicBinding` already uses, and the same per-session transcript that the
+completion-promise check already reads. No new state store, no new service dependency — the
+hook stays a self-contained bash Stop hook.
+
+## 4. Blocking authority
+
+- [x] Consumer of existing detectors (topic registry + transcript liveness), not a new brittle
+  check with blocking authority. The hook's blocking authority is exactly the pre-existing
+  autonomous-mode authority — unchanged in scope, only made restart-correct. No new gate.
+
+## 5. Interactions
+
+- **SessionRecovery / respawn:** relies on respawn reusing the same tmux session name (verified
+  in `respawnSession(topicId, sessionName, …)`). If that contract ever changed, topic resolution
+  would fail and the hook would fall back to the liveness backstop — degraded, not broken.
+- **Progress-report path:** unchanged; still injects the report directive. The recovery-note
+  write is independent and additive.
+- **State-file mutations:** all use the existing temp-file + `mv` atomic pattern; the new
+  `record_session_id` follows suit. Concurrent fires use distinct `$$`-suffixed temp files.
+- **Other migrations:** `migrateAutonomousStopHookTopicKeyed` is order-independent (content-sniff
+  guarded) and idempotent; it neither reads nor writes state other migrations touch.
+
+## 6. External surfaces
+
+- **Channel-neutral delivery:** one best-effort outbound message per restart, routed to the
+  channel that owns the job (`report_channel`, default `telegram`) via a `deliver_recovery_note`
+  seam. Telegram wired via `telegram-reply.sh`; other channels (slack/whatsapp/imessage) are
+  owned by the Channel Parity initiative (Telegram topic 12270) and are recorded to the audit
+  trail without a silent Telegram misfire. No new endpoint, no new credential use. Failure is
+  swallowed (the audit record is the durable signal). The design deliberately makes no Telegram
+  assumption (user caveat, 2026-05-23).
+- **Filesystem:** new append-only `.instar/autonomous-recovery.jsonl` audit file (created on
+  first restart-resume), carrying a channel-neutral `channel` field. No reads outside the
+  project dir.
+
+## 7. Rollback cost
+
+Low. The hook is a single self-contained file; reverting the commit restores the prior
+behavior. The migration is content-sniff guarded, so a rollback that re-ships the old bundled
+hook would (on the next update) detect the topic-keyed marker absent and re-deploy the old hook
+— clean. No schema, no persisted state migration, no irreversible side effect. The audit file
+is additive and harmless if left behind.
+
+## 8. Test evidence
+
+RED reproduced first (restart-survives fails on the old hook). All three tiers green:
+12 unit behavioral cases, 5 migrator integration cases (incl. wiring/anti-dead-code), 1 e2e
+lifecycle. 36 PostUpdateMigrator-related tests green (no regression in the touched module).


### PR DESCRIPTION
## Problem

Autonomous mode keeps a session working until done, enforced by `autonomous-stop-hook.sh`. Ownership ("is THIS session the autonomous worker?") was keyed on the **Claude session UUID**. A long run hits the memory limit and restarts with a **new** UUID, but the state file still held the old one → the hook saw a mismatch, **failed open**, and let the still-running restarted session exit. Autonomy died silently for hours until the user poked it (observed 2026-05-23).

## Fix

Key ownership on the **topic** the session serves — a stable "address" resolved from the tmux session name via `topic-session-registry.json`. `SessionRecovery` respawns a restarted session into the **same** tmux name, so the restarted session is still recognized as the owner. Session-UUID matching is demoted to a **liveness-gated backstop** (only when topic resolution is unavailable; a UUID mismatch is resolved by checking the recorded owner's transcript freshness — adopt a dead owner, leave a live one).

**One channel-neutral recovery note** per restart: a durable audit record (`.instar/autonomous-recovery.jsonl`, carries `channel`) plus best-effort delivery to whichever channel owns the job (`report_channel`, default `telegram`) via a `deliver_recovery_note` seam — **no Telegram assumption baked in**. Wiring the remaining channels is the separate **Channel Parity initiative**.

**Collateral fixes in the same hook:** UTC-parsed-as-local **timezone bug** (`-u` added to BSD `date -j -f`), **pipefail crash** on an absent optional frontmatter key (`fm_get` helper), and a **fail-safe** so an unparseable `started_at` can't trigger a premature exit.

**Migration:** `installAutonomousSkill()` is install-if-missing, so existing agents get the fix via an idempotent `PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed` (content-sniff + stock-fingerprint guarded, wired into `run()`).

## Evidence

RED reproduced first (restart-survives fails on the old hook), GREEN after. See `upgrades/NEXT.md` → Evidence for the reproduction + the direct timezone-skew verification.

## Tests (all green)

- Unit: 14 behavioral cases driving the real hook (restart-survives, foreign-topic-exits, liveness backstop both sides, recovery-note-once+dedup, channel-seam, fail-safe/robustness) + updated source-analysis tests
- Integration: 5 migrator cases (upgrade / idempotent / customized-untouched / no-op / **wiring anti-dead-code guard**)
- E2E: full restart-resume lifecycle
- Full pre-push suite: 2397 tests green

## Docs / governance

Approved spec `docs/specs/autonomous-topic-keyed-identity.md` (+ ELI16 overview), side-effects review `upgrades/side-effects/autonomous-topic-keyed-identity.md`, release note `upgrades/NEXT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)