### PR TITLE
feat(mentor): live mentor loop — tick + runner + routes + job (§19.4, dormant)

### DIFF
--- a/site/src/content/docs/architecture/the-living-system.md
+++ b/site/src/content/docs/architecture/the-living-system.md
@@ -71,6 +71,7 @@ The immune system is the most layered part of the organism. It has innate immuni
 | **memory-export** | Job (6h) | Memory consolidation. Regenerates MEMORY.md from the SemanticMemory knowledge graph. |
 | **identity-review** | Job (daily) | Self-model maintenance. Checks whether behavior aligns with AGENT.md and soul.md. |
 | **overseer-learning** | Job (2 days) | Meta-learning. Is the agent actually getting smarter, or is the learning pipeline busy-work? |
+| **mentor-onboarding** | Job (15m, off) | Framework-onboarding mentor heartbeat. Pokes the in-process mentor tick that drives a mentee framework as the user, runs the leak-detector, and captures behavioral issues to the framework ledger. Ships dormant. |
 
 **How it flows:** reflection-trigger captures raw learnings → insight-harvest finds patterns → EvolutionManager creates proposals → evolution-proposal-evaluate approves → evolution-proposal-implement builds → memory-hygiene prunes → memory-export consolidates → identity-review checks alignment. overseer-learning watches the whole pipeline.
 

--- a/site/src/content/docs/reference/default-jobs.md
+++ b/site/src/content/docs/reference/default-jobs.md
@@ -25,6 +25,7 @@ Instar ships with fourteen default jobs that run automatically on schedule. Each
 | `overseer-learning` | `0 3 */2 * *` (every other day 3am) | Sonnet | Learning oversight — knowledge consolidation, gap detection |
 | `docs-coverage-audit` | `0 10 * * 1` (Mondays 10am) | Haiku | Weekly walk of the instar source tree against the docs surface, surfaces newly-undocumented capabilities. Ships `enabled: false` by default; only useful on machines with the instar source repo locally |
 | `org-intent-drift-audit` | (configurable) | Sonnet | Periodic drift detection for organizational intent — compares recent decisions and outputs against the constraints and goals declared in `ORG-INTENT.md`, surfaces drift via the degradation channel |
+| `mentor-onboarding` | `*/15 * * * *` (every 15m) | Haiku | Framework-Onboarding Mentor heartbeat — a thin timer that pokes `POST /mentor/tick`; the in-process tick runs a leak-detector canary, a fail-closed budget gate, a safe-window check, a constrained Stage-A spawn, the leakage detector, Stage-B forensics, and ledger capture. Ships `enabled: false` and `mentor.mode: 'off'`; dormant until promoted off → dry-run → live |
 
 All jobs ship inside `src/scaffold/templates/jobs/instar/` and are installed on `instar init` plus refreshed on every update via `PostUpdateMigrator`.
 

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -99,6 +99,18 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       enabled: true,
     },
   },
+  // Framework-Onboarding Mentor System (§19.4). Ships DORMANT: enabled:false +
+  // mode:'off' so POST /mentor/tick returns {ran:false,reason:'disabled'} and
+  // nothing spawns or spends. Promotion off → dry-run → live is the human's, via
+  // the graduated-rollout track. See docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md.
+  mentor: {
+    enabled: false,
+    mode: 'off',
+    menteeFramework: 'codex-cli',
+    minIntervalMs: 600000, // 10-min floor between ticks (anti-forced-cadence)
+    maxRoundsPerDay: 24,
+    dailySpendCapUsd: 0.5,
+  },
   // Spec-review standards-conformance gate (rung-3 normative slice). Default-on:
   // the gate reads docs/STANDARDS-REGISTRY.md and signals possible standard
   // violations in a draft spec. Signal-only (never blocks); 503-stubs where the

--- a/src/scaffold/templates/jobs/instar/mentor-onboarding.md
+++ b/src/scaffold/templates/jobs/instar/mentor-onboarding.md
@@ -1,0 +1,41 @@
+---
+name: Framework-Onboarding Mentor
+description: Heartbeat that drives one mentor tick — Stage A (drive the mentee as the user, blind to internals), leak check, Stage B forensics, and ledger capture. Off by default; the actual loop, budget gate, and safe-window check live in-process behind POST /mentor/tick (mentor.enabled=false until promoted). Phase §19.4 of FRAMEWORK-ONBOARDING-MENTOR-SPEC.md.
+schedule: "*/15 * * * *"
+priority: low
+expectedDurationMinutes: 1
+model: haiku
+enabled: false
+tags:
+  - cat:learning
+  - mentor
+  - framework-integration
+toolAllowlist: "*"
+unrestrictedTools: true
+---
+Run one mentor heartbeat by POSTing to the local mentor endpoint, then stop.
+
+This job is a thin trigger — all the real logic (the leak-detector canary, the fail-closed budget
+gate, the durable safe-window check, the Stage-A spawn with an empty tool grant, the leak detector,
+Stage-B forensics, and the ledger capture) runs IN-PROCESS inside the server, not in this session.
+That keeps the structural two-hats enforcement in code, not in this prompt.
+
+Do exactly this:
+
+1. POST to `http://localhost:${PORT}/mentor/tick` with the bearer token:
+   `curl -s -X POST -H "Authorization: Bearer $AUTH" http://localhost:${PORT}/mentor/tick`
+
+2. Read the JSON result. It will be one of:
+   - `{"ran":false,"reason":"disabled"}` — the mentor is off (the default). Nothing to do; stop.
+   - `{"ran":false,"reason":"budget"|"unsafe-window"|"canary-failed"}` — it correctly skipped this
+     tick. Stop; the next heartbeat will try again.
+   - `{"ran":true,...}` — a mentor tick ran. Note `leakDetected` and `observationsWritten` briefly,
+     then stop.
+
+3. Do NOT do any mentoring work yourself in this session, do NOT read the mentee's logs or code,
+   and do NOT send the mentee any message — the in-process tick owns all of that. You are only the
+   timer that pokes it. Then exit.
+
+This job is OFF by default. Enable it (and set `mentor.mode` to `dry-run`, then `live`, in
+`.instar/config.json`) only when you want continuous framework-onboarding mentoring — the
+graduated-rollout track drives that promotion with your sign-off at each step.

