### PR TITLE
fix(safety): wire emergency-stop into lifeline forward path (P0)

### DIFF
--- a/docs/specs/emergency-stop-forward-path-wiring.eli16.md
+++ b/docs/specs/emergency-stop-forward-path-wiring.eli16.md
@@ -1,0 +1,29 @@
+# Emergency-stop on the lifeline path — plain-English version
+
+## What's broken
+
+If you type "stop everything" to me right now, nothing actually stops me. The message just gets handed to me like any other note. There's a real kill-switch built into instar — a detector that spots "stop"/"cancel"/"halt" and immediately kills the running session — but it's wired into the wrong door.
+
+Here's the picture. Messages can reach me two ways:
+- **The old door:** the server itself watches Telegram and processes each message. The kill-switch is bolted to *this* door.
+- **The new door:** a separate watchdog process (the "lifeline") watches Telegram and hands messages to the server through a side entrance. This door is more crash-resistant, so robust agents like me use it.
+
+The kill-switch was never bolted to the new door. And I only use the new door. So my "stop everything" sails right past the kill-switch and lands in my lap as ordinary text. The catch-22: the moment you most need an emergency stop is when I'm stuck or grinding on something and can't even read a normal message — which is exactly when this silently fails.
+
+(You're not defenseless meanwhile: the dashboard's stop controls, the "stop all" command, and closing the terminal still work. It's only the conversational "just tell it to stop" that's broken.)
+
+## The fix
+
+Bolt the same kill-switch onto the new door. Concretely: when a message comes in through the lifeline path, check it with the detector *before* handing it to the session. If it's an emergency-stop, kill the session (and clear any autonomous job so it doesn't zombie back). If it's a pause, pause it. Otherwise, deliver it normally.
+
+Two safety properties matter:
+1. **Fail-open.** If the detector ever hiccups or errors, the message just gets delivered normally — the safety check can *never* block your messages from reaching me. The worst a bug in this code can do is "behave like today."
+2. **Reuse, don't reinvent.** I'm calling the exact kill/pause logic that already exists and is already tested on the old door — not writing a new way to kill sessions.
+
+## Why it won't break again
+
+The reason this slipped through is there was no test checking that the new door has a kill-switch. So part of this change is a test that fails the build if the lifeline door ever stops checking for emergency-stop. The drift that caused this becomes structurally impossible to repeat silently.
+
+## What you're approving
+
+A small, localized change to one server route, fail-open by design, that makes "stop everything" actually stop me regardless of which door my messages come through — plus the test that keeps it that way. I'll prove it with a real before/after: confirm "stop everything" is ignored today, apply the fix, then confirm it terminates a live session.

