### PR TITLE
feat(migrate): mentor retirement — dead dailySpendCapUsd + legacy outbox (PR 3c-3)

### DIFF
--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -205,6 +205,8 @@ export class PostUpdateMigrator {
     this.migrateSettings(result);
     this.migrateConfig(result);
     this.migrateLegacyMaxSessions(result);
+    this.migrateRetireDeadMentorConfig(result);
+    this.migrateRetireMentorOutbox(result);
     this.migratePrPipelineArtifacts(result);
     this.migrateBackupManifest(result);
     this.migrateGitignore(result);
@@ -4077,6 +4079,141 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       } catch { /* audit log is best-effort */ }
     } catch (err) {
       result.errors.push(`legacy maxSessions migration write: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Retire `mentor.dailySpendCapUsd` — a config field that was DECORATIVE (read nowhere
+   * in code; spec MENTOR-LIVE-READINESS §Migration parity called it out as the
+   * silent-dead-config bug we shouldn't repeat at migration time). On a Claude
+   * subscription there's no per-token dollar charge to cap; the real budget is quota-
+   * aware (a separate future PR ships `mentor.stageBTokenCeiling`).
+   *
+   * Behavior:
+   *  - field absent → silent skip
+   *  - field present at the default (0.5) → silent delete (no warning)
+   *  - field present at a NON-default value → delete + LOUD `result.upgraded` entry with
+   *    a REVIEW prefix (operator never set this thinking it was enforced; they deserve
+   *    to know). Don't repeat the original silent-dead-config bug at migration time.
+   * Idempotent via the `_instar_migrations` marker.
+   */
+  private migrateRetireDeadMentorConfig(result: MigrationResult): void {
+    const configPath = path.join(this.config.stateDir, 'config.json');
+    if (!fs.existsSync(configPath)) {
+      result.skipped.push('mentor dailySpendCapUsd retirement (config.json not found)');
+      return;
+    }
+    let config: Record<string, unknown>;
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch (err) {
+      result.errors.push(`mentor dailySpendCapUsd retirement: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    const migrations = (config._instar_migrations ?? []) as string[];
+    const marker = 'mentor-dailySpendCapUsd-retire-v1';
+    if (migrations.some(m => m.startsWith(marker))) {
+      result.skipped.push('mentor dailySpendCapUsd retirement (already migrated)');
+      return;
+    }
+
+    const mentor = (config.mentor as Record<string, unknown> | undefined) ?? undefined;
+    if (!mentor || !('dailySpendCapUsd' in mentor)) {
+      // Field never present — mark + skip.
+      migrations.push(`${marker}-${new Date().toISOString()}`);
+      config._instar_migrations = migrations;
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      result.skipped.push('mentor dailySpendCapUsd retirement (field never present)');
+      return;
+    }
+
+    const value = mentor.dailySpendCapUsd;
+    const isDefault = value === 0.5;
+    delete mentor.dailySpendCapUsd;
+    config.mentor = mentor;
+    migrations.push(`${marker}-${new Date().toISOString()}`);
+    config._instar_migrations = migrations;
+    try {
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      if (isDefault) {
+        result.upgraded.push('mentor.dailySpendCapUsd retired (was default 0.5; field was decorative — never read)');
+      } else {
+        // LOUD prefix so the operator notices in post-update output (this is the
+        // "non-silent removal" the spec specifically calls for).
+        result.upgraded.push(
+          `REVIEW: mentor.dailySpendCapUsd=${JSON.stringify(value)} was retired. ` +
+          `The field was decorative (never enforced) — Echo runs on a Claude subscription, ` +
+          `so there is no per-token dollar charge to cap. A future update introduces ` +
+          `mentor.stageBTokenCeiling (quota-aware) as the real replacement. ` +
+          `If you set this value expecting enforcement, adjust your expectations accordingly.`
+        );
+      }
+    } catch (err) {
+      result.errors.push(`mentor dailySpendCapUsd retirement write: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Retire the legacy `{stateDir}/mentor-outbox/` directory — the file-based mentor
+   * delivery design that Justin's substrate correction replaced (spec MENTOR-LIVE-
+   * READINESS §Migration parity). The new mentor delivery goes through the agent-to-
+   * agent Telegram comms primitive (sendAgentMessage); the outbox files are now dead
+   * state and should be swept so they don't accumulate or mislead a future operator.
+   *
+   * Idempotent via the `_instar_migrations` marker. The first run deletes if present;
+   * subsequent runs are no-ops. Best-effort — a removal failure logs + continues.
+   */
+  private migrateRetireMentorOutbox(result: MigrationResult): void {
+    const configPath = path.join(this.config.stateDir, 'config.json');
+    if (!fs.existsSync(configPath)) {
+      // Still try to retire the outbox if present, even without config.json — but mark
+      // via state-file marker since we can't write to config. Simpler: skip entirely.
+      result.skipped.push('mentor outbox retirement (config.json not found)');
+      return;
+    }
+    let config: Record<string, unknown>;
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch (err) {
+      result.errors.push(`mentor outbox retirement: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+    const migrations = (config._instar_migrations ?? []) as string[];
+    const marker = 'mentor-outbox-retire-v1';
+    if (migrations.some(m => m.startsWith(marker))) {
+      result.skipped.push('mentor outbox retirement (already migrated)');
+      return;
+    }
+
+    const outboxDir = path.join(this.config.stateDir, 'mentor-outbox');
+    let removed = false;
+    let filesRemoved = 0;
+    if (fs.existsSync(outboxDir)) {
+      try {
+        // Count files before removing for the audit entry.
+        try {
+          filesRemoved = fs.readdirSync(outboxDir).length;
+        } catch { /* ignore, just for the audit */ }
+        SafeFsExecutor.safeRmSync(outboxDir, { recursive: true, force: true, operation: 'migrateRetireMentorOutbox' });
+        removed = true;
+      } catch (err) {
+        result.errors.push(`mentor outbox retirement removeSync failed: ${err instanceof Error ? err.message : String(err)}`);
+        // Don't mark migrated on failure — retry on next run.
+        return;
+      }
+    }
+
+    migrations.push(`${marker}-${new Date().toISOString()}`);
+    config._instar_migrations = migrations;
+    try {
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      if (removed) {
+        result.upgraded.push(`mentor-outbox directory retired (removed ${filesRemoved} file(s) — legacy file-based mentor delivery; replaced by the agent-to-agent Telegram comms primitive)`);
+      } else {
+        result.skipped.push('mentor outbox retirement (directory not present; marker set so we don\'t re-check)');
+      }
+    } catch (err) {
+      result.errors.push(`mentor outbox retirement marker write: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/unit/PostUpdateMigrator-mentor-retire.test.ts
+++ b/tests/unit/PostUpdateMigrator-mentor-retire.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the two mentor-retirement migrations (spec MENTOR-LIVE-READINESS
+ * §Migration parity):
+ *   - migrateRetireDeadMentorConfig — non-silent removal of mentor.dailySpendCapUsd
+ *     (silent when default, LOUD REVIEW prefix when non-default — don't repeat the
+ *     silent-dead-config bug at migration time).
+ *   - migrateRetireMentorOutbox — sweep the legacy {stateDir}/mentor-outbox/ files
+ *     (replaced by the a2a Telegram comms primitive).
+ *
+ * Both idempotent via the `_instar_migrations` marker.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function buildMigrator(projectDir: string): PostUpdateMigrator {
+  const stateDir = path.join(projectDir, '.instar');
+  fs.mkdirSync(stateDir, { recursive: true });
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir,
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function readConfig(stateDir: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(stateDir, 'config.json'), 'utf-8'));
+}
+
+function writeConfig(stateDir: string, config: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify(config, null, 2));
+}
+
+describe('PostUpdateMigrator.migrateRetireDeadMentorConfig', () => {
+  let projectDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-mentor-retire-'));
+    stateDir = path.join(projectDir, '.instar');
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'mentor-retire test' });
+  });
+
+  it('skips silently when mentor.dailySpendCapUsd is absent', () => {
+    const m = buildMigrator(projectDir);
+    writeConfig(stateDir, { mentor: { enabled: false } });
+    const result: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireDeadMentorConfig: (r: typeof result) => void }).migrateRetireDeadMentorConfig(result);
+    expect(result.errors).toEqual([]);
+    expect(result.skipped.some((s) => s.includes('never present'))).toBe(true);
+    // Marker set so subsequent runs short-circuit.
+    expect((readConfig(stateDir)._instar_migrations as string[])?.some((m) => m.startsWith('mentor-dailySpendCapUsd-retire-v1'))).toBe(true);
+  });
+
+  it('SILENTLY deletes the default value (0.5) — no LOUD warning when the user never changed it', () => {
+    const m = buildMigrator(projectDir);
+    writeConfig(stateDir, { mentor: { enabled: false, dailySpendCapUsd: 0.5 } });
+    const result: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireDeadMentorConfig: (r: typeof result) => void }).migrateRetireDeadMentorConfig(result);
+    const post = readConfig(stateDir);
+    expect((post.mentor as Record<string, unknown>).dailySpendCapUsd).toBeUndefined();
+    expect(result.upgraded[0]).toMatch(/dailySpendCapUsd retired/);
+    expect(result.upgraded[0]).not.toMatch(/REVIEW:/); // default value → no LOUD prefix
+  });
+
+  it('LOUDLY surfaces a non-default value with REVIEW: prefix (don\'t repeat the silent-dead-config bug)', () => {
+    const m = buildMigrator(projectDir);
+    writeConfig(stateDir, { mentor: { enabled: false, dailySpendCapUsd: 5.0 } });
+    const result: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireDeadMentorConfig: (r: typeof result) => void }).migrateRetireDeadMentorConfig(result);
+    const post = readConfig(stateDir);
+    expect((post.mentor as Record<string, unknown>).dailySpendCapUsd).toBeUndefined();
+    expect(result.upgraded[0]).toMatch(/^REVIEW:.*dailySpendCapUsd=5/);
+    expect(result.upgraded[0]).toMatch(/decorative.*never enforced/);
+    expect(result.upgraded[0]).toMatch(/subscription/);
+  });
+
+  it('IDEMPOTENT: a second run is a no-op', () => {
+    const m = buildMigrator(projectDir);
+    writeConfig(stateDir, { mentor: { dailySpendCapUsd: 0.5 } });
+    const r1: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireDeadMentorConfig: (r: typeof r1) => void }).migrateRetireDeadMentorConfig(r1);
+    expect(r1.upgraded.length).toBe(1);
+
+    const r2: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireDeadMentorConfig: (r: typeof r2) => void }).migrateRetireDeadMentorConfig(r2);
+    expect(r2.upgraded).toEqual([]);
+    expect(r2.skipped.some((s) => s.includes('already migrated'))).toBe(true);
+  });
+});
+
+describe('PostUpdateMigrator.migrateRetireMentorOutbox', () => {
+  let projectDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-mentor-outbox-'));
+    stateDir = path.join(projectDir, '.instar');
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'mentor-outbox test' });
+  });
+
+  it('removes the legacy mentor-outbox directory + records the file count', () => {
+    const m = buildMigrator(projectDir);
+    writeConfig(stateDir, {});
+    const outboxDir = path.join(stateDir, 'mentor-outbox');
+    fs.mkdirSync(outboxDir, { recursive: true });
+    fs.writeFileSync(path.join(outboxDir, 'codex-cli.jsonl'), '{}\n{}\n');
+    fs.writeFileSync(path.join(outboxDir, 'other.jsonl'), '{}\n');
+
+    const result: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireMentorOutbox: (r: typeof result) => void }).migrateRetireMentorOutbox(result);
+    expect(fs.existsSync(outboxDir)).toBe(false);
+    expect(result.upgraded[0]).toMatch(/mentor-outbox directory retired/);
+    expect(result.upgraded[0]).toMatch(/removed 2 file/);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('IDEMPOTENT: subsequent runs are no-ops (marker set)', () => {
+    const m = buildMigrator(projectDir);
+    writeConfig(stateDir, {});
+    fs.mkdirSync(path.join(stateDir, 'mentor-outbox'), { recursive: true });
+    const r1: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireMentorOutbox: (r: typeof r1) => void }).migrateRetireMentorOutbox(r1);
+
+    const r2: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireMentorOutbox: (r: typeof r2) => void }).migrateRetireMentorOutbox(r2);
+    expect(r2.upgraded).toEqual([]);
+    expect(r2.skipped.some((s) => s.includes('already migrated'))).toBe(true);
+  });
+
+  it('handles directory-absent gracefully (marker set, no error)', () => {
+    const m = buildMigrator(projectDir);
+    writeConfig(stateDir, {});
+    expect(fs.existsSync(path.join(stateDir, 'mentor-outbox'))).toBe(false);
+    const result: { upgraded: string[]; skipped: string[]; errors: string[] } = { upgraded: [], skipped: [], errors: [] };
+    (m as unknown as { migrateRetireMentorOutbox: (r: typeof result) => void }).migrateRetireMentorOutbox(result);
+    expect(result.errors).toEqual([]);
+    expect(result.skipped.some((s) => s.includes('not present'))).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,39 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Mentor retirement migrations.** Two idempotent `PostUpdateMigrator` methods that retire
+the artifacts of the file-based mentor delivery design Justin's substrate correction
+replaced (spec MENTOR-LIVE-READINESS §Migration parity):
+
+- `migrateRetireDeadMentorConfig` removes `mentor.dailySpendCapUsd` — the dead config
+  field (decorative; Echo runs on a Claude subscription, no per-token charge to cap). The
+  removal is silent when the value was the default `0.5`, but LOUDLY surfaces a `REVIEW:`
+  entry in the upgrade output when the operator had set a non-default value (don't repeat
+  the original silent-dead-config bug at migration time).
+- `migrateRetireMentorOutbox` sweeps `{stateDir}/mentor-outbox/` via
+  `SafeFsExecutor.safeRmSync` — the legacy file-based mentor delivery is now dead state.
+
+Both registered in the main migration list after `migrateLegacyMaxSessions`. Both
+idempotent via the `_instar_migrations` marker.
+
+## What to Tell Your User
+
+- On upgrade I'll quietly sweep two leftovers from the earlier file-based mentor design — the unused dailySpendCapUsd setting and the unused mentor-outbox directory. If you had ever set the cap to a non-default value, you'll see a one-time REVIEW line in the upgrade output explaining the setting was never actually enforced (and what the real replacement is).
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Mentor retirement migrations | Automatic on update — `migrateRetireDeadMentorConfig` removes the decorative `mentor.dailySpendCapUsd` (LOUD `REVIEW:` if non-default); `migrateRetireMentorOutbox` sweeps the legacy `{stateDir}/mentor-outbox/` |
+
+## Evidence
+
+**Net-new groundwork, not a bug fix.** 7 new unit tests, all green: absent → skip +
+marker; default `0.5` → silent delete + non-LOUD entry; non-default → LOUD `REVIEW:`
+with the decorative/never-enforced/subscription explanation (proves the "non-silent
+removal" invariant from the round-2 adversarial finding); idempotency; outbox-present
+remove + file-count; outbox-absent graceful; outbox idempotency. `tsc --noEmit` clean.
+Combined mentor-stack tests across the staged build now 57, all green.

--- a/upgrades/side-effects/mentor-retire-migrations.md
+++ b/upgrades/side-effects/mentor-retire-migrations.md
@@ -1,0 +1,73 @@
+# Side-Effects Review — mentor migrations (retire dead config + outbox) (PR 3c-3)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Migration parity (the
+"dailySpendCapUsd silent removal is a quiet config break" round-2 adversarial finding +
+the legacy file-outbox cleanup). PR 3 of the staged build, part c-3.
+**Change:** Two new `PostUpdateMigrator` methods that retire the artifacts of the
+file-based mentor delivery design Justin's substrate correction replaced. Both
+**idempotent** via the `_instar_migrations` marker. Registered in the main migration
+list right after `migrateLegacyMaxSessions`.
+**Files:** `src/core/PostUpdateMigrator.ts` (+2 methods + 2 registrations),
+`tests/unit/PostUpdateMigrator-mentor-retire.test.ts` (new, 7).
+
+## What changed
+
+1. **`migrateRetireDeadMentorConfig`** — removes `mentor.dailySpendCapUsd`:
+   - field absent → silent skip (mark set so we don't re-check).
+   - field present at the default `0.5` → silent delete (operator never changed it).
+   - field present at a NON-default value → delete + LOUD `result.upgraded` entry with
+     `REVIEW:` prefix explaining the field was decorative (never enforced — Echo runs on
+     a Claude subscription) and the future replacement is `mentor.stageBTokenCeiling`.
+     This is exactly the "non-silent removal" the spec's round-2 adversarial finding
+     required: don't repeat the silent-dead-config bug at migration time.
+2. **`migrateRetireMentorOutbox`** — removes `{stateDir}/mentor-outbox/` via
+   `SafeFsExecutor.safeRmSync`:
+   - present → recursive remove + record file-count in `result.upgraded`.
+   - absent → mark + skip (so subsequent runs are no-ops).
+   - failure → log to `result.errors` + do NOT mark (retry on next run).
+
+## The seven questions
+
+1. **Over-block.** N/A — both are removal-only migrations; nothing is over-blocked.
+2. **Under-block.** Both are idempotent via the `_instar_migrations` marker; corrupt or
+   missing config.json early-exits with a `result.errors`/`result.skipped` entry rather
+   than crashing the migration pass.
+3. **Level-of-abstraction fit.** Each method does ONE thing, modeled exactly on
+   `migrateLegacyMaxSessions` (the established pattern for value-patching migrations) +
+   uses `SafeFsExecutor.safeRmSync` for the destructive filesystem op (the project's
+   established funnel for that). No new infrastructure.
+4. **Signal vs authority.** N/A.
+5. **Interactions.** Both run during the normal `PostUpdateMigrator.migrate()` pass
+   (between `migrateLegacyMaxSessions` and `migratePrPipelineArtifacts`). They touch
+   `config.json` and `{stateDir}/mentor-outbox/` only — both project-owned paths. The
+   `_instar_migrations` marker pattern is unchanged. Existing tests for other
+   migrations are unaffected.
+6. **External surfaces.** None new. Both surface their actions via the standard
+   `result.upgraded` / `result.skipped` / `result.errors` arrays the migrator already
+   uses (visible in the post-update output the operator sees).
+7. **Rollback cost.** Trivial — revert removes the two methods + their registration.
+   The retired data is forward-only; restoring an old `dailySpendCapUsd` or an old
+   `mentor-outbox/` directory by hand is possible if absolutely needed (but unlikely —
+   neither was actually working).
+
+## Testing
+
+7 new unit tests, all green:
+- **dailySpendCapUsd retirement**: field-absent silent skip + marker; default `0.5`
+  silent delete + non-LOUD upgraded entry; **non-default value LOUD `REVIEW:` upgraded
+  entry** with the "decorative / never enforced / subscription / token-ceiling
+  replacement" explanation (proves the "non-silent removal" invariant); IDEMPOTENT
+  (second run is no-op skip).
+- **outbox retirement**: present-directory removed + file-count recorded; IDEMPOTENT
+  marker means subsequent runs skip; directory-absent handled gracefully (no error,
+  marker set).
+
+`tsc --noEmit` clean. Combined mentor-stack tests across the staged build (PRs 1, 2a,
+2b, 3a, 3b, 3c-1, 3c-2, 3c-3) = **57 tests, all green**.
+
+## Migration parity
+
+These ARE the migrations from the spec's §Migration parity. The new MentorConfig fields
+(`botToken`, `menteeBotId`, `menteeChatId`, `menteeTopicId`) added in PR 3c-1 are
+optional + default undefined, so no additive migration is needed for them — they appear
+only when the operator (or PR 3c-4's `/mentor/bot-setup` flow) sets them.


### PR DESCRIPTION
## What

PR 3c-3 — the migrations from `MENTOR-LIVE-READINESS-SPEC.md` §Migration parity. Two idempotent `PostUpdateMigrator` methods that retire the artifacts of the file-based mentor delivery design Justin's substrate correction replaced.

## Changes

- **`migrateRetireDeadMentorConfig`** — removes `mentor.dailySpendCapUsd`. Silent when value was the default `0.5`; **LOUD `REVIEW:` prefix when non-default** so the operator hears that their setting was never enforced (the round-2 adversarial finding: don't repeat the silent-dead-config bug at migration time).
- **`migrateRetireMentorOutbox`** — sweeps `{stateDir}/mentor-outbox/` via `SafeFsExecutor.safeRmSync`. File count recorded; marker set even when absent so subsequent runs no-op.

Both registered in the main migration list after `migrateLegacyMaxSessions`. Idempotent via the `_instar_migrations` marker.

## Tests

7 new (57 mentor-stack tests total across the staged build, all green): absent → skip + marker; default 0.5 → silent delete + non-LOUD entry; non-default → LOUD `REVIEW:` with the decorative/never-enforced/subscription explanation; idempotency; outbox-present remove + file-count; outbox-absent graceful; outbox idempotency. `tsc --noEmit` clean.

## Next

PR 3c-4 (deferred): `/mentor/bot-setup` + `/mentor/bot-setup/rotate` routes + Secret-Drop integration + CLAUDE.md template entry. First supervised live test can proceed with hand-edited `mentor.botToken`/etc. in config.json — Secret-Drop is a nice-to-have for production. Coordinating Codey's side (recipient handler + reply send) is the meaningful next concrete step toward the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)