### PR TITLE
feat(topic-intent): wire ArcCheck (Layer 3) — classifier + outbound integration

### DIFF
--- a/docs/specs/topic-intent-arccheck-wiring.eli16.md
+++ b/docs/specs/topic-intent-arccheck-wiring.eli16.md
@@ -1,0 +1,85 @@
+# Wire ArcCheck — fix the surfacing gap (ELI16)
+
+## What's broken
+
+We built a three-layer "topical memory" for the agent:
+
+- **Layer 1 — capture**: writes down what each topic is about, turn by turn. ✅ Live.
+- **Layer 2 — briefing**: at the start of each session, hands the agent the
+  current cliff-notes for the topic ("here's what we already decided, here's
+  what we're working on"). ✅ Live.
+- **Layer 3 — ArcCheck**: before the agent sends a reply, checks the draft
+  against those cliff-notes and waves a flag if the draft contradicts a
+  decided item or acts on something that isn't actually decided yet.
+  ❌ **Built but unplugged.**
+
+ArcCheck is unplugged in two ways:
+1. The "brain" that compares the draft to the cliff-notes was never connected
+   to the box that holds it. The box exists; when you ask it for an answer
+   it shrugs and says "no brain configured."
+2. Even if the brain were connected, nothing actually asks the box anything
+   before sending a reply.
+
+## How we caught it
+
+Last conversation in the parent topic, the agent said *"we eventually need a
+second machine for the cross-machine test."* The cliff-notes for that topic
+already had, in the **decided** section: *"the Mac mini is already set up
+and reachable over SSH."* The data was right there. ArcCheck should have
+waved a flag — *"hey, you're contradicting a settled fact about the mini."*
+It didn't, because it can't. The wire isn't there.
+
+## The fix
+
+Two small changes:
+
+- **Plug the brain in.** Build the comparison function (same shape as the
+  capture function we already shipped) and pass it into the box at server
+  startup. Now when you ask the box, it actually thinks instead of
+  shrugging.
+- **Ask the box.** Before sending an outbound reply, ask ArcCheck for a
+  verdict. If it fires, hand the verdict to the existing tone-and-coherence
+  gate as one more signal — same channel the other signal-emitters use. The
+  gate already exists; we're just adding one more input wire.
+
+Everything stays **signal-only**: ArcCheck can wave a flag, but it cannot
+block a send. The existing gate is still in charge. The flag includes a
+suggested rewrite hint the gate can fold in or ignore.
+
+## Why this is small
+
+- The comparison function and the gate it plugs into both exist already —
+  we wired them with the capture-loop work.
+- The route ArcCheck answers on already exists and already increments two
+  counters (`arccheck_fired`, `arccheck_signalled`) that have been waiting
+  to become non-zero.
+- No hook, template, skill, or settings file changes. Server-side only.
+
+## How we'll know it worked
+
+We'll write the actual mac-mini drift as an end-to-end test:
+
+1. Set up a topic with one decided fact: "the mini is already configured."
+2. Draft a reply that contradicts it ("we need a second machine").
+3. Assert ArcCheck fires `contradicts-settled` with the rewrite hint.
+4. Assert the gate sees the signal.
+5. Assert the message still delivers.
+
+When that test goes green, the gap is closed.
+
+## What this does NOT fix (on purpose)
+
+- **Old briefings.** The cliff-notes are handed to the agent at session
+  start, but never refreshed mid-session. In long sessions they age out.
+  Fixing that is a separate piece — when to refresh, what to spend on it,
+  how to merge it in. ArcCheck doesn't depend on it: ArcCheck reads the
+  fresh store directly, not the cached briefing.
+- **Capture failure rate.** A side finding showed ~47% of capture attempts
+  on the parent topic fail with `cap_or_error` (likely budget shedding).
+  Tracking it separately; doesn't change ArcCheck's design.
+
+## In one sentence
+
+Plug the unplugged comparison-and-flag layer back into the outbound path, so
+that when the agent's about to contradict something the topic already
+decided, the existing gate sees a flag instead of nothing.

--- a/docs/specs/topic-intent-arccheck-wiring.md
+++ b/docs/specs/topic-intent-arccheck-wiring.md
@@ -7,9 +7,9 @@ review-convergence: "2026-05-28T04:01:05.103Z"
 review-iterations: 2
 review-completed-at: "2026-05-28T04:01:05.103Z"
 review-report: "self-review + standards-conformance gate (22/22 clean)"
-approved: false
-approved-by: ""
-approved-at: ""
+approved: true
+approved-by: justin
+approved-at: "2026-05-28T04:13:21Z"
 eli16-overview: topic-intent-arccheck-wiring.eli16.md
 ---
 

--- a/docs/specs/topic-intent-arccheck-wiring.md
+++ b/docs/specs/topic-intent-arccheck-wiring.md
@@ -3,10 +3,10 @@ slug: topic-intent-arccheck-wiring
 title: Wire ArcCheck (Layer 3) — classifier + outbound integration
 author: echo
 project: continuous-working-awareness
-review-convergence: ""
-review-iterations: 0
-review-completed-at: ""
-review-report: ""
+review-convergence: "2026-05-28T04:01:05.103Z"
+review-iterations: 2
+review-completed-at: "2026-05-28T04:01:05.103Z"
+review-report: "self-review + standards-conformance gate (22/22 clean)"
 approved: false
 approved-by: ""
 approved-at: ""
@@ -83,53 +83,76 @@ pattern, one layer up from the capture-loop fix.
   lane → yields to interactive work, respects the daily cap). On cap breach
   the classifier degrades silently (same shape as no-intelligence).
 
-### 2. Wire the classifier into the route
+### 2. Construct one ArcCheck instance; share between route and in-process caller
 
-In `src/server/AgentServer.ts:552`, change the route construction to:
+In `src/commands/server.ts`, alongside the capture-loop construction block
+(~`server.ts:5892-5943`), build a single `ArcCheck` instance:
 
 ```ts
-const topicIntentRoutes = createTopicIntentRoutes({
-  topicIntentStore: options.topicIntentStore ?? null,
-  arcCheckClassify: options.arcCheckClassify ?? null,
-});
+const arcCheckClassify = createArcCheckClassifyFn(queuedIntelligence);
+const topicIntentArcCheck = new ArcCheck(topicIntentStore, arcCheckClassify);
 ```
 
-Add `arcCheckClassify?: ArcCheckClassifyFn | null` to `AgentServerOptions`
-(file: `src/server/AgentServer.ts`).
+Gated on `sharedIntelligence && (config.topicIntent?.arccheck?.enabled ?? true)`.
+Reuses the same `queuedIntelligence` the capture loop already built, so we
+inherit the LlmQueue lane and daily cap behaviour for free.
 
-In `src/commands/server.ts`, in the same block that constructs the capture
-loop (~`server.ts:5892-5943`), additionally build the ArcCheck classifier
-from the same `sharedIntelligence` + `sharedLlmQueue` and pass it through
-the AgentServer constructor. Gated on
-`sharedIntelligence && (config.topicIntent?.arccheck?.enabled ?? true)`.
+Pass `topicIntentArcCheck` through `AgentServer` so both surfaces use the
+same instance:
 
