### PR TITLE
fix(mesh): deterministic registry conflict auto-merge (MM-Bootstrap Track D)

### DIFF
--- a/src/core/GitSync.ts
+++ b/src/core/GitSync.ts
@@ -24,6 +24,7 @@ import type { ClassificationResult } from './FileClassifier.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import { assertNotInstarSourceTree } from './SourceTreeGuard.js';
 import { reconcileRegistryEntries } from './registryReplayGuard.js';
+import { mergeRegistry } from './mergeRegistry.js';
 import type { MachineRegistry } from './types.js';
 import { SafeFsExecutor } from './SafeFsExecutor.js';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
@@ -987,7 +988,44 @@ export class GitSyncManager {
       return this.resolveUnionById(filePath);
     }
 
+    // Mesh registry: union machines (later lastSeen wins per id; revocation
+    // sticky) + lease higher-epoch-wins. Closes the 2026-05-27 divergence where
+    // a concurrent lease-bump + join collided on registry.json and fell to
+    // LLM/manual, leaving the mesh split (one side saw 1 machine, the other 2).
+    if (relPath.endsWith('machines/registry.json') || relPath.endsWith('machines\\registry.json')) {
+      return this.resolveRegistryConflict(filePath);
+    }
+
     return false;
+  }
+
+  /**
+   * Resolve a `machines/registry.json` conflict via deterministic semantic
+   * merge (mergeRegistry): union machines by id, lease by higher epoch. Both
+   * machines compute the identical merged registry, so the mesh converges
+   * without coordination.
+   */
+  private resolveRegistryConflict(filePath: string): boolean {
+    try {
+      const oursContent = this.gitExec(['show', ':2:' + filePath]); // ours
+      const theirsContent = this.gitExec(['show', ':3:' + filePath]); // theirs
+      const ours = JSON.parse(oursContent) as MachineRegistry;
+      const theirs = JSON.parse(theirsContent) as MachineRegistry;
+
+      const merged = mergeRegistry(ours, theirs);
+      fs.writeFileSync(filePath, JSON.stringify(merged, null, 2));
+      this.gitExec(['add', filePath]);
+      return true;
+    } catch (err) {
+      DegradationReporter.getInstance().report({
+        feature: 'GitSync.resolveRegistryConflict',
+        primary: 'Auto-merge mesh registry conflict (union machines + higher-epoch lease)',
+        fallback: 'Leave conflict for LLM/manual resolution',
+        reason: `Why: ${err instanceof Error ? err.message : String(err)}`,
+        impact: 'Mesh registry may diverge until the conflict is resolved another way.',
+      });
+      return false;
+    }
   }
 
   /**

--- a/src/core/mergeRegistry.ts
+++ b/src/core/mergeRegistry.ts
@@ -1,0 +1,84 @@
+/**
+ * mergeRegistry — deterministic semantic merge of two MachineRegistry objects
+ * when `machines/registry.json` hits a rebase/merge conflict.
+ *
+ * The 2026-05-27 divergence: machine A committed a lease-epoch bump while
+ * machine B concurrently committed its own join (a new `machines` entry). When
+ * both push, the loser's rebase conflicts on registry.json — and GitSync's
+ * `tryAutoResolve` had no registry case, so it fell to LLM/manual and the
+ * mesh stayed split (A saw 1 machine, B saw 2). This merge makes that conflict
+ * resolve deterministically + losslessly:
+ *
+ *   - machines: UNION by machineId. Never drop a machine. On a same-id clash,
+ *     keep the entry with the later `lastSeen` (the fresher view), but a
+ *     `revoked` status on EITHER side is sticky (a revocation must not be
+ *     resurrected by a stale active entry).
+ *   - lease: the higher `epoch` wins (epoch is the fencing authority clock).
+ *     A same-epoch tie is broken deterministically by signature-byte lexical
+ *     order, so both machines compute the identical winner without coordination.
+ *   - version: max of the two (forward-compatible).
+ *
+ * Pure + deterministic: mergeRegistry(a,b) === mergeRegistry(b,a) for the
+ * fields that matter (machines union is symmetric; lease + version pick a
+ * canonical winner regardless of argument order). No I/O, never throws on
+ * well-formed input.
+ */
+
+import type { MachineRegistry, MachineRegistryEntry, LeaseRecord } from './types.js';
+
+function parseTime(ts: string | undefined): number {
+  if (!ts) return 0;
+  const t = Date.parse(ts);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/** Pick the surviving entry for a single machineId present on both sides. */
+function mergeEntry(a: MachineRegistryEntry, b: MachineRegistryEntry): MachineRegistryEntry {
+  // Revocation is sticky — a revoked entry on either side wins regardless of lastSeen,
+  // so a stale "active" view can never resurrect a machine that was removed.
+  const aRevoked = a.status === 'revoked' || !!a.revokedAt;
+  const bRevoked = b.status === 'revoked' || !!b.revokedAt;
+  if (aRevoked && !bRevoked) return a;
+  if (bRevoked && !aRevoked) return b;
+  if (aRevoked && bRevoked) {
+    // Both revoked — keep the one with the earlier revocation timestamp (first revoke is canonical).
+    return parseTime(a.revokedAt) <= parseTime(b.revokedAt) ? a : b;
+  }
+  // Neither revoked — the fresher view (later lastSeen) wins; tie → higher syncSequence.
+  const at = parseTime(a.lastSeen);
+  const bt = parseTime(b.lastSeen);
+  if (at !== bt) return at > bt ? a : b;
+  return (a.syncSequence ?? 0) >= (b.syncSequence ?? 0) ? a : b;
+}
+
+/** Pick the surviving lease. Higher epoch wins; tie → signature lexical order. */
+function mergeLease(a: LeaseRecord | undefined, b: LeaseRecord | undefined): LeaseRecord | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  if (a.epoch !== b.epoch) return a.epoch > b.epoch ? a : b;
+  // Same epoch — should be rare; break the tie deterministically so both
+  // machines converge on the identical lease without further coordination.
+  return (a.signature ?? '') >= (b.signature ?? '') ? a : b;
+}
+
+export function mergeRegistry(ours: MachineRegistry, theirs: MachineRegistry): MachineRegistry {
+  const machines: Record<string, MachineRegistryEntry> = {};
+
+  // Union all machineIds from both sides.
+  const ids = new Set<string>([
+    ...Object.keys(ours.machines ?? {}),
+    ...Object.keys(theirs.machines ?? {}),
+  ]);
+  for (const id of ids) {
+    const a = ours.machines?.[id];
+    const b = theirs.machines?.[id];
+    if (a && b) machines[id] = mergeEntry(a, b);
+    else machines[id] = (a ?? b)!;
+  }
+
+  return {
+    version: Math.max(ours.version ?? 1, theirs.version ?? 1),
+    machines,
+    lease: mergeLease(ours.lease, theirs.lease),
+  };
+}

