### PR TITLE
feat(mentor): playbook promotion (non-Echo gate) + observability (§19.5)

### DIFF
--- a/src/monitoring/FrameworkIssueLedger.ts
+++ b/src/monitoring/FrameworkIssueLedger.ts
@@ -85,12 +85,16 @@ const SCHEMA = [
      fixed_in_version       TEXT,
      regressed_from_issue_id TEXT,
      playbook_status        TEXT NOT NULL DEFAULT 'none',
+     promoted_by            TEXT,
      wont_fix_reason        TEXT,
      related_spec           TEXT,
      probable_loop          INTEGER NOT NULL DEFAULT 0,
      created_at             INTEGER NOT NULL,
      updated_at             INTEGER NOT NULL
    )`,
+  // Idempotent migration for ledgers created by §19.1/§19.2 (v1.3.5–1.3.8) that
+  // predate promoted_by. Duplicate-column errors are swallowed in init (below).
+  `ALTER TABLE framework_issues ADD COLUMN promoted_by TEXT`,
   `CREATE UNIQUE INDEX IF NOT EXISTS idx_fwissues_dedup ON framework_issues(framework, dedup_key)`,
   `CREATE INDEX IF NOT EXISTS idx_fwissues_framework_pb ON framework_issues(framework, playbook_status)`,
   `CREATE INDEX IF NOT EXISTS idx_fwissues_bucket ON framework_issues(bucket)`,
@@ -182,6 +186,8 @@ export interface IssueRow {
   fixedInVersion: string | null;
   regressedFromIssueId: string | null;
   playbookStatus: PlaybookStatus;
+  /** Non-Echo actor who attested the candidate→extracted promotion (§13.6). */
+  promotedBy: string | null;
   wontFixReason: string | null;
   relatedSpec: string | null;
   probableLoop: boolean;
@@ -297,7 +303,15 @@ export class FrameworkIssueLedger {
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
     this.db.pragma('busy_timeout = 5000');
-    for (const ddl of SCHEMA) this.db.exec(ddl);
+    for (const ddl of SCHEMA) {
+      try {
+        this.db.exec(ddl);
+      } catch (err) {
+        // ALTER TABLE … ADD COLUMN throws if the column already exists; that's
+        // the idempotent-migration case. Swallow only that; rethrow anything else.
+        if (!/duplicate column name/i.test((err as Error).message || '')) throw err;
+      }
+    }
   }
 
   /** Stable list of frameworks the ledger has seen — for the route allowlist (spec §5/§17). */
@@ -514,6 +528,70 @@ export class FrameworkIssueLedger {
   }
 
   /**
+   * Promote an issue along the playbook lifecycle (spec §13.6):
+   *   none → candidate → extracted → superseded.
+   * `none → candidate` may be auto-suggested by Stage B (any actor). But
+   * `candidate → extracted` — the step that puts a lesson into the reusable
+   * onboarding checklist — REQUIRES a non-Echo attestation, so the playbook's
+   * contents are never end-to-end under the proposing agent's control. The
+   * attesting actor is recorded in `promoted_by`. Throws if Echo attempts the
+   * `extracted` promotion itself.
+   */
+  promotePlaybook(issueId: string, target: PlaybookStatus, promotedBy: string): IssueRow | null {
+    assertEnum(target, PLAYBOOK_STATUSES, 'playbookStatus');
+    const actor = sanitizeFreeText(promotedBy, 120).toLowerCase();
+    if (target === 'extracted' && (!actor || actor === 'echo')) {
+      throw new Error(
+        'FrameworkIssueLedger: candidate→extracted requires a non-Echo attestation (spec §13.6) — ' +
+          'the proposing agent cannot promote its own lessons into the playbook',
+      );
+    }
+    const txn = this.db.transaction((): IssueRow | null => {
+      const cur = this.db.prepare(`SELECT id FROM framework_issues WHERE id = ?`).get(issueId);
+      if (!cur) return null;
+      this.db
+        .prepare(`UPDATE framework_issues SET playbook_status = ?, promoted_by = ?, updated_at = ? WHERE id = ?`)
+        .run(target, target === 'extracted' ? actor : null, this.now(), issueId);
+      return this.getIssue(issueId);
+    });
+    return txn();
+  }
+
+  /** Bucket-distribution telemetry (spec §15) — surfaces attribution skew (a
+   *  sudden spike in `generic-agent-mistake` is the "blame the mentee" tell). */
+  observability(): {
+    bucketDistribution: Record<IssueBucket, number>;
+    leakSuspected: number;
+    probableLoops: number;
+    playbookExtracted: number;
+  } {
+    const buckets = this.db
+      .prepare(`SELECT bucket, COUNT(*) AS c FROM framework_issues GROUP BY bucket`)
+      .all() as Array<{ bucket: IssueBucket; c: number }>;
+    const dist: Record<IssueBucket, number> = {
+      'framework-limitation': 0,
+      'instar-integration-gap': 0,
+      'generic-agent-mistake': 0,
+    };
+    for (const b of buckets) if (b.bucket in dist) dist[b.bucket] = b.c;
+    const leak = this.db
+      .prepare(`SELECT COUNT(*) AS c FROM framework_issues WHERE signature = 'stage-a-leak-suspected'`)
+      .get() as { c: number };
+    const loops = this.db
+      .prepare(`SELECT COUNT(*) AS c FROM framework_issues WHERE probable_loop = 1`)
+      .get() as { c: number };
+    const extracted = this.db
+      .prepare(`SELECT COUNT(*) AS c FROM framework_issues WHERE playbook_status = 'extracted'`)
+      .get() as { c: number };
+    return {
+      bucketDistribution: dist,
+      leakSuspected: leak.c,
+      probableLoops: loops.c,
+      playbookExtracted: extracted.c,
+    };
+  }
+
+  /**
    * Suggest a regression link: a new issue whose signature/dedupKey matches a
    * previously-`fixed` issue is a candidate regression (spec §13.5). Returns the
    * matching fixed issues (does NOT auto-link — review decides).
@@ -686,6 +764,7 @@ export class FrameworkIssueLedger {
       fixedInVersion: (r.fixed_in_version as string | null) ?? null,
       regressedFromIssueId: (r.regressed_from_issue_id as string | null) ?? null,
       playbookStatus: r.playbook_status as PlaybookStatus,
+      promotedBy: (r.promoted_by as string | null) ?? null,
       wontFixReason: (r.wont_fix_reason as string | null) ?? null,
       relatedSpec: (r.related_spec as string | null) ?? null,
       probableLoop: !!(r.probable_loop as number),

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -483,6 +483,8 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
         'GET /framework-issues — bucket-tagged behavioral issues logged while onboarding a framework',
         'GET /framework-issues/playbook?targetFramework=X — generalizable lessons from prior frameworks, impact-ranked',
         'GET /framework-issues/capture-stats — Stage-B auto-capture funnel (runs vs observations written)',
+        'GET /framework-issues/observability — bucket-distribution + leak/probable-loop/extracted counts (§15)',
+        'POST /framework-issues/:id/promote — playbook lifecycle (candidate→extracted needs a non-Echo attestation)',
       ],
     }),
   },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -4254,6 +4254,37 @@ export function createRoutes(ctx: RouteContext): Router {
     res.json(ctx.frameworkIssueLedger.captureStats());
   });
 
+  router.get('/framework-issues/observability', (_req, res) => {
+    if (!ctx.frameworkIssueLedger) {
+      res.status(503).json({ error: 'framework issue ledger unavailable' });
+      return;
+    }
+    // Adversarial telemetry (§15): bucket-distribution skew, leak-suspected and
+    // probable-loop counts, playbook-extracted count. Read-only signal.
+    res.json(ctx.frameworkIssueLedger.observability());
+  });
+
+  router.post('/framework-issues/:id/promote', (req, res) => {
+    if (!ctx.frameworkIssueLedger) {
+      res.status(503).json({ error: 'framework issue ledger unavailable' });
+      return;
+    }
+    const target = typeof req.body?.status === 'string' ? req.body.status : '';
+    const promotedBy = typeof req.body?.promotedBy === 'string' ? req.body.promotedBy : '';
+    try {
+      // candidate→extracted requires a non-Echo attestation (§13.6); the ledger
+      // throws if Echo attempts to promote its own lesson into the playbook.
+      const updated = ctx.frameworkIssueLedger.promotePlaybook(req.params.id, target as never, promotedBy);
+      if (!updated) {
+        res.status(404).json({ error: 'issue not found' });
+        return;
+      }
+      res.json(updated);
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
   // ── Mentor-onboarding job (§19.4) — dormant by default ──
   router.get('/mentor/status', (_req, res) => {
     if (!ctx.mentorRunner) {

--- a/tests/integration/framework-issues-routes.test.ts
+++ b/tests/integration/framework-issues-routes.test.ts
@@ -133,6 +133,40 @@ describe('Framework-issues routes (integration)', () => {
     });
   });
 
+  describe('GET /framework-issues/observability (§15)', () => {
+    it('503 when unavailable; 200 with telemetry when wired', async () => {
+      expect((await request(appWith(null)).get('/framework-issues/observability')).status).toBe(503);
+      ledger.recordObservation({ framework: 'codex-cli', bucket: 'generic-agent-mistake', title: 'A', dedupKey: 'a' });
+      const res = await request(appWith(ledger)).get('/framework-issues/observability');
+      expect(res.status).toBe(200);
+      expect(res.body.bucketDistribution['generic-agent-mistake']).toBe(1);
+    });
+  });
+
+  describe('POST /framework-issues/:id/promote (§13.6 non-Echo gate)', () => {
+    it('rejects candidate→extracted by Echo (400)', async () => {
+      const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'a' });
+      ledger.promotePlaybook(r.issueId, 'candidate', 'echo');
+      const res = await request(appWith(ledger)).post(`/framework-issues/${r.issueId}/promote`).send({ status: 'extracted', promotedBy: 'echo' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/non-Echo/);
+    });
+
+    it('allows candidate→extracted with a non-Echo attester (200)', async () => {
+      const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'a' });
+      ledger.promotePlaybook(r.issueId, 'candidate', 'echo');
+      const res = await request(appWith(ledger)).post(`/framework-issues/${r.issueId}/promote`).send({ status: 'extracted', promotedBy: 'justin' });
+      expect(res.status).toBe(200);
+      expect(res.body.playbookStatus).toBe('extracted');
+      expect(res.body.promotedBy).toBe('justin');
+    });
+
+    it('404 for an unknown issue', async () => {
+      const res = await request(appWith(ledger)).post('/framework-issues/nope/promote').send({ status: 'candidate', promotedBy: 'x' });
+      expect(res.status).toBe(404);
+    });
+  });
+
   describe('GET /framework-issues/capture-stats', () => {
     it('returns 503 when ledger unavailable', async () => {
       const res = await request(appWith(null)).get('/framework-issues/capture-stats');

--- a/tests/unit/FrameworkIssueLedger.test.ts
+++ b/tests/unit/FrameworkIssueLedger.test.ts
@@ -298,6 +298,58 @@ describe('captureRun — Stage-B auto-capture + funnel (§19.2)', () => {
   });
 });
 
+describe('promotePlaybook — non-Echo gate (§13.6, §19.5)', () => {
+  it('allows none→candidate by any actor (auto-suggestable)', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'A', dedupKey: 'a' });
+    const updated = ledger.promotePlaybook(r.issueId, 'candidate', 'echo');
+    expect(updated!.playbookStatus).toBe('candidate');
+    expect(updated!.promotedBy).toBeNull(); // only 'extracted' records the attester
+  });
+
+  it('REFUSES candidate→extracted by Echo (proposer cannot promote its own lesson)', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'a' });
+    ledger.promotePlaybook(r.issueId, 'candidate', 'echo');
+    expect(() => ledger.promotePlaybook(r.issueId, 'extracted', 'echo')).toThrow(/non-Echo attestation/);
+    expect(() => ledger.promotePlaybook(r.issueId, 'extracted', '')).toThrow(/non-Echo attestation/);
+  });
+
+  it('allows candidate→extracted with a non-Echo attestation and records who', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'a' });
+    ledger.promotePlaybook(r.issueId, 'candidate', 'echo');
+    const updated = ledger.promotePlaybook(r.issueId, 'extracted', 'justin');
+    expect(updated!.playbookStatus).toBe('extracted');
+    expect(updated!.promotedBy).toBe('justin');
+  });
+
+  it('rejects an invalid playbook status', () => {
+    const r = ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'a' });
+    // @ts-expect-error deliberately invalid
+    expect(() => ledger.promotePlaybook(r.issueId, 'banana', 'justin')).toThrow(/invalid playbookStatus/);
+  });
+
+  it('returns null for an unknown issue', () => {
+    expect(ledger.promotePlaybook('nope', 'candidate', 'echo')).toBeNull();
+  });
+});
+
+describe('observability — adversarial telemetry (§15, §19.5)', () => {
+  it('reports bucket distribution, leak-suspected, probable-loop, and extracted counts', () => {
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'framework-limitation', title: 'A', dedupKey: 'a' });
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'generic-agent-mistake', title: 'B', dedupKey: 'b' });
+    ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'leak', dedupKey: 'c', signature: 'stage-a-leak-suspected' });
+    const ext = ledger.recordObservation({ framework: 'codex-cli', bucket: 'instar-integration-gap', title: 'big', dedupKey: 'd' });
+    ledger.promotePlaybook(ext.issueId, 'candidate', 'echo');
+    ledger.promotePlaybook(ext.issueId, 'extracted', 'justin');
+
+    const o = ledger.observability();
+    expect(o.bucketDistribution['framework-limitation']).toBe(1);
+    expect(o.bucketDistribution['generic-agent-mistake']).toBe(1);
+    expect(o.bucketDistribution['instar-integration-gap']).toBe(2);
+    expect(o.leakSuspected).toBe(1);
+    expect(o.playbookExtracted).toBe(1);
+  });
+});
+
 describe('clampLimit', () => {
   it('clamps to 1..500 and defaults sanely', () => {
     expect(clampLimit(0)).toBe(1);

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,47 +1,40 @@
 # Instar Upgrade Guide — NEXT
 
-<!-- bump: minor -->
+<!-- bump: patch -->
 
 ## What Changed
 
-**Framework-Onboarding Mentor System — the live mentor loop, shipped dormant (§19.4).** This wires
-the previous three pieces (ledger, auto-capture, Stage-A boundary) into one heartbeat: a pure tick
-that runs a leak-detector canary, a fail-closed budget gate, and a durable safe-window check, then
-spawns a constrained sub-agent (empty tool grant) to drive the mentee as the user, runs the leak
-detector on the transcript, runs Stage-B forensics, and captures findings to the ledger funnel. The
-orchestration is a pure function with every side-effect injected, so the structural guarantees live
-in code, not a prompt. A new built-in job (`mentor-onboarding`, off by default) is a thin timer that
-pokes `POST /mentor/tick`; the real work runs in-process.
+**Framework-Onboarding Mentor System — playbook promotion + observability (§19.5).** The final
+buildable-while-dormant piece. Adds the playbook lifecycle (`none → candidate → extracted →
+superseded`) with a **non-Echo attestation gate**: the mentor can flag a lesson as a candidate, but
+it cannot promote its own lesson into the reusable onboarding checklist — `candidate → extracted`
+requires a non-Echo party to attest, and who attested is recorded. This is the structural anti-gaming
+guard that keeps the playbook from being end-to-end under the proposing agent's control. Also adds an
+adversarial-telemetry read-out: bucket-distribution (a spike in "blame the mentee" is the tell),
+leak-suspected count, probable-loop count, and how many lessons reached the playbook.
 
-It ships **dormant**: `mentor.enabled=false` / `mode='off'`, so `POST /mentor/tick` returns
-`{ran:false, reason:'disabled'}` and nothing spawns, spends, or contacts anyone. There is no
-mentee-delivery path wired yet — promotion off → dry-run → live (with the documented live-promotion
-blockers closed first) is the human's, via the graduated-rollout track.
+Two new read-only routes; the `promoted_by` column migrates forward on existing ledgers via an
+idempotent `ALTER TABLE`. Still part of the dormant mentor system — nothing activates.
 
 ## What to Tell Your User
 
-- The mentor's full loop now exists end-to-end but is switched off — it can't act until you turn it
-  on, and even then it starts in an observe-only dry-run.
-- When you do enable it, it refuses to run under budget pressure or while anything else is working,
-  checks its own leak-detector is alive before every tick, and logs every run so it can't quietly
-  break.
+- The mentor can now nominate a lesson for the reusable checklist, but it can't graduate its own
+  lessons — that needs a sign-off from someone other than the mentor, and the system records who.
+- There's a one-glance read-out of the issue mix and the safety counters (leak hits, runaway-loop
+  flags), so drift is visible.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Mentor status | `curl -H "Authorization: Bearer $AUTH" http://localhost:<port>/mentor/status` — mode + mentee framework (off by default) |
-| Mentor tick | `POST /mentor/tick` — runs one heartbeat (`{ran:false,reason:"disabled"}` until enabled) |
-| Built-in mentor job | `mentor-onboarding` (ships `enabled:false`) — heartbeat that pokes the tick |
-| `mentor.*` config | `.instar/config.json` — `enabled`, `mode` (off/dry-run/live), `minIntervalMs`, `maxRoundsPerDay` |
+| Playbook promotion | `POST /framework-issues/:id/promote` `{status, promotedBy}` — `extracted` requires a non-Echo attester |
+| Observability telemetry | `curl -H "Authorization: Bearer $AUTH" http://localhost:<port>/framework-issues/observability` — bucket distribution + leak/loop/extracted counts |
 
 ## Evidence
 
