### PR TITLE
feat(release-hygiene): Release-Readiness Visibility — Layer A + Layer B (PR-2 of 3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,13 @@ jobs:
           elif grep -q '\[Feature name\]' upgrades/NEXT.md && grep -q '\[Capability\]' upgrades/NEXT.md; then
             echo "NEXT.md is still a template — nothing to publish"
             echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif grep -q 'auto-draft-unreviewed' upgrades/NEXT.md; then
+            # Layer A auto-drafted this guide but a human hasn't reviewed it yet
+            # (release-readiness-visibility spec §4.1.1). Skipping keeps the
+            # silent-skip semantics correct for the unreviewed case; the
+            # release-readiness sentinel surfaces the blocked release as a signal.
+            echo "NEXT.md still has auto-draft-unreviewed markers — awaiting human review, not publishing"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "NEXT.md has content — proceeding with publish"
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The architecture was distilled from [**Dawn**](https://dawn.bot-me.ai) — an AI
 | Forgets what you told it last week. | Remembers across thousands of sessions. <br/>*(SQLite + FTS5, rolling summaries)* |
 | Contradicts its own past decisions. | Catches contradictions before they ship. <br/>*(Coherence Gate, 9 reviewers)* |
 | Loses the thread when the window fills. | Comes back with the full thread, every time. <br/>*(CompactionSentinel, WorkingMemoryAssembler)* |
+| Silently stops shipping when a release stalls. | Surfaces the blocked release as ONE deduped, age-escalating Attention item. <br/>*(ReleaseReadinessSentinel — instar-dev / maintainer environments)* |
 | Drops commitments after a session boundary. | Tracks commitments durably; nudges itself when they go overdue. <br/>*(CommitmentTracker, PromiseBeacon)* |
 | Breaks when the framework updates. | Updates without breaking what you've deployed. <br/>*(Migration Parity Standard)* |
 | Default ALLOW-ALL permissions. | Layered safety gates by default. <br/>*(PEL + Coherence Gate + Operation Gate)* |

--- a/scripts/analyze-release.js
+++ b/scripts/analyze-release.js
@@ -36,6 +36,11 @@ const ROOT = path.resolve(__dirname, '..');
 const args = process.argv.slice(2);
 const JSON_ONLY = args.includes('--json');
 const RECOMMEND_ONLY = args.includes('--recommend-only');
+// --draft-guide writes/merges upgrades/NEXT.md from the computed change-list
+// (Layer A of the release-readiness-visibility spec). Drafted content carries
+// `auto-draft-unreviewed` markers that BOTH publish gates reject until a human
+// reviews each section — so auto-fill can never ship un-reviewed notes.
+const DRAFT_GUIDE = args.includes('--draft-guide');
 
 // --ref=<rev> selects the tip the analysis runs against (default HEAD).
 // Layer B of the release-readiness-visibility spec passes --ref=FETCH_HEAD so the
@@ -584,6 +589,214 @@ function generateChangeDescriptions(analysis) {
   return descriptions;
 }
 
+// ── Auto-draft (Layer A of release-readiness-visibility spec) ────────
+//
+// Turns the computed change-list into a NEXT.md draft. Every drafted item
+// carries an `auto-draft-unreviewed` marker. The publish gates
+// (check-upgrade-guide.js validator + publish.yml skip predicate) refuse to
+// ship a guide that still has those markers, so auto-fill removes the "blank
+// guide" root cause WITHOUT defeating the human-review purpose of the gate.
+
+const UNREVIEWED_BLOCK_MARKER = '<!-- auto-draft-unreviewed-block -->';
+const UNCOVERED_BEGIN = '<!-- BEGIN auto-draft-uncovered (unreviewed) -->';
+const UNCOVERED_END = '<!-- END auto-draft-uncovered (unreviewed) -->';
+
+/**
+ * Neutralize commit-message-sourced text before it lands in a published guide:
+ *   - strip HTML comments (prevents forging `<!-- bump: -->` / unreviewed markers)
+ *   - collapse whitespace, cap length
+ *   - escape leading markdown control chars so an item can't break section bounds
+ */
+function sanitizeDraftText(s) {
+  let t = String(s ?? '')
+    .replace(/<!--[\s\S]*?-->/g, '') // strip HTML comments
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (t.length > 200) t = t.slice(0, 197).trimEnd() + '…';
+  // Escape leading control sequences (heading / hr) so a crafted message can't
+  // inject a new section boundary.
+  t = t.replace(/^(#{1,6}\s)/, '\\$1').replace(/^(-{3,})/, '\\$1');
+  return t;
+}
+
+const FALLBACK_USER_IMPACTS = new Set([
+  'Review the commit for user-facing changes',
+  'Review the commit for specifics',
+]);
+
+function unreviewed(slug) {
+  return `<!-- auto-draft-unreviewed: ${slug} -->`;
+}
+
+/** Does the existing guide already mention this change description? */
+function descriptionMentioned(desc, content) {
+  const lc = content.toLowerCase();
+  // Endpoint: the path token (e.g. "/release-readiness").
+  const ep = /:\s*[A-Z]+\s+(\/\S+)/.exec(desc.summary);
+  if (ep) return lc.includes(ep[1].toLowerCase());
+  // CLI command: "instar <cmd>".
+  const cmd = /instar\s+([a-z][\w:-]*)/i.exec(desc.summary);
+  if (cmd) return lc.includes(cmd[1].toLowerCase());
+  // Config field: "New config option: <field>".
+  const cfg = /config option:\s*(\w+)/i.exec(desc.summary);
+  if (cfg) return lc.includes(cfg[1].toLowerCase());
+  // Otherwise (commit-derived): any >4-char keyword from the summary.
+  const kws = desc.summary.replace(/^(feat|fix)[:(]?\s*/i, '').split(/\s+/).filter((w) => w.length > 4).slice(0, 4);
+  return kws.length > 0 && kws.some((k) => lc.includes(k.toLowerCase()));
+}
+
+/** One "## What Changed" bullet for a description. */
+function changedBullet(desc) {
+  return `- **${desc.type}**: ${sanitizeDraftText(desc.summary)} — ${sanitizeDraftText(desc.detail)}`;
+}
+
+/** Build the three required sections' bodies from the change-list. */
+function buildSectionBodies(changeDescriptions, hasFix) {
+  const whatChanged = changeDescriptions.length
+    ? changeDescriptions.map(changedBullet).join('\n')
+    : '- (no structurally-detected changes; describe the release manually)';
+
+  // "What to Tell Your User" must stay plain — no backticks/camelCase/code.
+  // Use the generic userImpact lines (already plain) and a HUMAN-REQUIRED note
+  // for any commit whose impact the analyzer couldn't infer.
+  const userLines = [];
+  const seen = new Set();
+  for (const d of changeDescriptions) {
+    const impact = FALLBACK_USER_IMPACTS.has(d.userImpact)
+      ? 'HUMAN-REQUIRED: describe what this means for the user'
+      : d.userImpact;
+    const line = `- ${sanitizeDraftText(impact)}`;
+    if (!seen.has(line)) { seen.add(line); userLines.push(line); }
+  }
+  const tellUser = userLines.length ? userLines.join('\n') : '- HUMAN-REQUIRED: summarize the user-facing impact';
+
+  const capRows = changeDescriptions
+    .filter((d) => d.type === 'feature' || d.type === 'enhancement')
+    .map((d) => `| ${sanitizeDraftText(d.summary)} | ${sanitizeDraftText(d.agentImpact)} |`)
+    .join('\n') || '| (none) | — |';
+
+  let out =
+`## What Changed
+
+${unreviewed('what-changed')}
+${whatChanged}
+
+## What to Tell Your User
+
+${unreviewed('tell-user')}
+${tellUser}
+
+## Summary of New Capabilities
+
+${unreviewed('capabilities')}
+| Capability | How to Use |
+|-----------|-----------|
+${capRows}
+`;
+
+  if (hasFix) {
+    out +=
+`
+## Evidence
+
+${unreviewed('evidence')}
+HUMAN-REQUIRED: reproduction + observed before/after, or "Not reproducible in dev — [concrete reason]". Unit tests passing is not evidence.
+`;
+  }
+  return out;
+}
+
+/** Full NEXT.md draft (used when the guide is absent or a pristine template). */
+function buildFullDraft(changeDescriptions, recommended, hasFix) {
+  return `# Upgrade Guide — vNEXT
+
+<!-- bump: ${recommended} -->
+${UNREVIEWED_BLOCK_MARKER}
+<!-- Auto-drafted from the classified commit range. Every section below carries an
+     auto-draft-unreviewed marker. A human reviews each section and replaces its
+     marker with a reviewed-by receipt before this guide can publish.
+     See docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md §4.1.1. -->
+
+${buildSectionBodies(changeDescriptions, hasFix)}`;
+}
+
+/** The uncovered-delta block appended to a guide that already has human content. */
+function buildUncoveredBlock(changeDescriptions, existingContent) {
+  const uncovered = changeDescriptions.filter((d) => !descriptionMentioned(d, existingContent));
+  if (uncovered.length === 0) return '';
+  const items = uncovered.map((d) => `- ${unreviewed(slugifyDesc(d))} **${d.type}**: ${sanitizeDraftText(d.summary)}`).join('\n');
+  return `${UNCOVERED_BEGIN}
+<!-- These changes were detected in the commit range but not yet mentioned above.
+     Fold them into the sections above (or describe why they need no note), then
+     remove each marker with a reviewed-by receipt. -->
+${items}
+${UNCOVERED_END}`;
+}
+
+function slugifyDesc(d) {
+  return (d.summary || 'item').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'item';
+}
+
+const PRISTINE_TEMPLATE = (c) => c.includes('[Feature name]') && c.includes('[Capability]');
+
+/**
+ * Write or merge upgrades/NEXT.md. Race-guarded against publish finalize.
+ * Returns a short status string for logging.
+ */
+function writeOrMergeGuide(changeDescriptions, recommended, hasFix) {
+  const upgradesDir = path.join(ROOT, 'upgrades');
+  const nextPath = path.join(upgradesDir, 'NEXT.md');
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
+  const versionGuide = path.join(upgradesDir, `${pkg.version}.md`);
+
+  fs.mkdirSync(upgradesDir, { recursive: true });
+
+  // Race guard against publish-finalize: refuse to draft once a finalize has
+  // produced upgrades/{version}.md. Per RELEASE-READINESS-VISIBILITY-SPEC §4.1.3
+  // this version-file check IS the cross-host guarantee (finalize renames
+  // NEXT.md → {version}.md in CI on a separate checkout; git's ref-update
+  // atomicity covers the merge). The intra-host O_EXCL advisory lock the spec
+  // also describes is intentionally omitted here: releasing it requires a
+  // destructive fs.unlink (forbidden by lint-no-direct-destructive in this
+  // dependency-free, test-copyable script), and the draft job is single-runner
+  // per the multi-machine lease, so concurrent local drafters don't occur.
+  if (fs.existsSync(versionGuide)) {
+    return `skipped: upgrades/${pkg.version}.md already finalized — not drafting`;
+  }
+
+  const existing = fs.existsSync(nextPath) ? fs.readFileSync(nextPath, 'utf-8') : '';
+
+  if (!existing.trim() || PRISTINE_TEMPLATE(existing)) {
+    fs.writeFileSync(nextPath, buildFullDraft(changeDescriptions, recommended, hasFix));
+    return 'wrote full draft (guide was absent or a pristine template)';
+  }
+
+  // Human content present — additive, never-clobber. Regenerate only the
+  // uncovered-delta block (idempotent). Coverage is measured against the
+  // HUMAN content only: strip any prior auto-block first, otherwise the
+  // block's own text would count as "coverage" and the block would
+  // oscillate (present on one run, absent the next).
+  const beginIdx = existing.indexOf(UNCOVERED_BEGIN);
+  const endIdx = existing.indexOf(UNCOVERED_END);
+  let tail = '';
+  let humanContent = existing;
+  if (beginIdx !== -1) {
+    tail = endIdx !== -1 ? existing.slice(endIdx + UNCOVERED_END.length) : '';
+    humanContent = existing.slice(0, beginIdx) + tail;
+  }
+  const block = buildUncoveredBlock(changeDescriptions, humanContent);
+  let body;
+  if (beginIdx !== -1) {
+    body = existing.slice(0, beginIdx).replace(/\s+$/, '') + (block ? `\n\n${block}` : '') + tail;
+  } else if (block) {
+    body = existing.replace(/\s+$/, '') + `\n\n${block}\n`;
+  } else {
+    return 'no uncovered changes — guide already covers the change-list';
+  }
+  fs.writeFileSync(nextPath, body);
+  return block ? 'merged uncovered-delta block into existing guide' : 'removed stale uncovered-delta block (now fully covered)';
+}
+
 // ── Main ─────────────────────────────────────────────────────────────
 
 const lastTag = getLastReleaseTag();
@@ -643,6 +856,14 @@ if (bumpRecommendation.minorSignals.length > 0) {
 if (bumpRecommendation.patchSignals.length > 0) {
   log(`    Patch signals:`);
   for (const s of bumpRecommendation.patchSignals) log(`      - ${s}`);
+}
+
+if (DRAFT_GUIDE) {
+  const hasFix = analysis.commits.fixes.length > 0;
+  const status = writeOrMergeGuide(changeDescriptions, bumpRecommendation.recommended, hasFix);
+  log(`\n  Draft guide: ${status}`);
+  console.log(status);
+  process.exit(0);
 }
 
 if (RECOMMEND_ONLY) {

--- a/scripts/upgrade-guide-validator.mjs
+++ b/scripts/upgrade-guide-validator.mjs
@@ -2,6 +2,8 @@
 // The CLI entry point (check-upgrade-guide.js) wraps this with I/O.
 // Extracted for unit testability.
 
+import crypto from 'node:crypto';
+
 export const REQUIRED_SECTIONS = [
   '## What Changed',
   '## What to Tell Your User',
@@ -207,6 +209,9 @@ export function validateGuideContent(content) {
     issues.push(...evidenceIssues(content));
   }
 
+  // Auto-draft review gate — unreviewed markers + receipt validity.
+  issues.push(...autoDraftReviewIssues(content));
+
   return issues;
 }
 
@@ -217,4 +222,119 @@ export function validateGuideContent(content) {
 export function parseBumpType(content) {
   const match = /<!--\s*bump:\s*(patch|minor|major)\s*-->/.exec(content);
   return match ? match[1] : null;
+}
+
+// ── Auto-draft review gate (release-readiness-visibility spec §4.1.1) ──
+//
+// Layer A auto-drafts NEXT.md from the classified commit range. Every drafted
+// section carries an `auto-draft-unreviewed` marker. The publish gate refuses
+// to ship a guide while any such marker remains, so auto-fill removes the
+// "blank guide" root cause WITHOUT shipping un-reviewed notes. A human signals
+// review by REPLACING a section's marker with a hash-locked `reviewed-by`
+// receipt; editing the section afterward invalidates the hash and re-blocks.
+
+export const REVIEW_RECEIPT_MAX_AGE_DAYS = 30;
+
+const UNREVIEWED_MARKER_RE = /<!--\s*auto-draft-unreviewed(?:-block)?(?::[^>]*?)?\s*-->/g;
+const REVIEW_RECEIPT_RE = /<!--\s*reviewed-by:\s*(.+?)\s*@\s*([0-9T:.+\-Z]+)\s*:hash=([a-f0-9]{64})\s*-->/gi;
+// A `reviewed-by` comment that does NOT match the strict form above — used to
+// catch receipts missing the required :hash= (the iter-3 V2 fix).
+const REVIEW_RECEIPT_LOOSE_RE = /<!--\s*reviewed-by:[^>]*-->/gi;
+
+/**
+ * Canonicalize a section body for hashing: LF line endings, drop the receipt
+ * line itself, strip trailing whitespace per line, trim. Mirrors the rule in
+ * RELEASE-READINESS-VISIBILITY-SPEC §4.1.1.
+ */
+export function canonicalizeSectionForHash(body) {
+  return String(body)
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .filter((l) => !/<!--\s*reviewed-by:/i.test(l))
+    .map((l) => l.replace(/\s+$/, ''))
+    .join('\n')
+    .trim();
+}
+
+export function sectionReviewHash(body) {
+  return crypto.createHash('sha256').update(canonicalizeSectionForHash(body)).digest('hex');
+}
+
+/** Split content into H2 sections: [{ title, body }]. */
+function h2Sections(content) {
+  const out = [];
+  const re = /^## (.+)$/gm;
+  let m;
+  const heads = [];
+  while ((m = re.exec(content)) !== null) heads.push({ title: m[1].trim(), idx: m.index, after: re.lastIndex });
+  for (let i = 0; i < heads.length; i++) {
+    const end = i + 1 < heads.length ? heads[i + 1].idx : content.length;
+    out.push({ title: heads[i].title, body: content.slice(heads[i].after, end) });
+  }
+  return out;
+}
+
+/**
+ * Gate issues for the auto-draft review state. Returns issue strings (empty = ok):
+ *   1. Any remaining `auto-draft-unreviewed` marker blocks publish.
+ *   2. A `reviewed-by` receipt missing the required `:hash=` blocks.
+ *   3. A receipt whose hash doesn't match its (canonicalized) section blocks
+ *      — i.e. the section was edited after review.
+ *   4. A receipt older than REVIEW_RECEIPT_MAX_AGE_DAYS blocks.
+ * (Full "marker stripped without a receipt" detection needs a git-diff and is
+ * the tracked Phase-2 CI check per §4.1.1 — out of scope for this snapshot gate.)
+ */
+export function autoDraftReviewIssues(content, now = Date.now()) {
+  const issues = [];
+
+  const unreviewed = content.match(UNREVIEWED_MARKER_RE) || [];
+  if (unreviewed.length > 0) {
+    issues.push(
+      `guide has ${unreviewed.length} unreviewed auto-draft marker(s) — a human must review each section and ` +
+      `replace its 'auto-draft-unreviewed' marker with a 'reviewed-by: <name> @ <ISO-date> :hash=<sha256>' receipt ` +
+      `before this guide can publish (RELEASE-READINESS-VISIBILITY-SPEC §4.1.1)`,
+    );
+  }
+
+  // Loose receipts that don't match the strict (with :hash=) form.
+  const looseAll = content.match(REVIEW_RECEIPT_LOOSE_RE) || [];
+  for (const loose of looseAll) {
+    REVIEW_RECEIPT_RE.lastIndex = 0;
+    if (!REVIEW_RECEIPT_RE.test(loose)) {
+      issues.push(
+        `malformed reviewed-by receipt (missing required ':hash=<sha256>' or bad date): ${loose.trim()}. ` +
+        `Required form: <!-- reviewed-by: <name> @ <ISO-date> :hash=<sha256> -->`,
+      );
+    }
+  }
+
+  // Strict receipts: validate hash-match against their section + age window.
+  for (const section of h2Sections(content)) {
+    REVIEW_RECEIPT_RE.lastIndex = 0;
+    let r;
+    while ((r = REVIEW_RECEIPT_RE.exec(section.body)) !== null) {
+      const [, , dateStr, hash] = r;
+      const ts = Date.parse(dateStr);
+      if (Number.isNaN(ts)) {
+        issues.push(`reviewed-by receipt in "## ${section.title}" has an unparseable date: "${dateStr}"`);
+        continue;
+      }
+      const ageDays = (now - ts) / (24 * 60 * 60 * 1000);
+      if (ageDays > REVIEW_RECEIPT_MAX_AGE_DAYS) {
+        issues.push(
+          `reviewed-by receipt in "## ${section.title}" is ${Math.floor(ageDays)} days old ` +
+          `(max ${REVIEW_RECEIPT_MAX_AGE_DAYS}) — re-review the section and refresh the receipt`,
+        );
+      }
+      const actual = sectionReviewHash(section.body);
+      if (actual !== hash) {
+        issues.push(
+          `reviewed-by receipt in "## ${section.title}" hash mismatch — the section was edited after review. ` +
+          `Re-review and update :hash= to ${actual}`,
+        );
+      }
+    }
+  }
+
+  return issues;
 }

--- a/site/src/content/docs/features/observability.md
+++ b/site/src/content/docs/features/observability.md
@@ -68,6 +68,12 @@ Long-running sessions accumulate a lot of activity. The session activity sentine
 
 The partitioner is the algorithm that decides where one episode ends and the next begins. It uses signals like topic switches, long pauses, explicit user marking, and job-boundary events.
 
+## Release readiness (instar-dev / maintainer environments)
+
+Components: `ReleaseReadinessSentinel`.
+
+A repo-gated watchdog that makes a stalled instar release impossible to miss. It evaluates canonical `main` and, when finished work sits unreleased while publishing is blocked, raises ONE deduped, age-escalating item on the Attention queue. Ships OFF (Echo dogfoods first); the `release-readiness-check` job drives it. Null on any install with no analyzable instar git repo. Routes: `GET /release-readiness`, `POST /release-readiness/tick`, `POST /release-readiness/rollback` (loud — raises a HIGH attention item + audits, never silent).
+
 ## Credential management
 
 Components: `SessionCredentialManager`, `ClaudeConfigCredentialProvider`, `KeychainCredentialProvider`, `BitwardenProvider`.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8091,7 +8091,47 @@ export async function startServer(options: StartOptions): Promise<void> {
       ));
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb, stopNotifier });
+    // ── ReleaseReadinessSentinel (Layer B of release-readiness-visibility) ──
+    // Repo-gated dev-environment watchdog: only constructed when the install has
+    // an analyzable instar git repo AND the feature is enabled in config. On a
+    // plain npm-installed agent (no instar repo) it stays null → routes 503,
+    // never a spurious signal. Not start()ed here — the off-by-default
+    // release-readiness-check job drives tick() via POST /release-readiness/tick.
+    let releaseReadinessSentinel: import('../monitoring/ReleaseReadinessSentinel.js').ReleaseReadinessSentinel | null = null;
+    {
+      const rrCfg = config.monitoring?.releaseReadiness;
+      const repoPath = rrCfg?.repoPath ?? process.cwd();
+      if (rrCfg?.enabled) {
+        const { isAnalyzableRepo, buildReleaseReadinessDeps } = await import('../monitoring/releaseReadinessWiring.js');
+        if (isAnalyzableRepo(repoPath)) {
+          const { ReleaseReadinessSentinel } = await import('../monitoring/ReleaseReadinessSentinel.js');
+          const deps = buildReleaseReadinessDeps({
+            repoPath,
+            statePath: path.join(config.stateDir, 'release-readiness.json'),
+            auditPath: path.join(config.stateDir, '..', 'logs', 'sentinel-events.jsonl'),
+            port: config.port,
+            authToken: config.authToken ?? '',
+            canonicalRemote: rrCfg.canonicalRemote,
+            fetchTimeoutMs: rrCfg.fetchTimeoutMs,
+          });
+          releaseReadinessSentinel = new ReleaseReadinessSentinel(deps, {
+            enabled: true,
+            tickIntervalMs: rrCfg.tickIntervalMs,
+            backlogAgeDaysSilent: rrCfg.backlogAgeDaysSilent,
+            backlogAgeDaysLow: rrCfg.backlogAgeDaysLow,
+            backlogAgeDaysMedium: rrCfg.backlogAgeDaysMedium,
+            backlogAgeDaysHigh: rrCfg.backlogAgeDaysHigh,
+            hysteresisHours: rrCfg.hysteresisHours,
+            staleEpisodeTtlDays: rrCfg.staleEpisodeTtlDays,
+          });
+          console.log(pc.green('  ReleaseReadinessSentinel enabled (release-hygiene watchdog — job-driven)'));
+        } else {
+          console.log(pc.dim('  ReleaseReadinessSentinel enabled in config but no analyzable instar repo found — staying inert'));
+        }
+      }
+    }
+
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb, stopNotifier });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -74,6 +74,21 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       attributionConfidenceFloor: 0.6,
       insightTelegramEscalation: false,
     },
+    // ReleaseReadinessSentinel (docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md
+    // §4.2). Ships OFF — Echo dogfoods first. Repo-gated: inert unless the
+    // install has an analyzable instar git repo. Thresholds default to
+    // silent <2d, LOW ≥2d, MEDIUM ≥4d, HIGH ≥7d.
+    releaseReadiness: {
+      enabled: false,
+      tickIntervalMs: 21_600_000,
+      backlogAgeDaysSilent: 2,
+      backlogAgeDaysLow: 2,
+      backlogAgeDaysMedium: 4,
+      backlogAgeDaysHigh: 7,
+      hysteresisHours: 12,
+      staleEpisodeTtlDays: 30,
+      fetchTimeoutMs: 30_000,
+    },
     // Master gate for Telegram delivery of silently-stopped-sentinel
     // escalations. Default false → sentinel notices are housekeeping and stay
     // in the logs (server.log + sentinel-events.jsonl). Set true to receive

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2502,6 +2502,22 @@ When the user is reading the Threadline hub topic and says **"open this"** or **
       result.upgraded.push('CLAUDE.md: added Threadline hub + "open this" guidance (CMT-519)');
     }
 
+    // release-readiness-visibility §7 — Agent Awareness + Migration Parity:
+    // existing agents must learn the release-readiness watchdog endpoints, not
+    // just new agents via init. Content-sniff on the route marker.
+    if (!content.includes('/release-readiness')) {
+      const rrSection = `
+### Release Readiness (instar-dev / maintainer environments only)
+
+A repo-gated watchdog that makes a stalled instar release impossible to miss: it evaluates canonical \`main\` and, when finished work sits unreleased while publishing is blocked, raises ONE deduped, age-escalating item on the Attention queue. Ships OFF; the \`release-readiness-check\` job drives it. Null/503 on any install with no analyzable instar git repo.
+- Status: \`GET /release-readiness\` · Run one check: \`POST /release-readiness/tick\`
+- Disable (loud — raises a HIGH attention item + audits, never silent): \`POST /release-readiness/rollback\` · re-arm: \`POST /release-readiness/enable\`
+`;
+      content += '\n' + rrSection;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Release Readiness watchdog awareness (release-readiness-visibility)');
+    }
+
     // CMT-529 — agents migrated under CMT-519 got the OLD "call the bind endpoint"
     // wording; "open this" is now a STRUCTURAL intercept (handled before the agent).
     // Re-patch the stale sentence so the agent doesn't try to call the endpoint /

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2726,6 +2726,36 @@ export interface MonitoringConfig {
     insightTelegramEscalation?: boolean;
   };
   /**
+   * ReleaseReadinessSentinel (docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md §4.2)
+   * — Layer B. A repo-gated dev-environment watchdog: evaluates the canonical
+   * `main` of the instar checkout and surfaces a stalled/blocked release as a
+   * single, deduped, age-escalating Attention item. Ships OFF (Echo dogfoods
+   * first). Inert on any install with no analyzable instar git repo. Tier 0.
+   */
+  releaseReadiness?: {
+    /** Master kill switch (default: false). */
+    enabled: boolean;
+    /** Scan cadence (ms) (default: 21_600_000 = 6h). */
+    tickIntervalMs?: number;
+    /** Backlog age (days) below which the check is silent (default: 2). */
+    backlogAgeDaysSilent?: number;
+    /** Age thresholds (days) for LOW / MEDIUM / HIGH priority (default: 2 / 4 / 7). */
+    backlogAgeDaysLow?: number;
+    backlogAgeDaysMedium?: number;
+    backlogAgeDaysHigh?: number;
+    /** Hysteresis window (hours) before re-raising the same episode (default: 12). */
+    hysteresisHours?: number;
+    /** TTL (days) after which an abandoned open episode is reaped as stale (default: 30). */
+    staleEpisodeTtlDays?: number;
+    /** Bounded canonical-fetch timeout (ms) (default: 30_000). */
+    fetchTimeoutMs?: number;
+    /** Override the canonical remote NAME (default: auto-detect a JKHeadley/instar
+     *  remote; a non-canonical override raises a HIGH-priority signal). */
+    canonicalRemote?: string;
+    /** Override the instar repo path to analyze (default: the agent home). */
+    repoPath?: string;
+  };
+  /**
    * Master gate for Telegram delivery of silently-stopped-sentinel escalations
    * (SentinelNotifier). Default false → sentinel notices are logged to the
    * server log + .instar/../logs/sentinel-events.jsonl only; the user never

--- a/src/monitoring/ReleaseReadinessSentinel.ts
+++ b/src/monitoring/ReleaseReadinessSentinel.ts
@@ -1,0 +1,377 @@
+/**
+ * ReleaseReadinessSentinel — Layer B of the release-readiness-visibility spec.
+ *
+ * Watches whether a release is blocked/stalling and makes it impossible to miss.
+ * The original incident (2026-05-27): npm publishing silently stalled since
+ * v1.3.26 — green merges, green CI, no published release, no alert. The publish
+ * workflow's NEXT.md gate is a *silent skip*: a stalled release is
+ * indistinguishable from "nothing to publish". This sentinel is the missing
+ * visibility — a recurring, near-silent check that surfaces a stuck release as
+ * a single, deduped, escalating Attention item.
+ *
+ * Design (spec §4.2):
+ *   - Reads canonical `main` (FETCH_HEAD), not the local checkout, so a stale
+ *     dev branch can't produce a false "all clear".
+ *   - "Blocked" is decoupled from NEXT.md state (so Layer A's auto-draft can't
+ *     silence the alarm by clearing the file): unreleased feature/fix commits
+ *     exist AND the guide can't publish (missing/template/unreviewed), OR the
+ *     analyzer reports critical/high coverage gaps.
+ *   - Near-silent: silent below threshold (state + log only); ONE Attention
+ *     item per stall episode above it, keyed on the OLDEST unreleased commit
+ *     SHA (stable across ticks — not a resettable per-tick id), priority scaled
+ *     by backlog age, 12h hysteresis on re-raise after an auto-resolve.
+ *   - Fail-loud: any evaluation failure (fetch error, analyzer error) raises a
+ *     low-priority Attention item — never a silent catch (that would re-create
+ *     the exact bug this fixes).
+ *   - Lifecycle owner: detect → surface → auto-resolve → reap, with
+ *     resolveEpisodesInRange consulted by the publish-finalize path.
+ *   - Repo-gated: needs an analyzable instar git repo (dev/maintainer env). On
+ *     an npm-installed agent with no such repo the deps make the check inert.
+ *   - Supervision: Tier 0 (mechanical computation + fixed-template wording).
+ */
+
+import { EventEmitter } from 'node:events';
+
+/** Parsed subset of `analyze-release.js --json` the sentinel needs. */
+export interface AnalyzerReport {
+  lastTag: string;
+  commitCount: number;
+  analysis: {
+    commitClassification: { features: number; fixes: number };
+  };
+  guideCoverage: { criticalGaps: number; highGaps: number };
+}
+
+export interface OldestCommit {
+  sha: string;
+  dateMs: number;
+}
+
+export interface ReadinessEpisode {
+  /** Stable key: SHA of the oldest unreleased commit at first detection. */
+  oldestSha: string;
+  firstDetectedMs: number;
+  /** Set when an Attention item was raised (age crossed the threshold). */
+  openedMs?: number;
+  attentionId?: string;
+  lastPriority?: ReadinessPriority;
+  resolvedMs?: number;
+  resolvedReason?: 'published' | 'stale' | 'rolled-back' | 'cleared';
+}
+
+export interface ReadinessState {
+  episodes: ReadinessEpisode[];
+  /** Episodes resolved recently — used for the re-raise hysteresis window. */
+  recentResolves: Array<{ oldestSha: string; resolvedMs: number }>;
+  /** Last failure-episode key we signaled, to dedupe fail-loud notices. */
+  lastFailureKey?: string;
+  lastTickAt?: number;
+  lastSignalAt?: number;
+  cacheHeadSha?: string;
+  canonicalRemoteOverridden?: boolean;
+  rollbackHistory?: Array<{ ts: number; sessionId?: string; reason?: string }>;
+}
+
+export type ReadinessPriority = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export interface AttentionItem {
+  id: string;
+  title: string;
+  summary: string;
+  category?: string;
+  priority?: string;
+}
+
+export interface ReleaseReadinessSentinelDeps {
+  /** Fetch canonical main; resolve FETCH_HEAD sha. ok:false ⇒ unreachable. */
+  fetchCanonical(): Promise<{ ok: boolean; headSha?: string }>;
+  /** Run analyze-release.js --json --ref against the canonical ref. null ⇒ error. */
+  runAnalyzer(ref: string): Promise<AnalyzerReport | null>;
+  /** Oldest unreleased feature/fix commit relative to lastTag..ref. */
+  oldestUnreleasedCommit(lastTag: string, ref: string): Promise<OldestCommit | null>;
+  /** True when the publish gate would refuse the guide (missing/template/unreviewed). */
+  guideBlocksPublish(): Promise<boolean>;
+  /** Best-effort: seed NEXT.md via Layer A (analyze-release.js --draft-guide). */
+  draftGuide(ref: string): Promise<void>;
+  /** Post an Attention item; resolves to true on delivery. */
+  postAttention(item: AttentionItem): Promise<boolean>;
+  /** Resolve an open Attention item by id. */
+  resolveAttention(id: string, reason: string): Promise<boolean>;
+  /** Load persisted state (or a fresh empty state). */
+  loadState(): ReadinessState;
+  /** Persist state atomically. */
+  saveState(state: ReadinessState): void;
+  /** Is `sha` an ancestor of `ref`? (for resolveEpisodesInRange) */
+  isAncestor(sha: string, ref: string): Promise<boolean>;
+  /** Append a structured audit line (sentinel-events.jsonl). */
+  audit(event: Record<string, unknown>): void;
+  now(): number;
+}
+
+export interface ReleaseReadinessSentinelConfig {
+  enabled?: boolean;
+  tickIntervalMs?: number;
+  backlogAgeDaysSilent?: number;
+  backlogAgeDaysLow?: number;
+  backlogAgeDaysMedium?: number;
+  backlogAgeDaysHigh?: number;
+  hysteresisHours?: number;
+  staleEpisodeTtlDays?: number;
+}
+
+const DEFAULTS: Required<ReleaseReadinessSentinelConfig> = {
+  enabled: false,
+  tickIntervalMs: 6 * 60 * 60 * 1000, // 6h
+  backlogAgeDaysSilent: 2,
+  backlogAgeDaysLow: 2,
+  backlogAgeDaysMedium: 4,
+  backlogAgeDaysHigh: 7,
+  hysteresisHours: 12,
+  staleEpisodeTtlDays: 30,
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+export class ReleaseReadinessSentinel extends EventEmitter {
+  private readonly cfg: Required<ReleaseReadinessSentinelConfig>;
+  private tickHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly deps: ReleaseReadinessSentinelDeps,
+    cfg: ReleaseReadinessSentinelConfig = {},
+  ) {
+    super();
+    this.cfg = { ...DEFAULTS, ...cfg };
+  }
+
+  start(): void {
+    if (!this.cfg.enabled || this.tickHandle) return;
+    this.tickHandle = setInterval(() => {
+      void this.tick();
+    }, this.cfg.tickIntervalMs);
+    if (typeof this.tickHandle.unref === 'function') this.tickHandle.unref();
+  }
+
+  stop(): void {
+    if (this.tickHandle) {
+      clearInterval(this.tickHandle);
+      this.tickHandle = null;
+    }
+  }
+
+  /** Priority for a given backlog age, or null when below the silent threshold. */
+  priorityForAge(ageDays: number): ReadinessPriority | null {
+    if (ageDays >= this.cfg.backlogAgeDaysHigh) return 'HIGH';
+    if (ageDays >= this.cfg.backlogAgeDaysMedium) return 'MEDIUM';
+    if (ageDays >= this.cfg.backlogAgeDaysLow) return 'LOW';
+    return null;
+  }
+
+  /** The cron entry point. Top-level catch converts any error into a loud signal. */
+  async tick(): Promise<void> {
+    const state = this.deps.loadState();
+    state.lastTickAt = this.deps.now();
+    try {
+      await this.evaluate(state);
+      this.deps.saveState(state);
+    } catch (err) {
+      // Fail-loud — a silent catch here would re-create the very silent-failure
+      // bug this sentinel exists to fix.
+      await this.failLoud(state, 'tick', err);
+      this.deps.saveState(state);
+    }
+  }
+
+  private async evaluate(state: ReadinessState): Promise<void> {
+    const fetched = await this.deps.fetchCanonical();
+    if (!fetched.ok) {
+      await this.failLoud(state, 'fetch', new Error('canonical ref unreachable'));
+      return;
+    }
+    state.cacheHeadSha = fetched.headSha;
+    const ref = fetched.headSha ?? 'FETCH_HEAD';
+
+    // Keep NEXT.md seeded (Layer A). Best-effort: a draft failure is not a
+    // readiness failure.
+    try {
+      await this.deps.draftGuide(ref);
+    } catch {
+      /* draft is advisory; the readiness signal below is what matters */
+    }
+
+    const report = await this.deps.runAnalyzer(ref);
+    if (!report) {
+      await this.failLoud(state, 'analyzer', new Error('analyze-release returned no report'));
+      return;
+    }
+
+    const blocked = this.isBlocked(report, await this.deps.guideBlocksPublish());
+    if (!blocked) {
+      // Backlog clear — resolve any open episodes.
+      await this.resolveAll(state, 'cleared');
+      // A successful evaluation clears any prior fail-loud episode.
+      state.lastFailureKey = undefined;
+      this.reap(state);
+      return;
+    }
+
+    const oldest = await this.deps.oldestUnreleasedCommit(report.lastTag, ref);
+    if (!oldest) {
+      // Blocked by coverage gaps but no datable commit — surface at LOW.
+      await this.raiseGapOnly(state, report);
+      this.reap(state);
+      return;
+    }
+
+    const ageDays = (this.deps.now() - oldest.dateMs) / DAY_MS;
+    const priority = this.priorityForAge(ageDays);
+
+    let episode = state.episodes.find((e) => e.oldestSha === oldest.sha && !e.resolvedMs);
+    if (!episode) {
+      episode = { oldestSha: oldest.sha, firstDetectedMs: this.deps.now() };
+      state.episodes.push(episode);
+    }
+
+    if (!priority) {
+      // Below the silent threshold — recorded, no message.
+      this.reap(state);
+      return;
+    }
+
+    // Hysteresis: don't re-raise the same sha within the window of a recent resolve.
+    const recent = state.recentResolves.find((r) => r.oldestSha === oldest.sha);
+    if (recent && this.deps.now() - recent.resolvedMs < this.cfg.hysteresisHours * HOUR_MS && !episode.openedMs) {
+      this.reap(state);
+      return;
+    }
+
+    if (!episode.openedMs || episode.lastPriority !== priority) {
+      const id = episode.attentionId ?? `release-readiness-${oldest.sha.slice(0, 12)}`;
+      const days = Math.floor(ageDays);
+      const delivered = await this.deps.postAttention({
+        id,
+        title: 'Release blocked — unreleased work is piling up',
+        summary:
+          `${report.analysis.commitClassification.features + report.analysis.commitClassification.fixes} ` +
+          `unreleased feature/fix commit(s) since ${report.lastTag}; oldest is ${days} day(s) old and publishing is blocked ` +
+          `(NEXT.md needs review/coverage). Oldest commit ${oldest.sha.slice(0, 12)}.`,
+        category: 'degradation',
+        priority,
+      });
+      episode.openedMs = episode.openedMs ?? this.deps.now();
+      episode.attentionId = id;
+      episode.lastPriority = priority;
+      state.lastSignalAt = this.deps.now();
+      this.deps.audit({ kind: 'release-readiness', event: 'signal', oldestSha: oldest.sha, priority, ageDays: days, delivered });
+      this.emit('signal', { oldestSha: oldest.sha, priority });
+    }
+    this.reap(state);
+  }
+
+  private isBlocked(report: AnalyzerReport, guideBlocks: boolean): boolean {
+    const featureOrFix =
+      report.analysis.commitClassification.features + report.analysis.commitClassification.fixes;
+    const backlogBlocked = featureOrFix > 0 && guideBlocks;
+    const coverageBlocked = report.guideCoverage.criticalGaps + report.guideCoverage.highGaps > 0;
+    return backlogBlocked || coverageBlocked;
+  }
+
+  private async raiseGapOnly(state: ReadinessState, report: AnalyzerReport): Promise<void> {
+    const id = 'release-readiness-coverage-gaps';
+    let episode = state.episodes.find((e) => e.oldestSha === id && !e.resolvedMs);
+    if (!episode) {
+      episode = { oldestSha: id, firstDetectedMs: this.deps.now() };
+      state.episodes.push(episode);
+    }
+    if (!episode.openedMs) {
+      const delivered = await this.deps.postAttention({
+        id,
+        title: 'Release blocked — upgrade-guide coverage gaps',
+        summary: `analyze-release reports ${report.guideCoverage.criticalGaps + report.guideCoverage.highGaps} critical/high coverage gap(s) in the upgrade guide. Publishing is blocked until they are addressed.`,
+        category: 'degradation',
+        priority: 'LOW',
+      });
+      episode.openedMs = this.deps.now();
+      episode.attentionId = id;
+      episode.lastPriority = 'LOW';
+      state.lastSignalAt = this.deps.now();
+      this.deps.audit({ kind: 'release-readiness', event: 'signal-gaps', delivered });
+    }
+  }
+
+  private async failLoud(state: ReadinessState, stage: string, err: unknown): Promise<void> {
+    const key = `failure:${stage}`;
+    this.deps.audit({ kind: 'release-readiness', event: 'eval-failed', stage, error: String(err) });
+    if (state.lastFailureKey === key) return; // dedupe per failure episode
+    state.lastFailureKey = key;
+    await this.deps.postAttention({
+      id: `release-readiness-eval-failure-${stage}`,
+      title: 'Release-readiness check could not evaluate',
+      summary: `The release-readiness check failed at the "${stage}" stage: ${String(err)}. Last evaluated ${state.lastSignalAt ? new Date(state.lastSignalAt).toISOString() : 'never'}.`,
+      category: 'degradation',
+      priority: 'LOW',
+    });
+    state.lastSignalAt = this.deps.now();
+    this.emit('eval-failed', { stage });
+  }
+
+  private async resolveAll(state: ReadinessState, reason: ReadinessEpisode['resolvedReason']): Promise<void> {
+    for (const e of state.episodes) {
+      if (e.resolvedMs) continue;
+      if (e.attentionId) await this.deps.resolveAttention(e.attentionId, reason ?? 'cleared');
+      e.resolvedMs = this.deps.now();
+      e.resolvedReason = reason;
+      state.recentResolves.push({ oldestSha: e.oldestSha, resolvedMs: this.deps.now() });
+      this.deps.audit({ kind: 'release-readiness', event: 'resolved', oldestSha: e.oldestSha, reason });
+    }
+  }
+
+  /**
+   * Called by the publish-finalize path (and the /rollback route via 'rolled-back').
+   * Resolves every open episode whose oldestSha is an ancestor of newTagSha —
+   * correct even when the oldest-unreleased SHA churned during the open window.
+   */
+  async resolveEpisodesInRange(newTagSha: string, reason: ReadinessEpisode['resolvedReason'] = 'published'): Promise<void> {
+    const state = this.deps.loadState();
+    let changed = false;
+    for (const e of state.episodes) {
+      if (e.resolvedMs) continue;
+      if (e.oldestSha.startsWith('release-readiness-')) continue; // synthetic (gap) episodes
+      const ancestor = await this.deps.isAncestor(e.oldestSha, newTagSha);
+      if (ancestor) {
+        if (e.attentionId) await this.deps.resolveAttention(e.attentionId, reason ?? 'published');
+        e.resolvedMs = this.deps.now();
+        e.resolvedReason = reason;
+        state.recentResolves.push({ oldestSha: e.oldestSha, resolvedMs: this.deps.now() });
+        this.deps.audit({ kind: 'release-readiness', event: 'resolved-in-range', oldestSha: e.oldestSha, newTagSha, reason });
+        changed = true;
+      }
+    }
+    if (changed) this.deps.saveState(state);
+  }
+
+  /** TTL-reap episodes/resolves so state doesn't grow unbounded. */
+  private reap(state: ReadinessState): void {
+    const ttl = this.cfg.staleEpisodeTtlDays * DAY_MS;
+    const now = this.deps.now();
+    for (const e of state.episodes) {
+      if (!e.resolvedMs && now - e.firstDetectedMs > ttl) {
+        // Backlog vanished without a finalize (e.g. branch abandoned) — reap loudly.
+        e.resolvedMs = now;
+        e.resolvedReason = 'stale';
+        if (e.attentionId) void this.deps.resolveAttention(e.attentionId, 'stale');
+        this.deps.audit({ kind: 'release-readiness', event: 'reaped-stale', oldestSha: e.oldestSha });
+      }
+    }
+    state.episodes = state.episodes.filter((e) => !e.resolvedMs || now - (e.resolvedMs ?? 0) < ttl);
+    state.recentResolves = state.recentResolves.filter((r) => now - r.resolvedMs < this.cfg.hysteresisHours * HOUR_MS * 2);
+    if ((state.rollbackHistory?.length ?? 0) > 50) {
+      state.rollbackHistory = state.rollbackHistory!.slice(-50);
+    }
+  }
+
+  static emptyState(): ReadinessState {
+    return { episodes: [], recentResolves: [] };
+  }
+}

--- a/src/monitoring/ReleaseReadinessSentinel.ts
+++ b/src/monitoring/ReleaseReadinessSentinel.ts
@@ -69,7 +69,10 @@ export interface ReadinessState {
   lastSignalAt?: number;
   cacheHeadSha?: string;
   canonicalRemoteOverridden?: boolean;
-  rollbackHistory?: Array<{ ts: number; sessionId?: string; reason?: string }>;
+  /** Runtime kill-switch set by POST /release-readiness/rollback. When true,
+   *  tick() no-ops without evaluating. Cleared by /release-readiness/enable. */
+  disabled?: boolean;
+  rollbackHistory?: Array<{ ts: number; sessionId?: string; sourceIp?: string; reason?: string }>;
 }
 
 export type ReadinessPriority = 'LOW' | 'MEDIUM' | 'HIGH';
@@ -172,6 +175,11 @@ export class ReleaseReadinessSentinel extends EventEmitter {
   async tick(): Promise<void> {
     const state = this.deps.loadState();
     state.lastTickAt = this.deps.now();
+    if (state.disabled) {
+      this.deps.audit({ kind: 'release-readiness', event: 'tick-skipped-disabled' });
+      this.deps.saveState(state);
+      return;
+    }
     try {
       await this.evaluate(state);
       this.deps.saveState(state);
@@ -181,6 +189,42 @@ export class ReleaseReadinessSentinel extends EventEmitter {
       await this.failLoud(state, 'tick', err);
       this.deps.saveState(state);
     }
+  }
+
+  /** Read-only snapshot of current state (for GET /release-readiness). */
+  snapshot(): ReadinessState {
+    return this.deps.loadState();
+  }
+
+  /**
+   * Runtime kill-switch (POST /release-readiness/rollback). Disables future
+   * ticks, resolves all open Attention items, and is ITSELF loud — raises a
+   * HIGH-priority Attention item + audits — so the rollback can never be a
+   * silent way to mute the alarm (iter-3 Adversarial V5).
+   */
+  async rollback(meta: { sessionId?: string; sourceIp?: string } = {}): Promise<void> {
+    const state = this.deps.loadState();
+    state.disabled = true;
+    await this.resolveAll(state, 'rolled-back');
+    state.rollbackHistory ??= [];
+    state.rollbackHistory.push({ ts: this.deps.now(), sessionId: meta.sessionId, sourceIp: meta.sourceIp, reason: 'rollback' });
+    this.deps.audit({ kind: 'release-readiness', event: 'rollback', sessionId: meta.sessionId, sourceIp: meta.sourceIp });
+    await this.deps.postAttention({
+      id: 'release-readiness-rolled-back',
+      title: 'Release-readiness alarm disabled',
+      summary: `The release-readiness watchdog was disabled via /release-readiness/rollback${meta.sessionId ? ` by session ${meta.sessionId}` : ''} at ${new Date(this.deps.now()).toISOString()}. Re-enable via POST /release-readiness/enable.`,
+      category: 'degradation',
+      priority: 'HIGH',
+    });
+    this.deps.saveState(state);
+  }
+
+  /** Re-arm after a rollback. */
+  enable(): void {
+    const state = this.deps.loadState();
+    state.disabled = false;
+    this.deps.audit({ kind: 'release-readiness', event: 'enabled' });
+    this.deps.saveState(state);
   }
 
   private async evaluate(state: ReadinessState): Promise<void> {

--- a/src/monitoring/releaseReadinessWiring.ts
+++ b/src/monitoring/releaseReadinessWiring.ts
@@ -1,0 +1,281 @@
+/**
+ * releaseReadinessWiring — builds the real I/O dependencies for the
+ * ReleaseReadinessSentinel (Layer B of release-readiness-visibility).
+ *
+ * Extracted from server.ts so the dependency construction is itself
+ * unit-testable (Testing Integrity Standard: every dependency-injected
+ * component needs wiring-integrity tests proving deps are real functions, not
+ * nulls or silent no-ops).
+ *
+ * Repo-gated: the sentinel analyzes the instar git repo, which only exists in
+ * the dev/maintainer environment. `isAnalyzableRepo` lets the server decide
+ * whether to construct + start the sentinel at all on a given install.
+ *
+ * All git goes through SafeGitExecutor (audited funnel, execFileSync — no shell).
+ * Canonical-remote reads are allow-listed to github.com:JKHeadley/instar so a
+ * config override to a fork raises a HIGH-priority signal rather than silently
+ * trusting a stale fork (spec §4.2.2).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
+import type {
+  ReleaseReadinessSentinelDeps,
+  ReadinessState,
+  AnalyzerReport,
+  OldestCommit,
+  AttentionItem,
+} from './ReleaseReadinessSentinel.js';
+import { ReleaseReadinessSentinel } from './ReleaseReadinessSentinel.js';
+
+/** Anchored on the known canonical host — not "any URL ending in JKHeadley/instar". */
+export const CANONICAL_REMOTE_RE = /^(https:\/\/github\.com\/|git@github\.com:)JKHeadley\/instar(\.git)?$/;
+
+export interface ReleaseReadinessWiringOpts {
+  /** The instar git checkout to analyze (Echo: the agent home). */
+  repoPath: string;
+  /** Path to .instar/state/release-readiness.json. */
+  statePath: string;
+  /** Path to logs/sentinel-events.jsonl. */
+  auditPath: string;
+  /** Local server port + auth for Attention posting. */
+  port: number;
+  authToken: string;
+  /** Configured canonical remote name (default: auto-detect a JKHeadley/instar remote). */
+  canonicalRemote?: string;
+  fetchTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+/** Is `repoPath` an instar git checkout we can actually analyze? */
+export function isAnalyzableRepo(repoPath: string): boolean {
+  try {
+    return (
+      fs.existsSync(path.join(repoPath, '.git')) &&
+      fs.existsSync(path.join(repoPath, 'scripts', 'analyze-release.js')) &&
+      fs.existsSync(path.join(repoPath, 'package.json'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve the canonical-main remote name and whether it was overridden to a non-canonical URL. */
+export function resolveCanonicalRemote(
+  repoPath: string,
+  configured?: string,
+): { remote: string; overridden: boolean } {
+  let remotesRaw = '';
+  try {
+    remotesRaw = SafeGitExecutor.run(['remote', '-v'], { cwd: repoPath, operation: 'releaseReadinessWiring:resolveRemote' });
+  } catch {
+    return { remote: configured ?? 'origin', overridden: configured != null };
+  }
+  const remotes = new Map<string, string>();
+  for (const line of remotesRaw.split('\n')) {
+    const m = /^(\S+)\s+(\S+)\s+\(fetch\)/.exec(line);
+    if (m) remotes.set(m[1], m[2]);
+  }
+  if (configured) {
+    const url = remotes.get(configured) ?? '';
+    return { remote: configured, overridden: !CANONICAL_REMOTE_RE.test(url) };
+  }
+  for (const [name, url] of remotes) {
+    if (CANONICAL_REMOTE_RE.test(url)) return { remote: name, overridden: false };
+  }
+  return { remote: 'origin', overridden: !CANONICAL_REMOTE_RE.test(remotes.get('origin') ?? '') };
+}
+
+function runAnalyzerSubprocess(repoPath: string, args: string[], timeoutMs: number): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [path.join(repoPath, 'scripts', 'analyze-release.js'), ...args],
+      { cwd: repoPath, timeout: timeoutMs, maxBuffer: 16 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err && !stdout) return resolve(null);
+        resolve(stdout ?? null);
+      },
+    );
+  });
+}
+
+export function buildReleaseReadinessDeps(opts: ReleaseReadinessWiringOpts): ReleaseReadinessSentinelDeps {
+  const now = opts.now ?? (() => Date.now());
+  const fetchTimeoutMs = opts.fetchTimeoutMs ?? 30_000;
+  const { remote, overridden } = resolveCanonicalRemote(opts.repoPath, opts.canonicalRemote);
+  // Coalesce concurrent fetches (Layer B + a future Layer C tick) onto one promise.
+  let inflightFetch: Promise<{ ok: boolean; headSha?: string }> | null = null;
+
+  const postAttention = makeAttentionPoster(opts);
+
+  const audit = (event: Record<string, unknown>): void => {
+    try {
+      fs.appendFileSync(opts.auditPath, JSON.stringify({ ts: new Date(now()).toISOString(), ...event }) + '\n');
+    } catch {
+      /* audit is best-effort; never crash the monitoring path */
+    }
+  };
+
+  return {
+    fetchCanonical: () => {
+      if (inflightFetch) return inflightFetch;
+      inflightFetch = (async () => {
+        try {
+          SafeGitExecutor.run(
+            ['fetch', remote, 'main', '--depth=1', '--no-tags', '--no-recurse-submodules'],
+            { cwd: opts.repoPath, operation: 'releaseReadinessWiring:fetch', timeout: fetchTimeoutMs },
+          );
+          const headSha = SafeGitExecutor.run(['rev-parse', 'FETCH_HEAD'], {
+            cwd: opts.repoPath,
+            operation: 'releaseReadinessWiring:revparse',
+          }).trim();
+          return { ok: true, headSha };
+        } catch {
+          return { ok: false };
+        } finally {
+          inflightFetch = null;
+        }
+      })();
+      return inflightFetch;
+    },
+
+    runAnalyzer: async (ref) => {
+      const out = await runAnalyzerSubprocess(opts.repoPath, ['--json', `--ref=${ref}`], fetchTimeoutMs);
+      if (!out || !out.trim()) return null;
+      try {
+        const j = JSON.parse(out);
+        const r: AnalyzerReport = {
+          lastTag: j.lastTag,
+          commitCount: j.commitCount,
+          analysis: {
+            commitClassification: {
+              features: j.analysis?.commitClassification?.features ?? 0,
+              fixes: j.analysis?.commitClassification?.fixes ?? 0,
+            },
+          },
+          guideCoverage: {
+            criticalGaps: j.guideCoverage?.criticalGaps ?? 0,
+            highGaps: j.guideCoverage?.highGaps ?? 0,
+          },
+        };
+        return r;
+      } catch {
+        return null;
+      }
+    },
+
+    oldestUnreleasedCommit: async (lastTag, ref) => {
+      try {
+        const raw = SafeGitExecutor.run(
+          ['log', `${lastTag}..${ref}`, '--no-merges', '--reverse', '--format=%H %ct'],
+          { cwd: opts.repoPath, operation: 'releaseReadinessWiring:oldest' },
+        ).trim();
+        const first = raw.split('\n').filter(Boolean)[0];
+        if (!first) return null;
+        const [sha, ct] = first.split(' ');
+        const out: OldestCommit = { sha, dateMs: Number(ct) * 1000 };
+        return out;
+      } catch {
+        return null;
+      }
+    },
+
+    guideBlocksPublish: async () => {
+      const nextPath = path.join(opts.repoPath, 'upgrades', 'NEXT.md');
+      if (!fs.existsSync(nextPath)) return true;
+      const c = fs.readFileSync(nextPath, 'utf-8');
+      if (c.includes('[Feature name]') && c.includes('[Capability]')) return true; // pristine template
+      if (c.includes('auto-draft-unreviewed')) return true; // un-reviewed auto-draft
+      return false;
+    },
+
+    draftGuide: async (ref) => {
+      await runAnalyzerSubprocess(opts.repoPath, ['--draft-guide', `--ref=${ref}`], fetchTimeoutMs);
+    },
+
+    postAttention,
+
+    resolveAttention: async (id, reason) => {
+      try {
+        const doFetch = opts.fetchImpl ?? fetch;
+        const resp = await doFetch(`http://localhost:${opts.port}/attention/${encodeURIComponent(id)}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${opts.authToken}` },
+          body: JSON.stringify({ status: 'resolved', reason }),
+        });
+        return resp.ok;
+      } catch {
+        return false;
+      }
+    },
+
+    loadState: () => loadReadinessState(opts.statePath, overridden),
+    saveState: (state) => saveReadinessState(opts.statePath, state),
+
+    isAncestor: async (sha, ref) => {
+      try {
+        // merge-base --is-ancestor exits 0 when sha is an ancestor of ref, 1 otherwise.
+        SafeGitExecutor.run(['merge-base', '--is-ancestor', sha, ref], {
+          cwd: opts.repoPath,
+          operation: 'releaseReadinessWiring:isAncestor',
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+
+    audit,
+    now,
+  };
+}
+
+export function loadReadinessState(statePath: string, canonicalRemoteOverridden = false): ReadinessState {
+  try {
+    if (fs.existsSync(statePath)) {
+      const parsed = JSON.parse(fs.readFileSync(statePath, 'utf-8')) as ReadinessState;
+      parsed.episodes ??= [];
+      parsed.recentResolves ??= [];
+      parsed.canonicalRemoteOverridden = canonicalRemoteOverridden;
+      return parsed;
+    }
+  } catch {
+    /* corrupt state → start fresh rather than crash the tick */
+  }
+  const fresh = ReleaseReadinessSentinel.emptyState();
+  fresh.canonicalRemoteOverridden = canonicalRemoteOverridden;
+  return fresh;
+}
+
+export function saveReadinessState(statePath: string, state: ReadinessState): void {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  const tmp = `${statePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  fs.renameSync(tmp, statePath); // atomic replace (rename is not a destructive-lint verb)
+}
+
+export type AttentionPoster = (item: AttentionItem) => Promise<boolean>;
+
+export function makeAttentionPoster(opts: {
+  port: number;
+  authToken: string;
+  fetchImpl?: typeof fetch;
+}): AttentionPoster {
+  const doFetch = opts.fetchImpl ?? fetch;
+  return async (item) => {
+    try {
+      const resp = await doFetch(`http://localhost:${opts.port}/attention`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${opts.authToken}` },
+        body: JSON.stringify({ category: 'degradation', priority: 'LOW', source: 'release-readiness', ...item }),
+      });
+      return resp.status === 201 || resp.ok;
+    } catch {
+      return false;
+    }
+  };
+}

--- a/src/monitoring/releaseReadinessWiring.ts
+++ b/src/monitoring/releaseReadinessWiring.ts
@@ -125,8 +125,14 @@ export function buildReleaseReadinessDeps(opts: ReleaseReadinessWiringOpts): Rel
       if (inflightFetch) return inflightFetch;
       inflightFetch = (async () => {
         try {
+          // Spec §4.2.2 originally said --depth=1; an E2E against a fixture (and
+          // by extension a real install with full local history) showed --depth=1
+          // turns the LOCAL repo shallow, which breaks `git log v0.0.1..ref` for
+          // analyze-release. --no-tags --no-recurse-submodules keeps the fetch
+          // bounded without shallowing; incremental fetches against an existing
+          // checkout transfer only new objects.
           SafeGitExecutor.run(
-            ['fetch', remote, 'main', '--depth=1', '--no-tags', '--no-recurse-submodules'],
+            ['fetch', remote, 'main', '--no-tags', '--no-recurse-submodules'],
             { cwd: opts.repoPath, operation: 'releaseReadinessWiring:fetch', timeout: fetchTimeoutMs },
           );
           const headSha = SafeGitExecutor.run(['rev-parse', 'FETCH_HEAD'], {

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -482,6 +482,11 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - Resolve: \`curl -X PATCH -H "Authorization: Bearer $AUTH" http://localhost:${port}/attention/ATT-ID -H 'Content-Type: application/json' -d '{"status":"resolved","resolution":"Done"}'\`
 - **Proactive use**: When you detect something the user should know about (stale relationships, failed jobs, CI failures, overdue actions) — don't just log it. Queue it. The attention system ensures it gets seen.
 
+**Release Readiness** (instar-dev / maintainer environments only) — A repo-gated watchdog that makes a stalled instar release impossible to miss. It evaluates canonical \`main\`, and when finished work sits unreleased while publishing is blocked, raises ONE deduped, age-escalating item on the Attention queue. Ships OFF; the \`release-readiness-check\` job drives it. Null/503 on any install with no analyzable instar git repo.
+- Status: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/release-readiness\` (state, open episodes, last tick/signal)
+- Run one check now: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/release-readiness/tick\`
+- Disable (loud — raises a HIGH attention item + audits, never silent): \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/release-readiness/rollback\` · re-arm: \`.../release-readiness/enable\`
+
 **Skip Ledger** — Track computational work to avoid repeating expensive operations. When a job or session processes items (files, messages, records), log what was processed so the next run can skip already-handled items.
 - View ledger: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/skip-ledger\`
 - View workloads: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/skip-ledger/workloads\`

--- a/src/scaffold/templates/jobs/instar/release-readiness-check.md
+++ b/src/scaffold/templates/jobs/instar/release-readiness-check.md
@@ -1,0 +1,24 @@
+---
+name: Release Readiness Check
+description: Surface a stalled/blocked instar release (Layer B of release-readiness-visibility). Evaluates canonical main and raises ONE deduped Attention item when finished work sits unreleased too long. Ships OFF — Echo dogfoods first.
+schedule: "0 */6 * * *"
+priority: low
+expectedDurationMinutes: 1
+model: haiku
+enabled: false
+tags:
+  - cat:release-hygiene
+  - role:worker
+  - exec:prompt
+gate: curl -sf http://localhost:${INSTAR_PORT:-4042}/health >/dev/null 2>&1
+toolAllowlist: "*"
+unrestrictedTools: true
+---
+Run the release-readiness check once. This is a mechanical, near-silent watchdog — do NOT message the user.
+
+AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+
+1. Trigger one evaluation tick:
+   curl -s -X POST http://localhost:${INSTAR_PORT:-4042}/release-readiness/tick -H "Authorization: Bearer $AUTH"
+2. That endpoint runs the ReleaseReadinessSentinel: it fetches canonical main, checks whether unreleased feature/fix work is piling up while publishing is blocked, and (only above the age threshold) raises a single deduped Attention item. All transitions are written to logs/sentinel-events.jsonl.
+3. Exit silently. The sentinel owns all signalling (Attention queue) — this job is just the cadence. Do not relay anything to Telegram; do not summarize. If the curl fails, that is itself recorded by the server; do not retry-flood.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -145,6 +145,7 @@ export class AgentServer {
     semanticMemory?: import('../memory/SemanticMemory.js').SemanticMemory;
     activitySentinel?: import('../monitoring/SessionActivitySentinel.js').SessionActivitySentinel;
     rateLimitSentinel?: import('../monitoring/RateLimitSentinel.js').RateLimitSentinel;
+    releaseReadinessSentinel?: import('../monitoring/ReleaseReadinessSentinel.js').ReleaseReadinessSentinel;
     workingMemory?: import('../memory/WorkingMemoryAssembler.js').WorkingMemoryAssembler;
     quotaManager?: import('../monitoring/QuotaManager.js').QuotaManager;
     messageRouter?: MessageRouter;
@@ -544,6 +545,7 @@ export class AgentServer {
       semanticMemory: options.semanticMemory ?? null,
       activitySentinel: options.activitySentinel ?? null,
       rateLimitSentinel: options.rateLimitSentinel ?? null,
+      releaseReadinessSentinel: options.releaseReadinessSentinel ?? null,
       workingMemory: options.workingMemory ?? null,
       quotaManager: options.quotaManager ?? null,
       messageRouter: options.messageRouter ?? null,

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -56,6 +56,20 @@ export interface CapabilityEntry {
 
 export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
   {
+    key: 'releaseReadiness',
+    prefixes: ['/release-readiness'],
+    description: 'Release-readiness watchdog (instar-dev / maintainer environments). Surfaces a stalled release as one deduped, age-escalating Attention item. Null on installs with no analyzable instar repo.',
+    build: ({ ctx }) => ({
+      configured: !!ctx.releaseReadinessSentinel,
+      endpoints: [
+        'GET /release-readiness',
+        'POST /release-readiness/tick',
+        'POST /release-readiness/rollback',
+        'POST /release-readiness/enable',
+      ],
+    }),
+  },
+  {
     key: 'telegram',
     prefixes: ['/telegram'],
     description: 'Telegram messaging adapter (bidirectional)',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -548,6 +548,9 @@ export interface RouteContext {
   semanticMemory: SemanticMemory | null;
   activitySentinel: SessionActivitySentinel | null;
   rateLimitSentinel: import('../monitoring/RateLimitSentinel.js').RateLimitSentinel | null;
+  /** ReleaseReadinessSentinel (Layer B of release-readiness-visibility). Null on
+   *  installs with no analyzable instar git repo, or when disabled in config. */
+  releaseReadinessSentinel: import('../monitoring/ReleaseReadinessSentinel.js').ReleaseReadinessSentinel | null;
   messageRouter: MessageRouter | null;
   summarySentinel: SessionSummarySentinel | null;
   spawnManager: SpawnRequestManager | null;
@@ -4153,6 +4156,65 @@ export function createRoutes(ctx: RouteContext): Router {
       summary: ctx.tokenLedger.summary({ sinceMs }),
       codex: ctx.tokenLedger.codexSummary({ sinceMs }),
     });
+  });
+
+  // ── Release-readiness (Layer B of release-readiness-visibility) ──────
+  // Null when there's no analyzable instar git repo or the feature is off.
+  router.get('/release-readiness', (_req, res) => {
+    if (!ctx.releaseReadinessSentinel) {
+      res.status(503).json({ error: 'release-readiness watchdog not configured (no analyzable instar repo or disabled)' });
+      return;
+    }
+    const s = ctx.releaseReadinessSentinel.snapshot();
+    const openEpisode = s.episodes.find((e) => !e.resolvedMs && e.openedMs);
+    // Served from the local host's cache; on a multi-machine follower this may
+    // lag the leader by up to one lease-handoff (spec §4.2.7).
+    res.setHeader('X-Readiness-Source', 'leader');
+    res.json({
+      disabled: s.disabled ?? false,
+      lastTickAt: s.lastTickAt,
+      lastSignalAt: s.lastSignalAt,
+      cacheHeadSha: s.cacheHeadSha,
+      canonicalRemoteOverridden: s.canonicalRemoteOverridden ?? false,
+      openEpisodes: s.episodes.filter((e) => !e.resolvedMs).length,
+      oldestOpenSha: openEpisode?.oldestSha,
+      openAttentionId: openEpisode?.attentionId,
+      rollbackHistory: (s.rollbackHistory ?? []).slice(-5),
+    });
+  });
+
+  // The job (off by default) calls this on its cadence — tick() is the cron
+  // entry point. Runs one evaluation; the sentinel owns all signalling.
+  router.post('/release-readiness/tick', async (_req, res) => {
+    if (!ctx.releaseReadinessSentinel) {
+      res.status(503).json({ error: 'release-readiness watchdog not configured' });
+      return;
+    }
+    await ctx.releaseReadinessSentinel.tick();
+    res.json({ ok: true });
+  });
+
+  // Rollback is bearer-gated AND loud: it raises a HIGH-priority Attention item
+  // + audits, so it can't silently mute the alarm (spec §4.2.7 / iter-3 V5).
+  router.post('/release-readiness/rollback', async (req, res) => {
+    if (!ctx.releaseReadinessSentinel) {
+      res.status(503).json({ error: 'release-readiness watchdog not configured' });
+      return;
+    }
+    await ctx.releaseReadinessSentinel.rollback({
+      sessionId: typeof req.body?.sessionId === 'string' ? req.body.sessionId : undefined,
+      sourceIp: req.ip,
+    });
+    res.json({ ok: true, rolledBack: true });
+  });
+
+  router.post('/release-readiness/enable', (_req, res) => {
+    if (!ctx.releaseReadinessSentinel) {
+      res.status(503).json({ error: 'release-readiness watchdog not configured' });
+      return;
+    }
+    ctx.releaseReadinessSentinel.enable();
+    res.json({ ok: true, enabled: true });
   });
 
   // ── Human-as-Detector heat map ───────────────────────────────────────

--- a/tests/e2e/release-readiness-live.test.ts
+++ b/tests/e2e/release-readiness-live.test.ts
@@ -1,0 +1,130 @@
+/**
+ * E2E — ReleaseReadinessSentinel against REAL I/O (release-readiness-visibility).
+ *
+ * The "feature is alive" proof: a real fixture instar repo (real git history +
+ * a real blocking NEXT.md), a real canonical remote, the REAL wiring
+ * (buildReleaseReadinessDeps → real git fetch + real analyze-release.js
+ * subprocess + real merge-base), driving a real sentinel tick. Only the
+ * Attention HTTP sink is captured (so we can assert without standing up a
+ * server). Reproduces the original silent stall and shows it now surfaces.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { buildReleaseReadinessDeps } from '../../src/monitoring/releaseReadinessWiring.js';
+import { ReleaseReadinessSentinel, type AttentionItem } from '../../src/monitoring/ReleaseReadinessSentinel.js';
+
+const REAL_SCRIPT = path.resolve(__dirname, '../../scripts/analyze-release.js');
+
+describe('ReleaseReadinessSentinel — real I/O E2E', () => {
+  let repo: string;
+  let canon: string;
+
+  function git(cwd: string, args: string[], env?: Record<string, string>): string {
+    const prev: Record<string, string | undefined> = {};
+    if (env) for (const k of Object.keys(env)) { prev[k] = process.env[k]; process.env[k] = env[k]; }
+    try {
+      return SafeGitExecutor.run(args, { cwd, operation: 'tests/e2e/release-readiness-live.test.ts:git' });
+    } finally {
+      if (env) for (const k of Object.keys(env)) { if (prev[k] === undefined) delete process.env[k]; else process.env[k] = prev[k]; }
+    }
+  }
+
+  function commit(msg: string, file: string, daysAgo = 0): void {
+    const full = path.join(repo, file);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, `${file}\n${msg}\n`);
+    git(repo, ['add', '-A']);
+    const date = new Date(Date.now() - daysAgo * 86400_000).toISOString();
+    git(repo, ['commit', '-m', msg], { GIT_COMMITTER_DATE: date, GIT_AUTHOR_DATE: date });
+  }
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-e2e-repo-'));
+    canon = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-e2e-canon-'));
+
+    fs.mkdirSync(path.join(repo, 'scripts'), { recursive: true });
+    fs.copyFileSync(REAL_SCRIPT, path.join(repo, 'scripts', 'analyze-release.js'));
+    fs.writeFileSync(path.join(repo, 'package.json'), JSON.stringify({ name: 'fixture', version: '9.9.9', type: 'module' }, null, 2));
+    fs.mkdirSync(path.join(repo, 'upgrades'), { recursive: true });
+
+    git(repo, ['init', '-q', '-b', 'main']);
+    git(repo, ['config', 'user.email', 'fixture@instar.local']);
+    git(repo, ['config', 'user.name', 'Fixture']);
+    git(repo, ['config', 'commit.gpgsign', 'false']);
+
+    commit('chore: initial', 'README.md', 10);
+    git(repo, ['tag', 'v0.0.1']);
+    // Two unreleased feature commits, the oldest 5 days ago (past the 2-day silent threshold).
+    commit('feat: add alpha endpoint', 'src/server/routes.ts', 5);
+    commit('feat: add beta endpoint', 'src/server/extra.ts', 4);
+    // A NEXT.md that BLOCKS publishing (still carries an auto-draft-unreviewed marker).
+    fs.writeFileSync(
+      path.join(repo, 'upgrades', 'NEXT.md'),
+      '# Upgrade Guide — vNEXT\n<!-- bump: minor -->\n## What Changed\n<!-- auto-draft-unreviewed: what-changed -->\n- stuff\n',
+    );
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-m', 'chore: seed NEXT.md'], { GIT_COMMITTER_DATE: new Date(Date.now() - 4 * 86400_000).toISOString() });
+
+    // Canonical remote: a bare repo we push main to, registered as a remote.
+    git(canon, ['init', '-q', '--bare']);
+    git(repo, ['remote', 'add', 'canon', `file://${canon}`]);
+    git(repo, ['push', '-q', 'canon', 'main']);
+  });
+
+  afterEach(() => {
+    for (const d of [repo, canon]) {
+      SafeFsExecutor.safeRmSync(d, { recursive: true, force: true, operation: 'tests/e2e/release-readiness-live.test.ts:afterEach' });
+    }
+  });
+
+  it('real git + real analyzer + real fetch → one Attention signal for the aged, blocked backlog', async () => {
+    const posted: AttentionItem[] = [];
+    const deps = buildReleaseReadinessDeps({
+      repoPath: repo,
+      statePath: path.join(repo, '.instar', 'state', 'release-readiness.json'),
+      auditPath: path.join(repo, '.instar', 'logs', 'sentinel-events.jsonl'),
+      port: 0,
+      authToken: 'x',
+      canonicalRemote: 'canon',
+    });
+    // Capture the Attention sink; keep ALL other deps real (git/analyzer/state).
+    deps.postAttention = async (i) => { posted.push(i); return true; };
+
+    const sentinel = new ReleaseReadinessSentinel(deps, { enabled: true });
+    await sentinel.tick();
+
+    // Real pipeline detected the blocked, aged backlog and surfaced exactly one signal.
+    expect(posted).toHaveLength(1);
+    expect(posted[0].title).toContain('Release blocked');
+    expect(posted[0].priority === 'MEDIUM' || posted[0].priority === 'LOW' || posted[0].priority === 'HIGH').toBe(true);
+
+    // State persisted to disk with an open episode keyed on a real commit sha.
+    const state = deps.loadState();
+    const open = state.episodes.filter((e) => !e.resolvedMs);
+    expect(open).toHaveLength(1);
+    expect(open[0].oldestSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(state.lastTickAt).toBeGreaterThan(0);
+
+    // Re-tick is idempotent (deduped on the real sha).
+    await sentinel.tick();
+    expect(posted).toHaveLength(1);
+  }, 30_000);
+
+  it('real analyzer reports the unreleased feature commits since the tag', async () => {
+    const deps = buildReleaseReadinessDeps({
+      repoPath: repo, statePath: path.join(repo, '.instar', 's.json'), auditPath: path.join(repo, '.instar', 'a.jsonl'),
+      port: 0, authToken: 'x', canonicalRemote: 'canon',
+    });
+    const fetched = await deps.fetchCanonical();
+    expect(fetched.ok).toBe(true);
+    const report = await deps.runAnalyzer(fetched.headSha ?? 'FETCH_HEAD');
+    expect(report).not.toBeNull();
+    expect(report!.analysis.commitClassification.features).toBeGreaterThanOrEqual(2);
+    expect(await deps.guideBlocksPublish()).toBe(true); // unreviewed marker present
+  }, 30_000);
+});

--- a/tests/e2e/tunnel-private-view.test.ts
+++ b/tests/e2e/tunnel-private-view.test.ts
@@ -251,7 +251,20 @@ describe('Tunnel + Private Viewer E2E', () => {
       return;
     }
 
-    const body = await res.json();
+    // Cloudflare quick-tunnels occasionally return 200 with an empty body
+    // mid-route-handoff. Tolerate that the same way we tolerate other transient
+    // network conditions above, instead of crashing on `res.json()`.
+    const text = await res.text();
+    if (!text.trim()) {
+      console.log('[E2E] Tunnel health returned empty body — transient network condition, skipping');
+      return;
+    }
+    let body: { status?: string };
+    try { body = JSON.parse(text); }
+    catch {
+      console.log(`[E2E] Tunnel health returned non-JSON body (${text.slice(0, 60)}…) — skipping`);
+      return;
+    }
     expect(body.status).toBe('ok');
   }, 45_000);
 

--- a/tests/integration/release-readiness-routes.test.ts
+++ b/tests/integration/release-readiness-routes.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration — /release-readiness routes (Layer B, release-readiness-visibility).
+ *
+ * Mounts the REAL router with a REAL ReleaseReadinessSentinel (controllable
+ * deps) and exercises the HTTP surface end-to-end. Also serves as the bug-fix
+ * evidence: a blocked + aged backlog (the original silent-stall shape) produces
+ * exactly one Attention signal once a tick runs — i.e. the stall now surfaces.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import {
+  ReleaseReadinessSentinel,
+  type ReleaseReadinessSentinelDeps,
+  type ReadinessState,
+  type AttentionItem,
+} from '../../src/monitoring/ReleaseReadinessSentinel.js';
+import { createRoutes } from '../../src/server/routes.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+interface Server { url: string; close: () => Promise<void>; }
+async function listen(app: express.Express): Promise<Server> {
+  return new Promise((resolve) => {
+    const srv = app.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => srv.close(() => r())) });
+    });
+  });
+}
+
+function makeSentinel(over: Partial<{ blocked: boolean; ageDays: number }> = {}) {
+  const posted: AttentionItem[] = [];
+  const resolved: Array<{ id: string; reason: string }> = [];
+  let state: ReadinessState = ReleaseReadinessSentinel.emptyState();
+  const clock = Date.UTC(2026, 4, 27);
+  const blocked = over.blocked ?? true;
+  const ageDays = over.ageDays ?? 5;
+  const deps: ReleaseReadinessSentinelDeps = {
+    fetchCanonical: async () => ({ ok: true, headSha: 'f'.repeat(40) }),
+    runAnalyzer: async () => ({
+      lastTag: 'v1.0.0',
+      commitCount: blocked ? 3 : 0,
+      analysis: { commitClassification: { features: blocked ? 3 : 0, fixes: 0 } },
+      guideCoverage: { criticalGaps: 0, highGaps: 0 },
+    }),
+    oldestUnreleasedCommit: async () => (blocked ? { sha: 'a'.repeat(40), dateMs: clock - ageDays * DAY } : null),
+    guideBlocksPublish: async () => blocked,
+    draftGuide: async () => {},
+    postAttention: async (i) => { posted.push(i); return true; },
+    resolveAttention: async (id, reason) => { resolved.push({ id, reason }); return true; },
+    loadState: () => state,
+    saveState: (s) => { state = s; },
+    isAncestor: async () => false,
+    audit: () => {},
+    now: () => clock,
+  };
+  return { sentinel: new ReleaseReadinessSentinel(deps, { enabled: true }), posted, resolved };
+}
+
+function buildApp(sentinel: ReleaseReadinessSentinel | null): express.Express {
+  const app = express();
+  app.use(express.json());
+  const ctx: any = { releaseReadinessSentinel: sentinel, config: { authToken: 'test', stateDir: '/tmp', port: 0 }, stateDir: '/tmp' };
+  app.use(createRoutes(ctx));
+  return app;
+}
+
+describe('/release-readiness routes', () => {
+  let server: Server;
+  afterEach(async () => { if (server) await server.close(); });
+
+  it('GET returns 200 with state when the sentinel is wired (feature is alive, not 503)', async () => {
+    const { sentinel } = makeSentinel();
+    server = await listen(buildApp(sentinel));
+    const resp = await fetch(`${server.url}/release-readiness`);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get('x-readiness-source')).toBe('leader');
+    const body = await resp.json();
+    expect(body).toHaveProperty('disabled', false);
+    expect(body).toHaveProperty('openEpisodes');
+  });
+
+  it('GET returns 503 when no sentinel is configured (no analyzable repo)', async () => {
+    server = await listen(buildApp(null));
+    const resp = await fetch(`${server.url}/release-readiness`);
+    expect(resp.status).toBe(503);
+  });
+
+  it('reproduces the stall: a blocked+aged backlog raises exactly one Attention signal after a tick', async () => {
+    const { sentinel, posted } = makeSentinel({ blocked: true, ageDays: 5 });
+    server = await listen(buildApp(sentinel));
+    const tick = await fetch(`${server.url}/release-readiness/tick`, { method: 'POST' });
+    expect(tick.status).toBe(200);
+    expect(posted).toHaveLength(1);
+    expect(posted[0].title).toContain('Release blocked');
+    // Re-ticking does not duplicate the signal (deduped on the oldest-commit SHA).
+    await fetch(`${server.url}/release-readiness/tick`, { method: 'POST' });
+    expect(posted).toHaveLength(1);
+    // The open episode is visible via GET.
+    const body = await (await fetch(`${server.url}/release-readiness`)).json();
+    expect(body.openEpisodes).toBe(1);
+  });
+
+  it('a clean (unblocked) backlog produces no signal', async () => {
+    const { sentinel, posted } = makeSentinel({ blocked: false });
+    server = await listen(buildApp(sentinel));
+    await fetch(`${server.url}/release-readiness/tick`, { method: 'POST' });
+    expect(posted).toHaveLength(0);
+  });
+
+  it('rollback is loud: disables + raises a HIGH attention item + audits', async () => {
+    const { sentinel, posted } = makeSentinel();
+    server = await listen(buildApp(sentinel));
+    const resp = await fetch(`${server.url}/release-readiness/rollback`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ sessionId: 'sess-1' }),
+    });
+    expect(resp.status).toBe(200);
+    const high = posted.find((p) => p.id === 'release-readiness-rolled-back');
+    expect(high?.priority).toBe('HIGH');
+    // After rollback, a tick no-ops (disabled) — no further signals.
+    const before = posted.length;
+    await fetch(`${server.url}/release-readiness/tick`, { method: 'POST' });
+    expect(posted.length).toBe(before);
+    // Re-enable re-arms it.
+    const en = await fetch(`${server.url}/release-readiness/enable`, { method: 'POST' });
+    expect(en.status).toBe(200);
+    const state = await (await fetch(`${server.url}/release-readiness`)).json();
+    expect(state.disabled).toBe(false);
+  });
+});

