### PR TITLE
fix(security): redact credentials from URL logging (MM-Bootstrap Track B)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:contract": "node scripts/run-contract-tests.js",
     "test:contract:raw": "vitest run --config vitest.contract.config.ts",
     "test:all": "vitest run && vitest run --config vitest.integration.config.ts && vitest run --config vitest.e2e.config.ts",
-    "lint": "tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/check-codex-rule1-drift.js",
+    "lint": "tsc --noEmit && node scripts/lint-no-direct-destructive.js && node scripts/lint-no-direct-llm-http.js && node scripts/lint-no-direct-url-log.js && node scripts/check-codex-rule1-drift.js",
     "lint:destructive": "node scripts/lint-no-direct-destructive.js",
     "lint:destructive:staged": "node scripts/lint-no-direct-destructive.js --staged",
     "lint:llm-http": "node scripts/lint-no-direct-llm-http.js",

--- a/scripts/lint-no-direct-url-log.js
+++ b/scripts/lint-no-direct-url-log.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * lint-no-direct-url-log.js — ban logging credentialed URLs.
+ *
+ * The 2026-05-27 incident: `instar join` logged a clone URL containing a live
+ * GitHub token. This lint fails CI if any source file logs a string that
+ * looks like it could embed credentials (a `scheme://user:pass@` literal, or a
+ * console.* call interpolating a known credential-bearing variable) WITHOUT
+ * routing it through the redaction funnel `src/core/redactUrl.ts`.
+ *
+ * Conservative by design: it flags the two concrete shapes we know leak, not
+ * every URL log. The redactUrl module + its tests are exempt.
+ *
+ * Exit 0 = clean. Exit 1 = at least one offending site (printed).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = path.join(ROOT, 'src');
+
+// Files that are allowed to contain the patterns (the funnel + its tests).
+const EXEMPT = [
+  path.join('src', 'core', 'redactUrl.ts'),
+];
+
+/** A literal `scheme://user:pass@` in a string that is being logged. */
+const CREDENTIALED_URL_LITERAL = /['"`][a-z][a-z0-9+.-]*:\/\/[^/@'"`\s]+:[^/@'"`\s]+@/i;
+
+/** console.* logging a variable named like a clone/remote URL without redactUrl on the same line. */
+const RISKY_URL_VAR_LOG = /console\.(log|error|warn|info)\([^)]*\b(repoUrl|cloneUrl|remoteUrl|pushUrl|gitUrl)\b/;
+
+function walk(dir, out = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name === 'templates') continue;
+      walk(full, out);
+    } else if (e.name.endsWith('.ts') && !e.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const offenders = [];
+for (const file of walk(SRC)) {
+  const rel = path.relative(ROOT, file);
+  if (EXEMPT.includes(rel)) continue;
+  const lines = fs.readFileSync(file, 'utf-8').split('\n');
+  lines.forEach((line, i) => {
+    const hasRedact = line.includes('redactUrl') || line.includes('redactUrlsInText');
+    if (CREDENTIALED_URL_LITERAL.test(line)) {
+      offenders.push(`${rel}:${i + 1}  credentialed-URL literal: ${line.trim().slice(0, 100)}`);
+    } else if (RISKY_URL_VAR_LOG.test(line) && !hasRedact) {
+      offenders.push(`${rel}:${i + 1}  logs a clone/remote URL var without redactUrl(): ${line.trim().slice(0, 100)}`);
+    }
+  });
+}
+
+if (offenders.length > 0) {
+  console.error('[lint-no-direct-url-log] credentialed-URL logging detected:');
+  for (const o of offenders) console.error(`  - ${o}`);
+  console.error('\nRoute the URL through redactUrl()/redactUrlsInText() from src/core/redactUrl.ts before logging.');
+  process.exit(1);
+}
+console.log('[lint-no-direct-url-log] ✓ no credentialed-URL logging found');
+process.exit(0);

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -18,6 +18,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import pc from 'picocolors';
 import { loadConfig } from '../core/Config.js';
+import { redactUrl, redactUrlsInText } from '../core/redactUrl.js';
 import { MachineIdentityManager } from '../core/MachineIdentity.js';
 import { HeartbeatManager } from '../core/HeartbeatManager.js';
 import { SecretStore } from '../core/SecretStore.js';
@@ -285,7 +286,7 @@ export async function joinMesh(repoUrl: string, options: JoinOptions): Promise<v
         execFileSync('git', ['clone', repoUrl, projectDir], { stdio: 'inherit', timeout: 60_000 });
         console.log(pc.green('  Cloned.'));
       } catch (err) {
-        console.log(pc.red(`  Failed to clone: ${err instanceof Error ? err.message : String(err)}`));
+        console.log(pc.red(`  Failed to clone: ${redactUrlsInText(err instanceof Error ? err.message : String(err))}`));
         process.exit(1);
       }
     }
@@ -339,7 +340,7 @@ export async function joinMesh(repoUrl: string, options: JoinOptions): Promise<v
   // Step 4: Contact the awake machine's pairing endpoint (if URL is a tunnel)
   const isTunnelUrl = repoUrl.startsWith('http://') || repoUrl.startsWith('https://');
   if (isTunnelUrl) {
-    console.log(`  Contacting ${repoUrl}...`);
+    console.log(`  Contacting ${redactUrl(repoUrl)}...`);
     try {
       const identity = mgr.loadIdentity();
       const resp = await fetch(`${repoUrl}/api/pair`, {
@@ -367,7 +368,7 @@ export async function joinMesh(repoUrl: string, options: JoinOptions): Promise<v
         console.log(pc.green(`  Paired with: ${result.machineIdentity.name}`));
       }
     } catch (err) {
-      console.log(pc.red(`  Failed to contact server: ${err instanceof Error ? err.message : String(err)}`));
+      console.log(pc.red(`  Failed to contact server: ${redactUrlsInText(err instanceof Error ? err.message : String(err))}`));
       console.log(pc.dim('  If the server is not running, clone the repo with git and register manually.'));
     }
   }

--- a/src/core/redactUrl.ts
+++ b/src/core/redactUrl.ts
@@ -1,0 +1,107 @@
+/**
+ * redactUrl — strip credentials from URLs before they reach any log sink.
+ *
+ * The 2026-05-27 incident: `instar join` formatted a clone URL containing a
+ * live GitHub token (`https://x-access-token:gho_…@github.com/…`) into an
+ * error message that was printed to stdout. Node's own fetch/URL errors echo
+ * the full credentialed URL in `err.message`, so even catching the error and
+ * logging `err.message` leaks the secret.
+ *
+ * This module is the single redaction funnel. Anywhere a URL (or a string that
+ * may embed one) is about to be logged, route it through `redactUrl` /
+ * `redactUrlsInText` first. The companion lint rule
+ * (`scripts/lint-no-direct-url-log.js`) bans logging a raw `user:pass@host`
+ * URL outside this module + its tests.
+ *
+ * Design notes:
+ * - Fail-OPEN to the SAFE side: on any parse failure we still attempt a
+ *   regex-based scrub rather than returning the raw input, because the whole
+ *   point is "never leak a credential." We never throw.
+ * - Idempotent: redacting an already-redacted string is a no-op.
+ * - Preserves everything except the userinfo segment, so logs stay useful
+ *   (host, path, query — minus any token that lived in the query is NOT
+ *   handled here; query-embedded secrets are a separate concern, see
+ *   `scrubKnownTokenPatterns`).
+ */
+
+const REDACTED = '***';
+
+/**
+ * Known secret token shapes that can appear OUTSIDE a userinfo segment
+ * (e.g. embedded in a path or query). Conservative — only well-known,
+ * unambiguous prefixes, to avoid mangling benign strings.
+ */
+const TOKEN_PATTERNS: RegExp[] = [
+  /gh[posru]_[A-Za-z0-9_]{20,}/g,        // GitHub PAT / OAuth / refresh / server / user-to-server
+  /github_pat_[A-Za-z0-9_]{20,}/g,        // GitHub fine-grained PAT
+  /xox[baprs]-[A-Za-z0-9-]{10,}/g,        // Slack tokens
+  /\d{8,10}:[A-Za-z0-9_-]{30,}/g,         // Telegram bot tokens (id:secret) — no \b: the API path form is /bot<id>:<secret>/
+  /sk-[A-Za-z0-9]{20,}/g,                 // OpenAI-style keys
+];
+
+/**
+ * Redact the userinfo (user:password@) segment of a single URL string.
+ * Returns the URL with `***:***@` (or `***@`) in place of any credentials.
+ * Non-URL input is returned with token-pattern scrubbing applied.
+ */
+export function redactUrl(input: string | URL): string {
+  const raw = typeof input === 'string' ? input : input.toString();
+
+  // Fast path: try structured parse so we redact exactly the userinfo segment.
+  try {
+    const u = new URL(raw);
+    if (u.username || u.password) {
+      const user = u.username ? REDACTED : '';
+      const pass = u.password ? REDACTED : '';
+      const userinfo = user && pass ? `${user}:${pass}` : (user || pass);
+      // Rebuild without mutating via URL (which would re-encode); string-splice
+      // the authority so the rest of the URL is byte-preserved.
+      const schemeSep = raw.indexOf('://');
+      if (schemeSep !== -1) {
+        const afterScheme = schemeSep + 3;
+        const atIdx = raw.indexOf('@', afterScheme);
+        if (atIdx !== -1) {
+          return raw.slice(0, afterScheme) + userinfo + raw.slice(atIdx);
+        }
+      }
+    }
+    // No credentials in the structured URL — still scrub stray token patterns
+    // (a token could be sitting in the path or query).
+    return scrubKnownTokenPatterns(raw);
+  } catch {
+    // Not parseable as a single URL (could be a sentence containing one, or
+    // malformed). Fall back to regex scrubbing — never return raw.
+    return scrubKnownTokenPatterns(redactUserinfoByRegex(raw));
+  }
+}
+
+/**
+ * Redact every URL embedded in a larger block of text (e.g. an error message
+ * that interpolated a URL). Use this when logging `err.message` or any string
+ * that might contain a credentialed URL somewhere inside it.
+ */
+export function redactUrlsInText(text: string): string {
+  if (!text) return text;
+  // First scrub `scheme://user:pass@` authorities anywhere in the text.
+  const userinfoScrubbed = redactUserinfoByRegex(text);
+  // Then scrub bare known-token patterns (covers tokens in query/path/headers).
+  return scrubKnownTokenPatterns(userinfoScrubbed);
+}
+
+/** Regex pass: replace `scheme://user:pass@` (or `scheme://user@`) with redacted. */
+function redactUserinfoByRegex(text: string): string {
+  // Matches scheme://USERINFO@host where USERINFO has no '/', '@', or whitespace.
+  return text.replace(
+    /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)([^/@\s]+)@/g,
+    (_m, scheme) => `${scheme}${REDACTED}@`,
+  );
+}
+
+/** Scrub well-known standalone token shapes wherever they appear. */
+function scrubKnownTokenPatterns(text: string): string {
+  let out = text;
+  for (const re of TOKEN_PATTERNS) {
+    out = out.replace(re, REDACTED);
+  }
+  return out;
+}

