### PR TITLE
feat(feedback-factory): dispatch request handlers (Phase 1, increment 12)

### DIFF
--- a/src/feedback-factory/dispatch/handlers.ts
+++ b/src/feedback-factory/dispatch/handlers.ts
@@ -1,0 +1,140 @@
+/**
+ * handlers.ts — framework-agnostic dispatch (guidance-out) request handlers.
+ *
+ * Faithful port of handleList + handleCreate from the reference dispatch endpoint
+ * (the-portal/pages/api/instar/dispatches/index.ts), lifted out of Next.js into
+ * pure request→response functions over the FeedbackStore + the ported dispatch
+ * logic (dispatch.ts). The canonical front binds these; the operated deploy
+ * supplies the real store + the internal key. Reproduces the reference's exact
+ * status codes, auth, validation messages, and the version-compat filter.
+ *
+ * Note: unlike the public feedback receiver (which DEFAULTS an invalid type),
+ * dispatch create REJECTS an invalid type — it's an internal, authed endpoint.
+ */
+
+import {
+  isValidDispatchType, isValidDispatchPriority, SEMVER_RE, DISPATCH_TYPES,
+  filterDispatchesForVersion, normalizeDispatchTitle, type DispatchRecord,
+} from './dispatch.js';
+import type { FeedbackStore } from '../store/FeedbackStore.js';
+
+export interface DispatchListRequest {
+  headers: Record<string, string | string[] | undefined>;
+  query: { since?: string; type?: string };
+}
+export interface DispatchCreateRequest {
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+}
+export interface DispatchResponse {
+  status: number;
+  json: unknown;
+}
+
+function header(headers: DispatchListRequest['headers'], name: string): string | undefined {
+  const v = headers[name];
+  return Array.isArray(v) ? v[0] : v;
+}
+
+/** Port of handleList: fingerprint-gate, since/type filter, version-compat filter, mapped output. */
+export function handleDispatchList(req: DispatchListRequest, deps: { store: FeedbackStore; now: number }): DispatchResponse {
+  const ua = (header(req.headers, 'user-agent') || '').toLowerCase();
+  if (!ua.includes('instar/')) {
+    return { status: 400, json: { error: 'Invalid request format' } };
+  }
+
+  // since: only applied when it parses to a valid date (mirrors the reference).
+  let since: string | undefined;
+  if (req.query.since && !isNaN(new Date(req.query.since).getTime())) {
+    since = new Date(req.query.since).toISOString();
+  }
+  const type = req.query.type && isValidDispatchType(req.query.type) ? req.query.type : undefined;
+
+  let dispatches = deps.store.listDispatches({ since, type });
+
+  const version = header(req.headers, 'x-instar-version');
+  if (version && SEMVER_RE.test(version)) {
+    dispatches = filterDispatchesForVersion(dispatches, version);
+  }
+
+  return {
+    status: 200,
+    json: {
+      dispatches: dispatches.map((d) => ({
+        dispatchId: d.dispatchId,
+        type: d.type,
+        title: d.title,
+        content: d.content,
+        priority: d.priority,
+        minVersion: d.minVersion ?? null,
+        maxVersion: d.maxVersion ?? null,
+        createdAt: d.createdAt,
+      })),
+      count: dispatches.length,
+      asOf: new Date(deps.now).toISOString(),
+    },
+  };
+}
+
+export interface DispatchCreateDeps {
+  store: FeedbackStore;
+  /** The internal API key the caller must present (x-internal-key or Bearer). */
+  internalKey: string;
+  now: number;
+  generateDispatchId?: () => string;
+}
+
+/** Port of handleCreate: internal-auth, validation (type REJECTED, priority defaulted), dedup-by-title, create. */
+export function handleDispatchCreate(req: DispatchCreateRequest, deps: DispatchCreateDeps): DispatchResponse {
+  const provided = header(req.headers, 'x-internal-key')
+    || header(req.headers, 'authorization')?.replace('Bearer ', '');
+  if (provided !== deps.internalKey) {
+    return { status: 401, json: { error: 'Authentication required' } };
+  }
+
+  if (!req.body || typeof req.body !== 'object') {
+    return { status: 400, json: { error: 'Request body must be JSON' } };
+  }
+  const body = req.body as Record<string, unknown>;
+
+  if (!body.title || typeof body.title !== 'string' || body.title.trim().length < 3) {
+    return { status: 400, json: { error: 'title is required (min 3 characters)' } };
+  }
+  if (!body.content || typeof body.content !== 'string' || body.content.trim().length < 10) {
+    return { status: 400, json: { error: 'content is required (min 10 characters)' } };
+  }
+  if (!body.type || !isValidDispatchType(body.type)) {
+    return { status: 400, json: { error: `type must be one of: ${DISPATCH_TYPES.join(', ')}` } };
+  }
+  const priority = body.priority && isValidDispatchPriority(body.priority) ? body.priority : 'normal';
+
+  if (body.minVersion && !SEMVER_RE.test(body.minVersion as string)) {
+    return { status: 400, json: { error: 'minVersion must be valid semver' } };
+  }
+  if (body.maxVersion && !SEMVER_RE.test(body.maxVersion as string)) {
+    return { status: 400, json: { error: 'maxVersion must be valid semver' } };
+  }
+
+  const normalizedTitle = normalizeDispatchTitle(body.title);
+
+  const existing = deps.store.findDispatchByTitle(normalizedTitle);
+  if (existing) {
+    return { status: 200, json: { dispatchId: existing.dispatchId, created: false, duplicate: true } };
+  }
+
+  const dispatchId = (deps.generateDispatchId ?? (() => `dsp-${deps.now.toString(36)}-${Math.random().toString(36).slice(2, 6)}`))();
+  const record: DispatchRecord = {
+    dispatchId,
+    type: body.type as string,
+    title: normalizedTitle,
+    content: (body.content as string).trim().slice(0, 50000),
+    priority: priority as string,
+    minVersion: (body.minVersion as string) || null,
+    maxVersion: (body.maxVersion as string) || null,
+    active: true,
+    createdAt: new Date(deps.now).toISOString(),
+  };
+  deps.store.createDispatch(record);
+
+  return { status: 201, json: { dispatchId, created: true, duplicate: false } };
+}