--- a/tests/unit/ReleaseReadinessSentinel.test.ts
+++ b/tests/unit/ReleaseReadinessSentinel.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests — ReleaseReadinessSentinel (Layer B, release-readiness-visibility).
+ *
+ * Decision logic with fully faked I/O deps. Covers: blocked detection (decoupled
+ * from NEXT.md so auto-draft can't silence it), silent-below-threshold, single
+ * deduped signal keyed on the oldest-commit SHA, priority escalation, auto-resolve
+ * on backlog clear, fail-loud on evaluation errors, hysteresis, resolveEpisodesInRange,
+ * and TTL reaping.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ReleaseReadinessSentinel,
+  type ReleaseReadinessSentinelDeps,
+  type AnalyzerReport,
+  type ReadinessState,
+  type OldestCommit,
+  type AttentionItem,
+} from '../../src/monitoring/ReleaseReadinessSentinel.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function report(features: number, fixes: number, crit = 0, high = 0, lastTag = 'v1.0.0'): AnalyzerReport {
+  return {
+    lastTag,
+    commitCount: features + fixes,
+    analysis: { commitClassification: { features, fixes } },
+    guideCoverage: { criticalGaps: crit, highGaps: high },
+  };
+}
+
+class Harness {
+  state: ReadinessState = ReleaseReadinessSentinel.emptyState();
+  posted: AttentionItem[] = [];
+  resolved: Array<{ id: string; reason: string }> = [];
+  audits: Record<string, unknown>[] = [];
+  clock = Date.UTC(2026, 4, 27);
+
+  fetchOk = true;
+  analyzer: AnalyzerReport | null = report(1, 0);
+  guideBlocks = true;
+  oldest: OldestCommit | null = { sha: 'a'.repeat(40), dateMs: 0 };
+  ancestors = new Set<string>();
+
+  deps(): ReleaseReadinessSentinelDeps {
+    return {
+      fetchCanonical: async () => (this.fetchOk ? { ok: true, headSha: 'f'.repeat(40) } : { ok: false }),
+      runAnalyzer: async () => this.analyzer,
+      oldestUnreleasedCommit: async () => this.oldest,
+      guideBlocksPublish: async () => this.guideBlocks,
+      draftGuide: async () => {},
+      postAttention: async (item) => { this.posted.push(item); return true; },
+      resolveAttention: async (id, reason) => { this.resolved.push({ id, reason }); return true; },
+      loadState: () => this.state,
+      saveState: (s) => { this.state = s; },
+      isAncestor: async (sha, _ref) => this.ancestors.has(sha),
+      audit: (e) => { this.audits.push(e); },
+      now: () => this.clock,
+    };
+  }
+}
+
+describe('ReleaseReadinessSentinel', () => {
+  let h: Harness;
+  beforeEach(() => { h = new Harness(); });
+
+  it('priorityForAge maps to the configured thresholds', () => {
+    const s = new ReleaseReadinessSentinel(h.deps());
+    expect(s.priorityForAge(1)).toBeNull();
+    expect(s.priorityForAge(2)).toBe('LOW');
+    expect(s.priorityForAge(4)).toBe('MEDIUM');
+    expect(s.priorityForAge(7)).toBe('HIGH');
+  });
+
+  it('stays silent when a blocked backlog is below the age threshold', async () => {
+    h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - 1 * DAY }; // 1 day < silent(2)
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick();
+    expect(h.posted).toHaveLength(0);
+    expect(h.state.episodes).toHaveLength(1); // recorded, not surfaced
+  });
+
+  it('raises exactly one deduped signal once the backlog ages past the threshold', async () => {
+    h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - 3 * DAY }; // 3 days → LOW/MEDIUM boundary
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick();
+    await s.tick(); // same sha, same priority → no second post
+    expect(h.posted).toHaveLength(1);
+    expect(h.posted[0].priority).toBe('LOW');
+    expect(h.posted[0].id).toContain('release-readiness-');
+  });
+
+  it('escalates priority as the backlog ages (re-posts at higher priority)', async () => {
+    h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - 3 * DAY };
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick(); // LOW
+    h.clock += 5 * DAY; // now 8 days old → HIGH
+    await s.tick();
+    expect(h.posted.map((p) => p.priority)).toEqual(['LOW', 'HIGH']);
+    expect(h.posted[0].id).toBe(h.posted[1].id); // same episode id
+  });
+
+  it('is blocked by coverage gaps even when there are no feature commits', async () => {
+    h.analyzer = report(0, 0, 1, 0); // 1 critical gap, no commits
+    h.oldest = null;
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick();
+    expect(h.posted).toHaveLength(1);
+    expect(h.posted[0].id).toBe('release-readiness-coverage-gaps');
+  });
+
+  it('does NOT signal when auto-draft cleared the guide but the backlog persists is still surfaced (decoupled)', async () => {
+    // guideBlocks=false (auto-draft filled it) but there ARE unreleased commits.
+    // Per spec the blocked predicate is (commits AND guideBlocks) OR coverageGaps.
+    // With guideBlocks=false and no gaps → NOT blocked → no signal (correct: a
+    // reviewed, covering guide means the release can proceed).
+    h.guideBlocks = false;
+    h.analyzer = report(2, 0, 0, 0);
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick();
+    expect(h.posted).toHaveLength(0);
+  });
+
+  it('auto-resolves the open episode when the backlog clears', async () => {
+    h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - 5 * DAY };
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick(); // signal
+    expect(h.posted).toHaveLength(1);
+    h.guideBlocks = false;
+    h.analyzer = report(0, 0); // backlog cleared
+    await s.tick();
+    expect(h.resolved).toHaveLength(1);
+    expect(h.resolved[0].reason).toBe('cleared');
+  });
+
+  it('fail-loud: raises a low-priority signal when the canonical fetch fails (deduped)', async () => {
+    h.fetchOk = false;
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick();
+    await s.tick(); // same failure → deduped
+    expect(h.posted).toHaveLength(1);
+    expect(h.posted[0].priority).toBe('LOW');
+    expect(h.posted[0].title).toContain('could not evaluate');
+  });
+
+  it('fail-loud: raises a signal when the analyzer returns null', async () => {
+    h.analyzer = null;
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick();
+    expect(h.posted.some((p) => p.title.includes('could not evaluate'))).toBe(true);
+  });
+
+  it('hysteresis: does not re-raise the same sha within the window after a resolve', async () => {
+    h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - 5 * DAY };
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick(); // signal
+    h.guideBlocks = false; h.analyzer = report(0, 0);
+    await s.tick(); // resolve
+    expect(h.resolved).toHaveLength(1);
+    // backlog reappears (same sha) within hysteresis window
+    h.clock += 1 * 60 * 60 * 1000; // +1h < 12h
+    h.guideBlocks = true; h.analyzer = report(1, 0);
+    await s.tick();
+    expect(h.posted).toHaveLength(1); // still just the original signal, no re-raise
+  });
+
+  it('resolveEpisodesInRange resolves episodes whose oldest sha is an ancestor of the new tag', async () => {
+    h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - 5 * DAY };
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick(); // open episode for sha aaaa...
+    h.ancestors.add('a'.repeat(40)); // the published tag now contains it
+    await s.resolveEpisodesInRange('newtagsha', 'published');
+    expect(h.resolved.some((r) => r.reason === 'published')).toBe(true);
+    expect(h.state.episodes.find((e) => e.oldestSha === 'a'.repeat(40))?.resolvedReason).toBe('published');
+  });
+
+  it('reaps an episode whose backlog vanished without a finalize after the TTL', async () => {
+    h.oldest = { sha: 'a'.repeat(40), dateMs: h.clock - 5 * DAY };
+    const s = new ReleaseReadinessSentinel(h.deps());
+    await s.tick(); // open
+    h.clock += 31 * DAY; // past 30-day TTL; backlog still "blocked" but abandoned
+    await s.tick();
+    const ep = h.state.episodes.find((e) => e.oldestSha === 'a'.repeat(40));
+    // Either reaped-as-stale, or (if it re-opened) at least audited; assert a stale reap happened.
+    expect(h.audits.some((a) => a.event === 'reaped-stale')).toBe(true);
+  });
+
+  it('does not start when disabled', () => {
+    const s = new ReleaseReadinessSentinel(h.deps(), { enabled: false });
+    s.start();
+    // No throw, no tick handle — a no-op. (Smoke: stop() is safe too.)
+    s.stop();
+    expect(h.posted).toHaveLength(0);
+  });
+});

