### PR TITLE
feat(mentor): Stage-B deep forensics — read mentee signals + classify to ledger

### DIFF
--- a/src/scheduler/MentorStageBForensics.ts
+++ b/src/scheduler/MentorStageBForensics.ts
@@ -1,0 +1,118 @@
+/**
+ * MentorStageBForensics — the "look under the hood" analysis of Stage B
+ * (FRAMEWORK-ONBOARDING-MENTOR-SPEC §3.2, §19.4 deep-forensics follow-on).
+ *
+ * After Stage A drives the mentee, Stage B reads the mentee's actual signals
+ * (recent rollout/session activity + server-log errors/sentinel events) and
+ * classifies what went wrong into the three buckets, writing findings to the
+ * ledger. This module is the PURE core: prompt assembly + defensive parsing of
+ * the LLM's classification. The I/O (reading rollouts/logs) and the LLM call are
+ * injected, so it's fully unit-testable without an LLM or the filesystem.
+ *
+ * Signal-only: produces ForensicFinding[] for the ledger; never gates or acts.
+ */
+import {
+  ISSUE_BUCKETS,
+  ISSUE_SEVERITIES,
+  type IssueBucket,
+  type IssueSeverity,
+  type ForensicFinding,
+} from '../monitoring/FrameworkIssueLedger.js';
+
+const MAX_FINDINGS_PER_RUN = 10; // bound a single tick's output
+const MAX_TITLE = 200;
+
+/** A normalized slug for a conservative dedupKey when the model omits one. */
+function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80) || 'untitled';
+}
+
+/**
+ * Build the Stage-B forensic prompt. The model is asked to classify ONLY what
+ * the signals actually evidence into the three buckets, and to output a strict
+ * JSON array — no prose. Conservative by instruction: report nothing rather than
+ * speculate (false findings poison the ledger/playbook).
+ */
+export function buildForensicPrompt(framework: string, signals: string): string {
+  return [
+    `You are the "developer hat" of a framework-onboarding mentor, doing forensics on the agent`,
+    `framework "${framework}". Below are real signals from its recent activity (logs, session`,
+    `usage, errors). Identify concrete behavioral issues these signals EVIDENCE — do not speculate.`,
+    `Classify each into exactly one bucket:`,
+    `  - "framework-limitation": the engine's own limit (e.g. argv overflow, context truncation)`,
+    `  - "instar-integration-gap": Instar not fitting this engine right (a wiring/config defect)`,
+    `  - "generic-agent-mistake": a one-off mistake any agent could make`,
+    ``,
+    `Output ONLY a JSON array (no markdown, no prose). Each element:`,
+    `  {"bucket": "...", "title": "<short>", "severity": "low|medium|high", "dedupKey": "<stable-id>"}`,
+    `If the signals evidence no concrete issue, output []. Never invent issues.`,
+    ``,
+    `--- Signals ---`,
+    signals.slice(0, 12000), // bound the prompt
+  ].join('\n');
+}
+
+/**
+ * Parse the model's forensic output into validated findings. Defensive: tolerates
+ * markdown fences / surrounding prose, drops malformed or invalid-enum entries,
+ * caps count + field lengths, and derives a conservative dedupKey when the model
+ * omits one. Returns [] on any parse failure (never throws — a bad forensic read
+ * must not crash a tick).
+ */
+export function parseForensicFindings(raw: string, framework: string): ForensicFinding[] {
+  if (!raw || !raw.trim()) return [];
+  // Extract the first JSON array in the output (tolerate ```json fences / prose).
+  const start = raw.indexOf('[');
+  const end = raw.lastIndexOf(']');
+  if (start === -1 || end === -1 || end <= start) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.slice(start, end + 1));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: ForensicFinding[] = [];
+  for (const item of parsed) {
+    if (out.length >= MAX_FINDINGS_PER_RUN) break;
+    if (!item || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    const bucket = o.bucket as string;
+    if (!ISSUE_BUCKETS.includes(bucket as IssueBucket)) continue; // drop invalid bucket
+    const title = typeof o.title === 'string' ? o.title.trim().slice(0, MAX_TITLE) : '';
+    if (!title) continue;
+    const severity: IssueSeverity = ISSUE_SEVERITIES.includes(o.severity as IssueSeverity)
+      ? (o.severity as IssueSeverity)
+      : 'medium';
+    const dedupKey =
+      typeof o.dedupKey === 'string' && o.dedupKey.trim()
+        ? `${framework}::${slug(o.dedupKey)}`
+        : `${framework}::${slug(title)}`;
+    out.push({ bucket: bucket as IssueBucket, title, severity, dedupKey, signature: title });
+  }
+  return out;
+}
+
+export interface AnalyzeForensicsInput {
+  framework: string;
+  /** Assembled forensic signals (log tail + session digest). Empty ⇒ no findings. */
+  signals: string;
+  /** The LLM call (injected — IntelligenceProvider.evaluate in production). */
+  evaluate: (prompt: string) => Promise<string>;
+}
+
+/**
+ * Run the Stage-B forensic analysis: classify the assembled signals into findings.
+ * Returns [] when there are no signals (nothing observed this tick) so the tick
+ * still records a run in the funnel. Never throws.
+ */
+export async function analyzeForensics(input: AnalyzeForensicsInput): Promise<ForensicFinding[]> {
+  if (!input.signals || !input.signals.trim()) return [];
+  let raw: string;
+  try {
+    raw = await input.evaluate(buildForensicPrompt(input.framework, input.signals));
+  } catch {
+    return []; // a failed forensic LLM call is a no-op tick, not a crash
+  }
+  return parseForensicFindings(raw, input.framework);
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -59,6 +59,8 @@ import { TokenLedgerPoller } from '../monitoring/TokenLedgerPoller.js';
 import { FrameworkIssueLedger } from '../monitoring/FrameworkIssueLedger.js';
 import { MentorOnboardingRunner, DEFAULT_MENTOR_CONFIG, type MentorConfig } from '../scheduler/MentorOnboardingRunner.js';
 import { STAGE_A_ALLOWED_TOOLS } from '../monitoring/MentorStageA.js';
+import { analyzeForensics } from '../scheduler/MentorStageBForensics.js';
+import { parseCodexRollout } from '../monitoring/CodexRolloutParser.js';
 import type { ForensicFinding } from '../monitoring/FrameworkIssueLedger.js';
 import { BurnDetector } from '../monitoring/BurnDetector.js';
 import { BurnThrottleRunbook } from '../monitoring/BurnThrottleRunbook.js';
@@ -648,9 +650,37 @@ export class AgentServer {
    * graduated-rollout track. The live spawn/forensics paths are real code, gated
    * behind that flag and validated via test-as-self before promotion.
    */
+  /** Find the N most recently-modified rollout .jsonl files under a codex sessions
+   *  dir (nested year/month/day). Best-effort; returns [] on any error. */
+  private findRecentRolloutFiles(sessionsDir: string, n: number): string[] {
+    const found: Array<{ path: string; mtime: number }> = [];
+    const walk = (dir: string, depth: number): void => {
+      if (depth > 5) return;
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) walk(full, depth + 1);
+        else if (e.name.endsWith('.jsonl')) {
+          try {
+            found.push({ path: full, mtime: fs.statSync(full).mtimeMs });
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    };
+    walk(sessionsDir, 0);
+    return found.sort((a, b) => b.mtime - a.mtime).slice(0, n).map((f) => f.path);
+  }
+
   private buildMentorRunner(
     ledger: FrameworkIssueLedger,
-    options: { config: unknown; intelligence?: import('../core/types.js').IntelligenceProvider | null },
+    options: { config: { stateDir?: string }; intelligence?: import('../core/types.js').IntelligenceProvider | null },
     serverDataDir: string,
   ): MentorOnboardingRunner {
     const getConfig = (): MentorConfig => ({
@@ -688,13 +718,46 @@ export class AgentServer {
           }
           return self.sessionManager.captureOutput(tmux, 200) ?? '';
         },
-        // Stage-B deep log-forensics (assembling the mentee's rollouts/diffs and
-        // classifying) is a tracked follow-on; today the loop's real signal is the
-        // Stage-A leak detector (§4.3). Returns [] when no forensic inputs exist so
-        // the funnel still logs the run. <!-- tracked: topic-13435 -->
-        runStageBForensics: async (): Promise<ForensicFinding[]> => {
-          void intelligence;
-          return [];
+        // Stage-B deep forensics (§3.2): assemble the mentee's real signals
+        // (recent server-log errors/sentinel lines + a codex-rollout usage digest)
+        // and classify them into bucketed findings via the LLM. Returns [] when no
+        // intelligence provider or no signals (so the funnel still logs the run).
+        // The pure prompt/parse logic lives in MentorStageBForensics (tested);
+        // this closure only does the I/O (read logs/rollouts).
+        runStageBForensics: async (framework: string): Promise<ForensicFinding[]> => {
+          if (!intelligence) return [];
+          let signals = '';
+          try {
+            const logPath = path.join(options.config.stateDir!, 'logs', 'server.log');
+            if (fs.existsSync(logPath)) {
+              const buf = fs.readFileSync(logPath, 'utf-8');
+              const errLines = buf
+                .split('\n')
+                .filter((l) => /error|sentinel|delivery|fail|timeout|degrad/i.test(l))
+                .slice(-40);
+              if (errLines.length) signals += `## Recent server-log signals\n${errLines.join('\n')}\n\n`;
+            }
+            // Codex-rollout usage digest (rate-limit pressure / token burn) for codex frameworks.
+            if (framework.startsWith('codex')) {
+              const sessionsDir = path.join(os.homedir(), '.codex', 'sessions');
+              const recent = self.findRecentRolloutFiles(sessionsDir, 3);
+              for (const f of recent) {
+                const parsed = parseCodexRollout(fs.readFileSync(f, 'utf-8'));
+                if (parsed) {
+                  signals += `## Codex session ${parsed.sessionId.slice(0, 8)} (model ${parsed.model ?? '?'})\n` +
+                    `tokens=${parsed.totalTokens} primaryRateLimit=${parsed.primaryUsedPercent ?? '?'}% ` +
+                    `secondaryRateLimit=${parsed.secondaryUsedPercent ?? '?'}% turns=${parsed.tokenCountEvents}\n\n`;
+                }
+              }
+            }
+          } catch (err) {
+            console.warn('[mentor] Stage-B signal gathering failed (non-fatal):', err);
+          }
+          return analyzeForensics({
+            framework,
+            signals,
+            evaluate: (prompt) => intelligence.evaluate(prompt, { model: 'capable', maxTokens: 1500, attribution: { component: 'mentor-stage-b' } }),
+          });
         },
         // Safe-window: any other running (non-protected) session means the system
         // is busy — conservative "don't interrupt." Refined per-mentee at live

--- a/tests/e2e/mentor-onboarding-lifecycle.test.ts
+++ b/tests/e2e/mentor-onboarding-lifecycle.test.ts
@@ -80,6 +80,19 @@ describe('Mentor-onboarding E2E lifecycle (alive + dormant)', () => {
     expect((await request(app).get('/mentor/status')).status).toBe(401);
   });
 
+  it('boots clean with the Stage-B forensics wiring (server alive, mentor dormant)', async () => {
+    // PR B wires real Stage-B forensics (rollout/log reading + LLM classify) into
+    // the runner. This asserts that wiring doesn't break boot and the mentor stays
+    // dormant on the production init path.
+    const status = await request(app).get('/mentor/status').set(auth());
+    expect(status.status).toBe(200);
+    expect(status.body.enabled).toBe(false);
+    // A dormant tick still returns disabled — the forensics path is never reached.
+    const tick = await request(app).post('/mentor/tick').set(auth());
+    expect(tick.status).toBe(200);
+    expect(tick.body).toEqual({ ran: false, reason: 'disabled' });
+  });
+
   it('the built-in mentor job template ships OFF by default', () => {
     const thisDir = path.dirname(fileURLToPath(import.meta.url));
     const repoRoot = path.resolve(thisDir, '..', '..');

--- a/tests/unit/MentorStageBForensics.test.ts
+++ b/tests/unit/MentorStageBForensics.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tier-1 unit tests for MentorStageBForensics — the Stage-B "look under the hood"
+ * analysis (FRAMEWORK-ONBOARDING-MENTOR-SPEC §3.2, §19.4).
+ *
+ * Defensive parsing is the load-bearing property: a bad LLM forensic read must
+ * never crash a tick or poison the ledger with malformed/invented findings.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildForensicPrompt,
+  parseForensicFindings,
+  analyzeForensics,
+} from '../../src/scheduler/MentorStageBForensics.js';
+
+describe('buildForensicPrompt', () => {
+  it('names the framework, the three buckets, and demands JSON-only output', () => {
+    const p = buildForensicPrompt('codex-cli', 'some error log');
+    expect(p).toContain('codex-cli');
+    expect(p).toMatch(/framework-limitation/);
+    expect(p).toMatch(/instar-integration-gap/);
+    expect(p).toMatch(/generic-agent-mistake/);
+    expect(p).toMatch(/JSON array/);
+    expect(p).toContain('some error log');
+  });
+  it('bounds the signals length', () => {
+    const p = buildForensicPrompt('x', 'a'.repeat(20000));
+    expect(p.length).toBeLessThan(13000);
+  });
+});
+
+describe('parseForensicFindings — defensive', () => {
+  it('parses a clean JSON array into validated findings', () => {
+    const raw = JSON.stringify([
+      { bucket: 'framework-limitation', title: 'argv overflow on long thread', severity: 'high', dedupKey: 'argv-overflow' },
+      { bucket: 'instar-integration-gap', title: 'hook not firing', severity: 'medium' },
+    ]);
+    const f = parseForensicFindings(raw, 'codex-cli');
+    expect(f).toHaveLength(2);
+    expect(f[0].bucket).toBe('framework-limitation');
+    expect(f[0].dedupKey).toBe('codex-cli::argv-overflow');
+    expect(f[1].dedupKey).toBe('codex-cli::hook-not-firing'); // derived from title
+    expect(f[1].severity).toBe('medium');
+  });
+
+  it('tolerates markdown fences / surrounding prose', () => {
+    const raw = 'Here are the issues:\n```json\n[{"bucket":"generic-agent-mistake","title":"typo in commit"}]\n```\nDone.';
+    const f = parseForensicFindings(raw, 'codex-cli');
+    expect(f).toHaveLength(1);
+    expect(f[0].severity).toBe('medium'); // default
+  });
+
+  it('drops entries with an invalid bucket or missing title', () => {
+    const raw = JSON.stringify([
+      { bucket: 'nonsense', title: 'x' },
+      { bucket: 'framework-limitation' }, // no title
+      { bucket: 'framework-limitation', title: 'valid one' },
+    ]);
+    const f = parseForensicFindings(raw, 'codex-cli');
+    expect(f).toHaveLength(1);
+    expect(f[0].title).toBe('valid one');
+  });
+
+  it('returns [] for non-JSON, non-array, or empty output (never throws)', () => {
+    expect(parseForensicFindings('', 'x')).toEqual([]);
+    expect(parseForensicFindings('the agent seems fine', 'x')).toEqual([]);
+    expect(parseForensicFindings('{"not":"an array"}', 'x')).toEqual([]);
+    expect(parseForensicFindings('[ broken json', 'x')).toEqual([]);
+  });
+
+  it('caps the number of findings per run', () => {
+    const many = JSON.stringify(Array.from({ length: 50 }, (_, i) => ({ bucket: 'framework-limitation', title: `issue ${i}` })));
+    expect(parseForensicFindings(many, 'x').length).toBeLessThanOrEqual(10);
+  });
+});
+
+describe('analyzeForensics', () => {
+  it('returns [] without calling the LLM when there are no signals', async () => {
+    const evaluate = vi.fn(async () => '[]');
+    const f = await analyzeForensics({ framework: 'codex-cli', signals: '   ', evaluate });
+    expect(f).toEqual([]);
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it('classifies real signals via the injected LLM', async () => {
+    const evaluate = vi.fn(async () => '[{"bucket":"framework-limitation","title":"context truncated mid-task","severity":"high"}]');
+    const f = await analyzeForensics({ framework: 'codex-cli', signals: 'ERROR: context window exceeded', evaluate });
+    expect(evaluate).toHaveBeenCalledOnce();
+    expect(f).toHaveLength(1);
+    expect(f[0].bucket).toBe('framework-limitation');
+    expect(f[0].severity).toBe('high');
+  });
+
+  it('returns [] (no crash) when the LLM call throws', async () => {
+    const evaluate = vi.fn(async () => { throw new Error('LLM unavailable'); });
+    const f = await analyzeForensics({ framework: 'codex-cli', signals: 'some signal', evaluate });
+    expect(f).toEqual([]);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,37 +1,38 @@
 # Instar Upgrade Guide — NEXT
 
-<!-- bump: patch -->
+<!-- bump: minor -->
 
 ## What Changed
 
-**Framework-Onboarding Mentor System — live-readiness hardening.** Closes the three things the
-§19.4 reviewer flagged as must-haves before the mentor can ever be promoted to `live`: the tick is
-now fire-and-forget (a slow helper-spawn can't hang the request — the result lands in
-`/mentor/status`); the helper-spawn now kills its session and bails cleanly if it overruns (no
-orphaned panes, no half-read transcripts); and `live` mode now has a real, safe delivery path — it
-appends the message to a durable per-mentee outbox the mentee's running session picks up, instead of
-spawning a fresh counterpart session (the structural fix for the agent-to-agent message loop). Still
-dormant by default.
+**Framework-Onboarding Mentor System — Stage-B deep forensics.** The "look under the hood" half of
+the mentor loop is now real. Instead of recording nothing, Stage B reads the mentee's actual recent
+signals — error/sentinel lines from the server log plus a usage digest from its recent Codex session
+rollouts (token burn, rate-limit pressure) — and asks the model to classify any concrete issues into
+the three buckets (engine limitation / Instar integration gap / one-off mistake), writing them to the
+ledger. The prompt-and-parse logic is a separate pure module, defensively tested: malformed or
+invented entries are dropped, and a failed forensic read is a no-op tick, never a crash or a poisoned
+ledger. Still dormant.
 
 ## What to Tell Your User
 
-- The mentor's plumbing is now safe to switch on without it hanging or leaking sessions, and when it
-  eventually talks to the mentee it does so the calm way (drop a note in their inbox, no spawning).
-- Nothing's changed day-to-day; it's still off until you turn it on, and turning it fully live is
-  still gated behind your sign-off.
+- When the mentor inspects the mentee, it now actually reads its logs and recent sessions and writes
+  down what it finds — bucketed and ranked — rather than just noting that an inspection happened.
+- It's deliberately cautious: it reports nothing rather than guess, so the notebook stays trustworthy.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Async mentor tick | `POST /mentor/tick` returns 202; outcome in `GET /mentor/status`.lastResult |
-| Persist-only delivery | live mode appends to `server-data/mentor-outbox/<framework>.jsonl` (never spawns) |
+| Stage-B forensics | Automatic inside a live/dry-run mentor tick — reads server-log errors + codex-rollout digest, classifies into ledger findings |
+| Defensive forensic parse | `MentorStageBForensics.parseForensicFindings()` — drops malformed/invalid entries; never throws |
 
 ## Evidence
 
-Net-new hardening of a dormant feature, not a bug fix — no prior production failure. Proven by tests:
-the delivery path is asserted to fire **only in live mode and never in dry-run** (and to no-op safely
-when unwired); the async tick is asserted to return 202 with the result landing in `status.lastResult`
-and the in-flight guard preventing overlap; the spawn-kill-on-timeout path throws after killing the
-session so the tick captures a clean failure rather than a partial transcript. 27 mentor tests +
-route-completeness/discoverability gates; affected push-config suite green (745) vs canonical main.
+Net-new feature, not a bug fix — no prior production failure. Proven by tests: the parser is asserted
+to handle clean JSON, markdown-fenced output, and surrounding prose; to **drop invalid-bucket and
+titleless entries**; to return `[]` for non-JSON/empty/broken input (never throw); to cap findings
+per run; and to derive a stable dedupKey when the model omits one. `analyzeForensics` is asserted to
+**skip the LLM call entirely when there are no signals**, to classify real signals via the injected
+model, and to return `[]` (no crash) when the LLM throws. 10 unit tests + an e2e confirming the server
+boots clean with the forensics wiring and stays dormant; affected push-config suite green (488) vs
+canonical main.

--- a/upgrades/side-effects/mentor-stageb-forensics.md
+++ b/upgrades/side-effects/mentor-stageb-forensics.md
@@ -1,0 +1,62 @@
+# Side-Effects Review — Stage-B deep forensics (§19.4 follow-on)
+
+**Spec:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` (converged 5 iters, approved by Justin)
+**Change:** Makes Stage B *real* — instead of returning `[]`, it now reads the mentee's actual
+signals (recent server-log error/sentinel lines + a codex-rollout usage digest) and classifies them
+into bucketed findings via the LLM. New pure module `MentorStageBForensics` (prompt assembly +
+defensive parse, fully unit-tested); the AgentServer closure does the I/O (read logs/rollouts) and
+injects `IntelligenceProvider.evaluate`.
+**Files:** `src/scheduler/MentorStageBForensics.ts` (new), `src/server/AgentServer.ts`,
+`tests/unit/MentorStageBForensics.test.ts` (new), `tests/e2e/mentor-onboarding-lifecycle.test.ts`,
+`upgrades/NEXT.md`.
+
+## Principle check (Phase 1)
+
+Decision point? No new one. Stage B produces *signal* (ForensicFinding[] → the ledger). It reads
+logs/rollouts (read-only) and classifies via the LLM. No gating, no action. Still dormant
+(`mentor.enabled=false`), and Stage B only runs inside an enabled+safe+in-budget tick.
+
+## The seven questions
+
+1. **Over-block.** N/A — produces findings, blocks nothing. The prompt instructs the model to
+   report `[]` rather than speculate, biasing toward fewer (real) findings over false ones.
+2. **Under-block.** Forensic signals are bounded (last 40 error-ish log lines + ≤3 recent rollout
+   digests); a subtle issue not evidenced in those signals won't be caught — acceptable (the loop's
+   other signal is the Stage-A leak detector, and the funnel logs every run). The parse is defensive:
+   invalid-bucket / titleless / malformed entries are dropped; a non-JSON or throwing LLM call yields
+   `[]`, never a crash or a poisoned ledger entry.
+3. **Level-of-abstraction fit.** Prompt + parse are a pure module (`MentorStageBForensics`) — no I/O,
+   no LLM — so the classification logic is unit-tested in isolation. The AgentServer closure owns the
+   I/O (reads `logs/server.log` + `~/.codex/sessions/` via the existing `parseCodexRollout`). Correct
+   split; reuses the established rollout parser rather than re-implementing.
+4. **Signal vs authority.** Compliant. Findings are signal; the human + normal gates hold authority.
+   The model is constrained to the three buckets + JSON; free-text is title-only and length-capped.
+5. **Interactions.** Reuses `parseCodexRollout` (no new rollout logic) and `IntelligenceProvider`
+   (the established judgment-call path, `model: capable`, attributed `mentor-stage-b`). Findings flow
+   to `ledger.captureRun` (existing funnel). Signal-gathering is wrapped in try/catch — a log/rollout
+   read failure degrades to fewer signals, never a crash.
+6. **External surfaces.** No new routes. Reads existing on-disk logs/rollouts (read-only). The LLM
+   call is a background-attributed judgment call. Still Bearer-gated overall; still dormant.
+7. **Rollback cost.** Low. Revert restores the `[]` stub. No schema/migration change.
+
+## Phase 5 — second-pass
+
+Not required. No new decision surface — Stage B was always specced to read + classify; this fills in
+the real reader/classifier behind the §19.4 loop (which carried the dedicated second-pass). The new
+logic is pure + defensively-tested; the I/O is read-only with try/catch. Bias is explicitly toward
+no-finding over false-finding.
+
+## Remaining before `live`
+
+`getSurface` still returns an empty conversation history (Stage A has thin context until the
+Threadline conversation source is wired) — tracked (<!-- tracked: topic-13435 -->), and validated at
+the live step. Forensic depth is intentionally bounded; richer diff/PR analysis is a future follow-on.
+
+## Testing
+
+- Tier 1 (unit, +10): prompt names framework + buckets + JSON-only; parse handles clean JSON,
+  markdown fences, invalid-bucket/titleless drops, non-JSON/empty → [], finding cap, dedupKey
+  derivation; analyzeForensics no-LLM-call-without-signals, classifies real signals, []-on-throw.
+- Tier 3 (e2e, +1): server boots clean with the forensics wiring; mentor stays dormant
+  (`/mentor/tick` → disabled) on the production path.
+- route-completeness + discoverability gates pass; affected push-config suite green (488) vs main.


### PR DESCRIPTION
Makes Stage B *real* — the "look under the hood" half of the mentor loop now reads the mentee's actual signals and classifies issues, instead of returning `[]`. Still dormant.

## What's in it

- **`MentorStageBForensics`** (new pure module) — `buildForensicPrompt` + `parseForensicFindings` + `analyzeForensics`. Prompt asks the model to classify ONLY what the signals evidence into the 3 buckets, JSON-only. Parse is **defensive**: tolerates markdown fences/prose, drops invalid-bucket/titleless entries, returns `[]` for non-JSON/empty/throwing input (never crashes, never poisons the ledger), caps findings/run, derives a stable dedupKey when omitted.
- **AgentServer wiring** — `runStageBForensics` reads the last ~40 error/sentinel lines from `server.log` + a usage digest from the 3 most-recent Codex rollouts (via the existing `parseCodexRollout`), then classifies via `IntelligenceProvider.evaluate`. Read-only I/O, wrapped in try/catch.

## Testing

10 unit (clean JSON / fenced / invalid-drop / non-JSON→[] / cap / dedupKey derivation; analyze: no-LLM-without-signals, classify-real-signals, []-on-throw) + 1 e2e (server boots clean with forensics wiring, stays dormant). route-completeness + discoverability gates pass; affected push-config suite green (488) vs canonical main.

## Still before live

`getSurface` returns empty conversation history until the Threadline conversation source is wired (tracked) — Stage A has thin context until then, validated at the live step. Forensic depth is intentionally bounded (log tail + rollout digest); richer diff/PR analysis is a future follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)