### PR TITLE
Add provider-neutral robust development workflows

### DIFF
--- a/docs/specs/provider-neutral-robust-development-workflows.eli16.md
+++ b/docs/specs/provider-neutral-robust-development-workflows.eli16.md
@@ -1,0 +1,38 @@
+# Plain-English Overview: Making Strong Development Habits Portable
+
+Instar has developed a careful way of changing itself. Echo usually works in a
+separate worktree, writes a plan before coding, thinks through side effects,
+keeps evidence of what changed, and uses gates that refuse rushed or incomplete
+work. Those habits have helped Instar improve without turning every fix into a
+new problem.
+
+The issue is that some of those habits live in Echo's local workflow, or in
+Claude-shaped skill files, instead of in a format every Instar agent and every
+provider can discover. Codey, running on Codex, can already be held to the same
+git gate in the Instar repo. But Codex does not yet get the same clear
+phase-by-phase guidance that Echo gets from the local development skills.
+
+This spec turns that into a two-layer system. The first layer is a general
+"robust development" workflow that can help with any serious project. It covers
+worktree hygiene, planning first, reviewing side effects, keeping evidence,
+tracking work that is intentionally outside the change, and verifying before
+delivery. That should not be limited to Instar; it is useful whenever the work
+has real risk.
+
+The second layer is special to Instar itself. When the agent is changing Instar,
+the workflow adds the stricter Instar rules: the existing pre-commit gate, the
+trace file, the side-effects artifact, the ELI16 companion, human approval, and
+the repo-local development skills. Those requirements stay Instar-specific
+because they are tied to Instar's release process and constitution.
+
+The important principle is "context-gated, not Echo-gated." Echo should not be
+the only agent capable of improving Instar. But the Instar-specific workflow also
+should not appear everywhere during ordinary user tasks. The agent should see it
+when it is actually working in an approved Instar development context.
+
+This also adds a prevention mechanism: a weekly built-in drift-audit job,
+disabled by default. Echo should enable it first because Echo is currently the
+main Instar developer agent. The job compares what Echo is using locally against
+what Instar exposes to all agents and providers. If a useful practice is becoming
+Echo-only, the job surfaces it as a migration candidate before the gap grows.
+