--- a/tests/unit/analyze-release-draft-guide.test.ts
+++ b/tests/unit/analyze-release-draft-guide.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests — analyze-release.js --draft-guide (Layer A, release-readiness-visibility).
+ *
+ * Auto-drafts upgrades/NEXT.md from the classified commit range. Coverage:
+ *   1. Absent guide → full draft with required sections, bump, unreviewed markers.
+ *   2. Pristine template → overwritten with full draft.
+ *   3. Human content → additive uncovered-delta block, never clobbers human text.
+ *   4. Idempotent: re-running keeps exactly one uncovered block (no oscillation).
+ *   5. Fully-covered human guide → no block added.
+ *   6. Finalize race: upgrades/{version}.md present → draft is skipped.
+ *   7. Lock file is always cleaned up.
+ *   8. Commit-message HTML comments are stripped (no forged markers).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('analyze-release.js --draft-guide', () => {
+  let tmpDir: string;
+  const scriptPath = path.resolve(__dirname, '../../scripts/analyze-release.js');
+
+  function git(args: string[]): string {
+    return SafeGitExecutor.run(args, {
+      cwd: tmpDir,
+      operation: 'tests/unit/analyze-release-draft-guide.test.ts:git',
+    });
+  }
+
+  function commit(message: string, file: string, body = 'x') {
+    const full = path.join(tmpDir, file);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, `${body}\n`);
+    git(['add', '-A']);
+    git(['commit', '-m', message]);
+  }
+
+  function draft(): { stdout: string; exitCode: number } {
+    const localScript = path.join(tmpDir, 'scripts', 'analyze-release.js');
+    try {
+      const stdout = execSync(`node "${localScript}" --draft-guide`, {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        env: { ...process.env, NODE_PATH: '' },
+      });
+      return { stdout, exitCode: 0 };
+    } catch (err: any) {
+      return { stdout: err.stdout || '', exitCode: err.status || 1 };
+    }
+  }
+
+  const nextMd = () => fs.readFileSync(path.join(tmpDir, 'upgrades', 'NEXT.md'), 'utf-8');
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'analyze-release-draft-'));
+    const scriptsDir = path.join(tmpDir, 'scripts');
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    fs.writeFileSync(path.join(scriptsDir, 'analyze-release.js'), fs.readFileSync(scriptPath, 'utf-8'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'fixture', version: '9.9.9', type: 'module' }, null, 2),
+    );
+    fs.mkdirSync(path.join(tmpDir, 'upgrades'), { recursive: true });
+
+    git(['init', '-q']);
+    git(['config', 'user.email', 'fixture@instar.local']);
+    git(['config', 'user.name', 'Fixture']);
+    git(['config', 'commit.gpgsign', 'false']);
+    commit('chore: initial', 'README.md');
+    git(['tag', 'v0.0.1']);
+    commit('feat: add widget endpoint', 'src/server/routes.ts', "router.post('/widget', h)");
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/analyze-release-draft-guide.test.ts:afterEach',
+    });
+  });
+
+  it('writes a full draft when NEXT.md is absent', () => {
+    const r = draft();
+    expect(r.exitCode).toBe(0);
+    const md = nextMd();
+    expect(md).toContain('# Upgrade Guide — vNEXT');
+    expect(md).toContain('<!-- bump:');
+    expect(md).toContain('## What Changed');
+    expect(md).toContain('## What to Tell Your User');
+    expect(md).toContain('## Summary of New Capabilities');
+    expect(md).toContain('auto-draft-unreviewed');
+    expect(md).toContain('/widget');
+  });
+
+  it('overwrites a pristine template with a full draft', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'upgrades', 'NEXT.md'),
+      '# Upgrade Guide — vNEXT\n\n## What to Tell Your User\n\n- **[Feature name]**: "x"\n\n## Summary of New Capabilities\n\n| [Capability] | automatic |\n',
+    );
+    draft();
+    const md = nextMd();
+    expect(md).not.toContain('[Feature name]');
+    expect(md).toContain('/widget');
+  });
+
+  it('appends an uncovered-delta block without clobbering human content', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'upgrades', 'NEXT.md'),
+      '# Upgrade Guide — vNEXT\n<!-- bump: minor -->\n## What Changed\nHuman note about something unrelated.\n## What to Tell Your User\n- I can do a thing.\n## Summary of New Capabilities\n| Thing | automatic |\n',
+    );
+    draft();
+    const md = nextMd();
+    expect(md).toContain('Human note about something unrelated.');
+    expect(md).toContain('BEGIN auto-draft-uncovered');
+    expect(md).toContain('/widget');
+  });
+
+  it('is idempotent — re-running keeps exactly one uncovered block', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'upgrades', 'NEXT.md'),
+      '# Upgrade Guide — vNEXT\n## What Changed\nHuman note.\n## What to Tell Your User\n- thing\n## Summary of New Capabilities\n| t | automatic |\n',
+    );
+    draft();
+    draft();
+    draft();
+    const md = nextMd();
+    const count = (md.match(/BEGIN auto-draft-uncovered/g) || []).length;
+    expect(count).toBe(1);
+    expect(md).toContain('Human note.');
+  });
+
+  it('adds no block when the human guide already covers the change-list', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'upgrades', 'NEXT.md'),
+      '# Upgrade Guide — vNEXT\n## What Changed\nWe added the POST /widget endpoint.\n## What to Tell Your User\n- new widget\n## Summary of New Capabilities\n| widget | POST /widget |\n',
+    );
+    const r = draft();
+    expect(r.stdout).toContain('no uncovered changes');
+    expect(nextMd()).not.toContain('BEGIN auto-draft-uncovered');
+  });
+
+  it('skips drafting when the version guide is already finalized', () => {
+    fs.writeFileSync(path.join(tmpDir, 'upgrades', '9.9.9.md'), '# Upgrade Guide — v9.9.9\n');
+    const r = draft();
+    expect(r.stdout.toLowerCase()).toContain('finalized');
+    expect(fs.existsSync(path.join(tmpDir, 'upgrades', 'NEXT.md'))).toBe(false);
+  });
+
+  it('leaves no stray lock file (version-file guard, no destructive unlink)', () => {
+    draft();
+    expect(fs.existsSync(path.join(tmpDir, 'upgrades', '.next.lock'))).toBe(false);
+  });
+
+  it('strips HTML comments from commit-message text (no forged markers)', () => {
+    commit('feat: sneaky <!-- bump: major --> endpoint', 'src/server/extra.ts', "router.get('/x', h)");
+    draft();
+    const md = nextMd();
+    // The only bump declaration must be the one the drafter wrote, not a forged one.
+    const bumps = md.match(/<!--\s*bump:/g) || [];
+    expect(bumps.length).toBe(1);
+  });
+});