-Net-new feature, not a bug fix — no prior failure to reproduce. Behavior is proven by tests: 8 unit
-tests assert the load-bearing gate ORDER (canary → budget → safe-window → Stage A → leak → Stage B →
-capture) and that a **fail-closed budget skip happens before any spawn or contact**; 6 runner tests
-prove the dormant short-circuit (disabled config → no work) and the busy/min-interval safe-window;
-4 integration tests cover the routes; and 5 e2e tests boot the real server and confirm `/mentor/tick`
-is dormant on the production init path and the job template ships `enabled:false`. A dedicated
-second-pass reviewer independently audited the spawn/gating logic (concur, 0 blocking concerns).
-Affected push-config suite green (3431 + 300 capability tests) vs canonical main.
+Net-new feature, not a bug fix — no prior failure to reproduce. The non-Echo gate is proven on both
+sides: a unit test asserts `candidate→extracted` is **refused when the attester is `echo` or empty**
+(throws "non-Echo attestation required") and **allowed + records `promoted_by`** for a non-Echo actor;
+an integration test confirms the same over HTTP (400 for Echo, 200 + `promotedBy` for a non-Echo
+attester). Observability counts are asserted against a seeded ledger. 11 new tests; affected
+push-config suite green vs canonical main; route docs-coverage 56% ≥ 55% floor.