--- a/docs/specs/provider-neutral-robust-development-workflows.md
+++ b/docs/specs/provider-neutral-robust-development-workflows.md
@@ -1,0 +1,157 @@
+---
+slug: provider-neutral-robust-development-workflows
+title: Provider-neutral robust development workflows
+author: codey
+project: instar
+status: approved
+review-convergence: "2026-05-26T16:24:56Z"
+review-iterations: 4
+review-note: "Converged through iterative Codey draft + Echo live-repo critique + Justin approval on 2026-05-26. This was a bootstrapping Codex parity spec; full automated /spec-converge is the capability this work makes portable."
+review-report: "docs/specs/reports/provider-neutral-robust-development-workflows-convergence.md"
+approved: true
+approved-by: justin
+eli16-overview: provider-neutral-robust-development-workflows.eli16.md
+---
+
+# Provider-Neutral Robust Development Workflows
+
+## Problem Statement
+
+Instar has a mature development discipline around Echo's work on Instar itself:
+worktree hygiene, spec-first planning, side-effects review, trace/evidence
+artifacts, semantic review, and gate-backed verification. That discipline has
+proven useful, but parts of it are still represented as Echo-local prose or
+Claude-shaped skills rather than provider-neutral workflow contracts.
+
+This creates two problems:
+
+- A Codex-based Instar agent can be subject to the same structural git gates,
+  but may not discover the phase-ordered guidance needed to satisfy them.
+- Practices that should benefit all serious project work remain coupled to
+  Instar-only development, even when the underlying discipline generalizes.
+
+## Goal
+
+Create a two-layer workflow model:
+
+1. **Generic robust project-development workflow** for substantial project work.
+2. **Instar evolution overlay** for changes to Instar itself.
+
+The model is context-gated, not Echo-gated. Any qualified Instar agent should be
+able to use robust development guidance. When the project is Instar itself, the
+Instar overlay adds the stricter repo-local gates and artifacts.
+
+## Non-Goals
+
+- Do not weaken the existing Instar pre-commit gate.
+- Do not reimplement the existing `write-trace.mjs` trace emitter.
+- Do not make Instar-specific release mechanics mandatory for every project.
+- Do not make agent identity the safety authority.
+- Do not force a heavyweight process for tiny, low-risk edits.
+
+## Layer 1: Generic Robust Project Development
+
+Layer 1 should be available to any project when work is substantial or risky.
+
+Robust mode is appropriate when work touches source behavior, persistence,
+external services, shared runtime behavior, security/privacy surfaces, release
+mechanics, or multi-file architecture. Small documentation edits, one-file local
+script changes with no behavior impact, and quick lookups can stay lightweight.
+
+The generic workflow has these phases:
+
+1. **Scope and context.** Identify the project, branch, topic binding, and risk.
+2. **Isolation strategy.** Prefer a dedicated worktree for substantial changes,
+   keep shared checkouts clean, and explain when a worktree is not used.
+3. **Provider placement constraints.** Some harnesses need worktrees under an
+   agent-home path for sandbox survival. This is provider/platform-specific, not
+   a universal rule.
+4. **Spec-first plan.** For substantial work, state the goal, non-goals,
+   affected surfaces, and review strategy before code.
+5. **Side-effects review.** Identify user-visible behavior, persistence,
+   security, external systems, rollback cost, and adjacent interactions.
+6. **Tracked later-work.** Any work intentionally left outside the change must
+   have an owner or tracker. Do not leave orphan "TODO later" statements.
+7. **Implementation.** Make scoped changes, preserve user work, avoid unrelated
+   refactors.
+8. **Evidence.** Record what changed, why, and how it was verified.
+9. **Verification.** Run focused checks and broader checks when shared behavior
+   is touched.
+10. **Delivery.** Summarize the result, evidence, and residual risk.
+
+## Layer 2: Instar Evolution Overlay
+
+Layer 2 applies when the project is Instar itself.
+
+Additional requirements:
+
+- Recognize the Instar source checkout through existing SourceTreeGuard and
+  coherence infrastructure. Do not hand-roll checkout detection.
+- Surface repo-local workflows such as `/instar-dev` and `/spec-converge`.
+- Use `skills/instar-dev/scripts/write-trace.mjs`; do not rebuild trace
+  emission.
+- Satisfy `scripts/instar-dev-precommit.js` unchanged.
+- Keep `approved: true` as a human authority action.
+- Include the ELI16 companion.
+- Pass the orphan later-work/content scanner.
+- Treat workflow descriptor edits as in-scope gate-protected files.
+- Validate a new provider path with semantic review from Echo or another
+  qualified reviewer.
+
+## Workflow Descriptors
+
+Provider-neutral descriptors make workflow guidance discoverable outside one
+harness's native slash-command system.
+
+This change adds:
+
+- `skills/robust-development/workflow.descriptor.json`
+- `skills/instar-dev/workflow.descriptor.json`
+- `skills/spec-converge/workflow.descriptor.json`
+
+The descriptor is the provider adapter contract. The existing `SKILL.md` prose
+remains the human source of intent where a skill exists.
+
+## Instar Developer Drift Audit
+
+Instar should ship an off-by-default built-in job template that audits drift
+between developer-local practices and provider-neutral Instar surfaces.
+
+The template should be enabled first for Echo because Echo is currently the
+primary Instar developer agent. It must not be only an Echo-local user job,
+because that would recreate the drift pattern it is meant to catch.
+
+The audit compares current developer practices against a checked-in baseline
+manifest of provider-neutral development surfaces. When it finds actionable
+drift, it produces a short private report or attention item. When no actionable
+drift exists, it stays quiet.
+
+## Safety Model
+
+Workflow entry is a signal, not an authority. Surfacing robust workflow guidance
+does not grant permission to ship.
+
+Authority remains with the project controls: topic/project coherence, worktree
+isolation, existing git gates, human approval, side-effects artifacts, tests,
+review, and merge discipline.
+
+For Instar, the structural gate plus human approval are the real authority. A
+"qualified agent" label must never become the safety story.
+
+## Acceptance Criteria
+
+- Codex can discover a generic robust development workflow for substantial
+  project work.
+- The generic workflow includes worktree hygiene and provider-specific placement
+  constraints.
+- In non-Instar projects, Codex does not surface Instar-specific gates.
+- In an Instar source checkout, Codex can discover the Instar overlay workflow
+  descriptors.
+- Descriptor edits are in scope for the Instar pre-commit gate.
+- The developer drift audit ships as a built-in job template, disabled by
+  default.
+- A checked-in baseline manifest exists for the drift audit.
+- Instar-specific artifacts continue to use `write-trace.mjs` and the existing
+  pre-commit gate.
+- Human approval remains human-controlled.
+