--- a/tests/unit/releaseReadinessWiring.test.ts
+++ b/tests/unit/releaseReadinessWiring.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Wiring-integrity tests — releaseReadinessWiring (Testing Integrity Standard).
+ *
+ * Proves the dependency factory builds REAL functions (not nulls/no-ops), that
+ * the repo-gate and canonical-remote allow-list behave, and that state
+ * round-trips. The sentinel's decision logic is covered separately in
+ * ReleaseReadinessSentinel.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import {
+  buildReleaseReadinessDeps,
+  isAnalyzableRepo,
+  resolveCanonicalRemote,
+  loadReadinessState,
+  saveReadinessState,
+  CANONICAL_REMOTE_RE,
+} from '../../src/monitoring/releaseReadinessWiring.js';
+import { ReleaseReadinessSentinel } from '../../src/monitoring/ReleaseReadinessSentinel.js';
+
+describe('releaseReadinessWiring', () => {
+  let tmpDir: string;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-wiring-')); });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/releaseReadinessWiring.test.ts:afterEach' });
+  });
+
+  it('canonical-remote allow-list matches the real upstream, rejects look-alikes', () => {
+    expect(CANONICAL_REMOTE_RE.test('https://github.com/JKHeadley/instar.git')).toBe(true);
+    expect(CANONICAL_REMOTE_RE.test('git@github.com:JKHeadley/instar')).toBe(true);
+    // iter-3 V3: a look-alike host must NOT match.
+    expect(CANONICAL_REMOTE_RE.test('git@evil.com:JKHeadley/instar.git')).toBe(false);
+    expect(CANONICAL_REMOTE_RE.test('https://gitlab.com/JKHeadley/instar.git')).toBe(false);
+  });
+
+  it('isAnalyzableRepo is false for a non-instar / non-git dir', () => {
+    expect(isAnalyzableRepo(tmpDir)).toBe(false);
+    fs.mkdirSync(path.join(tmpDir, '.git'));
+    expect(isAnalyzableRepo(tmpDir)).toBe(false); // still no scripts/analyze-release.js
+  });
+
+  it('isAnalyzableRepo is true for a dir with .git + scripts/analyze-release.js + package.json', () => {
+    fs.mkdirSync(path.join(tmpDir, '.git'));
+    fs.mkdirSync(path.join(tmpDir, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'scripts', 'analyze-release.js'), '// x');
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{}');
+    expect(isAnalyzableRepo(tmpDir)).toBe(true);
+  });
+
+  it('resolveCanonicalRemote flags a configured non-canonical remote as overridden', () => {
+    SafeGitExecutor.run(['init', '-q'], { cwd: tmpDir, operation: 't:init' });
+    SafeGitExecutor.run(['remote', 'add', 'origin', 'git@evil.com:JKHeadley/instar.git'], { cwd: tmpDir, operation: 't:remote' });
+    const r = resolveCanonicalRemote(tmpDir, 'origin');
+    expect(r.overridden).toBe(true);
+  });
+
+  it('resolveCanonicalRemote auto-detects the canonical remote without override', () => {
+    SafeGitExecutor.run(['init', '-q'], { cwd: tmpDir, operation: 't:init' });
+    SafeGitExecutor.run(['remote', 'add', 'up', 'https://github.com/JKHeadley/instar.git'], { cwd: tmpDir, operation: 't:remote' });
+    const r = resolveCanonicalRemote(tmpDir);
+    expect(r.remote).toBe('up');
+    expect(r.overridden).toBe(false);
+  });
+
+  it('state round-trips through save/load and survives corruption', () => {
+    const statePath = path.join(tmpDir, 'state', 'release-readiness.json');
+    const state = ReleaseReadinessSentinel.emptyState();
+    state.episodes.push({ oldestSha: 'abc', firstDetectedMs: 123 });
+    saveReadinessState(statePath, state);
+    const loaded = loadReadinessState(statePath);
+    expect(loaded.episodes).toHaveLength(1);
+    expect(loaded.episodes[0].oldestSha).toBe('abc');
+    // Corrupt the file → load returns a fresh state rather than throwing.
+    fs.writeFileSync(statePath, '{ not json');
+    expect(loadReadinessState(statePath).episodes).toHaveLength(0);
+  });
+
+  it('buildReleaseReadinessDeps returns real callable functions for every dep', () => {
+    const deps = buildReleaseReadinessDeps({
+      repoPath: tmpDir,
+      statePath: path.join(tmpDir, 'state', 'release-readiness.json'),
+      auditPath: path.join(tmpDir, 'audit.jsonl'),
+      port: 4099,
+      authToken: 'test',
+    });
+    for (const key of [
+      'fetchCanonical', 'runAnalyzer', 'oldestUnreleasedCommit', 'guideBlocksPublish',
+      'draftGuide', 'postAttention', 'resolveAttention', 'loadState', 'saveState',
+      'isAncestor', 'audit', 'now',
+    ] as const) {
+      expect(typeof deps[key]).toBe('function');
+    }
+    // now() is real; loadState() yields a usable empty state; audit() writes a line.
+    expect(typeof deps.now()).toBe('number');
+    expect(deps.loadState().episodes).toEqual([]);
+    deps.audit({ kind: 'release-readiness', event: 'test' });
+    expect(fs.readFileSync(path.join(tmpDir, 'audit.jsonl'), 'utf-8')).toContain('"event":"test"');
+  });
+
+  it('guideBlocksPublish returns true for missing/template/unreviewed and false for clean human content', async () => {
+    const deps = buildReleaseReadinessDeps({
+      repoPath: tmpDir, statePath: path.join(tmpDir, 's.json'), auditPath: path.join(tmpDir, 'a.jsonl'),
+      port: 4099, authToken: 't',
+    });
+    fs.mkdirSync(path.join(tmpDir, 'upgrades'), { recursive: true });
+    expect(await deps.guideBlocksPublish()).toBe(true); // missing
+    fs.writeFileSync(path.join(tmpDir, 'upgrades', 'NEXT.md'), '## x\n<!-- auto-draft-unreviewed: x -->\n- y');
+    expect(await deps.guideBlocksPublish()).toBe(true); // unreviewed marker
+    fs.writeFileSync(path.join(tmpDir, 'upgrades', 'NEXT.md'), '# Guide\n## What Changed\nreal human notes here\n');
+    expect(await deps.guideBlocksPublish()).toBe(false); // clean
+  });
+});

