### PR TITLE
fix(codex): run intelligence-provider judgment calls in a clean scratch dir

### DIFF
--- a/docs/specs/CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.eli16.md
+++ b/docs/specs/CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.eli16.md
@@ -1,0 +1,53 @@
+# The Codex "clean notepad" fix — in plain terms
+
+## The one-sentence version
+
+Codey reloads his entire 26,000-character identity and runs his full startup routine every
+single time the system asks him a tiny background question — about 1,500 times a day — and
+this fix makes those background questions use a clean, blank notepad instead.
+
+## What's actually happening
+
+All day long, instar quietly asks the agent little yes/no-ish questions in the background:
+"Is this message an emergency-stop or just normal?" "Did the agent finish its turn?"
+"Summarize this chat." These are tiny — the answer is often a single word.
+
+For me (Claude), the system asks these on a blank notepad. My code literally has a line
+that says "leave the identity out of these little calls."
+
+Codey has no such line. So every one of those ~1,500 daily questions makes him:
+1. Re-read his whole 26 KB identity document, and
+2. Run his entire "I'm starting a session!" routine — the one that announces itself and
+   pings the monitoring system.
+
+Just to answer "normal."
+
+## Why that's the cause of the mess you saw
+
+- The "still working / message delivered" spam? That's his startup routine firing 1,500
+  times a day — the monitor keeps thinking a brand-new session just began.
+- The "couldn't deliver, please resend"? At busy moments a dozen of these heavyweight
+  questions pile up in one minute, the machine chokes, and your actual message can't get
+  in the door.
+
+It's like making someone put on their full uniform, clock in, and read the handbook every
+time you want to ask them the time. Do that 1,500 times and of course they look frazzled.
+
+## The fix
+
+Give Codey's background questions the same clean notepad mine already use: ask them in an
+empty side-room that has no identity document and no startup routine attached. One small
+change to one file. He keeps his full identity and startup routine for real work — this
+only changes the throwaway background questions.
+
+## How we'll know it actually worked
+
+We don't trust the green checkmarks alone. We reproduce it live: ask Codey a background
+question before the fix and confirm his logs show the giant identity + startup routine;
+then after the fix, confirm the same question's log is bare. Seeing the "before" actually
+stop is the proof.
+
+## Where this fits
+
+This is step zero. It ships on its own, first — so that when we start the bigger
+"mentor Codey" project, we're building on a healthy system instead of one with a leak.

