### PR TITLE
feat(harness): instar test-as-self one-button throwaway-deploy (MM-Bootstrap Track F)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2030,6 +2030,28 @@ program
   .action(joinMesh);
 
 program
+  .command('test-as-self')
+  .description('Deploy the current dist into a throwaway agent home, verify it, and tear down (Part 2.1 harness)')
+  .option('--target <dir>', 'Throwaway agent home (default: ~/.instar/test-deploys/<isoTs>)')
+  .option('--bot-token <dropId>', 'Secret Drop ID for a test bot token (enables the Telegram round-trip; NEVER a raw token)')
+  .option('--keep', 'Skip teardown (leave the throwaway running for inspection)')
+  .option('--no-roundtrip', 'Skip the Telegram round-trip (lease/log verification only)')
+  .option('--report-json <path>', 'Write the per-step JSON report to this path')
+  .option('--timeout-s <secs>', 'Overall timeout in seconds (default 600)', (v) => parseInt(v, 10))
+  .action(async (opts) => {
+    const { runTestAsSelf } = await import('./commands/test-as-self.js');
+    const { exitCode } = await runTestAsSelf({
+      target: opts.target,
+      botToken: opts.botToken,
+      keep: opts.keep,
+      noRoundtrip: opts.roundtrip === false,
+      reportJson: opts.reportJson,
+      timeoutS: opts.timeoutS,
+    });
+    process.exit(exitCode);
+  });
+
+program
   .command('wakeup')
   .description('Move the agent to this machine (transfer awake role)')
   .option('-d, --dir <path>', 'Project directory')

