### PR TITLE
feat(cli): instar spec conformance — run the standards-conformance gate from the CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -486,6 +486,23 @@ worktreeCmd
     }
   });
 
+// ── Spec review (standards-conformance gate) ─────────────────────
+
+const specCmd = program
+  .command('spec')
+  .description('Spec-authoring tools (the standards-conformance gate).');
+
+specCmd
+  .command('conformance <path>')
+  .description('Check a draft spec against the living constitution and print a rule-by-rule report (signal only — never blocks).')
+  .option('-d, --dir <path>', 'Project directory')
+  .option('--port <port>', 'Server port (defaults to config.port, else 4040)', (v: string) => parseInt(v, 10))
+  .option('--json', 'Emit the raw JSON report instead of formatted output')
+  .action(async (specPath: string, opts: { dir?: string; port?: number; json?: boolean }) => {
+    const { runSpecConformance } = await import('./commands/spec.js');
+    await runSpecConformance({ specPath, dir: opts.dir, port: opts.port, json: opts.json });
+  });
+
 // ── Backup ───────────────────────────────────────────────────────
 
 const backupCmd = program

--- a/src/commands/spec.ts
+++ b/src/commands/spec.ts
@@ -1,0 +1,105 @@
+/**
+ * `instar spec conformance <path>` — run the standards-conformance gate against
+ * a draft spec from the command line.
+ *
+ * Thin client over the local server's POST /spec/conformance-check: the server
+ * already has the subscription-backed intelligence provider wired, so the CLI
+ * just reads the spec, posts it, and prints the rule-by-rule report. Signal-only
+ * — it advises; it never blocks. Spec: docs/specs/standards-conformance-gate.md
+ * (tracked deferral `scg-cli`).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import pc from 'picocolors';
+
+export interface SpecConformanceOptions {
+  /** Path to the spec markdown file. */
+  specPath: string;
+  /** Project dir (for loadConfig). */
+  dir?: string;
+  /** Server port override. */
+  port?: number;
+  /** Emit raw JSON instead of the formatted report. */
+  json?: boolean;
+}
+
+interface ConformanceFinding { standard: string; family: string; status: string; reason: string }
+interface ConformanceResponse {
+  report: { findings: ConformanceFinding[]; standardsChecked: number; degraded: boolean; degradeReason?: string };
+  registryCanary: { ok: boolean; articleCount: number; failures: string[] };
+}
+
+export async function runSpecConformance(opts: SpecConformanceOptions): Promise<void> {
+  const abs = path.resolve(opts.specPath);
+  if (!fs.existsSync(abs)) {
+    console.error(pc.red(`Spec not found: ${abs}`));
+    process.exit(1);
+  }
+  const markdown = fs.readFileSync(abs, 'utf-8');
+
+  // Resolve port + auth from config (falls back to a sane default).
+  let port = opts.port ?? 4040;
+  let authToken: string | undefined;
+  try {
+    const { loadConfig } = await import('../core/Config.js');
+    const config = loadConfig(opts.dir);
+    if (!opts.port && typeof config.port === 'number') port = config.port;
+    authToken = config.authToken;
+  } catch { /* project may not be initialized — proceed with defaults */ }
+
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+
+  let resp: Response;
+  try {
+    resp = await fetch(`http://localhost:${port}/spec/conformance-check`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ markdown }),
+      signal: AbortSignal.timeout(60_000),
+    });
+  } catch (err) {
+    console.error(pc.red(`Could not reach the instar server on port ${port}: ${(err as Error).message}`));
+    console.error('Is the server running? Try: instar server start');
+    process.exit(1);
+  }
+
+  if (!resp.ok) {
+    if (resp.status === 503) {
+      console.error(pc.yellow('The standards-conformance gate is disabled or the constitution is unreadable on this host.'));
+    } else {
+      console.error(pc.red(`Conformance check failed: ${resp.status} ${resp.statusText}`));
+    }
+    process.exit(1);
+  }
+
+  const data = await resp.json() as ConformanceResponse;
+
+  if (opts.json) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  // Formatted report.
+  const { report, registryCanary } = data;
+  console.log(pc.bold(`\nStandards conformance — ${path.basename(abs)}`));
+  console.log(pc.dim(`Checked against ${report.standardsChecked} standards · registry canary: ${registryCanary.ok ? pc.green('ok') : pc.red('FAILED')}`));
+  if (!registryCanary.ok) {
+    console.log(pc.red(`  ⚠ registry canary failures: ${registryCanary.failures.join('; ')}`));
+  }
+  if (report.degraded) {
+    console.log(pc.yellow(`\n  (report degraded: ${report.degradeReason ?? 'unknown'} — no findings produced; this is advisory, not authoritative)`));
+    return;
+  }
+  if (report.findings.length === 0) {
+    console.log(pc.green('\n  ✓ No possible standard-violations flagged.'));
+    return;
+  }
+  console.log(pc.bold(`\n  ${report.findings.length} possible violation(s) flagged (signal — you decide):\n`));
+  for (const f of report.findings) {
+    console.log(`  ${pc.yellow('•')} ${pc.bold(f.standard)} ${pc.dim(`[${f.family}]`)}`);
+    console.log(`    ${f.reason}`);
+  }
+  console.log('');
+}

