### PR TITLE
fix(telegram): structural poll-ownership lease — prevents 409 dual-poll class

### DIFF
--- a/docs/specs/SELF-PROPAGATION-HARNESS-SPEC.eli16.md
+++ b/docs/specs/SELF-PROPAGATION-HARNESS-SPEC.eli16.md
@@ -1,0 +1,31 @@
+# ELI16 — Self-Propagation Harness + the "two listeners" fix
+
+## The goal
+
+You want to be able to put "me" onto a second machine and test that I work there — over real Telegram — without it being a fiddly, hand-done dance every time. Right now it IS hand-done, and that's exactly why the last live test left muddy evidence.
+
+## The two things that bit us last time
+
+1. **"Two things trying to listen at once."** Telegram only lets ONE program listen for a bot's messages at a time. I have two programs that *can* listen: the lightweight "lifeline" (the normal listener) and the main server. The server is supposed to stay quiet and let the lifeline listen — but the only thing making it stay quiet is *remembering* to start it with a special flag. Forget the flag, and both try to listen, and Telegram throws a "conflict" error. That's willpower, not structure.
+
+2. **A crash we mislabeled.** We'd written it down as a deep low-level "mutex" crash. It wasn't — it was a plain out-of-memory blowout (a helper process ate all its memory and died). And the test agent's own server actually started up fine and was still alive after that crash. So the real story is different from our notes, and the evidence is fuzzy because the deploy was done by hand.
+
+## The fix — two parts
+
+**Part 1 — make the "two listeners" problem impossible (you picked this).** Instead of relying on a flag, the lifeline leaves a little "I've got the listening covered" note. The server checks for that note on startup; if it's there and current, the server automatically stays quiet. Now it doesn't matter how the server was started — it can't double-listen. (If there's no note, the server behaves exactly as today, so nothing else changes.)
+
+**Part 2 — the one-button harness.** A single command, `instar test-as-self`, that does the whole deploy as clean, checked steps: set up a throwaway test agent, copy my current code (rebuilding the bits that are machine-specific), start it the right way, send a test message and confirm I reply, capture any crash properly, and tidy up afterward. Repeatable and safe to re-run — so next time we get clean evidence instead of sifting crash logs by hand.
+
+This is also the thing that unblocks the cross-machine test we've been holding (the seamlessness work).
+
+## What you'll notice
+
+Nothing in day-to-day use. Under the hood: the "conflict" error class is gone for good, and deploying me onto another machine becomes one command instead of a careful manual ritual.
+
+## Honest note
+
+The out-of-memory crash is diagnosed but NOT yet fixed — I won't claim a fix until the harness reproduces it cleanly and I see the real cause. The harness is the tool that lets me do that properly.
+
+## Risk
+
+Low for Part 1 (the "note" check is additive and falls back to today's behavior if the note is missing). Part 2 is a new command that only touches a throwaway test agent — never you, never the real setup.

--- a/docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md
+++ b/docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md
@@ -1,0 +1,56 @@
+---
+approved: true
+review-convergence: internal-adversarial-2026-05-27 (single-reviewer conformance pass against the six Instar standards — no-manual-work, structure>willpower, signal-vs-authority, near-silent, 3-tier-testing, migration-parity — plus gameability/over-block sweep. Scope locked via Justin's AskUserQuestion answer + explicit "go" on the ELI16: harness + structural poll-ownership lease. /spec-converge not run: branded skill not installed on this checkout, same as prior specs this session.)
+---
+
+# Spec — Agent Self-Propagation Harness + Poll-Ownership Lease (Task 4 / CMT-560)
+
+## Problem
+
+Deploying "me" onto a second machine for a live test is currently a fragile, hand-done sequence (mint a bot, configure the agent, copy the dist, start the server, smoke-test, restore). The 2026-05-27 live test surfaced two failures, and the ad-hoc nature of the deploy made them hard to pin (diagnostics: `.instar/task4-self-propagation-diagnostics.local.md`):
+
+1. **Telegram 409 dual-poll (structural gap, code-verified).** instar has two potential Telegram pollers — the lifeline (canonical, forwards to the server) and the server's own `TelegramAdapter` (`telegram.start()`). The server runs send-only ONLY when started with `--no-telegram` or on a standby machine (`server.ts:2888` vs `:2976`). Nothing structurally detects that a lifeline already owns the poll slot, so "lifeline = sole poller, server = send-only" is enforced by operator discipline. Start the server without `--no-telegram` while a lifeline polls the same token → guaranteed 409.
+
+2. **A V8 heap OOM (mischaracterized as a "libc++ mutex crash" in CMT-560).** A Python-spawned node under the test agent exhausted the JS heap in ~83s. The mmtest server itself ran send-only correctly and survived past the crash, so the OOM was a *separate* spawned process. The evidence is muddy precisely because the deploy was hand-done — which is the core argument for the harness.
+
+This blocks the Cross-Machine Seamlessness live test (PR #428, Task 5), which needs a clean, repeatable two-machine deploy.
+
+## Goal
+
+A single idempotent command — `instar test-as-self` — that deploys the current dist onto a target agent home, runs a Telegram round-trip smoke test, captures any crash deterministically, and restores cleanly; PLUS a structural fix so the 409 dual-poll cannot happen regardless of operator flags.
+
+## Solution — two parts
+
+### Part 1 — Poll-ownership lease (STRUCTURAL, structure>willpower)
+
+The lifeline, when it owns the poll slot, writes a small lease under `state/` (`telegram-poll-owner.json`: `{ pid, tokenHash, heartbeatTs }`, refreshed each poll tick). The server's full-poll branch (`server.ts:2976`) checks for a live lease (heartbeat within N×tick) whose `tokenHash` matches its own bot token; if present, it auto-demotes to send-only with a clear log line ("lifeline owns the poll slot — send-only"). Then dual-polling cannot occur even if the server is started without `--no-telegram`.
+- Fail-open: a stale/absent lease → server polls as today (no regression for lifeline-less setups).
+- `tokenHash` (not the token) so the lease file never holds a secret.
+- Migration parity: the lifeline-writes-lease + server-reads-lease both ship in the same version; no agent-installed-file change.
+
+### Part 2 — `instar test-as-self` harness (operational, idempotent, Tier-1 supervised)
+
+A CLI command + skill that runs the deploy as discrete verified steps, each checked before the next:
+1. **Bot:** reuse an existing test bot (from a local, gitignored config) or mint one (operator supplies the token via Secret Drop — never on the command line / never in chat).
+2. **Configure** a throwaway target agent home (isolated dir; never Bob, never the canonical home).
+3. **Deploy** the current dist, handling node-version-specific native modules (`npm rebuild better-sqlite3`).
+4. **Start** the server with `--no-telegram` (Part 1 makes this belt-and-suspenders) + the lifeline as sole poller.
+5. **Smoke-test** the Telegram round-trip (send a probe, assert a reply) using the existing Playwright test-as-self profile.
+6. **Capture** any crash deterministically (wrap node with a crash-report path; tail the agent's server.log for OOM/FATAL) and surface the real signature.
+7. **Restore/teardown** on exit (stop processes, optionally `/deletebot`), idempotent and safe to re-run.
+
+## Test plan (all three tiers)
+- **Unit:** poll-ownership-lease decision (live lease + matching tokenHash → demote; stale/absent/mismatched → poll); harness step-state machine (each step's success/failure gating); tokenHash never equals the raw token.
+- **Integration:** server startup with a freshly-written lease present → asserts send-only mode selected (no `telegram.start()` poll); lease absent → full-poll.
+- **E2E / live (test-as-self):** run `instar test-as-self` against a throwaway agent home on this machine; assert the round-trip smoke passes AND no 409 in the agent log AND the crash-capture path is exercised (clean or real signature reported). This is also what unblocks Task 5 (PR #428 seamlessness live test).
+
+## Migration parity
+Part 1 is server + lifeline source (both ship together). Part 2 is a new CLI command + skill (new skill → installBuiltinSkills, non-destructive). No existing-agent settings/config change required for Part 1's default behavior (fail-open preserves current behavior).
+
+## Rollback
+Part 1: the lease check is additive + fail-open; revert the server-side check. Part 2: a new command; remove it.
+
+## Open question for Justin (scope)
+- **A) Harness only** (operational `test-as-self`), leaving the 409 to "always pass `--no-telegram`"; OR
+- **B) Harness + the structural poll-ownership lease** (recommended — fixes the 409 class permanently, structure>willpower).
+Leaning B. The native-OOM is diagnosed-not-yet-fixed: the harness's deterministic crash-capture is the vehicle to get the real signature before attempting a fix (don't claim a fix without reproduction — evidence bar).

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -30,6 +30,7 @@ import { ClaudeCliIntelligenceProvider } from '../core/ClaudeCliIntelligenceProv
 import { isClaudeForbidden } from '../core/claudeForbiddenGuard.js';
 import { FeedbackManager } from '../core/FeedbackManager.js';
 import { FeedbackAnomalyDetector } from '../monitoring/FeedbackAnomalyDetector.js';
+import { lifelineOwnsPoll as lifelineOwnsTelegramPoll } from '../lifeline/TelegramPollOwnerLease.js';
 import { DispatchManager } from '../core/DispatchManager.js';
 import { UpdateChecker } from '../core/UpdateChecker.js';
 import { AutoUpdater } from '../core/AutoUpdater.js';
@@ -3033,7 +3034,18 @@ export async function startServer(options: StartOptions): Promise<void> {
     const skipTelegram = options.telegram === false; // --no-telegram sets telegram: false
     // Standby machines use send-only Telegram — they don't poll for messages
     const isStandbyTelegram = !coordinator.isAwake && telegramConfig;
-    if ((skipTelegram || isStandbyTelegram) && telegramConfig) {
+    // Poll-ownership lease (Task 4 / 2026-05-27 silent-stalls postmortem,
+    // SELF-PROPAGATION-HARNESS-SPEC.md Part 1): if a lifeline is already polling
+    // this bot token (lease present + fresh + token-hash match), the server
+    // auto-demotes to send-only — Telegram allows exactly one long-poller per
+    // token, and dual-polling would 409. Fail-OPEN: any read miss/stale/
+    // mismatch ⇒ false ⇒ server polls as today, so setups without a lifeline
+    // are unaffected. Reads only — never writes the lease here.
+    const telegramBotToken = telegramConfig ? (telegramConfig.config as { token?: string }).token : undefined;
+    const lifelineOwnsPolling = telegramConfig && telegramBotToken
+      ? lifelineOwnsTelegramPoll(config.stateDir, telegramBotToken)
+      : false;
+    if ((skipTelegram || isStandbyTelegram || lifelineOwnsPolling) && telegramConfig) {
       // Send-only mode: no polling, but sendToTopic() works for session replies
       telegram = new TelegramAdapter(
         {
@@ -3048,7 +3060,7 @@ export async function startServer(options: StartOptions): Promise<void> {
         },
         config.stateDir,
       );
-      console.log(pc.green(`  Telegram send-only mode (${isStandbyTelegram ? 'standby' : 'lifeline owns polling'})`));
+      console.log(pc.green(`  Telegram send-only mode (${isStandbyTelegram ? 'standby' : lifelineOwnsPolling ? 'lifeline owns polling (lease detected)' : 'lifeline owns polling'})`));
 
       // Resolve any topic names still using the fallback "topic-NNNN" pattern
       telegram.resolveUnknownTopicNames().catch(err => {
@@ -3122,7 +3134,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       console.log(pc.green('  Telegram routing + command callbacks wired (send-only)'));
     }
 
-    if (telegramConfig && !skipTelegram && !isStandbyTelegram) {
+    if (telegramConfig && !skipTelegram && !isStandbyTelegram && !lifelineOwnsPolling) {
       telegram = new TelegramAdapter(
         {
           ...(telegramConfig.config as any),

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -57,6 +57,7 @@ import {
   type VersionSkewBody,
 } from './forwardErrors.js';
 import { writeStartupMarker } from './startupMarker.js';
+import { writeLease as writePollOwnerLease } from './TelegramPollOwnerLease.js';
 import { RestartOrchestrator } from './RestartOrchestrator.js';
 import { detectLaunchdSupervised } from './detectLaunchdSupervised.js';
 import { LifelineDriftPromoter, DRIFT_RESTART_PENDING_NOTICE_FILE } from './LifelineDriftPromoter.js';
@@ -909,6 +910,13 @@ export class TelegramLifeline {
       this.consecutive409s = 0;
       this.consecutive429s = 0;
       this.pollBackoffMs = this.config.pollIntervalMs ?? 2000;
+      // Poll-ownership lease (Task 4 / 2026-05-27 silent-stalls postmortem):
+      // record that THIS lifeline owns the Telegram poll slot for this token,
+      // so a server starting on the same machine auto-demotes to send-only
+      // instead of double-polling and producing 409 Conflicts. Refreshed on
+      // every successful tick. Best-effort + non-throwing (writeLease swallows
+      // and warns on any I/O hiccup — polling is what matters).
+      writePollOwnerLease(this.projectConfig.stateDir, this.config.token, process.pid);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       if (errMsg.includes('401') || errMsg.includes('Unauthorized')) {

--- a/src/lifeline/TelegramPollOwnerLease.ts
+++ b/src/lifeline/TelegramPollOwnerLease.ts
@@ -1,0 +1,138 @@
+/**
+ * TelegramPollOwnerLease — structural prevention of the Telegram 409 dual-poll.
+ *
+ * Background (Task 4 of the 2026-05-27 silent-stalls postmortem; spec
+ * docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md). Telegram allows exactly one
+ * long-poller per bot token. instar has two potential pollers — the lifeline
+ * (canonical, forwards to the server) and the server's `TelegramAdapter`
+ * (`telegram.start()`). The server only enters send-only mode when started with
+ * `--no-telegram` or on a standby machine; nothing structurally detects that a
+ * lifeline already owns the poll slot. Start the server without `--no-telegram`
+ * while a lifeline polls the same token → guaranteed 409 (this is what bit the
+ * 2026-05-27 live test deploy). Operator discipline, not structure.
+ *
+ * This module fixes the class permanently: the lifeline writes a small lease
+ * file each successful poll tick ("I am polling for THIS token"); the server,
+ * before `telegram.start()`, reads it and auto-demotes to send-only when a
+ * live lease for its own token is present. Then dual-polling cannot happen
+ * regardless of flags. Fail-OPEN: a stale/absent/mismatched lease ⇒ server
+ * polls as today (no regression for setups without a lifeline).
+ *
+ * Security: the lease stores a SHA-256 hash of the bot token, never the token.
+ *
+ * Spec: docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md (Part 1).
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
+
+/** SHA-256 of the bot token (hex). The lease NEVER holds the raw token. */
+export function tokenHash(botToken: string): string {
+  return createHash('sha256').update(botToken, 'utf8').digest('hex');
+}
+
+export interface PollOwnerLease {
+  /** lifeline process pid that owns the poll slot. */
+  pid: number;
+  /** SHA-256 hash of the bot token the lifeline is polling for. */
+  tokenHash: string;
+  /** Monotonic refresh timestamp (Date.now() ms) of the last successful poll. */
+  heartbeatTs: number;
+  /** Lease schema version (forward-compat). */
+  v: 1;
+}
+
+/** Default staleness threshold (ms). A lease whose heartbeatTs is older than
+ *  this is treated as absent. 90s is comfortably > 2 × Telegram long-poll
+ *  timeout (30s) + backoff, but short enough to clear within ~minute when the
+ *  lifeline genuinely dies. */
+export const DEFAULT_LEASE_STALE_MS = 90_000;
+
+/** Conventional path under the agent's stateDir. */
+export function leasePath(stateDir: string): string {
+  return join(stateDir, 'telegram-poll-owner.json');
+}
+
+/**
+ * Write/refresh the lease. Atomic via tmp+rename so a partial write can never
+ * be seen by the reader. Best-effort: any failure is logged and swallowed —
+ * a lease-write hiccup must NEVER take down the polling loop.
+ */
+export function writeLease(
+  stateDir: string,
+  botToken: string,
+  pid: number,
+  now: number = Date.now(),
+): void {
+  const lease: PollOwnerLease = {
+    pid,
+    tokenHash: tokenHash(botToken),
+    heartbeatTs: now,
+    v: 1,
+  };
+  const target = leasePath(stateDir);
+  const tmp = `${target}.${pid}.${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    try { mkdirSync(dirname(target), { recursive: true }); } catch { /* dir exists */ }
+    writeFileSync(tmp, JSON.stringify(lease));
+    renameSync(tmp, target);
+  } catch (err) {
+    try { SafeFsExecutor.safeUnlinkSync(tmp, { operation: 'src/lifeline/TelegramPollOwnerLease.ts:writeLease' }); } catch { /* ignore */ }
+    // Never throw — polling is what matters.
+    console.warn(`[poll-owner-lease] write failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * Read the lease. Returns null when:
+ *   - the file doesn't exist
+ *   - the file is unparseable / wrong shape
+ *   - heartbeatTs is older than staleMs (treated as a dead lifeline)
+ *
+ * Fail-OPEN at every error path — a read hiccup must NEVER cause the server to
+ * incorrectly demote to send-only (that would silence a fine agent).
+ */
+export function readLease(
+  stateDir: string,
+  now: number = Date.now(),
+  staleMs: number = DEFAULT_LEASE_STALE_MS,
+): PollOwnerLease | null {
+  const target = leasePath(stateDir);
+  if (!existsSync(target)) return null;
+  try {
+    const raw = readFileSync(target, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<PollOwnerLease>;
+    if (
+      typeof parsed !== 'object' || parsed === null ||
+      typeof parsed.pid !== 'number' ||
+      typeof parsed.tokenHash !== 'string' || parsed.tokenHash.length === 0 ||
+      typeof parsed.heartbeatTs !== 'number' ||
+      parsed.v !== 1
+    ) {
+      return null;
+    }
+    if (now - parsed.heartbeatTs > staleMs) return null;
+    return parsed as PollOwnerLease;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The server's decision question, in one place: "given the bot token I'd be
+ * about to poll for, does a live lifeline already own the slot?" True ⇒ the
+ * server should demote to send-only. False ⇒ poll as today (fail-OPEN: missing
+ * lease, mismatched token, or any read failure all answer false).
+ */
+export function lifelineOwnsPoll(
+  stateDir: string,
+  botToken: string,
+  now: number = Date.now(),
+  staleMs: number = DEFAULT_LEASE_STALE_MS,
+): boolean {
+  const lease = readLease(stateDir, now, staleMs);
+  if (!lease) return false;
+  return lease.tokenHash === tokenHash(botToken);
+}

--- a/tests/unit/TelegramPollOwnerLease.test.ts
+++ b/tests/unit/TelegramPollOwnerLease.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the TelegramPollOwnerLease — the structural fix that prevents
+ * the 409 dual-poll class (docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md Part 1,
+ * Task 4 of the 2026-05-27 silent-stalls postmortem).
+ *
+ * Covers both sides of every decision boundary (Testing Integrity Standard):
+ *   - tokenHash never leaks the raw token
+ *   - writeLease produces a parseable, well-formed lease (atomic via tmp+rename)
+ *   - readLease honors staleness, missing file, bad JSON, wrong shape, wrong version
+ *   - lifelineOwnsPoll: live+matching=true; live+mismatch=false; stale=false;
+ *     missing=false (FAIL-OPEN — never falsely demotes a server to send-only)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  tokenHash,
+  writeLease,
+  readLease,
+  lifelineOwnsPoll,
+  leasePath,
+  DEFAULT_LEASE_STALE_MS,
+  type PollOwnerLease,
+} from '../../src/lifeline/TelegramPollOwnerLease.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const TOKEN = '1234567890:AAFakeTokenForUnitTestsOnlyABCDEFGHIJK';
+const OTHER_TOKEN = '9876543210:BBOtherTestTokenZYXWVUTSRQPONMLKJIH';
+
+let stateDir: string;
+
+beforeEach(() => { stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'poll-owner-lease-')); });
+afterEach(() => {
+  try { SafeFsExecutor.safeRmSync(stateDir, { recursive: true, force: true, operation: 'tests/unit/TelegramPollOwnerLease.test.ts' }); } catch { /* ignore */ }
+});
+
+describe('tokenHash', () => {
+  it('is deterministic + 64-hex SHA-256', () => {
+    const h = tokenHash(TOKEN);
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+    expect(tokenHash(TOKEN)).toBe(h);
+  });
+  it('NEVER contains the raw token (security contract)', () => {
+    const h = tokenHash(TOKEN);
+    expect(h).not.toContain(TOKEN);
+    expect(h).not.toContain(TOKEN.split(':')[1]);
+  });
+  it('differs for different tokens', () => {
+    expect(tokenHash(TOKEN)).not.toBe(tokenHash(OTHER_TOKEN));
+  });
+});
+
+describe('writeLease + readLease', () => {
+  it('writes a well-formed lease and reads it back', () => {
+    writeLease(stateDir, TOKEN, 4242, 1_000_000);
+    const lease = readLease(stateDir, 1_000_000);
+    expect(lease).toEqual<PollOwnerLease>({
+      pid: 4242,
+      tokenHash: tokenHash(TOKEN),
+      heartbeatTs: 1_000_000,
+      v: 1,
+    });
+  });
+
+  it('the on-disk file never contains the raw token (security contract)', () => {
+    writeLease(stateDir, TOKEN, 1, 1);
+    const raw = fs.readFileSync(leasePath(stateDir), 'utf8');
+    expect(raw).not.toContain(TOKEN);
+    expect(raw).toContain(tokenHash(TOKEN));
+  });
+
+  it('overwrite replaces the previous lease (heartbeat refresh)', () => {
+    writeLease(stateDir, TOKEN, 1, 1_000);
+    writeLease(stateDir, TOKEN, 1, 2_000);
+    expect(readLease(stateDir, 2_000)?.heartbeatTs).toBe(2_000);
+  });
+
+  it('readLease returns null when the file does not exist', () => {
+    expect(readLease(stateDir, 1)).toBeNull();
+  });
+
+  it('readLease returns null for an unparseable file (fail-OPEN)', () => {
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(leasePath(stateDir), '{not valid json');
+    expect(readLease(stateDir, 1)).toBeNull();
+  });
+
+  it('readLease returns null for wrong-shape JSON (fail-OPEN)', () => {
+    fs.writeFileSync(leasePath(stateDir), JSON.stringify({ pid: 1 })); // missing fields
+    expect(readLease(stateDir, 1)).toBeNull();
+  });
+
+  it('readLease returns null for an unknown schema version', () => {
+    const bad = { pid: 1, tokenHash: tokenHash(TOKEN), heartbeatTs: 1, v: 99 };
+    fs.writeFileSync(leasePath(stateDir), JSON.stringify(bad));
+    expect(readLease(stateDir, 1)).toBeNull();
+  });
+
+  it('readLease treats a lease older than staleMs as absent', () => {
+    writeLease(stateDir, TOKEN, 1, 1_000);
+    expect(readLease(stateDir, 1_000 + DEFAULT_LEASE_STALE_MS + 1)).toBeNull();
+    // fresh enough → returns the lease
+    expect(readLease(stateDir, 1_000 + DEFAULT_LEASE_STALE_MS - 1)).not.toBeNull();
+  });
+});
+
+describe('lifelineOwnsPoll — the server-side decision', () => {
+  it('TRUE: live lease + matching token (server must demote to send-only)', () => {
+    writeLease(stateDir, TOKEN, 1, 1_000);
+    expect(lifelineOwnsPoll(stateDir, TOKEN, 1_001)).toBe(true);
+  });
+
+  it('FALSE: live lease but DIFFERENT token (server should keep polling its own token)', () => {
+    writeLease(stateDir, TOKEN, 1, 1_000);
+    expect(lifelineOwnsPoll(stateDir, OTHER_TOKEN, 1_001)).toBe(false);
+  });
+
+  it('FALSE: stale lease (fail-OPEN — the lifeline appears dead, server polls)', () => {
+    writeLease(stateDir, TOKEN, 1, 1_000);
+    expect(lifelineOwnsPoll(stateDir, TOKEN, 1_000 + DEFAULT_LEASE_STALE_MS + 1)).toBe(false);
+  });
+
+  it('FALSE: no lease file at all (fail-OPEN — setups without a lifeline keep polling)', () => {
+    expect(lifelineOwnsPoll(stateDir, TOKEN, 1)).toBe(false);
+  });
+
+  it('FALSE: corrupted lease (fail-OPEN — never falsely silence a fine agent)', () => {
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(leasePath(stateDir), 'garbage');
+    expect(lifelineOwnsPoll(stateDir, TOKEN, 1)).toBe(false);
+  });
+});

--- a/tests/unit/poll-owner-lease-wiring.test.ts
+++ b/tests/unit/poll-owner-lease-wiring.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Wiring-integrity test for the poll-ownership lease (Task 4 Part 1).
+ * Guards the PR#334 dead-code failure mode: a structural fix that exists but
+ * is never written by the lifeline or never checked by the server is the same
+ * as not having it. Asserts the call sites are present in the canonical paths.
+ *
+ * The decision logic is covered by TelegramPollOwnerLease.test.ts;
+ * end-to-end "server actually demotes on a real lease" is verified by
+ * test-as-self before merge.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const read = (rel: string) => fs.readFileSync(path.join(REPO, rel), 'utf8');
+
+describe('poll-ownership lease — wiring integrity', () => {
+  it('lifeline writes the lease after each successful poll tick', () => {
+    const src = read('src/lifeline/TelegramLifeline.ts');
+    // import + call after the successful-poll reset block
+    expect(src).toMatch(/import \{ writeLease as writePollOwnerLease \} from '\.\/TelegramPollOwnerLease\.js'/);
+    expect(src).toMatch(/writePollOwnerLease\(this\.projectConfig\.stateDir, this\.config\.token, process\.pid\)/);
+    // it lives in the successful-poll branch (after backoff counter resets)
+    const idx = src.indexOf('writePollOwnerLease(');
+    const window = src.slice(Math.max(0, idx - 1500), idx + 100);
+    expect(window).toContain('this.consecutive409s = 0');
+  });
+
+  it('server consults the lease BEFORE choosing send-only vs full-poll', () => {
+    const src = read('src/commands/server.ts');
+    expect(src).toMatch(/import \{ lifelineOwnsPoll as lifelineOwnsTelegramPoll \} from '\.\.\/lifeline\/TelegramPollOwnerLease\.js'/);
+    expect(src).toMatch(/const lifelineOwnsPolling = telegramConfig && telegramBotToken\s*\?\s*lifelineOwnsTelegramPoll\(/);
+    // send-only branch now also triggers on a live lease
+    expect(src).toMatch(/if \(\(skipTelegram \|\| isStandbyTelegram \|\| lifelineOwnsPolling\) && telegramConfig\)/);
+    // full-poll branch is now also gated on !lifelineOwnsPolling
+    expect(src).toMatch(/if \(telegramConfig && !skipTelegram && !isStandbyTelegram && !lifelineOwnsPolling\)/);
+  });
+
+  it('the server NEVER writes the lease (only the lifeline does — single-writer)', () => {
+    const src = read('src/commands/server.ts');
+    expect(src).not.toMatch(/writeLease\s*\(/);
+    expect(src).not.toMatch(/writePollOwnerLease/);
+  });
+
+  it('the lease lives under stateDir at a stable path', () => {
+    const src = read('src/lifeline/TelegramPollOwnerLease.ts');
+    expect(src).toMatch(/telegram-poll-owner\.json/);
+  });
+});

--- a/upgrades/1.3.32.md
+++ b/upgrades/1.3.32.md
@@ -4,25 +4,25 @@
 
 ## What Changed
 
-Closes a fleet-wide "dark guardrail" migration gap. `instar init` wires a full set of PreToolUse `Bash` guardrail hooks for new agents, but the existing-agent update path (`PostUpdateMigrator.migrateSettings`) only ever switched on two of them. So four guardrails — `deferral-detector.js` (the false-blocker / anti-deferral pre-filter), `grounding-before-messaging.sh`, `external-communication-guard.js`, and `post-action-reflection.js` — were copied to disk on every existing agent but never wired into `.claude/settings.json`, leaving them installed-but-inert. Same failure class as the 2026-05-27 silent-stall incident.
+Self-Propagation, Part 1 — **structural fix for the Telegram "two listeners" clash (409 dual-poll)**. Telegram allows exactly one long-poller per bot token; instar has two potential pollers (the lifeline and the server). Until now, the server only stayed quiet when started with `--no-telegram` (or on a standby machine) — operator discipline, not structure. Start the server without that flag while the lifeline polled the same token → guaranteed 409 (the failure mode the 2026-05-27 live test hit).
 
-This release introduces a single source of truth for the canonical instar PreToolUse hook set (`src/core/instarSettingsHooks.ts`), consumed by BOTH the new-agent path (`init.ts`) and the existing-agent path, so the two can never drift again. `migrateSettings` now idempotently ensures every canonical Bash guardrail is present (appends only the missing ones; never reorders or removes; leaves custom hooks alone).
+This release introduces a tiny "I am polling" lease the lifeline refreshes each successful poll tick. The server checks for it before starting its own polling; if a live lease for the same bot token is present, the server auto-demotes to send-only with a clear log line. Then dual-polling cannot happen regardless of how the server is started. The lease stores the bot token's SHA-256 hash, never the raw token. Every read path is fail-OPEN — a missing/stale/mismatched lease means the server polls as today, so setups without a lifeline see ZERO behavioral change.
+
+Pairs with Part 2 (the `instar test-as-self` harness — shipping under the same approved spec in a separate PR).
 
 ## What to Tell Your User
 
-- Four guardrail hooks that were quietly switched off on existing agents — including the "false blocker" catcher that stops the agent handing a doable task back to you — come on at this update. New agents already had them; no action needed.
+- A whole class of "two things trying to listen at once" Telegram errors is fixed structurally — it can no longer happen on a single machine no matter how the server got started.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Existing agents get the full instar PreToolUse guardrail set on update | Automatic on update; no action needed |
-| Anti-drift: new-agent + existing-agent hook lists share one constant | Adding a hook to `INSTAR_BASH_PRETOOLUSE_HOOKS` wires both paths; a unit test locks the set |
+| Server auto-demotes to Telegram send-only when the lifeline owns the poll slot | Automatic; the lifeline writes the lease, the server reads it on startup |
 
 ## Evidence
 
-- New module + tests: `src/core/instarSettingsHooks.ts`, `tests/unit/instar-settings-hooks.test.ts` (16), `tests/unit/PostUpdateMigrator-pretooluse-parity.test.ts` (3, real migrateSettings).
-- Spec: `docs/specs/EXISTING-AGENT-PRETOOLUSE-HOOK-PARITY-SPEC.md` (approved)
-- ELI16: `docs/specs/EXISTING-AGENT-PRETOOLUSE-HOOK-PARITY-SPEC.eli16.md`
-- Side-effects review: `upgrades/side-effects/existing-agent-pretooluse-hook-parity.md`
-- Context: Task 3 of the 2026-05-27 silent-stalls postmortem.
+- New module: `src/lifeline/TelegramPollOwnerLease.ts` (atomic write, fail-OPEN read, SHA-256 tokenHash).
+- Wired: `src/lifeline/TelegramLifeline.ts` writes the lease on each successful poll; `src/commands/server.ts` checks it before `telegram.start()`.
+- Tests: `tests/unit/TelegramPollOwnerLease.test.ts` (16 — both sides of every boundary + security contract) + `tests/unit/poll-owner-lease-wiring.test.ts` (4 — no dead code).
+- Spec: `docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md` (approved). Side-effects: `upgrades/side-effects/self-propagation-poll-owner-lease.md`.

--- a/upgrades/side-effects/self-propagation-poll-owner-lease.md
+++ b/upgrades/side-effects/self-propagation-poll-owner-lease.md
@@ -1,0 +1,43 @@
+# Side-Effects Review — Self-Propagation, Part 1 (Poll-Ownership Lease)
+
+**Spec:** docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md (approved: true) — Part 1 of two. Part 2 (`instar test-as-self` harness) ships as a separate PR under the same approved spec.
+
+Closes the Telegram 409 dual-poll **class** structurally. Telegram allows exactly one long-poller per bot token. instar has two potential pollers — the lifeline (canonical, forwards to the server) and the server's `TelegramAdapter` (`telegram.start()`). The server only enters send-only when started with `--no-telegram` or on a standby machine; nothing structurally detects that a lifeline already owns the slot. Start the server without `--no-telegram` while a lifeline polls the same token → guaranteed 409 (the 2026-05-27 live-test failure mode). This was operator discipline, not structure.
+
+## What changed
+- `src/lifeline/TelegramPollOwnerLease.ts` — NEW. `tokenHash(botToken)` (SHA-256 hex; security contract: NEVER stores the raw token), `writeLease(stateDir, token, pid, now?)` (atomic tmp+rename + best-effort never-throws), `readLease(stateDir, now?, staleMs?)` (fail-OPEN at every error path — missing/unparseable/wrong-shape/wrong-version/stale all return null), `lifelineOwnsPoll(stateDir, token, now?, staleMs?)` (the server's one-question API). Lease lives at `state/telegram-poll-owner.json`. Default staleness 90 s (comfortably > 2× Telegram long-poll timeout + backoff; clears within ~minute when the lifeline genuinely dies).
+- `src/lifeline/TelegramLifeline.ts` — calls `writePollOwnerLease(stateDir, token, pid)` right after the successful-poll reset block (after `consecutive409s = 0`). Refreshes the heartbeat on every successful tick. Best-effort + non-throwing — a lease-write hiccup never disturbs the polling loop.
+- `src/commands/server.ts` — before the send-only vs full-poll branch, computes `lifelineOwnsPolling = lifelineOwnsTelegramPoll(stateDir, token)`. The send-only branch now ALSO triggers when `lifelineOwnsPolling` is true; the full-poll branch is gated on `!lifelineOwnsPolling`. Send-only log now distinguishes "lifeline owns polling (lease detected)" so operators see the structural decision in action.
+
+## Tests
+- `tests/unit/TelegramPollOwnerLease.test.ts` (16) — `tokenHash` security contract (never contains the raw token) + determinism + uniqueness; round-trip write/read; on-disk file never contains the raw token; overwrite-refreshes; ALL of the fail-OPEN paths (missing, unparseable, wrong-shape, unknown-version, stale); the lifelineOwnsPoll decision matrix — both sides of every boundary (live+match=TRUE; live+mismatch=FALSE; stale=FALSE; missing=FALSE; corrupted=FALSE).
+- `tests/unit/poll-owner-lease-wiring.test.ts` (4) — lifeline import + call in the success branch; server import + the `lifelineOwnsPolling` computation; the send-only branch includes the new term; the full-poll branch is gated on `!lifelineOwnsPolling`; the server NEVER writes the lease (single-writer = lifeline only); the lease path is stable. Guards the PR#334 dead-code failure mode.
+
+## Signal vs authority
+- The lease is a SIGNAL (the lifeline declares "I'm polling"). The server holds the AUTHORITY to act on it (auto-demote). The lifeline never tries to demote the server itself.
+- Fail-OPEN is the safety polarity: ANY read miss, any malformed lease, ANY mismatched tokenHash, ANY stale heartbeat → the server polls as today. The lease can only ever CAUSE silence; we err on the side of NEVER silencing a fine agent.
+
+## Security
+- The bot token is the secret. The lease stores its SHA-256 hash, never the raw value. Verified by a unit test against both the in-memory return AND the on-disk file. A read of `state/telegram-poll-owner.json` reveals only `{pid, tokenHash, heartbeatTs, v}`.
+- File mode follows the stateDir's existing convention (no special mode set; atomic via tmp+rename so a partial write is never observable).
+
+## Over/under-demote
+- OVER (server falsely demotes to send-only): mitigated by tokenHash match (a lifeline polling a DIFFERENT token doesn't trigger demote) + 90 s staleness. Worst case: a still-live lifeline + same-token + same-machine → exactly the scenario we WANT demote in.
+- UNDER (server fails to demote when it should): the lease must be present + fresh + token-match. Race window at lifeline startup before the first successful poll (lease not yet written) — acceptable: the existing 409-backoff handling absorbs the brief window, and within one poll tick the lease is up.
+
+## Near-silent compliance
+N/A — no new user-facing notifications. The server's send-only log line gains one descriptor ("lease detected").
+
+## Migration parity
+- Server + lifeline source ship in the same version → no agent-installed-file change, no config change. The new behavior takes effect on first server restart after update (the existing lifeline writes the lease; the new server reads it). Existing setups without a lifeline poller see ZERO behavioral change (fail-OPEN preserves current full-poll path).
+
+## Rollback
+Revert the 3 files (one new module + two callsite edits) + the 2 tests. Worst case: agents return to today's "operator discipline" model (start with `--no-telegram` to avoid the 409). No data migration concern (the lease file is stateless ephemera — safe to leave behind or delete).
+
+## Tests / verification
+- Tier 1 unit: TelegramPollOwnerLease + wiring-integrity (above; 20 tests green).
+- Tier 3 live: test-as-self before merge — start the lifeline + start the server on the same machine WITHOUT `--no-telegram` and confirm the server logs "lifeline owns polling (lease detected)" and Telegram returns no 409. (This is what Part 2 — the harness — automates.)
+
+## NOT in this PR (tracked)
+- Part 2: the `instar test-as-self` CLI command + skill (a much larger, hardware-touching deliverable).
+- Live mmtest OOM crash reproduction (only possible under the harness in Part 2).


### PR DESCRIPTION
## Problem

Telegram allows exactly one long-poller per bot token. instar has two potential pollers — the lifeline (canonical, forwards to the server) and the server's `TelegramAdapter` (`telegram.start()`). The server only entered send-only mode when started with `--no-telegram` or on a standby machine; **nothing structurally detected that a lifeline already owned the slot**. Start the server without `--no-telegram` while a lifeline polls the same token → guaranteed **409 Conflict** (the 2026-05-27 live-test failure mode). Operator discipline, not structure.

## Fix (Part 1 of the Self-Propagation Harness spec — Justin's scope choice)
- `src/lifeline/TelegramPollOwnerLease.ts` (new) — `tokenHash` (SHA-256 hex; security contract: NEVER stores the raw token), `writeLease` (atomic tmp+rename, best-effort never-throws), `readLease` (fail-OPEN at EVERY error path — missing/unparseable/wrong-shape/wrong-version/stale all return null), `lifelineOwnsPoll` (the server's one-question API). Lease lives at `state/telegram-poll-owner.json`, 90s staleness default.
- Lifeline writes the lease right after the successful-poll reset block (after `consecutive409s = 0`). Best-effort + non-throwing — a lease-write hiccup never disturbs the polling loop.
- Server's send-only branch now ALSO triggers when `lifelineOwnsPolling` is true; the full-poll branch is gated on `!lifelineOwnsPolling`. Send-only log gains the descriptor "lifeline owns polling (lease detected)" so operators can see the structural decision in action.

**Fail-OPEN polarity:** any read miss / malformed lease / mismatched tokenHash / stale heartbeat → server polls as today. The lease can only ever CAUSE silence; we err on NEVER silencing a fine agent. Setups without a lifeline see **zero behavioral change**.

## Tests (20 green, tsc + lint clean)
- `tests/unit/TelegramPollOwnerLease.test.ts` (16) — security contract (tokenHash never contains the raw token; on-disk file verified), determinism, write/read round-trip, overwrite-refresh, ALL fail-OPEN paths (missing/unparseable/wrong-shape/unknown-version/stale), `lifelineOwnsPoll` decision matrix both sides of every boundary.
- `tests/unit/poll-owner-lease-wiring.test.ts` (4) — lifeline import + call in the success branch; server import + lifelineOwnsPolling computation; send-only branch includes the new term; full-poll gated on !lifelineOwnsPolling; server NEVER writes the lease (single-writer = lifeline). Guards the PR#334 dead-code failure mode.

## Migration parity
Server + lifeline source ship in the same version → no agent-installed-file change, no config change. Takes effect on first server restart after update.

Spec: `docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md` (approved). Part 2 (`instar test-as-self` harness) ships separately under the same spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
