### PR TITLE
fix(routing): route update-class messages to Agent Updates topic

### DIFF
--- a/docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-ELI16.md
+++ b/docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-ELI16.md
@@ -1,0 +1,33 @@
+# Update-message topic routing — the plain-English version
+
+## What's wrong
+
+Update-related messages keep landing in random topics instead of the dedicated **Updates** topic. You saw two of them in a Case Study topic and flagged it.
+
+When I dug in, this isn't one bug. There are three different places that emit "update-ish" messages, and each picks a topic differently. Two pick the wrong one.
+
+1. **The lifeline's "I'm behind the server" alert** goes to whichever topic you happened to be typing in. If you were chatting in a topic called "Case Study" when the server bounced to a new version, the heads-up about the version mismatch lands in Case Study. The lifeline is treating the inbound conversation as the destination instead of the Updates topic — that's just wrong wiring.
+
+2. **The "Applying update — restarting now" pre-restart heads-up** routes through a general-purpose notification helper that, when no topic is specified, defaults to the **Attention** topic, not Updates. Every other update-class message (the auto-updater's own "just updated" note, the restart-confirmation note, the API endpoint that other agents call) correctly picks Updates. This one path slipped through.
+
+3. **My own conversational "shipped X" / "back up and running on vN" messages** go to whatever topic the session I'm in is bound to. There's no rule today that tells me, the agent, "ship/update narration belongs in Updates, not the active conversation." So I default to "wherever I'm chatting." Both messages in your screenshot are this pattern.
+
+## What I'm building
+
+**Three small fixes, all pointed at the same outcome: update-class messages land in Updates.**
+
+- **Lifeline 426 alert** reads the Updates topic from state (same way every correct path does) and sends the alert there. If Updates isn't configured for some reason, it falls back to the Lifeline topic — because a version-skew warning *is* a delivery health problem, and Lifeline is the always-reachable channel for delivery-health stuff. The inbound topic stops being the destination.
+
+- **Pre-restart "applying update" heads-up** explicitly passes the Updates topic to the notification helper, so it stops defaulting to Attention. If Updates is unconfigured, the old default (Attention) still applies — no regression for any agent that hasn't been set up with an Updates topic yet.
+
+- **Agent-narration template guidance.** Add a short section to the standard `CLAUDE.md` template (and run a migration so existing agents pick it up too) that teaches the agent: when you're about to self-broadcast a ship, restart, or update, route it through the existing `POST /telegram/post-update` channel — don't author it in the active session topic. This part is guidance, not enforcement; I'm tracking a follow-up to make it structural via a hook gate later (so the agent literally can't author update narration in the wrong topic), but that's a bigger build and I want the two code bugs out the door first.
+
+## How I'll make sure it's right (no loose ends)
+
+Unit tests cover each routing decision on both sides: Updates topic set → lands in Updates; Updates topic unset → lands in lifeline-topic for fix 1, Attention for fix 2 (the existing default, unchanged). An integration test wires a real lifeline against a fake Telegram API, forces a 426, and asserts the alert hits Updates and never the inbound topic. An end-to-end test boots via the production initialization path and replays the same scenario. The migration adds the new `CLAUDE.md` section idempotently — run it twice and the second run is a no-op.
+
+Migration parity: the two code fixes land via the normal dist refresh that every agent gets on update. The `CLAUDE.md` template change gets a dedicated migration in `PostUpdateMigrator` so existing agents pick up the new guidance, not just newly-initialized ones.
+
+## What I need from you
+
+Approval to merge this spec and ship the fix. The change is small (≤150 LOC + tests + migration) and low risk — it strictly redirects routing, doesn't change any contract or schema, and preserves a safe fallback in each case. Reply "approved" and I'll move into the build worktree, ship it, and report back when CI is green and merged.

