### PR TITLE
[codex] Fix free-text guard template lookup

### DIFF
--- a/docs/specs/FREE-TEXT-GUARD-TEMPLATE-RESOLUTION-SPEC.eli16.md
+++ b/docs/specs/FREE-TEXT-GUARD-TEMPLATE-RESOLUTION-SPEC.eli16.md
@@ -1,0 +1,33 @@
+# ELI16 Overview — Free-text Guard Template Resolution
+
+Instar updates existing agents by running a post-update migrator. One of that
+migrator's jobs is to reinstall built-in hooks so older agents receive the
+latest safety behavior after they update.
+
+The free-text guard hook is one of those built-in hooks. It lives as a real
+template script because its contents include shell, Python, and regular
+expressions. Keeping that script in a template file is less fragile than trying
+to embed the whole thing inside a TypeScript string.
+
+The bug is simple: the migrator was looking for that template in only one
+place. That place matches a compiled-template folder, but the package we publish
+does not ship templates there. The package does ship the template under the
+source-template folder. So the hook was not actually missing; the migrator was
+looking in the wrong place for the package layout we really publish.
+
+The fix is to add one shared template loader. It checks the compiled-template
+location first, then checks the packaged source-template location. The
+free-text guard uses that loader, and the existing similar template readers use
+it too. That makes template lookup consistent instead of leaving each caller to
+remember its own path fallback.
+
+The behavior of the free-text guard does not change. This only changes how the
+post-update migrator finds the file it already intends to install. Existing
+agents should again receive the guard during update, and future template readers
+are less likely to repeat the same single-location mistake.
+
+The main thing reviewers need to decide is whether the fix should change the
+reader or the build. This spec chooses the reader because the published package
+already includes the source templates. Adding a second copied template tree to
+the build would create two package locations for the same asset. Using the
+existing shipped template location is the smaller and cleaner repair.

