### PR TITLE
Session-lifecycle robustness — Phase 3 (#7 quota soft-check + label-rename bonus)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3309,6 +3309,19 @@ export async function startServer(options: StartOptions): Promise<void> {
       await telegram.start();
       console.log(pc.green(`  Telegram connected (stall alerts: ${sharedIntelligence ? 'LLM-gated' : 'timer-only'})`));
 
+      // UNIFIED-SESSION-LIFECYCLE bonus — session label follows topic rename.
+      // When the user renames a Telegram forum topic, update the bound
+      // session's display `name` ONLY (never tmuxSession or id). Fire-and-
+      // forget; rename-display is non-critical.
+      telegram.setTopicRenamedHandler((topicId, newName) => {
+        const tmuxSession = telegram?.getSessionForTopic(topicId);
+        if (!tmuxSession) return;
+        const renamed = sessionManager.renameSessionByTmux(tmuxSession, newName);
+        if (renamed) {
+          console.log(`[session-rename] Updated bound session "${tmuxSession}" display name → "${newName}" (topic ${topicId})`);
+        }
+      });
+
       // Threadline → Telegram bridge — mirrors inbound/outbound threadline
       // messages into per-thread Telegram topics. Default-OFF; the relay
       // handler below and the threadline_send tool consult bridge.mirror*

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -396,6 +396,28 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Update a session's display `name` only (UNIFIED-SESSION-LIFECYCLE bonus —
+   * session label follows topic rename). NEVER touches `tmuxSession` (the
+   * stable key tmux + every internal lookup uses) or `id` (the stable UUID
+   * state lookups use). The rename surfaces in the dashboard + any place that
+   * prints `session.name`; the operational identity stays intact.
+   *
+   * Idempotent + safe: if the session isn't found or the name is unchanged,
+   * the call is a no-op. Returns true when a save occurred.
+   */
+  renameSessionByTmux(tmuxSession: string, newName: string): boolean {
+    if (!newName || typeof newName !== 'string') return false;
+    const trimmed = newName.trim();
+    if (!trimmed) return false;
+    const session = this.state.listSessions().find((s) => s.tmuxSession === tmuxSession);
+    if (!session) return false;
+    if (session.name === trimmed) return false;
+    session.name = trimmed;
+    this.state.saveSession(session);
+    return true;
+  }
+
+  /**
    * Resolve tri-state liveness for many sessions from ONE tmux snapshot via the
    * P1 oracle (UNIFIED-SESSION-LIFECYCLE §P5 backstop). `reachable` is false when
    * the snapshot was non-authoritative (control plane unreachable) — in which

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -494,10 +494,25 @@ export class TelegramAdapter implements MessagingAdapter {
    * trust the click came from the owner.
    */
   private tunnelConsentHandler: ((action: 'grant' | 'decline', nonce: string) => Promise<string>) | null = null;
+  /**
+   * UNIFIED-SESSION-LIFECYCLE bonus — fired when a Telegram forum topic is
+   * renamed. Wired in server.ts to update the bound session's display name
+   * (display `name` only — never the tmuxSession key or id). Fire-and-forget.
+   */
+  private topicRenamedHandler: ((topicId: number, newName: string) => void | Promise<void>) | null = null;
 
   /** Wire the tunnel-consent callback handler (called by TunnelManager). */
   setTunnelConsentHandler(fn: ((action: 'grant' | 'decline', nonce: string) => Promise<string>) | null): void {
     this.tunnelConsentHandler = fn;
+  }
+
+  /**
+   * Wire the topic-renamed callback (UNIFIED-SESSION-LIFECYCLE bonus). Fires
+   * fire-and-forget when a Telegram forum topic is renamed; consumers update
+   * the bound session's display `name` only (never the tmuxSession key or id).
+   */
+  setTopicRenamedHandler(fn: ((topicId: number, newName: string) => void | Promise<void>) | null): void {
+    this.topicRenamedHandler = fn;
   }
 
   /**
@@ -3641,9 +3656,23 @@ export class TelegramAdapter implements MessagingAdapter {
     if (detectedName) {
       const currentName = this.topicToName.get(numericTopicId);
       if (!currentName || /^topic-\d+$/.test(currentName) || msg.forum_topic_edited?.name) {
+        const isRename = !!msg.forum_topic_edited?.name && currentName !== detectedName;
         this.topicToName.set(numericTopicId, detectedName);
         this.saveRegistry();
         console.log(`[telegram] Captured topic name: ${numericTopicId} → "${detectedName}"`);
+        // UNIFIED-SESSION-LIFECYCLE bonus — fire on TRUE rename only (not on
+        // initial capture or topic creation). The handler updates the bound
+        // session's display `name` so the dashboard label tracks the user's
+        // rename. Fire-and-forget: rename-display is non-critical.
+        if (isRename && this.topicRenamedHandler) {
+          try {
+            void Promise.resolve(this.topicRenamedHandler(numericTopicId, detectedName)).catch((err) => {
+              console.error(`[telegram] topicRenamedHandler failed for ${numericTopicId}:`, err);
+            });
+          } catch (err) {
+            console.error(`[telegram] topicRenamedHandler threw for ${numericTopicId}:`, err);
+          }
+        }
       }
     }
 

--- a/src/monitoring/QuotaManager.ts
+++ b/src/monitoring/QuotaManager.ts
@@ -12,6 +12,8 @@
  */
 
 import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { QuotaTracker } from './QuotaTracker.js';
 import type { QuotaCollector, CollectionResult } from './QuotaCollector.js';
 import type { SessionMigrator, AccountSnapshot } from './SessionMigrator.js';
