### PR TITLE
Codex parity follow-ups: live-config drift canary (C4) + Stop-payload runtime-verified (B1)

### DIFF
--- a/docs/specs/codex-full-parity-fixes.eli16.md
+++ b/docs/specs/codex-full-parity-fixes.eli16.md
@@ -48,3 +48,9 @@ After I drafted this plan, I ran it past five reviewers (security, adversarial, 
 - Two real bugs in already-shipped code got fixed on the spot: a fallback that silently did nothing in the real environment, and a missing cache that made startup do extra work.
 
 Net: the plan is the same shape, but honest about what's proven vs not, and safer about how it ships. The full reviewer findings are in the convergence report linked in the frontmatter.
+
+## Update: the two follow-ups, done (2026-05-25)
+
+Both small follow-ups are now closed:
+- **Soup check (B1):** I drove a real Codex turn and grabbed exactly what the two end-of-turn checkers receive. The "last thing the agent said" field came back filled in with the real reply — so those checkers genuinely get fed on Codex. Confirmed, no code change needed.
+- **Real-building canary (C4):** the drift alarm now also reads the ACTUAL installed config on an agent and confirms the safety guards are present AND switched on (trusted) — catching a clobbered config or a dark/untrusted agent, not just blueprint mistakes.

--- a/docs/specs/codex-full-parity-fixes.md
+++ b/docs/specs/codex-full-parity-fixes.md
@@ -112,7 +112,7 @@ before build/merge — RECOMMEND Justin triggers it on this P0 now.
 
 **Fix:** accept `tool_name` ∈ {`Bash`, `exec_command`} and read `tool_input.cmd || tool_input.command` — the same pattern already applied to dangerous-command-guard and grounding-before-messaging. Migration via PostUpdateMigrator (always-overwrite instar hook).
 
-### P1 — response-review Codex Stop-payload correctness — 🟡 SCHEMA-OK, RUNTIME-UNVERIFIED
+### P1 — response-review Codex Stop-payload correctness — ✅ RUNTIME-VERIFIED (B1, no code change)
 
 **Finding:** `response-review.js:45` (and `claim-intercept-response.js:120`) read
 `input.last_assistant_message`. The codex 0.133 Rust binary's embedded Stop-hook input
@@ -181,9 +181,12 @@ all incorporated below. Resolutions become hard gates on the P0 build + the P1/P
 
 ### BLOCKING (must resolve before the relevant code merges)
 
-- **B1 — response-review "RESOLVED" was schema≠runtime.** Corrected above to
-  SCHEMA-OK/RUNTIME-UNVERIFIED. Gate: capture a real codey Stop payload, assert
-  `last_assistant_message` non-empty, drive incoherent-reply→hold. (lessons-aware, adversarial)
+- **B1 — ✅ DONE 2026-05-25 (runtime-verified, no code change).** Captured a REAL Codex 0.133 Stop
+  payload live (scratch agent, trusted Stop logger, real `codex exec` turn). Payload keys:
+  `session_id, turn_id, transcript_path, cwd, hook_event_name, model, permission_mode,
+  stop_hook_active, last_assistant_message`; `last_assistant_message` held the EXACT reply. So
+  response-review.js + claim-intercept-response.js genuinely receive the reply at runtime on
+  Codex — the schema≠runtime gap is closed, NO code change needed. (was the lessons-aware/adversarial blocking item)
 - **B2 — P1-before-P0 dark-guard window.** The P1 migration always-overwrites `.codex/hooks.json`
   → hash change → Codex untrusts every guard until re-armed. If P1 releases before P0's
   auto-arm, existing Codex agents lose WORKING guards (incl. dangerous-command-guard) on update

--- a/src/providers/adapters/openai-codex/canary/codexHookContractCanary.ts
+++ b/src/providers/adapters/openai-codex/canary/codexHookContractCanary.ts
@@ -41,6 +41,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { buildInstarCodexHookGroups } from '../../../../core/installCodexHooks.js';
+import { codexHooksArmingStatus, expectedHookSlots } from '../../../../core/codexHookTrust.js';
 
 /** Hook events instar's enforcement layer registers and depends on. */
 export const REQUIRED_CODEX_HOOK_EVENTS = [
@@ -216,5 +217,66 @@ export function runCodexHookContractCanary(): CodexHookContractCanaryResult {
       missingEventsInBinary,
       failures,
     },
+  };
+}
+
+/**
+ * Layer C — installed-config drift check (C4). Unlike Layer A (which asserts the BUILDER
+ * output) this reads what is ACTUALLY on disk for a specific agent and confirms the gates are
+ * present AND trusted: the project `.codex/hooks.json` carries instar's Stop review trio
+ * (response-review + claim-intercept-response + scope-coherence) AND every instar hook slot has
+ * a `trusted_hash` (and isn't `enabled = false`) in `$CODEX_HOME/config.toml [hooks.state]`.
+ * Catches reality drifting from the blueprint — a hand-edited/clobbered hooks.json, an untrusted
+ * (dark) agent, or a user-disabled guard — which Layer A cannot see. Runtime/health use
+ * (per-agent), not a CI invariant: returns 'skip' when no hooks.json exists.
+ */
+export interface InstalledCodexHookTrustCheck {
+  status: 'ok' | 'drift' | 'skip';
+  hooksJsonPresent: boolean;
+  stopTrioInstalled: boolean;
+  allArmed: boolean;
+  untrusted: string[];
+  disabled: string[];
+  issues: string[];
+}
+
+const STOP_TRIO = ['response-review.js', 'claim-intercept-response.js', 'scope-coherence-checkpoint.js'];
+
+export function checkInstalledCodexHookTrust(projectDir: string, codexHome?: string): InstalledCodexHookTrustCheck {
+  const home = codexHome || path.join(os.homedir(), '.codex');
+  const issues: string[] = [];
+
+  let realProjectDir = projectDir;
+  try { realProjectDir = fs.realpathSync(projectDir); } catch { /* use as-is */ }
+  const hooksJsonPath = path.join(realProjectDir, '.codex', 'hooks.json');
+
+  let hooks: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
+  try {
+    hooks = (JSON.parse(fs.readFileSync(hooksJsonPath, 'utf-8')).hooks) ?? {};
+  } catch {
+    return { status: 'skip', hooksJsonPresent: false, stopTrioInstalled: false, allArmed: false, untrusted: [], disabled: [], issues: ['no .codex/hooks.json'] };
+  }
+
+  const stopCmds = (hooks.Stop?.[0]?.hooks ?? []).map((h) => h.command ?? '');
+  const stopTrioInstalled = STOP_TRIO.every((s) => stopCmds.some((c) => c.includes(s)));
+  if (!stopTrioInstalled) issues.push(`installed Stop trio incomplete: have [${stopCmds.map((c) => c.split('/').pop()).join(', ')}], want ${STOP_TRIO.join(' + ')}`);
+  if (stopCmds.some((c) => c.includes('deferral-detector.js'))) issues.push('deferral-detector.js is on Stop in the installed config (it belongs on PreToolUse)');
+
+  let configBody = '';
+  try { configBody = fs.readFileSync(path.join(home, 'config.toml'), 'utf-8'); } catch { /* none = nothing trusted */ }
+  const slots: string[] = expectedHookSlots(hooks);
+  const status = codexHooksArmingStatus(configBody, hooksJsonPath, slots) as { untrusted: string[]; disabled: string[]; allArmed: boolean };
+  if (status.untrusted.length) issues.push(`untrusted (dark) slots: ${status.untrusted.join(', ')}`);
+  if (status.disabled.length) issues.push(`explicitly disabled slots: ${status.disabled.join(', ')}`);
+
+  const ok = stopTrioInstalled && status.allArmed && !stopCmds.some((c) => c.includes('deferral-detector.js'));
+  return {
+    status: ok ? 'ok' : 'drift',
+    hooksJsonPresent: true,
+    stopTrioInstalled,
+    allArmed: status.allArmed,
+    untrusted: status.untrusted,
+    disabled: status.disabled,
+    issues,
   };
 }

