### PR TITLE
feat(monitoring): ContextWedgeSentinel — detect+recover thinking-block-400 session wedge

### DIFF
--- a/docs/specs/context-wedge-sentinel.eli16.md
+++ b/docs/specs/context-wedge-sentinel.eli16.md
@@ -1,0 +1,42 @@
+# ContextWedgeSentinel — Plain-English Overview
+
+> The one-line version: when a session gets permanently stuck on a specific "can't edit the thinking block" error and dies while still looking busy, we now notice it and (optionally) restart it cleanly.
+
+## The problem in one breath
+
+A session got permanently stuck and Justin only saw "standby" replies while the real session failed instantly on every message. The cause: when a tool call gets cancelled inside a *batch* of parallel tool calls while the model is using extended thinking, the harness corrupts the thinking part of the last turn — and after that, the AI service rejects every attempt to continue with a `400 … thinking blocks … cannot be modified` error. The session is dead but keeps printing the error, so none of our existing "is a session stuck?" watchers caught it.
+
+## What already exists
+
+- **The silently-stopped sentinels** — two existing watchers. One notices when a session goes *quiet* (stops printing anything); the other notices when a session loses its connection. Both try a gentle "nudge" (press Enter) to wake it.
+- **SessionRefresh** — the existing machinery that kills a session and respawns it while *keeping* the conversation (it resumes from where it left off).
+- **The audit log** — every watcher writes what it sees to a `sentinel-events.jsonl` file; by default the user never gets pinged.
+- **The Graduated Feature Rollout track** — the system that lets a risky feature ship "off," watches whether it proves itself, and nags toward turning it on for everyone.
+
+## What this adds
+
+A third watcher — the **ContextWedgeSentinel** — that recognizes this exact "stuck on a thinking-block error" death and can recover from it. The crucial twist: a gentle nudge can't fix this one (re-trying just re-sends the broken turn and hits the same error), so recovery means a *fresh* restart that throws away the corrupted conversation instead of resuming it.
+
+- Noticing the problem and writing it to the audit log is **on by default** — it's harmless, it never touches a session.
+- Actually restarting a stuck session is **off by default** and opt-in, because restarting is destructive.
+
+## The new pieces
+
+- **ContextWedgeSentinel** — watches each session for the thinking-block error showing up as the *live tail* of the screen, waits ~45 seconds to confirm the session really is stuck (not just mentioning the error in passing), then either logs it, escalates it, or restarts it depending on the setting. It is NOT allowed to restart a session on its own unless an operator turned that on.
+- **SessionRefresh "fresh mode"** — a new option that, after killing the stuck session, deletes the saved "resume here" pointer so the next message starts a brand-new conversation. Without this, the restart would just reload the corrupted conversation and get stuck all over again — an endless loop.
+
+## The safeguards
+
+**Prevents falsely killing a healthy session.** A session merely *talking about* this bug (like the one writing this) won't be flagged: the error has to be the live bottom-of-screen tail AND still be there 45 seconds later with no progress. And the destructive restart is opt-in — by default the worst that happens is a log entry and (if enabled) a heads-up.
+
+**Prevents the endless re-stuck loop.** The fresh restart clears the saved resume pointer, so the new session can't reload the broken conversation.
+
+**Prevents accidental fleet-wide surprises.** Restarting ships "off." It rides the rollout track, which nags toward "on" only after it proves itself, and turning it on is a deliberate human change.
+
+## What ships when
+
+It all ships in one change, but in a safe order of *behavior*: detection + logging are live immediately for everyone (harmless); the automatic restart is dark and opt-in. Echo turns the restart on for itself first to dogfood it. Only after it proves itself over a week (several real recoveries, zero false restarts) does it get promoted toward on-by-default for everyone.
+
+## What you actually need to decide
+
+You already approved the design — the only open question is whether you want the automatic restart to default **on** fleet-wide eventually (yes, via the rollout track) or stay opt-in forever.