--- a/src/feedback-factory/store/FeedbackStore.ts
+++ b/src/feedback-factory/store/FeedbackStore.ts
@@ -15,6 +15,7 @@
 
 import type { FeedbackItem, Cluster, ClusterResult } from '../processor/types.js';
 import type { ReopenDecision } from '../processor/reopen.js';
+import type { DispatchRecord } from '../dispatch/dispatch.js';
 
 /** Read-only observability counters for the capture→cluster→reopen loop (spec §2.7). */
 export interface FeedbackMetrics {
@@ -42,6 +43,12 @@ export interface FeedbackStore {
   hasFeedback(feedbackId: string): boolean;
   /** Persist a newly-received feedback item (the receiver write). */
   addFeedback(item: FeedbackItem): void;
+  /** Active dispatches matching an optional since/type filter, oldest-first (the dispatch list read). */
+  listDispatches(filter?: { since?: string; type?: string }): DispatchRecord[];
+  /** Find an existing dispatch by exact (normalized) title — the create-dedup check. */
+  findDispatchByTitle(title: string): DispatchRecord | undefined;
+  /** Persist a new dispatch. */
+  createDispatch(record: DispatchRecord): void;
   metrics(): FeedbackMetrics;
 }
 
@@ -116,6 +123,24 @@ export class InMemoryFeedbackStore implements FeedbackStore {
 
   addFeedback(item: FeedbackItem): void {
     this.feedback.set(item.feedbackId, { status: 'unprocessed', ...item });
+  }
+
+  private dispatches = new Map<string, DispatchRecord>();
+
+  listDispatches(filter?: { since?: string; type?: string }): DispatchRecord[] {
+    return [...this.dispatches.values()]
+      .filter((d) => d.active !== false)
+      .filter((d) => !filter?.since || String(d.createdAt ?? '') >= filter.since)
+      .filter((d) => !filter?.type || d.type === filter.type)
+      .sort((a, b) => String(a.createdAt ?? '').localeCompare(String(b.createdAt ?? '')));
+  }
+
+  findDispatchByTitle(title: string): DispatchRecord | undefined {
+    return [...this.dispatches.values()].find((d) => d.title === title);
+  }
+
+  createDispatch(record: DispatchRecord): void {
+    this.dispatches.set(record.dispatchId, { active: true, ...record });
   }
 
   metrics(): FeedbackMetrics {

--- a/tests/unit/feedback-factory/dispatch-handlers.test.ts
+++ b/tests/unit/feedback-factory/dispatch-handlers.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests (Tier 1) — framework-agnostic dispatch request handlers.
+ *
+ * Faithful port of handleList + handleCreate: exact auth, status codes, messages,
+ * the version-compat filter, and create-dedup. Clock + id injected for determinism.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { handleDispatchList, handleDispatchCreate } from '../../../src/feedback-factory/dispatch/handlers.js';
+import { InMemoryFeedbackStore } from '../../../src/feedback-factory/store/FeedbackStore.js';
+
+const NOW = 1_700_000_000_000;
+const KEY = 'internal-key';
+const UA = { 'user-agent': 'instar/1.3.0' };
+
+function freshStore() {
+  const store = new InMemoryFeedbackStore();
+  return store;
+}
+const create = (store: InMemoryFeedbackStore, body: Record<string, unknown>, id: string) =>
+  handleDispatchCreate({ headers: { 'x-internal-key': KEY }, body }, { store, internalKey: KEY, now: NOW, generateDispatchId: () => id });
+
+describe('handleDispatchList', () => {
+  it('400s when the agent fingerprint (instar/ UA) is missing', () => {
+    const r = handleDispatchList({ headers: { 'user-agent': 'curl/8' }, query: {} }, { store: freshStore(), now: NOW });
+    expect(r).toMatchObject({ status: 400, json: { error: 'Invalid request format' } });
+  });
+
+  it('lists active dispatches with count + asOf', () => {
+    const store = freshStore();
+    create(store, { type: 'lesson', title: 'a lesson title', content: 'a sufficiently long body' }, 'dsp-1');
+    const r = handleDispatchList({ headers: UA, query: {} }, { store, now: NOW });
+    expect(r.status).toBe(200);
+    expect((r.json as any).count).toBe(1);
+    expect((r.json as any).asOf).toBe(new Date(NOW).toISOString());
+  });
+
+  it('applies the version-compat filter (a min-version dispatch is hidden from older agents)', () => {
+    const store = freshStore();
+    create(store, { type: 'lesson', title: 'needs v1.4.0+', content: 'only for new agents', minVersion: '1.4.0' }, 'dsp-min');
+    const newAgent = handleDispatchList({ headers: { 'user-agent': 'instar/1.4.0', 'x-instar-version': '1.4.0' }, query: {} }, { store, now: NOW });
+    const oldAgent = handleDispatchList({ headers: { 'user-agent': 'instar/1.3.0', 'x-instar-version': '1.3.0' }, query: {} }, { store, now: NOW });
+    expect((newAgent.json as any).count).toBe(1);
+    expect((oldAgent.json as any).count).toBe(0);
+  });
+
+  it('filters by type', () => {
+    const store = freshStore();
+    create(store, { type: 'lesson', title: 'lesson one', content: 'body body body' }, 'd1');
+    create(store, { type: 'security', title: 'security one', content: 'body body body' }, 'd2');
+    const r = handleDispatchList({ headers: UA, query: { type: 'security' } }, { store, now: NOW });
+    expect((r.json as any).dispatches.map((d: any) => d.dispatchId)).toEqual(['d2']);
+  });
+});
+
+describe('handleDispatchCreate', () => {
+  it('401 without the internal key', () => {
+    const r = handleDispatchCreate({ headers: {}, body: {} }, { store: freshStore(), internalKey: KEY, now: NOW });
+    expect(r).toMatchObject({ status: 401, json: { error: 'Authentication required' } });
+  });
+
+  it('accepts Bearer form of the internal key', () => {
+    const store = freshStore();
+    const r = handleDispatchCreate(
+      { headers: { authorization: `Bearer ${KEY}` }, body: { type: 'lesson', title: 'ok title', content: 'long enough body' } },
+      { store, internalKey: KEY, now: NOW, generateDispatchId: () => 'dsp-x' },
+    );
+    expect(r.status).toBe(201);
+  });
+
+  it('validates title/content/type/version with exact messages', () => {
+    const store = freshStore();
+    const hk = (body: Record<string, unknown>) => handleDispatchCreate({ headers: { 'x-internal-key': KEY }, body }, { store, internalKey: KEY, now: NOW });
+    expect(hk({ type: 'lesson', title: 'ab', content: 'long enough body' }).json).toEqual({ error: 'title is required (min 3 characters)' });
+    expect(hk({ type: 'lesson', title: 'ok title', content: 'short' }).json).toEqual({ error: 'content is required (min 10 characters)' });
+    expect((hk({ type: 'nope', title: 'ok title', content: 'long enough body' }).json as any).error).toContain('type must be one of:');
+    expect(hk({ type: 'lesson', title: 'ok title', content: 'long enough body', minVersion: 'x.y' }).json).toEqual({ error: 'minVersion must be valid semver' });
+  });
+
+  it('creates (201) then dedups by title (200 duplicate)', () => {
+    const store = freshStore();
+    const body = { type: 'lesson', title: 'dedup me', content: 'long enough body here' };
+    const first = create(store, body, 'dsp-a');
+    expect(first).toMatchObject({ status: 201, json: { dispatchId: 'dsp-a', created: true } });
+    const second = create(store, body, 'dsp-b');
+    expect(second).toMatchObject({ status: 200, json: { dispatchId: 'dsp-a', created: false, duplicate: true } });
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Twelfth increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, approved). Ports the **dispatch request handlers** — the "send guidance back to agents" side — out of the reference Next.js endpoint (`the-portal/pages/api/instar/dispatches/index.ts`) into framework-agnostic functions at `src/feedback-factory/dispatch/handlers.ts`, plus the store operations they need (`listDispatches` / `findDispatchByTitle` / `createDispatch`).
+
+List gates on the agent fingerprint, applies the since/type filter and the version-compat filter (so guidance only reaches the agent versions it applies to), and returns the mapped result. Create requires the internal key, validates the body, dedups by title, and creates. **Not wired into any route yet** — no behavioral change. This completes the front door's request layer (receive a report + send guidance both ported).
+
+## What to Tell Your User
+
+- Both halves of the feedback loop's front door are now ported and behave exactly like Dawn's originals — catching reports, and sending version-targeted guidance back.
+- That's the entire request + decision layer done. What's left to actually go live is the database wiring and the deploy — now being coordinated with Dawn.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Dispatch handlers (TS port) | `handleDispatchList` + `handleDispatchCreate` in `src/feedback-factory/dispatch/handlers.ts` — framework-agnostic, not yet wired |
+| Store dispatch seam | `FeedbackStore.listDispatches` / `findDispatchByTitle` / `createDispatch` |
+
+## Evidence
+
+- Reference is TypeScript, so equivalence is by faithful transcription plus both-sides-of-boundary tests (8): list UA-gate 400; basic list with count + asOf; version-compat filter hiding a min-version dispatch from an older agent; type filter; create 401 without the key; Bearer-form auth accepted; exact validation messages for title/content/type/version; 201-then-200-duplicate dedup by title.

--- a/upgrades/side-effects/feedback-factory-dispatch-handlers.md
+++ b/upgrades/side-effects/feedback-factory-dispatch-handlers.md
@@ -1,0 +1,32 @@
+# Side-Effects Review — dispatch request handlers (Phase 1, increment 12)
+
+**Slug:** `feedback-factory-dispatch-handlers`
+**Date:** `2026-05-27`
+**Author:** Echo (autonomous → interactive)
+**Spec:** `docs/specs/feedback-factory-migration.md` (converged v2, approved by Justin 2026-05-26)
+**Scope:** The framework-agnostic dispatch request handlers (faithful ports of `handleList` + `handleCreate`) + the store dispatch ops. Completes the front's request layer (receiver + dispatch). NOT the HTTP binding/deploy.
+
+## Summary of the change
+
+Adds `src/feedback-factory/dispatch/handlers.ts` — `handleDispatchList` + `handleDispatchCreate`, faithful ports of the reference dispatch endpoint, as pure request→response functions over the FeedbackStore + the ported dispatch logic (dispatch.ts). Adds `FeedbackStore.listDispatches`/`findDispatchByTitle`/`createDispatch` + `InMemoryFeedbackStore` impls. Reproduces the reference exactly: list gates on the `instar/` UA, applies the since/type DB filter + the version-compat filter, returns the mapped `{dispatches, count, asOf}`; create requires the internal key (x-internal-key or Bearer), validates (title ≥3, content ≥10, **type REJECTED** if invalid, priority defaulted, min/maxVersion semver), dedups by normalized title, and returns 201/200-duplicate. **Not wired into any route yet** — no behavioral change.
+
+Note the asymmetry with the public receiver: dispatch create REJECTS an invalid type (it's an internal, authed endpoint), whereas the public feedback receiver defaults it — both faithful to their respective references.
+
+## Seven-dimension review
+
+1. **Over/under-reach** — Pure request→response functions over the store. Not wired to any route. The internal-key auth is injected (the operated binding provides the real key).
+2. **Level-of-abstraction fit** — Reusable "recipe" → core; the framework binding + real store are operated-side. The version-compat filter reuses the already-tested `filterDispatchesForVersion`.
+3. **Signal vs Authority** — N/A; create is internal-authed (the reference's 401 gate is reproduced); list is the `instar/`-UA fingerprint gate.
+4. **Interactions** — `dispatch/handlers.ts` imports dispatch.ts + the store interface; nothing imports it yet. Store gains a dispatches Map (isolated from feedback/clusters).
+5. **Rollback cost** — Trivial: delete the handlers + store ops + tests.
+6. **Migration parity** — N/A. Core library code; no agent-installed file.
+7. **Failure modes** — (a) Response divergence → exact status/message/auth/order tested. (b) Version-compat filter wrong → reuses the 9/9-tested `filterDispatchesForVersion` + a hidden-from-older-agent handler test. (c) Dedup-by-title divergence → tested (201 then 200-duplicate). (d) Auth bypass → 401 tested for missing/wrong key; Bearer form tested.
+
+## Tests
+
+- Tier-1 unit (CI): `tests/unit/feedback-factory/dispatch-handlers.test.ts` — 8 tests (list: UA-gate, basic list+asOf, version-compat hide, type filter; create: 401, Bearer-auth, validation messages, 201-then-dedup).
+- No E2E this increment — the route binding + deploy are gated on the blocked app-placement + Prisma-adapter decisions.
+
+## Status note
+
+With this, the **entire front + processor request/decision layer is ported** (receiver submit + dispatch list/create handlers, all the processor brain, the store seam + composition + observability). The only remaining feedback-factory work is genuinely blocked on external inputs: the real Prisma adapter (DB creds/schema), the framework binding + Vercel deploy (app-placement + Vercel project), agent-awareness (after live), and the operational cutover (Dawn + live systems).


### PR DESCRIPTION
Twelfth increment of the approved **Feedback Factory Migration** (`docs/specs/feedback-factory-migration.md`) — completes the front's request layer.

## Summary
Ports `handleList` + `handleCreate` (the reference dispatch endpoint) into framework-agnostic `handleDispatchList` / `handleDispatchCreate` at `src/feedback-factory/dispatch/handlers.ts` — pure request→response over the `FeedbackStore` + the ported dispatch logic. List gates on the `instar/` UA, applies since/type + the version-compat filter, returns mapped `{dispatches,count,asOf}`; create requires the internal key, validates (**type REJECTED** — internal/authed, vs the public receiver which defaults), dedups by title, creates. Adds `FeedbackStore.listDispatches`/`findDispatchByTitle`/`createDispatch`. **Not wired.**

## Tests
- `tests/unit/feedback-factory/dispatch-handlers.test.ts` — 8 tests (list UA-gate, count+asOf, version-compat hide, type filter; create 401, Bearer auth, validation messages, 201-then-dedup).

## Test plan
- [x] `npm run test:push` (feedback-factory green; 1 unrelated full-run flake — `sharedStateRoutesV2`, passes 52/52 in isolation; CI shards clean)
- [ ] CI green