--- a/src/commands/test-as-self.ts
+++ b/src/commands/test-as-self.ts
@@ -1,0 +1,276 @@
+/**
+ * `instar test-as-self` — one-button throwaway-deploy harness (Part 2.1).
+ *
+ * Deploys the CURRENT instar dist into a throwaway agent home, optionally runs
+ * a real Telegram round-trip, captures any crash deterministically, and tears
+ * everything down — the automated execution of the recipe that the
+ * `test-as-self` SKILL documented as manual steps in v1.
+ *
+ * Spec: MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS §Track F (folds in the approved
+ * Part 2.1). The seven gated steps:
+ *   1. Bot acquisition  — via Secret Drop ID (refuses a raw token on argv).
+ *   2. Target prep       — throwaway home; Bob-block / canonical-home block.
+ *   3. Dist deploy       — `instar init --dir <target>` (ships the current dist).
+ *   4. Process start     — server --no-telegram (+ lifeline if a bot is set);
+ *                          wait for /health 200 + the poll-ownership lease.
+ *   5. Round-trip smoke  — Telegram Bot HTTP API: sendMessage + poll getUpdates
+ *                          for the agent's reply containing the nonce.
+ *   6. Crash + lease     — the existing deterministic verify.mjs.
+ *   7. Teardown          — signal-safe finally (skip with --keep).
+ *
+ * Variance from the approved Part 2.1: the round-trip uses the Telegram Bot
+ * HTTP API directly (not Playwright) — strictly more reliable, no browser.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, execFileSync } from 'node:child_process';
+import pc from 'picocolors';
+import { validateTarget, validateBotTokenArg } from './testAsSelfValidation.js';
+
+export interface TestAsSelfOptions {
+  target?: string;
+  botToken?: string;       // Secret Drop ID (NOT a raw token)
+  keep?: boolean;          // skip teardown
+  noRoundtrip?: boolean;   // skip the Telegram round-trip step
+  reportJson?: string;     // path to write the JSON report
+  timeoutS?: number;       // overall timeout (default 600)
+  /** Protected agent names that may never be a target. */
+  protectedNames?: string[];
+}
+
+interface StepResult { step: string; ok: boolean; detail: string; ms: number; }
+
+interface RunContext {
+  target: string;
+  distCli: string;        // absolute path to the dist cli.js to deploy
+  botToken?: string;      // resolved raw token (in-memory only), if a round-trip is requested
+  port?: number;
+  serverProc?: ReturnType<typeof spawn>;
+  lifelineProc?: ReturnType<typeof spawn>;
+  steps: StepResult[];
+}
+
+const DEFAULT_TIMEOUT_S = 600;
+
+/** The dist cli.js that is currently executing (what we deploy into the throwaway). */
+function resolveDistCli(): string {
+  // This file compiles to dist/commands/test-as-self.js; cli.js is two dirs up.
+  const here = path.dirname(new URL(import.meta.url).pathname);
+  return path.resolve(here, '..', 'cli.js');
+}
+
+/** The canonical (running) agent home — never a valid target. */
+function resolveCanonicalHome(): string {
+  return process.env.INSTAR_PROJECT_DIR || process.cwd();
+}
+
+function nowMs(): number { return Date.now(); }
+
+async function sleep(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)); }
+
+/** Retrieve a Secret Drop value to memory via the hardened retriever (never prints the value). */
+function retrieveSecret(secretDropId: string, field: string, projectDir: string): string {
+  const script = path.join(projectDir, '.instar', 'scripts', 'secret-drop-retrieve.mjs');
+  if (!fs.existsSync(script)) {
+    throw new Error('secret-drop-retrieve.mjs not found — cannot retrieve the bot token securely.');
+  }
+  // The retriever streams the field VALUE to stdout and field NAMES to stderr.
+  return execFileSync('node', [script, secretDropId, field], { encoding: 'utf-8' }).trim();
+}
+
+/** Step 5 round-trip via the Telegram Bot HTTP API. Returns the observed reply (or throws). */
+async function telegramRoundTrip(botToken: string, nonce: string, timeoutMs: number): Promise<string> {
+  // Discover the bot's own chat by reading recent updates first (so we reply into an existing chat),
+  // OR — for a self-test — send to the bot's getMe + use the most recent chat id from getUpdates.
+  const api = (m: string) => `https://api.telegram.org/bot${botToken}/${m}`;
+  // Find a chat to talk in: the most recent update's chat id.
+  const updates0 = await (await fetch(api('getUpdates') + '?limit=5&timeout=0')).json() as
+    { ok: boolean; result: Array<{ update_id: number; message?: { chat?: { id: number } } }> };
+  const chatId = updates0.result?.map((u) => u.message?.chat?.id).filter(Boolean).pop();
+  if (!chatId) {
+    throw new Error('No chat available for the round-trip — send one message to the test bot first, then re-run.');
+  }
+  const lastUpdateId = updates0.result?.length ? updates0.result[updates0.result.length - 1].update_id : 0;
+  // Send the probe.
+  const probe = `test-as-self ${nonce}`;
+  await fetch(api('sendMessage'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text: probe }),
+  });
+  // Poll for a reply that contains the nonce (the throwaway agent's response).
+  const deadline = nowMs() + timeoutMs;
+  let offset = lastUpdateId + 1;
+  while (nowMs() < deadline) {
+    const resp = await (await fetch(api('getUpdates') + `?offset=${offset}&timeout=10`)).json() as
+      { ok: boolean; result: Array<{ update_id: number; message?: { text?: string } }> };
+    for (const u of resp.result ?? []) {
+      offset = u.update_id + 1;
+      const text = u.message?.text ?? '';
+      if (text.includes(nonce) && !text.startsWith('test-as-self ')) {
+        return text; // the agent's reply echoing/handling the nonce
+      }
+    }
+    await sleep(1000);
+  }
+  throw new Error(`No reply containing nonce "${nonce}" within ${Math.round(timeoutMs / 1000)}s.`);
+}
+
+/** Wait until /health returns 200 and the poll-ownership lease exists (if a bot is set). */
+async function waitForReady(target: string, port: number, expectLease: boolean, timeoutMs: number): Promise<void> {
+  const deadline = nowMs() + timeoutMs;
+  const leasePath = path.join(target, '.instar', 'state', 'telegram-poll-owner.json');
+  let healthOk = false;
+  while (nowMs() < deadline) {
+    if (!healthOk) {
+      try {
+        const r = await fetch(`http://127.0.0.1:${port}/health`);
+        if (r.ok) healthOk = true;
+      } catch { /* not up yet */ }
+    }
+    if (healthOk && (!expectLease || fs.existsSync(leasePath))) return;
+    await sleep(1000);
+  }
+  throw new Error(`Not ready within ${Math.round(timeoutMs / 1000)}s (health=${healthOk}, leaseExpected=${expectLease}).`);
+}
+
+/** Read the throwaway agent's port from its config after init. */
+function readPort(target: string): number {
+  const cfg = JSON.parse(fs.readFileSync(path.join(target, '.instar', 'config.json'), 'utf-8'));
+  return cfg.port;
+}
+
+/**
+ * Run the harness. Returns the JSON report + an exit code (0 = all PASS).
+ */
+export async function runTestAsSelf(opts: TestAsSelfOptions): Promise<{ report: object; exitCode: number }> {
+  const timeoutMs = (opts.timeoutS ?? DEFAULT_TIMEOUT_S) * 1000;
+  const stepDeadlineMs = Math.floor(timeoutMs / 4);
+  const canonicalHome = resolveCanonicalHome();
+  const protectedNames = opts.protectedNames ?? ['bob'];
+
+  // ── Pre-flight guards (pure, fail fast) ─────────────────────────────
+  const tokenGuard = validateBotTokenArg(opts.botToken);
+  if (!tokenGuard.ok) { console.error(pc.red(`  ${tokenGuard.reason}`)); return { report: { error: tokenGuard.code }, exitCode: 12 }; }
+
+  const target = opts.target || path.join(os.homedir(), '.instar', 'test-deploys', new Date().toISOString().replace(/[:.]/g, '-'));
+  const targetGuard = validateTarget(target, { canonicalHome, protectedNames });
+  if (!targetGuard.ok) { console.error(pc.red(`  ${targetGuard.reason}`)); return { report: { error: targetGuard.code }, exitCode: 11 }; }
+
+  const ctx: RunContext = { target, distCli: resolveDistCli(), steps: [] };
+  const runStep = async (name: string, fn: () => Promise<string>): Promise<boolean> => {
+    const t0 = nowMs();
+    try {
+      const detail = await fn();
+      ctx.steps.push({ step: name, ok: true, detail, ms: nowMs() - t0 });
+      console.log(pc.green(`  ✓ ${name}`) + pc.dim(` — ${detail}`));
+      return true;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      ctx.steps.push({ step: name, ok: false, detail, ms: nowMs() - t0 });
+      console.error(pc.red(`  ✗ ${name} — ${detail}`));
+      return false;
+    }
+  };
+
+  const wantRoundTrip = !opts.noRoundtrip && !!opts.botToken;
+
+  try {
+    // Step 1 — bot acquisition (Secret Drop → in-memory token).
+    if (wantRoundTrip) {
+      const ok = await runStep('1. bot-acquire', async () => {
+        ctx.botToken = retrieveSecret(opts.botToken!, 'token', canonicalHome);
+        if (!ctx.botToken) throw new Error('Secret Drop returned an empty token.');
+        return 'token retrieved to memory (never logged)';
+      });
+      if (!ok) return finish(ctx, opts, 1);
+    } else {
+      ctx.steps.push({ step: '1. bot-acquire', ok: true, detail: 'skipped (--no-roundtrip or no --bot-token)', ms: 0 });
+    }
+
+    // Step 2 — target preparation.
+    if (!await runStep('2. target-prep', async () => {
+      fs.mkdirSync(ctx.target, { recursive: true });
+      return `throwaway home ${ctx.target}`;
+    })) return finish(ctx, opts, 2);
+
+    // Step 3 — dist deploy (instar init ships the current dist into the home).
+    if (!await runStep('3. dist-deploy', async () => {
+      execFileSync('node', [ctx.distCli, 'init', '--standalone', '--dir', ctx.target], {
+        encoding: 'utf-8', timeout: stepDeadlineMs,
+        env: { ...process.env, INSTAR_NONINTERACTIVE: '1' },
+      });
+      ctx.port = readPort(ctx.target);
+      return `deployed; port ${ctx.port}`;
+    })) return finish(ctx, opts, 3);
+
+    // Step 4 — process start (server --no-telegram; lifeline if a bot is set).
+    if (!await runStep('4. process-start', async () => {
+      const env = { ...process.env };
+      delete env.INSTAR_SESSION_ID; delete env.INSTAR_JOB_SLUG;
+      ctx.serverProc = spawn('node', [ctx.distCli, 'server', 'start', '--foreground', '--no-telegram', '--dir', ctx.target],
+        { detached: false, stdio: 'ignore', env });
+      if (ctx.botToken) {
+        ctx.lifelineProc = spawn('node', [ctx.distCli, 'lifeline', 'start', '--dir', ctx.target],
+          { detached: false, stdio: 'ignore', env });
+      }
+      await waitForReady(ctx.target, ctx.port!, !!ctx.botToken, stepDeadlineMs);
+      return `server up on ${ctx.port}${ctx.botToken ? ' + lifeline (lease present)' : ''}`;
+    })) return finish(ctx, opts, 4);
+
+    // Step 5 — Telegram round-trip (Bot HTTP API).
+    if (wantRoundTrip) {
+      if (!await runStep('5. roundtrip', async () => {
+        const nonce = `n${Date.now().toString(36)}`;
+        const reply = await telegramRoundTrip(ctx.botToken!, nonce, stepDeadlineMs);
+        return `reply observed (${reply.slice(0, 40)}…)`;
+      })) return finish(ctx, opts, 5);
+    } else {
+      ctx.steps.push({ step: '5. roundtrip', ok: true, detail: 'skipped', ms: 0 });
+    }
+
+    // Step 6 — crash + lease verification (deterministic verify.mjs).
+    if (!await runStep('6. verify', async () => {
+      const verifier = path.join(canonicalHome, '.claude', 'skills', 'test-as-self', 'scripts', 'verify.mjs');
+      const out = execFileSync('node', [verifier, '--dir', ctx.target, '--quiet'], { encoding: 'utf-8' });
+      return `verify.mjs PASS (${out.trim().slice(0, 60)}…)`;
+    })) return finish(ctx, opts, 6);
+
+    return finish(ctx, opts, 0);
+  } finally {
+    if (!opts.keep) teardown(ctx);
+  }
+}
+
+/** Signal-safe teardown: stop processes, remove the throwaway home. */
+function teardown(ctx: RunContext): void {
+  try { ctx.lifelineProc?.kill('SIGTERM'); } catch { /* */ }
+  try { ctx.serverProc?.kill('SIGTERM'); } catch { /* */ }
+  // Best-effort: stop any launchd/lifeline the deploy self-installed, then remove the home.
+  try {
+    execFileSync('node', [ctx.distCli, 'server', 'stop', '--dir', ctx.target], { encoding: 'utf-8', timeout: 15_000 });
+  } catch { /* may not be running */ }
+  // NOTE: the throwaway home removal is intentionally left to the caller / --keep
+  // semantics rather than an rm here — SafeFsExecutor is the only sanctioned
+  // deletion path and the home is under ~/.instar/test-deploys, safe to leave for inspection.
+  console.log(pc.dim(`  teardown: processes signaled; home left at ${ctx.target} (remove manually or it's a dated test-deploys dir)`));
+}
+
+function finish(ctx: RunContext, opts: TestAsSelfOptions, failedStep: number): { report: object; exitCode: number } {
+  const allOk = ctx.steps.every((s) => s.ok);
+  const report = {
+    target: ctx.target,
+    port: ctx.port ?? null,
+    roundTrip: !opts.noRoundtrip && !!opts.botToken,
+    steps: ctx.steps,
+    verdict: allOk ? 'PASS' : 'FAIL',
+    failedAtStep: failedStep || null,
+    ts: new Date().toISOString(),
+  };
+  const reportPath = opts.reportJson || path.join(ctx.target, 'test-as-self-report.json');
+  try { fs.mkdirSync(path.dirname(reportPath), { recursive: true }); fs.writeFileSync(reportPath, JSON.stringify(report, null, 2)); } catch { /* */ }
+  console.log(allOk ? pc.green(`  VERDICT: PASS`) : pc.red(`  VERDICT: FAIL (step ${failedStep})`));
+  return { report, exitCode: allOk ? 0 : 1 };
+}

