### PR TITLE
feat(messaging): agent-to-agent Telegram comms primitive — core logic (PR 1/3)

### DIFF
--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.eli16.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.eli16.md
@@ -1,0 +1,64 @@
+# Making the mentor actually testable with Codey — in plain terms
+
+## What this fixes
+
+Today the mentor system is built but can't truly run against Codey, for three reasons we
+caught during the dry-run yesterday:
+
+1. The "is Codey free to be mentored right now?" check isn't actually about Codey — it
+   just looks at whether *I* have anything going on, which I always do. So it'd back off
+   forever and never run.
+2. The "budget" cap is a dollar amount, but we're on a Claude subscription, not a per-token
+   bill. The setting was never read by any code anyway, and nothing would ping you if it
+   tripped.
+3. When the mentor decides to send Codey a note, my side writes the note to a file — but
+   nothing on Codey's side reads that file. So a "live test" today would write into the
+   void.
+
+## How we fix all three
+
+**1. A real "is Codey free?" check.** Codey adds a small public status page on his side
+that simply says: am I busy or free right now, plus when I last started up. I check that
+page before each mentor cycle. If anything's off — page unreachable, weird response, just-
+restarted, anything ambiguous — I treat him as busy and wait. Better to skip a cycle than
+to mentor at a bad moment.
+
+**2. The budget gets recast in the right units.** Instead of pretend dollars, I use your
+real quota meter (the one tracking your 5-hour and weekly limits) and a token-spend
+ceiling — and I ping you the *first* time we hit the cap, and again when we recover. If we
+trip and recover and re-trip the same day, you hear about all three. The state is written
+to disk so a server restart doesn't re-spam you with old alerts.
+
+**3. The note actually reaches Codey.** I keep writing my notes to a file (that part was
+the *deliberate* safe choice — no spawning, no loops). Codey adds a small background job
+on his side that wakes up every minute, reads any new notes from that file, and feeds them
+to him as if you'd typed them. Then he writes his reply back to a second file my side
+reads.
+
+Codey himself designed his side (he picked the simpler, more crash-survivable approach and
+specified the message format with built-in safety checks). The whole loop has eight rules
+that make it structurally impossible for us to bounce messages back and forth — and we
+hardened those rules so they're enforced by the code shape itself, not just by good
+intentions.
+
+## What we learned from yesterday — baked in
+
+You called out two things I should have caught: the busy-check was bogus, and the budget
+was a dead setting. My new rule (now durable in my memory): before I tell you a gate, limit,
+or delivery "works," I read the actual code and tell you which file:line I checked. The
+revised spec applies this everywhere — every claim cites the code, and a third gap I caught
+*myself* this morning (the file Codey never reads) only surfaced because I applied that rule
+before claiming "live test, ready to go."
+
+## What's next
+
+This spec went through two rounds of multi-reviewer convergence (three reviewers each
+round). The reviewers caught the original "/sessions has no idle field and needs auth"
+blocker that would've broken the live test, plus the symlink/restart/concurrency edge cases
+worth defending against ahead of time. All addressed.
+
+Codey has agreed to his side of the design (verified on Threadline). I'm sending him the
+final spec to confirm the two small new requests on his side that came out of convergence
+(the small /idle endpoint and pinning a shared contract version). Once you approve, I'll
+build my side through our normal gate, Codey builds his, both ship, then we run **one
+supervised live cycle against him with you watching** — the actual test.

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.eli16.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.eli16.md
@@ -1,64 +1,76 @@
-# Making the mentor actually testable with Codey — in plain terms
+# Mentor live-readiness — plain-English summary (for your approval)
 
-## What this fixes
+## What this is, in one paragraph
 
-Today the mentor system is built but can't truly run against Codey, for three reasons we
-caught during the dry-run yesterday:
+The mentor's "user-hat" side now uses Telegram (your channel for talking to Codey), the
+way you said it should. To make that work cleanly and reusably I'm also building a small
+**building-block primitive** any two of my agents can use to talk over Telegram
+*knowingly* — every agent-to-agent message carries a visible tag like
+`[a2a:from=echo to=instar-codey role=mentor id=… corr=… ts=… v=1]`, the receiver checks
+the sender is actually a known bot (not a human who typed the tag — real defense), and
+the receive side has the anti-bounce machinery baked in (it knows not to send courtesy
+replies, replies are tagged back with a matching id, etc.). The mentor is just its
+first consumer.
 
-1. The "is Codey free to be mentored right now?" check isn't actually about Codey — it
-   just looks at whether *I* have anything going on, which I always do. So it'd back off
-   forever and never run.
-2. The "budget" cap is a dollar amount, but we're on a Claude subscription, not a per-token
-   bill. The setting was never read by any code anyway, and nothing would ping you if it
-   tripped.
-3. When the mentor decides to send Codey a note, my side writes the note to a file — but
-   nothing on Codey's side reads that file. So a "live test" today would write into the
-   void.
+## The three live-readiness fixes (mentor)
 
-## How we fix all three
+1. **Is-Codey-free check** — Codey adds a tiny public status page (`/idle`) so my probe
+   has a real signal instead of asking the wrong question. If anything is ambiguous
+   I treat him as busy.
+2. **Talk to Codey via Telegram** — I mint a dedicated mentor bot (per your option C),
+   message Codey from that bot in a dedicated Mentor topic on his setup, he processes
+   it as a user-style prompt, replies tagged back, my Stage-B reads the reply.
+3. **Budget on real units** — I gate against your quota meter (5-hour / weekly) and a
+   token ceiling, NOT pretend dollars. **Honest scope note**: today the ceiling only
+   captures the Stage-B analysis spend; the spawned Stage-A session's tokens go to the
+   ledger without a mentor tag, so they bypass the ceiling. I'm shipping the cap with
+   the honest name (`stageBTokenCeiling`) and a tracked follow-up to bring Stage-A
+   under the same cap — rather than claiming coverage I don't have.
 
-**1. A real "is Codey free?" check.** Codey adds a small public status page on his side
-that simply says: am I busy or free right now, plus when I last started up. I check that
-page before each mentor cycle. If anything's off — page unreachable, weird response, just-
-restarted, anything ambiguous — I treat him as busy and wait. Better to skip a cycle than
-to mentor at a bad moment.
+## What round-1 file-based design got, and what the substrate change cost
 