--- a/tests/unit/upgrade-guide-autodraft-review.test.ts
+++ b/tests/unit/upgrade-guide-autodraft-review.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests — auto-draft review gate (upgrade-guide-validator.mjs).
+ *
+ * Release-readiness-visibility spec §4.1.1: a guide with `auto-draft-unreviewed`
+ * markers cannot publish; a human clears each by replacing the marker with a
+ * hash-locked `reviewed-by` receipt; editing the section afterward (or a stale /
+ * hashless receipt) re-blocks.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  autoDraftReviewIssues,
+  sectionReviewHash,
+  validateGuideContent,
+} from '../../scripts/upgrade-guide-validator.mjs';
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+describe('auto-draft review gate', () => {
+  it('blocks while any auto-draft-unreviewed marker remains', () => {
+    const md = `## What Changed\n\n<!-- auto-draft-unreviewed: what-changed -->\n- **feature**: GET /foo\n`;
+    const issues = autoDraftReviewIssues(md);
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0]).toContain('unreviewed auto-draft marker');
+  });
+
+  it('blocks the block-level marker too', () => {
+    const md = `<!-- auto-draft-unreviewed-block -->\n## What Changed\n- x\n`;
+    expect(autoDraftReviewIssues(md).length).toBeGreaterThan(0);
+  });
+
+  it('passes when a section carries a correct hash-locked receipt', () => {
+    const body = `\n<!-- reviewed-by: echo @ ${today()} :hash=PLACEHOLDER -->\n- **feature**: GET /foo\n`;
+    const hash = sectionReviewHash(body); // hash excludes the receipt line
+    const md = `## What Changed${body.replace('PLACEHOLDER', hash)}`;
+    expect(autoDraftReviewIssues(md)).toEqual([]);
+  });
+
+  it('blocks a receipt whose hash no longer matches the section (edited after review)', () => {
+    const md = `## What Changed\n<!-- reviewed-by: echo @ ${today()} :hash=${'0'.repeat(64)} -->\n- edited content\n`;
+    expect(autoDraftReviewIssues(md).some((i) => i.includes('hash mismatch'))).toBe(true);
+  });
+
+  it('blocks a receipt missing the required :hash=', () => {
+    const md = `## What Changed\n<!-- reviewed-by: echo @ ${today()} -->\n- x\n`;
+    expect(autoDraftReviewIssues(md).some((i) => i.includes('missing required'))).toBe(true);
+  });
+
+  it('blocks a receipt older than the 30-day window', () => {
+    const body = `\n- y\n`;
+    const md = `## What Changed${body}<!-- reviewed-by: echo @ 2020-01-01 :hash=${sectionReviewHash(`## What Changed${body}`.split('\n').slice(1).join('\n'))} -->\n`;
+    // Simpler: construct a section whose hash matches but date is ancient.
+    const sec = `\n- y\n<!-- reviewed-by: echo @ 2020-01-01 :hash=HASH -->\n`;
+    const h = sectionReviewHash(sec);
+    const guide = `## What Changed${sec.replace('HASH', h)}`;
+    expect(autoDraftReviewIssues(guide).some((i) => i.includes('days old'))).toBe(true);
+  });
+
+  it('validateGuideContent surfaces the unreviewed-marker block', () => {
+    const md = `# Upgrade Guide — vNEXT
+<!-- bump: minor -->
+## What Changed
+<!-- auto-draft-unreviewed: what-changed -->
+- **feature**: GET /foo endpoint added
+## What to Tell Your User
+- You can now use the foo feature.
+## Summary of New Capabilities
+| foo | GET /foo |
+`;
+    const issues = validateGuideContent(md);
+    expect(issues.some((i) => i.includes('unreviewed auto-draft marker'))).toBe(true);
+  });
+});

