### PR TITLE
fix(SourceTreeGuard): extend sourceTreeReadOk to readSync + expand verb set

### DIFF
--- a/src/core/SafeGitExecutor.ts
+++ b/src/core/SafeGitExecutor.ts
@@ -142,7 +142,18 @@ export const READONLY_GIT_VERBS: ReadonlySet<string> = new Set([
  * source-tree guard.)
  */
 export const SOURCE_TREE_READ_TIER_VERBS: ReadonlySet<string> = new Set([
+  // data-pull verbs (execSync path)
   'fetch',
+  // read-tier verbs the watchdog + reconciler need against the source tree
+  // (readSync path — defense-in-depth source-tree check also gates these,
+  // so the bypass must work for both methods)
+  'rev-parse',
+  'ls-tree',
+  'show',
+  'log',
+  'cat-file',
+  'merge-base',
+  'remote', // shape-checked to list/get-url only; needed by resolveCanonicalRemote
 ]);
 
 // ── Env denylist ────────────────────────────────────────────────────
@@ -760,8 +771,15 @@ export class SafeGitExecutor {
       );
     }
 
-    // Defense-in-depth: source-tree check on the read path too.
-    runSourceTreeChecks(targets, opts.operation, 'git', verb);
+    // Defense-in-depth: source-tree check on the read path too — UNLESS the
+    // caller opted into the narrow read-tier allowlist (the LAYER B/C
+    // canonical-ref read path that legitimately operates against the agent's
+    // own instar checkout). See SafeGitOptions.sourceTreeReadOk.
+    if (!(opts.sourceTreeReadOk && SOURCE_TREE_READ_TIER_VERBS.has(verb))) {
+      runSourceTreeChecks(targets, opts.operation, 'git', verb);
+    } else {
+      audit('git', opts.operation, verb, targets[0], 'allowed', 'sourceTreeReadOk-bypass');
+    }
 
     const env = sanitizeEnv(opts.env);
     let stdout: string;

--- a/src/core/featureRolloutScan.ts
+++ b/src/core/featureRolloutScan.ts
@@ -152,12 +152,13 @@ export function scanSpecArtifactsCanonical(opts: CanonicalScanOpts): CanonicalSc
   const canonicalHeadSha = SafeGitExecutor.run(['rev-parse', 'FETCH_HEAD'], {
     cwd: opts.repoPath,
     operation: 'featureRolloutScan:canonicalRevParse',
+    sourceTreeReadOk: true,
   }).trim();
 
   // 2) Enumerate spec files on main.
   const lsSpecs = SafeGitExecutor.run(
     ['ls-tree', '-r', '--name-only', canonicalHeadSha, '--', 'docs/specs/'],
-    { cwd: opts.repoPath, operation: 'featureRolloutScan:lsSpecs' },
+    { cwd: opts.repoPath, operation: 'featureRolloutScan:lsSpecs', sourceTreeReadOk: true },
   );
   const specPaths = lsSpecs.split('\n').map((s) => s.trim()).filter((p) => p.endsWith('.md') && !p.endsWith('.eli16.md'));
 
