### PR TITLE
feat(monitoring): HumanAsDetectorLog — human corrections as guardian-failure signals

### DIFF
--- a/docs/specs/human-as-detector.eli16.md
+++ b/docs/specs/human-as-detector.eli16.md
@@ -1,0 +1,55 @@
+# Human-as-Detector — the plain-English version
+
+## What this is
+
+Right now, when you catch the agent getting something wrong — "that's out of date," "you
+already told me the opposite," "why didn't you notice this?" — the agent just fixes it and
+moves on. The correction itself gets thrown away.
+
+That's a waste, because your correction is actually a really valuable clue. If *you* had to
+catch the mistake, it means one of the agent's *own* automated safety checks — the things
+that are supposed to catch stale facts, contradictions, and incoherence — failed to catch it
+first. So every time you point something out, it's a little flag that says "a guardrail
+missed this one."
+
+This feature starts keeping score of those flags. Each correction you make gets quietly
+logged and tagged with *which* guardrail probably should have caught it. Over weeks, that
+builds a "heat map": a ranked list of which safety checks keep letting things slip past. That
+tells us exactly where the agent's automated guardrails are weak and worth strengthening —
+instead of guessing.
+
+## Why it matters
+
+It turns your feedback into a permanent, measurable signal instead of a one-off fix. It's the
+"never let user feedback go to waste" idea, built as actual running code. It's also the first
+working piece of the bigger "working awareness" goal — the part that learns from the moments
+the agent slips.
+
+## How it works (lightly)
+
+A small, simple pattern-matcher reads each message you send. It uses no AI and no internet —
+just a careful list of phrases that signal a correction (deliberately tuned to under-react, so
+it doesn't cry wolf). When it spots a real correction, it records a short note. There's a
+quiet read-only page (`/human-as-detector/summary`) where the heat map can be viewed.
+
+## The tradeoffs and the safety choices
+
+- **It only watches, never blocks.** This is a thermometer, not a gate. It records and
+  summarizes; it never stops the agent from doing anything. So even if it mis-reads a message,
+  the worst case is a slightly-off statistic — never a broken action or a dropped message.
+- **It protects your privacy.** Your actual words are *not* written to disk — only the
+  category of correction and which guardrail it points at. So if you happen to type a password
+  or private detail while correcting the agent, it won't end up sitting in a log file forever.
+- **It survives restarts.** The agent restarts often (updates, etc.); the heat map reloads its
+  history on startup so it doesn't reset to zero every time.
+- **It can be fooled, and that's okay.** Someone spamming "that's wrong" could skew the
+  numbers — but since the heat map only informs us and controls nothing, that just makes a
+  chart noisy, not the agent unsafe.
+- **Telegram first.** This version watches your Telegram messages. Slack and the other channels
+  are an easy, already-planned follow-up.
+
+## What changes for you
+
+Almost nothing visible day-to-day — it works silently. The payoff is slower and bigger: over
+time, the agent's blind spots become *visible and measurable*, so we can fix the guardrails
+that keep failing instead of patching the same kind of mistake over and over.

--- a/docs/specs/human-as-detector.md
+++ b/docs/specs/human-as-detector.md
@@ -1,0 +1,196 @@
+---
+slug: human-as-detector
+title: HumanAsDetectorLog — treat a human-caught coherence break as a guardian-failure signal
+author: echo
+source: Dawn handoff (the-portal/.claude/instar-feedback/handoff-human-as-detector), 2026-05-24
+review-convergence: "2026-05-24T20:23:19.780Z"
+review-iterations: 2
+review-completed-at: "2026-05-24T20:23:19.780Z"
+review-report: "docs/specs/reports/human-as-detector-convergence.md"
+approved: true
+approved-by: justin
+approved-at: "2026-05-24T20:53:00Z"
+eli16-overview: human-as-detector.eli16.md
+---
+
+# HumanAsDetectorLog
+
+## Problem statement
+
+When the user has to surface something wrong — a stale claim, a contradiction, a state
+incoherence, "why didn't you catch this" — Instar today treats it as a normal input to fix
+quietly. That throws away the most valuable signal in the whole system.
+
+A human correction is **evidence that some automated monitor/gate/guardian that should have
+caught the break didn't.** Logged over time, these corrections form a heat map of "where the
+human is doing the system's job" — which reveals exactly which automated layers are dead
+weight and which coverage gaps are real. This is the *user-feedback facet* of the Continuous
+Working Awareness north star (`docs/NORTH-STAR.md`): **never let a user correction go to
+waste.**
+
+Instar already has `CoherenceMonitor`, `CoherenceGate`, and `DegradationReporter` — but all of
+those watch the system's OWN state. **None treat a human correction as a signal.** This spec
+closes that gap.
+
+The lesson is Dawn's (2026-04-26, "Justin Pointing Things Out = Guardian Failure"), handed off
+for porting into Instar. Dawn's handoff explicitly routes ratification through Justin: "Echo
+turns this into a formal spec, takes it to Justin for ratification, and ships via PR." This
+document is that formal spec.
+
+## Proposed design
+
+A new monitor, `src/monitoring/HumanAsDetectorLog.ts`, mirroring the established
+`DegradationReporter` shape:
+
+- **Singleton.** `getInstance()`, `configure({ stateDir, agentName })` at startup,
+  `resetForTesting()` for tests.
+- **`classify(text)`** — pure, deterministic, no I/O. Lowercases the text, tests a
+  conservative weighted regex signal set, returns
+  `{ category, suspectedFailedLayer, confidence, matchedSignals }` or `null`. The
+  unit-testable core. No LLM, no network.
+- **`observe({ text, source, topicId?, messageId? })`** — calls `classify`; on a hit, records
+  to an in-memory ring (capped 200) + appends one JSONL line + emits a single loud
+  `console.warn`. **Best-effort; never throws into the caller.** Returns the signal or `null`.
+- **`summarizeByLayer()`** — groups recorded signals by suspected failed layer, most-frequent
+  first. The heat map.
+- **`observeInboundMessage(log, entry, source)`** — the gating decision extracted from the
+  server wiring so it is unit-testable: observe ONLY inbound HUMAN messages that carry text;
+  agent-authored and empty entries are skipped.
+- **Persistence (metadata only):** append-only `<stateDir>/metrics/human-as-detector.jsonl`,
+  wrapped in try/catch (the `console.warn` is the safety net if disk write fails). **The
+  on-disk record carries metadata only — never `messagePreview` (the user's raw words).** A
+  secret or PII a user types mid-correction must not leak into a long-lived append-only audit
+  trail; the preview stays in the in-memory ring for the live session's heat map and is
+  dropped before persistence. The file is created `0600` and the `metrics/` dir `0700` as
+  defense-in-depth on the metadata that remains. *(Both hardenings added during spec
+  convergence — the security reviewer flagged the cleartext-preview-on-disk leak.)*
+- **Restart durability:** `configure()` hydrates the in-memory ring from the last 200
+  persisted records (best-effort, try/catch). The heat map (`summarizeByLayer` + `recent`)
+  reads only the ring, and instar restarts often (auto-update, lifeline coordination) — without
+  hydration the heat map would silently empty on every restart even though the history is on
+  disk. Hydrated entries have an empty preview (it was never persisted); the per-layer counts —
+  the point of the heat map — are fully restored. *(Added during spec convergence — the
+  scalability reviewer flagged the volatile-ring-empties-on-restart gap.)*
+
+**Categories** (each signal rule maps to the guardian layer that should plausibly have caught
+that class of break): `factual-correction`, `staleness`, `contradiction`,
+`source-of-truth-drift`, `repeat-ask`, `meta-failure`.
+
+**Precision over recall (deliberate).** Signals are weighted; a lone weak signal (e.g.
+"actually,") is below the `totalWeight >= 2` threshold and ignored, because a false positive
+pollutes the heat map while a miss only loses one data point. Confidence: `>=5` high, `>=3`
+medium, else low.
+
+### Wiring (server.ts, additive — ~10 lines)
+
+1. Configure the singleton at startup, next to `DegradationReporter` (`stateDir`, `agentName`
+   = `config.projectName`).
+2. Chain `observeInboundMessage(log, entry)` onto `telegram.onMessageLogged`, **preserving any
+   prior callback** (TopicMemory dual-write, PresenceProxy, keep-watching) by capturing and
+   calling the existing callback first. Only inbound human messages are observed.
+
+### Observability surface
+
+Read-only `GET /human-as-detector/summary` returns `{ byLayer, recent }` (the heat map grouped
+by suspected failed layer, plus recent signals). The route is singleton-backed (always
+available; no 503 path). It is classified in `INTERNAL_PREFIXES` (operator-only observability,
+matching `quota`, `watchdog`, `telemetry`, `scope-coherence`, `rate-limit`) — the heat map is a
+diagnostic surface, not an agent-discoverable capability. Agent-side surfacing (e.g.
+"you've corrected me on staleness three times") is a future Usher/evolution rung, not this PR.
+
+## Scope — Telegram-first (deliberate, tracked)
+
+This PR wires the observer onto the **Telegram** inbound path only. Slack, WhatsApp, and
+iMessage each have their own `onMessageLogged` chain and are **not** observed yet, so a
+correction made over those adapters produces no signal and the heat map under-counts for
+multi-adapter agents. This is a deliberate v1 boundary, not a silent omission: the classifier
+and `observeInboundMessage` gate are adapter-agnostic, so extending to the other adapters is a
+small, mechanical follow-up <!-- tracked: cwa-multi-adapter-capture --> (chain
+`observeInboundMessage` onto each adapter's `onMessageLogged`, inbound-human only). Tracked as
+a same-effort follow-up <!-- tracked: cwa-multi-adapter-capture -->, not an orphan note.
+*(Raised by the lessons-aware reviewer as a multi-entry-point trap — engaged explicitly here
+per the No-Deferrals standard.)*
+
+## Side-effects review
+
+- **Over-block:** none — the module gates nothing; it cannot block any action.
+- **Under-block / false negatives:** the conservative `totalWeight >= 2` threshold means some
+  genuine corrections won't register. Accepted by design: a missed signal loses one data
+  point; a false positive pollutes the heat map. Precision over recall is the right bias for a
+  diagnostic that informs (not gates) evolution.
+- **False positives / poisoning:** a user can trivially skew counts by repeating correction
+  phrases. Accepted because the signal **gates nothing** — poisoning degrades a diagnostic, not
+  a control. `source`/`topicId` are recorded so an operator can spot single-source flooding.
+- **Level-of-abstraction fit:** a singleton monitor mirroring `DegradationReporter`, chained on
+  the existing `onMessageLogged` callback — the same seam other message observers use. No new
+  abstraction introduced.
+- **Interactions:** chains (not replaces) the prior `onMessageLogged` callbacks (TopicMemory
+  dual-write, PresenceProxy, keep-watching) by capturing and invoking the predecessor first —
+  verified across all four chain links. The new route is classified in `INTERNAL_PREFIXES`, so
+  the discoverability gate is satisfied.
+- **Privacy:** raw user text never reaches disk (metadata-only persistence, `0600`); a future
+  consumer that feeds `messagePreview` (in-memory) into an LLM would reintroduce a
+  prompt-injection surface — flagged here for that future rung.
+- **No kill-switch (deliberate):** there is no `enabled` config flag. Justified: `observe`
+  never throws, I/O is gated behind a classifier hit (rare, human-paced), and the blast radius
+  of a misfire is a noisy JSONL line + one `console.warn`. A flag can be added later if the
+  classifier proves noisy in production; it is not warranted for a signal-only, never-throws v1.
+- **Rollback cost:** trivial (see *Risk and rollback*).
+
+## Why this is signal, not authority
+
+The log only **records** and **summarizes**. It has no blocking authority and gates nothing.
+Consumers — a human reading the heat map, or future evolution tooling — decide what to do.
+This conforms to the signal-vs-authority standard (`docs/signal-vs-authority.md`): a brittle,
+low-context regex detector emits signals only; it never vetoes.
+
+## Risk and rollback
+
+Low. Additive, isolated module. Worst case on a logic bug: a spurious JSONL line or a missed
+signal — neither affects message delivery, because `observe` never throws into the caller. The
+classifier's false-positive risk is bounded by the `totalWeight >= 2` threshold. Rollback is
+trivial: drop the module, the endpoint, the `INTERNAL_PREFIXES` entry, and the ~10 wiring
+lines — no schema, no migration, no config default.
+
+## Migration parity
+
+The feature is server-side code (the wiring lives in `server.ts`, which every agent runs on
+update) plus a new read-only route. There is **no** agent-installed-file change — no hook, no
+`.claude/settings.json`, no config default, no CLAUDE.md template entry (the route is internal,
+so adding it to the agent-facing template would be inconsistent). Therefore no
+`PostUpdateMigrator` work is required: agents receive the behavior with the server code on
+their next update.
+
+## Build-on-current-main caveat (from the handoff)
+
+Dawn's reference module + tests are correct, but her **local Instar checkout is 405 commits
+behind `origin/main` with 719 staged changes (138 deletions of real upstream files).** Building
+from it would silently revert the `SafeFsExecutor` destructive-operation containment (PRs
+#98/#99) and the iMessage `[image:/path]` attachment inlining (commit 2d4deb73). This spec is
+implemented **fresh on current main**; the ~10 wiring lines are re-applied by hand, never
+copied from her staged `server.ts`. (The irony is noted: blindly committing her tree would
+cause exactly the silent regression this module exists to detect.)
+
+## Testing (all three tiers — Testing Integrity Standard)
+
+- **Tier 1 (unit, 22):** `classify` across every category + both sides of the
+  weight-threshold boundary; `observe` records/persists/never-throws; `summarizeByLayer`
+  ordering; `observeInboundMessage` wiring-integrity (inbound-human observed; agent / empty /
+  non-correction skipped); and the convergence-added privacy/durability tests (preview never
+  hits disk; the heat map hydrates from disk on a fresh instance; hydration is a safe no-op
+  with no file).
+- **Tier 2 (integration, 3):** `GET /human-as-detector/summary` through the real `createRoutes`
+  pipeline — empty before any signal, surfaces a recorded correction, ignores a non-correction.
+- **Tier 3 (e2e, 2):** boots `createRoutes` on a live HTTP server — endpoint alive (200, not
+  503), and an observed correction flows to the live endpoint AND to the JSONL on disk
+  (cross-session audit trail).
+- `npx tsc --noEmit` clean; `npm run lint` clean (destructive-tool + LLM-HTTP + codex-rule1).
+
+## Acceptance criteria
+
+1. A human correction over Telegram produces exactly one signal in
+   `.instar/metrics/human-as-detector.jsonl`, mapped to a plausible failed layer.
+2. A non-correction message produces no signal.
+3. `GET /human-as-detector/summary` returns the heat map and recent signals; never 503.
+4. Message delivery is never blocked or slowed by the observer (best-effort, never throws).
+5. No existing upstream feature is reverted; all three test tiers and lint are green.

--- a/docs/specs/reports/human-as-detector-convergence.md
+++ b/docs/specs/reports/human-as-detector-convergence.md
@@ -1,0 +1,89 @@
+# Convergence Report — HumanAsDetectorLog
+
+## ELI10 Overview
+
+We're adding a way for the agent to learn from the moments *you* catch its mistakes. Today,
+when you say "that's wrong" or "that's out of date," the agent just fixes it and forgets it.
+But your catching it is itself a clue: it means one of the agent's own automated safety
+checks should have caught the problem and didn't. This feature quietly logs each correction
+and tags it with which safety check probably failed, building a "heat map" of where the
+agent's guardrails are weakest — so we can strengthen the right ones instead of guessing.
+
+It's deliberately a thermometer, not a gate: it only watches and records, it never blocks
+anything, and it can never slow down or break a message getting to the agent. It uses no AI
+and no internet — just a careful list of correction phrases, tuned to under-react so it
+doesn't cry wolf.
+
+The main tradeoffs: it's biased toward missing some corrections rather than logging false
+ones (a missed one loses a data point; a false one pollutes the map). It can be skewed by
+someone spamming correction phrases — but since it controls nothing, that only makes a chart
+noisy, not the agent unsafe. This version watches Telegram; the other channels are an easy
+planned follow-up.
+
+## Original vs Converged
+
+The original spec described a correct, working module (ported from Dawn's reference) but the
+review round caught two real problems that the converged version fixes:
+
+1. **Privacy leak fixed.** Originally the on-disk log stored a 220-character preview of your
+   actual message. If you ever typed a password or private detail while correcting the agent,
+   it would have sat in a log file forever. After review, the raw words are kept only in
+   short-lived memory and **never written to disk** — the log keeps only the category and
+   which guardrail failed. The file is also locked down to owner-only permissions.
+
+2. **The heat map no longer empties on restart.** Originally the summary you'd view read only
+   from in-memory data, so every time the agent restarted (which it does often, for updates),
+   the heat map silently reset to zero even though the history was safe on disk. After review,
+   it reloads its history from disk on startup.
+
+The review also made the **Telegram-only scope explicit** (Slack/WhatsApp/iMessage are a
+tracked follow-up, not a silent gap) and added a **structured side-effects section** to the
+spec.
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec/code changes |
+|-----------|-----------------------|-------------------|-------------------|
+| 1 | security, scalability, lessons-aware | 4 | metadata-only persistence + 0600/0700; restart hydration from JSONL; explicit Telegram-first scope note; structured side-effects section; +3 unit tests |
+| 2 | (converged) | 0 | none — all material findings addressed; remaining items (kill-switch, dashboard tab, source/topicId in summary) documented as deliberate v1 choices / future rungs |
+
+Abbreviated convergence (sanctioned for a small, Dawn-pre-reviewed pattern-instance that
+mirrors `DegradationReporter`): internal reviewers only (security, scalability/integration,
+lessons-aware — the mandatory pass), external cross-model reviewers skipped. One review round
+plus an addressing round.
+
+## Full Findings Catalog
+
+**Iteration 1**
+
+- **[Security · MEDIUM] World-readable JSONL persisting `messagePreview` (raw user text).**
+  Resolution: persist metadata only (drop `messagePreview` before write); create file `0600`,
+  dir `0700`. The preview survives only in the in-memory ring for the live session.
+- **[Scalability/Integration · MEDIUM] Summary endpoint reads only the volatile in-memory
+  ring → heat map silently empties on every restart.** Resolution: `configure()` hydrates the
+  ring from the last 200 persisted records (best-effort).
+- **[Lessons-aware · MEDIUM] Adapter-coverage gap — only Telegram inbound observed; Slack/etc.
+  corrections silently skew the map (multi-entry-point trap).** Resolution: explicit, tracked
+  "Telegram-first" scope section + follow-up task; the gate (`observeInboundMessage`) is
+  adapter-agnostic so extension is mechanical. (No-Deferrals satisfied: tracked, not orphaned.)
+- **[Lessons-aware · LOW] Spec lacked a structured side-effects artifact section.** Resolution:
+  added a Side-effects review section (over/under-block, poisoning, abstraction-fit,
+  interactions, privacy, no-kill-switch rationale, rollback).
+
+**Non-material (noted, not blocking):**
+- Callback chaining verified sound (preserves TopicMemory/PresenceProxy/keep-watching) — no change.
+- Migration parity claim verified correct (server-side code only) — no change.
+- Multi-machine JSONL isolation verified (per-agent stateDir) — no change.
+- ReDoS: regex set is linear, no catastrophic backtracking — no change.
+- Authority: confirmed pure-signal, gates nothing — the most important property, holds.
+- Kill-switch flag: deliberately omitted for a never-throws, signal-only v1 (documented).
+- `messagePreview` → future-LLM-consumer injection: one-line caveat added for that future rung.
+- Optional classify input-length cap: noted, not adopted (linear cost, low value).
+
+## Convergence verdict
+
+Converged at iteration 2. No material findings remain in the addressing round. All four
+material findings from iteration 1 are resolved in code (privacy + hydration, with 3 new unit
+tests) and in the spec (scope note + side-effects section). The feature ships all three test
+tiers green (22 unit + 3 integration + 2 e2e) with `tsc` and `lint` clean. Spec is ready for
+user review and approval.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -74,6 +74,7 @@ import { AutonomousEvolution } from '../core/AutonomousEvolution.js';
 import { DispatchScopeEnforcer } from '../core/DispatchScopeEnforcer.js';
 import { TrustRecovery } from '../core/TrustRecovery.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { HumanAsDetectorLog, observeInboundMessage } from '../monitoring/HumanAsDetectorLog.js';
 import { resolveStableNodeBinary } from '../utils/resolveNodeBinary.js';
 import { SelfKnowledgeTree } from '../knowledge/SelfKnowledgeTree.js';
 import { CoverageAuditor } from '../knowledge/CoverageAuditor.js';
@@ -2164,6 +2165,16 @@ export async function startServer(options: StartOptions): Promise<void> {
       stateDir: config.stateDir,
       agentName: config.projectName,
       instarVersion: startupVersion,
+    });
+
+    // HumanAsDetectorLog — treats a human-caught coherence break (a correction,
+    // a "you already said", a "why didn't you catch this") as evidence that some
+    // automated guardian failed. Configured early; the inbound-message observe()
+    // is chained onto telegram.onMessageLogged once telegram is up (see below).
+    const humanAsDetectorLog = HumanAsDetectorLog.getInstance();
+    humanAsDetectorLog.configure({
+      stateDir: config.stateDir,
+      agentName: config.projectName,
     });
 
     // Clean up stale Telegram temp files on startup
@@ -5846,6 +5857,15 @@ export async function startServer(options: StartOptions): Promise<void> {
             senderUsername: entry.senderUsername,
             platformUserId: entry.telegramUserId?.toString(),
           });
+        };
+
+        // Human-as-Detector: observe inbound HUMAN messages for coherence-break
+        // corrections — a correction the user had to make is evidence a guardian
+        // failed. Chains the prior callback; best-effort (observe never throws).
+        const beforeHadCallback = telegram.onMessageLogged;
+        telegram.onMessageLogged = (entry) => {
+          if (beforeHadCallback) beforeHadCallback(entry);
+          observeInboundMessage(humanAsDetectorLog, entry);
         };
 
         presenceProxy.start();

--- a/src/monitoring/HumanAsDetectorLog.ts
+++ b/src/monitoring/HumanAsDetectorLog.ts
@@ -1,0 +1,318 @@
+/**
+ * HumanAsDetectorLog — treats every human-caught coherence break as a
+ * first-class diagnostic signal about which automated layer FAILED.
+ *
+ * The insight (Dawn's 2026-04-26 Lesson, "Justin Pointing Things Out =
+ * Guardian Failure"): when a human has to surface something wrong — a stale
+ * claim, a contradiction, a state incoherence — that is not a normal input to
+ * be quietly fixed. It is evidence that some monitor/gate/guardian that was
+ * supposed to catch it didn't. Logging these over time produces a heat map of
+ * "where the human is doing the system's job," which tells you which automated
+ * layers are dead weight and which coverage gaps are real.
+ *
+ * Instar already has CoherenceMonitor, CoherenceGate, and DegradationReporter —
+ * but all of those watch the system's OWN state. None of them treat a human
+ * correction as a signal. This closes that gap.
+ *
+ * Pattern mirrors DegradationReporter: singleton, configure() at startup,
+ * append-only JSONL persistence, best-effort and never throws into the caller.
+ *
+ * Usage:
+ *   const log = HumanAsDetectorLog.getInstance();
+ *   log.configure({ stateDir, agentName });
+ *   // On every inbound human message:
+ *   log.observe({ text, topicId, messageId, source: 'telegram' });
+ *
+ * Ported from Dawn's human-as-detector.jsonl infrastructure.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** A detected human-as-detector signal. */
+export interface HumanDetectorSignal {
+  /** ISO timestamp when the signal was recorded */
+  ts: string;
+  /** Where the correction arrived from (telegram, slack, lifeline, ...) */
+  source: string;
+  /** Topic/channel id, if known */
+  topicId: number | null;
+  /** Message id, if known */
+  messageId: number | null;
+  /** Coarse classification of what kind of break the human surfaced */
+  category: HumanDetectorCategory;
+  /** Which automated layer should plausibly have caught this first */
+  suspectedFailedLayer: string;
+  /** Confidence the message really is a human-caught coherence break */
+  confidence: 'low' | 'medium' | 'high';
+  /** Why the classifier fired (the signal phrases it matched) */
+  matchedSignals: string[];
+  /** Short preview of the human's message (truncated) */
+  messagePreview: string;
+}
+
+export type HumanDetectorCategory =
+  | 'factual-correction'      // "that's wrong", "actually X is Y"
+  | 'staleness'               // "out of date", "you said that days ago"
+  | 'contradiction'           // "but you just said", "that contradicts"
+  | 'source-of-truth-drift'   // "the record says X but you said Y"
+  | 'repeat-ask'              // "I already told you", "again?"
+  | 'meta-failure';           // "why didn't the system catch this"
+
+interface SignalRule {
+  /** Regex tested against the lowercased message text */
+  pattern: RegExp;
+  category: HumanDetectorCategory;
+  /** Which guardian/monitor should have caught this class of break */
+  suspectedLayer: string;
+  /** Weight toward confidence */
+  weight: number;
+  /** Human-readable label for matchedSignals */
+  label: string;
+}
+
+// Conservative signal set — biased toward precision over recall. A missed
+// signal is a lost data point; a false positive pollutes the heat map.
+const SIGNAL_RULES: SignalRule[] = [
+  { pattern: /\bthat'?s (not right|wrong|incorrect|false)\b/, category: 'factual-correction', suspectedLayer: 'CoherenceGate / output-sanity', weight: 3, label: "that's wrong" },
+  { pattern: /\b(this|that) is (wrong|incorrect|false)\b/, category: 'factual-correction', suspectedLayer: 'CoherenceGate / output-sanity', weight: 3, label: 'this is wrong' },
+  { pattern: /\byou (said|claimed|told me)\b.*\b(but|however|actually|not)\b/, category: 'contradiction', suspectedLayer: 'CoherenceMonitor (self-claim consistency)', weight: 3, label: 'you said X but' },
+  { pattern: /\bthat contradicts\b|\bcontradicts what\b/, category: 'contradiction', suspectedLayer: 'CoherenceMonitor (self-claim consistency)', weight: 3, label: 'contradicts' },
+  { pattern: /\b(out of date|outdated|stale|no longer true|already (resolved|fixed|done))\b/, category: 'staleness', suspectedLayer: 'freshness-gate / state-of-truth registry', weight: 3, label: 'stale/outdated' },
+  { pattern: /\bthe (record|registry|state|file) says\b/, category: 'source-of-truth-drift', suspectedLayer: 'source-of-truth registry sync', weight: 2, label: 'record says' },
+  { pattern: /\bi (already (told|said)|just told you)\b/, category: 'repeat-ask', suspectedLayer: 'commitment/memory recall', weight: 2, label: 'I already told you' },
+  { pattern: /\bwhy (didn'?t|did no|wasn'?t).*(catch|caught|detect|flag|notice)\b/, category: 'meta-failure', suspectedLayer: 'guardian coverage (no owner)', weight: 3, label: 'why not caught' },
+  { pattern: /\bactually,?\s/, category: 'factual-correction', suspectedLayer: 'CoherenceGate / output-sanity', weight: 1, label: 'actually,' },
+  { pattern: /\bthat'?s not (what|how)\b/, category: 'factual-correction', suspectedLayer: 'CoherenceGate / output-sanity', weight: 2, label: "that's not what/how" },
+];
+
+const PREVIEW_MAX = 220;
+
+export class HumanAsDetectorLog {
+  private static instance: HumanAsDetectorLog | null = null;
+
+  private stateDir: string | null = null;
+  private agentName = 'unknown';
+  /** In-memory ring of recent signals (for health/summary without disk reads) */
+  private recent: HumanDetectorSignal[] = [];
+
+  private constructor() {}
+
+  static getInstance(): HumanAsDetectorLog {
+    if (!HumanAsDetectorLog.instance) {
+      HumanAsDetectorLog.instance = new HumanAsDetectorLog();
+    }
+    return HumanAsDetectorLog.instance;
+  }
+
+  /** Reset singleton for testing. */
+  static resetForTesting(): void {
+    HumanAsDetectorLog.instance = null;
+  }
+
+  configure(opts: { stateDir: string; agentName?: string }): void {
+    this.stateDir = opts.stateDir;
+    if (opts.agentName) this.agentName = opts.agentName;
+    // Repopulate the in-memory ring from disk so the heat map survives the
+    // frequent restarts instar undergoes (auto-update, lifeline coordination).
+    this.hydrateFromDisk();
+  }
+
+  /**
+   * Classify a piece of human text WITHOUT recording it. Pure, deterministic,
+   * no I/O — this is the unit-testable core.
+   *
+   * Returns null if the text doesn't look like a coherence-break correction.
+   */
+  classify(text: string): {
+    category: HumanDetectorCategory;
+    suspectedFailedLayer: string;
+    confidence: 'low' | 'medium' | 'high';
+    matchedSignals: string[];
+  } | null {
+    if (!text || typeof text !== 'string') return null;
+    const lower = text.toLowerCase();
+
+    const matched: SignalRule[] = [];
+    for (const rule of SIGNAL_RULES) {
+      if (rule.pattern.test(lower)) matched.push(rule);
+    }
+    if (matched.length === 0) return null;
+
+    // Strongest-weight rule decides the category & suspected layer.
+    const top = matched.reduce((a, b) => (b.weight > a.weight ? b : a));
+    const totalWeight = matched.reduce((sum, r) => sum + r.weight, 0);
+
+    // A lone weight-1 signal ("actually,") is too weak on its own.
+    if (totalWeight < 2) return null;
+
+    const confidence: 'low' | 'medium' | 'high' =
+      totalWeight >= 5 ? 'high' : totalWeight >= 3 ? 'medium' : 'low';
+
+    return {
+      category: top.category,
+      suspectedFailedLayer: top.suspectedLayer,
+      confidence,
+      matchedSignals: matched.map((r) => r.label),
+    };
+  }
+
+  /**
+   * Observe an inbound human message. If it looks like a coherence-break
+   * correction, record it. Returns the recorded signal, or null if the message
+   * wasn't a correction. Never throws.
+   */
+  observe(input: {
+    text: string;
+    source: string;
+    topicId?: number | null;
+    messageId?: number | null;
+  }): HumanDetectorSignal | null {
+    try {
+      const verdict = this.classify(input.text);
+      if (!verdict) return null;
+
+      const signal: HumanDetectorSignal = {
+        ts: new Date().toISOString(),
+        source: input.source,
+        topicId: input.topicId ?? null,
+        messageId: input.messageId ?? null,
+        category: verdict.category,
+        suspectedFailedLayer: verdict.suspectedFailedLayer,
+        confidence: verdict.confidence,
+        matchedSignals: verdict.matchedSignals,
+        messagePreview: input.text.slice(0, PREVIEW_MAX),
+      };
+
+      this.recent.push(signal);
+      if (this.recent.length > 200) this.recent = this.recent.slice(-200);
+
+      this.persist(signal);
+
+      // Visible, never silent — mirrors DegradationReporter's console signal.
+      console.warn(
+        `[HUMAN-AS-DETECTOR] ${signal.category} (${signal.confidence}) — ` +
+        `suspected layer that should have caught it: ${signal.suspectedFailedLayer}`,
+      );
+
+      return signal;
+    } catch {
+      // Best-effort — a logging failure must never break message handling.
+      return null;
+    }
+  }
+
+  /** Recent in-memory signals (for health checks / summary endpoint). */
+  getRecent(): HumanDetectorSignal[] {
+    return [...this.recent];
+  }
+
+  /**
+   * Summarize signals grouped by suspected failed layer — the heat map of
+   * "where the human is doing the system's job."
+   */
+  summarizeByLayer(): Array<{ layer: string; count: number; categories: string[] }> {
+    const byLayer = new Map<string, { count: number; categories: Set<string> }>();
+    for (const s of this.recent) {
+      const entry = byLayer.get(s.suspectedFailedLayer) ?? { count: 0, categories: new Set<string>() };
+      entry.count++;
+      entry.categories.add(s.category);
+      byLayer.set(s.suspectedFailedLayer, entry);
+    }
+    return [...byLayer.entries()]
+      .map(([layer, v]) => ({ layer, count: v.count, categories: [...v.categories] }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  // ── Internal ──────────────────────────────────────────────
+
+  private persist(signal: HumanDetectorSignal): void {
+    if (!this.stateDir) return;
+    try {
+      const dir = path.join(this.stateDir, 'metrics');
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+      const filePath = path.join(dir, 'human-as-detector.jsonl');
+      // Persist METADATA ONLY — never the user's raw words. messagePreview
+      // stays in the in-memory ring for this session's heat map, but is kept
+      // OFF disk so a secret/PII a user types mid-correction can't leak into
+      // the append-only audit trail. Mode 0600 is defense-in-depth on the
+      // metadata that remains (file mode applies only on creation).
+      const { messagePreview: _omitFromDisk, ...metadata } = signal;
+      fs.appendFileSync(
+        filePath,
+        JSON.stringify({ ...metadata, agentName: this.agentName }) + '\n',
+        { mode: 0o600 },
+      );
+    } catch {
+      // Disk persistence is best-effort; the console.warn is the safety net.
+    }
+  }
+
+  /**
+   * Best-effort: repopulate the in-memory ring from the last 200 persisted
+   * records. The heat map (summarizeByLayer + recent) reads only the ring, so
+   * without this it would silently empty on every restart even though the full
+   * history is on disk. Persisted records carry no messagePreview (kept off
+   * disk by persist()), so hydrated entries have an empty preview — the byLayer
+   * counts, which are the point of the heat map, are fully restored.
+   */
+  private hydrateFromDisk(): void {
+    if (!this.stateDir) return;
+    try {
+      const filePath = path.join(this.stateDir, 'metrics', 'human-as-detector.jsonl');
+      if (!fs.existsSync(filePath)) return;
+      const lines = fs.readFileSync(filePath, 'utf-8').split('\n').filter((l) => l.trim());
+      const hydrated: HumanDetectorSignal[] = [];
+      for (const line of lines.slice(-200)) {
+        try {
+          const r = JSON.parse(line) as Partial<HumanDetectorSignal>;
+          if (!r.category || !r.suspectedFailedLayer) continue;
+          hydrated.push({
+            ts: r.ts ?? '',
+            source: r.source ?? 'unknown',
+            topicId: r.topicId ?? null,
+            messageId: r.messageId ?? null,
+            category: r.category,
+            suspectedFailedLayer: r.suspectedFailedLayer,
+            confidence: r.confidence ?? 'low',
+            matchedSignals: r.matchedSignals ?? [],
+            messagePreview: r.messagePreview ?? '',
+          });
+        } catch {
+          // skip a malformed line — best-effort hydration
+        }
+      }
+      this.recent = hydrated;
+    } catch {
+      // unreadable file → start with an empty ring; never throw at startup
+    }
+  }
+}
+
+/** Minimal shape of an inbound message-logged entry the wiring reads. */
+export interface InboundMessageEntry {
+  fromUser?: boolean;
+  text?: string;
+  topicId?: number | null;
+  messageId?: number | null;
+}
+
+/**
+ * The gating decision used where the log is chained onto a message adapter's
+ * onMessageLogged: observe ONLY inbound HUMAN messages that carry text. Agent
+ * messages and empty entries are skipped. Extracted from the server wiring so
+ * the inbound-human gate is unit-testable (wiring-integrity), not buried inline.
+ */
+export function observeInboundMessage(
+  log: HumanAsDetectorLog,
+  entry: InboundMessageEntry,
+  source = 'telegram',
+): HumanDetectorSignal | null {
+  if (!entry.fromUser || !entry.text) return null;
+  return log.observe({
+    text: entry.text,
+    source,
+    topicId: entry.topicId ?? null,
+    messageId: entry.messageId ?? null,
+  });
+}

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -727,6 +727,7 @@ export const INTERNAL_PREFIXES: ReadonlyArray<{ prefix: string; reason: string }
   { prefix: 'delivery-queue', reason: 'operator-only relay queue observability' },
   { prefix: 'prompt-gate', reason: 'operator-only prompt-gate observability' },
   { prefix: 'scope-coherence', reason: 'operator-only scope-coherence observability' },
+  { prefix: 'human-as-detector', reason: 'operator-only observability — the heat map of human-caught guardian failures; the agent-facing payoff is the silent capture + future evolution use, not a discoverable endpoint' },
   { prefix: 'rate-limit', reason: 'operator-only rate-limit-sentinel observability — agent-facing surface is the sentinel’s own notices' },
   { prefix: 'slack', reason: 'surfaced via messaging adapters' },
   { prefix: 'whatsapp', reason: 'surfaced via messaging adapters' },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -22,6 +22,7 @@ import type { WriteOperation, WriteToken } from '../core/StateWriteAuthority.js'
 import { writeLifelineRestartSignal } from '../core/version-skew.js';
 import { validateWriteToken, canPerformOperation } from '../core/StateWriteAuthority.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
+import { HumanAsDetectorLog } from '../monitoring/HumanAsDetectorLog.js';
 import { parseVersion, compareVersions } from '../lifeline/versionHandshake.js';
 import {
   GATE_ROUTE_VERSION,
@@ -3986,6 +3987,19 @@ export function createRoutes(ctx: RouteContext): Router {
       sinceMs,
       summary: ctx.tokenLedger.summary({ sinceMs }),
       codex: ctx.tokenLedger.codexSummary({ sinceMs }),
+    });
+  });
+
+  // ── Human-as-Detector heat map ───────────────────────────────────────
+  // "Where the human is doing the system's job": coherence breaks a human had
+  // to surface, grouped by the automated layer that should plausibly have
+  // caught each. Observability-only, read-only. The singleton is always
+  // configured at startup, so no availability guard is needed.
+  router.get('/human-as-detector/summary', (_req, res) => {
+    const log = HumanAsDetectorLog.getInstance();
+    res.json({
+      byLayer: log.summarizeByLayer(),
+      recent: log.getRecent().slice(-50),
     });
   });
 

--- a/tests/e2e/human-as-detector-lifecycle.test.ts
+++ b/tests/e2e/human-as-detector-lifecycle.test.ts
@@ -1,0 +1,107 @@
+/**
+ * E2E lifecycle test (Tier 3) for Human-as-Detector.
+ *
+ * Boots the real route tree (createRoutes) on a live HTTP server and proves
+ * the feature is ALIVE end-to-end: an observed inbound human correction flows
+ * through the gating helper, lands in the heat map AND on disk, and the
+ * /human-as-detector/summary endpoint returns 200 (not 503) over real HTTP.
+ *
+ * "Is the feature actually alive?" — the single most important tier for any
+ * feature with API routes (CLAUDE.md Testing Integrity Standard).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import type { Server } from 'node:http';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { HumanAsDetectorLog, observeInboundMessage } from '../../src/monitoring/HumanAsDetectorLog.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('E2E: Human-as-Detector lifecycle', () => {
+  let projectDir: string;
+  let stateDir: string;
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-had-e2e-'));
+    stateDir = path.join(projectDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    HumanAsDetectorLog.resetForTesting();
+    HumanAsDetectorLog.getInstance().configure({ stateDir, agentName: 'had-e2e' });
+
+    const ctx = {
+      config: {
+        projectName: 'had-e2e', projectDir, stateDir, port: 0,
+        sessions: {} as any, scheduler: {} as any,
+      } as any,
+      sessionManager: { listRunningSessions: () => [] } as any,
+      state: { getJobState: () => null, getSession: () => null } as any,
+      scheduler: null, telegram: null, relationships: null, feedback: null,
+      dispatches: null, updateChecker: null, autoUpdater: null, autoDispatcher: null,
+      quotaTracker: null, publisher: null, viewer: null, tunnel: null, evolution: null,
+      watchdog: null, triageNurse: null, topicMemory: null, discoveryEvaluator: null,
+      startTime: new Date(),
+    } as RouteContext;
+
+    const app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctx));
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        const addr = server.address();
+        const port = typeof addr === 'object' && addr ? addr.port : 0;
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    HumanAsDetectorLog.resetForTesting();
+    try {
+      SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/e2e/human-as-detector-lifecycle.test.ts' });
+    } catch { /* best-effort */ }
+  });
+
+  it('endpoint is alive (200) and empty before any signal', async () => {
+    const res = await fetch(`${baseUrl}/human-as-detector/summary`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.byLayer).toEqual([]);
+    expect(body.recent).toEqual([]);
+  });
+
+  it('an observed inbound correction flows to the live endpoint AND to disk', async () => {
+    // Simulate the server's inbound-message wiring via the same gating helper.
+    const signal = observeInboundMessage(HumanAsDetectorLog.getInstance(), {
+      fromUser: true,
+      text: "you said that's done, but the registry says it's still open",
+      topicId: 12118,
+      messageId: 7,
+    });
+    expect(signal).not.toBeNull();
+
+    const res = await fetch(`${baseUrl}/human-as-detector/summary`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.byLayer.length).toBeGreaterThan(0);
+    expect(body.recent.length).toBe(1);
+    expect(body.recent[0].topicId).toBe(12118);
+
+    // End-to-end persistence: the signal is on disk for cross-session audit.
+    const jsonlPath = path.join(stateDir, 'metrics', 'human-as-detector.jsonl');
+    expect(fs.existsSync(jsonlPath)).toBe(true);
+    const lines = fs.readFileSync(jsonlPath, 'utf-8').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBe(1);
+    const persisted = JSON.parse(lines[0]);
+    expect(persisted.topicId).toBe(12118);
+    expect(persisted.agentName).toBe('had-e2e');
+  });
+});

