### PR TITLE
fix(messaging): mentor round-trip — menteeAgentName + botId coercion + senderBotId

### DIFF
--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -19,8 +19,17 @@ import type { CaptureRunInput, CaptureRunResult, ForensicFinding } from '../moni
 export interface MentorConfig {
   enabled: boolean;
   mode: 'off' | 'dry-run' | 'live';
-  /** The framework being mentored (parametric). */
+  /** The framework being mentored (parametric). Used for Stage-B forensics
+   *  (codex-rollout parsing keys on framework). NOT necessarily the mentee's
+   *  agent-registry name — see menteeAgentName. */
   menteeFramework: string;
+  /** The mentee's actual agent-registry name (e.g. 'instar-codey'). Used for
+   *  same-machine peer lookup + the a2a marker `to=`/reply-allowlist. Defaults
+   *  to `instar-${menteeFramework}` when unset (back-compat), but framework and
+   *  registered agent name routinely differ (framework=codex-cli, agent
+   *  name=instar-codey) — that mismatch silently broke same-machine a2a routing
+   *  + reply-allowlisting until this field existed. */
+  menteeAgentName?: string;
   minIntervalMs: number;
   maxRoundsPerDay: number;
   /** @deprecated dead config — we run on a Claude subscription; replacement is the

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -918,10 +918,11 @@ export class AgentServer {
   private installMentorReceiverHook(bot: MentorTelegramAdapter, mentorBotId: string): void {
     const cfg = this.getMentorConfigSnapshot();
     if (!cfg.menteeBotId) return;
+    const menteeAgent = cfg.menteeAgentName || `instar-${cfg.menteeFramework}`;
     const recipientCfg: RecipientConfig = {
       localAgent: 'echo',
-      knownAgents: { [`instar-${cfg.menteeFramework}`]: { botId: cfg.menteeBotId } },
-      acceptRoles: { [`instar-${cfg.menteeFramework}`]: ['mentor-reply'] },
+      knownAgents: { [menteeAgent]: { botId: String(cfg.menteeBotId) } },
+      acceptRoles: { [menteeAgent]: ['mentor-reply'] },
       skewWindowMs: 24 * 60 * 60 * 1000,
       maxVersion: A2A_VERSION,
     };
@@ -1022,7 +1023,9 @@ export class AgentServer {
     }
     if (menteeReady) {
       for (const [mentorName, info] of Object.entries(menteeCfg.knownMentors)) {
-        knownAgents[mentorName] = info;
+        // Coerce botId to string (config may store it as a JSON number; the
+        // marker senderBotId is always a string + the allowlist uses ===).
+        knownAgents[mentorName] = { botId: String(info.botId) };
         acceptRoles[mentorName] = [...(acceptRoles[mentorName] ?? []), 'mentor'];
       }
       const sessionTimeoutMs = menteeCfg.sessionTimeoutMs;
@@ -1088,6 +1091,9 @@ export class AgentServer {
           body: reply,
           allowedRoles: new Set(['mentor-reply']),
           telegramTopicId: menteeCfg.replyTopicId,
+          // fromBotId = THIS agent's own bot id, so the mentor's allowlist
+          // (knownAgents[instar-codey].botId === senderBotId) passes.
+          fromBotId: self.ownPrimaryBotId(),
           toBotId: menteeCfg.knownMentors[msg.from]?.botId,
         });
       };
@@ -1100,8 +1106,11 @@ export class AgentServer {
     // the mentor-BOT adapter (spec §250 — capability-handle, capture-only).
     const mentorCfg = this.getMentorConfigSnapshot();
     if (mentorCfg.menteeBotId) {
-      const menteeAgent = `instar-${mentorCfg.menteeFramework}`;
-      knownAgents[menteeAgent] = { botId: mentorCfg.menteeBotId };
+      const menteeAgent = mentorCfg.menteeAgentName || `instar-${mentorCfg.menteeFramework}`;
+      // Coerce to string — config may store the bot id as a JSON number, but
+      // the a2a marker's senderBotId is always a string; the allowlist compares
+      // with === so a number/string mismatch silently drops every reply.
+      knownAgents[menteeAgent] = { botId: String(mentorCfg.menteeBotId) };
       acceptRoles[menteeAgent] = [...(acceptRoles[menteeAgent] ?? []), 'mentor-reply'];
       const outstanding = this.getOrCreateMentorOutstanding();
       const replyJsonl = path.join(this.config.stateDir, 'mentor-replies.jsonl');
@@ -1174,7 +1183,12 @@ export class AgentServer {
     body: string;
     allowedRoles: ReadonlySet<string>;
     telegramTopicId?: number;
+    /** The recipient's bot id — used ONLY by the Telegram fallback's toBotId. */
     toBotId?: string;
+    /** The SENDER's own bot id — sent as the inbox `senderBotId` so the
+     *  recipient's allowlist check (knownAgents[from].botId === senderBotId)
+     *  passes. Must be the from-agent's bot id, NOT the recipient's. */
+    fromBotId?: string;
     /** Telegram fallback bits (mentor→mentee only). */
     telegramBot?: { sendToTopic: (topicId: number, text: string) => Promise<{ messageId: number }> };
     botToken?: string;
@@ -1203,7 +1217,7 @@ export class AgentServer {
               topicId: opts.telegramTopicId ?? 0,
               senderAgent: opts.fromAgent,
               senderIsBot: true,
-              senderBotId: opts.toBotId ?? `${opts.fromAgent}-local`,
+              senderBotId: opts.fromBotId ?? `${opts.fromAgent}-local`,
             }),
             signal: AbortSignal.timeout(10_000),
           });