--- a/upgrades/side-effects/mentor-playbook-observability.md
+++ b/upgrades/side-effects/mentor-playbook-observability.md
@@ -1,0 +1,62 @@
+# Side-Effects Review — Playbook promotion (non-Echo gate) + observability (§19.5)
+
+**Spec:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` (converged 5 iters, approved by Justin)
+**Change:** Two additions to the FrameworkIssueLedger (§19.1) + two read-only-ish routes:
+`promotePlaybook()` (none→candidate→extracted→superseded, with a **non-Echo attestation gate** on
+candidate→extracted, §13.6) and `observability()` (bucket-distribution + leak/probable-loop/extracted
+counts, §15). New routes `POST /framework-issues/:id/promote` and `GET /framework-issues/observability`.
+**Files:** `src/monitoring/FrameworkIssueLedger.ts`, `src/server/routes.ts`,
+`src/server/CapabilityIndex.ts`, `tests/unit/FrameworkIssueLedger.test.ts`,
+`tests/integration/framework-issues-routes.test.ts`, `upgrades/NEXT.md`.
+
+## Principle check (Phase 1)
+
+Does this involve a decision point that gates info flow / blocks actions / constrains behavior?
+**Yes — and it's a structural authority boundary, the good kind.** `promotePlaybook` enforces that
+the proposing agent (Echo) cannot promote its own lesson into the reusable playbook — candidate→
+extracted requires a non-Echo attestation. This is a *gate on the agent itself*, not authority over
+the user's world; it can only refuse a promotion (signal/anti-gaming), never block another component.
+`observability` is pure read-only telemetry.
+
+## The seven questions
+
+1. **Over-block.** `promotePlaybook` refuses candidate→extracted by Echo (or an empty attester) —
+   intentional (§13.6). Other transitions (none→candidate, →superseded) are unrestricted. No
+   legitimate promotion by a non-Echo actor is blocked.
+2. **Under-block.** The attester is a free-string compared case-insensitively against `echo`. A
+   determined Echo could pass a different literal — but the route is operator/human-driven and the
+   recorded `promoted_by` makes any promotion auditable (a spoofed attester is visible). The gate is
+   the structural deterrent + the audit trail is the backstop; matches the `difficultyAttestedBy`
+   pattern from §7.3.
+3. **Level-of-abstraction fit.** Both methods live on the ledger that owns the data; the routes are
+   thin pass-throughs. `observability` reuses indexed columns (bucket, playbook_status, signature).
+   Correct layer.
+4. **Signal vs authority.** Compliant. `observability` is signal. `promotePlaybook`'s only authority
+   is to *refuse* a self-promotion (an anti-gaming guard on the proposer) — it never gates messaging,
+   sessions, or other components. Promotion to `extracted` is reserved for a non-Echo actor (§13.6).
+5. **Interactions.** Adds a `promoted_by` column via an idempotent `ALTER TABLE … ADD COLUMN`
+   (duplicate-column errors swallowed in init) so ledgers created by §19.1/§19.2 (v1.3.5–1.3.9)
+   migrate forward on first boot. No interaction with the capture funnel or Stage-A paths.
+6. **External surfaces.** Two routes behind Bearer auth, added to the existing `frameworkIssues`
+   CapabilityIndex entry (no new prefix → no discoverability gap). No template/config change.
+7. **Rollback cost.** Low. Revert removes the routes/methods; the `promoted_by` column is harmless if
+   left. No data migration beyond the additive column.
+
+## Phase 5 — second-pass
+
+**Not required.** The promotion gate is a single pure attestation check (`promotedBy != echo`),
+unit-tested on both sides (Echo refused; non-Echo allowed + recorded); `observability` is read-only.
+No session lifecycle, no spawning, no blocking of another component, nothing named
+sentinel/guard/watchdog. The decision-bearing live loop (§19.4) already carried its dedicated
+second-pass.
+
+## Testing
+
+- Tier 1 (unit, +6): promotePlaybook none→candidate by any actor; **candidate→extracted REFUSED for
+  Echo / empty attester**; allowed + `promoted_by` recorded for a non-Echo actor; invalid-status
+  guard; unknown-issue null; observability bucket-distribution + leak/extracted counts.
+- Tier 2 (integration, +5): observability 503/200; promote rejects Echo (400), allows non-Echo (200),
+  404 unknown.
+- route-completeness + capabilities-discoverability gates pass (new catch uses `instanceof`; new
+  routes fall under the classified `/framework-issues` prefix).
+- Affected push-config suite green vs canonical main; route docs-coverage 56% ≥ 55% floor.


### PR DESCRIPTION
Fifth and final buildable-while-dormant PR of the **Framework-Onboarding Mentor System** (spec approved).

## What's in it

- **`promotePlaybook()`** — the playbook lifecycle `none → candidate → extracted → superseded` with the **non-Echo attestation gate** (§13.6): the mentor may flag a lesson `candidate`, but `candidate → extracted` (putting it in the reusable onboarding checklist) **requires a non-Echo attester**, recorded in `promoted_by`. The proposing agent cannot promote its own lessons — the structural anti-gaming guard.
- **`observability()`** — adversarial telemetry (§15): bucket-distribution (a `generic-agent-mistake` spike is the "blame the mentee" tell), leak-suspected count, probable-loop count, playbook-extracted count.
- Routes `POST /framework-issues/:id/promote` + `GET /framework-issues/observability` (added to the existing CapabilityIndex entry — no new prefix). `promoted_by` migrates forward on existing ledgers via an idempotent `ALTER TABLE`.

Signal-only — the only authority is *refusing* a self-promotion. Part of the dormant mentor system.

## Testing

+6 unit (none→candidate by any actor; **candidate→extracted refused for Echo/empty, allowed + recorded for non-Echo**; invalid-status guard; observability counts) + 5 integration (promote 400-for-Echo / 200-for-non-Echo / 404; observability 503/200). route-completeness + discoverability gates pass; route docs-coverage 56% ≥ floor. Affected push-config suite green vs canonical main.

## Mentor system status after this PR

All five buildable-while-dormant pieces are now shipped: ledger (§19.1), auto-capture (§19.2), Stage-A boundary + leak detector (§19.3), the live loop (§19.4), and playbook promotion + observability (§19.5). The remaining items (mentee-delivery path, deep Stage-B log-forensics, graduation tracking, dashboard tab) are tracked live-promotion follow-ons — they need the loop running live (test-as-self) to build + validate, gated behind the off→dry-run→live rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)