### PR TITLE
feat(feedback-factory): port the auto-reopen-on-regression decision to TS (Phase 1, increment 8)

### DIFF
--- a/src/feedback-factory/processor/reopen.ts
+++ b/src/feedback-factory/processor/reopen.ts
@@ -1,0 +1,58 @@
+/**
+ * reopen.ts — TS port of the auto-reopen-on-regression decision.
+ *
+ * Ports the decision embedded in cmd_apply_clusters (the-portal/.claude/scripts/
+ * feedback-processor.py, the regression branch ~:1543) out of the DB-write code
+ * into a pure function. When the clustering driver (cluster.ts) merges a new
+ * report into a cluster that was already fixed/resolved/deferred (a "possible
+ * regression" note), the cluster is auto-reopened. This computes the reopen
+ * outcome from the cluster's prior status:
+ *
+ *   - deferred  → AGED-REOPEN  → status 'new',          annotate actionTaken,   no recurrence bump
+ *   - otherwise → REGRESSION   → status 'investigating', annotate researchNotes, bump recurrenceCount
+ *
+ * The DB writes (the prisma update with `{ increment: 1 }` etc.) stay in the
+ * adapter; this is the pure decision + the audit-note text. `now` is injected.
+ * Reference is interleaved with DB I/O, so equivalence is by faithful
+ * transcription + exhaustive unit tests (no clean isolated reference function to
+ * run a cross-runtime harness against).
+ */
+
+import type { Cluster } from './types.js';
+
+export interface ReopenDecision {
+  /** New lifecycle status to set on the reopened cluster. */
+  newStatus: 'new' | 'investigating';
+  /** Whether to bump recurrenceCount (chronic-regression accounting; NOT for aged-reopen). */
+  bumpRecurrence: boolean;
+  /** Which cluster field the audit note is appended to. */
+  annotateField: 'actionTaken' | 'researchNotes';
+  /** The note tag. */
+  noteTag: 'AGED-REOPEN' | 'REGRESSION';
+  /** The audit note appended to the chosen field. */
+  note: string;
+}
+
+/**
+ * Compute the auto-reopen outcome for a cluster being merged into on a regression.
+ * `wasStatus` is the cluster's status before reopen; `feedbackId` is the incoming
+ * report; `now` is the injected ISO timestamp (reference uses new Date().toISOString()).
+ */
+export function computeReopen(cluster: Cluster, feedbackId: string, now: string): ReopenDecision {
+  const wasStatus = cluster.status ?? null;
+  const isAged = wasStatus === 'deferred';
+  const newStatus: 'new' | 'investigating' = isAged ? 'new' : 'investigating';
+  const noteTag: 'AGED-REOPEN' | 'REGRESSION' = isAged ? 'AGED-REOPEN' : 'REGRESSION';
+  const fixedInVersion = (cluster.fixedInVersion as string) || 'n/a';
+
+  // Verbatim from the reference's regressionNote template.
+  const note = `[${noteTag} ${now}] New report matched cluster previously marked '${wasStatus}' (fixedInVersion=${fixedInVersion}). Auto-reopened to '${newStatus}' for review. Report: ${feedbackId}`;
+
+  return {
+    newStatus,
+    bumpRecurrence: !isAged,
+    annotateField: isAged ? 'actionTaken' : 'researchNotes',
+    noteTag,
+    note,
+  };
+}

