### PR TITLE
fix(publish): tighten auto-draft-unreviewed gate predicate (meta-bug from release-readiness-visibility ship)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,11 +50,16 @@ jobs:
           elif grep -q '\[Feature name\]' upgrades/NEXT.md && grep -q '\[Capability\]' upgrades/NEXT.md; then
             echo "NEXT.md is still a template — nothing to publish"
             echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif grep -q 'auto-draft-unreviewed' upgrades/NEXT.md; then
+          elif grep -qE '<!--[[:space:]]*auto-draft-unreviewed' upgrades/NEXT.md; then
             # Layer A auto-drafted this guide but a human hasn't reviewed it yet
             # (release-readiness-visibility spec §4.1.1). Skipping keeps the
             # silent-skip semantics correct for the unreviewed case; the
             # release-readiness sentinel surfaces the blocked release as a signal.
+            #
+            # Match the comment SHAPE (`<!-- auto-draft-unreviewed...`), not the
+            # bare substring — a NEXT.md that describes the marker in prose
+            # (e.g. "this section carries an auto-draft-unreviewed marker")
+            # is a human-authored doc and must not trip the gate.
             echo "NEXT.md still has auto-draft-unreviewed markers — awaiting human review, not publishing"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

The Release-Readiness Visibility gate I shipped in PR #442 has an over-loose predicate in the publish workflow: `grep -q 'auto-draft-unreviewed' upgrades/NEXT.md` matches the bare substring anywhere, including human-authored prose that legitimately mentions the marker by name. That's exactly what happened to the v1.4.0 publish for PR #447 (release notes for the spec itself, which describes the marker mechanism in plain English).

Tightened to `grep -qE '<!--[[:space:]]*auto-draft-unreviewed'` — matches the comment SHAPE, not the substring. Plain prose no longer trips; real markers and block markers still do.

## Test plan

- [x] Prose mention ("the auto-draft-unreviewed marker") → no match
- [x] `<!-- auto-draft-unreviewed: x -->` → matches
- [x] `<!-- auto-draft-unreviewed-block -->` → matches

Once this lands, the v1.4.0 publish that's currently sitting blocked will go through on the next push to main (re-running PR #447's publish workflow, or by piggybacking on this PR's own merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)