### PR TITLE
feat(feedback-factory): dry-run/compare machinery (ShadowStore + parity + runner)

### DIFF
--- a/src/feedback-factory/dryrun/dryRunCompare.ts
+++ b/src/feedback-factory/dryrun/dryRunCompare.ts
@@ -1,0 +1,137 @@
+/**
+ * dryRunCompare.ts — the Phase-1/3 dry-run/compare runner.
+ *
+ * docs/specs/feedback-factory-migration.md §2.5: the ported Instar processor runs
+ * read-only against Portal's LIVE canonical DB and its decisions are compared to
+ * Portal's over the order-independent invariants (parity.ts). Portal stays the SOLE
+ * writer through cutover (the ReadOnlyShadowStore guard guarantees Instar never
+ * mutates the curated history). This runner drives that comparison and emits a
+ * durable JSONL audit trail; `result.divergent` is the structural signal that
+ * blocks Phase 4 cutover.
+ *
+ * Two seams keep it buildable + testable today while the live pieces are
+ * credentials-gated:
+ *   - {@link ParitySource} is the read-only window source. In production it's a
+ *     thin Prisma adapter over Portal's read-only Postgres (built once Dawn hands
+ *     off read-credentials, via `prisma db pull` so it matches the live schema
+ *     exactly). In tests it's {@link InMemoryParitySource} seeded with a corpus.
+ *   - Invariant 1 (fingerprint) is fully live-ready: it recomputes each Portal
+ *     cluster's fingerprint and diffs against the stored value — pure, no replay.
+ *     Invariants 2 & 3 (status/recurrence) compare two outcome lists; Instar's side
+ *     requires a faithful replay from window-START cluster state, which a
+ *     current-state read cannot supply — so the runner accepts those outcome lists
+ *     as inputs (supplied from a snapshot / full-history export) rather than
+ *     deriving them from a point-in-time read. This is a documented data dependency,
+ *     not an omission: the comparator and emit path handle all three invariants.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import {
+  compareInvariants,
+  type ClusterOutcome,
+  type ParityResult,
+  type PortalCluster,
+} from '../processor/parity.js';
+
+/** Read-only window source for the dry-run. Production = Prisma over Portal's DB. */
+export interface ParitySource {
+  /** Portal's active clusters (with stored fingerprint, status, recurrence) — invariant 1. */
+  readPortalClusters(): PortalCluster[];
+}
+
+/** Options for one dry-run/compare pass. */
+export interface DryRunOptions {
+  /** Where to append JSONL compare records. Omit to skip the audit trail (return-only). */
+  outPath?: string;
+  /** ISO timestamp for the summary record (injected for deterministic tests). */
+  now?: string;
+  /**
+   * Optional cluster-outcome lists for invariants 2 & 3 (status + recurrence).
+   * Supplied from a window-start snapshot / full-history replay; omit for a
+   * fingerprint-only pass (the always-available live gate).
+   */
+  instarOutcomes?: ClusterOutcome[];
+  portalOutcomes?: ClusterOutcome[];
+}
+
+/** One line in the JSONL audit trail. */
+export type DryRunRecord =
+  | { kind: 'fingerprint-divergence'; clusterId: string; instar: string; portal: string }
+  | {
+      kind: 'outcome-divergence';
+      fingerprint: string;
+      divergence: 'status' | 'recurrence' | 'missing-instar' | 'missing-portal';
+      instar?: string | number;
+      portal?: string | number;
+    }
+  | {
+      kind: 'summary';
+      at: string;
+      clustersCompared: number;
+      outcomesCompared: number;
+      fingerprintDivergences: number;
+      outcomeDivergences: number;
+      divergent: boolean;
+    };
+
+/** Flatten a {@link ParityResult} into the JSONL record stream (divergences then summary). */
+export function toRecords(result: ParityResult, now: string): DryRunRecord[] {
+  const records: DryRunRecord[] = [];
+  for (const d of result.fingerprintDivergences) {
+    records.push({ kind: 'fingerprint-divergence', clusterId: d.clusterId, instar: d.instar, portal: d.portal });
+  }
+  for (const d of result.outcomeDivergences) {
+    records.push({
+      kind: 'outcome-divergence',
+      fingerprint: d.fingerprint,
+      divergence: d.kind,
+      instar: d.instar,
+      portal: d.portal,
+    });
+  }
+  records.push({
+    kind: 'summary',
+    at: now,
+    clustersCompared: result.clustersCompared,
+    outcomesCompared: result.outcomesCompared,
+    fingerprintDivergences: result.fingerprintDivergences.length,
+    outcomeDivergences: result.outcomeDivergences.length,
+    divergent: result.divergent,
+  });
+  return records;
+}
+
+/**
+ * Run one dry-run/compare pass: read Portal's clusters, compare invariants, append
+ * the JSONL audit trail, and return the verdict. NEVER writes to Portal's DB — the
+ * source is read-only and the runner only reads + compares + appends a local log.
+ */
+export function runDryRunCompare(source: ParitySource, opts: DryRunOptions = {}): ParityResult {
+  const now = opts.now ?? new Date().toISOString();
+  const portalClusters = source.readPortalClusters();
+
+  const result = compareInvariants({
+    portalClusters,
+    instarOutcomes: opts.instarOutcomes,
+    portalOutcomes: opts.portalOutcomes,
+  });
+
+  if (opts.outPath) {
+    const lines = toRecords(result, now)
+      .map((r) => JSON.stringify(r))
+      .join('\n');
+    mkdirSync(dirname(opts.outPath), { recursive: true });
+    appendFileSync(opts.outPath, lines + '\n');
+  }
+
+  return result;
+}
+
+/** In-memory ParitySource — the test implementation + the shape the Prisma adapter mirrors. */
+export class InMemoryParitySource implements ParitySource {
+  constructor(private readonly clusters: PortalCluster[]) {}
+  readPortalClusters(): PortalCluster[] {
+    return this.clusters.map((c) => ({ ...c }));
+  }
+}