--- a/tests/integration/human-as-detector-routes.test.ts
+++ b/tests/integration/human-as-detector-routes.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Integration test (Tier 2) for the Human-as-Detector observability route.
+ *
+ * Proves GET /human-as-detector/summary works through the real HTTP pipeline
+ * (createRoutes) and reflects signals recorded on the singleton. The route
+ * reads HumanAsDetectorLog.getInstance() directly (singleton, like
+ * DegradationReporter), so the test configures the singleton, records a
+ * correction, then asserts the endpoint surfaces it in the heat map.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { HumanAsDetectorLog } from '../../src/monitoring/HumanAsDetectorLog.js';
+
+function createMinimalContext(stateDir: string): RouteContext {
+  return {
+    config: {
+      projectName: 'test-project',
+      projectDir: path.dirname(stateDir),
+      stateDir,
+      port: 0,
+      sessions: {} as any,
+      scheduler: {} as any,
+    } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null,
+    telegram: null,
+    relationships: null,
+    feedback: null,
+    dispatches: null,
+    updateChecker: null,
+    autoUpdater: null,
+    autoDispatcher: null,
+    quotaTracker: null,
+    publisher: null,
+    viewer: null,
+    tunnel: null,
+    evolution: null,
+    watchdog: null,
+    triageNurse: null,
+    topicMemory: null,
+    discoveryEvaluator: null,
+    startTime: new Date(),
+  } as RouteContext;
+}
+
+describe('Human-as-Detector routes (integration)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let app: express.Express;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'had-routes-test-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    HumanAsDetectorLog.resetForTesting();
+    HumanAsDetectorLog.getInstance().configure({ stateDir, agentName: 'test' });
+
+    const ctx = createMinimalContext(stateDir);
+    app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctx));
+  });
+
+  afterEach(() => {
+    HumanAsDetectorLog.resetForTesting();
+    try {
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/human-as-detector-routes.test.ts' });
+    } catch { /* best-effort */ }
+  });
+
+  it('returns an empty heat map before any signal', async () => {
+    const res = await request(app).get('/human-as-detector/summary');
+    expect(res.status).toBe(200);
+    expect(res.body.byLayer).toEqual([]);
+    expect(res.body.recent).toEqual([]);
+  });
+
+  it('surfaces a recorded correction in the heat map and recent list', async () => {
+    const log = HumanAsDetectorLog.getInstance();
+    const signal = log.observe({
+      text: "that's wrong, the record says otherwise",
+      source: 'telegram',
+      topicId: 12118,
+      messageId: 42,
+    });
+    expect(signal).not.toBeNull();
+
+    const res = await request(app).get('/human-as-detector/summary');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.byLayer)).toBe(true);
+    expect(res.body.byLayer.length).toBeGreaterThan(0);
+    expect(res.body.byLayer[0]).toHaveProperty('layer');
+    expect(res.body.byLayer[0]).toHaveProperty('count');
+    expect(res.body.recent.length).toBe(1);
+    expect(res.body.recent[0].topicId).toBe(12118);
+    expect(res.body.recent[0].category).toBe('factual-correction');
+  });
+
+  it('ignores a non-correction message (no signal, empty map)', async () => {
+    const log = HumanAsDetectorLog.getInstance();
+    const signal = log.observe({ text: 'thanks, that looks great!', source: 'telegram' });
+    expect(signal).toBeNull();
+
+    const res = await request(app).get('/human-as-detector/summary');
+    expect(res.status).toBe(200);
+    expect(res.body.byLayer).toEqual([]);
+    expect(res.body.recent).toEqual([]);
+  });
+});