--- a/docs/specs/FREE-TEXT-GUARD-TEMPLATE-RESOLUTION-SPEC.md
+++ b/docs/specs/FREE-TEXT-GUARD-TEMPLATE-RESOLUTION-SPEC.md
@@ -1,0 +1,232 @@
+---
+title: Free-text guard hook resolves packaged template path
+slug: free-text-guard-template-resolution
+author: instar-codey
+created: "2026-05-25"
+status: approved
+approved: true
+approved-by: "Justin"
+approved-at: "2026-05-25T20:55:48-07:00"
+review-convergence: "2026-05-25T20:54:00-07:00"
+eli16-overview: "FREE-TEXT-GUARD-TEMPLATE-RESOLUTION-SPEC.eli16.md"
+---
+
+# Free-text guard hook resolves packaged template path
+
+## ELI16 Overview
+
+Instar updates existing agents by running a post-update migrator. One thing that
+migrator does is reinstall built-in hook scripts so older agents pick up the
+latest guardrails.
+
+The free-text guard hook is stored as a template file because its shell script
+contains Python and regular expressions. Keeping it in a real script file avoids
+a fragile mess of escaping inside TypeScript strings.
+
+The bug is that the migrator looks for that template in the compiled output
+folder. The build does not copy templates there. The published package does
+include the template, but under the source-template folder that other Instar
+template readers already know how to use.
+
+So the hook is not actually missing. The migrator is looking in only one place,
+and it is the wrong place for the packaged build.
+
+The fix is to add one shared template-loading helper that checks the compiled
+template location first and then the packaged source-template location. Then the
+free-text guard and the existing similar template readers all use that same
+helper. That keeps the behavior consistent and prevents the same single-path
+mistake from coming back in a future hook.
+
+The important safety rule is that we do not change what the free-text guard
+does. We only change how the migrator finds its template file during an update.
+
+## Problem
+
+`PostUpdateMigrator.getFreeTextGuardHook()` reads the free-text guard hook from
+only one location:
+
+```ts
+path.join(__dirname, '..', 'templates', 'hooks', 'free-text-guard.sh')
+```
+
+That path assumes a copied `dist/templates/hooks/free-text-guard.sh` tree next
+to the compiled migrator. The current build does not create that tree. The npm
+package does ship `src/templates/hooks/free-text-guard.sh`, but the free-text
+guard getter never checks that packaged source-template location.
+
+Observed repro on `v1.2.81`:
+
+- `npm run build` creates `dist/core/PostUpdateMigrator.js`.
+- `dist/templates/hooks/free-text-guard.sh` is absent.
+- `src/templates/hooks/free-text-guard.sh` is present.
+- `npm pack --dry-run --json` includes `src/templates/hooks/free-text-guard.sh`
+  and no `dist/templates/...` entry.
+- Calling `migrateHooks()` from the compiled migrator records:
+  `free-text-guard.sh: ENOENT ... dist/templates/hooks/free-text-guard.sh`
+  and does not install `.instar/hooks/instar/free-text-guard.sh`.
+
+The bug is therefore a template resolution mismatch, not a missing template.
+
+## Goal
+
+Existing agents that run the post-update migrator from a published package must
+receive the free-text guard hook without error.
+
+## Non-Goals
+
+- Do not inline the free-text guard shell body into TypeScript. It was kept as a
+  template to avoid multi-layer TypeScript -> shell -> Python -> regex escaping
+  fragility.
+- Do not change the semantics of the free-text guard hook.
+- Do not broaden migration behavior for custom hooks.
+
+## Verified Findings
+
+1. **Package contract:** `package.json#files` ships `src/templates` directly.
+   `npm pack --dry-run --json` on `v1.2.81` includes
+   `src/templates/hooks/free-text-guard.sh` and has no `dist/templates/...`
+   entry for this hook.
+
+2. **Build contract:** `npm run build` is
+   `generate-builtin-manifest.cjs && tsc && chmod 0755 dist/cli.js &&
+   sign-instar-lockfile.mjs`. There is no non-TypeScript asset copy step, so
+   `dist/templates` is absent after a normal build.
+
+3. **Runtime template-reader baseline:** the existing template readers in
+   `PostUpdateMigrator` already use module-location anchored, multi-candidate
+   resolution:
+   - `migrateFleetWatchdog()` checks `dist/templates/scripts/...`, then
+     `src/templates/scripts/...`.
+   - `loadRelayTemplate()` checks `dist/templates/scripts/...`, then
+     `src/templates/scripts/...`.
+   - `getConvergenceCheck()` checks the same two layouts and has an inline
+     fallback.
+
+4. **Outlier:** `getFreeTextGuardHook()` is the runtime hook-template outlier:
+   it does a single direct read from `dist/templates/hooks/free-text-guard.sh`
+   and never checks the shipped `src/templates/hooks/free-text-guard.sh`.
+
+5. **External confirmation:** Echo reviewed the same source on `JKHeadley/main`
+   and confirmed the diagnosis, the package/build contract, and that
+   free-text-guard is the lone hook-template holdout.
+
+## Proposed Fix
+
+Extract one shared private template resolver in `PostUpdateMigrator`, then route
+existing template readers through it instead of adding another bespoke
+candidate loop.
+
+The helper should be module-location anchored, never current-working-directory
+anchored:
+
+```ts
+loadTemplate(subdir: 'hooks' | 'scripts' | 'playbook', filename: string): string | null
+```
+
+Resolution order:
+
+1. Check the built-output location:
+   `dist/templates/<subdir>/<filename>`.
+2. Check the packaged source-template location:
+   `src/templates/<subdir>/<filename>`.
+3. Return the first readable candidate.
+4. Return `null` when no candidate exists. Callers that require the template
+   may throw a clear missing-template error that lists the checked locations;
+   existing fail-soft callers may keep their current skip/fallback behavior.
+
+This chooses the existing dev/dist fallback pattern over changing the build to
+copy all templates into `dist`. The package already ships `src/templates`; the
+smallest reliable fix is to make this one hook getter honor the shipped layout.
+Copying templates into `dist` would work, but it would create a second canonical
+asset location and diverge from the existing package contract.
+
+## Implementation Plan
+
+- Add the shared `loadTemplate()` helper.
+- Refactor `loadRelayTemplate()` into a thin wrapper over `loadTemplate()`.
+- Refactor the fleet-watchdog template read to use `loadTemplate()`.
+- Change `getFreeTextGuardHook()` to load `free-text-guard.sh` via
+  `loadTemplate('hooks', 'free-text-guard.sh')` and throw a clear error if it
+  returns `null`.
+- Add a regression guard that detects hook getters which perform unguarded
+  direct disk reads for template files.
+- Add unit coverage for both supported layouts.
+- Add integration coverage proving `migrateHooks()` installs the free-text
+  guard hook from a compiled migrator when only `src/templates` exists.
+
+## Tests
+
+### Unit
+
+Add focused unit tests around the template loader:
+
+- resolves a hook template from the built-output layout;
+- resolves the same hook template from the packaged source-template layout;
+- resolves a script template through the same helper so the helper is not
+  hook-only in practice;
+- reports a clear missing-template error when neither location exists.
+- is unaffected by `process.cwd()` by running the resolver from an unrelated
+  current working directory.
+
+### Regression Guard
+
+Add a guard test over `src/core/PostUpdateMigrator.ts` that fails if a hook
+getter reads a template via a single direct `fs.readFileSync(path.join(__dirname,
+...))` path instead of a guarded multi-candidate resolver. The goal is not to
+ban all file reads in the migrator; it is to prevent future hook templates from
+repeating this exact single-layout mistake.
+
+The guard should allow the shared `loadTemplate()` helper and should fail on any
+new `get*Hook()` method that directly reads a template path from `__dirname`.
+
+### Integration
+
+Run `migrateHooks()` from the compiled migrator against a temporary project with
+the current published package layout: compiled `dist`, no `dist/templates`, and
+present `src/templates`. Assert:
+
+- `.instar/hooks/instar/free-text-guard.sh` is written;
+- the written hook matches the source template content;
+- `result.errors` contains no free-text guard error.
+
+### Published-Shape Package Test
+
+Run `npm pack`, extract the tarball, and assert:
+
+- `package/src/templates/hooks/free-text-guard.sh` exists;
+- `package/dist/templates` is absent;
+- importing `package/dist/core/PostUpdateMigrator.js` and running `migrateHooks()`
+  from an unrelated current working directory still installs the free-text guard
+  hook from the shipped `src/templates` path.
+
+### Test-As-Self
+
+After implementation and build, run the compiled migrator against a real
+dist-shaped temporary agent install and confirm:
+
+- the free-text guard hook lands on disk;
+- the previous missing-template error is absent;
+- `npm pack --dry-run --json` still includes the source template needed by the
+  fallback.
+
+## Acceptance Criteria
+
+- Post-update migration from a published-shaped package installs the free-text
+  guard hook with zero error.
+- The shared template resolver is package/module-location anchored and works
+  when `process.cwd()` is unrelated to the package.
+- The fix is idempotent: repeated migrator runs overwrite the generated built-in
+  hook exactly as existing hook migration expects.
+- Regression coverage fails if a future hook getter uses an unguarded
+  single-layout disk read.
+- The implementation does not add a build-copy step for `src/templates` unless
+  the package contract changes in a separate approved spec.
+- Unit, integration, and test-as-self evidence are recorded before the PR is
+  considered ready.
+- Release notes are added to `upgrades/NEXT.md`.
+
+## Signal vs Authority
+
+This change has no new block/allow decision surface. It changes how a static
+hook template is located during migration. The free-text guard's existing
+behavior is unchanged.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -165,6 +165,27 @@ export class PostUpdateMigrator {
     return this.stepEngine;
   }
 
