### PR TITLE
feat(messaging): a2a comms — audit ledger + processed-id store (PR 3a/3)

### DIFF
--- a/site/src/content/docs/architecture/the-living-system.md
+++ b/site/src/content/docs/architecture/the-living-system.md
@@ -203,3 +203,22 @@ The biological metaphor isn't decorative — it's a diagnostic framework.
 - [Default Jobs](/reference/default-jobs) — Detailed descriptions of all 26 scheduled jobs
 - [Self-Healing](/features/self-healing) — The user-facing perspective on recovery
 - [Evolution System](/features/evolution) — How the Memory & Learning system appears to users
+
+---
+
+## Inter-agent comms (the new building block)
+
+A small set of internal modules powers the agent-to-agent Telegram comms primitive — the
+groundwork for one Instar agent messaging another over Telegram with built-in anti-loop
+machinery. **Ships dark today**; the mentor system will be its first consumer:
+
+- **`AgentTelegramComms`** — the pure logic: visible `[a2a:from=… to=… role=… id=… corr=…
+  ts=… v=1]` marker, strict parser, the recipient routing decision (with the user-spoof
+  defense — a human typing the marker is dropped, not routed), and cycle-detection on
+  `(fromBot, toBot, topic, role, corr)`.
+- **`AgentTelegramLedger`** — append-only JSONL of every send and every receive decision.
+  Best-effort + non-throwing (an audit-write failure cannot crash a tick).
+- **`ProcessedIdStore`** — bounded persistent set of recently-seen marker ids so a
+  Telegram retry or adapter restart can't double-inject the same prompt.
+
+See `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` for the full design.

--- a/site/src/content/docs/architecture/under-the-hood.md
+++ b/site/src/content/docs/architecture/under-the-hood.md
@@ -367,3 +367,16 @@ The sections above describe what each subsystem does at a behavioral level. The 
 ### `src/providers/` — cross-framework intelligence routing
 
 `AnthropicIntelligenceProvider`, `CostAwareRoutingPolicy`, `LocalModelAdapter`, `ProviderRegistry`, `StallTriageNurse` (provider-side fork), `TierResolver`.
+
+## Inter-agent comms (agent-to-agent Telegram primitive)
+
+- **`AgentTelegramComms`** (`src/messaging/AgentTelegramComms.ts`) — the agent-to-agent
+  Telegram comms primitive's pure logic: marker parse/format, the recipient routing
+  matrix (incl. user-spoof defense + per-source role acceptance), and cycle-detection.
+- **`AgentTelegramLedger`** (`src/messaging/AgentTelegramLedger.ts`) — append-only JSONL
+  audit trail of every a2a send and every receive decision (routed or dropped, with the
+  reason code). Best-effort + non-throwing.
+- **`ProcessedIdStore`** (`src/messaging/ProcessedIdStore.ts`) — bounded persistent set
+  of recently-processed marker ids; idempotency against Telegram retry / adapter restart.
+
+Spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2a.

