### PR TITLE
chore(test-safety): pre-push e2e gate + shared test helper + safe-merge guard

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -38,9 +38,11 @@ else
 fi
 
 # Try up to 2 times — flaky tests may fail intermittently
+SMOKE_OK=0
 for attempt in 1 2; do
   if $TEST_CMD; then
-    exit 0
+    SMOKE_OK=1
+    break
   fi
   if [ "$attempt" -eq 1 ]; then
     echo ""
@@ -49,5 +51,19 @@ for attempt in 1 2; do
   fi
 done
 
-echo "❌ Tests failed on both attempts. Debug with: $TEST_CMD"
-exit 1
+if [ "$SMOKE_OK" != "1" ]; then
+  echo "❌ Tests failed on both attempts. Debug with: $TEST_CMD"
+  exit 1
+fi
+
+# ── Path-scoped e2e gate ──────────────────────────────────────────────
+# Both the smoke tier AND test:push use vitest.push.config.ts, which EXCLUDES
+# tests/e2e/**. So a change can pass everything above yet break the separate
+# `E2E Tests` CI job (PR #381 turned main red this way). When the push touches
+# an e2e-load-bearing area, run that area's e2e suite now. Path-scoped, so
+# unrelated pushes pay nothing. Opt out: INSTAR_PRE_PUSH_E2E_SKIP=1 git push
+echo "🔒 Running path-scoped e2e gate..."
+if ! node scripts/pre-push-e2e-scope.mjs; then
+  exit 1
+fi
+exit 0

