### PR TITLE
fix(enable-layer): telemetry deadlock + broken feature toggles + enableAction-validity guard

### DIFF
--- a/docs/specs/enable-layer-coherence.eli16.md
+++ b/docs/specs/enable-layer-coherence.eli16.md
@@ -1,0 +1,23 @@
+# Enable-layer coherence (the low-risk half) — plain-English version
+
+## What this is
+
+When we went to "turn on every feature," we found some of the on/off switches were wired to nothing — flipping them did nothing, or errored. This fixes the three cases where that's an objective bug with one obviously-correct answer. (The cases that need a real judgment call from you — like retiring the "act without asking" autonomy path — are deliberately NOT in here; they're a separate piece waiting on your decision.)
+
+## The three fixes
+
+1. **The telemetry catch-22.** Telemetry had a chicken-and-egg bug: the "turn telemetry on" button needed the telemetry engine to already be running, but that engine only got built at startup if telemetry was already on. So you could never turn it on through its own button. The fix: always build the engine (it's cheap and does nothing until switched on — it already refuses to send anything while off, and there are tests proving that). Now the button works. (Your telemetry stays off — this just unbreaks the switch for anyone who wants it.)
+
+2. **Two dead switches.** The "dispatches" and "feedback" feature switches pointed at settings the system flatly refused to change, so flipping them just errored. Both are real settings — they just weren't on the list of things the switch is allowed to touch. Added them to the list. Switches work now.
+
+3. **A guard so this never happens again.** I added a build-time test that checks every feature's on/off switch actually points at something real. If anyone ever ships a feature with a switch wired to nothing, the build fails. This test earned its keep immediately — while writing it, it caught the "feedback" switch bug on its own (I only knew about "dispatches" going in).
+
+## Why it's safe
+
+- The telemetry change can't leak anything: the engine refuses to send while off, and that's covered by existing tests. Worst case of any bug in this whole change is "behaves exactly like today."
+- The two switch fixes only *enable* switches that were broken — they don't change any default. Your features stay exactly as on/off as they are now.
+- The guard is just a test; it changes no behavior.
+
+## What you approved
+
+The low-risk, objective slice: unbreak the telemetry button, unbreak the two dead switches, and add the guard that keeps switches honest. The judgment calls stay parked for your explicit yes.

--- a/docs/specs/enable-layer-coherence.md
+++ b/docs/specs/enable-layer-coherence.md
@@ -1,0 +1,67 @@
+---
+title: "Enable-layer coherence (low-risk half) — telemetry deadlock + broken toggles + an enableAction-validity guard"
+slug: enable-layer-coherence
+status: draft
+approved: true
+approved-by: Justin
+approved-via: "Telegram topic 12702 (2026-05-25) — Echo proposed taking 'the LOW-RISK half of the coherence cleanup — fixing the lying on/off switches and the telemetry deadlock (objective bug-fixes, no judgment calls)' while holding the two judgment calls; Justin: 'Yes, approved.'"
+review-convergence: "inherits feature-activation-coherence iter-1 convergence (reports/feature-activation-coherence-convergence.md) — this is the M5-recommended split's low-risk spec-1, scoped to objective bug-fixes only; plus empirical validation (the enableAction-validity guard caught a real second bug, `feedback`, during implementation)."
+date: 2026-05-25
+author: echo
+parent-spec: docs/specs/feature-activation-coherence.md
+eli16-overview: enable-layer-coherence.eli16.md
+---
+
+# Enable-layer coherence (low-risk half)
+
+## One-paragraph summary
+
+This is the M5-recommended split's **low-risk spec-1** of the feature-activation-coherence work — scoped to objective enable-path bug-fixes with no design-judgment calls (the behavior-reducing dispositions — autonomous-evolution execution retirement, response-review merge — are deferred to a separate behavior-disposition spec). It fixes three things: (1) the **telemetry enable deadlock** (the heartbeat was only constructed when telemetry was already enabled, so `POST /telemetry/enable` could never turn it on); (2) **two broken feature toggles** (`dispatches` and `feedback` enableActions patched config keys absent from the `PATCH /config` allowlist → 400); and (3) a **build-time enableAction-validity guard** that asserts every feature's enable/disable action targets a real, accepted surface — so this whole class can't recur. The guard found the `feedback` bug during implementation (a second instance of the known `dispatches` class).
+
+## Problem
+
+From the topic-12702 dogfood: the feature catalog advertises toggles that don't work. Three objective, no-judgment instances:
+- **Telemetry deadlock:** `telemetryHeartbeat` constructed only `if (config.monitoring?.telemetry?.enabled)` at boot (`server.ts`), but `POST /telemetry/enable` 503s when it's null — chicken-and-egg.
+- **Broken toggles:** `dispatches` (and, found by the new guard, `feedback`) have FeatureDefinition enableActions that `PATCH /config {<key>:...}` for a key not in the route's allowlist → 400. Both are real config keys (`types.ts`: `dispatches?`, `feedback?`; read in `server.ts`).
+- **No guard:** nothing asserted that an enableAction targets a patchable surface — which is exactly how these shipped.
+
+## Non-goals
+
+- Not the behavior-reducing dispositions (autonomous-evolution execution retirement, response-review merge) — separate spec, separate side-effects + cross-model review.
+- Not the `/features` derived-state / runtime-probe map (convergence B2) — that's the larger Part-1.1 work; deferred to the behavior/enable-layer-2 increment.
+- Not changing what telemetry sends or to whom; Echo's telemetry stays off.
+
+## Design
+
+1. **Telemetry: always-construct, gate the effects.** Construct `TelemetryHeartbeat` unconditionally at boot, passing `config.monitoring?.telemetry ?? { enabled: false }`. Construction is cheap/pure; `start()` and `submit()` already `return` early when `!config.enabled` (verified: `TelemetryHeartbeat.test.ts` "does not start/send when disabled"). So a constructed-but-disabled heartbeat never loops and never egresses, and `POST /telemetry/enable` (which 503s only when the heartbeat is null) now works. After enable, config is flipped and the next restart starts submissions — matching the endpoint's existing "restart" contract.
+2. **Allowlist the two real keys.** Add `dispatches` and `feedback` to the `PATCH /config` allowlist, extracted to an exported module-scope `PATCHABLE_CONFIG_KEYS` (single source of truth so the guard can't drift from the route).
+3. **enableAction-validity guard.** `tests/unit/feature-enableaction-validity.test.ts` asserts, for every `BUILTIN_FEATURES` entry: a `PATCH /config` enable/disable action's body keys are all in `PATCHABLE_CONFIG_KEYS`; a non-`/config` action targets a known dedicated endpoint (`/api/files/config`, `/telemetry/enable`, `/telemetry/disable`). Its absence is what let these bugs ship.
+
+## Testing (tiers)
+
+- **Unit:** the enableAction-validity guard (new, 15 tests) — both sides of the boundary (valid `/config` keys, valid dedicated endpoints, and a regression assertion for `dispatches`). Telemetry self-gating already covered by `TelemetryHeartbeat.test.ts` (disabled → no start/no send).
+- **Integration/route:** `telemetry-routes.test.ts` covers the enable route with a constructed heartbeat (the post-fix runtime state). The always-construct change is a boot-logic change covered by typecheck + the existing e2e server-boot suite.
+- **Regression:** touched-area suite green (telemetry routes, TelemetryHeartbeat, validity = 99 passing); typecheck clean.
+
+## Migration parity
+
+Pure server-side code (`src/commands/server.ts`, `src/server/routes.ts`) + a test. Ships to every agent on the normal server update; no agent-installed file changes, no `PostUpdateMigrator` work. The allowlist additions and always-construct take effect on the next server build for all agents.
+
+## Rollback
+
+Each fix is independently revertable. Telemetry: revert to conditional construction (deadlock returns; no other effect — fail-safe). Allowlist: remove the two keys (toggles 400 again). Guard: delete the test. No state/schema changes.
+
+## Signal-vs-authority compliance
+
+No new gate, no blocking authority added. The allowlist is a passive accept-list; the guard is a build-time test. Telemetry authority (consent + enabled flag) is unchanged.
+
+## Side-effects review
+
+See `upgrades/side-effects/enable-layer-coherence.md`. Headline: always-constructing telemetry is side-effect-safe because start/submit self-gate (tested); the allowlist additions only *enable* two toggles that were inert; the guard is build-time only. Worst case of any bug here is "behaves like today."
+
+## Success criteria
+
+- `POST /telemetry/enable` succeeds without a pre-existing enabled state.
+- `dispatches` and `feedback` toggles function via `PATCH /config`.
+- The enableAction-validity guard is green and would fail the build on any future enableAction pointing at a non-patchable surface.
+- No regression; telemetry egress unchanged (off for Echo).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.79",
+  "version": "1.2.80",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2651,19 +2651,28 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.green(`  Quota tracking enabled (${quotaFile})`));
     }
 