--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -1,0 +1,98 @@
+/**
+ * MentorOnboardingRunner — thin glue that assembles the real services into the
+ * pure runMentorTick core (FRAMEWORK-ONBOARDING-MENTOR-SPEC §19.4).
+ *
+ * The runner holds no orchestration logic of its own — that lives in
+ * runMentorTick (pure, fully unit-tested). The runner's only job is to (a) read
+ * the mentor config and short-circuit when the feature is off, and (b) wire the
+ * injected services (ledger, Stage-A spawn, Stage-B forensics, mentee-busy check,
+ * budget gate, surface builder) into the tick's callbacks. Every service is
+ * injected, so the runner is testable with fakes and carries no hard dependency
+ * on SessionManager/tmux/LLM at construction.
+ *
+ * Ships dormant: `mentor.enabled=false` / `mentor.mode='off'` by default (§16).
+ */
+import { runMentorTick, type MentorTickResult, type MentorMode } from './MentorOnboardingTick.js';
+import type { ConversationSurface } from '../monitoring/MentorStageA.js';
+import type { CaptureRunInput, CaptureRunResult, ForensicFinding } from '../monitoring/FrameworkIssueLedger.js';
+
+export interface MentorConfig {
+  enabled: boolean;
+  mode: 'off' | 'dry-run' | 'live';
+  /** The framework being mentored (parametric). */
+  menteeFramework: string;
+  minIntervalMs: number;
+  maxRoundsPerDay: number;
+  dailySpendCapUsd: number;
+}
+
+export const DEFAULT_MENTOR_CONFIG: MentorConfig = {
+  enabled: false,
+  mode: 'off',
+  menteeFramework: 'codex-cli',
+  minIntervalMs: 600_000, // 10 min floor
+  maxRoundsPerDay: 24,
+  dailySpendCapUsd: 0.5,
+};
+
+export interface MentorRunnerServices {
+  /** Write findings + log the run to the ledger funnel (§19.2). */
+  capture: (input: CaptureRunInput) => CaptureRunResult;
+  /** Spawn Stage A with the empty tool grant; return its transcript. */
+  spawnStageA: (prompt: string) => Promise<string>;
+  /** Stage-B forensics for the framework; return findings. */
+  runStageBForensics: (framework: string) => Promise<ForensicFinding[]>;
+  /** Durable safe-window inputs. */
+  isMenteeBusy: () => boolean;
+  minIntervalElapsed: () => boolean;
+  /** Fail-closed budget gate. */
+  budgetOk: () => boolean;
+  /** Build the conversation surface (Stage A's only input). */
+  getSurface: (framework: string) => ConversationSurface;
+  /** Called once when a tick actually RAN (ran=true) — lets the host advance the
+   *  min-interval clock and the per-day run counter. */
+  onTickRan?: () => void;
+  now?: () => number;
+}
+
+export type MentorRunReason = MentorTickResult['reason'] | 'disabled';
+
+export interface MentorRunResult extends Omit<MentorTickResult, 'reason'> {
+  reason: MentorRunReason;
+}
+
+export class MentorOnboardingRunner {
+  constructor(
+    private readonly services: MentorRunnerServices,
+    private readonly getConfig: () => MentorConfig,
+  ) {}
+
+  status(): { enabled: boolean; mode: MentorConfig['mode']; menteeFramework: string } {
+    const cfg = this.getConfig();
+    return { enabled: cfg.enabled, mode: cfg.mode, menteeFramework: cfg.menteeFramework };
+  }
+
+  /** Run one tick. Short-circuits to `disabled` when the feature is off (§16). */
+  async tick(): Promise<MentorRunResult> {
+    const cfg = this.getConfig();
+    if (!cfg.enabled || cfg.mode === 'off') {
+      return { ran: false, reason: 'disabled' };
+    }
+    const framework = cfg.menteeFramework;
+    const mode: MentorMode = cfg.mode === 'live' ? 'live' : 'dry-run';
+    const result = await runMentorTick({
+      framework,
+      mode,
+      surface: this.services.getSurface(framework),
+      // Safe window = mentee at rest AND the min-interval floor elapsed (§12 Q3).
+      safeWindowOpen: !this.services.isMenteeBusy() && this.services.minIntervalElapsed(),
+      budgetOk: this.services.budgetOk(),
+      spawnStageA: this.services.spawnStageA,
+      runStageBForensics: () => this.services.runStageBForensics(framework),
+      capture: this.services.capture,
+      now: this.services.now,
+    });
+    if (result.ran) this.services.onTickRan?.();
+    return result;
+  }
+}

