### PR TITLE
ci(publish): post-publish smoke gate (MM-Bootstrap Track A, re-scoped)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,6 +172,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Post-publish smoke test (clean install + --version)
+        if: steps.guide-check.outputs.skip != 'true' && steps.tier-gate.outputs.skip != 'true'
+        run: node scripts/post-publish-smoke.mjs "${{ steps.bump.outputs.version }}"
+
       - name: Commit version bump & tag
         if: steps.guide-check.outputs.skip != 'true' && steps.tier-gate.outputs.skip != 'true'
         env:

--- a/scripts/post-publish-smoke.mjs
+++ b/scripts/post-publish-smoke.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * post-publish-smoke.mjs — regression gate that a freshly-published instar
+ * tarball actually installs + runs.
+ *
+ * Track A of MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS (re-scoped). The 2026-05-27
+ * "empty dist" scare turned out to be self-inflicted (an rsync --delete), NOT a
+ * publish bug — the published tarball was complete. So this is NOT fixing an
+ * active bug; it's cheap regression insurance: if the publish pipeline EVER
+ * ships a tarball missing its compiled output, this catches it within minutes
+ * of release instead of when an agent's fresh install fails in the wild.
+ *
+ * What it does (in CI, right after `npm publish`):
+ *   1. Wait for npm to propagate the just-published version (bounded retry).
+ *   2. `npm install instar@<version>` into a throwaway prefix.
+ *   3. Run the installed `dist/cli.js --version`.
+ *   4. Assert it reports <version>. Exit 1 (fail the release workflow) otherwise.
+ *
+ * Usage:  node scripts/post-publish-smoke.mjs <version>
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+/** Pure: does the `instar --version` output report the expected version? */
+export function versionMatches(cliOutput, expected) {
+  // cli prints the bare version (commander default) possibly with surrounding whitespace/newlines.
+  return cliOutput.split(/\s+/).map((s) => s.trim()).includes(expected);
+}
+
+async function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function waitForPropagation(version, deadlineMs) {
+  const end = Date.now() + deadlineMs;
+  while (Date.now() < end) {
+    try {
+      const published = execFileSync('npm', ['view', `instar@${version}`, 'version'], { encoding: 'utf-8' }).trim();
+      if (published === version) return true;
+    } catch { /* not propagated yet */ }
+    await sleep(10_000);
+  }
+  return false;
+}
+
+async function main() {
+  const version = process.argv[2];
+  if (!version) { console.error('Usage: post-publish-smoke.mjs <version>'); process.exit(2); }
+
+  console.log(`[smoke] waiting for instar@${version} to propagate on npm…`);
+  if (!await waitForPropagation(version, 180_000)) {
+    console.error(`[smoke] instar@${version} did not appear on npm within 3m`);
+    process.exit(1);
+  }
+
+  const prefix = mkdtempSync(path.join(tmpdir(), 'instar-smoke-'));
+  console.log(`[smoke] clean-installing instar@${version} into ${prefix}`);
+  execFileSync('npm', ['install', '--prefix', prefix, `instar@${version}`], { encoding: 'utf-8', stdio: 'inherit' });
+
+  const cli = path.join(prefix, 'node_modules', 'instar', 'dist', 'cli.js');
+  if (!existsSync(cli)) {
+    console.error(`[smoke] FAIL: ${cli} missing — the published tarball shipped without its compiled dist.`);
+    process.exit(1);
+  }
+
+  const out = execFileSync('node', [cli, '--version'], { encoding: 'utf-8' });
+  if (!versionMatches(out, version)) {
+    console.error(`[smoke] FAIL: \`instar --version\` reported "${out.trim()}", expected "${version}".`);
+    process.exit(1);
+  }
+
+  console.log(`[smoke] ✓ instar@${version} clean-installs and runs (--version → ${version}).`);
+  process.exit(0);
+}
+
+// Only run main() when invoked directly (not when imported by the unit test).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => { console.error(`[smoke] error: ${err?.message ?? err}`); process.exit(1); });
+}

