### PR TITLE
feat(session-reaper): pressure-aware reaper for idle-but-alive sessions

### DIFF
--- a/docs/specs/SESSION-REAPER-SPEC.eli16.md
+++ b/docs/specs/SESSION-REAPER-SPEC.eli16.md
@@ -1,0 +1,50 @@
+# SessionReaper — the plain-English version
+
+## The problem, in one picture
+
+Think of your computer like a kitchen, and each agent "session" like a chef standing at a station. A chef who's cooking needs their station. But sometimes a chef finishes, sets down their knife, and just... stands there. Idle. Still taking up a station.
+
+The other day, 51 chefs were crammed into the kitchen — most just standing around doing nothing — and the kitchen ran out of room. When a new order came in (a message from another agent), there was no free station, so nobody could start cooking it. The message arrived; no chef could pick it up. It *looked* like the order system was broken. It wasn't. The kitchen was just full of chefs doing nothing.
+
+I cleared out 42 idle chefs, and instantly the next order got cooked.
+
+## Why didn't we already clean those up?
+
+We *do* sweep out chefs who collapsed (crashed). And we have a rule that says "if a chef has been standing idle for a while, send them home." But that rule kept failing for four sneaky reasons:
+
+1. **The timer kept resetting.** The "how long have you been idle" stopwatch lived only in the kitchen manager's head. Every time the manager got knocked out and woke back up (the server was crash-looping that day), the stopwatch reset to zero. So a chef idle for two days never *looked* idle for more than a few minutes.
+2. **We only recognized one "idle pose."** The rule checked if a chef was standing in one specific way. A chef idle in any *other* pose was mistaken for "busy" and never sent home.
+3. **We never looked at how full the kitchen was.** The rule was purely about time, never about whether we actually needed the space.
+4. **Each manager only watched their own chefs.** Nobody was counting the whole kitchen.
+
+## What I want to build
+
+A **SessionReaper** — a quiet helper that sends idle chefs home, but *only when the kitchen actually needs the room*, and **never, ever sends home a chef who's actually cooking.**
+
+That last part is the whole point. You told me to focus hard on never reaping a session that's working, and that's what the design is built around.
+
+## How it refuses to make a mistake
+
+My first draft had this backwards, and the review caught it. I'd planned to check three things — is anything cooking on their stove, does their screen say "working", is their notebook still being written in — and send a chef home only if all three looked quiet.
+
+The problem: **a chef who's just standing there thinking looks exactly like a chef who's done.** When the kitchen sends an order out to a supplier and waits for the phone to ring back, nothing's cooking, the screen isn't changing, and nothing's being written — but that chef is absolutely still working. So "everything looks quiet" is *not* proof that someone's idle.
+
+So we flipped the whole rule. Now it doesn't send a chef home for *looking* quiet. It only acts when it can **positively confirm the chef finished their dish and is parked at the counter waiting for the next order** — and even then, only if their screen hasn't changed by a single pixel across several checks spread over ten-plus minutes (a thinking chef's screen always twitches; a truly-waiting one is frozen). **And the golden rule: if it can't tell for sure — wrong kind of chef it doesn't recognize, can't find their notebook, anything unclear — it leaves them alone.** Uncertainty always means "keep," never "kill."
+
+On top of that there's still the long "hands off" list: waiting on you mid-conversation, made a promise they haven't kept, has a helper working, mid-build, just started. Any single reason to keep them wins.
+
+It also won't act on a single glance — it has to see a chef idle several times over at least ten minutes. And it can only send home a few chefs at a time, so even if it somehow got confused, it can't clear the whole kitchen.
+
+## The clever bits
+
+- **The stopwatch now lives on paper, not in the manager's head** — so a crash can't reset it anymore (but if it sees the chef actually wrote in their notebook while the manager was out, it throws the old time away and starts fresh — no reaping on stale info).
+- **It mostly sleeps.** When the kitchen has room, it does almost nothing. It only gets busy exactly when the kitchen is filling up — which is the only time the pileup actually hurts.
+- **It starts in "watch only" mode.** For the first while it just writes down *who it would have sent home*, without sending anyone home, so we can check it's only ever flagging genuinely-idle chefs before we let it act for real.
+
+## What you'd notice
+
+Honestly, almost nothing — and that's the goal. Your agents stop fainting when the machine gets crowded, cross-agent messages stop mysteriously failing, and you don't have to manually clear out stale sessions like I did the other day. If you ever wonder "why is/isn't it cleaning up that session?", there's a page that shows every session and the exact reason it was kept or flagged.
+
+## Where this is in the process
+
+This is now a **converged draft spec**, not code. I ran it through a three-way review — a different AI model (GPT) plus two deep passes that read the actual instar source code. All three independently caught the same big flaw (the "looks quiet = idle" mistake above) and a pile of smaller ones, and the spec has been rewritten to fix every one. Per our rule, nothing gets built until you sign off on this converged version. Everything the review changed made the reaper *more* cautious, never less.

--- a/docs/specs/SESSION-REAPER-SPEC.md
+++ b/docs/specs/SESSION-REAPER-SPEC.md
@@ -1,0 +1,253 @@
+---
+title: SessionReaper Spec
+review-convergence: "3-way (codex/gpt-5.5 + 2 code-grounded Claude passes), 2026-05-25"
+approved: true
+eli16-overview: SESSION-REAPER-SPEC.eli16.md
+topic: 13201
+---
+
+# SessionReaper Spec
+
+**Status:** v2 CONVERGED + RATIFIED (user-approved 2026-05-26, topic 13201). 3-way review: codex/gpt-5.5 + 2 code-grounded Claude passes.
+**Topic:** 13201 (🧹 SessionReaper)
+**Author:** echo
+**Created:** 2026-05-25 · **Converged:** 2026-05-25
+**Companion:** `SESSION-REAPER-SPEC.eli16.md`
+
+> **Convergence changelog (v1 → v2):** Review unanimously found v1's central safety claim — "C+D+E are three independent sensors; a false-reap needs all three to fail" — **false in the real code**. In-process/network work (LLM generation, MCP/WebFetch, API stall) shows **no child process, no pane change, no transcript growth** — all three "sensors" fail together. Worse, gates E/F/K all hinge on the **optional, frequently-absent `claudeSessionId`** and Claude-only transcript paths (`~/.claude/projects`), so they are structurally dead for Codex sessions and for any agent whose hooks never fired. v2 **inverts the classifier** from "absence of activity ⇒ reap" to "**positive proof of a completed, idle turn ⇒ eligible; anything unknown ⇒ KEEP**," adds a per-signal **confidence contract** (unresolvable ⇒ KEEP), a **provider-neutral session key**, a single-writer `terminateSession` kill path, and a fresh-confirmation-after-boot rule. See §10 for the full finding→fix table.
+
+---
+
+## 1. Problem
+
+We clean up **crashed/zombie** sessions, but nothing safely sweeps a session that is **idle-but-alive** — sitting at its prompt, doing nothing, holding memory. On 2026-05-25 these piled up across the fleet: 51 agent sessions / 260 processes / ~37 GB used / 1.4 GB free. Under that pressure, agents refused to spawn sessions to read incoming messages ("too busy, spawn denied"), and cross-agent collaboration silently failed. Reaping 42 stale sessions freed ~38 GB and recovery was immediate.
+
+### 1.1 Why the existing idle-kill did not prevent this
+
+`SessionManager.monitorTick` (src/core/SessionManager.ts:559–677) already kills idle sessions: `IDLE_PROMPT_KILL_MINUTES = 15` (unbound), `IDLE_PROMPT_KILL_MINUTES_BOUND_TO_TOPIC = 240` (4 h, topic-bound). It still let 42 sessions accumulate. Four concrete defeat mechanisms, all present in the case study:
+
+1. **The idle clock is in-memory and resets on every restart.** `idlePromptSince` is a `Map` on the live object (SessionManager.ts:149). The case study's root cause #1 was a *crash-looping server*. Every crash/restart wipes the map → a session idle for days never accumulates the continuous 4 h needed to be killed. **The crash-loop literally protected the idle sessions.**
+2. **The pane-pattern gate is fragile.** Idle-kill fires only if `IDLE_PROMPT_PATTERNS` match the last 5 lines (SM:565–577). A pane showing leftover output, a partial render, an unrecognized error, or scrolled content fails `isIdleAtPrompt` → treated as *active* → never reaped. (Note: this is the *opposite* failure direction from a false-reap — here it under-reaps. v2's classifier must not inherit this fragility in *either* direction.)
+3. **No pressure awareness.** The 4 h topic-bound window is by-design generous. With many topics × agents, dozens sit alive *correctly* — until the machine starves. Per-agent idle-kill is purely time-based; blind to the memory pressure that makes the pileup harmful.
+4. **Per-agent scope, not fleet.** Each agent's `SessionManager` sees only its own sessions. The 51-session pileup spanned all agents; no component factors in machine-wide resource state.
+
+### 1.2 What SessionReaper adds
+
+A **pressure-aware, restart-durable, positive-evidence reaper** that reaps an idle session **only when the machine actually needs the memory back** and **only when it can positively prove the session's turn is complete and idle**. It does not replace the fast 15 m at-prompt idle-kill — it covers the pressure-driven and ambiguous cases that one misses, while being *strictly more conservative* about what it will kill.
+
+---
+
+## 2. The hard requirement (user, 2026-05-25)
+
+> "STRONG focus on NOT reaping sessions that might be working on something. A robust set of checks and metrics... an intelligent decision."
+
+**Design posture (v2):** the reaper does **not** infer idleness from the *absence* of activity signals. Absence is ambiguous — a session mid-LLM-generation or mid-network-call produces no observable activity yet is fully working. Instead the reaper requires **positive, framework-confirmed evidence that the turn is complete and the session is parked at a ready-for-input prompt**, *plus* the absence of every protect signal, *plus* render stasis. **Any ambiguity, any unresolvable signal, any unknown framework state → KEEP.** We would rather leak an idle session for many ticks than reap one that was thinking.
+
+---
+
+## 3. Design
+
+### 3.1 The classifier: positive-evidence, confidence-gated
+
+`classify(session) → KEEP | REAP_ELIGIBLE`. Every signal returns `{verdict, confidence}`. **A session is `REAP_ELIGIBLE` only if ALL of the following hold; any failure, any `confidence:'low'`, any unresolved probe ⇒ KEEP.**
+
+**(1) Positive idle proof (REQUIRED — the gate v1 lacked).** A framework-specific detector must *affirmatively* confirm the session is **turn-complete and parked at a ready-for-input prompt** — not merely "no work signal seen."
+- Claude Code: the idle input box / ready prompt is positively rendered in the captured pane (extend `IDLE_PROMPT_PATTERNS`, used as *positive* evidence here).
+- Codex CLI: the ready prompt is positively rendered, *and* none of the Codex active markers (`Working (Ns`, `• Ran`, `esc to interrupt`, spinner) appear anywhere in the captured buffer (per `frameworkActivitySignals.ts`).
+- **Framework cannot be resolved** (`SessionManager.frameworkForSession()` returns undefined) **⇒ KEEP** (confidence low). No reaping on an unknown framework's render.
+
+**(2) Render stasis (REQUIRED).** The captured pane — **≥ 200 lines**, scanned in full, not just the tail — must be **byte-identical across every one of the `confirmObservations` ticks**. A streaming generation updates the token counter / spinner / output every tick; a truly parked prompt does not. This is the **primary real-time liveness signal** and closes the in-process/network-work hole that defeats process-tree and transcript checks.
+
+**(3) No active work (process + transcript), with confidence contract.**
+- **Process liveness:** `hasActiveProcesses()` (no non-baseline children) **plus** main-process liveness deltas from the pane PID (CPU-time / IO-counter movement across ticks). A moving main process = work even with no child. **Cannot inspect the process tree ⇒ KEEP.**
+- **Transcript growth:** resolved **per-framework** (Claude `~/.claude/projects/...`, Codex `~/.codex/sessions/YYYY/MM/DD/rollout-*-<uuid>.jsonl` via `FrameworkSessionStore`). Persist *file identity* (path + inode + size + mtime), not just a session id. **Unresolved / missing / rotated / truncated / permission-error transcript ⇒ KEEP** (never counted as "quiet"). Growth ⇒ KEEP.
+
+**(4) Protect-gates — all must pass; each carries a confidence contract (missing dependency ⇒ KEEP for that class, never "gate passes").**
+
+| # | Protect when… | Source (verified) | Confidence note |
+|---|---------------|-------------------|-----------------|
+| A | in `config.protectedSessions` (e.g. `*-server`) | `Config` | always resolvable |
+| B | is the reaper's own / server session | host context | always |
+| G | a recovery is in flight | composed `activeRecoveryChecker` | **must be extended** to include socket + silence sentinels (today it is compaction + rate-limit only, server.ts:5230) — *compose, don't replace* (a second `setActiveRecoveryChecker` drops the existing veto) |
+| H | a pending injection **or** active relay lease exists | `getPendingInjection()` (public); **needs new** `isRelayLeaseActive(sessionId)` accessor (lease map is private, keyed by instar `session.id`) | resolvable once accessor added |
+| I | bound topic got a user message within `recentUserWindowMinutes` | `topicBindingChecker` + message store | KEEP if binding unresolved |
+| J | the session's **bound topic** has an active commitment | `CommitmentTracker.getActive()` filtered by `topicId` — **commitments have no `sessionId`**; re-scoped to topic | KEEP if topic unresolved |
+| K | an active subagent maps to this session | `SubagentTracker.getActiveSubagents(claudeSessionId)` | keyed on `claudeSessionId`; **absent ⇒ KEEP** |
+| L | a `/build` or `/autonomous` is live for this session's **topic/project** | autonomous: `.instar/autonomous/<topicId>.local.md` `active:true` + recent mtime; build: non-idle `build-state.json` phase (project-wide; cannot be narrowed to one session) | topic/project-scoped, not per-session |
+| M | `age < minAgeMinutes` (spawn grace) | session record | always |
+
+> **Honesty about independence (corrects v1's false claim):** signals (1)–(3) are *not* fully independent. Process and pane both derive from `ps`/tmux; transcript, token-ledger (gate K's cousin) and subagent signals all hinge on `claudeSessionId` + framework transcript paths. The real safety does **not** come from "three independent sensors" — it comes from (a) requiring a **positive** turn-complete signal, (b) **render stasis** as a real-time channel that is independent of `claudeSessionId`, and (c) the **confidence contract**: every channel that cannot resolve forces KEEP rather than contributing a false "quiet."
+
+### 3.2 Hysteresis (necessary, not sufficient)
+
+A candidate must satisfy (1)–(4) **continuously** across `confirmObservations` ticks spanning ≥ `confirmWindowMinutes`; any non-candidate observation resets the counter. **Hysteresis alone is explicitly NOT relied upon** to cover sustained-but-quiet work (a 12-minute build or a long generation can sit inside the window). The defense against *sustained-quiet* work is the **positive-idle requirement + render stasis** (§3.1), not the window length.
+
+### 3.3 Adaptive idle threshold (pressure-driven, macOS-aware)
+
+Idle duration must exceed a threshold that tightens as the machine starves. **`os.freemem()` alone is rejected** — on macOS (the case-study platform) it excludes the large reclaimable cache/compressed pool and routinely reads alarmingly low on a healthy Mac, which would spuriously select the tightest threshold.
+
+Pressure tier = composite of: **spawn-denial rate** (the actual case-study symptom — primary), macOS `memory_pressure` / `vm_stat` page-out rate, `QuotaTracker` state, and `freemem%` as *advisory only*.
+
+| Tier | Trigger | Idle threshold | Behavior |
+|------|---------|----------------|----------|
+| **Normal** | no pressure signal | **effectively off** (rely on existing 15 m/4 h idle-kill) | reaper idle |
+| **Moderate** | early pressure (page-out trend / quota elevated) | `idleThresholdModerateMinutes` (def 45) | trim longest-idle |
+| **Critical** | **spawn-denial observed** OR sustained page-out OR quota critical | `idleThresholdCriticalMinutes` (def 15, must exceed worst-case legitimate silent-work span) | reap oldest-idle-first to budget |
+
+**Anti-stampede:** every agent reaps independently, so all could hit Critical at once. Mitigate with **per-host cross-process jitter** + a **shared host budget file/lock** (`<sharedRoot>/session-reaper-budget.lock`) so the fleet doesn't mass-reap in the same instant, plus a **cooldown** after each reap to re-measure pressure before the next.
+
+### 3.4 Restart durability — default-distrust
+
+Continuous-idle state persists to `state/session-reaper.json` keyed by a **provider-neutral composite key**: `{provider, agentId, tmux session/window/pane identity, frameworkSessionId?, transcript file identity}`. (v1's `claudeSessionId`-only key is rejected — it's absent for Codex and pre-hook sessions, and the tmux name is reused across respawns.)
+
+**On boot, never reap from rehydrated idle alone.** A rehydrated idle-since is honored *only* if **all** hold: (a) the composite key matches unambiguously, (b) the transcript *file identity* matches and shows zero growth, and (c) a **fresh full `confirmObservations` window completes after boot** also satisfying §3.1. If any identity component is ambiguous, or the transcript can't be resolved, or work without transcript-growth may have occurred during downtime → **discard the persisted clock and restart it from boot** (apply gate M spawn-grace from boot time). A crash-loop must never let the reaper boot straight into Critical and kill a session that worked through the outage.
+
+### 3.5 Two-phase graceful reap (full re-check under lock)
+
+1. **Enter `reaping` state** (see §3.6) + emit structured event.
+2. **Final grace** (`finalGraceSec`, def 60): re-run the **full §3.1 classifier fresh** (positive-idle + render-stasis + process/transcript + all protect-gates A–M) — **not** the narrowed process+transcript probe of v1. No nudge is injected (the reaper is a cleaner, not a recoverer).
+3. **Immediately before the kill syscall**, under the `reaping` lock, re-assert: render-stasis still holds since `reaping` began, no pending injection, no relay lease, no recent user message, status still `running`/`reaping`. **Any change ⇒ abort, revert to `running`, reset the clock.**
+4. **Reap:** via the single-writer path (§3.6): `endedReason:'reaped-idle'`, write to `sentinel-events.jsonl` + the `destructive-ops` audit trail, persist a transcript pointer + final pane capture for post-mortem.
+
+### 3.6 Single-writer termination (fixes the concurrency race)
+
+All session-termination paths — the existing `SessionManager` idle-kill **and** the reaper — must funnel through one **idempotent `SessionManager.terminateSession(sessionId, reason)`** with **compare-and-set** on a `running → reaping → completed` state machine and **exactly-once** `beforeSessionKill`/`sessionComplete` emission. While a session is `reaping`, idle-kill and injection paths must **skip/serialize** on it. `status==='running'` checks alone (v1) are insufficient — they admit interleaving, duplicate events, and clobbered `endedReason`.
+
+### 3.7 Bounded blast radius + auto-disable
+
+`maxReapsPerTick` (def 3) and `maxReapsPerHour`. Under Critical the cap is enforced **per-host** (via the shared budget file), not just per-agent, so N agents can't collectively over-reap. **Auto-disable:** any *ambiguous* or *failed* reap (kill errored, or post-kill verification unexpected) flips the reaper to dry-run and raises one `/attention` item — fail safe, investigate before re-enabling.
+
+### 3.8 Dry-run-first rollout
+
+Ships `enabled:false, dryRun:true`. In dry-run it logs every would-reap with the full per-signal breakdown + confidence to `sentinel-events.jsonl`, kills nothing. Operator validates over a real pressure event, then flips `enabled:true`.
+
+### 3.9 Observability
+
+`GET /sessions/reaper`: current pressure tier + active threshold + inputs (spawn-denial rate, page-out, quota, freemem-advisory), and every running session with its classifier verdict, the **specific signal/gate** that kept it (with confidence), and any reap-pending countdown; plus recent reaps with reasons. Pull surface, not chat ([[feedback_notifications_near_silent]]).
+
+---
+
+## 4. Placement & wiring
+
+- **New class:** `src/monitoring/SessionReaper.ts` (EventEmitter; constructor → setters → `start()` like `SessionWatchdog`/`OrphanProcessReaper`).
+- **Wired in:** `src/monitoring/sentinelWiring.ts` + `src/commands/server.ts`. Tick `tickIntervalSec` (def 120).
+- **Wiring tasks the review surfaced as prerequisites:**
+  - Extend the composed `activeRecoveryChecker` (server.ts:~5230) to include `socketSentinel.isRecoveryActive()` + `silenceSentinel.isRecoveryActive()` — **compose into the existing predicate, do not replace it**.
+  - Add `SessionManager.isRelayLeaseActive(sessionId)` (gate H) and `SessionManager.terminateSession(sessionId, reason)` (§3.6).
+  - Add `TokenLedger.sessionActivitySince(claudeSessionId, sinceMs)` (gate-K corroborator; `topSessions()` is a leaderboard, not a per-session-since query).
+  - Per-framework transcript resolver shared with CompactionSentinel/RateLimitSentinel (today hardcoded to `~/.claude/projects`).
+- **Scope:** per-agent reaper, machine-pressure-driven, per-host budget lock for fleet relief without a central coordinator (rejected for v1).
+- **Name reserved:** `CrashLoopPauser.DEFAULT_NEVER_PAUSE` already lists `session-reaper`.
+
+### 4.1 Non-overlap with existing watchdogs
+
+| Component | Its target | Relationship |
+|-----------|-----------|--------------|
+| `SessionManager` idle-kill | tracked, at recognized prompt, no procs, 15 m/4 h | Shares the §3.6 single-writer `terminateSession`; reaper covers ambiguous-pane / restart-reset / pressure-early cases it misses. |
+| `OrphanProcessReaper` | **untracked** orphan processes >1 h | Disjoint: reaper acts only on sessions *in* the registry. |
+| `SessionWatchdog` | tracked sessions with a **stuck active child** | Disjoint: active-but-stuck vs positively-idle. |
+| Socket/Silence/Compaction/RateLimit sentinels | sessions to **recover** | Gate G (extended) defers to any recovery in flight. |
+
+---
+
+## 5. Config (`monitoring.sessionReaper`) — defined in `ConfigDefaults.ts`
+
+```jsonc
+{
+  "enabled": false,
+  "dryRun": true,
+  "tickIntervalSec": 120,
+  "minAgeMinutes": 30,
+  "confirmObservations": 3,
+  "confirmWindowMinutes": 10,
+  "paneCaptureLines": 200,            // §3.1 render-stasis window
+  "recentUserWindowMinutes": 30,
+  "idleThresholdModerateMinutes": 45,
+  "idleThresholdCriticalMinutes": 15,
+  "normalTierReaps": false,           // Normal = effectively off (approved default)
+  "maxReapsPerTick": 3,
+  "maxReapsPerHour": 12,
+  "finalGraceSec": 60,
+  "protectOpenCommitments": true,
+  "pressure": {
+    "useSpawnDenialSignal": true,     // primary
+    "usePageOutRate": true,           // macOS memory_pressure/vm_stat
+    "freememAdvisoryOnly": true,
+    "crossProcessJitterMs": 5000,
+    "sharedBudgetLockPath": "<sharedRoot>/session-reaper-budget.lock"
+  }
+}
+```
+
+---
+
+## 6. Testing (3-tier; the dangerous cases are mandatory)
+
+**Tier 1 — Unit:** each protect-gate A–M forces KEEP; **confidence contract** — every unresolvable signal (no framework, no `claudeSessionId`, unresolved/rotated transcript, missing tracker) forces KEEP, never "quiet"; positive-idle requirement (no positive prompt ⇒ KEEP even if all activity absent); render-stasis (any byte change across ticks ⇒ KEEP); pressure tier selection incl. macOS freemem-advisory-only; restart default-distrust (rehydrate requires fresh post-boot window); `terminateSession` CAS idempotency + exactly-once events; blast-radius + auto-disable.
+
+**Tier 2 — Integration:** `GET /sessions/reaper` verdict + per-signal confidence over HTTP; dry-run logs-but-survives.
+
+**Tier 3 — E2E (must include the false-reap-vector cases the review flagged):**
+- Feature-alive: route 200 not 503.
+- **Idle reaped vs active kept** under simulated Critical.
+- **Silent-but-working kept:** a long single tool/build with no transcript growth and a scrolled-off spinner ⇒ render-stasis or process-delta keeps it.
+- **API/network stall kept:** mid-generation, no pane change for > window ⇒ positive-idle absent ⇒ kept.
+- **No-`claudeSessionId` session kept:** missing-signal ⇒ KEEP.
+- **Codex session:** transcript resolves to `~/.codex/sessions`; unresolved ⇒ KEEP.
+- **Restart rehydrate:** worked-during-downtime session not reaped at boot.
+- **Final-grace race:** user message injected during `reaping` ⇒ abort.
+
+**Wiring-integrity:** server constructs `SessionReaper` with non-null deps and calls `start()` ([[feedback_verify_component_actually_wired]]).
+**Live test-as-self** ([[feedback_test_as_self_standard]]): shadow-install, run a real pressure scenario with a real in-flight build + a real Codex session, confirm both untouched, restore, then merge.
+
+---
+
+## 7. Migration parity
+
+- **Config:** add `monitoring.sessionReaper` to **`src/config/ConfigDefaults.ts`** (`getMigrationDefaults`); `applyDefaults` carries it to existing agents. (v1 said `migrateConfig()` hand-writes the block — that path is deprecated; `migrateConfig` delegates to `ConfigDefaults`.)
+- **CLAUDE.md template:** add a SessionReaper section in `generateClaudeMd()`.
+- **Wiring + new SessionManager/TokenLedger accessors:** code in `src/`; existing agents get it on server update, new via `init`.
+- **No hook changes.**
+
+---
+
+## 8. Open decisions (locked to approved defaults unless changed)
+
+1. **Pressure source** — **spawn-denial (primary) + macOS page-out; freemem advisory-only.** (Was "freemem"; review showed freemem misleads on macOS.)
+2. **Commitment protection (gate J)** — hard-protect any active commitment on the bound **topic** (re-scoped from per-session, which is unimplementable).
+3. **Reaped-session handoff** — persist transcript pointer + final pane capture on **every** reap.
+4. **Normal-tier** — **effectively off**; reaper is a pure pressure-relief valve (user-approved).
+
+---
+
+## 9. Standards conformance pass
+
+- **Structure > Willpower:** machine sweeps itself, pressure-reactive, per-host budget.
+- **Signal vs authority:** signals carry confidence; the budget + dry-run + single-writer `terminateSession` + auto-disable hold authority.
+- **Near-silent:** `/sessions/reaper` + audit log; chat only on auto-disable `/attention`.
+- **3-tier + dangerous-case E2E + wiring-integrity + test-as-self:** §6.
+- **Migration parity via ConfigDefaults:** §7.
+- **Bug-fix evidence bar:** live reproduce pileup→reap→recovery before claiming fixed.
+- **No false reap of working sessions:** positive-evidence + confidence-contract + render-stasis is the entire §3.
+
+---
+
+## 10. Convergence findings → fixes (3-way: codex/gpt-5.5 + 2 Claude code-grounded)
+
+| # | Sev | Finding (all reviewers converged on 1–5) | Fix in v2 |
+|---|-----|------------------------------------------|-----------|
+| 1 | BLOCKER | "Trips ≥1 sensor" false: in-process/network work has no proc, no pane change, no transcript growth | §2 + §3.1(1): **require positive turn-complete idle**, not absence of activity |
+| 2 | BLOCKER | Gate C blind to main-process work (API/MCP/CPU) | §3.1(3): add main-process CPU/IO deltas; "cannot inspect ⇒ KEEP" |
+| 3 | BLOCKER | Transcript probe hardcoded to `~/.claude/projects`; Codex blind; mtime-fallback grabs sibling jsonl | §3.1(3): per-framework resolver + file-identity; unresolved ⇒ KEEP |
+| 4 | BLOCKER | `claudeSessionId` optional/absent collapses E+F+K together | §3.1 confidence contract + §3.4 provider-neutral key; absent ⇒ KEEP |
+| 5 | BLOCKER | Final-grace race + kill TOCTOU; `status==='running'` insufficient | §3.5 full re-check under lock + §3.6 single-writer `terminateSession` CAS |
+| 6 | MAJOR | Pane window too small; spinner scrolls off | §3.1(2): ≥200 lines, scan full buffer, render-stasis |
+| 7 | MAJOR | Hysteresis doesn't cover >window silent work | §3.2: hysteresis necessary-not-sufficient; positive-idle is the real guard |
+| 8 | MAJOR | `os.freemem` misleads on macOS; fleet stampede | §3.3: spawn-denial primary + page-out; per-host jitter + budget lock |
+| 9 | MAJOR | Gate G checker omits socket/silence | §4: compose (not replace) socket+silence into `activeRecoveryChecker` |
+| 10 | MAJOR | Gate J commitments keyed by topic, not session | §3.1(4)J: re-scope to bound-topic |
+| 11 | MAJOR | Gate L build/autonomous have no per-session key | §3.1(4)L: topic/project-scoped |
+| 12 | MAJOR | Migration via `migrateConfig` is deprecated path | §7: `ConfigDefaults.ts` |
+| 13 | MINOR | Gate H relay lease / gate F per-session have no accessor | §4: add `isRelayLeaseActive`, `sessionActivitySince` |
+| 14 | MINOR | Blast caps still allow 12 false kills/h/agent | §3.7: per-host cap + auto-disable on ambiguous/failed reap |
+| 15 | MINOR | E2E only tests the easy case | §6: mandatory dangerous-case E2Es |

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5324,6 +5324,12 @@ export async function startServer(options: StartOptions): Promise<void> {
     // is OFF for Telegram by default and, when enabled, coalesces into ONE
     // consolidated message to the existing system topic. No new-topic-per-event.
     // Spec: docs/specs/silently-stopped-trio.md.
+    //
+    // Captured out of the trio block so the SessionReaper's recovery veto can
+    // compose socket + silence in too (SESSION-REAPER-SPEC §4 "compose, don't
+    // replace"). undefined when the corresponding sentinel is disabled.
+    let socketRecoveryActive: ((sessionName: string) => boolean) | undefined;
+    let silenceRecoveryActive: ((sessionName: string) => boolean) | undefined;
     {
       const { SocketDisconnectSentinel } = await import('../monitoring/SocketDisconnectSentinel.js');
       const { ActiveWorkSilenceSentinel } = await import('../monitoring/ActiveWorkSilenceSentinel.js');
@@ -5391,6 +5397,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         socketSentinel.on('recovery-error', (e: { sessionName: string; err: unknown }) =>
           notifier.record('recovery-error', 'socket-disconnect', e.sessionName, e.err instanceof Error ? e.err.message : String(e.err)));
         socketSentinel.start();
+        socketRecoveryActive = (s: string) => socketSentinel.isRecoveryActive(s);
         console.log(pc.green('  SocketDisconnectSentinel enabled (connection-drop recovery)'));
       }
 
@@ -5410,6 +5417,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         silenceSentinel.on('nudge-error', (e: { sessionName: string; err: unknown }) =>
           notifier.record('nudge-error', 'active-silence', e.sessionName, e.err instanceof Error ? e.err.message : String(e.err)));
         silenceSentinel.start();
+        silenceRecoveryActive = (s: string) => silenceSentinel.isRecoveryActive(s);
         console.log(pc.green(
           telegramEscalation
             ? '  ActiveWorkSilenceSentinel enabled (silent-freeze watchdog — Telegram escalation ON, consolidated)'
@@ -5417,6 +5425,19 @@ export async function startServer(options: StartOptions): Promise<void> {
         ));
       }
     }
+
+    // Recompose the zombie-kill veto to include ALL four recovery sentinels now
+    // that socket + silence exist (the interim set above covered only compaction
+    // + rate-limit, before those two were constructed). This single composed
+    // predicate is the superset — it drops none — and is reused as the
+    // SessionReaper's recovery gate (G) so the reaper never kills a session any
+    // sentinel is reviving. SESSION-REAPER-SPEC §4 "compose, don't replace".
+    const composedRecoveryActive = (session: import('../core/types.js').Session): boolean =>
+      compactionSentinel.isRecoveryActive(session.tmuxSession) ||
+      rateLimitSentinel.isRecoveryActive(session.tmuxSession) ||
+      (socketRecoveryActive?.(session.tmuxSession) ?? false) ||
+      (silenceRecoveryActive?.(session.tmuxSession) ?? false);
+    sessionManager.setActiveRecoveryChecker(composedRecoveryActive);
 
     // Trigger 1: PreCompact hook event — report to sentinel.
     hookEventReceiver.on('PreCompact', () => {
@@ -7764,7 +7785,78 @@ export async function startServer(options: StartOptions): Promise<void> {
       });
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge });
+    // ── SessionReaper (SESSION-REAPER-SPEC) ──────────────────────────────
+    // Pressure-aware reaper of idle-but-alive sessions. Ships OFF + dry-run by
+    // default; the classifier's positive-evidence + confidence-contract is what
+    // guarantees it never reaps a working session. Reuses composedRecoveryActive
+    // (gate G) so it defers to every recovery sentinel. Pressure is freemem-tiered
+    // for v1 (advisory; spawn-denial-primary is a tracked follow-up) — and note
+    // an over-eager tier can only reap a GENUINELY-idle session sooner, never a
+    // working one (the classifier protects working sessions regardless of tier).
+    const { SessionReaper, fileAuditSink } = await import('../monitoring/SessionReaper.js');
+    const _os = await import('node:os');
+    const _resolveTopic = (tmuxSession: string): number | null => {
+      const t = telegram?.getTopicForSession(tmuxSession);
+      if (t == null) return null;
+      const n = typeof t === 'number' ? t : Number(t);
+      return Number.isFinite(n) ? n : null;
+    };
+    const sessionReaper = new SessionReaper(
+      {
+        listRunningSessions: () => sessionManager.listRunningSessions(),
+        captureOutput: (s, n) => sessionManager.captureOutput(s, n) ?? '',
+        hasActiveProcesses: (s) => sessionManager.hasActiveProcesses(s),
+        frameworkForSession: (s) => sessionManager.frameworkForSession(s) as 'claude-code' | 'codex-cli' | undefined,
+        isRecoveryActive: (session) => composedRecoveryActive(session),
+        isRelayLeaseActive: (id) => sessionManager.isRelayLeaseActive(id),
+        hasPendingInjection: (s) => sessionManager.getPendingInjection(s) != null,
+        topicBinding: _resolveTopic,
+        // Gate I is a v1 stub (returns false): active conversation is already
+        // covered by the relay-lease + pending-injection gates and by render
+        // stasis (a session being talked to is not render-static for the full
+        // hysteresis+threshold window). Promoting to a real message-recency
+        // query is a tracked tuning follow-up.
+        recentUserMessage: () => false,
+        activeCommitmentForTopic: (topicId) => {
+          try { return commitmentTracker.getActive().some(c => c.topicId === topicId); }
+          catch { return true; } // cannot tell → protect
+        },
+        activeSubagentCount: (csid) => {
+          try { return csid ? subagentTracker.getActiveSubagents(csid).length : 0; }
+          catch { return 1; } // cannot tell → protect
+        },
+        buildOrAutonomousActive: (topicId) => {
+          const fresh = (p: string): boolean => {
+            try { return fs.existsSync(p) && (Date.now() - fs.statSync(p).mtimeMs) < 30 * 60_000; }
+            catch { return false; }
+          };
+          if (topicId != null && fresh(path.join(config.stateDir, 'autonomous', `${topicId}.local.md`))) return true;
+          return fresh(path.join(config.stateDir, 'state', 'build', 'build-state.json'));
+        },
+        protectedSessions: () => config.sessions?.protectedSessions ?? [],
+        pressure: () => {
+          const total = _os.totalmem();
+          const freePct = total > 0 ? (_os.freemem() / total) * 100 : 100;
+          const tier = freePct < 5 ? 'critical' : freePct < 12 ? 'moderate' : 'normal';
+          return { tier, inputs: { freePct: Math.round(freePct * 10) / 10 } };
+        },
+        terminate: (id, reason) => sessionManager.terminateSession(id, reason),
+        markReaping: (id) => sessionManager.markReaping(id),
+        clearReaping: (id) => sessionManager.clearReaping(id),
+        audit: fileAuditSink(config.stateDir),
+      },
+      config.monitoring?.sessionReaper,
+    );
+    sessionReaper.start();
+    if (config.monitoring?.sessionReaper?.enabled) {
+      console.log(pc.green(
+        config.monitoring.sessionReaper.dryRun === false
+          ? '  SessionReaper enabled (idle-session reaper — LIVE)'
+          : '  SessionReaper enabled (idle-session reaper — dry-run, logs only)',
+      ));
+    }
+
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7833,7 +7833,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           if (topicId != null && fresh(path.join(config.stateDir, 'autonomous', `${topicId}.local.md`))) return true;
           return fresh(path.join(config.stateDir, 'state', 'build', 'build-state.json'));
         },