--- a/src/feedback-factory/processor/parity.ts
+++ b/src/feedback-factory/processor/parity.ts
@@ -1,0 +1,175 @@
+/**
+ * parity.ts — the Phase-3 live-mirror invariant comparator.
+ *
+ * docs/specs/feedback-factory-migration.md §2.3/§2.5: the live dual-forward gate
+ * compares ONLY order-independent invariants between Portal's processor and the
+ * ported Instar processor — because clustering is order-dependent (a report merges
+ * into whichever similar cluster already exists) and the two instances will NOT see
+ * reports in identical order/timing, a raw cluster-membership diff would fail on
+ * benign ordering noise and pressure us to weaken the gate. The spec pins three
+ * invariants:
+ *
+ *   1. FINGERPRINT (per cluster)  — `computeFingerprint(cluster.type, cluster.title)`,
+ *                                    exactly as the reference's cmd_backfill_fingerprints
+ *                                    (:256) derives it. Recomputing it over Portal's
+ *                                    LIVE clusters and diffing against the stored
+ *                                    fingerprint is a pure cross-implementation
+ *                                    equivalence check — fully order-independent and
+ *                                    needs no replay. It is the highest-signal gate:
+ *                                    it catches the byte-level Python↔JS divergence
+ *                                    (Unicode regex classes, SHA encoding, tokenizer/
+ *                                    case-fold) on REAL production titles the
+ *                                    recorded adversarial corpus may not cover.
+ *   2. terminal STATUS per group  — keyed by fingerprint (the stable cluster key),
+ *                                    NOT raw clusterId (slug IDs differ across
+ *                                    instances). Requires Instar's recomputed outcomes.
+ *   3. RECURRENCE/cycling count    — keyed by fingerprint; chronic-regression
+ *                                    accounting that should converge on the same set.
+ *
+ * This module is PURE. Invariant 1 needs only Portal's stored clusters (read-only).
+ * Invariants 2 & 3 compare two pre-computed outcome lists; the runner
+ * (dryrun/dryRunCompare.ts) supplies Instar's side from a throwaway replay — never
+ * against Portal's DB (see ReadOnlyShadowStore). `divergent === true` is the
+ * structural signal that BLOCKS Phase 4 cutover (spec §2.5 Phase 4/5).
+ */
+
+import { computeFingerprint } from './fingerprint.js';
+
+/** The canonical fingerprint for a cluster: exactly the reference's per-cluster derivation. */
+export function clusterFingerprint(cluster: { type: string; title: string }): string {
+  return computeFingerprint(cluster.type, cluster.title);
+}
+
+/** A cluster as read from Portal's canonical DB (the dry-run reads these read-only). */
+export interface PortalCluster {
+  clusterId: string;
+  type: string;
+  title: string;
+  /** The fingerprint Portal stored (the @unique dedup key). */
+  fingerprint: string;
+  status?: string;
+  recurrenceCount?: number;
+}
+
+/** A cluster-level outcome, keyed by fingerprint (the order-independent cluster identity). */
+export interface ClusterOutcome {
+  fingerprint: string;
+  /** Terminal lifecycle status (e.g. 'resolved', 'investigating', 'new'). */
+  status: string;
+  /** Chronic-regression recurrence count. */
+  recurrenceCount: number;
+}
+
+/** One per-cluster fingerprint divergence. */
+export interface FingerprintDivergence {
+  clusterId: string;
+  instar: string;
+  portal: string;
+}
+
+/** One cluster-outcome divergence (status and/or recurrence), keyed by fingerprint. */
+export interface OutcomeDivergence {
+  fingerprint: string;
+  kind: 'status' | 'recurrence' | 'missing-instar' | 'missing-portal';
+  instar?: string | number;
+  portal?: string | number;
+}
+
+/** The full parity verdict over a window. `divergent` gates Phase 4 cutover. */
+export interface ParityResult {
+  clustersCompared: number;
+  outcomesCompared: number;
+  fingerprintDivergences: FingerprintDivergence[];
+  outcomeDivergences: OutcomeDivergence[];
+  /** True iff ANY invariant diverged — the structural cutover block. */
+  divergent: boolean;
+}
+
+/**
+ * Invariant 1 (fingerprint) — pure, fully order-independent, no replay. Recomputes
+ * each Portal cluster's fingerprint via the ported `computeFingerprint` and diffs
+ * against the fingerprint Portal stored. Any mismatch is a REAL divergence (the
+ * ported fingerprint logic differs from the Python reference on a real title) —
+ * never benign ordering noise. This is the live extension of the recorded-corpus
+ * fingerprint-parity harness.
+ *
+ * Clusters with no stored fingerprint (e.g. created before a backfill) are skipped
+ * — there is nothing to compare against, and flagging them would be a false positive.
+ */
+export function compareClusterFingerprints(portalClusters: PortalCluster[]): FingerprintDivergence[] {
+  const out: FingerprintDivergence[] = [];
+  for (const c of portalClusters) {
+    if (!c.fingerprint) continue;
+    const instar = clusterFingerprint(c);
+    if (instar !== c.fingerprint) {
+      out.push({ clusterId: c.clusterId, instar, portal: c.fingerprint });
+    }
+  }
+  return out;
+}
+
+/**
+ * Invariants 2 & 3 (terminal status + recurrence) — keyed by fingerprint, NOT raw
+ * clusterId. Compares Instar's recomputed cluster outcomes against Portal's actuals.
+ * A fingerprint present on one side but not the other is itself a divergence (the
+ * two instances grouped reports differently in a way that matters).
+ */
+export function compareClusterOutcomes(
+  instar: ClusterOutcome[],
+  portal: ClusterOutcome[],
+): OutcomeDivergence[] {
+  const out: OutcomeDivergence[] = [];
+  const instarByFp = new Map(instar.map((c) => [c.fingerprint, c]));
+  const portalByFp = new Map(portal.map((c) => [c.fingerprint, c]));
+
+  for (const [fp, p] of portalByFp) {
+    const i = instarByFp.get(fp);
+    if (!i) {
+      out.push({ fingerprint: fp, kind: 'missing-instar', portal: p.status });
+      continue;
+    }
+    if (i.status !== p.status) {
+      out.push({ fingerprint: fp, kind: 'status', instar: i.status, portal: p.status });
+    }
+    if (i.recurrenceCount !== p.recurrenceCount) {
+      out.push({
+        fingerprint: fp,
+        kind: 'recurrence',
+        instar: i.recurrenceCount,
+        portal: p.recurrenceCount,
+      });
+    }
+  }
+  for (const [fp, i] of instarByFp) {
+    if (!portalByFp.has(fp)) {
+      out.push({ fingerprint: fp, kind: 'missing-portal', instar: i.status });
+    }
+  }
+  return out;
+}
+
+/**
+ * Full comparison over all three invariants → the cutover-gating verdict.
+ * `instarOutcomes`/`portalOutcomes` are optional: the fingerprint invariant (1) is
+ * always run over Portal's clusters; the outcome invariants (2 & 3) run only when
+ * both outcome lists are supplied (they require Instar's throwaway replay, which
+ * is order-dependent — see dryRunCompare).
+ */
+export function compareInvariants(args: {
+  portalClusters: PortalCluster[];
+  instarOutcomes?: ClusterOutcome[];
+  portalOutcomes?: ClusterOutcome[];
+}): ParityResult {
+  const fingerprintDivergences = compareClusterFingerprints(args.portalClusters);
+  const outcomeDivergences =
+    args.instarOutcomes && args.portalOutcomes
+      ? compareClusterOutcomes(args.instarOutcomes, args.portalOutcomes)
+      : [];
+  return {
+    clustersCompared: args.portalClusters.length,
+    outcomesCompared: args.portalOutcomes?.length ?? 0,
+    fingerprintDivergences,
+    outcomeDivergences,
+    divergent: fingerprintDivergences.length > 0 || outcomeDivergences.length > 0,
+  };
+}

