### PR TITLE
fix(mentor): decouple ledger+runner init from TokenLedger (production 503 cascade)

### DIFF
--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -430,26 +430,33 @@ export class AgentServer {
           maxFilesPerScan: 500,
           yieldEveryNFiles: 25,
         });
-        // Framework-Onboarding Mentor System issue ledger — read-only
-        // observability, signal-only (never gates). Instantiated here at
-        // startup so its two tables auto-create on first boot of this version
-        // (spec §14.3 — no schema migration needed). Lazy/best-effort: a
-        // failure leaves the /framework-issues routes returning 503, never
-        // blocking server startup.
-        try {
-          this.frameworkIssueLedger = new FrameworkIssueLedger({
-            dbPath: path.join(serverDataDir, 'framework-issue-ledger.db'),
-          });
-          this.mentorRunner = this.buildMentorRunner(this.frameworkIssueLedger, options, serverDataDir);
-        } catch (err) {
-          console.warn('[instar] framework-issue-ledger init failed (non-fatal):', err);
-          this.frameworkIssueLedger = null;
-          this.mentorRunner = null;
-        }
       }
     } catch (err) {
       console.warn('[instar] token-ledger init failed (non-fatal):', err);
       this.tokenLedger = null;
+    }
+
+    // Framework-Onboarding Mentor System issue ledger — read-only observability,
+    // signal-only (never gates). Its two tables auto-create on first boot (spec
+    // §14.3 — no schema migration needed). DELIBERATELY in its OWN try/catch,
+    // independent of TokenLedger: a TokenLedger init failure (e.g. a stale
+    // token-ledger.db schema on an existing agent) must NOT cascade and take the
+    // mentor ledger + runner down with it. (Found in production: an agent whose
+    // TokenLedger threw `no such column: attribution_key` had the mentor routes
+    // 503 purely because the two were sequenced in one try block.)
+    if (options.config.stateDir) {
+      try {
+        const serverDataDir = path.join(options.config.stateDir, 'server-data');
+        fs.mkdirSync(serverDataDir, { recursive: true });
+        this.frameworkIssueLedger = new FrameworkIssueLedger({
+          dbPath: path.join(serverDataDir, 'framework-issue-ledger.db'),
+        });
+        this.mentorRunner = this.buildMentorRunner(this.frameworkIssueLedger, options, serverDataDir);
+      } catch (err) {
+        console.warn('[instar] framework-issue-ledger init failed (non-fatal):', err);
+        this.frameworkIssueLedger = null;
+        this.mentorRunner = null;
+      }
     }
 
     // Routes

--- a/tests/e2e/mentor-onboarding-lifecycle.test.ts
+++ b/tests/e2e/mentor-onboarding-lifecycle.test.ts
@@ -102,3 +102,58 @@ describe('Mentor-onboarding E2E lifecycle (alive + dormant)', () => {
     expect(body).toMatch(/^enabled:\s*false\s*$/m);
   });
 });
+
+describe('Mentor ledger survives a broken TokenLedger (regression: production cascade)', () => {
+  // Reproduces the exact production bug: an agent whose TokenLedger init throws
+  // (Echo's `no such column: attribution_key`) must NOT have the mentor ledger +
+  // runner taken down with it. Before the decoupling fix, both lived in one try
+  // block and a TokenLedger throw → /mentor + /framework-issues all 503.
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+  const AUTH = 'test-e2e-mentor-tokenledger-cascade';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mentor-cascade-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    const serverDataDir = path.join(stateDir, 'server-data');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.mkdirSync(serverDataDir, { recursive: true });
+    // Pre-plant a CORRUPT token-ledger.db so the real TokenLedger constructor
+    // throws on open — standing in for Echo's stale-schema failure.
+    fs.writeFileSync(path.join(serverDataDir, 'token-ledger.db'), 'this is not a sqlite database — corrupt on purpose');
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+
+    const config: InstarConfig = {
+      projectName: 'e2e', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH,
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    } as InstarConfig;
+
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir) });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/mentor-onboarding-lifecycle.test.ts:cascade' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('a corrupt token-ledger.db (TokenLedger fails) does NOT 503 the mentor surface', async () => {
+    // TokenLedger should be down, but the mentor ledger + runner are independent.
+    const status = await request(app).get('/mentor/status').set(auth());
+    expect(status.status).toBe(200); // NOT 503 — the cascade is broken
+    expect(status.body.enabled).toBe(false);
+
+    const fi = await request(app).get('/framework-issues').set(auth());
+    expect(fi.status).toBe(200); // ledger alive despite TokenLedger failure
+    expect(Array.isArray(fi.body.issues)).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,33 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Framework-Onboarding Mentor System — fault-isolate the ledger from TokenLedger init.** Found by
+deploying to a real server: the mentor issue-ledger and runner were constructed in the same
+try-block as the TokenLedger, so an agent whose TokenLedger init throws (e.g. a stale token-ledger.db
+schema — `no such column: attribution_key`) had its `/framework-issues` + `/mentor/*` routes return
+503 purely as collateral. Moved the mentor ledger + runner to their own independent try/catch, so a
+TokenLedger failure can no longer cascade. Tests use a fresh state dir where TokenLedger is healthy,
+which is why this only showed up on a real deploy.
+
+## What to Tell Your User
+
+- The mentor system now stays available even on agents whose (unrelated) token-usage ledger is in a
+  bad state — a real situation that was silently 503-ing the mentor routes.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Fault-isolated mentor init | Automatic — `/mentor/*` + `/framework-issues` survive a TokenLedger init failure |
+
+## Evidence
+
+Found in production (not a test gap): deployed the merged mentor system to a real server whose
+TokenLedger had been throwing `no such column: attribution_key` since 2026-05-25, and the mentor
+routes all returned 503 as collateral. Fix proven by an e2e regression that pre-plants a corrupt
+`token-ledger.db` (forcing the real TokenLedger constructor to fail) and asserts `/mentor/status` and
+`/framework-issues` return 200, not 503 — the cascade is broken. 7 mentor e2e tests; affected
+push-config suite green vs canonical main.