--- a/docs/specs/reports/provider-neutral-robust-development-workflows-convergence.md
+++ b/docs/specs/reports/provider-neutral-robust-development-workflows-convergence.md
@@ -1,0 +1,37 @@
+# Convergence Report: Provider-Neutral Robust Development Workflows
+
+## ELI16 Summary
+
+The spec started as a narrow Codex parity fix for `/instar-dev` and
+`/spec-converge`. Review changed that framing. The better design is a two-layer
+workflow system: a generic robust development workflow for any substantial
+project work, plus an Instar-specific overlay for changing Instar itself.
+
+Echo reviewed the draft against the live repo and confirmed that artifact
+emission is already provider-neutral through `write-trace.mjs`; the gap is
+discoverability and phase guidance. Justin then broadened the goal: strong
+development practices should not be restricted to Instar if they are useful for
+any project.
+
+## Review Iterations
+
+| Iteration | Reviewer | Material Finding | Resolution |
+| --- | --- | --- | --- |
+| 1 | Codey self-audit | Codex lacks `/instar-dev` and `/spec-converge` invocation guidance. | Drafted provider-neutral invocation spec. |
+| 2 | Echo | Artifact emission already works cross-harness; focus on discoverability and guidance. | Rescoped away from rebuilding trace emission. |
+| 3 | Justin | Worktrees and robust strategies should generalize beyond Instar. | Split generic robust workflow from Instar overlay. |
+| 4 | Echo | Worktree hygiene and sandbox-survival are different motivations; drift audit should ship as a template. | Added conditional placement rules, gate-protected descriptors, and built-in drift audit. |
+
+## Convergence Verdict
+
+Converged for implementation. The approved slice is:
+
+- Add provider-neutral workflow descriptors.
+- Add the built-in off-by-default developer drift audit job template.
+- Add a checked-in baseline manifest for the audit.
+- Include descriptor edits in the Instar pre-commit gate's in-scope set.
+
+This report represents a bootstrapping convergence path: the exact provider-neutral
+workflow being specified is the mechanism that will make future Codex-led
+convergence less manual.
+

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -76,6 +76,7 @@ function inScope(file) {
   if (file.startsWith('src/')) return true;
   if (file.startsWith('scripts/')) return true;
   if (file.startsWith('.husky/')) return true;
+  if (file.startsWith('skills/') && file.endsWith('/workflow.descriptor.json')) return true;
   if (file.startsWith('skills/') && file.endsWith('SKILL.md')) return true;
   if (file.startsWith('skills/') && (file.endsWith('.sh') || file.endsWith('.mjs') || file.endsWith('.js'))) return true;
   return false;

--- a/skills/instar-dev/workflow.descriptor.json
+++ b/skills/instar-dev/workflow.descriptor.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "id": "instar-dev",
+  "title": "Instar Development Overlay",
+  "audience": "Instar-developing agents in a recognized Instar source checkout",
+  "scope": "instar-source",
+  "sourceOfIntent": "skills/instar-dev/SKILL.md",
+  "requires": [
+    "recognized Instar source checkout via existing SourceTreeGuard/coherence infrastructure",
+    "approved spec with ELI16 overview",
+    "side-effects artifact",
+    "fresh trace from skills/instar-dev/scripts/write-trace.mjs"
+  ],
+  "phases": [
+    "spec-prerequisite",
+    "principle-check",
+    "planning",
+    "build",
+    "side-effects-review",
+    "tracked-later-work-check",
+    "second-pass-review-when-high-risk",
+    "trace-commit-verify"
+  ],
+  "scripts": {
+    "writeTrace": "skills/instar-dev/scripts/write-trace.mjs",
+    "preCommitGate": "scripts/instar-dev-precommit.js"
+  },
+  "humanAuthority": [
+    "approved: true in spec frontmatter"
+  ],
+  "providerNotes": {
+    "codex": "Surface as phase guidance plus callable repo scripts; do not depend on Claude slash command invocation."
+  }
+}
+

