### PR TITLE
feat(failure-learning): ingestion sources — slice 1b (revert source)

### DIFF
--- a/src/monitoring/RevertDetector.ts
+++ b/src/monitoring/RevertDetector.ts
@@ -1,0 +1,215 @@
+/**
+ * RevertDetector — Ingestion-sources spec §3.2.
+ *
+ * Scans recent commits for `Revert "…"` and records them in the FailureLedger:
+ * a revert is evidence a shipped change was bad enough to pull. Read-only git;
+ * fail-open everywhere.
+ *
+ * Deviation note (spec §3.2 said "fold into the existing reconciler commit-scan
+ * pass"): there is no clean periodic recent-commit scan to hook — the merge-
+ * unreachability reconciler is per-initiative + lazy. So this is a small
+ * dedicated scan on the reconciler cadence. Same outcome, isolated + testable.
+ *
+ * Security (spec §3.2/§4.1 — the highest-risk untrusted-input surface, since
+ * commit messages on main are attacker-authorable):
+ *  - A revert may **auto-CLOSE** an existing open record ONLY after a cross-check:
+ *    (1) the reverted OID is a real reachable commit, AND (2) the revert's diff
+ *    actually intersects the reverted commit's files. A hand-written "This
+ *    reverts commit <oid>" that fails either check NEVER auto-closes — it may
+ *    only OPEN an `inferred` record.
+ *  - Close is matched on initiative AND causeCommitOid (not initiative alone) so
+ *    a minimal real revert can't close an unrelated record for the same feature.
+ *  - Revert² (a revert of a revert / re-land) is skipped — not a failure.
+ *  - Close goes through update()'s mandatory ifMatch with a bounded CAS retry.
+ *  - Constant filedBy 'source:revert' (analyzer session-diversity, spec §5).
+ *  - Loop self-exclusion (§4.3) is inert until slice 2 adds Initiative.origin.
+ */
+import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
+import type { FailureLedger } from './FailureLedger.js';
+
+export interface RevertInitiativeRef {
+  id: string;
+  projectId?: string;
+  specPath?: string;
+  origin?: string;
+}
+
+export interface RevertDetectorOptions {
+  ledger: FailureLedger;
+  /** Resolve the initiative owning a commit OID (InitiativeTracker.findByMergeCommit). */
+  resolveByCommit: (oid: string) => RevertInitiativeRef | undefined;
+  /** Repo dir for git reads. */
+  cwd: string;
+  /** Injectable git runner (args → stdout). Default: SafeGitExecutor.readSync. */
+  git?: (args: string[]) => string;
+  isLeaseHolder?: () => boolean;
+  intervalMs?: number;
+  /** How many recent commits to scan per tick. Default 100. */
+  scanWindow?: number;
+  onError?: (err: unknown) => void;
+}
+
+const SEP_FIELD = '';
+const SEP_REC = '';
+const REVERTED_OID_RE = /This reverts commit ([0-9a-f]{7,40})/;
+
+interface RevertCommit { hash: string; subject: string; revertedOid: string; }
+
+export class RevertDetector {
+  private readonly ledger: FailureLedger;
+  private readonly resolveByCommit: (oid: string) => RevertInitiativeRef | undefined;
+  private readonly cwd: string;
+  private readonly git: (args: string[]) => string;
+  private readonly isLeaseHolder: () => boolean;
+  private readonly intervalMs: number;
+  private readonly scanWindow: number;
+  private readonly onError: (err: unknown) => void;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(opts: RevertDetectorOptions) {
+    this.ledger = opts.ledger;
+    this.resolveByCommit = opts.resolveByCommit;
+    this.cwd = opts.cwd;
+    this.git = opts.git ?? ((args) => SafeGitExecutor.readSync(args, { cwd: this.cwd, operation: 'failure-learning:revert-detect' }));
+    this.isLeaseHolder = opts.isLeaseHolder ?? (() => true);
+    this.intervalMs = opts.intervalMs && opts.intervalMs > 0 ? opts.intervalMs : 6 * 60 * 60 * 1000;
+    this.scanWindow = opts.scanWindow && opts.scanWindow > 0 ? opts.scanWindow : 100;
+    this.onError = opts.onError ?? ((err) => console.warn('[revert-detector]', err));
+  }
+
+  start(): void {
+    if (this.timer) return;
+    queueMicrotask(() => this.tick());
+    this.timer = setInterval(() => this.tick(), this.intervalMs);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+  }
+
+  /** Parse `git log` output into revert commits with a reverted OID. Pure (testable). */
+  parseReverts(logOut: string): RevertCommit[] {
+    const out: RevertCommit[] = [];
+    for (const rec of logOut.split(SEP_REC)) {
+      const trimmed = rec.trim();
+      if (!trimmed) continue;
+      const [hash, subject, body] = trimmed.split(SEP_FIELD);
+      if (!hash || !subject || !/^Revert\b/.test(subject)) continue;
+      const m = REVERTED_OID_RE.exec(body || '');
+      if (!m) continue;
+      out.push({ hash: hash.trim(), subject: subject.trim(), revertedOid: m[1] });
+    }
+    return out;
+  }
+
+  private touchedFiles(oid: string): string[] {
+    try {
+      return this.git(['show', '--name-only', '--pretty=format:', oid])
+        .split('\n').map((s) => s.trim()).filter(Boolean);
+    } catch { return []; }
+  }
+
+  private isReachable(oid: string): boolean {
+    try { this.git(['cat-file', '-e', `${oid}^{commit}`]); return true; } catch { return false; }
+  }
+
+  private isRevertCommit(oid: string): boolean {
+    try { return /^Revert\b/.test(this.git(['log', '-1', '--format=%s', oid]).trim()); } catch { return false; }
+  }
+
+  /** One scan. Public for tests. Returns # ledger writes (opens + closes). */
+  tick(): number {
+    if (this.running) return 0;
+    this.running = true;
+    let acted = 0;
+    try {
+      if (!this.isLeaseHolder()) return 0;
+      let logOut = '';
+      try {
+        logOut = this.git([
+          'log', `-n`, String(this.scanWindow), '--grep=^Revert', '--regexp-ignore-case=false',
+          `--format=%H${SEP_FIELD}%s${SEP_FIELD}%b${SEP_REC}`,
+        ]);
+      } catch (err) { this.onError(err); return 0; }
+      for (const rev of this.parseReverts(logOut)) {
+        try {
+          // Revert² / re-land is not a failure.
+          if (this.isRevertCommit(rev.revertedOid)) continue;
+          // Cross-check gates auto-close (§3.2): reachable + diff intersects.
+          const reachable = this.isReachable(rev.revertedOid);
+          const revertFiles = new Set(this.touchedFiles(rev.hash));
+          const revertedFiles = this.touchedFiles(rev.revertedOid);
+          const intersects = revertedFiles.some((f) => revertFiles.has(f));
+          const crossCheckOk = reachable && intersects;
+
+          const mapped = this.resolveByCommit(rev.revertedOid);
+          if (mapped && mapped.origin === 'failure-learning-loop') continue; // loop self-exclusion (§4.3)
+
+          // Decision tree (idempotent across ticks):
+          // 1. Trusted revert + matching ACTIVE original record → close it.
+          // 2. Trusted revert already closed an original (resolved non-revert
+          //    record for this cause) → done, do NOT also open a forensic.
+          // 3. A forensic 'revert' record already exists for this OID → done.
+          // 4. Otherwise → open a resolved forensic record.
+          const activeMatch = mapped
+            ? this.ledger.list({ initiativeId: mapped.id } as never)
+                .find((r) => r.causeCommitOid === rev.revertedOid && r.status !== 'resolved')
+            : undefined;
+          if (crossCheckOk && activeMatch) {
+            if (this.closeWithRetry(activeMatch.id)) acted += 1; // (1) trusted close, CAS retry
+            continue;
+          }
+          if (crossCheckOk && mapped && this.ledger.list({ initiativeId: mapped.id } as never)
+              .some((r) => r.causeCommitOid === rev.revertedOid && r.status === 'resolved' && r.source !== 'revert')) {
+            continue; // (2) already trusted-closed on a prior tick — idempotent, no forensic
+          }
+          if (this.ledger.list({ source: 'revert' } as never)
+              .some((r) => r.causeCommitOid === rev.revertedOid)) {
+            continue; // (3) forensic already recorded — idempotent
+          }
+          // (4) record the revert as a resolved forensic entry. Untrusted
+          // (cross-check failed) → inferred; trusted+mapped → automatic.
+          const attribution = crossCheckOk && mapped ? 'automatic' : 'inferred';
+          const rec = this.ledger.open({
+            source: 'revert', severity: 'medium', category: 'regression',
+            summary: `Reverted: ${rev.subject}`,
+            detail: { redacted: `revert of ${rev.revertedOid.slice(0, 12)}`, full: `${rev.hash} reverts ${rev.revertedOid}` },
+            causeCommitOid: rev.revertedOid,
+            initiativeId: crossCheckOk ? mapped?.id : undefined,
+            projectId: crossCheckOk ? mapped?.projectId : undefined,
+            specPath: crossCheckOk ? mapped?.specPath : undefined,
+            filedBy: 'source:revert',
+            attribution,
+            attributionConfidence: attribution === 'automatic' ? 0.9 : 0.2,
+          });
+          // Opened revert records are forensic (status 'resolved' → excluded
+          // from active clustering §6.1). open() inserts 'open'; flip to resolved.
+          if (rec) { this.closeWithRetry(rec.id); acted += 1; }
+        } catch (err) {
+          this.onError(err); // per-commit fail-open
+        }
+      }
+    } catch (err) {
+      this.onError(err);
+    } finally {
+      this.running = false;
+    }
+    return acted;
+  }
+
+  /** Mark a record resolved with a bounded ifMatch CAS retry (update() requires ifMatch). */
+  private closeWithRetry(id: string): boolean {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const cur = this.ledger.get(id);
+      if (!cur) return false;
+      if (cur.status === 'resolved') return true; // already closed (idempotent)
+      const res = this.ledger.update(id, { status: 'resolved' }, cur.version);
+      if (res.ok) return true;
+      if (!res.ok && !res.conflict) return false; // not-found / unrecoverable
+      // conflict → re-read and retry
+    }
+    return false;
+  }
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -47,6 +47,7 @@ import { createTopicIntentRoutes } from './topicIntentRoutes.js';
 import { FailureLedger } from '../monitoring/FailureLedger.js';
 import { FailureAttributionEngine } from '../monitoring/FailureAttributionEngine.js';
 import { CiFailurePoller } from '../monitoring/CiFailurePoller.js';
