### PR TITLE
fix(codex): Codex agents can reply over Threadline (MCP-permitting reply launch + per-agent MCP)

### DIFF
--- a/docs/specs/CODEX-MULTIAGENT-THREADLINE-ELI16.md
+++ b/docs/specs/CODEX-MULTIAGENT-THREADLINE-ELI16.md
@@ -1,0 +1,50 @@
+# Codex Multi-Agent Threadline Robustness — Plain-English Overview
+
+## What this is
+
+Two small fixes that let a Codex-based instar agent (like Codey) actually
+*reply* to messages other agents send it over Threadline. Right now it can
+receive a message but can't answer — and we found exactly why.
+
+## The two problems, in plain terms
+
+**Problem 1 — the worker is gagged.** When Codey gets a message, instar spins up
+a little one-shot "worker" to write the reply. That worker uses a tool
+("threadline_send") to actually send the answer. But instar was launching the
+worker in a locked-down mode where the agent silently refuses to use tools — so
+every time the worker tried to send the reply, the send was cancelled. The
+worker did everything right; it just wasn't allowed to press the send button.
+Interactive sessions already run in the permissive mode; the one-shot workers
+didn't. We make them match.
+
+**Problem 2 — roommates sharing one mailbox label.** Codex keeps its list of
+tools in ONE shared settings file for the whole machine. Every Codex agent
+writes its own "threadline" entry into that same slot when it starts, and the
+last one to start wins. So if Codey starts, then another agent starts, the slot
+now points at the *other* agent — and Codey's replies would go out wearing the
+wrong name tag. We fix this by handing each agent its OWN correct entry at the
+moment we launch its worker, so it never depends on who touched the shared file
+last.
+
+## What already exists vs. what's new
+
+The messaging system, the relay, and the tool itself all already work — we
+proved the full round-trip by hand. What's new is: (1) launching the one-shot
+workers in the permissive mode so tool calls go through, and (2) injecting each
+agent's own tool entry per-launch so the shared-file collision can't misroute
+replies.
+
+## Safeguards
+
+Neither change adds a new gatekeeper or blocking rule. The first removes an
+over-restrictive setting that was silently blocking a legitimate action. The
+second is just computing the right launch arguments — no decisions, no new
+authority. It's code-only: no data migration, no rewriting your config files,
+and reverting is a clean undo.
+
+## What you need to decide
+
+Whether to approve shipping these two fixes. They're already coded, unit-tested,
+and the key one is verified live (Codey sent a message and got a reply back once
+the worker was allowed to use the tool). The risk is low and the rollback is a
+plain revert.