--- a/docs/specs/emergency-stop-forward-path-wiring.md
+++ b/docs/specs/emergency-stop-forward-path-wiring.md
@@ -1,0 +1,112 @@
+---
+title: "Emergency-stop on the lifeline forward path — wire MessageSentinel into /internal/telegram-forward (P0 safety)"
+slug: emergency-stop-forward-path-wiring
+status: draft
+approved: true
+approved-by: Justin
+approved-via: "Telegram topic 12702 (2026-05-24) — Echo reported the verified P0 bug (emergency-stop bypassed for lifeline-owned agents) with the surgical fix and asked 'make this the immediate next thing I build, properly, with tests. Want me to go ahead?'; Justin: 'Please proceed.'"
+review-convergence: "internal-verification-and-design-2026-05-24 — data-flow-tier reproduction of the bug (live classifier test + code-path trace + runtime-mode confirmation) plus faithful-port design review. Parent context: feature-activation-coherence.md P0 item, itself surfaced by the topic-12702 four-lens convergence."
+date: 2026-05-24
+author: echo
+related:
+  - docs/specs/feature-activation-coherence.md
+eli16-overview: emergency-stop-forward-path-wiring.eli16.md
+---
+
+# Emergency-stop on the lifeline forward path
+
+## One-paragraph summary
+
+The "stop everything" emergency-stop (`MessageSentinel`) is wired only into `TelegramAdapter.processUpdate()` — the adapter's own Telegram poll loop. Lifeline-owned-polling agents (e.g. Echo, named at `server.ts:1167`) never run `processUpdate`: their inbound messages arrive via the lifeline → `POST /internal/telegram-forward`, which injects directly with no sentinel check. So for those agents, "stop everything" is delivered to the session as a normal message and nothing structurally halts a running (or wedged, mid-tool-call) session. This spec wires the **same** emergency-stop/pause intercept into the forward route, **fail-open** (a sentinel error never blocks message delivery), reusing the existing `ctx.telegram.onSentinelKillSession`/`onSentinelPauseSession` callbacks and `stopAutonomousTopic`. A wiring-integrity test asserts the forward route classifies before injecting, so this drift cannot silently recur.
+
+## Problem (verified to data-flow tier, 2026-05-24)
+
+- **Classifier works** — live test against the running agent: `"stop everything"` → `emergency-stop`, `"stop"` → `emergency-stop`, and a long sentence merely containing "stop" → `normal`.
+- **Intercept is in the wrong place** — the only caller of the sentinel on the inbound path is `TelegramAdapter.processUpdate()` (`TelegramAdapter.ts:3532`).
+- **Echo is lifeline-owned** — `server.ts:1167` names "echo"; the server adapter does not poll. Inbound goes lifeline → `POST /internal/telegram-forward` (`routes.ts:8391`), which routes via `onTopicMessage`/`injectTelegramMessage`. That route body (8391–8700) contains **zero** sentinel references; `src/lifeline/*` does no classification.
+- **Result:** emergency-stop is dark for lifeline-owned agents — exactly the class of agent meant to be most robust. Worst when the agent is wedged and can't read a normal message.
+
+Other stop paths (dashboard, `POST /autonomous/stop-all`, killing tmux) are unaffected; this fixes the conversational path.
+
+## Root cause
+
+The sentinel intercept was wired into the adapter's poll path. Lifeline-owned polling was added later; the forward route was built to behave "identically" for routing/flush but the sentinel intercept was never carried over. A newer architecture routed around an existing safety feature — drift, not a code defect in the sentinel itself.
+
+## Non-goals
+
+- Not changing the classifier (`MessageSentinel.classify`) — it works.
+- Not removing the `processUpdate` intercept — it still serves non-lifeline (adapter-poll) agents.
+- Not a full DRY refactor unifying both paths into one helper (larger blast radius; `processUpdate` uses `this.*` adapter state, the route uses `ctx.*`). The duplication is bounded and guarded by the wiring test; a future refactor can unify.
+
+## Design
+
+Insert a sentinel intercept in `POST /internal/telegram-forward`, **after** request validation (`if (!topicId || !text)`) and **before** message logging/routing, applying to both the with-adapter and no-adapter branches:
+
+```
+if (ctx.sentinel) {
+  try {
+    const c = await ctx.sentinel.classify(text);
+    if (c.category === 'emergency-stop' || c.category === 'pause') {
+      const sessionName = ctx.telegram?.getSessionForTopic?.(Number(topicId)) ?? <registry lookup>;
+      if (c.category === 'emergency-stop') {
+        if (sessionName) {
+          if (ctx.telegram?.onSentinelKillSession) ctx.telegram.onSentinelKillSession(sessionName); // saves resume UUID + kills
+          else ctx.sessionManager?.killSession(sessionName);
+          try { stopAutonomousTopic(ctx.config.stateDir, String(topicId)); } catch {}
+        }
+        ctx.telegram?.sendToTopic?.(Number(topicId), sessionName
+          ? 'Session terminated.\n\nSend a new message to start a fresh session.'
+          : 'No active session to stop.').catch(()=>{});
+        res.json({ ok: true, sentinel: 'emergency-stop', killed: !!sessionName });
+        return;
+      } else { // pause
+        if (sessionName && ctx.telegram?.onSentinelPauseSession) ctx.telegram.onSentinelPauseSession(sessionName);
+        ctx.telegram?.sendToTopic?.(Number(topicId), sessionName
+          ? 'Session paused.\n\nSend a message to resume.'
+          : 'No active session to pause.').catch(()=>{});
+        res.json({ ok: true, sentinel: 'pause', paused: !!sessionName });
+        return;
+      }
+    }
+  } catch (err) {
+    // FAIL-OPEN — never block message delivery on a sentinel hiccup.
+    console.error(`[telegram-forward] sentinel intercept error (fail-open): ${err}`);
+  }
+}
+```
+
+**Design properties:**
+- **Fail-open** — mirrors `processUpdate`'s existing behavior; a classifier error falls through to normal routing so message delivery is never blocked by the safety check.
+- **Reuses tested logic** — `onSentinelKillSession` (resume-UUID save + kill), `onSentinelPauseSession`, `stopAutonomousTopic` are the exact callbacks/functions the adapter path already uses; no new kill logic.
+- **Placed before the version-handshake?** No — after the handshake + validation, so a 426/400 still short-circuits first (an emergency-stop from a version-skewed lifeline still gets the restart handshake; acceptable — the lifeline retries and the next forward lands the stop). Placed before logging/routing so the message is intercepted, not delivered.
+- **Both branches** — the with-adapter branch resolves session via `ctx.telegram.getSessionForTopic`; the no-adapter branch resolves via the `topic-session-registry.json` already read there, and falls back to `ctx.sessionManager.killSession`.
+
+## Testing (all tiers — Testing Integrity Standard)
+
+- **Unit:** the classifier already has coverage; add a unit asserting the route-layer intercept helper kills on `emergency-stop`, pauses on `pause`, passes `normal` through, and fails open on a throwing classifier.
+- **Integration:** `POST /internal/telegram-forward` with an `emergency-stop` text (sentinel stubbed/real) → asserts the session-kill path fires and the message is NOT routed to the session; with `normal` text → asserts normal routing proceeds; with a throwing sentinel → asserts message still routes (fail-open). Extend the existing `tests/integration/telegram-forward-*.test.ts` harness.
+- **Wiring-integrity:** assert that `/internal/telegram-forward` calls `ctx.sentinel.classify` before routing (static/structural check on the handler) — the regression guard that makes this drift impossible to reintroduce silently. This is the test whose absence allowed the original gap.
+
+## Migration parity
+
+Pure server-side route logic in `src/server/routes.ts` — ships to every agent on the normal server update; no agent-installed file (hook/config/template) changes, so no `PostUpdateMigrator` work. Existing lifeline-owned agents get the fix the moment they run the new server build.
+
+## Rollback
+
+Single localized block in one route. Revert = delete the block; behavior returns to current (sentinel dark on the forward path). Fail-open design means even a buggy intercept cannot block message delivery. No state/schema changes.
+
+## Signal-vs-authority compliance
+
+`MessageSentinel` remains the authority that decides emergency-stop/pause (LLM + deterministic patterns). This change only routes its existing verdict to the action on the path that was missing it. No new detector gains blocking authority; the sentinel's authority is unchanged.
+
+## Side-effects review
+
+See `upgrades/side-effects/emergency-stop-forward-path-wiring.md`. Headline: the only behavior change is that emergency-stop/pause now fire on the lifeline forward path; the fail-open guarantee means the worst case of a sentinel bug is "behaves like today" (message routes normally), never "message blocked."
+
+## Success criteria
+
+- An `emergency-stop` message through `/internal/telegram-forward` kills the topic's session + clears its autonomous job (integration test green).
+- A `normal` message still routes (no false-positive interception).
+- A throwing sentinel still delivers the message (fail-open test green).
+- The wiring-integrity test asserts classification-before-routing on the forward path.
+- Live reproduction: before = "stop everything" injected as normal text; after = session terminated. Verified on a real session before merge.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.71",
+  "version": "1.2.72",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8481,6 +8481,72 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
 