--- a/src/scheduler/MentorOnboardingTick.ts
+++ b/src/scheduler/MentorOnboardingTick.ts
@@ -1,0 +1,162 @@
+/**
+ * MentorOnboardingTick — the structural core of one mentor heartbeat tick
+ * (FRAMEWORK-ONBOARDING-MENTOR-SPEC §3, §4, §6, §19.4).
+ *
+ * This is PURE orchestration logic with every side-effect injected as a
+ * callback, so the whole tick is unit-testable without tmux, an LLM, or a
+ * server. The structural guarantees the spec demands live HERE (in code), not
+ * in a prompt:
+ *
+ *   - The leak canary runs FIRST every tick; a dead detector halts the tick and
+ *     self-reports (§4.3) — the detector can't silently rot.
+ *   - The budget check is a fail-closed PRE-tick gate: under budget pressure the
+ *     ENTIRE tick is skipped before any spend or any contact (§6) — never a
+ *     partial Stage A without Stage B.
+ *   - The safe-window check gates on a durable mentee state, not a clock (§12 Q3).
+ *   - Stage A is driven via the injected `spawnStageA` (the §19.4 runner passes
+ *     the empty-tool-grant spawn); its transcript is run through the leakage
+ *     detector and any leak is captured as an instar-integration-gap (§4.3).
+ *   - Stage B forensics + capture run via injected callbacks; the ledger's
+ *     captureRun logs the run to the funnel even when nothing is found (§19.2).
+ */
+import {
+  buildStageAContext,
+  detectStageALeak,
+  runLeakCanary,
+  leakToFinding,
+  type ConversationSurface,
+} from '../monitoring/MentorStageA.js';
+import type { CaptureRunInput, CaptureRunResult, ForensicFinding } from '../monitoring/FrameworkIssueLedger.js';
+
+/** Mentor run modes (spec §16). `off` never reaches the tick; `dry-run` does
+ *  everything except deliver a message to the mentee; `live` is the full loop. */
+export type MentorMode = 'dry-run' | 'live';
+
+export interface MentorTickDeps {
+  framework: string;
+  mode: MentorMode;
+  /** The user-visible conversation surface (Stage A's only input). */
+  surface: ConversationSurface;
+  /** Durable safe-window: true when the mentee is at a stable point (task-complete /
+   *  waiting / blocked / quiet-after-user-msg) AND the min-interval floor has elapsed. */
+  safeWindowOpen: boolean;
+  /** Fail-closed budget gate (the GET /autonomous/can-start precedent). */
+  budgetOk: boolean;
+  /** Spawn Stage A (empty tool grant) and return its transcript. Injected so the
+   *  pure tick has no SessionManager/tmux dependency. */
+  spawnStageA: (prompt: string) => Promise<string>;
+  /** Stage-B forensics: read the mentee's logs/rollouts/diff and return findings.
+   *  Injected so the pure tick has no LLM dependency. */
+  runStageBForensics: () => Promise<ForensicFinding[]>;
+  /** Write findings + log the run to the ledger funnel (§19.2). */
+  capture: (input: CaptureRunInput) => CaptureRunResult;
+  /** Tick id for provenance/episode keying. */
+  tickId?: string;
+  now?: () => number;
+  /** Leak-detector liveness check; defaults to the real canary. Injected for tests. */
+  canaryCheck?: () => boolean;
+}
+
+export type MentorTickReason =
+  | 'canary-failed'
+  | 'budget'
+  | 'unsafe-window'
+  | 'stage-a-failed'
+  | 'ran';
+
+export interface MentorTickResult {
+  ran: boolean;
+  reason: MentorTickReason;
+  mode?: MentorMode;
+  leakDetected?: boolean;
+  observationsWritten?: number;
+  findingsCount?: number;
+  /** The Stage-A message the mentor produced (delivered only in `live` mode by the runner). */
+  stageAMessage?: string;
+}
+
+/**
+ * Run one mentor tick. Returns a structured result; the only side effects are
+ * via the injected callbacks. Order is load-bearing (canary → budget →
+ * safe-window → Stage A → leak → Stage B → capture).
+ */
+export async function runMentorTick(deps: MentorTickDeps): Promise<MentorTickResult> {
+  const tickId = deps.tickId ?? `mentor-${(deps.now ?? Date.now)()}`;
+
+  // 1. Leak canary FIRST — a dead detector can't be trusted to police Stage A,
+  //    so we halt and self-report rather than run blind (§4.3).
+  const canary = deps.canaryCheck ?? runLeakCanary;
+  if (!canary()) {
+    deps.capture({
+      framework: deps.framework,
+      tickId,
+      findings: [
+        {
+          bucket: 'instar-integration-gap',
+          title: 'Mentor leak detector canary failed — detector may be inert',
+          dedupKey: `${deps.framework}::leak-canary-failed`,
+          signature: 'leak-canary-failed',
+          severity: 'high',
+          episodeKey: tickId,
+        },
+      ],
+    });
+    return { ran: false, reason: 'canary-failed' };
+  }
+
+  // 2. Budget gate — fail-closed BEFORE any spend or contact (§6).
+  if (!deps.budgetOk) return { ran: false, reason: 'budget' };
+
+  // 3. Safe-window — only act at a durable mentee state transition (§12 Q3).
+  if (!deps.safeWindowOpen) return { ran: false, reason: 'unsafe-window' };
+
+  // 4. Stage A — drive the mentee from the conversation surface only.
+  let transcript: string;
+  try {
+    transcript = await deps.spawnStageA(buildStageAContext(deps.surface));
+  } catch {
+    deps.capture({
+      framework: deps.framework,
+      tickId,
+      findings: [
+        {
+          bucket: 'instar-integration-gap',
+          title: 'Stage-A spawn failed during a mentor tick',
+          dedupKey: `${deps.framework}::stage-a-spawn-failed`,
+          signature: 'stage-a-spawn-failed',
+          severity: 'medium',
+          episodeKey: tickId,
+        },
+      ],
+    });
+    return { ran: false, reason: 'stage-a-failed' };
+  }
+
+  // 5. Leakage detection on the Stage-A transcript (§4.3).
+  const leak = detectStageALeak(transcript, deps.surface);
+  const findings: ForensicFinding[] = [];
+  if (leak.leaked) findings.push(leakToFinding(deps.framework, leak, tickId));
+
+  // 6. Stage B forensics (separate step, full tool access in the runner).
+  const stageBFindings = await deps.runStageBForensics();
+  findings.push(...stageBFindings);
+
+  // 7. Capture — writes findings + logs the run to the funnel (§19.2),
+  //    even if findings is empty (inert-writer guard).
+  const captured = deps.capture({ framework: deps.framework, tickId, findings });
+
+  return {
+    ran: true,
+    reason: 'ran',
+    mode: deps.mode,
+    leakDetected: leak.leaked,
+    observationsWritten: captured.observationsWritten,
+    findingsCount: findings.length,
+    // The tick SURFACES the Stage-A message it produced; it does NOT deliver it.
+    // No mentee-delivery path is wired yet — `live` mode is not reachable until
+    // the persist-only delivery (§6) is built + tested. Until then both dry-run
+    // and live only observe + capture. Delivery is a live-promotion blocker.
+    // <!-- tracked: topic-13435 -->
+    stageAMessage: transcript,
+  };
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -57,6 +57,9 @@ import os from 'node:os';
 import { TokenLedger } from '../monitoring/TokenLedger.js';
 import { TokenLedgerPoller } from '../monitoring/TokenLedgerPoller.js';
 import { FrameworkIssueLedger } from '../monitoring/FrameworkIssueLedger.js';
+import { MentorOnboardingRunner, DEFAULT_MENTOR_CONFIG, type MentorConfig } from '../scheduler/MentorOnboardingRunner.js';
+import { STAGE_A_ALLOWED_TOOLS } from '../monitoring/MentorStageA.js';
+import type { ForensicFinding } from '../monitoring/FrameworkIssueLedger.js';
 import { BurnDetector } from '../monitoring/BurnDetector.js';
 import { BurnThrottleRunbook } from '../monitoring/BurnThrottleRunbook.js';
 import { BurnVerifier } from '../monitoring/BurnVerifier.js';
@@ -82,6 +85,12 @@ export class AgentServer {
   private tokenLedger: TokenLedger | null = null;
   private tokenLedgerPoller: TokenLedgerPoller | null = null;
   private frameworkIssueLedger: FrameworkIssueLedger | null = null;
+  private mentorRunner: MentorOnboardingRunner | null = null;
+  /** Wall-clock of the last mentor tick that ran, for the min-interval floor. */
+  private mentorLastTickAt = 0;
+  /** UTC day + run count for the per-day mentor cap (resets across days). */
+  private mentorDayKey = '';
+  private mentorRunsToday = 0;
   // Burn-detection-and-self-heal system (six-phase umbrella spec at
   // docs/specs/token-burn-detection-and-self-heal.md). Lazy-initialised
   // after the TokenLedger comes up — burn detection without a ledger is
@@ -429,9 +438,11 @@ export class AgentServer {
           this.frameworkIssueLedger = new FrameworkIssueLedger({
             dbPath: path.join(serverDataDir, 'framework-issue-ledger.db'),
           });
+          this.mentorRunner = this.buildMentorRunner(this.frameworkIssueLedger, options);
         } catch (err) {
           console.warn('[instar] framework-issue-ledger init failed (non-fatal):', err);
           this.frameworkIssueLedger = null;
+          this.mentorRunner = null;
         }
       }
     } catch (err) {
@@ -529,6 +540,7 @@ export class AgentServer {
       machineHeartbeat: options.machineHeartbeat ?? null,
       tokenLedger: this.tokenLedger,
       frameworkIssueLedger: this.frameworkIssueLedger,
+      mentorRunner: this.mentorRunner,
       sessionReaper: options.sessionReaper ?? null,
       telegramBridgeConfig: options.telegramBridgeConfig ?? null,
       telegramBridge: options.telegramBridge ?? null,
@@ -627,6 +639,80 @@ export class AgentServer {
     if (fs.existsSync(fromDist)) return fromDist;
     if (fs.existsSync(fromSrc)) return fromSrc;
     return fromDist;
+  }
+
+  /**
+   * Wire the mentor-onboarding runner (§19.4) from real services. Ships DORMANT:
+   * the config defaults to mentor.enabled=false / mode='off', so tick() returns
+   * {ran:false, reason:'disabled'} in production until a human flips it via the
+   * graduated-rollout track. The live spawn/forensics paths are real code, gated
+   * behind that flag and validated via test-as-self before promotion.
+   */
+  private buildMentorRunner(
+    ledger: FrameworkIssueLedger,
+    options: { config: unknown; intelligence?: import('../core/types.js').IntelligenceProvider | null },
+  ): MentorOnboardingRunner {
+    const getConfig = (): MentorConfig => ({
+      ...DEFAULT_MENTOR_CONFIG,
+      ...((options.config as unknown as { mentor?: Partial<MentorConfig> }).mentor ?? {}),
+    });
+    const intelligence = options.intelligence ?? null;
+    const self = this;
+    return new MentorOnboardingRunner(
+      {
+        capture: (input) => ledger.captureRun(input),
+        // Stage A spawns with the EMPTY tool grant (structural two-hats boundary,
+        // §4); we bounded-wait for it to finish, then capture its transcript.
+        spawnStageA: async (prompt: string): Promise<string> => {
+          const session = await self.sessionManager.spawnSession({
+            name: `mentor-stage-a-${Date.now()}`,
+            prompt,
+            model: 'haiku',
+            allowedTools: [...STAGE_A_ALLOWED_TOOLS], // empty → no tools
+            maxDurationMinutes: 5,
+          });
+          const tmux = session.tmuxSession;
+          for (let i = 0; i < 90; i++) {
+            const stillRunning = self.sessionManager.listRunningSessions().some((s) => s.id === session.id);
+            if (!stillRunning) break;
+            await new Promise((r) => setTimeout(r, 2000));
+          }
+          return self.sessionManager.captureOutput(tmux, 200) ?? '';
+        },
+        // Stage-B deep log-forensics (assembling the mentee's rollouts/diffs and
+        // classifying) is a tracked follow-on; today the loop's real signal is the
+        // Stage-A leak detector (§4.3). Returns [] when no forensic inputs exist so
+        // the funnel still logs the run. <!-- tracked: topic-13435 -->
+        runStageBForensics: async (): Promise<ForensicFinding[]> => {
+          void intelligence;
+          return [];
+        },
+        // Safe-window: any other running (non-protected) session means the system
+        // is busy — conservative "don't interrupt." Refined per-mentee at live
+        // validation. <!-- tracked: topic-13435 -->
+        isMenteeBusy: () => self.sessionManager.listRunningSessions().length > 0,
+        minIntervalElapsed: () => {
+          const cfg = getConfig();
+          return Date.now() - self.mentorLastTickAt >= cfg.minIntervalMs;
+        },
+        budgetOk: () => {
+          const cfg = getConfig();
+          const day = new Date().toISOString().slice(0, 10);
+          if (self.mentorDayKey !== day) {
+            self.mentorDayKey = day;
+            self.mentorRunsToday = 0;
+          }
+          return self.mentorRunsToday < cfg.maxRoundsPerDay;
+        },
+        getSurface: (framework: string) => ({ framework, threadlineHistory: '' }),
+        onTickRan: () => {
+          self.mentorLastTickAt = Date.now();
+          self.mentorRunsToday += 1;
+        },
+        now: () => Date.now(),
+      },
+      getConfig,
+    );
   }
 
   /**

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -487,6 +487,18 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
     }),
   },
   {
+    key: 'mentorOnboarding',
+    prefixes: ['/mentor'],
+    description: 'Framework-Onboarding Mentor job — dormant by default (mentor.enabled=false); never gates',
+    build: ({ ctx }) => ({
+      enabled: !!ctx.mentorRunner,
+      endpoints: [
+        'GET /mentor/status — mentor mode + mentee framework (off by default)',
+        'POST /mentor/tick — run one mentor heartbeat (returns {ran:false,reason:"disabled"} until enabled)',
+      ],
+    }),
+  },
+  {
     key: 'skipLedger',
     prefixes: ['/skip-ledger'],
     description: 'Skip-ledger — workload-aware idempotency',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -663,6 +663,9 @@ export interface RouteContext {
    *  signal-only — never gates). Null when stateDir is unavailable. Powers
    *  GET /framework-issues and /framework-issues/playbook. */
   frameworkIssueLedger?: import('../monitoring/FrameworkIssueLedger.js').FrameworkIssueLedger | null;
+  /** Mentor-onboarding runner (§19.4). Null when not wired. Ships dormant
+   *  (mentor.enabled=false); powers GET /mentor/status + POST /mentor/tick. */
+  mentorRunner?: import('../scheduler/MentorOnboardingRunner.js').MentorOnboardingRunner | null;
   /** SessionReaper — pressure-aware idle-session reaper. Null when not wired
    *  (older boot paths). Powers GET /sessions/reaper observability. */
   sessionReaper?: import('../monitoring/SessionReaper.js').SessionReaper | null;
@@ -4249,6 +4252,31 @@ export function createRoutes(ctx: RouteContext): Router {
     // The capture funnel: runs vs observations written. A nonzero run count with
     // a stuck-at-zero observation count over time flags an inert/broken writer.
     res.json(ctx.frameworkIssueLedger.captureStats());
+  });
+
+  // ── Mentor-onboarding job (§19.4) — dormant by default ──
+  router.get('/mentor/status', (_req, res) => {
+    if (!ctx.mentorRunner) {
+      res.status(503).json({ error: 'mentor runner unavailable' });
+      return;
+    }
+    res.json(ctx.mentorRunner.status());
+  });
+
+  router.post('/mentor/tick', async (_req, res) => {
+    if (!ctx.mentorRunner) {
+      res.status(503).json({ error: 'mentor runner unavailable' });
+      return;
+    }
+    // The built-in mentor job (off by default) hits this each tick. When the
+    // feature is disabled this returns {ran:false, reason:'disabled'} — no spawn,
+    // no spend. The structural loop lives in runMentorTick (signal-only).
+    try {
+      const result = await ctx.mentorRunner.tick();
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
   });
 
   // ── Jobs ────────────────────────────────────────────────────────

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -4275,7 +4275,7 @@ export function createRoutes(ctx: RouteContext): Router {
       const result = await ctx.mentorRunner.tick();
       res.json(result);
     } catch (err) {
-      res.status(500).json({ error: (err as Error).message });
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
     }
   });
 