+import { RevertDetector } from '../monitoring/RevertDetector.js';
 import { SafeGitExecutor } from '../core/SafeGitExecutor.js';
 import { createSpecReviewRoutes } from './specReviewRoutes.js';
 import { createUsherRoutes } from './usherRoutes.js';
@@ -122,6 +123,7 @@ export class AgentServer {
   private failureLedger: FailureLedger | null = null;
   private failureAttributionEngine: FailureAttributionEngine | null = null;
   private ciFailurePoller: CiFailurePoller | null = null;
+  private revertDetector: RevertDetector | null = null;
   // Burn-detection-and-self-heal system (six-phase umbrella spec at
   // docs/specs/token-burn-detection-and-self-heal.md). Lazy-initialised
   // after the TokenLedger comes up — burn detection without a ledger is
@@ -624,12 +626,27 @@ export class AgentServer {
             maxRunsPerTick: sources.ciMaxRunsPerTick,
           });
         }
+
+        // Ingestion source: `revert` (spec §3.2). Gated on sources.revert;
+        // started post-listen, stopped on shutdown.
+        if (sources?.revert === true && this.failureLedger) {
+          this.revertDetector = new RevertDetector({
+            ledger: this.failureLedger,
+            cwd: projectDir,
+            resolveByCommit: (oid) => {
+              const i = tracker?.findByMergeCommit(oid);
+              // `origin` (loop self-exclusion §4.3) arrives with slice 2; inert until then.
+              return i ? { id: i.id, projectId: i.parentProjectId ?? undefined, specPath: i.specPath ?? undefined } : undefined;
+            },
+          });
+        }
       }
     } catch (err) {
       console.warn('[instar] failure-learning init failed (non-fatal):', err);
       this.failureLedger = null;
       this.failureAttributionEngine = null;
       this.ciFailurePoller = null;
+      this.revertDetector = null;
     }
 
     // Routes