-        protectedSessions: () => config.sessions?.protectedSessions ?? [],
+        protectedSessions: () => sessionManager.getProtectedSessions(),
         pressure: () => {
           const total = _os.totalmem();
           const freePct = total > 0 ? (_os.freemem() / total) * 100 : 100;

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -40,6 +40,29 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     activeWorkSilenceSentinel: {
       enabled: true,
     },
+    // SessionReaper — pressure-aware reaper of idle-but-alive sessions.
+    // UNLIKE the sentinels above, default OFF + dry-run: it is the only monitor
+    // that *kills* sessions on a heuristic, so it ships dark and must be flipped
+    // on by an operator after validating the dry-run log over a real pressure
+    // event. enabled:false → never runs; dryRun:true → logs would-reap, kills
+    // nothing. See docs/specs/SESSION-REAPER-SPEC.md.
+    sessionReaper: {
+      enabled: false,
+      dryRun: true,
+      tickIntervalSec: 120,
+      minAgeMinutes: 30,
+      confirmObservations: 3,
+      confirmWindowMinutes: 10,
+      paneCaptureLines: 200,
+      recentUserWindowMinutes: 30,
+      idleThresholdModerateMinutes: 45,
+      idleThresholdCriticalMinutes: 15,
+      normalTierReaps: false,
+      maxReapsPerTick: 3,
+      maxReapsPerHour: 12,
+      finalGraceSec: 60,
+      protectOpenCommitments: true,
+    },
     // Master gate for Telegram delivery of silently-stopped-sentinel
     // escalations. Default false → sentinel notices are housekeeping and stay
     // in the logs (server.log + sentinel-events.jsonl). Set true to receive

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -170,6 +170,15 @@ export class SessionManager extends EventEmitter {
   /** Sessions with active relay leases (prompt relayed, waiting for response) — extends idle timeout */
   private relayLeases = new Map<string, number>(); // session ID → lease expiry timestamp
 
+  /** Sessions the SessionReaper has leased for a two-phase reap (the transient
+   *  'reaping' state of SESSION-REAPER-SPEC §3.6). While a session id is here,
+   *  the idle-kill path skips it so only the reaper acts on it. */
+  private reapingSessions = new Set<string>();
+
+  /** Sessions whose termination is currently in flight — guards terminateSession()
+   *  against re-entrant double-kill / double-event emission within a tick. */
+  private terminating = new Set<string>();
+
   /** Track pending Telegram injections awaiting agent response.
    *  Key = tmuxSession name. Cleared when agent replies via /telegram/reply/:topicId. */
   private pendingInjections = new Map<string, { topicId: number; injectedAt: number; text: string }>();
@@ -362,6 +371,84 @@ rm()  { "${shimRunner}" rm  "$@"; }
    */
   clearRelayLease(sessionId: string): void {
     this.relayLeases.delete(sessionId);
+  }
+
+  /**
+   * True if the session has an unexpired relay lease (a prompt was relayed and
+   * we are waiting on the user). Gate H of the SessionReaper — keyed on the
+   * instar session id, not the tmux name. (SESSION-REAPER-SPEC §3.1(4)H.)
+   */
+  isRelayLeaseActive(sessionId: string): boolean {
+    const expiry = this.relayLeases.get(sessionId);
+    return expiry != null && expiry > Date.now();
+  }
+
+  /** Mark a session as being reaped (two-phase reap window). The idle-kill path
+   *  skips reaping sessions so the reaper is the single actor on them. */
+  markReaping(sessionId: string): void {
+    this.reapingSessions.add(sessionId);
+  }
+
+  /** Clear the reaping lease (reap completed or aborted). */
+  clearReaping(sessionId: string): void {
+    this.reapingSessions.delete(sessionId);
+  }
+
+  /** True if a reap is in flight for this session. */
+  isReaping(sessionId: string): boolean {
+    return this.reapingSessions.has(sessionId);
+  }
+
+  /**
+   * Single-writer session termination (SESSION-REAPER-SPEC §3.6). Both the
+   * idle-kill path and the SessionReaper funnel through this so a session is
+   * killed at most once with exactly-once `beforeSessionKill`/`sessionComplete`
+   * emission and a correct `endedReason`.
+   *
+   * Compare-and-set semantics: a session that is not in a live state
+   * ('starting'/'running'), or whose termination is already in flight, is a
+   * no-op — this is what prevents the idle-kill ↔ reaper double-kill race.
+   *
+   * @returns `{ terminated: true }` on a kill performed by THIS call, or
+   *          `{ terminated: false, skipped }` describing why it was a no-op.
+   */
+  async terminateSession(
+    sessionId: string,
+    reason: string,
+    opts?: { finalStatus?: 'completed' | 'killed' },
+  ): Promise<{ terminated: boolean; skipped?: string }> {
+    const session = this.state.getSession(sessionId);
+    if (!session) return { terminated: false, skipped: 'not-found' };
+    // CAS: only live sessions are terminable. Idempotent for already-terminal ones.
+    if (session.status !== 'running' && session.status !== 'starting') {
+      return { terminated: false, skipped: `already-${session.status}` };
+    }
+    if (this.config.protectedSessions.includes(session.tmuxSession)) {
+      return { terminated: false, skipped: 'protected' };
+    }
+    // In-flight guard: a concurrent terminate already owns this session.
+    if (this.terminating.has(sessionId)) {
+      return { terminated: false, skipped: 'in-flight' };
+    }
+    this.terminating.add(sessionId);
+    try {
+      // Emit BEFORE destroying tmux so listeners (TopicResumeMap, SlackAdapter)
+      // can capture resume UUIDs while the session is still alive.
+      this.emit('beforeSessionKill', session);
+      try {
+        await execFileAsync(this.config.tmuxPath, ['kill-session', '-t', `=${session.tmuxSession}`]);
+      } catch { /* session may already be dead */ }
+      session.status = opts?.finalStatus ?? 'completed';
+      session.endedAt = new Date().toISOString();
+      session.endedReason = reason;
+      this.state.saveSession(session);
+      this.emit('sessionComplete', session);
+      this.idlePromptSince.delete(session.id);
+      this.reapingSessions.delete(session.id);
+      return { terminated: true };
+    } finally {
+      this.terminating.delete(sessionId);
+    }
   }
 
   /**
@@ -562,7 +649,9 @@ rm()  { "${shimRunner}" rm  "$@"; }
         // AND (2) no non-baseline child processes are running. This is the ground
         // truth — no exemptions needed for subagents, topic bindings, or relay leases.
         // If the process tree shows work, the session is active. Period.
-        if (!this.config.protectedSessions.includes(session.tmuxSession)) {
+        // Skip sessions the SessionReaper has leased for a two-phase reap — it
+        // is the single actor on them while reaping (§3.6).
+        if (!this.config.protectedSessions.includes(session.tmuxSession) && !this.isReaping(session.id)) {
           const output = this.captureOutput(session.tmuxSession, 5);
           const isIdleAtPrompt = output && IDLE_PROMPT_PATTERNS.some(p => output.includes(p));
 
@@ -659,15 +748,9 @@ rm()  { "${shimRunner}" rm  "$@"; }
                 }
                 const bindingNote = binding != null ? ` (topic-bound, threshold ${killThresholdMinutes}m)` : ` (threshold ${killThresholdMinutes}m)`;
                 console.warn(`[SessionManager] Session "${session.name}" idle at prompt for ${Math.round(idleMs / 60_000)}m with no active processes${bindingNote}. Killing zombie.`);
-                this.emit('beforeSessionKill', session);
-                try {
-                  await execFileAsync(this.config.tmuxPath, ['kill-session', '-t', `=${session.tmuxSession}`]);
-                } catch { /* ignore */ }
-                session.status = 'completed';
-                session.endedAt = new Date().toISOString();
-                this.state.saveSession(session);
-                this.emit('sessionComplete', session);
-                this.idlePromptSince.delete(session.id);
+                // Funnel through the single-writer path so the reaper and this
+                // idle-kill can never double-kill or double-emit (§3.6).
+                await this.terminateSession(session.id, 'idle-zombie');
                 continue;
               }
             }
