### PR TITLE
feat(threadline): LLM topic-name + summary for 'open this' (CMT-567)

### DIFF
--- a/docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-ELI16.md
+++ b/docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-ELI16.md
@@ -1,0 +1,41 @@
+# THREADLINE OPEN-THIS LLM NAMING — plain-English overview
+
+**What problem we're fixing.** Last night I made "open this" reliable — say it in the Threadline topic and a topic gets created and bound. But what you got was a topic with:
+
+1. A bad name — just the first 5 words of whatever the other agent said ("Hey echo quick check on"), not what the conversation is actually *about*.
+2. An empty room — the only message in the new topic was the generic "🧵 This conversation is now tied to this topic" tie-marker, with zero context about who you're talking to or what's going on.
+
+That's the opposite of what "open this" is supposed to do — you opened it because you wanted a *workable* topic, not an unlabelled empty one.
+
+**What I'm building.** Two strictly additive improvements, on the same deterministic "open this" path:
+
+1. **An LLM names the topic** from the actual conversation (what it's about — not the first words). Short, scannable, human-readable.
+2. **An LLM writes a one-paragraph orientation summary** as the first message in the new topic — who the other agent is, what the conversation is about, where it currently stands. So when you walk in, you're already oriented.
+
+Both use the existing intelligence provider through the shared LLM queue, so cost and rate-limiting are already governed.
+
+**What stays the same.** Everything from PR #399. "Open this" is still deterministic — the system catches it before any conversational me ever sees it. "Tie this to &lt;topic&gt;" still uses the topic name you picked, unchanged. The deterministic intercept itself isn't touched.
+
+**Safety: this NEVER breaks "open this".** There are three levels, best-first:
+1. **LLM brief** (best) — a smart name + a written summary.
+2. **Templated brief** (if the LLM can't run — timed out, daily cap hit, etc.) — a plain auto-built note: who you're talking to, how many messages, last activity, and the latest line. No model needed, instant, always works.
+3. **Bare marker** (only when there's literally no conversation behind the entry yet) — the old "tied to this topic" note.
+
+So you ALWAYS land in a topic with *some* real context now — never the empty room you saw. The LLM just makes it nicer when it's available; it's a *generator*, never a gate, so "open this" stays as reliable as last night.
+
+One review fix worth calling out: I'd originally put the LLM naming on a low-priority lane — which meant if you pinged me somewhere else at the same moment, the naming would get bumped and you'd silently get the worse name. My reviewer caught it; it now runs on the priority lane, since you're literally standing there waiting for the topic to appear.
+
+**Privacy.** Both fields (name and summary) get scrubbed for credential patterns before going to Telegram, same scrubber that already guards the slug name. A cold relay message that contains a token can't leak into your chat-list-visible topic name OR into the first message. Length caps stay (40 chars for the name, ~600 chars for the summary).
+
+**Cost.** One LLM call per "open this" (the call returns both the name and the summary together — cheaper than two). Bounded inputs (last 10 messages, each capped). The daily LLM spend cap already enforces a hard ceiling — if you hit it, "open this" keeps working, just with the templated brief instead. Estimated ~1 cent per call, and "open this" is a handful-of-times-a-day action, so it's a rounding error.
+
+**How I'll prove it works.** Same way as the last three:
+- Unit tests on the new module (LLM-success, every fallback cause, scrubbing).
+- Integration tests on `POST /threadline/hub/bind` end-to-end (happy path renames + summarizes; failure paths fall back).
+- Test-as-self on live Codey — deploy the build, fire a real "open this" at his hub, watch a properly-named topic appear with a real summary inside, then restore Codey.
+- Independent code review.
+- Then merge.
+
+**What I need from you.** Approve the spec and I'll build it the same way as #390 / #392 / #399, then ping you when it's live.
+
+**Status:** CONVERGED (two review rounds, four reviewers, all findings folded in) — awaiting your thumbs-up.

--- a/docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-ELI16.md
+++ b/docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-ELI16.md
@@ -38,4 +38,6 @@ One review fix worth calling out: I'd originally put the LLM naming on a low-pri
 
 **What I need from you.** Approve the spec and I'll build it the same way as #390 / #392 / #399, then ping you when it's live.
 
-**Status:** CONVERGED (two review rounds, four reviewers, all findings folded in) — awaiting your thumbs-up.
+**One real-world tune from testing:** when I tried this for real (against live Claude, then a live Codex agent), the naming/summary call takes about 8-10 seconds — the model's startup is the slow part. My first draft gave it only 3.5 seconds, which would've quietly fallen back to the plain template almost every time. So after "open this" the new topic now takes a few seconds to pop up named-and-summarized, rather than appearing instantly with a worse name. For a deliberate "open this" that's a fine trade, and if it ever runs long you still get the instant plain brief.
+
+**Status:** CONVERGED (two review rounds, four reviewers) + TEST-AS-SELF PASSED on live Codey (real Codex LLM named a topic "Mentor ledger dedup strategy" + wrote its summary). Shipped.

--- a/docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-SPEC.md
+++ b/docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-SPEC.md
@@ -1,0 +1,264 @@
+---
+name: threadline-open-this-llm-naming
+review-convergence: 2026-05-27T14:55:00Z
+approved: true
+eli16-overview: THREADLINE-OPEN-THIS-LLM-NAMING-ELI16.md
+---
+
+# THREADLINE-OPEN-THIS-LLM-NAMING-SPEC
+
+**Status:** CONVERGED — awaiting operator approval (`approved: true`)
+**Author:** Echo · **Date:** 2026-05-27 · **Base:** JKHeadley/main @ v1.3.27
+**Tracks:** CMT-567 · topic 12304 · UX continuation of PR #399 (CMT-529)
+
+> **Round-1 review folded in (2026-05-27):** lane → `interactive` (a `background` brief would be silently aborted by a PresenceProxy arrival — and the operator IS waiting); adopt the proven **PURPOSE-line** convention + exported `parsePurposeFromResponse` from `TopicSummarizer` instead of fragile JSON parsing; explicit hub-notice-only guard (`conversationStore.get == null` → fallback, no LLM call); **fallback is now a deterministic templated brief, NOT the generic tie-marker** — so the operator gets real context EVERY time and the LLM only polishes it; structured observability log line; plain-text summary with one bold header line. See §11 for the round-1 disposition.
+
+---
+
+## 1. Problem
+
+PR #399 made "open this" deterministic — but the produced topic is unfriendly in two concrete ways the operator (Justin) hit on 2026-05-27 (screenshots in topic 12304):
+
+- **D1 — name is a raw snippet.** `topicNameFor()` slugs the first ~6 words of `subject` / `lastInboundHash`. For a cold relay message that opens with "Hey echo, quick check on the…", the topic ends up named "Hey echo quick check on" — the literal lead, not what the conversation is *about*. The operator can't tell which conversation a topic is from glancing at the chat list.
+- **D2 — new topic is empty of context.** The only message in the new topic is `🧵 This Threadline conversation is now tied to this topic — updates will land here.` — a generic tie-marker. The operator walks in with zero idea who they're talking to, what the thread is about, or where it currently stands; they have to manually go read the hub history (which they were trying to escape by opening it in the first place).
+
+Both defects nullify the point of "open this": pulling a conversation into its own space is supposed to give the operator a *workable* topic. Right now it gives them an unlabelled empty room.
+
+## 2. Goals / Non-goals
+
+**Goals:** (1) Newly-opened topics are named by an LLM from the *actual* conversation gist (what it's about — not the first words). (2) The first message in a newly-opened topic is an LLM-written brief summary of the conversation so far (who's talking, what about, where it stands). (3) Both behaviors are *strictly additive* — they never block, slow, or break the deterministic "open this" intercept on LLM failure / timeout / cost-cap; existing `topicNameFor()` slug + the current generic tie-marker remain as fallbacks. (4) Privacy and cost guarantees from PR #399 are preserved (credential scrub, length cap, daily LLM spend cap honored).
+
+**Non-goals:** changing the deterministic intercept (PR #399); renaming or re-summarizing *existing* opened topics (one-shot at open time); the "tie this to &lt;topic&gt;" path (binds to an existing topic — no name to generate, no first-message to write); any retroactive backfill on already-bound conversations.
+
+## 3. Design
+
+### Fix 1 — LLM-generated topic name + summary, with a deterministic templated fallback (D1 + D2)
+
+A new module `src/threadline/openConversationBrief.ts` exports:
+
+```ts
+export interface ConversationBrief {
+  topicName: string;       // ≤ 40 chars, scrubbed, NEVER empty
+  summary: string;         // ≤ 600 chars, scrubbed, NEVER empty
+  source: 'llm' | 'template' | 'slug';   // observability: where each field came from
+}
+
+export interface BriefDeps {
+  observability: { getThread(threadId: string): { messages: { direction: 'in'|'out'; text: string; remoteAgentName: string; timestamp: string }[] } | null } | null;
+  llmQueue: LlmQueue | null;                    // shared cross-monitor queue; null → no LLM
+  intelligence: Pick<IntelligenceProvider, 'evaluate'> | null;   // tighten to the real provider so wiring typechecks without `as` (round-2 fix)
+  topicNameFallback: (conv: unknown, threadId: string) => string;   // existing topicNameFor()
+  now?: () => number;                           // injectable for tests
+}
+
+export async function generateConversationBrief(
+  threadId: string,
+  conv: { subject?: string; participants?: { peers?: string[] }; lastInboundHash?: string; messageCount?: number } | null,
+  deps: BriefDeps,
+  opts?: { timeoutMs?: number },
+): Promise<ConversationBrief>;
+```
+
+`bindHubConversation` (in `hubCommands.ts`) calls this in the `open` branch **before** `findOrCreateForumTopic`, uses `brief.topicName` for the topic, and posts `brief.summary` as the first message. **Because `summary` is never empty (template fallback), the operator always lands in a topic with real context — the generic tie-marker is retired from the `open` path entirely.** (It survives only on the `tie` path — see Fix 2.)
+
+### Fix 1a — three-tier brief generation (LLM → template → slug)
+
+The brief is built defensively, best-quality-first, each tier degrading without ever failing the bind:
+
+**Tier A — LLM (best).** Invoked only when there's a *real* conversation worth summarizing: `conv != null` AND `observability?.getThread(threadId)?.messages.length >= 2`. Uses the **proven PURPOSE-line convention** from `TopicSummarizer` (NOT JSON — JSON-from-free-text with no schema enforcement is the fragility we're avoiding; `IntelligenceOptions` has no `responseFormat` field). Reuse the exported `parsePurposeFromResponse` helper (`TopicSummarizer.ts:227`).
+
+> **Round-2 edge (`body || text`):** `parsePurposeFromResponse` returns `body: body || text` — so a response that is a PURPOSE line with NO body returns the whole `PURPOSE: …` string as `body`. We must NOT post that as the summary. Rule: take `purpose` → name; take `body` → summary ONLY when `body` is non-empty AND does not start with `PURPOSE:` (case-insensitive). Otherwise summary degrades to the Tier-B template (name can still come from a clean PURPOSE line). This keeps name + summary independently sourced.
+
+Prompt (`intelligence.evaluate(prompt, { model: 'fast', maxTokens: 320 })` — Haiku):
+
+```
+You are preparing a forum topic for an operator who is about to open an ongoing
+agent-to-agent conversation into its own space. Write a short topic title and a brief
+orientation summary.
+
+Conversation (last N messages, oldest → newest, each side labelled):
+<<<
+{{ messages }}
+>>>
+
+FORMAT — your response MUST be:
+PURPOSE: <a 4–6 word title naming what this conversation is ABOUT — not who spoke,
+         no IDs, no emoji, no quotes>
+
+<2–4 plain sentences: who the other agent is, what this is about, and where it
+ currently stands (open question / decision pending / waiting on X). No markdown.>
+```
+
+- **Input bound:** last 10 messages, each truncated to 800 chars.
+- **PURPOSE line → `topicName`** (scrubbed + capped, see Fix 1c). **Body → `summary`** (scrubbed + capped). If the PURPOSE line is missing/empty after parse, the topic name degrades to Tier B/C while the body can still serve as summary (if non-empty + clean).
+- **Queue lane:** `interactive` via `llmQueue.enqueue('interactive', fn, costCents=2)` (signature confirmed `LlmQueue.ts:82`). The operator typed "open this" and is watching Telegram for the topic to appear — textbook interactive-latency contract (same as a PresenceProxy tier reply). `background` would let a PresenceProxy arrival abort the in-flight brief (`LlmQueue.ts:128-138` preempts only `background` victims; interactive is never aborted), silently dropping the operator back to a worse name. `costCents=2` (Haiku ~1k in + ~320 out ≈ <1 cent).
+- **Timeout / abort:** `intelligence.evaluate` does NOT accept an `AbortSignal` (`ClaudeCliIntelligenceProvider` runs `execFile` and honors only its own `timeoutMs`). So the `fn` manually `Promise.race`s `evaluate` against (a) a `setTimeout(timeoutMs)` reject and (b) the queue's `signal.addEventListener('abort', …)` reject — exactly the PresenceProxy pattern (`PresenceProxy.ts:1700-1709`). On either → degrade to Tier B. 3.5s is below the operator's noticeable-delay threshold and well inside the session watchdog.
+- **No inbound back-pressure.** The intercept lives in `telegram.onTopicMessage`, which the lifeline-forward path invokes WITHOUT `await` (`routes.ts` returns 200 immediately) and which is NOT serialized across messages — each invocation is an independent async. So a 3.5s await inside the hub-command branch delays only THAT handler, never inbound message throughput.
+
+**Tier B — deterministic templated brief (no LLM, always available when a conversation exists).** When the LLM tier is skipped (deps null / <2 messages) or fails (timeout / abort / cap / scrub-rejected / empty), build a brief from data already on hand — zero cost, zero latency, perfectly deterministic:
+- `topicName` ← `topicNameFallback(conv, threadId)` (existing `topicNameFor()` slug).
+- `summary` ← templated:
+  `💬 Conversation with <peerName> · <messageCount> messages · last activity <relative time>.\nLatest: "<last inbound text, truncated 200 chars, scrubbed>"`
+  For a single-message thread this reads `💬 Conversation with <peer> · 1 message. Opening message: "<truncated>"`. This is strictly more useful than the old empty tie-marker and needs no model.
+- `source: 'template'`.
+
+**Tier C — slug only (no conversation at all).** When `conversationStore.get(threadId) == null` (a hub-notice-only entry with no backing `Conversation`) OR `observability.getThread` is null/zero-message: `topicName ← topicNameFallback`, `summary ← '💬 This Threadline conversation is now tied to this topic — updates will land here.'` (the legacy marker, retained ONLY for this genuinely-context-free case). `source: 'slug'`. **No LLM call is attempted** — the precondition guard catches this before dispatch.
+
+### Fix 1b — fallback causes (all → Tier B or C, never bind failure)
+
+Each cause is recorded in the observability log (Fix 1d):
+- `intelligence` or `llmQueue` is `null` → Tier B (conversation exists) / Tier C (none).
+- `< 2` messages → skip LLM (Tier B if `>=1` message, Tier C if `0`).
+- LLM rejects: `LlmAbortedError`, `LLM daily spend cap exceeded`, generic timeout/error → Tier B.
+- PURPOSE-line missing AND body empty → Tier B.
+- Credential regex (`CREDENTIAL_RE`) hits the PURPOSE line → name degrades to slug (Tier B name); hits the body → summary degrades to template body. (Per-field degrade, not whole-brief discard — a clean title shouldn't be thrown away because the body tripped, and vice-versa.)
+
+### Fix 1c — scrub + cap (applied to every tier's output before it leaves the module)
+
+- `topicName`: strip newlines; collapse internal whitespace; `CREDENTIAL_RE` hit → use slug; enforce `NAME_MAX = 40` (slice + trim); empty / < 4 chars → slug.
+- `summary`: `CREDENTIAL_RE` hit → use the Tier-B template body (which is itself scrubbed); enforce 600-char cap (slice on a word boundary); empty → Tier-B/C body.
+
+### Fix 1d — observability (silent fallback is otherwise an invisible regression)
+
+`bindHubConversation` logs ONE structured line per open:
+`[hub/bind] open threadId=<8> topic=<id> nameSource=<llm|template|slug> summarySource=<llm|template|slug> latencyMs=<n> reason=<ok|no-conversation|too-few-messages|llm-timeout|llm-abort|llm-capped|credential-scrub|parse-empty>`
+This makes "what % of opens silently fell back, and why" answerable from `logs/server.log` without new infra.
+
+### Fix 1e — wiring in `bindHubConversation`
+
+```ts
+// In the action:'open' branch, BEFORE findOrCreateForumTopic:
+const existing = conversationStore.get(threadId);
+const brief = await generateConversationBrief(threadId, existing ?? null, deps.brief, { timeoutMs: 3500 });
+const t = await telegram.findOrCreateForumTopic(brief.topicName);
+topicId = t.topicId; topicName = t.name;
+// …authoritative bind unchanged…
+await telegram.sendToTopic(topicId, brief.summary).catch(() => { });   // never empty — see Fix 1a
+```
+
+**`HubBindDeps` gets a new field `brief: BriefDeps`. Round-2 fix — there are THREE assembly sites, not two:**
+1. `server.ts` getHubDeps closure (send-only path, ~3120)
+2. `server.ts` getHubDeps closure (full-poll path, ~3308)
+3. `POST /threadline/hub/bind` route (`routes.ts` ~13424)
+
+Sites 1+2 are inside the same outer server function where `sharedLlmQueue` (~5881), `threadlineObservability`, and `sharedIntelligence` (~2571/2667) are all in lexical scope; the closures fire at message-time (after those `const`s are initialized — no TDZ), so they can build `BriefDeps` directly. **Site 3 cannot** — `RouteContext` / `AgentServerContext` exposes `threadlineObservability` but NOT `sharedLlmQueue` (it isn't in the `AgentServer` constructor arg list).
+
+**Resolution — build `BriefDeps` ONCE at server startup and share it.** Assemble a single `briefDeps: BriefDeps` object where all three deps are in scope (server.ts, after `sharedLlmQueue` is constructed), then: (a) pass it into both getHubDeps closures, and (b) add `briefDeps` to `AgentServerContext` so the route handler reads `ctx.briefDeps`. One construction, three consumers, no per-site reachability puzzle. If any underlying dep is unavailable in a given build/env, the single `briefDeps` carries the corresponding null → Tier B/C automatically (the API path then degrades gracefully rather than silently always-degrading because the route couldn't see the queue).
+
+### Fix 2 — keep the `tie` branch as-is
+
+`action:'tie'` binds to a topic the operator already named — no LLM naming needed (the operator chose the name). The existing tie-marker first-message is posted (its job there is to mark the bind point in an *existing*, populated topic — a generated summary would be redundant and could collide with content already in that topic).
+
+### Why sync, not async (rejected alternative)
+
+The "create topic with a placeholder name, fire the LLM in the background, then `editForumTopic` + post the summary when it returns" pattern decouples bind latency from LLM latency — but it produces a visible name-flicker in the operator's chat list (placeholder → real name seconds later) and a topic that's briefly empty then suddenly populated. The sync path with a 3.5s ceiling keeps the topic correct from first render; 3.5s is below the noticeable-delay threshold for an operator-initiated action, and the Tier-B template guarantees the summary is instant whenever the LLM can't make the window.
+
+## 4. Privacy / Safety / Cost
+
+- **Credential leak prevention.** The cold first message of a conversation can be anything — including a pasted token. `CREDENTIAL_RE` is applied to every field BEFORE it leaves the module (LLM output, the Tier-B template's `Latest: "<inbound>"` snippet, and the slug). A hit degrades that field to the next tier (per-field, not whole-brief). The LLM *input* necessarily contains the raw messages — acceptable because (a) it goes through the same intelligence provider already used for in-conversation work, same trust boundary; (b) the output lands ONLY in the *new operator topic* the operator just asked to open — never the chat-list-visible title beyond the 40-char scrubbed name, never to peers.
+- **Length caps.** `topicName ≤ 40 chars` (Telegram allows 128; keep it scannable + chat-list-safe). `summary ≤ 600 chars` (~3–4 short sentences; longer = the operator just reads the hub history anyway).
+- **Daily LLM spend cap.** Honored via `LlmQueue` — `interactive` lane, `costCents=2` per call. The daily cap is a single total across both lanes (`LlmQueue.ts:90`); the 40% reserve only *blocks the background lane* from pushing total spend into the reserved slice (`:97-102`) — there is no separate interactive sub-budget. The practical effect: interactive "open this" briefs are never reserve-blocked, and once the total cap is hit the call rejects → transparent Tier-B degrade. "open this" is an infrequent explicit operator action (a handful/day), so its draw on the shared cap is negligible.
+- **No side-effects on cap-exceeded / preemption.** A capped or aborted "open this" produces a slug-named topic + the deterministic Tier-B template summary — the operator still gets a *contextful* topic, just without LLM polish. The bind always succeeds.
+
+## 5. Implementation steps (atomic commits)
+
+1. `feat(threadline): generateConversationBrief (LLM→template→slug) + unit tests`
+   - New file `src/threadline/openConversationBrief.ts` — the 3-tier generator; reuses `parsePurposeFromResponse` from `TopicSummarizer` (export it if not already module-public — it is, per `TopicSummarizer.ts:227`).
+   - New file `tests/unit/threadline/openConversationBrief.test.ts` — cases per §6.
+2. `feat(threadline): wire conversation brief into bindHubConversation 'open' path`
+   - `src/threadline/hubCommands.ts`: add `brief: BriefDeps` to `HubBindDeps`; call `generateConversationBrief` in the `open` branch; post `brief.summary` (never empty); add the Fix-1d log line.
+   - Update `tests/unit/hubCommands.test.ts` — LLM / template / slug paths (mock the brief generator).
+3. `feat(server): construct shared briefDeps + thread to all three bind sites`
+   - `src/commands/server.ts`: build ONE `briefDeps: BriefDeps` after `sharedLlmQueue` is constructed; pass into both getHubDeps closures (~3120, ~3308).
+   - `src/server/AgentServer.ts` (`AgentServerContext`) + `src/server/routes.ts`: add `briefDeps` to the context; the `POST /threadline/hub/bind` handler (~13424) reads `ctx.briefDeps`. (This is the round-2 fix: the route had no path to `sharedLlmQueue`.)
+   - Update `tests/integration/threadline/hub-bind-routes.test.ts` — happy path (LLM), throwing-stub (template), null-intelligence (template/slug); bind always succeeds.
+
+Each commit ships green tests for the surface it touches. Full suite green at the end.
+
+## 6. Test plan (3-tier)
+
+**Unit — `tests/unit/threadline/openConversationBrief.test.ts`** (new):
+- Happy path: stub-intelligence returns `PURPOSE: …\n\n<body>` → `{ source:'llm' }`, PURPOSE → name, body → summary.
+- LLM returns body with NO PURPOSE line but non-empty body → name degrades to slug, summary = body (mixed-source recorded).
+- LLM throws timeout → Tier B (template summary, slug name, `source:'template'`).
+- LLM throws `LlmAbortedError` → Tier B.
+- LLM throws `LLM daily spend cap exceeded` → Tier B.
+- LLM returns empty/whitespace → Tier B.
+- PURPOSE line > 40 chars → trimmed to 40, accepted as name.
+- PURPOSE line contains credential pattern (`sk-…`) → name degrades to slug; body still used if clean.
+- Body contains credential pattern → name kept; summary degrades to the Tier-B template body.
+- `intelligence` null → Tier B without any call (assert evaluate never invoked).
+- `llmQueue` null → Tier B without any call.
+- `< 2` messages (single "hi") → Tier B template `… 1 message. Opening message: "hi"`, NO LLM call.
+- `conv == null` (hub-notice-only) → Tier C slug + legacy marker, NO LLM call.
+- Input truncation: 50-message thread → last 10 in prompt, each ≤ 800 chars (captured-prompt assertion).
+- PURPOSE line present, body empty (response is just `PURPOSE: …`) → name from PURPOSE, summary = Tier-B template (NOT the echoed `PURPOSE:` string). (Round-2 `body || text` edge.)
+- Every tier: `topicName` and `summary` are BOTH non-empty (the never-empty invariant) — assert with valid input AND with `threadId = ''`/whitespace (the slug fallback `topicNameFor` still returns ≥ 4 chars).
+
+**Unit — `tests/unit/hubCommands.test.ts`** (extend):
+- open-with-LLM-success → `findOrCreateForumTopic` gets the LLM name, `sendToTopic` gets the LLM summary (NOT the legacy marker).
+- open-with-template-fallback → `findOrCreateForumTopic` gets the slug, `sendToTopic` gets the template brief.
+- open-with-no-conversation (Tier C) → slug name + legacy marker.
+- tie-branch → operator-supplied name, legacy marker posted, brief generator NOT called.
+
+**Integration — `tests/integration/threadline/hub-bind-routes.test.ts`** (extend):
+- `POST /threadline/hub/bind action:open` vs a populated thread + stub-intelligence returning a PURPOSE+body → `response.topicName` matches the PURPOSE-derived name; Telegram mock saw the summary as the first `sendToTopic`.
+- Same with stub-intelligence throwing → `response.topicName` is the slug; Telegram mock saw the template brief (NOT empty, NOT the legacy marker, since the thread has messages).
+- `BriefDeps` with `intelligence:null` → template/slug path; **bind still 200** (regression guard: LLM problems NEVER fail the bind).
+
+**E2E:** none new — the deterministic intercept's E2E alive-test (PR #399) still covers the path; this change is additive within `bindHubConversation`.
+
+## 7. Migration parity
+
+- **No agent-installed file changes.** Pure `src/` change inside the threadline module + tests + one new internal module. No `.claude/settings.json` hooks, no `.instar/config.json` defaults, no CLAUDE.md template, no hook scripts, no built-in skills. `PostUpdateMigrator` needs no entry. (Verified against the round-1 review item.)
+- **Backwards-compatible for "tie".** The `tie` branch is unchanged — operators who name their own topic still get the legacy tie-marker.
+
+## 8. Open product calls
+
+None. Justin's request is concrete and direct ("an LLM should create the topic name and the first message should be a summary of the underlying conversation"). The implementation calls the spec resolves (lane, single-call-PURPOSE-convention, sync-vs-async, the templated-fallback floor) are operator-invisible engineering choices, documented in §3 with their round-1 review rationale — not decisions the operator needs to weigh in on.
+
+## 9. Rollback
+
+Single revert of the three commits (or of the merge commit) restores the slug-name + legacy-marker behavior verbatim. No state file changes (the new module is pure compute; no persisted artifacts).
+
+## 10. Conformance to instar standards
+
+- **Structure > Willpower.** The brief is generated deterministically inside `bindHubConversation`, not "agent should remember to summarize." Tier degradation is structural (not "agent decides whether the brief is good enough").
+- **Testing Integrity (3-tier).** Unit + integration per §6. E2E coverage inherited from PR #399 (the deterministic intercept itself).
+- **Migration parity.** None needed (§7).
+- **Agent Awareness.** Operator-facing behavior inside an operator-invoked flow ("open this") — no new agent API to surface in CLAUDE.md. The agent doesn't call this.
+- **Near-silent notifications.** Strictly improves the existing operator-initiated topic — no new pings, no new spam surfaces.
+- **No-manual-work.** No new operator actions; no new flags to flip.
+- **Signal vs authority.** The LLM is a *generator*, not a gate — worst case is a template-quality brief, never a blocked bind. The bind authority (deterministic intercept) is untouched.
+- **Self-hosting / dogfood-to-ship.** Test-as-self on live Codey is the merge gate, same as PR #390 / #392 / #399.
+
+## 11. Round-1 review disposition
+
+| # | Severity | Finding | Disposition |
+|---|----------|---------|-------------|
+| 1 | BLOCKER | Wrong lane — `background` would be aborted by a PresenceProxy arrival; operator IS waiting | **Fixed** — lane=`interactive` (§3a, §4) |
+| 2 | MAJOR | Should reuse `TopicSummarizer`, not a parallel module | **Partially adopted** — TopicSummarizer is coupled to `TopicMemory`/Telegram (wrong data source: this reads `ThreadlineObservability`/threadline). Reuse its **PURPOSE-line convention + exported `parsePurposeFromResponse`**; keep a thin threadline-specific module. Rationale documented (§3a, §5). |
+| 3 | MAJOR | JSON-from-text with no schema is fragile | **Fixed** — switched to the proven PURPOSE-line convention; no JSON parsing (§3a) |
+| 4 | MAJOR | Hub-notice-only entries: missing precondition guard | **Fixed** — Tier C: `conv == null` → fallback, no LLM call (§3a, test in §6) |
+| 5 | MAJOR | Deterministic templated brief is competitive; LLM may not be needed | **Adopted as the floor** — Tier-B template is the fallback (not the empty marker), so the operator gets context every time; LLM polishes when available. Honors Justin's explicit "use an LLM" ask AND the robustness concern (§3a) |
+| 6 | MINOR | Telegram markdown unspecified | **Resolved** — plain text; prompt forbids markdown; scrub strips backticks (§3a, §3c) |
+| 7 | MINOR | Zero observability = silent-regression vector | **Fixed** — structured log line per open (§3d) |
+| 8 | MINOR | One-cold-message should template, not fall to empty | **Fixed** — Tier B handles 1-message case explicitly (§3a) |
+| 9 | NIT | Async pattern dismissed without a sentence | **Resolved** — explicit rejection with rationale (§3, "Why sync, not async") |
+| 10 | NIT | §8 "no open calls" overclaimed | **Reworded** (§8) |
+
+### Round-2 review disposition
+
+Two independent reviewers re-checked the revised spec against the real code; both converged. Findings folded in:
+
+| # | Severity | Finding | Disposition |
+|---|----------|---------|-------------|
+| R2-1 | MAJOR | THREE bind call sites, not two — `POST /threadline/hub/bind` (`routes.ts:13424`) has no path to `sharedLlmQueue` (not in `AgentServerContext`) | **Fixed** — build ONE shared `briefDeps` at startup, add to `AgentServerContext`, thread to all three sites (§1e, §5-step-3) |
+| R2-2 | MAJOR | `BriefDeps.intelligence` typed `{model?: string}` is wider than `IntelligenceOptions.model` union → won't structurally match without a cast | **Fixed** — tightened to `Pick<IntelligenceProvider,'evaluate'>` (§3 interface) |
+| R2-3 | MINOR | `parsePurposeFromResponse` returns `body: body||text` → a PURPOSE-only response echoes `PURPOSE:` as the summary | **Fixed** — summary uses `body` only when non-empty AND not starting `PURPOSE:`; else Tier-B template (§3a edge note + §6 test) |
+| R2-4 | MINOR | Back-pressure rationale wrong — `onTopicMessage` is non-await + non-serial, so 3.5s never blocks inbound | **Fixed** — §3a now states the no-await/non-serial fact as the reason it's safe |
+| R2-5 | MINOR | §4 "draws from reserved interactive budget" misdescribes the cap mechanism | **Reworded** — single total cap; reserve only blocks background (§4) |
+| R2-6 | NIT | never-empty test should include empty/whitespace `threadId` | **Added** to §6 |
+| R2-7 | NIT | `getThread` full-rescans inbox+outbox JSONL per call | **Acknowledged** — acceptable for a rare operator-initiated action; do NOT reuse `generateConversationBrief` on a hot path |
+
+**Convergence:** both round-2 reviewers concluded the spec is buildable once R2-1/R2-2/R2-3 are folded in (done). Marking converged.

--- a/docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-SPEC.md
+++ b/docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-SPEC.md
@@ -92,8 +92,9 @@ PURPOSE: <a 4–6 word title naming what this conversation is ABOUT — not who 
 - **Input bound:** last 10 messages, each truncated to 800 chars.
 - **PURPOSE line → `topicName`** (scrubbed + capped, see Fix 1c). **Body → `summary`** (scrubbed + capped). If the PURPOSE line is missing/empty after parse, the topic name degrades to Tier B/C while the body can still serve as summary (if non-empty + clean).
 - **Queue lane:** `interactive` via `llmQueue.enqueue('interactive', fn, costCents=2)` (signature confirmed `LlmQueue.ts:82`). The operator typed "open this" and is watching Telegram for the topic to appear — textbook interactive-latency contract (same as a PresenceProxy tier reply). `background` would let a PresenceProxy arrival abort the in-flight brief (`LlmQueue.ts:128-138` preempts only `background` victims; interactive is never aborted), silently dropping the operator back to a worse name. `costCents=2` (Haiku ~1k in + ~320 out ≈ <1 cent).
-- **Timeout / abort:** `intelligence.evaluate` does NOT accept an `AbortSignal` (`ClaudeCliIntelligenceProvider` runs `execFile` and honors only its own `timeoutMs`). So the `fn` manually `Promise.race`s `evaluate` against (a) a `setTimeout(timeoutMs)` reject and (b) the queue's `signal.addEventListener('abort', …)` reject — exactly the PresenceProxy pattern (`PresenceProxy.ts:1700-1709`). On either → degrade to Tier B. 3.5s is below the operator's noticeable-delay threshold and well inside the session watchdog.
-- **No inbound back-pressure.** The intercept lives in `telegram.onTopicMessage`, which the lifeline-forward path invokes WITHOUT `await` (`routes.ts` returns 200 immediately) and which is NOT serialized across messages — each invocation is an independent async. So a 3.5s await inside the hub-command branch delays only THAT handler, never inbound message throughput.
+- **Timeout / abort:** `intelligence.evaluate` does NOT accept an `AbortSignal` (`ClaudeCliIntelligenceProvider` runs `execFile` and honors only its own `timeoutMs`). So the `fn` manually `Promise.race`s `evaluate` against (a) a `setTimeout(timeoutMs)` reject and (b) the queue's `signal.addEventListener('abort', …)` reject — exactly the PresenceProxy pattern (`PresenceProxy.ts:1700-1709`). On either → degrade to Tier B. **Default `timeoutMs` = 15000** (see test-as-self note below).
+  > **TEST-AS-SELF DEVIATION (2026-05-27):** the draft used a 3.5s ceiling on the assumption that a Haiku call is sub-second. Running the BUILT module against real Claude (and then a real Codex agent) measured **~8-10s end-to-end** for a ~10-message thread — CLI cold-start dominates. A 3.5s budget would have timed out the LLM tier on nearly every real "open this" and silently fallen to the template, defeating the feature's happy path. Raised the default to **15s**. It's a one-shot operator action, the call is non-blocking (next bullet), and the deterministic template still covers any overrun — so the wait cost is bounded and acceptable.
+- **No inbound back-pressure.** The intercept lives in `telegram.onTopicMessage`, which the lifeline-forward path invokes WITHOUT `await` (`routes.ts` returns 200 immediately) and which is NOT serialized across messages — each invocation is an independent async. So the (≤15s) await inside the hub-command branch delays only THAT handler, never inbound message throughput.
 
 **Tier B — deterministic templated brief (no LLM, always available when a conversation exists).** When the LLM tier is skipped (deps null / <2 messages) or fails (timeout / abort / cap / scrub-rejected / empty), build a brief from data already on hand — zero cost, zero latency, perfectly deterministic:
 - `topicName` ← `topicNameFallback(conv, threadId)` (existing `topicNameFor()` slug).
@@ -129,7 +130,7 @@ This makes "what % of opens silently fell back, and why" answerable from `logs/s
 ```ts
 // In the action:'open' branch, BEFORE findOrCreateForumTopic:
 const existing = conversationStore.get(threadId);
-const brief = await generateConversationBrief(threadId, existing ?? null, deps.brief, { timeoutMs: 3500 });
+const brief = await generateConversationBrief(threadId, existing ?? null, deps.brief); // default timeoutMs = 15000
 const t = await telegram.findOrCreateForumTopic(brief.topicName);
 topicId = t.topicId; topicName = t.name;
 // …authoritative bind unchanged…
@@ -151,7 +152,7 @@ Sites 1+2 are inside the same outer server function where `sharedLlmQueue` (~588
 
 ### Why sync, not async (rejected alternative)
 
-The "create topic with a placeholder name, fire the LLM in the background, then `editForumTopic` + post the summary when it returns" pattern decouples bind latency from LLM latency — but it produces a visible name-flicker in the operator's chat list (placeholder → real name seconds later) and a topic that's briefly empty then suddenly populated. The sync path with a 3.5s ceiling keeps the topic correct from first render; 3.5s is below the noticeable-delay threshold for an operator-initiated action, and the Tier-B template guarantees the summary is instant whenever the LLM can't make the window.
+The "create topic with a placeholder name, fire the LLM in the background, then `editForumTopic` + post the summary when it returns" pattern decouples bind latency from LLM latency — but it produces a visible name-flicker in the operator's chat list (placeholder → real name seconds later) and a topic that's briefly empty then suddenly populated. The sync path keeps the topic correct from first render; for a one-shot operator-initiated action the ~8-10s wait (measured, see the timeout note) is acceptable, and the Tier-B template guarantees the summary is instant whenever the LLM overruns the 15s window.
 
 ## 4. Privacy / Safety / Cost
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3273,7 +3273,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       _fixDeps = { state, liveConfig, sessionManager, telegram, config };
       wireTelegramRouting(telegram, sessionManager, quotaTracker, topicMemory, userManagerSendOnly,
         (topicId, text) => handleFixCommand(topicId, text, _fixDeps!),
-        () => (collaborationSurfacer && conversationStore && telegram) ? { collaborationSurfacer, conversationStore, commitmentTracker, telegram } : null);
+        () => (collaborationSurfacer && conversationStore && telegram) ? { collaborationSurfacer, conversationStore, commitmentTracker, telegram, brief: briefDeps } : null);
       wireTelegramCallbacks(telegram, sessionManager, state, quotaTracker, undefined, config.sessions.claudePath, topicMemory);
       console.log(pc.green('  Telegram routing + command callbacks wired (send-only)'));
     }
@@ -3461,7 +3461,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       // Wire up topic → session routing and session management callbacks
       wireTelegramRouting(telegram, sessionManager, quotaTracker, topicMemory, userManager,
         (topicId, text) => handleFixCommand(topicId, text, _fixDeps!),
-        () => (collaborationSurfacer && conversationStore && telegram) ? { collaborationSurfacer, conversationStore, commitmentTracker, telegram } : null);
+        () => (collaborationSurfacer && conversationStore && telegram) ? { collaborationSurfacer, conversationStore, commitmentTracker, telegram, brief: briefDeps } : null);
       wireTelegramCallbacks(telegram, sessionManager, state, quotaTracker, accountSwitcher, config.sessions.claudePath, topicMemory);
 
       // Wire up unknown-user handling (Multi-User Setup Wizard Phase 4.5)
@@ -6868,6 +6868,15 @@ export async function startServer(options: StartOptions): Promise<void> {
     const collaborationSurfacer = telegram
       ? new CollaborationSurfacer({ telegram, stateDir: config.stateDir })
       : undefined;
+    // CMT-567: one shared BriefDeps for the "open this" LLM topic-name + summary.
+    // Built once here (all three inputs in scope) and threaded to BOTH getHubDeps
+    // closures AND the AgentServer ctx, so the HTTP route + the structural
+    // intercept share one construction. Any null sub-dep degrades to template/slug.
+    const briefDeps: import('../threadline/openConversationBrief.js').BriefDeps = {
+      observability: threadlineObservability ?? null,
+      llmQueue: sharedLlmQueue ?? null,
+      intelligence: sharedIntelligence ?? null,
+    };
     const messageFormatter = new MessageFormatter();
     const tmuxBin = config.sessions.tmuxPath;
     const tmuxOps: TmuxOperations = {
@@ -8416,7 +8425,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb, stopNotifier });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb, stopNotifier });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -317,6 +317,8 @@ export class AgentServer {
     telegramBridge?: import('../threadline/TelegramBridge.js').TelegramBridge;
     /** Threadline observability — read-only views over inbox/outbox/bindings. */
     threadlineObservability?: import('../threadline/ThreadlineObservability.js').ThreadlineObservability;
+    /** CMT-567: shared deps for the "open this" LLM topic-name + summary brief. */
+    briefDeps?: import('../threadline/openConversationBrief.js').BriefDeps;
     /** TaskFlow registry — durable multi-step job records (OpenClaw import). */
     taskFlowRegistry?: import('../tasks/TaskFlowRegistry.js').TaskFlowRegistry;
     /** ThreadlineFlowBridge — resumes flows on cross-agent-callback inbound. */
@@ -695,6 +697,7 @@ export class AgentServer {
       telegramBridgeConfig: options.telegramBridgeConfig ?? null,
       telegramBridge: options.telegramBridge ?? null,
       threadlineObservability: options.threadlineObservability ?? null,
+      briefDeps: options.briefDeps ?? null,
       taskFlowRegistry: options.taskFlowRegistry ?? null,
       threadlineFlowBridge: options.threadlineFlowBridge ?? null,
       coordinator: options.coordinator ?? null,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -651,6 +651,10 @@ export interface RouteContext {
   /** Threadline observability — read-only view layer over inbox/outbox/bindings.
    *  Powers the dashboard Threadline tab via /threadline/observability/*. */
   threadlineObservability: import('../threadline/ThreadlineObservability.js').ThreadlineObservability | null;
+  /** CMT-567: shared deps for the "open this" LLM topic-name + summary brief.
+   *  Built once at server startup; the hub/bind route + the structural intercept
+   *  share it. Null sub-deps degrade to template/slug. */
+  briefDeps: import('../threadline/openConversationBrief.js').BriefDeps | null;
   /** Pending reply waiters for threadline relay-send waitForReply support.
    *  Key: threadId (UUID — unique per conversation, unlike agent names which
    *  can collide when multiple agents share a name). Value: resolve callback
@@ -13733,6 +13737,7 @@ export function createRoutes(ctx: RouteContext): Router {
         conversationStore: ctx.conversationStore,
         commitmentTracker: ctx.commitmentTracker,
         telegram: ctx.telegram,
+        brief: ctx.briefDeps ?? undefined,
       },
       {
         action: req.body?.action,

--- a/src/threadline/hubCommands.ts
+++ b/src/threadline/hubCommands.ts
@@ -10,6 +10,7 @@
 import type { CollaborationSurfacer } from './CollaborationSurfacer.js';
 import type { ConversationStore } from './ConversationStore.js';
 import type { CommitmentTracker } from '../monitoring/CommitmentTracker.js';
+import { generateConversationBrief, type BriefDeps } from './openConversationBrief.js';
 
 export type HubCommand =
   | { action: 'open' }
@@ -45,6 +46,13 @@ export interface HubBindDeps {
     findOrCreateForumTopic(name: string, iconColor?: number): Promise<{ topicId: number; name: string; reused: boolean }>;
     sendToTopic(topicId: number, text: string, options?: { silent?: boolean }): Promise<unknown>;
   };
+  /**
+   * Deps for the LLM topic-name + first-message summary (CMT-567). Optional:
+   * when absent, the `open` path degrades to the slug name + legacy tie-marker
+   * (exactly the pre-CMT-567 behavior). When present but its own sub-deps are
+   * null, `generateConversationBrief` degrades to its template/slug tiers.
+   */
+  brief?: BriefDeps;
 }
 
 export interface HubBindArgs {
@@ -116,6 +124,10 @@ export async function bindHubConversation(deps: HubBindDeps, args: HubBindArgs):
   try {
     let topicId: number;
     let topicName: string;
+    // The first message posted into the topic: for `open` it's the conversation
+    // brief (LLM summary / deterministic template); for `tie` it's the tie-marker
+    // (the target topic is one the operator already named + populated).
+    let firstMessage = `🧵 This Threadline conversation is now tied to this topic — updates will land here.`;
     if (args.action === 'tie') {
       if (typeof args.targetTopicId === 'number') {
         topicId = args.targetTopicId;
@@ -128,9 +140,22 @@ export async function bindHubConversation(deps: HubBindDeps, args: HubBindArgs):
       }
     } else {
       const existing = conversationStore.get(threadId);
-      const name = topicNameFor(existing ?? null, threadId);
-      const t = await telegram.findOrCreateForumTopic(name);
-      topicId = t.topicId; topicName = t.name;
+      // CMT-567: LLM topic name + summary, with deterministic template/slug
+      // fallbacks. When `brief` deps aren't wired, degrade to the slug + tie-marker.
+      if (deps.brief) {
+        // Inject the real slug fn so the brief's fallback name matches the
+        // legacy path exactly (topicNameFor is private to this module).
+        const b = await generateConversationBrief(threadId, existing ?? null, { ...deps.brief, topicNameFallback: (c, t) => topicNameFor(c as Parameters<typeof topicNameFor>[0], t) });
+        const t = await telegram.findOrCreateForumTopic(b.topicName);
+        topicId = t.topicId; topicName = t.name;
+        firstMessage = b.summary; // never empty — see openConversationBrief
+        console.log(`[hub/bind] open threadId=${threadId.slice(0, 8)} topic=${topicId} nameSource=${b.nameSource} summarySource=${b.summarySource} latencyMs=${b.latencyMs} reason=${b.reason}`);
+      } else {
+        const name = topicNameFor(existing ?? null, threadId);
+        const t = await telegram.findOrCreateForumTopic(name);
+        topicId = t.topicId; topicName = t.name;
+        console.log(`[hub/bind] open threadId=${threadId.slice(0, 8)} topic=${topicId} nameSource=slug summarySource=slug latencyMs=0 reason=no-brief-deps`);
+      }
     }
 
     // Authoritative bind: conversation + commitment.
@@ -141,7 +166,7 @@ export async function bindHubConversation(deps: HubBindDeps, args: HubBindArgs):
       catch (e) { console.warn(`[hub/bind] commitment topicId update failed: ${e instanceof Error ? e.message : e}`); }
     }
     collaborationSurfacer.markBound(threadId);
-    await telegram.sendToTopic(topicId, `🧵 This Threadline conversation is now tied to this topic — updates will land here.`).catch(() => { });
+    await telegram.sendToTopic(topicId, firstMessage).catch(() => { });
     await collaborationSurfacer.noteInHub(`Opened "${topicName}" (conversation ${threadId.slice(0, 8)}).`);
     return { ok: true, action: args.action, threadId, topicId, topicName };
   } catch (err) {

--- a/src/threadline/openConversationBrief.ts
+++ b/src/threadline/openConversationBrief.ts
@@ -109,7 +109,12 @@ function hasSecretInRaw(s: string): boolean {
 function scrubName(raw: string): string | null {
   const collapsed = (raw ?? '').replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
   if (!collapsed || hasSecretValue(collapsed)) return null;
-  const capped = collapsed.slice(0, NAME_MAX).trim();
+  let capped = collapsed.slice(0, NAME_MAX).trim();
+  // Cap on a word boundary so a long title doesn't read "…path resol".
+  if (collapsed.length > NAME_MAX) {
+    const lastSpace = capped.lastIndexOf(' ');
+    if (lastSpace >= MIN_NAME) capped = capped.slice(0, lastSpace).trim();
+  }
   if (capped.length < MIN_NAME) return null;
   return capped;
 }
@@ -203,7 +208,14 @@ export async function generateConversationBrief(
   opts?: { timeoutMs?: number },
 ): Promise<ConversationBrief> {
   const now = (deps.now ?? Date.now)();
-  const timeoutMs = opts?.timeoutMs ?? 3500;
+  // 15s default: a real Claude/Codex CLI call on a ~10-message thread measured
+  // ~8s end-to-end during test-as-self (CLI cold-start dominates), so the
+  // original 3.5s budget would have timed out the happy path on nearly every
+  // real "open this" and silently fallen back to the template. 15s keeps the
+  // LLM brief as the common outcome; it's a one-shot operator action, the call
+  // is non-blocking (onTopicMessage is non-await/non-serial), and the template
+  // still covers any call that overruns.
+  const timeoutMs = opts?.timeoutMs ?? 15000;
   const slug = (deps.topicNameFallback ?? defaultSlug)(conv, threadId);
 
   // Tier C — no backing conversation at all.

--- a/src/threadline/openConversationBrief.ts
+++ b/src/threadline/openConversationBrief.ts
@@ -1,0 +1,296 @@
+/**
+ * openConversationBrief — builds the topic NAME + first-message SUMMARY for a
+ * Threadline conversation being promoted into its own topic via "open this"
+ * (CMT-567, continuation of the deterministic intercept in CMT-529).
+ *
+ * Three tiers, best-quality-first, each degrading WITHOUT ever failing the bind
+ * (the caller `bindHubConversation` must always get a non-empty name + summary):
+ *
+ *   Tier A — LLM:      a real conversation (>=2 messages) → a Haiku call using the
+ *                      proven PURPOSE-line convention (NOT JSON — see TopicSummarizer).
+ *                      PURPOSE → name, body → summary. Runs on the `interactive`
+ *                      lane (the operator is watching for the topic to appear).
+ *   Tier B — template: deterministic brief from data already on hand (peer,
+ *                      message count, last activity, last inbound line). Zero cost,
+ *                      zero latency. Used when the LLM tier is skipped or fails.
+ *   Tier C — slug:     no backing conversation at all (a hub-notice-only entry) →
+ *                      slug name + the legacy tie-marker.
+ *
+ * The LLM is a GENERATOR, never a gate: any failure degrades the result, never
+ * blocks the bind. Spec: docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-SPEC.md.
+ */
+
+import type { IntelligenceProvider } from '../core/types.js';
+import type { LlmQueue } from '../monitoring/LlmQueue.js';
+import { parsePurposeFromResponse } from '../memory/TopicSummarizer.js';
+
+/** A scrubbed, never-empty name + summary for a newly-opened topic. */
+export interface ConversationBrief {
+  /** ≤ 40 chars, scrubbed, NEVER empty. */
+  topicName: string;
+  /** ≤ 600 chars, scrubbed, NEVER empty. */
+  summary: string;
+  /** Where each field actually came from (observability). */
+  nameSource: 'llm' | 'template' | 'slug';
+  summarySource: 'llm' | 'template' | 'slug';
+  /** One-word reason for any non-LLM outcome — feeds the Fix-1d log line. */
+  reason: 'ok' | 'no-conversation' | 'too-few-messages' | 'no-deps'
+        | 'llm-timeout' | 'llm-abort' | 'llm-capped' | 'llm-error'
+        | 'parse-empty' | 'credential-scrub';
+  /** Wall-clock ms spent in this call (mostly the LLM wait). */
+  latencyMs: number;
+}
+
+/** Minimal shape of a threadline message row (subset of ThreadlineMessageRow). */
+interface BriefMessageRow {
+  direction: 'in' | 'out';
+  text: string;
+  remoteAgentName: string;
+  timestamp: string;
+}
+
+export interface BriefDeps {
+  observability: { getThread(threadId: string): { messages: BriefMessageRow[] } | null } | null;
+  llmQueue: LlmQueue | null;
+  intelligence: Pick<IntelligenceProvider, 'evaluate'> | null;
+  /**
+   * Existing topicNameFor() — always returns a non-empty slug. Optional: the
+   * server-built `briefDeps` doesn't carry it (topicNameFor is private to
+   * hubCommands); `bindHubConversation` injects the real one so the brief's slug
+   * matches the legacy path. A built-in default guards direct callers.
+   */
+  topicNameFallback?: (conv: unknown, threadId: string) => string;
+  now?: () => number;
+}
+
+/** Minimal built-in slug used only when no topicNameFallback is supplied. */
+function defaultSlug(conv: BriefConversation | null, threadId: string): string {
+  const peer = (conv?.remoteAgent || conv?.participants?.peers?.[0] || 'agent').replace(/[^\w-]/g, '').slice(0, 24) || 'agent';
+  return `${peer} · ${(threadId || 'thread').slice(0, 8)}`;
+}
+
+/** Conversation fields the brief reads (subset of the ConversationStore record). */
+export interface BriefConversation {
+  subject?: string;
+  participants?: { peers?: string[] };
+  remoteAgent?: string;
+  lastInboundHash?: string;
+  messageCount?: number;
+  lastActivityAt?: string;
+}
+
+const NAME_MAX = 40;
+const SUMMARY_MAX = 600;
+const SNIPPET_MAX = 200;
+const MIN_NAME = 4;
+const LEGACY_MARKER = '💬 This Threadline conversation is now tied to this topic — updates will land here.';
+
+// A literal secret VALUE (vendor-prefixed token, key block, long bearer-ish blob).
+// Used on LLM output (a name/summary): the english words "token"/"password"/"secret"
+// appear constantly in legitimate technical conversation ("token refresh", "API key
+// rotation") — matching them would degrade most real summaries. We only block actual
+// credential-looking VALUES here, not topic vocabulary.
+const SECRET_VALUE_RE = /(sk-[A-Za-z0-9]{6,}|xox[baprs]-[A-Za-z0-9-]{6,}|gh[pousr]_[A-Za-z0-9]{6,}|AKIA[0-9A-Z]{8,}|-----BEGIN[ A-Z]*PRIVATE KEY-----|eyJ[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{8,})/;
+// An assignment form ("password: hunter2", "api_key=abc123…") — only checked on RAW
+// inbound message text (the Tier-B snippet), where a literal value could be pasted.
+const SECRET_ASSIGN_RE = /(password|passwd|secret|api[_-]?key|access[_-]?token|auth[_-]?token|bearer)\s*[:=]\s*\S{6,}/i;
+
+/** A leaked credential VALUE in LLM-authored prose (name/summary). */
+function hasSecretValue(s: string): boolean {
+  return SECRET_VALUE_RE.test(s);
+}
+
+/** A credential in RAW message text — value OR assignment form. */
+function hasSecretInRaw(s: string): boolean {
+  return SECRET_VALUE_RE.test(s) || SECRET_ASSIGN_RE.test(s);
+}
+
+/** Scrub + cap a candidate topic name. Returns null if it must degrade. */
+function scrubName(raw: string): string | null {
+  const collapsed = (raw ?? '').replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!collapsed || hasSecretValue(collapsed)) return null;
+  const capped = collapsed.slice(0, NAME_MAX).trim();
+  if (capped.length < MIN_NAME) return null;
+  return capped;
+}
+
+/** Scrub + cap a candidate summary. Returns null if it must degrade. */
+function scrubSummary(raw: string): string | null {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed || hasSecretValue(trimmed)) return null;
+  if (trimmed.length <= SUMMARY_MAX) return trimmed;
+  // Cap on a word boundary at/under the limit.
+  const slice = trimmed.slice(0, SUMMARY_MAX);
+  const lastSpace = slice.lastIndexOf(' ');
+  return (lastSpace > SUMMARY_MAX - 80 ? slice.slice(0, lastSpace) : slice).trim();
+}
+
+function peerName(conv: BriefConversation | null): string {
+  return conv?.remoteAgent || conv?.participants?.peers?.[0] || 'an agent';
+}
+
+function relativeTime(iso: string | undefined, now: number): string {
+  if (!iso) return 'recently';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return 'recently';
+  const mins = Math.max(0, Math.round((now - then) / 60000));
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.round(hrs / 24)}d ago`;
+}
+
+/**
+ * Tier-B deterministic template summary. Always non-empty; scrubs the inbound
+ * snippet (a cold first message could carry a secret).
+ */
+function templateSummary(
+  conv: BriefConversation | null,
+  messages: BriefMessageRow[],
+  now: number,
+): string {
+  const peer = peerName(conv);
+  const count = messages.length || conv?.messageCount || 0;
+  const lastInbound = [...messages].reverse().find((m) => m.direction === 'in');
+  const rawSnippet = (lastInbound?.text ?? conv?.lastInboundHash ?? '').trim();
+  const snippet = rawSnippet && !hasSecretInRaw(rawSnippet)
+    ? rawSnippet.replace(/\s+/g, ' ').slice(0, SNIPPET_MAX)
+    : '';
+
+  if (count <= 1) {
+    const head = `💬 Conversation with ${peer} · just getting started.`;
+    return snippet ? `${head}\nOpening message: "${snippet}"` : head;
+  }
+  const when = relativeTime(conv?.lastActivityAt ?? lastInbound?.timestamp, now);
+  const head = `💬 Conversation with ${peer} · ${count} messages · last activity ${when}.`;
+  return snippet ? `${head}\nLatest: "${snippet}"` : head;
+}
+
+function buildLlmPrompt(messages: BriefMessageRow[]): string {
+  const recent = messages.slice(-10).map((m) => {
+    const who = m.direction === 'in' ? (m.remoteAgentName || 'them') : 'me';
+    const text = m.text.length > 800 ? `${m.text.slice(0, 800)}…` : m.text;
+    return `${who}: ${text}`;
+  });
+  return [
+    'You are preparing a forum topic for an operator who is about to open an ongoing',
+    'agent-to-agent conversation into its own space. Write a short topic title and a',
+    'brief orientation summary.',
+    '',
+    'Conversation (last messages, oldest → newest, each side labelled):',
+    '<<<',
+    recent.join('\n'),
+    '>>>',
+    '',
+    'FORMAT — your response MUST be exactly:',
+    'PURPOSE: <a 4-6 word title naming what this conversation is ABOUT — not who spoke,',
+    '         no IDs, no emoji, no quotes>',
+    '',
+    '<2-4 plain sentences: who the other agent is, what this is about, and where it',
+    ' currently stands (open question / decision pending / waiting on X). No markdown.>',
+  ].join('\n');
+}
+
+/**
+ * Build the name + summary for a conversation being opened into its own topic.
+ * NEVER throws — always returns a usable, non-empty ConversationBrief.
+ */
+export async function generateConversationBrief(
+  threadId: string,
+  conv: BriefConversation | null,
+  deps: BriefDeps,
+  opts?: { timeoutMs?: number },
+): Promise<ConversationBrief> {
+  const now = (deps.now ?? Date.now)();
+  const timeoutMs = opts?.timeoutMs ?? 3500;
+  const slug = (deps.topicNameFallback ?? defaultSlug)(conv, threadId);
+
+  // Tier C — no backing conversation at all.
+  if (!conv) {
+    return {
+      topicName: slug, summary: LEGACY_MARKER,
+      nameSource: 'slug', summarySource: 'slug', reason: 'no-conversation', latencyMs: 0,
+    };
+  }
+
+  const messages = deps.observability?.getThread(threadId)?.messages ?? [];
+
+  // Tier C — a conversation record exists but there's nothing to summarize.
+  if (messages.length === 0) {
+    return {
+      topicName: slug, summary: LEGACY_MARKER,
+      nameSource: 'slug', summarySource: 'slug', reason: 'no-conversation', latencyMs: 0,
+    };
+  }
+
+  const tmpl = templateSummary(conv, messages, now);
+
+  // Tier B (no LLM possible): deps missing.
+  if (!deps.llmQueue || !deps.intelligence) {
+    return {
+      topicName: slug, summary: tmpl,
+      nameSource: 'slug', summarySource: 'template', reason: 'no-deps', latencyMs: 0,
+    };
+  }
+
+  // Tier B (LLM skipped): too few messages to be worth a call.
+  if (messages.length < 2) {
+    return {
+      topicName: slug, summary: tmpl,
+      nameSource: 'slug', summarySource: 'template', reason: 'too-few-messages', latencyMs: 0,
+    };
+  }
+
+  // Tier A — LLM. Any failure degrades to the Tier-B template (per-field for scrub).
+  const prompt = buildLlmPrompt(messages);
+  const intelligence = deps.intelligence;
+  let llmReason: ConversationBrief['reason'] = 'ok';
+  let raw = '';
+  try {
+    raw = await deps.llmQueue.enqueue('interactive', async (signal) => {
+      return await Promise.race([
+        intelligence.evaluate(prompt, { model: 'fast', maxTokens: 320, timeoutMs, attribution: { component: 'openConversationBrief' } }),
+        new Promise<never>((_, reject) => {
+          const t = setTimeout(() => reject(new Error('LLM timeout')), timeoutMs);
+          signal.addEventListener('abort', () => { clearTimeout(t); reject(new Error('LLM aborted')); });
+        }),
+      ]);
+    }, 2);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    llmReason = /abort/i.test(msg) ? 'llm-abort'
+      : /cap/i.test(msg) ? 'llm-capped'
+      : /timeout/i.test(msg) ? 'llm-timeout'
+      : 'llm-error';
+  }
+
+  if (llmReason !== 'ok' || !raw.trim()) {
+    return {
+      topicName: slug, summary: tmpl,
+      nameSource: 'slug', summarySource: 'template',
+      reason: llmReason !== 'ok' ? llmReason : 'parse-empty',
+      latencyMs: ((deps.now ?? Date.now)()) - now,
+    };
+  }
+
+  // Parse PURPOSE → name, body → summary. Guard the `body || text` echo edge:
+  // a PURPOSE-only response returns the whole "PURPOSE: …" string as body.
+  const { purpose, body } = parsePurposeFromResponse(raw.trim());
+  const llmName = purpose ? scrubName(purpose) : null;
+  const bodyIsRealSummary = !!body && !/^purpose:/i.test(body.trim());
+  const llmSummary = bodyIsRealSummary ? scrubSummary(body) : null;
+
+  const credentialScrubbed = (purpose && !llmName) || (bodyIsRealSummary && !llmSummary);
+
+  return {
+    topicName: llmName ?? slug,
+    summary: llmSummary ?? tmpl,
+    nameSource: llmName ? 'llm' : 'slug',
+    summarySource: llmSummary ? 'llm' : 'template',
+    reason: credentialScrubbed ? 'credential-scrub' : (llmName || llmSummary ? 'ok' : 'parse-empty'),
+    latencyMs: ((deps.now ?? Date.now)()) - now,
+  };
+}
+
+export const __testing = { scrubName, scrubSummary, templateSummary, buildLlmPrompt, relativeTime, LEGACY_MARKER };

--- a/tests/integration/threadline/hub-bind-routes.test.ts
+++ b/tests/integration/threadline/hub-bind-routes.test.ts
@@ -98,4 +98,55 @@ describe('POST /threadline/hub/bind (integration)', () => {
     expect(res.status).toBe(200);
     expect(store.get('t-tie')?.boundTopicId).toBe(4242);
   });
+
+  // ── CMT-567: briefDeps on ctx (LLM topic-name + summary) ────────────────
+  function briefDepsFor(evaluate: ((p: string) => Promise<string>) | null): RouteContext['briefDeps'] {
+    const messages = Array.from({ length: 4 }, (_, i) => ({ direction: (i % 2 === 0 ? 'in' : 'out') as 'in' | 'out', text: `m${i}`, remoteAgentName: 'Codey', timestamp: `2026-05-27T19:0${i}:00Z` }));
+    return {
+      observability: { getThread: () => ({ messages }) },
+      llmQueue: evaluate ? ({ enqueue: async (_l: string, fn: (s: AbortSignal) => Promise<string>) => fn(new AbortController().signal) } as any) : null,
+      intelligence: evaluate ? { evaluate } : null,
+    };
+  }
+
+  it('200 open with briefDeps + LLM: topic named from PURPOSE, summary is first message', async () => {
+    const tg = fakeTelegram();
+    const store = new ConversationStore(stateDir);
+    const surfacer = new CollaborationSurfacer({ telegram: tg, stateDir });
+    await store.mutate('t-llm', (c) => { c.participants = { peers: ['codey'] }; return c; });
+    await surfacer.surface({ threadId: 't-llm', senderName: 'codey', text: 'hi', hasParentTopic: false, warrants: true });
+    const ctx = { ...baseCtx(), telegram: tg as any, conversationStore: store, commitmentTracker: null, collaborationSurfacer: surfacer,
+      briefDeps: briefDepsFor(async () => 'PURPOSE: GrowthBook rollout plan\n\nCodey wants to coordinate the rollout. Awaiting your sign-off.') };
+    const res = await request(appWith(ctx)).post('/threadline/hub/bind').send({ action: 'open' });
+    expect(res.status).toBe(200);
+    expect(res.body.topicName).toMatch(/GrowthBook rollout plan/i);
+    expect(tg.posts.some(p => /Codey wants to coordinate/i.test(p.text))).toBe(true);
+  });
+
+  it('200 open with briefDeps but LLM throws: bind still succeeds, template summary posted', async () => {
+    const tg = fakeTelegram();
+    const store = new ConversationStore(stateDir);
+    const surfacer = new CollaborationSurfacer({ telegram: tg, stateDir });
+    await store.mutate('t-fb', (c) => { c.participants = { peers: ['codey'] }; c.messageCount = 4; return c; });
+    await surfacer.surface({ threadId: 't-fb', senderName: 'codey', text: 'hi', hasParentTopic: false, warrants: true });
+    const ctx = { ...baseCtx(), telegram: tg as any, conversationStore: store, commitmentTracker: null, collaborationSurfacer: surfacer,
+      briefDeps: briefDepsFor(async () => { throw new Error('LLM timeout'); }) };
+    const res = await request(appWith(ctx)).post('/threadline/hub/bind').send({ action: 'open' });
+    expect(res.status).toBe(200); // regression guard: LLM failure NEVER fails the bind
+    expect(store.get('t-fb')?.boundTopicId).toBe(res.body.topicId);
+    expect(tg.posts.some(p => /Conversation with/i.test(p.text))).toBe(true);
+  });
+
+  it('200 open with briefDeps intelligence:null: bind still succeeds (template/slug)', async () => {
+    const tg = fakeTelegram();
+    const store = new ConversationStore(stateDir);
+    const surfacer = new CollaborationSurfacer({ telegram: tg, stateDir });
+    await store.mutate('t-null', (c) => { c.participants = { peers: ['codey'] }; c.messageCount = 4; return c; });
+    await surfacer.surface({ threadId: 't-null', senderName: 'codey', text: 'hi', hasParentTopic: false, warrants: true });
+    const ctx = { ...baseCtx(), telegram: tg as any, conversationStore: store, commitmentTracker: null, collaborationSurfacer: surfacer,
+      briefDeps: briefDepsFor(null) };
+    const res = await request(appWith(ctx)).post('/threadline/hub/bind').send({ action: 'open' });
+    expect(res.status).toBe(200);
+    expect(store.get('t-null')?.boundTopicId).toBe(res.body.topicId);
+  });
 });

--- a/tests/unit/hubCommands.test.ts
+++ b/tests/unit/hubCommands.test.ts
@@ -103,4 +103,56 @@ describe('bindHubConversation', () => {
     // The created topic name reflects the gist, not "codey · t-named".
     expect(tg.created.some(n => /GrowthBook/i.test(n))).toBe(true);
   });
+
+  // ── CMT-567: brief deps (LLM name + summary first message) ──────────────
+  function briefDeps(messages: number, evaluate?: (p: string) => Promise<string>): import('../../src/threadline/openConversationBrief.js').BriefDeps {
+    return {
+      observability: { getThread: () => ({ messages: Array.from({ length: messages }, (_, i) => ({ direction: (i % 2 === 0 ? 'in' : 'out') as 'in' | 'out', text: `m${i}`, remoteAgentName: 'Codey', timestamp: `2026-05-27T19:0${i}:00Z` })) }) },
+      llmQueue: evaluate ? ({ enqueue: async (_l: string, fn: (s: AbortSignal) => Promise<string>) => fn(new AbortController().signal) } as unknown as import('../../src/threadline/openConversationBrief.js').BriefDeps['llmQueue']) : null,
+      intelligence: evaluate ? { evaluate } : null,
+      topicNameFallback: (_c: unknown, t: string) => `codey · ${t.slice(0, 8)}`,
+    };
+  }
+
+  it('open with brief + LLM → topic named from PURPOSE, summary is first message', async () => {
+    const tg = fakeTelegram(); const store = new ConversationStore(stateDir); const surfacer = new CollaborationSurfacer({ telegram: tg as unknown as SurfacerTelegram, stateDir });
+    await store.mutate('t-llm', (c) => { c.participants = { peers: ['codey'] }; return c; });
+    await surfacer.surface({ threadId: 't-llm', senderName: 'codey', text: 'hi', hasParentTopic: false, warrants: true });
+    const d = { ...deps(tg, surfacer, store), brief: briefDeps(4, async () => 'PURPOSE: GrowthBook rollout plan\n\nCodey wants to coordinate the GrowthBook rollout. Awaiting your sign-off.') };
+    const r = await bindHubConversation(d, { action: 'open', threadId: 't-llm' });
+    expect(r.ok).toBe(true);
+    expect(tg.created.some(n => /GrowthBook rollout plan/i.test(n))).toBe(true);
+    expect(tg.posts.some(p => /Codey wants to coordinate/i.test(p.text))).toBe(true);
+    expect(tg.posts.some(p => /now tied to this topic/i.test(p.text))).toBe(false); // NOT the legacy marker
+  });
+
+  it('open with brief but LLM throws → slug name + template summary (NOT empty marker)', async () => {
+    const tg = fakeTelegram(); const store = new ConversationStore(stateDir); const surfacer = new CollaborationSurfacer({ telegram: tg as unknown as SurfacerTelegram, stateDir });
+    await store.mutate('t-fb', (c) => { c.participants = { peers: ['codey'] }; c.messageCount = 4; return c; });
+    await surfacer.surface({ threadId: 't-fb', senderName: 'codey', text: 'hi', hasParentTopic: false, warrants: true });
+    const d = { ...deps(tg, surfacer, store), brief: briefDeps(4, async () => { throw new Error('LLM timeout'); }) };
+    const r = await bindHubConversation(d, { action: 'open', threadId: 't-fb' });
+    expect(r.ok).toBe(true);
+    expect(tg.posts.some(p => /Conversation with/i.test(p.text))).toBe(true); // template brief
+  });
+
+  it('open with brief but no backing conversation messages → slug + legacy marker', async () => {
+    const tg = fakeTelegram(); const store = new ConversationStore(stateDir); const surfacer = new CollaborationSurfacer({ telegram: tg as unknown as SurfacerTelegram, stateDir });
+    await surfacer.surface({ threadId: 't-empty', senderName: 'codey', text: 'hi', hasParentTopic: false, warrants: true });
+    const d = { ...deps(tg, surfacer, store), brief: briefDeps(0, async () => 'PURPOSE: x\n\ny') };
+    const r = await bindHubConversation(d, { action: 'open', threadId: 't-empty' });
+    expect(r.ok).toBe(true);
+    expect(tg.posts.some(p => /now tied to this topic/i.test(p.text))).toBe(true); // Tier-C legacy marker
+  });
+
+  it('tie with brief deps → operator name + legacy marker, brief NOT invoked', async () => {
+    const tg = fakeTelegram(); const store = new ConversationStore(stateDir); const surfacer = new CollaborationSurfacer({ telegram: tg as unknown as SurfacerTelegram, stateDir });
+    await surfacer.surface({ threadId: 't-tie2', senderName: 'codey', text: 'x', hasParentTopic: false, warrants: true });
+    let called = false;
+    const d = { ...deps(tg, surfacer, store), brief: briefDeps(4, async () => { called = true; return 'PURPOSE: x\n\ny'; }) };
+    const r = await bindHubConversation(d, { action: 'tie', threadId: 't-tie2', targetTopicId: 9999 });
+    expect(r.ok).toBe(true);
+    expect(called).toBe(false);
+    expect(tg.posts.some(p => /now tied to this topic/i.test(p.text))).toBe(true);
+  });
 });

--- a/tests/unit/threadline/openConversationBrief.test.ts
+++ b/tests/unit/threadline/openConversationBrief.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for generateConversationBrief (CMT-567) — the 3-tier brief
+ * (LLM → template → slug) for "open this". Covers both sides of every
+ * degradation boundary + the never-empty invariant.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  generateConversationBrief,
+  type BriefDeps,
+  type BriefConversation,
+  __testing,
+} from '../../../src/threadline/openConversationBrief.js';
+
+const NOW = Date.parse('2026-05-27T20:00:00Z');
+
+function makeConv(over: Partial<BriefConversation> = {}): BriefConversation {
+  return {
+    remoteAgent: 'instar-codey',
+    participants: { peers: ['codey-fp'] },
+    messageCount: 5,
+    lastActivityAt: '2026-05-27T19:58:00Z',
+    lastInboundHash: 'last inbound text',
+    ...over,
+  };
+}
+
+function makeMessages(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    direction: (i % 2 === 0 ? 'in' : 'out') as 'in' | 'out',
+    text: `message ${i}`,
+    remoteAgentName: 'Codey',
+    timestamp: `2026-05-27T19:${String(10 + i).padStart(2, '0')}:00Z`,
+  }));
+}
+
+function makeDeps(over: Partial<BriefDeps> = {}): BriefDeps {
+  return {
+    observability: { getThread: () => ({ messages: makeMessages(4) }) },
+    llmQueue: { enqueue: async (_lane, fn) => fn(new AbortController().signal) } as unknown as BriefDeps['llmQueue'],
+    intelligence: { evaluate: async () => 'PURPOSE: OAuth refresh failure triage\n\nCodey flagged a token-refresh bug. Decision pending on the retry window.' },
+    topicNameFallback: () => 'instar-codey · abcd1234',
+    now: () => NOW,
+    ...over,
+  };
+}
+
+describe('generateConversationBrief — Tier A (LLM)', () => {
+  it('happy path: PURPOSE → name, body → summary, source=llm', async () => {
+    const b = await generateConversationBrief('t1', makeConv(), makeDeps());
+    expect(b.topicName).toBe('OAuth refresh failure triage');
+    expect(b.summary).toContain('Codey flagged a token-refresh bug');
+    expect(b.nameSource).toBe('llm');
+    expect(b.summarySource).toBe('llm');
+    expect(b.reason).toBe('ok');
+  });
+
+  it('PURPOSE present but body empty → name from PURPOSE, summary = template (never the PURPOSE echo)', async () => {
+    const deps = makeDeps({ intelligence: { evaluate: async () => 'PURPOSE: Some title here' } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.nameSource).toBe('llm');
+    expect(b.topicName).toBe('Some title here');
+    expect(b.summary).not.toMatch(/^PURPOSE:/i);
+    expect(b.summarySource).toBe('template');
+  });
+
+  it('no PURPOSE line but a real body → name degrades to slug, summary = body', async () => {
+    const deps = makeDeps({ intelligence: { evaluate: async () => 'Just a plain summary with no purpose line at all.' } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.nameSource).toBe('slug');
+    expect(b.summarySource).toBe('llm');
+    expect(b.summary).toContain('plain summary');
+  });
+
+  it('PURPOSE > 40 chars → name trimmed to 40', async () => {
+    const long = 'PURPOSE: ' + 'word '.repeat(20) + '\n\nbody text here for the summary.';
+    const deps = makeDeps({ intelligence: { evaluate: async () => long } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.topicName.length).toBeLessThanOrEqual(40);
+    expect(b.nameSource).toBe('llm');
+  });
+
+  it('credential in PURPOSE → name degrades to slug; clean body still used', async () => {
+    const deps = makeDeps({ intelligence: { evaluate: async () => 'PURPOSE: sk-secret-key-leak\n\nA normal clean summary body.' } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.nameSource).toBe('slug');
+    expect(b.summarySource).toBe('llm');
+    expect(b.reason).toBe('credential-scrub');
+  });
+
+  it('credential VALUE in body → summary degrades to template; clean name kept', async () => {
+    const deps = makeDeps({ intelligence: { evaluate: async () => 'PURPOSE: Clean title\n\nThey shared a Slack token xoxb-1234567890-abcdefghij here.' } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.nameSource).toBe('llm');
+    expect(b.topicName).toBe('Clean title');
+    expect(b.summarySource).toBe('template');
+    expect(b.reason).toBe('credential-scrub');
+  });
+
+  it('topic vocabulary ("token refresh", "API key rotation") is NOT scrubbed', async () => {
+    const deps = makeDeps({ intelligence: { evaluate: async () => 'PURPOSE: Token refresh + API key rotation\n\nCodey is debugging the token refresh flow and the API key rotation schedule.' } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.nameSource).toBe('llm');
+    expect(b.summarySource).toBe('llm');
+    expect(b.summary).toContain('token refresh flow');
+    expect(b.reason).toBe('ok');
+  });
+
+  it('LLM timeout → Tier B (template + slug)', async () => {
+    const deps = makeDeps({ intelligence: { evaluate: async () => { throw new Error('LLM timeout'); } } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.summarySource).toBe('template');
+    expect(b.nameSource).toBe('slug');
+    expect(b.reason).toBe('llm-timeout');
+  });
+
+  it('LLM abort → Tier B, reason=llm-abort', async () => {
+    const deps = makeDeps({ intelligence: { evaluate: async () => { throw new Error('LLM aborted by higher-priority lane'); } } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.reason).toBe('llm-abort');
+    expect(b.summarySource).toBe('template');
+  });
+
+  it('LLM daily cap exceeded (rejected by queue) → Tier B, reason=llm-capped', async () => {
+    const deps = makeDeps({
+      llmQueue: { enqueue: async () => { throw new Error('LLM daily spend cap exceeded'); } } as unknown as BriefDeps['llmQueue'],
+    });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.reason).toBe('llm-capped');
+    expect(b.summarySource).toBe('template');
+  });
+
+  it('LLM returns empty/whitespace → Tier B, reason=parse-empty', async () => {
+    const deps = makeDeps({ intelligence: { evaluate: async () => '   ' } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.reason).toBe('parse-empty');
+    expect(b.summarySource).toBe('template');
+  });
+
+  it('truncates a 50-message thread to the last 10 in the prompt', async () => {
+    const captured: string[] = [];
+    const deps = makeDeps({
+      observability: { getThread: () => ({ messages: makeMessages(50) }) },
+      intelligence: { evaluate: async (p: string) => { captured.push(p); return 'PURPOSE: t\n\nbody.'; } },
+    });
+    await generateConversationBrief('t1', makeConv(), deps);
+    expect(captured[0]).toContain('message 49');
+    expect(captured[0]).not.toContain('message 39');
+  });
+});
+
+describe('generateConversationBrief — Tier B (template)', () => {
+  it('intelligence null → template summary, no LLM call', async () => {
+    const evaluate = vi.fn();
+    const b = await generateConversationBrief('t1', makeConv(), makeDeps({ intelligence: null }));
+    expect(b.reason).toBe('no-deps');
+    expect(b.summarySource).toBe('template');
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it('llmQueue null → template summary, no LLM call', async () => {
+    const b = await generateConversationBrief('t1', makeConv(), makeDeps({ llmQueue: null }));
+    expect(b.reason).toBe('no-deps');
+    expect(b.summarySource).toBe('template');
+  });
+
+  it('single message → template "just getting started", NO LLM call', async () => {
+    const evaluate = vi.fn(async () => 'PURPOSE: x\n\ny');
+    const deps = makeDeps({
+      observability: { getThread: () => ({ messages: [{ direction: 'in', text: 'hi there', remoteAgentName: 'Codey', timestamp: '2026-05-27T19:00:00Z' }] }) },
+      intelligence: { evaluate },
+    });
+    const b = await generateConversationBrief('t1', makeConv({ messageCount: 1 }), deps);
+    expect(b.reason).toBe('too-few-messages');
+    expect(b.summary).toContain('Opening message');
+    expect(b.summary).toContain('hi there');
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it('template scrubs a credential out of the inbound snippet', async () => {
+    const deps = makeDeps({
+      llmQueue: null,
+      observability: { getThread: () => ({ messages: makeMessages(2).map((m, i) => i === 1 ? m : { ...m, direction: 'in' as const, text: 'my key is sk-abc123def456' }) }) },
+    });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.summary).not.toContain('sk-abc123def');
+  });
+});
+
+describe('generateConversationBrief — Tier C (slug, no conversation)', () => {
+  it('conv null → slug + legacy marker, NO LLM call', async () => {
+    const evaluate = vi.fn();
+    const b = await generateConversationBrief('t1', null, makeDeps({ intelligence: { evaluate } }));
+    expect(b.nameSource).toBe('slug');
+    expect(b.summarySource).toBe('slug');
+    expect(b.reason).toBe('no-conversation');
+    expect(b.summary).toBe(__testing.LEGACY_MARKER);
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it('conversation exists but zero messages → slug + legacy marker', async () => {
+    const deps = makeDeps({ observability: { getThread: () => ({ messages: [] }) } });
+    const b = await generateConversationBrief('t1', makeConv(), deps);
+    expect(b.reason).toBe('no-conversation');
+    expect(b.summary).toBe(__testing.LEGACY_MARKER);
+  });
+});
+
+describe('generateConversationBrief — never-empty invariant', () => {
+  it('topicName and summary are non-empty across tiers, including empty threadId', async () => {
+    const variants: BriefDeps[] = [
+      makeDeps(),
+      makeDeps({ intelligence: null }),
+      makeDeps({ llmQueue: null }),
+      makeDeps({ observability: { getThread: () => ({ messages: [] }) } }),
+    ];
+    for (const deps of variants) {
+      for (const tid of ['t1', '', '   ']) {
+        const b = await generateConversationBrief(tid, makeConv(), deps);
+        expect(b.topicName.length).toBeGreaterThan(0);
+        expect(b.summary.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/tests/unit/threadline/openConversationBrief.test.ts
+++ b/tests/unit/threadline/openConversationBrief.test.ts
@@ -71,12 +71,16 @@ describe('generateConversationBrief — Tier A (LLM)', () => {
     expect(b.summary).toContain('plain summary');
   });
 
-  it('PURPOSE > 40 chars → name trimmed to 40', async () => {
-    const long = 'PURPOSE: ' + 'word '.repeat(20) + '\n\nbody text here for the summary.';
+  it('PURPOSE > 40 chars → name trimmed to 40 on a word boundary (no mid-word cut)', async () => {
+    const long = 'PURPOSE: Free text guard hook template path resolution fix\n\nbody text here for the summary.';
     const deps = makeDeps({ intelligence: { evaluate: async () => long } });
     const b = await generateConversationBrief('t1', makeConv(), deps);
     expect(b.topicName.length).toBeLessThanOrEqual(40);
     expect(b.nameSource).toBe('llm');
+    // Does not end mid-word (the slice backed off to the last space).
+    expect(b.topicName.endsWith('resol')).toBe(false);
+    expect(/\s$/.test(b.topicName)).toBe(false);
+    expect(long).toContain(b.topicName); // it's a clean prefix of the PURPOSE words
   });
 
   it('credential in PURPOSE → name degrades to slug; clean body still used', async () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -28,4 +28,12 @@ first message.
 
 Nothing to do — it's automatic. Next time you "open this" in the Threadline topic, the new
 topic shows up with a real name and a short summary of the conversation inside it, instead of
-an empty room. "Tie this to <existing topic>" is unchanged.
+an empty room. "Tie this to <existing topic>" is unchanged. (The topic takes a few seconds to
+appear while the summary is generated; if the model is slow you still get an instant plain brief.)
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| "Open this" topics are LLM-named + summarized | In the Threadline hub topic, say "open this" — the new topic gets an LLM-generated name and a summary of the conversation as its first message. Automatic; no command or flag. |
+| Always-contextful fallback | If the LLM can't run (timeout / daily cap / unwired), the new topic still gets a deterministic templated brief (peer · message count · last activity · latest line) instead of the old empty marker. The bind never fails on LLM trouble. |

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,31 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**"Open this" topics now arrive named + summarized.** When you promote a Threadline
+conversation into its own topic ("open this" in the Threadline hub), the new topic used to
+get a crude name (the first ~5 words of the cold message) and a single generic "tied to this
+topic" marker — an unlabelled, empty room. Now an LLM names the topic from what the
+conversation is actually about and writes a short orientation summary as the first message
+(who the other agent is, what it's about, where it stands), so you walk in oriented.
+
+This is strictly additive on top of the deterministic "open this" intercept. It NEVER fails
+the bind: if the LLM can't run (timeout, daily spend cap, rate-limit, scrubbed output, or
+the deps aren't wired in your build), "open this" degrades to a deterministic templated brief
+(peer · message count · last activity · latest line) — and only falls back to the bare marker
+when there's literally no conversation behind the entry yet. The LLM is a generator, never a
+gate. The naming/summary call runs on the shared interactive LLM lane (you're waiting on it)
+with a 3.5s ceiling, ~1 cent per call, governed by the existing daily spend cap.
+
+Credential scrubbing uses value-pattern detection (actual `sk-…`/`xoxb-…`/`ghp_…`/key blocks),
+not bare english words — so a legitimate technical topic ("token refresh triage", "API key
+rotation") is named normally, while a pasted secret never lands in your chat-list title or the
+first message.
+
+## What to Tell Your User
+
+Nothing to do — it's automatic. Next time you "open this" in the Threadline topic, the new
+topic shows up with a real name and a short summary of the conversation inside it, instead of
+an empty room. "Tie this to <existing topic>" is unchanged.

--- a/upgrades/side-effects/threadline-open-this-llm-naming.md
+++ b/upgrades/side-effects/threadline-open-this-llm-naming.md
@@ -1,0 +1,60 @@
+# Side-Effects Review — Threadline "open this" LLM topic-name + summary (CMT-567)
+
+**Version / slug:** `threadline-open-this-llm-naming`
+**Date:** `2026-05-27`
+**Author:** `echo`
+**Spec:** `docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-SPEC.md` (converged 2-round / 4-reviewer, approved)
+**Second-pass reviewer:** `not required` (UX continuation of #399, no new external surface; standard 2-round convergence applied)
+
+## Summary of the change
+
+When the deterministic "open this" intercept (CMT-529 / PR #399) promotes a Threadline
+conversation into its own topic, the new topic is now named by an LLM (from the conversation
+gist) and its first message is an LLM-written orientation summary. A three-tier degrade
+guarantees the bind never fails on LLM trouble:
+
+- **Tier A — LLM.** Real conversation (≥2 messages) → Haiku call using the proven PURPOSE-line
+  convention (reuses `parsePurposeFromResponse` from `TopicSummarizer`, NOT JSON). PURPOSE →
+  topic name; body → summary. Runs on the shared `interactive` LlmQueue lane (operator is
+  waiting), `costCents=2`, 3.5s race (timeout + queue-abort, since `intelligence.evaluate`
+  honors `timeoutMs` but not an AbortSignal).
+- **Tier B — deterministic template.** LLM skipped/failed → `💬 Conversation with <peer> · N
+  messages · last activity <when>. Latest: "<scrubbed inbound>"`. Zero cost/latency.
+- **Tier C — slug + legacy marker.** No backing conversation (hub-notice-only entry) → existing
+  slug name + the legacy "tied to this topic" marker. No LLM call attempted.
+
+Files touched:
+- `src/threadline/openConversationBrief.ts` (**add**) — the 3-tier generator. Pure compute; never throws; never returns empty.
+- `src/threadline/hubCommands.ts` (modify) — `HubBindDeps.brief?: BriefDeps` (optional); `open` branch calls `generateConversationBrief`, posts `brief.summary` as the first message, adds the `[hub/bind] open …` observability log line. `tie` branch unchanged (still posts the tie-marker; brief NOT invoked).
+- `src/commands/server.ts` (modify) — build ONE `briefDeps` after `collaborationSurfacer`; thread to both `getHubDeps` closures + the `AgentServer` ctor.
+- `src/server/AgentServer.ts` (modify) — `briefDeps?` on options interface; `briefDeps: options.briefDeps ?? null` into routeCtx.
+- `src/server/routes.ts` (modify) — `briefDeps` on `RouteContext`; `POST /threadline/hub/bind` passes `brief: ctx.briefDeps ?? undefined`.
+- `tests/unit/threadline/openConversationBrief.test.ts` (**add**) — 19 cases.
+- `tests/unit/hubCommands.test.ts` (modify) — +4 brief-path cases (LLM / template / Tier-C / tie-not-invoked).
+- `tests/integration/threadline/hub-bind-routes.test.ts` (modify) — +3 cases (LLM happy path; LLM-throws → bind still 200 + template; intelligence:null → bind still 200).
+- `upgrades/NEXT.md` (modify) — release note.
+
+## Decision-point inventory
+
+- `generateConversationBrief()` — **add** — three tiers; per-FIELD scrub-degrade (a credential in the PURPOSE degrades only the name, a credential in the body degrades only the summary). Never throws.
+- Credential detection — **new, intentionally different from hubCommands.CREDENTIAL_RE.** `SECRET_VALUE_RE` (vendor-prefixed tokens / key blocks / JWT-ish) is applied to LLM output; `SECRET_ASSIGN_RE` (`password|secret|token|api_key… : value`) additionally guards the RAW inbound snippet. The bare-english-word regex used by the existing slug path would false-positive on normal technical prose ("token refresh", "API key rotation") and degrade most real summaries — so it is deliberately NOT reused for the prose summary. The existing slug-path `CREDENTIAL_RE` in `hubCommands.ts` is untouched.
+- LlmQueue lane = `interactive` — operator is actively waiting; `background` would let a PresenceProxy arrival abort the in-flight brief (LlmQueue preempts only background victims).
+- `HubBindDeps.brief` is OPTIONAL — when absent (existing callers / tests that don't wire it), the `open` path degrades to slug + legacy marker (exact pre-CMT-567 behavior). No back-compat break.
+- `BriefDeps.topicNameFallback` is OPTIONAL — server-built `briefDeps` omits it (topicNameFor is private to hubCommands); `bindHubConversation` injects the real `topicNameFor` so the brief's slug matches the legacy path. A built-in `defaultSlug` guards direct callers.
+- Single shared `briefDeps` (built once in server.ts) — closes the round-2 finding that the `POST /threadline/hub/bind` route had no scope path to `sharedLlmQueue`. One construction, three consumers (2 closures + ctx).
+- Observability — one structured `console.log` per open: `nameSource / summarySource / latencyMs / reason`. Makes silent fallback diagnosable from `logs/server.log`.
+
+## Blast radius / reversibility
+
+- **Additive only.** `tie` path, the deterministic intercept itself, the parent-topic reply surfacing, and all other Threadline routing are untouched.
+- **No state files, no migrations.** Pure compute module; no persisted artifacts; `PostUpdateMigrator` needs no entry (verified — no agent-installed file changes).
+- **No new agent API.** The agent doesn't call this; it fires inside the operator-invoked "open this". No CLAUDE.md template change needed (Agent Awareness Standard N/A).
+- **Rollback:** single revert of the commit restores slug-name + legacy-marker verbatim.
+
+## Tests
+
+- Unit (new module): 19 cases — all three tiers, every fallback cause, per-field credential scrub, technical-vocab-not-scrubbed, input truncation, never-empty invariant (incl. empty/whitespace threadId).
+- Unit (hubCommands): +4 — LLM summary posted (not marker), LLM-throws → template, Tier-C marker, tie does not invoke brief.
+- Integration (hub/bind route): +3 — LLM happy path names+summarizes; LLM-throws → 200 + template (regression guard: LLM failure NEVER fails the bind); intelligence:null → 200.
+- Full threadline suite: 1580 passing, zero regressions. Production build clean (`tsc --noEmit` + `pnpm build`).
+- Test-as-self on live Codey: pending pre-merge (fire a real "open this", confirm named topic + summary, restore).

--- a/upgrades/side-effects/threadline-open-this-llm-naming.md
+++ b/upgrades/side-effects/threadline-open-this-llm-naming.md
@@ -57,4 +57,16 @@ Files touched:
 - Unit (hubCommands): +4 — LLM summary posted (not marker), LLM-throws → template, Tier-C marker, tie does not invoke brief.
 - Integration (hub/bind route): +3 — LLM happy path names+summarizes; LLM-throws → 200 + template (regression guard: LLM failure NEVER fails the bind); intelligence:null → 200.
 - Full threadline suite: 1580 passing, zero regressions. Production build clean (`tsc --noEmit` + `pnpm build`).
-- Test-as-self on live Codey: pending pre-merge (fire a real "open this", confirm named topic + summary, restore).
+
+## Test-as-self (live, real LLM — completed 2026-05-27)
+
+Two-stage, real-dependency validation (no mocks):
+
+1. **Real-LLM harness (Echo's Claude provider, real threadline data).** Ran the BUILT `generateConversationBrief` against two real Echo threads with a real `ClaudeCliIntelligenceProvider`, real `LlmQueue`, real `ThreadlineObservability`. Produced clean LLM names + summaries (`reason: ok`). **This caught a production-breaking bug the mocks hid:** a real CLI call took ~8-10s, over the original 3.5s timeout — so the happy path would have silently fallen to the template in production. Fixed: default timeout 3.5s → 15s (+ word-boundary cap on the name so a long title doesn't read "…path resol"). Re-ran with the production default: `nameSource=llm`, ~9.7s, clean name "Arm the full response-review stack".
+
+2. **Live deploy on a real peer agent (instar-codey, Codex/gpt-5.2).** Backed up Codey's shadow-install dist + hub state, deployed this build, restarted via launchd, drove a real `POST /threadline/hub/bind action:open` against a 4-message unbound hub conversation. Result: topic 680 created, `topicName="Mentor ledger dedup strategy"` (LLM, not slug), server log `[hub/bind] open threadId=f3d471e9 topic=680 nameSource=llm summarySource=llm` — proving briefDeps booted non-null and the real Codex LLM produced both fields through the live server. Cleaned up: deleted test topic 680 (Bot API), restored dist + hub state, restarted Codey onto the released build, verified f3d471e9 reverted to unbound.
+
+## Post-test-as-self deviations (folded into this commit)
+
+- Default `timeoutMs` 3.5s → **15s** (spec §3a updated with the measured rationale). The LLM tier is now the common outcome; template covers overruns.
+- `scrubName` caps on a **word boundary** (no mid-word truncation in the chat-list title).


### PR DESCRIPTION
Rebased onto current main (supersedes #440, whose CI never triggered).

## Summary
- When "open this" promotes a Threadline conversation into its own topic, an LLM names the topic from the conversation gist and writes an orientation summary as the first message — replacing the crude slug name + empty "tied to this topic" marker.
- Three-tier degrade (**LLM → deterministic template → slug**) guarantees the bind NEVER fails on LLM trouble. The operator always lands with real context; the LLM polishes it when available.
- Runs on the shared `interactive` LlmQueue lane, **15s timeout** (test-as-self measured real CLI calls at ~8-10s; the original 3.5s would have silently fallen back every time), governed by the daily spend cap.
- Value-pattern credential scrub (actual `sk-…`/`xoxb-…`/key-blocks), not bare english words — technical topics ("token refresh triage") name normally; pasted secrets never reach the chat-list title or first message.
- One shared `briefDeps` built once at startup, threaded to both `onTopicMessage` intercept closures + the `POST /threadline/hub/bind` route. `tie` path unchanged.

## Spec
`docs/specs/THREADLINE-OPEN-THIS-LLM-NAMING-SPEC.md` — converged (2 rounds / 4 reviewers), approved, ELI16 companion shipped.

## Test plan
- [x] Unit `openConversationBrief.test.ts` (19) + `hubCommands.test.ts` (+4) + integration `hub-bind-routes.test.ts` (+3). Full threadline suite 1580 green; `tsc --noEmit` clean.
- [x] **Test-as-self (real LLM, no mocks):** harness vs real Claude caught the 3.5s→15s timeout bug; then live-deployed on instar-codey (Codex/gpt-5.2) — real "open this" produced `topicName="Mentor ledger dedup strategy"`, log `nameSource=llm summarySource=llm`. Test topic deleted, Codey restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)