### PR TITLE
docs(skill): test-as-self leads with one-button + migrator (Track F follow-up)

### DIFF
--- a/.claude/skills/test-as-self/SKILL.md
+++ b/.claude/skills/test-as-self/SKILL.md
@@ -5,9 +5,21 @@ metadata:
   user_invocable: "true"
 ---
 
-# /test-as-self — Throwaway-Deploy Harness (Task 4 / Part 2 v1)
+# /test-as-self — Throwaway-Deploy Harness (Part 2.1)
 
-> Spec: `docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md`. Part 1 (the structural poll-ownership lease) ships in the same release. This is the MVP runbook + a deterministic verifier; full one-button automation (bot minting, Telegram round-trip via Playwright, OOM reproduction) is the follow-up Part 2.1.
+> Spec: `docs/specs/SELF-PROPAGATION-HARNESS-SPEC.md` + the Track F section of `docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md`. Part 1 (the structural poll-ownership lease) ships alongside. Part 2.1 folded the manual recipe below into a single command — use that first; the manual recipe is the fallback for fine-grained control.
+
+## The one-button path (Part 2.1 — use this first)
+
+```bash
+instar test-as-self --no-roundtrip                  # deploy + verify only (no bot)
+instar test-as-self --bot-token <secret-drop-id>    # + a real Telegram round-trip
+instar test-as-self --keep                          # leave it running for inspection
+```
+
+The command runs the seven gated steps automatically (bot-acquire via Secret Drop / target-prep with Bob+canonical-home guards / dist-deploy / process-start + wait for /health + lease / Telegram-Bot-HTTP-API round-trip / `verify.mjs` / signal-safe teardown) and emits a single JSON report; exit 0 = all PASS. Structural guards make it impossible to target your real agent home or Bob, and it refuses a raw bot token on the command line (Secret Drop only). The round-trip uses the Telegram Bot HTTP API directly (not Playwright) — no browser, no flake.
+
+Fall back to the manual recipe below only when you need step-by-step control or to debug a single step.
 
 ## When to use
 

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -215,6 +215,7 @@ export class PostUpdateMigrator {
     this.autoMigrateLegacyJobsJson(result);
     this.migrateSkillPortHardcoding(result);
     this.migrateBuildSkillMethodology(result);
+    this.migrateTestAsSelfSkill(result);
     this.migrateAutonomousStopHookTopicKeyed(result);
     this.migrateSelfKnowledgeTree(result);
     this.migrateSoulMd(result);
@@ -1289,6 +1290,41 @@ export class PostUpdateMigrator {
       }
     } catch (err) {
       result.errors.push(`skills/build/SKILL.md methodology migration: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * Update the deployed test-as-self SKILL.md to the Part 2.1 version that leads
+   * with the one-button `instar test-as-self` command (manual recipe demoted to
+   * fallback). installBuiltinSkills is install-if-missing, so existing agents
+   * never get the updated content through init — this dedicated migration is the
+   * only path (Migration Parity Standard, "updating existing skill content").
+   *
+   * Idempotent + conservative: re-copy the bundled SKILL.md only when the
+   * installed copy (a) lacks the Part 2.1 MARKER AND (b) still matches the stock
+   * FINGERPRINT. A customized skill is left untouched.
+   */
+  private migrateTestAsSelfSkill(result: MigrationResult): void {
+    try {
+      const skillFile = path.join(this.config.projectDir, '.claude', 'skills', 'test-as-self', 'SKILL.md');
+      if (!fs.existsSync(skillFile)) return; // installBuiltinSkills handles fresh installs
+      const current = fs.readFileSync(skillFile, 'utf8');
+      const MARKER = 'The one-button path (Part 2.1';
+      if (current.includes(MARKER)) return; // already updated — idempotent
+      // Stock-fingerprint guard: don't clobber a customized test-as-self skill.
+      if (!current.includes('Throwaway-Deploy Harness') || !current.includes('verify.mjs')) {
+        result.skipped.push('skills/test-as-self/SKILL.md: customized — left untouched (no Part 2.1 update)');
+        return;
+      }
+      const bundled = path.join(__dirname, '..', '..', '.claude', 'skills', 'test-as-self', 'SKILL.md');
+      if (!fs.existsSync(bundled)) return;
+      const next = fs.readFileSync(bundled, 'utf8');
+      if (next.includes(MARKER)) {
+        fs.writeFileSync(skillFile, next);
+        result.upgraded.push('skills/test-as-self/SKILL.md (Part 2.1: one-button instar test-as-self leads; manual recipe demoted)');
+      }
+    } catch (err) {
+      result.errors.push(`skills/test-as-self/SKILL.md migration: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/tests/unit/migrate-test-as-self-skill.test.ts
+++ b/tests/unit/migrate-test-as-self-skill.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for migrateTestAsSelfSkill — updates the deployed test-as-self
+ * SKILL.md to the Part 2.1 version (one-button command leads; manual recipe
+ * demoted). Covers update, idempotency, and customized-skill-left-untouched.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+let projectDir: string;
+
+function makeMigrator(): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir,
+    stateDir: path.join(projectDir, '.instar'),
+    port: 4042,
+    hasTelegram: false,
+    projectName: 'test',
+  });
+}
+
+function emptyResult() {
+  return { upgraded: [] as string[], skipped: [] as string[], errors: [] as string[] };
+}
+
+function writeSkill(content: string): string {
+  const dir = path.join(projectDir, '.claude', 'skills', 'test-as-self');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'SKILL.md');
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+const run = (result: ReturnType<typeof emptyResult>) =>
+  (makeMigrator() as unknown as { migrateTestAsSelfSkill: (r: typeof result) => void })
+    .migrateTestAsSelfSkill(result);
+
+// A stock v1 test-as-self skill: has the fingerprint, lacks the Part 2.1 marker.
+const STOCK_V1 = `---
+name: test-as-self
+---
+
+# /test-as-self — Throwaway-Deploy Harness (Task 4 / Part 2 v1)
+
+## Recipe — deploy + verify
+Run verify.mjs against the throwaway home.
+`;
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tas-skill-migration-'));
+});
+afterEach(() => {
+  SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/unit/migrate-test-as-self-skill.test.ts' });
+});
+
+describe('migrateTestAsSelfSkill', () => {
+  it('updates a stock v1 skill (has fingerprint, lacks Part 2.1 marker)', () => {
+    const file = writeSkill(STOCK_V1);
+    const result = emptyResult();
+    run(result);
+    const updated = fs.readFileSync(file, 'utf8');
+    expect(updated).toContain('The one-button path (Part 2.1');
+    expect(result.upgraded.some((u) => u.includes('skills/test-as-self/SKILL.md'))).toBe(true);
+  });
+
+  it('is idempotent — a skill that already has the Part 2.1 marker is unchanged', () => {
+    const already = STOCK_V1 + '\n## The one-button path (Part 2.1 — use this first)\n';
+    const file = writeSkill(already);
+    const before = fs.readFileSync(file, 'utf8');
+    const result = emptyResult();
+    run(result);
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+    expect(result.upgraded.length).toBe(0);
+  });
+
+  it('leaves a customized skill untouched (missing the stock fingerprint)', () => {
+    const customized = `---\nname: test-as-self\n---\n# My custom harness\nnothing standard here\n`;
+    const file = writeSkill(customized);
+    const result = emptyResult();
+    run(result);
+    expect(fs.readFileSync(file, 'utf8')).toBe(customized);
+    expect(result.skipped.some((s) => s.includes('customized'))).toBe(true);
+  });
+
+  it('no-ops when the skill is not installed (fresh install path)', () => {
+    const result = emptyResult();
+    run(result);
+    expect(result.upgraded.length).toBe(0);
+    expect(result.errors.length).toBe(0);
+  });
+});

