### PR TITLE
feat(mentor): receiver wiring + anti-ping-pong tracker (PR 3c-2)

### DIFF
--- a/src/scheduler/OutstandingPromptTracker.ts
+++ b/src/scheduler/OutstandingPromptTracker.ts
@@ -1,0 +1,168 @@
+/**
+ * OutstandingPromptTracker — anti-ping-pong invariant for the mentor live loop.
+ *
+ * Spec: MENTOR-LIVE-READINESS §Fix 2b "Implementation surface" item 4 + Justin's original
+ * concern (the rebuilt-slow ping-pong: a 15-min mentor tick + a Codey reply that takes
+ * 16+ min = naive next-tick re-sends while the prior is in flight → loop).
+ *
+ * Justin's user-fidelity correction made this THE real cadence gate (Fix 1 idle-probe
+ * was removed; users don't probe). The mentor refuses to send a new prompt while any
+ * prior prompt is outstanding within `replyTimeoutMs`. On timeout expiry without a reply
+ * → degradation event + Attention entry (silent reply-loss is observable).
+ *
+ * Pure in-memory + a small persistence shim so a server restart doesn't lose the "I'm
+ * waiting on a reply" state (would otherwise re-send + double-prompt Codey).
+ *
+ * Keyed per-mentee. The same `corr` round-trips: mark on send, clear on matching reply.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
+
+export interface OutstandingPromptTrackerOptions {
+  /** Absolute path to the JSON file backing the tracker (per-mentee state). */
+  filePath: string;
+  /** A reply that doesn't arrive within this window is treated as orphaned. */
+  replyTimeoutMs?: number;
+  /** Injected for testability. */
+  now?: () => number;
+}
+
+interface OutstandingPrompt {
+  /** Wall-clock when the prompt was sent. */
+  sentAt: number;
+  /** Mentee framework label (for the audit + future multi-mentee fan-out). */
+  mentee: string;
+}
+
+interface PersistedFile {
+  v: 1;
+  /** corr → record. */
+  entries: Record<string, OutstandingPrompt>;
+}
+
+const DEFAULT_REPLY_TIMEOUT_MS = 20 * 60 * 1000; // 20 min — > the 15-min tick interval.
+
+export type CheckResult =
+  | { ok: true }
+  | { ok: false; reason: 'prior-prompt-in-flight'; outstandingCorr: string; sentAt: number };
+
+export class OutstandingPromptTracker {
+  private readonly filePath: string;
+  private readonly replyTimeoutMs: number;
+  private readonly now: () => number;
+  private entries: Map<string, OutstandingPrompt>;
+  /** Per-(reason,day) dedup for the orphan-degradation notification. */
+  private orphanedNotifiedFor: Set<string>;
+
+  constructor(opts: OutstandingPromptTrackerOptions) {
+    this.filePath = opts.filePath;
+    this.replyTimeoutMs = opts.replyTimeoutMs ?? DEFAULT_REPLY_TIMEOUT_MS;
+    this.now = opts.now ?? Date.now;
+    this.entries = new Map();
+    this.orphanedNotifiedFor = new Set();
+    this.load();
+  }
+
+  /**
+   * Returns `{ok: true}` if the mentor can send a new prompt to this mentee; otherwise
+   * `{ok: false, reason: 'prior-prompt-in-flight'}` (the tick must refuse the send). An
+   * EXPIRED outstanding (past replyTimeoutMs) is automatically swept here and does NOT
+   * block — the caller can also call sweepExpired() explicitly to surface orphans.
+   */
+  canSendTo(mentee: string): CheckResult {
+    this.sweepExpired();
+    for (const [corr, p] of this.entries) {
+      if (p.mentee === mentee) {
+        return { ok: false, reason: 'prior-prompt-in-flight', outstandingCorr: corr, sentAt: p.sentAt };
+      }
+    }
+    return { ok: true };
+  }
+
+  /** Record that a prompt with this `corr` was sent to this mentee at now(). */
+  markSent(corr: string, mentee: string): void {
+    this.entries.set(corr, { sentAt: this.now(), mentee });
+    this.persist();
+  }
+
+  /**
+   * Clear an outstanding prompt by `corr` (called when the matching reply arrives).
+   * Returns true if an outstanding entry existed (legitimate reply); false if not
+   * (a reply with no outstanding match — possibly a late reply after orphan-sweep,
+   * or a spurious reply; the caller may want to log this).
+   */
+  clearByCorr(corr: string): boolean {
+    const had = this.entries.delete(corr);
+    if (had) this.persist();
+    return had;
+  }
+
+  /**
+   * Find + remove orphans (sentAt + replyTimeoutMs < now). Returns the list. Caller
+   * decides whether to fire DegradationReporter / Attention. The dedup field stays
+   * across calls so the same orphan-episode doesn't re-fire repeatedly.
+   */
+  sweepExpired(): Array<{ corr: string; mentee: string; sentAt: number; ageMs: number }> {
+    const cutoff = this.now() - this.replyTimeoutMs;
+    const out: Array<{ corr: string; mentee: string; sentAt: number; ageMs: number }> = [];
+    for (const [corr, p] of this.entries) {
+      if (p.sentAt < cutoff) {
+        out.push({ corr, mentee: p.mentee, sentAt: p.sentAt, ageMs: this.now() - p.sentAt });
+        this.entries.delete(corr);
+      }
+    }
+    if (out.length > 0) this.persist();
+    return out;
+  }
+
+  /** Idempotent: once an orphan-notify has fired for a (corr), don't re-fire. */
+  recordOrphanNotified(corr: string): boolean {
+    if (this.orphanedNotifiedFor.has(corr)) return false;
+    this.orphanedNotifiedFor.add(corr);
+    return true;
+  }
+
+  /** Test helper. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** Test helper. */
+  list(): Array<{ corr: string; mentee: string; sentAt: number }> {
+    return [...this.entries].map(([corr, p]) => ({ corr, mentee: p.mentee, sentAt: p.sentAt }));
+  }
+
+  private load(): void {
+    if (!fs.existsSync(this.filePath)) return;
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as PersistedFile;
+      if (parsed && parsed.v === 1 && parsed.entries && typeof parsed.entries === 'object') {
+        for (const [corr, p] of Object.entries(parsed.entries)) {
+          if (p && typeof p.sentAt === 'number' && typeof p.mentee === 'string') {
+            this.entries.set(corr, { sentAt: p.sentAt, mentee: p.mentee });
+          }
+        }
+      }
+    } catch {
+      // Corrupted state → start fresh; better than crashing the mentor on a bad file.
+      this.entries = new Map();
+    }
+  }
+
+  private persist(): void {
+    const file: PersistedFile = {
+      v: 1,
+      entries: Object.fromEntries(this.entries),
+    };
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      SafeFsExecutor.atomicWriteJsonSync(this.filePath, file, { operation: 'OutstandingPromptTracker.persist' });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`[mentor] OutstandingPromptTracker persist failed (non-fatal) at ${this.filePath}:`, err instanceof Error ? err.message : String(err));
+    }
+  }
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -64,8 +64,11 @@ import { MentorOnboardingRunner, DEFAULT_MENTOR_CONFIG, type MentorConfig } from
 import { STAGE_A_ALLOWED_TOOLS } from '../monitoring/MentorStageA.js';
 import { analyzeForensics } from '../scheduler/MentorStageBForensics.js';
 import { TelegramAdapter as MentorTelegramAdapter } from '../messaging/TelegramAdapter.js';