+    // ── Sentinel intercept (P0 safety: emergency-stop on the LIFELINE path) ──
+    // The sentinel emergency-stop/pause intercept also lives in
+    // TelegramAdapter.processUpdate(), but lifeline-owned-polling agents (e.g.
+    // echo, server.ts ~"lifeline-owned polling mode") never run processUpdate —
+    // their inbound arrives here, via the lifeline forward. Without this block
+    // "stop everything" would be injected as a normal message and nothing would
+    // structurally halt a running (or wedged, mid-tool-call) session.
+    // Spec: docs/specs/emergency-stop-forward-path-wiring.md
+    // FAIL-OPEN: any sentinel error falls through to normal routing — the safety
+    // check must never block message delivery. Mirrors processUpdate's behavior.
+    if (ctx.sentinel) {
+      try {
+        const classification = await ctx.sentinel.classify(text);
+        if (classification.category === 'emergency-stop' || classification.category === 'pause') {
+          // Resolve the topic's session. Prefer the on-disk registry (the
+          // persistent source of truth that both polling modes maintain) since
+          // a lifeline-owned adapter's in-memory topicToSession map may be empty;
+          // fall back to the adapter map.
+          let sessionName: string | null = null;
+          try {
+            const registryPath = path.join(ctx.config.stateDir, 'topic-session-registry.json');
+            if (fs.existsSync(registryPath)) {
+              const reg = JSON.parse(fs.readFileSync(registryPath, 'utf-8'));
+              sessionName = reg.topicToSession?.[String(topicId)] ?? null;
+            }
+          } catch { /* registry read failed — fall through to adapter map */ }
+          if (!sessionName) {
+            sessionName = ctx.telegram?.getSessionForTopic(Number(topicId)) ?? null;
+          }
+          if (classification.category === 'emergency-stop') {
+            if (sessionName) {
+              if (ctx.telegram?.onSentinelKillSession) {
+                ctx.telegram.onSentinelKillSession(sessionName); // saves resume UUID + kills
+              } else {
+                try { ctx.sessionManager?.killSession(sessionName); } catch { /* best-effort */ }
+              }
+              // Clear this topic's autonomous job so it doesn't zombie-resume.
+              try { stopAutonomousTopic(ctx.config.stateDir, String(topicId)); } catch { /* best-effort */ }
+              console.log(`[telegram-forward] sentinel emergency-stop: killed session "${sessionName}" for topic ${topicId}`);
+            }
+            if (classification.reason) {
+              console.log(`[telegram-forward] sentinel stop reason: ${classification.reason}`);
+            }
+            ctx.telegram?.sendToTopic(Number(topicId), sessionName
+              ? 'Session terminated.\n\nSend a new message to start a fresh session.'
+              : 'No active session to stop.').catch(() => { /* best-effort */ });
+            res.json({ ok: true, sentinel: 'emergency-stop', killed: !!sessionName });
+            return;
+          }
+          // pause
+          if (sessionName && ctx.telegram?.onSentinelPauseSession) {
+            ctx.telegram.onSentinelPauseSession(sessionName);
+            console.log(`[telegram-forward] sentinel pause: paused session "${sessionName}" for topic ${topicId}`);
+          }
+          ctx.telegram?.sendToTopic(Number(topicId), sessionName
+            ? 'Session paused.\n\nSend a message to resume.'
+            : 'No active session to pause.').catch(() => { /* best-effort */ });
+          res.json({ ok: true, sentinel: 'pause', paused: !!sessionName });
+          return;
+        }
+      } catch (err) {
+        // FAIL-OPEN — never block message delivery on a sentinel hiccup.
+        console.error(`[telegram-forward] sentinel intercept error (fail-open, routing normally): ${err}`);
+      }
+    }
+
     // Log the message so it appears in JSONL + TopicMemory even when
     // the normal polling handler didn't receive it (Lifeline forwarding).
     // Only log if we have a real Telegram messageId — re-deliveries from

