### PR TITLE
fix(monitoring): rate-limit recovery reaches non-topic-bound sessions

### DIFF
--- a/docs/specs/sentinel-reachability.eli16.md
+++ b/docs/specs/sentinel-reachability.eli16.md
@@ -1,0 +1,58 @@
+# Sentinel Reachability — plain English
+
+## What's broken
+
+We have a little guardian that watches for one specific problem: when Anthropic's
+servers get briefly busy and tell Claude "slow down for a bit" (a temporary
+throttle — *not* your usage limit running out). When that happens, the guardian
+is supposed to do two things: tell you "heads up, I got throttled, I'm backing
+off, you haven't been dropped," and then quietly poke the session to wake it back
+up once the busy spell passes.
+
+Here's the problem. Both of those actions started by asking one question: "Is
+this session attached to a Telegram topic?" If the answer was no, the guardian
+just stopped and did nothing — no message, no poke, nothing.
+
+Think of it like a smoke alarm wired to send its alert only to the upstairs
+phone. If you're standing in the kitchen with no upstairs phone, the alarm still
+"goes off" internally — but nothing reaches you. You'd swear the alarm was dead.
+
+Your interactive developer window — the one where you talk to me directly — isn't
+attached to a Telegram topic. So when you hit that throttle in that window, the
+guardian detected it, started its timer, and then dropped both the message and
+the wake-up poke on the floor. You sat watching a frozen screen. That's exactly
+what you reported, and why my earlier "it's fixed" was wrong: my tests only ever
+checked the upstairs-phone case.
+
+## What we're fixing
+
+Make the guardian reach you no matter what kind of window you're in:
+
+- **The wake-up poke** now has a second route. If there's no Telegram topic, it
+  uses a trusted internal path to nudge the session directly. (That internal path
+  is locked down — it can only be used from inside the program, never from the
+  outside web interface, so it can't become a security hole.)
+- **The "you're throttled" message** now tries your topic first, then falls back
+  to your always-there system channel (the lifeline), and if even that's missing,
+  it writes a loud note in the logs and on the dashboard. It never just goes
+  silent.
+- **A paper trail.** Every recovery attempt now leaves a record saying either
+  "reached the user" or "couldn't reach the user," so we can never again *think*
+  the guardian is working when it isn't.
+
+## What's NOT in this change
+
+The original plan also bundled two other things. Both are already handled, so
+they're left alone here: the worktree safety fix already shipped, and the
+"send all the quiet watcher alerts to Telegram" switch is deliberately staying
+OFF (we turned it off on purpose to stop a notification flood — flipping it back
+on would undo that).
+
+## How I proved it this time
+
+Not just tests. I rebuilt the real guardian, pointed it at a real terminal window
+that was *not* attached to any topic, triggered the throttle, and watched: the
+wake-up poke actually landed in the window, the "throttled, backing off" message
+and the "back online" message both reached the lifeline channel, and the paper
+trail showed "reached the user" with zero "couldn't reach." Before the fix, all
+of that was silence.

--- a/docs/specs/sentinel-reachability.md
+++ b/docs/specs/sentinel-reachability.md
@@ -1,0 +1,120 @@
+---
+slug: sentinel-reachability
+review-convergence: "internal-adversarial-1"
+approved: true
+approved-by: justin
+approval-basis: >
+  Justin greenlit the plan ("yes, please follow through with this, but also
+  note that the API rate-limit scenario is still not recovering even though we
+  claimed to deploy a fix", topic 2169). The narrowed scope (rate-limit recovery
+  only; worktree-clone + socket/silence parts already shipped via #334/#340/#351;
+  the sentinelTelegramEscalation default-flip is intentionally dropped as
+  superseded by the anti-flood design) was disclosed back to him before build.
+eli16-overview: sentinel-reachability.eli16.md
+companion-eli16: sentinel-reachability.eli16.md
+date: 2026-05-24
+---
+
+# Sentinel Reachability — rate-limit recovery for non-topic-bound sessions
+
+## Problem
+
+The RateLimitSentinel detects Anthropic's server-side throttle and schedules its
+backoff correctly, but both recovery actions in `server.ts` began with:
+
+```js
+const topicId = telegram?.getTopicForSession(sessionName);
+if (topicId == null) return;   // ← silent no-op
+```
+
+A developer's interactive Claude Code window is **not** bound to any Telegram
+topic. So for that session the resume nudge and the user notice both dropped on
+the floor — detection + backoff ran, then nothing reached the user. From the
+outside this is indistinguishable from the sentinel never existing. v1.2.33
+shipped past green tests because every fixture was topic-bound; the
+non-topic-bound path was never asserted (the inline logic was also untestable).
+
+## Scope
+
+This spec covers ONLY the rate-limit recovery reachability fix. The two sibling
+problems from the original "Sentinel Reachability + Worktree Isolation" spec are
+out of scope here because they already shipped or were superseded:
+
+- **Worktree clone-isolation** — shipped via #334 (`WorktreeManager` clone-default).
+- **Socket-disconnect / active-silence default** — `sentinelTelegramEscalation`
+  intentionally stays default-OFF (the post-2026-05-22 anti-flood design, #351).
+  The original spec's Part A3 (flip to default-on) is DROPPED.
+
+## Design
+
+### A1 — Notify reachability
+
+`notifyFn` delivery order, with no silent return at any step:
+1. The session's own Telegram topic (unchanged).
+2. Else the always-available lifeline (system) topic via `getLifelineTopicId()`.
+3. Else a `recovery-unreachable` audit event (so it's greppable, never silent).
+
+### A2 — Resume reachability
+
+`resumeFn`:
+- Topic-bound → topic-tagged nudge via `injectMessage` (provenance-checked).
+- Non-topic-bound → `SessionManager.injectInternalMessage`, a trusted in-process
+  path that bypasses the topic-prefix requirement and logs the injection with
+  `source: 'sentinel-recovery'`.
+
+### A3 — Audit trail
+
+Every recovery attempt records `recovery-reached` / `recovery-unreachable` to
+`logs/sentinel-events.jsonl`. Unreachable events also append to
+`.instar/sentinel-alerts.json` (rolling 200) so the dashboard surfaces them even
+without Telegram.
+
+### Testability
+
+The branching is extracted from inline server closures into
+`sentinelWiring.buildRateLimitRecoveryDeps()` — the gap (inline + untestable)
+that let the bug ship past green tests.
+
+## Security boundary
+
+`injectInternalMessage` bypasses InputGuard's topic-prefix provenance, so it is
+in-process only — never wired to an HTTP route. HTTP injection continues through
+`injectMessage`. Asserted by a test that `routes.ts` does not reference
+`injectInternalMessage`.
+
+## Verification
+
+- **Live reproduction:** real RateLimitSentinel lifecycle + real factory + real
+  tmux pane, non-topic-bound. Resume nudge landed in the pane; throttle notice +
+  "back online" reached the lifeline; audit recorded `recovery-reached`, zero
+  `recovery-unreachable`. Before the fix all silent.
+- **Unit:** `rate-limit-recovery-reachability.test.ts` — both sides of every
+  reachability boundary.
+- **Integration:** `rate-limit-recovery-sentinel-lifecycle.test.ts` — real
+  sentinel lifecycle driving the factory to the lifeline for a non-topic-bound
+  session + the never-silent unreachable case.
+- **Wiring/boundary:** `rate-limit-recovery-wiring.test.ts` — server wires the
+  real primitives (not no-ops) + the InputGuard HTTP boundary.
+
+## Migration parity
+
+No agent-installed file changes. Server-side binary code shipped via npm update;
+existing agents pick it up automatically. No config default, hook, skill, or
+CLAUDE.md template capability added.
+
+## Rollback
+
+`git revert` restores the two inline closures (reintroducing the silent no-op).
+`injectInternalMessage` + the factory become dead code; no state to undo.
+
+## Adversarial review log (internal-1)
+
+- **R1 — InputGuard bypass is a trust boundary.** Resolved: `injectInternalMessage`
+  is a SessionManager method only, never an HTTP route; logged with a `source`
+  label; HTTP path still enforces prefixing. Asserted by test T7.
+- **R2 — notifyFn throwing on unreachable.** Resolved: never throws; the audit
+  event is the durable record (the sentinel only console.warns on a throw).
+- **R3 — lifeline null during setup.** Resolved: the audit-event fallback +
+  `.instar/sentinel-alerts.json` cover the no-lifeline case; dashboard surfaces it.
+- **R4 — double-notify spam.** Out of scope; RateLimitSentinel's existing
+  check-in min-spacing governs notice cadence, unchanged here.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.62",
+  "version": "1.2.63",
   "description": "Persistent autonomy infrastructure for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5192,27 +5192,65 @@ export async function startServer(options: StartOptions): Promise<void> {
     const getClaudeSessionIdForName = (sessionName: string): string | undefined =>
       sessionManager.listRunningSessions().find(s => s.tmuxSession === sessionName)?.claudeSessionId;
 
-    // Neutral "continue" nudge — NOT the compaction-resume payload (which would
-    // falsely tell the agent its memory was reset). Topic-tagged so InputGuard
-    // accepts it.
-    const rateLimitResume = async (sessionName: string): Promise<boolean> => {
-      if (!sessionManager.isSessionAlive(sessionName)) return false;
-      const topicId = telegram?.getTopicForSession(sessionName);
-      if (topicId == null) return false;
-      const tagged = `[telegram:${topicId}] The temporary server throttle should have cleared — please continue where you left off.`;
-      return sessionManager.injectMessage(sessionName, tagged);
+    // Recovery-reachability audit trail. Both recovery paths below ALWAYS leave
+    // a record: a recovery-reached/recovery-unreachable line in the sentinel
+    // audit log, and — when delivery to the user fails entirely — an entry in
+    // .instar/sentinel-alerts.json so the dashboard surfaces it even without
+    // Telegram. The defining bug this closes: a non-topic-bound session (e.g. a
+    // developer's interactive Claude Code window) used to make both recovery
+    // paths silently no-op, so the throttle never recovered and nothing reached
+    // the user. Reachability is now unconditional — see the Sentinel
+    // Reachability spec.
+    const rlReachLogPath = path.join(config.stateDir, '..', 'logs', 'sentinel-events.jsonl');
+    const rlAlertsPath = path.join(config.stateDir, 'sentinel-alerts.json');
+    const recordRecovery = (
+      kind: 'recovery-reached' | 'recovery-unreachable',
+      sessionName: string,
+      detail: string,
+      fallbackTried: string[],
+    ): void => {
+      const entry = { timestamp: new Date().toISOString(), kind, sentinel: 'rate-limit', sessionName, detail, fallbackTried };
+      console.log(`[sentinel:${kind}] rate-limit/${sessionName} — ${detail}`);
+      try { fs.appendFileSync(rlReachLogPath, JSON.stringify(entry) + '\n'); } catch { /* best-effort */ }
+      if (kind === 'recovery-unreachable') {
+        // Append-only alert log the dashboard reads when Telegram can't be reached.
+        try {
+          let alerts: unknown[] = [];
+          if (fs.existsSync(rlAlertsPath)) {
+            try { alerts = JSON.parse(fs.readFileSync(rlAlertsPath, 'utf-8')) as unknown[]; } catch { alerts = []; }
+            if (!Array.isArray(alerts)) alerts = [];
+          }
+          alerts.push(entry);
+          fs.writeFileSync(rlAlertsPath, JSON.stringify(alerts.slice(-200), null, 2));
+        } catch { /* best-effort */ }
+      }
     };
-    // Route a user-facing notice for the session's topic (Telegram).
-    const rateLimitNotify = async (sessionName: string, text: string): Promise<void> => {
-      const topicId = telegram?.getTopicForSession(sessionName);
-      if (topicId == null) return;
-      const resp = await fetch(`http://localhost:${config.port}/telegram/reply/${topicId}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.authToken}` },
-        body: JSON.stringify({ text }),
-      });
-      if (!resp.ok) throw new Error(`rate-limit notify failed: ${resp.status}`);
-    };
+
+    // Reachability deps (extracted to sentinelWiring.buildRateLimitRecoveryDeps
+    // so the topic / lifeline / audit branching is unit-testable). Topic-bound
+    // sessions get a topic-tagged nudge + topic notice; non-topic-bound sessions
+    // (e.g. an interactive dev window) get a trusted internal nudge + a lifeline
+    // notice; if no channel is reachable, a recovery-unreachable audit event is
+    // recorded instead of a silent no-op.
+    const { buildRateLimitRecoveryDeps } = await import('../monitoring/sentinelWiring.js');
+    const { resumeFn: rateLimitResume, notifyFn: rateLimitNotify } = buildRateLimitRecoveryDeps({
+      isSessionAlive: (name) => sessionManager.isSessionAlive(name),
+      injectTopicNudge: (name, topicId, text) =>
+        sessionManager.injectMessage(name, `[telegram:${topicId}] ${text}`),
+      injectInternalNudge: (name, text) =>
+        sessionManager.injectInternalMessage(name, text, 'sentinel-recovery'),
+      getTopicForSession: (name) => telegram?.getTopicForSession(name),
+      getLifelineTopicId: () => telegram?.getLifelineTopicId?.(),
+      deliverNotice: async (topicId, text) => {
+        const resp = await fetch(`http://localhost:${config.port}/telegram/reply/${topicId}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.authToken}` },
+          body: JSON.stringify({ text }),
+        });
+        return resp.ok;
+      },
+      recordRecovery,
+    });
     const rlsCfg = config.monitoring?.rateLimitSentinel ?? { enabled: true };
     const rateLimitSentinel = new RateLimitSentinel(
       {

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -2154,6 +2154,39 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Internal-only injection for trusted in-process recovery agents (the
+   * sentinels). Bypasses InputGuard's topic-prefix provenance requirement so a
+   * recovery nudge can reach a session that is NOT bound to any Telegram topic
+   * (e.g. a developer's interactive Claude Code window). Without this path, the
+   * rate-limit / socket-disconnect / silence sentinels silently no-op for
+   * non-topic-bound sessions — the exact bug behind "the throttle never
+   * recovered in my dev window."
+   *
+   * SECURITY BOUNDARY: this method is NOT exposed over HTTP. The only callers
+   * are in-process sentinel recovery deps wired in server.ts. HTTP injection
+   * continues to flow through injectMessage(), which enforces topic prefixing.
+   * Every internal injection is recorded with source 'sentinel-recovery' so the
+   * audit log can distinguish trusted recovery nudges from user/topic traffic.
+   *
+   * @param source - audit label for the trusted caller (e.g. 'sentinel-recovery')
+   */
+  injectInternalMessage(tmuxSession: string, text: string, source = 'sentinel-recovery'): boolean {
+    if (!this.isSessionAlive(tmuxSession)) return false;
+    if (this.inputGuard) {
+      // Record the trusted bypass so it's distinguishable in the security log.
+      try {
+        this.inputGuard.logSecurityEvent({
+          event: 'internal-recovery-injection',
+          session: tmuxSession,
+          source,
+          messagePreview: text.slice(0, 100),
+        });
+      } catch { /* logging must never block a recovery nudge */ }
+    }
+    return this.rawInject(tmuxSession, text);
+  }
+
+  /**
    * Raw tmux send-keys injection. No validation — just sends text to the session.
    * Used by injectMessage after provenance checks pass.
    */

--- a/src/monitoring/sentinelWiring.ts
+++ b/src/monitoring/sentinelWiring.ts
@@ -212,6 +212,119 @@ export function buildActiveWorkSilenceDeps(opts: {
   };
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// RateLimitSentinel recovery deps — reachability under ALL session conditions.
+//
+// The original resume/notify closures in server.ts silently no-opped whenever
+// getTopicForSession returned null — which is exactly the case for a developer's
+// interactive Claude Code window (not bound to any Telegram topic). Detection +
+// backoff ran, then every output dropped on the floor, so the throttle never
+// recovered and nothing reached the user. Extracted here so the reachability
+// logic is unit-testable (it was previously inline + untestable, which is why
+// the bug shipped past green tests). Spec: Sentinel Reachability + Worktree
+// Isolation.
+// ───────────────────────────────────────────────────────────────────────────
+
+export type RecoveryReachKind = 'recovery-reached' | 'recovery-unreachable';
+
+/** The neutral "continue" nudge — NOT a compaction-resume payload (which would
+ *  falsely tell the agent its memory was reset). */
+export const RATE_LIMIT_RESUME_NUDGE =
+  'The temporary server throttle should have cleared — please continue where you left off.';
+
+export interface RateLimitRecoverySurface {
+  isSessionAlive(sessionName: string): boolean;
+  /** Topic-tagged nudge through the provenance-checked injectMessage path. */
+  injectTopicNudge(sessionName: string, topicId: number, text: string): boolean;
+  /** Trusted internal nudge that bypasses the topic-prefix requirement. */
+  injectInternalNudge(sessionName: string, text: string): boolean;
+  getTopicForSession(sessionName: string): number | null | undefined;
+  /** The always-available system topic; null during initial setup. */
+  getLifelineTopicId(): number | null | undefined;
+  /** Deliver a user-facing notice to a topic. Returns success; never throws. */
+  deliverNotice(topicId: number, text: string): Promise<boolean>;
+  /** Audit sink — invoked on EVERY recovery attempt. Never throws. */
+  recordRecovery(
+    kind: RecoveryReachKind,
+    sessionName: string,
+    detail: string,
+    fallbackTried: string[],
+  ): void;
+}
+
+/**
+ * Build the resume/notify functions for RateLimitSentinel. Both paths ALWAYS
+ * record an audit event and never silently return:
+ *  - resumeFn: topic-bound → topic-tagged inject; non-topic-bound → internal inject.
+ *  - notifyFn: session topic → lifeline topic → recovery-unreachable audit.
+ */
+export function buildRateLimitRecoveryDeps(s: RateLimitRecoverySurface): {
+  resumeFn: (sessionName: string) => Promise<boolean>;
+  notifyFn: (sessionName: string, text: string) => Promise<void>;
+} {
+  return {
+    resumeFn: async (sessionName) => {
+      if (!s.isSessionAlive(sessionName)) return false;
+      const topicId = s.getTopicForSession(sessionName);
+      if (topicId != null) {
+        const ok = s.injectTopicNudge(sessionName, topicId, RATE_LIMIT_RESUME_NUDGE);
+        s.recordRecovery(
+          ok ? 'recovery-reached' : 'recovery-unreachable',
+          sessionName,
+          ok ? 'resume nudge injected via topic' : 'topic injectMessage returned false',
+          ['topic'],
+        );
+        return ok;
+      }
+      // Non-topic-bound (e.g. interactive dev window): internal injection path.
+      const ok = s.injectInternalNudge(sessionName, RATE_LIMIT_RESUME_NUDGE);
+      s.recordRecovery(
+        ok ? 'recovery-reached' : 'recovery-unreachable',
+        sessionName,
+        ok
+          ? 'resume nudge injected via internal path (session not topic-bound)'
+          : 'internal injection returned false',
+        ['internal-injection'],
+      );
+      return ok;
+    },
+    notifyFn: async (sessionName, text) => {
+      const topicId = s.getTopicForSession(sessionName);
+      if (topicId != null) {
+        const ok = await s.deliverNotice(topicId, text).catch(() => false);
+        s.recordRecovery(
+          ok ? 'recovery-reached' : 'recovery-unreachable',
+          sessionName,
+          ok ? 'notice delivered to session topic' : 'topic delivery failed',
+          ['topic'],
+        );
+        return;
+      }
+      // No topic for this session — fall back to the lifeline (system) topic.
+      const lifelineId = s.getLifelineTopicId();
+      if (lifelineId != null) {
+        const ok = await s.deliverNotice(lifelineId, text).catch(() => false);
+        s.recordRecovery(
+          ok ? 'recovery-reached' : 'recovery-unreachable',
+          sessionName,
+          ok
+            ? 'notice delivered to lifeline topic (session not topic-bound)'
+            : 'lifeline delivery failed',
+          ['topic', 'lifeline'],
+        );
+        return;
+      }
+      // Neither a session topic nor a lifeline topic is available. Never silent.
+      s.recordRecovery(
+        'recovery-unreachable',
+        sessionName,
+        `no topic and no lifeline; notice not delivered: ${text.slice(0, 120)}`,
+        ['topic', 'lifeline', 'audit'],
+      );
+    },
+  };
+}
+
 /** FNV-1a — enough to detect that captured output changed. Not security-sensitive. */
 function cheapHash(s: string): string {
   let h = 0x811c9dc5;

--- a/tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts
+++ b/tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Integration — the REAL RateLimitSentinel driven through the REAL recovery
+ * factory (buildRateLimitRecoveryDeps), for a NON-topic-bound session.
+ *
+ * This is the CI-permanent form of the live tmux reproduction. The unit tests
+ * cover the factory branching in isolation; this proves the sentinel's actual
+ * lifecycle (detect → backoff → resume → verify → recovered) drives those deps
+ * and reaches the lifeline for a session with no topic — the exact path that
+ * silently no-opped in v1.2.33 and left Justin's dev window stuck on a throttle.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { RateLimitSentinel } from '../../src/monitoring/RateLimitSentinel.js';
+import { buildRateLimitRecoveryDeps } from '../../src/monitoring/sentinelWiring.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let sentinel: RateLimitSentinel | undefined;
+let tmp: string | undefined;
+afterEach(() => {
+  sentinel?.stop();
+  sentinel = undefined;
+  if (tmp) SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts' });
+  tmp = undefined;
+});
+
+function harness(opts: { topic: number | null; lifeline: number | null }) {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rl-recov-'));
+  const jsonlRoot = path.join(tmp, 'jsonl');
+  fs.mkdirSync(jsonlRoot, { recursive: true });
+  const jsonlFile = path.join(jsonlRoot, 'sess.jsonl');
+  fs.writeFileSync(jsonlFile, 'x'.repeat(100));
+
+  const notices: Array<{ topicId: number; text: string }> = [];
+  const internalNudges: string[] = [];
+  const recorded: Array<{ kind: string; detail: string }> = [];
+
+  const deps = buildRateLimitRecoveryDeps({
+    isSessionAlive: () => true,
+    injectTopicNudge: () => true,
+    injectInternalNudge: (_n, text) => { internalNudges.push(text); return true; },
+    getTopicForSession: () => opts.topic,
+    getLifelineTopicId: () => opts.lifeline,
+    deliverNotice: async (topicId, text) => { notices.push({ topicId, text }); return true; },
+    recordRecovery: (kind, _n, detail) => { recorded.push({ kind, detail }); },
+  });
+
+  sentinel = new RateLimitSentinel(
+    { resumeFn: deps.resumeFn, notifyFn: deps.notifyFn, projectDir: tmp, jsonlRoot, getClaudeSessionId: () => 'sess' },
+    { enabled: true, backoffScheduleMs: [120], verifyWindowMs: 400 },
+  );
+  return { jsonlFile, notices, internalNudges, recorded };
+}
+
+describe('RateLimitSentinel × recovery factory — non-topic-bound lifecycle', () => {
+  it('recovers a non-topic-bound session: internal nudge + lifeline notice + recovered', async () => {
+    const h = harness({ topic: null, lifeline: 4242 });
+
+    sentinel!.report('dev-window', 'idle-error');
+    // Simulate Claude processing the nudge (jsonl grows) during the verify window.
+    setTimeout(() => fs.appendFileSync(h.jsonlFile, 'y'.repeat(500)), 200);
+    await delay(900);
+
+    // The notice reached the lifeline (before the fix: nothing).
+    expect(h.notices.some((n) => n.topicId === 4242)).toBe(true);
+    // The resume nudge went through the internal (non-topic) injection path.
+    expect(h.internalNudges.length).toBeGreaterThanOrEqual(1);
+    // Everything recorded as reached; nothing unreachable.
+    expect(h.recorded.some((r) => r.kind === 'recovery-reached')).toBe(true);
+    expect(h.recorded.some((r) => r.kind === 'recovery-unreachable')).toBe(false);
+    // Lifecycle completed.
+    expect(sentinel!.isRecoveryActive('dev-window')).toBe(false);
+  });
+
+  it('no topic AND no lifeline → records recovery-unreachable, never silent', async () => {
+    const h = harness({ topic: null, lifeline: null });
+
+    sentinel!.report('orphan', 'idle-error');
+    await delay(400);
+
+    expect(h.notices).toHaveLength(0);
+    expect(h.recorded.some((r) => r.kind === 'recovery-unreachable')).toBe(true);
+  });
+});

--- a/tests/unit/rate-limit-recovery-reachability.test.ts
+++ b/tests/unit/rate-limit-recovery-reachability.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Reachability tests for RateLimitSentinel recovery deps.
+ *
+ * THE BUG THIS GUARDS: rate-limit recovery (resumeFn + notifyFn) used to call
+ * `getTopicForSession(name)` and silently `return` when it was null. A
+ * developer's interactive Claude Code window is NOT bound to any Telegram topic,
+ * so both recovery paths no-opped — detection + backoff ran, then every output
+ * dropped on the floor. From the user's seat it looked exactly as if no sentinel
+ * existed. v1.2.33 shipped past green tests because the only fixtures were
+ * topic-bound; the non-topic-bound path was never asserted.
+ *
+ * These tests assert the recovery actually REACHES a destination under every
+ * session condition: topic-bound, non-topic-bound (→ lifeline / internal inject),
+ * and fully unreachable (→ a loud recovery-unreachable audit event, never silent).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  buildRateLimitRecoveryDeps,
+  RATE_LIMIT_RESUME_NUDGE,
+  type RateLimitRecoverySurface,
+  type RecoveryReachKind,
+} from '../../src/monitoring/sentinelWiring.js';
+
+interface Recorded {
+  kind: RecoveryReachKind;
+  sessionName: string;
+  detail: string;
+  fallbackTried: string[];
+}
+
+/** A configurable fake surface that records every interaction. */
+function makeSurface(overrides: Partial<RateLimitRecoverySurface> = {}) {
+  const calls = {
+    topicNudges: [] as Array<{ name: string; topicId: number; text: string }>,
+    internalNudges: [] as Array<{ name: string; text: string }>,
+    delivered: [] as Array<{ topicId: number; text: string }>,
+    recorded: [] as Recorded[],
+  };
+  const surface: RateLimitRecoverySurface = {
+    isSessionAlive: () => true,
+    injectTopicNudge: (name, topicId, text) => {
+      calls.topicNudges.push({ name, topicId, text });
+      return true;
+    },
+    injectInternalNudge: (name, text) => {
+      calls.internalNudges.push({ name, text });
+      return true;
+    },
+    getTopicForSession: () => null,
+    getLifelineTopicId: () => null,
+    deliverNotice: async (topicId, text) => {
+      calls.delivered.push({ topicId, text });
+      return true;
+    },
+    recordRecovery: (kind, sessionName, detail, fallbackTried) => {
+      calls.recorded.push({ kind, sessionName, detail, fallbackTried });
+    },
+    ...overrides,
+  };
+  return { surface, calls };
+}
+
+describe('buildRateLimitRecoveryDeps — notifyFn reachability', () => {
+  it('topic-bound session → delivers the notice to the session topic', async () => {
+    const { surface, calls } = makeSurface({ getTopicForSession: () => 42 });
+    const { notifyFn } = buildRateLimitRecoveryDeps(surface);
+
+    await notifyFn('sess-a', 'throttled, backing off');
+
+    expect(calls.delivered).toEqual([{ topicId: 42, text: 'throttled, backing off' }]);
+    expect(calls.recorded[0].kind).toBe('recovery-reached');
+    expect(calls.recorded[0].fallbackTried).toEqual(['topic']);
+  });
+
+  it('NON-topic-bound session → falls back to the lifeline topic (the core bug)', async () => {
+    const { surface, calls } = makeSurface({
+      getTopicForSession: () => null, // interactive dev window — no topic
+      getLifelineTopicId: () => 7,
+    });
+    const { notifyFn } = buildRateLimitRecoveryDeps(surface);
+
+    await notifyFn('echo-dev', 'throttled, backing off, you are not dropped');
+
+    // Regression: before the fix this delivered NOTHING. Now it reaches lifeline.
+    expect(calls.delivered).toEqual([{ topicId: 7, text: 'throttled, backing off, you are not dropped' }]);
+    expect(calls.recorded[0].kind).toBe('recovery-reached');
+    expect(calls.recorded[0].fallbackTried).toEqual(['topic', 'lifeline']);
+  });
+
+  it('no topic AND no lifeline → records recovery-unreachable, never silent', async () => {
+    const { surface, calls } = makeSurface({
+      getTopicForSession: () => null,
+      getLifelineTopicId: () => null,
+    });
+    const { notifyFn } = buildRateLimitRecoveryDeps(surface);
+
+    await notifyFn('orphan-sess', 'the throttle notice');
+
+    expect(calls.delivered).toHaveLength(0);
+    expect(calls.recorded).toHaveLength(1);
+    expect(calls.recorded[0].kind).toBe('recovery-unreachable');
+    expect(calls.recorded[0].fallbackTried).toContain('audit');
+    expect(calls.recorded[0].detail).toContain('the throttle notice');
+  });
+
+  it('lifeline delivery failure → recovery-unreachable (no throw, no silent success)', async () => {
+    const { surface, calls } = makeSurface({
+      getTopicForSession: () => null,
+      getLifelineTopicId: () => 7,
+      deliverNotice: async () => false, // Telegram down
+    });
+    const { notifyFn } = buildRateLimitRecoveryDeps(surface);
+
+    await expect(notifyFn('sess', 'notice')).resolves.toBeUndefined();
+    expect(calls.recorded[0].kind).toBe('recovery-unreachable');
+  });
+
+  it('deliverNotice that throws is swallowed and recorded as unreachable', async () => {
+    const { surface, calls } = makeSurface({
+      getTopicForSession: () => 9,
+      deliverNotice: async () => {
+        throw new Error('network down');
+      },
+    });
+    const { notifyFn } = buildRateLimitRecoveryDeps(surface);
+
+    await expect(notifyFn('sess', 'notice')).resolves.toBeUndefined();
+    expect(calls.recorded[0].kind).toBe('recovery-unreachable');
+  });
+});
+
+describe('buildRateLimitRecoveryDeps — resumeFn reachability', () => {
+  it('topic-bound session → topic-tagged nudge', async () => {
+    const { surface, calls } = makeSurface({ getTopicForSession: () => 42 });
+    const { resumeFn } = buildRateLimitRecoveryDeps(surface);
+
+    const ok = await resumeFn('sess-a');
+
+    expect(ok).toBe(true);
+    expect(calls.topicNudges).toEqual([{ name: 'sess-a', topicId: 42, text: RATE_LIMIT_RESUME_NUDGE }]);
+    expect(calls.internalNudges).toHaveLength(0);
+    expect(calls.recorded[0].kind).toBe('recovery-reached');
+  });
+
+  it('NON-topic-bound session → internal injection nudge, returns true (the core bug)', async () => {
+    const { surface, calls } = makeSurface({ getTopicForSession: () => null });
+    const { resumeFn } = buildRateLimitRecoveryDeps(surface);
+
+    const ok = await resumeFn('echo-dev');
+
+    // Regression: before the fix this returned false WITHOUT injecting anything,
+    // so the sentinel escalated as "resumeFn declined" and the session never woke.
+    expect(ok).toBe(true);
+    expect(calls.internalNudges).toEqual([{ name: 'echo-dev', text: RATE_LIMIT_RESUME_NUDGE }]);
+    expect(calls.topicNudges).toHaveLength(0);
+    expect(calls.recorded[0].kind).toBe('recovery-reached');
+    expect(calls.recorded[0].fallbackTried).toEqual(['internal-injection']);
+  });
+
+  it('dead session → returns false (no nudge, no record)', async () => {
+    const { surface, calls } = makeSurface({ isSessionAlive: () => false });
+    const { resumeFn } = buildRateLimitRecoveryDeps(surface);
+
+    expect(await resumeFn('dead')).toBe(false);
+    expect(calls.topicNudges).toHaveLength(0);
+    expect(calls.internalNudges).toHaveLength(0);
+  });
+
+  it('internal injection that fails → recovery-unreachable', async () => {
+    const { surface, calls } = makeSurface({
+      getTopicForSession: () => null,
+      injectInternalNudge: () => false,
+    });
+    const { resumeFn } = buildRateLimitRecoveryDeps(surface);
+
+    expect(await resumeFn('sess')).toBe(false);
+    expect(calls.recorded[0].kind).toBe('recovery-unreachable');
+  });
+});

--- a/tests/unit/rate-limit-recovery-wiring.test.ts
+++ b/tests/unit/rate-limit-recovery-wiring.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Wiring-integrity + security-boundary guards for the rate-limit recovery fix.
+ *
+ * T5 (wiring integrity): server.ts must build the recovery deps from the REAL
+ *   primitives (injectInternalMessage, getLifelineTopicId), not no-ops. A feature
+ *   that compiles but is wired to nulls is the exact "shipped inert" failure mode
+ *   we keep hitting — this asserts the live wiring delegates to real functions.
+ *
+ * T7 (InputGuard boundary): injectInternalMessage bypasses the topic-prefix
+ *   provenance check, so it MUST NOT be reachable over HTTP. This asserts the
+ *   method exists on SessionManager but is never exposed through a route.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERVER_SRC = fs.readFileSync(path.join(process.cwd(), 'src/commands/server.ts'), 'utf-8');
+const SESSION_MANAGER_SRC = fs.readFileSync(path.join(process.cwd(), 'src/core/SessionManager.ts'), 'utf-8');
+const ROUTES_SRC = fs.readFileSync(path.join(process.cwd(), 'src/server/routes.ts'), 'utf-8');
+
+describe('T5 — rate-limit recovery wiring integrity', () => {
+  it('server.ts builds recovery deps via buildRateLimitRecoveryDeps', () => {
+    expect(SERVER_SRC).toContain('buildRateLimitRecoveryDeps');
+  });
+
+  it('wires the REAL non-topic-bound primitives (not no-ops)', () => {
+    // The whole bug was the non-topic path doing nothing. These two callbacks
+    // are what makes the non-topic path actually reach the user.
+    expect(SERVER_SRC).toContain('injectInternalMessage');
+    expect(SERVER_SRC).toContain('getLifelineTopicId');
+  });
+
+  it('the built resumeFn/notifyFn are handed to the RateLimitSentinel', () => {
+    // Guards against building the deps then forgetting to pass them in.
+    expect(SERVER_SRC).toMatch(/resumeFn:\s*rateLimitResume/);
+    expect(SERVER_SRC).toMatch(/notifyFn:\s*rateLimitNotify/);
+  });
+});
+
+describe('T7 — injectInternalMessage security boundary', () => {
+  it('SessionManager exposes injectInternalMessage', () => {
+    expect(SESSION_MANAGER_SRC).toContain('injectInternalMessage(');
+  });
+
+  it('injectInternalMessage is NOT reachable over any HTTP route', () => {
+    // The internal path bypasses InputGuard topic prefixing — it must stay
+    // in-process only. HTTP injection continues to flow through injectMessage,
+    // which enforces provenance.
+    expect(ROUTES_SRC).not.toContain('injectInternalMessage');
+  });
+
+  it('records a distinguishable audit event for the trusted bypass', () => {
+    expect(SESSION_MANAGER_SRC).toContain('internal-recovery-injection');
+    expect(SESSION_MANAGER_SRC).toContain("source = 'sentinel-recovery'");
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,84 @@
+# Upgrade Guide — rate-limit recovery now reaches non-topic-bound sessions
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+**Fix: the rate-limit sentinel now actually recovers a session that isn't bound
+to a Telegram topic.**
+
+When Anthropic's server-side throttle hit ("Server is temporarily limiting
+requests · not your usage limit"), the RateLimitSentinel detected it and ran its
+backoff correctly — but both of its recovery actions started by asking "is this
+session bound to a Telegram topic?" and silently did nothing if the answer was
+no. A developer's interactive Claude Code window isn't bound to a topic, so:
+
+- the "throttled, backing off, you're not dropped" notice went nowhere, and
+- the resume nudge that wakes the session back up went nowhere.
+
+From the outside this was indistinguishable from the sentinel not existing — the
+exact thing observed: a throttle sat on screen for minutes with no recovery and
+no signal. (v1.2.33 shipped past green tests because every test fixture was
+topic-bound; the non-topic-bound path was never exercised.)
+
+This release makes recovery reachable under **all** session conditions:
+
+- **Resume** — topic-bound sessions get the topic-tagged nudge as before;
+  non-topic-bound sessions get a trusted in-process injection
+  (`SessionManager.injectInternalMessage`) that bypasses the topic-prefix
+  requirement. This path is in-process only — never exposed over HTTP.
+- **Notify** — the user notice goes to the session's own topic, else falls back
+  to the always-available lifeline (system) topic, else is written as a loud
+  `recovery-unreachable` audit event. Never a silent drop.
+- **Audit** — every recovery attempt records `recovery-reached` /
+  `recovery-unreachable` to `logs/sentinel-events.jsonl`, and unreachable events
+  also land in `.instar/sentinel-alerts.json` so the dashboard surfaces them even
+  when Telegram can't be reached.
+
+The reachability branching was lifted out of the inline server closures into
+`sentinelWiring.buildRateLimitRecoveryDeps()` so it is unit-testable — closing
+the gap (inline + untestable logic) that let this ship past green tests.
+
+Spec: `Sentinel Reachability + Worktree Isolation` (the worktree-clone and
+socket/silence-default parts already shipped via #334/#340/#351; this is the
+remaining rate-limit recovery piece).
+Side-effects review: `upgrades/side-effects/rate-limit-recovery-reachability.md`.
+
+## What to Tell Your User
+
+If I'm ever hit by one of Anthropic's brief "servers are busy" throttles while
+you're talking to me in a plain window (not a Telegram topic), I'll now actually
+tell you I'm throttled and backing off — and I'll wake myself back up and let you
+know when it clears, instead of going silent until you poke me. Nothing changes
+for the normal Telegram case; this just closes the gap where a throttle in a
+direct dev window left you staring at a frozen screen.
+
+## Summary of New Capabilities
+
+No new user-facing capabilities — this is a behavior fix to existing rate-limit
+recovery. (Internal: `SessionManager.injectInternalMessage` for trusted
+in-process recovery nudges; `buildRateLimitRecoveryDeps` reachability factory.)
+
+## Evidence
+
+**Live reproduction (the bar that was missed last time).** Drove the *real*
+RateLimitSentinel lifecycle through the *real* recovery factory (wired exactly as
+`server.ts` wires it) against a *real* tmux pane that was **not** bound to any
+topic — the exact failure condition. Result: the resume nudge landed in the pane
+via the real internal-injection path, the "throttled, backing off" notice and the
+"back online" check-in both reached the lifeline topic, and the audit log
+recorded `recovery-reached` with zero `recovery-unreachable`. Before the fix all
+of those were silent.
+
+**Regression coverage (CI-permanent):**
+- `tests/unit/rate-limit-recovery-reachability.test.ts` (9) — both sides of every
+  reachability boundary: topic / lifeline / internal-injection / unreachable.
+- `tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts` (2) — the
+  real sentinel lifecycle (detect→backoff→resume→verify→recovered) driving the
+  factory to the lifeline for a non-topic-bound session, plus the
+  never-silent unreachable case.
+- `tests/unit/rate-limit-recovery-wiring.test.ts` (6) — wiring integrity (server
+  wires the real primitives, not no-ops) + the InputGuard HTTP boundary.
+
+`tsc` clean. The pre-existing rate-limit unit/integration/e2e suites stay green.

--- a/upgrades/side-effects/rate-limit-recovery-reachability.md
+++ b/upgrades/side-effects/rate-limit-recovery-reachability.md
@@ -1,0 +1,116 @@
+# Side-Effects Review — RateLimitSentinel recovery reachability
+
+**Version / slug:** `rate-limit-recovery-reachability`
+**Date:** `2026-05-24`
+**Author:** `echo`
+**Second-pass reviewer:** `internal-adversarial` (external /crossreview tooling not wired on this host)
+
+## Summary of the change
+
+The RateLimitSentinel detects Anthropic's server-side throttle correctly and
+schedules its backoff correctly, but its two recovery closures in `server.ts`
+(`rateLimitResume`, `rateLimitNotify`) both began with
+`const topicId = telegram?.getTopicForSession(sessionName); if (topicId == null) return`.
+For a session not bound to any Telegram topic — e.g. a developer's interactive
+Claude Code window — both paths silently no-opped. Detection + backoff ran, then
+the resume nudge and the user notice dropped on the floor. From the user's seat
+this is indistinguishable from no sentinel existing (the v1.2.33 ship that
+"recovered" in tests but never in Justin's real dev window).
+
+This PR makes recovery reachable under **all** session conditions:
+
+- **Resume** — topic-bound sessions get the topic-tagged nudge through the
+  provenance-checked `injectMessage` path (unchanged). Non-topic-bound sessions
+  get a new `SessionManager.injectInternalMessage` path that bypasses the
+  topic-prefix InputGuard requirement (trusted in-process caller, logged with
+  `source: 'sentinel-recovery'`).
+- **Notify** — session topic → lifeline (system) topic → a loud
+  `recovery-unreachable` audit event. Never a silent return.
+- **Audit** — every recovery attempt records `recovery-reached` /
+  `recovery-unreachable` to `logs/sentinel-events.jsonl`; an unreachable event
+  also appends to `.instar/sentinel-alerts.json` (rolling 200) so the dashboard
+  surfaces it even when Telegram is unavailable.
+
+The reachability branching was extracted from the inline closures into
+`sentinelWiring.buildRateLimitRecoveryDeps()` so it is unit-testable — the exact
+gap that let the bug ship past green tests (the logic was inline + untestable).
+
+**Files touched:**
+- `src/core/SessionManager.ts` (+`injectInternalMessage`, internal-only, NOT HTTP-exposed).
+- `src/monitoring/sentinelWiring.ts` (+`buildRateLimitRecoveryDeps`, `RATE_LIMIT_RESUME_NUDGE`, types).
+- `src/commands/server.ts` (rewired the two closures through the factory + a `recordRecovery` audit writer).
+- `tests/unit/rate-limit-recovery-reachability.test.ts` (new, 9 cases — both sides of every reachability boundary).
+- `tests/unit/rate-limit-recovery-wiring.test.ts` (new, 6 cases — T5 wiring integrity + T7 InputGuard boundary).
+- `upgrades/NEXT.md`, `package.json` bump.
+
+## Decision-point inventory
+
+- **Topic vs. non-topic resume path** — *modify*. Pure presence check on
+  `getTopicForSession`; topic path is byte-for-byte the old behavior, non-topic
+  path is the new internal injection. No judgment.
+- **Notify fallback order** — *new*. session-topic → lifeline → audit. Each step
+  is a null check; deterministic, no LLM.
+- **InputGuard bypass (`injectInternalMessage`)** — *new security-relevant path*.
+  Covered in §Security boundary below.
+- **Audit sink** — *new*. Append-only, best-effort, wrapped in try/catch so a
+  logging failure can never break a recovery nudge.
+
+## Over-block / under-block analysis
+
+- **Under-block (the bug):** recovery reaching nothing for non-topic-bound
+  sessions. Closed — every path now terminates in a delivery or a recorded
+  unreachable event.
+- **Over-block:** none introduced. The topic-bound path is unchanged. The new
+  internal injection only fires when there is genuinely no topic, and only from
+  the in-process sentinel.
+
+## Security boundary (InputGuard)
+
+`injectInternalMessage` bypasses the topic-prefix provenance check, so it is a
+trust boundary. Mitigations:
+- It is a method on `SessionManager` only — **not** wired to any HTTP route
+  (asserted by test T7: `routes.ts` must not contain `injectInternalMessage`).
+- All HTTP injection continues through `injectMessage`, which enforces
+  provenance / prefix.
+- Every internal injection logs an `internal-recovery-injection` security event
+  with the `source` label, so the audit log distinguishes trusted recovery
+  nudges from user/topic traffic.
+
+## Signal vs. authority
+
+No new blocking authority. The sentinel is a bounded recovery primitive; the new
+code only adds *delivery channels* and an *audit trail*. Nothing gates user
+actions or other sessions.
+
+## Interactions
+
+- **CompactionSentinel / other sentinels** — unchanged. The zombie-veto
+  composition and bidirectional defer logic are untouched.
+- **SentinelNotifier (socket/silence trio)** — untouched. Their default-off
+  `sentinelTelegramEscalation` is deliberately preserved (the post-2026-05-22
+  anti-flood design). This PR does **not** flip that default — the original
+  spec's Part A3 is intentionally dropped as superseded.
+- **InputGuard** — only adds a new logged event type; existing provenance flow
+  is unchanged.
+
+## Migration parity
+
+No agent-installed files change. This is server-side binary code
+(`SessionManager`, `sentinelWiring`, `server.ts`) shipped via npm update — every
+existing agent picks it up automatically on update with no migration entry. No
+new config default (the RateLimitSentinel is already default-on), no hook, no
+skill, no CLAUDE.md template capability. (Worktree clone-isolation and the
+socket/silence default already shipped separately via #334/#340/#351 and are out
+of scope here.)
+
+## Rollback
+
+Single, independent, trivially reversible: `git revert` restores the two inline
+closures (reintroducing the silent no-op). The new `injectInternalMessage` and
+factory become dead code on revert; no state migration to undo.
+
+## Out of scope
+
+- Flipping `sentinelTelegramEscalation` to default-on (superseded by anti-flood).
+- Socket-disconnect / active-silence sentinel reachability (default-off by design).
+- Worktree clone isolation (already shipped via #334).


### PR DESCRIPTION
## Problem

`RateLimitSentinel` detects Anthropic's server-side throttle and runs its backoff correctly, but both recovery closures in `server.ts` began with:

```js
const topicId = telegram?.getTopicForSession(sessionName);
if (topicId == null) return;   // ← silent no-op
```

A developer's interactive Claude Code window is **not** bound to any Telegram topic, so for that session the resume nudge and the user notice both silently dropped on the floor — detection + backoff ran, then nothing reached the user. From the outside, indistinguishable from no sentinel existing. v1.2.33 shipped past green tests because every fixture was topic-bound (and the logic was inline + untestable).

This is the production bug the operator hit directly: a throttle sat on screen for minutes with no recovery and no signal.

## Fix — recovery reachable under all conditions, never a silent return

- **resumeFn**: topic-bound → topic-tagged `injectMessage`; non-topic-bound → new `SessionManager.injectInternalMessage` (trusted in-process path, bypasses the topic-prefix InputGuard, **in-process only — never HTTP-exposed**, logged `source=sentinel-recovery`).
- **notifyFn**: session topic → lifeline (system) topic → a loud `recovery-unreachable` audit event.
- **Audit**: every attempt records `recovery-reached`/`recovery-unreachable` to `logs/sentinel-events.jsonl`; unreachable also to `.instar/sentinel-alerts.json` for the dashboard.
- Reachability branching extracted to `sentinelWiring.buildRateLimitRecoveryDeps()` — closing the inline+untestable gap that let the bug ship.

## Evidence (the bar that was missed last time)

**Live reproduction**: drove the real `RateLimitSentinel` lifecycle through the real factory (wired exactly as `server.ts` wires it) against a **real tmux pane not bound to any topic**. The resume nudge landed in the pane, the "throttled, backing off" notice and the "back online" check-in both reached the lifeline topic, and the audit recorded `recovery-reached` with zero `recovery-unreachable`. Before the fix all of those were silent.

**Regression coverage (17 new tests):**
- `tests/unit/rate-limit-recovery-reachability.test.ts` (9) — both sides of every reachability boundary.
- `tests/integration/rate-limit-recovery-sentinel-lifecycle.test.ts` (2) — real sentinel lifecycle driving the factory to the lifeline for a non-topic-bound session + the never-silent unreachable case.
- `tests/unit/rate-limit-recovery-wiring.test.ts` (6) — wiring integrity (real primitives, not no-ops) + InputGuard HTTP boundary.

Local smoke tier: 471/471 green. `tsc` + lint clean.

## Scope

Rate-limit recovery only. Worktree clone-isolation (#334) and socket/silence default-off (#351) already shipped; the original spec's `sentinelTelegramEscalation` default-flip (A3) is intentionally **dropped** as superseded by the anti-flood design.

Spec: `docs/specs/sentinel-reachability.md` · ELI16: `docs/specs/sentinel-reachability.eli16.md` · Side-effects: `upgrades/side-effects/rate-limit-recovery-reachability.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)