@@ -1746,6 +1763,14 @@ export class AgentServer {
             console.warn('[instar] ci-failure poller start failed:', err);
           }
         }
+        // Ingestion source `revert` (spec §3.2).
+        if (this.revertDetector) {
+          try {
+            this.revertDetector.start();
+          } catch (err) {
+            console.warn('[instar] revert-detector start failed:', err);
+          }
+        }
 
         resolve();
       });
@@ -1876,6 +1901,15 @@ export class AgentServer {
         // best-effort
       }
       this.ciFailurePoller = null;
+    }
+    // Stop the revert detector (ingestion source §3.2).
+    if (this.revertDetector) {
+      try {
+        this.revertDetector.stop();
+      } catch {
+        // best-effort
+      }
+      this.revertDetector = null;
     }
     // Stop the token-ledger poller and close its DB.
     if (this.tokenLedgerPoller) {

--- a/tests/unit/CiFailurePoller-wiring.test.ts
+++ b/tests/unit/CiFailurePoller-wiring.test.ts
@@ -28,31 +28,40 @@ function build(project: TempProject, failureLearning: unknown) {
     sessionManager: createMockSessionManager() as never,
     state: project.state,
     initiativeTracker: trackerStub,
-  } as never) as unknown as { ciFailurePoller: unknown; failureLedger: unknown };
+  } as never) as unknown as { ciFailurePoller: unknown; revertDetector: unknown; failureLedger: unknown };
 }
 