--- a/upgrades/side-effects/mentor-ledger-decouple.md
+++ b/upgrades/side-effects/mentor-ledger-decouple.md
@@ -1,0 +1,55 @@
+# Side-Effects Review — Decouple mentor ledger from TokenLedger init (production fix)
+
+**Spec:** `docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md` (converged 5 iters, approved by Justin)
+**Change:** The `FrameworkIssueLedger` + `MentorOnboardingRunner` construction was sequenced AFTER
+`new TokenLedger()` inside the SAME try block in `AgentServer`. If TokenLedger's constructor throws,
+the outer catch fires and the mentor ledger/runner never construct → `/framework-issues` + `/mentor/*`
+all return 503. Moved them to their OWN independent try/catch, so a TokenLedger failure can't cascade.
+**Files:** `src/server/AgentServer.ts`, `tests/e2e/mentor-onboarding-lifecycle.test.ts`, `upgrades/NEXT.md`.
+
+## How it was found
+
+Deployed the merged mentor system to Echo's real server (v1.3.22) and hit the routes — all 503.
+Echo's TokenLedger has thrown `SqliteError: no such column: attribution_key` on every boot since
+2026-05-25 (a stale token-ledger.db schema). Because my mentor-ledger construction was downstream of
+TokenLedger in one try, that pre-existing TokenLedger failure took the mentor surface down with it.
+The e2e tests never caught it because they use a fresh stateDir where TokenLedger constructs cleanly.
+This is exactly the production-only failure mode that a real deploy surfaces and tests can't.
+
+## Principle check (Phase 1)
+
+Decision point? No — a construction-ordering/resilience fix. Improves fault isolation. Signal-only.
+
+## The seven questions
+
+1. **Over-block.** None. Strictly improves availability (mentor survives TokenLedger failure).
+2. **Under-block.** The mentor ledger now has its OWN try/catch; if IT throws, the routes still 503
+   (correct — that's the real ledger being unavailable, not a cascade). No new failure masked.
+3. **Level-of-abstraction fit.** Each independent subsystem gets its own init try/catch — the right
+   pattern (TokenLedger failure ≠ mentor-ledger failure). Mirrors how other optional subsystems init.
+4. **Signal vs authority.** Unchanged.
+5. **Interactions.** The mentor block now recomputes `serverDataDir` (idempotent `mkdirSync`); no
+   shared state with the TokenLedger block beyond the directory. Construction order otherwise
+   unchanged. The poller/burn-detection (which depend on TokenLedger) are unaffected.
+6. **External surfaces.** Makes `/mentor/*` + `/framework-issues` resilient — they'll be alive on
+   agents whose TokenLedger is broken (a real population, e.g. Echo). No new surface.
+7. **Rollback cost.** Trivial — revert re-couples them (restoring the bug).
+
+## Phase 5 — second-pass
+
+Not required — a fault-isolation refactor (separate try/catch), no new decision/spawn surface; the
+§19.4 loop already carried the dedicated second-pass.
+
+## Related discovery (NOT in this PR — flagged separately)
+
+The deploy ALSO surfaced a fleet-wide, pre-existing bug unrelated to the mentor system: ALL built-in
+agentmd jobs fail to load (`jobCount=0`) because `InstallBuiltinJobs` generates per-slug manifests
+without a `priority` field while the manifest validator requires it (failing since ~2026-05-20, 1200+
+log occurrences). This is a core JobScheduler/InstallBuiltinJobs issue with fleet-wide blast radius —
+it needs its own spec'd fix, not a bundle with this mentor change. Flagged to Justin.
+
+## Testing
+
+E2E regression (+1): a pre-planted corrupt `token-ledger.db` makes the real TokenLedger fail, and the
+test asserts `/mentor/status` + `/framework-issues` are 200 (NOT 503) — the cascade is broken. 7 mentor
+e2e tests total; affected push-config suite green vs canonical main.


### PR DESCRIPTION
**Found by deploying the merged mentor system to a real server** (the kind of bug tests can't catch). The mentor ledger + runner were constructed *after* `new TokenLedger()` in the **same try block** in `AgentServer`. An agent whose TokenLedger init throws — Echo's has thrown `SqliteError: no such column: attribution_key` on every boot since 2026-05-25 — had the outer catch fire, so the mentor ledger/runner never constructed and `/framework-issues` + `/mentor/*` all returned **503** as pure collateral.

## Fix

Moved `FrameworkIssueLedger` + `MentorOnboardingRunner` to their **own independent try/catch**, decoupled from TokenLedger. A TokenLedger failure can no longer cascade to the mentor surface.

## Testing

E2E regression: pre-plants a corrupt `token-ledger.db` (forcing the real TokenLedger constructor to fail) and asserts `/mentor/status` + `/framework-issues` return 200, not 503 — the cascade is broken. The existing e2e missed this because it uses a fresh state dir where TokenLedger is healthy. 7 mentor e2e tests; affected push-config suite green vs canonical main.

## ⚠️ Separate fleet-wide discovery (NOT in this PR)

The deploy also surfaced a pre-existing, unrelated bug: **all built-in agentmd jobs fail to load** (`jobCount=0`) because `InstallBuiltinJobs` generates per-slug manifests **without** a `priority` field while the manifest validator **requires** it — failing since ~2026-05-20 (1200+ log occurrences). Fleet-wide blast radius; needs its own spec'd fix. Flagged for follow-up, deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)