### PR TITLE
feat(release-hygiene): analyze-release.js --ref flag (PR-1 of release-readiness-visibility)

### DIFF
--- a/docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.eli16.md
+++ b/docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.eli16.md
@@ -1,0 +1,38 @@
+# Release-Readiness Visibility — the plain-English version
+
+## What went wrong
+
+For a while, none of my new work was actually reaching anyone. A whole season's worth of finished features — about three dozen of them — were merged and "done," but the part that packages them up and ships them out had quietly stopped happening. Every agent, me included, kept running old code and had no idea. I only found out by accident: I went to use a feature I'd just finished, and my own server said it didn't exist.
+
+Then I found a twin of the same problem. We have a "whiteboard" that's supposed to automatically list every shipped feature so we never forget to finish raising it (turning it from "off and watched" to "on for everyone"). It missed the newest feature — because it only looks at the folder on *my* laptop, and I, being the developer, am usually working on a side-copy that I throw away after merging. So the freshest work is exactly what it can't see.
+
+## The one root cause
+
+Both are the same mistake: **a robot helper trusting whatever's lying around locally or in the moment, and going completely quiet when it decides to do nothing.** The safety checks all worked fine. What was missing was any *sound* when they chose to skip. Green lights everywhere, nothing shipped, nobody told.
+
+When I dug into the actual code, the two helpers fail *different halves* of the same rule:
+
+- **The shipper** looks at the right place (the real shared copy, "main") — but when the release notes aren't ready, it just silently does nothing. To the system, "the notes aren't ready" looks identical to "there's nothing to ship." So it shrugs and stays quiet.
+- **The whiteboard** does the opposite: it goes quiet too, *and* it's looking in the wrong place (my laptop's throwaway copy instead of the real shared one).
+
+## What I'm proposing
+
+Three moves, all the same idea: **look at the real shared copy, and speak up whenever you skip.**
+
+1. **Auto-write a first draft of the release notes.** Here's the lucky part: the tool that *checks* the release notes already figures out everything that changed — every new button, setting, and fix. It just never offered to *write it down*. So I'll teach it a "draft" button: it fills in a starting version of the notes from what it already knows. A human still edits and trims — but the page is never blank, which is the whole reason it went stale. (And it never overwrites anything a human wrote; it only ever adds the bits that are missing.)
+
+2. **A smoke alarm for stuck releases.** A cheap little check that runs on a timer, looks at the *real* shared copy, and asks: "Is anything finished-but-unshipped, and for how long?" If it's been stuck too long, it quietly raises one flag on my attention list — not a phone buzz unless it's really overdue. That's the missing sound. It never ships anything itself and never overrides a safety check — it just makes sure a stuck release can't stay invisible.
+
+3. **Fix the whiteboard's eyesight.** Make it read the real shared copy instead of my laptop, and figure out "is this actually merged?" from the real history — not from leftover scraps on my disk. And if it ever runs and finds nothing new when there *should* be something new, it has to leave a note saying so, instead of silently shrugging.
+
+## What I'm deliberately NOT doing
+
+I could force every single code change to update the release notes by hand. I'm leaving that out for now — the auto-draft plus the smoke alarm cover it, and forcing it would just add a nag to every commit. Easy to add later if the drift comes back.
+
+## The honest part
+
+The reason this is worth doing is that I'm the one who wrote the shortcut. There's literally a comment in the whiteboard's code — that I wrote — admitting "checking the real merge history properly is a refinement I'll do later." That "later" is now. Same with the release notes: the tool was always smart enough to draft them; I just never wired up the draft button.
+
+## Where this is
+
+This is a **draft spec, not code.** Per our own rule, I won't write a line of the actual change until this has been through review and you've signed off. The full technical version is the appendix; a short list of remaining choices (like how many days "too long" should be) is at the end of it.