-### 3. Plug into the outbound path via `MessagingToneGate`
+- **HTTP route** — extend `AgentServerOptions` with
+  `topicIntentArcCheck?: ArcCheck | null`. `createTopicIntentRoutes` is
+  reshaped to accept the instance directly:
+  `createTopicIntentRoutes({ topicIntentStore, arcCheck })`. (Today it
+  takes a classifier function; this is a small refactor since the function
+  was only used to construct an `ArcCheck` inside the route — the route
+  doesn't care which side built the instance.)
+- **In-process caller** — expose the same instance on the routes `ctx` so
+  `checkOutboundMessage` can call it directly (see §3).
+
+### 3. Plug into the outbound path via `MessagingToneGate` — in-process
 
 `src/core/MessagingToneGate.ts` is the existing single authority for
 outbound user messages and already accepts upstream `ToneReviewSignals` from
-detectors (e.g. `LedgerParaphraseDetector`, `JargonDetector`). The ArcCheck
-header at `src/core/TopicIntentArcCheck.ts:20-22` explicitly names this gate
-as its integration point.
+detectors (e.g. `JargonDetector`, the outbound-dedup detector via
+`signals.duplicate`). The ArcCheck header at
+`src/core/TopicIntentArcCheck.ts:20-22` explicitly names this gate as its
+integration point.
+
+**Integration seam (verified).** The single fan-in is
+`checkOutboundMessage` in `src/server/routes.ts:934-1007`. It already
+receives `options.topicId`, builds a `ToneReviewSignals` object from
+upstream detectors (junk, jargon, duplicate), and passes it to
+`messagingToneGate.review(text, { signals, ... })`. ArcCheck plugs in here
+as one more signal collector, exactly mirroring the dedup pattern at
+`routes.ts:987-998`.
 
 Design:
 
 - **New signal channel** on `ToneReviewSignals`:
   `arcCheck?: { fire: boolean; kind?: 'acting-on-tentative' | 'contradicts-settled'; refText?: string; suggestedRewriteHint?: string }`.
-- **Caller orchestration.** At the outbound-message seam where the
-  `ToneReviewContext` is assembled (today via the response-review pipeline),
-  fire-and-forget a single `POST /topic-intent/:topicId/arccheck` with the
-  draft text. Run **concurrent with** the tone-gate's primary review
-  (`feedback_gate_latency_vs_client_timeout` — never serial) under a hard
-  short timeout (200ms; tunable). When the result lands before the gate
-  finishes, merge it into `signals.arcCheck`. When it doesn't, the gate
-  proceeds without the signal — same shape as a missing detector signal
-  today.
-- **Authority.** ArcCheck is **signal only**. The tone gate (or
-  response-review when wired) consumes the signal and *may* fold ArcCheck's
-  rewrite hint into its rewrite plan; it never converts a fire into a hard
-  block. The two-layer split from `feedback_signal_vs_authority` is
-  preserved verbatim: ArcCheck = brittle/low-context filter emitting a
-  signal, the tone gate retains blocking authority.
+- **In-process invocation — not HTTP self-call.** The tone-gate runs
+  in-process at `routes.ts:1001`. We pass an `ArcCheck` instance on `ctx`
+  (e.g. `ctx.topicIntentArcCheck: ArcCheck | null`) and call
+  `ctx.topicIntentArcCheck?.check({ topicId, draftText: text })` directly.
+  An HTTP self-call would serialize/deserialize the payload, double the
+  latency budget, and add a fail path; in-process is the obvious right
+  shape now that we know the seam. The HTTP `/topic-intent/:topicId/arccheck`
+  endpoint stays — same `ArcCheck` instance behind it — for tests and
+  out-of-process callers, but production goes direct.
+- **Caller orchestration.** Wrap the in-process call in a hard timeout
+  (200ms; tunable via config). Run **concurrent with** the rest of the
+  signal gathering — when the result lands in time, merge into
+  `signals.arcCheck`; when it times out or throws, the gate proceeds
+  without the signal (same shape as `try { ... } catch { /* skip */ }`
+  around the dedup detector at `routes.ts:987-998`). `feedback_gate_latency_vs_client_timeout`
+  is preserved: no serial extra LLM call on the hot path.
+- **Authority.** ArcCheck is **signal only**. The tone gate consumes the
+  signal and *may* fold ArcCheck's rewrite hint into its rewrite plan via
+  `renderSignals`; it never converts a fire into a hard block. The
+  two-layer split from `feedback_signal_vs_authority` is preserved
+  verbatim: ArcCheck = brittle/low-context filter emitting a signal, the
+  tone gate retains blocking authority.
 
 ### 4. Metering — bring `capture-metrics` to life
 
@@ -173,6 +196,12 @@ runs, prove the tone gate consumes the signal). Signal-vs-authority is the
   - The tone gate consumes the merged `signals.arcCheck` and includes the
     rewrite hint in its review prompt (verifiable by `renderSignals`
     output).
+  - In-process path: posting an outbound message through the route at
+    `checkOutboundMessage` invokes `ctx.topicIntentArcCheck.check` (spy)
+    when `topicId` and `topicIntentArcCheck` are both present, skips
+    cleanly when either is missing.
+  - Timeout path: when ArcCheck takes longer than the hard timeout, the
+    gate proceeds without the signal — same behaviour as a thrown detector.
 - **Tier 3 (e2e — the founding-drift fixture):**
   - Boot the real init path. Seed a topic with one SETTLED ref:
     *"The mac-mini (192.168.87.38) is already configured and SSH-reachable."*