--- a/src/feedback-factory/store/ReadOnlyShadowStore.ts
+++ b/src/feedback-factory/store/ReadOnlyShadowStore.ts
@@ -1,0 +1,95 @@
+/**
+ * ReadOnlyShadowStore.ts — the dry-run write-guard for the feedback factory.
+ *
+ * Phase 1/3 of the migration (docs/specs/feedback-factory-migration.md §2.5) runs
+ * the ported Instar processor against Portal's LIVE canonical DB to compare its
+ * decisions against Portal's — but **Portal must remain the sole writer** (the
+ * one-shared-DB precondition prevents split-brain; two writers would corrupt the
+ * curated bug history). This wrapper enforces that structurally rather than by
+ * convention: every READ delegates to the wrapped store (Portal's read-only
+ * Postgres adapter in production, an InMemoryFeedbackStore in tests); every WRITE
+ * throws {@link ShadowStoreWriteError}.
+ *
+ * Why a guard and not just "don't call the writers": defense in depth. If any code
+ * path (e.g. an accidental `processUnprocessed(shadowStore, ...)` — which writes)
+ * runs against this store, the FIRST write attempt throws loudly at the seam
+ * instead of silently mutating Portal's data. The dry-run runner (dryRunCompare)
+ * never writes — it uses the pure comparator — but the guard means a future
+ * mis-wire can't quietly fork history. This is the "writes throw as a guard"
+ * contract confirmed with Dawn (the domain owner) on 2026-05-27.
+ *
+ * Structure > Willpower: the read-only guarantee lives in the type, not a comment.
+ */
+
+import type { FeedbackStore, FeedbackMetrics } from './FeedbackStore.js';
+import type { FeedbackItem, Cluster } from '../processor/types.js';
+import type { ReopenDecision } from '../processor/reopen.js';
+import type { DispatchRecord } from '../dispatch/dispatch.js';
+
+/** Thrown when any mutating FeedbackStore method is called on a ReadOnlyShadowStore. */
+export class ShadowStoreWriteError extends Error {
+  /** The mutating method that was (illegally) attempted. */
+  readonly method: string;
+  constructor(method: string) {
+    super(
+      `ReadOnlyShadowStore: write method '${method}' is forbidden — the dry-run ` +
+        `processor must never mutate the canonical feedback DB (Portal is sole ` +
+        `writer through cutover; see feedback-factory-migration.md §2.5).`,
+    );
+    this.name = 'ShadowStoreWriteError';
+    this.method = method;
+  }
+}
+
+/**
+ * Wraps a {@link FeedbackStore} so it is read-only: reads delegate, writes throw.
+ * The delegate supplies the reads — in production that's the Prisma read-only
+ * adapter over Portal's Postgres (credentials-gated, see dryRunCompare.ts); in
+ * tests it's an InMemoryFeedbackStore seeded with a corpus.
+ */
+export class ReadOnlyShadowStore implements FeedbackStore {
+  constructor(private readonly read: FeedbackStore) {}
+
+  // --- reads: delegate verbatim ---
+  getUnprocessedFeedback(): FeedbackItem[] {
+    return this.read.getUnprocessedFeedback();
+  }
+  getActiveClusters(): Cluster[] {
+    return this.read.getActiveClusters();
+  }
+  getCluster(clusterId: string): Cluster | undefined {
+    return this.read.getCluster(clusterId);
+  }
+  hasFeedback(feedbackId: string): boolean {
+    return this.read.hasFeedback(feedbackId);
+  }
+  listDispatches(filter?: { since?: string; type?: string }): DispatchRecord[] {
+    return this.read.listDispatches(filter);
+  }
+  findDispatchByTitle(title: string): DispatchRecord | undefined {
+    return this.read.findDispatchByTitle(title);
+  }
+  metrics(): FeedbackMetrics {
+    return this.read.metrics();
+  }
+
+  // --- writes: forbidden ---
+  upsertClusterFromItem(_clusterId: string, _item: FeedbackItem): void {
+    throw new ShadowStoreWriteError('upsertClusterFromItem');
+  }
+  mergeIntoCluster(_clusterId: string, _item: FeedbackItem): void {
+    throw new ShadowStoreWriteError('mergeIntoCluster');
+  }
+  applyReopen(_clusterId: string, _decision: ReopenDecision): void {
+    throw new ShadowStoreWriteError('applyReopen');
+  }
+  markProcessed(_feedbackId: string, _clusterId: string): void {
+    throw new ShadowStoreWriteError('markProcessed');
+  }
+  addFeedback(_item: FeedbackItem): void {
+    throw new ShadowStoreWriteError('addFeedback');
+  }
+  createDispatch(_record: DispatchRecord): void {
+    throw new ShadowStoreWriteError('createDispatch');
+  }
+}