--- a/docs/specs/context-wedge-sentinel.md
+++ b/docs/specs/context-wedge-sentinel.md
@@ -1,0 +1,156 @@
+---
+title: ContextWedgeSentinel — thinking-block-400 fast-fail wedge detection + fresh-respawn recovery
+date: 2026-05-28
+author: echo
+status: in-flight
+review-convergence: diagnosis-2026-05-28
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 15160 ("Sounds good" + graduated-rollout confirmation, 2026-05-28 ~09:50 PDT, in response to the live diagnosis + fix design)
+ships-staged: true
+rollout-flag-path: monitoring.contextWedgeSentinel.autoRecovery
+rollout-criteria: "≥3 distinct sessions auto-recovered (kind:recovered) with zero false-alarm-driven respawns over a ≥7-day live window"
+rollout-evidence-type: log-filter
+rollout-evidence-ref: logs/sentinel-events.jsonl
+rollout-evidence-filter: context-wedge
+companion-spec: silently-stopped-trio.md
+---
+
+# Spec — ContextWedgeSentinel
+
+**Date:** 2026-05-28 · **Author:** echo · **Status:** in-flight
+
+## Triggering incident
+
+A session (`echo-instar-exo`, topic 13481, the `mm-proof-build` worktree) was
+permanently dead but still emitting output. Justin saw only sentinel/standby
+replies to "How is this looking?" while the real session fast-failed every
+inbound message. The tmux pane showed, on every inject:
+
+```
+⎿  Cancelled: parallel tool call Bash(rm -rf /Users/.../echo…) errored
+⎿  API Error: 400 messages.9.content.20: `thinking` or `redacted_thinking`
+   blocks in the latest assistant message cannot be modified. These blocks
+   must remain as they were in the original response.
+✻ Cooked for 0s
+```
+
+### Root cause
+
+A tool call was cancelled **inside a parallel tool batch** while extended
+thinking was on (here the cancelled call was a recursive-delete aimed at the
+agent home — correctly blocked by the source-tree guard). When one call in a
+parallel batch is denied/cancelled, Claude Code cancels every sibling call, and
+that cancellation corrupts the **thinking block on the latest assistant turn**.
+The Anthropic API then rejects EVERY resume of that conversation with `400 …
+thinking blocks in the latest assistant message cannot be modified`. The session
+is permanently dead — but it keeps producing output (the instant 400), so:
+
+- **ActiveWorkSilenceSentinel** misses it — output never goes quiet.
+- **SocketDisconnectSentinel** misses it — no disconnect string.
+- A send-keys **nudge cannot recover it** — re-engaging just re-sends the
+  corrupted turn and hits the same 400.
+
+This is a new member of the "silently-stopped" failure class: *loudly*
+fast-failing rather than silent, and unrecoverable by nudge.
+
+## Design
+
+A 4th sentinel in the silently-stopped family (mirrors
+`SocketDisconnectSentinel`'s detector + lifecycle shape, wired through the same
+`SentinelNotifier` audit + tone-gated escalation path), with two differences
+driven by this failure's shape.
+
+### Detector + confirm window
+
+`detectContextWedge(text)` matches the API-specific phrase ("blocks in the
+latest assistant message cannot be modified"). The phrase is unusual enough that
+natural prose almost never contains it. The one case that does — **a session
+discussing this very bug** (e.g. the session writing this spec) — is defended
+two ways:
+
+1. **Tail gate** (`signatureIsTail`): the signature must appear in the live tail
+   of the captured frame, not merely somewhere in scrollback. A session that
+   mentioned the error and kept working has scrolled it out of the tail.
+2. **Confirm window** (default 45s): on first detection the sentinel waits, then
+   re-captures. The wedge is confirmed only if the signature is STILL the tail
+   (the session made no progress). A transient or a discussing-session clears.
+
+### Recovery — fresh respawn (NOT a nudge)
+
+The corrupted turn is permanent in the transcript, so recovery is a **clean
+respawn that does not `--resume` it**. This reuses `SessionRefresh` with a new
+`fresh: true` mode: after the kill (which fires `beforeSessionKill` → the
+`TopicResumeMap` saves the Claude UUID), the resume entry is **cleared** before
+the respawner reads it, so the bridge spawns a brand-new conversation instead of
+resuming the corrupted one. Without this, a naive kill would re-wedge on the
+next message — the kill saves the UUID, the next inbound message `--resume`s it,
+and the same 400 fires (an infinite re-wedge loop). `SessionRefresh`'s existing
+rate-guard caps respawns.
+
+### Recovery policy + Graduated Feature Rollout
+
+Detection + audit are **default-ON housekeeping** (they kill nothing). The
+destructive respawn is gated by `autoRecovery`, the rollout-staged flag:
+
+| Stage | autoRecovery | behavior |
+|-------|-------------|----------|
+| dark (default) | `{enabled:false}` | detect + audit + escalate (if Telegram on); no kill |
+| dry-run | `{enabled:true, dryRun:true}` | log a would-respawn row; no kill |
+| live | `{enabled:true, dryRun:false}` | kill + fresh respawn |
+| default-on | shipped default flipped | live for everyone |
+
+**Fleet-wide promotion (Justin's requirement).** `autoRecovery` is DELIBERATELY
+omitted from the persisted `ConfigDefaults` block: `applyDefaults()` is
+add-missing-only, so persisting `enabled:false` now would freeze it and a later
+flip could never reach existing agents. Instead the dark default lives as the
+runtime fallback in `server.ts` (`wedgeCfg.autoRecovery ?? {enabled:false,
+dryRun:true}`). Promotion to default-on is: (1) flip that runtime literal — every
+existing agent without a persisted override inherits it on next update with no
+migration; (2) add `autoRecovery:{enabled:true}` to `ConfigDefaults` so new
+agents + the rollout observer (which reads `defaultEnabled` from the shipped
+default at `rollout-flag-path`) see default-on. Agents that explicitly set their
+own value keep it (opt-out preserved). The twice-weekly `initiative-digest-review`
+job surfaces this track's stage + evidence and advocates promotion.
+
+### Escalation
+
+Routine transitions (detected / recovered / dry-run / false-alarm) are
+housekeeping → logs + `sentinel-events.jsonl` only. A confirmed wedge that is
+NOT auto-recovered (detect-only, the default) or whose respawn FAILED is an
+`escalated` event — the session is dead and nothing fixed it, exactly when the
+user should know. Telegram delivery is gated by the existing
+`sentinelTelegramEscalation` master switch (default OFF, coalesced to the system
+topic) — same posture as the trio.
+
+### SessionReaper veto
+
+`isRecoveryActive()` feeds `composedRecoveryActive`, so the reaper never kills a
+session while a wedge recovery is in flight (SESSION-REAPER-SPEC §4 "compose,
+don't replace").
+
+## Files
+
+- `src/monitoring/ContextWedgeSentinel.ts` (new) — detector + confirm-window + lifecycle.
+- `src/monitoring/sentinelWiring.ts` — `buildContextWedgeDeps` (recovery policy).
+- `src/monitoring/SentinelNotifier.ts` — `dry-run` + `false-alarm` event kinds.
+- `src/core/SessionRefresh.ts` — `fresh` mode (clears `TopicResumeMap`).
+- `src/core/types.ts` + `src/config/ConfigDefaults.ts` — config shape + default.
+- `src/commands/server.ts` — trio-block wiring + veto.
+
+## Tests (all three tiers)
+
+- **unit** `tests/unit/monitoring/ContextWedgeSentinel.test.ts` — detector, tail
+  gate, confirm-window false-alarm, all four recovery outcomes; `SessionRefresh.test.ts`
+  fresh-mode order (clear after kill, before respawn).
+- **integration** `tests/integration/context-wedge-sentinel-wiring.test.ts` —
+  full wiring through `SentinelNotifier` across all policies, default Telegram silent.
+- **e2e** `tests/e2e/context-wedge-sentinel-lifecycle.test.ts` — production
+  assembly writes context-wedge rows to `sentinel-events.jsonl` on disk + a WIRED
+  source guard (constructs / starts / veto / fresh-respawn) against dead code.
+
+## Signal-vs-authority
+
+The regex + tail gate + confirm window are detectors. `recoverFn` is a bounded
+recovery primitive (rate-guarded by `SessionRefresh`). Escalation routes through
+the existing `MessagingToneGate` via `SentinelNotifier`. No new blocking authority.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5627,12 +5627,15 @@ export async function startServer(options: StartOptions): Promise<void> {
     // replace"). undefined when the corresponding sentinel is disabled.
     let socketRecoveryActive: ((sessionName: string) => boolean) | undefined;
     let silenceRecoveryActive: ((sessionName: string) => boolean) | undefined;
+    let wedgeRecoveryActive: ((sessionName: string) => boolean) | undefined;
     {
       const { SocketDisconnectSentinel } = await import('../monitoring/SocketDisconnectSentinel.js');
       const { ActiveWorkSilenceSentinel } = await import('../monitoring/ActiveWorkSilenceSentinel.js');
+      const { ContextWedgeSentinel } = await import('../monitoring/ContextWedgeSentinel.js');
       const {
         buildSocketDisconnectDeps,
         buildActiveWorkSilenceDeps,
+        buildContextWedgeDeps,
         OutputActivityTracker,
       } = await import('../monitoring/sentinelWiring.js');
       const { SentinelNotifier } = await import('../monitoring/SentinelNotifier.js');
@@ -5721,6 +5724,53 @@ export async function startServer(options: StartOptions): Promise<void> {
             : '  ActiveWorkSilenceSentinel enabled (silent-freeze watchdog — logs only, Telegram escalation OFF)',
         ));
       }
+
+      // ── ContextWedgeSentinel — thinking-block-400 fast-fail wedge ──
+      // Detection + audit ship default-ON (harmless housekeeping). The
+      // destructive fresh-respawn is gated by autoRecovery (default OFF +
+      // dryRun) and rides the Graduated Feature Rollout track. freshRespawn is
+      // late-bound to _sessionRefresh (assigned later in boot) and only invoked
+      // at recovery time; it uses fresh-mode so the new session never --resume-s
+      // the corrupted transcript. Spec: docs/specs/context-wedge-sentinel.md.
+      const wedgeCfg = config.monitoring?.contextWedgeSentinel ?? { enabled: true };
+      if (wedgeCfg.enabled !== false) {
+        const autoRecovery = wedgeCfg.autoRecovery ?? { enabled: false, dryRun: true };
+        const wedgeSentinel = new ContextWedgeSentinel(
+          buildContextWedgeDeps({
+            sessions: sessionSurface,
+            escalate: (name, text) => notifier.escalate('context-wedge', name, text),
+            autoRecovery,
+            freshRespawn: async (name: string): Promise<boolean> => {
+              if (!_sessionRefresh) return false;
+              const result = await _sessionRefresh.refreshSession({
+                sessionName: name,
+                fresh: true,
+                reason: 'context-wedge-400',
+              });
+              return result.ok;
+            },
+          }),
+          {
+            enabled: wedgeCfg.enabled,
+            tickIntervalMs: wedgeCfg.tickIntervalMs,
+            confirmWindowMs: wedgeCfg.confirmWindowMs,
+          },
+        );
+        wedgeSentinel.on('detected', (e: { sessionName: string }) =>
+          notifier.record('detected', 'context-wedge', e.sessionName));
+        wedgeSentinel.on('recovered', (e: { sessionName: string }) =>
+          notifier.record('recovered', 'context-wedge', e.sessionName, 'fresh respawn'));
+        wedgeSentinel.on('dry-run', (e: { sessionName: string }) =>
+          notifier.record('dry-run', 'context-wedge', e.sessionName, 'would fresh-respawn'));
+        wedgeSentinel.on('false-alarm', (e: { sessionName: string }) =>
+          notifier.record('false-alarm', 'context-wedge', e.sessionName, 'signature scrolled out of tail'));
+        wedgeSentinel.on('recovery-error', (e: { sessionName: string; err: unknown }) =>
+          notifier.record('recovery-error', 'context-wedge', e.sessionName, e.err instanceof Error ? e.err.message : String(e.err)));
+        wedgeSentinel.start();
+        wedgeRecoveryActive = (s: string) => wedgeSentinel.isRecoveryActive(s);
+        const mode = autoRecovery.enabled ? (autoRecovery.dryRun ? 'auto-recover dry-run' : 'auto-recover LIVE') : 'detect-only';
+        console.log(pc.green(`  ContextWedgeSentinel enabled (thinking-block-400 wedge — ${mode})`));
+      }
     }
 
     // Recompose the zombie-kill veto to include ALL four recovery sentinels now
@@ -5733,7 +5783,8 @@ export async function startServer(options: StartOptions): Promise<void> {
       compactionSentinel.isRecoveryActive(session.tmuxSession) ||
       rateLimitSentinel.isRecoveryActive(session.tmuxSession) ||
       (socketRecoveryActive?.(session.tmuxSession) ?? false) ||
-      (silenceRecoveryActive?.(session.tmuxSession) ?? false);
+      (silenceRecoveryActive?.(session.tmuxSession) ?? false) ||
+      (wedgeRecoveryActive?.(session.tmuxSession) ?? false);
     sessionManager.setActiveRecoveryChecker(composedRecoveryActive);
 
     // Trigger 1: PreCompact hook event — report to sentinel.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -40,6 +40,21 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     activeWorkSilenceSentinel: {
       enabled: true,
     },
+    // ContextWedgeSentinel — detect+recover the "thinking blocks ... cannot be
+    // modified" 400 fast-fail wedge. Detection/audit ships default-ON (it kills
+    // nothing). The destructive fresh-respawn is gated behind autoRecovery,
+    // which ships dark (enabled:false) and rides the Graduated Feature Rollout
+    // track — promotion to default-on is a deliberate one-line flip of
+    // autoRecovery.enabled here, which (because the runtime reads it as a
+    // fallback against this shipped default) propagates to every existing agent
+    // on next update with no migration. See docs/specs/context-wedge-sentinel.md.
+    contextWedgeSentinel: {
+      enabled: true,
+      autoRecovery: {
+        enabled: false,
+        dryRun: true,
+      },
+    },
     // SessionReaper — pressure-aware reaper of idle-but-alive sessions.
     // UNLIKE the sentinels above, default OFF + dry-run: it is the only monitor
     // that *kills* sessions on a heuristic, so it ships dark and must be flipped

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -41,19 +41,20 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       enabled: true,
     },
     // ContextWedgeSentinel — detect+recover the "thinking blocks ... cannot be
-    // modified" 400 fast-fail wedge. Detection/audit ships default-ON (it kills
-    // nothing). The destructive fresh-respawn is gated behind autoRecovery,
-    // which ships dark (enabled:false) and rides the Graduated Feature Rollout
-    // track — promotion to default-on is a deliberate one-line flip of
-    // autoRecovery.enabled here, which (because the runtime reads it as a
-    // fallback against this shipped default) propagates to every existing agent
-    // on next update with no migration. See docs/specs/context-wedge-sentinel.md.
+    // modified" 400 fast-fail wedge. ONLY the detection switch is persisted here
+    // (it kills nothing; default-ON is stable). The destructive fresh-respawn
+    // flag `autoRecovery` is DELIBERATELY OMITTED from these persisted defaults:
+    // applyDefaults() is add-missing-only, so persisting autoRecovery.enabled
+    // now would freeze it and a later default-on flip could never reach existing
+    // agents. Instead the autoRecovery default lives as the runtime fallback in
+    // server.ts (the trio block). Graduated-Feature-Rollout promotion to
+    // default-on = (1) flip that runtime literal so every existing agent without
+    // a persisted override inherits it on next update, and (2) add
+    // `autoRecovery: { enabled: true }` here so new agents + the rollout observer
+    // (rollout-flag-path: monitoring.contextWedgeSentinel.autoRecovery) see it.
+    // See docs/specs/context-wedge-sentinel.md.
     contextWedgeSentinel: {
       enabled: true,
-      autoRecovery: {
-        enabled: false,
-        dryRun: true,
-      },
     },
     // SessionReaper — pressure-aware reaper of idle-but-alive sessions.
     // UNLIKE the sentinels above, default OFF + dry-run: it is the only monitor

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2765,6 +2765,29 @@ If a user asks "are my sentinels alerting?" or "why isn't the watchdog notifying
       result.skipped.push('CLAUDE.md: Sentinel Notifications section already present');
     }
 
+    // ContextWedgeSentinel — the 4th silently-stopped sentinel. Tells the agent
+    // about the thinking-block-400 wedge + that auto-recovery is opt-in. Without
+    // it, an agent asked "why did my session keep failing instantly / what is
+    // the thinking-block error?" has no grounded answer. Idempotent via marker.
+    if (!content.includes('ContextWedgeSentinel') && !content.includes('Stuck-Context Recovery (thinking-block wedge)')) {
+      const section = `
+## Stuck-Context Recovery (thinking-block wedge)
+
+The ContextWedgeSentinel (4th member of the silently-stopped family) detects a specific way a session dies: when a tool call is cancelled inside a PARALLEL tool batch while extended thinking is on, Claude Code cancels every sibling call and that corrupts the thinking block on the latest assistant turn. After that, the Anthropic API rejects every resume with \`400 … thinking blocks in the latest assistant message cannot be modified\`, so the session fast-fails instantly on every message ("Cooked for 0s") — permanently dead, yet still emitting output (so the silence + socket sentinels miss it).
+
+A nudge can't fix this (re-engaging re-sends the corrupted turn). Recovery is a FRESH respawn — kill + spawn a new session that does NOT \`--resume\` the corrupted transcript (the topic's resume UUID is cleared first, so the bridge can't re-wedge on the next message).
+
+- **Detection + audit are default-ON housekeeping** — every transition (detected / recovered / dry-run / false-alarm / escalated) lands in \`logs/sentinel-events.jsonl\`; the user sees nothing.
+- **Auto-recovery is OPT-IN** (it kills + respawns a session). It rides the Graduated Feature Rollout track and ships dark. Turn it on in \`.instar/config.json\`: \`{"monitoring": {"contextWedgeSentinel": {"autoRecovery": {"enabled": true, "dryRun": false}}}}\` (use \`dryRun: true\` first to log what it WOULD respawn). When OFF, a confirmed wedge escalates (gated by \`sentinelTelegramEscalation\`) so you can restart it yourself.
+- If a user asks "why did my session keep failing / get stuck on a thinking error?" — read \`logs/sentinel-events.jsonl\` (filter \`context-wedge\`) and explain the above. Spec: \`docs/specs/context-wedge-sentinel.md\`.
+`;
+      content += '\n' + section;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Stuck-Context Recovery section');
+    } else {
+      result.skipped.push('CLAUDE.md: Stuck-Context Recovery section already present');
+    }
+
     // Self-Heal: Update Restart Behavior — explains restart-cascade dampener
     // and lifeline drift auto-promote. Complementary to Version-Skew Self-
     // Recovery above (that one handles major.minor crossings; this one handles

--- a/src/core/SessionRefresh.ts
+++ b/src/core/SessionRefresh.ts
@@ -68,6 +68,16 @@ export interface RefreshOptions {
   sessionName: string;
   followUpPrompt?: string;
   reason?: string;
+  /**
+   * Fresh respawn: do NOT `--resume` the old session. After the kill (which
+   * fires beforeSessionKill → TopicResumeMap saves the Claude UUID), clear that
+   * resume entry so the respawner spawns a brand-new session with no
+   * conversation carried over. Used by ContextWedgeSentinel: the old
+   * transcript's latest assistant turn is corrupted (thinking-block 400), so
+   * resuming it would immediately re-wedge. Default false (continuity-preserving
+   * resume, the original self-refresh behavior).
+   */
+  fresh?: boolean;
 }
 
 const DEFAULT_MAX_PER_WINDOW = 5;