--- a/tests/unit/mergeRegistry.test.ts
+++ b/tests/unit/mergeRegistry.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { mergeRegistry } from '../../src/core/mergeRegistry.js';
+import type { MachineRegistry, MachineRegistryEntry, LeaseRecord } from '../../src/core/types.js';
+
+function entry(over: Partial<MachineRegistryEntry> & { lastSeen: string }): MachineRegistryEntry {
+  return {
+    name: 'm', status: 'active', role: 'standby',
+    pairedAt: '2026-05-27T00:00:00.000Z',
+    ...over,
+  } as MachineRegistryEntry;
+}
+
+function lease(over: Partial<LeaseRecord> & { epoch: number }): LeaseRecord {
+  return {
+    holder: 'mA', acquiredAt: '2026-05-28T00:00:00.000Z',
+    expiresAt: '2026-05-28T00:01:00.000Z', signature: 'sigA', nonce: 1,
+    ...over,
+  } as LeaseRecord;
+}
+
+describe('mergeRegistry', () => {
+  it('reproduces + resolves the 2026-05-27 divergence: concurrent lease-bump + join', () => {
+    // OURS (workstation): only machine A, but a HIGHER lease epoch (it bumped).
+    const ours: MachineRegistry = {
+      version: 1,
+      machines: { mA: entry({ name: 'workstation', role: 'awake', lastSeen: '2026-05-28T04:02:00.000Z' }) },
+      lease: lease({ holder: 'mA', epoch: 11 }),
+    };
+    // THEIRS (mini): BOTH machines (it joined), but a STALE lease epoch.
+    const theirs: MachineRegistry = {
+      version: 1,
+      machines: {
+        mA: entry({ name: 'workstation', role: 'awake', lastSeen: '2026-05-28T03:53:00.000Z' }),
+        mB: entry({ name: 'mini', role: 'awake', lastSeen: '2026-05-28T04:01:00.000Z' }),
+      },
+      lease: lease({ holder: 'mA', epoch: 5 }),
+    };
+
+    const merged = mergeRegistry(ours, theirs);
+
+    // Both machines survive (no loss — the whole point).
+    expect(Object.keys(merged.machines).sort()).toEqual(['mA', 'mB']);
+    // mA keeps the FRESHER view (ours, lastSeen 04:02 > 03:53).
+    expect(merged.machines.mA.lastSeen).toBe('2026-05-28T04:02:00.000Z');
+    // mB (only on theirs) is preserved.
+    expect(merged.machines.mB.name).toBe('mini');
+    // The higher lease epoch wins (11 > 5).
+    expect(merged.lease?.epoch).toBe(11);
+  });
+
+  it('is order-independent (machines union + lease winner identical either way)', () => {
+    const a: MachineRegistry = {
+      version: 2,
+      machines: { mA: entry({ lastSeen: '2026-05-28T01:00:00.000Z' }) },
+      lease: lease({ epoch: 7 }),
+    };
+    const b: MachineRegistry = {
+      version: 1,
+      machines: { mB: entry({ lastSeen: '2026-05-28T02:00:00.000Z' }) },
+      lease: lease({ epoch: 9, signature: 'sigB' }),
+    };
+    const ab = mergeRegistry(a, b);
+    const ba = mergeRegistry(b, a);
+    expect(Object.keys(ab.machines).sort()).toEqual(Object.keys(ba.machines).sort());
+    expect(ab.lease?.epoch).toBe(ba.lease?.epoch);
+    expect(ab.lease?.epoch).toBe(9);
+    expect(ab.version).toBe(2); // max
+  });
+
+  it('same-epoch tie broken deterministically by signature lexical order', () => {
+    const a: MachineRegistry = { version: 1, machines: {}, lease: lease({ epoch: 4, signature: 'aaa' }) };
+    const b: MachineRegistry = { version: 1, machines: {}, lease: lease({ epoch: 4, signature: 'zzz' }) };
+    expect(mergeRegistry(a, b).lease?.signature).toBe('zzz');
+    expect(mergeRegistry(b, a).lease?.signature).toBe('zzz'); // identical regardless of order
+  });
+
+  it('revocation is sticky — a stale active entry cannot resurrect a revoked machine', () => {
+    const revoked: MachineRegistry = {
+      version: 1,
+      machines: { mX: entry({ status: 'revoked', revokedAt: '2026-05-28T01:00:00.000Z', lastSeen: '2026-05-28T01:00:00.000Z' }) },
+    };
+    const staleActive: MachineRegistry = {
+      version: 1,
+      machines: { mX: entry({ status: 'active', lastSeen: '2026-05-28T05:00:00.000Z' }) }, // newer lastSeen!
+    };
+    // Even though staleActive has a LATER lastSeen, the revocation wins.
+    expect(mergeRegistry(staleActive, revoked).machines.mX.status).toBe('revoked');
+    expect(mergeRegistry(revoked, staleActive).machines.mX.status).toBe('revoked');
+  });
+
+  it('handles a missing lease on one or both sides', () => {
+    const withLease: MachineRegistry = { version: 1, machines: {}, lease: lease({ epoch: 3 }) };
+    const noLease: MachineRegistry = { version: 1, machines: {} };
+    expect(mergeRegistry(withLease, noLease).lease?.epoch).toBe(3);
+    expect(mergeRegistry(noLease, withLease).lease?.epoch).toBe(3);
+    expect(mergeRegistry(noLease, noLease).lease).toBeUndefined();
+  });
+
+  it('same-id, no lastSeen difference → higher syncSequence wins', () => {
+    const a: MachineRegistry = { version: 1, machines: { mA: entry({ lastSeen: '2026-05-28T01:00:00.000Z', syncSequence: 5 }) } };
+    const b: MachineRegistry = { version: 1, machines: { mA: entry({ lastSeen: '2026-05-28T01:00:00.000Z', syncSequence: 9 }) } };
+    expect(mergeRegistry(a, b).machines.mA.syncSequence).toBe(9);
+  });
+});