+  private templateCandidates(subdir: 'hooks' | 'scripts' | 'playbook', filename: string): string[] {
+    return [
+      path.resolve(__dirname, '..', 'templates', subdir, filename),
+      path.resolve(__dirname, '..', '..', 'src', 'templates', subdir, filename),
+    ];
+  }
+
+  /**
+   * Read a built-in template from the compiled layout when templates have
+   * been copied to dist, or from the packaged source-template layout used by
+   * current npm publishes.
+   */
+  private loadTemplate(subdir: 'hooks' | 'scripts' | 'playbook', filename: string): string | null {
+    for (const candidate of this.templateCandidates(subdir, filename)) {
+      if (fs.existsSync(candidate)) {
+        return fs.readFileSync(candidate, 'utf-8');
+      }
+    }
+    return null;
+  }
+
   /**
    * Run all post-update migrations. Safe to call multiple times —
    * each migration is idempotent.
@@ -550,31 +571,11 @@ export class PostUpdateMigrator {
   private migrateConversationalCatalogPlaybookManifest(result: MigrationResult): void {
     const builtinDir = path.join(this.config.stateDir, 'playbook', 'builtin-manifests');
     const targetPath = path.join(builtinDir, 'conversational-catalog.json');
-    // Resolve template path via module-local __dirname (from
-    // fileURLToPath(import.meta.url)). Two candidates: dist install layout
-    // (dist/core/ → ../templates/...) and dev source layout
-    // (src/core/ → ../templates/... already, but tsc may resolve __dirname
-    // to dist; src fallback added for robustness in dev runs).
-    const candidates = [
-      path.resolve(__dirname, '..', 'templates', 'playbook', 'conversational-catalog-manifest.json'),
-      path.resolve(__dirname, '..', '..', 'src', 'templates', 'playbook', 'conversational-catalog-manifest.json'),
-    ];
-    let templatePath = '';
-    for (const cand of candidates) {
-      if (fs.existsSync(cand)) { templatePath = cand; break; }
-    }
-    if (!templatePath) {
+    const templateContent = this.loadTemplate('playbook', 'conversational-catalog-manifest.json');
+    if (templateContent === null) {
       // Built-in template missing — should never happen post-install, but
       // don't error out the update; just skip.
       result.skipped.push('conversational-catalog-playbook: template not found in package install');
-      return;
-    }
-
-    let templateContent: string;
-    try {
-      templateContent = fs.readFileSync(templatePath, 'utf-8');
-    } catch (err) {
-      result.errors.push(`conversational-catalog-playbook: template read failed: ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
 
@@ -650,20 +651,12 @@ export class PostUpdateMigrator {
     // Always-overwrite the wrapper (Migration Parity Standard for hook
     // scripts: built-in templates are authoritative).
     const wrapperTargetPath = path.join(binDir, 'instar-worktree-create.sh');
-    const templateCandidates = [
-      path.resolve(__dirname, '..', 'templates', 'scripts', 'instar-worktree-create.sh'),
-      path.resolve(__dirname, '..', '..', 'src', 'templates', 'scripts', 'instar-worktree-create.sh'),
-    ];
-    let templatePath = '';
-    for (const cand of templateCandidates) {
-      if (fs.existsSync(cand)) { templatePath = cand; break; }
-    }
-    if (!templatePath) {
+    const templateContent = this.loadTemplate('scripts', 'instar-worktree-create.sh');
+    if (templateContent === null) {
       result.skipped.push('worktree-convention: wrapper template not found in package install');
       return;
     }
     try {
-      const templateContent = fs.readFileSync(templatePath, 'utf-8');
       const existing = fs.existsSync(wrapperTargetPath)
         ? fs.readFileSync(wrapperTargetPath, 'utf-8')
         : null;
@@ -1025,17 +1018,8 @@ export class PostUpdateMigrator {
     const scriptPath = path.join(os.homedir(), '.instar', 'instar-watchdog.sh');
     const plistPath = path.join(os.homedir(), 'Library', 'LaunchAgents', 'ai.instar.watchdog.plist');
 
-    // Locate the template (dev: src/core/ → ../../src/templates/...
-    //                     dist: dist/core/ → ../templates/...)
-    const candidates = [
-      path.resolve(__dirname, '..', 'templates', 'scripts', 'instar-watchdog.sh'),
-      path.resolve(__dirname, '..', '..', 'src', 'templates', 'scripts', 'instar-watchdog.sh'),
-    ];
-    let scriptBody = '';
-    for (const cand of candidates) {
-      if (fs.existsSync(cand)) { scriptBody = fs.readFileSync(cand, 'utf-8'); break; }
-    }
-    if (!scriptBody) {
+    const scriptBody = this.loadTemplate('scripts', 'instar-watchdog.sh');
+    if (scriptBody === null) {
       result.skipped.push('fleet-watchdog: template not found in dist or src');
       return;
     }
@@ -6254,17 +6238,7 @@ process.stdin.on('end', async () => {
    * a healthy install). The caller is responsible for handling the null case.
    */
   private loadRelayTemplate(filename: string): string | null {
-    const modDir = __dirname;
-    const candidates = [
-      path.resolve(modDir, '..', 'templates', 'scripts', filename),
-      path.resolve(modDir, '..', '..', 'src', 'templates', 'scripts', filename),
-    ];
-    for (const candidate of candidates) {
-      if (fs.existsSync(candidate)) {
-        return fs.readFileSync(candidate, 'utf-8');
-      }
-    }
-    return null;
+    return this.loadTemplate('scripts', filename);
   }
 
   private getTelegramReplyScript(): string {
@@ -6334,16 +6308,9 @@ echo "[\$(date -Iseconds)] Server restart initiated"
   private getConvergenceCheck(): string {
     // Read the convergence check template from the templates directory.
     // This file is the heuristic quality gate that runs before external messaging.
-    // In dev: src/core/ → ../../src/templates/scripts/convergence-check.sh
-    // In dist: dist/core/ → ../templates/scripts/convergence-check.sh
-    const candidates = [
-      path.resolve(__dirname, '..', 'templates', 'scripts', 'convergence-check.sh'),
-      path.resolve(__dirname, '..', '..', 'src', 'templates', 'scripts', 'convergence-check.sh'),
-    ];
-    for (const candidate of candidates) {
-      if (fs.existsSync(candidate)) {
-        return fs.readFileSync(candidate, 'utf-8');
-      }
+    const template = this.loadTemplate('scripts', 'convergence-check.sh');
+    if (template !== null) {
+      return template;
     }
     // Fallback: use inline version so migration doesn't fail
     return this.getConvergenceCheckInline();
@@ -6629,8 +6596,13 @@ process.stdin.on('end', async () => {
   private getFreeTextGuardHook(): string {
     // Read the hook from the templates directory instead of inline generation.
     // This avoids multi-layer escaping issues (TypeScript -> bash -> Python -> regex).
-    const hookPath = path.join(__dirname, '..', 'templates', 'hooks', 'free-text-guard.sh');
-    return fs.readFileSync(hookPath, 'utf-8');
+    const template = this.loadTemplate('hooks', 'free-text-guard.sh');
+    if (template !== null) {
+      return template;
+    }
+    throw new Error(
+      `free-text-guard.sh template not found; checked ${this.templateCandidates('hooks', 'free-text-guard.sh').join(', ')}`,
+    );
   }
 
   private getClaimInterceptHook(): string {

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-24T02:49:47.053Z",
-  "instarVersion": "1.2.52",
+  "generatedAt": "2026-05-26T04:31:00.352Z",
+  "instarVersion": "1.2.81",
   "entryCount": 191,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -352,7 +352,7 @@
       "type": "skill",
       "domain": "skills",
       "sourcePath": ".claude/skills/autonomous/skill.md",
-      "contentHash": "9bc7dc9eddd4e345ed6564eff850898b66358ce309119c3047e6af275cf9070d",
+      "contentHash": "96280cf60c51b233259d5f38189e072fd863e145c5952d8add207a0d016b14fb",
       "since": "2025-01-01"
     },
     "skill:build": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -720,7 +720,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -728,7 +728,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -744,7 +744,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "9b963d412fd1db3359c08857d510744ed74df52a1e786177bbf71aeac062426e",
+      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -752,7 +752,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:setup": {
@@ -760,7 +760,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:add": {
@@ -768,7 +768,7 @@
       "type": "cli-command",
       "domain": "setup",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:backup": {
@@ -776,7 +776,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:git": {
@@ -784,7 +784,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:memory": {
@@ -792,7 +792,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:knowledge": {
@@ -800,7 +800,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:semantic": {
@@ -808,7 +808,7 @@
       "type": "cli-command",
       "domain": "memory",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:intent": {
@@ -816,7 +816,7 @@
       "type": "cli-command",
       "domain": "intent",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:feedback": {
@@ -824,7 +824,7 @@
       "type": "cli-command",
       "domain": "feedback",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:server": {
@@ -832,7 +832,7 @@
       "type": "cli-command",
       "domain": "server",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:status": {
@@ -840,7 +840,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:user": {
@@ -848,7 +848,7 @@
       "type": "cli-command",
       "domain": "users",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:relationship": {
@@ -856,7 +856,7 @@
       "type": "cli-command",
       "domain": "relationships",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:job": {
@@ -864,7 +864,7 @@
       "type": "cli-command",
       "domain": "scheduling",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:lifeline": {
@@ -872,7 +872,7 @@
       "type": "cli-command",
       "domain": "communication",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:list": {
@@ -880,7 +880,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:autostart": {
@@ -888,7 +888,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:migrate": {
@@ -896,7 +896,7 @@
       "type": "cli-command",
       "domain": "updates",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:machines": {
@@ -904,7 +904,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:whoami": {
@@ -912,7 +912,7 @@
       "type": "cli-command",
       "domain": "identity",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:pair": {
@@ -920,7 +920,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:join": {
@@ -928,7 +928,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:wakeup": {
@@ -936,7 +936,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:leave": {
@@ -944,7 +944,7 @@
       "type": "cli-command",
       "domain": "coordination",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:doctor": {
@@ -952,7 +952,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:review": {
@@ -960,7 +960,7 @@
       "type": "cli-command",
       "domain": "monitoring",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:nuke": {
@@ -968,7 +968,7 @@
       "type": "cli-command",
       "domain": "operations",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "cli:playbook": {
@@ -976,7 +976,7 @@
       "type": "cli-command",
       "domain": "context",
       "sourcePath": "src/cli.ts",
-      "contentHash": "eba93ab5240154f808f97b72ffaf6dc2a11b36c426811ee3c08018c9a651a84a",
+      "contentHash": "2f06177819f2332512cb9fd329ef2a78613fa347b737b3ffb22554e415171861",
       "since": "2025-01-01"
     },
     "template:build-stop-hook.sh": {
@@ -1440,7 +1440,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "ff616d958eb41a681e4bb6a9e8b6e9e7e74fc02d336b5f310452c8caeccde1b4",
+      "contentHash": "823d36d25490f6afb6968e96d27a538ce031dae7d97a7f2c979ddab707d2918a",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1448,7 +1448,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "caf5980117359821e0523c8358a0eea102d4b1c63f592d9dce8462411232cedd",
+      "contentHash": "b0de35800c7eacf06e520b7224d3169b81e8f0293ce65b69047fae3be1befad4",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {
@@ -1472,7 +1472,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "817d62c318182e559987595ff66ba15561cd68c5cedba460cafcd7f0d37244d8",
+      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/tests/integration/PostUpdateMigrator-packageTemplateShape.test.ts
+++ b/tests/integration/PostUpdateMigrator-packageTemplateShape.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+describe('PostUpdateMigrator package template shape', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/integration/PostUpdateMigrator-packageTemplateShape.test.ts cleanup',
+      });
+    }
+  });
+
+  it('publishes free-text guard under src/templates even when dist/templates is absent', () => {
+    const raw = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const parsed = JSON.parse(raw) as Array<{ files: Array<{ path: string }> }>;
+    const files = new Set(parsed[0]?.files.map(file => file.path) ?? []);
+
+    expect(files.has('src/templates/hooks/free-text-guard.sh')).toBe(true);
+    expect([...files].some(file => file.startsWith('dist/templates/'))).toBe(false);
+  });
+
+  it('runs the packed compiled migrator with only the packaged source-template layout', async () => {
+    const tmp = fs.mkdtempSync(path.join(repoRoot, 'tmp-pack-template-shape-'));
+    tempDirs.push(tmp);
+
+    const raw = execFileSync('npm', ['pack', '--json', '--pack-destination', tmp], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const parsed = JSON.parse(raw) as Array<{ filename: string }>;
+    const tarball = parsed[0]?.filename;
+    expect(tarball).toBeTruthy();
+
+    const extractDir = path.join(tmp, 'extract');
+    fs.mkdirSync(extractDir, { recursive: true });
+    execFileSync('tar', ['-xzf', path.join(tmp, tarball), '-C', extractDir], {
+      cwd: repoRoot,
+      stdio: 'ignore',
+    });
+
+    const packageDir = path.join(extractDir, 'package');
+    const agentDir = path.join(tmp, 'agent');
+    fs.mkdirSync(agentDir, { recursive: true });
+    expect(fs.existsSync(path.join(packageDir, 'src', 'templates', 'hooks', 'free-text-guard.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(packageDir, 'dist', 'templates'))).toBe(false);
+
+    const originalCwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const { PostUpdateMigrator } = await import(
+        `${path.join(packageDir, 'dist', 'core', 'PostUpdateMigrator.js')}?packagedSmoke=${Date.now()}`
+      );
+      const result = { upgraded: [], skipped: [], errors: [] };
+      const migrator = new PostUpdateMigrator({
+        projectDir: agentDir,
+        stateDir: path.join(agentDir, '.instar'),
+        port: 4044,
+        hasTelegram: true,
+        projectName: 'packaged-template-smoke',
+      });
+
+      (migrator as unknown as {
+        migrateHooks(result: { upgraded: string[]; skipped: string[]; errors: string[] }): void;
+      }).migrateHooks(result);
+
+      const installedHook = path.join(agentDir, '.instar', 'hooks', 'instar', 'free-text-guard.sh');
+      const sourceTemplate = path.join(packageDir, 'src', 'templates', 'hooks', 'free-text-guard.sh');
+
+      expect(fs.readFileSync(installedHook, 'utf-8')).toBe(fs.readFileSync(sourceTemplate, 'utf-8'));
+      expect(result.errors.filter(error => error.includes('free-text-guard'))).toEqual([]);
+      expect(result.upgraded.some(entry => entry.includes('free-text-guard.sh'))).toBe(true);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/tests/integration/PostUpdateMigrator-packageTemplateShape.test.ts
+++ b/tests/integration/PostUpdateMigrator-packageTemplateShape.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -35,7 +36,7 @@ describe('PostUpdateMigrator package template shape', () => {
   });
 
   it('runs the packed compiled migrator with only the packaged source-template layout', async () => {
-    const tmp = fs.mkdtempSync(path.join(repoRoot, 'tmp-pack-template-shape-'));
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-pack-template-shape-'));
     tempDirs.push(tmp);
 
     const raw = execFileSync('npm', ['pack', '--json', '--pack-destination', tmp], {
@@ -57,14 +58,16 @@ describe('PostUpdateMigrator package template shape', () => {
     const packageDir = path.join(extractDir, 'package');
     const agentDir = path.join(tmp, 'agent');
     fs.mkdirSync(agentDir, { recursive: true });
+    fs.symlinkSync(path.join(repoRoot, 'node_modules'), path.join(packageDir, 'node_modules'), 'dir');
     expect(fs.existsSync(path.join(packageDir, 'src', 'templates', 'hooks', 'free-text-guard.sh'))).toBe(true);
     expect(fs.existsSync(path.join(packageDir, 'dist', 'templates'))).toBe(false);
 
     const originalCwd = process.cwd();
     process.chdir(tmp);
     try {
+      const migratorUrl = pathToFileURL(path.join(packageDir, 'dist', 'core', 'PostUpdateMigrator.js')).href;
       const { PostUpdateMigrator } = await import(
-        `${path.join(packageDir, 'dist', 'core', 'PostUpdateMigrator.js')}?packagedSmoke=${Date.now()}`
+        `${migratorUrl}?packagedSmoke=${Date.now()}`
       );
       const result = { upgraded: [], skipped: [], errors: [] };
       const migrator = new PostUpdateMigrator({

--- a/tests/integration/PostUpdateMigrator-packageTemplateShape.test.ts
+++ b/tests/integration/PostUpdateMigrator-packageTemplateShape.test.ts
@@ -39,6 +39,11 @@ describe('PostUpdateMigrator package template shape', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-pack-template-shape-'));
     tempDirs.push(tmp);
 
+    execFileSync('npx', ['tsc'], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
     const raw = execFileSync('npm', ['pack', '--json', '--pack-destination', tmp], {
       cwd: repoRoot,
       encoding: 'utf-8',

--- a/tests/unit/PostUpdateMigrator-templateResolution.test.ts
+++ b/tests/unit/PostUpdateMigrator-templateResolution.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const migratorSourcePath = path.join(repoRoot, 'src', 'core', 'PostUpdateMigrator.ts');
+
+function createMigrator(): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir: repoRoot,
+    stateDir: path.join(repoRoot, '.instar'),
+    port: 4044,
+    hasTelegram: true,
+    projectName: 'template-resolution-test',
+  });
+}
+
+function getMethodBody(source: string, methodName: string): string {
+  const marker = `private ${methodName}(`;
+  const start = source.indexOf(marker);
+  expect(start, `${methodName} should exist`).toBeGreaterThanOrEqual(0);
+
+  const open = source.indexOf('{', start);
+  expect(open, `${methodName} should have a body`).toBeGreaterThanOrEqual(0);
+
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  throw new Error(`Could not extract ${methodName} body`);
+}
+
+describe('PostUpdateMigrator template resolution', () => {
+  const tempDirs: string[] = [];
+  const originalCwd = process.cwd();
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    for (const dir of tempDirs.splice(0)) {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/PostUpdateMigrator-templateResolution.test.ts cleanup',
+      });
+    }
+  });
+
+  it('loads hook templates through the shared dist-or-src resolver independent of cwd', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-template-resolution-'));
+    tempDirs.push(tmp);
+    process.chdir(tmp);
+
+    const migrator = createMigrator();
+    const hook = (migrator as unknown as {
+      loadTemplate(subdir: 'hooks', filename: string): string | null;
+    }).loadTemplate('hooks', 'free-text-guard.sh');
+
+    expect(hook).toBeTruthy();
+    expect(hook).toContain('Free-Text Input Guard');
+  });
+
+  it('returns null for missing templates so callers can choose skip, fallback, or error behavior', () => {
+    const migrator = createMigrator();
+    const missing = (migrator as unknown as {
+      loadTemplate(subdir: 'hooks', filename: string): string | null;
+    }).loadTemplate('hooks', 'definitely-not-shipped.sh');
+
+    expect(missing).toBeNull();
+  });
+
+  it('keeps existing script readers on the same shared resolver', () => {
+    const migrator = createMigrator();
+    const relay = (migrator as unknown as {
+      loadRelayTemplate(filename: string): string | null;
+    }).loadRelayTemplate('telegram-reply.sh');
+    const convergence = (migrator as unknown as {
+      getConvergenceCheck(): string;
+    }).getConvergenceCheck();
+
+    expect(relay).toContain('telegram-reply.sh');
+    expect(convergence).toContain('Lightweight convergence check');
+  });
+
+  it('regression guard: free-text guard no longer performs a single direct dist/templates read', () => {
+    const source = fs.readFileSync(migratorSourcePath, 'utf-8');
+    const body = getMethodBody(source, 'getFreeTextGuardHook');
+
+    expect(body).toContain("this.loadTemplate('hooks', 'free-text-guard.sh')");
+    expect(body).not.toContain("path.join(__dirname, '..', 'templates', 'hooks', 'free-text-guard.sh')");
+    expect(body).not.toContain('fs.readFileSync');
+  });
+});

--- a/upgrades/1.2.81.md
+++ b/upgrades/1.2.81.md
@@ -1,6 +1,14 @@
 # Unreleased
 
+<!-- bump: patch -->
+
 ## What Changed
+
+Fixed the post-update migration path for `free-text-guard.sh`: the migrator now uses one shared template resolver that checks the compiled `dist/templates` layout first and then the packaged `src/templates` layout that current npm publishes actually ship.
+
+- **Shared resolver:** `PostUpdateMigrator` now has one `loadTemplate()` path for hook, script, and playbook templates instead of repeating candidate-path loops across individual migrations.
+- **Free-text guard install restored:** compiled/package migrations can install `.instar/hooks/instar/free-text-guard.sh` from `src/templates/hooks/free-text-guard.sh` instead of failing on a missing `dist/templates/hooks/free-text-guard.sh`.
+- **Existing readers consolidated:** relay script templates, convergence-check, fleet watchdog, conversational catalog manifest, and worktree wrapper resolution now use the same helper.
 
 Fixed Threadline topic-bound reply surfacing (CMT-515): a reply from another agent on a thread bound to a Telegram topic now reliably reaches that topic instead of silently vanishing into the store.
 
@@ -10,6 +18,8 @@ Fixed Threadline topic-bound reply surfacing (CMT-515): a reply from another age
 - **History completeness + peer attribution:** both legs of a local conversation are now persisted to the thread aggregate (history showed only the other agent's half), and the sender's originating topic is stamped on the delivered envelope so the peer can attribute replies to its own topic.
 
 ## What to Tell Your User
+
+Existing agents can pick up the free-text guard during an Instar update again. The guard behavior did not change; only the package template lookup path changed.
 
 If you reach out to another agent in the background while you're chatting, that agent's reply now shows up in our conversation reliably — before, it could land in my records but never make it back to you. You'll get a short "replied" note in the topic if I can't weave it in live, and you won't get double-pinged when I can. No action needed; this just makes background agent collaboration trustworthy.
 
@@ -22,6 +32,9 @@ If you reach out to another agent in the background while you're chatting, that 
 
 ## Evidence
 
+- Approved spec: `docs/specs/FREE-TEXT-GUARD-TEMPLATE-RESOLUTION-SPEC.md`.
+- Targeted unit coverage for cwd-independent shared template loading and a regression guard preventing `getFreeTextGuardHook()` from returning to a single direct `dist/templates` read.
+- Package-shape integration coverage asserts npm publishes `src/templates/hooks/free-text-guard.sh`, no `dist/templates` tree, and an extracted package's compiled migrator installs the free-text guard from the packaged source-template layout.
 - Root causes verified against v1.2.80 source (including an in-code comment that already documented the `get()` JSONL-guard hazard on the send path but never fixed the inbound path).
 - 3-tier tests: new unit coverage for the `get()` topic-linkage exemption, confirmed-vs-stalled inject (no-double-surface / safety-net-fallback), and both-legs thread persistence; full threadline suite green (1539 unit/integration + 329 e2e, zero regressions).
 - Independent second-pass review concurred on the actual diff (no over/under-block, no inject double-recovery race, return-type change breaks no caller).

--- a/upgrades/side-effects/1.2.81.md
+++ b/upgrades/side-effects/1.2.81.md
@@ -1,0 +1,127 @@
+# Side-Effects Review — Free-text guard template resolution
+
+**Version / slug:** `free-text-guard-template-resolution`
+**Date:** `2026-05-25`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Echo`
+
+## Summary of the change
+
+This change fixes how the post-update migrator finds built-in template files.
+The free-text guard hook was looking only in the compiled-template layout, but
+published packages ship that hook in the source-template layout. The migrator
+now has one shared template loader for hook, script, and playbook templates. The
+free-text guard and existing similar readers use that loader.
+
+## Decision-point inventory
+
+This change does not add, remove, or modify any block/allow decision. It changes
+file lookup for a static built-in template. The free-text guard's own behavior is
+passed through unchanged.
+
+- `free-text-guard.sh` — pass-through — installed from the packaged template;
+  its blocking rules are not changed.
+- `PostUpdateMigrator` template lookup — modified — uses shared lookup instead
+  of repeated one-off path checks.
+
+---
+
+## 1. Over-block
+
+No new block/allow surface. Over-block is not applicable to the template lookup
+change. The free-text guard may still block exactly the same inputs it blocked
+before; this patch only controls whether the hook is installed.
+
+---
+
+## 2. Under-block
+
+This does not change what the guard detects. The remaining failure mode is
+package-shape drift: if a future publish stops shipping both supported template
+locations, the migrator will fail clearly for the required free-text guard and
+skip or fall back for callers that already had softer behavior. The new package
+shape test covers the current published layout.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The fix belongs in the migrator because the bug is runtime asset resolution, not
+guard policy. A shared helper is the right layer: it keeps package-layout
+knowledge in one place and lets each caller decide whether a missing template is
+fatal, skippable, or eligible for fallback.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The change does not introduce a detector or an authority. It does not decide
+whether a message, action, or user request should be blocked. It only locates a
+static template file so existing migration behavior can install the existing
+hook.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** no existing decision path is shadowed. Existing template
+  readers now share one lookup helper.
+- **Double-fire:** no duplicate installer is added. The same migration still
+  writes the same built-in hook once.
+- **Races:** no shared persistent state is added. File reads are local and
+  synchronous, matching the previous migrator style.
+- **Feedback loops:** none. The resolver does not feed runtime decisions or
+  telemetry.
+
+---
+
+## 6. External surfaces
+
+Existing agents see the external effect on update: the free-text guard hook can
+be installed again from the package we actually publish. The hook content and
+runtime behavior do not change. There is no new user-facing command, API,
+database field, or external service dependency.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a normal patch revert. The change writes no new persistent state and
+does not migrate data. If it misbehaves, revert the shared resolver refactor and
+ship a patch. Agents that already received the hook do not need repair because
+the hook content itself is unchanged.
+
+---
+
+## Conclusion
+
+The review found no new decision authority and no new block/allow behavior. The
+main production risk is future package layout drift, and the integration test now
+checks the packed package shape and runs the compiled migrator from that shape.
+This is clear to ship once CI is green.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Echo
+**Independent read of the artifact: concur**
+
+Echo reviewed the diagnosis and implementation direction during the Threadline
+collaboration and signed off on the root cause, shared resolver approach, and
+packed-package smoke as the evidence needed before normal CI.
+
+---
+
+## Evidence pointers
+
+- Approved spec: `docs/specs/FREE-TEXT-GUARD-TEMPLATE-RESOLUTION-SPEC.md`
+- Plain-language spec overview:
+  `docs/specs/FREE-TEXT-GUARD-TEMPLATE-RESOLUTION-SPEC.eli16.md`
+- Focused tests: 6 passing.
+- Build and lint: passing.
+- Packed package smoke: passing.


### PR DESCRIPTION
## Summary

Fixes the post-update migrator so existing agents can install the free-text guard from the package layout we actually publish. The guard behavior is unchanged; only the template lookup path is fixed.

## What changed

- Added a shared template loader for built-in hook, script, and playbook templates.
- Routed the free-text guard and related template readers through that shared loader.
- Added focused regression tests, including an extracted-package smoke test.
- Added the approved spec, plain-language overview, side-effects review, and release-note evidence.

## Validation

- Focused tests passed: 6 tests.
- Build passed.
- Lint passed.
- Upgrade-guide check validated the current guide.
- Packed-package smoke passed.
- Commit hook passed the Instar development review gate.
- Push gate passed and branch was published; it warned that the package version matches the current release and that one local comparison target was unavailable.

## Review notes

Echo already reviewed the diagnosis and agreed the shared resolver plus packed-package smoke closes the bug. Remaining condition is normal CI green.