@@ -103,7 +113,7 @@ export class SessionRefresh {
    * unexpected internal errors from the respawner callback.
    */
   async refreshSession(opts: RefreshOptions): Promise<RefreshResult> {
-    const { sessionName, followUpPrompt, reason } = opts;
+    const { sessionName, followUpPrompt, reason, fresh } = opts;
 
     // ── detect ─────────────────────────────────────────────────────────
     if (!this.deps.telegram) {
@@ -173,9 +183,20 @@ export class SessionRefresh {
       // removed deliberately and the call returns null).
       this.deps.sessionManager.killSession(stateSession.id);
 
+      // Fresh respawn: drop the resume UUID that beforeSessionKill just saved,
+      // so the respawner finds no entry and spawns a brand-new conversation
+      // instead of `--resume`-ing the corrupted transcript. MUST run after the
+      // kill (beforeSessionKill writes the entry) and before the respawner
+      // reads it.
+      if (fresh) {
+        this.deps.topicResumeMap?.remove(topicId);
+        console.log(`[SessionRefresh] fresh respawn — cleared resume UUID for topic ${topicId} (sessionName=${sessionName})`);
+      }
+
       // The respawner spawns a fresh tmux session that runs `claude
       // --resume <uuid>` (resolved by spawnSessionForTopic via the saved
-      // TopicResumeMap entry) and re-registers the topic mapping.
+      // TopicResumeMap entry) and re-registers the topic mapping. With
+      // `fresh`, the entry was just cleared, so it spawns without --resume.
       const newSessionName = await this.deps.respawner(sessionName, topicId, followUpPrompt);
 
       // ── verify + finalize ────────────────────────────────────────────

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2718,6 +2718,46 @@ export interface MonitoringConfig {
     verifyWindowMs?: number;
   };
   /**
+   * ContextWedgeSentinel — detects the Claude Code "thinking/redacted_thinking
+   * blocks in the latest assistant message cannot be modified" 400 fast-fail
+   * wedge (a cancelled tool call inside a parallel batch corrupts the latest
+   * assistant turn's thinking block, so every subsequent resume 400s instantly
+   * and the session is permanently dead while still emitting output). A nudge
+   * cannot fix it; recovery is a FRESH respawn (kill + clear the topic's resume
+   * UUID so the bridge does not --resume the corrupted transcript).
+   *
+   * Detection/audit ships default-ON (housekeeping — harmless, kills nothing).
+   * The destructive respawn is gated behind `autoRecovery` (default OFF + dryRun)
+   * and rides the Graduated Feature Rollout track (rollout-flag-path:
+   * monitoring.contextWedgeSentinel.autoRecovery). See
+   * docs/specs/context-wedge-sentinel.md.
+   */
+  contextWedgeSentinel?: {
+    /** Master kill switch for detection + audit (default: true). */
+    enabled: boolean;
+    /** Scan-loop interval (ms) (default: 20_000). */
+    tickIntervalMs?: number;
+    /** How long the signature must persist as the non-progressing session tail
+     *  before the wedge is confirmed (ms) (default: 45_000). Guards against a
+     *  session merely discussing the error or a transient render. */
+    confirmWindowMs?: number;
+    /** Pane lines to capture when scanning for the signature (default: 30). */
+    captureLines?: number;
+    /**
+     * Destructive auto-recovery (fresh respawn). The Graduated-Feature-Rollout
+     * staged flag: dark (enabled:false) → dry-run (enabled:true + dryRun:true,
+     * logs would-respawn) → live (enabled:true + dryRun:false) → default-on
+     * (shipped default enabled:true). Read at runtime as a fallback against the
+     * shipped default so a default flip propagates fleet-wide with no migration.
+     */
+    autoRecovery?: {
+      /** Whether confirmed wedges are auto-respawned (default: false). */
+      enabled: boolean;
+      /** When true, log the would-respawn decision but kill nothing (default: true). */
+      dryRun?: boolean;
+    };
+  };
+  /**
    * SessionReaper — pressure-aware reaper of idle-but-alive sessions. The only
    * monitor that *kills* on a heuristic, so it ships OFF + dry-run by default.
    * See docs/specs/SESSION-REAPER-SPEC.md and DEFAULT_SESSION_REAPER_CONFIG.

--- a/src/monitoring/ContextWedgeSentinel.ts
+++ b/src/monitoring/ContextWedgeSentinel.ts
@@ -1,0 +1,293 @@
+/**
+ * ContextWedgeSentinel — detects Claude Code's "thinking/redacted_thinking
+ * blocks in the latest assistant message cannot be modified" 400 wedge and
+ * recovers via a FRESH respawn.
+ *
+ * The failure (diagnosed 2026-05-28): a tool call is cancelled inside a
+ * parallel tool batch while extended thinking is on. Claude Code cancels every
+ * sibling call, and that cancellation corrupts the thinking block on the latest
+ * assistant turn. The Anthropic API then rejects EVERY resume of that session
+ * with `400 ... thinking blocks in the latest assistant message cannot be
+ * modified`. The session fast-fails instantly on every inbound message ("Cooked
+ * for 0s"); it is permanently dead yet still emitting output, so neither the
+ * silence sentinel (output never goes quiet) nor the socket sentinel (no
+ * disconnect string) catches it.
+ *
+ * Critical difference from the other silently-stopped sentinels: a send-keys
+ * nudge CANNOT recover this — re-engaging just re-sends the corrupted turn and
+ * hits the same 400. The only recovery is a clean respawn that does NOT
+ * `--resume` the corrupted transcript. That is the injected `recoverFn`
+ * (wired to SessionRefresh fresh-mode, which clears the topic's resume UUID
+ * before respawning).
+ *
+ * Because recovery is destructive (kills + respawns a session), detection is
+ * gated by a CONFIRM WINDOW: the signature must still be the non-progressing
+ * session tail after `confirmWindowMs` before a wedge is confirmed. This is the
+ * defense against false-positives — most importantly a session merely
+ * *discussing* this very error (its tail keeps changing as it works, so the
+ * signature does not persist as the tail). And the destructive recovery itself
+ * is opt-in (autoRecovery, default off) and rides the Graduated Feature Rollout
+ * track; in the default detect-only mode the sentinel only audits + escalates.
+ *
+ * Spec: docs/specs/context-wedge-sentinel.md (companion to silently-stopped-trio.md)
+ *
+ * Signal-vs-authority: the regex + confirm-window are detectors. The recoverFn
+ * is a bounded recovery primitive (SessionRefresh rate-guards respawns). User-
+ * facing escalation routes through the existing MessagingToneGate via the
+ * SentinelNotifier path. No new blocking authority.
+ */
+
+import { EventEmitter } from 'node:events';
+
+export type ContextWedgeStatus =
+  | 'detected'
+  | 'confirming'
+  | 'recovered'
+  | 'escalated';
+
+/** Outcome of a recovery attempt, returned by the injected recoverFn. */
+export type WedgeRecoveryOutcome =
+  | 'respawned' // autoRecovery live: session was killed + freshly respawned
+  | 'dry-run' // autoRecovery dry-run: would-respawn logged, nothing killed
+  | 'detect-only' // autoRecovery off: no recovery action taken
+  | 'failed'; // autoRecovery live but the respawn attempt failed
+
+export interface ContextWedgeState {
+  sessionName: string;
+  detectedAt: number;
+  status: ContextWedgeStatus;
+}
+
+export interface ContextWedgeSentinelDeps {
+  /** Peek at the session's most recent tmux output (may be empty). */
+  getRecentOutput: (sessionName: string) => string;
+  /**
+   * Attempt recovery of a confirmed wedge. The wiring decides policy
+   * (detect-only / dry-run / live respawn) and reports back via the outcome.
+   * Never throws on the expected failure modes; rejection is treated as 'failed'.
+   */
+  recoverFn: (sessionName: string) => Promise<WedgeRecoveryOutcome>;
+  /** Route a user-facing escalation; server.ts owns topic routing + tone gate. */
+  notifyFn: (sessionName: string, text: string) => Promise<void>;
+  /** List the session names to scan each tick. Without it the sentinel is
+   *  event-driven only (caller invokes scanSession/report). */
+  listSessionNames?: () => string[];
+  /** Override Date.now (tests). */
+  now?: () => number;
+  /** Override timer setters (tests). */
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+export interface ContextWedgeSentinelConfig {
+  enabled?: boolean;
+  /** How often the self-driving loop scans every session (ms). Default 20s. */
+  tickIntervalMs?: number;
+  /** How long the signature must persist as the non-progressing tail before the
+   *  wedge is confirmed (ms). Default 45s. */
+  confirmWindowMs?: number;
+}
+
+const DEFAULT_CONFIG: Required<ContextWedgeSentinelConfig> = {
+  enabled: true,
+  tickIntervalMs: 20_000,
+  confirmWindowMs: 45_000,
+};
+
+/**
+ * Patterns for the thinking-block 400. Intentionally anchored on the unusual,
+ * API-specific phrase — natural prose almost never contains it, and the
+ * confirm-window + opt-in recovery cover the one case that does (a session
+ * discussing this very bug).
+ */
+export const CONTEXT_WEDGE_PATTERNS: readonly RegExp[] = [
+  /blocks in the latest assistant message cannot be modified/i,
+  /`?(?:thinking|redacted_thinking)`?\s+blocks.{0,80}cannot be modified/i,
+];
+
+/** Detector — true if `text` contains the thinking-block-400 signature. */
+export function detectContextWedge(text: string): boolean {
+  if (!text) return false;
+  for (const pat of CONTEXT_WEDGE_PATTERNS) {
+    if (pat.test(text)) return true;
+  }
+  return false;
+}
+
+/**
+ * Tail detector — is the signature present within the last `tailLines`
+ * non-empty lines of the capture? A genuinely wedged session shows the error as
+ * its live tail; a session that merely mentioned the error earlier and then
+ * kept working has scrolled it out of the tail.
+ */
+export function signatureIsTail(text: string, tailLines = 10): boolean {
+  if (!text) return false;
+  const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
+  const tail = lines.slice(-tailLines).join('\n');
+  return detectContextWedge(tail);
+}
+
+export class ContextWedgeSentinel extends EventEmitter {
+  private readonly cfg: Required<ContextWedgeSentinelConfig>;
+  private readonly states = new Map<string, ContextWedgeState>();
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private tickHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly deps: ContextWedgeSentinelDeps, cfg: ContextWedgeSentinelConfig = {}) {
+    super();
+    this.cfg = { ...DEFAULT_CONFIG, ...cfg };
+  }
+
+  /** Begin the self-driving scan loop. No-op without listSessionNames. */
+  start(): void {
+    if (!this.cfg.enabled || this.tickHandle) return;
+    if (!this.deps.listSessionNames) return;
+    this.tickHandle = setInterval(() => this.tick(), this.cfg.tickIntervalMs);
+    if (typeof this.tickHandle.unref === 'function') this.tickHandle.unref();
+  }
+
+  stop(): void {
+    if (this.tickHandle) {
+      clearInterval(this.tickHandle);
+      this.tickHandle = null;
+    }
+    this.shutdown();
+  }
+
+  /** One scan pass over every tracked session. */
+  tick(): void {
+    if (!this.cfg.enabled) return;
+    const names = this.deps.listSessionNames?.() ?? [];
+    for (const name of names) this.scanSession(name);
+  }
+
+  /** Scan one session for the wedge signature. */
+  scanSession(sessionName: string): void {
+    if (!this.cfg.enabled) return;
+    if (this.states.has(sessionName)) return; // already handling
+    const output = this.deps.getRecentOutput(sessionName);
+    // Require the signature to be the live TAIL, not merely present somewhere in
+    // the scrollback — the discriminator against a session discussing the bug.
+    if (!signatureIsTail(output)) return;
+    this.report(sessionName);
+  }
+
+  /** Public entry: report a detected (not yet confirmed) wedge. Idempotent. */
+  report(sessionName: string): void {
+    if (!this.cfg.enabled) return;
+    if (this.states.has(sessionName)) return;
+    const now = (this.deps.now ?? Date.now)();
+    const state: ContextWedgeState = {
+      sessionName,
+      detectedAt: now,
+      status: 'detected',
+    };
+    this.states.set(sessionName, state);
+    this.emit('detected', { sessionName });
+
+    // Enter the confirm window before any destructive action.
+    state.status = 'confirming';
+    const handle = this.setTimer(() => void this.confirm(sessionName), this.cfg.confirmWindowMs);
+    this.timers.set(sessionName, handle);
+  }
+
+  isRecoveryActive(sessionName: string): boolean {
+    const s = this.states.get(sessionName);
+    return !!s && s.status !== 'recovered' && s.status !== 'escalated';
+  }
+
+  listActive(): ContextWedgeState[] {
+    return Array.from(this.states.values());
+  }
+
+  clear(sessionName: string): void {
+    const t = this.timers.get(sessionName);
+    if (t) this.clearTimer(t);
+    this.timers.delete(sessionName);
+    this.states.delete(sessionName);
+  }
+
+  shutdown(): void {
+    for (const t of this.timers.values()) this.clearTimer(t);
+    this.timers.clear();
+    this.states.clear();
+  }
+
+  // ── Confirm + recover ────────────────────────────────────────────────
+
+  private async confirm(sessionName: string): Promise<void> {
+    const state = this.states.get(sessionName);
+    if (!state) return;
+    const output = this.deps.getRecentOutput(sessionName);
+
+    // Confirmation gate: the signature must STILL be the tail. If it scrolled
+    // out (the session progressed past the error), this was not a wedge — a
+    // false alarm (e.g. a session that quoted the error then kept working).
+    if (!signatureIsTail(output)) {
+      this.emit('false-alarm', { sessionName });
+      this.clear(sessionName);
+      return;
+    }
+
+    // Confirmed wedge → hand to the recovery policy.
+    let outcome: WedgeRecoveryOutcome = 'failed';
+    try {
+      outcome = await this.deps.recoverFn(sessionName);
+    } catch (err) {
+      this.emit('recovery-error', { sessionName, err });
+      outcome = 'failed';
+    }
+
+    switch (outcome) {
+      case 'respawned':
+        state.status = 'recovered';
+        this.emit('recovered', { sessionName });
+        this.clear(sessionName);
+        return;
+      case 'dry-run':
+        // Housekeeping only — would-have-respawned. Keep state so we don't
+        // re-confirm the same wedge every tick; the dry-run log is the signal.
+        state.status = 'escalated';
+        this.emit('dry-run', { sessionName });
+        return;
+      case 'detect-only':
+      case 'failed':
+      default:
+        this.escalate(sessionName, outcome);
+        return;
+    }
+  }
+
+  private escalate(sessionName: string, outcome: WedgeRecoveryOutcome): void {
+    const state = this.states.get(sessionName);
+    if (!state) return;
+    state.status = 'escalated';
+    const detail =
+      outcome === 'failed'
+        ? `${friendlyName(sessionName)} is wedged on a stuck-context error and my respawn attempt did not clear it. Want me to dig in?`
+        : `${friendlyName(sessionName)} is wedged on a stuck-context error (it can only be fixed by a fresh restart, which is currently off). Want me to restart it?`;
+    void this.notify(sessionName, detail);
+    this.emit('escalated', { sessionName, outcome });
+    // Keep state so a subsequent scan doesn't re-report the same wedge.
+  }
+
+  private async notify(sessionName: string, text: string): Promise<void> {
+    try {
+      await this.deps.notifyFn(sessionName, text);
+    } catch (err) {
+      this.emit('notify-error', { sessionName, err });
+    }
+  }
+
+  private setTimer(fn: () => void, ms: number): ReturnType<typeof setTimeout> {
+    return (this.deps.setTimer ?? setTimeout)(fn, ms);
+  }
+
+  private clearTimer(handle: ReturnType<typeof setTimeout>): void {
+    (this.deps.clearTimer ?? clearTimeout)(handle);
+  }
+}
+
+function friendlyName(sessionName: string): string {
+  return sessionName.replace(/^ai\.instar\./, '').replace(/-server$/, '').replace(/-lifeline$/, '');
+}

--- a/src/monitoring/SentinelNotifier.ts
+++ b/src/monitoring/SentinelNotifier.ts
@@ -38,7 +38,10 @@ export type SentinelEventKind =
   | 'escalation-suppressed'
   | 'nudge-error'
   | 'recovery-error'
-  | 'notify-error';
+  | 'notify-error'
+  // ContextWedgeSentinel transitions (thinking-block-400 wedge):
+  | 'dry-run' // autoRecovery dry-run — would have fresh-respawned, killed nothing
+  | 'false-alarm'; // confirm-window expired with the signature scrolled out of tail
 
 export interface SentinelLogEntry {
   ts: string;

--- a/src/monitoring/sentinelWiring.ts
+++ b/src/monitoring/sentinelWiring.ts
@@ -25,6 +25,10 @@ import type {
   ActiveWorkSilenceSentinelDeps,
   SessionRegistryEntry,
 } from './ActiveWorkSilenceSentinel.js';
+import type {
+  ContextWedgeSentinelDeps,
+  WedgeRecoveryOutcome,
+} from './ContextWedgeSentinel.js';
 import { getActivitySignal } from './frameworkActivitySignals.js';
 import type { IntelligenceFramework } from '../core/intelligenceProviderFactory.js';
 
@@ -77,6 +81,7 @@ export function makeAttentionPoster(opts: {
 
 const SOCKET_CAPTURE_LINES = 40;
 const SILENCE_CAPTURE_LINES = 40;
+const WEDGE_CAPTURE_LINES = 30;
 
 /**
  * Callback shape for routing a recovery-failed escalation through the
@@ -100,6 +105,49 @@ export function buildSocketDisconnectDeps(opts: {
       // re-engages without interrupting in-flight work (unlike Ctrl+C, which
       // would cancel a tool call that may still be running).
       return opts.sessions.sendKey(sessionName, 'Enter');
+    },
+    notifyFn: async (sessionName, text) => {
+      await opts.escalate(sessionName, text);
+    },
+    listSessionNames: () =>
+      opts.sessions.listRunningSessions().map((s) => s.tmuxSession),
+  };
+}
+
+/**
+ * Builds the ContextWedgeSentinel deps. The `recoverFn` encodes the
+ * detect-only / dry-run / live recovery policy from autoRecovery config and
+ * delegates the actual fresh respawn to the injected `freshRespawn` callback
+ * (server bootstrap wires it to SessionRefresh.refreshSession({ fresh: true }),
+ * which clears the topic's resume UUID so the new session never --resume-s the
+ * corrupted transcript). Keeping policy here — not in the sentinel — means the
+ * sentinel stays a pure detector + lifecycle and the rollout-staged flag is
+ * observed in exactly one place.
+ */
+export function buildContextWedgeDeps(opts: {
+  sessions: SentinelSessionSurface;
+  escalate: EscalateFn;
+  /** autoRecovery config (the Graduated-Feature-Rollout staged flag). */
+  autoRecovery: { enabled: boolean; dryRun?: boolean };
+  /** Performs the destructive fresh respawn. Returns true if the session was
+   *  actually killed + respawned. Wired to SessionRefresh fresh-mode. */
+  freshRespawn: (sessionName: string) => Promise<boolean>;
+}): ContextWedgeSentinelDeps {
+  return {
+    getRecentOutput: (sessionName) =>
+      opts.sessions.captureOutput(sessionName, WEDGE_CAPTURE_LINES) ?? '',
+    recoverFn: async (sessionName): Promise<WedgeRecoveryOutcome> => {
+      // dark: detection + audit only, no destructive action.
+      if (!opts.autoRecovery.enabled) return 'detect-only';
+      // dry-run: log the would-respawn decision, kill nothing.
+      if (opts.autoRecovery.dryRun) return 'dry-run';
+      // live: actually kill + fresh-respawn.
+      try {
+        const ok = await opts.freshRespawn(sessionName);
+        return ok ? 'respawned' : 'failed';
+      } catch {
+        return 'failed';
+      }
     },
     notifyFn: async (sessionName, text) => {
       await opts.escalate(sessionName, text);

--- a/tests/e2e/context-wedge-sentinel-lifecycle.test.ts
+++ b/tests/e2e/context-wedge-sentinel-lifecycle.test.ts
@@ -1,0 +1,168 @@
+// safe-git-allow: test file — no git calls.
+// safe-fs-allow: test file — writes only to its own tmp dir.
+
+/**
+ * E2E lifecycle test — ContextWedgeSentinel's production wiring.
+ *
+ * Two "feature is alive" gates (Testing Integrity Standard Tier 3):
+ *
+ *  1. JSONL audit on a real disk: assemble the EXACT components server.ts wires
+ *     (SentinelNotifier + buildContextWedgeDeps + ContextWedgeSentinel + the
+ *     sentinel→notifier event wiring) with the same log-sink shape
+ *     (<stateDir>/../logs/sentinel-events.jsonl), drive a confirmed wedge, and
+ *     read back the file the server would have written. Proves detection +
+ *     audit actually reach disk, and that detect-only mode kills nothing.
+ *
+ *  2. WIRED source check: the sentinel only matters if server.ts actually
+ *     constructs + starts it AND folds it into the SessionReaper recovery veto.
+ *     A grep against server.ts catches the dead-code failure (the exact sin the
+ *     trio committed in PR #334: shipped as orphan classes, never instantiated,
+ *     release notes falsely claimed "wired into server startup").
+ *
+ * Spec: docs/specs/context-wedge-sentinel.md
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ContextWedgeSentinel } from '../../src/monitoring/ContextWedgeSentinel.js';
+import {
+  buildContextWedgeDeps,
+  type SentinelSessionSurface,
+} from '../../src/monitoring/sentinelWiring.js';
+import { SentinelNotifier, type SentinelLogEntry } from '../../src/monitoring/SentinelNotifier.js';
+
+const WEDGE_TAIL = [
+  '  ⎿  API Error: 400 messages.9.content.20: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified.',
+  '✻ Cooked for 0s',
+].join('\n');
+
+interface Rig {
+  sentinel: ContextWedgeSentinel;
+  sentinelLogPath: string;
+  respawns: () => number;
+  cleanup: () => void;
+}
+
+/** Mirrors the production wiring in src/commands/server.ts (the trio block). */
+function wireProduction(opts: {
+  surface: SentinelSessionSurface;
+  autoRecovery: { enabled: boolean; dryRun?: boolean };
+  telegramEscalation?: boolean;
+}): Rig {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-wedge-e2e-'));
+  const logsDir = path.join(stateDir, '..', 'logs');
+  fs.mkdirSync(logsDir, { recursive: true });
+  const sentinelLogPath = path.join(logsDir, 'sentinel-events.jsonl');
+
+  const logSink = (entry: SentinelLogEntry): void => {
+    try { fs.appendFileSync(sentinelLogPath, JSON.stringify(entry) + '\n'); } catch { /* best-effort */ }
+  };
+  const notifier = new SentinelNotifier(
+    { log: logSink, sendConsolidated: async () => true },
+    { telegramEscalation: opts.telegramEscalation ?? false, coalesceWindowMs: 50 },
+  );
+
+  let respawns = 0;
+  const sentinel = new ContextWedgeSentinel(
+    buildContextWedgeDeps({
+      sessions: opts.surface,
+      escalate: (name, text) => notifier.escalate('context-wedge', name, text),
+      autoRecovery: opts.autoRecovery,
+      freshRespawn: async () => { respawns++; return true; },
+    }),
+    // Tiny real-timer confirm window so the e2e is fast + deterministic
+    // (the fake-timer timing path is exercised by the integration tier).
+    { confirmWindowMs: 20, tickIntervalMs: 20_000 },
+  );
+  // Same event wiring server.ts installs.
+  sentinel.on('detected', (e: { sessionName: string }) => notifier.record('detected', 'context-wedge', e.sessionName));
+  sentinel.on('recovered', (e: { sessionName: string }) => notifier.record('recovered', 'context-wedge', e.sessionName, 'fresh respawn'));
+  sentinel.on('dry-run', (e: { sessionName: string }) => notifier.record('dry-run', 'context-wedge', e.sessionName, 'would fresh-respawn'));
+  sentinel.on('false-alarm', (e: { sessionName: string }) => notifier.record('false-alarm', 'context-wedge', e.sessionName));
+
+  return {
+    sentinel,
+    sentinelLogPath,
+    respawns: () => respawns,
+    cleanup: () => { try { fs.rmSync(path.dirname(logsDir), { recursive: true, force: true }); } catch { /* ignore */ } },
+  };
+}
+
+function readAudit(p: string): SentinelLogEntry[] {
+  if (!fs.existsSync(p)) return [];
+  return fs.readFileSync(p, 'utf-8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+const settle = () => new Promise<void>(r => setTimeout(r, 80));
+
+describe('ContextWedgeSentinel E2E — production wiring writes the audit trail', () => {
+  it('detect-only (default): a confirmed wedge writes context-wedge rows to the JSONL, kills nothing', async () => {
+    const surface: SentinelSessionSurface = {
+      captureOutput: () => WEDGE_TAIL,
+      isSessionAlive: () => true,
+      sendKey: () => true,
+      listRunningSessions: () => [{ tmuxSession: 'echo-wedged' }],
+    };
+    const rig = wireProduction({ surface, autoRecovery: { enabled: false } });
+    try {
+      rig.sentinel.tick(); // scan via the self-driving path
+      await settle();
+      const audit = readAudit(rig.sentinelLogPath);
+      const wedgeRows = audit.filter(e => e.sentinel === 'context-wedge');
+      expect(wedgeRows.length).toBeGreaterThan(0);
+      expect(wedgeRows.some(e => e.kind === 'detected')).toBe(true);
+      expect(audit.some(e => e.kind === 'escalated' && e.sentinel === 'context-wedge')).toBe(true);
+      expect(rig.respawns()).toBe(0); // detect-only never kills
+    } finally {
+      rig.cleanup();
+    }
+  });
+
+  it('live: a confirmed wedge respawns and writes a recovered row', async () => {
+    const surface: SentinelSessionSurface = {
+      captureOutput: () => WEDGE_TAIL,
+      isSessionAlive: () => true,
+      sendKey: () => true,
+      listRunningSessions: () => [{ tmuxSession: 'echo-wedged' }],
+    };
+    const rig = wireProduction({ surface, autoRecovery: { enabled: true, dryRun: false } });
+    try {
+      rig.sentinel.tick();
+      await settle();
+      expect(rig.respawns()).toBe(1);
+      const audit = readAudit(rig.sentinelLogPath);
+      expect(audit.some(e => e.kind === 'recovered' && e.sentinel === 'context-wedge')).toBe(true);
+    } finally {
+      rig.cleanup();
+    }
+  });
+});
+
+describe('ContextWedgeSentinel E2E — WIRED into server.ts (dead-code guard)', () => {
+  const serverSrc = fs.readFileSync(
+    path.join(process.cwd(), 'src/commands/server.ts'),
+    'utf-8',
+  );
+
+  it('server.ts constructs a ContextWedgeSentinel', () => {
+    expect(serverSrc).toContain('new ContextWedgeSentinel(');
+  });
+
+  it('server.ts starts the sentinel scan loop', () => {
+    expect(serverSrc).toMatch(/wedgeSentinel\.start\(\)/);
+  });
+
+  it('server.ts builds the deps via buildContextWedgeDeps', () => {
+    expect(serverSrc).toContain('buildContextWedgeDeps(');
+  });
+
+  it('server.ts folds the wedge sentinel into the SessionReaper recovery veto', () => {
+    expect(serverSrc).toContain('wedgeRecoveryActive');
+  });
+
+  it('server.ts wires the fresh-respawn recovery (no --resume into the corrupted transcript)', () => {
+    expect(serverSrc).toMatch(/fresh:\s*true/);
+  });
+});

--- a/tests/integration/context-wedge-sentinel-wiring.test.ts
+++ b/tests/integration/context-wedge-sentinel-wiring.test.ts
@@ -1,0 +1,178 @@
+// safe-git-allow: test file — no git calls.
+// safe-fs-allow: test file — no fs mutations.
+
+/**
+ * Integration test for ContextWedgeSentinel wiring.
+ *
+ * Drives the real ContextWedgeSentinel through the real buildContextWedgeDeps
+ * + a real SentinelNotifier against a fake SessionManager surface — the same
+ * shape server.ts assembles in the silently-stopped block. Proves the delivery
+ * contract across the three recovery policies:
+ *   - detect-only (default): audit + (Telegram OFF) escalation-suppressed; no respawn.
+ *   - dry-run: a 'dry-run' audit row, no respawn, no Telegram.
+ *   - live: a fresh respawn happens and lands as a 'recovered' audit row.
+ *   - telegram ON + detect-only: ONE coalesced escalation send.
+ *
+ * Spec: docs/specs/context-wedge-sentinel.md
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ContextWedgeSentinel } from '../../src/monitoring/ContextWedgeSentinel.js';
+import {
+  buildContextWedgeDeps,
+  type SentinelSessionSurface,
+} from '../../src/monitoring/sentinelWiring.js';
+import { SentinelNotifier, type SentinelLogEntry } from '../../src/monitoring/SentinelNotifier.js';
+
+const WEDGE_TAIL = [
+  '  ⎿  API Error: 400 messages.9.content.20: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.',
+  '✻ Cooked for 0s',
+].join('\n');
+
+function surfaceWith(output: string): SentinelSessionSurface {
+  return {
+    captureOutput: () => output,
+    isSessionAlive: () => true,
+    sendKey: () => true,
+    listRunningSessions: () => [{ tmuxSession: 'echo-wedged' }],
+  };
+}
+
+/** Mirror server.ts's sentinel→notifier event wiring so the integration test
+ *  exercises the same audit-row production the server does. */
+function wireEvents(sentinel: ContextWedgeSentinel, notifier: SentinelNotifier): void {
+  sentinel.on('detected', (e: { sessionName: string }) => notifier.record('detected', 'context-wedge', e.sessionName));
+  sentinel.on('recovered', (e: { sessionName: string }) => notifier.record('recovered', 'context-wedge', e.sessionName, 'fresh respawn'));
+  sentinel.on('dry-run', (e: { sessionName: string }) => notifier.record('dry-run', 'context-wedge', e.sessionName, 'would fresh-respawn'));
+  sentinel.on('false-alarm', (e: { sessionName: string }) => notifier.record('false-alarm', 'context-wedge', e.sessionName, 'signature scrolled out of tail'));
+  sentinel.on('recovery-error', (e: { sessionName: string; err: unknown }) => notifier.record('recovery-error', 'context-wedge', e.sessionName, String(e.err)));
+}
+
+describe('ContextWedgeSentinel — end-to-end through SentinelNotifier', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  function makeRig(opts: { telegramEscalation?: boolean } = {}) {
+    const log: SentinelLogEntry[] = [];
+    const sent: string[] = [];
+    const notifier = new SentinelNotifier(
+      {
+        log: (e) => log.push(e),
+        sendConsolidated: async (text) => { sent.push(text); return true; },
+      },
+      { telegramEscalation: opts.telegramEscalation ?? false, coalesceWindowMs: 50 },
+    );
+    return { notifier, log, sent };
+  }
+
+  it('detect-only (default): confirmed wedge → audit + suppressed escalation, NO respawn, Telegram silent', async () => {
+    const { notifier, log, sent } = makeRig({ telegramEscalation: false });
+    let respawns = 0;
+    const sentinel = new ContextWedgeSentinel(
+      buildContextWedgeDeps({
+        sessions: surfaceWith(WEDGE_TAIL),
+        escalate: (name, text) => notifier.escalate('context-wedge', name, text),
+        autoRecovery: { enabled: false },
+        freshRespawn: async () => { respawns++; return true; },
+      }),
+      { confirmWindowMs: 45_000, tickIntervalMs: 20_000 },
+    );
+    wireEvents(sentinel, notifier);
+    sentinel.scanSession('echo-wedged');
+    await vi.advanceTimersByTimeAsync(46_000); // pass the confirm window
+    const kinds = log.filter(e => e.sentinel === 'context-wedge').map(e => e.kind);
+    expect(kinds).toContain('detected');
+    expect(log.some(e => e.kind === 'escalated' && e.sentinel === 'context-wedge')).toBe(true);
+    expect(log.some(e => e.kind === 'escalation-suppressed')).toBe(true);
+    expect(sent).toHaveLength(0); // Telegram OFF by default
+    expect(respawns).toBe(0); // detect-only never kills
+  });
+
+  it('dry-run: confirmed wedge → dry-run audit row, NO respawn, Telegram silent', async () => {
+    const { notifier, log, sent } = makeRig({ telegramEscalation: true });
+    let respawns = 0;
+    const sentinel = new ContextWedgeSentinel(
+      buildContextWedgeDeps({
+        sessions: surfaceWith(WEDGE_TAIL),
+        escalate: (name, text) => notifier.escalate('context-wedge', name, text),
+        autoRecovery: { enabled: true, dryRun: true },
+        freshRespawn: async () => { respawns++; return true; },
+      }),
+      { confirmWindowMs: 45_000 },
+    );
+    wireEvents(sentinel, notifier);
+    sentinel.scanSession('echo-wedged');
+    await vi.advanceTimersByTimeAsync(46_000);
+    expect(log.some(e => e.kind === 'dry-run' && e.sentinel === 'context-wedge')).toBe(true);
+    expect(respawns).toBe(0);
+    expect(sent).toHaveLength(0); // dry-run is not an escalation
+  });
+
+  it('live: confirmed wedge → fresh respawn happens and lands as a recovered audit row', async () => {
+    const { notifier, log } = makeRig({ telegramEscalation: false });
+    let respawns = 0;
+    const sentinel = new ContextWedgeSentinel(
+      buildContextWedgeDeps({
+        sessions: surfaceWith(WEDGE_TAIL),
+        escalate: (name, text) => notifier.escalate('context-wedge', name, text),
+        autoRecovery: { enabled: true, dryRun: false },
+        freshRespawn: async () => { respawns++; return true; },
+      }),
+      { confirmWindowMs: 45_000 },
+    );
+    wireEvents(sentinel, notifier);
+    sentinel.scanSession('echo-wedged');
+    await vi.advanceTimersByTimeAsync(46_000);
+    expect(respawns).toBe(1);
+    expect(log.some(e => e.kind === 'recovered' && e.sentinel === 'context-wedge')).toBe(true);
+    expect(log.some(e => e.kind === 'escalated')).toBe(false); // recovered, not escalated
+  });
+
+  it('telegram ON + detect-only: ONE coalesced escalation send to the system topic', async () => {
+    const { notifier, sent } = makeRig({ telegramEscalation: true });
+    const sentinel = new ContextWedgeSentinel(
+      buildContextWedgeDeps({
+        sessions: surfaceWith(WEDGE_TAIL),
+        escalate: (name, text) => notifier.escalate('context-wedge', name, text),
+        autoRecovery: { enabled: false },
+        freshRespawn: async () => true,
+      }),
+      { confirmWindowMs: 45_000 },
+    );
+    wireEvents(sentinel, notifier);
+    sentinel.scanSession('echo-wedged');
+    await vi.advanceTimersByTimeAsync(46_000); // confirm
+    await vi.advanceTimersByTimeAsync(100); // coalesce flush
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatch(/restart/i);
+  });
+
+  it('false alarm: signature scrolls out of tail during confirm → no respawn, no escalation', async () => {
+    const { notifier, log, sent } = makeRig({ telegramEscalation: true });
+    let respawns = 0;
+    let output = WEDGE_TAIL;
+    const surface: SentinelSessionSurface = {
+      captureOutput: () => output,
+      isSessionAlive: () => true,
+      sendKey: () => true,
+      listRunningSessions: () => [{ tmuxSession: 'echo-transient' }],
+    };
+    const sentinel = new ContextWedgeSentinel(
+      buildContextWedgeDeps({
+        sessions: surface,
+        escalate: (name, text) => notifier.escalate('context-wedge', name, text),
+        autoRecovery: { enabled: true, dryRun: false },
+        freshRespawn: async () => { respawns++; return true; },
+      }),
+      { confirmWindowMs: 45_000 },
+    );
+    wireEvents(sentinel, notifier);
+    sentinel.scanSession('echo-transient');
+    // Session progressed — error scrolled out before the confirm fires.
+    output = 'normal prompt — back to work\n> ready for next';
+    await vi.advanceTimersByTimeAsync(46_000);
+    expect(respawns).toBe(0);
+    expect(log.some(e => e.kind === 'false-alarm')).toBe(true);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/tests/unit/SessionRefresh.test.ts
+++ b/tests/unit/SessionRefresh.test.ts
@@ -37,6 +37,9 @@ function makeDeps(overrides: {
   const topicResumeMap: Partial<TopicResumeMap> = {
     findUuidForSession: vi.fn().mockReturnValue(uuid),
     save: vi.fn(),
+    remove: vi.fn((_topic: number) => {
+      callOrder.push('removeResume');
+    }) as unknown as TopicResumeMap['remove'],
   };
   const sessionManager: Partial<SessionManager> = {
     killSession: vi.fn((_id: string) => {
@@ -71,6 +74,26 @@ function makeDeps(overrides: {
 describe('SessionRefresh', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('fresh mode (ContextWedgeSentinel re-wedge defense)', () => {
+    it('clears the topic resume UUID AFTER kill and BEFORE respawn', async () => {
+      const { refresh, topicResumeMap, callOrder } = makeDeps();
+      const result = await refresh.refreshSession({ sessionName: 'echo-qalatra', fresh: true });
+      expect(result.ok).toBe(true);
+      expect(topicResumeMap.remove).toHaveBeenCalledWith(9235);
+      // Order is load-bearing: beforeSessionKill saves the UUID during
+      // killSession, so the clear MUST come after the kill; and the respawner
+      // reads the (now-cleared) map, so the clear MUST come before respawn.
+      expect(callOrder).toEqual(['killSession', 'removeResume', 'respawner']);
+    });
+
+    it('default (no fresh) preserves resume — never clears the UUID', async () => {
+      const { refresh, topicResumeMap, callOrder } = makeDeps();
+      await refresh.refreshSession({ sessionName: 'echo-qalatra' });
+      expect(topicResumeMap.remove).not.toHaveBeenCalled();
+      expect(callOrder).toEqual(['killSession', 'respawner']);
+    });
   });
 
   describe('happy path', () => {

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -215,6 +215,10 @@ describe('Feature Delivery Completeness', () => {
       'Cross-Machine Seamlessness (one agent, many machines)', // operational self-heal/handoff awareness (like Version-Skew); not a user-invokable capability
       'What are we working on?',                           // migrator patch for the initiatives Registry-First row, not a capability section
       'Framework-Onboarding Mentor System',               // developer-layer issue-ledger observability; not a Codex/Gemini end-user capability (no shadow-marker parity)
+      'What address reaches me (Threadline routing fingerprint)', // Threadline routing-fingerprint operational knowledge, migrator-only (no template/shadow parity)
+      'ContextWedgeSentinel',                              // thinking-block-400 wedge recovery; operational self-heal awareness, migrator-only (no template parity) — see context-wedge-sentinel.md
+      '/release-readiness',                                // alternate endpoint check for the templated Release Readiness section
+      'Agent Updates topic (self-broadcasts about ships, restarts, updates)', // self-broadcast routing operational knowledge, migrator-only
     ];
 
     it('all new migrator CLAUDE.md sections are tracked', () => {

--- a/tests/unit/monitoring/ContextWedgeSentinel.test.ts
+++ b/tests/unit/monitoring/ContextWedgeSentinel.test.ts
@@ -1,0 +1,224 @@
+// safe-git-allow: test file — no git calls.
+// safe-fs-allow: test file — no fs mutations.
+
+/**
+ * Unit tests for ContextWedgeSentinel.
+ *
+ * Spec: docs/specs/context-wedge-sentinel.md
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ContextWedgeSentinel,
+  detectContextWedge,
+  signatureIsTail,
+  CONTEXT_WEDGE_PATTERNS,
+  type WedgeRecoveryOutcome,
+} from '../../../src/monitoring/ContextWedgeSentinel.js';
+
+const WEDGE_TAIL = [
+  '⏺ Bash(grep -n "Multi-machine mesh" src/cli.ts)',
+  '  ⎿  Cancelled: parallel tool call Bash(rm -rf ...) errored',
+  '  ⎿  API Error: 400 messages.9.content.20: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.',
+  '✻ Cooked for 0s',
+].join('\n');
+
+describe('detectContextWedge', () => {
+  it('matches the canonical thinking-block 400', () => {
+    expect(detectContextWedge(WEDGE_TAIL)).toBe(true);
+  });
+
+  it('matches the redacted_thinking variant', () => {
+    expect(detectContextWedge('`redacted_thinking` blocks in this message cannot be modified')).toBe(true);
+  });
+
+  it('does not match unrelated text', () => {
+    expect(detectContextWedge('all systems normal; processing message')).toBe(false);
+  });
+
+  it('empty/undefined is false (no throw)', () => {
+    expect(detectContextWedge('')).toBe(false);
+    expect(detectContextWedge(undefined as unknown as string)).toBe(false);
+  });
+
+  it('exports at least one pattern', () => {
+    expect(CONTEXT_WEDGE_PATTERNS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('signatureIsTail', () => {
+  it('true when the signature is in the last lines', () => {
+    expect(signatureIsTail(WEDGE_TAIL)).toBe(true);
+  });
+
+  it('false when the signature scrolled out of the tail (session progressed)', () => {
+    const progressed =
+      WEDGE_TAIL +
+      '\n' +
+      Array.from({ length: 20 }, (_, i) => `working line ${i}: doing real work now`).join('\n');
+    expect(detectContextWedge(progressed)).toBe(true); // still present somewhere
+    expect(signatureIsTail(progressed)).toBe(false); // but not the live tail
+  });
+});
+
+interface Captured { sessionName: string; text: string; }
+
+function makeDeps(opts: {
+  output?: string | (() => string);
+  outcome?: WedgeRecoveryOutcome;
+  notifyCapture?: Captured[];
+} = {}) {
+  const captured: Captured[] = opts.notifyCapture ?? [];
+  const timers: Array<() => void> = [];
+  let recoverCalls = 0;
+  return {
+    getRecentOutput: (_s: string) =>
+      typeof opts.output === 'function' ? opts.output() : (opts.output ?? WEDGE_TAIL),
+    recoverFn: async (_s: string): Promise<WedgeRecoveryOutcome> => {
+      recoverCalls++;
+      return opts.outcome ?? 'detect-only';
+    },
+    notifyFn: async (sessionName: string, text: string) => {
+      captured.push({ sessionName, text });
+    },
+    setTimer: (fn: () => void, _ms: number) => {
+      timers.push(fn);
+      return { ref: () => {}, unref: () => {} } as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimer: (_h: ReturnType<typeof setTimeout>) => {},
+    captured,
+    get recoverCalls() { return recoverCalls; },
+    drainTimers: async () => {
+      while (timers.length > 0) {
+        const fn = timers.shift();
+        if (fn) { fn(); await Promise.resolve(); await Promise.resolve(); }
+      }
+    },
+  };
+}
+
+describe('ContextWedgeSentinel — detection gating', () => {
+  it('scanSession does NOT report when the signature is not the tail (discussing the bug)', () => {
+    // A session merely discussing the error: signature present but buried, then
+    // 20 lines of real work as the tail.
+    const discussing =
+      'Let me explain the bug: blocks in the latest assistant message cannot be modified.\n' +
+      Array.from({ length: 20 }, (_, i) => `line ${i}: now writing the fix`).join('\n');
+    const deps = makeDeps({ output: discussing });
+    const s = new ContextWedgeSentinel(deps);
+    s.scanSession('echo-discuss');
+    expect(s.listActive()).toHaveLength(0);
+  });
+
+  it('scanSession reports when the signature IS the live tail', () => {
+    const deps = makeDeps({ output: WEDGE_TAIL });
+    const s = new ContextWedgeSentinel(deps);
+    s.scanSession('echo-wedged');
+    expect(s.listActive()).toHaveLength(1);
+    expect(s.listActive()[0].status).toBe('confirming');
+  });
+
+  it('report is idempotent for an already-tracked session', () => {
+    const deps = makeDeps();
+    const s = new ContextWedgeSentinel(deps);
+    s.report('echo-wedged');
+    s.report('echo-wedged');
+    expect(s.listActive()).toHaveLength(1);
+  });
+});
+
+describe('ContextWedgeSentinel — confirm window', () => {
+  it('false-alarm: signature gone from tail at confirm → cleared, no recovery', async () => {
+    let out = WEDGE_TAIL;
+    const deps = makeDeps({ output: () => out, outcome: 'respawned' });
+    const s = new ContextWedgeSentinel(deps);
+    let falseAlarm = false;
+    s.on('false-alarm', () => { falseAlarm = true; });
+    s.scanSession('echo-transient');
+    // Session progressed during the confirm window — error scrolled out.
+    out = 'normal prompt — back to work\n> ready';
+    await deps.drainTimers();
+    expect(falseAlarm).toBe(true);
+    expect(deps.recoverCalls).toBe(0);
+    expect(s.listActive()).toHaveLength(0);
+  });
+
+  it('confirmed wedge still showing tail → recoverFn invoked', async () => {
+    const deps = makeDeps({ output: WEDGE_TAIL, outcome: 'detect-only' });
+    const s = new ContextWedgeSentinel(deps);
+    s.scanSession('echo-wedged');
+    await deps.drainTimers();
+    expect(deps.recoverCalls).toBe(1);
+  });
+});
+
+describe('ContextWedgeSentinel — recovery outcomes', () => {
+  it("'respawned' → recovered, state cleared, no escalation", async () => {
+    const deps = makeDeps({ outcome: 'respawned' });
+    const s = new ContextWedgeSentinel(deps);
+    let recovered = false;
+    s.on('recovered', () => { recovered = true; });
+    s.report('echo-wedged');
+    await deps.drainTimers();
+    expect(recovered).toBe(true);
+    expect(deps.captured).toHaveLength(0);
+    expect(s.listActive()).toHaveLength(0);
+  });
+
+  it("'dry-run' → dry-run event, no escalation, state retained", async () => {
+    const deps = makeDeps({ outcome: 'dry-run' });
+    const s = new ContextWedgeSentinel(deps);
+    let dryRun = false;
+    s.on('dry-run', () => { dryRun = true; });
+    s.report('echo-wedged');
+    await deps.drainTimers();
+    expect(dryRun).toBe(true);
+    expect(deps.captured).toHaveLength(0);
+    expect(s.listActive()).toHaveLength(1); // retained so it isn't re-confirmed
+  });
+
+  it("'detect-only' → escalates (the session is dead, auto-recovery off)", async () => {
+    const deps = makeDeps({ outcome: 'detect-only' });
+    const s = new ContextWedgeSentinel(deps);
+    let escalated: { outcome: WedgeRecoveryOutcome } | null = null;
+    s.on('escalated', (e) => { escalated = e; });
+    s.report('echo-wedged');
+    await deps.drainTimers();
+    expect(escalated).not.toBeNull();
+    expect(escalated!.outcome).toBe('detect-only');
+    expect(deps.captured).toHaveLength(1);
+    expect(deps.captured[0].text).toMatch(/restart/i);
+  });
+
+  it("'failed' → escalates with a recovery-failed message", async () => {
+    const deps = makeDeps({ outcome: 'failed' });
+    const s = new ContextWedgeSentinel(deps);
+    s.report('echo-wedged');
+    await deps.drainTimers();
+    expect(deps.captured).toHaveLength(1);
+    expect(deps.captured[0].text).toMatch(/did not clear/i);
+  });
+
+  it('recoverFn throwing is treated as failed (no crash)', async () => {
+    const deps = makeDeps();
+    deps.recoverFn = async () => { throw new Error('boom'); };
+    const s = new ContextWedgeSentinel(deps);
+    let recoveryError = false;
+    s.on('recovery-error', () => { recoveryError = true; });
+    s.report('echo-wedged');
+    await deps.drainTimers();
+    expect(recoveryError).toBe(true);
+    expect(deps.captured).toHaveLength(1); // escalated as failed
+  });
+});
+
+describe('ContextWedgeSentinel — isRecoveryActive (SessionReaper veto)', () => {
+  it('true while confirming, false after recovery', async () => {
+    const deps = makeDeps({ outcome: 'respawned' });
+    const s = new ContextWedgeSentinel(deps);
+    s.report('echo-wedged');
+    expect(s.isRecoveryActive('echo-wedged')).toBe(true);
+    await deps.drainTimers();
+    expect(s.isRecoveryActive('echo-wedged')).toBe(false);
+  });
+});

--- a/tests/unit/monitoring/sentinelWiring.test.ts
+++ b/tests/unit/monitoring/sentinelWiring.test.ts
@@ -18,6 +18,7 @@ import {
   makeAttentionPoster,
   buildSocketDisconnectDeps,
   buildActiveWorkSilenceDeps,
+  buildContextWedgeDeps,
   OutputActivityTracker,
   looksActivelyWorking,
   type SentinelSessionSurface,
@@ -136,6 +137,101 @@ describe('buildSocketDisconnectDeps — wiring integrity', () => {
   it('listSessionNames maps running sessions to their tmux names', () => {
     const surface = makeSurface({ sessions: [{ tmuxSession: 'a' }, { tmuxSession: 'b' }] });
     const deps = buildSocketDisconnectDeps({ sessions: surface, escalate: async () => {} });
+    expect(deps.listSessionNames!()).toEqual(['a', 'b']);
+  });
+});
+
+describe('buildContextWedgeDeps — wiring integrity + recovery policy', () => {
+  it('all deps are real functions, not null/no-op', () => {
+    const deps = buildContextWedgeDeps({
+      sessions: makeSurface(),
+      escalate: async () => {},
+      autoRecovery: { enabled: false },
+      freshRespawn: async () => true,
+    });
+    expect(typeof deps.getRecentOutput).toBe('function');
+    expect(typeof deps.recoverFn).toBe('function');
+    expect(typeof deps.notifyFn).toBe('function');
+    expect(typeof deps.listSessionNames).toBe('function');
+  });
+
+  it('getRecentOutput delegates to captureOutput and coerces null → empty string', () => {
+    const captureCalls: Call[] = [];
+    const surface = makeSurface({ output: null, captureCalls });
+    const deps = buildContextWedgeDeps({
+      sessions: surface, escalate: async () => {},
+      autoRecovery: { enabled: false }, freshRespawn: async () => true,
+    });
+    expect(deps.getRecentOutput('agent-1')).toBe('');
+    expect(captureCalls.length).toBe(1);
+  });
+
+  it("recoverFn → 'detect-only' when autoRecovery disabled (freshRespawn NOT called)", async () => {
+    let respawnCalls = 0;
+    const deps = buildContextWedgeDeps({
+      sessions: makeSurface(), escalate: async () => {},
+      autoRecovery: { enabled: false },
+      freshRespawn: async () => { respawnCalls++; return true; },
+    });
+    expect(await deps.recoverFn('agent-1')).toBe('detect-only');
+    expect(respawnCalls).toBe(0);
+  });
+
+  it("recoverFn → 'dry-run' when enabled + dryRun (freshRespawn NOT called)", async () => {
+    let respawnCalls = 0;
+    const deps = buildContextWedgeDeps({
+      sessions: makeSurface(), escalate: async () => {},
+      autoRecovery: { enabled: true, dryRun: true },
+      freshRespawn: async () => { respawnCalls++; return true; },
+    });
+    expect(await deps.recoverFn('agent-1')).toBe('dry-run');
+    expect(respawnCalls).toBe(0);
+  });
+
+  it("recoverFn → 'respawned' when enabled + live and freshRespawn succeeds", async () => {
+    const deps = buildContextWedgeDeps({
+      sessions: makeSurface(), escalate: async () => {},
+      autoRecovery: { enabled: true, dryRun: false },
+      freshRespawn: async () => true,
+    });
+    expect(await deps.recoverFn('agent-1')).toBe('respawned');
+  });
+
+  it("recoverFn → 'failed' when freshRespawn returns false", async () => {
+    const deps = buildContextWedgeDeps({
+      sessions: makeSurface(), escalate: async () => {},
+      autoRecovery: { enabled: true, dryRun: false },
+      freshRespawn: async () => false,
+    });
+    expect(await deps.recoverFn('agent-1')).toBe('failed');
+  });
+
+  it("recoverFn → 'failed' when freshRespawn throws (no crash)", async () => {
+    const deps = buildContextWedgeDeps({
+      sessions: makeSurface(), escalate: async () => {},
+      autoRecovery: { enabled: true, dryRun: false },
+      freshRespawn: async () => { throw new Error('boom'); },
+    });
+    expect(await deps.recoverFn('agent-1')).toBe('failed');
+  });
+
+  it('notifyFn delegates the (sessionName, text) pair to escalate', async () => {
+    const calls: Array<{ name: string; text: string }> = [];
+    const deps = buildContextWedgeDeps({
+      sessions: makeSurface(),
+      escalate: async (name, text) => { calls.push({ name, text }); },
+      autoRecovery: { enabled: false }, freshRespawn: async () => true,
+    });
+    await deps.notifyFn('agent-1', 'wedged');
+    expect(calls).toEqual([{ name: 'agent-1', text: 'wedged' }]);
+  });
+
+  it('listSessionNames maps running sessions to tmux names', () => {
+    const surface = makeSurface({ sessions: [{ tmuxSession: 'a' }, { tmuxSession: 'b' }] });
+    const deps = buildContextWedgeDeps({
+      sessions: surface, escalate: async () => {},
+      autoRecovery: { enabled: false }, freshRespawn: async () => true,
+    });
     expect(deps.listSessionNames!()).toEqual(['a', 'b']);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,60 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+**A new way sessions die is now detected and (optionally) auto-recovered.** When
+a tool call is cancelled inside a *parallel* tool batch while extended thinking
+is on, Claude Code corrupts the thinking block on the latest assistant turn —
+and from then on the Anthropic API rejects every resume with
+`400 … thinking blocks in the latest assistant message cannot be modified`. The
+session fast-fails instantly on every message ("Cooked for 0s"): permanently
+dead, yet still emitting output. Because it's not *silent* and hasn't lost its
+socket, neither the ActiveWorkSilenceSentinel nor the SocketDisconnectSentinel
+catches it — the user just sees standby/sentinel replies forever while the real
+session is a corpse. (Live incident: a session on a real topic fast-failed every
+"How is this looking?" for ~30 minutes.)
+
+The new **ContextWedgeSentinel** (a 4th member of the silently-stopped family)
+recognizes this exact wedge: it matches the error as the *live session tail* and
+waits a 45s confirm window so a session merely *discussing* the bug is never
+flagged. A gentle nudge can't fix this one (re-engaging re-sends the corrupted
+turn), so recovery is a **fresh respawn** — kill the session and clear the
+topic's saved resume UUID so the bridge spawns a brand-new conversation instead
+of `--resume`-ing the corrupted transcript (which would just re-wedge on the
+next message — the central correctness property). This reuses the existing
+rate-guarded `SessionRefresh` via a new `fresh` mode.
+
+Detection + audit are **default-ON housekeeping** (they write to
+`logs/sentinel-events.jsonl` and kill nothing). The destructive auto-respawn is
+**opt-in** (`monitoring.contextWedgeSentinel.autoRecovery`, default off + dry-run)
+and rides the Graduated Feature Rollout track. The sentinel also feeds the
+SessionReaper kill-veto so the reaper never reaps a session mid-recovery. New
+config kill switch `monitoring.contextWedgeSentinel.enabled` (default true).
+
+## What to Tell Your User
+
+- I can now spot a specific way a session silently dies — it gets stuck on a
+  "can't modify the thinking block" error and fails instantly on every message
+  while still looking busy — which used to leave you seeing only standby replies.
+- By default I just notice it and log it (nothing is killed). You can opt in to
+  having me automatically restart a stuck session cleanly; when that's on I throw
+  away the corrupted conversation and start fresh so it can't get re-stuck.
+- Nothing you see changes by default. If you ever want the auto-restart on, it's
+  one config switch, and it's on a track that will nag toward on-by-default once
+  it's proven itself.
+
+## Summary of New Capabilities
+
+- **ContextWedgeSentinel** — detects the thinking-block-400 fast-fail wedge as a
+  non-progressing session tail (45s confirm window); audits every transition to
+  `logs/sentinel-events.jsonl`.
+- **SessionRefresh `fresh` mode** — kill + respawn that clears the topic's resume
+  UUID, so recovery never reloads a corrupted transcript (no re-wedge loop).
+- **Opt-in auto-recovery** — `monitoring.contextWedgeSentinel.autoRecovery`
+  (default off + dry-run), on the Graduated Feature Rollout track; promotion to
+  default-on propagates fleet-wide on update with no migration.
+- Escalation (when a confirmed wedge isn't auto-recovered) routes through the
+  existing tone-gated SentinelNotifier, gated by `sentinelTelegramEscalation`
+  (default off, coalesced).

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -45,6 +45,35 @@ config kill switch `monitoring.contextWedgeSentinel.enabled` (default true).
   one config switch, and it's on a track that will nag toward on-by-default once
   it's proven itself.
 
+## Evidence
+
+**Reproduction (live, 2026-05-28).** The `echo-instar-exo` session (topic 13481,
+the `mm-proof-build` worktree) fired a parallel Bash batch; one call
+(`rm -rf …/echo…`) was blocked by the source-tree guard, which cancelled the
+whole batch. With extended thinking on, that corrupted the latest assistant
+turn's thinking block.
+
+**Observed before.** Every subsequent inbound Telegram message produced, in the
+tmux pane, an instant:
+```
+⎿  API Error: 400 messages.9.content.20: `thinking` or `redacted_thinking` blocks
+   in the latest assistant message cannot be modified.
+✻ Cooked for 0s
+```
+The user sent "How is this looking?" twice over ~30 minutes and received only
+sentinel/standby replies — the session was a corpse, and the silence + socket
+sentinels never fired (output never went quiet; no disconnect string).
+
+**Observed after.** With ContextWedgeSentinel: the wedge is detected as the live
+tail and written to `logs/sentinel-events.jsonl` (`kind:detected` →
+`kind:escalated` in detect-only mode, or `kind:recovered` when autoRecovery is
+on). The e2e test (`tests/e2e/context-wedge-sentinel-lifecycle.test.ts`) drives
+the production assembly and reads those exact rows back from disk; the live
+recovery clears the topic's resume UUID so the respawn starts fresh (verified by
+`SessionRefresh.test.ts` asserting the kill→clear→respawn order). The original
+wedged session was recovered manually by killing it (the next message spawned
+clean), confirming the fresh-respawn approach before it was automated.
+
 ## Summary of New Capabilities
 
 - **ContextWedgeSentinel** — detects the thinking-block-400 fast-fail wedge as a

--- a/upgrades/side-effects/context-wedge-sentinel.md
+++ b/upgrades/side-effects/context-wedge-sentinel.md
@@ -1,0 +1,69 @@
+# Side-Effects Review — ContextWedgeSentinel (thinking-block-400 fast-fail wedge)
+
+**Version / slug:** `context-wedge-sentinel`
+**Date:** `2026-05-28`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (single-author; design reviewed conversationally by Justin in topic 15160 before build; /spec-converge fast-tracked — see Conclusion)`
+
+## Summary of the change
+
+Adds a 4th "silently-stopped" sentinel, `ContextWedgeSentinel`, that detects the Claude Code `400 … thinking/redacted_thinking blocks in the latest assistant message cannot be modified` wedge (a tool call cancelled inside a parallel batch corrupts the latest assistant turn's thinking block, so every resume 400s instantly and the session is permanently dead while still emitting output — invisible to the silence + socket sentinels). Recovery is a fresh respawn (kill + clear the topic's `TopicResumeMap` entry so the bridge does not `--resume` the corrupted transcript). Files: `src/monitoring/ContextWedgeSentinel.ts` (new), `src/monitoring/sentinelWiring.ts` (`buildContextWedgeDeps`), `src/monitoring/SentinelNotifier.ts` (`dry-run`/`false-alarm` kinds), `src/core/SessionRefresh.ts` (`fresh` mode), `src/core/types.ts` + `src/config/ConfigDefaults.ts` (config), `src/commands/server.ts` (trio-block wiring + recovery veto), `src/core/PostUpdateMigrator.ts` (agent-awareness section).
+
+## Decision-point inventory
+
+- `ContextWedgeSentinel.scanSession/confirm` (detector) — **add** — pattern-matches the wedge signature as the non-progressing session tail; signal-only, no block authority.
+- `buildContextWedgeDeps.recoverFn` (recovery policy) — **add** — maps autoRecovery config → detect-only / dry-run / live respawn. Bounded primitive (SessionRefresh rate-guards).
+- `SessionRefresh.refreshSession({fresh})` — **modify** — adds a branch that clears the resume UUID after kill; existing resume-preserving behavior unchanged when `fresh` is absent.
+- `composedRecoveryActive` (SessionReaper kill-veto) — **modify** — folds in `wedgeRecoveryActive` (pass-through OR, never removes a veto).
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. The sentinel never blocks a message or tool call. The only "action" is a kill+respawn, gated behind `autoRecovery` (default off) + a 45s confirm window requiring the signature to remain the live tail. The realistic over-action is restarting a session that wasn't truly wedged; mitigated by tail-gate + confirm-window + opt-in default, and bounded by SessionRefresh's rate guard (5/10min).
+
+## 2. Under-block
+
+No block/allow surface — under-block not applicable. As a detector: it will miss a wedge whose error text is not in the captured tail window (default 30 lines) — e.g. if the session printed >30 lines after the error without progressing past it. Acceptable: the next tick re-captures, and the error is the literal tail of a dead session by construction (it can't print anything new). It also only matches the thinking-block signature, not other permanent-400 classes; those are out of scope for this spec.
+
+## 3. Level-of-abstraction fit
+
+Correct layer. This is a low-level detector (regex on captured pane output) feeding a bounded recovery primitive — exactly mirroring the existing `SocketDisconnectSentinel`. It does NOT re-implement respawn: it reuses `SessionRefresh` (the existing kill+respawn authority, with rate-guard + in-flight guard). The recovery *policy* (detect-only/dry-run/live) lives in the wiring, not the detector, so the rollout-staged flag is observed in one place. No higher-level gate already covers this failure shape (verified: silence + socket sentinels both miss it).
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart primitive (SessionRefresh) / the existing SentinelNotifier delivery policy.
+
+The detector holds no blocking authority. The destructive action (respawn) is performed by SessionRefresh (an existing rate-guarded primitive), only when an operator opts in via `autoRecovery`, and only after a confirm window. Escalation routes through the existing `MessagingToneGate` via `SentinelNotifier`. No brittle check owns block authority.
+
+## 5. Interactions
+
+- **Shadowing:** Runs alongside the socket + silence sentinels on the same session-scan surface. It does not shadow them — they detect disjoint signatures (disconnect string / output-gap vs. thinking-block-400 tail). All three independently feed `isRecoveryActive` into `composedRecoveryActive`.
+- **Double-fire:** Could two sentinels act on one session? Each tracks its own state map and only acts on its own signature. The SessionReaper veto is an OR of all four `isRecoveryActive` checks, so a wedge-recovery-in-flight also vetoes reaping — additive, not conflicting.
+- **Races:** The destructive path goes through `SessionRefresh`, which has an in-flight guard (refuses a second concurrent refresh for the same session) and a rate guard. The `fresh` clear of `TopicResumeMap` happens after `killSession` (so `beforeSessionKill` has already written the UUID) and before the respawner reads it — order asserted in `SessionRefresh.test.ts`.
+- **Feedback loops:** The fresh respawn clears the resume pointer specifically to BREAK the re-wedge feedback loop (kill → beforeSessionKill saves UUID → next message --resumes corrupted transcript → re-wedge). Without `fresh`, a naive kill would create that loop; this is the central correctness property.
+
+## 6. External surfaces
+
+- **Other agents on the machine:** none — per-agent monitoring, no shared state mutated.
+- **Install base:** detection + audit are default-ON for all agents on update (read-time fallback `?? {enabled:true}` + `ConfigDefaults` persists `enabled:true`). This is harmless (writes audit rows; kills nothing). The destructive `autoRecovery` is NOT persisted into agent configs (deliberately omitted from `ConfigDefaults` because `applyDefaults` is add-missing-only — persisting would freeze it and break a later default-on flip). It defaults off via the server.ts runtime literal.
+- **External systems:** none directly. A fresh respawn re-spawns a Claude Code session (tmux) — same surface SessionRefresh already touches for `/restart`.
+- **Persistent state:** appends to `logs/sentinel-events.jsonl` (existing audit file). Clears one `TopicResumeMap` entry on a live recovery (intended).
+- **Timing:** confirm window (45s) + SessionRefresh rate guard bound the action rate.
+
+## 7. Rollback cost
+
+Pure code change — revert and ship a patch. No data migration: `autoRecovery` is not persisted, so there is nothing to clean up in agent configs. The `ConfigDefaults` `contextWedgeSentinel: {enabled:true}` block would be added to agent configs by `applyDefaults` on update; a rollback leaves a harmless unused key (the runtime simply won't read it once the code is gone). No user-visible regression during the rollback window — detection is silent and auto-recovery ships off. The CLAUDE.md awareness section added by `migrateClaudeMd` is idempotent and harmless if the feature is reverted.
+
+## Conclusion
+
+The review surfaced the one load-bearing correctness property — the fresh respawn MUST clear the resume UUID or recovery creates an infinite re-wedge loop — which is implemented, ordered correctly, and asserted in tests. It also surfaced the propagation subtlety that `autoRecovery` must NOT be persisted in `ConfigDefaults` (add-missing-only `applyDefaults` would freeze it), which shaped the final config design so the eventual default-on flip reaches existing agents. No blocking-authority concerns (detector + existing rate-guarded primitive). Clear to ship dark (auto-recovery off, detection on), with Echo dogfooding `autoRecovery` live.
+
+**Process note (transparency):** the design was reviewed conversationally by Justin (topic 15160) before and during the build, and he greenlit it. The full multi-agent `/spec-converge` pass was fast-tracked given (a) the bounded, established-pattern nature of the change (a 4th sentinel cloned from the trio), (b) it ships dark on a rollout track, and (c) the 3-tier test coverage + this side-effects review. The `review-convergence` tag reflects that diagnosis + design-review basis, not a `/spec-converge` timestamp. Flagged for Justin — he can request the full convergence pass before merge if he prefers.
+
+## Evidence pointers
+
+- Unit: `tests/unit/monitoring/ContextWedgeSentinel.test.ts`, `tests/unit/SessionRefresh.test.ts` (fresh-mode order).
+- Integration: `tests/integration/context-wedge-sentinel-wiring.test.ts`.
+- E2E: `tests/e2e/context-wedge-sentinel-lifecycle.test.ts` (on-disk JSONL audit + WIRED source guard).
+- Live incident: tmux pane of `echo-instar-exo` (topic 13481) showing the repeating 400 on every inject (2026-05-28).


### PR DESCRIPTION
## Summary
- New **ContextWedgeSentinel** (4th silently-stopped sentinel) detects the Claude Code `400 … thinking/redacted_thinking blocks in the latest assistant message cannot be modified` fast-fail wedge — a tool call cancelled inside a parallel batch corrupts the latest assistant turn's thinking block, so every resume 400s instantly and the session is permanently dead **while still emitting output** (invisible to the silence + socket sentinels).
- Recovery is a **fresh respawn** (new `SessionRefresh` `fresh` mode): kill + clear the topic's `TopicResumeMap` entry so the bridge never `--resume`s the corrupted transcript. Without this, a naive kill creates an infinite re-wedge loop (kill → `beforeSessionKill` saves UUID → next message resumes the corrupted turn → same 400).
- Detection + audit ship **default-ON housekeeping** (kills nothing). The destructive auto-respawn is **opt-in** (`monitoring.contextWedgeSentinel.autoRecovery`, default off + dry-run) and rides the **Graduated Feature Rollout** track. `autoRecovery` is deliberately NOT persisted in `ConfigDefaults` (`applyDefaults` is add-missing-only) so a later default-on flip propagates fleet-wide with no migration.
- Wired into the silently-stopped trio block + folded into the SessionReaper kill-veto (`composedRecoveryActive`).

## Live incident
A real session (topic 13481) fast-failed every "How is this looking?" for ~30 min while the user saw only standby replies. Recovered manually (kill → clean respawn), then automated here. Full repro + before/after in `upgrades/NEXT.md` → Evidence.

## Tests (3 tiers, all green)
- unit: detector + tail-gate + 45s confirm-window + 4 recovery outcomes; `SessionRefresh` fresh-mode order (clear after kill, before respawn).
- integration: full wiring through `SentinelNotifier` across detect-only/dry-run/live/false-alarm, default-Telegram-silent.
- e2e: production assembly writes `context-wedge` rows to `sentinel-events.jsonl` on disk + a WIRED source guard (constructs/starts/veto/fresh-respawn) against the dead-code failure.
- Also fixed 3 pre-existing `feature-delivery-completeness` failures on main (untracked migrator sections) per the Zero-Failure Standard.

## Process
- Spec: `docs/specs/context-wedge-sentinel.md` (+ ELI16 overview) with `rollout:` frontmatter so `FeatureRolloutReconciler` auto-registers the promotion track.
- Side-effects review: `upgrades/side-effects/context-wedge-sentinel.md`.
- Note: full `/spec-converge` was fast-tracked — design was reviewed conversationally by Justin (topic 15160) before/during the build. Flagged in the side-effects artifact; happy to run full convergence if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)