### PR TITLE
fix(context-wedge): recover sessions whose topic binding exists only on disk

### DIFF
--- a/docs/specs/context-wedge-sentinel.md
+++ b/docs/specs/context-wedge-sentinel.md
@@ -154,3 +154,53 @@ don't replace").
 The regex + tail gate + confirm window are detectors. `recoverFn` is a bounded
 recovery primitive (rate-guarded by `SessionRefresh`). Escalation routes through
 the existing `MessagingToneGate` via `SentinelNotifier`. No new blocking authority.
+
+## Follow-up — disk-backed topic resolution (2026-05-28)
+
+**Gap found in production.** A confirmed wedge on the long-lived Codey
+collaboration session (Telegram topic 13435) was DETECTED but never recovered —
+the sentinel escalated "respawn attempt did not clear it" instead. Root cause:
+`SessionRefresh` resolves a session's topic via `TelegramAdapter.getTopicForSession`,
+which reads the **in-memory** `sessionToTopic` map. Echo's server runs
+`--no-telegram`, so its in-memory map is only a boot-time snapshot of the
+registry, while the lifeline keeps writing new topic↔session bindings to
+`topic-session-registry.json` on disk. A session bound AFTER the server booted
+therefore resolves to `null` in-memory → `refreshSession` returned
+`not_telegram_bound` → the dead session stayed dead. (The original spec's "v1
+scope: Telegram-bound only" framing masked this: the session WAS Telegram-bound;
+the binding just wasn't in this process's in-memory snapshot.)
+
+**Fix (scoped to the recovery path, not a hot-path semantics change).**
+`TelegramAdapter.resolveTopicForSessionFromDisk(sessionName)` performs a fresh
+read of the persisted registry and returns the bound topic (pure read; does not
+mutate the in-memory maps). `SessionRefresh` tries the in-memory lookup first
+and, only on a miss, falls back to the disk read before giving up. An in-memory
+hit short-circuits — the disk read is a fallback, never a default — so the hot
+path is unchanged. Genuinely unbound sessions (no binding on disk either) still
+return `not_telegram_bound`.
+
+**Why scope it to recovery, not `getTopicForSession` itself.** That accessor is
+on several hot paths (live-tail, reaper topic-binding); re-reading disk on every
+miss there would change broad behavior and could mask other bugs. The wedge
+recovery path runs rarely and benefits from the strongest possible resolution, so
+the fallback lives there. The broader in-memory/disk staleness on a
+`--no-telegram` server is noted as a tracked follow-up.
+
+### Follow-up files
+
+- `src/messaging/TelegramAdapter.ts` — `resolveTopicForSessionFromDisk` (disk-backed reverse lookup).
+- `src/core/SessionRefresh.ts` — in-memory-then-disk topic resolution.
+
+### Follow-up tests
+
+- **unit** `tests/unit/SessionRefresh.test.ts` — disk fallback (in-memory miss →
+  disk hit → respawn), in-memory hit short-circuits the disk read, both-miss →
+  `not_telegram_bound`. `tests/unit/telegram-registry-log.test.ts` — disk read of
+  a post-boot binding, missing file, corrupt file.
+- **integration** `tests/integration/session-refresh-disk-topic-fallback.test.ts`
+  — REAL `SessionRefresh` × REAL `TelegramAdapter`: a disk-only binding recovers
+  end-to-end (the exact Codey shape); a truly-unbound session still bails.
+- **e2e** `tests/e2e/context-wedge-sentinel-lifecycle.test.ts` — unchanged feature
+  coverage; also fixed a pre-existing cleanup bug there (`path.dirname(logsDir)`
+  resolved to `os.tmpdir()` itself, so `cleanup()` rm-rf'd the shared tmpdir base
+  and intermittently broke the next test's `mkdtemp`).

--- a/src/core/SessionRefresh.ts
+++ b/src/core/SessionRefresh.ts
@@ -17,8 +17,12 @@
  * docs/signal-vs-authority.md "safety guards on irreversible actions"
  * carve-out) — prevents infinite-respawn loops. Not a judgment call.
  *
