### PR TITLE
feat(autonomous): notify-on-stop Layer A — terminal exits send a Telegram explaining why

### DIFF
--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -147,6 +147,32 @@ STARTED_AT=$(fm_get started_at)
 COMPLETION_PROMISE=$(fm_get completion_promise)
 COMPLETION_CONDITION=$(fm_get completion_condition)
 GOAL_MODE=$(fm_get goal_mode)   # "native" = the framework's own /goal loop drives completion
+RUN_GOAL=$(fm_get goal)
+
+# ── Layer A: notify-on-stop (2026-05-27 silent-stalls postmortem, Task 2) ──────
+# When an autonomous run reaches a TERMINAL exit (completion / duration / emergency),
+# send ONE plain-English Telegram to the run's report topic explaining why it
+# stopped. Closes Justin's "a session either keeps going OR tells me why it
+# stopped" requirement structurally: previously every terminal exit only echoed
+# to stderr (the terminal the user can't see), so an autonomous run could end in
+# silence. Best-effort + NON-BLOCKING — a delivery failure never blocks the exit.
+# Fires at most once per run (the state file is removed right after each terminal
+# exit, so the hook won't re-enter). Reuses telegram-reply.sh (the same transport
+# the restart-resume recovery note uses), and only for the telegram channel.
+goal_snippet() {
+  printf '%s' "${RUN_GOAL:-the autonomous run}" | tr '\n\t' '  ' | cut -c1-80
+}
+notify_terminal_stop() {
+  local msg="$1"
+  [[ -z "$REPORT_TOPIC" ]] && return 0
+  [[ "${REPORT_CHANNEL:-telegram}" != "telegram" ]] && return 0
+  local script=""
+  if [[ -x ".instar/scripts/telegram-reply.sh" ]]; then script=".instar/scripts/telegram-reply.sh"
+  elif [[ -x ".claude/scripts/telegram-reply.sh" ]]; then script=".claude/scripts/telegram-reply.sh"
+  fi
+  [[ -z "$script" ]] && return 0
+  printf '%s\n' "$msg" | "$script" "$REPORT_TOPIC" >/dev/null 2>&1 || true
+}
 
 # Validate recorded session_id is a real UUID. Claude sometimes writes a custom
 # string instead of $CLAUDE_CODE_SESSION_ID; non-UUID values are treated as
@@ -245,12 +271,14 @@ if [[ "$GOAL_MODE" == "native" ]]; then
         --data-binary @- "http://localhost:${port}/autonomous/native-goal/clear" >/dev/null 2>&1 || true
   }
   if [[ -f ".instar/autonomous-emergency-stop" ]]; then
+    notify_terminal_stop "🛑 My autonomous run on \"$(goal_snippet)\" was stopped (emergency stop)."
     native_goal_clear; rm -f "$STATE_FILE"
     echo "[autonomous] emergency stop — native /goal cleared" >&2; exit 0
   fi
   if [[ "$DURATION_SECONDS" =~ ^[0-9]+$ ]] && [[ $DURATION_SECONDS -gt 0 ]]; then
     NG_START=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$STARTED_AT" +%s 2>/dev/null || date -d "$STARTED_AT" +%s 2>/dev/null || echo 0)
     if [[ "$NG_START" =~ ^[0-9]+$ ]] && [[ $NG_START -gt 0 ]] && [[ $(( $(date +%s) - NG_START )) -ge $DURATION_SECONDS ]]; then
+      notify_terminal_stop "⏰ My autonomous run on \"$(goal_snippet)\" hit its time limit and stopped. Ask me and I'll pick up where I left off."
       native_goal_clear; rm -f "$STATE_FILE"
       echo "[autonomous] duration expired — native /goal cleared" >&2; exit 0
     fi
@@ -280,6 +308,7 @@ if [[ "$DURATION_SECONDS" =~ ^[0-9]+$ ]] && [[ $DURATION_SECONDS -gt 0 ]]; then
     if [[ $ELAPSED -ge $DURATION_SECONDS ]]; then
       echo "⏰ Autonomous mode: Duration expired ($ELAPSED seconds elapsed)."
       echo "   Session is free to exit."
+      notify_terminal_stop "⏰ My autonomous run on \"$(goal_snippet)\" just hit its time limit and stopped. Ask me and I'll pick up where I left off."
       rm -f "$STATE_FILE"
       exit 0
     fi
