### PR TITLE
docs(specs): built-but-dark spec set — Liveness Reconciler, activation-coherence, stop-gate completion (DRAFTS, for review)

### DIFF
--- a/docs/specs/built-but-dark-liveness-reconciler.eli16.md
+++ b/docs/specs/built-but-dark-liveness-reconciler.eli16.md
@@ -1,0 +1,34 @@
+# Built-but-Dark Liveness Reconciler — the plain-English version
+
+## The problem in one breath
+
+We keep building features all the way — design them, code them, test them, merge them — and then forget to actually switch them on. The code is there. The lights are off. And nobody notices, sometimes for months.
+
+We caught this happening twice in one feature: a safety system meant to stop me from quitting work early was fully built on the server side... but the wire connecting it to the actual "I'm stopping now" moment was never run, and its on-switch doesn't even exist yet. A *second* backup for the same problem is also sitting there switched off. Two finished safety nets, both unplugged.
+
+## Why our existing checks didn't catch it
+
+We have a lot of safety checks — but every one of them runs while we're *building* a feature, and only if someone remembers to add it. It's like a house where every appliance has its own inspection sticker, but nobody ever walks through the finished house flipping switches to confirm the lights come on. We've never had that walkthrough.
+
+## What we're building
+
+A **Liveness Reconciler**: an automatic walkthrough. Once a week it goes down the list of every feature and asks four quick questions — does it exist, is it real (not a stub), is it actually plugged in, and is it actually doing anything? Then it labels each one:
+
+- **Live** — working, leave it alone.
+- **Dark** — built but switched off (the bug we hit).
+- **Hollow** — switched on but never actually used.
+- **Deploy-lag** — finished in the code but not in the version that's really running.
+
+## The important part: it won't nag you
+
+Justin's rule: this must NOT bury you in notifications. So the reconciler asks one more question before it ever bothers you — *"is there a recorded reason this is off?"* If you turned something off on purpose and we wrote down when and why, it stays quiet forever. It only speaks up about things that are off with **no explanation on record** — and even then, only if it's new, only if it's safety-critical, and all of them bundled into a single message instead of a pile.
+
+The great news: the "list of past decisions" this needs is **already about 70% built**. We have a little database that already tracks what's been offered, declined, and turned off — and it already knows to stop asking after you've said no a few times. We just point the new walkthrough at it and fill three small gaps: always record *why* something was turned off, widen what it tracks beyond just opt-in features, and have something actually read it.
+
+## How you'll experience it
+
+Normally: silence. Occasionally: one tidy message — "heads up, this safety feature is off and there's no note saying why." You answer once ("I turned that off because…"), we write it down, and it never asks again. Everything else just sits quietly on a dashboard page you can check whenever. Bonus: that page becomes the answer to "wait, why is this turned off?" — a real recorded reason instead of a shrug.
+
+## Proof it works
+
+It isn't finished until it can look at the two switched-off safety nets we already found and correctly shout "these are dark!" If it can't catch the exact bugs that inspired it, it failed.

--- a/docs/specs/built-but-dark-liveness-reconciler.eli16.md
+++ b/docs/specs/built-but-dark-liveness-reconciler.eli16.md
@@ -31,4 +31,18 @@ Normally: silence. Occasionally: one tidy message — "heads up, this safety fea
 
 ## Proof it works
 
-It isn't finished until it can look at the two switched-off safety nets we already found and correctly shout "these are dark!" If it can't catch the exact bugs that inspired it, it failed.
+It isn't finished until it can look at the two switched-off safety nets we already found and correctly shout "these are dark!" — AND, on that same first run, stay completely quiet about the hundred-plus things that are off perfectly on purpose. If it can't catch the exact bugs that inspired it without burying them in false alarms, it failed.
+
+## What the review round caught (and how we fixed it)
+
+I had several independent reviewers tear into the first draft. They found a genuinely serious problem: as first written, the walkthrough would have flooded you on its very first run. The repo has well over a hundred things that are switched "off" — but most of them are off *correctly* (optional features you simply haven't asked for, plus a pile of design documents that aren't features at all). The first draft would have flagged all of them as "dark," dumped them in your lap, and called it a day. That's the exact flood you said to avoid.
+
+Two fixes close that hole:
+
+1. **Tell apart "off on purpose" from "off by mistake."** Every feature now declares what it's *supposed* to be: a thing that must always be running (a safety net), or a thing that's correctly off until you ask for it (an optional extra). Only the first kind, when it's off, is ever a problem worth raising. Optional-and-off is just... fine, and stays silent.
+
+2. **Draw a line in the sand on day one.** The first time the walkthrough runs, it takes a snapshot and accepts the current state as the baseline — so it doesn't drag you through years of history at once. From then on it only speaks up about things that *change* or that we've explicitly marked as "this one really needs finishing" (like our two switched-off safety nets).
+
+They also caught that the first draft leaned on *me remembering* to write down why something got turned off — which is exactly the kind of "rely on willpower" mistake we're not allowed to make. Fixed: turning something off now *requires* a reason at the moment you do it, so there's nothing for me to forget.
+
+Honest caveat: all my reviewers were Claude-family. The outside opinions (other AI models) sometimes catch things we don't, so I'd recommend one more review round with those before you give the final yes.

