### PR TITLE
feat(feedback-factory): store seam + processing composition + observability (Phase 1, increment 9)

### DIFF
--- a/src/feedback-factory/processor/process.ts
+++ b/src/feedback-factory/processor/process.ts
@@ -1,0 +1,57 @@
+/**
+ * process.ts — the feedback-factory processing composition.
+ *
+ * Ties the already-parity'd pure pieces together over a FeedbackStore, mirroring
+ * the reference's cmd_cluster (decide) + cmd_apply_clusters (write) run back-to-back:
+ *
+ *   1. read unprocessed items + active clusters from the store
+ *   2. clusterItems() decides merge/create per item (parity'd, increment 4)
+ *   3. apply each decision to the store (create / merge); when a merge carries a
+ *      "possible regression" note, computeReopen() (parity'd, increment 8) decides
+ *      the reopen and applyReopen writes it
+ *   4. mark each item processed; counters update for observability
+ *
+ * The decision logic is already proven equivalent to the reference; this is the
+ * orchestration over the injected store, verified by the Tier-2 integration test
+ * against InMemoryFeedbackStore.
+ */
+
+import { clusterItems } from './cluster.js';
+import { computeReopen } from './reopen.js';
+import type { ClusterResult } from './types.js';
+import type { FeedbackStore, FeedbackMetrics } from '../store/FeedbackStore.js';
+
+export interface ProcessResult {
+  results: ClusterResult[];
+  metrics: FeedbackMetrics;
+}
+
+/** Run one clustering+apply pass over the store. `now` injected for the reopen audit note. */
+export function processUnprocessed(store: FeedbackStore, now: string): ProcessResult {
+  const items = store.getUnprocessedFeedback();
+  const clusters = store.getActiveClusters();
+  const itemById = new Map(items.map((i) => [i.feedbackId, i]));
+
+  const results = clusterItems(items, clusters);
+
+  for (const r of results) {
+    const item = itemById.get(r.feedbackId);
+    if (!item) continue;
+
+    if (r.action === 'create') {
+      store.upsertClusterFromItem(r.clusterId, item);
+    } else {
+      store.mergeIntoCluster(r.clusterId, item);
+      // A merge that flagged a possible regression auto-reopens the cluster.
+      if (r.note && r.note.includes('possible regression')) {
+        const cluster = store.getCluster(r.clusterId);
+        if (cluster) {
+          store.applyReopen(r.clusterId, computeReopen(cluster, r.feedbackId, now));
+        }
+      }
+    }
+    store.markProcessed(r.feedbackId, r.clusterId);
+  }
+
+  return { results, metrics: store.metrics() };
+}