-    // Set up opt-in telemetry heartbeat
+    // Set up opt-in telemetry heartbeat.
+    // ALWAYS construct, even when disabled — fixes the chicken-and-egg deadlock
+    // where POST /telemetry/enable returned 503 because the subsystem was only
+    // constructed when telemetry was already enabled at boot (so it could never
+    // be turned on through its own endpoint). Construction is cheap and pure;
+    // the side-effects (.start()/submit()) already self-gate on `config.enabled`
+    // inside TelemetryHeartbeat, so an always-constructed-but-disabled heartbeat
+    // never starts a loop and never submits. Spec: docs/specs/enable-layer-coherence.md
     let telemetryHeartbeat: import('../monitoring/TelemetryHeartbeat.js').TelemetryHeartbeat | undefined;
-    if (config.monitoring?.telemetry?.enabled) {
+    {
       const { TelemetryHeartbeat } = await import('../monitoring/TelemetryHeartbeat.js');
       telemetryHeartbeat = new TelemetryHeartbeat(
-        config.monitoring.telemetry,
+        config.monitoring?.telemetry ?? { enabled: false },
         config.stateDir,
         config.projectDir,
         config.version || 'unknown',
       );
       // Note: .start() is deferred until after scheduler is available so
-      // TelemetryCollector can be wired for Baseline submissions.
-      console.log(pc.green(`  Telemetry: enabled (${config.monitoring.telemetry.level || 'basic'} level, every ${Math.round((config.monitoring.telemetry.intervalMs || 21600000) / 3600000)}h)`));
+      // TelemetryCollector can be wired; .start() itself no-ops when disabled.
+      if (config.monitoring?.telemetry?.enabled) {
+        console.log(pc.green(`  Telemetry: enabled (${config.monitoring.telemetry.level || 'basic'} level, every ${Math.round((config.monitoring.telemetry.intervalMs || 21600000) / 3600000)}h)`));
+      }
     }
 
     // ── Prompt Gate: detect and handle interactive prompts in sessions ──

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -831,6 +831,27 @@ function skillCommandForAction(action: string, projectId: string, roundIndex: nu
   }
 }
 
