### PR TITLE
feat(autonomous): delegate to native /goal via session injection (Phase 2)

### DIFF
--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -146,6 +146,7 @@ DURATION_SECONDS=$(fm_get duration_seconds)
 STARTED_AT=$(fm_get started_at)
 COMPLETION_PROMISE=$(fm_get completion_promise)
 COMPLETION_CONDITION=$(fm_get completion_condition)
+GOAL_MODE=$(fm_get goal_mode)   # "native" = the framework's own /goal loop drives completion
 
 # Validate recorded session_id is a real UUID. Claude sometimes writes a custom
 # string instead of $CLAUDE_CODE_SESSION_ID; non-UUID values are treated as
@@ -225,6 +226,36 @@ except Exception:
 fi
 
 if [[ "$OWNER" != "true" ]]; then
+  exit 0
+fi
+
+# ── Native /goal delegation: the framework's own /goal loop owns completion. ──
+# instar injected "/goal <condition>" at start (goal_mode=native), so we DEFER the
+# continue/stop decision to native /goal's own Stop hook (we approve/exit; its hook
+# blocks until the condition is met — block wins over approve, so it stays in control).
+# instar still owns its terminal STOP concerns (emergency-stop, duration) and enforces
+# them by CLEARING native /goal first (inject "/goal clear" via the server).
+if [[ "$GOAL_MODE" == "native" ]]; then
+  native_goal_clear() {
+    local port auth
+    port=$(python3 -c "import json;print(json.load(open('.instar/config.json')).get('port',4040))" 2>/dev/null || echo 4040)
+    auth=$(python3 -c "import json;print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null || echo "")
+    jq -nc --arg t "$REPORT_TOPIC" '{topicId:$t}' \
+      | curl -s -m 10 -H "Authorization: Bearer $auth" -H 'Content-Type: application/json' \
+        --data-binary @- "http://localhost:${port}/autonomous/native-goal/clear" >/dev/null 2>&1 || true
+  }
+  if [[ -f ".instar/autonomous-emergency-stop" ]]; then
+    native_goal_clear; rm -f "$STATE_FILE"
+    echo "[autonomous] emergency stop — native /goal cleared" >&2; exit 0
+  fi
+  if [[ "$DURATION_SECONDS" =~ ^[0-9]+$ ]] && [[ $DURATION_SECONDS -gt 0 ]]; then
+    NG_START=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo 0)
+    if [[ "$NG_START" =~ ^[0-9]+$ ]] && [[ $NG_START -gt 0 ]] && [[ $(( $(date +%s) - NG_START )) -ge $DURATION_SECONDS ]]; then
+      native_goal_clear; rm -f "$STATE_FILE"
+      echo "[autonomous] duration expired — native /goal cleared" >&2; exit 0
+    fi
+  fi
+  # Not terminal → let native /goal decide completion. Approve (its hook keeps control).
   exit 0
 fi
 

--- a/.claude/skills/autonomous/scripts/setup-autonomous.sh
+++ b/.claude/skills/autonomous/scripts/setup-autonomous.sh
@@ -197,6 +197,31 @@ To complete, ALL of these must be true:
 - Then output: <promise>$COMPLETION_PROMISE</promise>
 EOF
 