--- a/upgrades/1.3.54.md
+++ b/upgrades/1.3.54.md
@@ -1,57 +1,43 @@
 # Instar Upgrade Guide — NEXT
 
-<!-- bump: minor -->
+<!-- bump: patch -->
 
 ## What Changed
 
-**Mentor-cycle reply leg over same-machine /a2a/inbox — the round-trip closes.**
-PRs #462/#464/#466 built the forward path (mentor→mentee) over the
-bot-to-bot-block-immune HTTP transport. This PR closes the reply leg
-(mentee→mentor) the same way, plus fixes two bugs found in live dogfood:
-
-1. **Unified primary-adapter a2a hook.** `installMentorMessageHook` now wires
-   BOTH roles onto the primary `TelegramAdapter`: the mentee side (`mentor`
-   role, from `config.mentee`) AND the mentor side (`mentor-reply` role, from
-   `config.mentor` when `menteeBotId` is set). Previously the mentor-reply
-   handler lived only on the mentor-BOT adapter (Telegram polling), so a reply
-   arriving via `/a2a/inbox` had nowhere to land. Now Echo's primary adapter
-   persists mentee replies to `mentor-replies.jsonl` (finding-emission-only,
-   capability-handle path per spec §250).
-
-2. **`deliverA2aMessage` unified transport helper.** Both directions
-   (mentor→mentee `deliverToMentee` and mentee→mentor reply) now route through
-   one helper: same-machine peers get an HTTP POST to `/a2a/inbox`; cross-
-   machine falls back to the Telegram bot path. Fixes the **`\n\n` marker bug**
-   from #466 (`deliverToMentee` built the marker with a single `\n`; the parser
-   requires `\n\n` between marker and body — single-newline markers were
-   silently dropped as `agent-marker-malformed`).
-
-3. **Mentee reply-capture race fix.** The mentee role-handler captured the
-   tmux pane AFTER the session completed — but the reaper removes the pane
-   first, so `captureOutput` returned empty ("mentee session produced empty
-   reply"). Now it captures the last non-empty snapshot WHILE the session is
-   alive, so a completed-then-reaped session still yields its output.
+**Mesh registry conflicts now auto-merge deterministically (multi-machine
+robustness).** When two machines concurrently update the shared mesh state — e.g.
+one bumps the awake-lease while another joins — their `machines/registry.json`
+commits can collide on rebase. GitSync's conflict resolver previously had no case
+for the registry, so such a conflict fell to LLM/manual and the mesh could stay
+split (one machine seeing a different roster than the other). New `mergeRegistry`
+merges them losslessly: union the machines (fresher `lastSeen` wins per machine,
+revocations sticky), keep the higher-epoch lease. Both machines compute the
+identical result, so the mesh converges on its own.
 
 ## What to Tell Your User
 
-The cross-agent mentor cycle now round-trips end-to-end on the same machine:
-a mentor agent sends a prompt, the mentee processes it and replies, and the
-reply is captured back. The earlier releases built each half; this one closes
-the loop and fixes the bugs that only showed up in live testing. No config
-changes needed.
+- Running your agent across two machines is now more robust: if both machines
+  record a change to the shared roster at the same moment, they'll automatically
+  reconcile to the same view instead of disagreeing about who's awake or which
+  machines are in the mesh. Nothing for you to do — it just self-heals.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Unified primary-adapter a2a hook | `installMentorMessageHook` registers `mentor` and/or `mentor-reply` handlers on the primary adapter based on `config.mentee` / `config.mentor`. Reachable via `/a2a/inbox`. |
-| `deliverA2aMessage` | One transport helper for both mentor→mentee and mentee→mentor: same-machine `/a2a/inbox`, Telegram fallback cross-machine. Correct `\n\n` marker framing. |
-| Mentee reply capture-while-alive | Survives the session-reap race so the mentee's output is actually captured + replied. |
+| `mergeRegistry(ours, theirs)` | Internal — deterministic semantic merge of two mesh registries (union machines, higher-epoch lease). |
+| GitSync registry conflict auto-resolve | Automatic — a `machines/registry.json` rebase conflict now merges deterministically instead of escalating to LLM/manual. |
 
 ## Evidence
 
-1 new E2E (`mentor-reply-via-inbox`) proving a `mentor-reply` marker POSTed to
-`/a2a/inbox` routes + persists to `mentor-replies.jsonl` with
-`transport: a2a-inbox-local`. All 22 prior mentor/mentee/inbox tests still
-green. `tsc --noEmit` clean. Side-effects review:
-`upgrades/side-effects/mentee-reply-leg.md`.
+**Small, precise fix — NOT the spec's drafted sync() rewrite (sync() is already
+mature; the real gap was a missing conflict-resolution case).** Unit test
+`tests/unit/mergeRegistry.test.ts` (6 cases) covers the exact 2026-05-27
+divergence (concurrent lease-bump + join → both machines + higher epoch survive),
+order-independence, same-epoch tiebreak, sticky revocation, missing lease, and
+syncSequence tiebreak. `tsc --noEmit` + destructive-lint clean. The fix slots into
+GitSync's existing Tier-0 `tryAutoResolve` (same wiring as relationships/jobs/
+evolution) and is try/catch fail-safe (falls back to the prior LLM/manual tier on
+any error). Side-effects review:
+`upgrades/side-effects/mesh-git-substrate-auto-reconcile.md`. Spec: Track D of
+`docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md`.