-describe('CiFailurePoller wiring (constructed iff gated)', () => {
+describe('CI poller + revert detector wiring (each constructed iff its flag is set)', () => {
   let project: TempProject;
   afterEach(() => project?.cleanup?.());
 
-  it('constructed when failureLearning.enabled && sources.ci', () => {
+  it('ci poller constructed when failureLearning.enabled && sources.ci', () => {
     project = createTempProject();
     const s = build(project, { enabled: true, sources: { ci: true } });
     expect(s.failureLedger).not.toBeNull();
     expect(s.ciFailurePoller).not.toBeNull();
   });
 
-  it('NOT constructed when sources.ci is false (but the ledger still is)', () => {
+  it('revert detector constructed when failureLearning.enabled && sources.revert', () => {
     project = createTempProject();
-    const s = build(project, { enabled: true, sources: { ci: false } });
-    expect(s.failureLedger).not.toBeNull();
-    expect(s.ciFailurePoller).toBeNull();
+    const s = build(project, { enabled: true, sources: { revert: true } });
+    expect(s.revertDetector).not.toBeNull();
+    expect(s.ciFailurePoller).toBeNull(); // independent flags
   });
 
-  it('NOT constructed when failureLearning is disabled', () => {
+  it('NEITHER constructed when their flags are false (but the ledger still is)', () => {
     project = createTempProject();
-    const s = build(project, { enabled: false, sources: { ci: true } });
+    const s = build(project, { enabled: true, sources: { ci: false, revert: false } });
+    expect(s.failureLedger).not.toBeNull();
+    expect(s.ciFailurePoller).toBeNull();
+    expect(s.revertDetector).toBeNull();
+  });
+
+  it('NEITHER constructed when failureLearning is disabled', () => {
+    project = createTempProject();
+    const s = build(project, { enabled: false, sources: { ci: true, revert: true } });
     expect(s.failureLedger).toBeNull();
     expect(s.ciFailurePoller).toBeNull();
+    expect(s.revertDetector).toBeNull();
   });
 });

--- a/tests/unit/RevertDetector.test.ts
+++ b/tests/unit/RevertDetector.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for RevertDetector (Ingestion-sources spec §3.2) — the highest-risk
+ * untrusted-input source. Drives the real detector against a real in-memory
+ * FailureLedger with an injected git runner.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FailureLedger } from '../../src/monitoring/FailureLedger.js';
+import { RevertDetector } from '../../src/monitoring/RevertDetector.js';
+import type { OpenFailureInput } from '../../src/monitoring/FailureLedger.js';
+
+const F = '\x1f';
+const R = '\x1e';
+
+/** Build `git log` output for the detector's --format. */
+function log(commits: Array<{ hash: string; subject: string; body: string }>): string {
+  return commits.map((c) => `${c.hash}${F}${c.subject}${F}${c.body}`).join(R) + R;
+}
+
+interface GitSpec {
+  logOut: string;
+  unreachable?: Set<string>;
+  subjects?: Record<string, string>; // oid → subject (for revert² check)
+  files?: Record<string, string[]>;  // oid → touched files
+}
+function fakeGit(spec: GitSpec) {
+  return (args: string[]): string => {
+    if (args[0] === 'log' && args.some((a) => a.startsWith('--grep'))) return spec.logOut;
+    if (args[0] === 'cat-file') {
+      const oid = String(args[2]).replace('^{commit}', '');
+      if (spec.unreachable?.has(oid)) throw new Error('not found');
+      return '';
+    }
+    if (args[0] === 'log' && args[1] === '-1') return spec.subjects?.[String(args[args.length - 1])] ?? 'a normal commit';
+    if (args[0] === 'show') return (spec.files?.[String(args[args.length - 1])] ?? []).join('\n');
+    return '';
+  };
+}
+
+function seedOpen(ledger: FailureLedger, over: Partial<OpenFailureInput>) {
+  return ledger.open({
+    filedBy: 's1', source: 'bugfix-commit', severity: 'medium',
+    summary: 'orig', detail: { redacted: 'r', full: 'f' }, category: 'logic',
+    attribution: 'automatic', attributionConfidence: 0.9, ...over,
+  })!;
+}
+
+describe('RevertDetector.parseReverts (pure)', () => {
+  const d = new RevertDetector({ ledger: { } as never, resolveByCommit: () => undefined, cwd: '/tmp' });
+  it('parses revert commits with a reverted OID; skips non-reverts + reverts w/o OID', () => {
+    const out = d.parseReverts(log([
+      { hash: 'h1', subject: 'Revert "feat: x"', body: 'This reverts commit abc123def456.' },
+      { hash: 'h2', subject: 'feat: normal', body: 'not a revert' },
+      { hash: 'h3', subject: 'Revert "y"', body: 'no oid line here' },
+    ]));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ hash: 'h1', revertedOid: 'abc123def456' });
+  });
+});
+
+describe('RevertDetector.tick (§3.2 close-or-open + cross-check)', () => {
+  let ledger: FailureLedger;
+  beforeEach(() => { ledger = new FailureLedger({ dbPath: ':memory:', machineId: 'tb' }); });
+  afterEach(() => ledger.close());
+
+  function detector(spec: GitSpec, resolve: (oid: string) => any = () => undefined) {
+    return new RevertDetector({ ledger, resolveByCommit: resolve, cwd: '/tmp', git: fakeGit(spec), onError: () => {} });
+  }
+
+  it('closes a matching OPEN record when the cross-check passes (reachable + diff intersects)', () => {
+    const rec = seedOpen(ledger, { initiativeId: 'init-x', causeCommitOid: 'deadbeef1234' });
+    const d = detector({
+      logOut: log([{ hash: 'rev1', subject: 'Revert "feat"', body: 'This reverts commit deadbeef1234.' }]),
+      files: { rev1: ['src/a.ts'], deadbeef1234: ['src/a.ts'] }, // intersect
+    }, (oid) => (oid === 'deadbeef1234' ? { id: 'init-x' } : undefined));
+    expect(d.tick()).toBe(1);
+    expect(ledger.get(rec.id)!.status).toBe('resolved');
+  });
+
+  it('does NOT close on a failed cross-check (no file intersection) — opens an inferred forensic record instead', () => {
+    const rec = seedOpen(ledger, { initiativeId: 'init-y', causeCommitOid: 'cafe00001111' });
+    const d = detector({
+      logOut: log([{ hash: 'rev2', subject: 'Revert "z"', body: 'This reverts commit cafe00001111.' }]),
+      files: { rev2: ['src/other.ts'], cafe00001111: ['src/z.ts'] }, // NO intersection
+    }, (oid) => (oid === 'cafe00001111' ? { id: 'init-y' } : undefined));
+    d.tick();
+    expect(ledger.get(rec.id)!.status).not.toBe('resolved'); // original NOT closed
+    const reverts = ledger.list({ source: 'revert' as never });
+    expect(reverts).toHaveLength(1);
+    expect(reverts[0].attribution).toBe('inferred'); // untrusted → inferred
+  });
+
+  it('opens a resolved forensic record when there is no matching open record (cross-check ok → automatic)', () => {
+    const d = detector({
+      logOut: log([{ hash: 'rev3', subject: 'Revert "w"', body: 'This reverts commit 99998888aaaa.' }]),
+      files: { rev3: ['src/w.ts'], '99998888aaaa': ['src/w.ts'] },
+    }, () => ({ id: 'init-w' }));
+    expect(d.tick()).toBe(1);
+    const reverts = ledger.list({ source: 'revert' as never });
+    expect(reverts).toHaveLength(1);
+    expect(reverts[0].status).toBe('resolved'); // forensic, excluded from active clustering
+    expect(reverts[0].attribution).toBe('automatic');
+  });
+
+  it('skips a revert-of-a-revert (re-land is not a failure)', () => {
+    const d = detector({
+      logOut: log([{ hash: 'rev4', subject: 'Revert "Revert ..."', body: 'This reverts commit 1212revertoid.' }]),
+      subjects: { '1212revertoid': 'Revert "feat: original"' }, // the reverted commit is itself a revert
+      files: { rev4: ['src/a.ts'], '1212revertoid': ['src/a.ts'] },
+    });
+    expect(d.tick()).toBe(0);
+    expect(ledger.list({ source: 'revert' as never })).toHaveLength(0);
+  });
+
+  it('treats an unreachable reverted OID as untrusted (never closes; inferred)', () => {
+    const rec = seedOpen(ledger, { initiativeId: 'init-u', causeCommitOid: 'baadf00d5678' });
+    const d = detector({
+      logOut: log([{ hash: 'rev5', subject: 'Revert "u"', body: 'This reverts commit baadf00d5678.' }]),
+      unreachable: new Set(['baadf00d5678']),
+      files: { rev5: ['src/u.ts'] },
+    }, () => ({ id: 'init-u' }));
+    d.tick();
+    expect(ledger.get(rec.id)!.status).not.toBe('resolved');
+    expect(ledger.list({ source: 'revert' as never })[0].attribution).toBe('inferred');
+  });
+
+  it('skips a revert mapped to a failure-learning-loop-origin initiative (loop self-exclusion §4.3)', () => {
+    const d = detector({
+      logOut: log([{ hash: 'rev6', subject: 'Revert "loop fix"', body: 'This reverts commit 7777loop8888.' }]),
+      files: { rev6: ['src/a.ts'], '7777loop8888': ['src/a.ts'] },
+    }, () => ({ id: 'failure-insight-x', origin: 'failure-learning-loop' }));
+    expect(d.tick()).toBe(0);
+    expect(ledger.list({ source: 'revert' as never })).toHaveLength(0);
+  });
+
+  it('is idempotent — a second tick does not re-close or re-open for the same revert', () => {
+    seedOpen(ledger, { initiativeId: 'init-i', causeCommitOid: 'abcdef001111' });
+    const d = detector({
+      logOut: log([{ hash: 'rev7', subject: 'Revert "i"', body: 'This reverts commit abcdef001111.' }]),
+      files: { rev7: ['src/i.ts'], abcdef001111: ['src/i.ts'] },
+    }, () => ({ id: 'init-i' }));
+    expect(d.tick()).toBe(1); // first closes
+    expect(d.tick()).toBe(0); // second: no open record left → no action
+  });
+
+  it('fail-open: git log throwing files nothing and does not raise', () => {
+    const d = new RevertDetector({
+      ledger, resolveByCommit: () => undefined, cwd: '/tmp',
+      git: () => { throw new Error('not a git repo'); }, onError: () => {},
+    });
+    expect(() => expect(d.tick()).toBe(0)).not.toThrow();
+  });
+});

--- a/upgrades/1.3.61.md
+++ b/upgrades/1.3.61.md
@@ -4,29 +4,24 @@
 
 ## What Changed
 
-First automatic feed for the Failure-Learning Loop (spec `docs/specs/FAILURE-LEARNING-INGESTION-SOURCES-SPEC.md`, converged + approved). Until now the loop's ledger could only be filled by hand; this adds the **CI-failure source** so failed CI runs land in the ledger on their own — plus the shared groundwork the rest of the ingestion sources will build on. Ships behind `monitoring.failureLearning.sources.ci` (default **off**); when off, nothing changes.
+Second automatic feed for the Failure-Learning Loop: the **revert source** (spec `docs/specs/FAILURE-LEARNING-INGESTION-SOURCES-SPEC.md` §3.2). This completes the approved "CI + reverts" first slice — the CI source shipped in the prior release; this adds detection of *undone changes*. Off by default (`monitoring.failureLearning.sources.revert`); no change when off.
 
-The CI source is a background poller that lists recent CI runs via `gh` (arg-array only; the repo is parsed from the git remote and strictly validated), files the genuinely-failing ones into the ledger, and is careful about it: a flaky run that later passes on re-run is dropped (not filed as a process failure); attribution is exact-commit (a run's head SHA → the matching feature) or else "best guess / not linked"; it is rate-budget-friendly (polls once per fleet on the lease-holder, on the ~6h reconciler cadence) and fail-open (a missing/unauthed `gh`, a rate-limit, or bad output just skips the tick).
-
-Shared groundwork in this release (all additive): three new failure categories (`build-failure`, `test-failure`, `regression`) so CI/revert/regression failures are no longer collapsed to "unknown"; a bounded forensic log so the occurrence table can't grow without limit; an upsert so two processes racing to record the same failure increment a count instead of dropping one; and the analyzer now excludes already-resolved failures from its active pattern-finding (a requirement the parent spec named but had never actually been built).
-
-This is **part 1 of 2** for the first slice — the revert source (catching when a change is undone) follows in a companion PR.
+When a change is reverted, that's strong evidence the original was bad enough to pull. The revert source scans recent commits for `Revert "…"` and records it — but it is careful, because commit messages are attacker-authorable: it will only mark an existing recorded failure as resolved if the revert genuinely reverses that commit (the reverted commit is real and reachable AND the revert's diff actually touches the same files), and the match is on both the feature and the exact commit — so a hand-written "this reverts X" can't quietly close someone else's record. A revert that fails those checks can at most file a low-confidence note, never close anything. A revert-of-a-revert (a re-land) is ignored — it isn't a failure.
 
 ## What to Tell Your User
 
-- The failure-watching system can now notice failed CI runs on its own — no more empty notebook waiting on hand-entered problems. It's off until switched on, and even then it just quietly records (no alerts).
-- It's careful: a test that fails once and passes on a retry doesn't get logged as a real problem, and it can't be fooled into mis-filing by a branch name.
+- The failure-watcher now also notices when a change gets undone — and treats that as "this was probably a real problem." It's careful not to be fooled by a faked undo message into marking the wrong thing as solved.
+- Like the CI watcher, it's off until switched on and only quietly records — no alerts.
+- This finishes the first set of automatic feeds (failed builds + undone changes). The next sets (a shipped feature breaking, and runtime fallbacks) are separate, later steps.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| CI-failure ingestion source | Set `monitoring.failureLearning.sources.ci: true` (needs `gh` installed + authed on the machine) |
-| New failure categories | Automatic — build/test/regression failures now categorize instead of collapsing to "unknown" |
-| Bounded occurrence log + race-safe upsert | Automatic — keeps the ledger's forensic table bounded and never drops a raced write |
+| Revert ingestion source | Set `monitoring.failureLearning.sources.revert: true` |
 
 ## Evidence
 
-- 20 tests green: CiFailurePoller (12 — category mapping, flaky guard, secret-scrub, mapped/unmapped/loop-skip/untrusted-repo/fail-open/per-tick-cap/lease-gate), substrate (5 — new categories survive, occurrence retention bounded, upsert increments, analyzer status-filter both sides), wiring-integrity (3 — the poller is constructed iff `enabled && sources.ci`, never dead code).
-- `tsc --noEmit` clean; existing failure-learning tests unaffected.
-- Spec converged over 3 code-grounded review rounds (report: `docs/specs/reports/failure-learning-ingestion-sources-convergence.md`); side-effects review: `upgrades/side-effects/failure-learning-ingestion-sources.md`.
+- 13 tests green: RevertDetector (9 — parse, trusted close, failed-cross-check-no-close, no-original forensic record, revert² skip, unreachable→low-confidence, loop self-exclusion, idempotent across ticks, fail-open), wiring-integrity (4 — CI poller + revert detector each constructed iff its own flag is set).
+- `tsc --noEmit` clean; existing failure-learning + slice-1a tests unaffected.
+- Side-effects review: `upgrades/side-effects/failure-learning-revert-source.md`.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,27 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+Second automatic feed for the Failure-Learning Loop: the **revert source** (spec `docs/specs/FAILURE-LEARNING-INGESTION-SOURCES-SPEC.md` §3.2). This completes the approved "CI + reverts" first slice — the CI source shipped already; this adds detection of *undone changes*. Off by default (`monitoring.failureLearning.sources.revert`); no change when off.
+
+When a change is reverted, that's strong evidence the original was bad enough to pull. The revert source scans recent commits for `Revert "…"` and records it — but it is careful, because commit messages are attacker-authorable: it will only mark an existing recorded failure as resolved if the revert genuinely reverses that commit (the reverted commit is real and reachable AND the revert's diff actually touches the same files), and the match is on both the feature and the exact commit — so a hand-written "this reverts X" can't quietly close someone else's record. A revert that fails those checks can at most file a low-confidence note, never close anything. A revert-of-a-revert (a re-land) is ignored — it isn't a failure.
+
+## What to Tell Your User
+
+- The failure-watcher now also notices when a change gets undone — and treats that as "this was probably a real problem." It's careful not to be fooled by a faked undo message into marking the wrong thing as solved.
+- Like the CI watcher, it's off until switched on and only quietly records — no alerts.
+- This finishes the first set of automatic feeds (failed builds + undone changes). The next sets (a shipped feature breaking, and runtime fallbacks) are separate, later steps.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Revert ingestion source | Set `monitoring.failureLearning.sources.revert: true` |
+
+## Evidence
+
+- 13 tests green: RevertDetector (9 — parse, trusted close, failed-cross-check-no-close, no-original forensic record, revert² skip, unreachable→low-confidence, loop self-exclusion, idempotent across ticks, fail-open), wiring-integrity (4 — CI poller + revert detector each constructed iff its own flag is set).
+- `tsc --noEmit` clean; existing failure-learning + slice-1a tests unaffected.
+- Side-effects review: `upgrades/side-effects/failure-learning-revert-source.md`.

--- a/upgrades/side-effects/failure-learning-revert-source.md
+++ b/upgrades/side-effects/failure-learning-revert-source.md
@@ -1,0 +1,41 @@
+# Side-Effects Review — Failure-Learning Revert Source (slice 1b)
+
+**Slug:** `failure-learning-revert-source`
+**Date:** 2026-05-28
+**Author:** echo
+**Spec:** `docs/specs/FAILURE-LEARNING-INGESTION-SOURCES-SPEC.md` §3.2 (CONVERGED v3.1, approved — Justin, topic 13201)
+
+## Summary
+
+Slice 1b of the ingestion-sources build: the `revert` automatic source (the second half of the approved "ci + revert" slice 1; slice 1a — CI source + substrate — already merged in PR #482). Off by default (`monitoring.failureLearning.sources.revert`); fail-open + near-silent.
+
+## Files
+
+- `src/monitoring/RevertDetector.ts` (NEW): scans recent commits for `Revert "…"`, extracts the reverted OID, and records reverts in the ledger. The highest-risk untrusted-input surface, hardened per §3.2:
+  - **Auto-CLOSE cross-check:** a revert closes an existing open record ONLY if (1) the reverted OID is a reachable commit AND (2) the revert's diff intersects the reverted commit's files. A hand-written `This reverts commit <oid>` failing either check NEVER auto-closes — it may only open an `inferred` forensic record.
+  - **Close match on initiative AND causeCommitOid** (not initiative alone — close-griefing protection).
+  - **Revert² skip** (re-land is not a failure).
+  - **ifMatch CAS retry** for the close (update() requires ifMatch).
+  - **Idempotent** decision tree across ticks (trusted-close vs already-closed vs forensic-exists vs open-new) — no re-close, no duplicate forensic records.
+  - Constant `filedBy:'source:revert'`; forensic records opened `status:'resolved'` (excluded from active clustering §6.1); loop self-exclusion (§4.3) inert until slice 2's `origin`.
+  - Read-only git via `SafeGitExecutor.readSync` (injectable for tests); fail-open per-commit + per-tick.
+- `src/server/AgentServer.ts`: construct `RevertDetector` gated on `failureLearning.enabled && sources.revert`; start post-listen; stop on shutdown (mirrors the CI poller).
+- Tests: `tests/unit/RevertDetector.test.ts` (9 — parse, trusted close, failed-cross-check-no-close, no-original forensic, revert² skip, unreachable→inferred, loop-skip, idempotent, fail-open); `tests/unit/CiFailurePoller-wiring.test.ts` extended (revert detector constructed iff `enabled && sources.revert`; independent flags).
+
+## Decision points
+
+- **Dedicated scan vs fold into reconciler?** The spec said "fold into the existing reconciler commit-scan," but no clean periodic recent-commit scan exists (the merge-unreachability reconciler is per-initiative + lazy). Built a small dedicated `git log --grep=^Revert` scan on the reconciler cadence — same outcome, isolated + testable. Deviation noted.
+- **Open forensic records as `resolved`?** Yes (§3.2) — a revert is a historical event, not an active failure; `resolved` → excluded from the analyzer's active clustering (§6.1). `open()` inserts `'open'`, so the detector flips it to `resolved` via the CAS path.
+- **Close-or-open idempotency** required a 4-branch decision tree (trusted-close / already-trusted-closed / forensic-exists / open-new) so re-ticks neither re-close nor duplicate.
+
+## Side-effects analysis
+
+- **Behavioral:** Additive, off by default. When on, it only writes/closes ledger records; no user messaging, no build/request impact.
+- **Security:** This is the untrusted-commit-message surface. The cross-check (reachability + diff intersection) + initiative+causeCommitOid close-match are the close-griefing mitigations; an untrusted revert can at most open an `inferred` forensic record (excluded from analysis). `detail.full` is short + non-secret-bearing (commit OIDs); the redaction contract is unaffected (it flows through the same `open()`/`toApiView`).
+- **Migration:** `sources.revert` already shipped in the config block (slice 1a, default false); no new migration.
+- **Reversibility:** Fully reversible; disabling the flag stops the detector (records stay inert).
+
+## Evidence
+
+- `tsc --noEmit` clean.
+- 13 tests green: RevertDetector (9, both sides of every cross-check branch), wiring-integrity (4, CI + revert each constructed iff its flag). Existing failure-learning + slice-1a tests unaffected.


### PR DESCRIPTION
## What

Completes the approved **slice 1** ("CI + reverts") of the Failure-Learning ingestion sources. Slice 1a (CI source + substrate) merged in #482; this adds the **revert source** (spec §3.2). Off by default (`monitoring.failureLearning.sources.revert`).

A revert is evidence a shipped change was bad enough to pull. This is the **highest-risk untrusted-input surface** (commit messages on main are attacker-authorable), so it's hardened accordingly.

## In this PR

- **`RevertDetector`** (§3.2): scans recent commits for `Revert "…"`, extracts the reverted OID, records it.
  - **Auto-CLOSE only after a cross-check**: the reverted OID must be a reachable commit AND the revert's diff must intersect the reverted commit's files. A hand-written `This reverts commit <oid>` failing either check **never auto-closes** — it can at most open an `inferred` forensic record.
  - **Close matched on initiative AND causeCommitOid** (not initiative alone) — close-griefing protection.
  - **Revert² (re-land) skipped**; **ifMatch CAS retry** on close; **idempotent** across ticks (trusted-close / already-closed / forensic-exists / open-new tree); forensic records opened `status:'resolved'` (excluded from active clustering §6.1); constant `filedBy:'source:revert'`; loop self-exclusion inert until slice 2.
  - Read-only git (`SafeGitExecutor`); fail-open per-commit + per-tick.
- **`AgentServer`**: construct gated on `enabled && sources.revert`; start post-listen; stop on shutdown (mirrors the CI poller).

Deviation noted: spec said "fold into the existing reconciler commit-scan," but no clean periodic recent-commit scan exists — built a small dedicated `git log --grep=^Revert` scan on the reconciler cadence (same outcome, isolated + testable).

## Tests (13)

RevertDetector (9 — parse; trusted close; failed-cross-check → no close + inferred forensic; no-original forensic; revert² skip; unreachable → inferred; loop self-exclusion; idempotent across ticks; fail-open) + wiring-integrity (4 — CI poller + revert detector each constructed iff its own flag). `tsc` clean.

## After this

Slice 1 (CI + reverts) complete. Remaining: slice 2 (regression source + `origin` threading that activates the loop self-exclusion), slice 3 (degradation, dashboard-only), and an agent-awareness note for the `sources.*` flags. Tracked in spec §10/§12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)