### PR TITLE
fix(test): repair threadline e2e harness broken by CMT-497 (#381)

### DIFF
--- a/tests/e2e/threadline/ThreadlineE2E.test.ts
+++ b/tests/e2e/threadline/ThreadlineE2E.test.ts
@@ -221,11 +221,11 @@ describe('Scenario 1: Happy Path — First Contact to Conversation', () => {
     dawn.threadMap.save(threadId, entry);
     // ThreadResumeMap.get checks for JSONL file existence; use direct file check
     const rawMap = JSON.parse(fs.readFileSync(
-      path.join(dawn.stateDir, 'threadline', 'thread-resume-map.json'), 'utf-8'
+      path.join(dawn.stateDir, 'threadline', 'conversations.json'), 'utf-8'
     ));
-    expect(rawMap[threadId]).toBeDefined();
-    expect(rawMap[threadId].remoteAgent).toBe('echo');
-    expect(rawMap[threadId].subject).toBe('First contact');
+    expect(rawMap.conversations[threadId]).toBeDefined();
+    expect(rawMap.conversations[threadId].remoteAgent).toBe('echo');
+    expect(rawMap.conversations[threadId].subject).toBe('First contact');
   });
 });
 
@@ -255,11 +255,11 @@ describe('Scenario 2: Session Resume After Restart', () => {
     // "Restart" — create new ThreadResumeMap from same stateDir
     const newMap = new ThreadResumeMap(dawn.stateDir, dawn.stateDir, '/bin/echo');
     const rawData = JSON.parse(fs.readFileSync(
-      path.join(dawn.stateDir, 'threadline', 'thread-resume-map.json'), 'utf-8'
+      path.join(dawn.stateDir, 'threadline', 'conversations.json'), 'utf-8'
     ));
-    expect(rawData[threadId]).toBeDefined();
-    expect(rawData[threadId].uuid).toBe(sessionUUID);
-    expect(rawData[threadId].state).toBe('active');
+    expect(rawData.conversations[threadId]).toBeDefined();
+    expect(rawData.conversations[threadId].sessionUuid).toBe(sessionUUID);
+    expect(rawData.conversations[threadId].state).toBe('active');
   });
 
   it('HandshakeManager recovers identity keys from stateDir after restart', () => {
@@ -847,9 +847,9 @@ describe('Scenario 8: Persistence Across Restarts', () => {
     expect(newCB.getState('echo')?.totalSuccesses).toBe(1);
 
     const rawMap = JSON.parse(fs.readFileSync(
-      path.join(dawn.stateDir, 'threadline', 'thread-resume-map.json'), 'utf-8'
+      path.join(dawn.stateDir, 'threadline', 'conversations.json'), 'utf-8'
     ));
-    expect(rawMap[threadId].remoteAgent).toBe('echo');
+    expect(rawMap.conversations[threadId].remoteAgent).toBe('echo');
   });
 });
 

--- a/tests/e2e/threadline/ThreadlineMCPE2E.test.ts
+++ b/tests/e2e/threadline/ThreadlineMCPE2E.test.ts
@@ -46,16 +46,14 @@ function cleanupDir(dir: string): void {
 }
 
 /**
- * Test-friendly ThreadResumeMap that skips JSONL file existence checks.
+ * Test-friendly ThreadResumeMap that skips the JSONL file-existence check.
+ * Phase 2a (CMT-497): ThreadResumeMap is a view over ConversationStore; the only
+ * thing tests need to bypass is the JSONL guard (no real Claude session files in
+ * tests), so override just that and use the real view logic.
  */
 class TestThreadResumeMap extends ThreadResumeMap {
-  get(threadId: string): import('../../../src/threadline/ThreadResumeMap.js').ThreadResumeEntry | null {
-    const filePath = (this as any).filePath;
-    try {
-      if (!fs.existsSync(filePath)) return null;
-      const map = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-      return map[threadId] || null;
-    } catch { return null; }
+  protected jsonlExists(): boolean {
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary

PR #381 (CMT-497 single-store collapse) turned main's `e2e` CI job red. Root cause: the e2e test harness was not updated for the refactor (my pre-push + watched checks run a faster subset, not `test:e2e` — the real miss). **Production code is unaffected — test-harness-only.**

- `ThreadlineMCPE2E.test.ts`: `TestThreadResumeMap.get()` reached into the now-removed private `filePath` field → returned null → the `threadline_history` tool's "verify thread exists" check failed with "Thread not found" → tests' `JSON.parse` choked on the error string. Fixed: override only `jsonlExists()` (use the real view logic), matching the integration harness #381 already fixed.
- `ThreadlineE2E.test.ts`: read the frozen `thread-resume-map.json` directly. Fixed: read `conversations.json` with the field bridge (`uuid`→`sessionUuid`).

## Test plan
- [x] All 324 threadline e2e tests pass
- [x] Full e2e suite: 2164 passed, 6 skipped, 0 failures
- [x] tsc clean

Unblocks the merge queue (a downstream PR is held behind the red main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)