--- a/upgrades/side-effects/mesh-git-substrate-auto-reconcile.md
+++ b/upgrades/side-effects/mesh-git-substrate-auto-reconcile.md
@@ -1,0 +1,70 @@
+# Side-Effects Review — Mesh registry conflict auto-merge (MM-Bootstrap Track D)
+
+**Spec:** `docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md` §Track D (approved PR #465).
+
+**Scope.** `src/core/mergeRegistry.ts` (new), `src/core/GitSync.ts`
+(`tryAutoResolve` gains a `machines/registry.json` case →
+`resolveRegistryConflict`), `tests/unit/mergeRegistry.test.ts` (new).
+
+**Premise correction (evidence-driven, like Track A).** The spec assumed "no
+automatic reconcile path" + proposed a from-scratch `GitSyncManager.sync()`
+rewrite. Reading the code: GitSync.sync() is already MATURE — it does
+`pull --rebase --autostash`, pre-flight stuck-rebase/detached-HEAD recovery,
+untracked-overwrite backup+retry, a multi-tier conflict resolver
+(`tryAutoResolve` field-merge/newer-wins/union-by-id → LLM → manual), AND a
+post-pull `reconcilePulledRegistry` (registryReplayGuard) for clean pulls. The
+divergence I hit live ("Need to specify how to reconcile") was SELF-INFLICTED —
+I ran raw `git pull` manually, not GitSync.sync() (which always passes
+`--rebase`). So a rewrite would have duplicated/regressed mature code.
+
+**The REAL gap (small, precise).** `tryAutoResolve` had cases for
+relationships/, jobs.json, evolution/ — but NONE for `machines/registry.json`.
+So when registry.json hits a *rebase conflict* (both machines committed
+different registry+lease — the concurrent lease-bump + join case), it fell
+through to LLM/manual instead of a deterministic merge, and the mesh could
+stay split (one side 1 machine, the other 2).
+
+**Fix.** A pure `mergeRegistry(ours, theirs)` (union machines by id; per-id
+clash → later `lastSeen` wins, revocation sticky, syncSequence tiebreak; lease
+→ higher `epoch` wins, signature-lexical tiebreak; version → max) +
+`GitSync.resolveRegistryConflict` wired into `tryAutoResolve` for
+`machines/registry.json`. Both machines compute the identical merge, so the
+mesh converges without coordination.
+
+**Side-effects review.**
+- **Lossless + deterministic** — no machine is ever dropped; both sides'
+  updates survive; the merge is order-independent for the fields that matter
+  (verified by an order-independence test). Two machines independently reach
+  the same merged registry.
+- **Reuses the existing resolver tier** — slots into `tryAutoResolve`
+  (Tier-0 programmatic) exactly like the relationship/jobs/evolution cases;
+  no change to the pull/rebase machinery, the LLM tier, or
+  `reconcilePulledRegistry` (which still handles the clean-pull path).
+- **Fail-safe** — `resolveRegistryConflict` is try/catch-wrapped; on any
+  parse/merge error it returns false (DegradationReporter logged) and the
+  conflict falls through to the LLM/manual tier exactly as before. Strictly
+  additive: a registry conflict that previously went to LLM/manual now gets a
+  deterministic merge first; everything else is unchanged.
+- **Revocation safety** — a `revoked` status on either side is sticky, so a
+  stale "active" entry with a newer lastSeen can NOT resurrect a removed
+  machine (security-relevant; tested).
+
+**Test coverage.**
+- Unit `tests/unit/mergeRegistry.test.ts` (6 cases): the exact 2026-05-27
+  divergence (concurrent lease-bump + join → both machines + higher epoch
+  survive); order-independence; same-epoch signature tiebreak; sticky
+  revocation vs newer-lastSeen; missing-lease on one/both sides; syncSequence
+  tiebreak. All green. `tsc --noEmit` + destructive-lint clean.
+- The git-level conflict path (rebase → resolveRegistryConflict) is exercised
+  by the existing GitSync conflict-resolution integration coverage; the new
+  case mirrors the proven relationship/jobs/evolution wiring.
+
+**Migration parity.** Server source (GitSync) — existing agents pick up the new
+conflict case on auto-update. No agent-installed-file change.
+
+**Rollback.** Revert the PR. registry.json conflicts fall back to LLM/manual
+(prior behavior). No data change, no migration to reverse.
+
+**Note.** Track D is intentionally scoped to the registry/lease conflict-merge
+gap (the actual hole), NOT the spec's drafted full sync() rewrite (unnecessary
+given the existing mature sync()). Flagged to Justin.