--- a/tests/unit/feedback-factory/reopen.test.ts
+++ b/tests/unit/feedback-factory/reopen.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests (Tier 1) — auto-reopen-on-regression decision.
+ *
+ * Reference is interleaved with DB writes, so equivalence is by faithful
+ * transcription + both-sides-of-boundary tests (deferred=aged vs others=regression).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeReopen } from '../../../src/feedback-factory/processor/reopen.js';
+import type { Cluster } from '../../../src/feedback-factory/processor/types.js';
+
+const NOW = '2026-05-27T00:00:00.000Z';
+const cluster = (extra: Partial<Cluster>): Cluster => ({ clusterId: 'c', title: 't', description: 'd', ...extra });
+
+describe('computeReopen', () => {
+  it('deferred → AGED-REOPEN: status new, annotate actionTaken, no recurrence bump', () => {
+    const d = computeReopen(cluster({ status: 'deferred' }), 'fb-1', NOW);
+    expect(d.newStatus).toBe('new');
+    expect(d.noteTag).toBe('AGED-REOPEN');
+    expect(d.annotateField).toBe('actionTaken');
+    expect(d.bumpRecurrence).toBe(false);
+  });
+
+  it('fixed → REGRESSION: status investigating, annotate researchNotes, bump recurrence', () => {
+    const d = computeReopen(cluster({ status: 'fixed', fixedInVersion: '1.2.3' }), 'fb-2', NOW);
+    expect(d.newStatus).toBe('investigating');
+    expect(d.noteTag).toBe('REGRESSION');
+    expect(d.annotateField).toBe('researchNotes');
+    expect(d.bumpRecurrence).toBe(true);
+  });
+
+  it('resolved → REGRESSION (same as fixed)', () => {
+    const d = computeReopen(cluster({ status: 'resolved' }), 'fb-3', NOW);
+    expect(d.newStatus).toBe('investigating');
+    expect(d.bumpRecurrence).toBe(true);
+  });
+
+  it('templates the audit note verbatim (tag, time, prior status, fixedInVersion, new status, report)', () => {
+    const d = computeReopen(cluster({ status: 'fixed', fixedInVersion: '1.2.3' }), 'fb-9', NOW);
+    expect(d.note).toBe(
+      `[REGRESSION ${NOW}] New report matched cluster previously marked 'fixed' (fixedInVersion=1.2.3). Auto-reopened to 'investigating' for review. Report: fb-9`,
+    );
+  });
+
+  it('falls back to fixedInVersion=n/a when absent', () => {
+    const d = computeReopen(cluster({ status: 'deferred' }), 'fb-4', NOW);
+    expect(d.note).toContain('fixedInVersion=n/a');
+    expect(d.note).toContain("previously marked 'deferred'");
+    expect(d.note).toContain("Auto-reopened to 'new'");
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,23 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Eighth increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, approved). Ports the **auto-reopen-on-regression decision** from the reference Python (`cmd_apply_clusters` in `the-portal/.claude/scripts/feedback-processor.py`) into a pure function at `src/feedback-factory/processor/reopen.ts`.
+
+When a new report gets grouped onto a bug that was already marked fixed, resolved, or deferred, the bug is automatically reopened for review. This computes how: a long-deferred bug becomes "new" again (an aged-reopen, logged on its action trail); a fixed/resolved bug becomes "investigating" again and bumps its recurrence counter (a regression, logged on its research notes). It also writes the exact audit note. Pure function; **not wired into any route or job yet** — no behavioral change.
+
+## What to Tell Your User
+
+- The safety behavior that catches a bug "coming back from the dead" — a report landing on an already-fixed bug auto-reopens it instead of silently swallowing it — is now ported, including the audit note that records why it reopened.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Auto-reopen decision (TS port) | Internal module `src/feedback-factory/processor/reopen.ts` — not yet wired |
+
+## Evidence
+
+- The decision is interleaved with database writes in the reference, so equivalence is by faithful transcription plus both-sides-of-boundary unit tests (5): the deferred (aged-reopen) branch vs the fixed/resolved (regression) branch — each asserting the right new status, which field gets annotated, and whether the recurrence counter bumps — plus the audit-note string asserted verbatim and the `fixedInVersion=n/a` fallback.

--- a/upgrades/side-effects/feedback-factory-reopen.md
+++ b/upgrades/side-effects/feedback-factory-reopen.md
@@ -1,0 +1,31 @@
+# Side-Effects Review — auto-reopen-on-regression decision (Phase 1, increment 8)
+
+**Slug:** `feedback-factory-reopen`
+**Date:** `2026-05-27`
+**Author:** Echo (autonomous)
+**Spec:** `docs/specs/feedback-factory-migration.md` (converged v2, approved by Justin 2026-05-26)
+**Scope:** The pure auto-reopen DECISION (which status/field/recurrence-bump + audit note) extracted from the regression branch of `cmd_apply_clusters`. The prisma writes stay in the (later) store adapter.
+
+## Summary of the change
+
+Ports the auto-reopen-on-regression decision into `src/feedback-factory/processor/reopen.ts` as the pure `computeReopen(cluster, feedbackId, now)`. When the clustering driver merges a report into a fixed/resolved/deferred cluster (a "possible regression"), the cluster is auto-reopened: `deferred → AGED-REOPEN → status 'new', annotate actionTaken, no recurrence bump`; otherwise `REGRESSION → status 'investigating', annotate researchNotes, bump recurrenceCount`. Also templates the audit note verbatim. `now` injected. **Not wired into any route/job yet.**
+
+## Equivalence verification
+
+The decision is interleaved with DB writes in the reference, so equivalence is by faithful transcription + both-sides-of-boundary unit tests (5): deferred vs fixed vs resolved → correct status/field/tag/recurrence; the audit-note string asserted verbatim (tag, time, prior status, `fixedInVersion`, new status, report id); `fixedInVersion=n/a` fallback.
+
+## Seven-dimension review
+
+1. **Over/under-reach** — Pure function, no I/O, no state, not imported by any runtime path. Returns the decision + note; the caller (store adapter) does the prisma update.
+2. **Level-of-abstraction fit** — Processor-logic layer, alongside cluster/transition/verify. The DB write (`{ increment: 1 }`, field append) is correctly left to the adapter.
+3. **Signal vs Authority** — N/A; produces a decision. The reopen is itself a legitimate guard (regression must not stay marked fixed) that exists in the reference.
+4. **Interactions** — None. New isolated module; nothing imports it yet. Pairs conceptually with `cluster.ts` (which emits the regression merge-note) but no code coupling yet.
+5. **Rollback cost** — Trivial: delete the module + tests.
+6. **Migration parity** — N/A. New internal library code; no agent-installed file touched.
+7. **Failure modes** — (a) Wrong field/status/recurrence per prior-status → both-sides tests. (b) Audit-note drift → asserted verbatim. (c) `now` non-determinism → injected.
+
+## Tests
+
+- Tier-1 unit (CI): `tests/unit/feedback-factory/reopen.test.ts` — 5 tests (aged vs regression branches, resolved, verbatim note, n/a fallback).
+- No cross-runtime parity harness (decision interleaved with DB writes in the reference; equivalence by transcription + boundary tests).
+- No integration/E2E this increment: not wired; attaches when the apply/store layer lands. Reasoned, documented.


### PR DESCRIPTION
Eighth increment of the approved **Feedback Factory Migration** (`docs/specs/feedback-factory-migration.md`).

## Summary
Ports the auto-reopen decision from `cmd_apply_clusters` → pure `computeReopen()` at `src/feedback-factory/processor/reopen.ts`. Merging a report into a fixed/resolved/deferred cluster auto-reopens it: `deferred → AGED-REOPEN` (status `new`, annotate `actionTaken`, no recurrence bump); else `REGRESSION` (status `investigating`, annotate `researchNotes`, bump `recurrenceCount`). Templates the audit note verbatim; `now` injected. The prisma writes stay in the (later) adapter. **Not wired.**

## Why this is safe / verified
- Decision interleaved with DB writes in the reference → equivalence by transcription + 5 both-sides-of-boundary unit tests (aged vs regression branches, resolved, verbatim audit note, `fixedInVersion=n/a` fallback).

## Tests
- Tier-1 unit (CI): `tests/unit/feedback-factory/reopen.test.ts` — 5 tests.
- No integration/E2E this increment — attaches when the apply/store layer lands (reasoned in the side-effects artifact).

## Test plan
- [x] `npm run test:push` (feedback-factory green; 2 unrelated full-run flakes — token-ledger async-yield + middleware-internal-auth — both pass 24/24 in isolation; CI shards clean)
- [ ] CI green