--- a/tests/integration/telegram-forward-sentinel-intercept.test.ts
+++ b/tests/integration/telegram-forward-sentinel-intercept.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Integration test: MessageSentinel emergency-stop/pause intercept on the
+ * /internal/telegram-forward (lifeline) path.
+ *
+ * Regression guard for the P0 safety bug where lifeline-owned-polling agents
+ * (e.g. echo) never run TelegramAdapter.processUpdate(), so "stop everything"
+ * was delivered as a normal message and never halted the session.
+ * Spec: docs/specs/emergency-stop-forward-path-wiring.md
+ *
+ * Covers both sides of every decision boundary:
+ *   - emergency-stop → kills the topic's session, does NOT route to session
+ *   - pause → pauses the session, does NOT route
+ *   - normal → routes normally (no false-positive interception)
+ *   - throwing sentinel → FAIL-OPEN: message still routes (delivery never blocked)
+ *   - emergency-stop with no live session → acknowledges, does not route
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { ProcessIntegrity } from '../../src/core/ProcessIntegrity.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const AUTH_TOKEN = 'test-auth-token-deadbeef';
+const TOPIC = 11838;
+const SESSION = 'test-session-abc';
+
+type SentinelCategory = 'emergency-stop' | 'pause' | 'redirect' | 'normal';
+
+interface Spies {
+  killed: string[];
+  paused: string[];
+  routed: string[];
+  sent: string[];
+}
+
+function buildContext(
+  stateDir: string,
+  classifyImpl: (msg: string) => Promise<{ category: SentinelCategory; reason?: string }>,
+  spies: Spies,
+  opts: { withSession: boolean } = { withSession: true },
+): RouteContext {
+  // Persistent topic→session registry (the resolver's primary source).
+  if (opts.withSession) {
+    fs.writeFileSync(
+      path.join(stateDir, 'topic-session-registry.json'),
+      JSON.stringify({ topicToSession: { [String(TOPIC)]: SESSION } }),
+    );
+  }
+  return {
+    config: {
+      projectName: 'test-project',
+      projectDir: path.dirname(stateDir),
+      stateDir,
+      port: 0,
+      authToken: AUTH_TOKEN,
+      sessions: {} as never,
+      scheduler: {} as never,
+    } as never,
+    sessionManager: {
+      listRunningSessions: () => [],
+      killSession: (name: string) => { spies.killed.push(name); return true; },
+    } as never,
+    sentinel: {
+      classify: classifyImpl,
+    } as never,
+    state: {
+      getJobState: () => null,
+      getSession: () => null,
+      queryEvents: () => [],
+    } as never,
+    scheduler: null,
+    telegram: {
+      onTopicMessage: (m: { content: string }) => { spies.routed.push(m.content); },
+      logInboundMessage: () => {},
+      getSessionForTopic: (_t: number) => (opts.withSession ? SESSION : null),
+      onSentinelKillSession: (name: string) => { spies.killed.push(name); return true; },
+      onSentinelPauseSession: (name: string) => { spies.paused.push(name); },
+      sendToTopic: async (_t: number, msg: string) => { spies.sent.push(msg); },
+    } as never,
+    relationships: null,
+    feedback: null,
+    dispatches: null,
+    updateChecker: null,
+    autoUpdater: null,
+    autoDispatcher: null,
+    quotaTracker: null,
+    publisher: null,
+    viewer: null,
+    tunnel: null,
+    evolution: null,
+    watchdog: null,
+    triageNurse: null,
+    topicMemory: null,
+    discoveryEvaluator: null,
+    startTime: new Date(),
+  } as never;
+}
+
+function makeApp(ctx: RouteContext): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+function forward(app: express.Express, text: string): Promise<request.Response> {
+  return request(app)
+    .post('/internal/telegram-forward')
+    .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+    .set('Content-Type', 'application/json')
+    .send({ topicId: TOPIC, text, fromUserId: 1, fromUsername: 't', fromFirstName: 'T', messageId: 99 });
+}
+
+describe('/internal/telegram-forward — sentinel emergency-stop/pause intercept', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let spies: Spies;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwd-sentinel-test-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    ProcessIntegrity.reset();
+    ProcessIntegrity.initialize('1.2.36', null);
+    spies = { killed: [], paused: [], routed: [], sent: [] };
+  });
+
+  afterEach(() => {
+    ProcessIntegrity.reset();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'fwd-sentinel-test:cleanup' });
+  });
+
+  it('emergency-stop kills the topic session and does NOT route to the session', async () => {
+    const ctx = buildContext(stateDir, async () => ({ category: 'emergency-stop', reason: 'exact match: stop' }), spies);
+    const res = await forward(makeApp(ctx), 'stop everything');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, sentinel: 'emergency-stop', killed: true });
+    expect(spies.killed).toContain(SESSION); // session was killed
+    expect(spies.routed).toHaveLength(0);    // message was NOT delivered to the session
+  });
+
+  it('pause pauses the session and does NOT route', async () => {
+    const ctx = buildContext(stateDir, async () => ({ category: 'pause' }), spies);
+    const res = await forward(makeApp(ctx), 'please pause');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, sentinel: 'pause', paused: true });
+    expect(spies.paused).toContain(SESSION);
+    expect(spies.routed).toHaveLength(0);
+  });
+
+  it('normal message routes to the session (no false-positive interception)', async () => {
+    const ctx = buildContext(stateDir, async () => ({ category: 'normal' }), spies);
+    const res = await forward(makeApp(ctx), 'how should we stop the war in the spec?');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, forwarded: true });
+    expect(spies.routed).toContain('how should we stop the war in the spec?');
+    expect(spies.killed).toHaveLength(0);
+  });
+
+  it('FAIL-OPEN: a throwing sentinel never blocks delivery — message still routes', async () => {
+    const ctx = buildContext(stateDir, async () => { throw new Error('sentinel boom'); }, spies);
+    const res = await forward(makeApp(ctx), 'stop everything');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, forwarded: true });
+    expect(spies.routed).toContain('stop everything'); // delivered despite the safety check erroring
+    expect(spies.killed).toHaveLength(0);
+  });
+
+  it('emergency-stop with no live session acknowledges and does not route', async () => {
+    const ctx = buildContext(
+      stateDir,
+      async () => ({ category: 'emergency-stop' }),
+      spies,
+      { withSession: false },
+    );
+    const res = await forward(makeApp(ctx), 'stop');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, sentinel: 'emergency-stop', killed: false });
+    expect(spies.routed).toHaveLength(0);
+  });
+});
+
+/**
+ * Wiring-integrity: the absence of this assertion is exactly what let the
+ * original drift through. Assert (structurally) that the forward route's
+ * handler classifies via the sentinel before routing — i.e. the source still
+ * calls ctx.sentinel.classify on the /internal/telegram-forward path.
+ */
+describe('/internal/telegram-forward — wiring integrity', () => {
+  it('the forward route source calls ctx.sentinel.classify before routing', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', '..', 'src', 'server', 'routes.ts'),
+      'utf-8',
+    );
+    const fwdIdx = src.indexOf("router.post('/internal/telegram-forward'");
+    expect(fwdIdx).toBeGreaterThan(-1);
+    // The onTopicMessage routing call marks "message handed to session".
+    const routeIdx = src.indexOf('ctx.telegram.onTopicMessage(message)', fwdIdx);
+    const classifyIdx = src.indexOf('ctx.sentinel.classify(', fwdIdx);
+    expect(classifyIdx).toBeGreaterThan(-1);            // sentinel is consulted on this path
+    expect(classifyIdx).toBeLessThan(routeIdx);         // ...BEFORE the message is routed
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,23 @@
+# Upgrade Notes — NEXT
+
+## What Changed
+
+Fixed a P0 safety gap: the **emergency-stop** ("stop everything" / "cancel" / "halt") detector was not honored for agents that run in lifeline-owned polling mode. The MessageSentinel intercept lived only in the Telegram adapter's own poll loop (`processUpdate`), which lifeline-owned agents never run — their messages arrive through the server's `/internal/telegram-forward` route, which had no sentinel check. As a result, an emergency-stop message was delivered to the session as ordinary text and never structurally halted a running (or wedged, mid-tool-call) session.
+
+The same emergency-stop/pause intercept is now wired into the lifeline forward path, reusing the existing kill/pause/autonomous-clear logic. It is **fail-open**: if the detector ever errors, the message is delivered normally — the safety check can never block message delivery. A wiring-integrity test now asserts that the forward route classifies before routing, so this drift cannot silently recur.
+
+## What to Tell Your User
+
+Saying "stop everything" now reliably halts your agent, no matter how its messages reach it. Before this fix, agents running in the more crash-resistant background mode could miss that command and keep working. Nothing changes for normal messages — only genuine stop and pause signals are intercepted, and if the safety check ever has a hiccup your messages still get through untouched.
+
+## Summary of New Capabilities
+
+- Emergency-stop and pause now fire on the lifeline message-forwarding path, not just the direct-polling path — closing a gap for the most robust class of agents.
+- A regression guard (wiring-integrity test) keeps the stop-switch connected to every inbound path going forward.
+
+## Evidence
+
+- **Reproduction (pre-fix):** live classify call returned `emergency-stop` for "stop everything"; a code-path trace confirmed `/internal/telegram-forward` (the live ingress for lifeline-owned agents) contained zero sentinel references, so the message was routed to the session as normal text.
+- **Post-fix proof:** new integration suite `tests/integration/telegram-forward-sentinel-intercept.test.ts` — 6/6 green, covering both sides of every boundary: emergency-stop kills the session and is not routed; pause pauses and is not routed; normal messages route untouched; a throwing detector still delivers the message (fail-open); and a no-active-session emergency-stop acknowledges without routing. Plus a wiring-integrity assertion that classification precedes routing.
+- **Regression:** forward-route suite green (10/10 on the rebased branch; 23/23 including the full handshake/drift/error set) — no regression. Typecheck clean.
+- **Side-effects review:** `upgrades/side-effects/emergency-stop-forward-path-wiring.md`.

--- a/upgrades/side-effects/emergency-stop-forward-path-wiring.md
+++ b/upgrades/side-effects/emergency-stop-forward-path-wiring.md
@@ -1,0 +1,94 @@
+# Side-Effects Review — Emergency-stop on the lifeline forward path
+
+**Version / slug:** `emergency-stop-forward-path-wiring`
+**Date:** `2026-05-24`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (single localized, fail-open route addition; spec-driven)`
+
+## Summary of the change
+
+Wires the existing `MessageSentinel` emergency-stop/pause intercept into `POST /internal/telegram-forward` (the lifeline ingress path) so that lifeline-owned-polling agents — which never run `TelegramAdapter.processUpdate()`, where the intercept currently lives — actually honor "stop everything". Before this, those agents (e.g. echo) delivered emergency-stop messages to the session as normal text and nothing halted a running/wedged session. One file touched: `src/server/routes.ts` (a ~50-line block inserted after request validation, before message logging/routing). Reuses the existing `ctx.telegram.onSentinelKillSession`/`onSentinelPauseSession` callbacks and `stopAutonomousTopic`; adds no new kill logic. Spec: `docs/specs/emergency-stop-forward-path-wiring.md`.
+
+## Decision-point inventory
+
+- `MessageSentinel.classify` (existing authority) — **pass-through** — its verdict is unchanged; this change only routes the verdict to an action on a path that previously ignored it.
+- `/internal/telegram-forward` routing decision — **modify** — adds an emergency-stop/pause short-circuit before the existing `onTopicMessage`/registry-inject routing. Normal messages are unaffected.
+- Session kill / pause / autonomous-clear — **pass-through** — reuses `onSentinelKillSession`, `onSentinelPauseSession`, `stopAutonomousTopic` exactly as the `processUpdate` path does.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+Only messages the sentinel classifies as `emergency-stop` or `pause` are intercepted (not routed to the session). That is the intended behavior and matches the already-live `processUpdate` path. The classifier's own over-block surface is unchanged (live-tested: a long sentence merely containing "stop" → `normal`, routed normally). A false-positive emergency-stop would terminate the session — but (a) the classifier already gates this with word-count + exact/regex/LLM disambiguation, and (b) the user can simply send a new message to respawn; no data loss (resume UUID is saved by `onSentinelKillSession`). No new over-block beyond what `processUpdate` already exhibits.
+
+---
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+- A genuinely-wedged classifier (LLM provider down) → fail-open → the emergency-stop is NOT honored (message routes normally). This is the deliberate trade: never block delivery. The deterministic exact/regex patterns ("stop", "cancel", "halt") do not require the LLM, so the most common emergency phrasings still classify without a provider.
+- Non-Telegram lifeline paths (none currently) would need the same treatment.
+- This change does not address the still-dark `processUpdate`-only assumption for any *other* per-message safety hook; scope is the sentinel only.
+
+---
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. The smart authority (`MessageSentinel`, LLM + deterministic patterns) already exists and already owns the decision. This change is pure routing: it ensures the authority's verdict reaches the action on the server-side ingress path that lifeline-owned agents use. It does not re-implement classification (would be the wrong layer); it consumes the existing authority's output. It places the intercept at the server route layer — the correct single choke-point for the lifeline path, mirroring where `processUpdate` sits for the adapter-poll path.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** docs/signal-vs-authority.md
+
+- [x] No — this change produces no new block/allow logic; it routes an existing smart-gate (`MessageSentinel`, LLM-backed with deterministic patterns) verdict to its action.
+
+The sentinel remains the sole authority. The forward route is a consumer of its verdict, not a new detector. No brittle logic gains blocking authority. (And the action is fail-open: a classifier error degrades to normal delivery, never to a wrong block.)
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The new block runs AFTER the version-handshake (426/400 still short-circuit first) and BEFORE message logging + `onTopicMessage` routing. It does not shadow the handshake. It intentionally shadows routing for emergency-stop/pause (that's the point) — confirmed `logInboundMessage` is skipped for intercepted messages, which is acceptable (an emergency-stop need not be logged as a conversational turn; the kill is logged to the server log).
+- **Double-fire:** For lifeline-owned agents, `processUpdate` does not run, so there is no double-intercept. For adapter-poll agents, the forward route is not used, so again no double-fire. The two paths are mutually exclusive per deployment mode. No agent runs both for the same message.
+- **Races:** `onSentinelKillSession` already encapsulates resume-UUID save + kill (its existing concurrency behavior is unchanged). `stopAutonomousTopic` is idempotent (best-effort, try/catch). Session resolution reads the registry file read-only.
+- **Feedback loops:** None. The intercept terminates routing; it does not feed back into the sentinel.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on same machine:** none — server-local route logic.
+- **Install base:** ships to every agent via the normal server build. Adapter-poll agents are unaffected (path unused); lifeline-owned agents gain the (intended) emergency-stop. No agent-installed file (hook/config/template) changes → no `PostUpdateMigrator` work.
+- **External systems:** on emergency-stop/pause the route now sends one Telegram message ("Session terminated." / "Session paused." / "No active session to stop."), matching the `processUpdate` user-facing copy. No new external endpoints.
+- **Persistent state:** none added. Reads `topic-session-registry.json` read-only; `onSentinelKillSession` writes the resume-UUID map exactly as today.
+- **Response shape:** the route now may return `{ ok:true, sentinel:'emergency-stop'|'pause', killed|paused }` instead of `{ ok:true, forwarded:true }` for intercepted messages. The lifeline treats any 200 as delivered; the new fields are additive and ignored by existing callers.
+
+---
+
+## 7. Rollback cost
+
+Pure code change in one route, fail-open by design. Back-out = revert the block; behavior returns to current (sentinel dark on the forward path). No persistent state, no schema, no migration, no agent-state repair. The fail-open guarantee means even a bug in the block degrades to "behaves like today" (message routes), never to blocked delivery — so the rollback urgency is low even if a defect ships.
+
+## Conclusion
+
+The review produced no design changes — the fix is a faithful port of the already-tested `processUpdate` intercept to the lifeline ingress path, consuming the existing sentinel authority, fail-open. The only behavioral change is that emergency-stop/pause now fire for lifeline-owned agents, which is the intended P0 safety fix. Integration tests cover both sides of every boundary (kill/pause/normal/fail-open/no-session) plus a wiring-integrity assertion that classification precedes routing (the guard whose absence caused the original drift). Clear to ship. Live end-to-end verification (real Telegram "stop everything" terminating a real session) occurs post-deploy, since it requires the merged build running; pre-merge proof is the integration suite exercising the real route handler.
+
+---
+
+## Second-pass review (if required)
+
+Not required — single localized, fail-open route addition with full test coverage and no new decision logic.
+
+---
+
+## Evidence pointers
+
+- Reproduction (pre-fix): live `POST /sentinel/classify` returns `emergency-stop` for "stop everything"; code trace shows `/internal/telegram-forward` (the live path for lifeline-owned echo) had zero sentinel references → message routed as normal.
+- Post-fix proof: `tests/integration/telegram-forward-sentinel-intercept.test.ts` — 6/6 green (emergency-stop kills + not-routed; pause; normal-routes; fail-open-routes; no-session; wiring-integrity classify-before-route).


### PR DESCRIPTION
## P0 safety fix

**"stop everything" was not honored for lifeline-owned-polling agents** (e.g. echo). The `MessageSentinel` emergency-stop/pause intercept lived only in `TelegramAdapter.processUpdate()` — the adapter's own poll loop — which lifeline-owned agents never run. Their inbound arrives via the lifeline → `POST /internal/telegram-forward`, which had **zero** sentinel references, so an emergency-stop was delivered to the session as normal text and nothing structurally halted a running (or wedged, mid-tool-call) session.

Verified to the data-flow tier: the classifier itself works (`"stop everything"` → `emergency-stop`); the gap was purely *where* the intercept was wired.

## The fix

Wire the same emergency-stop/pause intercept into `/internal/telegram-forward`, **fail-open** (a sentinel error never blocks message delivery), reusing the existing `onSentinelKillSession`/`onSentinelPauseSession` callbacks + `stopAutonomousTopic`. No new kill logic. The `processUpdate` intercept is unchanged (still serves adapter-poll agents).

## Tests

- New `tests/integration/telegram-forward-sentinel-intercept.test.ts` — 6/6 green: emergency-stop kills + not-routed; pause; normal routes untouched; **fail-open** (throwing sentinel still delivers); no-active-session acknowledges.
- **Wiring-integrity** assertion that the forward route classifies *before* routing — the guard whose absence caused the original drift.
- Full forward-route suite green (no regression); typecheck clean.

## Docs / process

- Spec: `docs/specs/emergency-stop-forward-path-wiring.md` (approved by Justin, Telegram topic 12702) + ELI16 companion.
- Side-effects review: `upgrades/side-effects/emergency-stop-forward-path-wiring.md`.
- Release notes: `upgrades/NEXT.md` (v1.2.72).

Pure server-side route logic — ships to every agent on the normal server update; no agent-installed file changes (no migration). Fail-open by design: worst case of a bug is "behaves like today."

🤖 Generated with [Claude Code](https://claude.com/claude-code)