### PR TITLE
feat(feedback-factory): port Jaccard title-similarity primitives to TS (Phase 1, increment 2)

### DIFF
--- a/scripts/feedback-factory/_py_similarity_ref.py
+++ b/scripts/feedback-factory/_py_similarity_ref.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Parity reference: Jaccard title similarity from the REAL feedback-processor.py.
+
+Imports the reference processor without running its CLI main (same approach as
+_py_fingerprint_ref.py) and calls its actual `_jaccard_similarity` over a corpus
+of title PAIRS. Emits JSON {a, b, sim} so the Node harness can diff the TS port.
+
+Usage: python3 _py_similarity_ref.py <processor_path> <pairs_corpus_path>
+"""
+import sys
+import json
+import importlib.util
+
+
+def load_processor(path):
+    spec = importlib.util.spec_from_file_location("_feedback_processor_ref_sim", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: _py_similarity_ref.py <processor_path> <pairs_corpus_path>", file=sys.stderr)
+        sys.exit(2)
+    processor_path, corpus_path = sys.argv[1], sys.argv[2]
+    proc = load_processor(processor_path)
+    with open(corpus_path, encoding="utf-8") as f:
+        corpus = json.load(f)
+    out = []
+    for pair in corpus["pairs"]:
+        a, b = pair["a"], pair["b"]
+        sim = proc._jaccard_similarity(a, b)
+        out.append({"a": a, "b": b, "sim": repr(sim)})  # repr() = full-precision float string
+    sys.stdout.write(json.dumps(out, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/feedback-factory/similarity-corpus.json
+++ b/scripts/feedback-factory/similarity-corpus.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Parity corpus of title PAIRS for the Jaccard similarity port. Covers identical / disjoint / partial-overlap / boundary (≈0.35, ≈0.55) / empty / punctuation-only / non-ASCII-dropped cases. Both Python json.load and Node JSON.parse decode identical bytes, so the input is shared.",
+  "pairs": [
+    { "a": "GitSync.pull fails intermittently", "b": "GitSync.pull fails intermittently" },
+    { "a": "auth token refresh broken", "b": "completely unrelated database migration" },
+    { "a": "session reaper kills active session", "b": "session reaper kills idle session" },
+    { "a": "the quick brown fox", "b": "the quick red fox" },
+    { "a": "alpha beta gamma delta", "b": "alpha beta epsilon zeta" },
+    { "a": "one two three four five", "b": "one two three six seven" },
+    { "a": "a b c d e f g", "b": "a b c d h i j" },
+    { "a": "tunnel retry exhaustion notify", "b": "tunnel retry backoff" },
+    { "a": "", "b": "non empty title" },
+    { "a": "non empty title", "b": "" },
+    { "a": "", "b": "" },
+    { "a": "!!! ??? ...", "b": "more punctuation: ;;; ///" },
+    { "a": "café résumé naïve", "b": "cafe resume naive" },
+    { "a": "İstanbul ören", "b": "istanbul oren" },
+    { "a": "Straße über", "b": "strasse uber" },
+    { "a": "arabic ٣٤٥ digits", "b": "arabic digits" },
+    { "a": "MixedCASE Tokens HERE", "b": "mixedcase tokens here" },
+    { "a": "duplicate duplicate duplicate word", "b": "duplicate word" },
+    { "a": "v1.2.3 release notes", "b": "v9.9.9 release notes" },
+    { "a": "GitSync.pull deadlock under load", "b": "GitSync push deadlock under heavy load now" }
+  ]
+}

--- a/scripts/feedback-factory/similarity-parity.mjs
+++ b/scripts/feedback-factory/similarity-parity.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * similarity-parity.mjs — LOCAL parity gate for the Jaccard title-similarity port.
+ *
+ * Runs the REAL reference Python (`_jaccard_similarity` from
+ * the-portal/.claude/scripts/feedback-processor.py) and the TS port over the
+ * shared pairs corpus and asserts the similarity values match. Like the
+ * fingerprint harness this is a LOCAL evidence gate, not a CI test (CI lacks the
+ * reference checkout). Values should be bit-identical (same IEEE-754 division);
+ * we allow a 1e-12 tolerance only to absorb float-string serialization, and we
+ * ALSO assert the threshold decisions (≥0.35, ≥0.55) agree exactly — those are
+ * what actually drive clustering.
+ *
+ * Reference path: PORTAL_PROCESSOR env, else the default the-portal checkout.
+ * TS port is imported from the built dist (`npm run build` first).
+ *
+ * Exit 0 = parity; exit 1 = mismatch.
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+
+const PROCESSOR = process.env.PORTAL_PROCESSOR
+  || '/Users/justin/Documents/Projects/the-portal/.claude/scripts/feedback-processor.py';
+const CORPUS = path.join(__dirname, 'similarity-corpus.json');
+const PY_REF = path.join(__dirname, '_py_similarity_ref.py');
+const EPS = 1e-12;
+
+if (!fs.existsSync(PROCESSOR)) {
+  console.error(`[sim-parity] reference processor not found: ${PROCESSOR}`);
+  console.error('[sim-parity] set PORTAL_PROCESSOR to the reference feedback-processor.py');
+  process.exit(2);
+}
+
+const py = spawnSync('python3', [PY_REF, PROCESSOR, CORPUS], { encoding: 'utf8' });
+if (py.status !== 0) {
+  console.error('[sim-parity] python reference failed:\n', py.stderr || py.stdout);
+  process.exit(2);
+}
+const reference = JSON.parse(py.stdout);
+
+const distUrl = new URL('file://' + path.join(ROOT, 'dist', 'feedback-factory', 'processor', 'similarity.js'));
+const { jaccardSimilarity } = await import(distUrl.href);
+
+const decide = (v) => (v >= 0.55 ? 'fixed-merge' : v >= 0.35 ? 'merge' : 'no-merge');
+
+let mismatches = 0;
+for (const ref of reference) {
+  const pySim = Number(ref.sim);
+  const tsSim = jaccardSimilarity(ref.a, ref.b);
+  const valueOk = Math.abs(tsSim - pySim) < EPS;
+  const decisionOk = decide(tsSim) === decide(pySim);
+  if (!valueOk || !decisionOk) {
+    mismatches++;
+    console.error(`[MISMATCH] a=${JSON.stringify(ref.a)} b=${JSON.stringify(ref.b)}`);
+    console.error(`           python=${pySim} (${decide(pySim)})  ts=${tsSim} (${decide(tsSim)})`);
+  }
+}
+
+const total = reference.length;
+if (mismatches === 0) {
+  console.error(`[sim-parity] ✓ ${total}/${total} similarity values + threshold decisions match the reference Python.`);
+  process.exit(0);
+} else {
+  console.error(`[sim-parity] ✗ ${mismatches}/${total} mismatches — the TS port diverges from the reference.`);
+  process.exit(1);
+}

--- a/src/feedback-factory/processor/similarity.ts
+++ b/src/feedback-factory/processor/similarity.ts
@@ -1,0 +1,43 @@
+/**
+ * similarity.ts — TS port of the feedback-factory title-similarity primitives.
+ *
+ * Part of scar (c) of docs/specs/feedback-factory-migration.md. Byte-exact port
+ * of `_tokenize` (:1389) and `_jaccard_similarity` (:1394) from the reference
+ * `the-portal/.claude/scripts/feedback-processor.py`. These are the FUZZY match
+ * layer that sits on top of the exact-match fingerprint (fingerprint.ts): two
+ * reports whose titles overlap enough (Jaccard ≥ threshold) are candidates for
+ * the same cluster. The threshold-application logic (0.35 vs the 0.55 fixed-
+ * cluster false-merge guard) lives in the clustering driver and is a later
+ * increment; this module is the pure, parity-testable similarity primitive.
+ *
+ * Divergence surface (per spec / convergence): the TOKENIZER. Python
+ * `re.findall(r'[a-z0-9]+', text.lower())` is ASCII-only — non-ASCII letters and
+ * Unicode digits are token separators, NOT token content. JS `/[a-z0-9]+/g`
+ * (no `u`, no `i`) matches the identical ASCII class, so the only residual risk
+ * is `.lower()` vs `.toLowerCase()` on characters that then survive the ASCII
+ * filter. The parity harness verifies equivalence over the adversarial corpus.
+ */
+
+/** Port of Python `_tokenize` (:1391): ASCII word tokens of the lowercased text, deduped. */
+export function tokenize(text: string): Set<string> {
+  // Python: set(re.findall(r'[a-z0-9]+', text.lower())). re.findall returns
+  // non-overlapping matches; String.match(//g) is the JS equivalent (null when
+  // none → treat as empty). The class is ASCII (no `u` flag), matching Python.
+  const matches = text.toLowerCase().match(/[a-z0-9]+/g);
+  return new Set(matches ?? []);
+}
+
+/** Port of Python `_jaccard_similarity` (:1394): |A∩B| / |A∪B|, 0 when either side is empty. */
+export function jaccardSimilarity(text1: string, text2: string): number {
+  const t1 = tokenize(text1);
+  const t2 = tokenize(text2);
+  if (t1.size === 0 || t2.size === 0) return 0.0;
+  let intersection = 0;
+  for (const tok of t1) {
+    if (t2.has(tok)) intersection++;
+  }
+  // |A∪B| = |A| + |B| − |A∩B|. Integer division as float — IEEE-754 doubles in
+  // both Python and JS, so boundary comparisons (≥0.35, ≥0.55) agree.
+  const union = t1.size + t2.size - intersection;
+  return intersection / union;
+}

--- a/tests/unit/feedback-factory/similarity.test.ts
+++ b/tests/unit/feedback-factory/similarity.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests (Tier 1) — feedback-factory similarity primitives (scar c, fuzzy layer).
+ *
+ * Behavioral + both-sides-of-boundary coverage that runs in CI. Byte-exact
+ * equivalence to the reference Python is proven separately by the local parity
+ * harness (scripts/feedback-factory/similarity-parity.mjs). Golden values anchor
+ * the exact output so a tokenizer/division regression fails in CI too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tokenize, jaccardSimilarity } from '../../../src/feedback-factory/processor/similarity.js';
+
+describe('tokenize', () => {
+  it('lowercases and splits on non-[a-z0-9], deduping', () => {
+    expect(tokenize('GitSync.pull FAILS')).toEqual(new Set(['gitsync', 'pull', 'fails']));
+    expect(tokenize('duplicate duplicate word')).toEqual(new Set(['duplicate', 'word']));
+  });
+
+  it('is ASCII-only — non-ASCII letters/digits are separators, not tokens', () => {
+    // "café" → "caf" + "" ; arabic digits dropped; é/ß split tokens.
+    expect(tokenize('café')).toEqual(new Set(['caf']));
+    expect(tokenize('arabic ٣٤٥ digits')).toEqual(new Set(['arabic', 'digits']));
+    expect(tokenize('Straße')).toEqual(new Set(['stra', 'e']));
+  });
+
+  it('returns an empty set for punctuation-only / empty input', () => {
+    expect(tokenize('')).toEqual(new Set());
+    expect(tokenize('!!! ??? ...')).toEqual(new Set());
+  });
+});
+
+describe('jaccardSimilarity', () => {
+  it('is 1.0 for identical token sets', () => {
+    expect(jaccardSimilarity('the quick brown fox', 'the quick brown fox')).toBe(1.0);
+    // Case/punctuation differences that tokenize identically still score 1.0.
+    expect(jaccardSimilarity('GitSync.pull FAILS', 'gitsync pull fails')).toBe(1.0);
+  });
+
+  it('is 0.0 for fully disjoint token sets', () => {
+    expect(jaccardSimilarity('alpha beta gamma', 'one two three')).toBe(0.0);
+  });
+
+  it('is 0.0 when either side has no tokens (the empty guard)', () => {
+    expect(jaccardSimilarity('', 'non empty title')).toBe(0.0);
+    expect(jaccardSimilarity('non empty title', '')).toBe(0.0);
+    expect(jaccardSimilarity('!!!', 'something')).toBe(0.0);
+  });
+
+  it('computes |A∩B| / |A∪B| exactly', () => {
+    // {the,quick,brown,fox} vs {the,quick,red,fox}: ∩={the,quick,fox}=3, ∪=5 → 0.6
+    expect(jaccardSimilarity('the quick brown fox', 'the quick red fox')).toBeCloseTo(0.6, 12);
+    // {a,b,c,d,e,f,g} vs {a,b,c,d,h,i,j}: ∩=4, ∪=10 → 0.4
+    expect(jaccardSimilarity('a b c d e f g', 'a b c d h i j')).toBeCloseTo(0.4, 12);
+  });
+
+  it('orders the merge thresholds correctly (the clustering decision boundary)', () => {
+    // ∩=3,∪=5 → 0.6 ≥ 0.55 (fixed-cluster false-merge threshold)
+    expect(jaccardSimilarity('the quick brown fox', 'the quick red fox')).toBeGreaterThanOrEqual(0.55);
+    // ∩=4,∪=10 → 0.4: ≥0.35 (default merge) but <0.55 (would NOT merge into a fixed cluster)
+    const mid = jaccardSimilarity('a b c d e f g', 'a b c d h i j');
+    expect(mid).toBeGreaterThanOrEqual(0.35);
+    expect(mid).toBeLessThan(0.55);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,27 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Second increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, approved). Ports the **fuzzy title-similarity primitives** — `_tokenize` + `_jaccard_similarity` — from the reference Python (`the-portal/.claude/scripts/feedback-processor.py`) to TypeScript at `src/feedback-factory/processor/similarity.ts`.
+
+These sit on top of the exact-match fingerprinter shipped in the previous increment: the fingerprint groups identically-normalized reports, and Jaccard similarity is the fuzzy layer that decides whether two *differently-worded* titles overlap enough to be the same bug (the input to the clustering merge thresholds). Still an internal building block — **not wired into any route or job yet**, so no behavioral change.
+
+## What to Tell Your User
+
+- More groundwork for moving the feedback system in-house — the piece that recognizes two differently-worded reports as the same underlying issue.
+- Same discipline as before: I proved my rewrite produces the same similarity scores AND the same group/don't-group decisions as Dawn's original, across 20 title pairs including the tricky non-English-text ones.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Title-similarity primitives (TS port) | Internal module `src/feedback-factory/processor/similarity.ts` — not yet wired |
+| Similarity parity harness | `node scripts/feedback-factory/similarity-parity.mjs` (local; set `PORTAL_PROCESSOR`) |
+
+## Evidence
+
+- **Parity vs the real reference Python:** ran `_jaccard_similarity` from the reference processor and the TS port over 20 title pairs (identical / disjoint / partial-overlap / near the 0.35 and 0.55 merge thresholds / empty / punctuation-only / non-ASCII). Result: **20/20 match** — both the raw similarity value and the merge-threshold decision (the math is bit-identical IEEE-754 division; the harness asserts the *decision* too, since that is what actually drives clustering).
+- **ASCII-tokenizer fidelity:** the reference tokenizer is ASCII-only (`[a-z0-9]+` after lowercasing), so the port uses the identical ASCII class — non-English letters and non-ASCII digits are separators in both, verified by the corpus.
+- **CI anchors:** unit tests assert exact ratios (0.6, 0.4) and the threshold ordering, so a tokenizer/division regression fails in CI even without the reference checkout.

--- a/upgrades/side-effects/feedback-factory-similarity.md
+++ b/upgrades/side-effects/feedback-factory-similarity.md
@@ -1,0 +1,32 @@
+# Side-Effects Review — feedback-factory similarity primitives (Phase 1, increment 2)
+
+**Slug:** `feedback-factory-similarity`
+**Date:** `2026-05-26`
+**Author:** Echo
+**Spec:** `docs/specs/feedback-factory-migration.md` (converged v2, approved by Justin 2026-05-26)
+**Scope:** The fuzzy title-similarity primitives — `_tokenize` (:1389) and `_jaccard_similarity` (:1394) of the reference processor — which sit on top of the exact-match fingerprint (increment 1) and underpin scar (c)'s false-merge guard. The threshold-application/clustering driver and the other scars are subsequent increments.
+
+## Summary of the change
+
+Ports `_tokenize` + `_jaccard_similarity` from `the-portal/.claude/scripts/feedback-processor.py` to `src/feedback-factory/processor/similarity.ts`. Pure functions, no I/O. **Not wired into any route/job yet** — no behavioral change. Adds the similarity parity harness (`scripts/feedback-factory/similarity-parity.mjs` + `_py_similarity_ref.py` + `similarity-corpus.json`) and Tier-1 unit tests.
+
+## Equivalence verification
+
+- **20/20 title pairs match the reference Python** — both the raw similarity value (1e-12 tolerance for float-string serialization only; the math is bit-identical IEEE-754 division) AND the threshold decisions (`≥0.55` fixed-merge, `≥0.35` merge, else no-merge), which are what actually drive clustering.
+- The tokenizer is ASCII-only in the reference (`re.findall(r'[a-z0-9]+', text.lower())`), so the JS port uses the identical ASCII class `/[a-z0-9]+/g` (no `u`, no `i`). Non-ASCII letters and Unicode digits are separators in both — verified by corpus entries (café→{caf}, arabic digits dropped, Straße→{stra,e}).
+
+## Seven-dimension review
+
+1. **Over/under-reach** — Pure deterministic functions, no I/O, no global state, not imported by any runtime path. Cannot affect existing behavior. Risk is equivalence-to-reference, addressed above.
+2. **Level-of-abstraction fit** — Processor-logic layer (`src/feedback-factory/processor/`), alongside the fingerprint port. Correct home.
+3. **Signal vs Authority** — N/A; pure computation. The threshold constants that turn a similarity score into a merge decision live in the (later) clustering driver, where the curated-lifecycle authority also lives.
+4. **Interactions** — None. New isolated module; nothing imports it yet. Parity scripts are LOCAL-only (external reference path via `PORTAL_PROCESSOR`), no CI dependency on the reference checkout.
+5. **Rollback cost** — Trivial: delete the module + tests + scripts. No data, no migration, no wiring.
+6. **Migration parity** — N/A. New internal library code; touches no agent-installed file.
+7. **Failure modes** — (a) Port diverges from reference → caught by the parity harness (20/20) + golden-shaped unit assertions in CI. (b) Float boundary divergence at exactly 0.35/0.55 → mitigated by identical IEEE-754 division + the parity harness asserting threshold DECISIONS, not just values. (c) Reference path absent → harness exits 2 with a clear message (local gate, not CI).
+
+## Tests
+
+- Tier-1 unit (CI): `tests/unit/feedback-factory/similarity.test.ts` — `tokenize` (lowercase/split/dedup, ASCII-only behavior, empty/punctuation), `jaccardSimilarity` (identical=1.0, disjoint=0.0, empty-guard=0.0, exact ∩/∪ ratios, threshold ordering). 8 tests.
+- Parity (local gate, evidence): `scripts/feedback-factory/similarity-parity.mjs` → **20/20** values + threshold decisions identical to the reference Python.
+- No integration/E2E this increment: not yet wired to a route/job; those tiers attach when the clustering driver + receiver land. Reasoned decision, documented.


### PR DESCRIPTION
Second increment of the approved **Feedback Factory Migration** (`docs/specs/feedback-factory-migration.md`, converged v2, approved).

## Summary
Byte-exact port of `_tokenize` (:1389) + `_jaccard_similarity` (:1394) from the reference `the-portal/.claude/scripts/feedback-processor.py` to `src/feedback-factory/processor/similarity.ts`. This is the **fuzzy match layer** on top of the exact-match fingerprinter (increment 1, PR #407): it decides whether two differently-worded titles overlap enough to be the same bug — the input to the clustering merge thresholds (scar c). Pure functions; **not wired into any route/job yet** — no behavioral change.

## Why this is safe / verified
- The reference tokenizer is ASCII-only (`re.findall(r'[a-z0-9]+', text.lower())`), so the port uses the identical ASCII class `/[a-z0-9]+/g` (no `u`, no `i`).
- **20/20 title pairs match the reference Python** on BOTH the raw similarity value (bit-identical IEEE-754 division) AND the merge-threshold decision (`≥0.55` fixed-merge / `≥0.35` merge / no-merge) — the decision is what actually drives clustering. Harness: `scripts/feedback-factory/similarity-parity.mjs` (local; reuses the increment-1 methodology).
- Unit tests anchor exact ratios (0.6, 0.4) + threshold ordering so a tokenizer/division regression fails in CI without the reference checkout.

## Tests
- Tier-1 unit (CI): `tests/unit/feedback-factory/similarity.test.ts` — 8 tests.
- Parity (local gate, evidence): 20/20.
- No integration/E2E this increment — not wired to a route/job yet (reasoned, in the side-effects artifact).

## Test plan
- [x] `npm run test:push` green (988 files / 18,551 tests; one transient flake on first run, clean on re-run)
- [x] Similarity parity 20/20 vs reference Python
- [ ] CI green