### PR TITLE
feat(feedback-factory): port the receiver intake defenses to TS (Phase 1, increment 6)

### DIFF
--- a/src/feedback-factory/receiver/defense.ts
+++ b/src/feedback-factory/receiver/defense.ts
@@ -1,0 +1,165 @@
+/**
+ * defense.ts — framework-agnostic port of the feedback receiver's intake defenses.
+ *
+ * Ports the six defense-in-depth layers of `the-portal/pages/api/instar/feedback.ts`
+ * (rate-limit, agent fingerprint, honeypot, HMAC signature, input validation,
+ * dedup-key/type) out of the Next.js handler into pure/injectable functions, so the
+ * canonical front (whatever framework hosts it) reuses the exact same logic. The
+ * HTTP wiring + the app/framework placement is deliberately NOT here (it is the
+ * architecture decision in the spec's blocked list); this is the reusable core.
+ *
+ * Reference is TypeScript, so equivalence is by faithful transcription + exhaustive
+ * both-sides-of-boundary unit tests (not a cross-runtime parity harness — those
+ * apply to the Python processor ports). `now` is injected everywhere the reference
+ * used `Date.now()`, so tests are deterministic.
+ *
+ * Convergence finding folded in: `normalizeWebhookSecret` trims the secret at load
+ * so a trailing newline can't silently break the HMAC (the reference relied on a
+ * "use printf not echo" warning; this makes it structural).
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const VALID_TYPES = ['bug', 'feature', 'improvement', 'question', 'hallucination', 'other'] as const;
+export type FeedbackType = typeof VALID_TYPES[number];
+
+export const SEMVER_RE = /^\d+\.\d+\.\d+(-[\w.]+)?$/;
+export const FEEDBACK_ID_RE = /^fb-[a-z0-9-]{6,36}$/;
+export const AGENT_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9 _-]{0,98}[a-zA-Z0-9]$/;
+export const NODE_VERSION_RE = /^v?\d+\.\d+\.\d+$/;
+
+export const RATE_LIMITS = {
+  perHour: 10,
+  perDay: 50,
+  windowHourMs: 60 * 60 * 1000,
+  windowDayMs: 24 * 60 * 60 * 1000,
+};
+
+/** Trim the webhook secret so a trailing newline can't silently break the HMAC (convergence finding). */
+export function normalizeWebhookSecret(secret: string | undefined): string | undefined {
+  return secret == null ? secret : secret.trim();
+}
+
+export function isValidType(type: unknown): type is FeedbackType {
+  return typeof type === 'string' && (VALID_TYPES as readonly string[]).includes(type);
+}
+
+/** Port of extractSourceIp: first x-forwarded-for hop, else remoteAddress, else 'unknown'. */
+export function extractSourceIp(headers: Record<string, string | string[] | undefined>, remoteAddress?: string): string {
+  const xff = headers['x-forwarded-for'];
+  const xffStr = Array.isArray(xff) ? xff[0] : xff;
+  return xffStr?.split(',')[0]?.trim() || remoteAddress || 'unknown';
+}
+
+/** Port of validateAgentFingerprint: UA must contain "instar/"; version header, if present, must be semver. */
+export function validateAgentFingerprint(userAgent: string | undefined, headerVersion?: string): { valid: boolean; reason?: string } {
+  const ua = userAgent || '';
+  if (!ua.toLowerCase().includes('instar/')) {
+    return { valid: false, reason: 'missing-ua' };
+  }
+  if (headerVersion && !SEMVER_RE.test(headerVersion)) {
+    return { valid: false, reason: 'invalid-version-header' };
+  }
+  return { valid: true };
+}
+
+/** Port of checkHoneypot: real agents never send `website`/`email`; presence ⇒ bot. */
+export function checkHoneypot(body: Record<string, unknown>): boolean {
+  return Boolean(body.website || body.email);
+}
+
+/**
+ * Port of verifySignature. HMAC-SHA256 over `${timestamp}.${JSON.stringify(body)}`,
+ * timing-safe compare, with a +5min / −1min replay window. `now` injected (ms).
+ */
+export function verifySignature(args: {
+  signature?: string;
+  timestamp?: string;
+  body: unknown;
+  secret: string | undefined;
+  now: number;
+}): boolean {
+  const { signature, timestamp, body, secret, now } = args;
+  if (!signature || !timestamp || !secret) return false;
+
+  const age = now - parseInt(timestamp, 10);
+  if (isNaN(age) || age > 300_000 || age < -60_000) return false;
+
+  const payload = `${timestamp}.${JSON.stringify(body)}`;
+  const expected = createHmac('sha256', secret).update(payload).digest('hex');
+
+  try {
+    const sigBuf = Buffer.from(signature, 'hex');
+    const expBuf = Buffer.from(expected, 'hex');
+    if (sigBuf.length !== expBuf.length) return false;
+    return timingSafeEqual(new Uint8Array(sigBuf), new Uint8Array(expBuf));
+  } catch {
+    return false;
+  }
+}
+
+/** Port of the input-validation block (:242–269): title ≥3, description ≥10, valid type, semver instarVersion. */
+export function validateFeedbackInput(body: Record<string, unknown>): { valid: boolean; error?: string } {
+  if (!body.type || !isValidType(body.type)) {
+    return { valid: false, error: 'Invalid request format' };
+  }
+  if (!body.title || typeof body.title !== 'string' || body.title.trim().length < 3) {
+    return { valid: false, error: 'Invalid request format' };
+  }
+  if (!body.description || typeof body.description !== 'string' || body.description.trim().length < 10) {
+    return { valid: false, error: 'Invalid request format' };
+  }
+  if (body.instarVersion && !SEMVER_RE.test(body.instarVersion as string)) {
+    return { valid: false, error: 'Invalid request format' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Port of the in-memory sliding-window rate limiter (checkRateLimit + prune) as an
+ * injectable class. `now()` is injectable for deterministic tests; defaults to Date.now.
+ */
+export class RateLimiter {
+  private store = new Map<string, { timestamps: number[] }>();
+  private lastPrune = 0;
+  private readonly pruneIntervalMs = 10 * 60 * 1000;
+
+  constructor(
+    private readonly limits = RATE_LIMITS,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  private prune(): void {
+    const now = this.now();
+    if (now - this.lastPrune < this.pruneIntervalMs) return;
+    this.lastPrune = now;
+    const cutoff = now - this.limits.windowDayMs;
+    this.store.forEach((entry, key) => {
+      entry.timestamps = entry.timestamps.filter(t => t > cutoff);
+      if (entry.timestamps.length === 0) this.store.delete(key);
+    });
+  }
+
+  check(ip: string): { allowed: boolean; retryAfterSec?: number } {
+    this.prune();
+    const now = this.now();
+    const entry = this.store.get(ip) || { timestamps: [] };
+    const hourAgo = now - this.limits.windowHourMs;
+    const dayAgo = now - this.limits.windowDayMs;
+    const hourCount = entry.timestamps.filter(t => t > hourAgo).length;
+    const dayCount = entry.timestamps.filter(t => t > dayAgo).length;
+
+    if (hourCount >= this.limits.perHour) {
+      const oldest = entry.timestamps.filter(t => t > hourAgo).sort()[0];
+      return { allowed: false, retryAfterSec: Math.ceil((oldest + this.limits.windowHourMs - now) / 1000) };
+    }
+    if (dayCount >= this.limits.perDay) {
+      const oldest = entry.timestamps.filter(t => t > dayAgo).sort()[0];
+      return { allowed: false, retryAfterSec: Math.ceil((oldest + this.limits.windowDayMs - now) / 1000) };
+    }
+
+    entry.timestamps.push(now);
+    this.store.set(ip, entry);
+    return { allowed: true };
+  }
+}

--- a/tests/unit/feedback-factory/defense.test.ts
+++ b/tests/unit/feedback-factory/defense.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests (Tier 1) — feedback receiver intake defenses.
+ *
+ * The reference is TypeScript (the-portal/pages/api/instar/feedback.ts), so
+ * equivalence is by faithful transcription + exhaustive both-sides-of-boundary
+ * tests here (not a cross-runtime parity harness). `now` is injected for
+ * determinism.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import {
+  normalizeWebhookSecret, isValidType, extractSourceIp, validateAgentFingerprint,
+  checkHoneypot, verifySignature, validateFeedbackInput, RateLimiter, RATE_LIMITS,
+} from '../../../src/feedback-factory/receiver/defense.js';
+
+describe('normalizeWebhookSecret', () => {
+  it('trims a trailing newline (the trailing-newline guard)', () => {
+    expect(normalizeWebhookSecret('instar-rising-tide-v1\n')).toBe('instar-rising-tide-v1');
+    expect(normalizeWebhookSecret('  s  ')).toBe('s');
+    expect(normalizeWebhookSecret(undefined)).toBeUndefined();
+  });
+});
+
+describe('isValidType', () => {
+  it('accepts valid types, rejects others', () => {
+    expect(isValidType('bug')).toBe(true);
+    expect(isValidType('hallucination')).toBe(true);
+    expect(isValidType('nonsense')).toBe(false);
+    expect(isValidType(42)).toBe(false);
+  });
+});
+
+describe('extractSourceIp', () => {
+  it('takes the first x-forwarded-for hop, then remoteAddress, then unknown', () => {
+    expect(extractSourceIp({ 'x-forwarded-for': '1.1.1.1, 2.2.2.2' })).toBe('1.1.1.1');
+    expect(extractSourceIp({}, '3.3.3.3')).toBe('3.3.3.3');
+    expect(extractSourceIp({})).toBe('unknown');
+  });
+});
+
+describe('validateAgentFingerprint', () => {
+  it('requires instar/ in the UA', () => {
+    expect(validateAgentFingerprint('instar/1.3.0').valid).toBe(true);
+    expect(validateAgentFingerprint('curl/8.0')).toEqual({ valid: false, reason: 'missing-ua' });
+    expect(validateAgentFingerprint(undefined)).toEqual({ valid: false, reason: 'missing-ua' });
+  });
+  it('rejects a malformed version header but allows absent', () => {
+    expect(validateAgentFingerprint('instar/1.3.0', '1.3.0').valid).toBe(true);
+    expect(validateAgentFingerprint('instar/1.3.0', 'not-semver')).toEqual({ valid: false, reason: 'invalid-version-header' });
+    expect(validateAgentFingerprint('instar/1.3.0', undefined).valid).toBe(true);
+  });
+});
+
+describe('checkHoneypot', () => {
+  it('flags presence of website/email as a bot', () => {
+    expect(checkHoneypot({ website: 'x' })).toBe(true);
+    expect(checkHoneypot({ email: 'x@y' })).toBe(true);
+    expect(checkHoneypot({ title: 'real' })).toBe(false);
+  });
+});
+
+describe('verifySignature', () => {
+  const secret = 'test-secret';
+  const body = { type: 'bug', title: 'hello' };
+  const now = 1_000_000_000_000;
+  const sign = (ts: number) => createHmac('sha256', secret).update(`${ts}.${JSON.stringify(body)}`).digest('hex');
+
+  it('accepts a valid signature inside the replay window', () => {
+    const ts = now - 1000;
+    expect(verifySignature({ signature: sign(ts), timestamp: String(ts), body, secret, now })).toBe(true);
+  });
+  it('rejects a wrong signature', () => {
+    const ts = now - 1000;
+    expect(verifySignature({ signature: 'deadbeef', timestamp: String(ts), body, secret, now })).toBe(false);
+  });
+  it('rejects missing fields / secret', () => {
+    expect(verifySignature({ timestamp: '1', body, secret, now })).toBe(false);
+    expect(verifySignature({ signature: 'x', body, secret, now })).toBe(false);
+    expect(verifySignature({ signature: 'x', timestamp: '1', body, secret: undefined, now })).toBe(false);
+  });
+  it('enforces the replay window (+5min / -1min)', () => {
+    const tooOld = now - 300_001; // age > 300_000 → reject
+    expect(verifySignature({ signature: sign(tooOld), timestamp: String(tooOld), body, secret, now })).toBe(false);
+    const tooFuture = now + 60_001; // age < -60_000 → reject
+    expect(verifySignature({ signature: sign(tooFuture), timestamp: String(tooFuture), body, secret, now })).toBe(false);
+    const justInside = now - 299_000;
+    expect(verifySignature({ signature: sign(justInside), timestamp: String(justInside), body, secret, now })).toBe(true);
+  });
+});
+
+describe('validateFeedbackInput', () => {
+  const ok = { type: 'bug', title: 'abc', description: '0123456789' };
+  it('accepts a well-formed body', () => {
+    expect(validateFeedbackInput(ok).valid).toBe(true);
+  });
+  it('rejects title < 3 and description < 10 (boundary)', () => {
+    expect(validateFeedbackInput({ ...ok, title: 'ab' }).valid).toBe(false);
+    expect(validateFeedbackInput({ ...ok, description: '123456789' }).valid).toBe(false);
+  });
+  it('rejects invalid type and bad instarVersion', () => {
+    expect(validateFeedbackInput({ ...ok, type: 'nope' }).valid).toBe(false);
+    expect(validateFeedbackInput({ ...ok, instarVersion: 'x.y' }).valid).toBe(false);
+    expect(validateFeedbackInput({ ...ok, instarVersion: '1.2.3' }).valid).toBe(true);
+  });
+});
+
+describe('RateLimiter', () => {
+  it('allows up to perHour then blocks with a retryAfter', () => {
+    let t = 1_000_000_000_000;
+    const rl = new RateLimiter(RATE_LIMITS, () => t);
+    for (let i = 0; i < RATE_LIMITS.perHour; i++) {
+      expect(rl.check('ip').allowed).toBe(true);
+    }
+    const blocked = rl.check('ip');
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSec).toBeGreaterThan(0);
+  });
+  it('lets the window slide — after an hour the count resets', () => {
+    let t = 1_000_000_000_000;
+    const rl = new RateLimiter(RATE_LIMITS, () => t);
+    for (let i = 0; i < RATE_LIMITS.perHour; i++) rl.check('ip');
+    expect(rl.check('ip').allowed).toBe(false);
+    t += RATE_LIMITS.windowHourMs + 1; // slide past the hour window
+    expect(rl.check('ip').allowed).toBe(true);
+  });
+  it('isolates limits per IP', () => {
+    let t = 1_000_000_000_000;
+    const rl = new RateLimiter(RATE_LIMITS, () => t);
+    for (let i = 0; i < RATE_LIMITS.perHour; i++) rl.check('ipA');
+    expect(rl.check('ipA').allowed).toBe(false);
+    expect(rl.check('ipB').allowed).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,27 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Sixth increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, approved). Ports the **receiver intake defenses** — the six security layers of the feedback front door — out of the reference Next.js handler (`the-portal/pages/api/instar/feedback.ts`) into framework-agnostic TypeScript at `src/feedback-factory/receiver/defense.ts`.
+
+The layers: a per-IP sliding-window rate limiter (10/hour, 50/day), the agent fingerprint check (User-Agent must say `instar/`, version header must be semver), the honeypot (real agents never send `website`/`email`), HMAC signature verification with a 5-minute replay window, input validation (title/description length, valid type, semver), and the type/dedup helpers. Pure/injectable functions plus one self-contained `RateLimiter` class. **Not wired into any route yet** — the HTTP/app placement is a separate decision; this is the reusable core.
+
+A convergence finding is folded in: the webhook secret is trimmed at load, so a trailing newline can't silently break the signature check (replacing a "be careful how you set it" warning with structure).
+
+## What to Tell Your User
+
+- The security guards on the feedback front door — rate limiting, bot traps, signature checks, input validation — are now ported into our own codebase, ready to attach to the new front door when we stand it up.
+- One sharp-edge removed for good: a stray newline in the signing secret used to be able to silently break verification; now it's trimmed automatically.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Receiver intake defenses (TS port) | Internal module `src/feedback-factory/receiver/defense.ts` — not yet wired |
+
+## Evidence
+
+- The reference is TypeScript, so equivalence is by faithful transcription plus exhaustive both-sides-of-boundary tests (16 unit tests): rate limit at 10 vs 11 and after a window slide and per-IP; fingerprint with/without `instar/` and valid/invalid version; honeypot present/absent; HMAC valid/wrong/missing and both replay-window edges (+5min/−1min); validation at title 2 vs 3 and description 9 vs 10. The clock is injected everywhere, so the time-based windows are tested deterministically.
+- The HMAC payload formula, replay thresholds, and validation bounds are copied verbatim from the reference the field agents already sign against.

--- a/upgrades/side-effects/feedback-factory-receiver-defense.md
+++ b/upgrades/side-effects/feedback-factory-receiver-defense.md
@@ -1,0 +1,33 @@
+# Side-Effects Review — feedback receiver intake defenses (Phase 1, increment 6)
+
+**Slug:** `feedback-factory-receiver-defense`
+**Date:** `2026-05-27`
+**Author:** Echo (autonomous)
+**Spec:** `docs/specs/feedback-factory-migration.md` (converged v2, approved by Justin 2026-05-26)
+**Scope:** The six intake defense layers of the receiver, ported as pure/injectable functions. NOT the Next.js/Vercel HTTP wiring (the app-placement architecture decision — spec's blocked list).
+
+## Summary of the change
+
+Ports the defense-in-depth logic of `the-portal/pages/api/instar/feedback.ts` out of the Next.js handler into `src/feedback-factory/receiver/defense.ts` as framework-agnostic functions: `RateLimiter` (in-memory sliding window, 10/hr + 50/day, injectable clock), `validateAgentFingerprint` (UA must contain `instar/`; version-header semver), `checkHoneypot` (website/email ⇒ bot), `verifySignature` (HMAC-SHA256 over `${timestamp}.${JSON.stringify(body)}`, timing-safe, +5min/−1min replay window, injectable `now`), `validateFeedbackInput` (title ≥3, description ≥10, valid type, semver version), plus the regex constants + `isValidType` + `extractSourceIp`. **Not wired into any route yet** — no behavioral change.
+
+Convergence finding folded in: `normalizeWebhookSecret` trims the secret at load so a trailing newline can't silently break the HMAC (replaces the reference's "use printf not echo" warning with structure).
+
+## Equivalence verification
+
+The reference is TypeScript (not Python), so equivalence is by **faithful transcription + exhaustive both-sides-of-boundary unit tests**, not a cross-runtime parity harness (those apply only to the Python processor ports). `now` is injected everywhere the reference used `Date.now()`, so the rate-limit window + replay window are tested deterministically (10 allowed → 11th blocked; window slide; per-IP isolation; replay-window edges at +5min/−1min; HMAC valid/wrong/missing). The HMAC formula, replay thresholds, and validation bounds are copied verbatim from the reference.
+
+## Seven-dimension review
+
+1. **Over/under-reach** — Pure/injectable functions + one stateful class (`RateLimiter`) that owns its own Map (no module-level global, unlike the reference — a deliberate improvement for testability + multi-instance safety). Not wired into any route.
+2. **Level-of-abstraction fit** — `src/feedback-factory/receiver/` — the receiver layer, separate from the processor. The HTTP/framework wiring is intentionally excluded (blocked architecture decision); this is the reusable core that any host calls.
+3. **Signal vs Authority** — N/A; these are validators/guards returning verdicts. The HTTP handler (later) decides the response code.
+4. **Interactions** — None. New isolated module; nothing imports it yet.
+5. **Rollback cost** — Trivial: delete the module + tests.
+6. **Migration parity** — N/A. New internal library code; no agent-installed file touched.
+7. **Failure modes** — (a) HMAC payload-construction divergence from what agents sign → the formula is transcribed verbatim (`${timestamp}.${JSON.stringify(body)}`); the sender side already uses this. (b) Trailing-newline secret → structurally trimmed (`normalizeWebhookSecret`) + tested. (c) Rate-limit clock non-determinism → injectable `now`, tested via window-slide. (d) Replay-window off-by-one → both edges (+5min/−1min) tested.
+
+## Tests
+
+- Tier-1 unit (CI): `tests/unit/feedback-factory/defense.test.ts` — 16 tests across all six layers + secret normalization + boundaries.
+- No cross-runtime parity harness (reference is TS; equivalence by transcription + boundary tests — noted above).
+- No integration/E2E this increment: the HTTP wiring/app placement is the blocked architecture decision; these functions attach to a route when that's decided. Reasoned, documented.


### PR DESCRIPTION
Sixth increment of the approved **Feedback Factory Migration** (`docs/specs/feedback-factory-migration.md`).

## Summary
Ports the six defense-in-depth layers of `the-portal/pages/api/instar/feedback.ts` out of the Next.js handler into framework-agnostic `src/feedback-factory/receiver/defense.ts`: `RateLimiter` (sliding window 10/hr + 50/day, injectable clock), `validateAgentFingerprint` (`instar/` UA + semver version header), `checkHoneypot` (website/email ⇒ bot), `verifySignature` (HMAC-SHA256 over `${ts}.${JSON.stringify(body)}`, timing-safe, +5min/−1min replay window, injectable `now`), `validateFeedbackInput` (title ≥3, desc ≥10, valid type, semver), + the regex constants / `isValidType` / `extractSourceIp`. Convergence finding folded in: `normalizeWebhookSecret` trims the secret at load so a trailing newline can't silently break the HMAC. **Not wired into any route yet** — the HTTP/app placement is the separate (blocked) architecture decision; this is the reusable core.

## Why this is safe / verified
- Reference is TypeScript, so equivalence is by faithful transcription + **16 exhaustive both-sides-of-boundary unit tests** (clock injected for determinism): rate limit at 10 vs 11 / window-slide / per-IP; fingerprint with/without `instar/` + valid/invalid version; honeypot present/absent; HMAC valid/wrong/missing + both replay-window edges; validation at title 2 vs 3 and desc 9 vs 10. (No cross-runtime parity harness — that applies only to the Python processor ports.)
- `RateLimiter` owns its own Map (no module-level global like the reference) — better for testability + multi-instance safety.

## Tests
- Tier-1 unit (CI): `tests/unit/feedback-factory/defense.test.ts` — 16 tests.
- No integration/E2E this increment — the HTTP wiring/app placement is the blocked architecture decision (reasoned in the side-effects artifact).

## Test plan
- [x] `npm run test:push` green (998 files / 18,695 tests)
- [x] 16 boundary unit tests
- [ ] CI green