### PR TITLE
feat(monitoring): notify-on-stop Layer B — gate-fed unjustified-stall heads-up

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7508,6 +7508,48 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.green(`  Unjustified Stop Gate: ${activeMode}${unjustifiedStopGate && stopGateDb ? ' (authority + SQLite wired)' : ' (degraded, fail-open)'}`));
     }
 
+    // notify-on-stop Layer B — surface a genuinely-stuck UNATTENDED stop to the
+    // user (docs/specs/NOTIFY-ON-STOP-SPEC.md). The evaluate route feeds each
+    // decision to StopNotifier, which filters to the notify-worthy classes
+    // (shadow+continue / escalate), the attended-gate, and per-session dedup,
+    // then hands a coalesced one-liner to a dedicated SentinelNotifier sink
+    // (single lifeline topic, log-always — reuses the post-2026-05-22 discipline).
+    // Default ON (Justin's "tell me why it stopped"); requires telegram wired.
+    let stopNotifier: import('../monitoring/StopNotifier.js').StopNotifier | null = null;
+    {
+      const nosCfg = config.monitoring?.notifyOnStop ?? {};
+      const nosEnabled = nosCfg.enabled !== false; // default true
+      const localTg = telegram;
+      if (nosEnabled && localTg) {
+        const stopLogPath = path.join(config.stateDir, '..', 'logs', 'sentinel-events.jsonl');
+        const stopLog = (entry: { kind: string; sessionName: string; detail?: string }): void => {
+          try { fs.appendFileSync(stopLogPath, JSON.stringify({ ...entry, sentinel: 'stop-notify', ts: new Date().toISOString() }) + '\n'); } catch { /* best-effort */ }
+        };
+        const send = async (text: string): Promise<boolean> => {
+          const topicId = localTg.getLifelineTopicId();
+          if (!topicId) return false;
+          try { await localTg.sendToTopic(topicId, text); return true; } catch { return false; }
+        };
+        const { SentinelNotifier } = await import('../monitoring/SentinelNotifier.js');
+        const stopSink = new SentinelNotifier(
+          { log: stopLog, sendConsolidated: send },
+          { telegramEscalation: true }, // notify-on-stop is default-on by design
+        );
+        const { StopNotifier } = await import('../monitoring/StopNotifier.js');
+        stopNotifier = new StopNotifier(
+          { escalate: (name, text) => stopSink.escalate('stop-gate', name, text) },
+          {
+            enabled: true,
+            unattendedOnly: nosCfg.unattendedOnly !== false,
+            ...(typeof nosCfg.cooldownMs === 'number' ? { cooldownMs: nosCfg.cooldownMs } : {}),
+          },
+        );
+        console.log(pc.green('  notify-on-stop Layer B: enabled (unjustified-stall heads-up — unattended-only, deduped, coalesced)'));
+      } else {
+        console.log(pc.dim(`  notify-on-stop Layer B: ${nosEnabled ? 'idle (no telegram)' : 'disabled by config'}`));
+      }
+    }
+
     // Response Review Pipeline (Coherence Gate) — evaluates agent responses before delivery.
     // Prefers the shared IntelligenceProvider (subscription-compatible) so the gate works
     // even without ANTHROPIC_API_KEY. Falls back to direct Anthropic API if a key is set