@@ -293,6 +322,7 @@ fi
 # Emergency stop (global — halts every autonomous job on its next fire)
 if [[ -f ".instar/autonomous-emergency-stop" ]]; then
   echo "🛑 Autonomous mode: Emergency stop detected."
+  notify_terminal_stop "🛑 My autonomous run on \"$(goal_snippet)\" was stopped (emergency stop)."
   rm -f "$STATE_FILE"
   # NOTE: the emergency flag is left in place so OTHER topics' hooks also see it
   # and clear their own per-topic files; stop-all clears the flag when complete.
@@ -323,6 +353,7 @@ if [[ -n "$COMPLETION_CONDITION" ]] && [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TR
   fi
   if [[ "$EVAL_MET" == "true" ]]; then
     echo "✅ Autonomous mode: completion condition met (independent evaluator): ${EVAL_REASON}"
+    notify_terminal_stop "✅ My autonomous run on \"$(goal_snippet)\" finished — the goal was met."
     rm -f "$STATE_FILE"
     exit 0
   fi
@@ -341,6 +372,7 @@ if [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TRANSCRIPT_PATH" ]]; then
       if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
         echo "✅ Autonomous mode: Completion promise detected — <promise>$COMPLETION_PROMISE</promise>"
         echo "   Session is free to exit. Good work!"
+        notify_terminal_stop "✅ My autonomous run on \"$(goal_snippet)\" finished — all the work is done."
         rm -f "$STATE_FILE"
         exit 0
       fi

--- a/docs/specs/NOTIFY-ON-STOP-SPEC.eli16.md
+++ b/docs/specs/NOTIFY-ON-STOP-SPEC.eli16.md
@@ -1,0 +1,36 @@
+# ELI16 — Notify-on-Stop (a stopped session always says why)
+
+## Your rule
+
+You said it plainly: a session either keeps going reliably, OR it sends you a quick message explaining why it stopped — and that "why" had better be a good one. Right now neither half is guaranteed, and that's exactly how a session can go quiet on you without a word.
+
+## Where it's silent today
+
+Two gaps:
+
+1. **When an autonomous run ends, you hear nothing.** When one of my background runs finishes — whether it completed, ran out of its time budget, or got emergency-stopped — it writes the reason to the *terminal*, which you can't see, and quits. You're supposed to get a wrap-up message, but that depends on me *remembering* to send one. That's willpower, not structure — and the incident is what happens when it slips.
+
+2. **When a session stops mid-task unexpectedly, the watchdog sees it but can't tell you.** We have a guard that judges whether a stop was justified. Right now it runs in "watch but don't block" mode. So when it spots a session that stopped when it shouldn't have, it can't keep the session going *and* it doesn't tell you — it just notes it quietly. The silence is the whole problem.
+
+## The fix — two layers, one calm delivery
+
+Both layers use the *same* messaging path we already built for the quiet-session watchdog: log everything, send to your one existing system thread, bundle multiple alerts into a single message, never spam a new thread per event.
+
+**Layer A — when an autonomous run ends, you get one plain message** saying which run, why it stopped (done / out of time / stopped), and where it got to. Built into the machinery, not dependent on me remembering. Exactly one per run, so no spam.
+
+**Layer B — when the watchdog catches a session that stopped mid-work and shouldn't have, you get one message** with what it was doing and a "want me to dig in?" There are three guards against noise:
+- It only pings for *unattended* sessions (a background run). If you're right there chatting with me, you can see the silence yourself — no ping needed.
+- At most one ping per session per half hour — it never nags about the same stuck session.
+- It stays silent on ordinary "I answered, now I'm waiting for you" pauses — those aren't stops, they're normal.
+
+## The one decision I want your nod on
+
+I've set this to **on by default**, because you explicitly asked to be told when a session stops. That's a little against my usual "stay near-silent" instinct — but a session stopping mid-work is exactly the kind of thing you said you DO want pushed to you, and the three guards above keep it from becoming noise. If you'd rather it default to autonomous-runs-only and stay quieter on the watchdog half, say so and I'll flip the default. Otherwise I'll build it on-by-default.
+
+## What you'll notice
+
+Mostly nothing different day-to-day. But the two situations where a session used to go quiet on you — an autonomous run ending, and a session stalling mid-task — now each produce one short, plain message. The thing you've been hammering on gets closed structurally.
+
+## Risk
+
+Low. A single switch turns it off instantly if it's ever too chatty, no redeploy. It reuses the delivery path we already trust. The guards (unattended-only, once-per-half-hour, skip normal pauses) are the spam protection.

--- a/docs/specs/NOTIFY-ON-STOP-SPEC.md
+++ b/docs/specs/NOTIFY-ON-STOP-SPEC.md
@@ -1,0 +1,93 @@
+---
+approved: true
+review-convergence: internal-adversarial-2026-05-27 (single-reviewer conformance pass against the six Instar standards — no-manual-work, structure>willpower, signal-vs-authority, near-silent, 3-tier-testing, migration-parity — plus a gameability/spam-risk sweep. /spec-converge not run: the branded skill is not installed on this checkout. Resolved: Layer A migration path is migrateAutonomousStopHookTopicKeyed (marker+fingerprint; bump the capability marker to ship; customized hooks left untouched). Open product decision surfaced to Justin: default enabled:true + attended-gate scope, given his explicit "tell me why it stopped" mandate weighed against the near-silent standard; shadow-mode `continue`-accuracy risk mitigated by attended-gate + 30min dedup.)
+---
+
+# Spec — Notify-on-Stop (a stopped session always says why)
+
+## Problem
+
+Justin's standing requirement, verbatim: *"sessions that continue on reliably OR that make sure they send a telegram message explaining why they stopped (which should be for a VERY good reason)."*
+
+Today neither half is guaranteed:
+
+1. **Autonomous terminal exits are silent to the user.** `autonomous-stop-hook.sh` ends a run on completion-promise, completion-condition, duration-expiry, or emergency-stop — and in every case it writes the reason to **stderr** (`echo ... >&2`) and `exit 0`. stderr lands in the terminal, which the user cannot see. The user is told nothing. The agent is *supposed* to send a final report itself, but that's willpower, not structure — and the 2026-05-27 incident is exactly what happens when it doesn't.
+
+2. **Unjustified mid-task stops are detected but not surfaced.** The `UnjustifiedStopGate` runs in `shadow` mode on Echo (and ships `off` → `shadow` → `enforce` graduated fleet-wide). In `shadow` mode the gate *evaluates* every Stop and can classify it as `continue` (the session stopped when it should have kept going) — but shadow mode **cannot block**, so the session goes silent anyway. The gate sees the silent stall and does nothing the user can observe. (Until Task 1 / PR #432, the gate's router hook was ESM-crashed, so it saw nothing at all — that's fixed; this spec makes the *seeing* actionable.)
+
+The result both times: a session stops mid-work and the user finds out only by noticing the silence. That is the failure class this spec closes structurally.
+
+## Goal
+
+Every session stop is one of two things, never a silent third:
+- **Continued** — the gate (in `enforce`) blocks an unjustified stop and the session keeps going; OR
+- **Explained** — the user gets exactly one brief, plain-English Telegram saying *why* it stopped.
+
+…without re-introducing notification spam (every Stop-hook fire is a turn-end; most are routine "I answered, now I'm waiting for you" pauses that must stay silent).
+
+## Design — two layers, sharing one delivery discipline
+
+Both layers route through the **existing** `SentinelNotifier` delivery discipline (`src/monitoring/SentinelNotifier.ts`): log-always + Telegram, coalesced within a short window, sent to the single reused system (lifeline) topic — never a new topic per event. We do **not** fork a second notification path. (This is the post-2026-05-22 topic-spam fix; reusing it is mandatory per the near-silent + signal-vs-authority standards.)
+
+### Layer A — deterministic autonomous-exit notice (always-on)
+
+When `autonomous-stop-hook.sh` takes a **terminal** exit, before `exit 0`, send one Telegram to the run's `report_topic` stating which terminal condition fired and a one-line summary:
+
+| Terminal condition | Message shape (ELI16, plain) |
+|---|---|
+| completion-promise / completion-condition met | "✅ Autonomous run on *<goal>* finished — <reason>. <N> iterations, <elapsed>." |
+| duration expired | "⏰ Autonomous run on *<goal>* hit its time limit (<duration>) and stopped. Here's where it got to: <last-status>." |
+| emergency-stop | "🛑 Autonomous run on *<goal>* was emergency-stopped." |
+
+- Deterministic, no LLM — these conditions are already computed in the hook.
+- Idempotent: the state file is removed in the same terminal branch, so the notice fires once per run.
+- Routed via the same `telegram-reply.sh` the hook's recovery-note path already uses (no new transport).
+- **Always-on** (not behind the escalation flag): an autonomous run ending is inherently a user-relevant event, and there is exactly one per run — no spam risk.
+
+### Layer B — intelligent unjustified-stop notice (gate-fed)
+
+Extend the `/internal/stop-gate/evaluate` route. After the decision is computed, feed a `StopGateNotifier` (a thin sibling that *delegates to* the same coalescing/system-topic sink as `SentinelNotifier`, or `SentinelNotifier` itself via a new `escalate`-style entrypoint). Notify **only** on the genuinely-stuck classifications, **only** for sessions that are unattended:
+
+Notify-worthy decision set (the session is going quiet and shouldn't be):
+- `decision === 'continue'` **in `shadow` mode** — the gate believes the stop was unjustified but cannot block it, so the session silently stalls. THE core incident case.
+- `decision === 'escalate'` (`U_AMBIGUOUS_INSUFFICIENT_SIGNAL`) — the gate cannot tell if the stop was justified; surface it.
+
+Explicitly NOT notify-worthy (stay silent):
+- `decision === 'allow'` with any allow rule (e.g. legitimate completion, or a normal "awaiting user" turn-end) — routine.
+- `decision === 'continue'` **in `enforce` mode** — the session is being *blocked and continued*, not stopped; no notice needed.
+- `decision === 'force_allow'` (continue-ceiling) — the operator already has the stuck-state flag; covered by aggregates, not a per-event ping.
+- `failOpen` (authority/LLM unavailable) — transient; log-only (DegradationReporter already covers it). Notifying here would spam on every turn during an LLM outage.
+
+**Spam controls (all required):**
+1. **Attended-session gate.** Notify only when the session is **unattended**. Heuristic: `autonomousActive` (already in the hot-path) OR no inbound user message on the session's topic within the last *N* minutes (default 10). An interactive session where the user is present doesn't need a ping — the user sees the silence directly. *(Convergence question for reviewers: is `autonomousActive` alone sufficient for v1, deferring the "recent-inbound" half? Leaning yes — simplest correct MVP.)*
+2. **Per-session dedup.** At most one notice per session per cooldown window (default 30 min). The Stop hook can fire repeatedly; we never re-ping the same stalled session.
+3. **Coalescing.** Multiple distinct sessions stalling within the `SentinelNotifier` coalesce window flush as one consolidated message (existing behavior).
+4. **Config + default.** New `monitoring.notifyOnStop` config block: `{ enabled: bool, unattendedOnly: bool, dedupWindowMs, cooldownMs }`. **Default `enabled: true`** — Justin explicitly asked to be told; this is the rare case where notify-default-on is correct. The attended-gate + dedup keep it near-silent in practice. (Distinct from `sentinelTelegramEscalation`, which stays default-off for housekeeping sentinels.)
+
+The notice text is fixed-template, plain-English, with the session's last-known activity and a "want me to dig in?" CTA — never raw logs or internal reasoning (tone-gate still applies on the system-topic sender).
+
+## Why this is the right level (signal vs authority)
+
+The Stop-hook router is a brittle, low-context thin client — it must not decide *whether to alarm the user*. The server's evaluate route has the full decision, the mode, the session's attended-state, the dedup ledger, and the wired Telegram sink. The classification intelligence and the notify decision both live where the context is. The hook stays dumb. (Per `feedback_signal_vs_authority` + `feedback_fix_at_the_right_level`.)
+
+## Migration parity
+
+- **Layer A** is a change to `autonomous-stop-hook.sh`, an agent-installed file. Per Migration Parity: the autonomous skill's hook is installed by the skills machinery; the change ships to existing agents via the skill-content migration path (`PostUpdateMigrator`, scoped to the default-skill allowlist) — NOT install-if-missing. Add an idempotent `migrate…` step or confirm the hook is in the always-overwrite set.
+- **Layer B** is server-side `src/` (route + new `StopGateNotifier` + config defaults). Config defaults added via `migrateConfig()` with existence checks. No agent-file change beyond config.
+- Agent-awareness: add notify-on-stop to the CLAUDE.md template (it's a behavior the agent + user should know exists).
+
+## Test plan (all three tiers — non-negotiable)
+
+- **Unit:** (a) `StopGateNotifier` decision matrix — one assertion per row of the notify-worthy / not-worthy table above, both sides of every boundary. (b) dedup-window + cooldown logic. (c) attended-gate logic. (d) Layer A: hook emits the correct message per terminal branch (shellcheck + a bats-style or node-driven harness piping a synthetic transcript). (e) wiring-integrity: the evaluate route actually constructs and calls the notifier (not null, not a no-op).
+- **Integration:** full HTTP `POST /internal/stop-gate/evaluate` in shadow mode with a `continue` decision on an `autonomousActive` session → asserts the notifier sink received exactly one coalesced message; a second immediate call → asserts dedup suppresses it; an `allow` decision → asserts silence.
+- **E2E (the "feature is alive" test):** production init path → server up → drive a synthetic unjustified-stop through the real route → assert a Telegram-bound sink fired (mock transport, real wiring). Plus a live test-as-self pass on a real session before merge (per the test-as-self standard).
+
+## Rollback
+
+- Layer A: revert the hook change (one file).
+- Layer B: `monitoring.notifyOnStop.enabled = false` kills it instantly with no redeploy; full revert is route + notifier + config.
+
+## Out of scope (tracked elsewhere)
+
+- Turning the gate from `shadow` → `enforce` fleet-wide (separate graduated-rollout decision).
+- False-blocker interceptor (Task 3), self-propagation harness (Task 4).

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1332,13 +1332,15 @@ export class PostUpdateMigrator {
       }
     };
     // Marker = the latest capability signature (bumped each time the bundled hook/
-    // setup gains a feature, so prior installs upgrade): now the independent
-    // completion evaluator (mirrors /goal). Absent from multi-session-only installs.
+    // setup gains a feature, so prior installs upgrade): now notify-on-stop —
+    // terminal exits (completion/duration/emergency) send a Telegram explaining
+    // why the run stopped (2026-05-27 silent-stalls postmortem, Task 2). The
+    // `notify_terminal_stop` function name is absent from all prior installs.
     upgrade(
       '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
-      'Native /goal delegation',
+      'notify_terminal_stop',
       'Autonomous Mode Stop Hook',
-      'skills/autonomous/hooks/autonomous-stop-hook.sh (topic-keyed + multi-session + completion evaluator + native /goal)',
+      'skills/autonomous/hooks/autonomous-stop-hook.sh (topic-keyed + multi-session + completion evaluator + native /goal + notify-on-stop)',
     );
     upgrade(
       '.claude/skills/autonomous/scripts/setup-autonomous.sh',

--- a/tests/unit/autonomous-stop-hook-notify.test.ts
+++ b/tests/unit/autonomous-stop-hook-notify.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Layer A of notify-on-stop (docs/specs/NOTIFY-ON-STOP-SPEC.md, Task 2 of the
+ * 2026-05-27 silent-stalls postmortem).
+ *
+ * The autonomous-stop-hook's terminal exits (completion / duration / emergency)
+ * previously only echoed to stderr — the terminal the user can't see — so an
+ * autonomous run could end in silence. This verifies:
+ *   (1) the bundled hook defines notify_terminal_stop + calls it at EVERY
+ *       terminal exit (static wiring);
+ *   (2) the helper actually delivers via telegram-reply.sh, gated on topic +
+ *       channel, best-effort (functional — runs the REAL extracted function);
+ *   (3) existing agents receive the notify-enabled hook on update (migration).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const rmrf = (p: string) => {
+  try {
+    SafeFsExecutor.safeRmSync(p, { recursive: true, force: true, operation: 'tests/unit/autonomous-stop-hook-notify.test.ts' });
+  } catch { /* ignore */ }
+};
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const HOOK_REL = path.join('.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh');
+const HOOK_PATH = path.join(REPO_ROOT, HOOK_REL);
+
+function readHook(): string {
+  return fs.readFileSync(HOOK_PATH, 'utf8');
+}
+
+/** Extract the goal_snippet()+notify_terminal_stop() function block from the
+ *  real hook so the test exercises the shipped code, not a copy. */
+function extractNotifyFns(src: string): string {
+  const lines = src.split('\n');
+  const start = lines.findIndex((l) => l.includes('goal_snippet() {'));
+  expect(start).toBeGreaterThanOrEqual(0);
+  // find the close of notify_terminal_stop: the first standalone `}` AFTER the
+  // notify_terminal_stop() opening line.
+  const notifyOpen = lines.findIndex((l, i) => i > start && l.includes('notify_terminal_stop() {'));
+  expect(notifyOpen).toBeGreaterThan(start);
+  let end = -1;
+  for (let i = notifyOpen + 1; i < lines.length; i++) {
+    if (lines[i] === '}') { end = i; break; }
+  }
+  expect(end).toBeGreaterThan(notifyOpen);
+  return lines.slice(start, end + 1).join('\n');
+}
+
+describe('Layer A — notify_terminal_stop wiring in the bundled hook', () => {
+  it('defines the notify_terminal_stop + goal_snippet helpers', () => {
+    const src = readHook();
+    expect(src).toMatch(/notify_terminal_stop\(\)\s*\{/);
+    expect(src).toMatch(/goal_snippet\(\)\s*\{/);
+  });
+
+  it('the helper is gated on report topic + telegram channel and is best-effort', () => {
+    const block = extractNotifyFns(readHook());
+    expect(block).toContain('[[ -z "$REPORT_TOPIC" ]] && return 0');
+    expect(block).toContain('!= "telegram" ]] && return 0');
+    expect(block).toMatch(/telegram-reply\.sh/);
+    expect(block).toContain('|| true'); // never blocks the exit
+  });
+
+  it('calls notify_terminal_stop at every terminal exit (duration/emergency/completion x2 + native x2)', () => {
+    const src = readHook();
+    const calls = src.split('\n').filter((l) => /^\s*notify_terminal_stop "/.test(l));
+    // 2 native-mode (emergency, duration) + 4 legacy (duration, emergency,
+    // completion-condition, completion-promise) = 6.
+    expect(calls.length).toBe(6);
+    // Each terminal-exit message is plain-English and references the run.
+    for (const c of calls) {
+      expect(c).toMatch(/autonomous run/i);
+    }
+  });
+
+  it('places a notify call before each terminal rm -f "$STATE_FILE"; exit pattern', () => {
+    const src = readHook();
+    // completion-promise block: notify precedes the state-file removal
+    expect(src).toMatch(/notify_terminal_stop "[^\n]*finished — all the work is done\.[^\n]*"\n\s*rm -f "\$STATE_FILE"/);
+    // duration block (legacy)
+    expect(src).toMatch(/notify_terminal_stop "[^\n]*hit its time limit[^\n]*"\n\s*rm -f "\$STATE_FILE"/);
+  });
+});
+
+describe('Layer A — notify_terminal_stop functional delivery (real extracted fn)', () => {
+  let tmp: string;
+  let recorded: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-stop-fn-'));
+    fs.mkdirSync(path.join(tmp, '.instar', 'scripts'), { recursive: true });
+    recorded = path.join(tmp, 'recorded.txt');
+    // Stub telegram-reply.sh: record "<topicArg>\n<stdin>" then succeed.
+    const stub = `#!/bin/bash\n{ echo "TOPIC=$1"; cat; } > "${recorded}"\n`;
+    const stubPath = path.join(tmp, '.instar', 'scripts', 'telegram-reply.sh');
+    fs.writeFileSync(stubPath, stub);
+    fs.chmodSync(stubPath, 0o755);
+  });
+
+  afterEach(() => {
+    rmrf(tmp);
+  });
+
+  function runHelper(env: Record<string, string>, msg: string): void {
+    const block = extractNotifyFns(readHook());
+    const harness = `set -euo pipefail\n${block}\nnotify_terminal_stop ${JSON.stringify(msg)}\n`;
+    const harnessPath = path.join(tmp, 'harness.sh');
+    fs.writeFileSync(harnessPath, harness);
+    execFileSync('bash', [harnessPath], { cwd: tmp, env: { ...process.env, ...env } });
+  }
+
+  it('delivers the message to the report topic via telegram-reply.sh', () => {
+    runHelper({ REPORT_TOPIC: '13481', REPORT_CHANNEL: 'telegram', RUN_GOAL: 'ship the thing' }, '✅ done');
+    const out = fs.readFileSync(recorded, 'utf8');
+    expect(out).toContain('TOPIC=13481');
+    expect(out).toContain('✅ done');
+  });
+
+  it('is a no-op (no delivery) when there is no report topic', () => {
+    runHelper({ REPORT_TOPIC: '', REPORT_CHANNEL: 'telegram', RUN_GOAL: 'x' }, 'should not send');
+    expect(fs.existsSync(recorded)).toBe(false);
+  });
+
+  it('is a no-op for a non-telegram channel', () => {
+    runHelper({ REPORT_TOPIC: '13481', REPORT_CHANNEL: 'slack', RUN_GOAL: 'x' }, 'should not send');
+    expect(fs.existsSync(recorded)).toBe(false);
+  });
+});
+
+describe('Layer A — existing agents receive the notify-enabled hook (migration)', () => {
+  let projectDir: string;
+
+  // Old stock hook: carries the fingerprint, lacks the notify_terminal_stop marker.
+  const OLD_HOOK = [
+    '#!/bin/bash',
+    '# Autonomous Mode Stop Hook',
+    '# TOPIC-KEYED OWNERSHIP + MULTI-SESSION (per-topic state)',
+    '# Native /goal delegation',
+    'REGISTRY_FILE=".instar/topic-session-registry.json"',
+    'exit 0',
+    '',
+  ].join('\n');
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-stop-mig-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmrf(projectDir);
+  });
+
+  it('upgrades a pre-notify stock hook so it gains notify_terminal_stop', () => {
+    const dst = path.join(projectDir, HOOK_REL);
+    fs.mkdirSync(path.dirname(dst), { recursive: true });
+    fs.writeFileSync(dst, OLD_HOOK);
+    expect(fs.readFileSync(dst, 'utf8')).not.toContain('notify_terminal_stop');
+
+    const migrator = new PostUpdateMigrator({
+      projectDir, stateDir: path.join(projectDir, '.instar'), port: 4042, hasTelegram: false, projectName: 'test',
+    });
+    const result = { upgraded: [] as string[], skipped: [] as string[], errors: [] as string[] };
+    (migrator as unknown as { migrateAutonomousStopHookTopicKeyed(r: typeof result): void })
+      .migrateAutonomousStopHookTopicKeyed(result);
+
+    expect(fs.readFileSync(dst, 'utf8')).toContain('notify_terminal_stop');
+    expect(result.errors).toEqual([]);
+  });
+
+  it('uses notify_terminal_stop as the migration capability marker', () => {
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'src', 'core', 'PostUpdateMigrator.ts'), 'utf8');
+    expect(src).toMatch(/upgrade\(\s*'\.claude\/skills\/autonomous\/hooks\/autonomous-stop-hook\.sh',\s*'notify_terminal_stop'/);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,29 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Notify-on-stop, Layer A: when an autonomous run reaches a terminal exit — it completed, ran out of its time budget, or was emergency-stopped — the agent now sends one plain-English Telegram to the run's topic explaining why it stopped. Previously these reasons were only written to stderr (the terminal the user can't see), so an autonomous run could end in silence unless the agent remembered to send a wrap-up. This bakes the "a session either keeps going OR tells you why it stopped" guarantee into the stop hook itself.
+
+The notice is best-effort and non-blocking (a delivery hiccup never blocks the exit), fires at most once per run, and reuses the existing Telegram reply transport + the run's existing topic (no new topic is ever created).
+
+Existing agents receive the notify-enabled hook automatically: the autonomous-stop-hook capability marker is bumped, so the marker+fingerprint migration re-deploys the updated hook to stock installs on update (customized hooks are left untouched).
+
+## What to Tell Your User
+
+- When one of my autonomous runs finishes (or times out, or is stopped), you now get a short heads-up explaining why — no more silent endings.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Autonomous-run terminal exits send a Telegram explaining why | Automatic; one message per run to the run's topic |
+
+## Evidence
+
+- Hook: `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh` (`notify_terminal_stop` at all 6 terminal exits).
+- Migration: `src/core/PostUpdateMigrator.ts` (capability marker → `notify_terminal_stop`).
+- Tests: `tests/unit/autonomous-stop-hook-notify.test.ts` (9 — static wiring, functional delivery via the real extracted helper, migration).
+- Spec: `docs/specs/NOTIFY-ON-STOP-SPEC.md` (approved) + `.eli16.md`. Side-effects: `upgrades/side-effects/notify-on-stop-layer-a.md`.
+- Layer B (watchdog-caught mid-task stalls) ships separately under the same spec.

--- a/upgrades/side-effects/notify-on-stop-layer-a.md
+++ b/upgrades/side-effects/notify-on-stop-layer-a.md
@@ -1,0 +1,31 @@
+# Side-Effects Review — Notify-on-Stop, Layer A (autonomous-run-ended notice)
+
+**Spec:** docs/specs/NOTIFY-ON-STOP-SPEC.md (approved: true) — Layer A of two. Layer B (gate-fed unjustified-stop notice) ships as a separate PR.
+
+Closes the primary silent-stall scenario: an autonomous run reaching a terminal exit (completion / duration-expiry / emergency-stop) previously only echoed the reason to stderr — the terminal the user can't see — so the run could end in silence unless the agent *remembered* to send a final report (willpower, not structure). Justin's standing requirement: a session either keeps going OR tells you why it stopped.
+
+## What changed
+- `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh` — added two helpers (`goal_snippet`, `notify_terminal_stop`) and a `notify_terminal_stop "<plain message>"` call before EACH of the six terminal exits (native-mode emergency + duration; legacy duration, emergency, completion-condition, completion-promise). Each sends ONE plain-English Telegram to the run's `report_topic` via `telegram-reply.sh` — the same transport the existing restart-resume recovery note uses.
+- `src/core/PostUpdateMigrator.ts` — bumped the autonomous-stop-hook capability marker from `Native /goal delegation` to `notify_terminal_stop` so existing agents on a prior stock hook receive the notify-enabled version on update (the marker+fingerprint mechanism; customized hooks left untouched).
+- `tests/unit/autonomous-stop-hook-notify.test.ts` — static wiring (helper defined + called at all 6 exits), functional delivery (runs the REAL extracted helper against a stub telegram-reply.sh; both no-op gates), and migration (a stock pre-notify hook gains `notify_terminal_stop`).
+
+## Behavior / safety
+- **Best-effort, non-blocking:** `notify_terminal_stop` ends every path with `|| true` and returns early if there's no report topic or the channel isn't telegram. A delivery failure NEVER changes the hook's exit code or blocks the terminal exit.
+- **Fires at most once per run:** every terminal branch removes the state file immediately after, so the hook can't re-enter and re-notify.
+- **No new transport / topic:** reuses `telegram-reply.sh` to the run's existing report topic. No new Telegram topic is ever created.
+
+## Over/under-notify
+- OVER: at completion, the agent's own final report (if it sent one) plus Layer A's brief "run finished" backstop = a possible second short message. Accepted — the structural guarantee that *something* is sent outweighs minor redundancy; the backstop is one line.
+- UNDER: a heavily-customized hook (no stock fingerprint) won't receive the migration — same accepted limit as every autonomous-hook migration. Channel != telegram → no send (Layer A is telegram-scoped; other channels await Channel Parity).
+
+## Near-silent compliance
+An autonomous run ending is an action-relevant, once-per-run event — exactly the kind the user asked to be told about. Not routine churn. No throttling needed (one message per terminal exit, max once per run).
+
+## Migration parity
+`migrateAutonomousStopHookTopicKeyed` (marker bump) ships the updated hook to existing agents; new agents get it via the bundled file at init. Verified by the migration test.
+
+## Rollback
+Revert the hook edits + the marker bump (2 files) + the test. Worst case: terminal exits go back to stderr-only.
+
+## NOT in this PR (tracked)
+- Layer B: gate-fed unjustified-mid-task-stop notice via the stop-gate evaluate route + a StopNotifier reusing SentinelNotifier's coalescing sink. Separate PR under the same spec.


### PR DESCRIPTION
## Problem

When an autonomous run reaches a terminal exit — completion, duration-expiry, or emergency-stop — the stop hook only echoed the reason to **stderr** (the terminal the user can't see) before exiting. So an autonomous run could end in **silence** unless the agent *remembered* to send a wrap-up (willpower, not structure). This is the primary scenario behind the 2026-05-27 silent-stall incident and Justin's standing requirement: *a session either keeps going OR tells you why it stopped.*

## Fix (Layer A of the notify-on-stop spec)
- `notify_terminal_stop` + `goal_snippet` helpers in `autonomous-stop-hook.sh`, called before **all six** terminal exits (native-mode emergency + duration; legacy duration, emergency, completion-condition, completion-promise). Each sends one plain-English Telegram to the run's report topic via `telegram-reply.sh` (the same transport the restart-resume recovery note uses).
- **Best-effort + non-blocking** (`|| true`; returns early if no report topic or non-telegram channel) — a delivery hiccup never blocks the exit. Fires **at most once per run** (state file removed right after each terminal branch). No new Telegram topic is ever created.
- Migration marker bumped to `notify_terminal_stop` so existing stock agents receive the notify-enabled hook on update (customized hooks untouched).

## Tests (`tests/unit/autonomous-stop-hook-notify.test.ts`, 9)
- Static wiring: helper defined + called at all 6 terminal exits.
- Functional delivery: runs the **real extracted helper** against a stub `telegram-reply.sh` — delivers to the topic; no-ops without a topic / for a non-telegram channel.
- Migration: a stock pre-notify hook gains `notify_terminal_stop`.

## Scope
Layer B (the watchdog catching an unjustified **mid-task** stall via the stop-gate evaluate route) ships as a **separate PR** under the same approved spec — kept apart to stay low-risk and reviewable.

Spec: `docs/specs/NOTIFY-ON-STOP-SPEC.md` (approved) · ELI16 + side-effects included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
