### PR TITLE
feat(messaging): a2a comms — recipient hook + TelegramAdapter wiring (PR 3b)

### DIFF
--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -176,6 +176,30 @@ interface LogEntry {
   telegramUserId?: number;
 }
 
+/**
+ * Pre-dispatch hook for the agent-to-agent Telegram comms primitive. Adapter calls this
+ * BEFORE normal onTopicMessage / this.handler dispatch on text messages. Returns
+ * {handled:true} → dispatch is skipped (hook routed or dropped the a2a event);
+ * {handled:false} → fall through to normal user flow. Spec: MENTOR-LIVE-READINESS §Fix 2b.
+ */
+export interface AgentMessageHookInput {
+  /** Raw message text (the body the marker parser inspects). */
+  text: string;
+  /** Telegram topic id (or GENERAL_TOPIC_ID fallback). */
+  topicId: number;
+  /** msg.from.is_bot (per Telegram's update shape). False for human users — the structural
+   *  half of the a2a spoof defense. */
+  senderIsBot: boolean;
+  /** msg.sender_chat.id (when present — group bot-as-channel relay). */
+  senderChatId?: string;
+  /** Effective bot identity: sender_chat.id ?? from.id, stringified. */
+  senderBotId?: string;
+  /** Wall-clock now (ms) — passed in for testability. */
+  now: number;
+}
+
+export type AgentMessageHook = (input: AgentMessageHookInput) => Promise<{ handled: boolean }>;
+
 export interface AttentionItem {
   id: string;
   title: string;
@@ -339,6 +363,14 @@ export class TelegramAdapter implements MessagingAdapter {
   /** When true, start() skips ensureLifelineTopic() — a non-primary bot must not create a
    *  second Lifeline topic in the chat. */
   private suppressLifelineAutoCreate: boolean;
+  /** Pre-dispatch hook for the agent-to-agent Telegram comms primitive (spec
+   *  MENTOR-LIVE-READINESS §Fix 2b). When set, the text-dispatch path calls this BEFORE
+   *  onTopicMessage / this.handler. If it returns {handled:true}, normal dispatch is
+   *  skipped (the hook routed the message to a role-handler OR dropped it as an a2a
+   *  security event). If {handled:false}, normal user flow continues. Other message types
+   *  (voice/photo/document) cannot carry the [a2a:…] marker and bypass the hook.
+   *  See installAgentMessageHook for the production binding. */
+  private agentMessageHook?: AgentMessageHook;
 
   // Attention queue (persisted to disk)
   private attentionItemToTopic: Map<string, number> = new Map();
@@ -1620,6 +1652,15 @@ export class TelegramAdapter implements MessagingAdapter {
 
   onMessage(handler: (message: Message) => Promise<void>): void {
     this.handler = handler;
+  }
+
+  /**
+   * Install the agent-to-agent Telegram comms pre-dispatch hook. The hook fires on text
+   * messages BEFORE onTopicMessage / this.handler dispatch — see AgentMessageHook docs
+   * above. Setting to undefined disables the hook (falls back to pure user-message flow).
+   */
+  setAgentMessageHook(hook: AgentMessageHook | undefined): void {
+    this.agentMessageHook = hook;
   }
 
   async resolveUser(channelIdentifier: string): Promise<string | null> {
@@ -3666,6 +3707,30 @@ export class TelegramAdapter implements MessagingAdapter {
     if (this.pendingPromptReply.has(numericTopicId) && text) {
       const handled = this.handlePendingPromptReply(numericTopicId, msg);
       if (handled) return;
+    }
+
+    // Agent-to-agent Telegram comms hook (spec MENTOR-LIVE-READINESS §Fix 2b). Runs BEFORE
+    // normal user-message dispatch on text messages so an a2a marker is intercepted as an
+    // agent event (route or drop), never falling through to topic-session spawning. Other
+    // message types can't carry markers — bypass entirely.
+    if (this.agentMessageHook && typeof text === 'string') {
+      try {
+        const senderChatId = msg.sender_chat?.id !== undefined ? String(msg.sender_chat.id) : undefined;
+        const senderBotId = senderChatId ?? (msg.from?.id !== undefined ? String(msg.from.id) : undefined);
+        const result = await this.agentMessageHook({
+          text,
+          topicId: numericTopicId,
+          senderIsBot: msg.from?.is_bot === true,
+          senderChatId,
+          senderBotId,
+          now: Date.now(),
+        });
+        if (result.handled) return;
+      } catch (err) {
+        // Hook must never crash the dispatch loop — log + fall through to normal user flow.
+        // (A broken hook is preferable to a frozen message pipeline.)
+        console.error(`[telegram] agentMessageHook error (falling through): ${err}`);
+      }
     }
 
     // Fire topic message callback (always fires — General topic falls back to ID 1)

--- a/src/messaging/installAgentMessageHook.ts
+++ b/src/messaging/installAgentMessageHook.ts
@@ -1,0 +1,130 @@
+/**
+ * installAgentMessageHook — production binding for the agent-to-agent Telegram comms
+ * receiver (spec MENTOR-LIVE-READINESS §Fix 2b, PR 3b). Composes the PR-1 routing logic
+ * (AgentTelegramComms.decideRoute) + the PR-3a storage primitives (AgentTelegramLedger,
+ * ProcessedIdStore) into the AgentMessageHook that TelegramAdapter calls before normal
+ * dispatch.
+ *
+ * The role-handler map is **per-recipient** (Echo registers `mentor-reply`; Codey
+ * registers `mentor`). Routed messages dispatch via the map; drops are audited; non-a2a
+ * messages fall through (`{handled:false}`).
+ */
+
+import {
+  decideRoute,
+  type RecipientConfig,
+  type IncomingContext,
+  type A2aMessage,
+} from './AgentTelegramComms.js';
+import type { AgentTelegramLedger, ReceiveAuditRow } from './AgentTelegramLedger.js';
+import type { ProcessedIdStore } from './ProcessedIdStore.js';
+import type { AgentMessageHook } from './TelegramAdapter.js';
+
+/** A role-handler is called when decideRoute returns 'route' for that role. The handler
+ *  consumes the message body (post-marker-strip) and any audit context it wants. */
+export type RoleHandler = (msg: A2aMessage, ctx: { topicId: number; senderBotId?: string }) => Promise<void>;
+
+export interface InstallAgentMessageHookDeps {
+  config: RecipientConfig;
+  ledger: AgentTelegramLedger;
+  processedIds: ProcessedIdStore;
+  /** Map of role → handler. A role-handler is called only when decideRoute returns
+   *  `route` AND the role is in `config.acceptRoles[from]` — the per-source admission
+   *  matrix gates ahead of the role-handler map. */
+  roleHandlers: Map<string, RoleHandler>;
+}
+
+/**
+ * Build the AgentMessageHook closure. Never throws — any internal error is captured
+ * + audited as a 'dropped' row with reason 'agent-marker-malformed' (the closest existing
+ * code), and the hook returns `{handled:true}` so a broken handler can't double-process
+ * via the user-flow fallback.
+ */
+export function buildAgentMessageHook(deps: InstallAgentMessageHookDeps): AgentMessageHook {
+  const isoTs = (ms: number) => new Date(ms).toISOString();
+
+  return async (input) => {
+    const ctx: IncomingContext = {
+      raw: input.text,
+      senderIsBot: input.senderIsBot,
+      senderChatId: input.senderChatId,
+      senderBotId: input.senderBotId,
+      now: input.now,
+    };
+    const decision = decideRoute(
+      ctx,
+      deps.config,
+      {
+        isProcessed: (id) => deps.processedIds.hasProcessed(id),
+        knownRole: (r) => deps.roleHandlers.has(r),
+      },
+    );
+
+    if (decision.action === 'fall-through') {
+      return { handled: false };
+    }
+
+    if (decision.action === 'drop') {
+      const row: ReceiveAuditRow = {
+        localTs: isoTs(input.now),
+        direction: 'received',
+        decision: 'dropped',
+        dropReason: decision.reason,
+        fromAgent: decision.msg?.from,
+        toAgent: decision.msg?.to,
+        role: decision.msg?.role,
+        id: decision.msg?.id,
+        corr: decision.msg?.corr,
+        ts: decision.msg?.ts,
+        telegramFromBotId: input.senderBotId,
+        telegramSenderChatId: input.senderChatId,
+        topicId: input.topicId,
+        rawPrefix: input.text.slice(0, 200),
+      };
+      deps.ledger.appendReceived(row);
+      return { handled: true };
+    }
+
+    // action === 'route'
+    const msg = decision.msg;
+    const handler = deps.roleHandlers.get(msg.role);
+    if (!handler) {
+      // Defensive: knownRole said yes but the map slot is undefined (race / wiring bug).
+      // Audit as dropped with a synthetic reason; do NOT fall through.
+      deps.ledger.appendReceived({
+        localTs: isoTs(input.now),
+        direction: 'received',
+        decision: 'dropped',
+        dropReason: 'agent-marker-unknown-role',
+        fromAgent: msg.from, toAgent: msg.to, role: msg.role, id: msg.id, corr: msg.corr, ts: msg.ts,
+        telegramFromBotId: input.senderBotId,
+        telegramSenderChatId: input.senderChatId,
+        topicId: input.topicId,
+      });
+      return { handled: true };
+    }
+
+    // Idempotency: mark BEFORE invoking the handler so a handler crash mid-process still
+    // dedups the retry (at-least-once delivery, exactly-once attempted processing).
+    deps.processedIds.markProcessed(msg.id);
+    deps.ledger.appendReceived({
+      localTs: isoTs(input.now),
+      direction: 'received',
+      decision: 'routed',
+      fromAgent: msg.from, toAgent: msg.to, role: msg.role, id: msg.id, corr: msg.corr, ts: msg.ts,
+      telegramFromBotId: input.senderBotId,
+      telegramSenderChatId: input.senderChatId,
+      topicId: input.topicId,
+    });
+    try {
+      await handler(msg, { topicId: input.topicId, senderBotId: input.senderBotId });
+    } catch (err) {
+      // A role-handler failure is recorded but doesn't un-mark the id (we still treat
+      // the message as processed; retrying would just re-fail). Stage-B forensics can see
+      // the routed row + the absence of a downstream effect.
+      // eslint-disable-next-line no-console
+      console.error(`[a2a] role-handler "${msg.role}" failed:`, err instanceof Error ? err.message : String(err));
+    }
+    return { handled: true };
+  };
+}

--- a/tests/unit/messaging/installAgentMessageHook.test.ts
+++ b/tests/unit/messaging/installAgentMessageHook.test.ts
@@ -1,0 +1,143 @@
+/**
+ * installAgentMessageHook (PR 3b) — end-to-end test of the agent-message hook closure
+ * (composes decideRoute + ledger + processed-id store + role-handler map).
+ *
+ * Plus a wiring-integrity test that asserts TelegramAdapter calls the hook on text
+ * messages BEFORE the existing onTopicMessage / this.handler dispatch.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { A2A_VERSION, formatMarker, type RecipientConfig, type A2aMessage } from '../../../src/messaging/AgentTelegramComms.js';
+import { AgentTelegramLedger, defaultLedgerPaths } from '../../../src/messaging/AgentTelegramLedger.js';
+import { ProcessedIdStore } from '../../../src/messaging/ProcessedIdStore.js';
+import { buildAgentMessageHook, type RoleHandler } from '../../../src/messaging/installAgentMessageHook.js';
+import { TelegramAdapter } from '../../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+const NOW = 1_779_900_000_000;
+
+function marker(over: Partial<{ from: string; to: string; role: string; id: string; corr: string; ts: number }> = {}): string {
+  const f = { from: 'instar-codey', to: 'echo', role: 'mentor-reply', id: 'r1', corr: 'p1', ts: NOW, ...over };
+  return formatMarker({ from: f.from, to: f.to, role: f.role, id: f.id, corr: f.corr, ts: f.ts }, 'hi from codey');
+}
+
+function cfg(over: Partial<RecipientConfig> = {}): RecipientConfig {
+  return {
+    localAgent: 'echo',
+    knownAgents: { 'instar-codey': { botId: 'codey-bot' } },
+    acceptRoles: { 'instar-codey': ['mentor-reply'] },
+    skewWindowMs: 24 * 60 * 60 * 1000,
+    maxVersion: A2A_VERSION,
+    ...over,
+  };
+}
+
+describe('buildAgentMessageHook — closure end-to-end', () => {
+  let dir: string;
+  let ledger: AgentTelegramLedger;
+  let store: ProcessedIdStore;
+  let calls: Array<{ msg: A2aMessage; topicId: number }>;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'a2a-hook-'));
+    ledger = new AgentTelegramLedger(defaultLedgerPaths(dir));
+    store = new ProcessedIdStore({ filePath: path.join(dir, 'pids.json'), now: () => NOW });
+    calls = [];
+  });
+  afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'a2a-hook test' }); });
+
+  const recordingHandler: RoleHandler = async (msg, ctx) => { calls.push({ msg, topicId: ctx.topicId }); };
+
+  function input(text: string, over: Partial<{ senderIsBot: boolean; senderChatId?: string; senderBotId?: string; topicId: number; now: number }> = {}) {
+    return { text, topicId: 42, senderIsBot: true, senderBotId: 'codey-bot', now: NOW, ...over };
+  }
+
+  function ledgerLines(file: 'sent' | 'received'): unknown[] {
+    const fp = file === 'sent' ? defaultLedgerPaths(dir).sentPath : defaultLedgerPaths(dir).receivedPath;
+    if (!fs.existsSync(fp)) return [];
+    return fs.readFileSync(fp, 'utf-8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  }
+
+  it('FALL-THROUGH: a non-marker user message returns {handled:false} and writes NO audit row', async () => {
+    const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: new Map() });
+    const r = await hook(input('hey echo, how are you?'));
+    expect(r).toEqual({ handled: false });
+    expect(ledgerLines('received')).toEqual([]); // user messages don't flood the audit
+  });
+
+  it('ROUTE: valid a2a marker with a registered role-handler → handler called, audit row written, id marked processed', async () => {
+    const handlers = new Map<string, RoleHandler>([['mentor-reply', recordingHandler]]);
+    const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: handlers });
+    const r = await hook(input(marker()));
+    expect(r).toEqual({ handled: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].msg).toMatchObject({ from: 'instar-codey', role: 'mentor-reply', id: 'r1', corr: 'p1' });
+    expect(calls[0].topicId).toBe(42);
+    const rows = ledgerLines('received');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ decision: 'routed', role: 'mentor-reply', id: 'r1', corr: 'p1' });
+    expect(store.hasProcessed('r1')).toBe(true); // idempotency anchor recorded
+  });
+
+  it('IDEMPOTENCY: a re-delivered marker (same id) is dropped without calling the handler', async () => {
+    const handlers = new Map<string, RoleHandler>([['mentor-reply', recordingHandler]]);
+    const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: handlers });
+    await hook(input(marker({ id: 'dup', corr: 'dup' })));
+    expect(calls).toHaveLength(1);
+    // Re-deliver
+    const r2 = await hook(input(marker({ id: 'dup', corr: 'dup' })));
+    expect(r2).toEqual({ handled: true });
+    expect(calls).toHaveLength(1); // NOT called a second time
+    const rows = ledgerLines('received');
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toMatchObject({ decision: 'dropped', dropReason: 'agent-marker-duplicate' });
+  });
+
+  it('SPOOF DEFENSE: a human-typed marker (senderIsBot=false, no sender_chat) is dropped, handler NOT called', async () => {
+    const handlers = new Map<string, RoleHandler>([['mentor-reply', recordingHandler]]);
+    const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: handlers });
+    const r = await hook(input(marker(), { senderIsBot: false, senderChatId: undefined, senderBotId: 'codey-bot' }));
+    expect(r).toEqual({ handled: true });
+    expect(calls).toHaveLength(0); // role-handler NOT invoked
+    expect(ledgerLines('received')[0]).toMatchObject({ decision: 'dropped', dropReason: 'agent-marker-spoofed-by-user' });
+  });
+
+  it('UNKNOWN-ROLE: marker with a role this recipient has no handler for is dropped', async () => {
+    // acceptRoles allows mentor-reply but no handler registered for it
+    const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: new Map() });
+    const r = await hook(input(marker()));
+    expect(r).toEqual({ handled: true });
+    expect(ledgerLines('received')[0]).toMatchObject({ decision: 'dropped', dropReason: 'agent-marker-unknown-role' });
+  });
+
+  it('HANDLER ERROR: a role-handler that throws is logged but does NOT crash dispatch + the id stays marked', async () => {
+    const throwingHandler: RoleHandler = async () => { throw new Error('boom'); };
+    const handlers = new Map<string, RoleHandler>([['mentor-reply', throwingHandler]]);
+    const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: handlers });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const r = await hook(input(marker({ id: 'e1', corr: 'e1' })));
+    expect(r).toEqual({ handled: true });
+    expect(store.hasProcessed('e1')).toBe(true); // marked even though handler failed
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe('TelegramAdapter wiring-integrity — hook fires before onTopicMessage', () => {
+  let dir: string;
+  let adapter: TelegramAdapter;
+
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'a2a-wiring-')); });
+  afterEach(async () => { if (adapter) await adapter.stop().catch(() => {}); SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'a2a-wiring test' }); });
+
+  it('TelegramAdapter exposes setAgentMessageHook and stores the hook', () => {
+    adapter = new TelegramAdapter({ token: 't', chatId: '-1001' }, dir);
+    const hook = async () => ({ handled: false });
+    adapter.setAgentMessageHook(hook);
+    expect((adapter as unknown as { agentMessageHook: unknown }).agentMessageHook).toBe(hook);
+    adapter.setAgentMessageHook(undefined);
+    expect((adapter as unknown as { agentMessageHook: unknown }).agentMessageHook).toBeUndefined();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -4,21 +4,41 @@
 
 ## What Changed
 
+Two related groundwork increments land together:
+
 Self-Propagation, Part 2 v1 — the **`/test-as-self` skill**: a deterministic post-deploy verifier for a throwaway agent home. Reads the Part 1 poll-ownership lease (present / fresh / well-formed / tokenHash-only security check), greps the server log for the Part 1 demote line (proves Part 1 actually fired in the live deploy — not just shipped), and tails the server + lifeline logs for the actual crash signatures (heap-OOM / `CheckIneffectiveMarkCompact` / Abort trap / libc++abi / SIGABRT — the signatures the 2026-05-27 mmtest diagnosis had wrong). Emits a single JSON report; exit 0 = all PASS; 1 = fail or crash detected.
 
-Includes a runbook (`SKILL.md`) for the tight deploy recipe and an explicit list of what v1 does NOT do (auto-mint bot, full Playwright Telegram round-trip, one-button command — those ship in Part 2.1 under the same approved spec).
+Includes a runbook (`SKILL.md`) for the tight deploy recipe and an explicit list of what v1 does NOT do (auto-mint bot, full Playwright Telegram round-trip, one-button command — those ship in Part 2.1 under the same approved spec). Pairs with Part 1 (the structural poll-ownership lease, shipping in #446).
 
-Pairs with Part 1 (the structural poll-ownership lease, shipping in #446).
+---
+
+**Agent-to-agent Telegram comms primitive — receiver wiring lands.** The TelegramAdapter
+now exposes a pre-dispatch hook (`setAgentMessageHook`) that the receiver side of the a2a
+primitive can install. When set, the hook intercepts text messages BEFORE normal user
+dispatch — if the message carries a valid `[a2a:from=… to=… role=… id=… corr=… ts=… v=1]`
+marker, the hook routes it to the registered role-handler or drops it as an a2a security
+event (every drop reason audited). When the hook returns "not handled" (no marker), the
+existing user-message flow continues unchanged. Ships **dark** — no caller invokes
+`setAgentMessageHook` yet; the mentor consumer wires it in the follow-up.
+
+The hook composer in `installAgentMessageHook.ts` ties together: the routing decision
+(from PR 1), the audit ledger and processed-id store (from PR 3a), and a per-recipient
+role-handler map. Spoof defense, per-source role acceptance, replay-window, and
+idempotency are all enforced by the composed flow — Stage-B forensics gets a routed +
+dropped audit trail it can replay.
 
 ## What to Tell Your User
 
-- A new `/test-as-self` skill that runs a deterministic check on a throwaway test deploy — verifies Part 1's structural fix actually fired in practice, and captures any crash signature for you instead of you guessing from log forensics.
+- A new test-as-self skill that runs a deterministic check on a throwaway test deploy — verifies Part 1's structural fix actually fired in practice, and captures any crash signature for you instead of you guessing from log forensics.
+- Still plumbing for the agent-to-agent Telegram feature; nothing changes for your agent today. Your normal Telegram messages flow exactly as before — only text messages with a fully-formed agent tag at the top are even considered, and nothing reads them yet.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
 | `/test-as-self` runbook + verifier | Follow the recipe in `.claude/skills/test-as-self/SKILL.md`; run `node .claude/skills/test-as-self/scripts/verify.mjs --dir <test-agent-home>` |
+| TelegramAdapter `setAgentMessageHook` | Internal — pre-dispatch hook fired on text messages before `onTopicMessage`; `{handled:true}` skips normal dispatch, `{handled:false}` falls through |
+| `buildAgentMessageHook` (composer) | Internal — `src/messaging/installAgentMessageHook.ts`; composes decideRoute + ledger + processed-id store + role-handler map into the hook closure |
 
 ## Evidence
 
@@ -26,3 +46,5 @@ Pairs with Part 1 (the structural poll-ownership lease, shipping in #446).
 - Installer: `src/commands/init.ts` (`installTestAsSelfSkill`, mirrors `installBuildSkill`; non-destructive, idempotent).
 - Tests: `tests/unit/test-as-self-verify.test.ts` (20 — both sides of every check boundary; security check rejects raw-token in file).
 - Spec: `docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md` (approved). Side-effects: `upgrades/side-effects/self-propagation-test-as-self-skill.md`.
+
+For the a2a receiver hook: 7 new unit tests (43 a2a-related tests total, all green) — fall-through on non-marker (no audit flood); route → handler called + routed audit row + id marked processed; idempotency (re-delivered id dropped, handler not called a 2nd time); user-spoof defense (handler not called even when from/id match); unknown-role drop; handler-error doesn't crash dispatch + id stays marked; TelegramAdapter `setAgentMessageHook` accepts + clears. `tsc --noEmit` clean. The change to Echo's primary Telegram dispatch is gated behind `if (this.agentMessageHook && ...)` and nothing calls `setAgentMessageHook` yet — the user message flow is byte-for-byte unchanged in production until the mentor consumer lands.

--- a/upgrades/side-effects/a2a-recipient-hook-wiring.md
+++ b/upgrades/side-effects/a2a-recipient-hook-wiring.md
@@ -1,0 +1,102 @@
+# Side-Effects Review — a2a recipient hook + TelegramAdapter wiring (PR 3b)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2b "Implementation surface"
+items 3 + the recipient routing flow + Codey's round-2 anti-loop discipline. PR 3 part b.
+**Change:** Wire the agent-to-agent Telegram comms receiver into the TelegramAdapter
+dispatch pipeline as a **pre-dispatch hook** (not a wrapper around an external handler).
+**Files:** `src/messaging/TelegramAdapter.ts` (additive: new field + setter + insertion
+point in the text-dispatch path), `src/messaging/installAgentMessageHook.ts` (new
+production binding that composes decideRoute + ledger + processed-id store + role-handler
+map into the hook closure), `tests/unit/messaging/installAgentMessageHook.test.ts` (new —
+end-to-end hook closure tests + adapter wiring-integrity).
+
+## Design correction (honesty up-front)
+
+The spec's PR-3b text described "wrap at server.ts:~3038." Reading the code revealed
+that's the TelegramAdapter *construction* line — there's no `telegram.onMessage(handler)`
+registration there or anywhere in the main dispatch (the only caller of
+`telegram.onMessage(...)` codebase-wide is `TelegramConfirmationTransport.ts:109`, a small
+provider). Telegram message handling is internal to TelegramAdapter — dispatch happens
+inside `poll()`'s per-update processing. The cleaner integration was a dedicated
+`agentMessageHook` field that the adapter calls **before** the existing
+`onTopicMessage`/`this.handler` dispatch in the text path (other message types can't
+carry the `[a2a:…]` marker, so they bypass entirely). One insertion point, minimally
+invasive.
+
+## What changed
+
+1. **TelegramAdapter** (`src/messaging/TelegramAdapter.ts`):
+   - New exported types: `AgentMessageHookInput`, `AgentMessageHook`.
+   - New private field `agentMessageHook?: AgentMessageHook` + public setter
+     `setAgentMessageHook(hook | undefined)`.
+   - In the text-dispatch path (after the Prompt Gate, before `onTopicMessage` —
+     i.e. AFTER auth + sentinel + prompt-gate, BEFORE normal user routing), the adapter
+     calls the hook if set. On `{handled:true}` → return (skip normal dispatch). On
+     `{handled:false}` → continue. On hook error → log + fall through (a broken hook
+     must NOT freeze the message pipeline).
+2. **installAgentMessageHook** (new — production hook composer):
+   - Builds an `AgentMessageHook` closure from injected `{config, ledger, processedIds,
+     roleHandlers}`.
+   - Calls `decideRoute(ctx, config, {isProcessed, knownRole})`.
+   - On `fall-through` → returns `{handled:false}` + writes NO row (user messages don't
+     flood the audit).
+   - On `drop` → writes a `ReceiveAuditRow` with the drop reason + returns `{handled:true}`.
+   - On `route` → marks the id processed **before** invoking the handler (so a handler
+     crash mid-process still dedups the retry — at-least-once delivery / exactly-once
+     attempted processing), writes a `decision:'routed'` row, then awaits the role
+     handler. A handler error is logged but does not unmark the id (retrying would just
+     re-fail; Stage-B can see the routed row + the absent downstream effect).
+
+## The seven questions
+
+1. **Over-block.** The hook only fires on TEXT messages with the field set + falls through
+   on `no-marker`. Other message types bypass entirely. The dispatch order (after
+   sentinel + prompt-gate) preserves priority for emergency-stop and active prompt-gate
+   collection.
+2. **Under-block.** The hook NEVER falls through on a marker-shaped message — it always
+   routes or drops (security event). The user-spoof defense (round-2 adversarial F1) is
+   inherited from `decideRoute`. Idempotency on receive: `processedIds.markProcessed` runs
+   before the handler so a retry can't double-invoke.
+3. **Level-of-abstraction fit.** Hook field on the adapter; composer module owns the
+   policy; pure routing logic stays in `decideRoute` (PR 1). Three layers, single
+   responsibility each, fully injectable for tests.
+4. **Signal vs authority.** `decideRoute` is the routing authority (unchanged from PR 1);
+   the hook is its actuator + audit writer + idempotency boundary.
+5. **Interactions — THE risk, and how it's bounded.** This touches Echo's primary message
+   dispatch in TelegramAdapter (the channel to the user). The change is dark-by-default:
+   the hook field starts undefined → the new code path is `if (this.agentMessageHook && ...)`
+   which is a no-op until something calls `setAgentMessageHook`. No production wiring
+   does that yet — the mentor consumer (PR 3c) will. Hook errors fall through to normal
+   flow (log + continue), so even a broken hook can't freeze user messages. The existing
+   Telegram suites (71 + 25 + 8 + 3 + 7 = 114 tests) pass unchanged.
+6. **External surfaces.** None new in this PR. The wiring module exports
+   `buildAgentMessageHook` for PR 3c (or any future consumer) to call.
+7. **Rollback cost.** Trivial — revert removes the additive field, setter, hook composer.
+   Dispatch loop returns to identical-to-pre-PR behavior (no field set → no code path
+   touched).
+
+## Testing
+
+7 new unit tests in `installAgentMessageHook.test.ts`, all green:
+- **fall-through**: non-marker user message → `{handled:false}` + NO audit row (don't
+  flood the ledger with every user message).
+- **route**: valid marker + registered role-handler → handler called with the parsed
+  message + topic id; `decision:'routed'` audit row written; id marked processed.
+- **idempotency**: re-delivered marker (same id) → dropped with reason
+  `agent-marker-duplicate`; handler NOT called a second time.
+- **spoof defense**: human-typed marker (`senderIsBot:false`, no `sender_chat`) → dropped
+  with `agent-marker-spoofed-by-user`; handler NOT called.
+- **unknown-role**: marker with no registered handler → dropped with
+  `agent-marker-unknown-role`; never falls through to user flow.
+- **handler error**: a role-handler that throws → logged, hook returns `{handled:true}`,
+  id stays marked (no infinite retry on a broken handler).
+- **TelegramAdapter wiring-integrity**: `setAgentMessageHook` accepts a hook + sets the
+  field; setting `undefined` clears it.
+
+Plus the 36 existing a2a tests (PRs 1, 2a, 2b, 3a) — 43 a2a-related tests in total, all
+green. `tsc --noEmit` clean.
+
+## Migration parity
+
+None — additive: no caller invokes `setAgentMessageHook` yet (PR 3c will). No config
+consumed, no routes, no agent-installed file changes.


### PR DESCRIPTION
## What

PR 3b — wires the a2a receiver into TelegramAdapter dispatch as a **pre-dispatch hook** (not the "wrap an external handler at server.ts" the spec assumed — verified by reading the code that `telegram.onMessage(...)` is only called by a small confirmation-transport provider, not the main dispatch; cleaner integration is a hook the adapter itself calls). Ships **dark** — no caller invokes `setAgentMessageHook` yet; PR 3c wires the mentor consumer. User-message flow is byte-for-byte unchanged in production.

## Changes

- **TelegramAdapter**: new `AgentMessageHook` type + `agentMessageHook` field + `setAgentMessageHook()` setter. Insertion point in the text-dispatch path (after auth + sentinel + prompt-gate, before `onTopicMessage`). Other message types can't carry markers and bypass entirely. Hook errors fall through (a broken hook must NOT freeze the message pipeline).
- **`installAgentMessageHook.ts`** (new): production composer that builds the hook closure from `decideRoute` (PR 1) + `AgentTelegramLedger` (PR 3a) + `ProcessedIdStore` (PR 3a) + a per-recipient role-handler map. fall-through → `{handled:false}` + NO audit row; route → mark id BEFORE invoking handler (a handler crash mid-process still dedups the retry), audit + await; drop → audit with the drop reason.

## Safety

The dispatch loop change is gated by `if (this.agentMessageHook && ...)` — undefined until something calls the setter (nothing does yet). The 71 existing Telegram suite tests + the 36 prior a2a tests pass unchanged.

## Tests

7 new (43 a2a-related total, all green): fall-through-no-audit, route + handler + processed-id, idempotency on re-delivery, user-spoof defense (handler not called even when from/id match), unknown-role drop, handler-error-doesn't-crash + id stays marked, TelegramAdapter setter wiring.

## Next

PR 3c: mentor consumer — Stage-A rewiring to use `sendAgentMessage` via the mentor bot (PR 2a's multi-instance adapter), Stage-B reply handler registered via this hook, outstanding-prompt tracker, quota-aware budget, `migrateRetireDeadMentorConfig` + `migrateRetireMentorOutbox`, mentor-bot config + `/mentor/bot-setup` routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)