@@ -8049,7 +8091,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       ));
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb, stopNotifier });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2735,6 +2735,22 @@ export interface MonitoringConfig {
    * 2026-05-22 topic-spam flood. See docs/specs/silently-stopped-trio.md.
    */
   sentinelTelegramEscalation?: boolean;
+  /**
+   * notify-on-stop Layer B (docs/specs/NOTIFY-ON-STOP-SPEC.md). When the
+   * UnjustifiedStopGate (shadow/enforce) judges a stop unjustified-but-unblockable
+   * (`continue` in shadow) or ambiguous (`escalate`) for an UNATTENDED session,
+   * send the user one coalesced heads-up. Default enabled (Justin's explicit
+   * "tell me why it stopped"); attended-gate + per-session dedup keep it
+   * near-silent. Distinct from sentinelTelegramEscalation (housekeeping, default-off).
+   */
+  notifyOnStop?: {
+    /** Master gate. Default true. */
+    enabled?: boolean;
+    /** Only notify unattended (autonomous) sessions. Default true. */
+    unattendedOnly?: boolean;
+    /** Per-session dedup window (ms). Default 1800000 (30 min). */
+    cooldownMs?: number;
+  };
   /** LLM-powered stall triage nurse — intelligent session recovery */
   triage?: {
     enabled: boolean;

--- a/src/monitoring/StopNotifier.ts
+++ b/src/monitoring/StopNotifier.ts
@@ -1,0 +1,149 @@
+/**
+ * StopNotifier — Layer B of notify-on-stop (docs/specs/NOTIFY-ON-STOP-SPEC.md,
+ * Task 2 of the 2026-05-27 silent-stalls postmortem).
+ *
+ * The UnjustifiedStopGate evaluate route classifies every Stop. In `shadow`
+ * mode the gate can judge a stop unjustified (decision `continue`) but CANNOT
+ * block it — so the session goes silent anyway. And an `escalate` decision means
+ * the gate couldn't even tell. Either way, an UNATTENDED session can stall
+ * mid-task and the user never hears about it. StopNotifier turns those specific
+ * classifications into ONE plain-English heads-up.
+ *
+ * It is a thin DECISION layer; delivery discipline (coalescing into one message,
+ * the single system/lifeline topic, log-always) is reused from SentinelNotifier
+ * via the injected `escalate` sink — StopNotifier never invents a second
+ * notification path (post-2026-05-22 topic-spam fix).
+ *
+ * Signal-vs-authority: the Stop-hook router is a dumb thin client; the decision
+ * about whether to ALARM the user lives here on the server, where the gate
+ * decision, the session's attended-state, and the dedup ledger all exist.
+ *
+ * Spam controls (all enforced here):
+ *   1. notify-worthy decision set ONLY (shadow+continue, or escalate).
+ *   2. attended-gate — by default, only UNATTENDED (autonomous) sessions; an
+ *      interactive session with the user present doesn't need a ping.
+ *   3. per-session dedup — at most one notice per session per cooldown window.
+ *   4. master enable flag (default ON — Justin explicitly asked to be told when
+ *      a session stops; the gates above keep it near-silent in practice).
+ */
+
+export type StopGateMode = 'off' | 'shadow' | 'enforce';
+export type StopGateDecision = 'continue' | 'allow' | 'escalate' | 'force_allow' | null;
+
+export type StopNotifyOutcome =
+  | 'sent'
+  | 'disabled'
+  | 'not-worthy'
+  | 'skipped-attended'
+  | 'skipped-dedup';
+
+export interface StopNotifierConfig {
+  /** Master gate. Default true (Justin's explicit "tell me why it stopped"). */
+  enabled?: boolean;
+  /** Only notify for unattended (autonomous) sessions. Default true. */
+  unattendedOnly?: boolean;
+  /** Per-session dedup window in ms. Default 30 min. */
+  cooldownMs?: number;
+}
+
+export interface StopNotifierDeps {
+  /**
+   * Delegated delivery — coalesced, single system topic, log-always. Wired in
+   * server.ts to a SentinelNotifier.escalate bound to the stop-notify channel.
+   * Synchronous fire-and-forget (SentinelNotifier batches + sends async).
+   */
+  escalate: (sessionName: string, text: string) => void;
+  now?: () => number;
+}
+
+export interface MaybeNotifyInput {
+  sessionId: string;
+  mode: StopGateMode;
+  decision: StopGateDecision;
+  /** Whether the stopping session is an autonomous (unattended) run. */
+  autonomousActive: boolean;
+  /** Optional short, already-sanitized context for the message (no raw logs). */
+  detail?: string;
+}
+
+const DEFAULTS: Required<StopNotifierConfig> = {
+  enabled: true,
+  unattendedOnly: true,
+  cooldownMs: 30 * 60_000,
+};
+
+/**
+ * True for the stop classifications that mean "an unjustified/ambiguous stop the
+ * user should hear about". Deliberately narrow:
+ *   - shadow + `continue`: gate believes the stop was unjustified but can't block
+ *     it (shadow) → the silent stall. THE core incident case.
+ *   - `escalate`: gate couldn't determine justification → surface it.
+ * Everything else stays silent: `allow` (routine/legit completion or awaiting
+ * user), `continue` in ENFORCE (the session is blocked & continues — not
+ * stopping), `force_allow` (continue-ceiling; operator already has the stuck
+ * flag), and the fail-open/null cases (transient; DegradationReporter covers).
+ */
+export function isNotifyWorthyStop(mode: StopGateMode, decision: StopGateDecision): boolean {
+  if (decision === 'escalate') return true;
+  if (decision === 'continue' && mode === 'shadow') return true;
+  return false;
+}
+
+export class StopNotifier {
+  private readonly cfg: Required<StopNotifierConfig>;
+  private readonly lastNotified = new Map<string, number>();
+
+  constructor(
+    private readonly deps: StopNotifierDeps,
+    cfg: StopNotifierConfig = {},
+  ) {
+    this.cfg = { ...DEFAULTS, ...cfg };
+  }
+
+  get enabled(): boolean {
+    return this.cfg.enabled === true;
+  }
+
+  /**
+   * Evaluate a stop-gate decision and, if it is a notify-worthy unattended
+   * stall not seen recently, hand a fixed-template heads-up to the delegated
+   * sink. Pure-ish: returns the outcome for tests; the only side effect is the
+   * (coalesced, log-always) escalate call. Never throws.
+   */
+  maybeNotify(input: MaybeNotifyInput): StopNotifyOutcome {
+    if (!this.enabled) return 'disabled';
+    if (!isNotifyWorthyStop(input.mode, input.decision)) return 'not-worthy';
+    if (this.cfg.unattendedOnly && !input.autonomousActive) return 'skipped-attended';
+
+    const now = (this.deps.now ?? Date.now)();
+    const last = this.lastNotified.get(input.sessionId);
+    if (last !== undefined && now - last < this.cfg.cooldownMs) return 'skipped-dedup';
+    this.lastNotified.set(input.sessionId, now);
+
+    try {
+      this.deps.escalate(this.sessionName(input.sessionId), this.composeMessage(input));
+    } catch {
+      // Delivery is best-effort; a sink failure must never disturb the route.
+    }
+    return 'sent';
+  }
+
+  private sessionName(sessionId: string): string {
+    // SentinelNotifier.friendly() trims platform prefixes; pass the id through.
+    return sessionId || 'a background session';
+  }
+
+  private composeMessage(input: MaybeNotifyInput): string {
+    const why =
+      input.decision === 'escalate'
+        ? "stopped mid-task and I couldn't confirm it was a justified place to stop"
+        : 'stopped mid-task when it looked like there was still work to do';
+    const detail = input.detail ? `\n\n${input.detail}` : '';
+    return `A background run ${why}. Want me to pick it back up?${detail}`;
+  }
+
+  /** Test seam. */
+  _resetForTests(): void {
+    this.lastNotified.clear();
+  }
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -218,6 +218,8 @@ export class AgentServer {
     unjustifiedStopGate?: import('../core/UnjustifiedStopGate.js').UnjustifiedStopGate;
     /** Stop-gate SQLite persistence (PR3). */
     stopGateDb?: import('../core/StopGateDb.js').StopGateDb;
+    /** notify-on-stop Layer B — surfaces genuinely-stuck unattended stops. */
+    stopNotifier?: import('../monitoring/StopNotifier.js').StopNotifier | null;
     /** Initiative tracker — persisted record of multi-phase long-running work. */
     initiativeTracker?: import('../core/InitiativeTracker.js').InitiativeTracker;
     /** Project-scope round runner (Phase 1b PR 3). */
@@ -590,6 +592,7 @@ export class AgentServer {
       ledgerSessionRegistry: options.ledgerSessionRegistry ?? null,
       unjustifiedStopGate: options.unjustifiedStopGate ?? null,
       stopGateDb: options.stopGateDb ?? null,
+      stopNotifier: options.stopNotifier ?? null,
       initiativeTracker: options.initiativeTracker ?? null,
       projectRoundRunner: options.projectRoundRunner ?? null,
       projectDriftChecker: options.projectDriftChecker ?? null,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -660,6 +660,10 @@ export interface RouteContext {
    *  the evaluate route will still produce a response, just without
    *  persistence. */
   stopGateDb: StopGateDb | null;
+  /** notify-on-stop Layer B — surfaces a genuinely-stuck unattended stop to the
+   *  user (coalesced via SentinelNotifier). Null when telegram isn't wired; the
+   *  evaluate route simply skips the notice. */
+  stopNotifier: import('../monitoring/StopNotifier.js').StopNotifier | null;
   /** Token-usage ledger (read-only observability over Claude Code JSONL
    *  transcripts). Null when stateDir is unavailable. */
   tokenLedger: import('../monitoring/TokenLedger.js').TokenLedger | null;
@@ -1640,6 +1644,10 @@ export function createRoutes(ctx: RouteContext): Router {
     const eventId = cryptoRandomUUID();
     const ts = Date.now();
     const reasonPreview = (body.untrustedContent.stopReason ?? '').slice(0, 200);
+    // notify-on-stop Layer B: whether the stopping session is unattended
+    // (autonomous). Used only to gate the user-facing notice (StopNotifier);
+    // never affects the gate decision itself.
+    const autonomousActive = getHotPathState({ sessionId: sessionId || undefined }).autonomousActive;
 
     // Kill-switch or mode=off: short-circuit to allow, no authority
     // call, no event logged (caller already knows not to call us here,
@@ -1819,6 +1827,15 @@ export function createRoutes(ctx: RouteContext): Router {
         rule: r.rule,
         reminder,
         latencyMs: r.latencyMs,
+      });
+      // notify-on-stop Layer B: surface a genuinely-stuck unattended stop to the
+      // user. No-ops for non-worthy decisions, attended sessions, and recent
+      // dups — see StopNotifier. Fire-and-forget; never affects the response.
+      ctx.stopNotifier?.maybeNotify({
+        sessionId,
+        mode,
+        decision: r.decision,
+        autonomousActive,
       });
     } else {
       // Fail-open: allow. Log with the failure kind so guardian-pulse

--- a/tests/unit/StopNotifier.test.ts
+++ b/tests/unit/StopNotifier.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for StopNotifier — Layer B of notify-on-stop
+ * (docs/specs/NOTIFY-ON-STOP-SPEC.md, Task 2 of the silent-stalls postmortem).
+ *
+ * Covers both sides of every decision boundary (Testing Integrity Standard):
+ * the notify-worthy classifications, every NOT-worthy classification, the
+ * attended-gate, per-session dedup/cooldown, and the master enable flag.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  StopNotifier,
+  isNotifyWorthyStop,
+  type StopGateMode,
+  type StopGateDecision,
+} from '../../src/monitoring/StopNotifier.js';
+
+function makeNotifier(cfg = {}, now = () => 1_000_000) {
+  const sent: Array<{ name: string; text: string }> = [];
+  const notifier = new StopNotifier({ escalate: (name, text) => sent.push({ name, text }), now }, cfg);
+  return { notifier, sent };
+}
+
+describe('isNotifyWorthyStop — the decision matrix (both sides)', () => {
+  const worthy: Array<[StopGateMode, StopGateDecision]> = [
+    ['shadow', 'continue'], // gate wanted to continue but can't block in shadow → silent stall
+    ['shadow', 'escalate'],
+    ['enforce', 'escalate'],
+  ];
+  const notWorthy: Array<[StopGateMode, StopGateDecision]> = [
+    ['enforce', 'continue'], // blocked & continues — not a stop
+    ['shadow', 'allow'],
+    ['enforce', 'allow'],
+    ['shadow', 'force_allow'],
+    ['shadow', null], // fail-open / transient
+    ['off', 'continue'],
+    ['off', 'escalate'], // off shouldn't even call us, but be safe — escalate is worthy regardless of mode
+  ];
+
+  for (const [mode, decision] of worthy) {
+    it(`WORTHY: mode=${mode} decision=${decision}`, () => {
+      expect(isNotifyWorthyStop(mode, decision)).toBe(true);
+    });
+  }
+  // 'escalate' is worthy in any mode by design; the off+escalate case is worthy.
+  it("escalate is worthy regardless of mode (including 'off')", () => {
+    expect(isNotifyWorthyStop('off', 'escalate')).toBe(true);
+  });
+  for (const [mode, decision] of notWorthy.filter(([, d]) => d !== 'escalate')) {
+    it(`NOT worthy: mode=${mode} decision=${decision}`, () => {
+      expect(isNotifyWorthyStop(mode, decision)).toBe(false);
+    });
+  }
+});
+
+describe('StopNotifier.maybeNotify', () => {
+  it('sends for a shadow+continue unattended stop', () => {
+    const { notifier, sent } = makeNotifier();
+    const outcome = notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'continue', autonomousActive: true });
+    expect(outcome).toBe('sent');
+    expect(sent).toHaveLength(1);
+    expect(sent[0].name).toBe('s1');
+    expect(sent[0].text).toMatch(/background run/i);
+  });
+
+  it('sends for an escalate unattended stop', () => {
+    const { notifier, sent } = makeNotifier();
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'escalate', autonomousActive: true })).toBe('sent');
+    expect(sent[0].text).toMatch(/couldn't confirm/i);
+  });
+
+  it('does NOT send for a routine allow', () => {
+    const { notifier, sent } = makeNotifier();
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'allow', autonomousActive: true })).toBe('not-worthy');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('does NOT send for continue in enforce (session is blocked & continues)', () => {
+    const { notifier, sent } = makeNotifier();
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'enforce', decision: 'continue', autonomousActive: true })).toBe('not-worthy');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('attended-gate: skips an attended (non-autonomous) session by default', () => {
+    const { notifier, sent } = makeNotifier();
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'continue', autonomousActive: false })).toBe('skipped-attended');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('attended-gate off: notifies an attended session when unattendedOnly=false', () => {
+    const { notifier, sent } = makeNotifier({ unattendedOnly: false });
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'continue', autonomousActive: false })).toBe('sent');
+    expect(sent).toHaveLength(1);
+  });
+
+  it('per-session dedup: a second worthy stop within the cooldown is suppressed', () => {
+    let t = 1_000_000;
+    const { notifier, sent } = makeNotifier({ cooldownMs: 1000 }, () => t);
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'continue', autonomousActive: true })).toBe('sent');
+    t += 500;
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'escalate', autonomousActive: true })).toBe('skipped-dedup');
+    expect(sent).toHaveLength(1);
+  });
+
+  it('dedup expires after the cooldown window', () => {
+    let t = 1_000_000;
+    const { notifier, sent } = makeNotifier({ cooldownMs: 1000 }, () => t);
+    notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'continue', autonomousActive: true });
+    t += 1500;
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'continue', autonomousActive: true })).toBe('sent');
+    expect(sent).toHaveLength(2);
+  });
+
+  it('dedup is per-session — a different session still notifies', () => {
+    const { notifier, sent } = makeNotifier({ cooldownMs: 999999 });
+    notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'continue', autonomousActive: true });
+    expect(notifier.maybeNotify({ sessionId: 's2', mode: 'shadow', decision: 'continue', autonomousActive: true })).toBe('sent');
+    expect(sent).toHaveLength(2);
+  });
+
+  it('master disable: never sends when enabled=false', () => {
+    const { notifier, sent } = makeNotifier({ enabled: false });
+    expect(notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'continue', autonomousActive: true })).toBe('disabled');
+    expect(sent).toHaveLength(0);
+  });
+
+  it('a throwing escalate sink never propagates (best-effort)', () => {
+    const notifier = new StopNotifier({ escalate: () => { throw new Error('sink down'); }, now: () => 1 }, {});
+    expect(() => notifier.maybeNotify({ sessionId: 's1', mode: 'shadow', decision: 'escalate', autonomousActive: true })).not.toThrow();
+  });
+});