--- a/tests/unit/feedback-factory/dry-run-compare.test.ts
+++ b/tests/unit/feedback-factory/dry-run-compare.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests (Tier 1) — dry-run/compare runner.
+ *
+ * End-to-end against InMemoryParitySource: reads Portal clusters, compares
+ * invariants, emits a JSONL audit trail, returns the verdict. Covers the clean
+ * (no-divergence) path, a divergent corpus, the outcome-invariant path, and the
+ * never-writes-to-source guarantee.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  runDryRunCompare,
+  toRecords,
+  InMemoryParitySource,
+  type DryRunRecord,
+} from '../../../src/feedback-factory/dryrun/dryRunCompare.js';
+import { clusterFingerprint, type PortalCluster, type ClusterOutcome } from '../../../src/feedback-factory/processor/parity.js';
+
+const cluster = (clusterId: string, type: string, title: string, extra: Partial<PortalCluster> = {}): PortalCluster => ({
+  clusterId,
+  type,
+  title,
+  fingerprint: clusterFingerprint({ type, title }),
+  ...extra,
+});
+
+const readJsonl = (path: string): DryRunRecord[] =>
+  readFileSync(path, 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+
+describe('runDryRunCompare', () => {
+  it('returns divergent=false and emits a clean summary when fingerprints match', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dryrun-'));
+    const out = join(dir, 'logs', 'compare.jsonl');
+    const source = new InMemoryParitySource([
+      cluster('c1', 'bug', 'gitsync.pull fails on rebase'),
+      cluster('c2', 'feature', 'add dark mode toggle'),
+    ]);
+
+    const result = runDryRunCompare(source, { outPath: out, now: '2026-05-27T00:00:00Z' });
+
+    expect(result.divergent).toBe(false);
+    expect(result.clustersCompared).toBe(2);
+    const records = readJsonl(out);
+    expect(records).toHaveLength(1); // just the summary
+    expect(records[0]).toMatchObject({ kind: 'summary', divergent: false, clustersCompared: 2, fingerprintDivergences: 0 });
+  });
+
+  it('detects a fingerprint divergence, sets divergent=true, and logs the divergence + summary', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dryrun-'));
+    const out = join(dir, 'compare.jsonl');
+    const source = new InMemoryParitySource([
+      cluster('c1', 'bug', 'good title'),
+      { clusterId: 'c2', type: 'bug', title: 'diverging title', fingerprint: 'PYTHON_ONLY_VALUE' },
+    ]);
+
+    const result = runDryRunCompare(source, { outPath: out, now: '2026-05-27T00:00:00Z' });
+
+    expect(result.divergent).toBe(true);
+    expect(result.fingerprintDivergences).toHaveLength(1);
+    expect(result.fingerprintDivergences[0].clusterId).toBe('c2');
+
+    const records = readJsonl(out);
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({ kind: 'fingerprint-divergence', clusterId: 'c2', portal: 'PYTHON_ONLY_VALUE' });
+    expect(records[1]).toMatchObject({ kind: 'summary', divergent: true, fingerprintDivergences: 1 });
+  });
+
+  it('compares outcome invariants when both outcome lists are supplied', () => {
+    const source = new InMemoryParitySource([cluster('c1', 'bug', 'title')]);
+    const portalOutcomes: ClusterOutcome[] = [{ fingerprint: 'fp-a', status: 'resolved', recurrenceCount: 1 }];
+    const instarOutcomes: ClusterOutcome[] = [{ fingerprint: 'fp-a', status: 'investigating', recurrenceCount: 1 }];
+
+    const result = runDryRunCompare(source, { instarOutcomes, portalOutcomes, now: '2026-05-27T00:00:00Z' });
+
+    expect(result.divergent).toBe(true);
+    expect(result.outcomeDivergences).toEqual([{ fingerprint: 'fp-a', kind: 'status', instar: 'investigating', portal: 'resolved' }]);
+  });
+
+  it('does not write any audit trail when outPath is omitted', () => {
+    const source = new InMemoryParitySource([cluster('c1', 'bug', 'title')]);
+    const result = runDryRunCompare(source);
+    expect(result.divergent).toBe(false); // return-only mode still works
+  });
+
+  it('never mutates the source (read-only guarantee)', () => {
+    const clusters = [cluster('c1', 'bug', 'title')];
+    const source = new InMemoryParitySource(clusters);
+    const before = JSON.stringify(source.readPortalClusters());
+    runDryRunCompare(source, { now: '2026-05-27T00:00:00Z' });
+    expect(JSON.stringify(source.readPortalClusters())).toBe(before);
+  });
+});
+
+describe('toRecords', () => {
+  it('orders divergences before the summary and stamps the timestamp', () => {
+    const records = toRecords(
+      {
+        clustersCompared: 1,
+        outcomesCompared: 0,
+        fingerprintDivergences: [{ clusterId: 'c1', instar: 'a', portal: 'b' }],
+        outcomeDivergences: [],
+        divergent: true,
+      },
+      '2026-05-27T12:00:00Z',
+    );
+    expect(records[0].kind).toBe('fingerprint-divergence');
+    expect(records[records.length - 1]).toMatchObject({ kind: 'summary', at: '2026-05-27T12:00:00Z', divergent: true });
+  });
+});