--- a/upgrades/1.3.56.md
+++ b/upgrades/1.3.56.md
@@ -4,32 +4,31 @@
 
 ## What Changed
 
-**Test-hygiene: unit tests no longer load plists into the real launchd.** The
-auto-start installer (`installMacOSLaunchAgent` / fleet-watchdog) did a real
-`launchctl bootstrap` after writing a plist — so a unit test exercising the
-plist-writing path loaded tmpdir-pointed plists into the operator's real launchd,
-leaving inert stale entries behind. New `launchctlLoadAllowed()` gate skips the
-live load under a test runner (vitest sets `VITEST`) or when
-`INSTAR_SKIP_LAUNCHCTL_LOAD` is set. Production behavior is unchanged.
+**test-as-self skill now leads with the one-button command (+ migration for
+existing agents).** Track F shipped `instar test-as-self` but the skill doc still
+read as the old manual runbook. The SKILL.md now leads with "The one-button path
+(Part 2.1)" — the command — with the manual recipe demoted to a fallback for
+fine-grained control. A `PostUpdateMigrator.migrateTestAsSelfSkill` patches
+existing agents' on-disk SKILL.md (conservative: only when it lacks the Part 2.1
+marker AND matches the stock fingerprint; customized skills untouched).
 
 ## What to Tell Your User
 
-- Internal test-hygiene fix: my test suite no longer accidentally registers
-  throwaway background-service entries on the machine it runs on. Nothing
-  user-facing; production startup is unchanged.
+- Internal: my test-as-self skill now points me at the one-command version first
+  instead of the old step-by-step recipe. No user-facing change.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| `launchctlLoadAllowed()` gate | Automatic — skips the live `launchctl bootstrap` under VITEST / `INSTAR_SKIP_LAUNCHCTL_LOAD`; production loads normally. |
+| test-as-self SKILL → one-button-first | Automatic — the skill now surfaces `instar test-as-self` as the primary path. |
+| `migrateTestAsSelfSkill` | Automatic on update — patches existing agents' SKILL.md to the Part 2.1 version (conservative + idempotent). |
 
 ## Evidence
 
