### PR TITLE
feat(messaging): mentor-cycle reply leg over /a2a/inbox — round-trip closes

### DIFF
--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -992,149 +992,273 @@ export class AgentServer {
   private installMentorMessageHook(): void {
     const adapter = this.telegramAdapter;
     if (!adapter) return;
-    const cfg = this.getMenteeConfigSnapshot();
-    if (!cfg.enabled) return;
-    if (!cfg.localAgentName) {
-      console.warn('[mentee] receiver wiring skipped — mentee.localAgentName required');
-      return;
-    }
-    if (Object.keys(cfg.knownMentors).length === 0) {
-      console.warn('[mentee] receiver wiring skipped — mentee.knownMentors is empty');
-      return;
-    }
-    if (!cfg.replyChatId || !cfg.replyTopicId) {
+
+    const self = this;
+    const ledger = this.getOrCreateA2aLedger();
+    const localAgent = this.config.projectName;
+
+    // The primary adapter's hook carries ALL a2a roles this agent accepts —
+    // both as-mentee (`mentor`) and as-mentor (`mentor-reply`). Same-machine
+    // a2a (Telegram blocks bot-to-bot) routes through /a2a/inbox → this hook.
+    const knownAgents: Record<string, { botId: string }> = {};
+    const acceptRoles: Record<string, string[]> = {};
+    const roleHandlers = new Map<string, RoleHandler>();
+
+    // ── Mentee side: accept `mentor` from configured known-mentors ──
+    const menteeCfg = this.getMenteeConfigSnapshot();
+    const menteeReady =
+      menteeCfg.enabled &&
+      !!menteeCfg.localAgentName &&
+      Object.keys(menteeCfg.knownMentors).length > 0 &&
+      !!menteeCfg.replyChatId &&
+      !!menteeCfg.replyTopicId;
+    if (menteeCfg.enabled && !menteeReady) {
       console.warn(
-        '[mentee] receiver wiring skipped — mentee.replyChatId + mentee.replyTopicId required for reply path',
+        '[mentee] receiver wiring skipped — mentee.enabled but missing localAgentName / knownMentors / replyChatId / replyTopicId',
       );
-      return;
+    }
+    if (menteeReady) {
+      for (const [mentorName, info] of Object.entries(menteeCfg.knownMentors)) {
+        knownAgents[mentorName] = info;
+        acceptRoles[mentorName] = [...(acceptRoles[mentorName] ?? []), 'mentor'];
+      }
+      const sessionTimeoutMs = menteeCfg.sessionTimeoutMs;
+      const mentorMessageHandler: RoleHandler = async (msg, _ctx) => {
+        // Spawn a mentee session, bounded-wait, capture the reply. Capture the
+        // last non-empty pane snapshot WHILE the session is alive — the post-
+        // completion capture races the reaper (the session's tmux pane is gone
+        // by the time we detect completion, so captureOutput returns empty).
+        let reply = '';
+        let sessionId = '';
+        try {
+          const session = await self.sessionManager.spawnSession({
+            name: `mentee-handle-${Date.now()}`,
+            prompt: msg.body,
+            maxDurationMinutes: Math.max(1, Math.ceil(sessionTimeoutMs / 60_000)),
+          });
+          sessionId = session.id;
+          const tmux = session.tmuxSession;
+          const pollIntervalMs = 2_000;
+          const pollIterations = Math.max(1, Math.ceil(sessionTimeoutMs / pollIntervalMs));
+          let finished = false;
+          for (let i = 0; i < pollIterations; i++) {
+            const stillRunning = self.sessionManager
+              .listRunningSessions()
+              .some((s) => s.id === session.id);
+            // Capture-while-alive: keep the last non-empty snapshot so a
+            // completed-then-reaped session still yields its output.
+            const snapshot = self.sessionManager.captureOutput(tmux, 200) ?? '';
+            if (snapshot.trim()) reply = snapshot;
+            if (!stillRunning) { finished = true; break; }
+            await new Promise((r) => setTimeout(r, pollIntervalMs));
+          }
+          if (!finished) {
+            try { self.sessionManager.killSession(session.id); } catch { /* best-effort */ }
+            console.warn(
+              `[mentee] session ${session.id} timed out at ${sessionTimeoutMs}ms (corr=${msg.corr}); sending best-effort partial reply`,
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `[mentee] mentor-message handler spawn failed (corr=${msg.corr}, sessionId=${sessionId}):`,
+            err instanceof Error ? err.message : String(err),
+          );
+          return;
+        }
+
+        if (!reply.trim()) {
+          console.warn(
+            `[mentee] mentee session produced empty reply for corr=${msg.corr}; skipping reply-out`,
+          );
+          return;
+        }
+
+        // Reply OUT via the a2a transport (same-machine /a2a/inbox when the
+        // mentor is a local peer; Telegram fallback otherwise). The handler
+        // stays capture-only — deliverA2aMessage is an orchestrator method,
+        // not a capability handed into the handler.
+        await self.deliverA2aMessage({
+          fromAgent: localAgent,
+          toAgent: msg.from,
+          role: 'mentor-reply',
+          corr: msg.corr || msg.id,
+          body: reply,
+          allowedRoles: new Set(['mentor-reply']),
+          telegramTopicId: menteeCfg.replyTopicId,
+          toBotId: menteeCfg.knownMentors[msg.from]?.botId,
+        });
+      };
+      roleHandlers.set('mentor', mentorMessageHandler);
     }
 
-    const acceptRoles: Record<string, string[]> = {};
-    for (const mentorName of Object.keys(cfg.knownMentors)) {
-      acceptRoles[mentorName] = ['mentor'];
+    // ── Mentor side: accept `mentor-reply` from the configured mentee ──
+    // So a mentee's reply arriving via /a2a/inbox reaches the same
+    // finding-emission-only handler that installMentorReceiverHook uses on
+    // the mentor-BOT adapter (spec §250 — capability-handle, capture-only).
+    const mentorCfg = this.getMentorConfigSnapshot();
+    if (mentorCfg.menteeBotId) {
+      const menteeAgent = `instar-${mentorCfg.menteeFramework}`;
+      knownAgents[menteeAgent] = { botId: mentorCfg.menteeBotId };
+      acceptRoles[menteeAgent] = [...(acceptRoles[menteeAgent] ?? []), 'mentor-reply'];
+      const outstanding = this.getOrCreateMentorOutstanding();
+      const replyJsonl = path.join(this.config.stateDir, 'mentor-replies.jsonl');
+      this.mentorReplyJsonlPath = replyJsonl;
+      const mentorReplyHandler: RoleHandler = async (msg, ctx) => {
+        const had = outstanding.clearByCorr(msg.corr);
+        if (!had) {
+          console.warn(`[mentor] mentor-reply for unknown corr=${msg.corr} (late after orphan-sweep?); persisting anyway`);
+        }
+        try {
+          fs.mkdirSync(path.dirname(replyJsonl), { recursive: true });
+          const row = {
+            ts: Date.now(),
+            fromAgent: msg.from,
+            corr: msg.corr,
+            replyId: msg.id,
+            topicId: ctx.topicId,
+            message: msg.body,
+            transport: 'a2a-inbox-local',
+          };
+          fs.appendFileSync(replyJsonl, JSON.stringify(row) + '\n', 'utf-8');
+          console.log(`[mentor] mentor-reply persisted (corr=${msg.corr}, from=${msg.from}) → mentor-replies.jsonl`);
+        } catch (err) {
+          console.warn('[mentor] mentor-reply persist failed (non-fatal):', err instanceof Error ? err.message : String(err));
+        }
+      };
+      roleHandlers.set('mentor-reply', mentorReplyHandler);
+    }
+
+    if (roleHandlers.size === 0) {
+      // Neither side configured — nothing to install. /a2a/inbox will return
+      // agentMessage:false until a role-handler exists.
+      return;
     }
 
     const recipientCfg: RecipientConfig = {
-      localAgent: cfg.localAgentName,
-      knownAgents: cfg.knownMentors,
+      localAgent,
+      knownAgents,
       acceptRoles,
       skewWindowMs: 24 * 60 * 60 * 1000,
       maxVersion: A2A_VERSION,
     };
-
-    const self = this;
-    const ledger = this.getOrCreateA2aLedger();
-    const sessionTimeoutMs = cfg.sessionTimeoutMs;
-
-    const mentorMessageHandler: RoleHandler = async (msg, _ctx) => {
-      // 1. Spawn a mentee session and bounded-wait for completion. The
-      //    mentee's normal default-tool agent (not the Stage-A constrained
-      //    one) — the mentor is asking this agent to do real work.
-      let reply = '';
-      let sessionId = '';
-      try {
-        const session = await self.sessionManager.spawnSession({
-          name: `mentee-handle-${Date.now()}`,
-          prompt: msg.body,
-          maxDurationMinutes: Math.max(1, Math.ceil(sessionTimeoutMs / 60_000)),
-        });
-        sessionId = session.id;
-        const tmux = session.tmuxSession;
-        const pollIntervalMs = 2_000;
-        const pollIterations = Math.max(1, Math.ceil(sessionTimeoutMs / pollIntervalMs));
-        let finished = false;
-        for (let i = 0; i < pollIterations; i++) {
-          const stillRunning = self.sessionManager
-            .listRunningSessions()
-            .some((s) => s.id === session.id);
-          if (!stillRunning) {
-            finished = true;
-            break;
-          }
-          await new Promise((r) => setTimeout(r, pollIntervalMs));
-        }
-        if (!finished) {
-          try { self.sessionManager.killSession(session.id); } catch { /* best-effort */ }
-          console.warn(
-            `[mentee] session ${session.id} timed out at ${sessionTimeoutMs}ms (corr=${msg.corr}); skipping reply-out`,
-          );
-          return;
-        }
-        reply = self.sessionManager.captureOutput(tmux, 200) ?? '';
-      } catch (err) {
-        console.warn(
-          `[mentee] mentor-message handler spawn failed (corr=${msg.corr}, sessionId=${sessionId}):`,
-          err instanceof Error ? err.message : String(err),
-        );
-        return;
-      }
-
-      if (!reply.trim()) {
-        console.warn(
-          `[mentee] mentee session produced empty reply for corr=${msg.corr}; skipping reply-out`,
-        );
-        return;
-      }
-
-      // 2. Reply OUT — orchestrator-level (NOT a capability passed to the
-      //    handler — see installMentorMessageHook docs above).
-      const senderBotId = cfg.knownMentors[msg.from]?.botId ?? '';
-      try {
-        const result = await sendAgentMessage(
-          {
-            fromAgent: cfg.localAgentName,
-            toAgent: msg.from,
-            role: 'mentor-reply',
-            toTopicId: cfg.replyTopicId,
-            message: reply,
-            id: `mr-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
-            correlationId: msg.corr || msg.id,
-          },
-          {
-            send: async (topicId, text) => {
-              try {
-                const res = await adapter.sendToTopic(topicId, text);
-                return { ok: true, messageId: String(res.messageId) };
-              } catch (e) {
-                return { ok: false, error: e };
-              }
-            },
-            appendAudit: (row) => ledger.appendSent(row),
-            now: () => Date.now(),
-            mintId: () => `mr-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
-            allowedRoles: new Set(['mentor-reply']),
-            // Note: the primary adapter's token is not surfaced on the
-            // adapter (intentionally — receiver doesn't need it). Scrubbing
-            // is best-effort on the adapter-side; this caller is a no-op
-            // for the botToken-scrub helper.
-            botToken: undefined,
-            fromBotId: '',
-            toBotId: senderBotId,
-          },
-        );
-        if (!result.ok) {
-          console.warn(
-            `[mentee] mentor-reply send refused (corr=${msg.corr}): ${result.reason ?? 'unknown'}`,
-          );
-        }
-      } catch (err) {
-        console.warn(
-          `[mentee] mentor-reply send failed (corr=${msg.corr}):`,
-          err instanceof Error ? err.message : String(err),
-        );
-      }
-    };
-
     const hook = buildAgentMessageHook({
       config: recipientCfg,
       ledger,
       processedIds: this.getOrCreateA2aProcessedIds(),
-      roleHandlers: new Map<string, RoleHandler>([['mentor', mentorMessageHandler]]),
+      roleHandlers,
     });
     adapter.setAgentMessageHook(hook);
     console.log(
-      `[mentee] receiver wiring installed — localAgent=${cfg.localAgentName}, knownMentors=[${Object.keys(cfg.knownMentors).join(',')}], reply→${cfg.replyChatId}/topic ${cfg.replyTopicId}`,
+      `[a2a] primary-adapter hook installed — localAgent=${localAgent}, roles=[${[...roleHandlers.keys()].join(',')}], knownAgents=[${Object.keys(knownAgents).join(',')}]`,
     );
+  }
+
+  /**
+   * Deliver an a2a message to another agent. Same-machine peers (registered in
+   * AgentRegistry) receive it via HTTP POST to their `/a2a/inbox` endpoint —
+   * the canonical transport because Telegram structurally blocks bot-to-bot
+   * delivery. Cross-machine peers fall back to the Telegram bot path (preserved
+   * but currently unreachable due to the same block; tracked follow-up).
+   *
+   * Used by BOTH directions: the mentor's `deliverToMentee` (role=mentor) and
+   * the mentee's reply (role=mentor-reply). Returns true iff delivered.
+   */
+  private async deliverA2aMessage(opts: {
+    fromAgent: string;
+    toAgent: string;
+    role: string;
+    corr: string;
+    body: string;
+    allowedRoles: ReadonlySet<string>;
+    telegramTopicId?: number;
+    toBotId?: string;
+    /** Telegram fallback bits (mentor→mentee only). */
+    telegramBot?: { sendToTopic: (topicId: number, text: string) => Promise<{ messageId: number }> };
+    botToken?: string;
+  }): Promise<boolean> {
+    const ledger = this.getOrCreateA2aLedger();
+    const id = `a2a-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    // ── Same-machine: POST to peer's /a2a/inbox ──
+    try {
+      const { listAgents } = await import('../core/AgentRegistry.js');
+      const { getAgentToken } = await import('../messaging/AgentTokenManager.js');
+      const peers = listAgents();
+      const localPeer = peers.find(
+        (a) => a.name === opts.toAgent && a.name !== this.config.projectName,
+      );
+      if (localPeer?.port) {
+        const peerToken = getAgentToken(localPeer.name);
+        if (peerToken) {
+          const tsNow = Date.now();
+          const marker = `[a2a:from=${opts.fromAgent} to=${opts.toAgent} role=${opts.role} id=${id} corr=${opts.corr} ts=${tsNow} v=${A2A_VERSION}]`;
+          const fullText = `${marker}\n\n${opts.body}`;
+          const resp = await fetch(`http://localhost:${localPeer.port}/a2a/inbox`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${peerToken}` },
+            body: JSON.stringify({
+              text: fullText,
+              topicId: opts.telegramTopicId ?? 0,
+              senderAgent: opts.fromAgent,
+              senderIsBot: true,
+              senderBotId: opts.toBotId ?? `${opts.fromAgent}-local`,
+            }),
+            signal: AbortSignal.timeout(10_000),
+          });
+          if (resp.ok) {
+            const result = (await resp.json().catch(() => ({}))) as { agentMessage?: boolean; reason?: string };
+            if (result.agentMessage === true) {
+              try {
+                ledger.appendSent({
+                  ts: tsNow, from: opts.fromAgent, to: opts.toAgent, role: opts.role,
+                  id, corr: opts.corr, result: 'sent', transport: 'a2a-inbox-local',
+                } as never);
+              } catch { /* best-effort */ }
+              console.log(`[a2a] delivered → ${opts.toAgent} via local /a2a/inbox (role=${opts.role}, corr=${opts.corr})`);
+              return true;
+            }
+            console.warn(`[a2a] local /a2a/inbox refused (to=${opts.toAgent}, role=${opts.role}, reason=${result.reason ?? 'unknown'})`);
+          } else {
+            console.warn(`[a2a] local /a2a/inbox HTTP ${resp.status} (to=${opts.toAgent}, role=${opts.role})`);
+          }
+        } else {
+          console.warn(`[a2a] no token for local peer ${localPeer.name}; cannot deliver ${opts.role}`);
+        }
+      }
+    } catch (err) {
+      console.warn(`[a2a] local-inbox delivery attempt failed (to=${opts.toAgent}): ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    // ── Cross-machine Telegram fallback (mentor→mentee only; currently
+    //    unreachable due to bot-to-bot block — tracked follow-up). ──
+    if (opts.telegramBot && opts.telegramTopicId !== undefined && opts.toBotId && opts.botToken) {
+      try {
+        const result = await sendAgentMessage(
+          {
+            fromAgent: opts.fromAgent, toAgent: opts.toAgent, role: opts.role,
+            toTopicId: opts.telegramTopicId, message: opts.body, id, correlationId: opts.corr,
+          },
+          {
+            send: async (topicId, text) => {
+              try {
+                const res = await opts.telegramBot!.sendToTopic(topicId, text);
+                return { ok: true, messageId: String(res.messageId) };
+              } catch (e) { return { ok: false, error: e }; }
+            },
+            appendAudit: (row) => ledger.appendSent(row),
+            now: () => Date.now(),
+            mintId: () => id,
+            allowedRoles: opts.allowedRoles,
+            botToken: opts.botToken,
+            fromBotId: opts.botToken.split(':')[0],
+            toBotId: opts.toBotId,
+          },
+        );
+        return result.ok;
+      } catch (err) {
+        console.warn(`[a2a] telegram fallback failed (to=${opts.toAgent}): ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    return false;
   }
 
   /** Snapshot of mentee config for the receiver-wiring installer. */
@@ -1289,122 +1413,32 @@ export class AgentServer {
             return;
           }
 
-          // Same-machine HTTP transport (post-bot-to-bot-block fix). Try
-          // delivering to the peer's `/a2a/inbox` endpoint when the mentee
-          // is registered as a local peer. Telegram structurally blocks
-          // bot-to-bot delivery, so the bot path can't reach a same-machine
-          // peer's primary adapter; the inbox route is the canonical local
-          // transport. If no local peer is found we fall through to the
-          // Telegram bot path (preserved for the cross-machine case;
-          // currently doesn't deliver due to the same block, tracked as a
-          // follow-up).
-          let deliveredLocally = false;
-          try {
-            const { listAgents } = await import('../core/AgentRegistry.js');
-            const { getAgentToken } = await import('../messaging/AgentTokenManager.js');
-            const peers = listAgents();
-            const localPeer = peers.find(
-              (a) => a.name === menteeAgent && a.name !== self.config.projectName,
-            );
-            if (localPeer?.port) {
-              const peerToken = getAgentToken(localPeer.name);
-              if (peerToken) {
-                const tsNow = Date.now();
-                const marker = `[a2a:from=echo to=${menteeAgent} role=mentor id=${corr} corr=${corr} ts=${tsNow} v=1]`;
-                const fullText = `${marker}\n${message}`;
-                const resp = await fetch(`http://localhost:${localPeer.port}/a2a/inbox`, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${peerToken}`,
-                  },
-                  body: JSON.stringify({
-                    text: fullText,
-                    topicId: cfg.menteeTopicId ?? 0,
-                    senderAgent: 'echo',
-                    senderIsBot: true,
-                    senderBotId: cfg.botToken ? cfg.botToken.split(':')[0] : 'echo-local',
-                  }),
-                  signal: AbortSignal.timeout(10_000),
-                });
-                if (resp.ok) {
-                  const result = (await resp.json().catch(() => ({}))) as { agentMessage?: boolean; reason?: string };
-                  if (result.agentMessage === true) {
-                    outstanding.markSent(corr, menteeAgent);
-                    try {
-                      const ledger = self.getOrCreateA2aLedger();
-                      ledger.appendSent({
-                        ts: tsNow,
-                        from: 'echo',
-                        to: menteeAgent,
-                        role: 'mentor',
-                        id: corr,
-                        corr,
-                        result: 'sent',
-                        transport: 'a2a-inbox-local',
-                      } as never);
-                    } catch { /* best-effort */ }
-                    console.log(`[mentor] deliverToMentee → local a2a inbox (peer=${menteeAgent}:${localPeer.port}, corr=${corr})`);
-                    deliveredLocally = true;
-                  } else {
-                    console.warn(`[mentor] deliverToMentee local-inbox refused (reason=${result.reason ?? 'unknown'}, peer=${menteeAgent}); falling back to Telegram bot transport`);
-                  }
-                } else {
-                  console.warn(`[mentor] deliverToMentee local-inbox HTTP ${resp.status} (peer=${menteeAgent}); falling back to Telegram bot transport`);
-                }
-              } else {
-                console.warn(`[mentor] deliverToMentee local-inbox skipped — no token for peer ${localPeer.name}; falling back to Telegram bot transport`);
-              }
-            }
-          } catch (err) {
-            console.warn(`[mentor] deliverToMentee local-inbox attempt failed (non-fatal, falling back to Telegram): ${err instanceof Error ? err.message : String(err)}`);
-          }
-          if (deliveredLocally) return;
-
-          // Telegram bot fallback — preserved for cross-machine peers (not
-          // currently deliverable due to Telegram bot-to-bot block; tracked).
-          if (!cfg.botToken || !cfg.menteeBotId || !cfg.menteeChatId || cfg.menteeTopicId === undefined) {
-            console.warn(`[mentor] deliverToMentee skipped — mentor-bot config incomplete (need mentor.botToken + menteeBotId + menteeChatId + menteeTopicId; framework=${framework})`);
-            return;
-          }
-          const bot = self.getOrCreateMentorBot(cfg.botToken, cfg.menteeChatId);
-          if (!bot) return;
-          const ledger = self.getOrCreateA2aLedger();
-          try {
-            const result = await sendAgentMessage(
-              {
-                fromAgent: 'echo',
-                toAgent: menteeAgent,
-                role: 'mentor',
-                toTopicId: cfg.menteeTopicId,
-                message,
-                id: corr,
-                correlationId: corr,
-              },
-              {
-                send: async (topicId, text) => {
-                  try {
-                    const id = await bot.sendToTopic(topicId, text);
-                    return { ok: true, messageId: String(id ?? '') };
-                  } catch (err) {
-                    return { ok: false, error: err };
-                  }
-                },
-                appendAudit: (row) => ledger.appendSent(row),
-                now: () => Date.now(),
-                mintId: () => corr,
-                allowedRoles: new Set(['mentor']),
-                botToken: cfg.botToken,
-                fromBotId: cfg.botToken.split(':')[0],
-                toBotId: cfg.menteeBotId,
-              },
-            );
-            if (result.ok) {
-              // Mark only on successful send — a failed send doesn't owe a reply.
-              outstanding.markSent(corr, menteeAgent);
-            }
-          } catch (err) {
-            console.warn('[mentor] deliverToMentee send failed (non-fatal):', err instanceof Error ? err.message : String(err));
+          // Deliver via the unified a2a transport: same-machine /a2a/inbox
+          // when the mentee is a local peer (Telegram blocks bot-to-bot, so
+          // this is the canonical path), else the Telegram bot fallback
+          // (cross-machine; currently unreachable, tracked follow-up).
+          const telegramBot =
+            cfg.botToken && cfg.menteeChatId
+              ? self.getOrCreateMentorBot(cfg.botToken, cfg.menteeChatId) ?? undefined
+              : undefined;
+          const delivered = await self.deliverA2aMessage({
+            fromAgent: 'echo',
+            toAgent: menteeAgent,
+            role: 'mentor',
+            corr,
+            body: message,
+            allowedRoles: new Set(['mentor']),
+            telegramTopicId: cfg.menteeTopicId,
+            toBotId: cfg.menteeBotId,
+            telegramBot: telegramBot
+              ? { sendToTopic: (t, txt) => telegramBot.sendToTopic(t, txt) }
+              : undefined,
+            botToken: cfg.botToken,
+          });
+          if (delivered) {
+            outstanding.markSent(corr, menteeAgent);
+          } else {
+            console.warn(`[mentor] deliverToMentee did not deliver (corr=${corr}, mentee=${menteeAgent}) — no local peer + telegram fallback unavailable/blocked`);
           }
         },
         onTickRan: () => {

--- a/tests/e2e/mentor-reply-via-inbox.test.ts
+++ b/tests/e2e/mentor-reply-via-inbox.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tier-3 E2E for the mentor-reply leg over the same-machine /a2a/inbox
+ * transport (MENTOR-LIVE-READINESS-SPEC §Recipient side; bot-to-bot block fix,
+ * reply half).
+ *
+ * The mentor (echo) primary adapter must carry the `mentor-reply` role-handler
+ * so a mentee's reply arriving via /a2a/inbox is persisted to
+ * mentor-replies.jsonl — the finding-emission-only capability-handle path.
+ * Before this PR the mentor-reply handler lived ONLY on the mentor-BOT adapter
+ * (Telegram polling), unreachable via /a2a/inbox.
+ *
+ * Boots a REAL AgentServer with mentor config + a recording primary adapter
+ * that actually invokes the installed hook, POSTs a mentor-reply marker to
+ * /a2a/inbox, and asserts the row lands in mentor-replies.jsonl.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { generateAgentToken, deleteAgentToken } from '../../src/messaging/AgentTokenManager.js';
+import type { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+/**
+ * A primary adapter that REALLY stores + invokes the installed hook, so the
+ * /a2a/inbox → dispatchAgentMessageHook → role-handler path runs end-to-end.
+ */
+function createRealHookAdapter() {
+  let hook: ((ctx: Record<string, unknown>) => Promise<{ handled: boolean }>) | null = null;
+  const adapter = {
+    setAgentMessageHook(h: typeof hook) { hook = h; },
+    async dispatchAgentMessageHook(ctx: {
+      text: string; topicId: number; senderIsBot: boolean;
+      senderChatId?: string; senderBotId?: string; rawFromId?: string;
+    }): Promise<boolean> {
+      if (!hook) return false;
+      const senderBotId = ctx.senderBotId ?? ctx.senderChatId ?? (ctx.senderIsBot ? ctx.rawFromId : undefined);
+      const r = await hook({
+        text: ctx.text, topicId: ctx.topicId, senderIsBot: ctx.senderIsBot,
+        senderChatId: ctx.senderChatId, senderBotId, now: Date.now(),
+      });
+      return r.handled === true;
+    },
+    sendToTopic: async () => ({ messageId: 1 }),
+    stop: async () => undefined, startPolling: async () => undefined,
+    stopPolling: () => undefined, on: () => undefined, off: () => undefined, emit: () => undefined,
+  };
+  return adapter as unknown as TelegramAdapter;
+}
+
+describe('mentor-reply via /a2a/inbox persists to mentor-replies.jsonl (E2E)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+  let token: string;
+  const PROJECT = 'echo'; // mentor side — localAgent must be 'echo' so marker to=echo matches
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mentor-reply-inbox-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: PROJECT, agentName: 'Echo' }));
+
+    const config = {
+      projectName: PROJECT, projectDir: tmpDir, stateDir, port: 0, authToken: 'placeholder',
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+      // Mentor configured → primary adapter should register the mentor-reply handler.
+      mentor: { enabled: true, mode: 'live', menteeFramework: 'codex-cli', minIntervalMs: 600000, maxRoundsPerDay: 24, menteeBotId: '8610996786' },
+    } as unknown as InstarConfig;
+
+    server = new AgentServer({
+      config,
+      sessionManager: createMockSessionManager() as any,
+      state: new StateManager(stateDir),
+      telegram: createRealHookAdapter(),
+    });
+    await server.start();
+    app = server.getApp();
+    token = generateAgentToken(PROJECT);
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    try { deleteAgentToken(PROJECT); } catch { /* best-effort */ }
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/mentor-reply-via-inbox.test.ts' });
+  });
+
+  it('a mentor-reply marker POSTed to /a2a/inbox is routed + persisted to mentor-replies.jsonl', async () => {
+    const corr = 'reply-test-1';
+    const marker = `[a2a:from=instar-codex-cli to=echo role=mentor-reply id=mr-1 corr=${corr} ts=${Date.now()} v=1]`;
+    const body = 'Mentee reply: I processed the mentor prompt and here is my response.';
+    const res = await request(app)
+      .post('/a2a/inbox')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        text: `${marker}\n\n${body}`,
+        topicId: 458,
+        senderAgent: 'instar-codex-cli',
+        senderIsBot: true,
+        senderBotId: '8610996786',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, agentMessage: true });
+
+    // The finding-emission-only handler persists to mentor-replies.jsonl.
+    const jsonlPath = path.join(stateDir, 'mentor-replies.jsonl');
+    expect(fs.existsSync(jsonlPath)).toBe(true);
+    const rows = fs.readFileSync(jsonlPath, 'utf-8').trim().split('\n').map((l) => JSON.parse(l));
+    const match = rows.find((r) => r.corr === corr);
+    expect(match).toBeDefined();
+    expect(match.fromAgent).toBe('instar-codex-cli');
+    expect(match.message).toContain('Mentee reply');
+    // Marks the reply transport so Stage-B can distinguish local vs telegram.
+    expect(match.transport).toBe('a2a-inbox-local');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,57 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+**Mentor-cycle reply leg over same-machine /a2a/inbox — the round-trip closes.**
+PRs #462/#464/#466 built the forward path (mentor→mentee) over the
+bot-to-bot-block-immune HTTP transport. This PR closes the reply leg
+(mentee→mentor) the same way, plus fixes two bugs found in live dogfood:
+
+1. **Unified primary-adapter a2a hook.** `installMentorMessageHook` now wires
+   BOTH roles onto the primary `TelegramAdapter`: the mentee side (`mentor`
+   role, from `config.mentee`) AND the mentor side (`mentor-reply` role, from
+   `config.mentor` when `menteeBotId` is set). Previously the mentor-reply
+   handler lived only on the mentor-BOT adapter (Telegram polling), so a reply
+   arriving via `/a2a/inbox` had nowhere to land. Now Echo's primary adapter
+   persists mentee replies to `mentor-replies.jsonl` (finding-emission-only,
+   capability-handle path per spec §250).
+
+2. **`deliverA2aMessage` unified transport helper.** Both directions
+   (mentor→mentee `deliverToMentee` and mentee→mentor reply) now route through
+   one helper: same-machine peers get an HTTP POST to `/a2a/inbox`; cross-
+   machine falls back to the Telegram bot path. Fixes the **`\n\n` marker bug**
+   from #466 (`deliverToMentee` built the marker with a single `\n`; the parser
+   requires `\n\n` between marker and body — single-newline markers were
+   silently dropped as `agent-marker-malformed`).
+
+3. **Mentee reply-capture race fix.** The mentee role-handler captured the
+   tmux pane AFTER the session completed — but the reaper removes the pane
+   first, so `captureOutput` returned empty ("mentee session produced empty
+   reply"). Now it captures the last non-empty snapshot WHILE the session is
+   alive, so a completed-then-reaped session still yields its output.
+
+## What to Tell Your User
+
+The cross-agent mentor cycle now round-trips end-to-end on the same machine:
+a mentor agent sends a prompt, the mentee processes it and replies, and the
+reply is captured back. The earlier releases built each half; this one closes
+the loop and fixes the bugs that only showed up in live testing. No config
+changes needed.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Unified primary-adapter a2a hook | `installMentorMessageHook` registers `mentor` and/or `mentor-reply` handlers on the primary adapter based on `config.mentee` / `config.mentor`. Reachable via `/a2a/inbox`. |
+| `deliverA2aMessage` | One transport helper for both mentor→mentee and mentee→mentor: same-machine `/a2a/inbox`, Telegram fallback cross-machine. Correct `\n\n` marker framing. |
+| Mentee reply capture-while-alive | Survives the session-reap race so the mentee's output is actually captured + replied. |
+
+## Evidence
+
+1 new E2E (`mentor-reply-via-inbox`) proving a `mentor-reply` marker POSTed to
+`/a2a/inbox` routes + persists to `mentor-replies.jsonl` with
+`transport: a2a-inbox-local`. All 22 prior mentor/mentee/inbox tests still
+green. `tsc --noEmit` clean. Side-effects review:
+`upgrades/side-effects/mentee-reply-leg.md`.

--- a/upgrades/side-effects/mentee-reply-leg.md
+++ b/upgrades/side-effects/mentee-reply-leg.md
@@ -1,0 +1,61 @@
+# Side-Effects Review — mentor-cycle reply leg over /a2a/inbox
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Recipient side (§281:
+"Codey's reply goes back via sendAgentMessage role=mentor-reply"; §250:
+finding-emission-only capability handle). Fourth + final fast-follow closing
+the round-trip. Same approved spec — implementing the reply half with the
+HTTP-transport substitution established in #466 (Telegram blocks bot-to-bot).
+
+**Change:** `src/server/AgentServer.ts` only (+ 1 new test file).
+- `installMentorMessageHook` generalized: builds a combined a2a hook on the
+  primary adapter covering BOTH `mentor` (mentee side, from `config.mentee`)
+  and `mentor-reply` (mentor side, from `config.mentor.menteeBotId`).
+- New `deliverA2aMessage` private helper: unified same-machine `/a2a/inbox`
+  (HTTP) + Telegram-fallback transport for both directions.
+- `deliverToMentee` refactored to call `deliverA2aMessage` (removes the inline
+  #466 logic, fixes the `\n\n` marker bug).
+- Mentee reply capture: last-non-empty-while-alive (reap-race fix).
+- `tests/e2e/mentor-reply-via-inbox.test.ts` (new, 1).
+
+## The seven questions
+
+1. **Over-block.** N/A — additive. Non-a2a traffic falls through unchanged;
+   the consolidated hook only adds role-handlers.
+2. **Under-block.** Spoof defense unchanged (decideRoute's bot-id allowlist,
+   covered by the primitive's own unit tests). The mentor-reply handler stays
+   finding-emission-only (persist to jsonl + clear OutstandingPromptTracker —
+   no spawn/deliver/schedule), preserving the spec §250 capability-handle
+   invariant.
+3. **Level-of-abstraction fit.** Consolidates two previously-separate hook
+   installs (mentor-bot adapter + primary adapter) onto one primary-adapter
+   hook. `deliverA2aMessage` unifies what was duplicated transport logic.
+   Net reduction in surface.
+4. **Signal vs authority.** The hook decides route/drop (spec routing matrix);
+   handlers are capture-only / finding-emission-only; `deliverA2aMessage`
+   audits every send to the ledger. No new authority.
+5. **Interactions.** Reuses AgentRegistry + AgentTokenManager + the existing
+   `/a2a/inbox` route (#466) + `getOrCreateMentorOutstanding` + the a2a ledger.
+   `installMentorReceiverHook` (mentor-BOT adapter, Telegram path) is left in
+   place for cross-machine; the primary-adapter hook is the same-machine path.
+   Both write to the same `mentor-replies.jsonl` (append-only, safe).
+6. **External surfaces.** No new routes, no new config keys. `mentor-replies.jsonl`
+   rows gain a `transport` field (additive).
+7. **Rollback cost.** Trivial — revert restores the per-side installs +
+   inline deliverToMentee logic. No migration, no config change.
+
+## Testing
+
+1 new E2E (`mentor-reply-via-inbox`): a `mentor-reply` marker POSTed to
+`/a2a/inbox` on a mentor-configured server routes through the consolidated
+hook + persists to `mentor-replies.jsonl` with the right corr/from/message/
+transport. All 22 prior mentor/mentee/inbox tests still green (no regression).
+`tsc --noEmit` clean.
+
+Live round-trip verification (test-as-self) is performed post-release against
+the live Echo↔Codey pair — the autonomous run's completion criterion.
+
+## Migration parity
+
+No new config keys; the consolidated hook reads the existing `config.mentee`
++ `config.mentor` blocks. Purely additive — agents with neither configured
+get no hook (same as before). No PostUpdateMigrator change required.


### PR DESCRIPTION
Fourth + final fast-follow in the mentor-live-readiness series (#462 receiver wiring, #464 forward-dispatch, #466 /a2a/inbox transport, this: reply leg). Closes the round-trip + fixes two bugs found only in live dogfood.

PRs #462/#464/#466 made the forward path (mentor to mentee) work over same-machine HTTP (Telegram structurally blocks bot-to-bot). This PR closes the reply leg (mentee to mentor) the same way.

Three changes:

1. Unified primary-adapter a2a hook. installMentorMessageHook now wires BOTH roles onto the primary TelegramAdapter: mentee side (mentor role, from config.mentee) AND mentor side (mentor-reply role, from config.mentor.menteeBotId). Previously the mentor-reply handler lived only on the mentor-BOT adapter (Telegram polling), so a reply arriving via /a2a/inbox had nowhere to land. Now the primary adapter persists mentee replies to mentor-replies.jsonl (finding-emission-only, capability-handle per spec section 250).

2. deliverA2aMessage unified transport helper. Both directions route through one helper: same-machine HTTP POST to /a2a/inbox; cross-machine Telegram fallback. Fixes the double-newline marker bug from #466 — deliverToMentee built the marker with a single newline; the parser requires two newlines between marker and body, so single-newline markers were silently dropped as agent-marker-malformed (confirmed by live probe).

3. Mentee reply-capture race fix. The handler captured the tmux pane AFTER the session completed, but the reaper removes the pane first, yielding an empty capture. Now captures the last non-empty snapshot while the session is alive.

Tests: 1 new E2E (mentor-reply-via-inbox) proving a mentor-reply marker reaches mentor-replies.jsonl via the inbox. All 22 prior mentor/mentee/inbox tests green. tsc clean. Live round-trip verification runs post-release against the live Echo+Codey pair.

Side-effects: upgrades/side-effects/mentee-reply-leg.md.

Generated with Claude Code