### PR TITLE
feat(messaging): a2a comms — sendAgentMessage + audit + token scrub (PR 2b/3)

### DIFF
--- a/src/messaging/AgentTelegramComms.ts
+++ b/src/messaging/AgentTelegramComms.ts
@@ -287,3 +287,178 @@ export class CycleDetector {
     }
   }
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// sendAgentMessage — the SEND side (spec §Fix 2a "Sender side")
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface SendAgentMessageInput {
+  fromAgent: string;
+  toAgent: string;
+  /** A role the caller is allowed to send (see allowedRoles). */
+  role: string;
+  /** Recipient bot's topic to write into. */
+  toTopicId: number;
+  /** Prompt content. Markdown is fine — the body is sent verbatim under the marker. */
+  message: string;
+  /** Optional: an existing stable id for this send (else a UUID is minted as a2aId). */
+  id?: string;
+  /** Optional: correlation id (for a reply, set to the prompt's id). Defaults to id. */
+  correlationId?: string;
+}
+
+export interface SendAgentMessageDeps {
+  /** Adapter-specific send. Must return a `messageId` on success. */
+  send: (toTopicId: number, text: string) => Promise<{ ok: true; messageId: string } | { ok: false; error: unknown }>;
+  /** Append one JSONL row to the sent-audit ledger (caller chooses path/storage). */
+  appendAudit: (row: SendAuditRow) => void;
+  /** Wall-clock now (ms) — injected. */
+  now: () => number;
+  /** UUID minter — injected so tests are deterministic. */
+  mintId: () => string;
+  /** Allowed-outbound-roles for THIS caller (constructor-time list). The role-handler
+   *  cannot send any role not in this list — refused at runtime, no marker formed. */
+  allowedRoles: ReadonlySet<string>;
+  /** The bot token to scrub from any error message before it leaves this module
+   *  (round-2 adversarial F5: Telegram 401s sometimes echo the token). */
+  botToken?: string;
+  /** Telegram identifiers for the audit row + future cycle-detection wiring. */
+  fromBotId: string;
+  toBotId: string;
+}
+
+export interface SendAuditRow {
+  localTs: string;
+  direction: 'sent';
+  fromAgent: string;
+  toAgent: string;
+  role: string;
+  id: string;
+  corr: string;
+  ts: number;
+  telegramFromBotId: string;
+  telegramToBotId: string;
+  topicId: number;
+  result: 'ok' | 'failed' | 'role-refused';
+  sentMessageId?: string;
+  reason?: string;
+}
+
+export interface SendAgentMessageResult {
+  ok: boolean;
+  a2aId?: string;
+  sentMessageId?: string;
+  reason?: string;
+}
+
+/**
+ * Send an agent-to-agent Telegram message. Formats the marker, calls the injected
+ * adapter, writes the sent-audit row (always — even on refusal/failure), and scrubs the
+ * bot token from any error surface before returning.
+ *
+ * Anti-loop invariant (spec §Fix 2a anti-loop #1): refuses any `role` not in the caller's
+ * `allowedRoles` set at runtime — no marker is formed, no send is attempted, an audit row
+ * is written with `result: 'role-refused'`. A role-handler that consumes role X cannot
+ * therefore send role X (the import-surface lint is a backup; this is the runtime guard).
+ */
+export async function sendAgentMessage(
+  input: SendAgentMessageInput,
+  deps: SendAgentMessageDeps,
+): Promise<SendAgentMessageResult> {
+  const now = deps.now();
+  const a2aId = input.id ?? deps.mintId();
+  const corr = input.correlationId ?? a2aId;
+
+  // Runtime anti-loop guard (spec §Fix 2a anti-loop #1).
+  if (!deps.allowedRoles.has(input.role)) {
+    deps.appendAudit({
+      localTs: new Date(now).toISOString(),
+      direction: 'sent',
+      fromAgent: input.fromAgent,
+      toAgent: input.toAgent,
+      role: input.role,
+      id: a2aId,
+      corr,
+      ts: now,
+      telegramFromBotId: deps.fromBotId,
+      telegramToBotId: deps.toBotId,
+      topicId: input.toTopicId,
+      result: 'role-refused',
+      reason: `role "${input.role}" not in caller's allowedRoles`,
+    });
+    return { ok: false, a2aId, reason: `role "${input.role}" not in caller's allowedRoles` };
+  }
+
+  let text: string;
+  try {
+    text = formatMarker(
+      { from: input.fromAgent, to: input.toAgent, role: input.role, id: a2aId, corr, ts: now },
+      input.message,
+    );
+  } catch (err) {
+    const reason = scrubToken(err instanceof Error ? err.message : String(err), deps.botToken);
+    deps.appendAudit({
+      localTs: new Date(now).toISOString(),
+      direction: 'sent',
+      fromAgent: input.fromAgent,
+      toAgent: input.toAgent,
+      role: input.role,
+      id: a2aId,
+      corr,
+      ts: now,
+      telegramFromBotId: deps.fromBotId,
+      telegramToBotId: deps.toBotId,
+      topicId: input.toTopicId,
+      result: 'failed',
+      reason: `format: ${reason}`,
+    });
+    return { ok: false, a2aId, reason: `format: ${reason}` };
+  }
+
+  const result = await deps.send(input.toTopicId, text);
+  const row: SendAuditRow = {
+    localTs: new Date(now).toISOString(),
+    direction: 'sent',
+    fromAgent: input.fromAgent,
+    toAgent: input.toAgent,
+    role: input.role,
+    id: a2aId,
+    corr,
+    ts: now,
+    telegramFromBotId: deps.fromBotId,
+    telegramToBotId: deps.toBotId,
+    topicId: input.toTopicId,
+    result: result.ok ? 'ok' : 'failed',
+    sentMessageId: result.ok ? result.messageId : undefined,
+    reason: result.ok ? undefined : scrubToken(stringifyError(result.error), deps.botToken),
+  };
+  deps.appendAudit(row);
+
+  return result.ok
+    ? { ok: true, a2aId, sentMessageId: result.messageId }
+    : { ok: false, a2aId, reason: row.reason };
+}
+
+/** Stringify an unknown error without crashing on weird shapes. */
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try { return JSON.stringify(err); } catch { return '[unstringifiable error]'; }
+}
+
+/** Scrub the bot token from a string so it can't leak through logs / audit / DegradationReporter
+ *  (round-2 adversarial F5: Telegram 401 response bodies sometimes echo the token). The
+ *  token is fixed-length and high-entropy enough that a literal-string replace is enough;
+ *  we strip the trailing path segment defensively in case only part is echoed. */
+export function scrubToken(s: string, token?: string): string {
+  if (!token) return s;
+  let out = s.split(token).join('[REDACTED-BOT-TOKEN]');
+  // Telegram tokens are <bot-id>:<secret>. If only the secret appears, scrub it too.
+  const colonIdx = token.indexOf(':');
+  if (colonIdx > 0) {
+    const secret = token.slice(colonIdx + 1);
+    if (secret.length >= 16) out = out.split(secret).join('[REDACTED-BOT-TOKEN]');
+  }
+  return out;
+}
+