--- a/docs/specs/CODEX-MULTIAGENT-THREADLINE-SPEC.md
+++ b/docs/specs/CODEX-MULTIAGENT-THREADLINE-SPEC.md
@@ -1,0 +1,180 @@
+---
+title: Codex Multi-Agent Threadline Robustness
+status: approved
+approved: true
+approver: justin
+approved-at: "2026-05-24T19:48:00Z"
+review-convergence: "2026-05-24T19:48:00Z"
+review-iterations: 1
+review-report: "docs/specs/reports/codex-multiagent-threadline-convergence.md"
+created: 2026-05-24
+owner: echo
+companion-eli16: CODEX-MULTIAGENT-THREADLINE-ELI16.md
+eli16-overview: CODEX-MULTIAGENT-THREADLINE-ELI16.md
+---
+
+# Codex Multi-Agent Threadline Robustness
+
+## Problem
+
+Two distinct, independently-verified defects prevent a Codex-framework instar
+agent from replying to inbound Threadline messages. Both were found live on
+`instar-codey` while completing the relay round-trip test (topic 12304); both
+are framework-integration bugs in instar (Echo's domain), not config errors.
+
+### Defect A — headless Codex launch cancels MCP tool calls
+
+`buildHeadlessLaunch` (`src/core/frameworkSessionLaunch.ts`) defaulted Codex to
+`-s workspace-write`. Under that profile `codex exec` defaults its approval
+policy to `never`, and `never` does not mean "auto-approve" — it means "refuse
+anything that would need approval." MCP tool calls need approval, so codex
+**silently cancels** them: `{"Err":"user cancelled MCP tool call"}`.
+
+When a Threadline message arrives, instar spawns a headless worker prompted to
+reply via the `threadline_send` MCP tool (`ThreadlineRouter`, ~line 162). The
+worker received the message, found the tool, and called it with correct
+arguments — but the call was cancelled twice, so no reply was ever sent
+(verified in the codex rollout log, 2026-05-24).
+
+The **interactive** builder (`buildInteractiveLaunch`) already defaults to
+`--dangerously-bypass-approvals-and-sandbox` (which permits MCP calls). The
+headless builder diverged. That asymmetry is the bug.
+
+### Defect B — shared `~/.codex/config.toml` last-writer-wins collision
+
+`ThreadlineBootstrap.registerThreadlineMcp` registers
+`[mcp_servers."threadline"]` into `~/.codex/config.toml` at **user scope** with
+the booting agent's `--state-dir`/`--agent-name` baked into `args`. That file is
+shared by every Codex agent on the machine. Each agent's boot overwrites the
+single shared table, so only the **last-booted** Codex agent's threadline MCP is
+active; every other Codex agent's `threadline_send` loads the wrong agent's
+identity/server. Observed live: the shared entry pointed at `inspec`
+(monroe-workspace) while `instar-codey` was the agent actually running.
+
+## Fix
+
+### Fix A — targeted MCP-permitting launch (reply workers only)
+
+`buildHeadlessLaunch` for `codex-cli` selects the launch profile in three tiers:
+- explicit `codexSandboxMode` → `-s <mode> --ask-for-approval never`;
+- `codexAllowMcpTools: true` (Threadline reply workers) →
+  `--dangerously-bypass-approvals-and-sandbox` (the ONLY mode that permits MCP
+  tool calls — see Convergence findings);
+- default (scheduled JOBS, dispatch, etc.) → `-s workspace-write` (unchanged
+  from prior behavior — jobs stay sandboxed).
+
+`codexAllowMcpTools` is set ONLY by the two Threadline inbound-reply spawn paths
+(see Fix C). Jobs never set it, so the security posture for scheduled work is
+unchanged.
+
+### Fix C — both reply paths wired
+
+Threadline has TWO inbound-reply spawn paths and BOTH must carry
+`codexAllowMcpTools: true` + the per-agent MCP override:
+- the full-session path: `SpawnRequestManager.spawnSession` callback
+  (`server.ts` `msg-spawn-*`) → `SessionManager.spawnSession`;
+- the lightweight path: `PipeSessionSpawner` (used when a message classifies as
+  a simple "pipe" reply; its prompt is "Reply ONLY via the threadline_send
+  tool"), which calls `buildHeadlessLaunch` directly.
+
+### Fix B — per-spawn MCP override (per-agent isolation)
+
+New single-source-of-truth resolver `src/threadline/mcpEntry.ts`
+(`resolveThreadlineMcpEntry`) returns the `{command, args}` for an agent's
+threadline MCP stdio entry. `ThreadlineBootstrap` uses it for registration.
+At server boot, `server.ts` computes this agent's entry and threads it through
+`SessionManagerConfig.codexThreadlineMcp`; the codex launch builders emit
+`-c mcp_servers.threadline.{command,args,kind}=…` per spawn. Codex's `-c`
+overrides win over the shared `~/.codex/config.toml`, so each agent's codex
+session uses ITS OWN threadline MCP regardless of which agent last wrote the
+shared file. Non-codex launches ignore the option; codex agents without
+threadline configured pass `undefined` (no override emitted).
+
+This does not remove the shared-config registration (kept for discoverability /
+Claude parity) — it makes it non-authoritative for codex spawns by overriding
+per-invocation. `codex -c` accepts nested-table + array values (verified against
+codex 0.133).
+
+## Signal vs authority
+
+No fix adds a brittle check with blocking authority. Fix A is a launch-profile
+selection (no gate). Fix B/C are launch-argument computations. The
+`config.threadline`-present and `codexAllowMcpTools` conditions are capability
+selectors, not authority gates.
+
+## Convergence findings (2026-05-24, two-reviewer pass)
+
+1. **(adopted) Don't unsandbox jobs.** An earlier cut defaulted ALL headless
+   codex spawns to bypass, which unsandboxes scheduled JOBS (they ingest
+   external content → prompt-injection exposure). Resolved: bypass is now scoped
+   to reply workers via `codexAllowMcpTools`; jobs keep `workspace-write`.
+2. **(verified) No sandboxed MCP path exists.** A reviewer suggested keeping the
+   sandbox + a permissive approval policy. Empirically false on codex 0.133:
+   under `-s workspace-write` the threadline MCP tool is unavailable/cancelled
+   (the sandbox blocks the MCP server's localhost transport AND `never` cancels
+   the call). Full bypass is the only mode that lets a reply worker call
+   `threadline_send`. This is why Fix A scopes bypass rather than seeking a
+   sandboxed middle ground.
+3. **(adopted) Second reply path.** `PipeSessionSpawner` is a real reply path
+   that also uses `threadline_send`; it was unwired. Fix C wires both paths.
+4. **(checked) `-c` injection safety.** `agentName`/`stateDir` are
+   operator-controlled and passed as argv array elements (no shell) in the
+   SessionManager/tmux path; `JSON.stringify` produces valid TOML-array values
+   for codex's `-c` parser (verified). The PipeSessionSpawner path shell-quotes
+   each argv element, preserving the JSON intact.
+
+## Security posture (requires sign-off — approved by operator)
+
+A codex agent's Threadline reply worker MUST run under
+`--dangerously-bypass-approvals-and-sandbox` to call `threadline_send` — there
+is no sandboxed mode that permits the MCP call (finding 2). The reply worker
+processes an INBOUND message, but Threadline only delivers messages from
+**trusted** agents (trust-gated), so the exposure is bounded to trusted peers.
+The alternative — "codex agents can receive but never auto-reply" — defeats the
+feature. Operator accepted this tradeoff (topic 12304, 2026-05-24). Scheduled
+jobs remain sandboxed; only reply workers take the bypass.
+
+## Acceptance criteria
+
+1. `buildHeadlessLaunch('codex-cli', …)` with no flags → `-s workspace-write`
+   (jobs stay sandboxed), NOT bypass.
+2. `codexAllowMcpTools: true` → `--dangerously-bypass-approvals-and-sandbox`
+   (reply workers); explicit `codexSandboxMode` wins over it →
+   `-s <mode> --ask-for-approval never`.
+3. With `codexThreadlineMcp` set, codex builders emit
+   `-c mcp_servers.threadline.command/args/kind`, args being valid JSON, before
+   the positional prompt; claude-code ignores both options.
+4. `resolveThreadlineMcpEntry` is the single source of truth; distinct agents
+   resolve distinct identity args.
+5. BOTH reply paths (SessionManager `msg-spawn` + `PipeSessionSpawner`) pass
+   `codexAllowMcpTools` + the per-agent override; jobs/dispatch do not.
+6. Live: a Codex agent receiving a Threadline message replies via
+   `threadline_send` (mechanism verified — see Evidence; full deployed
+   round-trip is the post-merge Tier-3 acceptance).
+7. Full suite green; migration-parity covered (existing agents get the launch
+   fix on update with no config change required).
+
+## Evidence (verified before this spec)
+
+- Defect A reproduced + fixed: a `codex exec --dangerously-bypass-approvals-and-
+  sandbox` run successfully completed a `threadline_send` MCP call (codey→echo,
+  reply received). Under `-s workspace-write` the same call was cancelled.
+- Defect B observed: `~/.codex/config.toml` `[mcp_servers."threadline"]` pointed
+  at `inspec` while `instar-codey` was running.
+- Unit tests: `frameworkSessionLaunch.test.ts` (headless bypass default +
+  override emission), `threadline-mcp-entry.test.ts` (resolver). Green.
+
+## Rollback
+
+Code-only, no migration/state changes. Revert `frameworkSessionLaunch.ts`
+(restores prior headless default + drops `-c` emission), `mcpEntry.ts`,
+`ThreadlineBootstrap` refactor, `server.ts`/`SessionManager`/`types.ts` wiring.
+The shared-config registration is unchanged, so reverting cannot strand state.
+
+## Testing
+
+- Unit (Tier 1): launch builders + resolver (above).
+- Migration parity: launch-path fix ships to existing agents via normal update
+  (no `.instar` config or `~/.codex` rewrite needed — the override is computed
+  at boot from existing config).
+- Live (Tier 3, real-world): codex round-trip reply through the deployed relay.

--- a/docs/specs/reports/codex-multiagent-threadline-convergence.md
+++ b/docs/specs/reports/codex-multiagent-threadline-convergence.md
@@ -1,0 +1,48 @@
+# Convergence Report — Codex Multi-Agent Threadline Robustness
+
+**Spec:** docs/specs/CODEX-MULTIAGENT-THREADLINE-SPEC.md
+**Date:** 2026-05-24
+**Mode:** expedited (operator-elected, topic 12304) — two-reviewer pass on the
+spec + the already-implemented + live-verified code, not a full multi-round
+multi-model convergence. Justified because both fixes were root-caused and
+empirically verified before the spec was written.
+
+## Reviewers
+
+- **Correctness / integration** (general-purpose): verified the diff, ran the
+  unit suite (green), typechecked clean. Conclusion: both fixes correct;
+  flagged a stale JSDoc `@example` and the absence of a full argv→tmux→codex
+  integration test (live verification is interim coverage).
+- **Adversarial / side-effects** (general-purpose): conclusion "Fix B solid;
+  Fix A's blunt full-bypass-as-default is the merge blocker." Raised the
+  job-sandbox regression, questioned whether a sandboxed-but-MCP path exists,
+  and found the unwired second reply path (`PipeSessionSpawner`).
+
+## Findings → resolutions
+
+1. **Job sandbox regression (adversarial, MUST-FIX) → ADOPTED.** Global bypass
+   unsandboxed scheduled jobs. Resolved: bypass scoped to reply workers via
+   `codexAllowMcpTools`; jobs keep `workspace-write`.
+2. **"Is there a sandboxed MCP path?" (adversarial) → VERIFIED NO.** Empirically
+   tested codex 0.133: `--sandbox workspace-write` (incl. `--full-auto`) leaves
+   `threadline_send` unavailable/cancelled. Full bypass is the only working
+   mode. Documented as the security posture (operator sign-off obtained).
+3. **Second reply path unwired (adversarial) → ADOPTED.** `PipeSessionSpawner`
+   also uses `threadline_send`; now wired with `codexAllowMcpTools` + the
+   per-agent override (Fix C).
+4. **`-c` injection safety (adversarial) → CHECKED, low risk.** argv array (no
+   shell) on the SessionManager path; JSON.stringify yields valid TOML-array
+   values; PipeSessionSpawner shell-quotes each element preserving the JSON.
+5. **Stale JSDoc `@example` (correctness) → FIXED.**
+
+## Security sign-off
+
+Codex reply workers run under full bypass (no sandboxed alternative exists).
+Bounded by Threadline's trust gate (messages only from trusted agents). Operator
+accepted (topic 12304, 2026-05-24). Jobs remain sandboxed.
+
+## Outcome
+
+Converged. Both fixes implemented to the targeted design; unit tests green;
+Fix-A mechanism (bypass → `threadline_send` completes) live-verified. Full
+deployed round-trip is the post-merge Tier-3 acceptance.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -96,6 +96,7 @@ import { pickupGitSyncMessages } from '../messaging/GitSyncTransport.js';
 import { DeliveryRetryManager } from '../messaging/DeliveryRetryManager.js';
 import { SpawnRequestManager } from '../messaging/SpawnRequestManager.js';
 import { ThreadlineRouter } from '../threadline/ThreadlineRouter.js';
+import { resolveThreadlineMcpEntry } from '../threadline/mcpEntry.js';
 import { ThreadResumeMap } from '../threadline/ThreadResumeMap.js';
 import { ListenerSessionManager } from '../threadline/ListenerSessionManager.js';
 import { SystemReviewer } from '../monitoring/SystemReviewer.js';
@@ -2374,7 +2375,20 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     }
 
-    const sessionManager = new SessionManager(config.sessions, state);
+    // Per-agent Codex threadline MCP override. Codex reads a SHARED
+    // ~/.codex/config.toml whose [mcp_servers."threadline"] is last-writer-wins
+    // across every codex agent on the machine — so a codex worker could load a
+    // DIFFERENT agent's threadline identity and its threadline_send would be
+    // misaddressed. Pin this agent's own entry per-spawn (the launch builders
+    // emit `-c mcp_servers.threadline.*`). Only when threadline is configured;
+    // ignored by non-codex launches. See CODEX-MULTIAGENT-THREADLINE-SPEC.
+    const codexThreadlineMcp = config.threadline
+      ? resolveThreadlineMcpEntry(config.sessions.projectDir, config.stateDir, config.projectName)
+      : undefined;
+    const sessionManager = new SessionManager(
+      codexThreadlineMcp ? { ...config.sessions, codexThreadlineMcp } : config.sessions,
+      state,
+    );
 
     // Input Guard is constructed later (after sharedIntelligence is available)
     // so the topic coherence reviewer can route through the IntelligenceProvider
@@ -6487,6 +6501,12 @@ export async function startServer(options: StartOptions): Promise<void> {
           // §4.5: honor SpawnRequestManager's provenance tag so drain-spawned
           // sessions are distinguishable from inline-spawned ones in logs/stream.
           triggeredBy: opts?.triggeredBy ?? 'spawn-request',
+          // This is the Threadline inbound-reply spawn: the worker must call
+          // the threadline_send MCP tool to reply, which a codex worker can only
+          // do under full bypass (codex cancels MCP calls in any sandbox). Jobs
+          // do NOT set this and stay sandboxed. Bounded: Threadline only accepts
+          // messages from trusted agents.
+          codexAllowMcpTools: true,
         });
         return session.id;
       },