- * v1 scope: Telegram-bound sessions only. Non-Telegram-bound respawn is a
- * v2 follow-up — returns { ok: false, code: 'not_telegram_bound' } for now.
+ * Scope: Telegram-bound sessions. Topic resolution checks the in-memory map
+ * first and, on a miss, falls back to a fresh disk read of the persisted
+ * topic-session registry — so a binding registered after this process loaded
+ * the registry (e.g. on a --no-telegram server) is still recoverable. Genuinely
+ * non-Telegram-bound sessions (Slack, iMessage, headless) return
+ * { ok: false, code: 'not_telegram_bound' } and remain a follow-up.
  */
 
 import type { SessionManager } from './SessionManager.js';
@@ -124,15 +128,27 @@ export class SessionRefresh {
       };
     }
 
-    const topicId = this.deps.telegram.getTopicForSession(sessionName);
+    let topicId = this.deps.telegram.getTopicForSession(sessionName);
     if (topicId === null) {
-      // TODO(v2): handle non-Telegram-bound sessions (Slack, iMessage,
-      // headless). Today only Telegram-bound is supported because the
-      // respawn path is built around topicId → context routing.
+      // In-memory miss does NOT mean the session is unbound. A binding
+      // registered after this process loaded the registry won't be in the
+      // in-memory reverse map — most importantly on a `--no-telegram` server,
+      // whose map reflects only its boot-time snapshot while the lifeline keeps
+      // writing new bindings to disk. That is exactly the gap that left wedged
+      // long-lived dev sessions (e.g. the Codey collaboration session, topic
+      // 13435) un-recoverable: getTopicForSession returned null, recovery bailed
+      // with not_telegram_bound, and the dead session stayed dead. Fall back to
+      // a fresh disk-backed reverse lookup before giving up.
+      topicId = this.deps.telegram.resolveTopicForSessionFromDisk?.(sessionName) ?? null;
+    }
+    if (topicId === null) {
+      // Genuinely unbound (no topic on disk either): non-Telegram-bound sessions
+      // (Slack, iMessage, headless) remain a follow-up — the respawn path is
+      // built around topicId → context routing.
       return {
         ok: false,
         code: 'not_telegram_bound',
-        message: `Session "${sessionName}" is not bound to a Telegram topic; cannot self-refresh in v1.`,
+        message: `Session "${sessionName}" is not bound to a Telegram topic (checked in-memory + disk registry); cannot self-refresh.`,
       };
     }
 

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -1921,6 +1921,42 @@ export class TelegramAdapter implements MessagingAdapter {
     return this.sessionToTopic.get(sessionName) ?? null;
   }
 
+  /**
+   * Disk-backed reverse lookup: re-reads the persisted topic-session registry
+   * and returns the topic bound to `sessionName`, or null. This is the fallback
+   * for {@link getTopicForSession} when the in-memory map misses because the
+   * binding was registered AFTER this process loaded the registry.
+   *
+   * The concrete gap (2026-05-28): a `--no-telegram` server's in-memory
+   * `sessionToTopic` reflects only its boot-time registry snapshot, while the
+   * lifeline keeps writing new topic↔session bindings to the file as long-lived
+   * dev sessions come up. A session bound after the server booted therefore
+   * resolves to null in-memory — which made ContextWedgeSentinel recovery bail
+   * with `not_telegram_bound` and leave the wedged session dead. A fresh disk
+   * read closes that hole on the (rare) recovery path without changing the
+   * hot-path semantics of getTopicForSession.
+   *
+   * Pure read: does NOT mutate the in-memory maps (the respawn path re-registers
+   * the new session for the topic anyway).
+   */
+  resolveTopicForSessionFromDisk(sessionName: string): number | null {
+    try {
+      const data = JSON.parse(fs.readFileSync(this.registryPath, 'utf-8'));
+      const t2s = data?.topicToSession;
+      if (t2s && typeof t2s === 'object') {
+        for (const [k, v] of Object.entries(t2s)) {
+          if (v === sessionName) {
+            const n = Number(k);
+            return Number.isFinite(n) ? n : null;
+          }
+        }
+      }
+    } catch {
+      // Registry file missing or corrupt — no fallback available.
+    }
+    return null;
+  }
+
   getTopicName(topicId: number): string | null {
     return this.topicToName.get(topicId) ?? null;
   }