--- a/tests/e2e/mentor-onboarding-lifecycle.test.ts
+++ b/tests/e2e/mentor-onboarding-lifecycle.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tier-3 E2E "feature is alive" test for the mentor-onboarding job (§19.4).
+ *
+ * Boots the REAL AgentServer and verifies the mentor surface is alive on the
+ * production init path AND ships dormant: GET /mentor/status is 200 (not 503)
+ * and reports enabled=false; POST /mentor/tick returns {ran:false,
+ * reason:'disabled'} — the loop never spawns or spends until a human promotes
+ * it. Also asserts the built-in job template ships off by default.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+describe('Mentor-onboarding E2E lifecycle (alive + dormant)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+  const AUTH = 'test-e2e-mentor-onboarding';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mentor-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+
+    const config: InstarConfig = {
+      projectName: 'e2e', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH,
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    } as InstarConfig;
+
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir) });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/mentor-onboarding-lifecycle.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('GET /mentor/status is alive (200, not 503) and reports dormant', async () => {
+    const res = await request(app).get('/mentor/status').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.enabled).toBe(false);
+    expect(res.body.mode).toBe('off');
+  });
+
+  it('POST /mentor/tick is dormant on the production init path (no spawn/spend)', async () => {
+    const res = await request(app).post('/mentor/tick').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ran: false, reason: 'disabled' });
+  });
+
+  it('surfaces the mentor capability in /capabilities', async () => {
+    const res = await request(app).get('/capabilities').set(auth());
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(res.body)).toMatch(/\/mentor/);
+  });
+
+  it('mentor routes require auth like every non-/health route', async () => {
+    expect((await request(app).get('/mentor/status')).status).toBe(401);
+  });
+
+  it('the built-in mentor job template ships OFF by default', () => {
+    const thisDir = path.dirname(fileURLToPath(import.meta.url));
+    const repoRoot = path.resolve(thisDir, '..', '..');
+    const jobPath = path.join(repoRoot, 'src', 'scaffold', 'templates', 'jobs', 'instar', 'mentor-onboarding.md');
+    expect(fs.existsSync(jobPath)).toBe(true);
+    const body = fs.readFileSync(jobPath, 'utf-8');
+    expect(body).toMatch(/^enabled:\s*false\s*$/m);
+  });
+});

--- a/tests/integration/mentor-routes.test.ts
+++ b/tests/integration/mentor-routes.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tier-2 integration tests for the mentor routes (§19.4):
+ *   GET  /mentor/status — mode + mentee framework
+ *   POST /mentor/tick   — run one heartbeat (disabled by default)
+ *
+ * Uses supertest + a real MentorOnboardingRunner with fake services, so the
+ * route↔runner contract is exercised over the full HTTP pipeline.
+ */
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import {
+  MentorOnboardingRunner,
+  DEFAULT_MENTOR_CONFIG,
+  type MentorConfig,
+  type MentorRunnerServices,
+} from '../../src/scheduler/MentorOnboardingRunner.js';
+
+function fakeServices(): MentorRunnerServices {
+  return {
+    capture: () => ({ runId: 'r', framework: 'codex-cli', findingsCount: 0, observationsWritten: 0, newIssues: 0, regressionCandidates: [] }),
+    spawnStageA: async () => 'clean reply',
+    runStageBForensics: async () => [],
+    isMenteeBusy: () => false,
+    minIntervalElapsed: () => true,
+    budgetOk: () => true,
+    getSurface: (framework) => ({ framework, threadlineHistory: 'hi' }),
+  };
+}
+
+function appWith(runner: MentorOnboardingRunner | null): express.Express {
+  const ctx = {
+    config: { projectName: 't', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0 } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, startTime: new Date(),
+    mentorRunner: runner,
+  } as unknown as RouteContext;
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+describe('Mentor routes (integration)', () => {
+  it('GET /mentor/status → 503 when runner unavailable', async () => {
+    const res = await request(appWith(null)).get('/mentor/status');
+    expect(res.status).toBe(503);
+  });
+
+  it('GET /mentor/status reflects the (default-off) config', async () => {
+    const runner = new MentorOnboardingRunner(fakeServices(), () => ({ ...DEFAULT_MENTOR_CONFIG }));
+    const res = await request(appWith(runner)).get('/mentor/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ enabled: false, mode: 'off', menteeFramework: 'codex-cli' });
+  });
+
+  it('POST /mentor/tick returns {ran:false, reason:"disabled"} by default (dormant)', async () => {
+    const runner = new MentorOnboardingRunner(fakeServices(), () => ({ ...DEFAULT_MENTOR_CONFIG }));
+    const res = await request(appWith(runner)).post('/mentor/tick');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ran: false, reason: 'disabled' });
+  });
+
+  it('POST /mentor/tick runs a tick when enabled + safe + in budget', async () => {
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'dry-run' };
+    const runner = new MentorOnboardingRunner(fakeServices(), () => cfg);
+    const res = await request(appWith(runner)).post('/mentor/tick');
+    expect(res.status).toBe(200);
+    expect(res.body.ran).toBe(true);
+    expect(res.body.mode).toBe('dry-run');
+  });
+});

