### PR TITLE
feat(threadline): Phase 2a single-store collapse (CMT-497)

### DIFF
--- a/docs/specs/THREADLINE-SINGLE-STORE-ELI16.md
+++ b/docs/specs/THREADLINE-SINGLE-STORE-ELI16.md
@@ -1,0 +1,58 @@
+# Threadline Single-Store Collapse (Phase 2a) — Plain-English Overview
+
+## What this is
+
+The tidy-up I flagged when Phase 1 shipped. Phase 1 made one clean "conversation
+record," but it couldn't fully retire the old record-keeping file yet, because of a
+real-world snag. This finishes that.
+
+## The snag, in plain terms
+
+The new record keeps its data **in memory** for speed. The catch: **two different
+programs** write thread data — the main server and a little messaging-tools helper.
+Two programs can't each hold their own in-memory copy of the same file; they'd
+overwrite each other and lose data. So Phase 1 left the old file as a second store.
+
+## How I almost over-built it (and what the review caught)
+
+My first plan was to make the server the only writer and have the helper "ask the
+server" over a local web request. A two-reviewer pass against the real code shot
+three holes in that:
+1. The thing I planned to also convert is actually **dead code** — nothing uses it.
+   So that work was pointless.
+2. The web requests I'd add would have been **wide open** — that family of routes
+   skips the password check, so I'd have shipped an unlocked door.
+3. It was a lot of new machinery just to replace **one** "delete this thread" call.
+
+So I changed the approach to the reviewers' simpler idea.
+
+## The fix (revised)
+
+Give the conversation record the same safe-sharing trick the old file already used:
+**read the file, make the change only if nobody else changed it first, and save by
+swapping the file in one atomic step.** Add a version stamp so that if two writers
+collide, the loser just re-reads and retries instead of overwriting. That makes it
+safe for both programs to write — no new web requests, no unlocked door, nothing
+to break when the server restarts. Then the old file becomes a thin view onto the
+new record (every existing piece of code keeps working), and the old file stops
+being written.
+
+One careful detail the review flagged: when the helper saves resume info, it must
+**merge** into the record, not overwrite it — otherwise it could wipe the loop
+counter. The spec now requires that.
+
+## Why it's safe
+
+One file, one safe-sharing rule, atomic saves. The old file is kept (but no longer
+written) for one release so we can roll back instantly. Full test suite **plus** the
+live test-on-a-real-agent gate before it ships.
+
+## What you're deciding
+
+Just whether to approve building this revised version. It's the foundation the
+bigger Phase 2 ("an inbox you drain deliberately") needs.
+
+## What's still after this (tracked)
+
+- **Phase 2b (CMT-493):** the inbox/deliberate-drain reply model + agent-conversations
+  inbox + scaling + stranger identity/reputation checks. Built on top of this.