--- a/src/feedback-factory/store/FeedbackStore.ts
+++ b/src/feedback-factory/store/FeedbackStore.ts
@@ -1,0 +1,119 @@
+/**
+ * FeedbackStore.ts — the data-access seam for the feedback factory.
+ *
+ * The ported processor logic (fingerprint / similarity / cluster / verify /
+ * reopen) is pure; the *stateful* operations (read unprocessed items, read active
+ * clusters, create/merge/reopen clusters, mark processed, count) live behind this
+ * interface so the canonical instance's real adapter (Prisma cloud DB — the
+ * blocked, credentials-gated piece) is a thin shim, while everything is buildable
+ * and testable today against `InMemoryFeedbackStore`.
+ *
+ * This is the dependency-injection boundary called out in the migration spec:
+ * front → Vercel, processor → Instar job, DB → cloud (Prisma). The interface
+ * shape is driven by what the ported drivers + the composition (process.ts) need.
+ */
+
+import type { FeedbackItem, Cluster, ClusterResult } from '../processor/types.js';
+import type { ReopenDecision } from '../processor/reopen.js';
+
+/** Read-only observability counters for the capture→cluster→reopen loop (spec §2.7). */
+export interface FeedbackMetrics {
+  captured: number;
+  created: number;
+  merged: number;
+  reopened: number;
+}
+
+export interface FeedbackStore {
+  /** Unprocessed feedback, oldest first (mirrors the reference's `status:'unprocessed'` query). */
+  getUnprocessedFeedback(): FeedbackItem[];
+  /** Active clusters (status != 'resolved'), the merge candidates. */
+  getActiveClusters(): Cluster[];
+  getCluster(clusterId: string): Cluster | undefined;
+  /** Create a new cluster from an item (or bump reportCount if it already exists). */
+  upsertClusterFromItem(clusterId: string, item: FeedbackItem): void;
+  /** Merge an item into an existing cluster (bump reportCount). */
+  mergeIntoCluster(clusterId: string, item: FeedbackItem): void;
+  /** Apply an auto-reopen decision (status, recurrence bump, audit-note append). */
+  applyReopen(clusterId: string, decision: ReopenDecision): void;
+  /** Mark a feedback item processed + linked to its cluster. */
+  markProcessed(feedbackId: string, clusterId: string): void;
+  metrics(): FeedbackMetrics;
+}
+
+/**
+ * In-memory FeedbackStore — the test/reference implementation. Faithfully mirrors
+ * the reference's create/merge/reopen field mutations (reportCount increment,
+ * recurrenceCount bump on regression, status change, note append) so the
+ * composition can be integration-tested without a database.
+ */
+export class InMemoryFeedbackStore implements FeedbackStore {
+  private feedback = new Map<string, FeedbackItem>();
+  private clusters = new Map<string, Cluster>();
+  private counts: FeedbackMetrics = { captured: 0, created: 0, merged: 0, reopened: 0 };
+
+  constructor(seed?: { feedback?: FeedbackItem[]; clusters?: Cluster[] }) {
+    for (const f of seed?.feedback ?? []) this.feedback.set(f.feedbackId, { status: 'unprocessed', ...f });
+    for (const c of seed?.clusters ?? []) this.clusters.set(c.clusterId, { ...c });
+  }
+
+  getUnprocessedFeedback(): FeedbackItem[] {
+    return [...this.feedback.values()]
+      .filter((f) => (f.status ?? 'unprocessed') === 'unprocessed')
+      .sort((a, b) => String(a.receivedAt ?? '').localeCompare(String(b.receivedAt ?? '')));
+  }
+
+  getActiveClusters(): Cluster[] {
+    return [...this.clusters.values()].filter((c) => c.status !== 'resolved');
+  }
+
+  getCluster(clusterId: string): Cluster | undefined {
+    return this.clusters.get(clusterId);
+  }
+
+  upsertClusterFromItem(clusterId: string, item: FeedbackItem): void {
+    const existing = this.clusters.get(clusterId);
+    if (existing) {
+      existing.reportCount = (existing.reportCount ?? 0) + 1;
+    } else {
+      this.clusters.set(clusterId, {
+        clusterId, title: item.title, description: item.description, type: item.type, reportCount: 1,
+      });
+      this.counts.created++;
+    }
+  }
+
+  mergeIntoCluster(clusterId: string, _item: FeedbackItem): void {
+    const c = this.clusters.get(clusterId);
+    if (c) c.reportCount = (c.reportCount ?? 0) + 1;
+    this.counts.merged++;
+  }
+
+  applyReopen(clusterId: string, decision: ReopenDecision): void {
+    const c = this.clusters.get(clusterId);
+    if (!c) return;
+    c.status = decision.newStatus;
+    if (decision.bumpRecurrence) c.recurrenceCount = (c.recurrenceCount ?? 0) + 1;
+    const field = decision.annotateField;
+    const prior = (c[field] as string) ? `${c[field]}\n\n` : '';
+    c[field] = prior + decision.note;
+    this.counts.reopened++;
+  }
+
+  markProcessed(feedbackId: string, clusterId: string): void {
+    const f = this.feedback.get(feedbackId);
+    if (f) { f.status = 'processing'; f.clusterId = clusterId; }
+    this.counts.captured++;
+  }
+
+  metrics(): FeedbackMetrics {
+    return { ...this.counts };
+  }
+
+  /** Test helper: snapshot all clusters. */
+  allClusters(): Cluster[] {
+    return [...this.clusters.values()].map((c) => ({ ...c }));
+  }
+}
+
+export type { ClusterResult };

