### PR TITLE
fix(SourceTreeGuard): opt-in data-pull (fetch) on instar source trees — closes the Release-Readiness dogfood gap

### DIFF
--- a/src/core/SafeGitExecutor.ts
+++ b/src/core/SafeGitExecutor.ts
@@ -130,6 +130,21 @@ export const READONLY_GIT_VERBS: ReadonlySet<string> = new Set([
   'stash', // shape-check: `stash list` / `stash show` allowed
 ]);
 
+/**
+ * Verbs that are "data-pull": they touch the object database and FETCH_HEAD
+ * but DO NOT modify the working tree, committed refs (heads/tags/remotes),
+ * or any source file. From SourceTreeGuard's "protect the instar source"
+ * standpoint they are read-tier. Permitted on the instar source tree ONLY
+ * when the caller opts in via `SafeGitOptions.sourceTreeReadOk: true`.
+ *
+ * Currently: `fetch` only. (`ls-remote` is pure-read and already in
+ * READONLY_GIT_VERBS — it goes through readSync which never trips the
+ * source-tree guard.)
+ */
+export const SOURCE_TREE_READ_TIER_VERBS: ReadonlySet<string> = new Set([
+  'fetch',
+]);
+
 // ── Env denylist ────────────────────────────────────────────────────
 
 const GIT_ENV_DENYLIST: ReadonlySet<string> = new Set([
@@ -583,6 +598,24 @@ export interface SafeGitOptions {
   input?: string | Buffer;
   /** Maximum buffer for stdout/stderr (execFileSync). */
   maxBuffer?: number;
+  /**
+   * Opt-in: allow execSync/spawn against the instar source tree for a small
+   * allowlist of data-pull verbs that do not mutate committed refs or the
+   * working tree (currently `fetch` and `ls-remote`). Defaults false.
+   *
+   * Why this exists: SourceTreeGuard refuses non-readonly git ops on the
+   * instar source tree (the 2026-04-22 incident-class). But the release-
+   * readiness watchdog (LAYER B of RELEASE-READINESS-VISIBILITY-SPEC) and
+   * its sibling FeatureRolloutReconciler canonical scan (LAYER C) NEED to
+   * pull the canonical `main` ref into the agent's own instar checkout —
+   * by-definition a source tree — to do their job. `git fetch <remote>
+   * <branch> --no-tags --no-recurse-submodules` writes only to FETCH_HEAD
+   * (transient) and the object database; it does not modify the working
+   * tree or any committed refs, so from the source-protection standpoint
+   * it is read-tier. `ls-remote` is pure read. This flag is the narrow,
+   * audited escape hatch the spec referenced.
+   */
+  sourceTreeReadOk?: boolean;
 }
 
 // ── Errors ─────────────────────────────────────────────────────────
@@ -614,8 +647,15 @@ export class SafeGitExecutor {
   static execSync(args: readonly string[], opts: SafeGitOptions): string {
     const { verb, targets } = extractVerbAndTargets(args, opts.cwd);
 
-    // Run source-tree assertion against every target.
-    runSourceTreeChecks(targets, opts.operation, 'git', verb);
+    // Run source-tree assertion against every target — unless the caller
+    // explicitly opted into the narrow data-pull allowlist (fetch / etc.)
+    // for the documented LAYER B + LAYER C canonical-ref read path. See
+    // SafeGitOptions.sourceTreeReadOk for the rationale.
+    if (!(opts.sourceTreeReadOk && SOURCE_TREE_READ_TIER_VERBS.has(verb))) {
+      runSourceTreeChecks(targets, opts.operation, 'git', verb);
+    } else {
+      audit('git', opts.operation, verb, targets[0], 'allowed', 'sourceTreeReadOk-bypass');
+    }
 
     // Verb classification.
     const verbArgs = sliceAfterVerb(args, verb);
@@ -662,7 +702,11 @@ export class SafeGitExecutor {
    */
   static spawn(args: readonly string[], opts: SafeGitOptions): ChildProcess {
     const { verb, targets } = extractVerbAndTargets(args, opts.cwd);
-    runSourceTreeChecks(targets, opts.operation, 'git', verb);
+    if (!(opts.sourceTreeReadOk && SOURCE_TREE_READ_TIER_VERBS.has(verb))) {
+      runSourceTreeChecks(targets, opts.operation, 'git', verb);
+    } else {
+      audit('git', opts.operation, verb, targets[0], 'allowed', 'sourceTreeReadOk-bypass');
+    }
 
     const verbArgs = sliceAfterVerb(args, verb);
     const ambiguousReadOnly = isReadOnlyShape(verb, verbArgs);

--- a/src/core/featureRolloutScan.ts
+++ b/src/core/featureRolloutScan.ts
@@ -139,7 +139,15 @@ export function scanSpecArtifactsCanonical(opts: CanonicalScanOpts): CanonicalSc
   //    shallows the local repo and breaks downstream git log).
   SafeGitExecutor.run(
     ['fetch', opts.canonicalRemote, 'main', '--no-tags', '--no-recurse-submodules'],
-    { cwd: opts.repoPath, operation: 'featureRolloutScan:canonicalFetch', timeout },
+    {
+      cwd: opts.repoPath,
+      operation: 'featureRolloutScan:canonicalFetch',
+      timeout,
+      // LAYER C explicitly scans the instar source tree (a present-but-on-
+      // wrong-branch spec is the bug being fixed). fetch is data-pull
+      // (FETCH_HEAD + objects only). See SafeGitOptions.sourceTreeReadOk.
+      sourceTreeReadOk: true,
+    },
   );
   const canonicalHeadSha = SafeGitExecutor.run(['rev-parse', 'FETCH_HEAD'], {
     cwd: opts.repoPath,

--- a/src/monitoring/releaseReadinessWiring.ts
+++ b/src/monitoring/releaseReadinessWiring.ts
@@ -133,7 +133,17 @@ export function buildReleaseReadinessDeps(opts: ReleaseReadinessWiringOpts): Rel
           // checkout transfer only new objects.
           SafeGitExecutor.run(
             ['fetch', remote, 'main', '--no-tags', '--no-recurse-submodules'],
-            { cwd: opts.repoPath, operation: 'releaseReadinessWiring:fetch', timeout: fetchTimeoutMs },
+            {
+              cwd: opts.repoPath,
+              operation: 'releaseReadinessWiring:fetch',
+              timeout: fetchTimeoutMs,
+              // The watchdog by-design runs against the instar source tree
+              // (the maintainer environment IS an instar checkout). fetch
+              // only touches FETCH_HEAD + objects — read-tier for source
+              // protection. Opt into the narrow allowlist documented on
+              // SafeGitOptions.sourceTreeReadOk.
+              sourceTreeReadOk: true,
+            },
           );
           const headSha = SafeGitExecutor.run(['rev-parse', 'FETCH_HEAD'], {
             cwd: opts.repoPath,

--- a/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
+++ b/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests — SafeGitExecutor `sourceTreeReadOk` opt + SOURCE_TREE_READ_TIER_VERBS.
+ *
+ * Layer B (ReleaseReadinessSentinel) and Layer C (FeatureRolloutReconciler
+ * canonical scan) need to `git fetch` the canonical ref into the agent's own
+ * instar checkout to do their job — and the agent home IS a source tree, so
+ * SourceTreeGuard blocks fetch by default. This opt is the narrow, audited
+ * escape hatch: data-pull verbs only (`fetch`), opt-in per call.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  SafeGitExecutor,
+  SOURCE_TREE_READ_TIER_VERBS,
+  DESTRUCTIVE_GIT_VERBS,
+} from '../../src/core/SafeGitExecutor.js';
+import { SourceTreeGuardError } from '../../src/core/SourceTreeGuard.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('SafeGitExecutor.sourceTreeReadOk', () => {
+  let srcTree: string;
+  let canon: string;
+  let nonSrc: string;
+
+  function git(cwd: string, args: string[]) {
+    return SafeGitExecutor.run(args, { cwd, operation: 'tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts:git' });
+  }
+
+  beforeEach(() => {
+    srcTree = fs.mkdtempSync(path.join(os.tmpdir(), 'sgx-src-'));
+    git(srcTree, ['init', '-q', '-b', 'main']);
+    git(srcTree, ['config', 'user.email', 't@t.l']);
+    git(srcTree, ['config', 'user.name', 'T']);
+    git(srcTree, ['config', 'commit.gpgsign', 'false']);
+    fs.writeFileSync(path.join(srcTree, 'README.md'), '#');
+    git(srcTree, ['add', '-A']);
+    git(srcTree, ['commit', '-qm', 'init']);
+
+    canon = fs.mkdtempSync(path.join(os.tmpdir(), 'sgx-canon-'));
+    git(canon, ['init', '-q', '--bare']);
+    git(srcTree, ['remote', 'add', 'canon', `file://${canon}`]);
+    git(srcTree, ['push', '-q', 'canon', 'main']);
+
+    nonSrc = fs.mkdtempSync(path.join(os.tmpdir(), 'sgx-other-'));
+    git(nonSrc, ['init', '-q', '-b', 'main']);
+    git(nonSrc, ['config', 'user.email', 't@t.l']);
+    git(nonSrc, ['config', 'user.name', 'T']);
+    git(nonSrc, ['config', 'commit.gpgsign', 'false']);
+    fs.writeFileSync(path.join(nonSrc, 'README.md'), '#');
+    git(nonSrc, ['add', '-A']);
+    git(nonSrc, ['commit', '-qm', 'init']);
+    git(nonSrc, ['remote', 'add', 'origin', `file://${canon}`]);
+
+    // NOW promote srcTree to "instar source tree" by making its `origin`
+    // remote point at a canonical instar URL — that's what
+    // SourceTreeGuard.layerRemoteUrl reads. Done last so the git init +
+    // commits above didn't themselves trip the guard. `canon` remains as
+    // a separate remote that the fetch-in-test actually uses.
+    git(srcTree, ['remote', 'add', 'origin', 'https://github.com/dawn/instar.git']);
+  });
+
+  afterEach(() => {
+    // Demote srcTree back to non-source-tree before SafeFsExecutor.safeRmSync
+    // (which also refuses to delete a recognized instar source tree). Strip
+    // the canonical-instar origin remote by overwriting .git/config with a
+    // minimal config (writeFile is not a destructive-lint verb).
+    try {
+      const cfgPath = path.join(srcTree, '.git', 'config');
+      const cfg = fs.readFileSync(cfgPath, 'utf-8').replace(/\[remote "origin"\][\s\S]*?(?=\n\[|$)/g, '');
+      fs.writeFileSync(cfgPath, cfg);
+    } catch { /* tolerate partial setup */ }
+    for (const d of [srcTree, canon, nonSrc]) {
+      SafeFsExecutor.safeRmSync(d, { recursive: true, force: true, operation: 'tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts:afterEach' });
+    }
+  });
+
+  it('defaults: fetch on a non-source tree works (no guard fires)', () => {
+    expect(() => SafeGitExecutor.run(
+      ['fetch', 'origin', 'main', '--no-tags', '--no-recurse-submodules'],
+      { cwd: nonSrc, operation: 't:fetch-non-src' },
+    )).not.toThrow();
+  });
+
+  it('defaults: fetch on a source tree IS BLOCKED by SourceTreeGuard', () => {
+    expect(() => SafeGitExecutor.run(
+      ['fetch', 'canon', 'main', '--no-tags', '--no-recurse-submodules'],
+      { cwd: srcTree, operation: 't:fetch-src' },
+    )).toThrow(SourceTreeGuardError);
+  });
+
+  it('sourceTreeReadOk + allowlist verb (fetch) → passes on a source tree', () => {
+    expect(() => SafeGitExecutor.run(
+      ['fetch', 'canon', 'main', '--no-tags', '--no-recurse-submodules'],
+      { cwd: srcTree, operation: 't:fetch-allowed', sourceTreeReadOk: true },
+    )).not.toThrow();
+  });
+
+  it('sourceTreeReadOk does NOT bypass for non-allowlist verbs (e.g. commit)', () => {
+    fs.writeFileSync(path.join(srcTree, 'new.txt'), 'x');
+    expect(() => SafeGitExecutor.run(
+      ['add', 'new.txt'],
+      { cwd: srcTree, operation: 't:add-not-allowlisted', sourceTreeReadOk: true },
+    )).toThrow(SourceTreeGuardError);
+  });
+
+  it('SOURCE_TREE_READ_TIER_VERBS is a closed, narrow set (fetch only initially)', () => {
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('fetch')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('commit')).toBe(false);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('push')).toBe(false);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('reset')).toBe(false);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('checkout')).toBe(false);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('rebase')).toBe(false);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('merge')).toBe(false);
+    // Sanity: the set must stay tiny. Two classifications are independent —
+    // fetch IS destructive for execSync routing AND source-tree-read-tier
+    // for guard purposes; that's by design.
+    expect(SOURCE_TREE_READ_TIER_VERBS.size).toBeLessThanOrEqual(3);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,26 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+<!-- Valid values: patch, minor, major -->
+
+## What Changed
+
+`SourceTreeGuard` gained a narrow, opt-in escape hatch for data-pull git operations on the instar source tree. The Release-Readiness Visibility watchdog (Layer B) and the FeatureRolloutReconciler canonical-ref scan (Layer C) both need to `git fetch` canonical `main` into the agent's own instar checkout to do their job — and the agent home IS by-definition an instar source tree. The guard's existing policy ("refuse non-readonly git ops on the source tree" — the 2026-04-22 incident class) caught the watchdog's first real tick on Echo: it correctly fail-louded with `release-readiness-eval-failure-fetch` and Layer C gracefully fell back to the local scan + emitted a degradation event. The architecture surfaced its own integration gap on day one of dogfooding — the principle of "speak up when you skip" worked exactly as designed.
+
+This PR closes the gap principledly: `SafeGitOptions.sourceTreeReadOk?: boolean` (default false) + a closed allowlist `SOURCE_TREE_READ_TIER_VERBS = ['fetch']` lets a specific caller opt into bypassing `SourceTreeGuard` for read-tier git ops. `git fetch <remote> <branch> --no-tags --no-recurse-submodules` writes only to `FETCH_HEAD` and the object database; it does NOT modify the working tree or any committed ref, so from the source-protection standpoint it is read-tier. The bypass is per-call, audit-logged, and the allowlist is small + closed.
+
+Both Layer B (`releaseReadinessWiring.fetchCanonical`) and Layer C (`featureRolloutScan.scanSpecArtifactsCanonical`) opt in at the callsite, so when the watchdog runs against the agent's own instar checkout the canonical-ref fetch goes through.
+
+## What to Tell Your User
+
+- **I can actually watch myself now**: the release watchdog I shipped a moment ago hit its first real safety guard the second I turned it on — and instead of going quiet, it raised a calm flag and explained exactly what was wrong. That self-catch was the architecture working as designed. This update closes the loop so it can fetch the canonical copy it needs without bypassing the broader safety policy.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Opt-in data-pull git on the instar source tree | Pass `sourceTreeReadOk: true` to `SafeGitExecutor.run`/`execSync`/`spawn` (verbs limited to `fetch`) |
+
+## Evidence
+
+Caught live on Echo during the dogfood handoff: with `monitoring.releaseReadiness.enabled: true`, the first tick failed at `fetch` with `SourceTreeGuardError: Refusing to run releaseReadinessWiring:fetch against the instar source tree`. The watchdog correctly raised exactly one LOW-priority Attention item (`release-readiness-eval-failure-fetch`, deduped across re-ticks) and recorded each failure in `logs/sentinel-events.jsonl`. Layer C correctly logged `feature-rollout canonical scan degraded: canonical-ref scan failed (SourceTreeGuardError) — falling back to local scan`. After this PR lands + republishes, the same tick on the same setup proceeds through fetch successfully and produces real backlog signal (or silence below the age threshold). Unit tests (5 in `tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts`) cover the truth table: default-blocks on source, opt-passes on source, non-allowlist-still-blocks on source, allowlist-set is closed.

--- a/upgrades/side-effects/source-tree-guard-data-pull.md
+++ b/upgrades/side-effects/source-tree-guard-data-pull.md
@@ -1,0 +1,35 @@
+# Side-Effects Review — SourceTreeGuard data-pull exemption for `git fetch`
+
+**Driver:** RELEASE-READINESS-VISIBILITY-SPEC §4.2.2 + §4.3.2 (Layer B + Layer C canonical-ref reads). Discovered during dogfood on Echo (the instar source IS the agent home — exactly the maintainer environment the spec targets).
+
+## What changed
+
+- **`src/core/SafeGitExecutor.ts`** —
+  - New `SafeGitOptions.sourceTreeReadOk?: boolean` (default false).
+  - New exported `SOURCE_TREE_READ_TIER_VERBS: Set<string>` — currently `['fetch']` only. Closed enumeration.
+  - `execSync` + `spawn` skip `runSourceTreeChecks` when `sourceTreeReadOk: true` AND the verb is in `SOURCE_TREE_READ_TIER_VERBS`. The bypass is audit-logged (`sourceTreeReadOk-bypass` reason).
+- **`src/monitoring/releaseReadinessWiring.ts`** — Layer B's `fetchCanonical` passes `sourceTreeReadOk: true`.
+- **`src/core/featureRolloutScan.ts`** — Layer C's `scanSpecArtifactsCanonical` passes `sourceTreeReadOk: true` for its bounded fetch.
+
+## Side-effects analysis
+
+**The dogfood that prompted this.** With Layers B + C live and Echo's `monitoring.releaseReadiness.enabled: true`, the very first real tick on Echo hit `SourceTreeGuardError` on the watchdog's `git fetch <canonical-remote> main`. The watchdog correctly fail-louded (one LOW-priority Attention item `release-readiness-eval-failure-fetch`, deduped across ticks, full audit in `sentinel-events.jsonl`). Layer C correctly degraded + fell back to the local scan with a degradation log. So the architecture caught its own integration gap. This PR closes the gap principledly.
+
+**Why this is safe.** SourceTreeGuard's mandate is "refuse destructive ops against the instar source tree" — the 2026-04-22 incident class. `git fetch <remote> <branch> --no-tags --no-recurse-submodules` writes only to `FETCH_HEAD` (transient ref) and the object database. It does NOT modify: the working tree, any committed ref (heads/tags/remotes), any source file. From the source-protection standpoint it is read-tier. `ls-remote` is pure read and already in `READONLY_GIT_VERBS` (so it goes through `readSync`, which doesn't run source-tree checks at all).
+
+**Why opt-in.** The bypass is opt-in per-call, not a global relaxation. Every callsite that uses it is reviewable and audit-logged. The allowlist is a small closed set (`fetch` only) — adding to it requires a spec edit + this same review pattern.
+
+**Reach.** Two callsites touched, both in the canonical-ref read path the spec defines (Layer B `fetchCanonical`, Layer C `scanSpecArtifactsCanonical`). Every existing callsite that does NOT pass `sourceTreeReadOk: true` is byte-identically guarded by the prior behavior.
+
+**Rollback.** Reverting this PR re-blocks the canonical-ref fetch on source trees. Layer B's fail-loud path keeps signaling on the failure; Layer C's local-scan fallback keeps working. The watchdog and the reconciler degrade gracefully back to their prior behavior — no broken state.
+
+## Testing
+
+- `tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts` (5 tests):
+  - Default: `fetch` on a non-source tree works (baseline).
+  - Default: `fetch` on a source tree is BLOCKED by `SourceTreeGuard`.
+  - `sourceTreeReadOk: true` + `fetch` on a source tree passes.
+  - `sourceTreeReadOk: true` does NOT bypass for non-allowlist verbs (e.g. `add`).
+  - `SOURCE_TREE_READ_TIER_VERBS` is a small closed set (`fetch` only, ≤3 entries).
+
+All green; lint clean.


### PR DESCRIPTION
## Summary

Caught live on Echo during the dogfood of the Release-Readiness Visibility spec: the watchdog NEEDS to `git fetch` canonical `main` into its own instar checkout to do its job, but the agent home IS by-definition an instar source tree. `SourceTreeGuard` (the 2026-04-22 incident-class guard) refuses any non-readonly git op on the source tree. So the watchdog correctly **fail-louded** (one LOW-priority `release-readiness-eval-failure-fetch` Attention item, deduped, with the full failure recorded in `sentinel-events.jsonl`), and Layer C correctly **degraded** + fell back to local scan. The architecture caught its own integration gap on day one — exactly the principle the spec exists to enforce.

This PR closes the gap principledly. `git fetch <remote> <branch> --no-tags --no-recurse-submodules` writes only to `FETCH_HEAD` and the object database; it does NOT modify the working tree or any committed ref. From SourceTreeGuard's "protect the source" mandate it is read-tier.

- `SafeGitOptions.sourceTreeReadOk?: boolean` (default false).
- Closed `SOURCE_TREE_READ_TIER_VERBS` set — currently `['fetch']` only.
- `execSync` + `spawn` skip the source-tree check ONLY when both are true; bypass audit-logged.
- Layer B (`releaseReadinessWiring.fetchCanonical`) + Layer C (`featureRolloutScan.scanSpecArtifactsCanonical`) opt in at the callsite.

## Test plan

- [x] 5 unit tests cover the truth table (`tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts`):
  - default: fetch on a non-source tree works
  - default: fetch on a source tree is blocked
  - `sourceTreeReadOk: true` + fetch on a source tree → passes
  - `sourceTreeReadOk: true` does NOT bypass for non-allowlist verbs
  - `SOURCE_TREE_READ_TIER_VERBS` is a closed narrow set
- [x] Lint clean (tsc + lint-no-direct-destructive + lint-no-direct-llm-http + codex-rule1-drift)
- [x] Side-effects review: `upgrades/side-effects/source-tree-guard-data-pull.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)