### PR TITLE
feat(memory): unify the working-awareness stores under one ranked read path (rung 2)

### DIFF
--- a/docs/specs/cwa-unify-stores.eli16.md
+++ b/docs/specs/cwa-unify-stores.eli16.md
@@ -1,0 +1,64 @@
+# Plain-English overview — one shelf instead of three
+
+## The one-sentence version
+
+Right now I keep "what's relevant" in three separate notebooks that don't talk to
+each other. This makes one ranked reading list that pulls from all three, so when
+I sit down I get *one* sorted view of what matters — not three half-answers.
+
+## Why this matters (the three-notebooks analogy)
+
+Imagine you kept your to-do reminders in three different notebooks: one for facts
+from conversations, one for handy reference cards, one for longer-term knowledge.
+Each notebook sorts itself its own way. When you start your day, you'd have to
+flip through all three and mentally merge them. That's me today.
+
+This change adds a front page that reads all three notebooks and gives me one
+ranked list — most-relevant first, faded stuff dropping off the bottom (but not
+thrown away; it comes back the moment it's mentioned again).
+
+## The important, non-obvious part
+
+I am NOT proposing to dump all three notebooks into one big database and shuffle
+everyone's pages around — that's a huge, risky move for little gain. Instead, I
+already have a thing called the "assembler" that, at the start of a session, pulls
+together the right context within a budget. It pulls from *some* of the
+notebooks today. This change just teaches it to also pull from the other two and
+rank everything together. The notebooks stay where they are; the *reading* is
+what gets unified.
+
+That's the load-bearing choice I want you to confirm: **unify the reading, leave
+the storage alone.** It's additive, reversible, and doesn't touch your existing
+data.
+
+## What it does, concretely
+
+1. Defines a common "card" shape so an item from any notebook looks the same to
+   the ranker (a bit of text, how relevant, how recent, where it came from).
+2. Ranks all the cards together (relevance, with older stuff gently sinking), then
+   fills the context up to a budget — same budgeting the assembler already does.
+3. Each notebook keeps its own sense of how fast things fade; the ranker just
+   blends them, it doesn't overrule them.
+4. Keeps score of which notebook contributed what, so we can see if the blend is
+   actually better and tune it.
+
+A safety promise built in: if the new notebooks are empty, what I assemble is
+*exactly* what I assemble today — so this can't quietly change existing behavior.
+
+## What I want from you
+
+This is the **ratification gate** — your sign-off before I build. The big one:
+
+- **(A)** Unify the *reading* (extend the assembler) — my strong pick — vs. merge
+  the actual storage and migrate data (much riskier, little upside).
+- **(B)** The exact ranking formula + how much room each notebook gets — starting
+  guesses, tunable later.
+- **(C)** Keep each notebook's own filtering inside that notebook (my pick) vs.
+  move it into the ranker.
+
+## One honest caveat
+
+This is the biggest, most structural step yet — it touches the shared assembler
+lots of things read from. I wrote and self-reviewed it, but the full multi-model
+review tooling isn't on this machine, so a fuller review before the code merges is
+especially worth it here. "Approved" means "direction's right, go build."

--- a/docs/specs/cwa-unify-stores.md
+++ b/docs/specs/cwa-unify-stores.md
@@ -3,10 +3,12 @@ slug: cwa-unify-stores
 title: Unify the working-awareness stores under one ranked read path
 author: echo
 project: continuous-working-awareness
-status: draft-pending-ratification
-review-convergence: null
-approved: false
-approved-by: null
+status: approved
+review-convergence: "2026-05-25T08:48:00Z"
+review-iterations: 1
+review-note: "Claude-authored + manual standards/lessons self-review (single angle). Full /spec-converge + /crossreview multi-model convergence NOT run — tooling absent on this host. Ratified by Justin 2026-05-25 with that caveat explicit; this is the most architectural rung — fuller multi-model review especially advisable before/with merge."
+approved: true
+approved-by: justin
 eli16-overview: cwa-unify-stores.eli16.md
 ---
 

--- a/docs/specs/cwa-unify-stores.md
+++ b/docs/specs/cwa-unify-stores.md
@@ -1,0 +1,183 @@
+---
+slug: cwa-unify-stores
+title: Unify the working-awareness stores under one ranked read path
+author: echo
+project: continuous-working-awareness
+status: draft-pending-ratification
+review-convergence: null
+approved: false
+approved-by: null
+eli16-overview: cwa-unify-stores.eli16.md
+---
+
+# Unify the Working-Awareness Stores (rung 2)
+
+## Problem statement
+
+Rungs 0–1 fill the topic-intent store from live conversation (facts/decisions +
+task frame). But that's now *another* island of agent memory alongside the
+others:
+
+- **Playbook** — a manifest of tagged, trigger-gated context items with their own
+  usefulness/decay lifecycle (`instar playbook`).
+- **Semantic / Episodic memory** — entity + episode stores with embeddings, vector
+  search, and digests (`src/memory/`).
+- **Topic-intent** — per-topic refs with a confidence/decay/tier model (rungs 0–1).
+
+Each has its own read path, its own ranking, its own decay. So "what context is
+relevant right now?" has *three different answers from three different doors* —
+and nothing reconciles them into one ranked set. That's the fragmentation the
+North Star (`docs/NORTH-STAR.md`) names as the real problem: *"a dozen
+single-purpose watchers with private state, no shared working set."* Rung 2 gives
+them **one ranked, decaying working set with one read path.**
+
+## The key reframing (and the central decision)
+
+There is already a partial unifier: **`WorkingMemoryAssembler`** — a
+token-budgeted assembler that queries SemanticMemory + EpisodicMemory + others and
+returns "right context, right amount, right moment" with per-source budgets and a
+tiered render strategy (top-N full / next-N compact / rest name-only).
+
+So rung 2 is **NOT** "migrate three stores into one database" (a massive, risky,
+low-reward data migration). It is **"make the assembler the single unified READ
+path"**: add topic-intent and Playbook as assembly *sources*, normalize every
+source's relevance + recency into one ranking under the existing token budget, so
+one assembled context draws from all of them consistently. The stores keep their
+specialized write paths and backends; the **read** is unified.
+
+**Decision flagged for ratification (A) — the architecture fork.** Recommended:
+**unify the read path** (extend `WorkingMemoryAssembler`), leaving storage as-is.
+Alternative: build a new physical unified store and migrate. Recommendation is
+strongly the former — it delivers the North Star's "one ranked working set, one
+read path" with additive, reversible change and no data migration, and it's
+honest about what these stores are (specialized backends, not interchangeable rows).
+
+## Proposed design
+
+### 1. A common ranked-item shape (the lingua franca)
+
+Define a normalized `WorkingSetItem` the assembler ranks across sources:
+`{ source, id, text, relevance (0–1), recencyAt, kind, originRef }`. Each source
+adapts its native model into it:
+
+- **topic-intent** → refs at/above a tier; `relevance` from the confidence
+  projection, `recencyAt` from `lastReinforcedAt`. (Decay already lives in the
+  projection — rungs 0–1.)
+- **Playbook** → items matching the session triggers/tags; `relevance` from the
+  item's usefulness score, `recencyAt` from its last-used timestamp.
+- **semantic/episodic** → the assembler's existing scored entities/digests,
+  wrapped in the same shape (no behavior change — just the adapter).
+
+### 2. One ranking + one decay posture
+
+The assembler ranks the merged `WorkingSetItem[]` by a blended score
+(relevance × a recency-decay factor), then applies the existing token budget +
+render tiers. Decay is **demotion not deletion** (the rung-0 posture, now applied
+across sources): a faded item drops out of the hot assembled set but remains in
+its backing store and re-warms on reference. Per-source decay half-lives are
+respected (topic-intent's per-kind horizons; Playbook's lifecycle) — the assembler
+normalizes them into one recency factor, it does not override them.
+
+### 3. One read path, additively
+
+`WorkingMemoryAssembler.assemble()` gains topic-intent + Playbook sources behind
+per-source token budgets (so adding them can't starve existing sources — budgets
+are additive with sane defaults). Callers that already use the assembler get the
+richer set for free; the individual stores' direct reads remain for their
+specialized callers (briefing, ArcCheck, `playbook list`). **No read path is
+removed** — the assembler becomes the *unified* one, not the *only* one.
+
+### 4. Signal vs. authority, near-silent, observability
+
+- The assembler **signals** a ranked set; it has no blocking authority (it informs
+  context, doesn't gate). Consistent with the whole North Star.
+- Observability (per the Observability article): meter what each source
+  contributes to assembled contexts (items offered / included / dropped-by-budget,
+  per source) so we can SEE whether unification actually improves the mix and tune
+  budgets from data.
+- No new per-turn cost: assembly already runs at session-start/compaction; adding
+  sources is more ranking, not more LLM calls.
+
+## Non-goals (tracked, not silent)
+
+- **Physical store merge / data migration** — explicitly rejected for v1
+  <!-- tracked: cwa-physical-store-merge --> (the read-path unification supersedes
+  the need; revisit only if a concrete backend reason emerges).
+- **The Usher / mid-task re-surfacing** is rung 4 <!-- tracked: cwa-usher -->; this
+  spec unifies the session-start/compaction read, not continuous mid-task injection.
+- **Capability + standards descriptors as sources** (rung-3 inward facet) ride a
+  follow-up <!-- tracked: cwa-capability-index-context --> once the lingua-franca
+  shape exists (this spec makes that cheap later).
+
+## Lessons carried (manual lessons-grep)
+
+- **No greenfield / build on what exists**: extend the assembler, don't reinvent —
+  the North Star explicitly says "not greenfield; generalizes a pattern we already
+  prototyped."
+- **Signal vs. authority**, **near-silent**, **Observability**, **framework-agnostic**
+  (pure ranking, no engine coupling), **migration parity** (additive sources +
+  budgets; no store schema change), **testing integrity** (3 tiers + the
+  no-regression pin that existing assembler output is unchanged when the new
+  sources are empty).
+- **Best-effort / degrade-safe**: a source that errors or is absent contributes
+  nothing and never breaks assembly (each source adapter is wrapped).
+
+## Testing (all three tiers)
+
+- **Tier 1 (unit):** each source adapter maps its native model → `WorkingSetItem`
+  correctly; the blended ranking orders a mixed set sanely; per-source budget caps
+  hold; an empty/erroring source is skipped (degrade-safe); **regression pin** —
+  with topic-intent + Playbook sources empty, assembled output is identical to
+  today's.
+- **Tier 2 (integration):** the assembler endpoint returns a context that includes
+  items from topic-intent + Playbook + semantic, correctly budgeted; observability
+  counts per-source contribution.
+- **Tier 3 (e2e):** boot the real path; populate a topic-intent ref + a Playbook
+  item + a semantic entity; assemble; confirm one ranked context draws from all
+  three under budget — the unified read path, alive.
+
+## Acceptance criteria
+
+1. `WorkingMemoryAssembler` produces one ranked context drawing from topic-intent,
+   Playbook, and semantic/episodic, under a token budget — verified e2e.
+2. Each source's native decay/recency is respected (not overridden) in the blend.
+3. With the new sources empty, assembled output is byte-for-byte today's
+   (regression pin) — additive, no behavior change for existing callers.
+4. A failing/absent source contributes nothing and never breaks assembly.
+5. Per-source contribution is metered (offered / included / dropped).
+6. No store schema migration; the individual read paths still work.
+7. All three tiers green; tsc + lint clean.
+
+## Risk and rollback
+
+Medium — it touches the shared assembler, but additively and behind per-source
+budgets, with a regression pin guaranteeing unchanged output when the new sources
+are empty. Worst case on a bug: a sub-optimal mix in an assembled context (a
+quality issue, never a delivery/data-loss issue). Rollback: drop the new source
+adapters; the assembler returns to its current sources. No data migration to undo.
+
+## Migration parity
+
+Additive assembler sources + per-source token-budget defaults (existence-checked)
++ observability counters. Server-side (every agent gets it on update). No store
+schema change, no hook/template/skill change.
+
+## Open decisions for ratification
+
+- **(A)** Unify the READ path via `WorkingMemoryAssembler` (recommended) vs. a new
+  physical unified store + migration. *This is the load-bearing decision.*
+- **(B)** The blended-score formula (relevance × recency-decay) and default
+  per-source token budgets — starting points, tunable via the observability
+  counters.
+- **(C)** Whether Playbook's trigger/tag gating stays Playbook-internal (assembler
+  consumes the already-filtered set — recommended) or moves into the assembler.
+
+## Convergence note (honest)
+
+Claude-authored draft + manual standards/lessons self-review; full `/spec-converge`
++ `/crossreview` multi-model tooling is absent on this host
+(`[[feedback_external_crossmodel_catches_what_internal_misses]]`). This is the
+largest, most architectural rung so far — ratification here = "this read-path-unification
+direction is right, build it," and a fuller multi-model review is especially
+worth doing before the code merges given the blast radius touches the shared
+assembler.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4271,13 +4271,17 @@ export async function startServer(options: StartOptions): Promise<void> {
     // Initialize WorkingMemoryAssembler — token-budgeted context assembly for session-start hooks.
     // Placed after activitySentinel so episodicMemory can be wired from the sentinel.
     // Skipped in minimal-config setups where neither memory system is available.
-    if (semanticMemory || activitySentinel) {
+    if (semanticMemory || activitySentinel || topicIntentStore) {
       workingMemory = new WorkingMemoryAssembler({
         semanticMemory,
         episodicMemory: activitySentinel?.getEpisodicMemory(),
+        // rung 2 — unified read path: topic-intent refs + Playbook manifest items
+        // join the assembled working set (both read-only, degrade-safe).
+        topicIntentStore,
+        stateDir: config.stateDir,
       });
       const epStatus = activitySentinel ? 'yes' : 'no';
-      console.log(pc.green(`  WorkingMemoryAssembler: ready (semantic: ${semanticMemory ? 'yes' : 'no'}, episodic: ${epStatus})`));
+      console.log(pc.green(`  WorkingMemoryAssembler: ready (semantic: ${semanticMemory ? 'yes' : 'no'}, episodic: ${epStatus}, topic-intent: ${topicIntentStore ? 'yes' : 'no'})`));
     }
 
     // Session Watchdog — auto-remediation for stuck commands

--- a/src/memory/WorkingMemoryAssembler.ts
+++ b/src/memory/WorkingMemoryAssembler.ts
@@ -25,6 +25,8 @@
 import type { SemanticMemory } from './SemanticMemory.js';
 import type { EpisodicMemory, ActivityDigest, SessionSynthesis } from './EpisodicMemory.js';
 import type { MemoryEntity, ScoredEntity } from '../core/types.js';
+import type { TopicIntentStore } from '../core/TopicIntent.js';
+import { rankWorkingSet, topicIntentToWorkingSet, playbookManifestToWorkingSet, type WorkingSetItem } from './WorkingSet.js';
 import { estimateTokens } from './Chunker.js';
 
 // ─── Types ──────────────────────────────────────────────────────────
@@ -34,6 +36,17 @@ export interface WorkingMemoryConfig {
   semanticMemory?: SemanticMemory;
   /** EpisodicMemory instance (optional — degrades gracefully) */
   episodicMemory?: EpisodicMemory;
+  /**
+   * TopicIntentStore (rung 2) — when provided, the topic's established refs join
+   * the unified working-set section. Optional; absent → that source is empty.
+   */
+  topicIntentStore?: TopicIntentStore;
+  /**
+   * State dir (rung 2) — when provided, Playbook manifest items matching the
+   * query join the unified working-set section (read-only manifest scan, no
+   * Python). Optional; absent → that source is empty.
+   */
+  stateDir?: string;
 
   /** Token budgets per source. Defaults provided. */
   tokenBudgets?: Partial<TokenBudgets>;
@@ -46,6 +59,8 @@ export interface TokenBudgets {
   episodes: number;
   /** Max tokens for relationship/people context */
   relationships: number;
+  /** Max tokens for the unified working set (topic-intent + Playbook) — rung 2 */
+  workingSet: number;
   /** Total max tokens (hard cap on entire assembly) */
   total: number;
 }
@@ -89,6 +104,7 @@ const DEFAULT_BUDGETS: TokenBudgets = {
   knowledge: 800,
   episodes: 400,
   relationships: 300,
+  workingSet: 500,
   total: 2000,
 };
 
@@ -97,11 +113,15 @@ const DEFAULT_BUDGETS: TokenBudgets = {
 export class WorkingMemoryAssembler {
   private semanticMemory?: SemanticMemory;
   private episodicMemory?: EpisodicMemory;
+  private topicIntentStore?: TopicIntentStore;
+  private stateDir?: string;
   private budgets: TokenBudgets;
 
   constructor(config: WorkingMemoryConfig) {
     this.semanticMemory = config.semanticMemory;
     this.episodicMemory = config.episodicMemory;
+    this.topicIntentStore = config.topicIntentStore;
+    this.stateDir = config.stateDir;
     this.budgets = { ...DEFAULT_BUDGETS, ...config.tokenBudgets };
   }
 
@@ -154,6 +174,24 @@ export class WorkingMemoryAssembler {
         if (relationshipSection.content) {
           sections.push(relationshipSection);
           totalTokens += relationshipSection.tokens;
+        }
+      }
+    }
+
+    // 4. Unified working set (rung 2): topic-intent refs + Playbook items, ranked
+    //    together by blended relevance×recency. Appended AFTER the existing
+    //    sources and gated on the new deps, so when neither is configured the
+    //    assembled output is byte-for-byte unchanged (regression pin).
+    if (this.topicIntentStore || this.stateDir) {
+      const remainingBudget = Math.min(
+        this.budgets.workingSet,
+        this.budgets.total - totalTokens,
+      );
+      if (remainingBudget > 50) {
+        const workingSetSection = this.assembleWorkingSet(trigger.topicId, queryTerms, remainingBudget);
+        if (workingSetSection.content) {
+          sections.push(workingSetSection);
+          totalTokens += workingSetSection.tokens;
         }
       }
     }
@@ -258,6 +296,50 @@ export class WorkingMemoryAssembler {
     }
 
     return this.renderEntities(people, budget, 'relationships');
+  }
+
+  // ─── Working Set Assembly (rung 2 — unified read path) ────────────
+
+  /**
+   * Assemble the unified working set: topic-intent refs (relevance = confidence,
+   * recency = lastReinforcedAt) + Playbook manifest items matching the query
+   * (relevance = trigger/tag match + usefulness, recency = freshness), ranked
+   * together by blended relevance×recency-decay and rendered under budget. Both
+   * sources are read-only + degrade-safe — a missing/erroring source contributes
+   * nothing and never breaks assembly.
+   */
+  private assembleWorkingSet(
+    topicId: number | undefined,
+    queryTerms: string[],
+    budget: number,
+  ): { name: string; content: string; tokens: number; count: number } {
+    const items: WorkingSetItem[] = [
+      ...topicIntentToWorkingSet(this.topicIntentStore, topicId),
+      ...playbookManifestToWorkingSet(this.stateDir, queryTerms),
+    ];
+    if (items.length === 0) {
+      return { name: 'working-set', content: '', tokens: 0, count: 0 };
+    }
+    const ranked = rankWorkingSet(items);
+    return this.renderWorkingSet(ranked, budget);
+  }
+
+  private renderWorkingSet(
+    items: WorkingSetItem[],
+    budget: number,
+  ): { name: string; content: string; tokens: number; count: number } {
+    const lines: string[] = [];
+    let tokens = 0;
+    let count = 0;
+    for (const item of items) {
+      const entry = `- **[${item.source}/${item.kind}]** ${item.text}`;
+      const entryTokens = estimateTokens(entry);
+      if (tokens + entryTokens > budget) break;
+      lines.push(entry);
+      tokens += entryTokens;
+      count++;
+    }
+    return { name: 'working-set', content: lines.join('\n'), tokens, count };
   }
 
   // ─── Rendering ────────────────────────────────────────────────────
@@ -424,6 +506,7 @@ export class WorkingMemoryAssembler {
       case 'knowledge': return 'Relevant Knowledge';
       case 'episodes': return 'Recent Activity';
       case 'relationships': return 'People Context';
+      case 'working-set': return 'Working Set (tracked context)';
       default: return name;
     }
   }

--- a/src/memory/WorkingSet.ts
+++ b/src/memory/WorkingSet.ts
@@ -1,0 +1,172 @@
+/**
+ * WorkingSet — the lingua franca that lets the WorkingMemoryAssembler rank items
+ * from different stores (topic-intent, Playbook, …) in one list (rung 2 of
+ * continuous-working-awareness).
+ *
+ * Each store adapts its native model into a `WorkingSetItem`; `rankWorkingSet`
+ * blends relevance with a recency-decay factor so a single ranked reading list
+ * draws from all sources consistently. Decay is demotion, not deletion — a faded
+ * item sinks in the ranking but stays in its backing store and re-warms on
+ * reference. Pure functions + read-only adapters; degrade-safe (a missing/empty
+ * source contributes nothing). Spec: docs/specs/cwa-unify-stores.md.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { TopicIntentStore } from '../core/TopicIntent.js';
+
+export interface WorkingSetItem {
+  /** Which store the item came from. */
+  source: 'topic-intent' | 'playbook';
+  /** Stable id within the source. */
+  id: string;
+  /** Short human-readable descriptor (the line shown in assembled context). */
+  text: string;
+  /** Native relevance, normalized to 0–1 (confidence, usefulness, match score). */
+  relevance: number;
+  /** ISO8601 of the item's last reinforcement / freshness (drives recency decay). */
+  recencyAt: string;
+  /** Item kind/category (for labelling). */
+  kind: string;
+}
+
+/** Recency half-life (days) for the blended score's decay factor. Tunable. */
+export const RECENCY_HALF_LIFE_DAYS = 30;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Blended score = relevance × recency-decay-factor. The recency factor is
+ * exp(-ln2 · ageDays / halfLife): 1.0 today, 0.5 at one half-life, etc. Items
+ * with no parseable recency are treated as "now" (factor 1) so a source that
+ * doesn't track recency isn't unfairly sunk.
+ */
+export function blendedScore(item: WorkingSetItem, nowMs: number = Date.now()): number {
+  const rel = Number.isFinite(item.relevance) ? Math.max(0, Math.min(1, item.relevance)) : 0;
+  let ageDays = 0;
+  const t = Date.parse(item.recencyAt);
+  if (Number.isFinite(t)) ageDays = Math.max(0, (nowMs - t) / MS_PER_DAY);
+  const recencyFactor = Math.exp((-Math.LN2 * ageDays) / RECENCY_HALF_LIFE_DAYS);
+  return rel * recencyFactor;
+}
+
+/** Rank a mixed working set by blended score (descending). Stable, pure. */
+export function rankWorkingSet(items: WorkingSetItem[], nowMs: number = Date.now()): WorkingSetItem[] {
+  return [...items]
+    .map((it, i) => ({ it, i, s: blendedScore(it, nowMs) }))
+    .sort((a, b) => (b.s - a.s) || (a.i - b.i))
+    .map(x => x.it);
+}
+
+// ── Source adapter: topic-intent ───────────────────────────────────────────
+
+/**
+ * Map a topic's established refs (at/above tentative) to WorkingSetItems.
+ * Relevance = the confidence projection; recency = lastReinforcedAt. Read-only,
+ * degrade-safe (no store / no topic / error → []).
+ */
+export function topicIntentToWorkingSet(
+  store: TopicIntentStore | null | undefined,
+  topicId: number | undefined,
+  nowMs?: number,
+): WorkingSetItem[] {
+  if (!store || typeof topicId !== 'number') return [];
+  try {
+    const refs = store.getRefsAtOrAbove(topicId, 'tentative', nowMs);
+    return refs.map(r => ({
+      source: 'topic-intent' as const,
+      id: r.refId,
+      text: r.text,
+      relevance: r.projection.confidence,
+      recencyAt: r.lastReinforcedAt,
+      kind: r.kind,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// ── Source adapter: Playbook (read-only manifest scan, no Python) ───────────
+
+interface RawPlaybookItem {
+  id?: string;
+  category?: string;
+  path?: string;
+  freshness?: string;
+  tokens_est?: number;
+  usefulness?: { helpful?: number; misleading?: number };
+  load_triggers?: string[];
+  tags?: { domains?: string[]; qualifiers?: string[] };
+}
+
+/**
+ * Read Playbook manifest JSONs under {stateDir}/playbook and map matching items
+ * to WorkingSetItems. Relevance blends trigger/tag overlap with the query and the
+ * item's usefulness signal; recency = freshness. Read-only (never invokes the
+ * Python scripts) and degrade-safe (no dir / parse error → []). When no query
+ * terms are given, returns [] (Playbook items are trigger-gated, not always-on).
+ */
+export function playbookManifestToWorkingSet(
+  stateDir: string | undefined,
+  queryTerms: string[],
+  nowMs?: number,
+): WorkingSetItem[] {
+  void nowMs;
+  if (!stateDir || queryTerms.length === 0) return [];
+  const dir = path.join(stateDir, 'playbook');
+  let files: string[];
+  try {
+    files = collectJsonFiles(dir);
+  } catch {
+    return [];
+  }
+  const terms = queryTerms.map(t => t.toLowerCase()).filter(Boolean);
+  const out: WorkingSetItem[] = [];
+  for (const file of files) {
+    let parsed: { items?: RawPlaybookItem[] };
+    try {
+      parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    } catch {
+      continue; // skip a corrupt manifest, keep going
+    }
+    if (!parsed || !Array.isArray(parsed.items)) continue;
+    for (const it of parsed.items) {
+      if (!it || !it.id) continue;
+      const haystack = [
+        ...(it.load_triggers ?? []),
+        ...(it.tags?.domains ?? []),
+        ...(it.tags?.qualifiers ?? []),
+        it.category ?? '',
+        it.id,
+      ].join(' ').toLowerCase();
+      const matches = terms.filter(t => haystack.includes(t)).length;
+      if (matches === 0) continue; // trigger-gated: only surface items the query touches
+      const matchScore = Math.min(1, matches / Math.max(1, terms.length));
+      const help = it.usefulness?.helpful ?? 0;
+      const mis = it.usefulness?.misleading ?? 0;
+      const usefulnessBoost = help + mis > 0 ? Math.max(0, (help - mis) / (help + mis)) : 0;
+      // Relevance = mostly match, with a small usefulness lift (capped at 1).
+      const relevance = Math.min(1, matchScore * 0.8 + usefulnessBoost * 0.2);
+      out.push({
+        source: 'playbook',
+        id: it.id,
+        text: `${it.id}${it.path ? ` (${it.path})` : ''}`,
+        relevance,
+        recencyAt: it.freshness ?? new Date(0).toISOString(),
+        kind: it.category ?? 'playbook',
+      });
+    }
+  }
+  return out;
+}
+
+/** Recursively collect *.json files under a dir (shallow-ish; returns [] if missing). */
+function collectJsonFiles(dir: string, depth = 3): string[] {
+  if (depth < 0 || !fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectJsonFiles(full, depth - 1));
+    else if (entry.isFile() && entry.name.endsWith('.json')) out.push(full);
+  }
+  return out;
+}

--- a/tests/integration/cwa-unify-stores-routes.test.ts
+++ b/tests/integration/cwa-unify-stores-routes.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration / e2e (Tier 2+3) for rung-2 store unification.
+ *
+ * Boots a real AgentServer (the production init path) with a
+ * WorkingMemoryAssembler wired to a real TopicIntentStore, and verifies the
+ * assembled-context HTTP route surfaces the unified "Working Set" section
+ * drawing from topic-intent — the unified read path, alive end-to-end. Also
+ * pins that with no topic-intent content the route is unchanged (no working-set).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { WorkingMemoryAssembler } from '../../src/memory/WorkingMemoryAssembler.js';
+import { TopicIntentStore, buildEvent } from '../../src/core/TopicIntent.js';
+import { createTempProject, createMockSessionManager } from '../helpers/setup.js';
+import type { TempProject, MockSessionManager } from '../helpers/setup.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+const AUTH = 'cwa-unify-routes-token';
+
+function buildConfig(project: TempProject, name: string): InstarConfig {
+  return {
+    projectName: name, projectDir: project.dir, stateDir: project.stateDir,
+    port: 0, authToken: AUTH, requestTimeoutMs: 5000, version: '0.0.0',
+    sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+    scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+    messaging: [], monitoring: {}, updates: {},
+  } as InstarConfig;
+}
+
+describe('GET /session/context/:topicId — unified working set (rung 2)', () => {
+  let project: TempProject;
+  let mockSM: MockSessionManager;
+  let store: TopicIntentStore;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+
+  beforeAll(() => {
+    project = createTempProject();
+    fs.writeFileSync(path.join(project.stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'cwa-unify', agentName: 'CWA' }));
+    mockSM = createMockSessionManager();
+    store = new TopicIntentStore(project.stateDir);
+    // Populate topic 42 with a decision the working set should surface.
+    store.appendEvidence(42, 'r1', buildEvent('r1', 'extract-user', 'm1'), { text: 'we will deploy via blue-green', kind: 'decision' });
+
+    const assembler = new WorkingMemoryAssembler({ topicIntentStore: store, stateDir: project.stateDir });
+    server = new AgentServer({
+      config: buildConfig(project, 'cwa-unify'),
+      sessionManager: mockSM as any,
+      state: project.state,
+      workingMemory: assembler,
+    });
+    app = server.getApp();
+  });
+
+  afterAll(() => { project?.cleanup(); });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('the unified read path is alive: 200 with the assembled payload shape', async () => {
+    const res = await request(app).get('/session/context/42').set(auth()).query({ prompt: 'how are we deploying' });
+    expect(res.status).toBe(200);
+    expect(typeof res.body.context).toBe('string');
+    expect(Array.isArray(res.body.sources)).toBe(true);
+  });
+
+  it('surfaces the topic-intent ref in a Working Set section', async () => {
+    const res = await request(app).get('/session/context/42').set(auth()).query({ prompt: 'how are we deploying' });
+    expect(res.status).toBe(200);
+    expect(res.body.context).toContain('Working Set');
+    expect(res.body.context).toContain('blue-green');
+    expect(res.body.sources.find((s: { name: string }) => s.name === 'working-set')).toBeDefined();
+  });
+
+  it('a topic with no refs yields no working-set section (additive — unchanged when empty)', async () => {
+    const res = await request(app).get('/session/context/999').set(auth()).query({ prompt: 'nothing here' });
+    expect(res.status).toBe(200);
+    expect(res.body.sources.find((s: { name: string }) => s.name === 'working-set')).toBeUndefined();
+    expect(res.body.context).not.toContain('Working Set');
+  });
+});

--- a/tests/unit/cwa-unify-stores.test.ts
+++ b/tests/unit/cwa-unify-stores.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests (Tier 1) for rung-2 store unification.
+ *
+ *   - WorkingSet: blended score, ranking, the topic-intent + Playbook adapters,
+ *     degrade-safety.
+ *   - WorkingMemoryAssembler integration: the REGRESSION PIN (no new deps →
+ *     output has no working-set section, existing behavior unchanged) + the
+ *     new working-set section appears when topic-intent/Playbook have content.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  blendedScore,
+  rankWorkingSet,
+  topicIntentToWorkingSet,
+  playbookManifestToWorkingSet,
+  type WorkingSetItem,
+} from '../../src/memory/WorkingSet.js';
+import { TopicIntentStore, buildEvent } from '../../src/core/TopicIntent.js';
+import { WorkingMemoryAssembler } from '../../src/memory/WorkingMemoryAssembler.js';
+
+const NOW = Date.parse('2026-03-01T00:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+let tempDir: string;
+beforeEach(() => { tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cwa-unify-')); });
+afterEach(() => { try { SafeFsExecutor.safeRmSync(tempDir, { recursive: true, force: true, operation: 'tests/unit/cwa-unify-stores.test.ts' }); } catch { /* best */ } });
+
+function item(over: Partial<WorkingSetItem>): WorkingSetItem {
+  return { source: 'topic-intent', id: 'i', text: 't', relevance: 0.5, recencyAt: new Date(NOW).toISOString(), kind: 'fact', ...over };
+}
+
+describe('WorkingSet ranking', () => {
+  it('blendedScore decays with age (half at one half-life)', () => {
+    const fresh = blendedScore(item({ relevance: 1, recencyAt: new Date(NOW).toISOString() }), NOW);
+    const old = blendedScore(item({ relevance: 1, recencyAt: new Date(NOW - 30 * DAY).toISOString() }), NOW);
+    expect(fresh).toBeCloseTo(1, 2);
+    expect(old).toBeCloseTo(0.5, 1);
+  });
+
+  it('ranks higher relevance × recency first; stable on ties', () => {
+    const items = [
+      item({ id: 'a', relevance: 0.9, recencyAt: new Date(NOW - 60 * DAY).toISOString() }), // decayed
+      item({ id: 'b', relevance: 0.6, recencyAt: new Date(NOW).toISOString() }),             // fresh
+      item({ id: 'c', relevance: 0.6, recencyAt: new Date(NOW).toISOString() }),             // tie with b → stable
+    ];
+    const ranked = rankWorkingSet(items, NOW).map(i => i.id);
+    expect(ranked[0]).toBe('b'); // 0.6 fresh beats 0.9 heavily-decayed
+    expect(ranked.indexOf('b')).toBeLessThan(ranked.indexOf('c')); // stable tie order
+  });
+});
+
+describe('topic-intent adapter', () => {
+  it('maps refs at/above tentative to WorkingSetItems; degrade-safe on no store', () => {
+    expect(topicIntentToWorkingSet(null, 1)).toEqual([]);
+    expect(topicIntentToWorkingSet(undefined, undefined)).toEqual([]);
+
+    const store = new TopicIntentStore(tempDir);
+    store.appendEvidence(42, 'ref-1', buildEvent('ref-1', 'extract-user', 'm1'), { text: 'use Path B', kind: 'decision' });
+    const items = topicIntentToWorkingSet(store, 42);
+    expect(items.length).toBe(1);
+    expect(items[0]).toMatchObject({ source: 'topic-intent', text: 'use Path B', kind: 'decision' });
+    expect(items[0].relevance).toBeGreaterThan(0);
+  });
+});
+
+describe('Playbook manifest adapter', () => {
+  function writeManifest(items: unknown[]) {
+    const dir = path.join(tempDir, 'playbook', 'builtin-manifests');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'm.json'), JSON.stringify({ version: 1, items }));
+  }
+
+  it('surfaces only items whose triggers/tags match the query; degrade-safe with no dir', () => {
+    expect(playbookManifestToWorkingSet(undefined, ['x'])).toEqual([]);
+    expect(playbookManifestToWorkingSet(tempDir, [])).toEqual([]); // no query → trigger-gated, nothing
+
+    writeManifest([
+      { id: '/a', category: 'infra', load_triggers: ['deploying', 'release'], tags: { domains: ['deploy'] }, freshness: new Date(NOW).toISOString(), usefulness: { helpful: 3, misleading: 0 } },
+      { id: '/b', category: 'infra', load_triggers: ['cooking'], tags: { domains: ['kitchen'] }, freshness: new Date(NOW).toISOString() },
+    ]);
+    const items = playbookManifestToWorkingSet(tempDir, ['deploying', 'the', 'app']);
+    expect(items.map(i => i.id)).toEqual(['/a']); // only the trigger-matching item
+    expect(items[0].source).toBe('playbook');
+    expect(items[0].relevance).toBeGreaterThan(0);
+  });
+
+  it('ignores a corrupt manifest without throwing', () => {
+    const dir = path.join(tempDir, 'playbook');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'bad.json'), '{ not valid json');
+    expect(() => playbookManifestToWorkingSet(tempDir, ['x'])).not.toThrow();
+    expect(playbookManifestToWorkingSet(tempDir, ['x'])).toEqual([]);
+  });
+});
+
+describe('WorkingMemoryAssembler — regression pin + new section', () => {
+  it('REGRESSION PIN: with no topic-intent/stateDir deps, output has no working-set section', () => {
+    const a = new WorkingMemoryAssembler({}); // no new deps, no memory systems
+    const out = a.assemble({ prompt: 'anything about deploying', topicId: 7 });
+    expect(out.sources.find(s => s.name === 'working-set')).toBeUndefined();
+    expect(out.context).not.toContain('Working Set');
+  });
+
+  it('with the deps present but EMPTY sources, still no working-set section (additive)', () => {
+    const store = new TopicIntentStore(tempDir); // empty store, no refs
+    const a = new WorkingMemoryAssembler({ topicIntentStore: store, stateDir: tempDir });
+    const out = a.assemble({ prompt: 'deploying', topicId: 999 });
+    expect(out.sources.find(s => s.name === 'working-set')).toBeUndefined();
+  });
+
+  it('surfaces a working-set section when topic-intent has refs', () => {
+    const store = new TopicIntentStore(tempDir);
+    store.appendEvidence(7, 'r1', buildEvent('r1', 'extract-user', 'm1'), { text: 'we will deploy via blue-green', kind: 'decision' });
+    const a = new WorkingMemoryAssembler({ topicIntentStore: store, stateDir: tempDir });
+    const out = a.assemble({ prompt: 'how are we deploying', topicId: 7 });
+    const ws = out.sources.find(s => s.name === 'working-set');
+    expect(ws).toBeDefined();
+    expect(ws!.count).toBeGreaterThanOrEqual(1);
+    expect(out.context).toContain('Working Set');
+    expect(out.context).toContain('blue-green');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,62 @@
+# Upgrade Guide — one ranked working set across the memory stores
+
+<!-- bump: minor -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+
+## What Changed
+
+**The memory stores now feed one ranked reading list instead of three separate ones.**
+
+Topic-intent (conversation facts + task frame), Playbook (tagged context items),
+and semantic/episodic memory each had their own read path and ranking. This unifies
+the **reading**: the existing working-memory assembler — already a token-budgeted
+multi-source context builder — now also draws from topic-intent and Playbook, and
+ranks everything together by relevance blended with a recency-decay factor (so
+fresher, more-relevant context floats up; stale context sinks but isn't deleted and
+re-warms on reference).
+
+The important design choice (ratified): this unifies the **reading, not the
+storage**. The three stores keep their own backends and write paths; the assembler
+is the single unified read. That makes it additive and reversible — and it's
+guarded by a regression pin: **when the new sources are empty, the assembled
+context is byte-for-byte what it was before.** Playbook is read straight from its
+manifest files (no Python invoked in the hot assembly path), and every new source
+is degrade-safe — a missing or erroring source contributes nothing and never
+breaks assembly.
+
+The result shows up as a "Working Set" section in the assembled context
+(`GET /session/context/:topicId`), drawing from all sources under one budget, with
+per-source contribution visible in the response's `sources`.
+
+**Evidence**: 11 new tests (8 unit — blended ranking, both source adapters,
+degrade-safety, and the regression pin; 3 boot-path route tests confirming the
+unified read path is alive and surfaces topic-intent in a Working Set section, and
+that a ref-less topic is unchanged). The existing 49 assembler + working-memory
+tests stay green (the regression pin, confirmed). `tsc` + lint clean.
+
+Spec: `docs/specs/cwa-unify-stores.md` (approved; Claude-authored + manual review —
+this is the most architectural rung, fuller multi-model review advisable, caveat
+ratified). ELI16: `docs/specs/cwa-unify-stores.eli16.md`. Side-effects:
+`upgrades/side-effects/cwa-unify-stores.md`.
+
+## What to Tell Your User
+
+- **One sorted view of what matters**: "I used to keep 'what's relevant right now'
+  in three separate notebooks that didn't talk to each other. Now they feed one
+  ranked reading list, so when we pick something up I get a single sorted view —
+  freshest and most-relevant first — instead of three half-answers."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Unified working set in assembled context | Automatic — `GET /session/context/:topicId` now includes a "Working Set" section drawing from topic-intent + Playbook + memory |
+| Blended relevance×recency ranking across sources | Automatic (the assembler ranks all sources together) |
+
+## Evidence
+
+Not a bug fix — a new capability over the existing assembler. Verified by 11 new
+tests including 3 that boot the real AgentServer and confirm the assembled-context
+route surfaces a topic-intent ref in a "Working Set" section, plus a regression pin
+(unit + the unchanged existing 49-test suites) proving the assembled output is
+identical when the new sources are empty. `tsc` + lint clean.

--- a/upgrades/side-effects/cwa-unify-stores.md
+++ b/upgrades/side-effects/cwa-unify-stores.md
@@ -1,0 +1,83 @@
+# Side-effects review — unify the working-awareness stores (rung 2)
+
+**Scope**: Give the working-awareness stores one ranked read path. Per the
+ratified spec (`docs/specs/cwa-unify-stores.md`), this unifies the READ — extends
+the existing `WorkingMemoryAssembler` to draw topic-intent refs + Playbook
+manifest items into one ranked working-set section — NOT a physical store
+migration. Additive, reversible, regression-pinned.
+
+**Files touched**:
+- `src/memory/WorkingSet.ts` — NEW. The `WorkingSetItem` lingua franca +
+  `blendedScore`/`rankWorkingSet` (relevance × recency-decay) + two read-only,
+  degrade-safe source adapters: `topicIntentToWorkingSet` (refs at/above tentative
+  → items; relevance = confidence, recency = lastReinforcedAt) and
+  `playbookManifestToWorkingSet` (scans `{stateDir}/playbook/**.json` manifests,
+  trigger/tag-gated by the query, relevance = match + usefulness, recency =
+  freshness — **never invokes the Python scripts**).
+- `src/memory/WorkingMemoryAssembler.ts` — optional `topicIntentStore` + `stateDir`
+  config; `workingSet` token budget (default 500); a new "Working Set" section
+  appended AFTER the existing knowledge/episodes/relationships sections, gated on
+  the new deps + content; `assembleWorkingSet`/`renderWorkingSet`; section header.
+- `src/commands/server.ts` — pass `topicIntentStore` + `stateDir` to the assembler
+  and broaden its construction gate to include `topicIntentStore` (so the unified
+  read path is available even in minimal setups).
+
+**Under-block**: None. The new section is purely additive context; it gates
+nothing. Each new source is read-only and wrapped so an error/absence contributes
+nothing.
+
+**Over-block**: None. No authority anywhere — the assembler informs context, it
+doesn't decide.
+
+**Level-of-abstraction fit**: The stores keep their backends and write paths; only
+the READ is unified, via the assembler that already does token-budgeted
+multi-source assembly. The new sources speak the same `WorkingSetItem` shape and
+flow through the same budget + render machinery. Playbook is read at the manifest
+level (a stable JSON file), not through its Python CLI — the right seam for a fast,
+degrade-safe assembler.
+
+**Signal vs authority**: N/A — pure read/ranking.
+
+**Interactions**:
+- **REGRESSION PIN (load-bearing):** the working-set section is appended after the
+  existing three and only when `topicIntentStore || stateDir` is configured AND a
+  source returns content. With the new deps absent OR their sources empty, the
+  assembled output is byte-for-byte unchanged — verified by (a) a dedicated unit
+  test, (b) the existing 26 assembler unit tests + 9 working-memory route tests +
+  the assembler-context route tests all still green, (c) a route test asserting a
+  ref-less topic yields no working-set section.
+- The assembler construction gate broadened to include `topicIntentStore` (always
+  present), so the assembler now constructs in more setups. This is additive —
+  callers in minimal setups gain a working-set context they didn't have; existing
+  setups' output is unchanged (pin).
+- The new section draws only from REMAINING token budget after the existing
+  sources, so it cannot starve them.
+- Playbook manifest scan is bounded (depth-limited, per-file try/catch) and
+  trigger-gated (empty query → no Playbook items), so it can't flood or slow
+  assembly.
+
+**External surfaces**: New module `src/memory/WorkingSet.ts` (exports
+`WorkingSetItem`, `blendedScore`, `rankWorkingSet`, the two adapters). New optional
+assembler config fields + a `workingSet` budget. The assembled-context HTTP routes
+now MAY include a "Working Set" section. No new endpoint, no config-shape change
+for users (the assembler deps are wired server-side).
+
+**Deferred (tracked)**: deeper cross-source blended re-ranking of the existing
+sources (`cwa-physical-store-merge` rejected; cross-blend is implicit future work),
+the Usher / mid-task re-surfacing (`cwa-usher`), capability+standards descriptors
+as sources (`cwa-capability-index-context`). All in the spec's non-goals.
+
+**Rollback cost**: Low. Drop the working-set section + the two adapter calls (or
+just don't pass `topicIntentStore`/`stateDir`); the assembler returns to its
+current three sources. No data migration. The regression pin guarantees the
+revert is a no-op for existing output.
+
+**Migration parity**: Additive assembler sources + budget default + the broadened
+construction gate — all server-side (every agent gets it on update). No store
+schema change, no hook/template/skill change, no user config change required.
+
+**Convergence honesty**: Claude-authored + manual review; full multi-model
+convergence tooling absent on host. This is the most architectural rung (touches
+the shared assembler), so the regression pin is the primary safety and a fuller
+multi-model review remains advisable — but the pin + the unchanged existing suites
+bound the risk tightly.


### PR DESCRIPTION
## What

Rung 2 of Continuous Working Awareness: give the working-awareness stores **one ranked read path**. Topic-intent (rungs 0–1), Playbook, and semantic/episodic memory each had their own read path + ranking. This unifies the *reading* — the existing `WorkingMemoryAssembler` (already a token-budgeted multi-source builder) now also draws topic-intent + Playbook into one ranked "Working Set" section, blended by relevance × recency-decay.

**The load-bearing design choice (ratified): unify the READ, not the storage.** The three stores keep their backends + write paths; the assembler is the single unified read. Additive, reversible, no data migration.

## How

- **`src/memory/WorkingSet.ts`** (new): the `WorkingSetItem` lingua franca + `blendedScore`/`rankWorkingSet`, and two **read-only, degrade-safe** source adapters — `topicIntentToWorkingSet` (refs ≥ tentative; relevance = confidence, recency = lastReinforcedAt) and `playbookManifestToWorkingSet` (scans `{stateDir}/playbook/**.json`, trigger/tag-gated, **never invokes the Python scripts**).
- **`WorkingMemoryAssembler`**: optional `topicIntentStore` + `stateDir`; a `workingSet` budget; the new section appended **after** the existing knowledge/episodes/relationships and gated on the new deps + content. `server.ts` wires the deps + broadens the construction gate.

## Regression pin (the safety anchor)

With the new sources absent **or empty**, the assembled output is **byte-for-byte unchanged**. Verified three ways: a dedicated unit test; the existing **49** assembler + working-memory tests all still green; and a boot-path route test asserting a ref-less topic yields no Working Set section.

## Testing (all tiers)

11 new tests: **8 unit** (blended ranking + recency decay; both adapters; degrade-safety on missing store / corrupt manifest; the regression pin; new-section-on-content) + **3 boot-path route** (real `AgentServer` → `/session/context/:topicId` surfaces a topic-intent ref in a "Working Set" section; ref-less topic unchanged). `tsc` + lint clean (incl. no-raw-LLM guard).

## Honesty note

Claude-authored spec + manual review; full `/spec-converge` + `/crossreview` multi-model tooling isn't on the build host. This is the most architectural rung (touches the shared assembler), so the regression pin is the primary safety and a fuller multi-model review remains advisable. Ratified by Justin with that caveat explicit.

Spec: `docs/specs/cwa-unify-stores.md`. Side-effects: `upgrades/side-effects/cwa-unify-stores.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)