--- a/docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md
+++ b/docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md
@@ -1,0 +1,297 @@
+---
+title: Release-Readiness Visibility — canonical-source + speak-on-skip for self-driving loops
+approved: true
+eli16-overview: RELEASE-READINESS-VISIBILITY-SPEC.eli16.md
+topic: 14100
+review-convergence: "2026-05-27T19:31:40.008Z"
+review-iterations: 3
+review-completed-at: "2026-05-27T19:31:40.008Z"
+review-report: "docs/specs/reports/release-readiness-visibility-convergence.md"
+---
+
+# Release-Readiness Visibility — making silent self-driving loops loud
+
+**Status:** CONVERGED (3 iterations + v3-final polish, 2026-05-27). `approved:` flag still false — awaiting Justin's structural sign-off. Author: echo · Created: 2026-05-27 · Topic: 14100 ("Release Hygiene")
+**Companion (required):** `RELEASE-READINESS-VISIBILITY-SPEC.eli16.md`
+**Convergence report:** `docs/specs/reports/release-readiness-visibility-convergence.md`
+
+> Per the instar-dev gate, no code ships until convergence (`/spec-converge`, ✅ done) and Justin sets `approved: true`.
+
+## Convergence changelog (v1 → v2 — material findings addressed)
+
+Iteration 1 (5 internal reviewers: security, scalability, adversarial, integration, lessons-aware; external cross-model reviewers skipped per the abbreviated-convergence allowance — framework-API approval not granted for this spec) surfaced **5 SERIOUS findings** in v1, all addressed below:
+
+| # | Finding (reviewer) | v1 problem | v2 fix |
+|---|--------------------|-----------|--------|
+| F1 | Adversarial #1 + Security #1/#2 | Auto-fill could ship **placeholder text** (`"Review the commit for specifics"`) past the publish gate, fleet-wide | §4.1 — auto-draft now writes a specific `<!-- auto-draft-unreviewed -->` poison marker that BOTH `check-upgrade-guide.js` and `publish.yml`'s skip predicate explicitly reject. Drafted text sanitized (strip HTML comments, length-cap, escape markers). |
+| F2 | Adversarial #2 | The alarm silences itself — Layer A clears the same conditions Layer B reads | §4.2 — Layer B's "blocked" detection is **decoupled from NEXT.md state**: gate on unreleased-feature-commits-without-covering-tag + presence of the unreviewed-marker. Auto-draft alone never clears the alarm. |
+| F3 | Scalability #1 | Layer C did ~356 git shell-outs every 6h (one per spec × 178 specs) | §4.3 — single batched `git ls-tree main docs/specs/` + single ancestry pass; per-tick scope limited to specs newer than the last-processed commit. |
+| F4 | Scalability #2 | Layer B re-ran the per-file diff loop every tick, uncached | §4.2 — readiness computation **cached on `main` HEAD SHA + last-tag SHA**; recompute only on SHA change. |
+| F5 | Adversarial #5 + Security #4 + Integration #3 | Reading local `main` gives a false "all clear"; `git fetch` with no timeout could hang the reconciler | §4.3 + §9.1 (resolved) — bounded `git fetch --depth=... --no-tags --no-recurse-submodules` with timeout before each canonical read is **normative**, not optional; on fetch failure → low-priority Attention item, never silent fall-back. Local-tree fall-back is config-gated and emits a degradation event. |
+
+Plus 8 MINOR findings addressed (sanitization details, lifecycle-owner class, supervision tier, stable dedupe key, observability route, migration mechanism naming, multi-machine clarification, rollback checklist). See the iteration-1 catalog in `docs/specs/reports/release-readiness-visibility-convergence.md` (written at Phase 4).
+
+## Convergence changelog (v2 → v3 — iter-2 findings addressed)
+
+Iteration 2 produced **2 CONVERGED** (security, lessons-aware) and **3 NEEDS-ITER-3** (scalability, adversarial, integration). One SERIOUS new blocker + 7 material findings, all addressed below:
+
+| # | Finding (reviewer) | v2 problem | v3 fix |
+|---|--------------------|-----------|--------|
+| F6 | Scalability iter-2 N1 (SERIOUS) | Spec asserted `analyze-release.js --ref=FETCH_HEAD` exists; **it does not** — script hardcodes `${tag}..HEAD`. As-stated Layer B silently runs against local HEAD → recreates F5. | §4.2.2 — explicit enumeration of the script changes (add `--ref` arg parser; thread ref through `getLastReleaseTag`, `getChangedFiles`, `getFileDiff`, `getCommitsSinceTag`); Layer B activation **gated on those landing first** (sequencing in §10). |
+| F7 | Adversarial iter-2 N1 (HIGH) | "Human review" of unreviewed-marker = stripping ~30 bytes; a tired human or a script bypasses the gate. | §4.1.1 — replace bare-strip with **review-receipt attestation**: removing an `auto-draft-unreviewed:<slug>` marker is only valid when accompanied (same section) by a `<!-- reviewed-by: <git-user> @ <ISO-date> -->` line. Validator rejects strip-without-receipt. |
+| F8 | Adversarial iter-2 N2 (MEDIUM) | `canonicalRemote` config = a kill-switch: point at an up-to-date fork → fetch succeeds, alarm silenced forever. | §4.2.2 — allow-list canonical remotes against the hardcoded pattern `^(.+:|.+\/)?JKHeadley/instar(\.git)?$`. An override to a non-matching remote is permitted but raises a HIGH-priority Attention item immediately and stamps the readiness state file with `canonicalRemoteOverridden: true`. |
+| F9 | Adversarial iter-2 N3 (MEDIUM) | `isEpisodeActive(commitSha)` keyed on the oldest-at-detection SHA; finalize misses if oldest churned, or collapses two episodes onto a stale SHA. | §4.2.5 — finalize calls `resolveEpisodesInRange(lastTagSha, newTagSha)`; sentinel auto-resolves every open episode whose oldestSha is an ancestor of `newTagSha`. New unit test for "oldest-commit churn during open episode." |
+| F10 | Adversarial iter-2 N4 (LOW) | K=3 on Layer C's first-enabled tick = 18h silent baseline window. | §4.3.3 — first tick after `featureRollout.canonicalRefScan` flips ON uses K=1; steady-state K=3 thereafter. |
+| F11 | Scalability iter-2 N3 (LOW) | Concurrent Layer B + Layer C fetch race when ticks coincide. | §4.2.2 — shared in-process **fetch-promise lock** (`Map<remote, Promise>`) so concurrent callers await the same fetch; advisory lock `.instar/state/.fetch.lock` for cross-process safety. |
+| F12 | Integration iter-2 N1 (MEDIUM) | `migrateClaudeMd` block for the §4.2.7 CLAUDE.md template line was missing — new agents get it via init; existing agents diverge (Migration Parity violation). | §7 — explicit bullet: idempotent content-sniff in `migrateClaudeMd` keyed on the marker string `/release-readiness` or a distinctive comment. |
+| F13 | Integration iter-2 N3 (LOW) | `scripts/rollback-release-readiness.mjs` doesn't reach agents on npm update (not under `dist/`, not in package `files`). | §10 + §4.2.7 — rollback is now an authenticated endpoint `POST /release-readiness/rollback` (callable by the agent from any session), not a local script. |
+
+Plus minor wording per iter-2 (lock is intra-host §4.1.3; cache-miss cost called out §4.2.3; cat-file batch O(new-only) §4.3.2; non-leader cache lag note §4.2.7; fetch-failure dedupe between B & C §4.2.2). The 5 reviewers + iter-2 catalog will roll into Phase-4 report.
+
+---
+
+## 1. Problem — two silent gaps, one root
+
+**Incident (2026-05-27).** npm publishing had been silently stuck since v1.3.26. A whole minor-release's worth of merged work — the mentor system, the feedback-factory port, multi-machine, threadline fixes, the failure-learning loop (≈36 feature commits / 15 new endpoints / 46 new files) — sat unreleased. Every agent, including Echo, ran stale code without knowing it. Echo only discovered it by going to activate a freshly-merged feature and finding its endpoints 404'ing on its own server.
+
+**Sibling finding (same thread).** The InitiativeTracker's auto-registration (`FeatureRolloutReconciler`, the loop whose entire job is "never forget to mature a shipped feature") missed the just-merged failure-learning-loop spec — because it scans the agent's **local working tree**, and as the developer Echo is usually on a side-branch or temp worktree (cleaned up after merge). The newest, freshly-merged work is exactly what it skips — and it says nothing.
+
+**The root they share:** a self-driving loop trusting whatever happens to be true *locally / in-the-moment*, with **no signal when it skips or no-ops**. Green merges, green CI, no published release, no alert.
+
+### 1.1 Precise mechanism (grounded in the actual code)
+
+The two loops fail **different halves** of the same principle:
+
+| Loop | Reads canonical source (main)? | Speaks up on skip/block? |
+|------|-------------------------------|--------------------------|
+| **Publish** (`.github/workflows/publish.yml`) | ✅ yes — checks out `ref: main` | ❌ **no** — silent skip |
+| **Board auto-register** (`featureRolloutScan.ts` → `FeatureRolloutReconciler`) | ❌ **no** — scans local working tree + local trace receipts | ❌ no — silent skip |
+
+**Publish loop — the silent skip (`publish.yml:44-55`).** If `upgrades/NEXT.md` is missing OR still contains the placeholder markers `[Feature name]` AND `[Capability]`, the job sets `skip=true` and does nothing — no error, no annotation, no alert. **A stalled release is indistinguishable from "nothing to publish."**
+
+**Board reconciler — the wrong source (`src/core/featureRolloutScan.ts`).** Reads `docs/specs/` from `repoRoot` (local working tree, `:66-69`) and local trace receipts `.instar/instar-dev-traces/*.json` (`:46-52`). It *infers* `merged = approved && traceExists` (`:82`); a comment at `:9-10` admits the shortcut: *"Precise git-merge introspection is a refinement."* It never consults git/main.
+
+### 1.2 What this spec deliberately does NOT change
+
+- The safety checks themselves stay as-is in their gating role. We add visibility and canonical sourcing, never relax a gate.
+- Per-PR NEXT.md enforcement remains out of scope (§8).
+
+## 2. What already exists (so we extend, not reinvent)
+
+- **`scripts/analyze-release.js`** classifies every commit since the last tag and produces `generateChangeDescriptions()` (`:488-563`). Today: only grades the guide + recommends a bump; never drafts.
+  - **CAVEAT (per iter-1 Adversarial #1):** `generateChangeDescriptions` emits placeholder strings for unstructured feature commits — `userImpact: 'Review the commit for user-facing changes'`, `agentImpact: 'Review the commit for specifics'` (`:543-547`). v2 sanitization in §4.1 treats this as poison until human-reviewed.
+- **`scripts/check-upgrade-guide.js`** — prepublish gate: validates section presence, finalizes `NEXT.md → {version}.md`, writes a fresh `NEXT_TEMPLATE`.
+- **`upgrade-guide-validator.mjs`** — owns `NEXT_TEMPLATE`, `REQUIRED_SECTIONS`, `validateGuideContent`, `parseBumpType`.
+- **Attention Queue** (`POST /attention`, bearer-gated via `authMiddleware`) — the existing pull surface for near-silent signals.
+- **Job system** — declarative `.instar/jobs/instar/*.md`. Installed via `InstallBuiltinJobs` (always-overwrite contract per its §Seamless Migration Guarantee), called from `PostUpdateMigrator.migrateBuiltinJobs` (`PostUpdateMigrator.ts:1257`). Operator-disabled state preserved per-slug in the schedule manifest.
+- **`FeatureRolloutReconciler` + `featureRolloutScan`** (PR #401) — board auto-register, server-wired at boot + 6h cadence.
+- **`SafeGitExecutor`** — audited git funnel using `execFileSync` (argv array, no shell). Already used by `analyze-release.js`. All git in v2 routes through it.
+
+## 3. Design principle
+
+> **Self-driving loops must (1) read the canonical source of truth (main), and (2) emit a visibility signal whenever they skip, no-op, block, or fail to evaluate.** A skip that produces no signal is a silent failure waiting to accumulate. This applies to the new code in this spec as much as to the loops it fixes — Layer B's own evaluation failures must signal, not silently catch.
+
+## 4. Design
+
+### 4.1 Layer A — Auto-draft the upgrade guide (root-cause removal, with publish-gate safety)
+
+**New mode:** `node scripts/analyze-release.js --draft-guide` writes `upgrades/NEXT.md` from `generateChangeDescriptions(analysis)`, structured into the required sections + a seeded `<!-- bump: TYPE -->`.
+
+#### 4.1.1 The unreviewed-content trust boundary (addresses F1)
+
+The published guide is read into every agent's context fleet-wide. Auto-drafted content has not been reviewed by a human and **must not be allowed past the publish gate** until it is.
+
+- **Poison marker:** every auto-drafted item is wrapped in a stable line marker `<!-- auto-draft-unreviewed: <slug> -->`. The full draft (when NEXT.md is absent/template) gets a top-of-file `<!-- auto-draft-unreviewed-block -->` marker.
+- **Review-receipt attestation (addresses F7, iter-3 Adversarial V2).** Removing an `auto-draft-unreviewed:<slug>` marker is **only valid** when accompanied, within the same section, by a `<!-- reviewed-by: <git-user> @ <ISO-date> :hash=<sha256> -->` line. The validator computes the marker→receipt mapping per section and rejects strip-without-receipt. **`:hash=<sha256>` is required, not optional** (per iter-3 V2) — it captures the canonicalized section text at review time; a later edit that changes the hash auto-invalidates the receipt and re-blocks publish, preventing the failure mode where "I reviewed the draft" silently grants a free pass to subsequent edits. **Canonicalization for the hash:** LF line endings, trim trailing whitespace on each line, exclude the receipt line itself from the input. The receipt's `<git-user>` is matched against `git config user.email` and the date must be within the last 30 days; server clock (CI) is authoritative for the window.
+  - **Scope note (iter-3 Adversarial V1):** the attestation is **anti-bypass** (defeats the `sed`/tired-human strip + script-driven removal), **not anti-impersonation** — an attacker with commit-write can set `git config user.email` to anything. Stronger identity (matching the receipt's `<git-user>` against the commit author of the strip via post-hoc `git log -p`) is a tracked Phase-2 hardening; not required for ratification.
+- **Gate amendment (publish-time):**
+  - `scripts/check-upgrade-guide.js` — `validateGuideContent` is extended to **fail validation** when any `auto-draft-unreviewed` marker remains *or* when a marker was removed without a matching `reviewed-by` receipt.
+  - `.github/workflows/publish.yml:50` — the skip predicate is extended to also set `skip=true` when the unreviewed marker is present. This keeps the silent-skip semantics correct for the unreviewed case (nothing publishes) while §4.2's signal makes the skip visible.
+- **Sanitization of drafted text** (addresses Security #1/#2):
+  1. Strip HTML comments (`<!--…-->`) from any commit-message-sourced text before insertion (prevents forged `<!-- bump: -->` / `<!-- auto-draft-unreviewed -->` markers).
+  2. Length-cap each item summary at 200 chars; truncate with ellipsis.
+  3. Escape markdown control characters that could break section boundaries (backslash-escape leading `#`, `---`).
+  4. Parse all markers only at line-start (e.g. `^<!--\s*bump:`) so embedded text can never forge them.
+- **Placeholder-text neutralization** (addresses F1 root): for any feature commit where `generateChangeDescriptions` would emit one of the fallback strings (`'Review the commit for specifics'`, `'Review the commit for user-facing changes'`), the auto-draft writes `<!-- auto-draft-unreviewed: HUMAN-REQUIRED — describe user impact -->` instead. The marker forces a human edit before publish can clear; the fallback strings never reach the published artifact.
+
+#### 4.1.2 Never-clobber merge
+
+- **NEXT.md absent or pristine template** → write full draft, all items marked unreviewed.
+- **NEXT.md has human content** → reuse `validateGuideCoverage` to compute the delta; append only uncovered items to a clearly-delimited `<!-- auto-draft: uncovered (unreviewed) -->` block (also gated by the unreviewed marker).
+- **Idempotent:** re-running reconciles the auto-draft block against current coverage; never duplicates entries; never grows unboundedly (cap N items per block).
+
+#### 4.1.3 Race guard against publish-finalize (addresses Security #5)
+
+`check-upgrade-guide.finalizeGuide()` renames `NEXT.md → {version}.md`. Layer A must no-op if a finalize is in flight or just completed:
+- Take a process-local advisory lock (`upgrades/.next.lock`, `O_EXCL`) before write. **NB:** this lock is intra-host only — it serializes drafters on the same agent host. The cross-host guarantee (the drafter on the agent host vs. `finalizeGuide()` running in GitHub Actions on a fresh checkout) comes solely from the post-finalize `{version}.md` existence check below + git's own ref-update atomicity at merge.
+- Before write, check that `upgrades/{currentPackageVersion}.md` does NOT exist (i.e. finalize hasn't just run); abort with a degradation event if it does.
+
+#### 4.1.4 Where it runs
+
+Invoked by Layer B's recurring check (so NEXT.md stays seeded continuously) and as `npm run draft:guide` for a developer mid-PR. **It does NOT run inside `publish.yml`** — drafting at publish time would mask a missing human review.
+
+### 4.2 Layer B — The release-readiness signal (decoupled, cached, fail-loud)
+
+A cheap recurring check that makes a stalled release impossible to miss.
+
+#### 4.2.1 Host
+
+A new declarative job at `src/scaffold/templates/jobs/instar/release-readiness-check.md` — shipped to agents via `InstallBuiltinJobs` (always-overwrite of the template body; per-slug `enabled: false` preserved in the schedule manifest). Ships **off by default** under graduated rollout; Echo opts in first.
+
+**Supervision tier (addresses Lessons #2):** Tier 0. Justification: the computation is mechanical (analyze-release JSON parse + threshold), and the user-facing wording is a fixed template (no LLM authorship). If a future variant adds LLM-shaped reasoning to the Attention-item text, the tier reclassifies to Tier 1.
+
+#### 4.2.2 Canonical source — normative (addresses F5, F6, F8, F11)
+
+- Before the readiness computation, run a bounded fetch: `git fetch <canonical-remote> main --depth=1 --no-tags --no-recurse-submodules` with a 30s timeout (configurable: `releaseReadiness.fetchTimeoutMs`).
+- **Canonical remote allow-list (addresses F8, iter-3 Adversarial V3):** the effective remote URL is matched against the hardcoded canonical pattern `^(https://github\.com/|git@github\.com:)JKHeadley/instar(\.git)?$` — anchored on the known canonical host (`github.com`), not "any transport with a `JKHeadley/instar` suffix" (per iter-3 V3, the looser regex matched `git@evil.com:JKHeadley/instar.git`). The default remote is the first configured remote whose URL matches, falling back to `origin`. An override via `releaseReadiness.canonicalRemote` to a non-matching URL is *permitted* (forks legitimately exist) but the sentinel raises a **HIGH-priority Attention item** at startup — *"release-readiness canonical remote overridden to non-canonical URL — alarm cannot guarantee upstream visibility"* — and stamps the readiness state file with `canonicalRemoteOverridden: true` until reverted.
+- **Fetch coordination (addresses F11):** concurrent fetch requests (Layer B + Layer C ticks coinciding) are coalesced via an in-process `Map<remote, Promise<FetchResult>>` — second caller awaits the first's promise rather than racing a duplicate `git fetch`. For cross-process safety on the same host, an advisory lock at `.instar/state/.fetch.lock` (`flock`-style, 60s break-stale) prevents two CLI invocations of the same tick from doubling up. The break-stale window is intentionally `2 × fetchTimeoutMs` (60s = 2 × 30s default) so a real in-flight fetch (bounded by the 30s timeout) cannot trip the break-stale; preserve this relationship if either is tuned (per iter-3 Scalability NF1).
+- **Fetch failure:** do NOT silently fall back. Raise a **low-priority Attention item**: *"Release-readiness check could not reach canonical ref — last evaluated at <ts>."* Deduped per failure episode. **Cross-feature dedupe:** Layer C's local-fallback degradation event (§4.3.1) shares this episode key — a single fetch failure produces one signal, not two.
+- **Analyzer is invoked against the fetched ref, not local HEAD (addresses F6, F-Adversarial #6):** Layer B activation is gated on a prerequisite script change to `analyze-release.js`. That script today hardcodes `${tag}..HEAD` in `getCommitsSinceTag`, `getChangedFiles`, `getFileDiff`, `getDiffStat` (lines 55-93) and parses only `--json`/`--recommend-only` flags (line 36-38). The prerequisite change must:
+  1. Add `--ref=<rev>` to the arg parser (default `HEAD` — preserves today's behavior for the prepublish chain in `package.json`).
+  2. Thread `refArg` through `getLastReleaseTag` (the tag-from-ref query), `getChangedFiles`, `getFileDiff`, `getDiffStat`, `getCommitsSinceTag` — replacing the literal `HEAD` with the parameterized ref.
+  3. Layer B invokes `analyze-release.js --json --ref=FETCH_HEAD`.
+  Until the prerequisite change has merged and is on `main`, Layer B's recurring job must remain `enabled: false` (sequencing in §10). The script-change PR ships independently of the sentinel/job PR.
+
+#### 4.2.3 What it computes (decoupled from NEXT.md — addresses F2)
+
+The "blocked" predicate has two **independent** conditions; either is sufficient:
+
+1. **Backlog with unreviewed coverage:** there are commits classified as `features` or `fixes` since the last published tag (from `analyze-release --json`'s `commitClassification`) **AND** (`NEXT.md` is missing OR matches the publish-skip template predicate OR contains any `auto-draft-unreviewed` marker).
+2. **Deep coverage gaps:** `analyze-release --json` reports `criticalGaps + highGaps > 0`.
+
+The age signal: **days since the OLDEST unreleased feature commit** (not newest — prevents a trickle of merges from resetting the clock, per Adversarial #3).
+
+**Caching (addresses F4):** the full computation is cached at `.instar/state/release-readiness.json` keyed on `{ canonicalHeadSha, lastTagSha, ourScriptVersion }`. A cron tick that finds the cache key valid does no git work beyond `git rev-parse FETCH_HEAD`. **Cache-miss cost (called out per iter-2 Scalability N2):** on a SHA change, the cache miss invokes `analyze-release.js --json` which today walks `getFileDiff` once per changed file (4 passes — routes, CLI, config, exports). For a ~46-file release backlog this is ~180 `git diff -- <file>` shell-outs. This is acceptable because cache miss only fires when canonical `main` advances (release-cadence rate, not cron-cadence rate); recompute does not run per tick. A future optimization could batch the four passes into a single whole-range diff walk — tracked but not blocking.
+
+#### 4.2.4 Signal, not authority (near-silent)
+
+- Below threshold (default: backlog age < 2 days) → **no message.** State file + log line only. Routine status never buzzes the user.
+- At/above threshold → exactly ONE Attention-Queue item per stall episode (`POST /attention`). Priority by age (defaults: low ≥2d, medium ≥4d, high ≥7d).
+- **Stable dedupe key (addresses Lessons #3):** the episode is keyed on **the SHA of the oldest unreleased feature commit** — stable across ticks, stable across re-evaluations, only changes when the backlog truly changes. Not a per-tick episode id (the scar from `feedback_notifications_near_silent`).
+- **Hysteresis (addresses Adversarial #3 flap):** after an auto-resolve, the same episode cannot re-raise within 12 hours (configurable).
+- The check **never publishes, never edits gates, never modifies NEXT.md state.** Signal-only.
+
+#### 4.2.5 Lifecycle owner + race guard (addresses Lessons #1)
+
+A single class `ReleaseReadinessSentinel` owns the episode lifecycle (detect → surface → auto-resolve → reap). Public surface:
+- `tick()` — the cron entry point.
+- `resolveEpisodesInRange(lastTagSha, newTagSha): Resolved[]` — consulted by `check-upgrade-guide.finalizeGuide()` when it ships a new tag. The sentinel iterates open episodes and auto-resolves every one whose `oldestSha` is an ancestor of `newTagSha` (`git merge-base --is-ancestor`). This addresses F9 — a finalize correctly closes episodes even when the oldest-unreleased SHA churned during the open window, and two open episodes spanning overlapping ranges both resolve cleanly. *(Replaces the v2 `isEpisodeActive(commitSha)` predicate, which had the SHA-churn miss documented in iter-2 Adversarial N3.)*
+- `reapStaleEpisodes(now, ttl)` — TTL-reap (default 30 days) for episodes whose backlog vanished without a finalize (e.g. branch abandoned). Reaps the open Attention item with `status: resolved, reason: "stale"` — the reason is loud (recorded, auditable), not a silent catch.
+
+#### 4.2.6 Fail-loud (addresses F-Security #3 + Scalability #5)
+
+Any uncaught error inside `ReleaseReadinessSentinel.tick()` is caught at the top level and converted to a **low-priority Attention item** *"Release-readiness check failed to evaluate at <ts>: <error-class>."* Deduped per error-class episode. **A silent catch is forbidden** — it would re-create the exact silent-failure bug §3 fixes. The fail-loud path is unit-tested.
+
+#### 4.2.7 Observability + rollback surface (addresses Integration #6, F13)
+
+- **`GET /release-readiness`** (bearer-gated): returns `{ state, oldestUnreleasedCommit, backlogAgeDays, lastTickAt, lastSignalAt, openAttentionId, cacheHeadSha, canonicalRemoteOverridden }`. Cheap, static read of the state file. **Multi-machine note (per iter-2 Adversarial N5):** served from the local agent host's cache; on a follower (non-lease-holder) the state may lag the leader by up to one lease-handoff window. The route advertises this in its response header `X-Readiness-Source: leader|follower` so dashboard callers can show staleness if relevant.
+- **`POST /release-readiness/rollback`** (bearer-gated, addresses F13, iter-3 Adversarial V5 + Security audit-log): authenticated revert endpoint that (a) flips `featureRollout.canonicalRefScan` to `false`, (b) disables the recurring job (`enabled: false` in the per-slug schedule manifest), (c) resolves all open release-readiness Attention items with `reason: "rolled-back"`, (d) leaves `.instar/state/release-readiness.json` in place (cheap, idempotent on re-enable). Callable from any agent session — agents do not need to clone the repo or run a local script.
+  - **Rollback is itself a visibility surface, not a silent kill (iter-3 V5).** Every invocation MUST: (1) raise a **HIGH-priority Attention item** *"release-readiness alarm disabled by session <id> at <ts> — re-enable via POST /release-readiness/enable"*; (2) append an audit entry to `logs/sentinel-events.jsonl` (the existing sentinel audit trail); (3) append to a `rollbackHistory[]` array in the readiness state file with `{ts, sessionId, sourceIp, reason}`. Without these, the rollback endpoint would itself be the silent-failure surface this entire spec exists to prevent. The audit trail is unit-tested as part of §6.
+- The CLAUDE.md template gains a one-line mention under "Registry First" (Agent Awareness standard) — see §7 for the matching `migrateClaudeMd` block.
+
+### 4.3 Layer C — Reconciler reads canonical main + speaks on skip (feature-flagged, batched, degradation-safe)
+
+Fix the wrong-source half of the board auto-register.
+
+#### 4.3.1 Feature-flag + graceful degradation (addresses Integration #3)
+
+- New config flag `featureRollout.canonicalRefScan` (default **off** under graduated rollout; flips on per the rollout track).
+- When ON: scan against canonical main as below.
+- When OFF: today's local-tree scan (preserves behavior; no boot risk).
+- **Boot safety:** all canonical-ref work is inside a `try` whose `catch` falls back to the local-tree scan AND emits a single degradation event per failure episode. **The reconciler must never throw into boot.**
+
+#### 4.3.2 Canonical-ref scan, batched (addresses F3)
+
+- Use the same `releaseReadiness.canonicalRemote` + bounded `git fetch` from §4.2.2 (Layer C piggybacks on Layer B's fetch when both run within `releaseReadiness.fetchTimeoutMs` of each other — single fetch per cadence-window).
+- **Single-call tree read:** `git ls-tree -r --name-only FETCH_HEAD docs/specs/` → set of spec paths on main, one call. For each path, read content via a single `git cat-file --batch` invocation (streaming all needed blobs in one process).
+- **Single-pass merge introspection:** instead of per-spec `git merge-base --is-ancestor`, run one `git log FETCH_HEAD --name-only --pretty=format:%H` scoped to `docs/specs/` and `.instar/instar-dev-traces/` — build an in-memory map of spec-path → first-merge-commit. `merged` is now derived in O(1) lookup per spec.
+- **Per-tick scope:** the scan only processes specs whose first-merge-commit is newer than the reconciler's `lastProcessedCommit` cursor (cursor stored alongside the existing OCC `version`). Bounded backfill (unchanged from PR #401) runs only on the first tick after enable. **`cat-file --batch` cost (per iter-2 Scalability N4):** the steady-state read set is `O(new specs since cursor)`, not `O(total specs)`. The bounded backfill (first-tick-after-enable) is the only `O(total)` operation and runs once.
+
+Replaces the inferred `merged = approved && traceExists` shortcut with real merge-state from main.
+
+#### 4.3.3 Skip signal — scoped to avoid noise (addresses Adversarial #4, F10)
+
+When a tick's "should have registered" set is non-empty but the actual register-or-update count is zero, emit a degradation event. After K consecutive ticks (default K=3), escalate to a low-priority Attention item. **First-enabled tick (addresses F10):** the very first tick after `featureRollout.canonicalRefScan` flips ON uses K=1 — there is no baseline yet, and an immediate signal on first enable is the right zero-tolerance behavior. Subsequent ticks revert to K=3 (steady state).
+
+**"Should have registered" is scoped to specs matching the existing registration predicate**, not "any newer spec":
+- Frontmatter `approved: true` AND
+- Frontmatter does NOT include `kind: meta` / `kind: report` (out-of-band specs that legitimately never register) AND
+- Not on the existing reconciler skip-list.
+
+Renames are detected via the `git log --follow` path on the new in-memory map (a rename is a non-skip; the existing record updates). Deletes are non-skips (the spec is gone from main; not eligible to register).
+
+### 4.4 The unifying outcome
+
+| Loop | Reads main | Speaks on skip |
+|------|-----------|----------------|
+| Publish | ✅ (already) | ✅ via Layer B (decoupled, fail-loud) |
+| Board auto-register | ✅ via Layer C (feature-flagged) | ✅ via Layer C scoped skip signal |
+| Layer B itself | ✅ (canonical fetch + cache) | ✅ (fail-loud is normative) |
+
+## 5. Standards conformance (self-audit)
+
+- **Structure > Willpower:** auto-seed > "remember to update NEXT.md"; recurring check > "remember to look"; reconciler reads main > "remember to be on right branch."
+- **No-manual-work:** A removes authoring chore; B removes "did the release go?" check.
+- **Signal vs authority:** B & C are signal-only; blocking authority stays with prepublish/CI gates. The publish-gate amendment in §4.1.1 is the *existing gate* learning to recognize unreviewed content — it does not introduce new blocking authority outside the gate.
+- **Near-silent:** silent below threshold; single deduped item above; auto-resolves; stable SHA-keyed dedupe (not a resettable id, per the documented scar).
+- **3-tier testing:** required (§6).
+- **Migration parity:** new job template + always-overwrite contract + config-defaults via `migrateConfig` (§7).
+- **Side-effects review:** owed at convergence Phase 4 across all 7 dimensions (over/under-signal, abstraction fit, interaction with finalize, rollback cost, etc.).
+- **Verify-wired:** §6 requires wiring-integrity tests + the Phase-1 "feature is alive" E2E for the sentinel, the new route, and the Layer C canonical-scan path.
+- **Bug-fix evidence bar:** §6 reproduces the original silent stall against a fixture, asserts it now surfaces — not just unit tests.
+
+## 6. Testing plan (all three tiers — non-negotiable)
+
+- **Unit:**
+  - `--draft-guide`: empty/template NEXT.md → full draft with all required sections + seeded bump + unreviewed marker; populated NEXT.md → additive uncovered-delta block only, never clobbers; idempotent re-run; placeholder fallbacks neutralized to HUMAN-REQUIRED markers; HTML-comment sanitization; length cap; forged-marker rejection.
+  - Publish-gate amendment: NEXT.md with unreviewed marker → `check-upgrade-guide.js` exits non-zero; `publish.yml` skip predicate (extracted into a unit-testable function) sets skip=true.
+  - `ReleaseReadinessSentinel.tick()`: blocked-and-aged → signal; clean → no signal; backlog-cleared via finalize → auto-resolve race-guard; dedupe across ticks on SHA key; hysteresis prevents re-raise within 12h; thrown error → low-priority Attention (fail-loud).
+  - Canonical fetch: timeout → low-priority Attention; success → cache populates; cache-hit avoids redundant git work.
+  - Layer C: spec on main but absent locally → detected as merged; local-only spec → NOT merged; rename detected (no skip); delete detected (no skip); `kind:meta` excluded from "should have registered"; OFF flag preserves today's behavior.
+  - Skip-signal scoping: tick that should register but doesn't → degradation; K consecutive → Attention.
+- **Integration (HTTP):** `GET /release-readiness` returns expected JSON; `POST /attention` from the sentinel succeeds; bearer-gated correctly.
+- **E2E (the "feature is alive" test):** reproduce the *original failure* — backlog of unreleased features + stale-template NEXT.md — and assert (a) the readiness check raises exactly one Attention item keyed on the oldest-commit SHA, (b) `--draft-guide` produces a NEXT.md that still **fails publish** until the unreviewed markers are removed, (c) removing the markers + finalize auto-resolves the Attention item atomically. Per the bug-fix evidence bar, the original silent stall must be reproduced and shown to now surface.
+
+## 7. Migration parity
+
+- New job template `src/scaffold/templates/jobs/instar/release-readiness-check.md` — installed via `InstallBuiltinJobs.ts` (always-overwrite template body; per-slug `enabled: false` preserved). Ships `enabled: false` in the schedule manifest. Reaches existing agents via `PostUpdateMigrator.migrateBuiltinJobs` (`PostUpdateMigrator.ts:1257`) on update.
+- New config defaults under `releaseReadiness.*` (`backlogAgeDaysSilent`, `*Low/Medium/High`, `fetchTimeoutMs`, `canonicalRemote`, `hysteresisHours`, `skipEscalationK`) and `featureRollout.canonicalRefScan` — added to `ConfigDefaults.ts` AND patched into existing agents via `migrateConfig()` with existence checks (no clobber of operator overrides).
+- **CLAUDE.md template change reaches existing agents (addresses F12, iter-3 Integration I3-N3).** §4.2.7 adds a paragraph under "Registry First" mentioning BOTH endpoints — `GET /release-readiness` (status) AND `POST /release-readiness/rollback` (revert) — so any agent learning the capability also learns the revert path. `src/scaffold/templates.ts` ships the new paragraph for fresh `init`. Per the Migration Parity Standard, existing agents pick it up via `PostUpdateMigrator.migrateClaudeMd` — add an idempotent content-sniff block keyed on the marker string `/release-readiness` (skip if present, append the canonical paragraph covering both endpoints if absent). Without this, new agents would diverge from existing agents on a documented capability — the exact failure the standard exists to prevent.
+- New state file `.instar/state/release-readiness.json` — created on first tick (no migration needed; absent is the valid initial state).
+- `analyze-release.js`, `check-upgrade-guide.js`, `publish.yml` — repo dev-tooling, no agent migration (confirmed: not referenced in `InstallBuiltinJobs.ts`, `templates.ts`, or any migration path). **However:** the `--ref` flag added per F6 must be backward-compatible — default `HEAD` preserves today's prepublish behavior (`npm run check:release` invoked from `prepublishOnly` chain in `package.json:41`). §6 includes a unit test asserting `--ref` absent ⇒ today's exact behavior (iter-2 Integration N2).
+- `featureRolloutScan.ts` / `FeatureRolloutReconciler` — agent-installed runtime code; reaches existing agents on `instar` package update (standard npm path).
+
+## 8. Out of scope
+
+- Per-PR NEXT.md enforcement in the instar-dev commit gate.
+- Relaxing/restructuring existing prepublish/CI gates beyond the unreviewed-marker amendment in §4.1.1.
+- Changes to the release-tier / deployment-lockdown layers in `publish.yml`.
+
+## 9. Open decisions (for iteration 2 + Justin)
+
+1. **Canonical-ref read mechanism for Layer C** — **RESOLVED (normative):** bounded `git fetch --depth=1` then `git show FETCH_HEAD:...` / `cat-file --batch`. The "no-fetch / read local main" option is rejected (stale-local-main is the exact bug). Iter-1 Adversarial #5 + Security #4 + Integration #3.
+2. **Backlog-age thresholds + hysteresis** — propose silent <2d, low ≥2d, medium ≥4d, high ≥7d; hysteresis 12h. Defensible? (Iter 2 may propose tighter.)
+3. **K for Layer C skip-signal escalation** — default 3. Aligned with §4.2's escalation curve?
+4. **Should `GET /release-readiness` be public (no-auth) for dashboard polling, or stay bearer-gated?** Lean bearer-gated for parity with other state endpoints; revisit if dashboard polling cost matters.
+5. **Layer A in CI** — should a bot keep NEXT.md drafted on each main push, in addition to the readiness job + manual? Lean NO — keeps a human firmly in the edit loop.
+
+## 10. Rollout + Rollback
+
+**Rollout — implementation sequencing (addresses F6 + graduated-rollout track):**
+
+The work ships in **three PRs**, in order, because PR-2 depends on a script-level prerequisite:
+
+1. **PR-1 — analyze-release.js `--ref` prerequisite.** Adds the `--ref=<rev>` flag and threads it through `getLastReleaseTag`/`getChangedFiles`/`getFileDiff`/`getDiffStat`/`getCommitsSinceTag`. Default `HEAD` (preserves prepublish chain). Unit test covers `--ref` absent ⇒ today's behavior. Ships independently; can land before either of the next two.
+2. **PR-2 — Layer A + Layer B (sentinel, route, job).** `--draft-guide` mode, publish-gate amendment, `ReleaseReadinessSentinel`, the new job template (ships `enabled: false`), `GET /release-readiness`, `POST /release-readiness/rollback`, all config defaults + migrations. **Hard requirement:** does not merge until PR-1 is on `main`. The CI check (per iter-3 Scalability NF2 + Integration I3-N1) MUST be a **required status check** in PR-2's branch protection (not just an opt-in job step) and MUST genuinely prove PR-1 landed, not just that the flag is silently accepted: invoke `analyze-release.js --ref=<a known prior-release tag SHA> --recommend-only` and assert the output differs from `--ref=HEAD` (i.e. the flag is actually threaded, not silently ignored).
+3. **PR-3 — Layer C (canonical-ref scan).** `featureRollout.canonicalRefScan` default OFF, the batched `ls-tree` / `cat-file --batch` / single-pass merge scan, the K=1-then-K=3 skip signal. Independent of PR-2; can ship in parallel once PR-1 has landed. PR-3 carries the **same required-status-check** as PR-2 (`--ref=<known SHA>` differs from `--ref=HEAD`) — per iter-3 Integration I3-N2, do not rely on author memory to enforce the prerequisite.
+
+`ships-staged: true` in frontmatter for the sentinel and the canonical-ref scan. Stages: dry-run (job ships `enabled: false`, log-only) → live (operator flips `enabled: true`, Echo first) → default-on. Layer C's `featureRollout.canonicalRefScan` advances on the same track.
+
+**Rollback (addresses Integration #4, F13):**
+- **Primary path (any agent, any session):** `POST /release-readiness/rollback` (§4.2.7) — bearer-gated, flips the flag OFF, disables the job, resolves open Attention items as `rolled-back`, leaves the state file in place. **No script clone needed.**
+- Job file `.instar/jobs/instar/release-readiness-check.md` — additionally, `InstallBuiltinJobs` retires the template automatically (flips `enabled: false`) when the template is removed from `src/scaffold/templates/jobs/instar/` in a future package version.
+- Config keys under `releaseReadiness.*` and `featureRollout.canonicalRefScan` — orphaned but harmless on package-level revert.
+- State file `.instar/state/release-readiness.json` — left in place (cheap, ignored). Re-enable picks up the prior cache key on first tick.
+- `featureRolloutScan.ts` changes — reverting the PR restores prior behavior (the OFF flag default means no-op on agents that never enabled it).
+
+**Multi-machine note:** within a single agent, the multi-machine lease guarantees a single readiness-job runner (per the Cross-Machine Seamlessness standard). Across agents (Echo + others), each agent runs its own readiness check on its own attention queue — that's correct, not a dedupe gap. Followers serving `GET /release-readiness` may return cache that lags the leader by ≤1 lease-handoff (advertised via `X-Readiness-Source` header, per §4.2.7).

--- a/docs/specs/reports/release-readiness-visibility-convergence.md
+++ b/docs/specs/reports/release-readiness-visibility-convergence.md
@@ -1,0 +1,97 @@
+# Convergence Report — Release-Readiness Visibility
+
+**Spec:** [docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md](../RELEASE-READINESS-VISIBILITY-SPEC.md)
+**ELI16 companion:** [docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.eli16.md](../RELEASE-READINESS-VISIBILITY-SPEC.eli16.md)
+**Slug:** `release-readiness-visibility`
+**Topic:** 14100 ("Release Hygiene")
+**Author:** echo
+**Converged at:** 2026-05-27 (iteration 3 + v3-final polish)
+**Iterations:** 3
+**Final-round material findings:** 0 (3 LOW polish items absorbed in v3-final pass; 2 LOW-MED items elevated to v3-final by adversarial review)
+**Reviewers:** 5 internal (security, scalability, adversarial, integration, lessons-aware). External cross-model (GPT/Gemini/Grok) deferred per the documented abbreviated-convergence allowance — framework-API approval not granted for this spec.
+
+---
+
+## ELI10 Overview
+
+This spec fixes a class of bug we just got bitten by: **a robot helper that trusts whatever happens to be on the local laptop, then goes completely quiet when it decides to do nothing.** The bite came in two flavors that turned out to share a root: (a) npm publishing silently stopped for a whole minor release worth of work — green merges, green tests, no published package, no alert — because nobody filled the upgrade notes; (b) our "whiteboard" that's supposed to auto-list every shipped feature missed the freshest one because it only looks at the folder on the developer's branch, which is usually a throwaway side-copy. Both have the same shape: a self-driving loop that trusts the wrong source and stays silent when it skips.
+
+The fix is one sentence applied three places: **read the canonical shared copy (main), and speak up whenever you skip.** Concretely: (1) the release-notes file gets auto-filled from the change-list the existing tool already computes — but with a "needs-human-review" stamp that BOTH publish gates reject until a reviewer signs it off (the reviewer signs by adding a content-hash line so they can't pass the gate by just stripping the stamp); (2) a cheap timer-check runs against main, and quietly raises one flag on the attention list when finished features sit unshipped too long — never a chat buzz unless it's really overdue; (3) the whiteboard learns to read main directly (not the local laptop) and leaves a note when it skips work it should have registered. The whole thing ships with a kill-switch endpoint (so an agent can revert if it goes wrong) — but the kill-switch itself raises a high-priority alert so it can't be used to silence the alarm without anyone noticing.
+
+The tradeoff the design accepts: we deliberately leave OUT forcing every single commit to update the release notes (it'd be redundant friction once auto-fill + the alarm exist), and we deliberately leave OUT a content-quality LLM review of auto-drafts (that'd be a separate spec; this one is about *visibility*, not content gating). What we get back is that the original silent-stall failure mode becomes structurally impossible.
+
+## Original vs Converged
+
+What the three review rounds actually changed (in plain English):
+
+- **Originally:** auto-fill would have shipped junk. The existing change-list tool emits fallback strings like *"Review the commit for specifics"* for any commit without structured metadata. Those strings PASS the publish gate (which only checks section presence, not content). So v1's auto-fill would have happily filled the notes with "Review the commit," and the publish workflow would have shipped that fleet-wide as the user-facing notes. **After review:** auto-fill writes a `HUMAN-REQUIRED` marker for those fallback strings; the publish gates were taught to reject any release-notes file with unreviewed markers; a human signals review by adding a hash-locked attestation line tied to their git identity. (Iter-1 Adversarial: SERIOUS → addressed.)
+
+- **Originally:** the alarm could silence itself. v1's "release is blocked" detection reused the same code that auto-fill cleared. So Layer A clears NEXT.md → Layer B sees "no longer blocked" → the alarm goes quiet, while the actual published content is junk. **After review:** the alarm's "blocked" check was decoupled from NEXT.md state — it gates on unreleased feature commits without a covering tag, independent of whether the file looks healthy. Auto-draft alone can never clear the alarm. (Iter-1 Adversarial: SERIOUS → addressed.)
+
+- **Originally:** the whiteboard fix would have been catastrophically slow. With ~178 specs on main and a per-spec `git merge-base` check every 6 hours, the reconciler would have spawned ~356 git processes per tick — seconds of synchronous shell-outs on every reconciler beat. **After review:** the scan was redesigned to use a single batched `git ls-tree` + a single `git log --name-only` ancestry pass, with the reading restricted to specs newer than the last-processed commit. Steady-state cost is "only what's actually new." (Iter-1 Scalability: SERIOUS → addressed.)
+
+- **Originally:** the spec said the readiness check would invoke `analyze-release.js --ref=FETCH_HEAD` — except that flag doesn't exist. The script hardcodes `tag..HEAD`. So as-written, Layer B would have silently run against the local branch — recreating the exact silent-failure bug it was supposed to fix. **After review:** the spec now explicitly enumerates the prerequisite script changes (add the `--ref` parser, thread it through five helpers), splits the work into three PRs in dependency order, and requires a real CI gate (`--ref=<known SHA>` must produce different output from `--ref=HEAD`) so the script change actually landed — not just "the flag was silently accepted." (Iter-2 Scalability: SERIOUS → addressed.)
+
+- **Originally:** human "review" of the unreviewed marker was just `sed -i 's/auto-draft-unreviewed//'`. A tired reviewer, or a script, could strip ~30 bytes and pass the gate. **After review:** removing the marker is only valid if accompanied by a hash-locked `reviewed-by` receipt; the hash captures the section content at review time, so a later edit silently invalidates the receipt and re-blocks publish. (Iter-2 Adversarial: HIGH → addressed.)
+
+- **Originally:** the `canonicalRemote` config was a quiet kill-switch — point it at an up-to-date fork and the alarm silences itself forever. **After review:** the canonical-remote URL is allow-listed against the actual `github.com:JKHeadley/instar` pattern (anchored on the known host); overrides are still permitted (forks legitimately exist) but raise a HIGH-priority Attention item at startup and stamp the state file with `canonicalRemoteOverridden: true` until reverted. (Iter-2/3 Adversarial: addressed.)
+
+- **Originally:** the rollback path was a script under `scripts/` — but agents installed via npm don't receive that directory. So "rollback" required cloning the repo. **After review:** rollback is an authenticated `POST /release-readiness/rollback` endpoint, callable from any agent session. AND because that endpoint is itself a silencing surface, every invocation MUST raise a HIGH-priority Attention item, write to the sentinel audit trail, and append to a `rollbackHistory[]` log — the rollback can't be used to silently disable the alarm. (Iter-2 Integration + Iter-3 Adversarial: addressed.)
+
+## Iteration Summary
+
+| Iteration | Reviewers verdict | Material findings | Spec sections changed |
+|-----------|-------------------|-------------------|-----------------------|
+| 1 | All 5 returned: 2 SERIOUS, 3 MINOR | 5 serious + 8 minor | §4.1 (sanitization + unreviewed-marker + race guard), §4.2 (decoupled-blocked + cache + fail-loud + lifecycle owner + observability route), §4.3 (batched scan + feature-flag + skip-signal scoping), §7 (migration shape), §10 (rollback checklist). v1→v2 rewrite. |
+| 2 | 2 CONVERGED (security, lessons-aware), 3 NEEDS-ITER-3 | 1 SERIOUS (`--ref` flag absent) + 7 material | §4.1.1 (review-receipt attestation), §4.2.2 (canonical-remote allow-list + fetch coordination + explicit script-change enumeration), §4.2.5 (resolveEpisodesInRange), §4.2.7 (rollback endpoint + multi-machine header), §4.3.3 (first-tick K=1), §7 (migrateClaudeMd block), §10 (PR sequencing). v2→v3 rewrite. |
+| 3 | All 5 CONVERGED | 0 SERIOUS/HIGH; 2 LOW-MED elevated by adversarial as "should land in v3-final, not iter 4" + 6 LOW polish | §4.1.1 (`:hash=` required + canonicalization spec + anti-bypass-vs-anti-impersonation note), §4.2.2 (regex tightened to github.com anchor + 60s=2×fetchTimeout note), §4.2.7 (rollback raises HIGH-Attention + sentinel audit + rollbackHistory[]), §7 (CLAUDE.md migration covers both endpoints), §10 (CI gate strengthened + required-status + PR-3 mirror). v3-final polish pass (no iter 4). |
+
+## Full Findings Catalog
+
+### Iteration 1
+
+**Security — MINOR ISSUES (1 elevated).** (1) Prompt-injection via commit messages flowing into fleet-wide guide; (2) forged `<!-- bump: -->` markers; (3) Layer B fail-open contradicts thesis; (4) unbounded git fetch cost; (5) race vs publish-finalize. **Resolutions in v2:** §4.1.1 sanitization (strip HTML comments, length-cap, escape, line-start-only markers), §4.1.1 unreviewed-marker poison-pill, §4.2.6 fail-loud normative, §4.2.2 bounded fetch + signal on failure, §4.1.3 advisory lock + post-finalize check.
+
+**Scalability — SERIOUS ISSUES.** (1) Layer C per-spec git fan-out ~356 calls/6h; (2) Layer B per-tick uncached diff loop; (3) `git fetch` no timeout; (4) growth/reaping unspecified; (5) fail-open re-creates the bug. **Resolutions in v2:** §4.3.2 batched `ls-tree` + single ancestry pass + per-tick cursor scope; §4.2.3 SHA-keyed cache; §4.2.2 bounded fetch with 30s timeout; §4.2.5 `reapStaleEpisodes` 30d TTL; §4.2.6 fail-loud normative.
+
+**Adversarial — SERIOUS ISSUES.** (1) Auto-fill defeats publish gate via fallback text passing section-presence; (2) Layer A clears Layer B's block conditions → alarm silences itself; (3) flap/threshold reset gaming; (4) Layer C false-positive on legitimate non-registrations + false-negative on renames/deletes; (5) stale local main; (6) analyze-release runs HEAD not main. **Resolutions in v2:** §4.1.1 unreviewed-marker rejected by BOTH gates + placeholder-neutralization; §4.2.3 blocked-predicate decoupled from NEXT.md state; §4.2.4 oldest-commit-age + 12h hysteresis + stable SHA-keyed dedupe; §4.3.3 "should have registered" scoped to (approved + non-meta + not-on-skip-list), rename = update, delete = non-skip; §4.2.2 mandatory bounded fetch (Open Decision 1 resolved normative); §4.2.2 analyzer invoked with `--ref=FETCH_HEAD`.
+
+**Integration — MINOR ISSUES (six).** (1) Migration mechanism for new job under-specified; (2) config-defaults migration shape unspecified; (3) Layer C boot fragility / not config-gated; (4) rollback residuals not enumerated; (5) multi-machine dedupe gap unclear; (6) dashboard/observability surface absent. **Resolutions in v2:** §4.2.1 + §7 names `src/scaffold/templates/jobs/instar/release-readiness-check.md` + `InstallBuiltinJobs` always-overwrite + `migrateBuiltinJobs`; §7 names config keys + `migrateConfig`; §4.3.1 feature-flag default-off + try/catch fallback never throws into boot; §10 explicit rollback checklist; §10 multi-machine clarification; §4.2.7 new `GET /release-readiness` route + CLAUDE.md template mention.
+
+**Lessons-aware — MINOR ISSUES.** (1) Own-the-lifecycle pattern not engaged for Layer B (no owner class, no race guard against `finalizeGuide()`); (2) supervision tier undeclared; (3) dedupe-key stability not specified (risk of the resettable-id scar from `feedback_notifications_near_silent`). **Resolutions in v2:** §4.2.5 introduces `ReleaseReadinessSentinel` as lifecycle owner with `isEpisodeActive(commitSha)` race guard + `reapStaleEpisodes`; §4.2.1 declares Tier 0 with mechanical-computation justification; §4.2.4 dedupe keyed on oldest-unreleased-commit SHA + 12h hysteresis.
+
+### Iteration 2
+
+**Security — CONVERGED.** All 5 iter-1 findings adequately addressed. Three wording-level new notes: (N1) clarify the advisory lock is intra-host only; (N2) acknowledge field set on `GET /release-readiness` is non-sensitive; (N3) cross-feature fetch-failure dedupe between Layer B + Layer C. **Resolutions in v3:** §4.1.3 NB on intra-host scope; §4.2.2 fetch-failure dedupe between B & C.
+
+**Scalability — NEEDS-ITER-3 (1 SERIOUS blocker).** **N1 SERIOUS:** spec asserts `analyze-release.js --ref=FETCH_HEAD` exists; it does not — script hardcodes `${tag}..HEAD`. As-written, Layer B silently runs against local HEAD → recreates the exact silent-failure bug being fixed. **N2 MEDIUM:** cache-miss path still pays per-file diff cost. **N3 LOW:** concurrent fetch race. **N4 LOW:** `cat-file --batch` unbounded. **Resolutions in v3:** §4.2.2 enumerates the precise script changes (add `--ref` parser; thread through 5 helpers) + §10 PR-1 prerequisite + CI gate; §4.2.3 explicit cache-miss cost justification (release-cadence not cron-cadence); §4.2.2 in-process `Map<remote,Promise>` + `flock` advisory lock; §4.3.2 steady-state O(new specs only).
+
+**Adversarial — NEEDS-ITER-3 (2 HIGH/MEDIUM, 3 LOW).** **N1 HIGH:** unreviewed-marker review = stripping ~30 bytes; tired-human/script bypass. **N2 MEDIUM:** `canonicalRemote` config is a kill-switch. **N3 MEDIUM:** `isEpisodeActive` keyed on oldest-at-detection SHA; SHA churn misses. **N4 LOW:** K=3 first-tick = 18h silent baseline. **N5 LOW:** non-leader cache lag invisible. **Resolutions in v3:** §4.1.1 review-receipt attestation; §4.2.2 allow-list + HIGH-priority Attention on override; §4.2.5 `resolveEpisodesInRange(lastTagSha, newTagSha)`; §4.3.3 first-tick K=1; §4.2.7 `X-Readiness-Source` header.
+
+**Integration — NEEDS-ITER-3 (3 LOW-MEDIUM).** **N1 MEDIUM:** `migrateClaudeMd` block missing → existing agents diverge from new agents (Migration Parity violation). **N2 LOW:** prepublish backward-compat for the new `--ref` flag untested. **N3 LOW:** `rollback-release-readiness.mjs` lives under `scripts/` — agents don't receive that on npm update. **Resolutions in v3:** §7 explicit `migrateClaudeMd` bullet with content-sniff on `/release-readiness` marker; §6 + §7 unit test asserting `--ref` absent ⇒ today's behavior; §4.2.7 + §10 rollback is an authenticated endpoint, not a local script.
+
+**Lessons-aware — CONVERGED.** All 3 iter-1 findings cleanly addressed (§4.2.5 lifecycle owner mirrors `CompactionSentinel` pattern; §4.2.1 Tier 0 declaration; §4.2.4 SHA-keyed stable dedupe with explicit callback to the documented scar). No new principle contradictions.
+
+### Iteration 3
+
+**Security — CONVERGED.** All v2 wording notes absorbed. Three LOW recommended fast-follows: audit-log on rollback (absorbed in v3-final §4.2.7), hash canonicalization spec (absorbed in v3-final §4.1.1), receipt↔commit-author binding (tracked as a Phase-2 follow-up; noted in v3-final §4.1.1).
+
+**Scalability — CONVERGED.** All 4 iter-2 findings addressed with code-grounded fixes. Two LOW additions: NF1 — note 60s = 2× fetchTimeoutMs (absorbed in v3-final §4.2.2); NF2 — strengthen PR-2 CI gate to use a known prior-release SHA so a silently-ignored flag fails the gate (absorbed in v3-final §10).
+
+**Adversarial — CONVERGED WITH TWO SMALL v3-FINAL EDITS.** All 5 iter-2 findings cleanly closed. **V2 LOW-MED:** require `:hash=` (not optional) on the review-receipt — absorbed in v3-final §4.1.1. **V5 MEDIUM:** rollback MUST raise HIGH-priority Attention + write to `logs/sentinel-events.jsonl` + `rollbackHistory[]` (otherwise the rollback endpoint is itself a silent-failure surface — exactly what this spec exists to prevent) — absorbed in v3-final §4.2.7. **V1 LOW:** receipts are anti-bypass, not anti-impersonation — noted as a scope clarification in v3-final §4.1.1, with stronger identity binding tracked as Phase 2. **V3 LOW:** canonical-remote regex tightened to require `github.com` host anchor — absorbed in v3-final §4.2.2. **V4 LOW:** out-of-order Tag race in `resolveEpisodesInRange` — design holds (ancestry check is idempotent under either order); no change needed.
+
+**Integration — CONVERGED.** All 3 iter-2 findings substantively addressed. Three LOW polish items absorbed in v3-final: (I3-N1) PR-2 CI gate as required-status check in branch protection (absorbed in §10); (I3-N2) PR-3 mirror gate (absorbed in §10); (I3-N3) CLAUDE.md migration block covers BOTH endpoints (GET status + POST rollback) so agents learn the revert path alongside the status path (absorbed in §7).
+
+**Lessons-aware — CONVERGED.** Targeted re-check against the five v3 areas (review-receipt vs. signal-vs-authority, canonical-remote allow-list vs. structure-vs-willpower, `resolveEpisodesInRange` vs. own-the-lifecycle, rollback endpoint vs. signal-vs-authority, first-tick K=1 vs. near-silent) — all clean. No new principle/lesson contradictions.
+
+## Convergence Verdict
+
+**Converged at iteration 3 + v3-final polish pass.** The final review round produced zero SERIOUS or HIGH findings; two LOW-MED items the adversarial reviewer explicitly flagged as "should land in v3-final, not iter 4" were absorbed in-spec along with the LOW polish items. The five reviewers' iter-3 verdicts: CONVERGED across the board.
+
+The spec's three layers and the unifying principle (canonical-source + speak-on-skip) survived review intact; the rewrites strengthened sanitization, decoupled the alarm from the file it auto-fills, made the canonical-source read normative and feature-flagged, gave the lifecycle a named owner with a real race-guard against publish-finalize, and turned the rollback endpoint from a potential silencing surface into a loud-and-audited one.
+
+**Phase-2 hardening (tracked, not blocking ratification):** (a) bind the review-receipt's git-identity to the commit author of the strip via post-hoc `git log -p` verification; (b) batch the four `getFileDiff` passes in `analyze-release.js` into a single whole-range diff walk.
+
+**Spec is ready for user review and approval.**
+
+To approve: edit the spec's frontmatter to set `approved: true` (or run `instar spec approve release-readiness-visibility`), then `/instar-dev` can proceed with implementation, following the three-PR sequencing in §10.

--- a/scripts/analyze-release.js
+++ b/scripts/analyze-release.js
@@ -37,6 +37,20 @@ const args = process.argv.slice(2);
 const JSON_ONLY = args.includes('--json');
 const RECOMMEND_ONLY = args.includes('--recommend-only');
 
+// --ref=<rev> selects the tip the analysis runs against (default HEAD).
+// Layer B of the release-readiness-visibility spec passes --ref=FETCH_HEAD so the
+// readiness check evaluates against canonical main, not the local checkout. The
+// default preserves the prepublish chain's behavior exactly (it never passes --ref).
+const REF = (() => {
+  const flag = args.find((a) => a === '--ref' || a.startsWith('--ref='));
+  if (!flag) return 'HEAD';
+  if (flag === '--ref') {
+    const idx = args.indexOf(flag);
+    return args[idx + 1] || 'HEAD';
+  }
+  return flag.slice('--ref='.length) || 'HEAD';
+})();
+
 function log(msg) {
   if (!JSON_ONLY) process.stderr.write(msg + '\n');
 }
@@ -53,16 +67,16 @@ function gitRead(args) {
 
 function getLastReleaseTag() {
   try {
-    return gitRead(['describe', '--tags', '--abbrev=0']).trim();
+    return gitRead(['describe', '--tags', '--abbrev=0', REF]).trim();
   } catch {
-    // No tags at all — diff against the initial commit
-    return gitRead(['rev-list', '--max-parents=0', 'HEAD']).trim();
+    // No tags at all — diff against the initial commit reachable from REF
+    return gitRead(['rev-list', '--max-parents=0', REF]).trim();
   }
 }
 
 function getCommitsSinceTag(tag) {
   try {
-    const raw = gitRead(['log', `${tag}..HEAD`, '--oneline', '--no-merges']);
+    const raw = gitRead(['log', `${tag}..${REF}`, '--oneline', '--no-merges']);
     return raw.trim().split('\n').filter(Boolean).map(line => {
       const [hash, ...rest] = line.split(' ');
       return { hash, message: rest.join(' ') };
@@ -74,7 +88,7 @@ function getCommitsSinceTag(tag) {
 
 function getDiffStat(tag) {
   try {
-    return gitRead(['diff', `${tag}..HEAD`, '--stat']).trim();
+    return gitRead(['diff', `${tag}..${REF}`, '--stat']).trim();
   } catch {
     return '';
   }
@@ -82,7 +96,7 @@ function getDiffStat(tag) {
 
 function getChangedFiles(tag) {
   try {
-    const raw = gitRead(['diff', `${tag}..HEAD`, '--name-status']);
+    const raw = gitRead(['diff', `${tag}..${REF}`, '--name-status']);
     return raw.trim().split('\n').filter(Boolean).map(line => {
       const [status, ...pathParts] = line.split('\t');
       return { status: status.charAt(0), file: pathParts.join('\t') };
@@ -94,7 +108,7 @@ function getChangedFiles(tag) {
 
 function getFileDiff(tag, file) {
   try {
-    return gitRead(['diff', `${tag}..HEAD`, '--', file]);
+    return gitRead(['diff', `${tag}..${REF}`, '--', file]);
   } catch {
     return '';
   }

--- a/tests/unit/analyze-release-ref-flag.test.ts
+++ b/tests/unit/analyze-release-ref-flag.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests — analyze-release.js `--ref` flag (release-readiness-visibility spec, PR-1).
+ *
+ * Layer B of the spec evaluates release-readiness against canonical `main`
+ * (FETCH_HEAD), not the local checkout. That requires analyze-release.js to
+ * accept a `--ref=<rev>` flag and thread it through the git range queries.
+ * Before this flag, the script hardcoded `${tag}..HEAD` — so Layer B would have
+ * silently analyzed local HEAD, recreating the exact silent-staleness bug the
+ * spec exists to fix.
+ *
+ * Coverage (the §10 CI gate depends on this):
+ *   1. Default (no --ref) analyzes HEAD — preserves the prepublish chain's behavior.
+ *   2. --ref=HEAD is identical to the default.
+ *   3. --ref=<an earlier commit> changes the analyzed range — different nearest
+ *      tag AND a different commit count (proves the ref is actually threaded,
+ *      not silently ignored).
+ *   4. --ref <space-separated form> parses identically to --ref=<equals form>.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync, execSync } from 'node:child_process';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('analyze-release.js --ref flag', () => {
+  let tmpDir: string;
+  let betaSha: string;
+  const scriptPath = path.resolve(__dirname, '../../scripts/analyze-release.js');
+
+  function git(args: string[]) {
+    return execFileSync('git', args, {
+      cwd: tmpDir,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  }
+
+  function commit(message: string, file: string) {
+    fs.writeFileSync(path.join(tmpDir, file), `${file}\n`);
+    git(['add', file]);
+    git(['commit', '-m', message]);
+    return git(['rev-parse', 'HEAD']).trim();
+  }
+
+  /** Run the copied script and parse its --json report. */
+  function runJson(extraArgs: string[]): { commitCount: number; fileCount: number; lastTag: string } {
+    const localScript = path.join(tmpDir, 'scripts', 'analyze-release.js');
+    const out = execSync(`node "${localScript}" --json ${extraArgs.join(' ')}`, {
+      cwd: tmpDir,
+      encoding: 'utf-8',
+      env: { ...process.env, NODE_PATH: '' },
+    });
+    const report = JSON.parse(out);
+    return {
+      commitCount: report.commitCount,
+      fileCount: report.fileCount,
+      lastTag: report.lastTag,
+    };
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'analyze-release-ref-'));
+
+    // Copy the real script into the temp project so __dirname/ROOT resolve here.
+    const scriptsDir = path.join(tmpDir, 'scripts');
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(scriptsDir, 'analyze-release.js'),
+      fs.readFileSync(scriptPath, 'utf-8'),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'fixture', version: '9.9.9', type: 'module' }, null, 2),
+    );
+
+    // Deterministic git fixture, isolated from the developer's global config.
+    git(['init', '-q']);
+    git(['config', 'user.email', 'fixture@instar.local']);
+    git(['config', 'user.name', 'Fixture']);
+    git(['config', 'commit.gpgsign', 'false']);
+
+    // History:
+    //   C1 (initial) ── tag v0.0.1
+    //   C2 feat alpha
+    //   C3 feat beta   ← betaSha (nearest tag v0.0.1, 2 commits since)
+    //   C4 feat gamma ── tag v0.0.2
+    //   C5 feat delta  (HEAD; nearest tag v0.0.2, 1 commit since)
+    commit('chore: initial', 'README.md');
+    git(['tag', 'v0.0.1']);
+    commit('feat: add alpha', 'alpha.txt');
+    betaSha = commit('feat: add beta', 'beta.txt');
+    commit('feat: add gamma', 'gamma.txt');
+    git(['tag', 'v0.0.2']);
+    commit('feat: add delta', 'delta.txt');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/analyze-release-ref-flag.test.ts:afterEach',
+    });
+  });
+
+  it('default (no --ref) analyzes HEAD — nearest tag v0.0.2, one commit since (C5)', () => {
+    const r = runJson([]);
+    expect(r.lastTag).toBe('v0.0.2');
+    expect(r.commitCount).toBe(1); // only C5 (delta) since v0.0.2
+    expect(r.fileCount).toBe(1);
+  });
+
+  it('--ref=HEAD is identical to the default', () => {
+    const def = runJson([]);
+    const headRef = runJson(['--ref=HEAD']);
+    expect(headRef).toEqual(def);
+  });
+
+  it('--ref=<earlier commit> changes the analyzed tip — different nearest tag and count', () => {
+    // From C3 (beta) the nearest tag is v0.0.1, with 2 commits since (alpha, beta).
+    // If --ref were silently ignored, this would still report HEAD's v0.0.2 / 1 commit.
+    const r = runJson([`--ref=${betaSha}`]);
+    expect(r.lastTag).toBe('v0.0.1');
+    expect(r.commitCount).toBe(2);
+    expect(r.fileCount).toBe(2);
+  });
+
+  it('--ref <space form> parses identically to --ref=<equals form>', () => {
+    const equalsForm = runJson([`--ref=${betaSha}`]);
+    const spaceForm = runJson(['--ref', betaSha]);
+    expect(spaceForm).toEqual(equalsForm);
+  });
+});

--- a/tests/unit/analyze-release-ref-flag.test.ts
+++ b/tests/unit/analyze-release-ref-flag.test.ts
@@ -21,7 +21,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execFileSync, execSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 describe('analyze-release.js --ref flag', () => {
@@ -29,11 +30,12 @@ describe('analyze-release.js --ref flag', () => {
   let betaSha: string;
   const scriptPath = path.resolve(__dirname, '../../scripts/analyze-release.js');
 
-  function git(args: string[]) {
-    return execFileSync('git', args, {
+  function git(args: string[]): string {
+    // SafeGitExecutor.run routes read verbs → readSync and others → execSync.
+    // Operations run inside an OS tmpdir, so the SourceTreeGuard never trips.
+    return SafeGitExecutor.run(args, {
       cwd: tmpDir,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
+      operation: 'tests/unit/analyze-release-ref-flag.test.ts:git',
     });
   }
 

--- a/upgrades/side-effects/release-readiness-visibility-pr1.md
+++ b/upgrades/side-effects/release-readiness-visibility-pr1.md
@@ -1,0 +1,26 @@
+# Side-Effects Review — Release-Readiness Visibility, PR-1 (`analyze-release.js --ref`)
+
+**Spec:** docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md (converged + approved 2026-05-27)
+**Scope of this PR:** the prerequisite-only change — add a `--ref=<rev>` flag to `scripts/analyze-release.js` and thread it through the git-range queries. No sentinel, no job, no routes (those are PR-2/PR-3). Plus the approved spec docs + convergence report + a unit test.
+
+## What changed
+
+- `scripts/analyze-release.js`: new `REF` constant parsed from `--ref=<rev>` / `--ref <rev>` (default `HEAD`). Threaded into `getLastReleaseTag`, `getCommitsSinceTag`, `getDiffStat`, `getChangedFiles`, `getFileDiff` — every place that previously hardcoded `HEAD`.
+- `tests/unit/analyze-release-ref-flag.test.ts`: 4 subprocess tests against a deterministic git fixture (default ≡ HEAD; `--ref=HEAD` ≡ default; `--ref=<earlier commit>` changes the analyzed tip — different nearest tag + commit count; space form ≡ equals form).
+- Spec + ELI16 + convergence report (docs only).
+
+## Side-effects analysis
+
+**Over/under-reach.** The change is additive and opt-in. `REF` defaults to `'HEAD'`, so every existing caller — most importantly the `prepublishOnly` chain (`npm run check:release` → `analyze-release.js`, which never passes `--ref`) — produces byte-identical behavior to before. There is no path where omitting the flag changes output. Verified by the `--ref=HEAD ≡ default` test.
+
+**Level-of-abstraction fit.** The ref is a module-level constant rather than a threaded parameter, matching the script's existing shape (`getLastReleaseTag()` already took no args and implicitly used HEAD). This keeps the diff minimal and the helpers' signatures unchanged for the four that already took `tag`.
+
+**Signal vs authority.** N/A for this PR — `analyze-release.js` is a read-only analyzer (it only reads git and prints a report). It gates nothing. The flag does not grant or remove any blocking authority. The downstream consumer that WILL use `--ref=FETCH_HEAD` (Layer B's readiness sentinel) is signal-only and ships in PR-2.
+
+**Interactions.** The only consumer touched today is the prepublish chain, which is unaffected (default HEAD). `check-upgrade-guide.js` is not touched. The `--ref` flag is forward-looking: PR-2's readiness job will invoke `--ref=FETCH_HEAD` after a bounded fetch of canonical main. Per §10 sequencing, PR-2 does not merge until this PR is on main, enforced by a required-status CI check that asserts `--ref=<known SHA>` differs from `--ref=HEAD` (i.e. the flag is genuinely threaded, not silently ignored).
+
+**Input safety.** `REF` flows only into `git` argv arrays via the existing `gitRead` helper (`execFileSync`, no shell) — no shell-injection surface. A bogus ref makes the underlying `git` call fail and the existing `try/catch` returns the empty/initial-commit fallback, exactly as today for a tagless repo.
+
+**Rollback cost.** Trivial — reverting this commit restores the hardcoded `HEAD`. No state, no config, no migration introduced by PR-1. The unit test reverts with it.
+
+**Testing.** Unit tier covered (4 tests, green). Integration/E2E tiers are not applicable to PR-1 in isolation (no routes/jobs yet) and land with PR-2, which adds the `GET /release-readiness` route + the "feature is alive" E2E that exercises the full readiness pipeline including the `--ref` path.


### PR DESCRIPTION
## Summary

PR-1 of 3 for the **Release-Readiness Visibility** spec (converged + approved, topic 14100). This is the prerequisite-only change.

- Adds a `--ref=<rev>` flag to `scripts/analyze-release.js` (default `HEAD`), threaded through `getLastReleaseTag`, `getCommitsSinceTag`, `getDiffStat`, `getChangedFiles`, `getFileDiff`.
- **Why:** Layer B's release-readiness sentinel (PR-2) must evaluate against canonical `main` (FETCH_HEAD), not the local checkout. Without `--ref`, it would silently analyze local HEAD — recreating the exact silent-staleness bug the spec exists to fix.
- Default `HEAD` preserves the `prepublishOnly` chain byte-for-byte.
- Ships the converged + approved spec, ELI16 companion, convergence report (3 iterations, 5 reviewers), and the PR-1 side-effects review.

## Spec

- `docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md` (approved)
- `docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.eli16.md`
- `docs/specs/reports/release-readiness-visibility-convergence.md`

## Test plan

- [x] Unit: `tests/unit/analyze-release-ref-flag.test.ts` (4 tests, green) — default ≡ HEAD; `--ref=HEAD` ≡ default; `--ref=<earlier commit>` changes the analyzed tip (different nearest tag + commit count); space form ≡ equals form.
- [ ] PR-2 adds the integration + "feature is alive" E2E that exercises the full readiness pipeline including the `--ref=FETCH_HEAD` path.

## Sequencing

Per spec §10: PR-2 (Layer A+B sentinel) and PR-3 (Layer C canonical scan) do **not** merge until this PR is on `main`, enforced by a required-status CI check asserting `--ref=<known SHA>` differs from `--ref=HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)