-**One helper + two install-path wraps; production load path unchanged.** Unit
-test `tests/unit/launchctl-load-guard.test.ts` (3): false under VITEST, false
-under the explicit opt-out, true in production. Verified the merged Track C test
-now runs with NO real-launchd pollution (no stale mmtest* entries) while still
-passing. `tsc` clean. Side-effects review:
-`upgrades/side-effects/launchctl-test-hygiene.md`. Follow-up to Track C of
+**Content + migration-parity follow-up to Track F; no behavior change.** Unit
+test `tests/unit/migrate-test-as-self-skill.test.ts` (4): stock-v1 updated,
+idempotent, customized-untouched, not-installed no-op. `tsc` clean. Mirrors the
+proven migrateBuildSkillMethodology pattern. Side-effects review:
+`upgrades/side-effects/test-as-self-skill-demote.md`. Follow-up to Track F of
 `docs/specs/MULTI-MACHINE-BOOTSTRAP-ROBUSTNESS-SPEC.md`.

--- a/upgrades/side-effects/test-as-self-skill-demote.md
+++ b/upgrades/side-effects/test-as-self-skill-demote.md
@@ -1,0 +1,38 @@
+# Side-Effects Review — test-as-self SKILL Part 2.1 demote + migrator (Track F follow-up)
+
+**Scope.** `.claude/skills/test-as-self/SKILL.md` (lead with the one-button
+command, demote the manual recipe to fallback), `src/core/PostUpdateMigrator.ts`
+(`migrateTestAsSelfSkill` + registration), `tests/unit/migrate-test-as-self-skill.test.ts`.
+
+**What + why.** Track F shipped the `instar test-as-self` command but left the
+SKILL.md as the v1 manual runbook (deferred, tracked). This closes that loop:
+the SKILL now leads with "## The one-button path (Part 2.1 — use this first)"
+(the command), with the manual recipe demoted to fallback — so an agent reading
+the skill reaches for the command first. Plus a PostUpdateMigrator method so
+EXISTING agents' on-disk SKILL.md gets the update (installBuiltinSkills is
+install-if-missing, so a dedicated migration is the only path per the Migration
+Parity Standard).
+
+**Side-effects review.**
+- **Content-only skill change** — no behavior change; the command itself shipped
+  in Track F (#472). This just makes it discoverable in the skill surface.
+- **Migration is conservative + idempotent** — re-copies the bundled SKILL only
+  when the installed copy LACKS the Part 2.1 marker AND still matches the stock
+  fingerprint (`Throwaway-Deploy Harness` + `verify.mjs`). A customized skill is
+  left untouched (recorded in result.skipped); an already-updated one is a no-op;
+  a not-installed one is a no-op. Mirrors the proven migrateBuildSkillMethodology
+  pattern exactly.
+- **No data/secret impact** — pure doc/skill content.
+
+**Test coverage.** Unit `tests/unit/migrate-test-as-self-skill.test.ts` (4):
+stock-v1 → updated (marker present, result.upgraded set); idempotent (already-
+marked → unchanged, no upgrade); customized → untouched (result.skipped);
+not-installed → no-op (no error). All green; tsc clean. The test also implicitly
+verifies the bundled SKILL.md carries the new marker.
+
+**Migration parity.** This IS the migration-parity fix for Track F's SKILL
+update. New agents get the new SKILL via installBuiltinSkills; existing agents
+get it via `migrateTestAsSelfSkill` on update.
+
+**Rollback.** Revert. The SKILL reverts to the v1 manual-first runbook; the
+command still works (it's independent). No data change.


### PR DESCRIPTION
**Track F follow-up** — closes the deferred SKILL.md/migration-parity loop.

Track F shipped the `instar test-as-self` command but left `.claude/skills/test-as-self/SKILL.md` as the v1 manual runbook. This:
- Leads the SKILL with **"The one-button path (Part 2.1 — use this first)"** (the command), demoting the manual recipe to a fallback for fine-grained control.
- Adds `PostUpdateMigrator.migrateTestAsSelfSkill` so **existing** agents get the updated SKILL on update (`installBuiltinSkills` is install-if-missing → a dedicated migration is the only path, per the Migration Parity Standard). Conservative + idempotent: re-copies only when the installed SKILL lacks the Part 2.1 marker AND matches the stock fingerprint; customized skills untouched.

**Tests:** `tests/unit/migrate-test-as-self-skill.test.ts` (4) — stock-v1→updated, idempotent, customized-untouched, not-installed no-op. `tsc` clean. Mirrors the proven `migrateBuildSkillMethodology` pattern.

Side-effects review: `upgrades/side-effects/test-as-self-skill-demote.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)