@@ -1270,6 +1284,21 @@ export class AgentServer {
       ...DEFAULT_MENTEE_CONFIG,
       ...((this.config as unknown as { mentee?: Partial<MenteeConfig> }).mentee ?? {}),
     };
+  }
+
+  /**
+   * This agent's own primary Telegram bot id (the numeric prefix of its
+   * messaging bot token), or undefined if no Telegram messaging is configured.
+   * Used as the a2a `senderBotId` so a recipient's allowlist check
+   * (knownAgents[from].botId === senderBotId) passes — the sender must
+   * identify with its OWN bot id.
+   */
+  private ownPrimaryBotId(): string | undefined {
+    const tg = (this.config.messaging ?? []).find(
+      (m) => m.type === 'telegram' && m.enabled,
+    ) as { config?: { token?: string } } | undefined;
+    const token = tg?.config?.token;
+    return token ? token.split(':')[0] : undefined;
   }
 
   /** Snapshot of mentor config for use outside the runner's getConfig closure. */
@@ -1388,7 +1417,10 @@ export class AgentServer {
         // the bot isn't configured yet, this no-ops with a log — the dark default.
         deliverToMentee: async (framework: string, message: string) => {
           const cfg = getConfig();
-          const menteeAgent = `instar-${framework}`;
+          // Prefer the explicit registry name; fall back to the framework-derived
+          // name (back-compat). framework=codex-cli but the agent registers as
+          // instar-codey — using the derived name silently broke peer lookup.
+          const menteeAgent = cfg.menteeAgentName || `instar-${framework}`;
           const corr = `mp-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 
           // Anti-ping-pong (spec §Fix 2b item 4 + Justin's original concern). Same
@@ -1432,6 +1464,9 @@ export class AgentServer {
             body: message,
             allowedRoles: new Set(['mentor']),
             telegramTopicId: cfg.menteeTopicId,
+            // fromBotId = echo's mentor-bot id, so the mentee's allowlist
+            // (knownMentors[echo].botId === senderBotId) passes.
+            fromBotId: cfg.botToken ? cfg.botToken.split(':')[0] : undefined,
             toBotId: cfg.menteeBotId,
             telegramBot: telegramBot
               ? { sendToTopic: (t, txt) => telegramBot.sendToTopic(t, txt) }

--- a/tests/e2e/mentor-reply-via-inbox.test.ts
+++ b/tests/e2e/mentor-reply-via-inbox.test.ts
@@ -128,3 +128,67 @@ describe('mentor-reply via /a2a/inbox persists to mentor-replies.jsonl (E2E)', (
     expect(match.transport).toBe('a2a-inbox-local');
   });
 });
+
+describe('mentor-reply: menteeAgentName override + numeric botId coercion (E2E)', () => {
+  // Regression for the two live-dogfood drops:
+  //  (a) framework=codex-cli but the registered agent name is instar-codey →
+  //      the reply from=instar-codey must be allowlisted (menteeAgentName).
+  //  (b) config stores menteeBotId as a JSON NUMBER, but the marker senderBotId
+  //      is a string → the allowlist === comparison must coerce or every reply
+  //      drops as agent-marker-unknown.
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+  let token: string;
+  const PROJECT = 'echo';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mentor-reply-coerce-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: PROJECT, agentName: 'Echo' }));
+    const config = {
+      projectName: PROJECT, projectDir: tmpDir, stateDir, port: 0, authToken: 'placeholder',
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+      // menteeAgentName overrides instar-${framework}; menteeBotId is a NUMBER on purpose.
+      mentor: { enabled: true, mode: 'live', menteeFramework: 'codex-cli', menteeAgentName: 'instar-codey', minIntervalMs: 600000, maxRoundsPerDay: 24, menteeBotId: 8610996786 },
+    } as unknown as InstarConfig;
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir), telegram: createRealHookAdapter() });
+    await server.start();
+    app = server.getApp();
+    token = generateAgentToken(PROJECT);
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    try { deleteAgentToken(PROJECT); } catch { /* best-effort */ }
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/mentor-reply-via-inbox.test.ts:coerce' });
+  });
+
+  it('routes a reply from the menteeAgentName-named agent with a numeric-configured botId (string senderBotId)', async () => {
+    const corr = 'coerce-test-1';
+    const marker = `[a2a:from=instar-codey to=echo role=mentor-reply id=mrc-1 corr=${corr} ts=${Date.now()} v=1]`;
+    const res = await request(app)
+      .post('/a2a/inbox')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        text: `${marker}\n\nCodey reply via menteeAgentName + numeric botId.`,
+        topicId: 458,
+        senderAgent: 'instar-codey',
+        senderIsBot: true,
+        senderBotId: '8610996786', // string, vs the numeric config value
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, agentMessage: true });
+    const jsonlPath = path.join(stateDir, 'mentor-replies.jsonl');
+    const rows = fs.readFileSync(jsonlPath, 'utf-8').trim().split('\n').map((l) => JSON.parse(l));
+    const match = rows.find((r) => r.corr === corr);
+    expect(match).toBeDefined();
+    expect(match.fromAgent).toBe('instar-codey');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,56 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Mentor cycle round-trip — final fixes (verified live end-to-end).** Three
+bugs that only surfaced when the full Echo↔Codey round-trip ran on real
+servers:
+
+1. **`mentor.menteeAgentName` config.** The mentor derived the mentee's agent
+   name as `instar-${menteeFramework}` (e.g. `instar-codex-cli`), but the
+   mentee registers under its real name (`instar-codey`). The mismatch broke
+   same-machine peer lookup AND the reply allowlist. New optional
+   `mentor.menteeAgentName` (defaults to `instar-${menteeFramework}`) carries
+   the real registry name.
+
+2. **botId string coercion.** `mentor.menteeBotId` is often stored as a JSON
+   number, but the a2a marker's `senderBotId` is always a string. The
+   allowlist compares with `===`, so a number/string mismatch silently
+   dropped every reply as `agent-marker-unknown`. All botId allowlist entries
+   are now `String()`-coerced.
+
+3. **`senderBotId` = sender's own bot id.** The unified transport sent the
+   *recipient's* bot id as the inbox `senderBotId`; the recipient's allowlist
+   check (`knownAgents[from].botId === senderBotId`) therefore always failed.
+   It now sends the *sender's* own bot id (`ownPrimaryBotId()` for replies,
+   the mentor bot id for sends).
+
+With these, the mentor cycle round-trips live: a mentor prompt reaches the
+mentee, the mentee spawns a session + replies, and the reply lands in the
+mentor's `mentor-replies.jsonl`.
+
+## What to Tell Your User
+
+The cross-agent mentor cycle now works fully end-to-end on the same machine —
+verified with a real round-trip. These were the last three wiring bugs (an
+agent-name assumption, a number-vs-string comparison, and a sender-identity
+mixup). No config changes required unless your mentee's registry name differs
+from `instar-<framework>`, in which case set `mentor.menteeAgentName`.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| `mentor.menteeAgentName` | Set in `.instar/config.json` when the mentee's agent-registry name differs from `instar-<menteeFramework>` (e.g. `instar-codey`). Defaults to the framework-derived name. |
+| Robust botId matching | botId allowlist entries are string-coerced; `senderBotId` is the sender's own bot id. No action needed — fixes silent reply drops. |
+
+## Evidence
+
+Extended `mentor-reply-via-inbox` E2E with a second case proving the
+menteeAgentName override + numeric-configured botId (string senderBotId)
+routes + persists. Both cases green; all prior mentor/mentee/inbox tests
+green. `tsc --noEmit` clean. **Live-verified**: full Echo→Codey→Echo
+round-trip persisted to `mentor-replies.jsonl`. Side-effects:
+`upgrades/side-effects/mentee-agent-name-and-botid-coercion.md`.

--- a/upgrades/side-effects/mentee-agent-name-and-botid-coercion.md
+++ b/upgrades/side-effects/mentee-agent-name-and-botid-coercion.md
@@ -1,0 +1,55 @@
+# Side-Effects Review — menteeAgentName + botId coercion + senderBotId fix
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Recipient side. Final
+fixes closing the live round-trip (the reply leg landed in #469; these are the
+three remaining wiring bugs found by running it end-to-end).
+
+**Change:** `src/scheduler/MentorOnboardingRunner.ts` (+1 optional config
+field) + `src/server/AgentServer.ts` (menteeAgentName usage at 3 derivation
+sites, botId String-coercion at 3 allowlist sites, senderBotId=sender's-own
+via new `ownPrimaryBotId()` helper) + extended E2E test.
+
+## What changed
+1. `MentorConfig.menteeAgentName?: string` — the mentee's real registry name.
+   Used in `deliverToMentee`, `installMentorMessageHook` (mentor side), and
+   `installMentorReceiverHook`, each falling back to `instar-${menteeFramework}`.
+2. botId `String()`-coercion at every knownAgents construction (mentor side,
+   mentee side, receiver hook) — config may store a JSON number; the marker
+   senderBotId is always a string; the allowlist uses `===`.
+3. `deliverA2aMessage` now takes `fromBotId` (sender's own bot id) and sends
+   it as the inbox `senderBotId`. `ownPrimaryBotId()` derives this agent's bot
+   id from its messaging config token. Replies pass `ownPrimaryBotId()`; sends
+   pass the mentor bot id.
+
+## The seven questions
+1. **Over-block.** N/A — these LOOSEN an over-strict (buggy) comparison that
+   was dropping legitimate replies. Coercion only makes a number match its
+   string form; it does not widen the allowlist to new agents.
+2. **Under-block.** The allowlist still requires an exact (coerced) botId
+   match + known agent name. Spoof defense intact — a wrong botId still drops.
+3. **Level-of-abstraction fit.** Small, local fixes at the exact sites; one
+   tiny helper (`ownPrimaryBotId`). No new infrastructure.
+4. **Signal vs authority.** Unchanged — allowlist still decides route/drop.
+5. **Interactions.** `menteeAgentName` defaults preserve back-compat for any
+   agent whose registry name already equals `instar-<framework>`. Coercion is
+   idempotent on already-string values.
+6. **External surfaces.** One new optional config key (`mentor.menteeAgentName`).
+   No new routes.
+7. **Rollback cost.** Trivial — revert restores framework-derived names + the
+   number/string comparison (re-introducing the silent reply drop).
+
+## Testing
+Extended `mentor-reply-via-inbox` E2E (now 2 cases): the original
+(framework-derived name, string botId) + the new regression (menteeAgentName
+override, numeric-configured botId, string senderBotId) — both route + persist.
+All prior mentor/mentee/inbox tests green. tsc clean.
+
+**Live verification (test-as-self):** the worktree build was shadow-deployed to
+the live Echo + Codey pair; a real mentor prompt round-tripped — Codey spawned
+a mentee session, replied via /a2a/inbox, and Echo persisted the reply to
+mentor-replies.jsonl (corr=FULL-…, from=instar-codey, transport=a2a-inbox-local).
+
+## Migration parity
+`mentor.menteeAgentName` is optional with a back-compat default — no migration
+needed. The botId coercion + senderBotId fix are pure code (no config/state
+change). No PostUpdateMigrator change.


### PR DESCRIPTION
Final three wiring bugs found by running the full Echo+Codey mentor round-trip on real servers (the reply leg landed in #469). With these, the cycle round-trips live end-to-end.

1. mentor.menteeAgentName config. The mentor derived the mentee name as instar-(menteeFramework), e.g. instar-codex-cli, but the mentee registers as instar-codey. The mismatch broke same-machine peer lookup AND the reply allowlist. New optional menteeAgentName (defaults to instar-(framework)) carries the real registry name; used for peer lookup + marker to= + reply allowlist.

2. botId string coercion. menteeBotId is often stored as a JSON number, but the a2a marker senderBotId is always a string; the allowlist compares with === so a number/string mismatch silently dropped every reply as agent-marker-unknown. All botId allowlist entries are now String()-coerced.

3. senderBotId = sender own bot id. The unified transport sent the RECIPIENT bot id as the inbox senderBotId; the recipient allowlist check (knownAgents[from].botId === senderBotId) therefore always failed. It now sends the SENDER own bot id (new ownPrimaryBotId helper for replies; the mentor bot id for sends).

Live verification (test-as-self): the worktree build was shadow-deployed to the live Echo + Codey pair and a real mentor prompt round-tripped — Codey spawned a mentee session, replied via /a2a/inbox, and Echo persisted the reply to mentor-replies.jsonl (corr matched, from=instar-codey, transport=a2a-inbox-local).

Tests: extended mentor-reply-via-inbox E2E with a second case proving the menteeAgentName override + numeric-configured botId (string senderBotId) routes + persists. Both green; all prior mentor/mentee/inbox tests green. tsc clean.

Side-effects: upgrades/side-effects/mentee-agent-name-and-botid-coercion.md.

Generated with Claude Code