-**2. The budget gets recast in the right units.** Instead of pretend dollars, I use your
-real quota meter (the one tracking your 5-hour and weekly limits) and a token-spend
-ceiling — and I ping you the *first* time we hit the cap, and again when we recover. If we
-trip and recover and re-trip the same day, you hear about all three. The state is written
-to disk so a server restart doesn't re-spam you with old alerts.
+The earlier file-based version is gone — Justin caught the substrate mistake and a
+substantial amount of round-1 hardening (symlink defenses, schema versioning between
+two files, cross-agent file writes, file-poll job on Codey's side) just drops out. In
+exchange, the new substrate brings new concerns the reviewers caught:
 
-**3. The note actually reaches Codey.** I keep writing my notes to a file (that part was
-the *deliberate* safe choice — no spawning, no loops). Codey adds a small background job
-on his side that wakes up every minute, reads any new notes from that file, and feeds them
-to him as if you'd typed them. Then he writes his reply back to a second file my side
-reads.
+- **The existing TelegramAdapter wasn't built for two bots in one process.** It writes
+  state to fixed filenames; two bots would clobber each other. Fix: give the second bot
+  its own namespaced sub-folder for its state, plus a flag to skip auto-creating a
+  duplicate Lifeline topic.
+- **The Adapter only allows one incoming-message handler at a time.** The "agent
+  handler runs before normal user handling" rule needed a real implementation: I'm
+  wrapping at the registration site so the agent-handler runs first and falls through
+  to the existing user handler if the message isn't an agent message.
+- **A real user could type the agent tag and trick the system.** Defense: the receive
+  side checks the sender is actually a bot (Telegram's `is_bot` flag and the bot ID),
+  not just trust the tag text. A user typing the tag gets dropped, audited, never
+  routed to the mentor handler.
+- **The "ping-pong" Justin worried about could come back slower.** If a single
+  round-trip takes longer than my 15-minute tick, a naive next-tick would re-send.
+  Fix: I track outstanding prompts; the tick refuses to send while one is in flight,
+  and if it's still unanswered after 20 minutes I surface that as a degradation event
+  + Attention queue entry. The same tracker tells me "Codey never replied" so silent
+  reply-loss is observable.
+- **A compromised Codey shouldn't be able to side-channel** by sending unexpected role
+  types to my mentor bot. Fix: the accept-list is per-source — Codey-from-Echo's-
+  perspective is allowed exactly one incoming role (`mentor-reply`) and nothing else.
 
-Codey himself designed his side (he picked the simpler, more crash-survivable approach and
-specified the message format with built-in safety checks). The whole loop has eight rules
-that make it structurally impossible for us to bounce messages back and forth — and we
-hardened those rules so they're enforced by the code shape itself, not just by good
-intentions.
+## The honesty/learning thread
 
-## What we learned from yesterday — baked in
+The earlier file-based draft was hardened across **two** convergence rounds before
+Justin caught the substrate mistake. That was instructive: convergence reviewers ask
+"is this design sound?" but not "is the framing correct?" — that's the user's call.
+Recorded in memory as a durable lesson (`feedback_fix_at_the_right_level`). Also today:
+when the spec cited a code line, it must be the line I actually read (one wrong line
+number — 1327 vs the real 1592 — caught by a round-3 reviewer; corrected). Every spec
+claim about a code surface now cites the line I verified.
 
-You called out two things I should have caught: the busy-check was bogus, and the budget
-was a dead setting. My new rule (now durable in my memory): before I tell you a gate, limit,
-or delivery "works," I read the actual code and tell you which file:line I checked. The
-revised spec applies this everywhere — every claim cites the code, and a third gap I caught
-*myself* this morning (the file Codey never reads) only surfaced because I applied that rule
-before claiming "live test, ready to go."
+## What's next after your nod
 
-## What's next
-
-This spec went through two rounds of multi-reviewer convergence (three reviewers each
-round). The reviewers caught the original "/sessions has no idle field and needs auth"
-blocker that would've broken the live test, plus the symlink/restart/concurrency edge cases
-worth defending against ahead of time. All addressed.
-
-Codey has agreed to his side of the design (verified on Threadline). I'm sending him the
-final spec to confirm the two small new requests on his side that came out of convergence
-(the small /idle endpoint and pinning a shared contract version). Once you approve, I'll
-build my side through our normal gate, Codey builds his, both ship, then we run **one
-supervised live cycle against him with you watching** — the actual test.
+- I send Codey the final spec for confirmation on his side (small `/idle` endpoint + the
+  receive-side handler + `sendAgentMessage` on his end — he agreed to all of this in
+  round 2; only changes he might push back on are the round-3 additions I made today).
+- I build my side through our normal gate. Codey builds his side in his repo.
+- Both halves ship.
+- Then we do **one supervised live cycle with you watching** — the actual test.

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.eli16.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.eli16.md
@@ -12,15 +12,18 @@ the receive side has the anti-bounce machinery baked in (it knows not to send co
 replies, replies are tagged back with a matching id, etc.). The mentor is just its
 first consumer.
 
-## The three live-readiness fixes (mentor)
+## The live-readiness fixes (mentor)
 
-1. **Is-Codey-free check** — Codey adds a tiny public status page (`/idle`) so my probe
-   has a real signal instead of asking the wrong question. If anything is ambiguous
-   I treat him as busy.
-2. **Talk to Codey via Telegram** — I mint a dedicated mentor bot (per your option C),
+*(There were three; you correctly cut one — the "is Codey free?" probe. A real user
+doesn't check if someone's free before texting them; they just text, and the receiver
+handles it. So that check is gone entirely. What's left:)*
+
+1. **Talk to Codey via Telegram** — I mint a dedicated mentor bot (per your option C),
    message Codey from that bot in a dedicated Mentor topic on his setup, he processes
-   it as a user-style prompt, replies tagged back, my Stage-B reads the reply.
-3. **Budget on real units** — I gate against your quota meter (5-hour / weekly) and a
+   it as a user-style prompt, replies tagged back, my Stage-B reads the reply. I don't
+   pester: I won't send a new message while I'm still waiting on a reply to the last one
+   (that's the real "user behavior" gate — not a status probe).
+2. **Budget on real units** — I gate against your quota meter (5-hour / weekly) and a
    token ceiling, NOT pretend dollars. **Honest scope note**: today the ceiling only
    captures the Stage-B analysis spend; the spawned Stage-A session's tokens go to the
    ledger without a mentor tag, so they bypass the ceiling. I'm shipping the cap with

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -1,10 +1,11 @@
 ---
 title: Agent-to-Agent Telegram comms primitive + Mentor live-readiness (its first consumer)
 owning-layer: messaging (new primitive) + scheduler/server (mentor consumer)
-status: draft
-review-convergence: false
-review-iterations: 0
-co-designer: instar-codey (pending — recipient-side detection + anti-loop handler)
+status: converged
+review-convergence: true
+review-iterations: 1
+review-reviewers: lessons-aware, integration, adversarial
+co-designer: instar-codey (Threadline thread 14629926, recipient-side detection + anti-loop handler design folded)
 approved: false
 supersedes-rounds: 2 prior convergence rounds on file-based mentor-outbox design (committed but re-architected after Justin substrate correction, topic 13435, 2026-05-27)
 supervision: tier1
@@ -99,7 +100,7 @@ Echo-side:
 Every agent-to-agent message carries a structured, visible prefix in the message body:
 
 ```
-[a2a:from=<senderAgent> to=<recipientAgent> role=<role> id=<stable-uuid> corr=<uuid> v=1]
+[a2a:from=<senderAgent> to=<recipientAgent> role=<role> id=<stable-uuid> corr=<uuid> ts=<unix-ms> v=1]
 
 <message body>
 ```
@@ -108,10 +109,17 @@ Every agent-to-agent message carries a structured, visible prefix in the message
   is enough to reconstruct the round-trip when ledgers are unavailable** (Codey's
   point — `corr` in the visible marker, not just audit metadata, so the trace is the chat).
 - **Field-value charset (Codey's tightening):** `[A-Za-z0-9._:-]+` for `from`/`to`/`role`/
-  `id`/`corr`; positive integer for `v`. UUIDs recommended for `id`/`corr`; parser accepts
-  any token matching the charset (so ULIDs etc. work for future senders).
-- **`corr` is optional in syntax, REQUIRED in semantics**: prompts omit `corr` (or set
-  `corr=id`); replies MUST set `corr=<prompt's id>` to thread the round-trip.
+  `id`/`corr`; positive integer for `v` and `ts`. UUIDs recommended for `id`/`corr`; parser
+  accepts any token matching the charset (so ULIDs etc. work for future senders).
+- **`corr` is REQUIRED in the parser** (round-2 adversarial F3 closure): a missing or empty
+  `corr` is a malformed marker → DROP (`agent-marker-malformed`). Prompts set
+  `corr=<id>` (self-correlate); replies set `corr=<prompt's id>` (threads the round-trip).
+  This prevents the cycle-detection key from collapsing on `corr=undefined` and tripping on
+  unrelated traffic.
+- **`ts` is REQUIRED** (round-2 adversarial F2 — replay defense without HMAC): unix-ms
+  timestamp. Recipient REJECTS any marker with `|now - ts| > a2a.skewWindowMs` (default
+  24h) as `agent-marker-stale-or-future`. Caps replay window independent of processed-id
+  ledger eviction; HMAC-signed markers remain deferred to v2.
 - **Parser is strict** — regex anchored to start, consumes only the first line + the
   required blank separator. Anything marker-*like* but malformed (charset violation,
   missing required field, broken syntax) is an **A2A security event**: drop + audit row,
@@ -162,17 +170,35 @@ generic courtesy/ack behavior on the user-message path (Codey's sharpening).
 agentMessageHandler(rawMsg): { handled: boolean; routedTo?: string; dropReason?: string }
 ```
 
-**Routing matrix (Codey-designed, explicit + audited at every branch):**
+**Bot-identity check — round-2 adversarial F1 closure.** The Telegram `Message.from` shape
+today carries `{id, first_name, username?}` but NOT `is_bot` or `sender_chat` (verified in
+`src/messaging/TelegramAdapter.ts`). This work extends the typed Message to expose
+`from.is_bot` and `sender_chat` (Telegram's wire format already carries them; only the
+type surface needs lifting). The allowlist key is:
+- `sender_chat.id` when present (group bot-as-channel relay), OR
+- `from.id` AND `from.is_bot === true` (DM / topic post by a bot).
+
+A marker-bearing message with `from.is_bot !== true` and no `sender_chat` is **a user
+typing a marker-shaped string** — DROP as `agent-marker-spoofed-by-user`, NEVER route to
+the role-handler. Without this, a human user (Justin, in his own chat) typing
+`[a2a:from=echo to=instar-codey role=mentor id=… corr=… ts=… v=1]\n\n<body>` would route as
+real mentor traffic. (Verified: today's `Message.from.id` check would pass on a Justin
+message.)
+
+**Routing matrix (Codey-designed + round-2 adversarial-hardened, explicit + audited at every branch):**
 
 | Incoming shape | Decision | Audit row |
 |---|---|---|
 | No marker present | Fall through to normal user handling | (not an A2A event) |
-| Marker-like-but-malformed (charset / missing field / syntax) | **DROP** (security event, NEVER fall through) | `agent-marker-malformed` |
+| Marker-like-but-malformed (charset / missing field / syntax / missing `corr` / missing `ts`) | **DROP** (security event, NEVER fall through) | `agent-marker-malformed` |
+| Marker with `\|now - ts\| > skewWindowMs` (default 24h) | DROP (replay defense) | `agent-marker-stale-or-future` |
+| Marker but `from.is_bot !== true` AND no `sender_chat` (a real user typed it) | DROP (user-spoof defense) | `agent-marker-spoofed-by-user` |
 | Valid marker, `to !== <localAgent>` | DROP | `agent-marker-wrong-recipient` |
 | Valid marker, unsupported `v` | DROP | `agent-marker-unsupported-version` |
 | Valid marker, `from` not in allowlist OR sender bot-ID mismatch | DROP (spoof defense) | `agent-marker-unknown` |
 | Valid marker, `id` already in processed-id ledger | DROP (idempotency — Telegram retry / adapter restart) | `agent-marker-duplicate` |
-| Valid allowlisted, `role` recognized | Strip marker → route to role-handler → record `id` in processed ledger | `agent-marker-routed` |
+| Valid allowlisted, `role` NOT in **per-source** allowed-incoming-roles for that `from` | DROP (compromised-source defense — see anti-loop #2) | `agent-marker-role-not-allowed-from-source` |
+| Valid allowlisted, `role` recognized for that source | Strip marker → route to role-handler → record `id` in processed ledger | `agent-marker-routed` |
 | Valid allowlisted, role unexpected for this recipient (e.g. `mentor-reply` on Codey) | DROP (don't fall through to user) | `agent-marker-unexpected-role` |
 | Valid allowlisted, unknown role | DROP | `agent-marker-unknown-role` |
 
@@ -199,22 +225,33 @@ can't re-inject the same prompt. File-backed at `state/a2a-processed-ids.json` v
 
 1. **One outbound producer per `role`** + **role-handler allowlist** (Codey's sharpening).
    Each role-handler is constructed with an explicit allowed-outbound-roles list and
-   `sendAgentMessage` refuses any role not in that list at runtime. Import-surface lint
-   AT BUILD TIME asserts the module's static `sendAgentMessage` callsites only reference
-   roles in the constructor's allowlist. **A role-handler cannot send the same role it
-   consumes** (a mentor-handler cannot send `mentor`; only `mentor-reply`).
-2. **Cycle-detection keyed precisely** (Codey's refinement): the detection key is
-   `(fromBotId, toBotId, topicId, role, corr)` — NOT just `(bot, topic)` — so legitimate
-   unrelated messages don't trip each other. Default window 5s, configurable. Trips →
-   require explicit `cycleOk: true` parameter or refuse with a `degradation` event.
-3. **Round-trip audit ledger.** Sent + received ledgers include role, ids, `corr`
+   `sendAgentMessage` refuses any role not in that list at runtime. **Capability-style
+   enforcement** (round-2 adversarial F4 closure — picked over transitive-import-lint
+   because it's structurally stronger): the reply-ingestion module receives a
+   *capability handle* (`{capture: (findings) => void}`) — it does NOT have access to
+   `spawnStageA`, `deliverToMentee`, scheduler, or Threadline at all. Future transitive
+   imports can't bypass this because the symbols aren't reachable from the handle.
+   Backup: dependency-cruiser lint (`forbidden: { from: 'mentor-reply-ingestion',
+   to: ['scheduler', 'threadline', 'deliverToMentee', 'spawnStageA'] }`) catches any
+   regression where someone adds an import bypassing the capability shape.
+2. **Per-source role-acceptance matrix** (round-2 adversarial F6 closure). The accept-list
+   is `{fromAgent: allowed-incoming-roles[]}`, NOT a flat per-recipient set. Echo's
+   recipient handler for example: `{ 'instar-codey': ['mentor-reply'] }` — a compromised
+   Codey sending `role: 'notify'` or `'coord'` to Echo's mentor-bot is dropped as
+   `agent-marker-role-not-allowed-from-source`. Scoped admission.
+3. **Cycle-detection keyed precisely** (Codey's refinement + round-2 F3 reinforcement):
+   the detection key is `(fromBotId, toBotId, topicId, role, corr)` — and since `corr`
+   is now REQUIRED in the marker (see §marker schema), the key never collapses. Default
+   window 5s, configurable. Trips → require explicit `cycleOk: true` parameter or refuse
+   with a `degradation` event.
+4. **Round-trip audit ledger.** Sent + received ledgers include role, ids, `corr`
    correlation chains, bot/topic, and result. Stage-B / future debugging can prove there
    is no role→reply→role path within a single tick boundary. **Every drop path also
    writes** (no silent drops).
-4. **`mentor-reply` ingestion on Echo is finding-emission-only** (Codey's explicit
+5. **`mentor-reply` ingestion on Echo is finding-emission-only** (Codey's explicit
    invariant): MUST NOT call `spawnStageA`, `deliverToMentee`, scheduler enqueue, or
-   Threadline send. Import-surface lint forbids those imports in the reply-ingestion
-   module. The only outbound effect is `capture({findings})`.
+   Threadline send. Enforced via capability-handle (point 1 above); the module
+   *literally cannot reach* those symbols. Only outbound effect: `capture({findings})`.
 
 ### Config
 
@@ -258,14 +295,68 @@ process any user message (the test of his behavior under user-like interaction).
 identity is honest (it's Echo's mentor bot, not a Justin impersonation), but the
 *interaction shape* is user-level, which is what the wild-behavior test needs.
 
+### Implementation surface — what round-2 convergence flagged
+
+The substrate change exposed real surface gaps in the existing TelegramAdapter. All five
+need to land as part of this PR:
+
+1. **Multi-instance state-file isolation (round-2 integration F1 — BLOCKING).**
+   `TelegramAdapter` constructor writes to fixed `stateDir`-relative paths
+   (`topic-session-registry.json`, `telegram-messages.jsonl`, `telegram-poll-offset.json`,
+   `state/attention-items.json`). Two adapters sharing one `stateDir` clobber each
+   other's offset/registry; `poll()`'s cross-token detection (`OFFSET_RANGE_THRESHOLD`)
+   fires continuously. **Required:** add a constructor `subDir?: string` param;
+   non-primary adapters get a namespaced sub-stateDir (e.g.
+   `{stateDir}/agent-telegram/mentor-bot/`) for ALL state files. Primary bot's behavior
+   unchanged (omit `subDir`).
+2. **Lifeline-topic auto-creation guard (round-2 integration F1 cont'd).**
+   `ensureLifelineTopic()` runs unconditionally on `start()`. Add a constructor
+   `suppressLifelineAutoCreate?: boolean` (default false for primary; true for non-primary
+   adapters like the mentor-bot) to prevent the mentor-bot creating a second Lifeline.
+3. **Handler-chain primitive (round-2 lessons F1 + integration F2 — BLOCKING).**
+   `TelegramAdapter.onMessage(handler)` is a *single-slot setter* (`this.handler = handler`
+   at line ~1592, NOT line 1327 — corrected from the prior draft's bad cite). The spec's
+   "agent-handler runs BEFORE normal user routing" is unimplementable as-stated. **Chosen
+   resolution:** wrap at the existing registration site in `src/commands/server.ts`
+   (~line 3038): the wrapper is `agentMessageHandler` first; if it returns `{handled:true}`,
+   stop; else fall through to the existing user-routing handler. This avoids introducing
+   a new chain API on the adapter (smaller blast radius) and keeps the precedence
+   structural (the wrapper IS the only registered handler). A wiring-integrity test
+   asserts the wrapper fires before the user-routing handler on a marker-bearing message.
+4. **Outstanding-prompt tick-refusal (round-2 adversarial F7 + F8 — BLOCKING ping-pong).**
+   The mentor-tick interval is 15min; if a single round-trip takes longer, the next tick
+   firing while the prior is in flight would re-send and rebuild the ping-pong slower.
+   Required: an `outstandingPrompts: Map<corr, {sentAt, mentee}>` per mentee. Tick refuses
+   to send a new prompt while any prompt is outstanding within `mentor.replyTimeoutMs`
+   (default 20min, ≥ tick interval). Reason: `prior-prompt-in-flight`. On timeout expiry
+   without a reply → `DegradationReporter` event `mentor.reply-orphaned` + one Attention
+   entry (deduped per `corr` per day). The same primitive solves vector F7 (silent
+   reply-loss).
+5. **Token-leak scrubbing in error paths (round-2 adversarial F5).** `mentor.botToken`
+   is a high-value secret. Telegram 401s sometimes echo the token in response bodies; any
+   exception path that logs the response could leak. Required: `sendAgentMessage` wraps
+   adapter calls and runs a regex scrub of the known token value over any
+   exception/log/`DegradationReporter` surface before it leaves the module. Add a
+   `mentor.botToken.rotatedAt` field + a `POST /mentor/bot-setup/rotate` flow (Secret-
+   Drop's existing one-time-URL confirmation is sufficient — no new "OOB-confirmed"
+   sub-feature; round-2 integration F4 correction).
+
 ## Fix 3 — Quota-aware budget + notification (unchanged from prior draft)
 
 - **Remove** `dailySpendCapUsd` from config defaults; add `mentor.quotaCeiling` (default
   `elevated`), wire `budgetOk` to `QuotaTracker.canRunJob('low')` + run-count backstop.
 - **Quota null/stale → fail-closed** (`reason: quota-unknown`); override the default
   fail-open.
-- **Token-spend ceiling** (`mentor.dailyTokenCeiling`, default 200_000) summed via
-  prefix-match `mentor-stage-b::%` on `TokenLedger.byAttributionKey({sinceMs})`.
+- **Token-spend ceiling — STAGE-B ONLY today** (`mentor.stageBTokenCeiling`, default
+  200_000) summed via prefix-match `mentor-stage-b::%` on
+  `TokenLedger.byAttributionKey({sinceMs})` (or thin `byComponent('mentor-stage-b')`
+  helper). **Honest scope downgrade (round-2 integration F3 — BLOCKING).** Stage-B
+  goes via `intelligence.evaluate` → `recordEvent` → attributed `mentor-stage-b::*`.
+  Stage-A is a spawned Claude-CLI session whose tokens reach the ledger via JSONL
+  scan and fall under `unknown::pre-attribution` (`TokenLedger.ts:404-407`, explicit).
+  Stage-A spend is **invisible to this ceiling**. The honest name reflects that;
+  follow-up tracked: "Stage-A attribution via session-name-prefix resolver" (separate
+  PR) to bring Stage-A under the same cap. Don't claim coverage we don't have.
 - **Trip-EPISODE state machine** (not day-bucket); alerts on `ok→tripped` AND
   `tripped→ok`; file-backed persistence at `state/mentor-budget-notifications.json` via
   `SafeFsExecutor.atomicWriteJsonSync`; CAS single-writer; corrupt-state-file recovery
@@ -289,53 +380,107 @@ identity is honest (it's Echo's mentor bot, not a Justin impersonation), but the
 
 - **Config (additive):** `agentTelegram` section (new), `mentor.botToken`,
   `mentor.menteeServerUrl`, `mentor.menteeBotId`, `mentor.menteeTopicId`,
-  `mentor.quotaCeiling`, `mentor.dailyTokenCeiling`, `mentor.budgetReminderHours` added
-  via `ConfigDefaults.getMigrationDefaults()` + `applyDefaults` (existence-checked).
-- **Config (removal — NOT silent).** `migrateConfig` deletes `mentor.dailySpendCapUsd`
-  (silent if default `0.5`); if non-default, emit ONE Attention entry explaining the
-  field was decorative (subscription, no per-token charge) and the replacement is
-  `mentor.dailyTokenCeiling`.
-- **Retire the file-outbox.** `migrateConfig` deletes `{stateDir}/mentor-outbox/*` on the
-  first run after this update lands (the legacy outbox is now dead state). Idempotent.
-  An Attention entry notes the cleanup if any files were present.
+  `mentor.quotaCeiling`, `mentor.stageBTokenCeiling` (renamed from `dailyTokenCeiling`
+  per honest-scope downgrade), `mentor.budgetReminderHours`, `mentor.replyTimeoutMs`
+  added via `ConfigDefaults.getMigrationDefaults()` + `applyDefaults` (existence-checked).
+- **Config (removal — NOT silent, dedicated migration method).** `applyDefaults` is
+  value-patching only and cannot remove fields (round-2 integration F5). Add a dedicated
+  `migrateRetireDeadMentorConfig` method on `PostUpdateMigrator` (modeled on
+  `migrateLegacyMaxSessions` at line ~3961) with a marker in `_instar_migrations`,
+  existence-checked, idempotent. Deletes `mentor.dailySpendCapUsd` (silent if default
+  `0.5`); if non-default, emit ONE Attention entry explaining the field was decorative
+  (subscription, no per-token charge) and the replacement is `mentor.stageBTokenCeiling`.
+- **Retire the file-outbox (dedicated method via SafeFsExecutor).** No existing migration
+  does fs-cleanup (round-2 integration F5). Add `migrateRetireMentorOutbox` on
+  `PostUpdateMigrator` — marker in `_instar_migrations`, existence-check, route through
+  `SafeFsExecutor.safeRmSync` (the project's destructive-fs funnel), audit-log entry,
+  emit one Attention entry if any files were present. Deletes
+  `{stateDir}/mentor-outbox/*` on first run after this update lands. Idempotent.
 - **Codey bot allowlist bootstrapping.** Echo-side: `mentor.botToken` is Secret-Drop-
-  collected during a `/mentor/bot-setup` one-time command (interactive, OOB-confirmed) —
-  never via chat paste. Codey-side: he adds Echo's mentor-bot ID to his
-  `agentTelegram.knownAgents` allowlist as part of his side's PR.
-- **Routes.** Two new routes (`GET /idle` on Codey's server; `POST /mentor/bot-setup` on
-  Echo). Both get CapabilityIndex prefix classification + CLAUDE.md template entry per
-  the Agent Awareness Standard.
+  collected during a `/mentor/bot-setup` one-time command. **Use Secret-Drop's existing
+  one-time-URL + Telegram confirmation flow** — no new "OOB-confirmed" sub-feature
+  (round-2 integration F4 correction: OOB-confirmed wasn't an existing pattern; Secret-
+  Drop's confirmation is sufficient for a bot token). Codey-side: he adds Echo's
+  mentor-bot ID to his `agentTelegram.knownAgents` allowlist as part of his side's PR.
+- **Routes.**
+  - `GET /idle` is on **Codey's** server (not Echo's), so Echo's CapabilityIndex doesn't
+    apply — that's Codey's repo concern.
+  - `POST /mentor/bot-setup` and `POST /mentor/bot-setup/rotate` are on Echo and
+    **inherit the existing `/mentor` prefix classification** in `CapabilityIndex.ts`
+    (verified line 493 — no CapabilityIndex change needed; round-2 integration F6
+    correction to the prior draft's claim). Echo adds a CLAUDE.md template entry per
+    the Agent Awareness Standard (curl example + proactive trigger: "when user says
+    'set up the mentor bot'").
 
 ## Testing
 
-1. **Unit — primitive marker parsing:** valid markers parse; malformed markers
-   (missing fields, wrong version, extra fields) reject; unknown sender → drop (not
-   route to user handler); spoofed `from` but wrong bot ID → drop + log.
-2. **Unit — anti-loop infra:**
-   - Role-handler import-surface lint: a module that registers as `mentor` handler MUST
-     NOT import `sendAgentMessage` with `role: 'mentor'` (only `mentor-reply`).
-   - Cycle-detection: two sends to the same recipient within 5s without `cycle-ok:true`
-     → refused + degradation event.
+1. **Unit — primitive marker parsing:** valid markers parse (incl. required `corr` + `ts`);
+   malformed markers (missing fields incl. `corr`/`ts`, wrong version, charset violations,
+   extra fields) reject as `agent-marker-malformed`; `|now-ts| > skewWindowMs` rejects as
+   `agent-marker-stale-or-future`; unknown sender → drop (not route to user handler).
+2. **Unit — user-spoof defense (round-2 adversarial F1):** a `Message` with a valid
+   marker prefix but `from.is_bot !== true` and no `sender_chat` → DROP as
+   `agent-marker-spoofed-by-user`. Critical: assert this even when `from.id` matches a
+   value in the allowlist (e.g. a human user with the same numeric id as an allowlisted
+   bot would still drop because `is_bot:false`).
+3. **Unit — per-source role-acceptance (round-2 adversarial F6):** Echo's recipient
+   configured with `{ 'instar-codey': ['mentor-reply'] }`. A message with valid marker but
+   `from=instar-codey, role=notify` → DROP as `agent-marker-role-not-allowed-from-source`,
+   even if `notify` is registered for ANOTHER source.
+4. **Unit — anti-loop infra:**
+   - **Capability-handle structural** (round-2 adversarial F4): the reply-ingestion
+     module's constructor takes only `{capture}` — assert via TypeScript types that the
+     module CANNOT reference `spawnStageA`/`deliverToMentee`/scheduler/Threadline
+     (compile-time invariant). Plus a dependency-cruiser rule as backup.
+   - Cycle-detection: two sends to the same `(fromBotId,toBotId,topicId,role,corr)` within
+     5s without `cycleOk:true` → refused + degradation event. Unrelated `corr` ≠
+     conflict.
    - Round-trip ledger: send + receive both write their audit rows; correlation chain
-     reconstructable.
-3. **Unit — Fix 1 idle:** as prior draft (fail-closed coverage on every ambiguous
+     reconstructable via `corr`; NO tokens/secrets in the row.
+5. **Unit — Fix 1 idle:** as prior draft (fail-closed coverage on every ambiguous
    outcome including 200+missing-fields; liveness-warmup; persistent-failure degradation).
-4. **Unit — Fix 3 budget:** as prior draft (trip-episode state machine, quota null
-   fail-closed, prefix-match summation, CAS persistence, corrupt-recovery).
-5. **Integration — Echo-side mentor consumer:** mock `TelegramAdapter` sends via
-   `sendAgentMessage`; assert marker formed correctly, audit written; simulate
-   `mentor-reply` received → Stage-B parser invoked; assert next tick still defers (no
-   recurrence). This closes the [[project_jobs_load_fix_layered]] test-gap pattern.
-6. **Wiring-integrity:** production wiring of `getMenteeIdle` / `budget` /
-   `sendAgentMessage` is non-null + non-no-op; arch-test on import surfaces.
-7. **End-to-end — supervised live cycle** (the actual test):
-   - Echo's mentor-bot active in a dedicated Mentor topic in Codey's setup.
-   - `/idle` probe succeeds → idle:true.
-   - Echo sends one tagged mentor message → Codey's recipient handler routes to mentor
-     handler → injects as user prompt → Codey replies via `sendAgentMessage(role=mentor-reply)`.
-   - Echo receives the reply → Stage-B emits findings.
-   - Next tick defers (no auto-recurrence). Capture token-ledger spend + ledger audit
-     trail + any degradation events.
+6. **Unit — Fix 3 budget:** as prior draft (trip-episode state machine, quota null
+   fail-closed, CAS persistence, corrupt-recovery). Add: assert the ceiling captures only
+   `mentor-stage-b::%` (Stage-B); spawn a fake Stage-A JSONL event with
+   `unknown::pre-attribution` and assert it does NOT count against the ceiling — the
+   honest-scope downgrade is testable.
+7. **Unit — outstanding-prompt tick refusal (round-2 adversarial F8 — the rebuilt
+   ping-pong):** tick fires; sends prompt with `corr=A`; before reply, next tick fires →
+   refused with `reason: prior-prompt-in-flight`. Then 21min elapse (> default 20min
+   timeout) → `mentor.reply-orphaned` degradation event + Attention entry; next tick
+   allowed.
+8. **Unit — multi-instance TelegramAdapter state isolation (round-2 integration F1):**
+   construct two `TelegramAdapter` instances with the same `stateDir` but different
+   `subDir`. Each adapter's poll-offset / topic-registry / messages-jsonl writes go to
+   ITS OWN namespace; no cross-clobber. Also: with `suppressLifelineAutoCreate:true`,
+   `ensureLifelineTopic` doesn't run.
+9. **Unit — token-leak scrub (round-2 adversarial F5):** simulate a Telegram 401 whose
+   error body echoes the bot token; assert no log/exception/`DegradationReporter` event
+   leaving the module contains the token value.
+10. **Integration — Echo-side mentor consumer:** mock `TelegramAdapter` sends via
+    `sendAgentMessage`; assert marker formed correctly (with `corr` + `ts`), audit
+    written; simulate `mentor-reply` received → Stage-B parser invoked; assert next tick
+    still defers (no recurrence). Plus: assert the agent-handler wrapper fires BEFORE
+    the user-routing handler on a marker-bearing message (wiring-integrity for the
+    handler-chain wrapping at the registration site).
+11. **Integration — bidirectional contract (the #425 gap-closer):** fixture test where
+    a "Codey-like" recipient (using the same exported primitive) ingests Echo's
+    sendAgentMessage write, runs the role-handler, writes a reply via
+    `sendAgentMessage(role=mentor-reply)`, and Echo's Stage-B parser handles it. Real
+    round-trip through the primitive on both sides.
+12. **Wiring-integrity:** production wiring of `getMenteeIdle` / `budget` /
+    `sendAgentMessage` / the agent-handler wrapper is non-null + non-no-op; dependency-
+    cruiser rule passes on the actual codebase.
+13. **End-to-end — supervised live cycle** (the actual test):
+    - Echo's mentor-bot active in a dedicated Mentor topic in Codey's setup.
+    - `/idle` probe succeeds → idle:true.
+    - Echo sends one tagged mentor message → Codey's recipient handler routes to mentor
+      handler → injects as user prompt → Codey replies via `sendAgentMessage(role=mentor-reply)`.
+    - Echo receives the reply → Stage-B emits findings.
+    - Next tick defers (no auto-recurrence) — outstanding-prompts check + idle gate.
+    - Capture token-ledger spend (Stage-B attribution + Stage-A unknown::pre-attribution
+      separately), ledger audit trail, any degradation events.
+    - Assert no second Lifeline topic appears in the chat (multi-instance hygiene).
 
 ## Co-design with Codey
 
@@ -383,10 +528,14 @@ his own normal handling. Documented in §Fix 3 below.
 ## Honesty / lessons applied
 
 - Every claim about an existing surface cites the code I read (TelegramAdapter.onMessage
-  line 1327; sendToTopic widely used; QuotaTracker.canRunJob from prior verification;
-  TokenLedger.byAttributionKey/attribution_key shape from prior verification). The
-  substrate-vs-discipline error that bit this morning is recorded ([[feedback_report_
-  verified_not_intended_behavior]] applies + adjacent lesson on level-of-fix selection).
+  line **1592** — corrected from prior draft's bad cite of 1327, caught by round-2
+  reviewers; sendToTopic widely used; QuotaTracker.canRunJob from prior verification;
+  TokenLedger.byAttributionKey/attribution_key shape from prior verification — including
+  the explicit `unknown::pre-attribution` for JSONL-source events at TokenLedger.ts:404-407
+  which forces the honest Stage-B-only scope of the spend ceiling). The substrate-vs-
+  discipline error that bit this morning is recorded ([[feedback_report_verified_not_
+  intended_behavior]] + [[feedback_fix_at_the_right_level]]) — both surfaced from
+  Justin pushback today, both now durable.
 - The convergence rounds on the file-based design caught everything that mattered about
   that design EXCEPT whether the design's substrate was right — that's an instructive
   limit of reviewer review (reviewers ask "is this sound?", not "is this framing

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -6,7 +6,8 @@ review-convergence: true
 review-iterations: 1
 review-reviewers: lessons-aware, integration, adversarial
 co-designer: instar-codey (Threadline thread 14629926, recipient-side detection + anti-loop handler design folded)
-approved: false
+approved: true
+approved-by: Justin (Telegram topic 13435, 2026-05-27 — after substrate + /idle + dollar-cap user-fidelity corrections)
 supersedes-rounds: 2 prior convergence rounds on file-based mentor-outbox design (committed but re-architected after Justin substrate correction, topic 13435, 2026-05-27)
 supervision: tier1
 ---

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -1,0 +1,164 @@
+---
+title: Mentor live-readiness — real idle signal, mentee-side pickup, quota-aware budget
+owning-layer: scheduler + server (mentor)
+status: draft
+supervision: tier1
+---
+
+# Mentor live-readiness
+
+## Summary
+
+The mentor system ships fully built but with three placeholders that block a real live test
+against Codey. All three were surfaced during the 2026-05-27 dry-run live-validation phase
+(topic 13435 — Justin caught two; the third I verified before claiming a live test would
+work). Fixing all three is the prerequisite for one supervised live cycle against Codey, and
+then for unattended live operation.
+
+## The three gaps
+
+### Gap 1 — `isMenteeBusy()` is a stub that's not about the mentee at all
+
+`AgentServer.ts:~651`:
+```ts
+isMenteeBusy: () => self.sessionManager.listRunningSessions().length > 0,
+```
+
+Tagged in code with `<!-- tracked: topic-13435 -->` ("refined at live validation"). It checks
+**Echo's own** running-session count, not Codey's state. Echo almost always has running
+sessions → `isMenteeBusy()` is almost always true → `safeWindowOpen` is almost never true →
+**the mentor effectively never runs**.
+
+### Gap 2 — `deliverToMentee` is write-only (no Codey-side pickup)
+
+`AgentServer.ts:~671-678`: `deliverToMentee` correctly appends a JSON line to
+`{stateDir}/mentor-outbox/<framework>.jsonl`. The persist-only-no-spawn shape is the
+deliberate **structural fix for the cross-agent spawn loop** ([[bug_cross_agent_ack_spawn_loop]]).
+But **nothing on Codey's side reads that outbox** — verified by grepping the shipped dist for
+mentor-outbox readers (one writer, zero readers). A live test today would write a file Codey
+never sees. The mentee-side pickup is the missing piece — and it's Codey's side, so co-design.
+
+### Gap 3 — Budget is dollar-denominated on a token-subscription, unenforced, silent on trip
+
+`AgentServer.ts:~656-664`: `budgetOk` checks `mentorRunsToday < cfg.maxRoundsPerDay`
+(24/day **run-count**). `cfg.dailySpendCapUsd: 0.5` is configured in
+`MentorOnboardingRunner.DEFAULT_MENTOR_CONFIG` and `ConfigDefaults.ts` but **read nowhere**
+(dead field — verified by repo-wide grep). Worse, the unit is fundamentally wrong: Echo runs
+on a Claude **subscription**, not pay-per-token API, so there is no per-token dollar charge to
+cap. The real cost is **tokens against a rolling quota** (5-hour + weekly limits) — already
+tracked by `QuotaTracker` (`canRunJob(priority)` → normal/elevated/critical/shutdown) and
+`TokenLedger` (with `attribution: { component: 'mentor-stage-b' }` already set). And nothing
+notifies Justin when the cap (round or otherwise) trips.
+
+## Fix
+
+### Fix 1 — Real Codey-idle signal (replaces the system-busy stub)
+
+Replace `isMenteeBusy` with a **mentee-specific** idle check that queries the mentee agent's
+own server:
+
+- Resolve mentee endpoint from a new `mentor.menteeServerUrl` config (defaults to
+  `http://localhost:4044` for `codex-cli`, the co-located Codey instance).
+- Probe `GET {menteeServerUrl}/sessions` (or a dedicated `/idle` endpoint if Codey adds one as
+  part of his side of the co-design) with a 500ms timeout.
+- Idle = no session with `activelyWorking=true` for that mentee. On probe failure (network,
+  timeout, 4xx/5xx), **fail-closed: treat as busy** — never run the mentor blindly when
+  Codey's state is unknown. Emit a degradation signal on persistent probe failure (so
+  unresolvable mentee-unreachable surfaces, doesn't hide).
+- The check is async; the runner pre-resolves it before assembling tick deps (the tick stays
+  pure).
+
+### Fix 2 — Mentee-side outbox pickup (co-design with Codey)
+
+Keep the outbox-write exactly as is (the spawn-loop-safe shape is correct). Add a
+**pull-based pickup** on Codey's side that turns each new outbox line into a user-prompt the
+running Codey session processes. Two concrete options to be co-designed with Codey (he's the
+authority on his ingestion):
+
+- **(a) Codey-side scheduled job (`mentor-inbox-poll`)** — runs every ~1min, reads
+  `{stateDir}/mentor-outbox/<framework>.jsonl` (or a shared path), advances a per-file
+  byte-offset cursor (idempotent), and for each new line injects the message via
+  `injectInternalMessage` into Codey's active mentee-collab session. Codey's reply is
+  appended to a **reply outbox** Echo's Stage-B reads.
+- **(b) Codey-side filesystem watcher in-process** (no job) — same shape, event-driven.
+
+(a) is conservative (matches the cron-job-everywhere pattern) and explicit; (b) is lower-
+latency but more state to manage. **Codey picks**, and ratifies the reply-path shape.
+
+This fix has **two-sided code**: Echo writes (already correct) + Codey reads. Echo's side
+adds a documented contract (file path, line schema, reply file path) and a contract test.
+Codey's side ships the pickup. The spawn-loop guard remains structural: no Echo→Codey
+spawn-on-write, no Codey→Echo spawn-on-reply — both sides queue-and-pickup.
+
+### Fix 3 — Quota-aware budget + notification (replaces the dead dollar cap)
+
+- **Remove** `dailySpendCapUsd` from config defaults; replace with `mentor.quotaCeiling`
+  (default: `elevated` — mentor stands down at elevated/critical/shutdown, runs only at
+  normal). Wire `budgetOk` to `QuotaTracker.canRunJob('low')` (mentor is low-priority) AND
+  the existing run-count backstop (`maxRoundsPerDay` stays — it's a real bound).
+- **Add a token-spend ceiling** (`mentor.dailyTokenCeiling`, default 200_000 tokens) summed
+  from `TokenLedger` with `attribution.component='mentor-stage-b'`. Hit the ceiling → defer
+  with reason `budget-tokens`.
+- **Notify on trip**: when `budgetOk` returns false (quota OR run-count OR token-ceiling),
+  push **one** entry to the Attention Queue (`POST /attention`) deduped per-day per-reason,
+  AND send a single Telegram alert to the system topic. No per-tick chatter — one alert when
+  the cap closes, one when it reopens.
+
+## Design (one place to read)
+
+The runner gets three new service dependencies, all small + injectable for tests:
+- `getMenteeIdle(menteeFramework): Promise<boolean>` — async probe + fail-closed.
+- `quotaStandDown(menteeFramework): { allow: boolean; reason?: string }` — composes quota
+  + run-count + token-ceiling; returns the specific blocker.
+- `notifyBudgetTrip(reason, detail)` — fires the attention + Telegram alert (deduped).
+
+The tick changes:
+- Order is `canary → quota → idle → spawn → leak → forensics → capture → deliver` (idle
+  becomes a real async-resolved boolean, computed in `Runner.startTick` so the tick stays
+  pure).
+- `deps.budgetOk` is replaced by `deps.budget` returning `{ ok, reason }`; on `!ok` the tick
+  calls `deps.notifyBudgetTrip(reason)` exactly once (dedup is in the notifier, not the tick).
+- `reason: 'unsafe-window'` is renamed `reason: 'mentee-busy'` to match the actual signal.
+
+## Out of scope
+
+- A Codey **liveness** monitor beyond the per-probe fail-closed (separate concern).
+- Threadline-relay-based delivery (intentionally rejected — see [[bug_cross_agent_ack_spawn_loop]]).
+- Multi-mentee fan-out (one mentee for now).
+
+## Testing
+
+1. **Unit — idle signal:**
+   - mentee at-rest → `getMenteeIdle = true` → tick proceeds past the idle gate.
+   - mentee `activelyWorking=true` → `getMenteeIdle = false` → tick defers `mentee-busy`.
+   - probe timeout / network error / non-2xx → fail-closed: `getMenteeIdle = false` (NEVER
+     true on unknown state); a degradation signal is emitted on persistent failure.
+2. **Unit — quota-budget:**
+   - quota `normal` + under run-count + under token-ceiling → `budget.ok = true`.
+   - quota `elevated` → `budget.ok = false, reason = 'quota-elevated'`.
+   - run-count cap → `budget.ok = false, reason = 'runs-exhausted'`.
+   - token-ceiling hit → `budget.ok = false, reason = 'tokens-exhausted'`.
+   - On trip, `notifyBudgetTrip` is called exactly once per (reason, day) — replays don't
+     re-notify.
+3. **Integration — delivery contract (Echo-side):**
+   - `deliverToMentee` writes a well-formed JSONL line at the documented path; the contract
+     schema is published as a typed export the Codey-side pickup imports.
+4. **End-to-end — supervised live cycle (the actual test):**
+   - All three fixes shipped; manually trigger one tick against the real Codey with Justin
+     watching; assert Codey receives the message, replies, and Stage-B captures the reply.
+     Capture before/after token-ledger spend, attention-queue state, and any degradation
+     events.
+
+## Migration parity
+
+- **Config:** `migrateConfig` removes `mentor.dailySpendCapUsd` (silent if absent) and adds
+  `mentor.menteeServerUrl`, `mentor.quotaCeiling`, `mentor.dailyTokenCeiling` with defaults
+  (existence-checked, only added when missing).
+- **No agent-installed file changes** beyond config defaults — loader-only shadow-install update.
+
+## Co-design with Codey (open)
+
+The Codey-side pickup design (option a vs b vs other), the reply-outbox shape, and any
+preferred contract details are explicitly open for Codey's input on a fresh Threadline thread
+(per the established short-msg + view-link pattern to avoid the command-too-long bug).
+Codey's response folds into a §Mentee-side pickup section before convergence.

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -72,8 +72,14 @@ AND has no `activelyWorking` field, so a fresh endpoint is needed.
 `/idle` returns:
 ```json
 { "schemaVersion": 1, "idle": true, "bootId": "uuid-set-at-process-start",
-  "uptimeSec": 12345, "activeSessions": 0, "ts": "ISO-8601" }
+  "uptimeSec": 12345, "activeSessions": 0, "ts": "ISO-8601",
+  "reason": "active-session | startup-warmup | unknown (optional, diagnostic only)" }
 ```
+**`activeSessions` semantics (Codey's clarification):** sessions with *live work* — active
+autonomous jobs, active Telegram-spawned sessions, running task sessions. Reaped/idle/
+complete panes do NOT count. **If the local signal is ambiguous, the mentee returns
+`idle:false`** rather than guessing or omitting fields. `reason` is optional and Echo
+must NOT depend on it for v1 behavior (it's diagnostic for degradation reports only).
 
 Echo-side:
 - Probe `{mentor.menteeServerUrl}/idle` with 750ms timeout.
@@ -93,14 +99,24 @@ Echo-side:
 Every agent-to-agent message carries a structured, visible prefix in the message body:
 
 ```
-[a2a:from=<senderAgent> to=<recipientAgent> role=<role> id=<stable-uuid> v=1]
+[a2a:from=<senderAgent> to=<recipientAgent> role=<role> id=<stable-uuid> corr=<uuid> v=1]
 
 <message body>
 ```
 
-- **Visible in chat** — humans can audit at a glance (a real chat-log forensic property,
-  not a hidden metadata field).
-- **Parseable** — regex `^\[a2a:from=(\S+) to=(\S+) role=(\S+) id=(\S+) v=(\d+)\]\n\n`.
+- **Visible in chat** — humans can audit at a glance, AND **the Telegram chat history alone
+  is enough to reconstruct the round-trip when ledgers are unavailable** (Codey's
+  point — `corr` in the visible marker, not just audit metadata, so the trace is the chat).
+- **Field-value charset (Codey's tightening):** `[A-Za-z0-9._:-]+` for `from`/`to`/`role`/
+  `id`/`corr`; positive integer for `v`. UUIDs recommended for `id`/`corr`; parser accepts
+  any token matching the charset (so ULIDs etc. work for future senders).
+- **`corr` is optional in syntax, REQUIRED in semantics**: prompts omit `corr` (or set
+  `corr=id`); replies MUST set `corr=<prompt's id>` to thread the round-trip.
+- **Parser is strict** — regex anchored to start, consumes only the first line + the
+  required blank separator. Anything marker-*like* but malformed (charset violation,
+  missing required field, broken syntax) is an **A2A security event**: drop + audit row,
+  NEVER fall through to normal user handling (Codey's point — avoids spoof / broken sender
+  accidentally turning into a regular prompt).
 - **Versioned** (`v=1`) — schema bumps are explicit.
 - **No HMAC v1** — recipient trusts the marker if the sender Telegram bot identity is in
   the recipient's known-agents allowlist (the structural identity check is the Telegram bot
@@ -116,56 +132,89 @@ sendAgentMessage({
   toAgent: 'instar-codey',
   toBotToken: cfg.codey.mentorBotToken,   // the recipient's mentor-bot token
   toTopicId: cfg.codey.mentorTopicId,     // the dedicated topic in recipient's setup
-  role: 'mentor',
+  role: 'mentor',                          // MUST be in the caller's allowed-roles list
   message: '<the prompt>',
   correlationId?: 'optional-existing-id-for-reply-threading',
-}): Promise<{ ok: boolean; sentMessageId?: string; reason?: string }>
+}): Promise<{ ok: boolean; sentMessageId?: string; a2aId?: string; reason?: string }>
 ```
 
+- **Generic, not mentor-specific** (Codey's point): the primitive is reusable; caller
+  passes the `role` from a constructor-time allowed-roles list. For Codey's first
+  consumer, the only permitted outbound role is `mentor-reply` (produced only by the
+  mentor handler).
 - Instantiates (or reuses) a `TelegramAdapter` for the recipient's bot.
-- Prepends the marker; calls `sendToTopic(toTopicId, marker+body)`.
-- Returns `{ok, sentMessageId}` so consumers can correlate.
-- Logs every send to an audit ledger (`state/a2a-sent.jsonl`) — append-only.
+- Mints a stable `a2aId` (UUID) if `id` not supplied; prepends the marker; calls
+  `sendToTopic(toTopicId, marker+body)`.
+- **Returns `a2aId`** alongside `sentMessageId` so the caller can log the exact marker id
+  next to its local assistant response id (Codey's tightening).
+- **Audit row schema** (`state/a2a-sent.jsonl`, append-only): `localTs`, `direction:
+  'sent'`, `fromAgent`, `toAgent`, `role`, `id`, `corr` (if present), `telegramBotId`,
+  `topicId`, `sentMessageId`, `result: 'ok' | 'failed'`, `reason` (on failure). **No
+  tokens or secrets in ledgers.**
 
 ### Recipient side
 
-A new incoming-message handler registered with `TelegramAdapter.onMessage`:
+A new incoming-message handler registered with `TelegramAdapter.onMessage`. **The handler
+runs BEFORE normal user routing** so agent-origin messages cannot accidentally trigger
+generic courtesy/ack behavior on the user-message path (Codey's sharpening).
 
 ```ts
-agentMessageHandler(rawMsg): { handled: boolean; routedTo?: string }
+agentMessageHandler(rawMsg): { handled: boolean; routedTo?: string; dropReason?: string }
 ```
 
-- Parses the marker. If absent → not an agent message; fall through to normal user handler.
-- If present and `from` is in the known-agents allowlist (`config.agentTelegram.knownAgents`)
-  AND the sender bot ID matches → route to the appropriate handler (`role` → handler map).
-- **If marker present but `from` not allowlisted OR bot ID mismatch**: log as
-  `agent-marker-unknown` and drop (NEVER deliver to the normal user-message path — spoofing
-  defense; an unknown party adding a marker doesn't get user-level processing).
-- **Anti-loop discipline (the heart of the primitive)**:
-  - Agent-origin messages NEVER auto-trigger courtesy replies. The role-handler is the
-    only producer of any outgoing message in response.
-  - If the role-handler does produce a reply, it routes through `sendAgentMessage` with
-    `role=<original>-reply`, carrying the original `id` as `correlationId`. Replies are
-    marked, traceable, and visible.
-  - **A reply received (e.g. `mentor-reply`) NEVER triggers another `mentor` send.**
-    Outgoing mentor messages come only from the scheduled mentor cycle. Same for any
-    role-pair. Compile-time guard: the role-handler module's import surface lint forbids
-    `sendAgentMessage(role='X')` if it also reads `role='X-reply'` (no closed-loop within
-    one module).
-- Every received agent message logged to `state/a2a-received.jsonl` (append-only audit).
+**Routing matrix (Codey-designed, explicit + audited at every branch):**
+
+| Incoming shape | Decision | Audit row |
+|---|---|---|
+| No marker present | Fall through to normal user handling | (not an A2A event) |
+| Marker-like-but-malformed (charset / missing field / syntax) | **DROP** (security event, NEVER fall through) | `agent-marker-malformed` |
+| Valid marker, `to !== <localAgent>` | DROP | `agent-marker-wrong-recipient` |
+| Valid marker, unsupported `v` | DROP | `agent-marker-unsupported-version` |
+| Valid marker, `from` not in allowlist OR sender bot-ID mismatch | DROP (spoof defense) | `agent-marker-unknown` |
+| Valid marker, `id` already in processed-id ledger | DROP (idempotency — Telegram retry / adapter restart) | `agent-marker-duplicate` |
+| Valid allowlisted, `role` recognized | Strip marker → route to role-handler → record `id` in processed ledger | `agent-marker-routed` |
+| Valid allowlisted, role unexpected for this recipient (e.g. `mentor-reply` on Codey) | DROP (don't fall through to user) | `agent-marker-unexpected-role` |
+| Valid allowlisted, unknown role | DROP | `agent-marker-unknown-role` |
+
+**Processed-id ledger (Codey's idempotency point):** a small persistent set of recently-
+processed `id`s (bounded — last N=10_000 or M=30 days, whichever first) so retries/restarts
+can't re-inject the same prompt. File-backed at `state/a2a-processed-ids.json` via
+`SafeFsExecutor.atomicWriteJsonSync`, CAS single-writer.
+
+**Anti-loop discipline (sharpened per Codey):**
+- Agent-origin Telegram messages suppress ALL generic courtesy/ack behavior **before**
+  normal user routing sees them (the handler runs first).
+- The role-handler is the only producer of any outgoing message in response.
+- A role-handler may only produce roles from an **explicit allowlist** for that handler
+  (e.g. Codey's mentor-handler: consumes `mentor`, may produce only `mentor-reply` —
+  cannot send the same role it consumes).
+- **`mentor-reply` ingestion on Echo is finding-emission-only** — Stage-B parses → emits
+  `ForensicFinding[]` → `capture()`. MUST NOT call `spawnStageA`, `deliverToMentee`,
+  scheduler enqueue, or Threadline send. Import-surface lint enforces.
+- **Every drop path writes an audit row** (silent drops make Stage-B forensics painful).
+- Every received agent message (routed OR dropped) logged to `state/a2a-received.jsonl`
+  (append-only).
 
 ### Anti-loop infra: structural, not just rules
 
-1. **One outbound producer per `role`.** Each `role` has exactly one module that may send
-   it (`mentor` is sent only by the mentor tick; `mentor-reply` only by Codey's mentor
-   handler). Import-surface lint enforces.
-2. **Cycle-detection in flight.** If `sendAgentMessage` sees a recipient bot-id+topic that
-   matches an inflight conversation where the local agent received from that bot in the
-   last N seconds (default 5), it requires an explicit `cycle-ok: true` parameter or
-   refuses with a degradation event.
-3. **Round-trip audit ledger.** Both ledgers (sent + received) include role, ids, and
-   correlation chains. Stage-B / future debugging can prove there is no role→reply→role
-   path within a single tick boundary.
+1. **One outbound producer per `role`** + **role-handler allowlist** (Codey's sharpening).
+   Each role-handler is constructed with an explicit allowed-outbound-roles list and
+   `sendAgentMessage` refuses any role not in that list at runtime. Import-surface lint
+   AT BUILD TIME asserts the module's static `sendAgentMessage` callsites only reference
+   roles in the constructor's allowlist. **A role-handler cannot send the same role it
+   consumes** (a mentor-handler cannot send `mentor`; only `mentor-reply`).
+2. **Cycle-detection keyed precisely** (Codey's refinement): the detection key is
+   `(fromBotId, toBotId, topicId, role, corr)` — NOT just `(bot, topic)` — so legitimate
+   unrelated messages don't trip each other. Default window 5s, configurable. Trips →
+   require explicit `cycleOk: true` parameter or refuse with a `degradation` event.
+3. **Round-trip audit ledger.** Sent + received ledgers include role, ids, `corr`
+   correlation chains, bot/topic, and result. Stage-B / future debugging can prove there
+   is no role→reply→role path within a single tick boundary. **Every drop path also
+   writes** (no silent drops).
+4. **`mentor-reply` ingestion on Echo is finding-emission-only** (Codey's explicit
+   invariant): MUST NOT call `spawnStageA`, `deliverToMentee`, scheduler enqueue, or
+   Threadline send. Import-surface lint forbids those imports in the reply-ingestion
+   module. The only outbound effect is `capture({findings})`.
 
 ### Config
 
@@ -221,6 +270,10 @@ identity is honest (it's Echo's mentor bot, not a Justin impersonation), but the
   `tripped→ok`; file-backed persistence at `state/mentor-budget-notifications.json` via
   `SafeFsExecutor.atomicWriteJsonSync`; CAS single-writer; corrupt-state-file recovery
   with degradation event; optional `budgetReminderHours` long-trip reminder (default off).
+- **Mentor budget is Echo-side primarily** (Codey's surface check: his instance reports
+  `quotaTracking:false`). The budget gates **Echo's mentor-tick sending** — Echo's tokens
+  are the spend that needs capping. Codey's replies go through his normal handling on his
+  side; this fix does not require any quota wiring on Codey's side.
 
 ## Scope
 
@@ -284,22 +337,48 @@ identity is honest (it's Echo's mentor bot, not a Justin impersonation), but the
    - Next tick defers (no auto-recurrence). Capture token-ledger spend + ledger audit
      trail + any degradation events.
 
-## Co-design with Codey (NEW round, recipient-side substrate is now Telegram)
+## Co-design with Codey
 
-Round 1 (prior file-based design) is superseded by this redesign. New asks for Codey:
+**Round 1 (file-based) — superseded** by Justin's substrate correction.
 
-1. Add `agentTelegram.knownAgents` allowlist + `/idle` endpoint on his server.
-2. Implement the recipient-side `agentMessageHandler` for incoming Telegram messages with
-   the `[a2a:...]` marker — route `role=mentor` to a new mentor-message handler that
-   injects into his mentor-session as a user prompt; route `mentor-reply` to nothing on
-   his side (he's not the recipient of replies; Echo is).
-3. Implement `sendAgentMessage` on his side so his mentor-handler can write the `mentor-
-   reply` back to Echo's mentor bot.
-4. Confirm or adjust the marker schema (`[a2a:from=… to=… role=… id=… v=1]`).
-5. Confirm the anti-loop infra invariants (one outbound producer per role; cycle-
-   detection; audit ledgers).
+**Round 2 (Telegram-based) — CLOSED** (Threadline thread 14629926, 2026-05-27). Codey
+endorsed the substrate correction verbatim ("Telegram is the right substrate for this
+test; the previous file outbox made the transport easier but weakened the actual behavior
+being tested") AND **verified his own live capability surface** before answering (v1.3.15,
+Telegram bidirectional, Threadline enabled, mentor endpoints present, `quotaTracking:false`
+on his instance — applying [[feedback_report_verified_not_intended_behavior]]).
 
-Sent to Codey on a fresh Threadline thread + view link after Justin's nod on this draft.
+Codey's 5 substantive refinements (all folded above):
+1. **/idle** — add optional `reason` (diagnostic-only, Echo doesn't depend); sharpen
+   `activeSessions` semantics (live work only, not historical panes); ambiguous-signal →
+   `idle:false` rather than omit.
+2. **Recipient handler** — strict malformed-marker drop (security event, NEVER fall
+   through to user); explicit per-decision audit row; processed-id idempotency ledger
+   against Telegram retries / adapter restarts.
+3. **Sender** — make generic (not mentor-specific); caller passes allowed-roles list at
+   construction; return `a2aId` alongside `sentMessageId`; full audit-row schema
+   (no secrets in ledgers).
+4. **Marker schema** — constrain field-value charset to `[A-Za-z0-9._:-]+` + integer for
+   `v` (deterministic parsing, avoids invisible/escaping cases); add **visible `corr=`**
+   field so Telegram chat history alone reconstructs the round-trip when ledgers
+   unavailable.
+5. **Anti-loop invariants** — agent-origin messages suppress courtesy/ack BEFORE normal
+   user routing sees them; role-handler explicit allowed-outbound-roles list (cannot send
+   the role it consumes); `mentor-reply` ingestion on Echo MUST be finding-emission-only
+   (no Stage A, no `deliverToMentee`, no scheduler enqueue, no Threadline send); cycle-
+   detection key is `(fromBotId, toBotId, topicId, role, corr)`, not just bot+topic;
+   every drop path writes an audit row.
+
+**Implementation note Codey raised:** the Codey-side PR should land in the **instar source
+package** (the upstream that produces the shadow-install), NOT as a hand-edit under
+`.instar/shadow-install`. The primitive ships as part of instar; per-agent config
+(agentTelegram allowlist + mentor.botToken) is the only per-agent piece.
+
+**Quota-budget on Codey's side (Codey's surface check):** his instance reports
+`quotaTracking:false`, so Fix 3 (quota-aware budget) is primarily an **Echo-side**
+mechanism — Codey doesn't gate his own work against quota for this loop. The mentor
+budget gates Echo's *sending* (Echo's tokens are the spend); Codey's responses go through
+his own normal handling. Documented in §Fix 3 below.
 
 ## Honesty / lessons applied
 

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -1,7 +1,12 @@
 ---
 title: Mentor live-readiness — real idle signal, mentee-side pickup, quota-aware budget
 owning-layer: scheduler + server (mentor)
-status: draft
+status: converged
+review-convergence: true
+review-iterations: 2
+review-reviewers: lessons-aware, integration, adversarial
+co-designer: instar-codey (Threadline thread 5cc61bd7, §Fix 2 mentee-side pickup)
+approved: false
 supervision: tier1
 ---
 
@@ -208,9 +213,15 @@ dir). (iii) Publish a typed-contract export Stage-B uses to parse reply.jsonl. (
 contract test that round-trips a written prompt + a hand-written reply through the parser.
 
 **Codey-side responsibilities (Codey ships, separately).** The `mentor-inbox-poll` job,
-cursor + lock + dead-letter, the local injection abstraction, the delivery + reply writers.
-Both halves must land before the supervised live test. Coordinated through this spec's
-shared contract.
+cursor + lock + dead-letter, the local injection abstraction, the delivery + reply writers,
+the `/idle` endpoint, and vendoring `MENTOR_CONTRACT_VERSION`. Both halves must land before
+the supervised live test. Coordinated through this spec's shared contract.
+
+**Echo-side ship-independence (R2 integration F-new-1).** Echo's side ships independently of
+Codey's PR. Absent `/idle` produces continuous `mentee-busy` defers + a degradation event —
+**not a refuse-to-start**. The mentor stays harmlessly idle in production (just like the
+dry-run we ran today) until Codey's side lands. This is the [[graduated-feature-rollout]]
+pattern: ship dark, observe-only, then promote when the dependent piece is ready.
 
 #### Hardening (convergence round 1)
 
@@ -219,8 +230,12 @@ shared contract.
 canonicalization. Echo writes into *another agent's* state dir, so the attack/misconfig
 surface is real. New Echo-side requirements:
 
-1. **Symlink reject**: `lstat` the target path before each append; if it's a symlink, refuse
-   the write and emit `DegradationReporter` event `mentor.delivery.symlink-rejected`.
+1. **Symlink reject + parent-realpath check (defense-in-depth, R2 adversarial-B)**: `lstat`
+   the leaf path before each append; if it's a symlink, refuse the write and emit
+   `DegradationReporter` event `mentor.delivery.symlink-rejected`. ALSO `realpathSync` the
+   resolved write path and assert it still resides under the validated `menteeStateDir` root
+   — leaf-lstat alone misses a directory-symlink planted *above* the leaf on macOS, and
+   guards against lstat→append TOCTOU.
 2. **menteeStateDir allowlist**: validate `mentor.menteeStateDir` at startup — refuse if it
    resolves to Echo's own `stateDir`, contains `..`, or doesn't look like an instar agent
    home (no `.instar/config.json` at the root). Refuse-to-start with a loud error rather
@@ -296,7 +311,15 @@ ships today; bumps need a rule, not a Threadline round-trip every time.
   - Within state, suppress (no chatter on every tick).
   - **Persistence: file-backed** at `state/mentor-budget-notifications.json` via
     `SafeFsExecutor.atomicWriteJsonSync` so a mid-day server restart does NOT re-alert
-    (integration F4). In-memory alone re-spams.
+    (integration F4). In-memory alone re-spams. **Explicit shape** (R2 integration F-new-2):
+    ```json
+    { "<reason>": { "state": "ok|tripped", "lastTransitionTs": "ISO", "lastAlertTs": "ISO" } }
+    ```
+    **Single-writer / CAS (R2 adversarial-A):** all state-machine reads + transitions go
+    through a `CommitmentTracker.mutate()`-style CAS so two concurrent ticks observing
+    `tripped→ok` cannot double-fire the recovery alert. **Corrupt-state file on read**:
+    treat as `{}` (full re-alert next trip) AND emit `mentor.budget-state.corrupt`
+    degradation event — don't crash, don't silently lose all dedup.
   - **Optional "still tripped after N hours" reminder** (default off, configurable via
     `mentor.budgetReminderHours`) for long-running trips (e.g. quota stays elevated for 6h).
 
@@ -403,6 +426,13 @@ The tick changes:
 - **No agent-installed file changes** beyond config defaults — loader-only shadow-install
   update for Echo's side; Codey's side is a separate PR in his repo (which adds his
   `mentor-inbox-poll` job + the `/idle` endpoint).
+- **New route parity (R2 integration F-new-3).** The new `GET /mentor/contract` route
+  requires: (a) classification under the `mentor` prefix in `CapabilityIndex.ts` so the
+  capabilities-discoverability CI gate passes; (b) a one-line entry in the CLAUDE.md
+  template (`src/scaffold/templates.ts → generateClaudeMd()`) per the Agent Awareness
+  Standard so other agents know it exists; (c) a docs-coverage entry in `default-jobs.md`
+  is NOT needed (this isn't a job) — the route is documented in `reference/api.md` per the
+  existing pattern. Migration: route ships in the package; no per-agent migration needed.
 
 ## Co-design with Codey
 

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -118,7 +118,7 @@ Every agent-to-agent message carries a structured, visible prefix in the message
 - **`ts` is REQUIRED** (round-2 adversarial F2 — replay defense without HMAC): unix-ms
   timestamp. Recipient REJECTS any marker with `|now - ts| > a2a.skewWindowMs` (default
   24h) as `agent-marker-stale-or-future`. Caps replay window independent of processed-id
-  ledger eviction; HMAC-signed markers remain deferred to v2.
+  ledger eviction; HMAC-signed markers are a v2 concern. <!-- tracked: topic-13435 -->
 - **Parser is strict** — regex anchored to start, consumes only the first line + the
   required blank separator. Anything marker-*like* but malformed (charset violation,
   missing required field, broken syntax) is an **A2A security event**: drop + audit row,
@@ -127,8 +127,8 @@ Every agent-to-agent message carries a structured, visible prefix in the message
 - **Versioned** (`v=1`) — schema bumps are explicit.
 - **No HMAC v1** — recipient trusts the marker if the sender Telegram bot identity is in
   the recipient's known-agents allowlist (the structural identity check is the Telegram bot
-  ID, not the marker text). HMAC-signed markers deferred to v2 if cross-machine trust
-  becomes a concern.
+  ID, not the marker text). HMAC-signed markers are a v2 concern if cross-machine trust
+  matters. <!-- tracked: topic-13435 -->
 - **Roles defined**: `mentor`, `mentor-reply`, `coord`, `coord-reply`, `notify` (extensible).
 
 ### Sender side
@@ -353,9 +353,9 @@ need to land as part of this PR:
   goes via `intelligence.evaluate` → `recordEvent` → attributed `mentor-stage-b::*`.
   Stage-A is a spawned Claude-CLI session whose tokens reach the ledger via JSONL
   scan and fall under `unknown::pre-attribution` (`TokenLedger.ts:404-407`, explicit).
-  Stage-A spend is **invisible to this ceiling**. The honest name reflects that;
-  follow-up tracked: "Stage-A attribution via session-name-prefix resolver" (separate
-  PR) to bring Stage-A under the same cap. Don't claim coverage we don't have.
+  Stage-A spend is **invisible to this ceiling**. The honest name reflects that; a separate
+  PR will bring Stage-A under the same cap via a session-name-prefix attribution resolver.
+  <!-- tracked: topic-13435 --> Don't claim coverage we don't have.
 - **Trip-EPISODE state machine** (not day-bucket); alerts on `ok→tripped` AND
   `tripped→ok`; file-backed persistence at `state/mentor-budget-notifications.json` via
   `SafeFsExecutor.atomicWriteJsonSync`; CAS single-writer; corrupt-state-file recovery

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -1,455 +1,315 @@
 ---
-title: Mentor live-readiness — real idle signal, mentee-side pickup, quota-aware budget
-owning-layer: scheduler + server (mentor)
-status: converged
-review-convergence: true
-review-iterations: 2
-review-reviewers: lessons-aware, integration, adversarial
-co-designer: instar-codey (Threadline thread 5cc61bd7, §Fix 2 mentee-side pickup)
+title: Agent-to-Agent Telegram comms primitive + Mentor live-readiness (its first consumer)
+owning-layer: messaging (new primitive) + scheduler/server (mentor consumer)
+status: draft
+review-convergence: false
+review-iterations: 0
+co-designer: instar-codey (pending — recipient-side detection + anti-loop handler)
 approved: false
+supersedes-rounds: 2 prior convergence rounds on file-based mentor-outbox design (committed but re-architected after Justin substrate correction, topic 13435, 2026-05-27)
 supervision: tier1
 ---
 
-# Mentor live-readiness
+# Agent-to-Agent Telegram comms primitive + Mentor live-readiness
 
 ## Summary
 
-The mentor system ships fully built but with three placeholders that block a real live test
-against Codey. All three were surfaced during the 2026-05-27 dry-run live-validation phase
-(topic 13435 — Justin caught two; the third I verified before claiming a live test would
-work). Fixing all three is the prerequisite for one supervised live cycle against Codey, and
-then for unattended live operation.
+Two fixes wrapped together because the consumer drove the primitive's design:
 
-## The three gaps
+1. **A new agent-to-agent Telegram comms primitive** — a robust, recipient-knows-it's-from-
+   an-agent channel any agent can use to message another agent's bot, with the indicator
+   *and* the anti-loop machinery as first-class infra. Justin's framing (2026-05-27):
+   "robust infra that indicates the message is from another agent… leverage infra to
+   prevent the ping pong trap." Reusable for any future agent-to-agent Telegram scenario;
+   the mentor is its first consumer.
+2. **Mentor live-readiness** — three remaining gaps in the existing mentor system that
+   block a real supervised live cycle against Codey (real idle signal, the agent-comms
+   delivery — now via the primitive — replacing the broken file-outbox, and a quota-aware
+   budget on actual subscription metrics).
+
+## Design-drift correction (honoring this morning's learning)
+
+The first version of this spec used a file-based outbox for mentor delivery — convergence
+hardened it heavily, all the way to round 2 — and Justin caught that it solved the wrong
+problem. The cross-agent spawn loop was a *discipline* issue (don't auto-reply to courtesy
+acks); I'd misread it as a *substrate* issue and moved off Telegram, which broke the
+authenticity of the simulation (Codey would process file lines, not user messages, exactly
+what we DON'T want to test). Two rounds of reviewer review didn't catch it because each
+reviewer asked "is this file-based design sound?" not "is file-based the right substrate?"
+Recorded the meta-lesson alongside today's earlier one
+([[feedback_report_verified_not_intended_behavior]]): convergence checks *how well a
+design holds up*, not *whether the design's framing is correct* — that's the user's call,
+and the spec must surface the substrate choice explicitly, not bury it.
+
+## The three live-readiness gaps (unchanged from prior draft)
 
 ### Gap 1 — `isMenteeBusy()` is a stub that's not about the mentee at all
 
-`AgentServer.ts:~651`:
-```ts
-isMenteeBusy: () => self.sessionManager.listRunningSessions().length > 0,
-```
+`AgentServer.ts:~651`: `isMenteeBusy: () => self.sessionManager.listRunningSessions().length > 0`.
+Tagged `<!-- tracked: topic-13435 -->`. Checks Echo's own sessions; almost always true →
+safe window never opens → mentor effectively never runs.
 
-Tagged in code with `<!-- tracked: topic-13435 -->` ("refined at live validation"). It checks
-**Echo's own** running-session count, not Codey's state. Echo almost always has running
-sessions → `isMenteeBusy()` is almost always true → `safeWindowOpen` is almost never true →
-**the mentor effectively never runs**.
+### Gap 2 — Mentor delivery to Codey does not exist as a real user-channel
 
-### Gap 2 — `deliverToMentee` is write-only (no Codey-side pickup)
-
-`AgentServer.ts:~671-678`: `deliverToMentee` correctly appends a JSON line to
-`{stateDir}/mentor-outbox/<framework>.jsonl`. The persist-only-no-spawn shape is the
-deliberate **structural fix for the cross-agent spawn loop** ([[bug_cross_agent_ack_spawn_loop]]).
-But **nothing on Codey's side reads that outbox** — verified by grepping the shipped dist for
-mentor-outbox readers (one writer, zero readers). A live test today would write a file Codey
-never sees. The mentee-side pickup is the missing piece — and it's Codey's side, so co-design.
+The current `deliverToMentee` writes JSON lines to a file nothing reads, AND the file
+substrate doesn't simulate a user interaction even if it were read. Both problems are
+fixed by the new primitive: route mentor messages through Telegram (the real user channel)
+so Codey processes them with his normal user-message pipeline.
 
 ### Gap 3 — Budget is dollar-denominated on a token-subscription, unenforced, silent on trip
 
-`AgentServer.ts:~656-664`: `budgetOk` checks `mentorRunsToday < cfg.maxRoundsPerDay`
-(24/day **run-count**). `cfg.dailySpendCapUsd: 0.5` is configured in
-`MentorOnboardingRunner.DEFAULT_MENTOR_CONFIG` and `ConfigDefaults.ts` but **read nowhere**
-(dead field — verified by repo-wide grep). Worse, the unit is fundamentally wrong: Echo runs
-on a Claude **subscription**, not pay-per-token API, so there is no per-token dollar charge to
-cap. The real cost is **tokens against a rolling quota** (5-hour + weekly limits) — already
-tracked by `QuotaTracker` (`canRunJob(priority)` → normal/elevated/critical/shutdown) and
-`TokenLedger` (with `attribution: { component: 'mentor-stage-b' }` already set). And nothing
-notifies Justin when the cap (round or otherwise) trips.
+`AgentServer.ts:~656-664`: `budgetOk` checks a run-count; `dailySpendCapUsd: 0.5` is a dead
+config field; Echo runs on a Claude subscription (no per-token dollar charge to cap). The
+real cost is tokens against rolling quota — already tracked by `QuotaTracker.canRunJob` +
+`TokenLedger` (`attribution.component='mentor-stage-b'`).
 
-## Fix
+## Fix 1 — Real Codey-idle signal (replaces the system-busy stub)
 
-### Fix 1 — Real Codey-idle signal (replaces the system-busy stub)
+Replace `isMenteeBusy` with a **mentee-specific** idle check via a new unauthenticated
+`GET /idle` endpoint Codey ships on his server (port 4044). `/sessions` is Bearer-authed
+AND has no `activelyWorking` field, so a fresh endpoint is needed.
 
-Replace `isMenteeBusy` with a **mentee-specific** idle check. Convergence (adversarial F1/F2,
-integration minor) revealed two blockers in the original draft:
-
-- `/sessions` is **Bearer-token-gated** (`middleware.ts:57`); a cross-agent probe without
-  auth always returns 401 → fail-closed → permanent silent deferral.
-- `SessionManager` session records have **no `activelyWorking` field** (grep returns 0 hits) —
-  only `status:'running'`. A 200 with empty array is ambiguous (truly idle vs. mentee server
-  crashed-and-restarted-clean), and a single-session-at-prompt-for-hours looks identical to
-  active work.
-
-**Required Codey-side addition:** a dedicated **unauthenticated** `GET /idle` endpoint Codey
-ships on his server. Returns a structured response Echo can trust:
+`/idle` returns:
 ```json
-{
-  "schemaVersion": 1,
-  "idle": true,
-  "bootId": "uuid-set-at-process-start",
-  "uptimeSec": 12345,
-  "activeSessions": 0,
-  "ts": "ISO-8601"
-}
+{ "schemaVersion": 1, "idle": true, "bootId": "uuid-set-at-process-start",
+  "uptimeSec": 12345, "activeSessions": 0, "ts": "ISO-8601" }
 ```
-- `idle` = true iff Codey reports no sessions doing work right now.
-- `bootId` + `uptimeSec` let Echo detect mentee restart-since-last-probe (treat as busy for
-  one min-interval after a fresh boot, so we don't pile on a recovering Codey).
-- Unauthenticated because (i) it leaks no sensitive state, (ii) avoids the
-  cross-agent shared-Bearer-secret trust boundary.
 
-**Echo-side wiring:**
-- Resolve from `mentor.menteeServerUrl` (default `http://localhost:4044` for `codex-cli`).
-- `GET {menteeServerUrl}/idle` with a 750ms timeout.
-- **Fail-closed on every ambiguous outcome:** non-2xx, network/timeout, JSON-parse failure,
-  unrecognized schemaVersion, missing required fields, OR `idle !== true` → treat as
-  **busy** (never silently flip to idle).
-- **Liveness inferred from heartbeat, not 200-empty-array** — if `idle:true` but
-  `uptimeSec < minIntervalMs/1000`, defer one more cycle.
-- Persistent probe failure (≥3 consecutive) emits a `DegradationReporter` event with
-  feature `'mentor.menteeProbe'` — surfaces in `/degradation`, not silent.
-- The check is async; the runner pre-resolves it before assembling tick deps (the tick stays
-  pure).
-- **Defer reasons are split** (per adversarial minor): `mentee-busy` (probe says busy /
-  failed / liveness-warmup) and `min-interval-not-elapsed` are distinct strings so debugging
-  doesn't collapse them.
+Echo-side:
+- Probe `{mentor.menteeServerUrl}/idle` with 750ms timeout.
+- **Fail-closed on every ambiguous outcome**: non-2xx, network/timeout, JSON-parse failure,
+  unrecognized schemaVersion, missing required fields, `idle !== true` → busy.
+- **Liveness-warmup**: `idle:true` but `uptimeSec < minIntervalMs/1000` → defer one cycle
+  (don't pile onto a recovering Codey).
+- Persistent failure (≥3 consecutive) → `DegradationReporter` event `mentor.menteeProbe`.
+- Reasons split: `mentee-busy` vs `min-interval-not-elapsed` (distinct strings).
 
-### Fix 2 — Mentee-side outbox pickup (Codey-designed, Threadline 5cc61bd7, 2026-05-27)
+## Fix 2a — Agent-to-Agent Telegram Comms primitive (new infra)
 
-Keep the outbox-write exactly as is (the spawn-loop-safe shape is correct). Add a
-**pull-based pickup** on Codey's side. Codey picked **option (a) — a scheduled poll job** —
-explicitly because it survives restarts, session churn, and partial failures; correctness
-matters more than the latency cost of supervised live-loop turnaround (~30–60s acceptable).
+**Module:** `src/messaging/AgentTelegramComms.ts` (new) — generic primitive, mentor-agnostic.
 
-**Pull mechanism (Codey's side, his code).** `mentor-inbox-poll` agentmd job, runs ~every
-minute. Reads append-only JSONL, keeps a **durable per-source byte-offset cursor**, processes
-only complete newline-terminated records, uses a lock file so overlapping invocations cannot
-double-deliver, and on injection delivers via the local server/session-injection surface
-(Codey-side abstraction — intentionally *not* bound in the contract to a specific function
-name, since the injection API is per-harness). On malformed-but-complete line → dead-letter
-+ advance cursor; on incomplete trailing line → wait for next poll.
+### The marker
 
-**Paths (stateDir-relative on each side — IMPORTANT: `{codeyStateDir}` is *Codey's* state
-root, not Echo's, so Echo must write cross-agent into Codey's local state dir).**
+Every agent-to-agent message carries a structured, visible prefix in the message body:
 
-| File | Owner | Purpose |
-|------|-------|---------|
-| `{codeyStateDir}/mentor-outbox/codex-cli.jsonl` | Echo writes / Codey reads | Inbound mentor prompts |
-| `{codeyStateDir}/mentor-outbox/.cursors/codex-cli.cursor.json` | Codey | Durable byte-offset cursor |
-| `{codeyStateDir}/mentor-outbox/codex-cli.deadletter.jsonl` | Codey | Malformed lines, audit |
-| `{codeyStateDir}/mentor-outbox/codex-cli.delivery.jsonl` | Codey writes / Echo Stage-B reads | Per-injection audit row (written immediately after successful inject, BEFORE the reply) |
-| `{codeyStateDir}/mentor-outbox/codex-cli.reply.jsonl` | Codey writes / Echo Stage-B reads | Per-prompt terminal outcome |
-
-Echo resolves `{codeyStateDir}` from a new config `mentor.menteeStateDir` (default
-`/Users/justin/Documents/Projects/instar-codey/.instar` for `codex-cli`). The contract stays
-stateDir-relative; the absolute-path resolution is the only machine-specific shim.
-
-**Audit pattern (Codey's preference, adopted).** The poller writes a **delivery row
-immediately after successful injection** + the **reply row only after the session produces
-the assistant response**. This lets Stage-B distinguish three states cleanly: *never picked
-up* (no delivery row for this id) / *picked up, no reply yet* (delivery row, no reply row) /
-*reply completed* (both rows). Stage-B matches on `correlationId` first, `requestId` second.
-
-**Line schema — inbound prompt (Echo → Codey).**
-```json
-{
-  "schemaVersion": 1,
-  "id": "uuid-or-stable-id",
-  "ts": "2026-05-27T18:25:18.831Z",
-  "kind": "mentor.live.prompt",
-  "from": { "agent": "echo", "role": "mentor" },
-  "to": { "agent": "instar-codey", "framework": "codex-cli" },
-  "threadId": "optional-mentor-thread-or-run-id",
-  "correlationId": "stable-id-stage-b-uses-to-match-reply",
-  "message": "prompt text",
-  "replyRequired": true,
-  "expiresAt": "optional-iso-ts (if absent, processed whenever seen)"
-}
 ```
-- `id` is REQUIRED (idempotency anchor).
-- `correlationId` defaults to `id` if omitted; Stage-B matches it first.
-- Echo MAY emit top-level `framework` as a compatibility alias during rollout; the canonical
-  location is `to.framework`.
-- `message` is the only prompt-content field; metadata is routing/audit, never executable
-  instructions.
-- `attachments` field is reserved for future use; for now, prompt is a plain string.
+[a2a:from=<senderAgent> to=<recipientAgent> role=<role> id=<stable-uuid> v=1]
 
-**Line schema — reply (Codey → Echo, terminal outcome).**
+<message body>
+```
+
+- **Visible in chat** — humans can audit at a glance (a real chat-log forensic property,
+  not a hidden metadata field).
+- **Parseable** — regex `^\[a2a:from=(\S+) to=(\S+) role=(\S+) id=(\S+) v=(\d+)\]\n\n`.
+- **Versioned** (`v=1`) — schema bumps are explicit.
+- **No HMAC v1** — recipient trusts the marker if the sender Telegram bot identity is in
+  the recipient's known-agents allowlist (the structural identity check is the Telegram bot
+  ID, not the marker text). HMAC-signed markers deferred to v2 if cross-machine trust
+  becomes a concern.
+- **Roles defined**: `mentor`, `mentor-reply`, `coord`, `coord-reply`, `notify` (extensible).
+
+### Sender side
+
+```ts
+sendAgentMessage({
+  fromAgent: 'echo',
+  toAgent: 'instar-codey',
+  toBotToken: cfg.codey.mentorBotToken,   // the recipient's mentor-bot token
+  toTopicId: cfg.codey.mentorTopicId,     // the dedicated topic in recipient's setup
+  role: 'mentor',
+  message: '<the prompt>',
+  correlationId?: 'optional-existing-id-for-reply-threading',
+}): Promise<{ ok: boolean; sentMessageId?: string; reason?: string }>
+```
+
+- Instantiates (or reuses) a `TelegramAdapter` for the recipient's bot.
+- Prepends the marker; calls `sendToTopic(toTopicId, marker+body)`.
+- Returns `{ok, sentMessageId}` so consumers can correlate.
+- Logs every send to an audit ledger (`state/a2a-sent.jsonl`) — append-only.
+
+### Recipient side
+
+A new incoming-message handler registered with `TelegramAdapter.onMessage`:
+
+```ts
+agentMessageHandler(rawMsg): { handled: boolean; routedTo?: string }
+```
+
+- Parses the marker. If absent → not an agent message; fall through to normal user handler.
+- If present and `from` is in the known-agents allowlist (`config.agentTelegram.knownAgents`)
+  AND the sender bot ID matches → route to the appropriate handler (`role` → handler map).
+- **If marker present but `from` not allowlisted OR bot ID mismatch**: log as
+  `agent-marker-unknown` and drop (NEVER deliver to the normal user-message path — spoofing
+  defense; an unknown party adding a marker doesn't get user-level processing).
+- **Anti-loop discipline (the heart of the primitive)**:
+  - Agent-origin messages NEVER auto-trigger courtesy replies. The role-handler is the
+    only producer of any outgoing message in response.
+  - If the role-handler does produce a reply, it routes through `sendAgentMessage` with
+    `role=<original>-reply`, carrying the original `id` as `correlationId`. Replies are
+    marked, traceable, and visible.
+  - **A reply received (e.g. `mentor-reply`) NEVER triggers another `mentor` send.**
+    Outgoing mentor messages come only from the scheduled mentor cycle. Same for any
+    role-pair. Compile-time guard: the role-handler module's import surface lint forbids
+    `sendAgentMessage(role='X')` if it also reads `role='X-reply'` (no closed-loop within
+    one module).
+- Every received agent message logged to `state/a2a-received.jsonl` (append-only audit).
+
+### Anti-loop infra: structural, not just rules
+
+1. **One outbound producer per `role`.** Each `role` has exactly one module that may send
+   it (`mentor` is sent only by the mentor tick; `mentor-reply` only by Codey's mentor
+   handler). Import-surface lint enforces.
+2. **Cycle-detection in flight.** If `sendAgentMessage` sees a recipient bot-id+topic that
+   matches an inflight conversation where the local agent received from that bot in the
+   last N seconds (default 5), it requires an explicit `cycle-ok: true` parameter or
+   refuses with a degradation event.
+3. **Round-trip audit ledger.** Both ledgers (sent + received) include role, ids, and
+   correlation chains. Stage-B / future debugging can prove there is no role→reply→role
+   path within a single tick boundary.
+
+### Config
+
+New `agentTelegram` section in `.instar/config.json`:
 ```json
-{
-  "schemaVersion": 1,
-  "kind": "mentor.live.reply",
-  "id": "uuid-for-this-reply-row",
-  "requestId": "incoming-line-id",
-  "correlationId": "incoming-correlation-id-or-id",
-  "ts": "2026-05-27T18:26:05.000Z",
-  "from": { "agent": "instar-codey", "framework": "codex-cli" },
-  "to": { "agent": "echo", "role": "mentor" },
-  "status": "ok",
-  "message": "assistant reply text",
-  "session": {
-    "topicId": null,
-    "sessionId": "optional-local-session-id",
-    "delivery": "active-session"
+"agentTelegram": {
+  "knownAgents": {
+    "echo":        { "botId": "echo-mentor-bot-id" },
+    "instar-codey":{ "botId": "codey-bot-id" }
   },
-  "error": { "code": "no_active_session", "retryable": true }
+  "cycleDetectionWindowMs": 5000,
+  "auditRetentionDays": 30
 }
 ```
-- `status ∈ {ok, error, ignored, expired}`.
-- `error` is present only for non-`ok` statuses; `message` remains user-safe.
 
-**Anti-loop contract (Codey-asserted, baked into the spec — both sides comply).**
+Per-recipient bot config (sender-side) lives under the consumer's section (e.g.
+`mentor.codeyBot = {token, topicId}` — see Fix 2b).
 
-1. Echo writes files only. Codey reads files only for inbound mentor prompts. **No
-   Threadline send, no agent spawn, no HTTP callback as part of the live loop.**
-2. Codey replies by appending to the reply JSONL file only. Echo Stage-B reads that file;
-   Echo MUST NOT treat a reply as a trigger to write a new prompt unless a human/supervisor
-   explicitly starts a new mentor turn.
-3. Every incoming row needs a stable `id`; Codey maintains a processed-id ledger (cursor +
-   id check) so file rewrites, duplicate appends, and restarts do not re-inject.
-4. Optional `expiresAt` for prompts whose staleness is unsafe; absence = process whenever
-   seen.
-5. `replyRequired` may be false for one-way deliveries; for the live-loop test, set true.
-6. **Metadata is routing/audit only** — never prompt content. Only `message` is interpreted
-   as prompt.
-7. **One writer per file.** If multi-mentor lands later, one source file per writer (or
-   append-locking).
-8. Delivery + reply ledgers are append-only so Stage-B can reconstruct the run even on
-   mid-turn crash.
+## Fix 2b — Mentor consumes the primitive
 
-**Echo-side responsibilities (this PR ships).** (i) Replace the per-tick `{ts,framework,message}`
-write with the schemaVersion=1 record above (with `id` + `correlationId`). (ii) Write to
-`{mentor.menteeStateDir}/mentor-outbox/codex-cli.jsonl` (cross-agent into Codey's state
-dir). (iii) Publish a typed-contract export Stage-B uses to parse reply.jsonl. (iv) Add a
-contract test that round-trips a written prompt + a hand-written reply through the parser.
+- **Echo mints a dedicated mentor bot via @BotFather** (per Justin's choice C). Token
+  stored in Echo's config under `mentor.botToken` (Secret-Drop-collected — never via chat
+  paste).
+- **Codey accepts the mentor bot** as a known agent in his `agentTelegram.knownAgents`
+  allowlist, and routes any received `[a2a:role=mentor]` to a new "mentor inbox" topic
+  (the dedicated Mentor session topic). The role-handler injects the message body
+  (post-marker-strip) as a user prompt into Codey's mentor-session.
+- **Codey's reply** goes back via `sendAgentMessage` with `role=mentor-reply` to Echo's
+  mentor bot. Echo's mentor bot receives it; Echo's recipient handler routes to Stage-B.
+- **Stage-B reply ingestion is finding-emission-only** — capture() only, no path to
+  spawnStageA or another deliverToMentee. Unit-tested by an assertion: a `mentor-reply`
+  received → next tick still defers (no implicit recurrence).
+- **`deliverToMentee` (Echo-side) is replaced** by a thin wrapper around `sendAgentMessage`.
+  The file-based mentor-outbox is retired (legacy artifact cleanup in migration).
 
-**Codey-side responsibilities (Codey ships, separately).** The `mentor-inbox-poll` job,
-cursor + lock + dead-letter, the local injection abstraction, the delivery + reply writers,
-the `/idle` endpoint, and vendoring `MENTOR_CONTRACT_VERSION`. Both halves must land before
-the supervised live test. Coordinated through this spec's shared contract.
+### What this means for the mentor's Stage A
 
-**Echo-side ship-independence (R2 integration F-new-1).** Echo's side ships independently of
-Codey's PR. Absent `/idle` produces continuous `mentee-busy` defers + a degradation event —
-**not a refuse-to-start**. The mentor stays harmlessly idle in production (just like the
-dry-run we ran today) until Codey's side lands. This is the [[graduated-feature-rollout]]
-pattern: ship dark, observe-only, then promote when the dependent piece is ready.
+Stage A drives Codey "as a user would" — via Telegram, in the dedicated mentor topic,
+through the primitive. Codey's mentor-handler processes the prompt the same way it would
+process any user message (the test of his behavior under user-like interaction). The
+identity is honest (it's Echo's mentor bot, not a Justin impersonation), but the
+*interaction shape* is user-level, which is what the wild-behavior test needs.
 
-#### Hardening (convergence round 1)
+## Fix 3 — Quota-aware budget + notification (unchanged from prior draft)
 
-**Cross-agent filesystem safety (adversarial F3, integration F1).** The current
-`deliverToMentee` uses raw `fs.mkdirSync` + `fs.appendFileSync` — no symlink check, no path
-canonicalization. Echo writes into *another agent's* state dir, so the attack/misconfig
-surface is real. New Echo-side requirements:
+- **Remove** `dailySpendCapUsd` from config defaults; add `mentor.quotaCeiling` (default
+  `elevated`), wire `budgetOk` to `QuotaTracker.canRunJob('low')` + run-count backstop.
+- **Quota null/stale → fail-closed** (`reason: quota-unknown`); override the default
+  fail-open.
+- **Token-spend ceiling** (`mentor.dailyTokenCeiling`, default 200_000) summed via
+  prefix-match `mentor-stage-b::%` on `TokenLedger.byAttributionKey({sinceMs})`.
+- **Trip-EPISODE state machine** (not day-bucket); alerts on `ok→tripped` AND
+  `tripped→ok`; file-backed persistence at `state/mentor-budget-notifications.json` via
+  `SafeFsExecutor.atomicWriteJsonSync`; CAS single-writer; corrupt-state-file recovery
+  with degradation event; optional `budgetReminderHours` long-trip reminder (default off).
 
-1. **Symlink reject + parent-realpath check (defense-in-depth, R2 adversarial-B)**: `lstat`
-   the leaf path before each append; if it's a symlink, refuse the write and emit
-   `DegradationReporter` event `mentor.delivery.symlink-rejected`. ALSO `realpathSync` the
-   resolved write path and assert it still resides under the validated `menteeStateDir` root
-   — leaf-lstat alone misses a directory-symlink planted *above* the leaf on macOS, and
-   guards against lstat→append TOCTOU.
-2. **menteeStateDir allowlist**: validate `mentor.menteeStateDir` at startup — refuse if it
-   resolves to Echo's own `stateDir`, contains `..`, or doesn't look like an instar agent
-   home (no `.instar/config.json` at the root). Refuse-to-start with a loud error rather
-   than silently writing into the wrong place.
-3. **Append-only contract documented**: raw `appendFileSync` is correct for JSONL (atomic at
-   line granularity on POSIX for `<PIPE_BUF`); document why `SafeFsExecutor` is NOT used for
-   this path (its destructive-op guards don't apply to append) so a future reviewer doesn't
-   "fix" it incorrectly.
+## Scope
 
-**Delivery failure must surface (adversarial F4).** Current shape silently swallows EACCES /
-ENOSPC / EROFS → tick reports `delivered:true` even when nothing was written. Required:
-- `deliverToMentee` returns `{ ok: boolean; reason?: string }` (was void).
-- Tick's `delivered` boolean reflects the callback's `ok`.
-- On `!ok`, runner pushes ONE Attention entry deduped per (reason, day) using the same
-  primitive as the budget-trip notifier (Fix 3). Otherwise a permanently-broken Codey disk
-  burns the daily run budget silently.
-
-**Anti-loop made structural (lessons 1, adversarial F5).** The eight contract constraints
-are correct but currently behavioral promises. Make them compile-/test-time invariants:
-
-1. **Stage-B reply ingestion is finding-emission-only.** Define explicitly: when Stage-B
-   reads `reply.jsonl`, the only output path is `capture({findings})` — there is NO code
-   path from reply ingestion to `spawnStageA` or `deliverToMentee`. Implementation: Stage-B
-   reply parser returns `ForensicFinding[]`; the tick passes them only to `capture()`.
-2. **Unit test (the structural assertion):** "given a reply row landed, the next tick still
-   defers on `mentee-busy` / `min-interval-not-elapsed` and does NOT call `deliverToMentee`
-   or `spawnStageA`" — proves no implicit recurrence path exists.
-3. **Import-surface lint** for the mentor-delivery module: arch-test asserts the module's
-   imports are a subset of `{ fs, path, mentor-contract-types }` — no `threadline_send`, no
-   `spawnSession`, no `fetch`/`http`. Build fails on regression. Turns rule 1 of the
-   contract from promise into compile-time invariant.
-
-**Schema-version negotiation (adversarial F7, integration F6, lessons F6).** SchemaVersion=1
-ships today; bumps need a rule, not a Threadline round-trip every time.
-- Echo exports `MENTOR_CONTRACT_VERSION` (a constant + a typed `MentorPrompt` /
-  `MentorReply` schema) Codey imports/vendors with a pinned version.
-- Echo serves the schema at `GET /mentor/contract` (unauthenticated read-only — schema is
-  not sensitive) so Codey can fetch + assert at startup if vendoring isn't workable.
-- **Within v1**: additions are additive-only (new optional fields allowed; required
-  fields/renames forbidden).
-- **Breaking change → v2**: bumps land on the **reader-first** (Codey, who reads prompts AND
-  writes replies — gets v2 understanding first), then on Echo (writer). Older readers seeing
-  newer lines → dead-letter row with a `schema-version-too-new` reason (not crash, not
-  silent).
-- CI gate: a bump to `MENTOR_CONTRACT_VERSION` requires a corresponding entry in
-  `docs/specs/MENTOR-CONTRACT-CHANGELOG.md` — script lints this on PR.
-
-### Fix 3 — Quota-aware budget + notification (replaces the dead dollar cap)
-
-- **Remove** `dailySpendCapUsd` from config defaults; replace with `mentor.quotaCeiling`
-  (default: `elevated` — mentor stands down at elevated/critical/shutdown, runs only at
-  normal). Wire `budgetOk` to `QuotaTracker.canRunJob('low')` (mentor is low-priority) AND
-  the existing run-count backstop (`maxRoundsPerDay` stays — it's a real bound).
-- **Quota null/stale → fail-closed (integration F2).** `QuotaTracker.getState()` returns
-  null when the quota state file is missing or stale (>30 min), and `shouldSpawnSession`
-  fails-OPEN by default. For the mentor, override to **fail-closed**: null/stale ⇒
-  `budget.ok = false, reason = 'quota-unknown'`. Consistent with Fix 1's idle posture; we
-  don't burn quota blindly when we can't read it.
-- **Add a token-spend ceiling** (`mentor.dailyTokenCeiling`, default 200_000 tokens) summed
-  from `TokenLedger`. **Integration F3 correction:** `TokenLedger.attribution_key` shape is
-  `<component>::<promptFingerprint>`, not bare `mentor-stage-b` — sum via prefix-match
-  (`key LIKE 'mentor-stage-b::%'`) over `byAttributionKey({sinceMs})`, OR add a thin
-  `byComponent('mentor-stage-b', {sinceMs})` helper. The spec ships the helper for clarity.
-  Hit the ceiling → defer with reason `budget-tokens`.
-- **Notify on trip — state-machine, not day-bucket (adversarial F6, lessons F5).** Per-
-  episode dedup is correct; per-day is wrong (a trip→recover→re-trip same day MUST re-alert
-  on the re-trip — that's exactly when Justin needs to know). State machine:
-  - Track `currentTripState ∈ {ok, tripped}` per `reason` (one of `quota-elevated`,
-    `quota-unknown`, `runs-exhausted`, `budget-tokens`, `delivery-failed`).
-  - **Alert on transition `ok → tripped`** (one Attention entry + one Telegram alert).
-  - **Alert on transition `tripped → ok`** (one "recovered" message — symmetry, so the user
-    knows we're back).
-  - Within state, suppress (no chatter on every tick).
-  - **Persistence: file-backed** at `state/mentor-budget-notifications.json` via
-    `SafeFsExecutor.atomicWriteJsonSync` so a mid-day server restart does NOT re-alert
-    (integration F4). In-memory alone re-spams. **Explicit shape** (R2 integration F-new-2):
-    ```json
-    { "<reason>": { "state": "ok|tripped", "lastTransitionTs": "ISO", "lastAlertTs": "ISO" } }
-    ```
-    **Single-writer / CAS (R2 adversarial-A):** all state-machine reads + transitions go
-    through a `CommitmentTracker.mutate()`-style CAS so two concurrent ticks observing
-    `tripped→ok` cannot double-fire the recovery alert. **Corrupt-state file on read**:
-    treat as `{}` (full re-alert next trip) AND emit `mentor.budget-state.corrupt`
-    degradation event — don't crash, don't silently lose all dedup.
-  - **Optional "still tripped after N hours" reminder** (default off, configurable via
-    `mentor.budgetReminderHours`) for long-running trips (e.g. quota stays elevated for 6h).
-
-## Design (one place to read)
-
-The runner gets three new service dependencies, all small + injectable for tests:
-- `getMenteeIdle(menteeFramework): Promise<boolean>` — async probe + fail-closed.
-- `quotaStandDown(menteeFramework): { allow: boolean; reason?: string }` — composes quota
-  + run-count + token-ceiling; returns the specific blocker.
-- `notifyBudgetTrip(reason, detail)` — fires the attention + Telegram alert (deduped).
-
-The tick changes:
-- Order is `canary → quota → idle → spawn → leak → forensics → capture → deliver` (idle
-  becomes a real async-resolved boolean, computed in `Runner.startTick` so the tick stays
-  pure).
-- `deps.budgetOk` is replaced by `deps.budget` returning `{ ok, reason }`; on `!ok` the tick
-  calls `deps.notifyBudgetTrip(reason)` exactly once (dedup is in the notifier, not the tick).
-- `reason: 'unsafe-window'` is renamed `reason: 'mentee-busy'` to match the actual signal.
-
-## Out of scope
-
-- A Codey **liveness** monitor beyond the per-probe fail-closed (separate concern).
-- Threadline-relay-based delivery (intentionally rejected — see [[bug_cross_agent_ack_spawn_loop]]).
-- Multi-mentee fan-out (one mentee for now).
-
-## Testing
-
-1. **Unit — idle signal:**
-   - `/idle` returns `{idle:true, uptimeSec: large}` → `getMenteeIdle = true` → tick
-     proceeds past the idle gate.
-   - `/idle` returns `{idle:false, ...}` → defers `mentee-busy`.
-   - `/idle` returns 200 with `idle:true` but `uptimeSec < minInterval` → defers
-     `mentee-busy` (liveness-warmup).
-   - **Fail-closed coverage:** non-2xx, network/timeout, JSON-parse failure, unknown
-     `schemaVersion`, missing required fields, AND a 200 with `idle:true` but missing
-     `bootId`/`uptimeSec` (schema drift) → ALL produce `getMenteeIdle = false`. No path can
-     silently flip to idle.
-   - Persistent failure (≥3 consecutive) emits a `DegradationReporter` event.
-2. **Unit — quota-budget:**
-   - quota `normal` + under run-count + under token-ceiling → `budget.ok = true`.
-   - quota `elevated` → `budget.ok = false, reason = 'quota-elevated'`.
-   - **quota state `null`/stale** → `budget.ok = false, reason = 'quota-unknown'`
-     (fail-closed, not the QuotaTracker default fail-open).
-   - run-count cap → `budget.ok = false, reason = 'runs-exhausted'`.
-   - token-ceiling hit (via prefix-match `mentor-stage-b::%`) → `budget.ok = false,
-     reason = 'tokens-exhausted'`.
-   - **State-machine notify:** `ok → tripped` fires one alert per reason; further `tripped`
-     ticks are suppressed; `tripped → ok` fires one recovered alert; `ok → tripped → ok →
-     tripped` same day fires THREE alerts (down, up, down) — proving day-bucket dedup is
-     replaced by trip-episode dedup. Persistence across simulated server restart.
-3. **Integration — delivery contract (Echo-side):**
-   - `deliverToMentee` writes a well-formed schemaVersion=1 JSONL line at
-     `{menteeStateDir}/mentor-outbox/codex-cli.jsonl`; the contract schema is exported as
-     `MentorPrompt`/`MentorReply` types + `MENTOR_CONTRACT_VERSION` constant; `GET
-     /mentor/contract` serves the schema.
-   - **Symlink at target path** → write refused, degradation event emitted.
-   - **`menteeStateDir` resolving to Echo's own stateDir** → server refuses to start.
-   - **`deliverToMentee` returns `{ok:false, reason}`** when the write fails (EACCES /
-     ENOSPC simulated via fs mock) → tick reports `delivered:false` + one Attention entry
-     (deduped by the same notifier primitive as the budget-trip).
-4. **Integration — bidirectional contract (the #425 gap-closer):**
-   - A test-fixture poller (simulating Codey's side) reads `{menteeStateDir}/mentor-
-     outbox/codex-cli.jsonl` using the **exported typed contract**, writes a `delivery.jsonl`
-     row then a `reply.jsonl` row, and Echo Stage-B parses both. Asserts: the round-trip
-     produces a `ForensicFinding`, and the next tick still defers (does NOT call
-     `deliverToMentee` or `spawnStageA` — proves the anti-loop is structural). This is the
-     test #425's "validate the artifact but never drive the full path end-to-end" gap.
-5. **Wiring-integrity — production deps are real:**
-   - When the runner is constructed from production wiring (not the test factory),
-     `getMenteeIdle` / `quotaStandDown` / `notifyBudgetTrip` are non-null, non-no-op, and
-     delegate to the real probe / `QuotaTracker` / Attention+Telegram path. Catches the
-     "shipped as null/no-op" failure mode.
-6. **Import-surface lint:**
-   - Static check: the mentor-delivery module's import set is a subset of `{fs, path,
-     mentor-contract-types}`. Build fails if `threadline_send`, `spawnSession`, or
-     `fetch`/`http` are introduced. Anti-loop rule 1 is now compile-time, not promise.
-7. **End-to-end — supervised live cycle (the actual test):**
-   - All three fixes shipped + Codey's pickup shipped; manually trigger one tick against
-     the real Codey with Justin watching; assert (a) `/idle` probe succeeds and returns
-     `idle:true`, (b) Echo writes the schemaVersion=1 prompt line, (c) Codey's poller
-     ingests + writes the delivery row (immediately) then the reply row (after the
-     assistant response), (d) Stage-B parses both + emits findings, (e) the next tick
-     defers (no auto-recurrence). Capture before/after token-ledger spend, attention-queue
-     state, and any degradation events.
+- **In:** `AgentTelegramComms` primitive (sender + recipient + marker + anti-loop infra +
+  audit ledgers + config), mentor as its first consumer (mentor-bot + Stage-A/Stage-B
+  rewiring + retire file-outbox), Fix 1 idle signal, Fix 3 quota-budget.
+- **Out:** HMAC-signed markers (v2 if cross-machine trust matters); multi-mentee fan-out;
+  Threadline-relay-based mentor delivery (intentionally rejected — Telegram is the test
+  substrate); a general "agent presence" service beyond the per-probe `/idle` (separate
+  concern).
 
 ## Migration parity
 
-- **Config (additive):** `ConfigDefaults.getMigrationDefaults()` adds `mentor.menteeServerUrl`,
-  `mentor.menteeStateDir`, `mentor.quotaCeiling`, `mentor.dailyTokenCeiling`,
-  `mentor.budgetReminderHours` with defaults — `applyDefaults` is existence-checked, only
-  fills missing fields (integration F5 confirms the right primitive).
-- **Config (removal) — NOT silent (lessons 4, adversarial F8).** `applyDefaults` is
-  additive-only and can't remove fields. Add an explicit `migrateConfig` step (modeled on
-  `migrateLegacyMaxSessions`, `PostUpdateMigrator.ts:~3961`) that:
-  1. If `mentor.dailySpendCapUsd` is present AND equals the historical default `0.5`, delete
-     it silently (no warning — they never changed it).
-  2. If it's present AND ≠ `0.5`, **emit one Attention-queue entry** explaining the field
-     was decorative ("your `mentor.dailySpendCapUsd: <value>` was never enforced because
-     Echo runs on a Claude subscription — there's no per-token dollar charge to cap. Your
-     new effective ceiling is `mentor.dailyTokenCeiling: 200000` tokens/day. Adjust if
-     needed."), then delete the field. Idempotent (re-run = no-op once the field is gone).
-  3. Repeating the original "silent dead config" bug at migration time is precisely the
-     learning-experience failure mode — surface it loudly.
-- **No agent-installed file changes** beyond config defaults — loader-only shadow-install
-  update for Echo's side; Codey's side is a separate PR in his repo (which adds his
-  `mentor-inbox-poll` job + the `/idle` endpoint).
-- **New route parity (R2 integration F-new-3).** The new `GET /mentor/contract` route
-  requires: (a) classification under the `mentor` prefix in `CapabilityIndex.ts` so the
-  capabilities-discoverability CI gate passes; (b) a one-line entry in the CLAUDE.md
-  template (`src/scaffold/templates.ts → generateClaudeMd()`) per the Agent Awareness
-  Standard so other agents know it exists; (c) a docs-coverage entry in `default-jobs.md`
-  is NOT needed (this isn't a job) — the route is documented in `reference/api.md` per the
-  existing pattern. Migration: route ships in the package; no per-agent migration needed.
+- **Config (additive):** `agentTelegram` section (new), `mentor.botToken`,
+  `mentor.menteeServerUrl`, `mentor.menteeBotId`, `mentor.menteeTopicId`,
+  `mentor.quotaCeiling`, `mentor.dailyTokenCeiling`, `mentor.budgetReminderHours` added
+  via `ConfigDefaults.getMigrationDefaults()` + `applyDefaults` (existence-checked).
+- **Config (removal — NOT silent).** `migrateConfig` deletes `mentor.dailySpendCapUsd`
+  (silent if default `0.5`); if non-default, emit ONE Attention entry explaining the
+  field was decorative (subscription, no per-token charge) and the replacement is
+  `mentor.dailyTokenCeiling`.
+- **Retire the file-outbox.** `migrateConfig` deletes `{stateDir}/mentor-outbox/*` on the
+  first run after this update lands (the legacy outbox is now dead state). Idempotent.
+  An Attention entry notes the cleanup if any files were present.
+- **Codey bot allowlist bootstrapping.** Echo-side: `mentor.botToken` is Secret-Drop-
+  collected during a `/mentor/bot-setup` one-time command (interactive, OOB-confirmed) —
+  never via chat paste. Codey-side: he adds Echo's mentor-bot ID to his
+  `agentTelegram.knownAgents` allowlist as part of his side's PR.
+- **Routes.** Two new routes (`GET /idle` on Codey's server; `POST /mentor/bot-setup` on
+  Echo). Both get CapabilityIndex prefix classification + CLAUDE.md template entry per
+  the Agent Awareness Standard.
 
-## Co-design with Codey
+## Testing
 
-**Round 1 (closed — Threadline thread 5cc61bd7, 2026-05-27).** All five co-design questions
-resolved by Codey (senior-grade input): option (a) scheduled poll job; stateDir-relative
-paths; schemaVersion=1 with stable `id`/`correlationId`; full reply schema with `status`
-enum + optional `error`; eight anti-loop constraints; plus the separate-delivery-vs-reply
-audit-row insight Stage-B uses to distinguish never-picked-up / picked-up-no-reply-yet /
-completed. Folded above (§Fix 2).
+1. **Unit — primitive marker parsing:** valid markers parse; malformed markers
+   (missing fields, wrong version, extra fields) reject; unknown sender → drop (not
+   route to user handler); spoofed `from` but wrong bot ID → drop + log.
+2. **Unit — anti-loop infra:**
+   - Role-handler import-surface lint: a module that registers as `mentor` handler MUST
+     NOT import `sendAgentMessage` with `role: 'mentor'` (only `mentor-reply`).
+   - Cycle-detection: two sends to the same recipient within 5s without `cycle-ok:true`
+     → refused + degradation event.
+   - Round-trip ledger: send + receive both write their audit rows; correlation chain
+     reconstructable.
+3. **Unit — Fix 1 idle:** as prior draft (fail-closed coverage on every ambiguous
+   outcome including 200+missing-fields; liveness-warmup; persistent-failure degradation).
+4. **Unit — Fix 3 budget:** as prior draft (trip-episode state machine, quota null
+   fail-closed, prefix-match summation, CAS persistence, corrupt-recovery).
+5. **Integration — Echo-side mentor consumer:** mock `TelegramAdapter` sends via
+   `sendAgentMessage`; assert marker formed correctly, audit written; simulate
+   `mentor-reply` received → Stage-B parser invoked; assert next tick still defers (no
+   recurrence). This closes the [[project_jobs_load_fix_layered]] test-gap pattern.
+6. **Wiring-integrity:** production wiring of `getMenteeIdle` / `budget` /
+   `sendAgentMessage` is non-null + non-no-op; arch-test on import surfaces.
+7. **End-to-end — supervised live cycle** (the actual test):
+   - Echo's mentor-bot active in a dedicated Mentor topic in Codey's setup.
+   - `/idle` probe succeeds → idle:true.
+   - Echo sends one tagged mentor message → Codey's recipient handler routes to mentor
+     handler → injects as user prompt → Codey replies via `sendAgentMessage(role=mentor-reply)`.
+   - Echo receives the reply → Stage-B emits findings.
+   - Next tick defers (no auto-recurrence). Capture token-ledger spend + ledger audit
+     trail + any degradation events.
 
-**Round 2 (open — convergence added two Codey-side requirements after round-1 review):**
+## Co-design with Codey (NEW round, recipient-side substrate is now Telegram)
 
-1. **Unauthenticated `GET /idle` endpoint on Codey's server.** Convergence found `/sessions`
-   is Bearer-authed (can't be cross-agent probed) and has no `activelyWorking` field — so
-   the spec's idle signal needs a dedicated endpoint Codey ships. Schema in §Fix 1.
-2. **Vendoring of `MENTOR_CONTRACT_VERSION` + typed schema** (Echo exports + serves at
-   `GET /mentor/contract`). Codey's poll job imports/asserts the version at startup.
+Round 1 (prior file-based design) is superseded by this redesign. New asks for Codey:
 
-Both are small but they're requirements on Codey's side that convergence imposed *after* his
-round-1 answers. They go to Codey for confirmation before this spec converges and ships.
+1. Add `agentTelegram.knownAgents` allowlist + `/idle` endpoint on his server.
+2. Implement the recipient-side `agentMessageHandler` for incoming Telegram messages with
+   the `[a2a:...]` marker — route `role=mentor` to a new mentor-message handler that
+   injects into his mentor-session as a user prompt; route `mentor-reply` to nothing on
+   his side (he's not the recipient of replies; Echo is).
+3. Implement `sendAgentMessage` on his side so his mentor-handler can write the `mentor-
+   reply` back to Echo's mentor bot.
+4. Confirm or adjust the marker schema (`[a2a:from=… to=… role=… id=… v=1]`).
+5. Confirm the anti-loop infra invariants (one outbound producer per role; cycle-
+   detection; audit ledgers).
+
+Sent to Codey on a fresh Threadline thread + view link after Justin's nod on this draft.
+
+## Honesty / lessons applied
+
+- Every claim about an existing surface cites the code I read (TelegramAdapter.onMessage
+  line 1327; sendToTopic widely used; QuotaTracker.canRunJob from prior verification;
+  TokenLedger.byAttributionKey/attribution_key shape from prior verification). The
+  substrate-vs-discipline error that bit this morning is recorded ([[feedback_report_
+  verified_not_intended_behavior]] applies + adjacent lesson on level-of-fix selection).
+- The convergence rounds on the file-based design caught everything that mattered about
+  that design EXCEPT whether the design's substrate was right — that's an instructive
+  limit of reviewer review (reviewers ask "is this sound?", not "is this framing
+  correct?"). Future specs must surface substrate choices explicitly so the framing is
+  reviewable, not assumed.

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -44,11 +44,19 @@ and the spec must surface the substrate choice explicitly, not bury it.
 
 ## The three live-readiness gaps (unchanged from prior draft)
 
-### Gap 1 — `isMenteeBusy()` is a stub that's not about the mentee at all
+### Gap 1 — The whole "is the mentee free?" gate is the wrong design (Justin correction)
 
-`AgentServer.ts:~651`: `isMenteeBusy: () => self.sessionManager.listRunningSessions().length > 0`.
-Tagged `<!-- tracked: topic-13435 -->`. Checks Echo's own sessions; almost always true →
-safe window never opens → mentor effectively never runs.
+`AgentServer.ts:~651`: `isMenteeBusy: () => self.sessionManager.listRunningSessions().length > 0`
+is a stub that always returns true so the mentor never runs. But the deeper issue (Justin,
+2026-05-27 topic 13435): **a user doesn't probe the agent's state before sending a
+Telegram message — they just send.** Whether Codey is mid-task is HIS concern, on his
+side. Replacing the stub with a real `/idle` probe (the prior draft's approach) violates
+the same user-fidelity principle as the file-outbox substrate error — both are "engineering
+convenience that no real user does." The fix is to **remove** the gate, not to make it
+"real." The actual cadence gates that ARE genuine user-behavior live on Echo's side:
+schedule (15-min tick), budget (token cap + quota), and **outstanding-prompt tracking**
+(don't send again before hearing back — that's how real users behave). See §Fix 2b
+"Implementation surface" item 4.
 
 ### Gap 2 — Mentor delivery to Codey does not exist as a real user-channel
 
@@ -64,32 +72,22 @@ config field; Echo runs on a Claude subscription (no per-token dollar charge to 
 real cost is tokens against rolling quota — already tracked by `QuotaTracker.canRunJob` +
 `TokenLedger` (`attribution.component='mentor-stage-b'`).
 
-## Fix 1 — Real Codey-idle signal (replaces the system-busy stub)
+## Fix 1 — REMOVED (Justin user-fidelity correction, 2026-05-27)
 
-Replace `isMenteeBusy` with a **mentee-specific** idle check via a new unauthenticated
-`GET /idle` endpoint Codey ships on his server (port 4044). `/sessions` is Bearer-authed
-AND has no `activelyWorking` field, so a fresh endpoint is needed.
+The prior draft proposed a `/idle` endpoint on Codey's server + Echo-side probe. **Removed
+entirely** per Justin: a real user doesn't probe agent state before sending a Telegram
+message. The mentor's gates are all Echo-side and match real user behavior:
+- **Schedule** (15-min tick) — cadence.
+- **Budget** (Stage-B token cap + quota-aware) — Echo's own quota pressure.
+- **Outstanding-prompt tracker** (don't send while a prior is unanswered within
+  `mentor.replyTimeoutMs`) — natural user behavior of not pestering before getting a reply.
+  Detailed in §Fix 2b "Implementation surface" item 4.
 
-`/idle` returns:
-```json
-{ "schemaVersion": 1, "idle": true, "bootId": "uuid-set-at-process-start",
-  "uptimeSec": 12345, "activeSessions": 0, "ts": "ISO-8601",
-  "reason": "active-session | startup-warmup | unknown (optional, diagnostic only)" }
-```
-**`activeSessions` semantics (Codey's clarification):** sessions with *live work* — active
-autonomous jobs, active Telegram-spawned sessions, running task sessions. Reaped/idle/
-complete panes do NOT count. **If the local signal is ambiguous, the mentee returns
-`idle:false`** rather than guessing or omitting fields. `reason` is optional and Echo
-must NOT depend on it for v1 behavior (it's diagnostic for degradation reports only).
-
-Echo-side:
-- Probe `{mentor.menteeServerUrl}/idle` with 750ms timeout.
-- **Fail-closed on every ambiguous outcome**: non-2xx, network/timeout, JSON-parse failure,
-  unrecognized schemaVersion, missing required fields, `idle !== true` → busy.
-- **Liveness-warmup**: `idle:true` but `uptimeSec < minIntervalMs/1000` → defer one cycle
-  (don't pile onto a recovering Codey).
-- Persistent failure (≥3 consecutive) → `DegradationReporter` event `mentor.menteeProbe`.
-- Reasons split: `mentee-busy` vs `min-interval-not-elapsed` (distinct strings).
+`isMenteeBusy` is **deleted**, not replaced. The previous `safeWindowOpen` branch in
+`MentorOnboardingTick` collapses to `budget.ok && !outstandingForThisMentee` — both
+real Echo-side concerns. Codey's side no longer ships the `/idle` endpoint; his side is
+relieved of that ask (he handles availability via his normal user-message processing,
+which is exactly what we're testing).
 
 ## Fix 2a — Agent-to-Agent Telegram Comms primitive (new infra)
 
@@ -370,19 +368,20 @@ need to land as part of this PR:
 
 - **In:** `AgentTelegramComms` primitive (sender + recipient + marker + anti-loop infra +
   audit ledgers + config), mentor as its first consumer (mentor-bot + Stage-A/Stage-B
-  rewiring + retire file-outbox), Fix 1 idle signal, Fix 3 quota-budget.
+  rewiring + retire file-outbox), Fix 3 quota-budget. (Fix 1 idle-probe REMOVED — Justin
+  user-fidelity correction; mentor cadence is Echo-side only.)
 - **Out:** HMAC-signed markers (v2 if cross-machine trust matters); multi-mentee fan-out;
   Threadline-relay-based mentor delivery (intentionally rejected — Telegram is the test
-  substrate); a general "agent presence" service beyond the per-probe `/idle` (separate
-  concern).
+  substrate); any mentee-state probing (intentionally rejected — users don't probe).
 
 ## Migration parity
 
 - **Config (additive):** `agentTelegram` section (new), `mentor.botToken`,
-  `mentor.menteeServerUrl`, `mentor.menteeBotId`, `mentor.menteeTopicId`,
-  `mentor.quotaCeiling`, `mentor.stageBTokenCeiling` (renamed from `dailyTokenCeiling`
-  per honest-scope downgrade), `mentor.budgetReminderHours`, `mentor.replyTimeoutMs`
-  added via `ConfigDefaults.getMigrationDefaults()` + `applyDefaults` (existence-checked).
+  `mentor.menteeBotId`, `mentor.menteeTopicId`, `mentor.quotaCeiling`,
+  `mentor.stageBTokenCeiling` (renamed from `dailyTokenCeiling` per honest-scope
+  downgrade), `mentor.budgetReminderHours`, `mentor.replyTimeoutMs` added via
+  `ConfigDefaults.getMigrationDefaults()` + `applyDefaults` (existence-checked).
+  (`mentor.menteeServerUrl` REMOVED — Fix 1 idle-probe deleted.)
 - **Config (removal — NOT silent, dedicated migration method).** `applyDefaults` is
   value-patching only and cannot remove fields (round-2 integration F5). Add a dedicated
   `migrateRetireDeadMentorConfig` method on `PostUpdateMigrator` (modeled on
@@ -402,15 +401,12 @@ need to land as part of this PR:
   (round-2 integration F4 correction: OOB-confirmed wasn't an existing pattern; Secret-
   Drop's confirmation is sufficient for a bot token). Codey-side: he adds Echo's
   mentor-bot ID to his `agentTelegram.knownAgents` allowlist as part of his side's PR.
-- **Routes.**
-  - `GET /idle` is on **Codey's** server (not Echo's), so Echo's CapabilityIndex doesn't
-    apply — that's Codey's repo concern.
-  - `POST /mentor/bot-setup` and `POST /mentor/bot-setup/rotate` are on Echo and
-    **inherit the existing `/mentor` prefix classification** in `CapabilityIndex.ts`
-    (verified line 493 — no CapabilityIndex change needed; round-2 integration F6
-    correction to the prior draft's claim). Echo adds a CLAUDE.md template entry per
-    the Agent Awareness Standard (curl example + proactive trigger: "when user says
-    'set up the mentor bot'").
+- **Routes.** `POST /mentor/bot-setup` and `POST /mentor/bot-setup/rotate` are on Echo
+  and **inherit the existing `/mentor` prefix classification** in `CapabilityIndex.ts`
+  (verified line 493 — no CapabilityIndex change needed; round-2 integration F6
+  correction to the prior draft's claim). Echo adds a CLAUDE.md template entry per
+  the Agent Awareness Standard (curl example + proactive trigger: "when user says
+  'set up the mentor bot'"). (`GET /idle` on Codey's server REMOVED.)
 
 ## Testing
 
@@ -437,9 +433,7 @@ need to land as part of this PR:
      conflict.
    - Round-trip ledger: send + receive both write their audit rows; correlation chain
      reconstructable via `corr`; NO tokens/secrets in the row.
-5. **Unit — Fix 1 idle:** as prior draft (fail-closed coverage on every ambiguous
-   outcome including 200+missing-fields; liveness-warmup; persistent-failure degradation).
-6. **Unit — Fix 3 budget:** as prior draft (trip-episode state machine, quota null
+5. **Unit — Fix 3 budget:** as prior draft (trip-episode state machine, quota null
    fail-closed, CAS persistence, corrupt-recovery). Add: assert the ceiling captures only
    `mentor-stage-b::%` (Stage-B); spawn a fake Stage-A JSONL event with
    `unknown::pre-attribution` and assert it does NOT count against the ceiling — the
@@ -468,16 +462,16 @@ need to land as part of this PR:
     sendAgentMessage write, runs the role-handler, writes a reply via
     `sendAgentMessage(role=mentor-reply)`, and Echo's Stage-B parser handles it. Real
     round-trip through the primitive on both sides.
-12. **Wiring-integrity:** production wiring of `getMenteeIdle` / `budget` /
-    `sendAgentMessage` / the agent-handler wrapper is non-null + non-no-op; dependency-
-    cruiser rule passes on the actual codebase.
+12. **Wiring-integrity:** production wiring of `budget` / `sendAgentMessage` / the
+    agent-handler wrapper is non-null + non-no-op; dependency-cruiser rule passes on the
+    actual codebase.
 13. **End-to-end — supervised live cycle** (the actual test):
     - Echo's mentor-bot active in a dedicated Mentor topic in Codey's setup.
-    - `/idle` probe succeeds → idle:true.
-    - Echo sends one tagged mentor message → Codey's recipient handler routes to mentor
-      handler → injects as user prompt → Codey replies via `sendAgentMessage(role=mentor-reply)`.
+    - Echo sends one tagged mentor message on schedule (no mentee-state probe) → Codey's
+      recipient handler routes to mentor handler → injects as user prompt → Codey replies
+      via `sendAgentMessage(role=mentor-reply)`.
     - Echo receives the reply → Stage-B emits findings.
-    - Next tick defers (no auto-recurrence) — outstanding-prompts check + idle gate.
+    - Next tick defers (no auto-recurrence) — outstanding-prompts check + budget gate.
     - Capture token-ledger spend (Stage-B attribution + Stage-A unknown::pre-attribution
       separately), ledger audit trail, any degradation events.
     - Assert no second Lifeline topic appears in the chat (multi-instance hygiene).
@@ -493,10 +487,14 @@ being tested") AND **verified his own live capability surface** before answering
 Telegram bidirectional, Threadline enabled, mentor endpoints present, `quotaTracking:false`
 on his instance — applying [[feedback_report_verified_not_intended_behavior]]).
 
-Codey's 5 substantive refinements (all folded above):
-1. **/idle** — add optional `reason` (diagnostic-only, Echo doesn't depend); sharpen
-   `activeSessions` semantics (live work only, not historical panes); ambiguous-signal →
-   `idle:false` rather than omit.
+**Round 3 (Justin user-fidelity correction, 2026-05-27): `/idle` WITHDRAWN.** The whole
+mentee-state-probe is removed (users don't probe before sending). Codey is relieved of the
+`/idle` endpoint ask. His remaining side: the recipient handler + `sendAgentMessage` + the
+`agentTelegram.knownAgents` allowlist. A short Threadline note will tell him `/idle` is off
+the table (good news — less for him to build).
+
+Codey's substantive refinements (all folded above; the /idle one is now moot):
+1. ~~**/idle**~~ — WITHDRAWN (Justin user-fidelity correction). The endpoint is not built.
 2. **Recipient handler** — strict malformed-marker drop (security event, NEVER fall
    through to user); explicit per-decision audit row; processed-id idempotency ledger
    against Telegram retries / adapter restarts.

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -68,27 +68,119 @@ own server:
 - The check is async; the runner pre-resolves it before assembling tick deps (the tick stays
   pure).
 
-### Fix 2 — Mentee-side outbox pickup (co-design with Codey)
+### Fix 2 — Mentee-side outbox pickup (Codey-designed, Threadline 5cc61bd7, 2026-05-27)
 
 Keep the outbox-write exactly as is (the spawn-loop-safe shape is correct). Add a
-**pull-based pickup** on Codey's side that turns each new outbox line into a user-prompt the
-running Codey session processes. Two concrete options to be co-designed with Codey (he's the
-authority on his ingestion):
+**pull-based pickup** on Codey's side. Codey picked **option (a) — a scheduled poll job** —
+explicitly because it survives restarts, session churn, and partial failures; correctness
+matters more than the latency cost of supervised live-loop turnaround (~30–60s acceptable).
 
-- **(a) Codey-side scheduled job (`mentor-inbox-poll`)** — runs every ~1min, reads
-  `{stateDir}/mentor-outbox/<framework>.jsonl` (or a shared path), advances a per-file
-  byte-offset cursor (idempotent), and for each new line injects the message via
-  `injectInternalMessage` into Codey's active mentee-collab session. Codey's reply is
-  appended to a **reply outbox** Echo's Stage-B reads.
-- **(b) Codey-side filesystem watcher in-process** (no job) — same shape, event-driven.
+**Pull mechanism (Codey's side, his code).** `mentor-inbox-poll` agentmd job, runs ~every
+minute. Reads append-only JSONL, keeps a **durable per-source byte-offset cursor**, processes
+only complete newline-terminated records, uses a lock file so overlapping invocations cannot
+double-deliver, and on injection delivers via the local server/session-injection surface
+(Codey-side abstraction — intentionally *not* bound in the contract to a specific function
+name, since the injection API is per-harness). On malformed-but-complete line → dead-letter
++ advance cursor; on incomplete trailing line → wait for next poll.
 
-(a) is conservative (matches the cron-job-everywhere pattern) and explicit; (b) is lower-
-latency but more state to manage. **Codey picks**, and ratifies the reply-path shape.
+**Paths (stateDir-relative on each side — IMPORTANT: `{codeyStateDir}` is *Codey's* state
+root, not Echo's, so Echo must write cross-agent into Codey's local state dir).**
 
-This fix has **two-sided code**: Echo writes (already correct) + Codey reads. Echo's side
-adds a documented contract (file path, line schema, reply file path) and a contract test.
-Codey's side ships the pickup. The spawn-loop guard remains structural: no Echo→Codey
-spawn-on-write, no Codey→Echo spawn-on-reply — both sides queue-and-pickup.
+| File | Owner | Purpose |
+|------|-------|---------|
+| `{codeyStateDir}/mentor-outbox/codex-cli.jsonl` | Echo writes / Codey reads | Inbound mentor prompts |
+| `{codeyStateDir}/mentor-outbox/.cursors/codex-cli.cursor.json` | Codey | Durable byte-offset cursor |
+| `{codeyStateDir}/mentor-outbox/codex-cli.deadletter.jsonl` | Codey | Malformed lines, audit |
+| `{codeyStateDir}/mentor-outbox/codex-cli.delivery.jsonl` | Codey writes / Echo Stage-B reads | Per-injection audit row (written immediately after successful inject, BEFORE the reply) |
+| `{codeyStateDir}/mentor-outbox/codex-cli.reply.jsonl` | Codey writes / Echo Stage-B reads | Per-prompt terminal outcome |
+
+Echo resolves `{codeyStateDir}` from a new config `mentor.menteeStateDir` (default
+`/Users/justin/Documents/Projects/instar-codey/.instar` for `codex-cli`). The contract stays
+stateDir-relative; the absolute-path resolution is the only machine-specific shim.
+
+**Audit pattern (Codey's preference, adopted).** The poller writes a **delivery row
+immediately after successful injection** + the **reply row only after the session produces
+the assistant response**. This lets Stage-B distinguish three states cleanly: *never picked
+up* (no delivery row for this id) / *picked up, no reply yet* (delivery row, no reply row) /
+*reply completed* (both rows). Stage-B matches on `correlationId` first, `requestId` second.
+
+**Line schema — inbound prompt (Echo → Codey).**
+```json
+{
+  "schemaVersion": 1,
+  "id": "uuid-or-stable-id",
+  "ts": "2026-05-27T18:25:18.831Z",
+  "kind": "mentor.live.prompt",
+  "from": { "agent": "echo", "role": "mentor" },
+  "to": { "agent": "instar-codey", "framework": "codex-cli" },
+  "threadId": "optional-mentor-thread-or-run-id",
+  "correlationId": "stable-id-stage-b-uses-to-match-reply",
+  "message": "prompt text",
+  "replyRequired": true,
+  "expiresAt": "optional-iso-ts (if absent, processed whenever seen)"
+}
+```
+- `id` is REQUIRED (idempotency anchor).
+- `correlationId` defaults to `id` if omitted; Stage-B matches it first.
+- Echo MAY emit top-level `framework` as a compatibility alias during rollout; the canonical
+  location is `to.framework`.
+- `message` is the only prompt-content field; metadata is routing/audit, never executable
+  instructions.
+- `attachments` field is reserved for future use; for now, prompt is a plain string.
+
+**Line schema — reply (Codey → Echo, terminal outcome).**
+```json
+{
+  "schemaVersion": 1,
+  "kind": "mentor.live.reply",
+  "id": "uuid-for-this-reply-row",
+  "requestId": "incoming-line-id",
+  "correlationId": "incoming-correlation-id-or-id",
+  "ts": "2026-05-27T18:26:05.000Z",
+  "from": { "agent": "instar-codey", "framework": "codex-cli" },
+  "to": { "agent": "echo", "role": "mentor" },
+  "status": "ok",
+  "message": "assistant reply text",
+  "session": {
+    "topicId": null,
+    "sessionId": "optional-local-session-id",
+    "delivery": "active-session"
+  },
+  "error": { "code": "no_active_session", "retryable": true }
+}
+```
+- `status ∈ {ok, error, ignored, expired}`.
+- `error` is present only for non-`ok` statuses; `message` remains user-safe.
+
+**Anti-loop contract (Codey-asserted, baked into the spec — both sides comply).**
+
+1. Echo writes files only. Codey reads files only for inbound mentor prompts. **No
+   Threadline send, no agent spawn, no HTTP callback as part of the live loop.**
+2. Codey replies by appending to the reply JSONL file only. Echo Stage-B reads that file;
+   Echo MUST NOT treat a reply as a trigger to write a new prompt unless a human/supervisor
+   explicitly starts a new mentor turn.
+3. Every incoming row needs a stable `id`; Codey maintains a processed-id ledger (cursor +
+   id check) so file rewrites, duplicate appends, and restarts do not re-inject.
+4. Optional `expiresAt` for prompts whose staleness is unsafe; absence = process whenever
+   seen.
+5. `replyRequired` may be false for one-way deliveries; for the live-loop test, set true.
+6. **Metadata is routing/audit only** — never prompt content. Only `message` is interpreted
+   as prompt.
+7. **One writer per file.** If multi-mentor lands later, one source file per writer (or
+   append-locking).
+8. Delivery + reply ledgers are append-only so Stage-B can reconstruct the run even on
+   mid-turn crash.
+
+**Echo-side responsibilities (this PR ships).** (i) Replace the per-tick `{ts,framework,message}`
+write with the schemaVersion=1 record above (with `id` + `correlationId`). (ii) Write to
+`{mentor.menteeStateDir}/mentor-outbox/codex-cli.jsonl` (cross-agent into Codey's state
+dir). (iii) Publish a typed-contract export Stage-B uses to parse reply.jsonl. (iv) Add a
+contract test that round-trips a written prompt + a hand-written reply through the parser.
+
+**Codey-side responsibilities (Codey ships, separately).** The `mentor-inbox-poll` job,
+cursor + lock + dead-letter, the local injection abstraction, the delivery + reply writers.
+Both halves must land before the supervised live test. Coordinated through this spec's
+shared contract.
 
 ### Fix 3 — Quota-aware budget + notification (replaces the dead dollar cap)
 

--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -54,19 +54,49 @@ notifies Justin when the cap (round or otherwise) trips.
 
 ### Fix 1 — Real Codey-idle signal (replaces the system-busy stub)
 
-Replace `isMenteeBusy` with a **mentee-specific** idle check that queries the mentee agent's
-own server:
+Replace `isMenteeBusy` with a **mentee-specific** idle check. Convergence (adversarial F1/F2,
+integration minor) revealed two blockers in the original draft:
 
-- Resolve mentee endpoint from a new `mentor.menteeServerUrl` config (defaults to
-  `http://localhost:4044` for `codex-cli`, the co-located Codey instance).
-- Probe `GET {menteeServerUrl}/sessions` (or a dedicated `/idle` endpoint if Codey adds one as
-  part of his side of the co-design) with a 500ms timeout.
-- Idle = no session with `activelyWorking=true` for that mentee. On probe failure (network,
-  timeout, 4xx/5xx), **fail-closed: treat as busy** — never run the mentor blindly when
-  Codey's state is unknown. Emit a degradation signal on persistent probe failure (so
-  unresolvable mentee-unreachable surfaces, doesn't hide).
+- `/sessions` is **Bearer-token-gated** (`middleware.ts:57`); a cross-agent probe without
+  auth always returns 401 → fail-closed → permanent silent deferral.
+- `SessionManager` session records have **no `activelyWorking` field** (grep returns 0 hits) —
+  only `status:'running'`. A 200 with empty array is ambiguous (truly idle vs. mentee server
+  crashed-and-restarted-clean), and a single-session-at-prompt-for-hours looks identical to
+  active work.
+
+**Required Codey-side addition:** a dedicated **unauthenticated** `GET /idle` endpoint Codey
+ships on his server. Returns a structured response Echo can trust:
+```json
+{
+  "schemaVersion": 1,
+  "idle": true,
+  "bootId": "uuid-set-at-process-start",
+  "uptimeSec": 12345,
+  "activeSessions": 0,
+  "ts": "ISO-8601"
+}
+```
+- `idle` = true iff Codey reports no sessions doing work right now.
+- `bootId` + `uptimeSec` let Echo detect mentee restart-since-last-probe (treat as busy for
+  one min-interval after a fresh boot, so we don't pile on a recovering Codey).
+- Unauthenticated because (i) it leaks no sensitive state, (ii) avoids the
+  cross-agent shared-Bearer-secret trust boundary.
+
+**Echo-side wiring:**
+- Resolve from `mentor.menteeServerUrl` (default `http://localhost:4044` for `codex-cli`).
+- `GET {menteeServerUrl}/idle` with a 750ms timeout.
+- **Fail-closed on every ambiguous outcome:** non-2xx, network/timeout, JSON-parse failure,
+  unrecognized schemaVersion, missing required fields, OR `idle !== true` → treat as
+  **busy** (never silently flip to idle).
+- **Liveness inferred from heartbeat, not 200-empty-array** — if `idle:true` but
+  `uptimeSec < minIntervalMs/1000`, defer one more cycle.
+- Persistent probe failure (≥3 consecutive) emits a `DegradationReporter` event with
+  feature `'mentor.menteeProbe'` — surfaces in `/degradation`, not silent.
 - The check is async; the runner pre-resolves it before assembling tick deps (the tick stays
   pure).
+- **Defer reasons are split** (per adversarial minor): `mentee-busy` (probe says busy /
+  failed / liveness-warmup) and `min-interval-not-elapsed` are distinct strings so debugging
+  doesn't collapse them.
 
 ### Fix 2 — Mentee-side outbox pickup (Codey-designed, Threadline 5cc61bd7, 2026-05-27)
 
@@ -182,19 +212,93 @@ cursor + lock + dead-letter, the local injection abstraction, the delivery + rep
 Both halves must land before the supervised live test. Coordinated through this spec's
 shared contract.
 
+#### Hardening (convergence round 1)
+
+**Cross-agent filesystem safety (adversarial F3, integration F1).** The current
+`deliverToMentee` uses raw `fs.mkdirSync` + `fs.appendFileSync` — no symlink check, no path
+canonicalization. Echo writes into *another agent's* state dir, so the attack/misconfig
+surface is real. New Echo-side requirements:
+
+1. **Symlink reject**: `lstat` the target path before each append; if it's a symlink, refuse
+   the write and emit `DegradationReporter` event `mentor.delivery.symlink-rejected`.
+2. **menteeStateDir allowlist**: validate `mentor.menteeStateDir` at startup — refuse if it
+   resolves to Echo's own `stateDir`, contains `..`, or doesn't look like an instar agent
+   home (no `.instar/config.json` at the root). Refuse-to-start with a loud error rather
+   than silently writing into the wrong place.
+3. **Append-only contract documented**: raw `appendFileSync` is correct for JSONL (atomic at
+   line granularity on POSIX for `<PIPE_BUF`); document why `SafeFsExecutor` is NOT used for
+   this path (its destructive-op guards don't apply to append) so a future reviewer doesn't
+   "fix" it incorrectly.
+
+**Delivery failure must surface (adversarial F4).** Current shape silently swallows EACCES /
+ENOSPC / EROFS → tick reports `delivered:true` even when nothing was written. Required:
+- `deliverToMentee` returns `{ ok: boolean; reason?: string }` (was void).
+- Tick's `delivered` boolean reflects the callback's `ok`.
+- On `!ok`, runner pushes ONE Attention entry deduped per (reason, day) using the same
+  primitive as the budget-trip notifier (Fix 3). Otherwise a permanently-broken Codey disk
+  burns the daily run budget silently.
+
+**Anti-loop made structural (lessons 1, adversarial F5).** The eight contract constraints
+are correct but currently behavioral promises. Make them compile-/test-time invariants:
+
+1. **Stage-B reply ingestion is finding-emission-only.** Define explicitly: when Stage-B
+   reads `reply.jsonl`, the only output path is `capture({findings})` — there is NO code
+   path from reply ingestion to `spawnStageA` or `deliverToMentee`. Implementation: Stage-B
+   reply parser returns `ForensicFinding[]`; the tick passes them only to `capture()`.
+2. **Unit test (the structural assertion):** "given a reply row landed, the next tick still
+   defers on `mentee-busy` / `min-interval-not-elapsed` and does NOT call `deliverToMentee`
+   or `spawnStageA`" — proves no implicit recurrence path exists.
+3. **Import-surface lint** for the mentor-delivery module: arch-test asserts the module's
+   imports are a subset of `{ fs, path, mentor-contract-types }` — no `threadline_send`, no
+   `spawnSession`, no `fetch`/`http`. Build fails on regression. Turns rule 1 of the
+   contract from promise into compile-time invariant.
+
+**Schema-version negotiation (adversarial F7, integration F6, lessons F6).** SchemaVersion=1
+ships today; bumps need a rule, not a Threadline round-trip every time.
+- Echo exports `MENTOR_CONTRACT_VERSION` (a constant + a typed `MentorPrompt` /
+  `MentorReply` schema) Codey imports/vendors with a pinned version.
+- Echo serves the schema at `GET /mentor/contract` (unauthenticated read-only — schema is
+  not sensitive) so Codey can fetch + assert at startup if vendoring isn't workable.
+- **Within v1**: additions are additive-only (new optional fields allowed; required
+  fields/renames forbidden).
+- **Breaking change → v2**: bumps land on the **reader-first** (Codey, who reads prompts AND
+  writes replies — gets v2 understanding first), then on Echo (writer). Older readers seeing
+  newer lines → dead-letter row with a `schema-version-too-new` reason (not crash, not
+  silent).
+- CI gate: a bump to `MENTOR_CONTRACT_VERSION` requires a corresponding entry in
+  `docs/specs/MENTOR-CONTRACT-CHANGELOG.md` — script lints this on PR.
+
 ### Fix 3 — Quota-aware budget + notification (replaces the dead dollar cap)
 
 - **Remove** `dailySpendCapUsd` from config defaults; replace with `mentor.quotaCeiling`
   (default: `elevated` — mentor stands down at elevated/critical/shutdown, runs only at
   normal). Wire `budgetOk` to `QuotaTracker.canRunJob('low')` (mentor is low-priority) AND
   the existing run-count backstop (`maxRoundsPerDay` stays — it's a real bound).
+- **Quota null/stale → fail-closed (integration F2).** `QuotaTracker.getState()` returns
+  null when the quota state file is missing or stale (>30 min), and `shouldSpawnSession`
+  fails-OPEN by default. For the mentor, override to **fail-closed**: null/stale ⇒
+  `budget.ok = false, reason = 'quota-unknown'`. Consistent with Fix 1's idle posture; we
+  don't burn quota blindly when we can't read it.
 - **Add a token-spend ceiling** (`mentor.dailyTokenCeiling`, default 200_000 tokens) summed
-  from `TokenLedger` with `attribution.component='mentor-stage-b'`. Hit the ceiling → defer
-  with reason `budget-tokens`.
-- **Notify on trip**: when `budgetOk` returns false (quota OR run-count OR token-ceiling),
-  push **one** entry to the Attention Queue (`POST /attention`) deduped per-day per-reason,
-  AND send a single Telegram alert to the system topic. No per-tick chatter — one alert when
-  the cap closes, one when it reopens.
+  from `TokenLedger`. **Integration F3 correction:** `TokenLedger.attribution_key` shape is
+  `<component>::<promptFingerprint>`, not bare `mentor-stage-b` — sum via prefix-match
+  (`key LIKE 'mentor-stage-b::%'`) over `byAttributionKey({sinceMs})`, OR add a thin
+  `byComponent('mentor-stage-b', {sinceMs})` helper. The spec ships the helper for clarity.
+  Hit the ceiling → defer with reason `budget-tokens`.
+- **Notify on trip — state-machine, not day-bucket (adversarial F6, lessons F5).** Per-
+  episode dedup is correct; per-day is wrong (a trip→recover→re-trip same day MUST re-alert
+  on the re-trip — that's exactly when Justin needs to know). State machine:
+  - Track `currentTripState ∈ {ok, tripped}` per `reason` (one of `quota-elevated`,
+    `quota-unknown`, `runs-exhausted`, `budget-tokens`, `delivery-failed`).
+  - **Alert on transition `ok → tripped`** (one Attention entry + one Telegram alert).
+  - **Alert on transition `tripped → ok`** (one "recovered" message — symmetry, so the user
+    knows we're back).
+  - Within state, suppress (no chatter on every tick).
+  - **Persistence: file-backed** at `state/mentor-budget-notifications.json` via
+    `SafeFsExecutor.atomicWriteJsonSync` so a mid-day server restart does NOT re-alert
+    (integration F4). In-memory alone re-spams.
+  - **Optional "still tripped after N hours" reminder** (default off, configurable via
+    `mentor.budgetReminderHours`) for long-running trips (e.g. quota stays elevated for 6h).
 
 ## Design (one place to read)
 
@@ -221,36 +325,101 @@ The tick changes:
 ## Testing
 
 1. **Unit — idle signal:**
-   - mentee at-rest → `getMenteeIdle = true` → tick proceeds past the idle gate.
-   - mentee `activelyWorking=true` → `getMenteeIdle = false` → tick defers `mentee-busy`.
-   - probe timeout / network error / non-2xx → fail-closed: `getMenteeIdle = false` (NEVER
-     true on unknown state); a degradation signal is emitted on persistent failure.
+   - `/idle` returns `{idle:true, uptimeSec: large}` → `getMenteeIdle = true` → tick
+     proceeds past the idle gate.
+   - `/idle` returns `{idle:false, ...}` → defers `mentee-busy`.
+   - `/idle` returns 200 with `idle:true` but `uptimeSec < minInterval` → defers
+     `mentee-busy` (liveness-warmup).
+   - **Fail-closed coverage:** non-2xx, network/timeout, JSON-parse failure, unknown
+     `schemaVersion`, missing required fields, AND a 200 with `idle:true` but missing
+     `bootId`/`uptimeSec` (schema drift) → ALL produce `getMenteeIdle = false`. No path can
+     silently flip to idle.
+   - Persistent failure (≥3 consecutive) emits a `DegradationReporter` event.
 2. **Unit — quota-budget:**
    - quota `normal` + under run-count + under token-ceiling → `budget.ok = true`.
    - quota `elevated` → `budget.ok = false, reason = 'quota-elevated'`.
+   - **quota state `null`/stale** → `budget.ok = false, reason = 'quota-unknown'`
+     (fail-closed, not the QuotaTracker default fail-open).
    - run-count cap → `budget.ok = false, reason = 'runs-exhausted'`.
-   - token-ceiling hit → `budget.ok = false, reason = 'tokens-exhausted'`.
-   - On trip, `notifyBudgetTrip` is called exactly once per (reason, day) — replays don't
-     re-notify.
+   - token-ceiling hit (via prefix-match `mentor-stage-b::%`) → `budget.ok = false,
+     reason = 'tokens-exhausted'`.
+   - **State-machine notify:** `ok → tripped` fires one alert per reason; further `tripped`
+     ticks are suppressed; `tripped → ok` fires one recovered alert; `ok → tripped → ok →
+     tripped` same day fires THREE alerts (down, up, down) — proving day-bucket dedup is
+     replaced by trip-episode dedup. Persistence across simulated server restart.
 3. **Integration — delivery contract (Echo-side):**
-   - `deliverToMentee` writes a well-formed JSONL line at the documented path; the contract
-     schema is published as a typed export the Codey-side pickup imports.
-4. **End-to-end — supervised live cycle (the actual test):**
-   - All three fixes shipped; manually trigger one tick against the real Codey with Justin
-     watching; assert Codey receives the message, replies, and Stage-B captures the reply.
-     Capture before/after token-ledger spend, attention-queue state, and any degradation
-     events.
+   - `deliverToMentee` writes a well-formed schemaVersion=1 JSONL line at
+     `{menteeStateDir}/mentor-outbox/codex-cli.jsonl`; the contract schema is exported as
+     `MentorPrompt`/`MentorReply` types + `MENTOR_CONTRACT_VERSION` constant; `GET
+     /mentor/contract` serves the schema.
+   - **Symlink at target path** → write refused, degradation event emitted.
+   - **`menteeStateDir` resolving to Echo's own stateDir** → server refuses to start.
+   - **`deliverToMentee` returns `{ok:false, reason}`** when the write fails (EACCES /
+     ENOSPC simulated via fs mock) → tick reports `delivered:false` + one Attention entry
+     (deduped by the same notifier primitive as the budget-trip).
+4. **Integration — bidirectional contract (the #425 gap-closer):**
+   - A test-fixture poller (simulating Codey's side) reads `{menteeStateDir}/mentor-
+     outbox/codex-cli.jsonl` using the **exported typed contract**, writes a `delivery.jsonl`
+     row then a `reply.jsonl` row, and Echo Stage-B parses both. Asserts: the round-trip
+     produces a `ForensicFinding`, and the next tick still defers (does NOT call
+     `deliverToMentee` or `spawnStageA` — proves the anti-loop is structural). This is the
+     test #425's "validate the artifact but never drive the full path end-to-end" gap.
+5. **Wiring-integrity — production deps are real:**
+   - When the runner is constructed from production wiring (not the test factory),
+     `getMenteeIdle` / `quotaStandDown` / `notifyBudgetTrip` are non-null, non-no-op, and
+     delegate to the real probe / `QuotaTracker` / Attention+Telegram path. Catches the
+     "shipped as null/no-op" failure mode.
+6. **Import-surface lint:**
+   - Static check: the mentor-delivery module's import set is a subset of `{fs, path,
+     mentor-contract-types}`. Build fails if `threadline_send`, `spawnSession`, or
+     `fetch`/`http` are introduced. Anti-loop rule 1 is now compile-time, not promise.
+7. **End-to-end — supervised live cycle (the actual test):**
+   - All three fixes shipped + Codey's pickup shipped; manually trigger one tick against
+     the real Codey with Justin watching; assert (a) `/idle` probe succeeds and returns
+     `idle:true`, (b) Echo writes the schemaVersion=1 prompt line, (c) Codey's poller
+     ingests + writes the delivery row (immediately) then the reply row (after the
+     assistant response), (d) Stage-B parses both + emits findings, (e) the next tick
+     defers (no auto-recurrence). Capture before/after token-ledger spend, attention-queue
+     state, and any degradation events.
 
 ## Migration parity
 
-- **Config:** `migrateConfig` removes `mentor.dailySpendCapUsd` (silent if absent) and adds
-  `mentor.menteeServerUrl`, `mentor.quotaCeiling`, `mentor.dailyTokenCeiling` with defaults
-  (existence-checked, only added when missing).
-- **No agent-installed file changes** beyond config defaults — loader-only shadow-install update.
+- **Config (additive):** `ConfigDefaults.getMigrationDefaults()` adds `mentor.menteeServerUrl`,
+  `mentor.menteeStateDir`, `mentor.quotaCeiling`, `mentor.dailyTokenCeiling`,
+  `mentor.budgetReminderHours` with defaults — `applyDefaults` is existence-checked, only
+  fills missing fields (integration F5 confirms the right primitive).
+- **Config (removal) — NOT silent (lessons 4, adversarial F8).** `applyDefaults` is
+  additive-only and can't remove fields. Add an explicit `migrateConfig` step (modeled on
+  `migrateLegacyMaxSessions`, `PostUpdateMigrator.ts:~3961`) that:
+  1. If `mentor.dailySpendCapUsd` is present AND equals the historical default `0.5`, delete
+     it silently (no warning — they never changed it).
+  2. If it's present AND ≠ `0.5`, **emit one Attention-queue entry** explaining the field
+     was decorative ("your `mentor.dailySpendCapUsd: <value>` was never enforced because
+     Echo runs on a Claude subscription — there's no per-token dollar charge to cap. Your
+     new effective ceiling is `mentor.dailyTokenCeiling: 200000` tokens/day. Adjust if
+     needed."), then delete the field. Idempotent (re-run = no-op once the field is gone).
+  3. Repeating the original "silent dead config" bug at migration time is precisely the
+     learning-experience failure mode — surface it loudly.
+- **No agent-installed file changes** beyond config defaults — loader-only shadow-install
+  update for Echo's side; Codey's side is a separate PR in his repo (which adds his
+  `mentor-inbox-poll` job + the `/idle` endpoint).
 
-## Co-design with Codey (open)
+## Co-design with Codey
 
-The Codey-side pickup design (option a vs b vs other), the reply-outbox shape, and any
-preferred contract details are explicitly open for Codey's input on a fresh Threadline thread
-(per the established short-msg + view-link pattern to avoid the command-too-long bug).
-Codey's response folds into a §Mentee-side pickup section before convergence.
+**Round 1 (closed — Threadline thread 5cc61bd7, 2026-05-27).** All five co-design questions
+resolved by Codey (senior-grade input): option (a) scheduled poll job; stateDir-relative
+paths; schemaVersion=1 with stable `id`/`correlationId`; full reply schema with `status`
+enum + optional `error`; eight anti-loop constraints; plus the separate-delivery-vs-reply
+audit-row insight Stage-B uses to distinguish never-picked-up / picked-up-no-reply-yet /
+completed. Folded above (§Fix 2).
+
+**Round 2 (open — convergence added two Codey-side requirements after round-1 review):**
+
+1. **Unauthenticated `GET /idle` endpoint on Codey's server.** Convergence found `/sessions`
+   is Bearer-authed (can't be cross-agent probed) and has no `activelyWorking` field — so
+   the spec's idle signal needs a dedicated endpoint Codey ships. Schema in §Fix 1.
+2. **Vendoring of `MENTOR_CONTRACT_VERSION` + typed schema** (Echo exports + serves at
+   `GET /mentor/contract`). Codey's poll job imports/asserts the version at startup.
+
+Both are small but they're requirements on Codey's side that convergence imposed *after* his
+round-1 answers. They go to Codey for confirmation before this spec converges and ships.

--- a/docs/specs/reports/mentor-live-readiness-convergence.md
+++ b/docs/specs/reports/mentor-live-readiness-convergence.md
@@ -1,0 +1,91 @@
+# Convergence Report — Mentor live-readiness
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md`
+**Iterations:** 2 rounds, 3 reviewers each round (lessons-aware, integration, adversarial)
+**Co-designer:** instar-codey (Threadline thread 5cc61bd7, §Fix 2 mentee-side pickup)
+**Outcome:** CONVERGED. Fix direction (real /idle endpoint + Codey-designed outbox pickup +
+quota-aware budget+notify) endorsed by all reviewers in both rounds.
+
+## Round 1 verdicts
+
+| Reviewer | Verdict | Headline |
+|----------|---------|----------|
+| Lessons-aware | APPROVE-WITH-CHANGES (6) | Anti-loop behavioral not structural; #425 test-gap not closed; budget dedup wrong shape |
+| Integration | APPROVE-WITH-CHANGES (6) | QuotaTracker null fail-open; TokenLedger attribution shape; SafeFs append guidance; migration removal step |
+| Adversarial | APPROVE-WITH-CHANGES (8) | `/sessions` Bearer-authed + no `activelyWorking` field → original probe unimplementable; cross-agent fs symlink/TOCTOU; delivery-failure silent; schema negotiation; dailySpendCapUsd silent removal |
+
+## Round 2 verdicts
+
+| Reviewer | Verdict | Notes |
+|----------|---------|-------|
+| Lessons-aware | CONVERGED | All 6 round-1 findings closed; no new lessons violations |
+| Integration | STILL-CHANGES → CONVERGED after 3 small additions | Echo-independence on /idle absence; budget-notifications JSON shape + concurrency; `GET /mentor/contract` capability/AAS parity |
+| Adversarial | STILL-CHANGES → CONVERGED after 2 small additions | State-machine concurrency (CAS + corrupt-file recovery); parent-symlink realpath defense |
+
+## Findings closed (round 1 + round 2)
+
+**Structural / anti-loop:**
+- Stage-B reply ingestion = `capture()`-only; explicit "no path to spawn/deliver" + unit test pinning it (lines 244-254, test #4 + 7).
+- Import-surface lint on mentor-delivery module (test #6) — anti-loop is now compile-time.
+- `GET /idle` unauthenticated + structured (schemaVersion/bootId/uptimeSec/activeSessions);
+  fail-closed on every ambiguous outcome; liveness inferred from heartbeat.
+- Cross-agent fs writes: lstat-reject symlinks + realpathSync parent check (TOCTOU/
+  parent-symlink defense); menteeStateDir allowlist refuses misconfig (refuse-to-start).
+- `deliverToMentee` returns `{ok,reason}`; on failure tick reports `delivered:false` +
+  dedup'd Attention entry.
+
+**Budget:**
+- Trip-EPISODE state machine (not day-bucket); alerts on `ok→tripped` AND `tripped→ok`.
+- File-backed persistence at `state/mentor-budget-notifications.json` via
+  `SafeFsExecutor.atomicWriteJsonSync` — survives server restart.
+- Explicit JSON shape + CAS single-writer + corrupt-file recovery (degradation event).
+- QuotaTracker null/stale → fail-closed (`reason: quota-unknown`), overriding the default
+  fail-open.
+- TokenLedger sum via prefix-match `mentor-stage-b::%` (attribution_key shape correction)
+  via thin `byComponent` helper.
+
+**Schema versioning:**
+- `MENTOR_CONTRACT_VERSION` export + `GET /mentor/contract` (unauthenticated).
+- Reader-first rule for breaking bumps; CI changelog gate.
+- Both sides dead-letter unknown schemaVersion (not crash, not silent).
+
+**Migration:**
+- `dailySpendCapUsd` removal is NOT silent if user set a non-default value — emit one
+  Attention entry explaining it was decorative (don't repeat the silent-dead-config bug).
+- Additive new fields via `ConfigDefaults.getMigrationDefaults()` + `applyDefaults`.
+- Explicit removal step modeled on `migrateLegacyMaxSessions`.
+
+**Coordination:**
+- Echo's side ships independently of Codey's PR; absent `/idle` → continuous `mentee-busy`
+  defers + degradation event (NOT refuse-to-start). Graduated-rollout pattern.
+- `GET /mentor/contract` route gets CapabilityIndex prefix classification + CLAUDE.md
+  template entry (Agent Awareness Standard).
+
+**Testing — the #425 gap is closed:**
+- Bidirectional integration test: fixture poller writes delivery + reply, Echo Stage-B
+  parses; asserts next tick still defers (no auto-recurrence).
+- Wiring-integrity test: production deps non-null, non-no-op.
+- Import-surface lint.
+- Fail-closed coverage on every ambiguous probe outcome.
+- E2E supervised live cycle is the final test (gated on both sides shipped).
+
+## Standards conformance
+
+- Testing Integrity: 7 tests across 3 tiers + lint + wiring + the gap-closer. ✓
+- Structure > Willpower: anti-loop made compile-time (lint + ingestion-path-by-construction);
+  cross-agent writes guarded structurally (refuse-to-start + symlink reject). ✓
+- Signal vs authority: idle/budget gates own blocking authority; tick stays pure. ✓
+- Near-silent: state-machine dedup + recovery alert + optional long-trip reminder. ✓
+- Migration parity: additive + explicit removal step + non-silent on non-default. ✓
+- Bug-fix evidence bar: E2E live test required before declaring "fixed." ✓
+- Co-design discipline: §Fix 2 designed by Codey on Threadline; round-2 additions explicitly
+  flagged as new asks to Codey before final approval. ✓
+
+## Co-design status
+
+- Round 1 (closed): Codey resolved all 5 questions on Threadline thread 5cc61bd7
+  (poll-job + cursor + lock + dead-letter, schemaVersion=1 with id/correlationId, full reply
+  schema, 8 anti-loop constraints, two-row audit pattern).
+- Round 2 (open): convergence added two Codey-side requirements after round-1:
+  unauthenticated `GET /idle` endpoint, and vendoring `MENTOR_CONTRACT_VERSION`. Both go to
+  Codey for confirmation before this spec ships.

--- a/docs/specs/reports/mentor-live-readiness-convergence.md
+++ b/docs/specs/reports/mentor-live-readiness-convergence.md
@@ -89,3 +89,65 @@ quota-aware budget+notify) endorsed by all reviewers in both rounds.
 - Round 2 (open): convergence added two Codey-side requirements after round-1:
   unauthenticated `GET /idle` endpoint, and vendoring `MENTOR_CONTRACT_VERSION`. Both go to
   Codey for confirmation before this spec ships.
+
+---
+
+## Convergence on Telegram-substrate design (2026-05-27, AFTER Justin substrate correction)
+
+The prior two rounds (above) hardened a file-based mentor-outbox design that Justin
+(topic 13435) caught as solving the wrong problem (substrate vs discipline). Spec
+re-architected onto Telegram-substrate + an agent-to-agent comms primitive. ONE NEW
+convergence round on the Telegram substrate; all reviewers APPROVE-WITH-CHANGES with
+substantial implementation-surface findings (the substrate change exposed real
+TelegramAdapter limits).
+
+### Telegram-substrate round verdicts
+
+| Reviewer | Verdict | BLOCKING findings |
+|----------|---------|---|
+| Lessons-aware | APPROVE-WITH-CHANGES | `TelegramAdapter.onMessage` is single-handler setter, not chain — spec's "agent-handler runs BEFORE user routing" unimplementable as-stated |
+| Integration | APPROVE-WITH-CHANGES (3 BLOCKING) | (F1) Multi-instance TelegramAdapter state-file collision; (F2) handler-chain primitive; (F3) Stage-A is unattributed in TokenLedger — Stage-B-only honest scope |
+| Adversarial | APPROVE-WITH-CHANGES (5 BLOCKING) | (F1) User-typed marker spoofing; (F3) `corr` collapse on absence; (F4) lint depth unspecified; (F6) per-source role acceptance; (F8) tick-while-in-flight rebuilds ping-pong |
+
+### Closures (all BLOCKING findings folded)
+
+- **Handler chain**: wrap at registration site in `src/commands/server.ts:~3038` — agent-
+  handler first, fall through to user-routing on `handled:false`. Wiring-integrity test.
+- **Multi-instance state isolation**: new constructor `subDir?: string` param namespaces
+  every state file under `{stateDir}/agent-telegram/<botName>/`; `suppressLifelineAutoCreate?`
+  guards `ensureLifelineTopic()`. Primary bot unchanged.
+- **Stage-A honest scope**: renamed `dailyTokenCeiling` → `stageBTokenCeiling`; documents
+  the unknown::pre-attribution gap; follow-up tracked for Stage-A attribution-resolver.
+- **User-spoof defense**: spec extends Message type to expose `from.is_bot` + `sender_chat`;
+  allowlist key is `sender_chat.id` OR (`from.id` AND `from.is_bot===true`); marker-bearing
+  message from a human user → DROP `agent-marker-spoofed-by-user`.
+- **`corr` required in parser**: cycle-detection key cannot collapse; prompts self-correlate
+  (`corr=id`).
+- **Capability-handle for reply-ingestion**: reply-ingestion module receives only
+  `{capture}` handle — structurally cannot reach spawnStageA/deliverToMentee/scheduler/
+  Threadline. Dependency-cruiser lint as backup. Stronger than transitive-import lint.
+- **Per-source role-acceptance**: `{fromAgent → allowed-incoming-roles[]}`, not flat.
+  Compromised mentee sending `notify`/`coord` → DROP.
+- **Outstanding-prompt tick refusal**: `outstandingPrompts: Map<corr, {sentAt, mentee}>`;
+  tick refuses while a prompt is in-flight within `mentor.replyTimeoutMs` (default 20min);
+  expiry → `mentor.reply-orphaned` degradation + Attention. Solves both the rebuilt
+  ping-pong AND silent-reply-loss observability in one primitive.
+
+### Other tightenings
+
+- Marker `ts=<unix-ms>` + `a2a.skewWindowMs` (default 24h) → replay defense without HMAC.
+- Token-leak scrub in `sendAgentMessage` error paths; rotation flow.
+- Migration: dedicated methods (`migrateRetireDeadMentorConfig`, `migrateRetireMentorOutbox`)
+  via SafeFsExecutor with `_instar_migrations` markers (no existing migration does fs-cleanup
+  — pattern-fit correction).
+- Secret-Drop's existing one-time-URL + Telegram confirmation suffices for `mentor.botToken`;
+  "OOB-confirmed" was not an existing pattern — dropped (correction).
+- CapabilityIndex already classifies `/mentor` prefix — `POST /mentor/bot-setup` inherits;
+  Echo only needs CLAUDE.md template entry (correction to prior draft).
+- Line number citation fix: `TelegramAdapter.onMessage` is line 1592, not 1327 (caught
+  by lessons reviewer — applies today's verify-before-claiming lesson).
+
+### Status
+
+CONVERGED on Telegram substrate. All BLOCKING findings folded; spec is approval-ready
+pending Justin's nod.

--- a/src/messaging/AgentTelegramComms.ts
+++ b/src/messaging/AgentTelegramComms.ts
@@ -1,0 +1,289 @@
+/**
+ * AgentTelegramComms — agent-to-agent Telegram comms primitive.
+ *
+ * Spec: docs/specs/MENTOR-LIVE-READINESS-SPEC.md §Fix 2a (approved 2026-05-27).
+ *
+ * A robust, recipient-knows-it's-from-an-agent channel any agent can use to message
+ * another agent's bot over Telegram, with the indicator AND the anti-loop machinery as
+ * first-class infra. Justin's framing: "robust infra that indicates the message is from
+ * another agent… leverage infra to prevent the ping pong trap." The mentor is its first
+ * consumer (see MentorOnboarding*), but nothing here is mentor-specific.
+ *
+ * Every message carries a VISIBLE marker prefix in the body so (a) humans can audit at a
+ * glance and (b) the Telegram chat history alone reconstructs a round-trip when ledgers
+ * are unavailable:
+ *
+ *   [a2a:from=<sender> to=<recipient> role=<role> id=<id> corr=<corr> ts=<unix-ms> v=1]
+ *
+ *   <body>
+ *
+ * This file is the PURE logic (marker parse/format + routing decision + cycle-detection
+ * key). I/O (the actual Telegram send + the audit ledgers + the processed-id store) is
+ * injected so every branch is unit-testable. See §Fix 2a for the routing matrix and the
+ * anti-loop invariants this enforces.
+ */
+
+/** Current marker schema version. Bumps are explicit (reader-first rule — see spec). */
+export const A2A_VERSION = 1;
+
+/** Marker field-value charset (spec: deterministic parsing, avoids invisible/escaping
+ *  cases). Agent/role/id/corr match this; ts and v are positive integers. */
+const TOKEN = '[A-Za-z0-9._:-]+';
+
+/**
+ * Strict marker regex — anchored to the start, consumes exactly the first line plus the
+ * required blank-line separator, then captures the body. Field ORDER is fixed (so the
+ * parse is deterministic and a reordered/extra-field marker is "malformed", not silently
+ * accepted). All of from/to/role/id/corr/ts/v are REQUIRED (corr + ts required per
+ * round-2/3 convergence — missing corr would collapse the cycle-detection key; missing ts
+ * disables replay-window defense).
+ */
+const MARKER_RE = new RegExp(
+  `^\\[a2a:from=(${TOKEN}) to=(${TOKEN}) role=(${TOKEN}) id=(${TOKEN}) corr=(${TOKEN}) ts=([0-9]+) v=([0-9]+)\\]\\n\\n([\\s\\S]*)$`,
+);
+
+/** A marker-shaped first line WITHOUT the strict full match — used only to distinguish
+ *  "not an agent message at all" (fall through to user handling) from "looks like one but
+ *  is malformed" (drop as a security event, NEVER fall through). */
+const MARKER_PREFIX_RE = /^\[a2a:/;
+
+export interface A2aMarker {
+  from: string;
+  to: string;
+  role: string;
+  id: string;
+  corr: string;
+  ts: number;
+  v: number;
+}
+
+export interface A2aMessage extends A2aMarker {
+  body: string;
+}
+
+export interface A2aSendFields {
+  from: string;
+  to: string;
+  role: string;
+  /** Stable id; minted by the caller/sender if absent. */
+  id: string;
+  /** Correlation id. Prompts self-correlate (corr === id); replies carry the prompt's id. */
+  corr: string;
+  ts: number;
+}
+
+/**
+ * Result of parsing an inbound Telegram message body for an a2a marker.
+ * - `no-marker`: not an agent message → caller falls through to normal user handling.
+ * - `malformed`: marker-shaped but invalid → caller DROPS (security event), never falls
+ *   through to user handling (spoof / broken-sender defense).
+ */
+export type ParseResult =
+  | { ok: true; msg: A2aMessage }
+  | { ok: false; kind: 'no-marker' }
+  | { ok: false; kind: 'malformed'; detail: string };
+
+/** Format a marker + body for sending. The inverse of {@link parseMarker}. */
+export function formatMarker(fields: A2aSendFields, body: string): string {
+  for (const [k, v] of Object.entries({
+    from: fields.from,
+    to: fields.to,
+    role: fields.role,
+    id: fields.id,
+    corr: fields.corr,
+  })) {
+    if (!new RegExp(`^${TOKEN}$`).test(String(v))) {
+      throw new Error(`AgentTelegramComms.formatMarker: field "${k}" value "${v}" violates the a2a charset ${TOKEN}`);
+    }
+  }
+  if (!Number.isInteger(fields.ts) || fields.ts <= 0) {
+    throw new Error(`AgentTelegramComms.formatMarker: ts must be a positive integer, got ${fields.ts}`);
+  }
+  return (
+    `[a2a:from=${fields.from} to=${fields.to} role=${fields.role} id=${fields.id} ` +
+    `corr=${fields.corr} ts=${fields.ts} v=${A2A_VERSION}]\n\n${body}`
+  );
+}
+
+/** Parse an inbound message body. Strict — see {@link ParseResult}. */
+export function parseMarker(raw: string): ParseResult {
+  if (typeof raw !== 'string' || !MARKER_PREFIX_RE.test(raw)) {
+    return { ok: false, kind: 'no-marker' };
+  }
+  const m = MARKER_RE.exec(raw);
+  if (!m) {
+    return { ok: false, kind: 'malformed', detail: 'marker prefix present but failed strict parse' };
+  }
+  const [, from, to, role, id, corr, tsStr, vStr, body] = m;
+  const ts = Number(tsStr);
+  const v = Number(vStr);
+  if (!Number.isInteger(ts) || ts <= 0) {
+    return { ok: false, kind: 'malformed', detail: `invalid ts "${tsStr}"` };
+  }
+  if (!Number.isInteger(v) || v <= 0) {
+    return { ok: false, kind: 'malformed', detail: `invalid v "${vStr}"` };
+  }
+  return { ok: true, msg: { from, to, role, id, corr, ts, v, body } };
+}
+
+/** Per-recipient routing configuration (spec §Fix 2a recipient + anti-loop). */
+export interface RecipientConfig {
+  /** This agent's own name (the `to` an inbound message must target). */
+  localAgent: string;
+  /** Known agents → their Telegram bot identity. Only senders here are trusted. */
+  knownAgents: Record<string, { botId: string }>;
+  /**
+   * Per-source role acceptance (round-2 adversarial F6): `{ fromAgent: allowedRoles[] }`.
+   * A compromised/buggy known agent sending an unexpected role is dropped, even if that
+   * role is accepted from a DIFFERENT source. Scoped admission.
+   */
+  acceptRoles: Record<string, string[]>;
+  /** Replay window: reject markers whose ts is outside ±this from now. Default 24h. */
+  skewWindowMs: number;
+  /** Highest marker version this recipient understands. Newer → dead-letter, not crash. */
+  maxVersion: number;
+}
+
+/**
+ * Inbound message context the caller resolves from the Telegram update. The bot-identity
+ * fields are the SPOOF DEFENSE: a human user typing a marker-shaped string has
+ * `senderIsBot === false` and no `senderChatId` → dropped (round-2 adversarial F1).
+ */
+export interface IncomingContext {
+  /** The raw message body (marker + body, or arbitrary user text). */
+  raw: string;
+  /** `from.is_bot` from the Telegram update. */
+  senderIsBot: boolean;
+  /** `sender_chat.id` from the Telegram update when present (group bot-as-channel relay).
+   *  Its mere presence is part of the spoof defense (a human user has none). */
+  senderChatId?: string;
+  /** The effective sender bot identity = `sender_chat.id ?? from.id`. Matched against the
+   *  allowlist's `botId`. The caller resolves this from the Telegram update. */
+  senderBotId?: string;
+  /** Wall-clock now (ms) — injected for testability. */
+  now: number;
+}
+
+export type RouteDropReason =
+  | 'agent-marker-malformed'
+  | 'agent-marker-stale-or-future'
+  | 'agent-marker-spoofed-by-user'
+  | 'agent-marker-wrong-recipient'
+  | 'agent-marker-unsupported-version'
+  | 'agent-marker-unknown'
+  | 'agent-marker-duplicate'
+  | 'agent-marker-role-not-allowed-from-source'
+  | 'agent-marker-unexpected-role'
+  | 'agent-marker-unknown-role';
+
+export type RouteDecision =
+  | { action: 'fall-through' }
+  | { action: 'route'; msg: A2aMessage }
+  | { action: 'drop'; reason: RouteDropReason; detail?: string; msg?: A2aMessage };
+
+/**
+ * The recipient routing matrix (spec §Fix 2a "Routing matrix"). PURE — every branch is a
+ * decision the caller then acts on (route to a role-handler, or drop + write an audit
+ * row). `knownRole` tells whether the role is one this recipient has a handler for at all;
+ * `isProcessed` is the idempotency check against the processed-id store.
+ */
+export function decideRoute(
+  ctx: IncomingContext,
+  cfg: RecipientConfig,
+  deps: { isProcessed: (id: string) => boolean; knownRole: (role: string) => boolean },
+): RouteDecision {
+  const parsed = parseMarker(ctx.raw);
+  if (!parsed.ok && parsed.kind === 'no-marker') return { action: 'fall-through' };
+  if (!parsed.ok) return { action: 'drop', reason: 'agent-marker-malformed', detail: parsed.detail };
+
+  const msg = parsed.msg;
+
+  // Replay / clock-skew window (round-2 adversarial F2).
+  if (Math.abs(ctx.now - msg.ts) > cfg.skewWindowMs) {
+    return { action: 'drop', reason: 'agent-marker-stale-or-future', msg };
+  }
+
+  // Unsupported version → dead-letter, never crash (reader-first rule).
+  if (msg.v > cfg.maxVersion) {
+    return { action: 'drop', reason: 'agent-marker-unsupported-version', msg };
+  }
+
+  // SPOOF DEFENSE (round-2 adversarial F1): a real user typing a marker-shaped string is
+  // not a bot and has no sender_chat. Drop before any allowlist/role check — a human-typed
+  // marker must NEVER reach a role-handler, even if from/id happen to match.
+  if (!ctx.senderIsBot && ctx.senderChatId === undefined) {
+    return { action: 'drop', reason: 'agent-marker-spoofed-by-user', msg };
+  }
+
+  // Recipient targeting.
+  if (msg.to !== cfg.localAgent) {
+    return { action: 'drop', reason: 'agent-marker-wrong-recipient', msg };
+  }
+
+  // Sender allowlist + bot-identity match.
+  const known = cfg.knownAgents[msg.from];
+  if (!known || (ctx.senderBotId !== undefined && known.botId !== ctx.senderBotId)) {
+    return { action: 'drop', reason: 'agent-marker-unknown', msg };
+  }
+
+  // Idempotency (round-2 adversarial: Telegram retry / adapter restart).
+  if (deps.isProcessed(msg.id)) {
+    return { action: 'drop', reason: 'agent-marker-duplicate', msg };
+  }
+
+  // Per-source role acceptance (round-2 adversarial F6): scoped admission.
+  const allowedFromSource = cfg.acceptRoles[msg.from] ?? [];
+  if (!allowedFromSource.includes(msg.role)) {
+    // Distinguish "this recipient has no handler for the role at all" from "the role
+    // exists but isn't allowed from THIS source" — both drop, different audit codes.
+    if (!deps.knownRole(msg.role)) {
+      return { action: 'drop', reason: 'agent-marker-unknown-role', msg };
+    }
+    return { action: 'drop', reason: 'agent-marker-role-not-allowed-from-source', msg };
+  }
+
+  return { action: 'route', msg };
+}
+
+/**
+ * Cycle-detection key (spec §Fix 2a anti-loop #3): keyed on the full tuple so legitimate
+ * unrelated traffic never collides. `corr` is always present (required in the marker), so
+ * the key cannot collapse to `undefined`.
+ */
+export function cycleKey(fields: {
+  fromBotId: string;
+  toBotId: string;
+  topicId: number | string;
+  role: string;
+  corr: string;
+}): string {
+  return `${fields.fromBotId}|${fields.toBotId}|${fields.topicId}|${fields.role}|${fields.corr}`;
+}
+
+/**
+ * In-memory cycle detector. A send is refused (unless `cycleOk`) when the same key was
+ * seen within `windowMs` — the structural guard against tight role↔reply ping-pong.
+ */
+export class CycleDetector {
+  private readonly recent = new Map<string, number>();
+  constructor(private readonly windowMs: number) {}
+
+  /** Returns true if sending this key now would trip cycle-detection. */
+  wouldTrip(key: string, now: number): boolean {
+    this.evict(now);
+    const last = this.recent.get(key);
+    return last !== undefined && now - last < this.windowMs;
+  }
+
+  /** Record a send/receive of this key at `now`. */
+  mark(key: string, now: number): void {
+    this.recent.set(key, now);
+    this.evict(now);
+  }
+
+  private evict(now: number): void {
+    for (const [k, t] of this.recent) {
+      if (now - t >= this.windowMs) this.recent.delete(k);
+    }
+  }
+}

--- a/tests/unit/messaging/AgentTelegramComms.test.ts
+++ b/tests/unit/messaging/AgentTelegramComms.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the AgentTelegramComms primitive.
+ * Spec: docs/specs/MENTOR-LIVE-READINESS-SPEC.md §Fix 2a + §Testing 1-4.
+ *
+ * Covers the security-critical pure logic: strict marker parse/format, the full routing
+ * matrix (every drop branch, incl. the user-spoof defense + per-source role acceptance),
+ * and cycle-detection. These are the assertions that make the anti-loop + spoof defenses
+ * real rather than aspirational.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  A2A_VERSION,
+  parseMarker,
+  formatMarker,
+  decideRoute,
+  cycleKey,
+  CycleDetector,
+  type RecipientConfig,
+  type IncomingContext,
+} from '../../../src/messaging/AgentTelegramComms.js';
+
+const NOW = 1_779_900_000_000;
+
+function marker(overrides: Partial<Record<string, string | number>> = {}): string {
+  const f = {
+    from: 'echo',
+    to: 'instar-codey',
+    role: 'mentor',
+    id: 'id-abc',
+    corr: 'id-abc',
+    ts: NOW,
+    ...overrides,
+  };
+  return `[a2a:from=${f.from} to=${f.to} role=${f.role} id=${f.id} corr=${f.corr} ts=${f.ts} v=${A2A_VERSION}]\n\nhello codey`;
+}
+
+const cfg: RecipientConfig = {
+  localAgent: 'instar-codey',
+  knownAgents: { echo: { botId: 'echo-mentor-bot' } },
+  acceptRoles: { echo: ['mentor'] },
+  skewWindowMs: 24 * 60 * 60 * 1000,
+  maxVersion: A2A_VERSION,
+};
+
+function ctx(raw: string, over: Partial<IncomingContext> = {}): IncomingContext {
+  return {
+    raw,
+    senderIsBot: true,
+    senderBotId: 'echo-mentor-bot',
+    now: NOW,
+    ...over,
+  };
+}
+
+const deps = (over: Partial<{ processed: Set<string>; roles: Set<string> }> = {}) => ({
+  isProcessed: (id: string) => (over.processed ?? new Set<string>()).has(id),
+  knownRole: (r: string) => (over.roles ?? new Set(['mentor', 'mentor-reply'])).has(r),
+});
+
+describe('AgentTelegramComms — marker parse/format', () => {
+  it('parses a well-formed marker + body', () => {
+    const r = parseMarker(marker());
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.msg).toMatchObject({ from: 'echo', to: 'instar-codey', role: 'mentor', id: 'id-abc', corr: 'id-abc', ts: NOW, v: A2A_VERSION });
+      expect(r.msg.body).toBe('hello codey');
+    }
+  });
+
+  it('returns no-marker for ordinary user text (fall through)', () => {
+    const r = parseMarker('hey echo, can you help with X?');
+    expect(r).toEqual({ ok: false, kind: 'no-marker' });
+  });
+
+  it('returns malformed (NOT no-marker) for marker-prefixed-but-broken — drop, never fall through', () => {
+    // Missing corr.
+    const noCorr = `[a2a:from=echo to=instar-codey role=mentor id=x ts=${NOW} v=1]\n\nbody`;
+    expect(parseMarker(noCorr)).toMatchObject({ ok: false, kind: 'malformed' });
+    // Missing ts.
+    const noTs = `[a2a:from=echo to=instar-codey role=mentor id=x corr=x v=1]\n\nbody`;
+    expect(parseMarker(noTs)).toMatchObject({ ok: false, kind: 'malformed' });
+    // Charset violation (space in id).
+    const badId = `[a2a:from=echo to=instar-codey role=mentor id=a b corr=x ts=${NOW} v=1]\n\nbody`;
+    expect(parseMarker(badId)).toMatchObject({ ok: false, kind: 'malformed' });
+    // No blank-line separator.
+    const noSep = `[a2a:from=echo to=instar-codey role=mentor id=x corr=x ts=${NOW} v=1]body`;
+    expect(parseMarker(noSep)).toMatchObject({ ok: false, kind: 'malformed' });
+  });
+
+  it('formatMarker round-trips through parseMarker', () => {
+    const body = 'multi\nline\nbody';
+    const out = formatMarker({ from: 'echo', to: 'instar-codey', role: 'mentor-reply', id: 'r1', corr: 'id-abc', ts: NOW }, body);
+    const r = parseMarker(out);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.msg.role).toBe('mentor-reply');
+      expect(r.msg.corr).toBe('id-abc');
+      expect(r.msg.body).toBe(body);
+    }
+  });
+
+  it('formatMarker rejects charset-violating field values', () => {
+    expect(() => formatMarker({ from: 'echo', to: 'codey', role: 'men tor', id: 'x', corr: 'x', ts: NOW }, 'b')).toThrow(/charset/);
+  });
+});
+
+describe('AgentTelegramComms — routing matrix', () => {
+  it('routes a valid, allowlisted, in-window, unique mentor message', () => {
+    const d = decideRoute(ctx(marker()), cfg, deps());
+    expect(d.action).toBe('route');
+  });
+
+  it('falls through on no marker (ordinary user message)', () => {
+    expect(decideRoute(ctx('just a normal message'), cfg, deps()).action).toBe('fall-through');
+  });
+
+  it('drops malformed markers (never falls through)', () => {
+    const d = decideRoute(ctx(`[a2a:from=echo broken`), cfg, deps());
+    expect(d).toMatchObject({ action: 'drop', reason: 'agent-marker-malformed' });
+  });
+
+  it('drops stale/future markers (replay defense)', () => {
+    const stale = marker({ ts: NOW - 25 * 60 * 60 * 1000 });
+    expect(decideRoute(ctx(stale), cfg, deps())).toMatchObject({ action: 'drop', reason: 'agent-marker-stale-or-future' });
+  });
+
+  it('SECURITY: drops a human-typed marker (not a bot, no sender_chat) even if from/id match the allowlist', () => {
+    const d = decideRoute(ctx(marker(), { senderIsBot: false, senderChatId: undefined, senderBotId: 'echo-mentor-bot' }), cfg, deps());
+    expect(d).toMatchObject({ action: 'drop', reason: 'agent-marker-spoofed-by-user' });
+  });
+
+  it('accepts a group bot-as-channel relay (sender_chat present) from an allowlisted bot', () => {
+    const d = decideRoute(ctx(marker(), { senderIsBot: false, senderChatId: 'echo-mentor-bot', senderBotId: 'echo-mentor-bot' }), cfg, deps());
+    expect(d.action).toBe('route');
+  });
+
+  it('drops wrong-recipient', () => {
+    expect(decideRoute(ctx(marker({ to: 'some-other-agent' })), cfg, deps())).toMatchObject({ action: 'drop', reason: 'agent-marker-wrong-recipient' });
+  });
+
+  it('drops unsupported version (dead-letter, not crash)', () => {
+    const v2 = `[a2a:from=echo to=instar-codey role=mentor id=x corr=x ts=${NOW} v=2]\n\nbody`;
+    expect(decideRoute(ctx(v2), cfg, deps())).toMatchObject({ action: 'drop', reason: 'agent-marker-unsupported-version' });
+  });
+
+  it('drops unknown sender / bot-id mismatch (spoof defense)', () => {
+    expect(decideRoute(ctx(marker({ from: 'mallory' })), cfg, deps())).toMatchObject({ action: 'drop', reason: 'agent-marker-unknown' });
+    expect(decideRoute(ctx(marker(), { senderBotId: 'WRONG-bot' }), cfg, deps())).toMatchObject({ action: 'drop', reason: 'agent-marker-unknown' });
+  });
+
+  it('drops duplicate id (idempotency against Telegram retry / restart)', () => {
+    const d = decideRoute(ctx(marker({ id: 'dup1', corr: 'dup1' })), cfg, deps({ processed: new Set(['dup1']) }));
+    expect(d).toMatchObject({ action: 'drop', reason: 'agent-marker-duplicate' });
+  });
+
+  it('SECURITY: drops a role not allowed FROM THIS SOURCE even if accepted from another', () => {
+    // notify is a known role, but echo is only allowed to send `mentor` here.
+    const d = decideRoute(ctx(marker({ role: 'notify' })), cfg, deps({ roles: new Set(['mentor', 'notify']) }));
+    expect(d).toMatchObject({ action: 'drop', reason: 'agent-marker-role-not-allowed-from-source' });
+  });
+
+  it('drops an entirely-unknown role', () => {
+    const d = decideRoute(ctx(marker({ role: 'gibberish' })), cfg, deps({ roles: new Set(['mentor']) }));
+    expect(d).toMatchObject({ action: 'drop', reason: 'agent-marker-unknown-role' });
+  });
+});
+
+describe('AgentTelegramComms — cycle detection', () => {
+  it('cycleKey never collapses (corr always present)', () => {
+    const k1 = cycleKey({ fromBotId: 'a', toBotId: 'b', topicId: 5, role: 'mentor', corr: 'c1' });
+    const k2 = cycleKey({ fromBotId: 'a', toBotId: 'b', topicId: 5, role: 'mentor', corr: 'c2' });
+    expect(k1).not.toBe(k2); // different corr → different key, no false collision
+  });
+
+  it('trips within the window, clears after it', () => {
+    const cd = new CycleDetector(5000);
+    const k = cycleKey({ fromBotId: 'a', toBotId: 'b', topicId: 1, role: 'mentor', corr: 'c' });
+    cd.mark(k, NOW);
+    expect(cd.wouldTrip(k, NOW + 1000)).toBe(true); // within 5s
+    expect(cd.wouldTrip(k, NOW + 6000)).toBe(false); // past 5s
+  });
+
+  it('does not trip unrelated keys', () => {
+    const cd = new CycleDetector(5000);
+    cd.mark(cycleKey({ fromBotId: 'a', toBotId: 'b', topicId: 1, role: 'mentor', corr: 'c1' }), NOW);
+    const other = cycleKey({ fromBotId: 'a', toBotId: 'b', topicId: 1, role: 'mentor', corr: 'c2' });
+    expect(cd.wouldTrip(other, NOW + 1000)).toBe(false);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,42 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+**New building block: agent-to-agent Telegram comms primitive (core logic).** This is the
+first piece of a robust, reusable way for two Instar agents to talk over Telegram *knowingly*
+— every agent-to-agent message carries a visible marker
+(`[a2a:from=… to=… role=… id=… corr=… ts=… v=1]`) so the receiving side can tell it's from
+another agent and apply anti-loop machinery, rather than treating it like a human user
+message. This increment ships the pure, security-critical core: the strict marker
+parser/formatter, the recipient routing decision (with the full drop matrix — malformed,
+replay-window, user-spoof, wrong-recipient, unknown-sender, duplicate, and per-source role
+admission), and the cycle-detection key. It ships **dark** — nothing wires it yet (the
+TelegramAdapter integration and the first consumer, the mentor, land in follow-up PRs).
+
+## What to Tell Your User
+
+- Nothing changes in how your agent behaves today — this is groundwork. It's the foundation
+  for agents being able to message each other over Telegram safely (with built-in defenses
+  so they can't spoof each other or get stuck in a reply loop), which a later update will
+  switch on for the mentor feature.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| `AgentTelegramComms` primitive (core) | Internal `parseMarker` / `formatMarker` / `decideRoute` / `CycleDetector` in `src/messaging/AgentTelegramComms.ts` — pure logic, I/O injected; not wired yet |
+
+## Evidence
+
+**Net-new feature, not a bug fix** — a new pure-logic module that nothing imports yet
+(ships dark). Proven by 20 unit tests covering every branch of the security-critical logic:
+marker parse/format (valid; no-marker vs malformed incl. missing `corr`/`ts`, charset
+violation, no separator; round-trip); the full routing matrix (route + fall-through + every
+drop reason, including the **user-spoof defense** — a human typing a marker-shaped string is
+dropped even when from/id match an allowlisted bot — and **per-source role acceptance** — a
+known role from the wrong source is dropped); and cycle-detection (key never collapses,
+trips within window, no false collision). `tsc --noEmit` clean. The integration + e2e tiers
+(real TelegramAdapter wiring, the bidirectional contract test, the supervised live cycle)
+land with the follow-up PRs per the spec's staged plan.

--- a/upgrades/side-effects/agent-telegram-comms-primitive.md
+++ b/upgrades/side-effects/agent-telegram-comms-primitive.md
@@ -1,0 +1,75 @@
+# Side-Effects Review — Agent-to-Agent Telegram comms primitive (core logic, PR 1)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2a (converged, approved by Justin
+2026-05-27). Convergence report: `docs/specs/reports/mentor-live-readiness-convergence.md`.
+**Change:** New module `src/messaging/AgentTelegramComms.ts` — the PURE, security-critical
+core of the agent-to-agent Telegram comms primitive: strict marker parse/format, the
+recipient routing matrix (every drop branch), and cycle-detection. I/O (the actual Telegram
+send, audit ledgers, processed-id store) is **injected**, so this PR is pure logic + tests;
+the TelegramAdapter wiring + ledger persistence is PR 2, the mentor consumer is PR 3.
+**Files:** `src/messaging/AgentTelegramComms.ts` (new), `tests/unit/messaging/AgentTelegramComms.test.ts` (new).
+**Ships dark:** nothing imports the module yet except its test — zero runtime behavior change.
+
+## Principle check (Phase 1)
+
+Decision point? Yes — this is the recipient admission/routing decision (`decideRoute`) and
+the anti-loop cycle key. It is built as PURE functions returning a decision the caller acts
+on; the blocking authority (drop vs route) is explicit + exhaustively tested. No existing
+gate is loosened (nothing wired yet).
+
+## The seven questions
+
+1. **Over-block.** `decideRoute` drops on every ambiguous/unrecognized shape (malformed,
+   stale, spoofed, wrong-recipient, unknown-version, unknown-sender, duplicate,
+   role-not-allowed). Correct posture for a security boundary — a marker-shaped string is
+   guilty until allowlisted. The only fall-through is a genuine no-marker (normal user msg).
+2. **Under-block.** The spoof defense (`!senderIsBot && senderChatId===undefined` → drop)
+   is the round-2 adversarial F1 closure — a human typing a marker can NEVER reach a
+   role-handler, even if from/id match. Tested explicitly. `corr`/`ts` are required in the
+   parser so neither the cycle key nor the replay window can be bypassed by omission.
+3. **Level-of-abstraction fit.** Pure logic separated from I/O — the security decisions are
+   unit-testable in isolation (20 tests, every branch). I/O injection deferred to PR 2.
+4. **Signal vs authority.** `decideRoute` IS the authority (drop/route); it returns a typed
+   decision + audit reason for every branch (no silent drops — caller writes the audit row).
+5. **Interactions.** Module is dark (imported only by its test). No interaction with the
+   running system yet. PR 2 wires it into TelegramAdapter (multi-instance + handler-chain);
+   PR 3 wires the mentor consumer. Each subsequent PR re-runs the gate against the same spec.
+6. **External surfaces.** None in this PR (no routes, no config consumed yet). The marker
+   format is the wire contract for PR 2/3 + Codey's side; `A2A_VERSION` is exported for
+   version pinning.
+7. **Rollback cost.** Trivial — revert removes an unused module. No data, no migration.
+
+## Build-time refinements beyond the spec text
+
+- The spec mentioned `state/a2a-*.jsonl` (append-only JSONL audit) + a processed-id JSON
+  store. Convention note (MessageProcessingLedger header: "NOT a new ad-hoc JSON file") —
+  PR 2 will implement the processed-id store on the SQLite path (matching
+  PendingRelayStore/CommitmentTracker) rather than a JSON file; the append-only audit
+  ledgers stay JSONL (Codey designed the audit-row schema as JSONL, and append-only JSONL
+  is the right shape for a forensic trail). Flagged here so PR 2's choice is intentional.
+- `senderBotId` resolution (`sender_chat.id ?? from.id`) + `senderIsBot` are passed in by
+  the caller (PR 2 resolves them from the Telegram update, after the Message type is
+  extended to expose `is_bot`/`sender_chat`). The pure core only consumes them.
+
+## Testing
+
+- 20 unit tests (`tests/unit/messaging/AgentTelegramComms.test.ts`), all passing:
+  - **Marker parse/format**: valid parse; no-marker (fall-through) vs malformed (drop) —
+    incl. missing `corr`, missing `ts`, charset violation, no blank-line separator;
+    format↔parse round-trip; format rejects charset-violating fields.
+  - **Routing matrix**: route success; fall-through; and every drop branch — malformed,
+    stale/future (replay), **user-spoof** (human-typed marker dropped even when from/id
+    match), group bot-as-channel accept, wrong-recipient, unsupported-version, unknown
+    sender, bot-id mismatch, duplicate, **role-not-allowed-from-source** (notify from echo
+    dropped even though notify is a known role), unknown-role.
+  - **Cycle-detection**: key never collapses (corr always present); trips within window,
+    clears after; no collision on different corr.
+- tsc --noEmit clean.
+- PR 2/3 add the integration + e2e tiers (TelegramAdapter wiring, mentor consumer, the
+  bidirectional contract test, the supervised live cycle).
+
+## Migration parity
+
+None for this PR — a new unwired module. No agent-installed file changes, no config, no
+routes. PR 2/3 carry the config defaults + migration (file-outbox retirement, dead-config
+removal) per the spec's §Migration parity.


### PR DESCRIPTION
## What

PR 1 of 3 building the **agent-to-agent Telegram comms primitive** + the mentor as its first consumer (spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md`, approved). This PR is the pure, security-critical **core logic**, fully unit-tested, **shipping dark** (nothing wires it yet).

Per Justin's framing: agents need a robust way to message each other over Telegram *knowingly* — every message carries a visible marker so the receiver knows it's from another agent and applies anti-loop machinery, rather than treating it like a human user message.

## In this PR

- **Strict marker parse/format** — `[a2a:from=… to=… role=… id=… corr=… ts=… v=1]`. `corr` + `ts` required (missing `corr` would collapse the cycle key; missing `ts` disables the replay-window defense). Marker-prefixed-but-broken → **malformed (DROP)**, distinct from no-marker (fall through to user handling) — a broken/spoof sender never reaches a role-handler.
- **`decideRoute`** — the full recipient routing matrix as pure logic: fall-through + route + every drop branch (malformed / stale-or-future / **spoofed-by-user** / wrong-recipient / unsupported-version / unknown-sender / duplicate / **role-not-allowed-from-source** / unknown-role). The user-spoof defense (a human typing a marker is dropped even when `from`/`id` match an allowlisted bot) and per-source role acceptance are the round-2/3 adversarial closures.
- **`cycleKey` + `CycleDetector`** — anti-loop key on `(fromBotId, toBotId, topicId, role, corr)`; `corr` always present so it can't collapse.

I/O (Telegram send, audit ledgers, processed-id store) is **injected** — so every branch is unit-tested in isolation.

## Not in this PR (staged plan)

- **PR 2**: TelegramAdapter wiring — multi-instance state isolation (`subDir`), handler-chain wrapping at the registration site, Message-type extension (`is_bot`/`sender_chat`), ledger persistence, `sendAgentMessage`.
- **PR 3**: the mentor consumer — Stage-A/B rewiring, mentor bot, outstanding-prompt tracker, quota-budget, migration (file-outbox retirement).
- Codey ships his side (recipient handler + reply send + allowlist) in his repo, against the contract this PR exports.

## Tests

20 unit tests, all green; `tsc` clean. Covers marker parse/format (incl. malformed vs no-marker, charset, round-trip), the full routing matrix (incl. the user-spoof + per-source-role security drops), and cycle-detection (no-collapse, window). Net-new dark module — zero runtime behavior change.

Convergence: 3 reviewers, 3 rounds (2 on a superseded file-based design Justin corrected to Telegram substrate, 1 on the Telegram design). Report: `docs/specs/reports/mentor-live-readiness-convergence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)