--- a/tests/unit/feedback-factory/parity.test.ts
+++ b/tests/unit/feedback-factory/parity.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests (Tier 1) — Phase-3 parity invariant comparator.
+ *
+ * Both-sides-of-boundary for all three order-independent invariants (spec §2.3):
+ *   1. per-cluster fingerprint  — match vs real (Python↔JS) divergence
+ *   2. terminal status          — match vs divergence
+ *   3. recurrence count         — match vs divergence
+ * Plus the missing-on-one-side cases. The "correct" stored fingerprints are
+ * computed with the real `clusterFingerprint`, so the test stays valid if the
+ * fingerprint logic legitimately changes (the recorded-corpus harness pins the
+ * exact bytes).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  clusterFingerprint,
+  compareClusterFingerprints,
+  compareClusterOutcomes,
+  compareInvariants,
+  type PortalCluster,
+  type ClusterOutcome,
+} from '../../../src/feedback-factory/processor/parity.js';
+
+const cluster = (clusterId: string, type: string, title: string, extra: Partial<PortalCluster> = {}): PortalCluster => ({
+  clusterId,
+  type,
+  title,
+  fingerprint: clusterFingerprint({ type, title }), // correct by construction
+  ...extra,
+});
+
+describe('compareClusterFingerprints (invariant 1)', () => {
+  it('no divergence when stored fingerprints match the recomputed ones', () => {
+    const clusters = [
+      cluster('c1', 'bug', 'gitsync.pull fails on rebase'),
+      cluster('c2', 'bug', 'telegram relay drops message'),
+      cluster('c3', 'feature', 'add dark mode toggle'),
+    ];
+    expect(compareClusterFingerprints(clusters)).toEqual([]);
+  });
+
+  it('flags a cluster whose stored fingerprint diverges (the silent history-fork hazard)', () => {
+    const good = cluster('c1', 'bug', 'gitsync.pull fails');
+    const bad: PortalCluster = { ...cluster('c2', 'bug', 'telegram relay drops message'), fingerprint: 'STALE_OR_PYTHON_ONLY_VALUE' };
+    const divergences = compareClusterFingerprints([good, bad]);
+    expect(divergences).toHaveLength(1);
+    expect(divergences[0].clusterId).toBe('c2');
+    expect(divergences[0].portal).toBe('STALE_OR_PYTHON_ONLY_VALUE');
+    expect(divergences[0].instar).toBe(clusterFingerprint({ type: 'bug', title: 'telegram relay drops message' }));
+  });
+
+  it('skips clusters with no stored fingerprint (no false positives pre-backfill)', () => {
+    const noFp: PortalCluster = { clusterId: 'c1', type: 'bug', title: 't', fingerprint: '' };
+    expect(compareClusterFingerprints([noFp])).toEqual([]);
+  });
+});
+
+describe('compareClusterOutcomes (invariants 2 & 3)', () => {
+  const base: ClusterOutcome[] = [
+    { fingerprint: 'fp-a', status: 'resolved', recurrenceCount: 0 },
+    { fingerprint: 'fp-b', status: 'investigating', recurrenceCount: 3 },
+  ];
+
+  it('no divergence when status + recurrence match (keyed by fingerprint, not clusterId)', () => {
+    expect(compareClusterOutcomes(base, [...base])).toEqual([]);
+  });
+
+  it('flags a terminal-status divergence', () => {
+    const instar: ClusterOutcome[] = [{ fingerprint: 'fp-a', status: 'investigating', recurrenceCount: 0 }, base[1]];
+    const out = compareClusterOutcomes(instar, base);
+    expect(out).toEqual([{ fingerprint: 'fp-a', kind: 'status', instar: 'investigating', portal: 'resolved' }]);
+  });
+
+  it('flags a recurrence-count divergence', () => {
+    const instar: ClusterOutcome[] = [base[0], { fingerprint: 'fp-b', status: 'investigating', recurrenceCount: 5 }];
+    const out = compareClusterOutcomes(instar, base);
+    expect(out).toEqual([{ fingerprint: 'fp-b', kind: 'recurrence', instar: 5, portal: 3 }]);
+  });
+
+  it('flags clusters present on only one side', () => {
+    const instar: ClusterOutcome[] = [base[0], { fingerprint: 'fp-c', status: 'new', recurrenceCount: 0 }];
+    const portal: ClusterOutcome[] = [base[0], base[1]];
+    const out = compareClusterOutcomes(instar, portal);
+    expect(out).toContainEqual({ fingerprint: 'fp-b', kind: 'missing-instar', portal: 'investigating' });
+    expect(out).toContainEqual({ fingerprint: 'fp-c', kind: 'missing-portal', instar: 'new' });
+  });
+});
+
+describe('compareInvariants (full verdict)', () => {
+  it('divergent=false when all invariants hold', () => {
+    const clusters = [cluster('c1', 'bug', 'gitsync.pull fails')];
+    const outcomes: ClusterOutcome[] = [{ fingerprint: 'fp-a', status: 'resolved', recurrenceCount: 0 }];
+    const r = compareInvariants({ portalClusters: clusters, instarOutcomes: outcomes, portalOutcomes: outcomes });
+    expect(r.divergent).toBe(false);
+    expect(r.clustersCompared).toBe(1);
+    expect(r.outcomesCompared).toBe(1);
+  });
+
+  it('divergent=true on any fingerprint divergence (fingerprint-only pass, no outcomes)', () => {
+    const bad: PortalCluster = { clusterId: 'c1', type: 'bug', title: 't', fingerprint: 'WRONG' };
+    const r = compareInvariants({ portalClusters: [bad] });
+    expect(r.divergent).toBe(true);
+    expect(r.fingerprintDivergences).toHaveLength(1);
+    expect(r.outcomeDivergences).toEqual([]);
+  });
+
+  it('skips outcome comparison when only one outcome list is supplied', () => {
+    const clusters = [cluster('c1', 'bug', 'ok title')];
+    const r = compareInvariants({ portalClusters: clusters, instarOutcomes: [{ fingerprint: 'x', status: 'new', recurrenceCount: 0 }] });
+    expect(r.outcomeDivergences).toEqual([]);
+    expect(r.divergent).toBe(false);
+  });
+});