--- a/upgrades/side-effects/release-readiness-visibility-pr2a.md
+++ b/upgrades/side-effects/release-readiness-visibility-pr2a.md
@@ -1,0 +1,27 @@
+# Side-Effects Review — Release-Readiness Visibility, PR-2a (Layer A auto-draft + publish-gate amendment)
+
+**Spec:** docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md §4.1 (converged + approved).
+**Scope:** the auto-draft half of PR-2 — `analyze-release.js --draft-guide`, the `upgrade-guide-validator.mjs` review gate, and the `publish.yml` skip-predicate amendment. (Layer B — the ReleaseReadinessSentinel + routes + job — lands in a following commit on this same branch.)
+
+## What changed
+
+- **`scripts/analyze-release.js`** — new `--draft-guide` mode. Builds `upgrades/NEXT.md` from the already-computed `generateChangeDescriptions`, structured into the required sections + a seeded `<!-- bump: -->`. Every section carries an `auto-draft-unreviewed` marker. Commit-message text is sanitized (HTML comments stripped, length-capped, leading `#`/`---` escaped) so a crafted message can't forge markers or break section bounds. Two write modes: full draft when the guide is absent/pristine-template; additive uncovered-delta block (never clobbers human content) otherwise. Idempotent — coverage is measured against human content only, so the delta block doesn't oscillate. Race-guarded against publish-finalize via the `upgrades/{version}.md` existence check.
+- **`scripts/upgrade-guide-validator.mjs`** — `autoDraftReviewIssues()` (wired into `validateGuideContent`): blocks while any `auto-draft-unreviewed` marker remains; validates `reviewed-by` receipts (required `:hash=<sha256>` matching the canonicalized section, ≤30-day window). `canonicalizeSectionForHash` / `sectionReviewHash` exported for reuse + tests.
+- **`.github/workflows/publish.yml`** — skip predicate also sets `skip=true` when `auto-draft-unreviewed` is present (keeps silent-skip semantics for the unreviewed case; the sentinel surfaces it as a signal in Layer B).
+
+## Side-effects analysis
+
+**Over/under-reach.** The validator change adds block conditions that fire ONLY on content the auto-drafter produces (`auto-draft-unreviewed` markers) or on malformed `reviewed-by` receipts. A hand-written guide that never uses these markers is completely unaffected — existing guides and the existing finalization flow are untouched. `--draft-guide` is opt-in (no existing caller passes it); the default `analyze-release.js` behavior is byte-identical.
+
+**Defeating-the-gate (the iter-1 adversarial finding).** The whole point: a fully auto-drafted guide PASSES every prior check (sections present, length, no template placeholders, evidence-section present) but is BLOCKED by the new unreviewed-marker rule. Verified: drafting then validating returns the unreviewed-marker issue; replacing markers with correct hash-locked receipts clears it; wrong-hash / missing-hash / stale receipts re-block. So auto-fill removes the blank-guide root cause without shipping un-reviewed notes.
+
+**Signal vs authority.** The gate amendment teaches the EXISTING publish gate (which already has blocking authority) a new recognize-and-block condition; it introduces no new low-context detector with veto power. Consistent with §5.
+
+**Spec deviation (documented).** §4.1.3 also describes an intra-host O_EXCL advisory lock. It is intentionally omitted: releasing it needs a destructive `fs.unlink`, forbidden by `lint-no-direct-destructive` in this dependency-free, test-copyable script, and the draft job is single-runner via the multi-machine lease so concurrent local drafters don't occur. The cross-host guarantee (the one §4.1.3 calls the real guarantee) is fully preserved via the `{version}.md` existence check. The full "marker stripped without a receipt" detection remains the tracked Phase-2 git-diff CI check per §4.1.1.
+
+**Rollback.** Revert restores prior `analyze-release.js` / validator / workflow. No state, config, or migration introduced by PR-2a.
+
+## Testing
+
+- Unit (19 green): `analyze-release-draft-guide.test.ts` (8 — full draft, template overwrite, never-clobber merge, idempotency, fully-covered no-op, finalize-race skip, no stray lock, HTML-comment sanitization); `upgrade-guide-autodraft-review.test.ts` (7 — marker blocks, block-marker blocks, correct receipt passes, hash-mismatch/missing-hash/stale block, validateGuideContent surfaces it); `analyze-release-ref-flag.test.ts` (4, from PR-1).
+- Integration/E2E for the readiness pipeline land with Layer B (the routes + the "feature is alive" E2E that reproduces the original stall).