--- a/tests/unit/HumanAsDetectorLog.test.ts
+++ b/tests/unit/HumanAsDetectorLog.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { HumanAsDetectorLog, observeInboundMessage } from '../../src/monitoring/HumanAsDetectorLog.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('HumanAsDetectorLog', () => {
+  let tmpDir: string;
+  let log: HumanAsDetectorLog;
+
+  beforeEach(() => {
+    HumanAsDetectorLog.resetForTesting();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hadl-'));
+    log = HumanAsDetectorLog.getInstance();
+    log.configure({ stateDir: tmpDir, agentName: 'test-agent' });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/HumanAsDetectorLog.test.ts' });
+    HumanAsDetectorLog.resetForTesting();
+  });
+
+  describe('classify (pure, deterministic)', () => {
+    it('flags an explicit factual correction', () => {
+      const v = log.classify("That's wrong, the X account was reinstated days ago.");
+      expect(v).not.toBeNull();
+      // staleness signal ("days ago" isn't matched, but "reinstated"/"that's wrong" is)
+      expect(['factual-correction', 'staleness']).toContain(v!.category);
+      expect(v!.confidence).toBe('medium'); // "that's wrong" (weight 3)
+    });
+
+    it('flags a self-contradiction', () => {
+      const v = log.classify('You said the deadline was tomorrow but actually it already passed.');
+      expect(v).not.toBeNull();
+      expect(v!.category).toBe('contradiction');
+      expect(v!.suspectedFailedLayer).toMatch(/CoherenceMonitor/);
+    });
+
+    it('flags staleness', () => {
+      const v = log.classify('This is out of date — that was already fixed.');
+      expect(v).not.toBeNull();
+      expect(v!.category).toBe('staleness');
+      expect(v!.confidence).toBe('medium'); // staleness rule (weight 3)
+    });
+
+    it('flags a meta-failure question', () => {
+      const v = log.classify("Why didn't the system catch this before sending it to me?");
+      expect(v).not.toBeNull();
+      expect(v!.category).toBe('meta-failure');
+      expect(v!.suspectedFailedLayer).toMatch(/coverage/);
+    });
+
+    it('reaches high confidence when multiple strong signals stack', () => {
+      // contradiction (3) + "that's wrong" (3) = 6 → high
+      const v = log.classify("You told me it shipped, but that's wrong.");
+      expect(v).not.toBeNull();
+      expect(v!.confidence).toBe('high');
+      expect(v!.matchedSignals.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('does NOT flag a benign message', () => {
+      expect(log.classify('Thanks, that looks great. Can you also add a chart?')).toBeNull();
+      expect(log.classify('What time is the meeting tomorrow?')).toBeNull();
+      expect(log.classify('')).toBeNull();
+    });
+
+    it('does NOT flag a lone weak "actually" signal', () => {
+      // weight-1 only → below the threshold of 2
+      expect(log.classify('Actually, I think a chart would be nice here.')).toBeNull();
+    });
+
+    it('is null-safe on non-string input', () => {
+      // @ts-expect-error testing runtime guard
+      expect(log.classify(null)).toBeNull();
+      // @ts-expect-error testing runtime guard
+      expect(log.classify(undefined)).toBeNull();
+    });
+  });
+
+  describe('observe (records + persists)', () => {
+    it('records a correction and writes JSONL', () => {
+      const signal = log.observe({
+        text: "That's incorrect — you said it was done but the record says otherwise.",
+        source: 'telegram',
+        topicId: 25726,
+        messageId: 42,
+      });
+      expect(signal).not.toBeNull();
+      expect(signal!.source).toBe('telegram');
+      expect(signal!.topicId).toBe(25726);
+
+      const file = path.join(tmpDir, 'metrics', 'human-as-detector.jsonl');
+      expect(fs.existsSync(file)).toBe(true);
+      const lines = fs.readFileSync(file, 'utf-8').trim().split('\n');
+      expect(lines.length).toBe(1);
+      const parsed = JSON.parse(lines[0]);
+      expect(parsed.agentName).toBe('test-agent');
+      expect(parsed.category).toBeTruthy();
+    });
+
+    it('returns null and writes nothing for benign messages', () => {
+      const signal = log.observe({ text: 'Sounds good, thanks!', source: 'telegram' });
+      expect(signal).toBeNull();
+      const file = path.join(tmpDir, 'metrics', 'human-as-detector.jsonl');
+      expect(fs.existsSync(file)).toBe(false);
+    });
+
+    it('truncates long previews', () => {
+      const long = "That's wrong. " + 'x'.repeat(500);
+      const signal = log.observe({ text: long, source: 'telegram' });
+      expect(signal!.messagePreview.length).toBeLessThanOrEqual(220);
+    });
+
+    it('appends multiple signals', () => {
+      log.observe({ text: "That's wrong.", source: 'telegram' });
+      log.observe({ text: 'This is out of date.', source: 'slack' });
+      const file = path.join(tmpDir, 'metrics', 'human-as-detector.jsonl');
+      const lines = fs.readFileSync(file, 'utf-8').trim().split('\n');
+      expect(lines.length).toBe(2);
+    });
+
+    it('never throws even if stateDir is unset', () => {
+      HumanAsDetectorLog.resetForTesting();
+      const fresh = HumanAsDetectorLog.getInstance(); // no configure()
+      expect(() => fresh.observe({ text: "That's wrong.", source: 'telegram' })).not.toThrow();
+    });
+  });
+
+  describe('summarizeByLayer (heat map)', () => {
+    it('groups signals by suspected failed layer, most-frequent first', () => {
+      log.observe({ text: "That's wrong.", source: 'telegram' });
+      log.observe({ text: "That's incorrect.", source: 'telegram' });
+      log.observe({ text: 'This is out of date.', source: 'telegram' });
+
+      const summary = log.summarizeByLayer();
+      expect(summary.length).toBeGreaterThanOrEqual(2);
+      // output-sanity layer fired twice, should rank first
+      expect(summary[0].count).toBeGreaterThanOrEqual(summary[summary.length - 1].count);
+      const total = summary.reduce((s, e) => s + e.count, 0);
+      expect(total).toBe(3);
+    });
+
+    it('returns empty when nothing observed', () => {
+      expect(log.summarizeByLayer()).toEqual([]);
+    });
+  });
+});
+
+describe('observeInboundMessage — inbound-human gating (wiring integrity)', () => {
+  let tmpDir: string;
+  let log: HumanAsDetectorLog;
+
+  beforeEach(() => {
+    HumanAsDetectorLog.resetForTesting();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hadl-gate-'));
+    log = HumanAsDetectorLog.getInstance();
+    log.configure({ stateDir: tmpDir, agentName: 'test-agent' });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/HumanAsDetectorLog.test.ts' });
+    HumanAsDetectorLog.resetForTesting();
+  });
+
+  it('observes an inbound human correction', () => {
+    const signal = observeInboundMessage(log, {
+      fromUser: true, text: "that's wrong", topicId: 5, messageId: 9,
+    });
+    expect(signal).not.toBeNull();
+    expect(signal!.category).toBe('factual-correction');
+    expect(signal!.topicId).toBe(5);
+    expect(log.getRecent()).toHaveLength(1);
+  });
+
+  it('does NOT observe agent-authored messages', () => {
+    const signal = observeInboundMessage(log, {
+      fromUser: false, text: "that's wrong", topicId: 5,
+    });
+    expect(signal).toBeNull();
+    expect(log.getRecent()).toHaveLength(0);
+  });
+
+  it('does NOT observe empty or textless entries', () => {
+    expect(observeInboundMessage(log, { fromUser: true, text: '' })).toBeNull();
+    expect(observeInboundMessage(log, { fromUser: true })).toBeNull();
+    expect(log.getRecent()).toHaveLength(0);
+  });
+
+  it('returns null for an inbound human message that is not a correction', () => {
+    const signal = observeInboundMessage(log, { fromUser: true, text: 'sounds good, thanks!' });
+    expect(signal).toBeNull();
+    expect(log.getRecent()).toHaveLength(0);
+  });
+});
+
+describe('persistence privacy + restart hydration', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    HumanAsDetectorLog.resetForTesting();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hadl-persist-'));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/HumanAsDetectorLog.test.ts' });
+    HumanAsDetectorLog.resetForTesting();
+  });
+
+  it('NEVER persists messagePreview to disk (the raw user words stay off the audit trail)', () => {
+    const log = HumanAsDetectorLog.getInstance();
+    log.configure({ stateDir: tmpDir, agentName: 'a' });
+    log.observe({ text: "that's wrong — the key is sk-secret-xyz", source: 'telegram', topicId: 1 });
+
+    const jsonl = fs.readFileSync(path.join(tmpDir, 'metrics', 'human-as-detector.jsonl'), 'utf-8').trim();
+    const rec = JSON.parse(jsonl);
+    expect(rec).not.toHaveProperty('messagePreview');
+    expect(jsonl).not.toContain('sk-secret-xyz');
+    // metadata IS persisted
+    expect(rec.category).toBe('factual-correction');
+    expect(rec.topicId).toBe(1);
+    // but the live in-memory ring keeps the preview for this session's heat map
+    expect(log.getRecent()[0].messagePreview).toContain('sk-secret-xyz');
+  });
+
+  it('hydrates the heat map from disk on a fresh instance (survives restart)', () => {
+    const log1 = HumanAsDetectorLog.getInstance();
+    log1.configure({ stateDir: tmpDir, agentName: 'a' });
+    log1.observe({ text: "that's wrong", source: 'telegram', topicId: 1 });
+    log1.observe({ text: 'this is out of date', source: 'telegram', topicId: 1 });
+    expect(log1.getRecent()).toHaveLength(2);
+
+    // Simulate a restart: brand-new singleton, same stateDir.
+    HumanAsDetectorLog.resetForTesting();
+    const log2 = HumanAsDetectorLog.getInstance();
+    log2.configure({ stateDir: tmpDir, agentName: 'a' });
+
+    // Heat map is restored from disk, not empty.
+    expect(log2.getRecent().length).toBe(2);
+    const layers = log2.summarizeByLayer();
+    expect(layers.reduce((s, e) => s + e.count, 0)).toBe(2);
+  });
+
+  it('hydration is a safe no-op when no JSONL exists yet', () => {
+    const log = HumanAsDetectorLog.getInstance();
+    log.configure({ stateDir: tmpDir, agentName: 'a' });
+    expect(log.getRecent()).toEqual([]);
+    expect(log.summarizeByLayer()).toEqual([]);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,57 @@
+# Upgrade Guide — NEXT (human-as-detector)
+
+<!-- bump: minor -->
+<!-- minor = new capability, backward compatible -->
+
+## What Changed
+
+**New: instar now treats a human-caught coherence break as a first-class diagnostic signal.**
+
+When the user has to point something out — "that's wrong", "you already said the opposite",
+"that's out of date", "why didn't you catch this" — that correction is no longer just an
+input to fix quietly. It is evidence that some automated guardian (CoherenceGate,
+CoherenceMonitor, a freshness check) *should* have caught it and didn't. The new
+`HumanAsDetectorLog` (`src/monitoring/HumanAsDetectorLog.ts`) observes inbound human
+messages, classifies corrections with a conservative, precision-biased regex set (no LLM,
+no network), and records each as a signal mapped to the guardian layer that plausibly
+failed. Over time this builds a heat map of "where the human is doing the system's job",
+exposed read-only at `GET /human-as-detector/summary`.
+
+This is the user-feedback half of the Continuous Working Awareness north star: never let a
+user correction go to waste. It mirrors `DegradationReporter`: a singleton configured at
+startup, append-only JSONL persistence at `.instar/metrics/human-as-detector.jsonl`,
+best-effort, and it never throws into message handling. The observe hook is chained onto the
+inbound Telegram message callback (preserving prior callbacks; only inbound human messages
+are observed).
+
+## What to Tell Your User
+
+When you point out something I got wrong or stale, I now treat that as a sign one of my own
+safety checks missed it — not just a one-off to fix and forget. I quietly keep score of which
+checks keep letting things slip past, so we can see where my automated guardrails are weak and
+strengthen them over time. Nothing for you to set up; existing agents get it on their next
+update. You can ask me to show the heat map of where you've had to catch my mistakes.
+
+## Summary of New Capabilities
+
+- New `HumanAsDetectorLog` monitor: classifies inbound human corrections into categories
+  (factual-correction, staleness, contradiction, source-of-truth-drift, repeat-ask,
+  meta-failure), each mapped to the guardian layer that should have caught it.
+- New read-only endpoint `GET /human-as-detector/summary` — the heat map grouped by suspected
+  failed layer, plus recent signals.
+- Append-only audit trail at `.instar/metrics/human-as-detector.jsonl`.
+- Always-on, no config, no LLM, no network; best-effort and never throws into message handling.
+
+## Evidence
+
+- Tier 1 (unit): 19 tests — 15 on the classifier/observe/heat-map core, 4 on the
+  inbound-human gating helper (`observeInboundMessage`). All pass.
+- Tier 2 (integration): 3 tests against the real `createRoutes` pipeline — empty map,
+  recorded correction surfaces, non-correction ignored. All pass.
+- Tier 3 (e2e): 2 tests booting the real route tree on a live HTTP server — endpoint alive
+  (200), and an observed correction flows to the live endpoint AND to the JSONL on disk.
+  All pass.
+- `npx tsc --noEmit` clean.
+- Ported from Dawn's reference implementation (the-portal handoff); built fresh on current
+  `origin/main`, not from the stale local checkout (avoids reverting SafeFsExecutor /
+  iMessage-attachment features per the handoff's critical warnings).

--- a/upgrades/side-effects/human-as-detector.md
+++ b/upgrades/side-effects/human-as-detector.md
@@ -1,0 +1,43 @@
+# Side-Effects Review — HumanAsDetectorLog
+
+**Change**: Ports Dawn's human-as-detector pattern into Instar. Treats every human-caught
+coherence break as a first-class signal about which automated layer failed to catch it.
+
+## Files
+- `src/monitoring/HumanAsDetectorLog.ts` (new) — singleton, deterministic no-LLM classifier,
+  append-only `.instar/metrics/human-as-detector.jsonl`, `summarizeByLayer()` heat map, plus
+  the `observeInboundMessage()` gating helper (inbound-human-only).
+- `tests/unit/HumanAsDetectorLog.test.ts` (new) — 19 unit tests (classifier/observe/heat-map +
+  gating-helper wiring integrity).
+- `tests/integration/human-as-detector-routes.test.ts` (new) — 3 tests via real `createRoutes`.
+- `tests/e2e/human-as-detector-lifecycle.test.ts` (new) — 2 tests, live HTTP boot + disk.
+- `src/server/routes.ts` — adds read-only `GET /human-as-detector/summary` (singleton-backed).
+- `src/commands/server.ts` — configure() at startup; `observeInboundMessage()` chained onto
+  `telegram.onMessageLogged` (chains prior callbacks; only inbound human messages).
+
+## Side effects
+- **New disk write**: appends to `.instar/metrics/human-as-detector.jsonl` only when an
+  inbound human message matches a correction signal. Best-effort; wrapped in try/catch; never
+  throws into message handling.
+- **Console**: one `[HUMAN-AS-DETECTOR]` warn line per detected signal (mirrors
+  DegradationReporter's loud-not-silent convention).
+- **No network, no LLM, no external calls.** Classifier is pure regex over a conservative set.
+- **No behavior change to message handling**: the hook only observes; prior `onMessageLogged`
+  callbacks (TopicMemory dual-write, PresenceProxy, keep-watching) are preserved via chaining.
+- **New endpoint** is read-only and singleton-backed (always available; no 503 path).
+
+## Risk
+- Low. Additive, isolated module. Worst case on a logic bug: a spurious JSONL line or a missed
+  signal — neither affects message delivery (observe never throws into the caller).
+- False-positive risk on the classifier is bounded by the `totalWeight >= 2` threshold (lone
+  weak signals like "actually," are ignored).
+- Rollback cost: trivial — drop the module, the endpoint, and the ~6 wiring lines; no schema,
+  no migration, no config default.
+
+## Signal vs authority
+- Pure signal. The log only *records* and *summarizes*; it has no blocking authority and gates
+  nothing. Consumers (a human reading the heat map, or future evolution tooling) decide.
+
+## Verification
+- `npx tsc --noEmit` — clean (no new errors).
+- `npx vitest run` on the three new test files — 24/24 pass across unit + integration + e2e.


### PR DESCRIPTION
## Summary

Ports Dawn's **human-as-detector** pattern into Instar (the-portal handoff). When the user has to surface something wrong — a correction, a contradiction, a stale claim, "why didn't you catch this" — it is no longer just an input to fix quietly. It is recorded as **evidence that some automated guardian should have caught it and didn't**, building a heat map of "where the human is doing the system's job."

This is the **user-feedback half of the Continuous Working Awareness north star**: never let a user correction go to waste.

## What's included
- `src/monitoring/HumanAsDetectorLog.ts` — singleton, deterministic no-LLM/no-network regex classifier (precision-biased), append-only `.instar/metrics/human-as-detector.jsonl`, `summarizeByLayer()` heat map, and the `observeInboundMessage()` inbound-human gating helper. Best-effort; never throws into message handling.
- `GET /human-as-detector/summary` — read-only heat map (singleton-backed; always available).
- Wiring in `server.ts`: configure at startup; observe chained onto `telegram.onMessageLogged` (inbound-human only; prior callbacks preserved).
- `upgrades/NEXT.md` + `upgrades/side-effects/human-as-detector.md`.

## Testing (all three tiers, green)
- **Unit (19)**: classifier/observe/heat-map (15) + inbound-human gating wiring-integrity (4).
- **Integration (3)**: real `createRoutes` pipeline — empty map, recorded correction surfaces, non-correction ignored.
- **E2E (2)**: live HTTP boot — endpoint alive (200), observed correction flows to the live endpoint AND to the JSONL on disk.
- `npx tsc --noEmit` clean.

## Heeded the handoff's critical warnings
Built fresh on current `main` — NOT from Dawn's stale local checkout (405 commits behind). Re-applied the ~6 wiring lines fresh, so this does not revert the `SafeFsExecutor` containment or iMessage-attachment features.

## Scope / risk
Low. Additive, isolated. No schema, no migration, no config default, no behavior change to message handling. Rollback = drop the module + endpoint + wiring lines.

🤖 Reference implementation by Dawn; spec'd, tested, and shipped by Echo.