--- a/tests/unit/feedback-factory/shadow-store.test.ts
+++ b/tests/unit/feedback-factory/shadow-store.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests (Tier 1) — ReadOnlyShadowStore (dry-run write-guard).
+ *
+ * Both-sides-of-boundary: every READ delegates to the wrapped store; every WRITE
+ * throws ShadowStoreWriteError. This is the structural guarantee that the dry-run
+ * processor can never mutate Portal's canonical feedback DB (spec §2.5).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { InMemoryFeedbackStore } from '../../../src/feedback-factory/store/FeedbackStore.js';
+import {
+  ReadOnlyShadowStore,
+  ShadowStoreWriteError,
+} from '../../../src/feedback-factory/store/ReadOnlyShadowStore.js';
+import type { FeedbackItem, Cluster } from '../../../src/feedback-factory/processor/types.js';
+
+const seedFeedback: FeedbackItem[] = [
+  { feedbackId: 'fb-1', title: 'gitsync.pull fails', description: 'pull throws', type: 'bug', receivedAt: '2026-01-01T00:00:00Z' },
+];
+const seedClusters: Cluster[] = [
+  { clusterId: 'cluster-gitsync-pull', title: 'gitsync.pull fails', description: 'pull throws', type: 'bug', status: 'investigating', fingerprint: 'abc123', recurrenceCount: 2 },
+];
+
+function makeStores() {
+  const inner = new InMemoryFeedbackStore({ feedback: seedFeedback, clusters: seedClusters });
+  const shadow = new ReadOnlyShadowStore(inner);
+  return { inner, shadow };
+}
+
+describe('ReadOnlyShadowStore — reads delegate', () => {
+  it('getUnprocessedFeedback returns the wrapped store\'s data', () => {
+    const { inner, shadow } = makeStores();
+    expect(shadow.getUnprocessedFeedback()).toEqual(inner.getUnprocessedFeedback());
+    expect(shadow.getUnprocessedFeedback().map((f) => f.feedbackId)).toEqual(['fb-1']);
+  });
+
+  it('getActiveClusters / getCluster delegate', () => {
+    const { shadow } = makeStores();
+    expect(shadow.getActiveClusters().map((c) => c.clusterId)).toEqual(['cluster-gitsync-pull']);
+    expect(shadow.getCluster('cluster-gitsync-pull')?.fingerprint).toBe('abc123');
+    expect(shadow.getCluster('missing')).toBeUndefined();
+  });
+
+  it('hasFeedback / metrics / listDispatches / findDispatchByTitle delegate', () => {
+    const { shadow } = makeStores();
+    expect(shadow.hasFeedback('fb-1')).toBe(true);
+    expect(shadow.hasFeedback('nope')).toBe(false);
+    expect(shadow.metrics()).toEqual({ captured: 0, created: 0, merged: 0, reopened: 0 });
+    expect(shadow.listDispatches()).toEqual([]);
+    expect(shadow.findDispatchByTitle('anything')).toBeUndefined();
+  });
+});
+
+describe('ReadOnlyShadowStore — writes throw', () => {
+  const item: FeedbackItem = { feedbackId: 'fb-x', title: 't', description: 'd', type: 'bug' };
+
+  it('upsertClusterFromItem throws and does NOT mutate the inner store', () => {
+    const { inner, shadow } = makeStores();
+    expect(() => shadow.upsertClusterFromItem('c', item)).toThrow(ShadowStoreWriteError);
+    // inner store is untouched
+    expect(inner.getActiveClusters()).toHaveLength(1);
+  });
+
+  it('every mutating method throws ShadowStoreWriteError with the method name', () => {
+    const { shadow } = makeStores();
+    const calls: Array<[string, () => void]> = [
+      ['upsertClusterFromItem', () => shadow.upsertClusterFromItem('c', item)],
+      ['mergeIntoCluster', () => shadow.mergeIntoCluster('c', item)],
+      ['applyReopen', () => shadow.applyReopen('c', { newStatus: 'new', bumpRecurrence: false, annotateField: 'researchNotes', noteTag: 'AGED-REOPEN', note: 'n' })],
+      ['markProcessed', () => shadow.markProcessed('fb-1', 'c')],
+      ['addFeedback', () => shadow.addFeedback(item)],
+      ['createDispatch', () => shadow.createDispatch({ dispatchId: 'd', title: 't', type: 'bug', content: 'c' })],
+    ];
+    for (const [method, fn] of calls) {
+      try {
+        fn();
+        throw new Error(`expected ${method} to throw`);
+      } catch (e) {
+        expect(e).toBeInstanceOf(ShadowStoreWriteError);
+        expect((e as ShadowStoreWriteError).method).toBe(method);
+      }
+    }
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -4,25 +4,33 @@
 
 ## What Changed
 
-Notify-on-stop, Layer B: when the Unjustified Stop Gate judges a stop unjustified-but-unblockable (`continue` in shadow mode — the gate wants to keep going but shadow can't block, so the session silently stalls) or ambiguous (`escalate`), and the stopping session is **unattended** (an autonomous run), the user now gets one coalesced plain-English heads-up ("a background run stopped mid-task — want me to pick it back up?"). Previously the gate saw these and could do nothing the user could observe.
+**Notify-on-stop, Layer B.** When the Unjustified Stop Gate judges a stop unjustified-but-unblockable (`continue` in shadow mode — the gate wants to keep going but shadow can't block, so the session silently stalls) or ambiguous (`escalate`), and the stopping session is **unattended** (an autonomous run), the user now gets one coalesced plain-English heads-up ("a background run stopped mid-task — want me to pick it back up?"). Previously the gate saw these and could do nothing the user could observe.
 
-Tightly bounded to stay near-silent: only those two genuinely-stuck decision classes, only unattended sessions, at most once per session per 30 minutes, coalesced onto the single system (lifeline) topic. Routine turn-ends, blocked-and-continued stops, and transient fail-opens stay silent. Default ON (Justin's explicit "tell me why it stopped"); disable with `monitoring.notifyOnStop.enabled=false`.
+Tightly bounded to stay near-silent: only those two genuinely-stuck decision classes, only unattended sessions, at most once per session per 30 minutes, coalesced onto the single system (lifeline) topic. Routine turn-ends, blocked-and-continued stops, and transient fail-opens stay silent. Default ON (Justin's explicit "tell me why it stopped"); disable with `monitoring.notifyOnStop.enabled=false`. Pairs with Layer A (autonomous-run terminal-exit notices).
 
-Pairs with Layer A (autonomous-run terminal-exit notices). Together: a session either keeps going, or the user is told why it stopped.
+**Feedback Factory Migration — dry-run/compare machinery.** Next increment of the migration (spec `docs/specs/feedback-factory-migration.md`, approved). Ships the safety harness that lets the ported Instar processor run safely against Portal's live database during the cutover — without ever being able to change it. Three new internal modules under `src/feedback-factory/`:
+
+- **`store/ReadOnlyShadowStore.ts`** — a read-only wrapper around the feedback data layer. Reads pass through; every write throws. The structural guarantee that the dry-run can never mutate the curated bug history (Portal stays the sole writer through cutover).
+- **`processor/parity.ts`** — the comparator for the three order-independent invariants the migration spec pins: per-cluster fingerprint, terminal status, and recurrence count. Recomputing fingerprints over the live clusters and diffing them is the highest-signal check — it catches any Python↔TypeScript divergence on real production titles.
+- **`dryrun/dryRunCompare.ts`** — the runner: reads the clusters, compares the invariants, writes a JSONL audit trail, and returns a verdict. `divergent === true` is the signal that blocks cutover.
+
+Still internal building blocks — not yet wired into any route or job, so no behavioral change. The live database adapter behind the read-only seam lands once Dawn hands off the read credentials.
 
 ## What to Tell Your User
 
 - If one of my background runs stalls mid-task when it shouldn't have, you now get a single heads-up — even when the watchdog can't restart it itself.
+- On the feedback system: this is the safety harness for moving it in-house. It lets me run my new version *alongside* Dawn's, reading the same live data, and prove they make identical decisions — while making it physically impossible for my version to touch the real records. The comparison is built to ignore harmless ordering differences and only flag *real* disagreements.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
 | Unjustified mid-task stalls on unattended sessions surface one coalesced Telegram | Automatic (default on); `monitoring.notifyOnStop.enabled=false` to disable |
+| Read-only shadow store (write-guard) | Internal `src/feedback-factory/store/ReadOnlyShadowStore.ts` — wraps any `FeedbackStore`; writes throw |
+| Parity invariant comparator | Internal `src/feedback-factory/processor/parity.ts` — `compareInvariants()` |
+| Dry-run/compare runner | Internal `src/feedback-factory/dryrun/dryRunCompare.ts` — `runDryRunCompare(source, opts)` → verdict + JSONL |
 
 ## Evidence
 
-- `src/monitoring/StopNotifier.ts` (decision matrix + attended-gate + dedup); wired via `src/server/routes.ts` (evaluate route), `src/commands/server.ts` (construction), `src/server/AgentServer.ts` (forward).
-- Config: `monitoring.notifyOnStop` in `src/core/types.ts`.
-- Tests: `tests/unit/StopNotifier.test.ts` (21) + `tests/unit/stop-notifier-wiring.test.ts` (6).
-- Spec: `docs/specs/NOTIFY-ON-STOP-SPEC.md` (approved). Side-effects: `upgrades/side-effects/notify-on-stop-layer-b.md`.
+- **Notify-on-stop Layer B:** `src/monitoring/StopNotifier.ts` (decision matrix + attended-gate + dedup); wired via `src/server/routes.ts`, `src/commands/server.ts`, `src/server/AgentServer.ts`. Config: `monitoring.notifyOnStop` in `src/core/types.ts`. Tests: `tests/unit/StopNotifier.test.ts` (21) + `tests/unit/stop-notifier-wiring.test.ts` (6). Spec: `docs/specs/NOTIFY-ON-STOP-SPEC.md`. Side-effects: `upgrades/side-effects/notify-on-stop-layer-b.md`.
+- **Feedback-factory dry-run:** 21 new unit tests across the three modules, all green; full feedback-factory unit dir 128/128 green; `tsc --noEmit` clean. Both-sides-of-boundary: every read delegates AND every write throws (with the offending method name); the comparator asserts no-divergence on matching data plus a real divergence for each invariant; the runner covers the clean path, a divergent corpus, the JSONL audit trail, return-only mode, and the never-mutates-the-source guarantee. Faithful to the reference: per-cluster fingerprint is derived exactly as the Python's `cmd_backfill_fingerprints` (`computeFingerprint(cluster.type, cluster.title)`). Side-effects: `upgrades/side-effects/feedback-factory-dryrun.md`.

--- a/upgrades/side-effects/feedback-factory-dryrun.md
+++ b/upgrades/side-effects/feedback-factory-dryrun.md
@@ -1,0 +1,93 @@
+# Side-effects review — feedback-factory dry-run/compare + ReadOnlyShadowStore
+
+Spec: `docs/specs/feedback-factory-migration.md` (converged v2, approved 2026-05-26).
+Increment: the Phase-1/3 dry-run/compare machinery — `ReadOnlyShadowStore` (write-guard),
+`parity.ts` (invariant comparator), `dryRunCompare.ts` (runner + `ParitySource` seam).
+Purely additive: three new `src/feedback-factory/` files + three new unit test files; zero
+edits to existing code.
+
+## What this ships
+
+The mechanism that lets the ported Instar processor run **read-only against Portal's live
+canonical DB** and have its decisions compared to Portal's, with Portal remaining the sole
+writer through cutover (the one-shared-DB precondition that prevents split-brain). Three
+order-independent invariants per spec §2.3:
+
+1. **Fingerprint (per cluster)** — `computeFingerprint(cluster.type, cluster.title)` recomputed
+   over Portal's live clusters and diffed against the stored value. Pure, no replay, fully
+   order-independent. The highest-signal gate (catches byte-level Python↔JS divergence on real
+   production titles). Faithful to the reference's `cmd_backfill_fingerprints` (:256).
+2. **Terminal status** — keyed by fingerprint, not raw slug clusterId.
+3. **Recurrence/cycling count** — keyed by fingerprint.
+
+`result.divergent === true` is the structural signal that blocks Phase 4 cutover.
+
+## Over-block / under-block
+
+- **ReadOnlyShadowStore**: deliberately over-strict on writes — every one of the 6 mutating
+  methods throws. This is the correct direction: the failure we are guarding against
+  (corrupting Portal's curated bug history) is catastrophic and irreversible, while a false
+  block is a loud, immediate, recoverable error at the seam. No under-block path exists: there
+  is no method that silently no-ops a write.
+- **Fingerprint comparator**: skips clusters with no stored fingerprint (pre-backfill rows) —
+  prevents the false positive of flagging "divergence" against an empty string. It does NOT
+  skip any cluster that *has* a fingerprint, so it cannot under-block a real divergence.
+- **Outcome comparator (status/recurrence)**: treats a fingerprint present on only one side as
+  a divergence (`missing-instar` / `missing-portal`) rather than ignoring it — chosen to
+  surface grouping disagreements rather than hide them. This is the conservative (over-surface)
+  direction, appropriate for a cutover gate.
+
+## Level-of-abstraction fit
+
+- The comparator is **pure** (no I/O) and lives beside the other pure processor logic in
+  `processor/`. The runner owns the I/O (read source + JSONL append) and lives in a new
+  `dryrun/` directory — matching the existing separation (pure decision logic vs. composition).
+- `ParitySource` is the single read-only seam. The Prisma-over-Postgres adapter is the only
+  production implementation and is intentionally NOT built here (credentials-gated — see
+  Deferrals). The interface is the contract Dawn confirmed her adapter slots into.
+- `ReadOnlyShadowStore` wraps the existing `FeedbackStore` interface rather than inventing a
+  new one — it is a faithful decorator, so any present or future `FeedbackStore` consumer can
+  be made read-only without changes.
+
+## Signal-vs-authority compliance
+
+This increment is **signal-only**, not authority. It produces a verdict (`divergent`) and a
+JSONL audit trail; it takes no action — no cutover, no migration, no messaging, no mutation.
+The authority to advance Phase 4 remains with the operator + Dawn's line-by-line review. This
+matches the Instar separation: a brittle/automated comparator detects and emits; a
+higher-context human/gate decides. The runner cannot itself flip any switch.
+
+## Interactions
+
+- **Portal's canonical DB**: read-only by construction (ShadowStore guard + read-only
+  `ParitySource`). The runner only ever reads + appends to a *local* JSONL log. No write path
+  to Portal exists in this code.
+- **The ported processor (`process.ts` → `processUnprocessed`)**: the runner does NOT call it
+  (it would write). The comparator uses only the pure functions. The ShadowStore guard is the
+  backstop if a future caller wires `processUnprocessed` against a shadow store by mistake —
+  it throws at the first write instead of corrupting data.
+- **Existing feedback-factory tests**: unaffected (additive change; full unit dir green —
+  128 tests including the 21 new).
+- **No config, hook, route, template, or migration surface is touched** — so no Migration
+  Parity / Agent Awareness obligation is triggered by *this* increment (those land with the
+  receiver/dispatch wiring + observability increments, which DO touch routes/templates).
+
+## Rollback cost
+
+Trivial and isolated. Three new `src/` files + three new test files, no edits elsewhere,
+nothing wired into server startup or routes yet. Reverting the commit removes the files with
+zero downstream impact — nothing imports them in production paths. No data migration, no
+state, no deployed surface.
+
+## Deferrals
+
+- The **Prisma-over-Postgres `ParitySource` adapter** is not built in this increment.
+  Reason: it requires Dawn's read-only Postgres credentials + `prisma db pull` against the live
+  schema (a genuine external dependency, not avoidable work). The `ParitySource` interface +
+  `InMemoryParitySource` make the runner fully buildable and testable now; the live adapter
+  slots in behind the interface the moment credentials land. <!-- tracked: topic-12476 -->
+- **Auto-derivation of Instar's status/recurrence outcomes (invariants 2 & 3) from a
+  point-in-time read** is not built. Reason: a faithful replay needs window-START cluster state,
+  which a current-state read cannot supply; the outcomes must come from a snapshot / full-history
+  export. The comparator + runner accept those outcome lists as inputs today, so the path is
+  complete pending the data source. <!-- tracked: topic-12476 -->


### PR DESCRIPTION
## Summary

Next increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, converged v2, approved 2026-05-26). Ships the **dry-run/compare machinery** that lets the ported Instar processor run read-only against Portal's live canonical DB and compare its decisions to Portal's over the spec's three order-independent invariants — with Portal as the sole writer through cutover.

- **`store/ReadOnlyShadowStore.ts`** — `FeedbackStore` decorator: reads delegate, every one of the 6 write methods throws `ShadowStoreWriteError`. The structural guarantee the dry-run can never mutate Portal's curated bug history (the one-shared-DB / split-brain-prevention precondition).
- **`processor/parity.ts`** — pure comparator for the three invariants (spec §2.3): per-cluster **fingerprint** (recomputed over live clusters, no replay — faithful to the reference's `cmd_backfill_fingerprints`), terminal **status**, **recurrence** count. Keyed by fingerprint, not raw slug clusterId, so benign ordering noise can't trip it.
- **`dryrun/dryRunCompare.ts`** — runner + `ParitySource` read-only seam; emits a JSONL audit trail; `result.divergent` is the structural signal that blocks Phase 4 cutover.

Additive only — three new `src/feedback-factory/` modules + three test files, **zero edits to existing code**, not yet wired into routes/jobs.

### Deferred behind the seam (tracked, topic 12476)
- The **Prisma-over-Postgres `ParitySource` adapter** — needs Dawn's read-only Postgres credentials + `prisma db pull` against the live schema. The `ParitySource` interface + `InMemoryParitySource` make everything buildable/testable now; the live adapter slots in behind the interface when credentials land.
- **Auto-deriving Instar's status/recurrence outcomes from a point-in-time read** — a faithful replay needs window-START cluster state (snapshot / full-history export), so the runner accepts those outcome lists as inputs today.

## Test plan

- [x] 21 new unit tests across the three modules, all green
- [x] Full feedback-factory unit dir 128/128 green
- [x] `tsc --noEmit` clean
- [x] Both-sides-of-boundary: every read delegates AND every write throws; no-divergence vs a real divergence for each invariant; runner clean path + divergent corpus + JSONL contents + never-mutates-source
- [x] `/instar-dev` gate passed (trace + side-effects artifact + approved spec chain)
- [x] pre-push smoke passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)