+/**
+ * Top-level config keys that may be patched via `PATCH /config`.
+ * Exported as the single source of truth so the enableAction-validity test
+ * (tests/unit/feature-enableaction-validity.test.ts) can assert that every
+ * FeatureDefinition whose enableAction patches `/config` targets a key that is
+ * actually patchable — the guard that catches the `dispatches`-class bug
+ * (enableAction pointing at a non-allowlisted key) at build time.
+ * Spec: docs/specs/enable-layer-coherence.md
+ */
+export const PATCHABLE_CONFIG_KEYS: ReadonlySet<string> = new Set([
+  'evolution', 'threadline', 'publishing', 'tunnel', 'gitBackup',
+  'externalOperations', 'responseReview', 'inputGuard', 'monitoring',
+  'updates', 'sessions', 'jobs',
+  // `dispatches` and `feedback` each have a FeatureDefinition whose enableAction
+  // patches that key; without them here those toggles 400 (the switch points at
+  // a key the API refuses to change). Both are real config keys (types.ts:
+  // dispatches?, feedback?; read in server.ts). The enableAction-validity test
+  // (tests/unit/feature-enableaction-validity.test.ts) caught both.
+  'dispatches', 'feedback',
+]);
+
 export function createRoutes(ctx: RouteContext): Router {
   const router = Router();
 
@@ -11138,11 +11159,9 @@ export function createRoutes(ctx: RouteContext): Router {
 
     // Allowlist of top-level config keys that can be patched via API.
     // Prevents callers from overwriting auth tokens, project paths, etc.
-    const allowedKeys = new Set([
-      'evolution', 'threadline', 'publishing', 'tunnel', 'gitBackup',
-      'externalOperations', 'responseReview', 'inputGuard', 'monitoring',
-      'updates', 'sessions', 'jobs',
-    ]);
+    // Single source of truth (module-scope export) so the enableAction-validity
+    // test stays in lock-step with what the API actually accepts.
+    const allowedKeys = PATCHABLE_CONFIG_KEYS;
 
     const disallowed = Object.keys(patch).filter(k => !allowedKeys.has(k));
     if (disallowed.length > 0) {

--- a/tests/unit/feature-enableaction-validity.test.ts
+++ b/tests/unit/feature-enableaction-validity.test.ts
@@ -1,0 +1,89 @@
+/**
+ * enableAction-validity guard.
+ *
+ * Every FeatureDefinition advertises an enableAction/disableAction the agent
+ * uses to toggle the feature. If that action patches a config key the API
+ * refuses to change, the toggle is a lie (it 400s) — the exact `dispatches`
+ * bug found in the topic-12702 "built but dark" investigation, where
+ * `dispatches`'s enableAction patched a key absent from the PATCH /config
+ * allowlist.
+ *
+ * This test asserts every enableAction/disableAction targets a real, accepted
+ * surface: either a PATCH /config whose body keys are all in the (exported,
+ * single-source-of-truth) allowlist, or one of the dedicated feature endpoints.
+ * Its ABSENCE is what let the dispatches bug ship.
+ *
+ * Spec: docs/specs/enable-layer-coherence.md
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BUILTIN_FEATURES } from '../../src/core/FeatureDefinitions.js';
+import { PATCHABLE_CONFIG_KEYS } from '../../src/server/routes.js';
+
+// Dedicated (non-/config) endpoints that real routes implement for toggling.
+// Each must correspond to an actually-registered route (verified separately by
+// the route's own tests); listed here so the validity check knows they're valid
+// enable surfaces rather than failing them as "unknown target".
+const KNOWN_TOGGLE_ENDPOINTS = new Set<string>([
+  '/api/files/config',   // dashboard-file-viewer — PATCH, dedicated handler
+  '/telemetry/enable',   // baseline-telemetry — POST
+  '/telemetry/disable',  // baseline-telemetry — POST
+]);
+
+interface ToggleAction {
+  method: string;
+  path: string;
+  body?: Record<string, unknown>;
+}
+
+function checkAction(featureId: string, kind: string, action: ToggleAction | undefined): void {
+  if (!action) return; // some features may omit one direction
+  const { method, path, body } = action;
+  expect(method, `${featureId}.${kind}: missing method`).toBeTruthy();
+  expect(path, `${featureId}.${kind}: missing path`).toBeTruthy();
+
+  if (path === '/config' && method === 'PATCH') {
+    // Every top-level config key the action patches must be API-patchable.
+    const keys = Object.keys(body ?? {});
+    expect(keys.length, `${featureId}.${kind}: PATCH /config with empty body`).toBeGreaterThan(0);
+    for (const key of keys) {
+      expect(
+        PATCHABLE_CONFIG_KEYS.has(key),
+        `${featureId}.${kind} patches config key "${key}" which is NOT in the PATCH /config allowlist — the toggle would 400. ` +
+          `Add "${key}" to PATCHABLE_CONFIG_KEYS in src/server/routes.ts, or fix the enableAction.`,
+      ).toBe(true);
+    }
+    return;
+  }
+
+  // Non-/config actions must target a known dedicated toggle endpoint.
+  expect(
+    KNOWN_TOGGLE_ENDPOINTS.has(path),
+    `${featureId}.${kind} targets "${method} ${path}", which is neither PATCH /config nor a known dedicated toggle endpoint. ` +
+      `If this is a real endpoint, add it to KNOWN_TOGGLE_ENDPOINTS; otherwise the toggle points at nothing.`,
+  ).toBe(true);
+}
+
+describe('FeatureDefinition enableAction/disableAction validity', () => {
+  it('every feature has at least an enableAction', () => {
+    for (const def of BUILTIN_FEATURES) {
+      expect(def.enableAction, `${def.id}: missing enableAction`).toBeTruthy();
+    }
+  });
+
+  for (const def of BUILTIN_FEATURES) {
+    it(`${def.id}: enable/disable actions target a real, patchable surface`, () => {
+      checkAction(def.id, 'enableAction', def.enableAction as unknown as ToggleAction);
+      checkAction(def.id, 'disableAction', def.disableAction as unknown as ToggleAction);
+    });
+  }
+
+  it('regression: the dispatches enableAction is now patchable (the original bug)', () => {
+    const dispatches = BUILTIN_FEATURES.find(f => f.id === 'dispatches');
+    expect(dispatches, 'dispatches feature definition should exist').toBeTruthy();
+    const body = (dispatches!.enableAction as unknown as ToggleAction).body ?? {};
+    for (const key of Object.keys(body)) {
+      expect(PATCHABLE_CONFIG_KEYS.has(key), `dispatches patches "${key}"`).toBe(true);
+    }
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,28 @@
+# Upgrade Notes — NEXT
+
+## What Changed
+
+Enable-layer coherence — three objective fixes so a feature's on/off switch actually works:
+
+1. **Telemetry deadlock fixed.** `POST /telemetry/enable` previously returned 503 ("subsystem not initialized") because the telemetry heartbeat was only constructed at boot *if telemetry was already enabled* — so it could never be turned on through its own endpoint. The heartbeat is now always constructed (construction is cheap and pure); the side-effecting parts (`start()`/submit()) already self-gate on the enabled flag, so a constructed-but-disabled heartbeat never starts a loop and never sends anything. Enabling now works.
+
+2. **Two broken feature toggles fixed.** The `dispatches` and `feedback` feature toggles pointed at config keys the API refused to change, so calling them returned 400 (the switch was wired to nothing). Both keys are now accepted by `PATCH /config`. (Both are real config keys; the toggles simply weren't in the allowlist.)
+
+3. **A guard so this can't recur.** A new build-time test asserts every feature's enable/disable action targets a real, accepted surface — a patchable config key or a known dedicated endpoint. This guard found the `feedback` toggle bug during development (in addition to the already-known `dispatches` one).
+
+## What to Tell Your User
+
+A few feature on/off switches were quietly wired to nothing — flipping them did nothing or errored. They work now, and there's a new safety check that fails the build if any future feature ships with a switch that points nowhere. Nothing changes in normal operation; this just makes "turn this feature on" mean what it says.
+
+## Summary of New Capabilities
+
+- `POST /telemetry/enable` works without a pre-existing enabled state (deadlock removed).
+- The `dispatches` and `feedback` feature toggles now function via `PATCH /config`.
+- New build-time guard: every feature's enable/disable action must target a real, patchable surface.
+
+## Evidence
+
+- **enableAction-validity guard** (`tests/unit/feature-enableaction-validity.test.ts`) — 15/15 green; it actively caught the `feedback` toggle bug (a second instance of the same class as the known `dispatches` bug) during development.
+- **Telemetry safety** relies on the already-tested self-gating: `TelemetryHeartbeat.test.ts` covers "does not start when disabled" and "does not send when disabled," so always-constructing is side-effect-safe; the route's enable behavior is covered by `telemetry-routes.test.ts`.
+- **Regression:** touched-area suite green (telemetry routes, TelemetryHeartbeat, validity = 99 passing); typecheck clean.
+- **Side-effects review:** `upgrades/side-effects/enable-layer-coherence.md`.

--- a/upgrades/side-effects/enable-layer-coherence.md
+++ b/upgrades/side-effects/enable-layer-coherence.md
@@ -1,0 +1,74 @@
+# Side-Effects Review — Enable-layer coherence (low-risk half)
+
+**Version / slug:** `enable-layer-coherence`
+**Date:** `2026-05-25`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (objective bug-fixes, fail-safe, full guard coverage; spec-driven, approved)`
+
+## Summary of the change
+
+Three objective enable-path fixes (the low-risk half of feature-activation-coherence, approved by Justin): (1) always-construct `TelemetryHeartbeat` so `POST /telemetry/enable` isn't a deadlock (`src/commands/server.ts`); (2) add `dispatches` + `feedback` to the `PATCH /config` allowlist, extracted to an exported `PATCHABLE_CONFIG_KEYS` (`src/server/routes.ts`), fixing two toggles that 400'd; (3) a build-time enableAction-validity guard (`tests/unit/feature-enableaction-validity.test.ts`) that fails the build if any feature's enable/disable action targets a non-patchable surface. Spec: `docs/specs/enable-layer-coherence.md`.
+
+## Decision-point inventory
+
+- `PATCH /config` allowlist — **modify** — add two real config keys (`dispatches`, `feedback`); extract to a module-scope export.
+- Telemetry heartbeat construction — **modify** — always construct (was conditional); side-effects unchanged (self-gated internally).
+- enableAction-validity guard — **add** — build-time test, no runtime surface.
+
+---
+
+## 1. Over-block
+
+No new block/allow runtime surface that rejects legitimate input. The allowlist change *widens* what `PATCH /config` accepts (adds two keys); it cannot newly reject anything. Telemetry construction has no block surface. "No over-block — the change only widens acceptance + adds a build-time test."
+
+## 2. Under-block
+
+The enableAction-validity guard could miss a malformed action shape it doesn't model (e.g. a future action with a method other than PATCH/POST, or a `/config` body nested differently). It checks top-level body keys for `PATCH /config` and a known-endpoint set otherwise; an exotic future action shape would pass unchecked. Acceptable: it covers every current shape and the failure mode it guards (non-allowlisted config key). Telemetry: a classifier/provider outage means telemetry simply doesn't send (it's off anyway) — no under-block of anything user-facing.
+
+## 3. Level-of-abstraction fit
+
+Right layer. The allowlist is the existing accept-list at the route boundary; extracting it to an export (consumed by both the route and the test) is the correct single-source-of-truth move. The telemetry fix matches the existing always-construct/gate-effects pattern already used by `PrivateViewer`/publishing in the same file. The guard is a build-time unit test — the right place to assert a static invariant about FeatureDefinitions.
+
+## 4. Signal vs authority compliance
+
+**Reference:** docs/signal-vs-authority.md
+- [x] No — this change has no new block/allow authority surface (allowlist widening + always-construct + a build-time test).
+
+No brittle logic gains blocking authority. The allowlist is a passive accept-list (unchanged mechanism). Telemetry's authority (consent checker + enabled flag) is untouched.
+
+## 5. Interactions
+
+- **Shadowing:** none. Allowlist check is unchanged in position; telemetry construction moved from conditional to unconditional but `.start()` is still deferred to the same post-scheduler point and still no-ops when disabled.
+- **Double-fire:** none. Telemetry record callsites (`recordSessionSpawned`, `setConsentChecker`) now run for an always-constructed heartbeat; when disabled they buffer counters that never submit (bounded, harmless) and set a consent checker only consulted during (gated) submission.
+- **Races:** none new. Construction is synchronous at boot; the allowlist is read-only per request.
+- **Feedback loops:** none.
+
+## 6. External surfaces
+
+- **Other agents / install base:** ships to all agents on the normal server update. Telemetry stays off unless explicitly enabled (Echo: off). The two toggle fixes only make `dispatches`/`feedback` *enable-able* via API — they don't change any default (both remain whatever the config says; for Echo, `dispatches` absent = off, `feedback` already on).
+- **External systems:** no new egress. Telemetry submission remains gated on enabled + consent (both off for Echo). Enabling `dispatches` for a *downstream* agent now also constructs its puller (`AutoDispatcher`, gated on `config.dispatches` existing) — but that only happens if that agent's config has dispatches, which is their choice.
+- **Persistent state:** none added. `POST /telemetry/enable` provisions an install id only when actually called (unchanged).
+- **Response shape:** unchanged for existing callers (allowlist widening doesn't alter success/empty responses for previously-accepted keys).
+
+## 7. Rollback cost
+
+Pure code + a test. Each fix independently revertable: telemetry → conditional construction (deadlock returns, nothing else); allowlist → drop the two keys (toggles 400 again); guard → delete the test. No persistent state, no migration, no agent-state repair, no user-visible regression during rollback. Fail-safe: a bug in the telemetry change cannot cause egress (start/submit self-gate) — worst case is "behaves like today."
+
+## Conclusion
+
+No design changes from the review. The guard validated itself by catching a real second bug (`feedback`) during implementation — a strong signal the abstraction is right. All three fixes are objective, fail-safe, and independently revertable; telemetry egress is unchanged (off for Echo). Clear to ship. The behavior-reducing dispositions (autonomous-evolution execution retirement, response-review merge) are deliberately excluded — they await Justin's explicit decision in a separate spec.
+
+---
+
+## Second-pass review (if required)
+
+Not required — objective bug-fixes, fail-safe, full guard coverage, spec-driven + approved.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/feature-enableaction-validity.test.ts` — 15/15 green; caught the `feedback` toggle bug during development.
+- `tests/unit/TelemetryHeartbeat.test.ts` — "does not start when disabled" / "does not send when disabled" (the property making always-construct safe).
+- `tests/unit/telemetry-routes.test.ts` — enable-route behavior with a constructed heartbeat.
+- Typecheck clean; touched-area regression sweep 99 passing.


### PR DESCRIPTION
The approved **low-risk half** of the feature-activation-coherence cleanup (topic 12702) — objective enable-path bug-fixes, no judgment calls (the behavior-reducing dispositions are deferred to a separate spec awaiting decision).

## Three fixes

1. **Telemetry deadlock.** `POST /telemetry/enable` 503'd because `TelemetryHeartbeat` was only constructed when telemetry was *already* enabled at boot — so it could never be turned on through its own endpoint. Now always-constructed; `start()`/`submit()` already self-gate on `enabled` (tested), so disabled = no loop, no egress. Enable works.
2. **Two dead toggles.** `dispatches` and `feedback` enableActions patched config keys absent from the `PATCH /config` allowlist → 400. Both are real config keys; added to an exported `PATCHABLE_CONFIG_KEYS` (single source of truth).
3. **enableAction-validity guard** (`tests/unit/feature-enableaction-validity.test.ts`). Asserts every feature's enable/disable action targets a real patchable surface — the guard whose absence let these ship. **It caught the `feedback` bug during development** (a 2nd instance of the known `dispatches` class).

## Tests

- Guard: 15/15 green (both sides of the boundary + a `dispatches` regression assertion).
- Telemetry safety covered by existing `TelemetryHeartbeat.test.ts` ("does not start/send when disabled") — what makes always-construct safe.
- Touched-area regression sweep: 99 passing; typecheck clean.

## Safety

Fail-safe by design: a bug in the telemetry change can't cause egress (start/submit self-gate). The allowlist change only *enables* two toggles that were inert — no default changes. Telemetry stays off for this agent. Pure server-side code; no migration. Spec: `docs/specs/enable-layer-coherence.md` (approved). Side-effects: `upgrades/side-effects/enable-layer-coherence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)