--- a/skills/robust-development/workflow.descriptor.json
+++ b/skills/robust-development/workflow.descriptor.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "id": "robust-development",
+  "title": "Robust Project Development",
+  "audience": "Any agent doing substantial project development work",
+  "scope": "generic-project",
+  "activation": {
+    "mode": "risk-based",
+    "suggestWhen": [
+      "source behavior changes",
+      "persistence or state changes",
+      "external service integration",
+      "shared runtime behavior",
+      "security or privacy surface",
+      "release or deployment mechanics",
+      "multi-file architecture"
+    ],
+    "lightweightWhen": [
+      "documentation-only edit",
+      "single-file local script tweak with no behavior change",
+      "quick lookup or explanation"
+    ]
+  },
+  "phases": [
+    "scope-and-context",
+    "isolation-strategy",
+    "provider-placement-constraints",
+    "spec-first-plan",
+    "side-effects-review",
+    "tracked-later-work",
+    "implementation",
+    "evidence",
+    "verification",
+    "delivery"
+  ],
+  "worktreePolicy": {
+    "default": "prefer-for-substantial-work",
+    "ifNotUsed": "explain why the lightweight path is safe",
+    "placement": "provider-conditional"
+  },
+  "authority": "workflow guidance only; project gates and human approvals remain authoritative"
+}
+

--- a/skills/spec-converge/workflow.descriptor.json
+++ b/skills/spec-converge/workflow.descriptor.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "id": "spec-converge",
+  "title": "Instar Spec Convergence",
+  "audience": "Instar-developing agents preparing an Instar source change",
+  "scope": "instar-source",
+  "sourceOfIntent": "skills/spec-converge/SKILL.md",
+  "requires": [
+    "spec file under docs/specs",
+    "ELI16 overview companion",
+    "reviewer findings resolved to convergence"
+  ],
+  "phases": [
+    "initial-review-round",
+    "spec-update",
+    "convergence-check",
+    "convergence-report",
+    "frontmatter-tag",
+    "user-handoff"
+  ],
+  "scripts": {
+    "writeConvergenceTag": "skills/spec-converge/scripts/write-convergence-tag.mjs"
+  },
+  "outputs": [
+    "review-convergence frontmatter tag",
+    "review report under docs/specs/reports",
+    "user approval handoff"
+  ],
+  "humanAuthority": [
+    "approved: true is not written by this workflow"
+  ]
+}
+

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-26T04:31:00.352Z",
-  "instarVersion": "1.2.81",
+  "generatedAt": "2026-05-26T16:54:50.021Z",
+  "instarVersion": "1.2.83",
   "entryCount": 191,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -392,7 +392,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -400,7 +400,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -408,7 +408,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -416,7 +416,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -424,7 +424,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -432,7 +432,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -440,7 +440,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -448,7 +448,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -456,7 +456,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -464,7 +464,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -472,7 +472,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -480,7 +480,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -488,7 +488,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -496,7 +496,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -504,7 +504,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -512,7 +512,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -520,7 +520,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -528,7 +528,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -536,7 +536,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -544,7 +544,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -552,7 +552,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -560,7 +560,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -568,7 +568,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -576,7 +576,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -584,7 +584,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -592,7 +592,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -600,7 +600,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -608,7 +608,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -616,7 +616,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -624,7 +624,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -632,7 +632,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -640,7 +640,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -648,7 +648,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -656,7 +656,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -664,7 +664,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -672,7 +672,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -680,7 +680,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -688,7 +688,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -696,7 +696,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -704,7 +704,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -712,7 +712,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -720,7 +720,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -728,7 +728,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -744,7 +744,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "14df7a55267370b38a717411ec2dd50be2364f68e4e6e4c6ca031b9ce5f2ca40",