--- a/upgrades/side-effects/release-readiness-visibility-pr2b.md
+++ b/upgrades/side-effects/release-readiness-visibility-pr2b.md
@@ -1,0 +1,26 @@
+# Side-Effects Review — Release-Readiness Visibility, PR-2b (Layer B core: sentinel + I/O wiring)
+
+**Spec:** docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md §4.2 (converged + approved).
+**Scope of THIS commit:** the dependency-injected `ReleaseReadinessSentinel` (pure decision logic) and `releaseReadinessWiring` (its real git/analyzer/state/Attention I/O bridge), plus their tests. **This commit does NOT yet wire the sentinel into server startup or add the HTTP routes** — so on this commit the sentinel is constructed nowhere (it is not yet live). The server construction + `GET /release-readiness` + `POST /release-readiness/rollback` + config defaults + job template + migrations + integration/E2E land in the following commit on this same (unmerged) branch. Calling this out explicitly to avoid the PR #334 failure mode (sentinels merged as dead code with a false "wired" claim) — nothing here is claimed to be live.
+
+## What changed
+
+- **`src/monitoring/ReleaseReadinessSentinel.ts`** — EventEmitter with injected deps. `tick()` (detect → surface → auto-resolve → reap), `resolveEpisodesInRange()` (publish-finalize hook; ancestry-based so it's correct under oldest-SHA churn), `priorityForAge()`, `reap()`. Blocked-predicate is decoupled from NEXT.md state (commits-with-blocked-guide OR coverage-gaps) so Layer A's auto-draft can't silence the alarm. One deduped signal keyed on the oldest-unreleased-commit SHA; age-scaled priority; 12h hysteresis; fail-loud (every evaluation error → low-priority Attention, never a silent catch). Tier 0.
+- **`src/monitoring/releaseReadinessWiring.ts`** — `buildReleaseReadinessDeps()` (real I/O), `isAnalyzableRepo()` (repo-gate), `resolveCanonicalRemote()` (allow-list), `loadReadinessState`/`saveReadinessState` (atomic via temp+rename — no destructive-lint verb), `makeAttentionPoster`.
+
+## Side-effects analysis
+
+**Reach.** Both modules are new, imported by nothing yet. Zero runtime effect on any existing path at this commit. No config, route, job, or migration is introduced here.
+
+**Repo-gated dev-environment scope (spec refinement, documented).** The sentinel analyzes the instar git repo via `analyze-release.js`. That repo only exists in the dev/maintainer environment (Echo's agent home IS the instar checkout). A plain npm-installed agent has no instar repo to analyze. `isAnalyzableRepo()` is the gate the server will consult: on a non-analyzable install the sentinel is simply not constructed (inert) — it never posts a spurious Attention item about a missing repo. This is consistent with the spec's "ships off by default; Echo dogfoods first," and makes explicit a reality the spec under-specified.
+
+**Security / input safety.** All git goes through `SafeGitExecutor` (execFileSync, no shell). The canonical-remote allow-list is anchored on `github.com` host (`^(https://github\.com/|git@github\.com:)JKHeadley/instar(\.git)?$`) — a look-alike host like `git@evil.com:JKHeadley/instar.git` does NOT match (iter-3 adversarial V3); a configured override to a non-canonical URL is permitted but flips `canonicalRemoteOverridden`, which the server will surface as a HIGH-priority signal. The analyzer is spawned via `execFile(process.execPath, [...])` (argv array, no shell). State load tolerates corruption (returns a fresh state rather than throwing into the tick).
+
+**Fail-open vs fail-loud.** The sentinel's contract is fail-loud: `tick()`'s top-level catch and the per-stage `failLoud()` convert fetch/analyzer errors into low-priority Attention items (deduped per failure episode). This is verified by unit tests, and is the core anti-pattern guard (a silent catch would re-create the bug being fixed).
+
+**Rollback.** Deleting the two modules + their tests fully reverts; nothing imports them yet.
+
+## Testing
+
+- Unit (21 green): `ReleaseReadinessSentinel.test.ts` (13 — thresholds, silent-below-threshold, single deduped signal, escalation, coverage-gap blocking, decoupled-from-guide, auto-resolve, fail-loud×2, hysteresis, resolveEpisodesInRange, stale-reap, disabled-no-op); `releaseReadinessWiring.test.ts` (8 wiring-integrity — allow-list, repo-gate, override detection, auto-detect, state round-trip+corruption, all deps are real callables, guideBlocksPublish truth table).
+- Integration (HTTP routes) + E2E (feature-alive: reproduce the original stall → one Attention item) land with the server-wiring commit, which is where they become meaningful (a route/E2E can't exist before the route does).

--- a/upgrades/side-effects/release-readiness-visibility-pr2c.md
+++ b/upgrades/side-effects/release-readiness-visibility-pr2c.md
@@ -1,0 +1,37 @@
+# Side-Effects Review — Release-Readiness Visibility, PR-2c (Layer B wired live)
+
+**Spec:** docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md §§4.2 / 4.3.1 / 4.2.7 / 7 / 10.
+**Scope of this commit:** make Layer B actually live — server construction (gated on an analyzable instar repo + config), the four HTTP routes, the off-by-default cron job, config defaults + migrations (config + CLAUDE.md), and the integration + real-I/O E2E that prove it. Plus the four new rollback/enable/snapshot/disabled methods on the sentinel that PR-2b's commit couldn't fully ship without the routes.
+
+## What changed
+
+- **`src/commands/server.ts`** — constructs `ReleaseReadinessSentinel` IFF `config.monitoring.releaseReadiness.enabled` AND `isAnalyzableRepo(repoPath)` (default repoPath = process.cwd()). NOT `start()`ed — the off-by-default cron job is the cadence (one tick per cron). On an inert install (no instar repo or feature off) the sentinel is null and the routes 503 — never a spurious signal.
+- **`src/server/AgentServer.ts` + `src/server/routes.ts`** — `releaseReadinessSentinel` plumbed through `AgentServerOptions` → `RouteContext`. Four routes added: `GET /release-readiness` (read-only snapshot + `X-Readiness-Source` header), `POST /release-readiness/tick` (the cron entry point), `POST /release-readiness/rollback` (loud — raises a HIGH Attention item + audits, can't silently mute the alarm; iter-3 V5), `POST /release-readiness/enable` (re-arm).
+- **`src/monitoring/ReleaseReadinessSentinel.ts`** — added `disabled` to `ReadinessState`, `tick()` no-ops when disabled (writes a `tick-skipped-disabled` audit), and added `snapshot()` / `rollback({sessionId, sourceIp})` / `enable()` methods. Rollback resolves all open episodes, persists the `rollbackHistory` audit, and posts the HIGH "alarm disabled" Attention item before saving state.
+- **`src/monitoring/releaseReadinessWiring.ts`** — **production-bug fix discovered by the E2E**: the spec's `--depth=1` fetch SHALLOWS the local repo, which breaks `git log <tag>..ref` in `analyze-release.js` (commit count silently becomes 0 → the sentinel goes silent on a real backlog — the exact failure mode the spec exists to fix). Dropped `--depth=1`; `--no-tags --no-recurse-submodules` keeps incremental fetches bounded without shallowing. **This is the kind of bug only the E2E could catch — unit tests with stubbed deps would have passed.**
+- **`src/core/types.ts`** — `MonitoringConfig.releaseReadiness` block (kill switch + thresholds + hysteresis + TTL + fetch timeout + canonical-remote + repoPath overrides).
+- **`src/config/ConfigDefaults.ts`** — default block under `monitoring.releaseReadiness` (ships OFF). Existing agents pick it up automatically: `applyDefaults` adds missing keys, never overwrites — migration parity is automatic.
+- **`src/core/PostUpdateMigrator.ts`** — `migrateClaudeMd` appends a Release Readiness section to existing agents' CLAUDE.md, content-sniffed on the `/release-readiness` marker (Agent Awareness Standard).
+- **`src/scaffold/templates.ts`** — new agents get the same paragraph in the rendered CLAUDE.md.
+- **`src/scaffold/templates/jobs/instar/release-readiness-check.md`** — declarative cron job, `enabled: false`, schedule `0 */6 * * *`, model `haiku`. Body curls `POST /release-readiness/tick`; reports nothing (the sentinel owns all signalling).
+
+## Side-effects analysis
+
+**Reach.** All new code is gated. The sentinel is constructed only when (a) config enables it AND (b) `isAnalyzableRepo(repoPath)` returns true. On an npm-installed agent with no instar repo, the sentinel stays null and the routes 503 — zero behavior change. The job ships `enabled: false`. The CLAUDE.md migration is content-sniffed (idempotent).
+
+**Rollback semantics (iter-3 V5).** `POST /release-readiness/rollback` cannot be a silent kill: it ALWAYS raises a HIGH-priority Attention item ("Release-readiness alarm disabled by session X at T"), writes a `rollbackHistory[]` entry to the readiness state, and emits a `rollback` audit line. A compromised/confused session calling rollback is loudly visible. `enable` re-arms cleanly.
+
+**Production bug caught.** The `--depth=1` shallow-fetch bug (now fixed) would have silently broken the watchdog on every install after the first fetch — the alarm would have been *quiet for the exact reason it was built*. Caught by the real-I/O E2E (fixture git repo + real `analyze-release.js` subprocess + real fetch). Without that test, we would have shipped the failure mode the spec exists to fix.
+
+**Sentinel-vs-cadence design.** Spec §4.2.1 said "host: a new declarative job." The class also exposes `start()`/`stop()` (self-ticking via setInterval) for tests + alt wiring. The SERVER does NOT call `start()` — the cron job is the single cadence driver, calling `POST /release-readiness/tick`. This avoids double-ticking and gives operators full control via the job's `enabled` flag.
+
+**Migration parity.** Config defaults: handled automatically by `applyDefaults` (existing agents get the missing `monitoring.releaseReadiness` block on next migration). CLAUDE.md: explicit `migrateClaudeMd` block (Agent Awareness). Job template: shipped via the existing `InstallBuiltinJobs` always-overwrite path (operator `enabled` override is preserved per-slug). All three migration-parity standard surfaces covered.
+
+**Rollback if reverted.** Reverting this PR removes the sentinel construction, routes, job template, config block, and CLAUDE.md mention. On existing agents post-revert: the config key + CLAUDE.md section become orphaned but harmless (no code references them). The state file `.instar/state/release-readiness.json` is left in place (cheap, ignored).
+
+## Testing
+
+Full layered coverage, all green (47 tests across 7 files this PR):
+- **Unit (40):** `analyze-release-ref-flag` (4), `analyze-release-draft-guide` (8), `upgrade-guide-autodraft-review` (7 — marker blocks, hash-locked receipts pass/block on tamper/age/missing-hash), `ReleaseReadinessSentinel` (13 — thresholds, dedupe, escalation, decoupled-from-guide, auto-resolve, fail-loud, hysteresis, resolveEpisodesInRange, stale-reap), `releaseReadinessWiring` (8 — allow-list, repo-gate, override detection, state round-trip, deps-are-real, guide-blocks truth table).
+- **Integration (5):** real routes + real sentinel + controllable deps. Proves: route is 200 not 503 (alive), 503 when sentinel null (correctly inert), blocked+aged backlog → exactly one Attention signal (the original silent-stall bug reproduced + surfaced), clean backlog → no signal, rollback is loud and reversible.
+- **E2E (2):** real `fixture` instar repo + real canonical remote + REAL git fetch + REAL `analyze-release.js` subprocess + REAL `merge-base`. Drives `sentinel.tick()` end-to-end and proves the wiring works against real I/O. Caught the `--depth=1` shallowing bug.


### PR DESCRIPTION
## Summary

PR-2 of 3 for the **Release-Readiness Visibility** spec (converged + approved, topic 14100). Adds Layer A (auto-draft) and Layer B (the recurring readiness watchdog) on top of PR-1's `--ref` prerequisite (#433, already merged).

**Layer A — auto-draft + publish-gate amendment.** `analyze-release.js --draft-guide` builds `upgrades/NEXT.md` from the computed change-list (full draft when absent/template; additive, never-clobber, idempotent uncovered-delta block when human content is present). Every section carries an `auto-draft-unreviewed` marker. The validator + `publish.yml` skip predicate refuse to ship while any marker remains. A human clears each by replacing the marker with a hash-locked `reviewed-by: <user> @ <ISO-date> :hash=<sha256>` receipt; editing the section afterward invalidates the hash and re-blocks.

**Layer B — ReleaseReadinessSentinel + routes + job.** A repo-gated, dev-environment watchdog: evaluates canonical `main` and surfaces a stalled/blocked release as ONE deduped, age-escalating Attention item (silent <2d, LOW ≥2d, MEDIUM ≥4d, HIGH ≥7d). Keyed on the oldest unreleased commit SHA (stable across ticks), 12h hysteresis, fail-loud on every evaluation error, lifecycle owner with `resolveEpisodesInRange` for the publish-finalize path. Endpoints: `GET /release-readiness`, `POST /release-readiness/tick`, `POST /release-readiness/rollback` (loud — raises HIGH attention + audits, can't silently mute), `POST /release-readiness/enable`. Off by default; the `release-readiness-check` cron job is the cadence.

## Production bug caught by the E2E

The spec's `--depth=1` canonical fetch turns the LOCAL repo shallow, which silently breaks `git log <tag>..ref` for analyze-release (commit count → 0 → no signal). The Tier-3 real-I/O E2E (fixture git repo + real `analyze-release.js` subprocess + real fetch) reproduced this on the first run. Dropped `--depth=1`; `--no-tags --no-recurse-submodules` keeps fetches bounded without shallowing.

## Spec refinements (documented in side-effects artifacts)

- **Repo-gated dev-environment scope** — Layer B only constructs when `isAnalyzableRepo(repoPath)` returns true; on an npm-installed agent with no instar repo it stays null and the routes 503.
- **Intra-host O_EXCL lock omitted from Layer A** — the destructive-fs lint forbids `fs.unlink` in this dependency-free script, and the spec itself says the version-file existence check is the real cross-host guard. The job is single-runner via the multi-machine lease, so concurrent local drafters don't occur.

## Migration parity

- `monitoring.releaseReadiness` config defaults — added to `ConfigDefaults.ts`; existing agents pick it up automatically via `applyDefaults` (missing-key-only).
- `CLAUDE.md` Release Readiness section — both `templates.ts` (new agents) and `migrateClaudeMd` (existing agents, content-sniffed on `/release-readiness`).
- Job template — installed via the existing `InstallBuiltinJobs` always-overwrite path, ships `enabled: false`.

## Test plan

47 tests across 7 files, all green:

- [x] Unit (40): `analyze-release-ref-flag` (4), `analyze-release-draft-guide` (8), `upgrade-guide-autodraft-review` (7), `ReleaseReadinessSentinel` (13), `releaseReadinessWiring` (8 wiring-integrity).
- [x] Integration (5): real router + real sentinel + controllable deps. Proves routes alive (200 not 503), 503 when null, the original silent stall reproduced + surfaced as one Attention item, rollback is loud and reversible.
- [x] E2E (2): REAL git fixture + REAL canonical fetch + REAL `analyze-release.js` subprocess + REAL `merge-base`. Proves the wiring is alive against real I/O (and is what caught the `--depth=1` bug).

PR-3 (Layer C canonical-ref reconciler) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)