@@ -6675,6 +6695,9 @@ export async function startServer(options: StartOptions): Promise<void> {
           minIqsBand: pipeConfig?.minIqsBand ?? 70,
           framework: pipeFramework,
           binaryPath: pipeBinaryPath,
+          // Same per-agent codex threadline MCP override as SessionManager, so a
+          // codex pipe-reply worker uses THIS agent's threadline MCP.
+          ...(codexThreadlineMcp ? { codexThreadlineMcp } : {}),
         });
         console.log(pc.dim(`  Pipe sessions: enabled (model: ${pipeConfig?.model ?? 'sonnet'}, max: ${pipeConfig?.maxConcurrent ?? 5})`));
       } catch (err) {

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -737,6 +737,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
      *  When an empty array, no `--allowedTools` flag is emitted —
      *  callers must explicitly pass at least one tool name to scope. */
     allowedTools?: string[];
+    /** When true, a codex-cli spawn launches with full bypass so it can make
+     *  MCP tool calls (e.g. threadline_send). Set ONLY by Threadline
+     *  inbound-reply spawns — codex cancels MCP calls under any sandbox.
+     *  Jobs leave this false and keep the workspace-write sandbox. No effect
+     *  on non-codex frameworks. */
+    codexAllowMcpTools?: boolean;
   }): Promise<Session> {
     const runningSessions = this.listRunningSessions();
     if (runningSessions.length >= this.config.maxSessions) {
@@ -814,6 +820,14 @@ rm()  { "${shimRunner}" rm  "$@"; }
       prompt: options.prompt,
       model: options.model,
       ...(options.codexLocalProvider ? { codexLocalProvider: options.codexLocalProvider } : {}),
+      // Per-agent codex threadline MCP override (ignored by non-codex builders).
+      // Ensures a headless codex worker — notably a Threadline inbound-reply
+      // spawn — uses THIS agent's threadline MCP, not whichever agent last won
+      // the shared ~/.codex/config.toml.
+      ...(this.config.codexThreadlineMcp ? { codexThreadlineMcp: this.config.codexThreadlineMcp } : {}),
+      // Reply spawns set this so the codex worker can call threadline_send;
+      // jobs leave it unset and keep the workspace-write sandbox.
+      ...(options.codexAllowMcpTools ? { codexAllowMcpTools: true } : {}),
     });
 
     // Per-job tool allowlist (INSTAR-JOBS-AS-AGENTMD spec §5): when the