+      "contentHash": "e7ecb683c067a3e36768c52252eac303ea9178c3a060828f5673251e8b8908c1",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1440,7 +1440,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "823d36d25490f6afb6968e96d27a538ce031dae7d97a7f2c979ddab707d2918a",
+      "contentHash": "8cd98b665356990ea26c422b9bab3f6aee15ce48798d5fe17fff3757fc617213",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1448,7 +1448,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "b0de35800c7eacf06e520b7224d3169b81e8f0293ce65b69047fae3be1befad4",
+      "contentHash": "a689041288c39070fd0d13362193bd4335367cb5a1db5458e3f73a6295b6e4c7",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {
@@ -1472,7 +1472,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "6d39067fcc08b508d083da5fa99d977c23a07c08f273225432faf018d301b702",
+      "contentHash": "bad77b5bab7acab1f4f10870e0ec2e8cf56004a01ec00a05076159e400419a34",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/src/data/instar-dev-surface-baseline.json
+++ b/src/data/instar-dev-surface-baseline.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-26T16:24:56Z",
+  "description": "Baseline manifest for the Instar developer drift audit. It lists provider-neutral development surfaces that should not silently regress into Echo-only practice.",
+  "surfaces": [
+    {
+      "id": "workflow:robust-development",
+      "kind": "workflow-descriptor",
+      "path": "skills/robust-development/workflow.descriptor.json",
+      "scope": "generic-project"
+    },
+    {
+      "id": "workflow:instar-dev",
+      "kind": "workflow-descriptor",
+      "path": "skills/instar-dev/workflow.descriptor.json",
+      "scope": "instar-source"
+    },
+    {
+      "id": "workflow:spec-converge",
+      "kind": "workflow-descriptor",
+      "path": "skills/spec-converge/workflow.descriptor.json",
+      "scope": "instar-source"
+    },
+    {
+      "id": "script:instar-dev-write-trace",
+      "kind": "script",
+      "path": "skills/instar-dev/scripts/write-trace.mjs",
+      "scope": "instar-source"
+    },
+    {
+      "id": "script:spec-converge-write-tag",
+      "kind": "script",
+      "path": "skills/spec-converge/scripts/write-convergence-tag.mjs",
+      "scope": "instar-source"
+    },
+    {
+      "id": "gate:instar-dev-precommit",
+      "kind": "gate",
+      "path": "scripts/instar-dev-precommit.js",
+      "scope": "instar-source"
+    }
+  ]
+}
+

