### PR TITLE
Session-lifecycle robustness — Phase 2 (#5/#6/#8/#9 onto ReapAuthority)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -4906,10 +4906,21 @@ export async function startServer(options: StartOptions): Promise<void> {
               return /^\d+$/.test(pid) ? parseInt(pid, 10) : null;
             } catch { return null; }
           },
-          killSession: (name) => {
-            // Route through SessionManager to fire beforeSessionKill hook
-            const session = sessionManager.listRunningSessions().find(s => s.tmuxSession === name);
-            if (session) { sessionManager.killSession(session.id); return; }
+          // UNIFIED-SESSION-LIFECYCLE §P0 #8: route the kill-to-respawn through
+          // the ReapAuthority with disposition:'recovery-bounce' (silent §P3
+          // notifier — a bounce is not a disappearance) and bypassRecoveryFlag
+          // (the recovery's own in-flight flag would otherwise refuse its own
+          // kill via the KEEP-guard).
+          killSession: async (name) => {
+            const session = sessionManager.listRunningSessions().find((s) => s.tmuxSession === name);
+            if (session) {
+              await sessionManager.terminateSession(session.id, 'session-recovery', {
+                disposition: 'recovery-bounce',
+                finalStatus: 'killed',
+                bypassRecoveryFlag: true,
+              });
+              return;
+            }
             // Fallback: direct tmux kill for untracked sessions
             try {
               const tmux = detectTmuxPath();
@@ -4917,6 +4928,8 @@ export async function startServer(options: StartOptions): Promise<void> {
               execFileSync(tmux, ['kill-session', '-t', `=${name}`], { encoding: 'utf-8' });
             } catch { /* may already be dead */ }
           },
+          // P1/P2 cross-check dep — see SessionRecovery.killForRecovery().
+          hasActiveProcesses: (name) => sessionManager.hasActiveProcesses(name),
           respawnSession: async (topicId, _sessionName, recoveryPrompt) => {
             // Check Slack first (synthetic IDs are negative)
             const slackChId = slackProxyChannelMap.get(topicId);

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -6708,6 +6708,12 @@ export async function startServer(options: StartOptions): Promise<void> {
     // Start SleepWakeDetector (re-validate sessions on wake)
     const { SleepWakeDetector } = await import('../core/SleepWakeDetector.js');
     const sleepWakeDetector = new SleepWakeDetector();
+    // §P0 #9 (SE-8): give the scheduler's wake-reaper a cumulative-sleep view
+    // (not the single last sleep event) so a job that spanned multiple sleeps
+    // isn't reaped early.
+    if (scheduler) {
+      scheduler.setCumulativeSleepProvider((a, b) => sleepWakeDetector.getCumulativeSleepMsBetween(a, b));
+    }
     sleepWakeDetector.on('wake', async (event: { sleepDurationSeconds: number; timestamp: string }) => {
       console.log(`[SleepWake] Wake detected after ~${event.sleepDurationSeconds}s sleep`);
 
@@ -6784,7 +6790,7 @@ export async function startServer(options: StartOptions): Promise<void> {
       let reapResult: { reaped: string[]; skipped: number } = { reaped: [], skipped: 0 };
       try {
         if (scheduler) {
-          reapResult = scheduler.reapStuckRuns(event);
+          reapResult = await scheduler.reapStuckRuns(event);
         }
       } catch (err) {
         console.error('[SleepWake][reaper] unexpected error:', err);

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -528,6 +528,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
       disposition?: 'terminal' | 'recovery-bounce';
       origin?: 'operator' | 'autonomous';
       knownDead?: boolean;
+      bypassRecoveryFlag?: boolean;
     },
   ): Promise<{ terminated: boolean; skipped?: string }> {
     const session = this.state.getSession(sessionId);
@@ -569,7 +570,15 @@ rm()  { "${shimRunner}" rm  "$@"; }
       // liveness to protect, so skip the guard. Lease + protected + CAS still apply.
       if (!opts?.knownDead) {
         const blocked = this.reapGuard?.blockedReason(session);
-        if (blocked) {
+        // `bypassRecoveryFlag` (UNIFIED-SESSION-LIFECYCLE §P0 #8): the recovery
+        // engine itself sets the recovery-in-flight flag synchronously before
+        // its kill-to-respawn, so the guard would otherwise refuse the
+        // recovery's own kill. Bypass ONLY the recovery-in-flight check — all
+        // other KEEP-guards (active subagent, recent-user-message, etc.) still
+        // apply, so a session mid-conversation isn't killed-to-respawn under
+        // the cover of "recovery."
+        const bypassThis = !!(opts?.bypassRecoveryFlag && blocked?.reason === 'recovery-in-flight');
+        if (blocked && !bypassThis) {
           this.emit('reapBlocked', { session, reason, skipped: blocked.reason, origin });
           return { terminated: false, skipped: blocked.reason };
         }

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -1511,6 +1511,20 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Every tmuxSession name SessionManager has ever known (any status — running,
+   * completed, failed, killed). Backs the OrphanProcessReaper's exact-id orphan
+   * classification (UNIFIED-SESSION-LIFECYCLE §P0 #6): a process is an instar-
+   * orphan ONLY when its tmuxSession exactly matches a name instar has tracked,
+   * never via a project-prefix substring (which over-matches user-created
+   * sessions that happen to share the prefix).
+   */
+  listKnownTmuxSessions(): Set<string> {
+    const out = new Set<string>();
+    for (const s of this.state.listSessions()) out.add(s.tmuxSession);
+    return out;
+  }
+
+  /**
    * Get cached running session info (count + list) without blocking the event loop.
    * Updated asynchronously by the monitor tick every 5 seconds.
    * Safe to call from the health endpoint and other latency-sensitive paths.

--- a/src/core/SleepWakeDetector.ts
+++ b/src/core/SleepWakeDetector.ts
@@ -63,6 +63,31 @@ export class SleepWakeDetector extends EventEmitter {
     }
   }
 
+  /**
+   * Cumulative wall-time-asleep during the half-open window [startMs, endMs).
+   * Used by the wake-reaper (UNIFIED-SESSION-LIFECYCLE §P0 #9 / SE-8) to subtract
+   * sleep that overlapped a job run rather than relying on the single last
+   * `sleepDurationSeconds` event — a run that started before multiple sleeps was
+   * previously credited only the last sleep's duration and reaped early.
+   *
+   * Each wake event's sleep window is approximated as
+   *   [wakeTimestamp − sleepDurationSeconds, wakeTimestamp].
+   * Returns the sum of overlap with the query window in milliseconds. Returns 0
+   * when the history is empty or no event overlaps.
+   */
+  getCumulativeSleepMsBetween(startMs: number, endMs: number): number {
+    if (endMs <= startMs) return 0;
+    let total = 0;
+    for (const e of this.wakeHistory) {
+      const wakeMs = new Date(e.timestamp).getTime();
+      const sleepStartMs = wakeMs - e.sleepDurationSeconds * 1000;
+      const overlapStart = Math.max(startMs, sleepStartMs);
+      const overlapEnd = Math.min(endMs, wakeMs);
+      if (overlapEnd > overlapStart) total += overlapEnd - overlapStart;
+    }
+    return total;
+  }
+
   /** Get wake event stats for telemetry reporting. */
   getStats(sinceMs?: number): { wakeCount: number; totalSleepSeconds: number; longestSleepSeconds: number } {
     const since = sinceMs ?? 0;

--- a/src/monitoring/OrphanProcessReaper.ts
+++ b/src/monitoring/OrphanProcessReaper.ts
@@ -149,8 +149,14 @@ export class OrphanProcessReaper extends EventEmitter {
     const claudeProcesses = this.findAllFrameworkProcesses();
     const tmuxSessions = this.listAllTmuxSessions();
     const trackedSessions = this.getTrackedSessionNames();
+    // UNIFIED-SESSION-LIFECYCLE §P0 #6 — every tmux name instar has ever known
+    // (running + completed + failed + killed). The orphan classifier uses
+    // EXACT-id membership in this set rather than a project-prefix substring, so
+    // a user-created tmux session that happens to share the prefix (e.g. user
+    // typing `tmux new -s the-portal-myhand`) is NOT false-classified as orphan.
+    const knownInstarSessions = this.sessionManager.listKnownTmuxSessions();
 
-    const classified = this.classifyProcesses(claudeProcesses, tmuxSessions, trackedSessions);
+    const classified = this.classifyProcesses(claudeProcesses, tmuxSessions, trackedSessions, knownInstarSessions);
 
     const tracked = classified.filter(p => p.classification === 'tracked');
     const orphans = classified.filter(p => p.classification === 'instar-orphan');
@@ -175,10 +181,34 @@ export class OrphanProcessReaper extends EventEmitter {
 
     for (const orphan of orphans) {
       if (orphan.elapsedMs > orphanMaxAge && autoKill) {
+        // §P0 #6 P2-style work check: 60-min age is NECESSARY, not SUFFICIENT.
+        // An orphan with active child processes is doing real work — defer the
+        // reap rather than killing a working pipeline.
+        if (this.processHasActiveChildren(orphan.pid)) {
+          const msg = `Kept orphan PID ${orphan.pid} (age ${this.formatDuration(orphan.elapsedMs)}, tmux: ${orphan.tmuxSession || 'none'}) — active child processes (work check vetoed reap)`;
+          report.actionsPerformed.push(msg);
+          console.log(`[OrphanReaper] ${msg}`);
+          continue;
+        }
         this.killProcess(orphan.pid);
-        // Also kill the tmux session if it exists — but NEVER the server session
+        // Also kill the tmux session if it exists — but NEVER the server session.
+        // §P0 #6 route through ReapAuthority when the orphan's tmuxSession
+        // matches a CURRENTLY-tracked session (a race between this scan and a
+        // tracking refresh): the authority's KEEP-guard + lease gate + reap-log
+        // + sessionReaped emission then apply. Otherwise the state record is
+        // already terminal — just clean up the stray tmux pane.
         if (orphan.tmuxSession && orphan.tmuxSession !== serverSessionName) {
-          this.killTmuxSession(orphan.tmuxSession);
+          const trackedNow = this.sessionManager
+            .listRunningSessions()
+            .find((s) => s.tmuxSession === orphan.tmuxSession);
+          if (trackedNow) {
+            await this.sessionManager.terminateSession(trackedNow.id, 'orphan-reap', {
+              disposition: 'terminal',
+              finalStatus: 'killed',
+            });
+          } else {
+            this.killTmuxSession(orphan.tmuxSession);
+          }
         }
         const msg = `Killed orphan PID ${orphan.pid} (${Math.round(orphan.rssKB / 1024)}MB, running ${this.formatDuration(orphan.elapsedMs)}, tmux: ${orphan.tmuxSession || 'none'})`;
         report.actionsPerformed.push(msg);
@@ -391,6 +421,7 @@ export class OrphanProcessReaper extends EventEmitter {
     processes: FrameworkProcess[],
     tmuxSessions: Map<number, string>,
     trackedSessions: Set<string>,
+    knownInstarSessions: Set<string>,
   ): ClassifiedProcess[] {
     return processes.map(proc => {
       // Resolve which tmux session this process belongs to
@@ -414,12 +445,16 @@ export class OrphanProcessReaper extends EventEmitter {
           };
         }
 
-        // In a tmux session matching our project prefix but NOT tracked
-        if (tmuxSession.startsWith(this.projectPrefix)) {
+        // EXACT-id orphan: the tmux session name matches one instar has
+        // tracked (current or historical), but isn't in the live-tracked set.
+        // This replaces the old prefix-startsWith match per
+        // UNIFIED-SESSION-LIFECYCLE §P0 #6 — a user-created session that happens
+        // to share the project prefix is NOT classified as orphan.
+        if (knownInstarSessions.has(tmuxSession)) {
           return {
             ...proc,
             classification: 'instar-orphan' as const,
-            reason: `In project-prefixed tmux "${tmuxSession}" but not tracked by SessionManager`,
+            reason: `In instar-known tmux "${tmuxSession}" but not currently tracked by SessionManager`,
           };
         }
 
@@ -525,6 +560,27 @@ export class OrphanProcessReaper extends EventEmitter {
       if (err.code !== 'ESRCH') {
         console.error(`[OrphanReaper] Failed to kill PID ${pid}:`, err);
       }
+      return false;
+    }
+  }
+
+  /**
+   * §P0 #6 work-check: does the process have at least one active child? Used as
+   * a 60-min-age-is-necessary-not-sufficient gate before a reap. A pgrep-empty
+   * orphan is genuinely idle and safe to reap; an orphan with running children
+   * is doing real work and must be kept.
+   *
+   * Errors → `false` (cannot inspect ⇒ allow the reap to proceed, matching the
+   * pre-Phase-2 behavior; this never makes the reaper MORE aggressive — the
+   * helper is a soft veto layered on top of the existing age gate).
+   */
+  private processHasActiveChildren(pid: number): boolean {
+    try {
+      const out = shellExec(`pgrep -P ${pid} 2>/dev/null`).trim();
+      return out.length > 0;
+    } catch {
+      // @silent-fallback-ok — cannot inspect (no permission / process gone) ⇒
+      // do not block the reap; the age gate already gives 60 min of grace.
       return false;
     }
   }

--- a/src/monitoring/SessionRecovery.ts
+++ b/src/monitoring/SessionRecovery.ts
@@ -62,8 +62,23 @@ export interface SessionRecoveryDeps {
   isSessionAlive: (sessionName: string) => boolean;
   /** Get the PID of the pane in a tmux session */
   getPanePid?: (sessionName: string) => number | null;
-  /** Kill a tmux session */
-  killSession: (sessionName: string) => void;
+  /**
+   * Kill a tmux session — for kill-to-respawn paths this should route through
+   * `SessionManager.terminateSession(id, 'session-recovery', { disposition:
+   * 'recovery-bounce', finalStatus: 'killed', bypassRecoveryFlag: true })` so the
+   * §P3 notifier stays silent (a bounce is not a disappearance) and the kill
+   * lands in the reap-log as a recovery-bounce (UNIFIED-SESSION-LIFECYCLE §P0 #8).
+   * Implementations may be async; callers `await` the result.
+   */
+  killSession: (sessionName: string) => void | Promise<void>;
+  /**
+   * P1/P2 cross-check (UNIFIED-SESSION-LIFECYCLE §P0 #8): does the session's
+   * tmux pane have active child processes? A JSONL stall on a process that is
+   * still producing real work is almost always a false read — keep the session
+   * and let the next tick re-evaluate. Undefined ⇒ check is skipped (defaults
+   * to the pre-Phase-2 behavior).
+   */
+  hasActiveProcesses?: (sessionName: string) => boolean;
   /** Respawn a session for a topic, optionally with a recovery prompt */
   respawnSession: (topicId: number, sessionName?: string, recoveryPrompt?: string) => Promise<void>;
   /** Send a message to a topic */
@@ -243,6 +258,31 @@ export class SessionRecovery extends EventEmitter {
   // Recovery Methods
   // ============================================================================
 
+  /**
+   * Shared kill-to-respawn entry (UNIFIED-SESSION-LIFECYCLE §P0 #8).
+   *  - P1/P2 cross-check first: if the tmux pane has active child processes the
+   *    session is doing real work and the JSONL "stall/crash" reading is almost
+   *    certainly stale — defer this recovery attempt, let the next tick re-read.
+   *  - Otherwise route through the dep's killSession (which is wired in
+   *    server.ts to `terminateSession(disposition:'recovery-bounce',
+   *    bypassRecoveryFlag:true)` so the §P3 notifier stays silent — a bounce is
+   *    not a disappearance — and the kill lands in the reap-log).
+   *
+   *  @returns `'killed'` on a kill we performed; `'deferred-still-working'`
+   *           when the work-check vetoed the kill.
+   */
+  private async killForRecovery(sessionName: string): Promise<'killed' | 'deferred-still-working'> {
+    if (this.deps.hasActiveProcesses && this.deps.hasActiveProcesses(sessionName)) {
+      console.log(
+        `[SessionRecovery] "${sessionName}": P1/P2 cross-check found active child processes — `
+          + `deferring recovery (JSONL stall but the process is still producing work)`,
+      );
+      return 'deferred-still-working';
+    }
+    await this.deps.killSession(sessionName);
+    return 'killed';
+  }
+
   private async recoverFromStall(
     topicId: number,
     sessionName: string,
@@ -263,7 +303,12 @@ export class SessionRecovery extends EventEmitter {
     this.emit('recovery:stall', { topicId, sessionName, stall, attemptNumber });
 
     // Kill and respawn (stalls don't need truncation — just resume)
-    this.deps.killSession(sessionName);
+    if ((await this.killForRecovery(sessionName)) === 'deferred-still-working') {
+      return {
+        recovered: false, failureType: 'stall', attemptNumber,
+        message: `Stall recovery deferred for ${sessionName} — work-check found active children; the JSONL "stall" reading is unreliable while the process is producing work`,
+      };
+    }
 
     await new Promise(resolve => setTimeout(resolve, 3000));
 
@@ -320,7 +365,12 @@ export class SessionRecovery extends EventEmitter {
     const detectedAt = Date.now();
 
     // Kill the session — it's stuck at the "conversation too long" prompt
-    this.deps.killSession(sessionName);
+    if ((await this.killForRecovery(sessionName)) === 'deferred-still-working') {
+      return {
+        recovered: false, failureType: 'context_exhaustion', attemptNumber,
+        message: `Context-exhaustion recovery deferred for ${sessionName} — work-check found active children`,
+      };
+    }
 
     // Grace period: poll topic history for any in-flight agent reply from the
     // dying session. If one lands, capture its text so the fresh session can
@@ -443,7 +493,12 @@ export class SessionRecovery extends EventEmitter {
     }
 
     // Kill (might already be dead) and respawn
-    this.deps.killSession(sessionName);
+    if ((await this.killForRecovery(sessionName)) === 'deferred-still-working') {
+      return {
+        recovered: false, failureType: 'crash', attemptNumber,
+        message: `Crash recovery deferred for ${sessionName} — work-check found active children (the JSONL "crashed" reading conflicts with a running process)`,
+      };
+    }
     await new Promise(resolve => setTimeout(resolve, 3000));
 
     const recoveryPrompt = this.buildCrashRecoveryPrompt(crash, strategy);
@@ -504,7 +559,12 @@ export class SessionRecovery extends EventEmitter {
     }
 
     // Kill and respawn
-    this.deps.killSession(sessionName);
+    if ((await this.killForRecovery(sessionName)) === 'deferred-still-working') {
+      return {
+        recovered: false, failureType: 'error_loop', attemptNumber,
+        message: `Error-loop recovery deferred for ${sessionName} — work-check found active children`,
+      };
+    }
     await new Promise(resolve => setTimeout(resolve, 3000));
 
     const recoveryPrompt = this.buildErrorLoopRecoveryPrompt(loop, strategy);

--- a/src/monitoring/SessionWatchdog.ts
+++ b/src/monitoring/SessionWatchdog.ts
@@ -274,7 +274,7 @@ export class SessionWatchdog extends EventEmitter {
     const existing = this.escalationState.get(tmuxSession);
 
     if (existing && existing.level > EscalationLevel.Monitoring) {
-      this.handleEscalation(tmuxSession, existing);
+      await this.handleEscalation(tmuxSession, existing);
       return;
     }
 
@@ -481,7 +481,7 @@ export class SessionWatchdog extends EventEmitter {
     this.emit('compaction-idle', tmuxSession);
   }
 
-  private handleEscalation(tmuxSession: string, state: EscalationState): void {
+  private async handleEscalation(tmuxSession: string, state: EscalationState): Promise<void> {
     const now = Date.now();
 
     if (!this.isProcessAlive(state.stuckChildPid)) {
@@ -531,12 +531,41 @@ export class SessionWatchdog extends EventEmitter {
         this.recordIntervention(tmuxSession, EscalationLevel.SigKill, `SIGKILL ${state.stuckChildPid}`, child);
         break;
 
-      case EscalationLevel.KillSession:
-        console.log(`[Watchdog] "${tmuxSession}": killing tmux session`);
-        this.killTmuxSession(tmuxSession);
-        this.recordIntervention(tmuxSession, EscalationLevel.KillSession, 'Killed tmux session', child);
+      case EscalationLevel.KillSession: {
+        // UNIFIED-SESSION-LIFECYCLE §P0 #5: route the final-level kill through the
+        // single ReapAuthority instead of the raw `tmux kill-session`. The
+        // authority consults the P2 KEEP-guard (relay-lease / active subagent /
+        // recent-user-message / etc.) and the awake-machine lease gate before any
+        // autonomous kill — so a session the guards would have kept survives a
+        // buggy watchdog, gains exactly-once sessionComplete/sessionReaped
+        // emission, and lands in the reap-log with its reason.
+        console.log(`[Watchdog] "${tmuxSession}": requesting session kill via ReapAuthority`);
+        const sess = this.sessionManager
+          .listRunningSessions()
+          .find((s) => s.tmuxSession === tmuxSession);
+        if (!sess) {
+          // Session already gone — nothing to kill.
+          this.recordIntervention(tmuxSession, EscalationLevel.KillSession, 'session already gone', child);
+          this.escalationState.delete(tmuxSession);
+          break;
+        }
+        const result = await this.sessionManager.terminateSession(sess.id, 'watchdog-stuck', {
+          disposition: 'terminal',
+          finalStatus: 'killed',
+        });
+        if (result.terminated) {
+          this.recordIntervention(tmuxSession, EscalationLevel.KillSession, 'terminated via ReapAuthority', child);
+        } else {
+          // The authority refused (protected / lease / a KEEP). Stand down — the
+          // guards own this decision; the §P5 backstop will surface a
+          // persistently-stale session for an operator decision rather than the
+          // watchdog re-escalating against a guarded session every tick.
+          console.log(`[Watchdog] "${tmuxSession}": kill refused — ${result.skipped} (standing down)`);
+          this.recordIntervention(tmuxSession, EscalationLevel.KillSession, `kept (${result.skipped})`, child);
+        }
         this.escalationState.delete(tmuxSession);
         break;
+      }
     }
   }
 
@@ -860,11 +889,6 @@ export class SessionWatchdog extends EventEmitter {
     }
   }
 
-  private killTmuxSession(tmuxSession: string): void {
-    try {
-      shellExec(`${this.config.sessions.tmuxPath} kill-session -t "=${tmuxSession}" 2>/dev/null`);
-    } catch {}
-  }
 
   private recordIntervention(
     sessionName: string,

--- a/src/scheduler/JobScheduler.ts
+++ b/src/scheduler/JobScheduler.ts
@@ -115,6 +115,14 @@ export class JobScheduler {
 
   /** Optional job claim manager for multi-machine deduplication (Phase 4C) */
   private claimManager: JobClaimManager | null = null;
+  /**
+   * UNIFIED-SESSION-LIFECYCLE §P0 #9 (SE-8): function returning cumulative
+   * wall-time-asleep in milliseconds during a half-open window [startMs, endMs).
+   * Wired by server.ts to SleepWakeDetector.getCumulativeSleepMsBetween. When
+   * unset, the wake-reaper falls back to no sleep subtraction (the pre-Phase-2
+   * behavior — never more aggressive).
+   */
+  private cumulativeSleepProvider: ((startMs: number, endMs: number) => number) | null = null;
 
   /** Optional LLM provider for per-job reflection (Living Skills Phase 4) */
   private intelligence: IntelligenceProvider | null = null;
@@ -144,6 +152,15 @@ export class JobScheduler {
    */
   setMessenger(adapter: MessagingAdapter): void {
     this.messenger = adapter;
+  }
+
+  /**
+   * Inject the cumulative-sleep provider used by the wake-reaper
+   * (UNIFIED-SESSION-LIFECYCLE §P0 #9 / SE-8). Pass undefined or omit to leave
+   * the reaper in its no-subtraction fallback behavior.
+   */
+  setCumulativeSleepProvider(fn: (startMs: number, endMs: number) => number): void {
+    this.cumulativeSleepProvider = fn;
   }
 
   /**
@@ -540,7 +557,7 @@ export class JobScheduler {
    * Reaping is idempotent: a second invocation finds the run is no
    * longer `pending` and skips it.
    */
-  reapStuckRuns(sleepEvent: { sleepDurationSeconds: number }): { reaped: string[]; skipped: number } {
+  async reapStuckRuns(sleepEvent: { sleepDurationSeconds: number }): Promise<{ reaped: string[]; skipped: number }> {
     const result = { reaped: [] as string[], skipped: 0 };
 
     const minSleepSec = this.config.wakeReaper?.minSleepSeconds ?? 60;
@@ -562,14 +579,45 @@ export class JobScheduler {
       const job = jobMap.get(run.slug);
       const expMin = job?.expectedDurationMinutes ?? DEFAULT_EXPECTED_MINUTES;
       const thresholdMs = expMin * multiplier * 60_000;
-      const elapsedMs = now - new Date(run.startedAt).getTime();
-      if (elapsedMs <= thresholdMs) {
+      const runStartMs = new Date(run.startedAt).getTime();
+      const elapsedMs = now - runStartMs;
+      // §P0 #9 / SE-8: cumulative wall-time-asleep DURING this run, not the single
+      // last sleepDurationSeconds. A run that started before multiple sleeps was
+      // previously credited only the last sleep and reaped early.
+      const cumulativeSleepMs = this.cumulativeSleepProvider?.(runStartMs, now) ?? 0;
+      const effectiveElapsed = elapsedMs - cumulativeSleepMs;
+      if (effectiveElapsed <= thresholdMs) {
         result.skipped++;
         continue;
       }
 
+      // §P0 #9 P1/P2 gate — a progressing process is KEEP regardless of clock.
+      // The wall-clock gap can exceed the threshold for an actively-running job
+      // (the user kept the machine awake; the job stalled on a remote API; etc.)
+      // — never reap a session that's still producing real work.
+      if (this.sessionManager.hasActiveProcesses?.(sessionName)) {
+        console.log(
+          `[scheduler][reaper] "${sessionName}" effective-elapsed ${Math.round(effectiveElapsed / 60_000)}m `
+            + `exceeded ${expMin}m × ${multiplier} threshold, but P1/P2 work-check found active children — keeping`,
+        );
+        result.skipped++;
+        continue;
+      }
+
+      // §P0 #9 route through the ReapAuthority — the authority's protected-set
+      // + lease gate + reap-log + sessionReaped emission apply (one chokepoint).
       try {
-        this.sessionManager.killSession?.(sessionName);
+        const tracked = this.sessionManager.listRunningSessions?.().find((s) => s.tmuxSession === sessionName);
+        if (tracked) {
+          await this.sessionManager.terminateSession?.(tracked.id, 'wake-reaper', {
+            disposition: 'terminal',
+            finalStatus: 'killed',
+          });
+        } else {
+          // Not currently tracked — fall back to killSession (which itself is a
+          // pane-only teardown when the state record is already terminal).
+          this.sessionManager.killSession?.(sessionName);
+        }
       } catch {
         // Best-effort — session may already be dead.
       }
@@ -578,7 +626,7 @@ export class JobScheduler {
         this.runHistory.recordCompletion({
           runId,
           result: 'timeout',
-          error: `Reaped on wake — sleep gap of ${sleepEvent.sleepDurationSeconds}s exceeded ${expMin}min × ${multiplier} threshold`,
+          error: `Reaped on wake — effective elapsed ${Math.round(effectiveElapsed / 60_000)}m (cumulative sleep ${Math.round(cumulativeSleepMs / 60_000)}m subtracted) exceeded ${expMin}min × ${multiplier} threshold`,
         });
       } catch (err) {
         // Leave activeRunIds entry intact: run is still 'pending' in the ledger,

--- a/tests/unit/JobScheduler-reaper.test.ts
+++ b/tests/unit/JobScheduler-reaper.test.ts
@@ -77,7 +77,7 @@ describe('JobScheduler.reapStuckRuns', () => {
       .map(l => JSON.parse(l));
   }
 
-  it('does nothing when sleep is shorter than the minimum threshold', () => {
+  it('does nothing when sleep is shorter than the minimum threshold', async () => {
     createScheduler();
     const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60_000).toISOString();
     seedPendingRun({
@@ -87,14 +87,14 @@ describe('JobScheduler.reapStuckRuns', () => {
       startedAt: fourHoursAgo,
     });
 
-    const result = scheduler.reapStuckRuns({ sleepDurationSeconds: 30 });
+    const result = await scheduler.reapStuckRuns({ sleepDurationSeconds: 30 });
 
     expect(result.reaped).toEqual([]);
     expect(result.skipped).toBe(0);
     expect((scheduler as any).activeRunIds.size).toBe(1);
   });
 
-  it('skips a pending run whose elapsed time is under the 2× threshold', () => {
+  it('skips a pending run whose elapsed time is under the 2× threshold', async () => {
     createScheduler();
     // health-check has expectedDurationMinutes: 2 — threshold is 4 minutes.
     // Started 1 minute ago → still well within budget.
@@ -106,7 +106,7 @@ describe('JobScheduler.reapStuckRuns', () => {
       startedAt: oneMinuteAgo,
     });
 
-    const result = scheduler.reapStuckRuns({ sleepDurationSeconds: 600 });
+    const result = await scheduler.reapStuckRuns({ sleepDurationSeconds: 600 });
 
     expect(result.reaped).toEqual([]);
     expect(result.skipped).toBe(1);
@@ -117,7 +117,7 @@ describe('JobScheduler.reapStuckRuns', () => {
     expect(lines[0].result).toBe('pending');
   });
 
-  it('reaps a pending run whose elapsed time exceeds the 2× threshold', () => {
+  it('reaps a pending run whose elapsed time exceeds the 2× threshold', async () => {
     createScheduler();
     // health-check has expectedDurationMinutes: 2 — threshold is 4 minutes.
     // Started 4 hours ago — well past it.
@@ -129,7 +129,7 @@ describe('JobScheduler.reapStuckRuns', () => {
       startedAt: fourHoursAgo,
     });
 
-    const result = scheduler.reapStuckRuns({ sleepDurationSeconds: 14400 });
+    const result = await scheduler.reapStuckRuns({ sleepDurationSeconds: 14400 });
 
     expect(result.reaped).toEqual(['health-check']);
     expect(result.skipped).toBe(0);
@@ -141,10 +141,15 @@ describe('JobScheduler.reapStuckRuns', () => {
     expect(completion.result).toBe('timeout');
     expect(completion.runId).toBe('health-check-test-3');
     expect(completion.error).toContain('Reaped on wake');
-    expect(completion.error).toContain('14400s');
+    // §P0 #9 / SE-8 error contract: the message names the effective-elapsed
+    // (wall-clock minus cumulative sleep) and the threshold, not the single
+    // last sleep duration.
+    expect(completion.error).toMatch(/effective elapsed/);
+    expect(completion.error).toMatch(/cumulative sleep/);
+    expect(completion.error).toMatch(/threshold/);
   });
 
-  it('is idempotent — a second invocation finds nothing to reap', () => {
+  it('is idempotent — a second invocation finds nothing to reap', async () => {
     createScheduler();
     const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60_000).toISOString();
     seedPendingRun({
@@ -154,11 +159,11 @@ describe('JobScheduler.reapStuckRuns', () => {
       startedAt: fourHoursAgo,
     });
 
-    const first = scheduler.reapStuckRuns({ sleepDurationSeconds: 14400 });
+    const first = await scheduler.reapStuckRuns({ sleepDurationSeconds: 14400 });
     expect(first.reaped).toEqual(['health-check']);
 
     const linesAfterFirst = readLedgerLines();
-    const second = scheduler.reapStuckRuns({ sleepDurationSeconds: 14400 });
+    const second = await scheduler.reapStuckRuns({ sleepDurationSeconds: 14400 });
 
     expect(second.reaped).toEqual([]);
     expect(second.skipped).toBe(0);
@@ -166,7 +171,7 @@ describe('JobScheduler.reapStuckRuns', () => {
     expect(readLedgerLines()).toHaveLength(linesAfterFirst.length);
   });
 
-  it('handles multiple stuck runs in one pass', () => {
+  it('handles multiple stuck runs in one pass', async () => {
     createScheduler();
     const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60_000).toISOString();
     seedPendingRun({
@@ -182,14 +187,14 @@ describe('JobScheduler.reapStuckRuns', () => {
       startedAt: fourHoursAgo,
     });
 
-    const result = scheduler.reapStuckRuns({ sleepDurationSeconds: 14400 });
+    const result = await scheduler.reapStuckRuns({ sleepDurationSeconds: 14400 });
 
     expect(result.reaped.sort()).toEqual(['email-check', 'health-check']);
     expect(result.skipped).toBe(0);
     expect((scheduler as any).activeRunIds.size).toBe(0);
   });
 
-  it('honors a custom thresholdMultiplier', () => {
+  it('honors a custom thresholdMultiplier', async () => {
     createScheduler({ wakeReaper: { thresholdMultiplier: 100 } });
     // 4 hours past start, but with multiplier 100 the threshold is 200 minutes
     // → 4h elapsed (240min) > 200min, so still reapable.
@@ -203,13 +208,13 @@ describe('JobScheduler.reapStuckRuns', () => {
       startedAt: oneHourAgo,
     });
 
-    const result = scheduler.reapStuckRuns({ sleepDurationSeconds: 7200 });
+    const result = await scheduler.reapStuckRuns({ sleepDurationSeconds: 7200 });
 
     expect(result.reaped).toEqual([]);
     expect(result.skipped).toBe(1);
   });
 
-  it('honors a custom minSleepSeconds', () => {
+  it('honors a custom minSleepSeconds', async () => {
     createScheduler({ wakeReaper: { minSleepSeconds: 1 } });
     const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60_000).toISOString();
     seedPendingRun({
@@ -220,7 +225,7 @@ describe('JobScheduler.reapStuckRuns', () => {
     });
 
     // 5s sleep — under default 60s, but allowed by override.
-    const result = scheduler.reapStuckRuns({ sleepDurationSeconds: 5 });
+    const result = await scheduler.reapStuckRuns({ sleepDurationSeconds: 5 });
 
     expect(result.reaped).toEqual(['health-check']);
   });

--- a/tests/unit/session-lifecycle-phase-2-wiring.test.ts
+++ b/tests/unit/session-lifecycle-phase-2-wiring.test.ts
@@ -32,6 +32,14 @@ const serverSource = fs.readFileSync(
   path.join(process.cwd(), 'src/commands/server.ts'),
   'utf-8',
 );
+const schedulerSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/scheduler/JobScheduler.ts'),
+  'utf-8',
+);
+const sleepWakeSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/core/SleepWakeDetector.ts'),
+  'utf-8',
+);
 
 describe('Phase 2 — per-killer routing contracts', () => {
   describe('#5 SessionWatchdog → ReapAuthority', () => {
@@ -121,6 +129,35 @@ describe('Phase 2 — per-killer routing contracts', () => {
       // The bypass is scoped to the recovery-in-flight reason, not the whole guard.
       expect(sessionManagerSource).toContain('bypassRecoveryFlag');
       expect(sessionManagerSource).toMatch(/blocked\?\.reason\s*===\s*'recovery-in-flight'/);
+    });
+  });
+
+  describe('#9 wake-reaper → P1/P2 + cumulative sleep + ReapAuthority', () => {
+    it('reapStuckRuns is async and uses CUMULATIVE sleep (SE-8), not the single last event', () => {
+      expect(schedulerSource).toMatch(/async reapStuckRuns/);
+      // The cumulative-sleep provider is consulted with [runStartMs, now).
+      expect(schedulerSource).toMatch(/cumulativeSleepProvider\?\.\(runStartMs, now\)/);
+      // Effective elapsed = elapsed − cumulative sleep.
+      expect(schedulerSource).toMatch(/effectiveElapsed\s*=\s*elapsedMs\s*-\s*cumulativeSleepMs/);
+    });
+
+    it('the P1/P2 gate keeps a session whose process is still producing work — regardless of clock', () => {
+      // Before any kill, hasActiveProcesses is consulted; on true the reaper
+      // keeps the session (the spec: "a progressing process is KEEP regardless
+      // of clock").
+      expect(schedulerSource).toMatch(/sessionManager\.hasActiveProcesses\?\.\(sessionName\)/);
+      expect(schedulerSource).toMatch(/P1\/P2 work-check found active children/);
+    });
+
+    it('routes the kill through terminateSession with disposition:terminal when tracked', () => {
+      expect(schedulerSource).toMatch(/terminateSession\?\.\(\s*tracked\.id\s*,\s*'wake-reaper'/);
+      expect(schedulerSource).toContain("disposition: 'terminal'");
+      expect(schedulerSource).toContain("finalStatus: 'killed'");
+    });
+
+    it('SleepWakeDetector exposes the cumulative-sleep accessor + server wires it', () => {
+      expect(sleepWakeSource).toMatch(/getCumulativeSleepMsBetween\(/);
+      expect(serverSource).toMatch(/setCumulativeSleepProvider/);
     });
   });
 });

--- a/tests/unit/session-lifecycle-phase-2-wiring.test.ts
+++ b/tests/unit/session-lifecycle-phase-2-wiring.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Phase-2 routing contracts — UNIFIED-SESSION-LIFECYCLE per-killer guarantees.
+ *
+ * Each killer in Phase 2 (#5 watchdog, #6 orphan, #8 SessionRecovery, #9 wake-
+ * reaper) must funnel its kill through `SessionManager.terminateSession` so the
+ * single ReapAuthority enforces protected/lease/KEEP-guard + emits the
+ * sessionReaped event used by the reap-log + notice. These source assertions are
+ * the structural ratchet — a future commit cannot quietly drop the funnel.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const watchdogSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/monitoring/SessionWatchdog.ts'),
+  'utf-8',
+);
+
+describe('Phase 2 — per-killer routing contracts', () => {
+  describe('#5 SessionWatchdog → ReapAuthority', () => {
+    it('the final escalation level routes through terminateSession with terminal disposition', () => {
+      // Find the KillSession case body (closing brace marks the end).
+      const block = watchdogSource.match(/case EscalationLevel\.KillSession:\s*\{[\s\S]*?\n\s{6}\}/);
+      expect(block, 'KillSession case must be a block').toBeTruthy();
+      const body = block![0];
+      expect(body).toMatch(/this\.sessionManager\.terminateSession\(\s*sess\.id\s*,\s*'watchdog-stuck'/);
+      expect(body).toContain("disposition: 'terminal'");
+      expect(body).toContain("finalStatus: 'killed'");
+    });
+
+    it('does NOT call the raw tmux kill-session directly from the watchdog', () => {
+      expect(watchdogSource).not.toMatch(/tmuxPath.*kill-session/);
+    });
+
+    it('a KEEP-refused kill stands down (no re-escalation against a guarded session)', () => {
+      // The skipped-branch must clear escalationState (don't keep hammering a
+      // guarded session every tick — the §P5 backstop owns that escalation).
+      const block = watchdogSource.match(/case EscalationLevel\.KillSession:\s*\{[\s\S]*?\n\s{6}\}/);
+      expect(block).toBeTruthy();
+      const body = block![0];
+      expect(body).toMatch(/!result\.terminated|else \{/);
+      expect(body).toMatch(/escalationState\.delete\(tmuxSession\)/);
+      // And the log line names the skipped reason explicitly so an operator can
+      // see which guard kept the session.
+      expect(body).toContain('kill refused');
+    });
+  });
+});

--- a/tests/unit/session-lifecycle-phase-2-wiring.test.ts
+++ b/tests/unit/session-lifecycle-phase-2-wiring.test.ts
@@ -24,6 +24,14 @@ const sessionManagerSource = fs.readFileSync(
   path.join(process.cwd(), 'src/core/SessionManager.ts'),
   'utf-8',
 );
+const recoverySource = fs.readFileSync(
+  path.join(process.cwd(), 'src/monitoring/SessionRecovery.ts'),
+  'utf-8',
+);
+const serverSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/commands/server.ts'),
+  'utf-8',
+);
 
 describe('Phase 2 — per-killer routing contracts', () => {
   describe('#5 SessionWatchdog → ReapAuthority', () => {
@@ -78,6 +86,41 @@ describe('Phase 2 — per-killer routing contracts', () => {
       expect(orphanSource).toMatch(/terminateSession\(\s*trackedNow\.id\s*,\s*'orphan-reap'/);
       expect(orphanSource).toContain("disposition: 'terminal'");
       expect(orphanSource).toContain("finalStatus: 'killed'");
+    });
+  });
+
+  describe('#8 SessionRecovery → P1/P2 cross-check + recovery-bounce disposition', () => {
+    it('all kill-to-respawn paths go through killForRecovery (single shared chokepoint)', () => {
+      // Direct deps.killSession calls must only appear inside the helper itself.
+      const directCalls = recoverySource.match(/this\.deps\.killSession\(/g) ?? [];
+      // Exactly one — the helper.
+      expect(directCalls.length).toBe(1);
+      // And the helper performs the P1/P2 cross-check first.
+      const helper = recoverySource.match(/private async killForRecovery[\s\S]*?\n {2}\}/);
+      expect(helper).toBeTruthy();
+      expect(helper![0]).toContain('hasActiveProcesses');
+      expect(helper![0]).toContain('deferred-still-working');
+    });
+
+    it('the work-check vetoes the kill (the JSONL reading is unreliable while the process produces work)', () => {
+      // Every recovery method bails with a deferred-still-working result when
+      // the cross-check fires.
+      const deferredReturns = recoverySource.match(/deferred-still-working/g) ?? [];
+      // The helper returns it; each of the 4 recovery methods checks it.
+      expect(deferredReturns.length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('the wiring routes the kill through terminateSession with recovery-bounce disposition + bypassRecoveryFlag', () => {
+      // server.ts wires the dep.killSession to terminateSession with the right opts.
+      expect(serverSource).toMatch(/terminateSession\([^)]*'session-recovery'/);
+      expect(serverSource).toContain("disposition: 'recovery-bounce'");
+      expect(serverSource).toContain('bypassRecoveryFlag: true');
+    });
+
+    it('terminateSession respects bypassRecoveryFlag for the recovery-in-flight guard ONLY', () => {
+      // The bypass is scoped to the recovery-in-flight reason, not the whole guard.
+      expect(sessionManagerSource).toContain('bypassRecoveryFlag');
+      expect(sessionManagerSource).toMatch(/blocked\?\.reason\s*===\s*'recovery-in-flight'/);
     });
   });
 });

--- a/tests/unit/session-lifecycle-phase-2-wiring.test.ts
+++ b/tests/unit/session-lifecycle-phase-2-wiring.test.ts
@@ -16,6 +16,14 @@ const watchdogSource = fs.readFileSync(
   path.join(process.cwd(), 'src/monitoring/SessionWatchdog.ts'),
   'utf-8',
 );
+const orphanSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/monitoring/OrphanProcessReaper.ts'),
+  'utf-8',
+);
+const sessionManagerSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/core/SessionManager.ts'),
+  'utf-8',
+);
 
 describe('Phase 2 — per-killer routing contracts', () => {
   describe('#5 SessionWatchdog → ReapAuthority', () => {
@@ -44,6 +52,32 @@ describe('Phase 2 — per-killer routing contracts', () => {
       // And the log line names the skipped reason explicitly so an operator can
       // see which guard kept the session.
       expect(body).toContain('kill refused');
+    });
+  });
+
+  describe('#6 OrphanProcessReaper → exact-id + work-check + ReapAuthority', () => {
+    it('classifies by EXACT-id membership in instar-known sessions (no project-prefix substring match)', () => {
+      // The legacy prefix-startsWith match is gone.
+      expect(orphanSource).not.toMatch(/tmuxSession\.startsWith\(this\.projectPrefix\)/);
+      // The new gate is exact-id membership in SessionManager.listKnownTmuxSessions().
+      expect(orphanSource).toContain('knownInstarSessions.has(tmuxSession)');
+      // And SessionManager exposes the corresponding lookup.
+      expect(sessionManagerSource).toContain('listKnownTmuxSessions()');
+    });
+
+    it('60-min age gate is NECESSARY but NOT SUFFICIENT — defers when the process has active children', () => {
+      // The work-check (pgrep -P → non-empty) must veto the reap before any kill.
+      expect(orphanSource).toContain('processHasActiveChildren(orphan.pid)');
+      expect(orphanSource).toMatch(/pgrep\s+-P\s+\$\{pid\}/);
+      // And the deferred path logs a Kept-not-Killed action so it surfaces.
+      expect(orphanSource).toContain('Kept orphan PID');
+      expect(orphanSource).toContain('work check vetoed reap');
+    });
+
+    it('routes through terminateSession when the orphan tmuxSession matches a currently-tracked session', () => {
+      expect(orphanSource).toMatch(/terminateSession\(\s*trackedNow\.id\s*,\s*'orphan-reap'/);
+      expect(orphanSource).toContain("disposition: 'terminal'");
+      expect(orphanSource).toContain("finalStatus: 'killed'");
     });
   });
 });

--- a/tests/unit/sleep-wake-cumulative.test.ts
+++ b/tests/unit/sleep-wake-cumulative.test.ts
@@ -1,0 +1,57 @@
+/**
+ * SleepWakeDetector.getCumulativeSleepMsBetween — UNIFIED-SESSION-LIFECYCLE
+ * §P0 #9 (SE-8). The wake-reaper uses this to subtract cumulative wall-time-
+ * asleep DURING a run from elapsed wall-clock, rather than the single last
+ * sleepDurationSeconds event (which under-credited multi-sleep runs).
+ */
+import { describe, it, expect } from 'vitest';
+import { SleepWakeDetector } from '../../src/core/SleepWakeDetector.js';
+
+function pushWake(d: SleepWakeDetector, wakeAtMs: number, sleepSec: number): void {
+  // Internal history shape — keep test in lockstep with the implementation.
+  (d as unknown as { wakeHistory: Array<{ sleepDurationSeconds: number; timestamp: string }> })
+    .wakeHistory.push({ sleepDurationSeconds: sleepSec, timestamp: new Date(wakeAtMs).toISOString() });
+}
+
+describe('SleepWakeDetector.getCumulativeSleepMsBetween (§P0 #9 / SE-8)', () => {
+  it('returns 0 when the history is empty', () => {
+    const d = new SleepWakeDetector();
+    expect(d.getCumulativeSleepMsBetween(0, 10_000_000_000)).toBe(0);
+  });
+
+  it('returns 0 when the window is empty (start >= end)', () => {
+    const d = new SleepWakeDetector();
+    pushWake(d, 1000, 60);
+    expect(d.getCumulativeSleepMsBetween(1000, 1000)).toBe(0);
+  });
+
+  it('counts a fully-contained sleep window', () => {
+    const d = new SleepWakeDetector();
+    // wake at t=1000ms, slept 0.5s → sleep window [500, 1000]
+    pushWake(d, 1000, 0.5);
+    expect(d.getCumulativeSleepMsBetween(0, 2000)).toBe(500);
+  });
+
+  it('counts the overlap when the sleep extends past the query window', () => {
+    const d = new SleepWakeDetector();
+    // Sleep window [500, 1000]; query [700, 1200] ⇒ overlap = 300ms.
+    pushWake(d, 1000, 0.5);
+    expect(d.getCumulativeSleepMsBetween(700, 1200)).toBe(300);
+  });
+
+  it('sums multiple sleeps that overlap the run window — the SE-8 fix', () => {
+    const d = new SleepWakeDetector();
+    // Run window [0, 10000]. Two sleeps, both inside.
+    pushWake(d, 3000, 1);   // sleep [2000, 3000] → 1000ms
+    pushWake(d, 8000, 2);   // sleep [6000, 8000] → 2000ms
+    expect(d.getCumulativeSleepMsBetween(0, 10_000)).toBe(3000);
+  });
+
+  it('ignores sleeps that fall entirely before or after the query window', () => {
+    const d = new SleepWakeDetector();
+    pushWake(d, 1000, 1);   // sleep [0, 1000]   — before the window
+    pushWake(d, 5000, 1);   // sleep [4000, 5000] — inside
+    pushWake(d, 9000, 1);   // sleep [8000, 9000] — after the window
+    expect(d.getCumulativeSleepMsBetween(3000, 6000)).toBe(1000);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -65,3 +65,100 @@ through the real `buildIntelligenceProvider` factory and drives them:
 rate-limit classifier on true-positive and unrelated-error strings, and the
 chokepoint wiring). `tsc --noEmit` clean. The server log emits
 `[llm-circuit] OPEN: …` / `[llm-circuit] closing: …` lines on each transition.
+
+---
+
+**Phase 2 of the unified session-lifecycle robustness work (spec
+`docs/specs/unified-session-lifecycle-robustness.md`).** The four remaining
+autonomous session killers — the SessionWatchdog, OrphanProcessReaper,
+SessionRecovery (kill-to-respawn), and the scheduler's wake-reaper — are now
+funneled through the single ReapAuthority that shipped in Phase 1. Each one
+gains the careful KEEP-checks and the awake-machine lease gate the previous
+killer-of-the-week didn't have, plus structural fixes to a few long-standing
+near-misses.
+
+What landed:
+
+- **#5 SessionWatchdog.** The final escalation level (the session-kill that
+  fires after Ctrl+C / SIGTERM / SIGKILL all failed to free a stuck child) now
+  routes through `terminateSession('watchdog-stuck', terminal/killed)` instead
+  of a raw `tmux kill-session`. If the authority's KEEP-guards refuse the kill
+  (a relay lease, an active subagent, a recent user message, etc.), the
+  watchdog STANDS DOWN — clears its escalation state, logs the exact refusal
+  reason, and lets the §P5 backstop own the operator-decision escalation.
+- **#6 OrphanProcessReaper.** Three changes. (a) Orphan classification is now
+  EXACT-id membership in `listKnownTmuxSessions()`, not project-prefix
+  startsWith — so a user-created `tmux new -s the-portal-myhand` is `external`,
+  not orphan, and the reaper cannot false-reap a user pane. (b) The 60-minute
+  age threshold is necessary, not sufficient: a new `processHasActiveChildren`
+  work-check (pgrep -P) vetoes the kill when the orphan still has running
+  children, and the deferred path logs a `Kept orphan PID … work check vetoed
+  reap` action. (c) When the orphan's tmux name matches a currently-tracked
+  session, the kill goes through the ReapAuthority for the lifecycle events +
+  reap-log entry.
+- **#8 SessionRecovery.** A single shared `killForRecovery()` helper consults
+  `hasActiveProcesses` before every kill-to-respawn — if the pane is producing
+  work, the JSONL stall/crash reading is unreliable and the recovery defers
+  with a structured `deferred-still-working` result. All four recovery paths
+  (stall, context-exhaustion, crash, error-loop) route through this helper.
+  The actual kill goes through `terminateSession('session-recovery',
+  recovery-bounce, bypassRecoveryFlag:true)` so the §P3 "shut down" notice
+  stays silent on a bounce (which is not a disappearance) and the reap-log
+  records the recovery-bounce disposition. `bypassRecoveryFlag` is narrowly
+  scoped to the `recovery-in-flight` KEEP-guard reason — all other KEEP-
+  guards still apply, so a session mid-conversation isn't killed-to-respawn
+  under the cover of "recovery."
+- **#9 wake-reaper.** Three changes. (a) The threshold-check now uses
+  CUMULATIVE wall-time-asleep during the run (the new
+  `SleepWakeDetector.getCumulativeSleepMsBetween()`), not the single last
+  `sleepDurationSeconds` event — a job that spanned multiple sleeps was
+  previously credited only the last sleep and reaped early. (b) The P1/P2 work
+  gate keeps a session whose process is still producing work, regardless of
+  clock. (c) The kill routes through `terminateSession('wake-reaper',
+  terminal/killed)` when tracked.
+
+All four killers now share the same brain — the structural guarantee the
+spec's audit named when it found "is this session alive/dead/stuck/working?"
+answered ad-hoc in eight different places.
+
+## What to Tell Your User
+
+- Every part of the agent that can shut a session down — the stuck-child
+  watchdog, the orphan-process cleanup, the crash-recovery, and the after-
+  sleep cleanup — now goes through the same careful gatekeeper that the boot
+  cleanup uses. None of them can quietly kill a session that might still be
+  working.
+- The watchdog's last-resort session kill, the crash-recovery's restart, and
+  the after-sleep cleanup all show up in the reap-log with the reason, so the
+  "where did my session go?" answer is always there.
+- A crash-recovery restart (kill + respawn fresh) stays quiet — it's a bounce,
+  not a disappearance — but it's still logged.
+- The orphan-process cleanup can no longer accidentally classify a tmux pane
+  you started yourself as one of mine, and it will defer the kill if the
+  orphan still has active child processes.
+- After your machine sleeps and wakes, the job cleanup correctly subtracts the
+  total sleep time (across multiple sleeps if needed) before deciding a job
+  ran too long, so a job that was paused while you closed the lid isn't
+  marked stuck.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Every autonomous killer routes through the single ReapAuthority | Automatic — the watchdog, orphan reaper, crash-recovery, and wake-reaper all funnel through `terminateSession`. |
+| Recovery-bounce disposition stays silent in the "shut down" notice | Automatic — a kill-to-respawn doesn't pretend a session vanished; it still lands in the reap-log. |
+| Orphan reaper: exact-id classification + work-check + ReapAuthority routing | Automatic — `listKnownTmuxSessions()` replaces the prefix match; `processHasActiveChildren` vetoes reaping a working orphan. |
+| Wake-reaper: cumulative-sleep math + P1/P2 work gate | Automatic — multi-sleep runs no longer reaped early; an actively-working session is kept regardless of clock. |
+
+## Evidence
+
+- All Phase 1 unit/integration/e2e tests remain green, plus 14 new Phase-2
+  wiring contracts (SessionWatchdog → ReapAuthority routing + KEEP stand-down,
+  OrphanProcessReaper exact-id + work-check + P0, SessionRecovery
+  killForRecovery + recovery-bounce + bypassRecoveryFlag scope, wake-reaper
+  cumulative-sleep + P1/P2 + P0), 6 new SleepWakeDetector cumulative-sleep
+  math tests, and the existing JobScheduler reaper suite (7) updated to the
+  new async + effective-elapsed contract.
+- `tsc --noEmit` clean. Existing SessionWatchdog (58), OrphanProcessReaper
+  (9), SessionRecovery (9), terminate-CAS (9), session-timeout/activity-aware
+  (4+6) tests all still pass.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -239,3 +239,29 @@ no-silent-fallbacks ratchet doesn't count them: `ReapLog.read` (no log file ⇒
 empty list is correct, not degraded) and the §P5 transcript-tail read (an
 unreadable tail ⇒ no meaningful-advance signal this tick; treated as ambiguous,
 never as progress). Behavior unchanged.
+
+## Phase 2 — Commit #5: SessionWatchdog → ReapAuthority
+
+**Files:** `src/monitoring/SessionWatchdog.ts`,
+`tests/unit/session-lifecycle-phase-2-wiring.test.ts` (new).
+
+`handleEscalation` is now `async`; the final `EscalationLevel.KillSession` no
+longer calls a raw `tmux kill-session` — it resolves the instar session by
+`tmuxSession` and routes through
+`sessionManager.terminateSession(id, 'watchdog-stuck', { disposition: 'terminal', finalStatus: 'killed' })`.
+The authority's mandatory KEEP-guard + lease gate + protected-set check now
+apply: a session the guards would have kept survives a buggy watchdog. The raw
+`killTmuxSession` method is deleted; the LLM gate + stdin guard + signal
+escalations (CtrlC / SigTerm / SigKill) are unchanged.
+
+**Stand-down on KEEP (anti-thrash):** if the authority refuses the kill
+(`protected` / `not-lease-holder` / a KEEP-guard hold / `in-flight`), the
+watchdog logs the exact reason, records a `kept (<reason>)` intervention, and
+**clears escalationState**. It does not re-escalate against a guarded session
+every tick — the §P5 backstop owns operator-decision escalation for a
+persistently-stale session.
+
+**Tests:** existing SessionWatchdog tests (58) green; new wiring contract (3) green; typecheck clean.
+
+**Rollback:** revert this commit; the raw `killTmuxSession` is the only thing
+deleted and is recoverable from history.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -329,3 +329,36 @@ implementation can await terminateSession.
 **Tests:** SessionRecovery (9) + terminate-CAS (9) + Phase-2 wiring (10) green; typecheck clean.
 
 **Rollback:** revert this commit. `bypassRecoveryFlag` becomes unused but harmless.
+
+## Phase 2 — Commit #9: wake-reaper → P1/P2 + cumulative sleep + ReapAuthority
+
+**Files:** `src/scheduler/JobScheduler.ts`, `src/core/SleepWakeDetector.ts`,
+`src/commands/server.ts`, `tests/unit/JobScheduler-reaper.test.ts`,
+`tests/unit/sleep-wake-cumulative.test.ts` (new),
+`tests/unit/session-lifecycle-phase-2-wiring.test.ts`.
+
+Three spec-faithful changes:
+1. **Cumulative sleep (SE-8).** `SleepWakeDetector.getCumulativeSleepMsBetween(startMs, endMs)`
+   sums the overlap of every recorded sleep window with the query range. The
+   wake-reaper now reads `cumulativeSleepProvider(runStartMs, now)` per run and
+   uses `effectiveElapsed = elapsedMs − cumulativeSleep` against its threshold —
+   a run that spanned multiple sleeps is no longer reaped early because the old
+   code credited only the single last `sleepDurationSeconds` event.
+2. **P1/P2 gate.** Before any kill, `sessionManager.hasActiveProcesses(sessionName)`
+   is consulted; on `true` the run is KEPT regardless of clock (spec: "a
+   progressing process is KEEP regardless of clock"). The deferred run is
+   counted as `skipped` and a structured log line names the reason.
+3. **Route through P0.** When a stuck-run session is currently tracked, the
+   kill goes through
+   `terminateSession(id, 'wake-reaper', { disposition:'terminal', finalStatus:'killed' })`
+   — the authority's protected-set + lease gate + reap-log + `sessionReaped`
+   emission apply. Untracked tmux panes fall back to the raw `killSession`.
+
+`reapStuckRuns` is now async; the timeout error message now names the effective-
+elapsed + cumulative-sleep subtraction instead of the single last sleep event.
+
+**Tests:** JobScheduler reaper (7, updated to async + new error contract) +
+SleepWakeDetector cumulative (6, new) + Phase-2 wiring (14) green; typecheck clean.
+
+**Rollback:** revert this commit. `getCumulativeSleepMsBetween` becomes unused
+but harmless.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -265,3 +265,34 @@ persistently-stale session.
 
 **Rollback:** revert this commit; the raw `killTmuxSession` is the only thing
 deleted and is recoverable from history.
+
+## Phase 2 — Commit #6: OrphanProcessReaper → exact-id + work-check + ReapAuthority
+
+**Files:** `src/monitoring/OrphanProcessReaper.ts`, `src/core/SessionManager.ts`,
+`tests/unit/session-lifecycle-phase-2-wiring.test.ts`.
+
+Three spec-faithful changes:
+1. **Exact-id classification.** The legacy `tmuxSession.startsWith(this.projectPrefix)`
+   substring match is replaced by EXACT membership in
+   `SessionManager.listKnownTmuxSessions()` — the new method returns every tmux
+   name instar has ever tracked (any status). A user-created tmux session that
+   happens to share the project prefix is now classified `external`, not
+   `instar-orphan`, so the reaper cannot false-reap a user pane.
+2. **60-min age = necessary, not sufficient.** Before any orphan kill the new
+   `processHasActiveChildren(pid)` helper (`pgrep -P`) is consulted; a positive
+   result vetoes the reap and surfaces a `Kept orphan PID … work check vetoed
+   reap` action. An uninspectable result returns `false` (allowed to proceed)
+   to preserve prior behavior — this gate is a soft veto layered on top of the
+   age gate, never an escalation.
+3. **Route through P0 when applicable.** When the orphan's tmuxSession matches a
+   CURRENTLY-tracked session (a scan/refresh race), the kill goes through
+   `terminateSession(id, 'orphan-reap', { disposition:'terminal', finalStatus:'killed' })`
+   so the authority's KEEP-guard + lease gate + reap-log entry + `sessionReaped`
+   emission apply. Otherwise the tracked record is already terminal and the raw
+   tmux-kill cleans up the stray pane.
+
+The server session remains excluded unconditionally.
+
+**Tests:** OrphanProcessReaper (9) + Phase-2 wiring (6) green; typecheck clean.
+
+**Rollback:** revert this commit. `listKnownTmuxSessions()` becomes unused but harmless.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -296,3 +296,36 @@ The server session remains excluded unconditionally.
 **Tests:** OrphanProcessReaper (9) + Phase-2 wiring (6) green; typecheck clean.
 
 **Rollback:** revert this commit. `listKnownTmuxSessions()` becomes unused but harmless.
+
+## Phase 2 — Commit #8: SessionRecovery → P1/P2 cross-check + recovery-bounce disposition
+
+**Files:** `src/monitoring/SessionRecovery.ts`, `src/core/SessionManager.ts`,
+`src/commands/server.ts`, `tests/unit/session-lifecycle-phase-2-wiring.test.ts`.
+
+Three spec-faithful changes:
+1. **P1/P2 cross-check** — a new shared `killForRecovery(name)` helper inside
+   `SessionRecovery` consults `deps.hasActiveProcesses` BEFORE any kill. When
+   the tmux pane has active child processes, the recovery DEFERS this attempt
+   and returns a structured `deferred-still-working` result with the correct
+   `failureType` (stall / context_exhaustion / crash / error_loop). All four
+   recovery paths route through this helper — `deps.killSession` is no longer
+   called directly from any recovery method.
+2. **`disposition:'recovery-bounce'`** — the dep's `killSession` is rewired in
+   server.ts to route through
+   `sessionManager.terminateSession(id, 'session-recovery', { disposition:
+   'recovery-bounce', finalStatus: 'killed', bypassRecoveryFlag: true })`. The
+   §P3 notifier is silent on recovery-bounce, so the user isn't told "shut
+   down" when the bounce immediately respawns; the reap-log still records it.
+3. **`bypassRecoveryFlag` (scoped)** — terminateSession gains an opt that
+   skips ONLY the `recovery-in-flight` KEEP-guard reason (not the whole guard).
+   Without it the recovery would refuse to kill its OWN in-flight session.
+   Other KEEP-guards (active subagent, recent-user-message, etc.) still apply
+   so a session mid-conversation is not killed-to-respawn under the cover of
+   "recovery."
+
+`SessionRecoveryDeps.killSession` is now `() => void | Promise<void>` so the
+implementation can await terminateSession.
+
+**Tests:** SessionRecovery (9) + terminate-CAS (9) + Phase-2 wiring (10) green; typecheck clean.
+
+**Rollback:** revert this commit. `bypassRecoveryFlag` becomes unused but harmless.


### PR DESCRIPTION
## Summary

Phase 2 of the unified session-lifecycle robustness spec (`docs/specs/unified-session-lifecycle-robustness.md`, approved). Brings the four remaining autonomous session killers onto the single ReapAuthority shipped in Phase 1. Per the spec, each killer is one atomic commit so any one can be reverted without affecting the others.

- **#5 SessionWatchdog** — final-level kill routes through `terminateSession('watchdog-stuck', terminal/killed)`; a KEEP-refused kill STANDS DOWN (clears escalation state, logs the reason) so the watchdog doesn't re-hammer a guarded session.
- **#6 OrphanProcessReaper** — three changes: exact-id classification via new `listKnownTmuxSessions()` (kills the prefix-overmatch); P2 work-check (`pgrep -P`) makes the 60-min age gate necessary-not-sufficient; routes through P0 when the orphan tmuxSession matches a currently-tracked session.
- **#8 SessionRecovery** — single `killForRecovery()` chokepoint with P1/P2 cross-check (`hasActiveProcesses` → defer with structured `deferred-still-working` result); kill goes through `terminateSession('session-recovery', recovery-bounce, bypassRecoveryFlag:true)` so the §P3 notifier stays silent on a bounce; new `bypassRecoveryFlag` scoped narrowly to the `recovery-in-flight` KEEP-reason — all other KEEP-guards still apply.
- **#9 wake-reaper** — cumulative wall-time-asleep math (SE-8: `SleepWakeDetector.getCumulativeSleepMsBetween`) replaces single-last-sleep credit; P1/P2 gate keeps a progressing process regardless of clock; routes through `terminateSession('wake-reaper', terminal/killed)` when tracked.

After this PR, all four killers share the same brain as the Phase-1 boot-purge / age-kill / idle-zombie — the structural guarantee the spec's audit named when it found "is this session alive/dead/stuck/working?" answered ad-hoc in eight different places.

## Test plan

- [x] Unit: SessionWatchdog (58) + OrphanProcessReaper (9) + SessionRecovery (9) + terminate-CAS (9) + Phase-2 wiring (14) + SleepWakeDetector cumulative (6) + JobScheduler reaper (7, updated to async + new effective-elapsed contract).
- [x] `tsc --noEmit` clean.
- [ ] CI full sharded suite (authority).

Spec / side-effects artifact updated per-killer; trace + `/instar-dev` pre-commit gate green for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)