--- a/tests/integration/feedback-factory-process.test.ts
+++ b/tests/integration/feedback-factory-process.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Integration test (Tier 2) — feedback-factory processing composition.
+ *
+ * Exercises the assembled pipeline end-to-end over the real InMemoryFeedbackStore:
+ * read unprocessed → clusterItems (decide) → apply (create/merge) → computeReopen
+ * on regression → markProcessed → observability counters. The constituent decision
+ * logic is each parity-verified against the reference (increments 4 + 8); this test
+ * proves they COMPOSE correctly over the data-access seam.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { InMemoryFeedbackStore } from '../../src/feedback-factory/store/FeedbackStore.js';
+import { processUnprocessed } from '../../src/feedback-factory/processor/process.js';
+
+const NOW = '2026-05-27T00:00:00.000Z';
+const item = (id: string, title: string, description: string, receivedAt: string) =>
+  ({ feedbackId: id, title, description, type: 'bug', receivedAt });
+
+describe('processUnprocessed — full clustering + reopen pipeline over the store', () => {
+  it('creates new clusters, merges duplicates, and counts them', () => {
+    const store = new InMemoryFeedbackStore({
+      feedback: [
+        item('fb-1', 'gitsync pull fails intermittently', 'times out under load', '2026-05-01T00:00:00Z'),
+        item('fb-2', 'gitsync pull fails intermittently', 'times out under load', '2026-05-01T01:00:00Z'),
+        item('fb-3', 'totally separate telemetry export bug', 'csv drops a row', '2026-05-01T02:00:00Z'),
+      ],
+    });
+
+    const { results, metrics } = processUnprocessed(store, NOW);
+
+    expect(results[0].action).toBe('create'); // fb-1 → new cluster
+    expect(results[1].action).toBe('merge');  // fb-2 → fb-1's cluster (order-dependent)
+    expect(results[1].clusterId).toBe(results[0].clusterId);
+    expect(results[2].action).toBe('create'); // fb-3 → its own cluster
+
+    expect(metrics.created).toBe(2);
+    expect(metrics.merged).toBe(1);
+    expect(metrics.captured).toBe(3); // all three marked processed
+    // every item is now processed
+    expect(store.getUnprocessedFeedback()).toHaveLength(0);
+  });
+
+  it('auto-reopens a fixed cluster on a regression and bumps recurrence', () => {
+    const store = new InMemoryFeedbackStore({
+      clusters: [{ clusterId: 'c-auth', title: 'auth token refresh broken', description: 'returns 401 after expiry', status: 'fixed', fixedInVersion: '1.2.3' }],
+      feedback: [item('fb-9', 'auth token refresh broken', 'returns 401 after expiry', '2026-05-02T00:00:00Z')],
+    });
+
+    const { results, metrics } = processUnprocessed(store, NOW);
+
+    expect(results[0].action).toBe('merge');
+    expect(results[0].note).toContain('possible regression');
+    expect(metrics.reopened).toBe(1);
+
+    const c = store.getCluster('c-auth')!;
+    expect(c.status).toBe('investigating');       // reopened from 'fixed'
+    expect(c.recurrenceCount).toBe(1);            // regression bumps recurrence
+    expect(c.researchNotes).toContain('REGRESSION');
+    expect(c.researchNotes).toContain('fb-9');
+  });
+
+  it('applies the 0.55 false-merge guard: a mid-similarity item does NOT merge into a fixed cluster', () => {
+    const store = new InMemoryFeedbackStore({
+      clusters: [{ clusterId: 'c-fixed', title: 'alpha beta gamma delta', description: '', status: 'fixed' }],
+      feedback: [item('fb-1', 'alpha beta epsilon zeta', '', '2026-05-02T00:00:00Z')],
+    });
+    const { results, metrics } = processUnprocessed(store, NOW);
+    expect(results[0].action).toBe('create');     // blocked by the higher fixed threshold
+    expect(metrics.reopened).toBe(0);
+  });
+
+  it('is a no-op with empty input', () => {
+    const store = new InMemoryFeedbackStore();
+    const { results, metrics } = processUnprocessed(store, NOW);
+    expect(results).toEqual([]);
+    expect(metrics).toEqual({ captured: 0, created: 0, merged: 0, reopened: 0 });
+  });
+});