--- a/src/scaffold/templates/jobs/instar/developer-tools-drift-audit.md
+++ b/src/scaffold/templates/jobs/instar/developer-tools-drift-audit.md
@@ -1,0 +1,57 @@
+---
+name: Developer Tools Drift Audit
+description: Weekly check for drift between Instar developer-local practices and provider-neutral Instar workflows. Off by default; useful for agents actively developing Instar.
+schedule: "0 11 * * 1"
+priority: medium
+expectedDurationMinutes: 8
+model: capable
+enabled: false
+tags:
+  - cat:learning
+  - audit
+  - instar-dev-only
+toolAllowlist: "*"
+unrestrictedTools: true
+---
+Run a weekly developer-tools drift audit for Instar development.
+
+This job prevents useful development practices from staying local to one agent
+or provider. It is shipped as a built-in template and disabled by default. Echo
+is expected to be the first enabled instance because Echo is currently the
+primary Instar developer agent, but the template is not Echo-only by design.
+
+The job:
+
+1. Verify context. Continue only if the current environment is a recognized
+   Instar source checkout or an approved Instar development worktree. Use the
+   existing SourceTreeGuard/coherence surfaces if available. If this is not an
+   Instar development context, stay silent.
+
+2. Read the checked-in baseline at `src/data/instar-dev-surface-baseline.json`.
+   This is the prior-state contract for provider-neutral development surfaces.
+
+3. Inventory current developer surfaces:
+   - `skills/*/workflow.descriptor.json`
+   - `skills/*/SKILL.md`
+   - scripts referenced by workflow descriptors
+   - Instar development gates under `scripts/`
+   - built-in job templates under `src/scaffold/templates/jobs/instar/`
+   - provider-specific scaffolding that exposes development workflows
+
+4. Compare current surfaces to the baseline. Look for:
+   - developer practices present in Echo/local prose but absent from descriptors
+   - scripts or gates other agents can trigger but cannot discover how to satisfy
+   - Claude-only assumptions in guidance that should be provider-neutral
+   - robust project-development practices that should generalize beyond Instar
+   - Instar-only mechanics that should remain in the Instar overlay
+   - resolved migration candidates that should update the baseline
+
+5. If no actionable drift exists, stay silent. Most weeks should be silent.
+
+6. If actionable drift exists, create a short private report or attention item.
+   Lead with the practical gap, then list migration candidates and recommended
+   next actions. Keep Telegram output brief and plain-English.
+
+7. This is a guardian job, not a doer. Surface drift and proposed routing. Do not
+   autonomously change workflows, gates, or provider surfaces from the job run.
+