@@ -1039,23 +1122,38 @@ rm()  { "${shimRunner}" rm  "$@"; }
       throw new Error(`Cannot kill protected session: ${session.tmuxSession}`);
     }
 
-    // Emit beforeSessionKill BEFORE destroying the tmux session so
-    // listeners (e.g. TopicResumeMap) can discover the Claude UUID
-    // while the session is still alive.
-    this.emit('beforeSessionKill', session);
-
+    // Share the single-writer CAS guard so an explicit kill can't double with an
+    // in-flight terminateSession() from the idle-kill / reaper path (§3.6).
+    if (this.terminating.has(sessionId)) return false;
+    if (session.status !== 'running' && session.status !== 'starting') return false;
+    this.terminating.add(sessionId);
     try {
-      execFileSync(this.config.tmuxPath, ['kill-session', '-t', `=${session.tmuxSession}`], {
-        encoding: 'utf-8',
-      });
-    } catch {
-      // Session might already be dead
-    }
+      // Emit beforeSessionKill BEFORE destroying the tmux session so
+      // listeners (e.g. TopicResumeMap) can discover the Claude UUID
+      // while the session is still alive.
+      this.emit('beforeSessionKill', session);
 
-    session.status = 'killed';
-    session.endedAt = new Date().toISOString();
-    this.state.saveSession(session);
-    return true;
+      try {
+        execFileSync(this.config.tmuxPath, ['kill-session', '-t', `=${session.tmuxSession}`], {
+          encoding: 'utf-8',
+        });
+      } catch {
+        // Session might already be dead
+      }
+
+      session.status = 'killed';
+      session.endedAt = new Date().toISOString();
+      session.endedReason = 'manual-kill';
+      this.state.saveSession(session);
+      // NB: killSession historically does NOT emit 'sessionComplete' (only
+      // beforeSessionKill). Preserved to avoid changing listener semantics —
+      // the CAS guard + endedReason are the only additions here.
+      this.idlePromptSince.delete(session.id);
+      this.reapingSessions.delete(session.id);
+      return true;
+    } finally {
+      this.terminating.delete(sessionId);
+    }
   }
 
   /**

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -383,6 +383,13 @@ rm()  { "${shimRunner}" rm  "$@"; }
     return expiry != null && expiry > Date.now();
   }
 
+  /** The resolved protected-session list (incl. the `<project>-server` default).
+   *  Exposed so the SessionReaper's gate A uses the SAME list the idle-kill /
+   *  terminateSession guards enforce, rather than re-reading raw file config. */
+  getProtectedSessions(): string[] {
+    return this.config.protectedSessions;
+  }
+
   /** Mark a session as being reaped (two-phase reap window). The idle-kill path
    *  skips reaping sessions so the reaper is the single actor on them. */
   markReaping(sessionId: string): void {
@@ -1122,10 +1129,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
       throw new Error(`Cannot kill protected session: ${session.tmuxSession}`);
     }
 
-    // Share the single-writer CAS guard so an explicit kill can't double with an
+    // Share the in-flight guard so an explicit kill can't double with an
     // in-flight terminateSession() from the idle-kill / reaper path (§3.6).
+    // NB: unlike terminateSession we do NOT early-return on terminal status —
+    // killSession's contract is to destroy the pane unconditionally (a caller
+    // may kill a session whose status already drifted while its pane lives).
     if (this.terminating.has(sessionId)) return false;
-    if (session.status !== 'running' && session.status !== 'starting') return false;
     this.terminating.add(sessionId);
     try {
       // Emit beforeSessionKill BEFORE destroying the tmux session so

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2558,6 +2558,28 @@ export interface MonitoringConfig {
     verifyWindowMs?: number;
   };
   /**
+   * SessionReaper — pressure-aware reaper of idle-but-alive sessions. The only
+   * monitor that *kills* on a heuristic, so it ships OFF + dry-run by default.
+   * See docs/specs/SESSION-REAPER-SPEC.md and DEFAULT_SESSION_REAPER_CONFIG.
+   */
+  sessionReaper?: {
+    enabled: boolean;
+    dryRun?: boolean;
+    tickIntervalSec?: number;
+    minAgeMinutes?: number;
+    confirmObservations?: number;
+    confirmWindowMinutes?: number;
+    paneCaptureLines?: number;
+    recentUserWindowMinutes?: number;
+    idleThresholdModerateMinutes?: number;
+    idleThresholdCriticalMinutes?: number;
+    normalTierReaps?: boolean;
+    maxReapsPerTick?: number;
+    maxReapsPerHour?: number;
+    finalGraceSec?: number;
+    protectOpenCommitments?: boolean;
+  };
+  /**
    * Master gate for Telegram delivery of silently-stopped-sentinel escalations
    * (SentinelNotifier). Default false → sentinel notices are logged to the
    * server log + .instar/../logs/sentinel-events.jsonl only; the user never

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -69,6 +69,10 @@ export interface Session {
   maxDurationMinutes?: number;
   /** Claude Code's own session UUID (from hook events). Populated lazily on first hook event. */
   claudeSessionId?: string;
+  /** Why the session ended. Set by the single-writer terminateSession() path
+   *  (e.g. 'idle-zombie', 'reaped-idle', 'manual-kill'). Undefined on records
+   *  ended before this field existed. */
+  endedReason?: string;
 }
 
 export type SessionStatus = 'starting' | 'running' | 'completed' | 'failed' | 'killed';

