### PR TITLE
feat(multi-machine): Cross-Machine Seamlessness — one agent across machines (G1 lease + G2 auto-sync + G3 no-loss/no-dup)

### DIFF
--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
@@ -2,9 +2,25 @@
 
 *Companion to [`CROSS-MACHINE-SEAMLESSNESS-SPEC.md`](./CROSS-MACHINE-SEAMLESSNESS-SPEC.md). Read this first; the technical spec is the appendix.*
 
-## The dream
+## The dream (measured the right way: from the user's side)
 
 Picture one employee — call her Luna — who has a desk in two offices. You should be able to walk into either office and it's the same Luna: she remembers the conversation you were just having, the task she was halfway through, everything. You never notice she's actually in two places. That's the goal: **one agent that follows you across machines with no amnesia.**
+
+**The crucial point: "seamless" is judged entirely from the user's chair, in the actual channel — Telegram.** It's not about clever syncing under the hood; it's about what the person texting the agent experiences. The test is simple: someone is mid-conversation on Telegram, the agent quietly switches machines underneath them, and they notice *nothing* —
+
+- no message of theirs gets lost,
+- they never get the same answer twice,
+- the reply still knows exactly what they were just talking about (no "sorry, who is this?"),
+- no sudden "hi, how can I help you?" restart,
+- no weird long pause.
+
+Everything in this spec exists to deliver that experience. The plumbing is just the means.
+
+### The user stories driving it
+
+- **Failover mid-chat:** the machine serving me dies, I keep texting, I notice nothing.
+- **My two machines:** same agent, same conversation, on either machine — I switch and don't miss a beat.
+- **Reliability I feel but don't see:** the agent is just always there and coherent; that it spans machines is invisible. More machines = more reliable, never more noise.
 
 ## What we already had — and what we just proved
 
@@ -29,7 +45,7 @@ And the headline feature — handing the conversation from one live machine to a
 
 2. **Automatic filing.** The on-duty machine quietly saves its updates to the shared cabinet on a schedule, and the backup reads them. This is the thing that was missing — and we'll add a test that would have caught it.
 
-3. **No amnesia.** The real magic. The current conversation and the half-finished work get continuously copied to the backup machine, so when you switch, the other machine is already caught up. The handoff rule is strict: the new machine has to confirm "I've got everything" *before* the old one lets go — so nothing is dropped.
+3. **The seamless Telegram experience (the real magic).** This is the user-facing piece, and it has three parts working together: (a) the current conversation and half-finished work get continuously copied to the backup machine, so it's already caught up; (b) the Telegram "phone line" is handed over cleanly — only one machine is ever answering at a time (so you never get a double reply), and it's handed off at an exact spot so no message slips through the cracks; (c) the new machine picks up the thread instead of starting fresh, so the very next reply still knows what you were talking about. The handoff rule is strict: the new machine has to confirm "I've got everything and I've got the line" *before* the old one lets go.
 
 ## You're in control of the dial
 

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
@@ -68,6 +68,18 @@ You told me this has to be tunable — balance smoothness against wasted effort.
 
 How an agent *installs itself* onto a new machine in the first place (the SSH-and-git access we set up by hand today) is a separate, related write-up — your "agent does it all after one yes" standard. I'm keeping the two specs separate so each stays focused, but they're cousins, and today's hands-on run feeds both.
 
+## What the formal review tightened (and why it matters to you)
+
+I ran the draft through the formal review — five different expert "hats" plus an outside-model reviewer. They agreed on a handful of real holes, and fixing them genuinely made the design safer. In plain terms:
+
+- **"One captain" now uses numbered tickets, not a clock.** The first draft picked the captain by "who checked in most recently," which a machine with a wrong clock could win unfairly. Now there's a single numbered badge (each new captain takes the next number), and you can only act as captain if you're holding the current badge. Clocks can't game it anymore.
+- **No double-replies is now a hard lock, not a hope.** The draft assumed "only one machine listens, so no double answers." Reviewers pointed out that during a messy handoff both machines can briefly think they're listening. So now every incoming message gets a ticket and is only ever *answered once* — even if it arrives twice, the second one is recognized and ignored. Double replies become structurally impossible, not just unlikely.
+- **The private wire between your machines is now locked down.** The conversation copy that flows to the backup can contain sensitive stuff. The draft left that "to be decided" — now it's required to be encrypted, the receiving machine has to prove it's really yours, and any secrets get stripped before they cross.
+- **One manager runs the whole handoff.** Instead of five parts each doing a piece (which is how things fall through cracks), one component owns the handoff start-to-finish and won't let go of the baton until the other machine has *proven* it caught up.
+- **It won't spam your repo or your phone.** Heartbeats no longer get written into permanent history (which would've bloated things), and if the two machines genuinely can't agree, you get *one* clear question — not a buzz every 30 seconds.
+
+The honest bar you set survived intact: a handoff is still allowed to feel like a quick compaction pause. What review added is that it's *never* allowed to lose or double-answer a message while doing it.
+
 ## Bottom line
 
 The foundation is real and works. The "seamless" part is now three clearly-defined pieces instead of a vague wish — and we know they're the right three because we watched the system miss exactly those on real hardware. And thanks to your nudge, the bar is now honest: a handoff should feel no worse than a compaction pause or a fresh-session catch-up — quick, and back up to speed — not a magic trick we'd over-engineer chasing.

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
@@ -6,7 +6,7 @@
 
 Picture one employee — call her Luna — who has a desk in two offices. You should be able to walk into either office and it's the same Luna: she remembers the conversation you were just having, the task she was halfway through, everything. You never notice she's actually in two places. That's the goal: **one agent that follows you across machines with no amnesia.**
 
-**The crucial point: "seamless" is judged entirely from the user's chair, in the actual channel — Telegram.** It's not about clever syncing under the hood; it's about what the person texting the agent experiences. The test is simple: someone is mid-conversation on Telegram, the agent quietly switches machines underneath them, and they notice *nothing* —
+**The crucial point: "seamless" is judged entirely from the user's chair, in whatever channel they're using.** Telegram is the default and the one we test first, but the exact same promise has to hold on Slack and any other channel we add — so we build it as a general rule of the channel layer, not a Telegram special case. It's not about clever syncing under the hood; it's about what the person messaging the agent experiences. The test is simple: someone is mid-conversation (on Telegram, Slack, wherever), the agent quietly switches machines underneath them, and they notice *nothing* —
 
 - no message of theirs gets lost,
 - they never get the same answer twice,
@@ -45,7 +45,9 @@ And the headline feature — handing the conversation from one live machine to a
 
 2. **Automatic filing.** The on-duty machine quietly saves its updates to the shared cabinet on a schedule, and the backup reads them. This is the thing that was missing — and we'll add a test that would have caught it.
 
-3. **The seamless Telegram experience (the real magic).** This is the user-facing piece, and it has three parts working together: (a) the current conversation and half-finished work get continuously copied to the backup machine, so it's already caught up; (b) the Telegram "phone line" is handed over cleanly — only one machine is ever answering at a time (so you never get a double reply), and it's handed off at an exact spot so no message slips through the cracks; (c) the new machine picks up the thread instead of starting fresh, so the very next reply still knows what you were talking about. The handoff rule is strict: the new machine has to confirm "I've got everything and I've got the line" *before* the old one lets go.
+3. **The seamless conversation experience (the real magic).** This is the user-facing piece, and it has three parts working together: (a) the current conversation and half-finished work get continuously copied to the backup machine, so it's already caught up; (b) the "phone line" to the channel is handed over cleanly — only one machine is ever answering at a time (so you never get a double reply), and it's handed off at an exact spot so no message slips through the cracks; (c) the new machine picks up the thread instead of starting fresh, so the very next reply still knows what you were talking about. The handoff rule is strict: the new machine has to confirm "I've got everything and I've got the line" *before* the old one lets go.
+
+**And it's not Telegram-only.** Each channel has its own version of "pick up exactly where I left off" — Telegram tracks a message number, Slack has its own bookmark, and so on. So instead of hard-coding Telegram, the spec defines one "clean handoff contract" that every channel has to meet, builds it for Telegram first as the reference, and proves it on Slack too. Any new channel we add later is only considered done when it passes the same handoff test — so seamlessness comes built-in, not bolted on per channel.
 
 ## You're in control of the dial
 

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
@@ -1,0 +1,44 @@
+# Cross-Machine Seamlessness — Plain English
+
+*Companion to [`CROSS-MACHINE-SEAMLESSNESS-SPEC.md`](./CROSS-MACHINE-SEAMLESSNESS-SPEC.md). Read this first; the technical spec is the appendix.*
+
+## The dream
+
+Picture one employee — call her Luna — who has a desk in two offices. You should be able to walk into either office and it's the same Luna: she remembers the conversation you were just having, the task she was halfway through, everything. You never notice she's actually in two places. That's the goal: **one agent that follows you across machines with no amnesia.**
+
+## What we already had — and what we just proved
+
+We'd already built most of the hard plumbing: the two offices know they're the same company, they share a filing cabinet, and there's a rule for who's "on duty."
+
+On May 26 we ran it on two real machines for the very first time (your laptop and a Mac mini, using a throwaway test agent so nothing real was at risk). Two things genuinely worked:
+
+- **Linking the two machines into one agent** — done, on real hardware.
+- **A backup taking over when the main one is dark** — the mini, finding nobody home, correctly said "then I'm on duty."
+
+## The two things that broke (this is the useful part)
+
+1. **Two captains.** After the mini took charge, the shared directory listed *both* machines as "on duty" at once — nobody marked the powered-off laptop as "off duty." The info to fix it was sitting right there (the laptop hadn't checked in for nearly an hour), but no rule was actually enforcing the cleanup.
+
+2. **No automatic filing.** Even with the mini running, it wasn't automatically filing its updates into the shared cabinet. I had to walk the paperwork over by hand. So the "they quietly keep each other in sync" promise wasn't actually happening.
+
+And the headline feature — handing the conversation from one live machine to another with no memory loss — we couldn't even test yet, because that piece doesn't exist.
+
+## What this spec builds (three pieces, in order)
+
+1. **One captain, always.** A simple, automatic rule: if two machines both think they're on duty, the one that's actually been active recently wins, and the silent one is marked off duty. No human needed; it just settles itself. (And if it genuinely can't tell — say both are equally active — it asks you rather than flip-flopping.)
+
+2. **Automatic filing.** The on-duty machine quietly saves its updates to the shared cabinet on a schedule, and the backup reads them. This is the thing that was missing — and we'll add a test that would have caught it.
+
+3. **No amnesia.** The real magic. The current conversation and the half-finished work get continuously copied to the backup machine, so when you switch, the other machine is already caught up. The handoff rule is strict: the new machine has to confirm "I've got everything" *before* the old one lets go — so nothing is dropped.
+
+## You're in control of the dial
+
+You told me this has to be tunable — balance smoothness against wasted effort. So everything has a knob: how often they sync, how fresh the backup's copy has to be, how aggressive the handoff is. The defaults are tuned for a personal two-machine setup; someone with ten machines or a tight budget can dial it down. More machines means more reliability — without meaning more constant chatter.
+
+## What's NOT in this spec (on purpose)
+
+How an agent *installs itself* onto a new machine in the first place (the SSH-and-git access we set up by hand today) is a separate, related write-up — your "agent does it all after one yes" standard. I'm keeping the two specs separate so each stays focused, but they're cousins, and today's hands-on run feeds both.
+
+## Bottom line
+
+The foundation is real and works. The "seamless" part is now three clearly-defined pieces instead of a vague wish — and we know they're the right three because we watched the system miss exactly those on real hardware.

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md
@@ -16,6 +16,17 @@ Picture one employee — call her Luna — who has a desk in two offices. You sh
 
 Everything in this spec exists to deliver that experience. The plumbing is just the means.
 
+## The honest bar (your nudge): "as smooth as a compaction pause," not magic
+
+You pushed back on the word *seamless*, and you were right — chasing magically-perfect, zero-gap invisibility is where you'd over-build. So here's the honest yardstick we're actually holding ourselves to: a machine handoff should feel **no worse than two things the agent already does that you're used to** — pausing to *compact* (tidy up its memory), or spinning up a *fresh session* when you message a quiet topic and it takes a beat to get up to speed. Nobody expects those to be invisible. They expect them to be quick and to come back knowing what's going on. That's exactly the bar for a handoff. The nice bonus: that means we reuse the catch-up machinery we already trust, instead of building a fragile new "always-live wire" between machines just to chase perfection.
+
+So the goal isn't "perfectly invisible" — it's **carry over as much fresh context as we possibly can, and degrade gracefully when we can't.** And there are really two flavors of handoff, with two fair expectations:
+
+- **Planned hand-off** (both machines awake, one politely passes the baton): near-instant, full context goes across cleanly. This is the smooth case.
+- **Hard failover** (a machine crashes, or the internet drops while you're in the middle of a live test): best-effort. The backup picks up from the last good save — it might miss the last few seconds, exactly like a session that crashed and recovered. We *deliberately don't* twist ourselves into knots trying to make that rare worst-case perfect. If you were running live development tests when a machine's internet dropped mid-handoff, a tiny gap is honest and fine.
+
+**And one thing you specifically asked for: the agent always knows which machine it was just on, and that a handoff happened.** It's cheap, and it lets the agent be upfront — "picking this back up from the other machine" — when its context is a little behind, instead of pretending nothing changed. It also feeds the idea you raised early on, that each machine can know what's specific to it.
+
 ### The user stories driving it
 
 - **Failover mid-chat:** the machine serving me dies, I keep texting, I notice nothing.
@@ -59,4 +70,4 @@ How an agent *installs itself* onto a new machine in the first place (the SSH-an
 
 ## Bottom line
 
-The foundation is real and works. The "seamless" part is now three clearly-defined pieces instead of a vague wish — and we know they're the right three because we watched the system miss exactly those on real hardware.
+The foundation is real and works. The "seamless" part is now three clearly-defined pieces instead of a vague wish — and we know they're the right three because we watched the system miss exactly those on real hardware. And thanks to your nudge, the bar is now honest: a handoff should feel no worse than a compaction pause or a fresh-session catch-up — quick, and back up to speed — not a magic trick we'd over-engineer chasing.

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
@@ -1,8 +1,20 @@
+---
+title: "Cross-Machine Seamlessness"
+slug: "cross-machine-seamlessness"
+author: "echo"
+eli16-overview: "CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md"
+principal-deferral-approval: pending  # the port-collision / runnable-config onboarding gaps (recurrence-risk) are deferred to the companion Self-Propagation spec; requires Justin sign-off before that spec is approved
+review-convergence: "2026-05-27T05:52:19.795Z"
+review-iterations: 5
+review-completed-at: "2026-05-27T05:52:19.795Z"
+review-report: "docs/specs/reports/cross-machine-seamlessness-convergence.md"
+---
+
 # Cross-Machine Seamlessness Specification
 
 > Close the gap between "a backup machine can take over" and "the same agent follows you across machines with no amnesia." Grounded in real-hardware Phase 0 verification.
 
-**Status**: Draft v0 (grounded in real-hardware verification 2026-05-26)
+**Status**: Draft v1 (converged through multi-angle review; grounded in real-hardware verification 2026-05-26)
 **Author**: Echo (with Justin's direction)
 **Builds on**: [`MULTI-MACHINE-SPEC.md`](./MULTI-MACHINE-SPEC.md) (v3, converged) — this spec does NOT replace it; it closes the seamlessness gap that v3 explicitly deferred.
 **Companion (read first)**: [`CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md`](./CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md)
@@ -14,14 +26,16 @@
 
 1. [Overview](#overview)
 2. [User Stories & Channel Experience](#user-stories--channel-experience)
-3. [Phase 0 Findings (Empirical Grounding)](#phase-0-findings-empirical-grounding)
-4. [Design Principles](#design-principles)
-5. [The Seamlessness Gap — Precise Definition](#the-seamlessness-gap--precise-definition)
-6. [Proposed Design](#proposed-design)
-7. [Tunability](#tunability)
-8. [Testing Strategy](#testing-strategy)
-9. [Migration Parity](#migration-parity)
-10. [Related Work & Open Questions](#related-work--open-questions)
+3. [Guarantees: What Is Hard vs Best-Effort (RPO/RTO)](#guarantees-what-is-hard-vs-best-effort-rporto)
+4. [Phase 0 Findings (Empirical Grounding)](#phase-0-findings-empirical-grounding)
+5. [Design Principles](#design-principles)
+6. [Coordination Primitive — The Fenced Lease](#coordination-primitive--the-fenced-lease)
+7. [The Seamlessness Gap — Precise Definition](#the-seamlessness-gap--precise-definition)
+8. [Proposed Design](#proposed-design)
+9. [Tunability](#tunability)
+10. [Testing Strategy](#testing-strategy)
+11. [Migration Parity & Agent Awareness](#migration-parity--agent-awareness)
+12. [Related Work & Open Questions](#related-work--open-questions)
 
 ---
 
@@ -29,9 +43,11 @@
 
 The converged multi-machine spec (v3) delivered machine identity, secure pairing, git-based state sync, primary/standby coordination, heartbeat/failover, and graceful handoff *machinery*. What it explicitly deferred — and what the EXO 3.0 "cross-machine single agent" vision needs most — is **seamlessness**: the experience that an agent is one logical identity that follows the user across machines with no loss of in-flight context.
 
-**The yardstick is the user's experience in the channel** (Telegram is the default and reference; Slack and any other channel must work equally), not internal state mechanics. "Seamless" is defined entirely from the user's side: a person is mid-conversation with the agent over Telegram; the agent quietly moves machines underneath them; and the person notices *nothing* — no dropped message, no duplicate reply, no "sorry, what were we talking about?", no fresh greeting, no awkward gap. The internal state sync exists only to deliver that channel experience. Every design choice below is justified by a user story, not by architectural elegance.
+**The yardstick is the user's experience in the channel** (Telegram is the default and reference; Slack and any other channel must work equally), not internal state mechanics. "Seamless" is defined entirely from the user's side: a person is mid-conversation with the agent over Telegram; the agent quietly moves machines underneath them; and the person notices *nothing* worse than a brief "getting up to speed" beat. The internal state sync exists only to deliver that channel experience. Every design choice below is justified by a user story, not by architectural elegance.
 
-This spec defines the narrow, high-leverage work to close that gap. It is deliberately scoped to the **runtime** seamlessness problem. The **onboarding** problem (how an agent installs itself onto a new machine) is captured as related work for a companion spec (see §9).
+This spec defines the narrow, high-leverage work to close that gap. It is deliberately scoped to the **runtime** seamlessness problem. The **onboarding** problem (how an agent installs itself onto a new machine) is captured as related work for a companion spec (see §12).
+
+> **What review changed (v0 → v1).** The first draft trusted wall-clock timestamps for leader election, treated "only one machine consumes the channel" as sufficient to prevent duplicate replies, and left the live-tail transport's security as an open question. Multi-angle review (security, scalability, adversarial, integration, lessons-aware, and an external GPT-class reviewer) showed all three were unsafe under the exact failure modes this spec exists to handle (clock skew, network partition, crash mid-handoff). v1 introduces a single **fenced-lease** coordination primitive as the backbone, makes message processing **idempotent at the message level** (so duplicates are structurally impossible rather than merely unlikely), and promotes transport security to a normative requirement.
 
 ---
 
@@ -39,8 +55,8 @@ This spec defines the narrow, high-leverage work to close that gap. It is delibe
 
 The whole spec serves these. Each gap and design choice traces back to one.
 
-- **US1 — Invisible failover mid-conversation.** *As a user chatting with the agent on Telegram, when the machine currently serving me goes down, I keep chatting and notice nothing — my next message is answered normally, with full memory of what we were just discussing.* (No lost message, no duplicate reply, no re-introduction, no long stall.)
-- **US2 — Same agent across my machines.** *As a user (e.g. Adriana) who works on two machines, it's the same agent on both — same conversation, same half-finished task, same context — so I can switch machines and not miss a beat.*
+- **US1 — Invisible failover mid-conversation.** *As a user chatting with the agent on Telegram, when the machine currently serving me goes down, I keep chatting and notice nothing worse than a short catch-up beat — my next message is answered normally, with memory of what we were just discussing.*
+- **US2 — Same agent across my machines.** *As a user who works on two machines, it's the same agent on both — same conversation, same half-finished task, same context — so I can switch machines and not miss a beat.*
 - **US3 — Reliability that's felt, not seen.** *As a user, I just experience an agent that's always there and always coherent; the fact that it spans several machines is invisible. More machines should mean more reliability, never more noise or more confusion.*
 
 ### The realistic bar: "no worse than a compaction pause or a fresh-session catch-up"
@@ -50,31 +66,46 @@ We are explicitly **not** chasing magically-perfect, zero-latency seamlessness. 
 The goal is therefore: **carry over as much fresh handoff context as possible, and degrade gracefully when we can't.** Two flavors, two expectations:
 
 - **Planned handoff** (both machines awake; one passes the baton): near-instant, full context flushed across cleanly.
-- **Hard failover** (a machine crashes, or the internet drops mid–live-test): best-effort. The backup resumes from the last good sync — it may miss the last few seconds of in-flight context, exactly like a session that crashed and recovered. We explicitly do **not** over-engineer to guarantee perfection in this rare worst case.
+- **Hard failover** (a machine crashes, or the internet drops mid–live-test): best-effort. The backup resumes from the last good sync — it may miss the last few seconds of in-flight *context*, exactly like a session that crashed and recovered. We explicitly do **not** over-engineer to guarantee perfect context recovery in this rare worst case. (Note: "may miss context" is about conversational *freshness*, not about *losing or duplicating messages* — those remain hard guarantees; see §3.)
 
 ### What "seamless" means, measured from the channel (acceptance criteria)
 
 User-facing pass/fail bars, observed on the channel, not in the code:
 
-1. **No lost messages.** Every message the user sends during/around a handoff is processed exactly once. *(Hard guarantee, both flavors — this is the one we don't compromise.)*
-2. **No duplicate replies.** The user never receives the same answer twice (a real, recurring instar failure mode — see drain-respawn / gate-latency duplicates). Only one machine "owns" the channel at a time. *(Hard guarantee, both flavors.)*
-3. **Maximal context, no fresh-start.** The first reply from the new machine reflects the conversation as of the last sync — no generic greeting, no "what were we talking about?" In a planned handoff this is fully current; in a hard failover it is as-of-last-sync (the compaction/continuation bar). *(Best-effort, bounded by sync freshness.)*
-4. **Pause no worse than a compaction / fresh-session catch-up.** A brief, recognizable "getting up to speed" moment is acceptable; an open-ended hang or silent drop is not. Tunable (see §6).
+1. **No lost messages.** Every message the user sends during/around a handoff is processed *at least once and acted on exactly once*. *(Hard guarantee, both flavors — see §3 for the mechanism.)*
+2. **No duplicate replies.** The user never receives the same answer twice (a real, recurring instar failure mode — see drain-respawn / gate-latency duplicates). *(Hard guarantee, both flavors — enforced by message-level idempotency, not merely by single-consumer ingress; see §3 and §8 G3.)*
+3. **Maximal context, no fresh-start.** The first reply from the new machine reflects the conversation as of the last sync — no generic greeting, no "what were we talking about?" In a planned handoff this is fully current; in a hard failover it is as-of-last-sync (the compaction/continuation bar). *(Best-effort, bounded by sync freshness — see RPO in §3.)*
+4. **Pause no worse than a compaction / fresh-session catch-up.** A brief, recognizable "getting up to speed" moment is acceptable; an open-ended hang or silent drop is not. Bounded by RTO (§3) and tunable (§9).
 5. **Channel identity follows the agent.** The channel's thread/conversation binding (Telegram topic, Slack channel+thread, etc.) moves with the agent, so replies land in the same conversation regardless of which machine produced them.
-6. **Machine-awareness.** The agent always knows which machine served the last turn and that a handoff occurred. This is cheap, lets the agent be honest when context is partial ("picking this up from the other machine"), and feeds per-machine self-knowledge (each machine tracking what is specific to it).
+6. **Machine-awareness.** The agent always knows which machine served the last turn and that a handoff occurred. This is cheap, lets the agent be honest when context is partial ("picking this up from the other machine"), and feeds per-machine self-knowledge. Provenance is recorded as an **Integrated-Being Ledger** entry (kind `turn-provenance`) — the existing *synced* cross-machine store, not a new parallel one — and surfaced to the agent via the existing CONTINUATION injection, not a permanent CLAUDE.md section (avoids context bloat, lesson L1). Because the IBL is synced (not local-only), provenance is consistent across a handoff; if a failover outpaces IBL sync, the agent reports honestly ("served from the other machine, exact provenance catching up") rather than asserting a stale machine.
 
 ### Channel-agnostic by design (Telegram is the default, not the spec)
 
-Seamlessness is a property of the **channel layer**, not of Telegram specifically. Instar already routes every channel through the adapter pattern (`MessageRouter` → `TelegramAdapter`, `SlackAdapter`, `WhatsAppAdapter`, iMessage, …). This spec defines a single **Channel Seamlessness Contract** that every adapter must satisfy; Telegram is the reference/default implementation, and Slack is the explicit second target. No mechanism here may be Telegram-specific — anything Telegram-specific lives *inside* the Telegram adapter.
+Seamlessness is a property of the **channel layer**, not of Telegram specifically. Instar already routes every channel through the adapter pattern (`MessageRouter` → `TelegramAdapter`, `SlackAdapter`, `WhatsAppAdapter`, iMessage, …). This spec defines a single **Channel Seamlessness Contract** that every adapter must satisfy; Telegram is the reference/default implementation, and Slack is the explicit second target. **WhatsApp and iMessage are out of scope for the launch contract** (they get the contract later). No mechanism here may be Telegram-specific — anything Telegram-specific lives *inside* the Telegram adapter.
 
-**The Channel Seamlessness Contract (every adapter implements):**
+**The Channel Seamlessness Contract (every adapter implements).** This requires extending the existing `MessagingAdapter` interface (`src/core/types.ts`), which today exposes only `start`/`stop`/`send`/`onMessage`/`resolveUser`. The new methods (final signatures fixed during implementation):
 
-1. **Single-owner ingress.** Exactly one machine consumes the channel's inbound stream at any moment (two consumers = duplicate handling). Ownership is recorded in the mesh and transfers atomically on handoff/failover — the outgoing machine releases only once the incoming machine holds the claim.
-2. **Resumable consumption position (exactly-once).** Each adapter exposes a durable "where I left off" marker that can be recorded into synced state and resumed by another machine, so the inbound stream is consumed exactly once across a transfer — none dropped, none double-handled. *The marker is per-channel:* Telegram = the long-poll `update_id` offset; Slack = the Events API delivery + per-event dedup id (or socket-mode cursor); other adapters define their own. The contract is "a resumable, exactly-once position exists," not any specific cursor.
-3. **Portable conversation identity.** The channel's thread/conversation handle (Telegram topic, Slack channel+thread_ts, etc.) is machine-independent, so replies land in the same conversation regardless of which machine produced them.
-4. **Context-before-answer.** The receiving machine must hold that conversation's history + live tail before it answers (prevents the "fresh start" failure). This part is channel-independent — it's agent state, routed by conversation identity.
+1. **`getIngressPosition(): IngressPosition`** — the adapter's durable "where I left off" marker, serializable into synced state. Telegram = the long-poll `update_id` offset; Slack = the per-conversation `lastTs` cursor (`channelResumeMap`) with documented best-effort semantics (Slack socket-mode has *no* exactly-once cursor — see below).
+2. **`stopConsuming(): Promise<IngressPosition>`** — stop the inbound loop, drain or discard any in-flight batch deterministically, and return the durable position *after* the stop is complete (not the in-memory cursor).
+3. **`resumeConsuming(position: IngressPosition): Promise<void>`** — resume the inbound loop from exactly that position.
+4. **`dedupeKey(rawEvent): string`** — a stable provider-level identity for an inbound event (Telegram `update_id`; Slack `event_id`/`client_msg_id`), used by the message-processing ledger (§3, §8 G3) so a redelivered event is recognized and not re-acted-on.
 
-Instar already has a "messages are not lost — they replay on recovery" guarantee for version-skew restarts; the resumable-position requirement (2) is the cross-machine generalization of it.
+**Channels are at-least-once, not exactly-once.** Telegram long-poll and Slack Events API both redeliver on reconnect/retry; an offset/cursor alone does not give exactly-once *processing* across a consumer transfer. The contract therefore guarantees exactly-once *effect* via (4) + the durable message-processing ledger, **not** by assuming the cursor is a transactional boundary. Slack in particular: socket-mode resumes from reconnect, so its resumable position is the coarse `lastTs` and its exactly-once property comes entirely from `event_id` dedup. A new adapter is "seamless-ready" only when it passes the §10 contract-conformance suite.
+
+---
+
+## Guarantees: What Is Hard vs Best-Effort (RPO/RTO)
+
+The honest split (this is what makes "no worse than a compaction pause" a checkable promise, not a vibe):
+
+| Property | Guarantee | Mechanism | Bound |
+|----------|-----------|-----------|-------|
+| Message **acted-on exactly once** (no lost, no duplicate reply) | **HARD** (both planned + hard failover) | Durable per-message processing ledger keyed by `dedupeKey`; idempotent reply/outbox reservation gated by fencing token; dual-medium `reply_committed` marker + outbound idempotency key | Always, with one named impossibility-floor exception: a single duplicate reply is possible only under a simultaneous triple-fault (reply physically sent → hard crash before the marker reaches tunnel *or* git → channel has no native outbound dedup). See §8 G3a. |
+| Outbound reply delivered | **HARD, at-least-once with dedup** | Outbox reservation + fencing token; receiver-side dedup by reply key | Always |
+| Conversational **context freshness** | **BEST-EFFORT** | Live-tail sync (planned: synchronous flush; failover: last synced tail) | **RPO** = `liveTailMaxStalenessMs` (default 5s). Planned handoff RPO ≈ 0. |
+| User-perceived **pause** at handoff | **BEST-EFFORT, bounded** | CONTINUATION resume on receiving machine | **RTO** ≤ `handoffAckTimeoutMs` + continuation spin-up (target: ≤ a normal fresh-session spin-up) |
+
+**RPO** (Recovery Point Objective) = how much in-flight *context* a hard failover may lose: at most one live-tail staleness window. **RTO** (Recovery Time Objective) = how long the user may wait: bounded by the ack timeout plus a normal session catch-up. Message *processing* is never sacrificed to either bound — only context freshness and pause length are best-effort. This directly encodes Justin's framing: a handoff is allowed to feel like a compaction pause, but it is never allowed to drop or double-answer a message.
 
 ---
 
@@ -90,133 +121,165 @@ This spec is not theoretical. On 2026-05-26 the multi-machine system was run on 
 **What does NOT work yet (this spec's targets):**
 
 - **❌ G1 — Split-brain resolution.** After self-election, the mesh registry recorded **both** machines as `role: awake` simultaneously. The newly-awake machine never demoted the silent peer, even though the differentiator was present (the silent machine's `lastSeen` was ~54 minutes stale, far past the 15-minute failover threshold).
-- **❌ G2 — Automated state sync.** A running server modified its local registry (role change) and other state, but did **not** auto-commit/push those changes to git. Cross-machine state propagated only when pushed/pulled by hand. (The converged spec assumed `SyncOrchestrator` handles this; on real hardware it did not fire for registry/role state.)
+- **❌ G2 — Automated state sync.** A running server modified its local registry (role change) and other state, but did **not** auto-commit/push those changes to git. Cross-machine state propagated only when pushed/pulled by hand. **Root cause confirmed during review:** `MultiMachineCoordinator` holds no reference to `SyncOrchestrator` and emits its `roleChange` event with no subscriber that marks the registry dirty — so the push never fires. This is a *wiring* gap, and the fix must name the wiring (§8 G2), not just the intent, or it will ship as dead code a second time.
 - **❌ G3 — Live state sync + graceful handoff (untested, by design).** The test exercised startup-election against a dead peer, not a clean baton-pass between two live machines, because the seamless live-state path does not yet exist.
 
-**Onboarding findings (→ companion spec, §9):** granting an agent access to a new machine is **two** bootstraps (SSH onto the host, *and* git credential to fetch the agent's repo); `join` does not create a runnable `config.json`, so a freshly-joined server defaults to port 4040 and can **collide with an existing agent** on that machine; the configured port does not propagate (it lives in gitignored `config.json`).
+**Onboarding findings (→ companion spec, §12):** granting an agent access to a new machine is **two** bootstraps (SSH onto the host, *and* git credential to fetch the agent's repo); `join` does not create a runnable `config.json`, so a freshly-joined server defaults to port 4040 and can **collide with an existing agent** on that machine; the configured port does not propagate (it lives in gitignored `config.json`).
 
 ---
 
 ## Design Principles
 
-- **Structure > Willpower.** Split-brain resolution and state sync must be code that runs deterministically — never an agent "remembering" to reconcile. (The Phase 0 split-brain persisted precisely because nothing *enforced* demotion.)
-- **Signal vs. Authority.** Detectors (e.g. "I see two awake machines") emit *signals*; only the coordinator, with full context, has authority to demote a peer or trigger a handoff. No brittle filter unilaterally changes mesh roles.
-- **Near-silent.** Sync and reconciliation are housekeeping. They write to logs/audit trails, not to the user's chat. The user hears about cross-machine activity only when it is actionable (e.g. an unresolvable split-brain requiring a decision).
-- **Tunable latency vs. efficiency** (explicit Justin requirement). Seamlessness has a cost (network, compute, git churn). Every cadence/aggressiveness knob is configurable with sane defaults; "more machines = more reliable" must not mean "more machines = constant chatter."
-- **Git as durable substrate, tunnel as low-latency channel.** Reuse the proven git sync for durable state; add a direct tunnel channel only where latency demands it (the live conversation tail).
-- **Reuse the catch-up model, don't reinvent.** A handoff is the cross-machine generalization of compaction-recovery and fresh-session continuation. The receiving machine resumes via the existing **CONTINUATION** mechanism, and the user-facing bar is "no worse than a compaction pause." We do not build a fragile always-streaming pipe to chase perfect seamlessness — best-effort context + graceful degradation is the explicit, accepted design point.
-- **Machine-aware by default.** The agent records which machine served each turn (provenance, in synced state) and knows when it is resuming someone else's turn. Cheap, and it underpins honest "picking this up from the other machine" behavior plus per-machine self-knowledge.
+- **Structure > Willpower.** Awake-only privilege is enforced by a **structural gate**, never by an agent or process "remembering" to demote itself. The job scheduler and every channel's ingress consumer check `holdsValidLease(self)` against synced state *on each tick / before each poll* and refuse to operate otherwise — even if the in-process demotion signal was never delivered (the Phase 0 split-brain was exactly a missing structural demotion). A machine that cannot prove it is visible (sync push failing past a threshold) self-suspends ingress.
+- **Signal vs. Authority.** Detectors (e.g. "I see two awake machines") emit *signals*; **only the holder of the current coordination lease has authority** to demote a peer, transfer ingress, or write authority-bearing registry state. Non-holders may detect and signal but must not mutate roles. This removes the v0 anti-pattern where every machine simultaneously ran the resolver and all wrote the registry.
+- **Idempotency over single-consumer.** "No duplicate replies" is guaranteed by making message *effects* idempotent (a durable processing ledger keyed on the provider event id + a fencing-token-gated outbox), not by the weaker assumption that exactly one machine ever consumes. Single-consumer is still the normal case; idempotency is what holds during the overlap window of a partition or crash.
+- **Near-silent.** Sync and reconciliation are housekeeping. They write to logs/audit trails, not the user's chat. The user hears about cross-machine activity only when it is genuinely actionable (an unresolvable split-brain requiring a decision) — and that escalation is **deduped per partition-episode**, never per heartbeat tick.
+- **Tunable latency vs. efficiency** (explicit Justin requirement). Every cadence/aggressiveness knob is configurable with sane defaults; "more machines = more reliable" must not mean "more machines = constant chatter" — enforced by an explicit cost ceiling (§9).
+- **Ephemeral liveness ≠ durable history.** Heartbeats/leases are high-frequency and disposable; git history is durable and append-only. They must not share a write path, or the repo bloats by thousands of commits/day (§8 G2).
+- **Reuse the catch-up model, don't reinvent.** A handoff is the cross-machine generalization of compaction-recovery and fresh-session continuation. The receiving machine resumes via the existing **CONTINUATION** mechanism; the user-facing bar is "no worse than a compaction pause." No fragile always-streaming pipe.
+- **Own the lifecycle.** A single sentinel class owns the whole handoff (detect → attempt → verify → retry → finalize) with race guards, rather than scattering the steps across five components (§8 G3e).
+
+---
+
+## Coordination Primitive — The Fenced Lease
+
+Everything authority-bearing (who is awake, who holds channel ingress) is expressed as a **fenced lease**, the standard distributed-systems primitive for "exactly one holder, safe under clock skew and partition." This single primitive resolves the split-brain, ingress-ownership, and authority findings together.
+
+- **Epoch (fencing token).** A monotonically increasing integer, advanced once per successful lease acquisition. It is the *authority clock* — never wall-clock time. Stored in the registry as `leaseEpoch`.
+- **Lease record.** A single registry object: `{ holder: machineId, epoch: N, expiresAt: <holder-local-monotonic+TTL>, signature }`, signed with the holder's Ed25519 key (the v3 machine key). Acquisition is a **compare-and-swap**: a machine may take the lease only by writing `epoch = currentEpoch + 1` and only if no unexpired higher-or-equal epoch exists. Git has no native CAS, so the CAS is enforced via (a) push-fast-forward-or-reject + re-read + re-evaluate, and (b) epoch monotonicity: a push that would not advance the epoch, or that conflicts, is rejected and retried from fresh state. **Epoch gaps are explicitly safe** — any holder observed at an epoch higher than mine wins on re-read; skipping a number is never an error. To prevent a symmetric **livelock** (two live machines repeatedly contending and re-reading without either landing), CAS acquisition has a bounded retry (default 5, exponential backoff); after exhaustion the higher-`machineId` machine backs off for `leaseTtlMs` before retrying, guaranteeing one side lands. A machine that cannot push at all (net-isolated) self-suspends ingress (structural gate, §8 G2) rather than serving on an unconfirmable lease. The **low-latency authoritative copy of the lease travels over the tunnel** (bounded by RTT); the git copy is the durable audit trail, not the transfer mechanism — this closes the git-cadence transfer-window race.
+- **Fencing check.** Before *every* awake-only action — ingress poll, scheduler tick, outbound send, authority-bearing registry write — the actor verifies it holds the lease at the current epoch (`holdsValidLease(self)`), and stamps its writes/sends with that epoch. Any consumer (registry, outbox, the channel-send path) **rejects actions stamped with a stale epoch.** A wedged old-awake that resumes after the lease moved on is fenced out: its late writes and late sends carry an old epoch and are dropped. **The epoch used for the fencing check is `max(tunnel-observed, git-committed)`** — a fast tunnel copy can *accelerate* acquisition but can never lower the observed epoch below what git has already committed. Normatively, **a tunnel lease message is accepted only if its `leaseEpoch ≥ the current git-committed epoch`** (below-floor messages are dropped), and each lease message carries a per-holder monotonic nonce so a replay of a previously-seen message is detected and ignored — together these mean a delayed/replayed tunnel message can neither trick a standby into believing a stale lease is current nor suppress a legitimate acquisition once the real holder's lease has TTL-expired.
+- **Lease renewal requires the tunnel medium.** A holder renews its lease over the tunnel each `ingressHeartbeatMs`. If it cannot renew for `> leaseTtlMs` (tunnel unreachable), it **MUST self-suspend ingress regardless of its local monotonic clock** — the lease lapses; it does not get to keep serving on a clock it controls. This closes the tunnel-down / git-up split-authority window (a stranded old-awake stops within `leaseTtlMs`, well before a standby's failover acquisition).
+- **`machineId` is unforgeable.** Derived from the machine's Ed25519 public key (hash/truncation), so it is unique and cryptographically bound — safe to use as the deterministic tiebreaker and as the lease holder identity.
+- **Clock-skew safety.** Election authority is the epoch, not `lastSeen`. `lastSeen` is retained only for human-readable staleness and for the *liveness* heuristic (presumed-dead after `failoverThresholdMs`), and that threshold must exceed worst-case NTP drift by ≥2×. A machine with a fast clock can no longer "win" anything — it has no way to advance the epoch without a valid CAS.
+
+A machine's roles map onto the lease: **awake = holds the coordination lease**; **standby = does not.** "Split-brain" becomes definitionally impossible for *new* actions (two machines cannot both hold the same epoch); any residual overlap during a transfer is bounded by the lease TTL and rendered harmless by the idempotent message ledger.
 
 ---
 
 ## The Seamlessness Gap — Precise Definition
 
-The gap decomposes into three sub-problems, in dependency order:
-
 | ID | Gap | Why it matters | Phase 0 evidence |
 |----|-----|----------------|------------------|
-| **G1** | Split-brain resolution | Two "awake" machines = duplicated work, conflicting writes, user confusion | Registry showed both `awake` |
-| **G2** | Automated state sync | Without it, no machine has a current view of the mesh; failover/handoff act on stale data | Role change never pushed to git |
-| **G3** | Seamless channel experience: ingress ownership transfer + conversation-context availability + no-visible-seam | The actual user-facing "no amnesia" experience on Telegram (US1/US2) | Not yet built |
+| **G1** | Lease-based leader resolution (replaces split-brain "resolver") | Two "awake" machines = duplicated work, conflicting writes, user confusion | Registry showed both `awake` |
+| **G2** | Automated state sync, with ephemeral/durable separation + the missing wiring | Without it, no machine has a current view of the mesh; failover/handoff act on stale data | Role change never pushed; `SyncOrchestrator` not wired to `roleChange` |
+| **G3** | Seamless channel experience: idempotent ingress + lease-fenced ownership transfer + context availability + a lifecycle owner | The actual user-facing "no amnesia, no double-reply" experience (US1/US2) | Not yet built |
 
-G2 is a prerequisite for trustworthy G1 and G3 (you cannot resolve or hand off on stale state).
+G2 is a prerequisite for trustworthy G1 and G3 (you cannot resolve or hand off on stale state). G1's determinism holds **only** because the lease lives on the low-latency tunnel path; the git copy may lag, but authority does not depend on the git copy being current.
 
 ---
 
 ## Proposed Design
 
-### G1 — Split-Brain Resolution
+### G1 — Lease-Based Leader Resolution
 
-Add a deterministic resolver to `HeartbeatManager` / `MultiMachineCoordinator`:
+Replaces the v0 "every machine runs the resolver and writes the registry" design (which violated signal-vs-authority and raced under skew).
 
-- **Detection (signal).** On each heartbeat tick, if the synced registry shows more than one machine in `role: awake`, emit a `split-brain-detected` signal with the candidate set.
-- **Resolution (authority).** The coordinator resolves deterministically:
-  1. A machine whose `lastSeen` is older than the failover threshold is **demoted** to `standby` (it is presumed dead/offline).
-  2. Among machines with fresh heartbeats, the one with the most recent `lastSeen` wins; ties broken by lowest `machineId` (deterministic, so all machines independently reach the same verdict).
-  3. The winner writes the corrected registry (single `awake`); demoted entries are marked `standby` (and `status: offline` if past threshold).
-- **Self-demotion safety.** A machine that determines *it* lost must stop awake-only activity (job scheduling, Telegram ingress claim) before yielding — never two schedulers running.
-- **Escalation.** If the candidates are genuinely co-fresh and cannot be deterministically separated (clock skew, true partition), emit an Attention-queue item rather than flip-flop. This is the only user-visible path, and only when truly unresolvable.
+- **Detection (signal, any machine).** On each heartbeat tick, if the synced registry shows more than one machine claiming `awake`, or the lease appears expired/contested, emit a `lease-contested` signal. Detection never mutates roles.
+- **Acquisition (authority, CAS).** A machine that believes it should be awake (startup with no live holder; failover threshold passed for the current holder; planned handoff target) attempts to acquire the lease: CAS `epoch+1` over the tunnel; on git, push-or-reject-then-reread. Exactly one acquisition can win an epoch. The winner is, by construction, the single authority.
+- **Demotion is structural, not cooperative.** A machine that does *not* hold the current lease is standby — its scheduler and ingress consumers are gated off by `holdsValidLease(self)` regardless of any in-memory signal. The Phase 0 "nobody demoted the silent peer" cannot recur: the silent peer's lease expires, and a single CAS acquisition by the live machine makes it the sole holder; the silent peer, on any later action, fails its own fencing check.
+- **Liveness tiebreak.** Presumed-dead (`lastSeen` older than `failoverThresholdMs`, which exceeds NTP drift ×2) frees the lease for acquisition. If two genuinely-live machines contend, the CAS resolves it deterministically (only one epoch advance wins); the unforgeable lowest-`machineId` is the deterministic preference for *who attempts first*, but correctness does not depend on it — the CAS is the real arbiter.
+- **Escalation (the only user-visible path).** If acquisition cannot complete (e.g. a true partition where neither side can advance the epoch via any shared medium), emit **one** Attention-queue item, deduped on a stable `partitionEpisodeId` (not per-tick), carrying a specific decision ("machine X looks alive but unreachable — demote it? Y/N") and a `recurrenceCount`. After `splitBrainEscalationCooldownMs` the resolver stops re-evaluating until the user acts.
+- **Supervision.** Tier 0 (pure deterministic algorithm, no policy judgment) — *justified*: the escalation fires only on an **unambiguous** trigger (`lastSeen` past the drift-padded `failoverThresholdMs`, or a CAS that cannot land on any shared medium), and the Attention item presents the contested state as **data** (which machine, its last-seen, the evidence) plus a Y/N decision — it does not author a recommendation. There is no soft framing judgment for an LLM to get wrong; the only judgment (which machine to keep) is the user's. (If future telemetry shows the deterministic framing can still mislead, a Tier-1 framing pass is the upgrade path — noted, not built.)
 
-### G2 — Automated State Sync
+### G2 — Automated State Sync (with the missing wiring named)
 
-Make the running server actually propagate mesh state (the Phase 0 gap):
-
-- `SyncOrchestrator` on the **awake** machine auto-commits + pushes registry and heartbeat changes on a tunable cadence (debounced; not on every field write).
-- Standby machines pull on a tunable cadence and on wake.
-- Reuse existing `GitSync` field-merge / signed-commit machinery (no new transport for durable state).
-- **Idempotent + conflict-free:** registry writes are last-writer-wins per-machine-entry (each machine only authors its own entry, except role demotions which are authored by the resolver winner). This avoids merge conflicts on the shared registry.
-- **Failure handling:** a push failure is a signal (retry with backoff), not a crash; sync health is observable via `/health` and `instar doctor`.
+- **Ephemeral vs durable split (closes the git-bloat finding).** Heartbeat/lease liveness is **not** committed to git history on every tick. It lives in a compact, single-blob state file written by atomic rename and propagated over the tunnel; only **meaningful, durable** state transitions (role/lease epoch change, work-ledger checkpoints) are committed to git, and those are debounced and coarse. Steady-state healthy operation produces ~0 commits, not thousands/day.
+- **The wiring (the Phase 0 fix, stated explicitly).** `MultiMachineCoordinator.on('roleChange', …)` (and lease-epoch change) calls `syncOrchestrator.markRegistryDirty()`; the subscription is established in `AgentServer` startup where both objects already exist; the debounce lives in a `RegistrySyncDebouncer` (or `GitSync`'s pending-paths flush). A **wiring-integrity test** (§10) asserts the subscription exists and a simulated role change triggers a push — this test would have caught Phase 0.
+- **Single-writer for authority state.** Only the lease holder writes authority-bearing registry fields; each machine writes only its own liveness entry. This removes the O(N) thundering-herd of every machine pushing a corrected registry.
+- **Push contention handling.** Every push is preceded by `pull --rebase`; on non-fast-forward, re-read, re-evaluate against the current epoch, and only act if still authoritative; exponential backoff, max-retry, then a sync-health signal. A machine failing to push its liveness for `> ingressHeartbeatMs × N` self-suspends ingress (structural gate above).
+- **Replay/freshness on pull.** Applied registry commits must carry a strictly-increasing `syncSequence` per author, **the `leaseEpoch` they were authored under**, and a valid signature (v3 signed-commit + revoked-machine rejection already exists). A commit is discarded (logged, not applied) if it is unsigned, its `syncSequence` is stale for its author, **or its `leaseEpoch` is lower than the current committed epoch** — the epoch check catches the case a per-author sequence cannot: a machine that wiped/restored local state (sequence resets to 0) or re-keyed cannot smuggle in an authority-bearing write, because its stale `leaseEpoch` is rejected regardless of a locally-monotonic sequence.
+- **Unknown-key first commit is constrained.** The **first** commit from a previously-unseen `machineId` (a re-keyed or freshly-joined machine) is accepted **only** if it is `role: standby` + `rejoined: true` (or a valid pairing-join record); any unknown-key first commit asserting an awake role or a lease claim is rejected. A rejoining machine must always pull-and-read before writing — it never writes its stale prior role. (Security-negative test, §10.)
+- **Supervision.** Tier 0 (mechanical), with the sync-health signal feeding the existing monitoring layer.
 
 ### G3 — Seamless Channel Experience
 
-This is the user-facing core (US1/US2), and it is defined by the channel, not by internal state. It has three parts that together deliver the acceptance criteria in §2.
+The user-facing core (US1/US2), defined by the channel. Five parts.
 
-**(a) Channel-state classes and transports.** Two kinds of state must reach the receiving machine:
+**(a) Idempotent message processing (the no-loss / no-duplicate guarantee).** A durable **message-processing ledger**, keyed by the adapter's `dedupeKey(rawEvent)`, records each inbound event's lifecycle: `received → processing → reply_committed → cursor_advanced`. Rules:
+- An event whose `dedupeKey` is already `reply_committed`/`cursor_advanced` is **never acted on again** — redelivery (Telegram retry, Slack reconnect, or a transfer-window overlap) is recognized and dropped.
+- The outbound reply is reserved in a **fencing-token-gated outbox** before send; a machine may only send while holding the lease at the stamped epoch. A fenced (stale-epoch) machine's in-flight reply is suppressed at the send path. This is what actually prevents the double-reply the spec promises — not the assumption of a single consumer.
+- **Outbound idempotency key + dual-medium sent-marker (closes the `reply_committed`-during-failover dup).** Every reply carries a deterministic idempotency key (`hash(dedupeKey + replyIndex)`) that any machine re-running the same event reproduces identically. The `reply_committed` marker (and the idempotency key of the sent reply) is propagated over **both** the tunnel *and* git, so a failover where either medium survived sees the reply already happened and does not re-send. On a channel with native outbound dedup, the key makes re-send a no-op even if no marker propagated. **Honest residual:** the only case that can still produce *one* duplicate reply is the simultaneous triple-fault — reply physically sent, then the holder hard-crashes before the marker reaches *either* medium, on a channel with *no* native outbound dedup (Telegram). This is the Two-Generals impossibility floor, not a design defect; it is bounded to a single duplicate, surfaced honestly in §3, and mitigated (not eliminable) by the dual-medium marker + idempotency key.
+- The ingress cursor advances **only** on durable completion (`cursor_advanced`), so a crash before completion replays the event (at-least-once) and the ledger makes the replay a no-op-or-resume (exactly-once effect).
+- **Storage substrate (named, per lesson L17 + Migration Parity).** The ledger and outbox are **SQLite-backed** (the same proven path as `PendingRelayStore` / `CommitmentTracker`: WAL + busy_timeout, per-agent-id isolation), **not** a new ad-hoc JSON file and **not** a new git-synced blob. They **self-initialize** on first access (schema created if absent) — no `migrateConfig` schema step needed; this is stated in §11. They are not folded into the Integrated-Being Ledger because their write rate (per-message, sub-second) and dedup-keyed access pattern differ from the IBL's coarse durable entries — this divergence is deliberate, not the L17 backtrack-tell.
+- **Durability is local-immediate, cross-machine bounded by the lease medium (honest statement).** Each lifecycle transition is flushed to local SQLite **synchronously, on commit** — *not* on the debounced `registrySyncDebounceMs` git cadence — so a crash-and-restart on the *same* machine never double-acts. For a *hard failover to another* machine, ledger transitions propagate over the **same low-latency tunnel as the lease** (not the coarse git path), so the receiving machine's view is fresh to within tunnel RTT; the residual worst case (tunnel-down hard crash) is bounded and reconciled by `dedupeKey` on the provider's at-least-once redelivery — the channel itself re-presents the event, and the ledger dedups it once the standby's ledger catches up.
+- **Stuck-`processing` recovery.** An entry left in `processing` past `maxProcessingMs` (e.g. the old holder was fenced mid–LLM-turn and its reply suppressed) is eligible for re-run by the current lease holder, which re-executes the turn from the ledger entry's stored input. The fenced machine's abandoned output is discarded. This prevents an event from being stranded in `processing` forever when a lease moves during a long turn. (Tier-1 test, §10.)
 
-- **Durable work state** (work ledger, in-flight task list) → **git** (coarse, every N seconds, tunable). Survives crashes; this is the cross-machine work-ledger visibility the v3 spec named "not yet implemented."
-- **Live conversation tail** (the recent exchanges + current turn context for each active channel/topic) → **direct tunnel channel** between awake and standby (low-latency push), buffered so the standby always holds a near-current copy. This is what satisfies "context retained" (criterion 3) — the receiving machine can answer the next message coherently.
+**(b) Channel-state classes and transports.**
+- **Durable work state** (work ledger, in-flight task list, the message-processing ledger) → **git** (coarse, on checkpoint, tunable; subject to the ephemeral/durable split in G2).
+- **Live conversation tail** (recent exchanges + current-turn context per active topic) → **direct tunnel channel**, low-latency push, **persisted on the standby** (acknowledged, with freshness metadata) so a hard failover has a durable, not merely in-memory, copy. Bounded by `liveTailMaxBytesPerTopic` (drop-oldest) and a push-rate cap; on N>3 machines, only the designated next-in-line standby maintains a live-tail subscription, others pull from git (the cost ceiling that makes "more machines = more reliable, not more chatter" actually hold).
+- **Tail flushes are sequence-deduped on the standby (context-integrity).** Each flush carries the monotonic sequence (§8 G3c). The standby applies a flush **only if its sequence is `lastAppliedSeq + 1`**, coalescing/holding out-of-order flushes and dropping duplicates — so an at-least-once tunnel redelivery cannot double-append and corrupt the persisted context window (which would make the post-failover reply misrepresent history, violating criterion 3). Out-of-order flushes are held only until `liveTailOutOfOrderTimeoutMs` (default = `leaseTtlMs`); if the gap is never filled (sender died mid-sequence), the standby **declares the gap unfillable, discards the held flushes, and proceeds with the last contiguous sequence** as its resumable tail — bounding the holdout buffer and never wedging the standby behind a gap the at-least-once channel will re-present anyway. To bound the redaction/leak surface, large raw tool-output is **carried by reference** (a pointer into the durable encrypted work-ledger) rather than inlined into the tail wherever feasible, so the secret-redaction problem (§8 G3c) is reduced structurally, not left purely to pattern-matching.
 
-**(b) Channel ingress ownership transfer (the no-loss / no-duplicate guarantee).** This implements the Channel Seamlessness Contract (§2) and is channel-agnostic; each adapter plugs in its own resumable position. The protocol guarantees exactly-once handling:
+**(c) Live-tail transport security (NORMATIVE — promoted from open question).** The live tail carries the most sensitive data in the system (user messages, tool outputs, incidentally-present secrets). It therefore MUST:
+- Be **mutually authenticated** — the receiver's machine identity is verified against the mesh registry's Ed25519 public key before any tail content is accepted or decrypted.
+- Use **authenticated encryption in transit** — the same scheme as v3 secret sync (ephemeral X25519 key agreement + XChaCha20-Poly1305), forward-secret per flush.
+- Carry a **monotonic sequence** for replay protection and a wall-clock stamp **for staleness display only** (never for election).
+- **Redact/exclude secrets** — content matching v3's secret patterns (tokens, keys, Secret Drop payloads) is redacted or routed through the v3 secret channel, never sent in the clear over the tail. The redaction **category set is versioned alongside this spec** (a named enum, not an ad-hoc inline regex) so it can be extended as new token/credential shapes appear; combined with the carry-by-reference rule (§8 G3b), the tail minimizes raw sensitive bytes structurally rather than relying on pattern-matching alone. Note the residual: the standby persists the *decrypted* tail, so a compromised standby is a cleartext-exposure surface — carry-by-reference keeps the heaviest such content (tool output) out of the tail.
+- Be **rejected if the peer identity cannot be verified.** A §10 security-negative test asserts this.
 
-1. Incoming machine signals intent to take ingress ownership.
-2. Outgoing machine **stops consuming** and records the adapter's resumable position into synced state (Telegram: last-processed `update_id`; Slack: last-acked event/cursor; etc.).
-3. Incoming machine **resumes consuming from that exact position** — messages in the transfer window are processed exactly once (none dropped, none double-handled). This directly serves criteria 1 & 2.
-4. Only one machine ever holds the ingress claim at a time (enforced via the mesh registry / a claim record), so two machines can never both reply.
+**(d) Verifiable, bounded handoff acknowledgment.** "Caught up" is not a bare boolean. The incoming machine's ack must **echo**: the live-tail sequence number it holds, the ingress position it will resume from, and a hash of the thread history it loaded. The outgoing machine verifies the echo matches what it flushed *before* yielding. There is a hard `handoffAckTimeoutMs`: if the verified ack does not arrive, the **graceful handoff is aborted and the outgoing machine stays awake** (planned case) or the system falls through to failover semantics — it **never** yields ingress on an unverified or absent ack. The ack travels over the same tunnel as the tail, so a dead tunnel correctly forces failover mode rather than a false "caught up."
 
-The handoff orchestration (claim, record-position, resume) lives in the shared coordination layer; only the "read/record/resume my position" primitive is per-adapter. Telegram is the reference implementation; Slack is the second target and validates that the contract is genuinely channel-agnostic.
+**(e) The handoff lifecycle owner (own-the-lifecycle).** A single **`HandoffSentinel`** owns the entire handoff as an explicit epoch state machine — `prepare → tail_synced → ingress_fenced → new_owner_active → old_owner_standby → committed` — with one entry point, per-handoff state, verify-before-finalize, bounded retry, terminal events (`handed-off` / `failover-complete` / `failed`), and a **race guard** so the zombie reaper / scheduler do not act mid-handoff. **The outgoing machine retains the lease (and its fencing epoch) through the entire `ingress_fenced → new_owner_active` window**; the incoming machine attempts its lease-CAS acquisition **only after receiving an explicit `yield` signal from the outgoing machine**, which is sent *only* on a verified ack (§8 G3d) AND a passing Tier-1 validation. A validator timeout or ack-verification failure means **no `yield` signal is sent** — so the incoming machine never initiates its CAS, the outgoing machine simply stays awake, and there is no window in which both attempt to hold the same epoch. (This closes the planned-handoff yield race; a hard failover, by contrast, has no outgoing machine to send `yield`, so the incoming acquires via the lease-TTL-expiry path in §6.) Every worker (channel send, scheduler) acts from the current epoch and rejects stale epochs. This replaces the v0 design that scattered handoff steps across `HeartbeatManager`, `MultiMachineCoordinator`, `SyncOrchestrator`, and `HandoffManager` with no owner. `HandoffManager` is *extended* (new `flushToIncoming` / `awaitVerifiedAck` methods) — its current behavior covers only WIP-commit + note-file (steps equivalent to prepare + a coarse commit), not the live two-machine protocol.
+- A `minHandoffIntervalMs` prevents oscillation from hammering the CONTINUATION machinery (each resume is an LLM call).
+- **Supervision.** Tier 1 — handoff errors are user-visible; a Haiku-class validator confirms the receiving machine's ack/echo before the lease yields. **Latency budget (lesson B24):** the validator's own timeout is sized well inside `handoffAckTimeoutMs`, and a validator timeout is treated as **"ack not verified" → abort the graceful handoff (outgoing machine stays awake)** — never as an implicit pass. The lease is never yielded on an unconfirmed validation.
 
-**(c) Graceful handoff protocol (both machines live):**
+**(f) CONTINUATION resume.** On the receiving side, the agent session resumes via the existing **CONTINUATION** mechanism — it picks up the conversation rather than re-greeting (criterion 3), and surfaces machine-provenance honestly when context is as-of-last-sync.
 
-1. New machine requests handoff (existing `HandoffManager` path).
-2. Current-awake **flushes** the live conversation tail + work ledger to the incoming machine and confirms.
-3. Incoming machine **acks "caught up"** (it holds the live tail + thread history) *before* the current-awake yields — this prevents the "fresh start" failure (criterion 3).
-4. Ingress ownership transfers per (b); the channel/topic binding follows the agent (criterion 5).
-5. Current-awake demotes to standby; incoming promotes to awake; registry updated (G2 propagates it).
-6. On the receiving side, the agent session resumes via the existing **CONTINUATION** mechanism — it picks up the conversation rather than re-greeting.
-
-**Failover (outgoing machine died, not graceful):** the incoming machine cannot receive a flush, so it relies on the last synced live tail (freshness bounded by `liveTailBufferMs`) + thread history + the recorded ingress offset. The user may experience at most a small catch-up gap (criterion 4's bound) but no lost/duplicate messages and no amnesia beyond the buffer window.
-
-The "seamlessness bar" — how fresh the live tail must be, and how aggressive the handoff is — is **tunable** (see §6). A near-instant bar buffers continuously; a relaxed bar accepts a small catch-up pull at handoff. The bar is chosen to keep the user-perceived pause within criterion 4.
+**Failover (outgoing died):** no flush is possible; the incoming machine acquires the lease (CAS over whatever shared medium survives), resumes from the last *persisted* live tail (freshness = RPO bound) + thread history + the durable ingress position, and the message ledger guarantees no double-action on any in-flight event. The user may see at most an RTO-bounded catch-up beat and at most RPO-bounded missing context — never a lost or duplicated message.
 
 ---
 
 ## Tunability
 
-Per Justin's explicit requirement (balance latency/seamlessness vs. efficiency). All under `.instar/config.json` → `multiMachine`:
+Per Justin's explicit requirement. All under `.instar/config.json` → `multiMachine`. **Knobs are renamed to avoid collision** with the existing `MachineHeartbeat` (`DEFAULT_HEARTBEAT_INTERVAL_MS` = 30 min) and Threadline `ConnectionManager` (60s) — both also use `heartbeatIntervalMs`, so the seamlessness knobs carry distinct names.
 
 | Knob | Default | Meaning |
 |------|---------|---------|
-| `heartbeatIntervalMs` | 30s | How often the awake machine posts/pushes its heartbeat |
-| `registrySyncDebounceMs` | 10s | Debounce window for pushing registry changes |
-| `failoverThresholdMs` | (existing, ~15min) | How stale before a peer is presumed dead |
-| `liveTailTransport` | `tunnel` | `tunnel` (low-latency) \| `git` (durable-only, cheaper) |
-| `liveTailBufferMs` | 5s | Max staleness of the standby's live conversation copy |
-| `handoffBar` | `near-instant` | `near-instant` (continuous buffer) \| `relaxed` (catch-up at handoff) |
+| `ingressHeartbeatMs` | 30s | How often the lease holder refreshes its liveness/lease (distinct from the 30-min machine-presence heartbeat) |
+| `registrySyncDebounceMs` | 10s | Debounce window for committing *durable* registry changes to git |
+| `standbyPullIntervalMs` | `failoverThresholdMs / 4` (auto) | Standby git-pull cadence; auto-derived to satisfy the **< `failoverThresholdMs` / 3** invariant (validated on startup); explicit overrides are validated against the same bound |
+| `failoverThresholdMs` | (existing, ~15min) | How stale before a peer is presumed dead; must exceed worst-case NTP drift ×2 |
+| `leaseTtlMs` | 2 × `ingressHeartbeatMs` | Lease expiry; bounds the worst-case transfer overlap window |
+| `liveTailTransport` | `tunnel` | `tunnel` (low-latency) \| `git` (durable-only, cheaper; recommended default for N>3) |
+| `liveTailMaxStalenessMs` | 5s | RPO: max staleness of the standby's persisted live tail |
+| `liveTailPushRateMs` | = `liveTailMaxStalenessMs` | How often the holder pushes a tail flush; **invariant: ≤ `liveTailMaxStalenessMs`** (validated on startup) so the RPO bound is actually achievable |
+| `liveTailOutOfOrderTimeoutMs` | = `leaseTtlMs` | How long the standby holds an out-of-order flush before declaring the gap unfillable |
+| `liveTailMaxBytesPerTopic` | 256KB | Memory/bandwidth cap; drop-oldest on overflow |
+| `handoffAckTimeoutMs` | 5s | Max wait for a verified "caught up" ack before aborting graceful handoff |
+| `minHandoffIntervalMs` | 60s | Anti-oscillation floor (protects CONTINUATION LLM cost) |
+| `splitBrainEscalationCooldownMs` | 5min | After this, stop re-escalating an unresolved partition until the user acts |
+| `handoffBar` | `near-instant` | `near-instant` (continuous tail buffer) \| `relaxed` (catch-up pull at handoff) |
 
-Defaults target a good experience for 2-machine personal use; high-machine-count or cost-sensitive deployments dial cadence down.
+Defaults target a good experience for 2-machine personal use; high-machine-count or cost-sensitive deployments dial cadence down and/or switch `liveTailTransport: git`. **Startup validation enforces the cross-knob invariants** — `standbyPullIntervalMs < failoverThresholdMs / 3`, `standbyPullIntervalMs < leaseTtlMs` (so a standby always refreshes its git-committed epoch view at least once per lease lifetime — otherwise a short `ingressHeartbeatMs` could leave it deciding `max(tunnel,git)` on a stale git floor), and `liveTailPushRateMs ≤ liveTailMaxStalenessMs` — so a user widening `ingressHeartbeatMs` (which widens `leaseTtlMs`) cannot silently invalidate the RPO bound promised in §3; a violating config is rejected with a clear message rather than degrading quietly.
 
 ---
 
 ## Testing Strategy
 
-Per the Testing Integrity Standard — all three tiers, plus the real-hardware gate:
+Per the Testing Integrity Standard — all three tiers, plus wiring-integrity, fault-injection, channel-experience acceptance, and the real-hardware gate.
 
-- **Tier 1 (unit).** Split-brain resolver: both sides of every boundary — two-fresh-awake (deterministic winner), one-stale-one-fresh (demote stale), genuine tie (escalate), self-demotion (loser stops scheduler). Sync debounce logic. Live-tail buffer freshness.
-- **Tier 2 (integration).** Full HTTP pipeline: a running server auto-pushes registry on role change (the exact Phase 0 failure — this test would have caught it); standby pulls and converges; handoff over real tunnel transfers the live tail.
-- **Tier 3 (e2e lifecycle).** Multi-process: two servers, real local git remote, real localhost tunnels; drive a graceful handoff with an in-flight conversation and assert the incoming machine has the live tail before the outgoing yields; drive a hard failover and assert split-brain resolves to a single awake within threshold.
-- **Channel-experience acceptance (the real bar).** Beyond the mechanical tiers, the §2 user-facing criteria are tested *from the channel*: drive a real conversation across a handoff/failover and assert — exactly-once message handling (no loss, no duplicate reply), context retained in the first post-handoff reply (no re-greeting), and perceived gap within bound. This is the test that actually proves US1/US2; the mechanical tiers exist to make it pass.
-- **Contract conformance across channels.** The acceptance suite runs against **Telegram (reference) AND Slack** to prove the Channel Seamlessness Contract is genuinely channel-agnostic, not Telegram-shaped. A new adapter is "seamless-ready" only when it passes this same suite — making the contract the structural gate for any future channel.
-- **Real-hardware gate.** `docs/MULTI_MACHINE_VERIFICATION.md` (60 items) remains the live acceptance gate. G1/G2/G3 each map to specific checklist sections (§2 Heartbeat/Failover, §3 Git Sync, §6 Handoff, §7 Communication, §10 Full Lifecycle).
+- **Tier 1 (unit).** Lease CAS: two contenders, exactly one epoch advance wins; stale-epoch action rejected (fencing); `max(tunnel,git)` epoch never regresses below git-committed; epoch-gap accepted; livelock backoff lands one winner; expired lease frees acquisition; clock-skew machine cannot win; tunnel-unreachable-past-`leaseTtlMs` holder self-suspends ingress. Message-ledger: redelivered `dedupeKey` is a no-op; cursor advances only on `cursor_advanced`; transition flushed to SQLite synchronously (durable across same-machine crash-restart); `processing` past `maxProcessingMs` is re-runnable by the new holder. Live-tail: out-of-order/duplicate flush is coalesced/dropped (no doubled context). Sync debounce; live-tail staleness/byte-cap; escalation dedup by `partitionEpisodeId`.
+- **Tier 2 (integration).** Full HTTP pipeline: `roleChange`/lease-epoch change marks the registry dirty and triggers an auto-push (**the exact Phase 0 failure — this test gates it**); standby pulls and converges; stale-sequence commit on pull is discarded.
+- **Tier 3 (e2e lifecycle).** Multi-process: two servers, real local git remote, real localhost tunnels; planned handoff with an in-flight conversation asserts the incoming machine holds the verified tail before the lease yields; hard failover asserts a single lease holder within threshold and the message ledger prevents double-action.
+- **Wiring-integrity tests (required, per the "feature actually alive" lesson).** Assert: `MultiMachineCoordinator` has a live `roleChange` subscriber that calls into `SyncOrchestrator`; the `HandoffSentinel` is constructed and wired in `AgentServer` startup (not dead code); the live-tail transport component is started.
+- **Fault-injection (the adversarial/external block).** Inject crashes at every boundary: after channel ack before cursor sync, after cursor sync before reply, mid outbound send, during a non-fast-forward git push, under injected clock skew, with delayed/dropped tunnel packets, and with duplicate provider deliveries. Assert exactly-once *effect* and single-lease-holder in every case.
+- **Security-negative (the security block).** Forged/stale-epoch lease write rejected; unsigned/replayed/low-`leaseEpoch` registry commit rejected on pull; unknown-key first commit asserting `awake` rejected (only `standby`+`rejoined` accepted); live-tail rejected from a peer whose identity can't be verified; a false "caught up" ack whose echo-hash mismatches does not cause yield; secrets in the tail are redacted.
+- **"Feature is alive" E2E (the most important test).** An automated Tier-3 test asserts the server exposes `/health.multiMachine.syncStatus` and returns valid fields (not null, not 503) on a single-machine install — the standard Phase-1 alive check, distinct from the manual real-hardware gate.
+- **Channel-experience acceptance (the real bar).** Drive a real conversation across a handoff/failover and assert from the channel: exactly-once handling (no loss, no duplicate reply), context retained in the first post-handoff reply (no re-greeting), perceived pause within RTO. Runs against **Telegram (reference) AND Slack** to prove the contract is channel-agnostic — a new adapter is "seamless-ready" only when it passes this suite.
+- **Real-hardware gate.** `docs/MULTI_MACHINE_VERIFICATION.md` (60 items) remains the live acceptance gate. **It is a merge prerequisite for the launch increment** (not a post-merge afterthought); G1/G2/G3 each map to specific checklist sections (§2 Heartbeat/Failover, §3 Git Sync, §6 Handoff, §7 Communication, §10 Full Lifecycle). The new `/health.multiMachine.syncStatus` fields (below) give the checklist concrete endpoints to probe.
 
 ---
 
-## Migration Parity
+## Migration Parity & Agent Awareness
 
 Existing multi-machine agents must receive this on update, not just new ones:
 
-- **Config defaults** → `migrateConfig()` adds the `multiMachine` knobs (existence-checked, only missing fields).
-- **Resolver + auto-sync** ship in the server; existing agents get them on the next server update. No agent-installed file changes required for G1/G2 beyond config.
-- **Idempotent.** Resolver and sync are safe to run repeatedly; a single-machine agent (no peers) is a no-op.
+- **Config defaults** → `migrateConfig()` (sync path, applies before first server boot) adds the renamed `multiMachine` knobs, existence-checked per individual key, under a named marker `_instar_migrations: "seamlessness-v1-config-defaults"` for idempotency. The rename means no collision with any pre-existing `heartbeatIntervalMs`.
+- **Mesh protocol version gate (partial-migration safety).** The mesh carries a `protocolVersion`. A machine that does not support fenced leases + ingress dedup + handoff epochs is **ineligible for the awake lease** during a seamless handoff — an old-version machine cannot be handed authority, preventing a half-migrated mesh from running two coordination semantics at once.
+- **Resolver + auto-sync + HandoffSentinel + live-tail transport** ship in the server; existing agents get them on the next server update. The wiring (G2) is server-internal — covered by the wiring-integrity tests so it cannot regress to dead code.
+- **New durable stores self-initialize.** The SQLite-backed message-processing ledger and outbox create their schema on first access (the `PendingRelayStore` pattern) — no `PostUpdateMigrator` schema step is required, and an existing agent's first post-update server boot initializes them transparently. This is the explicit contract (not an assumption), so the stores are never "missing" on an upgraded agent.
+- **CLAUDE.md template (Agent Awareness Standard).** `generateClaudeMd()` gains a short multi-machine-seamlessness section (machine-aware honest-disclosure behavior; the `/capabilities` pointer for mesh/sync status; how to read a split-brain Attention escalation); `migrateClaudeMd()` adds it to existing agents with a content-sniffing guard. The honest-disclosure behavior itself is delivered via CONTINUATION injection at session-start, **not** a permanent prompt section (avoids L1 context bloat).
+- **Observability.** `/health` gains `multiMachine.syncStatus`: `{ leaseHolder, leaseEpoch, lastPushAt, lastPullAt, liveTailStalenessMs, splitBrainState }`; `instar doctor` surfaces the same. This is what the agent reads before claiming mesh state, and what the real-hardware checklist probes.
+- **Idempotent.** Resolver, sync, and migrations are safe to run repeatedly; a single-machine agent (no peers, holds its own lease trivially) is a no-op.
 
 ---
 
@@ -224,5 +287,5 @@ Existing multi-machine agents must receive this on update, not just new ones:
 
 - **Companion spec — Agent Self-Propagation Standard.** Justin's standard (one human authorization to grant an agent access to a new machine, then the agent installs itself and everything downstream). The Phase 0 onboarding findings feed it directly: the two-bootstrap access problem (SSH + git credential), `join` not creating a runnable `config.json`, and the default-port (4040) collision risk with an existing agent. **A joining machine must pick a free port and write a runnable config** — tracked there, not here.
 - **Server bring-up on a guarded/new machine.** `instar server start` is (correctly) blocked from inside an agent session. The self-propagation flow must define how an agent brings up its *own* server on a new machine without that guard — likely launchd/supervisor registration performed in the onboarding step. Open question for the companion spec.
-- **Open: clock-skew handling** in G1 ties (NTP assumption vs. logical clocks).
-- **Open: live-tail privacy** — the conversation tail crossing the tunnel must honor the same secret-handling rules as the v3 secret-sync channel.
+- **Closed by v1 (were open in v0):** clock-skew in elections (now epoch-fenced, not wall-clock); live-tail privacy (now normative §8 G3c). Retained as **explicit, principal-approvable deferrals only if** the launch increment scopes Slack to best-effort `lastTs` before the full Events-API dedup path — flagged for sign-off, not silently dropped.
+- **Open: lease medium under total partition.** When neither tunnel nor git is reachable between machines but both can reach the user channel, no shared medium can advance the epoch — the design correctly degrades to "each fences on its own last-known lease and self-suspends ingress if it can't refresh," but the *product* choice of which side keeps serving in a true split is the user-escalation path; whether a third arbiter (e.g. the channel itself as a tiebreak token) is worth adding is an open question.

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
@@ -29,7 +29,7 @@
 
 The converged multi-machine spec (v3) delivered machine identity, secure pairing, git-based state sync, primary/standby coordination, heartbeat/failover, and graceful handoff *machinery*. What it explicitly deferred — and what the EXO 3.0 "cross-machine single agent" vision needs most — is **seamlessness**: the experience that an agent is one logical identity that follows the user across machines with no loss of in-flight context.
 
-**The yardstick is the user's experience in the channel** (Telegram first), not internal state mechanics. "Seamless" is defined entirely from the user's side: a person is mid-conversation with the agent over Telegram; the agent quietly moves machines underneath them; and the person notices *nothing* — no dropped message, no duplicate reply, no "sorry, what were we talking about?", no fresh greeting, no awkward gap. The internal state sync exists only to deliver that channel experience. Every design choice below is justified by a user story, not by architectural elegance.
+**The yardstick is the user's experience in the channel** (Telegram is the default and reference; Slack and any other channel must work equally), not internal state mechanics. "Seamless" is defined entirely from the user's side: a person is mid-conversation with the agent over Telegram; the agent quietly moves machines underneath them; and the person notices *nothing* — no dropped message, no duplicate reply, no "sorry, what were we talking about?", no fresh greeting, no awkward gap. The internal state sync exists only to deliver that channel experience. Every design choice below is justified by a user story, not by architectural elegance.
 
 This spec defines the narrow, high-leverage work to close that gap. It is deliberately scoped to the **runtime** seamlessness problem. The **onboarding** problem (how an agent installs itself onto a new machine) is captured as related work for a companion spec (see §9).
 
@@ -51,15 +51,20 @@ These are the user-facing pass/fail bars — the real Phase-0-style gate, observ
 2. **No duplicate replies.** The user never receives the same answer twice (a real, recurring instar failure mode — see drain-respawn / gate-latency duplicates). Only one machine "owns" the channel at a time.
 3. **Context retained.** The first reply from the new machine demonstrates knowledge of the immediately-preceding exchange — no generic greeting, no "what were we talking about?" (honors the existing CONTINUATION discipline, now cross-machine).
 4. **No perceptible seam.** The pause the user experiences during a handoff stays under a tunable bound (default target: indistinguishable from a normal "agent is thinking" delay).
-5. **Channel identity follows the agent.** The Telegram topic/thread binding moves with the agent, so replies land in the same conversation thread regardless of which machine produced them.
+5. **Channel identity follows the agent.** The channel's thread/conversation binding (Telegram topic, Slack channel+thread, etc.) moves with the agent, so replies land in the same conversation regardless of which machine produced them.
 
-### Channel mechanics this requires (Telegram, generalizable to other adapters)
+### Channel-agnostic by design (Telegram is the default, not the spec)
 
-The agent's connection to Telegram is *long-poll ingress owned by one machine at a time*. Seamlessness therefore needs:
+Seamlessness is a property of the **channel layer**, not of Telegram specifically. Instar already routes every channel through the adapter pattern (`MessageRouter` → `TelegramAdapter`, `SlackAdapter`, `WhatsAppAdapter`, iMessage, …). This spec defines a single **Channel Seamlessness Contract** that every adapter must satisfy; Telegram is the reference/default implementation, and Slack is the explicit second target. No mechanism here may be Telegram-specific — anything Telegram-specific lives *inside* the Telegram adapter.
 
-- **Single-owner ingress with clean transfer.** Exactly one machine polls Telegram at any moment (two pollers = duplicate handling). On handoff/failover, ingress ownership transfers atomically — the outgoing machine stops polling only once the incoming machine has taken the claim.
-- **No-loss across the transfer window.** Messages that arrive during the brief transfer are buffered/replayed, not dropped. (Instar already has a "messages are not lost — they replay on recovery" pattern for version-skew restarts; reuse that guarantee here.)
-- **Conversation context on the receiving machine.** The per-topic thread history and the live tail of the current exchange must be present on the incoming machine before it answers — this is what prevents the "fresh start" failure.
+**The Channel Seamlessness Contract (every adapter implements):**
+
+1. **Single-owner ingress.** Exactly one machine consumes the channel's inbound stream at any moment (two consumers = duplicate handling). Ownership is recorded in the mesh and transfers atomically on handoff/failover — the outgoing machine releases only once the incoming machine holds the claim.
+2. **Resumable consumption position (exactly-once).** Each adapter exposes a durable "where I left off" marker that can be recorded into synced state and resumed by another machine, so the inbound stream is consumed exactly once across a transfer — none dropped, none double-handled. *The marker is per-channel:* Telegram = the long-poll `update_id` offset; Slack = the Events API delivery + per-event dedup id (or socket-mode cursor); other adapters define their own. The contract is "a resumable, exactly-once position exists," not any specific cursor.
+3. **Portable conversation identity.** The channel's thread/conversation handle (Telegram topic, Slack channel+thread_ts, etc.) is machine-independent, so replies land in the same conversation regardless of which machine produced them.
+4. **Context-before-answer.** The receiving machine must hold that conversation's history + live tail before it answers (prevents the "fresh start" failure). This part is channel-independent — it's agent state, routed by conversation identity.
+
+Instar already has a "messages are not lost — they replay on recovery" guarantee for version-skew restarts; the resumable-position requirement (2) is the cross-machine generalization of it.
 
 ---
 
@@ -139,12 +144,14 @@ This is the user-facing core (US1/US2), and it is defined by the channel, not by
 - **Durable work state** (work ledger, in-flight task list) → **git** (coarse, every N seconds, tunable). Survives crashes; this is the cross-machine work-ledger visibility the v3 spec named "not yet implemented."
 - **Live conversation tail** (the recent exchanges + current turn context for each active channel/topic) → **direct tunnel channel** between awake and standby (low-latency push), buffered so the standby always holds a near-current copy. This is what satisfies "context retained" (criterion 3) — the receiving machine can answer the next message coherently.
 
-**(b) Telegram ingress ownership transfer (the no-loss / no-duplicate guarantee).** Telegram ingress is single-owner long-poll. The protocol guarantees exactly-once handling:
+**(b) Channel ingress ownership transfer (the no-loss / no-duplicate guarantee).** This implements the Channel Seamlessness Contract (§2) and is channel-agnostic; each adapter plugs in its own resumable position. The protocol guarantees exactly-once handling:
 
 1. Incoming machine signals intent to take ingress ownership.
-2. Outgoing machine **stops polling** and records the last-processed update offset into synced state.
-3. Incoming machine **resumes polling from that exact offset** — messages in the transfer window are processed exactly once (none dropped, none double-handled). This directly serves criteria 1 & 2.
-4. Only one machine ever holds the poll claim at a time (enforced via the mesh registry / a claim record), so two machines can never both reply.
+2. Outgoing machine **stops consuming** and records the adapter's resumable position into synced state (Telegram: last-processed `update_id`; Slack: last-acked event/cursor; etc.).
+3. Incoming machine **resumes consuming from that exact position** — messages in the transfer window are processed exactly once (none dropped, none double-handled). This directly serves criteria 1 & 2.
+4. Only one machine ever holds the ingress claim at a time (enforced via the mesh registry / a claim record), so two machines can never both reply.
+
+The handoff orchestration (claim, record-position, resume) lives in the shared coordination layer; only the "read/record/resume my position" primitive is per-adapter. Telegram is the reference implementation; Slack is the second target and validates that the contract is genuinely channel-agnostic.
 
 **(c) Graceful handoff protocol (both machines live):**
 
@@ -185,7 +192,8 @@ Per the Testing Integrity Standard — all three tiers, plus the real-hardware g
 - **Tier 1 (unit).** Split-brain resolver: both sides of every boundary — two-fresh-awake (deterministic winner), one-stale-one-fresh (demote stale), genuine tie (escalate), self-demotion (loser stops scheduler). Sync debounce logic. Live-tail buffer freshness.
 - **Tier 2 (integration).** Full HTTP pipeline: a running server auto-pushes registry on role change (the exact Phase 0 failure — this test would have caught it); standby pulls and converges; handoff over real tunnel transfers the live tail.
 - **Tier 3 (e2e lifecycle).** Multi-process: two servers, real local git remote, real localhost tunnels; drive a graceful handoff with an in-flight conversation and assert the incoming machine has the live tail before the outgoing yields; drive a hard failover and assert split-brain resolves to a single awake within threshold.
-- **Channel-experience acceptance (the real bar).** Beyond the mechanical tiers, the §2 user-facing criteria are tested *from the channel*: drive a real Telegram conversation across a handoff/failover and assert — exactly-once message handling (no loss, no duplicate reply), context retained in the first post-handoff reply (no re-greeting), and perceived gap within bound. This is the test that actually proves US1/US2; the mechanical tiers exist to make it pass.
+- **Channel-experience acceptance (the real bar).** Beyond the mechanical tiers, the §2 user-facing criteria are tested *from the channel*: drive a real conversation across a handoff/failover and assert — exactly-once message handling (no loss, no duplicate reply), context retained in the first post-handoff reply (no re-greeting), and perceived gap within bound. This is the test that actually proves US1/US2; the mechanical tiers exist to make it pass.
+- **Contract conformance across channels.** The acceptance suite runs against **Telegram (reference) AND Slack** to prove the Channel Seamlessness Contract is genuinely channel-agnostic, not Telegram-shaped. A new adapter is "seamless-ready" only when it passes this same suite — making the contract the structural gate for any future channel.
 - **Real-hardware gate.** `docs/MULTI_MACHINE_VERIFICATION.md` (60 items) remains the live acceptance gate. G1/G2/G3 each map to specific checklist sections (§2 Heartbeat/Failover, §3 Git Sync, §6 Handoff, §7 Communication, §10 Full Lifecycle).
 
 ---

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
@@ -3,7 +3,8 @@ title: "Cross-Machine Seamlessness"
 slug: "cross-machine-seamlessness"
 author: "echo"
 eli16-overview: "CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md"
-principal-deferral-approval: pending  # the port-collision / runnable-config onboarding gaps (recurrence-risk) are deferred to the companion Self-Propagation spec; requires Justin sign-off before that spec is approved
+approved: true  # Justin approved 2026-05-27 over Telegram (topic 13481), after reviewing the 5-round convergence result
+principal-signoff: approved  # onboarding/self-install gaps are owned by ACT-156 (companion Self-Propagation spec); this spec's scope is approved as-is
 review-convergence: "2026-05-27T05:52:19.795Z"
 review-iterations: 5
 review-completed-at: "2026-05-27T05:52:19.795Z"
@@ -16,7 +17,7 @@ review-report: "docs/specs/reports/cross-machine-seamlessness-convergence.md"
 
 **Status**: Draft v1 (converged through multi-angle review; grounded in real-hardware verification 2026-05-26)
 **Author**: Echo (with Justin's direction)
-**Builds on**: [`MULTI-MACHINE-SPEC.md`](./MULTI-MACHINE-SPEC.md) (v3, converged) — this spec does NOT replace it; it closes the seamlessness gap that v3 explicitly deferred.
+**Builds on**: [`MULTI-MACHINE-SPEC.md`](./MULTI-MACHINE-SPEC.md) (v3, converged) — this spec does NOT replace it; it closes the seamlessness gap that v3 explicitly left open.
 **Companion (read first)**: [`CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md`](./CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md)
 **Motivating initiative**: Instar × EXO 3.0 — cross-machine single-agent ("one Luna across machines"), Pillar 2.
 
@@ -41,7 +42,7 @@ review-report: "docs/specs/reports/cross-machine-seamlessness-convergence.md"
 
 ## Overview
 
-The converged multi-machine spec (v3) delivered machine identity, secure pairing, git-based state sync, primary/standby coordination, heartbeat/failover, and graceful handoff *machinery*. What it explicitly deferred — and what the EXO 3.0 "cross-machine single agent" vision needs most — is **seamlessness**: the experience that an agent is one logical identity that follows the user across machines with no loss of in-flight context.
+The converged multi-machine spec (v3) delivered machine identity, secure pairing, git-based state sync, primary/standby coordination, heartbeat/failover, and graceful handoff *machinery*. What it explicitly left for a follow-on — and what the EXO 3.0 "cross-machine single agent" vision needs most — is **seamlessness**: the experience that an agent is one logical identity that follows the user across machines with no loss of in-flight context.
 
 **The yardstick is the user's experience in the channel** (Telegram is the default and reference; Slack and any other channel must work equally), not internal state mechanics. "Seamless" is defined entirely from the user's side: a person is mid-conversation with the agent over Telegram; the agent quietly moves machines underneath them; and the person notices *nothing* worse than a brief "getting up to speed" beat. The internal state sync exists only to deliver that channel experience. Every design choice below is justified by a user story, not by architectural elegance.
 
@@ -287,5 +288,5 @@ Existing multi-machine agents must receive this on update, not just new ones:
 
 - **Companion spec — Agent Self-Propagation Standard.** Justin's standard (one human authorization to grant an agent access to a new machine, then the agent installs itself and everything downstream). The Phase 0 onboarding findings feed it directly: the two-bootstrap access problem (SSH + git credential), `join` not creating a runnable `config.json`, and the default-port (4040) collision risk with an existing agent. **A joining machine must pick a free port and write a runnable config** — tracked there, not here.
 - **Server bring-up on a guarded/new machine.** `instar server start` is (correctly) blocked from inside an agent session. The self-propagation flow must define how an agent brings up its *own* server on a new machine without that guard — likely launchd/supervisor registration performed in the onboarding step. Open question for the companion spec.
-- **Closed by v1 (were open in v0):** clock-skew in elections (now epoch-fenced, not wall-clock); live-tail privacy (now normative §8 G3c). Retained as **explicit, principal-approvable deferrals only if** the launch increment scopes Slack to best-effort `lastTs` before the full Events-API dedup path — flagged for sign-off, not silently dropped.
+- **Closed by v1 (were open in v0):** clock-skew in elections (now epoch-fenced, not wall-clock); live-tail privacy (now normative §8 G3c). Retained as **explicit, principal-approvable deferrals only if** the launch increment scopes Slack to best-effort `lastTs` before the full Events-API dedup path — flagged for sign-off, not silently dropped. <!-- tracked: ACT-156 -->
 - **Open: lease medium under total partition.** When neither tunnel nor git is reachable between machines but both can reach the user channel, no shared medium can advance the epoch — the design correctly degrades to "each fences on its own last-known lease and self-suspends ingress if it can't refresh," but the *product* choice of which side keeps serving in a true split is the user-escalation path; whether a third arbiter (e.g. the channel itself as a tiebreak token) is worth adding is an open question.

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
@@ -13,14 +13,15 @@
 ## Table of Contents
 
 1. [Overview](#overview)
-2. [Phase 0 Findings (Empirical Grounding)](#phase-0-findings-empirical-grounding)
-3. [Design Principles](#design-principles)
-4. [The Seamlessness Gap — Precise Definition](#the-seamlessness-gap--precise-definition)
-5. [Proposed Design](#proposed-design)
-6. [Tunability](#tunability)
-7. [Testing Strategy](#testing-strategy)
-8. [Migration Parity](#migration-parity)
-9. [Related Work & Open Questions](#related-work--open-questions)
+2. [User Stories & Channel Experience](#user-stories--channel-experience)
+3. [Phase 0 Findings (Empirical Grounding)](#phase-0-findings-empirical-grounding)
+4. [Design Principles](#design-principles)
+5. [The Seamlessness Gap — Precise Definition](#the-seamlessness-gap--precise-definition)
+6. [Proposed Design](#proposed-design)
+7. [Tunability](#tunability)
+8. [Testing Strategy](#testing-strategy)
+9. [Migration Parity](#migration-parity)
+10. [Related Work & Open Questions](#related-work--open-questions)
 
 ---
 
@@ -28,9 +29,37 @@
 
 The converged multi-machine spec (v3) delivered machine identity, secure pairing, git-based state sync, primary/standby coordination, heartbeat/failover, and graceful handoff *machinery*. What it explicitly deferred — and what the EXO 3.0 "cross-machine single agent" vision needs most — is **seamlessness**: the experience that an agent is one logical identity that follows the user across machines with no loss of in-flight context.
 
-Concretely, the vision (per Justin): *Adriana switches laptops mid-conversation, and "Luna" keeps talking with no amnesia.* Today, even when failover works, the machine that takes over arrives without the live conversation and in-flight work state.
+**The yardstick is the user's experience in the channel** (Telegram first), not internal state mechanics. "Seamless" is defined entirely from the user's side: a person is mid-conversation with the agent over Telegram; the agent quietly moves machines underneath them; and the person notices *nothing* — no dropped message, no duplicate reply, no "sorry, what were we talking about?", no fresh greeting, no awkward gap. The internal state sync exists only to deliver that channel experience. Every design choice below is justified by a user story, not by architectural elegance.
 
 This spec defines the narrow, high-leverage work to close that gap. It is deliberately scoped to the **runtime** seamlessness problem. The **onboarding** problem (how an agent installs itself onto a new machine) is captured as related work for a companion spec (see §9).
+
+---
+
+## User Stories & Channel Experience
+
+The whole spec serves these. Each gap and design choice traces back to one.
+
+- **US1 — Invisible failover mid-conversation.** *As a user chatting with the agent on Telegram, when the machine currently serving me goes down, I keep chatting and notice nothing — my next message is answered normally, with full memory of what we were just discussing.* (No lost message, no duplicate reply, no re-introduction, no long stall.)
+- **US2 — Same agent across my machines.** *As a user (e.g. Adriana) who works on two machines, it's the same agent on both — same conversation, same half-finished task, same context — so I can switch machines and not miss a beat.*
+- **US3 — Reliability that's felt, not seen.** *As a user, I just experience an agent that's always there and always coherent; the fact that it spans several machines is invisible. More machines should mean more reliability, never more noise or more confusion.*
+
+### What "seamless" means, measured from the channel (acceptance criteria)
+
+These are the user-facing pass/fail bars — the real Phase-0-style gate, observed on the channel, not in the code:
+
+1. **No lost messages.** Every Telegram message the user sends during/around a handoff is processed exactly once.
+2. **No duplicate replies.** The user never receives the same answer twice (a real, recurring instar failure mode — see drain-respawn / gate-latency duplicates). Only one machine "owns" the channel at a time.
+3. **Context retained.** The first reply from the new machine demonstrates knowledge of the immediately-preceding exchange — no generic greeting, no "what were we talking about?" (honors the existing CONTINUATION discipline, now cross-machine).
+4. **No perceptible seam.** The pause the user experiences during a handoff stays under a tunable bound (default target: indistinguishable from a normal "agent is thinking" delay).
+5. **Channel identity follows the agent.** The Telegram topic/thread binding moves with the agent, so replies land in the same conversation thread regardless of which machine produced them.
+
+### Channel mechanics this requires (Telegram, generalizable to other adapters)
+
+The agent's connection to Telegram is *long-poll ingress owned by one machine at a time*. Seamlessness therefore needs:
+
+- **Single-owner ingress with clean transfer.** Exactly one machine polls Telegram at any moment (two pollers = duplicate handling). On handoff/failover, ingress ownership transfers atomically — the outgoing machine stops polling only once the incoming machine has taken the claim.
+- **No-loss across the transfer window.** Messages that arrive during the brief transfer are buffered/replayed, not dropped. (Instar already has a "messages are not lost — they replay on recovery" pattern for version-skew restarts; reuse that guarantee here.)
+- **Conversation context on the receiving machine.** The per-topic thread history and the live tail of the current exchange must be present on the incoming machine before it answers — this is what prevents the "fresh start" failure.
 
 ---
 
@@ -71,7 +100,7 @@ The gap decomposes into three sub-problems, in dependency order:
 |----|-----|----------------|------------------|
 | **G1** | Split-brain resolution | Two "awake" machines = duplicated work, conflicting writes, user confusion | Registry showed both `awake` |
 | **G2** | Automated state sync | Without it, no machine has a current view of the mesh; failover/handoff act on stale data | Role change never pushed to git |
-| **G3** | Live conversation/work-state sync + near-instant graceful handoff | The actual "no amnesia" experience | Not yet built |
+| **G3** | Seamless channel experience: ingress ownership transfer + conversation-context availability + no-visible-seam | The actual user-facing "no amnesia" experience on Telegram (US1/US2) | Not yet built |
 
 G2 is a prerequisite for trustworthy G1 and G3 (you cannot resolve or hand off on stale state).
 
@@ -101,22 +130,34 @@ Make the running server actually propagate mesh state (the Phase 0 gap):
 - **Idempotent + conflict-free:** registry writes are last-writer-wins per-machine-entry (each machine only authors its own entry, except role demotions which are authored by the resolver winner). This avoids merge conflicts on the shared registry.
 - **Failure handling:** a push failure is a signal (retry with backoff), not a crash; sync health is observable via `/health` and `instar doctor`.
 
-### G3 — Live State Sync + Graceful Handoff
+### G3 — Seamless Channel Experience
 
-The "no amnesia" core. Two state classes, two transports:
+This is the user-facing core (US1/US2), and it is defined by the channel, not by internal state. It has three parts that together deliver the acceptance criteria in §2.
+
+**(a) Channel-state classes and transports.** Two kinds of state must reach the receiving machine:
 
 - **Durable work state** (work ledger, in-flight task list) → **git** (coarse, every N seconds, tunable). Survives crashes; this is the cross-machine work-ledger visibility the v3 spec named "not yet implemented."
-- **Live conversation tail** (the last exchanges, current turn context) → **direct tunnel channel** between awake and standby (low-latency push), buffered so the standby always holds a near-current copy.
+- **Live conversation tail** (the recent exchanges + current turn context for each active channel/topic) → **direct tunnel channel** between awake and standby (low-latency push), buffered so the standby always holds a near-current copy. This is what satisfies "context retained" (criterion 3) — the receiving machine can answer the next message coherently.
 
-**Graceful handoff protocol (both machines live):**
+**(b) Telegram ingress ownership transfer (the no-loss / no-duplicate guarantee).** Telegram ingress is single-owner long-poll. The protocol guarantees exactly-once handling:
+
+1. Incoming machine signals intent to take ingress ownership.
+2. Outgoing machine **stops polling** and records the last-processed update offset into synced state.
+3. Incoming machine **resumes polling from that exact offset** — messages in the transfer window are processed exactly once (none dropped, none double-handled). This directly serves criteria 1 & 2.
+4. Only one machine ever holds the poll claim at a time (enforced via the mesh registry / a claim record), so two machines can never both reply.
+
+**(c) Graceful handoff protocol (both machines live):**
 
 1. New machine requests handoff (existing `HandoffManager` path).
-2. Current-awake **flushes** live conversation tail + work ledger to the incoming machine and confirms.
-3. Incoming machine **acks "caught up"** (it has the live tail) *before* the current-awake yields.
-4. Current-awake demotes to standby; incoming promotes to awake; registry updated (G2 propagates it).
-5. Telegram ingress claim transfers atomically (no double-poll, no dropped messages).
+2. Current-awake **flushes** the live conversation tail + work ledger to the incoming machine and confirms.
+3. Incoming machine **acks "caught up"** (it holds the live tail + thread history) *before* the current-awake yields — this prevents the "fresh start" failure (criterion 3).
+4. Ingress ownership transfers per (b); the channel/topic binding follows the agent (criterion 5).
+5. Current-awake demotes to standby; incoming promotes to awake; registry updated (G2 propagates it).
+6. On the receiving side, the agent session resumes via the existing **CONTINUATION** mechanism — it picks up the conversation rather than re-greeting.
 
-The "seamlessness bar" — how fresh the live tail must be at handoff — is **tunable** (see §6). A near-instant bar buffers continuously; a relaxed bar accepts a small catch-up pull at handoff.
+**Failover (outgoing machine died, not graceful):** the incoming machine cannot receive a flush, so it relies on the last synced live tail (freshness bounded by `liveTailBufferMs`) + thread history + the recorded ingress offset. The user may experience at most a small catch-up gap (criterion 4's bound) but no lost/duplicate messages and no amnesia beyond the buffer window.
+
+The "seamlessness bar" — how fresh the live tail must be, and how aggressive the handoff is — is **tunable** (see §6). A near-instant bar buffers continuously; a relaxed bar accepts a small catch-up pull at handoff. The bar is chosen to keep the user-perceived pause within criterion 4.
 
 ---
 
@@ -144,7 +185,8 @@ Per the Testing Integrity Standard — all three tiers, plus the real-hardware g
 - **Tier 1 (unit).** Split-brain resolver: both sides of every boundary — two-fresh-awake (deterministic winner), one-stale-one-fresh (demote stale), genuine tie (escalate), self-demotion (loser stops scheduler). Sync debounce logic. Live-tail buffer freshness.
 - **Tier 2 (integration).** Full HTTP pipeline: a running server auto-pushes registry on role change (the exact Phase 0 failure — this test would have caught it); standby pulls and converges; handoff over real tunnel transfers the live tail.
 - **Tier 3 (e2e lifecycle).** Multi-process: two servers, real local git remote, real localhost tunnels; drive a graceful handoff with an in-flight conversation and assert the incoming machine has the live tail before the outgoing yields; drive a hard failover and assert split-brain resolves to a single awake within threshold.
-- **Real-hardware gate.** `docs/MULTI_MACHINE_VERIFICATION.md` (60 items) remains the live acceptance gate. G1/G2/G3 each map to specific checklist sections (§2 Heartbeat/Failover, §3 Git Sync, §6 Handoff, §10 Full Lifecycle).
+- **Channel-experience acceptance (the real bar).** Beyond the mechanical tiers, the §2 user-facing criteria are tested *from the channel*: drive a real Telegram conversation across a handoff/failover and assert — exactly-once message handling (no loss, no duplicate reply), context retained in the first post-handoff reply (no re-greeting), and perceived gap within bound. This is the test that actually proves US1/US2; the mechanical tiers exist to make it pass.
+- **Real-hardware gate.** `docs/MULTI_MACHINE_VERIFICATION.md` (60 items) remains the live acceptance gate. G1/G2/G3 each map to specific checklist sections (§2 Heartbeat/Failover, §3 Git Sync, §6 Handoff, §7 Communication, §10 Full Lifecycle).
 
 ---
 

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
@@ -237,7 +237,7 @@ Per Justin's explicit requirement. All under `.instar/config.json` → `multiMac
 |------|---------|---------|
 | `ingressHeartbeatMs` | 30s | How often the lease holder refreshes its liveness/lease (distinct from the 30-min machine-presence heartbeat) |
 | `registrySyncDebounceMs` | 10s | Debounce window for committing *durable* registry changes to git |
-| `standbyPullIntervalMs` | `failoverThresholdMs / 4` (auto) | Standby git-pull cadence; auto-derived to satisfy the **< `failoverThresholdMs` / 3** invariant (validated on startup); explicit overrides are validated against the same bound |
+| `standbyPullIntervalMs` | `min(failoverThresholdMs/4, leaseTtlMs/2)` (auto) | Standby git-pull cadence; auto-derived to satisfy **both** the `< failoverThresholdMs/3` and `< leaseTtlMs` invariants at once (at default ratios `leaseTtlMs` is the binding bound, so a bare `failoverThresholdMs/4` would violate the leaseTtl invariant — implementation verified). Explicit overrides are validated against both bounds |
 | `failoverThresholdMs` | (existing, ~15min) | How stale before a peer is presumed dead; must exceed worst-case NTP drift ×2 |
 | `leaseTtlMs` | 2 × `ingressHeartbeatMs` | Lease expiry; bounds the worst-case transfer overlap window |
 | `liveTailTransport` | `tunnel` | `tunnel` (low-latency) \| `git` (durable-only, cheaper; recommended default for N>3) |

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
@@ -43,15 +43,25 @@ The whole spec serves these. Each gap and design choice traces back to one.
 - **US2 — Same agent across my machines.** *As a user (e.g. Adriana) who works on two machines, it's the same agent on both — same conversation, same half-finished task, same context — so I can switch machines and not miss a beat.*
 - **US3 — Reliability that's felt, not seen.** *As a user, I just experience an agent that's always there and always coherent; the fact that it spans several machines is invisible. More machines should mean more reliability, never more noise or more confusion.*
 
+### The realistic bar: "no worse than a compaction pause or a fresh-session catch-up"
+
+We are explicitly **not** chasing magically-perfect, zero-latency seamlessness. A machine handoff is the same *kind* of moment users already accept in two existing places: (a) the agent pausing to **compact**, and (b) messaging a topic where a **fresh session spins up and gets up to speed**. Nobody expects those to be invisible — they expect them quick, and to resume knowing what's going on. That is exactly the bar for a handoff. This lets us reuse the catch-up machinery we already trust (compaction-recovery, the CONTINUATION mechanism) rather than build a fragile always-streaming pipe.
+
+The goal is therefore: **carry over as much fresh handoff context as possible, and degrade gracefully when we can't.** Two flavors, two expectations:
+
+- **Planned handoff** (both machines awake; one passes the baton): near-instant, full context flushed across cleanly.
+- **Hard failover** (a machine crashes, or the internet drops mid–live-test): best-effort. The backup resumes from the last good sync — it may miss the last few seconds of in-flight context, exactly like a session that crashed and recovered. We explicitly do **not** over-engineer to guarantee perfection in this rare worst case.
+
 ### What "seamless" means, measured from the channel (acceptance criteria)
 
-These are the user-facing pass/fail bars — the real Phase-0-style gate, observed on the channel, not in the code:
+User-facing pass/fail bars, observed on the channel, not in the code:
 
-1. **No lost messages.** Every Telegram message the user sends during/around a handoff is processed exactly once.
-2. **No duplicate replies.** The user never receives the same answer twice (a real, recurring instar failure mode — see drain-respawn / gate-latency duplicates). Only one machine "owns" the channel at a time.
-3. **Context retained.** The first reply from the new machine demonstrates knowledge of the immediately-preceding exchange — no generic greeting, no "what were we talking about?" (honors the existing CONTINUATION discipline, now cross-machine).
-4. **No perceptible seam.** The pause the user experiences during a handoff stays under a tunable bound (default target: indistinguishable from a normal "agent is thinking" delay).
+1. **No lost messages.** Every message the user sends during/around a handoff is processed exactly once. *(Hard guarantee, both flavors — this is the one we don't compromise.)*
+2. **No duplicate replies.** The user never receives the same answer twice (a real, recurring instar failure mode — see drain-respawn / gate-latency duplicates). Only one machine "owns" the channel at a time. *(Hard guarantee, both flavors.)*
+3. **Maximal context, no fresh-start.** The first reply from the new machine reflects the conversation as of the last sync — no generic greeting, no "what were we talking about?" In a planned handoff this is fully current; in a hard failover it is as-of-last-sync (the compaction/continuation bar). *(Best-effort, bounded by sync freshness.)*
+4. **Pause no worse than a compaction / fresh-session catch-up.** A brief, recognizable "getting up to speed" moment is acceptable; an open-ended hang or silent drop is not. Tunable (see §6).
 5. **Channel identity follows the agent.** The channel's thread/conversation binding (Telegram topic, Slack channel+thread, etc.) moves with the agent, so replies land in the same conversation regardless of which machine produced them.
+6. **Machine-awareness.** The agent always knows which machine served the last turn and that a handoff occurred. This is cheap, lets the agent be honest when context is partial ("picking this up from the other machine"), and feeds per-machine self-knowledge (each machine tracking what is specific to it).
 
 ### Channel-agnostic by design (Telegram is the default, not the spec)
 
@@ -94,6 +104,8 @@ This spec is not theoretical. On 2026-05-26 the multi-machine system was run on 
 - **Near-silent.** Sync and reconciliation are housekeeping. They write to logs/audit trails, not to the user's chat. The user hears about cross-machine activity only when it is actionable (e.g. an unresolvable split-brain requiring a decision).
 - **Tunable latency vs. efficiency** (explicit Justin requirement). Seamlessness has a cost (network, compute, git churn). Every cadence/aggressiveness knob is configurable with sane defaults; "more machines = more reliable" must not mean "more machines = constant chatter."
 - **Git as durable substrate, tunnel as low-latency channel.** Reuse the proven git sync for durable state; add a direct tunnel channel only where latency demands it (the live conversation tail).
+- **Reuse the catch-up model, don't reinvent.** A handoff is the cross-machine generalization of compaction-recovery and fresh-session continuation. The receiving machine resumes via the existing **CONTINUATION** mechanism, and the user-facing bar is "no worse than a compaction pause." We do not build a fragile always-streaming pipe to chase perfect seamlessness — best-effort context + graceful degradation is the explicit, accepted design point.
+- **Machine-aware by default.** The agent records which machine served each turn (provenance, in synced state) and knows when it is resuming someone else's turn. Cheap, and it underpins honest "picking this up from the other machine" behavior plus per-machine self-knowledge.
 
 ---
 

--- a/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
+++ b/docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md
@@ -1,0 +1,166 @@
+# Cross-Machine Seamlessness Specification
+
+> Close the gap between "a backup machine can take over" and "the same agent follows you across machines with no amnesia." Grounded in real-hardware Phase 0 verification.
+
+**Status**: Draft v0 (grounded in real-hardware verification 2026-05-26)
+**Author**: Echo (with Justin's direction)
+**Builds on**: [`MULTI-MACHINE-SPEC.md`](./MULTI-MACHINE-SPEC.md) (v3, converged) — this spec does NOT replace it; it closes the seamlessness gap that v3 explicitly deferred.
+**Companion (read first)**: [`CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md`](./CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md)
+**Motivating initiative**: Instar × EXO 3.0 — cross-machine single-agent ("one Luna across machines"), Pillar 2.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Phase 0 Findings (Empirical Grounding)](#phase-0-findings-empirical-grounding)
+3. [Design Principles](#design-principles)
+4. [The Seamlessness Gap — Precise Definition](#the-seamlessness-gap--precise-definition)
+5. [Proposed Design](#proposed-design)
+6. [Tunability](#tunability)
+7. [Testing Strategy](#testing-strategy)
+8. [Migration Parity](#migration-parity)
+9. [Related Work & Open Questions](#related-work--open-questions)
+
+---
+
+## Overview
+
+The converged multi-machine spec (v3) delivered machine identity, secure pairing, git-based state sync, primary/standby coordination, heartbeat/failover, and graceful handoff *machinery*. What it explicitly deferred — and what the EXO 3.0 "cross-machine single agent" vision needs most — is **seamlessness**: the experience that an agent is one logical identity that follows the user across machines with no loss of in-flight context.
+
+Concretely, the vision (per Justin): *Adriana switches laptops mid-conversation, and "Luna" keeps talking with no amnesia.* Today, even when failover works, the machine that takes over arrives without the live conversation and in-flight work state.
+
+This spec defines the narrow, high-leverage work to close that gap. It is deliberately scoped to the **runtime** seamlessness problem. The **onboarding** problem (how an agent installs itself onto a new machine) is captured as related work for a companion spec (see §9).
+
+---
+
+## Phase 0 Findings (Empirical Grounding)
+
+This spec is not theoretical. On 2026-05-26 the multi-machine system was run on two real machines for the first time (a laptop + a Mac mini, a dedicated throwaway test agent), validating the v3 foundation and surfacing the precise gaps. Prior to this, the 60-item `MULTI_MACHINE_VERIFICATION.md` checklist was entirely unchecked.
+
+**What works on real hardware:**
+
+- **✅ Pairing (Checklist §1).** `instar pair` → `instar join <repo-url> --code` paired two real machines into one mesh. The pairing handshake completes **via the git repository** — no live server-to-server connection was required.
+- **✅ Self-election.** A standby machine whose server starts while no other machine is posting a fresh heartbeat correctly claims the `awake` role on its own.
+
+**What does NOT work yet (this spec's targets):**
+
+- **❌ G1 — Split-brain resolution.** After self-election, the mesh registry recorded **both** machines as `role: awake` simultaneously. The newly-awake machine never demoted the silent peer, even though the differentiator was present (the silent machine's `lastSeen` was ~54 minutes stale, far past the 15-minute failover threshold).
+- **❌ G2 — Automated state sync.** A running server modified its local registry (role change) and other state, but did **not** auto-commit/push those changes to git. Cross-machine state propagated only when pushed/pulled by hand. (The converged spec assumed `SyncOrchestrator` handles this; on real hardware it did not fire for registry/role state.)
+- **❌ G3 — Live state sync + graceful handoff (untested, by design).** The test exercised startup-election against a dead peer, not a clean baton-pass between two live machines, because the seamless live-state path does not yet exist.
+
+**Onboarding findings (→ companion spec, §9):** granting an agent access to a new machine is **two** bootstraps (SSH onto the host, *and* git credential to fetch the agent's repo); `join` does not create a runnable `config.json`, so a freshly-joined server defaults to port 4040 and can **collide with an existing agent** on that machine; the configured port does not propagate (it lives in gitignored `config.json`).
+
+---
+
+## Design Principles
+
+- **Structure > Willpower.** Split-brain resolution and state sync must be code that runs deterministically — never an agent "remembering" to reconcile. (The Phase 0 split-brain persisted precisely because nothing *enforced* demotion.)
+- **Signal vs. Authority.** Detectors (e.g. "I see two awake machines") emit *signals*; only the coordinator, with full context, has authority to demote a peer or trigger a handoff. No brittle filter unilaterally changes mesh roles.
+- **Near-silent.** Sync and reconciliation are housekeeping. They write to logs/audit trails, not to the user's chat. The user hears about cross-machine activity only when it is actionable (e.g. an unresolvable split-brain requiring a decision).
+- **Tunable latency vs. efficiency** (explicit Justin requirement). Seamlessness has a cost (network, compute, git churn). Every cadence/aggressiveness knob is configurable with sane defaults; "more machines = more reliable" must not mean "more machines = constant chatter."
+- **Git as durable substrate, tunnel as low-latency channel.** Reuse the proven git sync for durable state; add a direct tunnel channel only where latency demands it (the live conversation tail).
+
+---
+
+## The Seamlessness Gap — Precise Definition
+
+The gap decomposes into three sub-problems, in dependency order:
+
+| ID | Gap | Why it matters | Phase 0 evidence |
+|----|-----|----------------|------------------|
+| **G1** | Split-brain resolution | Two "awake" machines = duplicated work, conflicting writes, user confusion | Registry showed both `awake` |
+| **G2** | Automated state sync | Without it, no machine has a current view of the mesh; failover/handoff act on stale data | Role change never pushed to git |
+| **G3** | Live conversation/work-state sync + near-instant graceful handoff | The actual "no amnesia" experience | Not yet built |
+
+G2 is a prerequisite for trustworthy G1 and G3 (you cannot resolve or hand off on stale state).
+
+---
+
+## Proposed Design
+
+### G1 — Split-Brain Resolution
+
+Add a deterministic resolver to `HeartbeatManager` / `MultiMachineCoordinator`:
+
+- **Detection (signal).** On each heartbeat tick, if the synced registry shows more than one machine in `role: awake`, emit a `split-brain-detected` signal with the candidate set.
+- **Resolution (authority).** The coordinator resolves deterministically:
+  1. A machine whose `lastSeen` is older than the failover threshold is **demoted** to `standby` (it is presumed dead/offline).
+  2. Among machines with fresh heartbeats, the one with the most recent `lastSeen` wins; ties broken by lowest `machineId` (deterministic, so all machines independently reach the same verdict).
+  3. The winner writes the corrected registry (single `awake`); demoted entries are marked `standby` (and `status: offline` if past threshold).
+- **Self-demotion safety.** A machine that determines *it* lost must stop awake-only activity (job scheduling, Telegram ingress claim) before yielding — never two schedulers running.
+- **Escalation.** If the candidates are genuinely co-fresh and cannot be deterministically separated (clock skew, true partition), emit an Attention-queue item rather than flip-flop. This is the only user-visible path, and only when truly unresolvable.
+
+### G2 — Automated State Sync
+
+Make the running server actually propagate mesh state (the Phase 0 gap):
+
+- `SyncOrchestrator` on the **awake** machine auto-commits + pushes registry and heartbeat changes on a tunable cadence (debounced; not on every field write).
+- Standby machines pull on a tunable cadence and on wake.
+- Reuse existing `GitSync` field-merge / signed-commit machinery (no new transport for durable state).
+- **Idempotent + conflict-free:** registry writes are last-writer-wins per-machine-entry (each machine only authors its own entry, except role demotions which are authored by the resolver winner). This avoids merge conflicts on the shared registry.
+- **Failure handling:** a push failure is a signal (retry with backoff), not a crash; sync health is observable via `/health` and `instar doctor`.
+
+### G3 — Live State Sync + Graceful Handoff
+
+The "no amnesia" core. Two state classes, two transports:
+
+- **Durable work state** (work ledger, in-flight task list) → **git** (coarse, every N seconds, tunable). Survives crashes; this is the cross-machine work-ledger visibility the v3 spec named "not yet implemented."
+- **Live conversation tail** (the last exchanges, current turn context) → **direct tunnel channel** between awake and standby (low-latency push), buffered so the standby always holds a near-current copy.
+
+**Graceful handoff protocol (both machines live):**
+
+1. New machine requests handoff (existing `HandoffManager` path).
+2. Current-awake **flushes** live conversation tail + work ledger to the incoming machine and confirms.
+3. Incoming machine **acks "caught up"** (it has the live tail) *before* the current-awake yields.
+4. Current-awake demotes to standby; incoming promotes to awake; registry updated (G2 propagates it).
+5. Telegram ingress claim transfers atomically (no double-poll, no dropped messages).
+
+The "seamlessness bar" — how fresh the live tail must be at handoff — is **tunable** (see §6). A near-instant bar buffers continuously; a relaxed bar accepts a small catch-up pull at handoff.
+
+---
+
+## Tunability
+
+Per Justin's explicit requirement (balance latency/seamlessness vs. efficiency). All under `.instar/config.json` → `multiMachine`:
+
+| Knob | Default | Meaning |
+|------|---------|---------|
+| `heartbeatIntervalMs` | 30s | How often the awake machine posts/pushes its heartbeat |
+| `registrySyncDebounceMs` | 10s | Debounce window for pushing registry changes |
+| `failoverThresholdMs` | (existing, ~15min) | How stale before a peer is presumed dead |
+| `liveTailTransport` | `tunnel` | `tunnel` (low-latency) \| `git` (durable-only, cheaper) |
+| `liveTailBufferMs` | 5s | Max staleness of the standby's live conversation copy |
+| `handoffBar` | `near-instant` | `near-instant` (continuous buffer) \| `relaxed` (catch-up at handoff) |
+
+Defaults target a good experience for 2-machine personal use; high-machine-count or cost-sensitive deployments dial cadence down.
+
+---
+
+## Testing Strategy
+
+Per the Testing Integrity Standard — all three tiers, plus the real-hardware gate:
+
+- **Tier 1 (unit).** Split-brain resolver: both sides of every boundary — two-fresh-awake (deterministic winner), one-stale-one-fresh (demote stale), genuine tie (escalate), self-demotion (loser stops scheduler). Sync debounce logic. Live-tail buffer freshness.
+- **Tier 2 (integration).** Full HTTP pipeline: a running server auto-pushes registry on role change (the exact Phase 0 failure — this test would have caught it); standby pulls and converges; handoff over real tunnel transfers the live tail.
+- **Tier 3 (e2e lifecycle).** Multi-process: two servers, real local git remote, real localhost tunnels; drive a graceful handoff with an in-flight conversation and assert the incoming machine has the live tail before the outgoing yields; drive a hard failover and assert split-brain resolves to a single awake within threshold.
+- **Real-hardware gate.** `docs/MULTI_MACHINE_VERIFICATION.md` (60 items) remains the live acceptance gate. G1/G2/G3 each map to specific checklist sections (§2 Heartbeat/Failover, §3 Git Sync, §6 Handoff, §10 Full Lifecycle).
+
+---
+
+## Migration Parity
+
+Existing multi-machine agents must receive this on update, not just new ones:
+
+- **Config defaults** → `migrateConfig()` adds the `multiMachine` knobs (existence-checked, only missing fields).
+- **Resolver + auto-sync** ship in the server; existing agents get them on the next server update. No agent-installed file changes required for G1/G2 beyond config.
+- **Idempotent.** Resolver and sync are safe to run repeatedly; a single-machine agent (no peers) is a no-op.
+
+---
+
+## Related Work & Open Questions
+
+- **Companion spec — Agent Self-Propagation Standard.** Justin's standard (one human authorization to grant an agent access to a new machine, then the agent installs itself and everything downstream). The Phase 0 onboarding findings feed it directly: the two-bootstrap access problem (SSH + git credential), `join` not creating a runnable `config.json`, and the default-port (4040) collision risk with an existing agent. **A joining machine must pick a free port and write a runnable config** — tracked there, not here.
+- **Server bring-up on a guarded/new machine.** `instar server start` is (correctly) blocked from inside an agent session. The self-propagation flow must define how an agent brings up its *own* server on a new machine without that guard — likely launchd/supervisor registration performed in the onboarding step. Open question for the companion spec.
+- **Open: clock-skew handling** in G1 ties (NTP assumption vs. logical clocks).
+- **Open: live-tail privacy** — the conversation tail crossing the tunnel must honor the same secret-handling rules as the v3 secret-sync channel.

--- a/docs/specs/reports/cross-machine-seamlessness-convergence.md
+++ b/docs/specs/reports/cross-machine-seamlessness-convergence.md
@@ -1,0 +1,93 @@
+# Convergence Report — Cross-Machine Seamlessness
+
+**Spec:** `docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md`
+**Plain-English companion:** `docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.eli16.md`
+**Converged:** 2026-05-26 · **Review rounds:** 5 · **Author:** echo
+**Reviewers:** security, scalability, adversarial, integration, lessons-aware (internal Claude) + GPT-class external (codex). Gemini external was unavailable (no API auth in this environment); Grok has no CLI here. The mandatory lessons-aware reviewer ran every round it was scheduled and was clean by round 3.
+
+---
+
+## ELI10 Overview
+
+This spec is about making one AI agent that lives on two (or more) of your machines behave like a single, continuous assistant — so when the machine currently talking to you goes down, or you switch machines, the conversation just keeps going. You set the bar yourself: a handoff between machines should feel no worse than the agent pausing to tidy its memory, and it must *never* lose your message or answer you twice.
+
+The first draft had the right *shape* but trusted three things it shouldn't have: it picked which machine was "in charge" by comparing clocks (a machine with a wrong clock could cheat), it assumed "only one machine listens at a time" was enough to prevent double-replies (during a messy handoff, both can briefly listen), and it left the private wire that copies your conversation to the backup machine "to be decided" (that wire can carry secrets). Six expert reviewers — including an outside-model one — agreed those were real holes under exactly the failure conditions this feature exists to survive.
+
+The converged design fixes all three with one well-understood building block (a "fenced lease": a single numbered badge that exactly one machine can hold, that clocks can't game), makes every incoming message individually un-double-answerable (each gets a ticket and is only ever acted on once), and makes the private wire encrypted, identity-checked, and secret-stripped by requirement, not aspiration. It also separates the agent's constant "I'm alive" heartbeats from its permanent saved history (so the shared repo doesn't bloat by thousands of entries a day), names the exact wiring that was missing in the real-hardware test, and writes down honest limits: a handoff is allowed to feel like a brief catch-up, and there is exactly one rare triple-failure case (reply sent + machine crashes + both sync paths down at once, on a chat platform with no built-in dedup) where a single duplicate is physically unavoidable — that's a law-of-physics limit (the "Two Generals" problem), now stated plainly and bounded, not hidden.
+
+**What changes for users if it ships:** failover and machine-switching become invisible-to-mostly-invisible (a short catch-up beat at worst), with no lost or duplicated messages and no "who are you again?" restart — across Telegram first, Slack second, and any future channel held to the same contract. **Main tradeoff:** seamlessness costs some network/compute/sync chatter, so every cadence is a dial with sane defaults, and the design has an explicit cost ceiling so "more machines" never means "more noise."
+
+---
+
+## Original vs Converged
+
+| Aspect | Original (v0) | Converged (v1) |
+|--------|---------------|----------------|
+| **Who's in charge** | "Most recent `lastSeen` wins" — wall-clock comparison; every machine ran the resolver and wrote the registry | A **fenced lease** with a monotonic epoch; acquisition is a compare-and-swap; only the lease holder has authority to write roles. Clocks can't win anything. |
+| **No duplicate replies** | Assumed because "only one machine consumes the channel" | Guaranteed by **message-level idempotency**: a durable SQLite ledger keyed on the provider's event id + a fencing-token-gated outbox + an outbound idempotency key. A redelivered or transfer-window-overlap event is recognized and dropped. |
+| **Demotion** | A behavioral instruction ("the loser must stop") | A **structural gate**: scheduler + ingress consumers check `holdsValidLease(self)` each tick and refuse to run otherwise — even if the in-memory signal never arrived (this was the exact Phase 0 failure). |
+| **Live conversation wire** | "Direct tunnel," security left as an open question | **Normative**: mutual Ed25519 auth, X25519+XChaCha20-Poly1305 encryption, replay sequence, secret redaction, carry-by-reference for heavy content. |
+| **"Caught up" handoff ack** | A bare claim | **Verifiable** (echoes tail-seq + ingress-offset + history-hash) and **timeout-bounded** — never yield the lease on an unverified or absent ack. |
+| **Handoff ownership** | Scattered across 5 components | One **`HandoffSentinel`** owns detect→attempt→verify→retry→finalize as an explicit epoch state machine with a race guard. |
+| **Heartbeats vs git** | Auto-commit/push every 30s → thousands of commits/day | **Ephemeral liveness separated from durable history**; coarse commits only on meaningful change; pull-rebase + backoff; single-writer for authority state. |
+| **The Phase 0 wiring bug** | Described the *outcome* ("auto-sync") | **Names the wiring**: `MultiMachineCoordinator` `roleChange` → `SyncOrchestrator.markRegistryDirty`, plus a wiring-integrity test that would have caught Phase 0. |
+| **Guarantees** | "User notices nothing" (overclaimed) | **Honest RPO/RTO split**: message exactly-once = HARD (one named impossibility-floor exception); context freshness + pause = bounded best-effort, "no worse than a compaction pause." |
+| **Channels** | Telegram-centric | A **Channel Seamlessness Contract** (enumerated adapter methods); Telegram reference, Slack second target (honest about Slack's coarse cursor), others later. |
+
+---
+
+## Iteration Summary
+
+| Iteration | Reviewers | Material findings | Nature | Spec changes |
+|-----------|-----------|-------------------|--------|--------------|
+| 1 | security, scalability, adversarial, integration, lessons-aware, GPT | ~15 (criticals across all lenses, near-universal consensus) | **Architecture-level** — election model, idempotency, transport security, lifecycle ownership, git bloat, the Phase 0 wiring | Full rewrite v0→v1: introduced the fenced-lease backbone, message-processing ledger, normative tunnel security, HandoffSentinel, ephemeral/durable split, named wiring, RPO/RTO guarantee split, knob renames, adapter-interface enumeration, migration+observability |
+| 2 | security, adversarial, lessons-aware | 11 | **Second-order** — take-max epoch, ledger durability/substrate, tunnel-down split-authority, stuck-processing, rejoin/re-key, escalation framing, Haiku-timeout budget, new-store init, alive-test, deferral sign-off field | Targeted edits addressing each |
+| 3 | adversarial, lessons-aware | 3 (lessons-aware **clean**) | **Completeness** — RPO push-rate invariant, HandoffSentinel yield-signal race, out-of-order flush holdout | 3 targeted edits |
+| 4 | adversarial | 1 genuine + 1 trivial | **Deep edge** — triple-fault duplicate (Two-Generals floor) + `standbyPullIntervalMs` auto undefined | Idempotency key + dual-medium marker + honest residual; auto-value defined |
+| 5 | adversarial | 2 | **Narrow invariant-statements** — tunnel-lease replay floor; `standbyPullIntervalMs < leaseTtlMs` cross-knob validation | 2 targeted edits |
+
+**Convergence trajectory:** 15 → 11 → 3 → 1 → 2 — a sharp, monotonic decline from architecture defects to implementation-guidance invariants, with no regressions introduced by any fix.
+
+---
+
+## Full Findings Catalog
+
+### Round 1 (consensus themes; ~15 material)
+- **C1 — Wall-clock election unsafe → fenced lease + epoch** (CRITICAL; security, adversarial, lessons-aware, GPT). Resolved: §6 Coordination Primitive.
+- **C2 — Exactly-once not guaranteed; channels are at-least-once → durable idempotent ledger** (CRITICAL; GPT, adversarial). Resolved: §8 G3a.
+- **C3 — Live-tail transport security must be normative** (CRITICAL; security, GPT, adversarial, lessons-aware). Resolved: §8 G3c.
+- **C4 — "Caught up" ack must be verifiable + bounded** (CRITICAL/HIGH; security, adversarial, lessons-aware). Resolved: §8 G3d/e.
+- **C5 — Self-demotion must be a structural lease-gate** (CRITICAL; lessons-aware, adversarial, GPT). Resolved: §5, §8 G2.
+- **C6 — Own-the-lifecycle: one HandoffSentinel** (CRITICAL; lessons-aware, GPT). Resolved: §8 G3e.
+- **C7 — Git history bloat + push contention** (CRITICAL/HIGH; scalability, GPT). Resolved: §8 G2 ephemeral/durable split.
+- **C8 — The Phase 0 wiring gap (SyncOrchestrator↔roleChange)** (CRITICAL; integration, lessons-aware). Resolved: §8 G2 named wiring + wiring-integrity test.
+- **C9 — MessagingAdapter lacks contract methods; Slack has no durable cursor** (HIGH; integration, GPT). Resolved: §2 contract + enumerated methods.
+- **C10 — Config knob collision, migration marker, agent-awareness, observability, escalation dedup** (HIGH/MEDIUM; integration, lessons-aware, GPT, adversarial). Resolved: §9 renamed knobs, §11.
+- **C11 — Honest RPO/RTO guarantee split, supervision tiers, ledger provenance** (MEDIUM; GPT, scalability, lessons-aware). Resolved: §3, supervision per pipeline.
+
+### Round 2 (11 material, second-order) — all resolved
+Take-max epoch + tunnel-down self-suspend (§6); ledger SQLite substrate + synchronous flush + tunnel propagation (§8 G3a); live-tail sequence dedup (§8 G3b); stuck-`processing` recovery (§8 G3a); git-CAS epoch-gap safety + livelock backoff (§6); `leaseEpoch` on commits + unknown-key first-commit rule (§8 G2); secret-redaction versioning + carry-by-reference (§8 G3b/c); handoff Haiku-validator timeout = abort (§8 G3e); escalation Tier-0 justification (§8 G1); new-store self-init (§11); automated alive-test for `/health.syncStatus` (§10); `principal-deferral-approval: pending` (frontmatter); IBL provenance consistency (§2 criterion 6).
+
+### Round 3 (3 material; lessons-aware clean) — all resolved
+RPO push-rate invariant `liveTailPushRateMs ≤ liveTailMaxStalenessMs` (§9); HandoffSentinel explicit `yield`-signal / lease-retention through validation window (§8 G3e); `liveTailOutOfOrderTimeoutMs` bounded holdout (§8 G3b).
+
+### Round 4 (1 genuine + 1 trivial) — both resolved
+Triple-fault duplicate-reply window → outbound idempotency key + dual-medium `reply_committed` marker + honest Two-Generals residual in §3 (§8 G3a); `standbyPullIntervalMs` auto = `failoverThresholdMs / 4` (§9).
+
+### Round 5 (2 narrow completeness) — both resolved
+Tunnel-lease replay floor: accept tunnel lease only if `leaseEpoch ≥ git-committed epoch` + per-holder nonce (§6); cross-knob validation `standbyPullIntervalMs < leaseTtlMs` (§9).
+
+---
+
+## Convergence Verdict
+
+**Converged at the design level after 5 review rounds.** The architecture is sound: a single fenced-lease primitive resolves the split-brain/ingress-ownership/authority cluster; message-level idempotency makes the no-duplicate-reply guarantee structural; transport security is normative; one sentinel owns the handoff lifecycle; the Phase 0 wiring gap is named with a test that gates it.
+
+The final two rounds produced only narrow completeness items — explicit invariant statements an implementer needs but which are not design defects — plus one genuine deep edge (the Two-Generals impossibility floor) which is now mitigated and stated honestly rather than over-claimed. Every finding from every round was either resolved in the text or explicitly, honestly bounded. The mandatory lessons-aware reviewer (the structural anti-circular check) was clean from round 3 onward. Continuing to iterate against the adversarial long-tail would constitute false non-convergence; the spec is ready for user review and approval.
+
+**Honest caveats carried forward (not blockers, by design):**
+- `approved: true` is **not** set — that is the user's step (Justin). The frontmatter carries `principal-deferral-approval: pending` for the onboarding deferrals (port collision / runnable-config), which require Justin's sign-off before the *companion* Self-Propagation spec is approved.
+- External cross-model coverage was GPT-only (Gemini auth unavailable in this environment; no Grok CLI). GPT's findings were strongly concordant with the internal reviewers, so the cross-model angle was exercised, but a future re-run with Gemini/Grok would add breadth.
+- Slack's resumable position is the coarse `lastTs` cursor; full Events-API exactly-once for Slack is a scoped, sign-off-gated increment, not assumed complete.
+
+**Verdict: Converged. Ready for user review and approval.**

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -60,6 +60,9 @@ import { SessionRecovery } from '../monitoring/SessionRecovery.js';
 import { MultiMachineCoordinator } from '../core/MultiMachineCoordinator.js';
 import { MachineIdentityManager } from '../core/MachineIdentity.js';
 import { GitSyncManager } from '../core/GitSync.js';
+import { RegistrySyncDebouncer } from '../core/RegistrySyncDebouncer.js';
+import { wireRegistrySync } from '../core/wireRegistrySync.js';
+import { assertSeamlessnessInvariants } from '../core/seamlessnessConfig.js';
 import { ProjectMapper } from '../core/ProjectMapper.js';
 import { CapabilityMapper } from '../core/CapabilityMapper.js';
 import { ScopeVerifier } from '../core/ScopeVerifier.js';
@@ -2378,6 +2381,12 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     }
 
+    // Cross-Machine Seamlessness (spec §9) — resolve + validate the tunable
+    // knobs at startup. A violating config (e.g. a widened ingressHeartbeatMs
+    // that breaks the RPO bound) is REJECTED here with a clear message rather
+    // than degrading silently. Default/absent config resolves to valid values.
+    const seamlessness = assertSeamlessnessInvariants(config.multiMachine);
+
     // Read local signing key for machine route authentication
     let localSigningKeyPem = '';
     if (coordinator.enabled && coordinator.identity) {
@@ -2393,9 +2402,15 @@ export async function startServer(options: StartOptions): Promise<void> {
     // Only attempt git sync if the project directory is actually a git repo.
     // Standalone agents don't have git repos unless the user opted into cloud backup.
     let gitSync: GitSyncManager | undefined;
+    let registrySyncDebouncer: RegistrySyncDebouncer | undefined;
     const isGitRepo = fs.existsSync(path.join(config.projectDir, '.git'));
     const gitBackupEnabled = config.gitBackup?.enabled !== false;
-    if (coordinator.enabled && coordinator.isAwake && isGitRepo && gitBackupEnabled) {
+    // Construct gitSync for BOTH roles when this is a git-backed mesh machine:
+    // a standby needs it to pull, and a standby that later self-elects to awake
+    // (the Phase-0 scenario) must ALREADY have it so its role-change push fires.
+    // Only an awake machine pulls+pushes at boot; the durable registry push is
+    // driven by the RegistrySyncDebouncer below, gated on authority.
+    if (coordinator.enabled && isGitRepo && gitBackupEnabled) {
       try {
         gitSync = new GitSyncManager({
           projectDir: config.projectDir,
@@ -2411,11 +2426,29 @@ export async function startServer(options: StartOptions): Promise<void> {
           console.log(pc.green('  Git commit signing configured'));
         }
 
-        // Pull latest on startup
-        const syncResult = await gitSync.sync();
-        if (syncResult.pulled) {
-          console.log(pc.green(`  Git sync: pulled ${syncResult.commitsPulled} commit(s)`));
+        // Pull (and auto-push) latest on startup — awake machine only.
+        if (coordinator.isAwake) {
+          const syncResult = await gitSync.sync();
+          if (syncResult.pulled) {
+            console.log(pc.green(`  Git sync: pulled ${syncResult.commitsPulled} commit(s)`));
+          }
         }
+
+        // ── G2 wiring (spec §8 G2) — the Phase-0 fix, named explicitly ──
+        // MultiMachineCoordinator emits roleChange / leaseEpochChange; without
+        // a subscriber the durable push never fired. wireRegistrySync connects
+        // those events to a debounced, single-writer registry push. A
+        // wiring-integrity test asserts this subscription exists.
+        const gitSyncRef = gitSync;
+        registrySyncDebouncer = new RegistrySyncDebouncer({
+          commitAndPush: (msg, paths) => gitSyncRef.commitAndPush(msg, paths),
+          registryAbsPath: coordinator.managers.identityManager.registryPath,
+          isAuthoritative: () => coordinator.isAwake,
+          debounceMs: seamlessness.registrySyncDebounceMs,
+          logger: (m) => console.log(pc.dim(m)),
+        });
+        wireRegistrySync(coordinator, registrySyncDebouncer);
+        console.log(pc.dim('  Registry sync wired (roleChange/leaseEpoch → durable push)'));
       } catch (err) {
         // @silent-fallback-ok — git sync disabled gracefully
         console.log(pc.yellow(`  Git sync setup: ${err instanceof Error ? err.message : String(err)}`));
@@ -8270,6 +8303,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         }
       }
 
+      registrySyncDebouncer?.stop();
       gitSync?.stop();
       coordinator.stop();
       coherenceMonitor.stop();

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -63,6 +63,10 @@ import { GitSyncManager } from '../core/GitSync.js';
 import { RegistrySyncDebouncer } from '../core/RegistrySyncDebouncer.js';
 import { wireRegistrySync } from '../core/wireRegistrySync.js';
 import { assertSeamlessnessInvariants } from '../core/seamlessnessConfig.js';
+import { FencedLease, type LeaseCrypto } from '../core/FencedLease.js';
+import { GitLeaseStore } from '../core/GitLeaseStore.js';
+import { LeaseCoordinator } from '../core/LeaseCoordinator.js';
+import { sign as signEd25519, verify as verifyEd25519 } from '../core/MachineIdentity.js';
 import { ProjectMapper } from '../core/ProjectMapper.js';
 import { CapabilityMapper } from '../core/CapabilityMapper.js';
 import { ScopeVerifier } from '../core/ScopeVerifier.js';
@@ -2449,6 +2453,61 @@ export async function startServer(options: StartOptions): Promise<void> {
         });
         wireRegistrySync(coordinator, registrySyncDebouncer);
         console.log(pc.dim('  Registry sync wired (roleChange/leaseEpoch → durable push)'));
+
+        // ── G1 fenced-lease integration (spec §6) ──────────────────
+        // The lease becomes the authority for awake/standby. git is the durable
+        // CAS substrate (correct, bounded by git cadence — the tunnel accelerator
+        // is a tracked follow-on, ACT-156-adjacent). A holder that cannot refresh
+        // its lease over git for > leaseTtlMs self-suspends, preventing the
+        // partitioned-old-awake split-brain.
+        const idMgr = coordinator.managers.identityManager;
+        const selfMachineId = coordinator.identity!.machineId;
+        const leaseCrypto: LeaseCrypto = {
+          selfMachineId,
+          sign: (canonical) => signEd25519(canonical, idMgr.loadSigningKey()),
+          verify: (canonical, signature, holderMachineId) => {
+            const pub = idMgr.getSigningPublicKeyPem(holderMachineId);
+            if (!pub) return false;
+            try { return verifyEd25519(canonical, signature, pub); } catch { return false; }
+          },
+        };
+        const fencedLease = new FencedLease(leaseCrypto, {
+          leaseTtlMs: seamlessness.leaseTtlMs,
+          failoverThresholdMs: seamlessness.failoverThresholdMs,
+        });
+        const leaseStore = new GitLeaseStore({
+          machineId: selfMachineId,
+          loadRegistry: () => idMgr.loadRegistry(),
+          saveRegistry: (r) => idMgr.saveRegistry(r),
+          registryAbsPath: idMgr.registryPath,
+          pullRebase: () => gitSyncRef.pullRebase(),
+          commitAndPush: (msg, paths) => gitSyncRef.commitAndPush(msg, paths),
+          logger: (m) => console.log(pc.dim(m)),
+        });
+        const leaseCoordinator = new LeaseCoordinator({
+          lease: fencedLease,
+          store: leaseStore,
+          // tunnel accelerator omitted for the launch increment (git-only is
+          // correct; tunnel transport tracked for the follow-on).
+          presumedDeadHolders: () => {
+            const reg = idMgr.loadRegistry();
+            const nowMs = Date.now();
+            const dead = new Set<string>();
+            for (const [id, e] of Object.entries(reg.machines ?? {})) {
+              if (id === selfMachineId) continue;
+              const last = Date.parse(e.lastSeen);
+              if (!Number.isNaN(last) && nowMs - last > seamlessness.failoverThresholdMs) dead.add(id);
+            }
+            return dead;
+          },
+          onEpochAdvance: (epoch) => coordinator.emit('leaseEpochChange', epoch),
+          onSelfSuspend: (reason) => console.log(pc.yellow(`  [lease] self-suspend: ${reason}`)),
+          onEscalate: (info) => console.log(pc.yellow(`  [lease] split-brain escalation: ${info.reason} (holder ${info.holder})`)),
+          logger: (m) => console.log(pc.dim(m)),
+        });
+        coordinator.attachLeaseCoordinator(leaseCoordinator);
+        await coordinator.initializeLease();
+        console.log(pc.dim(`  Fenced lease active (epoch ${leaseCoordinator.currentEpoch()}, holder=${leaseCoordinator.currentHolder() ?? 'none'})`));
       } catch (err) {
         // @silent-fallback-ok — git sync disabled gracefully
         console.log(pc.yellow(`  Git sync setup: ${err instanceof Error ? err.message : String(err)}`));

--- a/src/core/FencedLease.ts
+++ b/src/core/FencedLease.ts
@@ -1,0 +1,242 @@
+/**
+ * FencedLease — the single coordination primitive for cross-machine
+ * seamlessness: "exactly one holder, safe under clock skew and partition."
+ *
+ * Spec: docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md §6.
+ *
+ * This module is the PURE LOGIC of the lease — epoch arithmetic, signing,
+ * expiry, the fencing check, tunnel-message acceptance, and the acquisition
+ * decision. The transport (git push-or-reject-reread, tunnel broadcast) is
+ * driven by a higher-level coordinator that calls these methods; keeping the
+ * logic pure makes the dangerous parts (CAS, fencing, clock-skew) unit-testable
+ * with in-memory fakes.
+ *
+ * Authority is the EPOCH (a monotonically increasing integer advanced once per
+ * acquisition), never wall-clock time. A machine with a fast clock cannot win
+ * anything — it has no way to advance the epoch without a valid CAS. `lastSeen`
+ * is retained only for the liveness heuristic (presumed-dead), and that
+ * threshold must exceed worst-case NTP drift by ≥2× (enforced by the caller).
+ */
+
+import type { LeaseRecord } from './types.js';
+
+/** Crypto seam — injected so the logic is testable without real key files. */
+export interface LeaseCrypto {
+  /** This machine's id (the only id we may name as `holder` when signing). */
+  selfMachineId: string;
+  /** Sign canonical bytes with this machine's Ed25519 private key → base64. */
+  sign(canonical: string): string;
+  /**
+   * Verify a signature attributed to `holderMachineId` against that machine's
+   * REGISTERED public key (looked up from the SAS-verified pairing registry).
+   * Returns false if the holder is unknown or the signature is invalid — so a
+   * forged lease naming an unknown/foreign holder never verifies.
+   */
+  verify(canonical: string, signature: string, holderMachineId: string): boolean;
+}
+
+export interface FencedLeaseConfig {
+  leaseTtlMs: number;
+  failoverThresholdMs: number;
+  /** Bounded CAS retry before the livelock backoff kicks in. Default 5. */
+  casMaxRetries?: number;
+}
+
+export interface AcquireDecision {
+  can: boolean;
+  reason: string;
+}
+
+export interface TunnelAcceptDecision {
+  accept: boolean;
+  reason: string;
+}
+
+const DEFAULT_CAS_MAX_RETRIES = 5;
+
+export class FencedLease {
+  private readonly crypto: LeaseCrypto;
+  private readonly leaseTtlMs: number;
+  private readonly failoverThresholdMs: number;
+  private readonly casMaxRetries: number;
+
+  constructor(crypto: LeaseCrypto, config: FencedLeaseConfig) {
+    this.crypto = crypto;
+    this.leaseTtlMs = config.leaseTtlMs;
+    this.failoverThresholdMs = config.failoverThresholdMs;
+    this.casMaxRetries = config.casMaxRetries ?? DEFAULT_CAS_MAX_RETRIES;
+  }
+
+  get selfMachineId(): string {
+    return this.crypto.selfMachineId;
+  }
+
+  // ── Canonical serialization + signing ─────────────────────────────
+
+  /**
+   * Stable, field-ordered serialization of the signable lease fields. The
+   * signature covers exactly these so a holder cannot later be impersonated
+   * by re-ordering fields or smuggling extra keys.
+   */
+  static canonicalize(lease: Pick<LeaseRecord, 'holder' | 'epoch' | 'acquiredAt' | 'expiresAt' | 'nonce'>): string {
+    return JSON.stringify([lease.holder, lease.epoch, lease.acquiredAt, lease.expiresAt, lease.nonce]);
+  }
+
+  /** Build + sign a lease record naming THIS machine as holder. */
+  signLease(epoch: number, acquiredAtIso: string, expiresAtIso: string, nonce: number): LeaseRecord {
+    const base = {
+      holder: this.crypto.selfMachineId,
+      epoch,
+      acquiredAt: acquiredAtIso,
+      expiresAt: expiresAtIso,
+      nonce,
+    };
+    const signature = this.crypto.sign(FencedLease.canonicalize(base));
+    return { ...base, signature };
+  }
+
+  /** Verify a lease's signature against its claimed holder's registered key. */
+  verifyLease(lease: LeaseRecord): boolean {
+    if (!lease || typeof lease.holder !== 'string' || typeof lease.epoch !== 'number') return false;
+    return this.crypto.verify(FencedLease.canonicalize(lease), lease.signature, lease.holder);
+  }
+
+  // ── Expiry + epoch ────────────────────────────────────────────────
+
+  /** True if the lease's holder-local expiry has passed. */
+  isExpired(lease: LeaseRecord | undefined | null, nowMs: number): boolean {
+    if (!lease) return true;
+    const expMs = Date.parse(lease.expiresAt);
+    if (Number.isNaN(expMs)) return true;
+    return nowMs >= expMs;
+  }
+
+  /**
+   * The epoch the fencing check uses: max(tunnel-observed, git-committed).
+   * A fast tunnel copy can ACCELERATE acquisition but can never lower the
+   * observed epoch below what git has already committed (spec §6).
+   */
+  static effectiveEpoch(tunnelEpoch: number, gitEpoch: number): number {
+    return Math.max(tunnelEpoch | 0, gitEpoch | 0);
+  }
+
+  // ── Fencing check (before EVERY awake-only action) ────────────────
+
+  /**
+   * Does THIS machine hold the lease at the current effective epoch? Used to
+   * gate ingress polls, scheduler ticks, outbound sends, and authority-bearing
+   * registry writes. A wedged old-awake whose lease moved on fails this and is
+   * fenced out (spec §6 "Fencing check").
+   */
+  holdsValidLease(lease: LeaseRecord | undefined | null, effectiveEpoch: number, nowMs: number): boolean {
+    if (!lease) return false;
+    if (lease.holder !== this.crypto.selfMachineId) return false;
+    // The lease we hold must be AT the current effective epoch — a stale-epoch
+    // lease (someone advanced past us) does not grant authority.
+    if (lease.epoch !== effectiveEpoch) return false;
+    if (this.isExpired(lease, nowMs)) return false;
+    return this.verifyLease(lease);
+  }
+
+  /**
+   * Should an action stamped with `stampedEpoch` be honored, given the current
+   * effective epoch? Any consumer (registry, outbox, channel-send) rejects
+   * actions stamped with a stale epoch (spec §6). Late writes/sends from a
+   * fenced old-awake carry an old epoch and are dropped.
+   */
+  static isStampCurrent(stampedEpoch: number, effectiveEpoch: number): boolean {
+    return stampedEpoch === effectiveEpoch;
+  }
+
+  // ── Tunnel lease acceptance (replay + floor guard) ────────────────
+
+  /**
+   * Decide whether to accept a lease record observed over the tunnel. Accept
+   * ONLY if: the signature verifies, the epoch is ≥ the git-committed floor
+   * (a below-floor message can neither trick a standby into believing a stale
+   * lease is current nor suppress a legitimate acquisition), AND the per-holder
+   * nonce is strictly greater than the last seen for that holder (replay guard).
+   */
+  acceptTunnelLease(
+    msg: LeaseRecord,
+    gitCommittedEpoch: number,
+    lastNonceByHolder: Record<string, number>,
+  ): TunnelAcceptDecision {
+    if (!this.verifyLease(msg)) {
+      return { accept: false, reason: 'signature-invalid-or-unknown-holder' };
+    }
+    if (msg.epoch < gitCommittedEpoch) {
+      return { accept: false, reason: `below-git-floor (msg epoch ${msg.epoch} < committed ${gitCommittedEpoch})` };
+    }
+    const lastNonce = lastNonceByHolder[msg.holder] ?? -1;
+    if (msg.nonce <= lastNonce) {
+      return { accept: false, reason: `replayed-or-stale-nonce (${msg.nonce} <= ${lastNonce})` };
+    }
+    return { accept: true, reason: 'accepted' };
+  }
+
+  // ── Acquisition decision (CAS candidate) ──────────────────────────
+
+  /**
+   * May this machine attempt to acquire the lease right now? True when:
+   *  - there is no current lease, OR
+   *  - the current lease is expired, OR
+   *  - the current holder is presumed dead (caller passes the set, derived
+   *    from lastSeen > failoverThresholdMs — never from a raw clock compare).
+   * A genuinely-live contended lease is resolved by the CAS itself (only one
+   * epoch advance wins); this method only decides whether to try.
+   */
+  canAcquire(
+    currentLease: LeaseRecord | undefined | null,
+    presumedDeadHolders: ReadonlySet<string>,
+    nowMs: number,
+  ): AcquireDecision {
+    if (!currentLease) return { can: true, reason: 'no-current-lease' };
+    if (this.isExpired(currentLease, nowMs)) return { can: true, reason: 'current-lease-expired' };
+    if (currentLease.holder === this.crypto.selfMachineId) {
+      return { can: true, reason: 'self-renew' };
+    }
+    if (presumedDeadHolders.has(currentLease.holder)) {
+      return { can: true, reason: `holder-presumed-dead (${currentLease.holder})` };
+    }
+    return { can: false, reason: `held-by-live-peer (${currentLease.holder})` };
+  }
+
+  /**
+   * Build the CAS candidate that advances the epoch by exactly one. Acquisition
+   * may only ever write `epoch = currentEpoch + 1`; epoch GAPS are explicitly
+   * safe (a higher epoch observed on re-read always wins). The expiry is
+   * holder-local (now + TTL), used for liveness/display, never for authority.
+   */
+  buildAcquisition(currentLease: LeaseRecord | undefined | null, nowMs: number, nonce: number): LeaseRecord {
+    const currentEpoch = currentLease?.epoch ?? 0;
+    const acquiredAt = new Date(nowMs).toISOString();
+    const expiresAt = new Date(nowMs + this.leaseTtlMs).toISOString();
+    return this.signLease(currentEpoch + 1, acquiredAt, expiresAt, nonce);
+  }
+
+  /**
+   * After CAS exhaustion (bounded retry), should THIS machine back off to let
+   * the other side land (livelock prevention, spec §6)? The deterministic rule:
+   * the higher unforgeable machineId backs off for one lease-TTL, guaranteeing
+   * one side wins. Below the retry cap, no backoff (keep contending).
+   */
+  shouldBackoffAfterContention(retryCount: number, contenderMachineId: string): boolean {
+    if (retryCount < this.casMaxRetries) return false;
+    // Higher machineId yields; lower machineId keeps trying → exactly one lands.
+    return this.crypto.selfMachineId > contenderMachineId;
+  }
+
+  /** Backoff duration after losing CAS contention. */
+  get backoffMs(): number {
+    return this.leaseTtlMs;
+  }
+
+  /** Expose config for callers that derive timers from it. */
+  get ttlMs(): number {
+    return this.leaseTtlMs;
+  }
+  get presumedDeadThresholdMs(): number {
+    return this.failoverThresholdMs;
+  }
+}

--- a/src/core/GitLeaseStore.ts
+++ b/src/core/GitLeaseStore.ts
@@ -1,0 +1,108 @@
+/**
+ * GitLeaseStore — the durable (git-backed) LeaseStore for LeaseCoordinator.
+ *
+ * Implements the lease CAS over git: git has no native compare-and-swap, so we
+ * do optimistic concurrency — pull-rebase to minimize the reject window, re-read
+ * the committed epoch, refuse to write unless our candidate strictly advances
+ * it, then commit+push. A non-fast-forward push (a peer advanced first) returns
+ * ok:false with the freshly-observed lease so LeaseCoordinator re-evaluates and
+ * either yields or retries with a higher epoch. We NEVER force-push.
+ *
+ * The write also bumps the holder's own registry entry (syncSequence +
+ * authoredUnderEpoch) so the lease commit passes peers' registryReplayGuard.
+ */
+
+import type { LeaseStore } from './LeaseCoordinator.js';
+import type { LeaseRecord, MachineRegistry } from './types.js';
+
+export interface GitLeaseStoreDeps {
+  /** This machine's id (the only entry we bump syncSequence on). */
+  machineId: string;
+  loadRegistry: () => MachineRegistry;
+  saveRegistry: (r: MachineRegistry) => void;
+  /** Absolute path of the registry file to stage. */
+  registryAbsPath: string;
+  /** Pull-rebase (best-effort) before reading/writing. */
+  pullRebase: () => boolean;
+  /** Commit + push the registry; false on non-ff/no-op. */
+  commitAndPush: (message: string, paths: string[]) => boolean;
+  logger?: (msg: string) => void;
+}
+
+export class GitLeaseStore implements LeaseStore {
+  private readonly d: GitLeaseStoreDeps;
+
+  constructor(deps: GitLeaseStoreDeps) {
+    this.d = deps;
+  }
+
+  private log(m: string): void {
+    this.d.logger?.(`[git-lease] ${m}`);
+  }
+
+  read(): { lease: LeaseRecord | null; epoch: number } {
+    const reg = this.d.loadRegistry();
+    return { lease: reg.lease ?? null, epoch: reg.lease?.epoch ?? 0 };
+  }
+
+  casWrite(candidate: LeaseRecord): { ok: boolean; observed: { lease: LeaseRecord | null; epoch: number } } {
+    // 1. Pull-rebase to shrink the reject window, then re-read the committed epoch.
+    this.d.pullRebase();
+    let reg = this.d.loadRegistry();
+    const committedEpoch = reg.lease?.epoch ?? 0;
+
+    // 2. CAS pre-check: only a strict +1 advance over the committed epoch is valid.
+    if (candidate.epoch <= committedEpoch) {
+      this.log(`CAS pre-check failed: candidate epoch ${candidate.epoch} <= committed ${committedEpoch}`);
+      return { ok: false, observed: { lease: reg.lease ?? null, epoch: committedEpoch } };
+    }
+
+    // 3. Write the lease + bump the holder's own freshness fields so peers'
+    //    replay guard accepts it.
+    reg.lease = candidate;
+    const entry = reg.machines[this.d.machineId];
+    if (entry) {
+      entry.syncSequence = (entry.syncSequence ?? 0) + 1;
+      entry.authoredUnderEpoch = candidate.epoch;
+    }
+    this.d.saveRegistry(reg);
+
+    // 4. Commit + push. On success the CAS landed.
+    const pushed = this.d.commitAndPush(
+      `chore(mesh): lease epoch ${candidate.epoch} → ${candidate.holder}`,
+      [this.d.registryAbsPath],
+    );
+    if (pushed) {
+      this.log(`lease epoch ${candidate.epoch} committed + pushed`);
+      return { ok: true, observed: { lease: candidate, epoch: candidate.epoch } };
+    }
+
+    // 5. Push rejected (a peer advanced) or no-op. Re-read after a pull and
+    //    report the observed state so the caller re-evaluates / retries.
+    this.d.pullRebase();
+    reg = this.d.loadRegistry();
+    const observedEpoch = reg.lease?.epoch ?? 0;
+    this.log(`push rejected/no-op; observed epoch now ${observedEpoch}`);
+    return { ok: false, observed: { lease: reg.lease ?? null, epoch: observedEpoch } };
+  }
+
+  refresh(lease: LeaseRecord): boolean {
+    // Pull first; if a peer has advanced past our epoch we've been superseded —
+    // do NOT overwrite a higher epoch with a same-epoch refresh.
+    this.d.pullRebase();
+    const reg = this.d.loadRegistry();
+    const committedEpoch = reg.lease?.epoch ?? 0;
+    if (committedEpoch > lease.epoch) {
+      this.log(`refresh declined: superseded (committed ${committedEpoch} > ${lease.epoch})`);
+      return false;
+    }
+    reg.lease = lease; // same epoch, fresh expiry + nonce
+    const entry = reg.machines[this.d.machineId];
+    if (entry) {
+      entry.syncSequence = (entry.syncSequence ?? 0) + 1;
+      entry.authoredUnderEpoch = lease.epoch;
+    }
+    this.d.saveRegistry(reg);
+    return this.d.commitAndPush(`chore(mesh): lease renew epoch ${lease.epoch}`, [this.d.registryAbsPath]);
+  }
+}

--- a/src/core/GitSync.ts
+++ b/src/core/GitSync.ts
@@ -23,6 +23,8 @@ import { FileClassifier } from './FileClassifier.js';
 import type { ClassificationResult } from './FileClassifier.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import { assertNotInstarSourceTree } from './SourceTreeGuard.js';
+import { reconcileRegistryEntries } from './registryReplayGuard.js';
+import type { MachineRegistry } from './types.js';
 import { SafeFsExecutor } from './SafeFsExecutor.js';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
 
@@ -194,6 +196,15 @@ export class GitSyncManager {
 
     // No git repo — return clean no-op (standalone agent without git backup)
     if (!this.isGitRepo()) return result;
+
+    // Cross-Machine Seamlessness §8 G2 — snapshot the registry BEFORE the pull
+    // so we can apply the replay/freshness + unknown-key guard to whatever the
+    // pull brings in (a clean fast-forward can still deliver a stale or
+    // unknown-key registry that signed-commit verification alone won't catch).
+    let registryBefore: MachineRegistry | null = null;
+    try {
+      registryBefore = this.identityManager.loadRegistry();
+    } catch { /* @silent-fallback-ok — reconcile skipped if snapshot unreadable */ }
 
     // 0. Pre-flight: detect and fix stuck rebase / detached HEAD before attempting pull
     let rebaseJustAborted = false;
@@ -408,6 +419,15 @@ export class GitSyncManager {
     // 2. Verify pulled commits
     if (result.pulled) {
       result.rejectedCommits = this.verifyPulledCommits();
+      // §8 G2 — apply the replay/freshness + unknown-key guard to the pulled
+      // registry, scrubbing any stale or unauthorized entries before we trust it.
+      if (registryBefore) {
+        try {
+          this.reconcilePulledRegistry(registryBefore);
+        } catch (err) {
+          console.warn(`[GitSync] registry reconcile warning: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
     }
 
     // 3. Push pending changes
@@ -433,6 +453,46 @@ export class GitSyncManager {
     });
 
     return result;
+  }
+
+  /**
+   * §8 G2 — reconcile a freshly-pulled registry against the pre-pull snapshot,
+   * scrubbing any entry that fails the replay/freshness or unknown-key guard.
+   * Signed-commit verification (verifyPulledCommits) already rejected unsigned
+   * or revoked COMMITS; this rejects stale/unauthorized registry ENTRIES that a
+   * valid signature alone would let through (e.g. a re-keyed machine whose
+   * per-author sequence reset, or an unknown key asserting an awake role). The
+   * lease object itself is reconciled by the FencedLease layer (epoch CAS), not
+   * here. Returns the rejected machineIds (for the caller's diagnostics/tests).
+   */
+  reconcilePulledRegistry(registryBefore: MachineRegistry): string[] {
+    const afterPull = this.identityManager.loadRegistry();
+    const committedEpoch = registryBefore.lease?.epoch ?? 0;
+    const { accepted, rejected } = reconcileRegistryEntries({
+      localEntries: registryBefore.machines ?? {},
+      incomingEntries: afterPull.machines ?? {},
+      currentCommittedEpoch: committedEpoch,
+    });
+    if (rejected.length === 0) return [];
+
+    // Rebuild a clean registry: start from the trusted pre-pull entries, then
+    // overlay the accepted incoming entries. Rejected entries fall back to the
+    // pre-pull value (or are omitted if they were never known locally).
+    const merged: typeof afterPull.machines = { ...(registryBefore.machines ?? {}) };
+    for (const [id, entry] of Object.entries(accepted)) merged[id] = entry;
+    afterPull.machines = merged;
+    this.identityManager.saveRegistry(afterPull);
+
+    for (const r of rejected) {
+      this.securityLog.append({
+        event: 'registry_entry_rejected',
+        machineId: this.machineId,
+        rejectedMachine: r.machineId,
+        reason: r.reason,
+      });
+      console.warn(`[GitSync] Rejected pulled registry entry for ${r.machineId}: ${r.reason}`);
+    }
+    return rejected.map((r) => r.machineId);
   }
 
   /**

--- a/src/core/GitSync.ts
+++ b/src/core/GitSync.ts
@@ -496,6 +496,23 @@ export class GitSyncManager {
   }
 
   /**
+   * Targeted pull-rebase (no auto-commit). Used by the lease CAS to minimize
+   * the push-reject window before writing a lease candidate. Returns true if
+   * the pull succeeded (HEAD may or may not have moved). Best-effort: returns
+   * false on any error rather than throwing.
+   */
+  pullRebase(): boolean {
+    if (!this.isGitRepo()) return false;
+    try {
+      this.gitExec(['pull', '--rebase', '--autostash']);
+      return true;
+    } catch {
+      // @silent-fallback-ok — lease CAS re-reads and retries on failure
+      return false;
+    }
+  }
+
+  /**
    * Stage files and commit with machine signing.
    */
   commitAndPush(message: string, paths?: string[]): boolean {

--- a/src/core/HandoffSentinel.ts
+++ b/src/core/HandoffSentinel.ts
@@ -1,0 +1,199 @@
+/**
+ * HandoffSentinel — the single owner of the planned-handoff lifecycle (spec §8 G3e).
+ *
+ * Replaces the v0 design that scattered handoff steps across HeartbeatManager,
+ * MultiMachineCoordinator, SyncOrchestrator, and HandoffManager with no owner.
+ * One entry point, an explicit state machine, verify-before-finalize, terminal
+ * events, and a race guard so the reaper/scheduler do not act mid-handoff.
+ *
+ * State machine (planned handoff):
+ *   idle → prepare → tail_synced → ingress_fenced → new_owner_active
+ *        → old_owner_standby → committed
+ *
+ * The CRITICAL invariant (spec §8 G3e): the OUTGOING machine retains the lease
+ * (and its fencing epoch) through ingress_fenced → new_owner_active; the
+ * incoming machine attempts its lease-CAS acquisition ONLY after an explicit
+ * `yield` signal, sent ONLY on a verified ack AND a passing validation. A
+ * validator timeout or ack-verification failure means NO yield is sent — the
+ * incoming never initiates its CAS, the outgoing simply stays awake, and there
+ * is no window in which both attempt to hold the same epoch.
+ *
+ * "Caught up" is never a bare boolean: the ack must echo the live-tail sequence,
+ * the ingress position, and a hash of the loaded thread history; the outgoing
+ * verifies the echo matches what it flushed before yielding.
+ */
+
+import type { IngressPosition } from './types.js';
+
+export type HandoffState =
+  | 'idle'
+  | 'prepare'
+  | 'tail_synced'
+  | 'ingress_fenced'
+  | 'new_owner_active'
+  | 'old_owner_standby'
+  | 'committed'
+  | 'aborted'
+  | 'failed';
+
+export type HandoffOutcome = 'handed-off' | 'aborted-stay-awake' | 'failed';
+
+/** What the outgoing machine flushed; the incoming must echo it back exactly. */
+export interface FlushManifest {
+  tailSeq: number;
+  ingressPosition: IngressPosition;
+  threadHistoryHash: string;
+}
+
+/** The incoming machine's "caught up" ack — must echo the flush manifest. */
+export interface HandoffAck {
+  tailSeq: number;
+  ingressPosition: IngressPosition;
+  threadHistoryHash: string;
+}
+
+export interface HandoffOps {
+  /** Flush the live tail + return the manifest the incoming must echo. */
+  flush: () => Promise<FlushManifest>;
+  /** Await the incoming machine's ack (null/throw → no ack). */
+  awaitAck: (timeoutMs: number) => Promise<HandoffAck | null>;
+  /** Tier-1 validation that the receiving machine is truly ready. */
+  validate: (ack: HandoffAck, manifest: FlushManifest) => Promise<boolean>;
+  /** Send the explicit yield signal — the ONLY trigger for the incoming CAS. */
+  sendYield: () => Promise<void>;
+  /** Demote self to standby (after a confirmed yield). */
+  demoteSelf: () => Promise<void>;
+}
+
+export interface HandoffSentinelConfig {
+  handoffAckTimeoutMs: number;
+  minHandoffIntervalMs: number;
+  now?: () => number;
+  logger?: (msg: string) => void;
+  onTerminal?: (outcome: HandoffOutcome, detail: string) => void;
+}
+
+export class HandoffSentinel {
+  private readonly ops: HandoffOps;
+  private readonly cfg: HandoffSentinelConfig;
+  private _state: HandoffState = 'idle';
+  private lastHandoffAt = 0;
+  private _inProgress = false;
+
+  constructor(ops: HandoffOps, cfg: HandoffSentinelConfig) {
+    this.ops = ops;
+    this.cfg = cfg;
+  }
+
+  private now(): number {
+    return (this.cfg.now ?? Date.now)();
+  }
+  private log(m: string): void {
+    this.cfg.logger?.(`[handoff] ${m}`);
+  }
+
+  get state(): HandoffState {
+    return this._state;
+  }
+
+  /** Race guard: the reaper/scheduler must not act while this is true. */
+  get inProgress(): boolean {
+    return this._inProgress;
+  }
+
+  private ackMatches(ack: HandoffAck, manifest: FlushManifest): boolean {
+    return (
+      ack.tailSeq === manifest.tailSeq &&
+      ack.threadHistoryHash === manifest.threadHistoryHash &&
+      ack.ingressPosition.platform === manifest.ingressPosition.platform &&
+      String(ack.ingressPosition.cursor) === String(manifest.ingressPosition.cursor)
+    );
+  }
+
+  /**
+   * Run a planned handoff to completion. The outgoing machine NEVER yields the
+   * lease unless the ack is verified AND validation passes; otherwise it aborts
+   * and stays awake.
+   */
+  async initiate(): Promise<HandoffOutcome> {
+    if (this._inProgress) return this.report('aborted-stay-awake', 'handoff already in progress');
+    // Anti-oscillation floor — protects CONTINUATION LLM cost.
+    if (this.lastHandoffAt !== 0 && this.now() - this.lastHandoffAt < this.cfg.minHandoffIntervalMs) {
+      return this.report('aborted-stay-awake', 'within minHandoffIntervalMs — staying awake');
+    }
+
+    this._inProgress = true;
+    try {
+      this._state = 'prepare';
+      let manifest: FlushManifest;
+      try {
+        manifest = await this.ops.flush();
+      } catch (err) {
+        this._state = 'failed';
+        return this.report('failed', `flush failed: ${msg(err)}`);
+      }
+      this._state = 'tail_synced';
+
+      // Await + VERIFY the ack. Timeout or mismatch → abort, stay awake.
+      let ack: HandoffAck | null;
+      try {
+        ack = await this.ops.awaitAck(this.cfg.handoffAckTimeoutMs);
+      } catch {
+        ack = null;
+      }
+      if (!ack) {
+        this._state = 'aborted';
+        return this.report('aborted-stay-awake', 'no verified ack within handoffAckTimeoutMs — staying awake');
+      }
+      if (!this.ackMatches(ack, manifest)) {
+        this._state = 'aborted';
+        return this.report('aborted-stay-awake', 'ack echo mismatch — staying awake');
+      }
+
+      // Tier-1 validation — a timeout/failure is treated as "not verified".
+      let valid = false;
+      try {
+        valid = await this.ops.validate(ack, manifest);
+      } catch {
+        valid = false;
+      }
+      if (!valid) {
+        this._state = 'aborted';
+        return this.report('aborted-stay-awake', 'validation failed/timed out — staying awake');
+      }
+
+      this._state = 'ingress_fenced';
+      // Only NOW do we yield — the incoming CAS is gated on this signal.
+      try {
+        await this.ops.sendYield();
+      } catch (err) {
+        this._state = 'aborted';
+        return this.report('aborted-stay-awake', `yield send failed: ${msg(err)} — staying awake`);
+      }
+      this._state = 'new_owner_active';
+
+      try {
+        await this.ops.demoteSelf();
+      } catch (err) {
+        // Lease already moved; if demotion fails we still hand off, but flag it.
+        this.log(`demoteSelf warning: ${msg(err)}`);
+      }
+      this._state = 'old_owner_standby';
+      this.lastHandoffAt = this.now();
+      this._state = 'committed';
+      return this.report('handed-off', 'planned handoff complete');
+    } finally {
+      this._inProgress = false;
+    }
+  }
+
+  private report(outcome: HandoffOutcome, detail: string): HandoffOutcome {
+    this.log(`${outcome}: ${detail}`);
+    this.cfg.onTerminal?.(outcome, detail);
+    return outcome;
+  }
+}
+
+function msg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/core/LeaseCoordinator.ts
+++ b/src/core/LeaseCoordinator.ts
@@ -1,0 +1,294 @@
+/**
+ * LeaseCoordinator — drives the FencedLease over the durable (git) and fast
+ * (tunnel) media, and owns the lifecycle of acquisition / renewal / fencing /
+ * escalation. Spec §6 + §8 G1.
+ *
+ * Correctness substrate is GIT: acquisition is a compare-and-swap implemented
+ * as write-then-push-or-reject-reread plus epoch monotonicity (git has no
+ * native CAS). The TUNNEL is an optional low-latency accelerator: it can raise
+ * the observed epoch (speeding acquisition) but can NEVER lower it below the
+ * git-committed floor, and a replayed/below-floor tunnel message is dropped by
+ * FencedLease.acceptTunnelLease. If the tunnel is unavailable the system
+ * degrades to git-only — correct, just bounded by git cadence — which is why
+ * Phase-0 pairing worked over git alone.
+ *
+ * Renewal requires the tunnel medium when one is configured: a holder that
+ * cannot renew for > leaseTtlMs MUST self-suspend ingress regardless of its
+ * local clock (closes the tunnel-down / git-up split-authority window).
+ *
+ * The store/transport are injected so the dangerous CAS-contention and
+ * self-suspend logic are unit-testable with in-memory fakes.
+ */
+
+import { FencedLease } from './FencedLease.js';
+import type { LeaseRecord } from './types.js';
+
+/** Durable (git-backed) view + CAS write of the lease. */
+export interface LeaseStore {
+  /** Read the current committed lease + its epoch (0 if none). */
+  read(): { lease: LeaseRecord | null; epoch: number };
+  /**
+   * Attempt to commit `candidate` as the new lease. Implements the CAS:
+   * returns ok:true if the candidate landed (fast-forward push accepted), or
+   * ok:false + the freshly-observed lease/epoch after a reject+reread so the
+   * caller can re-evaluate. MUST NOT force-push.
+   */
+  casWrite(candidate: LeaseRecord): { ok: boolean; observed: { lease: LeaseRecord | null; epoch: number } };
+  /**
+   * Refresh the SAME-epoch lease's expiry durably (renewal, not acquisition).
+   * Returns true if the refresh was confirmed over the durable medium (push
+   * succeeded). A holder that cannot refresh (partitioned) must self-suspend —
+   * this is the git-medium equivalent of the tunnel-renewal requirement, and
+   * it is what prevents a partitioned old-awake from extending its lease
+   * locally forever (the split-brain). Optional: a tunnel-backed deployment
+   * confirms over the tunnel instead and may no-op this.
+   */
+  refresh(lease: LeaseRecord): boolean;
+}
+
+/** Optional low-latency tunnel transport for the lease. */
+export interface LeaseTransport {
+  /** Broadcast our lease to peers. Resolves false if unreachable. */
+  broadcast(lease: LeaseRecord): Promise<boolean>;
+  /** The most-recent lease observed over the tunnel (and its source nonce map). */
+  observed(): { lease: LeaseRecord | null; lastNonceByHolder: Record<string, number> };
+  /** Whether the tunnel medium is currently reachable. */
+  isReachable(): boolean;
+}
+
+export interface LeaseCoordinatorDeps {
+  lease: FencedLease;
+  store: LeaseStore;
+  tunnel?: LeaseTransport;
+  /** Machines presumed dead (lastSeen older than failoverThresholdMs). */
+  presumedDeadHolders: () => ReadonlySet<string>;
+  /** Wall clock (injectable for tests). */
+  now?: () => number;
+  /** Escalate an unresolvable split-brain (deduped per partitionEpisodeId by the caller's sink). */
+  onEscalate?: (info: { partitionEpisodeId: string; holder: string; reason: string }) => void;
+  /** Fired when the holder must self-suspend ingress (tunnel-renewal lapse). */
+  onSelfSuspend?: (reason: string) => void;
+  /** Fired whenever our effective epoch advances (drives leaseEpochChange → registry push). */
+  onEpochAdvance?: (epoch: number) => void;
+  logger?: (msg: string) => void;
+}
+
+export class LeaseCoordinator {
+  private readonly d: LeaseCoordinatorDeps;
+  private readonly fl: FencedLease;
+  private nonceCounter = 0;
+  private lastRenewOkAt: number;
+  private lastObservedEpoch = 0;
+  private suspended = false;
+  /**
+   * The freshest lease THIS machine has signed (acquisition or renewal). It is
+   * the authoritative low-latency copy of our own holding — we broadcast it
+   * over the tunnel, but git is only updated coarsely (on epoch change), so a
+   * renewal's new expiry lives here, not in git. Folded into effectiveView only
+   * while it is not superseded by a higher epoch.
+   */
+  private selfIssued: LeaseRecord | null = null;
+
+  constructor(deps: LeaseCoordinatorDeps) {
+    this.d = deps;
+    this.fl = deps.lease;
+    this.lastRenewOkAt = this.now();
+  }
+
+  private now(): number {
+    return (this.d.now ?? Date.now)();
+  }
+  private log(m: string): void {
+    this.d.logger?.(`[lease] ${m}`);
+  }
+  private nextNonce(): number {
+    return ++this.nonceCounter;
+  }
+
+  get selfMachineId(): string {
+    return this.fl.selfMachineId;
+  }
+  get isSuspended(): boolean {
+    return this.suspended;
+  }
+
+  /**
+   * Compute the current effective epoch = max(tunnel-observed accepted, git).
+   * A tunnel lease is folded in only if acceptTunnelLease passes (valid sig,
+   * ≥ git floor, fresh nonce).
+   */
+  private effectiveView(): { lease: LeaseRecord | null; epoch: number; gitEpoch: number } {
+    const git = this.d.store.read();
+    let bestLease = git.lease;
+    let epoch = git.epoch;
+    if (this.d.tunnel) {
+      const obs = this.d.tunnel.observed();
+      if (obs.lease) {
+        const decision = this.fl.acceptTunnelLease(obs.lease, git.epoch, obs.lastNonceByHolder);
+        if (decision.accept && obs.lease.epoch > epoch) {
+          bestLease = obs.lease;
+          epoch = obs.lease.epoch;
+        }
+      }
+    }
+    // Fold in our own freshest self-issued lease (a renewal's new expiry lives
+    // here, not in coarse git). Only while not superseded by a higher epoch.
+    if (this.selfIssued && this.selfIssued.holder === this.selfMachineId && this.selfIssued.epoch >= epoch) {
+      bestLease = this.selfIssued;
+      epoch = this.selfIssued.epoch;
+    }
+    return { lease: bestLease, epoch, gitEpoch: git.epoch };
+  }
+
+  /** Does THIS machine currently hold a valid lease at the effective epoch? */
+  holdsLease(): boolean {
+    if (this.suspended) return false;
+    const view = this.effectiveView();
+    return this.fl.holdsValidLease(view.lease, view.epoch, this.now());
+  }
+
+  /** The current effective epoch (for stamping writes/sends). */
+  currentEpoch(): number {
+    return this.effectiveView().epoch;
+  }
+
+  currentHolder(): string | null {
+    return this.effectiveView().lease?.holder ?? null;
+  }
+
+  /**
+   * Attempt to acquire (or self-renew) the lease if eligible. Returns true if
+   * THIS machine holds the lease afterward. Implements the bounded-retry CAS
+   * with livelock backoff.
+   */
+  async acquireIfEligible(): Promise<boolean> {
+    if (this.suspended) {
+      // A suspended holder may resume only by re-acquiring cleanly below.
+      this.suspended = false;
+    }
+    const dead = this.d.presumedDeadHolders();
+    let retries = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const view = this.effectiveView();
+      // Already hold it at the current epoch → just renew.
+      if (view.lease && view.lease.holder === this.selfMachineId && !this.fl.isExpired(view.lease, this.now())) {
+        return this.renew();
+      }
+      const decision = this.fl.canAcquire(view.lease, dead, this.now());
+      if (!decision.can) {
+        this.log(`acquire skipped: ${decision.reason}`);
+        return false;
+      }
+      const candidate = this.fl.buildAcquisition(view.lease, this.now(), this.nextNonce());
+      const res = this.d.store.casWrite(candidate);
+      if (res.ok) {
+        this.selfIssued = candidate;
+        await this.broadcast(candidate);
+        this.lastRenewOkAt = this.now();
+        this.emitEpoch(candidate.epoch);
+        this.log(`acquired lease at epoch ${candidate.epoch}`);
+        return true;
+      }
+      // CAS lost — someone advanced. Re-evaluate against the observed state.
+      const observedEpoch = res.observed.epoch;
+      if (observedEpoch >= candidate.epoch) {
+        this.log(`CAS lost to epoch ${observedEpoch} (our candidate ${candidate.epoch}) — yielding`);
+        this.emitEpoch(observedEpoch);
+        // If the winner is a presumed-dead/expired holder we'll retry; else stop.
+        if (!this.fl.canAcquire(res.observed.lease, dead, this.now()).can) return false;
+      }
+      retries++;
+      if (this.fl.shouldBackoffAfterContention(retries, res.observed.lease?.holder ?? '')) {
+        this.log(`livelock backoff after ${retries} retries — yielding for ${this.fl.backoffMs}ms`);
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Renew the held lease: re-sign with a fresh expiry, broadcast over the
+   * tunnel, and (coarsely, via the store on epoch change) keep git current.
+   * Returns false (and self-suspends) if the tunnel medium is configured but
+   * has been unreachable for longer than the lease TTL.
+   */
+  async renew(): Promise<boolean> {
+    const view = this.effectiveView();
+    if (!view.lease || view.lease.holder !== this.selfMachineId) return false;
+
+    // Re-sign with a fresh expiry (same epoch — renewal never advances it).
+    const renewed = this.fl.signLease(
+      view.epoch,
+      view.lease.acquiredAt,
+      new Date(this.now() + this.fl.ttlMs).toISOString(),
+      this.nextNonce(),
+    );
+
+    // Medium-agnostic renewal requirement: the renewal must be CONFIRMED over a
+    // shared medium — the tunnel (reachable broadcast) when configured, else a
+    // durable git refresh. A holder that cannot confirm over ANY medium for
+    // > leaseTtlMs MUST self-suspend, rather than extend its lease locally
+    // forever (which is exactly the partitioned-old-awake split-brain).
+    let confirmed: boolean;
+    if (this.d.tunnel) {
+      confirmed = await this.d.tunnel.broadcast(renewed).catch(() => false);
+    } else {
+      confirmed = this.d.store.refresh(renewed);
+    }
+
+    if (confirmed) {
+      this.selfIssued = renewed;
+      this.lastRenewOkAt = this.now();
+      return true;
+    }
+
+    if (this.now() - this.lastRenewOkAt > this.fl.ttlMs) {
+      this.suspended = true;
+      this.d.onSelfSuspend?.(
+        `could not confirm lease over ${this.d.tunnel ? 'tunnel' : 'git'} for > leaseTtlMs (${this.fl.ttlMs}ms) — lease lapsed`,
+      );
+      this.log('self-suspended: renewal-confirmation lapse');
+      return false;
+    }
+    // Within grace: keep serving on the EXISTING (soon-to-expire) lease — do
+    // NOT extend selfIssued's expiry, so it lapses if we never reconfirm.
+    return true;
+  }
+
+  private async broadcast(lease: LeaseRecord): Promise<void> {
+    if (!this.d.tunnel) return;
+    try {
+      const ok = await this.d.tunnel.broadcast(lease);
+      if (ok) this.lastRenewOkAt = this.now();
+    } catch (err) {
+      this.log(`broadcast failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private emitEpoch(epoch: number): void {
+    if (epoch !== this.lastObservedEpoch) {
+      this.lastObservedEpoch = epoch;
+      this.d.onEpochAdvance?.(epoch);
+    }
+  }
+
+  /**
+   * Detection (signal only): does the synced state show contention the lease
+   * cannot resolve (e.g. a presumed-dead holder we cannot demote because no
+   * shared medium can advance the epoch)? Escalates ONCE per partition episode.
+   */
+  checkForUnresolvableSplit(partitionEpisodeId: string): void {
+    const view = this.effectiveView();
+    if (!view.lease) return;
+    const dead = this.d.presumedDeadHolders();
+    const holderDead = dead.has(view.lease.holder);
+    const cannotAdvance = this.d.tunnel ? !this.d.tunnel.isReachable() : false;
+    if (holderDead && cannotAdvance && view.lease.holder !== this.selfMachineId) {
+      this.d.onEscalate?.({
+        partitionEpisodeId,
+        holder: view.lease.holder,
+        reason: 'presumed-dead holder cannot be demoted — no shared medium to advance the epoch',
+      });
+    }
+  }
+}

--- a/src/core/LiveTailBuffer.ts
+++ b/src/core/LiveTailBuffer.ts
@@ -1,0 +1,162 @@
+/**
+ * LiveTailBuffer — the standby-side persisted live-tail with sequence-dedup
+ * (spec §8 G3b). The holder pushes monotonic-sequence flushes of the live
+ * conversation tail; the standby applies a flush ONLY if its sequence is
+ * lastAppliedSeq + 1, coalescing/holding out-of-order flushes and dropping
+ * duplicates — so an at-least-once tunnel redelivery cannot double-append and
+ * corrupt the persisted context window (which would make a post-failover reply
+ * misrepresent history, violating acceptance criterion 3).
+ *
+ * Out-of-order flushes are held only until liveTailOutOfOrderTimeoutMs; if the
+ * gap is never filled (sender died mid-sequence) the buffer DECLARES THE GAP
+ * UNFILLABLE, discards the held flushes, and proceeds with the last contiguous
+ * sequence as its resumable tail — bounding the holdout buffer and never
+ * wedging the standby behind a gap the at-least-once channel will re-present.
+ *
+ * Bounded by liveTailMaxBytesPerTopic (drop-oldest). Pure logic — the encrypted
+ * transport feeds applyFlush(); persistence is the caller's (an injected sink).
+ */
+
+export interface LiveTailFlush {
+  seq: number;
+  topic: string;
+  /** Already-redacted, already-decrypted tail content for this flush. */
+  content: string;
+  /** Bytes (for the cap); defaults to content length. */
+  bytes?: number;
+  receivedAtMs?: number;
+}
+
+export interface LiveTailBufferConfig {
+  outOfOrderTimeoutMs: number;
+  maxBytesPerTopic: number;
+  now?: () => number;
+  logger?: (msg: string) => void;
+}
+
+interface TopicState {
+  lastAppliedSeq: number;
+  applied: LiveTailFlush[];
+  held: Map<number, LiveTailFlush & { heldAtMs: number }>;
+  bytes: number;
+}
+
+export interface ApplyResult {
+  applied: boolean;
+  reason: 'applied' | 'duplicate' | 'held-out-of-order' | 'gap-discarded-then-applied';
+}
+
+export class LiveTailBuffer {
+  private readonly cfg: LiveTailBufferConfig;
+  private topics = new Map<string, TopicState>();
+
+  constructor(cfg: LiveTailBufferConfig) {
+    this.cfg = cfg;
+  }
+
+  private now(): number {
+    return (this.cfg.now ?? Date.now)();
+  }
+  private log(m: string): void {
+    this.cfg.logger?.(`[live-tail] ${m}`);
+  }
+
+  private topic(id: string): TopicState {
+    let t = this.topics.get(id);
+    if (!t) {
+      t = { lastAppliedSeq: 0, applied: [], held: new Map(), bytes: 0 };
+      this.topics.set(id, t);
+    }
+    return t;
+  }
+
+  /**
+   * Apply a flush. Returns whether it was applied (or held/dropped). Enforces
+   * exactly-once contiguous application: dup dropped, out-of-order held, gap
+   * timed-out and discarded.
+   */
+  applyFlush(flush: LiveTailFlush): ApplyResult {
+    const t = this.topic(flush.topic);
+    const seq = flush.seq;
+
+    if (seq <= t.lastAppliedSeq) {
+      return { applied: false, reason: 'duplicate' };
+    }
+
+    if (seq === t.lastAppliedSeq + 1) {
+      this.commit(t, flush);
+      // Drain any held flushes that are now contiguous.
+      let next = t.lastAppliedSeq + 1;
+      while (t.held.has(next)) {
+        const h = t.held.get(next)!;
+        t.held.delete(next);
+        this.commit(t, h);
+        next = t.lastAppliedSeq + 1;
+      }
+      return { applied: true, reason: 'applied' };
+    }
+
+    // seq > lastAppliedSeq + 1 → there's a gap. Check whether the earliest held
+    // gap has timed out; if so, declare unfillable, discard held, and treat this
+    // flush's predecessor chain as the new contiguous baseline.
+    const evicted = this.evictTimedOutGaps(t);
+    if (evicted) {
+      // After discarding the unfillable gap, accept this flush as the new
+      // baseline (we proceed with the last contiguous sequence == this one).
+      t.lastAppliedSeq = seq - 1;
+      this.commit(t, flush);
+      return { applied: true, reason: 'gap-discarded-then-applied' };
+    }
+
+    // Hold it for the out-of-order window.
+    if (!t.held.has(seq)) {
+      t.held.set(seq, { ...flush, heldAtMs: this.now() });
+    }
+    return { applied: false, reason: 'held-out-of-order' };
+  }
+
+  /** Discard held flushes whose gap has exceeded the out-of-order timeout. */
+  private evictTimedOutGaps(t: TopicState): boolean {
+    if (t.held.size === 0) return false;
+    const oldestHeldAt = Math.min(...[...t.held.values()].map((h) => h.heldAtMs));
+    if (this.now() - oldestHeldAt > this.cfg.outOfOrderTimeoutMs) {
+      this.log(`gap unfillable after ${this.cfg.outOfOrderTimeoutMs}ms — discarding ${t.held.size} held flush(es)`);
+      t.held.clear();
+      return true;
+    }
+    return false;
+  }
+
+  /** A periodic tick the caller invokes to time out gaps even without new flushes. */
+  tick(topic: string): void {
+    const t = this.topics.get(topic);
+    if (t) this.evictTimedOutGaps(t);
+  }
+
+  private commit(t: TopicState, flush: LiveTailFlush): void {
+    const bytes = flush.bytes ?? Buffer.byteLength(flush.content);
+    t.applied.push({ ...flush });
+    t.bytes += bytes;
+    t.lastAppliedSeq = flush.seq;
+    // Enforce the per-topic byte cap (drop-oldest).
+    while (t.bytes > this.cfg.maxBytesPerTopic && t.applied.length > 1) {
+      const dropped = t.applied.shift()!;
+      t.bytes -= dropped.bytes ?? Buffer.byteLength(dropped.content);
+    }
+  }
+
+  /** The resumable tail for a topic (the contiguous applied content). */
+  getTail(topic: string): { lastAppliedSeq: number; content: string } {
+    const t = this.topics.get(topic);
+    if (!t) return { lastAppliedSeq: 0, content: '' };
+    return { lastAppliedSeq: t.lastAppliedSeq, content: t.applied.map((f) => f.content).join('') };
+  }
+
+  getLastAppliedSeq(topic: string): number {
+    return this.topics.get(topic)?.lastAppliedSeq ?? 0;
+  }
+
+  heldCount(topic: string): number {
+    return this.topics.get(topic)?.held.size ?? 0;
+  }
+}

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -22,6 +22,7 @@ import { HeartbeatManager } from './HeartbeatManager.js';
 import { SecurityLog } from './SecurityLog.js';
 import { NonceStore } from './NonceStore.js';
 import type { StateManager } from './StateManager.js';
+import type { LeaseCoordinator } from './LeaseCoordinator.js';
 import type { MachineRole, MachineIdentity, MultiMachineConfig, CoordinationMode } from './types.js';
 
 // ── Constants ────────────────────────────────────────────────────────
@@ -67,6 +68,14 @@ export class MultiMachineCoordinator extends EventEmitter {
   /** Integrated-Being v1 — tracks whether we've already emitted the
    *  per-machine-ledger warning this boot. Spec §Multi-machine. */
   private integratedBeingWarningEmitted: boolean = false;
+  /**
+   * Cross-Machine Seamlessness §6 — the fenced lease is the authority for
+   * "awake". When attached, holdsLease() gates the hot path (the structural
+   * demotion the Phase-0 split-brain was missing). Null on single-machine /
+   * non-git meshes, where the heartbeat path remains the authority.
+   */
+  private leaseCoordinator: LeaseCoordinator | null = null;
+  private leaseTicking: boolean = false;
 
   constructor(state: StateManager, config: CoordinatorConfig) {
     super();
@@ -335,10 +344,94 @@ export class MultiMachineCoordinator extends EventEmitter {
     if (!this._enabled) return false; // Single machine = always process
     // Independent mode: both machines always process
     if (this.coordinationMode === 'independent') return false;
-    if (this._role !== 'awake') return true; // Standby = skip
 
+    // Lease is authority when attached: a machine processes ONLY while it
+    // structurally holds the lease at the current epoch. A wedged old-awake
+    // whose lease moved on fails this even if its in-memory _role still says
+    // 'awake' — the exact structural demotion Phase-0 was missing.
+    if (this.leaseCoordinator) {
+      return !this.leaseCoordinator.holdsLease();
+    }
+
+    if (this._role !== 'awake') return true; // Standby = skip
     // Even if we think we're awake, check the heartbeat file
     return this.heartbeatManager.shouldDemote();
+  }
+
+  // ── Fenced-Lease integration (spec §6) ───────────────────────────
+
+  /**
+   * Attach the LeaseCoordinator (built once gitSync exists in server boot).
+   * From here the lease is the authority for awake/standby. Wires the lease's
+   * epoch-advance to a coordinator `leaseEpochChange` event so the registry
+   * sync debouncer pushes the new epoch durably.
+   */
+  attachLeaseCoordinator(lc: LeaseCoordinator): void {
+    this.leaseCoordinator = lc;
+  }
+
+  /** Whether this machine structurally holds the lease (false if none attached). */
+  holdsLease(): boolean {
+    return this.leaseCoordinator?.holdsLease() ?? this._role === 'awake';
+  }
+
+  /**
+   * Initialize the lease-based role at boot: attempt acquisition if eligible,
+   * then reconcile _role + StateManager read-only to whether we hold the lease.
+   */
+  async initializeLease(): Promise<void> {
+    if (!this.leaseCoordinator) return;
+    await this.leaseCoordinator.acquireIfEligible();
+    this.reconcileRoleToLease('lease-init');
+  }
+
+  /**
+   * Drive the lease on each monitor tick: renew if we hold it, else attempt
+   * failover acquisition. Reconciles role afterward. Fire-and-forget safe.
+   */
+  private async tickLease(): Promise<void> {
+    if (!this.leaseCoordinator || this.leaseTicking) return;
+    this.leaseTicking = true;
+    try {
+      if (this.leaseCoordinator.holdsLease()) {
+        await this.leaseCoordinator.renew();
+      } else {
+        await this.leaseCoordinator.acquireIfEligible();
+      }
+      this.reconcileRoleToLease('lease-tick');
+    } catch {
+      // @silent-fallback-ok — a tick failure is retried next interval
+    } finally {
+      this.leaseTicking = false;
+    }
+  }
+
+  /** Bring _role + read-only into line with whether we hold the lease. */
+  private reconcileRoleToLease(reason: string): void {
+    if (!this.leaseCoordinator || !this._identity) return;
+    const holds = this.leaseCoordinator.holdsLease();
+    const desired: MachineRole = holds ? 'awake' : 'standby';
+    if (desired === this._role) return;
+    const oldRole = this._role;
+    this._role = desired;
+    this.identityManager.updateRole(this._identity.machineId, desired);
+    this.state.setReadOnly(!holds);
+    if (holds) this.startHeartbeatWriter();
+    else if (this.heartbeatWriteTimer) {
+      clearInterval(this.heartbeatWriteTimer);
+      this.heartbeatWriteTimer = null;
+    }
+    this.securityLog.append({
+      event: 'role_transition',
+      machineId: this._identity.machineId,
+      from: oldRole,
+      to: desired,
+      reason: `lease:${reason}`,
+    });
+    this.emit('roleChange', oldRole, desired);
+    if (holds) this.emit('promote');
+    else this.emit('demote');
+    console.log(`[MultiMachine] Lease reconcile → ${desired} (${reason})`);
   }
 
   // ── Private ──────────────────────────────────────────────────────
@@ -398,6 +491,13 @@ export class MultiMachineCoordinator extends EventEmitter {
     if (!this._identity) return;
     // Independent mode: no failover/demotion logic
     if (this.coordinationMode === 'independent') return;
+
+    // Lease is authority when attached — renew/acquire + reconcile role. The
+    // heartbeat below is retained only for liveness display in this mode.
+    if (this.leaseCoordinator) {
+      void this.tickLease();
+      return;
+    }
 
     if (this._role === 'awake') {
       // Awake machine: check if someone else took over

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -23,7 +23,21 @@ import { SecurityLog } from './SecurityLog.js';
 import { NonceStore } from './NonceStore.js';
 import type { StateManager } from './StateManager.js';
 import type { LeaseCoordinator } from './LeaseCoordinator.js';
+import { SEAMLESSNESS_PROTOCOL_VERSION } from './seamlessnessConfig.js';
 import type { MachineRole, MachineIdentity, MultiMachineConfig, CoordinationMode } from './types.js';
+
+/** Observability shape for /health.multiMachine.syncStatus (spec §11). */
+export interface MultiMachineSyncStatus {
+  enabled: boolean;
+  role: MachineRole;
+  leaseHolder: string | null;
+  leaseEpoch: number;
+  holdsLease: boolean;
+  /** 'clear' | 'contested' (more than one awake machine in the registry) | 'self-suspended'. */
+  splitBrainState: 'clear' | 'contested' | 'self-suspended';
+  protocolVersion: number;
+  awakeMachineCount: number;
+}
 
 // ── Constants ────────────────────────────────────────────────────────
 
@@ -373,6 +387,41 @@ export class MultiMachineCoordinator extends EventEmitter {
   /** Whether this machine structurally holds the lease (false if none attached). */
   holdsLease(): boolean {
     return this.leaseCoordinator?.holdsLease() ?? this._role === 'awake';
+  }
+
+  /**
+   * Observability snapshot for /health.multiMachine.syncStatus (spec §11).
+   * Always returns valid fields (never null/throws) — this is the Phase-1
+   * "feature is alive" surface. On a single-machine install it reports the
+   * trivially-held lease.
+   */
+  getSyncStatus(): MultiMachineSyncStatus {
+    let awakeMachineCount = 0;
+    try {
+      const reg = this.identityManager.loadRegistry();
+      for (const e of Object.values(reg.machines ?? {})) {
+        if (e.role === 'awake') awakeMachineCount++;
+      }
+    } catch { /* @silent-fallback-ok — registry unreadable → count 0 */ }
+
+    const holds = this.holdsLease();
+    const selfSuspended = this.leaseCoordinator?.isSuspended ?? false;
+    const splitBrainState: MultiMachineSyncStatus['splitBrainState'] = selfSuspended
+      ? 'self-suspended'
+      : awakeMachineCount > 1
+        ? 'contested'
+        : 'clear';
+
+    return {
+      enabled: this._enabled,
+      role: this._role,
+      leaseHolder: this.leaseCoordinator?.currentHolder() ?? (holds ? this._identity?.machineId ?? null : null),
+      leaseEpoch: this.leaseCoordinator?.currentEpoch() ?? 0,
+      holdsLease: holds,
+      splitBrainState,
+      protocolVersion: SEAMLESSNESS_PROTOCOL_VERSION,
+      awakeMachineCount,
+    };
   }
 
   /**

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2455,6 +2455,31 @@ Rule: I do not state that work landed inside another agent's state unless I have
       result.upgraded.push('CLAUDE.md: added Cross-Agent Communication Discipline (anti-confabulation) section');
     }
 
+    // Cross-Machine Seamlessness (spec §11 Agent Awareness). Existing
+    // multi-machine agents need to know about lease-based authority, the
+    // honest machine-provenance disclosure, and where to read mesh/sync status.
+    // Content-sniffed on a distinctive marker for idempotency.
+    if (!content.includes('Cross-Machine Seamlessness (one agent, many machines)')) {
+      const seamlessnessSection = `
+### Cross-Machine Seamlessness (one agent, many machines)
+
+When I run on more than one machine, I am ONE agent that follows the user across them — not clones. Exactly one machine is "awake" (serving) at a time, decided by a **fenced lease** (a clock-proof, numbered "who's in charge" badge). The other machine is standby and only takes over when the awake machine genuinely goes silent.
+
+What this means for how I behave:
+- **I never double-reply.** Each inbound message is handled exactly once (a durable per-message ledger keyed on the platform's event id), so a redelivery or a mid-handoff overlap can't make me answer twice.
+- **A handoff feels like a compaction pause, not amnesia.** When serving moves between machines, the new machine resumes the conversation via CONTINUATION — it picks up the thread rather than re-greeting. In a planned handoff the context is current; in a hard failover it's as-of-the-last-sync, so if my context is partial I say so honestly ("picking this back up from the other machine") rather than pretending nothing changed.
+- **I know which machine I'm on.** Turn provenance is recorded; if a failover outran the sync I disclose that the exact provenance is still catching up rather than asserting a stale machine.
+
+Where to look (never guess mesh state — read it):
+- \`GET /health\` → \`multiMachine.syncStatus\` = \`{ leaseHolder, leaseEpoch, holdsLease, splitBrainState, awakeMachineCount, protocolVersion }\`. \`instar doctor\` surfaces the same.
+- A genuinely **unresolvable split-brain** (a machine looks alive but unreachable, so the lease can't move) surfaces as a single **Attention-queue** item with a Y/N decision ("demote machine X?") — it is deduped per partition episode, never per heartbeat. If I see one, I present the data and the decision to the user; I do not silently pick.
+- Dials live under \`.instar/config.json\` → \`multiMachine\` (ingressHeartbeatMs, leaseTtlMs, liveTailMaxStalenessMs, handoffAckTimeoutMs, …). A nonsensical combination is rejected at startup with a clear message rather than degrading silently.
+`;
+      content += '\n' + seamlessnessSection;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Cross-Machine Seamlessness section');
+    }
+
     // CMT-519 — Threadline hub topic + "open this"/bind guidance. Existing agents
     // need to know threadline notices route parent-or-hub (never per-event topics)
     // and that "open this" / "tie this to X" in the hub means calling the bind

--- a/src/core/RegistrySyncDebouncer.ts
+++ b/src/core/RegistrySyncDebouncer.ts
@@ -1,0 +1,161 @@
+/**
+ * RegistrySyncDebouncer — G2 automated state sync (durable half).
+ *
+ * Spec: docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md §8 G2.
+ *
+ * The Phase-0 root cause: a running server changed its registry (role/lease)
+ * but NOTHING pushed that change to git, so cross-machine state only ever
+ * propagated by hand. This component closes that: a marked-dirty registry is
+ * debounced and committed+pushed to git — but ONLY the authoritative machine
+ * (lease holder / awake) writes durable authority-bearing state (single-writer,
+ * removing the O(N) thundering-herd of every machine pushing a corrected
+ * registry).
+ *
+ * This is the DURABLE path only. High-frequency liveness/heartbeat (ephemeral)
+ * never comes through here — it travels over the tunnel and stays out of git
+ * history, so steady-state healthy operation produces ~0 commits (the
+ * ephemeral-vs-durable split, spec §Design Principles).
+ *
+ * Push contention: commitAndPush performs `git push` which fails (returns
+ * false) on a non-fast-forward — we never force-push. Repeated failures past a
+ * threshold emit a sync-health signal so the lease layer can self-suspend
+ * ingress (a machine that cannot prove it is visible must not serve). The
+ * pull/rebase reconciliation itself lives in the periodic GitSync.sync cycle.
+ */
+
+export interface SyncHealthState {
+  healthy: boolean;
+  consecutiveFailures: number;
+  lastError?: string;
+  lastPushAt?: string;
+  lastAttemptAt?: string;
+}
+
+export interface RegistrySyncDeps {
+  /** Commit + push the given paths. Returns true if a commit was pushed. */
+  commitAndPush: (message: string, paths: string[]) => boolean;
+  /** Absolute path of the registry file to stage. */
+  registryAbsPath: string;
+  /**
+   * Single-writer gate: only flush when THIS machine has authority to write
+   * durable registry state (holds the lease / is awake). A standby marking
+   * dirty is a no-op push (it still updates its own liveness elsewhere).
+   */
+  isAuthoritative: () => boolean;
+  /** Debounce window (registrySyncDebounceMs). */
+  debounceMs: number;
+  /** Failures before the sync-health signal flips unhealthy. Default 3. */
+  maxConsecutiveFailures?: number;
+  /** Sync-health signal consumer (lease layer self-suspends ingress on unhealthy). */
+  onSyncHealth?: (s: SyncHealthState) => void;
+  logger?: (msg: string) => void;
+  now?: () => number;
+}
+
+export class RegistrySyncDebouncer {
+  private readonly deps: RegistrySyncDeps;
+  private readonly maxFailures: number;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private pendingReasons: string[] = [];
+  private flushing = false;
+  private health: SyncHealthState = { healthy: true, consecutiveFailures: 0 };
+  private stopped = false;
+
+  constructor(deps: RegistrySyncDeps) {
+    this.deps = deps;
+    this.maxFailures = deps.maxConsecutiveFailures ?? 3;
+  }
+
+  private now(): number {
+    return (this.deps.now ?? Date.now)();
+  }
+
+  private log(msg: string): void {
+    this.deps.logger?.(`[registry-sync] ${msg}`);
+  }
+
+  /**
+   * Mark the registry as needing a durable push. Debounced — many rapid marks
+   * within the window coalesce into a single commit (coarse, not per-tick).
+   */
+  markRegistryDirty(reason: string): void {
+    if (this.stopped) return;
+    this.pendingReasons.push(reason);
+    if (this.timer) return; // already scheduled
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.flush();
+    }, this.deps.debounceMs);
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  /**
+   * Flush immediately (also used by stop()). Returns true if a commit was
+   * pushed. A non-authoritative machine returns false without pushing
+   * (single-writer). Re-entrancy guarded.
+   */
+  async flush(): Promise<boolean> {
+    if (this.flushing) return false;
+    if (this.pendingReasons.length === 0) return false;
+    this.flushing = true;
+    const reasons = this.pendingReasons.slice(0, 8);
+    this.pendingReasons = [];
+    this.health.lastAttemptAt = new Date(this.now()).toISOString();
+
+    try {
+      if (!this.deps.isAuthoritative()) {
+        // Single-writer: a standby never writes durable authority-bearing state.
+        this.log(`skip flush — not authoritative (${reasons.length} pending reason(s) dropped)`);
+        return false;
+      }
+      const message = `chore(mesh): registry sync — ${reasons.join('; ').slice(0, 200)}`;
+      const pushed = this.deps.commitAndPush(message, [this.deps.registryAbsPath]);
+      if (pushed) {
+        this.health = {
+          healthy: true,
+          consecutiveFailures: 0,
+          lastPushAt: new Date(this.now()).toISOString(),
+          lastAttemptAt: this.health.lastAttemptAt,
+        };
+        this.deps.onSyncHealth?.(this.health);
+        this.log(`pushed: ${message}`);
+        return true;
+      }
+      // commitAndPush returns false either when nothing changed (benign) OR on
+      // a push failure. We can't distinguish here, so a "nothing to push" is
+      // treated as success (no failure increment) only if a prior push exists.
+      // To stay conservative we treat false as a non-failure unless we can see
+      // the working tree is dirty — handled by the caller's periodic sync.
+      this.log(`commitAndPush returned false (no-op or push declined): ${message}`);
+      return false;
+    } catch (err) {
+      const lastError = err instanceof Error ? err.message : String(err);
+      this.health = {
+        healthy: this.health.consecutiveFailures + 1 < this.maxFailures,
+        consecutiveFailures: this.health.consecutiveFailures + 1,
+        lastError,
+        lastPushAt: this.health.lastPushAt,
+        lastAttemptAt: this.health.lastAttemptAt,
+      };
+      this.deps.onSyncHealth?.(this.health);
+      this.log(`push failed (${this.health.consecutiveFailures}/${this.maxFailures}): ${lastError}`);
+      // Re-queue the reasons so the next mark/flush retries them.
+      this.pendingReasons.unshift(...reasons);
+      return false;
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  getHealth(): SyncHealthState {
+    return { ...this.health };
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/core/liveTailRedaction.ts
+++ b/src/core/liveTailRedaction.ts
@@ -1,0 +1,72 @@
+/**
+ * liveTailRedaction — versioned secret-redaction for the live tail (spec §8 G3c).
+ *
+ * The live tail carries the most sensitive data in the system (user messages,
+ * tool outputs, incidentally-present secrets). Before any tail content leaves
+ * this machine it is scrubbed of credential-shaped material. The category set
+ * is a NAMED, VERSIONED enum (not an ad-hoc inline regex) so it can be extended
+ * as new token/credential shapes appear — combined with carry-by-reference for
+ * large tool output (§8 G3b), the tail minimizes raw sensitive bytes
+ * structurally rather than relying on pattern-matching alone.
+ *
+ * Bump REDACTION_CATEGORY_VERSION when the category set changes, so a receiver
+ * can record which version scrubbed a flush.
+ */
+
+export const REDACTION_CATEGORY_VERSION = 1;
+
+export enum RedactionCategory {
+  BearerToken = 'bearer-token',
+  ApiKey = 'api-key',
+  PrivateKeyBlock = 'private-key-block',
+  AwsAccessKey = 'aws-access-key',
+  SecretAssignment = 'secret-assignment',
+  JwtLike = 'jwt-like',
+}
+
+interface CategoryRule {
+  category: RedactionCategory;
+  pattern: RegExp;
+}
+
+// Conservative, high-precision patterns — false positives (over-redaction) are
+// cheaper than leaking a secret over the wire. Each is global + case-insensitive
+// where appropriate.
+const RULES: CategoryRule[] = [
+  { category: RedactionCategory.PrivateKeyBlock, pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g },
+  { category: RedactionCategory.BearerToken, pattern: /\bBearer\s+[A-Za-z0-9._\-]{12,}/gi },
+  { category: RedactionCategory.AwsAccessKey, pattern: /\bAKIA[0-9A-Z]{16}\b/g },
+  { category: RedactionCategory.JwtLike, pattern: /\beyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\b/g },
+  // key/secret/token/password = "value" or : value
+  { category: RedactionCategory.SecretAssignment, pattern: /\b(?:api[_-]?key|secret|token|password|passwd|client[_-]?secret)\b\s*[:=]\s*["']?[A-Za-z0-9._\-]{8,}["']?/gi },
+  // Generic long opaque api-key-ish tokens (sk-, ghp_, xoxb-, etc.)
+  { category: RedactionCategory.ApiKey, pattern: /\b(?:sk|pk|rk|ghp|gho|ghs|xox[bpoa])[_-][A-Za-z0-9]{16,}\b/g },
+];
+
+const PLACEHOLDER = (c: RedactionCategory) => `[redacted:${c}]`;
+
+export interface RedactionResult {
+  text: string;
+  redactedCount: number;
+  categories: RedactionCategory[];
+  version: number;
+}
+
+/**
+ * Redact credential-shaped material from a string. Returns the scrubbed text,
+ * how many redactions occurred, and which categories fired (for the flush's
+ * redaction metadata).
+ */
+export function redactForLiveTail(input: string): RedactionResult {
+  let text = input;
+  let redactedCount = 0;
+  const categories = new Set<RedactionCategory>();
+  for (const { category, pattern } of RULES) {
+    text = text.replace(pattern, () => {
+      redactedCount++;
+      categories.add(category);
+      return PLACEHOLDER(category);
+    });
+  }
+  return { text, redactedCount, categories: [...categories], version: REDACTION_CATEGORY_VERSION };
+}

--- a/src/core/registryReplayGuard.ts
+++ b/src/core/registryReplayGuard.ts
@@ -1,0 +1,119 @@
+/**
+ * registryReplayGuard — G2 replay/freshness + unknown-key constraint (spec §8 G2).
+ *
+ * Validates an incoming (pulled) registry entry before it is applied locally.
+ * Signed-commit verification (v3) already rejects unsigned/revoked commits;
+ * this guard adds the content-level checks a signature alone cannot give:
+ *
+ *  1. Replay/freshness — a pulled entry whose per-author `syncSequence` is not
+ *     strictly greater than the last applied for its author is discarded.
+ *  2. Epoch floor — a pulled entry whose `authoredUnderEpoch` is below the
+ *     current committed epoch is discarded. This catches the case a per-author
+ *     sequence cannot: a machine that wiped/restored local state (sequence
+ *     resets to 0) or re-keyed cannot smuggle in an authority-bearing write,
+ *     because its stale leaseEpoch is rejected regardless of a locally-monotonic
+ *     sequence.
+ *  3. Unknown-key first commit — the FIRST commit from a previously-unseen
+ *     machineId is accepted ONLY if it is role:standby + rejoined:true (or a
+ *     pairing-join record). Any unknown-key first commit asserting an awake
+ *     role or a lease claim is rejected — a rejoining machine must pull-and-read
+ *     before writing, never assert its stale prior role.
+ *
+ * Pure logic, unit-tested on both sides of every boundary.
+ */
+
+import type { MachineRegistryEntry } from './types.js';
+
+export interface ReplayGuardInput {
+  machineId: string;
+  /** The incoming (pulled) entry for this machine. */
+  incoming: MachineRegistryEntry;
+  /** The locally-known entry for this machine (undefined = previously unseen). */
+  local?: MachineRegistryEntry;
+  /** The current committed lease epoch (registry.lease?.epoch ?? 0). */
+  currentCommittedEpoch: number;
+  /** Whether this incoming entry carries a valid pairing-join record (allows an awake-less first write). */
+  hasValidJoinRecord?: boolean;
+}
+
+export interface ReplayDecision {
+  accept: boolean;
+  reason: string;
+}
+
+export function evaluateRegistryEntry(input: ReplayGuardInput): ReplayDecision {
+  const { incoming, local, currentCommittedEpoch, hasValidJoinRecord } = input;
+
+  // ── Unknown-key first commit constraint ───────────────────────────
+  if (!local) {
+    if (hasValidJoinRecord) {
+      return { accept: true, reason: 'unknown-key-with-valid-join-record' };
+    }
+    const isStandby = incoming.role === 'standby';
+    const isRejoin = incoming.rejoined === true;
+    if (isStandby && isRejoin) {
+      return { accept: true, reason: 'unknown-key-standby-rejoin' };
+    }
+    return {
+      accept: false,
+      reason: `unknown-key-first-commit must be standby+rejoined (got role=${incoming.role}, rejoined=${incoming.rejoined})`,
+    };
+  }
+
+  // ── Replay/freshness (per-author monotonic sequence) ──────────────
+  const localSeq = local.syncSequence ?? -1;
+  const incomingSeq = incoming.syncSequence ?? -1;
+  if (incomingSeq <= localSeq) {
+    return {
+      accept: false,
+      reason: `stale-sync-sequence (incoming ${incomingSeq} <= local ${localSeq})`,
+    };
+  }
+
+  // ── Epoch floor (catches wiped/re-keyed sequence reset) ───────────
+  const authoredUnder = incoming.authoredUnderEpoch ?? 0;
+  if (authoredUnder < currentCommittedEpoch) {
+    return {
+      accept: false,
+      reason: `below-epoch-floor (authoredUnderEpoch ${authoredUnder} < committed ${currentCommittedEpoch})`,
+    };
+  }
+
+  return { accept: true, reason: 'fresh' };
+}
+
+/**
+ * Reconcile a full incoming registry against the local one, entry by entry.
+ * Returns the entries to apply (accepted) and the rejected ones with reasons
+ * (logged, never applied). The lease object is reconciled separately by the
+ * FencedLease layer (epoch CAS), not here.
+ */
+export function reconcileRegistryEntries(opts: {
+  localEntries: Record<string, MachineRegistryEntry>;
+  incomingEntries: Record<string, MachineRegistryEntry>;
+  currentCommittedEpoch: number;
+  joinRecords?: ReadonlySet<string>;
+}): {
+  accepted: Record<string, MachineRegistryEntry>;
+  rejected: Array<{ machineId: string; reason: string }>;
+} {
+  const accepted: Record<string, MachineRegistryEntry> = {};
+  const rejected: Array<{ machineId: string; reason: string }> = [];
+
+  for (const [machineId, incoming] of Object.entries(opts.incomingEntries)) {
+    const decision = evaluateRegistryEntry({
+      machineId,
+      incoming,
+      local: opts.localEntries[machineId],
+      currentCommittedEpoch: opts.currentCommittedEpoch,
+      hasValidJoinRecord: opts.joinRecords?.has(machineId) ?? false,
+    });
+    if (decision.accept) {
+      accepted[machineId] = incoming;
+    } else {
+      rejected.push({ machineId, reason: decision.reason });
+    }
+  }
+
+  return { accepted, rejected };
+}

--- a/src/core/seamlessnessConfig.ts
+++ b/src/core/seamlessnessConfig.ts
@@ -1,0 +1,170 @@
+/**
+ * Cross-Machine Seamlessness — config resolution + invariant validation.
+ *
+ * Spec: docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md §9 (Tunability).
+ *
+ * Resolves the optional `multiMachine` seamlessness knobs to concrete values
+ * with sane 2-machine-personal-use defaults, auto-derives the standby pull
+ * cadence, and enforces the cross-knob invariants. A violating config is
+ * REJECTED with a clear message rather than degrading silently — so a user
+ * widening `ingressHeartbeatMs` (which widens `leaseTtlMs`) cannot quietly
+ * invalidate the RPO bound the spec promises (§3).
+ */
+
+import type { MultiMachineConfig } from './types.js';
+
+/**
+ * The mesh protocol version this build speaks. A machine below this version
+ * is ineligible for the awake lease during a seamless handoff (spec §11
+ * partial-migration safety). Bump only on a breaking coordination change.
+ */
+export const SEAMLESSNESS_PROTOCOL_VERSION = 1;
+
+/** Fully-resolved seamlessness knobs (every field concrete). */
+export interface ResolvedSeamlessnessConfig {
+  ingressHeartbeatMs: number;
+  registrySyncDebounceMs: number;
+  standbyPullIntervalMs: number;
+  failoverThresholdMs: number;
+  leaseTtlMs: number;
+  liveTailTransport: 'tunnel' | 'git';
+  liveTailMaxStalenessMs: number;
+  liveTailPushRateMs: number;
+  liveTailOutOfOrderTimeoutMs: number;
+  liveTailMaxBytesPerTopic: number;
+  handoffAckTimeoutMs: number;
+  minHandoffIntervalMs: number;
+  splitBrainEscalationCooldownMs: number;
+  handoffBar: 'near-instant' | 'relaxed';
+  maxProcessingMs: number;
+  protocolVersion: number;
+}
+
+export class SeamlessnessConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SeamlessnessConfigError';
+  }
+}
+
+/**
+ * Resolve the failover threshold (ms) from the existing config field.
+ * `failoverTimeoutMinutes` is the canonical knob; default 15 min.
+ * Nullish-coalescing (not ||) so an explicit 0 isn't clobbered — but 0 is
+ * itself invalid and caught by validation.
+ */
+export function resolveFailoverThresholdMs(mm?: MultiMachineConfig): number {
+  const minutes = mm?.failoverTimeoutMinutes ?? 15;
+  return minutes * 60_000;
+}
+
+/**
+ * Resolve all seamlessness knobs to concrete values. Auto-derives
+ * `standbyPullIntervalMs` (failoverThresholdMs/4) and the tail/lease-linked
+ * defaults. Does NOT validate — call validateSeamlessnessInvariants() after.
+ */
+export function resolveSeamlessnessConfig(mm?: MultiMachineConfig): ResolvedSeamlessnessConfig {
+  const failoverThresholdMs = resolveFailoverThresholdMs(mm);
+  const ingressHeartbeatMs = mm?.ingressHeartbeatMs ?? 30_000;
+  const leaseTtlMs = mm?.leaseTtlMs ?? 2 * ingressHeartbeatMs;
+  const liveTailMaxStalenessMs = mm?.liveTailMaxStalenessMs ?? 5_000;
+
+  return {
+    ingressHeartbeatMs,
+    registrySyncDebounceMs: mm?.registrySyncDebounceMs ?? 10_000,
+    // Auto-derive to satisfy BOTH bounds at once: < failoverThresholdMs/3 AND
+    // < leaseTtlMs. At default ratios failoverThresholdMs (15min) ≫ leaseTtlMs
+    // (60s), so the binding bound is leaseTtlMs — the spec's bare /4 heuristic
+    // would violate the leaseTtl invariant it also mandates. We pick safely
+    // under both: min(failoverThresholdMs/4, leaseTtlMs/2).
+    standbyPullIntervalMs:
+      mm?.standbyPullIntervalMs ??
+      Math.min(Math.floor(failoverThresholdMs / 4), Math.floor(leaseTtlMs / 2)),
+    failoverThresholdMs,
+    leaseTtlMs,
+    liveTailTransport: mm?.liveTailTransport ?? 'tunnel',
+    liveTailMaxStalenessMs,
+    liveTailPushRateMs: mm?.liveTailPushRateMs ?? liveTailMaxStalenessMs,
+    liveTailOutOfOrderTimeoutMs: mm?.liveTailOutOfOrderTimeoutMs ?? leaseTtlMs,
+    liveTailMaxBytesPerTopic: mm?.liveTailMaxBytesPerTopic ?? 256 * 1024,
+    handoffAckTimeoutMs: mm?.handoffAckTimeoutMs ?? 5_000,
+    minHandoffIntervalMs: mm?.minHandoffIntervalMs ?? 60_000,
+    splitBrainEscalationCooldownMs: mm?.splitBrainEscalationCooldownMs ?? 5 * 60_000,
+    handoffBar: mm?.handoffBar ?? 'near-instant',
+    maxProcessingMs: mm?.maxProcessingMs ?? 5 * 60_000,
+    protocolVersion: mm?.protocolVersion ?? SEAMLESSNESS_PROTOCOL_VERSION,
+  };
+}
+
+/**
+ * Validate the cross-knob invariants (spec §9). Returns the list of
+ * violations (empty = valid). Callers that want hard-rejection use
+ * assertSeamlessnessInvariants().
+ *
+ * Invariants:
+ *  1. standbyPullIntervalMs < failoverThresholdMs / 3
+ *     — a standby must pull often enough to notice a dead holder well
+ *       before the failover threshold, or failover races stale data.
+ *  2. standbyPullIntervalMs < leaseTtlMs
+ *     — a standby must refresh its git-committed epoch view at least once
+ *       per lease lifetime, or it decides max(tunnel,git) on a stale git floor.
+ *  3. liveTailPushRateMs ≤ liveTailMaxStalenessMs
+ *     — the holder must push tail flushes at least as often as the RPO bound,
+ *       or the promised RPO is unachievable.
+ *  Plus basic positivity (a 0/negative cadence is never valid).
+ */
+export function validateSeamlessnessInvariants(c: ResolvedSeamlessnessConfig): string[] {
+  const errors: string[] = [];
+
+  const positives: Array<[keyof ResolvedSeamlessnessConfig, number]> = [
+    ['ingressHeartbeatMs', c.ingressHeartbeatMs],
+    ['registrySyncDebounceMs', c.registrySyncDebounceMs],
+    ['standbyPullIntervalMs', c.standbyPullIntervalMs],
+    ['failoverThresholdMs', c.failoverThresholdMs],
+    ['leaseTtlMs', c.leaseTtlMs],
+    ['liveTailMaxStalenessMs', c.liveTailMaxStalenessMs],
+    ['liveTailPushRateMs', c.liveTailPushRateMs],
+    ['handoffAckTimeoutMs', c.handoffAckTimeoutMs],
+  ];
+  for (const [name, value] of positives) {
+    if (!(value > 0)) errors.push(`multiMachine.${String(name)} must be > 0 (got ${value})`);
+  }
+
+  if (c.standbyPullIntervalMs >= c.failoverThresholdMs / 3) {
+    errors.push(
+      `multiMachine.standbyPullIntervalMs (${c.standbyPullIntervalMs}ms) must be < failoverThresholdMs/3 ` +
+      `(${Math.floor(c.failoverThresholdMs / 3)}ms) so a standby notices a dead holder before the failover threshold.`,
+    );
+  }
+  if (c.standbyPullIntervalMs >= c.leaseTtlMs) {
+    errors.push(
+      `multiMachine.standbyPullIntervalMs (${c.standbyPullIntervalMs}ms) must be < leaseTtlMs ` +
+      `(${c.leaseTtlMs}ms) so a standby refreshes its git-committed epoch view at least once per lease lifetime.`,
+    );
+  }
+  if (c.liveTailPushRateMs > c.liveTailMaxStalenessMs) {
+    errors.push(
+      `multiMachine.liveTailPushRateMs (${c.liveTailPushRateMs}ms) must be ≤ liveTailMaxStalenessMs ` +
+      `(${c.liveTailMaxStalenessMs}ms) so the promised RPO bound is achievable.`,
+    );
+  }
+
+  return errors;
+}
+
+/**
+ * Resolve + validate in one step, throwing SeamlessnessConfigError on any
+ * invariant violation. Use at server startup so a bad config is rejected
+ * loudly rather than degrading silently.
+ */
+export function assertSeamlessnessInvariants(mm?: MultiMachineConfig): ResolvedSeamlessnessConfig {
+  const resolved = resolveSeamlessnessConfig(mm);
+  const errors = validateSeamlessnessInvariants(resolved);
+  if (errors.length > 0) {
+    throw new SeamlessnessConfigError(
+      `Invalid multiMachine seamlessness config — refusing to start:\n` +
+      errors.map((e) => `  • ${e}`).join('\n'),
+    );
+  }
+  return resolved;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -529,6 +529,21 @@ export interface OutgoingMessage {
  * Messaging adapter interface.
  * Implement this for each platform (Telegram, Slack, Discord, etc.)
  */
+/**
+ * An adapter's durable "where I left off" marker (spec §Channel Seamlessness
+ * Contract). Telegram = the long-poll update_id offset; Slack = the
+ * per-conversation lastTs cursor. Serializable into synced state.
+ */
+export interface IngressPosition {
+  platform: string;
+  /** Opaque, adapter-specific resumable cursor (e.g. update_id offset, lastTs). */
+  cursor: string | number | null;
+  /** When this position was captured (ISO). */
+  capturedAt: string;
+  /** Optional per-conversation cursors (Slack channelResumeMap). */
+  perConversation?: Record<string, string | number>;
+}
+
 export interface MessagingAdapter {
   /** Platform name (e.g., "telegram", "slack") */
   platform: string;
@@ -542,6 +557,23 @@ export interface MessagingAdapter {
   onMessage(handler: (message: Message) => Promise<void>): void;
   /** Resolve a platform-specific identifier to a user ID */
   resolveUser(channelIdentifier: string): Promise<string | null>;
+
+  // ── Channel Seamlessness Contract (spec §, optional — opt-in per adapter) ──
+  // An adapter is "seamless-ready" only once it implements these AND passes the
+  // §10 contract-conformance suite. Optional so existing adapters compile
+  // unchanged; the seamless handoff path checks for their presence.
+  /** The adapter's durable resumable position, serializable into synced state. */
+  getIngressPosition?(): IngressPosition;
+  /** Stop the inbound loop, drain/discard in-flight deterministically, return the durable position AFTER stop. */
+  stopConsuming?(): Promise<IngressPosition>;
+  /** Resume the inbound loop from exactly the given position. */
+  resumeConsuming?(position: IngressPosition): Promise<void>;
+  /**
+   * A stable provider-level identity for an inbound raw event (Telegram
+   * update_id; Slack event_id/client_msg_id), used by the message-processing
+   * ledger so a redelivered event is recognized and not re-acted-on.
+   */
+  dedupeKey?(rawEvent: unknown): string;
 }
 
 // ── Monitoring ──────────────────────────────────────────────────────

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1476,6 +1476,58 @@ export interface MachineRegistryEntry {
   revokedBy?: string;
   /** Human-readable revocation reason */
   revokeReason?: string;
+  // ── Cross-Machine Seamlessness (spec v1) ──────────────────────────
+  /**
+   * Per-author monotonic sequence. Each authority-bearing registry write
+   * by this machine increments it. A pulled commit whose syncSequence is
+   * not strictly greater than the last applied for its author is discarded
+   * (replay/freshness guard, spec §8 G2).
+   */
+  syncSequence?: number;
+  /**
+   * leaseEpoch this entry was authored under. A pulled commit whose
+   * leaseEpoch is lower than the current committed epoch is discarded —
+   * catches a wiped/re-keyed machine whose per-author sequence reset to 0.
+   */
+  authoredUnderEpoch?: number;
+  /**
+   * Mesh protocol version this machine speaks. A machine below the
+   * fenced-lease protocol version is ineligible for the awake lease
+   * during a seamless handoff (partial-migration safety, spec §11).
+   */
+  protocolVersion?: number;
+  /**
+   * Set true on the FIRST commit from a re-keyed / freshly-joined machine.
+   * Such a first commit is accepted only if role is 'standby' + rejoined
+   * (spec §8 G2 unknown-key-first-commit constraint).
+   */
+  rejoined?: boolean;
+}
+
+/**
+ * Fenced lease — the single coordination primitive for "exactly one holder,
+ * safe under clock skew and partition" (spec §6). awake = holds the lease.
+ */
+export interface LeaseRecord {
+  /** machineId of the current holder */
+  holder: string;
+  /** Fencing token: monotonically increasing integer, the authority clock */
+  epoch: number;
+  /** ISO timestamp of acquisition (display/audit only — never election authority) */
+  acquiredAt: string;
+  /**
+   * Holder-local expiry (acquiredAt + leaseTtlMs). Used for the liveness
+   * heuristic and display; authority is the epoch, not this clock.
+   */
+  expiresAt: string;
+  /** Ed25519 signature over the canonical {holder,epoch,acquiredAt,expiresAt,nonce} */
+  signature: string;
+  /**
+   * Per-holder monotonic nonce. A tunnel lease message replaying a
+   * previously-seen nonce for the same holder is detected and ignored
+   * (spec §6 replay protection).
+   */
+  nonce: number;
 }
 
 export interface MachineRegistry {
@@ -1483,6 +1535,11 @@ export interface MachineRegistry {
   version: number;
   /** Map of machineId -> registry entry */
   machines: Record<string, MachineRegistryEntry>;
+  /**
+   * The current fenced lease (spec §6). Authority-bearing — only the lease
+   * holder may advance it via CAS. Absent on a fresh single-machine mesh.
+   */
+  lease?: LeaseRecord;
 }
 
 export interface MultiMachineConfig {
@@ -1500,6 +1557,46 @@ export interface MultiMachineConfig {
    * - 'independent': Both machines active with separate Telegram groups
    */
   coordinationMode?: CoordinationMode;
+
+  // ── Cross-Machine Seamlessness (spec v1 §9 Tunability) ────────────
+  // All optional with sane defaults; renamed to avoid collision with the
+  // 30-min MachineHeartbeat and 60s Threadline ConnectionManager intervals.
+  /** How often the lease holder refreshes its liveness/lease over the tunnel. Default 30s. */
+  ingressHeartbeatMs?: number;
+  /** Debounce window for committing DURABLE registry changes to git. Default 10s. */
+  registrySyncDebounceMs?: number;
+  /**
+   * Standby git-pull cadence. Default auto = failoverThresholdMs/4, validated
+   * against the < failoverThresholdMs/3 AND < leaseTtlMs invariants on startup.
+   */
+  standbyPullIntervalMs?: number;
+  /** Lease expiry; bounds worst-case transfer overlap. Default 2 × ingressHeartbeatMs. */
+  leaseTtlMs?: number;
+  /** Live-tail transport: 'tunnel' (low-latency) | 'git' (durable-only, cheaper N>3). Default 'tunnel'. */
+  liveTailTransport?: 'tunnel' | 'git';
+  /** RPO: max staleness of the standby's persisted live tail. Default 5s. */
+  liveTailMaxStalenessMs?: number;
+  /** How often the holder pushes a tail flush. Invariant: ≤ liveTailMaxStalenessMs. */
+  liveTailPushRateMs?: number;
+  /** How long the standby holds an out-of-order flush before declaring the gap unfillable. Default = leaseTtlMs. */
+  liveTailOutOfOrderTimeoutMs?: number;
+  /** Memory/bandwidth cap per topic; drop-oldest on overflow. Default 256KB. */
+  liveTailMaxBytesPerTopic?: number;
+  /** Max wait for a verified "caught up" ack before aborting graceful handoff. Default 5s. */
+  handoffAckTimeoutMs?: number;
+  /** Anti-oscillation floor (protects CONTINUATION LLM cost). Default 60s. */
+  minHandoffIntervalMs?: number;
+  /** After this, stop re-escalating an unresolved partition until the user acts. Default 5min. */
+  splitBrainEscalationCooldownMs?: number;
+  /** 'near-instant' (continuous tail buffer) | 'relaxed' (catch-up pull at handoff). Default 'near-instant'. */
+  handoffBar?: 'near-instant' | 'relaxed';
+  /** A message-ledger entry left 'processing' past this is re-runnable by the new holder. Default 5min. */
+  maxProcessingMs?: number;
+  /**
+   * Mesh protocol version override. Normally left unset (the build constant
+   * SEAMLESSNESS_PROTOCOL_VERSION applies); present so migrations/tests can pin it.
+   */
+  protocolVersion?: number;
 }
 
 // ── Agent Autonomy ──────────────────────────────────────────────────

--- a/src/core/wireRegistrySync.ts
+++ b/src/core/wireRegistrySync.ts
@@ -1,0 +1,53 @@
+/**
+ * wireRegistrySync — the named G2 wiring (spec §8 G2).
+ *
+ * The Phase-0 finding was a WIRING gap: MultiMachineCoordinator emits
+ * `roleChange` (and now `leaseEpochChange`) but no subscriber marked the
+ * registry dirty, so the durable push never fired. The spec demands the fix
+ * NAME the wiring rather than restate intent — this factory IS that wiring,
+ * extracted as a testable seam so a wiring-integrity test can assert the
+ * subscription exists and that a simulated role change triggers a push (the
+ * test that would have caught Phase 0).
+ */
+
+export interface CoordinatorEventSource {
+  on(event: string, listener: (...args: any[]) => void): unknown;
+  off(event: string, listener: (...args: any[]) => void): unknown;
+}
+
+export interface RegistryDirtySink {
+  markRegistryDirty(reason: string): void;
+}
+
+export interface RegistrySyncWiring {
+  /** Detach the subscriptions (used on shutdown / in tests). */
+  unwire(): void;
+  /** Event names this wiring subscribes to (asserted by wiring-integrity tests). */
+  readonly wiredEvents: readonly string[];
+}
+
+/**
+ * Subscribe a registry-dirty sink (the RegistrySyncDebouncer) to the
+ * coordinator's authority-changing events. Returns a handle that can detach
+ * the subscriptions and reports which events it wired (so tests can assert the
+ * wiring is real, not dead code).
+ */
+export function wireRegistrySync(
+  coordinator: CoordinatorEventSource,
+  sink: RegistryDirtySink,
+): RegistrySyncWiring {
+  const onRole = (from: unknown, to: unknown) =>
+    sink.markRegistryDirty(`roleChange ${String(from)}->${String(to)}`);
+  const onEpoch = (epoch: unknown) => sink.markRegistryDirty(`leaseEpoch=${String(epoch)}`);
+
+  coordinator.on('roleChange', onRole);
+  coordinator.on('leaseEpochChange', onEpoch);
+
+  return {
+    wiredEvents: ['roleChange', 'leaseEpochChange'],
+    unwire() {
+      coordinator.off('roleChange', onRole);
+      coordinator.off('leaseEpochChange', onEpoch);
+    },
+  };
+}

--- a/src/messaging/FencedOutbox.ts
+++ b/src/messaging/FencedOutbox.ts
@@ -1,0 +1,88 @@
+/**
+ * FencedOutbox — fencing-token-gated outbound reply path (spec §8 G3a).
+ *
+ * "No duplicate replies" is enforced here STRUCTURALLY, not by assuming a single
+ * consumer. A reply is sent only while this machine holds the lease at the epoch
+ * the reply was stamped under; a fenced (stale-epoch) machine's in-flight reply
+ * is SUPPRESSED at the send path. The reply is committed to the message ledger
+ * with a deterministic idempotency key (hash(dedupeKey + replyIndex)) so any
+ * machine re-running the same event reproduces it identically — and the ledger
+ * recognizes an already-committed reply and refuses to re-send.
+ *
+ * On a channel with native outbound dedup the idempotency key makes a re-send a
+ * no-op; on a channel without it (Telegram), the dual-medium reply_committed
+ * marker (propagated by the sync layer) is what prevents a failover re-send.
+ */
+
+import { MessageProcessingLedger, computeReplyIdempotencyKey } from './MessageProcessingLedger.js';
+
+export interface FencedOutboxDeps {
+  ledger: MessageProcessingLedger;
+  /** The current effective fencing epoch. */
+  currentEpoch: () => number;
+  /** Whether this machine structurally holds the lease right now. */
+  holdsLease: () => boolean;
+  logger?: (msg: string) => void;
+}
+
+export interface SendOutcome {
+  sent: boolean;
+  suppressed: boolean;
+  reason: 'sent' | 'already-replied' | 'fenced-no-lease' | 'fenced-stale-epoch' | 'send-failed';
+  idempotencyKey: string;
+}
+
+export class FencedOutbox {
+  private readonly d: FencedOutboxDeps;
+
+  constructor(deps: FencedOutboxDeps) {
+    this.d = deps;
+  }
+
+  private log(m: string): void {
+    this.d.logger?.(`[outbox] ${m}`);
+  }
+
+  /**
+   * Send a reply for `dedupeKey`, stamped under `stampedEpoch` (the epoch the
+   * turn began processing under). Returns the outcome. The actual platform send
+   * is `sendFn`; it is invoked ONLY after the fencing checks pass.
+   */
+  async send(
+    dedupeKey: string,
+    replyIndex: number,
+    stampedEpoch: number,
+    sendFn: () => Promise<void>,
+  ): Promise<SendOutcome> {
+    const idempotencyKey = computeReplyIdempotencyKey(dedupeKey, replyIndex);
+
+    // Idempotency: if a reply was already committed (locally or via a remote
+    // dual-medium marker), do not send again.
+    if (this.d.ledger.isActedOn(dedupeKey)) {
+      this.log(`already replied to ${dedupeKey} — suppressing`);
+      return { sent: false, suppressed: true, reason: 'already-replied', idempotencyKey };
+    }
+
+    // Fencing: only the current lease holder, at the stamped epoch, may send.
+    if (!this.d.holdsLease()) {
+      this.log(`fenced (no lease) — suppressing reply to ${dedupeKey}`);
+      return { sent: false, suppressed: true, reason: 'fenced-no-lease', idempotencyKey };
+    }
+    const epoch = this.d.currentEpoch();
+    if (epoch !== stampedEpoch) {
+      this.log(`fenced (stale epoch ${stampedEpoch} != current ${epoch}) — suppressing reply to ${dedupeKey}`);
+      return { sent: false, suppressed: true, reason: 'fenced-stale-epoch', idempotencyKey };
+    }
+
+    try {
+      await sendFn();
+    } catch (err) {
+      this.log(`send failed for ${dedupeKey}: ${err instanceof Error ? err.message : String(err)}`);
+      return { sent: false, suppressed: false, reason: 'send-failed', idempotencyKey };
+    }
+
+    // Commit the reply marker (durable, synchronous) BEFORE advancing the cursor.
+    this.d.ledger.commitReply(dedupeKey, idempotencyKey, stampedEpoch);
+    return { sent: true, suppressed: false, reason: 'sent', idempotencyKey };
+  }
+}

--- a/src/messaging/MessageProcessingLedger.ts
+++ b/src/messaging/MessageProcessingLedger.ts
@@ -1,0 +1,245 @@
+/**
+ * MessageProcessingLedger — the no-loss / no-duplicate-reply guarantee (spec §8 G3a).
+ *
+ * A durable, SQLite-backed record of each inbound message's lifecycle:
+ *   received → processing → reply_committed → cursor_advanced
+ * keyed by the adapter's `dedupeKey(rawEvent)` (Telegram update_id, Slack
+ * event_id/client_msg_id). Rules:
+ *
+ *  - An event whose dedupeKey is already reply_committed/cursor_advanced is
+ *    NEVER acted on again — a redelivery (Telegram retry, Slack reconnect, or a
+ *    transfer-window overlap during a handoff) is recognized and dropped. This
+ *    is what makes "no duplicate replies" structural, not merely "only one
+ *    consumer".
+ *  - The ingress cursor advances ONLY on durable completion (cursor_advanced),
+ *    so a crash before completion replays the event (at-least-once) and the
+ *    ledger makes the replay a no-op-or-resume (exactly-once effect).
+ *  - Each transition is flushed to local SQLite synchronously on commit (WAL +
+ *    NORMAL), so a same-machine crash-restart never double-acts.
+ *  - A stuck `processing` entry past maxProcessingMs (old holder fenced
+ *    mid-turn) is re-runnable by the current holder from its stored input.
+ *
+ * Substrate is SQLite (the proven PendingRelayStore/CommitmentTracker path) —
+ * NOT a new ad-hoc JSON file and NOT a git-synced blob. Schema self-initializes
+ * on first access (no PostUpdateMigrator step needed). Per-agent-id isolation.
+ */
+
+import Database from 'better-sqlite3';
+import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type LedgerState = 'received' | 'processing' | 'reply_committed' | 'cursor_advanced';
+
+export interface LedgerEntry {
+  dedupeKey: string;
+  platform: string;
+  topic: string | null;
+  state: LedgerState;
+  receivedAt: string;
+  processingStartedAt: string | null;
+  replyCommittedAt: string | null;
+  cursorAdvancedAt: string | null;
+  replyIdempotencyKey: string | null;
+  replyEpoch: number | null;
+  inputSnapshot: string | null;
+  attempts: number;
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS message_ledger (
+  dedupe_key TEXT PRIMARY KEY,
+  platform TEXT NOT NULL,
+  topic TEXT,
+  state TEXT NOT NULL,
+  received_at TEXT NOT NULL,
+  processing_started_at TEXT,
+  reply_committed_at TEXT,
+  cursor_advanced_at TEXT,
+  reply_idempotency_key TEXT,
+  reply_epoch INTEGER,
+  input_snapshot TEXT,
+  attempts INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_message_ledger_state ON message_ledger(state);
+`;
+
+export function resolveMessageLedgerPath(stateDir: string, agentId: string): string {
+  const safe = agentId.replace(/[^A-Za-z0-9._-]/g, '_') || 'default';
+  return path.join(stateDir, 'state', `message-ledger.${safe}.sqlite`);
+}
+
+/**
+ * Deterministic outbound idempotency key — any machine re-running the same
+ * inbound event reproduces it identically (spec §8 G3a). Used so a failover
+ * re-send is recognized as the same reply.
+ */
+export function computeReplyIdempotencyKey(dedupeKey: string, replyIndex: number): string {
+  return crypto.createHash('sha256').update(`${dedupeKey}::${replyIndex}`).digest('hex').slice(0, 32);
+}
+
+export class MessageProcessingLedger {
+  private readonly db: BetterSqliteDatabase;
+  readonly path: string;
+
+  private constructor(db: BetterSqliteDatabase, dbPath: string) {
+    this.db = db;
+    this.path = dbPath;
+  }
+
+  static open(agentId: string, stateDir: string): MessageProcessingLedger {
+    const dbPath = resolveMessageLedgerPath(stateDir, agentId);
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    const db = new Database(dbPath);
+    try { fs.chmodSync(dbPath, 0o600); } catch { /* best-effort */ }
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = NORMAL');
+    db.pragma('busy_timeout = 5000');
+    db.exec(SCHEMA);
+    return new MessageProcessingLedger(db, dbPath);
+  }
+
+  /** Open an in-memory ledger (tests). */
+  static openMemory(): MessageProcessingLedger {
+    const db = new Database(':memory:');
+    db.pragma('busy_timeout = 5000');
+    db.exec(SCHEMA);
+    return new MessageProcessingLedger(db, ':memory:');
+  }
+
+  /**
+   * Record an inbound event. Idempotent on dedupeKey (INSERT OR IGNORE).
+   * Returns whether this is the first time we've seen it + the current state.
+   * A caller seeing firstSeen:false with an acted-on state must DROP the event.
+   */
+  record(dedupeKey: string, opts: { platform: string; topic?: string | null; input?: string }): {
+    firstSeen: boolean;
+    state: LedgerState;
+  } {
+    const now = new Date().toISOString();
+    const info = this.db
+      .prepare(
+        `INSERT OR IGNORE INTO message_ledger (dedupe_key, platform, topic, state, received_at, input_snapshot)
+         VALUES (?, ?, ?, 'received', ?, ?)`,
+      )
+      .run(dedupeKey, opts.platform, opts.topic ?? null, now, opts.input ?? null);
+    const row = this.get(dedupeKey)!;
+    return { firstSeen: info.changes === 1, state: row.state };
+  }
+
+  /** Has this event already been acted on (reply committed or cursor advanced)? */
+  isActedOn(dedupeKey: string): boolean {
+    const row = this.get(dedupeKey);
+    return !!row && (row.state === 'reply_committed' || row.state === 'cursor_advanced');
+  }
+
+  /**
+   * Claim an event for processing under the given fencing epoch. Returns false
+   * if it has already been acted on (drop). A stuck 'processing' entry can be
+   * re-claimed (the old holder was fenced); attempts is incremented.
+   */
+  beginProcessing(dedupeKey: string, epoch: number): boolean {
+    const row = this.get(dedupeKey);
+    if (!row) return false;
+    if (row.state === 'reply_committed' || row.state === 'cursor_advanced') return false;
+    this.db
+      .prepare(
+        `UPDATE message_ledger
+         SET state = 'processing', processing_started_at = ?, reply_epoch = ?, attempts = attempts + 1
+         WHERE dedupe_key = ?`,
+      )
+      .run(new Date().toISOString(), epoch, dedupeKey);
+    return true;
+  }
+
+  /**
+   * Commit that a reply was sent. Records the deterministic idempotency key and
+   * the fencing epoch it was committed under. Idempotent — committing twice is
+   * a no-op (the marker already exists).
+   */
+  commitReply(dedupeKey: string, replyIdempotencyKey: string, epoch: number): void {
+    this.db
+      .prepare(
+        `UPDATE message_ledger
+         SET state = 'reply_committed', reply_committed_at = ?, reply_idempotency_key = ?, reply_epoch = ?
+         WHERE dedupe_key = ? AND state NOT IN ('reply_committed','cursor_advanced')`,
+      )
+      .run(new Date().toISOString(), replyIdempotencyKey, epoch, dedupeKey);
+  }
+
+  /** Advance the ingress cursor — only call after durable reply commit. */
+  advanceCursor(dedupeKey: string): void {
+    this.db
+      .prepare(
+        `UPDATE message_ledger SET state = 'cursor_advanced', cursor_advanced_at = ?
+         WHERE dedupe_key = ? AND state = 'reply_committed'`,
+      )
+      .run(new Date().toISOString(), dedupeKey);
+  }
+
+  /**
+   * Apply a reply_committed marker propagated from another machine (dual-medium
+   * marker, spec §8 G3a): if we have the entry and it's not yet acted on, mark
+   * it committed so a failover does not re-send. Creates the entry if unknown
+   * (the other machine saw it first).
+   */
+  applyRemoteReplyMarker(dedupeKey: string, opts: { platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }): void {
+    const now = new Date().toISOString();
+    this.db
+      .prepare(
+        `INSERT INTO message_ledger (dedupe_key, platform, topic, state, received_at, reply_committed_at, reply_idempotency_key, reply_epoch)
+         VALUES (?, ?, ?, 'reply_committed', ?, ?, ?, ?)
+         ON CONFLICT(dedupe_key) DO UPDATE SET
+           state = CASE WHEN message_ledger.state IN ('reply_committed','cursor_advanced') THEN message_ledger.state ELSE 'reply_committed' END,
+           reply_committed_at = COALESCE(message_ledger.reply_committed_at, excluded.reply_committed_at),
+           reply_idempotency_key = COALESCE(message_ledger.reply_idempotency_key, excluded.reply_idempotency_key),
+           reply_epoch = COALESCE(message_ledger.reply_epoch, excluded.reply_epoch)`,
+      )
+      .run(dedupeKey, opts.platform, opts.topic ?? null, now, now, opts.replyIdempotencyKey, opts.epoch);
+  }
+
+  /**
+   * Entries stuck in 'processing' past maxProcessingMs — eligible for re-run by
+   * the current lease holder from their stored input (spec §8 G3a). The old
+   * holder's abandoned output is discarded (the new holder re-executes).
+   */
+  reclaimStuck(maxProcessingMs: number, nowMs: number = Date.now()): LedgerEntry[] {
+    const rows = this.db
+      .prepare(`SELECT * FROM message_ledger WHERE state = 'processing'`)
+      .all() as any[];
+    return rows
+      .map(rowToEntry)
+      .filter((e) => {
+        if (!e.processingStartedAt) return false;
+        const startedMs = Date.parse(e.processingStartedAt);
+        return !Number.isNaN(startedMs) && nowMs - startedMs > maxProcessingMs;
+      });
+  }
+
+  get(dedupeKey: string): LedgerEntry | null {
+    const row = this.db.prepare(`SELECT * FROM message_ledger WHERE dedupe_key = ?`).get(dedupeKey) as any;
+    return row ? rowToEntry(row) : null;
+  }
+
+  close(): void {
+    try { this.db.close(); } catch { /* best-effort */ }
+  }
+}
+
+function rowToEntry(row: any): LedgerEntry {
+  return {
+    dedupeKey: row.dedupe_key,
+    platform: row.platform,
+    topic: row.topic ?? null,
+    state: row.state,
+    receivedAt: row.received_at,
+    processingStartedAt: row.processing_started_at ?? null,
+    replyCommittedAt: row.reply_committed_at ?? null,
+    cursorAdvancedAt: row.cursor_advanced_at ?? null,
+    replyIdempotencyKey: row.reply_idempotency_key ?? null,
+    replyEpoch: row.reply_epoch ?? null,
+    inputSnapshot: row.input_snapshot ?? null,
+    attempts: row.attempts ?? 0,
+  };
+}

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -11,7 +11,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import type { MessagingAdapter, Message, OutgoingMessage, UserChannel, IntelligenceProvider } from '../core/types.js';
+import type { MessagingAdapter, Message, OutgoingMessage, UserChannel, IntelligenceProvider, IngressPosition } from '../core/types.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import { NotificationBatcher, NotificationTier } from './NotificationBatcher.js';
 import type { ContentValidationConfig } from './TopicContentValidator.js';
@@ -825,6 +825,59 @@ export class TelegramAdapter implements MessagingAdapter {
         console.error('[telegram] Failed to flush batcher on stop:', err);
       }
       this.batcher.stop();
+    }
+  }
+
+  // ── Channel Seamlessness Contract (spec §) — Telegram reference impl ──
+
+  /**
+   * Stable provider-level identity for an inbound update — the Telegram
+   * update_id. Used by the message-processing ledger so a redelivered update
+   * (retry / reconnect / transfer-window overlap) is recognized and not
+   * re-acted-on.
+   */
+  dedupeKey(rawEvent: unknown): string {
+    const u = rawEvent as { update_id?: number } | undefined;
+    if (u && typeof u.update_id === 'number') return `telegram:${u.update_id}`;
+    // Fallback for already-normalized Message objects carrying the id in metadata.
+    const m = rawEvent as { metadata?: { update_id?: number }; id?: string } | undefined;
+    if (m?.metadata?.update_id != null) return `telegram:${m.metadata.update_id}`;
+    return `telegram:${m?.id ?? 'unknown'}`;
+  }
+
+  /** The durable resumable position — the long-poll update_id offset. */
+  getIngressPosition(): IngressPosition {
+    return { platform: 'telegram', cursor: this.lastUpdateId, capturedAt: new Date().toISOString() };
+  }
+
+  /**
+   * Stop the inbound loop deterministically and return the durable position
+   * AFTER the stop (the persisted offset), so a handoff resumes from exactly
+   * where this machine left off — never replaying or skipping.
+   */
+  async stopConsuming(): Promise<IngressPosition> {
+    this.polling = false;
+    if (this.pollTimeout) {
+      clearTimeout(this.pollTimeout);
+      this.pollTimeout = null;
+    }
+    this.saveOffset(); // durable — the position is the persisted offset, not the in-memory cursor
+    return this.getIngressPosition();
+  }
+
+  /** Resume the inbound loop from exactly the given position. */
+  async resumeConsuming(position: IngressPosition): Promise<void> {
+    if (position.platform !== 'telegram') {
+      throw new Error(`resumeConsuming: wrong platform ${position.platform} for telegram adapter`);
+    }
+    const cursor = typeof position.cursor === 'number' ? position.cursor : Number(position.cursor);
+    if (Number.isFinite(cursor) && cursor >= 0) {
+      // Resume from exactly this offset (never lower than what we know, to avoid replay).
+      this.lastUpdateId = Math.max(this.lastUpdateId, cursor);
+      this.saveOffset();
+    }
+    if (!this.polling) {
+      await this.start();
     }
   }
 

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -417,6 +417,13 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - Stop every job: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/autonomous/stop-all\`
 - Proactive: user asks "what autonomous jobs are running?" → GET /autonomous/sessions. "stop everything" → POST /autonomous/stop-all. "stop the job on topic X" → POST /autonomous/sessions/X/stop.
 
+**Cross-Machine Seamlessness (one agent, many machines)** — When I run on more than one machine, I am ONE agent that follows the user across them, not clones. Exactly one machine is "awake" at a time, decided by a **fenced lease** (a clock-proof, numbered "who's in charge" badge); the other is standby and takes over only when the awake machine genuinely goes silent.
+- **I never double-reply** — each inbound message is handled exactly once (durable per-message ledger keyed on the platform event id), so a redelivery or mid-handoff overlap can't make me answer twice.
+- **A handoff feels like a compaction pause, not amnesia** — the new machine resumes via CONTINUATION (picks up the thread, no re-greeting). Planned handoff = current context; hard failover = as-of-last-sync, and if my context is partial I say so honestly ("picking this back up from the other machine").
+- Read mesh/sync state, never guess it: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/health\` → \`multiMachine.syncStatus\` (\`leaseHolder, leaseEpoch, holdsLease, splitBrainState, awakeMachineCount\`); \`instar doctor\` shows the same.
+- A genuinely **unresolvable split-brain** surfaces as ONE Attention-queue item with a Y/N decision ("demote machine X?"), deduped per partition episode — I present it to the user, I don't silently pick.
+- Dials under \`.instar/config.json\` → \`multiMachine\` (ingressHeartbeatMs, leaseTtlMs, liveTailMaxStalenessMs, handoffAckTimeoutMs, …); a nonsensical combo is rejected at startup, not run silently.
+
 **Relationships** — Track people I interact with.
 - List: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/relationships\`
 

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -549,6 +549,7 @@ export class AgentServer {
       threadlineObservability: options.threadlineObservability ?? null,
       taskFlowRegistry: options.taskFlowRegistry ?? null,
       threadlineFlowBridge: options.threadlineFlowBridge ?? null,
+      coordinator: options.coordinator ?? null,
       startTime: this.startTime,
     };
     this.routeContext = routeCtx;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -677,6 +677,8 @@ export interface RouteContext {
    *  cross-agent-callback when a matching threadline message arrives. Null
    *  when TaskFlow is not enabled. */
   threadlineFlowBridge: import('../tasks/ThreadlineFlowBridge.js').ThreadlineFlowBridge | null;
+  /** Multi-machine coordinator (cross-machine seamlessness) — null on single-machine installs. */
+  coordinator: import('../core/MultiMachineCoordinator.js').MultiMachineCoordinator | null;
   startTime: Date;
 }
 
@@ -1208,6 +1210,13 @@ export function createRoutes(ctx: RouteContext): Router {
       base.sessions = { current: sessionCount, max: maxSessions };
       base.schedulerRunning = ctx.scheduler !== null;
       base.consecutiveJobFailures = totalFailures;
+
+      // Cross-Machine Seamlessness (spec §11) — the Phase-1 "feature is alive"
+      // surface. Always present with valid fields (never null/503), even on a
+      // single-machine install (where the lease is trivially held).
+      base.multiMachine = ctx.coordinator
+        ? { enabled: true, syncStatus: ctx.coordinator.getSyncStatus() }
+        : { enabled: ctx.config.multiMachine?.enabled ?? false, syncStatus: null };
       base.project = ctx.config.projectName;
       base.node = process.version;
       base.memory = {

--- a/tests/unit/FencedLease.test.ts
+++ b/tests/unit/FencedLease.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tier-1 unit tests for FencedLease — the cross-machine coordination primitive.
+ *
+ * Covers both sides of every decision boundary the spec (§6) calls out:
+ * CAS epoch advance, fencing (stale-epoch rejection), max(tunnel,git) never
+ * regressing below the git floor, epoch-gap safety, clock-skew immunity,
+ * tunnel replay/floor guards, expiry, presumed-dead acquisition, and the
+ * livelock backoff. Uses REAL Ed25519 keys (not a stub signer) so the
+ * signature path is exercised end-to-end.
+ */
+
+import { describe, it, expect } from 'vitest';
+import crypto from 'node:crypto';
+import { FencedLease, type LeaseCrypto } from '../../src/core/FencedLease.js';
+import type { LeaseRecord } from '../../src/core/types.js';
+
+function genKey() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  return { publicKey, privateKey };
+}
+
+/** A two-machine keyring; verify() resolves the holder's registered pubkey. */
+function makeCrypto(selfMachineId: string, keys: Record<string, { publicKey: string; privateKey: string }>): LeaseCrypto {
+  return {
+    selfMachineId,
+    sign(canonical: string): string {
+      return crypto.sign(null, Buffer.from(canonical), keys[selfMachineId].privateKey).toString('base64');
+    },
+    verify(canonical: string, signature: string, holderMachineId: string): boolean {
+      const pub = keys[holderMachineId]?.publicKey;
+      if (!pub) return false; // unknown holder → never verifies
+      try {
+        return crypto.verify(null, Buffer.from(canonical), pub, Buffer.from(signature, 'base64'));
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+const TTL = 60_000;
+const FAILOVER = 15 * 60_000;
+
+describe('FencedLease', () => {
+  const keys = { A: genKey(), B: genKey() };
+  const leaseA = () => new FencedLease(makeCrypto('A', keys), { leaseTtlMs: TTL, failoverThresholdMs: FAILOVER });
+  const leaseB = () => new FencedLease(makeCrypto('B', keys), { leaseTtlMs: TTL, failoverThresholdMs: FAILOVER });
+
+  describe('CAS acquisition advances the epoch by exactly one', () => {
+    it('first acquisition from empty starts at epoch 1', () => {
+      const a = leaseA();
+      const acq = a.buildAcquisition(undefined, 1_000, 1);
+      expect(acq.epoch).toBe(1);
+      expect(acq.holder).toBe('A');
+      expect(a.verifyLease(acq)).toBe(true);
+    });
+
+    it('acquisition over an existing lease advances epoch+1', () => {
+      const a = leaseA();
+      const prior: LeaseRecord = leaseB().buildAcquisition(undefined, 0, 1); // epoch 1, holder B
+      const acq = a.buildAcquisition(prior, 1_000, 1);
+      expect(acq.epoch).toBe(2);
+      expect(acq.holder).toBe('A');
+    });
+
+    it('exactly one of two contenders wins an epoch (same target epoch, CAS picks one)', () => {
+      const a = leaseA();
+      const b = leaseB();
+      const prior: LeaseRecord = a.buildAcquisition(undefined, 0, 1); // epoch 1 by A
+      // Both contend to advance to epoch 2; both build epoch-2 candidates.
+      const candA = a.buildAcquisition(prior, 1_000, 2);
+      const candB = b.buildAcquisition(prior, 1_000, 1);
+      expect(candA.epoch).toBe(2);
+      expect(candB.epoch).toBe(2);
+      // The transport CAS lands exactly one; both are validly signed by their holder.
+      expect(a.verifyLease(candA)).toBe(true);
+      expect(b.verifyLease(candB)).toBe(true);
+      // Cross-verification: A's lease verifies under B's verifier too (same keyring).
+      expect(b.verifyLease(candA)).toBe(true);
+    });
+  });
+
+  describe('fencing — stale epoch is rejected', () => {
+    it('holdsValidLease true only when held at the current effective epoch', () => {
+      const a = leaseA();
+      const lease = a.buildAcquisition(undefined, 1_000, 1); // epoch 1
+      expect(a.holdsValidLease(lease, 1, 2_000)).toBe(true);
+      // Effective epoch moved to 2 (someone advanced past us) → fenced out.
+      expect(a.holdsValidLease(lease, 2, 2_000)).toBe(false);
+    });
+
+    it('a non-holder never holds the lease', () => {
+      const a = leaseA();
+      const b = leaseB();
+      const leaseByB = b.buildAcquisition(undefined, 1_000, 1);
+      expect(a.holdsValidLease(leaseByB, 1, 2_000)).toBe(false); // A is not holder
+      expect(b.holdsValidLease(leaseByB, 1, 2_000)).toBe(true);
+    });
+
+    it('isStampCurrent rejects a stale-epoch stamped action', () => {
+      expect(FencedLease.isStampCurrent(1, 1)).toBe(true);
+      expect(FencedLease.isStampCurrent(1, 2)).toBe(false);
+    });
+  });
+
+  describe('effectiveEpoch = max(tunnel, git), never below git floor', () => {
+    it('takes the higher of tunnel/git', () => {
+      expect(FencedLease.effectiveEpoch(5, 3)).toBe(5);
+      expect(FencedLease.effectiveEpoch(2, 7)).toBe(7); // a lagging tunnel cannot lower below git
+    });
+  });
+
+  describe('tunnel lease acceptance (replay + floor + signature guards)', () => {
+    it('accepts a valid, above-floor, fresh-nonce lease', () => {
+      const a = leaseA();
+      const msg = leaseB().buildAcquisition(undefined, 1_000, 5); // holder B, epoch 1, nonce 5
+      const d = a.acceptTunnelLease(msg, 0, {});
+      expect(d.accept).toBe(true);
+    });
+
+    it('rejects a below-git-floor lease', () => {
+      const a = leaseA();
+      const msg = leaseB().buildAcquisition(undefined, 1_000, 5); // epoch 1
+      const d = a.acceptTunnelLease(msg, 3, {}); // git floor is already 3
+      expect(d.accept).toBe(false);
+      expect(d.reason).toContain('below-git-floor');
+    });
+
+    it('rejects a replayed/stale nonce for the same holder', () => {
+      const a = leaseA();
+      const msg = leaseB().buildAcquisition(undefined, 1_000, 5);
+      const d = a.acceptTunnelLease(msg, 0, { B: 5 }); // already saw nonce 5 from B
+      expect(d.accept).toBe(false);
+      expect(d.reason).toContain('replayed-or-stale-nonce');
+    });
+
+    it('rejects a lease with an invalid/forged signature', () => {
+      const a = leaseA();
+      const msg = leaseB().buildAcquisition(undefined, 1_000, 5);
+      const forged: LeaseRecord = { ...msg, signature: Buffer.from('garbage').toString('base64') };
+      const d = a.acceptTunnelLease(forged, 0, {});
+      expect(d.accept).toBe(false);
+      expect(d.reason).toContain('signature-invalid');
+    });
+
+    it('rejects a lease naming an unknown holder', () => {
+      const a = leaseA();
+      // Craft a lease claiming holder "C" (not in keyring) — cannot verify.
+      const cryptoC = makeCrypto('C', { ...keys, C: genKey() });
+      const leaseC = new FencedLease(cryptoC, { leaseTtlMs: TTL, failoverThresholdMs: FAILOVER });
+      const msg = leaseC.buildAcquisition(undefined, 1_000, 1); // holder C
+      const d = a.acceptTunnelLease(msg, 0, {}); // A's keyring has no C
+      expect(d.accept).toBe(false);
+    });
+  });
+
+  describe('expiry + clock-skew immunity', () => {
+    it('isExpired true once holder-local TTL passes', () => {
+      const a = leaseA();
+      const lease = a.buildAcquisition(undefined, 0, 1); // expires at TTL
+      expect(a.isExpired(lease, TTL - 1)).toBe(false);
+      expect(a.isExpired(lease, TTL)).toBe(true);
+    });
+
+    it('a fast-clock machine cannot win — authority is epoch, not time', () => {
+      // B has a wildly fast clock but builds the SAME epoch as everyone else.
+      const b = leaseB();
+      const prior = leaseA().buildAcquisition(undefined, 0, 1); // epoch 1
+      const fastClockCandidate = b.buildAcquisition(prior, 9_999_999_999, 1);
+      // The clock only sets expiresAt; the epoch is still currentEpoch+1.
+      expect(fastClockCandidate.epoch).toBe(2);
+      // It does not get a higher epoch from a fast clock.
+    });
+  });
+
+  describe('acquisition decision', () => {
+    it('can acquire when no lease exists', () => {
+      expect(leaseA().canAcquire(undefined, new Set(), 1_000).can).toBe(true);
+    });
+    it('can acquire when the current lease is expired', () => {
+      const a = leaseA();
+      const expired = a.buildAcquisition(undefined, 0, 1); // expires at TTL
+      expect(a.canAcquire(expired, new Set(), TTL + 1).can).toBe(true);
+    });
+    it('can acquire when the holder is presumed dead', () => {
+      const a = leaseA();
+      const heldByB = leaseB().buildAcquisition(undefined, 1_000, 1);
+      expect(a.canAcquire(heldByB, new Set(['B']), 2_000).can).toBe(true);
+    });
+    it('CANNOT acquire a live peer-held, unexpired lease', () => {
+      const a = leaseA();
+      const heldByB = leaseB().buildAcquisition(undefined, 1_000, 1);
+      const d = a.canAcquire(heldByB, new Set(), 2_000); // B not presumed dead, not expired
+      expect(d.can).toBe(false);
+      expect(d.reason).toContain('held-by-live-peer');
+    });
+    it('can always self-renew', () => {
+      const a = leaseA();
+      const mine = a.buildAcquisition(undefined, 1_000, 1);
+      expect(a.canAcquire(mine, new Set(), 2_000).can).toBe(true);
+    });
+  });
+
+  describe('livelock backoff', () => {
+    it('no backoff below the retry cap', () => {
+      expect(leaseA().shouldBackoffAfterContention(0, 'B')).toBe(false);
+      expect(leaseA().shouldBackoffAfterContention(4, 'B')).toBe(false);
+    });
+    it('after the cap, the higher machineId backs off and the lower keeps trying', () => {
+      // "A" < "B" lexically. After 5 retries contending with B:
+      const a = leaseA(); // self = A (lower)
+      const b = leaseB(); // self = B (higher)
+      expect(a.shouldBackoffAfterContention(5, 'B')).toBe(false); // A keeps trying
+      expect(b.shouldBackoffAfterContention(5, 'A')).toBe(true);  // B backs off
+      // Exactly one side yields → guaranteed progress.
+    });
+  });
+});

--- a/tests/unit/FencedOutbox.test.ts
+++ b/tests/unit/FencedOutbox.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tier-1 tests for FencedOutbox — structural no-duplicate-reply (§8 G3a).
+ * Covers: normal send, already-replied suppression, fenced-no-lease, fenced
+ * stale-epoch, and that a suppressed reply never invokes the platform send.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MessageProcessingLedger } from '../../src/messaging/MessageProcessingLedger.js';
+import { FencedOutbox } from '../../src/messaging/FencedOutbox.js';
+
+let ledger: MessageProcessingLedger;
+afterEach(() => ledger?.close());
+
+function setup(opts: { holdsLease?: boolean; epoch?: number } = {}) {
+  ledger = MessageProcessingLedger.openMemory();
+  const outbox = new FencedOutbox({
+    ledger,
+    currentEpoch: () => opts.epoch ?? 1,
+    holdsLease: () => opts.holdsLease ?? true,
+  });
+  return { ledger, outbox };
+}
+
+describe('FencedOutbox', () => {
+  it('sends when holding the lease at the stamped epoch, then commits the marker', async () => {
+    const { ledger, outbox } = setup({ holdsLease: true, epoch: 1 });
+    ledger.record('m1', { platform: 'telegram' });
+    ledger.beginProcessing('m1', 1);
+    const sendFn = vi.fn(async () => {});
+    const r = await outbox.send('m1', 0, 1, sendFn);
+    expect(r.sent).toBe(true);
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(ledger.isActedOn('m1')).toBe(true);
+  });
+
+  it('suppresses a reply when already replied (idempotent, no platform send)', async () => {
+    const { ledger, outbox } = setup({ holdsLease: true, epoch: 1 });
+    ledger.record('m2', { platform: 'telegram' });
+    ledger.beginProcessing('m2', 1);
+    await outbox.send('m2', 0, 1, async () => {});
+    // Second attempt (e.g. a replay) must not re-send.
+    const sendFn = vi.fn(async () => {});
+    const r = await outbox.send('m2', 0, 1, sendFn);
+    expect(r.sent).toBe(false);
+    expect(r.reason).toBe('already-replied');
+    expect(sendFn).not.toHaveBeenCalled();
+  });
+
+  it('suppresses (fences) when this machine does not hold the lease', async () => {
+    const { ledger, outbox } = setup({ holdsLease: false, epoch: 1 });
+    ledger.record('m3', { platform: 'telegram' });
+    const sendFn = vi.fn(async () => {});
+    const r = await outbox.send('m3', 0, 1, sendFn);
+    expect(r.sent).toBe(false);
+    expect(r.reason).toBe('fenced-no-lease');
+    expect(sendFn).not.toHaveBeenCalled();
+    expect(ledger.isActedOn('m3')).toBe(false);
+  });
+
+  it('suppresses when the lease epoch has moved past the stamped epoch', async () => {
+    // Turn began under epoch 1, but the lease has since advanced to epoch 2 —
+    // this machine is a fenced old-awake; its late reply must be dropped.
+    const { ledger, outbox } = setup({ holdsLease: true, epoch: 2 });
+    ledger.record('m4', { platform: 'telegram' });
+    ledger.beginProcessing('m4', 1);
+    const sendFn = vi.fn(async () => {});
+    const r = await outbox.send('m4', 0, 1, sendFn);
+    expect(r.sent).toBe(false);
+    expect(r.reason).toBe('fenced-stale-epoch');
+    expect(sendFn).not.toHaveBeenCalled();
+  });
+
+  it('reports send-failed without committing the marker', async () => {
+    const { ledger, outbox } = setup({ holdsLease: true, epoch: 1 });
+    ledger.record('m5', { platform: 'telegram' });
+    ledger.beginProcessing('m5', 1);
+    const r = await outbox.send('m5', 0, 1, async () => { throw new Error('telegram 500'); });
+    expect(r.sent).toBe(false);
+    expect(r.reason).toBe('send-failed');
+    expect(ledger.isActedOn('m5')).toBe(false); // not committed → safe to retry
+  });
+});

--- a/tests/unit/HandoffSentinel.test.ts
+++ b/tests/unit/HandoffSentinel.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tier-1 tests for HandoffSentinel — the planned-handoff lifecycle owner (§8 G3e).
+ * The critical safety property: the lease is NEVER yielded unless the ack is
+ * verified AND validation passes. Both sides of every gate are covered.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { HandoffSentinel, type HandoffOps, type FlushManifest, type HandoffAck } from '../../src/core/HandoffSentinel.js';
+import type { IngressPosition } from '../../src/core/types.js';
+
+const POS: IngressPosition = { platform: 'telegram', cursor: 4242, capturedAt: '2026-01-01T00:00:00Z' };
+const MANIFEST: FlushManifest = { tailSeq: 7, ingressPosition: POS, threadHistoryHash: 'abc123' };
+const GOOD_ACK: HandoffAck = { tailSeq: 7, ingressPosition: POS, threadHistoryHash: 'abc123' };
+
+function ops(over?: Partial<HandoffOps>): HandoffOps {
+  return {
+    flush: vi.fn(async () => MANIFEST),
+    awaitAck: vi.fn(async () => GOOD_ACK),
+    validate: vi.fn(async () => true),
+    sendYield: vi.fn(async () => {}),
+    demoteSelf: vi.fn(async () => {}),
+    ...over,
+  };
+}
+const cfg = (over?: any) => ({ handoffAckTimeoutMs: 5_000, minHandoffIntervalMs: 60_000, ...over });
+
+describe('HandoffSentinel', () => {
+  it('completes a planned handoff when ack verifies and validation passes', async () => {
+    const o = ops();
+    const s = new HandoffSentinel(o, cfg());
+    const outcome = await s.initiate();
+    expect(outcome).toBe('handed-off');
+    expect(s.state).toBe('committed');
+    expect(o.sendYield).toHaveBeenCalledTimes(1);
+    expect(o.demoteSelf).toHaveBeenCalledTimes(1);
+  });
+
+  it('ABORTS and stays awake (no yield) when no ack arrives', async () => {
+    const o = ops({ awaitAck: vi.fn(async () => null) });
+    const s = new HandoffSentinel(o, cfg());
+    const outcome = await s.initiate();
+    expect(outcome).toBe('aborted-stay-awake');
+    expect(o.sendYield).not.toHaveBeenCalled(); // never yields without a verified ack
+    expect(o.demoteSelf).not.toHaveBeenCalled();
+  });
+
+  it('ABORTS when the ack echo does not match the flush manifest', async () => {
+    const o = ops({ awaitAck: vi.fn(async () => ({ ...GOOD_ACK, threadHistoryHash: 'WRONG' })) });
+    const s = new HandoffSentinel(o, cfg());
+    expect(await s.initiate()).toBe('aborted-stay-awake');
+    expect(o.sendYield).not.toHaveBeenCalled();
+  });
+
+  it('ABORTS when the ingress position echo mismatches', async () => {
+    const o = ops({ awaitAck: vi.fn(async () => ({ ...GOOD_ACK, ingressPosition: { ...POS, cursor: 9999 } })) });
+    const s = new HandoffSentinel(o, cfg());
+    expect(await s.initiate()).toBe('aborted-stay-awake');
+    expect(o.sendYield).not.toHaveBeenCalled();
+  });
+
+  it('ABORTS when validation fails (no yield)', async () => {
+    const o = ops({ validate: vi.fn(async () => false) });
+    const s = new HandoffSentinel(o, cfg());
+    expect(await s.initiate()).toBe('aborted-stay-awake');
+    expect(o.sendYield).not.toHaveBeenCalled();
+  });
+
+  it('treats a validator throw/timeout as "not verified" (no yield)', async () => {
+    const o = ops({ validate: vi.fn(async () => { throw new Error('validator timeout'); }) });
+    const s = new HandoffSentinel(o, cfg());
+    expect(await s.initiate()).toBe('aborted-stay-awake');
+    expect(o.sendYield).not.toHaveBeenCalled();
+  });
+
+  it('fails (not yield) when the flush itself fails', async () => {
+    const o = ops({ flush: vi.fn(async () => { throw new Error('flush boom'); }) });
+    const s = new HandoffSentinel(o, cfg());
+    expect(await s.initiate()).toBe('failed');
+    expect(o.sendYield).not.toHaveBeenCalled();
+  });
+
+  it('respects the anti-oscillation floor', async () => {
+    let now = 1_000_000;
+    const o = ops();
+    const s = new HandoffSentinel(o, cfg({ now: () => now }));
+    expect(await s.initiate()).toBe('handed-off');
+    // Immediately try again within minHandoffIntervalMs.
+    now += 1_000;
+    const second = await s.initiate();
+    expect(second).toBe('aborted-stay-awake');
+    expect((o.flush as any).mock.calls.length).toBe(1); // second handoff never even flushed
+  });
+
+  it('exposes inProgress=false after completion (race guard releases)', async () => {
+    const s = new HandoffSentinel(ops(), cfg());
+    await s.initiate();
+    expect(s.inProgress).toBe(false);
+  });
+
+  it('emits a terminal event with the outcome', async () => {
+    const onTerminal = vi.fn();
+    const s = new HandoffSentinel(ops(), cfg({ onTerminal }));
+    await s.initiate();
+    expect(onTerminal).toHaveBeenCalledWith('handed-off', expect.any(String));
+  });
+});

--- a/tests/unit/LeaseCoordinator.test.ts
+++ b/tests/unit/LeaseCoordinator.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tier-1 tests for LeaseCoordinator — drives FencedLease over a (fake) durable
+ * store + (fake) tunnel. Covers acquisition, CAS contention, presumed-dead
+ * takeover, the tunnel-renewal self-suspend, the max(tunnel,git) fencing view,
+ * and unresolvable-split escalation. Real Ed25519 keys.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import crypto from 'node:crypto';
+import { FencedLease, type LeaseCrypto } from '../../src/core/FencedLease.js';
+import { LeaseCoordinator, type LeaseStore, type LeaseTransport } from '../../src/core/LeaseCoordinator.js';
+import type { LeaseRecord } from '../../src/core/types.js';
+
+function genKey() {
+  return crypto.generateKeyPairSync('ed25519', {
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+const KEYS: Record<string, { publicKey: string; privateKey: string }> = { A: genKey(), B: genKey() };
+function crypt(self: string): LeaseCrypto {
+  return {
+    selfMachineId: self,
+    sign: (c) => crypto.sign(null, Buffer.from(c), KEYS[self].privateKey).toString('base64'),
+    verify: (c, sig, holder) => {
+      const pub = KEYS[holder]?.publicKey;
+      if (!pub) return false;
+      try { return crypto.verify(null, Buffer.from(c), pub, Buffer.from(sig, 'base64')); } catch { return false; }
+    },
+  };
+}
+
+const TTL = 60_000;
+const FAILOVER = 15 * 60_000;
+
+/** In-memory durable store with optional pre-write contention injection. */
+class FakeStore implements LeaseStore {
+  lease: LeaseRecord | null = null;
+  epoch = 0;
+  /** If set, runs before each casWrite to simulate a peer advancing. */
+  beforeWrite?: () => void;
+  /** Controls whether a same-epoch refresh push succeeds (git reachability). */
+  refreshOk = true;
+  read() { return { lease: this.lease, epoch: this.epoch }; }
+  refresh(lease: LeaseRecord) {
+    if (!this.refreshOk) return false;
+    if ((this.lease?.epoch ?? 0) > lease.epoch) return false;
+    this.lease = lease;
+    return true;
+  }
+  casWrite(candidate: LeaseRecord) {
+    this.beforeWrite?.();
+    // Fast-forward accepted only if candidate strictly advances by exactly +1
+    // over the CURRENT committed epoch (anything else = lost the race).
+    if (candidate.epoch === this.epoch + 1) {
+      this.lease = candidate;
+      this.epoch = candidate.epoch;
+      return { ok: true, observed: { lease: this.lease, epoch: this.epoch } };
+    }
+    return { ok: false, observed: { lease: this.lease, epoch: this.epoch } };
+  }
+}
+
+function makeFlA() { return new FencedLease(crypt('A'), { leaseTtlMs: TTL, failoverThresholdMs: FAILOVER }); }
+function makeFlB() { return new FencedLease(crypt('B'), { leaseTtlMs: TTL, failoverThresholdMs: FAILOVER }); }
+
+describe('LeaseCoordinator', () => {
+  it('acquires from empty and reports holding', async () => {
+    const store = new FakeStore();
+    const lc = new LeaseCoordinator({
+      lease: makeFlA(), store, presumedDeadHolders: () => new Set(), now: () => 1_000,
+    });
+    expect(await lc.acquireIfEligible()).toBe(true);
+    expect(lc.holdsLease()).toBe(true);
+    expect(lc.currentEpoch()).toBe(1);
+    expect(lc.currentHolder()).toBe('A');
+  });
+
+  it('cannot acquire a live peer-held lease, can take a presumed-dead one', async () => {
+    const store = new FakeStore();
+    // B holds epoch 1.
+    store.lease = makeFlB().buildAcquisition(undefined, 500, 1);
+    store.epoch = 1;
+    let dead = new Set<string>();
+    const lc = new LeaseCoordinator({
+      lease: makeFlA(), store, presumedDeadHolders: () => dead, now: () => 2_000,
+    });
+    expect(await lc.acquireIfEligible()).toBe(false); // B live
+    dead = new Set(['B']);
+    expect(await lc.acquireIfEligible()).toBe(true); // B presumed dead → A takes over
+    expect(lc.currentEpoch()).toBe(2);
+    expect(lc.currentHolder()).toBe('A');
+  });
+
+  it('CAS contention: yields when a live peer advances the epoch mid-flight', async () => {
+    const store = new FakeStore();
+    const lc = new LeaseCoordinator({
+      lease: makeFlA(), store, presumedDeadHolders: () => new Set(), now: () => 1_000,
+    });
+    // Just before A's write lands, B sneaks in epoch 1 (live, not dead).
+    store.beforeWrite = () => {
+      if (store.epoch === 0) {
+        store.lease = makeFlB().buildAcquisition(undefined, 900, 1);
+        store.epoch = 1;
+      }
+    };
+    const got = await lc.acquireIfEligible();
+    expect(got).toBe(false); // A's epoch-1 candidate is rejected; B (live) holds it
+    expect(store.lease?.holder).toBe('B');
+  });
+
+  it('self-suspends when the tunnel is unreachable past leaseTtlMs', async () => {
+    const store = new FakeStore();
+    let reachable = true;
+    let now = 1_000;
+    const onSelfSuspend = vi.fn();
+    const tunnel: LeaseTransport = {
+      broadcast: async () => reachable,
+      observed: () => ({ lease: null, lastNonceByHolder: {} }),
+      isReachable: () => reachable,
+    };
+    const lc = new LeaseCoordinator({
+      lease: makeFlA(), store, tunnel, presumedDeadHolders: () => new Set(),
+      now: () => now, onSelfSuspend,
+    });
+    expect(await lc.acquireIfEligible()).toBe(true);
+    // Tunnel goes dark; advance time past TTL and renew.
+    reachable = false;
+    now = 1_000 + TTL + 1;
+    expect(await lc.renew()).toBe(false);
+    expect(onSelfSuspend).toHaveBeenCalledTimes(1);
+    expect(lc.holdsLease()).toBe(false); // suspended → no authority
+  });
+
+  it('git-only: self-suspends when the durable refresh cannot push past leaseTtlMs', async () => {
+    const store = new FakeStore();
+    let now = 1_000;
+    const onSelfSuspend = vi.fn();
+    const lc = new LeaseCoordinator({
+      lease: makeFlA(), store, presumedDeadHolders: () => new Set(), now: () => now, onSelfSuspend,
+    });
+    expect(await lc.acquireIfEligible()).toBe(true);
+    // Git push (refresh) starts failing — partitioned holder.
+    store.refreshOk = false;
+    now = 1_000 + TTL + 1;
+    expect(await lc.renew()).toBe(false);
+    expect(onSelfSuspend).toHaveBeenCalledTimes(1);
+    expect(lc.holdsLease()).toBe(false);
+  });
+
+  it('a reachable tunnel keeps the lease alive across renewals', async () => {
+    const store = new FakeStore();
+    let now = 1_000;
+    const tunnel: LeaseTransport = {
+      broadcast: async () => true,
+      observed: () => ({ lease: null, lastNonceByHolder: {} }),
+      isReachable: () => true,
+    };
+    const lc = new LeaseCoordinator({
+      lease: makeFlA(), store, tunnel, presumedDeadHolders: () => new Set(), now: () => now,
+    });
+    await lc.acquireIfEligible();
+    now += TTL * 2;
+    expect(await lc.renew()).toBe(true);
+    expect(lc.holdsLease()).toBe(true);
+  });
+
+  it('escalates an unresolvable split (dead holder + tunnel down)', async () => {
+    const store = new FakeStore();
+    store.lease = makeFlB().buildAcquisition(undefined, 500, 1);
+    store.epoch = 1;
+    const onEscalate = vi.fn();
+    const tunnel: LeaseTransport = {
+      broadcast: async () => false,
+      observed: () => ({ lease: null, lastNonceByHolder: {} }),
+      isReachable: () => false,
+    };
+    const lc = new LeaseCoordinator({
+      lease: makeFlA(), store, tunnel, presumedDeadHolders: () => new Set(['B']),
+      now: () => 2_000, onEscalate,
+    });
+    lc.checkForUnresolvableSplit('episode-1');
+    expect(onEscalate).toHaveBeenCalledTimes(1);
+    expect(onEscalate.mock.calls[0][0].holder).toBe('B');
+  });
+
+  it('fires onEpochAdvance when the epoch moves', async () => {
+    const store = new FakeStore();
+    const onEpochAdvance = vi.fn();
+    const lc = new LeaseCoordinator({
+      lease: makeFlA(), store, presumedDeadHolders: () => new Set(), now: () => 1_000, onEpochAdvance,
+    });
+    await lc.acquireIfEligible();
+    expect(onEpochAdvance).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/LiveTailBuffer.test.ts
+++ b/tests/unit/LiveTailBuffer.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tier-1 tests for LiveTailBuffer (sequence-dedup, §8 G3b) + liveTailRedaction (§8 G3c).
+ * Context integrity: no double-append, ordered application, bounded holdout,
+ * gap-discard, byte cap. Plus redaction of credential-shaped material.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LiveTailBuffer } from '../../src/core/LiveTailBuffer.js';
+import { redactForLiveTail, RedactionCategory } from '../../src/core/liveTailRedaction.js';
+
+const T = 'topic-1';
+const flush = (seq: number, content: string) => ({ seq, topic: T, content });
+
+describe('LiveTailBuffer — sequence dedup', () => {
+  it('applies contiguous flushes in order', () => {
+    const b = new LiveTailBuffer({ outOfOrderTimeoutMs: 60_000, maxBytesPerTopic: 1_000_000 });
+    expect(b.applyFlush(flush(1, 'a')).reason).toBe('applied');
+    expect(b.applyFlush(flush(2, 'b')).reason).toBe('applied');
+    expect(b.getTail(T).content).toBe('ab');
+    expect(b.getLastAppliedSeq(T)).toBe(2);
+  });
+
+  it('drops a duplicate flush (no double-append)', () => {
+    const b = new LiveTailBuffer({ outOfOrderTimeoutMs: 60_000, maxBytesPerTopic: 1_000_000 });
+    b.applyFlush(flush(1, 'a'));
+    b.applyFlush(flush(2, 'b'));
+    const dup = b.applyFlush(flush(2, 'b')); // at-least-once redelivery
+    expect(dup.applied).toBe(false);
+    expect(dup.reason).toBe('duplicate');
+    expect(b.getTail(T).content).toBe('ab'); // not 'abb'
+  });
+
+  it('holds an out-of-order flush then drains when the gap fills', () => {
+    const b = new LiveTailBuffer({ outOfOrderTimeoutMs: 60_000, maxBytesPerTopic: 1_000_000 });
+    b.applyFlush(flush(1, 'a'));
+    const held = b.applyFlush(flush(3, 'c')); // gap at 2
+    expect(held.reason).toBe('held-out-of-order');
+    expect(b.heldCount(T)).toBe(1);
+    expect(b.getTail(T).content).toBe('a');
+    // Fill the gap → 2 then drains 3.
+    const fill = b.applyFlush(flush(2, 'b'));
+    expect(fill.reason).toBe('applied');
+    expect(b.getTail(T).content).toBe('abc');
+    expect(b.heldCount(T)).toBe(0);
+  });
+
+  it('declares an unfillable gap after the timeout and proceeds', () => {
+    let now = 1_000;
+    const b = new LiveTailBuffer({ outOfOrderTimeoutMs: 5_000, maxBytesPerTopic: 1_000_000, now: () => now });
+    b.applyFlush(flush(1, 'a'));
+    b.applyFlush(flush(3, 'c')); // held, gap at 2
+    now += 6_000; // gap times out
+    const res = b.applyFlush(flush(5, 'e')); // a later flush arrives
+    expect(res.reason).toBe('gap-discarded-then-applied');
+    expect(b.getLastAppliedSeq(T)).toBe(5);
+    expect(b.heldCount(T)).toBe(0); // held discarded
+  });
+
+  it('enforces the per-topic byte cap (drop-oldest)', () => {
+    const b = new LiveTailBuffer({ outOfOrderTimeoutMs: 60_000, maxBytesPerTopic: 5 });
+    b.applyFlush({ seq: 1, topic: T, content: 'aaa', bytes: 3 });
+    b.applyFlush({ seq: 2, topic: T, content: 'bbb', bytes: 3 }); // total 6 > 5 → drop oldest
+    const tail = b.getTail(T);
+    expect(tail.content).toBe('bbb');
+    expect(tail.lastAppliedSeq).toBe(2);
+  });
+});
+
+describe('liveTailRedaction', () => {
+  it('redacts a bearer token', () => {
+    const r = redactForLiveTail('Authorization: Bearer abcdef1234567890XYZ');
+    expect(r.text).not.toContain('abcdef1234567890XYZ');
+    expect(r.categories).toContain(RedactionCategory.BearerToken);
+    expect(r.redactedCount).toBeGreaterThan(0);
+  });
+
+  it('redacts a private key block', () => {
+    const pem = '-----BEGIN OPENSSH PRIVATE KEY-----\nMIIB...secret...\n-----END OPENSSH PRIVATE KEY-----';
+    const r = redactForLiveTail(`here is my key:\n${pem}`);
+    expect(r.text).not.toContain('secret');
+    expect(r.categories).toContain(RedactionCategory.PrivateKeyBlock);
+  });
+
+  it('redacts secret assignments and api keys', () => {
+    const r = redactForLiveTail('api_key = "sk-ABCD1234EFGH5678IJKL" and token: ghp_abcdefghijklmnop1234');
+    expect(r.text).not.toContain('sk-ABCD1234EFGH5678IJKL');
+    expect(r.redactedCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('leaves ordinary text untouched', () => {
+    const r = redactForLiveTail('what were we discussing about the deploy?');
+    expect(r.text).toBe('what were we discussing about the deploy?');
+    expect(r.redactedCount).toBe(0);
+  });
+});

--- a/tests/unit/MessageProcessingLedger.test.ts
+++ b/tests/unit/MessageProcessingLedger.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tier-1 tests for MessageProcessingLedger — the no-loss / no-duplicate-reply
+ * core (spec §8 G3a). Real SQLite (in-memory). Both sides of every boundary:
+ * redelivery dropped, cursor advances only on durable completion, stuck-
+ * processing re-run, dual-medium remote marker.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  MessageProcessingLedger,
+  computeReplyIdempotencyKey,
+} from '../../src/messaging/MessageProcessingLedger.js';
+
+let ledger: MessageProcessingLedger;
+afterEach(() => ledger?.close());
+
+describe('MessageProcessingLedger', () => {
+  it('records a new event as received (firstSeen)', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    const r = ledger.record('upd-1', { platform: 'telegram', topic: '13481' });
+    expect(r.firstSeen).toBe(true);
+    expect(r.state).toBe('received');
+    expect(ledger.isActedOn('upd-1')).toBe(false);
+  });
+
+  it('a redelivery of an acted-on event is recognized and NOT first-seen', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-1', { platform: 'telegram' });
+    ledger.beginProcessing('upd-1', 1);
+    ledger.commitReply('upd-1', computeReplyIdempotencyKey('upd-1', 0), 1);
+    // Telegram redelivers the same update.
+    const again = ledger.record('upd-1', { platform: 'telegram' });
+    expect(again.firstSeen).toBe(false);
+    expect(again.state).toBe('reply_committed');
+    expect(ledger.isActedOn('upd-1')).toBe(true); // caller drops it
+  });
+
+  it('beginProcessing returns false once acted on (no double-act)', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-2', { platform: 'telegram' });
+    ledger.beginProcessing('upd-2', 1);
+    ledger.commitReply('upd-2', computeReplyIdempotencyKey('upd-2', 0), 1);
+    expect(ledger.beginProcessing('upd-2', 2)).toBe(false);
+  });
+
+  it('cursor advances only from reply_committed', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-3', { platform: 'telegram' });
+    ledger.advanceCursor('upd-3'); // still 'received' → no-op
+    expect(ledger.get('upd-3')!.state).toBe('received');
+    ledger.beginProcessing('upd-3', 1);
+    ledger.commitReply('upd-3', computeReplyIdempotencyKey('upd-3', 0), 1);
+    ledger.advanceCursor('upd-3');
+    expect(ledger.get('upd-3')!.state).toBe('cursor_advanced');
+  });
+
+  it('commitReply is idempotent — committing twice keeps the first marker', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-4', { platform: 'telegram' });
+    ledger.beginProcessing('upd-4', 1);
+    const key = computeReplyIdempotencyKey('upd-4', 0);
+    ledger.commitReply('upd-4', key, 1);
+    ledger.commitReply('upd-4', 'DIFFERENT', 9); // must be ignored
+    const row = ledger.get('upd-4')!;
+    expect(row.replyIdempotencyKey).toBe(key);
+    expect(row.replyEpoch).toBe(1);
+  });
+
+  it('reclaimStuck finds processing entries past maxProcessingMs', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-5', { platform: 'telegram', input: '{"text":"hi"}' });
+    ledger.beginProcessing('upd-5', 1);
+    const started = Date.parse(ledger.get('upd-5')!.processingStartedAt!);
+    // Not yet stuck.
+    expect(ledger.reclaimStuck(60_000, started + 1_000)).toHaveLength(0);
+    // Past the threshold → reclaimable, with stored input for re-run.
+    const stuck = ledger.reclaimStuck(60_000, started + 61_000);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].dedupeKey).toBe('upd-5');
+    expect(stuck[0].inputSnapshot).toBe('{"text":"hi"}');
+  });
+
+  it('a re-claimed stuck entry can be re-processed by the new holder', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('upd-6', { platform: 'telegram' });
+    ledger.beginProcessing('upd-6', 1); // old holder, epoch 1
+    // New holder (epoch 2) re-claims and commits.
+    expect(ledger.beginProcessing('upd-6', 2)).toBe(true);
+    expect(ledger.get('upd-6')!.attempts).toBe(2);
+    ledger.commitReply('upd-6', computeReplyIdempotencyKey('upd-6', 0), 2);
+    expect(ledger.get('upd-6')!.replyEpoch).toBe(2);
+  });
+
+  it('applyRemoteReplyMarker prevents a failover re-send (dual-medium marker)', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    // We received it but had not replied when the other machine did + propagated.
+    ledger.record('upd-7', { platform: 'telegram' });
+    ledger.applyRemoteReplyMarker('upd-7', {
+      platform: 'telegram',
+      replyIdempotencyKey: computeReplyIdempotencyKey('upd-7', 0),
+      epoch: 3,
+    });
+    expect(ledger.isActedOn('upd-7')).toBe(true);
+    expect(ledger.beginProcessing('upd-7', 4)).toBe(false); // won't re-send
+  });
+
+  it('applyRemoteReplyMarker creates the entry if the event was unknown locally', () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.applyRemoteReplyMarker('upd-8', {
+      platform: 'slack',
+      replyIdempotencyKey: 'k8',
+      epoch: 2,
+    });
+    expect(ledger.isActedOn('upd-8')).toBe(true);
+  });
+
+  it('idempotency key is deterministic across machines', () => {
+    expect(computeReplyIdempotencyKey('upd-x', 0)).toBe(computeReplyIdempotencyKey('upd-x', 0));
+    expect(computeReplyIdempotencyKey('upd-x', 0)).not.toBe(computeReplyIdempotencyKey('upd-x', 1));
+  });
+});

--- a/tests/unit/multimachine-syncstatus.test.ts
+++ b/tests/unit/multimachine-syncstatus.test.ts
@@ -1,0 +1,55 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup, not a production path.
+/**
+ * Feature-alive check (spec §11 / Testing Integrity Phase-1): the
+ * /health.multiMachine.syncStatus surface returns VALID fields (never null/
+ * throws) even on a single-machine install. Exercises the real
+ * MultiMachineCoordinator.getSyncStatus() — the observability the health route
+ * serves.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { MultiMachineCoordinator } from '../../src/core/MultiMachineCoordinator.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SEAMLESSNESS_PROTOCOL_VERSION } from '../../src/core/seamlessnessConfig.js';
+
+let dir: string;
+let coord: MultiMachineCoordinator;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-mm-syncstatus-'));
+});
+afterEach(() => {
+  coord?.stop();
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('MultiMachineCoordinator.getSyncStatus — feature-alive surface', () => {
+  it('returns valid, non-null fields on a single-machine install (no identity)', () => {
+    coord = new MultiMachineCoordinator(new StateManager(dir), { stateDir: dir });
+    coord.start(); // no identity → single machine, always awake
+
+    const s = coord.getSyncStatus();
+    // Every field present and well-typed (not null where the contract says so).
+    expect(typeof s.enabled).toBe('boolean');
+    expect(s.enabled).toBe(false); // single machine = multi-machine disabled
+    expect(['awake', 'standby']).toContain(s.role);
+    expect(s.role).toBe('awake');
+    expect(typeof s.leaseEpoch).toBe('number');
+    expect(typeof s.holdsLease).toBe('boolean');
+    expect(s.holdsLease).toBe(true); // single machine trivially "holds"
+    expect(['clear', 'contested', 'self-suspended']).toContain(s.splitBrainState);
+    expect(s.splitBrainState).toBe('clear');
+    expect(s.protocolVersion).toBe(SEAMLESSNESS_PROTOCOL_VERSION);
+    expect(typeof s.awakeMachineCount).toBe('number');
+  });
+
+  it('getSyncStatus never throws even if the registry is unreadable', () => {
+    coord = new MultiMachineCoordinator(new StateManager(dir), { stateDir: dir });
+    coord.start();
+    // Should not throw regardless of registry state.
+    expect(() => coord.getSyncStatus()).not.toThrow();
+  });
+});

--- a/tests/unit/registry-sync-wiring.test.ts
+++ b/tests/unit/registry-sync-wiring.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Wiring-integrity + behavior tests for G2 automated state sync.
+ *
+ * The headline test ("a simulated role change triggers a push") is the exact
+ * Phase-0 failure this feature exists to close — it asserts the wiring is real,
+ * not dead code. Per the "feature actually alive" lesson, the subscription seam
+ * is verified, not assumed.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { wireRegistrySync } from '../../src/core/wireRegistrySync.js';
+import { RegistrySyncDebouncer } from '../../src/core/RegistrySyncDebouncer.js';
+
+describe('wireRegistrySync (wiring integrity)', () => {
+  it('reports the events it wires (real subscription, not dead code)', () => {
+    const coord = new EventEmitter();
+    const sink = { markRegistryDirty: vi.fn() };
+    const wiring = wireRegistrySync(coord, sink);
+    expect(wiring.wiredEvents).toContain('roleChange');
+    expect(wiring.wiredEvents).toContain('leaseEpochChange');
+  });
+
+  it('emitting roleChange marks the registry dirty', () => {
+    const coord = new EventEmitter();
+    const sink = { markRegistryDirty: vi.fn() };
+    wireRegistrySync(coord, sink);
+    coord.emit('roleChange', 'standby', 'awake');
+    expect(sink.markRegistryDirty).toHaveBeenCalledTimes(1);
+    expect(sink.markRegistryDirty.mock.calls[0][0]).toContain('standby->awake');
+  });
+
+  it('emitting leaseEpochChange marks the registry dirty', () => {
+    const coord = new EventEmitter();
+    const sink = { markRegistryDirty: vi.fn() };
+    wireRegistrySync(coord, sink);
+    coord.emit('leaseEpochChange', 7);
+    expect(sink.markRegistryDirty).toHaveBeenCalledTimes(1);
+    expect(sink.markRegistryDirty.mock.calls[0][0]).toContain('7');
+  });
+
+  it('unwire detaches the subscriptions', () => {
+    const coord = new EventEmitter();
+    const sink = { markRegistryDirty: vi.fn() };
+    const wiring = wireRegistrySync(coord, sink);
+    wiring.unwire();
+    coord.emit('roleChange', 'standby', 'awake');
+    expect(sink.markRegistryDirty).not.toHaveBeenCalled();
+  });
+});
+
+describe('RegistrySyncDebouncer (durable push behavior)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('THE PHASE-0 TEST: an authoritative role change triggers a debounced push of the registry', async () => {
+    const commitAndPush = vi.fn().mockReturnValue(true);
+    const deb = new RegistrySyncDebouncer({
+      commitAndPush,
+      registryAbsPath: '/tmp/agent/machines/registry.json',
+      isAuthoritative: () => true,
+      debounceMs: 100,
+    });
+    // Wire a real coordinator → real debouncer (full seam).
+    const coord = new EventEmitter();
+    wireRegistrySync(coord, deb);
+
+    coord.emit('roleChange', 'standby', 'awake');
+    expect(commitAndPush).not.toHaveBeenCalled(); // debounced, not yet
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(commitAndPush).toHaveBeenCalledTimes(1);
+    const [message, paths] = commitAndPush.mock.calls[0];
+    expect(message).toContain('registry sync');
+    expect(paths).toEqual(['/tmp/agent/machines/registry.json']);
+  });
+
+  it('coalesces multiple rapid marks into one push', async () => {
+    const commitAndPush = vi.fn().mockReturnValue(true);
+    const deb = new RegistrySyncDebouncer({
+      commitAndPush,
+      registryAbsPath: '/tmp/r.json',
+      isAuthoritative: () => true,
+      debounceMs: 100,
+    });
+    deb.markRegistryDirty('a');
+    deb.markRegistryDirty('b');
+    deb.markRegistryDirty('c');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(commitAndPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('single-writer: a standby (non-authoritative) never pushes', async () => {
+    const commitAndPush = vi.fn().mockReturnValue(true);
+    const deb = new RegistrySyncDebouncer({
+      commitAndPush,
+      registryAbsPath: '/tmp/r.json',
+      isAuthoritative: () => false, // standby
+      debounceMs: 50,
+    });
+    deb.markRegistryDirty('role change while standby');
+    await vi.advanceTimersByTimeAsync(50);
+    expect(commitAndPush).not.toHaveBeenCalled();
+  });
+
+  it('repeated push failures flip the sync-health signal unhealthy at the threshold', async () => {
+    const healthEvents: boolean[] = [];
+    const commitAndPush = vi.fn(() => {
+      throw new Error('non-fast-forward');
+    });
+    const deb = new RegistrySyncDebouncer({
+      commitAndPush,
+      registryAbsPath: '/tmp/r.json',
+      isAuthoritative: () => true,
+      debounceMs: 10,
+      maxConsecutiveFailures: 3,
+      onSyncHealth: (s) => healthEvents.push(s.healthy),
+    });
+    // Drive three flushes via direct flush() calls (each re-queues on failure).
+    deb.markRegistryDirty('x');
+    await deb.flush();
+    await deb.flush();
+    await deb.flush();
+    expect(deb.getHealth().consecutiveFailures).toBe(3);
+    expect(deb.getHealth().healthy).toBe(false);
+    expect(healthEvents).toContain(false);
+  });
+
+  it('a successful push resets failure count + records lastPushAt', async () => {
+    let fail = true;
+    const commitAndPush = vi.fn(() => {
+      if (fail) throw new Error('temporary');
+      return true;
+    });
+    const deb = new RegistrySyncDebouncer({
+      commitAndPush,
+      registryAbsPath: '/tmp/r.json',
+      isAuthoritative: () => true,
+      debounceMs: 10,
+    });
+    deb.markRegistryDirty('x');
+    await deb.flush(); // fails, re-queues
+    expect(deb.getHealth().consecutiveFailures).toBe(1);
+    fail = false;
+    await deb.flush(); // succeeds
+    expect(deb.getHealth().consecutiveFailures).toBe(0);
+    expect(deb.getHealth().healthy).toBe(true);
+    expect(deb.getHealth().lastPushAt).toBeTruthy();
+  });
+});

--- a/tests/unit/registryReplayGuard.test.ts
+++ b/tests/unit/registryReplayGuard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tier-1 + security-negative tests for the registry replay/freshness guard (spec §8 G2).
+ * Both sides of every boundary: stale sequence, epoch floor, unknown-key constraint.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateRegistryEntry, reconcileRegistryEntries } from '../../src/core/registryReplayGuard.js';
+import type { MachineRegistryEntry } from '../../src/core/types.js';
+
+function entry(over?: Partial<MachineRegistryEntry>): MachineRegistryEntry {
+  return {
+    name: 'm',
+    status: 'active' as any,
+    role: 'standby',
+    pairedAt: '2026-01-01T00:00:00Z',
+    lastSeen: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('evaluateRegistryEntry — replay/freshness', () => {
+  it('accepts a fresh entry (higher sequence, current epoch)', () => {
+    const d = evaluateRegistryEntry({
+      machineId: 'A',
+      incoming: entry({ syncSequence: 5, authoredUnderEpoch: 3 }),
+      local: entry({ syncSequence: 4, authoredUnderEpoch: 3 }),
+      currentCommittedEpoch: 3,
+    });
+    expect(d.accept).toBe(true);
+  });
+
+  it('rejects a stale (replayed) sequence', () => {
+    const d = evaluateRegistryEntry({
+      machineId: 'A',
+      incoming: entry({ syncSequence: 4, authoredUnderEpoch: 3 }),
+      local: entry({ syncSequence: 4, authoredUnderEpoch: 3 }),
+      currentCommittedEpoch: 3,
+    });
+    expect(d.accept).toBe(false);
+    expect(d.reason).toContain('stale-sync-sequence');
+  });
+
+  it('rejects an entry authored under a stale epoch (wiped/re-keyed sequence reset)', () => {
+    // A machine wiped local state: sequence resets to a high number again, but
+    // its authoredUnderEpoch is stale → caught by the epoch floor.
+    const d = evaluateRegistryEntry({
+      machineId: 'A',
+      incoming: entry({ syncSequence: 99, authoredUnderEpoch: 2 }),
+      local: entry({ syncSequence: 4, authoredUnderEpoch: 5 }),
+      currentCommittedEpoch: 5,
+    });
+    expect(d.accept).toBe(false);
+    expect(d.reason).toContain('below-epoch-floor');
+  });
+});
+
+describe('evaluateRegistryEntry — unknown-key first commit', () => {
+  it('accepts an unknown key only as standby + rejoined', () => {
+    const d = evaluateRegistryEntry({
+      machineId: 'NEW',
+      incoming: entry({ role: 'standby', rejoined: true }),
+      local: undefined,
+      currentCommittedEpoch: 5,
+    });
+    expect(d.accept).toBe(true);
+  });
+
+  it('REJECTS an unknown key asserting an awake role (security-negative)', () => {
+    const d = evaluateRegistryEntry({
+      machineId: 'EVIL',
+      incoming: entry({ role: 'awake', rejoined: true }),
+      local: undefined,
+      currentCommittedEpoch: 5,
+    });
+    expect(d.accept).toBe(false);
+    expect(d.reason).toContain('unknown-key-first-commit');
+  });
+
+  it('REJECTS an unknown key that is standby but not flagged rejoined', () => {
+    const d = evaluateRegistryEntry({
+      machineId: 'EVIL',
+      incoming: entry({ role: 'standby', rejoined: false }),
+      local: undefined,
+      currentCommittedEpoch: 5,
+    });
+    expect(d.accept).toBe(false);
+  });
+
+  it('accepts an unknown key with a valid pairing-join record', () => {
+    const d = evaluateRegistryEntry({
+      machineId: 'PAIRED',
+      incoming: entry({ role: 'awake' }),
+      local: undefined,
+      currentCommittedEpoch: 5,
+      hasValidJoinRecord: true,
+    });
+    expect(d.accept).toBe(true);
+  });
+});
+
+describe('reconcileRegistryEntries', () => {
+  it('applies accepted entries and reports rejected ones', () => {
+    const result = reconcileRegistryEntries({
+      localEntries: {
+        A: entry({ syncSequence: 4, authoredUnderEpoch: 5 }),
+        B: entry({ syncSequence: 1, authoredUnderEpoch: 5 }),
+      },
+      incomingEntries: {
+        A: entry({ syncSequence: 5, authoredUnderEpoch: 5 }), // fresh → accept
+        B: entry({ syncSequence: 1, authoredUnderEpoch: 5 }), // stale → reject
+        EVIL: entry({ role: 'awake' }),                       // unknown awake → reject
+      },
+      currentCommittedEpoch: 5,
+    });
+    expect(Object.keys(result.accepted)).toEqual(['A']);
+    expect(result.rejected.map((r) => r.machineId).sort()).toEqual(['B', 'EVIL']);
+  });
+});

--- a/tests/unit/seamlessness-fault-injection.test.ts
+++ b/tests/unit/seamlessness-fault-injection.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Fault-injection (spec §10) — exactly-once EFFECT across simulated crashes and
+ * failovers, composing the real MessageProcessingLedger + FencedOutbox + a lease
+ * epoch. Asserts the headline acceptance criteria (no lost message, no duplicate
+ * reply) hold at the boundaries the feature exists to survive:
+ *   - crash after channel-ack before reply (replay → exactly-once)
+ *   - crash mid-processing (old holder fenced; new holder re-runs once)
+ *   - duplicate provider delivery (recognized + dropped)
+ *   - a fenced old-awake's late reply suppressed at the send path
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MessageProcessingLedger } from '../../src/messaging/MessageProcessingLedger.js';
+import { FencedOutbox } from '../../src/messaging/FencedOutbox.js';
+
+let ledger: MessageProcessingLedger;
+afterEach(() => ledger?.close());
+
+/** A controllable lease view shared by an outbox. */
+function leaseView(initial: { holds: boolean; epoch: number }) {
+  const state = { ...initial };
+  return {
+    state,
+    holdsLease: () => state.holds,
+    currentEpoch: () => state.epoch,
+  };
+}
+
+describe('seamlessness fault-injection — exactly-once effect', () => {
+  it('crash AFTER reply-commit, then a redelivery: never replies twice', async () => {
+    ledger = MessageProcessingLedger.openMemory();
+    const lv = leaseView({ holds: true, epoch: 1 });
+    const outbox = new FencedOutbox({ ledger, currentEpoch: lv.currentEpoch, holdsLease: lv.holdsLease });
+    const send = vi.fn(async () => {});
+
+    // Turn 1: process + reply.
+    ledger.record('u1', { platform: 'telegram' });
+    ledger.beginProcessing('u1', 1);
+    expect((await outbox.send('u1', 0, 1, send)).sent).toBe(true);
+
+    // CRASH before cursor_advanced (reply committed, cursor not advanced).
+    // The channel redelivers u1 on restart.
+    const redeliver = ledger.record('u1', { platform: 'telegram' });
+    expect(redeliver.firstSeen).toBe(false);
+    expect(ledger.isActedOn('u1')).toBe(true);
+    const second = await outbox.send('u1', 0, 1, send);
+    expect(second.sent).toBe(false); // recognized, dropped
+    expect(send).toHaveBeenCalledTimes(1); // exactly once
+  });
+
+  it('crash MID-processing: old holder fenced, new holder re-runs exactly once', async () => {
+    ledger = MessageProcessingLedger.openMemory();
+    // Old holder begins processing under epoch 1, then dies (no reply).
+    ledger.record('u2', { platform: 'telegram', input: '{"text":"do the thing"}' });
+    ledger.beginProcessing('u2', 1);
+
+    // Lease moves to a new holder at epoch 2 (failover). The stuck entry is
+    // reclaimable past maxProcessingMs.
+    const started = Date.parse(ledger.get('u2')!.processingStartedAt!);
+    const stuck = ledger.reclaimStuck(60_000, started + 61_000);
+    expect(stuck.map((e) => e.dedupeKey)).toContain('u2');
+    expect(stuck[0].inputSnapshot).toBe('{"text":"do the thing"}'); // re-run from stored input
+
+    // New holder re-claims + replies under epoch 2.
+    const lv = leaseView({ holds: true, epoch: 2 });
+    const outbox = new FencedOutbox({ ledger, currentEpoch: lv.currentEpoch, holdsLease: lv.holdsLease });
+    expect(ledger.beginProcessing('u2', 2)).toBe(true);
+    const send = vi.fn(async () => {});
+    expect((await outbox.send('u2', 0, 2, send)).sent).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    // The OLD holder (epoch 1) wakes up wedged and tries to send its abandoned
+    // reply — it is fenced (stale epoch) and suppressed.
+    const oldView = leaseView({ holds: true, epoch: 2 }); // current epoch is 2
+    const oldOutbox = new FencedOutbox({ ledger, currentEpoch: oldView.currentEpoch, holdsLease: oldView.holdsLease });
+    const oldSend = vi.fn(async () => {});
+    const oldResult = await oldOutbox.send('u2', 0, 1, oldSend); // stamped under stale epoch 1
+    expect(oldResult.sent).toBe(false);
+    expect(oldResult.reason).toBe('already-replied'); // new holder already committed
+    expect(oldSend).not.toHaveBeenCalled();
+  });
+
+  it('duplicate provider delivery during a transfer window is dropped', async () => {
+    ledger = MessageProcessingLedger.openMemory();
+    const r1 = ledger.record('u3', { platform: 'telegram' });
+    const r2 = ledger.record('u3', { platform: 'telegram' }); // overlap redelivery
+    expect(r1.firstSeen).toBe(true);
+    expect(r2.firstSeen).toBe(false);
+  });
+
+  it('a partitioned old-awake (no lease) cannot send at all', async () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('u4', { platform: 'telegram' });
+    ledger.beginProcessing('u4', 1);
+    const lv = leaseView({ holds: false, epoch: 1 }); // lost the lease
+    const outbox = new FencedOutbox({ ledger, currentEpoch: lv.currentEpoch, holdsLease: lv.holdsLease });
+    const send = vi.fn(async () => {});
+    const r = await outbox.send('u4', 0, 1, send);
+    expect(r.sent).toBe(false);
+    expect(r.reason).toBe('fenced-no-lease');
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('dual-medium remote marker (from the other machine) prevents a re-send after failover', async () => {
+    ledger = MessageProcessingLedger.openMemory();
+    ledger.record('u5', { platform: 'telegram' });
+    // The other machine replied + propagated the marker over the surviving medium.
+    ledger.applyRemoteReplyMarker('u5', { platform: 'telegram', replyIdempotencyKey: 'k', epoch: 2 });
+    const lv = leaseView({ holds: true, epoch: 2 });
+    const outbox = new FencedOutbox({ ledger, currentEpoch: lv.currentEpoch, holdsLease: lv.holdsLease });
+    const send = vi.fn(async () => {});
+    const r = await outbox.send('u5', 0, 2, send);
+    expect(r.sent).toBe(false);
+    expect(r.reason).toBe('already-replied');
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/seamlessnessConfig.test.ts
+++ b/tests/unit/seamlessnessConfig.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tier-1 unit tests for seamlessness config resolution + invariant validation.
+ * Spec §9 (Tunability). Both sides of every invariant boundary are covered.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSeamlessnessConfig,
+  validateSeamlessnessInvariants,
+  assertSeamlessnessInvariants,
+  SeamlessnessConfigError,
+  SEAMLESSNESS_PROTOCOL_VERSION,
+} from '../../src/core/seamlessnessConfig.js';
+import type { MultiMachineConfig } from '../../src/core/types.js';
+
+const baseMM = (over?: Partial<MultiMachineConfig>): MultiMachineConfig => ({
+  enabled: true,
+  autoFailover: true,
+  failoverTimeoutMinutes: 15,
+  autoFailoverConfirm: false,
+  ...over,
+});
+
+describe('resolveSeamlessnessConfig', () => {
+  it('applies sane defaults', () => {
+    const c = resolveSeamlessnessConfig(baseMM());
+    expect(c.ingressHeartbeatMs).toBe(30_000);
+    expect(c.leaseTtlMs).toBe(60_000); // 2 × ingressHeartbeatMs
+    expect(c.registrySyncDebounceMs).toBe(10_000);
+    expect(c.liveTailTransport).toBe('tunnel');
+    expect(c.liveTailMaxStalenessMs).toBe(5_000);
+    expect(c.liveTailPushRateMs).toBe(5_000); // = staleness
+    expect(c.handoffBar).toBe('near-instant');
+    expect(c.protocolVersion).toBe(SEAMLESSNESS_PROTOCOL_VERSION);
+  });
+
+  it('auto-derives standbyPullIntervalMs under BOTH bounds (min of fo/4 and leaseTtl/2)', () => {
+    const c = resolveSeamlessnessConfig(baseMM());
+    expect(c.failoverThresholdMs).toBe(15 * 60_000);
+    // At default ratios leaseTtl/2 (30s) is the binding bound, not failover/4 (225s).
+    expect(c.standbyPullIntervalMs).toBe(Math.min((15 * 60_000) / 4, c.leaseTtlMs / 2));
+    expect(c.standbyPullIntervalMs).toBe(30_000);
+    // And it actually satisfies the validated invariants:
+    expect(c.standbyPullIntervalMs).toBeLessThan(c.leaseTtlMs);
+    expect(c.standbyPullIntervalMs).toBeLessThan(c.failoverThresholdMs / 3);
+  });
+
+  it('leaseTtlMs follows a widened ingressHeartbeatMs', () => {
+    const c = resolveSeamlessnessConfig(baseMM({ ingressHeartbeatMs: 45_000 }));
+    expect(c.leaseTtlMs).toBe(90_000);
+  });
+
+  it('explicit overrides win over defaults', () => {
+    const c = resolveSeamlessnessConfig(baseMM({ liveTailTransport: 'git', liveTailMaxBytesPerTopic: 1024 }));
+    expect(c.liveTailTransport).toBe('git');
+    expect(c.liveTailMaxBytesPerTopic).toBe(1024);
+  });
+});
+
+describe('validateSeamlessnessInvariants', () => {
+  it('default config is valid', () => {
+    expect(validateSeamlessnessInvariants(resolveSeamlessnessConfig(baseMM()))).toEqual([]);
+  });
+
+  it('rejects standbyPullIntervalMs >= failoverThresholdMs/3', () => {
+    // failoverThresholdMs = 900_000; /3 = 300_000. Set pull to 300_000 (boundary, must fail).
+    const c = resolveSeamlessnessConfig(baseMM({ standbyPullIntervalMs: 300_000 }));
+    const errs = validateSeamlessnessInvariants(c);
+    expect(errs.some((e) => e.includes('failoverThresholdMs/3'))).toBe(true);
+  });
+
+  it('rejects standbyPullIntervalMs >= leaseTtlMs', () => {
+    // Make leaseTtlMs small (via ingressHeartbeatMs) but keep pull large within the /3 bound.
+    // ingressHeartbeatMs=20_000 → leaseTtl=40_000. pull must be < 40_000 AND < 300_000.
+    const c = resolveSeamlessnessConfig(baseMM({ ingressHeartbeatMs: 20_000, standbyPullIntervalMs: 50_000 }));
+    const errs = validateSeamlessnessInvariants(c);
+    expect(errs.some((e) => e.includes('leaseTtlMs'))).toBe(true);
+  });
+
+  it('rejects liveTailPushRateMs > liveTailMaxStalenessMs', () => {
+    const c = resolveSeamlessnessConfig(baseMM({ liveTailPushRateMs: 10_000, liveTailMaxStalenessMs: 5_000 }));
+    const errs = validateSeamlessnessInvariants(c);
+    expect(errs.some((e) => e.includes('liveTailPushRateMs'))).toBe(true);
+  });
+
+  it('rejects non-positive cadences', () => {
+    const c = resolveSeamlessnessConfig(baseMM({ ingressHeartbeatMs: 0 }));
+    const errs = validateSeamlessnessInvariants(c);
+    expect(errs.some((e) => e.includes('ingressHeartbeatMs'))).toBe(true);
+  });
+});
+
+describe('assertSeamlessnessInvariants', () => {
+  it('returns the resolved config when valid', () => {
+    const c = assertSeamlessnessInvariants(baseMM());
+    expect(c.ingressHeartbeatMs).toBe(30_000);
+  });
+
+  it('throws SeamlessnessConfigError on a violating config', () => {
+    expect(() => assertSeamlessnessInvariants(baseMM({ liveTailPushRateMs: 10_000, liveTailMaxStalenessMs: 5_000 }))).toThrow(
+      SeamlessnessConfigError,
+    );
+  });
+});

--- a/tests/unit/telegram-seamless-contract.test.ts
+++ b/tests/unit/telegram-seamless-contract.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Channel Seamlessness Contract conformance — Telegram reference adapter (spec §).
+ * dedupeKey stability, getIngressPosition shape, stopConsuming returns the durable
+ * position, resumeConsuming restores the offset without replaying.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('TelegramAdapter — Channel Seamlessness Contract', () => {
+  let adapter: TelegramAdapter;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tg-contract-'));
+    adapter = new TelegramAdapter({ token: 't', chatId: '-100123456', pollIntervalMs: 100 }, tmpDir);
+  });
+  afterEach(async () => {
+    await adapter.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/telegram-seamless-contract.test.ts' });
+  });
+
+  it('implements all four contract methods', () => {
+    expect(typeof adapter.dedupeKey).toBe('function');
+    expect(typeof adapter.getIngressPosition).toBe('function');
+    expect(typeof adapter.stopConsuming).toBe('function');
+    expect(typeof adapter.resumeConsuming).toBe('function');
+  });
+
+  it('dedupeKey is stable for the same update_id and distinct across updates', () => {
+    expect(adapter.dedupeKey!({ update_id: 555 })).toBe('telegram:555');
+    expect(adapter.dedupeKey!({ update_id: 555 })).toBe(adapter.dedupeKey!({ update_id: 555 }));
+    expect(adapter.dedupeKey!({ update_id: 556 })).not.toBe(adapter.dedupeKey!({ update_id: 555 }));
+  });
+
+  it('dedupeKey falls back to normalized message metadata', () => {
+    expect(adapter.dedupeKey!({ metadata: { update_id: 777 }, id: 'x' })).toBe('telegram:777');
+  });
+
+  it('getIngressPosition reports the telegram offset', () => {
+    const pos = adapter.getIngressPosition!();
+    expect(pos.platform).toBe('telegram');
+    expect(typeof pos.cursor).toBe('number');
+    expect(pos.capturedAt).toBeTruthy();
+  });
+
+  it('stopConsuming returns the durable position and resumeConsuming restores it (no replay)', async () => {
+    const pos = await adapter.stopConsuming!();
+    expect(pos.platform).toBe('telegram');
+    expect(adapter.isPolling).toBe(false);
+    // Resuming from a higher offset advances; never lowers below known (no replay).
+    await adapter.resumeConsuming!({ platform: 'telegram', cursor: 12345, capturedAt: new Date().toISOString() });
+    const after = adapter.getIngressPosition!();
+    expect(Number(after.cursor)).toBeGreaterThanOrEqual(12345);
+    await adapter.stop();
+  });
+
+  it('resumeConsuming rejects a wrong-platform position', async () => {
+    await expect(
+      adapter.resumeConsuming!({ platform: 'slack', cursor: 1, capturedAt: new Date().toISOString() }),
+    ).rejects.toThrow(/wrong platform/);
+  });
+});

--- a/upgrades/side-effects/PR-BODY-cross-machine-seamlessness.md
+++ b/upgrades/side-effects/PR-BODY-cross-machine-seamlessness.md
@@ -1,0 +1,63 @@
+# Cross-Machine Seamlessness — one agent that follows the user across machines
+
+Implements the converged + approved **Cross-Machine Seamlessness** spec
+(`docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md`), grounded in the 2026-05-26
+real-hardware Phase-0 run. Closes the gap between "a backup machine can take
+over" and "the same agent follows you across machines with no amnesia and no
+double-replies."
+
+## What this fixes (the Phase-0 findings)
+- **G2 — auto-sync never fired.** A self-electing machine changed its role but
+  nothing pushed it to git. Now `roleChange`/`leaseEpochChange` → a debounced,
+  single-writer `RegistrySyncDebouncer` push (the wiring is named + a
+  wiring-integrity test reproduces the original failure and proves it caught).
+- **G1 — split-brain.** Two machines both showed `awake`. Replaced with a
+  **fenced lease** (clock-proof, epoch-fenced CAS); `shouldSkipProcessing` gates
+  on `holdsLease()`, so a wedged old-awake is structurally fenced out. A holder
+  that can't confirm its lease over a shared medium for > leaseTtlMs
+  self-suspends (no partitioned-old-awake split-brain).
+- **G3 — the seamless channel experience.** Durable message-processing ledger
+  (no-loss / no-duplicate-reply, structural), fencing-gated outbox, encrypted-
+  live-tail buffer with sequence-dedup + secret redaction, and a HandoffSentinel
+  that yields the lease ONLY on a verified ack + passing validation (else stays
+  awake). Channel Seamlessness Contract implemented by Telegram (reference) +
+  Slack (second target).
+
+## Layers (commit-by-commit)
+1. Foundations + G2 auto-sync (types, config resolver/validator, FencedLease,
+   RegistrySyncDebouncer, registryReplayGuard, the named wiring).
+2. G1 fenced-lease leader resolution (LeaseCoordinator + GitLeaseStore + live
+   coordinator integration).
+3. G3 idempotent ledger + handoff lifecycle + adapter contract.
+4. G3 live-tail buffer + redaction + fenced outbox.
+5. Observability (`/health.multiMachine.syncStatus`) + agent awareness
+   (CLAUDE.md generate + migrate).
+6. Telegram + Slack Channel Seamlessness Contract.
+
+## Tunability, migration parity, observability
+- All §9 knobs under `.instar/config.json` → `multiMachine`, with startup
+  invariant validation (a violating config is rejected, not run silently).
+- Knobs default in code (existing agents get the feature without config bloat);
+  server code ships automatically; SQLite stores self-initialize; CLAUDE.md
+  awareness is migrated to existing agents.
+- `/health.multiMachine.syncStatus` (leaseHolder, leaseEpoch, holdsLease,
+  splitBrainState, awakeMachineCount, protocolVersion) — the Phase-1
+  feature-alive surface.
+
+## Tests
+~100 new unit tests (real Ed25519, real SQLite): lease CAS/fencing/clock-skew/
+livelock, registry replay/epoch/unknown-key guard, the Phase-0-catching push
+wiring test, message-ledger redelivery/stuck-recovery/dual-medium marker,
+fenced-outbox suppression, live-tail sequence-dedup/gap-discard, redaction,
+HandoffSentinel verify-before-yield (every abort gate), feature-alive syncStatus,
+and Telegram + Slack contract conformance.
+
+## Deliberate staging (honest)
+- The **live cross-machine handoff TRANSPORT** (server-to-server live-tail + ack
+  over the wire) and the **inbound-dispatch integration** of the ledger/outbox
+  are the validation-phase work proven by the real-hardware gate (test-as-self
+  over Telegram on two machines). The machinery is built + unit-tested here; the
+  wire integration lands with the hardware validation.
+- Onboarding/self-propagation gaps are tracked to ACT-156 (companion spec).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/upgrades/side-effects/cross-machine-seamlessness-g1-lease.md
+++ b/upgrades/side-effects/cross-machine-seamlessness-g1-lease.md
@@ -1,0 +1,71 @@
+# Side-Effects Review — Cross-Machine Seamlessness: G1 fenced-lease integration
+
+**Spec:** docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md §6 + §8 G1 (converged, approved)
+**Increment:** wire the FencedLease primitive into the live coordinator as the
+authority for awake/standby — closing the Phase-0 split-brain structurally.
+
+## What changed
+- `src/core/LeaseCoordinator.ts` (new) — drives FencedLease over a durable store
+  (+ optional tunnel): acquisition (bounded-retry CAS + livelock backoff),
+  renewal with a medium-agnostic confirmation requirement, the `holdsLease()`
+  fencing gate, epoch-advance signal, and unresolvable-split escalation. Tracks
+  `selfIssued` (the holder's freshest self-signed lease) so a renewal's new
+  expiry is honored without churning git.
+- `src/core/GitLeaseStore.ts` (new) — durable CAS over git: pull-rebase →
+  epoch-check → write → push-or-reject-reread (never force-push). `refresh()`
+  does a same-epoch durable expiry bump and declines if superseded. Bumps the
+  holder's syncSequence/authoredUnderEpoch so the lease write passes peers'
+  replay guard.
+- `src/core/GitSync.ts` — added `pullRebase()` (targeted, no auto-commit) for
+  the lease CAS. Additive.
+- `src/core/MultiMachineCoordinator.ts` — optional `leaseCoordinator`;
+  `shouldSkipProcessing()` returns `!holdsLease()` when attached (the structural
+  demotion Phase-0 lacked); `attachLeaseCoordinator` / `initializeLease` /
+  `tickLease` / `reconcileRoleToLease`; the monitor tick drives the lease when
+  attached (heartbeat retained for liveness display only).
+- `src/commands/server.ts` — constructs the lease crypto (signs with the
+  identity key whose pubkey is registered; verifies peers via the SAS-paired
+  registry), the GitLeaseStore, and the LeaseCoordinator; attaches + initializes
+  it; wires onEpochAdvance → `leaseEpochChange` (→ durable registry push).
+
+## Over-block / under-block
+- **Over-block:** `shouldSkipProcessing` now gates on `holdsLease()`. Risk: a
+  single git-backed machine that briefly can't read its own lease would skip
+  processing. Mitigated — a single machine acquires epoch 1 trivially at
+  `initializeLease()` (no peer to contend), and `holdsLease` reads its own
+  `selfIssued` lease (in-memory), not requiring git. Non-git / single-machine /
+  independent-mode meshes have NO leaseCoordinator → fall back to the existing
+  heartbeat path unchanged.
+- **Under-block:** git-only (no tunnel) means lease transfer latency is bounded
+  by git cadence, not RTT. Acceptable for the launch increment (Phase 0 proved
+  pairing works over git alone). The split-brain SAFETY is preserved via the
+  refresh-confirmation self-suspend (a partitioned holder stops within
+  leaseTtlMs). The tunnel ACCELERATOR is a tracked follow-on, not a correctness
+  gap.
+
+## Signal vs authority
+- Detectors emit signals (`checkForUnresolvableSplit`, sync-health); only the
+  lease HOLDER mutates authority-bearing state. A non-holder fails its own
+  fencing check and self-fences — no cooperative demotion needed.
+
+## Interactions
+- The lease epoch advance fires `leaseEpochChange`, which the G2 wireRegistrySync
+  already subscribes → the new epoch is pushed durably. Closed loop.
+- `reconcileRoleToLease` updates `_role` + StateManager read-only + heartbeat
+  writer to match lease holding — keeps existing role-dependent code paths
+  (scheduler `coordinator.isAwake`, etc.) coherent.
+- Heartbeat failover logic is bypassed when a lease is attached (the lease is
+  the single authority) — avoids two mechanisms fighting over role.
+
+## Rollback cost
+- Low–moderate. The lease is only active when git-backed multi-machine is
+  enabled AND construction succeeds (inside the existing try/catch). Reverting
+  the server.ts block + the coordinator's lease methods restores the
+  heartbeat-only behavior; the new modules become dead code.
+
+## Tests
+- `tests/unit/LeaseCoordinator.test.ts` (real Ed25519): acquire, presumed-dead
+  takeover, CAS contention yield, tunnel + git-only self-suspend, escalation,
+  epoch-advance signal. FencedLease/config/wiring/replay suites still green (57
+  total). Coordinator-integration + git-CAS-under-real-contention land in the
+  Tier-3 e2e + the real-hardware gate.

--- a/upgrades/side-effects/cross-machine-seamlessness-g2-foundation.md
+++ b/upgrades/side-effects/cross-machine-seamlessness-g2-foundation.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — Cross-Machine Seamlessness: foundations + G2 auto-sync
+
+**Spec:** docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md (converged, approved)
+**Increment:** type/config foundations, the FencedLease primitive (logic), and G2
+automated state sync with the named wiring + pull-side replay/freshness guard.
+
+## What changed
+
+New, self-contained modules (no behavior wired into existing flows except the two named seams):
+- `src/core/seamlessnessConfig.ts` — resolve + validate the §9 tunable knobs; auto-derives
+  `standbyPullIntervalMs = min(failoverThresholdMs/4, leaseTtlMs/2)` to satisfy BOTH cross-knob
+  invariants (the bare `/4` the spec first stated violated the `< leaseTtlMs` invariant at default
+  ratios — caught by the unit test; spec table corrected to match).
+- `src/core/FencedLease.ts` — pure lease logic (epoch CAS candidate, signing/verify, fencing check
+  `holdsValidLease`, `effectiveEpoch = max(tunnel,git)`, tunnel accept guard, presumed-dead
+  acquisition, livelock backoff). Transport-agnostic; not yet wired into the coordinator (that is the
+  G1 integration step).
+- `src/core/RegistrySyncDebouncer.ts` — debounced, single-writer durable registry push + sync-health
+  signal.
+- `src/core/wireRegistrySync.ts` — the NAMED G2 wiring (coordinator roleChange/leaseEpochChange →
+  markRegistryDirty), extracted as a testable seam.
+- `src/core/registryReplayGuard.ts` — pure replay/freshness + epoch-floor + unknown-key-first-commit
+  validator.
+
+Edits to existing files:
+- `src/core/types.ts` — additive optional fields on `MachineRegistryEntry` (syncSequence,
+  authoredUnderEpoch, protocolVersion, rejoined), new `LeaseRecord`, optional `lease` on
+  `MachineRegistry`, and the seamlessness knobs on `MultiMachineConfig`. All optional → no existing
+  caller breaks.
+- `src/core/GitSync.ts` — `sync()` snapshots the registry before pull and calls a new
+  `reconcilePulledRegistry()` after a successful pull to scrub stale/unauthorized entries. Additive;
+  on any error it warns and continues (never blocks sync).
+- `src/commands/server.ts` — validates the seamlessness config at startup (rejects a violating
+  config), constructs `gitSync` for BOTH roles (so a self-electing standby can push), and wires the
+  RegistrySyncDebouncer. Stops it on shutdown.
+
+## Over-block / under-block
+- **Over-block risk:** startup config validation throws on a violating override. Mitigated: default
+  and absent configs resolve to valid values (unit-tested), so only an explicitly bad override fails —
+  which is the intended "reject, don't degrade silently" behavior (spec §9).
+- **Under-block risk:** the replay guard only runs when `registryBefore` was readable and the pull
+  changed HEAD; a first-ever pull with no prior registry simply trusts the incoming (no local baseline
+  to compare). Acceptable — signed-commit verification still applies, and the unknown-key constraint
+  still rejects an unknown machine asserting awake.
+
+## Level-of-abstraction fit
+- The durable push lives in a debouncer (coarse, registry-only), NOT in the per-tick heartbeat path —
+  honoring the ephemeral/durable split so steady-state produces ~0 commits.
+- FencedLease is pure logic with injected crypto; the transport (git/tunnel) is the coordinator's job.
+  This keeps the dangerous CAS/fencing logic unit-testable.
+
+## Signal vs. authority
+- RegistrySyncDebouncer is single-writer: it only pushes when `isAuthoritative()` (awake / lease
+  holder). A standby marking dirty is a no-op push — removes the O(N) thundering-herd.
+- The replay guard and sync-health are SIGNALS (reject an entry / flip health); the authority to act
+  on unhealthy sync (self-suspend ingress) belongs to the lease layer, wired in the G1 step.
+
+## Interactions
+- `gitSync` now constructed for standby too. It does NOT pull/push at boot unless awake (the boot
+  `sync()` stays gated on `isAwake`); construction alone has no side effects beyond signing setup.
+- `reconcilePulledRegistry` writes back a cleaned registry only when something was rejected — normal
+  pulls are untouched (no spurious writes).
+- The lease object in the registry is explicitly NOT reconciled by the guard (the FencedLease epoch
+  CAS owns it) — avoids two components fighting over the same field.
+
+## Rollback cost
+- Low. New modules are unreferenced except the two seams in server.ts/GitSync.ts. Reverting the
+  server.ts wiring + the GitSync snapshot/reconcile block restores prior behavior exactly; the new
+  files become dead code. No schema/migration shipped in this increment (config knobs are read with
+  defaults; migrateConfig lands in P4).
+
+## Tests
+- `tests/unit/FencedLease.test.ts` (real Ed25519), `seamlessnessConfig.test.ts`,
+  `registry-sync-wiring.test.ts` (incl. the Phase-0-catching "role change triggers a push" test),
+  `registryReplayGuard.test.ts`. All green. Tier-2 (real git repo) reconcile + Tier-3 land in P5.

--- a/upgrades/side-effects/cross-machine-seamlessness-g3-telegram-contract.md
+++ b/upgrades/side-effects/cross-machine-seamlessness-g3-telegram-contract.md
@@ -1,0 +1,36 @@
+# Side-Effects Review — Cross-Machine Seamlessness: Telegram adapter contract impl
+
+**Spec:** docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md §Channel Seamlessness Contract (converged, approved)
+
+## What changed
+- `src/messaging/TelegramAdapter.ts` — implements the Channel Seamlessness
+  Contract (the reference adapter):
+  - `dedupeKey(rawEvent)` → `telegram:<update_id>` (with a fallback to a
+    normalized Message's metadata.update_id).
+  - `getIngressPosition()` → `{ platform:'telegram', cursor:lastUpdateId, ... }`.
+  - `stopConsuming()` → halts the poll loop, persists the offset, returns the
+    DURABLE position (the saved offset, not the in-memory cursor).
+  - `resumeConsuming(position)` → restores the offset (never lowers it below
+    what we already know, so no replay) and restarts polling; rejects a
+    wrong-platform position.
+
+## Over-block / under-block
+- All four methods are additive (the interface declares them optional). No
+  existing TelegramAdapter behavior changes — start/stop/send/onMessage are
+  untouched. `resumeConsuming` uses `Math.max(lastUpdateId, cursor)` so it can
+  only advance the offset, never rewind into a replay.
+
+## Signal vs authority / interactions
+- These are pure adapter capabilities (where-am-I / stop / resume / identify);
+  they carry no authority. The seamless handoff path (a follow-on) calls them;
+  on their own they have no runtime effect until invoked.
+- `stopConsuming` reuses the existing `saveOffset()` (atomic-rename), so the
+  durable position is consistent with the normal poll-offset persistence.
+
+## Rollback cost
+- Minimal — removing the four methods reverts to the prior adapter exactly.
+
+## Tests
+- `tests/unit/telegram-seamless-contract.test.ts` (6): all four methods present,
+  dedupeKey stability/distinctness + metadata fallback, ingress-position shape,
+  stop→durable-position→resume round-trip (no replay), wrong-platform rejection.

--- a/upgrades/side-effects/cross-machine-seamlessness-g3a-ledger-handoff.md
+++ b/upgrades/side-effects/cross-machine-seamlessness-g3a-ledger-handoff.md
@@ -1,0 +1,56 @@
+# Side-Effects Review — Cross-Machine Seamlessness: G3 idempotent ledger + handoff lifecycle + adapter contract
+
+**Spec:** docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md §8 G3a/G3e + Channel Seamlessness Contract (converged, approved)
+
+## What changed
+- `src/messaging/MessageProcessingLedger.ts` (new) — SQLite-backed
+  received→processing→reply_committed→cursor_advanced lifecycle keyed by
+  dedupeKey. Redelivery of an acted-on event is dropped; cursor advances only on
+  durable completion; stuck-`processing` entries are re-runnable; a remote
+  reply-committed marker (dual-medium) prevents a failover re-send. Deterministic
+  `computeReplyIdempotencyKey(dedupeKey, replyIndex)`. Self-initializing schema,
+  per-agent-id isolation, WAL+busy_timeout (the PendingRelayStore pattern).
+- `src/core/HandoffSentinel.ts` (new) — the planned-handoff state machine
+  (prepare→tail_synced→ingress_fenced→new_owner_active→old_owner_standby→
+  committed). Yields the lease ONLY on a verified ack (echo of tailSeq + ingress
+  position + thread-history hash) AND a passing validation; otherwise aborts and
+  stays awake. Anti-oscillation floor + a race guard (`inProgress`).
+- `src/core/types.ts` — new `IngressPosition` type and OPTIONAL Channel
+  Seamlessness Contract methods on `MessagingAdapter`
+  (getIngressPosition/stopConsuming/resumeConsuming/dedupeKey).
+
+## Over-block / under-block
+- The contract methods are OPTIONAL, so every existing adapter
+  (Telegram/Slack/WhatsApp/iMessage) compiles unchanged — no adapter is forced
+  "seamless-ready" before it implements + passes the conformance suite.
+- The ledger's `record` is INSERT OR IGNORE — a benign double-record is a no-op;
+  a genuinely new event is `firstSeen:true`. No over-block (it never refuses a
+  first-seen event).
+
+## Signal vs authority
+- The ledger is a pure substrate (records facts); it carries no authority. The
+  fencing epoch is STORED (reply_epoch) but the authority to send is the lease
+  layer's (the fencing-gated outbox, next increment).
+- HandoffSentinel encodes the authority rule structurally: no yield without
+  verified ack + validation. The validator is a Tier-1 signal; the yield is the
+  authority act, gated on it.
+
+## Interactions
+- MessageProcessingLedger is standalone (not yet wired into the inbound path —
+  that wiring + the fencing-gated outbox is the next G3 increment). No live
+  behavior changes from this commit.
+- HandoffSentinel is standalone (constructed + wired in the integration step);
+  its ops are injected, so it has no ambient dependencies.
+- `applyRemoteReplyMarker` uses COALESCE so a local commit already present is
+  never downgraded — safe under concurrent local+remote marking.
+
+## Rollback cost
+- Minimal — both new modules are unreferenced by live code in this commit; the
+  types change is purely additive (optional fields). Reverting removes the files
+  with no behavioral impact.
+
+## Tests
+- `tests/unit/MessageProcessingLedger.test.ts` (real SQLite, 10 tests): redelivery
+  dropped, cursor-only-on-completion, idempotent commit, stuck re-run, dual-medium
+  marker. `tests/unit/HandoffSentinel.test.ts` (10 tests): every abort gate proven
+  to NOT yield. 77 unit tests green overall.

--- a/upgrades/side-effects/cross-machine-seamlessness-g3bc-livetail-outbox.md
+++ b/upgrades/side-effects/cross-machine-seamlessness-g3bc-livetail-outbox.md
@@ -1,0 +1,51 @@
+# Side-Effects Review — Cross-Machine Seamlessness: live-tail buffer + redaction + fenced outbox
+
+**Spec:** docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md §8 G3a/G3b/G3c (converged, approved)
+
+## What changed (all new, standalone modules)
+- `src/core/LiveTailBuffer.ts` — standby-side persisted tail with strict
+  sequence-dedup: applies a flush only at lastAppliedSeq+1, holds out-of-order,
+  drops duplicates, and after liveTailOutOfOrderTimeoutMs declares an unfillable
+  gap (discards held, proceeds) — bounding the holdout and preventing context
+  corruption. Per-topic byte cap (drop-oldest).
+- `src/core/liveTailRedaction.ts` — versioned (REDACTION_CATEGORY_VERSION) named
+  enum of credential categories + redactForLiveTail(); scrubs bearer tokens,
+  private-key blocks, AWS keys, JWT-like, api-keys, secret assignments before any
+  tail content leaves the machine.
+- `src/messaging/FencedOutbox.ts` — structural no-duplicate-reply at the send
+  path: sends only while holding the lease at the stamped epoch; suppresses a
+  fenced (no-lease / stale-epoch) machine's reply; idempotent via the ledger's
+  acted-on check + deterministic idempotency key.
+
+## Over-block / under-block
+- FencedOutbox SUPPRESSES on no-lease/stale-epoch — intended over-block (a fenced
+  machine must not send). Risk of under-send if `holdsLease()` is wrongly false;
+  mitigated because a single machine trivially holds its lease, and the stamped
+  epoch equals the current epoch in the normal (non-handoff) case.
+- Redaction is conservative/high-precision; over-redaction (a false positive) is
+  acceptable per spec ("false positives cheaper than a leak"). Ordinary prose is
+  left untouched (tested).
+
+## Signal vs authority
+- FencedOutbox consults the lease authority (holdsLease/currentEpoch injected) —
+  it does not itself decide authority, it enforces it at the send boundary.
+- LiveTailBuffer is a pure data structure (no authority); it only guarantees
+  context integrity on the receiving side.
+
+## Interactions
+- All three are standalone in this commit (not yet wired into the live message
+  path — that integration is the next increment). No runtime behavior changes.
+- FencedOutbox depends on MessageProcessingLedger (already shipped) — commitReply
+  is idempotent, so a double-send attempt is safe.
+- Redaction is designed to run before the (encrypted) transport; carry-by-
+  reference for large tool output (a follow-on in the transport wiring) reduces
+  the raw sensitive surface structurally beyond pattern-matching.
+
+## Rollback cost
+- Minimal — unreferenced by live code. Reverting removes the files.
+
+## Tests
+- `tests/unit/LiveTailBuffer.test.ts` (9): order, dup-drop, hold+drain,
+  gap-discard, byte cap, redaction categories. `tests/unit/FencedOutbox.test.ts`
+  (5): send, already-replied, fenced-no-lease, fenced-stale-epoch, send-failed.
+  91 unit tests green overall.

--- a/upgrades/side-effects/cross-machine-seamlessness-p4-awareness-observability.md
+++ b/upgrades/side-effects/cross-machine-seamlessness-p4-awareness-observability.md
@@ -1,0 +1,54 @@
+# Side-Effects Review — Cross-Machine Seamlessness: observability + agent awareness + migration parity
+
+**Spec:** docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md §11 (converged, approved)
+
+## What changed
+- `src/core/MultiMachineCoordinator.ts` — `getSyncStatus()`: the
+  /health.multiMachine.syncStatus surface (leaseHolder, leaseEpoch, holdsLease,
+  splitBrainState, awakeMachineCount, protocolVersion). Always returns valid
+  fields (never null/throws) — the Phase-1 "feature is alive" surface.
+- `src/server/routes.ts` — RouteContext gains `coordinator`; authed `/health`
+  now includes `multiMachine: { enabled, syncStatus }`.
+- `src/server/AgentServer.ts` — threads `options.coordinator` into the route
+  context.
+- `src/scaffold/templates.ts` (`generateClaudeMd`) + `src/core/PostUpdateMigrator.ts`
+  (`migrateClaudeMd`) — a concise Cross-Machine Seamlessness awareness section
+  (one-agent-many-machines, no double-reply, compaction-pause handoff bar, honest
+  machine-provenance, where to read sync status, how to read a split-brain
+  escalation). New agents get it via generate; existing agents via the
+  content-sniffed migration.
+
+## Migration parity decision (explicit)
+- The `multiMachine` seamlessness KNOBS default safely in code
+  (`resolveSeamlessnessConfig` applies defaults for any absent key), so every
+  existing agent's server resolves valid values without a config write. I
+  DELIBERATELY did not write ~13 knobs into every agent's config.json — that is
+  noise, and functional migration parity is already achieved by the code
+  defaults + the server code shipping + the SQLite stores self-initializing +
+  the CLAUDE.md awareness migration. The dials remain user-settable under
+  `multiMachine` (documented in the awareness section). A literal config-knob
+  migration is a trivial follow-on if a reviewer wants it.
+
+## Over-block / under-block
+- `getSyncStatus` is read-only and defensive (try/catch around the registry
+  read → awakeMachineCount 0 on failure). It cannot block anything.
+- `/health.multiMachine` is only in the AUTHED branch (unchanged auth posture);
+  the unauthenticated basic health is untouched.
+
+## Signal vs authority / interactions
+- Pure observability — no authority, no mutation. RouteContext.coordinator is
+  `| null`; single-machine installs report `{ enabled:false, syncStatus:null }`
+  or the trivially-held lease. Existing route tests still pass (tolerant
+  context builders).
+- protocolVersion is reported (for partial-migration visibility); its
+  enforcement point (refusing to hand the awake lease to an old-version machine)
+  lands with the live two-machine handoff transport.
+
+## Rollback cost
+- Low. Removing the /health block + getSyncStatus + the template sections
+  reverts cleanly; the RouteContext field is additive (`| null`).
+
+## Tests
+- `tests/unit/multimachine-syncstatus.test.ts` — the feature-alive surface
+  returns valid non-null fields on a single-machine install and never throws.
+  119 unit tests green overall.


### PR DESCRIPTION
Implements the converged + approved **Cross-Machine Seamlessness** spec (`docs/specs/CROSS-MACHINE-SEAMLESSNESS-SPEC.md`), grounded in the 2026-05-26 real-hardware Phase-0 run. Closes the gap between "a backup machine can take over" and "the same agent follows you across machines with no amnesia and no double-replies."

## Fixes the Phase-0 findings
- **G2 — auto-sync never fired.** `MultiMachineCoordinator` emitted `roleChange` but nothing pushed it to git. Now `roleChange`/`leaseEpochChange` → a debounced, single-writer `RegistrySyncDebouncer` push. The wiring is named (`wireRegistrySync`) and a wiring-integrity test reproduces the original failure and proves it's caught.
- **G1 — split-brain.** Replaced with a **fenced lease** (clock-proof, epoch-fenced CAS over git). `shouldSkipProcessing` gates on `holdsLease()`, so a wedged old-awake is structurally fenced out. A holder that can't confirm its lease over a shared medium for > leaseTtlMs self-suspends (no partitioned-old-awake split-brain).
- **G3 — seamless channel experience.** Durable SQLite message-processing ledger (structural no-loss / no-duplicate-reply), fencing-gated outbox, encrypted-live-tail buffer with sequence-dedup + versioned secret redaction, and a `HandoffSentinel` that yields the lease ONLY on a verified ack + passing validation (else stays awake).

## Also
- `/health.multiMachine.syncStatus` (the Phase-1 feature-alive surface) + `instar doctor`.
- Tunability knobs under `multiMachine` with startup invariant validation (a violating config is rejected, not run silently).
- Migration parity: knobs default in code; CLAUDE.md awareness section migrated to existing agents; SQLite stores self-initialize.
- Channel Seamlessness Contract: **Telegram** reference implementation + conformance tests.

## Tests
~109 new unit tests (real Ed25519, real SQLite) across 13 files: lease CAS/fencing/clock-skew/livelock, registry replay/epoch/unknown-key guard, the Phase-0-catching push-wiring test, message-ledger redelivery/stuck-recovery/dual-medium marker, fenced-outbox suppression, live-tail sequence-dedup/gap-discard, redaction, HandoffSentinel verify-before-yield (every abort gate), the feature-alive syncStatus surface, Telegram contract conformance, and a **fault-injection capstone** proving exactly-once across crash/failover/duplicate-delivery. Full CI-mirror suite green (1004 files, 18,732 passed).

## Honest staging / deferrals
- **Slack** Channel Seamlessness Contract impl was built + unit-tested but **dropped from this PR** — the pre-push gate (correctly) requires real-Slack-API contract evidence, unavailable in this environment. Telegram (reference) ships; Slack is the spec-stated principal-approvable second target. Tracked: **ACT-157**.
- The **live cross-machine handoff TRANSPORT** (server-to-server live-tail + ack over the wire) and the **inbound-dispatch integration** of the ledger/outbox are the validation-phase work proven by the real-hardware gate (test-as-self over Telegram on two machines). The machinery is built + unit-tested here.
- Onboarding/self-propagation gaps tracked to **ACT-156** (companion spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)