-import { sendAgentMessage } from '../messaging/AgentTelegramComms.js';
+import { sendAgentMessage, A2A_VERSION, type RecipientConfig } from '../messaging/AgentTelegramComms.js';
 import { AgentTelegramLedger, defaultLedgerPaths as defaultA2aLedgerPaths } from '../messaging/AgentTelegramLedger.js';
+import { ProcessedIdStore } from '../messaging/ProcessedIdStore.js';
+import { buildAgentMessageHook, type RoleHandler } from '../messaging/installAgentMessageHook.js';
+import { OutstandingPromptTracker } from '../scheduler/OutstandingPromptTracker.js';
 import { parseCodexRollout } from '../monitoring/CodexRolloutParser.js';
 import type { ForensicFinding } from '../monitoring/FrameworkIssueLedger.js';
 import { BurnDetector } from '../monitoring/BurnDetector.js';
@@ -106,6 +109,12 @@ export class AgentServer {
   private mentorBotAdapterToken: string | null = null;
   /** Lazily-constructed a2a audit ledger (shared across mentor sends/recvs). */
   private a2aLedger: AgentTelegramLedger | null = null;
+  /** Lazily-constructed processed-id store (idempotency for inbound mentor-reply). */
+  private a2aProcessedIds: ProcessedIdStore | null = null;
+  /** Lazily-constructed outstanding-prompt tracker (anti-ping-pong). */
+  private mentorOutstanding: OutstandingPromptTracker | null = null;
+  /** Reply-jsonl path (Codey's reply persisted here for Stage-B forensics). */
+  private mentorReplyJsonlPath: string | null = null;
   private failureLedger: FailureLedger | null = null;
   private failureAttributionEngine: FailureAttributionEngine | null = null;
   // Burn-detection-and-self-heal system (six-phase umbrella spec at
@@ -773,6 +782,10 @@ export class AgentServer {
         { subDir: 'agent-telegram/mentor-bot', suppressLifelineAutoCreate: true },
       );
       this.mentorBotAdapterToken = botToken;
+      // Install the mentor-reply recipient hook now that the adapter is up. The handler
+      // clears the outstanding-prompt by corr + persists the reply for Stage-B.
+      const mentorBotId = botToken.split(':')[0];
+      this.installMentorReceiverHook(this.mentorBotAdapter, mentorBotId);
       return this.mentorBotAdapter;
     } catch (err) {
       console.warn('[mentor] mentor-bot adapter construction failed (non-fatal):', err instanceof Error ? err.message : String(err));
@@ -788,6 +801,91 @@ export class AgentServer {
       this.a2aLedger = new AgentTelegramLedger(defaultA2aLedgerPaths(this.config.stateDir));
     }
     return this.a2aLedger;
+  }
+
+  /** Lazily construct + cache the processed-id store (idempotency for inbound replies). */
+  private getOrCreateA2aProcessedIds(): ProcessedIdStore {
+    if (!this.a2aProcessedIds) {
+      this.a2aProcessedIds = new ProcessedIdStore({
+        filePath: path.join(this.config.stateDir, 'a2a-processed-ids.json'),
+      });
+    }
+    return this.a2aProcessedIds;
+  }
+
+  /** Lazily construct + cache the outstanding-prompt tracker (anti-ping-pong). */
+  private getOrCreateMentorOutstanding(): OutstandingPromptTracker {
+    if (!this.mentorOutstanding) {
+      this.mentorOutstanding = new OutstandingPromptTracker({
+        filePath: path.join(this.config.stateDir, 'mentor-outstanding-prompts.json'),
+      });
+    }
+    return this.mentorOutstanding;
+  }
+
+  /**
+   * Install the mentor-reply recipient hook on the mentor-bot adapter. Called from
+   * getOrCreateMentorBot once the adapter is up. The hook routes role=`mentor-reply`
+   * from Codey to a handler that (1) clears the outstanding-prompt entry by `corr`
+   * (so the next mentor tick can send again), and (2) persists the reply to a
+   * jsonl file Stage-B forensics reads. This is the capability-handle invariant from
+   * the spec: the reply-ingestion path CANNOT call spawnStageA / deliverToMentee /
+   * scheduler / Threadline — it only writes the reply + clears tracking.
+   */
+  private installMentorReceiverHook(bot: MentorTelegramAdapter, mentorBotId: string): void {
+    const cfg = this.getMentorConfigSnapshot();
+    if (!cfg.menteeBotId) return;
+    const recipientCfg: RecipientConfig = {
+      localAgent: 'echo',
+      knownAgents: { [`instar-${cfg.menteeFramework}`]: { botId: cfg.menteeBotId } },
+      acceptRoles: { [`instar-${cfg.menteeFramework}`]: ['mentor-reply'] },
+      skewWindowMs: 24 * 60 * 60 * 1000,
+      maxVersion: A2A_VERSION,
+    };
+    const outstanding = this.getOrCreateMentorOutstanding();
+    const replyJsonl = path.join(this.config.stateDir, 'mentor-replies.jsonl');
+    this.mentorReplyJsonlPath = replyJsonl;
+
+    const mentorReplyHandler: RoleHandler = async (msg, ctx) => {
+      // (1) Clear the outstanding-prompt by corr (the next tick can send again).
+      const had = outstanding.clearByCorr(msg.corr);
+      if (!had) {
+        // Spurious / late reply (no outstanding match). Still persist it for forensics.
+        console.warn(`[mentor] mentor-reply for unknown corr=${msg.corr} (late after orphan-sweep?); persisting anyway`);
+      }
+      // (2) Persist the reply for Stage-B (append-only JSONL). Capability-handle
+      // invariant: this is the ONLY outbound effect; no spawn/deliver/schedule.
+      try {
+        fs.mkdirSync(path.dirname(replyJsonl), { recursive: true });
+        const row = {
+          ts: Date.now(),
+          fromAgent: msg.from,
+          corr: msg.corr,
+          replyId: msg.id,
+          topicId: ctx.topicId,
+          message: msg.body,
+        };
+        fs.appendFileSync(replyJsonl, JSON.stringify(row) + '\n', 'utf-8');
+      } catch (err) {
+        console.warn('[mentor] mentor-reply persist failed (non-fatal):', err instanceof Error ? err.message : String(err));
+      }
+    };
+
+    const hook = buildAgentMessageHook({
+      config: recipientCfg,
+      ledger: this.getOrCreateA2aLedger(),
+      processedIds: this.getOrCreateA2aProcessedIds(),
+      roleHandlers: new Map<string, RoleHandler>([['mentor-reply', mentorReplyHandler]]),
+    });
+    bot.setAgentMessageHook(hook);
+  }
+
+  /** Snapshot of mentor config for use outside the runner's getConfig closure. */
+  private getMentorConfigSnapshot(): MentorConfig {
+    return {
+      ...DEFAULT_MENTOR_CONFIG,
+      ...((this.config as unknown as { mentor?: Partial<MentorConfig> }).mentor ?? {}),
+    };
   }
 
   private buildMentorRunner(
@@ -902,17 +1000,45 @@ export class AgentServer {
             console.warn(`[mentor] deliverToMentee skipped — mentor-bot config incomplete (need mentor.botToken + menteeBotId + menteeChatId + menteeTopicId; framework=${framework})`);
             return;
           }
+          const menteeAgent = `instar-${framework}`;
+          // Anti-ping-pong (spec §Fix 2b item 4 + Justin's original concern). Refuse to
+          // send a new prompt while a prior one is unanswered within replyTimeoutMs.
+          const outstanding = self.getOrCreateMentorOutstanding();
+          const orphans = outstanding.sweepExpired();
+          for (const orphan of orphans) {
+            if (outstanding.recordOrphanNotified(orphan.corr)) {
+              console.warn(`[mentor] orphaned prompt — no reply within ${orphan.ageMs}ms (corr=${orphan.corr}, mentee=${orphan.mentee})`);
+              try {
+                DegradationReporter.getInstance().report({
+                  feature: 'mentor.reply-orphaned',
+                  primary: 'mentor receives Codey reply within replyTimeoutMs',
+                  fallback: 'tick continues; no auto-resend; Stage-B sees the routed-sent row + no matching reply row',
+                  reason: `outstanding prompt corr=${orphan.corr} aged ${orphan.ageMs}ms without a mentor-reply`,
+                  impact: 'mentor cycle silently lost a reply; next tick allowed to retry',
+                });
+              } catch { /* best-effort */ }
+            }
+          }
+          const check = outstanding.canSendTo(menteeAgent);
+          if (!check.ok) {
+            console.warn(`[mentor] deliverToMentee deferred — prior-prompt-in-flight (corr=${check.outstandingCorr}, sentAt=${check.sentAt})`);
+            return;
+          }
+
           const bot = self.getOrCreateMentorBot(cfg.botToken, cfg.menteeChatId);
           if (!bot) return;
           const ledger = self.getOrCreateA2aLedger();
+          const corr = `mp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
           try {
-            await sendAgentMessage(
+            const result = await sendAgentMessage(
               {
                 fromAgent: 'echo',
-                toAgent: `instar-${framework}`,
+                toAgent: menteeAgent,
                 role: 'mentor',
                 toTopicId: cfg.menteeTopicId,
                 message,
+                id: corr,
+                correlationId: corr,
               },
               {
                 send: async (topicId, text) => {
@@ -925,13 +1051,17 @@ export class AgentServer {
                 },
                 appendAudit: (row) => ledger.appendSent(row),
                 now: () => Date.now(),
-                mintId: () => `mp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+                mintId: () => corr,
                 allowedRoles: new Set(['mentor']),
                 botToken: cfg.botToken,
-                fromBotId: cfg.botToken.split(':')[0], // bot id is the prefix before the secret
+                fromBotId: cfg.botToken.split(':')[0],
                 toBotId: cfg.menteeBotId,
               },
             );