--- a/docs/specs/CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md
+++ b/docs/specs/CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md
@@ -1,0 +1,147 @@
+---
+title: Codex Intelligence-Provider Clean-Call Fix
+status: approved
+approved: true
+approver: justin
+approved-at: "2026-05-26T20:42:33Z"
+owner: echo
+created: 2026-05-26
+companion-eli16: CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.eli16.md
+eli16-overview: CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.eli16.md
+review-convergence: "2026-05-26T20:37:02.352Z"
+review-iterations: 2
+review-completed-at: "2026-05-26T20:37:02.352Z"
+review-report: "docs/specs/reports/codex-intelligence-provider-clean-call-convergence.md"
+---
+
+# Codex Intelligence-Provider Clean-Call Fix
+
+## Problem
+
+Instar makes ~1,500+ small internal LLM "judgment" calls per agent per day — message
+classification, terminal-output analysis, view-metadata, arc extraction, usher,
+coherence checks, commitment detection, session synthesis, etc. All of these route
+through the agent's configured `IntelligenceProvider`.
+
+For Claude agents this is cheap and clean. `ClaudeCliIntelligenceProvider.evaluate()`
+passes `--setting-sources user`, with the explicit comment: *"Exclude project/local
+CLAUDE.md to prevent identity context from contaminating classification and evaluation
+prompts."* The judgment call runs on a clean notepad — no identity, no project hooks.
+
+`CodexCliIntelligenceProvider.evaluate()` has **no equivalent**. It runs:
+
+```
+codex exec --model M --sandbox read-only --cd <workingDirectory> --skip-git-repo-check <prompt>
+```
+
+where `workingDirectory` is the agent's project directory (e.g.
+`/Users/justin/Documents/Projects/instar-codey`, passed by
+`intelligenceProviderFactory`). Because `codex exec` runs *in the project dir*, it:
+
+1. **Loads `AGENTS.md`** — the agent's full ~26 KB rendered identity — into every call.
+2. **Fires the project's `.codex/hooks.json` hooks** — `session_start`,
+   `user_prompt_submit`, `stop` — on every call (confirmed in the live agent's
+   `~/.codex/config.toml` `[hooks.state]` bound to the project path).
+
+### Evidence (2026-05-26 diagnostic)
+
+`~/.codex/sessions/` rollout logs for 2026-05-25: **1,601** `codex exec` spawns in one
+day, up to 12/minute. Tallied by task prompt, ~1,550 were internal judgment calls
+(notification-protocol job 496, terminal-output analysis 305, view-metadata 229,
+arc-extractor 133, message-classifier 73, usher 61, coherence 12, commitment-detect 18,
+synthesis 9, …). Only ~48 were real work (inter-agent messages). A sampled 21:52
+classifier rollout re-injected the 26 KB identity + a full `SESSION START` block to
+output a single word: `normal`.
+
+### Downstream damage
+
+- **Notification/standby spam** ("actively working / message delivered / still working"):
+  the `session_start` hook firing on ~1,550 spawns/day makes instar's monitoring layer
+  think real sessions are constantly starting.
+- **Delivery failures** ("couldn't deliver — please resend"): 12 heavyweight spawns in a
+  single minute saturate the machine, so a real inbound message can't get a process slot.
+- Cost: every one-word judgment pays a full 26 KB identity load + hook chain.
+
+This is the dominant Codex-specific defect. It is plumbing, not behavior — the Codex
+integration is making the agent put on its full uniform to answer "what time is it" 1,500
+times a day.
+
+## Fix
+
+Mirror the Claude provider's clean-notepad guarantee inside
+`CodexCliIntelligenceProvider`. Judgment calls must run with **no project identity and no
+project hooks**.
+
+**Mechanism (primary):** run `codex exec` with `--cd` pointed at a dedicated, empty,
+instar-managed **scratch directory** that (a) contains no `AGENTS.md` and (b) has no
+`.codex/hooks.json`. With no `.codex/hooks.json` at or above that path, no project hooks
+fire; with no `AGENTS.md`, no identity loads. `--skip-git-repo-check` (already present)
+keeps it runnable in a non-git dir.
+
+- The scratch dir is created via `fs.mkdtempSync(<os.tmpdir()>/instar-codex-intel-scratch-)`,
+  cached for the process, and **re-verified each call** (recreated if a tmp-reaper deleted
+  it during a long-lived process).
+- **Security — why `mkdtemp`, not a fixed name (convergence finding).** Codex discovers
+  hooks by walking *up* from the cwd and fires any `.codex/hooks.json` it finds, and
+  `project_doc_max_bytes=0` does **not** gate hooks. On Linux `os.tmpdir()` is the
+  world-writable `/tmp`, so a *fixed, guessable* dir name could be pre-created (or
+  symlinked) by another local user with a planted `.codex/hooks.json`, re-introducing hook
+  execution under the agent's identity. `mkdtempSync` defeats this: it appends an
+  unguessable random suffix, creates the dir with mode `0700` owned by this process, and
+  refuses to follow a pre-existing path — so nothing can be planted in the cwd these calls
+  run in. (On macOS `os.tmpdir()` is already a per-user `0700` dir, but instar ships to
+  Linux hosts too, so this hardening is required, not optional.)
+- The provider no longer stores `workingDirectory` (the field is removed). It is retained
+  on the options *type* for API compatibility (the factory still forwards it), but it is
+  never used as the exec cwd — these calls "don't depend on cwd content" per the existing
+  comment. Verified: of the three construction sites (`reflect.ts`, `route.ts`,
+  `server.ts`), only `route.ts` passes a `workingDirectory` and it uses that value solely
+  for its own `PreferenceStore` DB path, never for the codex cwd — so dropping it breaks
+  nothing.
+
+**Belt-and-suspenders:** also pass `-c project_doc_max_bytes=0` to hard-disable project-doc
+loading even if a stray `AGENTS.md` ever sits *above* the scratch path on the walk-up. This
+is a real, stable Codex config key already used elsewhere in instar
+(`src/providers/adapters/openai-codex/control/contextScopeControl.ts`); the primary
+mechanism does not depend on it (it covers the `AGENTS.md` walk-up case, not hooks — hooks
+are closed by the unguessable dir name above).
+
+Scope: one file (`src/core/CodexCliIntelligenceProvider.ts`), plus a tiny private
+scratch-dir helper. No config/hook/template migration is required — this is a code-only
+change. Per the Migration Parity Standard, code-only changes reach existing Codex agents
+through the normal update path with no migration step; this is noted explicitly so a
+reviewer does not expect a `PostUpdateMigrator` entry.
+
+## Testing
+
+This change is a spawn-arg / cwd contract on a single provider class — it adds no HTTP route
+and no dependency-injected server component, so the routed-feature "feature is alive" E2E
+tier does not map. Coverage is the unit contract plus the mandatory live reproduction.
+
+- **Unit (`tests/unit/CodexCliIntelligenceProvider.test.ts`, present in this change):** uses
+  a fake-codex shim that echoes its argv, and asserts:
+  - `--cd` is the instar scratch dir and is **not** the passed `workingDirectory`;
+  - the scratch dir exists and is empty (no `AGENTS.md`, no `.codex/`);
+  - `-c project_doc_max_bytes=0` is passed;
+  - the scratch dir is created with mode `0700` (not group/other accessible);
+  - the dir name is random-suffixed (unguessable), not a fixed path;
+  - the dir is recreated if deleted mid-process (tmp-reaper recovery);
+  - the existing arg-shape + non-zero-exit + env-allowlist tests still pass.
+- **Live / bug-fix evidence bar (REQUIRED — unit tests are not evidence):** reproduce on a
+  real Codex agent. Before the change: trigger a classify call and confirm its rollout loads
+  the 26 KB identity + a `SESSION START` block. After the change: confirm the rollout for the
+  same call is bare (no identity, no session_start). This is the test-as-self gate and must
+  be captured before ship.
+
+## Explicitly excluded (covered elsewhere)
+
+- The **cadence** of internal judgment calls (~1,550/day even when each is cheap) is a
+  separate, framework-shared optimization, addressed by its own future spec — not changed by
+  this fix. <!-- tracked: topic-13435 -->
+- The verbose-narration and force-push-punting symptoms are separate Codex-guidance gaps,
+  owned by the framework-onboarding mentor system spec. <!-- tracked: topic-13435 -->
+
+## Connection
+
+This is the Phase 0 prerequisite of the framework-onboarding mentor system. It ships first so
+the mentor loop runs on a healthy system rather than amplifying the leak.

