### PR TITLE
feat(feedback-factory): receiver submit handler + handleSubmit fidelity fix (Phase 1, increment 11)

### DIFF
--- a/src/feedback-factory/receiver/defense.ts
+++ b/src/feedback-factory/receiver/defense.ts
@@ -98,22 +98,13 @@ export function verifySignature(args: {
   }
 }
 
-/** Port of the input-validation block (:242–269): title ≥3, description ≥10, valid type, semver instarVersion. */
-export function validateFeedbackInput(body: Record<string, unknown>): { valid: boolean; error?: string } {
-  if (!body.type || !isValidType(body.type)) {
-    return { valid: false, error: 'Invalid request format' };
-  }
-  if (!body.title || typeof body.title !== 'string' || body.title.trim().length < 3) {
-    return { valid: false, error: 'Invalid request format' };
-  }
-  if (!body.description || typeof body.description !== 'string' || body.description.trim().length < 10) {
-    return { valid: false, error: 'Invalid request format' };
-  }
-  if (body.instarVersion && !SEMVER_RE.test(body.instarVersion as string)) {
-    return { valid: false, error: 'Invalid request format' };
-  }
-  return { valid: true };
-}
+// NOTE: an earlier `validateFeedbackInput` helper lived here but diverged from the
+// reference handleSubmit — it REJECTED an invalid `type` (the reference DEFAULTS it
+// to 'other'), used a generic error message instead of the reference's specific
+// per-field messages, and omitted the agentName/nodeVersion format checks. The
+// faithful validation now lives inline in `handleFeedbackSubmit` (handlers.ts),
+// which reproduces handleSubmit's exact order, messages, and type-default. The
+// imperfect helper was removed to avoid two divergent validators.
 
 /**
  * Port of the in-memory sliding-window rate limiter (checkRateLimit + prune) as an

--- a/src/feedback-factory/receiver/handlers.ts
+++ b/src/feedback-factory/receiver/handlers.ts
@@ -1,0 +1,144 @@
+/**
+ * handlers.ts — framework-agnostic feedback-receiver request handler.
+ *
+ * Faithful port of `handleSubmit` from the reference receiver
+ * (the-portal/pages/api/instar/feedback.ts), lifted out of Next.js into a pure
+ * request→response function over the FeedbackStore interface + the ported intake
+ * defenses (defense.ts). The canonical front (Vercel function / Next route /
+ * instar server) is a thin binding that maps its req/res to this. This is the
+ * reusable "recipe"; the operated deploy supplies the framework binding + the
+ * real (Prisma) store.
+ *
+ * Reproduces handleSubmit's EXACT order, status codes, and error messages so a
+ * deployed agent's feedback sender behaves identically. Notably the reference
+ * DEFAULTS an invalid `type` to 'other' (does NOT reject it) — see the note in
+ * defense.ts about the superseded validateFeedbackInput helper.
+ */
+
+import {
+  extractSourceIp, validateAgentFingerprint, checkHoneypot, verifySignature,
+  isValidType, SEMVER_RE, AGENT_NAME_RE, NODE_VERSION_RE, FEEDBACK_ID_RE,
+  type RateLimiter,
+} from './defense.js';
+import type { FeedbackStore } from '../store/FeedbackStore.js';
+
+export interface FeedbackRequest {
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+  remoteAddress?: string;
+}
+
+export interface FeedbackResponse {
+  status: number;
+  headers?: Record<string, string>;
+  json: unknown;
+}
+
+export interface FeedbackHandlerDeps {
+  store: FeedbackStore;
+  rateLimiter: RateLimiter;
+  /** Normalized webhook secret (see normalizeWebhookSecret); undefined ⇒ unsigned-but-accepted. */
+  secret: string | undefined;
+  /** Injected clock (ms) for the HMAC replay window. */
+  now: number;
+  /** Injected id generator (defaults to the reference's `fb-<base36 time>-<rand>`). */
+  generateFeedbackId?: () => string;
+}
+
+function header(headers: FeedbackRequest['headers'], name: string): string | undefined {
+  const v = headers[name];
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function defaultFeedbackId(now: number): string {
+  return `fb-${now.toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+/** Port of handleSubmit. Returns the status/headers/json the canonical front sends back. */
+export function handleFeedbackSubmit(req: FeedbackRequest, deps: FeedbackHandlerDeps): FeedbackResponse {
+  const { store, rateLimiter, secret, now } = deps;
+  const sourceIp = extractSourceIp(req.headers, req.remoteAddress);
+
+  // Layer 1: rate limit.
+  const rate = rateLimiter.check(sourceIp);
+  if (!rate.allowed) {
+    return {
+      status: 429,
+      headers: { 'Retry-After': String(rate.retryAfterSec) },
+      json: { error: 'Rate limit exceeded', retryAfterSec: rate.retryAfterSec },
+    };
+  }
+
+  // Layer 2: agent fingerprint (400, not 403 — don't reveal it's a fingerprint check).
+  const fp = validateAgentFingerprint(header(req.headers, 'user-agent'), header(req.headers, 'x-instar-version'));
+  if (!fp.valid) {
+    return { status: 400, json: { error: 'Invalid request format' } };
+  }
+
+  // Layer 3: honeypot — silently accept without storing (don't tip off the bot).
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  if (checkHoneypot(body)) {
+    return { status: 200, json: { id: 'fb-received', received: true } };
+  }
+
+  // Layer 3.5: HMAC signature (non-blocking — unsigned still accepted, marked unverified).
+  const verified = verifySignature({
+    signature: header(req.headers, 'x-instar-signature'),
+    timestamp: header(req.headers, 'x-instar-timestamp'),
+    body: req.body,
+    secret,
+    now,
+  });
+
+  // Layer 4: input validation (exact reference order + messages).
+  if (!req.body || typeof req.body !== 'object') {
+    return { status: 400, json: { error: 'Request body must be JSON' } };
+  }
+  const title = body.title;
+  if (!title || typeof title !== 'string' || title.trim().length < 3) {
+    return { status: 400, json: { error: 'title is required (min 3 characters)' } };
+  }
+  const description = body.description;
+  if (!description || typeof description !== 'string' || description.trim().length < 10) {
+    return { status: 400, json: { error: 'description is required (min 10 characters)' } };
+  }
+  // The reference DEFAULTS an invalid type to 'other' — it does not reject.
+  const type = body.type && isValidType(body.type) ? body.type : 'other';
+
+  if (body.agentName && !AGENT_NAME_RE.test(body.agentName as string)) {
+    return { status: 400, json: { error: 'Invalid agentName format' } };
+  }
+  if (body.instarVersion && !SEMVER_RE.test(body.instarVersion as string)) {
+    return { status: 400, json: { error: 'Invalid instarVersion format (expected semver)' } };
+  }
+  if (body.nodeVersion && !NODE_VERSION_RE.test(body.nodeVersion as string)) {
+    return { status: 400, json: { error: 'Invalid nodeVersion format' } };
+  }
+
+  // feedbackId: use a valid agent-provided one, else generate.
+  const provided = body.feedbackId;
+  const feedbackId = typeof provided === 'string' && FEEDBACK_ID_RE.test(provided)
+    ? provided
+    : (deps.generateFeedbackId ?? (() => defaultFeedbackId(now)))();
+
+  // Layer 5: dedup — idempotent on a known feedbackId.
+  if (store.hasFeedback(feedbackId)) {
+    return { status: 200, json: { id: feedbackId, received: true, duplicate: true } };
+  }
+
+  store.addFeedback({
+    feedbackId,
+    type,
+    title: (title as string).trim().slice(0, 500),
+    description: (description as string).trim().slice(0, 10000),
+    agentName: ((body.agentName as string) || 'unknown').slice(0, 100),
+    instarVersion: ((body.instarVersion as string) || 'unknown').slice(0, 20),
+    nodeVersion: ((body.nodeVersion as string) || 'unknown').slice(0, 20),
+    os: ((body.os as string) || 'unknown').slice(0, 100),
+    context: typeof body.context === 'string' ? body.context.slice(0, 5000) : undefined,
+    sourceIp,
+    verified,
+  });
+
+  return { status: 200, json: { id: feedbackId, received: true } };
+}

--- a/src/feedback-factory/store/FeedbackStore.ts
+++ b/src/feedback-factory/store/FeedbackStore.ts
@@ -38,6 +38,10 @@ export interface FeedbackStore {
   applyReopen(clusterId: string, decision: ReopenDecision): void;
   /** Mark a feedback item processed + linked to its cluster. */
   markProcessed(feedbackId: string, clusterId: string): void;
+  /** True if a feedback item with this feedbackId already exists (the dedup check). */
+  hasFeedback(feedbackId: string): boolean;
+  /** Persist a newly-received feedback item (the receiver write). */
+  addFeedback(item: FeedbackItem): void;
   metrics(): FeedbackMetrics;
 }
 
@@ -104,6 +108,14 @@ export class InMemoryFeedbackStore implements FeedbackStore {
     const f = this.feedback.get(feedbackId);
     if (f) { f.status = 'processing'; f.clusterId = clusterId; }
     this.counts.captured++;
+  }
+
+  hasFeedback(feedbackId: string): boolean {
+    return this.feedback.has(feedbackId);
+  }
+
+  addFeedback(item: FeedbackItem): void {
+    this.feedback.set(item.feedbackId, { status: 'unprocessed', ...item });
   }
 
   metrics(): FeedbackMetrics {

--- a/tests/unit/feedback-factory/defense.test.ts
+++ b/tests/unit/feedback-factory/defense.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from 'vitest';
 import { createHmac } from 'node:crypto';
 import {
   normalizeWebhookSecret, isValidType, extractSourceIp, validateAgentFingerprint,
-  checkHoneypot, verifySignature, validateFeedbackInput, RateLimiter, RATE_LIMITS,
+  checkHoneypot, verifySignature, RateLimiter, RATE_LIMITS,
 } from '../../../src/feedback-factory/receiver/defense.js';
 
 describe('normalizeWebhookSecret', () => {
@@ -89,21 +89,6 @@ describe('verifySignature', () => {
   });
 });
 
-describe('validateFeedbackInput', () => {
-  const ok = { type: 'bug', title: 'abc', description: '0123456789' };
-  it('accepts a well-formed body', () => {
-    expect(validateFeedbackInput(ok).valid).toBe(true);
-  });
-  it('rejects title < 3 and description < 10 (boundary)', () => {
-    expect(validateFeedbackInput({ ...ok, title: 'ab' }).valid).toBe(false);
-    expect(validateFeedbackInput({ ...ok, description: '123456789' }).valid).toBe(false);
-  });
-  it('rejects invalid type and bad instarVersion', () => {
-    expect(validateFeedbackInput({ ...ok, type: 'nope' }).valid).toBe(false);
-    expect(validateFeedbackInput({ ...ok, instarVersion: 'x.y' }).valid).toBe(false);
-    expect(validateFeedbackInput({ ...ok, instarVersion: '1.2.3' }).valid).toBe(true);
-  });
-});
 
 describe('RateLimiter', () => {
   it('allows up to perHour then blocks with a retryAfter', () => {

--- a/tests/unit/feedback-factory/handlers.test.ts
+++ b/tests/unit/feedback-factory/handlers.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests (Tier 1) — framework-agnostic feedback receiver handler.
+ *
+ * Faithful port of the reference handleSubmit: exact status codes, error messages,
+ * order, the type-default-to-'other', the non-blocking HMAC, dedup, and storage.
+ * Clock + id generator injected for determinism; runs over InMemoryFeedbackStore.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { handleFeedbackSubmit } from '../../../src/feedback-factory/receiver/handlers.js';
+import { RateLimiter, RATE_LIMITS } from '../../../src/feedback-factory/receiver/defense.js';
+import { InMemoryFeedbackStore } from '../../../src/feedback-factory/store/FeedbackStore.js';
+
+const NOW = 1_000_000_000_000;
+const UA = { 'user-agent': 'instar/1.3.0' };
+const okBody = { type: 'bug', title: 'a real title', description: 'a sufficiently long description' };
+
+function mk(overrides: Partial<Parameters<typeof handleFeedbackSubmit>[1]> = {}) {
+  const store = new InMemoryFeedbackStore();
+  const rateLimiter = new RateLimiter(RATE_LIMITS, () => NOW);
+  return {
+    store,
+    deps: { store, rateLimiter, secret: 'sec', now: NOW, generateFeedbackId: () => 'fb-generated-1', ...overrides },
+  };
+}
+
+describe('handleFeedbackSubmit', () => {
+  it('429 when rate-limited (Retry-After set)', () => {
+    const { deps } = mk();
+    for (let i = 0; i < RATE_LIMITS.perHour; i++) deps.rateLimiter.check('1.1.1.1');
+    const r = handleFeedbackSubmit({ headers: { ...UA, 'x-forwarded-for': '1.1.1.1' }, body: okBody }, deps);
+    expect(r.status).toBe(429);
+    expect(r.headers?.['Retry-After']).toBeDefined();
+  });
+
+  it('400 (generic) when the agent fingerprint is missing', () => {
+    const { deps } = mk();
+    const r = handleFeedbackSubmit({ headers: { 'user-agent': 'curl/8' }, body: okBody }, deps);
+    expect(r).toMatchObject({ status: 400, json: { error: 'Invalid request format' } });
+  });
+
+  it('silently 200s a honeypot hit without storing', () => {
+    const { store, deps } = mk();
+    const r = handleFeedbackSubmit({ headers: UA, body: { ...okBody, website: 'x' } }, deps);
+    expect(r).toMatchObject({ status: 200, json: { id: 'fb-received', received: true } });
+    expect(store.hasFeedback('fb-generated-1')).toBe(false);
+  });
+
+  it('400s with the exact reference messages for title/description', () => {
+    const { deps } = mk();
+    expect(handleFeedbackSubmit({ headers: UA, body: { ...okBody, title: 'ab' } }, deps).json)
+      .toEqual({ error: 'title is required (min 3 characters)' });
+    expect(handleFeedbackSubmit({ headers: UA, body: { ...okBody, description: 'too short' } }, deps).json)
+      .toEqual({ error: 'description is required (min 10 characters)' });
+  });
+
+  it('DEFAULTS an invalid type to "other" (does NOT reject) — the fidelity fix', () => {
+    const { store, deps } = mk();
+    const r = handleFeedbackSubmit({ headers: UA, body: { ...okBody, type: 'nonsense' } }, deps);
+    expect(r.status).toBe(200);
+    expect(store.getUnprocessedFeedback()[0].type).toBe('other');
+  });
+
+  it('400s on malformed agentName / instarVersion / nodeVersion', () => {
+    const { deps } = mk();
+    expect(handleFeedbackSubmit({ headers: UA, body: { ...okBody, agentName: '!!' } }, deps).json)
+      .toEqual({ error: 'Invalid agentName format' });
+    expect(handleFeedbackSubmit({ headers: UA, body: { ...okBody, instarVersion: 'x.y' } }, deps).json)
+      .toEqual({ error: 'Invalid instarVersion format (expected semver)' });
+    expect(handleFeedbackSubmit({ headers: UA, body: { ...okBody, nodeVersion: 'abc' } }, deps).json)
+      .toEqual({ error: 'Invalid nodeVersion format' });
+  });
+
+  it('stores on success, marking unverified when there is no signature', () => {
+    const { store, deps } = mk();
+    const r = handleFeedbackSubmit({ headers: UA, body: okBody }, deps);
+    expect(r).toMatchObject({ status: 200, json: { id: 'fb-generated-1', received: true } });
+    const stored = store.getUnprocessedFeedback()[0];
+    expect(stored.feedbackId).toBe('fb-generated-1');
+    expect(stored.verified).toBe(false);
+  });
+
+  it('marks verified:true with a valid HMAC signature', () => {
+    const { store, deps } = mk();
+    const ts = String(NOW - 1000);
+    const sig = createHmac('sha256', 'sec').update(`${ts}.${JSON.stringify(okBody)}`).digest('hex');
+    handleFeedbackSubmit({ headers: { ...UA, 'x-instar-signature': sig, 'x-instar-timestamp': ts }, body: okBody }, deps);
+    expect(store.getUnprocessedFeedback()[0].verified).toBe(true);
+  });
+
+  it('honors a valid agent-provided feedbackId and is idempotent on dedup', () => {
+    const { deps } = mk();
+    const body = { ...okBody, feedbackId: 'fb-abc123' };
+    const first = handleFeedbackSubmit({ headers: UA, body }, deps);
+    expect(first.json).toMatchObject({ id: 'fb-abc123', received: true });
+    const second = handleFeedbackSubmit({ headers: UA, body }, deps);
+    expect(second.json).toMatchObject({ id: 'fb-abc123', received: true, duplicate: true });
+  });
+
+  it('400s a non-object body', () => {
+    const { deps } = mk();
+    expect(handleFeedbackSubmit({ headers: UA, body: 'not json' }, deps).json)
+      .toEqual({ error: 'Request body must be JSON' });
+  });
+});

--- a/tests/unit/feedback-factory/store.test.ts
+++ b/tests/unit/feedback-factory/store.test.ts
@@ -67,4 +67,13 @@ describe('InMemoryFeedbackStore', () => {
     expect(s.getCluster('c1')?.recurrenceCount).toBeUndefined();
     expect(s.getCluster('c1')?.actionTaken).toBe('N');
   });
+
+  it('addFeedback / hasFeedback (the receiver dedup seam)', () => {
+    const s = new InMemoryFeedbackStore();
+    expect(s.hasFeedback('fb-1')).toBe(false);
+    s.addFeedback(item('fb-1'));
+    expect(s.hasFeedback('fb-1')).toBe(true);
+    // added feedback defaults to unprocessed → visible to the processor
+    expect(s.getUnprocessedFeedback().map(f => f.feedbackId)).toContain('fb-1');
+  });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,27 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Eleventh increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, approved). Ports the **receiver submit handler** — the actual "receive a report" request logic — out of the reference Next.js handler (`the-portal/pages/api/instar/feedback.ts`, `handleSubmit`) into a framework-agnostic function at `src/feedback-factory/receiver/handlers.ts`, plus the store operations it needs (`addFeedback` / `hasFeedback`).
+
+It runs the full intake gauntlet (rate-limit → fingerprint → honeypot → signature → validation → dedup → store) and returns exactly the status codes and messages the reference returns, so a deployed agent's feedback sender behaves identically. The canonical front door (whatever framework hosts it) becomes a thin binding around this. **Not wired into any route yet** — no behavioral change.
+
+Also corrects a fidelity slip found while building this: an earlier validation helper rejected an unknown report "type", but the real receiver quietly defaults an unknown type to "other". The faithful behavior now lives in the handler; the imperfect helper was removed.
+
+## What to Tell Your User
+
+- The "receive a report" front-door logic is now ported, behaving exactly like Dawn's original down to the error messages — so when we stand up the new front door, field agents won't notice any difference.
+- A small correctness fix went in too: a leftover validation helper was stricter than the real thing about report categories; it's now removed in favor of the faithful version.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Receiver submit handler (TS port) | Internal `handleFeedbackSubmit` in `src/feedback-factory/receiver/handlers.ts` — framework-agnostic, not yet wired |
+| Store receiver seam | `FeedbackStore.addFeedback` + `hasFeedback` |
+
+## Evidence
+
+- Reference is TypeScript, so equivalence is by faithful transcription plus exhaustive both-sides-of-boundary tests (11 handler tests): rate-limit 429 with Retry-After; missing-fingerprint generic 400; honeypot silent-200-without-storing; exact title/description messages; **invalid type defaults to "other" (not rejected)** — the corrected behavior; malformed agentName/instarVersion/nodeVersion messages; success path marking unverified without a signature and verified with a valid HMAC; a valid agent-provided id honored with idempotent dedup; non-object body rejected. All 103 feedback-factory tests pass together.

--- a/upgrades/side-effects/feedback-factory-receiver-handler.md
+++ b/upgrades/side-effects/feedback-factory-receiver-handler.md
@@ -1,0 +1,31 @@
+# Side-Effects Review — receiver submit handler + a fidelity correction (Phase 1, increment 11)
+
+**Slug:** `feedback-factory-receiver-handler`
+**Date:** `2026-05-27`
+**Author:** Echo (autonomous → interactive)
+**Spec:** `docs/specs/feedback-factory-migration.md` (converged v2, approved by Justin 2026-05-26)
+**Scope:** The framework-agnostic receiver submit handler (faithful port of `handleSubmit`), the store ops it needs (`addFeedback`/`hasFeedback`), AND a correction to increment-6's `validateFeedbackInput` (see below).
+
+## Summary of the change
+
+Adds `src/feedback-factory/receiver/handlers.ts` — `handleFeedbackSubmit(req, deps) → {status, headers?, json}`, a faithful port of the reference `handleSubmit` (the-portal/pages/api/instar/feedback.ts) lifted out of Next.js into a pure request→response function over the FeedbackStore interface + the ported defenses. The canonical front (Vercel function / Next route / instar server) becomes a thin binding. Reproduces the reference's EXACT order, status codes (429/400/200), and error messages so deployed agents' feedback senders behave identically. Adds `FeedbackStore.addFeedback` + `hasFeedback` (the receiver write + dedup seam) + `InMemoryFeedbackStore` impls. **Not wired into any route yet** — no behavioral change. Notification (Telegram) is intentionally NOT in the core handler — it's an operated-side concern the binding adds.
+
+## Fidelity correction (increment 6)
+
+Building this surfaced that increment-6's `validateFeedbackInput` (defense.ts) **diverged from the reference**: it REJECTED an invalid `type` (the reference DEFAULTS it to `'other'`), used a generic error message instead of the reference's specific per-field messages, and omitted the agentName/nodeVersion format checks. That helper was a premature abstraction — the reference validates inline. **Removed** `validateFeedbackInput` (+ its tests); the faithful validation now lives inline in `handleFeedbackSubmit` (exact messages, order, and the type-default). The other defense.ts functions (verifySignature, fingerprint, honeypot, RateLimiter, regexes) were faithful + are reused unchanged.
+
+## Seven-dimension review
+
+1. **Over/under-reach** — Pure request→response function + a self-contained `RateLimiter` (injected). The over-reach in increment 6 (rejecting valid-but-defaulted types) is REMOVED — the handler now matches the reference's leniency exactly. No route wired.
+2. **Level-of-abstraction fit** — The handler is reusable "recipe" → core package; the framework binding + Prisma store are operated-side. Notification kept out of core. Correct split.
+3. **Signal vs Authority** — N/A; returns a response. HMAC is non-blocking (unsigned still accepted, marked `verified:false`) — faithful to the reference.
+4. **Interactions** — `handlers.ts` imports defense.ts + the store interface; nothing imports `handlers.ts` yet. Removing `validateFeedbackInput` is safe — only its own test referenced it (verified by grep).
+5. **Rollback cost** — Trivial: delete handlers.ts + restore the helper. (But the helper was incorrect — keeping it removed is the right state.)
+6. **Migration parity** — N/A. Core library code; no agent-installed file. (The sender repoint is the separate, blocked cutover step.)
+7. **Failure modes** — (a) Response divergence from the reference → exact status/message/order tested incl. the type-default fidelity fix + non-object-body + dedup-idempotency. (b) HMAC verified flag wrong → tested signed vs unsigned. (c) Rate-limit non-determinism → injected clock. (d) feedbackId generation non-determinism → injected generator.
+
+## Tests
+
+- Tier-1 unit (CI): `tests/unit/feedback-factory/handlers.test.ts` (11 — 429 / fingerprint-400 / honeypot-silent / exact title+desc messages / **type-default-to-other** / agentName+version messages / success+unverified / verified-with-HMAC / provided-id + dedup-idempotency / non-object-body), plus `store.test.ts` +1 (addFeedback/hasFeedback), and `defense.test.ts` updated (validateFeedbackInput removed).
+- All 103 feedback-factory unit+integration tests green together.
+- No E2E this increment — the route binding + deploy are gated on the blocked app-placement + Prisma-adapter decisions.


### PR DESCRIPTION
Eleventh increment of the approved **Feedback Factory Migration** (`docs/specs/feedback-factory-migration.md`).

## Summary
Ports `handleSubmit` (the reference receiver) into framework-agnostic `handleFeedbackSubmit()` at `src/feedback-factory/receiver/handlers.ts` — a pure request→response function over the `FeedbackStore` interface + the ported defenses, reproducing the reference's **exact** status codes / messages / order so deployed agents' senders behave identically. Adds `FeedbackStore.addFeedback`/`hasFeedback` (receiver write + dedup seam). **Not wired into any route yet**; Telegram notify left to the operated binding.

## Fidelity correction (increment 6)
Building this surfaced that increment-6's `validateFeedbackInput` **rejected** an invalid `type` while the reference **defaults it to `'other'`**, used a generic message, and omitted agentName/nodeVersion checks. Removed it (+ its tests); faithful validation now lives inline in the handler. The other defense.ts functions were faithful and are reused unchanged.

## Tests
- `tests/unit/feedback-factory/handlers.test.ts` — 11 tests (incl. the type-default fix, exact messages, HMAC verified flag, dedup idempotency, non-object body).
- `store.test.ts` +1 (addFeedback/hasFeedback); `defense.test.ts` updated.
- All 103 feedback-factory tests green together.

## Test plan
- [x] `npm run test:push` (feedback-factory green; 1 unrelated flake — `token-ledger > scanAllAsync`, documented timing-flaky, passes on CI)
- [ ] CI green