--- a/tests/unit/stop-notifier-wiring.test.ts
+++ b/tests/unit/stop-notifier-wiring.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Wiring-integrity test for notify-on-stop Layer B (StopNotifier).
+ *
+ * Guards the exact failure mode from PR #334 (sentinels shipped as dead code
+ * with a false "wired" claim): a component that exists but is never constructed
+ * or never called. Asserts the full chain is connected —
+ *   evaluate route → ctx.stopNotifier.maybeNotify → server.ts constructs it →
+ *   AgentServer forwards it to the routes ctx.
+ *
+ * The decision logic itself is covered by StopNotifier.test.ts; the live
+ * route-fires-notifier end-to-end is verified by test-as-self before merge.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(REPO, rel), 'utf8');
+
+describe('notify-on-stop Layer B — wiring integrity', () => {
+  it('the evaluate route feeds each decision to ctx.stopNotifier.maybeNotify', () => {
+    const src = read('src/server/routes.ts');
+    expect(src).toMatch(/ctx\.stopNotifier\?\.maybeNotify\(\{/);
+    // and passes the real decision + mode + attended-state
+    const call = src.slice(src.indexOf('ctx.stopNotifier?.maybeNotify(')).slice(0, 220);
+    expect(call).toContain('mode');
+    expect(call).toContain('decision: r.decision');
+    expect(call).toContain('autonomousActive');
+  });
+
+  it('the routes ctx declares a stopNotifier field', () => {
+    expect(read('src/server/routes.ts')).toMatch(/stopNotifier:\s*import\([^)]*StopNotifier[^)]*\)\.StopNotifier\s*\|\s*null/);
+  });
+
+  it('server.ts constructs a StopNotifier and passes it into AgentServer', () => {
+    const src = read('src/commands/server.ts');
+    expect(src).toMatch(/new StopNotifier\(/);
+    expect(src).toMatch(/unjustifiedStopGate, stopGateDb, stopNotifier \}/);
+  });
+
+  it('AgentServer accepts stopNotifier and forwards it to the routes ctx', () => {
+    const src = read('src/server/AgentServer.ts');
+    expect(src).toMatch(/stopNotifier\?:/);
+    expect(src).toMatch(/stopNotifier:\s*options\.stopNotifier\s*\?\?\s*null/);
+  });
+
+  it('the StopNotifier sink is a SentinelNotifier with escalation ON (coalesced single-topic reuse)', () => {
+    const src = read('src/commands/server.ts');
+    // The dedicated stop-notify sink is default-on (distinct from the
+    // housekeeping sentinel notifier, which is default-off).
+    const block = src.slice(src.indexOf('notify-on-stop Layer B'));
+    expect(block).toMatch(/new SentinelNotifier\(/);
+    expect(block).toMatch(/telegramEscalation: true/);
+    expect(block).toMatch(/stopSink\.escalate\(/);
+  });
+
+  it('Layer B respects the config master gate (enabled !== false default-on)', () => {
+    const src = read('src/commands/server.ts');
+    const block = src.slice(src.indexOf('notify-on-stop Layer B'));
+    expect(block).toMatch(/notifyOnStop/);
+    expect(block).toMatch(/enabled !== false/);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -8,7 +8,7 @@ Notify-on-stop, Layer B: when the Unjustified Stop Gate judges a stop unjustifie
 
 Tightly bounded to stay near-silent: only those two genuinely-stuck decision classes, only unattended sessions, at most once per session per 30 minutes, coalesced onto the single system (lifeline) topic. Routine turn-ends, blocked-and-continued stops, and transient fail-opens stay silent. Default ON (Justin's explicit "tell me why it stopped"); disable with `monitoring.notifyOnStop.enabled=false`.
 
-Pairs with Layer A (autonomous-run terminal-exit notices, shipped in #437). Together: a session either keeps going, or the user is told why it stopped.
+Pairs with Layer A (autonomous-run terminal-exit notices). Together: a session either keeps going, or the user is told why it stopped.
 
 ## What to Tell Your User
 
@@ -24,5 +24,5 @@ Pairs with Layer A (autonomous-run terminal-exit notices, shipped in #437). Toge
 
 - `src/monitoring/StopNotifier.ts` (decision matrix + attended-gate + dedup); wired via `src/server/routes.ts` (evaluate route), `src/commands/server.ts` (construction), `src/server/AgentServer.ts` (forward).
 - Config: `monitoring.notifyOnStop` in `src/core/types.ts`.
-- Tests: `tests/unit/StopNotifier.test.ts` (21 — both sides of every decision boundary, gates, dedup) + `tests/unit/stop-notifier-wiring.test.ts` (6 — no dead code).
+- Tests: `tests/unit/StopNotifier.test.ts` (21) + `tests/unit/stop-notifier-wiring.test.ts` (6).
 - Spec: `docs/specs/NOTIFY-ON-STOP-SPEC.md` (approved). Side-effects: `upgrades/side-effects/notify-on-stop-layer-b.md`.

--- a/upgrades/side-effects/notify-on-stop-layer-b.md
+++ b/upgrades/side-effects/notify-on-stop-layer-b.md
@@ -1,0 +1,34 @@
+# Side-Effects Review — Notify-on-Stop, Layer B (gate-fed unjustified-stall notice)
+
+**Spec:** docs/specs/NOTIFY-ON-STOP-SPEC.md (approved: true) — Layer B of two. Layer A (autonomous-run-ended notice) shipped in a prior PR.
+
+When the UnjustifiedStopGate (shadow/enforce) classifies a stop as unjustified-but-unblockable (`continue` in `shadow` — the gate wants to continue but shadow can't block, so the session silently stalls) or ambiguous (`escalate`), an UNATTENDED session can go quiet mid-task and the user never hears about it. Layer B turns those specific classifications into ONE coalesced heads-up.
+
+## What changed
+- `src/monitoring/StopNotifier.ts` (new) — thin DECISION layer: `isNotifyWorthyStop` (shadow+continue OR escalate; everything else silent) + attended-gate (unattended/autonomous only, default) + per-session dedup (30-min cooldown) + master enable (default ON). Delivery is delegated to an injected `escalate` sink.
+- `src/commands/server.ts` — constructs a dedicated `SentinelNotifier` (telegramEscalation **on** — distinct from the housekeeping sentinel notifier, which stays default-off) reusing the lifeline-topic `sendConsolidated` transport + a JSONL log; wraps it in a `StopNotifier`. Null when telegram isn't wired or config disables it.
+- `src/server/routes.ts` — the `/internal/stop-gate/evaluate` route computes `autonomousActive` (via `getHotPathState`) and, after the authority decision, calls `ctx.stopNotifier?.maybeNotify({ sessionId, mode, decision, autonomousActive })`. Fire-and-forget; never affects the gate decision or the HTTP response.
+- `src/server/AgentServer.ts` — accepts + forwards `stopNotifier` to the routes ctx.
+- `src/core/types.ts` — `monitoring.notifyOnStop?: { enabled?, unattendedOnly?, cooldownMs? }`.
+- Tests: `StopNotifier.test.ts` (21 — both sides of every decision boundary, attended-gate, dedup window/expiry/per-session, master gate, throwing-sink safety) + `stop-notifier-wiring.test.ts` (6 — route→notifier→sink→server→AgentServer chain, guards the PR#334 dead-code failure mode).
+
+## Signal vs authority
+The Stop-hook router is a dumb thin client; the decision to ALARM the user lives server-side in StopNotifier, where the gate decision + attended-state + dedup ledger all exist. StopNotifier adds NO blocking authority — it's a delivery decision only. It never changes the gate's `decision`.
+
+## Near-silent compliance
+Default-on is the deliberate exception Justin explicitly asked for ("tell me why it stopped"), and it is tightly bounded: only two genuinely-stuck decision classes, only unattended sessions, at most once per session per 30 min, coalesced into one message on the single lifeline topic. Routine turn-ends (`allow`), blocked-and-continued (`continue` in enforce), continue-ceiling (`force_allow`), and fail-open are all silent. A single config flag (`monitoring.notifyOnStop.enabled=false`) kills it with no redeploy.
+
+## Over/under-notify
+- OVER: a shadow-mode `continue` could occasionally be a gate misjudgment (the CONTINUE_CEILING exists because the authority can be wrong). Mitigated by attended-gate + 30-min dedup; the alternative (a silent autonomous stall) is exactly what Justin wants eliminated.
+- UNDER: when the gate is `off` (no evaluate call) there's no Layer B notice — but Layer A still covers autonomous terminal exits, and the gate runs in `shadow` on real agents.
+
+## Migration parity
+Default-on works WITHOUT any config key present (`enabled !== false` ⇒ true when undefined), so existing agents get it on update to this version with no migrateConfig step. The wiring is server-side; no agent-installed-file change.
+
+## Rollback
+`monitoring.notifyOnStop.enabled=false` (instant, no redeploy) or revert the 6 files + 2 tests.
+
+## Tests / verification
+- Tier 1 unit: StopNotifier.test.ts (decision matrix both sides + gates).
+- Wiring-integrity: stop-notifier-wiring.test.ts (no dead code).
+- Tier 3 live: test-as-self before merge — drive a synthetic shadow+continue on an autonomous session through the real route and confirm the lifeline-topic heads-up fires once (and a routine `allow` stays silent).


### PR DESCRIPTION
## Problem

When the Unjustified Stop Gate (shadow/enforce) judges a stop **unjustified-but-unblockable** (`continue` in `shadow` — the gate wants to keep going but shadow can't block, so the session silently stalls) or **ambiguous** (`escalate`), an **unattended** session can go quiet mid-task and the user never hears about it. Layer A covers autonomous *terminal* exits; this covers the *mid-task* stall the watchdog catches but can't fix.

## Fix (Layer B of the notify-on-stop spec)
- `src/monitoring/StopNotifier.ts` — thin DECISION layer: `isNotifyWorthyStop` (shadow+continue OR escalate; everything else silent) + attended-gate (unattended/autonomous only, default) + per-session 30-min dedup + master enable (default ON).
- Delivery delegated to a dedicated `SentinelNotifier` sink (`telegramEscalation` **on**, single lifeline topic, coalesced, log-always) — reuses the post-2026-05-22 anti-topic-spam discipline; adds **no** blocking authority.
- Wired: the `/internal/stop-gate/evaluate` route feeds each decision to `ctx.stopNotifier?.maybeNotify(...)` (server decides whether to alarm — the Stop-hook router stays dumb; signal-vs-authority). `server.ts` constructs it; `AgentServer` forwards it to ctx. New `monitoring.notifyOnStop` config.
- **Default-on works with no config key present** → existing agents get it on update with no migrateConfig step. `monitoring.notifyOnStop.enabled=false` disables instantly.

## Near-silent
Default-on is the deliberate exception Justin asked for, tightly bounded: two genuinely-stuck decision classes only, unattended only, once per session per 30 min, coalesced on one topic. `allow` / `continue`-in-enforce / `force_allow` / fail-open all stay silent.

## Tests
- `tests/unit/StopNotifier.test.ts` (21) — both sides of every decision boundary, attended-gate, dedup window/expiry/per-session, master gate, throwing-sink safety.
- `tests/unit/stop-notifier-wiring.test.ts` (6) — route→notifier→sink→server→AgentServer chain (guards the PR#334 dead-code failure mode).
- Live route-fires-notifier verified via test-as-self before merge.

Spec: `docs/specs/NOTIFY-ON-STOP-SPEC.md` (approved, merged with Layer A in #437) · ELI16 + side-effects included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
