### PR TITLE
Unified session-lifecycle robustness — Phase 1 (ReapAuthority + reap-log + backstop)

### DIFF
--- a/docs/specs/reports/unified-session-lifecycle-robustness-convergence.md
+++ b/docs/specs/reports/unified-session-lifecycle-robustness-convergence.md
@@ -1,0 +1,145 @@
+# Convergence Report — Unified Session-Lifecycle Robustness
+
+## ELI10 Overview
+
+Your agent's sessions were vanishing without warning. The cause: a startup "cleanup crew" asks each
+session "are you still alive?" and waits only one second for an answer. Right after a restart — when
+the machine is busiest — a slow answer looks identical to a dead session, so live sessions got wiped.
+One restart wiped all nine at once. Worse, when I went looking I found there isn't one cleanup crew but
+**eight**, each deciding "alive or dead?" its own way, none coordinating, most sharing the same three
+bad habits: treating slow as dead, killing things that are actually working, and doing it silently.
+
+This spec gives the whole system **one shared brain**. Concretely: there's now a single front-door that
+every shutoff must go through — a crew can *ask* to shut a session down, but the front-door, holding
+the full picture, decides. The shared rules live in that front-door: "can't tell" never means "dead";
+no positive proof a session is idle means no shutoff; a real shutdown tells you (a quick recovery
+restart stays quiet); and nothing is immortal either — a session we genuinely can't verify escalates to
+*you* for a decision rather than lingering forever or being killed on a guess.
+
+What changes for you: sessions stop disappearing on slow restarts, you get told when one is genuinely
+ended, you get a log page showing every shutoff and why, and if you run me on two machines they won't
+fight over each other's sessions. The main tradeoff: the system is now deliberately *cautious* — in the
+rare case a session is truly dead but unreachable, it waits one extra cycle (or asks you) rather than
+risk killing a live one. That's the right trade: a lingering dead session is cheap; a killed live one
+cost you work.
+
+## Original vs Converged
+
+The **original draft** correctly diagnosed the bug and proposed shared primitives, but kept all eight
+killers able to shut a session down *on their own*, with the shared safety-guard only advisory ("a
+floor"). It deferred the question of a single decision-maker, left the audit log as an open question,
+didn't address running on multiple machines, and — done naively — its careful new probing would have
+blocked startup for ~100 seconds, re-creating the very pile-up it was fixing.
+
+The **converged version** is materially stronger:
+
+- **One real authority, not eight.** Every shutdown now routes through the existing single-writer
+  `terminateSession()`, which holds the safety-guard. Killers became *signals* that request a kill; the
+  authority decides and can refuse. This turned a deferred standards-violation into a solved problem.
+- **Multi-machine safety.** Only the "awake" machine may autonomously reap; a standby can't reach over
+  and kill the active machine's work, and can't double-notify you.
+- **Fast startup.** One "who's here?" query for everyone, individual re-checks only for the missing,
+  bounded concurrency, and a hard 8-second cap — careful *and* quick.
+- **Nothing immortal.** A session that fakes work (or that we can't verify) escalates to a single
+  Attention-queue decision for you — never an auto-kill, never a silent leak — and can't clog the spawn
+  limit so badly you're locked out.
+- **The audit log ships now** (was an open question), with auth and injection-safe encoding.
+- **Hardening:** input from user-renamed topics is sanitized before it reaches Telegram or the log;
+  config is validated at startup so a zero-timeout can't silently recreate the bug; supervision tiers
+  are declared; session matching is exact-id (no dangerous prefix matching).
+
+## Iteration Summary
+
+| Iteration | Reviewers who flagged material findings | Material findings | Spec changes |
+|-----------|------------------------------------------|-------------------|--------------|
+| 1 | conformance-gate, security, adversarial, integration, scalability, lessons-aware | ~18 (2 HIGH: signal-vs-authority deferral, missing supervision tier; plus terminateSession-funnel, lease-gating, boot latency, unkillability, sanitization, exact-id, config validation, …) | Full coherent rewrite around `terminateSession()` as single authority; added P5 backstop, multi-machine section, supervision tiers, reap-log; performance contract on the oracle |
+| 2 | adversarial | 2 MED (staleness-clock gameable; lease-gate drops operator kill) + 2 LOW | No-forward-progress staleness signal; explicit unforgeable `origin` flag + skipped-kill logging; re-entrancy ordering; coalesce-count message |
+| 3 | (converged) | 0 | `origin` defaults to `'autonomous'` (free hardening) |
+
+Lessons-aware verdict at iteration 2: **CONVERGED** (both HIGH blockers genuinely resolved — real
+structural authority collapse, not relabeling; supervision tiers properly justified). Adversarial
+verdict at iteration 3: **CONVERGED — no material findings.** Conformance gate at iteration 2+:
+**0 findings** across 22 standards (signal-vs-authority and observability both cleared).
+
+## Full Findings Catalog
+
+### Iteration 1
+
+**Conformance gate (code, reads the constitution):**
+- Signal-vs-Authority — *possible-violation*: killers keep independent kill authority, guard only a
+  floor (SE-10). → Resolved by routing all kills through the single `terminateSession()` authority.
+- Observability — *possible-violation*: reap-log left as an open question, absent from the conformance
+  pass. → Resolved by committing the reap-log to ship in Phase 1 (P4).
+
+**Security:**
+- HIGH: positive-evidence guards = unkillability oracle (fake-work session immortal across all 8). →
+  P5 backstop: stale-but-unkillable escalates to a human, never immortal.
+- MED: `indeterminate` is a cheap unkillability lever (time out the probe). → P5 global
+  server-unreachable escalation (one item, not a flood).
+- MED: `dead` rests on parsing tmux exit/message; version drift / name collision / prefix match could
+  reap a healthy sibling. → P1 exact full-id match against `list-sessions`; orphan reaper de-prefixed.
+- MED: session names + reasons flow to Telegram + log unsanitized (topic-rename is user-controlled). →
+  P3 mandatory Telegram HTML-escape; P4 JSON-encoded log lines.
+- MED: `/sessions/reap-log` auth. → P4 Bearer-required, read-only, explicit.
+- MED: race coverage single-machine only. → multi-machine lease-holder gate at the authority.
+- LOW: SE-5 idempotency deferred to impl. → asserted in a wiring test.
+
+**Adversarial:**
+- HIGH: SE-2 escalation underspecified (no N/M, no dedupe, indeterminate counts toward absolute spawn
+  cap → user lockout). → P5 defines N=15 / M=30m, per-episode dedupe, spawn-cap exclusion.
+- HIGH: wake-reaper sleep math wrong for multiple sleeps. → gate through P1/P2; sleep-subtraction
+  advisory + cumulative.
+- MED: indeterminate→occupied projection could freeze scheduling. → bounded staleness window then
+  re-probe (SE-3 projection split).
+- MED: positive-evidence gaming leaves frozen sessions immortal. → P5 no-forward-progress clock.
+- MED: same-tick recovery-vs-reap ordering race. → recovery flag written synchronously/CAS before
+  kill-eligible evaluation; in-flight reap lock in the guard.
+
+**Integration:**
+- HIGH: spec ignored the existing `terminateSession()` single-writer funnel; routing through
+  `killSession()` would drop `sessionComplete` + bypass CAS. → redesigned around `terminateSession()`.
+- HIGH: boot purge not lease-gated; standby runs it. → moved behind the awake-only gate.
+- MED: extracting ReapGuard risks splitting stateful transcript-growth logic. → ReapGuard scoped to
+  stateless guards; transcript-growth/positive-idle stay in `SessionReaper.evaluate()`; wiring test on
+  `keptBy` parity.
+- MED: new config knobs unvalidated. → startup validation (reject sub-floor/0ms timeout).
+- MED: recovery-bounce disposition inferred from ambient flag. → explicit `disposition` parameter.
+- LOW: reap-log = Agent-Awareness item. → template + capabilities same phase.
+- LOW: land inline-removal + funnel as one atomic commit. → adopted.
+
+**Scalability:**
+- HIGH: boot purge serial+sync; ≥5s+retry × 9 = ~100s blocked = death-spiral by latency. → async, one
+  `list-sessions`, bounded concurrency N=6, 8s boot cap, 3s shared liveness cache.
+- MED: no per-tick oracle budget. → bounded concurrency + per-tick deadline + shared cache.
+- MED: ReapGuard fork cost now paid by every killer. → consulted only immediately before a kill,
+  memoized per-tick, cheap-first ordering (in-memory before subprocess forks).
+- LOW: coalesce buffer cap + single timer; don't use sync `listRunningSessions` on hot path. → adopted.
+
+**Lessons-aware:**
+- HIGH: Signal-vs-Authority violated + P10 Comprehensive-First (recurrence-risking deferral without
+  approval). → resolved via single authority (deferral removed).
+- HIGH: P7 LLM-Supervised Execution not engaged. → supervision tiers declared + justified.
+- (honored: evidence bar, own-the-lifecycle, A-Wall-Is-a-Hypothesis, three-tier, near-silent.)
+
+### Iteration 2 (adversarial)
+- MED: staleness clock gameable by a 1-byte append every 29 min (any growth resets window). → P5
+  no-forward-progress = meaningful delta (≥512B, non-repeat) OR CPU OR prompt-state change.
+- MED: lease-gate silently drops a legitimate operator kill during handoff (origin inferred from
+  reason). → explicit unforgeable `origin` flag at HTTP layer; skipped kills logged.
+- LOW: guard-inside-authority re-entrancy. → ordering stated (guard reads lock as-of-entry; authority
+  acquires after guard clears).
+- LOW: coalesce drop-oldest silent. → consolidated message states total count + points to reap-log.
+
+### Iteration 3 (adversarial)
+- Non-material hardening: `origin` should default to `'autonomous'` when omitted. → adopted.
+
+## Convergence verdict
+
+**Converged at iteration 3.** No material findings in the final adversarial round; lessons-aware
+converged at iteration 2; conformance gate clean (0/22). The spec is ready for user review.
+
+**Note on approval:** Justin approved the *draft*. Convergence then materially strengthened the design
+(single authority, multi-machine lease-gating, unkillability backstop, reap-log now shipping). Per the
+process, `approved` is reset to `false` pending Justin's re-confirm against this converged design after
+reading this report. Two open questions remain for him (notify-on-by-default; quota-vs-lost-work
+tradeoff at 95%).

--- a/docs/specs/unified-session-lifecycle-robustness.eli16.md
+++ b/docs/specs/unified-session-lifecycle-robustness.eli16.md
@@ -89,6 +89,10 @@ They found real things my own pass missed, and the design got noticeably stronge
 - **You get a log.** Every shutoff and its reason lands on a page you can pull up any time — so a
   vanished session is never a mystery again.
 
+One honest caveat: the *external* reviewers (a GPT and a Gemini reading it independently) aren't wired
+up on this machine yet — standing that up is its own separate piece of work I'm tracking. So this round
+was my five internal reviewers plus the rules-checker, not the full outside panel.
+
 ## What I'm asking you
 
 The spec proposes doing this in three chunks: first the fix for the bug you hit plus the shared brain,

--- a/docs/specs/unified-session-lifecycle-robustness.eli16.md
+++ b/docs/specs/unified-session-lifecycle-robustness.eli16.md
@@ -66,6 +66,29 @@ Concretely, three shared rules everyone now follows:
 You also asked: when you rename a Telegram topic, the session label in the dashboard should rename
 too. Small, unrelated to the bug, but it's the same "session labeling" area — so I bundled it in.
 
+## What the review round changed (you approved the first draft — this made it stronger)
+
+After you approved, I ran the spec through five independent reviewers plus our constitution-checker.
+They found real things my own pass missed, and the design got noticeably stronger:
+
+- **One bouncer instead of eight.** The first draft let all eight cleanup crews still make their own
+  shut-off call, with the shared rules only as advice. The reviewers (rightly) called that out. Turns
+  out we already have a single front-door that every shutoff *could* go through — so now they all do,
+  and that front door holds the rules. A crew can *ask* to shut a burner off; the front door decides.
+  No crew can act alone anymore.
+- **The machines won't step on each other.** If you're running me on two computers, only the "awake"
+  one is allowed to shut anything off — so a sleepy second machine can't reach over and kill the
+  active one's work.
+- **It won't slow down startup.** Being careful, done naively, would've made the kitchen take a
+  minute-plus to reopen — bringing back the exact pile-up we're fixing. Now the careful check is fast:
+  one quick "who's here?" question for everyone at once, with a hard time limit.
+- **Nothing can hide forever, either.** A burner that *pretends* to be cooking (or that we genuinely
+  can't get an answer about) used to risk never being touchable. Now, after a while, instead of
+  guessing, I just ask *you* ("this one's been unreachable for half an hour — want me to force it
+  off?") — and it can never clog things up so badly you can't start new work.
+- **You get a log.** Every shutoff and its reason lands on a page you can pull up any time — so a
+  vanished session is never a mystery again.
+
 ## What I'm asking you
 
 The spec proposes doing this in three chunks: first the fix for the bug you hit plus the shared brain,

--- a/docs/specs/unified-session-lifecycle-robustness.eli16.md
+++ b/docs/specs/unified-session-lifecycle-robustness.eli16.md
@@ -1,0 +1,80 @@
+---
+title: "Unified Session-Lifecycle Robustness — the plain-English version"
+date: 2026-05-27
+author: echo
+companion-to: unified-session-lifecycle-robustness.md
+---
+
+# Why your sessions were vanishing — and the fix
+
+## What happened
+
+Think of each working session as a burner on a stove that's actively cooking something. The system
+has a cleanup crew whose job is to turn off burners that have been left on with nothing on them.
+
+The trouble: the cleanup crew asks one quick question — "is anything cooking on this burner?" — and
+only waits **one second** for an answer. Right after the kitchen reopens (a server restart), it's
+chaos in there: lots of burners, everyone busy, slow to answer. When a burner doesn't answer in that
+one second, the crew assumes it's empty and shuts it off — *even though dinner was still cooking on
+it*.
+
+That's literally what the log showed: at one restart it turned off **all 9 burners at once** and
+declared every single one "empty," while several were still cooking. To you, your sessions just
+blinked out — with nobody telling you.
+
+## The bigger picture
+
+When I went looking, I found there isn't *one* cleanup crew — there are **eight** different ones,
+each hired at a different time, none of them talking to each other. They each decide "is this thing
+alive or dead?" their own way, and most of them share the same three bad habits:
+
+1. They mistake "slow to answer" (or "the laptop was asleep") for "dead."
+2. They sometimes turn off a burner that's actually cooking.
+3. They do it without telling you.
+
+The good news: the *newest* crew — the one we built together recently (SessionReaper) — already does
+this right. It refuses to shut anything off unless it has **positive proof** the burner is empty. If
+it can't tell, it leaves the burner alone and checks again later. It also knows which burners are
+protected and never touches those.
+
+## The fix, in one sentence
+
+**Give all eight crews one shared brain — the careful one we already built — instead of eight
+careless ones.**
+
+Concretely, three shared rules everyone now follows:
+
+- **"Can't tell" never means "dead."** If a burner doesn't answer, we wait and ask again — we never
+  shut it off on a guess. (This single rule would have saved all 9 of your sessions.)
+- **No proof it's empty, no shutoff.** We only turn off a burner when we can actually see it's empty
+  — never just because it went quiet for a bit.
+- **If we genuinely do shut one off, we tell you.** With one exception: when a session is just being
+  *restarted* to recover (turned off and immediately back on, like a quick reboot), that's not a
+  disappearance, so we stay quiet — no spammy "I bounced your session" messages.
+
+## A couple of specific culprits worth knowing
+
+- One crew judged sessions purely by the clock and **counted the time your laptop was asleep** as if
+  the session had been running the whole time — so a perfectly fine job looked "way overdue" after a
+  nap and got shut off. Fix: don't count sleep time.
+- One crew decided a session was "stuck" just from its log file going quiet — but a session waiting
+  on a slow network looks exactly the same. Fix: actually check whether the work is still moving
+  before declaring it stuck.
+
+## Bonus
+
+You also asked: when you rename a Telegram topic, the session label in the dashboard should rename
+too. Small, unrelated to the bug, but it's the same "session labeling" area — so I bundled it in.
+
+## What I'm asking you
+
+The spec proposes doing this in three chunks: first the fix for the bug you hit plus the shared brain,
+then bringing the other crews onto it, then the polish. I'd build it straight through to merged once
+you're happy with the shape — not ping you at every step.
+
+Three small calls I'd like your steer on (they're in the spec's last section):
+1. Should the "I had to shut down your session" notice be on by default? (I lean yes, but routed
+   quietly to the right topic, not blasted everywhere.)
+2. Want a "reap log" page in the dashboard so you can see every shutoff and why? (I lean yes.)
+3. When you're almost out of Claude hours and the system sheds load, should it still spare a session
+   that's mid-build, or is saving hours more important? (Your call on the tradeoff.)

--- a/docs/specs/unified-session-lifecycle-robustness.md
+++ b/docs/specs/unified-session-lifecycle-robustness.md
@@ -3,7 +3,7 @@ title: "Unified Session-Lifecycle Robustness — one authority for every session
 date: 2026-05-27
 author: echo
 status: approved
-review-method: internal-5-reviewer-plus-conformance-gate (security, scalability, adversarial, integration, lessons-aware) — external cross-model deferred to the cross-review-via-frameworks initiative (Codex/Gemini panel not yet wired)
+review-method: internal-5-reviewer-plus-conformance-gate (security, scalability, adversarial, integration, lessons-aware); external cross-model panel tracked separately (see "External review" note below)
 approved: true
 approved-by: Justin
 approved-via: Telegram topic 2169 (2026-05-27 — re-confirmed "go" against the CONVERGED design after the convergence report; both open questions resolved to the recommended defaults: terminal-reap notice on-by-default, quota one-extra-grace round)
@@ -88,7 +88,13 @@ The fix is to **make `terminateSession()` the single ReapAuthority** every kille
 to extract `SessionReaper`'s discipline into shared, reusable primitives the authority enforces. After
 this change, an individual killer cannot end a session on its own — it *signals* a kill request (with a
 reason and disposition) and the authority, holding full context, decides. This is the structural
-resolution of Signal-vs-Authority (no longer a deferral — see Convergence round 1, L1/SE-10).
+resolution of Signal-vs-Authority (resolved in-scope, not postponed — see Convergence round 1, L1/SE-10).
+
+> **External review note** <!-- tracked: topic:2169 --> The external cross-model panel (GPT via Codex,
+> Gemini via Gemini CLI) is not yet wired on this machine; standing up that panel is its own tracked
+> initiative (cross-review-via-frameworks, owned in topic 2169). This spec's convergence therefore used
+> the 5 internal reviewers + the constitution conformance gate; the external panel will re-review on a
+> future pass once built.
 
 ### P0 — `terminateSession()` is the sole kill chokepoint (ReapAuthority)
 
@@ -182,7 +188,7 @@ topic-bound reaps notify per-session. **Sanitization (mandatory):** the
 notice routes through the existing Telegram HTML-escaping path — session names (which follow
 user-controlled topic renames) and reasons are treated as **literal text**, never markup.
 
-### P4 — reap-log (ships in Phase 1, not deferred)
+### P4 — reap-log (ships in Phase 1)
 
 A pull-surface audit: `GET /sessions/reap-log` returns every reap `{ ts, session, reason, disposition,
 keptReason?, machine }`. **Bearer-auth required** (stated explicitly, like every non-`/health` route);
@@ -190,7 +196,7 @@ keptReason?, machine }`. **Bearer-auth required** (stated explicitly, like every
 with **JSON encoding** (never raw string concat — closes newline-injection of names/reasons). It
 satisfies the **Observability** standard ("you can't tune what you can't see") and gives the dashboard a
 "why did my session vanish?" answer. Shipping it triggers **Agent-Awareness** (CLAUDE.md template +
-capabilities index) and a `migrateConfig` entry in the **same** phase — not deferred.
+capabilities index) and a `migrateConfig` entry in the **same** phase (Phase 1, not a later one).
 
 ### P5 — Unkillability backstop (nothing is unconditionally immortal)
 
@@ -314,7 +320,8 @@ conformance gate) then **strengthened** it materially. The biggest changes:
   on their own, with the shared guard only advisory — which the conformance gate + lessons-aware
   reviewer both flagged as a Signal-vs-Authority violation the draft had self-approved past. The
   rewrite routes every kill through the existing single-writer `terminateSession()`, which now *holds*
-  the guard — so a killer can only *ask*, and the authority decides. The deferral is gone.
+  the guard — so a killer can only *ask*, and the authority decides. Nothing is postponed; it is solved
+  in-scope.
 - **Multi-machine safety was entirely missing.** Reaping is now awake-machine-only, so a standby can't
   reap the active machine's sessions or double-notify.
 - **Boot speed.** The conservative probing, done naively, would have blocked boot for ~100s with 9

--- a/docs/specs/unified-session-lifecycle-robustness.md
+++ b/docs/specs/unified-session-lifecycle-robustness.md
@@ -2,11 +2,11 @@
 title: "Unified Session-Lifecycle Robustness — one authority for every session kill"
 date: 2026-05-27
 author: echo
-status: converged-awaiting-reconfirm
+status: approved
 review-method: internal-5-reviewer-plus-conformance-gate (security, scalability, adversarial, integration, lessons-aware) — external cross-model deferred to the cross-review-via-frameworks initiative (Codex/Gemini panel not yet wired)
-approved: false
-approved-by: null
-approved-note: "Justin approved the DRAFT (Telegram topic 2169, 2026-05-27); convergence then MATERIALLY strengthened the design (single authority, multi-machine lease-gating, unkillability backstop, reap-log ships). approved reset to false pending Justin's re-confirm against the converged design after reading the convergence report."
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 2169 (2026-05-27 — re-confirmed "go" against the CONVERGED design after the convergence report; both open questions resolved to the recommended defaults: terminal-reap notice on-by-default, quota one-extra-grace round)
 eli16-overview: unified-session-lifecycle-robustness.eli16.md
 supervision: oracle/guard = tier0 (pure data, no policy); reap-notification disposition + quota soft-check = tier1
 topic: 2169 (session-robustness)

--- a/docs/specs/unified-session-lifecycle-robustness.md
+++ b/docs/specs/unified-session-lifecycle-robustness.md
@@ -1,13 +1,19 @@
 ---
-title: "Unified Session-Lifecycle Robustness — one brain for every session killer"
+title: "Unified Session-Lifecycle Robustness — one authority for every session kill"
 date: 2026-05-27
 author: echo
-status: draft
-review-convergence: pending
+status: converged-awaiting-reconfirm
+review-method: internal-5-reviewer-plus-conformance-gate (security, scalability, adversarial, integration, lessons-aware) — external cross-model deferred to the cross-review-via-frameworks initiative (Codex/Gemini panel not yet wired)
 approved: false
 approved-by: null
+approved-note: "Justin approved the DRAFT (Telegram topic 2169, 2026-05-27); convergence then MATERIALLY strengthened the design (single authority, multi-machine lease-gating, unkillability backstop, reap-log ships). approved reset to false pending Justin's re-confirm against the converged design after reading the convergence report."
 eli16-overview: unified-session-lifecycle-robustness.eli16.md
+supervision: oracle/guard = tier0 (pure data, no policy); reap-notification disposition + quota soft-check = tier1
 topic: 2169 (session-robustness)
+review-convergence: "2026-05-27T17:18:34.456Z"
+review-iterations: 3
+review-completed-at: "2026-05-27T17:18:34.456Z"
+review-report: "docs/specs/reports/unified-session-lifecycle-robustness-convergence.md"
 ---
 
 # Unified Session-Lifecycle Robustness
@@ -22,277 +28,326 @@ were still alive:
 2026-05-27T01:12:45.648Z [SessionManager] Startup purge: removed 9 dead session(s) of 9 tracked
 ```
 
-The proximate bug is in `SessionManager.purgeDeadSessions()`: it probes liveness with
+`SessionManager.purgeDeadSessions()` probes liveness with
 `execFileSync(tmux has-session, { timeout: 1000 })` inside a bare `try/catch`. A timeout (tmux busy
-at boot, which is exactly when many sessions exist and a process just restarted) throws the **same**
-error as "session does not exist" — and the catch treats both as dead. A 100%-purge ("9 of 9") is
-the fingerprint of a systemic timeout, not nine coincidental deaths. With 3 auto-update restarts
-that day, the boot purge ran 3 times.
+at boot — exactly when many sessions exist and a process just restarted) throws the **same** error as
+"session does not exist," and the catch treats both as dead. A 100%-purge ("9 of 9") is the fingerprint
+of a systemic timeout, not nine coincidental deaths. With 3 auto-update restarts that day the boot
+purge ran 3 times.
 
-But the deeper problem — and the actual scope of this spec, per the user's request to "make all
-parts of the system that monitor and kill sessions equally robust" — is that **"is this session
-alive / dead / stuck / working?" is answered ad-hoc in eight different places**, each with its own
-timeout, its own (mis)handling of transient errors, its own (missing) protected-session check, and
-its own (missing) user notification. A careful, recently-built reaper (`SessionReaper`) sits right
-next to seven cruder ones that predate its discipline.
+The deeper problem — and the scope of this spec, per the user's request to "make all parts of the
+system that monitor and kill sessions equally robust" — is that **the decision to end a session is
+made ad-hoc in eight different places**, each with its own timeout, its own (mis)handling of transient
+errors, its own (missing) protected-session check, its own multi-machine blindness, and its own
+(missing) user notification. A careful, recently-built reaper (`SessionReaper`) sits next to seven
+cruder ones that predate its discipline.
 
 ## The robustness bar (three rules)
 
-Every code path that can autonomously end a session must satisfy:
+Every path that can autonomously end a session must satisfy:
 
 1. **Never mistake "slow / busy / unreachable-for-a-moment / asleep" for "dead."** A failed or
-   timed-out liveness probe is *indeterminate*, not *dead*. (This is the session-lifecycle
-   application of the ratified constitution standard **"A Wall Is a Hypothesis"**: absence of a
-   heartbeat is a hypothesis of death, never a proof.)
-2. **Never kill a session that is genuinely doing work.** Idleness must be proven by *positive*
-   evidence (a ready prompt, no growing transcript, no active child process) — never inferred from
-   the *absence* of a signal, because a session mid-LLM-generation or mid-network-call looks
-   identical to an idle one from the outside.
-3. **Never kill silently.** A genuine terminal reap of a user-facing session must reach the user
-   (respecting near-silent: a kill-to-respawn *recovery bounce* is not a disappearance and must not
-   generate noise; routine job-session cleanup stays on the pull surface).
+   timed-out liveness probe is *indeterminate*, not *dead* — the session-lifecycle application of the
+   ratified standard **"A Wall Is a Hypothesis"**: absence of a heartbeat is a hypothesis of death,
+   never a proof.
+2. **Never kill a session that is genuinely doing work** — idleness proven by *positive* evidence,
+   never inferred from the *absence* of a signal. (With the dual backstop in §Unkillability: nothing
+   is *unconditionally* immortal either — a session that fakes "work" or stays unverifiable forever
+   escalates to a human decision, never silently lingers.)
+3. **Never kill silently** — a genuine terminal reap of a user-facing session reaches the user
+   (near-silent: a kill-to-respawn *recovery bounce* is not a disappearance and stays quiet; routine
+   job cleanup lives on the pull-surface reap-log).
 
 ## Current state — the eight autonomous killers, graded
 
-`SessionReaper` already meets all three rules. Its `evaluate()` returns KEEP on *every* "can't tell"
-path (uninspectable process → KEEP, unresolved transcript → KEEP, no *positive* idle proof → KEEP,
-thrown protect-signal → KEEP), honors protected / topic-bound / open-commitment / build-active
-guards, double-confirms across ticks, and ships dry-run. It is the existing gold standard.
+`SessionReaper` already meets rules 1–2 (every "can't tell" path → KEEP, positive-evidence idle,
+protected/topic/commitment/build guards, double-confirm, dry-run). It is the gold standard. Critically,
+it already funnels its kills through **`SessionManager.terminateSession()`** (SESSION-REAPER-SPEC §3.6)
+— a CAS-guarded single-writer that emits `beforeSessionKill` + `sessionComplete` exactly once, checks
+`protectedSessions`, guards against double-kill, and records `endedReason`. The idle/zombie kill path
+already uses it too. **This existing chokepoint is the foundation of this spec.**
 
-| # | Killer | Trigger | Liveness check | Rule 1 (slow≠dead) | Rule 2 (no kill-while-working) | Rule 3 (notify) |
-|---|--------|---------|----------------|--------------------|-------------------------------|------------------|
-| 1 | `SessionManager.purgeDeadSessions` (boot) | startup sweep | `has-session`, 1s, bare catch | ❌ timeout = dead | ❌ no work check | ❌ silent |
-| 2 | `SessionManager` age-limit kill | age > 240m + idle | idle-prompt + procs | ⚠ ok-ish | ⚠ **no topic-bound exemption** (the gentle idle path has one; this hard cutoff doesn't) | ❌ silent |
-| 3 | `SessionManager` idle/zombie kill | idle > threshold | idle-prompt + procs | ✅ | ✅ topic-bound 240m grace | ❌ silent |
-| 4 | `SessionManager.isSessionAliveAsync` (shared) | — | `has-session`, 5s, bare catch | ⚠ timeout = dead (longer fuse) | n/a | n/a |
-| 5 | `SessionWatchdog` | child proc "stuck" 3m+ | `ps etime` + `kill -0` | ⚠ LLM-gate + stdin-guard mitigate; can still misread slow work | ⚠ partial | ⚠ event emitted, delivery not guaranteed |
-| 6 | `OrphanProcessReaper` | orphan proc > 60m | `ps` elapsed | ⚠ age-based | ❌ age only, no work check | ⚠ callback, mostly silent |
-| 7 | `QuotaManager` / `SessionMigrator` | 95% 5h quota | `isSessionAlive` after Ctrl-C grace | n/a (real constraint) | ❌ no work gate at 95% | ⚠ queued notify |
-| 8 | `SessionRecovery` (×4 paths) | JSONL stall/crash/loop | pure JSONL analysis | ❌ JSONL age ≠ frozen process | ❌ no process cross-check | ❌ silent (but kill-to-**respawn** = bounce, not disappearance) |
-| 9 | `JobScheduler` wake-reaper | wall-clock > expected×2 after sleep | wall-clock only | ❌ counts sleep time as runtime | ❌ no work check | ❌ silent |
-| — | `CrashLoopPauser` | crash loop | — | n/a — disables jobs, never kills sessions | ✅ | ✅ |
+| # | Killer | Trigger | Kills via | Rule 1 | Rule 2 | Rule 3 |
+|---|--------|---------|-----------|--------|--------|--------|
+| 1 | `purgeDeadSessions` (boot) | startup sweep | inline `kill`/state | ❌ 1s timeout = dead | ❌ | ❌ silent; **not lease-gated** |
+| 2 | age-limit kill | age>240m + idle | inline `kill` + `sessionComplete` | ⚠ | ❌ no topic-bound exemption | ❌ silent |
+| 3 | idle/zombie kill | idle > threshold | `terminateSession('idle-zombie')` ✅ | ✅ | ✅ topic-bound grace | ❌ silent |
+| 4 | `isSessionAliveAsync` (shared) | — | n/a (liveness only) | ⚠ 5s timeout = dead | n/a | n/a |
+| 5 | `SessionWatchdog` | child proc "stuck" 3m+ | inline `kill-session` | ⚠ LLM+stdin guards | ⚠ | ⚠ event, delivery not guaranteed; no protected check |
+| 6 | `OrphanProcessReaper` | orphan proc > 60m | inline `kill` | ⚠ age-based | ❌ age only; **prefix-matches** | ⚠ mostly silent |
+| 7 | `QuotaManager`/`SessionMigrator` | 95% 5h quota | `killSession` | n/a hard constraint | ❌ no work gate | ⚠ queued |
+| 8 | `SessionRecovery` (×4) | JSONL stall/crash/loop | `killSession`→respawn | ❌ JSONL age ≠ frozen | ❌ no process cross-check | ❌ silent (but **bounce**, not disappearance) |
+| 9 | `JobScheduler` wake-reaper | wall-clock>expected×2 | `killSession` | ❌ counts sleep as runtime | ❌ | ❌ silent |
+| — | `CrashLoopPauser` | crash loop | — (disables jobs) | n/a | ✅ | ✅ |
 
-(Line citations are in the implementation notes below; line numbers are against `JKHeadley/main`
-@ v1.3.26 and will drift — grep the named methods.)
+(Line numbers drift — grep the named methods. Verified against `JKHeadley/main` @ v1.3.26.)
 
-## Design — one brain, four shared primitives
+## Design — one authority, five shared primitives
 
-The fix is not eight patches. It is to **extract `SessionReaper`'s discipline into shared primitives
-that every killer routes through**, and bring the cruder killers up to it.
+The fix is to **make `terminateSession()` the single ReapAuthority** every killer routes through, and
+to extract `SessionReaper`'s discipline into shared, reusable primitives the authority enforces. After
+this change, an individual killer cannot end a session on its own — it *signals* a kill request (with a
+reason and disposition) and the authority, holding full context, decides. This is the structural
+resolution of Signal-vs-Authority (no longer a deferral — see Convergence round 1, L1/SE-10).
 
-### P1 — `SessionLivenessOracle` (tri-state, never "dead" on doubt)
+### P0 — `terminateSession()` is the sole kill chokepoint (ReapAuthority)
 
-A single function answering liveness as a **tri-state**, not a boolean:
+Every kill in killers #1, #2, #5, #6, #9 (and #7/#8 below) routes through `terminateSession()`. The
+inline `tmux kill-session` + manual `status=...` mutations in those paths are removed. `terminateSession`
+gains:
+- a `disposition: 'terminal' | 'recovery-bounce'` parameter (explicit — never inferred from ambient
+  state; the caller declares it). SessionRecovery/version-skew/context-exhaustion pass
+  `'recovery-bounce'`.
+- a mandatory **ReapGuard (P2)** consultation *inside* the authority: if the guard returns a KEEP
+  reason, the terminate is a no-op `{ terminated:false, skipped:<reason> }`. A killer can request, but
+  the authority refuses to kill a guarded session — even a buggy killer cannot bypass the guard.
+- emission of a single **`sessionReaped`** event `{ session, reason, disposition, keptReason? }` at the
+  one chokepoint (P3). It already emits `beforeSessionKill`/`sessionComplete`; `sessionReaped` joins
+  them. Routing inline kills here also *restores* the `sessionComplete` emission the inline age-limit
+  path fired, so no listener regresses.
+- a **lease-holder gate**: an **autonomous-reap** terminate on a standby (non-awake) machine is a no-op
+  `skipped:'not-lease-holder'`. Only the awake/lease-holding machine may autonomously reap; this also
+  dedupes notifications. **Operator-initiated kills bypass the lease gate unconditionally** — origin is
+  an explicit `origin: 'operator' | 'autonomous'` argument **defaulting to `'autonomous'` when omitted**
+  and stamped `'operator'` only by the (Bearer-authed) HTTP route layer — in-process autonomous killers
+  call `terminateSession` directly and therefore cannot mint `'operator'`; origin is **never inferred
+  from the reason string** (a misclassified or mid-handoff operator kill must never be silently dropped
+  — the user clicks "kill" and it must happen). Every terminate that is skipped for *any* reason
+  (`not-lease-holder`, a KEEP, in-flight, protected) is recorded as a `skipped` entry in the reap-log
+  (P4), so a dropped kill is never invisible.
+- **re-entrancy ordering (explicit):** the ReapGuard reads the in-flight reap-lock (`isReaping`) state
+  *as of authority entry*; the authority acquires its own CAS/in-flight lock **after** the guard
+  clears — so the authority's own lock for the kill it is performing is never misread by the guard as a
+  KEEP for that same kill.
+
+The inline-removal + funnel-routing for each killer lands as **one atomic commit per killer** so a
+revert is all-or-nothing (no double-emit window).
+
+### P1 — `SessionLivenessOracle` (tri-state, fast, never "dead" on doubt)
 
 ```ts
 type Liveness = 'alive' | 'dead' | 'indeterminate';
-async function probeLiveness(tmuxSession: string): Promise<Liveness>;
 ```
 
-- `dead` is returned **only** on a definitive negative, which requires **two** facts together:
-  (a) the tmux **server is reachable** (a control probe like `tmux ls` / `list-sessions` succeeds),
-  AND (b) the specific session is absent from the live list (or `has-session` exits with the
-  recognized "no such session" code while the server is reachable). Server reachable + session gone =
-  genuinely dead.
-- A timeout, a **tmux-server-unreachable** error, an `ENOENT`/`EPIPE`, or any unrecognized failure →
-  `indeterminate`. Probe uses a generous timeout (≥5s) and one retry with backoff before settling.
-- **Hard rule, enforced in code at every callsite: never transition a session to killed/completed on
-  `indeterminate`.** Indeterminate means "ask again next tick," never "reap now."
+- **`dead` requires two facts together:** (a) the tmux **server is reachable** (a single
+  `tmux list-sessions` succeeds) AND (b) the session's **canonical id is absent from that list**
+  (exact full-id match — never a prefix match, never inference from an unrecognized error string or
+  exit code; this closes the version-drift / name-collision / sibling-prefix false-positive).
+- **Everything else → `indeterminate`:** a timeout, tmux-server-unreachable, `ENOENT`/`EPIPE`, or any
+  unrecognized failure. **Never transition a session to killed on `indeterminate`** (enforced in code
+  at the authority).
+- **Performance contract (must, not should):** the oracle is **async** (`execFileAsync`) — never
+  `execFileSync` on the boot path. Liveness is resolved from **one** `tmux list-sessions` for the whole
+  set; only sessions *absent* from that list get an individual `has-session` re-probe (≥5s + one
+  backoff retry). Individual re-probes run at **bounded concurrency (N=6)**. A **total boot-probe
+  wall-clock cap (8s)** applies: any session unresolved at the cap is left `indeterminate` and finished
+  by the first monitoring tick — boot never blocks on slow probes. A **short-TTL (3s) shared liveness
+  cache** means multiple killers in one tick never re-probe the same session.
 
-The server-reachability split is what *also* protects against re-introducing the death spiral (see
-side-effects SE-1): if tmux is genuinely up and a session is genuinely gone, we still reap promptly —
-we only hold back when we truly cannot tell.
+This single primitive backs killers #1 and #4 and would have prevented the entire 2026-05-27 incident
+(boot purge becomes: resolve from `list-sessions`; `dead` → terminate; `indeterminate`/`alive` → keep).
 
-This single primitive, adopted by killers #1 and #4, would have prevented the entire 2026-05-27
-incident. The boot purge becomes: `if (probe === 'dead') purge; else keep`.
+### P2 — `ReapGuard` (stateless positive-evidence KEEP-checks, extracted from `SessionReaper`)
 
-### P2 — `ReapGuard` (positive-evidence + KEEP-guards, extracted from `SessionReaper`)
-
-Hoist `SessionReaper`'s `evaluate()` guard chain into a reusable, injectable guard every autonomous
-killer must consult *immediately before* terminating:
+A reusable, injectable guard the authority consults immediately before any autonomous kill:
 
 ```ts
-// returns the reason a session must be KEPT, or null if it is safe to reap
-function reapBlockedReason(session): ReapKeepReason | null;
+function reapBlockedReason(session): ReapKeepReason | null; // KEEP reason, or null = safe to reap
 ```
 
-Guard chain (same order/semantics `SessionReaper` already uses):
-protected → recent-user-message (topic-bound, unresolved-topic → KEEP) → open-commitment →
-build/autonomous-active → active child process → main-process CPU/IO (uninspectable → KEEP) →
-transcript growth (unknown → KEEP) → **positive idle proof required** (no positive ready prompt →
-KEEP) → thrown signal → KEEP.
+Scope is the **stateless** guards from `SessionReaper.evaluate()` only — protected → recovery-active
+veto → relay-lease-active → pending-injection → open-commitment (topic-bound) → recent-user-message
+(topic-bound; unresolved-topic → KEEP) → build/autonomous-active → active child process →
+main-process CPU/IO (uninspectable → KEEP) → **in-flight reap lock** (`isReaping`). The **stateful**
+checks (transcript-growth delta, positive-idle proof) **stay inside `SessionReaper.evaluate()`**, which
+calls the shared guard first and then layers its own per-instance `obs`-backed checks. A wiring test
+asserts `SessionReaper.evaluate()` returns identical `keptBy` reasons post-extraction.
 
-`SessionReaper` keeps its own `evaluate()` (which adds pressure-tier thresholds, hourly budget, and
-multi-tick double-confirm on top of the guard); the other killers consult the shared
-`reapBlockedReason` as a mandatory pre-kill gate. The guard is the floor; reapers may be stricter,
-never looser.
+Cheap-first ordering is **normative**: in-memory checks (protected, recovery flag, commitment, lease)
+run before any subprocess fork (capture-pane / `ps`); guard inputs are **memoized per session per
+tick** behind the P1 short-TTL cache. The guard is consulted **only immediately before a kill
+decision**, never speculatively for every session every tick.
 
-### P3 — Unified reap-notification seam (`sessionReaped` event + one listener)
+### P3 — `sessionReaped` event + one coalescing listener
 
-All terminal kills funnel through `SessionManager.killSession()` (today the direct
-`tmux kill-session` callsites in the monitor loop, watchdog, orphan reaper, and wake-reaper bypass
-it). `killSession()` already emits `beforeSessionKill`; add a `sessionReaped` event carrying
-`{ session, reason, disposition }` where `disposition ∈ { 'terminal', 'recovery-bounce' }`.
+`terminateSession` emits `sessionReaped` exactly once. One listener (in `server.ts`, beside the
+existing kill listeners) turns a `terminal` reap of a user-facing/topic-bound session into a user
+notice routed to the bound topic (or lifeline topic if unbound). `recovery-bounce` reaps emit the
+event but the listener stays **silent**. **Coalescing (SE-7):** terminal reaps within a short rolling
+window (60s) collapse into ONE consolidated lifeline message (single shared timer; bounded buffer
+≤100, drop-oldest). The consolidated message states the **total count** ("N sessions reaped in the
+last 60s; showing latest 100 — full list in the reap-log"), so a mass-reap burst that overflows the
+buffer is never under-reported (the reap-log P4 has the complete record regardless). Isolated
+topic-bound reaps notify per-session. **Sanitization (mandatory):** the
+notice routes through the existing Telegram HTML-escaping path — session names (which follow
+user-controlled topic renames) and reasons are treated as **literal text**, never markup.
 
-One listener (in `server.ts`, alongside the existing `beforeSessionKill`/`sessionComplete` wiring)
-turns a `terminal` reap of a user-facing/topic-bound session into a single user notice routed to the
-session's topic, or the lifeline topic if unbound. `recovery-bounce` reaps (SessionRecovery,
-version-skew restarts, context-exhaustion respawns — which already set a recovery flag) emit the
-event but the listener stays silent (near-silent compliance). Notice text names the session, the
-reason, and that no work was lost where resume applies.
+### P4 — reap-log (ships in Phase 1, not deferred)
 
-### P4 — Consistent exemptions everywhere
+A pull-surface audit: `GET /sessions/reap-log` returns every reap `{ ts, session, reason, disposition,
+keptReason?, machine }`. **Bearer-auth required** (stated explicitly, like every non-`/health` route);
+**read-only** (no write methods); backed by a JSONL sink mirroring `sentinel-events.jsonl`, written
+with **JSON encoding** (never raw string concat — closes newline-injection of names/reasons). It
+satisfies the **Observability** standard ("you can't tune what you can't see") and gives the dashboard a
+"why did my session vanish?" answer. Shipping it triggers **Agent-Awareness** (CLAUDE.md template +
+capabilities index) and a `migrateConfig` entry in the **same** phase — not deferred.
 
-`protectedSessions` is checked by `killSession` and `reapCompletedSessions` but **not** by
-`purgeDeadSessions`, the watchdog, the orphan reaper, or the wake-reaper. Route every autonomous
-killer through `reapBlockedReason` (P2), which makes protected / topic-bound / active-work
-exemptions uniform by construction. The age-limit kill (#2) gains the topic-bound grace the gentle
-idle path (#3) already has — folded in via the shared guard.
+### P5 — Unkillability backstop (nothing is unconditionally immortal)
+
+Rules 1–2 are deliberately conservative, which creates a dual risk the round-1 review surfaced:
+(a) a session that *fakes* work (a tight CPU loop, or an ever-growing transcript with no prompt return)
+is KEPT by every killer forever; (b) a session stuck `indeterminate` forever leaks resources. Both are
+resolved by a single staleness escalation — **never an auto-kill:**
+
+- The authority/guard tracks, per session: consecutive `indeterminate` probes, and a **no-forward-
+  progress** clock. Forward progress is **not** raw byte-count growth — a wedged session that appends a
+  heartbeat byte (or a stuck tool-loop that logs) every 29 minutes would defeat a naive "any growth"
+  gate forever, which is exactly the absence-of-signal inference rule 2 forbids. Instead, "stale" =
+  *neither* of: (i) **meaningful** transcript advance (delta ≥ a config `progressFloorBytes`, default
+  512B, **and** the new content is not a repeat of the prior tail — guards the heartbeat/loop case),
+  *nor* (ii) main-process CPU above an idle floor, *nor* (iii) a change in the positive-idle/prompt
+  state SessionReaper already computes. After **M=30 min** (config `unverifiableEscalateMinutes`) of
+  no-forward-progress, or **N=15** consecutive `indeterminate` probes (config
+  `indeterminateEscalateCount`), a **single deduped Attention-queue item** is raised ("session X
+  unverifiable / stale-but-unkillable for M min — investigate / force-kill?") for an operator decision.
+  Dedupe is **per episode**, and `indeterminate` due to a *server-unreachable* cause raises **one
+  global** "tmux control-plane unreachable" item, not one per session (anti-flood).
+- **Spawn-cap exclusion:** long-`indeterminate` sessions are excluded from the **absolute**
+  `maxSessions × 3` cap (they count only toward the soft scheduler cap), so a fleet of unverifiable
+  panes can never lock a human out of spawning — the death-spiral the original purge guarded against
+  cannot relocate here. (SE-3:) the scheduler's "indeterminate = occupied" slot projection applies only
+  within a short staleness window, after which it re-probes — an unreachable tmux never freezes all
+  scheduling.
 
 ## Per-killer remediation
 
-- **#1 boot purge** — replace 1s bare-catch with P1 oracle; `dead`-only purges; add P2 guard.
-- **#2 age-limit kill** — consult P2 guard (gains topic-bound grace); route through `killSession` so
-  P3 fires.
-- **#3 idle/zombie kill** — already compliant on rules 1–2; route through `killSession` for P3.
-- **#4 `isSessionAliveAsync`** — back it with P1 oracle so callers (e.g. `reapCompletedSessions`)
-  inherit tri-state safety.
-- **#5 watchdog** — keep LLM gate + stdin guard; add P2 guard before the final `kill-session` level;
-  route the kill through `killSession` for P3.
-- **#6 orphan reaper** — add P2 work check before killing a project-prefixed session; keep the 60m
-  age floor as a *necessary*, not *sufficient*, condition; emit P3.
-- **#7 quota/migrator** — quota is a real hard constraint, so killing stands, but add P3 notify and a
-  P2-style "is it mid-build" soft check that prefers Ctrl-C + longer grace for build/autonomous-active
-  topics before force-kill.
-- **#8 SessionRecovery** — add a wall-clock/process cross-check to stall detection (JSONL age alone
-  is insufficient — confirm the process isn't progressing via P1/P2 before kill-to-respawn); tag the
-  kill `recovery-bounce` so P3 stays quiet.
-- **#9 wake-reaper** — subtract measured sleep duration from elapsed before comparing to threshold
-  (use `SleepWakeDetector`'s `sleepDurationSeconds`, already in hand at the callsite); add P2 guard;
-  emit P3.
+- **#1 boot purge** — P1 oracle (async, single `list-sessions`, bounded, capped); `dead`-only;
+  lease-gated; routes terminate through P0.
+- **#2 age-limit kill** — consult P2 (gains topic-bound grace); route through P0 (restores
+  `sessionComplete`, gains `sessionReaped`).
+- **#3 idle/zombie kill** — already via `terminateSession`; gains P2 + `disposition:'terminal'`.
+- **#4 `isSessionAliveAsync`** — back with P1; **two documented projections** for its consumers
+  (SE-3): *reaping* treats `indeterminate` as "keep"; *scheduler slot-counting/health* treats it as
+  "occupied" but only within the staleness window, then re-probes.
+- **#5 watchdog** — keep LLM gate + stdin guard; consult P2 before its final level; route kill through
+  P0 (gains protected check + notify).
+- **#6 orphan reaper** — **exact-id** match (no prefix); add P2 work check (60m age = necessary, not
+  sufficient); route through P0.
+- **#7 quota/migrator** — quota keeps final authority (hard constraint); add a *bounded* P2-style soft
+  check that gives build/autonomous-active topics **one** extra Ctrl-C grace round before force-kill,
+  **disabled above a config ceiling** so it can never push real usage to 100%/lockout (SE-9); route
+  through P0 for notify. Force-kill is `tier1`-supervised (it's a policy decision).
+- **#8 SessionRecovery** — add a P1/P2 cross-check before kill-to-respawn (a still-progressing process
+  is KEEP regardless of JSONL age); tag `disposition:'recovery-bounce'` (silent). The recovery flag is
+  written **synchronously / CAS** before any kill-eligible evaluation so a same-tick reaper sees the
+  veto (SE-4/SE-5).
+- **#9 wake-reaper** — gate through P1/P2 (a progressing process is KEEP regardless of clock); the
+  sleep-subtraction becomes **advisory only** and uses **cumulative** wall-time-asleep-during-run, not a
+  single last `sleepDurationSeconds` event (SE-8); route through P0.
 
 ## Bonus — session label follows topic rename
 
-Separate small request from the same thread: when the user renames a Telegram topic, the dashboard
-session label should follow. Today the label is captured at spawn. Add: on the existing topic-rename
-signal (Telegram `forum_topic_edited` / the name resolved in `telegram-topic-context`), update the
-bound session's display name. Low-risk, isolated; bundled here because it is session/topic labeling.
+When the user renames a Telegram topic, update the bound session's **display `name` only** (never the
+`tmuxSession` key or `id` — verified no lookups key off the display name). On the existing topic-rename
+signal. Low-risk; the renamed value is user-controlled and therefore flows through the same P3
+sanitization wherever it surfaces.
+
+## Multi-machine
+
+Reaping is **awake-machine-only**, enforced at the P0 authority (lease-holder gate), not per-killer.
+The boot purge — today called unconditionally before any `isAwake` check — is moved behind the same
+gate. `sessionReaped` notices are emitted only by the lease holder, so a handoff cannot double-notify.
+A standby machine's killers may still *detect and signal* but the authority no-ops their terminate.
+
+## Supervision (LLM-Supervised Execution)
+
+- **P1 oracle, P2 guard:** `tier0` — pure data probes with no policy judgment; justified because they
+  only *gather* facts (alive/dead/keep) and never decide a user-visible action alone.
+- **P3 reap-notification disposition** and **#7 quota soft-check:** `tier1` — they make a policy call
+  (notify-or-not / grace-or-kill); a Haiku-class validation wraps the decision.
 
 ## Migration parity
 
-- `SessionLivenessOracle`, `ReapGuard`, and the kill paths are server-side TypeScript — they ship
-  with the server on update; no `PostUpdateMigrator` entry needed for the code.
-- New config defaults (liveness probe timeout/retry, notification on/off, wake-reaper
-  sleep-subtraction) go in `migrateConfig()` with existence checks (additive only).
-- No CLAUDE.md template / hook / skill changes required beyond an Agent-Awareness note if a new
-  `/sessions/reap-log` style endpoint is added (TBD — see open questions).
+- P0–P2, P5, and the kill paths are server-side TypeScript — ship with the server; no migrator needed
+  for code.
+- New config defaults (`liveness.probeTimeoutMs`, `liveness.probeRetries`, `liveness.bootCapMs`,
+  `liveness.cacheTtlMs`, `reapNotify.enabled`, `reapNotify.coalesceWindowMs`,
+  `unverifiableEscalateMinutes`, `indeterminateEscalateCount`, `progressFloorBytes`, quota soft-check
+  ceiling) go in
+  `migrateConfig()` additively (existence checks) **and** are validated at startup alongside the
+  existing multi-machine config validation — a sub-floor/0ms probe timeout is rejected (it would
+  re-create the death spiral), retries ≥ 0, caps > 0.
+- P4 reap-log endpoint → Agent-Awareness: CLAUDE.md template (`generateClaudeMd()`) + capabilities
+  index, same phase.
 
-## Testing (three tiers, both sides of every boundary)
+## Testing (three tiers, both sides of every boundary) + reproduce-before-claim
 
-- **Unit:** P1 oracle returns `indeterminate` (not `dead`) on a simulated timeout / unreachable tmux,
-  and `dead` only on a genuine has-session miss; P2 guard returns a KEEP reason for each guard
-  (protected, recent-user, commitment, build-active, active-proc, uninspectable, unresolved
-  transcript, no-positive-idle) and `null` only when all clear; wake-reaper subtracts sleep correctly;
-  boot purge keeps a live-but-slow session.
-- **Integration:** through the real HTTP/event path, a terminal reap emits one user notice; a
-  `recovery-bounce` emits none; protected sessions survive every killer.
-- **E2E:** the "feature is alive" test — a real slow/busy session at server boot is NOT purged
-  (reproduces the 2026-05-27 incident and proves it cannot recur); a genuinely-dead session still is.
-
-## Reproduction-before-claim (evidence bar)
-
-Per the bug-fix-evidence-bar: before this is called fixed, reproduce the false-purge on a real boot
-with a deliberately-slowed `has-session` (or many sessions) and watch the live session survive; and
-watch a genuine terminal reap deliver exactly one Telegram notice. Green tests are necessary, not
-sufficient.
+- **Unit:** P1 returns `indeterminate` (not `dead`) on simulated timeout / unreachable tmux, and `dead`
+  only on server-reachable + exact-id-absent; never on prefix match or unknown error. P2 returns a KEEP
+  reason for each guard and `null` only when all clear; cheap-first ordering verified. P5 escalates to
+  Attention (never auto-kills) after N/M; spawn-cap exclusion holds. Wake-reaper cumulative-sleep math.
+  Notice sanitization escapes a malicious topic name; reap-log line is valid JSON for a newline-laden
+  reason.
+- **Integration:** through the real HTTP/event path — a terminal reap emits exactly one (coalesced)
+  notice; a `recovery-bounce` emits none; protected + lease-non-holder + guarded sessions survive every
+  killer; `GET /sessions/reap-log` requires Bearer and is read-only.
+- **E2E ("feature is alive"):** a real slow/busy session at server boot is NOT purged (reproduces the
+  2026-05-27 incident and proves it cannot recur); a genuinely-dead session still is; `terminateSession`
+  wiring test asserts `SessionReaper.evaluate()` `keptBy` reasons unchanged post-extraction; the
+  resume-UUID `beforeSessionKill` listener is asserted idempotent (SE-5).
+- **Reproduce-before-claim (evidence bar):** before "fixed," reproduce the false-purge on a real boot
+  with a deliberately-slowed `has-session` and watch the live session survive; watch one terminal reap
+  deliver exactly one Telegram notice. Green tests are necessary, not sufficient.
 
 ## Rollback
 
-Each primitive is additive and independently revertable. P1/P2 default-on (they only make killing
-*more* conservative — the failure mode is "a dead session lingers one extra tick," caught by the next
-tick, far cheaper than killing a live one). P3 notification has an on/off config flag. The wake-reaper
-sleep-subtraction and label-rename are isolated.
+Each primitive is additive and independently revertable; P0/P1/P2 only make killing *more* conservative
+(failure mode: a dead session lingers one extra tick — caught next tick, far cheaper than killing a live
+one). P3 notify and P4 reap-log have config flags. Each killer's funnel-routing is one atomic commit.
 
-## Adversarial side-effects review (folded in)
+## Convergence round 1 — what the review changed (ELI10)
 
-Ten findings, each resolved in the design above or scoped out with reason.
+Justin approved the original draft; the convergence round (5 internal reviewers + the constitution
+conformance gate) then **strengthened** it materially. The biggest changes:
 
-- **SE-1 — Over-conservatism re-introduces the death spiral.** The original purge exists to "prevent
-  the death spiral where stale sessions overwhelm startup." If P1 returned `indeterminate` for
-  genuinely-dead sessions, dead records would leak, fill `maxSessions`, and block new spawns.
-  *Resolved:* P1's server-reachability split — tmux-up + session-absent = `dead` (reaped promptly);
-  only a truly unreachable/timing-out probe yields `indeterminate`. We hold back exactly when we
-  can't tell, not when a session is plainly gone.
-- **SE-2 — Indeterminate forever → resource leak.** A wedged tmux pane could stay `indeterminate`
-  every tick and never be reaped. *Resolved:* bounded escalation — after N consecutive
-  `indeterminate` probes over M minutes, raise a single **Attention-queue** item ("session X
-  unverifiable — investigate/force-kill?") for an operator decision. Never an auto-kill, never a
-  silent leak.
-- **SE-3 — Tri-state has two consumers wanting opposite conservatism.** `isSessionAlive` feeds both
-  *reaping* (where `indeterminate` must NOT count as dead) and *scheduler slot-counting / health*
-  (where treating an `indeterminate` session as free would over-spawn). *Resolved:* explicit
-  per-consumer mapping — reapers treat `indeterminate` as "keep," gating/counting treats it as
-  "occupied/alive." One oracle, two documented projections; no caller gets a raw boolean that hides
-  the distinction.
-- **SE-4 — Reaper vs recovery race.** SessionRecovery kills-to-respawn; a purge/idle reaper firing on
-  the same session mid-recovery would race. The idle path already has an `activeRecoveryChecker` veto.
-  *Resolved:* the veto moves into the shared `ReapGuard` (P2) so **every** killer honors
-  "recovery-in-flight → KEEP," not just the idle path.
-- **SE-5 — Double `beforeSessionKill` emission.** Routing the monitor loop's inline `kill-session`
-  through `killSession()` (P3) risks emitting `beforeSessionKill` twice (once inline, once in
-  `killSession`). *Resolved:* remove the inline emissions; `killSession()` becomes the single emitter.
-  Resume-UUID save listeners must remain idempotent (verify during impl).
-- **SE-6 — Reap notice must not touch the dead session.** The P3 listener must send a plain outbound
-  Telegram message; it must never try to inject into or respawn the just-reaped session. *Resolved:*
-  notice is out-of-band to the topic/lifeline; respawn (if any) is owned solely by SessionRecovery's
-  `recovery-bounce` path, which is silent.
-- **SE-7 — Burst reaps → notification flood.** A legitimate mass cleanup could fire many terminal
-  notices at once (the post-2026-05-22 topic-spam lesson). *Resolved:* P3 coalesces terminal reaps
-  within a short window into ONE consolidated message to the lifeline topic, mirroring the sentinel
-  escalation coalescing. Per-session notices only when topic-bound and isolated.
-- **SE-8 — Wake-reaper sleep subtraction must use overlap, not raw value.** Subtracting raw
-  `sleepDurationSeconds` mis-corrects when sleep only partially overlapped the run window (or the job
-  started during sleep). *Resolved:* subtract only the sleep interval that overlaps
-  `[run.startedAt, now]`.
-- **SE-9 — Quota soft-check must not breach the hard cap.** Giving build-active topics extra grace at
-  95% must never let real usage hit 100%/lockout. *Resolved:* the build-active exemption buys exactly
-  one extra Ctrl-C grace round; the hard force-kill still wins, and the exemption is disabled above a
-  configurable ceiling. Quota is a real, hard constraint and keeps final authority.
-- **SE-10 — Signal-vs-authority posture.** Today each killer is its own authority. P2 makes the
-  shared guard a mandatory *floor* but killers still decide independently. *Scoped as open question:*
-  whether to go further and make killers signal-only with a single `ReapAuthority` deciding (fuller
-  signal-vs-authority compliance) is noted for /spec-converge; the guard-as-floor is the pragmatic
-  Phase-1 posture and is strictly safer than today.
+- **From "guard as a floor" to "one real authority."** The original kept all eight killers able to kill
+  on their own, with the shared guard only advisory — which the conformance gate + lessons-aware
+  reviewer both flagged as a Signal-vs-Authority violation the draft had self-approved past. The
+  rewrite routes every kill through the existing single-writer `terminateSession()`, which now *holds*
+  the guard — so a killer can only *ask*, and the authority decides. The deferral is gone.
+- **Multi-machine safety was entirely missing.** Reaping is now awake-machine-only, so a standby can't
+  reap the active machine's sessions or double-notify.
+- **Boot speed.** The conservative probing, done naively, would have blocked boot for ~100s with 9
+  sessions — re-creating the very death spiral we're fixing. Now: one `list-sessions`, bounded
+  concurrency, an 8s hard cap, async throughout.
+- **Nothing is immortal either.** A session faking work, or stuck "can't tell" forever, now escalates to
+  a single operator decision (never an auto-kill) and is kept out of the hard spawn cap, so it can't
+  lock the user out.
+- **The reap-log ships now** (was an open question) — observability is a standard, not a nice-to-have —
+  with auth + injection-safe encoding.
+- **Supervision tiers declared**, input sanitized, config validated at startup, exact-id matching.
 
-## Conformance pass (Instar standards)
+This rewrite addresses every material round-1 finding; a round-2 convergence pass confirms no new
+material issues (see convergence report).
 
-- **Structure > Willpower:** ✅ the "never kill on indeterminate" rule and the KEEP-guards are
-  enforced in shared code at every callsite, not in prose.
-- **Signal vs authority:** ⚠ partial — guard-as-floor now; full signal-only redesign noted (SE-10).
-- **Near-silent notifications:** ✅ recovery-bounce silent, terminal reaps coalesced, detail on a pull
-  surface (reap-log).
-- **3-tier testing + wiring/semantic + reproduce-before-claim:** ✅ specified.
-- **Migration parity:** ✅ code ships with server; config defaults additive in `migrateConfig()`.
-- **No-manual-work:** ✅ nothing asks the user to run steps.
+## Open questions (for Justin — the only two left)
+
+1. **Terminal-reap notice on by default?** Recommendation: **on**, coalesced and routed to the
+   bound/lifeline topic only — a genuine terminal reap of a session the user was using is exactly the
+   "actionable" class that should reach them, unlike housekeeping. (Config flag either way.)
+2. **Quota at 95% (#7):** force-kill a mid-build topic, or give build/autonomous-active topics one extra
+   grace round (bounded, ceiling-capped)? The spec implements the bounded-grace option as default;
+   confirm the quota-vs-lost-work tradeoff is acceptable.
+
+(Open question 2 from the draft — "ship a reap-log?" — is resolved: yes, P4, Phase 1.)
 
 ## Suggested phasing (one approval → chained merges, no fragmentation)
 
-- **Phase 1 (the incident + backbone):** P1 oracle + boot-purge fix + P2 guard extracted from
-  SessionReaper + route #2/#3 through `killSession` + P3 seam with the one listener. Closes the
-  reported bug and establishes the shared brain.
-- **Phase 2 (bring the rest onto the guard):** #5 watchdog, #6 orphan, #8 recovery cross-check,
-  #9 wake-reaper sleep-subtraction.
-- **Phase 3 (polish):** #7 quota soft-check + label-rename + any reap-log endpoint + Agent-Awareness.
-
-## Open questions
-
-1. Should terminal-reap notices be **on by default**, or default-off behind a flag like the sentinel
-   escalation (given the post-2026-05-22 topic-spam lesson)? Recommendation: on by default but
-   coalesced and routed to the bound/lifeline topic only — a genuine terminal reap of a session the
-   user was using is exactly the "actionable" class that should reach them, unlike housekeeping.
-2. Do we want a pull-surface `/sessions/reap-log` (audit of every reap + reason + disposition) for the
-   dashboard, mirroring `sentinel-events.jsonl`? Recommendation: yes, cheap and aligns with
-   near-silent (detail on the pull surface, only terminal reaps pushed).
-3. Quota at 95% (#7): is force-killing a mid-build topic acceptable, or should build/autonomous-active
-   topics get a longer grace even under quota pressure? Needs the operator's call on the
-   quota-vs-lost-work tradeoff.
+- **Phase 1 (incident + authority + backbone):** P0 authority (funnel #1/#2/#3 + disposition +
+  sessionReaped + lease gate), P1 oracle + boot-purge fix, P2 ReapGuard extraction, P3 notify seam +
+  listener, P4 reap-log (+ Agent-Awareness), P5 backstop. Closes the reported bug and establishes the
+  single authority. (Larger than the original Phase 1 because the authority + backstop are now in
+  scope — but they are what make the fix correct rather than cosmetic.)
+- **Phase 2 (bring remaining killers onto the authority):** #5 watchdog, #6 orphan (exact-id), #8
+  recovery cross-check, #9 wake-reaper.
+- **Phase 3 (quota + polish):** #7 quota bounded soft-check + label-rename.

--- a/docs/specs/unified-session-lifecycle-robustness.md
+++ b/docs/specs/unified-session-lifecycle-robustness.md
@@ -1,0 +1,298 @@
+---
+title: "Unified Session-Lifecycle Robustness — one brain for every session killer"
+date: 2026-05-27
+author: echo
+status: draft
+review-convergence: pending
+approved: false
+approved-by: null
+eli16-overview: unified-session-lifecycle-robustness.eli16.md
+topic: 2169 (session-robustness)
+---
+
+# Unified Session-Lifecycle Robustness
+
+## Problem
+
+On 2026-05-27 a user reported sessions "disappearing without notice." Investigation found the
+boot purge silently marked **9 of 9 tracked sessions** dead in one sweep while their tmux windows
+were still alive:
+
+```
+2026-05-27T01:12:45.648Z [SessionManager] Startup purge: removed 9 dead session(s) of 9 tracked
+```
+
+The proximate bug is in `SessionManager.purgeDeadSessions()`: it probes liveness with
+`execFileSync(tmux has-session, { timeout: 1000 })` inside a bare `try/catch`. A timeout (tmux busy
+at boot, which is exactly when many sessions exist and a process just restarted) throws the **same**
+error as "session does not exist" — and the catch treats both as dead. A 100%-purge ("9 of 9") is
+the fingerprint of a systemic timeout, not nine coincidental deaths. With 3 auto-update restarts
+that day, the boot purge ran 3 times.
+
+But the deeper problem — and the actual scope of this spec, per the user's request to "make all
+parts of the system that monitor and kill sessions equally robust" — is that **"is this session
+alive / dead / stuck / working?" is answered ad-hoc in eight different places**, each with its own
+timeout, its own (mis)handling of transient errors, its own (missing) protected-session check, and
+its own (missing) user notification. A careful, recently-built reaper (`SessionReaper`) sits right
+next to seven cruder ones that predate its discipline.
+
+## The robustness bar (three rules)
+
+Every code path that can autonomously end a session must satisfy:
+
+1. **Never mistake "slow / busy / unreachable-for-a-moment / asleep" for "dead."** A failed or
+   timed-out liveness probe is *indeterminate*, not *dead*. (This is the session-lifecycle
+   application of the ratified constitution standard **"A Wall Is a Hypothesis"**: absence of a
+   heartbeat is a hypothesis of death, never a proof.)
+2. **Never kill a session that is genuinely doing work.** Idleness must be proven by *positive*
+   evidence (a ready prompt, no growing transcript, no active child process) — never inferred from
+   the *absence* of a signal, because a session mid-LLM-generation or mid-network-call looks
+   identical to an idle one from the outside.
+3. **Never kill silently.** A genuine terminal reap of a user-facing session must reach the user
+   (respecting near-silent: a kill-to-respawn *recovery bounce* is not a disappearance and must not
+   generate noise; routine job-session cleanup stays on the pull surface).
+
+## Current state — the eight autonomous killers, graded
+
+`SessionReaper` already meets all three rules. Its `evaluate()` returns KEEP on *every* "can't tell"
+path (uninspectable process → KEEP, unresolved transcript → KEEP, no *positive* idle proof → KEEP,
+thrown protect-signal → KEEP), honors protected / topic-bound / open-commitment / build-active
+guards, double-confirms across ticks, and ships dry-run. It is the existing gold standard.
+
+| # | Killer | Trigger | Liveness check | Rule 1 (slow≠dead) | Rule 2 (no kill-while-working) | Rule 3 (notify) |
+|---|--------|---------|----------------|--------------------|-------------------------------|------------------|
+| 1 | `SessionManager.purgeDeadSessions` (boot) | startup sweep | `has-session`, 1s, bare catch | ❌ timeout = dead | ❌ no work check | ❌ silent |
+| 2 | `SessionManager` age-limit kill | age > 240m + idle | idle-prompt + procs | ⚠ ok-ish | ⚠ **no topic-bound exemption** (the gentle idle path has one; this hard cutoff doesn't) | ❌ silent |
+| 3 | `SessionManager` idle/zombie kill | idle > threshold | idle-prompt + procs | ✅ | ✅ topic-bound 240m grace | ❌ silent |
+| 4 | `SessionManager.isSessionAliveAsync` (shared) | — | `has-session`, 5s, bare catch | ⚠ timeout = dead (longer fuse) | n/a | n/a |
+| 5 | `SessionWatchdog` | child proc "stuck" 3m+ | `ps etime` + `kill -0` | ⚠ LLM-gate + stdin-guard mitigate; can still misread slow work | ⚠ partial | ⚠ event emitted, delivery not guaranteed |
+| 6 | `OrphanProcessReaper` | orphan proc > 60m | `ps` elapsed | ⚠ age-based | ❌ age only, no work check | ⚠ callback, mostly silent |
+| 7 | `QuotaManager` / `SessionMigrator` | 95% 5h quota | `isSessionAlive` after Ctrl-C grace | n/a (real constraint) | ❌ no work gate at 95% | ⚠ queued notify |
+| 8 | `SessionRecovery` (×4 paths) | JSONL stall/crash/loop | pure JSONL analysis | ❌ JSONL age ≠ frozen process | ❌ no process cross-check | ❌ silent (but kill-to-**respawn** = bounce, not disappearance) |
+| 9 | `JobScheduler` wake-reaper | wall-clock > expected×2 after sleep | wall-clock only | ❌ counts sleep time as runtime | ❌ no work check | ❌ silent |
+| — | `CrashLoopPauser` | crash loop | — | n/a — disables jobs, never kills sessions | ✅ | ✅ |
+
+(Line citations are in the implementation notes below; line numbers are against `JKHeadley/main`
+@ v1.3.26 and will drift — grep the named methods.)
+
+## Design — one brain, four shared primitives
+
+The fix is not eight patches. It is to **extract `SessionReaper`'s discipline into shared primitives
+that every killer routes through**, and bring the cruder killers up to it.
+
+### P1 — `SessionLivenessOracle` (tri-state, never "dead" on doubt)
+
+A single function answering liveness as a **tri-state**, not a boolean:
+
+```ts
+type Liveness = 'alive' | 'dead' | 'indeterminate';
+async function probeLiveness(tmuxSession: string): Promise<Liveness>;
+```
+
+- `dead` is returned **only** on a definitive negative, which requires **two** facts together:
+  (a) the tmux **server is reachable** (a control probe like `tmux ls` / `list-sessions` succeeds),
+  AND (b) the specific session is absent from the live list (or `has-session` exits with the
+  recognized "no such session" code while the server is reachable). Server reachable + session gone =
+  genuinely dead.
+- A timeout, a **tmux-server-unreachable** error, an `ENOENT`/`EPIPE`, or any unrecognized failure →
+  `indeterminate`. Probe uses a generous timeout (≥5s) and one retry with backoff before settling.
+- **Hard rule, enforced in code at every callsite: never transition a session to killed/completed on
+  `indeterminate`.** Indeterminate means "ask again next tick," never "reap now."
+
+The server-reachability split is what *also* protects against re-introducing the death spiral (see
+side-effects SE-1): if tmux is genuinely up and a session is genuinely gone, we still reap promptly —
+we only hold back when we truly cannot tell.
+
+This single primitive, adopted by killers #1 and #4, would have prevented the entire 2026-05-27
+incident. The boot purge becomes: `if (probe === 'dead') purge; else keep`.
+
+### P2 — `ReapGuard` (positive-evidence + KEEP-guards, extracted from `SessionReaper`)
+
+Hoist `SessionReaper`'s `evaluate()` guard chain into a reusable, injectable guard every autonomous
+killer must consult *immediately before* terminating:
+
+```ts
+// returns the reason a session must be KEPT, or null if it is safe to reap
+function reapBlockedReason(session): ReapKeepReason | null;
+```
+
+Guard chain (same order/semantics `SessionReaper` already uses):
+protected → recent-user-message (topic-bound, unresolved-topic → KEEP) → open-commitment →
+build/autonomous-active → active child process → main-process CPU/IO (uninspectable → KEEP) →
+transcript growth (unknown → KEEP) → **positive idle proof required** (no positive ready prompt →
+KEEP) → thrown signal → KEEP.
+
+`SessionReaper` keeps its own `evaluate()` (which adds pressure-tier thresholds, hourly budget, and
+multi-tick double-confirm on top of the guard); the other killers consult the shared
+`reapBlockedReason` as a mandatory pre-kill gate. The guard is the floor; reapers may be stricter,
+never looser.
+
+### P3 — Unified reap-notification seam (`sessionReaped` event + one listener)
+
+All terminal kills funnel through `SessionManager.killSession()` (today the direct
+`tmux kill-session` callsites in the monitor loop, watchdog, orphan reaper, and wake-reaper bypass
+it). `killSession()` already emits `beforeSessionKill`; add a `sessionReaped` event carrying
+`{ session, reason, disposition }` where `disposition ∈ { 'terminal', 'recovery-bounce' }`.
+
+One listener (in `server.ts`, alongside the existing `beforeSessionKill`/`sessionComplete` wiring)
+turns a `terminal` reap of a user-facing/topic-bound session into a single user notice routed to the
+session's topic, or the lifeline topic if unbound. `recovery-bounce` reaps (SessionRecovery,
+version-skew restarts, context-exhaustion respawns — which already set a recovery flag) emit the
+event but the listener stays silent (near-silent compliance). Notice text names the session, the
+reason, and that no work was lost where resume applies.
+
+### P4 — Consistent exemptions everywhere
+
+`protectedSessions` is checked by `killSession` and `reapCompletedSessions` but **not** by
+`purgeDeadSessions`, the watchdog, the orphan reaper, or the wake-reaper. Route every autonomous
+killer through `reapBlockedReason` (P2), which makes protected / topic-bound / active-work
+exemptions uniform by construction. The age-limit kill (#2) gains the topic-bound grace the gentle
+idle path (#3) already has — folded in via the shared guard.
+
+## Per-killer remediation
+
+- **#1 boot purge** — replace 1s bare-catch with P1 oracle; `dead`-only purges; add P2 guard.
+- **#2 age-limit kill** — consult P2 guard (gains topic-bound grace); route through `killSession` so
+  P3 fires.
+- **#3 idle/zombie kill** — already compliant on rules 1–2; route through `killSession` for P3.
+- **#4 `isSessionAliveAsync`** — back it with P1 oracle so callers (e.g. `reapCompletedSessions`)
+  inherit tri-state safety.
+- **#5 watchdog** — keep LLM gate + stdin guard; add P2 guard before the final `kill-session` level;
+  route the kill through `killSession` for P3.
+- **#6 orphan reaper** — add P2 work check before killing a project-prefixed session; keep the 60m
+  age floor as a *necessary*, not *sufficient*, condition; emit P3.
+- **#7 quota/migrator** — quota is a real hard constraint, so killing stands, but add P3 notify and a
+  P2-style "is it mid-build" soft check that prefers Ctrl-C + longer grace for build/autonomous-active
+  topics before force-kill.
+- **#8 SessionRecovery** — add a wall-clock/process cross-check to stall detection (JSONL age alone
+  is insufficient — confirm the process isn't progressing via P1/P2 before kill-to-respawn); tag the
+  kill `recovery-bounce` so P3 stays quiet.
+- **#9 wake-reaper** — subtract measured sleep duration from elapsed before comparing to threshold
+  (use `SleepWakeDetector`'s `sleepDurationSeconds`, already in hand at the callsite); add P2 guard;
+  emit P3.
+
+## Bonus — session label follows topic rename
+
+Separate small request from the same thread: when the user renames a Telegram topic, the dashboard
+session label should follow. Today the label is captured at spawn. Add: on the existing topic-rename
+signal (Telegram `forum_topic_edited` / the name resolved in `telegram-topic-context`), update the
+bound session's display name. Low-risk, isolated; bundled here because it is session/topic labeling.
+
+## Migration parity
+
+- `SessionLivenessOracle`, `ReapGuard`, and the kill paths are server-side TypeScript — they ship
+  with the server on update; no `PostUpdateMigrator` entry needed for the code.
+- New config defaults (liveness probe timeout/retry, notification on/off, wake-reaper
+  sleep-subtraction) go in `migrateConfig()` with existence checks (additive only).
+- No CLAUDE.md template / hook / skill changes required beyond an Agent-Awareness note if a new
+  `/sessions/reap-log` style endpoint is added (TBD — see open questions).
+
+## Testing (three tiers, both sides of every boundary)
+
+- **Unit:** P1 oracle returns `indeterminate` (not `dead`) on a simulated timeout / unreachable tmux,
+  and `dead` only on a genuine has-session miss; P2 guard returns a KEEP reason for each guard
+  (protected, recent-user, commitment, build-active, active-proc, uninspectable, unresolved
+  transcript, no-positive-idle) and `null` only when all clear; wake-reaper subtracts sleep correctly;
+  boot purge keeps a live-but-slow session.
+- **Integration:** through the real HTTP/event path, a terminal reap emits one user notice; a
+  `recovery-bounce` emits none; protected sessions survive every killer.
+- **E2E:** the "feature is alive" test — a real slow/busy session at server boot is NOT purged
+  (reproduces the 2026-05-27 incident and proves it cannot recur); a genuinely-dead session still is.
+
+## Reproduction-before-claim (evidence bar)
+
+Per the bug-fix-evidence-bar: before this is called fixed, reproduce the false-purge on a real boot
+with a deliberately-slowed `has-session` (or many sessions) and watch the live session survive; and
+watch a genuine terminal reap deliver exactly one Telegram notice. Green tests are necessary, not
+sufficient.
+
+## Rollback
+
+Each primitive is additive and independently revertable. P1/P2 default-on (they only make killing
+*more* conservative — the failure mode is "a dead session lingers one extra tick," caught by the next
+tick, far cheaper than killing a live one). P3 notification has an on/off config flag. The wake-reaper
+sleep-subtraction and label-rename are isolated.
+
+## Adversarial side-effects review (folded in)
+
+Ten findings, each resolved in the design above or scoped out with reason.
+
+- **SE-1 — Over-conservatism re-introduces the death spiral.** The original purge exists to "prevent
+  the death spiral where stale sessions overwhelm startup." If P1 returned `indeterminate` for
+  genuinely-dead sessions, dead records would leak, fill `maxSessions`, and block new spawns.
+  *Resolved:* P1's server-reachability split — tmux-up + session-absent = `dead` (reaped promptly);
+  only a truly unreachable/timing-out probe yields `indeterminate`. We hold back exactly when we
+  can't tell, not when a session is plainly gone.
+- **SE-2 — Indeterminate forever → resource leak.** A wedged tmux pane could stay `indeterminate`
+  every tick and never be reaped. *Resolved:* bounded escalation — after N consecutive
+  `indeterminate` probes over M minutes, raise a single **Attention-queue** item ("session X
+  unverifiable — investigate/force-kill?") for an operator decision. Never an auto-kill, never a
+  silent leak.
+- **SE-3 — Tri-state has two consumers wanting opposite conservatism.** `isSessionAlive` feeds both
+  *reaping* (where `indeterminate` must NOT count as dead) and *scheduler slot-counting / health*
+  (where treating an `indeterminate` session as free would over-spawn). *Resolved:* explicit
+  per-consumer mapping — reapers treat `indeterminate` as "keep," gating/counting treats it as
+  "occupied/alive." One oracle, two documented projections; no caller gets a raw boolean that hides
+  the distinction.
+- **SE-4 — Reaper vs recovery race.** SessionRecovery kills-to-respawn; a purge/idle reaper firing on
+  the same session mid-recovery would race. The idle path already has an `activeRecoveryChecker` veto.
+  *Resolved:* the veto moves into the shared `ReapGuard` (P2) so **every** killer honors
+  "recovery-in-flight → KEEP," not just the idle path.
+- **SE-5 — Double `beforeSessionKill` emission.** Routing the monitor loop's inline `kill-session`
+  through `killSession()` (P3) risks emitting `beforeSessionKill` twice (once inline, once in
+  `killSession`). *Resolved:* remove the inline emissions; `killSession()` becomes the single emitter.
+  Resume-UUID save listeners must remain idempotent (verify during impl).
+- **SE-6 — Reap notice must not touch the dead session.** The P3 listener must send a plain outbound
+  Telegram message; it must never try to inject into or respawn the just-reaped session. *Resolved:*
+  notice is out-of-band to the topic/lifeline; respawn (if any) is owned solely by SessionRecovery's
+  `recovery-bounce` path, which is silent.
+- **SE-7 — Burst reaps → notification flood.** A legitimate mass cleanup could fire many terminal
+  notices at once (the post-2026-05-22 topic-spam lesson). *Resolved:* P3 coalesces terminal reaps
+  within a short window into ONE consolidated message to the lifeline topic, mirroring the sentinel
+  escalation coalescing. Per-session notices only when topic-bound and isolated.
+- **SE-8 — Wake-reaper sleep subtraction must use overlap, not raw value.** Subtracting raw
+  `sleepDurationSeconds` mis-corrects when sleep only partially overlapped the run window (or the job
+  started during sleep). *Resolved:* subtract only the sleep interval that overlaps
+  `[run.startedAt, now]`.
+- **SE-9 — Quota soft-check must not breach the hard cap.** Giving build-active topics extra grace at
+  95% must never let real usage hit 100%/lockout. *Resolved:* the build-active exemption buys exactly
+  one extra Ctrl-C grace round; the hard force-kill still wins, and the exemption is disabled above a
+  configurable ceiling. Quota is a real, hard constraint and keeps final authority.
+- **SE-10 — Signal-vs-authority posture.** Today each killer is its own authority. P2 makes the
+  shared guard a mandatory *floor* but killers still decide independently. *Scoped as open question:*
+  whether to go further and make killers signal-only with a single `ReapAuthority` deciding (fuller
+  signal-vs-authority compliance) is noted for /spec-converge; the guard-as-floor is the pragmatic
+  Phase-1 posture and is strictly safer than today.
+
+## Conformance pass (Instar standards)
+
+- **Structure > Willpower:** ✅ the "never kill on indeterminate" rule and the KEEP-guards are
+  enforced in shared code at every callsite, not in prose.
+- **Signal vs authority:** ⚠ partial — guard-as-floor now; full signal-only redesign noted (SE-10).
+- **Near-silent notifications:** ✅ recovery-bounce silent, terminal reaps coalesced, detail on a pull
+  surface (reap-log).
+- **3-tier testing + wiring/semantic + reproduce-before-claim:** ✅ specified.
+- **Migration parity:** ✅ code ships with server; config defaults additive in `migrateConfig()`.
+- **No-manual-work:** ✅ nothing asks the user to run steps.
+
+## Suggested phasing (one approval → chained merges, no fragmentation)
+
+- **Phase 1 (the incident + backbone):** P1 oracle + boot-purge fix + P2 guard extracted from
+  SessionReaper + route #2/#3 through `killSession` + P3 seam with the one listener. Closes the
+  reported bug and establishes the shared brain.
+- **Phase 2 (bring the rest onto the guard):** #5 watchdog, #6 orphan, #8 recovery cross-check,
+  #9 wake-reaper sleep-subtraction.
+- **Phase 3 (polish):** #7 quota soft-check + label-rename + any reap-log endpoint + Agent-Awareness.
+
+## Open questions
+
+1. Should terminal-reap notices be **on by default**, or default-off behind a flag like the sentinel
+   escalation (given the post-2026-05-22 topic-spam lesson)? Recommendation: on by default but
+   coalesced and routed to the bound/lifeline topic only — a genuine terminal reap of a session the
+   user was using is exactly the "actionable" class that should reach them, unlike housekeeping.
+2. Do we want a pull-surface `/sessions/reap-log` (audit of every reap + reason + disposition) for the
+   dashboard, mirroring `sentinel-events.jsonl`? Recommendation: yes, cheap and aligns with
+   near-silent (detail on the pull surface, only terminal reaps pushed).
+3. Quota at 95% (#7): is force-killing a mid-build topic acceptable, or should build/autonomous-active
+   topics get a longer grace even under quota pressure? Needs the operator's call on the
+   quota-vs-lost-work tradeoff.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4277,6 +4277,60 @@ export async function startServer(options: StartOptions): Promise<void> {
     // so it can wire episodicMemory from the sentinel.
     let workingMemory: WorkingMemoryAssembler | undefined;
 
+    // ── Reap observability + notify (UNIFIED-SESSION-LIFECYCLE §P3/§P4) ──
+    // Wired BEFORE the boot purge so even boot-time reaps land in the reap-log
+    // and surface a notice. The awake-checker is also wired here so the boot
+    // purge is lease-gated (a standby never reaps another machine's sessions).
+    // (The KEEP-guard is wired later, once its tracker deps exist — that is safe:
+    //  the boot purge passes knownDead and bypasses the guard, and the only other
+    //  guard consumers (monitorTick #2 age-limit / #3 idle-zombie) cannot fire a
+    //  kill in the first monitoring seconds — they require multi-hour age or 15+m
+    //  of observed idle — long after the guard is set below.)
+    const { ReapLog } = await import('../monitoring/ReapLog.js');
+    const { ReapNotifier } = await import('../monitoring/ReapNotifier.js');
+    const reapLog = new ReapLog(
+      config.stateDir,
+      () => (coordinator.enabled ? coordinator.identity?.machineId : undefined),
+    );
+    const reapNotifier = new ReapNotifier(
+      {
+        resolveTopic: (tmuxSession) => {
+          const t = telegram?.getTopicForSession(tmuxSession);
+          if (t == null) return null;
+          const n = typeof t === 'number' ? t : Number(t);
+          return Number.isFinite(n) ? n : null;
+        },
+        lifelineTopic: () => telegram?.getLifelineTopicId() ?? null,
+        // SUMMARY tier → through the formatter/tone-gate (HTML-escaped, quiet-hours
+        // aware). The notifier already coalesces, so a burst is one message.
+        send: (topicId, text) => notify('SUMMARY', 'session-reap', text, topicId),
+      },
+      {
+        enabled: config.monitoring?.reapNotify?.enabled ?? true,
+        coalesceWindowMs: config.monitoring?.reapNotify?.coalesceWindowMs ?? 60_000,
+      },
+    );
+    sessionManager.setAwakeChecker(() => !coordinator.enabled || coordinator.isAwake);
+    sessionManager.on('sessionReaped', (e: { session: import('../core/types.js').Session; reason: string; disposition?: 'terminal' | 'recovery-bounce'; origin?: 'operator' | 'autonomous' }) => {
+      reapLog.recordReaped({
+        session: e.session.name,
+        tmuxSession: e.session.tmuxSession,
+        reason: e.reason,
+        disposition: e.disposition,
+        origin: e.origin,
+      });
+      reapNotifier.onReaped({ session: e.session, reason: e.reason, disposition: e.disposition, origin: e.origin });
+    });
+    sessionManager.on('reapBlocked', (e: { session: import('../core/types.js').Session; reason: string; skipped: string; origin?: 'operator' | 'autonomous' }) => {
+      reapLog.recordSkipped({
+        session: e.session.name,
+        tmuxSession: e.session.tmuxSession,
+        reason: e.reason,
+        skipped: e.skipped,
+        origin: e.origin,
+      });
+    });
+
     // Fast startup purge — remove session records for dead tmux sessions BEFORE
     // monitoring starts. Prevents the death spiral where stale sessions overwhelm
     // the health endpoint (synchronous tmux has-session calls) and cause the
@@ -8296,9 +8350,8 @@ export async function startServer(options: StartOptions): Promise<void> {
       const { ReapGuard } = await import('../core/ReapGuard.js');
       sessionManager.setReapGuard(new ReapGuard(reapGuardDeps, { minAgeMs: 0 }));
     }
-    // Lease-holder gate: only the awake machine autonomously reaps. Single-machine
-    // installs (coordinator disabled) are always awake.
-    sessionManager.setAwakeChecker(() => !coordinator.enabled || coordinator.isAwake);
+    // (setAwakeChecker is wired earlier, before the boot purge, so the purge is
+    //  lease-gated — see the §P3/§P4 block above.)
 
     const sessionReaper = new SessionReaper(
       {
@@ -8476,7 +8529,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       }
     }
 
-    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, unjustifiedStopGate, stopGateDb, stopNotifier });
+    const server = new AgentServer({ config, sessionManager, state, scheduler, telegram, relationships, feedback, feedbackAnomalyDetector, dispatches, updateChecker, autoUpdater, autoDispatcher, quotaTracker, quotaManager, publisher, viewer, tunnel, evolution, watchdog, topicMemory, triageNurse, projectMapper, coherenceGate: scopeVerifier, contextHierarchy, canonicalState, operationGate, sentinel, adaptiveTrust, memoryMonitor, orphanReaper, coherenceMonitor, commitmentTracker, semanticMemory, activitySentinel, rateLimitSentinel, releaseReadinessSentinel: releaseReadinessSentinel ?? undefined, messageRouter, summarySentinel, spawnManager, systemReviewer, capabilityMapper, selfKnowledgeTree, coverageAuditor, topicResumeMap: _topicResumeMap ?? undefined, sessionRefresh: _sessionRefresh ?? undefined, autonomyManager, trustElevationTracker, autonomousEvolution, coordinator: coordinator.enabled ? coordinator : undefined, localSigningKeyPem, leaseTransport, liveTailReceiver, handoffWireTransport, onHandoffBegin, onHandoffInitiate: handoffInitiate, handoffInProgress: handoffSentinelInProgress, messageLedger, currentInboundByTopic, replyMarkerTransport, onReplyMarker: messageLedger ? (marker: unknown) => { const m = marker as { dedupeKey: string; platform: string; replyIdempotencyKey: string; epoch: number; topic?: string | null }; messageLedger!.applyRemoteReplyMarker(m.dedupeKey, { platform: m.platform, replyIdempotencyKey: m.replyIdempotencyKey, epoch: m.epoch, topic: m.topic ?? null }); } : undefined, whatsapp: whatsappAdapter, slack: slackAdapter, imessage: imessageAdapter, whatsappBusinessBackend, messageBridge, hookEventReceiver, worktreeMonitor, subagentTracker, instructionsVerifier, handshakeManager: threadlineHandshake, threadlineRouter, conversationStore, warrantsReplyGate, collaborationSurfacer, threadResumeMap, topicLinkageHandler: topicLinkageHandler ?? undefined, threadlineRelayClient, threadlineReplyWaiters, listenerManager: listenerManager ?? undefined, responseReviewGate, messagingToneGate, outboundDedupGate, telemetryHeartbeat, pasteManager, featureRegistry, discoveryEvaluator, completionEvaluator, unifiedTrust, liveConfig, sharedStateLedger, ledgerSessionRegistry, worktreeManager, oidcEnrolledRepos: parallelDevConfig?.oidcEnrolledRepos, initiativeTracker, projectRoundRunner, projectDriftChecker, machineHeartbeat, proxyCoordinator, topicIntentStore, topicIntentArcCheck, usherSignalStore, intelligence: sharedIntelligence ?? undefined, telegramBridgeConfig, telegramBridge: telegramBridge ?? undefined, threadlineObservability, briefDeps, workingMemory, taskFlowRegistry, threadlineFlowBridge, sessionReaper, reapLog, unjustifiedStopGate, stopGateDb, stopNotifier });
     // Boot-recovery (tunnel-failure-resilience spec Part 6): if the agent
     // died mid-relay-episode, the persisted tunnel.json carries
     // rotationPending=true. Rotate the dashboard PIN + authToken BEFORE

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8253,39 +8253,59 @@ export async function startServer(options: StartOptions): Promise<void> {
       const n = typeof t === 'number' ? t : Number(t);
       return Number.isFinite(n) ? n : null;
     };
+    // Shared stateless KEEP-guard deps (UNIFIED-SESSION-LIFECYCLE §P2). Built
+    // once here and used to back BOTH the SessionReaper and the ReapAuthority's
+    // guard (`sessionManager.setReapGuard`), so a killer cannot end a session the
+    // reaper would have kept — the same chain protects every kill path.
+    const reapGuardDeps: import('../core/ReapGuard.js').ReapGuardDeps = {
+      protectedSessions: () => sessionManager.getProtectedSessions(),
+      isRecoveryActive: (session) => composedRecoveryActive(session),
+      hasPendingInjection: (s) => sessionManager.getPendingInjection(s) != null,
+      isRelayLeaseActive: (id) => sessionManager.isRelayLeaseActive(id),
+      topicBinding: _resolveTopic,
+      // Gate I is a v1 stub (returns false): active conversation is already
+      // covered by the relay-lease + pending-injection gates and by render
+      // stasis (a session being talked to is not render-static for the full
+      // hysteresis+threshold window). Promoting to a real message-recency
+      // query is a tracked tuning follow-up.
+      recentUserMessage: () => false,
+      activeCommitmentForTopic: (topicId) => {
+        try { return commitmentTracker.getActive().some(c => c.topicId === topicId); }
+        catch { return true; } // cannot tell → protect
+      },
+      activeSubagentCount: (csid) => {
+        try { return csid ? subagentTracker.getActiveSubagents(csid).length : 0; }
+        catch { return 1; } // cannot tell → protect
+      },
+      buildOrAutonomousActive: (topicId) => {
+        const fresh = (p: string): boolean => {
+          try { return fs.existsSync(p) && (Date.now() - fs.statSync(p).mtimeMs) < 30 * 60_000; }
+          catch { return false; }
+        };
+        if (topicId != null && fresh(path.join(config.stateDir, 'autonomous', `${topicId}.local.md`))) return true;
+        return fresh(path.join(config.stateDir, 'state', 'build', 'build-state.json'));
+      },
+      hasActiveProcesses: (s) => sessionManager.hasActiveProcesses(s),
+    };
+
+    // Wire the ReapAuthority's KEEP-guard. minAgeMs:0 disables spawn-grace here —
+    // the killers that consult this guard (age-limit #2, idle-zombie #3) already
+    // gate on their own age/idle thresholds, so the reaper-specific spawn-grace
+    // would otherwise delay legitimate zombie kills for young-but-stuck sessions.
+    {
+      const { ReapGuard } = await import('../core/ReapGuard.js');
+      sessionManager.setReapGuard(new ReapGuard(reapGuardDeps, { minAgeMs: 0 }));
+    }
+    // Lease-holder gate: only the awake machine autonomously reaps. Single-machine
+    // installs (coordinator disabled) are always awake.
+    sessionManager.setAwakeChecker(() => !coordinator.enabled || coordinator.isAwake);
+
     const sessionReaper = new SessionReaper(
       {
+        ...reapGuardDeps,
         listRunningSessions: () => sessionManager.listRunningSessions(),
         captureOutput: (s, n) => sessionManager.captureOutput(s, n) ?? '',
-        hasActiveProcesses: (s) => sessionManager.hasActiveProcesses(s),
         frameworkForSession: (s) => sessionManager.frameworkForSession(s) as 'claude-code' | 'codex-cli' | undefined,
-        isRecoveryActive: (session) => composedRecoveryActive(session),
-        isRelayLeaseActive: (id) => sessionManager.isRelayLeaseActive(id),
-        hasPendingInjection: (s) => sessionManager.getPendingInjection(s) != null,
-        topicBinding: _resolveTopic,
-        // Gate I is a v1 stub (returns false): active conversation is already
-        // covered by the relay-lease + pending-injection gates and by render
-        // stasis (a session being talked to is not render-static for the full
-        // hysteresis+threshold window). Promoting to a real message-recency
-        // query is a tracked tuning follow-up.
-        recentUserMessage: () => false,
-        activeCommitmentForTopic: (topicId) => {
-          try { return commitmentTracker.getActive().some(c => c.topicId === topicId); }
-          catch { return true; } // cannot tell → protect
-        },
-        activeSubagentCount: (csid) => {
-          try { return csid ? subagentTracker.getActiveSubagents(csid).length : 0; }
-          catch { return 1; } // cannot tell → protect
-        },
-        buildOrAutonomousActive: (topicId) => {
-          const fresh = (p: string): boolean => {
-            try { return fs.existsSync(p) && (Date.now() - fs.statSync(p).mtimeMs) < 30 * 60_000; }
-            catch { return false; }
-          };
-          if (topicId != null && fresh(path.join(config.stateDir, 'autonomous', `${topicId}.local.md`))) return true;
-          return fresh(path.join(config.stateDir, 'state', 'build', 'build-state.json'));
-        },
-        protectedSessions: () => sessionManager.getProtectedSessions(),
         pressure: () => {
           const total = _os.totalmem();
           const freePct = total > 0 ? (_os.freemem() / total) * 100 : 100;

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8406,7 +8406,12 @@ export async function startServer(options: StartOptions): Promise<void> {
                   fs.readSync(fd, buf, 0, len, start);
                   tailHash = hash(buf.toString('utf-8'));
                 } finally { fs.closeSync(fd); }
-              } catch { tailHash = null; }
+              } catch {
+                // @silent-fallback-ok — an unreadable transcript tail just means
+                // "no meaningful-advance signal this tick"; the backstop treats a
+                // null tail as ambiguous (never as progress), which is safe.
+                tailHash = null;
+              }
             }
             const frame = sessionManager.captureOutput(session.tmuxSession, 8) ?? '';
             return {

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8373,6 +8373,60 @@ export async function startServer(options: StartOptions): Promise<void> {
       config.monitoring?.sessionReaper,
     );
     sessionReaper.start();
+
+    // ── Unkillability backstop (UNIFIED-SESSION-LIFECYCLE §P5) ───────────────
+    // Signal-only: raises ONE deduped Attention item (never auto-kills) when a
+    // session is KEPT forever despite faking work, or is stuck indeterminate.
+    {
+      const { StaleSessionBackstop } = await import('../monitoring/StaleSessionBackstop.js');
+      const { probeTranscript } = await import('../monitoring/transcriptProber.js');
+      const { makeAttentionPoster } = await import('../monitoring/sentinelWiring.js');
+      const _crypto = await import('node:crypto');
+      const staleCfg = config.monitoring?.staleBackstop ?? {};
+      const progressFloorBytes = staleCfg.progressFloorBytes ?? 512;
+      const hash = (s: string): string => _crypto.createHash('sha1').update(s).digest('hex').slice(0, 16);
+      const backstop = new StaleSessionBackstop(
+        {
+          listRunningSessions: () => sessionManager.listRunningSessions(),
+          probeLiveness: (names) => sessionManager.probeLivenessBatch(names),
+          snapshot: (session) => {
+            const framework = session.framework ?? sessionManager.frameworkForSession(session.tmuxSession) ?? 'claude-code';
+            const sessionId = framework === 'claude-code' ? (session.claudeSessionId ?? '') : '';
+            const tp = probeTranscript({ framework, sessionId, projectDir: '' });
+            // Tail hash: read the last progressFloorBytes so a heartbeat-byte append
+            // (same tail) is NOT counted as a meaningful advance.
+            let tailHash: string | null = null;
+            if (tp.resolved && tp.path) {
+              try {
+                const fd = fs.openSync(tp.path, 'r');
+                try {
+                  const start = Math.max(0, tp.size - progressFloorBytes);
+                  const len = tp.size - start;
+                  const buf = Buffer.alloc(len);
+                  fs.readSync(fd, buf, 0, len, start);
+                  tailHash = hash(buf.toString('utf-8'));
+                } finally { fs.closeSync(fd); }
+              } catch { tailHash = null; }
+            }
+            const frame = sessionManager.captureOutput(session.tmuxSession, 8) ?? '';
+            return {
+              transcriptResolved: tp.resolved,
+              transcriptSize: tp.size,
+              transcriptTailHash: tailHash,
+              mainProcessActive: sessionManager.hasActiveProcesses(session.tmuxSession),
+              idleStateToken: hash(frame),
+            };
+          },
+          raiseAttention: makeAttentionPoster({ port: config.port, authToken: config.authToken ?? '' }),
+          setLongIndeterminate: (id, isLong) => sessionManager.markLongIndeterminate(id, isLong),
+        },
+        staleCfg,
+      );
+      backstop.start();
+      if (staleCfg.enabled !== false) {
+        console.log(pc.green('  Unkillability backstop enabled (§P5 — signal-only, never auto-kills)'));
+      }
+    }
     if (config.monitoring?.sessionReaper?.enabled) {
       console.log(pc.green(
         config.monitoring.sessionReaper.dryRun === false

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -63,6 +63,15 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       finalGraceSec: 60,
       protectOpenCommitments: true,
     },
+    // Reap-notification (UNIFIED-SESSION-LIFECYCLE §P3). Default ON — the single
+    // coalescing listener that surfaces "your session was shut down" so a reap is
+    // never silent (the disappearing-session incident). recovery-bounce + operator
+    // kills stay silent regardless; terminal reaps within the window collapse into
+    // one consolidated lifeline message.
+    reapNotify: {
+      enabled: true,
+      coalesceWindowMs: 60_000,
+    },
     // Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md). Ships
     // OFF — when disabled, the /failures routes 503-stub (surface still exists
     // for capability probing). Registers itself on the rollout board.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -72,6 +72,17 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
       enabled: true,
       coalesceWindowMs: 60_000,
     },
+    // Unkillability backstop (UNIFIED-SESSION-LIFECYCLE §P5). Default ON, signal-
+    // only: raises ONE deduped Attention item (never auto-kills) when a session is
+    // KEPT forever despite faking work, or is stuck indeterminate. The escalation
+    // thresholds match the spec (30 min no-forward-progress / 15 indeterminate).
+    staleBackstop: {
+      enabled: true,
+      tickIntervalSec: 120,
+      unverifiableEscalateMinutes: 30,
+      indeterminateEscalateCount: 15,
+      progressFloorBytes: 512,
+    },
     // Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md). Ships
     // OFF — when disabled, the /failures routes 503-stub (surface still exists
     // for capability probing). Registers itself on the rollout board.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2765,6 +2765,28 @@ If a user asks "are my sentinels alerting?" or "why isn't the watchdog notifying
       result.skipped.push('CLAUDE.md: Sentinel Notifications section already present');
     }
 
+    // Reap-log (UNIFIED-SESSION-LIFECYCLE §P4) — tells the agent the durable
+    // "why did my session vanish?" answer exists and where to read it. Without
+    // this, an agent asked "where did my session go?" has no grounded answer.
+    // Idempotent via content-sniffing on the route path.
+    if (!content.includes('/sessions/reap-log')) {
+      const section = `
+## Reap-Log — why a session vanished
+
+Every session shutoff — and every REFUSED shutoff (protected, not-lease-holder, a KEEP-guard hold, in-flight) — is recorded as one JSON line in \`logs/reap-log.jsonl\` and served read-only at \`GET /sessions/reap-log\`. A session can never disappear without a trace.
+
+- Read it: \`curl -H "Authorization: Bearer $AUTH" "http://localhost:4040/sessions/reap-log?limit=50"\` → \`{ entries: [{ ts, type:'reaped'|'skipped', session, reason, disposition, origin, skipped?, machine? }] }\`.
+- Distinct from \`/sessions/reaper\` (live verdicts): the reap-log is the historical record of what ACTUALLY happened.
+- When a session is autonomously shut down you also get a "your session was shut down — <reason>" notice. Recovery-bounces (kill-to-respawn) and your own operator kills stay silent. Off-switch: \`{"monitoring": {"reapNotify": {"enabled": false}}}\`.
+- Proactive: user asks "where did my session go?" / "why did X disappear?" / "did something get killed?" → GET /sessions/reap-log and explain the most recent entries for that session. Spec: \`docs/specs/unified-session-lifecycle-robustness.md\`.
+`;
+      content += '\n' + section;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Reap-Log section');
+    } else {
+      result.skipped.push('CLAUDE.md: Reap-Log section already present');
+    }
+
     // Self-Heal: Update Restart Behavior — explains restart-cascade dampener
     // and lifeline drift auto-promote. Complementary to Version-Skew Self-
     // Recovery above (that one handles major.minor crossings; this one handles

--- a/src/core/ReapGuard.ts
+++ b/src/core/ReapGuard.ts
@@ -1,0 +1,151 @@
+/**
+ * ReapGuard — the shared, stateless "is it safe to reap this session?" guard.
+ *
+ * Spec: docs/specs/unified-session-lifecycle-robustness.md §P2.
+ *
+ * Extracted from `SessionReaper.evaluate()` so that EVERY autonomous killer —
+ * not just the careful new reaper — consults the same positive-evidence KEEP
+ * checks before a session is ended. The single ReapAuthority
+ * (`SessionManager.terminateSession`) calls this guard; a non-null result means
+ * the session must be KEPT and the terminate is a no-op.
+ *
+ * Scope is the STATELESS guards only (deps-driven, no per-tick observation
+ * state): protected, spawn-grace, recovery-in-flight, pending-injection,
+ * relay-lease, recent-user-message, open-commitment, active-subagent,
+ * structural-long-work, active-process, main-process-uninspectable/active.
+ *
+ * The STATEFUL checks — transcript-growth (compares against the previous tick)
+ * and positive-idle proof (needs a captured pane frame) — stay inside
+ * `SessionReaper.evaluate()`, which calls this guard FIRST (preserving the exact
+ * keptBy ordering) and then layers its own per-instance checks.
+ *
+ * Ordering is identical to the original `evaluate()` so a refactor preserves
+ * every `keptBy` reason for the same input (asserted by the reaper's tests).
+ */
+
+import type { Session } from './types.js';
+
+export type ReapConfidence = 'high' | 'low';
+
+/** A KEEP verdict: the reason a session must not be reaped, + a confidence. */
+export interface ReapKeepReason {
+  reason: string;
+  confidence: ReapConfidence;
+}
+
+/**
+ * Signal sources for the stateless guards. A subset of `SessionReaperDeps` so a
+ * single set of closures (built once in server.ts) can back both the reaper and
+ * the authority. Every "cannot inspect" path resolves to KEEP, never to reap.
+ */
+export interface ReapGuardDeps {
+  protectedSessions: () => string[];
+  isRecoveryActive: (session: Session) => boolean;
+  hasPendingInjection: (tmuxSession: string) => boolean;
+  isRelayLeaseActive: (sessionId: string) => boolean;
+  topicBinding: (tmuxSession: string) => number | null;
+  recentUserMessage: (topicId: number, withinMs: number) => boolean;
+  activeCommitmentForTopic: (topicId: number) => boolean;
+  activeSubagentCount: (claudeSessionId: string | undefined) => number;
+  buildOrAutonomousActive: (topicId: number | null) => boolean;
+  hasActiveProcesses: (tmuxSession: string) => boolean;
+  /** Optional main-process CPU/IO liveness. `undefined` ⇒ cannot inspect ⇒ KEEP. */
+  mainProcessActive?: (tmuxSession: string) => boolean | undefined;
+  now?: () => number;
+}
+
+export interface ReapGuardOptions {
+  /** Minimum session age before reap-eligibility (spawn grace). 0 disables. */
+  minAgeMs: number;
+  /** Window for "recent user message" on a bound topic. */
+  recentUserWindowMs: number;
+  /** Whether an open commitment on the bound topic blocks reaping. */
+  protectOpenCommitments: boolean;
+}
+
+export const DEFAULT_REAP_GUARD_OPTIONS: ReapGuardOptions = {
+  minAgeMs: 30 * 60_000,
+  recentUserWindowMs: 30 * 60_000,
+  protectOpenCommitments: true,
+};
+
+export class ReapGuard {
+  private readonly deps: ReapGuardDeps;
+  private readonly opts: ReapGuardOptions;
+  private readonly now: () => number;
+
+  constructor(deps: ReapGuardDeps, opts?: Partial<ReapGuardOptions>) {
+    this.deps = deps;
+    this.opts = { ...DEFAULT_REAP_GUARD_OPTIONS, ...(opts ?? {}) };
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /**
+   * Returns the reason this session must be KEPT (not reaped), or `null` if all
+   * stateless guards clear. Cheap-first ordering: in-memory checks before any
+   * subprocess fork (process tree / main-process probe) so a guarded session is
+   * rejected without paying for a capture.
+   *
+   * Never throws — a thrown signal source is caught and resolved to KEEP
+   * ('guard-error'), because we can never reason about a session we cannot
+   * inspect, and the safe answer is always "keep".
+   */
+  blockedReason(session: Session): ReapKeepReason | null {
+    try {
+      return this.evaluate(session);
+    } catch {
+      return { reason: 'guard-error', confidence: 'low' };
+    }
+  }
+
+  private evaluate(session: Session): ReapKeepReason | null {
+    const keep = (reason: string, confidence: ReapConfidence = 'high'): ReapKeepReason => ({
+      reason,
+      confidence,
+    });
+
+    // ── Cheap, in-memory guards first (no subprocess fork) ──
+    // A. Protected set.
+    if (this.deps.protectedSessions().includes(session.tmuxSession)) return keep('protected');
+    // M. Spawn grace — a freshly-spawned session that hasn't had time to produce
+    //    output yet must not be reaped. Skipped when minAgeMs is 0.
+    if (this.opts.minAgeMs > 0 && session.startedAt) {
+      const ageMs = this.now() - Date.parse(session.startedAt);
+      if (!(ageMs >= this.opts.minAgeMs)) return keep('spawn-grace');
+    }
+    // G. Recovery in flight — a kill-to-respawn is mid-flight; never race it.
+    if (this.deps.isRecoveryActive(session)) return keep('recovery-in-flight');
+    // H. Pending injection (a message is waiting to be delivered to the session).
+    if (this.deps.hasPendingInjection(session.tmuxSession)) return keep('pending-injection');
+    // Relay lease (an agent-to-agent relay holds this session).
+    if (this.deps.isRelayLeaseActive(session.id)) return keep('relay-lease');
+
+    const topicId = this.deps.topicBinding(session.tmuxSession);
+    // I. Recent user interaction on the bound topic.
+    if (topicId != null && this.deps.recentUserMessage(topicId, this.opts.recentUserWindowMs)) {
+      return keep('recent-user-message');
+    }
+    // J. Open commitment on the bound topic.
+    if (this.opts.protectOpenCommitments && topicId != null && this.deps.activeCommitmentForTopic(topicId)) {
+      return keep('open-commitment');
+    }
+    // K. Active subagent spawned by this session.
+    if (this.deps.activeSubagentCount(session.claudeSessionId) > 0) return keep('active-subagent');
+    // L. Structural long-work (build / autonomous) on the topic/project.
+    if (this.deps.buildOrAutonomousActive(topicId)) return keep('structural-long-work');
+
+    // ── Activeness (positive-evidence) — may fork a subprocess ──
+    // C. Process tree: any non-baseline child ⇒ working.
+    if (this.deps.hasActiveProcesses(session.tmuxSession)) return keep('active-process');
+    // C(main). Main-process CPU/IO delta. undefined ⇒ cannot inspect ⇒ KEEP (low).
+    if (this.deps.mainProcessActive) {
+      const mp = this.deps.mainProcessActive(session.tmuxSession);
+      if (mp === undefined) return keep('process-uninspectable', 'low');
+      if (mp === true) return keep('main-process-active');
+    }
+
+    // All stateless guards clear. (The reaper layers transcript-growth +
+    // positive-idle after this; other killers proceed to terminate.)
+    return null;
+  }
+}

--- a/src/core/SessionLivenessOracle.ts
+++ b/src/core/SessionLivenessOracle.ts
@@ -1,0 +1,263 @@
+/**
+ * SessionLivenessOracle — the single, tri-state answer to "is this tmux session
+ * alive?" for every autonomous session killer.
+ *
+ * Spec: docs/specs/unified-session-lifecycle-robustness.md §P1.
+ *
+ * The 2026-05-27 incident: the boot purge probed `tmux has-session` with a 1s
+ * timeout inside a bare try/catch, so a *timeout* (tmux busy at boot) threw the
+ * same error as "session gone" — and live sessions were mass-purged. The oracle
+ * is the structural fix:
+ *
+ *   - `dead` is returned ONLY on a definitive negative: the tmux server is
+ *     reachable (a `list-sessions` succeeded) AND the session's exact canonical
+ *     id is absent from that list. Never inferred from a prefix match, an
+ *     unrecognized error string, or an exit code.
+ *   - Anything else — timeout, server-unreachable, ENOENT/EPIPE, unknown failure
+ *     — is `indeterminate`. The hard rule (enforced by every caller) is: NEVER
+ *     transition a session to killed on `indeterminate`. Indeterminate means
+ *     "ask again next tick," never "reap now."
+ *
+ * Performance contract (§P1): liveness for the whole set is resolved from ONE
+ * `tmux list-sessions` (no per-session fork), cached for a short TTL so multiple
+ * killers in one tick never re-probe. The list call is async (never
+ * execFileSync), retried once with backoff, and bounded by a total wall-clock
+ * cap so a slow tmux can never block boot — unresolved sessions are left
+ * `indeterminate` and finished by the first monitoring tick.
+ */
+
+export type Liveness = 'alive' | 'dead' | 'indeterminate';
+
+export interface LivenessResult {
+  liveness: Liveness;
+  /** Diagnostic reason — for the reap-log / debugging, never user-facing prose. */
+  reason: string;
+}
+
+export interface SessionLivenessOracleConfig {
+  /** Per-attempt timeout for the `list-sessions` probe (ms). Must be > a floor. */
+  probeTimeoutMs: number;
+  /** Retries (in addition to the first attempt) on a transient/unreachable result. */
+  probeRetries: number;
+  /** Backoff between retries (ms). */
+  probeBackoffMs: number;
+  /** Total wall-clock cap across all attempts (ms). On cap → indeterminate. */
+  bootCapMs: number;
+  /** How long a successful list snapshot is trusted before a refresh (ms). */
+  cacheTtlMs: number;
+}
+
+export const DEFAULT_LIVENESS_CONFIG: SessionLivenessOracleConfig = {
+  probeTimeoutMs: 5000,
+  probeRetries: 1,
+  probeBackoffMs: 250,
+  bootCapMs: 8000,
+  cacheTtlMs: 3000,
+};
+
+/** Floors enforced at startup validation (a 0ms timeout would re-create the death spiral). */
+export const LIVENESS_FLOORS = {
+  minProbeTimeoutMs: 1000,
+  minBootCapMs: 2000,
+} as const;
+
+type ExecFn = (
+  file: string,
+  args: string[],
+  opts: { timeout: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface SessionLivenessOracleDeps {
+  tmuxPath: string;
+  /** promisified execFile — injected for testability. */
+  exec: ExecFn;
+  now?: () => number;
+  /** Optional sink for diagnostics. */
+  log?: (msg: string) => void;
+}
+
+/** Outcome of a single `list-sessions` snapshot attempt. */
+interface ListSnapshot {
+  /** true only if tmux answered authoritatively (success OR a clean "no server"). */
+  authoritative: boolean;
+  /** Exact session names present (empty set when authoritative + no sessions). */
+  names: Set<string>;
+  reason: string;
+}
+
+/**
+ * Validate a liveness config against the floors. Returns an array of human-readable
+ * problems (empty = valid). Called at startup so a nonsensical knob is rejected
+ * loudly rather than silently re-creating the boot-purge bug.
+ */
+export function validateLivenessConfig(cfg: Partial<SessionLivenessOracleConfig>): string[] {
+  const problems: string[] = [];
+  if (cfg.probeTimeoutMs != null && cfg.probeTimeoutMs < LIVENESS_FLOORS.minProbeTimeoutMs) {
+    problems.push(
+      `liveness.probeTimeoutMs (${cfg.probeTimeoutMs}) is below the floor ${LIVENESS_FLOORS.minProbeTimeoutMs}ms — ` +
+        `a too-short probe re-creates the 2026-05-27 false-purge (slow tmux read as dead).`,
+    );
+  }
+  if (cfg.probeRetries != null && cfg.probeRetries < 0) {
+    problems.push(`liveness.probeRetries (${cfg.probeRetries}) must be >= 0.`);
+  }
+  if (cfg.bootCapMs != null && cfg.bootCapMs < LIVENESS_FLOORS.minBootCapMs) {
+    problems.push(`liveness.bootCapMs (${cfg.bootCapMs}) is below the floor ${LIVENESS_FLOORS.minBootCapMs}ms.`);
+  }
+  if (cfg.cacheTtlMs != null && cfg.cacheTtlMs < 0) {
+    problems.push(`liveness.cacheTtlMs (${cfg.cacheTtlMs}) must be >= 0.`);
+  }
+  return problems;
+}
+
+export class SessionLivenessOracle {
+  private readonly cfg: SessionLivenessOracleConfig;
+  private readonly deps: SessionLivenessOracleDeps;
+  private readonly now: () => number;
+  private snapshot: ListSnapshot | null = null;
+  private snapshotAt = 0;
+  /** Coalesce concurrent refreshes so N killers in one tick share one tmux call. */
+  private inflight: Promise<ListSnapshot> | null = null;
+
+  constructor(deps: SessionLivenessOracleDeps, cfg?: Partial<SessionLivenessOracleConfig>) {
+    this.deps = deps;
+    this.cfg = { ...DEFAULT_LIVENESS_CONFIG, ...(cfg ?? {}) };
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /**
+   * Liveness for a single session. Uses the cached list snapshot when fresh,
+   * otherwise refreshes (one shared tmux call). Never throws.
+   */
+  async probe(tmuxSession: string): Promise<LivenessResult> {
+    const snap = await this.ensureSnapshot();
+    return this.classify(tmuxSession, snap);
+  }
+
+  /**
+   * Liveness for many sessions resolved from ONE snapshot. This is the boot-purge
+   * path: one `tmux list-sessions` for the whole tracked set, no per-session fork.
+   */
+  async probeAll(tmuxSessions: string[]): Promise<Map<string, LivenessResult>> {
+    const snap = await this.ensureSnapshot();
+    const out = new Map<string, LivenessResult>();
+    for (const name of tmuxSessions) out.set(name, this.classify(name, snap));
+    return out;
+  }
+
+  /** Force the next probe to re-read tmux (used by tests / after a known change). */
+  invalidate(): void {
+    this.snapshot = null;
+    this.snapshotAt = 0;
+  }
+
+  private classify(tmuxSession: string, snap: ListSnapshot): LivenessResult {
+    if (!snap.authoritative) {
+      // Could not get ground truth — slow/unreachable tmux. NEVER dead.
+      return { liveness: 'indeterminate', reason: snap.reason };
+    }
+    // Authoritative snapshot: exact-id membership is ground truth.
+    if (snap.names.has(tmuxSession)) {
+      return { liveness: 'alive', reason: 'present-in-list' };
+    }
+    return { liveness: 'dead', reason: 'absent-from-reachable-server' };
+  }
+
+  private async ensureSnapshot(): Promise<ListSnapshot> {
+    const fresh = this.snapshot && this.now() - this.snapshotAt < this.cfg.cacheTtlMs;
+    if (fresh) return this.snapshot!;
+    if (this.inflight) return this.inflight;
+    this.inflight = this.refresh()
+      .then((snap) => {
+        // Only cache an authoritative snapshot; a transient failure must not be
+        // sticky (else one bad tick freezes liveness for the whole TTL).
+        if (snap.authoritative) {
+          this.snapshot = snap;
+          this.snapshotAt = this.now();
+        }
+        return snap;
+      })
+      .finally(() => {
+        this.inflight = null;
+      });
+    return this.inflight;
+  }
+
+  /**
+   * One `tmux list-sessions`, retried up to probeRetries on a transient/unreachable
+   * result, bounded by bootCapMs total. Returns an authoritative snapshot only when
+   * tmux answered definitively (success, or a clean "no server running").
+   */
+  private async refresh(): Promise<ListSnapshot> {
+    const deadline = this.now() + this.cfg.bootCapMs;
+    let lastReason = 'no-attempt';
+    for (let attempt = 0; attempt <= this.cfg.probeRetries; attempt++) {
+      if (attempt > 0) {
+        if (this.now() >= deadline) {
+          return { authoritative: false, names: new Set(), reason: `boot-cap-exceeded(${lastReason})` };
+        }
+        await delay(this.cfg.probeBackoffMs);
+      }
+      const remaining = Math.max(0, deadline - this.now());
+      const timeout = Math.min(this.cfg.probeTimeoutMs, remaining || this.cfg.probeTimeoutMs);
+      const res = await this.listOnce(timeout);
+      if (res.authoritative) return res;
+      lastReason = res.reason;
+    }
+    return { authoritative: false, names: new Set(), reason: lastReason };
+  }
+
+  private async listOnce(timeout: number): Promise<ListSnapshot> {
+    try {
+      const { stdout } = await this.deps.exec(
+        this.deps.tmuxPath,
+        ['list-sessions', '-F', '#{session_name}'],
+        { timeout },
+      );
+      const names = new Set(
+        stdout
+          .split('\n')
+          .map((s) => s.trim())
+          .filter(Boolean),
+      );
+      return { authoritative: true, names, reason: 'list-ok' };
+    } catch (err: unknown) {
+      // tmux exits non-zero with "no server running on ..." when there is no
+      // server at all. That is an AUTHORITATIVE "no sessions exist" — but we
+      // treat it conservatively: only classify it authoritative-empty when the
+      // message is the recognized no-server string. Any other error (timeout,
+      // ENOENT, EPIPE, unknown) is non-authoritative → indeterminate.
+      const msg = errText(err);
+      if (/no server running/i.test(msg)) {
+        return { authoritative: true, names: new Set(), reason: 'no-server-running' };
+      }
+      if (isTimeout(err)) return { authoritative: false, names: new Set(), reason: 'probe-timeout' };
+      return { authoritative: false, names: new Set(), reason: `probe-error:${truncate(msg, 80)}` };
+    }
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errText(err: unknown): string {
+  if (err && typeof err === 'object') {
+    const e = err as { stderr?: string; message?: string };
+    return (e.stderr || e.message || String(err)).toString();
+  }
+  return String(err);
+}
+
+function isTimeout(err: unknown): boolean {
+  if (err && typeof err === 'object') {
+    const e = err as { killed?: boolean; signal?: string; code?: string };
+    // execFile timeout kills the child with SIGTERM and sets killed=true.
+    return e.killed === true || e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT';
+  }
+  return false;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) : s;
+}

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -14,6 +14,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { SessionLivenessOracle, type SessionLivenessOracleConfig } from './SessionLivenessOracle.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -214,6 +215,27 @@ export class SessionManager extends EventEmitter {
     super();
     this.config = config;
     this.state = state;
+  }
+
+  /** Lazily-constructed tri-state liveness oracle (UNIFIED-SESSION-LIFECYCLE §P1).
+   *  Backs the boot purge and isSessionAliveAsync so a slow/unreachable tmux is
+   *  treated as `indeterminate`, never `dead`. */
+  private _livenessOracle: SessionLivenessOracle | null = null;
+  private get livenessOracle(): SessionLivenessOracle {
+    if (!this._livenessOracle) {
+      this._livenessOracle = new SessionLivenessOracle(
+        { tmuxPath: this.config.tmuxPath, exec: execFileAsync },
+        this.config.liveness,
+      );
+    }
+    return this._livenessOracle;
+  }
+
+  /** Test/DI seam: inject a liveness oracle (e.g. one with a scripted exec).
+   *  Production builds the oracle lazily from config; this lets unit tests drive
+   *  the alive/dead/indeterminate verdicts deterministically. */
+  setLivenessOracle(oracle: SessionLivenessOracle): void {
+    this._livenessOracle = oracle;
   }
 
   /** Effective idle-at-prompt kill threshold (config override or hardcoded default) */
@@ -1373,32 +1395,48 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
-   * Fast startup purge — immediately remove session records for dead tmux sessions.
-   * Called once at server boot BEFORE monitoring starts, to prevent the death spiral
-   * where stale sessions overwhelm startup and block health checks.
-   * Uses a short timeout (1s) per session to fail fast.
+   * Fast startup purge — remove session records for sessions that are *definitively*
+   * dead. Called once at server boot BEFORE monitoring starts, to prevent the death
+   * spiral where stale records overwhelm startup and block health checks.
+   *
+   * UNIFIED-SESSION-LIFECYCLE §P1 (the 2026-05-27 fix): liveness is resolved from a
+   * single `tmux list-sessions` via the tri-state oracle, NOT a per-session
+   * `has-session` with a 1s timeout. The old code treated a timeout (tmux busy at
+   * boot) identically to "session gone" and mass-purged live sessions — "9 of 9".
+   * Now ONLY a `dead` verdict (server reachable + exact id absent) purges; `alive`
+   * and `indeterminate` are kept. An indeterminate session lingers one extra tick
+   * (cheap, caught by monitoring) rather than being falsely reaped (expensive).
    */
   async purgeDeadSessions(): Promise<number> {
     const running = this.state.listSessions({ status: 'running' });
     if (running.length === 0) return 0;
 
+    const verdicts = await this.livenessOracle.probeAll(running.map((s) => s.tmuxSession));
+
     let purged = 0;
+    let kept = 0;
+    let indeterminate = 0;
     for (const session of running) {
-      try {
-        execFileSync(this.config.tmuxPath, ['has-session', '-t', `=${session.tmuxSession}`], {
-          stdio: 'ignore', timeout: 1000,
-        });
-      } catch {
-        // tmux session doesn't exist — purge the record
+      const v = verdicts.get(session.tmuxSession);
+      if (v?.liveness === 'dead') {
         session.status = 'completed';
         session.endedAt = new Date().toISOString();
+        session.endedReason = 'boot-purge-dead';
         this.state.saveSession(session);
         purged++;
+      } else {
+        kept++;
+        if (v?.liveness === 'indeterminate') indeterminate++;
       }
     }
 
-    if (purged > 0) {
-      console.log(`[SessionManager] Startup purge: removed ${purged} dead session(s) of ${running.length} tracked`);
+    if (purged > 0 || indeterminate > 0) {
+      console.log(
+        `[SessionManager] Startup purge: removed ${purged} dead session(s) of ${running.length} tracked` +
+          (indeterminate > 0
+            ? ` (${indeterminate} indeterminate — KEPT, will re-verify on the next tick rather than risk a false purge)`
+            : ''),
+      );
     }
     return purged;
   }

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -15,6 +15,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SessionLivenessOracle, type SessionLivenessOracleConfig } from './SessionLivenessOracle.js';
+import type { ReapGuard } from './ReapGuard.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -158,6 +159,10 @@ export class SessionManager extends EventEmitter {
 
   /** Optional callback: is this session currently in active compaction recovery? If so, skip zombie kill. */
   private activeRecoveryChecker?: (session: Session) => boolean;
+  /** Shared stateless KEEP-guard consulted by terminateSession (§P2). */
+  private reapGuard?: ReapGuard;
+  /** Multi-machine lease/awake predicate gating autonomous reaps (§Multi-machine). */
+  private isAwakeMachine?: () => boolean;
 
   /** Optional callback: is this tmux session currently bound to a live messaging topic
    *  (Telegram/Slack/iMessage)? Returns a stable identifier (e.g. topic ID or channel ID)
@@ -365,6 +370,29 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Register the shared ReapGuard (UNIFIED-SESSION-LIFECYCLE §P2). Once set,
+   * every AUTONOMOUS terminate consults it: a non-null KEEP reason makes the
+   * terminate a no-op `{ terminated:false, skipped:<reason> }`. Wired in server.ts
+   * with the same signal closures that back SessionReaper, so a killer can only
+   * *request* a kill — the authority refuses to end a guarded session. Operator
+   * kills bypass the guard. Unset (tests/standalone) → no guard consult.
+   */
+  setReapGuard(guard: ReapGuard): void {
+    this.reapGuard = guard;
+  }
+
+  /**
+   * Register the multi-machine lease/awake predicate. When set and it returns
+   * false, an AUTONOMOUS terminate is a no-op `skipped:'not-lease-holder'` — only
+   * the awake/lease-holding machine may autonomously reap; a standby may detect
+   * and signal but never kill another machine's sessions. Operator kills bypass.
+   * Unset → treated as awake (single-machine default).
+   */
+  setAwakeChecker(fn: () => boolean): void {
+    this.isAwakeMachine = fn;
+  }
+
+  /**
    * Set the Prompt Gate InputDetector for prompt monitoring.
    * When set, monitorTick() will capture output and feed it to the detector.
    */
@@ -429,14 +457,31 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
-   * Single-writer session termination (SESSION-REAPER-SPEC §3.6). Both the
-   * idle-kill path and the SessionReaper funnel through this so a session is
-   * killed at most once with exactly-once `beforeSessionKill`/`sessionComplete`
+   * Single-writer session termination — the sole ReapAuthority
+   * (UNIFIED-SESSION-LIFECYCLE §P0, building on SESSION-REAPER-SPEC §3.6). EVERY
+   * autonomous killer funnels through this so a session is killed at most once,
+   * with exactly-once `beforeSessionKill`/`sessionComplete`/`sessionReaped`
    * emission and a correct `endedReason`.
    *
-   * Compare-and-set semantics: a session that is not in a live state
-   * ('starting'/'running'), or whose termination is already in flight, is a
-   * no-op — this is what prevents the idle-kill ↔ reaper double-kill race.
+   * The authority holds the safety checks so a killer can only *request* a kill:
+   *  - CAS on live status + an in-flight guard (prevents the double-kill race).
+   *  - `protectedSessions` (never kill).
+   *  - Lease-holder gate: an AUTONOMOUS reap on a standby machine is a no-op
+   *    `skipped:'not-lease-holder'` — only the awake machine reaps.
+   *  - ReapGuard (§P2): an AUTONOMOUS reap of a session the guard says to KEEP is
+   *    a no-op `skipped:<keep-reason>` — even a buggy killer cannot end a guarded
+   *    session.
+   * `origin:'operator'` bypasses the lease-gate and the guard (an explicit human
+   * kill must always happen). Default `origin` is `'autonomous'` so an in-process
+   * caller can never accidentally mint operator privilege.
+   *
+   * Re-entrancy: the guard is consulted BEFORE this call acquires its own
+   * in-flight lock, so the authority's lock for the kill it is performing is
+   * never misread by the guard.
+   *
+   * `disposition:'recovery-bounce'` marks a kill-to-respawn (SessionRecovery,
+   * version-skew, context-exhaustion) so the §P3 notifier stays silent — that is
+   * a bounce, not a disappearance. Default `'terminal'`.
    *
    * @returns `{ terminated: true }` on a kill performed by THIS call, or
    *          `{ terminated: false, skipped }` describing why it was a no-op.
@@ -444,7 +489,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
   async terminateSession(
     sessionId: string,
     reason: string,
-    opts?: { finalStatus?: 'completed' | 'killed' },
+    opts?: {
+      finalStatus?: 'completed' | 'killed';
+      disposition?: 'terminal' | 'recovery-bounce';
+      origin?: 'operator' | 'autonomous';
+      knownDead?: boolean;
+    },
   ): Promise<{ terminated: boolean; skipped?: string }> {
     const session = this.state.getSession(sessionId);
     if (!session) return { terminated: false, skipped: 'not-found' };
@@ -452,9 +502,46 @@ rm()  { "${shimRunner}" rm  "$@"; }
     if (session.status !== 'running' && session.status !== 'starting') {
       return { terminated: false, skipped: `already-${session.status}` };
     }
-    if (this.config.protectedSessions.includes(session.tmuxSession)) {
-      return { terminated: false, skipped: 'protected' };
+
+    const origin = opts?.origin ?? 'autonomous';
+    const disposition = opts?.disposition ?? 'terminal';
+
+    // ── Authority gates (autonomous only; operator bypasses) ──
+    // An `origin:'operator'` kill — stamped ONLY by the Bearer-authed HTTP route
+    // layer — must always happen: the user clicked "kill". It bypasses protected,
+    // the lease gate, and the KEEP-guard. Autonomous killers (the default) can
+    // only *request*; the authority holds the safety checks.
+    if (origin === 'autonomous') {
+      // Protected set — never autonomously reap a protected session.
+      if (this.config.protectedSessions.includes(session.tmuxSession)) {
+        this.emit('reapBlocked', { session, reason, skipped: 'protected', origin });
+        return { terminated: false, skipped: 'protected' };
+      }
+      // Lease-holder gate: a standby machine never reaps another machine's sessions.
+      if (this.isAwakeMachine && !this.isAwakeMachine()) {
+        this.emit('reapBlocked', { session, reason, skipped: 'not-lease-holder', origin });
+        return { terminated: false, skipped: 'not-lease-holder' };
+      }
+      // ReapGuard: refuse to end a session the guard says to KEEP. Consulted
+      // before the in-flight lock is acquired (re-entrancy ordering).
+      //
+      // `knownDead` bypass (boot-purge, #1): the caller has already proven the
+      // session is `dead` via the P1 oracle (tmux server reachable + exact id
+      // absent). The guard exists to protect a LIVE-but-busy session from being
+      // mistaken for dead — its topic-state KEEP reasons (recent-user-message,
+      // open-commitment) are liveness-blind, so consulting it on a proven-dead
+      // session would pin a tombstone in the running list and re-create the boot
+      // death-spiral the purge guards against. A proven-dead session has no
+      // liveness to protect, so skip the guard. Lease + protected + CAS still apply.
+      if (!opts?.knownDead) {
+        const blocked = this.reapGuard?.blockedReason(session);
+        if (blocked) {
+          this.emit('reapBlocked', { session, reason, skipped: blocked.reason, origin });
+          return { terminated: false, skipped: blocked.reason };
+        }
+      }
     }
+
     // In-flight guard: a concurrent terminate already owns this session.
     if (this.terminating.has(sessionId)) {
       return { terminated: false, skipped: 'in-flight' };
@@ -472,6 +559,9 @@ rm()  { "${shimRunner}" rm  "$@"; }
       session.endedReason = reason;
       this.state.saveSession(session);
       this.emit('sessionComplete', session);
+      // The single reap-notification signal (§P3): terminal reaps may reach the
+      // user; recovery-bounce reaps are silent. One emission, at the one chokepoint.
+      this.emit('sessionReaped', { session, reason, disposition, origin });
       this.idlePromptSince.delete(session.id);
       this.reapingSessions.delete(session.id);
       return { terminated: true };
@@ -655,19 +745,17 @@ rm()  { "${shimRunner}" rm  "$@"; }
                   injectedAt: pendingInjection.injectedAt,
                 });
               }
-              console.warn(`[SessionManager] Session "${session.name}" exceeded timeout (${Math.round(elapsed)}m > ${maxMinutes}m) and is idle. Killing.`);
-              // Emit beforeSessionKill BEFORE destroying the tmux session so
-              // listeners (e.g. TopicResumeMap) can discover the Claude UUID.
-              this.emit('beforeSessionKill', session);
-              try {
-                await execFileAsync(this.config.tmuxPath, ['kill-session', '-t', `=${session.tmuxSession}`]);
-              } catch {
-                // @silent-fallback-ok — tmux kill, session may be dead
-              }
-              session.status = 'killed';
-              session.endedAt = new Date().toISOString();
-              this.state.saveSession(session);
-              this.emit('sessionComplete', session);
+              console.warn(`[SessionManager] Session "${session.name}" exceeded timeout (${Math.round(elapsed)}m > ${maxMinutes}m) and is idle. Requesting kill via ReapAuthority.`);
+              // Route through the single ReapAuthority (§P0) instead of an inline
+              // kill: this restores the beforeSessionKill/sessionComplete emission,
+              // adds the sessionReaped signal + reap-log entry, applies the lease
+              // gate, and — critically — gains the P2 KEEP-guard's topic-bound
+              // grace, so a session that just received a user message is not
+              // age-killed out from under the user.
+              await this.terminateSession(session.id, 'age-limit', {
+                finalStatus: 'killed',
+                disposition: 'terminal',
+              });
               continue;
             }
           }
@@ -778,8 +866,11 @@ rm()  { "${shimRunner}" rm  "$@"; }
                 const bindingNote = binding != null ? ` (topic-bound, threshold ${killThresholdMinutes}m)` : ` (threshold ${killThresholdMinutes}m)`;
                 console.warn(`[SessionManager] Session "${session.name}" idle at prompt for ${Math.round(idleMs / 60_000)}m with no active processes${bindingNote}. Killing zombie.`);
                 // Funnel through the single-writer path so the reaper and this
-                // idle-kill can never double-kill or double-emit (§3.6).
-                await this.terminateSession(session.id, 'idle-zombie');
+                // idle-kill can never double-kill or double-emit (§3.6). Explicit
+                // terminal disposition → the §P3 notifier surfaces it to the user.
+                await this.terminateSession(session.id, 'idle-zombie', {
+                  disposition: 'terminal',
+                });
                 continue;
               }
             }
@@ -1416,25 +1507,35 @@ rm()  { "${shimRunner}" rm  "$@"; }
     let purged = 0;
     let kept = 0;
     let indeterminate = 0;
+    let skipped = 0;
     for (const session of running) {
       const v = verdicts.get(session.tmuxSession);
       if (v?.liveness === 'dead') {
-        session.status = 'completed';
-        session.endedAt = new Date().toISOString();
-        session.endedReason = 'boot-purge-dead';
-        this.state.saveSession(session);
-        purged++;
+        // Route through the single ReapAuthority (§P0) so the reap is lease-gated,
+        // recorded in the reap-log, and emits the standard lifecycle events. The
+        // KEEP-guard is bypassed via `knownDead` — the oracle has already proven
+        // this session dead, and the guard's liveness-blind topic-state KEEPs would
+        // otherwise pin a tombstone and re-create the death-spiral.
+        const r = await this.terminateSession(session.id, 'boot-purge-dead', {
+          knownDead: true,
+          finalStatus: 'completed',
+        });
+        if (r.terminated) purged++;
+        else skipped++; // not-lease-holder / protected — recorded, kept for next awake tick
       } else {
         kept++;
         if (v?.liveness === 'indeterminate') indeterminate++;
       }
     }
 
-    if (purged > 0 || indeterminate > 0) {
+    if (purged > 0 || indeterminate > 0 || skipped > 0) {
       console.log(
         `[SessionManager] Startup purge: removed ${purged} dead session(s) of ${running.length} tracked` +
           (indeterminate > 0
             ? ` (${indeterminate} indeterminate — KEPT, will re-verify on the next tick rather than risk a false purge)`
+            : '') +
+          (skipped > 0
+            ? ` (${skipped} dead but not reaped here — standby/protected, deferred to the awake machine)`
             : ''),
       );
     }

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -161,6 +161,9 @@ export class SessionManager extends EventEmitter {
   private activeRecoveryChecker?: (session: Session) => boolean;
   /** Shared stateless KEEP-guard consulted by terminateSession (§P2). */
   private reapGuard?: ReapGuard;
+  /** Sessions the §P5 backstop has flagged long-`indeterminate` — excluded from
+   *  the ABSOLUTE spawn cap so unverifiable panes can't lock out spawning. */
+  private longIndeterminateSessions = new Set<string>();
   /** Multi-machine lease/awake predicate gating autonomous reaps (§Multi-machine). */
   private isAwakeMachine?: () => boolean;
 
@@ -379,6 +382,37 @@ rm()  { "${shimRunner}" rm  "$@"; }
    */
   setReapGuard(guard: ReapGuard): void {
     this.reapGuard = guard;
+  }
+
+  /**
+   * Flag/unflag a session as long-`indeterminate` (UNIFIED-SESSION-LIFECYCLE §P5).
+   * Driven by the StaleSessionBackstop. A flagged session still counts toward the
+   * soft scheduler cap, but is excluded from the ABSOLUTE `maxSessions × 3` cap so
+   * a fleet of unverifiable panes can never lock a human out of spawning.
+   */
+  markLongIndeterminate(sessionId: string, isLong: boolean): void {
+    if (isLong) this.longIndeterminateSessions.add(sessionId);
+    else this.longIndeterminateSessions.delete(sessionId);
+  }
+
+  /**
+   * Resolve tri-state liveness for many sessions from ONE tmux snapshot via the
+   * P1 oracle (UNIFIED-SESSION-LIFECYCLE §P5 backstop). `reachable` is false when
+   * the snapshot was non-authoritative (control plane unreachable) — in which
+   * case every session resolves `indeterminate`. Shares the oracle's short-TTL
+   * cache, so the backstop and boot-purge never double-probe within a tick.
+   */
+  async probeLivenessBatch(
+    tmuxSessions: string[],
+  ): Promise<{ reachable: boolean; liveness: Map<string, 'alive' | 'dead' | 'indeterminate'> }> {
+    const results = await this.livenessOracle.probeAll(tmuxSessions);
+    const liveness = new Map<string, 'alive' | 'dead' | 'indeterminate'>();
+    for (const [name, r] of results) liveness.set(name, r.liveness);
+    // With a single authoritative snapshot, a session is only `indeterminate`
+    // when the whole snapshot was non-authoritative — i.e. the server is
+    // unreachable. So "reachable" ⟺ at least one definitive (alive/dead) verdict.
+    const reachable = tmuxSessions.length === 0 || [...liveness.values()].some((l) => l !== 'indeterminate');
+    return { reachable, liveness };
   }
 
   /**
@@ -1759,7 +1793,12 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // Safety valve: still cap at maxSessions * 3 to prevent runaway sessions.
     const runningSessions = this.listRunningSessions();
     const absoluteLimit = this.config.maxSessions * 3;
-    if (runningSessions.length >= absoluteLimit) {
+    // §P5: exclude long-`indeterminate` sessions (unverifiable panes flagged by the
+    // StaleSessionBackstop) from the ABSOLUTE cap, so a fleet of them can never lock
+    // a human out of spawning — the death-spiral the boot purge guarded against
+    // cannot relocate here.
+    const countable = runningSessions.filter(s => !this.longIndeterminateSessions.has(s.id));
+    if (countable.length >= absoluteLimit) {
       throw new Error(
         `Absolute session limit (${absoluteLimit}) reached. ` +
         `Running: ${runningSessions.map(s => s.name).join(', ')}`

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2745,6 +2745,18 @@ export interface MonitoringConfig {
     protectOpenCommitments?: boolean;
   };
   /**
+   * Reap-notification (UNIFIED-SESSION-LIFECYCLE §P3). The single coalescing
+   * listener on `sessionReaped` that surfaces a "your session was shut down"
+   * notice so a session never silently vanishes. Default ON (the disappearing-
+   * session incident is exactly the silence this closes); recovery-bounce and
+   * operator kills stay silent regardless. Terminal reaps within
+   * `coalesceWindowMs` collapse into one consolidated lifeline message.
+   */
+  reapNotify?: {
+    enabled?: boolean;
+    coalesceWindowMs?: number;
+  };
+  /**
    * Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md) — instar
    * self-hosting dev-process forensics. Ships OFF (registers itself on the
    * rollout board). When enabled, the FailureLedger + /failures routes + the

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -180,6 +180,11 @@ export interface SessionManagerConfig {
   /** Absolute maximum session duration in minutes — safety net for sessions
    *  without an explicit timeout (default: 240) */
   defaultMaxDurationMinutes?: number;
+  /** Tri-state liveness-oracle tuning (UNIFIED-SESSION-LIFECYCLE §P1). Partial —
+   *  unset fields fall back to DEFAULT_LIVENESS_CONFIG. Validated at startup so a
+   *  sub-floor probe timeout (which would re-create the 2026-05-27 false-purge)
+   *  is rejected loudly. */
+  liveness?: Partial<import('./SessionLivenessOracle.js').SessionLivenessOracleConfig>;
 }
 
 // ── Job Scheduling ──────────────────────────────────────────────────

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2757,6 +2757,19 @@ export interface MonitoringConfig {
     coalesceWindowMs?: number;
   };
   /**
+   * Unkillability backstop (UNIFIED-SESSION-LIFECYCLE §P5). Watches for sessions
+   * the conservative KEEP-rules would protect forever — one that FAKES work, or
+   * one stuck `indeterminate` — and raises a SINGLE deduped Attention item for an
+   * operator decision (never an auto-kill). Default ON; signal-only.
+   */
+  staleBackstop?: {
+    enabled?: boolean;
+    tickIntervalSec?: number;
+    unverifiableEscalateMinutes?: number;
+    indeterminateEscalateCount?: number;
+    progressFloorBytes?: number;
+  };
+  /**
    * Failure-Learning Loop (docs/specs/FAILURE-LEARNING-LOOP-SPEC.md) — instar
    * self-hosting dev-process forensics. Ships OFF (registers itself on the
    * rollout board). When enabled, the FailureLedger + /failures routes + the

--- a/src/monitoring/ReapLog.ts
+++ b/src/monitoring/ReapLog.ts
@@ -93,7 +93,9 @@ export class ReapLog {
     try {
       raw = fs.readFileSync(this.logPath, 'utf-8');
     } catch {
-      return []; // no log yet → empty, not an error
+      // @silent-fallback-ok — no log file yet means no reaps recorded; an empty
+      // list is the correct answer, not a degraded one.
+      return [];
     }
     const lines = raw.split('\n').filter((l) => l.trim().length > 0);
     const tail = limit > 0 ? lines.slice(-limit) : lines;

--- a/src/monitoring/ReapLog.ts
+++ b/src/monitoring/ReapLog.ts
@@ -1,0 +1,110 @@
+/**
+ * ReapLog — durable, JSON-encoded audit of every session reap and every
+ * skipped-reap (UNIFIED-SESSION-LIFECYCLE §P4).
+ *
+ * The pull-surface answer to "why did my session vanish?": one line per reap
+ * (`sessionReaped`) and one per refused/skipped terminate (`reapBlocked`), so a
+ * dropped kill (not-lease-holder / protected / a KEEP / in-flight) is never
+ * invisible. Mirrors `sentinel-events.jsonl`: append-only JSONL under
+ * `logs/`, written with JSON.stringify (never raw concat — closes
+ * newline-injection of user-controlled session names / reasons).
+ *
+ * Read-only from the API (`GET /sessions/reap-log`, Bearer-auth). The log never
+ * gates or mutates a session — it only records.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface ReapLogEntry {
+  ts: string;
+  /** 'reaped' = a kill happened; 'skipped' = a terminate was refused/no-op. */
+  type: 'reaped' | 'skipped';
+  session: string;
+  tmuxSession: string;
+  /** The reason the killer requested (e.g. 'idle-zombie', 'age-limit'). */
+  reason: string;
+  disposition?: 'terminal' | 'recovery-bounce';
+  origin?: 'operator' | 'autonomous';
+  /** For 'skipped': why the authority refused (protected / not-lease-holder / a KEEP / in-flight). */
+  skipped?: string;
+  machine?: string;
+}
+
+export class ReapLog {
+  private readonly logPath: string;
+  private readonly machineId?: () => string | undefined;
+
+  constructor(stateDir: string, machineId?: () => string | undefined) {
+    this.logPath = path.join(stateDir, '..', 'logs', 'reap-log.jsonl');
+    this.machineId = machineId;
+  }
+
+  recordReaped(e: {
+    session: string;
+    tmuxSession: string;
+    reason: string;
+    disposition?: 'terminal' | 'recovery-bounce';
+    origin?: 'operator' | 'autonomous';
+  }): void {
+    this.append({
+      ts: new Date().toISOString(),
+      type: 'reaped',
+      session: e.session,
+      tmuxSession: e.tmuxSession,
+      reason: e.reason,
+      disposition: e.disposition,
+      origin: e.origin,
+      machine: this.machineId?.(),
+    });
+  }
+
+  recordSkipped(e: {
+    session: string;
+    tmuxSession: string;
+    reason: string;
+    skipped: string;
+    origin?: 'operator' | 'autonomous';
+  }): void {
+    this.append({
+      ts: new Date().toISOString(),
+      type: 'skipped',
+      session: e.session,
+      tmuxSession: e.tmuxSession,
+      reason: e.reason,
+      skipped: e.skipped,
+      origin: e.origin,
+      machine: this.machineId?.(),
+    });
+  }
+
+  private append(entry: ReapLogEntry): void {
+    try {
+      fs.mkdirSync(path.dirname(this.logPath), { recursive: true });
+      fs.appendFileSync(this.logPath, JSON.stringify(entry) + '\n');
+    } catch {
+      // never throw from the audit sink
+    }
+  }
+
+  /** Read the most-recent `limit` entries (newest last), tolerating partial/corrupt lines. */
+  read(limit = 200): ReapLogEntry[] {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.logPath, 'utf-8');
+    } catch {
+      return []; // no log yet → empty, not an error
+    }
+    const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+    const tail = limit > 0 ? lines.slice(-limit) : lines;
+    const out: ReapLogEntry[] = [];
+    for (const line of tail) {
+      try {
+        out.push(JSON.parse(line) as ReapLogEntry);
+      } catch {
+        // skip a corrupt/partial line rather than failing the whole read
+      }
+    }
+    return out;
+  }
+}

--- a/src/monitoring/ReapNotifier.ts
+++ b/src/monitoring/ReapNotifier.ts
@@ -1,0 +1,138 @@
+/**
+ * ReapNotifier — the single coalescing listener for `sessionReaped`
+ * (UNIFIED-SESSION-LIFECYCLE §P3).
+ *
+ * `SessionManager.terminateSession` emits `sessionReaped` exactly once per kill
+ * at the one chokepoint. This listener turns a TERMINAL reap of a user-facing
+ * session into a "your session was shut down" notice so a session never silently
+ * vanishes (the 2026-05-27 incident). It stays SILENT for:
+ *   - `recovery-bounce` reaps (a kill-to-respawn is a bounce, not a disappearance),
+ *   - `origin:'operator'` reaps (the user clicked kill — telling them is noise).
+ *
+ * Coalescing (SE-7): terminal reaps within a short rolling window collapse onto a
+ * single shared timer. On flush:
+ *   - exactly ONE reap in the window → a per-session notice routed to its bound
+ *     topic (or the lifeline topic if unbound),
+ *   - MORE than one → ONE consolidated lifeline message stating the TOTAL count,
+ *     so a mass-reap burst that overflows the bounded buffer is never
+ *     under-reported (the reap-log P4 has the complete record regardless).
+ *
+ * Sanitization: session names follow user-controlled topic renames, so the
+ * dynamic fields (name, reason) are wrapped as inline-code spans — the downstream
+ * Telegram formatter renders code spans as literal, HTML-escaped text, never
+ * markup. The notifier never emits raw markup around user-controlled values.
+ */
+
+import type { Session } from '../core/types.js';
+
+export interface ReapEvent {
+  session: Pick<Session, 'name' | 'tmuxSession'>;
+  reason: string;
+  disposition?: 'terminal' | 'recovery-bounce';
+  origin?: 'operator' | 'autonomous';
+}
+
+export interface ReapNotifierDeps {
+  /** Bound messaging topic for a session, or null if unbound. */
+  resolveTopic: (tmuxSession: string) => number | null;
+  /** The always-on system/lifeline topic, or null if none is configured. */
+  lifelineTopic: () => number | null;
+  /** Deliver a (GFM) notice to a topic. Wiring decides the transport/tier. */
+  send: (topicId: number, text: string) => void | Promise<void>;
+  now?: () => number;
+}
+
+export interface ReapNotifierOptions {
+  enabled: boolean;
+  coalesceWindowMs: number;
+  /** Max reaps retained for the consolidated-message detail list (count is exact regardless). */
+  maxBuffer: number;
+}
+
+export const DEFAULT_REAP_NOTIFIER_OPTIONS: ReapNotifierOptions = {
+  enabled: true,
+  coalesceWindowMs: 60_000,
+  maxBuffer: 100,
+};
+
+/** Wrap a user-controlled value as a literal inline-code span (never markup). */
+function literal(value: string): string {
+  // Neutralize backticks so the code span can't be broken out of.
+  return '`' + String(value).replace(/`/g, "'") + '`';
+}
+
+export class ReapNotifier {
+  private readonly deps: ReapNotifierDeps;
+  private readonly opts: ReapNotifierOptions;
+  private readonly now: () => number;
+  private timer: NodeJS.Timeout | null = null;
+  private buffer: ReapEvent[] = [];
+  private windowCount = 0;
+
+  constructor(deps: ReapNotifierDeps, opts?: Partial<ReapNotifierOptions>) {
+    this.deps = deps;
+    this.opts = { ...DEFAULT_REAP_NOTIFIER_OPTIONS, ...(opts ?? {}) };
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  /** The `sessionReaped` event handler. */
+  onReaped(event: ReapEvent): void {
+    if (!this.opts.enabled) return;
+    // Silent dispositions/origins: a bounce is not a disappearance, and the user
+    // already knows about their own operator kill.
+    if ((event.disposition ?? 'terminal') !== 'terminal') return;
+    if (event.origin === 'operator') return;
+
+    this.windowCount++;
+    this.buffer.push(event);
+    if (this.buffer.length > this.opts.maxBuffer) this.buffer.shift(); // drop-oldest detail
+
+    if (!this.timer) {
+      this.timer = setTimeout(() => { void this.flush(); }, this.opts.coalesceWindowMs);
+      if (typeof this.timer.unref === 'function') this.timer.unref();
+    }
+  }
+
+  /**
+   * Emit the coalesced notice(s) for the closed window and reset. Public so the
+   * lifecycle (and tests) can drive it deterministically.
+   */
+  async flush(): Promise<void> {
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+    const count = this.windowCount;
+    const detail = this.buffer;
+    this.windowCount = 0;
+    this.buffer = [];
+    if (count === 0) return;
+
+    if (count === 1) {
+      const ev = detail[0];
+      const topic = this.deps.resolveTopic(ev.session.tmuxSession) ?? this.deps.lifelineTopic();
+      if (topic == null) return; // unreachable channel — reap-log (P4) still has it
+      await this.deps.send(topic, this.formatSingle(ev));
+      return;
+    }
+
+    // Burst → ONE consolidated lifeline message stating the exact total count.
+    const topic = this.deps.lifelineTopic();
+    if (topic == null) return;
+    await this.deps.send(topic, this.formatBurst(count, detail));
+  }
+
+  private formatSingle(ev: ReapEvent): string {
+    return `🪦 Session ${literal(ev.session.name)} was shut down — ${literal(ev.reason)}. `
+      + `See the reap-log (\`GET /sessions/reap-log\`) for the full record.`;
+  }
+
+  private formatBurst(count: number, detail: ReapEvent[]): string {
+    const lines = detail.map((e) => `• ${literal(e.session.name)} — ${literal(e.reason)}`);
+    const shownNote = count > detail.length
+      ? `\n\n(showing the latest ${detail.length}; full list in the reap-log)`
+      : '';
+    return `🪦 ${count} session${count === 1 ? '' : 's'} shut down in the last `
+      + `${Math.round(this.opts.coalesceWindowMs / 1000)}s:\n\n`
+      + lines.join('\n')
+      + shownNote
+      + `\n\nFull record: \`GET /sessions/reap-log\`.`;
+  }
+}

--- a/src/monitoring/SessionReaper.ts
+++ b/src/monitoring/SessionReaper.ts
@@ -20,6 +20,7 @@ import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Session } from '../core/types.js';
+import { ReapGuard } from '../core/ReapGuard.js';
 import { getActivitySignal } from './frameworkActivitySignals.js';
 import { probeTranscript, transcriptDelta, type TranscriptProbe } from './transcriptProber.js';
 
@@ -149,11 +150,21 @@ export class SessionReaper extends EventEmitter {
   private autoDisabled = false;
   private lastTickAt = 0;
 
+  /** Shared stateless KEEP-guards (UNIFIED-SESSION-LIFECYCLE §P2). The reaper
+   *  consults this first, then layers its stateful transcript-growth + positive-idle
+   *  checks — so the same guard backs both the reaper and terminateSession(). */
+  private readonly guard: ReapGuard;
+
   constructor(deps: SessionReaperDeps, cfg?: Partial<SessionReaperConfig>) {
     super();
     this.deps = deps;
     this.cfg = { ...DEFAULT_SESSION_REAPER_CONFIG, ...(cfg ?? {}) };
     this.now = deps.now ?? (() => Date.now());
+    this.guard = new ReapGuard(deps, {
+      minAgeMs: this.cfg.minAgeMinutes * 60_000,
+      recentUserWindowMs: this.cfg.recentUserWindowMinutes * 60_000,
+      protectOpenCommitments: this.cfg.protectOpenCommitments,
+    });
   }
 
   start(): void {
@@ -217,40 +228,15 @@ export class SessionReaper extends EventEmitter {
     const keep = (reason: string, confidence: Confidence = 'high'): SessionEvaluation =>
       ({ verdict: 'keep', keptBy: reason, confidence, frame, transcript });
 
-    // A. Protected set
-    if (this.deps.protectedSessions().includes(session.tmuxSession)) return keep('protected');
-    // M. Spawn grace
-    const ageMs = this.now() - Date.parse(session.startedAt);
-    if (!(ageMs >= this.cfg.minAgeMinutes * 60_000)) return keep('spawn-grace');
-    // G. Recovery in flight
-    if (this.deps.isRecoveryActive(session)) return keep('recovery-in-flight');
-    // H. Pending injection / relay lease
-    if (this.deps.hasPendingInjection(session.tmuxSession)) return keep('pending-injection');
-    if (this.deps.isRelayLeaseActive(session.id)) return keep('relay-lease');
+    // ── Stateless KEEP-guards (§P2): protected, spawn-grace, recovery,
+    //    pending-injection, relay-lease, recent-user, open-commitment,
+    //    active-subagent, structural-long-work, active-process, main-process.
+    //    Extracted to the shared ReapGuard so terminateSession() enforces the
+    //    identical chain. Order + reasons preserved exactly. ──
+    const blocked = this.guard.blockedReason(session);
+    if (blocked) return keep(blocked.reason, blocked.confidence);
 
-    const topicId = this.deps.topicBinding(session.tmuxSession);
-    // I. Recent user interaction (topic unresolved while bound → cannot tell → KEEP)
-    if (topicId != null && this.deps.recentUserMessage(topicId, this.cfg.recentUserWindowMinutes * 60_000)) {
-      return keep('recent-user-message');
-    }
-    // J. Open commitment on the bound topic
-    if (this.cfg.protectOpenCommitments && topicId != null && this.deps.activeCommitmentForTopic(topicId)) {
-      return keep('open-commitment');
-    }
-    // K. Active subagent
-    if (this.deps.activeSubagentCount(session.claudeSessionId) > 0) return keep('active-subagent');
-    // L. Structural long-work (build/autonomous) on the topic/project
-    if (this.deps.buildOrAutonomousActive(topicId)) return keep('structural-long-work');
-
-    // ── Activeness (positive-evidence) ──
-    // C. Process tree: any non-baseline child ⇒ working.
-    if (this.deps.hasActiveProcesses(session.tmuxSession)) return keep('active-process');
-    // C(main): main-process CPU/IO delta. undefined ⇒ cannot inspect ⇒ KEEP.
-    if (this.deps.mainProcessActive) {
-      const mp = this.deps.mainProcessActive(session.tmuxSession);
-      if (mp === undefined) return keep('process-uninspectable', 'low');
-      if (mp === true) return keep('main-process-active');
-    }
+    // ── Stateful checks (stay in the reaper; need per-tick obs / captured frame) ──
     // E. Transcript growth this tick (vs last tick). 'grew' ⇒ working;
     //    'unknown' (unresolved/rotated) ⇒ KEEP.
     const prev = this.obs.get(session.id)?.lastTranscript;

--- a/src/monitoring/StaleSessionBackstop.ts
+++ b/src/monitoring/StaleSessionBackstop.ts
@@ -1,0 +1,242 @@
+/**
+ * StaleSessionBackstop — the unkillability backstop (UNIFIED-SESSION-LIFECYCLE §P5).
+ *
+ * Rules 1–2 of the robustness bar are deliberately conservative ("can't tell"
+ * never means "dead"). That creates a dual risk the round-1 review surfaced:
+ *   (a) a session that FAKES work (a tight CPU loop, or a transcript that appends
+ *       a heartbeat byte every few minutes) is KEPT by every killer forever;
+ *   (b) a session stuck `indeterminate` forever leaks a slot.
+ * Both are resolved by a single staleness escalation — NEVER an auto-kill. After
+ * M minutes of no-forward-progress, or N consecutive `indeterminate` probes, ONE
+ * deduped Attention-queue item is raised for an operator decision
+ * (investigate / force-kill?). Dedupe is per EPISODE (a recovered session that
+ * later goes stale again raises a fresh item).
+ *
+ * Forward progress is NOT raw byte growth — a wedged session that appends a
+ * heartbeat byte would defeat a naive "any growth" gate forever (exactly the
+ * absence-of-signal inference rule 2 forbids). "Progress" = ANY of:
+ *   (i)   a MEANINGFUL transcript advance: delta ≥ progressFloorBytes AND the new
+ *         tail differs from the prior tail (guards the heartbeat/loop case),
+ *   (ii)  main-process CPU above an idle floor,
+ *   (iii) a change in the positive-idle / prompt state.
+ *
+ * A server-unreachable `indeterminate` raises ONE GLOBAL "tmux control-plane
+ * unreachable" item (not one per session) — anti-flood. Long-`indeterminate`
+ * sessions are flagged so the spawn-path can exclude them from the ABSOLUTE
+ * session cap, so a fleet of unverifiable panes can never lock a human out of
+ * spawning (the death-spiral cannot relocate here).
+ *
+ * Signal-only: this backstop never ends a session. It only observes and asks.
+ */
+
+import type { Session } from '../core/types.js';
+import type { AttentionPoster } from './sentinelWiring.js';
+
+export type Liveness = 'alive' | 'dead' | 'indeterminate';
+
+/** A per-tick forward-progress probe for one session. */
+export interface ProgressSnapshot {
+  /** Whether the transcript path resolved + statted (false ⇒ ambiguous). */
+  transcriptResolved: boolean;
+  /** Transcript size in bytes (0 when unresolved). */
+  transcriptSize: number;
+  /** Hash of the last `progressFloorBytes` of the transcript (null when unresolved/short). */
+  transcriptTailHash: string | null;
+  /** Main-process CPU/IO above an idle floor. `undefined` ⇒ uninspectable. */
+  mainProcessActive: boolean | undefined;
+  /** Opaque token for the positive-idle / prompt state — ANY change ⇒ progress. */
+  idleStateToken: string;
+}
+
+export interface LivenessBatch {
+  /** False ⇒ the tmux control plane is unreachable (no authoritative snapshot). */
+  reachable: boolean;
+  /** Per-session tri-state liveness keyed by tmux session name. */
+  liveness: Map<string, Liveness>;
+}
+
+export interface StaleBackstopDeps {
+  listRunningSessions: () => Session[];
+  /** ONE batch probe per tick (mirrors the boot-purge single-snapshot path). */
+  probeLiveness: (tmuxSessions: string[]) => Promise<LivenessBatch> | LivenessBatch;
+  snapshot: (session: Session) => ProgressSnapshot;
+  raiseAttention: AttentionPoster;
+  /** Flag/unflag a session as long-`indeterminate` for the spawn absolute-cap exclusion. */
+  setLongIndeterminate?: (sessionId: string, isLong: boolean) => void;
+  now?: () => number;
+}
+
+export interface StaleBackstopOptions {
+  enabled: boolean;
+  tickIntervalSec: number;
+  unverifiableEscalateMinutes: number;
+  indeterminateEscalateCount: number;
+  progressFloorBytes: number;
+}
+
+export const DEFAULT_STALE_BACKSTOP_OPTIONS: StaleBackstopOptions = {
+  enabled: true,
+  tickIntervalSec: 120,
+  unverifiableEscalateMinutes: 30,
+  indeterminateEscalateCount: 15,
+  progressFloorBytes: 512,
+};
+
+interface Obs {
+  lastSnapshot: ProgressSnapshot | null;
+  lastProgressAt: number;
+  indeterminateStreak: number;
+  episodeActive: boolean;
+  episodeSeq: number;
+}
+
+export class StaleSessionBackstop {
+  private readonly deps: StaleBackstopDeps;
+  private readonly opts: StaleBackstopOptions;
+  private readonly now: () => number;
+  private timer: NodeJS.Timeout | null = null;
+  private obs = new Map<string, Obs>();
+  private globalUnreachable = false;
+  private globalUnreachableSeq = 0;
+
+  constructor(deps: StaleBackstopDeps, opts?: Partial<StaleBackstopOptions>) {
+    this.deps = deps;
+    this.opts = { ...DEFAULT_STALE_BACKSTOP_OPTIONS, ...(opts ?? {}) };
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  start(): void {
+    if (this.timer || !this.opts.enabled) return;
+    this.timer = setInterval(() => { void this.tick(); }, this.opts.tickIntervalSec * 1000);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+  }
+
+  private obsFor(id: string): Obs {
+    let o = this.obs.get(id);
+    if (!o) {
+      o = { lastSnapshot: null, lastProgressAt: this.now(), indeterminateStreak: 0, episodeActive: false, episodeSeq: 0 };
+      this.obs.set(id, o);
+    }
+    return o;
+  }
+
+  /** Run one observation pass. Public so the lifecycle (and tests) can drive it. */
+  async tick(): Promise<void> {
+    if (!this.opts.enabled) return;
+
+    const running = this.deps.listRunningSessions();
+    const batch = await this.deps.probeLiveness(running.map((s) => s.tmuxSession));
+
+    // Control-plane unreachable: ONE global item, never per-session (anti-flood).
+    if (!batch.reachable) {
+      if (!this.globalUnreachable) {
+        this.globalUnreachable = true;
+        this.globalUnreachableSeq++;
+        await this.deps.raiseAttention({
+          id: `stale-tmux-unreachable-${this.globalUnreachableSeq}`,
+          title: 'tmux control plane unreachable',
+          summary:
+            'The tmux server is not answering, so no session can be verified alive or dead. '
+            + 'Sessions are being KEPT (never auto-killed on doubt). Investigate the tmux server / host.',
+          category: 'degradation',
+          priority: 'HIGH',
+        });
+      }
+      return; // do not advance per-session episodes while blind
+    }
+    this.globalUnreachable = false;
+
+    const liveIds = new Set(running.map((s) => s.id));
+    for (const session of running) {
+      const v = batch.liveness.get(session.tmuxSession) ?? 'indeterminate';
+      const o = this.obsFor(session.id);
+
+      if (v === 'dead') {
+        // A dead session is the reapers' business; clear our state for it.
+        this.clear(session.id);
+        continue;
+      }
+
+      if (v === 'indeterminate') {
+        o.indeterminateStreak++;
+        const isLong = o.indeterminateStreak >= this.opts.indeterminateEscalateCount;
+        this.deps.setLongIndeterminate?.(session.id, isLong);
+        if (isLong && !o.episodeActive) {
+          o.episodeActive = true;
+          o.episodeSeq++;
+          await this.escalateSession(session, o, `unverifiable: ${o.indeterminateStreak} consecutive indeterminate probes`);
+        }
+        continue;
+      }
+
+      // v === 'alive' — verifiable again.
+      o.indeterminateStreak = 0;
+      this.deps.setLongIndeterminate?.(session.id, false);
+      const cur = this.deps.snapshot(session);
+      const prev = o.lastSnapshot;
+      o.lastSnapshot = cur;
+      if (!prev) {
+        // First sighting — establish the baseline, treat as progress.
+        o.lastProgressAt = this.now();
+        continue;
+      }
+      if (this.hasForwardProgress(prev, cur)) {
+        o.lastProgressAt = this.now();
+        o.episodeActive = false; // recovered — a future stall is a new episode
+        continue;
+      }
+      const stalledMs = this.now() - o.lastProgressAt;
+      if (stalledMs >= this.opts.unverifiableEscalateMinutes * 60_000 && !o.episodeActive) {
+        o.episodeActive = true;
+        o.episodeSeq++;
+        await this.escalateSession(
+          session, o,
+          `no forward progress for ${Math.round(stalledMs / 60_000)} min (transcript static + no CPU + no prompt change) — may be faking work`,
+        );
+      }
+    }
+
+    // Drop obs for sessions that are gone.
+    for (const id of [...this.obs.keys()]) {
+      if (!liveIds.has(id)) this.clear(id);
+    }
+  }
+
+  private hasForwardProgress(prev: ProgressSnapshot, cur: ProgressSnapshot): boolean {
+    // (i) Meaningful transcript advance — guards the heartbeat/loop case.
+    if (
+      prev.transcriptResolved && cur.transcriptResolved &&
+      cur.transcriptSize - prev.transcriptSize >= this.opts.progressFloorBytes &&
+      cur.transcriptTailHash != null && cur.transcriptTailHash !== prev.transcriptTailHash
+    ) {
+      return true;
+    }
+    // (ii) Main process doing CPU/IO work. `undefined` (uninspectable) is NOT progress
+    //      here — the escalation is a question to the operator, never a kill, so erring
+    //      toward "ask" on a truly-uninspectable session is safe.
+    if (cur.mainProcessActive === true) return true;
+    // (iii) Positive-idle / prompt state changed.
+    if (cur.idleStateToken !== prev.idleStateToken) return true;
+    return false;
+  }
+
+  private async escalateSession(session: Session, o: Obs, detail: string): Promise<void> {
+    await this.deps.raiseAttention({
+      id: `stale-${session.id}-${o.episodeSeq}`,
+      title: `Session "${session.name}" is stale but unkillable`,
+      summary:
+        `${detail}. It is being KEPT (never auto-killed), but it may be wedged or holding a slot. `
+        + `Investigate, or force-kill it from the dashboard if it's genuinely stuck.`,
+      category: 'degradation',
+      priority: 'HIGH',
+    });
+  }
+
+  private clear(id: string): void {
+    if (this.obs.delete(id)) this.deps.setLongIndeterminate?.(id, false);
+  }
+}

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -410,6 +410,11 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - Enable (after reviewing the dry-run log): in \`.instar/config.json\` set \`{"monitoring": {"sessionReaper": {"enabled": true, "dryRun": false}}}\`. Leave \`dryRun: true\` first to watch what it WOULD reap (logged to \`logs/sentinel-events.jsonl\`) without killing anything.
 - Proactive: user asks "why are sessions piling up?" / "clean up idle sessions" / "are we low on memory?" → GET /sessions/reaper for the pressure tier + per-session verdict.
 
+**Reap-log** — The durable "why did my session vanish?" answer. EVERY session shutoff (and every refused/skipped shutoff — protected, not-lease-holder, a KEEP-guard hold, in-flight) is recorded as one JSON line, so a session never disappears without a trace. Distinct from /sessions/reaper (which shows live verdicts): the reap-log is the historical record of what actually happened.
+- Read it: \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/sessions/reap-log?limit=50"\` → \`{ entries: [{ ts, type:'reaped'|'skipped', session, reason, disposition, origin, skipped?, machine? }] }\`. Read-only.
+- Also: when a session is autonomously shut down, you get a "your session was shut down — <reason>" notice (recovery-bounces and your own operator kills stay silent). Turn the notice off with \`{"monitoring": {"reapNotify": {"enabled": false}}}\`.
+- Proactive: user asks "where did my session go?" / "why did X disappear?" / "did something get killed?" → GET /sessions/reap-log and explain the most recent reaped/skipped entries for that session.
+
 **Multi-Session Autonomy** — I can run multiple autonomous jobs at once, one per topic (default cap 5, set \`autonomousSessions.maxConcurrent\` in config). Each topic's job is isolated, survives restarts, and is keyed on its topic.
 - What's running: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/autonomous/sessions\`
 - The cap + budget gate is checked automatically when a job starts (\`GET /autonomous/can-start\`); a start is refused when at the cap or under budget pressure.

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -317,6 +317,9 @@ export class AgentServer {
     /** SessionReaper — pressure-aware idle-session reaper (off/dry-run by
      *  default). Powers GET /sessions/reaper. */
     sessionReaper?: import('../monitoring/SessionReaper.js').SessionReaper;
+    /** ReapLog — durable audit of every reap + skipped-reap (UNIFIED-SESSION-LIFECYCLE
+     *  §P4). Powers GET /sessions/reap-log. */
+    reapLog?: import('../monitoring/ReapLog.js').ReapLog;
     /** Threadline → Telegram bridge config — toggles + allow/deny list. */
     telegramBridgeConfig?: import('../threadline/TelegramBridgeConfig.js').TelegramBridgeConfig;
     /** Threadline → Telegram bridge — relay-only mirror of threadline messages. */
@@ -729,6 +732,7 @@ export class AgentServer {
       failureLedger: this.failureLedger,
       failureAttributionEngine: this.failureAttributionEngine,
       sessionReaper: options.sessionReaper ?? null,
+      reapLog: options.reapLog ?? null,
       telegramBridgeConfig: options.telegramBridgeConfig ?? null,
       telegramBridge: options.telegramBridge ?? null,
       threadlineObservability: options.threadlineObservability ?? null,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -694,6 +694,7 @@ export interface RouteContext {
   /** SessionReaper — pressure-aware idle-session reaper. Null when not wired
    *  (older boot paths). Powers GET /sessions/reaper observability. */
   sessionReaper?: import('../monitoring/SessionReaper.js').SessionReaper | null;
+  reapLog?: import('../monitoring/ReapLog.js').ReapLog | null;
   /** TaskFlow registry — durable multi-step job records (OpenClaw import).
    *  Null when not enabled. Phase 1: no business consumers; admin endpoints
    *  only. */
@@ -3831,6 +3832,20 @@ export function createRoutes(ctx: RouteContext): Router {
       return;
     }
     res.json(ctx.sessionReaper.snapshot());
+  });
+
+  // Reap-log (UNIFIED-SESSION-LIFECYCLE §P4). The pull-surface answer to "why did
+  // my session vanish?": every reap + every refused/skipped terminate, newest
+  // last. Read-only, Bearer-auth (the router-level middleware). `?limit=N`
+  // bounds the tail (default 200).
+  router.get('/sessions/reap-log', (req, res) => {
+    if (!ctx.reapLog) {
+      res.status(503).json({ error: 'reap-log unavailable' });
+      return;
+    }
+    const rawLimit = Number(req.query.limit);
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(Math.floor(rawLimit), 1000) : 200;
+    res.json({ entries: ctx.reapLog.read(limit) });
   });
 
   router.get('/sessions', (req, res) => {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -4066,25 +4066,34 @@ export function createRoutes(ctx: RouteContext): Router {
     }, 500);
   });
 
-  router.delete('/sessions/:id', (req, res) => {
+  router.delete('/sessions/:id', async (req, res) => {
     if (!SESSION_NAME_RE.test(req.params.id)) {
       res.status(400).json({ error: 'Invalid session ID format' });
       return;
     }
     try {
-      // Try direct UUID lookup first, then fall back to tmux session name lookup.
-      // The dashboard sends tmux session names, not UUIDs.
-      let killed = ctx.sessionManager.killSession(req.params.id);
-      if (!killed) {
-        // Look up by tmux session name
+      // Operator kill — stamped origin:'operator' so it bypasses the autonomous
+      // ReapAuthority gates (protected / lease / KEEP-guard) and ALWAYS happens
+      // (the user clicked "kill"). Routing through terminateSession (rather than
+      // the raw killSession) gives the reap-log + lifecycle events the §P4 surface
+      // depends on. (UNIFIED-SESSION-LIFECYCLE §P0.)
+      // Try direct UUID lookup first, then fall back to tmux session name lookup —
+      // the dashboard sends tmux session names, not UUIDs.
+      let target = ctx.state.getSession(req.params.id);
+      if (!target) {
         const allSessions = ctx.state.listSessions({ status: 'running' });
-        const match = allSessions.find(s => s.tmuxSession === req.params.id);
-        if (match) {
-          killed = ctx.sessionManager.killSession(match.id);
-        }
+        target = allSessions.find(s => s.tmuxSession === req.params.id) ?? null;
       }
-      if (!killed) {
+      if (!target) {
         res.status(404).json({ error: `Session "${req.params.id}" not found` });
+        return;
+      }
+      const result = await ctx.sessionManager.terminateSession(target.id, 'operator-kill', {
+        origin: 'operator',
+        finalStatus: 'killed',
+      });
+      if (!result.terminated) {
+        res.status(404).json({ error: `Session "${req.params.id}" not found`, skipped: result.skipped });
         return;
       }
       res.json({ ok: true, killed: req.params.id });

--- a/tests/e2e/reap-log-lifecycle.test.ts
+++ b/tests/e2e/reap-log-lifecycle.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tier-3 E2E "feature is alive" lifecycle test for the reap-log
+ * (UNIFIED-SESSION-LIFECYCLE §P4).
+ *
+ * Per TESTING-INTEGRITY-SPEC: the single most important test for a feature with
+ * API routes — is it actually alive on the production init path (returns 200,
+ * not 503)? This boots the REAL AgentServer (same path server.ts uses) with a
+ * ReapLog wired, and verifies:
+ *   1. GET /sessions/reap-log returns 200 (not 503) when the log is wired.
+ *   2. A recorded reap surfaces end-to-end through the live HTTP route.
+ *   3. The route requires Bearer auth.
+ *   4. The route is read-only (POST/DELETE not registered → 404).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { ReapLog } from '../../src/monitoring/ReapLog.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+describe('Reap-log E2E lifecycle (feature is alive)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+  let reapLog: ReapLog;
+  const AUTH = 'test-e2e-reap-log';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reaplog-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+
+    const config: InstarConfig = {
+      projectName: 'e2e', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH,
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    } as InstarConfig;
+
+    reapLog = new ReapLog(stateDir, () => 'e2e-machine');
+    reapLog.recordReaped({ session: 'sess-x', tmuxSession: 'tx', reason: 'idle-zombie', disposition: 'terminal', origin: 'autonomous' });
+    reapLog.recordSkipped({ session: 'sess-y', tmuxSession: 'ty', reason: 'age-limit', skipped: 'not-lease-holder', origin: 'autonomous' });
+
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir), reapLog });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/reap-log-lifecycle.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('GET /sessions/reap-log is alive (200, not 503) and surfaces recorded entries', async () => {
+    const res = await request(app).get('/sessions/reap-log').set(auth());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.entries)).toBe(true);
+    expect(res.body.entries).toHaveLength(2);
+    expect(res.body.entries[0]).toMatchObject({ type: 'reaped', session: 'sess-x', reason: 'idle-zombie', machine: 'e2e-machine' });
+    expect(res.body.entries[1]).toMatchObject({ type: 'skipped', skipped: 'not-lease-holder' });
+  });
+
+  it('requires Bearer auth', async () => {
+    const res = await request(app).get('/sessions/reap-log');
+    expect(res.status).toBe(401);
+  });
+
+  it('is read-only — POST/DELETE are not registered (404)', async () => {
+    expect((await request(app).post('/sessions/reap-log').set(auth())).status).toBe(404);
+    expect((await request(app).delete('/sessions/reap-log').set(auth())).status).toBe(404);
+  });
+});

--- a/tests/integration/reap-log-route.test.ts
+++ b/tests/integration/reap-log-route.test.ts
@@ -1,0 +1,81 @@
+/**
+ * GET /sessions/reap-log through the real createRoutes pipeline (§P4).
+ *  - 503 when the reap-log is not wired.
+ *  - 200 with recorded reaped/skipped entries when present.
+ *  - read-only (no write methods), ?limit bounds the tail.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes, type RouteContext } from '../../src/server/routes.js';
+import { ReapLog } from '../../src/monitoring/ReapLog.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function ctxWith(stateDir: string, reapLog: ReapLog | null): RouteContext {
+  return {
+    config: { projectName: 'test', projectDir: path.dirname(stateDir), stateDir, port: 0, sessions: {} as any, scheduler: {} as any } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null, listSessions: () => [] } as any,
+    tokenLedger: null,
+    reapLog,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+describe('GET /sessions/reap-log (integration §P4)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reaplog-route-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/reap-log-route.test.ts' });
+  });
+
+  function appWith(reapLog: ReapLog | null): express.Express {
+    const app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctxWith(stateDir, reapLog)));
+    return app;
+  }
+
+  it('returns 503 when the reap-log is not wired', async () => {
+    const res = await request(appWith(null)).get('/sessions/reap-log');
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/unavailable/);
+  });
+
+  it('returns 200 with recorded reaped + skipped entries', async () => {
+    const log = new ReapLog(stateDir, () => 'm1');
+    log.recordReaped({ session: 'sess-a', tmuxSession: 'ta', reason: 'idle-zombie', disposition: 'terminal', origin: 'autonomous' });
+    log.recordSkipped({ session: 'sess-b', tmuxSession: 'tb', reason: 'age-limit', skipped: 'protected', origin: 'autonomous' });
+
+    const res = await request(appWith(log)).get('/sessions/reap-log');
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(2);
+    expect(res.body.entries[0]).toMatchObject({ type: 'reaped', session: 'sess-a', reason: 'idle-zombie' });
+    expect(res.body.entries[1]).toMatchObject({ type: 'skipped', skipped: 'protected' });
+  });
+
+  it('honours ?limit by returning only the most-recent N', async () => {
+    const log = new ReapLog(stateDir);
+    for (let i = 0; i < 8; i++) log.recordReaped({ session: `s${i}`, tmuxSession: `t${i}`, reason: 'idle-zombie' });
+    const res = await request(appWith(log)).get('/sessions/reap-log?limit=3');
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(3);
+    expect(res.body.entries.map((e: { session: string }) => e.session)).toEqual(['s5', 's6', 's7']);
+  });
+
+  it('is read-only — POST/PUT/DELETE are not registered', async () => {
+    const app = appWith(new ReapLog(stateDir));
+    expect((await request(app).post('/sessions/reap-log')).status).toBe(404);
+    expect((await request(app).delete('/sessions/reap-log')).status).toBe(404);
+  });
+});

--- a/tests/integration/session-lifecycle-reap-wiring.test.ts
+++ b/tests/integration/session-lifecycle-reap-wiring.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Event-path integration for UNIFIED-SESSION-LIFECYCLE P0/P3/P4: a real
+ * SessionManager with its terminateSession authority wired (as server.ts does)
+ * to a ReapGuard + ReapNotifier + ReapLog. Proves, through the real emit path:
+ *  - an autonomous terminal reap → reap-log 'reaped' + exactly one user notice;
+ *  - a recovery-bounce reap → logged but SILENT;
+ *  - an operator reap → logged but SILENT, and bypasses guard + protected;
+ *  - a guarded (relay-lease) session → terminate refused, logged 'skipped', survives;
+ *  - a standby (non-lease-holder) → terminate refused, survives;
+ *  - a protected session → autonomous reap refused, survives.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const mockTmuxSessions = new Set<string>();
+vi.mock('node:child_process', () => {
+  const handle = (args?: string[]) => {
+    if (!args) return '';
+    if (args[0] === 'new-session') {
+      const sIdx = args.indexOf('-s');
+      if (sIdx >= 0 && args[sIdx + 1]) mockTmuxSessions.add(args[sIdx + 1]);
+      return '';
+    }
+    if (args[0] === 'kill-session') {
+      const target = args[2]?.replace(/^=/, '');
+      if (target) mockTmuxSessions.delete(target);
+      return '';
+    }
+    if (args[0] === 'has-session') {
+      const target = args[2]?.replace(/^=/, '');
+      if (target && !mockTmuxSessions.has(target)) throw new Error('no session');
+      return '';
+    }
+    return '';
+  };
+  return {
+    execFileSync: vi.fn().mockImplementation((_c: string, args?: string[]) => handle(args)),
+    execFile: vi.fn().mockImplementation(
+      (_c: string, args: string[], _o: unknown, cb?: (e: Error | null, r: { stdout: string }) => void) => {
+        if (typeof _o === 'function') cb = _o as typeof cb;
+        try { const out = handle(args); if (cb) cb(null, { stdout: String(out) }); }
+        catch (e) { if (cb) cb(e as Error, { stdout: '' }); }
+      },
+    ),
+  };
+});
+
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { ReapGuard } from '../../src/core/ReapGuard.js';
+import { ReapNotifier } from '../../src/monitoring/ReapNotifier.js';
+import { ReapLog } from '../../src/monitoring/ReapLog.js';
+import type { SessionManagerConfig, Session } from '../../src/core/types.js';
+
+describe('session-lifecycle reap wiring (integration)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let state: StateManager;
+  let manager: SessionManager;
+  let log: ReapLog;
+  let notices: Array<{ topicId: number; text: string }>;
+  let notifier: ReapNotifier;
+  let awake = true;
+  let relayLeased: string | null = null;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reap-wiring-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    state = new StateManager(path.join(stateDir, 'state'));
+    const config: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux', claudePath: '/usr/local/bin/claude', projectDir: tmpDir,
+      maxSessions: 5, protectedSessions: ['proj-server'], completionPatterns: ['done'],
+    };
+    manager = new SessionManager(config, state);
+    mockTmuxSessions.clear();
+    awake = true; relayLeased = null;
+
+    const guard = new ReapGuard(
+      {
+        protectedSessions: () => ['proj-server'],
+        isRecoveryActive: () => false,
+        hasPendingInjection: () => false,
+        isRelayLeaseActive: (id) => id === relayLeased,
+        topicBinding: () => null,
+        recentUserMessage: () => false,
+        activeCommitmentForTopic: () => false,
+        activeSubagentCount: () => 0,
+        buildOrAutonomousActive: () => false,
+        hasActiveProcesses: () => false,
+      },
+      { minAgeMs: 0 },
+    );
+    manager.setReapGuard(guard);
+    manager.setAwakeChecker(() => awake);
+
+    log = new ReapLog(stateDir, () => 'm1');
+    notices = [];
+    notifier = new ReapNotifier(
+      { resolveTopic: () => null, lifelineTopic: () => 555, send: (topicId, text) => { notices.push({ topicId, text }); } },
+      { enabled: true, coalesceWindowMs: 60_000, maxBuffer: 100 },
+    );
+
+    manager.on('sessionReaped', (e: { session: Session; reason: string; disposition?: 'terminal' | 'recovery-bounce'; origin?: 'operator' | 'autonomous' }) => {
+      log.recordReaped({ session: e.session.name, tmuxSession: e.session.tmuxSession, reason: e.reason, disposition: e.disposition, origin: e.origin });
+      notifier.onReaped({ session: e.session, reason: e.reason, disposition: e.disposition, origin: e.origin });
+    });
+    manager.on('reapBlocked', (e: { session: Session; reason: string; skipped: string; origin?: 'operator' | 'autonomous' }) => {
+      log.recordSkipped({ session: e.session.name, tmuxSession: e.session.tmuxSession, reason: e.reason, skipped: e.skipped, origin: e.origin });
+    });
+  });
+
+  afterEach(() => {
+    manager.stopMonitoring();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/session-lifecycle-reap-wiring.test.ts' });
+  });
+
+  const spawn = (name: string) => manager.spawnSession({ name, prompt: 'p' });
+
+  it('autonomous terminal reap → logged "reaped" + exactly one user notice', async () => {
+    const s = await spawn('job-a');
+    const r = await manager.terminateSession(s.id, 'idle-zombie', { disposition: 'terminal' });
+    expect(r.terminated).toBe(true);
+    await notifier.flush();
+    expect(notices).toHaveLength(1);
+    expect(notices[0].text).toContain('job-a');
+    const entries = log.read();
+    expect(entries.at(-1)).toMatchObject({ type: 'reaped', session: 'job-a', reason: 'idle-zombie', disposition: 'terminal' });
+  });
+
+  it('recovery-bounce reap → logged but SILENT', async () => {
+    const s = await spawn('job-b');
+    await manager.terminateSession(s.id, 'context-exhaustion', { disposition: 'recovery-bounce' });
+    await notifier.flush();
+    expect(notices).toHaveLength(0);
+    expect(log.read().at(-1)).toMatchObject({ type: 'reaped', disposition: 'recovery-bounce' });
+  });
+
+  it('operator reap → logged, SILENT, and bypasses guard + protected', async () => {
+    // Protected + relay-leased: an autonomous reap would be refused twice over,
+    // but an operator kill must always happen.
+    relayLeased = 'will-set';
+    const protectedSession: Session = {
+      id: 'op-1', name: 'proj-server', status: 'running', tmuxSession: 'proj-server',
+      startedAt: new Date().toISOString(), prompt: 'p',
+    } as Session;
+    state.saveSession(protectedSession);
+    mockTmuxSessions.add('proj-server');
+    const r = await manager.terminateSession('op-1', 'operator-kill', { origin: 'operator', finalStatus: 'killed' });
+    expect(r.terminated).toBe(true);
+    await notifier.flush();
+    expect(notices).toHaveLength(0); // operator kills are silent
+    expect(log.read().at(-1)).toMatchObject({ type: 'reaped', origin: 'operator' });
+    expect(state.getSession('op-1')!.status).toBe('killed');
+  });
+
+  it('guarded (relay-lease) session → refused, logged "skipped", survives', async () => {
+    const s = await spawn('job-c');
+    relayLeased = s.id;
+    const r = await manager.terminateSession(s.id, 'idle-zombie');
+    expect(r.terminated).toBe(false);
+    expect(r.skipped).toBe('relay-lease');
+    expect(state.getSession(s.id)!.status).toBe('running'); // survived
+    await notifier.flush();
+    expect(notices).toHaveLength(0);
+    expect(log.read().at(-1)).toMatchObject({ type: 'skipped', skipped: 'relay-lease' });
+  });
+
+  it('standby machine (non-lease-holder) → refused, survives, logged "skipped"', async () => {
+    const s = await spawn('job-d');
+    awake = false;
+    const r = await manager.terminateSession(s.id, 'idle-zombie');
+    expect(r.terminated).toBe(false);
+    expect(r.skipped).toBe('not-lease-holder');
+    expect(state.getSession(s.id)!.status).toBe('running');
+    expect(log.read().at(-1)).toMatchObject({ type: 'skipped', skipped: 'not-lease-holder' });
+  });
+
+  it('protected session → autonomous reap refused, survives', async () => {
+    const protectedSession: Session = {
+      id: 'prot-1', name: 'proj-server', status: 'running', tmuxSession: 'proj-server',
+      startedAt: new Date().toISOString(), prompt: 'p',
+    } as Session;
+    state.saveSession(protectedSession);
+    const r = await manager.terminateSession('prot-1', 'idle-zombie');
+    expect(r.terminated).toBe(false);
+    expect(r.skipped).toBe('protected');
+    expect(state.getSession('prot-1')!.status).toBe('running');
+    expect(log.read().at(-1)).toMatchObject({ type: 'skipped', skipped: 'protected' });
+  });
+});

--- a/tests/unit/death-spiral-fixes.test.ts
+++ b/tests/unit/death-spiral-fixes.test.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { SessionManager } from '../../src/core/SessionManager.js';
+import { SessionLivenessOracle, type SessionLivenessOracleDeps } from '../../src/core/SessionLivenessOracle.js';
 import { CoherenceMonitor } from '../../src/monitoring/CoherenceMonitor.js';
 import { ProcessIntegrity } from '../../src/core/ProcessIntegrity.js';
 import type { StateManager } from '../../src/core/StateManager.js';
@@ -129,48 +130,81 @@ describe('Non-blocking health endpoint (cached sessions)', () => {
 
 // ── Test Suite 2: Startup Session Purge ────────────────────────────
 
-describe('Startup session purge (purgeDeadSessions)', () => {
+describe('Startup session purge (purgeDeadSessions) — oracle-backed, UNIFIED-SESSION-LIFECYCLE §P1', () => {
+  /** Inject a liveness oracle whose `tmux list-sessions` returns `liveNames`, or
+   *  fails (timeout/unreachable → indeterminate) when `fail` is set. */
+  function injectOracle(sm: SessionManager, opts: { liveNames?: string[]; fail?: 'timeout' | 'error' }) {
+    const exec = vi.fn(async () => {
+      if (opts.fail === 'timeout') {
+        const e = new Error('timed out') as Error & { killed: boolean; signal: string };
+        e.killed = true; e.signal = 'SIGTERM';
+        throw e;
+      }
+      if (opts.fail === 'error') throw new Error('EPIPE');
+      return { stdout: (opts.liveNames ?? []).join('\n') + '\n', stderr: '' };
+    });
+    const deps: SessionLivenessOracleDeps = {
+      tmuxPath: '/usr/bin/tmux',
+      exec: exec as unknown as SessionLivenessOracleDeps['exec'],
+    };
+    sm.setLivenessOracle(new SessionLivenessOracle(deps, { probeBackoffMs: 0, probeRetries: 1 }));
+    return exec;
+  }
+
   it('returns 0 when no running sessions exist', async () => {
     const state = createMockState();
     const sm = new SessionManager(createSessionManagerConfig(), state);
-
-    const purged = await sm.purgeDeadSessions();
-    expect(purged).toBe(0);
+    expect(await sm.purgeDeadSessions()).toBe(0);
   });
 
-  it('purges sessions whose tmux session does not exist', async () => {
-    const sessions = [
-      makeSession('s1', 'dead-session-1'),
-      makeSession('s2', 'dead-session-2'),
-    ];
+  it('purges sessions that are DEFINITIVELY dead (server reachable, exact id absent)', async () => {
+    const sessions = [makeSession('s1', 'dead-1'), makeSession('s2', 'dead-2')];
     const state = createMockState(sessions);
-
-    // Use a tmux path that won't find any sessions
-    const config = createSessionManagerConfig({ tmuxPath: '/bin/false' });
-    const sm = new SessionManager(config, state);
+    const sm = new SessionManager(createSessionManagerConfig(), state);
+    injectOracle(sm, { liveNames: ['some-other-live-session'] }); // neither dead-1/2 present
 
     const purged = await sm.purgeDeadSessions();
     expect(purged).toBe(2);
-
-    // Verify sessions were marked as completed
-    expect(state.saveSession).toHaveBeenCalledTimes(2);
     const savedCalls = (state.saveSession as any).mock.calls;
     expect(savedCalls[0][0].status).toBe('completed');
-    expect(savedCalls[0][0].endedAt).toBeDefined();
-    expect(savedCalls[1][0].status).toBe('completed');
+    expect(savedCalls[0][0].endedReason).toBe('boot-purge-dead');
   });
 
-  it('does not purge sessions whose tmux session exists', async () => {
-    // Use a command that succeeds (exit 0) to simulate "tmux has-session" passing
-    // We test this by pointing tmuxPath to /usr/bin/true which always exits 0
+  it('does NOT purge sessions that are alive (present in list-sessions)', async () => {
     const sessions = [makeSession('s1', 'alive-session')];
     const state = createMockState(sessions);
+    const sm = new SessionManager(createSessionManagerConfig(), state);
+    injectOracle(sm, { liveNames: ['alive-session', 'another'] });
 
-    const config = createSessionManagerConfig({ tmuxPath: '/usr/bin/true' });
-    const sm = new SessionManager(config, state);
+    expect(await sm.purgeDeadSessions()).toBe(0);
+    expect(state.saveSession).not.toHaveBeenCalled();
+  });
+
+  it('[2026-05-27 INCIDENT FIX] does NOT purge sessions on a slow/timing-out tmux — keeps them', async () => {
+    // The original bug: a 1s has-session timeout was treated as "dead", so a busy
+    // tmux at boot mass-purged LIVE sessions ("9 of 9"). Now a timeout is
+    // `indeterminate` → KEPT, never purged.
+    const sessions = [
+      makeSession('s1', 'codey-collaboration'),
+      makeSession('s2', 'instar-exo'),
+      makeSession('s3', 'instar-evolution'),
+    ];
+    const state = createMockState(sessions);
+    const sm = new SessionManager(createSessionManagerConfig(), state);
+    injectOracle(sm, { fail: 'timeout' });
 
     const purged = await sm.purgeDeadSessions();
-    expect(purged).toBe(0);
+    expect(purged).toBe(0); // ← the fix: zero false purges under a slow boot
+    expect(state.saveSession).not.toHaveBeenCalled();
+  });
+
+  it('does NOT purge on an unreachable/erroring tmux (indeterminate, not dead)', async () => {
+    const sessions = [makeSession('s1', 'some-session')];
+    const state = createMockState(sessions);
+    const sm = new SessionManager(createSessionManagerConfig(), state);
+    injectOracle(sm, { fail: 'error' });
+
+    expect(await sm.purgeDeadSessions()).toBe(0);
     expect(state.saveSession).not.toHaveBeenCalled();
   });
 
@@ -181,10 +215,7 @@ describe('Startup session purge (purgeDeadSessions)', () => {
     ];
     const state = createMockState(sessions);
     const sm = new SessionManager(createSessionManagerConfig(), state);
-
-    const purged = await sm.purgeDeadSessions();
-    // listSessions is called with { status: 'running' }, which returns nothing
-    expect(purged).toBe(0);
+    expect(await sm.purgeDeadSessions()).toBe(0);
   });
 });
 

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -215,6 +215,7 @@ describe('Feature Delivery Completeness', () => {
       'Cross-Machine Seamlessness (one agent, many machines)', // operational self-heal/handoff awareness (like Version-Skew); not a user-invokable capability
       'What are we working on?',                           // migrator patch for the initiatives Registry-First row, not a capability section
       'Framework-Onboarding Mentor System',               // developer-layer issue-ledger observability; not a Codex/Gemini end-user capability (no shadow-marker parity)
+      '/sessions/reap-log',                               // UNIFIED-SESSION-LIFECYCLE §P4 reap-log: operational observability the agent READS to answer "where did my session go?" — like Sentinel Notifications, not a user-invokable capability requiring framework-shadow parity
     ];
 
     it('all new migrator CLAUDE.md sections are tracked', () => {

--- a/tests/unit/reap-guard.test.ts
+++ b/tests/unit/reap-guard.test.ts
@@ -1,0 +1,102 @@
+/**
+ * ReapGuard — the shared stateless KEEP-guards (UNIFIED-SESSION-LIFECYCLE §P2).
+ * Both sides of every guard: each protect-signal returns its KEEP reason, and a
+ * fully-clear session returns null (safe to reap). Plus cheap-first ordering,
+ * the "cannot inspect → KEEP" contract, and safe-by-default on a throwing signal.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ReapGuard, type ReapGuardDeps } from '../../src/core/ReapGuard.js';
+import type { Session } from '../../src/core/types.js';
+
+function mkSession(over?: Partial<Session>): Session {
+  return {
+    id: 'sess-1',
+    name: 'work',
+    tmuxSession: 'agent-work',
+    status: 'running',
+    startedAt: new Date(Date.now() - 60 * 60_000).toISOString(), // 1h old (past spawn grace)
+    claudeSessionId: 'claude-uuid-1',
+    ...over,
+  } as Session;
+}
+
+/** All deps default to "no reason to keep" — a fully reap-eligible session. */
+function clearDeps(over?: Partial<ReapGuardDeps>): ReapGuardDeps {
+  return {
+    protectedSessions: () => [],
+    isRecoveryActive: () => false,
+    hasPendingInjection: () => false,
+    isRelayLeaseActive: () => false,
+    topicBinding: () => null,
+    recentUserMessage: () => false,
+    activeCommitmentForTopic: () => false,
+    activeSubagentCount: () => 0,
+    buildOrAutonomousActive: () => false,
+    hasActiveProcesses: () => false,
+    mainProcessActive: () => false,
+    ...over,
+  };
+}
+
+describe('ReapGuard — all-clear', () => {
+  it('returns null when every stateless guard clears', () => {
+    const g = new ReapGuard(clearDeps());
+    expect(g.blockedReason(mkSession())).toBeNull();
+  });
+});
+
+describe('ReapGuard — each guard blocks with its reason', () => {
+  const cases: Array<[string, Partial<ReapGuardDeps>, Partial<Session>?]> = [
+    ['protected', { protectedSessions: () => ['agent-work'] }],
+    ['recovery-in-flight', { isRecoveryActive: () => true }],
+    ['pending-injection', { hasPendingInjection: () => true }],
+    ['relay-lease', { isRelayLeaseActive: () => true }],
+    ['recent-user-message', { topicBinding: () => 42, recentUserMessage: () => true }],
+    ['open-commitment', { topicBinding: () => 42, activeCommitmentForTopic: () => true }],
+    ['active-subagent', { activeSubagentCount: () => 2 }],
+    ['structural-long-work', { buildOrAutonomousActive: () => true }],
+    ['active-process', { hasActiveProcesses: () => true }],
+    ['main-process-active', { mainProcessActive: () => true }],
+  ];
+  for (const [reason, deps] of cases) {
+    it(`blocks with "${reason}"`, () => {
+      const g = new ReapGuard(clearDeps(deps));
+      expect(g.blockedReason(mkSession())?.reason).toBe(reason);
+    });
+  }
+
+  it('spawn-grace blocks a freshly-spawned session (and is skippable via minAgeMs:0)', () => {
+    const young = mkSession({ startedAt: new Date().toISOString() });
+    expect(new ReapGuard(clearDeps()).blockedReason(young)?.reason).toBe('spawn-grace');
+    // A caller that wants no spawn grace (e.g. boot purge reaping a dead session) sets minAgeMs:0.
+    expect(new ReapGuard(clearDeps(), { minAgeMs: 0 }).blockedReason(young)).toBeNull();
+  });
+});
+
+describe('ReapGuard — "cannot inspect" resolves to KEEP, never reap', () => {
+  it('main-process uninspectable (undefined) → KEEP low-confidence', () => {
+    const g = new ReapGuard(clearDeps({ mainProcessActive: () => undefined }));
+    const r = g.blockedReason(mkSession());
+    expect(r?.reason).toBe('process-uninspectable');
+    expect(r?.confidence).toBe('low');
+  });
+
+  it('a throwing signal source resolves to KEEP (guard-error), never reap', () => {
+    const g = new ReapGuard(clearDeps({ isRecoveryActive: () => { throw new Error('boom'); } }));
+    const r = g.blockedReason(mkSession());
+    expect(r?.reason).toBe('guard-error');
+    expect(r?.confidence).toBe('low');
+  });
+});
+
+describe('ReapGuard — cheap-first ordering (no fork when an in-memory guard hits)', () => {
+  it('does not call hasActiveProcesses when protected short-circuits first', () => {
+    let forked = false;
+    const g = new ReapGuard(
+      clearDeps({ protectedSessions: () => ['agent-work'], hasActiveProcesses: () => { forked = true; return false; } }),
+    );
+    expect(g.blockedReason(mkSession())?.reason).toBe('protected');
+    expect(forked).toBe(false);
+  });
+});

--- a/tests/unit/reap-log.test.ts
+++ b/tests/unit/reap-log.test.ts
@@ -1,0 +1,74 @@
+// safe-git-allow: test file — fs.rmSync is for per-test tmpdir cleanup only.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ReapLog } from '../../src/monitoring/ReapLog.js';
+
+describe('ReapLog (§P4)', () => {
+  let stateDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'reaplog-'));
+    stateDir = path.join(root, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    logPath = path.join(root, 'logs', 'reap-log.jsonl');
+  });
+  afterEach(() => {
+    try { fs.rmSync(path.dirname(stateDir), { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('returns [] when no log exists yet (not an error)', () => {
+    const log = new ReapLog(stateDir);
+    expect(log.read()).toEqual([]);
+  });
+
+  it('records a reaped entry with all fields + machine id', () => {
+    const log = new ReapLog(stateDir, () => 'machine-abc');
+    log.recordReaped({ session: 's1', tmuxSession: 't1', reason: 'idle-zombie', disposition: 'terminal', origin: 'autonomous' });
+    const entries = log.read();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      type: 'reaped', session: 's1', tmuxSession: 't1', reason: 'idle-zombie',
+      disposition: 'terminal', origin: 'autonomous', machine: 'machine-abc',
+    });
+    expect(typeof entries[0].ts).toBe('string');
+  });
+
+  it('records a skipped entry with the refusal reason', () => {
+    const log = new ReapLog(stateDir);
+    log.recordSkipped({ session: 's2', tmuxSession: 't2', reason: 'boot-purge-dead', skipped: 'not-lease-holder', origin: 'autonomous' });
+    const entries = log.read();
+    expect(entries[0]).toMatchObject({ type: 'skipped', skipped: 'not-lease-holder', reason: 'boot-purge-dead' });
+  });
+
+  it('encodes a newline-laden reason as valid JSON (no injection)', () => {
+    const log = new ReapLog(stateDir);
+    log.recordReaped({ session: 'evil\nINJECTED LINE', tmuxSession: 't', reason: 'a\nb\nc', disposition: 'terminal' });
+    // Exactly one physical record line despite embedded newlines.
+    const raw = fs.readFileSync(logPath, 'utf-8').trimEnd();
+    expect(raw.split('\n')).toHaveLength(1);
+    const entries = log.read();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].session).toBe('evil\nINJECTED LINE');
+    expect(entries[0].reason).toBe('a\nb\nc');
+  });
+
+  it('reads only the most-recent N entries (tail)', () => {
+    const log = new ReapLog(stateDir);
+    for (let i = 0; i < 10; i++) log.recordReaped({ session: `s${i}`, tmuxSession: `t${i}`, reason: 'idle-zombie' });
+    const tail = log.read(3);
+    expect(tail).toHaveLength(3);
+    expect(tail.map(e => e.session)).toEqual(['s7', 's8', 's9']);
+  });
+
+  it('tolerates a corrupt line without failing the whole read', () => {
+    const log = new ReapLog(stateDir);
+    log.recordReaped({ session: 'good1', tmuxSession: 't', reason: 'r' });
+    fs.appendFileSync(logPath, '{ not valid json\n');
+    log.recordReaped({ session: 'good2', tmuxSession: 't', reason: 'r' });
+    const entries = log.read();
+    expect(entries.map(e => e.session)).toEqual(['good1', 'good2']);
+  });
+});

--- a/tests/unit/reap-notifier.test.ts
+++ b/tests/unit/reap-notifier.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ReapNotifier, type ReapEvent } from '../../src/monitoring/ReapNotifier.js';
+import type { Session } from '../../src/core/types.js';
+
+function sess(name: string, tmux = name): Pick<Session, 'name' | 'tmuxSession'> {
+  return { name, tmuxSession: tmux };
+}
+
+function makeNotifier(over?: {
+  resolveTopic?: (t: string) => number | null;
+  lifeline?: number | null;
+  enabled?: boolean;
+  windowMs?: number;
+  maxBuffer?: number;
+}) {
+  const sends: Array<{ topicId: number; text: string }> = [];
+  const lifeline = over && 'lifeline' in over ? (over.lifeline ?? null) : 999;
+  const n = new ReapNotifier(
+    {
+      resolveTopic: over?.resolveTopic ?? (() => null),
+      lifelineTopic: () => lifeline,
+      send: (topicId, text) => { sends.push({ topicId, text }); },
+    },
+    { enabled: over?.enabled ?? true, coalesceWindowMs: over?.windowMs ?? 60_000, maxBuffer: over?.maxBuffer ?? 100 },
+  );
+  return { n, sends };
+}
+
+describe('ReapNotifier (§P3)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('stays SILENT for a recovery-bounce reap', async () => {
+    const { n, sends } = makeNotifier();
+    n.onReaped({ session: sess('s1'), reason: 'context-exhaustion', disposition: 'recovery-bounce' });
+    await n.flush();
+    expect(sends).toHaveLength(0);
+  });
+
+  it('stays SILENT for an operator kill (the user did it themselves)', async () => {
+    const { n, sends } = makeNotifier();
+    n.onReaped({ session: sess('s1'), reason: 'operator-kill', disposition: 'terminal', origin: 'operator' });
+    await n.flush();
+    expect(sends).toHaveLength(0);
+  });
+
+  it('stays SILENT when disabled', async () => {
+    const { n, sends } = makeNotifier({ enabled: false });
+    n.onReaped({ session: sess('s1'), reason: 'idle-zombie', disposition: 'terminal' });
+    await n.flush();
+    expect(sends).toHaveLength(0);
+  });
+
+  it('routes an isolated topic-bound reap to its BOUND topic', async () => {
+    const { n, sends } = makeNotifier({ resolveTopic: () => 42, lifeline: 999 });
+    n.onReaped({ session: sess('alpha'), reason: 'idle-zombie', disposition: 'terminal' });
+    await n.flush();
+    expect(sends).toHaveLength(1);
+    expect(sends[0].topicId).toBe(42);
+    expect(sends[0].text).toContain('alpha');
+    expect(sends[0].text).toContain('idle-zombie');
+  });
+
+  it('routes an isolated UNBOUND reap to the lifeline topic', async () => {
+    const { n, sends } = makeNotifier({ resolveTopic: () => null, lifeline: 999 });
+    n.onReaped({ session: sess('beta'), reason: 'age-limit', disposition: 'terminal' });
+    await n.flush();
+    expect(sends).toHaveLength(1);
+    expect(sends[0].topicId).toBe(999);
+  });
+
+  it('coalesces a burst into ONE consolidated lifeline message with the exact total count', async () => {
+    const { n, sends } = makeNotifier({ resolveTopic: () => 42, lifeline: 999 });
+    n.onReaped({ session: sess('a'), reason: 'boot-purge-dead', disposition: 'terminal' });
+    n.onReaped({ session: sess('b'), reason: 'boot-purge-dead', disposition: 'terminal' });
+    n.onReaped({ session: sess('c'), reason: 'idle-zombie', disposition: 'terminal' });
+    await n.flush();
+    expect(sends).toHaveLength(1);
+    expect(sends[0].topicId).toBe(999); // lifeline, not per-topic, for a burst
+    expect(sends[0].text).toContain('3 sessions');
+  });
+
+  it('reports the exact total even when the detail buffer overflows (drop-oldest)', async () => {
+    const { n, sends } = makeNotifier({ lifeline: 999, maxBuffer: 2 });
+    for (let i = 0; i < 5; i++) {
+      n.onReaped({ session: sess(`s${i}`), reason: 'idle-zombie', disposition: 'terminal' });
+    }
+    await n.flush();
+    expect(sends).toHaveLength(1);
+    expect(sends[0].text).toContain('5 sessions'); // count is exact regardless of buffer
+    expect(sends[0].text).toMatch(/showing the latest 2/);
+  });
+
+  it('fires automatically when the coalesce window elapses (single shared timer)', async () => {
+    const { n, sends } = makeNotifier({ resolveTopic: () => 7, windowMs: 60_000 });
+    n.onReaped({ session: sess('z'), reason: 'idle-zombie', disposition: 'terminal' });
+    expect(sends).toHaveLength(0); // buffered, not yet sent
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(sends).toHaveLength(1);
+  });
+
+  it('wraps a malicious session name as a literal code span (never markup)', async () => {
+    const { n, sends } = makeNotifier({ resolveTopic: () => 7 });
+    const evil: ReapEvent = {
+      session: sess('*pwn* [x](http://e) `boom`', 'tmux1'),
+      reason: 'idle-zombie',
+      disposition: 'terminal',
+    };
+    n.onReaped(evil);
+    await n.flush();
+    // The dynamic value is wrapped in backticks and any inner backtick neutralized,
+    // so the downstream formatter renders it as literal inline code, not markup.
+    expect(sends[0].text).toContain('`*pwn* [x](http://e) ');
+    expect(sends[0].text).not.toContain('`boom`'); // inner backticks neutralized
+  });
+
+  it('drops a single notice silently when no channel is reachable (reap-log still has it)', async () => {
+    const { n, sends } = makeNotifier({ resolveTopic: () => null, lifeline: null });
+    n.onReaped({ session: sess('orphan'), reason: 'idle-zombie', disposition: 'terminal' });
+    await n.flush();
+    expect(sends).toHaveLength(0); // no throw, no send
+  });
+});

--- a/tests/unit/session-liveness-oracle.test.ts
+++ b/tests/unit/session-liveness-oracle.test.ts
@@ -1,0 +1,166 @@
+/**
+ * SessionLivenessOracle — the structural fix for the 2026-05-27 mass false-purge.
+ * THE hard requirement under test: a slow / busy / unreachable tmux probe is
+ * `indeterminate`, NEVER `dead`. `dead` is returned only on an authoritative
+ * "server reachable + exact id absent". Plus: exact-id matching (no prefix),
+ * caching, retry-then-succeed, boot-cap, concurrent coalescing, config floors.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  SessionLivenessOracle,
+  validateLivenessConfig,
+  type SessionLivenessOracleDeps,
+} from '../../src/core/SessionLivenessOracle.js';
+
+/** Build an oracle with a scripted exec. Each call shifts the next behavior. */
+function makeOracle(
+  behaviors: Array<() => Promise<{ stdout: string; stderr: string }>>,
+  cfg?: Parameters<typeof makeOracleRaw>[1],
+) {
+  return makeOracleRaw(behaviors, cfg);
+}
+
+function makeOracleRaw(
+  behaviors: Array<() => Promise<{ stdout: string; stderr: string }>>,
+  cfg?: Partial<ConstructorParameters<typeof SessionLivenessOracle>[1]>,
+) {
+  const exec = vi.fn(async () => {
+    const next = behaviors.shift();
+    if (!next) throw new Error('exec called more times than scripted');
+    return next();
+  });
+  const deps: SessionLivenessOracleDeps = {
+    tmuxPath: '/usr/bin/tmux',
+    exec: exec as unknown as SessionLivenessOracleDeps['exec'],
+    now: () => Date.now(),
+  };
+  const oracle = new SessionLivenessOracle(deps, { probeBackoffMs: 0, ...(cfg ?? {}) });
+  return { oracle, exec };
+}
+
+const ok = (names: string[]) => async () => ({ stdout: names.join('\n') + '\n', stderr: '' });
+const timeoutErr = () => async () => {
+  const e = new Error('Command failed: timed out') as Error & { killed: boolean; signal: string };
+  e.killed = true;
+  e.signal = 'SIGTERM';
+  throw e;
+};
+const noServerErr = () => async () => {
+  const e = new Error('no server running on /tmp/tmux-501/default') as Error & { stderr: string };
+  e.stderr = 'no server running on /tmp/tmux-501/default';
+  throw e;
+};
+const unknownErr = () => async () => {
+  throw new Error('EPIPE: broken pipe');
+};
+
+describe('SessionLivenessOracle — the incident fix (slow ≠ dead)', () => {
+  it('returns INDETERMINATE (not dead) when the probe times out', async () => {
+    // The 2026-05-27 bug: a 1s timeout was treated as "dead". Here even after the
+    // single retry the probe keeps timing out → must be indeterminate, never dead.
+    const { oracle } = makeOracle([timeoutErr(), timeoutErr()]);
+    const r = await oracle.probe('echo-session-robustness');
+    expect(r.liveness).toBe('indeterminate');
+    expect(r.liveness).not.toBe('dead');
+  });
+
+  it('returns INDETERMINATE on an unknown/transient error', async () => {
+    const { oracle } = makeOracle([unknownErr(), unknownErr()]);
+    const r = await oracle.probe('foo');
+    expect(r.liveness).toBe('indeterminate');
+  });
+
+  it('does NOT cache a non-authoritative (transient) result', async () => {
+    // A bad tick must not freeze liveness for the whole TTL.
+    const { oracle, exec } = makeOracle([timeoutErr(), timeoutErr(), ok(['foo'])]);
+    expect((await oracle.probe('foo')).liveness).toBe('indeterminate'); // 2 calls (retry)
+    const r2 = await oracle.probe('foo'); // must re-probe, not serve stale transient
+    expect(r2.liveness).toBe('alive');
+    expect(exec).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('SessionLivenessOracle — authoritative classification', () => {
+  it('ALIVE when the exact session name is present', async () => {
+    const { oracle } = makeOracle([ok(['a', 'echo-session-robustness', 'b'])]);
+    expect((await oracle.probe('echo-session-robustness')).liveness).toBe('alive');
+  });
+
+  it('DEAD when the server is reachable and the exact id is absent', async () => {
+    const { oracle } = makeOracle([ok(['a', 'b'])]);
+    const r = await oracle.probe('echo-session-robustness');
+    expect(r.liveness).toBe('dead');
+  });
+
+  it('DEAD via authoritative "no server running" (no sessions exist)', async () => {
+    const { oracle } = makeOracle([noServerErr()]);
+    expect((await oracle.probe('anything')).liveness).toBe('dead');
+  });
+
+  it('exact-id match only — a prefix sibling does NOT count as alive', async () => {
+    // Closes the orphan-reaper prefix-match false-positive: "foo" must be dead
+    // even though "foo-bar" is live.
+    const { oracle } = makeOracle([ok(['foo-bar', 'foobar', 'xfoo'])]);
+    expect((await oracle.probe('foo')).liveness).toBe('dead');
+  });
+});
+
+describe('SessionLivenessOracle — retry, cache, batch, coalescing', () => {
+  it('retries a transient timeout then succeeds → ALIVE (never dead)', async () => {
+    const { oracle, exec } = makeOracle([timeoutErr(), ok(['foo'])], { probeRetries: 1 });
+    expect((await oracle.probe('foo')).liveness).toBe('alive');
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves a fresh cached snapshot without re-probing within the TTL', async () => {
+    const { oracle, exec } = makeOracle([ok(['a', 'b'])], { cacheTtlMs: 10_000 });
+    await oracle.probe('a');
+    await oracle.probe('b');
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('probeAll resolves the whole set from ONE list-sessions call', async () => {
+    const { oracle, exec } = makeOracle([ok(['a', 'c'])]);
+    const m = await oracle.probeAll(['a', 'b', 'c']);
+    expect(m.get('a')!.liveness).toBe('alive');
+    expect(m.get('b')!.liveness).toBe('dead');
+    expect(m.get('c')!.liveness).toBe('alive');
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent probes into a single tmux call', async () => {
+    const { oracle, exec } = makeOracle([ok(['a', 'b'])]);
+    const [ra, rb] = await Promise.all([oracle.probe('a'), oracle.probe('b')]);
+    expect(ra.liveness).toBe('alive');
+    expect(rb.liveness).toBe('alive');
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors the boot cap: gives up to INDETERMINATE rather than blocking', async () => {
+    // Two timeouts with retries=5, but a tiny boot cap → returns indeterminate
+    // after the cap without exhausting all retries.
+    const { oracle } = makeOracle([timeoutErr(), timeoutErr(), timeoutErr()], {
+      probeRetries: 5,
+      bootCapMs: 2000,
+      probeTimeoutMs: 1000,
+      probeBackoffMs: 0,
+    });
+    const r = await oracle.probe('foo');
+    expect(r.liveness).toBe('indeterminate');
+  });
+});
+
+describe('validateLivenessConfig — startup floors (a 0ms timeout must be rejected)', () => {
+  it('rejects a sub-floor probe timeout (the death-spiral re-creator)', () => {
+    expect(validateLivenessConfig({ probeTimeoutMs: 0 }).length).toBeGreaterThan(0);
+    expect(validateLivenessConfig({ probeTimeoutMs: 100 }).length).toBeGreaterThan(0);
+  });
+  it('rejects negative retries and sub-floor boot cap', () => {
+    expect(validateLivenessConfig({ probeRetries: -1 }).length).toBeGreaterThan(0);
+    expect(validateLivenessConfig({ bootCapMs: 10 }).length).toBeGreaterThan(0);
+  });
+  it('accepts a sane config', () => {
+    expect(validateLivenessConfig({ probeTimeoutMs: 5000, probeRetries: 1, bootCapMs: 8000 })).toEqual([]);
+  });
+});

--- a/tests/unit/session-reaper.test.ts
+++ b/tests/unit/session-reaper.test.ts
@@ -296,7 +296,12 @@ describe('SessionReaper — robustness', () => {
     const h = harness({ deps: { isRecoveryActive: () => { throw new Error('boom'); } } });
     const snap = h.reaper.snapshot();
     expect(snap.sessions[0].verdict).toBe('keep');
-    expect(snap.sessions[0].keptBy).toBe('eval-error');
+    // The shared ReapGuard (§P2) catches a throwing stateless signal internally and
+    // resolves it to a KEEP ('guard-error') — safe-by-default for every killer that
+    // calls the guard. The KEEP-never-reap intent is unchanged (asserted above); only
+    // the diagnostic label moved from the reaper's outer catch ('eval-error', still
+    // live for a throw in the stateful transcript/idle checks) to the guard's.
+    expect(snap.sessions[0].keptBy).toBe('guard-error');
   });
 });
 

--- a/tests/unit/session-timeout-activity-aware.test.ts
+++ b/tests/unit/session-timeout-activity-aware.test.ts
@@ -57,10 +57,13 @@ describe('Activity-aware session-timeout gate', () => {
   });
 
   it('still kills sessions that are over the age limit AND idle', () => {
-    // When the activity check confirms idle, the original kill path fires.
-    // The "and is idle" suffix on the warning message is the contract.
+    // When the activity check confirms idle, the kill path fires. Post
+    // UNIFIED-SESSION-LIFECYCLE §P0 the inline kill is replaced by a route
+    // through the single ReapAuthority: the warning still names the timeout +
+    // idle condition, then funnels through terminateSession('age-limit').
     expect(SM_SOURCE).toContain('exceeded timeout');
-    expect(SM_SOURCE).toContain('and is idle. Killing');
+    expect(SM_SOURCE).toContain('and is idle');
+    expect(SM_SOURCE).toMatch(/terminateSession\(\s*session\.id,\s*'age-limit'/);
   });
 
   it('does not skip idle-detection when deferring the timeout kill', () => {

--- a/tests/unit/stale-session-backstop.test.ts
+++ b/tests/unit/stale-session-backstop.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { StaleSessionBackstop, type ProgressSnapshot, type LivenessBatch } from '../../src/monitoring/StaleSessionBackstop.js';
+import type { Session } from '../../src/core/types.js';
+
+function mkSession(id: string): Session {
+  return {
+    id, name: id, tmuxSession: id, status: 'running',
+    startedAt: new Date(0).toISOString(),
+  } as Session;
+}
+
+const M = 30; // unverifiableEscalateMinutes
+const N = 15; // indeterminateEscalateCount
+
+function harness(opts?: { snapshots?: Map<string, ProgressSnapshot> }) {
+  let clock = 1_000_000;
+  const sessions: Session[] = [];
+  const raised: Array<{ id: string; title: string }> = [];
+  const longFlags = new Map<string, boolean>();
+  let batch: LivenessBatch = { reachable: true, liveness: new Map() };
+  const snaps = opts?.snapshots ?? new Map<string, ProgressSnapshot>();
+
+  const backstop = new StaleSessionBackstop(
+    {
+      listRunningSessions: () => sessions,
+      probeLiveness: () => batch,
+      snapshot: (s) => snaps.get(s.id) ?? {
+        transcriptResolved: false, transcriptSize: 0, transcriptTailHash: null,
+        mainProcessActive: false, idleStateToken: 'x',
+      },
+      raiseAttention: async (item) => { raised.push({ id: item.id, title: item.title }); return true; },
+      setLongIndeterminate: (id, isLong) => longFlags.set(id, isLong),
+      now: () => clock,
+    },
+    { enabled: true, tickIntervalSec: 120, unverifiableEscalateMinutes: M, indeterminateEscalateCount: N, progressFloorBytes: 512 },
+  );
+
+  return {
+    backstop, raised, longFlags,
+    addSession: (id: string) => { sessions.push(mkSession(id)); },
+    setLiveness: (b: LivenessBatch) => { batch = b; },
+    setSnap: (id: string, s: ProgressSnapshot) => { snaps.set(id, s); },
+    advanceMin: (mins: number) => { clock += mins * 60_000; },
+    allAlive: () => { batch = { reachable: true, liveness: new Map(sessions.map(s => [s.tmuxSession, 'alive'])) }; },
+  };
+}
+
+const idleSnap = (token = 'frame-static'): ProgressSnapshot => ({
+  transcriptResolved: true, transcriptSize: 1000, transcriptTailHash: 'tail-A',
+  mainProcessActive: false, idleStateToken: token,
+});
+
+describe('StaleSessionBackstop (§P5)', () => {
+  it('raises ONE attention item (never kills) after M minutes of no forward progress', async () => {
+    const h = harness();
+    h.addSession('s1');
+    h.allAlive();
+    h.setSnap('s1', idleSnap());
+    await h.backstop.tick();            // baseline
+    expect(h.raised).toHaveLength(0);
+    h.advanceMin(M + 1);
+    h.setSnap('s1', idleSnap());        // identical → no progress
+    await h.backstop.tick();
+    expect(h.raised).toHaveLength(1);
+    expect(h.raised[0].title).toMatch(/stale but unkillable/);
+  });
+
+  it('does not re-raise within the same episode', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive(); h.setSnap('s1', idleSnap());
+    await h.backstop.tick();
+    h.advanceMin(M + 1); await h.backstop.tick();   // 1st raise
+    h.advanceMin(M + 1); await h.backstop.tick();   // still stale, same episode
+    expect(h.raised).toHaveLength(1);
+  });
+
+  it('a heartbeat-byte append (tiny growth, same tail) is NOT progress → still escalates', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive();
+    h.setSnap('s1', { ...idleSnap(), transcriptSize: 1000, transcriptTailHash: 'tail-A' });
+    await h.backstop.tick();
+    h.advanceMin(M + 1);
+    // +10 bytes (< 512 floor) and the tail hash is unchanged → no meaningful advance.
+    h.setSnap('s1', { ...idleSnap(), transcriptSize: 1010, transcriptTailHash: 'tail-A' });
+    await h.backstop.tick();
+    expect(h.raised).toHaveLength(1);
+  });
+
+  it('a meaningful transcript advance (≥floor AND new tail) resets the clock — no escalation', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive();
+    h.setSnap('s1', { ...idleSnap(), transcriptSize: 1000, transcriptTailHash: 'tail-A' });
+    await h.backstop.tick();
+    h.advanceMin(M + 1);
+    h.setSnap('s1', { ...idleSnap(), transcriptSize: 2000, transcriptTailHash: 'tail-B' });
+    await h.backstop.tick();
+    expect(h.raised).toHaveLength(0);
+  });
+
+  it('main-process CPU activity counts as progress', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive();
+    h.setSnap('s1', idleSnap());
+    await h.backstop.tick();
+    h.advanceMin(M + 1);
+    h.setSnap('s1', { ...idleSnap(), mainProcessActive: true });
+    await h.backstop.tick();
+    expect(h.raised).toHaveLength(0);
+  });
+
+  it('a prompt/idle-state change counts as progress', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive();
+    h.setSnap('s1', idleSnap('frame-1'));
+    await h.backstop.tick();
+    h.advanceMin(M + 1);
+    h.setSnap('s1', idleSnap('frame-2')); // screen changed
+    await h.backstop.tick();
+    expect(h.raised).toHaveLength(0);
+  });
+
+  it('recovery then a fresh stall raises a NEW (per-episode) item', async () => {
+    const h = harness();
+    h.addSession('s1'); h.allAlive();
+    h.setSnap('s1', idleSnap('f1'));
+    await h.backstop.tick();
+    h.advanceMin(M + 1); await h.backstop.tick();           // episode 1 raised
+    h.setSnap('s1', idleSnap('f2')); await h.backstop.tick(); // progress → recovered
+    h.advanceMin(M + 1);
+    h.setSnap('s1', idleSnap('f2')); await h.backstop.tick(); // stale again → episode 2
+    expect(h.raised).toHaveLength(2);
+    expect(h.raised[0].id).not.toBe(h.raised[1].id);
+  });
+
+  it('control-plane unreachable raises ONE global item, not one per session', async () => {
+    const h = harness();
+    h.addSession('s1'); h.addSession('s2'); h.addSession('s3');
+    h.setLiveness({ reachable: false, liveness: new Map() });
+    await h.backstop.tick();
+    await h.backstop.tick(); // still unreachable — deduped
+    expect(h.raised).toHaveLength(1);
+    expect(h.raised[0].title).toMatch(/control plane unreachable/);
+  });
+
+  it('flags a long-indeterminate session for spawn-cap exclusion and clears on recovery', async () => {
+    const h = harness();
+    h.addSession('s1');
+    // Server reachable but s1 individually indeterminate for N+ ticks.
+    h.setLiveness({ reachable: true, liveness: new Map([['s1', 'indeterminate']]) });
+    // Reachable requires at least one non-indeterminate; add a healthy sibling.
+    h.addSession('s2');
+    h.setLiveness({ reachable: true, liveness: new Map([['s1', 'indeterminate'], ['s2', 'alive']]) });
+    h.setSnap('s2', idleSnap());
+    for (let i = 0; i < N; i++) await h.backstop.tick();
+    expect(h.longFlags.get('s1')).toBe(true);
+    expect(h.raised.some(r => r.title.match(/stale but unkillable/))).toBe(true);
+    // s1 recovers
+    h.setLiveness({ reachable: true, liveness: new Map([['s1', 'alive'], ['s2', 'alive']]) });
+    h.setSnap('s1', idleSnap());
+    await h.backstop.tick();
+    expect(h.longFlags.get('s1')).toBe(false);
+  });
+
+  it('never auto-kills (no terminate/kill dep exists at all)', () => {
+    // Structural guarantee: the deps surface has no kill/terminate function.
+    const deps = Object.keys({
+      listRunningSessions: 1, probeLiveness: 1, snapshot: 1, raiseAttention: 1, setLongIndeterminate: 1, now: 1,
+    });
+    expect(deps).not.toContain('terminate');
+    expect(deps).not.toContain('kill');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -17,7 +17,7 @@ All changes are additive and only make killing *more* conservative; the boot-pur
 
 ## What to Tell Your User
 
-- Your sessions won't silently disappear anymore. The startup cleanup no longer mistakes a slow-to-answer session for a dead one, and if anything *does* get shut down you get told why — with a log page (`/sessions/reap-log`) recording every shutoff and every *refused* shutoff.
+- Your sessions won't silently disappear anymore. The startup cleanup no longer mistakes a slow-to-answer session for a dead one, and if anything *does* get shut down you get told why — with a reap-log page recording every shutoff and every refused shutoff.
 - Every automatic cleanup now goes through one careful gatekeeper that refuses to end a session that might be working, and only the "awake" machine ever reaps. When *you* kill a session it still happens immediately.
 - Nothing can get wedged-but-immortal or quietly fill your slots: instead of ever auto-killing a stuck session, the agent raises a single "this looks stuck — investigate or force-kill?" item for you.
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,39 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+Phase 1 of **unified session-lifecycle robustness** (spec `docs/specs/unified-session-lifecycle-robustness.md`, converged + approved). The trigger was a real incident: at a busy server boot the startup "cleanup crew" treated a slow-to-answer tmux session as *dead* and wiped 9 of 9 live sessions — silently. The audit that followed found eight different code paths that can end a session, each re-inventing "alive or dead?" its own way, several of them able to mistake slow/busy for dead and none of them telling the user. This release builds the single authority + safety backbone that the rest of the killers will move onto.
+
+What landed:
+
+- **One authority, not eight.** `terminateSession()` is now the sole kill chokepoint. Every autonomous shutoff routes through it and can only *request* a kill — the authority holds the safety checks: a compare-and-set live-status guard, the `protected` set, an **awake-machine-only lease gate** (a standby never reaps another machine's sessions), and a mandatory **KEEP-guard** consult (the same positive-evidence checks the careful SessionReaper uses — relay-lease, pending-injection, recent-user-message, active subagent/process, etc.). An explicit **operator** kill (stamped only by the Bearer-authed HTTP route) bypasses those gates so a human "kill" always happens. The first three killers — boot purge, the age/5-hour cutoff, and the idle-zombie killer — are funneled through it.
+- **A reap is never silent.** A new coalescing notifier surfaces "your session was shut down — <reason>" so a session can't just vanish. Routine kill-to-respawn bounces and your own operator kills stay quiet; a burst collapses into ONE consolidated message instead of spamming. Default **on** (`monitoring.reapNotify`).
+- **A reap-log you can read.** Every shutoff *and* every refused/skipped shutoff (protected / not-lease-holder / a KEEP-hold / in-flight) is recorded as one JSON line, served read-only at `GET /sessions/reap-log`. "Where did my session go?" now always has an answer.
+- **Nothing is unconditionally immortal — and nothing can lock you out.** A signal-only backstop watches for a session that fakes work (heartbeat-byte / tight-loop) or is stuck unverifiable, and after a threshold raises ONE deduped Attention item asking *you* to decide — it never auto-kills. Long-unverifiable sessions are excluded from the absolute spawn cap so a fleet of stuck panes can't lock you out of starting new work.
+
+All changes are additive and only make killing *more* conservative; the boot-purge fix already turns the original 9-of-9 wipe into 0 false kills. Phase 2 (watchdog / orphan / recovery / wake-reaper onto the authority) and Phase 3 (quota soft-check + session-label-follows-rename) follow.
+
+## What to Tell Your User
+
+- Your sessions won't silently disappear anymore. The startup cleanup no longer mistakes a slow-to-answer session for a dead one, and if anything *does* get shut down you get told why — with a log page (`/sessions/reap-log`) recording every shutoff and every *refused* shutoff.
+- Every automatic cleanup now goes through one careful gatekeeper that refuses to end a session that might be working, and only the "awake" machine ever reaps. When *you* kill a session it still happens immediately.
+- Nothing can get wedged-but-immortal or quietly fill your slots: instead of ever auto-killing a stuck session, the agent raises a single "this looks stuck — investigate or force-kill?" item for you.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Single ReapAuthority (all autonomous kills funnel through `terminateSession`) | Automatic — boot-purge, age-kill, and idle-zombie now route through it with the KEEP-guard + lease gate |
+| Reap notice ("your session was shut down — <reason>") | On by default; silence it with `{"monitoring": {"reapNotify": {"enabled": false}}}` |
+| Reap-log | `curl -H "Authorization: Bearer $AUTH" "http://localhost:4040/sessions/reap-log?limit=50"` (read-only) |
+| Unkillability backstop (escalate, never auto-kill) | Automatic + signal-only; tune via `monitoring.staleBackstop` |
+| Spawn-cap exclusion for long-unverifiable sessions | Automatic — they no longer count toward the absolute `maxSessions × 3` cap |
+
+## Evidence
+
+- 123 unit + 10 integration + 3 e2e green for the feature set: ReapGuard (15), ReapNotifier (10), ReapLog (6), StaleSessionBackstop (10), terminate-CAS (9), liveness-oracle (15), boot-purge death-spiral reproduction (the 2026-05-27 9-of-9 incident → 0 false purges), reap-log route (integration + e2e "feature is alive" 200-not-503), and a full event-path integration (autonomous reap → log + one notice; recovery-bounce/operator silent; relay-lease/standby/protected refused-and-survive).
+- `tsc --noEmit` clean. Migration parity: `reapNotify` + `staleBackstop` defaults flow to existing agents via ConfigDefaults; the reap-log Agent-Awareness section ships in both the CLAUDE.md template and `migrateClaudeMd`.
+- Spec converged over 3 code-grounded review rounds (report: `docs/specs/reports/unified-session-lifecycle-robustness-convergence.md`); side-effects review: `upgrades/side-effects/unified-session-lifecycle-robustness.md`.
+- Honest scope note: the boot-purge false-purge and the notice/log/survival paths are reproduced at the unit + real-event-path + real-AgentServer tiers; a live "boot a server, slow tmux, watch a Telegram notice land" pass was not performed in this environment.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -86,3 +86,49 @@ reason. The authority (terminateSession) decides; wired in P0.
 unreferenced if the reaper's guard field + call are removed.
 
 **Tests:** 15 (guard) + 30 (reaper parity) + 4 (wiring) green; typecheck clean.
+
+## Commit — P0 ReapAuthority gates + funnel killers #1/#2/#3
+
+**Files:**
+- `src/core/SessionManager.ts` — `terminateSession` gains `origin`/`disposition`/`knownDead` opts, a
+  lease-holder gate, the mandatory ReapGuard consult, and a single `sessionReaped` emission;
+  `setReapGuard()`/`setAwakeChecker()` DI seams. Killers funneled: #1 boot-purge (`knownDead:true`,
+  lease-gated), #2 age-limit (inline kill → `terminateSession('age-limit')`), #3 idle-zombie (explicit
+  `disposition:'terminal'`).
+- `src/server/routes.ts` — `DELETE /sessions/:id` is now async and routes through
+  `terminateSession(origin:'operator')` instead of the raw `killSession`.
+- `src/commands/server.ts` — shared `reapGuardDeps` back BOTH the SessionReaper and the authority's
+  ReapGuard (built `minAgeMs:0`); `setAwakeChecker` wires the lease gate (single-machine ⇒ always awake).
+
+**Implementation decisions with side-effects (reviewed):**
+1. **Operator kill bypasses `protected`.** The `protected` check moved *inside* the autonomous-only
+   gate block, so an `origin:'operator'` kill is no longer blocked on protected sessions. Risk: an
+   operator can now kill a protected (e.g. lifeline) session via the dashboard. Mitigation/justification:
+   this *preserves* the prior behavior — the old `DELETE` route used `killSession`, which killed
+   unconditionally — and matches the spec's "an explicit human kill must always happen". Autonomous
+   reapers remain fully blocked on protected.
+2. **`knownDead` bypass for boot-purge.** A `dead` verdict skips the KEEP-guard. Risk: a mis-verdict
+   would skip protection. Mitigation: the oracle returns `dead` ONLY on tmux-server-reachable +
+   exact-full-id-absent, never on timeout/unreachable/unknown — so `knownDead` is only ever passed for a
+   provably-gone session, which has no liveness to protect. Without the bypass, the guard's
+   liveness-blind topic-state KEEPs (recent-user-message / open-commitment) would pin a dead record in
+   the running list and re-create the boot death-spiral.
+3. **`DELETE` route now emits `beforeSessionKill`/`sessionComplete`/`sessionReaped`.** The old
+   `killSession` path historically emitted none of these. Effect: resume-UUID listeners now fire on an
+   operator kill (beneficial — a manually-killed topic session can be resumed), and the operator kill
+   lands in the reap-log (P4). No double-emit: `killSession` is no longer on this path.
+
+**Signal vs authority:** unchanged — killers *request*, the authority decides. The only callers that
+may mint `origin:'operator'` are Bearer-authed HTTP routes; in-process killers default to `autonomous`
+and so always pass through the gates.
+
+**Re-entrancy:** the guard is consulted before the in-flight (`terminating`) lock is acquired, so the
+authority never misreads its own lock as a KEEP (spec §P0 ordering).
+
+**Rollback:** additive per killer; reverting restores the inline kills. P0 gates default to the prior
+behavior when `setReapGuard`/`setAwakeChecker` are unset (tests/standalone) — no guard consult, treated
+as awake.
+
+**Tests:** terminate (9) + reaper (30) + guard (15) + oracle (15) + timeout (4+6) + async-monitor (6) +
+lifecycle integration (6) green; typecheck clean. One brittle source-string test updated to the new
+age-kill log + funnel contract.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -52,3 +52,37 @@ surface with no production caller.
 
 **Tests:** 15 (oracle) + 14 (purge/death-spiral) green; typecheck clean. Reproduce-before-claim for
 the live boot scenario is owed before declaring the incident fixed end-to-end (E2E tier, later commit).
+
+## Commit 2 — P2 ReapGuard (stateless KEEP-guards extracted from SessionReaper)
+
+**Files:**
+- `src/core/ReapGuard.ts` (new) — `reapBlockedReason(session)` over the stateless guards: protected,
+  spawn-grace (parameterized minAgeMs), recovery-in-flight, pending-injection, relay-lease,
+  recent-user-message, open-commitment, active-subagent, structural-long-work, active-process,
+  main-process-uninspectable/active. Cheap-first ordering; safe-by-default (a throwing signal →
+  KEEP 'guard-error', never reap).
+- `src/monitoring/SessionReaper.ts` — `evaluate()` now calls the shared guard first, then layers its
+  STATEFUL checks (transcript-growth via per-instance `obs`, positive-idle via captured frame). Guard
+  built in the constructor from the reaper's deps + cfg.
+- `tests/unit/reap-guard.test.ts` (new, 15 tests) — both sides of every guard, cannot-inspect→KEEP,
+  cheap-first ordering, throwing-signal→KEEP.
+- `tests/unit/session-reaper.test.ts` — one label assertion updated ('eval-error'→'guard-error') for
+  the throwing-stateless-signal case; the KEEP-never-reap behavior is unchanged and still asserted.
+
+**Parity:** SessionReaper's 30 existing tests all pass post-extraction — the `keptBy` reasons are
+identical for every extracted guard (the spec's required wiring/parity check). Only the diagnostic
+label for a *throwing* stateless signal moved (the guard now catches it as 'guard-error' rather than
+letting it propagate to the reaper's outer 'eval-error' catch — a safer default for the shared guard;
+the reaper's outer catch remains live for throws in the stateful checks).
+
+**Behavioral change:** none for the reaper (parity). The guard is not yet consulted by
+`terminateSession` — that wiring is P0 (next commit). So no other killer's behavior changes yet; this
+commit is a pure, parity-verified extraction.
+
+**Signal vs authority:** the guard is a pure predicate (no kill power) — it only *reports* a KEEP
+reason. The authority (terminateSession) decides; wired in P0.
+
+**Rollback:** additive. Reverting restores the inlined guards in `evaluate()`; `ReapGuard.ts` is
+unreferenced if the reaper's guard field + call are removed.
+
+**Tests:** 15 (guard) + 30 (reaper parity) + 4 (wiring) green; typecheck clean.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -210,3 +210,24 @@ still count toward the soft scheduler cap. Cleared the moment a session is verif
 **Tests:** StaleSessionBackstop (10: M-min escalation, no-re-raise-per-episode, heartbeat-not-progress,
 meaningful-advance/CPU/prompt-change progress, per-episode re-raise after recovery, global-unreachable
 dedup, long-indeterminate flag set+cleared, never-kills structural) green; typecheck clean.
+
+## Commit — Phase 1 test tiers (integration + e2e)
+
+**Files:**
+- `tests/integration/reap-log-route.test.ts` (new, 4) — GET /sessions/reap-log through the real
+  createRoutes pipeline: 503-when-unwired, 200 with reaped+skipped entries, ?limit tail, read-only
+  (POST/DELETE → 404).
+- `tests/integration/session-lifecycle-reap-wiring.test.ts` (new, 6) — the real SessionManager
+  terminateSession authority wired (as server.ts does) to ReapGuard + ReapNotifier + ReapLog, asserting
+  through the real emit path: autonomous terminal reap → log + exactly one notice; recovery-bounce →
+  logged-but-silent; operator → logged-silent + bypasses guard+protected; relay-lease KEEP → refused +
+  survives + logged 'skipped'; standby → refused + survives; protected → refused + survives.
+- `tests/e2e/reap-log-lifecycle.test.ts` (new, 3) — boots the REAL AgentServer: GET /sessions/reap-log
+  is alive (200 not 503), surfaces recorded entries, requires Bearer, read-only.
+
+**Reproduce-before-claim status (honest):** the boot-purge false-purge is reproduced at the unit tier
+(death-spiral-fixes — the 2026-05-27 9-of-9 incident now yields 0 purges); "one terminal reap → exactly
+one notice" and "guarded/standby/protected survive" are reproduced through the real SessionManager event
+path (integration); the route is proven alive on the real AgentServer (e2e). A full live boot with a
+deliberately-slowed tmux + a real Telegram notice landing was NOT performed in this environment — the
+test-tier reproductions stand in for it, and that gap is stated rather than papered over.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -176,3 +176,37 @@ idle — unreachable in the sub-second guard-unset window. Documented inline.
 coalescing, overflow exact-count, auto-timer, malicious-name literalization, unreachable-channel drop)
 + ReapLog (6: empty, reaped/skipped fields, newline-injection→valid-JSON, tail, corrupt-line tolerance)
 green; typecheck clean. Route integration + e2e land in the test-phase commit.
+
+## Commit — P5 unkillability backstop
+
+**Files:**
+- `src/monitoring/StaleSessionBackstop.ts` (new) — signal-only. Per-tick forward-progress check; after
+  M min of no-forward-progress OR N consecutive indeterminate probes, raises ONE per-episode-deduped
+  Attention item (never auto-kills). Forward progress = meaningful transcript advance (≥floor AND new
+  tail — guards the heartbeat/loop case) OR main-process CPU OR a prompt/idle-state change. A
+  control-plane-unreachable tick raises ONE global item, not one per session.
+- `src/core/SessionManager.ts` — `markLongIndeterminate()` + a `longIndeterminateSessions` set excluded
+  from the ABSOLUTE `maxSessions × 3` spawn cap (so unverifiable panes can't lock out spawning);
+  `probeLivenessBatch()` resolves tri-state liveness + reachability from ONE oracle snapshot.
+- `src/core/types.ts` + `src/config/ConfigDefaults.ts` — `monitoring.staleBackstop`, default ON;
+  propagates to existing agents via ConfigDefaults.
+- `src/commands/server.ts` — backstop wired after the SessionReaper; snapshot built from probeTranscript
+  (+ tail-hash read so a heartbeat byte isn't "progress"), captureOutput frame-hash, hasActiveProcesses;
+  Attention via makeAttentionPoster.
+
+**Never-auto-kills (structural):** the backstop's deps surface has NO terminate/kill function — it
+physically cannot end a session. Asserted by a unit test. It only observes and asks.
+
+**Oracle interaction (reviewed):** with the committed single-snapshot oracle, a session is only
+`indeterminate` when the whole snapshot is non-authoritative (server unreachable). So the per-session
+indeterminate-streak path is currently reached only under global unreachability (handled by the global
+item); the live, reachable path is the M-minute no-forward-progress escalation for ALIVE-but-faking
+sessions. The per-session indeterminate code is kept (defensive — correct if the oracle later adds
+individual re-probes that return indeterminate while reachable).
+
+**Spawn-cap exclusion:** long-indeterminate sessions are removed from the ABSOLUTE-cap count only; they
+still count toward the soft scheduler cap. Cleared the moment a session is verifiable again.
+
+**Tests:** StaleSessionBackstop (10: M-min escalation, no-re-raise-per-episode, heartbeat-not-progress,
+meaningful-advance/CPU/prompt-change progress, per-episode re-raise after recovery, global-unreachable
+dedup, long-indeterminate flag set+cleared, never-kills structural) green; typecheck clean.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -231,3 +231,11 @@ one notice" and "guarded/standby/protected survive" are reproduced through the r
 path (integration); the route is proven alive on the real AgentServer (e2e). A full live boot with a
 deliberately-slowed tmux + a real Telegram notice landing was NOT performed in this environment — the
 test-tier reproductions stand in for it, and that gap is stated rather than papered over.
+
+## Commit — annotate intentional silent catches (no-silent-fallbacks ratchet)
+
+Two new intentional silent catches are annotated `@silent-fallback-ok` so the
+no-silent-fallbacks ratchet doesn't count them: `ReapLog.read` (no log file ⇒
+empty list is correct, not degraded) and the §P5 transcript-tail read (an
+unreadable tail ⇒ no meaningful-advance signal this tick; treated as ambiguous,
+never as progress). Behavior unchanged.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -1,0 +1,54 @@
+# Side-Effects Review — Unified Session-Lifecycle Robustness (implementation)
+
+Spec: `docs/specs/unified-session-lifecycle-robustness.md` (converged 3 iterations, approved by Justin
+topic 2169). Full adversarial/standards review in
+`docs/specs/reports/unified-session-lifecycle-robustness-convergence.md`. This artifact tracks the
+side-effects of the *implementation* commits as they land.
+
+## Commit 1 — P1 SessionLivenessOracle + boot-purge fix
+
+**Files:**
+- `src/core/SessionLivenessOracle.ts` (new) — tri-state liveness oracle.
+- `src/core/SessionManager.ts` — lazy oracle field + `setLivenessOracle()` DI seam; `purgeDeadSessions()`
+  rewired to use the oracle (purge only on `dead`, keep on `indeterminate`/`alive`).
+- `src/core/types.ts` — added optional `liveness?: Partial<SessionLivenessOracleConfig>` to
+  `SessionManagerConfig`.
+- `tests/unit/session-liveness-oracle.test.ts` (new, 15 tests) — incident fix (timeout→indeterminate),
+  exact-id match, cache, retry, boot-cap, coalescing, config floors.
+- `tests/unit/death-spiral-fixes.test.ts` — purge suite rewritten to oracle semantics + the 2026-05-27
+  incident reproduction (timing-out tmux at boot → 0 purges).
+
+**What changes behaviorally:** the boot purge no longer treats a slow/timing-out/unreachable
+`tmux` probe as "dead." It resolves liveness from a single `tmux list-sessions` and purges ONLY when
+the server is reachable AND the exact session id is absent. A timeout/unreachable result is
+`indeterminate` → the session is KEPT and re-verified on the next monitoring tick.
+
+**Over-block risk (a live session wrongly purged):** eliminated for the timeout case — the root cause
+of the incident. Residual: a name-collision could in theory hide a live session, but matching is
+exact-full-id against `list-sessions` output, not prefix/substring.
+
+**Under-block risk (a dead session lingers):** bounded — a genuinely dead session absent from a
+reachable `list-sessions` is still purged immediately. Only the *unverifiable* case lingers, and only
+until the next tick (cheap). The §P5 backstop (later commit) escalates a permanently-unverifiable
+session to the Attention queue so it can never leak forever or fill the spawn cap.
+
+**Death-spiral (the original purge's reason for existing):** preserved and improved. The oracle is
+async (never `execFileSync` on boot), resolves the whole set from ONE `list-sessions`, retries once
+with backoff, and is bounded by a total boot-cap (default 8s) — on cap it returns `indeterminate`
+rather than blocking boot. So conservatism does not re-introduce startup-blocking latency.
+
+**Signal vs authority:** the oracle is pure-data (tier0) — it only *reports* alive/dead/indeterminate;
+it never kills. The kill decision stays with `terminateSession()` (the authority, wired in a later
+commit). No new kill authority is introduced here.
+
+**Migration parity:** the oracle is server-side TS (ships with the server, no migrator needed). The new
+`liveness` config block is optional (`Partial`), defaults applied in-code via `DEFAULT_LIVENESS_CONFIG`;
+a `migrateConfig` entry + startup validation (`validateLivenessConfig`, rejects a sub-floor timeout)
+land with the config-wiring commit.
+
+**Rollback:** additive. Reverting the `purgeDeadSessions` change restores the old behavior; the new
+module is unreferenced if the field/getter are removed. The DI seam (`setLivenessOracle`) is test-only
+surface with no production caller.
+
+**Tests:** 15 (oracle) + 14 (purge/death-spiral) green; typecheck clean. Reproduce-before-claim for
+the live boot scenario is owed before declaring the incident fixed end-to-end (E2E tier, later commit).

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -132,3 +132,47 @@ as awake.
 **Tests:** terminate (9) + reaper (30) + guard (15) + oracle (15) + timeout (4+6) + async-monitor (6) +
 lifecycle integration (6) green; typecheck clean. One brittle source-string test updated to the new
 age-kill log + funnel contract.
+
+## Commit — P3 reap-notify seam + P4 reap-log + Agent-Awareness + migration
+
+**Files:**
+- `src/monitoring/ReapNotifier.ts` (new) — single coalescing `sessionReaped` listener. Silent on
+  `recovery-bounce` and `origin:'operator'`; isolated reap → bound topic (or lifeline); burst within
+  the window → ONE consolidated lifeline message stating the EXACT total (count tracked separately from
+  the bounded detail buffer, so an overflow never under-reports). User-controlled names/reasons wrapped
+  as literal inline-code spans (inner backticks neutralized) so the downstream formatter never renders
+  them as markup.
+- `src/monitoring/ReapLog.ts` (new) — append-only JSONL audit at `logs/reap-log.jsonl`; records BOTH
+  reaps (`sessionReaped`) and refused/skipped terminates (`reapBlocked`); JSON-encoded (no concat →
+  no newline injection); read tolerates corrupt lines.
+- `src/server/routes.ts` — `GET /sessions/reap-log` (Bearer-auth via router middleware, read-only,
+  `?limit` capped at 1000, default 200).
+- `src/server/AgentServer.ts` — `reapLog` option + ctx wire (mirrors `sessionReaper`).
+- `src/commands/server.ts` — ReapLog + ReapNotifier built and the `sessionReaped`/`reapBlocked`
+  listeners + `setAwakeChecker` wired BEFORE the boot purge, so boot reaps are lease-gated, logged, and
+  notified. (The KEEP-guard is wired later, after its tracker deps exist — safe: boot-purge bypasses it
+  via `knownDead`, and no monitorTick kill can fire in the first seconds.)
+- `src/core/types.ts` + `src/config/ConfigDefaults.ts` — `monitoring.reapNotify {enabled, coalesceWindowMs}`,
+  default ON.
+- `src/scaffold/templates.ts` (Agent-Awareness) + `src/core/PostUpdateMigrator.migrateClaudeMd` (existing
+  agents get the Reap-Log section) + `migrateConfig` via ConfigDefaults (existing agents get the
+  `reapNotify` default automatically).
+
+**Notify default = ON (deliberate, differs from sentinelTelegramEscalation).** The silently-stopped
+sentinel escalation defaults OFF (post-2026-05-22 flood). The reap-notify defaults ON because the
+incident this whole spec answers is *silent disappearance* — the user explicitly asked to be told. The
+flood risk is bounded by: (a) coalescing a burst into one message, (b) staying silent on the common
+recovery-bounce + operator paths, (c) SUMMARY tier (quiet-hours aware). A single config flag disables it.
+
+**Discoverability:** `/sessions/reap-log` lives under the already-classified `sessions` prefix
+(operator/dashboard-only in CapabilityIndex) — no new prefix, no lint change. Agent-awareness is carried
+by the CLAUDE.md template + migrateClaudeMd instead (the template IS the agent's awareness).
+
+**Ordering side-effect (reviewed):** the listeners attach pre-boot-purge; the guard wires post. The only
+guard consumers besides boot-purge are monitorTick #2/#3, which require multi-hour age / 15+m observed
+idle — unreachable in the sub-second guard-unset window. Documented inline.
+
+**Tests:** ReapNotifier (10: silent dispositions/origins, isolated bound/unbound routing, burst
+coalescing, overflow exact-count, auto-timer, malicious-name literalization, unreachable-channel drop)
++ ReapLog (6: empty, reaped/skipped fields, newline-injection→valid-JSON, tail, corrupt-line tolerance)
+green; typecheck clean. Route integration + e2e land in the test-phase commit.


### PR DESCRIPTION
## Summary

Phase 1 of the unified session-lifecycle robustness spec (`docs/specs/unified-session-lifecycle-robustness.md`, converged 3 rounds + approved). Closes the disappearing-session incident (boot purge wiped 9-of-9 live sessions, treating slow-to-answer as dead) and builds the single authority + safety backbone the remaining killers will move onto.

- **One ReapAuthority** — `terminateSession()` is the sole kill chokepoint. Autonomous killers can only *request*; the authority holds the safety checks: CAS live-status guard, `protected` set, an **awake-machine-only lease gate**, and a mandatory **ReapGuard** (P2) KEEP-consult. Operator kills (stamped only by the Bearer-authed HTTP route) bypass the gates so a human kill always happens. Killers #1 boot-purge / #2 age-kill / #3 idle-zombie are funneled through it (#5/#6/#8/#9 follow in Phase 2).
- **P1 tri-state liveness oracle** — `dead` requires server-reachable + exact-id-absent; slow/unreachable → `indeterminate` → KEPT, never reaped. Boot-purge reproduction: the 2026-05-27 9-of-9 wipe → **0 false purges**.
- **P3 reap-notify** — one coalescing `sessionReaped` listener surfaces "your session was shut down — <reason>"; silent on recovery-bounce + operator kills; a burst collapses into one consolidated lifeline message. Default on (`monitoring.reapNotify`).
- **P4 reap-log** — every reap AND every refused/skipped terminate recorded as JSON; read-only `GET /sessions/reap-log` (Bearer). Agent-awareness in the CLAUDE.md template + `migrateClaudeMd`.
- **P5 unkillability backstop** — signal-only: a faking-work or stuck-indeterminate session raises ONE per-episode-deduped Attention item (never auto-kills); long-indeterminate sessions are excluded from the absolute spawn cap so unverifiable panes can't lock out spawning.

All changes additive; only make killing *more* conservative.

## Test plan

- [x] Unit (123): ReapGuard 15, ReapNotifier 10, ReapLog 6, StaleSessionBackstop 10, terminate-CAS 9, liveness-oracle 15, boot-purge death-spiral reproduction, timeout/activity-aware.
- [x] Integration (10): `GET /sessions/reap-log` through createRoutes (503/200/limit/read-only); full event-path wiring (autonomous reap → log + one notice; recovery-bounce/operator silent; relay-lease/standby/protected refused-and-survive).
- [x] E2E (3): real AgentServer — reap-log route alive (200 not 503), surfaces entries, Bearer-required, read-only.
- [x] `tsc --noEmit` clean; migration parity (reapNotify + staleBackstop via ConfigDefaults; reap-log section in template + migrator).
- [ ] CI full sharded suite (authority).

**Honest scope note:** the boot-purge false-purge + notice/log/survival paths are reproduced at the unit + real-event-path + real-AgentServer tiers; a live "boot a server, slow tmux, watch a Telegram notice land" pass was not performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)