@@ -93,6 +95,40 @@ export interface QuotaManagerConfig {
   autoMigrate?: boolean;
   /** Allow JSONL-estimated data to trigger migration (default: false) */
   jsonlCanTriggerMigration?: boolean;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * §P0 #7 — does the agent have any active build or autonomous run RIGHT NOW?
+ * The soft-check uses this as a coarse "give working sessions one extra Ctrl+C
+ * grace round" signal. Fresh = mtime within 30 min. Errors → false (soft check
+ * silently falls back to straight force-kill, matching pre-Phase-3 behavior).
+ */
+function isBuildOrAutonomousActiveNow(stateDir: string): boolean {
+  const FRESH_MS = 30 * 60_000;
+  const fresh = (p: string): boolean => {
+    try {
+      if (!fs.existsSync(p)) return false;
+      return Date.now() - fs.statSync(p).mtimeMs < FRESH_MS;
+    } catch {
+      // @silent-fallback-ok — cannot stat ⇒ treat as not-active
+      return false;
+    }
+  };
+  if (fresh(path.join(stateDir, 'state', 'build', 'build-state.json'))) return true;
+  try {
+    const autonomousDir = path.join(stateDir, 'autonomous');
+    if (!fs.existsSync(autonomousDir)) return false;
+    for (const name of fs.readdirSync(autonomousDir)) {
+      if (!name.endsWith('.local.md')) continue;
+      if (fresh(path.join(autonomousDir, name))) return true;
+    }
+    return false;
+  } catch {
+    // @silent-fallback-ok — directory missing or unreadable ⇒ not-active
+    return false;
+  }
 }
 
 // ── QuotaManager class ───────────────────────────────────────────────
@@ -301,6 +337,25 @@ export class QuotaManager extends EventEmitter {
       },
       getAccountStatuses: () => switcher.getAccountStatuses() as AccountSnapshot[],
       switchAccount: (email) => switcher.switchAccount(email),
+      // §P0 #7 — route force-kill through the single ReapAuthority so the
+      // §P3 notifier fires + the reap-log records the `quota-shed` reason.
+      terminateSession: (sessionId, reason, opts) =>
+        sm.terminateSession(sessionId, reason, opts),
+      // §P0 #7 P2-style soft check (one extra Ctrl+C grace round on a working
+      // session). Build/autonomous-active = the same "structural long work"
+      // signal used by the SessionReaper KEEP-guard — a fresh build-state.json
+      // OR a fresh autonomous/*.local.md anywhere under the state dir. Coarse
+      // by design: when any active long-running work exists, all sessions get
+      // the soft grace (precision trades for simplicity here; quota's ceiling
+      // backstop ensures the soft check can never block above the ceiling).
+      isBuildOrAutonomousActive: () => isBuildOrAutonomousActiveNow(this.config.stateDir),
+      // §P0 #7 / SE-9 — the soft-check ceiling. quotaUsagePercent feeds the
+      // disable-above-ceiling check so the bounded soft-check can never push
+      // real usage to 100%/lockout.
+      // Unknown usage ⇒ assume 100% so the soft check stays disabled (we never
+      // want to grant grace when we cannot confirm we're below the ceiling —
+      // SE-9 fail-closed posture).
+      quotaUsagePercent: () => this.tracker.getState()?.usagePercent ?? 100,
     });
 
     // Recover from any in-progress migration that was interrupted

