### PR TITLE
fix(messaging): mentor cycle smoothness — robust reply capture + remote-aware isMenteeBusy

### DIFF
--- a/src/monitoring/SessionReplyExtractor.ts
+++ b/src/monitoring/SessionReplyExtractor.ts
@@ -1,0 +1,106 @@
+/**
+ * SessionReplyExtractor — pull the FINAL assistant message out of a completed
+ * mentee session's persisted transcript, instead of racing the live tmux pane.
+ *
+ * The mentor cycle's reply leg (MENTOR-LIVE-READINESS-SPEC §Recipient side)
+ * spawns a mentee session and needs its reply. Reading the tmux pane after the
+ * session completes is racy (the reaper removes the pane first → empty capture)
+ * AND yields raw stream JSON rather than clean prose. The transcript files
+ * persist the assistant's final message verbatim:
+ *
+ *   - Codex: the rollout JSONL carries
+ *     `{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"…"}}`
+ *     (the cleanest source); fallbacks are the last `agent_message` event or the
+ *     last `response_item` message with role=assistant.
+ *   - Claude Code: the session JSONL carries assistant turns; the last
+ *     assistant text block is the reply.
+ *
+ * Both extractors are pure (string in → string|null out), tolerant of
+ * malformed/partial lines, and return null when no assistant text is present
+ * (the caller then falls back to the tmux capture).
+ */
+
+/** Extract the final assistant message from a Codex rollout JSONL file's content. */
+export function extractCodexFinalMessage(content: string): string | null {
+  if (!content) return null;
+  let lastTaskComplete: string | null = null;
+  let lastAgentMessage: string | null = null;
+  let lastAssistantItem: string | null = null;
+
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line[0] !== '{') continue;
+    let d: Record<string, unknown>;
+    try {
+      d = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const type = d['type'];
+    const payload = (d['payload'] ?? {}) as Record<string, unknown>;
+    const ptype = payload['type'];
+
+    if (type === 'event_msg' && ptype === 'task_complete') {
+      const m = payload['last_agent_message'];
+      if (typeof m === 'string' && m.trim()) lastTaskComplete = m;
+    } else if (type === 'event_msg' && ptype === 'agent_message') {
+      const m = payload['message'];
+      if (typeof m === 'string' && m.trim()) lastAgentMessage = m;
+    } else if (type === 'response_item' && ptype === 'message' && payload['role'] === 'assistant') {
+      const content_ = payload['content'];
+      if (Array.isArray(content_)) {
+        const text = content_
+          .map((c) => (c && typeof c === 'object' ? (c as Record<string, unknown>)['text'] : undefined))
+          .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+          .join('\n');
+        if (text.trim()) lastAssistantItem = text;
+      }
+    }
+  }
+
+  // Preference order: task_complete (the canonical final message) → last
+  // agent_message event → last assistant response_item.
+  return lastTaskComplete ?? lastAgentMessage ?? lastAssistantItem;
+}
+
+/**
+ * Extract the final assistant message from a Claude Code session JSONL
+ * transcript's content. Claude JSONL rows are one JSON object per line; an
+ * assistant turn has `{type:'assistant', message:{content:[{type:'text',text}]}}`
+ * (or a string content). Returns the last assistant text block.
+ */
+export function extractClaudeFinalMessage(content: string): string | null {
+  if (!content) return null;
+  let last: string | null = null;
+
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line[0] !== '{') continue;
+    let d: Record<string, unknown>;
+    try {
+      d = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    // Two shapes seen: top-level {type:'assistant', message:{...}} and the
+    // message object directly. Normalize.
+    const isAssistant =
+      d['type'] === 'assistant' ||
+      (typeof d['role'] === 'string' && d['role'] === 'assistant');
+    if (!isAssistant) continue;
+    const msg = (d['message'] ?? d) as Record<string, unknown>;
+    const c = msg['content'];
+    let text: string | null = null;
+    if (typeof c === 'string' && c.trim()) {
+      text = c;
+    } else if (Array.isArray(c)) {
+      const joined = c
+        .map((b) => (b && typeof b === 'object' ? (b as Record<string, unknown>)['text'] : undefined))
+        .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+        .join('\n');
+      if (joined.trim()) text = joined;
+    }
+    if (text) last = text;
+  }
+  return last;
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -72,6 +72,7 @@ import { ProcessedIdStore } from '../messaging/ProcessedIdStore.js';
 import { buildAgentMessageHook, type RoleHandler } from '../messaging/installAgentMessageHook.js';
 import { OutstandingPromptTracker } from '../scheduler/OutstandingPromptTracker.js';
 import { parseCodexRollout } from '../monitoring/CodexRolloutParser.js';
