### PR TITLE
feat(topic-intent): config-overridable decay horizons (cwa-decay-profile-config)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2417,8 +2417,12 @@ export async function startServer(options: StartOptions): Promise<void> {
     // TopicIntentStore (Layer 1 of the Topic Intent Layer): per-topic
     // confidence tracker. File-backed, framework-agnostic — works under
     // Claude Code AND Codex sessions. See docs/specs/topic-intent-layer.md.
-    const { TopicIntentStore } = await import('../core/TopicIntent.js');
+    const { TopicIntentStore, configureDecayProfiles } = await import('../core/TopicIntent.js');
     const topicIntentStore = new TopicIntentStore(config.stateDir);
+    // Apply any operator decay-horizon overrides (existence-checked; invalid
+    // values ignored). No-op when unset → built-in defaults. Tracked refinement
+    // cwa-decay-profile-config of the rung-1 task-context spec.
+    configureDecayProfiles(config.topicIntent?.capture?.decayProfiles);
 
     // Shared intelligence provider — lightweight LLM for internal classification tasks.
     // Subscription path only: routes through the Claude CLI (`claude -p`), which bills against

--- a/src/core/TopicIntent.ts
+++ b/src/core/TopicIntent.ts
@@ -172,17 +172,67 @@ export interface DecayProfile { graceDays: number; halfLifeDays: number }
 
 const LONG_PROFILE: DecayProfile = { graceDays: DECAY_GRACE_DAYS, halfLifeDays: DECAY_HALF_LIFE_DAYS };
 
-const DECAY_PROFILES: Record<RefKind, DecayProfile> = {
-  fact: LONG_PROFILE,
-  decision: LONG_PROFILE,
+/** The built-in defaults (the code-constant baseline; config may override). */
+const DEFAULT_DECAY_PROFILES: Record<RefKind, DecayProfile> = {
+  fact: { ...LONG_PROFILE },
+  decision: { ...LONG_PROFILE },
   method: { graceDays: 1, halfLifeDays: 7 },     // short — the active how
   goal: { graceDays: 2, halfLifeDays: 14 },      // short–medium — the active what
   audience: { graceDays: 3, halfLifeDays: 30 },  // medium — who it's for, persists across a task cluster
 };
 
+/**
+ * The ACTIVE per-kind decay profiles. Starts as the defaults; an operator may
+ * override individual kinds via config (`topicIntent.capture.decayProfiles`)
+ * once, at startup, through `configureDecayProfiles`. Process-wide policy —
+ * decay is a global tuning knob, not per-call state. (Tracked refinement
+ * `cwa-decay-profile-config` of the rung-1 spec, docs/specs/topic-intent-task-context-capture.md §3.)
+ */
+let activeDecayProfiles: Record<RefKind, DecayProfile> = structuredCloneProfiles(DEFAULT_DECAY_PROFILES);
+
+function structuredCloneProfiles(p: Record<RefKind, DecayProfile>): Record<RefKind, DecayProfile> {
+  return {
+    fact: { ...p.fact }, decision: { ...p.decision }, method: { ...p.method },
+    goal: { ...p.goal }, audience: { ...p.audience },
+  };
+}
+
+/** A partial per-kind override: any subset of kinds, any subset of {graceDays, halfLifeDays}. */
+export type DecayProfileOverrides = Partial<Record<RefKind, Partial<DecayProfile>>>;
+
+/**
+ * Apply config overrides on top of the defaults (existence-checked: only the
+ * fields/kinds present are changed; everything else keeps the default). Invalid
+ * values (non-finite, ≤ 0) are ignored so a bad config can never break decay.
+ * Idempotent — always re-derives from DEFAULTS, so calling twice with different
+ * overrides doesn't compound. Returns the resolved active profiles.
+ */
+export function configureDecayProfiles(overrides?: DecayProfileOverrides): Record<RefKind, DecayProfile> {
+  const next = structuredCloneProfiles(DEFAULT_DECAY_PROFILES);
+  if (overrides) {
+    for (const kind of Object.keys(next) as RefKind[]) {
+      const o = overrides[kind];
+      if (!o) continue;
+      if (typeof o.graceDays === 'number' && Number.isFinite(o.graceDays) && o.graceDays > 0) {
+        next[kind].graceDays = o.graceDays;
+      }
+      if (typeof o.halfLifeDays === 'number' && Number.isFinite(o.halfLifeDays) && o.halfLifeDays > 0) {
+        next[kind].halfLifeDays = o.halfLifeDays;
+      }
+    }
+  }
+  activeDecayProfiles = next;
+  return structuredCloneProfiles(next);
+}
+
+/** Restore the built-in defaults (primarily for test isolation). */
+export function resetDecayProfiles(): void {
+  activeDecayProfiles = structuredCloneProfiles(DEFAULT_DECAY_PROFILES);
+}
+
 /** Resolve the decay profile for a kind; missing/unknown kind → long profile (rung-0 default). */
 export function decayProfileFor(kind?: RefKind): DecayProfile {
-  return (kind && DECAY_PROFILES[kind]) || LONG_PROFILE;
+  return (kind && activeDecayProfiles[kind]) || LONG_PROFILE;
 }
 
 const AUTHORITY_THRESHOLD = 0.7;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1701,6 +1701,14 @@ export interface InstarConfig {
   topicIntent?: {
     capture?: {
       enabled?: boolean;
+      /**
+       * Optional per-kind decay-horizon overrides (existence-checked). Any subset
+       * of refKinds (fact/decision/method/audience/goal), any subset of
+       * {graceDays, halfLifeDays}; omitted fields keep the built-in defaults.
+       * Lets operators tune the short/medium/long horizons from real data without
+       * a code change. See docs/specs/topic-intent-task-context-capture.md §3.
+       */
+      decayProfiles?: Record<string, { graceDays?: number; halfLifeDays?: number }>;
     };
   };
   /**

--- a/tests/unit/TopicIntent-decay-profile-config.test.ts
+++ b/tests/unit/TopicIntent-decay-profile-config.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for config-overridable decay profiles (cwa-decay-profile-config).
+ * The per-kind decay horizons (rung 1) are code defaults that an operator may
+ * override via config; overrides are existence-checked and validated.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  configureDecayProfiles,
+  resetDecayProfiles,
+  decayProfileFor,
+  projectConfidence,
+  buildEvent,
+} from '../../src/core/TopicIntent.js';
+
+const T0 = Date.parse('2026-01-01T00:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+afterEach(() => resetDecayProfiles());
+
+describe('configureDecayProfiles', () => {
+  it('defaults are in effect with no overrides', () => {
+    configureDecayProfiles(undefined);
+    expect(decayProfileFor('method')).toEqual({ graceDays: 1, halfLifeDays: 7 });
+    expect(decayProfileFor('fact')).toEqual({ graceDays: 30, halfLifeDays: 180 });
+  });
+
+  it('overrides only the specified kind+field; everything else keeps the default', () => {
+    configureDecayProfiles({ method: { halfLifeDays: 21 } });
+    expect(decayProfileFor('method')).toEqual({ graceDays: 1, halfLifeDays: 21 }); // grace unchanged
+    expect(decayProfileFor('goal')).toEqual({ graceDays: 2, halfLifeDays: 14 });   // untouched kind
+    expect(decayProfileFor('fact')).toEqual({ graceDays: 30, halfLifeDays: 180 });
+  });
+
+  it('ignores invalid values (non-finite, <= 0) — a bad config never breaks decay', () => {
+    configureDecayProfiles({ method: { graceDays: -5, halfLifeDays: 0 }, goal: { halfLifeDays: Infinity } });
+    expect(decayProfileFor('method')).toEqual({ graceDays: 1, halfLifeDays: 7 }); // both invalid → default
+    expect(decayProfileFor('goal')).toEqual({ graceDays: 2, halfLifeDays: 14 });  // invalid → default
+  });
+
+  it('is idempotent — re-deriving from defaults, not compounding', () => {
+    configureDecayProfiles({ method: { halfLifeDays: 21 } });
+    configureDecayProfiles({ method: { graceDays: 3 } }); // second call: halfLifeDays should revert to default
+    expect(decayProfileFor('method')).toEqual({ graceDays: 3, halfLifeDays: 7 });
+  });
+
+  it('resetDecayProfiles restores the built-in defaults', () => {
+    configureDecayProfiles({ method: { halfLifeDays: 99 } });
+    resetDecayProfiles();
+    expect(decayProfileFor('method')).toEqual({ graceDays: 1, halfLifeDays: 7 });
+  });
+
+  it('the override actually changes projection decay', () => {
+    const ev = [buildEvent('r', 'extract-user', 'm1', { at: new Date(T0).toISOString() })]; // +0.40
+    const at8 = T0 + 8 * DAY;
+    // default method: grace 1, half-life 7 → day 8 ≈ 0.20
+    configureDecayProfiles(undefined);
+    expect(projectConfidence(ev, new Date(T0).toISOString(), at8, 'method').confidence).toBeCloseTo(0.20, 2);
+    // override method to a long horizon → barely decays by day 8
+    configureDecayProfiles({ method: { graceDays: 30, halfLifeDays: 180 } });
+    expect(projectConfidence(ev, new Date(T0).toISOString(), at8, 'method').confidence).toBeCloseTo(0.40, 2);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,49 +1,52 @@
-# Upgrade Guide — `instar spec conformance` CLI
+# Upgrade Guide — tunable topic-intent decay horizons
 
 <!-- bump: minor -->
 <!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
 
 ## What Changed
 
-**You can now run the standards-conformance gate from the command line.**
+**You can now tune how fast each kind of memory fades, from config.**
 
-The conformance gate (shipped in v1.2.69) checks a draft spec against the living
-constitution and reports possible standard-violations — but until now you had to
-call its HTTP route directly. This adds the tracked `scg-cli` follow-up: a
-command-line entry point.
+Rung 1 gave topic-intent memories different "shelf lives" — a method ("we're
+testing over Telegram") fades in about a week, an audience in about a month,
+facts and decisions over months. Those numbers were code constants. This ships
+the tracked `cwa-decay-profile-config` follow-up: they're now overridable via
+config, so we can tune them from real data without a code change.
 
-`instar spec conformance <path>` reads a spec file, sends it to the local server's
-conformance route, and prints a rule-by-rule report — "this part might break
-No-Manual-Work, here's why." It's a thin client over the existing route, so the
-subscription-backed model stays server-side (the CLI never touches a raw API). It
-**advises only** — it prints possible violations, never a pass/fail that blocks
-anything. `--json` emits the raw report; `--port`/`--dir` override the defaults.
+`topicIntent.capture.decayProfiles` takes any subset of refkinds
+(method/audience/goal/fact/decision) and any subset of `{graceDays, halfLifeDays}`;
+anything you don't specify keeps the built-in default. Invalid values (zero,
+negative, non-finite) are ignored — a bad config can never break decay; it just
+falls back to the default. Set nothing and behavior is exactly as before.
 
-If the server isn't running it says so clearly and exits non-zero, rather than
-hanging or crashing.
+Example: slow down how fast a "method" frame fades —
+`{"topicIntent":{"capture":{"decayProfiles":{"method":{"halfLifeDays":21}}}}}`.
 
-**Evidence**: 5 unit tests (posts the spec markdown to the route, renders flagged
-findings, clean-pass, degraded-as-advisory, `--json`, missing-file exit). `tsc` +
-lint clean.
+**Evidence**: 6 unit tests (defaults, partial override, invalid-ignored,
+idempotent, reset, and that an override actually changes projected decay). The
+rung-0/rung-1 decay math is unchanged when no override is set (existing
+projection tests green). `tsc` + lint clean.
 
-Spec: `docs/specs/standards-conformance-gate.md` (the `scg-cli` tracked deferral,
-now shipped). Side-effects: `upgrades/side-effects/scg-cli.md`.
+Spec: `docs/specs/topic-intent-task-context-capture.md` §3 (the
+`cwa-decay-profile-config` tracked deferral, now shipped). Side-effects:
+`upgrades/side-effects/cwa-decay-profile-config.md`.
 
 ## What to Tell Your User
 
-- **Check a spec from the terminal**: "Run `instar spec conformance <path>` and I'll
-  check that spec against our standards and point out anything that might break a
-  rule — it's advice, not a gate."
+- **Tune memory shelf-lives**: "How fast I forget different kinds of context is
+  now adjustable in config — if a 'how we're working' note fades too fast or
+  sticks too long, we can dial it without changing code."
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Conformance check from the CLI | `instar spec conformance <path> [--json] [--port N] [--dir P]` |
+| Override topic-intent decay horizons | `topicIntent.capture.decayProfiles.<kind>.{graceDays,halfLifeDays}` in `.instar/config.json` (optional; omitted → defaults) |
 
 ## Evidence
 
-Not a bug fix — a CLI wrapper over the existing conformance route. Verified by 5
-unit tests that stub the server and assert the command posts the spec markdown and
-renders the report (findings, clean-pass, degraded-advisory, JSON, missing-file
-exit). `tsc` + lint clean.
+Not a bug fix — a tuning knob over the rung-1 decay model. Verified by 6 unit
+tests including one that confirms an override actually changes projected decay
+(a method ref barely decays by day 8 under a long-horizon override vs. ~halving
+under the default). No-override behavior is byte-for-byte the prior defaults.
+`tsc` + lint clean.

--- a/upgrades/side-effects/cwa-decay-profile-config.md
+++ b/upgrades/side-effects/cwa-decay-profile-config.md
@@ -1,0 +1,58 @@
+# Side-effects review — config-overridable decay profiles (cwa-decay-profile-config)
+
+**Scope**: Ship the tracked `cwa-decay-profile-config` deferral from the rung-1
+task-context spec (`docs/specs/topic-intent-task-context-capture.md` §3, approved):
+let operators tune the per-kind decay horizons (method/audience/goal/fact/decision)
+via config instead of code constants, so the short/medium/long numbers become
+tunable from real data without a code change.
+
+**Files touched**:
+- `src/core/TopicIntent.ts` — split `DECAY_PROFILES` into `DEFAULT_DECAY_PROFILES`
+  (the baseline) + a mutable `activeDecayProfiles`; add `configureDecayProfiles(overrides)`
+  (existence-checked, validated, idempotent — always re-derives from defaults),
+  `resetDecayProfiles()` (test isolation), and `DecayProfileOverrides` type.
+  `decayProfileFor` now reads the active profiles. `projectConfidence` is
+  unchanged (still pure w.r.t. its args; it calls `decayProfileFor`).
+- `src/core/types.ts` — `topicIntent.capture.decayProfiles?` config field.
+- `src/commands/server.ts` — call `configureDecayProfiles(config.topicIntent?.capture?.decayProfiles)`
+  once at startup, right after the TopicIntentStore is constructed.
+- `tests/unit/TopicIntent-decay-profile-config.test.ts` — 6 tests (defaults,
+  partial override, invalid-ignored, idempotent, reset, projection-reflects-override).
+
+**Under-block**: An override only changes the numbers it specifies; everything
+else keeps the default. Invalid values (non-finite / ≤ 0) are silently ignored,
+so a malformed config can never break decay (the loop falls back to defaults).
+
+**Over-block**: None. This is a tuning knob, not a gate.
+
+**Level-of-abstraction fit**: Decay horizons are process-wide *policy*, so a
+module-level configurable map (set once at startup) is the right level — not
+per-call state. `projectConfidence` keeps its signature and purity-w.r.t-args;
+the only behavioral input it gains is the global policy via `decayProfileFor`,
+which already read a module constant. `configureDecayProfiles` always re-derives
+from `DEFAULT_DECAY_PROFILES` so it's idempotent and order-independent.
+
+**Signal vs authority**: N/A (a tuning value, no decision authority).
+
+**Interactions**:
+- `configureDecayProfiles` is called once at server startup. If never called
+  (e.g. tests, or a path that doesn't boot the server), the defaults are in
+  effect — identical to pre-change behavior. **Rung-0/rung-1 decay math is
+  unchanged when no override is set** (fact/decision stay 30/180; task kinds keep
+  their defaults), so existing projection tests are unaffected.
+- `resetDecayProfiles()` exists for test isolation (module-global state); tests
+  call it in `afterEach`.
+- Idempotent + validated → re-running migration / re-reading config is safe.
+
+**External surfaces**: New config field `topicIntent.capture.decayProfiles`
+(optional, existence-checked). New exported `configureDecayProfiles`,
+`resetDecayProfiles`, `DecayProfileOverrides`. No new endpoint.
+
+**Rollback cost**: Low. Revert `decayProfileFor` to read a const + drop the
+config field + the startup call; behavior returns to fixed code-constant
+profiles (today's state). No persisted state involved.
+
+**Migration parity**: Pure config-read at startup (server-side; every agent
+gets the capability on update). The field is opt-in with an existence check, so
+no `ConfigDefaults` entry is required — absence → built-in defaults. No
+hook/template/skill change.


### PR DESCRIPTION
## What

Ships the tracked `cwa-decay-profile-config` follow-up from the rung-1 task-context spec (§3): the per-kind decay horizons (method/audience/goal/fact/decision) become tunable via config instead of code constants, so the short/medium/long numbers can be tuned from real data without a code change.

## How

- `DECAY_PROFILES` split into `DEFAULT_DECAY_PROFILES` (baseline) + mutable `activeDecayProfiles`; `configureDecayProfiles(overrides)` (existence-checked, validates positive/finite, **idempotent** — re-derives from defaults so order/repeat is safe) + `resetDecayProfiles()` (test isolation); `decayProfileFor` reads the active map.
- `topicIntent.capture.decayProfiles?` config field (any subset of kinds/fields; omitted → default).
- `configureDecayProfiles(config…)` called once at server startup, right after the TopicIntentStore is built. No-op when unset.
- `projectConfidence` unchanged. **No-override behavior is byte-for-byte the prior defaults** (existing projection tests green).

## Testing

6 unit tests: defaults, partial override, invalid-ignored, idempotent, reset, and that an override actually changes projected decay (a method ref barely decays by day 8 under a long-horizon override vs. ~halving under the default). `tsc` + lint clean.

## Governance

Covered by the already-approved `docs/specs/topic-intent-task-context-capture.md` §3 (the `cwa-decay-profile-config` tracked deferral). Side-effects: `upgrades/side-effects/cwa-decay-profile-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)