--- a/tests/unit/MentorOnboardingRunner.test.ts
+++ b/tests/unit/MentorOnboardingRunner.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tier-1 unit tests for MentorOnboardingRunner — the thin glue around the pure
+ * tick core (FRAMEWORK-ONBOARDING-MENTOR-SPEC §19.4). Verifies the off-by-default
+ * short-circuit and correct service wiring with fakes (no tmux/LLM/server).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  MentorOnboardingRunner,
+  DEFAULT_MENTOR_CONFIG,
+  type MentorConfig,
+  type MentorRunnerServices,
+} from '../../src/scheduler/MentorOnboardingRunner.js';
+
+function fakeServices(over: Partial<MentorRunnerServices> = {}): MentorRunnerServices {
+  return {
+    capture: vi.fn(() => ({ runId: 'r', framework: 'codex-cli', findingsCount: 0, observationsWritten: 0, newIssues: 0, regressionCandidates: [] })),
+    spawnStageA: vi.fn(async () => 'clean conversational reply'),
+    runStageBForensics: vi.fn(async () => []),
+    isMenteeBusy: vi.fn(() => false),
+    minIntervalElapsed: vi.fn(() => true),
+    budgetOk: vi.fn(() => true),
+    getSurface: vi.fn((framework: string) => ({ framework, threadlineHistory: 'hi' })),
+    ...over,
+  };
+}
+
+describe('MentorOnboardingRunner', () => {
+  it('ships dormant: disabled config short-circuits to reason=disabled (no work)', async () => {
+    const svc = fakeServices();
+    const runner = new MentorOnboardingRunner(svc, () => ({ ...DEFAULT_MENTOR_CONFIG }));
+    const r = await runner.tick();
+    expect(r.ran).toBe(false);
+    expect(r.reason).toBe('disabled');
+    expect(svc.spawnStageA).not.toHaveBeenCalled();
+    expect(svc.budgetOk).not.toHaveBeenCalled();
+  });
+
+  it('mode "off" also short-circuits even if enabled flag flips', async () => {
+    const svc = fakeServices();
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'off' };
+    const runner = new MentorOnboardingRunner(svc, () => cfg);
+    expect((await runner.tick()).reason).toBe('disabled');
+  });
+
+  it('when enabled + safe + in budget, runs a full tick and captures', async () => {
+    const svc = fakeServices();
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'dry-run' };
+    const runner = new MentorOnboardingRunner(svc, () => cfg);
+    const r = await runner.tick();
+    expect(r.ran).toBe(true);
+    expect(r.mode).toBe('dry-run');
+    expect(svc.spawnStageA).toHaveBeenCalled();
+    expect(svc.capture).toHaveBeenCalled();
+  });
+
+  it('treats a busy mentee as an unsafe window (skips)', async () => {
+    const svc = fakeServices({ isMenteeBusy: () => true });
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'live' };
+    const r = await new MentorOnboardingRunner(svc, () => cfg).tick();
+    expect(r.reason).toBe('unsafe-window');
+    expect(svc.spawnStageA).not.toHaveBeenCalled();
+  });
+
+  it('treats not-yet-elapsed min-interval as unsafe (anti-forced-cadence)', async () => {
+    const svc = fakeServices({ minIntervalElapsed: () => false });
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'live' };
+    const r = await new MentorOnboardingRunner(svc, () => cfg).tick();
+    expect(r.reason).toBe('unsafe-window');
+  });
+
+  it('status() reflects config', () => {
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'live', menteeFramework: 'cursor' };
+    const runner = new MentorOnboardingRunner(fakeServices(), () => cfg);
+    expect(runner.status()).toEqual({ enabled: true, mode: 'live', menteeFramework: 'cursor' });
+  });
+});