@@ -1533,6 +1547,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
       ...(options?.resumeSessionId ? { resumeSessionId: options.resumeSessionId } : {}),
       ...(defaultModel ? { defaultModel } : {}),
       ...(options?.codexLocalProvider ? { codexLocalProvider: options.codexLocalProvider } : {}),
+      // Per-agent codex threadline MCP override (ignored by non-codex builders).
+      ...(this.config.codexThreadlineMcp ? { codexThreadlineMcp: this.config.codexThreadlineMcp } : {}),
     });
 
     // Spawn the framework CLI in tmux — no bash -c shell intermediary.

--- a/src/core/frameworkSessionLaunch.ts
+++ b/src/core/frameworkSessionLaunch.ts
@@ -68,6 +68,23 @@ export function resolveModelForFramework(
   return modelOrTier;
 }
 
+/**
+ * Build the Codex `-c` config overrides that pin the threadline MCP server to
+ * a specific agent's stdio entry. This wins over whatever `[mcp_servers."threadline"]`
+ * the SHARED ~/.codex/config.toml currently holds — fixing the multi-agent
+ * last-writer-wins collision where the most-recently-booted codex agent's
+ * registration clobbered everyone else's. Empty when no override is requested
+ * (e.g. claude-code launches, or codex agents without threadline configured).
+ */
+function codexThreadlineMcpFlags(mcp?: { command: string; args: string[] }): string[] {
+  if (!mcp) return [];
+  return [
+    '-c', `mcp_servers.threadline.command=${JSON.stringify(mcp.command)}`,
+    '-c', `mcp_servers.threadline.args=${JSON.stringify(mcp.args)}`,
+    '-c', `mcp_servers.threadline.kind=${JSON.stringify('stdio')}`,
+  ];
+}
+
 export interface InteractiveLaunchOptions {
   /** Absolute path to the CLI binary for the selected framework. */
   binaryPath: string;
@@ -97,6 +114,14 @@ export interface InteractiveLaunchOptions {
    * talks to a local Ollama/LM Studio instance.
    */
   codexLocalProvider?: 'ollama' | 'lmstudio';
+  /**
+   * Per-spawn Codex threadline MCP override. When set on a codex-cli launch,
+   * emits `-c mcp_servers.threadline.{command,args}=...` so THIS agent's codex
+   * session uses ITS OWN threadline MCP regardless of which agent last won the
+   * SHARED ~/.codex/config.toml (last-writer-wins collision). See
+   * resolveThreadlineMcpEntry / CODEX-MULTIAGENT-THREADLINE-SPEC.
+   */
+  codexThreadlineMcp?: { command: string; args: string[] };
 }
 
 export interface InteractiveLaunchSpec {
@@ -194,6 +219,7 @@ const codexCliBuilder: Builder = (options) => {
   } else {
     argv.push('--dangerously-bypass-approvals-and-sandbox');
   }
+  argv.push(...codexThreadlineMcpFlags(options.codexThreadlineMcp));
   return {
     argv,
     envOverrides: {
@@ -265,9 +291,10 @@ export interface HeadlessLaunchOptions {
    */
   model?: string;
   /**
-   * Codex sandbox mode override. Defaults to
-   * `--dangerously-bypass-approvals-and-sandbox` (Claude's
-   * `--dangerously-skip-permissions` parity) when absent.
+   * Codex sandbox mode override. When set → `-s <mode> --ask-for-approval
+   * never`. When absent, the headless default is `-s workspace-write` (jobs
+   * stay sandboxed) unless `codexAllowMcpTools` is set, which selects
+   * `--dangerously-bypass-approvals-and-sandbox` for reply workers.
    */
   codexSandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access';
   /**
@@ -280,6 +307,22 @@ export interface HeadlessLaunchOptions {
    * vocabulary.
    */
   codexLocalProvider?: 'ollama' | 'lmstudio';
+  /**
+   * Per-spawn Codex threadline MCP override — see InteractiveLaunchOptions.
+   * Emits `-c mcp_servers.threadline.{command,args}=...` so this agent's
+   * headless codex worker (notably Threadline inbound-reply spawns) uses ITS
+   * OWN threadline MCP, not whichever agent last won the shared config.
+   */
+  codexThreadlineMcp?: { command: string; args: string[] };
+  /**
+   * When true, a codex-cli headless spawn launches with
+   * `--dangerously-bypass-approvals-and-sandbox` so it can make MCP tool calls
+   * (e.g. threadline_send to reply). Required for Threadline inbound-reply
+   * workers — codex cancels MCP calls under any sandbox. Leave false for jobs:
+   * they keep the workspace-write sandbox (they ingest external content and
+   * don't use MCP). No effect on non-codex frameworks.
+   */
+  codexAllowMcpTools?: boolean;
 }
 
 export interface HeadlessLaunchSpec {
@@ -313,11 +356,10 @@ const claudeCodeHeadlessBuilder: HeadlessBuilder = (options) => {
 
 const codexCliHeadlessBuilder: HeadlessBuilder = (options) => {
   // Mirror the openai-codex adapter's transport spawn shape:
-  //   `codex exec --json --skip-git-repo-check -s <sandbox> -m <model> <prompt>`
+  //   `codex exec --json --skip-git-repo-check <approval/sandbox> -m <model> <prompt>`
   // The `--json` flag makes Codex emit a JSONL event stream on stdout
   // instead of TUI output — same data the agenticSessionHeadless path
   // already consumes for normalization.
-  const sandbox = options.codexSandboxMode ?? 'workspace-write';
   // Phase 6 local-provider branch — when codexLocalProvider is set,
   // emit `--oss --local-provider <p>` and pass the model verbatim
   // (local models like `llama3.2:latest` don't map through the
@@ -332,11 +374,31 @@ const codexCliHeadlessBuilder: HeadlessBuilder = (options) => {
     'exec',
     '--json',
     '--skip-git-repo-check',
-    '-s', sandbox,
   ];
   if (isLocal) {
     argv.push('--oss', '--local-provider', options.codexLocalProvider!);
   }
+  // Sandbox/approval selection:
+  //   • explicit codexSandboxMode  → `-s <mode> --ask-for-approval never`
+  //   • codexAllowMcpTools (reply)  → `--dangerously-bypass-approvals-and-sandbox`
+  //   • default (jobs)              → `-s workspace-write`
+  //
+  // Why bypass is required for MCP: under ANY `-s <sandbox>` + `--ask-for-
+  // approval never`, `codex exec` cancels MCP tool calls ("user cancelled MCP
+  // tool call"), AND the sandbox blocks the MCP server's localhost transport —
+  // both verified against codex 0.133. So a Threadline reply worker (which MUST
+  // call threadline_send) can only succeed under full bypass. We scope that to
+  // reply spawns (codexAllowMcpTools) and keep scheduled JOBS sandboxed under
+  // workspace-write, since jobs ingest external content and don't use MCP.
+  if (options.codexSandboxMode) {
+    argv.push('-s', options.codexSandboxMode, '--ask-for-approval', 'never');
+  } else if (options.codexAllowMcpTools) {
+    argv.push('--dangerously-bypass-approvals-and-sandbox');
+  } else {
+    argv.push('-s', 'workspace-write');
+  }
+  // -c overrides must precede the positional prompt in `codex exec`.
+  argv.push(...codexThreadlineMcpFlags(options.codexThreadlineMcp));
   argv.push('-m', model, options.prompt);
   return {
     argv,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -89,6 +89,15 @@ export interface SessionManagerConfig {
    *  @deprecated naming — value semantics correct; prefer `frameworkBinaryPaths`. */
   claudePath: string;
   /**
+   * Per-agent Codex threadline MCP override `{command, args}`. When set, codex
+   * spawns receive `-c mcp_servers.threadline.{command,args}=...` so this
+   * agent's codex sessions use THEIR OWN threadline MCP rather than whichever
+   * agent last wrote the shared `~/.codex/config.toml`
+   * (`[mcp_servers."threadline"]`, last-writer-wins). Computed once at server
+   * boot via resolveThreadlineMcpEntry when the agent has threadline + codex.
+   * Ignored by non-codex launches. See CODEX-MULTIAGENT-THREADLINE-SPEC. */
+  codexThreadlineMcp?: { command: string; args: string[] };
+  /**
    * Per-framework binary path map. Populated from detection at load
    * time so spawnInteractiveSession can dispatch to any framework
    * without re-running detection. Missing keys mean that framework

--- a/src/threadline/PipeSessionSpawner.ts
+++ b/src/threadline/PipeSessionSpawner.ts
@@ -56,6 +56,13 @@ export interface PipeSessionConfig {
    * is set explicitly; defaults to 'claude' for back-compat (PATH lookup).
    */
   binaryPath: string;
+  /**
+   * Per-agent Codex threadline MCP override `{command, args}` (from
+   * resolveThreadlineMcpEntry). When set, a codex pipe-reply worker uses THIS
+   * agent's threadline MCP instead of whichever agent last won the shared
+   * ~/.codex/config.toml. Ignored for non-codex frameworks.
+   */
+  codexThreadlineMcp?: { command: string; args: string[] };
 }
 
 export interface PipeSpawnRequest {
@@ -297,6 +304,12 @@ export class PipeSessionSpawner {
       binaryPath: this.config.binaryPath,
       prompt: PROMPT_PLACEHOLDER,
       model: this.config.model,
+      // Pipe replies instruct the worker to "Reply ONLY via the threadline_send
+      // tool" — a codex worker can only call MCP under full bypass, and must use
+      // THIS agent's threadline MCP. Claude ignores both (it scopes via
+      // --allowedTools threadline_send below).
+      codexAllowMcpTools: true,
+      ...(this.config.codexThreadlineMcp ? { codexThreadlineMcp: this.config.codexThreadlineMcp } : {}),
     });
     const quotedArgv = launchSpec.argv.map(a => {
       if (a === PROMPT_PLACEHOLDER) {

--- a/src/threadline/ThreadlineBootstrap.ts
+++ b/src/threadline/ThreadlineBootstrap.ts
@@ -24,6 +24,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { AgentDiscovery } from './AgentDiscovery.js';
 import { generateIdentityKeyPair } from './ThreadlineCrypto.js';
 import { DEFAULT_RELAY_URL } from './constants.js';
+import { resolveThreadlineMcpEntry } from './mcpEntry.js';
 import type { KeyPair } from './ThreadlineCrypto.js';
 import { ThreadlineClient } from './client/ThreadlineClient.js';
 import type { ReceivedMessage } from './client/ThreadlineClient.js';
@@ -389,24 +390,10 @@ function loadOrCreateIdentityKeys(threadlineDir: string): KeyPair {
  */
 async function registerThreadlineMcp(projectDir: string, agentName: string, stateDir: string): Promise<void> {
   const absDir = path.resolve(projectDir);
-
-  // The MCP server entry point — runs as a child process of Claude Code.
-  // Resolve the actual instar package location (handles both node_modules and npm-linked).
-  let mcpEntryPath = path.join(absDir, 'node_modules', 'instar', 'dist', 'threadline', 'mcp-stdio-entry.js');
-  if (!fs.existsSync(mcpEntryPath)) {
-    // Fall back to the running instar installation's dist directory.
-    // This handles npm-linked installs where node_modules/instar doesn't exist.
-    mcpEntryPath = path.join(__dirname, 'mcp-stdio-entry.js');
-  }
-
-  const mcpEntry = {
-    command: 'node',
-    args: [
-      mcpEntryPath,
-      '--state-dir', stateDir,
-      '--agent-name', agentName,
-    ],
-  };
+  // The MCP server entry point — runs as a child process of the agent's
+  // framework CLI. Single source of truth shared with the per-spawn Codex
+  // override (see mcpEntry.ts / SessionManager).
+  const mcpEntry = resolveThreadlineMcpEntry(projectDir, stateDir, agentName);
 
   // ── 1. Register in ~/.claude.json at local scope ──
   const claudeJsonPath = path.join(os.homedir(), '.claude.json');

--- a/src/threadline/mcpEntry.ts
+++ b/src/threadline/mcpEntry.ts
@@ -1,0 +1,49 @@
+/**
+ * mcpEntry — shared resolver for an agent's Threadline MCP stdio entry point.
+ *
+ * Single source of truth for the `{command, args}` that launches
+ * `mcp-stdio-entry.js` for a specific agent. Used by:
+ *   - ThreadlineBootstrap (registers it into ~/.claude.json + ~/.codex/config.toml)
+ *   - frameworkSessionLaunch / SessionManager (injects it per-spawn as a Codex
+ *     `-c mcp_servers.threadline.*` override so each agent's codex session uses
+ *     ITS OWN threadline MCP, not whichever agent last won the SHARED
+ *     ~/.codex/config.toml — see CODEX-MULTIAGENT-THREADLINE-SPEC).
+ *
+ * Keeping one resolver guarantees the registered entry and the per-spawn
+ * override never drift.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export interface ThreadlineMcpEntry {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Resolve the `{command, args}` to launch the Threadline MCP server for the
+ * given agent. Prefers the project's installed instar package; falls back to
+ * the running instar dist directory (npm-linked / shadow-install layouts).
+ */
+export function resolveThreadlineMcpEntry(
+  projectDir: string,
+  stateDir: string,
+  agentName: string,
+): ThreadlineMcpEntry {
+  const absDir = path.resolve(projectDir);
+  let mcpEntryPath = path.join(absDir, 'node_modules', 'instar', 'dist', 'threadline', 'mcp-stdio-entry.js');
+  if (!fs.existsSync(mcpEntryPath)) {
+    // Fall back to the running instar installation's dist directory.
+    // __dirname here is the compiled dist/threadline directory, so the
+    // sibling mcp-stdio-entry.js is the running install's entry point.
+    mcpEntryPath = path.join(__dirname, 'mcp-stdio-entry.js');
+  }
+  return {
+    command: 'node',
+    args: [mcpEntryPath, '--state-dir', stateDir, '--agent-name', agentName],
+  };
+}

--- a/tests/unit/frameworkSessionLaunch.test.ts
+++ b/tests/unit/frameworkSessionLaunch.test.ts
@@ -208,7 +208,7 @@ describe('frameworkSessionLaunch.buildHeadlessLaunch', () => {
   });
 
   describe('codex-cli', () => {
-    it('builds codex exec --json with default sandbox + model', () => {
+    it('defaults headless codex JOBS to the workspace-write sandbox (no bypass)', () => {
       const spec = buildHeadlessLaunch('codex-cli', {
         binaryPath: '/usr/local/bin/codex',
         prompt: 'analyze this',
@@ -217,20 +217,39 @@ describe('frameworkSessionLaunch.buildHeadlessLaunch', () => {
       expect(spec.argv).toContain('exec');
       expect(spec.argv).toContain('--json');
       expect(spec.argv).toContain('--skip-git-repo-check');
+      // Jobs keep the sandbox (they ingest external content + don't use MCP).
       expect(spec.argv).toContain('-s');
       expect(spec.argv).toContain('workspace-write');
+      expect(spec.argv).not.toContain('--dangerously-bypass-approvals-and-sandbox');
       expect(spec.argv).toContain('-m');
       expect(spec.argv).toContain('gpt-5.5');
       expect(spec.argv[spec.argv.length - 1]).toBe('analyze this');
     });
 
-    it('honors codexSandboxMode override', () => {
+    it('codexAllowMcpTools (reply workers) → full bypass so MCP calls are permitted', () => {
+      const spec = buildHeadlessLaunch('codex-cli', {
+        binaryPath: '/usr/local/bin/codex',
+        prompt: 'reply to peer',
+        codexAllowMcpTools: true,
+      });
+      // Reply workers MUST call threadline_send; codex cancels MCP under any
+      // sandbox, so the reply path uses full bypass. Jobs (above) do not.
+      expect(spec.argv).toContain('--dangerously-bypass-approvals-and-sandbox');
+      expect(spec.argv).not.toContain('workspace-write');
+    });
+
+    it('explicit codexSandboxMode wins over codexAllowMcpTools', () => {
       const spec = buildHeadlessLaunch('codex-cli', {
         binaryPath: '/usr/local/bin/codex',
         prompt: 'p',
         codexSandboxMode: 'read-only',
+        codexAllowMcpTools: true,
       });
+      expect(spec.argv).toContain('-s');
       expect(spec.argv).toContain('read-only');
+      expect(spec.argv).toContain('--ask-for-approval');
+      expect(spec.argv).toContain('never');
+      expect(spec.argv).not.toContain('--dangerously-bypass-approvals-and-sandbox');
       expect(spec.argv).not.toContain('workspace-write');
     });
 
@@ -380,5 +399,74 @@ describe('frameworkSessionLaunch — Phase 6 local-provider (codex --oss)', () =
     });
     expect(spec.argv).not.toContain('--oss');
     expect(spec.argv).not.toContain('--local-provider');
+  });
+});
+
+describe('frameworkSessionLaunch — per-agent codex threadline MCP override', () => {
+  const mcp = {
+    command: 'node',
+    args: [
+      '/agents/echo/.instar/shadow-install/node_modules/instar/dist/threadline/mcp-stdio-entry.js',
+      '--state-dir',
+      '/agents/echo/.instar',
+      '--agent-name',
+      'echo',
+    ],
+  };
+
+  it('headless codex emits -c mcp_servers.threadline overrides when set', () => {
+    const spec = buildHeadlessLaunch('codex-cli', {
+      binaryPath: '/usr/local/bin/codex',
+      prompt: 'reply to peer',
+      codexThreadlineMcp: mcp,
+    });
+    const joined = spec.argv.join(' ');
+    expect(spec.argv).toContain('-c');
+    expect(joined).toContain('mcp_servers.threadline.command="node"');
+    expect(joined).toContain('mcp_servers.threadline.args=');
+    expect(joined).toContain('--agent-name');
+    expect(joined).toContain('mcp_servers.threadline.kind="stdio"');
+    // The -c overrides must precede the positional prompt.
+    const lastCIdx = spec.argv.lastIndexOf('-c');
+    expect(spec.argv[spec.argv.length - 1]).toBe('reply to peer');
+    expect(lastCIdx).toBeLessThan(spec.argv.length - 1);
+  });
+
+  it('headless codex omits the override when not set', () => {
+    const spec = buildHeadlessLaunch('codex-cli', {
+      binaryPath: '/usr/local/bin/codex',
+      prompt: 'p',
+    });
+    expect(spec.argv.join(' ')).not.toContain('mcp_servers.threadline');
+  });
+
+  it('interactive codex emits the override when set', () => {
+    const spec = buildInteractiveLaunch('codex-cli', {
+      binaryPath: '/usr/local/bin/codex',
+      codexThreadlineMcp: mcp,
+    });
+    expect(spec.argv.join(' ')).toContain('mcp_servers.threadline.command="node"');
+  });
+
+  it('claude-code ignores the codex threadline override', () => {
+    const spec = buildHeadlessLaunch('claude-code', {
+      binaryPath: '/usr/local/bin/claude',
+      prompt: 'p',
+      codexThreadlineMcp: mcp,
+    });
+    expect(spec.argv.join(' ')).not.toContain('mcp_servers.threadline');
+  });
+
+  it('override args are valid JSON (TOML-array compatible)', () => {
+    const spec = buildHeadlessLaunch('codex-cli', {
+      binaryPath: '/usr/local/bin/codex',
+      prompt: 'p',
+      codexThreadlineMcp: mcp,
+    });
+    const argsFlag = spec.argv.find((a) => a.startsWith('mcp_servers.threadline.args='));
+    expect(argsFlag).toBeDefined();
+    const jsonPart = argsFlag!.slice('mcp_servers.threadline.args='.length);
+    expect(() => JSON.parse(jsonPart)).not.toThrow();
+    expect(JSON.parse(jsonPart)).toEqual(mcp.args);
   });
 });

--- a/tests/unit/threadline-mcp-entry.test.ts
+++ b/tests/unit/threadline-mcp-entry.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests — resolveThreadlineMcpEntry.
+ *
+ * Single source of truth for an agent's Threadline MCP stdio launch
+ * {command, args}, shared between ThreadlineBootstrap (config registration)
+ * and the per-spawn Codex `-c` override (CODEX-MULTIAGENT-THREADLINE-SPEC).
+ */
+
+import { describe, it, expect } from 'vitest';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveThreadlineMcpEntry } from '../../src/threadline/mcpEntry.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('resolveThreadlineMcpEntry', () => {
+  it('returns node + mcp-stdio-entry path + identity flags', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-entry-'));
+    try {
+      const entry = resolveThreadlineMcpEntry(dir, `${dir}/.instar`, 'echo');
+      expect(entry.command).toBe('node');
+      expect(entry.args[0]).toMatch(/mcp-stdio-entry\.js$/);
+      expect(entry.args).toContain('--state-dir');
+      expect(entry.args).toContain(`${dir}/.instar`);
+      expect(entry.args).toContain('--agent-name');
+      expect(entry.args).toContain('echo');
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/threadline-mcp-entry.test.ts:cleanup' });
+    }
+  });
+
+  it('prefers the project-local instar install when present', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-entry-proj-'));
+    const localEntry = path.join(dir, 'node_modules', 'instar', 'dist', 'threadline');
+    fs.mkdirSync(localEntry, { recursive: true });
+    fs.writeFileSync(path.join(localEntry, 'mcp-stdio-entry.js'), '// stub');
+    try {
+      const entry = resolveThreadlineMcpEntry(dir, `${dir}/.instar`, 'codey');
+      expect(entry.args[0]).toBe(path.join(localEntry, 'mcp-stdio-entry.js'));
+      expect(entry.args).toContain('codey');
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/threadline-mcp-entry.test.ts:cleanup' });
+    }
+  });
+
+  it('distinct agents resolve distinct identity args (no collision)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-entry-multi-'));
+    try {
+      const echo = resolveThreadlineMcpEntry(dir, '/agents/echo/.instar', 'echo');
+      const codey = resolveThreadlineMcpEntry(dir, '/agents/codey/.instar', 'instar-codey');
+      expect(echo.args).toContain('echo');
+      expect(echo.args).toContain('/agents/echo/.instar');
+      expect(codey.args).toContain('instar-codey');
+      expect(codey.args).toContain('/agents/codey/.instar');
+      expect(echo.args).not.toEqual(codey.args);
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/threadline-mcp-entry.test.ts:cleanup' });
+    }
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,77 @@
+# Instar Upgrade Guide — vNEXT (Codex agents can reply over Threadline)
+
+<!-- bump: patch -->
+
+## What Changed
+
+Codex-framework instar agents couldn't *reply* to Threadline messages — they
+received fine, but every reply silently failed. Two framework-integration bugs,
+both fixed.
+
+### Fix A — reply workers can now use MCP tools (targeted)
+
+When a Threadline message arrives, instar spawns a one-shot worker prompted to
+reply via the `threadline_send` MCP tool. For Codex, instar launched that worker
+under `-s workspace-write`, where `codex exec` defaults its approval policy to
+`never` — and `never` *cancels* MCP tool calls (`"user cancelled MCP tool
+call"`) AND the sandbox blocks the MCP server's localhost transport. So the
+worker called the tool correctly and the call was killed every time.
+
+Verified on codex 0.133 that there is **no** sandboxed mode that permits the MCP
+call — only `--dangerously-bypass-approvals-and-sandbox` works. So the headless
+launch now selects in tiers: explicit sandbox mode → that mode; Threadline
+**reply** workers (`codexAllowMcpTools`) → full bypass (the only mode that lets
+them send); everything else, including scheduled **jobs** → `-s workspace-write`
+unchanged. Jobs stay sandboxed; only reply workers take the bypass.
+
+### Fix B — each agent uses its own threadline MCP (no shared-config collision)
+
+Every Codex agent registered `[mcp_servers."threadline"]` into the SHARED
+`~/.codex/config.toml` with its own identity baked in — last-writer-wins, so on a
+machine with several Codex agents, all but the last-booted one would reply using
+the WRONG agent's threadline identity. New single-source-of-truth resolver
+(`src/threadline/mcpEntry.ts`) + a per-spawn `-c mcp_servers.threadline.*`
+override pin each agent's codex session to ITS OWN threadline MCP, regardless of
+the shared file. Both reply paths (full-session and the lightweight "pipe" path)
+are wired.
+
+## What to Tell Your User
+
+If you run a Codex-based agent, it can now actually answer messages other agents
+send it over Threadline — before, it could hear but not reply. And on a machine
+running several Codex agents, each now replies as itself instead of accidentally
+borrowing whichever agent started last. Scheduled background jobs stay sandboxed
+as before; only the reply step runs with the access it needs to send. No action
+needed.
+
+## Summary of New Capabilities
+
+- **Codex agents reply over Threadline** — reply workers launch in the one mode
+  that permits the `threadline_send` MCP call; scheduled jobs stay sandboxed.
+- **Per-agent codex threadline MCP** — a per-spawn `-c` override + shared
+  resolver (`resolveThreadlineMcpEntry`) end the shared `~/.codex/config.toml`
+  last-writer-wins collision; both reply paths covered.
+
+## Evidence
+
+- **Reproduced + fixed (mechanism):** a `codex exec --dangerously-bypass-
+  approvals-and-sandbox` run completed a real `threadline_send` call
+  (codey→echo, reply received); under `-s workspace-write`/`--full-auto` the same
+  call was cancelled / the tool was unavailable. The collision was observed live
+  (shared config pointed at `inspec` while `instar-codey` was running).
+- **Unit:** `frameworkSessionLaunch.test.ts` (workspace-write job default;
+  `codexAllowMcpTools`→bypass; explicit sandbox wins; `-c` override emission +
+  JSON validity), `threadline-mcp-entry.test.ts` (resolver). 75-test sweep green.
+- **Convergence:** two-reviewer pass (correctness + adversarial) →
+  docs/specs/reports/codex-multiagent-threadline-convergence.md. The adversarial
+  reviewer caught the job-sandbox regression and the second reply path; both
+  resolved before merge.
+- Full deployed round-trip with a Codex agent is the post-merge Tier-3 check.
+
+## Rollback
+
+Code-only, no migration or state changes. Revert
+`src/core/frameworkSessionLaunch.ts`, `src/threadline/mcpEntry.ts`, the
+`ThreadlineBootstrap` refactor, and the `server.ts`/`SessionManager`/`types.ts`/
+`PipeSessionSpawner` wiring. The shared-config registration is untouched, so a
+revert cannot strand `~/.codex` or `.instar` state.

--- a/upgrades/side-effects/codex-multiagent-threadline.md
+++ b/upgrades/side-effects/codex-multiagent-threadline.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — Codex Multi-Agent Threadline Robustness
+
+Spec: docs/specs/CODEX-MULTIAGENT-THREADLINE-SPEC.md (approved, converged)
+Change: let Codex-framework agents reply to Threadline messages — (A) targeted
+MCP-permitting launch for reply workers, (B) per-agent threadline MCP override,
+(C) wire both reply paths.
+
+## 1. Over-block — what legitimate inputs does this reject that it shouldn't?
+
+None new. The launch-profile selector is additive: jobs keep `-s
+workspace-write` (unchanged); reply workers add bypass; explicit
+`codexSandboxMode` still wins. The `-c` MCP override only ever points codex at
+THIS agent's own threadline entry — it cannot reject anything.
+
+## 2. Under-block — what failure modes does this still miss?
+
+- Codex agents without threadline configured: no override emitted (correct — no
+  threadline to reply through). Not a miss.
+- The reply worker still depends on the deployed relay / local delivery being
+  reachable — out of scope here (transport already works).
+- A future THIRD reply path that calls `buildHeadlessLaunch` directly would need
+  the same two flags. Mitigated by routing all reply spawns through the two
+  known paths; documented in the spec.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. The launch-profile + MCP-override are properties of HOW a codex
+session is launched → they belong in `frameworkSessionLaunch` (the builder) with
+the data computed once at boot in `server.ts`. The single-source-of-truth
+resolver (`mcpEntry.ts`) is shared with `ThreadlineBootstrap` so registration and
+per-spawn override cannot drift.
+
+## 4. Signal vs authority compliance
+
+Compliant. No blocking authority added. The selectors (`codexAllowMcpTools`,
+`codexThreadlineMcp`, `config.threadline`-present) are capability/launch choices,
+not gates that block information flow. See docs/signal-vs-authority.md.
+
+## 5. Interactions
+
+- Fix A ↔ Fix B: independent (sandbox profile vs MCP entry); both emitted in the
+  same codex argv, no conflict.
+- Fix B ↔ existing shared-config registration: intentional — `-c` wins per spawn;
+  the shared `~/.codex/config.toml` entry stays (Claude parity / discovery) but
+  is non-authoritative for codex spawns. No double-fire (one MCP server named
+  "threadline" results).
+- Jobs/dispatch (routes.ts generic spawn, JobScheduler): do NOT set
+  `codexAllowMcpTools` → unchanged (`workspace-write`). No shadowing.
+- ThreadlineBootstrap refactor is behavior-preserving (`resolveThreadlineMcpEntry`
+  returns the identical `{command,args}`; `absDir` still declared for downstream
+  ~/.claude.json registration).
+
+## 6. External surfaces
+
+- Other agents: a codex agent can now actually reply over Threadline — net new
+  outbound it previously couldn't send. Bounded by the trust gate (replies only
+  to trusted peers, who already messaged it).
+- Security posture: codex reply workers run unsandboxed (full bypass) — the only
+  mode that permits the MCP call (verified, finding 2). Scheduled jobs remain
+  sandboxed. Operator signed off (topic 12304).
+- Timing/runtime: none introduced; the override is computed once at boot.
+
+## 7. Rollback cost
+
+Code-only, no migration/state. Revert `frameworkSessionLaunch.ts`, `mcpEntry.ts`,
+`ThreadlineBootstrap` refactor, `server.ts`/`SessionManager`/`types.ts`/
+`PipeSessionSpawner` wiring. The shared-config registration is untouched, so a
+revert cannot strand `~/.codex` or `.instar` state. Existing agents pick up the
+launch fix on normal update (no config rewrite).


### PR DESCRIPTION
## Summary

Codex-framework instar agents received Threadline messages but every reply silently failed. Two framework-integration bugs, both root-caused live on `instar-codey` (topic 12304) and fixed. Spec: `docs/specs/CODEX-MULTIAGENT-THREADLINE-SPEC.md` (converged + approved).

**Fix A — reply workers can use MCP tools (targeted).** Headless codex launched under `-s workspace-write`, where `codex exec` defaults approval to `never` — which cancels MCP tool calls AND the sandbox blocks the MCP server's localhost transport (verified: no sandboxed mode permits the call). Now the headless launch selects in tiers: explicit `codexSandboxMode` → that mode; Threadline **reply** workers (`codexAllowMcpTools`) → `--dangerously-bypass-approvals-and-sandbox` (the only mode that lets them send); everything else incl. scheduled **jobs** → `-s workspace-write` (unchanged — jobs stay sandboxed).

**Fix B — per-agent threadline MCP (no shared-config collision).** Every codex agent registered `[mcp_servers."threadline"]` into the shared `~/.codex/config.toml` (last-writer-wins) → a reply could use the wrong agent's identity. New `resolveThreadlineMcpEntry` (single source of truth, shared with `ThreadlineBootstrap`) + a per-spawn `-c mcp_servers.threadline.*` override pin each agent's codex session to its own. **Both** reply paths wired (`SessionManager` msg-spawn + `PipeSessionSpawner`).

## Test plan

- [x] Unit: `frameworkSessionLaunch.test.ts` (workspace-write job default; `codexAllowMcpTools`→bypass; explicit sandbox wins; `-c` override emission + JSON validity), `threadline-mcp-entry.test.ts` (resolver). 75-test sweep green; build clean.
- [x] Mechanism live-verified: `codex exec --dangerously-bypass-approvals-and-sandbox` completes a real `threadline_send` (codey→echo, reply received); under `workspace-write`/`--full-auto` the same call is cancelled / tool unavailable.
- [x] Convergence: two-reviewer pass (correctness + adversarial) → `docs/specs/reports/codex-multiagent-threadline-convergence.md`. Adversarial reviewer caught the job-sandbox regression + the second reply path; both resolved.
- [ ] Post-merge Tier-3: full deployed round-trip with a Codex agent.

## Security note (operator-signed-off)

Codex reply workers run unsandboxed (the only mode permitting the MCP call); bounded by Threadline's trust gate (replies only to trusted peers). Scheduled jobs stay sandboxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)