### PR TITLE
fix(setup): gate launchctl load under test (MM-Bootstrap Track C test-hygiene)

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -729,6 +729,21 @@ function findInstarRoot(): string {
  *
  * Returns true if auto-start was installed successfully.
  */
+
+/**
+ * Whether the real `launchctl bootout/bootstrap` (loading a plist into the live
+ * user launchd) is allowed. Skipped under a test runner (vitest auto-sets
+ * `VITEST`) or when `INSTAR_SKIP_LAUNCHCTL_LOAD` is set — so a unit test that
+ * exercises the plist-WRITING path (e.g. the init→join handoff test) never
+ * loads a tmpdir-pointed plist into the operator's real launchd and leaves
+ * stale `status 78` entries behind (test-hygiene fix, MM-Bootstrap Track C
+ * follow-up). The plist file is still written/removed; only the live load is
+ * gated, so the unit-under-test (the plist content) is unaffected.
+ */
+export function launchctlLoadAllowed(): boolean {
+  return !process.env.VITEST && !process.env.INSTAR_SKIP_LAUNCHCTL_LOAD;
+}
+
 export function installAutoStart(projectName: string, projectDir: string, hasTelegram: boolean): boolean {
   const platform = process.platform;
 
@@ -1582,13 +1597,15 @@ export function installFleetWatchdog(): boolean {
       return false;
     }
 
-    // Reload (bootout if loaded; bootstrap fresh)
-    try {
-      execFileSync('launchctl', ['bootout', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
-    } catch { /* not loaded — fine */ }
-    try {
-      execFileSync('launchctl', ['bootstrap', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
-    } catch { /* bootstrap failure — non-fatal, will run on next login */ }
+    // Reload (bootout if loaded; bootstrap fresh) — skipped under test.
+    if (launchctlLoadAllowed()) {
+      try {
+        execFileSync('launchctl', ['bootout', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
+      } catch { /* not loaded — fine */ }
+      try {
+        execFileSync('launchctl', ['bootstrap', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
+      } catch { /* bootstrap failure — non-fatal, will run on next login */ }
+    }
 
     return true;
   } catch (err) {
@@ -1678,13 +1695,15 @@ ${argsXml}
       return false;
     }
 
-    // Load the agent
-    try {
-      // Unload first if already loaded
-      execFileSync('launchctl', ['bootout', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
-    } catch { /* not loaded yet — fine */ }
+    // Load the agent (skipped under test — see launchctlLoadAllowed).
+    if (launchctlLoadAllowed()) {
+      try {
+        // Unload first if already loaded
+        execFileSync('launchctl', ['bootout', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
+      } catch { /* not loaded yet — fine */ }
 
-    execFileSync('launchctl', ['bootstrap', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
+      execFileSync('launchctl', ['bootstrap', `gui/${process.getuid?.() ?? 501}`, plistPath], { stdio: 'ignore' });
+    }
 
     // Ensure the user-machine fleet watchdog is installed alongside this agent.
     // Singleton per machine — first agent setup creates it, subsequent setups

--- a/tests/unit/launchctl-load-guard.test.ts
+++ b/tests/unit/launchctl-load-guard.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { launchctlLoadAllowed } from '../../src/commands/setup.js';
+
+/**
+ * Track C follow-up (test-hygiene): the real `launchctl bootstrap` is gated so
+ * unit tests that write a plist never load a tmpdir-pointed plist into the
+ * operator's real launchd (the 2026-05-28 stale-status-78 pollution).
+ */
+describe('launchctlLoadAllowed (test-hygiene guard)', () => {
+  const savedVitest = process.env.VITEST;
+  const savedSkip = process.env.INSTAR_SKIP_LAUNCHCTL_LOAD;
+
+  afterEach(() => {
+    if (savedVitest === undefined) delete process.env.VITEST; else process.env.VITEST = savedVitest;
+    if (savedSkip === undefined) delete process.env.INSTAR_SKIP_LAUNCHCTL_LOAD; else process.env.INSTAR_SKIP_LAUNCHCTL_LOAD = savedSkip;
+  });
+
+  it('is FALSE under a vitest run (VITEST set) — no real launchd load in tests', () => {
+    process.env.VITEST = 'true';
+    delete process.env.INSTAR_SKIP_LAUNCHCTL_LOAD;
+    expect(launchctlLoadAllowed()).toBe(false);
+  });
+
+  it('is FALSE when INSTAR_SKIP_LAUNCHCTL_LOAD is set (explicit opt-out)', () => {
+    delete process.env.VITEST;
+    process.env.INSTAR_SKIP_LAUNCHCTL_LOAD = '1';
+    expect(launchctlLoadAllowed()).toBe(false);
+  });
+
+  it('is TRUE in a normal (production) environment — neither flag set', () => {
+    delete process.env.VITEST;
+    delete process.env.INSTAR_SKIP_LAUNCHCTL_LOAD;
+    expect(launchctlLoadAllowed()).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -4,35 +4,32 @@
 
 ## What Changed
 
-**Post-publish smoke gate (publish-pipeline regression insurance).** A new step
-after `npm publish` clean-installs the just-published version into a throwaway
-prefix and runs `instar --version`, asserting the tarball actually installs and
-reports the right version. If the publish pipeline ever ships a tarball missing
-its compiled output, this catches it within minutes of release instead of when a
-fresh install fails in the wild. (Track A was re-scoped from a "fix" to this gate:
-the original "empty dist" scare was self-inflicted, not a real publish bug.)
+**Test-hygiene: unit tests no longer load plists into the real launchd.** The
+auto-start installer (`installMacOSLaunchAgent` / fleet-watchdog) did a real
+`launchctl bootstrap` after writing a plist — so a unit test exercising the
+plist-writing path loaded tmpdir-pointed plists into the operator's real launchd,
+leaving inert stale entries behind. New `launchctlLoadAllowed()` gate skips the
+live load under a test runner (vitest sets `VITEST`) or when
+`INSTAR_SKIP_LAUNCHCTL_LOAD` is set. Production behavior is unchanged.
 
 ## What to Tell Your User
 
-- Internal release-pipeline hardening: after I publish a new version, CI now
-  immediately does a clean install of it and checks it runs, so a broken release
-  can't slip out unnoticed. Nothing changes for you — it's a safety net on my own
-  shipping process.
+- Internal test-hygiene fix: my test suite no longer accidentally registers
+  throwaway background-service entries on the machine it runs on. Nothing
+  user-facing; production startup is unchanged.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Post-publish smoke gate | Automatic in the publish workflow — clean-installs the just-published version + asserts `instar --version`. |
+| `launchctlLoadAllowed()` gate | Automatic — skips the live `launchctl bootstrap` under VITEST / `INSTAR_SKIP_LAUNCHCTL_LOAD`; production loads normally. |
 
 ## Evidence
 
-**Re-scoped to regression insurance (the original premise was a self-inflicted
-artifact, not a bug).** `scripts/post-publish-smoke.mjs` waits for npm
-propagation, clean-installs into a throwaway prefix, asserts `dist/cli.js` exists
-+ `--version` matches. Unit test `tests/unit/post-publish-smoke.test.ts` (4)
-covers the pure version-match logic incl the 1.3.5-vs-1.3.55 substring trap.
-`publish.yml` validates as YAML; the step mirrors the existing publish steps'
-structure + gating. Side-effects review:
-`upgrades/side-effects/publish-completeness-smoke-gate.md`. Spec: Track A of
+**One helper + two install-path wraps; production load path unchanged.** Unit
+test `tests/unit/launchctl-load-guard.test.ts` (3): false under VITEST, false
+under the explicit opt-out, true in production. Verified the merged Track C test
+now runs with NO real-launchd pollution (no stale mmtest* entries) while still
+passing. `tsc` clean. Side-effects review:
+`upgrades/side-effects/launchctl-test-hygiene.md`. Follow-up to Track C of
 `docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md`.

--- a/upgrades/side-effects/launchctl-test-hygiene.md
+++ b/upgrades/side-effects/launchctl-test-hygiene.md
@@ -1,0 +1,42 @@
+# Side-Effects Review — launchctl load test-hygiene guard (MM-Bootstrap Track C follow-up)
+
+**Scope.** `src/commands/setup.ts` (new `launchctlLoadAllowed()` helper + guard
+at the 2 install-path `launchctl bootstrap` sites: installMacOSLaunchAgent +
+installFleetWatchdog), `tests/unit/launchctl-load-guard.test.ts` (new).
+
+**Problem.** The Track C unit test (merged #470) writes a LaunchAgent plist via
+`installAutoStart` to verify the Label-keyed-replace property. But
+`installMacOSLaunchAgent` does a real `launchctl bootstrap` (load) after writing
+— so the test loaded tmpdir-pointed plists into the operator's REAL launchd,
+leaving stale `ai.instar.mmtesthandoff` / `ai.instar.mmteststandby` entries
+(status 78, program gone) after the tmpdir was cleaned. Inert but real
+test-pollution of the user's launchd, discovered 2026-05-28.
+
+**Fix.** `launchctlLoadAllowed()` returns false under a test runner (vitest
+auto-sets `VITEST`) or when `INSTAR_SKIP_LAUNCHCTL_LOAD` is set. The two
+install-path bootout+bootstrap blocks are wrapped in it. The plist file is still
+written/removed; only the LIVE load is gated — so the unit-under-test (plist
+content) is unaffected, and production (neither flag set) loads normally.
+
+**Side-effects review.**
+- **No production behavior change** — in a normal environment neither VITEST nor
+  INSTAR_SKIP_LAUNCHCTL_LOAD is set, so `launchctlLoadAllowed()` is true and the
+  load happens exactly as before.
+- **Tests no longer pollute real launchd** — verified: re-running the Track C
+  test creates NO mmtesthandoff/mmteststandby entries (the guard skipped the
+  load), and the test still passes (it asserts plist CONTENT, not live load).
+- **uninstallAutoStart's bootout is intentionally NOT gated** — that's cleanup
+  (removing a real entry), correct to keep even in tests; only the install-path
+  LOAD is the pollution vector.
+- **Minimal surface** — one helper + two wraps; no new dependency.
+
+**Test coverage.** Unit `tests/unit/launchctl-load-guard.test.ts` (3): false
+under VITEST, false under INSTAR_SKIP_LAUNCHCTL_LOAD, true when neither set
+(production). Plus the existing Track C test now verifiably runs without
+pollution.
+
+**Migration parity.** Server source (setup.ts) — existing agents pick up on
+auto-update. No agent-installed-file change; production load behavior unchanged.
+
+**Rollback.** Revert. Tests would resume polluting real launchd (inert stale
+entries). No production impact either way.


### PR DESCRIPTION
**Track C follow-up** (test-hygiene) — found during the MM-Bootstrap overnight run.

**Problem.** The Track C unit test (merged #470) writes a LaunchAgent plist to verify the Label-keyed-replace property — but `installMacOSLaunchAgent` does a real `launchctl bootstrap` after writing, so the test loaded tmpdir-pointed plists into the operator's **real** launchd, leaving inert stale `ai.instar.mmtesthandoff`/`mmteststandby` entries (status 78) behind.

**Fix.** `launchctlLoadAllowed()` returns false under a test runner (vitest auto-sets `VITEST`) or `INSTAR_SKIP_LAUNCHCTL_LOAD`; the 2 install-path bootout+bootstrap blocks are wrapped in it. The plist is still written/removed — only the live load is gated — so the unit-under-test (plist content) is unaffected and production loads normally. `uninstall`'s bootout stays ungated (intentional cleanup).

**Verified:** re-running the merged Track C test creates zero real-launchd entries (guard skipped the load) and the test still passes. Unit test (3): false under VITEST / explicit opt-out, true in production.

Side-effects review: `upgrades/side-effects/launchctl-test-hygiene.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)