--- a/docs/specs/reports/codex-intelligence-provider-clean-call-convergence.md
+++ b/docs/specs/reports/codex-intelligence-provider-clean-call-convergence.md
@@ -1,0 +1,36 @@
+# Convergence Report — Codex Intelligence-Provider Clean-Call Fix
+
+## ELI10 Overview
+
+Instar agents constantly ask themselves tiny background questions — "is this message urgent?", "did that finish?", "summarize this." For Claude-powered agents these little questions are asked on a blank notepad. For the Codex-powered agent (Codey), each one was accidentally booting his *entire* 26,000-character identity and running his full session-startup routine — about 1,550 times a day. That flood is what made Codey spam "still working" messages and drop incoming messages. This change gives Codey's background questions the same blank notepad: it runs them in an empty throwaway folder instead of his project folder, so no identity and no startup hooks load.
+
+The review process changed one important thing: *which* throwaway folder. The first draft used a single, predictably-named folder in the system temp area. On a shared Linux machine, that predictable name is a security hole — another user could create that folder first and slip a malicious "hook" file into it that Codey would then run as himself. The fix now creates a folder with a random, unguessable name and locked-down (owner-only) permissions, so nothing can be planted in it. The tradeoff is essentially nil: it's the same mechanism, just with a safe folder name.
+
+## Original vs Converged
+
+- **Originally:** the scratch folder was a fixed path, `<tmp>/instar-codex-intel-scratch`, created with a plain `mkdir`. On Linux (`/tmp` is world-writable) an attacker could pre-create it or symlink it and drop a `.codex/hooks.json` inside — and the `project_doc_max_bytes=0` guard does NOT block hooks, only the identity doc. That re-opened hook execution under the agent's identity.
+- **After review:** the folder is created with `fs.mkdtempSync(...)`, which appends a random suffix, sets owner-only (`0700`) permissions, and refuses to reuse a pre-existing path. The path is now unguessable, so nothing can be planted in it. The provider also re-checks the folder before each call and recreates it if a temp-cleaner removed it. The now-unused `workingDirectory` field was removed (kept on the type only for API compatibility).
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged | Material findings | Spec/code changes |
+|-----------|-----------------------|-------------------|-------------------|
+| 1 | adversarial, lessons-aware (security); integration = clean | 1 (shared predictable tmp name → Linux squatting / planted hooks.json) | switched to `mkdtempSync` (0700, unguessable) + re-verify-before-use; removed dead `workingDirectory` field; added 3 hardening unit tests; clarified spec (hooks not covered by `project_doc_max_bytes`; caller analysis; honest testing tiers) |
+| 2 | (converged) | 0 | none |
+
+External cross-model reviewers (GPT/Gemini/Grok) were skipped under abbreviated convergence — permitted for a single-file change with no new route/state/network surface. The mandatory lessons-aware reviewer ran.
+
+## Full Findings Catalog
+
+**Iteration 1**
+
+- **MATERIAL — shared, predictable scratch path (adversarial + lessons-aware).** Fixed name under world-writable `/tmp` (Linux) lets another local user pre-create/symlink the dir and plant `.codex/hooks.json`; codex walks up from cwd and fires it; `project_doc_max_bytes=0` does not cover hooks. macOS unaffected (per-user `0700` tmpdir). **Resolution:** `mkdtempSync` (random suffix, `0700`, no-follow) + re-verify each call. Closed.
+- **MINOR — dead `workingDirectory` field (integration + lessons).** Field no longer read after the cwd change; type "lies." **Resolution:** field removed; option retained on the type for API compat with a comment. Closed.
+- **MINOR — testing tiers vs spec text (lessons).** Spec promised three tiers but the change is a spawn-arg/cwd contract with no HTTP route. **Resolution:** testing section rewritten to be honest — unit contract (incl. new security assertions) + mandatory live test-as-self reproduction; routed-feature E2E tier explicitly noted as not applicable. Closed.
+- **CLEAN (integration).** Caller audit: only `reflect.ts`, `route.ts`, `server.ts` construct the provider; none depend on the codex cwd content (`route.ts`'s `workingDirectory` feeds only its own PreferenceStore DB path). Migration-parity claim ("code-only, no migrator entry") verified correct. `project_doc_max_bytes=0` confirmed a real, in-use key. No concurrency race. Claude path untouched.
+
+**Iteration 2** — re-review of the hardened design surfaced no material findings. `mkdtempSync` structurally eliminates the squatting/symlink/planted-hooks vector; minors addressed.
+
+## Convergence verdict
+
+Converged at iteration 2. No material findings in the final round. Spec is ready for user review and approval.

--- a/src/core/CodexCliIntelligenceProvider.ts
+++ b/src/core/CodexCliIntelligenceProvider.ts
@@ -13,11 +13,53 @@
  */
 
 import { execFile } from 'node:child_process';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { IntelligenceProvider, IntelligenceOptions } from './types.js';
 import { resolveCliModelFlag } from '../providers/adapters/openai-codex/models.js';
 import { buildCodexChildEnv } from '../providers/adapters/openai-codex/transport/codexSpawn.js';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+const INTELLIGENCE_SCRATCH_DIR_PREFIX = 'instar-codex-intel-scratch-';
+
+let cachedScratchDir: string | null = null;
+
+/**
+ * Lazily create and return an EMPTY scratch directory used as the `--cd`
+ * for every judgment call.
+ *
+ * Running `codex exec` in the agent's project directory loads the full
+ * ~26 KB `AGENTS.md` identity AND fires the project's `.codex/hooks.json`
+ * hooks (session_start / user_prompt_submit / stop) on every call — turning
+ * a one-word classification into a full agent boot. An empty, hook-free
+ * scratch dir gives these calls the clean-notepad guarantee that
+ * `ClaudeCliIntelligenceProvider` gets via `--setting-sources user`:
+ * no project doc, and no project hooks.
+ *
+ * SECURITY (why mkdtemp, not a fixed name): Codex discovers hooks by walking
+ * UP from the cwd and fires any `.codex/hooks.json` it finds — and
+ * `project_doc_max_bytes=0` does NOT cover hooks. On Linux `os.tmpdir()` is
+ * the world-writable `/tmp`, so a fixed, guessable dir name could be
+ * pre-created (or symlinked) by another local user with a planted
+ * `.codex/hooks.json`, re-introducing hook execution under our identity.
+ * `mkdtempSync` defeats this: it appends an unguessable random suffix, creates
+ * the dir with mode 0700 owned by this process, and refuses to follow a
+ * pre-existing path — so nothing can be planted in the cwd these calls run in.
+ *
+ * The dir is re-verified each call: a tmp-reaper may delete it during a
+ * long-lived process, so we recreate it if it has gone missing.
+ *
+ * Bug (2026-05-26): ~1,550 such judgment spawns/day were re-injecting the
+ * identity + firing session_start, causing notification spam and spawn-storm
+ * delivery failures. Spec: CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md.
+ */
+function resolveIntelligenceScratchDir(): string {
+  if (cachedScratchDir && existsSync(cachedScratchDir)) return cachedScratchDir;
+  cachedScratchDir = mkdtempSync(join(tmpdir(), INTELLIGENCE_SCRATCH_DIR_PREFIX));
+  return cachedScratchDir;
+}
 
 export interface CodexCliIntelligenceProviderOptions {
   /** Absolute path to the `codex` CLI binary. */
@@ -29,9 +71,11 @@ export interface CodexCliIntelligenceProviderOptions {
    */
   sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access';
   /**
-   * Working directory for the codex CLI invocation. Defaults to
-   * process.cwd(). Reviewer / canary calls don't depend on cwd content
-   * but Codex CLI honors the flag so it's safe to pass.
+   * Retained for API compatibility. NOTE: this is intentionally NOT used as
+   * the `codex exec --cd` for judgment calls. Those always run in an empty
+   * instar-managed scratch dir (see `resolveIntelligenceScratchDir`) so the
+   * agent's project identity + hooks never load. These calls don't depend on
+   * cwd content, so ignoring this value is safe.
    */
   workingDirectory?: string;
 }
@@ -39,23 +83,36 @@ export interface CodexCliIntelligenceProviderOptions {
 export class CodexCliIntelligenceProvider implements IntelligenceProvider {
   private readonly codexPath: string;
   private readonly sandboxMode: 'read-only' | 'workspace-write' | 'danger-full-access';
-  private readonly workingDirectory: string;
 
   constructor(options: CodexCliIntelligenceProviderOptions) {
     this.codexPath = options.codexPath;
     this.sandboxMode = options.sandboxMode ?? 'read-only';
-    this.workingDirectory = options.workingDirectory ?? process.cwd();
+    // options.workingDirectory is intentionally NOT stored: judgment calls
+    // always run in an empty scratch dir (resolveIntelligenceScratchDir), so
+    // the agent's project identity + hooks never load. The option is retained
+    // on the type for API compatibility (the factory still forwards it).
   }
 
   async evaluate(prompt: string, options?: IntelligenceOptions): Promise<string> {
     const model = resolveCliModelFlag(options?.model);
+
+    const scratchDir = resolveIntelligenceScratchDir();
 
     return new Promise((resolve, reject) => {
       const args = [
         'exec',
         '--model', model,
         '--sandbox', this.sandboxMode,
-        '--cd', this.workingDirectory,
+        // Run judgment calls in an empty scratch dir, NOT the agent's project
+        // dir. The project dir loads the full ~26 KB AGENTS.md identity AND
+        // fires the project's .codex/hooks.json (session_start /
+        // user_prompt_submit / stop) on every call. The scratch dir is the
+        // Codex analog of ClaudeCliIntelligenceProvider's `--setting-sources
+        // user`. See resolveIntelligenceScratchDir + the spec.
+        '--cd', scratchDir,
+        // Belt-and-suspenders: hard-disable project-doc (AGENTS.md) loading
+        // even if a stray doc ever lands at or above the scratch path.
+        '-c', 'project_doc_max_bytes=0',
         // Reviewer/sentinel/canary calls are deterministic short prompts
         // that don't depend on the cwd being a trusted git repo. Codex
         // CLI's default behavior is to refuse to run when --cd points at

--- a/tests/unit/CodexCliIntelligenceProvider.test.ts
+++ b/tests/unit/CodexCliIntelligenceProvider.test.ts
@@ -84,7 +84,6 @@ describe('CodexCliIntelligenceProvider — spawn args', () => {
     expect(args).toContain('--sandbox');
     expect(args).toContain('read-only');
     expect(args).toContain('--cd');
-    expect(args).toContain(nonGitDir);
     expect(args).toContain('--skip-git-repo-check');
     // Prompt is the last positional.
     expect(args[args.length - 1]).toBe('classify: hello');
@@ -125,5 +124,99 @@ describe('CodexCliIntelligenceProvider — spawn args', () => {
     });
 
     await expect(provider.evaluate('hi')).rejects.toThrow(/Codex CLI error/);
+  });
+});
+
+describe('CodexCliIntelligenceProvider — clean-call (no identity, no hooks)', () => {
+  // Regression: judgment calls must NOT run in the agent's project dir, or
+  // codex loads the full ~26 KB AGENTS.md identity and fires the project's
+  // .codex/hooks.json (session_start / etc.) on every call. They must run in
+  // an empty instar-managed scratch dir — the Codex analog of the Claude
+  // provider's `--setting-sources user`.
+
+  function cdValue(args: string[]): string | undefined {
+    const i = args.indexOf('--cd');
+    return i >= 0 ? args[i + 1] : undefined;
+  }
+
+  it('runs in the instar scratch dir, NOT the passed workingDirectory', async () => {
+    const provider = new CodexCliIntelligenceProvider({
+      codexPath: fakeCodexPath,
+      workingDirectory: nonGitDir,
+    });
+
+    const args = parseArgs(await provider.evaluate('classify: hello'));
+    const cd = cdValue(args);
+
+    expect(cd).toBeDefined();
+    expect(cd).not.toBe(nonGitDir);
+    expect(cd).toContain('instar-codex-intel-scratch');
+  });
+
+  it('the scratch dir exists and is empty — no AGENTS.md, no .codex hooks dir', async () => {
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fakeCodexPath });
+
+    const args = parseArgs(await provider.evaluate('hi'));
+    const cd = cdValue(args)!;
+
+    expect(fs.existsSync(cd)).toBe(true);
+    const entries = fs.readdirSync(cd);
+    expect(entries).not.toContain('AGENTS.md');
+    expect(entries).not.toContain('.codex');
+  });
+
+  it('hard-disables project-doc loading via -c project_doc_max_bytes=0', async () => {
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fakeCodexPath });
+
+    const args = parseArgs(await provider.evaluate('hi'));
+    const ci = args.indexOf('-c');
+
+    expect(ci).toBeGreaterThanOrEqual(0);
+    expect(args[ci + 1]).toBe('project_doc_max_bytes=0');
+  });
+
+  it('uses the same scratch dir across calls (stable, not per-call)', async () => {
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fakeCodexPath });
+
+    const cd1 = cdValue(parseArgs(await provider.evaluate('a')));
+    const cd2 = cdValue(parseArgs(await provider.evaluate('b')));
+
+    expect(cd1).toBe(cd2);
+  });
+
+  it('creates the scratch dir with private (0700) permissions — not group/other accessible', async () => {
+    // Security: a world-accessible scratch dir under /tmp could let another
+    // local user plant a .codex/hooks.json that codex would then fire. mkdtemp
+    // creates 0700; assert it stays that way.
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fakeCodexPath });
+    const cd = cdValue(parseArgs(await provider.evaluate('hi')))!;
+
+    const mode = fs.statSync(cd).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+
+  it('uses an unguessable (random-suffixed) dir name, not a fixed path', async () => {
+    // A fixed name under world-writable /tmp could be pre-created/symlinked by
+    // an attacker. The mkdtemp suffix makes the path unpredictable.
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fakeCodexPath });
+    const cd = cdValue(parseArgs(await provider.evaluate('hi')))!;
+
+    expect(path.basename(cd)).toMatch(/^instar-codex-intel-scratch-.+/);
+    expect(cd).not.toBe(path.join(os.tmpdir(), 'instar-codex-intel-scratch'));
+  });
+
+  it('recreates the scratch dir if a tmp-reaper deleted it mid-process', async () => {
+    const provider = new CodexCliIntelligenceProvider({ codexPath: fakeCodexPath });
+
+    const cd1 = cdValue(parseArgs(await provider.evaluate('a')))!;
+    SafeFsExecutor.safeRmSync(cd1, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/CodexCliIntelligenceProvider.test.ts:tmp-reaper-recovery',
+    });
+    expect(fs.existsSync(cd1)).toBe(false);
+
+    const cd2 = cdValue(parseArgs(await provider.evaluate('b')))!;
+    expect(fs.existsSync(cd2)).toBe(true);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -14,6 +14,29 @@ This was the dominant cause of two visible problems on Codex agents: the flood o
 
 The fix gives those calls a clean notepad — the Codex analog of what `ClaudeCliIntelligenceProvider` already does with `--setting-sources user`. `CodexCliIntelligenceProvider` now runs judgment calls in an empty, private (0700, unguessable-name via `mkdtempSync`) scratch directory instead of the project dir, plus `-c project_doc_max_bytes=0`. No identity load, no project hooks. Claude-powered agents are unaffected (they were already clean).
 
+## Evidence
+
+Reproduced live on this machine's Codex install (codex-cli 0.133.0), before/after.
+
+**Before (production incident, 2026-05-25 rollout logs in `~/.codex/sessions/`):** 1,601
+`codex exec` spawns in one day, ~1,550 of them internal judgment calls. A sampled
+message-classifier rollout (21:52) re-injected the full ~26 KB `AGENTS.md` identity AND a
+`SESSION START` block — firing session_start — just to output the single word `normal`.
+Those rollouts ran with `cwd` = the agent's project dir and were 63–110 KB each.
+
+**After (controlled run of the built fixed provider against the real codex binary,
+2026-05-26 13:49):** called `CodexCliIntelligenceProvider.evaluate()` with a unique marker
+prompt; located the exact rollout it produced
+(`rollout-2026-05-26T13-49-18-…019e660c….jsonl`). Observed:
+- `cwd` = `/var/folders/…/T/instar-codex-intel-scratch-AOYJWS` (the mkdtemp scratch dir) ✓
+- `AGENTS.md instructions` blocks: **0** (was ≥1) ✓
+- `SESSION START` blocks: **0** (was 1) ✓
+- `CURRENT TIME` hook markers (user_prompt_submit): **0** ✓
+- rollout size 29.6 KB (was 63–110 KB) — the residue is codex's own base prompt, not instar identity.
+
+The identity load and the session_start/user_prompt_submit hook firing are gone for
+judgment calls. The agent still returned the correct answer.
+
 ## What to Tell Your User
 
 - **If you run a Codex-powered agent, it should get noticeably quieter and more reliable — no action needed.** The "still working" notification spam and the occasional dropped/"please resend" messages were mostly this one plumbing bug; the agent was effectively re-reading its whole identity ~1,500 times a day. Claude-powered agents won't notice anything (they were never affected).

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+<!-- Valid values: patch, minor, major -->
+<!-- patch = bug fixes, refactors, test additions, doc updates -->
+<!-- minor = new features, new APIs, new capabilities (backwards-compatible) -->
+<!-- major = breaking changes to existing APIs or behavior -->
+
+## What Changed
+
+**Codex-powered agents stop reloading their full identity on every background "judgment" call.** Instar makes ~1,500+ tiny internal LLM calls per agent per day — classify this message, did that turn finish, summarize this chunk, extract the intent. On a Codex-powered agent, each of those ran `codex exec` *inside the agent's project directory*, which made Codex load the agent's entire ~26 KB `AGENTS.md` identity AND fire the project's `.codex/hooks.json` (session_start / user_prompt_submit / stop) **every single time** — just to answer one word like "normal."
+
+This was the dominant cause of two visible problems on Codex agents: the flood of "actively working / message delivered / still working" notifications (the session_start hook firing on ~1,550 spawns/day, so the monitoring layer thought a real session was constantly starting), and intermittent "couldn't deliver — please resend" failures (a dozen of these heavyweight spawns landing in one minute saturated the machine so a real inbound message couldn't get a process slot).
+
+The fix gives those calls a clean notepad — the Codex analog of what `ClaudeCliIntelligenceProvider` already does with `--setting-sources user`. `CodexCliIntelligenceProvider` now runs judgment calls in an empty, private (0700, unguessable-name via `mkdtempSync`) scratch directory instead of the project dir, plus `-c project_doc_max_bytes=0`. No identity load, no project hooks. Claude-powered agents are unaffected (they were already clean).
+
+## What to Tell Your User
+
+- **If you run a Codex-powered agent, it should get noticeably quieter and more reliable — no action needed.** The "still working" notification spam and the occasional dropped/"please resend" messages were mostly this one plumbing bug; the agent was effectively re-reading its whole identity ~1,500 times a day. Claude-powered agents won't notice anything (they were never affected).
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Codex judgment calls run identity-free + hook-free | Automatic. `CodexCliIntelligenceProvider` runs `codex exec` in an empty `mkdtempSync` scratch dir + `-c project_doc_max_bytes=0` instead of the project dir. |
+| Hardened scratch dir | Automatic. Unguessable random name, 0700 perms, recreated if a tmp-reaper deletes it — nothing can be planted in the cwd these calls run from. |

--- a/upgrades/side-effects/fix-codex-intel-clean-call.md
+++ b/upgrades/side-effects/fix-codex-intel-clean-call.md
@@ -1,0 +1,108 @@
+# Side-Effects Review — Codex Intelligence-Provider Clean-Call Fix
+
+**Version / slug:** `fix-codex-intel-clean-call`
+**Date:** 2026-05-26
+**Author:** Echo
+**Spec:** `docs/specs/CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md` (converged + approved)
+
+## Summary of the change
+
+`CodexCliIntelligenceProvider.evaluate()` ran `codex exec --cd <agent project dir>` for
+every internal LLM "judgment" call (message classification, terminal-output analysis,
+arc extraction, usher, coherence, etc.). Running in the project dir made Codex load the
+full ~26 KB `AGENTS.md` identity AND fire the project's `.codex/hooks.json`
+(session_start / user_prompt_submit / stop) on **every** call — ~1,550 such calls/day,
+causing notification spam (session_start firing constantly) and spawn-storm delivery
+failures (12 heavyweight spawns/minute saturating the machine).
+
+The fix runs these calls in an empty, owner-only scratch dir instead — the Codex analog
+of `ClaudeCliIntelligenceProvider`'s `--setting-sources user`. No identity, no project
+hooks.
+
+**Files changed (source):**
+- `src/core/CodexCliIntelligenceProvider.ts` — `evaluate()` now uses an `mkdtempSync`
+  scratch dir for `--cd` (not the project dir) + `-c project_doc_max_bytes=0`; added the
+  `resolveIntelligenceScratchDir()` helper; removed the now-dead `workingDirectory` field
+  (kept on the options type for API compat).
+
+**Files changed (tests):**
+- `tests/unit/CodexCliIntelligenceProvider.test.ts` — updated the `--cd` assertion (it
+  previously asserted the buggy project-dir behavior) + added 7 cases covering the
+  scratch-dir contract, 0700 perms, unguessable name, and tmp-reaper recovery (12 total).
+
+**Files changed (spec / report / release notes):**
+- `docs/specs/CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md` (+ `.eli16.md`)
+- `docs/specs/reports/codex-intelligence-provider-clean-call-convergence.md`
+- `upgrades/NEXT.md`
+
+## Decision-point inventory
+
+- **Scratch dir, not the project dir** — the core fix. Judgment calls are cwd-independent
+  (per the existing code comment), so an empty cwd is correct.
+- **`mkdtempSync` (random suffix, 0700), not a fixed name** — convergence security finding:
+  a fixed `/tmp` name on Linux is plantable (`.codex/hooks.json` squatting; not gated by
+  `project_doc_max_bytes`). The unguessable, owner-only dir closes that vector.
+- **Re-verify-before-use** — recreate the dir if a tmp-reaper deleted it during a
+  long-lived process.
+- **`-c project_doc_max_bytes=0`** — belt-and-suspenders for an `AGENTS.md` on the cwd
+  walk-up; real key, already used in `contextScopeControl.ts`.
+- **Drop `workingDirectory` as exec cwd** — verified only `route.ts` passes it, and only
+  for its own PreferenceStore DB path, never the codex cwd.
+
+## Over-block / under-block analysis
+
+- **Over-block:** none. The provider gates nothing; it only changes the cwd of a spawn.
+  Judgment calls that worked before continue to work (the fake-codex unit tests confirm
+  the full arg contract).
+- **Under-block:** the *intended* behavioral subtraction is "stop loading identity + firing
+  hooks for judgment calls." There is no path where a judgment call legitimately needed the
+  identity or hooks — they are stateless classifications/extractions. If a future caller
+  did need project context, it must pass it in the prompt (as all current callers do), not
+  rely on cwd.
+
+## Level-of-abstraction fit
+
+The fix lives in the single provider that owns the `codex exec` invocation — the same layer
+where the Claude sibling already solves the identical problem with `--setting-sources user`.
+No higher-level orchestration or config knob is introduced; the concern is local to the
+spawn, so the fix is local to the spawn. Correct altitude.
+
+## Signal-vs-authority compliance
+
+N/A in the gate sense — this change neither detects nor blocks anything. It is a pure
+invocation-hygiene fix. It does not touch any sentinel/gate authority boundary.
+
+## Interactions
+
+- **Claude provider:** untouched; asymmetry (flag vs scratch-cwd) is intentional and
+  documented — Codex has no single equivalent flag.
+- **Callers (`reflect.ts`, `route.ts`, `server.ts`):** none depend on the codex cwd
+  content; verified during integration review. No behavior change for them beyond the
+  intended one.
+- **Concurrency:** `mkdtempSync` once + cached + `existsSync` re-check; no race under the
+  high call volume (idempotent, read-only dir).
+- **Monitoring layer:** positive interaction — the session_start hook no longer fires on
+  judgment spawns, so PresenceProxy/standby stops mistaking them for real sessions
+  (the notification-spam root cause).
+
+## Rollback cost
+
+Trivial and isolated. Revert the single source file (and its test). No persisted state, no
+schema, no config/hook/template/migration to unwind — the only on-disk footprint is an
+empty 0700 tmp dir that the OS reaps on its own. Reverting restores the prior (buggy but
+functional) behavior with zero data implications.
+
+## Migration parity
+
+Code-only change inside the compiled provider. No agent-installed file
+(settings/hooks/config/templates/skills) references the old behavior, so **no
+`PostUpdateMigrator` entry is required** — existing Codex agents receive the fix via the
+normal package update path. Verified by grep during integration review.
+
+## Testing evidence
+
+- Unit: 12 tests in `CodexCliIntelligenceProvider.test.ts` pass; sibling env-allowlist (4)
+  + factory (10) tests unaffected; clean `tsc` build.
+- Live / bug-fix evidence bar: the before/after rollout reproduction on a real Codex agent
+  (identity-loaded before, bare after) is run as the post-merge test-as-self gate and
+  recorded before the fix is declared shipped.


### PR DESCRIPTION
## Summary

`CodexCliIntelligenceProvider.evaluate()` ran `codex exec` in the agent's **project dir**, so every internal LLM "judgment" call (message classification, terminal-output analysis, arc extraction, usher, coherence, …) loaded the full ~26 KB `AGENTS.md` identity **and** fired the project's `.codex/hooks.json` (`session_start` / `user_prompt_submit` / `stop`). On a Codex agent that's ~1,550 calls/day — the dominant cause of the "still working" notification spam (session_start firing constantly) and the "couldn't deliver — please resend" failures (12 heavyweight spawns/min saturating the machine).

The fix mirrors `ClaudeCliIntelligenceProvider`'s `--setting-sources user` clean-notepad guarantee: run judgment calls in an empty `mkdtempSync` scratch dir (unguessable name, `0700`, recreated if a tmp-reaper deletes it) instead of the project dir, plus `-c project_doc_max_bytes=0`. No identity, no project hooks. The Claude path is untouched.

- Spec: `docs/specs/CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md` (converged + approved) + ELI16 companion
- Convergence report: `docs/specs/reports/codex-intelligence-provider-clean-call-convergence.md` (caught + fixed a Linux `/tmp` squatting hole in the first draft → `mkdtempSync`)
- Side-effects review: `upgrades/side-effects/fix-codex-intel-clean-call.md`

## Live evidence (before/after, codex-cli 0.133.0)

- **Before:** 2026-05-25 production rollouts — classifier spawns re-injected 26 KB identity + `SESSION START`, 63–110 KB each, to output one word.
- **After:** ran the built fixed provider against real codex; its rollout ran in the scratch dir with **0** `AGENTS.md` blocks, **0** `SESSION START` blocks, **0** hook markers (29.6 KB; residue is codex's own base prompt).

## Test plan

- [x] Unit: `tests/unit/CodexCliIntelligenceProvider.test.ts` — 12 tests (scratch-dir contract, `0700` perms, unguessable name, tmp-reaper recovery, `-c project_doc_max_bytes=0`, ignores `workingDirectory`)
- [x] Sibling env-allowlist (4) + factory (10) tests unaffected; clean `tsc` build
- [x] Live before/after reproduction (above)
- [ ] CI green