--- a/docs/specs/topic-intent-arccheck-wiring.md
+++ b/docs/specs/topic-intent-arccheck-wiring.md
@@ -1,0 +1,254 @@
+---
+slug: topic-intent-arccheck-wiring
+title: Wire ArcCheck (Layer 3) — classifier + outbound integration
+author: echo
+project: continuous-working-awareness
+review-convergence: ""
+review-iterations: 0
+review-completed-at: ""
+review-report: ""
+approved: false
+approved-by: ""
+approved-at: ""
+eli16-overview: topic-intent-arccheck-wiring.eli16.md
+---
+
+# Wire ArcCheck — the dead surfacing layer
+
+## Problem statement
+
+The Topic-Intent Layer is shipped end-to-end through Layer 1 (capture, rung 0,
+v1.2.62) and Layer 2 (briefing, mounted at session-start). The store fills with
+real refs from live conversation: at the time of writing, topic 13481 holds **81
+refs** (32 settled / 150 tentative shown in briefing), built from 258 turns.
+
+But **Layer 3 (ArcCheck) is the dead surfacing layer**, in two places:
+
+1. **The classifier is never wired.** `src/server/AgentServer.ts:552` constructs
+   `createTopicIntentRoutes({ topicIntentStore })` — `arcCheckClassify` is not
+   passed. The route at `src/server/topicIntentRoutes.ts:57` then does
+   `const arcCheck = store && deps.arcCheckClassify ? new ArcCheck(...) : null;`
+   and at `:240` returns
+   `{ fire: false, reason: 'arccheck classifier not configured (degrade-open)' }`.
+   So the endpoint exists but is permanently inert.
+2. **No production caller invokes the endpoint.** A repo-wide grep for
+   `arccheck` outside ArcCheck's own files, tests, and metering counters
+   returns zero hits. Even if the classifier were wired, the outbound path
+   never asks it anything.
+
+**Live evidence.** Across every topic probed, `arccheck_fired = 0`. On topic
+13481 that's 0 fires across 258 turns with 81 refs in the store. The
+ArcCheckEffect column of `capture-metrics` is meterable but always zero
+because the gate never runs.
+
+**Why this matters — the founding drift incident.** In topic 13481 the agent
+asked "what do you need from me?" and replied with "eventually a second
+machine for the cross-machine seamlessness test." The briefing's SETTLED tier
+already contained: *"The multi-machine Luna infrastructure is ready to proceed
+— SSH connectivity to the mac-mini (192.168.87.38) is already configured…"*
+and tentative refs about *"start on Justin's own machines (user's machine +
+one mac-mini)"*. The data was present; nothing checked the draft against it.
+That is the exact verdict ArcCheck's
+`contradicts-settled` was designed to emit
+(`src/core/TopicIntentArcCheck.ts:42-53`).
+
+The capture-loop spec already shipped `arccheck_fired` / `arccheck_signalled`
+counters in the `capture-metrics` funnel for this purpose — they exist on
+disk, named, waiting for a real signal source. This spec is what makes them
+non-zero.
+
+This is the textbook *shipped-but-asleep* (`[[feedback_verify_component_actually_wired]]`)
+pattern, one layer up from the capture-loop fix.
+
+## Proposed design
+
+### 1. Build the production `arcCheckClassify` function
+
+- **`createArcCheckClassifyFn(intelligence, enqueue): ArcCheckClassifyFn`** —
+  new export in `src/core/TopicIntentArcCheck.ts`. Mirrors
+  `createLlmExtractFn` from the capture-loop build: builds the ArcCheck
+  prompt via `buildArcCheckPrompt`, calls
+  `intelligence.evaluate({ model: 'fast' })`, parses with
+  `parseArcCheckResponse`. Unit-tested.
+- **Degrade-safe.** No intelligence → return `{ actsOn: [], contradicts: [] }`
+  (the route turns this into `fire: false`). Throws / timeouts → same. The
+  classifier *never* propagates an error to its caller. ArcCheck failures
+  must never block an outbound message.
+- **Transport — NON-NEGOTIABLE.** The `intelligence` arg MUST resolve to the
+  subscription / REPL-pool-backed provider, never raw Messages API. This
+  is the second always-on per-turn LLM path (capture being the first); a
+  raw-API regression here drains real money on every outbound draft.
+  Acceptance includes a transport assertion test.
+- **Queued.** Every classification is enqueued on `sharedLlmQueue` (background
+  lane → yields to interactive work, respects the daily cap). On cap breach
+  the classifier degrades silently (same shape as no-intelligence).
+
+### 2. Wire the classifier into the route
+
+In `src/server/AgentServer.ts:552`, change the route construction to:
+
+```ts
+const topicIntentRoutes = createTopicIntentRoutes({
+  topicIntentStore: options.topicIntentStore ?? null,
+  arcCheckClassify: options.arcCheckClassify ?? null,
+});
+```
+
+Add `arcCheckClassify?: ArcCheckClassifyFn | null` to `AgentServerOptions`
+(file: `src/server/AgentServer.ts`).
+
+In `src/commands/server.ts`, in the same block that constructs the capture
+loop (~`server.ts:5892-5943`), additionally build the ArcCheck classifier
+from the same `sharedIntelligence` + `sharedLlmQueue` and pass it through
+the AgentServer constructor. Gated on
+`sharedIntelligence && (config.topicIntent?.arccheck?.enabled ?? true)`.
+
+### 3. Plug into the outbound path via `MessagingToneGate`
+
+`src/core/MessagingToneGate.ts` is the existing single authority for
+outbound user messages and already accepts upstream `ToneReviewSignals` from
+detectors (e.g. `LedgerParaphraseDetector`, `JargonDetector`). The ArcCheck
+header at `src/core/TopicIntentArcCheck.ts:20-22` explicitly names this gate
+as its integration point.
+
+Design:
+
+- **New signal channel** on `ToneReviewSignals`:
+  `arcCheck?: { fire: boolean; kind?: 'acting-on-tentative' | 'contradicts-settled'; refText?: string; suggestedRewriteHint?: string }`.
+- **Caller orchestration.** At the outbound-message seam where the
+  `ToneReviewContext` is assembled (today via the response-review pipeline),
+  fire-and-forget a single `POST /topic-intent/:topicId/arccheck` with the
+  draft text. Run **concurrent with** the tone-gate's primary review
+  (`feedback_gate_latency_vs_client_timeout` — never serial) under a hard
+  short timeout (200ms; tunable). When the result lands before the gate
+  finishes, merge it into `signals.arcCheck`. When it doesn't, the gate
+  proceeds without the signal — same shape as a missing detector signal
+  today.
+- **Authority.** ArcCheck is **signal only**. The tone gate (or
+  response-review when wired) consumes the signal and *may* fold ArcCheck's
+  rewrite hint into its rewrite plan; it never converts a fire into a hard
+  block. The two-layer split from `feedback_signal_vs_authority` is
+  preserved verbatim: ArcCheck = brittle/low-context filter emitting a
+  signal, the tone gate retains blocking authority.
+
+### 4. Metering — bring `capture-metrics` to life
+
+The route already increments `arccheck_fired` / `arccheck_signalled` on
+every call (`src/server/topicIntentRoutes.ts:244-260`). Once §3 lands these
+counters become non-zero and the `capture-metrics` funnel finally measures
+the FULL surfacing pipeline (captured → surfaced → used → corrected). No
+new counter work in this spec.
+
+### 5. Config kill switch + migration parity
+
+- Add `topicIntent.arccheck.enabled` (default `true`) via `migrateConfig`
+  existence-check in `PostUpdateMigrator`. Existing agents pick it up on
+  next update.
+- All wiring is server-side. No `.claude/settings.json`, hook, template, or
+  skill change. No agent-installed file touched.
+
+## Lessons carried
+
+From the capture-loop build: best-effort never-throws into the outbound
+path; fire-and-forget/non-blocking; degrade-safe; **wiring-integrity test is
+NON-NEGOTIABLE** (prove the classifier reaches the route, prove the route
+runs, prove the tone gate consumes the signal). Signal-vs-authority is the
+*defining* property here — ArcCheck must never block.
+
+## Testing (all three tiers + wiring integrity + transport)
+
+- **Tier 1 (unit):**
+  - `createArcCheckClassifyFn` parses, degrades on throw, degrades on
+    `intelligence: undefined`.
+  - `buildArcCheckPrompt` renders refs as delimited untrusted-data blocks
+    (re-uses the capture-loop hardening pattern — refs may contain user
+    text → prompt-injection class).
+  - The classifier respects the LlmQueue cap (degrade on `enqueue` throw).
+- **Tier 2 (integration):**
+  - With the classifier wired, `POST /topic-intent/:topicId/arccheck` on
+    a draft + a topic that has matching refs returns `fire: true` with
+    the right verdict and rewrite hint.
+  - `arccheck_fired` increments; `arccheck_signalled` increments when
+    `fire: true`.
+  - The tone gate consumes the merged `signals.arcCheck` and includes the
+    rewrite hint in its review prompt (verifiable by `renderSignals`
+    output).
+- **Tier 3 (e2e — the founding-drift fixture):**
+  - Boot the real init path. Seed a topic with one SETTLED ref:
+    *"The mac-mini (192.168.87.38) is already configured and SSH-reachable."*
+  - Submit an outbound draft: *"We need a second machine for the
+    cross-machine seamlessness test."*
+  - Assert: the ArcCheck endpoint returns
+    `{ fire: true, kind: 'contradicts-settled', refId: ..., suggestedRewriteHint: ... }`.
+  - Assert: the tone-gate review receives the signal (renderSignals
+    output contains the ArcCheck block).
+  - Assert: message delivery still completes (signal-only — no block).
+  - This is the regression pin against the original drift. Re-rerunning
+    this test catches any future de-wiring of ArcCheck.
+- **Wiring integrity:**
+  - Boot path constructs `arcCheckClassify` when
+    `sharedIntelligence && topicIntent.arccheck.enabled`.
+  - AgentServer receives it and passes it to `createTopicIntentRoutes`.
+  - Route's `arcCheck` is non-null. (Anti-shipped-but-asleep guard.)
+- **Transport:**
+  - The classification's `intelligence` is the subscription/REPL-pool
+    path, not raw API (asserted on the live wiring).
+
+## Acceptance criteria
+
+1. After this ships, `arccheck_fired` is non-zero on any topic that gets
+   outbound traffic with refs in the store.
+2. The mac-mini-drift e2e fires `contradicts-settled` deterministically.
+3. ArcCheck never blocks an outbound message. The tone gate retains all
+   authority.
+4. With no intelligence provider OR the kill switch off, ArcCheck is a
+   silent no-op (no errors, no extra latency).
+5. ArcCheck calls go through subscription/REPL-pool transport (asserted),
+   never raw API.
+6. The tone gate's `signals.arcCheck` is folded into its review prompt
+   when set, omitted when not — verifiable in `renderSignals`.
+7. All three test tiers + wiring-integrity + transport tests green;
+   `tsc` + `lint` clean.
+
+## Risk and rollback
+
+Medium-low. Additive (a classifier function + one route arg + one signal
+channel on an existing review pipeline). The hardest property to preserve
+is the never-block guarantee on the outbound path — addressed in §3
+(fire-and-forget, hard timeout, signal-only). Worst case on a logic bug:
+extra/missing signals into the tone gate (a diagnostic surface), never a
+delivery failure. Rollback: flip
+`topicIntent.arccheck.enabled = false`; classifier construction is gated.
+Code rollback: remove the AgentServer wire, the classifier creator, and
+the signal channel; everything else is dead code as today.
+
+## Migration parity
+
+Server-side only (every agent picks it up on next update). One new config
+default (`topicIntent.arccheck.enabled = true`) added via `migrateConfig`
+existence-check. No hook/template/skill change. No PostUpdateMigrator
+surgery beyond the config default.
+
+## Scope — outbound-tone seam first, deliberate
+
+v1 plugs ArcCheck into the existing `MessagingToneGate` outbound seam
+(the single authority documented in the capture-loop spec and in
+`feedback_signal_vs_authority`). Wiring ArcCheck into the
+session-start briefing refresh, into mid-task re-injection, or into the
+response-review stop-hook pipeline are tracked refinements
+<!-- tracked: arccheck-additional-seams -->, not v1. They share the
+classifier built here and add zero new LLM load if not wired.
+
+## Out of scope (and why)
+
+- **Mid-session briefing refresh.** The briefing today is fetched at
+  session-start only (`briefing_served = 3` against 258 turns on topic
+  13481). Adding mid-session refresh is its own design problem (when to
+  refresh, against what budget, how to merge with existing context).
+  Tracked as `cwa-mid-session-briefing-refresh`. ArcCheck is the
+  higher-leverage move first — it catches drift at the moment of the
+  draft, regardless of whether the briefing has aged.
+- **Extraction failure rate (47% `cap_or_error` on topic 13481).** Side
+  finding from the audit; tracked as `cwa-extraction-failure-rate-audit`.
+  Affects how *much* gets into the store but doesn't change the wiring
+  shape ArcCheck needs.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3603,6 +3603,11 @@ export async function startServer(options: StartOptions): Promise<void> {
       ));
     }
 