+# ── Native /goal delegation: where the framework has a native /goal loop, hand the
+# condition to it (instar injects "/goal <condition>" via the server → SessionManager
+# send-keys) and mark goal_mode:native so the stop-hook defers completion to it. Only
+# with a condition + a per-topic job + Claude Code >= 2.1.139. Best-effort: on any miss
+# we leave goal_mode empty and instar's own independent evaluator drives (Phase 1).
+if [[ -n "$COMPLETION_CONDITION" ]] && [[ -n "$REPORT_TOPIC" ]]; then
+  CLAUDE_VER=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+  NATIVE_GOAL_OK="false"
+  if [[ -n "$CLAUDE_VER" ]]; then
+    # /goal requires Claude Code >= 2.1.139.
+    if [[ "$(printf '%s\n2.1.139\n' "$CLAUDE_VER" | sort -V | head -1)" == "2.1.139" ]]; then
+      NATIVE_GOAL_OK="true"
+    fi
+  fi
+  if [[ "$NATIVE_GOAL_OK" == "true" ]]; then
+    NG_PORT=$(python3 -c "import json;print(json.load(open('.instar/config.json')).get('port',4040))" 2>/dev/null || echo 4040)
+    NG_AUTH=$(python3 -c "import json;print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null || echo "")
+    jq -nc --arg t "$REPORT_TOPIC" --arg c "$COMPLETION_CONDITION" '{topicId:$t,condition:$c}' \
+      | curl -s -m 8 -H "Authorization: Bearer $NG_AUTH" -H 'Content-Type: application/json' \
+        --data-binary @- "http://localhost:${NG_PORT}/autonomous/native-goal/set" >/dev/null 2>&1 \
+      && echo "  Native /goal: handed condition to Claude Code's /goal loop" \
+      || echo "  Native /goal: unavailable — using instar's own completion evaluator"
+  fi
+fi
+
 echo "🔄 Autonomous mode activated!"
 echo ""
 echo "Goal: $GOAL"

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1217,15 +1217,15 @@ export class PostUpdateMigrator {
     // completion evaluator (mirrors /goal). Absent from multi-session-only installs.
     upgrade(
       '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
-      'independent evaluator (mirrors /goal)',
+      'Native /goal delegation',
       'Autonomous Mode Stop Hook',
-      'skills/autonomous/hooks/autonomous-stop-hook.sh (topic-keyed + multi-session + completion evaluator)',
+      'skills/autonomous/hooks/autonomous-stop-hook.sh (topic-keyed + multi-session + completion evaluator + native /goal)',
     );
     upgrade(
       '.claude/skills/autonomous/scripts/setup-autonomous.sh',
-      'completion_condition:',
+      'native-goal/set',
       'autonomous-state.local.md',
-      'skills/autonomous/scripts/setup-autonomous.sh (per-topic + completion-condition)',
+      'skills/autonomous/scripts/setup-autonomous.sh (per-topic + completion-condition + native /goal)',
     );
   }
 

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -648,6 +648,8 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
           'POST /autonomous/stop-all — stop every autonomous job ("stop everything")',
           'POST /autonomous/sessions/:topic/stop — stop one topic\'s job',
           'POST /autonomous/evaluate-completion — independent /goal-style judge: is a verifiable condition met?',
+          'POST /autonomous/native-goal/set — delegate completion to the framework native /goal (injects /goal <condition>)',
+          'POST /autonomous/native-goal/clear — clear the native /goal for a topic',
         ],
       };
     },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2967,6 +2967,48 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