--- a/scripts/pre-push-e2e-scope.mjs
+++ b/scripts/pre-push-e2e-scope.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// safe-git-allow: pre-push bootstrap — read-only git only (merge-base / rev-parse
+// / diff --name-only); runs before TS is compiled, so it can't use SafeGitExecutor.
 /**
  * pre-push-e2e-scope — run the END-TO-END suite for the area being pushed.
  *

--- a/scripts/pre-push-e2e-scope.mjs
+++ b/scripts/pre-push-e2e-scope.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * pre-push-e2e-scope — run the END-TO-END suite for the area being pushed.
+ *
+ * Why: the pre-push smoke tier (`test:push` / `test:smoke`) uses
+ * `vitest.push.config.ts`, which EXCLUDES `tests/e2e/**`. So a change can pass
+ * pre-push + the watched CI checks yet break the separate `E2E Tests` CI job —
+ * exactly what turned main red in PR #381 (the threadline single-store refactor
+ * left two e2e test harnesses stale; fixed in #383). A red e2e job blocks the
+ * whole merge queue.
+ *
+ * This gate closes that hole structurally: when the push touches an
+ * "e2e-load-bearing" source area, it runs that area's e2e suite BEFORE the push
+ * is allowed — automatically, not by memory. It is PATH-SCOPED, so unrelated
+ * pushes pay nothing.
+ *
+ * Opt out: INSTAR_PRE_PUSH_E2E_SKIP=1 git push  (CI still runs the full e2e job)
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+
+if (process.env.INSTAR_PRE_PUSH_E2E_SKIP === '1' || process.env.INSTAR_PRE_PUSH_SKIP === '1') {
+  console.log('⏭️  pre-push e2e scope skipped (env) — CI still runs the full e2e job.');
+  process.exit(0);
+}
+
+/**
+ * Map a changed-source-path matcher → the e2e suite path(s) that exercise it.
+ * Extend this as more areas gain e2e coverage. Keep entries narrow so the gate
+ * stays fast and only fires for the area actually changed.
+ */
+const SCOPE_MAP = [
+  { match: /^src\/threadline\//, e2e: ['tests/e2e/threadline/'] },
+  { match: /^tests\/e2e\/threadline\//, e2e: ['tests/e2e/threadline/'] },
+  { match: /^tests\/helpers\/TestThreadResumeMap\.ts$/, e2e: ['tests/e2e/threadline/'] },
+];
+
+let changed = [];
+try {
+  // Changes on this branch since it diverged from origin/main. The pre-push
+  // hook already fetched origin/main; fall back to HEAD~1 if the ref is absent.
+  let base = '';
+  try {
+    base = execSync('git merge-base origin/main HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    base = execSync('git rev-parse HEAD~1', { encoding: 'utf-8' }).trim();
+  }
+  const out = execSync(`git diff --name-only ${base} HEAD`, { encoding: 'utf-8' });
+  changed = out.split('\n').map(s => s.trim()).filter(Boolean);
+} catch (err) {
+  console.warn(`pre-push-e2e-scope: could not compute changed files (${err instanceof Error ? err.message : err}) — skipping (CI still runs e2e).`);
+  process.exit(0);
+}
+
+const suites = new Set();
+for (const file of changed) {
+  for (const rule of SCOPE_MAP) {
+    if (rule.match.test(file)) rule.e2e.forEach(s => suites.add(s));
+  }
+}
+
+if (suites.size === 0) {
+  process.exit(0); // nothing e2e-load-bearing changed — fast path
+}
+
+const suiteList = [...suites];
+console.log(`🧪 pre-push e2e scope: changed files touch ${suiteList.join(', ')} — running their e2e suite(s)...`);
+console.log('   Opt out: INSTAR_PRE_PUSH_E2E_SKIP=1 git push (CI still runs the full e2e job)');
+
+const res = spawnSync(
+  'npx',
+  ['vitest', 'run', '--config', 'vitest.e2e.config.ts', ...suiteList],
+  { stdio: 'inherit', encoding: 'utf-8' },
+);
+
+if (res.status !== 0) {
+  console.error('❌ Scoped e2e suite failed. Fix before pushing, or INSTAR_PRE_PUSH_E2E_SKIP=1 to bypass (CI will still catch it).');
+  process.exit(1);
+}
+console.log('✅ Scoped e2e suite passed.');
+process.exit(0);

--- a/scripts/safe-merge.mjs
+++ b/scripts/safe-merge.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * safe-merge — merge a PR ONLY after every check (incl. the e2e job) is green.
+ *
+ * Why: we merge with `gh pr merge --admin` to jump the hot-branch queue, but
+ * `--admin` BYPASSES branch-protection's required-checks enforcement — which is
+ * how PR #381 merged while the `E2E Tests` job was red and turned main red for
+ * everyone. This wrapper re-imposes the requirement that `--admin` removes:
+ * it waits for all checks to finish, refuses the merge if ANY check failed (and
+ * specifically verifies an e2e check ran + passed), and only then merges.
+ *
+ * Usage:  node scripts/safe-merge.mjs <PR#> [--admin] [--squash|--merge|--rebase]
+ *   --admin       still allowed (for the BEHIND/hot-branch case) — but ONLY
+ *                 reached AFTER this script has confirmed every check is green.
+ *   default merge method: --merge
+ *
+ * Exit non-zero (and do NOT merge) on any red/failed check.
+ */
+
+import { execSync, spawnSync } from 'node:child_process';
+
+const REPO = 'JKHeadley/instar';
+const args = process.argv.slice(2);
+const pr = args.find(a => /^\d+$/.test(a));
+const useAdmin = args.includes('--admin');
+const method = args.find(a => ['--squash', '--merge', '--rebase'].includes(a)) || '--merge';
+
+if (!pr) {
+  console.error('usage: node scripts/safe-merge.mjs <PR#> [--admin] [--squash|--merge|--rebase]');
+  process.exit(2);
+}
+
+function checks() {
+  // gh pr checks exits non-zero when checks are failing/pending; capture either way.
+  const r = spawnSync('gh', ['pr', 'checks', pr, '--repo', REPO], { encoding: 'utf-8' });
+  return (r.stdout || '') + (r.stderr || '');
+}
+
+// Poll until nothing is pending (cap ~20 min).
+console.log(`safe-merge: waiting for PR #${pr} checks to finish...`);
+const deadline = Date.now() + 20 * 60 * 1000;
+let out = checks();
+while (/\bpending\b/.test(out)) {
+  if (Date.now() > deadline) {
+    console.error('safe-merge: timed out waiting for checks. NOT merging.');
+    process.exit(1);
+  }
+  execSync('sleep 15');
+  out = checks();
+}
+
+// Parse rows: "<name>\t<state>\t<elapsed>\t<url>". States: pass | fail | skipping | ...
+const rows = out.split('\n').map(l => l.trim()).filter(Boolean);
+const failed = [];
+let sawE2e = false;
+let e2ePassed = false;
+for (const line of rows) {
+  const cols = line.split('\t').map(c => c.trim());
+  const name = cols[0] || '';
+  const state = (cols[1] || '').toLowerCase();
+  if (!name || !state) continue;
+  const ok = state === 'pass' || state === 'skipping' || state === 'neutral';
+  if (/e2e/i.test(name)) {
+    sawE2e = true;
+    if (state === 'pass') e2ePassed = true;
+  }
+  if (!ok) failed.push(`${name}: ${state}`);
+}
+
+if (failed.length > 0) {
+  console.error(`safe-merge: REFUSING — ${failed.length} check(s) not green:\n  ${failed.join('\n  ')}`);
+  process.exit(1);
+}
+if (!sawE2e) {
+  console.error('safe-merge: REFUSING — no e2e check found in the PR checks. The e2e job is the one --admin bypasses; do not merge without it. (Override only with explicit human sign-off.)');
+  process.exit(1);
+}
+if (!e2ePassed) {
+  console.error('safe-merge: REFUSING — an e2e check is present but did not report pass.');
+  process.exit(1);
+}
+
+console.log(`safe-merge: all checks green (e2e confirmed). Merging PR #${pr} (${method}${useAdmin ? ' --admin' : ''})...`);
+const mergeArgs = ['pr', 'merge', pr, '--repo', REPO, method];
+if (useAdmin) mergeArgs.push('--admin');
+const m = spawnSync('gh', mergeArgs, { stdio: 'inherit', encoding: 'utf-8' });
+process.exit(m.status ?? 0);

--- a/tests/e2e/threadline/ThreadlineMCPE2E.test.ts
+++ b/tests/e2e/threadline/ThreadlineMCPE2E.test.ts
@@ -22,7 +22,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { ThreadlineMCPServer } from '../../../src/threadline/ThreadlineMCPServer.js';
 import { MCPAuth } from '../../../src/threadline/MCPAuth.js';
-import { ThreadResumeMap } from '../../../src/threadline/ThreadResumeMap.js';
+import { TestThreadResumeMap } from '../../helpers/TestThreadResumeMap.js';
 import { AgentTrustManager } from '../../../src/threadline/AgentTrustManager.js';
 import { AgentDiscovery } from '../../../src/threadline/AgentDiscovery.js';
 import type {
@@ -45,17 +45,7 @@ function cleanupDir(dir: string): void {
   try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/e2e/threadline/ThreadlineMCPE2E.test.ts:45' }); } catch { /* ignore */ }
 }
 
-/**
- * Test-friendly ThreadResumeMap that skips the JSONL file-existence check.
- * Phase 2a (CMT-497): ThreadResumeMap is a view over ConversationStore; the only
- * thing tests need to bypass is the JSONL guard (no real Claude session files in
- * tests), so override just that and use the real view logic.
- */
-class TestThreadResumeMap extends ThreadResumeMap {
-  protected jsonlExists(): boolean {
-    return true;
-  }
-}
+// TestThreadResumeMap is the shared helper in tests/helpers/ (imported above).
 
 // ── In-Memory Message System ─────────────────────────────────────────
 

--- a/tests/helpers/TestThreadResumeMap.ts
+++ b/tests/helpers/TestThreadResumeMap.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared test-only ThreadResumeMap.
+ *
+ * Phase 2a (CMT-497) made `ThreadResumeMap` a view over `ConversationStore`. In
+ * tests there are no real Claude session JSONL files, so the production
+ * `jsonlExists()` resume-guard would make `get()` return null. This subclass
+ * overrides ONLY that guard and otherwise uses the real view logic.
+ *
+ * This lives in ONE place on purpose: the regression that turned main red
+ * (PR #381 → fixed in #383) happened because this helper was duplicated across
+ * the integration + e2e suites and one copy went stale during the refactor.
+ * One shared copy means a future refactor updates it once, everywhere.
+ */
+
+import { ThreadResumeMap } from '../../src/threadline/ThreadResumeMap.js';
+
+export class TestThreadResumeMap extends ThreadResumeMap {
+  protected jsonlExists(): boolean {
+    return true;
+  }
+}

--- a/tests/integration/threadline/ThreadlineMCP.test.ts
+++ b/tests/integration/threadline/ThreadlineMCP.test.ts
@@ -28,23 +28,8 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { ThreadlineMCPServer } from '../../../src/threadline/ThreadlineMCPServer.js';
 import { MCPAuth } from '../../../src/threadline/MCPAuth.js';
 import { ThreadResumeMap } from '../../../src/threadline/ThreadResumeMap.js';
+import { TestThreadResumeMap } from '../../helpers/TestThreadResumeMap.js';
 import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
-
-/**
- * Test-friendly ThreadResumeMap that skips JSONL file existence checks.
- * In production, ThreadResumeMap.get() verifies the Claude JSONL file exists.
- * In tests, those files don't exist, so we override to skip that check.
- */
-class TestThreadResumeMap extends ThreadResumeMap {
-  /**
-   * Phase 2a: ThreadResumeMap is a view over ConversationStore. The only thing
-   * tests need to bypass is the JSONL-existence guard (no real Claude session
-   * files in tests); the rest of get() uses the real view logic.
-   */
-  protected jsonlExists(): boolean {
-    return true;
-  }
-}
 import { AgentDiscovery } from '../../../src/threadline/AgentDiscovery.js';
 import { AgentTrustManager } from '../../../src/threadline/AgentTrustManager.js';
 import type {


### PR DESCRIPTION
## Summary

Three structural fixes so the PR #381 → red-main class can't recur. Root cause was twofold: the pre-push/smoke tier (and `test:push`) use `vitest.push.config.ts` which **excludes `tests/e2e/**`**, and `gh pr merge --admin` **bypasses** the separate `E2E Tests` CI job.

1. **Path-scoped pre-push e2e gate** (`scripts/pre-push-e2e-scope.mjs` + `.husky/pre-push`): when a push touches an e2e-load-bearing area (`src/threadline/**`, the threadline e2e suite, or the shared helper), it runs that area's e2e suite before allowing the push. Path-scoped → unrelated pushes pay nothing. Opt out: `INSTAR_PRE_PUSH_E2E_SKIP=1`.
2. **One shared `TestThreadResumeMap`** (`tests/helpers/`): replaces the duplicated copies in the integration + e2e suites (the copy that went stale in #381). Future refactors update it once, everywhere.
3. **`safe-merge` guard** (`scripts/safe-merge.mjs`): re-imposes the all-checks-green-incl-e2e requirement that `--admin` removes — refuses to merge over a red/unfinished e2e job.

## Test plan
- [x] Shared helper: integration + e2e MCP suites green (26 tests) on the consolidated helper
- [x] Pre-push e2e gate dogfooded: it auto-detected this branch's threadline change and ran `tests/e2e/threadline/` (324 pass) — and ran live on the actual push of this PR
- [x] Both scripts syntax-checked; tsc clean
- [x] This PR will be merged via `safe-merge` (dogfooding #3)

Follow-up to #383 (the test-only hotfix that unblocked main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)