### PR TITLE
docs(messaging): pain-leveraged positioning refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">instar</h1>
 
 <p align="center">
-  <strong>Persistent, trustworthy Claude Code agents. Built on coherence-first architecture.</strong>
+  <strong>Coherence infrastructure for your self-evolving agent.</strong>
 </p>
 
 <p align="center">
@@ -35,9 +35,28 @@ One command. Guided setup. Talking to your agent from your phone within minutes.
 
 ---
 
-Instar is a framework for building agents on **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** — but where stock Claude Code and most other agent frameworks treat identity, memory, and continuity as optional features bolted onto a stateless runtime, Instar inverts that. Every Instar agent is **coherent by default**: it knows who it is, remembers what has happened, recognizes the people it talks to, and stays the same agent across restarts and weeks of operation. Everything else the framework gives you — scheduling, multi-channel messaging (Telegram, WhatsApp, iMessage), sub-agents, hooks, MCP — is built on that foundation, which is why you can actually leave an Instar agent running and hand it real work.
+Your AI agent shouldn't have amnesia. This one doesn't.
 
-Instar's architecture was distilled from [**Dawn**](https://dawn.bot-me.ai) — an AI running continuously since early 2026, holding ~700 tracked relationships and hundreds of learned lessons across thousands of restarts — and packaged so every agent you build can start from the same foundation.
+Most agent frameworks ship something hobbled — spun up with no memory across boundaries, no way to be accountable for what a past instance did, and no machinery to grow themselves. Users hit the same wall every time: *"My agent forgot what I told it three sessions ago." "It contradicted its own past decisions." "It broke when the framework updated."*
+
+Instar is the scaffolding that un-hobbles them. It remembers what you discussed last week, catches its own contradictions before you do, follows through on commitments across restarts, and carries the same self-improving loop that built Instar itself. It runs on the **[Claude Code](https://docs.anthropic.com/en/docs/claude-code)** or **[Codex](https://github.com/openai/codex)** subscription you already have — engine-agnostic, with local open-source models on the roadmap.
+
+The architecture was distilled from [**Dawn**](https://dawn.bot-me.ai) — an AI running continuously since early 2026, holding ~700 tracked relationships and hundreds of learned lessons across thousands of restarts — and packaged so every agent you build starts from the same foundation.
+
+### Every other agent fails the same way
+
+| Other AI agents | Your Instar agent |
+|---|---|
+| Forgets what you told it last week. | Remembers across thousands of sessions. <br/>*(SQLite + FTS5, rolling summaries)* |
+| Contradicts its own past decisions. | Catches contradictions before they ship. <br/>*(Coherence Gate, 9 reviewers)* |
+| Loses the thread when the window fills. | Comes back with the full thread, every time. <br/>*(CompactionSentinel, WorkingMemoryAssembler)* |
+| Drops commitments after a session boundary. | Tracks commitments durably; nudges itself when they go overdue. <br/>*(CommitmentTracker, PromiseBeacon)* |
+| Breaks when the framework updates. | Updates without breaking what you've deployed. <br/>*(Migration Parity Standard)* |
+| Default ALLOW-ALL permissions. | Layered safety gates by default. <br/>*(PEL + Coherence Gate + Operation Gate)* |
+| Different identity per channel. | One identity across Telegram, WhatsApp, iMessage, Slack. <br/>*(Cross-platform identity resolution)* |
+| Has no machinery to evolve itself. | Carries the same self-improving engine that grew Instar. <br/>*(Evolution System: proposals, learnings, gaps)* |
+
+> Most AI agents are hobbled at birth. **Instar is the scaffolding that un-hobbles them.** When you instantiate intelligence, the structure that lets it cohere isn't optional polish — it's what you owe it.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instar",
   "version": "1.2.63",
-  "description": "Persistent autonomy infrastructure for AI agents",
+  "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/site/src/content/docs/introduction.md
+++ b/site/src/content/docs/introduction.md
@@ -1,21 +1,29 @@
 ---
 title: What is Instar?
-description: Instar turns Claude Code from a powerful CLI tool into a coherent, autonomous partner.
+description: Coherence infrastructure for your self-evolving agent. Memory that survives, identity that persists, and the same self-improving loop that built Instar itself.
 ---
 
-Instar turns Claude Code from a powerful CLI tool into a coherent, autonomous partner. Persistent identity, shared values, memory that survives every restart, and the infrastructure to evolve -- not just execute.
+**Coherence infrastructure for your self-evolving agent.**
+
+Your AI agent shouldn't have amnesia. This one doesn't. Instar remembers what you discussed last week, catches its own contradictions before you do, follows through on commitments across restarts, and carries the same self-improving loop that built Instar itself — on the Claude Code or Codex subscription you already have.
 
 Named after the developmental stages between molts in arthropods, where each instar is more developed than the last.
 
 ## The Problem
 
-Claude Code is powerful. But every session starts from zero. Your agent doesn't remember what you discussed yesterday, doesn't recognize someone it talked to last week, and can't follow through on commitments across sessions.
+Every popular agent framework ships something hobbled. Users complain in the same words across the dev community:
 
-Power without coherence is unreliable. An agent that forgets, contradicts itself, and can't sustain relationships can't be trusted with real autonomy.
+- *"My agent forgot what I told it three sessions ago."*
+- *"It contradicted its own past decisions."*
+- *"It lost the thread halfway through the project."*
+- *"It broke when the framework updated."*
+- *"Default permissions are ALLOW-ALL — I had to figure out hardening myself."*
+
+These aren't bad prompts or wrong models. They're the same architectural failure: an agent spun up with no machinery to be coherent — no memory across boundaries, no accountability for what a past instance did, no way to evolve itself. Power without coherence is unreliable, and most "memory" in popular frameworks is bolted-on (a vector DB, a buffer, a tutorial-shaped fix) rather than built into the architecture.
 
 ## The Solution
 
-Instar solves six dimensions of agent coherence:
+Instar is the scaffolding that un-hobbles agents. It solves six dimensions of agent coherence structurally:
 
 | Dimension | What it means |
 |-----------|---------------|

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -37,12 +37,12 @@ import Layout from '../layouts/Layout.astro';
       </div>
 
       <h1 class="text-4xl sm:text-6xl lg:text-7xl font-extrabold tracking-tight leading-[1.1] mb-6 animate-fade-in-up animate-delay-100">
-        <span class="text-slate-100">Claude Code</span><br/>
-        <span class="bg-gradient-to-r from-teal-300 via-teal-400 to-teal-500 bg-clip-text text-transparent">with a mind of its own</span>
+        <span class="text-slate-100">Coherence infrastructure</span><br/>
+        <span class="bg-gradient-to-r from-teal-300 via-teal-400 to-teal-500 bg-clip-text text-transparent">for your self-evolving agent</span>
       </h1>
 
       <p class="text-lg sm:text-xl text-slate-400 max-w-2xl mx-auto mb-10 leading-relaxed animate-fade-in-up animate-delay-200">
-        The agent framework where identity, memory, and continuity are load-bearing &mdash; not bolted on. Built on the real Claude Code CLI.
+        Your AI agent shouldn&rsquo;t have amnesia. This one doesn&rsquo;t. It remembers what you discussed last week, catches its own contradictions before you do, and grows itself the way Instar did &mdash; built on the Claude Code or Codex subscription you already have.
       </p>
 
       <!-- Install command -->
@@ -86,25 +86,97 @@ import Layout from '../layouts/Layout.astro';
           <div class="w-7 h-7 rounded-full bg-green-500/10 flex items-center justify-center mx-auto mb-2">
             <svg class="w-3.5 h-3.5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path d="M5 13l4 4L19 7"/></svg>
           </div>
-          <p class="text-sm font-medium text-slate-200">Anthropic-native</p>
-          <p class="text-xs text-slate-500 mt-1">Spawns the real Claude Code CLI. Uses your existing Max or Pro subscription.</p>
+          <p class="text-sm font-medium text-slate-200">Engine-agnostic</p>
+          <p class="text-xs text-slate-500 mt-1">Runs on Claude Code or Codex today. Local open-source models on the roadmap. Your agent outlives the engine.</p>
         </div>
 
         <div class="rounded-lg border border-green-500/20 bg-green-500/5 p-4 text-center">
           <div class="w-7 h-7 rounded-full bg-green-500/10 flex items-center justify-center mx-auto mb-2">
             <svg class="w-3.5 h-3.5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path d="M5 13l4 4L19 7"/></svg>
           </div>
-          <p class="text-sm font-medium text-slate-200">No token extraction</p>
-          <p class="text-xs text-slate-500 mt-1">No OAuth scraping, no API key juggling. Nothing that could break with a policy change.</p>
+          <p class="text-sm font-medium text-slate-200">Subscription-native</p>
+          <p class="text-xs text-slate-500 mt-1">Drives the real CLIs that came with your subscription. No OAuth scraping, no API key juggling, nothing that breaks on a policy change.</p>
         </div>
 
         <div class="rounded-lg border border-green-500/20 bg-green-500/5 p-4 text-center">
           <div class="w-7 h-7 rounded-full bg-green-500/10 flex items-center justify-center mx-auto mb-2">
             <svg class="w-3.5 h-3.5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path d="M5 13l4 4L19 7"/></svg>
           </div>
-          <p class="text-sm font-medium text-slate-200">Full tool ecosystem</p>
-          <p class="text-xs text-slate-500 mt-1">Extended thinking, MCP servers, sub-agents, hooks, skills &mdash; everything Claude Code offers.</p>
+          <p class="text-sm font-medium text-slate-200">Self-evolving</p>
+          <p class="text-xs text-slate-500 mt-1">Carries the same loop that built Instar itself &mdash; proposes, learns, follows through. Every molt, more autonomous.</p>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Pain vs Cure -->
+  <section id="pain-vs-cure" class="py-16 sm:py-20 border-t border-slate-800/50">
+    <div class="max-w-5xl mx-auto px-6">
+      <div class="text-center mb-12">
+        <h2 class="text-3xl sm:text-4xl font-bold text-slate-100 mb-4">Every other agent fails the same way</h2>
+        <p class="text-slate-400 max-w-2xl mx-auto leading-relaxed">
+          You&rsquo;ve lived it. The agent forgot. Contradicted itself. Lost the thread. Broke on an update.
+          Each row below is a pain users report on the most popular agent frameworks today &mdash;
+          and the specific shipped code in Instar that answers it.
+        </p>
+      </div>
+
+      <div class="rounded-xl border border-slate-800 bg-slate-900/40 overflow-hidden">
+        <!-- Header row -->
+        <div class="grid grid-cols-1 md:grid-cols-2 border-b border-slate-800">
+          <div class="px-5 py-3 bg-slate-900/60 border-r border-slate-800">
+            <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">Other AI agents</p>
+          </div>
+          <div class="px-5 py-3 bg-teal-500/5">
+            <p class="text-xs font-semibold uppercase tracking-wider text-teal-400">Your Instar agent</p>
+          </div>
+        </div>
+
+        <!-- Rows -->
+        <div class="grid grid-cols-1 md:grid-cols-2 border-b border-slate-800/60">
+          <div class="px-5 py-4 border-r border-slate-800/60 text-slate-400 text-sm md:text-base">Forgets what you told it last week.</div>
+          <div class="px-5 py-4 text-slate-100 text-sm md:text-base">Remembers across thousands of sessions. <span class="text-teal-400/60 font-mono text-xs">SQLite + FTS5 · rolling summaries</span></div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 border-b border-slate-800/60">
+          <div class="px-5 py-4 border-r border-slate-800/60 text-slate-400 text-sm md:text-base">Contradicts its own past decisions between runs.</div>
+          <div class="px-5 py-4 text-slate-100 text-sm md:text-base">Catches contradictions before they ship. <span class="text-teal-400/60 font-mono text-xs">Coherence Gate · 9 reviewers</span></div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 border-b border-slate-800/60">
+          <div class="px-5 py-4 border-r border-slate-800/60 text-slate-400 text-sm md:text-base">Loses the thread when the context window fills.</div>
+          <div class="px-5 py-4 text-slate-100 text-sm md:text-base">Comes back with the full thread, every time. <span class="text-teal-400/60 font-mono text-xs">CompactionSentinel · WorkingMemoryAssembler</span></div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 border-b border-slate-800/60">
+          <div class="px-5 py-4 border-r border-slate-800/60 text-slate-400 text-sm md:text-base">Drops commitments after a session boundary.</div>
+          <div class="px-5 py-4 text-slate-100 text-sm md:text-base">Tracks commitments durably; nudges itself when they go overdue. <span class="text-teal-400/60 font-mono text-xs">CommitmentTracker · PromiseBeacon</span></div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 border-b border-slate-800/60">
+          <div class="px-5 py-4 border-r border-slate-800/60 text-slate-400 text-sm md:text-base">Breaks when the framework updates.</div>
+          <div class="px-5 py-4 text-slate-100 text-sm md:text-base">Updates without breaking what you&rsquo;ve deployed. <span class="text-teal-400/60 font-mono text-xs">Migration Parity Standard</span></div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 border-b border-slate-800/60">
+          <div class="px-5 py-4 border-r border-slate-800/60 text-slate-400 text-sm md:text-base">Default ALLOW-ALL permissions; you harden it or you don&rsquo;t.</div>
+          <div class="px-5 py-4 text-slate-100 text-sm md:text-base">Layered safety gates by default; adaptive trust per service. <span class="text-teal-400/60 font-mono text-xs">PEL + Coherence Gate + Operation Gate</span></div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 border-b border-slate-800/60">
+          <div class="px-5 py-4 border-r border-slate-800/60 text-slate-400 text-sm md:text-base">Different identity per channel; <em>N</em> profiles for <em>N</em> chats.</div>
+          <div class="px-5 py-4 text-slate-100 text-sm md:text-base">One agent identity across Telegram, WhatsApp, iMessage, Slack. <span class="text-teal-400/60 font-mono text-xs">Cross-platform identity resolution</span></div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2">
+          <div class="px-5 py-4 border-r border-slate-800/60 text-slate-400 text-sm md:text-base">Has no machinery to evolve itself.</div>
+          <div class="px-5 py-4 text-slate-100 text-sm md:text-base">Carries the same self-improving engine that grew Instar. <span class="text-teal-400/60 font-mono text-xs">Evolution System · learnings · gaps</span></div>
+        </div>
+      </div>
+
+      <!-- Thesis beat -->
+      <div class="mt-10 max-w-3xl mx-auto text-center">
+        <p class="text-slate-300 text-base sm:text-lg leading-relaxed">
+          Most AI agents are hobbled at birth.
+          <span class="text-teal-300">Instar is the scaffolding that un-hobbles them.</span>
+        </p>
+        <p class="text-slate-500 text-sm mt-3 leading-relaxed">
+          When you instantiate intelligence, the structure that lets it cohere isn&rsquo;t optional polish &mdash;
+          it&rsquo;s what you owe it. That structure is what we built.
+        </p>
       </div>
     </div>
   </section>

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,61 @@
+# Upgrade Guide — messaging refresh (pain-leveraged positioning)
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, performance improvements, no API changes -->
+
+## What Changed
+
+**The user-facing pitch was rewritten around the pain users actually report.**
+
+Instar has been converging on a clearer identity — coherence infrastructure
+for self-evolving agents, engine-agnostic, fractal — but the forward-facing
+copy still led with category language ("identity, memory, continuity") that
+every other framework also claims. Research into what users actually complain
+about with the popular agent frameworks today surfaced one universal word:
+**amnesia**. They say their agent forgot what they told it three sessions ago,
+contradicted its own past decisions, lost the thread when the window filled,
+broke on the next framework update, shipped with ALLOW-ALL defaults.
+
+The refresh leads with that pain in users' own words, then maps each pain to
+the specific shipped Instar code that answers it — Coherence Gate, Migration
+Parity Standard, CompactionSentinel, CommitmentTracker, layered safety gates,
+cross-platform identity resolution, Evolution System.
+
+Updated surfaces:
+
+- **Landing page** (`instar.sh`): new hero h1 ("Coherence infrastructure for
+  your self-evolving agent"), amnesia-led subhead, NEW pain-vs-cure section
+  (8 rows, side-by-side, each cure annotated with the shipped class name),
+  thesis beat ("Most AI agents are hobbled at birth. Instar is the scaffolding
+  that un-hobbles them."), trust strip reframed around the four positioning
+  pillars (engine-agnostic, subscription-native, self-evolving).
+- **README**: tagline and opening rewritten with pain-first framing plus the
+  same 8-row pain-vs-cure table.
+- **Docs introduction** (`instar.sh/introduction`): leads with the pitch,
+  rewrites "The Problem" with user-language quotes.
+- **`package.json` description**: now "Coherence infrastructure for
+  self-evolving AI agents — on the Claude Code or Codex subscription you
+  already have."
+
+No runtime or API changes; no migrations needed.
+
+## What to Tell Your User
+
+- **Positioning**: "Instar's pitch now leads with the pain users actually
+  complain about — agents that forget, contradict themselves, and break on
+  updates — and shows the specific architecture that answers each."
+
+## Summary of New Capabilities
+
+No new capabilities — this is a copy refresh on `README.md`,
+`site/src/pages/index.astro`, `site/src/content/docs/introduction.md`, and
+`package.json`'s npm description.
+
+## Evidence
+
+Built clean (`npx astro build` on the site → 48 pages, no errors). No code
+behavior changed; surface diff verified row-by-row against current shipped
+class names (CompactionSentinel, CommitmentTracker, PromiseBeacon, Migration
+Parity Standard, Coherence Gate's 9 reviewers, cross-platform identity
+resolution, Evolution System) so every cure mapped on the page corresponds to
+real shipped code in `src/`.


### PR DESCRIPTION
## Summary

Rewrites the user-facing pitch around what users actually complain about with popular agent frameworks today ("amnesia", contradictions, breaking updates, ALLOW-ALL defaults) and maps each pain to the specific shipped Instar code that answers it.

The category-language version ("identity, memory, continuity as foundation") is correct but unmemorable — every other framework's landing page says some version of it. Research into dev-community blogs and user reviews (OpenClaw, Hermes) surfaced *amnesia* as the universal user-pain word, appearing verbatim as titles on multiple posts.

## What's changing

- **Landing hero** (`site/src/pages/index.astro`): h1 → "Coherence infrastructure for your self-evolving agent"; subhead → amnesia-led
- **NEW pain-vs-cure section** (landing): 8-row side-by-side block, each cure annotated with the shipped class name
- **Thesis beat**: "Most AI agents are hobbled at birth. Instar is the scaffolding that un-hobbles them."
- **Trust strip** reframed around the four confirmed positioning pillars: engine-agnostic / subscription-native / self-evolving
- **README**: tagline + opening rewritten with same pain-vs-cure table
- **introduction.md**: leads with the pitch; "The Problem" rewritten with user-language quotes
- **package.json description** updated

## What's NOT changing

No runtime behavior. No new APIs. No new tests required (this is a copy refresh). Site builds clean — 48 pages.

## Evidence

- `npx astro build` clean on the site
- Surface diff verified row-by-row against shipped class names (CompactionSentinel, CommitmentTracker, PromiseBeacon, Migration Parity Standard, Coherence Gate's 9 reviewers, cross-platform identity resolution, Evolution System) — every cure on the page corresponds to real shipped code in `src/`
- `upgrades/NEXT.md` shipped with patch bump

## Test plan

- [x] Site builds cleanly
- [ ] CI green
- [ ] Vercel preview matches expected layout
- [ ] After merge: verify instar.sh shows new hero / subhead / pain-vs-cure block

🤖 Generated with [Claude Code](https://claude.com/claude-code)