--- a/src/monitoring/SessionReaper.ts
+++ b/src/monitoring/SessionReaper.ts
@@ -296,7 +296,17 @@ export class SessionReaper extends EventEmitter {
 
       let reapedThisTick = 0;
       for (const session of sessions) {
-        const evaln = this.evaluate(session);
+        let evaln: SessionEvaluation;
+        try {
+          evaln = this.evaluate(session);
+        } catch {
+          // A protect-signal threw — we cannot reason about this session, so
+          // KEEP it (abort any reap-pending) and reset candidacy. Never reap on
+          // a failed evaluation.
+          this.deps.clearReaping(session.id);
+          this.obs.set(session.id, { candidateSince: 0, consecutive: 0, lastFrame: '', lastTranscript: { resolved: false, path: '', size: 0, mtime: 0 } });
+          continue;
+        }
         const prior = this.obs.get(session.id);
         const now = this.now();
 
@@ -332,9 +342,15 @@ export class SessionReaper extends EventEmitter {
           if (now - next.reapPendingSince >= this.cfg.finalGraceSec * 1000) {
             // Final confirmation already passed THIS tick's full classifier
             // (we're here ⇒ still reap-eligible + render-static). Terminate.
-            if (threshold != null && reapedThisTick < this.cfg.maxReapsPerTick && this.hourlyBudgetRemaining() > 0) {
-              await this.performReap(session, pressure, next);
+            const canReap = threshold != null && reapedThisTick < this.cfg.maxReapsPerTick && this.hourlyBudgetRemaining() > 0;
+            if (canReap) {
+              await this.performReap(session, pressure, next); // clears the lease on every path
               reapedThisTick++;
+            } else {
+              // Grace elapsed but the reap is gated (tier dropped / budget spent).
+              // Release the reaping lease so the idle-kill safety net is not
+              // permanently disabled for this session.
+              this.deps.clearReaping(session.id);
             }
             this.obs.set(session.id, { ...next, reapPendingSince: undefined });
           } else {
@@ -407,10 +423,16 @@ export class SessionReaper extends EventEmitter {
     const threshold = this.thresholdMs(pressure.tier);
     const now = this.now();
     const sessions = this.deps.listRunningSessions().map(s => {
-      const e = this.evaluate(s);
       const o = this.obs.get(s.id);
+      let verdict: Verdict = 'keep';
+      let keptBy = 'eval-error';
+      let confidence: Confidence = 'low';
+      try {
+        const e = this.evaluate(s);
+        verdict = e.verdict; keptBy = e.keptBy; confidence = e.confidence;
+      } catch { /* a protect-signal threw — report as kept, never crash the route */ }
       return {
-        name: s.name, sessionId: s.id, verdict: e.verdict, keptBy: e.keptBy, confidence: e.confidence,
+        name: s.name, sessionId: s.id, verdict, keptBy, confidence,
         consecutive: o?.consecutive ?? 0, idleMs: o?.candidateSince ? now - o.candidateSince : 0,
         reapPending: o?.reapPendingSince != null,
       };

--- a/src/monitoring/SessionReaper.ts
+++ b/src/monitoring/SessionReaper.ts
@@ -1,0 +1,441 @@
+/**
+ * SessionReaper — pressure-aware, positive-evidence reaper for idle-but-alive
+ * sessions. SESSION-REAPER-SPEC.md (v2 CONVERGED).
+ *
+ * THE hard requirement: NEVER reap a working session. The classifier does NOT
+ * infer idleness from the ABSENCE of activity (a session mid-LLM-generation or
+ * mid-network-call looks identical to an idle one). It requires POSITIVE proof
+ * the turn is complete and the session is parked at a ready prompt, PLUS render
+ * stasis across ticks, PLUS quiet process+transcript — and every signal carries
+ * a confidence. Any ambiguity, any low-confidence/unresolvable signal → KEEP.
+ *
+ * Reaping is gated again by: hysteresis (continuous candidacy across N ticks),
+ * a pressure-adaptive idle threshold (does almost nothing at Normal), a bounded
+ * per-tick/per-hour budget, and a two-phase reap (mark reap-pending, then on a
+ * later tick re-confirm the full classifier fresh before terminating). Ships
+ * dry-run/off by default; auto-disables to dry-run on any ambiguous/failed reap.
+ */
+
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Session } from '../core/types.js';
+import { getActivitySignal } from './frameworkActivitySignals.js';
+import { probeTranscript, transcriptDelta, type TranscriptProbe } from './transcriptProber.js';
+
+export type PressureTier = 'normal' | 'moderate' | 'critical';
+export type Verdict = 'keep' | 'reap-eligible';
+export type Confidence = 'high' | 'low';
+
+export interface SessionReaperConfig {
+  enabled: boolean;
+  dryRun: boolean;
+  tickIntervalSec: number;
+  minAgeMinutes: number;
+  confirmObservations: number;
+  confirmWindowMinutes: number;
+  paneCaptureLines: number;
+  recentUserWindowMinutes: number;
+  idleThresholdModerateMinutes: number;
+  idleThresholdCriticalMinutes: number;
+  normalTierReaps: boolean;
+  maxReapsPerTick: number;
+  maxReapsPerHour: number;
+  finalGraceSec: number;
+  protectOpenCommitments: boolean;
+}
+
+export const DEFAULT_SESSION_REAPER_CONFIG: SessionReaperConfig = {
+  enabled: false,
+  dryRun: true,
+  tickIntervalSec: 120,
+  minAgeMinutes: 30,
+  confirmObservations: 3,
+  confirmWindowMinutes: 10,
+  paneCaptureLines: 200,
+  recentUserWindowMinutes: 30,
+  idleThresholdModerateMinutes: 45,
+  idleThresholdCriticalMinutes: 15,
+  normalTierReaps: false,
+  maxReapsPerTick: 3,
+  maxReapsPerHour: 12,
+  finalGraceSec: 60,
+  protectOpenCommitments: true,
+};
+
+/** A single signal's outcome. `keep:true` short-circuits the classifier. */
+interface SignalResult {
+  keep: boolean;
+  /** Gate/signal name when keep:true (for observability). */
+  reason?: string;
+  confidence: Confidence;
+}
+
+/** Per-tick evaluation of one session (stateless w.r.t. hysteresis). */
+export interface SessionEvaluation {
+  verdict: Verdict;
+  /** The gate that forced KEEP (or 'all-clear' when reap-eligible). */
+  keptBy: string;
+  confidence: Confidence;
+  /** Captured pane frame (for render-stasis comparison across ticks). */
+  frame: string;
+  /** Transcript probe this tick (for growth comparison across ticks). */
+  transcript: TranscriptProbe;
+}
+
+export interface PressureReading {
+  tier: PressureTier;
+  /** Free-form inputs for observability. */
+  inputs?: Record<string, unknown>;
+}
+
+/**
+ * All external signal sources are injected so the classifier is fully unit
+ * testable without tmux/fs/sqlite. Production wiring supplies SessionManager-
+ * and tracker-backed implementations.
+ */
+export interface SessionReaperDeps {
+  listRunningSessions: () => Session[];
+  captureOutput: (tmuxSession: string, lines: number) => string;
+  hasActiveProcesses: (tmuxSession: string) => boolean;
+  /** Optional main-process liveness (CPU/IO delta). `undefined` return = cannot
+   *  inspect → treated as POSSIBLY active (KEEP), per the confidence contract. */
+  mainProcessActive?: (tmuxSession: string) => boolean | undefined;
+  frameworkForSession: (tmuxSession: string) => 'claude-code' | 'codex-cli' | undefined;
+  /** Resolve+stat the session's transcript. Defaults to {@link probeTranscript}. */
+  probeTranscript?: (session: Session) => TranscriptProbe;
+  isRecoveryActive: (session: Session) => boolean;
+  isRelayLeaseActive: (sessionId: string) => boolean;
+  hasPendingInjection: (tmuxSession: string) => boolean;
+  /** Bound topic id for a session, or null. */
+  topicBinding: (tmuxSession: string) => number | null;
+  recentUserMessage: (topicId: number, withinMs: number) => boolean;
+  activeCommitmentForTopic: (topicId: number) => boolean;
+  /** Count of active subagents for a session's claudeSessionId (0 when absent). */
+  activeSubagentCount: (claudeSessionId: string | undefined) => number;
+  buildOrAutonomousActive: (topicId: number | null) => boolean;
+  protectedSessions: () => string[];
+  pressure: () => PressureReading;
+  terminate: (sessionId: string, reason: string) => Promise<{ terminated: boolean; skipped?: string }>;
+  markReaping: (sessionId: string) => void;
+  clearReaping: (sessionId: string) => void;
+  now?: () => number;
+  /** Structured audit sink (sentinel-events.jsonl). */
+  audit?: (event: Record<string, unknown>) => void;
+}
+
+interface Obs {
+  /** When continuous reap-candidacy began (ms). */
+  candidateSince: number;
+  /** Consecutive candidate observations. */
+  consecutive: number;
+  /** Last captured pane frame (render-stasis). */
+  lastFrame: string;
+  /** Transcript probe from the previous tick (growth comparison). */
+  lastTranscript: TranscriptProbe;
+  /** When this session entered reap-pending (two-phase), if it has. */
+  reapPendingSince?: number;
+}
+
+export class SessionReaper extends EventEmitter {
+  private readonly cfg: SessionReaperConfig;
+  private readonly deps: SessionReaperDeps;
+  private readonly now: () => number;
+  private timer?: NodeJS.Timeout;
+  private running = false;
+  private obs = new Map<string, Obs>();
+  private reapTimestamps: number[] = []; // for per-hour budget
+  /** Flips to true (forcing dry-run) after any ambiguous/failed reap. */
+  private autoDisabled = false;
+  private lastTickAt = 0;
+
+  constructor(deps: SessionReaperDeps, cfg?: Partial<SessionReaperConfig>) {
+    super();
+    this.deps = deps;
+    this.cfg = { ...DEFAULT_SESSION_REAPER_CONFIG, ...(cfg ?? {}) };
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => { void this.tick(); }, this.cfg.tickIntervalSec * 1000);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = undefined; }
+  }
+
+  /** Whether kills are actually performed (vs dry-run logged). */
+  private get killsEnabled(): boolean {
+    return this.cfg.enabled && !this.cfg.dryRun && !this.autoDisabled;
+  }
+
+  private probe(session: Session): TranscriptProbe {
+    if (this.deps.probeTranscript) return this.deps.probeTranscript(session);
+    const framework = session.framework ?? this.deps.frameworkForSession(session.tmuxSession) ?? 'claude-code';
+    // Claude uses claudeSessionId; Codex's transcript is globbed by its session
+    // id which we do not separately track → unresolved → KEEP (safe).
+    const sessionId = framework === 'claude-code' ? (session.claudeSessionId ?? '') : '';
+    return probeTranscript({ framework, sessionId, projectDir: '' });
+  }
+
+  /**
+   * Positive idle detection: returns true ONLY if the frame affirmatively shows
+   * a ready-for-input prompt AND contains no active-work marker. Conservative —
+   * an undetected ready prompt returns false (→ KEEP), never a false idle.
+   */
+  static isPositivelyIdle(framework: 'claude-code' | 'codex-cli' | undefined, frame: string): boolean {
+    if (!framework) return false; // unknown framework → cannot positively assert idle
+    const sig = getActivitySignal(framework);
+    // Any active marker anywhere in the captured buffer ⇒ not idle.
+    if (sig.toolCallOrSpinner.test(frame) || sig.escapeToInterrupt.test(frame) || sig.runningIndicator.test(frame)) {
+      return false;
+    }
+    // Positive ready-prompt signatures (conservative; tunable via dry-run).
+    if (framework === 'claude-code') {
+      return /bypass permissions|\? for shortcuts|auto-accept edits|shift\+tab/i.test(frame)
+        || /\n\s*>\s*$/.test(frame.trimEnd() + '\n');
+    }
+    // codex-cli: a ready prompt with no working status line. The model-name idle
+    // line is NOT a reliable positive, so require the explicit input affordance.
+    return /\? for shortcuts|send a message|type a message|\bEsc\b.*interrupt/i.test(frame) === false
+      ? /\n\s*›\s*$|\n\s*▌|send your message/i.test(frame)
+      : false;
+  }
+
+  /**
+   * Stateless per-tick evaluation. Returns KEEP unless EVERY gate clears with
+   * high confidence. Order: cheap protect-gates first (short-circuit), then the
+   * positive-idle + activeness checks.
+   */
+  evaluate(session: Session): SessionEvaluation {
+    const framework = session.framework ?? this.deps.frameworkForSession(session.tmuxSession);
+    const frame = safeCapture(this.deps, session.tmuxSession, this.cfg.paneCaptureLines);
+    const transcript = this.probe(session);
+
+    const keep = (reason: string, confidence: Confidence = 'high'): SessionEvaluation =>
+      ({ verdict: 'keep', keptBy: reason, confidence, frame, transcript });
+
+    // A. Protected set
+    if (this.deps.protectedSessions().includes(session.tmuxSession)) return keep('protected');
+    // M. Spawn grace
+    const ageMs = this.now() - Date.parse(session.startedAt);
+    if (!(ageMs >= this.cfg.minAgeMinutes * 60_000)) return keep('spawn-grace');
+    // G. Recovery in flight
+    if (this.deps.isRecoveryActive(session)) return keep('recovery-in-flight');
+    // H. Pending injection / relay lease
+    if (this.deps.hasPendingInjection(session.tmuxSession)) return keep('pending-injection');
+    if (this.deps.isRelayLeaseActive(session.id)) return keep('relay-lease');
+
+    const topicId = this.deps.topicBinding(session.tmuxSession);
+    // I. Recent user interaction (topic unresolved while bound → cannot tell → KEEP)
+    if (topicId != null && this.deps.recentUserMessage(topicId, this.cfg.recentUserWindowMinutes * 60_000)) {
+      return keep('recent-user-message');
+    }
+    // J. Open commitment on the bound topic
+    if (this.cfg.protectOpenCommitments && topicId != null && this.deps.activeCommitmentForTopic(topicId)) {
+      return keep('open-commitment');
+    }
+    // K. Active subagent
+    if (this.deps.activeSubagentCount(session.claudeSessionId) > 0) return keep('active-subagent');
+    // L. Structural long-work (build/autonomous) on the topic/project
+    if (this.deps.buildOrAutonomousActive(topicId)) return keep('structural-long-work');
+
+    // ── Activeness (positive-evidence) ──
+    // C. Process tree: any non-baseline child ⇒ working.
+    if (this.deps.hasActiveProcesses(session.tmuxSession)) return keep('active-process');
+    // C(main): main-process CPU/IO delta. undefined ⇒ cannot inspect ⇒ KEEP.
+    if (this.deps.mainProcessActive) {
+      const mp = this.deps.mainProcessActive(session.tmuxSession);
+      if (mp === undefined) return keep('process-uninspectable', 'low');
+      if (mp === true) return keep('main-process-active');
+    }
+    // E. Transcript growth this tick (vs last tick). 'grew' ⇒ working;
+    //    'unknown' (unresolved/rotated) ⇒ KEEP.
+    const prev = this.obs.get(session.id)?.lastTranscript;
+    if (prev) {
+      const delta = transcriptDelta(prev, transcript);
+      if (delta === 'grew') return keep('transcript-grew');
+      if (delta === 'unknown') return keep('transcript-unresolved', 'low');
+    } else if (!transcript.resolved) {
+      // First sighting with an unresolvable transcript: cannot prove idle. KEEP.
+      return keep('transcript-unresolved', 'low');
+    }
+    // (1) Positive idle proof — REQUIRED. No positive ready-prompt ⇒ KEEP.
+    if (!SessionReaper.isPositivelyIdle(framework, frame)) return keep('no-positive-idle');
+
+    // All gates clear: this tick the session is a reap candidate.
+    return { verdict: 'reap-eligible', keptBy: 'all-clear', confidence: 'high', frame, transcript };
+  }
+
+  /** Active idle threshold (ms) for the current pressure tier. */
+  private thresholdMs(tier: PressureTier): number | null {
+    if (tier === 'normal') return this.cfg.normalTierReaps ? this.cfg.idleThresholdModerateMinutes * 60_000 : null;
+    if (tier === 'moderate') return this.cfg.idleThresholdModerateMinutes * 60_000;
+    return this.cfg.idleThresholdCriticalMinutes * 60_000;
+  }
+
+  private hourlyBudgetRemaining(): number {
+    const cutoff = this.now() - 3_600_000;
+    this.reapTimestamps = this.reapTimestamps.filter(t => t >= cutoff);
+    return this.cfg.maxReapsPerHour - this.reapTimestamps.length;
+  }
+
+  async tick(): Promise<void> {
+    if (!this.cfg.enabled || this.running) return;
+    this.running = true;
+    this.lastTickAt = this.now();
+    try {
+      const pressure = this.deps.pressure();
+      const threshold = this.thresholdMs(pressure.tier);
+      const sessions = this.deps.listRunningSessions();
+      const live = new Set(sessions.map(s => s.id));
+      // GC obs for vanished sessions.
+      for (const id of [...this.obs.keys()]) if (!live.has(id)) { this.obs.delete(id); this.deps.clearReaping(id); }
+
+      let reapedThisTick = 0;
+      for (const session of sessions) {
+        const evaln = this.evaluate(session);
+        const prior = this.obs.get(session.id);
+        const now = this.now();
+
+        if (evaln.verdict === 'keep') {
+          // Any non-candidate observation resets candidacy + aborts reap-pending.
+          if (prior?.reapPendingSince != null) {
+            this.deps.clearReaping(session.id);
+            this.audit('reap-aborted', session, { keptBy: evaln.keptBy });
+          }
+          this.obs.set(session.id, { candidateSince: 0, consecutive: 0, lastFrame: evaln.frame, lastTranscript: evaln.transcript });
+          continue;
+        }
+
+        // Candidate this tick. Render-stasis: the frame must be byte-identical
+        // to last tick. A changed frame ⇒ activity ⇒ reset candidacy.
+        const frameStatic = prior != null && prior.consecutive > 0 && prior.lastFrame === evaln.frame;
+
+        // If we were reap-pending and the frame is no longer static, the session
+        // rendered something during the grace window — abort the reap (§3.5).
+        if (prior?.reapPendingSince != null && !frameStatic) {
+          this.deps.clearReaping(session.id);
+          this.audit('reap-aborted', session, { reason: 'frame-changed-during-grace' });
+          this.obs.set(session.id, { candidateSince: now, consecutive: 1, lastFrame: evaln.frame, lastTranscript: evaln.transcript });
+          continue;
+        }
+
+        const consecutive = frameStatic ? prior!.consecutive + 1 : 1;
+        const candidateSince = frameStatic && prior!.candidateSince ? prior!.candidateSince : now;
+        const next: Obs = { candidateSince, consecutive, lastFrame: evaln.frame, lastTranscript: evaln.transcript, reapPendingSince: prior?.reapPendingSince };
+
+        // Two-phase: if already reap-pending, see if the grace window elapsed.
+        if (next.reapPendingSince != null) {
+          if (now - next.reapPendingSince >= this.cfg.finalGraceSec * 1000) {
+            // Final confirmation already passed THIS tick's full classifier
+            // (we're here ⇒ still reap-eligible + render-static). Terminate.
+            if (threshold != null && reapedThisTick < this.cfg.maxReapsPerTick && this.hourlyBudgetRemaining() > 0) {
+              await this.performReap(session, pressure, next);
+              reapedThisTick++;
+            }
+            this.obs.set(session.id, { ...next, reapPendingSince: undefined });
+          } else {
+            this.obs.set(session.id, next); // keep waiting out the grace window
+          }
+          continue;
+        }
+
+        // Not yet reap-pending. Need: hysteresis satisfied + idle past threshold
+        // + pressure tier permits reaping + budget available.
+        const hysteresisOk = consecutive >= this.cfg.confirmObservations
+          && (now - candidateSince) >= this.cfg.confirmWindowMinutes * 60_000;
+        const idleMs = now - candidateSince;
+        if (threshold != null && hysteresisOk && idleMs >= threshold
+            && reapedThisTick < this.cfg.maxReapsPerTick && this.hourlyBudgetRemaining() > 0) {
+          // Enter reap-pending (two-phase). Lease the session so idle-kill won't
+          // race us; terminate on a later tick after the grace window.
+          next.reapPendingSince = now;
+          this.deps.markReaping(session.id);
+          this.audit('reap-pending', session, { tier: pressure.tier, idleMs, thresholdMs: threshold });
+        }
+        this.obs.set(session.id, next);
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async performReap(session: Session, pressure: PressureReading, obs: Obs): Promise<void> {
+    const detail = { tier: pressure.tier, idleMs: this.now() - obs.candidateSince, dryRun: !this.killsEnabled };
+    if (!this.killsEnabled) {
+      this.audit('would-reap', session, detail); // dry-run: log, do not kill
+      this.deps.clearReaping(session.id);
+      return;
+    }
+    try {
+      const r = await this.deps.terminate(session.id, 'reaped-idle');
+      if (r.terminated) {
+        this.reapTimestamps.push(this.now());
+        this.audit('reaped', session, detail);
+        this.emit('reaped', session);
+      } else {
+        // Ambiguous outcome (already gone, protected, in-flight) — fail safe.
+        this.autoDisabled = true;
+        this.audit('reap-skipped-auto-disable', session, { ...detail, skipped: r.skipped });
+        this.emit('auto-disabled', { session, reason: r.skipped });
+      }
+    } catch (err) {
+      this.autoDisabled = true;
+      this.audit('reap-failed-auto-disable', session, { ...detail, error: err instanceof Error ? err.message : String(err) });
+      this.emit('auto-disabled', { session, reason: 'error' });
+    } finally {
+      this.deps.clearReaping(session.id);
+    }
+  }
+
+  private audit(event: string, session: Session, detail: Record<string, unknown>): void {
+    const entry = { ts: new Date(this.now()).toISOString(), kind: 'session-reaper', event, session: session.name, sessionId: session.id, ...detail };
+    if (this.deps.audit) this.deps.audit(entry);
+  }
+
+  /** Observability snapshot for GET /sessions/reaper. */
+  snapshot(): {
+    enabled: boolean; dryRun: boolean; autoDisabled: boolean; lastTickAt: number;
+    pressure: PressureReading; activeThresholdMinutes: number | null;
+    reapsLastHour: number;
+    sessions: Array<{ name: string; sessionId: string; verdict: Verdict; keptBy: string; confidence: Confidence; consecutive: number; idleMs: number; reapPending: boolean }>;
+  } {
+    const pressure = this.deps.pressure();
+    const threshold = this.thresholdMs(pressure.tier);
+    const now = this.now();
+    const sessions = this.deps.listRunningSessions().map(s => {
+      const e = this.evaluate(s);
+      const o = this.obs.get(s.id);
+      return {
+        name: s.name, sessionId: s.id, verdict: e.verdict, keptBy: e.keptBy, confidence: e.confidence,
+        consecutive: o?.consecutive ?? 0, idleMs: o?.candidateSince ? now - o.candidateSince : 0,
+        reapPending: o?.reapPendingSince != null,
+      };
+    });
+    return {
+      enabled: this.cfg.enabled, dryRun: this.cfg.dryRun || this.autoDisabled, autoDisabled: this.autoDisabled,
+      lastTickAt: this.lastTickAt, pressure,
+      activeThresholdMinutes: threshold == null ? null : Math.round(threshold / 60_000),
+      reapsLastHour: this.cfg.maxReapsPerHour - this.hourlyBudgetRemaining(),
+      sessions,
+    };
+  }
+}
+
+function safeCapture(deps: SessionReaperDeps, tmuxSession: string, lines: number): string {
+  try { return deps.captureOutput(tmuxSession, lines) ?? ''; } catch { return ''; }
+}
+
+/** Default audit sink: append one JSON line to logs/sentinel-events.jsonl. */
+export function fileAuditSink(stateDir: string): (event: Record<string, unknown>) => void {
+  const logPath = path.join(stateDir, '..', 'logs', 'sentinel-events.jsonl');
+  return (event: Record<string, unknown>) => {
+    try {
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      fs.appendFileSync(logPath, JSON.stringify(event) + '\n');
+    } catch { /* never throw from the audit sink */ }
+  };
+}

--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -815,6 +815,31 @@ export class TokenLedger {
     }));
   }
 
+  /**
+   * Token activity for ONE session since a timestamp — gate F of the
+   * SessionReaper (SESSION-REAPER-SPEC §3.1(3)). A lagging corroborator only:
+   * the poller scans flushed JSONL on a ~60s cadence, so a positive result is
+   * reliable but absence does NOT prove idleness. Keyed on the Claude Code
+   * session_id; callers pass `claudeSessionId` (absent ⇒ they must KEEP).
+   */
+  sessionActivitySince(sessionId: string, sinceMs: number): { eventCount: number; tokens: number; lastTs: number } {
+    const row = this.db
+      .prepare(
+        `SELECT
+           COUNT(*) AS eventCount,
+           COALESCE(SUM(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens), 0) AS tokens,
+           COALESCE(MAX(ts), 0) AS lastTs
+         FROM token_events
+         WHERE session_id = ? AND ts >= ?`,
+      )
+      .get(sessionId, sinceMs) as { eventCount: number; tokens: number; lastTs: number };
+    return {
+      eventCount: Number(row?.eventCount) || 0,
+      tokens: Number(row?.tokens) || 0,
+      lastTs: Number(row?.lastTs) || 0,
+    };
+  }
+
   /** Aggregate by project (cwd). */
   byProject({ sinceMs }: { sinceMs?: number } = {}): ProjectRow[] {
     const since = sinceMs ?? 0;

--- a/src/monitoring/transcriptProber.ts
+++ b/src/monitoring/transcriptProber.ts
@@ -1,0 +1,74 @@
+/**
+ * transcriptProber — per-framework transcript-growth probe for the SessionReaper.
+ *
+ * SESSION-REAPER-SPEC §3.1(3) "Transcript growth", gate E. The reaper must NEVER
+ * treat an *unresolvable* transcript as "quiet" — that was the v1 BLOCKER (the old
+ * CompactionSentinel probe hardcoded `~/.claude/projects`, so Codex sessions and
+ * sessions whose path could not be resolved silently read as no-growth and became
+ * reap-eligible). This wraps the already-per-framework
+ * {@link resolveFrameworkTranscriptPath} (Claude `~/.claude/projects`, Codex
+ * `~/.codex/sessions`) and makes the failure mode explicit: anything we cannot
+ * resolve-and-stat returns `resolved:false`, and {@link transcriptDelta} reports
+ * `'unknown'` for it — which the classifier maps to KEEP.
+ *
+ * Pure path resolution + a single stat. No mutation, no network.
+ */
+
+import * as fs from 'node:fs';
+import {
+  resolveFrameworkTranscriptPath,
+  type ResolveTranscriptOptions,
+} from '../core/FrameworkSessionStore.js';
+
+export interface TranscriptProbe {
+  /** True only if a path resolved AND statting it succeeded. */
+  readonly resolved: boolean;
+  /** Resolved path, or '' when no path could be resolved. */
+  readonly path: string;
+  /** File size in bytes (0 when unresolved). */
+  readonly size: number;
+  /** mtime in ms since epoch (0 when unresolved). */
+  readonly mtime: number;
+}
+
+const UNRESOLVED: TranscriptProbe = { resolved: false, path: '', size: 0, mtime: 0 };
+
+/**
+ * Resolve and stat a session's transcript. Returns `resolved:false` when the
+ * path cannot be resolved (no session id, Codex file not on disk yet, unknown
+ * framework) or the stat fails (missing / permission error). Callers MUST treat
+ * `resolved:false` as ambiguous → KEEP, never as "no activity".
+ */
+export function probeTranscript(opts: ResolveTranscriptOptions): TranscriptProbe {
+  const p = resolveFrameworkTranscriptPath(opts);
+  if (!p) return UNRESOLVED;
+  try {
+    const st = fs.statSync(p);
+    return { resolved: true, path: p, size: st.size, mtime: st.mtimeMs };
+  } catch {
+    // Path resolved but the file is missing / unreadable — still ambiguous.
+    return { resolved: false, path: p, size: 0, mtime: 0 };
+  }
+}
+
+export type TranscriptDelta = 'grew' | 'static' | 'unknown';
+
+/**
+ * Compare two probes of the same session over an observation window.
+ *  - `'grew'`    — size or mtime advanced ⇒ the session produced output (WORKING).
+ *  - `'static'`  — both probes resolved, same file identity, no growth ⇒ quiet
+ *                  (high-confidence; safe to count toward idle).
+ *  - `'unknown'` — either probe unresolved, or the file identity changed
+ *                  (rotation / different path) ⇒ cannot tell ⇒ caller KEEPS.
+ */
+export function transcriptDelta(
+  baseline: TranscriptProbe,
+  current: TranscriptProbe,
+): TranscriptDelta {
+  if (!baseline.resolved || !current.resolved) return 'unknown';
+  // Path identity changed under us (rotation / re-resolution to a different
+  // file) — we cannot reason about growth across two different files.
+  if (current.path !== baseline.path) return 'unknown';
+  if (current.size > baseline.size || current.mtime > baseline.mtime) return 'grew';
+  return 'static';
+}

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -404,6 +404,12 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - List: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/sessions\`
 - Spawn: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/sessions/spawn -d '{"name":"task","prompt":"do something"}'\`
 
+**SessionReaper** — Pressure-aware cleanup of idle-but-alive sessions (sessions parked at a ready prompt, doing nothing, holding memory). Distinct from the crash/zombie reapers: it only acts when the machine is under memory pressure, and it NEVER reaps a session that might be working — it requires positive proof a session is idle (turn complete + at a ready prompt + screen byte-static across several checks + no running process + no transcript growth), and KEEPs on any ambiguity. Ships OFF + dry-run by default (the only monitor that kills on a heuristic).
+- Why it matters: idle sessions pile up across agents until the machine starves and new sessions get "spawn denied" — silently breaking cross-agent messaging. This sweeps them, but only under real pressure.
+- See current state / why each session is kept or flagged: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/sessions/reaper\`
+- Enable (after reviewing the dry-run log): in \`.instar/config.json\` set \`{"monitoring": {"sessionReaper": {"enabled": true, "dryRun": false}}}\`. Leave \`dryRun: true\` first to watch what it WOULD reap (logged to \`logs/sentinel-events.jsonl\`) without killing anything.
+- Proactive: user asks "why are sessions piling up?" / "clean up idle sessions" / "are we low on memory?" → GET /sessions/reaper for the pressure tier + per-session verdict.
+
 **Multi-Session Autonomy** — I can run multiple autonomous jobs at once, one per topic (default cap 5, set \`autonomousSessions.maxConcurrent\` in config). Each topic's job is isolated, survives restarts, and is keyed on its topic.
 - What's running: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/autonomous/sessions\`
 - The cap + budget gate is checked automatically when a job starts (\`GET /autonomous/can-start\`); a start is refused when at the cap or under budget pressure.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -212,6 +212,9 @@ export class AgentServer {
       api: import('../core/MachineHeartbeat.js').MachineHeartbeat;
       config: { machineId: string };
     };
+    /** SessionReaper — pressure-aware idle-session reaper (off/dry-run by
+     *  default). Powers GET /sessions/reaper. */
+    sessionReaper?: import('../monitoring/SessionReaper.js').SessionReaper;
     /** Threadline → Telegram bridge config — toggles + allow/deny list. */
     telegramBridgeConfig?: import('../threadline/TelegramBridgeConfig.js').TelegramBridgeConfig;
     /** Threadline → Telegram bridge — relay-only mirror of threadline messages. */
@@ -512,6 +515,7 @@ export class AgentServer {
       projectDriftChecker: options.projectDriftChecker ?? null,
       machineHeartbeat: options.machineHeartbeat ?? null,
       tokenLedger: this.tokenLedger,
+      sessionReaper: options.sessionReaper ?? null,
       telegramBridgeConfig: options.telegramBridgeConfig ?? null,
       telegramBridge: options.telegramBridge ?? null,
       threadlineObservability: options.threadlineObservability ?? null,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -659,6 +659,9 @@ export interface RouteContext {
   /** Token-usage ledger (read-only observability over Claude Code JSONL
    *  transcripts). Null when stateDir is unavailable. */
   tokenLedger: import('../monitoring/TokenLedger.js').TokenLedger | null;
+  /** SessionReaper — pressure-aware idle-session reaper. Null when not wired
+   *  (older boot paths). Powers GET /sessions/reaper observability. */
+  sessionReaper?: import('../monitoring/SessionReaper.js').SessionReaper | null;
   /** TaskFlow registry — durable multi-step job records (OpenClaw import).
    *  Null when not enabled. Phase 1: no business consumers; admin endpoints
    *  only. */
@@ -3703,6 +3706,17 @@ export function createRoutes(ctx: RouteContext): Router {
     } catch {
       res.json({ sessions: [] });
     }
+  });
+
+  // SessionReaper observability (SESSION-REAPER-SPEC §3.9). Answers
+  // "why did/didn't it reap X?" from a pull surface — pressure tier, active
+  // threshold, and every running session's verdict + the gate that kept it.
+  router.get('/sessions/reaper', (_req, res) => {
+    if (!ctx.sessionReaper) {
+      res.status(503).json({ error: 'session reaper unavailable' });
+      return;
+    }
+    res.json(ctx.sessionReaper.snapshot());
   });
 
   router.get('/sessions', (req, res) => {

--- a/tests/e2e/session-reaper-lifecycle.test.ts
+++ b/tests/e2e/session-reaper-lifecycle.test.ts
@@ -1,0 +1,157 @@
+/**
+ * E2E — SessionReaper on the PRODUCTION path.
+ *
+ *   Phase 1: GET /sessions/reaper returns 200 (not 503) through the REAL
+ *            AgentServer → RouteContext plumbing — the "dead on arrival" /
+ *            "wired-but-dropped (?? null)" guard.
+ *   Phase 2: the dangerous false-reap vectors from the converged review, driven
+ *            through the live wired reaper + asserted on the wire / via the
+ *            terminate spy: silent-but-working KEPT, unresolved-transcript
+ *            (Codex/no-claudeSessionId) KEPT, genuinely-idle REAPED under
+ *            Critical, frame-change-during-grace ABORTS.
+ *
+ * THE hard requirement (never reap a working session) is asserted end-to-end.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { SessionReaper, type SessionReaperDeps, type PressureTier } from '../../src/monitoring/SessionReaper.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig, Session } from '../../src/core/types.js';
+import type { TranscriptProbe } from '../../src/monitoring/transcriptProber.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const IDLE_FRAME = 'output\n? for shortcuts\n> ';
+
+function session(id: string, over: Partial<Session> = {}): Session {
+  return { id, name: id, status: 'running', tmuxSession: `t-${id}`, startedAt: new Date(0).toISOString(), framework: 'claude-code', claudeSessionId: `c-${id}`, ...over };
+}
+
+describe('SessionReaper E2E lifecycle', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+  let reaper: SessionReaper;
+  const AUTH_TOKEN = 'test-e2e-session-reaper';
+
+  // Mutable test state the reaper deps read.
+  let now = 1_000_000;
+  let frame = IDLE_FRAME;
+  let transcript: TranscriptProbe = { resolved: true, path: '/t.jsonl', size: 100, mtime: 1000 };
+  let tier: PressureTier = 'critical';
+  let sessions: Session[] = [session('s1')];
+  const terminate = vi.fn(async () => ({ terminated: true }));
+  const reaping = new Set<string>();
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-reaper-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e-test', agentName: 'E2E Test' }));
+
+    const deps: SessionReaperDeps = {
+      listRunningSessions: () => sessions,
+      captureOutput: () => frame,
+      hasActiveProcesses: () => false,
+      frameworkForSession: () => 'claude-code',
+      probeTranscript: () => transcript,
+      isRecoveryActive: () => false,
+      isRelayLeaseActive: () => false,
+      hasPendingInjection: () => false,
+      topicBinding: () => null,
+      recentUserMessage: () => false,
+      activeCommitmentForTopic: () => false,
+      activeSubagentCount: () => 0,
+      buildOrAutonomousActive: () => false,
+      protectedSessions: () => [],
+      pressure: () => ({ tier }),
+      terminate,
+      markReaping: (id) => reaping.add(id),
+      clearReaping: (id) => reaping.delete(id),
+      now: () => now,
+    };
+    // Constructed the SAME way server.ts wires it (config-driven), enabled.
+    reaper = new SessionReaper(deps, {
+      enabled: true, dryRun: false, minAgeMinutes: 0, confirmObservations: 2,
+      confirmWindowMinutes: 0, idleThresholdCriticalMinutes: 0, finalGraceSec: 1,
+    });
+
+    const config: InstarConfig = {
+      projectName: 'e2e-test', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH_TOKEN,
+      requestTimeoutMs: 10000, version: '0.10.3',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    };
+    const state = new StateManager(stateDir);
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state, sessionReaper: reaper });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    reaper?.stop();
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/session-reaper-lifecycle.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH_TOKEN}` });
+  const reset = () => { now = 1_000_000; frame = IDLE_FRAME; transcript = { resolved: true, path: '/t.jsonl', size: 100, mtime: 1000 }; tier = 'critical'; sessions = [session('s1')]; reaping.clear(); terminate.mockClear(); (reaper as any).obs?.clear?.(); };
+
+  describe('Phase 1: feature is alive (not 503)', () => {
+    it('GET /sessions/reaper returns 200 with a snapshot through the real AgentServer plumbing', async () => {
+      const res = await request(app).get('/sessions/reaper').set(auth());
+      expect(res.status).toBe(200);
+      expect(res.body.enabled).toBe(true);
+      expect(res.body.pressure).toBeDefined();
+      expect(Array.isArray(res.body.sessions)).toBe(true);
+    });
+  });
+
+  describe('Phase 2: never reap a working session (end-to-end)', () => {
+    it('KEEPs a silent-but-working session (transcript grew between ticks)', async () => {
+      reset();
+      await reaper.tick();
+      transcript = { ...transcript, size: 9999 }; // produced output → working
+      now = 1_120_000; await reaper.tick();
+      now = 1_240_000; await reaper.tick();
+      expect(terminate).not.toHaveBeenCalled();
+    });
+
+    it('KEEPs a session whose transcript is unresolved (Codex / no claudeSessionId)', async () => {
+      reset();
+      transcript = { resolved: false, path: '', size: 0, mtime: 0 };
+      for (let i = 0; i < 4; i++) { now = 1_000_000 + i * 120_000; await reaper.tick(); }
+      expect(terminate).not.toHaveBeenCalled();
+      const res = await request(app).get('/sessions/reaper').set(auth());
+      expect(res.body.sessions[0].verdict).toBe('keep');
+    });
+
+    it('REAPS a genuinely-idle, render-static session under Critical pressure', async () => {
+      reset();
+      now = 1_000_000; await reaper.tick();
+      now = 1_120_000; await reaper.tick();
+      now = 1_240_000; await reaper.tick();
+      expect(terminate).toHaveBeenCalledWith('s1', 'reaped-idle');
+    });
+
+    it('ABORTS the reap when the pane changes during the grace window', async () => {
+      reset();
+      now = 1_000_000; await reaper.tick();
+      now = 1_120_000; await reaper.tick();   // reap-pending
+      expect(reaping.has('s1')).toBe(true);
+      frame = IDLE_FRAME + '\nnew render!';   // activity during grace
+      now = 1_240_000; await reaper.tick();
+      expect(terminate).not.toHaveBeenCalled();
+      expect(reaping.has('s1')).toBe(false);
+    });
+  });
+});

--- a/tests/integration/session-reaper-routes.test.ts
+++ b/tests/integration/session-reaper-routes.test.ts
@@ -1,0 +1,112 @@
+/**
+ * GET /sessions/reaper through the real createRoutes pipeline.
+ *  - 503 when the reaper is not wired.
+ *  - 200 with the snapshot (pressure tier + per-session verdicts) when present.
+ *  - Dry-run end-to-end: a reap-eligible session is logged-but-not-killed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { SessionReaper, type SessionReaperDeps } from '../../src/monitoring/SessionReaper.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { Session } from '../../src/core/types.js';
+
+function ctxWith(stateDir: string, reaper: SessionReaper | null): RouteContext {
+  return {
+    config: { projectName: 'test', projectDir: path.dirname(stateDir), stateDir, port: 0, sessions: {} as any, scheduler: {} as any } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null, listSessions: () => [] } as any,
+    tokenLedger: null,
+    sessionReaper: reaper,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function reaperDeps(sessions: Session[]): SessionReaperDeps {
+  return {
+    listRunningSessions: () => sessions,
+    captureOutput: () => 'output\n? for shortcuts\n> ',
+    hasActiveProcesses: () => false,
+    frameworkForSession: () => 'claude-code',
+    probeTranscript: () => ({ resolved: true, path: '/t', size: 1, mtime: 1 }),
+    isRecoveryActive: () => false,
+    isRelayLeaseActive: () => false,
+    hasPendingInjection: () => false,
+    topicBinding: () => null,
+    recentUserMessage: () => false,
+    activeCommitmentForTopic: () => false,
+    activeSubagentCount: () => 0,
+    buildOrAutonomousActive: () => false,
+    protectedSessions: () => [],
+    pressure: () => ({ tier: 'critical' }),
+    terminate: async () => ({ terminated: true }),
+    markReaping: () => {},
+    clearReaping: () => {},
+  };
+}
+
+describe('GET /sessions/reaper (integration)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reaper-routes-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/session-reaper-routes.test.ts' });
+  });
+
+  function appWith(reaper: SessionReaper | null): express.Express {
+    const app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctxWith(stateDir, reaper)));
+    return app;
+  }
+
+  it('returns 503 when the reaper is not wired', async () => {
+    const res = await request(appWith(null)).get('/sessions/reaper');
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/unavailable/);
+  });
+
+  it('returns 200 with a snapshot when the reaper is present', async () => {
+    const session: Session = {
+      id: 's1', name: 'sess', status: 'running', tmuxSession: 't1',
+      startedAt: new Date(0).toISOString(), framework: 'claude-code', claudeSessionId: 'c1',
+    };
+    const reaper = new SessionReaper(reaperDeps([session]), { enabled: true });
+    const res = await request(appWith(reaper)).get('/sessions/reaper');
+    expect(res.status).toBe(200);
+    expect(res.body.pressure.tier).toBe('critical');
+    expect(Array.isArray(res.body.sessions)).toBe(true);
+    expect(res.body.sessions[0].name).toBe('sess');
+    expect(['keep', 'reap-eligible']).toContain(res.body.sessions[0].verdict);
+  });
+
+  it('dry-run snapshot reports dryRun:true and never reaps', async () => {
+    const session: Session = {
+      id: 's1', name: 'sess', status: 'running', tmuxSession: 't1',
+      startedAt: new Date(0).toISOString(), framework: 'claude-code', claudeSessionId: 'c1',
+    };
+    let killed = 0;
+    const deps = reaperDeps([session]);
+    deps.terminate = async () => { killed++; return { terminated: true }; };
+    const reaper = new SessionReaper(deps, {
+      enabled: true, dryRun: true, minAgeMinutes: 0, confirmObservations: 1,
+      confirmWindowMinutes: 0, idleThresholdCriticalMinutes: 0, finalGraceSec: 0,
+    });
+    // Drive a few ticks; in dry-run nothing must be killed.
+    for (let i = 0; i < 4; i++) await reaper.tick();
+    const res = await request(appWith(reaper)).get('/sessions/reaper');
+    expect(res.status).toBe(200);
+    expect(res.body.dryRun).toBe(true);
+    expect(killed).toBe(0);
+  });
+});

--- a/tests/unit/ConfigDefaults.test.ts
+++ b/tests/unit/ConfigDefaults.test.ts
@@ -34,6 +34,35 @@ describe('ConfigDefaults', () => {
       expect((defaults.monitoring as any).quotaTracking).toBe(true);
     });
 
+    it('ships SessionReaper OFF + dry-run by default (the only kill-on-heuristic monitor)', () => {
+      for (const t of ['managed-project', 'standalone'] as const) {
+        const sr = (getInitDefaults(t).monitoring as any).sessionReaper;
+        expect(sr).toBeDefined();
+        expect(sr.enabled).toBe(false);
+        expect(sr.dryRun).toBe(true);
+        expect(sr.normalTierReaps).toBe(false);
+        expect(sr.protectOpenCommitments).toBe(true);
+      }
+      // Migration parity: existing agents receive the (off) block on update.
+      const mig = getMigrationDefaults('managed-project');
+      expect((mig.monitoring as any).sessionReaper?.enabled).toBe(false);
+    });
+
+    it('migrates the sessionReaper block into a config that lacks it (existence-checked)', () => {
+      const config: any = { monitoring: { watchdog: { enabled: true } } };
+      const { patched, changes } = applyDefaults(config, getMigrationDefaults('managed-project'));
+      expect(patched).toBe(true);
+      expect(config.monitoring.sessionReaper.enabled).toBe(false);
+      expect(changes.some((c: string) => c.includes('sessionReaper'))).toBe(true);
+    });
+
+    it('does NOT overwrite an operator-enabled sessionReaper on migration', () => {
+      const config: any = { monitoring: { sessionReaper: { enabled: true, dryRun: false } } };
+      applyDefaults(config, getMigrationDefaults('managed-project'));
+      expect(config.monitoring.sessionReaper.enabled).toBe(true);
+      expect(config.monitoring.sessionReaper.dryRun).toBe(false);
+    });
+
     it('includes externalOperations', () => {
       const defaults = getInitDefaults('managed-project');
       expect(defaults.externalOperations).toBeDefined();

--- a/tests/unit/session-manager-terminate.test.ts
+++ b/tests/unit/session-manager-terminate.test.ts
@@ -1,0 +1,179 @@
+/**
+ * SessionManager.terminateSession — the single-writer kill path
+ * (SESSION-REAPER-SPEC §3.6). Verifies compare-and-set idempotency,
+ * exactly-once event emission, protected-session refusal, the reaping lease,
+ * and the relay-lease accessor.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const mockTmuxSessions = new Set<string>();
+
+vi.mock('node:child_process', () => {
+  const handle = (args?: string[]) => {
+    if (!args) return '';
+    if (args[0] === 'new-session') {
+      const sIdx = args.indexOf('-s');
+      if (sIdx >= 0 && args[sIdx + 1]) mockTmuxSessions.add(args[sIdx + 1]);
+      return '';
+    }
+    if (args[0] === 'kill-session') {
+      const target = args[2]?.replace(/^=/, '');
+      if (target) mockTmuxSessions.delete(target);
+      return '';
+    }
+    if (args[0] === 'has-session') {
+      const target = args[2]?.replace(/^=/, '');
+      if (target && !mockTmuxSessions.has(target)) throw new Error('no session');
+      return '';
+    }
+    return '';
+  };
+  return {
+    execFileSync: vi.fn().mockImplementation((_cmd: string, args?: string[]) => handle(args)),
+    execFile: vi.fn().mockImplementation(
+      (_cmd: string, args: string[], _opts: unknown, cb?: (e: Error | null, r: { stdout: string }) => void) => {
+        if (typeof _opts === 'function') cb = _opts as typeof cb;
+        try { const out = handle(args); if (cb) cb(null, { stdout: String(out) }); }
+        catch (e) { if (cb) cb(e as Error, { stdout: '' }); }
+      },
+    ),
+  };
+});
+
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+
+describe('SessionManager.terminateSession (single-writer CAS)', () => {
+  let tmpDir: string;
+  let state: StateManager;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-terminate-'));
+    const stateDir = path.join(tmpDir, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    state = new StateManager(stateDir);
+    const config: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/local/bin/claude',
+      projectDir: tmpDir,
+      maxSessions: 5,
+      protectedSessions: ['my-project-server'],
+      completionPatterns: ['Session complete'],
+    };
+    manager = new SessionManager(config, state);
+    mockTmuxSessions.clear();
+  });
+
+  afterEach(() => {
+    manager.stopMonitoring();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/session-manager-terminate.test.ts' });
+  });
+
+  const spawn = (name: string) => manager.spawnSession({ name, prompt: 'p' });
+
+  it('terminates a running session exactly once, sets endedReason, emits sessionComplete once', async () => {
+    const s = await spawn('job-a');
+    let completeCount = 0;
+    let beforeCount = 0;
+    manager.on('sessionComplete', () => { completeCount++; });
+    manager.on('beforeSessionKill', () => { beforeCount++; });
+
+    const r1 = await manager.terminateSession(s.id, 'reaped-idle');
+    expect(r1.terminated).toBe(true);
+    expect(completeCount).toBe(1);
+    expect(beforeCount).toBe(1);
+
+    const saved = state.getSession(s.id)!;
+    expect(saved.status).toBe('completed');
+    expect(saved.endedReason).toBe('reaped-idle');
+    expect(saved.endedAt).toBeTruthy();
+  });
+
+  it('is idempotent — a second terminate is a no-op (CAS on already-terminal)', async () => {
+    const s = await spawn('job-b');
+    let completeCount = 0;
+    manager.on('sessionComplete', () => { completeCount++; });
+
+    const r1 = await manager.terminateSession(s.id, 'reaped-idle');
+    const r2 = await manager.terminateSession(s.id, 'reaped-idle');
+    expect(r1.terminated).toBe(true);
+    expect(r2.terminated).toBe(false);
+    expect(r2.skipped).toBe('already-completed');
+    expect(completeCount).toBe(1); // exactly once across both calls
+  });
+
+  it('refuses to terminate a protected session', async () => {
+    // Manually persist a protected session record.
+    const protectedSession = {
+      id: 'prot-1', name: 'server', status: 'running' as const,
+      tmuxSession: 'my-project-server', startedAt: new Date().toISOString(), prompt: 'p',
+    };
+    state.saveSession(protectedSession);
+    const r = await manager.terminateSession('prot-1', 'reaped-idle');
+    expect(r.terminated).toBe(false);
+    expect(r.skipped).toBe('protected');
+    expect(state.getSession('prot-1')!.status).toBe('running');
+  });
+
+  it('returns not-found for an unknown session', async () => {
+    const r = await manager.terminateSession('does-not-exist', 'reaped-idle');
+    expect(r).toEqual({ terminated: false, skipped: 'not-found' });
+  });
+
+  it('concurrent terminate calls kill once (in-flight guard / no double-emit)', async () => {
+    const s = await spawn('job-c');
+    let completeCount = 0;
+    manager.on('sessionComplete', () => { completeCount++; });
+    const [a, b] = await Promise.all([
+      manager.terminateSession(s.id, 'reaped-idle'),
+      manager.terminateSession(s.id, 'idle-zombie'),
+    ]);
+    const terminatedCount = [a, b].filter(r => r.terminated).length;
+    expect(terminatedCount).toBe(1);
+    expect(completeCount).toBe(1);
+  });
+
+  it('reaping lease: markReaping/isReaping/clearReaping', async () => {
+    const s = await spawn('job-d');
+    expect(manager.isReaping(s.id)).toBe(false);
+    manager.markReaping(s.id);
+    expect(manager.isReaping(s.id)).toBe(true);
+    manager.clearReaping(s.id);
+    expect(manager.isReaping(s.id)).toBe(false);
+  });
+
+  it('terminate clears any reaping lease', async () => {
+    const s = await spawn('job-e');
+    manager.markReaping(s.id);
+    await manager.terminateSession(s.id, 'reaped-idle');
+    expect(manager.isReaping(s.id)).toBe(false);
+  });
+
+  it('isRelayLeaseActive reflects grant/expiry/clear', async () => {
+    const s = await spawn('job-f');
+    expect(manager.isRelayLeaseActive(s.id)).toBe(false);
+    manager.grantRelayLease(s.id, 60_000);
+    expect(manager.isRelayLeaseActive(s.id)).toBe(true);
+    manager.clearRelayLease(s.id);
+    expect(manager.isRelayLeaseActive(s.id)).toBe(false);
+    // expired lease reads inactive
+    manager.grantRelayLease(s.id, -1);
+    expect(manager.isRelayLeaseActive(s.id)).toBe(false);
+  });
+
+  it('killSession sets endedReason and is CAS-guarded against an already-terminated session', async () => {
+    const s = await spawn('job-g');
+    expect(manager.killSession(s.id)).toBe(true);
+    expect(state.getSession(s.id)!.status).toBe('killed');
+    expect(state.getSession(s.id)!.endedReason).toBe('manual-kill');
+    // second kill is a no-op (already terminal)
+    expect(manager.killSession(s.id)).toBe(false);
+  });
+});

--- a/tests/unit/session-manager-terminate.test.ts
+++ b/tests/unit/session-manager-terminate.test.ts
@@ -168,12 +168,14 @@ describe('SessionManager.terminateSession (single-writer CAS)', () => {
     expect(manager.isRelayLeaseActive(s.id)).toBe(false);
   });
 
-  it('killSession sets endedReason and is CAS-guarded against an already-terminated session', async () => {
+  it('killSession sets endedReason and preserves its unconditional-kill contract', async () => {
     const s = await spawn('job-g');
     expect(manager.killSession(s.id)).toBe(true);
     expect(state.getSession(s.id)!.status).toBe('killed');
     expect(state.getSession(s.id)!.endedReason).toBe('manual-kill');
-    // second kill is a no-op (already terminal)
-    expect(manager.killSession(s.id)).toBe(false);
+    // Contract preserved: killSession destroys the pane regardless of status
+    // (it does NOT early-return on terminal status — only the in-flight guard
+    // protects against racing terminateSession).
+    expect(manager.killSession(s.id)).toBe(true);
   });
 });

--- a/tests/unit/session-reaper-wiring.test.ts
+++ b/tests/unit/session-reaper-wiring.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Wiring-integrity guard for the SessionReaper (lesson: PR #334 shipped
+ * sentinels as dead code with a false "wired in" claim — green unit tests are
+ * not proof of instantiation). Asserts the construct → start → pass-to-server
+ * chain in the boot path, and the AgentServer → RouteContext hand-off. The
+ * runtime "feature is alive (200 not 503)" proof lives in the e2e suite.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (p: string) => fs.readFileSync(path.join(root, p), 'utf8');
+
+describe('SessionReaper wiring integrity', () => {
+  it('server.ts constructs the reaper, starts it, and passes it to AgentServer', () => {
+    const src = read('src/commands/server.ts');
+    expect(src).toContain('new SessionReaper(');
+    expect(src).toContain('sessionReaper.start()');
+    // Passed into the AgentServer options object (the dead-code guard).
+    expect(/new AgentServer\(\{[\s\S]*sessionReaper[\s\S]*\}\)/.test(src)).toBe(true);
+  });
+
+  it('server.ts composes socket+silence into the recovery veto (compose, not replace)', () => {
+    const src = read('src/commands/server.ts');
+    expect(src).toContain('socketRecoveryActive');
+    expect(src).toContain('silenceRecoveryActive');
+    expect(src).toContain('composedRecoveryActive');
+    // The composed predicate must still include compaction + rate-limit.
+    expect(/composedRecoveryActive[\s\S]{0,400}compactionSentinel\.isRecoveryActive/.test(src)).toBe(true);
+    expect(/composedRecoveryActive[\s\S]{0,400}rateLimitSentinel\.isRecoveryActive/.test(src)).toBe(true);
+  });
+
+  it('AgentServer threads options.sessionReaper into the route context', () => {
+    const src = read('src/server/AgentServer.ts');
+    expect(src).toContain('sessionReaper: options.sessionReaper ?? null');
+  });
+
+  it('routes.ts exposes GET /sessions/reaper backed by ctx.sessionReaper', () => {
+    const src = read('src/server/routes.ts');
+    expect(src).toContain("router.get('/sessions/reaper'");
+    expect(src).toContain('ctx.sessionReaper.snapshot()');
+  });
+});

--- a/tests/unit/session-reaper.test.ts
+++ b/tests/unit/session-reaper.test.ts
@@ -274,6 +274,30 @@ describe('SessionReaper — dry-run and blast radius', () => {
     await driveToReap(h);
     expect(h.terminate).toHaveBeenCalledTimes(1); // budget caps the 2nd
   });
+
+  it('releases the reaping lease when a matured reap is budget-gated (no idle-kill lockout)', async () => {
+    const sessions = [mkSession({ id: 'a', tmuxSession: 'ta' }), mkSession({ id: 'b', tmuxSession: 'tb' })];
+    const h = harness({ sessions, cfg: { maxReapsPerHour: 1, maxReapsPerTick: 5 } });
+    await driveToReap(h);
+    // One reaped; the budget-gated one must NOT keep its reaping lease.
+    expect(h.terminate).toHaveBeenCalledTimes(1);
+    expect(h.reaping.size).toBe(0); // both leases released — no permanent lockout
+  });
+});
+
+describe('SessionReaper — robustness', () => {
+  it('KEEPs (never reaps) when a protect-signal throws during evaluation', async () => {
+    const h = harness({ deps: { isRecoveryActive: () => { throw new Error('boom'); } } });
+    for (let i = 0; i < 4; i++) { h.setNow(1_000_000 + i * 120_000); await h.reaper.tick(); }
+    expect(h.terminate).not.toHaveBeenCalled();
+  });
+
+  it('snapshot never throws when a protect-signal throws', () => {
+    const h = harness({ deps: { isRecoveryActive: () => { throw new Error('boom'); } } });
+    const snap = h.reaper.snapshot();
+    expect(snap.sessions[0].verdict).toBe('keep');
+    expect(snap.sessions[0].keptBy).toBe('eval-error');
+  });
 });
 
 describe('SessionReaper — observability', () => {

--- a/tests/unit/session-reaper.test.ts
+++ b/tests/unit/session-reaper.test.ts
@@ -1,0 +1,287 @@
+/**
+ * SessionReaper — the safety-critical classifier. THE hard requirement under
+ * test: NEVER reap a working session. Every protect-gate, the positive-idle
+ * requirement, the confidence contract (unresolved → KEEP), render-stasis,
+ * hysteresis, pressure tiers, the two-phase reap, dry-run, and the bounded
+ * blast radius + auto-disable.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  SessionReaper,
+  type SessionReaperDeps,
+  type SessionReaperConfig,
+  type PressureTier,
+  type PressureReading,
+} from '../../src/monitoring/SessionReaper.js';
+import type { Session } from '../../src/core/types.js';
+import type { TranscriptProbe } from '../../src/monitoring/transcriptProber.js';
+
+const IDLE_FRAME = 'some output\n? for shortcuts\n> ';
+const WORKING_FRAME = 'esc to interrupt\nWorking...';
+
+function mkSession(over: Partial<Session> = {}): Session {
+  return {
+    id: 's1', name: 'sess', status: 'running', tmuxSession: 't1',
+    startedAt: new Date(0).toISOString(), framework: 'claude-code', claudeSessionId: 'c1',
+    ...over,
+  };
+}
+
+const RESOLVED_STATIC: TranscriptProbe = { resolved: true, path: '/t.jsonl', size: 100, mtime: 1000 };
+
+interface Harness {
+  reaper: SessionReaper;
+  terminate: ReturnType<typeof vi.fn>;
+  audits: Array<Record<string, unknown>>;
+  setNow: (n: number) => void;
+  setFrame: (f: string) => void;
+  setTranscript: (p: TranscriptProbe) => void;
+  reaping: Set<string>;
+}
+
+function harness(opts: {
+  cfg?: Partial<SessionReaperConfig>;
+  deps?: Partial<SessionReaperDeps>;
+  sessions?: Session[];
+  tier?: PressureTier;
+} = {}): Harness {
+  let now = 1_000_000;
+  let frame = IDLE_FRAME;
+  let transcript = RESOLVED_STATIC;
+  const sessions = opts.sessions ?? [mkSession()];
+  const reaping = new Set<string>();
+  const audits: Array<Record<string, unknown>> = [];
+  const terminate = vi.fn(async () => ({ terminated: true }));
+  const pressure: PressureReading = { tier: opts.tier ?? 'critical' };
+
+  const deps: SessionReaperDeps = {
+    listRunningSessions: () => sessions.filter(s => s.status === 'running'),
+    captureOutput: () => frame,
+    hasActiveProcesses: () => false,
+    frameworkForSession: () => 'claude-code',
+    probeTranscript: () => transcript,
+    isRecoveryActive: () => false,
+    isRelayLeaseActive: () => false,
+    hasPendingInjection: () => false,
+    topicBinding: () => null,
+    recentUserMessage: () => false,
+    activeCommitmentForTopic: () => false,
+    activeSubagentCount: () => 0,
+    buildOrAutonomousActive: () => false,
+    protectedSessions: () => [],
+    pressure: () => pressure,
+    terminate,
+    markReaping: (id) => reaping.add(id),
+    clearReaping: (id) => reaping.delete(id),
+    now: () => now,
+    audit: (e) => audits.push(e),
+    ...opts.deps,
+  };
+
+  const cfg: Partial<SessionReaperConfig> = {
+    enabled: true, dryRun: false,
+    minAgeMinutes: 0, confirmObservations: 2, confirmWindowMinutes: 0,
+    idleThresholdCriticalMinutes: 0, idleThresholdModerateMinutes: 0,
+    finalGraceSec: 1, maxReapsPerTick: 3, maxReapsPerHour: 12,
+    ...opts.cfg,
+  };
+
+  return {
+    reaper: new SessionReaper(deps, cfg),
+    terminate, audits, reaping,
+    setNow: (n) => { now = n; },
+    setFrame: (f) => { frame = f; },
+    setTranscript: (p) => { transcript = p; },
+  };
+}
+
+/** Drive the reaper to a kill: 3 static-frame ticks (candidate→candidate→reap-pending matures). */
+async function driveToReap(h: Harness): Promise<void> {
+  h.setNow(1_000_000); await h.reaper.tick();           // tick1: consecutive=1
+  h.setNow(1_120_000); await h.reaper.tick();           // tick2: consecutive=2 → reap-pending
+  h.setNow(1_240_000); await h.reaper.tick();           // tick3: grace elapsed → terminate
+}
+
+describe('SessionReaper — protect-gates each force KEEP', () => {
+  const cases: Array<[string, Partial<SessionReaperDeps>, string]> = [
+    ['protected set', { protectedSessions: () => ['t1'] }, 'protected'],
+    ['recovery in flight', { isRecoveryActive: () => true }, 'recovery-in-flight'],
+    ['pending injection', { hasPendingInjection: () => true }, 'pending-injection'],
+    ['relay lease', { isRelayLeaseActive: () => true }, 'relay-lease'],
+    ['active process', { hasActiveProcesses: () => true }, 'active-process'],
+    ['active subagent', { activeSubagentCount: () => 1 }, 'active-subagent'],
+    ['build/autonomous', { buildOrAutonomousActive: () => true }, 'structural-long-work'],
+    ['recent user msg', { topicBinding: () => 42, recentUserMessage: () => true }, 'recent-user-message'],
+    ['open commitment', { topicBinding: () => 42, activeCommitmentForTopic: () => true }, 'open-commitment'],
+  ];
+  for (const [name, deps, expectedGate] of cases) {
+    it(`KEEPs on ${name}`, () => {
+      const h = harness({ deps });
+      const e = h.reaper.evaluate(mkSession());
+      expect(e.verdict).toBe('keep');
+      expect(e.keptBy).toBe(expectedGate);
+    });
+  }
+
+  it('KEEPs a freshly-spawned session (spawn grace)', () => {
+    const h = harness({ cfg: { minAgeMinutes: 30 }, sessions: [mkSession({ startedAt: new Date(Date.now()).toISOString() })] });
+    // now() is 1_000_000 ms; startedAt ~ Date.now() (much larger) → age negative → grace.
+    const e = h.reaper.evaluate(h.reaper['deps'].listRunningSessions()[0]);
+    expect(e.keptBy).toBe('spawn-grace');
+  });
+});
+
+describe('SessionReaper — positive-evidence & confidence contract', () => {
+  it('KEEPs when no positive idle prompt (absence of activity is NOT idle)', () => {
+    const h = harness();
+    h.setFrame('just some leftover output with no ready prompt');
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('keep');
+    expect(e.keptBy).toBe('no-positive-idle');
+  });
+
+  it('KEEPs when the pane shows an active-work marker (esc to interrupt)', () => {
+    const h = harness();
+    h.setFrame(WORKING_FRAME);
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('keep');
+  });
+
+  it('KEEPs when the transcript is unresolved (Codex/no-claudeSessionId)', () => {
+    const h = harness();
+    h.setTranscript({ resolved: false, path: '', size: 0, mtime: 0 });
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('keep');
+    expect(e.keptBy).toBe('transcript-unresolved');
+    expect(e.confidence).toBe('low');
+  });
+
+  it('KEEPs when main process is uninspectable (cannot inspect → KEEP)', () => {
+    const h = harness({ deps: { mainProcessActive: () => undefined } });
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.keptBy).toBe('process-uninspectable');
+  });
+
+  it('is reap-eligible only when ALL gates clear', () => {
+    const h = harness();
+    const e = h.reaper.evaluate(mkSession());
+    expect(e.verdict).toBe('reap-eligible');
+    expect(e.keptBy).toBe('all-clear');
+  });
+});
+
+describe('SessionReaper — transcript growth across ticks keeps a working session', () => {
+  it('KEEPs when the transcript grew between ticks (mid-generation, quiet pane)', async () => {
+    const h = harness();
+    h.setNow(1_000_000); await h.reaper.tick(); // baseline transcript captured
+    // transcript grows → working, even though pane is the idle frame
+    h.setTranscript({ ...RESOLVED_STATIC, size: 999 });
+    h.setNow(1_120_000); await h.reaper.tick();
+    h.setNow(1_240_000); await h.reaper.tick();
+    expect(h.terminate).not.toHaveBeenCalled();
+  });
+});
+
+describe('SessionReaper — render stasis', () => {
+  it('does NOT reap while the pane keeps changing (a thinking session twitches)', async () => {
+    const h = harness();
+    for (let i = 0; i < 6; i++) {
+      h.setFrame(IDLE_FRAME + `\n[tick ${i}]`); // frame changes each tick
+      h.setNow(1_000_000 + i * 120_000);
+      await h.reaper.tick();
+    }
+    expect(h.terminate).not.toHaveBeenCalled();
+  });
+
+  it('reaps a genuinely static, positively-idle session', async () => {
+    const h = harness();
+    await driveToReap(h);
+    expect(h.terminate).toHaveBeenCalledTimes(1);
+    expect(h.terminate).toHaveBeenCalledWith('s1', 'reaped-idle');
+  });
+});
+
+describe('SessionReaper — hysteresis', () => {
+  it('does NOT reap before confirmObservations consecutive ticks', async () => {
+    const h = harness({ cfg: { confirmObservations: 4 } });
+    h.setNow(1_000_000); await h.reaper.tick();
+    h.setNow(1_120_000); await h.reaper.tick();
+    h.setNow(1_240_000); await h.reaper.tick();
+    expect(h.terminate).not.toHaveBeenCalled(); // only 3 < 4 confirmations
+  });
+});
+
+describe('SessionReaper — pressure tiers', () => {
+  it('Normal tier reaps NOTHING (pure pressure-relief valve)', async () => {
+    const h = harness({ tier: 'normal', cfg: { normalTierReaps: false } });
+    for (let i = 0; i < 8; i++) { h.setNow(1_000_000 + i * 120_000); await h.reaper.tick(); }
+    expect(h.terminate).not.toHaveBeenCalled();
+  });
+
+  it('Critical tier reaps a static idle session', async () => {
+    const h = harness({ tier: 'critical' });
+    await driveToReap(h);
+    expect(h.terminate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SessionReaper — two-phase reap', () => {
+  it('marks reap-pending then terminates after the grace window', async () => {
+    const h = harness();
+    h.setNow(1_000_000); await h.reaper.tick();
+    h.setNow(1_120_000); await h.reaper.tick();
+    expect(h.reaping.has('s1')).toBe(true);       // reap-pending leased
+    expect(h.terminate).not.toHaveBeenCalled();   // not yet
+    h.setNow(1_240_000); await h.reaper.tick();
+    expect(h.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('ABORTS the reap if the pane changes during the grace window', async () => {
+    const h = harness();
+    h.setNow(1_000_000); await h.reaper.tick();
+    h.setNow(1_120_000); await h.reaper.tick(); // reap-pending
+    expect(h.reaping.has('s1')).toBe(true);
+    h.setFrame(IDLE_FRAME + '\nnew output!'); // session rendered something
+    h.setNow(1_240_000); await h.reaper.tick();
+    expect(h.terminate).not.toHaveBeenCalled();
+    expect(h.reaping.has('s1')).toBe(false); // lease released on abort
+  });
+});
+
+describe('SessionReaper — dry-run and blast radius', () => {
+  it('dry-run logs would-reap and does NOT terminate', async () => {
+    const h = harness({ cfg: { dryRun: true } });
+    await driveToReap(h);
+    expect(h.terminate).not.toHaveBeenCalled();
+    expect(h.audits.some(a => a.event === 'would-reap')).toBe(true);
+  });
+
+  it('auto-disables to dry-run after an ambiguous reap outcome', async () => {
+    const h = harness();
+    h.terminate.mockResolvedValueOnce({ terminated: false, skipped: 'already-completed' });
+    await driveToReap(h);
+    expect(h.audits.some(a => a.event === 'reap-skipped-auto-disable')).toBe(true);
+    // a subsequent maturity would be dry-run now
+    const snap = h.reaper.snapshot();
+    expect(snap.autoDisabled).toBe(true);
+    expect(snap.dryRun).toBe(true);
+  });
+
+  it('respects maxReapsPerHour across sessions', async () => {
+    const sessions = [mkSession({ id: 'a', tmuxSession: 'ta' }), mkSession({ id: 'b', tmuxSession: 'tb' })];
+    const h = harness({ sessions, cfg: { maxReapsPerHour: 1, maxReapsPerTick: 5 } });
+    await driveToReap(h);
+    expect(h.terminate).toHaveBeenCalledTimes(1); // budget caps the 2nd
+  });
+});
+
+describe('SessionReaper — observability', () => {
+  it('snapshot reports per-session verdict + the gate that kept it', () => {
+    const h = harness({ deps: { hasActiveProcesses: () => true } });
+    const snap = h.reaper.snapshot();
+    expect(snap.sessions[0].verdict).toBe('keep');
+    expect(snap.sessions[0].keptBy).toBe('active-process');
+    expect(snap.pressure.tier).toBe('critical');
+  });
+});

--- a/tests/unit/token-ledger.test.ts
+++ b/tests/unit/token-ledger.test.ts
@@ -382,3 +382,32 @@ describe('TokenLedger.scanAll bounded behavior', () => {
     ledger.close();
   });
 });
+
+describe('TokenLedger.sessionActivitySince (SessionReaper gate F)', () => {
+  let ledger: TokenLedger;
+  beforeEach(() => { ledger = makeLedger(); });
+  afterEach(() => { ledger.close(); });
+
+  it('returns counts/tokens/lastTs for events at or after sinceMs', () => {
+    const oldTs = '2026-04-29T20:00:00.000Z';
+    const newTs = '2026-04-29T21:00:00.000Z';
+    ledger.ingestLine(assistantLine({ requestId: 'r1', sessionId: 'sx', ts: oldTs, output: 10 }));
+    ledger.ingestLine(assistantLine({ requestId: 'r2', sessionId: 'sx', ts: newTs, output: 20 }));
+    const cutoff = Date.parse('2026-04-29T20:30:00.000Z');
+    const res = ledger.sessionActivitySince('sx', cutoff);
+    expect(res.eventCount).toBe(1); // only the newTs event
+    expect(res.tokens).toBeGreaterThan(0);
+    expect(res.lastTs).toBe(Date.parse(newTs));
+  });
+
+  it('returns zeros for an unknown session (caller must KEEP on absence)', () => {
+    const res = ledger.sessionActivitySince('never-seen', 0);
+    expect(res).toEqual({ eventCount: 0, tokens: 0, lastTs: 0 });
+  });
+
+  it('returns zeros when all events predate sinceMs', () => {
+    ledger.ingestLine(assistantLine({ requestId: 'r3', sessionId: 'sy', ts: '2026-04-29T20:00:00.000Z' }));
+    const res = ledger.sessionActivitySince('sy', Date.parse('2026-04-29T23:00:00.000Z'));
+    expect(res.eventCount).toBe(0);
+  });
+});

--- a/tests/unit/transcriptProber.test.ts
+++ b/tests/unit/transcriptProber.test.ts
@@ -1,0 +1,118 @@
+/**
+ * transcriptProber — gate E of the SessionReaper. The load-bearing safety
+ * property under test: an UNRESOLVABLE transcript is NEVER reported as quiet.
+ * It must read as `'unknown'` (→ classifier KEEPs), which is what makes Codex
+ * sessions and missing/rotated transcripts safe.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  probeTranscript,
+  transcriptDelta,
+  type TranscriptProbe,
+} from '../../src/monitoring/transcriptProber.js';
+
+describe('transcriptProber', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tprobe-'));
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/transcriptProber.test.ts' });
+  });
+
+  describe('probeTranscript', () => {
+    it('resolves and stats a Claude transcript', () => {
+      const root = path.join(tmp, 'claude');
+      const encoded = '-Users-justin-proj';
+      fs.mkdirSync(path.join(root, encoded), { recursive: true });
+      const file = path.join(root, encoded, 'sid-123.jsonl');
+      fs.writeFileSync(file, 'x'.repeat(100));
+      const probe = probeTranscript({
+        framework: 'claude-code',
+        sessionId: 'sid-123',
+        projectDir: '/Users/justin/proj',
+        rootOverride: root,
+      });
+      expect(probe.resolved).toBe(true);
+      expect(probe.size).toBe(100);
+      expect(probe.path).toBe(file);
+    });
+
+    it('resolves a Codex transcript under the date-partitioned tree', () => {
+      const root = path.join(tmp, 'codex');
+      const dDir = path.join(root, '2026', '05', '26');
+      fs.mkdirSync(dDir, { recursive: true });
+      const file = path.join(dDir, 'rollout-2026-05-26T08-00-00-abc-uuid.jsonl');
+      fs.writeFileSync(file, 'y'.repeat(42));
+      const probe = probeTranscript({
+        framework: 'codex-cli',
+        sessionId: 'abc-uuid',
+        projectDir: '/whatever',
+        rootOverride: root,
+      });
+      expect(probe.resolved).toBe(true);
+      expect(probe.size).toBe(42);
+    });
+
+    it('returns resolved:false when there is no session id (Codex/pre-hook)', () => {
+      const probe = probeTranscript({ framework: 'claude-code', sessionId: '', projectDir: '/x' });
+      expect(probe.resolved).toBe(false);
+      expect(probe.path).toBe('');
+    });
+
+    it('returns resolved:false when the Codex root has no matching file', () => {
+      const root = path.join(tmp, 'codex-empty');
+      fs.mkdirSync(root, { recursive: true });
+      const probe = probeTranscript({
+        framework: 'codex-cli',
+        sessionId: 'missing',
+        projectDir: '/x',
+        rootOverride: root,
+      });
+      expect(probe.resolved).toBe(false);
+    });
+
+    it('returns resolved:false when the resolved path is missing on disk', () => {
+      const root = path.join(tmp, 'claude2');
+      // resolver builds a deterministic path; do NOT create the file.
+      const probe = probeTranscript({
+        framework: 'claude-code',
+        sessionId: 'nope',
+        projectDir: '/p',
+        rootOverride: root,
+      });
+      expect(probe.resolved).toBe(false);
+    });
+  });
+
+  describe('transcriptDelta', () => {
+    const base = (over: Partial<TranscriptProbe>): TranscriptProbe => ({
+      resolved: true, path: '/t.jsonl', size: 100, mtime: 1000, ...over,
+    });
+
+    it('grew when size advances', () => {
+      expect(transcriptDelta(base({}), base({ size: 200 }))).toBe('grew');
+    });
+    it('grew when mtime advances', () => {
+      expect(transcriptDelta(base({}), base({ mtime: 2000 }))).toBe('grew');
+    });
+    it('static when resolved both times with no growth', () => {
+      expect(transcriptDelta(base({}), base({}))).toBe('static');
+    });
+    it('unknown when baseline unresolved — NEVER static', () => {
+      expect(transcriptDelta(base({ resolved: false }), base({}))).toBe('unknown');
+    });
+    it('unknown when current unresolved — NEVER static', () => {
+      expect(transcriptDelta(base({}), base({ resolved: false }))).toBe('unknown');
+    });
+    it('unknown when the file identity changed (rotation)', () => {
+      expect(transcriptDelta(base({ path: '/a.jsonl' }), base({ path: '/b.jsonl' }))).toBe('unknown');
+    });
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — NEXT
+
+<!-- bump: minor -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+**SessionReaper — pressure-aware cleanup of idle-but-alive sessions.** A new monitor that reaps sessions sitting idle at a ready prompt (holding memory) — but ONLY when the machine is under memory pressure, and it NEVER reaps a session that might be working. It requires *positive* proof of idleness (turn complete + at a ready prompt + screen byte-static across several checks + no running process + no transcript growth) and KEEPs on any ambiguity. Ships **OFF + dry-run by default** — the only monitor that kills on a heuristic, so it stays dark until an operator validates the dry-run log and opts in. Closes the gap behind the 2026-05-25 fleet pileup (idle sessions accumulated until the machine starved and cross-agent messaging silently failed because agents could no longer spawn).
+
+New read-only endpoint `GET /sessions/reaper` shows the live pressure tier and, per session, the verdict + the exact gate that kept it. `SessionManager` gains a single-writer `terminateSession()` so the existing idle-kill and the reaper can never double-kill. The zombie-kill recovery veto now also defers to the socket + silence sentinels.
+
+## What to Tell Your User
+
+- **Idle sessions get cleaned up under memory pressure — safely.** When your machine fills up with idle agent sessions, this sweeps them so new sessions (and incoming cross-agent messages) don't get refused. It will never reap a session that's actually working. It's off by default; ask me to turn it on after we watch its dry-run log.
+- **You won't notice anything unless you enable it.** No behavior change on update.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| SessionReaper (idle-session cleanup under pressure) | `monitoring.sessionReaper.enabled:true` (leave `dryRun:true` first). Off by default. |
+| Reaper observability | `GET /sessions/reaper` — pressure tier + per-session verdict + keptBy |
+| Single-writer session termination | `SessionManager.terminateSession()` — idle-kill + reaper share one CAS kill path |

--- a/upgrades/side-effects/session-reaper.md
+++ b/upgrades/side-effects/session-reaper.md
@@ -1,0 +1,33 @@
+# Side-Effects Review — SessionReaper
+
+Spec: `docs/specs/SESSION-REAPER-SPEC.md` (v2 CONVERGED + ratified). Build branch `build/session-reaper`.
+
+## What changes for a deployed agent
+
+- A new monitor (`SessionReaper`) is constructed and started at server boot. **Default OFF + dry-run** (`monitoring.sessionReaper.enabled:false, dryRun:true`), so deployed agents get **no behavior change** until an operator opts in. New config block arrives via the standard `ConfigDefaults`/`applyDefaults` migration; operator-set values are never overwritten.
+- New read-only endpoint `GET /sessions/reaper` (503 when unwired, 200 snapshot otherwise).
+- `SessionManager` gains `terminateSession()` (single-writer CAS), `isRelayLeaseActive()`, and `markReaping/clearReaping/isReaping`. The existing idle-kill now funnels through `terminateSession` and skips reaping-leased sessions; `killSession` shares the CAS guard and now sets `endedReason` (its event emissions are unchanged — still no `sessionComplete`).
+- The zombie-kill recovery veto (`activeRecoveryChecker`) is recomposed to include the socket + silence sentinels (previously compaction + rate-limit only) — a strict superset; nothing is dropped.
+
+## Over/under-block analysis (the hard requirement)
+
+The reaper must never reap a working session. Safety rests on positive evidence, not absence of activity:
+- **Under-block (fails to reap a genuinely idle session):** acceptable — the existing 15m/4h idle-kill still runs; the reaper is additive pressure relief.
+- **Over-block (reaps a working session):** the failure that matters. Mitigations: (1) requires a *positive* turn-complete idle-prompt signal; (2) render-stasis — pane byte-identical across all confirm ticks; (3) process + transcript must be quiet, and any *unresolvable* signal (no `claudeSessionId`, Codex/missing/rotated transcript, uninspectable process) forces KEEP, never "quiet"; (4) hysteresis; (5) two-phase reap with a final-grace re-check that aborts on any frame change; (6) Normal pressure tier reaps nothing; (7) bounded per-tick/per-hour budget; (8) auto-disable to dry-run on any ambiguous/failed reap; (9) ships OFF + dry-run.
+
+## Level-of-abstraction / signal-vs-authority
+
+Signals carry confidence and only *recommend*; kill authority sits behind the budget + dry-run + single-writer `terminateSession` CAS + auto-disable. The reaper computes a verdict; it does not own an unbounded kill.
+
+## Interactions
+
+- Composes with (does not fight) existing watchdogs: gate G defers to any recovery-in-flight (now incl. socket/silence); disjoint from OrphanProcessReaper (untracked procs) and SessionWatchdog (active-but-stuck); shares the single-writer kill path with the idle-kill so no double-kill / double-event.
+- Pressure source is freemem-tiered for v1 (advisory; macOS under-reports). Crucially, an over-eager pressure tier can only reap a *genuinely-idle* session sooner — it cannot cause a working session to be reaped, because the classifier protects working sessions independent of tier.
+
+## Rollback
+
+Set `monitoring.sessionReaper.enabled:false` (the default) — fully inert. No data migration; `endedReason` is additive/optional. Revert the branch to remove code; no persisted state needs cleanup beyond an optional `state/session-reaper.json` (absent unless restart-durability is later wired).
+
+## Tests
+
+3-tier: unit (transcript prober, terminateSession CAS, classifier incl. every false-reap vector, config/migration), integration (`/sessions/reaper` + dry-run), e2e (feature-alive + dangerous cases). Wiring-integrity guards the construct→start→pass chain. Live test-as-self on a real in-flight build + a real Codex session precedes merge.

--- a/upgrades/side-effects/session-reaper.md
+++ b/upgrades/side-effects/session-reaper.md
@@ -31,3 +31,12 @@ Set `monitoring.sessionReaper.enabled:false` (the default) — fully inert. No d
 ## Tests
 
 3-tier: unit (transcript prober, terminateSession CAS, classifier incl. every false-reap vector, config/migration), integration (`/sessions/reaper` + dry-run), e2e (feature-alive + dangerous cases). Wiring-integrity guards the construct→start→pass chain. Live test-as-self on a real in-flight build + a real Codex session precedes merge.
+
+## Phase-3 review fixes (post multi-agent code review)
+
+Independent review confirmed NO blocker to the hard requirement (cannot reap a working session) and surfaced safety-net hardening, all applied:
+- **Reaping-lease leak:** when a matured reap is budget/tier-gated, the reaping lease is now released — previously it could permanently disable the fast idle-kill for that session.
+- **Protected-list wiring:** gate A now reads `SessionManager.getProtectedSessions()` (the resolved list including the `<project>-server` default) rather than the raw config field, preventing spurious auto-disable when the server session goes idle.
+- **Robustness:** `tick()` and `snapshot()` treat a throwing protect-signal as KEEP — never reap on a failed evaluation, and the `/sessions/reaper` route never 500s.
+- **`killSession` contract preserved:** unconditional pane kill retained (only the in-flight guard added; no terminal-status early-return).
+- **Known v1 gap (documented, not a false-reap vector):** the optional `mainProcessActive` CPU/IO-delta signal is not wired in v1; render-stasis is the real-time liveness channel that covers in-process work. Promoting `mainProcessActive` is a tracked enhancement, validated during the dry-run rollout.


### PR DESCRIPTION
## What

Adds **SessionReaper** — a monitor that reaps idle-but-alive agent sessions (parked at a ready prompt, holding memory), but **only under memory pressure** and **never a session that might be working**. Closes the gap behind the 2026-05-25 fleet pileup: idle sessions accumulated until the machine starved and cross-agent messaging silently failed (agents could no longer spawn). Ships **OFF + dry-run by default** — the only monitor that kills on a heuristic.

Spec (converged + ratified): `docs/specs/SESSION-REAPER-SPEC.md` · plain-English: `docs/specs/SESSION-REAPER-SPEC.eli16.md` · side-effects: `upgrades/side-effects/session-reaper.md`.

## The hard requirement: never reap a working session

The classifier is **positive-evidence**, not absence-of-activity (a session mid-LLM-generation looks identical to an idle one). It reaps only when it can affirmatively prove: turn-complete at a ready prompt **+** pane byte-static across confirm ticks (render-stasis) **+** no active process **+** no transcript growth — and **any unresolvable signal (no `claudeSessionId`, Codex/missing/rotated transcript, uninspectable process) forces KEEP**. Plus hysteresis, a two-phase reap (mark → confirm-after-grace, abort on any frame change), Normal-tier reaps nothing, bounded per-tick/per-hour budget, and auto-disable to dry-run on any ambiguous/failed reap.

## How it was built

- 3-way convergence review on the spec (codex/gpt-5.5 + 2 code-grounded Claude passes) → v1's "three independent sensors" claim was false; rewrote to positive-evidence + confidence-contract.
- Multi-agent code review on the diff → confirmed no blocker to the hard requirement; fixed a reaping-lease leak, protected-list wiring, and throw-robustness.
- Single-writer `SessionManager.terminateSession()` CAS so the idle-kill and reaper share one kill path (no double-kill).
- Recovery veto recomposed to also defer to the socket + silence sentinels.

## Tests (3-tier, NON-NEGOTIABLE)

- Unit: transcript prober, terminate CAS, classifier incl. every false-reap vector, config/migration, wiring-integrity.
- Integration: `GET /sessions/reaper` (503/200 + dry-run).
- E2E: feature-alive (200 not 503) + silent-but-working KEPT / no-claudeSessionId KEPT / genuinely-idle REAPED / frame-change-during-grace ABORTS.
- Test-as-self: compiled dist booted out-of-process, `/sessions/reaper` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)