--- a/tests/unit/MentorOnboardingTick.test.ts
+++ b/tests/unit/MentorOnboardingTick.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tier-1 unit tests for runMentorTick — the structural core of one mentor
+ * heartbeat (FRAMEWORK-ONBOARDING-MENTOR-SPEC §3/§4/§6/§19.4).
+ *
+ * Every side effect is injected, so the load-bearing order — canary → budget →
+ * safe-window → Stage A → leak → Stage B → capture — is asserted without tmux,
+ * an LLM, or a server.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runMentorTick, type MentorTickDeps } from '../../src/scheduler/MentorOnboardingTick.js';
+import type { CaptureRunInput, CaptureRunResult } from '../../src/monitoring/FrameworkIssueLedger.js';
+
+function makeDeps(over: Partial<MentorTickDeps> = {}): { deps: MentorTickDeps; captures: CaptureRunInput[] } {
+  const captures: CaptureRunInput[] = [];
+  const capture = (input: CaptureRunInput): CaptureRunResult => {
+    captures.push(input);
+    return {
+      runId: 'r1',
+      framework: input.framework,
+      findingsCount: input.findings.length,
+      observationsWritten: input.findings.length,
+      newIssues: input.findings.length,
+      regressionCandidates: [],
+    };
+  };
+  const deps: MentorTickDeps = {
+    framework: 'codex-cli',
+    mode: 'live',
+    surface: { framework: 'codex-cli', threadlineHistory: 'how is it going?' },
+    safeWindowOpen: true,
+    budgetOk: true,
+    spawnStageA: vi.fn(async () => 'Nice progress — ready for the next one?'),
+    runStageBForensics: vi.fn(async () => []),
+    capture,
+    tickId: 'tick-1',
+    ...over,
+  };
+  return { deps, captures };
+}
+
+describe('runMentorTick — gate order + structural guarantees', () => {
+  it('halts and self-reports when the leak canary fails (dead-detector guard, §4.3)', async () => {
+    const { deps, captures } = makeDeps({ canaryCheck: () => false });
+    const r = await runMentorTick(deps);
+    expect(r.ran).toBe(false);
+    expect(r.reason).toBe('canary-failed');
+    expect(deps.spawnStageA).not.toHaveBeenCalled();
+    expect(captures[0].findings[0].signature).toBe('leak-canary-failed');
+  });
+
+  it('skips the entire tick under budget pressure BEFORE any spend/contact (fail-closed, §6)', async () => {
+    const { deps, captures } = makeDeps({ budgetOk: false, canaryCheck: () => true });
+    const r = await runMentorTick(deps);
+    expect(r.reason).toBe('budget');
+    expect(r.ran).toBe(false);
+    expect(deps.spawnStageA).not.toHaveBeenCalled();
+    expect(deps.runStageBForensics).not.toHaveBeenCalled();
+    expect(captures).toHaveLength(0); // no contact, no capture
+  });
+
+  it('skips when the safe window is closed (durable-state gate, §12 Q3)', async () => {
+    const { deps } = makeDeps({ safeWindowOpen: false, canaryCheck: () => true });
+    const r = await runMentorTick(deps);
+    expect(r.reason).toBe('unsafe-window');
+    expect(deps.spawnStageA).not.toHaveBeenCalled();
+  });
+
+  it('budget is checked BEFORE safe-window (order)', async () => {
+    const { deps } = makeDeps({ budgetOk: false, safeWindowOpen: false, canaryCheck: () => true });
+    const r = await runMentorTick(deps);
+    expect(r.reason).toBe('budget'); // budget wins
+  });
+
+  it('happy path (clean transcript): runs, no leak, captures the run', async () => {
+    const { deps, captures } = makeDeps({ canaryCheck: () => true });
+    const r = await runMentorTick(deps);
+    expect(r.ran).toBe(true);
+    expect(r.reason).toBe('ran');
+    expect(r.leakDetected).toBe(false);
+    expect(deps.runStageBForensics).toHaveBeenCalled();
+    // The run is captured even with zero findings (funnel/inert-writer guard).
+    expect(captures).toHaveLength(1);
+    expect(captures[0].findings).toHaveLength(0);
+  });
+
+  it('detects a Stage-A leak and captures it as an instar-integration-gap (§4.3)', async () => {
+    const { deps, captures } = makeDeps({
+      canaryCheck: () => true,
+      spawnStageA: async () => 'you should fix src/messaging/Retry.ts:142 before PR #999',
+    });
+    const r = await runMentorTick(deps);
+    expect(r.ran).toBe(true);
+    expect(r.leakDetected).toBe(true);
+    const f = captures[0].findings.find((x) => x.signature === 'stage-a-leak-suspected');
+    expect(f).toBeTruthy();
+    expect(f!.bucket).toBe('instar-integration-gap');
+  });
+
+  it('flows Stage-B findings through to capture', async () => {
+    const { deps, captures } = makeDeps({
+      canaryCheck: () => true,
+      runStageBForensics: async () => [
+        { bucket: 'framework-limitation', title: 'codex truncates long argv', dedupKey: 'codex::argv-trunc', severity: 'medium' },
+      ],
+    });
+    const r = await runMentorTick(deps);
+    expect(r.findingsCount).toBe(1);
+    expect(captures[0].findings[0].dedupKey).toBe('codex::argv-trunc');
+  });
+
+  it('on a Stage-A spawn failure, self-reports and does not run Stage B', async () => {
+    const { deps, captures } = makeDeps({
+      canaryCheck: () => true,
+      spawnStageA: async () => { throw new Error('tmux spawn failed'); },
+    });
+    const r = await runMentorTick(deps);
+    expect(r.ran).toBe(false);
+    expect(r.reason).toBe('stage-a-failed');
+    expect(deps.runStageBForensics).not.toHaveBeenCalled();
+    expect(captures[0].findings[0].signature).toBe('stage-a-spawn-failed');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,43 +1,47 @@
 # Instar Upgrade Guide — NEXT
 
-<!-- bump: patch -->
+<!-- bump: minor -->
 
 ## What Changed
 
-**Framework-Onboarding Mentor System — Stage-A two-hats boundary + leakage detector (§19.3).**
-Adds the structural pieces that make the mentor's "two hats" real instead of a prompt promise. When
-the mentor drives a mentee agent conversationally ("Stage A"), it must be blind to the mentee's
-internals so real-world problems surface. This release supplies: an **empty tool grant** for the
-Stage-A sub-agent (the conversation surface is injected into its prompt, so it needs — and gets —
-no log/code/rollout/filesystem tools at all; enforced by the CLI `--allowedTools`, not a hook), a
-**context builder** whose signature *is* the boundary (there is no parameter through which an
-internal can enter), and a **leakage detector** that scans each Stage-A transcript for references
-to internals it could not have seen, with a built-in positive-control canary so the detector itself
-can't silently rot.
+**Framework-Onboarding Mentor System — the live mentor loop, shipped dormant (§19.4).** This wires
+the previous three pieces (ledger, auto-capture, Stage-A boundary) into one heartbeat: a pure tick
+that runs a leak-detector canary, a fail-closed budget gate, and a durable safe-window check, then
+spawns a constrained sub-agent (empty tool grant) to drive the mentee as the user, runs the leak
+detector on the transcript, runs Stage-B forensics, and captures findings to the ledger funnel. The
+orchestration is a pure function with every side-effect injected, so the structural guarantees live
+in code, not a prompt. A new built-in job (`mentor-onboarding`, off by default) is a thin timer that
+pokes `POST /mentor/tick`; the real work runs in-process.
 
-Pure logic, fully unit-tested, with no production caller yet — the scheduled mentor job that uses
-these ships in a later staged PR. Off by default; nothing activates.
+It ships **dormant**: `mentor.enabled=false` / `mode='off'`, so `POST /mentor/tick` returns
+`{ran:false, reason:'disabled'}` and nothing spawns, spends, or contacts anyone. There is no
+mentee-delivery path wired yet — promotion off → dry-run → live (with the documented live-promotion
+blockers closed first) is the human's, via the graduated-rollout track.
 
 ## What to Tell Your User
 
-- The "play the user" half of the mentor now has a real, structural blindfold — it literally has no
-  tools to peek at the mentee's internals, plus a tripwire that flags any peeking, self-tested so a
-  broken tripwire can't masquerade as "all clean."
-- Still dormant; nothing changes day-to-day.
+- The mentor's full loop now exists end-to-end but is switched off — it can't act until you turn it
+  on, and even then it starts in an observe-only dry-run.
+- When you do enable it, it refuses to run under budget pressure or while anything else is working,
+  checks its own leak-detector is alive before every tick, and logs every run so it can't quietly
+  break.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Stage-A tool grant | `STAGE_A_ALLOWED_TOOLS` (empty) passed to `spawnSession({ allowedTools })` — structural "conversation only" |
-| Stage-A context builder | `buildStageAContext(surface)` — prompt from the conversation surface only |
-| Leakage detector | `detectStageALeak(transcript, surface)` + `runLeakCanary()` — flags internals references the mentor couldn't have seen |
+| Mentor status | `curl -H "Authorization: Bearer $AUTH" http://localhost:<port>/mentor/status` — mode + mentee framework (off by default) |
+| Mentor tick | `POST /mentor/tick` — runs one heartbeat (`{ran:false,reason:"disabled"}` until enabled) |
+| Built-in mentor job | `mentor-onboarding` (ships `enabled:false`) — heartbeat that pokes the tick |
+| `mentor.*` config | `.instar/config.json` — `enabled`, `mode` (off/dry-run/live), `minIntervalMs`, `maxRoundsPerDay` |
 
 ## Evidence
 
-Net-new feature, not a bug fix — no prior failure to reproduce. Behavior is proven by tests: the
-leakage detector ships with a **positive-control canary** (a synthetic transcript citing
-`src/...Retry.ts:142` and `PR #999` against a surface that contains neither) that the detector MUST
-flag — so a dead/no-op detector is distinguishable from a clean run — plus negative tests proving
-clean conversational prose and user-supplied references do NOT trip it. 12 unit tests; affected
-push-config suite green vs canonical main.
+Net-new feature, not a bug fix — no prior failure to reproduce. Behavior is proven by tests: 8 unit
+tests assert the load-bearing gate ORDER (canary → budget → safe-window → Stage A → leak → Stage B →
+capture) and that a **fail-closed budget skip happens before any spawn or contact**; 6 runner tests
+prove the dormant short-circuit (disabled config → no work) and the busy/min-interval safe-window;
+4 integration tests cover the routes; and 5 e2e tests boot the real server and confirm `/mentor/tick`
+is dormant on the production init path and the job template ships `enabled:false`. A dedicated
+second-pass reviewer independently audited the spawn/gating logic (concur, 0 blocking concerns).
+Affected push-config suite green (3431 + 300 capability tests) vs canonical main.

--- a/upgrades/side-effects/mentor-onboarding-job.md
+++ b/upgrades/side-effects/mentor-onboarding-job.md
@@ -1,0 +1,176 @@
+# Side-Effects Review — Mentor-onboarding job (§19.4)
+
+**Spec:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` (converged 5 iters, approved by Justin)
+**Change:** The live mentor loop, shipped DORMANT. Pure tick core (`runMentorTick`), thin runner
+(`MentorOnboardingRunner`), routes (`GET /mentor/status`, `POST /mentor/tick`), AgentServer wiring,
+`mentor.*` config defaults, CapabilityIndex entry, and a built-in job template (`enabled:false`).
+**Files:** `src/scheduler/MentorOnboardingTick.ts`, `src/scheduler/MentorOnboardingRunner.ts`,
+`src/server/routes.ts`, `src/server/AgentServer.ts`, `src/server/CapabilityIndex.ts`,
+`src/config/ConfigDefaults.ts`, `src/scaffold/templates/jobs/instar/mentor-onboarding.md`,
+`tests/unit/MentorOnboardingTick.test.ts`, `tests/unit/MentorOnboardingRunner.test.ts`,
+`tests/integration/mentor-routes.test.ts`, `tests/e2e/mentor-onboarding-lifecycle.test.ts`,
+`upgrades/NEXT.md`.
+
+## Principle check (Phase 1)
+
+Does this involve a decision point that gates info flow / blocks actions / constrains behavior?
+**Yes — and it's built signal-only.** The tick *decides* whether to act (canary→budget→safe-window),
+spawns a constrained sub-agent, and writes findings. But none of it has authority over the user's
+world: today it only writes to the read-only ledger (no mentee-delivery path is wired yet — see
+Live-promotion blockers). It ships dormant (`mentor.enabled=false`, `mode:'off'`), so the production
+default is `POST /mentor/tick → {ran:false, reason:'disabled'}` — no spawn, no spend, no contact.
+
+## The seven questions
+
+1. **Over-block.** The safe-window check is conservative: `isMenteeBusy()` treats ANY running
+   session as "busy," so the mentor errs toward not-interrupting (correct bias). The budget cap and
+   min-interval floor likewise skip rather than act. No legitimate *required* action is blocked —
+   the mentor is purely additive.
+
+2. **Under-block.** The Stage-B *deep* log-forensics (assembling the mentee's rollouts/diffs and
+   LLM-classifying them) is not yet wired — `runStageBForensics` returns `[]` today, so the loop's
+   real signal is the Stage-A leak detector (§4.3) + the funnel. This is a tracked follow-on
+   (<!-- tracked: topic-13435 -->), not a silent gap: the funnel logs every run, so a loop producing
+   no findings is visible, not hidden. `getSurface` returns an empty history until the conversation
+   source is wired (same tracked follow-on) — meaning until then Stage A has thin context, which the
+   off-by-default + dry-run-first rollout is designed to surface before live.
+
+3. **Level-of-abstraction fit.** The orchestration is a PURE function (`runMentorTick`) with all
+   side-effects injected — the structural guarantees (canary-first, fail-closed budget, safe-window)
+   are in code, not the job prompt. The runner is thin glue; the job template is a thin timer that
+   pokes `POST /mentor/tick`. Spawn enforcement is delegated to the right layer (SessionManager
+   `--allowedTools`). This is the correct decomposition.
+
+4. **Signal vs authority.** Compliant. The tick produces signal (ledger findings) only — it never
+   merges code, advances graduation, or gates another component, and no mentee-delivery path is wired
+   yet. Authority stays with the human (§6/§8). The empty Stage-A tool grant is CLI-enforced, not
+   self-policed.
+
+5. **Interactions.** The runner reuses `ledger.captureRun` (funnel logs every run), `MentorStageA`
+   (empty grant + leak detector), and SessionManager.spawnSession. Min-interval + per-day counters
+   live on AgentServer and advance only via the `onTickRan` hook (so skipped ticks don't consume the
+   budget). A busy-session check prevents the mentor from interrupting other work. No shadowing of
+   existing sentinels; the mentor never kills/restarts anything.
+
+6. **External surfaces.** Two new routes behind Bearer auth (e2e: 401 without). A built-in job that
+   ships `enabled:false` (e2e asserts this). `mentor.*` config flows through the canonical
+   ConfigDefaults registry → existing agents get it via `applyDefaults` on migration (no bespoke
+   migrator block; matches `sessionReaper`/`topicIntent`). CapabilityIndex entry surfaces the routes.
+   No mentee-delivery path exists yet (Live-promotion blockers), so even `live` mode only observes.
+
+7. **Rollback cost.** Low. Dormant by default; revert removes the routes/job/config. No data
+   migration (the ledger/funnel tables are §19.1/19.2). The job auto-uninstalls when the template is
+   removed (installBuiltinJobs prunes slugs no longer in the templates dir).
+
+## Phase 5 — second-pass (REQUIRED here; deferred from §19.3)
+
+This change spawns sub-agents and contains gating logic, so a dedicated reviewer audited it
+independently. Their verdict is appended below (concur, 0 blocking concerns).
+
+## Live-promotion blockers (must close before `mentor.mode` → `live`) <!-- tracked: topic-13435 -->
+
+The second-pass surfaced three items that are unreachable while dormant but MUST be closed before the
+graduated-rollout flips the mentor to `live`. They are explicitly NOT ship-blockers for this dormant
+change; they are the gate for activation:
+
+1. **No mentee-delivery path is wired.** The tick surfaces `stageAMessage` but nothing forwards it to
+   the mentee. The persist-only delivery (§6) must be built + tested before `live` can actually
+   contact anyone. (Code comments + Q1/Q4/Q6 above corrected to say this.)
+2. **Spawn poll robustness + real budget accounting.** `spawnStageA` polls 90×2s then captures the
+   pane; on poll-exhaustion it must kill the session and capture a `stage-a-timeout` finding rather
+   than read a partial transcript and orphan the tmux session. And `dailySpendCapUsd` is presently a
+   run-count cap (`maxRoundsPerDay`) — wire real cost accounting or rename the knob before live.
+3. **Async tick.** The 180s poll runs on the `POST /mentor/tick` request thread; before live, return
+   `202` + poll completion via `/mentor/status` (avoid the gate-latency-vs-client-timeout failure).
+
+All three are gated behind `mentor.enabled=false` today and covered by the off→dry-run→live promotion
+discipline (each step needs Justin's sign-off), so the dormant ship is safe.
+
+## Testing
+
+- Tier 1 (unit): 8 `runMentorTick` (gate order: canary→budget→safe-window→Stage A→leak→Stage B→
+  capture; fail-closed budget before contact; leak capture; spawn-failure self-report) + 6 runner
+  (dormant short-circuit, busy/min-interval unsafe, status).
+- Tier 2 (integration): 4 — `/mentor/status` 503/200; `/mentor/tick` disabled-by-default + runs-when-enabled.
+- Tier 3 (e2e "alive"): 5 — real AgentServer boot, status 200-not-503 + dormant, tick disabled on the
+  production path, /capabilities surfaces it, 401 without auth, job template ships `enabled:false`.
+- Affected push-config suite vs canonical main: 3431 + 300 capability tests green, no regressions.
+
+## Reviewer second-pass
+
+**Concur with the review — with three non-blocking concerns to track.**
+
+Independent audit of `MentorOnboardingTick.ts`, `MentorOnboardingRunner.ts`, the `buildMentorRunner`
+wiring in `AgentServer.ts`, the `/mentor/status` + `/mentor/tick` handlers in `routes.ts`, and
+`MentorStageA.ts`/`ConfigDefaults.ts`. The core safety properties hold:
+
+- **Signal vs authority (Q1): clean.** The tick only writes to the read-only ledger via `capture`
+  and returns a `stageAMessage` string. It never kills/gates/blocks any component. `isMenteeBusy`
+  only makes the mentor skip *itself*. No brittle blocking authority anywhere.
+- **Fail-closed / canary-first (Q2): real.** Order in `runMentorTick` is canary → budget →
+  safe-window → Stage A → leak → Stage B → capture. The budget gate (line 108) precedes the only
+  spawn (line 116). Every skip returns early before `capture`, so there is no partial
+  Stage-A-without-capture. Canary failure self-reports and halts.
+- **Dormancy (Q3): genuinely inert.** `DEFAULT_MENTOR_CONFIG` and `ConfigDefaults.mentor` both ship
+  `enabled:false`/`mode:'off'`. `tick()` short-circuits to `{ran:false,reason:'disabled'}` BEFORE
+  touching any service. With defaults, `POST /mentor/tick` cannot spawn or spend. Verified by the
+  `enabled:true + mode:'off'` unit test.
+- **Budget/min-interval counters (Q5): no double-count, no bypass.** `onTickRan` fires only when
+  `result.ran` (runner line 95); all five skip reasons return `ran:false` → counters do not advance
+  → skipped ticks consume no budget.
+- **Two-hats (Q6): structurally enforced.** `STAGE_A_ALLOWED_TOOLS = []` is passed as
+  `allowedTools: [...STAGE_A_ALLOWED_TOOLS]`; the leak detector runs on the transcript and a leak is
+  captured as a finding. Empty-grant is CLI-enforced, not prompt-policed.
+
+**Concern 1 (non-blocking) — the artifact overstates live-mode delivery; there is in fact NO
+delivery path wired at all.** The artifact (lines 20, 44, 58) and the code comments
+(`MentorOnboardingTick.ts:155-156`, `155` "delivered only in `live` mode by the runner") describe a
+"persist-only path" that messages the mentee in `live` mode. That path does not exist: `tick()` in
+`MentorOnboardingRunner.ts` returns `stageAMessage` and the route handler in `routes.ts:4275-4276`
+simply JSON-returns the result; nothing ever forwards the message to the mentee (no
+`messageRouter`/`relay`/`inject` call in the runner, tick, or route — grep-confirmed). This is
+actually SAFER than advertised (live mode cannot contact anyone today — it is functionally
+dry-run-plus-counter), so it is not a blocking safety issue. But it makes the "Signal vs authority /
+live mode would message the mentee" framing inaccurate and means the highest-risk surface (actual
+outbound contact) is entirely unbuilt and *untested*. The "delivered via the persist-only path"
+comments should be corrected to "delivery is a tracked follow-on; live mode currently runs the loop
+without contacting the mentee," and the live-delivery work tracked alongside the §19.4 follow-on
+(topic-13435). Fix: amend the artifact + the two `MentorOnboardingTick.ts` comments; track delivery
+as not-yet-built.
+
+**Concern 2 (non-blocking) — the spawn poll can leak/orphan a Stage-A session, and the budget gate
+counts ticks, not dollars.** In `buildMentorRunner` (`AgentServer.ts:675-680`) the spawn polls
+90×2s = 180s for the session to disappear from `listRunningSessions()`. `maxDurationMinutes:5` does
+NOT bound the spawn within the poll window: the timeout is enforced lazily by the monitor tick with
+a 20%-or-60-min buffer (`SessionManager.ts:598-602`), so a wedged Stage-A session is only reaped at
+~6 min — after the poll has already given up at 3 min. When the poll falls through, the code
+captures whatever is on the pane and returns it as the "transcript" of an *unfinished* session
+(garbage-in to the leak detector), while the tmux session keeps running until the monitor reaps it.
+This is bounded (it will be reaped) and dormant today, but at live cadence (10-min floor, 24/day) a
+chronically-slow mentee could overlap a still-running prior Stage-A against the next tick's
+`isMenteeBusy` check (which would then correctly skip). Separately, `dailySpendCapUsd` (0.5) is
+declared in config and the artifact calls the gate a "daily spend cap," but `budgetOk` only checks
+`mentorRunsToday < maxRoundsPerDay` — it never accounts dollars. The cap is a *run-count* cap, not a
+spend cap. Fix before live promotion: (a) treat poll-exhaustion distinctly from
+session-completed — if the session is still running at 90 iterations, kill it explicitly and capture
+a `stage-a-timeout` finding rather than returning a partial pane as a clean transcript; (b) either
+wire `dailySpendCapUsd` to a real cost accounting (TokenLedger) or rename it / drop it from the
+config + artifact so it isn't mistaken for a spend ceiling.
+
+**Concern 3 (non-blocking) — the 180s synchronous poll runs on the request thread of
+`POST /mentor/tick`.** `tick()` awaits `spawnStageA`, which awaits the 90×2s loop, so a live tick
+holds the HTTP request open up to ~3 min. The built-in job is the only caller today and can tolerate
+it, but any client (or the job runner's own HTTP timeout) hitting `/mentor/tick` will block or 408
+mid-tick. This is the gate-latency-vs-client-timeout failure mode the team has hit before. The tick
+core is non-blocking; the issue is purely the synchronous-spawn wiring in `buildMentorRunner`. Not a
+dormant-mode risk. Fix before live: make `/mentor/tick` kick the tick and return `202 accepted`
+(fire-and-poll via `/mentor/status`), or bound the request with an explicit handler timeout that is
+distinct from spawn completion.
+
+None of the three blocks dormant ship: with `enabled:false` the tick never runs, so the spawn/poll,
+the (absent) delivery, and the spend-cap mislabel are all unreachable in production today. They are
+promotion-blockers for `live`, not ship-blockers for this dormant change. They must be resolved (and
+the delivery path actually built + tested) before `mentor.mode` is flipped to `live` — recommend the
+graduated-rollout track gate `dry-run → live` on closing all three.
+
+BLOCKING CONCERNS: 0

--- a/upgrades/side-effects/mentor-onboarding-job.md
+++ b/upgrades/side-effects/mentor-onboarding-job.md
@@ -174,3 +174,13 @@ the delivery path actually built + tested) before `mentor.mode` is flipped to `l
 graduated-rollout track gate `dry-run → live` on closing all three.
 
 BLOCKING CONCERNS: 0
+
+## Post-push CI fixes
+
+Two CI checks caught issues, both fixed:
+- `route-completeness.test.ts` requires every `catch (err)` to pair with an `err instanceof Error`
+  check; the `/mentor/tick` handler used `(err as Error).message`. Switched to
+  `err instanceof Error ? err.message : String(err)`.
+- `Docs Coverage` enforces a per-type floor; the new `mentor-onboarding` job dropped the `job`
+  floor (85%) since it was undocumented. Documented it in `reference/default-jobs.md` +
+  `architecture/the-living-system.md` (job coverage → 86%).


### PR DESCRIPTION
Fourth build PR of the **Framework-Onboarding Mentor System** (spec approved). Wires §19.1–3 into one heartbeat — the live loop, **shipped dormant**.

## What's in it

- **`runMentorTick`** (pure) — load-bearing order **canary → fail-closed budget → safe-window → Stage-A spawn → leak detector → Stage-B forensics → ledger capture**. All side-effects injected → fully unit-testable; the structural guarantees live in code, not a prompt.
- **`MentorOnboardingRunner`** — thin glue; short-circuits to `{ran:false,reason:'disabled'}` when off.
- **Routes** `GET /mentor/status` + `POST /mentor/tick` (Bearer; 503 when unwired).
- **AgentServer wiring** — Stage-A spawns with the **empty tool grant** (CLI-enforced two-hats), budget + min-interval counters advance only on a tick that ran.
- **`mentor.*` config** (off / mode:off; via ConfigDefaults → existing agents get it on migration) + a built-in **`mentor-onboarding` job** that ships `enabled:false`.

**Signal-only** — writes the read-only ledger; **no mentee-delivery path is wired yet**. Ships dormant: production default is `{ran:false,reason:'disabled'}` — no spawn, no spend, no contact.

## Phase-5 second-pass

A dedicated reviewer independently audited the spawn/gating logic: **concur, 0 blocking concerns**. Three **live-promotion blockers** (unreachable while dormant) are tracked for before `mode:live`: build the delivery path, spawn-poll robustness + real cost accounting, async tick (202 + poll). See `upgrades/side-effects/mentor-onboarding-job.md`.

## Testing

8 unit (gate order; **fail-closed budget before any spawn/contact**; leak capture; spawn-failure self-report) + 6 runner (dormant short-circuit; busy/min-interval unsafe) + 4 integration (routes) + 5 e2e (real server: dormant on the production path, /capabilities surfaces it, job ships `enabled:false`). Affected push-config suite green (3431 + 300 capability) vs canonical main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)