--- a/src/messaging/AgentTelegramLedger.ts
+++ b/src/messaging/AgentTelegramLedger.ts
@@ -1,0 +1,98 @@
+/**
+ * AgentTelegramLedger — append-only audit trail for the agent-to-agent Telegram comms
+ * primitive (spec MENTOR-LIVE-READINESS §Fix 2a "Round-trip audit ledger" + Codey's
+ * round-2 design point: separate sent + received JSONLs so Stage-B forensics can
+ * reconstruct the round trip from the ledger files alone, OR from Telegram chat history
+ * alone via the visible `corr=` field).
+ *
+ * Conventions:
+ * - Append-only JSONL (atomic at line granularity on POSIX for `<PIPE_BUF` writes —
+ *   the same rationale the original mentor-outbox used; documented so a future reviewer
+ *   doesn't "fix" it to atomicWriteFileSync, which is wrong for append).
+ * - **No secrets in any row** (round-2 adversarial F5 — and the SendAuditRow shape
+ *   explicitly excludes the bot token; the ReceiveAuditRow only captures routing-level
+ *   marker fields, never the body).
+ * - Default paths: `{stateDir}/a2a-sent.jsonl` + `{stateDir}/a2a-received.jsonl`. The
+ *   caller may override (per-agent isolation, tests).
+ *
+ * I/O is the only side-effect; everything else is pure data.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { SendAuditRow, RouteDropReason } from './AgentTelegramComms.js';
+
+/** Audit row written by the recipient wiring on every a2a event that was either routed
+ *  to a role-handler or dropped. NO row is written when the message is `no-marker`
+ *  (fall-through to normal user handling) — that would log every user message. */
+export interface ReceiveAuditRow {
+  localTs: string;
+  direction: 'received';
+  decision: 'routed' | 'dropped';
+  /** When `dropped`, the reason code from the routing matrix (see RouteDropReason). */
+  dropReason?: RouteDropReason | 'agent-marker-malformed';
+  /** Parsed marker fields — present when the parse succeeded, undefined for malformed. */
+  fromAgent?: string;
+  toAgent?: string;
+  role?: string;
+  id?: string;
+  corr?: string;
+  ts?: number;
+  /** Telegram-side identifiers, when resolved. */
+  telegramFromBotId?: string;
+  telegramSenderChatId?: string;
+  topicId?: number;
+  /** First 200 chars of the raw inbound (post-marker-strip on route; raw on drop) so
+   *  forensic readers can reconstruct what happened from the ledger alone. NEVER the
+   *  full body for routed rows — the body went to the role-handler. */
+  rawPrefix?: string;
+}
+
+export interface AgentTelegramLedgerPaths {
+  sentPath: string;
+  receivedPath: string;
+}
+
+export function defaultLedgerPaths(stateDir: string): AgentTelegramLedgerPaths {
+  return {
+    sentPath: path.join(stateDir, 'a2a-sent.jsonl'),
+    receivedPath: path.join(stateDir, 'a2a-received.jsonl'),
+  };
+}
+
+/**
+ * Append-only JSONL audit ledger. Both `appendSent` and `appendReceived` are synchronous
+ * + best-effort: they NEVER throw (an audit-write failure must not crash a tick). Writes
+ * use `fs.appendFileSync` because atomic-write-replace is wrong for append-only files
+ * (see the documented rationale in the module header).
+ */
+export class AgentTelegramLedger {
+  private readonly sentPath: string;
+  private readonly receivedPath: string;
+
+  constructor(paths: AgentTelegramLedgerPaths) {
+    this.sentPath = paths.sentPath;
+    this.receivedPath = paths.receivedPath;
+  }
+
+  appendSent(row: SendAuditRow): void {
+    this.appendLine(this.sentPath, row);
+  }
+
+  appendReceived(row: ReceiveAuditRow): void {
+    this.appendLine(this.receivedPath, row);
+  }
+
+  private appendLine(target: string, row: unknown): void {
+    try {
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.appendFileSync(target, JSON.stringify(row) + '\n', 'utf-8');
+    } catch (err) {
+      // Best-effort audit: an audit-write failure must not crash a tick. Log but swallow.
+      // (Spec §Fix 2a "every drop path writes an audit row" — silent drops make Stage-B
+      // forensics painful, but a CRASHED tick is worse. We accept this trade-off.)
+      // eslint-disable-next-line no-console
+      console.warn(`[a2a-ledger] append failed (non-fatal) at ${target}:`, err instanceof Error ? err.message : String(err));
+    }
+  }
+}

