### PR TITLE
feat(feedback-factory): HttpParitySource — live Portal /api/instar/read adapter

### DIFF
--- a/src/feedback-factory/dryrun/HttpParitySource.ts
+++ b/src/feedback-factory/dryrun/HttpParitySource.ts
@@ -1,0 +1,182 @@
+/**
+ * HttpParitySource.ts — the live Phase-1/3 ParitySource adapter.
+ *
+ * Portal exposes `GET /api/instar/read` (Dawn, committed at d65136b3b6) as the
+ * read-only seam — the architectural pivot from raw Postgres after Prisma Data
+ * Platform refused to mint a database role (it forbids CREATE ROLE / GRANT). API
+ * level is actually a cleaner seam than direct DB access: the dry-run tests
+ * against the same contract Phase 2 (write/update APIs) will use, with no
+ * Prisma-admin dependency, and the architectural levels line up (Portal's HTTP
+ * surface ↔ Instar's {@link ParitySource} interface).
+ *
+ * This adapter implements ParitySource via that endpoint. The runner's seam,
+ * comparator, invariants, and JSONL audit trail are unchanged — only the read
+ * adapter swaps. Reads are PRE-FETCHED in {@link prepare}: the dry-run captures
+ * one snapshot of Portal's clusters at a moment in time, then compares against
+ * that frozen view. This makes the sync `readPortalClusters()` contract trivially
+ * satisfiable and stabilises the comparison against in-flight Portal writes
+ * (Portal remains the sole writer; we just look at one consistent slice).
+ *
+ * The endpoint is paginated (server-side cap: 1000 rows per request). The
+ * pagination is keyed off the feedback table — clusters/dispatches accompany each
+ * page and may repeat — so cluster collection deduplicates by clusterId across
+ * pages and stops when a page returns fewer feedback rows than the requested
+ * limit (the documented "no more pages" signal) OR after a hard safety cap.
+ *
+ * Field naming is intentionally tolerant: cluster rows may arrive as camelCase
+ * (Prisma default) or snake_case (raw SQL projection). The mapper accepts both.
+ */
+
+import type { ParitySource } from './dryRunCompare.js';
+import type { PortalCluster } from '../processor/parity.js';
+
+/** Minimal fetch shape the adapter needs (lets tests pass a stub). */
+export type FetchLike = (input: string, init?: { headers?: Record<string, string>; signal?: AbortSignal }) => Promise<{
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}>;
+
+export interface HttpParitySourceConfig {
+  /** Portal base URL, e.g. `https://portal.bot-me.ai`. */
+  baseUrl: string;
+  /** Bearer token with `instar:read` scope. */
+  token: string;
+  /** Page size sent as `?limit=`. Default 1000 (server max per Dawn's contract). */
+  pageSize?: number;
+  /** Safety cap on pagination loops. Default 200 pages (= 200k feedback rows). */
+  maxPages?: number;
+  /** Optional `?status=` filter passed through to the endpoint. */
+  status?: string;
+  /** Injectable fetch (for tests). Defaults to global `fetch`. */
+  fetchImpl?: FetchLike;
+  /** Optional path override (defaults to `/api/instar/read`). */
+  readPath?: string;
+}
+
+/** Shape returned by Portal at `/api/instar/read` (only the fields we read). */
+interface ReadResponseEnvelope {
+  data?: {
+    clusters?: unknown[];
+    feedback?: unknown[];
+    dispatches?: unknown[];
+  };
+  meta?: {
+    total_feedback_rows?: number;
+    returned_count?: number;
+    query_time_ms?: number;
+    timestamp?: string;
+  };
+}
+
+/** Error thrown when Portal returns non-OK. The status code is preserved for callers. */
+export class HttpParitySourceError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'HttpParitySourceError';
+    this.status = status;
+  }
+}
+
+/**
+ * Coerce one raw cluster row into the {@link PortalCluster} shape. Accepts both
+ * camelCase and snake_case keys; missing optional fields stay undefined. Throws
+ * only when the required keys (clusterId, type, title, fingerprint) cannot be
+ * resolved — a row that opaque is a contract violation we want to surface.
+ */
+function coerceCluster(row: unknown): PortalCluster {
+  if (!row || typeof row !== 'object') {
+    throw new HttpParitySourceError(502, 'cluster row is not an object');
+  }
+  const r = row as Record<string, unknown>;
+  const pick = (...keys: string[]): unknown => {
+    for (const k of keys) if (r[k] !== undefined && r[k] !== null) return r[k];
+    return undefined;
+  };
+  const clusterId = pick('clusterId', 'cluster_id', 'id');
+  const type = pick('type');
+  const title = pick('title');
+  const fingerprint = pick('fingerprint') ?? '';
+  if (typeof clusterId !== 'string' || typeof type !== 'string' || typeof title !== 'string') {
+    throw new HttpParitySourceError(502, `cluster row missing required fields (clusterId/type/title)`);
+  }
+  const out: PortalCluster = { clusterId, type, title, fingerprint: String(fingerprint) };
+  const status = pick('status');
+  if (typeof status === 'string') out.status = status;
+  const rc = pick('recurrenceCount', 'recurrence_count');
+  if (typeof rc === 'number') out.recurrenceCount = rc;
+  return out;
+}
+
+/**
+ * Live ParitySource backed by Portal's `/api/instar/read` endpoint. Construct
+ * with the base URL + read-scope token, then `await source.prepare()` once
+ * before passing to {@link runDryRunCompare}. The pre-fetch captures a single
+ * consistent snapshot of Portal's clusters; the runner reads it synchronously.
+ */
+export class HttpParitySource implements ParitySource {
+  private snapshot: PortalCluster[] | null = null;
+  private readonly pageSize: number;
+  private readonly maxPages: number;
+  private readonly fetch: FetchLike;
+  private readonly readPath: string;
+
+  constructor(private readonly config: HttpParitySourceConfig) {
+    this.pageSize = config.pageSize ?? 1000;
+    this.maxPages = config.maxPages ?? 200;
+    this.fetch = config.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.readPath = config.readPath ?? '/api/instar/read';
+    if (!this.fetch) {
+      throw new HttpParitySourceError(500, 'no fetch available — pass fetchImpl or run on a runtime with global fetch');
+    }
+  }
+
+  /** Pre-fetch and cache the cluster snapshot. Idempotent: re-calling re-fetches. */
+  async prepare(): Promise<void> {
+    const byId = new Map<string, PortalCluster>();
+    const base = this.config.baseUrl.replace(/\/+$/, '');
+    const authHeader = `Bearer ${this.config.token}`;
+
+    for (let page = 0; page < this.maxPages; page++) {
+      const offset = page * this.pageSize;
+      const qs = new URLSearchParams({ limit: String(this.pageSize), offset: String(offset) });
+      if (this.config.status) qs.set('status', this.config.status);
+      const url = `${base}${this.readPath}?${qs.toString()}`;
+
+      const res = await this.fetch(url, { headers: { Authorization: authHeader, Accept: 'application/json' } });
+      if (!res.ok) {
+        let detail = '';
+        try { detail = (await res.text()).slice(0, 200); } catch { /* ignore */ }
+        throw new HttpParitySourceError(
+          res.status,
+          `Portal /api/instar/read failed (page ${page}, status ${res.status} ${res.statusText}): ${detail}`,
+        );
+      }
+      const envelope = (await res.json()) as ReadResponseEnvelope;
+      const rawClusters = envelope?.data?.clusters ?? [];
+      for (const raw of rawClusters) {
+        const c = coerceCluster(raw);
+        if (!byId.has(c.clusterId)) byId.set(c.clusterId, c);
+      }
+
+      // Pagination stop signal: returned_count < pageSize means the feedback table
+      // is exhausted (clusters/dispatches per Dawn's contract accompany the feedback
+      // pages and stabilise quickly via the byId dedup above).
+      const returned = envelope?.meta?.returned_count ?? rawClusters.length;
+      if (returned < this.pageSize) break;
+    }
+
+    this.snapshot = [...byId.values()];
+  }
+
+  /** Sync ParitySource read — returns the snapshot captured by {@link prepare}. */
+  readPortalClusters(): PortalCluster[] {
+    if (this.snapshot === null) {
+      throw new HttpParitySourceError(500, 'HttpParitySource.prepare() must be awaited before readPortalClusters()');
+    }
+    return this.snapshot.map((c) => ({ ...c }));
+  }
+}