--- a/tests/unit/providers/adapters/openai-codex/canary/codexHookContractCanary.test.ts
+++ b/tests/unit/providers/adapters/openai-codex/canary/codexHookContractCanary.test.ts
@@ -7,12 +7,19 @@
  * (NEVER 'fail' for a missing binary).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {
   runCodexHookContractCanary,
   resolveCodexBinaryForCanary,
   REQUIRED_CODEX_HOOK_EVENTS,
+  checkInstalledCodexHookTrust,
 } from '../../../../../../src/providers/adapters/openai-codex/canary/codexHookContractCanary.js';
+import { installCodexHooks, buildInstarCodexHookGroups } from '../../../../../../src/core/installCodexHooks.js';
+import { expectedHookSlots } from '../../../../../../src/core/codexHookTrust.js';
+import { SafeFsExecutor } from '../../../../../../src/core/SafeFsExecutor.js';
 
 describe('runCodexHookContractCanary', () => {
   it('locks the load-bearing invariants: regex matcher, shell guard, deferral on PreToolUse, correct Stop trio', () => {
@@ -61,5 +68,80 @@ describe('runCodexHookContractCanary', () => {
   it('resolveCodexBinaryForCanary returns a string path or null (never throws)', () => {
     const p = resolveCodexBinaryForCanary();
     expect(p === null || typeof p === 'string').toBe(true);
+  });
+});
+
+describe('checkInstalledCodexHookTrust (Layer C — live-config drift)', () => {
+  let projectDir: string;
+  let codexHome: string;
+  let hooksJsonPath: string;
+  let slots: string[];
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canaryC-proj-'));
+    codexHome = fs.mkdtempSync(path.join(os.tmpdir(), 'canaryC-home-'));
+    installCodexHooks(projectDir);
+    hooksJsonPath = path.join(fs.realpathSync(projectDir), '.codex', 'hooks.json');
+    slots = expectedHookSlots(buildInstarCodexHookGroups(projectDir) as any);
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'canaryC:proj' });
+    SafeFsExecutor.safeRmSync(codexHome, { recursive: true, force: true, operation: 'canaryC:home' });
+  });
+
+  function writeTrust(trustedSlots: string[], disabled: string[] = []): void {
+    let body = '';
+    for (const s of trustedSlots) {
+      body += `[hooks.state."${hooksJsonPath}:${s}"]\ntrusted_hash = "sha256:x-${s}"\n`;
+      if (disabled.includes(s)) body += 'enabled = false\n';
+      body += '\n';
+    }
+    fs.writeFileSync(path.join(codexHome, 'config.toml'), body);
+  }
+
+  it('skips when the project has no .codex/hooks.json', () => {
+    const r = checkInstalledCodexHookTrust(fs.mkdtempSync(path.join(os.tmpdir(), 'empty-')), codexHome);
+    expect(r.status).toBe('skip');
+    expect(r.hooksJsonPresent).toBe(false);
+  });
+
+  it("reports 'drift' when the installed trio is present but UNtrusted (dark agent)", () => {
+    // hooks.json installed (correct trio) but config.toml has no trust entries
+    const r = checkInstalledCodexHookTrust(projectDir, codexHome);
+    expect(r.stopTrioInstalled).toBe(true);
+    expect(r.status).toBe('drift');
+    expect(r.allArmed).toBe(false);
+    expect(r.untrusted.length).toBeGreaterThan(0);
+  });
+
+  it("reports 'ok' when the trio is installed AND all slots are trusted", () => {
+    writeTrust(slots);
+    const r = checkInstalledCodexHookTrust(projectDir, codexHome);
+    expect(r.status).toBe('ok');
+    expect(r.stopTrioInstalled).toBe(true);
+    expect(r.allArmed).toBe(true);
+  });
+
+  it("reports 'drift' when a slot is explicitly disabled (enabled=false)", () => {
+    writeTrust(slots, [slots[0]]);
+    const r = checkInstalledCodexHookTrust(projectDir, codexHome);
+    expect(r.status).toBe('drift');
+    expect(r.disabled).toContain(slots[0]);
+  });
+
+  it("detects a clobbered hooks.json where deferral-detector wrongly sits on Stop", () => {
+    // Simulate the historical bug: rewrite Stop with deferral-detector instead of claim-intercept-response
+    const cfg = JSON.parse(fs.readFileSync(path.join(projectDir, '.codex', 'hooks.json'), 'utf-8'));
+    cfg.hooks.Stop[0].hooks = [
+      { type: 'command', command: `node ${projectDir}/.instar/hooks/instar/response-review.js` },
+      { type: 'command', command: `node ${projectDir}/.instar/hooks/instar/deferral-detector.js` },
+      { type: 'command', command: `node ${projectDir}/.instar/hooks/instar/scope-coherence-checkpoint.js` },
+    ];
+    fs.writeFileSync(path.join(projectDir, '.codex', 'hooks.json'), JSON.stringify(cfg));
+    writeTrust(expectedHookSlots(cfg.hooks));
+    const r = checkInstalledCodexHookTrust(projectDir, codexHome);
+    expect(r.status).toBe('drift');
+    expect(r.stopTrioInstalled).toBe(false); // claim-intercept-response missing
+    expect(r.issues.join(' ')).toMatch(/deferral-detector\.js is on Stop|Stop trio incomplete/);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,49 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+
+## What Changed
+
+Two Codex-parity follow-ups from the codex-full-parity spec (§7), both hardening the Codex
+safety-hook layer that shipped in the previous release:
+
+1. **Live-config drift detection for the Codex safety guards (C4).** A new check
+   (`checkInstalledCodexHookTrust`) reads what's ACTUALLY installed on a Codex agent — its
+   `.codex/hooks.json` plus the trust state in `~/.codex/config.toml` — and reports `ok` / `drift`
+   / `skip`. It confirms the end-of-turn review trio (response-review + claim-intercept-response +
+   scope-coherence) is present AND trusted (not disabled), and that the anti-deferral hook hasn't
+   drifted back onto the Stop event. The existing canary asserts the *blueprint* (what instar would
+   install); this catches *reality* drifting from it — a hand-edited or clobbered config, a
+   never-trusted ("dark") agent, or a guard a user turned off — which the blueprint check can't see.
+
+2. **Stop-payload runtime-verified (B1).** The two Codex Stop review-checkers read a
+   `last_assistant_message` field. We had confirmed Codex's binary *declares* that field; this
+   release confirms it at RUNTIME — a live Codex 0.133 turn was captured and the field held the
+   exact agent reply. So those checkers genuinely receive the response on Codex. No code change;
+   this closes the schema-vs-runtime gap the convergence review flagged.
+
+## What to Tell Your User
+
+- **Your Codex agent's safety guards now have a reality check**: "There's a new check that looks at
+  what's actually wired and switched on for a Codex agent — not just what should be — so a guard
+  can't quietly end up uninstalled, untrusted, or turned off without it being noticeable."
+- Nothing for you to do — it ships automatically on update.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Codex installed-config drift check (`checkInstalledCodexHookTrust`) | Programmatic — read-only health check of a Codex agent's hooks + trust state |
+| Codex Stop review-checkers runtime-verified | Automatic — no action needed |
+
+## Evidence
+
+- **C4**: `checkInstalledCodexHookTrust` reads the on-disk `.codex/hooks.json` + `config.toml`
+  `[hooks.state]` (reusing `codexHookTrust`) and returns `ok`/`drift`/`skip`. 5 new unit tests cover
+  skip (no hooks.json), drift (untrusted/dark agent), ok (trio present + trusted), drift (a slot
+  explicitly disabled), and a clobbered config where `deferral-detector` wrongly sits on Stop. 28
+  codex-area tests green; `tsc` clean. Side-effects review: `upgrades/side-effects/codex-parity-c4-canary-drift.md`.
+- **B1**: captured a real Codex 0.133 Stop payload from a live `codex exec` turn; payload keys
+  include `last_assistant_message`, which held the exact reply ("The quick brown fox jumps over the
+  lazy dog."). Confirms `response-review.js` + `claim-intercept-response.js` are fed at runtime on Codex.

--- a/upgrades/side-effects/codex-parity-c4-canary-drift.md
+++ b/upgrades/side-effects/codex-parity-c4-canary-drift.md
@@ -1,0 +1,33 @@
+# Side-Effects Review: C4 — canary live-config drift detector + B1 runtime-verified
+
+## Change
+1. **C4** — new `checkInstalledCodexHookTrust(projectDir, codexHome?)` in codexHookContractCanary.ts:
+   reads the ACTUAL installed `.codex/hooks.json` + `$CODEX_HOME/config.toml [hooks.state]` (reusing
+   codexHookTrust) and reports `ok` / `drift` / `skip` — asserting the Stop review trio is present
+   AND every instar slot is trusted (not enabled=false), and that deferral-detector is NOT on Stop.
+   Layer A asserts the BUILDER output; Layer C catches reality drifting (clobbered hooks.json,
+   dark/untrusted agent, user-disabled guard). Runtime/per-agent (skip when no hooks.json).
+2. **B1** — spec updated: response-review/claim-intercept Codex Stop-payload is now RUNTIME-VERIFIED
+   (captured a real Codex 0.133 Stop payload; `last_assistant_message` held the exact reply). No code.
+
+## Why
+Convergence review §7 C4 + B1. C4 makes the drift-alarm check reality, not just the blueprint —
+the reviewer's point that a hardcoded-trio assertion would encode the next drift as correct. B1
+closes the schema≠runtime gap for the two Stop review-checkers.
+
+## Scope / blast radius
+- C4 is a new read-only function (no mutation); reuses codexHookTrust (pure). Imported at top
+  (no lazy require — that broke under the ESM test runner). Not yet wired into a scheduled health
+  check — it's a building block a runtime caller (G5 arming canary / health) can use. RULE 3:
+  the canary module already carries a Rule 3.1 rationale; this extends it (read-only config parse).
+- B1: docs-only (spec status update).
+
+## Signal vs Authority / Rollback
+- Read-only check, no authority. Rollback: remove the function + tests + revert the spec line.
+
+## Tests
+- codexHookContractCanary.test.ts: +5 (skip/drift-untrusted/ok/disabled/clobbered-trio). 11 green.
+  installCodexHooks + codexHookTrust unaffected. tsc clean.
+
+## Publish
+- PR to JKHeadley/main (codex-parity-followups). Squash-merge.


### PR DESCRIPTION
## Summary
The two non-blocking follow-ups from the codex-full-parity spec (§7), now done.

- **C4 — canary live-config drift detector**: `checkInstalledCodexHookTrust(projectDir, codexHome?)` reads the ACTUAL installed `.codex/hooks.json` + `$CODEX_HOME/config.toml [hooks.state]` (reusing `codexHookTrust`) and returns `ok`/`drift`/`skip` — asserts the Stop review trio is present AND trusted (not `enabled=false`) and that `deferral-detector` is NOT on Stop. Layer A asserts the builder output; this catches reality drifting (clobbered hooks.json, dark/untrusted agent, user-disabled guard).
- **B1 — Stop-payload runtime-verified**: captured a real Codex 0.133 Stop payload live; `last_assistant_message` held the exact reply. `response-review` + `claim-intercept-response` are runtime-verified on Codex (schema≠runtime gap closed). No code change; spec updated.

## Test plan
- [x] 28 codex-area unit tests green (incl. +5 Layer-C drift tests); tsc clean.
- [x] B1 verified via a live Codex turn capture.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)