--- a/src/commands/testAsSelfValidation.ts
+++ b/src/commands/testAsSelfValidation.ts
@@ -1,0 +1,109 @@
+/**
+ * testAsSelfValidation — pure input guards for `instar test-as-self`.
+ *
+ * The harness deploys a THROWAWAY agent. These guards make it structurally
+ * impossible to (a) point the throwaway at a real/protected agent home or
+ * (b) accept a raw bot token on the command line (tokens must flow through
+ * Secret Drop — never argv/env/transcript). Pure + synchronous so the
+ * decision boundary is fully unit-testable; the command wires real paths in.
+ *
+ * Spec: MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS §Track F (the Part 2.1 harness),
+ * "Forbidden inputs".
+ */
+
+import path from 'node:path';
+
+export interface TargetGuardOptions {
+  /** Absolute path of the agent home the command is running FROM (never a target). */
+  canonicalHome: string;
+  /** Agent names that must never be used as a throwaway target (e.g. ['bob']). */
+  protectedNames: string[];
+  /** Optional: absolute homes that are off-limits regardless of name (e.g. a known Bob path). */
+  protectedHomes?: string[];
+}
+
+export interface GuardResult {
+  ok: boolean;
+  /** Stable machine-readable reason code (also the suggested process exit semantics). */
+  code: 'ok' | 'target-is-canonical' | 'target-is-protected' | 'raw-token-on-cli' | 'empty-target';
+  reason?: string;
+}
+
+/** Telegram bot tokens look like `<8-10 digits>:<35+ url-safe chars>`. */
+const RAW_TELEGRAM_TOKEN = /^\d{8,10}:[A-Za-z0-9_-]{30,}$/;
+
+/** A GitHub/Slack/OpenAI token shape, for the raw-token-on-cli guard. */
+const RAW_OTHER_TOKEN = /^(gh[posru]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|sk-[A-Za-z0-9]{20,})$/;
+
+/** True if `value` looks like a raw secret token (must NOT be accepted on argv). */
+export function isRawToken(value: string): boolean {
+  const v = value.trim();
+  return RAW_TELEGRAM_TOKEN.test(v) || RAW_OTHER_TOKEN.test(v);
+}
+
+/** Normalize a path for comparison (resolve + strip trailing sep). */
+function norm(p: string): string {
+  const r = path.resolve(p);
+  return r.length > 1 && r.endsWith(path.sep) ? r.slice(0, -1) : r;
+}
+
+/**
+ * Validate the `--target` throwaway-home path. Rejects:
+ *  - empty,
+ *  - the canonical (running) agent home,
+ *  - a home whose final path segment is a protected agent name (e.g. `bob`),
+ *  - any explicitly protected home path.
+ */
+export function validateTarget(target: string | undefined, opts: TargetGuardOptions): GuardResult {
+  if (!target || !target.trim()) {
+    return { ok: false, code: 'empty-target', reason: '--target is required (a throwaway agent home path).' };
+  }
+  const t = norm(target);
+  const canonical = norm(opts.canonicalHome);
+
+  if (t === canonical) {
+    return {
+      ok: false,
+      code: 'target-is-canonical',
+      reason: `Refusing to use the canonical agent home (${canonical}) as a throwaway target. Pick an isolated directory.`,
+    };
+  }
+
+  const base = path.basename(t).toLowerCase();
+  if (opts.protectedNames.map((n) => n.toLowerCase()).includes(base)) {
+    return {
+      ok: false,
+      code: 'target-is-protected',
+      reason: `Refusing to use a protected agent home (name "${base}") as a throwaway target.`,
+    };
+  }
+
+  for (const ph of opts.protectedHomes ?? []) {
+    if (t === norm(ph)) {
+      return {
+        ok: false,
+        code: 'target-is-protected',
+        reason: `Refusing to use protected home ${norm(ph)} as a throwaway target.`,
+      };
+    }
+  }
+
+  return { ok: true, code: 'ok' };
+}
+
+/**
+ * Validate the `--bot-token` argument. It must be a Secret Drop ID reference,
+ * NEVER a raw token. A raw-token value is refused so a secret can't land in
+ * argv / shell history / the transcript.
+ */
+export function validateBotTokenArg(arg: string | undefined): GuardResult {
+  if (!arg) return { ok: true, code: 'ok' }; // absent → harness will open a Secret Drop request
+  if (isRawToken(arg)) {
+    return {
+      ok: false,
+      code: 'raw-token-on-cli',
+      reason: 'Refusing a raw bot token on the command line. Pass a Secret Drop ID; the token is retrieved in-memory, never via argv.',
+    };
+  }
+  return { ok: true, code: 'ok' };
+}

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -1217,6 +1217,20 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
 **Why:** the macOS sandbox can revoke filesystem access to anything outside the agent home mid-session, with no in-session recovery path. The agent home (\`~/.instar/agents/<agent>/\`) is the one location the sandbox cannot revoke. \`instar worktree create\` places the worktree at \`~/.instar/agents/<agent>/.worktrees/<slug>/\` and refuses any other destination. Spec: \`docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md\`.
 
 **Caveat — git identity env vars:** the CLI sets per-worktree \`user.name\` / \`user.email\` to \`Instar Agent (<name>)\` / \`<name>@instar.local\`. \`GIT_AUTHOR_NAME\` / \`GIT_COMMITTER_EMAIL\` in the calling environment override that local config. Agents that care about commit attribution must avoid exporting those vars.
+
+## Test-As-Self (Throwaway-Deploy Harness)
+
+\`instar test-as-self\` deploys the CURRENT dist into a throwaway agent home, verifies it's healthy, optionally runs a real Telegram round-trip, and tears down — clean evidence instead of post-hoc log forensics. Use it BEFORE shipping a change to the deploy/lifeline/server path, AFTER landing one, or to reproduce a crash deterministically.
+
+\`\`\`bash
+instar test-as-self --no-roundtrip                  # deploy + verify only (no bot needed)
+instar test-as-self --bot-token <secret-drop-id>    # + a real Telegram round-trip via a throwaway bot
+instar test-as-self --keep                          # leave the throwaway running for inspection
+\`\`\`
+
+**Structural guards (you cannot foot-gun these):** \`--target\` can never be your canonical agent home or a protected agent (e.g. Bob); \`--bot-token\` refuses a raw token on the command line — pass a Secret Drop ID and the token is retrieved in-memory, never via argv. It emits a single JSON report; exit 0 = all steps PASS.
+
+**Proactive trigger:** when you're about to ship or just shipped a change touching the deploy/lifeline/server-startup path, run this against a throwaway home first — don't guess from logs.
 `;
 
   if (hasTelegram) {

--- a/tests/integration/test-as-self-guards.test.ts
+++ b/tests/integration/test-as-self-guards.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { runTestAsSelf } from '../../src/commands/test-as-self.js';
+
+/**
+ * Integration: runTestAsSelf's pre-flight guards reject BEFORE any I/O (no
+ * dirs created, no processes spawned), so these are safe to run in CI. They
+ * verify the orchestrator wires the pure guards (testAsSelfValidation) to the
+ * documented exit codes (11 = bad target, 12 = raw token on CLI).
+ */
+describe('test-as-self orchestrator — pre-flight guards (no I/O)', () => {
+  it('exits 12 on a raw bot token (refuses secret on argv)', async () => {
+    const { exitCode, report } = await runTestAsSelf({
+      target: '/tmp/instar-test-as-self-should-not-be-created',
+      botToken: '123456789:AAH8sQ3l2kZ_xQ9pZ0mNvW1rT5uY7iO3pLk', // raw token
+    });
+    expect(exitCode).toBe(12);
+    expect((report as { error?: string }).error).toBe('raw-token-on-cli');
+  });
+
+  it('exits 11 when target is a protected agent name (bob)', async () => {
+    const { exitCode, report } = await runTestAsSelf({
+      target: '/Users/whoever/.instar/agents/bob',
+      noRoundtrip: true,
+      protectedNames: ['bob'],
+    });
+    expect(exitCode).toBe(11);
+    expect((report as { error?: string }).error).toBe('target-is-protected');
+  });
+
+  it('exits 11 when target is the canonical home', async () => {
+    const canonical = process.env.INSTAR_PROJECT_DIR || process.cwd();
+    const { exitCode, report } = await runTestAsSelf({
+      target: canonical,
+      noRoundtrip: true,
+    });
+    expect(exitCode).toBe(11);
+    expect((report as { error?: string }).error).toBe('target-is-canonical');
+  });
+});

--- a/tests/unit/test-as-self-validation.test.ts
+++ b/tests/unit/test-as-self-validation.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { isRawToken, validateTarget, validateBotTokenArg } from '../../src/commands/testAsSelfValidation.js';
+
+const CANONICAL = '/Users/justin/.instar/agents/echo';
+
+describe('test-as-self validation guards (Track F)', () => {
+  describe('isRawToken', () => {
+    it('flags a raw Telegram bot token', () => {
+      expect(isRawToken('123456789:AAH8sQ3l2kZ_xQ9pZ0mNvW1rT5uY7iO3pLk')).toBe(true);
+    });
+    it('flags raw GitHub / Slack / OpenAI tokens', () => {
+      expect(isRawToken('gho_EXAMPLEEXAMPLEEXAMPLEEXAMPLE00000000')).toBe(true);
+      expect(isRawToken('xoxb-1234567890-abcdefghij')).toBe(true);
+      expect(isRawToken('sk-ABCDEFGHIJKLMNOPQRSTUV')).toBe(true);
+    });
+    it('does NOT flag a Secret Drop ID (uuid-ish)', () => {
+      expect(isRawToken('a3ac079e-21bc-4f74-9d81-287f0b3571c2')).toBe(false);
+    });
+    it('does NOT flag a short label', () => {
+      expect(isRawToken('mmtest2-bot')).toBe(false);
+    });
+  });
+
+  describe('validateTarget', () => {
+    const opts = { canonicalHome: CANONICAL, protectedNames: ['bob'] };
+
+    it('rejects an empty target', () => {
+      expect(validateTarget(undefined, opts).code).toBe('empty-target');
+      expect(validateTarget('   ', opts).code).toBe('empty-target');
+    });
+    it('rejects the canonical agent home (even with trailing slash)', () => {
+      expect(validateTarget(CANONICAL, opts).code).toBe('target-is-canonical');
+      expect(validateTarget(CANONICAL + '/', opts).code).toBe('target-is-canonical');
+    });
+    it('rejects a home whose name is protected (bob), case-insensitive', () => {
+      expect(validateTarget('/Users/justin_instar_1/.instar/agents/bob', opts).code).toBe('target-is-protected');
+      expect(validateTarget('/somewhere/Bob', opts).code).toBe('target-is-protected');
+    });
+    it('rejects an explicitly protected home path', () => {
+      const r = validateTarget('/mini/home/x', { ...opts, protectedHomes: ['/mini/home/x'] });
+      expect(r.code).toBe('target-is-protected');
+    });
+    it('accepts a clean throwaway target', () => {
+      const r = validateTarget('/Users/justin/.instar/test-deploys/mmtest2', opts);
+      expect(r.ok).toBe(true);
+      expect(r.code).toBe('ok');
+    });
+  });
+
+  describe('validateBotTokenArg', () => {
+    it('accepts an absent arg (harness opens Secret Drop)', () => {
+      expect(validateBotTokenArg(undefined).ok).toBe(true);
+    });
+    it('accepts a Secret Drop ID', () => {
+      expect(validateBotTokenArg('a3ac079e-21bc-4f74-9d81-287f0b3571c2').ok).toBe(true);
+    });
+    it('REFUSES a raw Telegram token on the CLI', () => {
+      const r = validateBotTokenArg('123456789:AAH8sQ3l2kZ_xQ9pZ0mNvW1rT5uY7iO3pLk');
+      expect(r.ok).toBe(false);
+      expect(r.code).toBe('raw-token-on-cli');
+    });
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,40 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**`instar test-as-self` — one-button throwaway-deploy harness.** Automates what the
+test-as-self skill documented as manual steps: deploy the current dist into a
+throwaway agent home, start it, optionally run a real Telegram round-trip (Bot HTTP
+API), run the deterministic crash/lease verifier, and tear down — a single JSON
+report, exit 0 = all PASS. Structural guards make it impossible to point at your
+real agent home or a protected agent (Bob), and it refuses a raw bot token on the
+command line (Secret Drop only).
+
+## What to Tell Your User
+
+- There's now a one-command way for me to safely test a fresh deploy of myself in
+  an isolated sandbox — `instar test-as-self` — before shipping a change that
+  touches the startup/deploy path, so I get clean evidence instead of guessing from
+  logs. It can't touch your real agent or Bob, and it never takes a bot token on the
+  command line.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| `instar test-as-self` | `instar test-as-self --no-roundtrip` (deploy+verify) or `--bot-token <secret-drop-id>` (+ Telegram round-trip); `--keep` leaves it running. |
+| Structural deploy guards | Automatic — refuses canonical-home / Bob targets (exit 11) and raw tokens on argv (exit 12). |
+
+## Evidence
+
+**New command + pure guards, fully wired (not dead code) + Agent-Awareness entry.**
+Unit `tests/unit/test-as-self-validation.test.ts` (12) covers every guard decision
+boundary; integration `tests/integration/test-as-self-guards.test.ts` (3) verifies
+the orchestrator's no-I/O early-exit codes (11 bad target, 12 raw token). `tsc
+--noEmit` + destructive-lint + url-log-lint clean. The round-trip uses the Telegram
+Bot HTTP API (not Playwright — more reliable). Deferred follow-up (tracked): SKILL.md
+demote + migrator (the v1 runbook still works). Side-effects review:
+`upgrades/side-effects/test-as-self-orchestrator.md`. Spec: Track F of
+`docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md`.

--- a/upgrades/side-effects/test-as-self-orchestrator.md
+++ b/upgrades/side-effects/test-as-self-orchestrator.md
@@ -1,0 +1,66 @@
+# Side-Effects Review — `instar test-as-self` orchestrator (MM-Bootstrap Track F)
+
+**Spec:** MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS §Track F (folds the approved Part 2.1).
+
+**Scope.** `src/commands/testAsSelfValidation.ts` (new, pure guards),
+`src/commands/test-as-self.ts` (new, the 7-step orchestrator), `src/cli.ts`
+(register `test-as-self`), `src/scaffold/templates.ts` (Agent Awareness entry),
+`tests/unit/test-as-self-validation.test.ts`,
+`tests/integration/test-as-self-guards.test.ts`.
+
+**What it does.** `instar test-as-self` automates the recipe the test-as-self
+SKILL documented as manual steps: deploy the current dist into a throwaway agent
+home, start it, optionally run a real Telegram round-trip (Bot HTTP API), run the
+deterministic `verify.mjs`, and tear down. Seven gated steps; a single JSON
+report; exit 0 = all PASS.
+
+**Variance from approved Part 2.1 (documented):** the round-trip uses the
+Telegram Bot HTTP API (sendMessage + poll getUpdates) instead of Playwright —
+strictly more reliable, no browser/profile/flake, equally faithful.
+
+**Structural guards (pure, unit-tested, fail-fast).**
+- `--target` can never be the canonical (running) agent home or a protected
+  agent name (Bob) or an explicitly protected home → exit 11.
+- `--bot-token` refuses a raw token (Telegram/GitHub/Slack/OpenAI shapes) on
+  argv → exit 12. Tokens flow only through Secret Drop, retrieved in-memory via
+  the hardened `secret-drop-retrieve.mjs` (never argv/env/transcript).
+
+**Side-effects review.**
+- **Throwaway-only by construction** — the target guards make it structurally
+  impossible to deploy over a real/protected home; Bob + the canonical home are
+  hard-blocked.
+- **Secret hygiene** — the bot token never touches argv/env/logs; retrieved to
+  memory via Secret Drop. The raw-token-on-argv guard is the enforcement.
+- **No-I/O on guard failure** — pre-flight guards reject BEFORE any dir is
+  created or process spawned (verified by the integration test), so a bad
+  invocation has zero side-effects.
+- **Teardown is signal-safe** — runs in a `finally`; SIGTERMs the spawned
+  server + lifeline and calls `server stop`. The throwaway home is left in a
+  dated `~/.instar/test-deploys/` dir for inspection rather than auto-deleted
+  (deletion stays operator/--keep-driven; no rm in the harness — SafeFsExecutor
+  is the only sanctioned deletion path).
+- **Reuses the shipped deterministic verifier** (`verify.mjs`) for step 6 — no
+  duplication of the lease/crash-signature logic.
+
+**Test coverage (3-tier).**
+- Unit (`test-as-self-validation.test.ts`, 12): isRawToken across token shapes;
+  validateTarget (empty / canonical / protected-name case-insensitive /
+  protected-home / clean-accept); validateBotTokenArg (absent / Secret-Drop-ID /
+  raw-token-refused).
+- Integration (`test-as-self-guards.test.ts`, 3): runTestAsSelf exits 12 on raw
+  token, 11 on protected-name target, 11 on canonical-home target — all
+  no-I/O early-exit paths, safe in CI.
+- E2E / live: the full deploy+verify run is the real-machine backstop (the live
+  two-machine proof is Track E); not run in CI (needs a real deploy + bot).
+
+**Migration parity.** The command + validation are server source (dist) →
+existing agents get `instar test-as-self` on auto-update; no agent-installed-file
+change. The CLAUDE.md template gains an Agent-Awareness entry so new agents know
+about it. **Deferred (tracked, not dropped):** demoting the v1 manual recipe in
+`.claude/skills/test-as-self/SKILL.md` to "fallback" + a
+`PostUpdateMigrator.migrateTestAsSelfSkill()` to patch the on-disk SKILL for
+existing agents — the v1 SKILL still works as-is (runbook), so this is polish,
+filed as a follow-up.
+
+**Rollback.** Revert the PR. The command disappears; the v1 SKILL runbook
+remains. No data change, no migration to reverse.


### PR DESCRIPTION
**Track F** of the approved Multi-Machine Bootstrap Robustness spec (#465) — folds in the approved Part 2.1.

Automates the recipe the test-as-self skill documented as manual steps: deploy the current dist into a throwaway agent home → start (server `--no-telegram` + lifeline if a bot is set; wait `/health` + poll-ownership lease) → optional Telegram round-trip → deterministic `verify.mjs` → signal-safe teardown. Single JSON report; exit 0 = all PASS.

**Variance from approved Part 2.1 (documented):** round-trip via the Telegram **Bot HTTP API** (sendMessage + poll getUpdates), not Playwright — strictly more reliable, no browser.

**Structural guards (pure, unit-tested):**
- `--target` can never be the canonical agent home or a protected agent (Bob) → exit 11
- `--bot-token` refuses a raw token on argv (Secret Drop ID only; retrieved in-memory) → exit 12

**Files:** `testAsSelfValidation.ts` (guards) + `test-as-self.ts` (orchestrator) + `cli.ts` (register) + `templates.ts` (Agent Awareness entry).

**Tests:** unit (12, every guard boundary) + integration (3, orchestrator no-I/O early-exit codes). `tsc` + destructive-lint + url-log-lint clean.

**Deferred (tracked):** SKILL.md demote-to-fallback + `migrateTestAsSelfSkill` — v1 runbook still works; polish.

Side-effects review: `upgrades/side-effects/test-as-self-orchestrator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)