--- a/tests/unit/instar-dev-precommit-deferrals.test.ts
+++ b/tests/unit/instar-dev-precommit-deferrals.test.ts
@@ -88,6 +88,7 @@ describe('instar-dev pre-commit — orphan deferrals enforcement', () => {
     specFrontmatter: string;
     specBody: string;
     artifactBody?: string;
+    touchedRel?: string;
   }): { specPath: string; artifactPath: string; tracePath: string } {
     const specRel = path.join('docs', 'specs', 'fixture.md');
     const eli16Rel = path.join('docs', 'specs', 'fixture.eli16.md');
@@ -110,16 +111,17 @@ describe('instar-dev pre-commit — orphan deferrals enforcement', () => {
 
     const sha = crypto.createHash('sha256').update(artifactBody).digest('hex');
 
-    // Add a benign staged file under src/ to satisfy the "in-scope" check.
-    const srcRel = 'src/touched.ts';
-    fs.writeFileSync(path.join(sandbox, srcRel), '// touched\n');
+    // Add a benign staged file under an in-scope path to exercise the gate.
+    const touchedRel = opts.touchedRel ?? 'src/touched.ts';
+    fs.mkdirSync(path.dirname(path.join(sandbox, touchedRel)), { recursive: true });
+    fs.writeFileSync(path.join(sandbox, touchedRel), '// touched\n');
 
     fs.writeFileSync(
       path.join(sandbox, traceRel),
       JSON.stringify({
         phase: 'complete',
         slug: 'fixture',
-        coveredFiles: [srcRel],
+        coveredFiles: [touchedRel],
         artifactPath: artifactRel,
         artifactSha256: sha,
         specPath: specRel,
@@ -127,7 +129,7 @@ describe('instar-dev pre-commit — orphan deferrals enforcement', () => {
       }, null, 2),
     );
 
-    execFileSync('git', ['add', srcRel, specRel, eli16Rel, artifactRel], { cwd: sandbox });
+    execFileSync('git', ['add', touchedRel, specRel, eli16Rel, artifactRel], { cwd: sandbox });
     return { specPath: specRel, artifactPath: artifactRel, tracePath: traceRel };
   }
 
@@ -252,5 +254,16 @@ describe('instar-dev pre-commit — orphan deferrals enforcement', () => {
     const result = await runHook(process.env, sandbox);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toMatch(/deferrals/i);
+  });
+
+  it('treats workflow descriptors as in-scope behavioral surfaces', async () => {
+    stageFixture({
+      specFrontmatter: 'title: Descriptor spec\napproved: true\nreview-convergence: tactical\neli16-overview: fixture.eli16.md',
+      specBody: 'Descriptor updates are reviewed through the same gate as skill and script changes.',
+      touchedRel: 'skills/instar-dev/workflow.descriptor.json',
+    });
+    const result = await runHook(process.env, sandbox);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toMatch(/covers 1 in-scope file/);
   });
 });

--- a/tests/unit/provider-neutral-workflow-descriptors.test.ts
+++ b/tests/unit/provider-neutral-workflow-descriptors.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+
+function readJson<T>(relPath: string): T {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, relPath), 'utf-8')) as T;
+}
+
+describe('provider-neutral workflow descriptors', () => {
+  const descriptors = [
+    {
+      relPath: 'skills/robust-development/workflow.descriptor.json',
+      id: 'robust-development',
+      scope: 'generic-project',
+    },
+    {
+      relPath: 'skills/instar-dev/workflow.descriptor.json',
+      id: 'instar-dev',
+      scope: 'instar-source',
+    },
+    {
+      relPath: 'skills/spec-converge/workflow.descriptor.json',
+      id: 'spec-converge',
+      scope: 'instar-source',
+    },
+  ];
+
+  it('declares the expected provider-neutral workflow surfaces', () => {
+    for (const descriptor of descriptors) {
+      const json = readJson<Record<string, unknown>>(descriptor.relPath);
+
+      expect(json.schemaVersion).toBe(1);
+      expect(json.id).toBe(descriptor.id);
+      expect(json.scope).toBe(descriptor.scope);
+      expect(Array.isArray(json.phases)).toBe(true);
+      expect((json.phases as unknown[]).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps the drift baseline aligned with descriptor files', () => {
+    const baseline = readJson<{
+      surfaces: Array<{ id: string; kind: string; path: string; scope: string }>;
+    }>('src/data/instar-dev-surface-baseline.json');
+
+    for (const descriptor of descriptors) {
+      const baselineEntry = baseline.surfaces.find((surface) => surface.path === descriptor.relPath);
+      expect(baselineEntry, `Missing baseline entry for ${descriptor.relPath}`).toBeDefined();
+      expect(baselineEntry?.kind).toBe('workflow-descriptor');
+      expect(baselineEntry?.scope).toBe(descriptor.scope);
+    }
+  });
+
+  it('ships the developer-tools drift audit as an off-by-default built-in template', () => {
+    const jobRelPath = 'src/scaffold/templates/jobs/instar/developer-tools-drift-audit.md';
+    const job = fs.readFileSync(path.join(ROOT, jobRelPath), 'utf-8');
+
+    expect(job).toMatch(/^enabled:\s*false$/m);
+    expect(job).toContain('src/data/instar-dev-surface-baseline.json');
+    expect(job).toContain('skills/*/workflow.descriptor.json');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,35 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+Instar now ships provider-neutral development workflow descriptors for robust project work, Instar source work, and spec convergence. This gives non-Echo and non-Claude agents a discoverable contract for the same development discipline Echo has been using: worktree-aware isolation, spec-first planning, side-effects review, evidence, verification, and trace-backed delivery.
+
+The Instar-specific overlay remains context-gated to recognized Instar source checkouts, while the generic robust-development descriptor can apply to substantial work in any project. Workflow descriptor edits are now covered by the Instar development pre-commit gate, so future drift in these surfaces requires the same reviewed trace path as skill and script edits.
+
+The release also ships an off-by-default weekly developer-tools drift audit template. It compares checked-in provider-neutral development surfaces against practices that may have stayed local to one agent or provider, then surfaces actionable drift without autonomously rewriting workflows.
+
+## What to Tell Your User
+
+Instar is getting better at sharing its own development discipline across agents. When an agent is doing serious project work, it has clearer guidance for planning, isolating changes, checking side effects, and proving the result. When an agent is specifically evolving Instar, it still follows the stricter Instar development path.
+
+There is also a quiet weekly audit template for Instar maintainers. It is off unless enabled, and its job is to notice when useful development practices have drifted into one agent's local habits instead of becoming available to all qualified Instar agents.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Robust project development workflow descriptor | Available in the checked-in skills surface for substantial project work. |
+| Instar development overlay descriptor | Available in recognized Instar source checkouts for Instar evolution work. |
+| Spec convergence workflow descriptor | Available in recognized Instar source checkouts for approved spec preparation. |
+| Developer-tools drift audit template | Installed as a built-in job template and disabled by default. |
+| Descriptor pre-commit coverage | Automatic when workflow descriptor files are staged in an Instar source commit. |
+
+## Evidence
+
+Validated with focused unit tests for descriptor shape, baseline alignment, disabled job template coverage, and pre-commit handling of workflow descriptors. Ran the full lint command and build. The build scan included the new developer-tools drift audit template; local lock-file signing skipped only because this worktree does not have the release private key.

--- a/upgrades/side-effects/provider-neutral-robust-development-workflows.md
+++ b/upgrades/side-effects/provider-neutral-robust-development-workflows.md
@@ -1,0 +1,29 @@
+# Side-effects Review: Provider-neutral Robust Development Workflows
+
+## 1. Behavior Surface
+
+This change introduces provider-neutral workflow descriptors for robust project development, Instar development, and spec convergence. It also adds a checked-in drift baseline and an off-by-default built-in job template that can compare provider-neutral Instar development surfaces against practices that may have stayed local to one agent or provider.
+
+## 2. User-visible Impact
+
+Most users see no immediate runtime change. Agents that receive the updated source can discover the generic robust-development workflow and the Instar-specific overlay without depending on a Claude slash command. Instar-developing agents also gain an installable, disabled weekly drift audit template that can be enabled when they are actively maintaining Instar itself.
+
+## 3. Safety and Authority
+
+The descriptors are guidance, not new authority. For Instar source changes, the existing authority chain remains the approved spec, ELI16 overview, side-effects artifact, trace, and pre-commit gate. The new pre-commit rule treats `skills/**/workflow.descriptor.json` as in-scope, so future edits to these guidance surfaces must pass the same Instar development review process as skill and script changes.
+
+## 4. Compatibility
+
+The new generic robust-development descriptor is scoped to substantial project development work in any project. The Instar development and spec convergence descriptors remain scoped to recognized Instar source checkouts. The built-in job template is disabled by default and instructs non-Instar contexts to stay silent, so it should not add noise for ordinary agent installs.
+
+## 5. Operational Concerns
+
+The developer-tools drift audit reads `src/data/instar-dev-surface-baseline.json` and inventories checked-in development surfaces. It should surface only actionable drift, preferably through a private report or attention item. It must not autonomously rewrite workflows or gates during a scheduled job run.
+
+## 6. Tests and Verification
+
+Focused tests cover the workflow descriptors, drift baseline alignment, disabled job template, and the pre-commit gate's treatment of workflow descriptors as in-scope behavioral surfaces. The existing built-in manifest test remains part of the focused test run to detect accidental source/manifest drift.
+
+## 7. Later-work Accounting
+
+No untracked later-work is introduced by this change. The weekly drift audit is itself the guard against future capability drift: it should surface concrete migration candidates when useful developer practices appear outside the provider-neutral descriptors or Instar overlay.


### PR DESCRIPTION
## Summary

- Adds provider-neutral workflow descriptors for robust project development, Instar development, and spec convergence.
- Adds a checked-in developer surface baseline and an off-by-default weekly developer-tools drift audit job template.
- Extends the Instar dev pre-commit gate to treat workflow descriptors as reviewed behavioral surfaces.
- Adds approved spec, ELI16 overview, convergence report, side-effects review, upgrade guide, and focused tests.

## Verification

- `npm test -- tests/unit/instar-dev-precommit-deferrals.test.ts tests/unit/provider-neutral-workflow-descriptors.test.ts tests/unit/builtin-manifest.test.ts`
- `npm run lint`
- `npm run build`
- `node scripts/instar-dev-precommit.js`
- `npm run check:upgrade-guide`
- Pre-push gate passed and branch pushed

## Notes

The standards-conformance registry canary passed in the isolated worktree, but the full HTTP conformance check is bound to the running Codey state project and degraded without an intelligence provider for this worktree. The spec already includes the live Codey/Echo convergence report and Justin approval.