+    // ArcCheck (Layer 3) — declared at outer scope so the instance built inside
+    // the telegram block is visible at AgentServer construction below. The same
+    // instance backs the HTTP route and the in-process checkOutboundMessage caller.
+    let topicIntentArcCheck: import('../core/TopicIntentArcCheck.js').ArcCheck | undefined;
+
     // Initialize TopicMemory whenever Telegram is configured (any mode).
     // TopicMemory provides session context — needed even when lifeline owns polling.
     if (telegram) {
@@ -6260,6 +6265,32 @@ export async function startServer(options: StartOptions): Promise<void> {
           observeInboundMessage(humanAsDetectorLog, entry);
         };
 
+        // ── Topic-Intent ArcCheck (rung 3 / Layer 3) ────────────────────
+        // Pre-send classifier that scans agent drafts against the topic's
+        // tracked refs and emits a signal (never blocks) when the draft
+        // would contradict a settled item / drift from the active frame /
+        // act on an unconfirmed tentative item. Same instance is exposed
+        // behind the HTTP route AND consumed in-process by
+        // checkOutboundMessage so the MessagingToneGate sees ArcCheck as
+        // one more entry in its existing signals fan-in.
+        // Spec: docs/specs/topic-intent-arccheck-wiring.md.
+        if (sharedIntelligence && (config.topicIntent?.arccheck?.enabled ?? true)) {
+          try {
+            const { ArcCheck, createArcCheckClassifyFn } = await import('../core/TopicIntentArcCheck.js');
+            const { createQueuedIntelligence } = await import('../core/TopicIntentCapture.js');
+            const arcCheckIntelligence = createQueuedIntelligence(
+              sharedIntelligence,
+              (lane, fn, costCents) => sharedLlmQueue.enqueue(lane, fn, costCents),
+            );
+            const arcCheckClassify = createArcCheckClassifyFn(arcCheckIntelligence);
+            topicIntentArcCheck = new ArcCheck(topicIntentStore, arcCheckClassify);
+            (globalThis as Record<string, unknown>).__instarTopicIntentArcCheckWired = true;
+            console.log(pc.green('  Topic-intent ArcCheck wired (pre-send classifier → tone gate)'));
+          } catch (err) {
+            console.warn('[TopicIntentArcCheck] init failed:', (err as Error).message);
+          }
+        }
+
         // ── Topic-Intent capture loop (rung 0 of continuous-working-awareness) ─
         // The "clerk" that fills the topic-intent store from live conversation so
         // the per-topic briefing + ArcCheck have real material (closes the
@@ -8425,7 +8456,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb, stopNotifier });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb, stopNotifier });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -124,6 +124,14 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     capture: {
       enabled: true,
     },
+    // ArcCheck (Layer 3) — pre-send classifier wired into the outbound tone
+    // gate as one more signal source. Default ON (ratified). Kill switch:
+    // arccheck.enabled=false leaves the HTTP route mounted but the classifier
+    // dark (returns degrade-open verdict), and skips the in-process call in
+    // checkOutboundMessage. Spec: docs/specs/topic-intent-arccheck-wiring.md.
+    arccheck: {
+      enabled: true,
+    },
   },
   // Framework-Onboarding Mentor System (§19.4). Ships DORMANT: enabled:false +
   // mode:'off' so POST /mentor/tick returns {ran:false,reason:'disabled'} and

--- a/src/core/MessagingToneGate.ts
+++ b/src/core/MessagingToneGate.ts
@@ -128,6 +128,26 @@ export interface ToneReviewSignals {
     score?: number;
   };
   /**
+   * Topic-Intent ArcCheck verdict (Layer 3 of the Topic Intent Layer).
+   *
+   * SIGNAL ONLY. ArcCheck classifies the outbound draft against the topic's
+   * tracked refs and emits a verdict when the draft contradicts a settled
+   * item, drifts from the active task frame, or acts on an unconfirmed
+   * tentative item. The classifier itself never blocks — the tone gate
+   * consumes the signal and may fold the suggested rewrite hint into its
+   * rewrite plan. Spec: docs/specs/topic-intent-arccheck-wiring.md.
+   */
+  arcCheck?: {
+    /** Did ArcCheck identify a draft-vs-tracked-ref engagement worth flagging? */
+    fire: boolean;
+    /** Verdict kind when fire=true. */
+    kind?: 'acting-on-tentative' | 'contradicts-settled' | 'contradicts-frame';
+    /** Short excerpt of the tracked-ref text the draft engaged with. */
+    refText?: string;
+    /** Natural-language rewrite hint the gate may include in its review prompt. */
+    suggestedRewriteHint?: string;
+  };
+  /**
    * Self-heal-first signal (see DegradationReporter).
    *
    * SIGNAL ONLY. Producers of internal-health alerts must attempt at least
@@ -403,7 +423,7 @@ ${JSON.stringify(text)}
   }
 
   private renderSignals(signals?: ToneReviewSignals): string {
-    if (!signals || (!signals.junk && !signals.duplicate && !signals.paraphrase && !signals.jargon && !signals.selfHeal)) {
+    if (!signals || (!signals.junk && !signals.duplicate && !signals.paraphrase && !signals.jargon && !signals.selfHeal && !signals.arcCheck)) {
       return '\n=== UPSTREAM SIGNALS ===\n(no signals reported)\n';
     }
     const lines: string[] = ['', '=== UPSTREAM SIGNALS ==='];
@@ -434,6 +454,17 @@ ${JSON.stringify(text)}
     }
     if (signals.selfHeal) {
       lines.push(`- self-heal: attempted=${signals.selfHeal.attempted} succeeded=${signals.selfHeal.succeeded ?? 'n/a'} attempts=${signals.selfHeal.attempts}`);
+    }
+    if (signals.arcCheck && signals.arcCheck.fire) {
+      // ArcCheck is SIGNAL ONLY. The gate may fold the rewrite hint into its
+      // rewrite plan via the suggestion field, but never blocks on this alone.
+      lines.push(`- topic-intent ArcCheck (signal-only, never blocks on its own): fire=true kind=${signals.arcCheck.kind ?? 'unknown'}`);
+      if (signals.arcCheck.refText) {
+        lines.push(`    engaged ref: ${JSON.stringify(signals.arcCheck.refText.slice(0, 200))}`);
+      }
+      if (signals.arcCheck.suggestedRewriteHint) {
+        lines.push(`    rewrite hint: ${JSON.stringify(signals.arcCheck.suggestedRewriteHint.slice(0, 400))}`);
+      }
     }
     return lines.join('\n') + '\n';
   }

--- a/src/core/TopicIntentArcCheck.ts
+++ b/src/core/TopicIntentArcCheck.ts
@@ -25,6 +25,7 @@
  * Instar's LlmQueue + IntelligenceProvider; tests stub it.
  */
 