+import { extractCodexFinalMessage, extractClaudeFinalMessage } from '../monitoring/SessionReplyExtractor.js';
 import type { ForensicFinding } from '../monitoring/FrameworkIssueLedger.js';
 import { BurnDetector } from '../monitoring/BurnDetector.js';
 import { BurnThrottleRunbook } from '../monitoring/BurnThrottleRunbook.js';
@@ -843,6 +844,65 @@ export class AgentServer {
   }
 
   /**
+   * Extract a completed mentee session's FINAL assistant message from its
+   * persisted transcript (clean prose), rather than the racy tmux-pane read.
+   * Returns null when no transcript reply is found — the caller then keeps the
+   * tmux-capture fallback.
+   *
+   * - Codex sessions: the newest rollout JSONL under $CODEX_HOME/sessions that
+   *   was written at/after the spawn → `task_complete.last_agent_message`.
+   * - Claude sessions: the session's JSONL transcript (by claudeSessionId) →
+   *   the last assistant text block.
+   */
+  private extractMenteeReplyFromTranscript(
+    session: { id: string; claudeSessionId?: string; framework?: string },
+    spawnTs: number,
+  ): string | null {
+    try {
+      const framework = String(session.framework ?? '');
+      // ── Codex path ──
+      if (framework.startsWith('codex')) {
+        const sessionsDir = path.join(os.homedir(), '.codex', 'sessions');
+        // The mentee rollout is the newest rollout written since the spawn
+        // (allow a small skew for the rollout file's first write lag).
+        const candidates = this.findRecentRolloutFiles(sessionsDir, 5);
+        for (const f of candidates) {
+          try {
+            if (fs.statSync(f).mtimeMs < spawnTs - 5_000) continue;
+            const text = extractCodexFinalMessage(fs.readFileSync(f, 'utf-8'));
+            if (text && text.trim()) return text;
+          } catch { /* try next candidate */ }
+        }
+        return null;
+      }
+      // ── Claude path ──
+      const claudeId = session.claudeSessionId;
+      if (claudeId) {
+        const projectsDir = path.join(os.homedir(), '.claude', 'projects');
+        // Find the <claudeId>.jsonl transcript anywhere under projects/.
+        const stack = [projectsDir];
+        for (let guard = 0; guard < 10_000 && stack.length; guard++) {
+          const dir = stack.pop()!;
+          let entries: fs.Dirent[];
+          try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+          for (const e of entries) {
+            const full = path.join(dir, e.name);
+            if (e.isDirectory()) stack.push(full);
+            else if (e.name === `${claudeId}.jsonl`) {
+              const text = extractClaudeFinalMessage(fs.readFileSync(full, 'utf-8'));
+              if (text && text.trim()) return text;
+            }
+          }
+        }
+      }
+      return null;
+    } catch (err) {
+      console.warn(`[mentee] transcript extraction failed (falling back to tmux capture): ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  }
+
+  /**
    * Lazily construct + cache the mentor-bot TelegramAdapter for the given token. Uses
    * PR 2a's multi-instance support (subDir + suppressLifelineAutoCreate) so the second
    * bot can't clobber the primary bot's state files OR auto-create a second Lifeline
@@ -1036,6 +1096,7 @@ export class AgentServer {
         // by the time we detect completion, so captureOutput returns empty).
         let reply = '';
         let sessionId = '';
+        const spawnTs = Date.now();
         try {
           const session = await self.sessionManager.spawnSession({
             name: `mentee-handle-${Date.now()}`,
@@ -1064,6 +1125,11 @@ export class AgentServer {
               `[mentee] session ${session.id} timed out at ${sessionTimeoutMs}ms (corr=${msg.corr}); sending best-effort partial reply`,
             );
           }
+          // Robust capture: prefer the session's persisted transcript (clean
+          // assistant prose) over the racy tmux-pane read. The pane read is
+          // only a fallback for when no transcript is found.
+          const fromTranscript = self.extractMenteeReplyFromTranscript(session, spawnTs);
+          if (fromTranscript && fromTranscript.trim()) reply = fromTranscript;
         } catch (err) {
           console.warn(
             `[mentee] mentor-message handler spawn failed (corr=${msg.corr}, sessionId=${sessionId}):`,
@@ -1390,10 +1456,20 @@ export class AgentServer {
             evaluate: (prompt) => intelligence.evaluate(prompt, { model: 'capable', maxTokens: 1500, attribution: { component: 'mentor-stage-b' } }),
           });
         },
-        // Safe-window: any other running (non-protected) session means the system
-        // is busy — conservative "don't interrupt." Refined per-mentee at live
-        // validation. <!-- tracked: topic-13435 -->
-        isMenteeBusy: () => self.sessionManager.listRunningSessions().length > 0,
+        // Safe-window: the mentee is "busy" iff there is an OUTSTANDING mentor
+        // prompt already in-flight to it (the OutstandingPromptTracker is the
+        // honest per-mentee busy signal — a prompt sent + not yet replied).
+        // The mentee is REMOTE (a separate agent/process), so Echo's own
+        // local session count says nothing about whether the mentee is free;
+        // the prior code (listRunningSessions().length > 0) wrongly blocked
+        // every tick because Echo always has sessions running. Gating on the
+        // outstanding-prompt tracker means: don't send a new prompt while the
+        // last one is unanswered — exactly the anti-ping-pong invariant.
+        isMenteeBusy: () => {
+          const cfg = getConfig();
+          const menteeAgent = cfg.menteeAgentName || `instar-${cfg.menteeFramework}`;
+          return !self.getOrCreateMentorOutstanding().canSendTo(menteeAgent).ok;
+        },
         minIntervalElapsed: () => {
           const cfg = getConfig();
           return Date.now() - self.mentorLastTickAt >= cfg.minIntervalMs;

--- a/tests/unit/SessionReplyExtractor.test.ts
+++ b/tests/unit/SessionReplyExtractor.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tier-1 unit tests for SessionReplyExtractor — pulling the final assistant
+ * message out of a completed mentee session's transcript (the robust reply
+ * capture that replaces the racy tmux-pane read).
+ */
+import { describe, it, expect } from 'vitest';
+import { extractCodexFinalMessage, extractClaudeFinalMessage } from '../../src/monitoring/SessionReplyExtractor.js';
+
+describe('extractCodexFinalMessage', () => {
+  it('prefers task_complete.last_agent_message (the canonical final reply)', () => {
+    const rollout = [
+      '{"type":"session_meta","payload":{"id":"x"}}',
+      '{"type":"event_msg","payload":{"type":"agent_message","message":"intermediate"}}',
+      '{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"item text"}]}}',
+      '{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"FINAL clean reply"}}',
+    ].join('\n');
+    expect(extractCodexFinalMessage(rollout)).toBe('FINAL clean reply');
+  });
+
+  it('falls back to the last agent_message event when no task_complete', () => {
+    const rollout = [
+      '{"type":"event_msg","payload":{"type":"agent_message","message":"first"}}',
+      '{"type":"event_msg","payload":{"type":"agent_message","message":"second (latest)"}}',
+    ].join('\n');
+    expect(extractCodexFinalMessage(rollout)).toBe('second (latest)');
+  });
+
+  it('falls back to the last assistant response_item when no agent_message/task_complete', () => {
+    const rollout = [
+      '{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"assistant reply"}]}}',
+      '{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"text","text":"a user msg"}]}}',
+    ].join('\n');
+    expect(extractCodexFinalMessage(rollout)).toBe('assistant reply');
+  });
+
+  it('joins multi-block assistant content', () => {
+    const rollout = '{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"line1"},{"type":"output_text","text":"line2"}]}}';
+    expect(extractCodexFinalMessage(rollout)).toBe('line1\nline2');
+  });
+
+  it('returns null for empty / no-assistant content + tolerates malformed lines', () => {
+    expect(extractCodexFinalMessage('')).toBeNull();
+    expect(extractCodexFinalMessage('not json\n{bad\n{"type":"session_meta","payload":{"id":"x"}}')).toBeNull();
+  });
+
+  it('ignores empty task_complete + uses the real one', () => {
+    const rollout = [
+      '{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"  "}}',
+      '{"type":"event_msg","payload":{"type":"agent_message","message":"real reply"}}',
+    ].join('\n');
+    expect(extractCodexFinalMessage(rollout)).toBe('real reply');
+  });
+});
+
+describe('extractClaudeFinalMessage', () => {
+  it('extracts the last assistant text block (top-level type:assistant)', () => {
+    const jsonl = [
+      '{"type":"user","message":{"content":[{"type":"text","text":"prompt"}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"first answer"}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"final answer"}]}}',
+    ].join('\n');
+    expect(extractClaudeFinalMessage(jsonl)).toBe('final answer');
+  });
+
+  it('handles string content + role-shaped rows', () => {
+    const jsonl = [
+      '{"role":"assistant","content":"string reply"}',
+    ].join('\n');
+    expect(extractClaudeFinalMessage(jsonl)).toBe('string reply');
+  });
+
+  it('joins multi-block assistant content + skips non-text blocks', () => {
+    const jsonl = '{"type":"assistant","message":{"content":[{"type":"text","text":"part1"},{"type":"tool_use","name":"x"},{"type":"text","text":"part2"}]}}';
+    expect(extractClaudeFinalMessage(jsonl)).toBe('part1\npart2');
+  });
+
+  it('returns null when no assistant turns + tolerates malformed lines', () => {
+    expect(extractClaudeFinalMessage('')).toBeNull();
+    expect(extractClaudeFinalMessage('{"type":"user","message":{"content":"hi"}}\nbad line')).toBeNull();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,47 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Mentor cycle: the two remaining smoothness issues fixed.**
+
+1. **Robust reply capture (no more empty / raw-JSON replies).** The mentee
+   role-handler captured the tmux pane after the session completed — racing
+   the reaper (→ empty reply) and yielding raw codex stream JSON. It now reads
+   the session's persisted transcript: codex → the rollout's
+   `task_complete.last_agent_message` (clean prose), claude → the JSONL
+   transcript's last assistant text. The tmux capture remains a fallback when
+   no transcript is found. New `SessionReplyExtractor` module (pure, unit-
+   tested) + `extractMenteeReplyFromTranscript` wiring.
+
+2. **`isMenteeBusy` is remote-aware.** It checked Echo's LOCAL
+   `sessionManager.listRunningSessions()` — always non-empty, so every mentor
+   tick was wrongly blocked as "busy" (the mentee is a separate remote agent;
+   Echo's local sessions say nothing about it). It now gates on the
+   `OutstandingPromptTracker` — busy iff a prior mentor prompt to this mentee
+   is still unanswered. That's the honest per-mentee signal and the same
+   anti-ping-pong invariant, so real ticks now fire when the mentee is idle.
+
+## What to Tell Your User
+
+The cross-agent mentor cycle now runs cleanly: replies come back as readable
+prose (not empty, not raw stream JSON), and the scheduled mentor tick actually
+fires when the mentee is free (it was previously always self-blocked). No
+config changes.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Transcript-based mentee reply capture | Automatic — the mentee reply is read from the session transcript (codex rollout / claude JSONL), clean prose, robust to the reap race. |
+| Remote-aware mentor safe-window | Automatic — `isMenteeBusy` gates on the outstanding-prompt tracker, so `/mentor/tick` runs when no prior prompt is in-flight. |
+
+## Evidence
+
+10 new unit tests for `SessionReplyExtractor` (codex task_complete / agent_message /
+response_item fallbacks + claude assistant extraction + malformed tolerance),
+all green. mentor-runner + mentor/mentee/inbox suites still green; `tsc
+--noEmit` clean. Live round-trip re-verification (tick-driven, clean prose)
+runs post-release. Side-effects:
+`upgrades/side-effects/mentor-cycle-smoothness.md`.

--- a/upgrades/side-effects/mentor-cycle-smoothness.md
+++ b/upgrades/side-effects/mentor-cycle-smoothness.md
@@ -1,0 +1,48 @@
+# Side-Effects Review — mentor cycle smoothness (capture + busy-gate)
+
+**Spec:** `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` §Recipient side. The two
+fast-follows from the live round-trip: reply-capture reliability + the
+remote-mentee safe-window.
+
+**Change:** new `src/monitoring/SessionReplyExtractor.ts` (pure extractors) +
+`src/server/AgentServer.ts` (`extractMenteeReplyFromTranscript` helper, wired
+into the mentee handler as transcript-first/tmux-fallback; `isMenteeBusy`
+gates on OutstandingPromptTracker) + unit tests.
+
+## What changed
+1. `extractCodexFinalMessage` / `extractClaudeFinalMessage` — pure, tolerant
+   parsers returning the final assistant prose (null when absent).
+2. `extractMenteeReplyFromTranscript(session, spawnTs)` — codex: newest rollout
+   written ≥ spawn → task_complete.last_agent_message; claude: the
+   `<claudeSessionId>.jsonl` under ~/.claude/projects → last assistant text.
+3. Mentee handler: after the bounded-wait, prefer the transcript reply; keep
+   the existing capture-while-alive tmux read as the only fallback.
+4. `isMenteeBusy`: `!getOrCreateMentorOutstanding().canSendTo(menteeAgent).ok`
+   instead of Echo's local session count.
+
+## The seven questions
+1. **Over-block.** isMenteeBusy now blocks LESS (only when a real prompt is
+   outstanding) — it was over-blocking before (always busy). Correct direction;
+   the anti-ping-pong invariant is preserved (one outstanding prompt per mentee).
+2. **Under-block.** The outstanding-prompt gate still prevents concurrent
+   prompts to the same mentee. Transcript reading is read-only (no new writes).
+3. **Level-of-abstraction fit.** Extractors are pure + isolated; the helper
+   reuses findRecentRolloutFiles (existing). isMenteeBusy reuses the existing
+   tracker. No new infrastructure.
+4. **Signal vs authority.** Extractors are pure signal; the handler decides.
+   isMenteeBusy is a gate input to the existing safe-window decision.
+5. **Interactions.** Reads ~/.codex/sessions + ~/.claude/projects (read-only).
+   Reuses OutstandingPromptTracker (shared with deliverToMentee — consistent
+   semantics). No new shared mutable state.
+6. **External surfaces.** None new. mentor-replies.jsonl now carries clean
+   prose instead of stream JSON (content-quality change, same schema).
+7. **Rollback cost.** Trivial — revert restores tmux-only capture + the local
+   session-count busy check.
+
+## Testing
+10 new unit tests (SessionReplyExtractor) green; mentor-runner + mentor/mentee/
+inbox suites green; tsc clean. Live tick-driven round-trip with clean-prose
+capture verified post-release (the autonomous run's completion criterion).
+
+## Migration parity
+No config keys, no state schema change. Pure code. No PostUpdateMigrator change.


### PR DESCRIPTION
The two fast-follows from the live mentor round-trip, so it runs with zero known issues.

1. Robust reply capture. The mentee role-handler captured the tmux pane after the session completed — racing the reaper (empty reply) and yielding raw codex stream JSON. It now reads the session persisted transcript: codex → the rollout task_complete.last_agent_message (clean prose); claude → the JSONL last assistant text. The tmux capture remains a fallback. New SessionReplyExtractor module (pure, 10 unit tests) + extractMenteeReplyFromTranscript wiring.

2. isMenteeBusy remote-aware. It checked Echo LOCAL sessionManager.listRunningSessions() — always non-empty, so every mentor tick was wrongly blocked as busy (the mentee is a separate remote agent; Echo local sessions say nothing about it). It now gates on the OutstandingPromptTracker — busy iff a prior mentor prompt to this mentee is still unanswered. Honest per-mentee signal + the same anti-ping-pong invariant, so real ticks fire when the mentee is idle.

Tests: 10 new unit tests (SessionReplyExtractor: codex task_complete/agent_message/response_item fallbacks + claude assistant extraction + malformed tolerance), all green. mentor-runner + mentor/mentee/inbox suites green. tsc clean. Live tick-driven round-trip with clean-prose capture re-verified post-release.

Side-effects: upgrades/side-effects/mentor-cycle-smoothness.md.

Generated with Claude Code