--- a/docs/specs/built-but-dark-liveness-reconciler.md
+++ b/docs/specs/built-but-dark-liveness-reconciler.md
@@ -1,0 +1,155 @@
+---
+title: "Built-but-dark Liveness Reconciler — automate verify-claim across the whole feature surface, ledger-informed, flood-free"
+slug: built-but-dark-liveness-reconciler
+status: draft
+approved: false
+date: 2026-05-24
+author: echo
+eli16-overview: built-but-dark-liveness-reconciler.eli16.md
+---
+
+# Built-but-dark Liveness Reconciler
+
+## One-paragraph summary
+
+Instar repeatedly ships features that are fully spec'd, coded, tested, and merged — and then never wired into runtime, never enabled in config, or never deployed. The context-death stop-gate is a caught-red-handed instance: the server authority shipped but its hook client and its activation never did, and **nothing noticed for months**. Every existing guard against this (`feature-delivery-completeness` three-legged-stool test, per-component wiring tests, `capabilities-discoverability` lint, E2E "feature is alive" tests, the manual `verify-claim` skill) runs at **build time, per-feature, opt-in**. None is a **runtime, fleet-wide, automatic** reconciler. This spec adds the **Liveness Reconciler**: a scheduled job + `/liveness` endpoint that automates the `verify-claim` 4-tier protocol (existence → substantive → wired → data-flow) across the entire declared feature surface, classifies each feature `VERIFIED` / `DARK` / `HOLLOW` / `DEPLOY-LAG`, and surfaces **only dark features that are unexplained and new** — where "explained" is defined by the **existing `FeatureRegistry` decision ledger** (`discovery.db` + `discovery-events.jsonl`), which already carries server-enforced anti-flood machinery (`MAX_DECLINES`, cooldowns, version-aware re-surfacing). The reconciler never mutates anything (detect-and-surface only; signal-vs-authority). Steady state is silent.
+
+## Problem
+
+On 2026-05-24 (topic 12702), Justin flagged a recurring gravity well: "fully spec'd and built features that either never get deployed or never turn on." Investigation confirmed it with a live example — the context-death stop-gate (`context-death-pitfall-prevention.md`, approved 2026-04-17): server-side `UnjustifiedStopGate` + `StopGateDb` + `/internal/stop-gate/*` routes + `instar gate` CLI all landed, but the hook-router client was never integrated (zero callers), no `unjustifiedStopGate` config dial exists, and it was never flipped past `mode=off`. A second, independent defense for the same hazard (`response-review.js` / CoherenceGate `responseReview` with `B15_CONTEXT_DEATH_STOP`) is *also* dark — file on disk, not in `settings.json Stop[]`, flag absent. Two complete defenses, both off, for months, with no alarm.
+
+Justin's framing requirement: the solution must be **robust but must NOT flood the user with notifications they have to handle**, and should leverage a **ledger of past decisions** (e.g. "the user purposefully disabled this on date X because Y") so the system can make an informed call about whether something is even worth raising.
+
+## Evidence
+
+1. **Live dark feature #1:** context-death stop-gate, server half shipped (commits #54, #56, `42cb9eeef`), hook client never wired (`grep` over `.claude/`, `src/data/`, `src/templates/`, `src/scaffold/` → zero callers of `/internal/stop-gate/evaluate`), `StopGateDb` eval events = 0.
+2. **Live dark feature #2:** `response-review.js` written to disk by `PostUpdateMigrator.ts:1428`, absent from `settings.json Stop[]` (`grep -c` = 0), `responseReview.enabled` absent from config.
+3. **Guard inventory (all build-time / opt-in):** `tests/unit/feature-delivery-completeness.test.ts` (init↔migrator↔docs parity), `tests/integration/*-wiring.test.ts` (per-component DI), `tests/unit/capabilities-discoverability.test.ts` (route-prefix classification), `tests/e2e/*-lifecycle.test.ts` (Phase-1 "alive"), `.claude/skills/verify-claim/SKILL.md` (manual). **No runtime fleet-wide reconciler exists.**
+4. **Ledger substrate already exists:** `src/core/FeatureRegistry.ts` persists `FeatureState` in `discovery.db` (SQLite) + append-only `state/discovery-events.jsonl` (`DiscoveryEvent`: timestamp/userId/featureId/previousState/newState/trigger/surfacedAs/context), with `MAX_DECLINES=3` (permanent quiet), `cooldownAfterSurfaceMs`/`cooldownAfterDeclineMs`, `declinedAtVersion` (version-aware re-surfacing), `VALID_TRANSITIONS` state machine, and `ConsentRecord` for high-tier activations.
+
+## Root cause
+
+We treat "merged with green CI" as the **authority** on whether a feature is alive. It is only a **signal** — it proves the code and its tests exist, not that the feature is wired, enabled, deployed, and flowing data. The `verify-claim` skill encodes the right four-tier check, but it is manual and per-claim, so it is only ever run when someone already suspects a problem. There is no continuous, whole-surface authority that reconciles *declared intent* against *runtime reality*. Without one, a feature that passes its own tests but is never switched on is invisible.
+
+## Non-goals
+
+- **Not** auto-remediation. The reconciler never edits config, settings, or hooks (posture A; see § Handling posture). Auto-fixing is a possible future spec, earned only after the detector is trusted.
+- **Not** a parallel ledger. We reuse `FeatureRegistry`'s `discovery.db` + `discovery-events.jsonl`. Inventing a second decision store would fork the truth.
+- **Not** a notifier that nags. Surfacing is gated by the existing anti-flood machinery plus this spec's suppression layers. Steady state is silent.
+- **Not** a security boundary. Like the parent stop-gate, this is drift/oversight correction, not adversarial defense.
+- **Not** a replacement for the build-time guards. It is the runtime backstop that catches what they miss (the activation/deployment gap downstream of merge).
+
+## Design constraints
+
+1. **Flood-free by construction (Justin's hard requirement).** A finding reaches the user only if it is dark AND unexplained AND new AND severity-warranted, after coalescing. Explained darkness (a recorded decision) is silent forever.
+2. **Ledger-informed, not ledger-duplicating.** Reuse `FeatureRegistry`. Extend its subject set and guarantee a reason is captured; do not build a second store.
+3. **Detect-only authority.** The reconciler is a signal/visibility surface. It never mutates runtime state. (Signal-vs-authority: detector signals; the human, or a future explicitly-approved gate, acts.)
+4. **Near-silent (CLAUDE.md notification standard).** Routine "all live" status goes to a pull surface (`/liveness`, dashboard), never pushed. Only safety-category unexplained-dark is pushed, coalesced into one digest.
+5. **Cheap.** Reconciliation is mostly deterministic (filesystem + git + route table + SQLite row counts). LLM use is optional and bounded (only for fuzzy spec↔capability matching, with a daily cap), so the steady-state cost is ~zero.
+
+## Design
+
+### Three sources of truth, reconciled
+
+For every **declared feature**, the reconciler gathers three independent readings and combines them via the `verify-claim` tiers:
+
+| Source | verify-claim tier | Question | Where it reads |
+|---|---|---|---|
+| **Intent** — what *should* be live | Existence / Substantive | "Is this declared and real?" | approved `docs/specs/*.md` (frontmatter `status: approved`), `FeatureDefinitions`, built-in hook files on disk, built-in skills |
+| **Wiring** — is it plugged in? | Wired | "Constructed / registered / mounted / referenced?" | `CapabilityIndex` (`enabled`, non-null `ctx.X`), `settings.json` hook registration, mounted route prefixes, sentinels started in server startup |
+| **Activation & flow** — is it doing anything? | Data-flow | "Flag on? Ever exercised?" | config flags, event/row counts (e.g. `StopGateDb` eval rows, review history, `lastSurfacedAt`, last-exercised timestamps) |
+
+### Status taxonomy (mirrors verify-claim's status set)
+
+- **VERIFIED** — declared + wired + enabled + has flow.
+- **DARK** — declared + substantive (file/class/route exists) but **not wired** OR **flag-off**. (Both stop-gate instances.)
+- **HOLLOW** — wired + enabled but **zero flow ever** (never exercised; the verify-claim "HOLLOW" status).
+- **DEPLOY-LAG** — present/merged in source but not reflected in the running artifact (e.g. merged to `main` but `npm view instar version` / running version behind, or a migration that writes a file but never registers it).
+
+### The decision ledger (reuse + close three gaps)
+
+The reconciler's "explained?" question is answered by `FeatureRegistry`. Three targeted extensions:
+
+1. **Guarantee a reason + timestamp on every off-decision (Justin's "note of when and why").**
+   - Make `DiscoveryEvent` require a non-empty reason when `newState ∈ {declined, disabled}` (today `context` is optional). Server rejects an off-transition with no reason.
+   - When a user disables a feature **conversationally** ("turn off X because Y"), the agent records the reason into the ledger via the feature's `disableAction` path (or a new `POST /features/:id/decision` carrying `{state, reason, actor, topicId}`). This is the agent's responsibility, enforced by the same grounding discipline as other user-facing state writes.
+2. **Extend the subject set beyond opt-in `FeatureDefinitions`.** Today the ledger tracks user-facing opt-in features. Add ledger subjects for the other dark classes — unwired hooks, undeployed/lagging code, hollow capabilities — keyed by a stable `subjectId` (e.g. `hook:response-review`, `capability:unjustifiedStopGate`, `route:/internal/stop-gate/evaluate`). These reuse the same `discovery.db` + `discovery-events.jsonl` + state machine + anti-flood counters.
+3. **Reconciler writes its own dispositions back.** When a finding is surfaced and the user responds, that response is recorded as a ledger decision (declined/disabled-with-reason, or acknowledged), so the existing `MAX_DECLINES`/cooldown/version-aware machinery suppresses re-surfacing automatically.
+
+### Surfacing pipeline — five suppression layers (flood-free)
+
+A finding passes through, in order; failing any layer means it stays silent:
+
+1. **Explained-darkness filter (the keystone).** Consult the ledger for the `subjectId`. If state ∈ {declined, disabled} **with a recorded reason**, OR `declineCount ≥ MAX_DECLINES` → silent forever. If declined but the feature's version changed since `declinedAtVersion` → eligible (rare).
+2. **Novelty filter.** Diff against the previous reconciliation run (persisted). Only newly-dark or newly-escalating subjects pass; steady-state re-confirmation is silent.
+3. **Severity gate.** Severity derived from `FeatureDefinitions.category`: `safety`-category unexplained-dark = critical; others = informational. Only critical is eligible to **push** (Telegram); the rest land on the pull surface (dashboard `/liveness`, Attention Queue at low priority).
+4. **Coalescing.** If multiple subjects qualify in one run, emit **one** consolidated digest (Attention Queue entry + at most one Telegram message), never N messages (the same fix applied to the sentinel topic-spam flood — CLAUDE.md § Sentinel Notifications).
+5. **Acknowledge-once.** Surfacing writes a pending-decision marker; any user response resolves it into a ledger decision → it will not re-surface (layer 1 then suppresses it).
+
+**Net user experience:** normally nothing. You are pinged about a feature at most once — only if it is genuinely dark, has no decision on record, is new, and is safety-relevant — and your answer ("I turned that off because…") is recorded so it never asks again. Everything else is a quiet line on the dashboard. The ledger doubles as institutional memory: "why is X off?" has a recorded answer.
+
+### Mechanism
+
+- **`LivenessReconciler` core class** (`src/monitoring/`). Pure-ish: takes a snapshot of intent/wiring/activation, returns a classified report. Deterministic except for optional bounded LLM spec↔capability fuzzy-matching (daily-capped, fail-open to "unmatched → flag for human" rather than silent-drop).
+- **`/liveness` endpoint** (`GET`, authed) — returns the latest report `{ subjectId, status, severity, explained, lastDecision, evidence }[]`. Phase-1 "alive" E2E asserts 200, not 503.
+- **Scheduled job** (weekly default; `instar`-job declarative def) runs the reconciler, diffs against the prior run, applies the five-layer pipeline, writes dispositions. Reuses the existing job scheduler + `supervision: tier1` (Haiku validates the surfacing decision before any push — LLM-Supervised Execution standard).
+- **Dashboard "Liveness" tab** — the pull surface; lists every subject with status + last decision + reason. This is where "explained" darkness lives visibly without ever pinging.
+- **CLI** `instar liveness [--since] [--status dark]` — operator view; shares the report.
+
+### Dogfood gate (non-negotiable)
+
+The reconciler is **not done** until, run against the current tree, it:
+1. Classifies the context-death stop-gate (`/internal/stop-gate/evaluate` route exists, zero callers, `StopGateDb` empty) as **DARK / unexplained** and surfaces it exactly once.
+2. Classifies `response-review.js` (on disk, not in `Stop[]`) as **DARK / unexplained**.
+3. After the rollout-completion spec wires the stop-gate and a decision is recorded, re-classifies it as **VERIFIED** (or explained) and goes silent.
+
+A detector that cannot catch the two bugs that motivated it has failed.
+
+## Rollout
+
+- **PR1: `LivenessReconciler` core + unit tests.** Intent/wiring/activation collectors; status classification; no surfacing yet. Unit tests cover both sides of each tier boundary (verify-claim parity).
+- **PR2: `/liveness` endpoint + Phase-1 E2E + dashboard tab + CLI.** Read-only surface. Integration test: route returns 200 with a real report.
+- **PR3: Ledger extensions.** Required-reason on off-transitions; extended subject set; `POST /features/:id/decision` (or reuse disableAction) for conversational reason capture. Migration parity for the `discovery.db` schema additions (idempotent). Wiring-integrity test that the reason is actually persisted.
+- **PR4: Surfacing pipeline (five layers) + scheduled job, observe-only.** Job runs and writes the report + dispositions but does **not** push; everything to the pull surface. Gather a few cycles of real data; confirm the dogfood gate (both dark gates flagged).
+- **PR5: Enable push for safety-category only.** Flip the severity-gate push for `safety` unexplained-dark, coalesced. Gated on: zero false-positive pushes across the observe-only cycles, dogfood gate green.
+
+Migration parity (CLAUDE.md standard) applies throughout: config defaults via `migrateConfig()`, job def installed for existing agents, `discovery.db` schema migration idempotent, any CLAUDE.md template capability section added per the Agent Awareness Standard.
+
+## Rollback
+
+- The reconciler mutates **no** runtime state, so disabling it is inert: remove/disable the scheduled job; `/liveness` becomes a stale-but-harmless read. Ledger extensions are additive (extra rows/columns), reversible by ignoring them. No feature is ever touched by this system, so there is no activation to revert.
+
+## Signal-vs-authority compliance
+
+| Component | Class | Mutates / blocks? | Notes |
+|---|---|---|---|
+| Intent/wiring/activation collectors | Detector | No | Deterministic readings. |
+| Status classifier | Detector | No | Maps readings → {VERIFIED,DARK,HOLLOW,DEPLOY-LAG}. |
+| Explained-darkness + 4 suppression layers | Detector | No | Decide whether to surface; never act on the feature. |
+| `FeatureRegistry` ledger | State | Appends decisions only | Reused; existing anti-flood authority. |
+| Tier1 supervisor (Haiku) on push | Authority (over the *message*) | Gates the notification only | Validates a push is warranted; cannot enable/disable any feature. |
+
+No component in this system enables, disables, wires, or deploys a feature. That authority remains with the human (or a future, separately-approved remediation spec).
+
+## Side-effects review
+
+- **Over-surface risk (the flood Justin fears):** mitigated structurally by five layers, dominated by the explained-darkness filter + the existing `MAX_DECLINES`/cooldown/version-aware machinery. Observe-only PR4 proves the false-positive rate before any push is enabled (PR5 gate).
+- **Under-surface risk (missing a real dark feature):** the deterministic collectors err toward flagging (unmatched spec→capability = flag, not silent-drop); HOLLOW/DEPLOY-LAG classes catch the subtler cases build-time guards miss.
+- **Ledger-poisoning / wrong-explanation:** decisions are append-only with actor + timestamp + reason; a stale "explained" can be re-opened by a version bump (version-aware re-surfacing) or an operator clearing the decision.
+- **Cost:** deterministic core ≈ free; optional LLM fuzzy-match daily-capped (target < $0.05/day). Weekly cadence.
+- **Interaction with build-time guards:** complementary, not redundant — they gate *merge*; this gates *liveness after merge*. The `feature-delivery-completeness` test remains the init↔migrator↔docs authority; the reconciler is the runtime backstop.
+
+## Success criteria
+
+- **Dogfood:** both dark gates correctly classified `DARK/unexplained`; after stop-gate rollout-completion + recorded decision, stop-gate re-classifies to `VERIFIED`/explained and goes silent.
+- **Flood-free:** across ≥4 observe-only weekly cycles, zero pushes for explained or repeat findings; ≤1 coalesced digest per cycle even with multiple findings.
+- **Coverage:** every approved spec maps to a reconciled subject (or is explicitly marked design-only/no-runtime-surface in the ledger).
+- **Silence at rest:** a fully-VERIFIED tree produces zero user-facing notifications.
+- **Institutional memory:** "why is feature X off?" answerable from the ledger for every disabled/declined subject (reason present).
+
+## Open questions (for /spec-converge)
+
+1. **Subject identity for non-FeatureDefinition classes.** Stable `subjectId` scheme for hooks/routes/capabilities so the ledger and reconciler agree across renames. (Proposed: `class:name`, with a rename-migration map.)
+2. **Spec↔capability matching.** Deterministic mapping table (spec frontmatter `slug` → capability key) vs bounded LLM fuzzy-match for un-mapped specs. Lean deterministic table + LLM only for the residual, fail-open to "flag for human."
+3. **DEPLOY-LAG detection fidelity.** How far to take the "merged ≠ published ≠ running" check (cheap: `UpdateChecker` version delta; richer: per-feature presence in the running build). Start cheap.
+4. **Cadence.** Weekly default vs event-triggered (post-merge / post-update hook). Start weekly; consider a post-update trigger later.

--- a/docs/specs/built-but-dark-liveness-reconciler.md
+++ b/docs/specs/built-but-dark-liveness-reconciler.md
@@ -1,155 +1,206 @@
 ---
-title: "Built-but-dark Liveness Reconciler — automate verify-claim across the whole feature surface, ledger-informed, flood-free"
+title: "Built-but-dark Liveness Reconciler — automate verify-claim across the whole feature surface, intent-modality-aware, baseline-anchored, flood-free"
 slug: built-but-dark-liveness-reconciler
 status: draft
 approved: false
 date: 2026-05-24
 author: echo
+review-iterations: 1
+review-convergence: "internal-multi-lens-2026-05-24 (architecture + standards + failure-modes + grounding); see reports/built-but-dark-liveness-reconciler-convergence.md"
 eli16-overview: built-but-dark-liveness-reconciler.eli16.md
 ---
 
 # Built-but-dark Liveness Reconciler
 
+> **Convergence note (iter-1 → this draft).** The first draft overclaimed reuse of three existing systems (`FeatureRegistry`, `CapabilityIndex`, runtime call signals) that do not hold the data it needs, and would have flooded on first run with 100+ false-positive "dark" findings. This revision adds the two missing architectural primitives the reviewers identified — an **intent-modality axis** (`should-be-live` vs `should-be-offerable`) and a **baseline anchor** — and replaces the FeatureRegistry-reuse story with a **dedicated `LivenessLedger` that reuses the anti-flood *patterns*** while keeping `FeatureRegistry` decisions as one (of several) explained-darkness inputs for the subjects it actually owns. Full findings + resolutions: `docs/specs/reports/built-but-dark-liveness-reconciler-convergence.md`.
+
 ## One-paragraph summary
 
-Instar repeatedly ships features that are fully spec'd, coded, tested, and merged — and then never wired into runtime, never enabled in config, or never deployed. The context-death stop-gate is a caught-red-handed instance: the server authority shipped but its hook client and its activation never did, and **nothing noticed for months**. Every existing guard against this (`feature-delivery-completeness` three-legged-stool test, per-component wiring tests, `capabilities-discoverability` lint, E2E "feature is alive" tests, the manual `verify-claim` skill) runs at **build time, per-feature, opt-in**. None is a **runtime, fleet-wide, automatic** reconciler. This spec adds the **Liveness Reconciler**: a scheduled job + `/liveness` endpoint that automates the `verify-claim` 4-tier protocol (existence → substantive → wired → data-flow) across the entire declared feature surface, classifies each feature `VERIFIED` / `DARK` / `HOLLOW` / `DEPLOY-LAG`, and surfaces **only dark features that are unexplained and new** — where "explained" is defined by the **existing `FeatureRegistry` decision ledger** (`discovery.db` + `discovery-events.jsonl`), which already carries server-enforced anti-flood machinery (`MAX_DECLINES`, cooldowns, version-aware re-surfacing). The reconciler never mutates anything (detect-and-surface only; signal-vs-authority). Steady state is silent.
+Instar repeatedly ships features that are fully spec'd, coded, tested, and merged — and then never wired into runtime, never enabled in config, or never deployed. The context-death stop-gate is the caught-red-handed instance: the server authority shipped but its hook client and activation never did, and nothing noticed for months. Every existing guard runs at **build time, per-feature, opt-in** (`feature-delivery-completeness`, per-component wiring tests, `capabilities-discoverability` lint, E2E "feature is alive" tests, the manual `verify-claim` skill) — none is a **runtime, fleet-wide, automatic** reconciler. This spec adds the **Liveness Reconciler**: a scheduled job + `/liveness` endpoint that classifies every subject in a **declared inventory** by `verify-claim`'s four tiers, but only treats "off/unwired" as a *defect* when the subject's **intent-modality is `should-be-live`** (a defense/infra feature that must run) — opt-in `should-be-offerable` features being correctly off is never a finding. A one-time **baseline anchor** marks the existing state as accepted so the first run is silent except genuine regressions. It surfaces only findings that are **unexplained, new, and severity-warranted**, coalesced, where "explained" is read from a purpose-built **`LivenessLedger`** (system-scoped, append-only, reusing the anti-flood patterns proven in `FeatureRegistry`: surface-caps, cooldowns, content-hash/version-aware re-surfacing) plus, for opt-in subjects it covers, `FeatureRegistry`'s existing decisions. The reconciler **mutates no feature** (detect-and-surface only; signal-vs-authority). Steady state is silent.
 
 ## Problem
 
-On 2026-05-24 (topic 12702), Justin flagged a recurring gravity well: "fully spec'd and built features that either never get deployed or never turn on." Investigation confirmed it with a live example — the context-death stop-gate (`context-death-pitfall-prevention.md`, approved 2026-04-17): server-side `UnjustifiedStopGate` + `StopGateDb` + `/internal/stop-gate/*` routes + `instar gate` CLI all landed, but the hook-router client was never integrated (zero callers), no `unjustifiedStopGate` config dial exists, and it was never flipped past `mode=off`. A second, independent defense for the same hazard (`response-review.js` / CoherenceGate `responseReview` with `B15_CONTEXT_DEATH_STOP`) is *also* dark — file on disk, not in `settings.json Stop[]`, flag absent. Two complete defenses, both off, for months, with no alarm.
+On 2026-05-24 (topic 12702), Justin flagged a recurring gravity well: "fully spec'd and built features that either never get deployed or never turn on." A live example confirmed it: the context-death stop-gate (`context-death-pitfall-prevention.md`, approved 2026-04-17) shipped its server half (`UnjustifiedStopGate` + `StopGateDb` + `/internal/stop-gate/*` routes + `instar gate` CLI, commits #54/#56/`42cb9eeef`) but the hook-router client was never integrated (zero callers of `/internal/stop-gate/evaluate`), no `unjustifiedStopGate` config dial exists, and it was never flipped past `mode=off`. A second, independent defense for the same hazard (`response-review.js` / CoherenceGate `responseReview` with `B15_CONTEXT_DEATH_STOP`) is *also* dark. Two complete defenses, both off, for months, no alarm.
 
-Justin's framing requirement: the solution must be **robust but must NOT flood the user with notifications they have to handle**, and should leverage a **ledger of past decisions** (e.g. "the user purposefully disabled this on date X because Y") so the system can make an informed call about whether something is even worth raising.
+Justin's hard requirement: **robust but must NOT flood the user with notifications they have to handle**, leveraging a **ledger of past decisions** ("the user purposefully disabled this on date X because Y") so the system makes an informed call about whether something is even worth raising.
 
 ## Evidence
 
-1. **Live dark feature #1:** context-death stop-gate, server half shipped (commits #54, #56, `42cb9eeef`), hook client never wired (`grep` over `.claude/`, `src/data/`, `src/templates/`, `src/scaffold/` → zero callers of `/internal/stop-gate/evaluate`), `StopGateDb` eval events = 0.
-2. **Live dark feature #2:** `response-review.js` written to disk by `PostUpdateMigrator.ts:1428`, absent from `settings.json Stop[]` (`grep -c` = 0), `responseReview.enabled` absent from config.
-3. **Guard inventory (all build-time / opt-in):** `tests/unit/feature-delivery-completeness.test.ts` (init↔migrator↔docs parity), `tests/integration/*-wiring.test.ts` (per-component DI), `tests/unit/capabilities-discoverability.test.ts` (route-prefix classification), `tests/e2e/*-lifecycle.test.ts` (Phase-1 "alive"), `.claude/skills/verify-claim/SKILL.md` (manual). **No runtime fleet-wide reconciler exists.**
-4. **Ledger substrate already exists:** `src/core/FeatureRegistry.ts` persists `FeatureState` in `discovery.db` (SQLite) + append-only `state/discovery-events.jsonl` (`DiscoveryEvent`: timestamp/userId/featureId/previousState/newState/trigger/surfacedAs/context), with `MAX_DECLINES=3` (permanent quiet), `cooldownAfterSurfaceMs`/`cooldownAfterDeclineMs`, `declinedAtVersion` (version-aware re-surfacing), `VALID_TRANSITIONS` state machine, and `ConsentRecord` for high-tier activations.
+1. Dark feature #1: context-death stop-gate — server half shipped, hook client never wired (`grep` over `.claude/`, `src/data/`, `src/templates/`, `src/scaffold/` → 0 callers of `/internal/stop-gate/evaluate`), `StopGateDb` eval events = 0. **`unjustifiedStopGate` is NOT a `FeatureDefinition`** (verified — 0 matches in `FeatureDefinitions.ts`).
+2. Dark feature #2: `response-review.js` written to disk by `PostUpdateMigrator.ts:1428`, absent from `settings.json Stop[]` (grep = 0), `responseReview.enabled` absent. **`response-review` IS a `FeatureDefinition`** (safety category) — so the two dogfood targets fall on opposite sides of the FeatureDefinition boundary, which the design must handle.
+3. Guard inventory (all build-time / opt-in): `tests/unit/feature-delivery-completeness.test.ts`, `tests/integration/*-wiring.test.ts`, `tests/unit/capabilities-discoverability.test.ts`, `tests/e2e/*-lifecycle.test.ts`, `.claude/skills/verify-claim/SKILL.md`. No runtime fleet-wide reconciler.
+4. Surface scale (verified): **194 spec files, ~128 `status: approved`**, **16 hooks**, **13 `FeatureDefinitions` (3 `safety`, mostly off-by-default opt-in)**. Most approved specs are standards/docs with **no runtime surface**. This scale is why naive "every off thing is dark" floods.
+5. Ledger substrate (verified, with limits): `FeatureRegistry` (`discovery.db` + `discovery-events.jsonl`) has `MAX_DECLINES=3`, cooldowns, `declinedAtVersion`, `VALID_TRANSITIONS`, `ConsentRecord`. **But:** it is gated on the 13-entry `definitions` map (`getState`/`transition` refuse unknown ids), is keyed per-`userId`, has no `undiscovered→disabled` edge, and its `DiscoveryEvent.context` is the only reason field and is **optional**. The boot-time config-sync path (`bootstrap()`) sets `disabled` with **no reason/actor**.
 
 ## Root cause
 
-We treat "merged with green CI" as the **authority** on whether a feature is alive. It is only a **signal** — it proves the code and its tests exist, not that the feature is wired, enabled, deployed, and flowing data. The `verify-claim` skill encodes the right four-tier check, but it is manual and per-claim, so it is only ever run when someone already suspects a problem. There is no continuous, whole-surface authority that reconciles *declared intent* against *runtime reality*. Without one, a feature that passes its own tests but is never switched on is invisible.
+We treat "merged with green CI" as the **authority** on whether a feature is alive. It is only a **signal**: it proves code + tests exist, not that the feature is wired, enabled, deployed, and flowing. `verify-claim` encodes the right four-tier check but is manual and per-claim. There is no continuous, whole-surface authority reconciling *declared intent* against *runtime reality* — and, crucially, no representation of **what kind of "live" a feature is supposed to be**, so "correctly off" and "wrongly dark" are indistinguishable.
 
 ## Non-goals
 
-- **Not** auto-remediation. The reconciler never edits config, settings, or hooks (posture A; see § Handling posture). Auto-fixing is a possible future spec, earned only after the detector is trusted.
-- **Not** a parallel ledger. We reuse `FeatureRegistry`'s `discovery.db` + `discovery-events.jsonl`. Inventing a second decision store would fork the truth.
-- **Not** a notifier that nags. Surfacing is gated by the existing anti-flood machinery plus this spec's suppression layers. Steady state is silent.
-- **Not** a security boundary. Like the parent stop-gate, this is drift/oversight correction, not adversarial defense.
-- **Not** a replacement for the build-time guards. It is the runtime backstop that catches what they miss (the activation/deployment gap downstream of merge).
+- **Not** auto-remediation. The reconciler never edits config/settings/hooks (posture A). Auto-fix is a future, separately-approved spec.
+- **Not** a security boundary. Drift/oversight correction, not adversarial defense.
+- **Not** a nagger. Surfacing is gated by intent-modality + baseline + the suppression layers. Steady state is silent.
+- **Not** a replacement for build-time guards. It is the runtime backstop downstream of merge.
+- **Not** a claim of detecting "zero callers" purely at runtime. See § "Honest scope of detection."
 
 ## Design constraints
 
-1. **Flood-free by construction (Justin's hard requirement).** A finding reaches the user only if it is dark AND unexplained AND new AND severity-warranted, after coalescing. Explained darkness (a recorded decision) is silent forever.
-2. **Ledger-informed, not ledger-duplicating.** Reuse `FeatureRegistry`. Extend its subject set and guarantee a reason is captured; do not build a second store.
-3. **Detect-only authority.** The reconciler is a signal/visibility surface. It never mutates runtime state. (Signal-vs-authority: detector signals; the human, or a future explicitly-approved gate, acts.)
-4. **Near-silent (CLAUDE.md notification standard).** Routine "all live" status goes to a pull surface (`/liveness`, dashboard), never pushed. Only safety-category unexplained-dark is pushed, coalesced into one digest.
-5. **Cheap.** Reconciliation is mostly deterministic (filesystem + git + route table + SQLite row counts). LLM use is optional and bounded (only for fuzzy spec↔capability matching, with a daily cap), so the steady-state cost is ~zero.
+1. **Flood-free by construction (hard requirement).** First run is silent except genuine regressions (baseline anchor). Steady state surfaces only `should-be-live` + dark + unexplained + new + severity-warranted, coalesced.
+2. **Intent-modality first.** "Off" is only a defect for `should-be-live` subjects. This is the primitive that collapses the 100+ cold-start false-positives to the small set that matters.
+3. **Detect-only authority.** The reconciler mutates no feature. (Signal-vs-authority.)
+4. **Structural reason-capture, never willpower.** A subject can become "explained" only through a structural path (API requires a reason; config-sync auto-stamps a synthetic reason). The reconciler NEVER assumes the agent remembered to record anything.
+5. **Honest reuse.** Reuse `FeatureRegistry` decisions for the FeatureDefinition subjects it owns; reuse the anti-flood *patterns* everywhere; build a dedicated store for non-FeatureDefinition subjects rather than overclaiming.
+6. **Cheap & deterministic.** Classification is filesystem/git/route-table/SQLite-count based. LLM use is bounded and optional.
+7. **The reconciler watches itself.** A liveness checker that can silently die is the ultimate built-but-dark; an independent heartbeat guards it.
 
 ## Design
 
-### Three sources of truth, reconciled
+### 1. The declared inventory + intent-modality (the keystone primitive)
 
-For every **declared feature**, the reconciler gathers three independent readings and combines them via the `verify-claim` tiers:
+The reconciler operates over a **declared inventory** of subjects. Each subject has a stable `subjectId` and an **intent-modality**:
 
-| Source | verify-claim tier | Question | Where it reads |
-|---|---|---|---|
-| **Intent** — what *should* be live | Existence / Substantive | "Is this declared and real?" | approved `docs/specs/*.md` (frontmatter `status: approved`), `FeatureDefinitions`, built-in hook files on disk, built-in skills |
-| **Wiring** — is it plugged in? | Wired | "Constructed / registered / mounted / referenced?" | `CapabilityIndex` (`enabled`, non-null `ctx.X`), `settings.json` hook registration, mounted route prefixes, sentinels started in server startup |
-| **Activation & flow** — is it doing anything? | Data-flow | "Flag on? Ever exercised?" | config flags, event/row counts (e.g. `StopGateDb` eval rows, review history, `lastSurfacedAt`, last-exercised timestamps) |
+- **`should-be-live`** — a defense, sentinel, safety hook, or infrastructure feature that is *supposed to be running* whenever the agent is up. Dark = defect. (e.g. the context-death stop-gate, `response-review` stop-hook, monitoring sentinels.)
+- **`should-be-offerable`** — an opt-in feature that is *correctly off until the user asks for it*. Off = working as designed; **never a finding** on the off-axis. (e.g. Threadline relay, tunnel, evolution auto-apply, named tunnel.)
+- **`design-only`** — a spec/standard/doc with no runtime surface. Excluded from liveness entirely.
 
-### Status taxonomy (mirrors verify-claim's status set)
+**How modality is assigned (deterministic, opt-in, no manual treadmill):**
+- A spec declares its runtime surface in frontmatter: `runtime-surface: <subjectId>` (+ `runtime-modality: live|offerable`). **Absence ⇒ `design-only` ⇒ silent.** This *inverts the dangerous default* the reviewers flagged: a spec is a liveness subject only if it opts in. The 100+ doc/standard specs never surface.
+- For `FeatureDefinitions`: modality derives from `consentTier` — `consentTier ∈ {network, self-governing}` (consent-required, opt-in) ⇒ `should-be-offerable`; otherwise the feature's spec must mark it `live` explicitly. (No silent promotion to `should-be-live`.)
+- For hooks/routes/sentinels not backed by a FeatureDefinition: an explicit, version-controlled **`liveness-manifest`** (`src/data/liveness-subjects.ts`) enumerates `should-be-live` infra subjects with their `subjectId`, severity, and the wiring/activation probes that prove them live. This manifest is small, reviewed, and is itself covered by `feature-delivery-completeness`-style parity (adding a sentinel/safety-hook requires adding its liveness entry — enforced by a test).
 
-- **VERIFIED** — declared + wired + enabled + has flow.
-- **DARK** — declared + substantive (file/class/route exists) but **not wired** OR **flag-off**. (Both stop-gate instances.)
-- **HOLLOW** — wired + enabled but **zero flow ever** (never exercised; the verify-claim "HOLLOW" status).
-- **DEPLOY-LAG** — present/merged in source but not reflected in the running artifact (e.g. merged to `main` but `npm view instar version` / running version behind, or a migration that writes a file but never registers it).
+Only `should-be-live` subjects can ever produce an off-axis finding. `should-be-offerable` subjects are tracked for HOLLOW/regression only (see taxonomy).
 
-### The decision ledger (reuse + close three gaps)
+### 2. Three reconciled readings (verify-claim tiers) — with corrected sources
 
-The reconciler's "explained?" question is answered by `FeatureRegistry`. Three targeted extensions:
+For each subject, gather three independent readings:
 
-1. **Guarantee a reason + timestamp on every off-decision (Justin's "note of when and why").**
-   - Make `DiscoveryEvent` require a non-empty reason when `newState ∈ {declined, disabled}` (today `context` is optional). Server rejects an off-transition with no reason.
-   - When a user disables a feature **conversationally** ("turn off X because Y"), the agent records the reason into the ledger via the feature's `disableAction` path (or a new `POST /features/:id/decision` carrying `{state, reason, actor, topicId}`). This is the agent's responsibility, enforced by the same grounding discipline as other user-facing state writes.
-2. **Extend the subject set beyond opt-in `FeatureDefinitions`.** Today the ledger tracks user-facing opt-in features. Add ledger subjects for the other dark classes — unwired hooks, undeployed/lagging code, hollow capabilities — keyed by a stable `subjectId` (e.g. `hook:response-review`, `capability:unjustifiedStopGate`, `route:/internal/stop-gate/evaluate`). These reuse the same `discovery.db` + `discovery-events.jsonl` + state machine + anti-flood counters.
-3. **Reconciler writes its own dispositions back.** When a finding is surfaced and the user responds, that response is recorded as a ledger decision (declined/disabled-with-reason, or acknowledged), so the existing `MAX_DECLINES`/cooldown/version-aware machinery suppresses re-surfacing automatically.
+| Reading | verify-claim tier | Source (corrected per grounding review) |
+|---|---|---|
+| **Intent** | Existence / Substantive | declared inventory: opt-in spec `runtime-surface` + `liveness-manifest` + `FeatureDefinitions`. Artifact existence on disk + non-stub check. |
+| **Wiring** | Wired | a **dedicated wiring snapshot** the reconciler builds: route-table dump **including `/internal/*`** (CapabilityIndex excludes those, so it is NOT the wiring authority — it is at most one hint), `settings.json` hook registration, and a server-startup **construction registry** (components register themselves at construction so "constructed?" is a runtime fact, not a guess). |
+| **Activation & flow** | Data-flow | config flag state; feature-specific activity counters where they exist (e.g. `StopGateDb` eval-event count — add a `countEvents()` accessor; `FeatureRegistry.lastSurfacedAt`); a **lightweight per-route invocation counter** (new, see § honest scope) for the wired-but-never-called case. |
 
-### Surfacing pipeline — five suppression layers (flood-free)
+### 3. Honest scope of detection
 
-A finding passes through, in order; failing any layer means it stays silent:
+There is no global per-route call tracker today (verified). Two honest moves:
+- **Add a minimal invocation counter** to the route layer (a single in-memory `Map<routePrefix, {count, lastAt}>` flushed periodically to the liveness store). This makes "wired-but-never-called" a genuine runtime signal for routes that opt into counting (cheap; safety/`should-be-live` routes opt in).
+- **Where a runtime signal is unavailable**, the wiring reading falls back to a **static reference scan** (does any hook/script/settings entry reference this subject?). This is acknowledged as static analysis run *continuously over the whole surface* — still strictly more than the opt-in/per-feature build-time guards, but the spec does **not** claim it is a runtime signal. The status carries a `evidenceKind: runtime|static` field so consumers know.
 
-1. **Explained-darkness filter (the keystone).** Consult the ledger for the `subjectId`. If state ∈ {declined, disabled} **with a recorded reason**, OR `declineCount ≥ MAX_DECLINES` → silent forever. If declined but the feature's version changed since `declinedAtVersion` → eligible (rare).
-2. **Novelty filter.** Diff against the previous reconciliation run (persisted). Only newly-dark or newly-escalating subjects pass; steady-state re-confirmation is silent.
-3. **Severity gate.** Severity derived from `FeatureDefinitions.category`: `safety`-category unexplained-dark = critical; others = informational. Only critical is eligible to **push** (Telegram); the rest land on the pull surface (dashboard `/liveness`, Attention Queue at low priority).
-4. **Coalescing.** If multiple subjects qualify in one run, emit **one** consolidated digest (Attention Queue entry + at most one Telegram message), never N messages (the same fix applied to the sentinel topic-spam flood — CLAUDE.md § Sentinel Notifications).
-5. **Acknowledge-once.** Surfacing writes a pending-decision marker; any user response resolves it into a ledger decision → it will not re-surface (layer 1 then suppresses it).
+### 4. Status taxonomy (mutually exclusive, with precedence)
 
-**Net user experience:** normally nothing. You are pinged about a feature at most once — only if it is genuinely dark, has no decision on record, is new, and is safety-relevant — and your answer ("I turned that off because…") is recorded so it never asks again. Everything else is a quiet line on the dashboard. The ledger doubles as institutional memory: "why is X off?" has a recorded answer.
+Evaluated in order; first match wins:
 
-### Mechanism
+1. **DESIGN-ONLY** — no runtime surface. Excluded.
+2. **INTENTIONALLY-OFF** — `should-be-offerable` + off. Correct by design; not a finding (tracked only for later HOLLOW once enabled).
+3. **DARK** — `should-be-live` + (not wired OR flag-off). **Defect.** (Both stop-gate instances.)
+4. **HOLLOW** — wired + enabled but zero flow where flow is *expected*. Requires an **`expects-flow` predicate** per subject (a sentinel that fires only on failure legitimately has zero flow → not HOLLOW; it sets `expects-flow: on-trigger-only`).
+5. **DEPLOY-LAG** — **demoted to a single global advisory**, not per-feature: `UpdateChecker` only exposes one installed-vs-published version delta (verified), so DEPLOY-LAG is one informational line ("running vX, latest vY"), never per-subject.
+6. **VERIFIED** — declared + wired + enabled + flow-as-expected.
 
-- **`LivenessReconciler` core class** (`src/monitoring/`). Pure-ish: takes a snapshot of intent/wiring/activation, returns a classified report. Deterministic except for optional bounded LLM spec↔capability fuzzy-matching (daily-capped, fail-open to "unmatched → flag for human" rather than silent-drop).
-- **`/liveness` endpoint** (`GET`, authed) — returns the latest report `{ subjectId, status, severity, explained, lastDecision, evidence }[]`. Phase-1 "alive" E2E asserts 200, not 503.
-- **Scheduled job** (weekly default; `instar`-job declarative def) runs the reconciler, diffs against the prior run, applies the five-layer pipeline, writes dispositions. Reuses the existing job scheduler + `supervision: tier1` (Haiku validates the surfacing decision before any push — LLM-Supervised Execution standard).
-- **Dashboard "Liveness" tab** — the pull surface; lists every subject with status + last decision + reason. This is where "explained" darkness lives visibly without ever pinging.
-- **CLI** `instar liveness [--since] [--status dark]` — operator view; shares the report.
+### 5. The LivenessLedger (dedicated; reuses anti-flood patterns)
 
-### Dogfood gate (non-negotiable)
+A purpose-built, **system-scoped** (no per-user key), append-only ledger — a new table in `discovery.db` (sharing the file, not the `FeatureRegistry` schema) `liveness_dispositions` + an append log `state/liveness-events.jsonl`:
 
-The reconciler is **not done** until, run against the current tree, it:
-1. Classifies the context-death stop-gate (`/internal/stop-gate/evaluate` route exists, zero callers, `StopGateDb` empty) as **DARK / unexplained** and surfaces it exactly once.
-2. Classifies `response-review.js` (on disk, not in `Stop[]`) as **DARK / unexplained**.
-3. After the rollout-completion spec wires the stop-gate and a decision is recorded, re-classifies it as **VERIFIED** (or explained) and goes silent.
+- Row: `{ subjectId, status, modality, disposition, reason, reasonClass, actor, ts, evidenceHash, surfaceCount }`.
+- `disposition ∈ { baseline-accepted, acknowledged, declined, snoozed, pending, open }` — a **liveness-specific** state model (resolving the "consent FSM has no undiscovered→disabled edge" finding; we do not reuse `VALID_TRANSITIONS`).
+- `reasonClass ∈ { permanent-by-design, conditional }`. **Conditional** explanations carry a re-validation key = `evidenceHash` (content hash of the subject's wiring/code) and re-surface (pull-surface only, never push) when that hash changes — fixing "stale explanation silences a real dark feature forever," and giving versionless subjects (hooks/routes) a re-surfacing key in place of `featureVersion`.
+- **Reuses the proven patterns:** a `MAX_SURFACES` cap (analogous to `MAX_DECLINES`) on *surfaces* (not declines, so an ignored finding still ages out — fixing the never-responded gap), cooldowns, and hash/version-aware re-surfacing.
+- **For FeatureDefinition subjects**, the reconciler ALSO reads `FeatureRegistry`'s existing `{declined, disabled}` + reason as an explained-darkness input (honest, bounded reuse where it actually fits — e.g. `response-review`).
 
-A detector that cannot catch the two bugs that motivated it has failed.
+### 6. The baseline anchor (cold-start flood fix)
+
+On first reconciliation against a tree (idempotent, gated, one-time per `subjectId`):
+- Every **`should-be-offerable`** subject currently off → no action (INTENTIONALLY-OFF, silent).
+- Every **`should-be-live`** subject currently dark → written as `disposition: baseline-accepted`, `reasonClass: conditional`, `reason: "present-and-dark at baseline <version> <date>; not individually triaged"`, with `evidenceHash` captured. **Silent at baseline**, BUT because it's `conditional` it appears on the pull-surface dashboard as "dark (baselined)" and re-surfaces (pull-surface) if its evidenceHash changes.
+- **Exception — the motivating regressions are NOT baseline-silenced:** a `should-be-live` subject whose intent source is a **spec approved AFTER the baseline date** (or explicitly tagged `liveness-priority: enforce`) is treated as an active finding, not baseline-accepted. The context-death stop-gate qualifies (approved 2026-04-17; its rollout is intended to complete) → it surfaces. This is how the dogfood gate stays honest without the baseline burying it.
+
+> **Design tension, surfaced for ratification:** baseline-accept means the *first* deploy of the reconciler does not re-litigate years of accumulated dark infra in one flood — but it also means a genuinely-bad pre-baseline dark feature stays quiet until its code changes. The `liveness-priority: enforce` tag + the post-baseline-approval rule are the escape valves. Justin should confirm this trade is acceptable (alternative: a one-time, paced "baseline review" digest of N-per-week rather than silent-accept).
+
+### 7. Surfacing pipeline (flood-free), in order
+
+A finding must pass every layer:
+1. **Modality gate** — only `should-be-live` + DARK (or expected-flow HOLLOW) proceeds. (Kills the opt-in false-positive class.)
+2. **Baseline gate** — baseline-accepted subjects are silent unless evidenceHash changed or they carry `liveness-priority: enforce`.
+3. **Explained-darkness gate** — `LivenessLedger` (+ `FeatureRegistry` for FD subjects) has a disposition with a reason, or `surfaceCount ≥ MAX_SURFACES` → silent. Config-sync-off subjects carry a synthetic `system` reason → silent.
+4. **Novelty gate** — diff vs prior run; only new/regressed proceeds.
+5. **Severity gate** — severity from the `liveness-manifest`/FeatureDefinition; only `severity: critical` (safety-critical, explicitly assigned — never inferred from a sparse enum) is eligible to push. Others → pull-surface.
+6. **Coalesce** — one digest, one push max per run.
+7. **Acknowledge/age** — surfacing increments `surfaceCount` and writes `pending`; a user response → `acknowledged`/`declined` (with reason); unanswered re-enters the next digest up to `MAX_SURFACES`, then ages to `pending-aged` → pull-surface only, never pushed again.
+
+### 8. Reason capture — structural (resolves C2 / no-manual-work)
+
+- The **only** ways a subject becomes "explained": (a) a decision through `POST /liveness/:subjectId/decision` (or the existing feature `disableAction`) which **requires a non-empty reason at the API layer** (server rejects reason-less off-decisions); (b) config-sync auto-stamps a synthetic `system` reason (`"absent/false in config as of <version>"`); (c) baseline-accept's synthetic reason. The agent recording a conversational "turn off X because Y" uses path (a) — but if it forgets, the subject is simply **not explained**, so the reconciler's *first* contact is a low-priority pull-surface "why is this off?" — it **never assumes** capture happened. No willpower dependency.
+
+### 9. Self-liveness (resolves "who watches the reconciler")
+
+`/liveness` exposes `lastReconciliationAt`. The existing `guardian-pulse` meta-monitor (a *different* mechanism than the weekly job) asserts `now - lastReconciliationAt < 2× cadence` and escalates if stale. The reconciler also lists **itself** as a `should-be-live` subject in its own report.
+
+### 10. Mechanism
+
+- **`LivenessReconciler`** core class (`src/monitoring/`), constructed in server startup with real deps (inventory builder, wiring snapshot, `LivenessLedger`, intelligence provider) and **self-registered in the startup construction registry** (so its own wiring is a runtime fact, and a wiring-integrity test asserts it — resolves H1).
+- **`GET /liveness`** (authed) — latest report; Phase-1 E2E asserts 200. Mirrors the `/tokens/summary` / `/operations/log` read-only pattern (verified to exist).
+- **Scheduled job** (default weekly; **plus a post-update trigger for `severity: critical` subjects** so a safety regression isn't blind for ~7 days — promotes open-question #4). `supervision: tier1` — Haiku supervises only the *surfacing/push decision*; classification is deterministic by design (explicit per the state-detection-robustness standard). Supervisor return type is structurally `{ shouldSurface, severity }` only — no field that could carry a mutation (type-enforces the no-mutation property).
+- **Dashboard "Liveness" tab** — the pull surface; every subject + status + disposition + reason + evidenceKind.
+- **CLI** `instar liveness [--status dark] [--since]`.
+
+### Dogfood gate (non-negotiable, revised)
+
+Run against the current tree, the reconciler must:
+1. Classify the context-death stop-gate (`route:/internal/stop-gate/evaluate` wired:false, `StopGateDb` empty; `should-be-live`; spec approved post-? — tagged `liveness-priority: enforce`) as **DARK / unexplained** and surface it **exactly once**, with `severity: critical` from the liveness-manifest (NOT inferred — resolving the "would detect then not push its own bug" finding).
+2. Classify `response-review` (FeatureDefinition, safety; on disk, not in `Stop[]`; `should-be-live`) as **DARK / unexplained**.
+3. On the same first run, classify the ~13 opt-in features + the 100+ doc-only specs as **INTENTIONALLY-OFF / DESIGN-ONLY** and produce **zero** additional pushes (the anti-flood proof).
+4. After the rollout-completion wires the stop-gate and a decision/baseline is recorded, re-classify it **VERIFIED** and go silent.
+
+A detector that catches its two bugs but buries them among 100 false positives has failed.
 
 ## Rollout
 
-- **PR1: `LivenessReconciler` core + unit tests.** Intent/wiring/activation collectors; status classification; no surfacing yet. Unit tests cover both sides of each tier boundary (verify-claim parity).
-- **PR2: `/liveness` endpoint + Phase-1 E2E + dashboard tab + CLI.** Read-only surface. Integration test: route returns 200 with a real report.
-- **PR3: Ledger extensions.** Required-reason on off-transitions; extended subject set; `POST /features/:id/decision` (or reuse disableAction) for conversational reason capture. Migration parity for the `discovery.db` schema additions (idempotent). Wiring-integrity test that the reason is actually persisted.
-- **PR4: Surfacing pipeline (five layers) + scheduled job, observe-only.** Job runs and writes the report + dispositions but does **not** push; everything to the pull surface. Gather a few cycles of real data; confirm the dogfood gate (both dark gates flagged).
-- **PR5: Enable push for safety-category only.** Flip the severity-gate push for `safety` unexplained-dark, coalesced. Gated on: zero false-positive pushes across the observe-only cycles, dogfood gate green.
+- **PR1: declared inventory + intent-modality + `LivenessReconciler` core + unit tests.** Inventory builder (spec frontmatter scan, `liveness-manifest`, FeatureDefinitions), modality assignment, three-reading collectors, status classifier with precedence. Unit tests cover BOTH sides of every boundary (modality live/offerable; each status; evidenceKind runtime/static).
+- **PR2: `/liveness` endpoint + Phase-1 E2E + dashboard tab + CLI + `generateClaudeMd` update (resolves C1).** Add `/liveness` to the CLAUDE.md template Capabilities section + a "Registry First" row ("why is X off? → GET /liveness") + a proactive trigger ("user asks 'is X on?' → GET /liveness"). Integration test: route returns 200 with a real report. (`feature-delivery-completeness` will now assert this parity.)
+- **PR3: `LivenessLedger` + structural reason-capture.** New `liveness_dispositions` table + `liveness-events.jsonl`; `POST /liveness/:subjectId/decision` with API-layer mandatory reason; config-sync synthetic-reason path; `reason`/`actor`/`reasonClass`/`evidenceHash` as first-class fields. Migration parity **named concretely**: the table is created by an idempotent `CREATE TABLE IF NOT EXISTS` in the ledger's self-migrating init (where `discovery.db` schema is owned), seeded for existing agents; `migrateConfig()` adds any config defaults existence-checked. Tests: integration (decision route over HTTP, reason-rejection), e2e (schema migration idempotent on an existing populated DB), wiring (reason actually persisted).
+- **PR4: baseline anchor + invocation counters + wiring snapshot + construction registry.** One-time idempotent baseline; per-route counter; startup construction registry + a **wiring-integrity test that `LivenessReconciler` is constructed with non-null deps and its job is registered** (resolves H1). Semantic-correctness tests for all seven suppression layers (both sides each).
+- **PR5: surfacing pipeline, observe-only.** Job runs, writes report + dispositions, **no push**; everything to pull-surface. Run ≥4 cycles; confirm the dogfood gate (both targets flagged, zero other pushes).
+- **PR6: enable push for `severity: critical` only + post-update trigger.** Gated on: zero false-positive pushes across observe-only cycles; dogfood gate green; self-liveness heartbeat wired in `guardian-pulse`.
 
-Migration parity (CLAUDE.md standard) applies throughout: config defaults via `migrateConfig()`, job def installed for existing agents, `discovery.db` schema migration idempotent, any CLAUDE.md template capability section added per the Agent Awareness Standard.
+Each PR leaves `npm run test:push`/`test:smoke` green (Zero-Failure Standard). Migration parity applies throughout (config defaults, job install for existing agents, idempotent `discovery.db` migration, CLAUDE.md template per Agent Awareness Standard).
 
 ## Rollback
 
-- The reconciler mutates **no** runtime state, so disabling it is inert: remove/disable the scheduled job; `/liveness` becomes a stale-but-harmless read. Ledger extensions are additive (extra rows/columns), reversible by ignoring them. No feature is ever touched by this system, so there is no activation to revert.
+The reconciler mutates **no** feature, so disabling it is inert: disable the scheduled job; `/liveness` becomes a stale-but-harmless read; the `guardian-pulse` heartbeat would (correctly) flag the reconciler itself as stale. Ledger tables are additive. No activation to revert.
 
 ## Signal-vs-authority compliance
 
-| Component | Class | Mutates / blocks? | Notes |
+| Component | Class | Mutates/blocks? | Notes |
 |---|---|---|---|
-| Intent/wiring/activation collectors | Detector | No | Deterministic readings. |
-| Status classifier | Detector | No | Maps readings → {VERIFIED,DARK,HOLLOW,DEPLOY-LAG}. |
-| Explained-darkness + 4 suppression layers | Detector | No | Decide whether to surface; never act on the feature. |
-| `FeatureRegistry` ledger | State | Appends decisions only | Reused; existing anti-flood authority. |
-| Tier1 supervisor (Haiku) on push | Authority (over the *message*) | Gates the notification only | Validates a push is warranted; cannot enable/disable any feature. |
+| Inventory builder + collectors + classifier | Detector | No | Deterministic readings + precedence taxonomy. |
+| Modality / baseline / explained / novelty / severity gates | Detector | No | Decide *whether to surface*; never act on a feature. |
+| `LivenessLedger` | State | Appends dispositions only | Purpose-built; reuses anti-flood patterns; no feature mutation. |
+| Tier1 supervisor (Haiku) | Authority over the *message* | Gates the push only | Return type `{shouldSurface,severity}` — structurally cannot carry a remediation action. |
 
-No component in this system enables, disables, wires, or deploys a feature. That authority remains with the human (or a future, separately-approved remediation spec).
+No component enables/disables/wires/deploys any feature. A static test (mirroring `signal-vs-authority.spec.ts`) asserts no block/mutation statement exists outside the enumerated detectors.
 
 ## Side-effects review
 
-- **Over-surface risk (the flood Justin fears):** mitigated structurally by five layers, dominated by the explained-darkness filter + the existing `MAX_DECLINES`/cooldown/version-aware machinery. Observe-only PR4 proves the false-positive rate before any push is enabled (PR5 gate).
-- **Under-surface risk (missing a real dark feature):** the deterministic collectors err toward flagging (unmatched spec→capability = flag, not silent-drop); HOLLOW/DEPLOY-LAG classes catch the subtler cases build-time guards miss.
-- **Ledger-poisoning / wrong-explanation:** decisions are append-only with actor + timestamp + reason; a stale "explained" can be re-opened by a version bump (version-aware re-surfacing) or an operator clearing the decision.
-- **Cost:** deterministic core ≈ free; optional LLM fuzzy-match daily-capped (target < $0.05/day). Weekly cadence.
-- **Interaction with build-time guards:** complementary, not redundant — they gate *merge*; this gates *liveness after merge*. The `feature-delivery-completeness` test remains the init↔migrator↔docs authority; the reconciler is the runtime backstop.
+- **Over-surface (the flood):** killed structurally by the modality gate (opt-in off is never a finding) + baseline anchor (pre-existing dark is accepted) + explained-gate + `MAX_SURFACES` + coalescing. Observe-only PR5 proves false-positive rate before any push (PR6 gate).
+- **Under-surface:** `should-be-live` + dark always surfaces (modulo explained); HOLLOW/`expects-flow` catches subtler cases; the `liveness-priority: enforce` tag prevents baseline from hiding the motivating bugs; conditional-reason re-validation (evidenceHash) prevents stale explanations from blindfolding forever.
+- **Manual-work audit:** modality is opt-in via frontmatter/manifest (version-controlled, parity-tested), not a per-cycle human treadmill; reason-capture is API-structural; baseline is one-time automatic. No standing manual capture.
+- **Self-darkness:** independent `guardian-pulse` heartbeat + self-listing.
+- **Cost:** deterministic core ≈ free; optional LLM fuzzy-match daily-capped (<$0.05/day); weekly + post-update-critical cadence.
+- **Interaction with build-time guards:** complementary; `feature-delivery-completeness` remains the init↔migrator↔docs authority and will now also assert `/liveness` parity.
 
 ## Success criteria
 
-- **Dogfood:** both dark gates correctly classified `DARK/unexplained`; after stop-gate rollout-completion + recorded decision, stop-gate re-classifies to `VERIFIED`/explained and goes silent.
-- **Flood-free:** across ≥4 observe-only weekly cycles, zero pushes for explained or repeat findings; ≤1 coalesced digest per cycle even with multiple findings.
-- **Coverage:** every approved spec maps to a reconciled subject (or is explicitly marked design-only/no-runtime-surface in the ledger).
-- **Silence at rest:** a fully-VERIFIED tree produces zero user-facing notifications.
-- **Institutional memory:** "why is feature X off?" answerable from the ledger for every disabled/declined subject (reason present).
+- **Dogfood:** both dark gates classified DARK/unexplained and surfaced (stop-gate `critical`/pushed); after rollout-completion + recorded decision, stop-gate → VERIFIED, silent.
+- **Flood-free (the gate that must be truthful):** across ≥4 observe-only cycles, **first run produces ≤2 pushes (the two motivating bugs) and zero others**; opt-in/doc-only subjects produce zero findings; ≤1 coalesced digest per cycle.
+- **Coverage:** every `should-be-live` subject in the manifest is reconciled; every opt-in spec either declares `runtime-surface` or is silently design-only (no manual annotation treadmill).
+- **Silence at rest:** a fully-VERIFIED tree → zero user-facing notifications.
+- **Institutional memory:** "why is X off?" answerable from the `LivenessLedger`/`FeatureRegistry` for every off `should-be-live` subject (reason present, synthetic or human).
+- **Self-liveness:** `guardian-pulse` alerts if the reconciler stops running.
 
-## Open questions (for /spec-converge)
+## Open questions (for further /spec-converge / external cross-model round)
 
-1. **Subject identity for non-FeatureDefinition classes.** Stable `subjectId` scheme for hooks/routes/capabilities so the ledger and reconciler agree across renames. (Proposed: `class:name`, with a rename-migration map.)
-2. **Spec↔capability matching.** Deterministic mapping table (spec frontmatter `slug` → capability key) vs bounded LLM fuzzy-match for un-mapped specs. Lean deterministic table + LLM only for the residual, fail-open to "flag for human."
-3. **DEPLOY-LAG detection fidelity.** How far to take the "merged ≠ published ≠ running" check (cheap: `UpdateChecker` version delta; richer: per-feature presence in the running build). Start cheap.
-4. **Cadence.** Weekly default vs event-triggered (post-merge / post-update hook). Start weekly; consider a post-update trigger later.
+1. **Baseline trade (flagged above):** silent-accept of pre-existing dark vs a paced "baseline review" digest. Needs Justin's call.
+2. **Invocation-counter scope:** which routes opt into counting (all `should-be-live` routes vs a curated set) and the memory cost at scale.
+3. **`liveness-manifest` governance:** how adding a sentinel/safety-hook is forced to add a manifest entry (proposed: a parity test like `feature-delivery-completeness`, but defining "every `should-be-live` thing" mechanically is itself the hard problem this spec is about — partial bootstrap risk).
+4. **External cross-model review:** per `feedback_external_crossmodel_catches_what_internal_misses`, a GPT/Gemini/Grok round should run before ratification; this convergence was Claude-family only.

--- a/docs/specs/context-death-stop-gate-rollout-completion.eli16.md
+++ b/docs/specs/context-death-stop-gate-rollout-completion.eli16.md
@@ -1,0 +1,28 @@
+# Stop-gate rollout completion — the plain-English version
+
+## What this is
+
+Back in April you approved a design for a safety referee called the **stop-gate**. Its job: when I try to quit work mid-task with a flimsy excuse like "let's continue in a fresh session," it checks whether the work is actually saved and safe to keep going on — and if so, overrules me and says "keep going." It only lets me stop for real reasons (a genuine question for you, missing info, a real error, or actually being done).
+
+## What actually happened
+
+We built the back half — the referee's brain, its memory, its logbook, even the command-line tool to run it. All merged. But the one small piece of glue that connects my "I'm stopping" moment to that brain was never added. So the brain sits there, fully built, with nothing ever calling it. And it was never switched on — it has an off / watch / enforce dial that's stuck on "off," and there isn't even a config slot for the dial yet.
+
+In other words: the referee exists, but it's blindfolded and asleep.
+
+## What this spec does
+
+It does **not** invent anything new — your April design already covered every piece. It just finishes the job that quietly stalled:
+
+1. **Add the glue** — the bit in the stop hook that actually calls the referee.
+2. **Add the on-switch** — the off/watch/enforce dial, defaulting to off, and make sure every existing agent gets it on update (not just brand-new ones).
+3. **Turn it to "watch"** — the referee starts judging and writing down what it *would* have done, but doesn't block anything yet. This gives us real data with zero risk.
+4. **Then turn it to "enforce"** — only after it's proven itself against the safety checks your original design already spelled out (enough real cases, enough human spot-checks, etc.).
+
+## Why it's safe
+
+At every step there's an instant kill-switch and the dial can go back to "off," which makes the whole thing a harmless no-op. We back up the existing hook before touching it. And we add one test that specifically checks the glue is really there — because a missing test is exactly how it went dark in the first place.
+
+## The honest footnote
+
+I originally told you the fix was a *different* switched-off gate (one that checks message tone). That was me guessing from the outside before reading your actual spec. There are genuinely two switched-off defenses for this same problem; this spec fixes the real, purpose-built one. The other is tracked separately.

--- a/docs/specs/context-death-stop-gate-rollout-completion.md
+++ b/docs/specs/context-death-stop-gate-rollout-completion.md
@@ -1,0 +1,87 @@
+---
+title: "Context-death stop-gate — rollout completion (wire the hook client, add config dial, flip to shadow→enforce)"
+slug: context-death-stop-gate-rollout-completion
+status: draft
+approved: false
+date: 2026-05-24
+author: echo
+parent-spec: docs/specs/context-death-pitfall-prevention.md
+eli16-overview: context-death-stop-gate-rollout-completion.eli16.md
+---
+
+# Context-death stop-gate — rollout completion
+
+## One-paragraph summary
+
+The context-death stop-gate was fully designed and approved in `context-death-pitfall-prevention.md` (approved by Justin 2026-04-17, 4 review iterations) and its **server half shipped** — `UnjustifiedStopGate` authority, `StopGateDb` SQLite decision log, and the full `/internal/stop-gate/*` route family (`hot-path`, `evaluate`, `kill-switch`, `mode`, `log`, `annotations`), plus the `instar gate` CLI. But the rollout **silently stopped after the server half**. The keystone that the approved spec calls for — the **hook-side router inside `autonomous-stop-hook.sh`** that detects stop signals and calls `/internal/stop-gate/evaluate` — was never integrated; there is no `unjustifiedStopGate` config type or default; and the mode dial was never flipped past `off` (PR4-shadow / PR5-enforce never happened). The authority sits fully built with **zero callers and zero eval events**. This spec does **not** introduce new design — it completes the approved rollout: (1) integrate the hook router (the unbuilt portion of the parent spec's PR3), (2) add the `unjustifiedStopGate` config field + migration, (3) flip to `shadow`, then (4) flip to `enforce`, both gated by the parent spec's already-approved threshold criteria.
+
+## Why this is not a new spec
+
+Per the instar-dev gate, src/ + hook changes require a converged, user-approved spec. **That spec exists and is approved** (`context-death-pitfall-prevention.md`). Every component named here is specified there:
+- Hook router pseudocode: parent spec § "(b) Unified stop-hook — `autonomous-stop-hook.sh` with internal router".
+- Config dial (`mode: off|shadow|enforce`): parent § "Config flag — server-mediated".
+- Detectors including `mentionsFreshSession`: parent § "Fast path (casual session)".
+- Shadow / enforce flip gates: parent § "Rollout" PR4 / PR5 and § "Success criteria".
+
+This document is a **rollout-completion plan** that re-grounds the unfinished PRs against current `main` (v1.2.62) and records *why the gap existed* (no decision was ever recorded; the rollout simply stalled — itself the motivating data point for the sibling Liveness Reconciler spec). It carries no design authority of its own; if any step here contradicts the parent spec, the parent spec wins.
+
+## Verified current state (on JKHeadley/main @ v1.2.62)
+
+| Parent-spec deliverable | Landed? | Evidence |
+|---|---|---|
+| PR0a server infra (`/internal/stop-gate/hot-path`, kill-switch, version contract) | ✅ | `src/server/routes.ts:1517+`, `src/server/stopGate.ts`; commit #54 |
+| PR0d e2e compaction harness | ✅ | commit `1f7f76a07` |
+| PR1 identity marker + migration | ✅ | commit `1395c2451` |
+| PR2 e2e compaction-recovery assertions | ✅ | commit `2c0c87f25` |
+| PR3 authority + SQLite + `evaluate` route | ⚠️ partial | `src/core/UnjustifiedStopGate.ts`, `src/core/StopGateDb.ts`, `routes.ts:1564` (`/internal/stop-gate/evaluate`); commit `42cb9eeef` — **server only; hook router omitted** |
+| PR3 **hook router in `autonomous-stop-hook.sh`** | ❌ **never landed** | `grep -rl "stop-gate/evaluate\|hot-path\|UnjustifiedStop"` over `.claude/`, `src/data/`, `src/templates/`, `src/scaffold/` → **zero callers** |
+| `unjustifiedStopGate` config type + default | ❌ missing | no match in `src/core/types.ts`, `src/core/Config.ts`, `src/data/` |
+| PR4 `instar gate` CLI + mode endpoint | ✅ | commit `737722036`, `routes.ts:1542` (`/internal/stop-gate/mode`) |
+| PR4 **flip to shadow** | ❌ never happened | no config default; mode dial absent |
+| PR5 **flip to enforce** | ❌ never happened | — |
+| StopGateDb eval events | 0 rows expected | authority has no caller |
+
+**Net:** the brain (authority + decision log + routes + CLI) is built; the nerve (hook router client) connecting the Stop event to the brain was never wired, and the on-switch (config dial) does not exist. This is a "built but dark" instance — see `docs/specs/built-but-dark-liveness-reconciler.md`.
+
+## Scope
+
+### In scope (completing the approved rollout)
+
+1. **Hook router (parent PR3, hook portion).** Integrate the router into `autonomous-stop-hook.sh` exactly per the parent spec's router pseudocode and fast-path budget. Key points carried verbatim from the parent:
+   - Single batched `GET /internal/stop-gate/hot-path?session=<id>` with 60s mtime-TTL file cache; `mode=off` or `killSwitch` → `exit 0` (zero cost past this point).
+   - `compactionInFlight` → fail-open (`exit 0`) with telemetry — never block during compaction.
+   - The unjustified-stop-check outcome is **authoritative** for the Stop event; autonomous-mode's pre-existing "block every stop" does **not** separately re-fire (no double-gate path — parent § iter-3 F1 fix).
+   - Detectors (signal-only, including `mentionsFreshSession`, `mentionsLaterSession`, `mentionsBreakPoint`, `suspiciouslyQuiet`); only the `UnjustifiedStopGate` LLM authority + deterministic evidence verifier can block.
+   - `durableArtifacts` collection via `git ls-files` + `introducingCommit` timestamp vs `sessionStartTs` (parent § F2 fix).
+   - On no `sessionStartTs` record → `exit 0` + one-time `DegradationReport` (fail-open).
+2. **Config dial.** Add `unjustifiedStopGate?: { mode: 'off' | 'shadow' | 'enforce' }` to config types, default `off`. Server reads it (it already exposes `/internal/stop-gate/mode`); hooks read mode via `/internal/stop-gate/hot-path`, never the file (parent § "Config flag — server-mediated").
+3. **Migration parity (CLAUDE.md Migration Parity Standard).**
+   - `migrateConfig()` — add `unjustifiedStopGate: { mode: 'off' }` if absent (existence-checked, idempotent).
+   - `migrateSettings()` / `migrateHooks()` — ensure the deployed `autonomous-stop-hook.sh` carries the router. Built-in hooks are always-overwritten on migration, so the router ships to existing agents on update. Verify the `feature-delivery-completeness` three-legged-stool test covers the new config block.
+   - Backup the existing hook to `.instar/hook-backups/` before overwrite (parent § I205).
+4. **Shadow flip (parent PR4).** `instar gate set unjustified-stop --mode shadow` once the hook router is live and the e2e compaction test is green. Shadow = observe-only: detectors fire, authority evaluates, decisions are logged to `StopGateDb`, **nothing blocks**. This generates the machine-side "human-as-detector heat map" the parent spec's measurement section describes.
+5. **Enforce flip (parent PR5).** Only after the parent spec's already-approved enforce-flip thresholds are met (≥50 triggered evals, ≥14 days shadow, ≥20 human-reviewed annotations from ≥2 operators, zero `invalidRule`/`invalidEvidence` in last 50, latency budgets, e2e ≥90% for 7 days). `instar gate set unjustified-stop --mode enforce --check-thresholds`.
+
+### Out of scope
+
+- Re-opening any parent-spec design decision. If reality forces a change, that is a parent-spec amendment, reviewed separately.
+- The **secondary** dark gate (`response-review.js` / CoherenceGate `responseReview` with `B15_CONTEXT_DEATH_STOP`). It is a separate outbound-message tone gate, also dark, tracked independently — NOT part of this rollout. Wiring it is a distinct decision (it reviews message tone, not Stop events). Noted here only to prevent re-conflation.
+- The always-on `deferral-detector.js` "fresh"-vocabulary backstop (cheap signal layer). Small and independent; folded into the Liveness Reconciler spec's signal-layer work or shipped as a trivial standalone change. Does not gate this rollout.
+
+## Testing (Testing Integrity Standard — all three tiers)
+
+- **Unit:** router decision logic (mode routing, kill-switch precedence, compaction fail-open, signal detection incl. `mentionsFreshSession`, `durableArtifacts` classification). Config default present + idempotent migration.
+- **Integration:** full HTTP pipeline — hook → `/internal/stop-gate/hot-path` → `/internal/stop-gate/evaluate` → `UnjustifiedStopGate` → `StopGateDb` row written. Mode=off short-circuits; mode=shadow logs-but-allows; mode=enforce blocks on a `continue` decision.
+- **E2E:** parent spec's compaction-recovery test (already built, PR2) must stay green; add a lifecycle test asserting `/internal/stop-gate/evaluate` returns 200 (alive) and that a fabricated context-death stop with a pre-session plan artifact yields a `continue` outcome in enforce mode.
+- **Wiring-integrity:** assert the deployed `autonomous-stop-hook.sh` actually contains a caller of `/internal/stop-gate/evaluate` (this is the exact regression that produced the dark gate — a test that would have caught it).
+
+## Rollback
+
+Inherits the parent spec's rollback verbatim: kill-switch (`instar gate kill-switch --set`, git-sync fanout), mode flip to `off`, decision log preserved. Additionally: the hook backup in `.instar/hook-backups/` allows reverting the router integration; `mode=off` makes the router a zero-cost no-op regardless.
+
+## Success criteria
+
+- A wiring-integrity test proves the deployed hook calls the evaluate endpoint (no longer dark).
+- `StopGateDb` accrues eval events in shadow mode (proof of data-flow, not just existence).
+- Parent spec's enforce-flip thresholds met before enforce.
+- The sibling Liveness Reconciler, run against this feature, flips it from `DARK` to `VERIFIED` after completion (dogfood cross-check).

--- a/docs/specs/feature-activation-coherence.eli16.md
+++ b/docs/specs/feature-activation-coherence.eli16.md
@@ -1,0 +1,35 @@
+# Feature Activation Coherence — the plain-English version
+
+## The honest correction first
+
+When I tried to turn the features on, I told you several were "dark — flag only, doing nothing." After digging into the actual code, I was wrong about three of them, and the truth is more interesting:
+
+- **input-guard** (a safety feature that screens incoming messages for sneaky injected instructions) is actually **already on and running** — I'd looked for it in the wrong place. It's not dark; it's just *labeled* as off.
+- **evolution-system** (where I propose improvements you approve) is **always running too** — its on/off switch is a fake; flipping it does nothing.
+- **publishing** is **on by default** and needs no setup at all.
+
+So I flipped a couple of switches that turned out to be decorative. No harm done, but it points at the real problem.
+
+## The real problem
+
+The list of "what features are on or off" **doesn't match what the code actually does.** Some features are advertised with an on/off switch that's wired to nothing. Some are running while the list says they're off. One (`autonomous-evolution`) has its switch wired to a setting that no part of the code ever reads — so the real control is somewhere else entirely. Telegram-style: it's a control panel where half the switches aren't connected to anything, and some lights are on with no switch at all.
+
+That's the deepest version of the "built but dark" disease — not just a dark feature, but a **map that lies about the territory.** Anyone (you or me) reading the feature list is being misled.
+
+## What this spec does — three things
+
+1. **Fix the control panel itself.** Make the feature list derive its on/off from what the code actually does, so it can't drift. Add tests that fail the build if a switch is wired to nothing, or if the list claims a feature is off when it's actually running. Fix the telegram-style deadlock where one feature can only be turned on if it's already on.
+
+2. **Decide what to do with each feature** — finish it, improve it, merge it into something newer that already does the job, or retire it:
+   - **input-guard, publishing, evolution-system**: already running — just fix the label to tell the truth.
+   - **autonomous-evolution** ("act without asking"): its switch is fake and the engine behind it was never finished. Collapse the three confusing settings into the one that's real, and keep changes human-approved rather than finishing the "act without asking" part — that's safer and matches our spec-first rule.
+   - **telemetry**: fix the deadlock so it *can* be turned on (for other users); leave it off for you, since comparing your agent to a "population" that's basically your own infra isn't useful.
+   - **dispatches** ("receive instructions from the instar maintainer"): this one's backwards for you — YOU are the maintainer. So it correctly stays off for your agent; we just fix it for the downstream agents it's actually meant for.
+   - **response-review**: turns out to be a heavy duplicate of a message-checker that already runs on everything you send. Merge the one or two useful bits into that, and retire the duplicate rather than running two checkers.
+
+3. **Hand the watchdog job to the Liveness Reconciler** (the other spec) so the control panel never silently drifts out of truth again. This spec is the one-time cleanup; the reconciler is the standing guard.
+
+## Two more things I tripped over
+
+- The context-death safety referee is even more switched-off than I thought — its memory/logbook isn't even created at startup. (Already covered by the stop-gate spec.)
+- The emergency-stop detector (the thing that's supposed to catch you saying "stop everything") may not actually be connected to your incoming messages. That's safety-critical, so I flagged it for its own quick check.

--- a/docs/specs/feature-activation-coherence.md
+++ b/docs/specs/feature-activation-coherence.md
@@ -1,0 +1,131 @@
+---
+title: "Feature Activation Coherence — make the feature catalog tell the runtime truth, fix the enable layer, and disposition each dark/lying feature"
+slug: feature-activation-coherence
+status: draft
+approved: false
+date: 2026-05-24
+author: echo
+related:
+  - docs/specs/built-but-dark-liveness-reconciler.md
+  - docs/specs/context-death-stop-gate-rollout-completion.md
+eli16-overview: feature-activation-coherence.eli16.md
+---
+
+# Feature Activation Coherence
+
+## One-paragraph summary
+
+A live dogfood attempt to "turn on every instar feature" (topic 12702, 2026-05-24) revealed that **the feature-activation layer is incoherent and the `FeatureDefinitions` catalog systematically lies about runtime reality.** Of 7 "off" opt-in features, none could be cleanly turned on, and on deeper inspection the off/on labels themselves were wrong: `input-guard`, `evolution-system`, and `publishing-telegraph` are actually **always-on at runtime** (wired via `SessionManager`/unconditional construction) while advertised as opt-in toggles; `autonomous-evolution`'s toggle writes a config key (`evolution.autoImplement`) that **no code reads** (the real gate is `AutonomyProfileManager.evolutionApprovalMode`); `baseline-telemetry`'s enable endpoint is a **chicken-and-egg deadlock**; and `dispatches` is **architecturally inverted** for a self-hosting maintainer and its enable action targets a non-allowlisted config key. This spec does three things: (1) fix the **enable layer** so a feature's declared state, its config, and its runtime behavior cannot drift apart; (2) apply a **per-feature disposition** (finish / improve / merge / retire) to each feature so the catalog stops advertising switches that do nothing; (3) hand the standing-detector role to the **Liveness Reconciler** (separate spec) so this never silently recurs. It is the one-time cleanup + the coherent mechanism; the reconciler is the watchdog.
+
+## Problem
+
+Justin's directive: dogfood every instar feature so we know it works coherently. Acting on it surfaced that you literally cannot — the activation machinery is broken in at least four ways, and worse, the catalog of "what's on/off" doesn't match what the code does. An agent (or user) reading `/features` is misled: it shows features as off that are running, and offers toggles that change nothing. That is the deepest form of the "built but dark" disease — not just dark features, but a **map that disagrees with the territory.**
+
+## Evidence (all live-verified on main v1.2.62 / the running agent)
+
+**Four enable-path failure classes (from the dogfood autopsy):**
+- **A — flag with no plumbing:** `response-review` (Stop-hook never registered), `dispatches` (and see inversion below).
+- **B — config ↔ registry desync + no hot-reload:** `PATCH /config {evolution|publishing}` sets the flag on disk but `FeatureRegistry.discoveryState` stays `undiscovered` until a restart re-runs `bootstrap()`; the running subsystem doesn't hot-reload.
+- **C — chicken-and-egg:** `POST /telemetry/enable` 503s because `telemetryHeartbeat` is only constructed at boot `if (config.monitoring?.telemetry?.enabled)` (`server.ts:2642`) — it can't be enabled through its own endpoint.
+- **D — enableAction targets a non-allowlisted key:** `dispatches`'s `enableAction` patches `dispatches`, absent from the `PATCH /config` allowlist (`routes.ts:11066-11070`) → 400.
+
+**The catalog lies (deeper finding, code-grounded):**
+- `input-guard` — constructed `if (config.inputGuard?.enabled !== false)` (default-ON, `server.ts:2570`), wired via `sessionManager.setInputGuard()`, and **actually runs** on `SessionManager.injectMessage()` (3 layers). Advertised in `FeatureDefinitions` as opt-in `network`-consent (off). **Live but labeled off.**
+- `evolution-system` — `EvolutionManager` constructed **unconditionally** ("always enabled — the feedback loop infrastructure", `server.ts:5003`); `evolution.enabled` is read by no runtime gate — it only flips a discovery-DB row. **Always-on; the toggle is a fiction.**
+- `publishing-telegraph` — `TelegraphService` auto-on (`server.ts:4916`, opt-out), zero-config (auto-creates a Telegraph account). **On by default; the 503 path is vestigial.**
+- `autonomous-evolution` — `evolution.autoImplement` is read by **no code**; the runtime authority is `AutonomyProfileManager.evolutionApprovalMode` (from `evolution.approvalMode` / autonomy profile). Three config keys for one concept, two of them dead. And `processProposalAutonomously()` (`EvolutionManager.ts:807`) has **zero callers** — the auto-implement pipeline never runs.
+
+**Two bonus dark systems (adjacent, found during re-assessment):**
+- `UnjustifiedStopGate` — `StopGateDb` is **never constructed** in `server.ts` (optional null-default param); no Stop-hook calls `/internal/stop-gate/evaluate`. Darker than first thought (handled by the stop-gate rollout-completion spec).
+- `MessageSentinel` — constructed + `/sentinel/classify` route, but **no live inbound-ingress call site** found (only the test route). The emergency-stop / "kill all sessions" classifier may not be wired to actual inbound messages — **safety-relevant; needs its own verification.**
+
+## Root cause
+
+Two sources of truth for "is this feature on" — `config.json` and the `FeatureRegistry` discovery DB — and a third de-facto truth: **what the code actually constructs and invokes.** Nothing keeps them in sync. Features are wired in three different idioms (unconditional construction; `!== false` default-on; `if (config.x.enabled)` opt-in), and the `FeatureDefinitions` catalog was written as if all were uniform opt-in toggles. So the catalog drifts from reality, enable actions target keys that nobody reads or that the API rejects, and "off" is meaningless without checking the code.
+
+## Non-goals
+
+- Not re-deciding the Liveness Reconciler design (separate, converged spec). This spec is the one-time cleanup + the coherent enable mechanism; the reconciler is the ongoing detector.
+- Not building auto-remediation. Dispositions are applied by humans/PRs, surfaced by the reconciler.
+- Not turning on features that are correctly off for *this* agent (e.g. `dispatches` for the maintainer). Coherence ≠ everything-on; it means the label matches reality and the choice is recorded.
+
+## Design constraints
+
+1. **One truth, derived not duplicated.** A feature's reported state must be derived from (or reconciled against) what the code actually does, not a free-floating flag.
+2. **An enable action must actually enable.** If `enableAction` can't make the feature work (wrong key, deadlock, no plumbing), it's a bug, gated by a test.
+3. **The catalog must not lie.** A feature advertised as opt-in must actually be gated by its config; a default-on feature must say so. Enforced by a test that cross-checks `FeatureDefinitions` against runtime wiring.
+4. **Self-hoster awareness.** A feature can be correctly-off-by-design for the maintainer's own agent; the catalog must express that, not flag it as a gap.
+
+## Design
+
+### Part 1 — Fix the enable layer (the mechanism)
+
+1. **Single derived state.** `/features` reports each feature's `enabled` by reconciling config + the actual runtime probe (is the subsystem constructed/invoked?), not just the discovery-DB row. Where they disagree, the response carries `mismatch: {configSays, runtimeSays}` (and the reconciler flags it). This removes the silent config↔registry drift.
+2. **EnableAction validity test.** A unit test asserts every `FeatureDefinition.enableAction`/`disableAction` (a) targets a key in the `PATCH /config` allowlist (or a real endpoint), and (b) targets a key that runtime code actually reads. This catches class A/D bugs (response-review, dispatches) at build time.
+3. **Always-construct, gate-the-effects.** Subsystems that today gate *construction* on a config flag (telemetry, `server.ts:2642`) switch to the publishing pattern: construct unconditionally (cheap, pure), gate only the side-effecting `.start()`/submission on `enabled`. Kills the chicken-and-egg (class C). `POST /telemetry/enable` then works.
+4. **Hot-reload or honest "restart needed".** Either the subsystem re-reads config on a `config-changed` signal, or the enable response truthfully reports `requiresRestart: true` AND the discovery state is updated immediately so config and registry agree (no class-B limbo). Minimum bar: config and registry never disagree silently.
+5. **Catalog-truth test.** A test cross-checks each `FeatureDefinition` against its runtime wiring idiom: a feature constructed unconditionally or `!== false` must be marked default-on in the catalog; a feature gated `if (config.x.enabled)` must be marked opt-in. Fails CI on drift. (This is the build-time companion to the runtime Liveness Reconciler.)
+
+### Part 2 — Per-feature dispositions
+
+| Feature | Disposition | Action |
+|---|---|---|
+| **input-guard** | **FINISH (tiny)** | It's live + default-on and the *only* inbound cross-topic-injection defense (not redundant with MessageSentinel — different axis). Fix the `FeatureDefinition` to say default-on (not opt-in `network`), and add it to the CLAUDE.md template (Agent Awareness Standard — currently omitted). No core-logic change. |
+| **publishing-telegraph** | **MERGE → always-on infra** | Auto-on, zero-config, functional. Retire the vestigial `enabled:false`/503 path and the misleading toggle; treat like `PrivateViewer` (no flag). Fix worktree-vs-agent-home CLAUDE.md Telegraph drift. |
+| **evolution-system** | **RETIRE the flag (keep the system)** | `EvolutionManager` is always-on baseline infra; `evolution.enabled` gates nothing. Delete the toggle + its no-op `disableAction`; document as baseline. (Or, if a real off-switch is wanted, add an actual route/construction gate — but (a) is honest + lower-risk since everything depends on it.) |
+| **autonomous-evolution** | **MERGE + RETIRE execution** | Collapse the 3-key triplication to the single runtime authority `AutonomyProfileManager.evolutionApprovalMode`; drop the unread `evolution.autoImplement`. RETIRE the auto-implement *execution* (`processProposalAutonomously` has no caller; the self-modification safety surface is large and collides with the instar-dev gate). Keep proposals human-approved via `PATCH /evolution/proposals/:id`. |
+| **baseline-telemetry** | **FINISH (deadlock fix)** | Apply the always-construct/gate-effects fix (Part 1.3) so the enable endpoint works for the population. Keep **Echo's own flag off** — low self-value for the maintainer whose "population" is largely their own infra. |
+| **dispatches** | **RETIRE for Echo + fix for others** | Architecturally inverted for the maintainer's own agent (Echo authors behavior; receiving Dawn dispatches collides with the instar-dev gate). Encode "maintainer agent leaves `dispatches` unset" as the intended state. Separately add `'dispatches'` to the `PATCH /config` allowlist so the catalog isn't lying to *downstream* agents who can legitimately use it. |
+| **response-review** | **MERGE → MessagingToneGate** | CoherenceGate is a heavy opt-in re-implementation of outbound gating that the always-on `MessagingToneGate` (B1–B16, incl. B15_CONTEXT_DEATH_STOP) already performs inline on every send. Port the unique value (claim-provenance / url-validity fact-check, recipient-scoped leakage) into MessagingToneGate as signals; retire the blocking Stop-hook activation path (or keep CoherenceGate strictly `observeOnly`). Do NOT wire it as a second blocking gate. |
+
+**Adjacent (own follow-ups, flagged not fixed here):**
+- `UnjustifiedStopGate` / stop-gate → handled by `context-death-stop-gate-rollout-completion.md` (now known to also need `StopGateDb` construction).
+- `MessageSentinel` inbound wiring → **needs its own verification spec** (is the emergency-stop classifier actually on the live ingress path? safety-relevant).
+
+### Part 3 — Hand off to the Liveness Reconciler
+
+Every issue above is exactly what the Liveness Reconciler (separate, converged spec) detects: config-on-but-runtime-off, runtime-on-but-catalog-off, enable-action-targets-dead-key, subsystem-null. This spec is the **one-time cleanup**; the reconciler is the **standing watchdog** that prevents recurrence. The catalog-truth test (Part 1.5) is the build-time companion.
+
+## Rollout
+
+- **PR1: enable-layer truth tests (red first).** Add the enableAction-validity test (1.2) and the catalog-truth test (1.5). They will FAIL against current code — that's the point; they document every lie. Mark known failures with tracked `// FEATURE-COHERENCE:` markers tied to the disposition PRs.
+- **PR2: telemetry deadlock fix** (1.3) — always-construct, gate `.start()`. Green the telemetry portion of PR1's tests.
+- **PR3: catalog truth for the always-on three** — input-guard, evolution-system, publishing: fix `FeatureDefinitions` to match reality (default-on / retire fictional toggles), add input-guard to CLAUDE.md template (Agent Awareness Standard). Green their PR1 assertions.
+- **PR4: autonomous-evolution merge** — collapse to `evolutionApprovalMode`; drop `autoImplement`; retire the auto-implement execution path (or gate behind explicit, separately-approved enablement). Migration parity for any config key rename.
+- **PR5: dispatches** — allowlist fix for downstream + encode maintainer-off posture for Echo.
+- **PR6: response-review merge** — port the unique reviewers into MessagingToneGate; retire the blocking Stop-hook path. (Coordinated with the stop-gate rollout-completion so the two context-death surfaces don't both get wired.)
+- **`/features` derived-state + mismatch reporting** (1.1, 1.4) lands with PR1/PR2.
+
+Each PR: 3-tier tests + wiring-integrity, leaves `test:push` green, migration parity for any agent-installed change (config defaults, CLAUDE.md template, `FeatureDefinitions`).
+
+## Rollback
+
+Per-PR and independent. The truth tests are additive. The telemetry always-construct is a pure-construction change (no behavior until enabled). Catalog edits are declarative. The autonomous-evolution and response-review merges are the only behavior-affecting changes and each is independently revertable; both reduce surface (retire) rather than add.
+
+## Signal-vs-authority compliance
+
+This spec adds no new gate. It corrects existing ones and removes a redundant blocking gate (response-review's Stop-hook). MessagingToneGate remains the single outbound authority; InputGuard remains the single inbound-injection detector (warn, not block). No detector gains blocking authority.
+
+## Side-effects review
+
+- **Over-reach:** retiring toggles (evolution, publishing) could surprise a user who believes they can turn the system off. Mitigation: if a real off-switch is wanted, Part-2 notes the alternative (add a true gate) — but the honest default is "this is baseline infra," documented.
+- **Self-modification safety:** retiring the auto-implement execution *reduces* risk (no silent self-edits); aligns with the instar-dev gate. The MERGE removes a confusing green light that does nothing today.
+- **Telemetry egress:** the deadlock fix enables the population feature for users who opt in; Echo stays off. No new default egress.
+- **dispatches:** leaving it off for Echo is the safe posture; the allowlist fix only affects downstream agents who explicitly enable it.
+- **Catalog edits + migration parity:** `FeatureDefinitions` changes reach existing agents via the normal update path; the catalog-truth test prevents re-drift.
+
+## Success criteria
+
+- `/features` reports state that matches runtime reality for all 13 features (no `mismatch`).
+- Every `enableAction` is valid (allowlisted key + read by runtime code) — enforced by test.
+- The catalog-truth test passes (no feature advertised opt-in that's actually always-on, and vice-versa).
+- `POST /telemetry/enable` works (no deadlock).
+- No feature toggle is a no-op (every advertised switch changes real behavior or is removed).
+- The Liveness Reconciler, run post-cleanup, reports zero `DARK/unexplained` and zero catalog mismatches.
+
+## Open questions (for /spec-converge)
+
+1. **Off-switch policy:** for always-on infra (evolution, publishing, input-guard), do we want real off-switches (add gates) or accept them as baseline (retire toggles)? Leaning baseline; Justin's call per feature.
+2. **response-review fate:** fully retire CoherenceGate, or keep it `observeOnly` as a fact-checking telemetry sink? The unique reviewers (claim-provenance/url-validity) have value the tone gate lacks.
+3. **MessageSentinel inbound wiring** — confirm whether the emergency-stop classifier is on the live ingress path; if not, that's a safety bug needing its own spec, prioritized.
+4. External cross-model review before ratification (per the reconciler spec's open question).

--- a/docs/specs/feature-activation-coherence.md
+++ b/docs/specs/feature-activation-coherence.md
@@ -80,7 +80,7 @@ Two sources of truth for "is this feature on" — `config.json` and the `Feature
 
 **Adjacent (own follow-ups, flagged not fixed here):**
 - `UnjustifiedStopGate` / stop-gate → handled by `context-death-stop-gate-rollout-completion.md` (now known to also need `StopGateDb` construction).
-- `MessageSentinel` inbound wiring → **needs its own verification spec** (is the emergency-stop classifier actually on the live ingress path? safety-relevant).
+- `MessageSentinel` inbound wiring → **VERIFIED BROKEN for lifeline-owned agents (P0 safety).** The sentinel intercept lives ONLY in `TelegramAdapter.processUpdate()` (`TelegramAdapter.ts:3532`), the adapter's own poll loop. Echo runs **lifeline-owned polling** (`server.ts:1167` names "echo"): the lifeline polls and forwards via `POST /internal/telegram-forward`, which injects directly (`onTopicMessage`/`injectTelegramMessage`) with **zero** sentinel references (`routes.ts:8391–8700`); `src/lifeline/*` does no classification. So "stop everything" is NOT structurally honored for Echo — it's injected as a normal message. The classifier itself is fine (live-tested: "stop everything"/"stop" → emergency-stop). **Fix (P0):** hoist the `processUpdate` sentinel logic into `/internal/telegram-forward` (classify before inject; on emergency-stop kill session + clear autonomous job via existing `onSentinelKillSession`; on pause → pause) so it fires regardless of polling owner + a wiring-integrity test asserting the forward route classifies before injecting + an integration test that an emergency-stop through the forward route kills the session. This is the highest-priority item in this spec.
 
 ### Part 3 — Hand off to the Liveness Reconciler
 

--- a/docs/specs/feature-activation-coherence.md
+++ b/docs/specs/feature-activation-coherence.md
@@ -5,6 +5,7 @@ status: draft
 approved: false
 date: 2026-05-24
 author: echo
+review-convergence: "internal-independent-review-2026-05-25 — one focused critical reviewer over the grounded draft; findings in reports/feature-activation-coherence-convergence.md. NOT YET RATIFIED (approved:false); blocking findings B1/B2 + recommended split (M5) must be resolved before implementation. External cross-model round still recommended."
 related:
   - docs/specs/built-but-dark-liveness-reconciler.md
   - docs/specs/context-death-stop-gate-rollout-completion.md
@@ -12,6 +13,16 @@ eli16-overview: feature-activation-coherence.eli16.md
 ---
 
 # Feature Activation Coherence
+
+> **CONVERGENCE NOTE (2026-05-25, iter-1).** An independent critical review found the core thesis sound but flagged must-fix items before implementation (full report: `reports/feature-activation-coherence-convergence.md`):
+> - **B1 (factual correction):** `response-review` is NOT "dead/unregistered plumbing." It IS registered as a Stop hook for **new** agents (`init.ts:4668`, codex hooks, always-overwritten by the migrator), gated on `responseReview.enabled` (off by default — correct opt-in). Echo (an **existing** agent) shows zero references → the real issue is a **migration-parity gap** (existing agents never got it added to `Stop[]`), plus off-by-default. So its disposition (MERGE → MessagingToneGate) must be re-justified on **redundancy** grounds (CoherenceGate duplicates the always-on tone gate), acknowledging it is a behavior change to a *working, opt-in* gate — not the removal of a dead path. (This corrects my earlier external-diagnosis error — same class as the MessageSentinel false-negative; verify liveness from the full code path, not the deployed artifact.)
+> - **B2 (blocking):** Part 1.1's "runtime probe" is under-specified. Needs a concrete `featureRuntimeProbe: Record<featureId, () => boolean>` map built in `server.ts` (where the 13 subsystem instances are in scope) and passed into `RouteContext`, with a per-feature probe-expression table (e.g. publishing→`ctx.publisher!=null`, telemetry→`ctx.telemetryHeartbeat!=null`, inputGuard→set on sessionManager). Part 1.5's catalog-truth test should reuse this probe (assert a new `FeatureDefinition.defaultState` matches the probe under empty config) rather than brittle static idiom-inference.
+> - **M4:** Migration: retired keys (`evolution.enabled`, `evolution.autoImplement`) are left on disk untouched; **`autoImplement` must NOT be mapped to `evolutionApprovalMode`** (it's inert today — mapping it would retroactively grant autonomy the user never had). Catalog ships in-package (reaches existing agents automatically).
+> - **M5 (recommended split):** split into (1) **enable-layer coherence** (Part 1 + the always-on-three catalog fixes + telemetry deadlock — low-risk, declarative/additive) and (2) a **behavior-disposition** spec for the only two surface-reducing changes (autonomous-evolution execution retirement + response-review merge), which warrant their own side-effects + cross-model review.
+> - **m7:** PR1's "red-first tests across PRs" violates the green-main standard — use `.skip`/`it.todo` (un-skipped in the disposition PR) or fold each truth-test into the PR that makes it pass.
+> - **m6/m8:** use existing `LiveConfig` EventEmitter for hot-reload (Part 1.4); add Agent-Awareness template edits for publishing/response-review changes too, not just input-guard.
+>
+> **Sound (don't touch):** the core thesis, the enableAction-validity test (Part 1.2), always-construct/gate-effects for telemetry (Part 1.3), evolution-system retire-the-flag, autonomous-evolution execution retirement, and the signal-vs-authority framing.
 
 ## One-paragraph summary
 
@@ -24,7 +35,7 @@ Justin's directive: dogfood every instar feature so we know it works coherently.
 ## Evidence (all live-verified on main v1.2.62 / the running agent)
 
 **Four enable-path failure classes (from the dogfood autopsy):**
-- **A — flag with no plumbing:** `response-review` (Stop-hook never registered), `dispatches` (and see inversion below).
+- **A — flag with no plumbing:** `dispatches` (enableAction targets a non-allowlisted key; see D + inversion below). *(Correction per convergence B1: `response-review` was previously listed here in error — it IS registered for new agents and is correctly opt-in/off; its real issue is a migration-parity gap for existing agents + redundancy with the tone gate, not "no plumbing." See the convergence note above.)*
 - **B — config ↔ registry desync + no hot-reload:** `PATCH /config {evolution|publishing}` sets the flag on disk but `FeatureRegistry.discoveryState` stays `undiscovered` until a restart re-runs `bootstrap()`; the running subsystem doesn't hot-reload.
 - **C — chicken-and-egg:** `POST /telemetry/enable` 503s because `telemetryHeartbeat` is only constructed at boot `if (config.monitoring?.telemetry?.enabled)` (`server.ts:2642`) — it can't be enabled through its own endpoint.
 - **D — enableAction targets a non-allowlisted key:** `dispatches`'s `enableAction` patches `dispatches`, absent from the `PATCH /config` allowlist (`routes.ts:11066-11070`) → 400.
@@ -80,7 +91,7 @@ Two sources of truth for "is this feature on" — `config.json` and the `Feature
 
 **Adjacent (own follow-ups, flagged not fixed here):**
 - `UnjustifiedStopGate` / stop-gate → handled by `context-death-stop-gate-rollout-completion.md` (now known to also need `StopGateDb` construction).
-- `MessageSentinel` inbound wiring → **VERIFIED BROKEN for lifeline-owned agents (P0 safety).** The sentinel intercept lives ONLY in `TelegramAdapter.processUpdate()` (`TelegramAdapter.ts:3532`), the adapter's own poll loop. Echo runs **lifeline-owned polling** (`server.ts:1167` names "echo"): the lifeline polls and forwards via `POST /internal/telegram-forward`, which injects directly (`onTopicMessage`/`injectTelegramMessage`) with **zero** sentinel references (`routes.ts:8391–8700`); `src/lifeline/*` does no classification. So "stop everything" is NOT structurally honored for Echo — it's injected as a normal message. The classifier itself is fine (live-tested: "stop everything"/"stop" → emergency-stop). **Fix (P0):** hoist the `processUpdate` sentinel logic into `/internal/telegram-forward` (classify before inject; on emergency-stop kill session + clear autonomous job via existing `onSentinelKillSession`; on pause → pause) so it fires regardless of polling owner + a wiring-integrity test asserting the forward route classifies before injecting + an integration test that an emergency-stop through the forward route kills the session. This is the highest-priority item in this spec.
+- `MessageSentinel` inbound wiring → **✅ DONE — SHIPPED** in PR #377 (`b3a8cf8f6`, released v1.2.72, 2026-05-25) via dedicated spec `emergency-stop-forward-path-wiring.md`. Entry retained for the record. Original finding: **VERIFIED BROKEN for lifeline-owned agents (P0 safety).** The sentinel intercept lived ONLY in `TelegramAdapter.processUpdate()` (`TelegramAdapter.ts:3532`), the adapter's own poll loop. Echo runs **lifeline-owned polling** (`server.ts:1167` names "echo"): the lifeline polls and forwards via `POST /internal/telegram-forward`, which injects directly (`onTopicMessage`/`injectTelegramMessage`) with **zero** sentinel references (`routes.ts:8391–8700`); `src/lifeline/*` does no classification. So "stop everything" is NOT structurally honored for Echo — it's injected as a normal message. The classifier itself is fine (live-tested: "stop everything"/"stop" → emergency-stop). **Fix (P0):** hoist the `processUpdate` sentinel logic into `/internal/telegram-forward` (classify before inject; on emergency-stop kill session + clear autonomous job via existing `onSentinelKillSession`; on pause → pause) so it fires regardless of polling owner + a wiring-integrity test asserting the forward route classifies before injecting + an integration test that an emergency-stop through the forward route kills the session. This is the highest-priority item in this spec.
 
 ### Part 3 — Hand off to the Liveness Reconciler
 

--- a/docs/specs/reports/built-but-dark-liveness-reconciler-convergence.md
+++ b/docs/specs/reports/built-but-dark-liveness-reconciler-convergence.md
@@ -1,0 +1,50 @@
+# Convergence report — Built-but-dark Liveness Reconciler
+
+**Date:** 2026-05-24 · **Author:** echo · **Round:** iter-1 (internal multi-lens) · **Spec:** `docs/specs/built-but-dark-liveness-reconciler.md`
+
+## Method
+
+Four independent reviewers, distinct lenses, run in parallel; all findings verified against live code by a dedicated grounding reviewer before acceptance:
+1. Architecture & correctness
+2. Standards conformance (CLAUDE.md standards + accumulated MEMORY lessons)
+3. Failure modes / edge cases / the flood requirement
+4. Codebase grounding (every load-bearing claim checked at file:line)
+
+**Limitation (must be addressed before ratification):** all reviewers were Claude-family. Per `feedback_external_crossmodel_catches_what_internal_misses`, an external GPT/Gemini/Grok round should run as the final convergence pass. Recorded as open-question #4 in the spec.
+
+## Verdict on the iter-1 draft
+
+**Do not approve as drafted.** The problem framing and flood-free *intent* were validated, but the design overclaimed reuse of three systems that do not hold the data it needs, and would have flooded on first run with 100+ false-positive findings — directly violating the hard requirement. The fix was a real architectural revision, not a tweak.
+
+## Findings → resolutions
+
+| # | Severity | Finding (verified) | Resolution in this draft |
+|---|---|---|---|
+| 1 | Blocking | Reconciler cannot classify its #1 dogfood target — `unjustifiedStopGate` is not a `FeatureDefinition`; `FeatureRegistry.getState/transition` refuse unknown ids. "Reuse ledger / no second store" contradicts "extend subject set." | Dedicated **`LivenessLedger`** (system-scoped, own schema/state model) for non-FeatureDefinition subjects; `FeatureRegistry` decisions reused only for the FD subjects it owns. Contradiction removed. |
+| 2 | Blocking | Consent FSM has no `undiscovered→declined/disabled` edge; can't mark a never-surfaced dark subject "explained"; anti-flood keyed on `featureVersion` absent for arbitrary subjects. | Liveness-specific `disposition` state model (`baseline-accepted/acknowledged/declined/snoozed/pending/open`); re-surfacing keyed on `evidenceHash` (content hash) for versionless subjects. |
+| 3 | Blocking | `CapabilityIndex` is the wrong wiring source — it *excludes* `/internal/*` (the stop-gate route is in `INTERNAL_PREFIXES`) and has no uniform enabled/wired boolean. | Dedicated **wiring snapshot**: route-table dump incl. `/internal/*` + `settings.json` + a startup **construction registry**. CapabilityIndex demoted to a hint. |
+| 4 | Blocking | "Zero callers" not runtime-detectable — no per-route counters exist; degenerates to static grep. | **Honest scope** section + a new lightweight per-route **invocation counter** for opt-in routes; static reference scan elsewhere, tagged `evidenceKind: static`. No overclaim. |
+| 5 | Blocking (flood) | Cold-start flood: ~128 approved specs + 16 hooks + 13 mostly-off opt-in features → 100+ "unexplained dark + new" on first run; "one digest of 100+" is still a flood; no baseline. | **Intent-modality axis** (off is a defect only for `should-be-live`) + **baseline anchor** (one-time accept of pre-existing dark). First-run target: ≤2 pushes, zero others. |
+| 6 | Blocking | "Nobody decided" vs "correctly default-off opt-in" indistinguishable; opt-in features (consentTier network/self-governing) are *supposed* to be off. | `should-be-offerable` modality (derived from consentTier / opt-in) → INTENTIONALLY-OFF, never a finding. |
+| 7 | Blocking | Config-sync disable (`bootstrap()`) carries no reason/actor; `DiscoveryEvent.context` optional; mandatory-reason would break boot. | Distinguish decision-disable (API requires reason) from config-sync-disable (synthetic `system` reason); `reason`/`actor`/`reasonClass` as first-class ledger fields. |
+| C1 | Critical | Agent Awareness violation — `/liveness` never added to `generateClaudeMd` (a capability-surfacing feature, itself un-surfaced). | Explicit PR2 deliverable: Capabilities entry + Registry-First row + proactive trigger; `feature-delivery-completeness` will enforce it. |
+| C2 | Critical | Reason-capture "the agent's responsibility, enforced by grounding discipline" = willpower (the exact anti-pattern Justin flagged). | **Structural reason-capture** (§8): API-layer mandatory reason; reconciler never assumes capture; first contact is a low-priority pull-surface "why is this off?". |
+| H1 | High | Reconciler's own wiring test not mandated (fails its own thesis). | PR4 wiring-integrity test: `LivenessReconciler` constructed with non-null deps + job registered; self-listed as a subject; `guardian-pulse` heartbeat. |
+| H2 | High | Per-PR test tiers inconsistent (PR3 schema + PR4 surfacing under-tested). | Per-PR tiers spelled out; semantic-correctness tests for both sides of all seven suppression layers; schema-migration idempotency e2e. |
+| H3 | High | discovery.db migration-parity asserted, not specified. | PR3 names the path: idempotent `CREATE TABLE IF NOT EXISTS` in ledger self-migrating init; seeded for existing agents; `migrateConfig` existence-checked. |
+| P1-E | High | Severity gate brittle — 3/13 are `safety`, ungoverned enum, non-FD subjects have no category → motivating bug would be detected then NOT pushed. | Severity from the explicit `liveness-manifest` (never inferred); dogfood gate asserts the stop-gate pushes at `critical`. |
+| P1-F | High | Stale "explained" silences a real dark feature forever. | `reasonClass: conditional` + `evidenceHash` re-validation (pull-surface re-surface on code change). |
+| P2-G | Medium | Acknowledge-once never-responded path undefined. | `MAX_SURFACES` cap on *surfaces* (not declines) → ages to pull-surface-only; no silent drop, no re-flood. |
+| P2-H | Medium | Self-darkness — reconciler can silently die. | `lastReconciliationAt` + independent `guardian-pulse` heartbeat; self-listed subject. |
+| #8/#9 | Major/Minor | Taxonomy not mutually exclusive; subjectId rename churn; DEPLOY-LAG not per-feature observable. | Precedence-ordered taxonomy + INTENTIONALLY-OFF + `expects-flow` predicate; stable subjectId + evidenceHash; DEPLOY-LAG demoted to one global advisory. |
+
+## Residual open questions (carried into the spec)
+
+1. Baseline trade: silent-accept vs paced baseline-review digest — **needs Justin's call**.
+2. Invocation-counter scope + memory cost at scale.
+3. `liveness-manifest` governance (the partial-bootstrap risk — defining "every should-be-live thing" mechanically is itself the hard problem).
+4. External cross-model review before ratification.
+
+## Status
+
+Revised draft addresses all blocking + critical + high findings and the truthfulness-affecting P1/P2s. Remaining work before `approved: true`: Justin's call on open-question #1, and (recommended) an external cross-model round.

--- a/docs/specs/reports/feature-activation-coherence-convergence.md
+++ b/docs/specs/reports/feature-activation-coherence-convergence.md
@@ -1,0 +1,33 @@
+# Convergence report — Feature Activation Coherence
+
+**Date:** 2026-05-25 · **Author:** echo · **Round:** iter-1 (internal, one focused independent reviewer) · **Spec:** `docs/specs/feature-activation-coherence.md`
+
+## Method
+
+One independent critical reviewer over the already-grounded draft (the dispositions came from a prior 3-agent code re-assessment, so this pass targeted design coherence / standards / implementability rather than re-verifying facts). All load-bearing claims re-checked against source at v1.2.72. **External cross-model round still recommended before ratification** (per `feedback_external_crossmodel_catches_what_internal_misses`).
+
+## Verdict
+
+Core thesis sound and well-grounded. Two blocking findings (one a factual correction of the author's own evidence) and a recommended split. Not ratified.
+
+## Findings → resolutions
+
+| # | Sev | Finding | Resolution |
+|---|---|---|---|
+| B1 | Blocking | `response-review` listed as "Class A — flag with no plumbing (Stop-hook never registered)" is **factually wrong**. It IS registered for new agents (`init.ts:4668`, `installCodexHooks.ts:96`, always-overwritten by `PostUpdateMigrator:1726`), gated on `responseReview.enabled` (off by default = correct opt-in). PR1's enableAction-validity test would find its enableAction *valid* (`responseReview` is allowlisted + read), contradicting the spec's "tests go red for response-review." | Corrected in spec (convergence note + evidence line). Verified independently: new agents get it in `Stop[]`; **Echo (existing) shows 0 references → real issue is a migration-parity gap** (existing agents never got it added to `Stop[]`) + off-by-default. Re-justify the MERGE on **redundancy** (CoherenceGate duplicates the always-on `MessagingToneGate`), acknowledging it's a behavior change to a *working* opt-in gate, not removal of dead code. |
+| B2 | Blocking | Part 1.1 "single derived state / runtime probe" under-specified — the `/features` route has no handle to the 13 subsystem instances; each probes differently. Unimplementable as written. | Spec note added: introduce `featureRuntimeProbe: Record<featureId, () => boolean>` built in `server.ts` (instances in scope), passed into `RouteContext`; per-feature probe table required. Part 1.5 catalog-truth test reuses this probe (assert new `FeatureDefinition.defaultState` vs probe under empty config) instead of static idiom-inference. |
+| M3 | Major | Part 1.5 catalog-truth test via static idiom classification (`new X()` vs `!== false` vs `if(config.x.enabled)`) is brittle — construction sites don't uniformly reference the configPath; regex mis-classifies, full AST is unbudgeted. | Replace with the runtime-probe-under-default-config approach (B2). Keep the genuinely-static, robust checks (configPath resolves to a real `InstarConfig` field; enableAction key allowlisted). Drop idiom inference. |
+| M4 | Major | Migration parity for retiring `evolution.enabled` / `evolution.autoImplement` asserted, not designed. `migrateConfig` is additive only. Risks: an agent with `evolution.enabled:false` now silently runs the always-on manager against their stated preference; mapping `autoImplement:true`→`autonomous` would **retroactively grant autonomy** (the key is inert today). | Spec note added: retired keys left on disk untouched; **`autoImplement` NOT mapped** to `evolutionApprovalMode`; catalog ships in-package (reaches existing agents automatically); add a one-time notice if an agent had explicitly set a now-retired flag. |
+| M5 | Major (recommended) | Scope too large: a mechanism rebuild + 7 dispositions + 2 safety findings of differing maturity in one spec. The shipped MessageSentinel item is even labeled "highest priority" (contradiction). | **Split** into (1) enable-layer coherence (Part 1 + always-on-three catalog fixes + telemetry deadlock — low-risk, declarative/additive) and (2) a behavior-disposition spec (autonomous-evolution execution retirement + response-review merge — the only surface-reducing changes; need own side-effects + cross-model). Reduce MessageSentinel to a one-line "shipped, see emergency-stop-forward-path-wiring.md." Flagged in convergence note; Justin to confirm the split. |
+| m6 | Minor | Part 1.4 hot-reload ignores existing `src/config/LiveConfig.ts` (EventEmitter + watchPaths, already in `ctx.liveConfig`). | Reference `LiveConfig` as the `config-changed` mechanism — de-risks the fallback, may make true hot-reload cheap. Noted in convergence note. |
+| m7 | Minor | PR1 "red-first tests across PRs" violates the non-negotiable green-main standard (Husky pre-push + CI branch protection). | Use `.skip`/`it.todo` with the marker (green push, documented gap), un-skipped in each disposition PR — or fold each truth-test into the PR that makes it pass. Noted. |
+| m8 | Minor | Agent-Awareness gap correctly flagged for input-guard (verified absent from `templates.ts`) but missed for publishing/response-review changes. | Add Agent-Awareness checklist line to PR3 and PR6. Noted. |
+| m9 | Minor | `dispatches` allowlist fix could move the lie from "API rejects" to "API accepts but still dark" if no downstream puller. | Verified the puller exists: `config.dispatches` → constructs `AutoDispatcher` (`server.ts:4778`). So enabling it for downstream agents genuinely wires the puller; for Echo, `config.dispatches` is absent (correct off-state). Lower concern than flagged; note the puller is gated on `config.dispatches` existing. |
+
+## Sound — do not touch
+
+Core thesis (all re-verified: dispatches enableAction non-allowlisted → 400; telemetry boot-gated deadlock; EvolutionManager unconditional; `autoImplement` read by nobody; `processProposalAutonomously` zero callers; publishing/input-guard `!== false` default-on; input-guard absent from template). The enableAction-validity test (strongest, robust). Always-construct/gate-effects for telemetry. Evolution-system retire-the-flag. Autonomous-evolution execution retirement (risk-reducing — path is dead). Signal-vs-authority framing.
+
+## Status
+
+Findings incorporated as a convergence note + evidence correction + `review-convergence` frontmatter tag. **Remaining before implementation:** resolve B2 (probe map design — fold into the spec body or the split's spec-1), apply the M5 split, then ratification (`approved: true` is Justin's act) + recommended external cross-model round.


### PR DESCRIPTION
**Draft — not for merge as-is.** Durable home + review surface for the three specs from the topic-12702 "built but dark" investigation. The P0 safety fix that this investigation surfaced already shipped separately (#377, v1.2.72).

## What's here (all `approved: false`)

1. **`built-but-dark-liveness-reconciler.md`** (+ ELI16 + convergence report) — the standing watchdog that reconciles declared-intent vs runtime-reality across the whole feature surface, ledger-informed + flood-free. Through one internal multi-lens convergence (caught & fixed a cold-start-flood design flaw). **Open design call:** day-one baseline (silent-accept vs paced review).
2. **`feature-activation-coherence.md`** (+ ELI16 + convergence report) — the catalog systematically lies about runtime on/off; fix the enable layer + per-feature dispositions (finish/improve/merge/retire). Through one internal convergence — see the convergence note for blocking findings (B1 response-review correction, B2 runtime-probe design) and the **recommended split** (enable-layer-coherence vs behavior-disposition).
3. **`context-death-stop-gate-rollout-completion.md`** (+ ELI16) — completes the already-approved context-death spec's unfinished rollout (hook router never wired + never flipped past `mode=off`).

## What's needed to move these to implementation

- **Ratification** (`approved: true` — your call, per the instar-dev gate).
- **Two design decisions:** the Reconciler baseline approach; and whether to run an external cross-model review round before ratifying.
- Resolve the activation-coherence convergence's B2 (probe-map design) + apply the recommended M5 split.

Each spec leads with a plain-English ELI16 overview. Nothing here changes runtime — pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)