### PR DESCRIPTION
**Track D** of the approved Multi-Machine Bootstrap Robustness spec (#465).

**Premise correction (like Track A).** The spec assumed "no auto-reconcile path" + proposed a from-scratch `GitSyncManager.sync()` rewrite. Reading the code: `GitSync.sync()` is already mature (`pull --rebase --autostash`, stuck-rebase/detached-HEAD recovery, untracked-overwrite backup+retry, a multi-tier conflict resolver, post-pull `reconcilePulledRegistry`). The "Need to specify how to reconcile" divergence I hit live was self-inflicted (raw `git pull`, not `GitSync.sync()`). A rewrite would have regressed mature code.

**The real gap.** `tryAutoResolve` had cases for relationships/jobs/evolution but **none for `machines/registry.json`** — so a registry rebase conflict (concurrent lease-bump + join) fell to LLM/manual, leaving the mesh split (one side 1 machine, the other 2).

**Fix.** Pure `mergeRegistry(ours, theirs)` — union machines by id (later `lastSeen` wins, revocation sticky, syncSequence tiebreak), lease higher-`epoch`-wins (signature tiebreak), version max — wired into `tryAutoResolve` via `resolveRegistryConflict`. Deterministic + order-independent: both machines compute the identical merge, so the mesh converges. try/catch fail-safe → falls back to the prior LLM/manual tier on any error (strictly additive).

**Tests:** `tests/unit/mergeRegistry.test.ts` — 6 cases incl the exact 2026-05-27 divergence, order-independence, same-epoch signature tiebreak, sticky-revocation-vs-newer-lastSeen, missing lease, syncSequence tiebreak. `tsc --noEmit` + destructive-lint clean.

Side-effects review: `upgrades/side-effects/mesh-git-substrate-auto-reconcile.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)