+  // Native /goal delegation (Phase 2): drive the framework's own /goal loop by
+  // INJECTING the slash command into the session (instar's core mechanism —
+  // SessionManager.sendInput / tmux send-keys), and mark the job goal_mode:native so
+  // the stop-hook defers completion to native /goal (still enforcing emergency/duration).
+  const resolveTopicSession = (topic: string): string | null => {
+    try {
+      const reg = JSON.parse(fs.readFileSync(path.join(ctx.config.stateDir, 'topic-session-registry.json'), 'utf8'));
+      return (reg.topicToSession || {})[topic] ?? null;
+    } catch { return null; }
+  };
+  const setGoalMode = (topic: string, mode: 'native' | '') => {
+    const f = path.join(ctx.config.stateDir, 'autonomous', `${topic}.local.md`);
+    if (!fs.existsSync(f)) return;
+    let c = fs.readFileSync(f, 'utf8');
+    c = /^goal_mode:/m.test(c) ? c.replace(/^goal_mode:.*$/m, `goal_mode: "${mode}"`)
+                              : c.replace(/^(active:.*)$/m, `$1\ngoal_mode: "${mode}"`);
+    fs.writeFileSync(f, c);
+  };
+
+  router.post('/autonomous/native-goal/set', (req, res) => {
+    const { topicId, condition } = req.body ?? {};
+    if (!topicId || !condition || typeof condition !== 'string') {
+      res.status(400).json({ error: '"topicId" and "condition" (string) required' });
+      return;
+    }
+    const tmux = resolveTopicSession(String(topicId));
+    if (!tmux) { res.status(404).json({ error: `no session for topic ${topicId}` }); return; }
+    const ok = ctx.sessionManager.sendInput(tmux, `/goal ${condition}`);
+    if (ok) setGoalMode(String(topicId), 'native');
+    res.status(ok ? 200 : 502).json({ ok, topicId, mode: ok ? 'native' : 'unchanged' });
+  });
+
+  router.post('/autonomous/native-goal/clear', (req, res) => {
+    const { topicId } = req.body ?? {};
+    if (!topicId) { res.status(400).json({ error: '"topicId" required' }); return; }
+    const tmux = resolveTopicSession(String(topicId));
+    if (!tmux) { res.status(404).json({ error: `no session for topic ${topicId}` }); return; }
+    const ok = ctx.sessionManager.sendInput(tmux, '/goal clear');
+    if (ok) setGoalMode(String(topicId), '');
+    res.status(ok ? 200 : 502).json({ ok, topicId });
+  });
+
   router.get('/capabilities', (_req, res) => {
     // /capabilities used to be a 440-line hand-curated object literal — the
     // documented self-discovery primitive, but the only structural enforcement

--- a/tests/integration/autonomous-sessions-api.test.ts
+++ b/tests/integration/autonomous-sessions-api.test.ts
@@ -20,6 +20,7 @@ import path from 'node:path';
 let project: TempProject;
 let server: Server;
 let baseUrl: string;
+const sentInputs: Array<{ tmux: string; input: string }> = [];
 
 function writeJob(stateDir: string, topic: string) {
   fs.mkdirSync(path.join(stateDir, 'autonomous'), { recursive: true });
@@ -45,7 +46,8 @@ describe('Multi-session autonomy API (integration)', () => {
     app.use(express.json());
     const router = createRoutes({
       config, state,
-      sessionManager: null as any, scheduler: null, telegram: null, relationships: null,
+      sessionManager: { sendInput: (tmux: string, input: string) => { sentInputs.push({ tmux, input }); return true; } } as any,
+      scheduler: null, telegram: null, relationships: null,
       feedback: null, dispatches: null, updateChecker: null, autoUpdater: null,
       autoDispatcher: null, quotaTracker: null, publisher: null, viewer: null, tunnel: null,
       evolution: null, watchdog: null, triageNurse: null, topicMemory: null,
@@ -150,5 +152,42 @@ describe('Multi-session autonomy API (integration)', () => {
       method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
     });
     expect(res.status).toBe(400);
+  });
+
+  it('POST /autonomous/native-goal/set injects /goal <condition> and flips goal_mode', async () => {
+    // registry maps topic 9984 -> tmux 'sess-x'; a per-topic job file exists.
+    fs.writeFileSync(path.join(project.stateDir, 'topic-session-registry.json'),
+      JSON.stringify({ topicToSession: { '9984': 'sess-x' }, topicToName: {} }));
+    writeJob(project.stateDir, '9984');
+    sentInputs.length = 0;
+
+    const res = await fetch(`${baseUrl}/autonomous/native-goal/set`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topicId: '9984', condition: 'all tests pass' }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).mode).toBe('native');
+    // injected the native /goal command into the topic's session
+    expect(sentInputs).toContainEqual({ tmux: 'sess-x', input: '/goal all tests pass' });
+    // goal_mode flipped in the per-topic state file
+    const stateFile = path.join(project.stateDir, 'autonomous', '9984.local.md');
+    expect(fs.readFileSync(stateFile, 'utf8')).toMatch(/goal_mode:\s*"native"/);
+  });
+
+  it('POST /autonomous/native-goal/clear injects /goal clear', async () => {
+    sentInputs.length = 0;
+    const res = await fetch(`${baseUrl}/autonomous/native-goal/clear`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ topicId: '9984' }),
+    });
+    expect(res.status).toBe(200);
+    expect(sentInputs).toContainEqual({ tmux: 'sess-x', input: '/goal clear' });
+  });
+
+  it('POST /autonomous/native-goal/set 404s for an unknown topic', async () => {
+    const res = await fetch(`${baseUrl}/autonomous/native-goal/set`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topicId: 'nope', condition: 'x' }),
+    });
+    expect(res.status).toBe(404);
   });
 });