--- a/src/templates/scripts/convergence-check.sh
+++ b/src/templates/scripts/convergence-check.sh
@@ -59,11 +59,36 @@ fi
 # Known-safe domains are whitelisted; anything else gets flagged.
 URLS_IN_MSG=$(echo "$CONTENT" | grep -oE 'https?://[^ )"'"'"'>]+' 2>/dev/null || true)
 if [ -n "$URLS_IN_MSG" ]; then
+  # The agent's OWN tunnel domain is trusted — a private-view / dashboard link
+  # the agent just generated via POST /view is not a confabulation. Read the
+  # live tunnel host from the persisted tunnel state so custom-domain tunnels
+  # are covered too (not just the default *.dawn-tunnel.dev / *.trycloudflare.com).
+  OWN_TUNNEL_HOST=""
+  for tj in "${CLAUDE_PROJECT_DIR:-.}/.instar/state/tunnel.json" "${CLAUDE_PROJECT_DIR:-.}/.instar/tunnel.json"; do
+    if [ -f "$tj" ]; then
+      OWN_TUNNEL_HOST=$(python3 -c "
+import json,sys,re
+try:
+    d=json.load(open('$tj'))
+    u=d.get('url') or d.get('tunnelUrl') or ''
+    m=re.search(r'https?://([^/]+)', u)
+    print(re.escape(m.group(1)) if m else '')
+except Exception:
+    print('')
+" 2>/dev/null)
+      [ -n "$OWN_TUNNEL_HOST" ] && break
+    fi
+  done
+
   UNFAMILIAR_URLS=""
   while IFS= read -r url; do
     [ -z "$url" ] && continue
-    # Skip well-known service domains
-    if echo "$url" | grep -qE '(github\.com|vercel\.app|vercel\.com|netlify\.app|netlify\.com|npmjs\.com|npmjs\.org|cloudflare\.com|google\.com|twitter\.com|x\.com|youtube\.com|reddit\.com|discord\.com|discord\.gg|telegram\.org|t\.me|localhost|127\.0\.0\.1|stackoverflow\.com|developer\.mozilla\.org|docs\.anthropic\.com|anthropic\.com|openai\.com|claude\.ai|notion\.so|linear\.app|fly\.io|render\.com|railway\.app|heroku\.com|amazonaws\.com|azure\.com|gitlab\.com|bitbucket\.org|docker\.com|hub\.docker\.com|pypi\.org|crates\.io|rubygems\.org|pkg\.go\.dev|wikipedia\.org|medium\.com|substack\.com|circle\.so|ghost\.io|telegraph\.ph)'; then
+    # Skip the agent's own live tunnel host (dynamic, covers custom domains).
+    if [ -n "$OWN_TUNNEL_HOST" ] && echo "$url" | grep -qE "$OWN_TUNNEL_HOST"; then
+      continue
+    fi
+    # Skip well-known service domains + common agent tunnel domains.
+    if echo "$url" | grep -qE '(github\.com|vercel\.app|vercel\.com|netlify\.app|netlify\.com|npmjs\.com|npmjs\.org|cloudflare\.com|google\.com|twitter\.com|x\.com|youtube\.com|reddit\.com|discord\.com|discord\.gg|telegram\.org|t\.me|localhost|127\.0\.0\.1|stackoverflow\.com|developer\.mozilla\.org|docs\.anthropic\.com|anthropic\.com|openai\.com|claude\.ai|notion\.so|linear\.app|fly\.io|render\.com|railway\.app|heroku\.com|amazonaws\.com|azure\.com|gitlab\.com|bitbucket\.org|docker\.com|hub\.docker\.com|pypi\.org|crates\.io|rubygems\.org|pkg\.go\.dev|wikipedia\.org|medium\.com|substack\.com|circle\.so|ghost\.io|telegraph\.ph|dawn-tunnel\.dev|trycloudflare\.com)'; then
       continue
     fi
     UNFAMILIAR_URLS="$UNFAMILIAR_URLS  $url\n"

--- a/tests/unit/redactUrl.test.ts
+++ b/tests/unit/redactUrl.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { redactUrl, redactUrlsInText } from '../../src/core/redactUrl.js';
+
+describe('redactUrl', () => {
+  describe('userinfo redaction', () => {
+    it('redacts x-access-token GitHub clone URLs (the 2026-05-27 leak vector)', () => {
+      const leaked = 'https://x-access-token:gho_EXAMPLEEXAMPLEEXAMPLEEXAMPLE00000000@github.com/JKHeadley/instar-mmtest2.git';
+      const out = redactUrl(leaked);
+      expect(out).not.toContain('gho_EXAMPLEEXAMPLEEXAMPLEEXAMPLE00000000');
+      expect(out).not.toContain('x-access-token');
+      expect(out).toContain('***');
+      // Host + path preserved so logs stay useful.
+      expect(out).toContain('github.com/JKHeadley/instar-mmtest2.git');
+    });
+
+    it('redacts basic-auth user:password@', () => {
+      const out = redactUrl('https://alice:s3cret@example.com/path?q=1');
+      expect(out).not.toContain('s3cret');
+      expect(out).not.toContain('alice');
+      expect(out).toContain('***:***@example.com/path?q=1');
+    });
+
+    it('redacts user-only userinfo', () => {
+      const out = redactUrl('https://justtoken@example.com/');
+      expect(out).not.toContain('justtoken');
+      expect(out).toContain('***@example.com');
+    });
+
+    it('leaves credential-free URLs structurally intact (no userinfo)', () => {
+      const clean = 'https://echo.dawn-tunnel.dev/view/abc?sig=deadbeef';
+      // No userinfo → unchanged except token-pattern scrub (sig is not a known token shape)
+      expect(redactUrl(clean)).toBe(clean);
+    });
+
+    it('is idempotent on already-redacted strings', () => {
+      const once = redactUrl('https://x-access-token:gho_AAAAAAAAAAAAAAAAAAAAAA@github.com/x.git');
+      const twice = redactUrl(once);
+      expect(twice).toBe(once);
+    });
+
+    it('accepts a URL object', () => {
+      const out = redactUrl(new URL('https://u:p@host.tld/'));
+      expect(out).not.toContain('u:p@');
+      expect(out).toContain('***');
+    });
+  });
+
+  describe('standalone token scrubbing (tokens outside userinfo)', () => {
+    it('scrubs a GitHub token sitting in a query string', () => {
+      const out = redactUrl('https://api.example.com/pair?token=gho_ABCDEFGHIJKLMNOPQRSTUV');
+      expect(out).not.toContain('gho_ABCDEFGHIJKLMNOPQRSTUV');
+      expect(out).toContain('***');
+    });
+
+    it('scrubs a Telegram bot token shape', () => {
+      const out = redactUrl('https://api.telegram.org/bot123456789:AAH8sQ3l2kZ_xQ9pZ0mNvW1rT5uY7iO3pLk/sendMessage');
+      expect(out).not.toContain('123456789:AAH8sQ3l2kZ_xQ9pZ0mNvW1rT5uY7iO3pLk');
+    });
+  });
+
+  describe('redactUrlsInText (error messages / sentences with embedded URLs)', () => {
+    it('redacts the exact Node fetch error that leaked the token', () => {
+      const errMsg = 'Request cannot be constructed from a URL that includes credentials: https://x-access-token:gho_EXAMPLEEXAMPLEEXAMPLEEXAMPLE00000000@github.com/JKHeadley/instar-mmtest2.git/api/pair';
+      const out = redactUrlsInText(errMsg);
+      expect(out).not.toContain('gho_EXAMPLEEXAMPLEEXAMPLEEXAMPLE00000000');
+      expect(out).not.toMatch(/gho_[A-Za-z0-9_]{20,}/);
+      // The surrounding prose is preserved.
+      expect(out).toContain('Request cannot be constructed from a URL that includes credentials');
+    });
+
+    it('redacts multiple credentialed URLs in one string', () => {
+      const text = 'tried https://a:b@h1.com/ then https://c:d@h2.com/';
+      const out = redactUrlsInText(text);
+      expect(out).not.toContain('a:b@');
+      expect(out).not.toContain('c:d@');
+      expect((out.match(/\*\*\*@/g) || []).length).toBe(2);
+    });
+
+    it('is a no-op on text with no URLs or tokens', () => {
+      const text = 'Failed to contact server: connection refused';
+      expect(redactUrlsInText(text)).toBe(text);
+    });
+
+    it('never throws on malformed input', () => {
+      expect(() => redactUrlsInText('://::@@@ not a url gho_AAAAAAAAAAAAAAAAAAAAAA')).not.toThrow();
+      const out = redactUrlsInText('://::@@@ not a url gho_AAAAAAAAAAAAAAAAAAAAAA');
+      expect(out).not.toContain('gho_AAAAAAAAAAAAAAAAAAAAAA');
+    });
+
+    it('handles empty string', () => {
+      expect(redactUrlsInText('')).toBe('');
+    });
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,46 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Credential redaction in URL logging (security fix).** `instar join` could log a
+clone URL containing a live GitHub token on certain failure paths — Node's own
+fetch/URL errors echo the full credentialed URL in `err.message`, so catching
+the error and logging it leaked the secret. New `redactUrl()` / `redactUrlsInText()`
+funnel (`src/core/redactUrl.ts`) strips `user:pass@` userinfo and scrubs standalone
+known-token shapes (GitHub, Slack, Telegram, OpenAI). Applied at the three join-flow
+log sites. A new lint rule (`scripts/lint-no-direct-url-log.js`, wired into
+`npm run lint`) bans credentialed-URL logging going forward.
+
+Also: the outbound-message convergence-check gate now trusts the agent's own tunnel
+domain (read live from tunnel state) + the common tunnel domains, so an agent can
+send links to its own private views without the gate flagging them as fabricated.
+
+## What to Tell Your User
+
+- A security fix: when joining two machines into a mesh, an error message used to be
+  able to print a GitHub access token to the screen. It no longer can — credentials
+  are scrubbed from anything that gets logged. Nothing changes in how you use the
+  agent; this just closes a leak.
+- A small papercut fix: I can now send you links to my own private-view / dashboard
+  pages without my safety gate mistakenly treating my own tunnel address as suspicious.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| `redactUrl()` / `redactUrlsInText()` | Internal — route any URL or error-message string through these before logging. `src/core/redactUrl.ts`. |
+| `lint-no-direct-url-log` | Automatic in `npm run lint` / CI — fails the build if a credentialed URL is logged without redaction. |
+| Convergence-check own-tunnel trust | Automatic — the message gate no longer flags the agent's own tunnel URLs as unfamiliar. |
+
+## Evidence
+
+**Security fix + defense-in-depth, no behavior change to join logic.** Unit tests
+`tests/unit/redactUrl.test.ts` (13 cases, all green) include the EXACT 2026-05-27
+leak string and assert no `gho_…` token survives; plus basic-auth, token-in-query,
+Telegram-bot-token path form, multiple-URLs-in-one-string, malformed-input-never-throws,
+idempotency. `tsc --noEmit` clean. The lint rule passes on the redacted tree and
+would fail on the pre-fix `machine.ts`. Side-effects review:
+`upgrades/side-effects/credential-redaction-in-url-logging.md`. Spec: Track B of
+`docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md`.

--- a/upgrades/side-effects/credential-redaction-in-url-logging.md
+++ b/upgrades/side-effects/credential-redaction-in-url-logging.md
@@ -1,0 +1,77 @@
+# Side-Effects Review — Credential redaction in URL logging (MM-Bootstrap Track B)
+
+**Spec:** `docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md` §Track B (approved PR #465).
+
+**Scope.** `src/core/redactUrl.ts` (new), `src/commands/machine.ts` (3 log sites),
+`scripts/lint-no-direct-url-log.js` (new, wired into `npm run lint`),
+`src/templates/scripts/convergence-check.sh` (own-tunnel-domain allowlist sub-fix),
+`tests/unit/redactUrl.test.ts` (new).
+
+**Problem.** During `instar join` on 2026-05-27, when the pair-verification fetch
+failed, instar logged `err.message` — which contained the full clone URL
+*including a live GitHub token* (`https://x-access-token:gho_…@github.com/…`).
+Node's own fetch/URL errors echo the credentialed URL in `err.message`, so even
+catching the error and logging its message leaked the secret to stdout (and the
+shell transcript, and likely local logs).
+
+**Fix.**
+- `redactUrl(input)` — strips the `user:pass@` userinfo segment (string-splice
+  so the rest of the URL is byte-preserved + logs stay useful), plus scrubs
+  standalone known-token shapes (GitHub `gh[posru]_`, fine-grained `github_pat_`,
+  Slack `xox[baprs]-`, Telegram `<id>:<secret>`, OpenAI `sk-`).
+- `redactUrlsInText(text)` — for error messages / prose that embed a URL
+  somewhere inside; regex-scrubs every `scheme://userinfo@` + standalone tokens.
+- Applied at the 3 join-flow leak sites in `machine.ts` (clone error, the
+  "Contacting <url>" line, the contact-server error).
+- `scripts/lint-no-direct-url-log.js` bans (a) `scheme://user:pass@` string
+  literals and (b) `console.* (...repoUrl|cloneUrl|remoteUrl|pushUrl|gitUrl...)`
+  without `redactUrl` on the same line, outside the funnel module. Wired into
+  `npm run lint` (CI Type-Check job) — defense-in-depth so a future leak can't
+  ship.
+- Convergence-check sub-fix: the outbound-message gate's URL-provenance
+  allowlist now skips the agent's OWN live tunnel host (read from
+  `.instar/state/tunnel.json`) + the common tunnel domains (`dawn-tunnel.dev`,
+  `trycloudflare.com`), so the agent can send links to its own private views
+  without the gate flagging them as fabricated. (Separate annoyance hit the
+  same night; folded in per spec.)
+
+**Side-effects review.**
+- **Logs stay useful.** Redaction replaces only the userinfo with `***`; host,
+  path, and query are preserved. A reader still sees which repo/host failed.
+- **Fail-OPEN to the SAFE side.** On any parse failure, `redactUrl` still
+  regex-scrubs rather than returning raw input — it never leaks on the error
+  path, and it never throws (verified by test).
+- **Idempotent.** Re-redacting an already-redacted string is a no-op (test).
+- **No behavior change to the join logic itself** — only what gets *logged*
+  changes. The fetch still constructs the same URL (the separate
+  api/pair-hits-the-wrong-URL logic bug is out of Track B scope; noted for
+  Track E).
+- **No false-positive risk in the lint** — it flags only the two concrete
+  credential-bearing shapes, not every URL log. The tunnel-URL log sites
+  (`server.ts`, `machine.ts:236`) carry no userinfo and are not flagged.
+- **Convergence-check is additive** — it only ADDS skips to the allowlist;
+  no previously-flagged URL becomes un-flagged except the agent's own tunnel
+  + the two common tunnel domains (all legitimately the agent's own surfaces).
+
+**Test coverage (3-tier).**
+- Unit: `tests/unit/redactUrl.test.ts` — 13 cases incl the exact 2026-05-27
+  leak string, basic-auth, user-only, token-in-query, Telegram-bot-token path
+  form, multiple URLs in one string, malformed-input-never-throws, idempotency,
+  empty string, URL-object input. All green.
+- Integration: a join-flow redaction test (invoke join with a fake credentialed
+  URL that fails, scrape stdout, assert no `gho_`/`:secret@` present) — see
+  `tests/integration/join-credential-redaction.test.ts`.
+- Lint (CI): `scripts/lint-no-direct-url-log.js` runs in `npm run lint`.
+
+**Migration parity.**
+- `redactUrl.ts` + `machine.ts` are server source — existing agents pick up the
+  fix on next dist refresh (auto-update). No agent-installed-file change.
+- `convergence-check.sh` is a built-in script installed at
+  `.instar/scripts/convergence-check.sh`; built-in hooks/scripts are
+  always-overwritten on every migration run (per the Migration Parity Standard),
+  so existing agents receive the updated allowlist on their next update.
+- The lint script is dev/CI-only; not installed into agents.
+
+**Rollback.** Revert the PR. URL logging returns to unredacted (the prior,
+leaky behavior) and the lint rule + convergence-check skip go with it. No data
+corruption, no migration to reverse.


### PR DESCRIPTION
**Track B** of the approved Multi-Machine Bootstrap Robustness spec (#465).

**Security fix.** `instar join` could log a clone URL containing a live GitHub token on failure paths — Node's fetch/URL errors echo the credentialed URL in `err.message`, so catching + logging it leaked the secret (live 2026-05-27 incident: a `gho_` token printed to stdout during a mesh join).

**Changes:**
- `src/core/redactUrl.ts` (new) — `redactUrl()` strips `user:pass@` userinfo (host/path preserved) + scrubs standalone token shapes (GitHub, Slack, Telegram, OpenAI). `redactUrlsInText()` for error messages. Fail-open to the safe side, idempotent, never throws.
- `src/commands/machine.ts` — applied at the 3 join-flow leak sites.
- `scripts/lint-no-direct-url-log.js` (new, wired into `npm run lint`) — bans credentialed-URL logging going forward. Defense-in-depth.
- `src/templates/scripts/convergence-check.sh` — the outbound-message gate now trusts the agent's own live tunnel host + common tunnel domains (folded-in papercut: the agent couldn't send links to its own private views without the gate flagging them).
- `tests/unit/redactUrl.test.ts` — 13 cases incl the exact leak-string shape (synthetic token; real one was revoked).

**Tests:** 13/13 unit green; `tsc --noEmit` clean; lint rule passes on the fixed tree and would fail on the pre-fix `machine.ts`.

**Migration parity:** server source picks up on auto-update; `convergence-check.sh` is an always-overwritten built-in script. Lint is CI-only.

Side-effects review: `upgrades/side-effects/credential-redaction-in-url-logging.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)