--- a/tests/unit/post-publish-smoke.test.ts
+++ b/tests/unit/post-publish-smoke.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs script, no types; we only exercise the pure export.
+import { versionMatches } from '../../scripts/post-publish-smoke.mjs';
+
+describe('post-publish-smoke versionMatches (Track A)', () => {
+  it('matches the bare version output (commander prints just the version)', () => {
+    expect(versionMatches('1.3.55\n', '1.3.55')).toBe(true);
+    expect(versionMatches('1.3.55', '1.3.55')).toBe(true);
+    expect(versionMatches('  1.3.55  ', '1.3.55')).toBe(true);
+  });
+
+  it('matches when the version is one token among others', () => {
+    expect(versionMatches('instar 1.3.55 (build x)', '1.3.55')).toBe(true);
+  });
+
+  it('does NOT match a different version (catches a stale/mis-tagged publish)', () => {
+    expect(versionMatches('1.3.54\n', '1.3.55')).toBe(false);
+    expect(versionMatches('', '1.3.55')).toBe(false);
+  });
+
+  it('does not false-match a substring (1.3.5 vs 1.3.55)', () => {
+    expect(versionMatches('1.3.5\n', '1.3.55')).toBe(false);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -4,37 +4,35 @@
 
 ## What Changed
 
-**`instar test-as-self` — one-button throwaway-deploy harness.** Automates what the
-test-as-self skill documented as manual steps: deploy the current dist into a
-throwaway agent home, start it, optionally run a real Telegram round-trip (Bot HTTP
-API), run the deterministic crash/lease verifier, and tear down — a single JSON
-report, exit 0 = all PASS. Structural guards make it impossible to point at your
-real agent home or a protected agent (Bob), and it refuses a raw bot token on the
-command line (Secret Drop only).
+**Post-publish smoke gate (publish-pipeline regression insurance).** A new step
+after `npm publish` clean-installs the just-published version into a throwaway
+prefix and runs `instar --version`, asserting the tarball actually installs and
+reports the right version. If the publish pipeline ever ships a tarball missing
+its compiled output, this catches it within minutes of release instead of when a
+fresh install fails in the wild. (Track A was re-scoped from a "fix" to this gate:
+the original "empty dist" scare was self-inflicted, not a real publish bug.)
 
 ## What to Tell Your User
 
-- There's now a one-command way for me to safely test a fresh deploy of myself in
-  an isolated sandbox — `instar test-as-self` — before shipping a change that
-  touches the startup/deploy path, so I get clean evidence instead of guessing from
-  logs. It can't touch your real agent or Bob, and it never takes a bot token on the
-  command line.
+- Internal release-pipeline hardening: after I publish a new version, CI now
+  immediately does a clean install of it and checks it runs, so a broken release
+  can't slip out unnoticed. Nothing changes for you — it's a safety net on my own
+  shipping process.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| `instar test-as-self` | `instar test-as-self --no-roundtrip` (deploy+verify) or `--bot-token <secret-drop-id>` (+ Telegram round-trip); `--keep` leaves it running. |
-| Structural deploy guards | Automatic — refuses canonical-home / Bob targets (exit 11) and raw tokens on argv (exit 12). |
+| Post-publish smoke gate | Automatic in the publish workflow — clean-installs the just-published version + asserts `instar --version`. |
 
 ## Evidence
 
-**New command + pure guards, fully wired (not dead code) + Agent-Awareness entry.**
-Unit `tests/unit/test-as-self-validation.test.ts` (12) covers every guard decision
-boundary; integration `tests/integration/test-as-self-guards.test.ts` (3) verifies
-the orchestrator's no-I/O early-exit codes (11 bad target, 12 raw token). `tsc
---noEmit` + destructive-lint + url-log-lint clean. The round-trip uses the Telegram
-Bot HTTP API (not Playwright — more reliable). Deferred follow-up (tracked): SKILL.md
-demote + migrator (the v1 runbook still works). Side-effects review:
-`upgrades/side-effects/test-as-self-orchestrator.md`. Spec: Track F of
+**Re-scoped to regression insurance (the original premise was a self-inflicted
+artifact, not a bug).** `scripts/post-publish-smoke.mjs` waits for npm
+propagation, clean-installs into a throwaway prefix, asserts `dist/cli.js` exists
++ `--version` matches. Unit test `tests/unit/post-publish-smoke.test.ts` (4)
+covers the pure version-match logic incl the 1.3.5-vs-1.3.55 substring trap.
+`publish.yml` validates as YAML; the step mirrors the existing publish steps'
+structure + gating. Side-effects review:
+`upgrades/side-effects/publish-completeness-smoke-gate.md`. Spec: Track A of
 `docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md`.

--- a/upgrades/side-effects/publish-completeness-smoke-gate.md
+++ b/upgrades/side-effects/publish-completeness-smoke-gate.md
@@ -1,0 +1,47 @@
+# Side-Effects Review — Post-publish smoke gate (MM-Bootstrap Track A, re-scoped)
+
+**Spec:** MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS §Track A (re-scoped per the
+evidence below).
+
+**Scope.** `scripts/post-publish-smoke.mjs` (new), `.github/workflows/publish.yml`
+(one new step after `npm publish`), `tests/unit/post-publish-smoke.test.ts` (new).
+
+**Premise correction (evidence-driven).** Track A originally targeted a
+"fleet-wide install blocker — the published tarball ships an empty dist." That
+premise is FALSE: a clean `npm install --prefix /tmp/... instar@latest` yields a
+complete dist (864 dist/core files) and runs. The "empty dist" hit during the
+2026-05-27 manual bring-up was self-inflicted (an `rsync -a --delete` wiping the
+global install). So there is no active bug to fix. Re-scoped (with Justin's
+default-build nod) to cheap REGRESSION INSURANCE: if the publish pipeline ever
+DOES ship a broken tarball, catch it within minutes of release.
+
+**What it does.** A new step after `npm publish` runs
+`post-publish-smoke.mjs <version>`: waits (bounded retry, 3m) for npm to
+propagate the just-published version, clean-installs it into a throwaway prefix,
+asserts `dist/cli.js` exists, runs `--version`, and asserts it reports the
+published version. Fails the release workflow loudly otherwise (before the
+version-bump commit/tag).
+
+**Side-effects review.**
+- **No effect on the happy path** — adds a verification step; a healthy publish
+  passes it in ~seconds-to-2min (npm propagation).
+- **Fails the workflow on a broken publish** — by design. A broken tarball halts
+  the release before tagging, so a bad version isn't blessed. (The tarball is
+  already on npm at that point — npm doesn't allow un-publish easily — but the
+  loud failure surfaces it immediately for a follow-up patch.)
+- **Throwaway prefix** — installs into `mkdtemp` under the OS tmpdir; no effect
+  on the repo or the runner's global state.
+- **Bounded** — 3-minute propagation deadline; never hangs the workflow.
+- **substring-safe version check** — `versionMatches` tokenizes (1.3.5 ≠ 1.3.55),
+  unit-tested both ways.
+
+**Test coverage.** Unit `tests/unit/post-publish-smoke.test.ts` (4) covers the
+pure `versionMatches` (bare output / token-among-others / mismatch / no
+substring false-match). The install+run path is exercised by the workflow itself
+on the next real publish (CI-only; not unit-mockable meaningfully).
+
+**Migration parity.** None — publish-pipeline + dev script; no agent-installed
+file.
+
+**Rollback.** Revert the PR. The smoke step disappears; publishes proceed
+unverified (the prior state). No data change.


### PR DESCRIPTION
**Track A** of the approved Multi-Machine Bootstrap Robustness spec (#465) — **re-scoped**.

**Premise correction:** Track A originally targeted "the published tarball ships an empty dist — fleet-wide install blocker." That's FALSE — a clean `npm install instar@latest` yields a complete dist (864 dist/core files) and runs. The empty dist I hit on 2026-05-27 was self-inflicted (`rsync -a --delete` wiping the global install). So there's no active bug. Re-scoped (Justin's default-build nod) to **regression insurance**.

**What it adds:** a step after `npm publish` runs `scripts/post-publish-smoke.mjs <version>` — waits for npm propagation (bounded 3m), clean-installs the just-published version into a throwaway prefix, asserts `dist/cli.js` exists + `--version` matches. If the pipeline ever ships a broken tarball, it fails the release loudly within minutes instead of when a fresh install fails in the wild.

**Tests:** unit (4) on the pure `versionMatches` incl the 1.3.5-vs-1.3.55 substring trap. `publish.yml` valid YAML; the step mirrors the existing publish-step gating.

Side-effects review: `upgrades/side-effects/publish-completeness-smoke-gate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)