### PR TITLE
fix(spec-gate): give the standards-conformance gate a real review budget (two 30s walls)

### DIFF
--- a/docs/specs/conformance-gate-timeout.eli16.md
+++ b/docs/specs/conformance-gate-timeout.eli16.md
@@ -1,0 +1,44 @@
+# Conformance-gate timeout fix — plain English
+
+## What this is about
+
+Instar has a "rules inspector." When someone writes a spec (a plan for a new feature or fix), this inspector reads our written constitution — the list of standards we hold ourselves to — and uses the AI to check the spec against every rule, then reports anything that looks like it breaks one. We recently wired it to run *automatically* during spec review, instead of relying on a person to remember to run it.
+
+## What went wrong
+
+I tested the inspector on a real, full-size spec — about 400 lines. It didn't answer. It gave up with a "timed out" error after 30 seconds.
+
+## The part I got wrong the first time (and why review matters)
+
+My first diagnosis found ONE cause and I wrote it up. Then I had a deliberately skeptical reviewer pick the plan apart — and it found a *second* cause I'd completely missed. Both had to be fixed. This is exactly why we run specs through review before writing code: my confident first answer was half-right, which is the most dangerous kind of wrong.
+
+Here are both, with a simple picture. Imagine the inspector is a worker who has to make one slow phone call to the AI to do its job.
+
+- **Wall 1 — the building's front-door curfew.** Our server locks any request out after 30 seconds, as a safety rule so nothing hangs forever. A few requests that genuinely need longer (the ones that make an AI call) are on a "give them more time" list and get up to two minutes. The inspector makes an AI call too, but nobody ever added it to that list — so it got kicked out at 30 seconds.
+- **Wall 2 — the worker's own phone has a 30-second auto-hangup.** Even if we let the worker stay in the building longer, the *phone itself* is set to hang up after 30 seconds. So the slow AI call gets cut off regardless. Worse: when the call is cut, the inspector shrugs and reports "nothing found" — which reads like the spec *passed*. So fixing only Wall 1 would turn a loud, obvious error into a quiet false "all clear." That's worse than the original bug.
+
+## Why it matters
+
+The inspector is *advisory* — it never blocks anything, it just flags concerns. So neither wall broke anything loudly. But together they meant that on big, important specs — exactly the ones where a constitutional check matters most — the inspector either errored out or, after a half-fix, would have quietly claimed everything was fine. A safety check that silently says "all clear" on the important cases is the worst outcome, because you trust it when you shouldn't.
+
+The good news: this is the "Instar improves itself" idea working as intended. I shipped the auto-wiring, immediately ate my own cooking by running it on a real spec, and the skeptical reviewer caught the rest. Our small test cases used tiny fake specs, so they never hit either wall.
+
+## What the fix is
+
+Take down both walls, cleanly:
+
+1. Add the inspector to the "give it more time" list (front-door curfew raised to three minutes for this one route).
+2. Teach the worker's phone to accept a longer limit when it's told to — and have the inspector tell it to use about two and a half minutes. Everyone else who makes quick AI calls is untouched; only this inspector opts into the longer limit.
+
+The two limits are set so the phone hangs up *just before* the front-door curfew would — so if a spec ever truly is too slow, you get a clean "couldn't finish, treat as advisory" instead of an ugly timeout error.
+
+## What's NOT changing
+
+- The inspector stays advisory. It still never blocks anything. More time only lets it *finish* and hand back its notes.
+- Every other AI call in the system keeps the same 30-second limit it has today — nothing else slows down or speeds up.
+- The fast "show me the inspector's stats" request keeps the normal limit; it makes no AI call, so it doesn't need more time.
+- Nothing on your end changes. No setting to flip, no command to run.
+
+## What you're deciding
+
+Whether to approve this fix so it can ship. It's small and fully reversible — four little edits and tests that lock in the correct behavior so it can't quietly slip back. The one thing worth knowing: it's a bit bigger than my first "one-line" estimate, because the review correctly found the second wall. Better to ship the whole fix than half of it.

