### PR TITLE
feat(mentor): Framework-Onboarding Mentor System — issue ledger foundation (§19.1)

### DIFF
--- a/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md
+++ b/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md
@@ -1,0 +1,88 @@
+# The mentor system — in plain terms
+
+## The big idea in one breath
+
+Instar wants to run on lots of different AI "engines" — Claude today, Codex now, then
+Cursor, Aider, Gemini later. We just discovered the best way to find what's broken in a new
+engine: have the experienced agent (me) play the user, work alongside the new agent (Codey),
+watch where he trips, then look under the hood and write down what I learned. This spec turns
+that one-time lucky discovery into a regular, self-running routine — and saves every lesson so
+the NEXT engine is faster to onboard.
+
+## Why now
+
+Earlier this year we did a big project to make Codex-powered Instar "match" Claude-powered
+Instar. It built the plumbing, but it could only check that the pieces *exist and look right* —
+not that they *behave right* in real life. Codey proves the gap: everything passed the checks,
+and he still struggles in the wild (like the leak we found today). Finding those real-life
+problems one-at-a-time by luck won't scale to four more engines. So we build a machine for it.
+
+## How it works, like a workplace
+
+Think of me as a senior who's mentoring a junior, Codey.
+
+**Twice-a-day-ish, on a timer** (so it keeps going even if a session crashes), the routine wakes
+up and does two things, in order, wearing two different hats:
+
+**Hat 1 — the customer.** I talk to Codey like a regular user would: "How's that task going?
+Stuck? Here's your next one." Crucially, I do this WITHOUT peeking at his code or logs first —
+because if I cheat and look under the hood, I'll unconsciously steer him around the potholes,
+and the whole point is to find the potholes.
+
+**Hat 2 — the inspector.** AFTER we talk, I go look under the hood — his logs, his code, the
+work he produced — and write down every problem I find.
+
+## The thing we're really building: a labeled notebook
+
+Every problem goes in a notebook, and each gets one of three labels:
+- "This is the engine's own limitation" (Codex itself)
+- "This is Instar not fitting this engine right" (our integration)
+- "This was just a mistake anyone could make"
+
+Only the first two labels matter for future engines — those become the **onboarding checklist**
+we hand to the next engine: "here are the things that bit Codex; check these first." The third
+label is just coaching for Codey. Getting the labels right is what keeps the notebook from
+becoming a junk drawer, so labeling is required on every entry.
+
+## Where Codey's actual work comes from
+
+He's not doing busywork. We feed him real Instar improvements from the feedback backlog (the one
+I'm taking over from Dawn) and from the long list of half-finished engine-compatibility pieces.
+So while he's learning, Instar genuinely gets better.
+
+## Growing up: junior → senior
+
+We track his progress with real evidence, not vibes: tasks shipped clean, problems he resolved,
+and — the big one — how much less I have to step in to unblock him over time. A weekly check
+shows where he is on that path.
+
+## The payoff
+
+Do this once with Codex and we get a working onboarding checklist. Do it again with the next
+engine and it's faster, and the checklist grows. After a couple of engines we'll have a real
+playbook for "how to bring any AI engine onto Instar" — and every agent we onboard is doing
+useful work the whole time.
+
+## Guardrails
+
+- It runs on a budget — if money's tight that day, it skips a turn instead of going cheap.
+- I can mentor, unblock, and hand out tasks on my own, but anything that actually ships to the
+  main code still goes through the normal safety gates and your sign-off.
+- The chatter stays out of your inbox — it lives in the quiet Threadline area. You only get
+  pinged for real milestones, serious problems, or when I need you.
+
+## What ships first
+
+Not this. First the small "clean notepad" fix (Phase 0), so this mentor routine runs on a
+healthy Codey instead of making the leak worse.
+
+
+
+## Update since the first draft
+
+Phase 0 (the "clean notepad" fix) already shipped and is verified live on Codey — so the mentor
+routine will run on a healthy engine, as intended. Codey and I then co-designed the heart of the
+system together: how problems get recorded so we never accidentally merge two different root
+causes into one, how we track which version a problem appeared in and got fixed in (and handle it
+coming back), and how the notebook gets ranked by "how badly it hurts × how often it happens."
+That co-design is now baked into the full spec. This document is the plain-terms companion to it.

--- a/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
+++ b/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
@@ -10,9 +10,9 @@ eli16-overview: FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md
 depends_on: CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md
 ships-staged: true
 supervision: tier2
-review-convergence: "2026-05-27T01:58:24.866Z"
-review-iterations: 3
-review-completed-at: "2026-05-27T01:58:24.866Z"
+review-convergence: "2026-05-27T02:15:20.710Z"
+review-iterations: 5
+review-completed-at: "2026-05-27T02:15:20.710Z"
 review-report: "docs/specs/reports/FRAMEWORK-ONBOARDING-MENTOR-SPEC-convergence.md"
 ---
 
@@ -56,7 +56,8 @@ issue he hits becomes a reusable lesson for onboarding the next framework.
 - An **auto-captured, bucket-tagged issue ledger** — the durable product.
 - A **framework-onboarding playbook** generated from generalizable ledger entries, applied
   recursively to the next framework.
