### PR TITLE
feat(mentor): wire deliverToMentee → sendAgentMessage via mentor-bot (PR 3c-1)

### DIFF
--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -23,7 +23,22 @@ export interface MentorConfig {
   menteeFramework: string;
   minIntervalMs: number;
   maxRoundsPerDay: number;
+  /** @deprecated dead config — we run on a Claude subscription; replacement is the
+   *  quota-aware Stage-B token ceiling (Fix 3 of MENTOR-LIVE-READINESS, separate PR).
+   *  Retained for backward-compat read; removed by migrateRetireDeadMentorConfig. */
   dailySpendCapUsd: number;
+  /** Telegram bot token Echo uses to send to the mentee (Secret-Drop-collected). When
+   *  unset, the mentor refuses to deliver (logs + no-op) — the wiring stays dark even
+   *  with mentor.enabled true, until a token is configured. */
+  botToken?: string;
+  /** Mentee's Telegram bot id (the recipient — Codey's bot). Used by Echo's mentor
+   *  bot to address its sends + by Codey-side allowlist for the spoof defense. */
+  menteeBotId?: string;
+  /** Mentee's Telegram chat id (the supergroup where Codey's topics live). Echo's
+   *  mentor bot sends INTO this chat (it's Codey's universe, not Echo's). */
+  menteeChatId?: string;
+  /** Topic id within menteeChatId that Echo writes mentor prompts to. */
+  menteeTopicId?: number;
 }
 
 export const DEFAULT_MENTOR_CONFIG: MentorConfig = {
@@ -33,6 +48,8 @@ export const DEFAULT_MENTOR_CONFIG: MentorConfig = {
   minIntervalMs: 600_000, // 10 min floor
   maxRoundsPerDay: 24,
   dailySpendCapUsd: 0.5,
+  // botToken / menteeBotId / menteeTopicId default undefined → mentor wiring stays
+  // dark until they are explicitly configured (per /mentor/bot-setup, future PR).
 };
 
 export interface MentorRunnerServices {

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -63,6 +63,9 @@ import { FrameworkIssueLedger } from '../monitoring/FrameworkIssueLedger.js';
 import { MentorOnboardingRunner, DEFAULT_MENTOR_CONFIG, type MentorConfig } from '../scheduler/MentorOnboardingRunner.js';
 import { STAGE_A_ALLOWED_TOOLS } from '../monitoring/MentorStageA.js';
 import { analyzeForensics } from '../scheduler/MentorStageBForensics.js';
+import { TelegramAdapter as MentorTelegramAdapter } from '../messaging/TelegramAdapter.js';
+import { sendAgentMessage } from '../messaging/AgentTelegramComms.js';
+import { AgentTelegramLedger, defaultLedgerPaths as defaultA2aLedgerPaths } from '../messaging/AgentTelegramLedger.js';
 import { parseCodexRollout } from '../monitoring/CodexRolloutParser.js';
 import type { ForensicFinding } from '../monitoring/FrameworkIssueLedger.js';
 import { BurnDetector } from '../monitoring/BurnDetector.js';
@@ -96,6 +99,13 @@ export class AgentServer {
   /** UTC day + run count for the per-day mentor cap (resets across days). */
   private mentorDayKey = '';
   private mentorRunsToday = 0;
+  /** Lazily-constructed second TelegramAdapter for the mentor bot (gated on
+   *  mentor.botToken). Per-token-cached so config reloads with the same token reuse the
+   *  same adapter (avoids leaking a new bot poll loop on every send). Spec §Fix 2b. */
+  private mentorBotAdapter: MentorTelegramAdapter | null = null;
+  private mentorBotAdapterToken: string | null = null;
+  /** Lazily-constructed a2a audit ledger (shared across mentor sends/recvs). */
+  private a2aLedger: AgentTelegramLedger | null = null;
   private failureLedger: FailureLedger | null = null;
   private failureAttributionEngine: FailureAttributionEngine | null = null;
   // Burn-detection-and-self-heal system (six-phase umbrella spec at
@@ -740,6 +750,46 @@ export class AgentServer {
     return found.sort((a, b) => b.mtime - a.mtime).slice(0, n).map((f) => f.path);
   }
 
+  /**
+   * Lazily construct + cache the mentor-bot TelegramAdapter for the given token. Uses
+   * PR 2a's multi-instance support (subDir + suppressLifelineAutoCreate) so the second
+   * bot can't clobber the primary bot's state files OR auto-create a second Lifeline
+   * topic. Reconfiguration (token change) tears down the old adapter first.
+   * Returns null on construction failure (logged) — caller treats as "no delivery."
+   */
+  private getOrCreateMentorBot(botToken: string, menteeChatId: string): MentorTelegramAdapter | null {
+    if (this.mentorBotAdapter && this.mentorBotAdapterToken === botToken) {
+      return this.mentorBotAdapter;
+    }
+    if (this.mentorBotAdapter && this.mentorBotAdapterToken !== botToken) {
+      this.mentorBotAdapter.stop().catch(() => {});
+      this.mentorBotAdapter = null;
+      this.mentorBotAdapterToken = null;
+    }
+    try {
+      this.mentorBotAdapter = new MentorTelegramAdapter(
+        { token: botToken, chatId: menteeChatId },
+        this.config.stateDir,
+        { subDir: 'agent-telegram/mentor-bot', suppressLifelineAutoCreate: true },
+      );
+      this.mentorBotAdapterToken = botToken;
+      return this.mentorBotAdapter;
+    } catch (err) {
+      console.warn('[mentor] mentor-bot adapter construction failed (non-fatal):', err instanceof Error ? err.message : String(err));
+      this.mentorBotAdapter = null;
+      this.mentorBotAdapterToken = null;
+      return null;
+    }
+  }
+
+  /** Lazily construct + cache the a2a audit ledger. Paths default under stateDir. */
+  private getOrCreateA2aLedger(): AgentTelegramLedger {
+    if (!this.a2aLedger) {
+      this.a2aLedger = new AgentTelegramLedger(defaultA2aLedgerPaths(this.config.stateDir));
+    }
+    return this.a2aLedger;
+  }
+
   private buildMentorRunner(
     ledger: FrameworkIssueLedger,
     options: { config: { stateDir?: string }; intelligence?: import('../core/types.js').IntelligenceProvider | null },
@@ -839,19 +889,51 @@ export class AgentServer {
           return self.mentorRunsToday < cfg.maxRoundsPerDay;
         },
         getSurface: (framework: string) => ({ framework, threadlineHistory: '' }),
-        // Persist-only delivery (§6): append the Stage-A message to a durable
-        // per-mentee outbox the mentee's already-running session picks up. This
-        // does NOT call threadline_send / spawn a counterpart session — the
-        // structural fix for the cross-agent spawn loop. Best-effort + never throws
-        // (delivery failure must not crash a tick). Called ONLY in live mode.
-        deliverToMentee: (framework: string, message: string) => {
+        // Live delivery via the agent-to-agent Telegram comms primitive (spec
+        // MENTOR-LIVE-READINESS §Fix 2b — Justin's substrate correction replaced the
+        // earlier file-outbox design). Echo's mentor-bot (a second TelegramAdapter, gated
+        // on mentor.botToken being set) sends a tagged [a2a:…] message to the mentee's
+        // bot in a dedicated mentor topic. The anti-spawn-loop discipline lives in the
+        // primitive (one outbound producer per role, no auto-reply, audit ledger). If
+        // the bot isn't configured yet, this no-ops with a log — the dark default.
+        deliverToMentee: async (framework: string, message: string) => {
+          const cfg = getConfig();
+          if (!cfg.botToken || !cfg.menteeBotId || !cfg.menteeChatId || cfg.menteeTopicId === undefined) {
+            console.warn(`[mentor] deliverToMentee skipped — mentor-bot config incomplete (need mentor.botToken + menteeBotId + menteeChatId + menteeTopicId; framework=${framework})`);
+            return;
+          }
+          const bot = self.getOrCreateMentorBot(cfg.botToken, cfg.menteeChatId);
+          if (!bot) return;
+          const ledger = self.getOrCreateA2aLedger();
           try {
-            const outboxDir = path.join(serverDataDir, 'mentor-outbox');
-            fs.mkdirSync(outboxDir, { recursive: true });
-            const line = JSON.stringify({ ts: Date.now(), framework, message }) + '\n';
-            fs.appendFileSync(path.join(outboxDir, `${framework.replace(/[^\w.-]/g, '_')}.jsonl`), line);
+            await sendAgentMessage(
+              {
+                fromAgent: 'echo',
+                toAgent: `instar-${framework}`,
+                role: 'mentor',
+                toTopicId: cfg.menteeTopicId,
+                message,
+              },
+              {
+                send: async (topicId, text) => {
+                  try {
+                    const id = await bot.sendToTopic(topicId, text);
+                    return { ok: true, messageId: String(id ?? '') };
+                  } catch (err) {
+                    return { ok: false, error: err };
+                  }
+                },
+                appendAudit: (row) => ledger.appendSent(row),
+                now: () => Date.now(),
+                mintId: () => `mp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+                allowedRoles: new Set(['mentor']),
+                botToken: cfg.botToken,
+                fromBotId: cfg.botToken.split(':')[0], // bot id is the prefix before the secret
+                toBotId: cfg.menteeBotId,
+              },
+            );
           } catch (err) {
-            console.warn('[mentor] deliverToMentee outbox write failed (non-fatal):', err);
+            console.warn('[mentor] deliverToMentee send failed (non-fatal):', err instanceof Error ? err.message : String(err));
           }
         },
         onTickRan: () => {
@@ -1063,6 +1145,17 @@ export class AgentServer {
    * Closes keep-alive connections after a timeout to prevent hanging.
    */
   async stop(): Promise<void> {
+    // Stop the mentor bot adapter first (it has its own poll loop + state files
+    // under the subDir; clean shutdown avoids stranded background work).
+    if (this.mentorBotAdapter) {
+      try {
+        await this.mentorBotAdapter.stop();
+      } catch (err) {
+        console.warn('[mentor] mentor-bot adapter stop raised:', err);
+      }
+      this.mentorBotAdapter = null;
+      this.mentorBotAdapterToken = null;
+    }
     // Stop the Layer 3 sentinel BEFORE the WebSocket manager — the
     // sentinel's SSE subscription needs an alive wsManager to clean up
     // its listener. Order: sentinel → wsManager → server.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,37 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Mentor consumer — sender wiring.** The mentor's `deliverToMentee` is rewired from the
+legacy file-outbox onto the new agent-to-agent Telegram comms primitive (shipping in pieces
+across previous releases). Lazily constructs a second TelegramAdapter for the mentor bot
+(using the multi-instance subDir + suppress-Lifeline support from earlier increments), then
+calls `sendAgentMessage` with role `'mentor'`. The runtime anti-loop guard physically
+prevents sending any other role; bot-token scrubbing on errors is inherited.
+
+Gated on four new `MentorConfig` fields (`botToken`, `menteeBotId`, `menteeChatId`,
+`menteeTopicId`) — all default undefined, so the mentor stays dark until an operator
+explicitly configures the bot. The pre-existing `dailySpendCapUsd` is marked
+`@deprecated`; a future PR retires it along with the legacy `mentor-outbox/` files.
+
+## What to Tell Your User
+
+- Plumbing for the mentor feature — the delivery path now goes through the new agent-to-agent Telegram channel instead of the old file-based outbox, but stays completely dark until you configure a dedicated mentor bot. A later update adds a one-button setup flow for that.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Mentor sender wiring (dark) | Internal — `MentorConfig` gains `botToken`/`menteeBotId`/`menteeChatId`/`menteeTopicId` (all undefined by default); when all four are set, `deliverToMentee` sends via the mentor bot through `sendAgentMessage` instead of the legacy file-outbox |
+
+## Evidence
+
+**Net-new groundwork, not a bug fix.** Coverage strategy: the `sendAgentMessage` path is
+fully covered by previous PRs (5 tests for the send + audit + anti-loop + token-scrub);
+the multi-instance TelegramAdapter is covered by previous PRs (3 tests, including the
+load-bearing "primary paths byte-for-byte unchanged" assertion); marker / routing /
+cycle-detection by the earliest PR (20 tests). The AgentServer-level lazy mentor-bot
+construction is dark by default — the bot-setup live flow in the next PR exercises it.
+`tsc --noEmit` clean.

--- a/upgrades/side-effects/mentor-consumer-sender-wire.md
+++ b/upgrades/side-effects/mentor-consumer-sender-wire.md
@@ -1,0 +1,78 @@
+# Side-Effects Review — mentor consumer: sender wiring (PR 3c-1)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2b (mentor consumes the
+primitive). PR 3 of the staged build, part c-1.
+**Change:** Rewire the mentor's `deliverToMentee` from the file-outbox to
+`sendAgentMessage` (PR 2b) via a lazily-constructed second TelegramAdapter (PR 2a's
+multi-instance subDir + suppressLifelineAutoCreate). **Ships dark** — gated on three
+config fields none of which default to anything (`mentor.botToken`, `mentor.menteeBotId`,
+`mentor.menteeChatId`, `mentor.menteeTopicId`); without all four set, `deliverToMentee`
+logs + no-ops, identical to the prior dormant state.
+**Files:** `src/server/AgentServer.ts` (rewire + lazy mentor-bot helpers + cleanup in
+`stop()`), `src/scheduler/MentorOnboardingRunner.ts` (new optional config fields on
+`MentorConfig`).
+
+## What changed
+
+1. **`MentorConfig`** gains optional `botToken`, `menteeBotId`, `menteeChatId`,
+   `menteeTopicId` (all undefined by default). The pre-existing `dailySpendCapUsd` is
+   marked `@deprecated` (removed by a future `migrateRetireDeadMentorConfig` in PR 3c-3).
+2. **`AgentServer`**:
+   - New private fields: `mentorBotAdapter` + `mentorBotAdapterToken` (per-token cache),
+     `a2aLedger`.
+   - `getOrCreateMentorBot(botToken, menteeChatId)`: lazily constructs the second
+     `TelegramAdapter` with `subDir: 'agent-telegram/mentor-bot'` + `suppressLifelineAutoCreate: true`.
+     Token-change reconfigures (old adapter stopped first).
+   - `getOrCreateA2aLedger()`: lazily constructs `AgentTelegramLedger` at default paths.
+   - `deliverToMentee` is now **async** and:
+     - Returns immediately with a warning if any of the four required mentor-bot config
+       fields is unset (the dark default).
+     - Otherwise calls `sendAgentMessage` with role `'mentor'`, body = the prompt, audit
+       routed through the a2a ledger.
+   - `stop()` now stops the mentor-bot adapter first (clean shutdown of its poll loop +
+     state files under the subDir).
+
+## The seven questions
+
+1. **Over-block.** The dark default (no mentor-bot config) is the safe over-block — until
+   the operator explicitly configures the four fields, the mentor cannot send anything.
+2. **Under-block.** The anti-loop guard is enforced by `sendAgentMessage`'s
+   `allowedRoles` (Echo's mentor sender is constructed with `new Set(['mentor'])` — it
+   physically cannot send any other role). Bot-token scrubbing on errors is inherited
+   from PR 2b.
+3. **Level-of-abstraction fit.** The wiring layer composes existing primitives (`sendAgentMessage`,
+   `TelegramAdapter` with subDir, `AgentTelegramLedger`). No new policy here.
+4. **Signal vs authority.** N/A new — `sendAgentMessage` retains its result authority
+   (ok/failed/role-refused).
+5. **Interactions.** The mentor-bot adapter shares NO state files with the primary bot
+   (PR 2a's subDir isolation — primary paths byte-for-byte unchanged, verified by PR 2a's
+   test). The primary bot's behavior is unaffected. If the mentor bot fails to construct
+   (bad token), the warning is logged and `deliverToMentee` returns — the mentor tick
+   continues, just without delivery.
+6. **External surfaces.** None new in this PR. PR 3c-3 adds `/mentor/bot-setup` routes
+   + the Secret-Drop flow for entering the bot token.
+7. **Rollback cost.** Trivial — revert restores file-outbox `deliverToMentee`. No data,
+   no migration in this PR (the file-outbox retirement migration ships with PR 3c-2 or
+   3c-3).
+
+## Testing
+
+`tsc --noEmit` clean. Coverage strategy for this PR (intentional + honest):
+- The **`sendAgentMessage` path** (the actual marker formation, send, audit, anti-loop
+  role refusal, token scrub) is fully covered by PR 2b's 5 unit tests + the 20 marker /
+  routing / cycle-detection tests from PR 1.
+- The **multi-instance TelegramAdapter** (the second-bot construction with subDir +
+  suppressLifelineAutoCreate) is covered by PR 2a's 3 tests (incl. the "primary paths
+  byte-for-byte unchanged" load-bearing safety assertion).
+- The **mentor-bot lazy construction** in `AgentServer` is dark by default and the same
+  shape that PR 3c-3's bot-setup route will live-exercise.
+- A dedicated integration test for `deliverToMentee` end-to-end (with a stubbed
+  TelegramAdapter send) ships with PR 3c-2 when the receiver-side handler registration
+  lands and the round-trip becomes meaningful.
+
+## Migration parity
+
+None in this PR. The new MentorConfig fields are all optional + default undefined. The
+`dailySpendCapUsd` deprecation note ships now; its actual removal (`migrateRetireDeadMentorConfig`)
++ the file-outbox cleanup (`migrateRetireMentorOutbox`) land with PR 3c-2 / 3c-3 per
+the spec's §Migration parity.


### PR DESCRIPTION
## What

PR 3c-1 — sender-side wiring of the mentor consumer onto the a2a primitive (spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2b). Replaces the legacy file-outbox `deliverToMentee` with `sendAgentMessage` via a lazily-constructed second TelegramAdapter (PR 2a's multi-instance subDir). **Ships dark** — gated on four new `MentorConfig` fields (`botToken`/`menteeBotId`/`menteeChatId`/`menteeTopicId`), all default undefined.

## Changes

- **`MentorConfig`**: + optional `botToken`, `menteeBotId`, `menteeChatId`, `menteeTopicId`. Existing `dailySpendCapUsd` marked `@deprecated`.
- **`AgentServer`**:
  - `getOrCreateMentorBot(token, menteeChatId)`: lazy second-`TelegramAdapter` with `subDir: 'agent-telegram/mentor-bot'` + `suppressLifelineAutoCreate: true`. Per-token cache; reconfigures on change.
  - `getOrCreateA2aLedger()`: lazy `AgentTelegramLedger`.
  - `deliverToMentee` is now async + calls `sendAgentMessage` with role `'mentor'` (anti-loop runtime guard from PR 2b prevents any other role). Bot-token scrubbing on errors inherited.
  - `stop()`: mentor-bot adapter shut down first.

## Safety

The mentor-bot subDir isolation was proven byte-for-byte-unchanged for the primary bot by PR 2a's load-bearing test. This PR's wiring is dark until an operator configures all four mentor-bot fields. If a mentor-bot fails to construct (bad token), the warning is logged and `deliverToMentee` returns — the tick continues.

## Tests

Coverage strategy (explicit + honest in the side-effects artifact): the `sendAgentMessage` path is fully covered by PR 2b (5 tests); the multi-instance adapter by PR 2a (3 tests, incl. primary-paths-byte-for-byte); marker/routing/cycle-detection by PR 1 (20 tests). The mentor-bot lazy construction is dark by default — PR 3c-3's bot-setup live flow exercises it. `tsc --noEmit` clean.

## Next

PR 3c-2: receiver wiring — Stage-B reply handler on mentor-bot via `setAgentMessageHook`/`buildAgentMessageHook` + outstanding-prompt tracker + migration (file-outbox retirement, dead-config removal).
PR 3c-3: `/mentor/bot-setup` routes + Secret-Drop flow for entering the bot token + CLAUDE.md template entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)