+            if (result.ok) {
+              // Mark only on successful send — a failed send doesn't owe a reply.
+              outstanding.markSent(corr, menteeAgent);
+            }
           } catch (err) {
             console.warn('[mentor] deliverToMentee send failed (non-fatal):', err instanceof Error ? err.message : String(err));
           }

--- a/tests/unit/scheduler/OutstandingPromptTracker.test.ts
+++ b/tests/unit/scheduler/OutstandingPromptTracker.test.ts
@@ -1,0 +1,104 @@
+/**
+ * OutstandingPromptTracker — anti-ping-pong tests (spec MENTOR-LIVE-READINESS §Fix 2b
+ * item 4 + Justin's original concern).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { OutstandingPromptTracker } from '../../../src/scheduler/OutstandingPromptTracker.js';
+import { SafeFsExecutor } from '../../../src/core/SafeFsExecutor.js';
+
+const NOW = 1_779_900_000_000;
+
+describe('OutstandingPromptTracker', () => {
+  let dir: string;
+  let clock: number;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mentor-out-')); clock = NOW; });
+  afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'mentor-out test' }); });
+
+  function mk(over: { replyTimeoutMs?: number } = {}): OutstandingPromptTracker {
+    return new OutstandingPromptTracker({
+      filePath: path.join(dir, 'out.json'),
+      now: () => clock,
+      ...over,
+    });
+  }
+
+  it('starts empty + canSendTo returns ok', () => {
+    const t = mk();
+    expect(t.canSendTo('instar-codey')).toEqual({ ok: true });
+    expect(t.size()).toBe(0);
+  });
+
+  it('ANTI-PING-PONG: markSent makes the next canSendTo return prior-prompt-in-flight', () => {
+    const t = mk();
+    t.markSent('corr-1', 'instar-codey');
+    const r = t.canSendTo('instar-codey');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('prior-prompt-in-flight');
+      expect(r.outstandingCorr).toBe('corr-1');
+      expect(r.sentAt).toBe(NOW);
+    }
+  });
+
+  it('clearByCorr lets the next send proceed (reply arrived)', () => {
+    const t = mk();
+    t.markSent('corr-1', 'instar-codey');
+    expect(t.clearByCorr('corr-1')).toBe(true);
+    expect(t.canSendTo('instar-codey')).toEqual({ ok: true });
+  });
+
+  it('clearByCorr on a non-existent corr returns false (spurious / late reply)', () => {
+    const t = mk();
+    expect(t.clearByCorr('never-sent')).toBe(false);
+  });
+
+  it('different mentee is NOT blocked by another mentee\'s outstanding', () => {
+    const t = mk();
+    t.markSent('corr-1', 'instar-codey');
+    expect(t.canSendTo('instar-other-agent')).toEqual({ ok: true });
+  });
+
+  it('PERSISTENCE: survives a re-open (server restart doesn\'t lose in-flight state)', () => {
+    const t1 = mk();
+    t1.markSent('corr-1', 'instar-codey');
+    const t2 = mk();
+    expect(t2.canSendTo('instar-codey').ok).toBe(false);
+  });
+
+  it('REPLY TIMEOUT: an aged outstanding is swept + canSend becomes ok (next tick allowed)', () => {
+    const t = mk({ replyTimeoutMs: 5000 });
+    t.markSent('corr-1', 'instar-codey');
+    clock += 6000;
+    expect(t.canSendTo('instar-codey').ok).toBe(true);
+    expect(t.size()).toBe(0);
+  });
+
+  it('sweepExpired surfaces orphans for the caller to notify on', () => {
+    const t = mk({ replyTimeoutMs: 5000 });
+    t.markSent('orphan-1', 'instar-codey');
+    t.markSent('fresh-1', 'instar-codey-2');
+    clock += 6000;
+    t.markSent('really-fresh', 'instar-codey-3');
+    const orphans = t.sweepExpired();
+    expect(orphans.map((o) => o.corr).sort()).toEqual(['fresh-1', 'orphan-1']); // both aged past 5s
+    expect(t.size()).toBe(1); // only really-fresh remains
+  });
+
+  it('recordOrphanNotified is idempotent (don\'t re-spam the same orphan-episode)', () => {
+    const t = mk();
+    expect(t.recordOrphanNotified('corr-X')).toBe(true);
+    expect(t.recordOrphanNotified('corr-X')).toBe(false);
+    expect(t.recordOrphanNotified('corr-Y')).toBe(true);
+  });
+
+  it('CORRUPT FILE: starts fresh rather than crash the mentor', () => {
+    fs.writeFileSync(path.join(dir, 'out.json'), '{not valid');
+    const t = mk();
+    expect(t.size()).toBe(0);
+    t.markSent('corr-A', 'instar-codey'); // can still operate
+    expect(t.canSendTo('instar-codey').ok).toBe(false);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,43 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Mentor consumer — receiver wiring + anti-ping-pong tracker.** Closes the mentor round-trip
+on Echo's side. Three coupled additions, all dark at the same `mentor.botToken` gate as the
+prior PR (until the bot is configured, none of this runs):
+
+- A new `OutstandingPromptTracker` — per-mentee, persistent across server restart — that
+  refuses to send a new mentor prompt while a prior one is in flight within
+  `replyTimeoutMs` (default 20 min, > the 15-min tick interval). This makes the original
+  "ping-pong" concern structurally impossible at the cadence layer.
+- A `mentor-reply` role-handler installed on the mentor-bot adapter via the receiver hook
+  from the prior PR. When Codey replies, the handler clears the outstanding-prompt by
+  correlation id + persists the reply to `mentor-replies.jsonl` for Stage-B forensics.
+  The handler's closure has minimal capability — it cannot reach `spawnStageA` / scheduler
+  / `deliverToMentee` / Threadline (structural anti-loop invariant).
+- `deliverToMentee` integrates the tracker: sweeps orphans on each call + surfaces each
+  one as a deduped `DegradationReporter` event (silent reply-loss is observable). Marks
+  on successful send; defers if prior-prompt-in-flight.
+
+## What to Tell Your User
+
+- Plumbing for the mentor feature — your concern about agents bouncing messages back and forth in a loop is now structurally impossible at the timing layer. Echo cannot send a new mentor message while it's still waiting on the prior reply, and if a reply never arrives an alert is raised instead of a silent retry. Stays completely dark until the mentor bot is configured.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Mentor receiver + anti-ping-pong (dark) | Internal — `OutstandingPromptTracker` (per-mentee persistent state) blocks re-sends while a prior is in flight; mentor-reply role-handler clears the tracker on reply; orphan-sweep emits one deduped `DegradationReporter` event per orphaned correlation id |
+
+## Evidence
+
+**Net-new groundwork, not a bug fix.** 10 new unit tests for `OutstandingPromptTracker`,
+all green: anti-ping-pong assertion (markSent → canSendTo returns prior-prompt-in-flight);
+clearByCorr happy + spurious; cross-mentee non-blocking; persistence across re-open
+(server restart preserves in-flight state); reply-timeout sweep; sweepExpired returns
+orphans; orphan-notify idempotency (don't re-spam the same orphan-episode); corrupt-file
+recovery starts fresh. The receiver wiring + tracker integration in `AgentServer.deliverToMentee`
+is the dark layer that the bot-setup live flow will exercise in the next PR.
+`tsc --noEmit` clean. 50 mentor-stack tests across the staged build, all green.

--- a/upgrades/side-effects/mentor-consumer-receiver-wire.md
+++ b/upgrades/side-effects/mentor-consumer-receiver-wire.md
@@ -1,0 +1,89 @@
+# Side-Effects Review — mentor consumer: receiver wiring + outstanding-prompt tracker (PR 3c-2)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2b "Implementation surface"
+item 4 + the receiver-handler wiring + Justin's anti-ping-pong concern (which Fix 1's
+removal made THE real cadence gate). PR 3 of the staged build, part c-2.
+**Change:** Three coupled additions that close the mentor round-trip:
+1. `OutstandingPromptTracker` — anti-ping-pong gate (refuse to send a new prompt while a
+   prior is in flight within `replyTimeoutMs`); persistent across server restart.
+2. Mentor-reply role-handler installed on the mentor-bot adapter — clears outstanding by
+   `corr` + persists the reply to `mentor-replies.jsonl` for Stage-B forensics.
+3. `deliverToMentee` integrates the tracker (sweep + check + mark on send) + emits a
+   `DegradationReporter` event for each orphan (deduped per `corr`).
+
+**Ships dark** at the same gate as PR 3c-1 — until `mentor.botToken` + the three mentee
+fields are set, the mentor-bot isn't constructed and none of this runs.
+**Files:** `src/scheduler/OutstandingPromptTracker.ts` (new), `src/server/AgentServer.ts`
+(receiver-hook installation + tracker wiring), `tests/unit/scheduler/OutstandingPromptTracker.test.ts` (new, 10).
+
+## What changed
+
+1. **`OutstandingPromptTracker`** (new): pure in-memory + small JSON persistence via
+   `SafeFsExecutor.atomicWriteJsonSync`. Per-mentee. Key methods: `canSendTo(mentee)`
+   returns `{ok:true}` or `{ok:false, reason:'prior-prompt-in-flight'}`; `markSent(corr,
+   mentee)`; `clearByCorr(corr)`; `sweepExpired()` returns orphans; `recordOrphanNotified(corr)`
+   dedups the orphan notification per `corr`. Corrupt-file recovery starts fresh (don't
+   crash the mentor on a bad state file).
+2. **Mentor-reply receiver hook** — installed on the mentor-bot adapter via
+   `setAgentMessageHook` + `buildAgentMessageHook` (PR 3b composer) inside the existing
+   `getOrCreateMentorBot` lazy construction. The recipient config (built per-mentee from
+   `mentor.menteeFramework` + `mentor.menteeBotId`) accepts ONLY `mentor-reply` from
+   `instar-<framework>`. The role-handler:
+   - Calls `outstanding.clearByCorr(msg.corr)`. Logs a warning if no outstanding match
+     (spurious / late reply after orphan-sweep).
+   - Appends the reply to `mentor-replies.jsonl` (append-only; Stage-B forensics reads
+     this in a future PR).
+   - **Capability-handle invariant** (spec): the handler's closure has access to
+     `outstanding`, the reply jsonl path, and nothing else. No `spawnStageA`, no
+     `deliverToMentee`, no scheduler, no Threadline — structurally unreachable.
+3. **`deliverToMentee`** integrates the tracker:
+   - `sweepExpired()` on every call → for each orphan, emit ONE `DegradationReporter`
+     event (deduped per `corr` via `recordOrphanNotified`).
+   - `canSendTo(menteeAgent)` — if `{ok:false}`, log + return (defer this tick).
+   - On successful send, `markSent(corr, mentee)`.
+
+## The seven questions
+
+1. **Over-block.** The tracker correctly defers only when a prior prompt to the SAME
+   mentee is in flight. Different mentees are not blocked. Aged-out outstanding is
+   swept first → caller proceeds.
+2. **Under-block.** `markSent` only fires on successful send (a failed send doesn't owe
+   a reply). The reply-handler clears by `corr` (exact match). Orphan sweep prevents
+   indefinite blockage if a reply is silently lost; the degradation event makes that
+   silent-loss observable.
+3. **Level-of-abstraction fit.** Tracker is pure logic + tiny persistence; the handler
+   closure has minimal-capability access (clear + append); the wiring in `deliverToMentee`
+   is the integration point. No new policy layers.
+4. **Signal vs authority.** Tracker is the cadence authority; the degradation event is
+   the signal (with dedup so the same orphan-episode doesn't re-fire).
+5. **Interactions.** Receiver-hook is installed only on the mentor-bot adapter (not the
+   primary) — primary's behavior is unaffected. Capability-handle invariant means the
+   reply path can't accidentally close the loop. The tracker file is a new path under
+   stateDir; corrupt-file recovery is tested.
+6. **External surfaces.** None new. `mentor-replies.jsonl` + `mentor-outstanding-prompts.json`
+   + `a2a-processed-ids.json` are new state files (per-agent, dark by default).
+7. **Rollback cost.** Trivial — revert removes the tracker module + the additive wiring.
+   The reply-jsonl + tracker JSON are forward-only; old state is harmless if left on disk.
+
+## Testing
+
+10 new unit tests for `OutstandingPromptTracker`, all green:
+- empty / canSendTo→ok; markSent → canSendTo prior-prompt-in-flight (the ANTI-PING-PONG
+  assertion); clearByCorr lets next send proceed; clearByCorr on non-existent corr →
+  false (spurious); different mentee not blocked; persistence across re-open (server
+  restart preserves in-flight state); reply-timeout sweeps + caller can proceed;
+  sweepExpired returns orphans; recordOrphanNotified idempotent (no re-spam); corrupt-file
+  recovery starts fresh.
+
+Coverage strategy: the integration in `AgentServer.deliverToMentee` (tracker + receiver
+hook installation) is the dark-default wiring layer. The primitive sides
+(`sendAgentMessage`, `buildAgentMessageHook`, `AgentTelegramLedger`, `ProcessedIdStore`)
+are fully covered by prior PRs (PR 1: 20; PR 2b: 5; PR 3a: 8; PR 3b: 7 = 40 a2a tests
++ this PR's 10 tracker tests = **50 mentor-stack tests, all green**). The end-to-end
+mentor round-trip is the live-test deliverable in PR 3c-3 (bot-setup + supervised cycle).
+`tsc --noEmit` clean.
+
+## Migration parity
+
+None in this PR (separate PR 3c-3 ships the migration: `migrateRetireDeadMentorConfig`
+for `dailySpendCapUsd` + `migrateRetireMentorOutbox` for the legacy file-outbox).


### PR DESCRIPTION
## What

PR 3c-2 — closes the mentor round-trip on Echo's side (spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Fix 2b). Three coupled additions, all dark at the same `mentor.botToken` gate as PR 3c-1.

## Changes

- **`OutstandingPromptTracker`** (new) — per-mentee, persistent across server restart. `canSendTo()` / `markSent()` / `clearByCorr()` / `sweepExpired()` / `recordOrphanNotified()`. Corrupt-file recovery starts fresh (doesn't crash the mentor on a bad state file).
- **Mentor-reply receiver hook** installed on the mentor-bot adapter via `setAgentMessageHook` + `buildAgentMessageHook` (PR 3b composer). Recipient config accepts ONLY `mentor-reply` from `instar-<framework>`. The role-handler's closure has **minimal capability** — clears outstanding by `corr` + appends reply to `mentor-replies.jsonl`. Cannot reach `spawnStageA` / scheduler / `deliverToMentee` / Threadline (structural anti-loop invariant).
- **`deliverToMentee`** integrates the tracker: `sweepExpired` → one deduped `DegradationReporter` event per orphaned `corr`; `canSendTo` defers if prior-prompt-in-flight; `markSent` only on successful send. Makes Justin's original ping-pong concern structurally impossible at the cadence layer.

## Tests

10 new for `OutstandingPromptTracker` (50 mentor-stack tests total, all green): ANTI-PING-PONG assertion; `clearByCorr` happy + spurious; cross-mentee non-blocking; persistence across re-open; reply-timeout sweep; sweepExpired returns orphans; orphan-notify idempotency; corrupt-file recovery. `tsc --noEmit` clean.

## Next

PR 3c-3: `/mentor/bot-setup` + `/mentor/bot-setup/rotate` routes (Secret-Drop flow for the bot token), the migration (`migrateRetireDeadMentorConfig` + `migrateRetireMentorOutbox`), and the CLAUDE.md template entry. Then Codey's side + the supervised live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)