--- a/tests/unit/messaging/AgentTelegramComms.test.ts
+++ b/tests/unit/messaging/AgentTelegramComms.test.ts
@@ -15,8 +15,12 @@ import {
   decideRoute,
   cycleKey,
   CycleDetector,
+  sendAgentMessage,
+  scrubToken,
   type RecipientConfig,
   type IncomingContext,
+  type SendAgentMessageDeps,
+  type SendAuditRow,
 } from '../../../src/messaging/AgentTelegramComms.js';
 
 const NOW = 1_779_900_000_000;
@@ -185,5 +189,87 @@ describe('AgentTelegramComms — cycle detection', () => {
     cd.mark(cycleKey({ fromBotId: 'a', toBotId: 'b', topicId: 1, role: 'mentor', corr: 'c1' }), NOW);
     const other = cycleKey({ fromBotId: 'a', toBotId: 'b', topicId: 1, role: 'mentor', corr: 'c2' });
     expect(cd.wouldTrip(other, NOW + 1000)).toBe(false);
+  });
+});
+
+describe('AgentTelegramComms — sendAgentMessage', () => {
+  function mkDeps(over: Partial<SendAgentMessageDeps> = {}): { deps: SendAgentMessageDeps; audit: SendAuditRow[]; sent: { topicId: number; text: string }[] } {
+    const audit: SendAuditRow[] = [];
+    const sent: { topicId: number; text: string }[] = [];
+    const deps: SendAgentMessageDeps = {
+      send: async (topicId, text) => { sent.push({ topicId, text }); return { ok: true, messageId: 'msg-99' }; },
+      appendAudit: (r) => audit.push(r),
+      now: () => NOW,
+      mintId: () => 'minted-id',
+      allowedRoles: new Set(['mentor']),
+      fromBotId: 'echo-mentor-bot',
+      toBotId: 'codey-bot',
+      botToken: '123456:fake-secret-token-value-1234',
+      ...over,
+    };
+    return { deps, audit, sent };
+  }
+
+  it('formats the marker, sends, returns a2aId + sentMessageId, writes ok audit row', async () => {
+    const { deps, audit, sent } = mkDeps();
+    const r = await sendAgentMessage(
+      { fromAgent: 'echo', toAgent: 'instar-codey', role: 'mentor', toTopicId: 42, message: 'hi' },
+      deps,
+    );
+    expect(r).toMatchObject({ ok: true, a2aId: 'minted-id', sentMessageId: 'msg-99' });
+    expect(sent[0].topicId).toBe(42);
+    // Round-trips back through parseMarker (the sender's marker is the receiver's input).
+    const parsed = parseMarker(sent[0].text);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.msg).toMatchObject({ from: 'echo', to: 'instar-codey', role: 'mentor', id: 'minted-id', corr: 'minted-id', ts: NOW });
+    expect(audit[0]).toMatchObject({ result: 'ok', sentMessageId: 'msg-99', fromAgent: 'echo', role: 'mentor', id: 'minted-id', corr: 'minted-id', topicId: 42 });
+  });
+
+  it('correlationId defaults to id; an explicit correlationId threads a reply back to a prompt', async () => {
+    const { deps, sent, audit } = mkDeps();
+    await sendAgentMessage(
+      { fromAgent: 'instar-codey', toAgent: 'echo', role: 'mentor', toTopicId: 7, message: 'reply', id: 'reply-1', correlationId: 'prompt-A' },
+      { ...deps, allowedRoles: new Set(['mentor', 'mentor-reply']) },
+    );
+    const parsed = parseMarker(sent[0].text);
+    if (parsed.ok) expect(parsed.msg.corr).toBe('prompt-A');
+    expect(audit[0].corr).toBe('prompt-A');
+  });
+
+  it('ANTI-LOOP: refuses to send a role not in the caller-allowed set — no send, role-refused audit', async () => {
+    const { deps, audit, sent } = mkDeps({ allowedRoles: new Set(['mentor-reply']) }); // mentor is NOT allowed
+    const r = await sendAgentMessage(
+      { fromAgent: 'instar-codey', toAgent: 'echo', role: 'mentor', toTopicId: 1, message: 'forbidden' },
+      deps,
+    );
+    expect(r.ok).toBe(false);
+    expect(sent).toHaveLength(0); // no send attempted
+    expect(audit[0]).toMatchObject({ result: 'role-refused' });
+    expect(audit[0].reason).toMatch(/role.*mentor.*not in.*allowedRoles/);
+  });
+
+  it('writes a failed audit row + scrubbed reason when the adapter throws', async () => {
+    const tokenInError = '123456:fake-secret-token-value-1234';
+    const { deps, audit } = mkDeps({
+      send: async () => ({ ok: false, error: new Error(`401 from Telegram: bot ${tokenInError} unauthorized`) }),
+    });
+    const r = await sendAgentMessage(
+      { fromAgent: 'echo', toAgent: 'instar-codey', role: 'mentor', toTopicId: 1, message: 'x' },
+      deps,
+    );
+    expect(r.ok).toBe(false);
+    // Token NEVER appears in the result or audit.
+    expect(r.reason).not.toContain(tokenInError);
+    expect(audit[0].result).toBe('failed');
+    expect(audit[0].reason).not.toContain(tokenInError);
+    expect(audit[0].reason).toContain('[REDACTED-BOT-TOKEN]');
+  });
+
+  it('scrubToken redacts both full token and just-the-secret-portion', () => {
+    const t = '123456:abcdef1234567890secret';
+    expect(scrubToken(`oops ${t} leaked`, t)).toContain('[REDACTED-BOT-TOKEN]');
+    expect(scrubToken(`partial: abcdef1234567890secret`, t)).toContain('[REDACTED-BOT-TOKEN]');
+    expect(scrubToken('no token here', t)).toBe('no token here');
+    expect(scrubToken('anything', undefined)).toBe('anything');
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,44 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Agent-to-agent Telegram comms primitive — send side now wired in.** Builds on the
+TelegramAdapter groundwork that landed in v1.3.34 (where the adapter learned to run a
+second bot cleanly + expose `is_bot`/`sender_chat` on inbound messages). This release adds
+the actual send function plus its safety machinery, still **dark** (no caller uses it
+yet — the mentor wires it in the follow-up):
+
+- **`sendAgentMessage`** — formats the visible `[a2a:from=… to=… role=… id=… corr=… ts=… v=1]`
+  marker, sends via an injected adapter, and writes one audit row for every outcome
+  (`ok` / `failed` / `role-refused`) — never silent.
+- **Runtime anti-loop guard** — refuses to send any role the caller wasn't constructed with
+  permission for. No marker formed, no send attempted, audit row written. This makes the
+  import-surface lint a backup rather than the only defense; the runtime guard always
+  applies. A role-handler that *consumes* role X structurally cannot *send* role X.
+- **Bot-token scrubbing on every error/audit surface** — Telegram 401 response bodies
+  sometimes echo the token; redaction makes leaks structurally impossible from this module.
+
+## What to Tell Your User
+
+- Nothing changes in how your agent behaves today — still plumbing. Your agent's own
+  Telegram keeps working exactly as before. A follow-up update wires this into the mentor
+  feature.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| `sendAgentMessage` + audit ledger | Internal — see `src/messaging/AgentTelegramComms.ts`; formats the marker, sends via injected adapter, writes a `SendAuditRow` for every outcome, scrubs the bot token |
+
+## Evidence
+
+**Net-new groundwork, not a bug fix.** Proven by 5 new unit tests (25 total in the suite,
+all green): happy-path send + audit (marker round-trips through `parseMarker` — sender output
+IS receiver input); correlation threading (explicit `correlationId` lands in the marker's
+`corr=` field for prompt↔reply linkage via Telegram chat history alone); the anti-loop
+role-refusal (a role not in the caller's allowed-set → no send, no marker, `role-refused`
+audit row); adapter failure with the bot token in the error body → token scrubbed from both
+the result reason and the audit row; `scrubToken` unit coverage across full-token,
+secret-portion, no-token-present, and undefined-token cases. `tsc --noEmit` clean.

--- a/upgrades/side-effects/agent-telegram-comms-send.md
+++ b/upgrades/side-effects/agent-telegram-comms-send.md
@@ -1,0 +1,71 @@
+# Side-Effects Review — agent-to-agent Telegram comms: send side + audit (PR 2b)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2a "Sender side" + anti-loop #1 +
+round-2 adversarial F5 (token-leak scrub). PR 2 of the staged build, part b.
+**Change:** Extend `src/messaging/AgentTelegramComms.ts` with `sendAgentMessage` (the
+adapter-agnostic send function), a `SendAuditRow` schema + appender hook, and `scrubToken`
+(redacts the bot token from any error surface before it leaves the module). I/O still
+**injected** — fully unit-testable; no caller invokes it yet (dark). PR 3 wires it.
+**Files:** `src/messaging/AgentTelegramComms.ts` (additive), `tests/unit/messaging/AgentTelegramComms.test.ts` (+5).
+
+## What changed
+
+- `sendAgentMessage(input, deps)` — mints/uses `a2aId` (UUID-or-supplied), defaults
+  `correlationId` to `id` (prompts self-correlate; replies thread on the prompt's id),
+  formats the marker via `formatMarker`, calls the injected `deps.send(topicId, text)`,
+  and writes ONE audit row (always — on `ok`, `failed`, or `role-refused`). Returns
+  `{ok, a2aId, sentMessageId?, reason?}`.
+- **Runtime anti-loop guard** (spec §Fix 2a anti-loop #1): refuses any `role` not in
+  `deps.allowedRoles` — NO send attempted, NO marker formed, audit row with
+  `result: 'role-refused'`. This makes the import-surface lint (deferred to PR 3) a
+  backup rather than the only defense; the runtime guard always applies.
+- `scrubToken(s, token)` — redacts the bot token (full + secret-portion) from any
+  string before it leaves the module. Wired into every error/audit path in
+  `sendAgentMessage` (round-2 adversarial F5: Telegram 401 response bodies sometimes
+  echo the token).
+
+## The seven questions
+
+1. **Over-block.** The runtime role-refusal is exact — a caller that legitimately needs
+   role X passes it in `allowedRoles`. No false-positive refusal.
+2. **Under-block.** Every send path writes an audit row (ok / failed / role-refused) — no
+   silent drop. Token scrub runs on every reason-string surface (format errors, send
+   errors). The audit row schema explicitly forbids secrets (verified in the artifact).
+3. **Level-of-abstraction fit.** I/O injected (`send`, `appendAudit`, `now`, `mintId`,
+   `botToken`, `fromBotId`, `toBotId`). The function is the wire-level send/marker/audit
+   logic; storage choice (JSONL vs SQLite) is the caller's (PR 3 picks).
+4. **Signal vs authority.** Send is the authority on "did the message leave my process";
+   the result is exact (`ok` only when the adapter returns a messageId). Audit row is the
+   signal trail. No silent best-effort.
+5. **Interactions — dark, but the module surface is shared with PR 1 + the existing
+   `decideRoute`.** The send side adds NEW exports (sendAgentMessage, scrubToken,
+   SendAuditRow, etc.) — existing imports unaffected. Dark today.
+6. **External surfaces.** None new in this PR. The audit row schema is the wire format
+   for future log readers (Stage-B forensics will read it in PR 3).
+7. **Rollback cost.** Trivial — revert removes additive exports + tests. No data, no
+   migration. PR 1 / PR 2a are not touched.
+
+## Testing
+
+- 5 new unit tests (25 total in the file, all green):
+  - **send + audit happy path**: marker round-trips through `parseMarker` (the sender's
+    output is the receiver's input — closes the wire-format integration informally);
+    `result: 'ok'` audit row with `sentMessageId` + correct fields.
+  - **correlation threading**: explicit `correlationId` lands in the marker's `corr=`
+    and in the audit row (prompt↔reply linkage via Telegram chat history alone, per
+    Codey's round-2 design point).
+  - **ANTI-LOOP runtime refusal**: a role not in `allowedRoles` → no send, role-refused
+    audit row with explanatory reason. Proves the import-lint isn't the only defense.
+  - **send-error with token in body**: adapter throws an error containing the bot token
+    → result + audit reason both scrubbed (no token leak through any surface).
+  - **scrubToken unit**: full-token + secret-portion + no-token-present + undefined-token
+    coverage.
+- `tsc --noEmit` clean.
+
+## Migration parity
+
+None — additive exports to a dark module. No config, no routes, no agent-installed file
+changes. PR 3 wires the receiver-handler at `server.ts`, the role handlers, the audit
+ledger persistence (JSONL append via SafeFsExecutor), and the processed-id store (SQLite
+per the convention note flagged in PR 1's artifact); migration (file-outbox retirement,
+dead-config removal) lands there per the spec's §Migration parity.


### PR DESCRIPTION
## What

PR 2b — the SEND side of the agent-to-agent Telegram comms primitive (spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2a "Sender side" + anti-loop #1 + round-2 adversarial F5). Extends `src/messaging/AgentTelegramComms.ts` additively. **Ships dark** — no caller invokes it yet; PR 3 wires the mentor consumer + recipient-handler at `server.ts` + ledger persistence + role-handler registration.

## Changes

- **`sendAgentMessage(input, deps)`** — mints/uses `a2aId`, defaults `correlationId` to `id` (prompts self-correlate, replies thread on the prompt's id), formats the marker via `formatMarker`, calls `deps.send(topicId, text)`, and writes ONE audit row for every outcome — `ok` / `failed` / `role-refused` — never silent.
- **ANTI-LOOP runtime guard** (spec §Fix 2a #1): refuses any `role` not in `deps.allowedRoles` — NO send attempted, NO marker formed, `role-refused` audit row. Makes the import-surface lint a backup, not the only defense.
- **`scrubToken`** redacts the bot token (full + secret-portion) from every error/audit string before it leaves the module — round-2 adversarial F5 (Telegram 401 response bodies sometimes echo the token).
- **`SendAuditRow` schema** — routing/audit metadata only, never secrets.

## Tests

5 new (25 total in the file, all green): happy-path round-trip through `parseMarker` (sender output IS receiver input — informal wire-format check); correlation threading; anti-loop role-refusal; adapter-failure with token in error body scrubbed from both result and audit; `scrubToken` unit coverage. `tsc --noEmit` clean. NEXT.md combined with PR 2a's pending content (no release cut between them).

## Next

PR 3: the recipient-handler wrap at `server.ts` + the mentor consumer (Stage-A/B rewiring, mentor bot, outstanding-prompt tracker, quota-budget, file-outbox-retirement migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)