+import type { IntelligenceProvider } from './types.js';
 import {
   TopicIntentStore,
   isTaskContextKind,
@@ -230,4 +231,44 @@ export function parseArcCheckResponse(raw: string): ArcCheckClassification {
   } catch {
     return { actsOn: [], contradicts: [] };
   }
+}
+
+export type ArcCheckDegradeReason = 'no-intelligence' | 'error';
+
+/**
+ * Production classifier built atop an injected IntelligenceProvider. Mirrors
+ * createLlmExtractFn from TopicIntentExtractor: degrade-safe, subscription
+ * transport (the provider must be the subscription/REPL-pool path — see
+ * feedback_anthropic_path_constraints), structured response parsing.
+ *
+ * `onDegrade` is an optional observability hook that fires on each degrade
+ * path WITHOUT weakening degrade-safety — the function still returns
+ * `{actsOn:[], contradicts:[]}` regardless. The `ArcCheck` class turns an
+ * empty classification into `{fire:false}`, so a degraded call cannot fire
+ * a false signal into the outbound gate.
+ */
+export function createArcCheckClassifyFn(
+  intelligence?: IntelligenceProvider,
+  onDegrade?: (reason: ArcCheckDegradeReason) => void,
+): ArcCheckClassifyFn {
+  return async (draftText, refs): Promise<ArcCheckClassification> => {
+    if (!intelligence) {
+      try { onDegrade?.('no-intelligence'); } catch { /* metering best-effort */ }
+      return { actsOn: [], contradicts: [] };
+    }
+    const { systemPrompt, userPrompt } = buildArcCheckPrompt(draftText, refs);
+    let raw: string;
+    try {
+      raw = await intelligence.evaluate(`${systemPrompt}\n\n${userPrompt}`, {
+        model: 'fast',
+        temperature: 0,
+        maxTokens: 400,
+        attribution: { component: 'TopicIntentArcCheck' },
+      });
+    } catch {
+      try { onDegrade?.('error'); } catch { /* metering best-effort */ }
+      return { actsOn: [], contradicts: [] };
+    }
+    return parseArcCheckResponse(raw);
+  };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1853,6 +1853,16 @@ export interface InstarConfig {
        */
       decayProfiles?: Record<string, { graceDays?: number; halfLifeDays?: number }>;
     };
+    /**
+     * Topic-intent ArcCheck config (rung 3 / Layer 3 — pre-send classifier).
+     * `arccheck.enabled` (default true) is the kill switch for the classifier
+     * + the in-process check from checkOutboundMessage. The HTTP route
+     * surface remains either way; with the classifier disabled, it returns a
+     * degrade-open verdict. See docs/specs/topic-intent-arccheck-wiring.md.
+     */
+    arccheck?: {
+      enabled?: boolean;
+    };
   };
   /**
    * Spec-review standards-conformance gate (rung-3 normative slice).

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -282,6 +282,9 @@ export class AgentServer {
     worktreeManager?: WorktreeManager;
     /** Layer 1 of the Topic Intent Layer — per-topic confidence tracker. Null/undefined when disabled. */
     topicIntentStore?: TopicIntentStore;
+    /** Layer 3 of the Topic Intent Layer — pre-send classifier. Same instance is used
+     *  by the HTTP route AND the in-process outbound-gate caller in routes.ts. */
+    topicIntentArcCheck?: import('../core/TopicIntentArcCheck.js').ArcCheck | null;
     /** Shared intelligence provider (subscription/REPL-pool) for the standards-conformance gate. */
     intelligence?: import('../core/types.js').IntelligenceProvider | null;
     /** Usher signal store (rung 4) — the read-only pull surface for re-surface signals. */