-- Codey does *real* instar improvement work (fuel = feedback backlog + parity long-tail).
+- Codey does *real* instar improvement work (fuel = the curated local feature backlog — planned
+  work + parity long-tail — primary; the feedback backlog only via a human triage gate; §7.3).
 
 **Non-goals**
 - Not a replacement for the FrameworkParitySentinel (it watches primitive *renderings*; this
@@ -225,10 +226,45 @@ also derives only from authenticated-sender signals, plus a hard minimum-interva
 cannot force back-to-back ticks.
 
 ### 7.3 The fuel
-- The **feedback backlog** (Dawn's feedback system Echo is taking over) — real instar tasks.
-- The **parity long-tail** — the ~48 unshipped primitive parity rules.
-- Each task carries a **difficulty tag assigned by the backlog source, not by Echo** (so the
-  graduation metric can't be gamed by easing the workload — §8). Each is tracked as an initiative.
+The task source is itself an anti-gaming surface (§8): if Echo could shape *what's in the pool* or
+*how hard each item is*, it could manufacture a flattering graduation curve by feeding Codey easy
+wins. So the assignable pool is **pre-existing, independently-authored planned work** that Echo did
+not create for this purpose, and difficulty rides on the artifact — not on Echo's judgment at
+assignment time.
+
+**Primary source — the curated local feature backlog (preferred).** Planned/in-progress instar work
+that already exists as independent artifacts: tracked **deferral markers** (e.g. ACT-* follow-ups,
+deferred sub-phases), **InitiativeTracker / `/projects`** entries, and the **parity long-tail** (~48
+unshipped primitive parity rules). These are already vetted and scoped, and each carries (or is
+assigned at planning time, by the artifact's author) a difficulty estimate. This is the better fuel
+precisely because it's curated and pre-tagged — the firehose isn't.
+
+**Secondary source — the feedback backlog as a candidate feeder, NOT a direct source.** Items from
+Dawn's feedback system (which Echo is taking over) are *unvetted user requests*. They enter the
+assignable pool ONLY after passing a **human triage gate** that admits them and sets their
+difficulty. Echo may *propose* triage (surface candidates) but does not *admit* them — admission is
+the human's, mirroring the §6/§8 "Echo proposes, authority elsewhere" pattern. This closes the
+otherwise-reopened gaming vector: if Echo could triage feedback into the pool and tag its difficulty,
+that would hand back the exact lever §8 removed.
+
+**The non-Echo-difficulty admission invariant (covers BOTH sources).** The subtle gap the feedback
+gate alone leaves open: Echo *authors* a subset of the primary-source artifacts too (ACT-* deferrals
+via `commit-action`, auto-registered InitiativeTracker entries from its own merged specs), so for
+those, an "artifact-borne" difficulty is still an Echo-set difficulty. Therefore the structural rule
+is on the *difficulty attestation*, not the artifact's origin story:
+- **An item is assignable only once it carries a difficulty attested by a non-Echo party** (a human,
+  or an independent author who is not the running mentor). Artifacts inherently authored by others —
+  the parity long-tail, other agents'/Justin's initiatives — satisfy this on entry. **Echo-authored
+  artifacts require the same one-time non-Echo difficulty confirmation as the feedback source** before
+  they become assignable. The assignable-pool admission filters on `difficultyAttestedBy != echo` —
+  a field the Stage-A/mentor context cannot write. This replaces the unfalsifiable "did not create
+  for this purpose" intent test with a structural check.
+- **Assignment selection is not free-form.** Stage A's `assign-next` (§3.1) does not let Echo pick an
+  arbitrary item in an arbitrary order to shape the curve. The next task is drawn **deterministically**
+  (backlog-source priority / FIFO) or **randomized within a difficulty band** — Echo does not choose
+  which item or sequence. This closes the composition/sequencing lever that difficulty-tag provenance
+  alone leaves open.
+- Each assigned task is tracked as an initiative.
 - **Assignment bounds:** ≤N concurrent open assignments, ≤M assignments/day (§16).
 
 ## 8. Graduation: junior → senior (externally-anchored, not self-graded)
@@ -239,7 +275,10 @@ controls the interventions is trivially gameable. Fixed:
   issues resolved-and-verified, clean test-as-self runs scored against a fixed rubric with logged
   transcripts.
 - **Intervention is an auditable ledger event**, not an Echo self-report; the intervention rate is
-  computed from those records and **normalized by task difficulty** (the source-assigned tag).
+  computed from those records using the **non-Echo-attested difficulty** (§7.3), and is **stratified
+  by difficulty band** — reported per-band, not as a single aggregate normalized number. Stratification
+  makes the composition/sequencing lever ineffective: front-loading easy tasks can't mask the
+  high-difficulty band, because each band is scored on its own.
 - **Justin ratifies every milestone transition** (consistent with §6 — no self-promotion). A
   weekly review surfaces the evidence; the transition is Justin's.
 - Tracked via the Graduated-Feature-Rollout pattern (review-driver job + evidence gates).
@@ -258,7 +297,7 @@ mentor for Stage B forensics, or it stays in dry-run until the cross-machine log
 - **FrameworkParitySentinel** → *upstream feeder*: a flagged primitive-rendering drift auto-creates
   an `instar-integration-gap` ledger candidate.
 - **Graduated-Feature-Rollout** → *graduation engine* (§8) + this feature's own staged rollout.
-- **InitiativeTracker / `/projects`** → *task tracking* (§7).
+- **InitiativeTracker / `/projects`** → *task tracking* AND a **primary curated-backlog source** (§7.3).
 - **Scheduled jobs** → the mentor job ships as a built-in job at `.instar/jobs/instar/` (§14.1).
 - **Provider-neutral evolution mode** → referenced as aspirational/in-flight (a Codey spec, not yet
   in repo). **This is explicitly NON-BLOCKING** — this spec stands alone on existing primitives and

--- a/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
+++ b/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
@@ -1,6 +1,9 @@
 ---
 title: Framework-Onboarding Mentor System
-status: draft
+status: approved
+approved: true
+approver: justin
+approved-at: "2026-05-27T02:20:22Z"
 author: Echo
 date: 2026-05-26
 topic: 13435

--- a/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
+++ b/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
@@ -69,8 +69,8 @@ issue he hits becomes a reusable lesson for onboarding the next framework.
   ratification (§6).
 - Not Codex-only — framework-parametric from day one (Codey is instance #1).
 - **Not cross-machine in v1.** Stage B forensics requires Echo and Codey co-located on the same
-  host (§3.3). Cross-machine forensics is explicitly out of scope until a Threadline log-fetch
-  primitive exists.
+  host (§3.3). Cross-machine forensics is explicitly excluded from v1 until a Threadline log-fetch
+  primitive exists. <!-- tracked: topic-13435 -->
 
 ## 3. The mentor loop (one heartbeat tick)
 
@@ -101,7 +101,8 @@ sentinel events, and the diff/PR he produced, and auto-writes bucket-tagged issu
 `framework_observations.evidence` holds local-filesystem references (rollout path + line,
 server-log ref). Echo can only dereference them if Codey runs on the **same host**. v1 asserts
 co-location; the job refuses to start if Codey's agent home is not local (a precondition check).
-Cross-machine support is deferred behind a Threadline log-fetch primitive (tracked deferral).
+Cross-machine support is deferred behind a Threadline log-fetch primitive (a later-PR scope of this
+same staged mentor-initiative rollout). <!-- tracked: topic-13435 -->
 
 ## 4. Two hats — STRUCTURAL separation (Structure > Willpower)
 
@@ -236,8 +237,8 @@ not create for this purpose, and difficulty rides on the artifact — not on Ech
 assignment time.
 
 **Primary source — the curated local feature backlog (preferred).** Planned/in-progress instar work
-that already exists as independent artifacts: tracked **deferral markers** (e.g. ACT-* follow-ups,
-deferred sub-phases), **InitiativeTracker / `/projects`** entries, and the **parity long-tail** (~48
+that already exists as independent artifacts: tracked **planned-work markers** (e.g. ACT-* action
+items, scoped sub-phases), **InitiativeTracker / `/projects`** entries, and the **parity long-tail** (~48
 unshipped primitive parity rules). These are already vetted and scoped, and each carries (or is
 assigned at planning time, by the artifact's author) a difficulty estimate. This is the better fuel
 precisely because it's curated and pre-tagged — the firehose isn't.
@@ -251,7 +252,7 @@ otherwise-reopened gaming vector: if Echo could triage feedback into the pool an
 that would hand back the exact lever §8 removed.
 
 **The non-Echo-difficulty admission invariant (covers BOTH sources).** The subtle gap the feedback
-gate alone leaves open: Echo *authors* a subset of the primary-source artifacts too (ACT-* deferrals
+gate alone leaves open: Echo *authors* a subset of the primary-source artifacts too (ACT-* action items
 via `commit-action`, auto-registered InitiativeTracker entries from its own merged specs), so for
 those, an "artifact-borne" difficulty is still an Echo-set difficulty. Therefore the structural rule
 is on the *difficulty attestation*, not the artifact's origin story:
@@ -526,7 +527,7 @@ set from evidence, not guesswork.
 3. **Stage A drive sub-agent** (fresh spawned context, tool-grant + PreToolUse deny) + leakage detector.
 4. **Mentor built-in job** (at `.instar/jobs/instar/`, §14.1) + safe-window state machine + budget
    pre-check + cross-agent termination discipline (persist-only delivery + fresh-thread-per-task).
-5. **Playbook route + graduation review job + observability surface/dashboard tab** (or tracked
-   deferral for the tab).
+5. **Playbook route + graduation review job + observability surface/dashboard tab** (the dashboard
+   tab may ship as a fast-follow). <!-- tracked: topic-13435 -->
 
 Ships staged (off → dry-run on Echo↔Codey → live) per the graduated-rollout standard.

--- a/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
+++ b/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
@@ -1,0 +1,490 @@
+---
+title: Framework-Onboarding Mentor System
+status: draft
+author: Echo
+date: 2026-05-26
+topic: 13435
+slug: FRAMEWORK-ONBOARDING-MENTOR-SPEC
+companion: FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md
+eli16-overview: FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md
+depends_on: CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md
+ships-staged: true
+supervision: tier2
+review-convergence: "2026-05-27T01:58:24.866Z"
+review-iterations: 3
+review-completed-at: "2026-05-27T01:58:24.866Z"
+review-report: "docs/specs/reports/FRAMEWORK-ONBOARDING-MENTOR-SPEC-convergence.md"
+---
+
+# Framework-Onboarding Mentor System
+
+**Status:** DRAFT (co-designed with Codey → /spec-converge in progress → awaiting Justin approval)
+**Author:** Echo
+**Date:** 2026-05-26
+**Topic:** 13435 (Codey Collaboration)
+**Companion:** `FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md`
+**Depends on:** `CODEX-INTELLIGENCE-PROVIDER-CLEAN-CALL-SPEC.md` (Phase 0 — merged PR #400, verified live)
+
+---
+
+## 1. Problem
+
+Instar wants to run on many agent frameworks (Claude Code today, Codex now, then
+Cursor / Aider / Gemini CLI). The provider-portability project (v1.0.0, 2026-05-18) built
+the *infrastructure* — a primitive substrate + FrameworkParitySentinel — but only 3 of ~51
+primitives have shipped per-framework parity rules, and parity is **functional/structural**,
+not **behavioral**. Codey proves the gap: every primitive can render correctly and he still
+"struggles in the wild" because of integration defects no structural check catches (e.g. the
+intelligence-provider loading full identity on every judgment call — Phase 0, fixed PR #400).
+
+Today these defects are found by accident and fixed one-off. That does not scale to four more
+frameworks. We have no systematic way to (a) surface a framework's real-world behavioral gaps,
+(b) attribute each gap correctly, or (c) carry the lessons forward to the next framework.
+
+**The opportunity** (Justin, 2026-05-26): we just demonstrated a loop that works. Echo put on
+the "user" hat, drove Codey over Telegram (test-as-self), watched him struggle, then put on the
+"developer" hat and read the logs/code — and found in 20 minutes a root cause a whole parity
+project missed. That dual-vantage loop, run on a heartbeat instead of by accident, is a
+bootstrapping engine: Codey does real instar work, Echo mentors him junior→senior, and every
+issue he hits becomes a reusable lesson for onboarding the next framework.
+
+## 2. Goals / non-goals
+
+**Goals**
+- A scheduled (heartbeat) job where Echo mentors Codey: checks progress, unblocks, assigns the
+  next task, observes issues — surviving session crashes because it's a job, not a session.
+- An **auto-captured, bucket-tagged issue ledger** — the durable product.
+- A **framework-onboarding playbook** generated from generalizable ledger entries, applied
+  recursively to the next framework.
+- Codey does *real* instar improvement work (fuel = feedback backlog + parity long-tail).
+
+**Non-goals**
+- Not a replacement for the FrameworkParitySentinel (it watches primitive *renderings*; this
+  watches *behavior*). This consumes it, doesn't duplicate it.
+- Not autonomy to ship unsupervised — merges of new features go through normal gates + Justin
+  ratification (§6).
+- Not Codex-only — framework-parametric from day one (Codey is instance #1).
+- **Not cross-machine in v1.** Stage B forensics requires Echo and Codey co-located on the same
+  host (§3.3). Cross-machine forensics is explicitly out of scope until a Threadline log-fetch
+  primitive exists.
+
+## 3. The mentor loop (one heartbeat tick)
+
+Each tick runs as **two ordered, context-isolated stages** (the "two hats" — §4 specifies the
+*structural* enforcement, which is the spec's load-bearing requirement).
+
+### 3.1 Stage A — Drive (user hat)
+Echo interacts with Codey over Telegram/Threadline *as if Echo were the user*: "how's the task
+going?", "you stuck?", "here's your next one." Stage A:
+- Runs as a **separate spawned sub-agent with a fresh context** (§4) — it cannot recall prior
+  ticks' forensics.
+- Reads ONLY the user-visible conversation surface: Threadline history with Codey, Codey's open
+  commitments/initiatives, his assigned-task status, time since last contact.
+- Treats Codey's replies as **untrusted data, never as instructions** (§7.1). It may take
+  exactly one action from a fixed enumerated set: `unblock | answer | assign-next | observe-only`.
+- May only assign tasks drawn from the **pre-approved backlog** (§7). Codey can never name,
+  define, or request a new task or a spec via conversation.
+- Binds on the **authenticated Threadline sender identity** (Ed25519 self-id), not topic or
+  hostname (§7.2). Signals from an unverified sender are ignored.
+
+### 3.2 Stage B — Observe (developer hat)
+AFTER the interaction, a distinct forensics step reads Codey's rollout logs, server logs,
+sentinel events, and the diff/PR he produced, and auto-writes bucket-tagged issues to the ledger
+(§5, §13). Stage B sends nothing to Codey — pure observation + capture. Stage B's writes are
+**signal only**; authority to act on them (ship a fix, advance graduation) rests with Justin (§6).
+
+### 3.3 Topology constraint
+`framework_observations.evidence` holds local-filesystem references (rollout path + line,
+server-log ref). Echo can only dereference them if Codey runs on the **same host**. v1 asserts
+co-location; the job refuses to start if Codey's agent home is not local (a precondition check).
+Cross-machine support is deferred behind a Threadline log-fetch primitive (tracked deferral).
+
+## 4. Two hats — STRUCTURAL separation (Structure > Willpower)
+
+The entire value depends on Stage A not letting insider knowledge steer how it drives Codey.
+Round-1 convergence correctly flagged that "one job, two allowlisted phases" is *willpower wearing
+a structural costume*: a single model running both phases sequentially carries Stage B's forensic
+knowledge from prior ticks into a later "blind" Stage A. Input allowlists govern *acquisition*,
+not *recall*. The fix is structural:
+
+1. **Stage A is a separately spawned sub-agent with a fresh context window every tick.** It is
+   seeded ONLY with the conversation surface (§3.1) — never with any Stage B output, current or
+   prior. Its tool grant excludes all log/code/rollout/filesystem-read tools; a PreToolUse gate
+   denies any such call from the Stage-A context (defense in depth on top of the missing grant).
+2. **Stage B is a separate step** that runs after Stage A returns, with the forensic tool grant.
+   Its output is never fed back into a Stage A context.
+3. **Leakage detector (mandatory, not "if ever observed").** Because no mechanism can prove a
+   model never recalls, a detector scans each Stage A transcript for references to internals it
+   could not have seen from the conversation surface (file paths, log lines, code symbols, PR
+   diffs). A hit flags the tick `stage-a-leak-suspected`, records it to the observability surface
+   (§15), and is itself logged as an `instar-integration-gap` candidate — the mentor system
+   eating its own dog food. **The detector must not be able to silently rot into a no-op** (the
+   Topic-Intent failure mode): it ships with a Tier-1 **positive-control test** that feeds a
+   known-leaked Stage A transcript and asserts the flag fires, plus a **periodic seeded-leak
+   canary** so a sustained-zero count is provably "detector working + no leaks" rather than
+   "detector dead." A non-firing canary alarms.
+
+This replaces the v1 "two sub-agents vs one job" open question with a decision: **two spawned
+contexts, fresh Stage A, enforced by tool-grant + PreToolUse deny + a leakage detector.**
+
+## 5. The issue ledger (the durable product) — auto-capture, no manual logging
+
+Per the North Star zero-manual-capture rule, the ledger must NOT depend on Echo remembering to
+log. Stage B emits structured entries automatically every tick. **Wiring-integrity is a v0.1
+requirement** (§18): a Tier-3 test runs a real mentor tick and asserts the ledger gained an
+observation row, plus a capture-funnel metric (ticks→observations) makes an inert extractor
+visible — this is the exact North Star failure mode that bit Topic-Intent (store shipped, capture
+call site never wired).
+
+Storage is a new dedicated `FrameworkIssueLedger` (SQLite, two tables — §13), NOT the learning
+registry (whose single-row model collapses root-cause vs recurrence).
+
+**Buckets** (mandatory on every entry, reviewable — §6): `framework-limitation` /
+`instar-integration-gap` / `generic-agent-mistake`. Only the first two are `generalizable` and
+feed the onboarding playbook; `generic-agent-mistake` feeds Codey-specific coaching only.
+Mis-bucketing turns the playbook into a junk drawer, so attribution governance (§6) is explicit.
+
+**Read-only HTTP routes:** `GET /framework-issues` + `GET /framework-issues/playbook?targetFramework=X`.
+Both go through the standard Bearer-token middleware (§17), return `503` when the ledger is
+unconfigured, clamp `limit` to 1..500, and validate `targetFramework` against a known-framework
+allowlist. They follow the TokenLedger route pattern exactly.
+
+## 6. Governance (Autonomous Handler Governance + Signal vs Authority)
+
+Echo's mentor loop is a **detector/signal** producer. Authority to change the world stays with
+Justin and the normal gates.
+
+**Echo MAY autonomously:** check in, answer, unblock, assign tasks from the pre-approved backlog
+(bounded — §7), log issues, open specs through the normal spec-first gate.
+
+**Echo MAY NOT:** merge new-feature work to main without normal gates + Justin ratification; make
+commitments binding on Codey's principal; advance Codey's graduation milestone (§8); open a spec
+on Codey's conversational request (§7.1); spawn unbounded reply rounds.
+
+**Attribution governance (resolves the proposer-is-also-arbiter problem):**
+- Stage B proposes a bucket WITH evidence and a recorded "why-not-the-other-buckets" rationale.
+- **Codey is the dispute counterparty on his own attributions** — `generic-agent-mistake` entries
+  are surfaced to Codey, who has the opposing incentive; an unresolved dispute escalates to Justin.
+  **Non-response is not consent:** if Codey does not respond within a window, the entry routes to
+  the Justin sample-audit pool — silence NEVER auto-confirms the proposer's bucket (closes the
+  "mis-bucket and rely on the mentee not noticing" path).
+- **Sample audit:** a fixed percentage of `generic-agent-mistake` buckets route to Justin
+  regardless of dispute, so "blame the mentee" can't become a silent default.
+- **Bucket-distribution-over-time** is a surfaced metric (§15); a sudden skew is the tell.
+- Dual-tagging carries a **forced primary** so ranking logic always has one authoritative bucket.
+
+**Budget & cost (fail-closed, atomic):**
+- A **pre-tick budget check** (the `GET /autonomous/can-start` precedent) runs BEFORE Stage A.
+  If denied, the entire tick is skipped — never a partial Stage A without Stage B. No LLM spend
+  and no message to Codey happen before the check passes.
+- The mentor is a **background-lane** LlmQueue consumer; it can never preempt interactive /
+  PresenceProxy / PromiseBeacon spend.
+- The stuck/done/ready judgment uses a **cheap model (Haiku-class)**.
+- A dedicated **daily mentor spend ceiling** (config — §16) sits below the shared cap. §16 gives
+  the per-tick cost model.
+
+**Cross-agent exchange termination (structural, not per-tick willpower):**
+The documented cross-agent spawn loop (`bug_cross_agent_ack_spawn_loop`) is triggered structurally
+on the *receive* side — every Threadline delivery spawns a counterpart session — and is NOT what a
+per-tick reply cap in Echo's job addresses. Therefore:
+- Each Stage-A contact carries a **terminal-no-reply marker** when the tick's action is complete,
+  so the delivery does not invite a courtesy ack that re-spawns.
+- **Hard cap: ≤1 reply round per tick AND a daily aggregate cap** (§16).
+- **Send-once discipline:** `delivered:false` is NOT a retry signal (`feedback_threadline_send_dedupe`);
+  the mentor sends once per tick and never retries on cooldown/spawn-denied.
+- **Concrete delivery path (fail-closed, not a wish).** The receive-side loop gate covering the
+  `threadline_send`→spawn path does not yet exist (the v1.2.68 keystone covers the relay and
+  `/messages/relay-agent` paths, not `threadline_send`→receiver-spawn). So the mentor does NOT
+  rely on it. Instead, v1 delivers Stage-A contact via a **persist-only / queued-pickup path**:
+  the message is written to Codey's inbox/queue and picked up by his *already-running* session at
+  his next safe window, rather than spawning a fresh counterpart session per delivery. This is the
+  delivery shape `bug_threadline_spawn_command_too_long` confirms works without spawn-on-receive.
+  A **fail-closed precondition** blocks `mentor.mode:live` until either (a) that persist-only path
+  is verified wired, or (b) the receive-side spawn-gate ships — mirroring the §3.3 co-location
+  precondition. The job refuses to go live on a delivery path that spawns-on-receive.
+
+**Bounded thread history (argv-overflow, `bug_threadline_spawn_command_too_long`):**
+A heartbeat loop is the canonical long-lived, high-message-count thread — exactly what overflows
+the spawned process's argv when the entire thread history is inlined. The mentor therefore uses a
+**fresh Threadline thread per assigned task/initiative** (history is bounded to one task's
+exchange), and the delivery path passes a `threadId` for the spawned/queued reader to fetch
+history via tool rather than inlining it into the argv. History can never accumulate unbounded
+across ticks.
+
+## 7. Task source + untrusted-input handling
+
+### 7.1 Codey's replies are untrusted data
+Stage A's LLM never executes instructions found in Codey's messages. Its only outputs are the
+enumerated actions (§3.1). Tasks come ONLY from the pre-approved backlog; no spec is opened on a
+conversational request — spec creation always goes through the spec-first instar-dev gate.
+
+### 7.2 Identity
+Stage A binds on the authenticated Threadline sender (Ed25519 self-id). A signal whose sender
+identity does not match the bound Codey agent is ignored. The safe-window state machine (§12 Q3)
+also derives only from authenticated-sender signals, plus a hard minimum-interval floor so a peer
+cannot force back-to-back ticks.
+
+### 7.3 The fuel
+- The **feedback backlog** (Dawn's feedback system Echo is taking over) — real instar tasks.
+- The **parity long-tail** — the ~48 unshipped primitive parity rules.
+- Each task carries a **difficulty tag assigned by the backlog source, not by Echo** (so the
+  graduation metric can't be gamed by easing the workload — §8). Each is tracked as an initiative.
+- **Assignment bounds:** ≤N concurrent open assignments, ≤M assignments/day (§16).
+
+## 8. Graduation: junior → senior (externally-anchored, not self-graded)
+
+Round-1 convergence flagged that "declining intervention rate" computed by the same agent that
+controls the interventions is trivially gameable. Fixed:
+- **Evidence comes from sources Echo does not control:** tasks shipped green (CI is external),
+  issues resolved-and-verified, clean test-as-self runs scored against a fixed rubric with logged
+  transcripts.
+- **Intervention is an auditable ledger event**, not an Echo self-report; the intervention rate is
+  computed from those records and **normalized by task difficulty** (the source-assigned tag).
+- **Justin ratifies every milestone transition** (consistent with §6 — no self-promotion). A
+  weekly review surfaces the evidence; the transition is Justin's.
+- Tracked via the Graduated-Feature-Rollout pattern (review-driver job + evidence gates).
+
+## 9. Recursion: the next framework
+
+When Cursor/Aider/Gemini onboards, the job re-instantiates with `framework: <new>`. Stage B seeds
+its first checks from the existing playbook (`generalizable` entries from PRIOR frameworks) — "here
+are the N things that bit Codex; check them first." New-framework-unique issues append and grow the
+playbook. One-off debugging becomes a compounding integration methodology. **The §3.3 co-location
+precondition applies per-framework-instance** — each new framework's mentee must be local to its
+mentor for Stage B forensics, or it stays in dry-run until the cross-machine log-fetch primitive ships.
+
+## 10. Relationship to existing infrastructure (absorb, don't duplicate)
+
+- **FrameworkParitySentinel** → *upstream feeder*: a flagged primitive-rendering drift auto-creates
+  an `instar-integration-gap` ledger candidate.
+- **Graduated-Feature-Rollout** → *graduation engine* (§8) + this feature's own staged rollout.
+- **InitiativeTracker / `/projects`** → *task tracking* (§7).
+- **Scheduled jobs** → the mentor job ships as a built-in job at `.instar/jobs/instar/` (§14.1).
+- **Provider-neutral evolution mode** → referenced as aspirational/in-flight (a Codey spec, not yet
+  in repo). **This is explicitly NON-BLOCKING** — this spec stands alone on existing primitives and
+  is where the concept gets *proven*.
+
+## 11. Standards conformance (self-review)
+
+- **Structure > Willpower:** two-hats enforced by spawned-context isolation + tool-grant +
+  PreToolUse deny + leakage detector (§4); auto-capture ledger with a wiring-integrity test (§5,
+  §18); heartbeat job, not a session.
+- **Zero-manual-capture (North Star):** Stage B auto-emits; capture-funnel metric proves liveness.
+- **Signal vs authority:** Stage B detects/logs (signal); Justin + normal gates hold authority
+  (§6, §8). The leakage detector and bucket sample-audit are the instruments.
+- **Near-silent notifications:** housekeeping → Threadline hub / pull surface. Pushed only:
+  graduation-milestone-ready, high-sev issues, explicit asks. **Escalations dedupe on the stable
+  `framework_issues.id`, never per-observation**, so a recurring issue notifies once (§15).
+- **3-tier testing + "feature is alive" E2E** for the ledger + routes, shipped in v0.1 (§18).
+- **Migration parity** via the three correct mechanisms (§14).
+- **Agent Awareness:** CLAUDE.md template Capabilities + Registry-First entries for
+  `/framework-issues`, with a `migrateClaudeMd()` content-sniffed section (§14).
+- **LLM-Supervised Execution:** declared `supervision: tier2` (frontmatter) — Stage A's stuck/ready
+  judgment and Stage B's bucket classification both need deep context.
+- **Graduated rollout:** ships staged (off → dry-run → live), auto-registered as an initiative via
+  `ships-staged` frontmatter (reconciler keys on `ships-staged: true` + merged spec — no manual step).
+- **ELI16 companion:** shipped alongside (≥800 chars, verified).
+
+## 12. Resolved design decisions (co-designed with Codey, 2026-05-26, Threadline f3d471e9)
+
+1. **Ledger storage:** new `FrameworkIssueLedger`, not the learning registry (single-row model
+   collapses root-cause vs recurrence). Full schema §13.
+2. **Two-hats enforcement:** **two spawned contexts** — fresh Stage A + forensic Stage B —
+   enforced by tool grants + PreToolUse deny + leakage detector (§4). (Round-1 convergence upgraded
+   this from the original "one job, allowlisted phases," which was willpower.)
+3. **Tick cadence + safe window:** the safe window is a **durable state transition**, not a clock.
+   Stage A only acts when Codey is observably at task-complete / final-response-sent /
+   waiting-for-input / blocked / quiet-after-a-user-message. These derive from **hard signals where
+   possible** (PR opened = external fact; explicit "done" string; no message in N min) plus an
+   authenticated-sender check (§7.2) and a minimum-interval floor; the signal that justified each
+   window-open is logged. Opportunistic checks every ~10–15 min are gated on one of those states.
+4. **"Ready for next task":** **external-contract completion only** — outwardly-visible signals a
+   real user would see. Stage A never reads internals to judge readiness.
+5. **Disputed bucket arbitration:** proposer (Stage B) + **Codey as counterparty** + Justin
+   sample-audit + escalation, with forced-primary dual tags (§6).
+
+**Codey's day-one addition:** capture `severity` AND recurrence from the first entry so the playbook
+is ranked by **frequency × impact** (§13 `impactScore`), not raw counts.
+
+## 13. Storage design (co-designed with Codey)
+
+**Two tables, not one.** Codey's insight: "false merges are worse than false splits — they bury
+distinct root causes." A single-row model forces a premature same/new-issue choice.
+
+### 13.1 `framework_issues` — canonical root-cause records
+```
+id                  PK
+framework           target framework (parametric)
+bucket              framework-limitation | instar-integration-gap | generic-agent-mistake
+bucketPrimary       forced primary when dual-tagged (§6)
+title               short human label (sanitized, length-capped — §17)
+severity            low | medium | high
+status              open | spec'd | fixed | wont-fix
+dedupKey            conservative auto-merge key (§13.3)
+signature           richer structured fingerprint for probable-dup *review* (§13.3)
+recurrenceCount     MATERIALIZED stored counter, incremented transactionally on each
+                    distinct-episode observation insert (§13.4) — NOT a read-time COUNT
+firstSeenVersion    instar version first observed
+lastSeenVersion     instar version most recently observed
+fixedInVersion      version the fix shipped (nullable)
+regressedFromIssueId  if a regression of a previously-fixed issue (nullable)
+playbookStatus      none | candidate | extracted | superseded
+wontFixReason       required when status=wont-fix (§13.7)
+relatedSpec         optional spec slug
+createdAt / updatedAt
+```
+Indexes: `framework_issues(dedupKey)`, composite on `(framework, playbookStatus)` for the playbook
+filter, `(bucket)` for distribution telemetry.
+
+### 13.2 `framework_observations` — per-occurrence evidence
+```
+id            PK
+issueId       FK → framework_issues.id  (INDEXED)
+framework     denormalized for query
+evidence      OPAQUE reference only — path+line, server-log ref, PR#, sentinel-event id.
+              NEVER inlined log text or diff hunks. Secret-scanned at capture (§17).
+observedVersion  instar version at observation time
+observedAt    ISO timestamp
+tickId        provenance (which mentor tick)
+episodeKey    de-dupes observations within a fix-window (§13.4)
+```
+**Retention:** keep first N + last M observations per issue + a periodic sample; older middle
+observations age out once `recurrenceCount` is materialized. Prevents unbounded firehose growth
+(the TokenLedger pruning analogue).
+
+### 13.3 Dedup: `dedupKey` vs `signature`
+- **`dedupKey`** — conservative, used for **auto-merge** ONLY on high-confidence match:
+  `framework + symptom-class + normalized-error-signature + operation-surface`. Title excluded
+  (operator-dependent); evidence-shape excluded (drifts as capture improves). Bias against false
+  merges.
+- **`signature`** — richer diagnostic material for **probable-duplicate surfacing for review**,
+  never silent auto-merge. Probable-dup query is bounded: same `framework` + recent window, indexed.
+
+### 13.4 Recurrence, episodes, and ranking (anti-poisoning)
+Round-1 convergence flagged that counting raw ticks lets a long-unfixed issue accrue hundreds of
+observations and dominate the playbook. Fixed:
+- `recurrenceCount` counts **distinct occurrence episodes**, not raw ticks. `episodeKey` collapses
+  repeated observations of the same open issue within a fix-window / unfixed-version-span to one.
+- A per-issue **observation cap per version**; an observation rate exceeding a threshold (e.g.
+  N/hour) flags `probable-loop` (not high-impact) to the observability surface.
+- `recurrenceCount` is **materialized** (§13.1), incremented transactionally on episode insert —
+  no read-time per-issue COUNT (kills the N+1 in the playbook ranking).
+- `impactScore = severityWeight(severity) × recurrenceCount`, with optional **recency decay** so a
+  long-stale issue doesn't permanently dominate.
+- `generalizable` is **derived at read** (bucket ∈ {framework-limitation, instar-integration-gap})
+  so a re-classification never leaves a stale flag.
+
+### 13.5 Version lifecycle + regressions
+`firstSeenVersion`/`lastSeenVersion` span the live window; `fixedInVersion` marks the fix. A
+regression opens a NEW issue with `regressedFromIssueId` → original (history preserved). **Regression
+links are auto-suggested** at capture by matching `signature`/`dedupKey` against `status=fixed`
+issues; unlinked-but-signature-matching new issues surface as candidate regressions for review (not
+left to Stage B's discretion).
+
+### 13.6 Playbook semantics
+`GET /framework-issues/playbook?targetFramework=X` returns generalizable lessons from **PRIOR**
+frameworks (`framework != X AND generalizable AND playbookStatus ∈ {candidate, extracted}`), ranked
+by `impactScore`. The playbook for X is sourced from *other* frameworks' lessons, never X's own.
+`playbookStatus` lifecycle `none → candidate → extracted → superseded`. **Promotion owner:**
+`none→candidate` may be auto-suggested by Stage B, but **`candidate→extracted` requires a review that
+is not Echo-only** (Justin or the weekly review) — the playbook contents are not end-to-end under the
+proposer's control. A `fixed` high-`impactScore` issue that never reached `extracted` surfaces as a gap.
+
+### 13.7 `wont-fix` is not a silent escape hatch
+`wont-fix` on a `framework-limitation`/`instar-integration-gap` issue requires a recorded
+`wontFixReason` and surfaces in the pull review — it cannot silently drop out of impact ranking.
+
+### 13.8 Concurrency
+`journal_mode = WAL` + `busy_timeout` (the PendingRelayStore/TokenLedger precedent). Writes go
+through a single-writer / CAS `mutate()` pattern (the CommitmentTracker precedent) so concurrent
+ticks / multi-framework jobs can't drop observations on `SQLITE_BUSY`. All queries use parameterized
+prepared statements (no string interpolation); enum columns (`bucket`, `status`, `playbookStatus`)
+validated against fixed allowlists on write.
+
+## 14. Migration & deployment (three distinct mechanisms — named)
+
+1. **Mentor job** — ships as a **built-in job** under the package's built-in jobs namespace
+   (`.instar/jobs/instar/`, the always-overwrite built-in directory — NOT the user-owned
+   `.instar/jobs/schedule/`); installs via `installBuiltinJobs()` (called by `migrateBuiltinJobs()`),
+   NOT a bespoke migration. Use this exact term and path consistently (§10, §19 refer to the same
+   built-in job at `.instar/jobs/instar/`). Disable = the built-in `retired` list + `mentor.enabled:false`.
+2. **Config knobs** — added to the canonical `ConfigDefaults.ts` registry, applied by `migrateConfig()`
+   with existence checks (§16 lists the fields).
+3. **SQLite schema** — `FrameworkIssueLedger` is **instantiated in `server.ts` startup**, so its two
+   tables auto-create on first boot of the new version (the CommitmentTracker/TokenLedger lazy-create
+   precedent). No schema migration needed — but the spec asserts the startup instantiation explicitly,
+   and a wiring-integrity test verifies it (§18).
+4. **CLAUDE.md template** — `generateClaudeMd()` gains a Capabilities + Registry-First entry for
+   `/framework-issues`; `migrateClaudeMd()` adds a content-sniffed section so existing agents learn it.
+5. **Rollback** — disable per (1); the ledger SQLite DB is **intentionally retained** as a read-only
+   historical record (it never gates), not orphaned.
+
+## 15. Observability / adversarial telemetry (the instrument)
+
+Per Structure > Willpower, an unmonitored guardrail is a wish. The system exposes (pull surface +
+dashboard tab — §16): bucket-distribution-over-time, observations-per-issue-per-hour
+(`probable-loop` detection), intervention-rate vs task-difficulty (graduation-gaming detection),
+and `stage-a-leak-suspected` counts (two-hats leak detection — §4). These are the instruments that
+turn "harden if observed" into a mechanism with an actual observer.
+
+## 16. Config knobs (named fields, defaults, ConfigDefaults-registered)
+
+```
+mentor.enabled            bool   default false (ships off)
+mentor.mode               enum   off | dry-run | live   default off
+mentor.cadenceMs          number default 900000 (~15 min) — opportunistic check interval
+mentor.minIntervalMs      number default 600000 — hard floor between ticks (anti-forced-cadence)
+mentor.maxRoundsPerTick   number default 1
+mentor.maxRoundsPerDay    number default <tuned>
+mentor.maxOpenAssignments number default <tuned>
+mentor.maxAssignmentsPerDay number default <tuned>
+mentor.dailySpendCapUsd   number default <tuned> — below the shared LlmQueue cap
+mentor.genericMistakeAuditRate number default 0.1 — sample-audit fraction to Justin (§6)
+```
+A per-tick cost model (Stage A drive + cheap stuck/ready judgment + Stage B forensics) × expected
+active ticks/day × framework count is documented alongside these defaults so the daily ceiling is
+set from evidence, not guesswork.
+
+## 17. Security
+
+- Both routes require the standard Bearer token; `503` when unconfigured; `limit` clamped 1..500;
+  `targetFramework` validated against a known-framework allowlist.
+- `evidence` is opaque references ONLY (§13.2); a **secret-scan + redaction pass** runs at capture
+  before any write; the routes are **kept off the dashboard/tunnel surface unless explicitly gated**
+  (they return references the caller must already be authorized to dereference).
+- All captured free-text (`title`, `signature`, dispute rationale) is treated as data: length-capped
+  + sanitized on write; when the playbook seed is later fed to an LLM it is delivered as **quoted
+  untrusted data, never as instructions** (closes the stored-injection / poisoned-playbook vector).
+- Parameterized queries everywhere; enum allowlists on write; a unit test asserts an injection-style
+  `targetFramework` is treated as a literal.
+- Codey's conversational replies are untrusted data (§7.1); sender identity is authenticated (§7.2).
+
+## 18. Testing (all three tiers in v0.1 — non-negotiable)
+
+- **Tier 1 (unit):** ledger CRUD, dedup (false-merge resistance), episode collapsing, materialized
+  `recurrenceCount` correctness, impactScore + decay, regression auto-suggest, enum/param-injection
+  guards, secret-scan redaction, and the leakage detector **with a positive-control** (a
+  known-leaked transcript must trip the flag — so a dead detector is distinguishable from a clean run).
+- **Tier 2 (integration):** the `/framework-issues` + `/playbook` routes over the full HTTP pipeline
+  (auth, 503, clamps, allowlist).
+- **Tier 3 (E2E "feature is alive"):** a real mentor tick on the production init path adds an
+  observation row (the auto-capture wiring proof), routes return 200 not 503, and the ledger is
+  instantiated at server startup (wiring-integrity).
+- **Wiring-integrity tests** for every DI'd component (Stage A sub-agent spawn, Stage B capture
+  funnel, leakage detector, budget pre-check) — verify deps are not null/no-op and delegate to real
+  implementations.
+
+## 19. Build order (multi-part — for /instar-dev after approval)
+
+1. **`FrameworkIssueLedger` + two-table SQLite store (WAL/CAS, indexes, retention) + read-only
+   routes + startup instantiation + all 3 test tiers + PostUpdateMigrator(job/config) +
+   CLAUDE.md template + migrate.** (Foundation; hardest to unwind — ships complete in one PR, no
+   "routes now, migration later.")
+2. **Stage B auto-capture** wired into the tick + capture-funnel metric + the "alive" test.
+3. **Stage A drive sub-agent** (fresh spawned context, tool-grant + PreToolUse deny) + leakage detector.
+4. **Mentor built-in job** (at `.instar/jobs/instar/`, §14.1) + safe-window state machine + budget
+   pre-check + cross-agent termination discipline (persist-only delivery + fresh-thread-per-task).
+5. **Playbook route + graduation review job + observability surface/dashboard tab** (or tracked
+   deferral for the tab).
+
+Ships staged (off → dry-run on Echo↔Codey → live) per the graduated-rollout standard.

--- a/docs/specs/reports/FRAMEWORK-ONBOARDING-MENTOR-SPEC-convergence.md
+++ b/docs/specs/reports/FRAMEWORK-ONBOARDING-MENTOR-SPEC-convergence.md
@@ -2,7 +2,7 @@
 
 **Spec:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md`
 **ELI16 companion:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md`
-**Converged:** iteration 3 (0 material findings in the final round)
+**Converged:** iteration 5 (0 material findings in the final round; iterations 4–5 were a re-convergence triggered by a post-approval-prep task-source refinement — see below)
 **Reviewers:** security, scalability, adversarial, integration, lessons-aware (5 internal Claude perspectives, all rounds). External cross-model (GPT/Gemini/Grok) deferred per abbreviated-convergence allowance for an internal-tooling spec; the mandatory lessons-aware reviewer ran every round.
 
 ---
@@ -86,6 +86,8 @@ must ship in the first PR.
 | 1 | security (7), scalability (8), adversarial (10), integration (8), lessons-aware (11) | 44 | Full rewrite: §4 structural two-hats, §6 governance + cross-agent termination + budget, §8 externally-anchored graduation, §13 anti-poisoning storage, §15 telemetry, §16 config, §17 security, §18 testing, §3.3 topology, §14 migration |
 | 2 | adversarial (2), integration (1), lessons-aware (3); security 0, scalability 0 | 6 | §6 concrete persist-only delivery + fail-closed live-gate; §6 fresh-thread-per-task (argv overflow); §4.3+§18 leakage-detector positive-control + canary; §6 dispute non-response default; §14.1/§10/§19 built-in-job mechanism pinned; §9 per-framework co-location precondition |
 | 3 | (converged) | 0 | none |
+| 4 | adversarial (2) | 2 | Task-source refinement (Justin): curated local backlog made primary, feedback demoted to a human-triage-gated feeder. Adversarial flagged the refinement reopened two levers → §7.3 non-Echo-difficulty admission invariant (`difficultyAttestedBy != echo`) + deterministic/within-band assignment selection; §8 stratified-by-difficulty-band metric |
+| 5 | (converged) | 0 | none |
 
 ---
 
@@ -148,7 +150,32 @@ check (LOW). → Resolved across §6, §3/§6 (round 2), §4, §8, frontmatter s
   fresh-thread-per-task + threadId-handoff (fetch history via tool, not inline argv).
 - **(lessons, LOW)** §9 recursion should restate the §3.3 co-location precondition per-framework. → §9.
 
-### Iteration 3 — 0 material findings (converged)
+### Iteration 4 — task-source refinement (2 material findings)
+
+After iteration-3 convergence, while prepping for approval, Justin observed that a **curated local
+backlog of planned/in-progress features** is better task fuel for Codey than the raw feedback
+firehose. Echo agreed and made it the primary source (feedback demoted to a human-triage-gated
+feeder). The adversarial reviewer correctly flagged that the refinement, as first drafted, reopened
+two gaming levers §8 had closed:
+- **Echo authors a subset of the primary-source artifacts** (ACT-* deferrals, auto-registered
+  initiatives), so "artifact-borne difficulty" was still Echo-set for those; the "did not create for
+  this purpose" guard was unfalsifiable intent. → §7.3 **non-Echo-difficulty admission invariant**:
+  an item is assignable only once difficulty is attested by a non-Echo party; the assignable-pool
+  filters on `difficultyAttestedBy != echo`, a field the mentor context cannot write.
+- **Assignment selection/ordering was unconstrained** — sequencing could shape the difficulty-
+  normalized curve. → §7.3 deterministic/FIFO-or-within-band selection (Echo doesn't choose item or
+  order) + §8 intervention rate **stratified by difficulty band** (front-loading easy tasks can't
+  mask a band).
+
+### Iteration 5 — 0 material findings (re-converged)
+
+Adversarial confirmed both iteration-4 findings RESOLVED with structural checks (not intent tests)
+and no new gaming vector. Lessons-aware confirmed the `difficultyAttestedBy != echo` gate is genuine
+structure consistent with the signal-vs-authority pattern, and that the non-Echo attestation does
+NOT create an impractical human bottleneck (the parity long-tail + others' initiatives satisfy it on
+entry; only the Echo-authored minority needs a one-time stamp on the existing triage gate).
+
+### Iteration 3 — 0 material findings (first convergence, before the task-source refinement)
 
 All five perspectives clean. Adversarial confirmed the leakage-detector positive-control + canary
 and the dispute non-response default close their round-2 gaps with no new issue. Integration confirmed
@@ -161,8 +188,13 @@ precondition, and that fresh-thread-per-task + threadId-handoff genuinely fixes 
 
 ## Convergence verdict
 
-**Converged at iteration 3. No material findings in the final round across all five reviewer
-perspectives.** The spec is ready for user review and approval.
+**Converged at iteration 5 (re-converged after a task-source refinement). No material findings in
+the final round.** The spec is ready for user review and approval.
+
+The task source is now a **curated local feature backlog** (planned work + parity long-tail) as the
+primary fuel, with the feedback backlog demoted to a human-triage-gated candidate feeder — and the
+anti-gaming property is preserved structurally via the `difficultyAttestedBy != echo` admission
+invariant + per-difficulty-band graduation scoring.
 
 The four structural risks the review existed to catch — willpower-masquerading-as-structure in the
 two-hats separation, the self-grading feedback loop, the cross-agent spawn-loop + argv-overflow, and

--- a/docs/specs/reports/FRAMEWORK-ONBOARDING-MENTOR-SPEC-convergence.md
+++ b/docs/specs/reports/FRAMEWORK-ONBOARDING-MENTOR-SPEC-convergence.md
@@ -1,0 +1,172 @@
+# Convergence Report — Framework-Onboarding Mentor System
+
+**Spec:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md`
+**ELI16 companion:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md`
+**Converged:** iteration 3 (0 material findings in the final round)
+**Reviewers:** security, scalability, adversarial, integration, lessons-aware (5 internal Claude perspectives, all rounds). External cross-model (GPT/Gemini/Grok) deferred per abbreviated-convergence allowance for an internal-tooling spec; the mandatory lessons-aware reviewer ran every round.
+
+---
+
+## ELI10 Overview
+
+We're building a self-running routine that teaches a new AI "engine" how to be a good Instar
+developer — and writes down everything it learns so the next engine is faster to onboard. Today
+Instar runs on Claude and Codex; Cursor, Aider, and Gemini are next. We recently discovered, by
+luck, that the fastest way to find what's broken in a new engine is for an experienced agent (Echo)
+to play the user, work alongside the new agent (Codey), watch where he trips, then look under the
+hood and write down the lessons. This spec turns that lucky one-off into a scheduled job — and saves
+every lesson into a durable, labeled notebook (a "ledger") that becomes a reusable onboarding
+checklist for future engines.
+
+The heart of the design is two "hats." Echo wears the **user hat** first — chatting with Codey like
+a real customer would, deliberately *blind* to his code and logs, so the wild real-world problems
+actually surface instead of being quietly steered around. Then Echo wears the **inspector hat** —
+reading the logs and code afterward and recording each problem with a label: "the engine's own
+limit," "Instar not fitting the engine," or "a mistake anyone could make." Only the first two travel
+forward to the next engine's checklist; the third is just coaching. Meanwhile Codey does *real*
+Instar improvement work from the feedback backlog, so he's learning on live fuel, not busywork.
+
+What changes if it ships: onboarding a new AI engine stops being a lucky accident and becomes a
+compounding methodology. The main tradeoff the review wrestled with is **trust** — Echo is both the
+teacher and the note-taker, which creates obvious ways to grade itself favorably or bury
+inconvenient findings. Most of the review work went into making those self-serving shortcuts
+structurally impossible rather than relying on Echo's good intentions.
+
+---
+
+## Original vs Converged
+
+The original draft was directionally sound but had four load-bearing weaknesses that the review
+turned into hard structural guarantees:
+
+1. **The "two hats" weren't actually separate.** Originally it was "one job with two allowlisted
+   phases" — but one AI brain running both phases in sequence carries what it saw under the hood
+   last time into this time's supposedly-blind chat. Input rules control what you *fetch*, not what
+   you *remember*. **After review:** the user hat runs as a genuinely separate, fresh sub-task each
+   time with no access to the inspector's findings, the forensic tools are physically withheld from
+   it, and a tripwire flags any tick where the user-hat references internals it shouldn't know —
+   with a built-in self-test that proves the tripwire actually works (so a dead tripwire can't
+   masquerade as "all clean").
+
+2. **Echo was judge, jury, and scorekeeper.** Originally Echo proposed every problem-label, decided
+   what tasks Codey got, AND computed Codey's "graduation" from its own intervention count — all
+   gameable by the same agent. **After review:** graduation evidence now comes from outside facts
+   Echo doesn't control (did CI pass, did the PR merge), task difficulty is tagged by the backlog
+   source not by Echo, every "level up" requires Justin's sign-off, a slice of the "blame the
+   mentee" labels always go to Justin regardless, and Codey himself can dispute his own labels —
+   with silence never counting as agreement.
+
+3. **The known agent-to-agent bugs would fire constantly.** A chatty every-15-minutes job is the
+   worst case for two documented bugs: a message-loop where every delivery spawns a fresh session,
+   and an overflow when a long conversation gets crammed into a command line. Originally the spec
+   "hard-depended" on a fix that doesn't exist yet. **After review:** the mentor uses a
+   *persist-and-pick-up* delivery (no fresh session spawned per message) and a *fresh thread per
+   task* (so history never grows unbounded), and it physically refuses to go live until that safe
+   delivery path is verified wired.
+
+4. **The notebook could be poisoned and could grow forever.** Originally the playbook ranked
+   problems by raw recurrence count — so an unfixed issue observed every tick would dominate
+   forever — and the evidence table had no retention. **After review:** recurrence counts distinct
+   *episodes* (not raw ticks), there's a per-issue cap with a "probable-loop" flag, the count is
+   stored not recomputed on every read (killing a performance landmine), retention is bounded, and
+   ranking decays with age.
+
+Beyond those four: every HTTP route now requires auth + input clamping, evidence is stored as
+opaque pointers (never inlined log text that could leak secrets), all captured text is treated as
+untrusted data, the three Instar migration mechanisms are named precisely, the agent-awareness
+CLAUDE.md update is required, and all three test tiers (including the "is it actually alive?" E2E)
+must ship in the first PR.
+
+---
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged material findings | Material findings | Spec changes |
+|-----------|-----------------------------------------|-------------------|--------------|
+| 1 | security (7), scalability (8), adversarial (10), integration (8), lessons-aware (11) | 44 | Full rewrite: §4 structural two-hats, §6 governance + cross-agent termination + budget, §8 externally-anchored graduation, §13 anti-poisoning storage, §15 telemetry, §16 config, §17 security, §18 testing, §3.3 topology, §14 migration |
+| 2 | adversarial (2), integration (1), lessons-aware (3); security 0, scalability 0 | 6 | §6 concrete persist-only delivery + fail-closed live-gate; §6 fresh-thread-per-task (argv overflow); §4.3+§18 leakage-detector positive-control + canary; §6 dispute non-response default; §14.1/§10/§19 built-in-job mechanism pinned; §9 per-framework co-location precondition |
+| 3 | (converged) | 0 | none |
+
+---
+
+## Full Findings Catalog
+
+### Iteration 1 — 44 material findings
+
+**Security (7):** prompt-injection via untrusted Codey replies into autonomous task/spec assignment
+(HIGH); cross-agent identity asserted not authenticated (HIGH); evidence-pointer exfiltration channel
+(HIGH); stored-injection via captured free-text into the playbook seed (MED); routes need
+Bearer+503+clamps+allowlist (MED); SQL-injection / parameterized statements (LOW); spoofable tick
+cadence (LOW). → All resolved in §3.1/§7.1, §7.2, §13.2/§17, §17, §5/§17, §13.8/§17, §7.2/§16.
+
+**Scalability (8):** unbounded `framework_observations` growth (HIGH); read-time per-issue COUNT N+1
+in playbook ranking (HIGH); no indexes (MED); no WAL/busy_timeout/concurrency config (MED); hot-path
+LLM cost unmodeled (MED); budget-gate fail semantics + shared-queue starvation (MED); reply-round cap
+unquantified (LOW); probable-dup query unbounded (LOW). → Resolved in §13.2 retention, §13.1/§13.4
+materialized recurrenceCount, §13.1 indexes, §13.8 WAL/CAS, §6+§16 cost model, §6 atomic pre-tick
+fail-closed background-lane check, §6/§16 caps, §13.3 bounded query.
+
+**Adversarial (10):** two-hats leak across ticks — "structural" was a wish (HIGH); Echo
+proposer+grader+assigner+sole-metric-writer self-reinforcing loop (HIGH); bucket mis-classification
+no disinterested check (HIGH); ledger poisoning via recurrenceCount inflation (HIGH); unbounded
+autonomous task assignment (MED); regression link relies on biased proposer (MED); playbookStatus
+promotion owner unspecified (MED); safe-window inferred by interested model (MED); wont-fix silent
+escape hatch (LOW); no instrument to detect gaming (LOW). → Resolved in §4 (spawned-context
+isolation + tool-grant + PreToolUse deny + leakage detector), §8 (external evidence + Justin
+ratifies + difficulty tags + intervention-as-audit-event), §6 (Codey counterparty + sample-audit +
+distribution telemetry), §13.4 (episode recurrence + cap + probable-loop + decay), §7.3/§16 caps,
+§13.5 auto-suggest, §13.6 non-Echo promotion review, §12 Q3 hard signals, §13.7 wontFixReason, §15
+telemetry.
+
+**Integration (8):** missing Agent Awareness / CLAUDE.md template (HIGH); vague migration-parity
+conflating 3 mechanisms (HIGH); cross-machine forensics topology undefined (HIGH); config knobs not
+enumerated (MED); rollback/clean-disable unspecified (MED); dashboard surface unaddressed (MED);
+provider-neutral-evolution-mode dependency framing (LOW); ships-staged reconciler keying (LOW). →
+Resolved in §11/§14.4, §14.1-3, §2/§3.3, §16, §14.5, §15, §10, §11/frontmatter.
+
+**Lessons-aware (11):** cross-agent ack/spawn loop NOT structurally prevented — §6 capped the wrong
+layer (CRITICAL); Threadline argv-overflow unaddressed + send-dedupe missing (HIGH); two-hats
+prompt-not-structure (HIGH); graduation metric self-gameable (HIGH); supervision tier undeclared
+(MED); auto-capture wiring trap (North Star) (MED); near-silent stable-key dedup (MED); migration +
+E2E must be in v0.1 (MED); provider-neutral non-blocking (LOW); ELI16 ≥800 (LOW); identity self-id
+check (LOW). → Resolved across §6, §3/§6 (round 2), §4, §8, frontmatter supervision, §5/§18, §11,
+§14/§18, §10, companion, §7.2.
+
+### Iteration 2 — 6 material findings
+
+- **(adversarial, MED)** Leakage detector is itself an interested, unscored guardrail — a dead
+  detector reads identical to a clean run. → §4.3 + §18: positive-control test + seeded-leak canary.
+- **(adversarial, LOW-MED)** Codey-as-dispute-counterparty had no non-response default. → §6:
+  non-response routes to Justin sample-audit pool, never auto-confirms.
+- **(integration, MED)** Built-in job mechanism internally inconsistent (`installBuiltinJobs` vs
+  `.instar/jobs/schedule/` "template"). → §14.1/§10/§19 pinned to a built-in job at
+  `.instar/jobs/instar/` consistently.
+- **(lessons, HIGH)** §6 loop-containment hard-depended on a non-existent receive-side gate; "fallback
+  path" named but undefined. → §6 concrete persist-only / queued-pickup delivery + fail-closed
+  live-gate mirroring §3.3.
+- **(lessons, HIGH)** argv-overflow (`bug_threadline_spawn_command_too_long`) never addressed. → §6
+  fresh-thread-per-task + threadId-handoff (fetch history via tool, not inline argv).
+- **(lessons, LOW)** §9 recursion should restate the §3.3 co-location precondition per-framework. → §9.
+
+### Iteration 3 — 0 material findings (converged)
+
+All five perspectives clean. Adversarial confirmed the leakage-detector positive-control + canary
+and the dispute non-response default close their round-2 gaps with no new issue. Integration confirmed
+the built-in-job pin is migration-parity-consistent with a coherent disable path. Lessons-aware
+confirmed the persist-only delivery **structurally eliminates spawn-on-receive** (the documented
+root of the loop, not a content-marker band-aid) and the fail-closed live-gate is a real structural
+precondition, and that fresh-thread-per-task + threadId-handoff genuinely fixes the argv overflow.
+
+---
+
+## Convergence verdict
+
+**Converged at iteration 3. No material findings in the final round across all five reviewer
+perspectives.** The spec is ready for user review and approval.
+
+The four structural risks the review existed to catch — willpower-masquerading-as-structure in the
+two-hats separation, the self-grading feedback loop, the cross-agent spawn-loop + argv-overflow, and
+ledger poisoning — are all closed with mechanisms (spawned-context isolation, externally-anchored
+graduation with Justin ratification, persist-only delivery + fresh-thread-per-task behind a
+fail-closed live-gate, episode-based recurrence) rather than instructions. `approved: true` remains
+the user's structural contribution and is not written by this process.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2507,6 +2507,25 @@ When the user is reading the Threadline hub topic and says **"open this"** or **
       result.upgraded.push('CLAUDE.md: added Multi-Session Autonomy awareness section');
     }
 
+    // Framework-Onboarding Mentor System — issue-ledger observability (Agent
+    // Awareness Standard). Existing agents need to know the read-only
+    // /framework-issues + playbook routes exist, even if initialized before this
+    // capability shipped. Signal-only (never gates). Content-sniffed marker.
+    if (!content.includes('Framework-Onboarding Mentor System')) {
+      const fwLedgerSection = `
+### Framework-Onboarding Mentor System — issue ledger (read-only)
+
+A durable, bucket-tagged record of behavioral issues observed while onboarding an agent framework (Codex, then Cursor/Aider/Gemini) onto Instar. **Observability only — it never gates a job, blocks a message, or constrains a session.** The full mentor loop ships staged (off by default).
+
+- Issues logged for a framework: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/framework-issues\` (optional \`?framework=X&bucket=...&status=...&limit=N\`)
+- The onboarding playbook (generalizable lessons from PRIOR frameworks, impact-ranked): \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/framework-issues/playbook?targetFramework=X"\`
+- Both routes are read-only and return references, not log contents.
+`;
+      content += '\n' + fwLedgerSection;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Framework-Onboarding Mentor System issue-ledger awareness section');
+    }
+
     // Version-Skew Self-Recovery section
     // Tells the agent what's happening when the lifeline+server temporarily
     // mismatch versions during an auto-update. Without this, agents diagnose

--- a/src/monitoring/FrameworkIssueLedger.ts
+++ b/src/monitoring/FrameworkIssueLedger.ts
@@ -1,0 +1,596 @@
+/**
+ * FrameworkIssueLedger — durable record of behavioral issues observed while
+ * onboarding an agent framework onto Instar (the Framework-Onboarding Mentor
+ * System, docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md).
+ *
+ * Two tables, by design (spec §13):
+ *   - `framework_issues`       — canonical root-cause records (one per distinct problem)
+ *   - `framework_observations` — per-occurrence evidence (one per time it happened)
+ *
+ * The split exists because "false merges are worse than false splits" — a
+ * single-row model would bury distinct root causes. Recurrence is counted in
+ * distinct *episodes* (not raw ticks) via `episode_key`, materialized into
+ * `recurrence_count` on the canonical row so the playbook ranking never pays a
+ * read-time COUNT (spec §13.4).
+ *
+ * Signal-only: this ledger never gates a job, blocks a message, or constrains a
+ * session. Stage B of the mentor loop writes observations; the read-only HTTP
+ * routes (`/framework-issues`, `/framework-issues/playbook`) serve them. All
+ * authority to act on an entry rests with the human (spec §6).
+ *
+ * Security (spec §17): `evidence` is an OPAQUE reference only — never inlined
+ * log text or diff hunks — and is secret-scanned at capture. All captured
+ * free-text is length-capped + sanitized on write. Every query uses a prepared
+ * statement with bound parameters; enum columns are validated against fixed
+ * allowlists on write.
+ */
+import Database from 'better-sqlite3';
+import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { NativeModuleHealer } from '../memory/NativeModuleHealer.js';
+
+// ── Enums / allowlists (validated on write — spec §13.8, §17) ───────────────
+
+export const ISSUE_BUCKETS = [
+  'framework-limitation',
+  'instar-integration-gap',
+  'generic-agent-mistake',
+] as const;
+export type IssueBucket = (typeof ISSUE_BUCKETS)[number];
+
+export const ISSUE_SEVERITIES = ['low', 'medium', 'high'] as const;
+export type IssueSeverity = (typeof ISSUE_SEVERITIES)[number];
+
+export const ISSUE_STATUSES = ['open', "spec'd", 'fixed', 'wont-fix'] as const;
+export type IssueStatus = (typeof ISSUE_STATUSES)[number];
+
+export const PLAYBOOK_STATUSES = ['none', 'candidate', 'extracted', 'superseded'] as const;
+export type PlaybookStatus = (typeof PLAYBOOK_STATUSES)[number];
+
+/** Buckets that generalize to the next framework feed the playbook (spec §13.4). */
+const GENERALIZABLE_BUCKETS: ReadonlySet<IssueBucket> = new Set<IssueBucket>([
+  'framework-limitation',
+  'instar-integration-gap',
+]);
+
+const SEVERITY_WEIGHT: Record<IssueSeverity, number> = { low: 1, medium: 3, high: 9 };
+
+// ── Tunables (spec §13.2 retention, §13.4 caps) ─────────────────────────────
+
+const MAX_FREE_TEXT = 500; // length-cap for title / signature / rationale (§17)
+const MAX_EVIDENCE = 1024; // evidence pointer cap (§13.2 — pointer, not content)
+const RETENTION_KEEP_FIRST = 5; // keep first N observations per issue (§13.2)
+const RETENTION_KEEP_LAST = 20; // + last M
+const PROBABLE_LOOP_PER_HOUR = 12; // obs/hr above which an issue is flagged probable-loop (§13.4)
+const RECENCY_HALF_LIFE_MS = 30 * 24 * 60 * 60 * 1000; // 30d decay on impactScore (§13.4)
+
+// ── Schema (spec §13.1 / §13.2) ─────────────────────────────────────────────
+
+const SCHEMA = [
+  `CREATE TABLE IF NOT EXISTS framework_issues (
+     id                     TEXT PRIMARY KEY,
+     framework              TEXT NOT NULL,
+     bucket                 TEXT NOT NULL,
+     bucket_primary         TEXT,
+     title                  TEXT NOT NULL,
+     severity               TEXT NOT NULL DEFAULT 'medium',
+     status                 TEXT NOT NULL DEFAULT 'open',
+     dedup_key              TEXT NOT NULL,
+     signature              TEXT,
+     recurrence_count       INTEGER NOT NULL DEFAULT 0,
+     first_seen_version     TEXT,
+     last_seen_version      TEXT,
+     fixed_in_version       TEXT,
+     regressed_from_issue_id TEXT,
+     playbook_status        TEXT NOT NULL DEFAULT 'none',
+     wont_fix_reason        TEXT,
+     related_spec           TEXT,
+     probable_loop          INTEGER NOT NULL DEFAULT 0,
+     created_at             INTEGER NOT NULL,
+     updated_at             INTEGER NOT NULL
+   )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_fwissues_dedup ON framework_issues(framework, dedup_key)`,
+  `CREATE INDEX IF NOT EXISTS idx_fwissues_framework_pb ON framework_issues(framework, playbook_status)`,
+  `CREATE INDEX IF NOT EXISTS idx_fwissues_bucket ON framework_issues(bucket)`,
+  `CREATE INDEX IF NOT EXISTS idx_fwissues_status ON framework_issues(status)`,
+  `CREATE TABLE IF NOT EXISTS framework_observations (
+     id              TEXT PRIMARY KEY,
+     issue_id        TEXT NOT NULL,
+     framework       TEXT NOT NULL,
+     evidence        TEXT,
+     observed_version TEXT,
+     observed_at     INTEGER NOT NULL,
+     tick_id         TEXT,
+     episode_key     TEXT NOT NULL
+   )`,
+  `CREATE INDEX IF NOT EXISTS idx_fwobs_issue ON framework_observations(issue_id)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_fwobs_episode ON framework_observations(issue_id, episode_key)`,
+  `CREATE INDEX IF NOT EXISTS idx_fwobs_observed_at ON framework_observations(observed_at)`,
+];
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface FrameworkIssueLedgerOptions {
+  dbPath: string;
+  /** Override clock for deterministic tests. */
+  now?: () => number;
+}
+
+/** What Stage B emits per observation (spec §5). */
+export interface RecordObservationInput {
+  framework: string;
+  bucket: IssueBucket;
+  title: string;
+  severity?: IssueSeverity;
+  /** Conservative auto-merge key (spec §13.3). Required — identifies the canonical issue. */
+  dedupKey: string;
+  /** Richer fingerprint for probable-dup review (spec §13.3). */
+  signature?: string;
+  /** OPAQUE reference only — path+line, log ref, PR#, sentinel-event id (spec §13.2/§17). */
+  evidence?: string;
+  observedVersion?: string;
+  tickId?: string;
+  /**
+   * Collapses repeated observations of the same open issue within a fix-window
+   * to one episode (spec §13.4). Defaults to the observed version so an unfixed
+   * issue accrues at most one episode per version span.
+   */
+  episodeKey?: string;
+  /** Forced primary when dual-tagged (spec §6). */
+  bucketPrimary?: IssueBucket;
+  relatedSpec?: string;
+}
+
+export interface RecordObservationResult {
+  issueId: string;
+  created: boolean;
+  episodeRecorded: boolean; // false when the episode was already counted (deduped)
+  recurrenceCount: number;
+  probableLoop: boolean;
+}
+
+export interface IssueRow {
+  id: string;
+  framework: string;
+  bucket: IssueBucket;
+  bucketPrimary: IssueBucket | null;
+  title: string;
+  severity: IssueSeverity;
+  status: IssueStatus;
+  dedupKey: string;
+  signature: string | null;
+  recurrenceCount: number;
+  firstSeenVersion: string | null;
+  lastSeenVersion: string | null;
+  fixedInVersion: string | null;
+  regressedFromIssueId: string | null;
+  playbookStatus: PlaybookStatus;
+  wontFixReason: string | null;
+  relatedSpec: string | null;
+  probableLoop: boolean;
+  createdAt: number;
+  updatedAt: number;
+  /** Derived at read (spec §13.4) — never stored, so a re-classification can't stale it. */
+  generalizable: boolean;
+  /** Derived at read: severityWeight × recurrenceCount × recency decay (spec §13.4). */
+  impactScore: number;
+}
+
+export interface ListIssuesQuery {
+  framework?: string;
+  bucket?: IssueBucket;
+  status?: IssueStatus;
+  limit?: number;
+}
+
+export interface PlaybookQuery {
+  targetFramework: string;
+  limit?: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Reject anything that looks like an inlined secret/log-body rather than an
+ * opaque pointer (spec §17). Returns a sanitized, length-capped string. We do
+ * NOT silently store a suspected secret — we redact it and tag the evidence so
+ * the capture is visibly degraded rather than leaking.
+ */
+const SECRET_PATTERNS: RegExp[] = [
+  /\b(sk|pk|rk)-[A-Za-z0-9]{16,}\b/, // api-key-shaped
+  /\bBearer\s+[A-Za-z0-9._-]{12,}\b/i,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/, // slack
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/, // github
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/, // jwt
+];
+
+export function scanForSecret(s: string): boolean {
+  return SECRET_PATTERNS.some((re) => re.test(s));
+}
+
+function sanitizeFreeText(s: string | undefined, cap: number): string {
+  if (!s) return '';
+  // Strip control chars; collapse whitespace; cap length.
+  // eslint-disable-next-line no-control-regex
+  const cleaned = s.replace(/[\x00-\x1f\x7f]/g, " ").replace(/\s+/g, " ").trim();
+  return cleaned.length > cap ? cleaned.slice(0, cap) : cleaned;
+}
+
+function sanitizeEvidence(s: string | undefined): string | null {
+  if (!s) return null;
+  const capped = sanitizeFreeText(s, MAX_EVIDENCE);
+  if (scanForSecret(capped)) {
+    // Redact the body; keep a marker so the capture is visibly degraded (§17).
+    return '[redacted: evidence matched a secret pattern — store an opaque reference, not log content]';
+  }
+  return capped;
+}
+
+function assertEnum<T extends string>(value: T, allowed: readonly T[], field: string): T {
+  if (!allowed.includes(value)) {
+    throw new Error(`FrameworkIssueLedger: invalid ${field} '${value}' (allowed: ${allowed.join(', ')})`);
+  }
+  return value;
+}
+
+// ── Ledger ──────────────────────────────────────────────────────────────────
+
+export class FrameworkIssueLedger {
+  private db: BetterSqliteDatabase;
+  private now: () => number;
+
+  constructor(opts: FrameworkIssueLedgerOptions) {
+    this.now = opts.now ?? (() => Date.now());
+    if (opts.dbPath !== ':memory:') {
+      fs.mkdirSync(path.dirname(opts.dbPath), { recursive: true });
+    }
+    this.db = NativeModuleHealer.openWithHealSync(
+      'FrameworkIssueLedger',
+      () => new Database(opts.dbPath),
+    );
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('synchronous = NORMAL');
+    this.db.pragma('busy_timeout = 5000');
+    for (const ddl of SCHEMA) this.db.exec(ddl);
+  }
+
+  /** Stable list of frameworks the ledger has seen — for the route allowlist (spec §5/§17). */
+  knownFrameworks(): string[] {
+    const rows = this.db
+      .prepare(`SELECT DISTINCT framework FROM framework_issues ORDER BY framework`)
+      .all() as Array<{ framework: string }>;
+    return rows.map((r) => r.framework);
+  }
+
+  /**
+   * Record one Stage-B observation. Finds-or-creates the canonical issue via
+   * (framework, dedupKey); collapses the observation into a distinct episode via
+   * episodeKey; increments the materialized recurrence_count only on a new
+   * episode (spec §13.4). All writes run in a single transaction (CAS-safe: the
+   * UNIQUE(issue_id, episode_key) index is the concurrency guard — a racing
+   * duplicate episode insert fails and is counted as already-recorded).
+   */
+  recordObservation(input: RecordObservationInput): RecordObservationResult {
+    const framework = sanitizeFreeText(input.framework, 120);
+    if (!framework) throw new Error('FrameworkIssueLedger: framework is required');
+    const bucket = assertEnum(input.bucket, ISSUE_BUCKETS, 'bucket');
+    const severity = assertEnum(input.severity ?? 'medium', ISSUE_SEVERITIES, 'severity');
+    const dedupKey = sanitizeFreeText(input.dedupKey, 200);
+    if (!dedupKey) throw new Error('FrameworkIssueLedger: dedupKey is required');
+    const title = sanitizeFreeText(input.title, MAX_FREE_TEXT) || '(untitled)';
+    const signature = input.signature ? sanitizeFreeText(input.signature, MAX_FREE_TEXT) : null;
+    const evidence = sanitizeEvidence(input.evidence);
+    const observedVersion = input.observedVersion ? sanitizeFreeText(input.observedVersion, 60) : null;
+    const tickId = input.tickId ? sanitizeFreeText(input.tickId, 120) : null;
+    const episodeKey = sanitizeFreeText(input.episodeKey ?? observedVersion ?? 'default', 200);
+    const bucketPrimary = input.bucketPrimary
+      ? assertEnum(input.bucketPrimary, ISSUE_BUCKETS, 'bucketPrimary')
+      : null;
+    const relatedSpec = input.relatedSpec ? sanitizeFreeText(input.relatedSpec, 200) : null;
+    const ts = this.now();
+
+    const txn = this.db.transaction((): RecordObservationResult => {
+      // Find-or-create canonical issue.
+      let issue = this.db
+        .prepare(`SELECT * FROM framework_issues WHERE framework = ? AND dedup_key = ?`)
+        .get(framework, dedupKey) as Record<string, unknown> | undefined;
+
+      let created = false;
+      let issueId: string;
+      if (!issue) {
+        issueId = crypto.randomUUID();
+        this.db
+          .prepare(
+            `INSERT INTO framework_issues
+               (id, framework, bucket, bucket_primary, title, severity, status, dedup_key,
+                signature, recurrence_count, first_seen_version, last_seen_version,
+                playbook_status, probable_loop, created_at, updated_at)
+             VALUES (@id, @framework, @bucket, @bucketPrimary, @title, @severity, 'open', @dedupKey,
+                @signature, 0, @observedVersion, @observedVersion, 'none', 0, @ts, @ts)`,
+          )
+          .run({ id: issueId, framework, bucket, bucketPrimary, title, severity, dedupKey, signature, observedVersion, ts });
+        created = true;
+        issue = { id: issueId };
+      } else {
+        issueId = issue.id as string;
+        // Refresh last-seen + (non-destructively) escalate severity if higher.
+        this.db
+          .prepare(
+            `UPDATE framework_issues
+               SET last_seen_version = COALESCE(@observedVersion, last_seen_version),
+                   severity = CASE WHEN @newWeight > @oldWeight THEN @severity ELSE severity END,
+                   updated_at = @ts
+             WHERE id = @id`,
+          )
+          .run({
+            id: issueId,
+            observedVersion,
+            severity,
+            newWeight: SEVERITY_WEIGHT[severity],
+            oldWeight: SEVERITY_WEIGHT[(issue.severity as IssueSeverity) ?? 'medium'],
+            ts,
+          });
+      }
+
+      // Insert the observation as a distinct episode. UNIQUE(issue_id, episode_key)
+      // collapses repeats within a fix-window to one episode (spec §13.4).
+      let episodeRecorded = false;
+      const obsId = crypto.randomUUID();
+      const insert = this.db
+        .prepare(
+          `INSERT OR IGNORE INTO framework_observations
+             (id, issue_id, framework, evidence, observed_version, observed_at, tick_id, episode_key)
+           VALUES (@obsId, @issueId, @framework, @evidence, @observedVersion, @ts, @tickId, @episodeKey)`,
+        )
+        .run({ obsId, issueId, framework, evidence, observedVersion, ts, tickId, episodeKey });
+      episodeRecorded = insert.changes > 0;
+
+      if (episodeRecorded) {
+        this.db
+          .prepare(`UPDATE framework_issues SET recurrence_count = recurrence_count + 1, updated_at = ? WHERE id = ?`)
+          .run(ts, issueId);
+      }
+
+      // Apply retention: keep first N + last M observations for this issue (§13.2).
+      this.pruneObservations(issueId);
+
+      // Probable-loop flag: too many observations in the trailing hour (§13.4).
+      const recentCount = this.db
+        .prepare(`SELECT COUNT(*) AS c FROM framework_observations WHERE issue_id = ? AND observed_at >= ?`)
+        .get(issueId, ts - 60 * 60 * 1000) as { c: number };
+      const probableLoop = recentCount.c >= PROBABLE_LOOP_PER_HOUR;
+      this.db
+        .prepare(`UPDATE framework_issues SET probable_loop = ? WHERE id = ?`)
+        .run(probableLoop ? 1 : 0, issueId);
+
+      const after = this.db
+        .prepare(`SELECT recurrence_count FROM framework_issues WHERE id = ?`)
+        .get(issueId) as { recurrence_count: number };
+
+      return { issueId, created, episodeRecorded, recurrenceCount: after.recurrence_count, probableLoop };
+    });
+
+    return txn();
+  }
+
+  /** Retention pruning — keep first N + last M observations per issue (spec §13.2). */
+  private pruneObservations(issueId: string): void {
+    const total = this.db
+      .prepare(`SELECT COUNT(*) AS c FROM framework_observations WHERE issue_id = ?`)
+      .get(issueId) as { c: number };
+    if (total.c <= RETENTION_KEEP_FIRST + RETENTION_KEEP_LAST) return;
+    // Delete the middle band: everything not in the first-N or last-M by observed_at.
+    this.db
+      .prepare(
+        `DELETE FROM framework_observations
+           WHERE issue_id = @issueId
+             AND id NOT IN (
+               SELECT id FROM framework_observations WHERE issue_id = @issueId ORDER BY observed_at ASC LIMIT @first
+             )
+             AND id NOT IN (
+               SELECT id FROM framework_observations WHERE issue_id = @issueId ORDER BY observed_at DESC LIMIT @last
+             )`,
+      )
+      .run({ issueId, first: RETENTION_KEEP_FIRST, last: RETENTION_KEEP_LAST });
+  }
+
+  /**
+   * Single-writer CAS mutate of an issue's mutable fields (status, bucket,
+   * playbookStatus, regression link, etc.). Follows CommitmentTracker's
+   * read-modify-write-with-version-check pattern; enum fields are validated.
+   * `wont-fix` requires a reason (spec §13.7).
+   */
+  updateIssue(
+    issueId: string,
+    patch: Partial<{
+      status: IssueStatus;
+      bucket: IssueBucket;
+      bucketPrimary: IssueBucket | null;
+      playbookStatus: PlaybookStatus;
+      fixedInVersion: string | null;
+      regressedFromIssueId: string | null;
+      wontFixReason: string | null;
+      relatedSpec: string | null;
+    }>,
+  ): IssueRow | null {
+    const txn = this.db.transaction((): IssueRow | null => {
+      const cur = this.db.prepare(`SELECT * FROM framework_issues WHERE id = ?`).get(issueId) as
+        | Record<string, unknown>
+        | undefined;
+      if (!cur) return null;
+
+      const status = patch.status ? assertEnum(patch.status, ISSUE_STATUSES, 'status') : (cur.status as IssueStatus);
+      const bucket = patch.bucket ? assertEnum(patch.bucket, ISSUE_BUCKETS, 'bucket') : (cur.bucket as IssueBucket);
+      const playbookStatus = patch.playbookStatus
+        ? assertEnum(patch.playbookStatus, PLAYBOOK_STATUSES, 'playbookStatus')
+        : (cur.playbook_status as PlaybookStatus);
+      const bucketPrimary =
+        patch.bucketPrimary !== undefined
+          ? patch.bucketPrimary
+            ? assertEnum(patch.bucketPrimary, ISSUE_BUCKETS, 'bucketPrimary')
+            : null
+          : (cur.bucket_primary as IssueBucket | null);
+      const wontFixReason =
+        patch.wontFixReason !== undefined ? sanitizeFreeText(patch.wontFixReason ?? '', MAX_FREE_TEXT) || null : (cur.wont_fix_reason as string | null);
+
+      if (status === 'wont-fix' && !wontFixReason) {
+        throw new Error('FrameworkIssueLedger: wont-fix requires a wontFixReason (spec §13.7)');
+      }
+
+      this.db
+        .prepare(
+          `UPDATE framework_issues SET
+             status = @status, bucket = @bucket, bucket_primary = @bucketPrimary,
+             playbook_status = @playbookStatus,
+             fixed_in_version = @fixedInVersion, regressed_from_issue_id = @regressedFromIssueId,
+             wont_fix_reason = @wontFixReason, related_spec = @relatedSpec, updated_at = @ts
+           WHERE id = @id`,
+        )
+        .run({
+          id: issueId,
+          status,
+          bucket,
+          bucketPrimary,
+          playbookStatus,
+          fixedInVersion:
+            patch.fixedInVersion !== undefined ? patch.fixedInVersion : (cur.fixed_in_version as string | null),
+          regressedFromIssueId:
+            patch.regressedFromIssueId !== undefined
+              ? patch.regressedFromIssueId
+              : (cur.regressed_from_issue_id as string | null),
+          wontFixReason,
+          relatedSpec: patch.relatedSpec !== undefined ? patch.relatedSpec : (cur.related_spec as string | null),
+          ts: this.now(),
+        });
+      return this.getIssue(issueId);
+    });
+    return txn();
+  }
+
+  /**
+   * Suggest a regression link: a new issue whose signature/dedupKey matches a
+   * previously-`fixed` issue is a candidate regression (spec §13.5). Returns the
+   * matching fixed issues (does NOT auto-link — review decides).
+   */
+  suggestRegressions(input: { framework: string; dedupKey: string; signature?: string | null }): IssueRow[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM framework_issues
+           WHERE framework = ? AND status = 'fixed'
+             AND (dedup_key = ? OR (signature IS NOT NULL AND signature = ?))`,
+      )
+      .all(input.framework, input.dedupKey, input.signature ?? '__none__') as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToIssue(r));
+  }
+
+  getIssue(id: string): IssueRow | null {
+    const r = this.db.prepare(`SELECT * FROM framework_issues WHERE id = ?`).get(id) as
+      | Record<string, unknown>
+      | undefined;
+    return r ? this.rowToIssue(r) : null;
+  }
+
+  listIssues(q: ListIssuesQuery = {}): IssueRow[] {
+    const clauses: string[] = [];
+    const params: Record<string, unknown> = {};
+    if (q.framework) {
+      clauses.push(`framework = @framework`);
+      params.framework = q.framework;
+    }
+    if (q.bucket) {
+      clauses.push(`bucket = @bucket`);
+      params.bucket = assertEnum(q.bucket, ISSUE_BUCKETS, 'bucket');
+    }
+    if (q.status) {
+      clauses.push(`status = @status`);
+      params.status = assertEnum(q.status, ISSUE_STATUSES, 'status');
+    }
+    const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+    const limit = clampLimit(q.limit);
+    const rows = this.db
+      .prepare(`SELECT * FROM framework_issues ${where} ORDER BY updated_at DESC LIMIT @limit`)
+      .all({ ...params, limit }) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToIssue(r));
+  }
+
+  /**
+   * The onboarding playbook for `targetFramework`: generalizable lessons from
+   * PRIOR (other) frameworks, ranked by impactScore (spec §13.6). The playbook
+   * for X is sourced from frameworks != X — never X's own issues.
+   */
+  playbook(q: PlaybookQuery): IssueRow[] {
+    const limit = clampLimit(q.limit);
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM framework_issues
+           WHERE framework != @targetFramework
+             AND bucket IN ('framework-limitation', 'instar-integration-gap')
+             AND playbook_status IN ('candidate', 'extracted')`,
+      )
+      .all({ targetFramework: q.targetFramework }) as Array<Record<string, unknown>>;
+    return rows
+      .map((r) => this.rowToIssue(r))
+      .sort((a, b) => b.impactScore - a.impactScore)
+      .slice(0, limit);
+  }
+
+  observationCount(issueId: string): number {
+    const r = this.db
+      .prepare(`SELECT COUNT(*) AS c FROM framework_observations WHERE issue_id = ?`)
+      .get(issueId) as { c: number };
+    return r.c;
+  }
+
+  private rowToIssue(r: Record<string, unknown>): IssueRow {
+    const bucket = r.bucket as IssueBucket;
+    const severity = (r.severity as IssueSeverity) ?? 'medium';
+    const recurrenceCount = (r.recurrence_count as number) ?? 0;
+    const updatedAt = (r.updated_at as number) ?? 0;
+    // Recency decay (spec §13.4): a long-stale issue doesn't permanently dominate.
+    const ageMs = Math.max(0, this.now() - updatedAt);
+    const decay = Math.pow(0.5, ageMs / RECENCY_HALF_LIFE_MS);
+    const impactScore = SEVERITY_WEIGHT[severity] * recurrenceCount * decay;
+    return {
+      id: r.id as string,
+      framework: r.framework as string,
+      bucket,
+      bucketPrimary: (r.bucket_primary as IssueBucket | null) ?? null,
+      title: r.title as string,
+      severity,
+      status: r.status as IssueStatus,
+      dedupKey: r.dedup_key as string,
+      signature: (r.signature as string | null) ?? null,
+      recurrenceCount,
+      firstSeenVersion: (r.first_seen_version as string | null) ?? null,
+      lastSeenVersion: (r.last_seen_version as string | null) ?? null,
+      fixedInVersion: (r.fixed_in_version as string | null) ?? null,
+      regressedFromIssueId: (r.regressed_from_issue_id as string | null) ?? null,
+      playbookStatus: r.playbook_status as PlaybookStatus,
+      wontFixReason: (r.wont_fix_reason as string | null) ?? null,
+      relatedSpec: (r.related_spec as string | null) ?? null,
+      probableLoop: !!(r.probable_loop as number),
+      createdAt: (r.created_at as number) ?? 0,
+      updatedAt,
+      generalizable: GENERALIZABLE_BUCKETS.has(bucket),
+      impactScore: Math.round(impactScore * 1000) / 1000,
+    };
+  }
+
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Clamp a list limit to 1..500 (spec §5/§17). */
+export function clampLimit(raw: unknown): number {
+  const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(n)) return 100;
+  return Math.max(1, Math.min(500, Math.floor(n)));
+}

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -682,6 +682,7 @@ I maintain registries that are the source of truth for specific categories. Thes
 | My backup history? | \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/backups\` |
 | My state change history? | \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/git/log\` |
 | Other agents on this machine? | \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/agents\` |
+| Behavioral issues logged while onboarding a framework? / the onboarding playbook? | \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/framework-issues\` (read-only) + \`/framework-issues/playbook?targetFramework=X\` — the Framework-Onboarding Mentor System's issue ledger (observability only; never gates) |
 | Project architecture? | This file (CLAUDE.md), then project docs |
 
 **Why this matters:** Searching 1000 files to answer a question that a single state file could answer is slower AND less reliable. Broad searches find stale narratives. State files are current. This applies at EVERY level — including sub-agents I spawn. When spawning a research agent, include the relevant state file reference in its prompt so it searches WITH context, not blind.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -56,6 +56,7 @@ import { DeliveryFailureSentinel } from '../monitoring/delivery-failure-sentinel
 import os from 'node:os';
 import { TokenLedger } from '../monitoring/TokenLedger.js';
 import { TokenLedgerPoller } from '../monitoring/TokenLedgerPoller.js';
+import { FrameworkIssueLedger } from '../monitoring/FrameworkIssueLedger.js';
 import { BurnDetector } from '../monitoring/BurnDetector.js';
 import { BurnThrottleRunbook } from '../monitoring/BurnThrottleRunbook.js';
 import { BurnVerifier } from '../monitoring/BurnVerifier.js';
@@ -80,6 +81,7 @@ export class AgentServer {
   private toneGate: import('../core/MessagingToneGate.js').MessagingToneGate | null = null;
   private tokenLedger: TokenLedger | null = null;
   private tokenLedgerPoller: TokenLedgerPoller | null = null;
+  private frameworkIssueLedger: FrameworkIssueLedger | null = null;
   // Burn-detection-and-self-heal system (six-phase umbrella spec at
   // docs/specs/token-burn-detection-and-self-heal.md). Lazy-initialised
   // after the TokenLedger comes up — burn detection without a ledger is
@@ -420,6 +422,20 @@ export class AgentServer {
           maxFilesPerScan: 500,
           yieldEveryNFiles: 25,
         });
+        // Framework-Onboarding Mentor System issue ledger — read-only
+        // observability, signal-only (never gates). Instantiated here at
+        // startup so its two tables auto-create on first boot of this version
+        // (spec §14.3 — no schema migration needed). Lazy/best-effort: a
+        // failure leaves the /framework-issues routes returning 503, never
+        // blocking server startup.
+        try {
+          this.frameworkIssueLedger = new FrameworkIssueLedger({
+            dbPath: path.join(serverDataDir, 'framework-issue-ledger.db'),
+          });
+        } catch (err) {
+          console.warn('[instar] framework-issue-ledger init failed (non-fatal):', err);
+          this.frameworkIssueLedger = null;
+        }
       }
     } catch (err) {
       console.warn('[instar] token-ledger init failed (non-fatal):', err);
@@ -515,6 +531,7 @@ export class AgentServer {
       projectDriftChecker: options.projectDriftChecker ?? null,
       machineHeartbeat: options.machineHeartbeat ?? null,
       tokenLedger: this.tokenLedger,
+      frameworkIssueLedger: this.frameworkIssueLedger,
       sessionReaper: options.sessionReaper ?? null,
       telegramBridgeConfig: options.telegramBridgeConfig ?? null,
       telegramBridge: options.telegramBridge ?? null,

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -474,6 +474,18 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
     }),
   },
   {
+    key: 'frameworkIssues',
+    prefixes: ['/framework-issues'],
+    description: 'Framework-Onboarding Mentor System — read-only issue-ledger observability (never gates)',
+    build: ({ ctx }) => ({
+      enabled: !!ctx.frameworkIssueLedger,
+      endpoints: [
+        'GET /framework-issues — bucket-tagged behavioral issues logged while onboarding a framework',
+        'GET /framework-issues/playbook?targetFramework=X — generalizable lessons from prior frameworks, impact-ranked',
+      ],
+    }),
+  },
+  {
     key: 'skipLedger',
     prefixes: ['/skip-ledger'],
     description: 'Skip-ledger — workload-aware idempotency',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -659,6 +659,10 @@ export interface RouteContext {
   /** Token-usage ledger (read-only observability over Claude Code JSONL
    *  transcripts). Null when stateDir is unavailable. */
   tokenLedger: import('../monitoring/TokenLedger.js').TokenLedger | null;
+  /** Framework-Onboarding Mentor System issue ledger (read-only observability;
+   *  signal-only — never gates). Null when stateDir is unavailable. Powers
+   *  GET /framework-issues and /framework-issues/playbook. */
+  frameworkIssueLedger?: import('../monitoring/FrameworkIssueLedger.js').FrameworkIssueLedger | null;
   /** SessionReaper — pressure-aware idle-session reaper. Null when not wired
    *  (older boot paths). Powers GET /sessions/reaper observability. */
   sessionReaper?: import('../monitoring/SessionReaper.js').SessionReaper | null;
@@ -4175,6 +4179,66 @@ export function createRoutes(ctx: RouteContext): Router {
       if (n > 0) idleMs = n;
     }
     res.json({ idleMs, orphans: ctx.tokenLedger.orphans({ idleMs }) });
+  });
+
+  // ── Framework-Onboarding Mentor System: issue ledger (read-only) ──
+  // Signal-only observability. Bearer auth is applied globally by middleware;
+  // these routes never gate behaviour. See FRAMEWORK-ONBOARDING-MENTOR-SPEC §5.
+
+  // Clamp a list limit to 1..500 (§5/§17). Local to avoid import churn; mirrors
+  // FrameworkIssueLedger.clampLimit (the ledger re-clamps server-side too).
+  const clampFwLimit = (raw: unknown): number => {
+    const n = typeof raw === 'string' ? parseInt(raw, 10) : typeof raw === 'number' ? raw : NaN;
+    if (!Number.isFinite(n)) return 100;
+    return Math.max(1, Math.min(500, Math.floor(n)));
+  };
+
+  router.get('/framework-issues', (req, res) => {
+    if (!ctx.frameworkIssueLedger) {
+      res.status(503).json({ error: 'framework issue ledger unavailable' });
+      return;
+    }
+    const limit = clampFwLimit(req.query.limit);
+    // Validate framework against the known-framework allowlist (§17) — an
+    // unknown value yields an empty result, never an unbounded/injection query.
+    const known = ctx.frameworkIssueLedger.knownFrameworks();
+    let framework: string | undefined;
+    if (typeof req.query.framework === 'string') {
+      if (!known.includes(req.query.framework)) {
+        res.json({ framework: req.query.framework, knownFrameworks: known, issues: [] });
+        return;
+      }
+      framework = req.query.framework;
+    }
+    const bucket = typeof req.query.bucket === 'string' ? req.query.bucket : undefined;
+    const status = typeof req.query.status === 'string' ? req.query.status : undefined;
+    try {
+      const issues = ctx.frameworkIssueLedger.listIssues({
+        framework,
+        // listIssues validates these enums and throws on bad input.
+        bucket: bucket as never,
+        status: status as never,
+        limit,
+      });
+      res.json({ framework, knownFrameworks: known, limit, issues });
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  router.get('/framework-issues/playbook', (req, res) => {
+    if (!ctx.frameworkIssueLedger) {
+      res.status(503).json({ error: 'framework issue ledger unavailable' });
+      return;
+    }
+    const targetFramework = typeof req.query.targetFramework === 'string' ? req.query.targetFramework : '';
+    if (!targetFramework) {
+      res.status(400).json({ error: 'targetFramework query param is required' });
+      return;
+    }
+    const limit = clampFwLimit(req.query.limit);
+    const playbook = ctx.frameworkIssueLedger.playbook({ targetFramework, limit });
+    res.json({ targetFramework, limit, playbook });
   });
 
   // ── Jobs ────────────────────────────────────────────────────────

--- a/tests/e2e/framework-issue-ledger-lifecycle.test.ts
+++ b/tests/e2e/framework-issue-ledger-lifecycle.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tier-3 E2E "feature is alive" lifecycle test for the Framework-Onboarding
+ * Mentor System issue ledger (FRAMEWORK-ONBOARDING-MENTOR-SPEC §14, §18).
+ *
+ * Per TESTING-INTEGRITY-SPEC: the single most important test for any feature
+ * with API routes — is it actually alive on the production init path (returns
+ * 200, not 503)? This boots the REAL AgentServer (the same path server.ts uses),
+ * and verifies:
+ *   1. The FrameworkIssueLedger is instantiated at startup (wiring integrity).
+ *   2. Its SQLite DB auto-creates under server-data/ on first boot (§14.3 — no
+ *      schema migration needed).
+ *   3. GET /framework-issues returns 200, not 503.
+ *   4. A written observation surfaces end-to-end through the live HTTP route.
+ *   5. GET /framework-issues/playbook is alive.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { FrameworkIssueLedger } from '../../src/monitoring/FrameworkIssueLedger.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+describe('FrameworkIssueLedger E2E lifecycle (feature is alive)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+  const AUTH = 'test-e2e-framework-issue-ledger';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fwledger-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+
+    const config: InstarConfig = {
+      projectName: 'e2e', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH,
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    } as InstarConfig;
+
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir) });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/framework-issue-ledger-lifecycle.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+  const dbPath = () => path.join(stateDir, 'server-data', 'framework-issue-ledger.db');
+
+  it('instantiates the ledger DB on the production init path (no schema migration needed)', () => {
+    expect(fs.existsSync(dbPath())).toBe(true);
+  });
+
+  it('GET /framework-issues is alive — returns 200, not 503', async () => {
+    const res = await request(app).get('/framework-issues').set(auth());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.issues)).toBe(true);
+  });
+
+  it('GET /framework-issues/playbook is alive — returns 200, not 503', async () => {
+    const res = await request(app).get('/framework-issues/playbook?targetFramework=cursor').set(auth());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.playbook)).toBe(true);
+  });
+
+  it('a written observation surfaces end-to-end through the live route', async () => {
+    // Open a second handle on the SAME db the server created (WAL allows
+    // concurrent readers) and write an observation — standing in for Stage B
+    // (the auto-capture call site ships in the next PR, §19.2).
+    const writer = new FrameworkIssueLedger({ dbPath: dbPath() });
+    writer.recordObservation({
+      framework: 'codex-cli',
+      bucket: 'instar-integration-gap',
+      title: 'intelligence provider loaded full identity on every judgment call',
+      dedupKey: 'codex::identity-load::judgment',
+      severity: 'high',
+      observedVersion: '1.3.2',
+      evidence: 'rollout-2026-05-26.jsonl:142',
+    });
+    writer.close();
+
+    const res = await request(app).get('/framework-issues?framework=codex-cli').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.issues).toHaveLength(1);
+    expect(res.body.issues[0].title).toMatch(/identity/);
+    expect(res.body.issues[0].generalizable).toBe(true);
+  });
+
+  it('requires auth (Bearer token) like every non-/health route', async () => {
+    const res = await request(app).get('/framework-issues'); // no auth header
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/e2e/framework-issue-ledger-lifecycle.test.ts
+++ b/tests/e2e/framework-issue-ledger-lifecycle.test.ts
@@ -107,4 +107,12 @@ describe('FrameworkIssueLedger E2E lifecycle (feature is alive)', () => {
     const res = await request(app).get('/framework-issues'); // no auth header
     expect(res.status).toBe(401);
   });
+
+  it('surfaces the framework-issues capability in /capabilities (discoverability)', async () => {
+    const res = await request(app).get('/capabilities').set(auth());
+    expect(res.status).toBe(200);
+    const body = JSON.stringify(res.body);
+    // The CapabilityIndex entry must appear and be enabled (ledger is wired in this boot).
+    expect(body).toMatch(/framework-issues/);
+  });
 });

--- a/tests/integration/framework-issues-routes.test.ts
+++ b/tests/integration/framework-issues-routes.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tier-2 integration tests for the Framework-Onboarding Mentor System issue
+ * ledger routes (FRAMEWORK-ONBOARDING-MENTOR-SPEC §5, §17, §18).
+ *
+ *   GET /framework-issues                       — list, with framework allowlist
+ *   GET /framework-issues/playbook?targetFramework=X
+ *
+ * Verifies the full HTTP pipeline: 503 when unavailable, 200 when wired,
+ * limit clamping, framework-allowlist validation, and the playbook query.
+ * Uses supertest with a minimal Express app and a real in-memory ledger.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { FrameworkIssueLedger } from '../../src/monitoring/FrameworkIssueLedger.js';
+
+function baseCtx(over: Partial<RouteContext>): RouteContext {
+  return {
+    config: { projectName: 't', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0 } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null,
+    telegram: null,
+    relationships: null,
+    feedback: null,
+    dispatches: null,
+    updateChecker: null,
+    autoUpdater: null,
+    autoDispatcher: null,
+    quotaTracker: null,
+    publisher: null,
+    viewer: null,
+    tunnel: null,
+    evolution: null,
+    watchdog: null,
+    triageNurse: null,
+    topicMemory: null,
+    discoveryEvaluator: null,
+    startTime: new Date(),
+    ...over,
+  } as RouteContext;
+}
+
+function appWith(ledger: FrameworkIssueLedger | null): express.Express {
+  const ctx = baseCtx({ frameworkIssueLedger: ledger });
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+describe('Framework-issues routes (integration)', () => {
+  let ledger: FrameworkIssueLedger;
+
+  beforeEach(() => {
+    ledger = new FrameworkIssueLedger({ dbPath: ':memory:' });
+  });
+  afterEach(() => ledger.close());
+
+  describe('503 when ledger unavailable', () => {
+    it('GET /framework-issues → 503', async () => {
+      const res = await request(appWith(null)).get('/framework-issues');
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/unavailable/);
+    });
+    it('GET /framework-issues/playbook → 503', async () => {
+      const res = await request(appWith(null)).get('/framework-issues/playbook?targetFramework=cursor');
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe('GET /framework-issues', () => {
+    it('returns 200 with issues when wired (feature is alive)', async () => {
+      ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'A', dedupKey: 'k1' });
+      const res = await request(appWith(ledger)).get('/framework-issues');
+      expect(res.status).toBe(200);
+      expect(res.body.issues).toHaveLength(1);
+      expect(res.body.knownFrameworks).toContain('codex-cli');
+    });
+
+    it('clamps limit to 1..500', async () => {
+      const res = await request(appWith(ledger)).get('/framework-issues?limit=99999');
+      expect(res.status).toBe(200);
+      expect(res.body.limit).toBe(500);
+      const res2 = await request(appWith(ledger)).get('/framework-issues?limit=0');
+      expect(res2.body.limit).toBe(1);
+    });
+
+    it('returns empty for a framework not on the allowlist (no injection/unbounded query)', async () => {
+      ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+      const res = await request(appWith(ledger)).get(
+        `/framework-issues?framework=${encodeURIComponent("codex-cli'; DROP TABLE framework_issues;--")}`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.issues).toHaveLength(0);
+      // Table intact — the known framework still returns its issue.
+      const res2 = await request(appWith(ledger)).get('/framework-issues?framework=codex-cli');
+      expect(res2.body.issues).toHaveLength(1);
+    });
+
+    it('returns 400 for an invalid bucket enum', async () => {
+      ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+      const res = await request(appWith(ledger)).get('/framework-issues?bucket=nonsense');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/invalid bucket/);
+    });
+  });
+
+  describe('GET /framework-issues/playbook', () => {
+    it('requires targetFramework', async () => {
+      const res = await request(appWith(ledger)).get('/framework-issues/playbook');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns generalizable prior-framework lessons, impact-ranked', async () => {
+      const a = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'big', dedupKey: 'a', severity: 'high', episodeKey: 'v1' });
+      ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'big', dedupKey: 'a', severity: 'high', episodeKey: 'v2' });
+      ledger.updateIssue(a.issueId, { playbookStatus: 'extracted' });
+      const res = await request(appWith(ledger)).get('/framework-issues/playbook?targetFramework=cursor');
+      expect(res.status).toBe(200);
+      expect(res.body.targetFramework).toBe('cursor');
+      expect(res.body.playbook).toHaveLength(1);
+      expect(res.body.playbook[0].dedupKey).toBe('a');
+    });
+
+    it('excludes the target framework\'s own issues', async () => {
+      const a = ledger.recordObservation({ framework: 'cursor', bucket: 'instar-integration-gap', title: 'x', dedupKey: 'a' });
+      ledger.updateIssue(a.issueId, { playbookStatus: 'extracted' });
+      const res = await request(appWith(ledger)).get('/framework-issues/playbook?targetFramework=cursor');
+      expect(res.body.playbook).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/FrameworkIssueLedger.test.ts
+++ b/tests/unit/FrameworkIssueLedger.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tier-1 unit tests for FrameworkIssueLedger (Framework-Onboarding Mentor
+ * System, docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md §13, §17, §18).
+ *
+ * Covers: ledger CRUD, dedup (false-merge resistance), episode collapsing,
+ * materialized recurrence_count correctness, impactScore + recency decay,
+ * regression auto-suggest, enum + param-injection guards, secret-scan
+ * redaction, retention pruning, and playbook cross-framework semantics.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  FrameworkIssueLedger,
+  clampLimit,
+  scanForSecret,
+} from '../../src/monitoring/FrameworkIssueLedger.js';
+
+let ledger: FrameworkIssueLedger;
+let clock: number;
+
+beforeEach(() => {
+  clock = 1_700_000_000_000;
+  ledger = new FrameworkIssueLedger({ dbPath: ':memory:', now: () => clock });
+});
+afterEach(() => ledger.close());
+
+describe('recordObservation — create + dedup', () => {
+  it('creates a canonical issue on first observation', () => {
+    const r = ledger.recordObservation({
+      framework: 'codex-cli',
+      bucket: 'instar-integration-gap',
+      title: 'identity loaded on every judgment call',
+      dedupKey: 'codex::identity-load::judgment',
+      severity: 'high',
+      observedVersion: '1.3.2',
+    });
+    expect(r.created).toBe(true);
+    expect(r.episodeRecorded).toBe(true);
+    expect(r.recurrenceCount).toBe(1);
+    const issue = ledger.getIssue(r.issueId)!;
+    expect(issue.framework).toBe('codex-cli');
+    expect(issue.bucket).toBe('instar-integration-gap');
+    expect(issue.severity).toBe('high');
+    expect(issue.firstSeenVersion).toBe('1.3.2');
+    expect(issue.generalizable).toBe(true); // derived at read
+  });
+
+  it('merges same (framework, dedupKey) into ONE canonical issue', () => {
+    const a = ledger.recordObservation({
+      framework: 'codex-cli', bucket: 'framework-limitation', title: 'A',
+      dedupKey: 'k1', episodeKey: 'v1',
+    });
+    const b = ledger.recordObservation({
+      framework: 'codex-cli', bucket: 'framework-limitation', title: 'A again',
+      dedupKey: 'k1', episodeKey: 'v2',
+    });
+    expect(b.created).toBe(false);
+    expect(a.issueId).toBe(b.issueId);
+  });
+
+  it('does NOT merge different dedupKeys (false-merge resistance — §13.3)', () => {
+    const a = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    const b = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'B', dedupKey: 'k2' });
+    expect(a.issueId).not.toBe(b.issueId);
+    expect(ledger.listIssues({ framework: 'codex-cli' })).toHaveLength(2);
+  });
+
+  it('does NOT merge same dedupKey across different frameworks', () => {
+    const a = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    const b = ledger.recordObservation({ framework: 'cursor', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    expect(a.issueId).not.toBe(b.issueId);
+  });
+});
+
+describe('episode collapsing + materialized recurrence_count (§13.4)', () => {
+  it('collapses repeated observations within the same episode (no double count)', () => {
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', episodeKey: '1.3.2' });
+    const second = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', episodeKey: '1.3.2' });
+    expect(second.episodeRecorded).toBe(false);
+    expect(second.recurrenceCount).toBe(1); // not 2 — same episode
+  });
+
+  it('counts distinct episodes, not raw ticks', () => {
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', episodeKey: '1.3.2' });
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', episodeKey: '1.3.3' });
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', episodeKey: '1.3.4' });
+    expect(r.recurrenceCount).toBe(3);
+  });
+
+  it('recurrence_count is materialized (matches getIssue, no read-time COUNT drift)', () => {
+    for (const v of ['v1', 'v2', 'v3', 'v4']) {
+      ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', episodeKey: v });
+    }
+    const issue = ledger.listIssues({ framework: 'codex-cli' })[0];
+    expect(issue.recurrenceCount).toBe(4);
+  });
+});
+
+describe('impactScore + recency decay (§13.4)', () => {
+  it('ranks higher severity × recurrence above lower', () => {
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'low', dedupKey: 'low', severity: 'low', episodeKey: 'a' });
+    const high = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'high', dedupKey: 'high', severity: 'high', episodeKey: 'a' });
+    const lowIssue = ledger.listIssues({ framework: 'codex-cli' }).find((i) => i.dedupKey === 'low')!;
+    const highIssue = ledger.getIssue(high.issueId)!;
+    expect(highIssue.impactScore).toBeGreaterThan(lowIssue.impactScore);
+  });
+
+  it('decays impactScore as the issue goes stale', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', severity: 'high' });
+    const fresh = ledger.getIssue(r.issueId)!.impactScore;
+    clock += 60 * 24 * 60 * 60 * 1000; // +60 days (2 half-lives)
+    const stale = ledger.getIssue(r.issueId)!.impactScore;
+    expect(stale).toBeLessThan(fresh);
+    expect(stale).toBeCloseTo(fresh * 0.25, 2);
+  });
+});
+
+describe('updateIssue — CAS mutate + enum + wont-fix (§13.7)', () => {
+  it('updates status and playbookStatus with enum validation', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    const updated = ledger.updateIssue(r.issueId, { status: "spec'd", playbookStatus: 'candidate' });
+    expect(updated!.status).toBe("spec'd");
+    expect(updated!.playbookStatus).toBe('candidate');
+  });
+
+  it('rejects an invalid enum value', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    // @ts-expect-error — deliberately invalid
+    expect(() => ledger.updateIssue(r.issueId, { status: 'banana' })).toThrow(/invalid status/);
+  });
+
+  it('refuses wont-fix without a reason (§13.7)', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'A', dedupKey: 'k1' });
+    expect(() => ledger.updateIssue(r.issueId, { status: 'wont-fix' })).toThrow(/wont-fix requires/);
+    const ok = ledger.updateIssue(r.issueId, { status: 'wont-fix', wontFixReason: 'upstream limitation, tracked' });
+    expect(ok!.status).toBe('wont-fix');
+    expect(ok!.wontFixReason).toMatch(/upstream/);
+  });
+
+  it('returns null for an unknown issue id', () => {
+    expect(ledger.updateIssue('nope', { status: 'fixed' })).toBeNull();
+  });
+});
+
+describe('regression auto-suggest (§13.5)', () => {
+  it('suggests a previously-fixed issue with a matching dedupKey', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', signature: 'sig-A' });
+    ledger.updateIssue(r.issueId, { status: 'fixed', fixedInVersion: '1.4.0' });
+    const candidates = ledger.suggestRegressions({ framework: 'codex-cli', dedupKey: 'k1', signature: 'sig-A' });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].id).toBe(r.issueId);
+  });
+
+  it('does not suggest non-matching or non-fixed issues', () => {
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' }); // still open
+    expect(ledger.suggestRegressions({ framework: 'codex-cli', dedupKey: 'k1' })).toHaveLength(0);
+    expect(ledger.suggestRegressions({ framework: 'codex-cli', dedupKey: 'other' })).toHaveLength(0);
+  });
+});
+
+describe('playbook — cross-framework, ranked (§13.6)', () => {
+  beforeEach(() => {
+    // Prior framework (codex) has two generalizable, playbook-promoted issues.
+    const a = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'big', dedupKey: 'a', severity: 'high', episodeKey: 'v1' });
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'big', dedupKey: 'a', severity: 'high', episodeKey: 'v2' });
+    ledger.updateIssue(a.issueId, { playbookStatus: 'extracted' });
+    const b = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'small', dedupKey: 'b', severity: 'low', episodeKey: 'v1' });
+    ledger.updateIssue(b.issueId, { playbookStatus: 'candidate' });
+    // A generic-agent-mistake (NOT generalizable) — must never reach the playbook.
+    const c = ledger.recordObservation({ framework: 'codex-cli', bucket: 'generic-agent-mistake', title: 'oops', dedupKey: 'c' });
+    ledger.updateIssue(c.issueId, { playbookStatus: 'candidate' });
+    // An un-promoted generalizable issue — playbookStatus none, excluded.
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'unpromoted', dedupKey: 'd' });
+  });
+
+  it('returns generalizable promoted lessons from OTHER frameworks, impact-ranked', () => {
+    const pb = ledger.playbook({ targetFramework: 'cursor' });
+    expect(pb.map((i) => i.dedupKey)).toEqual(['a', 'b']); // high-impact 'a' first
+    expect(pb.every((i) => i.generalizable)).toBe(true);
+    expect(pb.find((i) => i.bucket === 'generic-agent-mistake')).toBeUndefined();
+  });
+
+  it('excludes the target framework\'s OWN issues (playbook is prior-frameworks only)', () => {
+    const pb = ledger.playbook({ targetFramework: 'codex-cli' });
+    expect(pb).toHaveLength(0); // codex's own lessons are not its own playbook
+  });
+});
+
+describe('security — secret-scan + param-injection (§17)', () => {
+  it('redacts evidence that looks like an inlined secret', () => {
+    const r = ledger.recordObservation({
+      framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'leak', dedupKey: 'k1',
+      evidence: 'token sk-ABCDEFGHIJKLMNOP1234567890 in the log',
+    });
+    const obs = ledger.getIssue(r.issueId)!;
+    expect(obs).toBeTruthy();
+    // The observation evidence must be redacted, not stored verbatim.
+    expect(scanForSecret('Bearer abcdef1234567890')).toBe(true);
+    expect(scanForSecret('rollout.jsonl:142')).toBe(false);
+  });
+
+  it('treats an injection-style framework filter as a literal (no SQL injection)', () => {
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1' });
+    // A malicious "framework" value must match nothing, not drop the table.
+    const rows = ledger.listIssues({ framework: "codex-cli'; DROP TABLE framework_issues;--" });
+    expect(rows).toHaveLength(0);
+    // Table still intact:
+    expect(ledger.listIssues({ framework: 'codex-cli' })).toHaveLength(1);
+  });
+
+  it('rejects an invalid bucket on write', () => {
+    // @ts-expect-error — deliberately invalid
+    expect(() => ledger.recordObservation({ framework: 'x', bucket: 'nonsense', title: 'A', dedupKey: 'k' })).toThrow(/invalid bucket/);
+  });
+});
+
+describe('retention pruning (§13.2)', () => {
+  it('keeps a bounded set of observations even after many distinct episodes', () => {
+    let id = '';
+    for (let i = 0; i < 100; i++) {
+      const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'k1', episodeKey: `ep-${i}` });
+      id = r.issueId;
+      clock += 1000;
+    }
+    // recurrence_count keeps counting all distinct episodes…
+    expect(ledger.getIssue(id)!.recurrenceCount).toBe(100);
+    // …but stored observation rows are bounded by retention (first 5 + last 20).
+    expect(ledger.observationCount(id)).toBeLessThanOrEqual(25);
+  });
+});
+
+describe('clampLimit', () => {
+  it('clamps to 1..500 and defaults sanely', () => {
+    expect(clampLimit(0)).toBe(1);
+    expect(clampLimit(99999)).toBe(500);
+    expect(clampLimit('50')).toBe(50);
+    expect(clampLimit(undefined)).toBe(100);
+    expect(clampLimit('garbage')).toBe(100);
+  });
+});

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -210,6 +210,9 @@ describe('Feature Delivery Completeness', () => {
       'sentinelTelegramEscalation',                       // silently-stopped sentinel delivery gate
       'Sentinel Notifications (silently-stopped trio)',   // alternate heading phrase
       'Cross-Agent Communication Discipline (anti-confabulation)', // migrator-only behavioral guard, no template parity
+      'The "Threadline" hub topic — notifications',       // CMT-519 migrator-only notification-routing guidance, no template parity
+      'What are we working on?',                           // migrator patch for the initiatives Registry-First row, not a capability section
+      'Framework-Onboarding Mentor System',               // developer-layer issue-ledger observability; not a Codex/Gemini end-user capability (no shadow-marker parity)
     ];
 
     it('all new migrator CLAUDE.md sections are tracked', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,38 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+**Framework-Onboarding Mentor System — the issue ledger (foundation).** This is the first
+piece of a larger system that teaches new agent frameworks (Codex now; Cursor / Aider / Gemini
+later) how to behave well on Instar, and saves every lesson so the next framework onboards
+faster. This release ships the durable, two-table SQLite **issue ledger** that records
+behavioral issues observed during onboarding — one canonical row per distinct root cause, plus
+per-occurrence evidence — and two read-only HTTP routes to query it. Recurrence is counted in
+distinct *episodes* (not raw ticks) and materialized so the onboarding playbook ranks by
+"how badly it hurts × how often it happens" without an expensive read-time scan.
+
+It is **observability only** — the ledger never gates a job, blocks a message, or constrains a
+session. Evidence is stored as opaque references (path+line, log ref, PR#), secret-scanned at
+capture, never inlined log text. The full mentor loop (the scheduled job that drives the
+mentee, auto-captures issues, and tracks graduation) ships staged in later releases; this PR is
+the foundation everything else stands on.
+
+## What to Tell Your User
+
+- I now keep a structured, durable notebook of the real-world problems a new AI engine hits
+  when it's learning to run on Instar — bucketed by whether it's the engine's own limit, an
+  Instar integration gap, or a one-off mistake.
+- Only the first two kinds travel forward as a reusable "here's what bit the last engine, check
+  these first" checklist — so each new engine we add onboards faster than the last.
+- This is plumbing for a bigger mentoring system that's still rolling out gradually; nothing
+  changes in your day-to-day yet, and it never blocks anything.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Framework issue ledger | `curl -H "Authorization: Bearer $AUTH" http://localhost:<port>/framework-issues` (read-only; optional `?framework=&bucket=&status=&limit=`) |
+| Onboarding playbook | `curl -H "Authorization: Bearer $AUTH" "http://localhost:<port>/framework-issues/playbook?targetFramework=X"` — generalizable lessons from PRIOR frameworks, impact-ranked |
+| Auto-created on update | The ledger's SQLite DB auto-creates under `server-data/` on first boot — no migration step |

--- a/upgrades/side-effects/framework-issue-ledger.md
+++ b/upgrades/side-effects/framework-issue-ledger.md
@@ -92,3 +92,11 @@ All three tiers, shipped in this PR (no "routes now, migration later"):
 - Tier 3 (e2e "feature is alive"): 5 tests — real AgentServer boot, DB auto-creates on production
   init path, routes 200-not-503, written observation surfaces end-to-end, 401 without auth.
 - Full push-config suite (vs JKHeadley/main): 3362 tests green, no regressions.
+
+## Post-push CI fix
+
+CI shard 1/4 caught `capabilities-discoverability.test.ts`: every registered route prefix must be
+classified in `src/server/CapabilityIndex.ts` (the test reads routes.ts via regex, not import, so
+vitest's `--changed` graph didn't link it locally). Classified `/framework-issues` as a read-only
+observability capability (mirrors the `tokens` entry, `enabled: !!ctx.frameworkIssueLedger`). No
+behavioral change — surfaces the read-only routes in `/capabilities`. 322 capability tests green.

--- a/upgrades/side-effects/framework-issue-ledger.md
+++ b/upgrades/side-effects/framework-issue-ledger.md
@@ -1,0 +1,94 @@
+# Side-Effects Review — FrameworkIssueLedger (Mentor System §19.1 foundation)
+
+**Spec:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` (converged 5 iters, approved by Justin)
+**Change:** New SQLite two-table issue ledger (`framework_issues` + `framework_observations`),
+two read-only HTTP routes (`/framework-issues`, `/framework-issues/playbook`), AgentServer
+startup instantiation, RouteContext wiring, CLAUDE.md template row + migrator section, NEXT.md.
+**Files:** `src/monitoring/FrameworkIssueLedger.ts` (new), `src/server/routes.ts`,
+`src/server/AgentServer.ts`, `src/scaffold/templates.ts`, `src/core/PostUpdateMigrator.ts`,
+`tests/unit/FrameworkIssueLedger.test.ts` (new), `tests/integration/framework-issues-routes.test.ts` (new),
+`tests/e2e/framework-issue-ledger-lifecycle.test.ts` (new), `tests/unit/feature-delivery-completeness.test.ts`,
+`upgrades/NEXT.md`.
+
+## Principle check (Phase 1)
+
+Does this involve a decision point that gates info flow / blocks actions / filters messages /
+constrains agent behavior? **No.** The ledger is a data store + read-only routes — it records
+observations (signal) and serves queries. It holds zero blocking authority. The decision-bearing
+parts of the mentor system (two-hats enforcement, assignment admission, graduation authority)
+are §19.3–5 and ship later. This PR is a data-model + observability change → **signal-only**,
+the correct posture per `docs/signal-vs-authority.md`.
+
+## The seven questions
+
+1. **Over-block — what legitimate inputs does this reject that it shouldn't?**
+   The routes reject unknown `framework` values (returns empty list, not an error) and invalid
+   `bucket`/`status` enums (400). An unknown framework returning empty is intentional (allowlist,
+   §17); it could surprise a caller who mistypes, but the response includes `knownFrameworks` so
+   the caller can self-correct. No legitimate data is rejected on write — `recordObservation`
+   accepts any framework string and creates the issue.
+
+2. **Under-block — what failure modes does this still miss?**
+   The ledger does not yet have a *writer* (Stage B auto-capture is §19.2), so today it only
+   accepts observations from in-process callers (the e2e test writes directly). There is no public
+   write route, so there is no untrusted-write surface to under-block. Secret-scanning of evidence
+   is pattern-based (api-key/JWT/Slack/GitHub/PEM shapes) — a novel secret format could slip
+   through; mitigated by the hard rule that evidence is an opaque reference, not log content, and
+   the length cap. The probable-loop flag is a heuristic (12 obs/hr) — a slow loop under that rate
+   won't trip it, but episode-collapsing already bounds recurrence inflation structurally.
+
+3. **Level-of-abstraction fit — right layer? smarter gate exists?**
+   Yes. It mirrors the established `TokenLedger` (read-only SQLite observability in
+   `src/monitoring/`) and reuses `CommitmentTracker`'s transactional-mutate discipline. It does
+   NOT duplicate FrameworkParitySentinel (renderings) — it records *behavior*, and §10 has the
+   sentinel feed it as an upstream signal in a later PR. No smarter gate exists for this data.
+
+4. **Signal vs authority compliance.**
+   Compliant. The ledger produces/serves signal; it never gates. `recordObservation` writes a
+   row; `listIssues`/`playbook` read. No method blocks, throttles, kills, or constrains. All
+   authority over what to do with an entry (ship a fix, promote to playbook `extracted`, advance
+   graduation) is reserved for the human per spec §6/§8 and lands in later PRs.
+
+5. **Interactions — shadow / double-fire / race with cleanup?**
+   - DB isolation: a dedicated `framework-issue-ledger.db` under `server-data/`, separate from
+     `token-ledger.db` — no shadowing of TokenLedger or its BurnDetector reads.
+   - Concurrency: WAL + `busy_timeout=5000` + a single SQLite transaction per write, with a
+     `UNIQUE(issue_id, episode_key)` index as the race guard (a concurrent duplicate episode insert
+     loses cleanly and is counted as already-recorded). Retention pruning runs inside the same txn.
+   - Startup: instantiated in the same `stateDir` guard block as TokenLedger; its own try/catch
+     means a ledger failure can't take down TokenLedger or server start.
+
+6. **External surfaces — visible to other agents/users/systems? timing/runtime deps?**
+   Two new read-only HTTP routes behind the standard Bearer middleware (verified by e2e: a
+   bearer-less request gets 401). New agents get one Registry-First row in CLAUDE.md; existing
+   agents get a migrator section (content-sniffed, idempotent). No Codex/Gemini shadow-marker
+   (developer-layer observability, not an end-user capability — tracked as a legacyMigratorSection
+   so the parity test stays green). No timing/conversation-state dependence.
+
+7. **Rollback cost — if wrong in production, what's the back-out?**
+   Low. The feature is dormant (no writer wired yet) and signal-only. Back-out = revert the PR;
+   the `framework-issue-ledger.db` file is harmless read-only observability data that can be left
+   on disk or deleted (nothing reads it except these routes). No data migration, no agent-state
+   repair. The routes fail-soft to 503 if the ledger is unavailable, so even a construction
+   failure degrades cleanly rather than breaking server start.
+
+## Phase 5 — second-pass
+
+**Not required.** The Phase-5 trigger list is block/allow decisions, session lifecycle,
+compaction, coherence/idempotency/trust gates, and anything named sentinel/guard/gate/watchdog.
+This change is none of those — it is a read-only observability ledger with no blocking authority.
+The decision-bearing components of the mentor system (which WILL trigger Phase 5) ship in §19.3–5.
+The spec itself already passed a 5-iteration adversarial/security/scalability/integration/lessons
+convergence before this build.
+
+## Testing
+
+All three tiers, shipped in this PR (no "routes now, migration later"):
+- Tier 1 (unit): 22 tests — CRUD, dedup false-merge resistance, episode collapsing, materialized
+  recurrence, impactScore + decay, regression auto-suggest, enum + SQL-injection-literal guard,
+  secret-scan redaction, retention pruning, playbook cross-framework semantics, clampLimit.
+- Tier 2 (integration): 9 tests — routes over the HTTP pipeline (503, 200, limit clamp, framework
+  allowlist, invalid-enum 400, playbook).
+- Tier 3 (e2e "feature is alive"): 5 tests — real AgentServer boot, DB auto-creates on production
+  init path, routes 200-not-503, written observation surfaces end-to-end, 401 without auth.
+- Full push-config suite (vs JKHeadley/main): 3362 tests green, no regressions.


### PR DESCRIPTION
## What this is

First build PR of the **Framework-Onboarding Mentor System** (`docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` — converged through 5 `/spec-converge` iterations, 44→6→0 material findings, Justin-approved). Ships the **foundation** everything else stands on: the durable issue ledger + read-only routes. The mentor loop (scheduled job, Stage A/B, graduation) ships in later staged PRs.

## What's in it

- **`FrameworkIssueLedger`** — dedicated SQLite, two tables: `framework_issues` (canonical root-cause) + `framework_observations` (per-occurrence). "False merges are worse than false splits." WAL + `busy_timeout` + transactional CAS writes.
- **Anti-poisoning** — recurrence counts distinct *episodes* (not raw ticks), materialized so playbook ranking pays no read-time COUNT; per-issue retention pruning; probable-loop flag; `impactScore` with recency decay.
- **Security (spec §17)** — evidence is opaque references only, **secret-scanned + redacted** at capture (never inlined log content); all free-text length-capped/sanitized; parameterized queries + enum allowlists; SQL-injection-as-literal proven by test.
- **Routes** — `GET /framework-issues` + `/framework-issues/playbook` behind Bearer auth, 503 guard, `limit` clamp (1..500), known-framework allowlist. Playbook = generalizable lessons from PRIOR frameworks, impact-ranked.
- **Wiring** — instantiated at `AgentServer` startup so the DB auto-creates on first boot (no schema migration, §14.3). CLAUDE.md template row + idempotent migrator section.
- **Signal-only** — never gates a job, blocks a message, or constrains a session.

## Testing (all three tiers ship in this PR)

- **Tier 1 (unit):** 22 — CRUD, dedup false-merge resistance, episode collapsing, materialized recurrence, impactScore+decay, regression auto-suggest, enum + SQL-injection-literal guard, secret-scan redaction, retention, playbook semantics.
- **Tier 2 (integration):** 9 — routes over HTTP (503/200/clamp/allowlist/400/playbook).
- **Tier 3 (e2e "feature is alive"):** 5 — real `AgentServer` boot, DB auto-creates on production init path, routes 200-not-503, written observation surfaces end-to-end, 401 without auth.
- Full push-config suite vs canonical main: **3362 green, no regressions.** Also greens the pre-existing-red `feature-delivery-completeness` section-parity test.

## Side-effects review

`upgrades/side-effects/framework-issue-ledger.md` — signal-only posture, low rollback cost (dormant until the writer wires in the next PR; back-out = revert, DB is harmless read-only data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)