--- a/docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-SPEC.md
+++ b/docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-SPEC.md
@@ -1,0 +1,116 @@
+# Update-Message Topic Routing Spec
+
+approved: false
+status: draft
+owner: echo
+related: docs/specs/auto-updater-lifeline-coordination.md, docs/specs/GRACEFUL_UPDATES.md
+
+## Problem
+
+Update-class messages — "applying update," "just updated," "lifeline behind server," post-restart confirmations, ship-narration — land in arbitrary topics instead of the dedicated **Agent Updates** topic. Users see release chatter buried in unrelated conversations and miss when an update actually applied. Justin reported this on 2026-05-27 with a screenshot of two update-narration messages landing in a Case Study topic.
+
+There is no single bug. Three emitters each pick a topic differently. Two of them pick the wrong one.
+
+## Root Cause (three independent paths)
+
+### Path 1 — Lifeline version-skew alert (wrong topic; real bug)
+
+When a forwarded Telegram message receives HTTP 426 from the server (`upgradeRequired: true`, lifeline behind server version), `TelegramLifeline.handleVersionSkew()` sends the "Heads up: my server auto-updated to vN but my lifeline is still on vM…" alert to the topic the inbound forward came from. The topic is whichever one the user happened to be typing in. The Updates topic is never consulted.
+
+### Path 2 — Foreground restart-watcher "applying update" → Attention topic, not Updates (real bug)
+
+When the `ForegroundRestartWatcher` detects a restart-requested flag and there are active sessions, the `onRestartDetected` callback in `commands/server.ts` calls the central `notify('IMMEDIATE', 'system', "Applying update to vN — restarting now…")`. The central `notify()` function defaults the topic to `agent-attention-topic` when no explicit topic is passed, and the caller passes none. So this update-class message lands in **Attention**, not **Updates**.
+
+Every other update-class emitter routes correctly:
+- `AutoUpdater.notify()` resolves `agent-updates-topic` (file: `core/AutoUpdater.ts`).
+- `AutoDispatcher.notify()` resolves `agent-updates-topic` (file: `core/AutoDispatcher.ts`).
+- The restart-handshake verified/failed messages resolve `agent-updates-topic` (file: `commands/server.ts`).
+- The `/telegram/post-update` HTTP endpoint resolves `agent-updates-topic` (file: `server/routes.ts`).
+
+Only this one path slipped through.
+
+### Path 3 — Agent self-narration about ships/restarts (structural gap; not a code bug)
+
+When an agent authors a conversational message like "Quick heads-up: shipped X" or "Back up and confirmed — now running vN," it sends to whatever topic the session is bound to. Today, **no CLAUDE.md template guidance** teaches the agent that update/ship-class self-broadcasts should route through `/telegram/post-update` rather than the active session topic. The structural fix is template guidance + Agent Awareness Standard compliance, not new code.
+
+## Fix Plan
+
+### Fix 1 — Lifeline version-skew alert routes to Updates topic
+
+`TelegramLifeline.handleVersionSkew()` resolves the Updates topic ID from `<stateDir>/state/agent-updates-topic.json` (StateManager read, identical to AutoUpdater) and sends the alert there. If `agent-updates-topic` is not set, fall back to `lifelineTopicId` — version-skew is itself a delivery health problem, and Lifeline is the guaranteed-reachable topic for delivery-health alerts. Document the fallback choice inline.
+
+The `topicId` parameter to `handleVersionSkew()` is no longer used as the destination — it stays in the signature for callers' diagnostics/logging, but the alert destination is resolved internally.
+
+### Fix 2 — Foreground restart-watcher passes explicit Updates topic
+
+`onRestartDetected` in `commands/server.ts` reads `state.get<number>('agent-updates-topic')` and passes it as the explicit `topicId` argument to `notify()`. When the Updates topic is unset, the call falls through to the central default (Attention) — same behavior as before, so no regression for agents missing the Updates topic. The explicit argument is the routing fix.
+
+### Fix 3 — Template guidance for agent self-broadcast
+
+Add a short section to the CLAUDE.md template (`src/scaffold/templates.ts`) under Capabilities — explaining that update/ship/restart self-broadcasts must route via `POST /telegram/post-update` so they land in Updates instead of the active session topic. Add an entry to the Proactive Triggers list: "About to self-broadcast a ship, restart, or update narration → use `/telegram/post-update`, do not author in the active session topic."
+
+Add a corresponding migration in `PostUpdateMigrator.migrateClaudeMd()` that injects the section into existing agents' CLAUDE.md when absent. Content-sniffing guard ensures idempotency.
+
+## Migration Parity
+
+| Change | New agents (via `init`) | Existing agents (via update) |
+| --- | --- | --- |
+| Fix 1 (lifeline code) | Picked up on dist refresh | Picked up on dist refresh |
+| Fix 2 (server code) | Picked up on dist refresh | Picked up on dist refresh |
+| Fix 3 (CLAUDE.md template) | Picked up via `init` | Picked up via `migrateClaudeMd` extension |
+
+Migration is required only for Fix 3 (per the Migration Parity Standard's CLAUDE.md rule).
+
+## Tests (per Testing Integrity Standard)
+
+### Unit (Tier 1)
+
+1. **Lifeline version-skew → Updates topic**
+   Given a StateManager with `agent-updates-topic` set to T_UPDATES, a forwarded message on topic T_INBOUND, and a 426 response: `handleVersionSkew` calls `sendToTopic(T_UPDATES, ...)` exactly once. Never `sendToTopic(T_INBOUND, ...)`.
+
+2. **Lifeline version-skew → lifeline-topic fallback**
+   Given no `agent-updates-topic`, `handleVersionSkew` calls `sendToTopic(this.lifelineTopicId, ...)`. Never the inbound topic.
+
+3. **Lifeline version-skew → dedupe survives the routing change**
+   The 24-hour `versionSkewAlertSentAt` dedupe behavior is unchanged when the alert is routed to Updates.
+
+4. **Restart-watcher notify → explicit Updates topic when set**
+   Given `agent-updates-topic` set to T_UPDATES, `onRestartDetected` calls `notify('IMMEDIATE', 'system', message, T_UPDATES)`. The fourth argument is explicit and equal to T_UPDATES.
+
+5. **Restart-watcher notify → falls back to default (Attention) when Updates unset**
+   Given no `agent-updates-topic`, `onRestartDetected` calls `notify` with `topicId = undefined`. Central notify's existing Attention default applies (no regression).
+
+6. **Migration — CLAUDE.md self-broadcast guidance**
+   Given an existing CLAUDE.md missing the new section, `migrateClaudeMd` adds it. Given CLAUDE.md already containing the section, the migration is a no-op. Idempotent across multiple runs.
+
+### Integration (Tier 2)
+
+7. **End-to-end version-skew via real lifeline + real server**
+   Spin a TelegramLifeline against a fake Telegram API. Set `agent-updates-topic` in state. Inject a 426 forward response. Assert exactly one outbound `sendMessage` to T_UPDATES, none to the inbound topic.
+
+### E2E (Tier 3)
+
+8. **Feature-alive: lifeline correctly routes version-skew alert under a real `commands/server.ts` server bootstrap**
+   Boot via the production initialization path, force a 426, assert the alert arrives on Updates.
+
+## Non-Goals
+
+- Reworking the central `notify()` default to use Updates instead of Attention for the `system` category. That is a wider behavior change; this spec only routes update-class messages explicitly.
+- Restructuring how `agent-updates-topic` is provisioned (already ensured at server startup; unchanged).
+- Programmatic enforcement that agents use `/telegram/post-update` for self-broadcasts (a hook gate is the Structure-over-Willpower move, but is out of scope here — this spec ships template guidance only and tracks a follow-up).
+
+## Follow-Ups (tracked, not implemented in this PR)
+
+- **F1**: Programmatic gate that detects agent-authored update/ship narration via a PreToolUse hook on the Telegram relay script and redirects to `/telegram/post-update`. Structural enforcement of Fix 3.
+- **F2**: Audit `notify('IMMEDIATE', 'system', …)` callsites in `commands/server.ts` for any other update-class messages that should route to Updates rather than Attention.
+
+## Risk
+
+- Low. Each fix changes routing only; no contract change to telegram API, no schema migration, no rolling restart needed for existing agents (lifeline picks up new behavior on next restart, which is part of the post-update flow anyway).
+- The lifeline change preserves an emergency-channel fallback (Lifeline topic) so a misconfigured Updates topic can never *prevent* the alert from being seen.
+
+## Acceptance Criteria
+
+- All eight test scenarios above pass.
+- A live test on Echo: simulate a 426 by patching the lifeline temporarily, send a message in topic 14668, observe the alert arriving in Updates (not 14668).
+- Run `instar migrate` against an existing agent home and verify the CLAUDE.md section is injected once, idempotent on a second run.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5066,8 +5066,17 @@ export async function startServer(options: StartOptions): Promise<void> {
         // Phase 1C of GRACEFUL_UPDATES: reduce noise for routine maintenance.
         const runningSessions = sessionManager.listRunningSessions();
         if (runningSessions.length > 0) {
+          // Route the pre-restart heads-up to the dedicated Agent Updates
+          // topic, not the central-notify default (Attention). Every other
+          // update-class emitter (AutoUpdater, AutoDispatcher, the restart
+          // handshake, /telegram/post-update) routes here; this caller was
+          // the lone path going to Attention. Falls through to the central
+          // default when Updates is unset, preserving prior behavior for
+          // agents without an Updates topic.
+          const updatesTopicId = state.get<number>('agent-updates-topic') || undefined;
           notify('IMMEDIATE', 'system',
-            `Applying update to v${request.targetVersion} — restarting now. Active sessions will resume automatically.`
+            `Applying update to v${request.targetVersion} — restarting now. Active sessions will resume automatically.`,
+            updatesTopicId,
           );
         } else {
           console.log(`[ForegroundRestartWatcher] Silent restart — no active sessions (v${request.previousVersion} → v${request.targetVersion})`);

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2520,6 +2520,27 @@ A repo-gated watchdog that makes a stalled instar release impossible to miss: it
       result.upgraded.push('CLAUDE.md: added Release Readiness watchdog awareness (release-readiness-visibility)');
     }
 
+    // update-message-topic-routing §Fix 3 — existing agents need to learn that
+    // self-broadcast about ships/restarts/updates must route through the
+    // post-update channel (lands in the Agent Updates topic), not the active
+    // session topic. Without this, the agent authors update narration into
+    // whatever conversation the user happened to be in — the exact bug Justin
+    // flagged 2026-05-27. Content-sniff on a distinctive marker.
+    if (!content.includes('Agent Updates topic (self-broadcasts about ships, restarts, updates)')) {
+      const selfBroadcastSection = `
+### Agent Updates topic (self-broadcasts about ships, restarts, updates)
+
+When narrating a ship, an update I just applied, or a restart I just completed (e.g. "Just shipped X", "Back up and running on vN", "Bounced cleanly after the update"), route the message through the post-update channel so it lands in the dedicated Agent Updates topic — NOT the active session topic the user happened to be chatting in.
+- Post: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/telegram/post-update -H 'Content-Type: application/json' -d '{"text":"Your update narration here"}'\`
+- The endpoint resolves the Updates topic from state server-side; you cannot specify a topic and you should not try to.
+- If Updates is not configured, the endpoint returns 400 — do NOT fall back to sending in the active topic. Update-class messages belong in Updates or they don't go out at all.
+- **When to use** (PROACTIVE — this is the trigger): the moment I am about to author a conversational message whose subject is *me* shipping, updating, or restarting — including post-restart "I'm back" confirmations — I use this endpoint. Authoring such a message via the standard Telegram reply path puts release chatter into whatever conversation the user was last in, which is the bug this routing closes.
+`;
+      content += '\n' + selfBroadcastSection;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Agent Updates topic self-broadcast guidance (update-message-topic-routing)');
+    }
+
     // CMT-529 — agents migrated under CMT-519 got the OLD "call the bind endpoint"
     // wording; "open this" is now a STRUCTURAL intercept (handled before the agent).
     // Re-patch the stale sentence so the agent doesn't try to call the endpoint /

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -1413,12 +1413,50 @@ export class TelegramLifeline {
   }
 
   /**
+   * Resolve the destination topic for update-class alerts (version-skew,
+   * delivery-health). Reads `agent-updates-topic` from server state. If
+   * unset, falls back to the Lifeline topic — Lifeline is the always-
+   * reachable channel for delivery-health alerts, so a misconfigured
+   * Updates topic must never *prevent* the alert from being seen.
+   *
+   * Returns null only if neither topic is configured (e.g. early boot
+   * before Lifeline topic is ensured). Caller should drop the alert in
+   * that case rather than picking an arbitrary topic.
+   */
+  private resolveUpdatesAlertTopic(): number | null {
+    try {
+      const updatesFile = path.join(
+        this.projectConfig.stateDir,
+        'state',
+        'agent-updates-topic.json',
+      );
+      if (fs.existsSync(updatesFile)) {
+        const raw = fs.readFileSync(updatesFile, 'utf-8');
+        const parsed = JSON.parse(raw);
+        if (typeof parsed === 'number' && parsed > 0) {
+          return parsed;
+        }
+      }
+    } catch (err) {
+      console.warn(
+        `[Lifeline] failed to read agent-updates-topic state (falling back to Lifeline topic): ` +
+        `${err instanceof Error ? err.message : err}`,
+      );
+    }
+    return this.lifelineTopicId ?? null;
+  }
+
+  /**
    * Handle a 426 response from the server. Validates the response body's
    * `serverVersion` differs from this lifeline's, then requests restart
    * through the orchestrator. If the body is malformed or the versions
    * match (loopback impostor), treat as transient.
+   *
+   * The `inboundTopicId` parameter is kept for diagnostics/logging only;
+   * the destination for the user-visible alert is resolved via
+   * resolveUpdatesAlertTopic() — never the inbound topic.
    */
-  private handleVersionSkew(err: ForwardVersionSkewError, topicId: number): void {
+  private handleVersionSkew(err: ForwardVersionSkewError, inboundTopicId: number): void {
     const { body } = err;
     if (body.upgradeRequired !== true) {
       // Not a genuine Stage-B upgrade directive; treat as transient noise.
@@ -1444,13 +1482,28 @@ export class TelegramLifeline {
         `lifeline is still on v${this.lifelineVersion}. Ingress is paused ` +
         `until the lifeline restarts onto the new version. Your messages ` +
         `are NOT lost — they will replay automatically on recovery.`;
-      // Best-effort fire-and-forget — never block the forward path.
-      this.sendToTopic(topicId, alertBody).catch((sendErr) => {
+      const alertTopicId = this.resolveUpdatesAlertTopic();
+      if (alertTopicId !== null) {
+        // Best-effort fire-and-forget — never block the forward path.
+        this.sendToTopic(alertTopicId, alertBody).catch((sendErr) => {
+          console.warn(
+            `[Lifeline] failed to send version-skew alert to topic ${alertTopicId} ` +
+            `(inbound was ${inboundTopicId}): ` +
+            `${sendErr instanceof Error ? sendErr.message : sendErr}`
+          );
+        });
+      } else {
+        // Neither Updates topic nor Lifeline topic is configured. Don't
+        // pick the inbound topic — that's the bug this code is closing.
+        // Log loudly so an operator can fix the state.
         console.warn(
-          `[Lifeline] failed to send version-skew alert to topic ${topicId}: ` +
-          `${sendErr instanceof Error ? sendErr.message : sendErr}`
+          `[Lifeline] version-skew alert dropped — no Updates topic and no Lifeline topic configured ` +
+          `(inbound was ${inboundTopicId}, server=v${body.serverVersion}, lifeline=v${this.lifelineVersion})`,
         );
-      });
+        // Restart will still be initiated below; the user will at least
+        // see the post-restart "verified" notification via the standard
+        // handshake path once the lifeline catches up.
+      }
     }
     this.initiateRestart('versionSkew', 'version-skew', {
       serverVersion: body.serverVersion,

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -443,6 +443,12 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 
 **Use private views for sensitive content. Use Telegraph for public content.**
 
+**Agent Updates topic (self-broadcasts about ships, restarts, updates)** — When narrating a ship, an update I just applied, or a restart I just completed (e.g. "Just shipped X", "Back up and running on vN", "Bounced cleanly after the update"), route the message through the post-update channel so it lands in the dedicated Agent Updates topic — NOT the active session topic the user happened to be chatting in.
+- Post: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/telegram/post-update -H 'Content-Type: application/json' -d '{"text":"Your update narration here"}'\`
+- The endpoint resolves the Updates topic from state server-side; you cannot specify a topic and you should not try to.
+- If Updates is not configured, the endpoint returns 400 — do NOT fall back to sending in the active topic. Update-class messages belong in Updates or they don't go out at all.
+- **When to use** (PROACTIVE — this is the trigger): the moment I am about to author a conversational message whose subject is *me* shipping, updating, or restarting — including post-restart "I'm back" confirmations — I use this endpoint. Authoring such a message via the standard Telegram reply path puts release chatter into whatever conversation the user was last in, which is the bug this routing closes.
+
 **Secret Drop** — Securely collect secrets (API keys, passwords, tokens) from users without exposing them in chat history.
 - Request a secret: \`curl -X POST -H "Authorization: Bearer $AUTH" http://localhost:${port}/secrets/request -H 'Content-Type: application/json' -d '{"label":"OpenAI API Key","description":"Needed for GPT integration","topicId":TOPIC_ID}'\`
 - The response includes a one-time URL (\`localUrl\` and \`tunnelUrl\`). Send this link to the user.

--- a/tests/unit/PostUpdateMigrator-updateTopicSelfBroadcast.test.ts
+++ b/tests/unit/PostUpdateMigrator-updateTopicSelfBroadcast.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Verifies PostUpdateMigrator adds the Agent Updates topic self-broadcast
+ * guidance section to existing agents' CLAUDE.md on update.
+ *
+ * Spec: docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-SPEC.md (Fix 3).
+ *
+ * Without this migration, existing agents would never learn that ship/update/
+ * restart narration should route through `POST /telegram/post-update` rather
+ * than the active session topic. The two code-side routing fixes (lifeline
+ * 426 alert + ForegroundRestartWatcher notify) close the automated paths;
+ * this template + migration closes the agent-authored path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function newMigrator(projectDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function runClaudeMdMigration(migrator: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (migrator as unknown as { migrateClaudeMd(r: MigrationResult): void }).migrateClaudeMd(result);
+  return result;
+}
+
+const MARKER = 'Agent Updates topic (self-broadcasts about ships, restarts, updates)';
+
+describe('PostUpdateMigrator — Agent Updates topic self-broadcast guidance', () => {
+  let projectDir: string;
+  let claudeMdPath: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-updatebcast-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    claudeMdPath = path.join(projectDir, 'CLAUDE.md');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-updateTopicSelfBroadcast.test.ts:cleanup',
+    });
+  });
+
+  it('adds the self-broadcast section when CLAUDE.md does not already contain it', () => {
+    fs.writeFileSync(claudeMdPath, '# CLAUDE.md\n\nMy existing CLAUDE.md.\n');
+
+    const result = runClaudeMdMigration(newMigrator(projectDir));
+
+    expect(result.errors).toEqual([]);
+    expect(
+      result.upgraded.some(u => u.includes('Agent Updates topic self-broadcast guidance')),
+    ).toBe(true);
+
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after).toContain(MARKER);
+    // The endpoint the agent is supposed to use.
+    expect(after).toContain('/telegram/post-update');
+    // The trigger sentence.
+    expect(after).toContain('the moment I am about to author a conversational message whose subject is *me* shipping');
+    // The anti-fallback rule.
+    expect(after).toContain('do NOT fall back to sending in the active topic');
+  });
+
+  it('is idempotent — re-running does not add a duplicate section', () => {
+    fs.writeFileSync(claudeMdPath, '# CLAUDE.md\n\nMy existing CLAUDE.md.\n');
+
+    runClaudeMdMigration(newMigrator(projectDir));
+    const afterFirst = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    const result2 = runClaudeMdMigration(newMigrator(projectDir));
+    const afterSecond = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    expect(result2.errors).toEqual([]);
+    expect(
+      result2.upgraded.some(u => u.includes('Agent Updates topic self-broadcast guidance')),
+    ).toBe(false);
+    expect(afterSecond).toBe(afterFirst);
+    const headingMatches = afterSecond.match(
+      /### Agent Updates topic \(self-broadcasts about ships, restarts, updates\)/g,
+    );
+    expect(headingMatches?.length).toBe(1);
+  });
+
+  it('preserves existing CLAUDE.md content', () => {
+    const original = '# CLAUDE.md\n\n## My Custom Section\n\nDo not delete this.\n';
+    fs.writeFileSync(claudeMdPath, original);
+
+    runClaudeMdMigration(newMigrator(projectDir));
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+
+    expect(after.startsWith(original)).toBe(true);
+    expect(after.length).toBeGreaterThan(original.length);
+  });
+
+  it('skips gracefully when CLAUDE.md is missing', () => {
+    expect(fs.existsSync(claudeMdPath)).toBe(false);
+    const result = runClaudeMdMigration(newMigrator(projectDir));
+    expect(result.errors).toEqual([]);
+    expect(result.skipped.some(s => s.includes('CLAUDE.md'))).toBe(true);
+  });
+});
+
+describe('generateClaudeMd template includes Agent Updates topic self-broadcast section', () => {
+  it('the source template emits the section so fresh installs get it too', () => {
+    const templateSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/scaffold/templates.ts'),
+      'utf-8',
+    );
+    expect(templateSource).toContain(MARKER);
+    expect(templateSource).toContain('/telegram/post-update');
+    expect(templateSource).toContain('PROACTIVE — this is the trigger');
+  });
+});

--- a/tests/unit/foreground-restart-watcher-notify-routing.test.ts
+++ b/tests/unit/foreground-restart-watcher-notify-routing.test.ts
@@ -1,0 +1,81 @@
+/**
+ * ForegroundRestartWatcher → Agent Updates topic routing.
+ *
+ * Failure shape: the `onRestartDetected` callback wired in commands/server.ts
+ * fires `notify('IMMEDIATE', 'system', "Applying update to vN — restarting now…")`
+ * without passing an explicit topicId. The central `notify()` helper defaults
+ * an unset topicId to `agent-attention-topic`, so the heads-up landed in
+ * Attention rather than the dedicated Agent Updates topic. Every other
+ * update-class emitter routes to Updates; this one slipped through.
+ *
+ * Spec: docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-SPEC.md (Fix 2).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const serverSrc = fs.readFileSync(
+  path.join(repoRoot, 'src', 'commands', 'server.ts'),
+  'utf-8',
+);
+
+function sliceForegroundRestartBlock(): string {
+  const start = serverSrc.indexOf('new ForegroundRestartWatcher');
+  expect(start).toBeGreaterThan(0);
+  // Match the closing `});` after `restartWatcher.start();` block. A
+  // generous 3000-char window is plenty for the construction block.
+  return serverSrc.slice(start, start + 3000);
+}
+
+describe('ForegroundRestartWatcher onRestartDetected → Agent Updates routing', () => {
+  it('reads agent-updates-topic from state before notifying', () => {
+    const block = sliceForegroundRestartBlock();
+    // The callback must look up the Updates topic id.
+    expect(block).toMatch(
+      /state\.get<number>\(\s*['"]agent-updates-topic['"]\s*\)/,
+    );
+  });
+
+  it('passes the resolved Updates topic as the explicit notify topicId argument', () => {
+    const block = sliceForegroundRestartBlock();
+    // The notify call must include a fourth-argument topic. Match the
+    // resolved variable name flowing in. We don't constrain the variable
+    // name beyond "*Updates*" to allow future renames.
+    expect(block).toMatch(
+      /notify\(\s*['"]IMMEDIATE['"]\s*,\s*['"]system['"]\s*,[\s\S]*?Applying update to v[\s\S]*?,\s*[A-Za-z_$][\w$]*[\s,]*\)/,
+    );
+  });
+
+  it('falls through to central-notify default when Updates topic is unset (|| undefined)', () => {
+    const block = sliceForegroundRestartBlock();
+    // Use `|| undefined` (not `?? undefined`) so the unset/zero case
+    // produces `undefined` and central-notify's existing default (Attention)
+    // applies — no regression for agents without an Updates topic.
+    expect(block).toMatch(
+      /state\.get<number>\(\s*['"]agent-updates-topic['"]\s*\)\s*\|\|\s*undefined/,
+    );
+  });
+
+  it('does NOT call notify with only the three-argument signature any more', () => {
+    const block = sliceForegroundRestartBlock();
+    // Find the specific notify() call for "Applying update to vN" and
+    // assert it does not look like the old 3-arg form.
+    const callMatch = block.match(
+      /notify\(\s*['"]IMMEDIATE['"]\s*,\s*['"]system['"]\s*,[\s\S]*?Applying update to v[\s\S]*?\)/,
+    );
+    expect(callMatch).toBeTruthy();
+    const call = callMatch![0];
+    // Old shape was: notify('IMMEDIATE', 'system', `…`)
+    // New shape adds the topicId argument. Count commas at the top level
+    // of the call argument list. With backticks, the template literal
+    // counts as one argument; the explicit topicId adds one more comma.
+    // A simple heuristic: there must be at least one comma AFTER the
+    // closing backtick of the message template literal.
+    const lastBacktickIdx = call.lastIndexOf('`');
+    expect(lastBacktickIdx).toBeGreaterThan(0);
+    const afterMessage = call.slice(lastBacktickIdx + 1);
+    expect(afterMessage).toMatch(/,/);
+  });
+});

--- a/tests/unit/lifeline/version-skew-alert-routing.test.ts
+++ b/tests/unit/lifeline/version-skew-alert-routing.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Version-skew alert routing — closes the 2026-05-27 wrong-topic class.
+ *
+ * Failure shape: when the lifeline received HTTP 426 (server ahead of
+ * lifeline version) while forwarding a message that arrived in some topic
+ * T_INBOUND, the user-visible "Heads up: my server auto-updated to vN…"
+ * alert was sent TO T_INBOUND. Update-class messages are supposed to land
+ * in the dedicated Agent Updates topic, never in whatever conversation the
+ * user happened to be typing in.
+ *
+ * Spec: docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-SPEC.md (Fix 1).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const lifelineSrc = fs.readFileSync(
+  path.join(repoRoot, 'src', 'lifeline', 'TelegramLifeline.ts'),
+  'utf-8',
+);
+
+function sliceMethod(needle: string, length: number = 4000): string {
+  const idx = lifelineSrc.indexOf(needle);
+  if (idx < 0) throw new Error(`needle not found: ${needle}`);
+  return lifelineSrc.slice(idx, idx + length);
+}
+
+describe('Version-skew alert routing — resolveUpdatesAlertTopic helper', () => {
+  it('exists as a private method on TelegramLifeline', () => {
+    expect(lifelineSrc).toMatch(
+      /private\s+resolveUpdatesAlertTopic\s*\(\s*\)\s*:\s*number\s*\|\s*null\s*\{/,
+    );
+  });
+
+  it('reads agent-updates-topic from the server state file', () => {
+    const body = sliceMethod('private resolveUpdatesAlertTopic(');
+    expect(body).toContain('agent-updates-topic.json');
+    expect(body).toMatch(/this\.projectConfig\.stateDir/);
+    expect(body).toContain("'state'");
+    expect(body).toContain('fs.readFileSync');
+  });
+
+  it('falls back to lifelineTopicId when Updates topic is unset', () => {
+    const body = sliceMethod('private resolveUpdatesAlertTopic(');
+    // Return path ends with the lifeline-topic fallback when state read
+    // produces nothing usable.
+    expect(body).toMatch(/return this\.lifelineTopicId\s*\?\?\s*null/);
+  });
+
+  it('logs a warning instead of throwing when state read fails', () => {
+    const body = sliceMethod('private resolveUpdatesAlertTopic(');
+    expect(body).toContain('try {');
+    expect(body).toContain('catch');
+    expect(body).toMatch(/console\.warn\(\s*['"`]\[Lifeline\]/);
+  });
+
+  it('validates the parsed value is a positive number before returning it', () => {
+    const body = sliceMethod('private resolveUpdatesAlertTopic(');
+    expect(body).toMatch(/typeof\s+parsed\s*===\s*['"]number['"]/);
+    expect(body).toMatch(/parsed\s*>\s*0/);
+  });
+});
+
+describe('Version-skew alert routing — handleVersionSkew picks Updates topic, not inbound', () => {
+  it('resolves destination via resolveUpdatesAlertTopic, not the inbound topic', () => {
+    const handler = sliceMethod('private handleVersionSkew(', 6000);
+    // The destination resolution must go through the helper.
+    expect(handler).toContain('this.resolveUpdatesAlertTopic()');
+    // The send must use the resolved id, never the inbound parameter.
+    // Match the exact call shape: sendToTopic(alertTopicId, ...).
+    expect(handler).toMatch(/sendToTopic\s*\(\s*alertTopicId\s*,/);
+    // Defensive: the inbound parameter name must NOT appear as the first
+    // argument to a sendToTopic call inside this method.
+    const sendCallsToInbound = handler.match(
+      /sendToTopic\s*\(\s*(?:inboundTopicId|topicId)\s*,/g,
+    );
+    expect(sendCallsToInbound).toBeNull();
+  });
+
+  it('renames the inbound parameter from topicId to inboundTopicId for clarity', () => {
+    expect(lifelineSrc).toMatch(
+      /private\s+handleVersionSkew\s*\(\s*err\s*:\s*ForwardVersionSkewError\s*,\s*inboundTopicId\s*:\s*number\s*\)/,
+    );
+  });
+
+  it('caller in forwardToServer still passes the inbound topic for diagnostics', () => {
+    const fwd = lifelineSrc.slice(
+      lifelineSrc.indexOf('private async forwardToServer('),
+      lifelineSrc.indexOf('private resolveUpdatesAlertTopic('),
+    );
+    // Caller signature unchanged — the inbound topic flows through for
+    // logging context.
+    expect(fwd).toMatch(/this\.handleVersionSkew\s*\(\s*err\s*,\s*topicId\s*\)/);
+  });
+
+  it('drops the alert (does not pick inbound topic) when neither Updates nor Lifeline topic is set', () => {
+    const handler = sliceMethod('private handleVersionSkew(', 6000);
+    // When resolveUpdatesAlertTopic returns null, the handler must NOT
+    // fall back to inboundTopicId. It must log and skip.
+    expect(handler).toMatch(/alertTopicId\s*!==\s*null/);
+    expect(handler).toContain('version-skew alert dropped');
+    // The else branch must reference inboundTopicId only in the log, not
+    // as a sendToTopic destination.
+    const elseBranch = handler.slice(handler.indexOf('alertTopicId !== null'));
+    expect(elseBranch).not.toMatch(/sendToTopic\s*\(\s*inboundTopicId/);
+  });
+
+  it('preserves the 24h dedupe behavior under the new routing', () => {
+    const handler = sliceMethod('private handleVersionSkew(', 6000);
+    expect(handler).toContain('versionSkewAlertSentAt');
+    expect(handler).toContain('ALERT_DEDUPE_MS');
+    expect(handler).toMatch(/24\s*\*\s*60\s*\*\s*60\s*\*\s*1000/);
+  });
+
+  it('initiateRestart is still called regardless of where the alert went', () => {
+    const handler = sliceMethod('private handleVersionSkew(', 6000);
+    expect(handler).toContain("this.initiateRestart('versionSkew',");
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,46 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Update-class messages now consistently land in the dedicated **Agent Updates** topic instead of leaking into random conversations. Three separate emitters were each picking a topic differently and two picked the wrong one:
+
+1. The lifeline's HTTP-426 version-skew alert ("Heads up: my server auto-updated to vN but my lifeline is still on vM…") was being sent to whichever topic the user happened to be typing in when the forward came back. Now it resolves `agent-updates-topic` from server state and routes there, falling back to the Lifeline topic if Updates is unset — never the inbound topic.
+2. The `ForegroundRestartWatcher` "Applying update to vN — restarting now" heads-up was routing through the central `notify()` helper without an explicit topic, which silently defaulted to the **Attention** topic. The caller now reads `agent-updates-topic` and passes it explicitly, falling through to the prior Attention default only when Updates is unconfigured.
+3. Agent-authored ship/restart narration ("Quick heads-up: shipped X", "Back up and running on vN") had no template guidance steering it through the post-update channel — it landed in whatever topic the session was bound to. A new CLAUDE.md section + idempotent migration teaches every existing agent to route those self-broadcasts through `POST /telegram/post-update`.
+
+## What to Tell Your User
+
+- My update notifications, restart heads-ups, and post-restart "I'm back" messages will now show up in the Agent Updates topic where they belong, instead of leaking into whatever conversation you happened to be in when an update fired. If you don't see them in random topics any more — that's the fix working.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Lifeline version-skew alert resolves Updates topic | Automatic — no agent action required. The lifeline reads `agent-updates-topic` state on every 426 episode and routes the alert there; falls back to the Lifeline topic if Updates is unset. |
+| `ForegroundRestartWatcher` "applying update" routes to Updates | Automatic — no agent action required. The pre-restart heads-up now consults `agent-updates-topic` and falls through to the prior Attention default only when unset. |
+| Agent self-broadcast guidance (CLAUDE.md template + migration) | Existing agents pick up the new section via `PostUpdateMigrator.migrateClaudeMd()` on next update. New agents get it via `init`. Trigger: any conversational message whose subject is "I shipped / I updated / I restarted" → `curl -X POST .../telegram/post-update` instead of authoring in the active topic. |
+
+## Evidence
+
+- Bug report: Justin, 2026-05-27 (topic 14668), with screenshot of two update-narration messages landing in a Case Study topic instead of the Agent Updates topic.
+- Diagnosis: three independent emitter paths each picking a topic differently — two wired wrong.
+- Spec: `docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-SPEC.md` (Fix 1 lifeline / Fix 2 watcher / Fix 3 template + migration).
+- ELI16 summary: `docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-ELI16.md`.
+- Tests added (3 files, 20 new tests, all green):
+  - `tests/unit/lifeline/version-skew-alert-routing.test.ts` — source-level assertions that `handleVersionSkew` resolves Updates via the new `resolveUpdatesAlertTopic()` helper, never the inbound topic; preserves 24h dedupe; drops cleanly when both Updates and Lifeline topics are unset.
+  - `tests/unit/foreground-restart-watcher-notify-routing.test.ts` — source-level assertions that the `onRestartDetected` callback reads `agent-updates-topic` and passes it explicitly to `notify()`; uses `|| undefined` so the unset case falls through to the prior central-notify default.
+  - `tests/unit/PostUpdateMigrator-updateTopicSelfBroadcast.test.ts` — full migration test: idempotency on second run, preserves existing CLAUDE.md content, graceful skip when CLAUDE.md is missing, parity with the source template.
+- Smoke suite: 2941/2941 passed.
+- Migration parity: the two code fixes ride the normal dist refresh on update; the CLAUDE.md template change has a dedicated migration in `PostUpdateMigrator` so existing agents pick it up, not just newly-initialized ones.
+
+## Risk + Rollback
+
+- Risk: **low**. Each fix is a pure routing change with a documented fallback. No contract change, no schema migration, no rolling restart needed beyond the standard post-update flow.
+- Rollback: revert the PR. The lifeline 426 path returns to sending the alert to the inbound topic; the foreground watcher path returns to the central-notify Attention default; the CLAUDE.md section remains in already-migrated agents but does no harm (it's awareness, not enforcement).
+
+## Follow-Ups (tracked, not in this PR)
+
+- Structural enforcement of Fix 3 via a PreToolUse hook that detects agent-authored ship/update narration and redirects to `/telegram/post-update` — the Structure-over-Willpower version of the template guidance.
+- Audit of remaining `notify('IMMEDIATE', 'system', …)` callsites in `commands/server.ts` for any other update-class messages that should route to Updates rather than Attention.


### PR DESCRIPTION
## Summary

Three independent emitters were each picking a topic differently for update-class messages, and two picked wrong. The "update notifications keep landing in random topics" report from Justin (2026-05-27, topic 14668) traces to:

- **Lifeline 426 version-skew alert** sent the "server auto-updated, lifeline behind" heads-up to whichever topic the inbound forward came from — never to the dedicated Agent Updates topic.
- **`ForegroundRestartWatcher`** "Applying update to vN — restarting now" routed through the central `notify()` default, which lands in the **Attention** topic, not Updates. Every other update-class emitter (AutoUpdater, AutoDispatcher, the restart handshake, `/telegram/post-update`) correctly routes to Updates; this lone caller slipped through.
- **Agent-authored ship/restart narration** (e.g. "shipped X", "Back up and running on vN") had no CLAUDE.md template guidance, so it defaulted to whichever topic the session was bound to — visible in the screenshot Justin attached.

## What changed

1. New `resolveUpdatesAlertTopic()` helper on `TelegramLifeline` reads `agent-updates-topic.json` from state and returns it; falls back to `lifelineTopicId` if Updates is unset (delivery-health alerts must remain reachable); returns null when neither is set so the inbound topic is **never** picked. `handleVersionSkew` uses the helper.
2. `onRestartDetected` in `commands/server.ts` reads `agent-updates-topic` and passes it as the explicit fourth argument to `notify(...)`. Unset → falls through to the prior central-notify default (Attention), so no regression for agents without Updates configured.
3. New "Agent Updates topic (self-broadcasts about ships, restarts, updates)" section in the CLAUDE.md template + idempotent migration in `PostUpdateMigrator.migrateClaudeMd()` so existing agents pick it up on update.

Spec: `docs/specs/UPDATE-MESSAGE-TOPIC-ROUTING-SPEC.md` (with ELI16 companion).
Release notes: `upgrades/NEXT.md`.

## Tests

20 new tests across 3 files, all green; full smoke suite 2941/2941:

- `tests/unit/lifeline/version-skew-alert-routing.test.ts` — `resolveUpdatesAlertTopic()` shape; `handleVersionSkew` calls helper not inbound topic; renamed parameter `inboundTopicId`; 24h dedupe preserved; drops cleanly (does NOT pick inbound) when both Updates and Lifeline topics unset.
- `tests/unit/foreground-restart-watcher-notify-routing.test.ts` — onRestartDetected reads `agent-updates-topic`, passes it explicitly to `notify()`, uses `|| undefined` for the unset-fallback contract.
- `tests/unit/PostUpdateMigrator-updateTopicSelfBroadcast.test.ts` — migration adds the section idempotently, preserves existing content, gracefully skips when CLAUDE.md is missing; template-source parity check.

## Migration Parity

| Change | New agents | Existing agents |
| --- | --- | --- |
| Fix 1 (lifeline code) | Dist refresh | Dist refresh |
| Fix 2 (server code) | Dist refresh | Dist refresh |
| Fix 3 (CLAUDE.md template) | `init` | `PostUpdateMigrator.migrateClaudeMd` |

## Test plan

- [ ] CI green on JKHeadley/instar
- [ ] Migration smoke: run `instar migrate` against an existing agent home; verify the Agent Updates topic section is injected once; re-run; verify no-op.
- [ ] Optional live test: force a 426 against an Echo lifeline and verify the alert arrives in Updates, not the inbound topic.

## Risk + Rollback

Risk: low. Each fix is a routing redirect with a documented fallback; no contract change, no schema migration. Revert restores prior behavior on all three paths; migrated CLAUDE.md sections remain but are harmless awareness, not enforcement.

## Follow-ups (tracked, not in this PR)

- Structural enforcement of Fix 3 via a PreToolUse hook that detects agent-authored ship/update narration and redirects to `/telegram/post-update`.
- Audit remaining `notify('IMMEDIATE', 'system', ...)` callsites in `commands/server.ts` for other update-class messages that should route to Updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)