### PR TITLE
test(moltbridge): make real-server integration test opt-in (stop prod pollution)

### DIFF
--- a/tests/integration/moltbridge-integration.test.ts
+++ b/tests/integration/moltbridge-integration.test.ts
@@ -1,8 +1,16 @@
 /**
- * MoltBridge Integration Test — Real API calls against running server.
+ * MoltBridge Integration Test — Real API calls against a running server.
  *
- * REQUIRES: MoltBridge server running at localhost:3040
- * Skip if server is unavailable (test is conditional).
+ * OPT-IN ONLY. Set MOLTBRIDGE_TEST_URL to a DEDICATED TEST instance to run this:
+ *   MOLTBRIDGE_TEST_URL=http://localhost:3040 npm run test:integration
+ * If the env var is unset, the suite SKIPS entirely and touches no server.
+ *
+ * WHY OPT-IN (do not revert to a hardcoded URL): this test registers agents and
+ * there is NO agent-deregister endpoint to clean up through. It previously pointed
+ * unconditionally at localhost:3040 — the PRODUCTION MoltBridge registry — so every
+ * local run on a machine where prod was up registered fake "instar-test" agents that
+ * never got torn down. That accumulated 691 junk agents in the production graph
+ * (purged 2026-05-26). Never point this at production; use a throwaway instance.
  *
  * Tests the full flow: health → verify → register → discover → attest → IQS
  * using the real MoltBridge SDK (no mocks).
@@ -13,7 +21,9 @@ import { MoltBridgeClient, type MoltBridgeConfig } from '../../src/moltbridge/Mo
 import type { CanonicalIdentity } from '../../src/identity/types.js';
 import crypto from 'node:crypto';
 
-const MOLTBRIDGE_URL = 'http://localhost:3040';
+// Opt-in only: no default. Unset => suite skips and contacts no server (prevents
+// silently polluting whatever happens to be on localhost:3040, e.g. production).
+const MOLTBRIDGE_URL = process.env.MOLTBRIDGE_TEST_URL;
 
 // Generate a test identity
 function createTestIdentity(): CanonicalIdentity {
@@ -36,8 +46,9 @@ function createTestIdentity(): CanonicalIdentity {
   };
 }
 
-// Check if MoltBridge server is reachable
+// Check if a TEST MoltBridge server was opted into and is reachable.
 async function isServerAvailable(): Promise<boolean> {
+  if (!MOLTBRIDGE_URL) return false; // opt-in not set => never contact any server
   try {
     const res = await fetch(`${MOLTBRIDGE_URL}/health`, { signal: AbortSignal.timeout(3000) });
     const data = await res.json() as any;
@@ -54,7 +65,9 @@ describe('MoltBridge Integration (real server)', () => {
 
   const config: MoltBridgeConfig = {
     enabled: true,
-    apiUrl: MOLTBRIDGE_URL,
+    // Only used when serverAvailable (which requires MOLTBRIDGE_URL set). The
+    // invalid fallback keeps this type-correct and unable to reach a real host.
+    apiUrl: MOLTBRIDGE_URL ?? 'http://moltbridge.invalid',
     autoRegister: false,
     enrichmentMode: 'manual',
     agentName: 'instar-integration-test',
@@ -64,7 +77,11 @@ describe('MoltBridge Integration (real server)', () => {
   beforeAll(async () => {
     serverAvailable = await isServerAvailable();
     if (!serverAvailable) {
-      console.log('  ⏭ MoltBridge server not available at localhost:3040 — skipping integration tests');
+      console.log(
+        MOLTBRIDGE_URL
+          ? `  ⏭ MoltBridge test server not reachable at ${MOLTBRIDGE_URL} — skipping integration tests`
+          : '  ⏭ MOLTBRIDGE_TEST_URL not set — skipping MoltBridge integration tests (opt-in; never point at production)',
+      );
       return;
     }
 


### PR DESCRIPTION
## Problem
`tests/integration/moltbridge-integration.test.ts` pointed unconditionally at `localhost:3040` and registered fake agents (`platform: "instar-test"`, name `"Echo Integration Test"`) with **no teardown** — and the MoltBridge server exposes **no agent-deregister endpoint** to clean up through. On any machine where the **production** MoltBridge registry was running on :3040, every local run added junk agents to the production graph.

This accumulated **691 test agents** in production (98% of the 702 total). They were purged 2026-05-26 (real agents preserved, backup taken).

## Fix
Gate the suite behind an explicit `MOLTBRIDGE_TEST_URL` env var (opt-in):
- **Unset → the suite skips and contacts no server** (the new default — prevents silently hitting whatever is on :3040).
- Operators run it against a **dedicated throwaway instance**: `MOLTBRIDGE_TEST_URL=http://localhost:3040 npm run test:integration` — never production.
- Type-correct fallback (`http://moltbridge.invalid`) ensures the config can never resolve to a real host even if misused.

## Verification
Ran the file with no env var set → suite skips with a clear message, register/verify flow does not run, no server contact. 3 tests pass (the standalone circuit-breaker test is unaffected).

## Notes
- Tests-only change; no `src/` or product behavior affected (no NEXT.md entry needed).
- Follow-up worth considering: a dedicated MoltBridge test instance in CI so this real-API suite runs there instead of being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)