@@ -166,14 +167,14 @@ export function scanSpecArtifactsCanonical(opts: CanonicalScanOpts): CanonicalSc
   try {
     lsTraces = SafeGitExecutor.run(
       ['ls-tree', '-r', '--name-only', canonicalHeadSha, '--', '.instar/instar-dev-traces/'],
-      { cwd: opts.repoPath, operation: 'featureRolloutScan:lsTraces' },
+      { cwd: opts.repoPath, operation: 'featureRolloutScan:lsTraces', sourceTreeReadOk: true },
     );
   } catch { /* traces dir may not exist on main yet */ }
   const tracesByPath = new Map<string, TraceInfo>();
   for (const tp of lsTraces.split('\n').map((s) => s.trim()).filter((p) => p.endsWith('.json'))) {
     try {
       const blob = SafeGitExecutor.run(['show', `${canonicalHeadSha}:${tp}`], {
-        cwd: opts.repoPath, operation: 'featureRolloutScan:traceBlob',
+        cwd: opts.repoPath, operation: 'featureRolloutScan:traceBlob', sourceTreeReadOk: true,
       });
       const t = JSON.parse(blob);
       if (typeof t.specPath === 'string') {
@@ -192,7 +193,7 @@ export function scanSpecArtifactsCanonical(opts: CanonicalScanOpts): CanonicalSc
     let content: string;
     try {
       content = SafeGitExecutor.run(['show', `${canonicalHeadSha}:${specPath}`], {
-        cwd: opts.repoPath, operation: 'featureRolloutScan:specBlob',
+        cwd: opts.repoPath, operation: 'featureRolloutScan:specBlob', sourceTreeReadOk: true,
       });
     } catch { continue; }
     const fm = parseSpecFrontmatter(content);

--- a/src/monitoring/releaseReadinessWiring.ts
+++ b/src/monitoring/releaseReadinessWiring.ts
@@ -70,7 +70,7 @@ export function resolveCanonicalRemote(
 ): { remote: string; overridden: boolean } {
   let remotesRaw = '';
   try {
-    remotesRaw = SafeGitExecutor.run(['remote', '-v'], { cwd: repoPath, operation: 'releaseReadinessWiring:resolveRemote' });
+    remotesRaw = SafeGitExecutor.run(['remote', '-v'], { cwd: repoPath, operation: 'releaseReadinessWiring:resolveRemote', sourceTreeReadOk: true });
   } catch {
     return { remote: configured ?? 'origin', overridden: configured != null };
   }
@@ -148,6 +148,7 @@ export function buildReleaseReadinessDeps(opts: ReleaseReadinessWiringOpts): Rel
           const headSha = SafeGitExecutor.run(['rev-parse', 'FETCH_HEAD'], {
             cwd: opts.repoPath,
             operation: 'releaseReadinessWiring:revparse',
+            sourceTreeReadOk: true,
           }).trim();
           return { ok: true, headSha };
         } catch {
@@ -188,7 +189,7 @@ export function buildReleaseReadinessDeps(opts: ReleaseReadinessWiringOpts): Rel
       try {
         const raw = SafeGitExecutor.run(
           ['log', `${lastTag}..${ref}`, '--no-merges', '--reverse', '--format=%H %ct'],
-          { cwd: opts.repoPath, operation: 'releaseReadinessWiring:oldest' },
+          { cwd: opts.repoPath, operation: 'releaseReadinessWiring:oldest', sourceTreeReadOk: true },
         ).trim();
         const first = raw.split('\n').filter(Boolean)[0];
         if (!first) return null;
@@ -238,6 +239,7 @@ export function buildReleaseReadinessDeps(opts: ReleaseReadinessWiringOpts): Rel
         SafeGitExecutor.run(['merge-base', '--is-ancestor', sha, ref], {
           cwd: opts.repoPath,
           operation: 'releaseReadinessWiring:isAncestor',
+          sourceTreeReadOk: true,
         });
         return true;
       } catch {

--- a/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
+++ b/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
@@ -106,17 +106,49 @@ describe('SafeGitExecutor.sourceTreeReadOk', () => {
     )).toThrow(SourceTreeGuardError);
   });
 
-  it('SOURCE_TREE_READ_TIER_VERBS is a closed, narrow set (fetch only initially)', () => {
+  it('SOURCE_TREE_READ_TIER_VERBS is a closed read-tier set — no destructive write verbs', () => {
+    // Allowed read-tier verbs (data-pull + readonly used by LAYER B/C):
     expect(SOURCE_TREE_READ_TIER_VERBS.has('fetch')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('rev-parse')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('ls-tree')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('show')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('log')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('merge-base')).toBe(true);
+    // Must NEVER include verbs that modify the working tree or committed refs:
     expect(SOURCE_TREE_READ_TIER_VERBS.has('commit')).toBe(false);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('push')).toBe(false);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('reset')).toBe(false);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('checkout')).toBe(false);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('rebase')).toBe(false);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('merge')).toBe(false);
-    // Sanity: the set must stay tiny. Two classifications are independent —
-    // fetch IS destructive for execSync routing AND source-tree-read-tier
-    // for guard purposes; that's by design.
-    expect(SOURCE_TREE_READ_TIER_VERBS.size).toBeLessThanOrEqual(3);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('clean')).toBe(false);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('rm')).toBe(false);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('branch')).toBe(false);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('tag')).toBe(false);
+    // Bounded — adding to this set requires a spec edit + side-effects review.
+    expect(SOURCE_TREE_READ_TIER_VERBS.size).toBeLessThanOrEqual(10);
+  });
+
+  it('readSync path also honors sourceTreeReadOk — rev-parse on a source tree passes', () => {
+    // rev-parse FETCH_HEAD after a fetch (which leaves FETCH_HEAD pointing at canon's main).
+    SafeGitExecutor.run(
+      ['fetch', 'canon', 'main', '--no-tags', '--no-recurse-submodules'],
+      { cwd: srcTree, operation: 't:setup-fetch', sourceTreeReadOk: true },
+    );
+    expect(() => SafeGitExecutor.run(
+      ['rev-parse', 'FETCH_HEAD'],
+      { cwd: srcTree, operation: 't:revparse-allowed', sourceTreeReadOk: true },
+    )).not.toThrow();
+  });
+
+  it('readSync path WITHOUT sourceTreeReadOk: rev-parse on a source tree is STILL blocked', () => {
+    SafeGitExecutor.run(
+      ['fetch', 'canon', 'main', '--no-tags', '--no-recurse-submodules'],
+      { cwd: srcTree, operation: 't:setup-fetch2', sourceTreeReadOk: true },
+    );
+    expect(() => SafeGitExecutor.run(
+      ['rev-parse', 'FETCH_HEAD'],
+      { cwd: srcTree, operation: 't:revparse-default' },
+    )).toThrow(SourceTreeGuardError);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -4,6 +4,10 @@
 
 ## What Changed
 
+`SourceTreeGuard` `sourceTreeReadOk` opt extended to `readSync` (defense-in-depth source-tree check on the read path) + `SOURCE_TREE_READ_TIER_VERBS` expanded to cover the canonical-ref read path the watchdog and reconciler use (`rev-parse`, `ls-tree`, `show`, `log`, `cat-file`, `merge-base`, `remote`). Caught dogfooding Echo on v1.3.38: the previous fix only opened `execSync` to `fetch`, but every downstream readonly verb still tripped the guard. With this PR landed, the watchdog completes a real tick against the agent's own instar source.
+
+---
+
 Self-Propagation, Part 2 v1 — the **`/test-as-self` skill**: a deterministic post-deploy verifier for a throwaway agent home. Reads the Part 1 poll-ownership lease (present / fresh / well-formed / tokenHash-only security check), greps the server log for the Part 1 demote line (proves Part 1 actually fired in the live deploy — not just shipped), and tails the server + lifeline logs for the actual crash signatures (heap-OOM / `CheckIneffectiveMarkCompact` / Abort trap / libc++abi / SIGABRT — the signatures the 2026-05-27 mmtest diagnosis had wrong). Emits a single JSON report; exit 0 = all PASS; 1 = fail or crash detected.
 
 Includes a runbook (`SKILL.md`) for the tight deploy recipe and an explicit list of what v1 does NOT do (auto-mint bot, full Playwright Telegram round-trip, one-button command — those ship in Part 2.1 under the same approved spec).
@@ -12,7 +16,8 @@ Pairs with Part 1 (the structural poll-ownership lease, shipping in #446).
 
 ## What to Tell Your User
 
-- A new `/test-as-self` skill that runs a deterministic check on a throwaway test deploy — verifies Part 1's structural fix actually fired in practice, and captures any crash signature for you instead of you guessing from log forensics.
+- A new test-as-self skill that runs a deterministic check on a throwaway test deploy — verifies Part 1's structural fix actually fired in practice, and captures any crash signature for you instead of you guessing from log forensics.
+- I can finally complete a real release-readiness watchdog tick against my own checkout. The first dogfood attempt caught a real safety-guard interaction; this update closes the loop so the watchdog can read what it needs without bypassing the broader policy.
 
 ## Summary of New Capabilities
 

--- a/upgrades/side-effects/source-tree-guard-readsync-bypass.md
+++ b/upgrades/side-effects/source-tree-guard-readsync-bypass.md
@@ -1,0 +1,34 @@
+# Side-Effects Review — SourceTreeGuard read-tier bypass (extend to readSync)
+
+**Driver:** dogfood follow-up to PR #450 (source-tree-guard-data-pull). The narrow `sourceTreeReadOk` opt was added to `execSync` + `spawn` to let `git fetch` work on the agent's own instar checkout. After deploying v1.3.38 to Echo, the next layer of the same gap surfaced: `readSync` also runs source-tree-checks ("defense-in-depth"), and the canonical-ref scan path uses readonly verbs (`rev-parse`, `ls-tree`, `show`, `log`, `merge-base`, `remote -v`) that all go through `readSync` → all blocked on the source tree.
+
+## What changed
+
+- **`src/core/SafeGitExecutor.ts`** —
+  - `readSync` now honors `opts.sourceTreeReadOk` the same way `execSync` / `spawn` do: when the opt is true AND the verb is in `SOURCE_TREE_READ_TIER_VERBS`, skip `runSourceTreeChecks`; audit the bypass with the `sourceTreeReadOk-bypass` reason.
+  - `SOURCE_TREE_READ_TIER_VERBS` extended from `['fetch']` to `['fetch', 'rev-parse', 'ls-tree', 'show', 'log', 'cat-file', 'merge-base', 'remote']`. Still a small closed enumeration; still requires a spec edit to grow. Every verb is read-tier: none mutate the working tree or committed refs.
+- **`src/monitoring/releaseReadinessWiring.ts`** — every `SafeGitExecutor.run` callsite passes `sourceTreeReadOk: true`: `resolveCanonicalRemote` (`remote -v`), `fetchCanonical` (`rev-parse FETCH_HEAD` — fetch already had it), `oldestUnreleasedCommit` (`log`), `isAncestor` (`merge-base --is-ancestor`).
+- **`src/core/featureRolloutScan.ts`** — every `SafeGitExecutor.run` callsite in the canonical scan path passes `sourceTreeReadOk: true`: `rev-parse FETCH_HEAD`, `ls-tree` (spec + trace enumeration), `show` (spec + trace blob reads). `fetch` already had it.
+
+## Side-effects analysis
+
+**Why this is safe.** Every verb in the (still-small, still-closed) `SOURCE_TREE_READ_TIER_VERBS` set is read-tier: it does NOT modify the working tree, any committed ref, or any source file. `fetch` writes only to `FETCH_HEAD` + objects (transient). `rev-parse`, `ls-tree`, `show`, `log`, `cat-file`, `merge-base`, `remote -v/-get-url` are pure-read. The bypass is opt-in per-call, audit-logged, and only effective inside the closed verb allowlist.
+
+**Why the previous fix wasn't enough.** PR-450 only added the bypass to `execSync` + `spawn`, on the assumption that readonly verbs went through `readSync` which "didn't run source-tree checks." That was wrong: `readSync` runs them as defense-in-depth (catches repo-local aliases that could rebind a "read-only" verb). Every readonly verb on the agent's source tree was therefore still being blocked. This PR closes the gap at the right layer.
+
+**Reach.** Two real-code callsites touched (the two new ones added by the spec: Layer B wiring + Layer C scanner). Every existing `SafeGitExecutor.readSync` caller that does NOT pass `sourceTreeReadOk: true` is byte-identically guarded by the prior behavior.
+
+**Rollback.** Reverting this PR re-blocks the canonical-ref readSync calls on source trees. Layer B's fail-loud path keeps signaling on the failure; Layer C's local-scan fallback keeps working. No broken state.
+
+## Testing
+
+`tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts` (7 tests, all green):
+- default: fetch on non-source-tree works
+- default: fetch on source-tree blocked
+- `sourceTreeReadOk: true` + fetch on source-tree passes
+- `sourceTreeReadOk: true` does NOT bypass non-allowlist verbs (e.g. `add`)
+- `SOURCE_TREE_READ_TIER_VERBS` is a closed read-tier set — no destructive write verbs (commit/push/reset/checkout/rebase/merge/clean/rm/branch/tag); size ≤ 10
+- **readSync path also honors `sourceTreeReadOk` — `rev-parse FETCH_HEAD` on a source tree passes**
+- **readSync path WITHOUT `sourceTreeReadOk` — `rev-parse FETCH_HEAD` on a source tree STILL blocked**
+
+Lint clean.


### PR DESCRIPTION
## Summary

Dogfood follow-up to PR #450. v1.3.38 deployed to Echo and the watchdog's `fetch` succeeded — but every downstream readonly verb (`rev-parse FETCH_HEAD`, `log`, `merge-base`, `ls-tree`, `show`, `remote -v`) still tripped `SourceTreeGuard`. `readSync` runs source-tree-checks as defense-in-depth (catches repo-local aliases that could rebind a read-only verb), so the PR #450 bypass — which only opened `execSync` + `spawn` — left the canonical-ref read path blocked.

This PR closes the gap at the right layer:
- `readSync` honors `opts.sourceTreeReadOk` the same way `execSync` does.
- `SOURCE_TREE_READ_TIER_VERBS` expanded from `['fetch']` to also include `rev-parse`, `ls-tree`, `show`, `log`, `cat-file`, `merge-base`, `remote`. Still a small closed read-tier set; still requires a spec edit to grow. Every verb is read-tier — none mutate the working tree or committed refs.
- Layer B wiring + Layer C scanner pass `sourceTreeReadOk: true` on every `SafeGitExecutor.run` callsite (not just the fetch).

## Test plan

7 unit tests:
- default: fetch on non-source / source / etc. (4 from PR #450)
- closed-set invariant — destructive verbs (commit/push/reset/checkout/rebase/merge/clean/rm/branch/tag) are NOT present; size ≤ 10
- **readSync path WITH `sourceTreeReadOk`: `rev-parse FETCH_HEAD` on source tree → passes**
- **readSync path WITHOUT the opt: `rev-parse FETCH_HEAD` on source tree → STILL blocked**

Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)