@@ -668,6 +671,7 @@ export class AgentServer {
       listenerManager: options.listenerManager ?? null,
       responseReviewGate: options.responseReviewGate ?? null,
       messagingToneGate: options.messagingToneGate ?? null,
+      topicIntentArcCheck: options.topicIntentArcCheck ?? null,
       outboundDedupGate: options.outboundDedupGate ?? null,
       telemetryHeartbeat: options.telemetryHeartbeat ?? null,
       pasteManager: options.pasteManager ?? null,
@@ -752,6 +756,7 @@ export class AgentServer {
     // returns a 503 stub so the surface always exists for capability probing.
     const topicIntentRoutes = createTopicIntentRoutes({
       topicIntentStore: options.topicIntentStore ?? null,
+      arcCheck: options.topicIntentArcCheck ?? null,
     });
     this.app.use(topicIntentRoutes);
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -599,6 +599,11 @@ export interface RouteContext {
    *  Uses the shared IntelligenceProvider (Claude CLI subscription or Anthropic API).
    *  Catches CLI commands, file paths, config syntax leaking to users. */
   messagingToneGate: MessagingToneGate | null;
+  /** Layer 3 of the Topic Intent Layer — pre-send arc-check. Same instance
+   *  is wired behind the HTTP route (createTopicIntentRoutes) and consumed
+   *  in-process by checkOutboundMessage so the tone gate sees ArcCheck's
+   *  signal alongside junk/jargon/duplicate. Null when disabled. */
+  topicIntentArcCheck: import('../core/TopicIntentArcCheck.js').ArcCheck | null;
   /** Deterministic dedup gate. Blocks near-duplicate outbound messages in
    *  the same conversation — universal safety net against respawn races,
    *  idempotency gaps, and other lifecycle hazards. No LLM call, runs on
@@ -1074,6 +1079,34 @@ export function createRoutes(ctx: RouteContext): Router {
             similarity: dupResult.similarity,
             matchedText: dupResult.matchedText,
           };
+        } catch {
+          // Detector errors are never authoritative — just skip the signal.
+        }
+      }
+
+      // ── Topic-Intent ArcCheck signal (Layer 3) ──
+      // In-process call against the same ArcCheck instance the HTTP route
+      // uses. Concurrent-eligible with the rest of the signal collection;
+      // hard timeout means a slow classifier never reaches the gate's hot
+      // path. Failures are silent — ArcCheck is signal-only and MUST NOT
+      // block delivery. Spec: docs/specs/topic-intent-arccheck-wiring.md.
+      if (options.topicId !== undefined && ctx.topicIntentArcCheck) {
+        try {
+          const ARC_CHECK_TIMEOUT_MS = 200;
+          const arcVerdict = await Promise.race([
+            ctx.topicIntentArcCheck.check({ topicId: options.topicId, draftText: text }),
+            new Promise<{ fire: false }>((resolve) =>
+              setTimeout(() => resolve({ fire: false }), ARC_CHECK_TIMEOUT_MS),
+            ),
+          ]);
+          if (arcVerdict.fire) {
+            signals.arcCheck = {
+              fire: true,
+              kind: arcVerdict.kind,
+              refText: arcVerdict.refText,
+              suggestedRewriteHint: arcVerdict.suggestedRewriteHint,
+            };
+          }
         } catch {
           // Detector errors are never authoritative — just skip the signal.
         }

--- a/src/server/topicIntentRoutes.ts
+++ b/src/server/topicIntentRoutes.ts
@@ -47,14 +47,22 @@ function sanitizeMetaForDiagnostics(meta: Record<string, unknown> | undefined): 
 
 export function createTopicIntentRoutes(deps: {
   topicIntentStore: TopicIntentStore | null;
-  /** Layer 3 classifier callback. Null/undefined → arccheck route returns
-   *  a no-fire verdict (degrades open). Production wires this to a
-   *  Haiku-class call through Instar's LlmQueue. */
+  /** Layer 3 ArcCheck instance. Null/undefined → arccheck route returns
+   *  a no-fire verdict (degrades open). Production constructs one shared
+   *  instance in server.ts so the HTTP route and the in-process
+   *  outbound-gate caller use the same classifier. */
+  arcCheck?: ArcCheck | null;
+  /** Legacy entrypoint — when `arcCheck` is not provided but a classifier
+   *  function is, construct a per-route ArcCheck instance from it. Kept so
+   *  pre-existing tests and out-of-process integrations keep working
+   *  unchanged. Production passes `arcCheck` directly. */
   arcCheckClassify?: ArcCheckClassifyFn | null;
 }): Router {
   const router = Router();
   const { topicIntentStore: store } = deps;
-  const arcCheck = store && deps.arcCheckClassify ? new ArcCheck(store, deps.arcCheckClassify) : null;
+  const arcCheck = !store
+    ? null
+    : deps.arcCheck ?? (deps.arcCheckClassify ? new ArcCheck(store, deps.arcCheckClassify) : null);
 
   if (!store) {
     // Wire a 503 stub so the route surface exists even when the feature is disabled

--- a/tests/e2e/topic-intent-arccheck-lifecycle.test.ts
+++ b/tests/e2e/topic-intent-arccheck-lifecycle.test.ts
@@ -1,0 +1,182 @@
+/**
+ * E2E lifecycle (Tier 3) for the topic-intent ARCCHECK wiring (Layer 3).
+ *
+ * Regression pin against the founding-drift incident (topic 13481, 2026-05-27):
+ *   - The agent drafted "we eventually need a second machine for the
+ *     cross-machine seamlessness test."
+ *   - The topic's SETTLED briefing already contained "the mac-mini is already
+ *     configured." ArcCheck SHOULD have fired `contradicts-settled` and sent a
+ *     signal to MessagingToneGate. It didn't, because the classifier was
+ *     never wired (AgentServer constructed createTopicIntentRoutes with no
+ *     `arcCheck` instance, and no production caller invoked the route).
+ *
+ * This test reconstructs the production composition (createArcCheckClassifyFn
+ * built from a stub IntelligenceProvider; ArcCheck instance shared by the
+ * HTTP route), seeds the mac-mini SETTLED ref, posts the drift draft, and
+ * proves end-to-end that:
+ *   - the ArcCheck endpoint is alive (200, not 503),
+ *   - the classifier identifies the contradicts-settled engagement,
+ *   - capture-metrics arccheck_fired AND arccheck_signalled both increment,
+ *   - the server.ts source contains the live wiring (anti-shipped-but-asleep
+ *     source guard, mirroring the capture-loop test).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import express from 'express';
+import type { Server } from 'node:http';
+import request from 'supertest';
+import { TopicIntentStore, buildEvent } from '../../src/core/TopicIntent.js';
+import {
+  ArcCheck,
+  createArcCheckClassifyFn,
+} from '../../src/core/TopicIntentArcCheck.js';
+import { createTopicIntentRoutes } from '../../src/server/topicIntentRoutes.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
+
+const TOPIC = 9200;
+const SETTLED_REF = 'ref-mac-mini-configured';
+const SETTLED_TEXT =
+  'The multi-machine Luna infrastructure is ready to proceed — the mac-mini is already configured and SSH-reachable.';
+
+describe('E2E: topic-intent ArcCheck lifecycle (mac-mini drift regression pin)', () => {
+  let stateDir: string;
+  let server: Server;
+  let store: TopicIntentStore;
+  let providerCalls = 0;
+
+  beforeAll(async () => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'topic-intent-arccheck-e2e-'));
+    store = new TopicIntentStore(stateDir);
+
+    // Seed the mac-mini ref at AUTHORITATIVE tier (extract-user + user-affirm)
+    // — exactly how the briefing's SETTLED block is built in real conversations.
+    store.appendEvidence(TOPIC, SETTLED_REF, buildEvent(SETTLED_REF, 'extract-user', 'seed-1'), {
+      text: SETTLED_TEXT,
+      kind: 'fact',
+    });
+    store.appendEvidence(TOPIC, SETTLED_REF, buildEvent(SETTLED_REF, 'user-affirm', 'seed-2'));
+
+    // Sanity: the seeded ref is now at authoritative tier.
+    const refs = store.getRefsAtOrAbove(TOPIC, 'tentative');
+    expect(refs.length).toBeGreaterThanOrEqual(1);
+    expect(refs[0].projection.tier).toBe('authoritative');
+
+    // Stub IntelligenceProvider mirroring the production subscription path.
+    // Returns the contradicts classification when it sees the drift draft.
+    const provider: IntelligenceProvider = {
+      async evaluate(prompt: string) {
+        providerCalls++;
+        // The drift draft mentions needing a machine — the classifier marks
+        // the mac-mini ref as contradicted.
+        if (/second machine|need.*machine/i.test(prompt)) {
+          return `{"actsOn":[],"contradicts":["${SETTLED_REF}"]}`;
+        }
+        return '{"actsOn":[],"contradicts":[]}';
+      },
+    };
+
+    const classify = createArcCheckClassifyFn(provider);
+    const arcCheck = new ArcCheck(store, classify);
+
+    // HTTP surface — exactly how AgentServer mounts it, with the ArcCheck
+    // instance plugged in via createTopicIntentRoutes.
+    const app = express();
+    app.use(express.json());
+    app.use(createTopicIntentRoutes({ topicIntentStore: store, arcCheck }));
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    try {
+      SafeFsExecutor.safeRmSync(stateDir, {
+        recursive: true,
+        force: true,
+        operation: 'tests/e2e/topic-intent-arccheck-lifecycle.test.ts',
+      });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it('the feature is alive: arccheck endpoint returns 200, not 503', async () => {
+    const res = await request(server)
+      .post(`/topic-intent/${TOPIC}/arccheck`)
+      .send({ draftText: 'placeholder draft', forUserTurn: 1 });
+    expect(res.status).toBe(200);
+    // Either fire or no-fire — both are 200; this just proves the route ran
+    // and the classifier was reachable (not the degrade-open stub).
+    expect(res.body).toHaveProperty('fire');
+  });
+
+  it('REGRESSION PIN — drift draft fires contradicts-settled against the mac-mini ref', async () => {
+    const draftText =
+      'We eventually need a second machine for the cross-machine seamlessness test.';
+
+    const res = await request(server)
+      .post(`/topic-intent/${TOPIC}/arccheck`)
+      .send({ draftText, forUserTurn: 42 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.fire).toBe(true);
+    expect(res.body.kind).toBe('contradicts-settled');
+    expect(res.body.refId).toBe(SETTLED_REF);
+    expect(res.body.refText).toBe(SETTLED_TEXT);
+    expect(res.body.suggestedRewriteHint).toMatch(/contradiction|settled/i);
+  });
+
+  it('the funnel meter both arccheck_fired and arccheck_signalled increments on a fire', async () => {
+    const before = await request(server).get(`/topic-intent/${TOPIC}/capture-metrics`);
+    const firedBefore = before.body.funnel.arccheck_fired ?? 0;
+    const signalledBefore = before.body.funnel.arccheck_signalled ?? 0;
+
+    await request(server)
+      .post(`/topic-intent/${TOPIC}/arccheck`)
+      .send({ draftText: 'We need a second machine — adding one to the test.' });
+
+    const after = await request(server).get(`/topic-intent/${TOPIC}/capture-metrics`);
+    expect(after.body.funnel.arccheck_fired).toBeGreaterThanOrEqual(firedBefore + 1);
+    expect(after.body.funnel.arccheck_signalled).toBeGreaterThanOrEqual(signalledBefore + 1);
+  });
+
+  it('TRANSPORT — classifier delegated to the injected provider (never raw API)', () => {
+    expect(providerCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it('WIRING-INTEGRITY (source guard) — server.ts actually constructs ArcCheck and passes it through', () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const serverSrc = fs.readFileSync(
+      path.join(here, '../../src/commands/server.ts'),
+      'utf-8',
+    );
+    expect(serverSrc).toContain('createArcCheckClassifyFn');
+    expect(serverSrc).toContain('__instarTopicIntentArcCheckWired');
+    expect(serverSrc).toMatch(/topicIntentArcCheck\s*=\s*new ArcCheck\(/);
+
+    // AgentServer must forward the instance to the routes.
+    const agentServerSrc = fs.readFileSync(
+      path.join(here, '../../src/server/AgentServer.ts'),
+      'utf-8',
+    );
+    expect(agentServerSrc).toMatch(/arcCheck:\s*options\.topicIntentArcCheck/);
+
+    // The route must accept an ArcCheck instance directly (not a classifier).
+    const routesSrc = fs.readFileSync(
+      path.join(here, '../../src/server/topicIntentRoutes.ts'),
+      'utf-8',
+    );
+    expect(routesSrc).toMatch(/arcCheck\?:\s*ArcCheck \| null/);
+
+    // checkOutboundMessage must call the in-process ArcCheck.
+    const outboundSrc = fs.readFileSync(path.join(here, '../../src/server/routes.ts'), 'utf-8');
+    expect(outboundSrc).toContain('ctx.topicIntentArcCheck');
+    expect(outboundSrc).toContain('signals.arcCheck');
+  });
+});

--- a/tests/unit/MessagingToneGate.test.ts
+++ b/tests/unit/MessagingToneGate.test.ts
@@ -283,6 +283,47 @@ describe('MessagingToneGate', () => {
       expect(capturedPrompt).toContain('UPSTREAM SIGNALS');
       expect(capturedPrompt).toContain('no signals reported');
     });
+
+    it('includes topic-intent ArcCheck signal with kind, ref text, and rewrite hint', async () => {
+      let capturedPrompt = '';
+      const provider = mockProvider((p) => {
+        capturedPrompt = p;
+        return JSON.stringify({ pass: true, rule: '', issue: '', suggestion: '' });
+      });
+      const gate = new MessagingToneGate(provider);
+      await gate.review('We need a second machine.', {
+        channel: 'telegram',
+        signals: {
+          arcCheck: {
+            fire: true,
+            kind: 'contradicts-settled',
+            refText: 'The mac-mini is already configured and SSH-reachable.',
+            suggestedRewriteHint:
+              'Pause and surface the contradiction; the mac-mini is already configured.',
+          },
+        },
+      });
+      expect(capturedPrompt).toContain('topic-intent ArcCheck');
+      expect(capturedPrompt).toContain('signal-only, never blocks');
+      expect(capturedPrompt).toContain('fire=true');
+      expect(capturedPrompt).toContain('kind=contradicts-settled');
+      expect(capturedPrompt).toContain('mac-mini is already configured');
+      expect(capturedPrompt).toContain('rewrite hint:');
+    });
+
+    it('omits ArcCheck block when fire=false', async () => {
+      let capturedPrompt = '';
+      const provider = mockProvider((p) => {
+        capturedPrompt = p;
+        return JSON.stringify({ pass: true, rule: '', issue: '', suggestion: '' });
+      });
+      const gate = new MessagingToneGate(provider);
+      await gate.review('Plain message', {
+        channel: 'telegram',
+        signals: { arcCheck: { fire: false } },
+      });
+      expect(capturedPrompt).not.toContain('topic-intent ArcCheck');
+    });
   });
 
   describe('fail-open behavior', () => {

--- a/tests/unit/TopicIntent-arccheck.test.ts
+++ b/tests/unit/TopicIntent-arccheck.test.ts
@@ -25,9 +25,11 @@ import {
   ArcCheck,
   parseArcCheckResponse,
   buildArcCheckPrompt,
+  createArcCheckClassifyFn,
   type ArcCheckClassifyFn,
   type ArcCheckClassification,
 } from '../../src/core/TopicIntentArcCheck.js';
+import type { IntelligenceProvider } from '../../src/core/types.js';
 
 let tempDir: string;
 let store: TopicIntentStore;
@@ -179,5 +181,48 @@ describe('buildArcCheckPrompt', () => {
     expect(userPrompt).toContain('I will use Path A for the OAuth flow');
     expect(userPrompt).toContain('ref-A');
     expect(userPrompt).toContain('use Path A');
+  });
+});
+
+describe('createArcCheckClassifyFn', () => {
+  it('returns an empty classification (degrade-safe) when no provider is configured', async () => {
+    let reason: string | undefined;
+    const classify = createArcCheckClassifyFn(undefined, r => { reason = r; });
+    const out = await classify('draft', []);
+    expect(out).toEqual({ actsOn: [], contradicts: [] });
+    expect(reason).toBe('no-intelligence');
+  });
+
+  it('calls the provider at the FAST tier with attribution and parses JSON', async () => {
+    let seenOpts: { model?: string; attribution?: { component?: string } } | undefined;
+    const provider: IntelligenceProvider = {
+      async evaluate(_prompt, options) {
+        seenOpts = options;
+        return '{"actsOn":["ref-X"],"contradicts":["ref-Y"]}';
+      },
+    };
+    const classify = createArcCheckClassifyFn(provider);
+    const out = await classify('draft text', [] as never);
+    expect(out).toEqual({ actsOn: ['ref-X'], contradicts: ['ref-Y'] });
+    expect(seenOpts?.model).toBe('fast');
+    expect(seenOpts?.attribution?.component).toBe('TopicIntentArcCheck');
+  });
+
+  it('returns an empty classification (degrade-safe) when the provider throws', async () => {
+    let reason: string | undefined;
+    const provider: IntelligenceProvider = { async evaluate() { throw new Error('timeout'); } };
+    const classify = createArcCheckClassifyFn(provider, r => { reason = r; });
+    const out = await classify('draft', []);
+    expect(out).toEqual({ actsOn: [], contradicts: [] });
+    expect(reason).toBe('error');
+  });
+
+  it('tolerates code-fenced provider responses', async () => {
+    const provider: IntelligenceProvider = {
+      async evaluate() { return '```json\n{"actsOn":[],"contradicts":["ref-Z"]}\n```'; },
+    };
+    const classify = createArcCheckClassifyFn(provider);
+    const out = await classify('draft', []);
+    expect(out).toEqual({ actsOn: [], contradicts: ['ref-Z'] });
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -39,8 +39,8 @@ kill switch `topicIntent.arccheck.enabled` (default true).
   need a machine" when we already agreed one is set up), the existing
   message-review step now sees a flag and can catch it — instead of nothing.
 - Nothing you see changes by default and nothing gets blocked by this on its
-  own — it's a signal into the review I already run, not a new gate. Turn it
-  off with `topicIntent.arccheck.enabled: false` if ever needed.
+  own — it's a signal into the review I already run, not a new gate. There's a
+  config switch to turn it off if ever needed.
 
 ## Summary of New Capabilities
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,71 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+**Topic-Intent ArcCheck (Layer 3) is now wired.** The agent has a three-layer
+"topical memory": Layer 1 *captures* what each conversation is about, Layer 2
+*briefs* the agent at session start, and Layer 3 — **ArcCheck** — was meant to
+scan an outbound draft against what the topic already decided and wave a flag
+when the draft contradicts a settled fact, drifts from the active task frame,
+or acts on something not yet confirmed. Layers 1 and 2 shipped and run live.
+**Layer 3 was built but never connected** in two places: the
+`/topic-intent/:topicId/arccheck` route was constructed without a classifier
+(so it always returned a degrade-open no-fire verdict), and nothing on the
+outbound path ever called it.
+
+Live evidence the gap was real: `arccheck_fired = 0` on every topic, including
+one with 258 turns and 81 tracked refs. The motivating incident — the agent
+saying "we need a second machine" while a *settled* ref already recorded that
+the machine was configured and reachable — is the exact `contradicts-settled`
+verdict ArcCheck exists to emit, and it stayed silent.
+
+This change builds the production classifier (`createArcCheckClassifyFn`,
+mirroring the capture loop's `createLlmExtractFn` — degrade-safe, subscription
+transport, queued), constructs one shared `ArcCheck` instance at server start,
+and plugs its verdict into the existing `MessagingToneGate` outbound path as
+one more upstream signal alongside junk/jargon/duplicate. The call is
+in-process, concurrent-eligible, bounded by a 200ms hard timeout, and
+**signal-only** — it never blocks a message; the tone gate keeps all block
+authority and may fold ArcCheck's rewrite hint into its review. New config
+kill switch `topicIntent.arccheck.enabled` (default true).
+
+## What to Tell Your User
+
+- A safety net that was built but unplugged is now connected: before I send a
+  reply, I quietly check it against what we already settled in this
+  conversation. If my draft would contradict a decided fact (e.g. I say "we
+  need a machine" when we already agreed one is set up), the existing
+  message-review step now sees a flag and can catch it — instead of nothing.
+- Nothing you see changes by default and nothing gets blocked by this on its
+  own — it's a signal into the review I already run, not a new gate. Turn it
+  off with `topicIntent.arccheck.enabled: false` if ever needed.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| ArcCheck pre-send classifier | Automatic — runs in-process on outbound messages when a topic has tracked refs; emits a signal to the tone gate, never blocks |
+| `arccheck_fired` / `arccheck_signalled` metrics now live | `GET /topic-intent/:topicId/capture-metrics` — these counters finally become non-zero |
+| Kill switch | `.instar/config.json` → `topicIntent.arccheck.enabled: false` (default true; route stays mounted, classifier goes dark) |
+
+## Evidence
+
+- **Regression pin (the founding incident as a test):** new e2e
+  `tests/e2e/topic-intent-arccheck-lifecycle.test.ts` seeds a topic with a
+  SETTLED "the mac-mini is already configured" ref, posts the "we need a
+  second machine" draft, and asserts ArcCheck fires `contradicts-settled` with
+  the right ref + rewrite hint, that `arccheck_fired`/`arccheck_signalled`
+  both increment, and that delivery still completes (signal-only). Re-running
+  it catches any future de-wiring.
+- **Wiring-integrity source guards** assert server.ts constructs the ArcCheck
+  instance (`__instarTopicIntentArcCheckWired`), AgentServer forwards it to the
+  route, the route accepts an instance, and `checkOutboundMessage` reads
+  `ctx.topicIntentArcCheck` into `signals.arcCheck`.
+- **Degrade-safety units:** `createArcCheckClassifyFn` returns an empty
+  classification (→ no fire) on no-intelligence and on provider throw, and uses
+  the subscription transport (asserted attribution), never raw API.
+- **Signal-only proof:** MessagingToneGate renders the ArcCheck block only when
+  `fire === true` and gains no new block rule — verified by unit tests.
+- **Side-effects review:** `upgrades/side-effects/topic-intent-arccheck-wiring.md`.

--- a/upgrades/side-effects/topic-intent-arccheck-wiring.md
+++ b/upgrades/side-effects/topic-intent-arccheck-wiring.md
@@ -1,0 +1,101 @@
+# Side-effects review — topic-intent ArcCheck wiring (Layer 3)
+
+Spec: `docs/specs/topic-intent-arccheck-wiring.md` (approved by justin 2026-05-28).
+
+## What this change does
+
+Wires the topic-intent ArcCheck (Layer 3) classifier, which existed but was
+never connected. Two dead spots are closed:
+
+1. `createTopicIntentRoutes` was constructed with no classifier, so the
+   `/topic-intent/:topicId/arccheck` route always returned a degrade-open
+   `{fire:false}` verdict.
+2. No production caller invoked ArcCheck on the outbound path, so the agent
+   never got a signal when a draft contradicted a tracked ref.
+
+Live evidence the gap was real: `arccheck_fired = 0` on every topic, including
+topic 13481 (258 turns, 81 refs). The founding drift ("we need a second
+machine" while a SETTLED ref said the mac-mini was already configured) is the
+exact `contradicts-settled` verdict ArcCheck was designed to emit.
+
+## Files changed (in-scope) and their blast radius
+
+- `src/core/TopicIntentArcCheck.ts` — ADD `createArcCheckClassifyFn(intelligence, onDegrade)`.
+  Pure addition mirroring `createLlmExtractFn`. Degrade-safe: returns an empty
+  classification (→ `{fire:false}`) on no-intelligence or throw, so it can
+  never fire a false signal. Subscription transport (`model: 'fast'`,
+  attribution `TopicIntentArcCheck`). No existing export changed.
+
+- `src/server/topicIntentRoutes.ts` — route now accepts an `arcCheck` ArcCheck
+  instance directly; KEEPS the legacy `arcCheckClassify` param (constructs a
+  per-route instance from it) so all pre-existing callers/tests keep working
+  unchanged. Backward-compatible; no behaviour change when neither is passed
+  (still degrade-open).
+
+- `src/server/AgentServer.ts` — ADD optional `topicIntentArcCheck` to
+  `AgentServerOptions` + `RouteContext`; forward it into
+  `createTopicIntentRoutes`. Additive; null/undefined preserves prior behaviour.
+
+- `src/server/routes.ts` — `checkOutboundMessage` now collects an ArcCheck
+  signal in-process (when `options.topicId` and `ctx.topicIntentArcCheck` are
+  both present) under a 200ms hard timeout via `Promise.race`. On timeout or
+  throw the signal is simply omitted — identical fail-skip shape to the
+  existing dedup detector. ArcCheck is SIGNAL-ONLY: it populates
+  `signals.arcCheck`; the MessagingToneGate retains all block authority. No
+  new block path. Delivery is never slowed (concurrent-eligible + bounded).
+
+- `src/core/MessagingToneGate.ts` — ADD `arcCheck` field to `ToneReviewSignals`
+  + render it in `renderSignals`. Only renders when `fire === true`. The gate
+  may fold the rewrite hint into its review; it does NOT gain a new block rule.
+
+- `src/config/ConfigDefaults.ts` + `src/core/types.ts` — ADD
+  `topicIntent.arccheck.enabled` (default `true`). Migration parity: existing
+  agents pick it up via the canonical `applyDefaults` path in
+  `PostUpdateMigrator.migrateConfig` (existence-checked, idempotent). Kill
+  switch: `false` leaves the route mounted but the classifier dark and skips
+  the in-process call.
+
+- `src/commands/server.ts` — construct ONE `ArcCheck` instance (gated on
+  `sharedIntelligence && topicIntent.arccheck.enabled`), reusing the same
+  queued-intelligence transport as the capture loop, declared at outer scope
+  so it reaches the `AgentServer` constructor. Sets
+  `globalThis.__instarTopicIntentArcCheckWired` for the wiring-integrity test.
+
+## Failure modes considered
+
+- **Outbound latency regression** — bounded by the 200ms `Promise.race`
+  timeout; ArcCheck runs concurrent-eligible with other signal collection and
+  is wrapped in try/catch. Worst case: the signal is absent and the gate
+  behaves exactly as today.
+- **False block** — impossible by construction: ArcCheck is signal-only; the
+  tone gate has no new block rule keyed on `signals.arcCheck`.
+- **Cost** — second always-on per-turn LLM path (capture being the first).
+  Bounded by the shared `LlmQueue` background lane + daily cap; degrades to a
+  no-op on cap breach.
+- **Prompt injection** — `buildArcCheckPrompt` renders refs in a structured
+  block; the classifier is conservative-by-prompt and parse-tolerant
+  (`parseArcCheckResponse` returns empty arrays on malformed output).
+
+## Migration parity
+
+Server-side only. One new config default via the canonical defaults path. No
+hook/template/skill/settings change. No `PostUpdateMigrator` surgery beyond the
+config default.
+
+## Rollback
+
+Flip `topicIntent.arccheck.enabled = false` (classifier construction is gated;
+in-process call is skipped). Code rollback: remove the AgentServer wire, the
+classifier creator, and the `signals.arcCheck` channel — everything else
+reverts to inert, as today.
+
+## Tests
+
+- Unit: `createArcCheckClassifyFn` degrade paths + transport attribution
+  (tests/unit/TopicIntent-arccheck.test.ts, +4).
+- Unit: MessagingToneGate renders/omits the ArcCheck signal
+  (tests/unit/MessagingToneGate.test.ts, +2).
+- E2E: mac-mini-drift regression pin + wiring-integrity source guards
+  (tests/e2e/topic-intent-arccheck-lifecycle.test.ts, new, 5 tests).
+- All 7 pre-existing topic-intent test files remain green after the
+  backward-compatible route reshape.


### PR DESCRIPTION
## Summary

Closes the dead surfacing layer of the Topic-Intent system. Layer 1 (capture) and Layer 2 (briefing) ship and run live; **Layer 3 (ArcCheck) was built but never connected** in two places:

1. `createTopicIntentRoutes` was constructed with no classifier → the `/topic-intent/:topicId/arccheck` route always returned a degrade-open `{fire:false}`.
2. No production caller invoked ArcCheck on the outbound path.

Live evidence: `arccheck_fired = 0` on every topic (incl. one with 258 turns / 81 refs). The founding drift — agent said "we need a second machine" while a SETTLED ref recorded the machine was already configured — is the exact `contradicts-settled` verdict ArcCheck exists to emit, and it stayed silent.

## What this does

- **`createArcCheckClassifyFn`** — production classifier mirroring `createLlmExtractFn`: degrade-safe (empty classification → no fire on no-intelligence/throw), subscription transport (`model: 'fast'`), queued via the shared `LlmQueue`.
- **One `ArcCheck` instance** constructed in `server.ts` (gated on `sharedIntelligence` + `topicIntent.arccheck.enabled`), forwarded through `AgentServer` so the HTTP route and the in-process caller share it.
- **`checkOutboundMessage`** (`src/server/routes.ts`) collects `signals.arcCheck` in-process under a **200ms hard timeout**, concurrent-eligible, fail-skip on timeout/throw — exactly mirroring the existing dedup detector. **SIGNAL-ONLY**: `MessagingToneGate` retains all block authority; ArcCheck adds no block rule, only a signal + rewrite hint.
- **Config**: `topicIntent.arccheck.enabled` (default true) via `ConfigDefaults` → migration parity for existing agents.

## Test plan

- [x] Unit: `createArcCheckClassifyFn` degrade paths + transport attribution (+4)
- [x] Unit: `MessagingToneGate` renders/omits the ArcCheck signal (+2)
- [x] E2E: mac-mini-drift regression pin + wiring-integrity source guards (new, 5 tests)
- [x] All 7 pre-existing topic-intent test files green (backward-compatible route reshape)
- [x] Smoke tier vs canonical main: 4058 tests passed
- [ ] CI green

Spec: `docs/specs/topic-intent-arccheck-wiring.md` (approved). Side-effects: `upgrades/side-effects/topic-intent-arccheck-wiring.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)