--- a/docs/specs/conformance-gate-timeout.md
+++ b/docs/specs/conformance-gate-timeout.md
@@ -1,0 +1,86 @@
+---
+title: "Conformance-gate timeout fix — two 30s walls: middleware budget + provider honoring timeoutMs"
+slug: conformance-gate-timeout
+review-iterations: 1
+review-convergence: "v1 — converged after one adversarial + one standards round (2026-05-26). The adversarial round caught a BLOCKING miss in the v0 draft: a second, inner 30s wall in the intelligence providers that a middleware-only fix would have masked as a silent 'degraded' (empty) report — worse than the loud 408. Root cause and fix surface corrected accordingly. Standards round added the production-map wiring-integrity test requirement."
+eli16-overview: "conformance-gate-timeout.eli16.md"
+approved: false
+approval-context: "DRAFT — converged, awaiting Justin approval per the instar-dev gate (spec-first) before any src/ change."
+lessons-engaged:
+  - "Verify component is actually wired (PR #334 dead-code lesson) — the unit test must assert against the PRODUCTION override map, not a hand-rolled one, or it goes green while the wiring stays broken"
+  - "A test can encode the bug as correct — a middleware-only unit test would pass while the gate stays broken end-to-end (the inner provider wall)"
+  - "External/adversarial review catches what the author's own pass misses — the second 30s wall was invisible to me until the adversarial reviewer traced the provider"
+  - "Gate latency vs client timeout (B24) — budget the WHOLE synchronous path (middleware AND the provider's child-process timeout), not just the outer layer"
+  - "Bug-fix evidence bar — 408 reproduced; the inner wall verified by reading both providers + the reviewer call"
+  - "Don't over-engineer — honor an already-declared interface field; do not add config knobs or an async rearchitecture nobody needs"
+  - "ELI16 companion (sibling file)"
+  - "Seven-dimension side-effects review (§5)"
+build-mode: "Small, bounded, fully revertible — 4 source edits (2 providers honor timeoutMs, reviewer passes one, middleware outer budget) + tests across each boundary."
+---
+
+# Conformance-gate timeout fix
+
+> Read the ELI16 companion (`conformance-gate-timeout.eli16.md`) first. This is the technical detail.
+
+## 1. Problem (reproduced)
+
+`POST /spec/conformance-check` is the Standards-Conformance Gate — code that reads `docs/STANDARDS-REGISTRY.md` and uses a top-tier (opus) model to review a spec against every standing standard. PR #403 auto-wired it into `/spec-converge` Phase 1 so the constitutional pass runs structurally (the dogfood-to-ship enforcement of the Self-Hosting standard).
+
+On 2026-05-26, dogfooding the gate against a real ~400-line spec returned:
+
+```
+HTTP 408 {"error":"Request timeout","timeoutMs":30000}
+```
+
+## 2. Root cause — TWO 30-second walls, not one
+
+The v0 draft of this spec identified only the outer wall. An adversarial review traced the inner one. Both exist and both fire at ~30s:
+
+**Wall A (outer, HTTP middleware).** `requestTimeout` (`src/server/middleware.ts:291`) applies a 30s default to every route, with a `perPathOverrides` map granting LLM-backed routes more time. The outbound-messaging routes are registered at `OUTBOUND_MESSAGING_TIMEOUT_MS = 120_000` (`AgentServer.ts:380-388`). `/spec/conformance-check` was never added, so it inherits 30s and 408s.
+
+**Wall B (inner, provider child-process).** Even with Wall A raised, the review's opus call dies at 30s anyway: both intelligence providers hardcode the child-process timeout and **ignore the `timeoutMs` the interface already defines**:
+- `ClaudeCliIntelligenceProvider.evaluate` (`:35`) → `execFile(..., { timeout: DEFAULT_TIMEOUT_MS })`, `DEFAULT_TIMEOUT_MS = 30_000` (`:18,58`).
+- `CodexCliIntelligenceProvider.evaluate` (`:96`) → same, `:23,149`.
+- The interface `IntelligenceOptions.timeoutMs` exists and is documented "provider should honor or surface as throw" (`types.ts:632-633`), but neither provider reads it.
+- The reviewer (`standards-conformance.ts:120-125`) passes `{model, temperature, maxTokens, attribution}` — **no `timeoutMs`** — and on any throw returns `{ findings: [], degraded: true, degradeReason: 'error' }` (`:126-127`).
+
+**Why a middleware-only fix is worse than nothing.** With only Wall A raised, a slow review hits Wall B at 30s → `evaluate` rejects → the reviewer's `catch` returns an empty `degraded` report → the handler returns **200 with zero findings**. A loud, obvious 408 becomes a quiet "no problems found" — the silent-no-op our standards exist to prevent, now actively *masked* as success. The complete fix must remove BOTH walls.
+
+The companion GET route `/spec/conformance-metrics` only reads counters; it stays on the 30s default (it makes no model call).
+
+## 3. Fix (4 source edits + tests)
+
+1. **Providers honor `timeoutMs`** — in both `ClaudeCliIntelligenceProvider.ts:58` and `CodexCliIntelligenceProvider.ts:149`, change `timeout: DEFAULT_TIMEOUT_MS` → `timeout: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS`. This mirrors the existing `options?.model ?? DEFAULT_MODEL` pattern in each `evaluate`. `DEFAULT_TIMEOUT_MS` stays 30_000, so every caller that does NOT pass a budget is completely unchanged — only callers that opt in get more time.
+
+2. **Reviewer passes a budget** — in `standards-conformance.ts`, add `timeoutMs: CONFORMANCE_REVIEW_TIMEOUT_MS` to the `evaluate` options, with a named constant `CONFORMANCE_REVIEW_TIMEOUT_MS = 150_000` defined in that module.
+
+3. **Middleware outer budget** — in `AgentServer.ts`, define `SPEC_REVIEW_TIMEOUT_MS = 180_000` next to `OUTBOUND_MESSAGING_TIMEOUT_MS` and add `'/spec/conformance-check': SPEC_REVIEW_TIMEOUT_MS` to `perPathOverrides`. The 180s outer budget sits **above** the 150s inner budget on purpose: a genuinely-too-slow review is killed cleanly by the provider (→ degraded report, advisory, fail-open) ~30s before the middleware would 408, so the client never sees a raw timeout. Headroom rationale: a human-authored spec driving >150s of opus review is implausible; the ordering makes the over-budget case degrade gracefully rather than 408.
+
+4. **Extract the override map for testability** — lift the `perPathOverrides` object literal into a small exported `buildRequestTimeoutOverrides()` (or exported const) in `AgentServer.ts`/a sibling, so the unit test asserts against the **same map the server actually wires** (closes the dead-code/false-wiring trap — see §5).
+
+## 4. Why this scope and no more
+
+- No config knob (`specReview.conformance.timeoutMs`): nobody asked for runtime-tunable review latency, and adding it pulls in `ConfigDefaults` + a `migrateConfig` Migration-Parity entry for no benefit. A named constant is the right altitude.
+- No async rearchitecture: honoring an already-declared interface field + an outer budget fully resolves the reproduced failure class for human-authored specs. Async would be justified only if measurement ever showed specs approaching 150s, which the headroom makes implausible. This is a scoping boundary, not a promised future change.
+- `DEFAULT_TIMEOUT_MS` unchanged → zero behavior change for every other reviewer/sentinel/classifier that calls `evaluate` without a budget.
+
+## 5. Tests (Testing Integrity — covering each boundary the bug crossed)
+
+- **Provider honors `timeoutMs` (both providers, both sides of the boundary):** assert `execFile` is invoked with `{ timeout: <passed value> }` when `options.timeoutMs` is set, and with `30_000` when it is absent. Use the existing `CodexCliIntelligenceProvider.test.ts` execFile-seam pattern; add the mirror for the Claude provider.
+- **Reviewer passes the budget:** assert `StandardsConformanceReviewer.review` calls `intelligence.evaluate` with `timeoutMs === CONFORMANCE_REVIEW_TIMEOUT_MS` (a fake intelligence that records the options).
+- **Middleware wiring-integrity (production map):** assert that the override map the server actually builds (via the extracted `buildRequestTimeoutOverrides()`) resolves `/spec/conformance-check` → `SPEC_REVIEW_TIMEOUT_MS`, `/spec/conformance-metrics` → default, and an arbitrary path → default. This must read the PRODUCTION map, not a hand-rolled one — a hand-rolled map would let the test pass while the server stays misconfigured (the PR #334 dead-code lesson).
+- **Budget ordering invariant:** a cheap assertion that `CONFORMANCE_REVIEW_TIMEOUT_MS < SPEC_REVIEW_TIMEOUT_MS`, so the provider's clean kill always precedes the middleware 408.
+
+## 6. Seven-dimension side-effects review
+
+1. **Over/under-reach** — Provider change is gated behind `options?.timeoutMs` being present, so only opt-in callers are affected; default path byte-identical. Middleware override matches `/spec/conformance-check` (+children) only; `/spec/conformance-metrics` is a sibling, not a child, so it keeps the default (verified against the matcher `req.path === prefix || startsWith(prefix + '/')` + descending-length sort, `middleware.ts:297-310`).
+2. **Level-of-abstraction fit** — Each edit sits at its correct layer: child-process budget in the provider, review budget in the reviewer, HTTP budget in the middleware wiring. No logic leaks across layers.
+3. **Signal vs Authority** — Unchanged. The gate stays signal-only + fail-open; the fix only lets the review *finish* so it can emit its (advisory) signal. Blocking authority remains the separate later `scg-blocking-authority` item.
+4. **Interactions** — `DEFAULT_TIMEOUT_MS` untouched ⇒ no impact on the dozens of other `evaluate` callers (classifiers, sentinels, tone gate). Middleware change is one additive key. The two budgets interact only via the ordering invariant (§5), which a test pins.
+5. **Rollback cost** — Trivial and total: revert 4 small edits; no data, no state, no migration. Reverting restores prior (broken) behavior exactly.
+6. **Migration parity** — N/A. All four edits are server/library runtime code shipped in the package; none touch agent-installed files (`.claude/settings.json` / config / CLAUDE.md template / hooks / skills). Existing agents get it on package update like all runtime code.
+7. **Failure modes** — (a) Spec exceeds 150s → provider kills cleanly → fail-open degraded report (advisory), no 408, no regression vs today. (b) Someone later passes `timeoutMs` to a provider expecting the old hard 30s → covered by the default-unchanged guarantee + the both-sides test. (c) Override map drifts from the server's real wiring → prevented by testing the extracted production map. (d) Inner budget set ≥ outer → caught by the ordering-invariant test.
+
+## 7. Scope boundaries
+
+No async redesign and no config knob, for the reasons in §4 — these are deliberate scope limits with stated rationale, not unfinished work. Everything the reproduced failure requires is in §3.

--- a/docs/specs/conformance-gate-timeout.md
+++ b/docs/specs/conformance-gate-timeout.md
@@ -4,8 +4,8 @@ slug: conformance-gate-timeout
 review-iterations: 1
 review-convergence: "v1 — converged after one adversarial + one standards round (2026-05-26). The adversarial round caught a BLOCKING miss in the v0 draft: a second, inner 30s wall in the intelligence providers that a middleware-only fix would have masked as a silent 'degraded' (empty) report — worse than the loud 408. Root cause and fix surface corrected accordingly. Standards round added the production-map wiring-integrity test requirement."
 eli16-overview: "conformance-gate-timeout.eli16.md"
-approved: false
-approval-context: "DRAFT — converged, awaiting Justin approval per the instar-dev gate (spec-first) before any src/ change."
+approved: true
+approval-context: "Approved by Justin on 2026-05-26 (topic 12476) after the converged plain-English summary. The convergence's adversarial round caught the second (inner provider) 30s wall before any code was written; Justin approved the complete four-edit fix."
 lessons-engaged:
   - "Verify component is actually wired (PR #334 dead-code lesson) — the unit test must assert against the PRODUCTION override map, not a hand-rolled one, or it goes green while the wiring stays broken"
   - "A test can encode the bug as correct — a middleware-only unit test would pass while the gate stays broken end-to-end (the inner provider wall)"

--- a/src/core/ClaudeCliIntelligenceProvider.ts
+++ b/src/core/ClaudeCliIntelligenceProvider.ts
@@ -55,7 +55,11 @@ export class ClaudeCliIntelligenceProvider implements IntelligenceProvider {
       delete childEnv.CLAUDE_SESSION_ID;
 
       const child = execFile(this.claudePath, args, {
-        timeout: DEFAULT_TIMEOUT_MS,
+        // Honor a caller-supplied per-call budget (IntelligenceOptions.timeoutMs);
+        // fall back to the 30s default so every caller that omits it is unchanged.
+        // LLM-backed callers on a synchronous HTTP path (e.g. the standards-
+        // conformance gate reviewing a full spec) need more than 30s.
+        timeout: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         maxBuffer: 1024 * 1024, // 1MB
         env: childEnv,
       }, (error, stdout, stderr) => {

--- a/src/core/CodexCliIntelligenceProvider.ts
+++ b/src/core/CodexCliIntelligenceProvider.ts
@@ -146,7 +146,9 @@ export class CodexCliIntelligenceProvider implements IntelligenceProvider {
         this.codexPath,
         args,
         {
-          timeout: DEFAULT_TIMEOUT_MS,
+          // Honor a caller-supplied per-call budget (IntelligenceOptions.timeoutMs);
+          // fall back to the 30s default so every caller that omits it is unchanged.
+          timeout: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
           maxBuffer: 1024 * 1024,
           env: childEnv,
         },

--- a/src/core/reviewers/standards-conformance.ts
+++ b/src/core/reviewers/standards-conformance.ts
@@ -40,6 +40,17 @@ export interface ConformanceReport {
 
 /** Hard cap so a wall-of-text spec can't dominate the prompt (injection hardening). */
 export const MAX_SPEC_CHARS = 24000;
+
+/**
+ * Per-call budget passed to the provider for the conformance review. Reviewing
+ * a full spec against the whole constitution is a single heavy top-tier call
+ * that routinely exceeds the providers' 30s default; without this the call is
+ * killed mid-review and the gate returns a misleadingly-empty degraded report.
+ * Kept strictly BELOW the route's outer middleware budget (SPEC_REVIEW_TIMEOUT_MS
+ * in AgentServer) so the provider's clean kill fires before the HTTP 408 — a
+ * genuinely-too-slow spec degrades fail-open rather than erroring at the client.
+ */
+export const CONFORMANCE_REVIEW_TIMEOUT_MS = 150_000;
 const FENCE = '<<<SPEC';
 const FENCE_END = 'SPEC>>>';
 
@@ -121,6 +132,7 @@ export class StandardsConformanceReviewer {
         model: this.opts.model ?? 'capable',
         temperature: 0,
         maxTokens: 1200,
+        timeoutMs: CONFORMANCE_REVIEW_TIMEOUT_MS,
         attribution: { component: 'StandardsConformanceReviewer' },
       });
     } catch {

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -48,7 +48,7 @@ import { createSpecReviewRoutes } from './specReviewRoutes.js';
 import { createUsherRoutes } from './usherRoutes.js';
 import type { TopicIntentStore } from '../core/TopicIntent.js';
 import type { WorktreeManager } from '../core/WorktreeManager.js';
-import { corsMiddleware, authMiddleware, requestTimeout, errorHandler, dashboardSecurityHeaders } from './middleware.js';
+import { corsMiddleware, authMiddleware, requestTimeout, buildRequestTimeoutOverrides, errorHandler, dashboardSecurityHeaders } from './middleware.js';
 import { WebSocketManager } from './WebSocketManager.js';
 import { assertSqliteAvailable, PendingRelayStore } from '../messaging/pending-relay-store.js';
 import { getOrCreateBootId } from './boot-id.js';
@@ -370,22 +370,19 @@ export class AgentServer {
     // immediately invalidates old bearer tokens AND old HMAC-signed view
     // URLs without a restart.
     this.app.use(authMiddleware(() => this.config.authToken, options.config.projectName));
-    // Outbound messaging routes are intentionally LLM-backed (tone gate review)
-    // and involve third-party API calls (Telegram/Slack/WhatsApp Bot APIs) whose
-    // latency we don't control. The default 30s budget is routinely exceeded
-    // under normal load; a 408 fired while the handler's send is in flight
-    // causes the agent's client to treat a successful delivery as failure,
-    // regenerate, and retry — shipping a duplicate message. Extended budget
-    // of 120s accommodates the realistic p99 of this path.
-    const OUTBOUND_MESSAGING_TIMEOUT_MS = 120_000;
-    this.app.use(requestTimeout(options.config.requestTimeoutMs, {
-      '/telegram/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
-      '/telegram/post-update': OUTBOUND_MESSAGING_TIMEOUT_MS,
-      '/slack/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
-      '/whatsapp/send': OUTBOUND_MESSAGING_TIMEOUT_MS,
-      '/imessage/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
-      '/imessage/validate-send': OUTBOUND_MESSAGING_TIMEOUT_MS,
-    }));
+    // Per-path request-timeout overrides for LLM-backed / third-party routes
+    // (outbound messaging + the standards-conformance gate). The map and its
+    // matching logic are the single source of truth in middleware.ts so a
+    // wiring-integrity test asserts the exact production config. See
+    // buildRequestTimeoutOverrides() for the per-route rationale.
+    //
+    // E2E-PAIRING: EXEMPT — tunes the request-timeout BUDGET of an existing
+    // route (/spec/conformance-check), not a new route or feature. The route's
+    // "feature is alive" lifecycle is already covered by
+    // tests/e2e/standards-conformance-gate-lifecycle.test.ts; the budget itself
+    // is verified at the unit level (AgentServer-outbound-timeout.test.ts via the
+    // extracted production map/matcher). A 150s/180s budget is not E2E-observable.
+    this.app.use(requestTimeout(options.config.requestTimeoutMs, buildRequestTimeoutOverrides()));
 
     // ── Token Ledger ──────────────────────────────────────────────────
     // Read-only token-usage observability. Reads Claude Code's per-session

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -288,26 +288,68 @@ export function rateLimiter(windowMs: number = 60_000, maxRequests: number = 10)
  * Override matching is by longest-prefix, so a more specific prefix beats a
  * shorter parent if both are registered.
  */
+/**
+ * Extended request-timeout budget (ms) for outbound-messaging routes. They are
+ * LLM-backed (tone-gate review) and hit third-party APIs (Telegram/Slack/WhatsApp)
+ * whose latency we don't control; the 30s default 408s mid-send and triggers
+ * duplicate-send cascades on the client. 120s covers this path's realistic p99.
+ */
+export const OUTBOUND_MESSAGING_TIMEOUT_MS = 120_000;
+
+/**
+ * Extended budget for the standards-conformance gate route (`/spec/conformance-check`).
+ * It makes a single heavy top-tier review call over a full spec; the 30s default
+ * 408s on any real spec. Set ABOVE the reviewer's inner CONFORMANCE_REVIEW_TIMEOUT_MS
+ * (150s) so the provider's own clean kill fires first — a genuinely-too-slow spec
+ * degrades fail-open (advisory empty report) instead of erroring at the client.
+ */
+export const SPEC_REVIEW_TIMEOUT_MS = 180_000;
+
+/**
+ * The production per-path request-timeout overrides. Exported as the single
+ * source of truth so wiring-integrity tests assert against the SAME map the
+ * server actually wires — never a hand-rolled copy that could pass while the
+ * server is misconfigured (the PR-#334 dead-code lesson).
+ */
+export function buildRequestTimeoutOverrides(): Record<string, number> {
+  return {
+    '/telegram/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
+    '/telegram/post-update': OUTBOUND_MESSAGING_TIMEOUT_MS,
+    '/slack/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
+    '/whatsapp/send': OUTBOUND_MESSAGING_TIMEOUT_MS,
+    '/imessage/reply': OUTBOUND_MESSAGING_TIMEOUT_MS,
+    '/imessage/validate-send': OUTBOUND_MESSAGING_TIMEOUT_MS,
+    '/spec/conformance-check': SPEC_REVIEW_TIMEOUT_MS,
+  };
+}
+
+/**
+ * Resolve the timeout budget for a path against the overrides, by longest-prefix
+ * match. Exported and used by BOTH the middleware and its tests so the matching
+ * logic can never drift between what is tested and what runs. Match is exact
+ * prefix OR prefix followed by '/' so '/foo' never spuriously matches '/foo-bar'
+ * — and a sibling like '/spec/conformance-metrics' is NOT matched by the
+ * '/spec/conformance-check' prefix. req.path never carries the query string.
+ */
+export function resolveRequestTimeout(
+  reqPath: string,
+  defaultMs: number,
+  perPathOverrides: Record<string, number>,
+): number {
+  const sortedOverrides = Object.entries(perPathOverrides)
+    .sort((a, b) => b[0].length - a[0].length);
+  for (const [prefix, ms] of sortedOverrides) {
+    if (reqPath === prefix || reqPath.startsWith(prefix + '/')) return ms;
+  }
+  return defaultMs;
+}
+
 export function requestTimeout(
   defaultMs: number = 30_000,
   perPathOverrides: Record<string, number> = {},
 ) {
-  // Precompute overrides sorted by descending prefix length so longest-match
-  // wins without scanning every entry on every request.
-  const sortedOverrides = Object.entries(perPathOverrides)
-    .sort((a, b) => b[0].length - a[0].length);
-
   return (req: Request, res: Response, next: NextFunction): void => {
-    let timeoutMs = defaultMs;
-    for (const [prefix, ms] of sortedOverrides) {
-      // Match either exact prefix or prefix followed by '/' so that '/foo'
-      // does NOT spuriously match '/foo-bar'. req.path in Express never
-      // contains the query string, so no '?' branch is needed.
-      if (req.path === prefix || req.path.startsWith(prefix + '/')) {
-        timeoutMs = ms;
-        break;
-      }
-    }
+    const timeoutMs = resolveRequestTimeout(req.path, defaultMs, perPathOverrides);
 
     let done = false;
     const timer = setTimeout(() => {

--- a/tests/unit/AgentServer-outbound-timeout.test.ts
+++ b/tests/unit/AgentServer-outbound-timeout.test.ts
@@ -1,27 +1,37 @@
 /**
- * Structural guard: AgentServer must register extended request-timeout
- * overrides on every outbound messaging route.
+ * Wiring-integrity guard: the server's per-path request-timeout overrides must
+ * route LLM-backed / third-party routes to their extended budgets — and the
+ * fast sibling routes must stay on the default.
  *
- * A silent regression — typo in a path key, merge drop, or someone removing
- * an override during a refactor — would NOT fail the existing route tests,
- * because those tests don't exercise the 30s→120s distinction. This test
- * reads the AgentServer source and asserts each outbound-messaging prefix is
- * present in the override map, so any accidental removal fails CI.
+ * This asserts against the PRODUCTION map (`buildRequestTimeoutOverrides()`) and
+ * the PRODUCTION matcher (`resolveRequestTimeout()`) imported directly — not a
+ * source regex and not a hand-rolled copy. A hand-rolled map would let this pass
+ * while the server is misconfigured; importing the real functions closes that
+ * dead-code/false-wiring trap (PR-#334 lesson). AgentServer wires these exact
+ * functions, so a regression in the map or the matcher fails here.
  *
- * Background: fix for the duplicate-outbound-message bug where the 30s
- * global timeout fired on LLM-backed outbound routes. See
- * upgrades/side-effects/outbound-timeout-408-ambiguous.md.
+ * Background: the duplicate-outbound-message bug (30s 408 on LLM-backed outbound
+ * routes), and the conformance-gate timeout fix (docs/specs/conformance-gate-timeout.md)
+ * where /spec/conformance-check inherited the 30s default and 408'd on real specs.
  */
 
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  buildRequestTimeoutOverrides,
+  resolveRequestTimeout,
+  OUTBOUND_MESSAGING_TIMEOUT_MS,
+  SPEC_REVIEW_TIMEOUT_MS,
+} from '../../src/server/middleware.js';
+import { CONFORMANCE_REVIEW_TIMEOUT_MS } from '../../src/core/reviewers/standards-conformance.js';
 
-const AGENT_SERVER_PATH = path.join(import.meta.dirname, '../../src/server/AgentServer.ts');
-const source = fs.readFileSync(AGENT_SERVER_PATH, 'utf-8');
+const DEFAULT_MS = 30_000;
 
-describe('AgentServer — outbound messaging timeout overrides', () => {
-  const requiredPrefixes = [
+describe('request-timeout override map (production wiring)', () => {
+  const overrides = buildRequestTimeoutOverrides();
+
+  const outboundPrefixes = [
     '/telegram/reply',
     '/telegram/post-update',
     '/slack/reply',
@@ -30,30 +40,47 @@ describe('AgentServer — outbound messaging timeout overrides', () => {
     '/imessage/validate-send',
   ];
 
-  for (const prefix of requiredPrefixes) {
-    it(`wires ${prefix} to the extended-timeout override map`, () => {
-      // Match 'path-prefix': NUMBER as it appears in the requestTimeout call.
-      // Matches both quoted-string keys ('/telegram/reply': 120_000) and any
-      // reasonable whitespace.
-      const pattern = new RegExp(`['"]${prefix.replace(/\//g, '\\/')}['"]\\s*:`);
-      expect(source).toMatch(pattern);
+  for (const prefix of outboundPrefixes) {
+    it(`resolves ${prefix} to the outbound-messaging budget`, () => {
+      expect(resolveRequestTimeout(prefix, DEFAULT_MS, overrides)).toBe(OUTBOUND_MESSAGING_TIMEOUT_MS);
     });
   }
 
-  it('uses a numeric timeout (not the default 30s) for the outbound routes', () => {
-    // The override value should be materially larger than the default 30_000.
-    // Accept any value ≥ 90_000ms (90s) — gives room to tune the budget
-    // without having to update this test.
-    const match = source.match(/OUTBOUND_MESSAGING_TIMEOUT_MS\s*=\s*(\d[\d_]*)/);
-    expect(match).not.toBeNull();
-    const value = Number(match![1].replace(/_/g, ''));
-    expect(value).toBeGreaterThanOrEqual(90_000);
+  it('resolves /spec/conformance-check to the spec-review budget (the bug this fixed)', () => {
+    expect(resolveRequestTimeout('/spec/conformance-check', DEFAULT_MS, overrides)).toBe(SPEC_REVIEW_TIMEOUT_MS);
   });
 
-  it('still passes the global default to requestTimeout as the first arg', () => {
-    // Regression guard: the global 30s default for every non-outbound route
-    // must not be accidentally replaced with the outbound timeout.
-    expect(source).toMatch(/requestTimeout\(options\.config\.requestTimeoutMs,/);
+  it('leaves the fast sibling /spec/conformance-metrics on the default (no over-reach)', () => {
+    // It is a sibling, NOT a child of /spec/conformance-check, so longest-prefix
+    // matching must not catch it.
+    expect(resolveRequestTimeout('/spec/conformance-metrics', DEFAULT_MS, overrides)).toBe(DEFAULT_MS);
+  });
+
+  it('leaves an arbitrary unrelated route on the default', () => {
+    expect(resolveRequestTimeout('/health', DEFAULT_MS, overrides)).toBe(DEFAULT_MS);
+    expect(resolveRequestTimeout('/telegram/reply-but-different', DEFAULT_MS, overrides)).toBe(DEFAULT_MS);
+  });
+
+  it('uses budgets materially larger than the 30s default', () => {
+    expect(OUTBOUND_MESSAGING_TIMEOUT_MS).toBeGreaterThanOrEqual(90_000);
+    expect(SPEC_REVIEW_TIMEOUT_MS).toBeGreaterThanOrEqual(90_000);
+  });
+
+  it('orders the inner provider budget strictly below the outer HTTP budget', () => {
+    // The provider must kill a too-slow review cleanly (fail-open degraded
+    // report) BEFORE the middleware fires a 408 at the client. If this inverts,
+    // a slow spec produces a raw 408 again.
+    expect(CONFORMANCE_REVIEW_TIMEOUT_MS).toBeLessThan(SPEC_REVIEW_TIMEOUT_MS);
+  });
+
+  it('AgentServer wires the production override builder (not an inline literal)', () => {
+    const agentServerSrc = fs.readFileSync(
+      path.join(import.meta.dirname, '../../src/server/AgentServer.ts'),
+      'utf-8',
+    );
+    // Regression guard: the global default is still passed as the first arg, and
+    // the overrides come from the shared builder (so this test's map == prod's).
+    expect(agentServerSrc).toMatch(/requestTimeout\(options\.config\.requestTimeoutMs,\s*buildRequestTimeoutOverrides\(\)\)/);
   });
 });
 

--- a/tests/unit/ClaudeCliIntelligenceProvider-timeout.test.ts
+++ b/tests/unit/ClaudeCliIntelligenceProvider-timeout.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests — ClaudeCliIntelligenceProvider honors IntelligenceOptions.timeoutMs.
+ *
+ * Regression for the two-walls conformance-gate timeout bug
+ * (docs/specs/conformance-gate-timeout.md): the provider used to hardcode the
+ * child-process timeout at 30s and ignore the caller's budget, so an LLM-backed
+ * caller on a synchronous path (the standards-conformance gate reviewing a full
+ * spec) was killed at 30s regardless. `timeout` is an execFile *option*, not an
+ * argv flag, so we assert it behaviorally with a slow fake binary: a short
+ * budget must kill the call; a generous budget (and the unchanged 30s default)
+ * must let it finish.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ClaudeCliIntelligenceProvider } from '../../src/core/ClaudeCliIntelligenceProvider.js';
+import { clearClaudeForbidden } from '../../src/core/claudeForbiddenGuard.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let tmpDir: string;
+let slowClaudePath: string;
+
+beforeAll(() => {
+  clearClaudeForbidden(); // ensure the codex-only guard isn't tripped from another test
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-provider-timeout-'));
+  // Sleeps 1s, then prints — slow enough to be killed by a 100ms budget but
+  // comfortably under both a 5s budget and the 30s default.
+  slowClaudePath = path.join(tmpDir, 'slow-claude');
+  fs.writeFileSync(slowClaudePath, '#!/bin/sh\nsleep 1\necho "OK"\nexit 0\n', { mode: 0o755 });
+});
+
+afterAll(() => {
+  SafeFsExecutor.safeRmSync(tmpDir, {
+    recursive: true,
+    force: true,
+    operation: 'tests/unit/ClaudeCliIntelligenceProvider-timeout.test.ts:afterAll',
+  });
+});
+
+describe('ClaudeCliIntelligenceProvider — per-call timeout (IntelligenceOptions.timeoutMs)', () => {
+  it('honors a short timeoutMs — kills a slow call (pre-fix this budget was ignored)', async () => {
+    const provider = new ClaudeCliIntelligenceProvider(slowClaudePath);
+    await expect(provider.evaluate('hi', { timeoutMs: 100 })).rejects.toThrow();
+  });
+
+  it('a generous timeoutMs lets the same slow call finish', async () => {
+    const provider = new ClaudeCliIntelligenceProvider(slowClaudePath);
+    await expect(provider.evaluate('hi', { timeoutMs: 5000 })).resolves.toContain('OK');
+  });
+
+  it('without timeoutMs the 30s default is unchanged — a sub-default call still resolves', async () => {
+    const provider = new ClaudeCliIntelligenceProvider(slowClaudePath);
+    await expect(provider.evaluate('hi')).resolves.toContain('OK');
+  });
+});

--- a/tests/unit/CodexCliIntelligenceProvider.test.ts
+++ b/tests/unit/CodexCliIntelligenceProvider.test.ts
@@ -127,6 +127,34 @@ describe('CodexCliIntelligenceProvider — spawn args', () => {
   });
 });
 
+describe('CodexCliIntelligenceProvider — per-call timeout (IntelligenceOptions.timeoutMs)', () => {
+  // Regression for the two-walls conformance-gate timeout bug
+  // (docs/specs/conformance-gate-timeout.md): the provider used to hardcode the
+  // execFile timeout at 30s and ignore the caller's budget. `timeout` is an
+  // execFile option, not argv, so we assert it behaviorally with a slow fake.
+  let slowCodexPath: string;
+
+  beforeAll(() => {
+    slowCodexPath = path.join(tmpDir, 'slow-codex');
+    fs.writeFileSync(slowCodexPath, '#!/bin/sh\nsleep 1\necho "DONE"\nexit 0\n', { mode: 0o755 });
+  });
+
+  it('honors a short timeoutMs — kills a slow call (pre-fix this budget was ignored)', async () => {
+    const provider = new CodexCliIntelligenceProvider({ codexPath: slowCodexPath, workingDirectory: nonGitDir });
+    await expect(provider.evaluate('hi', { timeoutMs: 100 })).rejects.toThrow();
+  });
+
+  it('a generous timeoutMs lets the same slow call finish', async () => {
+    const provider = new CodexCliIntelligenceProvider({ codexPath: slowCodexPath, workingDirectory: nonGitDir });
+    await expect(provider.evaluate('hi', { timeoutMs: 5000 })).resolves.toContain('DONE');
+  });
+
+  it('without timeoutMs the 30s default is unchanged — a sub-default call still resolves', async () => {
+    const provider = new CodexCliIntelligenceProvider({ codexPath: slowCodexPath, workingDirectory: nonGitDir });
+    await expect(provider.evaluate('hi')).resolves.toContain('DONE');
+  });
+});
+
 describe('CodexCliIntelligenceProvider — clean-call (no identity, no hooks)', () => {
   // Regression: judgment calls must NOT run in the agent's project dir, or
   // codex loads the full ~26 KB AGENTS.md identity and fires the project's

--- a/tests/unit/standards-conformance-gate.test.ts
+++ b/tests/unit/standards-conformance-gate.test.ts
@@ -23,8 +23,9 @@ import {
   StandardsConformanceReviewer,
   buildConformancePrompt,
   parseConformanceResponse,
+  CONFORMANCE_REVIEW_TIMEOUT_MS,
 } from '../../src/core/reviewers/standards-conformance.js';
-import type { IntelligenceProvider } from '../../src/core/types.js';
+import type { IntelligenceProvider, IntelligenceOptions } from '../../src/core/types.js';
 
 const REGISTRY_PATH = path.join(process.cwd(), 'docs/STANDARDS-REGISTRY.md');
 
@@ -88,6 +89,22 @@ describe('StandardsConformanceReviewer', () => {
     expect(report.findings).toHaveLength(1);
     expect(report.findings[0].standard).toBe('No Manual Work (user *or* agent)');
     expect(report.findings[0].status).toBe('possible-violation');
+  });
+
+  it('passes the conformance review budget (timeoutMs) to the provider', async () => {
+    // Regression guard for the two-walls timeout bug: if the reviewer does not
+    // pass a budget, the provider's 30s default kills the review on any real
+    // spec and the gate silently returns an empty degraded report. The budget
+    // must reach the provider via IntelligenceOptions.timeoutMs.
+    let seen: IntelligenceOptions | undefined;
+    const provider: IntelligenceProvider = {
+      async evaluate(_prompt: string, options?: IntelligenceOptions) {
+        seen = options;
+        return '[]';
+      },
+    };
+    await new StandardsConformanceReviewer(provider).review('spec', FIXTURE_ARTICLES);
+    expect(seen?.timeoutMs).toBe(CONFORMANCE_REVIEW_TIMEOUT_MS);
   });
 
   it('degrades safe (empty report) when no provider is configured', async () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,44 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Standards-Conformance Gate (`POST /spec/conformance-check`, auto-invoked during `/spec-converge`) could not review a real, full-size spec — it timed out. The review hit **two** independent 30-second walls:
+
+1. The HTTP request-timeout middleware applied its 30s default to the route — the conformance route was never added to the per-path override map that already gives the LLM-backed messaging routes a longer budget.
+2. Both intelligence providers (`ClaudeCliIntelligenceProvider`, `CodexCliIntelligenceProvider`) hardcoded their `execFile` child-process timeout at 30s and ignored the `IntelligenceOptions.timeoutMs` the interface already defines, and the reviewer never passed one.
+
+A middleware-only fix would have been worse than the bug: past the outer wall, the model call still died at 30s inside the provider, and the reviewer swallows that throw into an empty `degraded` report — turning a loud 408 into a silent "no findings," which reads like the spec passed.
+
+The fix removes both walls: the providers now honor `options.timeoutMs ?? DEFAULT` (the 30s default is unchanged for every other caller — opt-in only); the conformance reviewer passes a 150s budget; the middleware grants the route a 180s outer budget (above the inner 150s so a genuinely-too-slow review degrades fail-open instead of erroring at the client). The override map and its longest-prefix matcher were lifted into `middleware.ts` as a single source of truth so a wiring-integrity test asserts the exact production config. The gate remains signal-only and fail-open — this only lets the review finish so it can emit its advisory report.
+
+## What to Tell Your User
+
+- **Spec self-review now works on real specs**: When you put a spec through review, the automatic constitution check can now actually finish on a full-length spec instead of quietly giving up — so it reports real concerns instead of a misleading "all clear."
+- It is still advisory only — it flags things for me to weigh, it never blocks on its own, and nothing on your end changes.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Conformance gate completes on full-size specs | Automatic during spec review (no longer times out at 30s) |
+| Providers honor a per-call time budget | Automatic — internal callers that need a longer LLM call now get it; the 30s default is unchanged for everything else |
+
+## Evidence
+
+**Failure reproduced (before):** Dogfooding the gate against a real ~400-line spec (the feedback-factory-migration draft, 18,218 chars) returned `HTTP 408 {"error":"Request timeout","timeoutMs":30000}`. Reading the code confirmed the second wall: both providers call `execFile(..., { timeout: DEFAULT_TIMEOUT_MS=30_000 })` and never read `options.timeoutMs`; the reviewer (`standards-conformance.ts`) passed no budget and returns `{ degraded: true, degradeReason: 'error' }` on any throw.
+
+**Verified to stop (after):** Built this branch and ran the actual `StandardsConformanceReviewer.review()` (real `ClaudeCliIntelligenceProvider`, model `capable`/opus) against that same 18,218-char spec and the live 23-article constitution:
+
+```
+=== RESULT after 36.9s ===
+degraded: false
+standardsChecked: 23
+findings: 1
+  - [Building] Testing Integrity: The spec sets parity-against-Python as the sole acceptance bar and explicitly subordinates...
+```
+
+The review ran for **36.9 seconds — past the exact 30s wall that previously killed it** — and returned a non-degraded report with a real finding. Pre-fix, this identical call is killed at 30s by the provider and yields an empty `degraded` report; post-fix it completes and emits real signal.
+
+**Mechanism regression-locked by behavioral tests** (not mocks): new tests spawn a slow real subprocess and prove a short `timeoutMs` now kills the call while a generous/absent budget lets it finish (both providers); the reviewer is asserted to pass `CONFORMANCE_REVIEW_TIMEOUT_MS`; and the production override map/matcher resolve `/spec/conformance-check` → 180s while the fast sibling `/spec/conformance-metrics` stays on the default. Full push suite: 983 files, 18,458 tests, 0 failures.

--- a/upgrades/side-effects/conformance-gate-timeout.md
+++ b/upgrades/side-effects/conformance-gate-timeout.md
@@ -1,0 +1,39 @@
+# Side-Effects Review — conformance-gate timeout fix
+
+**Slug:** `conformance-gate-timeout`
+**Date:** `2026-05-26`
+**Author:** Echo
+**Spec:** `docs/specs/conformance-gate-timeout.md` (converged v1, approved by Justin 2026-05-26)
+**Second-pass reviewer:** independent adversarial reviewer concurred ("blocking finding closed, nothing missing") after catching the second 30s wall in the v0 draft.
+
+## Summary of the change
+
+`POST /spec/conformance-check` (the Standards-Conformance Gate, auto-wired into `/spec-converge` by PR #403) timed out (HTTP 408 at 30s) on a real ~400-line spec. Root cause is **two** 30s walls: (A) the route was never added to the `requestTimeout` middleware's `perPathOverrides`, and (B) both `ClaudeCliIntelligenceProvider` and `CodexCliIntelligenceProvider` hardcoded `execFile(..., { timeout: 30_000 })` and ignored the `IntelligenceOptions.timeoutMs` the interface already defines, while the reviewer never passed one. A middleware-only fix would have converted the loud 408 into a silent empty `degraded` report (worse).
+
+Fix (4 source edits):
+1. Both providers: `timeout: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS` (default 30s unchanged for every other caller).
+2. `StandardsConformanceReviewer`: pass `timeoutMs: CONFORMANCE_REVIEW_TIMEOUT_MS` (150_000).
+3. `middleware.ts`: exported `OUTBOUND_MESSAGING_TIMEOUT_MS`, new `SPEC_REVIEW_TIMEOUT_MS = 180_000`, `buildRequestTimeoutOverrides()` (single source of truth, now includes `/spec/conformance-check`), and `resolveRequestTimeout()` (matching logic extracted + shared with tests).
+4. `AgentServer.ts`: wires `requestTimeout(..., buildRequestTimeoutOverrides())` instead of an inline literal.
+
+## Decision-point inventory
+
+No new decision point is created. The gate stays **signal-only + fail-open** — the change only lets the review *finish* so it can emit its (advisory) report. No blocking authority added (that remains the separate later `scg-blocking-authority` item).
+
+## Seven-dimension review
+
+1. **Over/under-reach** — Provider change is gated behind `options?.timeoutMs` being present, so the default path is byte-identical for every other `evaluate` caller (classifiers, sentinels, tone gate). Middleware override matches `/spec/conformance-check` (+children) only; the fast sibling `/spec/conformance-metrics` keeps the default — asserted by `resolveRequestTimeout('/spec/conformance-metrics', …) === default` in the unit test.
+2. **Level-of-abstraction fit** — Each edit sits at its correct layer: child-process budget in the provider, review budget in the reviewer, HTTP budget in the middleware. No cross-layer leakage.
+3. **Signal vs Authority** — Unchanged; verified above.
+4. **Interactions** — The two budgets interact only through the ordering invariant `CONFORMANCE_REVIEW_TIMEOUT_MS (150s) < SPEC_REVIEW_TIMEOUT_MS (180s)`, pinned by a test, so the provider's clean kill fires before the middleware 408 → fail-open, not a raw timeout.
+5. **Rollback cost** — Trivial and total: revert the edits; no data, no state, no migration.
+6. **Migration parity** — N/A. All edits are server/library runtime code shipped in the package; none touch agent-installed files (`.claude/settings.json` / config / CLAUDE.md template / hooks / skills). Existing agents receive it on package update like all runtime code.
+7. **Failure modes** — (a) Spec exceeds 150s → provider kills cleanly → fail-open degraded report (advisory); no 408, no regression vs today. (b) A caller passing `timeoutMs` to a provider expecting the old hard 30s → covered by the default-unchanged guarantee + the both-sides provider tests. (c) Override map drifting from the server's real wiring → prevented by testing the extracted production map/matcher. (d) Inner budget set ≥ outer → caught by the ordering-invariant test.
+
+## Tests added/changed
+
+- `tests/unit/ClaudeCliIntelligenceProvider-timeout.test.ts` (new) and an added block in `tests/unit/CodexCliIntelligenceProvider.test.ts`: behavioral — short `timeoutMs` kills a slow fake binary (regression catcher: pre-fix this budget was ignored), generous/absent budget resolves (honors longer; 30s default unchanged).
+- `tests/unit/standards-conformance-gate.test.ts`: asserts the reviewer passes `timeoutMs === CONFORMANCE_REVIEW_TIMEOUT_MS` to the provider.
+- `tests/unit/AgentServer-outbound-timeout.test.ts`: rewritten from a brittle source-regex into a wiring-integrity test that imports the production `buildRequestTimeoutOverrides()` + `resolveRequestTimeout()` and asserts `/spec/conformance-check` → 180s, `/spec/conformance-metrics` → default, plus the ordering invariant and that AgentServer wires the shared builder.
+
+All 44 tests across the four files pass. Independent reviewer re-verified the revised plan against live code.


### PR DESCRIPTION
## Summary
The Standards-Conformance Gate (`POST /spec/conformance-check`, auto-wired into `/spec-converge` by #403) 408'd on real specs. Root cause was **two** 30s walls:
1. The `requestTimeout` middleware default — the route was never added to the LLM-route override map.
2. Both intelligence providers hardcode `execFile(..., { timeout: 30_000 })` and ignore `IntelligenceOptions.timeoutMs`; the reviewer never passed one.

A middleware-only fix would have been **worse**: past the outer wall the model call still dies at 30s in the provider, and the reviewer turns that throw into a silent empty `degraded` report (reads like "passed"). This was caught by an adversarial review of the v0 spec.

## Fix
- Both providers: `timeout: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS` (30s default unchanged for every other caller — opt-in only).
- Reviewer passes `CONFORMANCE_REVIEW_TIMEOUT_MS = 150_000`.
- Middleware grants `/spec/conformance-check` `SPEC_REVIEW_TIMEOUT_MS = 180_000` (outer > inner so a too-slow review degrades fail-open, not a 408).
- Override map + longest-prefix matcher lifted into `middleware.ts` as the single source of truth for a wiring-integrity test.
- Gate stays signal-only + fail-open; no new authority.

Spec: `docs/specs/conformance-gate-timeout.md` (converged + approved). ELI16 + side-effects artifact included.

## Evidence
- **Before:** dogfooding the gate on a real 400-line spec → `HTTP 408 {"timeoutMs":30000}`.
- **After (live, this branch):** ran the real reviewer (`capable`/opus) against that same 18,218-char spec + the 23-article constitution → completed in **36.9s** (past the old 30s wall), `degraded: false`, 1 real finding.
- Behavioral tests (real subprocess, not mocks) lock the mechanism: short `timeoutMs` kills, generous/absent allows; reviewer passes the budget; production map resolves the route to 180s and leaves the fast sibling on default.
- Full push suite: 983 files, 18,458 tests, 0 failures.

## Test plan
- [x] `npm run test:push` green (983 files / 18,458 tests)
- [x] Live end-to-end verification of the fixed reviewer (36.9s, non-degraded)
- [ ] CI green