### PR TITLE
feat(autonomous): independent completion evaluator (adopts the /goal pattern)

### DIFF
--- a/.claude/skills/autonomous/SKILL.md
+++ b/.claude/skills/autonomous/SKILL.md
@@ -162,7 +162,16 @@ The stop hook will catch every attempt to exit and feed your task list back. Eac
 
 ## Step 4: Completion
 
-When ALL tasks are genuinely done:
+**Preferred: a verifiable completion CONDITION (independent judge, like /goal).**
+Pass `--completion-condition "<measurable end-state>"` when starting (e.g. "all tests in
+test/auth pass and `npm test` exits 0"). Each turn, an INDEPENDENT model judges the condition
+against what you've SURFACED in the conversation — so *run the real checks and show the
+evidence in your output*. When the judge confirms it, the hook exits automatically. You do not
+self-declare done. If the judge can't be reached, the run keeps going (fail-safe). This mirrors
+the framework `/goal` feature and is harder to fool than a self-declared promise.
+
+**Legacy fallback: self-declared promise.** If no condition is set, when ALL tasks are
+genuinely done:
 
 1. Verify every task is complete (re-read the list)
 2. Run `npx tsc --noEmit` — zero errors
@@ -171,7 +180,7 @@ When ALL tasks are genuinely done:
 5. Send final report via messaging
 6. Output: `<promise>ALL_TASKS_COMPLETE</promise>`
 
-The stop hook will detect the promise and allow exit.
+The stop hook detects the promise and allows exit.
 
 ---
 

--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -145,6 +145,7 @@ ITERATION=$(fm_get iteration)
 DURATION_SECONDS=$(fm_get duration_seconds)
 STARTED_AT=$(fm_get started_at)
 COMPLETION_PROMISE=$(fm_get completion_promise)
+COMPLETION_CONDITION=$(fm_get completion_condition)
 
 # Validate recorded session_id is a real UUID. Claude sometimes writes a custom
 # string instead of $CLAUDE_CODE_SESSION_ID; non-UUID values are treated as
@@ -267,7 +268,37 @@ if [[ -f ".instar/autonomous-emergency-stop" ]]; then
   exit 0
 fi
 
-# Completion promise (genuine completion)
+# Completion CONDITION — independent evaluator (mirrors /goal). Authoritative when
+# set; the self-declared promise below is the legacy fallback. FAIL-SAFE: if the
+# evaluator is unreachable or unsure, we keep working — never a false "done".
+EVAL_REASON=""
+if [[ -n "$COMPLETION_CONDITION" ]] && [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TRANSCRIPT_PATH" ]]; then
+  EVAL_MET=""
+  if [[ -n "${INSTAR_HOOK_EVAL_OVERRIDE:-}" ]]; then
+    # Test seam: "met" | "not-met" short-circuits the live evaluator call.
+    [[ "$INSTAR_HOOK_EVAL_OVERRIDE" == "met" ]] && EVAL_MET="true"
+    EVAL_REASON="override:$INSTAR_HOOK_EVAL_OVERRIDE"
+  else
+    EVAL_TAIL=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" 2>/dev/null | tail -6 \
+      | jq -r '.message.content | map(select(.type=="text")) | map(.text) | join("\n")' 2>/dev/null \
+      | tail -c 8000 || echo "")
+    EVAL_PORT=$(python3 -c "import json;print(json.load(open('.instar/config.json')).get('port',4040))" 2>/dev/null || echo 4040)
+    EVAL_AUTH=$(python3 -c "import json;print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null || echo "")
+    EVAL_RESP=$(jq -nc --arg c "$COMPLETION_CONDITION" --arg t "$EVAL_TAIL" '{condition:$c,transcriptTail:$t}' \
+      | curl -s -m 35 -H "Authorization: Bearer $EVAL_AUTH" -H 'Content-Type: application/json' \
+        --data-binary @- "http://localhost:${EVAL_PORT}/autonomous/evaluate-completion" 2>/dev/null || echo "")
+    EVAL_MET=$(printf '%s' "$EVAL_RESP" | jq -r '.met // empty' 2>/dev/null || echo "")
+    EVAL_REASON=$(printf '%s' "$EVAL_RESP" | jq -r '.reason // empty' 2>/dev/null || echo "")
+  fi
+  if [[ "$EVAL_MET" == "true" ]]; then
+    echo "✅ Autonomous mode: completion condition met (independent evaluator): ${EVAL_REASON}"
+    rm -f "$STATE_FILE"
+    exit 0
+  fi
+  # Not met / unreachable → keep working; EVAL_REASON (if any) becomes next-turn guidance.
+fi
+
+# Completion promise (genuine completion — legacy/self-declared fallback)
 if [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TRANSCRIPT_PATH" ]]; then
   LAST_LINE=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" 2>/dev/null | tail -1 || echo "")
   if [[ -n "$LAST_LINE" ]]; then
@@ -393,7 +424,16 @@ else
   TIME_MSG="no time limit"
 fi
 
-SYSTEM_MSG="🔄 Autonomous iteration $NEXT_ITERATION ($TIME_MSG) | Complete ALL tasks, then output <promise>$COMPLETION_PROMISE</promise> | Do NOT defer to future self — if you can do it now, DO IT NOW${REPORT_DIRECTIVE}"
+# When a completion CONDITION is set, an independent judge decides "done" — steer
+# toward the condition + feed back the judge's latest reason (mirrors /goal). When
+# only a legacy promise is set, keep the self-declared-promise directive.
+if [[ -n "$COMPLETION_CONDITION" ]]; then
+  GUIDANCE=""
+  [[ -n "$EVAL_REASON" ]] && GUIDANCE=" | Not done yet: ${EVAL_REASON}"
+  SYSTEM_MSG="🔄 Autonomous iteration $NEXT_ITERATION ($TIME_MSG) | Keep working until this is TRUE: ${COMPLETION_CONDITION}${GUIDANCE} | An independent check decides done from what you SURFACE — run the real checks and show the evidence. Do NOT defer — do it now${REPORT_DIRECTIVE}"
+else
+  SYSTEM_MSG="🔄 Autonomous iteration $NEXT_ITERATION ($TIME_MSG) | Complete ALL tasks, then output <promise>$COMPLETION_PROMISE</promise> | Do NOT defer to future self — if you can do it now, DO IT NOW${REPORT_DIRECTIVE}"
+fi
 
 # Block exit and feed prompt back
 jq -n \

--- a/.claude/skills/autonomous/scripts/setup-autonomous.sh
+++ b/.claude/skills/autonomous/scripts/setup-autonomous.sh
@@ -14,6 +14,7 @@ REPORT_CHANNEL="telegram"   # channel that owns this job; recovery note routes h
 LEVEL_UP="false"
 TASKS=""
 COMPLETION_PROMISE=""
+COMPLETION_CONDITION=""   # verifiable end-state; an independent judge decides "done" (mirrors /goal). Preferred over the self-declared promise.
 REPORT_INTERVAL="30m"
 
 while [[ $# -gt 0 ]]; do
@@ -44,6 +45,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --completion-promise)
       COMPLETION_PROMISE="$2"
+      shift 2
+      ;;
+    --completion-condition)
+      COMPLETION_CONDITION="$2"
       shift 2
       ;;
     --report-interval)
@@ -153,6 +158,7 @@ report_interval: "$REPORT_INTERVAL"
 last_report_at: ""
 level_up: $LEVEL_UP
 completion_promise: "$COMPLETION_PROMISE"
+completion_condition: "$COMPLETION_CONDITION"
 ---
 
 # Autonomous Session

--- a/docs/specs/goal-completion-evaluator.eli16.md
+++ b/docs/specs/goal-completion-evaluator.eli16.md
@@ -1,0 +1,36 @@
+# Independent "are we done?" judge for autonomous mode — Plain-English Overview
+
+> The one-line version: stop letting the worker decide it's finished, and bring in an independent judge to check a real finish-line — exactly how the new `/goal` feature works — and hand off to `/goal` itself where the framework already has it.
+
+## The problem in one breath
+
+When I'm working autonomously, the thing that decides "the job's done, I can stop" is *me saying so*. I can be wrong both ways — quit too early, or grind on after I'm actually done. The frameworks fixed this: their new `/goal` feature keeps an agent working until a *separate* model confirms a real, checkable finish-line.
+
+## What already exists
+
+- **Autonomous mode** — a safety latch keeps me working across turns until the job's done. Today "done" = I write a little "I promise it's done" token and the latch trusts it.
+- **`/goal`** (just shipped in Claude Code and Codex) — you set a finish-line condition and an independent judge model checks after every turn whether it's truly met. Claude's `/goal` is, under the hood, the *same kind of latch* I already use.
+- **Our own model-call plumbing** — instar already knows how to ask a small fast model a question (the same way our message-classifier and coherence checks do), with a daily spending cap.
+
+## What this adds
+
+- **An independent judge for "are we done?"** Instead of trusting my self-declared promise, the latch asks a fresh small model: "here's the finish-line and what just happened — is it met?" If no, keep going (with the judge's reason as a hint). If yes, stop. This works on *any* framework because it's our own judge.
+- **Hand-off to native `/goal` where it exists.** On Claude and Codex, we let *their* `/goal` judge run the loop and we stand our own judge down (no point running two). We keep doing the things `/goal` can't: juggling multiple topics at once, budget caps, messaging you, and safety.
+
+## The safeguards
+
+**No more grading my own homework.** A separate model decides done, against a measurable finish-line.
+
+**Never quits early by accident.** If our judge can't be reached (server down), we keep working rather than risk a false "done" — fail toward continuing.
+
+**No double-judging.** Where the framework's `/goal` is active, our judge steps aside.
+
+**The follow-up won't rot.** For v1 the judge reads the conversation (just like `/goal` does). Letting it run *real* checks itself (actually run the tests) is logged as a tracked commitment (ACT-152) that pings until it's done — not a comment that disappears. You specifically called this out, and it's handled.
+
+## What ships when
+
+Phase 1: our own independent judge (works everywhere) — the main win. Phase 2: hand off to native `/goal` where the framework has it. Each phase ships complete with its tests. Existing agents get it on their next update.
+
+## The decision (settled)
+
+You picked: run the judge every turn (tiny cost, capped), and v1 reads the conversation only — with the "run real checks too" enhancement tracked as a real commitment (ACT-152) that pings until it's done, not a someday-maybe.

--- a/docs/specs/goal-completion-evaluator.md
+++ b/docs/specs/goal-completion-evaluator.md
@@ -1,0 +1,102 @@
+---
+title: Autonomous mode — independent completion evaluator + native /goal leverage
+date: 2026-05-24
+author: echo
+review-convergence: internal-plus-conformance-2026-05-24
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 12143 (2026-05-24 — "Yes! Perfect! strong change", "GREAT if our autonomous skill leveraged /goal", then locked decisions "1) yes [evaluate every turn] 2) i agree [transcript-only v1; real-checks tracked as commitment ACT-152, not an untracked note]")
+eli16-overview: goal-completion-evaluator.eli16.md
+---
+
+# Autonomous mode — independent completion evaluator + native /goal leverage
+
+## Problem
+
+Instar's autonomous stop-hook decides "is the job done?" by scanning the transcript for a
+**self-declared** token: `<promise>$COMPLETION_PROMISE</promise>`. The agent grades its own
+homework — it can declare done prematurely or never declare when truly done. Both Claude Code
+`/goal` and Codex `/goal` solved this: keep working until an **independent** model confirms a
+**verifiable condition**. (Research: `.instar/reports/goal-skill-research.md`.) Notably,
+Claude Code's `/goal` is *itself a session-scoped prompt-based Stop hook* — the same mechanism
+class as `autonomous-stop-hook.sh` — so this is absorption, not a foreign bolt-on.
+
+## Design — CompletionEvaluator with two backends
+
+Completion becomes an independent judgment of a verifiable **condition** (a measurable
+end-state, not a free-text token), with two interchangeable backends:
+
+1. **Instar evaluator (default, framework-agnostic).** The stop-hook asks an independent model
+   (instar's `IntelligenceProvider`, small/fast tier, spend-capped by `LlmQueue`): "given this
+   condition + the recent transcript, is it met? yes/no + reason." Same contract as `/goal`
+   (judges what the agent surfaced; does not run tools). "No" → block + feed the reason back as
+   next-turn guidance. "Yes" → allow exit.
+2. **Native /goal delegation (when the framework provides it).** Where a native goal loop
+   exists (Claude Code ≥2.1.139 with hooks enabled; Codex `thread/goal`), the condition is set
+   as the native goal and the **native evaluator drives the loop**; instar's own evaluator
+   **stands down for that topic** — running both Stop-hook evaluators at once would double-fire.
+   Instar keeps the layer the native feature lacks: multi-topic orchestration, cap/quota,
+   messaging/recovery, emergency-stop, safety gates.
+
+Reuses existing infra: the `ThreadGoalSlot` capability (declared in the provider layer, its
+comment predating Claude's `/goal`) gates detection and is implemented for the Claude + Codex
+adapters; `IntelligenceProvider` + `LlmQueue` power the instar-side evaluator.
+
+## Locked decisions (Justin, topic 12143)
+
+- **Evaluate every turn** (matches `/goal`; small/fast tier; gated by the existing daily
+  `LlmQueue` spend cap).
+- **v1 evaluator is transcript-only** (matches `/goal` — judges what the agent surfaced). The
+  enhancement that lets the evaluator run real checks (`/verify-claim`: tests/build/grep) is a
+  **tracked commitment, ACT-152** (high priority, surfaced by the commitment-check job until
+  done, triggered on this PR's merge) — explicitly NOT an untracked future note, per Justin's
+  condition that it must not fall between the cracks.
+
+## Phasing
+
+**Phase 1 — Instar evaluator (the robustness win; framework-agnostic).**
+- State: add `completion_condition` (verifiable). Legacy `completion_promise` keeps working
+  (promise-only runs use the self-declared check) — back-compat.
+- Server: `POST /autonomous/evaluate-completion` — `{condition, transcriptTail}` → `{met, reason}`
+  via `IntelligenceProvider` (small/fast), spend-capped by `LlmQueue`.
+- Hook: when a condition is set, ask the evaluator each turn instead of trusting the promise;
+  block + feed reason on "no", allow exit on "yes". Fail-safe: server unreachable → fall back
+  to the promise check + keep running (never premature-exit). The `<promise>` path becomes a
+  legacy fallback, not removed.
+
+**Phase 2 — Native /goal leverage.**
+- Implement `ThreadGoalSlot` for the Claude (anthropic) + Codex adapters. Capability-detect at
+  autonomous start; where present, set the native goal = the condition, stand the instar
+  evaluator down for that topic, and read native status (Codex via its goal store; Claude via
+  transcript/headless). Where absent, Phase 1's instar evaluator runs (works everywhere).
+
+## Standards / parity
+- **Structure > Willpower:** completion is an independent gate, not agent self-report.
+- **Signal vs authority:** the evaluator is a full-context model judgment (condition +
+  transcript) — the loop's continue/stop authority, same as `/goal` — not a brittle filter.
+- **Migration parity:** hook + setup re-copied to existing agents (extend the existing
+  autonomous migration); new config/state fields existence-checked; CLAUDE.md awareness updated.
+- **Agent awareness:** CLAUDE.md template documents the condition + the evaluator.
+
+## Test plan (all three tiers)
+- **Unit:** evaluator decision both sides (met/not-met → allow/block+reason); condition path vs
+  legacy-promise fallback; server-unreachable fail-safe (keep running, no premature exit);
+  stand-down when native /goal active.
+- **Integration:** `POST /autonomous/evaluate-completion` returns the model's met/reason;
+  capability detection for ThreadGoalSlot.
+- **E2E:** a condition-driven autonomous run blocks while the condition is unmet and exits when
+  an independent evaluation confirms it (not when self-declared).
+
+## Acceptance criteria
+1. With a condition set, exit is gated by an independent evaluation, not a self-declared promise.
+2. Legacy promise-only runs still work.
+3. Server-down never causes a premature exit.
+4. Where native /goal exists, instar delegates and its own evaluator stands down (no double-fire).
+5. Existing agents receive it (migration parity); three tiers green; full suite green at push.
+
+## Risks
+- **Cost** (per-turn eval) — small/fast tier + `LlmQueue` daily cap.
+- **Evaluator wrong** — same risk class `/goal` accepts; mitigated by a well-formed condition +
+  the fail-safe (server-down → don't exit).
+- **Double-fire** (instar evaluator + native /goal) — Phase 2 stands instar's down when native
+  is active; explicit + tested.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7101,6 +7101,16 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.yellow('  Discovery evaluator: inactive (no IntelligenceProvider)'));
     }
 
+    // Independent autonomous-completion judge (mirrors /goal). Reuses the
+    // framework-aware sharedIntelligence; falls back to the self-declared promise
+    // when absent (the stop-hook handles that).
+    let completionEvaluator: import('../core/CompletionEvaluator.js').CompletionEvaluator | undefined;
+    if (sharedIntelligence) {
+      const { CompletionEvaluator } = await import('../core/CompletionEvaluator.js');
+      completionEvaluator = new CompletionEvaluator({ intelligence: sharedIntelligence });
+      console.log(pc.green('  Completion evaluator: active (independent /goal-style judge)'));
+    }
+
     // Register feature-discovery probe for self-knowledge tree (Phase 4: Agent Integration)
     if (selfKnowledgeTree && featureRegistry) {
       selfKnowledgeTree.probes.register('feature-discovery', async () => {
@@ -7464,7 +7474,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       });
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/core/CompletionEvaluator.ts
+++ b/src/core/CompletionEvaluator.ts
@@ -1,0 +1,103 @@
+/**
+ * CompletionEvaluator — independent "is the autonomous goal met?" judge.
+ *
+ * Replaces the autonomous stop-hook's self-declared `<promise>` check with an
+ * INDEPENDENT judgment: a small/fast model decides whether a verifiable
+ * completion CONDITION is met, judging only what the agent has surfaced in the
+ * recent transcript (it does not run tools — same contract as the framework
+ * `/goal` feature this mirrors). "Not met" returns a reason that the hook feeds
+ * back as next-turn guidance.
+ *
+ * This is the loop's continue/stop authority — a full-context model judgment
+ * (condition + transcript), not a brittle low-context filter. Runs on the
+ * shared IntelligenceProvider (Claude/Codex subscription or API), `fast` tier,
+ * spend-capped upstream by LlmQueue.
+ *
+ * Spec: docs/specs/goal-completion-evaluator.md
+ */
+
+import type { IntelligenceProvider } from './types.js';
+
+export interface CompletionVerdict {
+  /** Whether the condition is met (the loop may stop). */
+  met: boolean;
+  /** One-line reason — fed back as next-turn guidance when not met. */
+  reason: string;
+}
+
+export interface CompletionEvaluatorDeps {
+  intelligence: IntelligenceProvider;
+  /** Override model tier (default 'fast' — matches /goal's small-fast evaluator). */
+  modelTier?: 'fast' | 'balanced' | 'capable';
+}
+
+const PROMPT_VERSION = 'completion-eval-v1';
+
+export class CompletionEvaluator {
+  private readonly intelligence: IntelligenceProvider;
+  private readonly modelTier: 'fast' | 'balanced' | 'capable';
+
+  constructor(deps: CompletionEvaluatorDeps) {
+    this.intelligence = deps.intelligence;
+    this.modelTier = deps.modelTier ?? 'fast';
+  }
+
+  /**
+   * Judge whether `condition` is met given the recent transcript text.
+   * Robust to model phrasing: looks for an explicit MET/NOT_MET verdict.
+   * On any error/ambiguity, returns `met:false` — never falsely "done" (the
+   * caller treats "not met" as keep-working, which is the safe direction).
+   */
+  async evaluate(condition: string, transcriptTail: string): Promise<CompletionVerdict> {
+    const prompt = this.buildPrompt(condition, transcriptTail);
+    let raw: string;
+    try {
+      raw = await this.intelligence.evaluate(prompt, {
+        model: this.modelTier,
+        temperature: 0,
+        maxTokens: 200,
+        timeoutMs: 30_000,
+        attribution: { component: 'CompletionEvaluator' },
+      });
+    } catch (err) {
+      return { met: false, reason: `evaluator error (keep working): ${err instanceof Error ? err.message : String(err)}` };
+    }
+    return this.parse(raw);
+  }
+
+  private buildPrompt(condition: string, transcriptTail: string): string {
+    return [
+      'You are an INDEPENDENT completion checker for an autonomous coding agent.',
+      'Decide whether the agent has MET its completion condition, judging ONLY from',
+      'evidence the agent has surfaced in the transcript below. Do NOT assume work',
+      'that is not shown. If the condition requires a check (e.g. "tests pass") and',
+      'the transcript does not show that check succeeding, it is NOT met.',
+      '',
+      `COMPLETION CONDITION:\n${condition}`,
+      '',
+      `RECENT TRANSCRIPT (most recent last):\n${transcriptTail}`,
+      '',
+      'Respond on the FIRST line with exactly "MET" or "NOT_MET", then on the next',
+      'line a one-sentence reason. Nothing else.',
+    ].join('\n');
+  }
+
+  /** Parse the model output into a verdict. Conservative: defaults to not-met. */
+  private parse(raw: string): CompletionVerdict {
+    const text = (raw || '').trim();
+    if (!text) return { met: false, reason: 'empty evaluator response (keep working)' };
+    // First non-empty line carries the verdict.
+    const lines = text.split('\n').map((l) => l.trim()).filter(Boolean);
+    const first = (lines[0] || '').toUpperCase();
+    const reason = (lines[1] || lines[0] || '').slice(0, 300);
+    // "NOT_MET"/"NOT MET" must be checked before "MET" (substring).
+    if (/\bNOT[_ ]?MET\b/.test(first)) return { met: false, reason: reason || 'condition not yet met' };
+    if (/\bMET\b/.test(first)) return { met: true, reason: reason || 'condition met' };
+    // Ambiguous → safe direction (keep working).
+    return { met: false, reason: `ambiguous verdict, keeping work going: ${text.slice(0, 120)}` };
+  }
+
+  get promptVersion(): string {
+    return PROMPT_VERSION;
+  }
+}

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1212,18 +1212,20 @@ export class PostUpdateMigrator {
         result.errors.push(`${relPath} migration: ${err instanceof Error ? err.message : String(err)}`);
       }
     };
-    // Marker = the multi-session signature (absent from v1.2.55 topic-keyed installs).
+    // Marker = the latest capability signature (bumped each time the bundled hook/
+    // setup gains a feature, so prior installs upgrade): now the independent
+    // completion evaluator (mirrors /goal). Absent from multi-session-only installs.
     upgrade(
       '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
-      'MULTI-SESSION (per-topic state)',
+      'independent evaluator (mirrors /goal)',
       'Autonomous Mode Stop Hook',
-      'skills/autonomous/hooks/autonomous-stop-hook.sh (topic-keyed + multi-session per-topic state)',
+      'skills/autonomous/hooks/autonomous-stop-hook.sh (topic-keyed + multi-session + completion evaluator)',
     );
     upgrade(
       '.claude/skills/autonomous/scripts/setup-autonomous.sh',
-      'STATE_PATH=".instar/autonomous/',
+      'completion_condition:',
       'autonomous-state.local.md',
-      'skills/autonomous/scripts/setup-autonomous.sh (per-topic state path)',
+      'skills/autonomous/scripts/setup-autonomous.sh (per-topic + completion-condition)',
     );
   }
 

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -168,6 +168,7 @@ export class AgentServer {
     soulManager?: import('../core/SoulManager.js').SoulManager;
     featureRegistry?: import('../core/FeatureRegistry.js').FeatureRegistry;
     discoveryEvaluator?: import('../core/DiscoveryEvaluator.js').DiscoveryEvaluator;
+    completionEvaluator?: import('../core/CompletionEvaluator.js').CompletionEvaluator;
     unifiedTrust?: import('../threadline/UnifiedTrustWiring.js').UnifiedTrustSystem;
     liveConfig?: { set(path: string, value: unknown): void };
     /** Shared proxy coordinator (PresenceProxy ↔ PromiseBeacon ↔ /build heartbeat). */
@@ -484,6 +485,7 @@ export class AgentServer {
       soulManager: options.soulManager ?? null,
       featureRegistry: options.featureRegistry ?? null,
       discoveryEvaluator: options.discoveryEvaluator ?? null,
+      completionEvaluator: options.completionEvaluator ?? null,
       unifiedTrust: options.unifiedTrust ?? null,
       threadlineReplyWaiters: options.threadlineReplyWaiters ?? new Map(),
       proxyCoordinator: options.proxyCoordinator ?? null,

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -647,6 +647,7 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
           'GET /autonomous/can-start?priority= — cap + quota gate to consult before starting a new job',
           'POST /autonomous/stop-all — stop every autonomous job ("stop everything")',
           'POST /autonomous/sessions/:topic/stop — stop one topic\'s job',
+          'POST /autonomous/evaluate-completion — independent /goal-style judge: is a verifiable condition met?',
         ],
       };
     },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -592,6 +592,8 @@ export interface RouteContext {
   soulManager: import('../core/SoulManager.js').SoulManager | null;
   featureRegistry: import('../core/FeatureRegistry.js').FeatureRegistry | null;
   discoveryEvaluator: import('../core/DiscoveryEvaluator.js').DiscoveryEvaluator | null;
+  /** Independent autonomous-completion judge (mirrors /goal). Null if no IntelligenceProvider. */
+  completionEvaluator: import('../core/CompletionEvaluator.js').CompletionEvaluator | null;
   unifiedTrust: UnifiedTrustSystem | null;
   /** Shared proxy coordinator — mutex + /build heartbeat record for the
    *  PresenceProxy ↔ PromiseBeacon ↔ /build-heartbeat three-way deconfliction
@@ -2939,6 +2941,30 @@ export function createRoutes(ctx: RouteContext): Router {
     const topic = req.params.topic;
     const stopped = stopAutonomousTopic(ctx.config.stateDir, topic);
     res.status(stopped ? 200 : 404).json({ ok: stopped, topic });
+  });
+
+  // Independent completion judge for the autonomous stop-hook (mirrors /goal):
+  // given a verifiable condition + the recent transcript, decide met/not-met.
+  // The hook treats 503/unreachable as "keep working" (fail-safe — never a false done).
+  router.post('/autonomous/evaluate-completion', async (req, res) => {
+    if (!ctx.completionEvaluator) {
+      res.status(503).json({ error: 'No completion evaluator (IntelligenceProvider not configured)' });
+      return;
+    }
+    const { condition, transcriptTail } = req.body ?? {};
+    if (!condition || typeof condition !== 'string') {
+      res.status(400).json({ error: '"condition" (string) required' });
+      return;
+    }
+    try {
+      const verdict = await ctx.completionEvaluator.evaluate(
+        condition,
+        typeof transcriptTail === 'string' ? transcriptTail : '',
+      );
+      res.json(verdict);
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
   });
 
   router.get('/capabilities', (_req, res) => {

--- a/tests/integration/autonomous-sessions-api.test.ts
+++ b/tests/integration/autonomous-sessions-api.test.ts
@@ -12,6 +12,7 @@ import { StateManager } from '../../src/core/StateManager.js';
 import type { InstarConfig } from '../../src/core/types.js';
 import express from 'express';
 import { createRoutes } from '../../src/server/routes.js';
+import { CompletionEvaluator } from '../../src/core/CompletionEvaluator.js';
 import type { Server } from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -54,7 +55,16 @@ describe('Multi-session autonomy API (integration)', () => {
       commitmentTracker: null, semanticMemory: null, activitySentinel: null, workingMemory: null,
       quotaManager: null, systemReviewer: null, capabilityMapper: null, topicResumeMap: null,
       autonomyManager: null as any, trustElevationTracker: null as any, autonomousEvolution: null,
-      discoveryEvaluator: null, startTime: new Date(),
+      discoveryEvaluator: null,
+      // Stub IntelligenceProvider: "MET" only when the transcript mentions "passed".
+      completionEvaluator: new CompletionEvaluator({
+        intelligence: {
+          async evaluate(prompt: string) {
+            return /passed/i.test(prompt) ? 'MET\nthe transcript shows tests passed' : 'NOT_MET\nno passing evidence yet';
+          },
+        },
+      }),
+      startTime: new Date(),
     } as any);
     app.use(router);
     await new Promise<void>((resolve) => {
@@ -113,5 +123,32 @@ describe('Multi-session autonomy API (integration)', () => {
     expect((await res.json()).ok).toBe(true);
     const list = await (await fetch(`${baseUrl}/autonomous/sessions`)).json();
     expect(list.sessions).toEqual([]);
+  });
+
+  it('POST /autonomous/evaluate-completion returns met:true when the transcript shows success', async () => {
+    const res = await fetch(`${baseUrl}/autonomous/evaluate-completion`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ condition: 'all tests pass', transcriptTail: 'npm test → 42 passed' }),
+    });
+    expect(res.status).toBe(200);
+    const v = await res.json();
+    expect(v.met).toBe(true);
+    expect(v.reason).toBeTruthy();
+  });
+
+  it('POST /autonomous/evaluate-completion returns met:false when there is no success evidence', async () => {
+    const res = await fetch(`${baseUrl}/autonomous/evaluate-completion`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ condition: 'all tests pass', transcriptTail: 'still writing code' }),
+    });
+    const v = await res.json();
+    expect(v.met).toBe(false);
+  });
+
+  it('POST /autonomous/evaluate-completion 400s without a condition', async () => {
+    const res = await fetch(`${baseUrl}/autonomous/evaluate-completion`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/tests/unit/CompletionEvaluator.test.ts
+++ b/tests/unit/CompletionEvaluator.test.ts
@@ -1,0 +1,60 @@
+/**
+ * CompletionEvaluator — independent "is the goal met?" judge.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CompletionEvaluator } from '../../src/core/CompletionEvaluator.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
+
+function stubProvider(reply: string | (() => Promise<string>)): IntelligenceProvider {
+  return {
+    async evaluate(_prompt: string, _opts?: IntelligenceOptions): Promise<string> {
+      return typeof reply === 'function' ? reply() : reply;
+    },
+  };
+}
+
+describe('CompletionEvaluator', () => {
+  it('returns met:true on a MET verdict', async () => {
+    const e = new CompletionEvaluator({ intelligence: stubProvider('MET\nAll tests in test/auth pass per the transcript.') });
+    const v = await e.evaluate('all tests pass', 'ran npm test → 42 passed, 0 failed');
+    expect(v.met).toBe(true);
+    expect(v.reason).toMatch(/tests/i);
+  });
+
+  it('returns met:false on a NOT_MET verdict, with reason', async () => {
+    const e = new CompletionEvaluator({ intelligence: stubProvider('NOT_MET\n3 tests still failing in test/auth.') });
+    const v = await e.evaluate('all tests pass', 'npm test → 39 passed, 3 failed');
+    expect(v.met).toBe(false);
+    expect(v.reason).toMatch(/failing/i);
+  });
+
+  it('does not confuse NOT_MET with MET (substring guard)', async () => {
+    const e = new CompletionEvaluator({ intelligence: stubProvider('NOT MET\nstill working') });
+    expect((await e.evaluate('x', 'y')).met).toBe(false);
+  });
+
+  it('fails SAFE (met:false) on an empty response', async () => {
+    const e = new CompletionEvaluator({ intelligence: stubProvider('') });
+    expect((await e.evaluate('x', 'y')).met).toBe(false);
+  });
+
+  it('fails SAFE (met:false) on an ambiguous response', async () => {
+    const e = new CompletionEvaluator({ intelligence: stubProvider('hmm, maybe? hard to say') });
+    const v = await e.evaluate('x', 'y');
+    expect(v.met).toBe(false);
+    expect(v.reason).toMatch(/ambiguous/i);
+  });
+
+  it('fails SAFE (met:false) when the provider throws — never a false "done"', async () => {
+    const e = new CompletionEvaluator({ intelligence: stubProvider(async () => { throw new Error('LLM down'); }) });
+    const v = await e.evaluate('x', 'y');
+    expect(v.met).toBe(false);
+    expect(v.reason).toMatch(/error/i);
+  });
+
+  it('defaults to the fast model tier', () => {
+    const e = new CompletionEvaluator({ intelligence: stubProvider('MET\nok') });
+    expect(e.promptVersion).toBe('completion-eval-v1');
+  });
+});

--- a/tests/unit/autonomous-completion-condition.test.ts
+++ b/tests/unit/autonomous-completion-condition.test.ts
@@ -1,0 +1,81 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir; SafeFsExecutor migration tracked separately.
+/**
+ * Autonomous stop hook — completion CONDITION via independent evaluator (mirrors /goal).
+ *
+ * When `completion_condition` is set, the hook asks the evaluator endpoint each turn
+ * instead of trusting the self-declared <promise>. met → exit; not-met → block + feed
+ * the reason back. Fail-SAFE: if the evaluator is unreachable, keep working (never a
+ * false "done"). Uses the INSTAR_HOOK_EVAL_OVERRIDE test seam for the met/not-met paths.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const HOOK = path.join(process.cwd(), '.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh');
+const UUID = '04db2de7-8e82-4baf-9136-7a067bb2ec53';
+let tmp: string;
+
+function writeState(opts: { condition?: string; promise?: string }) {
+  const started = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  fs.writeFileSync(path.join(tmp, '.instar', 'autonomous-state.local.md'),
+    `---\nactive: true\niteration: 2\nsession_id: "${UUID}"\nduration_seconds: 0\nstarted_at: "${started}"\nreport_topic: ""\ncompletion_promise: "${opts.promise ?? ''}"\ncompletion_condition: "${opts.condition ?? ''}"\n---\n\nKeep going.\n`);
+}
+function writeTranscript(): string {
+  const p = path.join(tmp, 'transcript.jsonl');
+  fs.writeFileSync(p, JSON.stringify({ role: 'assistant', message: { content: [{ type: 'text', text: 'working on it' }] } }) + '\n');
+  return p;
+}
+function statePresent() { return fs.existsSync(path.join(tmp, '.instar', 'autonomous-state.local.md')); }
+
+function runHook(evalOverride?: string): { decision: string | null; exit: number } {
+  const env: NodeJS.ProcessEnv = { ...process.env, INSTAR_HOOK_NO_TMUX: '1', INSTAR_HOOK_TMUX_SESSION: '' };
+  if (evalOverride !== undefined) env.INSTAR_HOOK_EVAL_OVERRIDE = evalOverride;
+  let stdout = ''; let exit = 0;
+  try {
+    stdout = execFileSync('bash', [HOOK], {
+      cwd: tmp, input: JSON.stringify({ session_id: UUID, transcript_path: writeTranscript() }),
+      env, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (e: any) { exit = e.status ?? 1; stdout = e.stdout?.toString() ?? ''; }
+  let decision: string | null = null;
+  try { decision = JSON.parse(stdout.trim()).decision ?? null; } catch { /* allow-exit */ }
+  return { decision, exit };
+}
+
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-cond-')); fs.mkdirSync(path.join(tmp, '.instar'), { recursive: true }); });
+afterEach(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+describe('completion condition — independent evaluator', () => {
+  it('evaluator says MET → allows exit and clears state', () => {
+    writeState({ condition: 'all tests pass' });
+    const r = runHook('met');
+    expect(r.decision).not.toBe('block');
+    expect(r.exit).toBe(0);
+    expect(statePresent()).toBe(false); // state cleared on completion
+  });
+
+  it('evaluator says NOT-MET → blocks (keeps working), state retained', () => {
+    writeState({ condition: 'all tests pass' });
+    const r = runHook('not-met');
+    expect(r.decision).toBe('block');
+    expect(statePresent()).toBe(true);
+  });
+
+  it('FAIL-SAFE: condition set but evaluator unreachable → keeps working (never premature exit)', () => {
+    // No override → the hook curls the evaluator endpoint; no server is running in the
+    // test, so the call fails. The job must NOT exit — it blocks and keeps working.
+    writeState({ condition: 'all tests pass' });
+    const r = runHook(); // no override, no server
+    expect(r.decision).toBe('block');
+    expect(statePresent()).toBe(true);
+  });
+
+  it('legacy: no condition, self-declared promise path still works (blocks until promised)', () => {
+    writeState({ promise: 'ALL_DONE' }); // no condition
+    const r = runHook();
+    expect(r.decision).toBe('block'); // promise not in transcript → keep working
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,64 @@
+# Upgrade Guide — NEXT (autonomous completion evaluator)
+
+<!-- bump: minor -->
+<!-- minor = new capability, backward compatible -->
+
+## What Changed
+
+**New: autonomous mode can decide "done" with an independent judge — not the agent's own say-so.**
+
+Autonomous runs decided completion by scanning the transcript for a self-declared token
+(`<promise>...</promise>`) — the agent grading its own homework. Now you can set a verifiable
+**completion condition** and an INDEPENDENT small/fast model judges, each turn, whether the
+condition is met against what the agent has surfaced — exactly how the framework `/goal`
+feature works (Claude Code's `/goal` is itself a prompt-based Stop hook, the same mechanism as
+ours). Not met → keep working, with the judge's reason fed back as next-turn guidance. Met →
+the run exits. This is the loop's continue/stop authority, a full-context model judgment.
+
+- Start with `--completion-condition "<measurable end-state>"` (e.g. "all tests in test/auth
+  pass and `npm test` exits 0"). The self-declared `<promise>` path remains as a legacy
+  fallback when no condition is set — fully backward compatible.
+- **Fail-safe:** if the evaluator is unreachable, the run keeps working — a missing judge never
+  causes a false "done"/premature exit.
+- Endpoint: `POST /autonomous/evaluate-completion` `{condition, transcriptTail}` → `{met, reason}`,
+  via the shared `IntelligenceProvider` (framework-aware), spend-capped by `LlmQueue`.
+
+## What to Tell Your User
+
+When I work autonomously now, I don't get to declare myself finished — a separate judge checks
+a real finish-line you set (like "all tests pass") and only lets me stop when it's actually
+true. If that judge can't be reached, I keep working rather than risk a false "done." It's the
+same idea as the new `/goal` feature, built into our autonomous mode so it works on any
+framework. Nothing to set up; existing agents get it on their next update.
+
+## Summary of New Capabilities
+
+- `--completion-condition` for autonomous runs: a verifiable end-state judged independently.
+- `POST /autonomous/evaluate-completion` — independent /goal-style completion judge.
+- `CompletionEvaluator` (small/fast tier, spend-capped) — judges condition vs transcript; fails
+  safe (never a false "done").
+- Stop hook feeds the judge's reason back as next-turn guidance (mirrors `/goal`).
+- Legacy self-declared `<promise>` retained as fallback.
+
+## Migration Notes
+
+Existing agents receive the updated hook + setup script via
+`PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed` (marker bumped to the completion-evaluator
+signature). The evaluator activates automatically wherever an `IntelligenceProvider` is configured;
+where it isn't, the legacy promise path runs. No action required.
+
+## Evidence
+
+- **Unit:** `CompletionEvaluator.test.ts` (7) — MET/NOT_MET verdicts, NOT_MET-vs-MET substring
+  guard, and **fail-safe** (empty/ambiguous/throwing provider → `met:false`, never a false done).
+- **Integration:** `autonomous-sessions-api.test.ts` — `POST /autonomous/evaluate-completion`
+  returns met:true when the transcript shows success, met:false otherwise, 400 without a condition.
+- **Hook (behavioral):** `autonomous-completion-condition.test.ts` (4) — evaluator MET → exit +
+  clear state; NOT-MET → block + keep working; **evaluator unreachable → block + keep working
+  (no premature exit)**; legacy promise path preserved when no condition.
+
+## Tracked follow-up
+
+The enhancement to let the evaluator run real checks itself (`/verify-claim`: tests/build/grep)
+rather than judging only what's surfaced is tracked as commitment **ACT-152** (high priority,
+surfaced by the commitment-check job until done) — not an untracked note.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -28,8 +28,8 @@ the run exits. This is the loop's continue/stop authority, a full-context model 
 When I work autonomously now, I don't get to declare myself finished — a separate judge checks
 a real finish-line you set (like "all tests pass") and only lets me stop when it's actually
 true. If that judge can't be reached, I keep working rather than risk a false "done." It's the
-same idea as the new `/goal` feature, built into our autonomous mode so it works on any
-framework. Nothing to set up; existing agents get it on their next update.
+same idea as the new goal feature in Claude Code and Codex, built into our autonomous mode so it
+works on any framework. Nothing to set up; existing agents get it on their next update.
 
 ## Summary of New Capabilities
 

--- a/upgrades/side-effects/goal-completion-evaluator.md
+++ b/upgrades/side-effects/goal-completion-evaluator.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — autonomous completion evaluator (independent /goal-style judge)
+
+**Version / slug:** `goal-completion-evaluator`
+**Date:** 2026-05-24
+**Author:** echo
+**Second-pass reviewer:** internal conformance pass
+
+## Summary of the change
+
+Replaces the autonomous stop-hook's self-declared `<promise>` completion check (agent grades
+itself) with an **independent** judgment: when a verifiable `completion_condition` is set, a
+small/fast model judges each turn whether it's met against what the agent surfaced (same
+contract as the framework `/goal`). Phase 1 of `docs/specs/goal-completion-evaluator.md`. The
+self-declared promise remains as a legacy fallback. `src/` touched: `CompletionEvaluator.ts`
+(new), `routes.ts` (+RouteContext field + `/autonomous/evaluate-completion`), `AgentServer.ts`
+(thread-through), `commands/server.ts` (construct from sharedIntelligence), `CapabilityIndex.ts`
+(endpoint), `PostUpdateMigrator.ts` (marker bump). Non-src: the hook, setup script, SKILL.md, tests.
+
+## Decision-point inventory
+
+- `CompletionEvaluator.evaluate` — **add**: the loop's continue/stop authority. Judges
+  condition vs transcript; returns met/reason. The one new decision point.
+- `autonomous-stop-hook.sh` — **modify**: when a condition is set, ask the evaluator instead of
+  trusting the promise; promise path demoted to fallback; fail-safe on unreachable.
+- `setup-autonomous.sh` — **modify**: `--completion-condition` flag + state field. (`.claude/`.)
+- `POST /autonomous/evaluate-completion` — **add**: thin route over CompletionEvaluator.
+- `PostUpdateMigrator` marker — **modify**: bumped so prior installs upgrade.
+
+## 1. Over-block (trapping a session that should exit)
+- The evaluator returns met:true only on an explicit MET verdict; on met:true the run exits.
+  Over-block would mean never confirming a truly-met condition. Mitigated by a well-formed
+  condition + the reason-feedback loop. Same risk class `/goal` accepts.
+
+## 2. Under-block (false "done" / premature exit) — the critical direction
+- The evaluator **fails safe to met:false** on empty/ambiguous/error/unreachable — it can never
+  emit a false "done" from a failure. Tested (unit: empty/ambiguous/throw; hook: unreachable →
+  keep working). Server-down does NOT premature-exit. This is the strongest safety property.
+
+## 3. Level-of-abstraction fit
+- Correct. CompletionEvaluator mirrors existing IntelligenceProvider-backed evaluators
+  (DiscoveryEvaluator, CoherenceReviewer); reuses sharedIntelligence + LlmQueue spend cap.
+
+## 4. Blocking authority
+- [x] The evaluator IS the autonomous loop's continue/stop authority — appropriate, because it
+  is a **full-context model judgment** (condition + transcript), exactly like `/goal`, not a
+  brittle low-context filter. It only gates the autonomous loop, nothing else.
+
+## 5. Interactions
+- **Legacy promise:** preserved as fallback; runs with no condition behave exactly as before.
+- **Multi-session:** per-topic; the evaluator reads/clears the same per-topic state file.
+- **Cost:** one small/fast call per turn (matches `/goal`) — bounded by the LlmQueue daily cap.
+- **Restart/recovery/duration/emergency-stop:** unchanged; the condition check sits in the
+  terminal-checks block alongside them.
+
+## 6. External surfaces
+- **HTTP:** one new authed route `POST /autonomous/evaluate-completion` (under the already-claimed
+  `/autonomous` capability prefix). The hook calls it best-effort (port+auth from config); failure
+  is swallowed → keep working.
+- **LLM:** one small/fast `IntelligenceProvider.evaluate` per turn, attributed `CompletionEvaluator`,
+  spend-capped. No new external credential.
+
+## 7. Rollback cost
+- Low. Reverting restores the promise-only path; the migration marker is content-sniffed (a
+  rollback re-ships the prior hook, which lacks the new marker, and re-deploys cleanly). A
+  `completion_condition` left in a state file is simply ignored by an older hook.
+
+## 8. Test evidence
+- 7 unit (CompletionEvaluator incl. fail-safe), 8 integration (incl. 3 evaluate-completion route),
+  4 hook behavioral (met/not-met/unreachable-fail-safe/legacy). tsc clean; 61 affected tests green.


### PR DESCRIPTION
## What

Autonomous mode can now decide "done" with an **independent judge** instead of the agent's self-declared `<promise>`. Set a verifiable `--completion-condition` and a small/fast model judges each turn whether it's met against what the agent surfaced — exactly how the framework `/goal` feature works (Claude Code's `/goal` is itself a prompt-based Stop hook, the same mechanism as ours). This is Phase 1 of `docs/specs/goal-completion-evaluator.md` (approved).

ELI16: `docs/specs/goal-completion-evaluator.eli16.md`.

## How
- `CompletionEvaluator` (small/fast `IntelligenceProvider`, spend-capped by `LlmQueue`) — judges condition vs transcript; returns `{met, reason}`. **Fails safe to `met:false`** on empty/ambiguous/error — never a false "done".
- `POST /autonomous/evaluate-completion` (under the existing `/autonomous` capability).
- Stop hook: when a condition is set, asks the evaluator each turn; met → exit, not-met → block + feed the reason back as guidance; **server unreachable → keep working** (no premature exit). Self-declared `<promise>` retained as legacy fallback.
- `setup-autonomous.sh --completion-condition`; SKILL.md documents it as preferred.
- Migration marker bumped so existing (multi-session) agents receive the upgraded hook + setup.

## Framework-agnostic by design
Runs on Claude and Codex via instar's own `IntelligenceProvider` (already framework-aware). This *is* the "leverage /goal" win — we adopted its mechanism everywhere. (Note: literal delegation to a framework's native `/goal` is constrained — Claude Code's `/goal` has no programmatic API — so adopting the pattern, rather than delegating, is the higher-value path. See the PR discussion / spec Phase 2.)

## Tests (all green; full pre-push suite passed)
- Unit: `CompletionEvaluator` (7) — verdicts + the fail-safe cases (empty/ambiguous/throw → met:false).
- Integration: `autonomous-sessions-api` — the evaluate-completion route (met/not-met/400).
- Hook behavioral: `autonomous-completion-condition` (4) — met→exit, not-met→block, **unreachable→keep-working**, legacy-promise preserved.

## Governance
Approved spec + ELI16 + side-effects review + `/instar-dev` trace. The "evaluator runs real checks (verify-claim)" enhancement is tracked as commitment **ACT-152** (not an untracked note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)