### PR TITLE
fix(messaging): mentee receiver wiring fires on lifeline-forward path

### DIFF
--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -1309,6 +1309,21 @@ export class TelegramLifeline {
     text: string,
     rawMsg: NonNullable<TelegramUpdate['message']>,
   ): Promise<boolean> {
+    // a2a spoof-defense fields (MENTOR-LIVE-READINESS-SPEC §Recipient side). The
+    // server's /internal/telegram-forward handler passes these to
+    // `TelegramAdapter.dispatchAgentMessageHook` so the a2a hook can distinguish
+    // a real bot-sent marker (route) from a user typing a marker-shaped string
+    // (drop as `agent-marker-spoofed-by-user`). An older server reads only the
+    // fields it knows and ignores the rest. An older lifeline omits them →
+    // server treats senderIsBot as falsy → marker-bearing forwards drop closed,
+    // matching the spec invariant (a real user typing a marker MUST be dropped).
+    const rawFrom = rawMsg.from as { id?: number; is_bot?: boolean } | undefined;
+    const rawSenderChat = (rawMsg as { sender_chat?: { id?: number } }).sender_chat;
+    const senderIsBot = rawFrom?.is_bot === true;
+    const senderChatId = rawSenderChat?.id !== undefined ? String(rawSenderChat.id) : undefined;
+    const senderBotId =
+      senderChatId ?? (senderIsBot && rawFrom?.id !== undefined ? String(rawFrom.id) : undefined);
+
     const buildBody = (includeVersion: boolean): string =>
       JSON.stringify({
         topicId,
@@ -1318,6 +1333,9 @@ export class TelegramLifeline {
         fromFirstName: rawMsg.from.first_name,
         messageId: rawMsg.message_id,
         timestamp: new Date(rawMsg.date * 1000).toISOString(),
+        senderIsBot,
+        ...(senderChatId !== undefined ? { senderChatId } : {}),
+        ...(senderBotId !== undefined ? { senderBotId } : {}),
         ...(includeVersion ? { lifelineVersion: this.lifelineVersion } : {}),
       });
 

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -1663,6 +1663,56 @@ export class TelegramAdapter implements MessagingAdapter {
     this.agentMessageHook = hook;
   }
 
+  /**
+   * Dispatch an inbound text to the installed agent-message hook (if any) BEFORE
+   * normal user-message routing. Returns true iff the hook claimed the message
+   * (`{handled: true}`); the caller MUST then short-circuit and NOT route the
+   * message to the user-message flow.
+   *
+   * Why this is public: in send-only mode the primary adapter doesn't poll —
+   * the lifeline polls and forwards via `/internal/telegram-forward`. The
+   * forwarded path calls `onTopicMessage` directly, bypassing the polling
+   * text-dispatch site where the hook lives. Exposing this dispatcher lets the
+   * forward handler invoke the same gate before falling through, so the
+   * mentee receiver wiring fires regardless of message origin.
+   *
+   * Spoof defense: the hook needs `senderIsBot` AND `senderChatId` to decide
+   * whether a marker-bearing message is from a real bot or a user typing a
+   * marker-shaped string (spec §Routing matrix:
+   * `agent-marker-spoofed-by-user`). The caller passes through what it has;
+   * `senderBotId` is derived as `senderChatId` (group bot-as-channel) or the
+   * passed `rawFromId` when `senderIsBot` is true (DM / topic post by a bot).
+   */
+  async dispatchAgentMessageHook(ctx: {
+    text: string;
+    topicId: number;
+    senderIsBot: boolean;
+    senderChatId?: string;
+    senderBotId?: string;
+    rawFromId?: string;
+    now?: number;
+  }): Promise<boolean> {
+    if (!this.agentMessageHook) return false;
+    try {
+      const senderBotId =
+        ctx.senderBotId ?? ctx.senderChatId ?? (ctx.senderIsBot ? ctx.rawFromId : undefined);
+      const result = await this.agentMessageHook({
+        text: ctx.text,
+        topicId: ctx.topicId,
+        senderIsBot: ctx.senderIsBot,
+        senderChatId: ctx.senderChatId,
+        senderBotId,
+        now: ctx.now ?? Date.now(),
+      });
+      return result.handled === true;
+    } catch (err) {
+      // Hook must never crash the dispatch loop — log + fall through to normal user flow.
+      // (A broken hook is preferable to a frozen message pipeline.)
+      console.error(`[telegram] agentMessageHook error (falling through): ${err}`);
+      return false;
+    }
+  }
+
   async resolveUser(channelIdentifier: string): Promise<string | null> {
     return null;
   }
@@ -3722,24 +3772,16 @@ export class TelegramAdapter implements MessagingAdapter {
     // normal user-message dispatch on text messages so an a2a marker is intercepted as an
     // agent event (route or drop), never falling through to topic-session spawning. Other
     // message types can't carry markers — bypass entirely.
-    if (this.agentMessageHook && typeof text === 'string') {
-      try {
-        const senderChatId = msg.sender_chat?.id !== undefined ? String(msg.sender_chat.id) : undefined;
-        const senderBotId = senderChatId ?? (msg.from?.id !== undefined ? String(msg.from.id) : undefined);
-        const result = await this.agentMessageHook({
-          text,
-          topicId: numericTopicId,
-          senderIsBot: msg.from?.is_bot === true,
-          senderChatId,
-          senderBotId,
-          now: Date.now(),
-        });
-        if (result.handled) return;
-      } catch (err) {
-        // Hook must never crash the dispatch loop — log + fall through to normal user flow.
-        // (A broken hook is preferable to a frozen message pipeline.)
-        console.error(`[telegram] agentMessageHook error (falling through): ${err}`);
-      }
+    if (typeof text === 'string') {
+      const handled = await this.dispatchAgentMessageHook({
+        text,
+        topicId: numericTopicId,
+        senderIsBot: msg.from?.is_bot === true,
+        senderChatId: msg.sender_chat?.id !== undefined ? String(msg.sender_chat.id) : undefined,
+        senderBotId: undefined, // computed inside dispatch — see method docs
+        rawFromId: msg.from?.id !== undefined ? String(msg.from.id) : undefined,
+      });
+      if (handled) return;
     }
 
     // Fire topic message callback (always fires — General topic falls back to ID 1)

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -8910,7 +8910,16 @@ export function createRoutes(ctx: RouteContext): Router {
   let _versionMissingLogged = false;
 
   router.post('/internal/telegram-forward', async (req, res) => {
-    const { topicId, text, fromUserId, fromUsername, fromFirstName, messageId, lifelineVersion } = req.body;
+    const {
+      topicId, text, fromUserId, fromUsername, fromFirstName, messageId, lifelineVersion,
+      // a2a spoof-defense fields (MENTOR-LIVE-READINESS-SPEC §Recipient side). The
+      // lifeline forwards these when present in the Telegram update. Older lifelines
+      // omit them → `senderIsBot` defaults to falsy → any marker-bearing forwarded
+      // message is dropped as `agent-marker-spoofed-by-user` (fail-CLOSED for spoof
+      // defense, matching the spec invariant that a real user typing a marker MUST
+      // be dropped). Upgraded lifelines populate them and the hook routes normally.
+      senderIsBot, senderChatId, senderBotId,
+    } = req.body;
 
     // Server boot window: if version cache wasn't populated, skip handshake
     // rather than 426-erroneously. Lifeline retries after retryAfterMs.
@@ -9106,6 +9115,31 @@ export function createRoutes(ctx: RouteContext): Router {
         ctx.currentInboundByTopic?.set(String(topicId), dedupeKey);
       } catch (err) {
         console.error(`[telegram-forward] exactly-once gate error (fail-open, routing normally): ${err instanceof Error ? err.message : err}`);
+      }
+    }
+
+    // Agent-to-agent Telegram comms hook (spec MENTOR-LIVE-READINESS §Recipient side).
+    // The polling path invokes this gate inside the adapter; lifeline-forwarded messages
+    // bypass that path and arrive here, so we MUST invoke the same gate before falling
+    // through to user-message routing. If the hook returns handled=true we short-circuit
+    // — the message was an a2a event (routed to a role-handler or dropped per the spec's
+    // routing matrix) and must NOT also dispatch to the user-message path.
+    if (ctx.telegram && typeof text === 'string' && typeof topicId === 'number') {
+      try {
+        const handled = await ctx.telegram.dispatchAgentMessageHook({
+          text,
+          topicId,
+          senderIsBot: senderIsBot === true,
+          senderChatId: senderChatId !== undefined ? String(senderChatId) : undefined,
+          senderBotId: senderBotId !== undefined ? String(senderBotId) : undefined,
+          rawFromId: fromUserId !== undefined ? String(fromUserId) : undefined,
+        });
+        if (handled) {
+          res.json({ ok: true, forwarded: true, agentMessage: true });
+          return;
+        }
+      } catch (err) {
+        console.error(`[telegram-forward] agentMessageHook dispatch error (falling through): ${err instanceof Error ? err.message : err}`);
       }
     }
 

--- a/tests/integration/telegram-forward-a2a-dispatch.test.ts
+++ b/tests/integration/telegram-forward-a2a-dispatch.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tier-2 integration test for the /internal/telegram-forward → a2a-hook
+ * dispatch path (MENTOR-LIVE-READINESS-SPEC §Recipient side).
+ *
+ * The polling path invokes the agent-message hook inside the adapter; the
+ * lifeline-forward path used to bypass it (the bug that motivated this PR).
+ * This test asserts the route NOW calls `dispatchAgentMessageHook` BEFORE
+ * falling through to onTopicMessage:
+ *
+ *   1. Hook installed + claims message → response includes `agentMessage:true`,
+ *      onTopicMessage is NOT called (short-circuit).
+ *   2. Hook installed + lets message through → falls through to onTopicMessage.
+ *   3. No hook installed → falls through to onTopicMessage (existing behavior
+ *      preserved — pure additive change).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { ProcessIntegrity } from '../../src/core/ProcessIntegrity.js';
+
+function mountForwardRoute(telegram: unknown): express.Express {
+  const ctx = {
+    config: { projectName: 't', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0, authToken: '' } as any,
+    sessionManager: { listRunningSessions: () => [], isSessionAlive: () => false } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null, telegram, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, startTime: new Date(),
+    mentorRunner: null,
+    currentInboundByTopic: new Map(),
+  } as unknown as RouteContext;
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+// The /internal/telegram-forward handler fast-fails 503 if ProcessIntegrity's
+// runningVersion isn't a parseable semver. Freeze a known version in beforeEach
+// so the handshake path is bypassed cleanly (no lifelineVersion sent in body).
+beforeEach(() => { ProcessIntegrity.reset(); ProcessIntegrity.initialize('1.3.49', null); });
+afterEach(() => { ProcessIntegrity.reset(); });
+
+describe('/internal/telegram-forward → a2a-hook dispatch (integration)', () => {
+  it('SHORT-CIRCUITS when the hook claims the message (response carries agentMessage:true; onTopicMessage NOT called)', async () => {
+    let onTopicCalls = 0;
+    const adapter = {
+      onTopicMessage: () => { onTopicCalls++; },
+      logInboundMessage: () => undefined,
+      dispatchAgentMessageHook: async () => true,
+    };
+    const app = mountForwardRoute(adapter);
+    const res = await request(app)
+      .post('/internal/telegram-forward')
+      .set('Authorization', 'Bearer test')
+      .send({
+        topicId: 458,
+        text: '[a2a:from=echo to=instar-codey role=mentor id=a corr=a ts=1 v=1]\nhi',
+        fromUserId: 8781020500,
+        fromUsername: 'echo_mentor_bot',
+        fromFirstName: 'Echo Mentor',
+        messageId: 690,
+        senderIsBot: true,
+        senderBotId: '8781020500',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, forwarded: true, agentMessage: true });
+    expect(onTopicCalls).toBe(0);
+  });
+
+  it('FALLS THROUGH to onTopicMessage when the hook does NOT claim the message', async () => {
+    let onTopicCalls = 0;
+    const adapter = {
+      onTopicMessage: () => { onTopicCalls++; },
+      logInboundMessage: () => undefined,
+      dispatchAgentMessageHook: async () => false,
+    };
+    const app = mountForwardRoute(adapter);
+    const res = await request(app)
+      .post('/internal/telegram-forward')
+      .set('Authorization', 'Bearer test')
+      .send({
+        topicId: 458, text: 'hello user', fromUserId: 7812716706, messageId: 700,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.agentMessage).toBeUndefined();
+    expect(onTopicCalls).toBe(1);
+  });
+
+  it('preserves existing behavior when the adapter has NO dispatchAgentMessageHook (older adapter, pure additive change)', async () => {
+    let onTopicCalls = 0;
+    const adapter = {
+      onTopicMessage: () => { onTopicCalls++; },
+      logInboundMessage: () => undefined,
+      // No dispatchAgentMessageHook
+    };
+    const app = mountForwardRoute(adapter);
+    const res = await request(app)
+      .post('/internal/telegram-forward')
+      .set('Authorization', 'Bearer test')
+      .send({
+        topicId: 458, text: 'hello user', fromUserId: 7812716706, messageId: 701,
+      });
+    expect(res.status).toBe(200);
+    expect(onTopicCalls).toBe(1);
+  });
+});

--- a/tests/unit/TelegramAdapter-dispatchAgentMessageHook.test.ts
+++ b/tests/unit/TelegramAdapter-dispatchAgentMessageHook.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tier-1 unit tests for `TelegramAdapter.dispatchAgentMessageHook` —
+ * the public dispatcher that lets external callers (notably the
+ * /internal/telegram-forward handler in send-only mode, where the adapter
+ * doesn't poll) invoke the same a2a-hook gate the polling path uses.
+ *
+ * Covers:
+ *   - returns false when no hook is installed (no-op safe)
+ *   - returns true and invokes the hook when one is installed + handled
+ *   - returns false when the hook errors (fail-OPEN to user routing, never
+ *     crashes the dispatch pipeline)
+ *   - derives senderBotId correctly per spec §Recipient side (sender_chat
+ *     wins; falls back to rawFromId iff senderIsBot)
+ *   - omits senderBotId for human users (rawFromId without senderIsBot)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+
+function adapter(): TelegramAdapter {
+  return new TelegramAdapter(
+    { token: 'fake-token', chatId: '-1001234567890' } as never,
+    '/tmp/fake-state-dir-' + Math.random().toString(36).slice(2, 10),
+  );
+}
+
+describe('TelegramAdapter.dispatchAgentMessageHook', () => {
+  it('returns false (no-op) when no hook is installed', async () => {
+    const a = adapter();
+    const handled = await a.dispatchAgentMessageHook({
+      text: 'hi', topicId: 1, senderIsBot: true, rawFromId: '123',
+    });
+    expect(handled).toBe(false);
+  });
+
+  it('returns true when hook returns handled:true', async () => {
+    const a = adapter();
+    const hook = vi.fn().mockResolvedValue({ handled: true });
+    a.setAgentMessageHook(hook);
+    const handled = await a.dispatchAgentMessageHook({
+      text: 'hi', topicId: 1, senderIsBot: true, rawFromId: '123',
+    });
+    expect(handled).toBe(true);
+    expect(hook).toHaveBeenCalledOnce();
+  });
+
+  it('returns false when hook returns handled:false (fall through to user routing)', async () => {
+    const a = adapter();
+    a.setAgentMessageHook(vi.fn().mockResolvedValue({ handled: false }));
+    const handled = await a.dispatchAgentMessageHook({
+      text: 'no marker here', topicId: 1, senderIsBot: false, rawFromId: '7',
+    });
+    expect(handled).toBe(false);
+  });
+
+  it('FAIL-OPEN: hook throw → returns false + does not propagate (a broken hook never freezes the pipeline)', async () => {
+    const a = adapter();
+    a.setAgentMessageHook(vi.fn().mockRejectedValue(new Error('hook is broken')));
+    const handled = await a.dispatchAgentMessageHook({
+      text: 'hi', topicId: 1, senderIsBot: true, rawFromId: '123',
+    });
+    expect(handled).toBe(false);
+  });
+
+  it('derives senderBotId from sender_chat.id when present (group bot-as-channel relay)', async () => {
+    const a = adapter();
+    let received: Record<string, unknown> | undefined;
+    a.setAgentMessageHook(async (ctx) => { received = ctx; return { handled: true }; });
+    await a.dispatchAgentMessageHook({
+      text: 'x', topicId: 1, senderIsBot: true,
+      senderChatId: '-1001', rawFromId: '999',
+    });
+    expect(received?.senderBotId).toBe('-1001');
+  });
+
+  it('derives senderBotId from rawFromId when senderIsBot AND no sender_chat (DM / topic post by a bot)', async () => {
+    const a = adapter();
+    let received: Record<string, unknown> | undefined;
+    a.setAgentMessageHook(async (ctx) => { received = ctx; return { handled: true }; });
+    await a.dispatchAgentMessageHook({
+      text: 'x', topicId: 1, senderIsBot: true,
+      rawFromId: '8781020500',
+    });
+    expect(received?.senderBotId).toBe('8781020500');
+  });
+
+  it('OMITS senderBotId when senderIsBot is false AND no sender_chat (real user — spoof-defense input)', async () => {
+    const a = adapter();
+    let received: Record<string, unknown> | undefined;
+    a.setAgentMessageHook(async (ctx) => { received = ctx; return { handled: true }; });
+    await a.dispatchAgentMessageHook({
+      text: '[a2a:from=echo to=instar-codey role=mentor id=x corr=x ts=1 v=1]\nspoofed body',
+      topicId: 1, senderIsBot: false,
+      rawFromId: '7812716706', // human Justin
+    });
+    expect(received?.senderBotId).toBeUndefined();
+    expect(received?.senderIsBot).toBe(false);
+    // The downstream a2a hook will then drop as `agent-marker-spoofed-by-user`
+    // because senderIsBot===false AND senderChatId===undefined — covered by the
+    // existing buildAgentMessageHook tests, not re-tested here.
+  });
+
+  it('honors an explicit senderBotId override from the caller (forward-forward chain)', async () => {
+    const a = adapter();
+    let received: Record<string, unknown> | undefined;
+    a.setAgentMessageHook(async (ctx) => { received = ctx; return { handled: true }; });
+    await a.dispatchAgentMessageHook({
+      text: 'x', topicId: 1, senderIsBot: true,
+      senderBotId: 'explicit-override', senderChatId: '-1001', rawFromId: '999',
+    });
+    expect(received?.senderBotId).toBe('explicit-override');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,70 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Fix: mentee receiver wiring now fires on the lifeline-forward path.** The
+mentee receiver wiring shipped in PR #462 installs an a2a hook on the primary
+`TelegramAdapter`. But the hook only fired when the adapter polled directly.
+In production both Echo and Codey run with `--no-telegram` — the primary
+adapter is in send-only mode and never polls; the lifeline polls and forwards
+messages via `/internal/telegram-forward`, which called
+`ctx.telegram.onTopicMessage` directly and BYPASSED the a2a hook gate. The
+mentee-side receiver was dead in production as a result.
+
+This PR closes the gap end-to-end:
+
+1. **`TelegramAdapter.dispatchAgentMessageHook(ctx)` (new public method)** —
+   extracts the hook invocation from the polling text-dispatch path into a
+   reusable dispatcher. Polling now calls it; the lifeline-forward handler
+   ALSO calls it. Same gate, both paths.
+2. **`/internal/telegram-forward` (server)** — invokes
+   `dispatchAgentMessageHook` BEFORE falling through to `onTopicMessage`. If
+   the hook claims the message (`handled:true`), the route short-circuits
+   with `{ ok: true, forwarded: true, agentMessage: true }` and the
+   user-message path is NOT also dispatched.
+3. **`TelegramLifeline.forwardToServer` (lifeline)** — populates `senderIsBot`,
+   `senderChatId`, `senderBotId` in the forward body from the Telegram update.
+   Required so the a2a hook's spoof defense (drop a marker from a real user
+   typing a marker-shaped string) can apply on forwarded messages.
+
+**Backward compatibility:** newer server / older lifeline → `senderIsBot`
+omitted → treated as falsy → marker-bearing forwards drop closed (matches the
+spec invariant: a real user typing a marker MUST be dropped). Newer
+lifeline / older server → unknown fields ignored, no regression.
+
+**Caught by:** dogfood — Echo + Codey on v1.3.49, both with the receiver
+wiring from PR #462 installed and Codey's `config.mentee` block populated.
+Manual `/mentor/tick` failed silently because Codey's hook was never invoked
+on the lifeline-forward path. Spec §Recipient side describes the hook as
+"registered with `TelegramAdapter.onMessage`"; the original implementation
+read this as the polling path, missing the dual-path nature of message
+ingress in send-only mode.
+
+## What to Tell Your User
+
+A small fix that closes a quiet but real gap: the cross-agent mentor pipeline
+now actually fires end-to-end in production, not just in tests. The previous
+release shipped the receiver wiring, but only the polling adapter saw
+inbound a2a messages — and in production we run a separate process for
+polling, so the wiring was dead. After this update, mentor prompts route
+correctly through to mentee sessions, and replies come back. No config
+changes required on your end.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| `TelegramAdapter.dispatchAgentMessageHook(ctx)` | Public dispatcher — any caller in possession of the adapter can invoke the agent-message hook the same way the polling path does. The lifeline-forward handler now does this automatically. |
+| Lifeline-forward carries spoof-defense fields | `senderIsBot`/`senderChatId`/`senderBotId` are populated in the `/internal/telegram-forward` body so the a2a hook's spoof defense applies on forwarded messages. |
+
+## Evidence
+
+11 new tests, all green: 8 unit on `dispatchAgentMessageHook` (no-op safe,
+handled returns true, fall-through, FAIL-OPEN on hook throw, three
+senderBotId derivation modes, caller override); 3 integration on the
+`/internal/telegram-forward` route (short-circuit when claimed,
+fall-through when not, backward-compat with adapters lacking the method).
+`tsc --noEmit` clean. Side-effects review:
+`upgrades/side-effects/mentee-receiver-forward-dispatch.md`.

--- a/upgrades/side-effects/mentee-receiver-forward-dispatch.md
+++ b/upgrades/side-effects/mentee-receiver-forward-dispatch.md
@@ -1,0 +1,99 @@
+# Side-Effects Review — mentee receiver wiring fires on lifeline-forward path
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Recipient side.
+Fast-follow to PR #462 (mentee receiver wiring) — closes the dual-path
+ingress gap surfaced by dogfood.
+
+**Change:** Three production files + three test files.
+- `src/messaging/TelegramAdapter.ts` (+ ~55 LoC: `dispatchAgentMessageHook`
+  public method; polling text-dispatch now calls it instead of inlining the
+  hook logic — pure extraction, no behavior change on the polling path)
+- `src/server/routes.ts` (+ ~20 LoC: destructure `senderIsBot` /
+  `senderChatId` / `senderBotId` from forward body; invoke
+  `dispatchAgentMessageHook` before `onTopicMessage`; short-circuit on
+  `handled:true`)
+- `src/lifeline/TelegramLifeline.ts` (+ ~15 LoC: derive + include
+  `senderIsBot`/`senderChatId`/`senderBotId` in the forward body)
+- `tests/unit/TelegramAdapter-dispatchAgentMessageHook.test.ts` (new, 8)
+- `tests/integration/telegram-forward-a2a-dispatch.test.ts` (new, 3)
+
+## What changed
+
+1. **`dispatchAgentMessageHook` public method** on `TelegramAdapter`:
+   wraps the existing hook invocation with the FAIL-OPEN try/catch (a
+   broken hook never freezes the dispatch loop) and the senderBotId
+   derivation logic (sender_chat wins; rawFromId iff senderIsBot;
+   undefined for real users). Polling path now calls the dispatcher
+   instead of inlining the same code — pure extraction.
+2. **`/internal/telegram-forward` handler** destructures the new spoof-
+   defense fields from the request body. Before invoking `onTopicMessage`,
+   calls `dispatchAgentMessageHook`. On `handled:true`, returns
+   `{ ok: true, forwarded: true, agentMessage: true }` (NEW response shape
+   addition — additive, doesn't change the existing `{ ok, forwarded }`
+   contract for non-a2a forwards). On hook throw, logs + falls through
+   (same fail-open semantics as the polling path).
+3. **`TelegramLifeline.forwardToServer`** derives `senderIsBot` from
+   `rawMsg.from.is_bot === true`, `senderChatId` from
+   `rawMsg.sender_chat?.id`, `senderBotId` from `senderChatId ?? (isBot ?
+   rawMsg.from.id : undefined)`. Includes them in the buildBody output
+   only when they have values (omitted fields → server treats as falsy →
+   marker-bearing forwards drop closed for spoof defense).
+
+## The seven questions
+
+1. **Over-block.** N/A — additive. The forward route now invokes the hook
+   before `onTopicMessage`; if no hook is installed (or no adapter has
+   `dispatchAgentMessageHook`), the route falls through to the existing
+   behavior. Backward-compatible test (`preserves existing behavior when
+   the adapter has NO dispatchAgentMessageHook`) covers this.
+2. **Under-block.** Spoof defense is end-to-end on the forwarded path:
+   missing `senderIsBot` from older lifelines → server treats as falsy →
+   any marker drops as `agent-marker-spoofed-by-user`. This is the
+   fail-CLOSED side, matching spec invariant.
+3. **Level-of-abstraction fit.** Extraction-then-reuse: the hook
+   invocation logic moves from inlined to a method on the adapter, called
+   from both polling and forward paths. No new abstraction; just exposes
+   what was already there.
+4. **Signal vs authority.** The dispatcher returns a clean boolean to the
+   caller; the caller decides whether to short-circuit. Authority lives in
+   the caller (route or polling loop), not in the dispatcher. Same as the
+   prior inline version.
+5. **Interactions.** Reuses `agentMessageHook` set by `setAgentMessageHook`
+   — no new state. The forward route reads three new optional fields from
+   the body; older clients (lifeline pre-this-PR) omit them and get the
+   fail-CLOSED spoof defense automatically.
+6. **External surfaces.** The `/internal/telegram-forward` response gains
+   one additive flag (`agentMessage: true`) when the hook claims the
+   message; the existing `{ ok, forwarded }` contract is preserved
+   otherwise. No new routes. No new config.
+7. **Rollback cost.** Trivial — revert restores the inline hook call in
+   the polling path, drops the dispatcher and the forward-route call,
+   drops the lifeline body additions. The new `agentMessage:true` flag is
+   an additive response field, so any consumer relying on it would need a
+   one-line fix back to checking `forwarded:true` alone.
+
+## Testing
+
+11 new tests, all green (`tsc --noEmit` clean):
+
+- **Tier 1 unit (8):** `TelegramAdapter-dispatchAgentMessageHook` covers
+  no-op safe (no hook), handled:true short-circuit, handled:false
+  fall-through, FAIL-OPEN on hook throw, three senderBotId derivation
+  modes (sender_chat / rawFromId+isBot / undefined for users), explicit
+  override.
+- **Tier 2 integration (3):** `telegram-forward-a2a-dispatch` boots
+  `createRoutes` with a mock adapter through the real Express pipeline;
+  asserts short-circuit when hook claims, fall-through when not,
+  backward-compat when adapter lacks the method.
+- **Tier 3 E2E:** the existing `mentee-receiver-lifecycle.test.ts` from
+  PR #462 (which installs the hook end-to-end on server boot) plus the
+  live dogfood loop that motivated this PR are the lifecycle proof.
+
+## Migration parity
+
+No config changes; no new config keys. The lifeline-side change is
+deployed via the same npm release as the server-side change, so the
+mixed-version state is only momentary (server upgrades alongside its
+lifeline via the existing AutoUpdater + LifelineDriftPromoter pair).
+Mixed-version safety is preserved either direction (server new / lifeline
+old: spoof-fail-closed; server old / lifeline new: unknown fields ignored).


### PR DESCRIPTION
Fast-follow to #462. Caught by dogfood within 30 minutes of #462 merging.

## The gap

PR #462 installed the a2a hook on the primary `TelegramAdapter`, but the hook only fired on the adapter's polling path. In production both Echo and Codey run with `--no-telegram` — the primary adapter is send-only and never polls; the **lifeline polls and forwards** messages via `/internal/telegram-forward`, which called `ctx.telegram.onTopicMessage` directly and BYPASSED the a2a hook. The mentee-side receiver was dead in production as a result.

The spec describes the hook as "registered with `TelegramAdapter.onMessage`" (§Recipient side). I read that as the polling path. The actual production ingress in send-only mode is dual-path: polling OR forwarding. Owning it.

## The fix

Three coordinated changes:

1. **`TelegramAdapter.dispatchAgentMessageHook(ctx)`** — new public method. Extracts the hook invocation from the polling text-dispatch path (FAIL-OPEN try/catch + senderBotId derivation). Polling calls it; the forward handler calls it. Same gate, both paths.

2. **`/internal/telegram-forward`** — invokes the dispatcher BEFORE falling through to `onTopicMessage`. On `handled:true`, short-circuits with `{ok, forwarded, agentMessage:true}`. Older adapters lacking the method fall through unchanged (additive — covered by an integration test).

3. **`TelegramLifeline.forwardToServer`** — populates `senderIsBot` / `senderChatId` / `senderBotId` in the body. The spoof defense needs these to distinguish a real bot from a user typing a marker-shaped string.

## Mixed-version safety

Both directions:
- **Newer server + older lifeline** → missing `senderIsBot` → server treats as falsy → marker drops as `agent-marker-spoofed-by-user`. Fail-CLOSED for spoof defense; matches spec invariant.
- **Newer lifeline + older server** → unknown fields ignored; no regression.

## Tests

11 new tests, all green (`tsc --noEmit` clean):
- 8 unit on `dispatchAgentMessageHook`: no-op safe, handled:true, fall-through, FAIL-OPEN on throw, three senderBotId derivation modes, caller override.
- 3 integration on `/internal/telegram-forward`: short-circuit when claimed, fall-through when not, backward-compat (adapter lacks method).

## Side-effects review

`upgrades/side-effects/mentee-receiver-forward-dispatch.md` — the seven questions answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)