--- a/src/messaging/ProcessedIdStore.ts
+++ b/src/messaging/ProcessedIdStore.ts
@@ -1,0 +1,138 @@
+/**
+ * ProcessedIdStore — small persistent set of recently-processed a2a marker `id`s, so
+ * Telegram retries / adapter restarts can't double-inject the same prompt (spec
+ * MENTOR-LIVE-READINESS §Fix 2a "Processed-id ledger" + Codey's round-2 design point).
+ *
+ * Bounded by `maxEntries` (default 10_000) AND `maxAgeMs` (default 30 days) — whichever
+ * evicts first. **Bounded eviction is the same surface adversarial F2 worried about**:
+ * an `id` that ages out is no longer "duplicate" and could be re-injected by a replayer
+ * who captured it. The marker's `ts` + skew-window (24h default) is the defense at the
+ * primitive layer; this store's eviction policy is set generously so legitimate retries
+ * within hours/days are still de-duped.
+ *
+ * Convention note: instar prefers SQLite for durable dedup ledgers (MessageProcessingLedger,
+ * CommitmentTracker). This store uses a small JSON file because the working set is small
+ * (per-mentee processed-ids over 30d), the file is rewritten atomically on every mark, and
+ * there's no concurrent-writer story to need WAL. A future bump to SQLite is a drop-in
+ * replacement at the class boundary.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
+
+export interface ProcessedIdStoreOptions {
+  /** Absolute path to the JSON file backing the store. */
+  filePath: string;
+  /** Max entries to retain before evicting the oldest (default 10_000). */
+  maxEntries?: number;
+  /** Max age (ms) before an entry is evicted (default 30 days). */
+  maxAgeMs?: number;
+  /** Injected for testability. Default: Date.now. */
+  now?: () => number;
+}
+
+interface ProcessedRecord {
+  ts: number;
+}
+
+interface PersistedFile {
+  /** Schema version of the JSON layout (bumps are explicit). */
+  v: 1;
+  /** id → first-seen-ts. */
+  entries: Record<string, number>;
+}
+
+const DEFAULT_MAX_ENTRIES = 10_000;
+const DEFAULT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export class ProcessedIdStore {
+  private readonly filePath: string;
+  private readonly maxEntries: number;
+  private readonly maxAgeMs: number;
+  private readonly now: () => number;
+  private entries: Map<string, ProcessedRecord>;
+
+  constructor(opts: ProcessedIdStoreOptions) {
+    this.filePath = opts.filePath;
+    this.maxEntries = opts.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+    this.now = opts.now ?? Date.now;
+    this.entries = new Map();
+    this.load();
+  }
+
+  /** True if the id has been marked + has not been evicted. */
+  hasProcessed(id: string): boolean {
+    this.evictExpired();
+    return this.entries.has(id);
+  }
+
+  /** Mark this id processed at now() and persist. Idempotent (re-marking is a no-op
+   *  beyond refreshing the persisted snapshot). */
+  markProcessed(id: string): void {
+    if (!this.entries.has(id)) {
+      this.entries.set(id, { ts: this.now() });
+    }
+    this.evictExpired();
+    this.evictOverflow();
+    this.persist();
+  }
+
+  /** Test helper: current entry count. */
+  size(): number {
+    this.evictExpired();
+    return this.entries.size;
+  }
+
+  private load(): void {
+    if (!fs.existsSync(this.filePath)) return;
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedFile;
+      if (parsed && parsed.v === 1 && parsed.entries && typeof parsed.entries === 'object') {
+        for (const [id, ts] of Object.entries(parsed.entries)) {
+          if (typeof ts === 'number' && Number.isFinite(ts)) {
+            this.entries.set(id, { ts });
+          }
+        }
+      }
+    } catch {
+      // Corrupted store → start fresh (full re-allow). Better than crashing the recipient
+      // — duplicate prompts are recoverable; a dead recipient isn't.
+      this.entries = new Map();
+    }
+  }
+
+  private persist(): void {
+    const file: PersistedFile = {
+      v: 1,
+      entries: Object.fromEntries([...this.entries].map(([id, r]) => [id, r.ts])),
+    };
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      SafeFsExecutor.atomicWriteJsonSync(this.filePath, file, { operation: 'ProcessedIdStore.persist' });
+    } catch (err) {
+      // Best-effort persistence; on the next mark we retry.
+      // eslint-disable-next-line no-console
+      console.warn(`[a2a-processed-id] persist failed (non-fatal) at ${this.filePath}:`, err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  private evictExpired(): void {
+    const cutoff = this.now() - this.maxAgeMs;
+    for (const [id, r] of this.entries) {
+      if (r.ts < cutoff) this.entries.delete(id);
+    }
+  }
+
+  private evictOverflow(): void {
+    if (this.entries.size <= this.maxEntries) return;
+    // Drop oldest first.
+    const sorted = [...this.entries].sort((a, b) => a[1].ts - b[1].ts);
+    const dropCount = this.entries.size - this.maxEntries;
+    for (let i = 0; i < dropCount; i++) {
+      this.entries.delete(sorted[i][0]);
+    }
+  }
+}

--- a/tests/unit/messaging/AgentTelegramLedger.test.ts
+++ b/tests/unit/messaging/AgentTelegramLedger.test.ts
@@ -1,0 +1,144 @@
+/**
+ * AgentTelegramLedger + ProcessedIdStore unit tests (PR 3a, spec §Fix 2a "Round-trip audit
+ * ledger" + "Processed-id ledger").
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { AgentTelegramLedger, defaultLedgerPaths, type ReceiveAuditRow } from '../../../src/messaging/AgentTelegramLedger.js';
+import { ProcessedIdStore } from '../../../src/messaging/ProcessedIdStore.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+import type { SendAuditRow } from '../../../src/messaging/AgentTelegramComms.js';
+
+const NOW = 1_779_900_000_000;
+
+describe('AgentTelegramLedger', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'a2a-ledger-')); });
+  afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'a2a-ledger test' }); });
+
+  function mkSent(over: Partial<SendAuditRow> = {}): SendAuditRow {
+    return {
+      localTs: '2026-05-27T00:00:00.000Z', direction: 'sent', fromAgent: 'echo', toAgent: 'instar-codey',
+      role: 'mentor', id: 'i1', corr: 'i1', ts: NOW, telegramFromBotId: 'echo-bot', telegramToBotId: 'codey-bot',
+      topicId: 42, result: 'ok', sentMessageId: 'msg-1', ...over,
+    };
+  }
+
+  function mkRecv(over: Partial<ReceiveAuditRow> = {}): ReceiveAuditRow {
+    return {
+      localTs: '2026-05-27T00:00:01.000Z', direction: 'received', decision: 'routed',
+      fromAgent: 'instar-codey', toAgent: 'echo', role: 'mentor-reply', id: 'r1', corr: 'i1', ts: NOW,
+      telegramFromBotId: 'codey-bot', topicId: 42, ...over,
+    };
+  }
+
+  it('appendSent + appendReceived write JSONL rows to distinct files at the default paths', () => {
+    const paths = defaultLedgerPaths(dir);
+    const led = new AgentTelegramLedger(paths);
+    led.appendSent(mkSent());
+    led.appendSent(mkSent({ id: 'i2', corr: 'i2', sentMessageId: 'msg-2' }));
+    led.appendReceived(mkRecv());
+
+    expect(fs.existsSync(paths.sentPath)).toBe(true);
+    expect(fs.existsSync(paths.receivedPath)).toBe(true);
+    const sentLines = fs.readFileSync(paths.sentPath, 'utf-8').trim().split('\n');
+    expect(sentLines).toHaveLength(2);
+    expect(JSON.parse(sentLines[0])).toMatchObject({ direction: 'sent', id: 'i1', result: 'ok' });
+    expect(JSON.parse(sentLines[1])).toMatchObject({ id: 'i2', sentMessageId: 'msg-2' });
+    const recv = JSON.parse(fs.readFileSync(paths.receivedPath, 'utf-8').trim());
+    expect(recv).toMatchObject({ direction: 'received', decision: 'routed', role: 'mentor-reply', corr: 'i1' });
+  });
+
+  it('records drops with the drop reason (the routing matrix audit trail)', () => {
+    const paths = defaultLedgerPaths(dir);
+    const led = new AgentTelegramLedger(paths);
+    led.appendReceived(mkRecv({ decision: 'dropped', dropReason: 'agent-marker-spoofed-by-user', role: undefined, id: undefined }));
+    const r = JSON.parse(fs.readFileSync(paths.receivedPath, 'utf-8').trim());
+    expect(r).toMatchObject({ decision: 'dropped', dropReason: 'agent-marker-spoofed-by-user' });
+  });
+
+  it('NEVER throws when the directory is unwritable (best-effort; tick survives)', () => {
+    // Point ledger at a path whose parent is a regular file (mkdirSync will fail) —
+    // appendLine must NOT throw.
+    const blockerFile = path.join(dir, 'not-a-dir');
+    fs.writeFileSync(blockerFile, 'i am a file');
+    const led = new AgentTelegramLedger({
+      sentPath: path.join(blockerFile, 'sent.jsonl'),
+      receivedPath: path.join(blockerFile, 'received.jsonl'),
+    });
+    expect(() => led.appendSent(mkSent())).not.toThrow();
+    expect(() => led.appendReceived(mkRecv())).not.toThrow();
+  });
+});
+
+describe('ProcessedIdStore — idempotency dedup', () => {
+  let dir: string;
+  let clock: number;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'a2a-pids-')); clock = NOW; });
+  afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'a2a-pids test' }); });
+
+  function mk(over: Partial<{ maxEntries: number; maxAgeMs: number }> = {}): ProcessedIdStore {
+    return new ProcessedIdStore({
+      filePath: path.join(dir, 'pids.json'),
+      now: () => clock,
+      ...over,
+    });
+  }
+
+  it('marks + recalls + persists across re-open', () => {
+    const s1 = mk();
+    expect(s1.hasProcessed('abc')).toBe(false);
+    s1.markProcessed('abc');
+    expect(s1.hasProcessed('abc')).toBe(true);
+    // Re-open from disk
+    const s2 = mk();
+    expect(s2.hasProcessed('abc')).toBe(true);
+    expect(s2.hasProcessed('xyz')).toBe(false);
+  });
+
+  it('evicts entries older than maxAgeMs', () => {
+    const s = mk({ maxAgeMs: 5000 });
+    s.markProcessed('old');
+    clock += 6000;
+    expect(s.hasProcessed('old')).toBe(false); // expired
+    s.markProcessed('fresh');
+    expect(s.hasProcessed('fresh')).toBe(true);
+  });
+
+  it('evicts oldest when over maxEntries', () => {
+    const s = mk({ maxEntries: 3 });
+    s.markProcessed('a'); clock += 1;
+    s.markProcessed('b'); clock += 1;
+    s.markProcessed('c'); clock += 1;
+    expect(s.size()).toBe(3);
+    s.markProcessed('d'); // forces eviction of 'a'
+    expect(s.hasProcessed('a')).toBe(false);
+    expect(s.hasProcessed('b')).toBe(true);
+    expect(s.hasProcessed('d')).toBe(true);
+    expect(s.size()).toBe(3);
+  });
+
+  it('survives a corrupted file (starts fresh rather than crash)', () => {
+    fs.writeFileSync(path.join(dir, 'pids.json'), '{not valid json');
+    const s = mk();
+    expect(s.size()).toBe(0); // fresh start
+    s.markProcessed('q'); // can still operate
+    expect(s.hasProcessed('q')).toBe(true);
+  });
+
+  it('re-marking the same id is a no-op (idempotent)', () => {
+    const s = mk();
+    s.markProcessed('z');
+    const tsBefore = clock;
+    clock += 10_000;
+    s.markProcessed('z'); // does NOT refresh the ts (first-seen semantics)
+    // Force a re-load to verify persisted ts.
+    const s2 = mk();
+    // Inspect the persisted file directly: ts should be the original mark time.
+    const persisted = JSON.parse(fs.readFileSync(path.join(dir, 'pids.json'), 'utf-8'));
+    expect(persisted.entries.z).toBe(tsBefore);
+    expect(s2.hasProcessed('z')).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -15,11 +15,27 @@ The **Release-Readiness Visibility** spec (`docs/specs/RELEASE-READINESS-VISIBIL
 
 The fix path for an existing silent stall: the watchdog opens an Attention item; auto-draft fills NEXT.md but BOTH publish gates refuse it until a human reviews each section (replacing the marker with a hash-locked receipt); rollback flips a state-file kill-switch loudly.
 
+---
+
+**Agent-to-agent Telegram comms primitive — receiver-side storage primitives.** Two new
+internal modules the next update will use to wire the recipient side of the a2a primitive,
+both **dark** (no caller yet):
+
+- `AgentTelegramLedger` — append-only JSONL audit trail of every a2a send and every a2a
+  receive decision (routed or dropped, with the drop reason). Best-effort + non-throwing
+  (an audit-write failure must not crash a tick).
+- `ProcessedIdStore` — bounded persistent set of recently-processed marker `id`s, so
+  Telegram retries or adapter restarts can't double-inject the same prompt. Bounded by
+  `maxEntries` (10k default) AND `maxAgeMs` (30d default). Backed by an atomic-write JSON
+  file via SafeFsExecutor; corrupt-file recovery (starts fresh rather than crash the
+  recipient).
+
 ## What to Tell Your User
 
 - **I'll notice if my own ship is stuck**: when changes pile up and a release stops going out, I now raise a single, calm flag on my attention list — and the longer it sits, the louder that flag gets. You don't have to remember to check whether I'm actually shipping; I'll tell you when I'm not.
 - **The release notes draft themselves**: instead of waiting for someone to write release notes from scratch, the toolchain now sketches a starter version from the change list. A human still has to read and sign off on each section before it can publish — the safety net stays in place; it just isn't a blank page anymore.
 - **A merged feature can no longer be invisible to my own systems**: my feature board used to read whatever was on my laptop, which sometimes meant brand-new merged features didn't show up. It can now read the real shared copy directly, so the newest work stops being the most-hidden work.
+- The agent-to-agent Telegram comms infrastructure continues to land in pieces; still plumbing, nothing user-visible changes today.
 
 This change is off by default everywhere. I'll dogfood it on myself first.
 
@@ -31,9 +47,13 @@ This change is off by default everywhere. I'll dogfood it on myself first.
 | Auto-draft an upgrade guide | `node scripts/analyze-release.js --draft-guide` (writes `upgrades/NEXT.md` with unreviewed markers) |
 | Canonical-ref spec scan | Set `featureRollout.canonicalRefScan: true` and `featureRollout.canonicalRemote` in `.instar/config.json` |
 | Enable the watchdog | Set `monitoring.releaseReadiness.enabled: true` in `.instar/config.json`; the `release-readiness-check` job runs every 6h (still ships disabled — flip it on per agent) |
+| `AgentTelegramLedger` | Internal — `new AgentTelegramLedger(defaultLedgerPaths(stateDir))`; `appendSent(row)` + `appendReceived(row)`; JSONL, best-effort non-throwing |
+| `ProcessedIdStore` | Internal — `new ProcessedIdStore({filePath, maxEntries?, maxAgeMs?})`; `hasProcessed(id)` + `markProcessed(id)`; bounded + persistent |
 
 ## Evidence
 
 The Layer B real-I/O E2E (`tests/e2e/release-readiness-live.test.ts`) reproduces the original silent-stall shape against a fixture instar repo (real git fetch + real `analyze-release.js` subprocess + real `merge-base`) and asserts that exactly one Attention item is raised for an aged, blocked backlog. The Layer A unit tests (`tests/unit/analyze-release-draft-guide.test.ts` and `tests/unit/upgrade-guide-autodraft-review.test.ts`) reproduce the placeholder-text bypass adversarial review caught (the analyzer's `'Review the commit for specifics'` fallback that previously could pass the section-presence gate) and confirm the new validator blocks it. The Layer C unit test (`tests/unit/featureRolloutScan-canonical.test.ts`) reproduces the exact bug — a spec deleted from the local working tree but committed to main — and confirms the canonical scan still detects it as merged. ~64 tests added across three layered tiers, all green.
 
 Additionally, this very NEXT.md authoring revealed the meta-failure: the two PRs above merged but their publishes silently skipped because **NEXT.md didn't exist** — exactly the silent-skip mechanism Layer A + Layer B were built to surface. This guide is the unblock; once it publishes, the watchdog this guide describes goes live and can catch the same shape next time.
+
+Plus, the a2a comms storage primitives shipping here have 8 unit tests, all green: ledger writes to distinct files (append-only JSONL, one row per event); ledger captures the drop reason on routing-matrix drops; ledger never throws when the target is unwritable (best-effort guard tested by pointing at an unwritable path); store marks + recalls + persists across re-open; store evicts by `maxAgeMs` and by `maxEntries` (oldest first); store survives a corrupted file (starts fresh, doesn't crash); re-marking the same id is idempotent (first-seen-ts preserved).

--- a/upgrades/side-effects/a2a-ledger-and-processed-id-store.md
+++ b/upgrades/side-effects/a2a-ledger-and-processed-id-store.md
@@ -1,0 +1,68 @@
+# Side-Effects Review — a2a audit ledger + processed-id store (PR 3a)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2a "Round-trip audit ledger" +
+"Processed-id ledger" + Codey's round-2 idempotency-on-receive design point. PR 3 of the
+staged build, part a.
+**Change:** Two new storage primitive modules the receiver wiring (PR 3b) will consume:
+`AgentTelegramLedger` (append-only JSONL of sent + received audit rows) and
+`ProcessedIdStore` (bounded persistent set of recently-processed marker `id`s for Telegram
+retry / restart idempotency). Both **dark** — no caller yet; PR 3b wires the recipient
+handler at `server.ts` and uses these.
+**Files:** `src/messaging/AgentTelegramLedger.ts` (new), `src/messaging/ProcessedIdStore.ts`
+(new), `tests/unit/messaging/AgentTelegramLedger.test.ts` (new — covers both).
+
+## The seven questions
+
+1. **Over-block.** N/A — no gate. The ledger always writes; the store only blocks on a
+   recorded `id` (the idempotency guarantee).
+2. **Under-block.** Ledger writes are **best-effort + non-throwing** — an audit-write
+   failure must not crash a tick (spec note: "silent drops make Stage-B forensics painful,
+   but a crashed tick is worse"). Tested: pointing the ledger at an unwritable path → no
+   throw. The store's persistence is also best-effort (warn + continue on persist failure,
+   retry on next mark).
+3. **Level-of-abstraction fit.** Each module owns ONE thing — ledger appends rows; store
+   answers "have I seen this id." Both injectable for PR 3b's wiring + tests. JSONL append
+   is intentional (atomic at line granularity on POSIX for `<PIPE_BUF`); SafeFsExecutor's
+   atomic-write-replace is wrong for append (documented in module header so a future
+   reviewer doesn't "fix" it incorrectly).
+4. **Signal vs authority.** N/A.
+5. **Interactions — both modules are dark.** No caller, no runtime side-effect. PR 3b
+   integrates them into the recipient handler. The ReceiveAuditRow shape is the wire
+   contract for Stage-B forensics + future debugging.
+6. **External surfaces.** None new. Default paths are `{stateDir}/a2a-sent.jsonl` +
+   `{stateDir}/a2a-received.jsonl` + (PR 3b chooses) `{stateDir}/a2a-processed-ids.json`.
+   Caller may override.
+7. **Rollback cost.** Trivial — revert removes two unused modules. No data, no migration.
+
+## Convention notes
+
+- **JSONL ≠ SQLite for these two cases.** The MessageProcessingLedger header explicitly
+  prefers SQLite for dedup ledgers ("NOT a new ad-hoc JSON file") — and we follow that
+  spirit by isolating the data behind a class boundary (a SQLite swap-in is one constructor
+  away). The current JSON-file backing is justified for `ProcessedIdStore` because the
+  working set is small (bounded 10k entries / 30d), atomic-write-rewrite is cheap at that
+  size, and there's no concurrent-writer story to need WAL. For `AgentTelegramLedger`,
+  JSONL append IS the right shape (forensic trail, append-only, line-atomic).
+- **Eviction policy + the round-2 adversarial F2 surface.** The store evicts by
+  `maxEntries` (10k) OR `maxAgeMs` (30d) — whichever first. A replayer who captured an `id`
+  outside that window could re-inject it; the **defense at that layer is the marker's
+  `ts` + `skewWindowMs` (24h)** added in PR 1 (already shipped). The store's job is
+  "de-dup within the legitimate-retry window," not "absolute replay protection." Documented.
+
+## Testing
+
+8 unit tests, all green:
+- **Ledger**: appendSent + appendReceived to distinct files (+ JSONL line-per-row); drop
+  row with `dropReason` captured (the routing-matrix audit trail); **never throws** when
+  the target is unwritable (best-effort guard tested).
+- **Store**: mark + recall + persist-across-reopen; eviction by `maxAgeMs`; eviction by
+  `maxEntries` (oldest first); corrupt-file recovery (start fresh, don't crash); idempotent
+  re-mark (first-seen-ts preserved).
+- `tsc --noEmit` clean. Both modules dark (no caller).
+
+## Migration parity
+
+None — two new unwired modules. No agent-installed file changes, no config consumed yet.
+PR 3b adds the recipient handler wiring + `mentor.processedIdStorePath` (or similar) to
+config defaults; PR 3c (mentor consumer) adds the file-outbox retirement + dead-config
+removal migrations per the spec's §Migration parity.


### PR DESCRIPTION
## What

PR 3a — receiver-side storage primitives for the agent-to-agent Telegram comms (spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md`). Two new modules. Both **dark** — no caller yet; PR 3b wires the recipient handler at `server.ts` to consume them.

## Changes

- **`AgentTelegramLedger`** — append-only JSONL of sent + received audit rows (per Codey's round-2 design point: forensic trail reconstructable from ledgers alone OR from Telegram chat history alone via visible `corr=`). **Best-effort + non-throwing** (an audit-write failure must NOT crash a tick). JSONL append is intentional + atomic-at-line-granularity; SafeFsExecutor's atomic-write-replace is wrong for append (documented in module header).
- **`ProcessedIdStore`** — bounded persistent set of recently-processed marker `id`s (default 10k entries / 30d) so Telegram retries / adapter restarts can't double-inject. Atomic-write JSON via SafeFsExecutor; corrupt-file recovery starts fresh rather than crash. Class boundary keeps a future SQLite swap-in trivial (per the convention preferring SQLite for dedup ledgers, surfaced in the side-effects artifact).

The marker's `ts` + `skewWindowMs` defense (PR 1) is the absolute-replay protection at the primitive layer; this store's job is "de-dup within the legitimate-retry window."

## Tests

8 unit tests, all green: ledger writes to distinct files + JSONL one-row-per-event; drop reason captured in audit row; **ledger never throws on unwritable target**; store mark+recall+persist-across-reopen; age eviction; count eviction (oldest first); **corrupt-file recovery** (starts fresh); idempotent re-mark (first-seen `ts` preserved). `tsc --noEmit` clean.

## Next

PR 3b: recipient handler wrap at `server.ts` (the load-bearing wiring — agent handler runs first, falls through to user handler if not a2a) + the mentor consumer (Stage-A/B rewiring via the primitive, mentor bot, outstanding-prompt tracker, quota-budget, file-outbox-retirement migration, bot-setup routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)