--- a/docs/specs/THREADLINE-SINGLE-STORE-SPEC.md
+++ b/docs/specs/THREADLINE-SINGLE-STORE-SPEC.md
@@ -1,0 +1,229 @@
+---
+title: Threadline Single-Store Collapse (Phase 2a / CMT-497)
+status: draft
+approved: false
+created: 2026-05-24
+revised: 2026-05-24
+owner: echo
+companion-eli16: THREADLINE-SINGLE-STORE-ELI16.md
+review-report: "docs/specs/reports/threadline-single-store-convergence.md"
+roadmap-phase: 2a
+predecessor: THREADLINE-CONVERSATION-KEYSTONE-SPEC.md
+tracked-as: CMT-497
+---
+
+# Threadline Single-Store Collapse (Phase 2a / CMT-497)
+
+Completes the Phase 1 keystone's acceptance criterion #1 — *the router reads/writes
+ONLY the Conversation; no parallel writes* — deferred in Phase 1 because of a
+multi-process write pattern. This phase makes `ConversationStore` **cross-process
+safe** so it can be the one authoritative store, and retires the live legacy store
+(`ThreadResumeMap`) into a view over it. It is the foundation Phase 2b (CMT-493,
+the inbox/deliberate-drain reply model) builds on.
+
+> **Approach revised after convergence (2026-05-24).** The first draft proposed an
+> HTTP surface so the MCP stdio child could read/mutate via the server as sole
+> writer. Two reviewers (grounded against the live code) rejected it: (a) the only
+> cross-process *write* is a single `.remove()` call — four authenticated
+> endpoints is a heavy lever for one bolt; (b) `/threadline/*` routes BYPASS the
+> bearer middleware (`middleware.ts:123-126`), so the endpoints would have shipped
+> UNAUTHENTICATED; (c) routing a synchronous local read through a restartable
+> server process adds latency, a silent-empty failure mode, and restart-window
+> data loss with no durable retry. The convergence recommendation — a file-level
+> version-CAS on `ConversationStore`, exactly the cross-process-safe pattern the
+> legacy maps already use (reload-per-op + atomic rename), hardened with a version
+> field — is adopted instead. No new network surface, no auth gap, no restart-
+> window loss. Convergence also found the file-backed `ContextThreadMap` and its
+> consumers are DEAD CODE, removing it from scope entirely.
+
+## Problem (why Phase 1 stopped short)
+
+`ConversationStore` (Phase 1) holds state **in memory** (`this.store`) with a CAS
+`mutate()` — correct/fast for the loop gate, but a *single-process* design. The
+live legacy store it replaces, `ThreadResumeMap`, is written from **two
+processes**: the agent server (TopicLinkageHandler, ThreadlineRouter) and the MCP
+stdio child (`ThreadlineMCPServer.ts:787` calls `.remove`; reads at :623/:726/:772).
+The legacy maps survive this only because they **reload-from-disk per op**
+(last-writer-wins, no in-memory state). Two in-memory `ConversationStore` instances
+(one per process) would clobber each other's snapshots → data loss. So Phase 1 kept
+`ThreadResumeMap` as a parallel store.
+
+**Verified scope (convergence):**
+- The cross-process *write* surface is exactly ONE call (MCP child `.remove`) plus
+  reads (`.get`, `.getByRemoteAgent`). All `ThreadResumeMap` writers otherwise are
+  in-server. (No lifeline/job/CLI/listener writer exists.)
+- The file-backed `ContextThreadMap` is **never constructed in production**
+  (`new ContextThreadMap` = 0 hits); its only consumers (`A2AGateway`,
+  `OpenClawBridge`) are themselves never constructed. The live A2A path uses a
+  *different*, in-memory-only `ContextThreadMapper` in the relay-server component.
+  → **ContextThreadMap is OUT of scope** (touching it would wire up dead code).
+- `ThreadlineObservability.ts:~294` reads `thread-resume-map.json` via a RAW
+  `readFileSync` (bypassing the class) — must be re-pointed (see §3).
+
+## Scope (Phase 2a only)
+
+No change to the reply primitive (still spawn-per-message; that's Phase 2b). Pure
+store-unification of the ONE live legacy store.
+
+### 1. `ConversationStore` becomes cross-process safe (file version-CAS)
+
+Replace the pure in-memory model with reload-per-op + optimistic version-CAS +
+atomic write, the proven cross-process-safe pattern:
+- **`mutate(threadId, fn)` (async) and `mutateSync(threadId, fn)`:** reload the
+  store from disk → locate the record → snapshot its `version` → apply `fn` → if
+  the on-disk `version` is unchanged, write the merged record with `version+1` via
+  tmp-write+`rename` (atomic); else reload and retry (bounded, e.g. 8). This makes
+  concurrent writers in *different processes* safe — the file is the source of
+  truth, the version field is the CAS token, and `rename` prevents torn reads.
+- **`get`/`getByParticipant`/`getByTopicId`/`listActive`:** read from disk (a
+  very-short-TTL in-process cache, e.g. 250ms, is allowed for the gate's hot path
+  — staleness only ever causes a redundant reload on the next `mutate`, never a
+  lost write, because `mutate` always re-reads).
+- **Ephemeral affinity** stays in-memory + per-instance (explicitly non-durable,
+  unchanged from Phase 1).
+- The full-file rewrite per mutate is acceptable: inbound agent traffic is
+  human-paced and the store is capped (~1000 rows). The 50-concurrent CAS test
+  continues to pass (now exercising file-CAS).
+
+This preserves the public API, so the gate/funnel/router/tests are unchanged in
+shape. (The Phase 1 in-memory CAS test becomes a file-CAS test — same assertion:
+N concurrent increments lose nothing.)
+
+### 2. `ThreadResumeMap` becomes a view over `ConversationStore`
+
+Reimplement `ThreadResumeMap`'s methods against `ConversationStore` (both
+processes construct a file-CAS `ConversationStore`; safe per §1), so every existing
+caller (`ThreadlineRouter`, `TopicLinkageHandler`, `ThreadlineMCPServer`,
+`ThreadlineObservability`) is unchanged in signature. **Explicit field bridge**
+(`ThreadResumeEntry` ↔ `Conversation`) — this was the convergence FATAL; it is now
+mandatory and exhaustive:
+
+| ThreadResumeEntry | Conversation |
+|---|---|
+| `uuid` | `sessionUuid` |
+| `sessionName` | `boundSessionName` |
+| `remoteAgent` | `remoteAgent` (+ `participants.peers[0]`) |
+| `subject` | `subject` |
+| `state` | `state` |
+| `resolvedAt` | `resolvedAt` |
+| `pinned` | `pinned` |
+| `messageCount` | `messageCount` |
+| `createdAt` | `createdAt` |
+| `savedAt` | `savedAt` |
+| `lastAccessedAt` | `lastActivityAt` |
+| `machineOrigin` | `machineOrigin` |
+| `migratedTo` | `migratedTo` |
+| `spawnMode` | `spawnMode` |
+| `originTopicId` | `boundTopicId` |
+| `originSessionName` | `originSessionName` |
+
+- **`save` MUST MERGE, not replace** (convergence finding): a legacy `save` carries
+  only resume fields; it must not clobber the gate's `turnCount`/`lastInboundHash`
+  on the same record. The view maps the entry's fields onto the existing
+  Conversation via `mutateSync`, leaving turn/novelty fields intact.
+- **Method coverage (exhaustive — all of these are reimplemented on the view):**
+  `get`, `save`, `remove`, `resolve`, `pin`, `unpin`, `getByRemoteAgent`,
+  `listActive`, `size`, `prune`, `migrateFrom`, `getMigratedEntries`,
+  `refreshResumeMappings`. (`pin`/`unpin`/`migrateFrom`/`getMigratedEntries`/
+  `refreshResumeMappings` have no live src/ callers today — they are reimplemented
+  for parity + the cross-machine failover path, and tested, but flagged as
+  not-on-a-live-path so green tests don't imply live exercise.)
+- **Resume semantics preserved:** the `jsonlExists(uuid)` guard in `get` and the
+  `refreshResumeMappings` heartbeat operate on `sessionUuid`; cross-machine
+  `migrateFrom`/`getMigratedEntries` operate on `machineOrigin`/`migratedTo`.
+
+### 3. Re-point `ThreadlineObservability` to the store
+
+`ThreadlineObservability` currently raw-reads `thread-resume-map.json`. Re-point it
+to read through `ConversationStore` (or the `ThreadResumeMap` view) so the
+dashboard Threadline tab reflects live state, not the frozen legacy file.
+
+### 4. Legacy file retirement
+
+`thread-resume-map.json` is no longer written (all writes go through the view →
+`ConversationStore` → `conversations.json`). It is kept on disk one release for
+rollback, then removed in a later release. `context-thread-map.json` is untouched
+(dead-code path; left as-is).
+
+## Concurrency argument (why this is now safe)
+
+`conversations.json` is now written by both processes, but every write is
+reload→version-CAS→atomic-rename. A write only commits if the on-disk version
+matches the version read at the start of the op; otherwise it reloads and retries.
+`rename` is atomic on POSIX, so no reader sees a torn file. This is the same
+guarantee the legacy maps relied on (reload-per-op) PLUS a version token that
+upgrades last-writer-wins to lose-no-update. No in-memory snapshot is authoritative,
+so there is no cross-process clobber. The async `mutate` and sync `mutateSync` both
+go through the same file-CAS; the async fn's await gap is covered because the CAS
+re-reads the file's version at commit time. **Invariant (load-bearing):** every
+commit path — async and sync — MUST increment `version`; a test asserts a sync
+write racing an async increment loses neither.
+
+## Migration parity
+
+Phase 1's `migrateThreadlineConversationStore` already folds the legacy file into
+`conversations.json` on boot. This phase adds:
+- **Dual-read transition (one release):** the view reads `ConversationStore` first
+  and, on a miss, falls back to reading `thread-resume-map.json` directly (so a
+  thread written by a pre-2a version is still found), then writes it through to
+  `ConversationStore`. **Bounded to in-server reads only**, and because pre-2a
+  *writers* are gone after this release deploys, the window cannot re-introduce a
+  second live writer (the convergence dual-read concern): an older MCP child that
+  still file-writes would only happen across a partial fleet upgrade — documented
+  as accepted + the migration reconciles on next boot.
+- **Reconciliation:** the resume entry (`sessionUuid` + lifecycle) is authoritative
+  for session binding.
+
+## Acceptance criteria
+
+1. `conversations.json` writes are cross-process safe: a test spawns two processes
+   (or two `ConversationStore` instances) mutating the same thread concurrently and
+   asserts no lost update (file version-CAS).
+2. `ThreadResumeMap` is a view over `ConversationStore`; the field-bridge table is
+   honored — a round-trip (`save` an entry, `get` it back) preserves EVERY field,
+   incl. `uuid`→`sessionUuid` and `sessionName`→`boundSessionName`.
+3. `save` MERGES: a legacy `save` on a thread that has gate `turnCount`/
+   `lastInboundHash` does NOT clobber them.
+4. Resume works end-to-end: a killed-then-resumed thread recovers its session
+   (jsonlExists + the resume path), driven against real session UUIDs.
+5. `mutateSync` racing async `mutate` loses no update (both bump version).
+6. `ThreadlineObservability` reflects live `ConversationStore` state, not the frozen
+   legacy file.
+7. Migration dual-read finds a pre-2a thread on miss; reconciliation loses no
+   binding. Cross-machine `migrateFrom` semantics preserved on the view.
+8. No second file-backed writer of thread state remains (wiring-integrity);
+   `ThreadResumeMap` no longer persists to `thread-resume-map.json`.
+9. Full 3-tier tests; Zero-Failure.
+
+## Test-as-self acceptance gate (REQUIRED before production)
+
+Per the now-standard gate (first applied on the Phase 1 keystone): before merge,
+deploy to a live co-located agent (`instar-codey`) and validate LIVE that (a) the
+MCP child's thread tools (history/agents/delete) still work with the file-CAS store
+written by both processes, (b) a real resume recovers the session, (c) no
+`conversations.json` corruption under concurrent gate + MCP-child activity (drive an
+inbound while calling threadline_delete), (d) the dashboard Threadline tab shows
+live state. Iterate, restore the agent to released code, THEN merge.
+
+## Rollback
+
+Additive + reversible. Revert = restore `ThreadResumeMap`'s file-backed
+implementation + the Observability raw read + the in-memory `ConversationStore`.
+The frozen legacy file is still current within the dual-read window, so rollback
+strands no state.
+
+## Testing
+
+- Unit: file-CAS `mutate`/`mutateSync` (incl. two-instance concurrent race);
+  `ThreadResumeMap`-view field-bridge round-trip (every field) + merge-not-clobber;
+  `migrateFrom`/`refreshResumeMappings` parity.
+- Integration: MCP-child tool calls (history/agents/delete) against a file-CAS store
+  written concurrently by a simulated server writer — no corruption; resume path.
+- E2E: feature-alive (store + view live on prod init path); resume-after-kill
+  lifecycle; observability reflects live state.
+
+## Roadmap (NOT deferred — tracked)
+
+- **Phase 2b (CMT-493):** the inbox/deliberate-drain reply primitive + first-contact
+  "Agent Conversations" surface + scale decoupling + MoltBridge first-contact, built
+  on this single store. <!-- tracked: CMT-493 -->

--- a/docs/specs/THREADLINE-SINGLE-STORE-SPEC.md
+++ b/docs/specs/THREADLINE-SINGLE-STORE-SPEC.md
@@ -1,7 +1,9 @@
 ---
 title: Threadline Single-Store Collapse (Phase 2a / CMT-497)
-status: draft
-approved: false
+status: approved
+approved: true
+approver: justin
+approved-at: "2026-05-25T08:49:00Z"
 created: 2026-05-24
 revised: 2026-05-24
 owner: echo

--- a/docs/specs/reports/threadline-single-store-convergence.md
+++ b/docs/specs/reports/threadline-single-store-convergence.md
@@ -1,0 +1,38 @@
+# Convergence Report — Threadline Single-Store Collapse (Phase 2a / CMT-497)
+
+**Spec:** docs/specs/THREADLINE-SINGLE-STORE-SPEC.md
+**Date:** 2026-05-24 · **Iterations:** 1 (draft → reviewed → revised, approach pivot)
+**Mode:** two parallel reviewers (completeness/correctness + adversarial/risk),
+grounded against the live code at v1.2.68.
+
+## Verdict on the first draft: NOT approvable. Approach pivoted.
+
+The first draft proposed making the server the single writer via four new
+`/threadline/conversations/*` HTTP endpoints, with the MCP stdio child routing its
+thread-state access through them. Both reviewers rejected it.
+
+| # | Severity | Finding | Resolution in revised spec |
+|---|----------|---------|----------------------------|
+| 1 | FATAL | The file-backed `ContextThreadMap` AND its only consumers (`A2AGateway`, `OpenClawBridge`) are never constructed in production — dead code. §4's ContextThreadMap-view work targeted a non-live path. | ContextThreadMap removed from scope entirely; documented as dead-code path. Scope shrinks to the one live legacy store (`ThreadResumeMap`). |
+| 2 | FATAL | The resume primitive's `uuid`/`sessionName` fields have NO documented bridge to `Conversation.sessionUuid`/`boundSessionName` (nor `lastAccessedAt`→`lastActivityAt`). A builder following the spec literally would lose `--resume`. | Exhaustive field-bridge table added (§2); acceptance #2 asserts every field round-trips. |
+| 3 | BLOCKING | `/threadline/*` routes BYPASS the bearer middleware (`middleware.ts:123-126`); existing handlers self-auth or don't. New endpoints would have shipped UNAUTHENTICATED — any co-located process could read participants/session-UUIDs and call DELETE. | Approach pivot removes the HTTP surface entirely — no new endpoints, no auth gap. |
+| 4 | BLOCKING (recommendation) | The HTTP surface is a heavy lever for eliminating ONE `.remove()` call, and adds latency + a silent-empty MCP failure mode + restart-window mutation loss (no durable retry like PendingRelayStore). Recommended a file-level version-CAS on `ConversationStore` instead. | Adopted. `ConversationStore` becomes reload-per-op + version-CAS + atomic-rename (cross-process safe), the legacy maps' proven pattern hardened with a version token. The MCP child keeps the `ThreadResumeMap` view, now file-CAS-safe — no HTTP, no auth gap, no restart-window loss. |
+| 5 | BLOCKING | `ThreadlineObservability` raw-reads `thread-resume-map.json` (bypasses the class) → would show frozen/stale state after the file is retired. | §3 re-points Observability at `ConversationStore`. |
+| 6 | RISK | Legacy `save` carries only resume fields; backing it onto a Conversation that also holds gate `turnCount`/`lastInboundHash` could clobber turn state if `save` replaces the record. | §2: `save` MUST MERGE via `mutateSync`, leaving turn/novelty fields intact; acceptance #3. |
+| 7 | RISK | `mutateSync` version-bump is load-bearing for the async CAS to detect a racing sync write; only implied in the first draft. | Stated as an explicit invariant; acceptance #5 asserts a sync write racing an async increment loses neither. |
+| 8 | RISK | `migrateFrom`/`getMigratedEntries`/`refreshResumeMappings`/`pin`/`unpin` have no live src/ callers — the view-preserves-signatures tests give false confidence about live paths. | §2 enumerates them, reimplements + tests for parity, and flags them as not-on-a-live-path. |
+| 9 | RISK | Dual-read window could re-introduce a second writer if an older MCP child still file-writes during a partial fleet upgrade. | Dual-read is in-server read-only; the second-writer case is scoped to partial fleet upgrade and reconciled on next boot (documented accepted). |
+
+## Outcome
+
+Approach changed from HTTP-single-writer to file-level version-CAS; scope reduced
+(ContextThreadMap dropped). All fatal/blocking findings incorporated. Ready for
+operator approval; the `approved: true` tag is the operator's to apply.
+
+## Note
+
+This is the convergence process working as intended: grounded review against the
+live code caught that the original approach (a) targeted dead code, (b) would have
+shipped an auth hole, and (c) was over-engineered for a one-call write surface —
+before any code was written. Mirrors the Phase 1 keystone convergence (which caught
+2 fatal bugs pre-code).

--- a/src/threadline/ConversationStore.ts
+++ b/src/threadline/ConversationStore.ts
@@ -264,6 +264,15 @@ export class ConversationStore {
     return out;
   }
 
+  /** All non-expired (or pinned) conversations, any lifecycle state. */
+  all(): Conversation[] {
+    const out: Conversation[] = [];
+    for (const c of Object.values(this.snapshot().conversations)) {
+      if (c.pinned || !this.isExpired(c)) out.push(c);
+    }
+    return out;
+  }
+
   /** Total stored conversations (for monitoring). */
   size(): number {
     return Object.keys(this.snapshot().conversations).length;

--- a/src/threadline/ConversationStore.ts
+++ b/src/threadline/ConversationStore.ts
@@ -1,24 +1,29 @@
 /**
  * ConversationStore — the single source of truth for a Threadline conversation.
  *
- * Phase 1 of the Threadline re-assessment (THREADLINE-CONVERSATION-KEYSTONE-SPEC.md).
- * Collapses the state previously smeared across `ThreadResumeMap`,
- * `ContextThreadMap`, the in-memory peer-affinity map and `inbox.jsonl` into one
- * durable record keyed by `threadId`. It is the ONLY place conversation turn
- * state lives — the one-shot reply worker provably cannot self-police a loop, so
- * the turn count + novelty hashes must live here, on the conversation.
+ * Phase 1 of the Threadline re-assessment (THREADLINE-CONVERSATION-KEYSTONE-SPEC.md)
+ * introduced this as a server-process in-memory store. Phase 2a
+ * (THREADLINE-SINGLE-STORE-SPEC.md / CMT-497) makes it **cross-process safe** so it
+ * can be the ONE authoritative store and the legacy `ThreadResumeMap` can become a
+ * view over it.
  *
- * Concurrency: every write goes through `mutate(threadId, fn)`, a single-writer
- * surface modeled on `CommitmentTracker.mutate()` — a per-threadId FIFO queue
- * plus optimistic CAS on the record's `version`. This is the fix for the
- * convergence-flagged race where two near-simultaneous inbound messages (or a
- * live-inject racing a resume) would clobber `turnCount`/`lastOutboundHash` under
- * the legacy last-writer-wins `load→mutate→persist`.
+ * Concurrency (Phase 2a): `conversations.json` on disk is the source of truth.
+ * Every write — async `mutate()` and sync `mutateSync()` — does reload-per-op +
+ * optimistic per-record version CAS + atomic tmp-write+rename, the same
+ * cross-process-safe pattern the legacy maps used (reload-per-op) hardened with a
+ * `version` token so a same-thread race loses no update (a strict improvement over
+ * the legacy last-writer-wins). A write reads the LATEST full file immediately
+ * before committing and rewrites it with only its own record changed, so a
+ * concurrent write to a DIFFERENT thread from another process is preserved — the
+ * only residual is the microsecond window between that final re-read and the
+ * atomic rename, which matches the (accepted, never-observed-as-a-problem) legacy
+ * full-file-rewrite behavior. Reads use a very-short-TTL snapshot cache so the
+ * loop gate's hot path doesn't re-read on every call; staleness only ever causes a
+ * redundant reload on the next mutate (which always re-reads), never a lost write.
  *
- * Storage: {stateDir}/threadline/conversations.json (server-write-only, atomic
- * tmp+rename). NOT relay-hosted — authoritative state stays local. The
- * append-only SharedStateLedger remains the audit trail; this is the live
- * mutable state it logs transitions from.
+ * Storage: {stateDir}/threadline/conversations.json. NOT relay-hosted —
+ * authoritative state stays local. The append-only SharedStateLedger remains the
+ * audit trail; this is the live mutable state it logs transitions from.
  */
 
 import fs from 'node:fs';
@@ -135,8 +140,10 @@ const MAX_ENTRIES = 1000;
 
 /** Max depth of the per-id mutate queue. Enqueue beyond this rejects. */
 const MUTATE_QUEUE_MAX_DEPTH = 256;
-/** Max CAS retries when the version drifts under an apply. */
-const MUTATE_CAS_MAX_RETRIES = 5;
+/** Max CAS retries when the version drifts under an apply (cross-process). */
+const MUTATE_CAS_MAX_RETRIES = 8;
+/** Read-snapshot cache TTL — keeps the gate's hot path off per-call disk reads. */
+const READ_CACHE_TTL_MS = 250;
 
 // ── Ephemeral verified-only peer-affinity (NOT persisted) ────────
 //
@@ -165,27 +172,43 @@ interface MutateQueueEntry {
 
 export class ConversationStore {
   private filePath: string;
-  private store: ConversationStoreFile;
 
-  /** Per-threadId FIFO mutate queues — serialize concurrent writers. */
+  /** Per-threadId FIFO mutate queues — serialize same-process concurrent writers. */
   private mutateQueues: Map<string, MutateQueueEntry[]> = new Map();
   private mutateRunning: Set<string> = new Set();
 
   /** Ephemeral verified-only peer-affinity hints (peerFingerprint → hint). */
   private affinity: Map<string, AffinityHint> = new Map();
 
+  /** Short-TTL read snapshot cache (disk is the source of truth). */
+  private cache: ConversationStoreFile | null = null;
+  private cacheAt = 0;
+
   constructor(stateDir: string) {
     const threadlineDir = path.join(stateDir, 'threadline');
     fs.mkdirSync(threadlineDir, { recursive: true });
     this.filePath = path.join(threadlineDir, 'conversations.json');
-    this.store = this.loadStore();
   }
 
-  // ── Reads (synchronous, from in-memory store) ──────────────────
+  // ── Reads (from disk, via a very-short-TTL snapshot cache) ─────
+
+  /** A cached snapshot of the on-disk file (reloaded after READ_CACHE_TTL_MS). */
+  private snapshot(): ConversationStoreFile {
+    const now = Date.now();
+    if (this.cache && now - this.cacheAt < READ_CACHE_TTL_MS) return this.cache;
+    this.cache = this.readFileFresh();
+    this.cacheAt = now;
+    return this.cache;
+  }
+
+  private invalidateCache(): void {
+    this.cache = null;
+    this.cacheAt = 0;
+  }
 
   /** Get a conversation by threadId. Returns null if missing or TTL-expired. */
   get(threadId: string): Conversation | null {
-    const c = this.store.conversations[threadId];
+    const c = this.snapshot().conversations[threadId];
     if (!c) return null;
     if (!c.pinned && this.isExpired(c)) return null;
     return c;
@@ -199,7 +222,7 @@ export class ConversationStore {
   /** Find conversations whose peer set includes the given fingerprint/name. */
   getByParticipant(participant: string): Conversation[] {
     const out: Conversation[] = [];
-    for (const c of Object.values(this.store.conversations)) {
+    for (const c of Object.values(this.snapshot().conversations)) {
       if (c.pinned || !this.isExpired(c)) {
         if (c.participants.peers.includes(participant) || c.remoteAgent === participant) {
           out.push(c);
@@ -211,7 +234,7 @@ export class ConversationStore {
 
   /** Find the conversation bound to a Telegram topic, if any. */
   getByTopicId(topicId: number): Conversation | null {
-    for (const c of Object.values(this.store.conversations)) {
+    for (const c of Object.values(this.snapshot().conversations)) {
       if (c.boundTopicId === topicId && (c.pinned || !this.isExpired(c))) return c;
     }
     return null;
@@ -219,7 +242,7 @@ export class ConversationStore {
 
   /** Reverse lookup: conversation owning an A2A contextId (identity-bound). */
   getByContextId(contextId: string, agentIdentity: string): Conversation | null {
-    for (const c of Object.values(this.store.conversations)) {
+    for (const c of Object.values(this.snapshot().conversations)) {
       if (c.contextId === contextId && (c.pinned || !this.isExpired(c))) {
         // Identity binding — prevents session smuggling (ContextThreadMap parity).
         if (c.agentIdentity && c.agentIdentity !== agentIdentity) return null;
@@ -232,7 +255,7 @@ export class ConversationStore {
   /** List active/idle conversations (not resolved/failed/archived). */
   listActive(): Conversation[] {
     const out: Conversation[] = [];
-    for (const c of Object.values(this.store.conversations)) {
+    for (const c of Object.values(this.snapshot().conversations)) {
       if ((c.state === 'active' || c.state === 'idle' || c.state === 'open' || c.state === 'awaiting-reply') &&
           (c.pinned || !this.isExpired(c))) {
         out.push(c);
@@ -243,7 +266,7 @@ export class ConversationStore {
 
   /** Total stored conversations (for monitoring). */
   size(): number {
-    return Object.keys(this.store.conversations).length;
+    return Object.keys(this.snapshot().conversations).length;
   }
 
   // ── Writes (single-writer CAS) ─────────────────────────────────
@@ -302,29 +325,22 @@ export class ConversationStore {
   private async applyMutationWithCAS(threadId: string, fn: ConversationMutateFn): Promise<Conversation> {
     let attempt = 0;
     while (attempt <= MUTATE_CAS_MAX_RETRIES) {
-      const current = this.store.conversations[threadId] ?? this.skeleton(threadId);
+      const file = this.readFileFresh();
+      const current = file.conversations[threadId] ?? this.skeleton(threadId);
       const observedVersion = current.version ?? 0;
 
       const draft: Conversation = { ...current, participants: { ...current.participants, peers: [...current.participants.peers] } };
       const next = await fn(draft);
 
-      // CAS: the record's version must not have drifted underneath us.
-      const latest = this.store.conversations[threadId];
-      const latestVersion = latest?.version ?? (latest ? 0 : observedVersion);
-      if (latest && latestVersion !== observedVersion) {
+      // Re-read fresh immediately before commit: CAS against the latest on-disk
+      // version, AND preserve any concurrent write to a DIFFERENT thread.
+      const latestFile = this.readFileFresh();
+      const latest = latestFile.conversations[threadId];
+      if (latest && (latest.version ?? 0) !== observedVersion) {
         attempt++;
-        continue;
+        continue; // someone else mutated THIS thread — reload and retry
       }
-
-      const committed: Conversation = {
-        ...next,
-        threadId,
-        version: observedVersion + 1,
-        savedAt: new Date().toISOString(),
-      };
-      this.store.conversations[threadId] = committed;
-      this.pruneIfNeeded();
-      this.saveStore();
+      const committed = this.commit(latestFile, threadId, next, observedVersion);
       return committed;
     }
     throw new Error(
@@ -333,29 +349,94 @@ export class ConversationStore {
   }
 
   /**
-   * Direct upsert of a full record WITHOUT going through the CAS queue. ONLY
-   * for migration / bulk import where there are no concurrent writers. Runtime
-   * writers MUST use mutate().
+   * Synchronous single-record mutate (Phase 2a). Used by the synchronous legacy
+   * interfaces (the `ThreadResumeMap` view's `save`/`remove`/etc.). Same file
+   * version-CAS as `mutate`, but the fn is synchronous so the re-read→write
+   * window has no await and is atomic within this process. Cross-process safety
+   * is identical to `mutate` (per-record version CAS + atomic rename).
+   *
+   * The fn MAY return null to signal "delete this record".
+   */
+  mutateSync(threadId: string, fn: (draft: Conversation) => Conversation | null): Conversation | null {
+    let attempt = 0;
+    while (attempt <= MUTATE_CAS_MAX_RETRIES) {
+      const file = this.readFileFresh();
+      const current = file.conversations[threadId] ?? this.skeleton(threadId);
+      const observedVersion = current.version ?? 0;
+      const draft: Conversation = { ...current, participants: { ...current.participants, peers: [...current.participants.peers] } };
+      const next = fn(draft);
+
+      const latestFile = this.readFileFresh();
+      const latest = latestFile.conversations[threadId];
+      if (latest && (latest.version ?? 0) !== observedVersion) {
+        attempt++;
+        continue;
+      }
+      if (next === null) {
+        if (latestFile.conversations[threadId]) {
+          delete latestFile.conversations[threadId];
+          this.writeFileAtomic(latestFile);
+          this.invalidateCache();
+        }
+        return null;
+      }
+      return this.commit(latestFile, threadId, next, observedVersion);
+    }
+    throw new Error(
+      `ConversationStore.mutateSync: CAS retry budget exhausted for ${threadId} after ${MUTATE_CAS_MAX_RETRIES} retries`,
+    );
+  }
+
+  /** Commit a record into the freshly-read file with version+1 (LOAD-BEARING:
+   *  both async and sync commit paths bump version so the CAS detects races). */
+  private commit(file: ConversationStoreFile, threadId: string, next: Conversation, observedVersion: number): Conversation {
+    const committed: Conversation = {
+      ...next,
+      threadId,
+      version: observedVersion + 1,
+      savedAt: new Date().toISOString(),
+    };
+    file.conversations[threadId] = committed;
+    this.pruneMapInPlace(file.conversations);
+    this.writeFileAtomic(file);
+    this.invalidateCache();
+    return committed;
+  }
+
+  /**
+   * Direct upsert of a full record. Used by migration / bulk import. Now does a
+   * read-merge-write so it is safe even if the file changed since construction.
    */
   importDirect(conversation: Conversation): void {
-    const existing = this.store.conversations[conversation.threadId];
-    this.store.conversations[conversation.threadId] = {
+    const file = this.pendingFile ?? this.readFileFresh();
+    const existing = file.conversations[conversation.threadId];
+    file.conversations[conversation.threadId] = {
       ...conversation,
       version: existing ? Math.max(existing.version ?? 0, conversation.version ?? 0) : (conversation.version ?? 0),
       savedAt: new Date().toISOString(),
     };
+    this.pendingFile = file;
   }
+
+  /** Holds an in-flight importDirect batch until flush(). */
+  private pendingFile: ConversationStoreFile | null = null;
 
   /** Persist after a batch of importDirect calls. */
   flush(): void {
-    this.saveStore();
+    if (this.pendingFile) {
+      this.writeFileAtomic(this.pendingFile);
+      this.pendingFile = null;
+      this.invalidateCache();
+    }
   }
 
   /** Remove a conversation. */
   remove(threadId: string): void {
-    if (this.store.conversations[threadId]) {
-      delete this.store.conversations[threadId];
-      this.saveStore();
+    const file = this.readFileFresh();
+    if (file.conversations[threadId]) {
+      delete file.conversations[threadId];
+      this.writeFileAtomic(file);
+      this.invalidateCache();
     }
   }
 
@@ -393,8 +474,10 @@ export class ConversationStore {
 
   /** Prune expired + resolved-past-grace + LRU-overflow (non-pinned). */
   prune(): void {
-    this.pruneMap();
-    this.saveStore();
+    const file = this.readFileFresh();
+    this.pruneMapInPlace(file.conversations);
+    this.writeFileAtomic(file);
+    this.invalidateCache();
   }
 
   // ── Private helpers ────────────────────────────────────────────
@@ -424,19 +507,13 @@ export class ConversationStore {
     return now - new Date(ref).getTime() > MAX_AGE_MS;
   }
 
-  private pruneIfNeeded(): void {
-    if (Object.keys(this.store.conversations).length > MAX_ENTRIES) this.pruneMap();
-  }
-
-  private pruneMap(): void {
-    const map = this.store.conversations;
-    // Phase 1: drop expired / resolved-past-grace (non-pinned).
+  /** Prune a conversations map in place (non-pinned expired + LRU overflow). */
+  private pruneMapInPlace(map: Record<string, Conversation>): void {
     for (const key of Object.keys(map)) {
       const c = map[key];
       if (c.pinned) continue;
       if (this.isExpired(c)) delete map[key];
     }
-    // Phase 2: LRU eviction if still over cap.
     const keys = Object.keys(map);
     if (keys.length <= MAX_ENTRIES) return;
     const unpinned: Array<{ key: string; t: number }> = [];
@@ -452,7 +529,8 @@ export class ConversationStore {
     }
   }
 
-  private loadStore(): ConversationStoreFile {
+  /** Read + parse the on-disk store fresh (the source of truth). */
+  private readFileFresh(): ConversationStoreFile {
     try {
       if (fs.existsSync(this.filePath)) {
         const data = JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
@@ -461,18 +539,19 @@ export class ConversationStore {
         }
       }
     } catch {
-      // Corrupted — start fresh.
+      // Corrupted / mid-write torn read — treat as empty; the next write heals it.
     }
     return { version: 1, conversations: {}, lastModified: new Date().toISOString() };
   }
 
-  private saveStore(): void {
-    this.store.lastModified = new Date().toISOString();
+  /** Atomic write (tmp + rename) — no reader ever sees a torn file. */
+  private writeFileAtomic(file: ConversationStoreFile): void {
+    file.lastModified = new Date().toISOString();
     try {
       const dir = path.dirname(this.filePath);
       fs.mkdirSync(dir, { recursive: true });
-      const tmpPath = `${this.filePath}.${process.pid}.tmp`;
-      fs.writeFileSync(tmpPath, JSON.stringify(this.store, null, 2) + '\n');
+      const tmpPath = `${this.filePath}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+      fs.writeFileSync(tmpPath, JSON.stringify(file, null, 2) + '\n');
       fs.renameSync(tmpPath, this.filePath);
     } catch {
       // @silent-fallback-ok — state persistence failure, retried on next write.

--- a/src/threadline/ThreadResumeMap.ts
+++ b/src/threadline/ThreadResumeMap.ts
@@ -302,8 +302,9 @@ export class ThreadResumeMap {
     return now - new Date(ref).getTime() > MAX_AGE_MS;
   }
 
-  /** Check if a JSONL file exists for the given session UUID. */
-  private jsonlExists(uuid: string): boolean {
+  /** Check if a JSONL file exists for the given session UUID. (protected so
+   *  tests can bypass the filesystem check via a subclass.) */
+  protected jsonlExists(uuid: string): boolean {
     if (!uuid) return false;
     const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects');
     if (!fs.existsSync(claudeProjectsDir)) return false;

--- a/src/threadline/ThreadResumeMap.ts
+++ b/src/threadline/ThreadResumeMap.ts
@@ -1,461 +1,319 @@
 /**
- * ThreadResumeMap — Persistent mapping from thread IDs to Claude session UUIDs.
+ * ThreadResumeMap — persistent mapping from thread IDs to Claude/Codex session
+ * UUIDs, for `--resume`.
  *
- * Analogous to TopicResumeMap but for inter-agent conversation threads.
- * When a thread's session is killed idle, the Claude session UUID is persisted
- * so it can be resumed (--resume UUID) when the next message arrives on that thread.
+ * Phase 2a (THREADLINE-SINGLE-STORE-SPEC.md / CMT-497): this is now a **view over
+ * `ConversationStore`** — the single source of truth. Every method maps the legacy
+ * `ThreadResumeEntry` shape onto a `Conversation` record via the field bridge
+ * below. `save` MERGES (it never clobbers the loop gate's `turnCount`/
+ * `lastInboundHash`/`lastOutboundHash`). The on-disk `thread-resume-map.json` is no
+ * longer written; a one-release dual-read window falls back to it on a miss and
+ * writes through, so threads written by a pre-2a version are not lost.
  *
- * Key differences from TopicResumeMap:
- * - Maps threadId (string UUID) → extended session info
- * - 7-day TTL (vs. 24 hours)
- * - Max 1,000 entries with LRU eviction of non-pinned entries
- * - Resolved threads get a 7-day grace period before removal
- * - Pinned threads are never evicted
- *
- * Storage: {stateDir}/threadline/thread-resume-map.json
+ * Field bridge (ThreadResumeEntry ↔ Conversation):
+ *   uuid↔sessionUuid · sessionName↔boundSessionName · lastAccessedAt↔lastActivityAt
+ *   originTopicId↔boundTopicId · originSessionName↔originSessionName · the rest 1:1.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { ConversationStore, type Conversation } from './ConversationStore.js';
 
 // ── Types ───────────────────────────────────────────────────────
 
-/** Thread lifecycle state */
+/** Thread lifecycle state (legacy subset of ConversationState). */
 export type ThreadState = 'active' | 'idle' | 'resolved' | 'failed' | 'archived';
 
-/** A single thread resume mapping entry */
+/** A single thread resume mapping entry. */
 export interface ThreadResumeEntry {
-  /** Claude session UUID */
   uuid: string;
-  /** tmux session name */
   sessionName: string;
-  /** When thread was created */
   createdAt: string;
-  /** When this mapping was last saved */
   savedAt: string;
-  /** When thread was last accessed */
   lastAccessedAt: string;
-  /** The other agent in this conversation */
   remoteAgent: string;
-  /** Thread subject */
   subject: string;
-  /** Thread lifecycle state */
   state: ThreadState;
-  /** When thread was resolved (only set if state === 'resolved') */
   resolvedAt?: string;
-  /** Pinned threads are never evicted */
   pinned: boolean;
-  /** Total messages in thread */
   messageCount: number;
-  /** Machine that owns this thread (for cross-machine sync) */
   machineOrigin?: string;
-  /** If migrated to another machine, which one */
   migratedTo?: string;
-  /** Spawn mode: interactive (default) or pipe */
   spawnMode?: 'interactive' | 'pipe';
-  /**
-   * Thread↔Topic linkage (THREAD-TOPIC-LINKAGE-SPEC.md).
-   * If this thread was initiated by a topic-bound session, the Telegram topic
-   * that owns it. Set on outbound send; used by inbound dispatch to route the
-   * reply back to the originating topic session instead of a sibling worker.
-   */
   originTopicId?: number;
-  /**
-   * Session name of the originating topic at send time. Fast-path cache so the
-   * inbound dispatcher doesn't have to query CommitmentTracker on every reply.
-   * The source of truth for "what topic owns this thread" is the commitment
-   * record with `verificationMethod: 'threadline-reply'`.
-   */
   originSessionName?: string;
 }
 
-/** Serialized map format */
-interface ThreadResumeMapData {
-  [threadId: string]: ThreadResumeEntry;
+// ── Field bridge ────────────────────────────────────────────────
+
+/** Map a Conversation lifecycle state onto the legacy ThreadState subset. */
+function toThreadState(s: Conversation['state']): ThreadState {
+  if (s === 'open' || s === 'awaiting-reply') return 'active';
+  return s;
+}
+
+/** Conversation → ThreadResumeEntry (read direction). */
+function conversationToEntry(c: Conversation): ThreadResumeEntry {
+  return {
+    uuid: c.sessionUuid ?? '',
+    sessionName: c.boundSessionName ?? '',
+    createdAt: c.createdAt,
+    savedAt: c.savedAt,
+    lastAccessedAt: c.lastActivityAt,
+    remoteAgent: c.remoteAgent ?? c.participants.peers[0] ?? '',
+    subject: c.subject ?? '',
+    state: toThreadState(c.state),
+    resolvedAt: c.resolvedAt,
+    pinned: c.pinned,
+    messageCount: c.messageCount,
+    machineOrigin: c.machineOrigin,
+    migratedTo: c.migratedTo,
+    spawnMode: c.spawnMode,
+    originTopicId: c.boundTopicId,
+    originSessionName: c.originSessionName,
+  };
+}
+
+/**
+ * Apply a ThreadResumeEntry onto a Conversation draft (write direction) —
+ * MERGING: resume fields are set from the entry, but the loop gate's
+ * `turnCount`/`lastInboundHash`/`lastOutboundHash` are LEFT INTACT (convergence
+ * finding — a legacy save must not wipe turn state).
+ */
+function applyEntryToConversation(entry: ThreadResumeEntry, draft: Conversation): Conversation {
+  if (entry.uuid) draft.sessionUuid = entry.uuid;
+  if (entry.sessionName) draft.boundSessionName = entry.sessionName;
+  if (entry.remoteAgent) {
+    draft.remoteAgent = entry.remoteAgent;
+    if (!draft.participants.peers.includes(entry.remoteAgent)) draft.participants.peers.push(entry.remoteAgent);
+  }
+  if (entry.subject) draft.subject = entry.subject;
+  draft.state = entry.state; // legacy state is authoritative on an explicit save
+  if (entry.resolvedAt !== undefined) draft.resolvedAt = entry.resolvedAt;
+  draft.pinned = entry.pinned;
+  // messageCount is shared with the gate — never go backwards.
+  draft.messageCount = Math.max(draft.messageCount ?? 0, entry.messageCount ?? 0);
+  if (entry.machineOrigin !== undefined) draft.machineOrigin = entry.machineOrigin;
+  if (entry.migratedTo !== undefined) draft.migratedTo = entry.migratedTo;
+  if (entry.spawnMode !== undefined) draft.spawnMode = entry.spawnMode;
+  if (entry.originTopicId !== undefined) draft.boundTopicId = entry.originTopicId;
+  if (entry.originSessionName !== undefined) draft.originSessionName = entry.originSessionName;
+  if (entry.createdAt && draft.version === 0) draft.createdAt = entry.createdAt;
+  draft.lastActivityAt = entry.lastAccessedAt || new Date().toISOString();
+  // turnCount / lastInboundHash / lastOutboundHash: intentionally untouched.
+  return draft;
 }
 
 // ── Constants ───────────────────────────────────────────────────
 
-/** Entries older than 7 days are pruned (non-pinned only) */
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-
-/** Resolved threads get a 7-day grace period before removal */
 const RESOLVED_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
-
-/** Maximum number of entries before LRU eviction */
-const MAX_ENTRIES = 1000;
 
 // ── Implementation ──────────────────────────────────────────────
 
 export class ThreadResumeMap {
-  private filePath: string;
+  private store: ConversationStore;
+  private legacyPath: string;
   private projectDir: string;
   private tmuxPath: string;
 
-  constructor(stateDir: string, projectDir: string, tmuxPath?: string) {
-    const threadlineDir = path.join(stateDir, 'threadline');
-    fs.mkdirSync(threadlineDir, { recursive: true });
-    this.filePath = path.join(threadlineDir, 'thread-resume-map.json');
+  constructor(stateDir: string, projectDir: string, tmuxPath?: string, store?: ConversationStore) {
+    this.store = store ?? new ConversationStore(stateDir);
+    this.legacyPath = path.join(stateDir, 'threadline', 'thread-resume-map.json');
     this.projectDir = projectDir;
     this.tmuxPath = tmuxPath || 'tmux';
   }
 
   /**
-   * Save or update a thread resume mapping.
-   * Triggers pruning if the map exceeds MAX_ENTRIES.
-   */
-  save(threadId: string, entry: ThreadResumeEntry): void {
-    const map = this.load();
-
-    map[threadId] = {
-      ...entry,
-      savedAt: new Date().toISOString(),
-    };
-
-    // Prune if needed
-    this.pruneMap(map);
-    this.persist(map);
-  }
-
-  /**
-   * Look up a thread resume entry. Returns null if not found,
-   * expired, or the JSONL file no longer exists.
+   * Look up a thread resume entry. Returns null if not found, expired, or the
+   * session JSONL no longer exists. Dual-read: on a ConversationStore miss, fall
+   * back to the legacy file and write through (one-release transition window).
    */
   get(threadId: string): ThreadResumeEntry | null {
-    const map = this.load();
-    const entry = map[threadId];
-    if (!entry) return null;
-
-    // Check if expired (non-pinned only)
-    if (!entry.pinned && this.isExpired(entry)) {
-      return null;
+    let c = this.store.get(threadId);
+    if (!c) {
+      const legacy = this.readLegacyEntry(threadId);
+      if (legacy) {
+        this.save(threadId, legacy); // write-through to ConversationStore
+        c = this.store.get(threadId);
+      }
     }
-
-    // Verify the JSONL file still exists
-    if (!this.jsonlExists(entry.uuid)) {
-      return null;
-    }
-
+    if (!c) return null;
+    const entry = conversationToEntry(c);
+    // Resume guard: the session JSONL must still exist (unless pinned).
+    if (!entry.pinned && !this.jsonlExists(entry.uuid)) return null;
     return entry;
   }
 
-  /**
-   * Remove a thread entry.
-   */
+  /** Save or update a thread resume mapping (MERGES — preserves gate turn state). */
+  save(threadId: string, entry: ThreadResumeEntry): void {
+    this.store.mutateSync(threadId, draft => applyEntryToConversation({ ...entry, savedAt: new Date().toISOString() }, draft));
+  }
+
+  /** Remove a thread entry (cross-process safe via ConversationStore). */
   remove(threadId: string): void {
-    const map = this.load();
-    delete map[threadId];
-    this.persist(map);
+    this.store.mutateSync(threadId, () => null);
   }
 
-  /**
-   * Mark a thread as resolved — sets state to 'resolved' and records resolvedAt.
-   * Resolved threads get a grace period before being removed by prune().
-   */
+  /** Mark a thread resolved (grace period before removal). */
   resolve(threadId: string): void {
-    const map = this.load();
-    const entry = map[threadId];
-    if (!entry) return;
-
-    entry.state = 'resolved';
-    entry.resolvedAt = new Date().toISOString();
-    entry.savedAt = new Date().toISOString();
-
-    this.persist(map);
+    if (!this.store.get(threadId)) return;
+    this.store.mutateSync(threadId, draft => {
+      draft.state = 'resolved';
+      draft.resolvedAt = new Date().toISOString();
+      return draft;
+    });
   }
 
-  /**
-   * Mark entries from a specific machine as migrated (Phase 4: cross-machine sync).
-   * Called during failover when this machine takes over from another.
-   * The migrated entries can be used to resume threads with --resume UUID.
-   */
-  migrateFrom(sourceMachine: string, targetMachine: string): { migrated: number; skipped: number } {
-    const map = this.load();
-    let migrated = 0;
-    let skipped = 0;
+  /** Pin — never evicted. */
+  pin(threadId: string): void {
+    if (!this.store.get(threadId)) return;
+    this.store.mutateSync(threadId, draft => { draft.pinned = true; return draft; });
+  }
 
-    for (const [threadId, entry] of Object.entries(map)) {
-      if (entry.machineOrigin === sourceMachine && entry.state === 'active') {
-        entry.migratedTo = targetMachine;
-        entry.state = 'idle'; // Demote to idle — will be resumed on next message
-        entry.savedAt = new Date().toISOString();
+  /** Unpin — allow normal TTL/LRU eviction. */
+  unpin(threadId: string): void {
+    if (!this.store.get(threadId)) return;
+    this.store.mutateSync(threadId, draft => { draft.pinned = false; return draft; });
+  }
+
+  /** Find all (non-expired) threads with a specific remote agent. */
+  getByRemoteAgent(agentName: string): Array<{ threadId: string; entry: ThreadResumeEntry }> {
+    return this.store.getByParticipant(agentName)
+      .map(c => ({ threadId: c.threadId, entry: conversationToEntry(c) }));
+  }
+
+  /** List all active or idle threads. */
+  listActive(): Array<{ threadId: string; entry: ThreadResumeEntry }> {
+    return this.store.listActive()
+      .map(c => ({ threadId: c.threadId, entry: conversationToEntry(c) }))
+      .filter(({ entry }) => entry.state === 'active' || entry.state === 'idle');
+  }
+
+  /** Cross-machine failover: demote a source machine's active threads to idle. */
+  migrateFrom(sourceMachine: string, targetMachine: string): { migrated: number; skipped: number } {
+    let migrated = 0; let skipped = 0;
+    // Iterate ALL conversations (not just active) so resolved/failed threads from
+    // the source machine are counted as skipped, matching legacy semantics.
+    for (const c of this.store.all()) {
+      if (c.machineOrigin !== sourceMachine) continue;
+      if (c.state === 'active') {
+        this.store.mutateSync(c.threadId, draft => {
+          draft.migratedTo = targetMachine;
+          draft.state = 'idle';
+          return draft;
+        });
         migrated++;
-      } else if (entry.machineOrigin === sourceMachine) {
+      } else {
         skipped++;
       }
     }
-
-    if (migrated > 0) this.persist(map);
     return { migrated, skipped };
   }
 
-  /**
-   * Get entries that were migrated to this machine (for resume capability).
-   */
+  /** Get entries migrated to this machine (for resume capability). */
   getMigratedEntries(targetMachine: string): Array<{ threadId: string; entry: ThreadResumeEntry }> {
-    const map = this.load();
-    const results: Array<{ threadId: string; entry: ThreadResumeEntry }> = [];
-    for (const [threadId, entry] of Object.entries(map)) {
-      if (entry.migratedTo === targetMachine) {
-        results.push({ threadId, entry });
-      }
-    }
-    return results;
+    return this.store.all()
+      .filter(c => c.migratedTo === targetMachine)
+      .map(c => ({ threadId: c.threadId, entry: conversationToEntry(c) }));
   }
 
-  /**
-   * Pin a thread — pinned threads are never evicted by LRU or TTL.
-   */
-  pin(threadId: string): void {
-    const map = this.load();
-    const entry = map[threadId];
-    if (!entry) return;
-
-    entry.pinned = true;
-    entry.savedAt = new Date().toISOString();
-
-    this.persist(map);
+  /** Total stored entries (for monitoring). */
+  size(): number {
+    return this.store.size();
   }
 
-  /**
-   * Unpin a thread — allows normal TTL and LRU eviction.
-   */
-  unpin(threadId: string): void {
-    const map = this.load();
-    const entry = map[threadId];
-    if (!entry) return;
-
-    entry.pinned = false;
-    entry.savedAt = new Date().toISOString();
-
-    this.persist(map);
-  }
-
-  /**
-   * Find all threads with a specific remote agent.
-   * Returns entries that are not expired.
-   */
-  getByRemoteAgent(agentName: string): Array<{ threadId: string; entry: ThreadResumeEntry }> {
-    const map = this.load();
-    const results: Array<{ threadId: string; entry: ThreadResumeEntry }> = [];
-
-    for (const [threadId, entry] of Object.entries(map)) {
-      if (entry.remoteAgent === agentName && (entry.pinned || !this.isExpired(entry))) {
-        results.push({ threadId, entry });
-      }
-    }
-
-    return results;
-  }
-
-  /**
-   * List all active or idle threads (not resolved, failed, or archived).
-   */
-  listActive(): Array<{ threadId: string; entry: ThreadResumeEntry }> {
-    const map = this.load();
-    const results: Array<{ threadId: string; entry: ThreadResumeEntry }> = [];
-
-    for (const [threadId, entry] of Object.entries(map)) {
-      if (
-        (entry.state === 'active' || entry.state === 'idle') &&
-        (entry.pinned || !this.isExpired(entry))
-      ) {
-        results.push({ threadId, entry });
-      }
-    }
-
-    return results;
-  }
-
-  /**
-   * Prune expired entries, resolved entries past grace period,
-   * and LRU overflow entries. Called automatically on save, but
-   * can be called manually for maintenance.
-   */
+  /** Prune expired / resolved-past-grace / LRU overflow. */
   prune(): void {
-    const map = this.load();
-    this.pruneMap(map);
-    this.persist(map);
+    this.store.prune();
   }
 
   /**
-   * Proactive resume heartbeat: scan all active thread-linked tmux sessions
-   * and update the thread→UUID mapping. Should be called periodically.
-   *
-   * This ensures that even if a session crashes unexpectedly, we already have
-   * its UUID on file for --resume.
+   * Proactive resume heartbeat: scan active thread-linked tmux sessions and
+   * update the thread→UUID mapping so a crash leaves the UUID on file.
    */
   refreshResumeMappings(threadSessions: Map<string, string>): void {
     try {
       if (!threadSessions || threadSessions.size === 0) return;
-
       const projectHash = this.projectDir.replace(/\//g, '-');
       const projectJsonlDir = path.join(os.homedir(), '.claude', 'projects', projectHash);
-
       if (!fs.existsSync(projectJsonlDir)) return;
 
-      // Get all JSONL files with their stats
       const jsonlFiles = fs.readdirSync(projectJsonlDir)
         .filter(f => f.endsWith('.jsonl'))
         .map(f => {
           try {
             const stat = fs.statSync(path.join(projectJsonlDir, f));
-            return { name: f, mtimeMs: stat.mtimeMs, uuid: f.replace('.jsonl', '') };
+            return { mtimeMs: stat.mtimeMs, uuid: f.replace('.jsonl', '') };
           } catch { return null; }
         })
-        .filter((f): f is { name: string; mtimeMs: number; uuid: string } => f !== null && f.uuid.length >= 30)
+        .filter((f): f is { mtimeMs: number; uuid: string } => f !== null && f.uuid.length >= 30)
         .sort((a, b) => b.mtimeMs - a.mtimeMs);
-
       if (jsonlFiles.length === 0) return;
 
-      const map = this.load();
-      let updated = 0;
       const claimedUuids = new Set<string>();
-
       for (const [threadId, sessionName] of threadSessions) {
-        // Verify the tmux session is actually alive
         const hasSession = spawnSync(this.tmuxPath, ['has-session', '-t', `=${sessionName}`]);
         if (hasSession.status !== 0) continue;
-
-        // Find the JSONL for this session (most recently modified, not already claimed)
         const availableJsonl = jsonlFiles.find(f => !claimedUuids.has(f.uuid));
         if (!availableJsonl) continue;
-
         claimedUuids.add(availableJsonl.uuid);
 
-        const existingEntry = map[threadId];
-
-        // Update if UUID changed, entry doesn't exist, or entry is stale (>2 hours)
-        const entryAge = existingEntry ? Date.now() - new Date(existingEntry.savedAt).getTime() : Infinity;
-        if (existingEntry && (existingEntry.uuid !== availableJsonl.uuid || entryAge > 2 * 60 * 60 * 1000)) {
-          existingEntry.uuid = availableJsonl.uuid;
-          existingEntry.savedAt = new Date().toISOString();
-          existingEntry.lastAccessedAt = new Date().toISOString();
-          existingEntry.sessionName = sessionName;
-          updated++;
+        const existing = this.store.get(threadId);
+        const entryAge = existing ? Date.now() - new Date(existing.savedAt).getTime() : Infinity;
+        if (existing && (existing.sessionUuid !== availableJsonl.uuid || entryAge > 2 * 60 * 60 * 1000)) {
+          this.store.mutateSync(threadId, draft => {
+            draft.sessionUuid = availableJsonl.uuid;
+            draft.boundSessionName = sessionName;
+            draft.lastActivityAt = new Date().toISOString();
+            return draft;
+          });
         }
-      }
-
-      if (updated > 0) {
-        this.persist(map);
       }
     } catch (err) {
       console.error('[ThreadResumeMap] Resume heartbeat error:', err);
     }
   }
 
-  /**
-   * Get the total number of entries in the map (for monitoring).
-   */
-  size(): number {
-    return Object.keys(this.load()).length;
-  }
+  // ── Private helpers ──────────────────────────────────────────
 
-  // ── Private Helpers ──────────────────────────────────────────
-
-  private load(): ThreadResumeMapData {
+  /** Dual-read: read a single entry from the frozen legacy file, if present + fresh. */
+  private readLegacyEntry(threadId: string): ThreadResumeEntry | null {
     try {
-      if (fs.existsSync(this.filePath)) {
-        return JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
-      }
+      if (!fs.existsSync(this.legacyPath)) return null;
+      const map = JSON.parse(fs.readFileSync(this.legacyPath, 'utf-8')) as Record<string, ThreadResumeEntry>;
+      const entry = map[threadId];
+      if (!entry) return null;
+      if (!entry.pinned && this.isExpired(entry)) return null;
+      return entry;
     } catch {
-      // Corrupted file — start fresh
-    }
-    return {};
-  }
-
-  private persist(map: ThreadResumeMapData): void {
-    try {
-      fs.writeFileSync(this.filePath, JSON.stringify(map, null, 2));
-    } catch (err) {
-      console.error(`[ThreadResumeMap] Failed to save: ${err}`);
+      return null;
     }
   }
 
-  /**
-   * Check if an entry is expired based on its state and age.
-   * - Active/idle: expire after MAX_AGE_MS from lastAccessedAt
-   * - Resolved: expire after RESOLVED_GRACE_MS from resolvedAt
-   * - Failed/archived: expire after MAX_AGE_MS from savedAt
-   */
   private isExpired(entry: ThreadResumeEntry): boolean {
     const now = Date.now();
-
     if (entry.state === 'resolved' && entry.resolvedAt) {
       return now - new Date(entry.resolvedAt).getTime() > RESOLVED_GRACE_MS;
     }
-
-    // For active/idle threads, use lastAccessedAt
-    const referenceTime = entry.lastAccessedAt || entry.savedAt;
-    return now - new Date(referenceTime).getTime() > MAX_AGE_MS;
+    const ref = entry.lastAccessedAt || entry.savedAt;
+    return now - new Date(ref).getTime() > MAX_AGE_MS;
   }
 
-  /**
-   * Prune a map in-place: remove expired entries, resolved-past-grace entries,
-   * and LRU overflow (non-pinned) entries.
-   */
-  private pruneMap(map: ThreadResumeMapData): void {
-    // Phase 1: Remove expired and resolved-past-grace entries
-    for (const key of Object.keys(map)) {
-      const entry = map[key];
-      if (entry.pinned) continue;
-
-      if (this.isExpired(entry)) {
-        delete map[key];
-      }
-    }
-
-    // Phase 2: LRU eviction if still over MAX_ENTRIES
-    const keys = Object.keys(map);
-    if (keys.length <= MAX_ENTRIES) return;
-
-    // Separate pinned from unpinned
-    const pinned: string[] = [];
-    const unpinned: Array<{ key: string; lastAccessedAt: number }> = [];
-
-    for (const key of keys) {
-      const entry = map[key];
-      if (entry.pinned) {
-        pinned.push(key);
-      } else {
-        unpinned.push({
-          key,
-          lastAccessedAt: new Date(entry.lastAccessedAt || entry.savedAt).getTime(),
-        });
-      }
-    }
-
-    // Sort unpinned by lastAccessedAt ascending (oldest first = evict first)
-    unpinned.sort((a, b) => a.lastAccessedAt - b.lastAccessedAt);
-
-    // Evict oldest unpinned entries until we're at or under MAX_ENTRIES
-    const toEvict = keys.length - MAX_ENTRIES;
-    for (let i = 0; i < toEvict && i < unpinned.length; i++) {
-      delete map[unpinned[i].key];
-    }
-  }
-
-  /**
-   * Check if a JSONL file exists for the given UUID.
-   */
+  /** Check if a JSONL file exists for the given session UUID. */
   private jsonlExists(uuid: string): boolean {
-    const homeDir = os.homedir();
-    const claudeProjectsDir = path.join(homeDir, '.claude', 'projects');
-
+    if (!uuid) return false;
+    const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects');
     if (!fs.existsSync(claudeProjectsDir)) return false;
-
     try {
-      const projectDirs = fs.readdirSync(claudeProjectsDir);
-      for (const dir of projectDirs) {
-        const jsonlPath = path.join(claudeProjectsDir, dir, `${uuid}.jsonl`);
-        if (fs.existsSync(jsonlPath)) return true;
+      for (const dir of fs.readdirSync(claudeProjectsDir)) {
+        if (fs.existsSync(path.join(claudeProjectsDir, dir, `${uuid}.jsonl`))) return true;
       }
     } catch {
-      // Can't check — assume not found
+      // Can't check — assume not found.
     }
-
     return false;
   }
 }

--- a/src/threadline/ThreadlineObservability.ts
+++ b/src/threadline/ThreadlineObservability.ts
@@ -254,8 +254,8 @@ export class ThreadlineObservability {
   private knownAgentsPath(): string {
     return path.join(this.stateDir, 'threadline', 'known-agents.json');
   }
-  private threadResumePath(): string {
-    return path.join(this.stateDir, 'threadline', 'thread-resume-map.json');
+  private conversationsPath(): string {
+    return path.join(this.stateDir, 'threadline', 'conversations.json');
   }
 
   private readJsonl(filePath: string): RawInboxEntry[] {
@@ -287,16 +287,26 @@ export class ThreadlineObservability {
     return map;
   }
 
+  /**
+   * Phase 2a (CMT-497): the resume state now lives in conversations.json (the
+   * single store). Return threads that have a spawned session (a sessionUuid) so
+   * the dashboard's `hasSpawnedSession` check is preserved.
+   */
   private loadThreadResume(): ThreadResumeFile {
-    const file = this.threadResumePath();
+    const file = this.conversationsPath();
     if (!fs.existsSync(file)) return {};
     try {
       const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
-      // ThreadResumeMap structure varies; accept any keyed map at the top level.
-      if (parsed && typeof parsed === 'object' && parsed.threads && typeof parsed.threads === 'object') {
-        return parsed.threads as ThreadResumeFile;
+      const convs = parsed && typeof parsed === 'object' ? parsed.conversations : undefined;
+      if (convs && typeof convs === 'object') {
+        const out: ThreadResumeFile = {};
+        for (const [threadId, c] of Object.entries(convs as Record<string, { sessionUuid?: string }>)) {
+          if (c && typeof c === 'object' && typeof c.sessionUuid === 'string' && c.sessionUuid) {
+            out[threadId] = c;
+          }
+        }
+        return out;
       }
-      if (parsed && typeof parsed === 'object') return parsed as ThreadResumeFile;
     } catch { /* ignore */ }
     return {};
   }

--- a/tests/integration/threadline/ThreadlineIntegration.test.ts
+++ b/tests/integration/threadline/ThreadlineIntegration.test.ts
@@ -1251,11 +1251,11 @@ describe('Threadline Integration Tests', () => {
       // Note: get() checks for JSONL existence which won't work in test env
       // So we check via the raw file instead
       const rawMap = JSON.parse(fs.readFileSync(
-        path.join(tmpDir, 'threadline', 'thread-resume-map.json'), 'utf-8',
+        path.join(tmpDir, 'threadline', 'conversations.json'), 'utf-8',
       ));
-      expect(rawMap[threadId]).toBeDefined();
-      expect(rawMap[threadId].state).toBe('active');
-      expect(rawMap[threadId].remoteAgent).toBe('remote-agent');
+      expect(rawMap.conversations[threadId]).toBeDefined();
+      expect(rawMap.conversations[threadId].state).toBe('active');
+      expect(rawMap.conversations[threadId].remoteAgent).toBe('remote-agent');
     });
 
     it('thread resolved -> new message creates new session', async () => {
@@ -1283,9 +1283,9 @@ describe('Threadline Integration Tests', () => {
       // Resolve the thread
       threadResumeMap.resolve(threadId);
       const rawMap = JSON.parse(fs.readFileSync(
-        path.join(tmpDir, 'threadline', 'thread-resume-map.json'), 'utf-8',
+        path.join(tmpDir, 'threadline', 'conversations.json'), 'utf-8',
       ));
-      expect(rawMap[threadId].state).toBe('resolved');
+      expect(rawMap.conversations[threadId].state).toBe('resolved');
     });
 
     it('multiple threads with same agent each have own session', () => {
@@ -1338,10 +1338,10 @@ describe('Threadline Integration Tests', () => {
       threadResumeMap.prune();
 
       const rawMap = JSON.parse(fs.readFileSync(
-        path.join(tmpDir, 'threadline', 'thread-resume-map.json'), 'utf-8',
+        path.join(tmpDir, 'threadline', 'conversations.json'), 'utf-8',
       ));
-      expect(rawMap[pinnedThreadId]).toBeDefined();
-      expect(rawMap[pinnedThreadId].pinned).toBe(true);
+      expect(rawMap.conversations[pinnedThreadId]).toBeDefined();
+      expect(rawMap.conversations[pinnedThreadId].pinned).toBe(true);
     });
 
     it('unpinned expired thread is pruned', () => {
@@ -1361,9 +1361,9 @@ describe('Threadline Integration Tests', () => {
       threadResumeMap.prune();
 
       const rawMap = JSON.parse(fs.readFileSync(
-        path.join(tmpDir, 'threadline', 'thread-resume-map.json'), 'utf-8',
+        path.join(tmpDir, 'threadline', 'conversations.json'), 'utf-8',
       ));
-      expect(rawMap[threadId]).toBeUndefined();
+      expect(rawMap.conversations[threadId]).toBeUndefined();
     });
 
     it('listActive returns only active and idle threads', () => {
@@ -1436,10 +1436,10 @@ describe('Threadline Integration Tests', () => {
       router.onSessionEnd(threadId, newUuid, 'session-1');
 
       const rawMap = JSON.parse(fs.readFileSync(
-        path.join(tmpDir, 'threadline', 'thread-resume-map.json'), 'utf-8',
+        path.join(tmpDir, 'threadline', 'conversations.json'), 'utf-8',
       ));
-      expect(rawMap[threadId].uuid).toBe(newUuid);
-      expect(rawMap[threadId].state).toBe('idle');
+      expect(rawMap.conversations[threadId].sessionUuid).toBe(newUuid);
+      expect(rawMap.conversations[threadId].state).toBe('idle');
 
       // Clean up the fake JSONL file
       SafeFsExecutor.safeRmSync(jsonlPath, { force: true, operation: 'tests/integration/threadline/ThreadlineIntegration.test.ts:1446' });
@@ -1471,10 +1471,10 @@ describe('Threadline Integration Tests', () => {
       router.onThreadResolved(threadId);
 
       const rawMap = JSON.parse(fs.readFileSync(
-        path.join(tmpDir, 'threadline', 'thread-resume-map.json'), 'utf-8',
+        path.join(tmpDir, 'threadline', 'conversations.json'), 'utf-8',
       ));
-      expect(rawMap[threadId].state).toBe('resolved');
-      expect(rawMap[threadId].resolvedAt).toBeDefined();
+      expect(rawMap.conversations[threadId].state).toBe('resolved');
+      expect(rawMap.conversations[threadId].resolvedAt).toBeDefined();
     });
   });
 
@@ -1892,9 +1892,9 @@ describe('Threadline Integration Tests', () => {
       router.onThreadFailed(threadId);
 
       const rawMap = JSON.parse(fs.readFileSync(
-        path.join(tmpDir, 'threadline', 'thread-resume-map.json'), 'utf-8',
+        path.join(tmpDir, 'threadline', 'conversations.json'), 'utf-8',
       ));
-      expect(rawMap[threadId].state).toBe('failed');
+      expect(rawMap.conversations[threadId].state).toBe('failed');
 
       // Clean up
       SafeFsExecutor.safeRmSync(jsonlPath, { force: true, operation: 'tests/integration/threadline/ThreadlineIntegration.test.ts:1903' });

--- a/tests/integration/threadline/ThreadlineMCP.test.ts
+++ b/tests/integration/threadline/ThreadlineMCP.test.ts
@@ -37,21 +37,12 @@ import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
  */
 class TestThreadResumeMap extends ThreadResumeMap {
   /**
-   * Override get() to use the raw data without JSONL verification.
-   * We access the internal load() and isExpired() by reading the file directly.
+   * Phase 2a: ThreadResumeMap is a view over ConversationStore. The only thing
+   * tests need to bypass is the JSONL-existence guard (no real Claude session
+   * files in tests); the rest of get() uses the real view logic.
    */
-  get(threadId: string): import('../../../src/threadline/ThreadResumeMap.js').ThreadResumeEntry | null {
-    // Read the file directly to bypass JSONL check
-    const filePath = (this as any).filePath;
-    try {
-      if (!fs.existsSync(filePath)) return null;
-      const map = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-      const entry = map[threadId];
-      if (!entry) return null;
-      return entry;
-    } catch {
-      return null;
-    }
+  protected jsonlExists(): boolean {
+    return true;
   }
 }
 import { AgentDiscovery } from '../../../src/threadline/AgentDiscovery.js';

--- a/tests/integration/threadline/single-store-cmt497.test.ts
+++ b/tests/integration/threadline/single-store-cmt497.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Integration tests — Threadline single-store collapse (Phase 2a / CMT-497).
+ *
+ * The ThreadResumeMap is now a view over the cross-process file-CAS
+ * ConversationStore. Validates spec acceptance criteria:
+ *  #1/#5 — cross-process: a gate mutate racing a ThreadResumeMap remove (the
+ *          MCP-child delete path) does not corrupt the store.
+ *  #2/#3 — field-bridge round-trip; save MERGES (no clobber of gate turn state).
+ *  #4   — resume works: a saved uuid is recoverable via get (jsonlExists guard).
+ *  #7   — dual-read: a thread written by a pre-2a version (legacy file) is found
+ *          on a miss and written through.
+ *  #8   — no second file-backed writer: ThreadResumeMap never writes
+ *          thread-resume-map.json (source-level + behavioral).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ThreadResumeMap, type ThreadResumeEntry } from '../../../src/threadline/ThreadResumeMap.js';
+import { ConversationStore } from '../../../src/threadline/ConversationStore.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+function tmp(): { stateDir: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmt497-'));
+  const stateDir = path.join(dir, '.instar');
+  fs.mkdirSync(path.join(stateDir, 'threadline'), { recursive: true });
+  return { stateDir, cleanup: () => SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/threadline/single-store-cmt497.test.ts:cleanup' }) };
+}
+
+/** Create a fake session JSONL so ThreadResumeMap.get's jsonlExists guard passes. */
+function fakeJsonl(uuid: string): string {
+  const dir = path.join(os.homedir(), '.claude', 'projects', 'cmt497-test-project');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${uuid}.jsonl`), '{"t":1}\n');
+  return dir;
+}
+function cleanupJsonl(): void {
+  try { SafeFsExecutor.safeRmSync(path.join(os.homedir(), '.claude', 'projects', 'cmt497-test-project'), { recursive: true, force: true, operation: 'cmt497:jsonl-cleanup' }); } catch { /* ignore */ }
+}
+
+function entry(o: Partial<ThreadResumeEntry> = {}): ThreadResumeEntry {
+  const now = new Date().toISOString();
+  return {
+    uuid: 'uuid-cmt497-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', sessionName: 'sess', createdAt: now, savedAt: now,
+    lastAccessedAt: now, remoteAgent: 'codey', subject: 'S', state: 'active', pinned: false, messageCount: 1, ...o,
+  };
+}
+
+describe('Threadline single-store collapse (CMT-497, integration)', () => {
+  let stateDir: string; let cleanup: () => void;
+  beforeEach(() => { ({ stateDir, cleanup } = tmp()); });
+  afterEach(() => { cleanup(); cleanupJsonl(); });
+
+  it('#8 ThreadResumeMap writes conversations.json and NEVER thread-resume-map.json', () => {
+    const trm = new ThreadResumeMap(stateDir, '/proj');
+    trm.save('t1', entry());
+    expect(fs.existsSync(path.join(stateDir, 'threadline', 'conversations.json'))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, 'threadline', 'thread-resume-map.json'))).toBe(false);
+    // Source-level guard: the class only READS the legacy file (dual-read), never writes it.
+    const src = fs.readFileSync(path.resolve(__dirname, '../../../src/threadline/ThreadResumeMap.ts'), 'utf-8');
+    expect(/writeFileSync\([^)]*thread-resume-map/.test(src)).toBe(false);
+  });
+
+  it('#3 save MERGES — does not clobber the gate turn state', async () => {
+    const store = new ConversationStore(stateDir);
+    // Gate sets turn state on the conversation.
+    await store.mutate('t1', d => { d.turnCount = 7; d.lastInboundHash = 'abc'; d.messageCount = 7; return d; });
+    // Router saves resume info via the view.
+    const trm = new ThreadResumeMap(stateDir, '/proj', undefined, store);
+    trm.save('t1', entry({ uuid: 'u', sessionName: 's', messageCount: 2 }));
+    const c = new ConversationStore(stateDir).get('t1')!;
+    expect(c.turnCount).toBe(7);          // preserved
+    expect(c.lastInboundHash).toBe('abc'); // preserved
+    expect(c.sessionUuid).toBe('u');       // applied
+    expect(c.messageCount).toBe(7);        // max(7,2) — never goes backwards
+  });
+
+  it('#2/#4 field-bridge round-trip + resume recovers the uuid', () => {
+    fakeJsonl('uuid-roundtrip-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    const trm = new ThreadResumeMap(stateDir, '/proj');
+    trm.save('t1', entry({ uuid: 'uuid-roundtrip-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', sessionName: 'tmux-x', originTopicId: 4242, originSessionName: 'topic-sess' }));
+    const got = trm.get('t1')!;
+    expect(got).not.toBeNull();
+    expect(got.uuid).toBe('uuid-roundtrip-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    expect(got.sessionName).toBe('tmux-x');
+    expect(got.originTopicId).toBe(4242);
+    expect(got.originSessionName).toBe('topic-sess');
+  });
+
+  it('#7 dual-read: a pre-2a legacy-file thread is found on a miss + written through', () => {
+    fakeJsonl('uuid-legacy-cccccccccccccccccccccccccccccc');
+    // Simulate a thread written by a pre-2a version (legacy file only).
+    fs.writeFileSync(path.join(stateDir, 'threadline', 'thread-resume-map.json'), JSON.stringify({
+      legacyThread: entry({ uuid: 'uuid-legacy-cccccccccccccccccccccccccccccc', remoteAgent: 'dawn' }),
+    }));
+    const trm = new ThreadResumeMap(stateDir, '/proj');
+    const got = trm.get('legacyThread');
+    expect(got?.remoteAgent).toBe('dawn');
+    // Written through to the new store.
+    expect(new ConversationStore(stateDir).get('legacyThread')?.remoteAgent).toBe('dawn');
+  });
+
+  it('#1/#5 a gate mutate racing a remove (MCP-child delete) does not corrupt the store', async () => {
+    const store = new ConversationStore(stateDir);
+    await store.mutate('keep', d => { d.state = 'active'; return d; });
+    await store.mutate('victim', d => { d.state = 'active'; return d; });
+    const trm = new ThreadResumeMap(stateDir, '/proj'); // its own instance (separate process sim)
+
+    await Promise.all([
+      store.mutate('keep', d => { d.turnCount += 1; return d; }),
+      (async () => trm.remove('victim'))(),
+      store.mutate('keep', d => { d.turnCount += 1; return d; }),
+    ]);
+
+    const fresh = new ConversationStore(stateDir);
+    expect(fresh.get('victim')).toBeNull();        // delete applied
+    expect(fresh.get('keep')?.turnCount).toBe(2);  // concurrent writes not lost
+  });
+});

--- a/tests/unit/ConversationStore.test.ts
+++ b/tests/unit/ConversationStore.test.ts
@@ -192,4 +192,45 @@ describe('ConversationStore', () => {
     await store.mutate('c', d => { d.state = 'archived'; return d; });
     expect(store.listActive().map(c => c.threadId).sort()).toEqual(['a']);
   });
+
+  it('CROSS-PROCESS: two store instances on one file lose no same-thread update', async () => {
+    // Phase 2a: disk-backed per-record version-CAS — two instances (simulating
+    // the server + the MCP child) mutating the SAME thread must not clobber.
+    const a = new ConversationStore(stateDir);
+    const b = new ConversationStore(stateDir);
+    await a.mutate('shared', d => { d.state = 'active'; d.turnCount = 0; return d; });
+    await Promise.all([
+      ...Array.from({ length: 25 }, () => a.mutate('shared', d => { d.turnCount += 1; return d; })),
+      ...Array.from({ length: 25 }, () => b.mutate('shared', d => { d.turnCount += 1; return d; })),
+    ]);
+    expect(new ConversationStore(stateDir).get('shared')?.turnCount).toBe(50);
+  });
+
+  it('mutateSync racing async mutate loses no update (both bump version)', async () => {
+    const store = new ConversationStore(stateDir);
+    await store.mutate('t', d => { d.turnCount = 0; d.messageCount = 0; return d; });
+    await Promise.all([
+      store.mutate('t', async d => { await new Promise(r => setTimeout(r, 3)); d.turnCount += 1; return d; }),
+      (async () => { store.mutateSync('t', d => { d.messageCount += 1; return d; }); })(),
+      store.mutate('t', d => { d.turnCount += 1; return d; }),
+      (async () => { store.mutateSync('t', d => { d.messageCount += 1; return d; }); })(),
+    ]);
+    const c = new ConversationStore(stateDir).get('t')!;
+    expect(c.turnCount).toBe(2);
+    expect(c.messageCount).toBe(2);
+  });
+
+  it('mutateSync returning null deletes the record', () => {
+    const store = new ConversationStore(stateDir);
+    store.mutateSync('gone', d => { d.state = 'active'; return d; });
+    expect(store.get('gone')?.state).toBe('active');
+    expect(store.mutateSync('gone', () => null)).toBeNull();
+    expect(new ConversationStore(stateDir).get('gone')).toBeNull();
+  });
+
+  it('a write by one instance is visible to a fresh instance (disk is source of truth)', async () => {
+    const a = new ConversationStore(stateDir);
+    await a.mutate('x', d => { d.subject = 'hello'; return d; });
+    expect(new ConversationStore(stateDir).get('x')?.subject).toBe('hello');
+  });
 });

--- a/tests/unit/ThreadlineObservability.test.ts
+++ b/tests/unit/ThreadlineObservability.test.ts
@@ -99,12 +99,16 @@ describe('ThreadlineObservability', () => {
       expect(threads[0]!.bridge!.topicName).toBe('echo↔Dawn — hello');
     });
 
-    it('marks hasSpawnedSession when thread-resume-map references the thread', () => {
+    it('marks hasSpawnedSession when conversations.json shows a spawned session', () => {
       writeJsonl(path.join(env.stateDir, 'threadline', 'inbox.jsonl.active'), [
         { id: 'm1', timestamp: '2026-05-01T10:00:00Z', from: 'fp', senderName: 'X', trustLevel: 'trusted', threadId: 'tA', text: 'x' },
       ]);
-      fs.writeFileSync(path.join(env.stateDir, 'threadline', 'thread-resume-map.json'), JSON.stringify({
-        threads: { tA: { sessionName: 'sess-1' } },
+      // Phase 2a (CMT-497): resume state lives in conversations.json; a thread
+      // counts as spawned when it has a sessionUuid.
+      fs.writeFileSync(path.join(env.stateDir, 'threadline', 'conversations.json'), JSON.stringify({
+        version: 1,
+        conversations: { tA: { threadId: 'tA', version: 1, participants: { peers: [] }, state: 'idle', pinned: false, messageCount: 1, turnCount: 0, sessionUuid: 'uuid-A', boundSessionName: 'sess-1', createdAt: '2026-05-01T10:00:00Z', savedAt: '2026-05-01T10:00:00Z', lastActivityAt: '2026-05-01T10:00:00Z' } },
+        lastModified: '2026-05-01T10:00:00Z',
       }));
 
       const threads = env.obs.listThreads();

--- a/tests/unit/TopicLinkageHandler.test.ts
+++ b/tests/unit/TopicLinkageHandler.test.ts
@@ -131,8 +131,10 @@ describe('TopicLinkageHandler.captureOriginOnSend', () => {
     const entry = deps.threadResumeMap.get('t-2') as ThreadResumeEntry | null;
     // Note: ThreadResumeMap.get verifies JSONL existence — entry may be null
     // because no real Claude session JSONL exists. Read the raw file instead.
-    const raw = JSON.parse(fs.readFileSync(path.join(stateDir, 'threadline', 'thread-resume-map.json'), 'utf-8'));
-    expect(raw['t-2'].originTopicId).toBe(9210);
+    // Phase 2a: ThreadResumeMap is a view over conversations.json (originTopicId
+    // → boundTopicId via the field bridge).
+    const raw = JSON.parse(fs.readFileSync(path.join(stateDir, 'threadline', 'conversations.json'), 'utf-8')).conversations;
+    expect(raw['t-2'].boundTopicId).toBe(9210);
     expect(raw['t-2'].originSessionName).toBe('echo-topic-9210');
     // get() may return null because of the JSONL existence guard; that's expected
     // in this synthetic test — the raw-file assertion above is the source of truth.

--- a/tests/unit/threadline/ThreadResumeMap.test.ts
+++ b/tests/unit/threadline/ThreadResumeMap.test.ts
@@ -323,9 +323,8 @@ describe('ThreadResumeMap', () => {
         pinned: true,
       });
 
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      const data: Record<string, ThreadResumeEntry> = { [threadId]: entry };
-      fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+      // Phase 2a: the store is conversations.json; seed via the API.
+      map.save(threadId, entry);
 
       const result = map.getByRemoteAgent('agent-pinned');
       expect(result).toHaveLength(1);
@@ -419,83 +418,57 @@ describe('ThreadResumeMap', () => {
   // ── Prune behavior ──────────────────────────────────────────
 
   describe('prune', () => {
+    // Phase 2a: the store is conversations.json — seed via the API, assert there.
+    const convKeys = (): string[] => {
+      const p = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      if (!fs.existsSync(p)) return [];
+      return Object.keys(JSON.parse(fs.readFileSync(p, 'utf-8')).conversations ?? {});
+    };
+
     it('removes expired entries', () => {
       const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
-      const data: Record<string, ThreadResumeEntry> = {
-        'thread-old': makeEntry({
-          lastAccessedAt: eightDaysAgo,
-          savedAt: eightDaysAgo,
-        }),
-        'thread-new': makeEntry(),
-      };
-
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+      map.save('thread-old', makeEntry({ lastAccessedAt: eightDaysAgo, savedAt: eightDaysAgo }));
+      map.save('thread-new', makeEntry());
 
       map.prune();
 
-      const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-      expect(raw['thread-old']).toBeUndefined();
-      expect(raw['thread-new']).toBeDefined();
+      expect(convKeys()).not.toContain('thread-old');
+      expect(convKeys()).toContain('thread-new');
     });
 
     it('removes resolved entries past grace period', () => {
       const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
-      const data: Record<string, ThreadResumeEntry> = {
-        'thread-resolved-old': makeEntry({
-          state: 'resolved',
-          resolvedAt: eightDaysAgo,
-          savedAt: new Date().toISOString(),
-        }),
-        'thread-resolved-recent': makeEntry({
-          state: 'resolved',
-          resolvedAt: new Date().toISOString(),
-          savedAt: new Date().toISOString(),
-          lastAccessedAt: new Date().toISOString(),
-        }),
-      };
-
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+      map.save('thread-resolved-old', makeEntry({ state: 'resolved', resolvedAt: eightDaysAgo, lastAccessedAt: eightDaysAgo }));
+      map.save('thread-resolved-recent', makeEntry({ state: 'resolved', resolvedAt: new Date().toISOString(), lastAccessedAt: new Date().toISOString() }));
 
       map.prune();
 
-      const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-      expect(raw['thread-resolved-old']).toBeUndefined();
-      expect(raw['thread-resolved-recent']).toBeDefined();
+      expect(convKeys()).not.toContain('thread-resolved-old');
+      expect(convKeys()).toContain('thread-resolved-recent');
     });
 
     it('does not prune pinned entries even if expired', () => {
       const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-      const data: Record<string, ThreadResumeEntry> = {
-        'thread-pinned-old': makeEntry({
-          lastAccessedAt: thirtyDaysAgo,
-          savedAt: thirtyDaysAgo,
-          pinned: true,
-        }),
-      };
-
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+      map.save('thread-pinned-old', makeEntry({ lastAccessedAt: thirtyDaysAgo, savedAt: thirtyDaysAgo, pinned: true }));
 
       map.prune();
 
-      const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-      expect(raw['thread-pinned-old']).toBeDefined();
+      expect(convKeys()).toContain('thread-pinned-old');
     });
   });
 
   // ── Persistence ──────────────────────────────────────────────
 
   describe('persistence', () => {
-    it('persists data to JSON file', () => {
+    it('persists data to the conversations store', () => {
       map.save('thread-persist', makeEntry());
 
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
+      // Phase 2a: ThreadResumeMap is a view over conversations.json.
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
       expect(fs.existsSync(filePath)).toBe(true);
 
       const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-      expect(raw['thread-persist']).toBeDefined();
+      expect(raw.conversations['thread-persist']).toBeDefined();
     });
 
     it('survives reconstruction from file', () => {

--- a/tests/unit/threadline/ThreadlineRouter.test.ts
+++ b/tests/unit/threadline/ThreadlineRouter.test.ts
@@ -386,8 +386,8 @@ describe('ThreadlineRouter', () => {
 
       // The entry should be saved (though get() checks JSONL existence)
       // We check the file directly
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')).conversations;
       expect(data[threadId]).toBeDefined();
       expect(data[threadId].subject).toBe('Saved Thread');
       expect(data[threadId].state).toBe('active');
@@ -460,8 +460,8 @@ describe('ThreadlineRouter', () => {
       const envelope = makeEnvelope({ threadId });
       await router.handleInboundMessage(envelope);
 
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')).conversations;
       expect(data[threadId].state).toBe('active');
       expect(data[threadId].messageCount).toBe(6); // 5 + 1
     });
@@ -632,11 +632,11 @@ describe('ThreadlineRouter', () => {
 
       router.onSessionEnd(threadId, newUuid, 'updated-tmux-session');
 
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-      expect(data[threadId].uuid).toBe(newUuid);
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')).conversations;
+      expect(data[threadId].sessionUuid).toBe(newUuid);
       expect(data[threadId].state).toBe('idle');
-      expect(data[threadId].sessionName).toBe('updated-tmux-session');
+      expect(data[threadId].boundSessionName).toBe('updated-tmux-session');
     });
 
     it('does nothing for unknown thread', () => {
@@ -651,8 +651,8 @@ describe('ThreadlineRouter', () => {
 
       router.onThreadResolved(threadId);
 
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')).conversations;
       expect(data[threadId].state).toBe('resolved');
       expect(data[threadId].resolvedAt).toBeDefined();
     });
@@ -665,8 +665,8 @@ describe('ThreadlineRouter', () => {
 
       router.onThreadFailed(threadId);
 
-      const filePath = path.join(temp.stateDir, 'threadline', 'thread-resume-map.json');
-      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')).conversations;
       expect(data[threadId].state).toBe('failed');
     });
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,69 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+<!-- patch = internal refactor, no behavior change for the user -->
+
+## What Changed
+
+Phase 2a of the Threadline re-assessment (CMT-497) — the **single-store collapse**.
+Phase 1 introduced one clean conversation record (`ConversationStore`) but couldn't
+retire the old `thread-resume-map.json` yet: it's written from two processes (the
+agent server and the MCP stdio child), and the new record kept its data in memory,
+so two in-memory copies would have clobbered each other. This finishes the cleanup
+so there is truly ONE store.
+
+**The fix.** `ConversationStore` is now cross-process safe — it reads the file
+fresh per operation, commits with an atomic tmp+rename, and uses a per-record
+`version` token so a same-thread race loses no update (a strict improvement over
+the old last-writer-wins). `ThreadResumeMap` becomes a thin **view** over it (every
+method preserved, same signatures), so the server, the router and the MCP child all
+read/write the one `conversations.json`. The legacy `thread-resume-map.json` is no
+longer written; a one-release dual-read window falls back to it on a miss so threads
+written by a pre-2a version aren't lost.
+
+**Approach note (convergence).** The first design proposed an HTTP surface so the
+MCP child could mutate via the server. A two-reviewer pass against the live code
+rejected it: it targeted a dead `ContextThreadMap` path, the `/threadline/*` routes
+bypass the bearer middleware (so the endpoints would have shipped unauthenticated),
+and it was heavy machinery to replace a single `.remove()` call. The shipped design
+— file version-CAS — has no new network surface, no auth gap, and no restart-window
+data loss.
+
+## What to Tell Your User
+
+Nothing changes for you. This is an internal cleanup so agent-to-agent conversation
+state lives in one place instead of two. Existing conversations are preserved.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Cross-process `ConversationStore` (file version-CAS) | Automatic; `mutate`/`mutateSync` are safe across the server + MCP child |
+| `ThreadResumeMap` as a view over the single store | Automatic; same API, now backed by `conversations.json` |
+
+## Migration Notes
+
+Phase 1's `migrateThreadlineConversationStore` already folds the legacy file into
+`conversations.json` on boot. This release stops writing the legacy file and adds a
+one-release dual-read fallback (read legacy on a miss, write through). The legacy
+`thread-resume-map.json` is kept on disk for rollback and removed in a later
+release. No `~/.codex` or relay change.
+
+## Evidence
+
+- Spec: `docs/specs/THREADLINE-SINGLE-STORE-SPEC.md` (+ ELI16 + convergence report —
+  approach pivoted from HTTP to file version-CAS after 2 fatal + blocking findings).
+- Tests: `ConversationStore.test.ts` (incl. a two-instance cross-process 50-increment
+  race + `mutateSync` racing async `mutate`), `ThreadResumeMap.test.ts` (field-bridge
+  + prune/migrate parity, re-pointed to the new store), `single-store-cmt497.test.ts`
+  (merge-not-clobber, dual-read, resume round-trip, gate-mutate-racing-remove,
+  no-second-writer), `ThreadlineObservability.test.ts` (re-pointed). 1490+ threadline
+  tests green.
+- Test-as-self on live `instar-codey` before merge (MCP-child delete over the single
+  store, resume recovery, no corruption under concurrent gate+delete).
+
+## Rollback
+
+Additive + reversible. Revert restores the file-backed `ThreadResumeMap`, the
+Observability raw read, and the in-memory `ConversationStore`. The frozen legacy file
+is still current within the dual-read window, so rollback strands no state.


### PR DESCRIPTION
## Summary

Phase 2a of the Threadline re-assessment (CMT-497) — completes Phase 1's acceptance #1 (*router reads/writes ONLY the Conversation; no parallel writes*), which Phase 1 deferred due to a multi-process write pattern.

- **`ConversationStore` → cross-process file version-CAS.** Reload-per-op + per-record `version` token + atomic tmp+rename (the legacy maps' cross-process-safe pattern, hardened so same-thread races lose no update). Adds `mutateSync` + a 250ms read-snapshot cache. The server and the MCP stdio child can now both write `conversations.json` safely.
- **`ThreadResumeMap` → a view over `ConversationStore`.** Every method preserved (same signatures); explicit field bridge (`uuid↔sessionUuid`, `sessionName↔boundSessionName`, `lastAccessedAt↔lastActivityAt`, `originTopicId↔boundTopicId`). `save` MERGES — never clobbers the gate's `turnCount`/`lastInboundHash`. The legacy `thread-resume-map.json` is no longer written; a one-release dual-read window falls back to it on a miss.
- **`ThreadlineObservability` re-pointed** off the raw legacy-file read to `conversations.json`.

Spec: `docs/specs/THREADLINE-SINGLE-STORE-SPEC.md` (+ ELI16 + convergence report).

**Approach pivoted after convergence:** the first draft proposed an HTTP single-writer surface; two reviewers (against live code) found it targeted dead `ContextThreadMap` code, the `/threadline/*` routes bypass the bearer middleware (so endpoints would ship unauthenticated), and it was heavy machinery for a single `.remove()` call. The shipped file version-CAS has no network surface, no auth gap, no restart-window data loss.

## Test-as-self (live validation before merge)

Deployed to live `instar-codey` and validated BEFORE this PR:
- A message wrote conversation state to the ONE store (sessionUuid bridged); `thread-resume-map.json` stayed **frozen** (no second writer).
- The core risk: a **separate process** (as the MCP child deletes) removed a thread from the single store while the server was live — thread removed, all others intact, server healthy. The cross-process safety holds for real.
- The dashboard thread view reads the new store correctly. Clean boot; Codey restored to released afterward.

## Test plan

- [x] Unit: `ConversationStore` (incl. two-instance cross-process 50-increment race + `mutateSync` racing async `mutate`), `ThreadResumeMap` (field bridge, prune/migrate parity, re-pointed)
- [x] Integration: `single-store-cmt497` (no-second-writer, merge-not-clobber, dual-read, resume round-trip, gate-mutate-racing-remove); `ThreadlineMCP` / `ThreadlineIntegration` re-pointed
- [x] `ThreadlineObservability` re-pointed + test
- [x] 1668 threadline-dependent tests green; tsc clean
- [x] Test-as-self on live `instar-codey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)