--- a/tests/unit/autonomous-completion-condition.test.ts
+++ b/tests/unit/autonomous-completion-condition.test.ts
@@ -18,10 +18,10 @@ const HOOK = path.join(process.cwd(), '.claude', 'skills', 'autonomous', 'hooks'
 const UUID = '04db2de7-8e82-4baf-9136-7a067bb2ec53';
 let tmp: string;
 
-function writeState(opts: { condition?: string; promise?: string }) {
-  const started = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+function writeState(opts: { condition?: string; promise?: string; goalMode?: string; durationSeconds?: number; startedAt?: string }) {
+  const started = opts.startedAt ?? new Date().toISOString().replace(/\.\d+Z$/, 'Z');
   fs.writeFileSync(path.join(tmp, '.instar', 'autonomous-state.local.md'),
-    `---\nactive: true\niteration: 2\nsession_id: "${UUID}"\nduration_seconds: 0\nstarted_at: "${started}"\nreport_topic: ""\ncompletion_promise: "${opts.promise ?? ''}"\ncompletion_condition: "${opts.condition ?? ''}"\n---\n\nKeep going.\n`);
+    `---\nactive: true\niteration: 2\nsession_id: "${UUID}"\nduration_seconds: ${opts.durationSeconds ?? 0}\nstarted_at: "${started}"\nreport_topic: "9984"\ngoal_mode: "${opts.goalMode ?? ''}"\ncompletion_promise: "${opts.promise ?? ''}"\ncompletion_condition: "${opts.condition ?? ''}"\n---\n\nKeep going.\n`);
 }
 function writeTranscript(): string {
   const p = path.join(tmp, 'transcript.jsonl');
@@ -77,5 +77,33 @@ describe('completion condition — independent evaluator', () => {
     writeState({ promise: 'ALL_DONE' }); // no condition
     const r = runHook();
     expect(r.decision).toBe('block'); // promise not in transcript → keep working
+  });
+});
+
+describe('native /goal delegation (goal_mode: native)', () => {
+  it('defers to native /goal — approves/exits (no block) so native /goal stays in control', () => {
+    // goal_mode:native means the framework's own /goal hook owns completion. instar must
+    // NOT block (block would override native /goal); it approves and lets native decide.
+    writeState({ condition: 'all tests pass', goalMode: 'native' });
+    const r = runHook(); // even with the instar evaluator unreachable, native mode defers
+    expect(r.decision).not.toBe('block');
+    expect(r.exit).toBe(0);
+    expect(statePresent()).toBe(true); // job continues (native /goal enforces)
+  });
+
+  it('still enforces emergency-stop in native mode (clears state + exits)', () => {
+    writeState({ condition: 'x', goalMode: 'native' });
+    fs.writeFileSync(path.join(tmp, '.instar', 'autonomous-emergency-stop'), 'stop\n');
+    const r = runHook();
+    expect(r.exit).toBe(0);
+    expect(statePresent()).toBe(false); // instar cleared its state (+ best-effort native clear)
+  });
+
+  it('still enforces duration expiry in native mode (clears state + exits)', () => {
+    const past = new Date(Date.now() - 3600_000).toISOString().replace(/\.\d+Z$/, 'Z');
+    writeState({ condition: 'x', goalMode: 'native', durationSeconds: 10, startedAt: past });
+    const r = runHook();
+    expect(r.exit).toBe(0);
+    expect(statePresent()).toBe(false);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,67 @@
+# Upgrade Guide — NEXT (autonomous mode delegates to native /goal)
+
+<!-- bump: minor -->
+<!-- minor = new capability, backward compatible -->
+
+## What Changed
+
+**New: where the framework has a native /goal loop, autonomous mode hands the finish-line to it.**
+
+Phase 2 of `docs/specs/goal-completion-evaluator.md`. When an autonomous job is started with a
+completion condition AND the framework provides native /goal (Claude Code >= 2.1.139), instar
+now **injects `/goal <condition>` into the session** — using its core session-input mechanism
+(`SessionManager.sendInput` / tmux send-keys, the same way it injects any message) — and marks
+the job `goal_mode: native`. The framework's own /goal loop (with its own independent evaluator)
+then drives completion, and instar's stop-hook **defers** the continue/stop decision to it
+(approves each turn so native /goal stays in control). Where native /goal is absent, instar's
+own completion evaluator (shipped previously) drives — works everywhere.
+
+instar stays in charge of what native /goal doesn't cover: it still enforces **emergency-stop**
+and **duration expiry** on a native-goal job by injecting `/goal clear` first, then standing the
+job down. Multi-topic orchestration, cap/quota, and messaging remain instar's.
+
+- Endpoints: `POST /autonomous/native-goal/set {topicId, condition}` (inject + mark native),
+  `POST /autonomous/native-goal/clear {topicId}`.
+- `setup-autonomous.sh` auto-detects Claude Code >= 2.1.139 and activates native /goal when a
+  condition is set; otherwise falls back to instar's own evaluator.
+
+## What to Tell Your User
+
+When the tool I'm running already has its own "keep going until done" feature (Claude Code and
+Codex both added one called goal), I now hand my finish-line straight to it instead of running
+my own judge on top — no double-checking, and I use the tool's native machinery. Where the tool
+doesn't have it, my own judge still does the job. Either way I keep the safety controls (stop
+everything, time limits) and the ability to run several jobs at once. Nothing to set up.
+
+## Summary of New Capabilities
+
+- Native /goal delegation: instar injects `/goal <condition>` into the session and lets the
+  framework's loop own completion (`goal_mode: native`).
+- `POST /autonomous/native-goal/set` and `/autonomous/native-goal/clear`.
+- Auto-detection of Claude Code >= 2.1.139 in `setup-autonomous.sh`.
+- Stop-hook defers completion to native /goal while still enforcing emergency-stop + duration
+  (clears the native goal first).
+
+## Migration Notes
+
+Existing agents receive the updated hook + setup via
+`PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed` (marker bumped to the native-/goal
+signature). No action required.
+
+## Evidence
+
+- **Hook (behavioral):** `autonomous-completion-condition.test.ts` — `goal_mode: native` defers
+  (approves/exits, job retained, native /goal stays in control); emergency-stop and duration
+  expiry still clear state + exit in native mode.
+- **Integration:** `autonomous-sessions-api.test.ts` — `native-goal/set` injects `/goal
+  <condition>` into the topic's session (verified via the recorded `sendInput` call) and flips
+  `goal_mode: native`; `native-goal/clear` injects `/goal clear`; 404 on unknown topic.
+- tsc clean; 174 affected tests green.
+
+## Note on approach
+
+The original spec sketched Phase 2 via a `ThreadGoalSlot` provider primitive. The shipped
+approach instead drives native /goal by **injecting the slash command** through instar's
+existing session-input mechanism — simpler, and the correct use of a capability instar already
+has (rather than treating "no programmatic /goal API" as a blocker). Same intent (delegate to
+native /goal where present), better mechanism.

--- a/upgrades/side-effects/goal-native-delegation.md
+++ b/upgrades/side-effects/goal-native-delegation.md
@@ -1,0 +1,76 @@
+# Side-Effects Review — native /goal delegation (Phase 2)
+
+**Version / slug:** `goal-native-delegation`
+**Date:** 2026-05-24
+**Author:** echo
+**Second-pass reviewer:** internal conformance pass
+
+## Summary of the change
+
+Where the framework has a native /goal loop (Claude Code >= 2.1.139), autonomous mode delegates
+completion to it: instar **injects `/goal <condition>`** into the session via
+`SessionManager.sendInput` (tmux send-keys — its existing session-input mechanism), marks the
+job `goal_mode: native`, and the stop-hook **defers** the continue/stop decision to native
+/goal (approves each turn). instar still enforces emergency-stop + duration by injecting
+`/goal clear` first. Phase 2 of `docs/specs/goal-completion-evaluator.md`. `src/`: two routes
+(`/autonomous/native-goal/set|clear`) + capability-index entry + migration marker bump. Non-src:
+hook native branch, setup auto-detection.
+
+## Decision-point inventory
+- Stop-hook `goal_mode: native` branch — **modify**: defer completion to native /goal (approve);
+  still enforce emergency-stop + duration (clear native first). This REMOVES instar's completion
+  authority for native topics by design (native /goal is the authority there).
+- `POST /autonomous/native-goal/set` / `clear` — **add**: inject the slash command + flip
+  goal_mode. Thin; the side-effect is the session injection.
+- `setup-autonomous.sh` native detection — **modify** (`.claude/`): activate native mode when
+  Claude Code >= 2.1.139 + a condition is set.
+
+## 1. Over-block
+- In native mode instar approves (never blocks) for completion, so instar cannot over-block.
+  Native /goal's own hook decides. No new over-block path.
+
+## 2. Under-block (false "done" / premature exit)
+- instar approving in native mode does NOT cause a false done: in Claude Code's hook composition
+  a `block` from native /goal wins over instar's `approve`, so native /goal keeps the session
+  working until ITS evaluator confirms the condition. If native /goal somehow isn't active, the
+  session would exit — mitigated because goal_mode:native is only set after a successful inject
+  (the set endpoint flips the flag only when sendInput returns true).
+
+## 3. Level-of-abstraction fit
+- Correct + the point of the change: drive the framework's native feature via instar's own
+  session-input mechanism, rather than reimplementing or treating "no /goal API" as a blocker.
+
+## 4. Blocking authority
+- [x] In native mode instar **yields** completion authority to native /goal (reduces instar's
+  authority — safe direction) while retaining its terminal STOP concerns (emergency/duration) by
+  clearing the native goal. No new brittle authority added.
+
+## 5. Interactions (the key one: two Stop hooks)
+- instar's hook + native /goal's hook both fire each turn. Resolved by composition: instar
+  approves (completion) so native /goal's block keeps control; instar only force-stops on
+  emergency/duration, and does so by clearing native /goal first (so they don't fight).
+- **Emergency-stop** already kills the session via the sentinel path (native /goal dies with it);
+  the hook also clears native /goal on the flag. **Duration** clears native /goal then exits.
+- Falls back cleanly to the instar evaluator (Phase 1) when native /goal is absent.
+
+## 6. External surfaces
+- **Session injection:** instar types `/goal <condition>` / `/goal clear` into the agent's own
+  tmux session (send-keys). This is instar's established mechanism (initial-message injection).
+  No new external/credential surface.
+- **HTTP:** two authed routes under the already-claimed `/autonomous` prefix.
+
+## 7. Rollback cost
+- Low. Reverting restores instar's own evaluator everywhere (Phase 1 still in main). A
+  `goal_mode: native` left in a state file is ignored by an older hook (falls to the evaluator/
+  promise path). Migration marker is content-sniffed (rollback re-deploys cleanly).
+
+## 8. Test evidence
+- Hook: native defers (approve/exit, retained) + emergency/duration clear+exit. Integration:
+  set injects `/goal <cond>` (verified sendInput) + flips goal_mode; clear injects `/goal clear`;
+  404 unknown topic. tsc clean; 174 affected tests green.
+
+## Deviation from the original spec
+Spec Phase 2 sketched a `ThreadGoalSlot` provider primitive. Shipped instead via direct slash-
+command injection through `SessionManager.sendInput` — simpler and the correct use of an existing
+instar capability (per maintainer direction: "we already input text into sessions; use that to
+call /goal"). Same intent, better mechanism; `ThreadGoalSlot` left unimplemented (not needed).


### PR DESCRIPTION
## What

Phase 2 of `docs/specs/goal-completion-evaluator.md`: where the framework has a native `/goal` loop (Claude Code ≥2.1.139), autonomous mode hands the finish-line to it instead of running instar's own judge on top.

## How — via session injection (the corrected approach)

instar **injects `/goal <condition>` into the session** using its core mechanism (`SessionManager.sendInput` / tmux send-keys — the same way it injects any message), and marks the job `goal_mode: native`. The framework's own `/goal` loop (with its own evaluator) then drives completion, and instar's stop-hook **defers** — it approves each turn so native `/goal`'s block stays in control. Where native `/goal` is absent, instar's own evaluator (Phase 1, already in main) drives. Both-hooks composition resolved: instar approves for completion (native `/goal`'s block wins), and instar force-stops only on emergency/duration by injecting `/goal clear` first.

- `POST /autonomous/native-goal/set {topicId, condition}` (inject + mark native) and `POST /autonomous/native-goal/clear`.
- `setup-autonomous.sh` auto-detects Claude Code ≥2.1.139 and activates native `/goal` when a condition is set.
- instar retains emergency-stop, duration, multi-topic orchestration, cap/quota, messaging.

## Note on approach (deviation from the spec sketch)

The spec sketched Phase 2 via a `ThreadGoalSlot` provider primitive. Shipped instead via direct slash-command **injection** — simpler, and the correct use of a capability instar already has. (This corrects an earlier mis-call where "Claude `/goal` has no API" was treated as a blocker — instar's whole modality is typing into interactive sessions, which is exactly how you set `/goal`.) Same intent, better mechanism; `ThreadGoalSlot` left unimplemented (not needed).

## Tests (all green; full pre-push suite passed)
- Hook behavioral (`autonomous-completion-condition`): `goal_mode: native` defers (approve/exit, job retained); emergency-stop + duration still clear state + exit in native mode.
- Integration (`autonomous-sessions-api`): `native-goal/set` injects `/goal <condition>` (verified via recorded `sendInput`) + flips `goal_mode`; `native-goal/clear` injects `/goal clear`; 404 unknown topic.

## Governance
Same approved spec + ELI16 (in main) + side-effects review (`upgrades/side-effects/goal-native-delegation.md`) + `/instar-dev` trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)