### PR TITLE
feat(messaging): TelegramAdapter multi-instance isolation + sender-identity (PR 2a/3)

### DIFF
--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -114,7 +114,11 @@ interface TelegramUpdate {
   update_id: number;
   message?: {
     message_id: number;
-    from: { id: number; first_name: string; username?: string };
+    // `is_bot` distinguishes a bot-sent message from a human user typing the same text —
+    // the structural half of the a2a spoof defense (a human typing an [a2a:…] marker has
+    // is_bot:false). `sender_chat` is present for group bot-as-channel relays.
+    from: { id: number; first_name: string; username?: string; is_bot?: boolean };
+    sender_chat?: { id: number; type?: string; username?: string };
     chat: { id: number };
     message_thread_id?: number;
     text?: string;
@@ -327,6 +331,14 @@ export class TelegramAdapter implements MessagingAdapter {
   private messageLogPath: string;
   private offsetPath: string;
   private stateDir: string;
+  /** Per-bot state root. Equals stateDir for the primary bot; a namespaced sub-dir for
+   *  non-primary adapters (multi-instance isolation — spec MENTOR-LIVE-READINESS §Fix 2b).
+   *  Only the per-bot state files (registry/messages/offset/attention) live here; shared
+   *  config lookups stay on stateDir. */
+  private botStateDir: string;
+  /** When true, start() skips ensureLifelineTopic() — a non-primary bot must not create a
+   *  second Lifeline topic in the chat. */
+  private suppressLifelineAutoCreate: boolean;
 
   // Attention queue (persisted to disk)
   private attentionItemToTopic: Map<string, number> = new Map();
@@ -511,7 +523,11 @@ export class TelegramAdapter implements MessagingAdapter {
     return this.eventBus;
   }
 
-  constructor(config: TelegramConfig, stateDir: string) {
+  constructor(
+    config: TelegramConfig,
+    stateDir: string,
+    opts?: { subDir?: string; suppressLifelineAutoCreate?: boolean },
+  ) {
     if (config.chatId && !/^-?\d+$/.test(String(config.chatId))) {
       throw new Error(
         `Invalid Telegram chatId "${config.chatId}". Chat IDs must be numeric (e.g., -1001234567890). ` +
@@ -520,10 +536,20 @@ export class TelegramAdapter implements MessagingAdapter {
     }
     this.config = config;
     this.stateDir = stateDir;
-    this.registryPath = path.join(stateDir, 'topic-session-registry.json');
-    this.messageLogPath = path.join(stateDir, 'telegram-messages.jsonl');
-    this.offsetPath = path.join(stateDir, 'telegram-poll-offset.json');
-    this.attentionFilePath = path.join(stateDir, 'state', 'attention-items.json');
+    this.suppressLifelineAutoCreate = opts?.suppressLifelineAutoCreate ?? false;
+    // Multi-instance isolation: a non-primary adapter (e.g. the mentor bot) namespaces its
+    // per-bot state under {stateDir}/{subDir}/ so two adapters never clobber each other's
+    // poll-offset / registry / message-log / attention files (the reviewer-flagged
+    // collision that makes poll()'s cross-token detection fire continuously). The PRIMARY
+    // bot passes no subDir → botStateDir === stateDir → paths are byte-for-byte unchanged.
+    this.botStateDir = opts?.subDir ? path.join(stateDir, opts.subDir) : stateDir;
+    if (opts?.subDir) {
+      fs.mkdirSync(this.botStateDir, { recursive: true });
+    }
+    this.registryPath = path.join(this.botStateDir, 'topic-session-registry.json');
+    this.messageLogPath = path.join(this.botStateDir, 'telegram-messages.jsonl');
+    this.offsetPath = path.join(this.botStateDir, 'telegram-poll-offset.json');
+    this.attentionFilePath = path.join(this.botStateDir, 'state', 'attention-items.json');
     this.loadRegistry();
     this.loadOffset();
     this.loadAttentionItems();
@@ -770,8 +796,11 @@ export class TelegramAdapter implements MessagingAdapter {
     this.pollStoppedAt = null;
     this.pending401Retry = false;
 
-    // Ensure Lifeline topic exists (auto-recreate if deleted)
-    await this.ensureLifelineTopic();
+    // Ensure Lifeline topic exists (auto-recreate if deleted). A non-primary adapter
+    // (e.g. the mentor bot) must NOT create a second Lifeline topic in the chat.
+    if (!this.suppressLifelineAutoCreate) {
+      await this.ensureLifelineTopic();
+    }
 
     console.log(`[telegram] Starting long-polling...`);
     this.poll();

--- a/tests/unit/telegram-adapter-multi-instance.test.ts
+++ b/tests/unit/telegram-adapter-multi-instance.test.ts
@@ -1,0 +1,82 @@
+/**
+ * TelegramAdapter multi-instance state isolation (spec MENTOR-LIVE-READINESS §Fix 2b,
+ * round-2 integration F1 — the reviewer-flagged state-file collision).
+ *
+ * The load-bearing safety property: a PRIMARY adapter (no opts) must keep its state-file
+ * paths BYTE-FOR-BYTE unchanged (this code runs Echo's own Telegram — the channel to the
+ * user). A non-primary adapter (subDir set) namespaces its per-bot state so two bots can
+ * run in one process without clobbering each other's poll-offset / registry / message-log /
+ * attention files.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('TelegramAdapter — multi-instance state isolation', () => {
+  const adapters: TelegramAdapter[] = [];
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const a of adapters) await a.stop().catch(() => {});
+    adapters.length = 0;
+    for (const d of dirs) SafeFsExecutor.safeRmSync(d, { recursive: true, force: true, operation: 'telegram-multi-instance test cleanup' });
+    dirs.length = 0;
+  });
+
+  function tmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tg-multi-'));
+    dirs.push(d);
+    return d;
+  }
+
+  function make(stateDir: string, opts?: { subDir?: string; suppressLifelineAutoCreate?: boolean }): TelegramAdapter {
+    const a = new TelegramAdapter({ token: 't', chatId: '-1001' }, stateDir, opts);
+    adapters.push(a);
+    return a;
+  }
+
+  it('PRIMARY (no opts): state-file paths are byte-for-byte the historical {stateDir}/... paths', () => {
+    const dir = tmp();
+    const a = make(dir) as unknown as Record<string, string>;
+    // These exact paths are what every prior install wrote to — must NOT change.
+    expect(a.registryPath).toBe(path.join(dir, 'topic-session-registry.json'));
+    expect(a.messageLogPath).toBe(path.join(dir, 'telegram-messages.jsonl'));
+    expect(a.offsetPath).toBe(path.join(dir, 'telegram-poll-offset.json'));
+    expect(a.attentionFilePath).toBe(path.join(dir, 'state', 'attention-items.json'));
+    expect(a.botStateDir).toBe(dir);
+  });
+
+  it('subDir: per-bot state is namespaced under {stateDir}/{subDir}/ — no collision with primary', () => {
+    const dir = tmp();
+    const primary = make(dir) as unknown as Record<string, string>;
+    const mentor = make(dir, { subDir: 'agent-telegram/mentor-bot' }) as unknown as Record<string, string>;
+
+    const sub = path.join(dir, 'agent-telegram', 'mentor-bot');
+    expect(mentor.botStateDir).toBe(sub);
+    expect(mentor.offsetPath).toBe(path.join(sub, 'telegram-poll-offset.json'));
+    expect(mentor.registryPath).toBe(path.join(sub, 'topic-session-registry.json'));
+    expect(mentor.messageLogPath).toBe(path.join(sub, 'telegram-messages.jsonl'));
+    expect(mentor.attentionFilePath).toBe(path.join(sub, 'state', 'attention-items.json'));
+
+    // The critical isolation: the two adapters share NO state-file path.
+    expect(mentor.offsetPath).not.toBe(primary.offsetPath);
+    expect(mentor.registryPath).not.toBe(primary.registryPath);
+    expect(mentor.messageLogPath).not.toBe(primary.messageLogPath);
+    expect(mentor.attentionFilePath).not.toBe(primary.attentionFilePath);
+
+    // The sub-dir is created on construction.
+    expect(fs.existsSync(sub)).toBe(true);
+  });
+
+  it('suppressLifelineAutoCreate flag is recorded (non-primary bot will not create a 2nd Lifeline topic)', () => {
+    const dir = tmp();
+    const def = make(dir) as unknown as Record<string, boolean>;
+    expect(def.suppressLifelineAutoCreate).toBe(false); // primary default
+
+    const mentor = make(dir, { subDir: 'agent-telegram/mentor-bot', suppressLifelineAutoCreate: true }) as unknown as Record<string, boolean>;
+    expect(mentor.suppressLifelineAutoCreate).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,37 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**TelegramAdapter can now run a second bot cleanly (groundwork for agent-to-agent Telegram
+comms).** Two internal additions, both shipping dark (nothing uses them yet): (1) a
+non-primary Telegram adapter can namespace its own state files under a sub-directory, so two
+bots in one process never clobber each other's poll-offset / registry / message-log /
+attention files; and (2) inbound Telegram messages now expose whether the sender is a bot
+(`is_bot`) and any `sender_chat` — the structural input a later update uses to tell an
+agent-sent message from a human typing the same text. The primary bot's behavior and state
+paths are byte-for-byte unchanged.
+
+## What to Tell Your User
+
+- Nothing changes in how your agent behaves today — this is plumbing for a later feature
+  (agents messaging each other over Telegram). Your agent's own Telegram keeps working
+  exactly as before.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Multi-instance `TelegramAdapter` | Internal — `new TelegramAdapter(cfg, stateDir, { subDir, suppressLifelineAutoCreate })`; primary (no opts) unchanged |
+| Sender-identity on inbound messages | Internal — `message.from.is_bot` + `message.sender_chat` exposed on the update type |
+
+## Evidence
+
+**Net-new groundwork, not a bug fix.** Proven by a dedicated test asserting the load-bearing
+safety property — a PRIMARY adapter's four state-file paths are byte-for-byte the historical
+`{stateDir}/...` values (this code runs the agent's own Telegram, so an unchanged primary is
+the non-negotiable invariant) — plus that a `subDir` adapter namespaces all four files and
+shares no path with the primary. The existing Telegram suites (71 tests across 5 files) pass
+unchanged as the regression guard. `tsc --noEmit` clean. The wiring that consumes these
+(the agent-message recipient handler + `sendAgentMessage`) lands in the follow-up PR.

--- a/upgrades/side-effects/telegram-adapter-multi-instance.md
+++ b/upgrades/side-effects/telegram-adapter-multi-instance.md
@@ -1,0 +1,61 @@
+# Side-Effects Review — TelegramAdapter multi-instance isolation + Message-type extension (PR 2a)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2b "Implementation surface" items
+1-2 + round-2 integration F1 (converged, approved). PR 2 of the staged build, part a.
+**Change:** Make `TelegramAdapter` safe to run as a second (non-primary) instance in one
+process, and expose the Telegram fields the a2a spoof-defense needs. **Ships dark** — no
+caller passes the new options yet; the new Message fields are additive-optional.
+**Files:** `src/messaging/TelegramAdapter.ts`, `tests/unit/telegram-adapter-multi-instance.test.ts` (new).
+
+## What changed
+
+1. **Constructor opts `{ subDir?, suppressLifelineAutoCreate? }`** (3rd param, optional). When
+   `subDir` is set, the four per-bot state files (registry / message-log / poll-offset /
+   attention) live under `{stateDir}/{subDir}/` via a new `botStateDir`. The PRIMARY bot
+   (no `subDir`) gets `botStateDir === stateDir` → **paths are byte-for-byte unchanged**.
+2. **`suppressLifelineAutoCreate`** — `start()` skips `ensureLifelineTopic()` when true, so a
+   non-primary bot can't create a second Lifeline topic in the chat.
+3. **Message-type extension** — `message.from.is_bot?: boolean` + `message.sender_chat?` added
+   to `TelegramUpdate`. These are the structural inputs to the a2a user-spoof defense (a
+   human typing an `[a2a:…]` marker has `is_bot:false` and no `sender_chat`).
+
+## The seven questions
+
+1. **Over-block.** N/A — no gate. The only behavior gate is `suppressLifelineAutoCreate`,
+   default false (primary unaffected).
+2. **Under-block.** The reviewer-flagged collision (two adapters sharing
+   `telegram-poll-offset.json` → `poll()`'s cross-token detection fires continuously) is
+   eliminated: non-primary state is namespaced. Test asserts the two adapters share NO
+   state-file path.
+3. **Level-of-abstraction fit.** The isolation is at construction (one place), not scattered
+   per-callsite. `botStateDir` is the single source for per-bot paths.
+4. **Signal vs authority.** N/A.
+5. **Interactions — THE risk, and how it's bounded.** This file runs Echo's own (primary)
+   Telegram — the channel to the user. The change is built so the primary path is
+   **identical** (when `subDir` is undefined, `botStateDir === stateDir`). A dedicated test
+   asserts the four primary paths are byte-for-byte the historical `{stateDir}/...` values,
+   and the existing TelegramAdapter suites (71 tests across 5 files) pass unchanged — the
+   regression guard for "did I break my own comms." The new code only branches when `subDir`
+   is set, and nothing sets it yet (dark). Media/dashboard dirs still resolve off `stateDir`
+   inline — NOT isolated — which is fine: the reviewer flagged only the four constructor
+   state files, and the mentor bot (the only future `subDir` user) does no media/dashboard.
+6. **External surfaces.** None. No routes, no config consumed yet. The Message-type fields
+   are additive-optional (every existing reader ignores them).
+7. **Rollback cost.** Trivial — revert restores the 2-param constructor; no data, no migration
+   (the primary never wrote to a subDir).
+
+## Testing
+
+- `tests/unit/telegram-adapter-multi-instance.test.ts` (3 tests): **primary paths byte-for-byte
+  unchanged** (the load-bearing safety assertion); subDir namespaces all four state files +
+  shares no path with primary + creates the sub-dir; `suppressLifelineAutoCreate` recorded
+  (false default for primary).
+- Regression: existing Telegram suites (`TelegramAdapter`, `telegram-format-wireup`,
+  `telegram-adapter`) + the PR-1 `AgentTelegramComms` suite — 71 tests, all green.
+- `tsc --noEmit` clean.
+
+## Migration parity
+
+None — additive constructor option + additive optional Message fields. No agent-installed
+file change, no config consumed yet. PR 2b wires `sendAgentMessage` + the recipient handler;
+PR 3's config/migration is per the spec's §Migration parity.


### PR DESCRIPTION
## What

PR 2a of the agent-to-agent Telegram comms build (spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md`, approved; PR 1 = the primitive core, merged). This makes `TelegramAdapter` safe to run a **second bot** in one process, and exposes the Telegram fields the a2a spoof-defense needs. **Ships dark** — nothing passes the new options yet; the new Message fields are additive-optional.

## Changes

- **Constructor `opts.subDir`** — non-primary adapters namespace their four per-bot state files (registry / message-log / poll-offset / attention) under `{stateDir}/{subDir}/`, eliminating the reviewer-flagged collision (two adapters sharing `telegram-poll-offset.json` → `poll()`'s cross-token detection fires continuously). **The primary bot (no `subDir`) is byte-for-byte unchanged** — this runs Echo's own comms-to-user, so an unchanged primary is the non-negotiable invariant (asserted by test).
- **`opts.suppressLifelineAutoCreate`** — `start()` skips `ensureLifelineTopic()` so a non-primary bot can't create a second Lifeline topic.
- **`TelegramUpdate.message`** gains `from.is_bot` + `sender_chat` — the structural inputs to the a2a user-spoof defense (a human typing `[a2a:…]` has `is_bot:false`, no `sender_chat`).

## Safety

This touches the adapter that runs Echo's own Telegram. The change only branches when `subDir` is set (nothing does yet — dark). The dedicated test asserts the primary's four state-file paths are byte-for-byte the historical `{stateDir}/...` values, and the existing Telegram suites (71 tests / 5 files) pass unchanged as the regression guard.

## Next

PR 2b: the recipient-handler wrap at the `server.ts` registration site + `sendAgentMessage` + ledger persistence (wires PR 1's primitive to this adapter). PR 3: the mentor consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)