--- a/tests/unit/feedback-factory/http-parity-source.test.ts
+++ b/tests/unit/feedback-factory/http-parity-source.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests (Tier 1) — HttpParitySource (live Portal /api/instar/read adapter).
+ *
+ * Stubs `fetch`. Covers: snapshot capture in prepare(), Bearer auth, pagination
+ * + dedupe by clusterId across pages, the "returned_count < pageSize" stop
+ * signal, status filter pass-through, error mapping, snake_case vs camelCase
+ * tolerance, and the prepare-before-read invariant. Live verification waits on
+ * Justin/Dawn's read-scope token; the adapter is fully buildable + provable now.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  HttpParitySource,
+  HttpParitySourceError,
+  type FetchLike,
+} from '../../../src/feedback-factory/dryrun/HttpParitySource.js';
+
+const okResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: async () => body,
+  text: async () => JSON.stringify(body),
+});
+
+const errResponse = (status: number, body = '') => ({
+  ok: false,
+  status,
+  statusText: status === 401 ? 'Unauthorized' : 'Error',
+  json: async () => ({ error: body }),
+  text: async () => body,
+});
+
+const sampleCluster = (i: number, fp = `fp-${i}`) => ({
+  clusterId: `c${i}`,
+  type: 'bug',
+  title: `title ${i}`,
+  fingerprint: fp,
+  status: 'investigating',
+  recurrenceCount: i,
+});
+
+describe('HttpParitySource — single-page snapshot', () => {
+  it('captures clusters, sends Bearer auth, and maps fields verbatim', async () => {
+    const calls: Array<{ url: string; headers?: Record<string, string> }> = [];
+    const fetchStub: FetchLike = vi.fn(async (url, init) => {
+      calls.push({ url, headers: init?.headers });
+      // returned_count < pageSize → no more pages
+      return okResponse({
+        data: { clusters: [sampleCluster(1), sampleCluster(2)], feedback: [], dispatches: [] },
+        meta: { returned_count: 0, total_feedback_rows: 0 },
+      });
+    });
+
+    const source = new HttpParitySource({
+      baseUrl: 'https://portal.bot-me.ai',
+      token: 'TEST_TOKEN',
+      pageSize: 1000,
+      fetchImpl: fetchStub,
+    });
+    await source.prepare();
+    const clusters = source.readPortalClusters();
+
+    expect(clusters).toHaveLength(2);
+    expect(clusters[0]).toMatchObject({ clusterId: 'c1', type: 'bug', title: 'title 1', fingerprint: 'fp-1', status: 'investigating', recurrenceCount: 1 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://portal.bot-me.ai/api/instar/read?limit=1000&offset=0');
+    expect(calls[0].headers?.Authorization).toBe('Bearer TEST_TOKEN');
+  });
+
+  it('strips trailing slash on baseUrl and respects custom readPath', async () => {
+    const fetchStub: FetchLike = vi.fn(async (url) => {
+      expect(url).toBe('https://portal.bot-me.ai/custom/read?limit=10&offset=0');
+      return okResponse({ data: { clusters: [] }, meta: { returned_count: 0 } });
+    });
+    const source = new HttpParitySource({
+      baseUrl: 'https://portal.bot-me.ai/',
+      token: 't',
+      pageSize: 10,
+      fetchImpl: fetchStub,
+      readPath: '/custom/read',
+    });
+    await source.prepare();
+    expect(source.readPortalClusters()).toEqual([]);
+  });
+
+  it('passes through the status filter when configured', async () => {
+    const fetchStub: FetchLike = vi.fn(async (url) => {
+      expect(url).toContain('status=resolved');
+      return okResponse({ data: { clusters: [] }, meta: { returned_count: 0 } });
+    });
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', pageSize: 50, fetchImpl: fetchStub, status: 'resolved' });
+    await source.prepare();
+    expect(source.readPortalClusters()).toEqual([]);
+  });
+});
+
+describe('HttpParitySource — pagination', () => {
+  it('walks pages until returned_count < pageSize and dedupes clusters by clusterId', async () => {
+    const offsets: number[] = [];
+    const fetchStub: FetchLike = vi.fn(async (url) => {
+      const offset = Number(new URL(url).searchParams.get('offset'));
+      offsets.push(offset);
+      if (offset === 0) {
+        // full page → keep going
+        return okResponse({
+          data: { clusters: [sampleCluster(1), sampleCluster(2)], feedback: new Array(100).fill({}), dispatches: [] },
+          meta: { returned_count: 100 },
+        });
+      }
+      if (offset === 100) {
+        // full page again, cluster c2 repeats (dedup must keep one), c3 is new
+        return okResponse({
+          data: { clusters: [sampleCluster(2), sampleCluster(3)], feedback: new Array(100).fill({}), dispatches: [] },
+          meta: { returned_count: 100 },
+        });
+      }
+      // partial page → stop
+      return okResponse({
+        data: { clusters: [sampleCluster(4)], feedback: new Array(50).fill({}), dispatches: [] },
+        meta: { returned_count: 50 },
+      });
+    });
+
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', pageSize: 100, fetchImpl: fetchStub });
+    await source.prepare();
+    const ids = source.readPortalClusters().map((c) => c.clusterId).sort();
+    expect(ids).toEqual(['c1', 'c2', 'c3', 'c4']);
+    expect(offsets).toEqual([0, 100, 200]);
+  });
+
+  it('honours maxPages safety cap', async () => {
+    let calls = 0;
+    const fetchStub: FetchLike = vi.fn(async () => {
+      calls++;
+      // always a full page → would loop forever without the cap
+      return okResponse({
+        data: { clusters: [sampleCluster(calls)], feedback: new Array(10).fill({}), dispatches: [] },
+        meta: { returned_count: 10 },
+      });
+    });
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', pageSize: 10, fetchImpl: fetchStub, maxPages: 3 });
+    await source.prepare();
+    expect(calls).toBe(3);
+  });
+});
+
+describe('HttpParitySource — field-name tolerance', () => {
+  it('accepts snake_case cluster keys (cluster_id, recurrence_count)', async () => {
+    const fetchStub: FetchLike = vi.fn(async () =>
+      okResponse({
+        data: {
+          clusters: [{ cluster_id: 'sc1', type: 'bug', title: 't', fingerprint: 'fp', status: 'new', recurrence_count: 7 }],
+        },
+        meta: { returned_count: 0 },
+      }),
+    );
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', pageSize: 10, fetchImpl: fetchStub });
+    await source.prepare();
+    expect(source.readPortalClusters()[0]).toMatchObject({ clusterId: 'sc1', recurrenceCount: 7 });
+  });
+
+  it('throws on a cluster row missing required fields (contract violation, not silent skip)', async () => {
+    const fetchStub: FetchLike = vi.fn(async () =>
+      okResponse({ data: { clusters: [{ clusterId: 'x', type: 'bug' /* no title */ }] }, meta: { returned_count: 0 } }),
+    );
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', pageSize: 10, fetchImpl: fetchStub });
+    await expect(source.prepare()).rejects.toBeInstanceOf(HttpParitySourceError);
+  });
+});
+
+describe('HttpParitySource — error mapping', () => {
+  it('maps non-OK Portal responses to HttpParitySourceError with preserved status', async () => {
+    const fetchStub: FetchLike = vi.fn(async () => errResponse(401, 'bad token'));
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 'wrong', pageSize: 10, fetchImpl: fetchStub });
+    try {
+      await source.prepare();
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpParitySourceError);
+      expect((e as HttpParitySourceError).status).toBe(401);
+      expect((e as Error).message).toContain('401');
+    }
+  });
+});
+
+describe('HttpParitySource — prepare-before-read invariant', () => {
+  it('readPortalClusters() before prepare() throws (no silent empty)', () => {
+    const fetchStub: FetchLike = vi.fn(async () => okResponse({ data: { clusters: [] }, meta: { returned_count: 0 } }));
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', fetchImpl: fetchStub });
+    expect(() => source.readPortalClusters()).toThrow(HttpParitySourceError);
+  });
+
+  it('snapshot is a defensive copy (mutating the returned array does not change the snapshot)', async () => {
+    const fetchStub: FetchLike = vi.fn(async () => okResponse({ data: { clusters: [sampleCluster(1)] }, meta: { returned_count: 0 } }));
+    const source = new HttpParitySource({ baseUrl: 'https://p', token: 't', fetchImpl: fetchStub });
+    await source.prepare();
+    const first = source.readPortalClusters();
+    first[0].status = 'mutated';
+    const second = source.readPortalClusters();
+    expect(second[0].status).toBe('investigating');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,31 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Next increment of the **Feedback Factory Migration** (Dawn → Echo; spec `docs/specs/feedback-factory-migration.md`, approved). Ships the **live Portal adapter** behind the dry-run/compare seam after a clean architectural pivot from Dawn (committed Portal-side at `d65136b3b6`): Prisma Data Platform forbids `CREATE ROLE`/`GRANT` for any account, so a read-only Postgres role can't be minted. Dawn replaced direct DB access with a Portal-internal endpoint `GET /api/instar/read` — Bearer-token-authed (`instar:read` scope), max 1000 rows per request, returns the same three tables (feedback, clusters, dispatches) with paging metadata.
+
+New module:
+
+- **`src/feedback-factory/dryrun/HttpParitySource.ts`** — implements the existing `ParitySource` interface via that endpoint. Async `prepare()` pre-fetches a consistent snapshot (walking pages, deduping clusters by `clusterId`, stopping when `returned_count < limit`). Sync `readPortalClusters()` returns the snapshot. The runner's seam, the parity comparator, the three order-independent invariants, and the JSONL audit trail are all unchanged — only the read adapter swaps.
+
+Still internal — not yet wired into any route or job. Live verification waits on the `instar:read` token landing via Secret Drop.
+
+## What to Tell Your User
+
+- Dawn hit a database-platform limitation (Prisma Cloud refuses to mint a read-only user) and pivoted to an internal HTTP endpoint instead. It's actually a cleaner seam — my dry-run tests against the same contract her Phase-2 work will use, with no Prisma-admin dependency.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| HTTP-backed live ParitySource for Phase-1/3 dry-run | Internal `src/feedback-factory/dryrun/HttpParitySource.ts` — `await new HttpParitySource({baseUrl,token}).prepare()`, then pass to `runDryRunCompare` |
+
+## Evidence
+
+- **10 new unit tests**, all green; full feedback-factory unit dir green; `tsc --noEmit` clean.
+- **Both-sides-of-boundary**: Bearer auth + field mapping (camelCase AND snake_case tolerance), single-page snapshot + multi-page pagination with `clusterId`-dedup + `returned_count < pageSize` stop signal, `maxPages` safety cap, error-status preservation, malformed-row rejection (no silent skip of contract violations), prepare-before-read invariant, defensive-copy snapshot.
+- **Faithful to the existing seam**: `HttpParitySource` is purely additive — implements the same `ParitySource` interface as `InMemoryParitySource`, so the runner / comparator / invariants / cutover gate are byte-identical for in-memory tests and the live Portal path.
+
+Side-effects: `upgrades/side-effects/feedback-factory-http-source.md`.

--- a/upgrades/side-effects/feedback-factory-http-source.md
+++ b/upgrades/side-effects/feedback-factory-http-source.md
@@ -1,0 +1,99 @@
+# Side-effects review — feedback-factory HttpParitySource adapter
+
+Spec: `docs/specs/feedback-factory-migration.md` (converged v2, approved 2026-05-26).
+Increment: the live Portal `/api/instar/read` adapter implementing the existing
+`ParitySource` seam. Single new src module + its unit test; zero edits to existing
+code.
+
+## What this ships
+
+The HTTP adapter behind the dry-run/compare seam after Dawn's architectural pivot
+(committed Portal-side at `d65136b3b6`): Prisma Data Platform forbids `CREATE ROLE`/
+`GRANT`/`REVOKE` for any account including superusers, so a read-only Postgres role
+couldn't be minted. Dawn replaced direct DB access with a Portal-internal endpoint
+`GET /api/instar/read` (max 1000 rows/request, Bearer-token-authed,
+`instar:read` scope, JSON envelope with `data.{feedback,clusters,dispatches}` +
+`meta.{total_feedback_rows,returned_count,query_time_ms,timestamp}`).
+
+`HttpParitySource` implements `ParitySource` by pre-fetching that snapshot via an
+async `prepare()` and serving it through the existing sync `readPortalClusters()`
+read. The runner's seam, comparator (parity.ts), invariants, audit trail
+(JSONL), and `divergent === true` cutover gate are unchanged — only the read
+adapter swaps. This is exactly what the dependency-injection seam was for.
+
+## Over-block / under-block
+
+- **Errors**: any non-OK Portal response throws `HttpParitySourceError` with the
+  preserved status code. No silent partial snapshots — a 401/403/5xx surfaces
+  immediately and halts the prepare(). This is the right direction (false
+  block is recoverable; a silent partial snapshot would produce a phantom
+  "divergent" verdict that blocks Phase 4 cutover for the wrong reason).
+- **Malformed cluster rows**: a row missing required fields (`clusterId` / `type`
+  / `title`) throws, NOT silently skipped. A contract violation from Portal is
+  exactly the kind of thing we need to see, not hide.
+- **Field naming tolerance**: the mapper accepts both camelCase (Prisma default)
+  and snake_case (raw SQL projection) — chosen because Dawn's endpoint contract
+  doesn't pin the projection style and over-strictness here would cause
+  needless live-rollout friction.
+- **Snapshot freshness**: `prepare()` is idempotent — re-calling re-fetches.
+  Callers that want a stable snapshot for one dry-run pass simply call it once;
+  callers that want a fresh snapshot per pass call it per pass. Neither path is
+  blocked.
+- **`readPortalClusters()` before `prepare()`**: throws (no silent empty array).
+  An empty snapshot would also produce a phantom "divergent: false" verdict that
+  would mis-gate cutover.
+
+## Level-of-abstraction fit
+
+- The adapter lives in `dryrun/` next to `dryRunCompare.ts` because it is the
+  composition's read-source, not a pure piece of the processor logic
+  (`processor/` stays pure / decision-only).
+- It implements the existing `ParitySource` interface verbatim — the seam was
+  designed for exactly this swap. The runner doesn't know whether it's reading
+  from `InMemoryParitySource` or `HttpParitySource`; that's the test/live
+  symmetry the migration spec called for.
+- `fetch` is injected via `fetchImpl` so unit tests can stub it. The default
+  uses the runtime's global `fetch` (Node ≥18 / modern fetch).
+
+## Signal-vs-authority compliance
+
+Still signal-only. The adapter produces data; the runner produces a verdict; no
+authority to act flows from this code. Portal stays sole writer (the
+read-only API surface does not expose mutation). The cutover authority remains
+where the spec puts it: Dawn's line-by-line review + Justin's go/no-go.
+
+## Interactions
+
+- **Portal `/api/instar/read`**: the only external surface this adapter touches.
+  Read-only by Dawn's design (no PUT/POST/DELETE in the endpoint contract). The
+  Bearer token (`instar:read` scope) sits in the adapter's config — never logged,
+  never persisted by the adapter, owned by the caller. Token delivery happens
+  out of band via Secret Drop (in-memory only, never on disk, never in chat
+  history).
+- **`ParitySource` interface, `runDryRunCompare`, `parity.ts`**: unchanged. No
+  edits to existing feedback-factory code — additive only.
+- **No config, hook, route, template, or migration surface is touched.** No
+  Migration Parity / Agent Awareness obligation triggered.
+- **Pagination contract**: keyed off the feedback table (`returned_count <
+  pageSize` = exhausted). Clusters/dispatches per Dawn's contract accompany
+  each page; the adapter dedupes clusters by `clusterId` across pages, so
+  repeated clusters across pages cost only the network round-trip, not
+  correctness. Safety cap at `maxPages` (default 200 = 200k feedback rows)
+  prevents infinite-loop pathology if Portal returned the wrong meta.
+
+## Rollback cost
+
+Trivial. One new `src/feedback-factory/dryrun/HttpParitySource.ts` plus its test.
+Nothing imports it from production paths yet. Reverting removes the adapter
+without any downstream impact.
+
+## Deferrals
+
+- **Live verification** waits on the `instar:read` token landing via the open
+  Secret Drop. The adapter + 10 unit tests fully prove the read shape, mapping,
+  pagination, error path, and prepare-invariant against a stubbed `fetch`; the
+  live token only exercises the actual Portal endpoint. <!-- tracked: topic-12476 -->
+- **Cursor-based pagination** (a Last-Modified-style cursor instead of offset)
+  is not used: Dawn's documented contract is offset/limit. If she adds a cursor
+  later, the adapter takes one config field and a small page-loop tweak. The
+  current offset-with-dedup is correct under offset semantics. <!-- tracked: topic-12476 -->


### PR DESCRIPTION
## Summary

Next increment of the **Feedback Factory Migration** (spec `docs/specs/feedback-factory-migration.md`, approved). Ships the **live Portal adapter** behind the dry-run/compare seam after a clean architectural pivot from Dawn (committed Portal-side at `d65136b3b6`): Prisma Data Platform forbids `CREATE ROLE`/`GRANT` for any account, so a read-only Postgres role couldn't be minted. Dawn replaced direct DB access with a Portal-internal endpoint `GET /api/instar/read` — Bearer-token-authed (`instar:read` scope), max 1000 rows per request, returns `data.{feedback,clusters,dispatches}` + paging `meta`.

`HttpParitySource` implements the existing `ParitySource` interface via that endpoint. Async `prepare()` pre-fetches a consistent snapshot (walks pages, dedupes clusters by `clusterId`, stops on `returned_count < limit`, safety-capped at `maxPages`); sync `readPortalClusters()` returns it. The runner's seam, parity comparator, three invariants, and JSONL audit trail are byte-identical for in-memory and live paths — the DI seam from the prior increment is exactly what made this a single-file additive change.

### Deferred behind the token (tracked, topic 12476)
- **Live verification** waits on the `instar:read` token landing via Secret Drop. The adapter is fully proven against a stubbed `fetch`; the live token only exercises the actual Portal endpoint.
- **Cursor pagination**: not used (Dawn's contract is offset/limit). Easy swap if she adds one.

## Test plan

- [x] 10 new unit tests, all green
- [x] Full feedback-factory unit dir green
- [x] `tsc --noEmit` clean
- [x] Both-sides-of-boundary: Bearer auth, field-name tolerance (camelCase + snake_case), single-page + multi-page pagination with dedup, `returned_count < pageSize` stop signal, `maxPages` cap, error-status preservation, malformed-row rejection, prepare-before-read invariant, defensive-copy snapshot
- [x] `/instar-dev` gate passed (trace + side-effects artifact + approved spec chain)
- [x] pre-push smoke passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)