--- a/src/monitoring/SessionMigrator.ts
+++ b/src/monitoring/SessionMigrator.ts
@@ -35,6 +35,17 @@ export interface MigrationThresholds {
   minimumHeadroom: number;
   /** Grace period for session shutdown in ms (default 5000) */
   gracePeriodMs: number;
+  /**
+   * UNIFIED-SESSION-LIFECYCLE §P0 #7 — bounded soft-check.
+   * When `softCheckEnabled` and the current usage is at or below
+   * `softCheckMaxUsagePercent`, build/autonomous-active sessions get ONE extra
+   * Ctrl+C grace round of `softCheckExtraGraceMs` before force-kill. Above the
+   * ceiling the soft check is DISABLED so quota can never push real usage to
+   * 100%/lockout (SE-9) — the force-kill happens immediately.
+   */
+  softCheckEnabled?: boolean;
+  softCheckMaxUsagePercent?: number;
+  softCheckExtraGraceMs?: number;
 }
 
 export interface MigrationEvent {
@@ -104,6 +115,30 @@ export interface SessionMigratorDeps {
   getAccountStatuses: () => AccountSnapshot[];
   /** Switch to a target account */
   switchAccount: (email: string) => Promise<{ success: boolean; message: string }>;
+  /**
+   * UNIFIED-SESSION-LIFECYCLE §P0 #7 — when set, force-kills route through
+   * the single ReapAuthority so the kill emits sessionReaped and lands in the
+   * reap-log. Returns the standard `{ terminated, skipped? }` result.
+   */
+  terminateSession?: (
+    sessionId: string,
+    reason: string,
+    opts?: { disposition?: 'terminal' | 'recovery-bounce'; finalStatus?: 'completed' | 'killed' },
+  ) => Promise<{ terminated: boolean; skipped?: string }>;
+  /**
+   * P2-style soft check (§P0 #7) — does the tmux pane belong to a build or an
+   * active autonomous run? When true and the soft check is enabled (per
+   * thresholds), the session gets ONE extra Ctrl+C grace round before
+   * force-kill. Undefined ⇒ soft check is skipped (defaults to pre-Phase-3
+   * straight force-kill behavior).
+   */
+  isBuildOrAutonomousActive?: (tmuxSession: string) => boolean;
+  /**
+   * Current Anthropic-account usage percentage (0–100). Used by the bounded
+   * soft check to disable itself above `softCheckMaxUsagePercent` so quota's
+   * final authority cannot be undermined when usage is already near 100%.
+   */
+  quotaUsagePercent?: () => number;
 }
 
 export interface SessionMigratorConfig {
@@ -523,12 +558,61 @@ export class SessionMigrator extends EventEmitter {
     // Phase 2: Wait for grace period
     await this.sleep(this.thresholds.gracePeriodMs);
 
+    // §P0 #7 — bounded soft-check (SE-9): when current usage is at/below the
+    // configured ceiling, build/autonomous-active sessions get ONE extra Ctrl+C
+    // grace round before force-kill. Above the ceiling the soft check is
+    // disabled — quota's final authority cannot be undermined when usage is
+    // already near 100%/lockout.
+    const softEnabled = this.thresholds.softCheckEnabled !== false;
+    const softCeilingPct = this.thresholds.softCheckMaxUsagePercent ?? 95;
+    const softExtraGraceMs = this.thresholds.softCheckExtraGraceMs ?? this.thresholds.gracePeriodMs;
+    const currentUsagePct = this.deps.quotaUsagePercent?.() ?? 100;
+    const softCheckActive = softEnabled && currentUsagePct <= softCeilingPct;
+
     // Phase 3: Kill any sessions still alive
     const halted: HaltableSession[] = [];
     for (const session of sessions) {
       try {
         if (this.deps.isSessionAlive(session.tmuxSession)) {
-          this.deps.killSession(session.id);
+          // Soft check: give a working session one more chance before force-kill.
+          if (softCheckActive && this.deps.isBuildOrAutonomousActive?.(session.tmuxSession)) {
+            console.log(
+              `[SessionMigrator] "${session.tmuxSession}": active build/autonomous run — `
+                + `granting one extra ${Math.round(softExtraGraceMs / 1000)}s Ctrl+C grace before force-kill `
+                + `(usage ${currentUsagePct}% ≤ ceiling ${softCeilingPct}%)`,
+            );
+            try { this.deps.sendKey(session.tmuxSession, 'C-c'); } catch { /* @silent-fallback-ok */ }
+            await this.sleep(softExtraGraceMs);
+            if (!this.deps.isSessionAlive(session.tmuxSession)) {
+              halted.push(session);
+              continue;
+            }
+          }
+
+          // Emit the structural force-kill decision so a tier1 supervisor (LLM
+          // Haiku wrap, future) can observe inputs + outcome. The kill still
+          // happens — this is observability, not a gate.
+          this.emit('quota-force-kill-decision', {
+            tmuxSession: session.tmuxSession,
+            sessionId: session.id,
+            jobSlug: session.jobSlug,
+            currentUsagePct,
+            softCheckActive,
+            workingSoftCheckFired: softCheckActive && (this.deps.isBuildOrAutonomousActive?.(session.tmuxSession) ?? false),
+          });
+
+          // §P0 #7 route the force-kill through the single ReapAuthority when
+          // available (the §P3 notifier surfaces it; the reap-log records the
+          // `quota-shed` reason). Falls back to the raw killSession when the
+          // dep is unwired (older agents).
+          if (this.deps.terminateSession) {
+            await this.deps.terminateSession(session.id, 'quota-shed', {
+              disposition: 'terminal',
+              finalStatus: 'killed',
+            });
+          } else {
+            this.deps.killSession(session.id);
+          }
         }
         halted.push(session);
       } catch (err) {

--- a/tests/unit/session-lifecycle-phase-3-wiring.test.ts
+++ b/tests/unit/session-lifecycle-phase-3-wiring.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Phase-3 routing contracts — UNIFIED-SESSION-LIFECYCLE per-killer guarantees.
+ *
+ * #7 quota-shed (bounded soft-check + ReapAuthority routing) and the
+ * label-follows-topic-rename bonus.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const migratorSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/monitoring/SessionMigrator.ts'),
+  'utf-8',
+);
+const quotaManagerSource = fs.readFileSync(
+  path.join(process.cwd(), 'src/monitoring/QuotaManager.ts'),
+  'utf-8',
+);
+
+describe('Phase 3 — per-killer routing contracts', () => {
+  describe('#7 quota-shed → bounded soft-check + ReapAuthority', () => {
+    it('SessionMigrator threshold gains a bounded soft-check ceiling', () => {
+      expect(migratorSource).toContain('softCheckEnabled');
+      expect(migratorSource).toContain('softCheckMaxUsagePercent');
+      expect(migratorSource).toContain('softCheckExtraGraceMs');
+    });
+
+    it('the soft check fires ONLY when usage is below the ceiling (SE-9 fail-closed)', () => {
+      // The "softCheckActive" gate combines both flag + ceiling.
+      expect(migratorSource).toMatch(/softCheckActive\s*=\s*softEnabled\s*&&\s*currentUsagePct\s*<=\s*softCeilingPct/);
+      // Fail-closed: unknown usage ⇒ assume 100% so the soft check is disabled.
+      expect(quotaManagerSource).toMatch(/usagePercent\s*\?\?\s*100/);
+    });
+
+    it('a working session gets ONE extra Ctrl+C grace round before force-kill', () => {
+      // Inside the kill loop, when the work-check fires we send another C-c and
+      // wait the extra grace before force-killing.
+      const phase3Block = migratorSource.match(/Phase 3: Kill any sessions still alive[\s\S]*?return halted;/);
+      expect(phase3Block).toBeTruthy();
+      const body = phase3Block![0];
+      expect(body).toContain("sendKey(session.tmuxSession, 'C-c')");
+      expect(body).toContain('await this.sleep(softExtraGraceMs)');
+      expect(body).toContain('one extra');
+    });
+
+    it('routes the force-kill through the single ReapAuthority when wired', () => {
+      expect(migratorSource).toMatch(/this\.deps\.terminateSession\(\s*session\.id\s*,\s*'quota-shed'/);
+      expect(migratorSource).toContain("disposition: 'terminal'");
+      expect(migratorSource).toContain("finalStatus: 'killed'");
+    });
+
+    it('emits a structural force-kill decision event for future tier1 supervision', () => {
+      // The kill happens — this is observability, not a gate. A tier1
+      // supervisor (Haiku wrap) can subscribe to validate the policy decision.
+      expect(migratorSource).toMatch(/this\.emit\(\s*'quota-force-kill-decision'/);
+      // The payload names enough inputs to reproduce the decision.
+      const eventBlock = migratorSource.match(/'quota-force-kill-decision'[\s\S]*?\}\);/);
+      expect(eventBlock).toBeTruthy();
+      const body = eventBlock![0];
+      expect(body).toContain('currentUsagePct');
+      expect(body).toContain('softCheckActive');
+    });
+
+    it('QuotaManager wires terminateSession + isBuildOrAutonomousActive + quotaUsagePercent', () => {
+      expect(quotaManagerSource).toMatch(/terminateSession:\s*\(sessionId,\s*reason,\s*opts\)\s*=>\s*\n?\s*sm\.terminateSession/);
+      expect(quotaManagerSource).toMatch(/isBuildOrAutonomousActive:\s*\(\)\s*=>\s*isBuildOrAutonomousActiveNow/);
+      expect(quotaManagerSource).toContain('quotaUsagePercent:');
+    });
+  });
+});

--- a/tests/unit/session-lifecycle-phase-3-wiring.test.ts
+++ b/tests/unit/session-lifecycle-phase-3-wiring.test.ts
@@ -68,4 +68,43 @@ describe('Phase 3 — per-killer routing contracts', () => {
       expect(quotaManagerSource).toContain('quotaUsagePercent:');
     });
   });
+
+  describe('Bonus — session label follows topic rename', () => {
+    const sessionManagerSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/core/SessionManager.ts'),
+      'utf-8',
+    );
+    const telegramSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/messaging/TelegramAdapter.ts'),
+      'utf-8',
+    );
+    const serverSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/commands/server.ts'),
+      'utf-8',
+    );
+
+    it('SessionManager.renameSessionByTmux mutates ONLY the display name (never tmuxSession or id)', () => {
+      const fn = sessionManagerSource.match(/renameSessionByTmux\([^)]*\)[\s\S]*?\n {2}\}/);
+      expect(fn, 'method must exist').toBeTruthy();
+      const body = fn![0];
+      expect(body).toMatch(/session\.name\s*=\s*trimmed/);
+      // Defensive: the method MUST NOT touch tmuxSession or id.
+      expect(body).not.toMatch(/session\.tmuxSession\s*=/);
+      expect(body).not.toMatch(/session\.id\s*=/);
+    });
+
+    it('TelegramAdapter fires the handler on TRUE rename — not on initial-capture / creation', () => {
+      expect(telegramSource).toContain('setTopicRenamedHandler');
+      // The fire site is gated on isRename, which requires forum_topic_edited
+      // (rename event) AND name != currentName.
+      expect(telegramSource).toMatch(/isRename\s*=\s*!!msg\.forum_topic_edited\?\.name\s*&&\s*currentName\s*!==\s*detectedName/);
+      expect(telegramSource).toMatch(/if\s*\(isRename\s*&&\s*this\.topicRenamedHandler\)/);
+    });
+
+    it('server.ts wires the handler to update the BOUND session only via tmuxSession lookup', () => {
+      expect(serverSource).toMatch(/setTopicRenamedHandler\(\(topicId, newName\)/);
+      expect(serverSource).toMatch(/telegram\?\.getSessionForTopic\(topicId\)/);
+      expect(serverSource).toContain('sessionManager.renameSessionByTmux');
+    });
+  });
 });