--- a/tests/unit/spec-conformance-cli.test.ts
+++ b/tests/unit/spec-conformance-cli.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit test for `instar spec conformance` (scg-cli) — the thin client over
+ * POST /spec/conformance-check. Verifies it reads the spec, posts the markdown,
+ * and renders the report; fetch is stubbed (no live server).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { runSpecConformance } from '../../src/commands/spec.js';
+
+let tempDir: string;
+let specFile: string;
+let logs: string[];
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scg-cli-'));
+  specFile = path.join(tempDir, 'draft.md');
+  fs.writeFileSync(specFile, '# Draft\nThe user must remember to run sync.');
+  logs = [];
+  vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => { logs.push(a.join(' ')); });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  try { SafeFsExecutor.safeRmSync(tempDir, { recursive: true, force: true, operation: 'tests/unit/spec-conformance-cli.test.ts' }); } catch { /* best */ }
+});
+
+function stubFetch(body: unknown, ok = true, status = 200) {
+  const captured: { url?: string; init?: RequestInit } = {};
+  vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+    captured.url = url; captured.init = init;
+    return { ok, status, statusText: 'OK', json: async () => body } as unknown as Response;
+  });
+  return captured;
+}
+
+describe('runSpecConformance (CLI)', () => {
+  it('posts the spec markdown to /spec/conformance-check and prints flagged findings', async () => {
+    const captured = stubFetch({
+      report: {
+        findings: [{ standard: 'No Manual Work (user *or* agent)', family: 'Interaction', status: 'possible-violation', reason: 'requires the user to remember to run sync' }],
+        standardsChecked: 21, degraded: false,
+      },
+      registryCanary: { ok: true, articleCount: 22, failures: [] },
+    });
+
+    await runSpecConformance({ specPath: specFile, dir: tempDir });
+
+    expect(captured.url).toContain('/spec/conformance-check');
+    expect(JSON.parse(String(captured.init!.body))).toMatchObject({ markdown: expect.stringContaining('must remember to run sync') });
+    const out = logs.join('\n');
+    expect(out).toContain('No Manual Work');
+    expect(out).toMatch(/1 possible violation/);
+  });
+
+  it('prints a clean pass when no findings', async () => {
+    stubFetch({
+      report: { findings: [], standardsChecked: 21, degraded: false },
+      registryCanary: { ok: true, articleCount: 22, failures: [] },
+    });
+    await runSpecConformance({ specPath: specFile, dir: tempDir });
+    expect(logs.join('\n')).toMatch(/No possible standard-violations/);
+  });
+
+  it('surfaces a degraded report as advisory, not authoritative', async () => {
+    stubFetch({
+      report: { findings: [], standardsChecked: 21, degraded: true, degradeReason: 'no-intelligence' },
+      registryCanary: { ok: true, articleCount: 22, failures: [] },
+    });
+    await runSpecConformance({ specPath: specFile, dir: tempDir });
+    expect(logs.join('\n')).toMatch(/degraded.*no-intelligence/);
+  });
+
+  it('--json emits the raw response', async () => {
+    stubFetch({
+      report: { findings: [], standardsChecked: 21, degraded: false },
+      registryCanary: { ok: true, articleCount: 22, failures: [] },
+    });
+    await runSpecConformance({ specPath: specFile, dir: tempDir, json: true });
+    const out = logs.join('\n');
+    expect(out).toContain('"standardsChecked": 21');
+  });
+
+  it('exits non-zero when the spec file is missing', async () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((): never => { throw new Error('exit'); }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(runSpecConformance({ specPath: path.join(tempDir, 'nope.md'), dir: tempDir })).rejects.toThrow('exit');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,49 @@
+# Upgrade Guide — `instar spec conformance` CLI
+
+<!-- bump: minor -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+
+## What Changed
+
+**You can now run the standards-conformance gate from the command line.**
+
+The conformance gate (shipped in v1.2.69) checks a draft spec against the living
+constitution and reports possible standard-violations — but until now you had to
+call its HTTP route directly. This adds the tracked `scg-cli` follow-up: a
+command-line entry point.
+
+`instar spec conformance <path>` reads a spec file, sends it to the local server's
+conformance route, and prints a rule-by-rule report — "this part might break
+No-Manual-Work, here's why." It's a thin client over the existing route, so the
+subscription-backed model stays server-side (the CLI never touches a raw API). It
+**advises only** — it prints possible violations, never a pass/fail that blocks
+anything. `--json` emits the raw report; `--port`/`--dir` override the defaults.
+
+If the server isn't running it says so clearly and exits non-zero, rather than
+hanging or crashing.
+
+**Evidence**: 5 unit tests (posts the spec markdown to the route, renders flagged
+findings, clean-pass, degraded-as-advisory, `--json`, missing-file exit). `tsc` +
+lint clean.
+
+Spec: `docs/specs/standards-conformance-gate.md` (the `scg-cli` tracked deferral,
+now shipped). Side-effects: `upgrades/side-effects/scg-cli.md`.
+
+## What to Tell Your User
+
+- **Check a spec from the terminal**: "Run `instar spec conformance <path>` and I'll
+  check that spec against our standards and point out anything that might break a
+  rule — it's advice, not a gate."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Conformance check from the CLI | `instar spec conformance <path> [--json] [--port N] [--dir P]` |
+
+## Evidence
+
+Not a bug fix — a CLI wrapper over the existing conformance route. Verified by 5
+unit tests that stub the server and assert the command posts the spec markdown and
+renders the report (findings, clean-pass, degraded-advisory, JSON, missing-file
+exit). `tsc` + lint clean.

--- a/upgrades/side-effects/scg-cli.md
+++ b/upgrades/side-effects/scg-cli.md
@@ -1,0 +1,48 @@
+# Side-effects review — `instar spec conformance` CLI (scg-cli)
+
+**Scope**: Ship the tracked `scg-cli` deferral from the standards-conformance-gate
+spec (`docs/specs/standards-conformance-gate.md`, approved/merged in #373): a
+command-line entry point to the conformance gate, so a spec can be checked
+against the constitution without curl. Thin client over the existing
+`POST /spec/conformance-check` route.
+
+**Files touched**:
+- `src/commands/spec.ts` — NEW. `runSpecConformance({specPath,dir,port,json})`:
+  reads the spec file, resolves port + authToken from `loadConfig`, POSTs
+  `{markdown}` to the local server's conformance route, prints a formatted
+  rule-by-rule report (or `--json`). Server-down / 503 / missing-file are clear
+  errors with non-zero exit.
+- `src/cli.ts` — register `instar spec conformance <path>` (a `spec` command group
+  + `conformance` subcommand) using the established Commander + `loadConfig` pattern.
+- `tests/unit/spec-conformance-cli.test.ts` — 5 tests (posts markdown, prints
+  findings, clean-pass, degraded-advisory, --json, missing-file exit).
+
+**Under-block / over-block**: None. The CLI only *reads* a spec and *prints* a
+report; it has no authority (mirrors the route's signal-only nature). It cannot
+block anything.
+
+**Level-of-abstraction fit**: The CLI is a thin presentation layer over the
+already-built route + reviewer; it duplicates no logic. It reuses the standard
+CLI→local-server pattern (`loadConfig` → port/authToken → fetch), so the
+subscription-backed intelligence provider stays server-side (the CLI never
+constructs an LLM client).
+
+**Signal vs authority**: Inherits the route's signal-only posture — prints
+"possible violations (you decide)", never a pass/fail verdict that gates anything.
+
+**Interactions**:
+- Requires the local server running (it's a client). Server-down → a clear
+  "Is the server running?" error + exit 1, not a crash.
+- Reads `config.port` (so it targets the agent's real port, e.g. 4042) with a 4040
+  fallback; reads `authToken` for the Bearer header.
+- 60s fetch timeout (a `capable`-tier conformance check can take a while).
+
+**External surfaces**: New CLI subcommand `instar spec conformance <path>
+[--dir] [--port] [--json]`. New exported `runSpecConformance`. No new endpoint,
+no config change.
+
+**Rollback cost**: Trivial. Remove the command registration + `src/commands/spec.ts`
++ the test. The route it calls is unaffected.
+
+**Migration parity**: CLI code only (shipped in the package; every agent gets it
+on update). No hook/template/config/skill change.


### PR DESCRIPTION
## What

Ships the tracked `scg-cli` follow-up from the standards-conformance-gate spec (#373): a command-line entry point to the conformance gate.

`instar spec conformance <path>` reads a spec file, posts it to the local server's `POST /spec/conformance-check`, and prints a rule-by-rule report ("this part might break No-Manual-Work, here's why"). A thin client over the existing route — the subscription-backed model stays server-side (the CLI never touches a raw API). **Signal-only** (advises, never blocks). `--json` for raw output; `--port`/`--dir` overrides. Server-down → clear error + non-zero exit.

## Testing

5 unit tests (stubbed server): posts the spec markdown to the route, renders flagged findings, clean-pass, degraded-as-advisory, `--json`, missing-file exit. `tsc` + lint clean.

## Governance

Covered by the already-approved `docs/specs/standards-conformance-gate.md` (the `scg-cli` tracked deferral). Side-effects: `upgrades/side-effects/scg-cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)