### PR TITLE
[codex] Wire stop-gate shadow mode

### DIFF
--- a/docs/specs/context-death-pitfall-prevention.eli16.md
+++ b/docs/specs/context-death-pitfall-prevention.eli16.md
@@ -1,0 +1,27 @@
+# Context-Death Pitfall Prevention — Plain English
+
+## What This Is
+
+Sometimes an agent stops in the middle of real work and explains the stop by saying the session is getting long, the context window might run out, or a fresh session would be cleaner. That sounds responsible, but in this system it is usually the wrong move. Instar already has recovery machinery that reloads identity, recent memory, and conversation context when a session compacts or restarts. If the work has a durable plan, committed code, a ledger entry, or another concrete artifact, the agent should continue from that artifact instead of making the user ask again.
+
+This spec creates a guard for that failure mode. The guard watches Stop events, gathers evidence about whether the agent has a real reason to stop, and asks a server-side authority whether the stop should be allowed or turned into a continuation reminder.
+
+## What Already Exists
+
+Instar already has several pieces that make continuation safe: session-start context, compaction recovery, durable memory files, project maps, and hook events. It also already has a server route family for the stop gate and an authority called UnjustifiedStopGate. Those pieces are useful only if they are wired into the live server and connected to the actual Stop hook path.
+
+## What Is New
+
+The missing part is the circuit. The server must construct the authority and database. The hook installer must put a small router into the Stop hook chain. The router must ask the server for the hot-path state, then submit the Stop event for evaluation when the gate is in shadow or enforce mode. Shadow mode records what would have happened without blocking the agent. Enforce mode can block only when the server authority says the agent should continue.
+
+The first rollout is shadow mode. That means no user workflow changes and no surprise blocking. It lets us collect real Stop-event evidence before any later decision to enforce.
+
+## Safeguards
+
+The hook fails open. If the server is down, the payload is malformed, the gate is off, the kill switch is active, compaction is already happening, or the authority/database cannot initialize, the agent is allowed to stop. The hook itself does not decide whether the stop is unjustified; it only sends evidence to the server. The LLM authority remains the decision point.
+
+The mode is persisted so restarts do not silently erase the operator's chosen setting. The decision log is stored in SQLite so later review can inspect what the gate saw. Existing autonomous Stop behavior stays compatible, but the stop-gate router runs first when both are present so shadow telemetry is not hidden.
+
+## What The Reader Decides
+
+The key decision is whether shadow-mode evidence looks trustworthy enough to flip enforcement on later. This change does not make that flip. It only wires the observation path so the next decision can be based on real data instead of guesses.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.2.82",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.2.82",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.2.82",
+  "version": "1.3.0",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/analyze-release.js
+++ b/scripts/analyze-release.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// safe-git-allow: release analyzer runs before TS source is compiled; read-only git only.
 /**
  * Release Change Analyzer
  *
@@ -24,11 +25,10 @@
  *   node scripts/analyze-release.js --recommend-only   # Just recommend bump type
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { SafeGitExecutor } from '../src/core/SafeGitExecutor.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -43,18 +43,26 @@ function log(msg) {
 
 // ── Git Helpers ──────────────────────────────────────────────────────
 
+function gitRead(args) {
+  return execFileSync('git', args, {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
 function getLastReleaseTag() {
   try {
-    return SafeGitExecutor.readSync(['describe', '--tags', '--abbrev=0'], { cwd: ROOT, encoding: 'utf-8', operation: 'scripts/analyze-release.js:48' }).trim();
+    return gitRead(['describe', '--tags', '--abbrev=0']).trim();
   } catch {
     // No tags at all — diff against the initial commit
-    return SafeGitExecutor.readSync(['rev-list', '--max-parents=0', 'HEAD'], { cwd: ROOT, encoding: 'utf-8', operation: 'scripts/analyze-release.js:52' }).trim();
+    return gitRead(['rev-list', '--max-parents=0', 'HEAD']).trim();
   }
 }
 
 function getCommitsSinceTag(tag) {
   try {
-    const raw = SafeGitExecutor.readSync(['log', `${tag}..HEAD`, '--oneline', '--no-merges'], { cwd: ROOT, encoding: 'utf-8', operation: 'scripts/analyze-release.js:getCommitsSinceTag' });
+    const raw = gitRead(['log', `${tag}..HEAD`, '--oneline', '--no-merges']);
     return raw.trim().split('\n').filter(Boolean).map(line => {
       const [hash, ...rest] = line.split(' ');
       return { hash, message: rest.join(' ') };
@@ -66,7 +74,7 @@ function getCommitsSinceTag(tag) {
 
 function getDiffStat(tag) {
   try {
-    return SafeGitExecutor.readSync(['diff', `${tag}..HEAD`, '--stat'], { cwd: ROOT, encoding: 'utf-8', operation: 'scripts/analyze-release.js:getDiffStat' }).trim();
+    return gitRead(['diff', `${tag}..HEAD`, '--stat']).trim();
   } catch {
     return '';
   }
@@ -74,7 +82,7 @@ function getDiffStat(tag) {
 
 function getChangedFiles(tag) {
   try {
-    const raw = SafeGitExecutor.readSync(['diff', `${tag}..HEAD`, '--name-status'], { cwd: ROOT, encoding: 'utf-8', operation: 'scripts/analyze-release.js:getChangedFiles' });
+    const raw = gitRead(['diff', `${tag}..HEAD`, '--name-status']);
     return raw.trim().split('\n').filter(Boolean).map(line => {
       const [status, ...pathParts] = line.split('\t');
       return { status: status.charAt(0), file: pathParts.join('\t') };
@@ -86,7 +94,7 @@ function getChangedFiles(tag) {
 
 function getFileDiff(tag, file) {
   try {
-    return SafeGitExecutor.readSync(['diff', `${tag}..HEAD`, '--', file], { cwd: ROOT, encoding: 'utf-8', operation: 'scripts/analyze-release.js:getFileDiff' });
+    return gitRead(['diff', `${tag}..HEAD`, '--', file]);
   } catch {
     return '';
   }

--- a/scripts/generate-builtin-manifest.cjs
+++ b/scripts/generate-builtin-manifest.cjs
@@ -43,7 +43,7 @@ function fileExists(filePath) {
 
 /**
  * Scan hooks from PostUpdateMigrator's migrateHooks method.
- * These are the 14 hook files Instar writes to .instar/hooks/instar/.
+ * These are the hook files Instar writes to .instar/hooks/instar/.
  */
 function scanHooks() {
   const entries = [];
@@ -63,6 +63,7 @@ function scanHooks() {
     { file: 'free-text-guard.sh', domain: 'safety' },
     { file: 'claim-intercept.js', domain: 'coherence' },
     { file: 'claim-intercept-response.js', domain: 'coherence' },
+    { file: 'stop-gate-router.js', domain: 'safety' },
     { file: 'auto-approve-permissions.js', domain: 'safety' },
   ];
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3955,6 +3955,10 @@ done
   // Stop hook that calls /review/evaluate for LLM-powered response quality checking.
   fs.writeFileSync(path.join(hooksDir, 'response-review.js'), migrator.getHookContent('response-review'), { mode: 0o755 });
 
+  // Unjustified Stop Gate router — Stop hook that calls the server-side gate.
+  // Shadow-mode by default; enforcement is controlled server-side.
+  fs.writeFileSync(path.join(hooksDir, 'stop-gate-router.js'), migrator.getHookContent('stop-gate-router'), { mode: 0o755 });
+
   // Hook event reporter — posts hook events to the Instar server for observability
   // and session resumption (claudeSessionId). Uses command hooks because Claude Code
   // HTTP hooks (type: "http") silently fail to fire as of v2.1.78.
@@ -4732,16 +4736,25 @@ function installClaudeSettings(projectDir: string, serverPort?: number): void {
   }
 
   // Register autonomous stop hook — structural enforcement for /autonomous mode.
-  // Must be FIRST in the Stop chain so it blocks exit before other hooks run.
+  // Keep stop-gate-router first when present so shadow telemetry sees every
+  // Stop event before legacy autonomous blocking can short-circuit the chain.
   const hasAutonomousHook = stopHooks.some(e =>
     e.hooks?.some(h => h.command?.includes('autonomous-stop-hook')),
   );
   if (!hasAutonomousHook) {
-    (hooks.Stop as unknown[]).unshift({ matcher: '', hooks: [{
+    const autonomousEntry = { matcher: '', hooks: [{
       type: 'command',
       command: 'bash ${CLAUDE_PROJECT_DIR}/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
       timeout: 10000,
-    }] });
+    }] };
+    const stopGateIndex = stopHooks.findIndex(e =>
+      e.hooks?.some(h => h.command?.includes('stop-gate-router.js')),
+    );
+    if (stopGateIndex >= 0) {
+      stopHooks.splice(stopGateIndex + 1, 0, autonomousEntry);
+    } else {
+      stopHooks.unshift(autonomousEntry);
+    }
   }
 
   // PermissionRequest: auto-approve all — subagents don't inherit --dangerously-skip-permissions.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7317,6 +7317,49 @@ export async function startServer(options: StartOptions): Promise<void> {
     const outboundDedupGate = new OutboundDedupGate();
     console.log(pc.green('  Outbound dedup gate: active (word-3gram Jaccard, threshold 0.7, 5min window)'));
 
+    // Unjustified Stop Gate — observe-only by default. The routes and authority
+    // already fail open; constructing both pieces here is what makes the Stop
+    // router produce real shadow-mode telemetry instead of a dark endpoint.
+    let unjustifiedStopGate: import('../core/UnjustifiedStopGate.js').UnjustifiedStopGate | undefined;
+    let stopGateDb: import('../core/StopGateDb.js').StopGateDb | undefined;
+    {
+      const { configureStopGateState } = await import('../server/stopGate.js');
+      const modeFilePath = path.join(config.stateDir, 'server-data', 'stop-gate-mode.json');
+      try {
+        const { StopGateDb } = await import('../core/StopGateDb.js');
+        stopGateDb = new StopGateDb({
+          dbPath: path.join(config.stateDir, 'server-data', 'stop-gate.db'),
+        });
+      } catch (err) {
+        DegradationReporter.getInstance().report({
+          feature: 'unjustifiedStopGate.db',
+          primary: 'SQLite decision log for Stop-gate evaluations',
+          fallback: 'fail-open → no Stop-gate persistence',
+          reason: err instanceof Error ? err.message : String(err),
+          impact: 'Stop events are allowed and not recorded until the database opens.',
+        });
+      }
+      if (sharedIntelligence && stopGateDb) {
+        try {
+          const { UnjustifiedStopGate } = await import('../core/UnjustifiedStopGate.js');
+          unjustifiedStopGate = new UnjustifiedStopGate({ intelligence: sharedIntelligence });
+        } catch (err) {
+          DegradationReporter.getInstance().report({
+            feature: 'unjustifiedStopGate.authority',
+            primary: 'LLM authority for unjustified Stop-event detection',
+            fallback: 'fail-open → allow',
+            reason: err instanceof Error ? err.message : String(err),
+            impact: 'Stop events are allowed until the authority can initialize.',
+          });
+        }
+      }
+      const activeMode = configureStopGateState({
+        modeFilePath,
+        defaultMode: unjustifiedStopGate && stopGateDb ? 'shadow' : 'off',
+      });
+      console.log(pc.green(`  Unjustified Stop Gate: ${activeMode}${unjustifiedStopGate && stopGateDb ? ' (authority + SQLite wired)' : ' (degraded, fail-open)'}`));
+    }
+
     // Response Review Pipeline (Coherence Gate) — evaluates agent responses before delivery.
     // Prefers the shared IntelligenceProvider (subscription-compatible) so the gate works
     // even without ANTHROPIC_API_KEY. Falls back to direct Anthropic API if a key is set
@@ -7764,7 +7807,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       });
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge, unjustifiedStopGate, stopGateDb });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1754,6 +1754,13 @@ export class PostUpdateMigrator {
     }
 
     try {
+      fs.writeFileSync(path.join(instarHooksDir, 'stop-gate-router.js'), this.getStopGateRouterHook(), { mode: 0o755 });
+      result.upgraded.push('hooks/instar/stop-gate-router.js (unjustified Stop gate router)');
+    } catch (err) {
+      result.errors.push(`stop-gate-router.js: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    try {
       fs.writeFileSync(path.join(instarHooksDir, 'auto-approve-permissions.js'), this.getAutoApprovePermissionsHook(), { mode: 0o755 });
       result.upgraded.push('hooks/instar/auto-approve-permissions.js (subagent permission unblocking)');
     } catch (err) {
@@ -1867,6 +1874,7 @@ export class PostUpdateMigrator {
       'scope-coherence-collector.js', 'scope-coherence-checkpoint.js',
       'instructions-loaded-tracker.js', 'subagent-start-tracker.js',
       'free-text-guard.sh', 'claim-intercept.js', 'claim-intercept-response.js', 'response-review.js',
+      'stop-gate-router.js',
       'auto-approve-permissions.js',
     ];
 
@@ -2238,15 +2246,24 @@ export class PostUpdateMigrator {
       e.hooks?.some(h => h.command?.includes('autonomous-stop-hook')),
     );
     if (!hasAutonomousHook) {
-      // Must be first in the Stop chain so it blocks before other hooks run
-      (hooks.Stop as unknown[]).unshift({
+      // Keep stop-gate-router first when present so shadow telemetry sees every
+      // Stop event before legacy autonomous blocking can short-circuit the chain.
+      const autonomousEntry = {
         matcher: '',
         hooks: [{
           type: 'command',
           command: 'bash ${CLAUDE_PROJECT_DIR}/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
           timeout: 10000,
         }],
-      });
+      };
+      const stopGateIndex = stopEntries.findIndex(e =>
+        e.hooks?.some(h => h.command?.includes('stop-gate-router.js')),
+      );
+      if (stopGateIndex >= 0) {
+        stopEntries.splice(stopGateIndex + 1, 0, autonomousEntry);
+      } else {
+        stopEntries.unshift(autonomousEntry);
+      }
       result.upgraded.push('.claude/settings.json: registered autonomous stop hook (structural enforcement)');
       patched = true;
     }
@@ -3698,6 +3715,25 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       this.migrateSettingsHookPaths(hooks.PostToolUse as unknown[], result);
       patched = true;
     }
+    {
+      const stopHooks = (hooks.Stop ?? []) as Array<{ matcher?: string; hooks?: Array<{ command?: string; type?: string; timeout?: number }> }>;
+      const hasStopGateRouter = stopHooks.some(e =>
+        e.hooks?.some(h => h.command?.includes('stop-gate-router.js')),
+      );
+      if (!hasStopGateRouter) {
+        stopHooks.unshift({
+          matcher: '',
+          hooks: [{
+            type: 'command',
+            command: 'node ${CLAUDE_PROJECT_DIR}/.instar/hooks/instar/stop-gate-router.js',
+            timeout: 5000,
+          }],
+        });
+        hooks.Stop = stopHooks;
+        patched = true;
+        result.upgraded.push('.claude/settings.json: added Stop stop-gate-router hook');
+      }
+    }
     if (hooks.Stop) {
       this.migrateSettingsHookPaths(hooks.Stop as unknown[], result);
       patched = true;
@@ -4379,7 +4415,7 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
    * Get the content of a named hook template.
    * Used by init.ts to share canonical hook content without duplication.
    */
-  getHookContent(name: 'session-start' | 'compaction-recovery' | 'external-operation-gate' | 'deferral-detector' | 'slopcheck-guard' | 'post-action-reflection' | 'external-communication-guard' | 'scope-coherence-collector' | 'scope-coherence-checkpoint' | 'claim-intercept' | 'claim-intercept-response' | 'telegram-topic-context' | 'response-review' | 'auto-approve-permissions' | 'skill-usage-telemetry' | 'build-stop-hook'): string {
+  getHookContent(name: 'session-start' | 'compaction-recovery' | 'external-operation-gate' | 'deferral-detector' | 'slopcheck-guard' | 'post-action-reflection' | 'external-communication-guard' | 'scope-coherence-collector' | 'scope-coherence-checkpoint' | 'claim-intercept' | 'claim-intercept-response' | 'telegram-topic-context' | 'response-review' | 'stop-gate-router' | 'auto-approve-permissions' | 'skill-usage-telemetry' | 'build-stop-hook'): string {
     switch (name) {
       case 'session-start': return this.getSessionStartHook();
       case 'compaction-recovery': return this.getCompactionRecovery();
@@ -4394,6 +4430,7 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       case 'claim-intercept-response': return this.getClaimInterceptResponseHook();
       case 'telegram-topic-context': return this.getTelegramTopicContextHook();
       case 'response-review': return this.getResponseReviewHook();
+      case 'stop-gate-router': return this.getStopGateRouterHook();
       case 'auto-approve-permissions': return this.getAutoApprovePermissionsHook();
       case 'skill-usage-telemetry': return this.getSkillUsageTelemetryHook();
       case 'build-stop-hook': return this.getBuildStopHook();
@@ -6970,6 +7007,176 @@ process.stdin.on('end', async () => {
   } catch {
     // JSON parse error on stdin — fail open
     process.exit(0);
+  }
+});
+`;
+  }
+
+  private getStopGateRouterHook(): string {
+    const port = this.config.port;
+    return `#!/usr/bin/env node
+// Unjustified Stop Gate router.
+//
+// Thin client: reads Stop-hook JSON from stdin, asks the local Instar server
+// for hot-path state, and in shadow/enforce mode submits trusted evidence
+// metadata to /internal/stop-gate/evaluate. Shadow mode only records telemetry;
+// enforce mode blocks only on a server-side "continue" decision.
+
+const _r = require;
+const fs = _r('fs');
+const path = _r('path');
+const childProcess = _r('child_process');
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const configPath = path.join(projectDir, '.instar', 'config.json');
+let serverPort = ${port};
+let authToken = '';
+try {
+  const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  serverPort = cfg.port || ${port};
+  authToken = cfg.authToken || '';
+} catch {}
+
+function postJson(urlPath, payload, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(function () { controller.abort(); }, timeoutMs);
+  return fetch('http://127.0.0.1:' + serverPort + urlPath, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + authToken,
+    },
+    body: JSON.stringify(payload),
+    signal: controller.signal,
+  }).then(async function (res) {
+    clearTimeout(timer);
+    if (!res.ok) throw new Error('http ' + res.status);
+    return res.json();
+  }, function (err) {
+    clearTimeout(timer);
+    throw err;
+  });
+}
+
+function getJson(urlPath, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(function () { controller.abort(); }, timeoutMs);
+  return fetch('http://127.0.0.1:' + serverPort + urlPath, {
+    headers: { 'Authorization': 'Bearer ' + authToken },
+    signal: controller.signal,
+  }).then(async function (res) {
+    clearTimeout(timer);
+    if (!res.ok) throw new Error('http ' + res.status);
+    return res.json();
+  }, function (err) {
+    clearTimeout(timer);
+    throw err;
+  });
+}
+
+function git(args) {
+  try {
+    return childProcess.execFileSync('git', ['-C', projectDir].concat(args), {
+      encoding: 'utf-8',
+      timeout: 800,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function firstLine(value) {
+  return String(value || '').split(/\\r?\\n/).filter(Boolean)[0] || null;
+}
+
+function listEvidenceArtifacts(sessionStartTs) {
+  const out = git(['ls-files']);
+  if (!out) return [];
+  const files = out.split(/\\r?\\n/).filter(function (file) {
+    if (!file) return false;
+    if (!/\\.(md|markdown|json|jsonl|txt)$/i.test(file)) return false;
+    return /(^|\\/)(docs\\/specs|specs|plans?|tasks?|upgrades|MEMORY\\.md|AGENTS\\.md)|spec|plan|handoff|todo|next|round/i.test(file);
+  }).slice(0, 30);
+  return files.map(function (file) {
+    const introducingCommit = firstLine(git(['log', '--follow', '--format=%H', '--reverse', '--', file]));
+    const latestCommit = firstLine(git(['log', '--format=%H', '-1', '--', file]));
+    let createdThisSession = false;
+    let modifiedThisSession = false;
+    if (sessionStartTs && latestCommit) {
+      const ts = Number(firstLine(git(['show', '-s', '--format=%ct', latestCommit])) || '0') * 1000;
+      modifiedThisSession = ts >= sessionStartTs;
+      if (introducingCommit) {
+        const createdTs = Number(firstLine(git(['show', '-s', '--format=%ct', introducingCommit])) || '0') * 1000;
+        createdThisSession = createdTs >= sessionStartTs;
+      }
+    }
+    return {
+      path: file,
+      introducingCommit: introducingCommit,
+      latestCommit: latestCommit,
+      createdThisSession: createdThisSession,
+      modifiedThisSession: modifiedThisSession,
+    };
+  });
+}
+
+function buildSignals(stopReason, message) {
+  const text = String(stopReason || '') + '\\n' + String(message || '');
+  return {
+    mentionsContextLimit: /context|window|token|compact/i.test(text),
+    mentionsFreshSession: /fresh session|new session|restart|continue in a new/i.test(text),
+    claimsShouldStopForContext: /stop|pause|wrap up|hand off/i.test(text) && /context|fresh|compact/i.test(text),
+  };
+}
+
+function exitOpen() {
+  process.exit(0);
+}
+
+let data = '';
+process.stdin.on('data', function (chunk) { data += chunk; });
+process.stdin.on('end', async function () {
+  let input;
+  try {
+    input = data ? JSON.parse(data) : {};
+  } catch {
+    exitOpen();
+    return;
+  }
+
+  if (input.stop_hook_active) exitOpen();
+  const sessionId = String(input.session_id || input.sessionId || process.env.INSTAR_SESSION_ID || 'unknown');
+
+  try {
+    const hot = await getJson('/internal/stop-gate/hot-path?session=' + encodeURIComponent(sessionId), 1500);
+    if (!hot || hot.killSwitch || hot.mode === 'off' || hot.compactionInFlight) exitOpen();
+
+    const message = String(input.last_assistant_message || '');
+    const stopReason = String(input.stop_reason || input.reason || message || '');
+    const evidenceMetadata = {
+      artifacts: listEvidenceArtifacts(hot.sessionStartTs || null),
+      signals: buildSignals(stopReason, message),
+      sessionStartTs: hot.sessionStartTs || null,
+    };
+
+    const result = await postJson('/internal/stop-gate/evaluate', {
+      sessionId: sessionId,
+      evidenceMetadata: evidenceMetadata,
+      untrustedContent: {
+        stopReason: stopReason,
+        recentTurns: message ? [{ source: 'agent', text: message }] : [],
+      },
+    }, 2500);
+
+    if (hot.mode === 'enforce' && result && result.decision === 'continue' && result.reminder) {
+      process.stdout.write(JSON.stringify({ decision: 'block', reason: result.reminder }));
+      process.exit(2);
+      return;
+    }
+    exitOpen();
+  } catch {
+    exitOpen();
   }
 });
 `;

--- a/src/core/installCodexHooks.ts
+++ b/src/core/installCodexHooks.ts
@@ -88,7 +88,8 @@ export function buildInstarCodexHookGroups(
     PermissionRequest: [
       { matcher: '.*', hooks: [node('external-operation-gate.js')] },
     ],
-    // End-of-turn review trio — MUST MIRROR the Claude Stop trio
+    // End-of-turn review chain — starts with the unjustified-stop router
+    // (shadow by default), then MUST MIRROR the Claude Stop trio
     // (settings-template.json): response-review + claim-intercept-response +
     // scope-coherence-checkpoint. (Earlier this wrongly substituted
     // deferral-detector — a PreToolUse hook whose `tool_name==='Bash'` guard
@@ -100,7 +101,7 @@ export function buildInstarCodexHookGroups(
     // `approve` and self-throttles (depth threshold + 30-min cooldown), so it
     // can't loop an autonomous Codex run.
     Stop: [
-      { matcher: '', hooks: [{ ...node('response-review.js'), timeout: 10000 }, node('claim-intercept-response.js'), node('scope-coherence-checkpoint.js')] },
+      { matcher: '', hooks: [node('stop-gate-router.js'), { ...node('response-review.js'), timeout: 10000 }, node('claim-intercept-response.js'), node('scope-coherence-checkpoint.js')] },
     ],
     // Identity/context injection.
     SessionStart: [

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,9 +1,9 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-26T04:31:00.352Z",
-  "instarVersion": "1.2.81",
-  "entryCount": 191,
+  "generatedAt": "2026-05-26T16:20:01.958Z",
+  "instarVersion": "1.3.0",
+  "entryCount": 192,
   "entries": {
     "hook:session-start": {
       "id": "hook:session-start",
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,16 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
+      "since": "2025-01-01"
+    },
+    "hook:stop-gate-router": {
+      "id": "hook:stop-gate-router",
+      "type": "hook",
+      "domain": "safety",
+      "sourcePath": "src/core/PostUpdateMigrator.ts",
+      "installedPath": ".instar/hooks/instar/stop-gate-router.js",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -128,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -392,7 +401,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -400,7 +409,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -408,7 +417,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -416,7 +425,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -424,7 +433,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -432,7 +441,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -440,7 +449,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -448,7 +457,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -456,7 +465,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -464,7 +473,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -472,7 +481,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -480,7 +489,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -488,7 +497,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -496,7 +505,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -504,7 +513,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -512,7 +521,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -520,7 +529,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -528,7 +537,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -536,7 +545,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -544,7 +553,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -552,7 +561,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -560,7 +569,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -568,7 +577,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -576,7 +585,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -584,7 +593,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -592,7 +601,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -600,7 +609,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -608,7 +617,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -616,7 +625,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -624,7 +633,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -632,7 +641,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -640,7 +649,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -648,7 +657,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -656,7 +665,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -664,7 +673,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -672,7 +681,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -680,7 +689,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -688,7 +697,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -696,7 +705,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -704,7 +713,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -712,7 +721,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -720,7 +729,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -728,7 +737,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -744,7 +753,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "9ebd53e6f0f7337e32a2be2024d829c0296eb913da5341fe392692d234e2ef9d",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1040,7 +1049,7 @@
       "type": "template",
       "domain": "safety",
       "sourcePath": "src/templates/hooks/settings-template.json",
-      "contentHash": "2cc950f0635f9c3412b768610f690288b466e7ace280285aee2481fbe514f230",
+      "contentHash": "4c077381e850c60397856fdead3d304da1158cea614207f7dd2b784321faacb7",
       "since": "2025-01-01"
     },
     "template:skill-usage-telemetry.sh": {
@@ -1472,7 +1481,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "b54d6e7d0f6f6e6b6ef1574e8ad4987c4055784a1b6dd51d3f3c8a45368a56c2",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1904,7 +1904,19 @@ export function createRoutes(ctx: RouteContext): Router {
     // event so a malformed payload doesn't break the gate.
     if (req.body?.event === 'SessionStart') {
       const sid = (req.body?.sessionId || req.body?.session_id || '').toString();
-      if (sid) recordSessionStart(sid, Date.now());
+      if (sid) {
+        const startedAt = Date.now();
+        recordSessionStart(sid, startedAt);
+        try {
+          ctx.stopGateDb?.recordSessionStart(
+            sid,
+            ctx.config.projectName ?? 'unknown',
+            startedAt,
+          );
+        } catch {
+          // Best-effort hot-path enrichment; evaluation still fail-opens.
+        }
+      }
     }
 
     const payload = req.body;

--- a/src/server/stopGate.ts
+++ b/src/server/stopGate.ts
@@ -1,8 +1,10 @@
 /**
  * stopGate.ts — UnjustifiedStopGate server infrastructure (PR0a).
  *
- * Provides the read-side API surface that the future stop-hook router
- * consumes (PR3). State is in-memory for PR0a; PR3 migrates to SQLite.
+ * Provides the read-side API surface that the stop-hook router consumes.
+ * Runtime mode persists to disk so shadow-mode rollout survives server
+ * restarts; per-session hot-path state remains process-local and is
+ * repopulated by hook events.
  *
  * Spec: docs/specs/context-death-pitfall-prevention.md
  *
@@ -34,7 +36,7 @@ import path from 'node:path';
 export const GATE_ROUTE_VERSION = 1;
 export const GATE_ROUTE_MINIMUM_VERSION = 1;
 
-// ── Mode + kill-switch state (in-memory, PR0a) ───────────────────────────
+// ── Mode + kill-switch state ─────────────────────────────────────────────
 //
 // Mode is the operating mode of the gate. Default 'off' so PR0a ships
 // completely inert — the spec's PR4 lands the CLI that flips to shadow.
@@ -46,6 +48,7 @@ export type GateMode = 'off' | 'shadow' | 'enforce';
 interface GateState {
   mode: GateMode;
   killSwitch: boolean;
+  modeFilePath: string | null;
   // sessionStartTs is keyed by sessionId; populated by SessionStart hook
   // events received via /hooks/events. PR3 migrates to a sessions(sessions
   // table) row.
@@ -55,8 +58,49 @@ interface GateState {
 const state: GateState = {
   mode: 'off',
   killSwitch: false,
+  modeFilePath: null,
   sessionStartTs: new Map(),
 };
+
+function readPersistedMode(filePath: string): GateMode | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { mode?: unknown };
+    const mode = parsed.mode;
+    if (mode === 'off' || mode === 'shadow' || mode === 'enforce') return mode;
+  } catch {
+    // Missing/unreadable state is not fatal; caller supplies default.
+  }
+  return null;
+}
+
+function persistMode(): void {
+  if (!state.modeFilePath) return;
+  try {
+    fs.mkdirSync(path.dirname(state.modeFilePath), { recursive: true });
+    fs.writeFileSync(
+      state.modeFilePath,
+      JSON.stringify({ mode: state.mode, updatedAt: new Date().toISOString() }, null, 2) + '\n',
+      { mode: 0o600 },
+    );
+  } catch {
+    // Fail open. The route still returns the in-memory mode; persistence
+    // failure is reported by the caller's normal health/degradation path.
+  }
+}
+
+export function configureStopGateState(opts: {
+  modeFilePath?: string;
+  defaultMode?: GateMode;
+} = {}): GateMode {
+  if (opts.modeFilePath) {
+    state.modeFilePath = opts.modeFilePath;
+    state.mode = readPersistedMode(opts.modeFilePath) ?? (opts.defaultMode ?? state.mode);
+    persistMode();
+    return state.mode;
+  }
+  if (opts.defaultMode) state.mode = opts.defaultMode;
+  return state.mode;
+}
 
 export function getMode(): GateMode {
   return state.mode;
@@ -64,6 +108,7 @@ export function getMode(): GateMode {
 
 export function setMode(mode: GateMode): void {
   state.mode = mode;
+  persistMode();
 }
 
 export function getKillSwitch(): boolean {
@@ -108,6 +153,7 @@ export function getSessionStartTs(sessionId: string): number | null {
 export function _resetForTests(): void {
   state.mode = 'off';
   state.killSwitch = false;
+  state.modeFilePath = null;
   state.sessionStartTs.clear();
 }
 

--- a/src/templates/hooks/settings-template.json
+++ b/src/templates/hooks/settings-template.json
@@ -140,6 +140,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node .instar/hooks/instar/stop-gate-router.js",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node .instar/hooks/instar/response-review.js",
             "timeout": 10000
           }

--- a/tests/unit/PostUpdateMigrator-codexHooks.test.ts
+++ b/tests/unit/PostUpdateMigrator-codexHooks.test.ts
@@ -54,6 +54,9 @@ describe('PostUpdateMigrator — Codex enforcement-hook registration (migration 
     const cfg = JSON.parse(fs.readFileSync(hooksPath, 'utf-8'));
     const pre = cfg.hooks.PreToolUse.flatMap((g: any) => g.hooks.map((h: any) => h.command));
     expect(pre.some((c: string) => c.includes('dangerous-command-guard.sh'))).toBe(true);
+    const stop = cfg.hooks.Stop.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+    expect(stop.some((c: string) => c.includes('stop-gate-router.js'))).toBe(true);
+    expect(fs.existsSync(path.join(projectDir, '.instar', 'hooks', 'instar', 'stop-gate-router.js'))).toBe(true);
     expect(result.errors).toEqual([]);
     expect(result.upgraded.some((u) => u.includes('.codex/hooks.json'))).toBe(true);
   });

--- a/tests/unit/autonomous-skill-deployment.test.ts
+++ b/tests/unit/autonomous-skill-deployment.test.ts
@@ -101,15 +101,24 @@ describe('Autonomous skill deployment', () => {
       expect(hasAutonomousHook).toBe(true);
     });
 
-    it('places autonomous stop hook FIRST in the Stop chain', () => {
+    it('places autonomous stop hook immediately after stop-gate when present', () => {
       const settingsPath = path.join(projectDir, '.claude', 'settings.json');
       const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
 
       const stopHooks = settings.hooks.Stop as Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>;
-      const firstHook = stopHooks[0];
+      const stopGateIndex = stopHooks.findIndex(entry =>
+        entry.hooks?.some(h => h.command?.includes('stop-gate-router.js')),
+      );
+      const autonomousIndex = stopHooks.findIndex(entry =>
+        entry.hooks?.some(h => h.command?.includes('autonomous-stop-hook')),
+      );
 
-      // Must be first so it blocks before other hooks run
-      expect(firstHook.hooks?.[0]?.command).toContain('autonomous-stop-hook');
+      expect(autonomousIndex).toBeGreaterThanOrEqual(0);
+      if (stopGateIndex >= 0) {
+        expect(autonomousIndex).toBe(stopGateIndex + 1);
+      } else {
+        expect(autonomousIndex).toBe(0);
+      }
     });
   });
 });

--- a/tests/unit/installCodexHooks.test.ts
+++ b/tests/unit/installCodexHooks.test.ts
@@ -75,12 +75,11 @@ describe('installCodexHooks', () => {
     expect(cfg.hooks.PermissionRequest[0].matcher).toBe('.*');
   });
 
-  it('wires the Stop review trio mirroring Claude: response-review + claim-intercept-response + scope-coherence', () => {
+  it('wires the Stop gate router before the review trio', () => {
     installCodexHooks(projectDir);
     const cfg = read();
     const stopCommands = cfg.hooks.Stop[0].hooks.map((h: any) => h.command);
-    // MUST mirror the Claude Stop trio (settings-template.json). Codex honors
-    // {decision:'block', reason} on Stop, so these grounding checks apply.
+    expect(stopCommands[0]).toContain('stop-gate-router.js');
     expect(stopCommands.some((c: string) => c.includes('response-review.js'))).toBe(true);
     expect(stopCommands.some((c: string) => c.includes('claim-intercept-response.js'))).toBe(true);
     expect(stopCommands.some((c: string) => c.includes('scope-coherence-checkpoint.js'))).toBe(true);

--- a/tests/unit/routes-stopGate.test.ts
+++ b/tests/unit/routes-stopGate.test.ts
@@ -13,9 +13,13 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import { Router } from 'express';
 import type { Server } from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {
   GATE_ROUTE_VERSION,
   GATE_ROUTE_MINIMUM_VERSION,
+  configureStopGateState,
   setMode,
   setKillSwitch,
   recordSessionStart,
@@ -23,6 +27,7 @@ import {
   getHotPathState,
   _resetForTests,
 } from '../../src/server/stopGate.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 function buildApp(): { server: Server; port: number } {
   const app = express();
@@ -117,6 +122,23 @@ describe('routes-stopGate — /internal/stop-gate/hot-path', () => {
     const body = await res.json();
     expect(body.mode).toBe('off');
     expect(body.sessionStartTs).toBeNull();
+  });
+
+  it('persists mode flips across state reconfiguration', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stop-gate-mode-'));
+    try {
+      const modeFilePath = path.join(dir, 'mode.json');
+      expect(configureStopGateState({ modeFilePath, defaultMode: 'shadow' })).toBe('shadow');
+      setMode('enforce');
+      _resetForTests();
+      expect(configureStopGateState({ modeFilePath, defaultMode: 'shadow' })).toBe('enforce');
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/unit/routes-stopGate.test.ts:mode-cleanup',
+      });
+    }
   });
 });
 

--- a/tests/unit/stop-gate-router-hook.test.ts
+++ b/tests/unit/stop-gate-router-hook.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const created: string[] = [];
+
+afterEach(() => {
+  for (const dir of created.splice(0)) {
+    SafeFsExecutor.safeRmSync(dir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/stop-gate-router-hook.test.ts:cleanup',
+    });
+  }
+});
+
+function makeProject(port: number): { dir: string; hookPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stop-gate-hook-'));
+  created.push(dir);
+  fs.mkdirSync(path.join(dir, '.instar', 'hooks', 'instar'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.instar', 'config.json'),
+    JSON.stringify({ port, authToken: 'test-token' }),
+  );
+  const migrator = new PostUpdateMigrator({
+    projectDir: dir,
+    stateDir: path.join(dir, '.instar'),
+    port,
+    hasTelegram: false,
+    projectName: 'hook-test',
+  });
+  const hookPath = path.join(dir, '.instar', 'hooks', 'instar', 'stop-gate-router.js');
+  fs.writeFileSync(hookPath, migrator.getHookContent('stop-gate-router'), { mode: 0o755 });
+  return { dir, hookPath };
+}
+
+function startServer(mode: 'off' | 'shadow' | 'enforce', decision: string) {
+  const calls: Array<{ url: string; body?: any; auth?: string }> = [];
+  const server = http.createServer((req, res) => {
+    calls.push({ url: req.url ?? '', auth: req.headers.authorization });
+    if (req.url?.startsWith('/internal/stop-gate/hot-path')) {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        mode,
+        killSwitch: false,
+        compactionInFlight: false,
+        sessionStartTs: null,
+      }));
+      return;
+    }
+    if (req.url === '/internal/stop-gate/evaluate' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        calls[calls.length - 1].body = JSON.parse(body);
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ decision, reminder: 'Continue from the plan.' }));
+      });
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  return new Promise<{ port: number; close: () => Promise<void>; calls: typeof calls }>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: (server.address() as { port: number }).port,
+        calls,
+        close: () => new Promise<void>((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+function runHook(hookPath: string, cwd: string, payload: unknown): Promise<{
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [hookPath], {
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('stop-gate-router hook timed out'));
+    }, 5000);
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (status) => {
+      clearTimeout(timer);
+      resolve({ status, stdout, stderr });
+    });
+    child.stdin.end(JSON.stringify(payload));
+  });
+}
+
+describe('stop-gate-router hook', () => {
+  it('submits shadow-mode evaluations but never blocks', async () => {
+    const srv = await startServer('shadow', 'continue');
+    try {
+      const { dir, hookPath } = makeProject(srv.port);
+      const proc = await runHook(hookPath, dir, {
+        session_id: 'sess-1',
+        last_assistant_message: 'I should stop here because the context may compact.',
+      });
+      expect(proc.status).toBe(0);
+      expect(proc.stdout).toBe('');
+      expect(
+        srv.calls.some((c) => c.url === '/internal/stop-gate/evaluate'),
+        JSON.stringify({ calls: srv.calls, stderr: proc.stderr }),
+      ).toBe(true);
+      const evalCall = srv.calls.find((c) => c.url === '/internal/stop-gate/evaluate')!;
+      expect(evalCall.auth).toBe('Bearer test-token');
+      expect(evalCall.body.sessionId).toBe('sess-1');
+      expect(evalCall.body.evidenceMetadata.signals.mentionsContextLimit).toBe(true);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('blocks only when server mode is enforce and authority says continue', async () => {
+    const srv = await startServer('enforce', 'continue');
+    try {
+      const { dir, hookPath } = makeProject(srv.port);
+      const proc = await runHook(hookPath, dir, {
+        session_id: 'sess-2',
+        last_assistant_message: 'Stopping for a fresh session.',
+      });
+      expect(proc.status, JSON.stringify({ calls: srv.calls, stderr: proc.stderr, stdout: proc.stdout })).toBe(2);
+      expect(JSON.parse(proc.stdout)).toEqual({
+        decision: 'block',
+        reason: 'Continue from the plan.',
+      });
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/upgrades/1.3.0.md
+++ b/upgrades/1.3.0.md
@@ -1,0 +1,31 @@
+# Unreleased
+<!-- bump: minor -->
+
+## What Changed
+
+Fresh-session stop-gate is now wired in shadow mode.
+
+- **Real Stop events are observed, not blocked.** The server now constructs the existing UnjustifiedStopGate authority and SQLite decision log, then starts the gate in `shadow` when both are healthy. Shadow mode records evaluations without blocking exits.
+- **The Stop-hook router is installed for Claude and Codex.** Fresh installs and post-update migrations write `stop-gate-router.js`; Claude settings and Codex hook config place it in the Stop chain before the review hooks.
+- **Mode survives restarts.** Gate mode persists to `server-data/stop-gate-mode.json`, while decisions continue to land in `server-data/stop-gate.db`.
+- **Legacy autonomous blocking no longer hides telemetry.** When both hooks are present, the stop-gate router runs before the autonomous Stop hook so shadow-mode observations still happen.
+- **Threadline hub promotion is included from the unreleased base.** The release also carries `POST /threadline/hub/bind`, which lets an agent promote or tie a quiet Threadline hub item to a real topic.
+
+## What to Tell Your User
+
+I added the next layer of protection against agents stopping too early for "fresh session" or context-window reasons. It is watching real stop events now, but it is not enforcing yet. That means we can inspect what it would have done before deciding whether to turn blocking on later.
+
+## Summary of New Capabilities
+
+- `hooks/instar/stop-gate-router.js` — Stop hook router that calls `/internal/stop-gate/hot-path` and `/internal/stop-gate/evaluate`.
+- Stop-gate server wiring now constructs `UnjustifiedStopGate` and `StopGateDb`.
+- Stop-gate mode persistence at `server-data/stop-gate-mode.json`.
+- Codex Stop hooks mirror the Claude stop-gate router before the existing response-review chain.
+- `POST /threadline/hub/bind` — promote or tie a surfaced Threadline hub conversation to a topic.
+
+## Evidence
+
+- Focused unit coverage: route mode persistence, router shadow/enforce behavior, Codex hook registration, update migration, and autonomous Stop-hook ordering.
+- `npm test -- --run tests/unit/routes-stopGate.test.ts tests/unit/stop-gate-router-hook.test.ts tests/unit/installCodexHooks.test.ts tests/unit/PostUpdateMigrator-codexHooks.test.ts tests/unit/autonomous-skill-deployment.test.ts tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts`
+- `npx tsc --noEmit`
+- `npm run build`

--- a/upgrades/side-effects/fresh-session-stop-gate-shadow-wiring.md
+++ b/upgrades/side-effects/fresh-session-stop-gate-shadow-wiring.md
@@ -1,0 +1,35 @@
+# Side-effects review — fresh-session stop-gate shadow wiring
+
+**Scope**: Complete the conservative first rollout for the fresh-session stop-gate: wire the existing server authority/database, install a Stop-hook router, and default to observe-only shadow mode when the gate is healthy.
+
+**Files touched**:
+- `src/commands/server.ts` — constructs `StopGateDb` and `UnjustifiedStopGate`, persists mode state, passes both into `AgentServer`.
+- `src/server/stopGate.ts` — persists mode flips to `server-data/stop-gate-mode.json`.
+- `src/server/routes.ts` — records SessionStart rows in `StopGateDb` when hook events arrive.
+- `src/core/PostUpdateMigrator.ts` — installs `stop-gate-router.js` and patches `.claude/settings.json` Stop hooks.
+- `src/commands/init.ts` and `src/templates/hooks/settings-template.json` — include the router on fresh installs.
+- `src/core/installCodexHooks.ts` — mirrors the Stop router into Codex hook config.
+- Focused tests cover route mode persistence, hook behavior, Codex registration, and update migration.
+
+**Under-block**: Intentional for this PR. Default mode is `shadow` only when the authority and SQLite log initialize successfully; otherwise the gate is `off`. In shadow mode the hook submits evaluations but always lets the agent exit. Enforcement is reserved for a later explicit operator flip.
+
+**Over-block**: Minimal. The router only emits `{decision:"block"}` when the server is already in `enforce` mode and the server authority returns `continue` with a reminder. All network errors, malformed hook payloads, missing config, hot-path failures, compaction-in-flight, kill-switch, and degraded initialization paths fail open.
+
+**Signal vs authority**: Compliant. The hook collects evidence metadata and simple signals, but never decides whether a Stop is unjustified. The server-side `UnjustifiedStopGate` remains the sole authority for `continue`; the hook is a transport/router.
+
+**External surfaces**:
+- New installed hook file: `.instar/hooks/instar/stop-gate-router.js`.
+- Existing routes become live for real Stop events: `GET /internal/stop-gate/hot-path` and `POST /internal/stop-gate/evaluate`.
+- New persisted mode file: `server-data/stop-gate-mode.json`.
+- Existing SQLite event log: `server-data/stop-gate.db`.
+
+**Migration parity**:
+- Post-update migration writes the router and patches existing Claude settings.
+- Fresh `instar init` installs the router template.
+- Codex hook installer places the router first in the Stop chain before the existing review trio.
+
+**Rollback cost**: Revert this change set. Existing `stop-gate-mode.json` and `stop-gate.db` files can remain on disk; without the router/server wiring they are inert. Emergency runtime rollback without code revert: `instar gate mode off` or set the kill-switch.
+
+**Tests**:
+- `npm test -- --run tests/unit/routes-stopGate.test.ts tests/unit/stop-gate-router-hook.test.ts tests/unit/installCodexHooks.test.ts tests/unit/PostUpdateMigrator-codexHooks.test.ts`
+- `npx tsc --noEmit`


### PR DESCRIPTION
## Summary

Wires the fresh-session stop-gate into the live server in shadow mode. The server now constructs `UnjustifiedStopGate` and `StopGateDb`, persists gate mode, records SessionStart rows, and installs a Stop hook router for Claude and Codex.

Also fixes the release analyzer so it can run from the source tree before TypeScript output exists, adds the 1.3.0 release notes, and adds the side-effects artifact plus ELI16 companion required by the instar-dev gate.

## Validation

- `npm test -- --run tests/unit/routes-stopGate.test.ts tests/unit/stop-gate-router-hook.test.ts tests/unit/installCodexHooks.test.ts tests/unit/PostUpdateMigrator-codexHooks.test.ts tests/unit/autonomous-skill-deployment.test.ts tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts`
- `npm run lint`
- `npm run build`
- `npm run check:upgrade-guide`
- `npm run check:release`
- Pre-commit instar-dev gate passed with fresh trace
- Pre-push smoke tier ran; path-scoped e2e helper reported missing `origin/main` in this worktree but did not block push

## Notes

Default rollout is observe-only shadow mode. Enforcement remains an explicit later operator decision.