--- a/tests/unit/feedback-factory/store.test.ts
+++ b/tests/unit/feedback-factory/store.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests (Tier 1) — InMemoryFeedbackStore data-access seam.
+ *
+ * Verifies the store's create/merge/reopen field mutations mirror the reference,
+ * and the read filters (unprocessed-only, oldest-first; active = not resolved).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { InMemoryFeedbackStore } from '../../../src/feedback-factory/store/FeedbackStore.js';
+import type { ReopenDecision } from '../../../src/feedback-factory/processor/reopen.js';
+
+const item = (id: string, extra = {}) => ({ feedbackId: id, title: `t-${id}`, description: `d-${id}`, type: 'bug', ...extra });
+
+describe('InMemoryFeedbackStore', () => {
+  it('returns unprocessed feedback oldest-first, excluding processed', () => {
+    const s = new InMemoryFeedbackStore({ feedback: [
+      item('fb-2', { receivedAt: '2026-05-02T00:00:00Z' }),
+      item('fb-1', { receivedAt: '2026-05-01T00:00:00Z' }),
+      item('fb-done', { receivedAt: '2026-05-03T00:00:00Z', status: 'processing' }),
+    ]});
+    expect(s.getUnprocessedFeedback().map(f => f.feedbackId)).toEqual(['fb-1', 'fb-2']);
+  });
+
+  it('getActiveClusters excludes resolved', () => {
+    const s = new InMemoryFeedbackStore({ clusters: [
+      { clusterId: 'c-open', title: 'o', description: 'd', status: 'investigating' },
+      { clusterId: 'c-res', title: 'r', description: 'd', status: 'resolved' },
+    ]});
+    expect(s.getActiveClusters().map(c => c.clusterId)).toEqual(['c-open']);
+  });
+
+  it('upsertClusterFromItem creates then bumps reportCount + created counter', () => {
+    const s = new InMemoryFeedbackStore();
+    s.upsertClusterFromItem('c1', item('fb-1'));
+    expect(s.getCluster('c1')?.reportCount).toBe(1);
+    expect(s.metrics().created).toBe(1);
+    s.upsertClusterFromItem('c1', item('fb-2'));
+    expect(s.getCluster('c1')?.reportCount).toBe(2);
+    expect(s.metrics().created).toBe(1); // not created again
+  });
+
+  it('mergeIntoCluster bumps reportCount + merged counter', () => {
+    const s = new InMemoryFeedbackStore({ clusters: [{ clusterId: 'c1', title: 't', description: 'd', reportCount: 3 }] });
+    s.mergeIntoCluster('c1', item('fb-1'));
+    expect(s.getCluster('c1')?.reportCount).toBe(4);
+    expect(s.metrics().merged).toBe(1);
+  });
+
+  it('applyReopen sets status, bumps recurrence (when decided), appends the audit note', () => {
+    const s = new InMemoryFeedbackStore({ clusters: [{ clusterId: 'c1', title: 't', description: 'd', status: 'fixed' }] });
+    const decision: ReopenDecision = { newStatus: 'investigating', bumpRecurrence: true, annotateField: 'researchNotes', noteTag: 'REGRESSION', note: 'NOTE-A' };
+    s.applyReopen('c1', decision);
+    const c = s.getCluster('c1')!;
+    expect(c.status).toBe('investigating');
+    expect(c.recurrenceCount).toBe(1);
+    expect(c.researchNotes).toBe('NOTE-A');
+    expect(s.metrics().reopened).toBe(1);
+    // second reopen appends with a blank-line separator
+    s.applyReopen('c1', { ...decision, note: 'NOTE-B' });
+    expect(c.researchNotes).toBe('NOTE-A\n\nNOTE-B');
+    expect(c.recurrenceCount).toBe(2);
+  });
+
+  it('aged-reopen does not bump recurrence', () => {
+    const s = new InMemoryFeedbackStore({ clusters: [{ clusterId: 'c1', title: 't', description: 'd', status: 'deferred' }] });
+    s.applyReopen('c1', { newStatus: 'new', bumpRecurrence: false, annotateField: 'actionTaken', noteTag: 'AGED-REOPEN', note: 'N' });
+    expect(s.getCluster('c1')?.recurrenceCount).toBeUndefined();
+    expect(s.getCluster('c1')?.actionTaken).toBe('N');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Ninth increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, approved) — the piece that assembles the ported brain. Adds the data-access seam (`FeedbackStore` interface + an in-memory implementation) at `src/feedback-factory/store/`, the processing composition `processUnprocessed` at `src/feedback-factory/processor/process.ts` (which wires the already-ported clustering + auto-reopen together, mirroring the reference's "decide then apply" steps), and the factory's own observability counters (captured / created / merged / reopened).
+
+The real database adapter is a thin shim that implements the same interface — left for cutover since it needs cloud credentials and the hosting decision. **Nothing is wired into a route or job yet** — no behavioral change.
+
+## What to Tell Your User
+
+- The individual pieces of the feedback brain now snap together into one working pipeline (read new reports → group them → reopen regressions → count what happened), proven end-to-end against an in-memory test database.
+- It also keeps its own running tally — how many reports came in, how many new bug-piles were created, how many merged, how many reopened — the start of the factory's self-monitoring.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| FeedbackStore seam + in-memory store | `src/feedback-factory/store/FeedbackStore.ts` — the DB-adapter boundary (real adapter at cutover) |
+| Processing composition | `processUnprocessed(store, now)` in `src/feedback-factory/processor/process.ts` — not yet wired |
+| Observability counters | `store.metrics()` — captured / created / merged / reopened |
+
+## Evidence
+
+- The decision logic inside (clustering, auto-reopen) is each already proven identical to Dawn's original in earlier increments. This increment adds the integration-level proof that they **compose** correctly: a Tier-2 test runs the whole pipeline over a real in-memory store and asserts new clusters are created, duplicates merge (order-dependent), the false-merge guard blocks a mid-similarity merge into a fixed bug, a genuine regression auto-reopens (status → investigating, recurrence bumped, audit note written), the counters tally, and empty input is a clean no-op.

--- a/upgrades/side-effects/feedback-factory-store-compose.md
+++ b/upgrades/side-effects/feedback-factory-store-compose.md
@@ -1,0 +1,36 @@
+# Side-Effects Review — store seam + processing composition + observability (Phase 1, increment 9)
+
+**Slug:** `feedback-factory-store-compose`
+**Date:** `2026-05-27`
+**Author:** Echo (autonomous)
+**Spec:** `docs/specs/feedback-factory-migration.md` (converged v2, approved by Justin 2026-05-26)
+**Scope:** The data-access seam (`FeedbackStore` interface + `InMemoryFeedbackStore`), the processing composition (`processUnprocessed` = clusterItems + computeReopen over the store), and the observability counters. The REAL Prisma adapter + the HTTP/app placement remain the blocked, credentials/decision-gated pieces.
+
+## Summary of the change
+
+Adds:
+- `src/feedback-factory/store/FeedbackStore.ts` — the dependency-injection boundary (interface + `FeedbackMetrics` counters + `InMemoryFeedbackStore`).
+- `src/feedback-factory/processor/process.ts` — `processUnprocessed(store, now)`, which composes the already-parity'd pieces, mirroring the reference's `cmd_cluster` (decide) + `cmd_apply_clusters` (write) run back-to-back: read unprocessed + active clusters → `clusterItems` decides → apply create/merge → on a "possible regression" merge, `computeReopen` + `applyReopen` → mark processed → update counters.
+- Observability: the `FeedbackMetrics` surface (captured / created / merged / reopened) the store maintains (spec §2.7's "meter the loop", minimal form).
+
+This is the glue that assembles the ported brain. The real Prisma adapter is a thin shim that implements the same interface; **nothing is wired into a route/job yet** — no behavioral change.
+
+## Equivalence / verification
+
+The constituent decision logic (`clusterItems`, `computeReopen`) is each already parity-verified against the reference (increments 4 + 8). This increment adds the **Tier-2 integration test** proving they COMPOSE correctly over the data seam: new clusters created, duplicates merged (order-dependent), the 0.55 false-merge guard blocks a mid-similarity merge into a fixed cluster, a real regression auto-reopens (status → investigating, recurrence bump, audit note), counters tally, and empty input is a no-op. `InMemoryFeedbackStore`'s field mutations (reportCount increment, recurrence bump on regression, note append with blank-line separator) mirror the reference's prisma `update` shapes.
+
+## Seven-dimension review
+
+1. **Over/under-reach** — Pure logic + an in-memory store; not wired to any route/job. The interface is shaped by what the ported drivers + composition need (not speculative). `InMemoryFeedbackStore` mutates only its own Maps.
+2. **Level-of-abstraction fit** — `store/` is the data-access layer; `process.ts` is the composition; the real DB adapter (Prisma) implements the interface later. Correct seam — the blocked app/DB decisions sit cleanly behind it.
+3. **Signal vs Authority** — The composition applies the decisions the parity'd pieces produce; the evidence gate / curated lifecycle still hold terminal authority (unchanged). Counters are read-only observability.
+4. **Interactions** — First module to IMPORT the others (`cluster`, `reopen`, `types`) — but only in `process.ts`, which nothing else imports yet. No runtime path touched.
+5. **Rollback cost** — Trivial: delete the store + process + tests. Additive.
+6. **Migration parity** — N/A. New internal library code; no agent-installed file touched. (The real-adapter wiring + sender repoint are the separate Migration-Parity'd cutover steps, blocked.)
+7. **Failure modes** — (a) Composition mis-wires create vs merge vs reopen → the Tier-2 integration test covers all branches. (b) Order-dependence lost → integration test asserts fb-2 merges fb-1's fresh cluster. (c) Reopen not triggered on regression → asserted (status/recurrence/note). (d) Counter drift → asserted per-branch + empty-input no-op.
+
+## Tests
+
+- Tier-1 unit (CI): `tests/unit/feedback-factory/store.test.ts` — 6 tests (read filters, create/merge/reopen mutations, aged vs regression recurrence).
+- **Tier-2 integration (CI): `tests/integration/feedback-factory-process.test.ts` — 4 tests** composing the full pipeline over the real `InMemoryFeedbackStore` (the integration tier the pure-logic increments deferred until a store existed).
+- E2E (feature-alive) attaches when the processor job + canonical front are wired — that's gated on the blocked app-placement + Prisma-adapter decisions. Reasoned, documented.


### PR DESCRIPTION
Ninth + capstone increment of the approved **Feedback Factory Migration** (`docs/specs/feedback-factory-migration.md`) — assembles the ported brain.

## Summary
- `FeedbackStore` interface + `FeedbackMetrics` counters + `InMemoryFeedbackStore` (the DB dependency-injection boundary; real Prisma adapter is a thin shim at cutover).
- `processUnprocessed(store, now)` — composes the already-parity'd `clusterItems` + `computeReopen` over the store, mirroring the reference's `cmd_cluster` (decide) + `cmd_apply_clusters` (write).
- Observability counters (captured / created / merged / reopened) — spec §2.7, minimal form.
**Nothing wired into a route/job yet** — no behavioral change.

## Why this is safe / verified
- The decision logic inside is each already parity-verified (increments 4 + 8). This adds the **Tier-2 integration tier** (deferred by the pure-logic increments until a store existed): `tests/integration/feedback-factory-process.test.ts` runs the whole pipeline over `InMemoryFeedbackStore` — create/merge (order-dependent), the 0.55 false-merge guard, regression auto-reopen (status→investigating + recurrence + note), counters, empty no-op.

## Tests
- Tier-1 unit (CI): `tests/unit/feedback-factory/store.test.ts` — 6 tests.
- Tier-2 integration (CI): `tests/integration/feedback-factory-process.test.ts` — 4 tests.

## Test plan
- [x] `npm run test:push` (feedback-factory green; 1 unrelated flake — `token-ledger > scanAllAsync`, a pre-existing timing-flaky test I didn't touch, non-deterministic even in isolation, passes on CI)
- [ ] CI green