### PR TITLE
feat(feedback-factory): port the dispatch (guidance-out) logic to TS (Phase 1, increment 7)

### DIFF
--- a/src/feedback-factory/dispatch/dispatch.ts
+++ b/src/feedback-factory/dispatch/dispatch.ts
@@ -1,0 +1,87 @@
+/**
+ * dispatch.ts — framework-agnostic port of the dispatch (guidance-out) logic.
+ *
+ * Ports the pure logic of `the-portal/pages/api/instar/dispatches/index.ts` out of
+ * the Next.js handler: the dispatch type/priority vocab, the semver comparison used
+ * for version-compat filtering (an agent only receives a dispatch whose
+ * [minVersion, maxVersion] window includes the agent's version), the list query
+ * filter (since/type/version), and the create-dedup title normalization. The HTTP
+ * wiring + storage are excluded (the app-placement decision); this is the reusable
+ * core. Reference is TypeScript, so equivalence is by faithful transcription +
+ * exhaustive both-sides-of-boundary tests (not a cross-runtime parity harness).
+ */
+
+export const DISPATCH_TYPES = ['strategy', 'behavioral', 'lesson', 'configuration', 'security', 'action'] as const;
+export type DispatchType = typeof DISPATCH_TYPES[number];
+export const DISPATCH_PRIORITIES = ['low', 'normal', 'high', 'critical'] as const;
+export type DispatchPriority = typeof DISPATCH_PRIORITIES[number];
+
+export const SEMVER_RE = /^\d+\.\d+\.\d+(-[\w.]+)?$/;
+
+export function isValidDispatchType(type: unknown): type is DispatchType {
+  return typeof type === 'string' && (DISPATCH_TYPES as readonly string[]).includes(type);
+}
+export function isValidDispatchPriority(p: unknown): p is DispatchPriority {
+  return typeof p === 'string' && (DISPATCH_PRIORITIES as readonly string[]).includes(p);
+}
+
+/** Port of parseVersion: leading major.minor.patch → [n,n,n]; [0,0,0] if unparseable. */
+export function parseVersion(v: string): [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(v);
+  if (!match) return [0, 0, 0];
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/** Port of isVersionGte: version >= min (major.minor.patch, equal counts as gte). */
+export function isVersionGte(version: string, min: string): boolean {
+  const v = parseVersion(version);
+  const m = parseVersion(min);
+  for (let i = 0; i < 3; i++) {
+    if (v[i] > m[i]) return true;
+    if (v[i] < m[i]) return false;
+  }
+  return true; // equal
+}
+
+/** Port of isVersionLte: version <= max (equal counts as lte). */
+export function isVersionLte(version: string, max: string): boolean {
+  const v = parseVersion(version);
+  const m = parseVersion(max);
+  for (let i = 0; i < 3; i++) {
+    if (v[i] < m[i]) return true;
+    if (v[i] > m[i]) return false;
+  }
+  return true; // equal
+}
+
+export interface DispatchRecord {
+  dispatchId: string;
+  type: string;
+  title: string;
+  content?: string;
+  priority?: string;
+  minVersion?: string | null;
+  maxVersion?: string | null;
+  active?: boolean;
+  createdAt?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Port of handleList's version-compat filter: a dispatch is included only if the
+ * agent's version is within its [minVersion, maxVersion] window. Mirrors the
+ * reference — applied only when the agent sent a valid-semver version; otherwise
+ * all candidates pass (the caller gates on SEMVER_RE before calling).
+ */
+export function filterDispatchesForVersion(dispatches: DispatchRecord[], version: string): DispatchRecord[] {
+  return dispatches.filter((d) => {
+    if (d.minVersion && !isVersionGte(version, d.minVersion)) return false;
+    if (d.maxVersion && !isVersionLte(version, d.maxVersion)) return false;
+    return true;
+  });
+}
+
+/** Port of the create-path title normalization used for dedup: trim + cap at 500 chars. */
+export function normalizeDispatchTitle(title: string): string {
+  return title.trim().slice(0, 500);
+}

--- a/tests/unit/feedback-factory/dispatch.test.ts
+++ b/tests/unit/feedback-factory/dispatch.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests (Tier 1) — dispatch (guidance-out) logic.
+ *
+ * Reference is TypeScript, so equivalence is by faithful transcription +
+ * exhaustive both-sides-of-boundary tests (no cross-runtime parity harness).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isValidDispatchType, isValidDispatchPriority, parseVersion, isVersionGte, isVersionLte,
+  filterDispatchesForVersion, normalizeDispatchTitle, type DispatchRecord,
+} from '../../../src/feedback-factory/dispatch/dispatch.js';
+
+describe('vocab', () => {
+  it('validates types and priorities', () => {
+    expect(isValidDispatchType('strategy')).toBe(true);
+    expect(isValidDispatchType('bug')).toBe(false);
+    expect(isValidDispatchPriority('critical')).toBe(true);
+    expect(isValidDispatchPriority('urgent')).toBe(false);
+  });
+});
+
+describe('parseVersion', () => {
+  it('extracts major.minor.patch, ignoring prerelease', () => {
+    expect(parseVersion('1.2.3')).toEqual([1, 2, 3]);
+    expect(parseVersion('10.20.30-beta.2')).toEqual([10, 20, 30]);
+  });
+  it('returns [0,0,0] for unparseable input', () => {
+    expect(parseVersion('garbage')).toEqual([0, 0, 0]);
+    expect(parseVersion('1.2')).toEqual([0, 0, 0]);
+  });
+});
+
+describe('isVersionGte / isVersionLte (equal counts as both)', () => {
+  it('handles equal / greater / lesser across components', () => {
+    expect(isVersionGte('1.2.3', '1.2.3')).toBe(true);
+    expect(isVersionGte('1.3.0', '1.2.9')).toBe(true);
+    expect(isVersionGte('1.2.2', '1.2.3')).toBe(false);
+    expect(isVersionGte('2.0.0', '1.9.9')).toBe(true);
+
+    expect(isVersionLte('1.2.3', '1.2.3')).toBe(true);
+    expect(isVersionLte('1.2.3', '1.3.0')).toBe(true);
+    expect(isVersionLte('1.3.0', '1.2.9')).toBe(false);
+    expect(isVersionLte('1.9.9', '2.0.0')).toBe(true);
+  });
+});
+
+describe('filterDispatchesForVersion', () => {
+  const ds: DispatchRecord[] = [
+    { dispatchId: 'd-none', type: 'lesson', title: 'no bounds' },
+    { dispatchId: 'd-min', type: 'lesson', title: 'min 1.3.0', minVersion: '1.3.0' },
+    { dispatchId: 'd-max', type: 'lesson', title: 'max 1.2.0', maxVersion: '1.2.0' },
+    { dispatchId: 'd-window', type: 'lesson', title: '1.1.0–1.4.0', minVersion: '1.1.0', maxVersion: '1.4.0' },
+  ];
+  it('includes unbounded dispatches always', () => {
+    expect(filterDispatchesForVersion(ds, '1.2.5').map(d => d.dispatchId)).toContain('d-none');
+  });
+  it('respects minVersion (boundary inclusive)', () => {
+    expect(filterDispatchesForVersion(ds, '1.3.0').map(d => d.dispatchId)).toContain('d-min');
+    expect(filterDispatchesForVersion(ds, '1.2.9').map(d => d.dispatchId)).not.toContain('d-min');
+  });
+  it('respects maxVersion (boundary inclusive)', () => {
+    expect(filterDispatchesForVersion(ds, '1.2.0').map(d => d.dispatchId)).toContain('d-max');
+    expect(filterDispatchesForVersion(ds, '1.2.1').map(d => d.dispatchId)).not.toContain('d-max');
+  });
+  it('respects a both-bounds window', () => {
+    expect(filterDispatchesForVersion(ds, '1.2.0').map(d => d.dispatchId)).toContain('d-window');
+    expect(filterDispatchesForVersion(ds, '1.0.9').map(d => d.dispatchId)).not.toContain('d-window');
+    expect(filterDispatchesForVersion(ds, '1.4.1').map(d => d.dispatchId)).not.toContain('d-window');
+  });
+});
+
+describe('normalizeDispatchTitle', () => {
+  it('trims and caps at 500 chars', () => {
+    expect(normalizeDispatchTitle('  hi  ')).toBe('hi');
+    expect(normalizeDispatchTitle('x'.repeat(600)).length).toBe(500);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,23 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Seventh increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, approved). Ports the **dispatch (guidance-out) logic** — the channel that sends learnings/guidance back to agents — out of the reference Next.js handler (`the-portal/pages/api/instar/dispatches/index.ts`) into framework-agnostic TypeScript at `src/feedback-factory/dispatch/dispatch.ts`.
+
+Includes the dispatch type/priority vocabulary + validators, the semver comparison used for version-compat filtering (an agent only receives a dispatch whose version window includes its version), and the title normalization used to dedup on create. Pure functions; **not wired into any route yet** — no behavioral change.
+
+## What to Tell Your User
+
+- The "send guidance back to agents" side of the feedback loop is now ported too — including the version-targeting logic that makes sure a piece of guidance only reaches the agent versions it applies to.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Dispatch logic (TS port) | Internal module `src/feedback-factory/dispatch/dispatch.ts` — not yet wired |
+
+## Evidence
+
+- Reference is TypeScript, so equivalence is by faithful transcription plus exhaustive both-sides-of-boundary tests (9 unit tests): semver comparison at equal/greater/lesser across all three components; the version-compat filter with min-only, max-only, both-bounds, and unbounded dispatches (boundaries inclusive); unparseable version → treated as 0.0.0; title trim + 500-char cap. The comparison loop, inclusive-equal semantics, and the filter predicate are copied verbatim from the reference.

--- a/upgrades/side-effects/feedback-factory-dispatch.md
+++ b/upgrades/side-effects/feedback-factory-dispatch.md
@@ -1,0 +1,31 @@
+# Side-Effects Review — dispatch (guidance-out) logic (Phase 1, increment 7)
+
+**Slug:** `feedback-factory-dispatch`
+**Date:** `2026-05-27`
+**Author:** Echo (autonomous)
+**Spec:** `docs/specs/feedback-factory-migration.md` (converged v2, approved by Justin 2026-05-26)
+**Scope:** The pure logic of the dispatch endpoint (the channel that sends guidance back out to agents) — type/priority vocab, semver version-compat filtering, and the create-dedup title normalization. NOT the HTTP wiring/storage (app-placement decision, blocked).
+
+## Summary of the change
+
+Ports the pure logic of `the-portal/pages/api/instar/dispatches/index.ts` into `src/feedback-factory/dispatch/dispatch.ts`: the dispatch `DISPATCH_TYPES`/`DISPATCH_PRIORITIES` vocab + validators, `parseVersion`/`isVersionGte`/`isVersionLte` (the semver comparison), `filterDispatchesForVersion` (an agent only receives a dispatch whose `[minVersion, maxVersion]` window includes its version), and `normalizeDispatchTitle` (trim + 500-char cap, used for create-dedup). **Not wired into any route yet** — no behavioral change.
+
+## Equivalence verification
+
+Reference is TypeScript, so equivalence is by faithful transcription + exhaustive both-sides-of-boundary unit tests (9): semver compare at equal/greater/lesser across all three components; the version-compat filter with min-only / max-only / both-bounds / unbounded, boundaries inclusive; unparseable version → `[0,0,0]`; title trim + 500 cap. The comparison loop, the inclusive-equal semantics, and the filter predicate are copied verbatim from the reference.
+
+## Seven-dimension review
+
+1. **Over/under-reach** — Pure functions, no I/O, no state, not imported by any runtime path.
+2. **Level-of-abstraction fit** — `src/feedback-factory/dispatch/` — the dispatch layer. HTTP/storage excluded (the blocked app-placement decision); this is the reusable core.
+3. **Signal vs Authority** — N/A; pure filters/validators.
+4. **Interactions** — None. New isolated module; nothing imports it yet.
+5. **Rollback cost** — Trivial: delete the module + tests.
+6. **Migration parity** — N/A. New internal library code; no agent-installed file touched.
+7. **Failure modes** — (a) Semver-compare divergence (esp. inclusive-equal + multi-component ordering) → covered by both-direction tests across all components. (b) Unparseable version handling → tested ([0,0,0] fallback matches the reference, so a garbage version is treated as 0.0.0). (c) Title-dedup divergence → trim+slice(500) transcribed + tested.
+
+## Tests
+
+- Tier-1 unit (CI): `tests/unit/feedback-factory/dispatch.test.ts` — 9 tests (vocab, parseVersion, gte/lte, version-compat filter boundaries, title normalization).
+- No cross-runtime parity harness (reference is TS; equivalence by transcription + boundary tests).
+- No integration/E2E this increment: HTTP wiring/storage is the blocked app-placement decision; this logic attaches to a route when that's decided. Reasoned, documented.


### PR DESCRIPTION
Seventh increment of the approved **Feedback Factory Migration** (`docs/specs/feedback-factory-migration.md`).

## Summary
Ports the pure logic of `the-portal/pages/api/instar/dispatches/index.ts` → `src/feedback-factory/dispatch/dispatch.ts`: dispatch type/priority vocab + validators, `parseVersion`/`isVersionGte`/`isVersionLte` (semver compare), `filterDispatchesForVersion` (an agent only receives a dispatch whose `[minVersion, maxVersion]` window includes its version), and `normalizeDispatchTitle` (trim + 500-cap dedup). **Not wired into any route yet.**

## Why this is safe / verified
- Reference is TypeScript → equivalence by faithful transcription + 9 both-sides-of-boundary unit tests: semver compare equal/greater/lesser across all components; version-compat filter with min-only / max-only / both / unbounded (boundaries inclusive); unparseable version → 0.0.0; title trim + 500-cap.

## Tests
- Tier-1 unit (CI): `tests/unit/feedback-factory/dispatch.test.ts` — 9 tests.
- No integration/E2E this increment — HTTP wiring/storage is the blocked app-placement decision (reasoned in the side-effects artifact).

## Test plan
- [x] `npm run test:push` green (999 files / 18,717 tests)
- [ ] CI green