--- a/tests/unit/session-rename-by-tmux.test.ts
+++ b/tests/unit/session-rename-by-tmux.test.ts
@@ -1,0 +1,89 @@
+// safe-git-allow: test file — fs.rmSync is for per-test tmpdir cleanup only.
+/**
+ * SessionManager.renameSessionByTmux — UNIFIED-SESSION-LIFECYCLE bonus
+ * (session label follows topic rename). The CRITICAL property: update the
+ * display `name` ONLY. tmuxSession and id MUST NEVER change.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn().mockReturnValue(''),
+  execFile: vi.fn().mockImplementation(
+    (_c: string, _args: string[], _opts: unknown, cb?: (e: Error | null, r: { stdout: string }) => void) => {
+      if (typeof _opts === 'function') cb = _opts as typeof cb;
+      if (cb) cb(null, { stdout: '' });
+    },
+  ),
+}));
+
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { Session, SessionManagerConfig } from '../../src/core/types.js';
+
+describe('SessionManager.renameSessionByTmux (bonus — label follows topic rename)', () => {
+  let tmp: string;
+  let state: StateManager;
+  let mgr: SessionManager;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-'));
+    fs.mkdirSync(path.join(tmp, 'state'), { recursive: true });
+    state = new StateManager(path.join(tmp, 'state'));
+    const cfg: SessionManagerConfig = {
+      tmuxPath: '/usr/bin/tmux', claudePath: '/usr/bin/claude', projectDir: tmp,
+      maxSessions: 5, protectedSessions: [], completionPatterns: [],
+    };
+    mgr = new SessionManager(cfg, state);
+  });
+
+  afterEach(() => {
+    mgr.stopMonitoring();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function seed(name: string, tmux: string): Session {
+    const s: Session = {
+      id: 'id-' + tmux, name, status: 'running', tmuxSession: tmux,
+      startedAt: new Date().toISOString(), prompt: 'p',
+    } as Session;
+    state.saveSession(s);
+    return s;
+  }
+
+  it('updates ONLY the display name — never tmuxSession or id', () => {
+    seed('old name', 'project-foo');
+    expect(mgr.renameSessionByTmux('project-foo', 'My Renamed Topic')).toBe(true);
+    const after = state.getSession('id-project-foo')!;
+    expect(after.name).toBe('My Renamed Topic');
+    expect(after.tmuxSession).toBe('project-foo');
+    expect(after.id).toBe('id-project-foo');
+  });
+
+  it('is a no-op when the new name is unchanged (idempotent)', () => {
+    seed('same', 'project-bar');
+    expect(mgr.renameSessionByTmux('project-bar', 'same')).toBe(false);
+    expect(state.getSession('id-project-bar')!.name).toBe('same');
+  });
+
+  it('is a no-op for an unknown tmuxSession (does not throw)', () => {
+    expect(mgr.renameSessionByTmux('does-not-exist', 'Whatever')).toBe(false);
+  });
+
+  it('rejects an empty / whitespace-only / non-string new name', () => {
+    seed('original', 'project-baz');
+    expect(mgr.renameSessionByTmux('project-baz', '')).toBe(false);
+    expect(mgr.renameSessionByTmux('project-baz', '   ')).toBe(false);
+    // Non-string at runtime (defensive).
+    expect(mgr.renameSessionByTmux('project-baz', null as unknown as string)).toBe(false);
+    expect(state.getSession('id-project-baz')!.name).toBe('original');
+  });
+
+  it('trims surrounding whitespace from the new name', () => {
+    seed('original', 'project-trim');
+    expect(mgr.renameSessionByTmux('project-trim', '  Trimmed Name  ')).toBe(true);
+    expect(state.getSession('id-project-trim')!.name).toBe('Trimmed Name');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,71 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Phase 3 of the unified session-lifecycle robustness work (spec
+`docs/specs/unified-session-lifecycle-robustness.md`) — the last two items.**
+With Phase 1 and Phase 2 already on main, this completes the converged design:
+every autonomous killer shares the same brain, and the small UX bonus you
+asked for is in.
+
+What landed:
+
+- **#7 quota soft-check (bounded).** The quota-driven session migrator (the
+  thing that halts running sessions to switch accounts when you're running out
+  of weekly/5-hour budget) used to send Ctrl+C, wait `gracePeriodMs`, and then
+  force-kill anyone still alive. Now: when current usage is at or below a
+  configurable ceiling (`softCheckMaxUsagePercent`, default 95%), an
+  active build or autonomous run gets ONE extra Ctrl+C grace round before
+  force-kill. ABOVE the ceiling the soft check is **disabled** so quota's
+  final authority is never undermined; if current usage can't be read,
+  it's treated as 100% (fail-closed — no grace without proof we're below
+  the ceiling). The force-kill itself now goes through the single
+  ReapAuthority (`terminateSession('quota-shed', terminal/killed)`) so the
+  "your session was shut down" notice fires + the reap-log records the
+  `quota-shed` reason. A new structured `quota-force-kill-decision` event
+  publishes the inputs for a future Tier-1 supervisor.
+- **Bonus — session label follows topic rename.** When you rename a Telegram
+  forum topic, the bound session's display `name` updates to match. The
+  operational identity (`tmuxSession` key + `id` UUID) is never touched —
+  every internal lookup keeps working. The handler fires ONLY on a true
+  rename event (`forum_topic_edited`), not on initial-capture or topic
+  creation. The renamed value flows through the same §P3 sanitization
+  (literal code spans) wherever it surfaces in user-facing notices, so a
+  malicious name can't inject markup.
+
+This closes the spec's Phase 3 scope. After this, all eight autonomous
+killers (boot purge, age-kill, idle-zombie, watchdog, orphan reaper,
+SessionRecovery, wake-reaper, quota-shed) share the same authority + KEEP-
+guard + lease gate + reap-log + sessionReaped event.
+
+## What to Tell Your User
+
+- When you're running low on hours, the quota cleanup is gentler: a
+  session that's actively building or running an autonomous task gets one
+  more polite Ctrl+C before being shut down — unless we're already very
+  near the limit, in which case quota's final authority still kicks in
+  immediately. Either way, the shutdown shows up in the reap-log with the
+  reason.
+- When you rename a Telegram topic, the session label updates to match
+  what you renamed it. The agent's plumbing keeps working — only the
+  display name changes.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Bounded quota soft-check (one extra Ctrl+C grace for working sessions) | Automatic. Tunable via `monitoring.sessionMigration.thresholds.softCheckEnabled` / `softCheckMaxUsagePercent` (default 95) / `softCheckExtraGraceMs` (default = `gracePeriodMs`). |
+| Quota force-kill via ReapAuthority + `quota-force-kill-decision` event | Automatic — surfaces "your session was shut down — quota-shed" + lands in the reap-log; a future Tier-1 LLM supervisor can subscribe to the decision event. |
+| Session label follows Telegram topic rename | Automatic — rename a forum topic, the bound session's display name follows. |
+
+## Evidence
+
+- Unit: SessionManager rename (5) + Phase-3 wiring (9) green; SessionMigrator
+  existing (37) still passes; SessionWatchdog (58), OrphanProcessReaper (9),
+  SessionRecovery (9), terminate-CAS (9), JobScheduler reaper (7),
+  SleepWakeDetector cumulative (6) — all still green.
+- `tsc --noEmit` clean.
+- Side-effects review updated per-commit:
+  `upgrades/side-effects/unified-session-lifecycle-robustness.md`.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -401,3 +401,32 @@ letting that grace push real usage to 100%/lockout.
 
 **Rollback:** revert this commit. The new thresholds default to safe values and
 the migrator dep stays optional, so older callers are unaffected.
+
+## Phase 3 — Commit (bonus): session label follows topic rename
+
+**Files:** `src/core/SessionManager.ts`, `src/messaging/TelegramAdapter.ts`,
+`src/commands/server.ts`, `tests/unit/session-rename-by-tmux.test.ts` (new),
+`tests/unit/session-lifecycle-phase-3-wiring.test.ts`.
+
+When the user renames a Telegram forum topic, the bound session's DISPLAY name
+follows the rename — but the operational identity (`tmuxSession` key + `id`
+UUID) stays intact, as the spec requires.
+
+1. **`SessionManager.renameSessionByTmux(tmuxSession, newName)`** — updates
+   `session.name` ONLY. NEVER touches `tmuxSession` (the tmux key + every
+   internal lookup) or `id` (state lookups). Idempotent; safe on unknown
+   tmuxSession; rejects empty / whitespace-only / non-string names.
+2. **`TelegramAdapter.setTopicRenamedHandler`** — wires a fire-and-forget
+   callback fired ONLY on a true rename (`forum_topic_edited` present AND the
+   name changed). Initial-capture and topic-creation cases do not fire.
+3. **server.ts wiring** — `setTopicRenamedHandler((topicId, newName) => {
+   sessionManager.renameSessionByTmux(telegram.getSessionForTopic(topicId), newName); })`.
+
+Because the renamed value is user-controlled, it flows through the same §P3
+sanitization (literal code spans) wherever it surfaces in user-facing notices.
+
+**Tests:** SessionManager rename (5) + Phase-3 wiring (9, including the bonus
+contracts) green; typecheck clean.
+
+**Rollback:** revert this commit; the handler stays optional, so older callers
+are unaffected.

--- a/upgrades/side-effects/unified-session-lifecycle-robustness.md
+++ b/upgrades/side-effects/unified-session-lifecycle-robustness.md
@@ -362,3 +362,42 @@ SleepWakeDetector cumulative (6, new) + Phase-2 wiring (14) green; typecheck cle
 
 **Rollback:** revert this commit. `getCumulativeSleepMsBetween` becomes unused
 but harmless.
+
+## Phase 3 — Commit #7: quota soft-check (bounded, force-kill via ReapAuthority)
+
+**Files:** `src/monitoring/SessionMigrator.ts`, `src/monitoring/QuotaManager.ts`,
+`tests/unit/session-lifecycle-phase-3-wiring.test.ts` (new).
+
+The quota migrator's force-kill path now goes through the single ReapAuthority,
+and grants a bounded extra-grace round to working sessions — without ever
+letting that grace push real usage to 100%/lockout.
+
+1. **Bounded soft-check (SE-9).** New `MigrationThresholds`:
+   `softCheckEnabled` (default true), `softCheckMaxUsagePercent` (default 95),
+   `softCheckExtraGraceMs` (default = `gracePeriodMs`). The kill loop computes
+   `softCheckActive = softEnabled && currentUsagePct ≤ softCeilingPct`. **Above**
+   the ceiling the soft check is **disabled** — quota's final authority cannot
+   be undermined when usage is already near 100%. When unknown,
+   `quotaUsagePercent` falls back to **100** (fail-closed posture: no grace
+   without proof we're below the ceiling).
+2. **One extra Ctrl+C grace round.** When the soft check is active AND
+   `isBuildOrAutonomousActive()` returns true, the session gets ONE more C-c +
+   `softCheckExtraGraceMs` wait before force-kill. The current implementation
+   uses a coarse signal — `state/build/build-state.json` fresh OR any
+   `autonomous/*.local.md` fresh under 30 min — which trades per-topic
+   precision for simplicity (the ceiling backstop bounds the worst case).
+3. **Route through ReapAuthority.** The force-kill goes through
+   `deps.terminateSession(id, 'quota-shed', { disposition: 'terminal',
+   finalStatus: 'killed' })` so the §P3 notifier surfaces "your session was
+   shut down — quota-shed" and the reap-log records it. Falls back to
+   `deps.killSession` only if `terminateSession` is unwired (older agents).
+4. **Tier-1 supervision seam.** A new `quota-force-kill-decision` event is
+   emitted with `{ tmuxSession, sessionId, jobSlug, currentUsagePct,
+   softCheckActive, workingSoftCheckFired }` so a future Haiku-wrapping
+   supervisor can validate the policy decision. The event is observability,
+   not a gate — the kill still happens.
+
+**Tests:** session-migrator existing (37) + Phase-3 wiring (6) green; typecheck clean.
+
+**Rollback:** revert this commit. The new thresholds default to safe values and
+the migrator dep stays optional, so older callers are unaffected.


### PR DESCRIPTION
## Summary

Phase 3 of the unified session-lifecycle robustness spec (`docs/specs/unified-session-lifecycle-robustness.md`, approved). Brings the LAST autonomous killer (#7 quota-shed) onto the ReapAuthority and lands the bonus the spec called out. After this, all 8 autonomous session killers share the same brain.

- **#7 quota soft-check (bounded).** New thresholds (`softCheckEnabled`/`softCheckMaxUsagePercent`/`softCheckExtraGraceMs`). When current usage is ≤ ceiling, an active build/autonomous run gets ONE extra Ctrl+C grace round before force-kill. Above the ceiling the soft check is DISABLED so quota's final authority isn't undermined; unknown usage → 100% (fail-closed). Force-kill via `terminateSession('quota-shed', terminal/killed)` → §P3 notice + reap-log. New `quota-force-kill-decision` event publishes the inputs for a future Tier-1 supervisor.
- **Bonus — label follows topic rename.** `SessionManager.renameSessionByTmux` updates `session.name` ONLY (NEVER tmuxSession or id — asserted in tests). TelegramAdapter fires the handler ONLY on true rename (`forum_topic_edited` AND name changed). Wired in server.ts via `getSessionForTopic` → `renameSessionByTmux`.

## Test plan

- [x] Unit: SessionManager rename (5) + Phase-3 wiring (9) + SessionMigrator (37) + all Phase 2 suites (114).
- [x] `tsc --noEmit` clean.
- [x] Side-effects artifact + `/instar-dev` trace per commit.
- [ ] CI full sharded suite (authority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)