--- a/tests/e2e/context-wedge-sentinel-lifecycle.test.ts
+++ b/tests/e2e/context-wedge-sentinel-lifecycle.test.ts
@@ -52,7 +52,11 @@ function wireProduction(opts: {
   telegramEscalation?: boolean;
 }): Rig {
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-wedge-e2e-'));
-  const logsDir = path.join(stateDir, '..', 'logs');
+  // logs live INSIDE the per-test stateDir, not as a sibling. The previous
+  // `path.join(stateDir, '..', 'logs')` made cleanup's `path.dirname(logsDir)`
+  // resolve to os.tmpdir() ITSELF — so cleanup() rm-rf'd the shared tmpdir base,
+  // which intermittently broke the next test's mkdtemp with ENOENT.
+  const logsDir = path.join(stateDir, 'logs');
   fs.mkdirSync(logsDir, { recursive: true });
   const sentinelLogPath = path.join(logsDir, 'sentinel-events.jsonl');
 
@@ -86,7 +90,7 @@ function wireProduction(opts: {
     sentinel,
     sentinelLogPath,
     respawns: () => respawns,
-    cleanup: () => { try { fs.rmSync(path.dirname(logsDir), { recursive: true, force: true }); } catch { /* ignore */ } },
+    cleanup: () => { try { fs.rmSync(stateDir, { recursive: true, force: true }); } catch { /* ignore */ } },
   };
 }
 

--- a/tests/integration/session-refresh-disk-topic-fallback.test.ts
+++ b/tests/integration/session-refresh-disk-topic-fallback.test.ts
@@ -1,0 +1,109 @@
+// safe-git-allow: test file — no git calls.
+
+/**
+ * Integration test for the disk-backed topic fallback in SessionRefresh.
+ *
+ * Drives the REAL SessionRefresh against a REAL TelegramAdapter (only
+ * SessionManager/StateManager/respawner are mocked), proving the cross-component
+ * contract that the unit tests stub out: when a session's topic binding exists
+ * ONLY on disk (the in-memory sessionToTopic map missed it — the exact shape of
+ * a --no-telegram server whose map is a boot-time snapshot while the lifeline
+ * keeps writing bindings to the registry file), refreshSession still resolves
+ * the topic and proceeds to respawn instead of bailing with not_telegram_bound.
+ *
+ * This is the gap that left the wedged Codey collaboration session (topic 13435)
+ * un-recoverable on 2026-05-28.
+ *
+ * Spec: docs/specs/context-wedge-sentinel.md (null-topic recovery follow-up)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SessionRefresh } from '../../src/core/SessionRefresh.js';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { SessionManager } from '../../src/core/SessionManager.js';
+import type { StateManager } from '../../src/core/StateManager.js';
+import type { TopicResumeMap } from '../../src/core/TopicResumeMap.js';
+
+describe('SessionRefresh × TelegramAdapter — disk-backed topic fallback', () => {
+  let tmpDir: string;
+  let adapter: TelegramAdapter;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-sr-disk-'));
+    adapter = new TelegramAdapter({ token: 'test-token', chatId: '-100123' }, tmpDir);
+  });
+
+  afterEach(async () => {
+    await adapter.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/session-refresh-disk-topic-fallback.test.ts' });
+  });
+
+  function makeRefresh(sessionName: string) {
+    const killed: string[] = [];
+    const respawned: Array<{ sessionName: string; topicId: number }> = [];
+
+    const sessionManager: Partial<SessionManager> = {
+      killSession: vi.fn((id: string) => { killed.push(id); return true; }) as unknown as SessionManager['killSession'],
+    };
+    const state: Partial<StateManager> = {
+      listSessions: vi.fn().mockReturnValue([{ id: 'state-1', tmuxSession: sessionName, status: 'running' }]) as unknown as StateManager['listSessions'],
+    };
+    const topicResumeMap: Partial<TopicResumeMap> = {
+      remove: vi.fn() as unknown as TopicResumeMap['remove'],
+    };
+
+    const refresh = new SessionRefresh({
+      sessionManager: sessionManager as SessionManager,
+      state: state as StateManager,
+      telegram: adapter,
+      topicResumeMap: topicResumeMap as TopicResumeMap,
+      respawner: vi.fn(async (name: string, topicId: number) => {
+        respawned.push({ sessionName: name, topicId });
+        return `${name}-respawned`;
+      }),
+    });
+
+    return { refresh, killed, respawned, topicResumeMap };
+  }
+
+  it('recovers a session whose topic binding exists only on disk (in-memory miss)', async () => {
+    const sessionName = 'echo-codey-collaboration';
+
+    // Simulate the lifeline having written the binding to the registry file
+    // AFTER this adapter loaded — so the in-memory reverse map does not have it.
+    const registryPath = path.join(tmpDir, 'topic-session-registry.json');
+    fs.writeFileSync(registryPath, JSON.stringify({ topicToSession: { '13435': sessionName } }));
+
+    // Precondition: the in-memory lookup genuinely misses.
+    expect(adapter.getTopicForSession(sessionName)).toBeNull();
+
+    const { refresh, killed, respawned, topicResumeMap } = makeRefresh(sessionName);
+    const result = await refresh.refreshSession({ sessionName, fresh: true, reason: 'context-wedge-400' });
+
+    expect(result.ok).toBe(true);
+    expect(result).toMatchObject({ ok: true, topicId: 13435 });
+    // Full recovery happened: killed the dead session, cleared the resume UUID
+    // (fresh mode), and respawned bound to the disk-resolved topic.
+    expect(killed).toEqual(['state-1']);
+    expect(topicResumeMap.remove).toHaveBeenCalledWith(13435);
+    expect(respawned).toEqual([{ sessionName, topicId: 13435 }]);
+  });
+
+  it('still bails with not_telegram_bound when the disk registry has no binding either', async () => {
+    const sessionName = 'truly-orphan-session';
+    // Registry exists but binds a different session.
+    adapter.registerTopicSession(999, 'someone-else');
+
+    const { refresh, killed, respawned } = makeRefresh(sessionName);
+    const result = await refresh.refreshSession({ sessionName, fresh: true });
+
+    expect(result.ok).toBe(false);
+    expect((result as { code: string }).code).toBe('not_telegram_bound');
+    expect(killed).toEqual([]);
+    expect(respawned).toEqual([]);
+  });
+});

--- a/tests/unit/SessionRefresh.test.ts
+++ b/tests/unit/SessionRefresh.test.ts
@@ -22,6 +22,9 @@ function makeDeps(overrides: {
   rateLimit?: { maxPerWindow: number; windowMs: number };
   clock?: () => number;
   noTelegram?: boolean;
+  /** Topic the disk-backed reverse lookup resolves to. Omit to leave the
+   *  method off the mock entirely (simulates an adapter build without it). */
+  diskTopicId?: number | null;
 } = {}) {
   const topicId = overrides.topicId === undefined ? 9235 : overrides.topicId;
   const stateSession = overrides.stateSession === undefined
@@ -34,6 +37,9 @@ function makeDeps(overrides: {
   const telegram: Partial<TelegramAdapter> = {
     getTopicForSession: vi.fn().mockReturnValue(topicId),
   };
+  if (overrides.diskTopicId !== undefined) {
+    telegram.resolveTopicForSessionFromDisk = vi.fn().mockReturnValue(overrides.diskTopicId);
+  }
   const topicResumeMap: Partial<TopicResumeMap> = {
     findUuidForSession: vi.fn().mockReturnValue(uuid),
     save: vi.fn(),
@@ -270,8 +276,49 @@ describe('SessionRefresh', () => {
     });
   });
 
+  describe('disk-backed topic fallback (in-memory registry miss)', () => {
+    it('resolves the topic from disk when the in-memory map misses, then respawns', async () => {
+      // The real-world gap: a --no-telegram server's in-memory sessionToTopic
+      // reflects only its boot snapshot, so a session bound after boot (e.g. the
+      // Codey collaboration dev session) returns null from getTopicForSession.
+      // The disk registry still has the binding — recovery must use it.
+      const { refresh, telegram, respawner, sessionManager } = makeDeps({
+        topicId: null,
+        diskTopicId: 13435,
+        stateSession: { id: 'state-codey', tmuxSession: 'echo-codey-collaboration' },
+      });
+      const result = await refresh.refreshSession({ sessionName: 'echo-codey-collaboration', fresh: true });
+      expect(result).toEqual({ ok: true, newSessionName: 'new-tmux-session', topicId: 13435 });
+      expect(telegram.resolveTopicForSessionFromDisk).toHaveBeenCalledWith('echo-codey-collaboration');
+      // The respawn used the disk-resolved topic end-to-end.
+      expect(sessionManager.killSession).toHaveBeenCalledWith('state-codey');
+      expect(respawner).toHaveBeenCalledWith('echo-codey-collaboration', 13435, undefined);
+    });
+
+    it('does NOT consult the disk fallback when the in-memory lookup hits', async () => {
+      const { refresh, telegram } = makeDeps({ topicId: 9235, diskTopicId: 13435 });
+      const result = await refresh.refreshSession({ sessionName: 'echo-qalatra' });
+      expect(result).toEqual({ ok: true, newSessionName: 'new-tmux-session', topicId: 9235 });
+      // In-memory hit short-circuits — the disk read is a fallback, not a default.
+      expect(telegram.resolveTopicForSessionFromDisk).not.toHaveBeenCalled();
+    });
+
+    it('returns not_telegram_bound when BOTH in-memory and disk miss', async () => {
+      const { refresh, telegram, respawner, sessionManager } = makeDeps({
+        topicId: null,
+        diskTopicId: null,
+      });
+      const result = await refresh.refreshSession({ sessionName: 'orphan-session' });
+      expect(result.ok).toBe(false);
+      expect((result as { code: string }).code).toBe('not_telegram_bound');
+      expect(telegram.resolveTopicForSessionFromDisk).toHaveBeenCalledWith('orphan-session');
+      expect(respawner).not.toHaveBeenCalled();
+      expect(sessionManager.killSession).not.toHaveBeenCalled();
+    });
+  });
+
   describe('failure modes', () => {
-    it('returns not_telegram_bound when session has no topic binding', async () => {
+    it('returns not_telegram_bound when session has no topic binding (no disk fallback available)', async () => {
       const { refresh, respawner, sessionManager } = makeDeps({ topicId: null });
       const result = await refresh.refreshSession({ sessionName: 'orphan-session' });
       expect(result).toEqual({

--- a/tests/unit/telegram-registry-log.test.ts
+++ b/tests/unit/telegram-registry-log.test.ts
@@ -67,6 +67,43 @@ describe('TelegramAdapter registry and message log', () => {
       expect(adapter.getTopicName(999)).toBeNull();
     });
 
+    describe('resolveTopicForSessionFromDisk (recovery fallback)', () => {
+      it('resolves a binding written to disk AFTER the adapter loaded (in-memory miss)', () => {
+        // The core gap: getTopicForSession reads the in-memory map, which is
+        // only the boot-time snapshot. Simulate the lifeline writing a NEW
+        // binding to the registry file after this adapter's load.
+        expect(adapter.getTopicForSession('codey-collab')).toBeNull(); // in-memory miss
+
+        const registryPath = path.join(tmpDir, 'topic-session-registry.json');
+        fs.writeFileSync(registryPath, JSON.stringify({
+          topicToSession: { '13435': 'codey-collab' },
+        }));
+
+        // In-memory still misses, but the disk fallback finds it.
+        expect(adapter.getTopicForSession('codey-collab')).toBeNull();
+        expect(adapter.resolveTopicForSessionFromDisk('codey-collab')).toBe(13435);
+      });
+
+      it('returns null when the session is in no on-disk binding', () => {
+        adapter.registerTopicSession(42, 'known-session');
+        expect(adapter.resolveTopicForSessionFromDisk('ghost-session')).toBeNull();
+      });
+
+      it('returns null when the registry file does not exist', () => {
+        // Fresh tmpDir with no registry written yet.
+        const freshDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tg-noreg-'));
+        const a = new TelegramAdapter({ token: 't', chatId: '-1' }, freshDir);
+        expect(a.resolveTopicForSessionFromDisk('anything')).toBeNull();
+        SafeFsExecutor.safeRmSync(freshDir, { recursive: true, force: true, operation: 'tests/unit/telegram-registry-log.test.ts:noreg' });
+      });
+
+      it('does not throw on a corrupt registry file', () => {
+        const registryPath = path.join(tmpDir, 'topic-session-registry.json');
+        fs.writeFileSync(registryPath, '{ this is not valid json');
+        expect(adapter.resolveTopicForSessionFromDisk('whoever')).toBeNull();
+      });
+    });
+
     it('uses atomic write (tmp + rename) for registry', () => {
       const source = fs.readFileSync(
         path.join(process.cwd(), 'src/messaging/TelegramAdapter.ts'),

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,65 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**ContextWedgeSentinel recovery now resolves a session's topic from disk when
+the in-memory registry misses** (spec `docs/specs/context-wedge-sentinel.md`,
+Follow-up section). This closes a real gap that left a wedged long-lived dev
+session un-recovered.
+
+The thinking-block-400 wedge sentinel (shipped v1.3.62, PR #485) recovers a
+dead session via a fresh respawn through `SessionRefresh`, which needs the
+session's Telegram topic to route the respawn. It resolved that topic from an
+**in-memory** map. On a `--no-telegram` server that map is only a boot-time
+snapshot, while the lifeline keeps writing new topic↔session bindings to the
+registry file on disk. So a session bound AFTER the server booted resolved to
+`null`, recovery bailed with `not_telegram_bound`, and the dead session stayed
+dead — exactly what happened to the Codey collaboration session (topic 13435).
+
+What landed:
+
+- **`TelegramAdapter.resolveTopicForSessionFromDisk(sessionName)`** — a fresh,
+  read-only lookup of the persisted `topic-session-registry.json`. Returns the
+  bound topic or null; never mutates in-memory state; never throws (missing or
+  corrupt file → null).
+- **`SessionRefresh` topic resolution is now in-memory-then-disk.** It tries the
+  in-memory lookup first and, only on a miss, falls back to the disk read before
+  giving up. An in-memory hit short-circuits, so the hot path is unchanged.
+  Genuinely unbound sessions still return `not_telegram_bound`.
+- **Bonus fix** — a pre-existing flake in the wedge e2e test whose `cleanup()`
+  rm-rf'd `os.tmpdir()` itself (a `path.dirname` mistake), intermittently
+  breaking the next test's `mkdtemp`. Now scoped to the per-test dir.
+
+## What to Tell Your User
+
+- The session self-heal for the "stuck thinking-block" failure (the one that
+  made sessions silently fast-fail) now also recovers long-lived dev sessions
+  that were started before the server last restarted. Previously those one class
+  of sessions could be detected but not auto-restarted; now they are.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Wedge auto-recovery for sessions bound after server boot | Automatic — no config. Rides the existing `monitoring.contextWedgeSentinel.autoRecovery` flag (unchanged from PR #485). |
+
+## Migration Notes
+
+No migration required. This is pure `src/` logic (TelegramAdapter + SessionRefresh)
+with no agent-installed files changed — no `.claude/settings.json` hooks, no
+`.instar/config.json` defaults, no CLAUDE.md template, no hook scripts, no skills.
+Every agent receives it through the normal dist update; the `autoRecovery` config
+shape already exists from PR #485, so there is nothing for `PostUpdateMigrator` to
+patch.
+
+## Evidence
+
+- Unit: `tests/unit/SessionRefresh.test.ts` (20 pass, +3 disk-fallback cases),
+  `tests/unit/telegram-registry-log.test.ts` (20 pass, +4 disk-read cases).
+- Integration: `tests/integration/session-refresh-disk-topic-fallback.test.ts`
+  (2 pass) — REAL `SessionRefresh` × REAL `TelegramAdapter`, disk-only binding
+  recovers end-to-end (the exact Codey shape); truly-unbound still bails.
+- E2E: `tests/e2e/context-wedge-sentinel-lifecycle.test.ts` (7 pass, flake fixed).
+- Full related set: 114 pass across 8 files.

--- a/upgrades/side-effects/context-wedge-null-topic-recovery.md
+++ b/upgrades/side-effects/context-wedge-null-topic-recovery.md
@@ -1,0 +1,100 @@
+# Side-Effects Review — ContextWedge recovery: disk-backed topic resolution
+
+**Version / slug:** `context-wedge-null-topic-recovery`
+**Date:** `2026-05-28`
+**Author:** `echo`
+**Spec:** `docs/specs/context-wedge-sentinel.md` (Follow-up section)
+**Second-pass reviewer:** `not required` (see §"Phase 5 trigger check")
+
+## Summary of the change
+
+The ContextWedgeSentinel (shipped v1.3.62, PR #485) auto-recovers a thinking-block-400
+session wedge via a fresh respawn through `SessionRefresh`. In production it
+DETECTED a wedge on the long-lived Codey collaboration session (Telegram topic
+13435) but failed to recover it — escalating "respawn attempt did not clear it."
+
+Root cause: `SessionRefresh` resolves a session's topic via
+`TelegramAdapter.getTopicForSession`, which reads the **in-memory** `sessionToTopic`
+map. Echo's server runs `--no-telegram`, so that map is only a boot-time snapshot
+of the registry, while the lifeline keeps writing new topic↔session bindings to
+`topic-session-registry.json` on disk. A session bound AFTER the server booted
+resolves to `null` in-memory → `refreshSession` returned `not_telegram_bound` →
+the dead session stayed dead.
+
+This change adds a disk-backed fallback to the topic resolution used by recovery:
+
+- `TelegramAdapter.resolveTopicForSessionFromDisk(sessionName)` — a fresh read of
+  the persisted registry returning the bound topic, or null. **Pure read** — does
+  not mutate the in-memory maps.
+- `SessionRefresh.refreshSession` — tries `getTopicForSession` (in-memory) first;
+  on a `null`, falls back to `resolveTopicForSessionFromDisk` before bailing. An
+  in-memory hit short-circuits, so the disk read is a fallback, never a default.
+  Genuinely unbound sessions (no binding on disk either) still return
+  `not_telegram_bound` exactly as before.
+
+**Files touched:**
+- `src/messaging/TelegramAdapter.ts` (+38 lines: `resolveTopicForSessionFromDisk` + doc).
+- `src/core/SessionRefresh.ts` (in-memory→disk resolution; updated header + failure message).
+- `tests/unit/SessionRefresh.test.ts` (+3 cases + a `diskTopicId` mock override).
+- `tests/unit/telegram-registry-log.test.ts` (+4 cases for the disk-read method).
+- `tests/integration/session-refresh-disk-topic-fallback.test.ts` (new — REAL SessionRefresh × REAL TelegramAdapter).
+- `tests/e2e/context-wedge-sentinel-lifecycle.test.ts` (fixed a pre-existing cleanup bug — see below).
+- `docs/specs/context-wedge-sentinel.md` (Follow-up section).
+
+## Decision-point inventory
+
+- **Topic resolution (in-memory vs disk)** — *modify*. Was in-memory-only; is now
+  in-memory-then-disk-fallback. The selection is a pure presence check
+  (`inMemory ?? diskFallback ?? bail`), no judgment. Both branches are exercised
+  by tests; the in-memory branch is unchanged for the common case.
+- **Disk read of the registry** — *read-only, additive*. Reads the existing
+  `topic-session-registry.json` that `TelegramAdapter.saveRegistry` already writes.
+  No new file, no new format, no write. Wrapped in try/catch → returns null on a
+  missing/corrupt file (test-covered) so it can never throw into recovery.
+- **Respawn (kill + fresh spawn)** — *unchanged*. Already gated by `SessionRefresh`'s
+  rate guard + in-flight guard + the sentinel's confirm window + the `autoRecovery`
+  opt-in flag. This change only makes the topic *resolvable*; it does not loosen any
+  guard or change when a respawn fires.
+
+## Blast radius
+
+- **No new authority, no new gate, no new detector.** A topic-resolution fallback
+  behind an existing, already-guarded recovery primitive.
+- **Hot paths unchanged.** `getTopicForSession` is untouched; its many callers
+  (live-tail, SessionReaper topic-binding) behave identically. Only `SessionRefresh`
+  consults the disk fallback, and only on an in-memory miss.
+- **No agent-installed files changed** — no `.claude/settings.json` hooks, no
+  `.instar/config.json` defaults, no CLAUDE.md template, no hook scripts, no skills.
+  So **no PostUpdateMigrator entry is required**: the fix is pure `src/` logic that
+  reaches every agent through the normal dist update. (`autoRecovery` config already
+  exists from PR #485.)
+- **Idempotent / side-effect-free fallback.** Pure read; safe to call repeatedly.
+
+## Pre-existing-bug fix (bundled)
+
+While running the e2e (`context-wedge-sentinel-lifecycle.test.ts`) the "live"
+case failed at setup with `mkdtemp ENOENT`. The test's `cleanup()` did
+`fs.rmSync(path.dirname(logsDir), …)` where `logsDir = path.join(stateDir, '..', 'logs')`
+— so `path.dirname(logsDir)` resolved to `os.tmpdir()` ITSELF, and cleanup rm-rf'd
+the shared tmpdir base, intermittently breaking the next test's `mkdtemp`. It only
+"passed" before when the OS base happened to survive (permissions / timing). Fixed
+by nesting logs INSIDE the per-test `stateDir` and cleaning up exactly `stateDir`.
+Fixed here (not deferred) per the Zero-Failure Standard since it sits in the same
+feature I'm shipping.
+
+## Phase 5 trigger check (second-pass reviewer)
+
+Second pass **not required**: no new authority, no destructive operation introduced
+(the only rm-rf change *removes* an over-broad delete), no external surface, no
+migration. The change is an additive, read-only fallback behind an existing
+rate-guarded recovery primitive, with full three-tier test coverage (114 tests
+green across the related files).
+
+## Verification
+
+- `tests/unit/SessionRefresh.test.ts` — 20 pass (incl. 3 new disk-fallback cases).
+- `tests/unit/telegram-registry-log.test.ts` — 20 pass (incl. 4 new disk-read cases).
+- `tests/integration/session-refresh-disk-topic-fallback.test.ts` — 2 pass
+  (disk-only binding recovers; truly-unbound still bails).
+- `tests/e2e/context-wedge-sentinel-lifecycle.test.ts` — 7 pass (flake fixed).
+- Full related set: 114 pass across 8 files.


### PR DESCRIPTION
## What & why

Follow-up to the ContextWedgeSentinel (v1.3.62, #485). In production the sentinel **detected** a thinking-block-400 wedge on the long-lived **Codey collaboration session (topic 13435)** but failed to recover it — it escalated *"respawn attempt did not clear it"* instead.

**Root cause:** `SessionRefresh` resolves a session's topic via `TelegramAdapter.getTopicForSession`, which reads the **in-memory** `sessionToTopic` map. A `--no-telegram` server's map is only a boot-time snapshot, while the lifeline keeps writing new topic↔session bindings to `topic-session-registry.json` on disk. A session bound **after** the server booted resolved to `null` → `refreshSession` returned `not_telegram_bound` → the dead session stayed dead. (The original "v1 scope: Telegram-bound only" framing masked this — the session *was* bound; the binding just wasn't in this process's in-memory snapshot.)

## The fix (scoped to the recovery path, not a hot-path change)

- **`TelegramAdapter.resolveTopicForSessionFromDisk(sessionName)`** — a fresh, read-only reverse lookup of the persisted registry. Returns the bound topic or null; never mutates in-memory state; never throws (missing/corrupt file → null).
- **`SessionRefresh`** now resolves topic **in-memory-then-disk**: tries the in-memory lookup first, falls back to the disk read only on a miss, and only then bails. An in-memory hit short-circuits, so `getTopicForSession`'s hot-path callers (live-tail, reaper) are untouched. Genuinely unbound sessions still return `not_telegram_bound`.

## Tests — all three tiers (114 green across the related files)

- **unit** — `SessionRefresh.test.ts`: disk fallback (in-memory miss → disk hit → respawn), in-memory hit short-circuits the disk read, both-miss → `not_telegram_bound`. `telegram-registry-log.test.ts`: disk read of a post-boot binding, missing file, corrupt file.
- **integration** — `session-refresh-disk-topic-fallback.test.ts` (new): REAL `SessionRefresh` × REAL `TelegramAdapter` recovers a disk-only binding end-to-end (the exact Codey shape); a truly-unbound session still bails.
- **e2e** — existing `context-wedge-sentinel-lifecycle.test.ts`. Also **fixed a pre-existing flake** there: `cleanup()` did `fs.rmSync(path.dirname(logsDir), …)` where `path.dirname(logsDir)` resolved to `os.tmpdir()` itself, so it rm-rf'd the shared tmpdir base and intermittently broke the next test's `mkdtemp`. Now scoped to the per-test dir.

## Migration / blast radius

No migration required — pure `src/` logic (TelegramAdapter + SessionRefresh), no agent-installed files changed. Every agent gets it through the normal dist update; the `autoRecovery` config shape already exists from #485. No new authority, no new gate, no new detector.

Spec: `docs/specs/context-wedge-sentinel.md` (Follow-up section) · side-effects: `upgrades/side-effects/context-wedge-null-topic-recovery.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)