### PR TITLE
fix(monitoring): CollaborationRedrive — fingerprint-as-relatedAgent + escalation-flood cooldown (dogfood fix)

### DIFF
--- a/src/monitoring/CollaborationRedriveEngine.ts
+++ b/src/monitoring/CollaborationRedriveEngine.ts
@@ -29,6 +29,7 @@
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
 import type { CommitmentTracker, Commitment } from './CommitmentTracker.js';
 import type { CompletionEvaluator } from '../core/CompletionEvaluator.js';
 import type { ThreadlineClient } from '../threadline/client/ThreadlineClient.js';
@@ -46,6 +47,17 @@ export interface CollaborationRedriveConfig {
   maxRedrivesPerTick: number;
   trustFloor: string;
   dedupeJaccard: number;
+  /**
+   * Dogfood fix (2026-05-28): an unresolvable peer name is a STABLE condition
+   * (the name is missing from known-agents.json — it doesn't fix itself on
+   * the next sweep). Without a cooldown, the engine escalated to the
+   * Attention queue every few sweeps for every such peer → notification
+   * flood on Echo, observed live. After this many ms since the last
+   * unreachable-peer escalation for a given peer, the engine may escalate
+   * again. Default 24h. Cooldown is durable (persisted to disk), so it
+   * survives restart.
+   */
+  unreachableEscalationCooldownMs: number;
 }
 
 export const DEFAULT_REDRIVE_CONFIG: CollaborationRedriveConfig = {
@@ -58,6 +70,7 @@ export const DEFAULT_REDRIVE_CONFIG: CollaborationRedriveConfig = {
   maxRedrivesPerTick: 1,
   trustFloor: 'verified',
   dedupeJaccard: 0.7,
+  unreachableEscalationCooldownMs: 24 * 60 * 60 * 1000,
 };
 
 export interface CollaborationRedriveDeps {
@@ -67,6 +80,11 @@ export interface CollaborationRedriveDeps {
   surfacer?: CollaborationSurfacer;
   raiseAttention?: (item: { title: string; body: string; priority?: 'low' | 'medium' | 'high'; source?: string }) => Promise<unknown>;
   knownAgentsPath: string;
+  /**
+   * Where to persist the per-peer "last unreachable escalation" timestamp
+   * log (dogfood fix). Defaults next to `knownAgentsPath` if not set.
+   */
+  escalationLogPath?: string;
   now?: () => number;
   log?: { log: (m: string) => void; warn: (m: string) => void };
 }
@@ -89,7 +107,10 @@ export class CollaborationRedriveEngine {
   private readonly now: () => number;
   private readonly log: { log: (m: string) => void; warn: (m: string) => void };
   private sweepTimer: NodeJS.Timeout | null = null;
-  private unresolvedNameStrikes = new Map<string, number>();
+  /** Resolved path to the durable per-peer unreachable-escalation log. */
+  private readonly escalationLogPath: string;
+  /** In-memory cache of the on-disk escalation log; lazy-loaded. */
+  private escalationLogCache: Record<string, string> | null = null;
 
   constructor(deps: CollaborationRedriveDeps, cfg: Partial<CollaborationRedriveConfig> = {}) {
     this.cfg = { ...DEFAULT_REDRIVE_CONFIG, ...cfg };
@@ -99,6 +120,50 @@ export class CollaborationRedriveEngine {
       log: (m) => console.log(`[CollabRedrive] ${m}`),
       warn: (m) => console.warn(`[CollabRedrive] ${m}`),
     };
+    // Default the escalation log next to known-agents.json (already a
+    // per-agent path under .instar/threadline) unless the caller overrides.
+    this.escalationLogPath = deps.escalationLogPath
+      ?? path.join(path.dirname(deps.knownAgentsPath), 'collab-redrive-escalation-log.json');
+  }
+
+  /**
+   * Has it been at least `unreachableEscalationCooldownMs` since we last
+   * escalated "can't reach <peer>" for this peer? Reads from the durable
+   * log; if the cooldown has elapsed (or there's no record), the engine
+   * may escalate again. Persistent across restart by design.
+   */
+  private shouldEscalateUnreachable(peer: string, nowMs: number): boolean {
+    const log = this.loadEscalationLog();
+    const lastIso = log[peer];
+    if (!lastIso) return true;
+    const lastMs = Date.parse(lastIso);
+    if (!Number.isFinite(lastMs)) return true;
+    return (nowMs - lastMs) >= this.cfg.unreachableEscalationCooldownMs;
+  }
+
+  private recordUnreachableEscalation(peer: string, nowMs: number): void {
+    const log = this.loadEscalationLog();
+    log[peer] = new Date(nowMs).toISOString();
+    try {
+      fs.mkdirSync(path.dirname(this.escalationLogPath), { recursive: true });
+      fs.writeFileSync(this.escalationLogPath, JSON.stringify(log, null, 2));
+    } catch (err) {
+      this.log.warn(`failed to persist escalation log: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private loadEscalationLog(): Record<string, string> {
+    if (this.escalationLogCache !== null) return this.escalationLogCache;
+    try {
+      const raw = fs.readFileSync(this.escalationLogPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      this.escalationLogCache = (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+        ? (parsed as Record<string, string>)
+        : {};
+    } catch {
+      this.escalationLogCache = {};
+    }
+    return this.escalationLogCache;
   }
 
   start(): void {
@@ -192,25 +257,30 @@ export class CollaborationRedriveEngine {
 
       const fingerprint = this.resolveFingerprint(peer);
       if (!fingerprint) {
-        const strikes = (this.unresolvedNameStrikes.get(peer) ?? 0) + 1;
-        this.unresolvedNameStrikes.set(peer, strikes);
-        result.skipped[c.id] = `unresolved-name (strike ${strikes})`;
-        if (strikes >= 3 && this.deps.raiseAttention) {
+        // Dogfood fix (2026-05-28): unresolvable peer names are STABLE
+        // conditions (the name is missing from known-agents.json — it won't
+        // resolve itself on the next sweep). The original strike-counter
+        // escalated every few sweeps and reset, producing a notification
+        // flood. The cooldown is durable per-peer: at most one
+        // "can't reach <peer> — unknown routing" item per peer per
+        // `unreachableEscalationCooldownMs` (default 24h), persisted to
+        // disk so it survives restart.
+        result.skipped[c.id] = 'unresolved-name';
+        if (this.shouldEscalateUnreachable(peer, nowMs) && this.deps.raiseAttention) {
           try {
             await this.deps.raiseAttention({
               title: `can't reach ${peer} — unknown routing`,
-              body: `Tried to nudge ${peer} on commitment ${c.id} ("${c.userRequest.slice(0, 120)}") but no fingerprint resolved from known-agents.json after ${strikes} attempts. Add ${peer} to known-agents.json or close the commitment.`,
+              body: `Tried to nudge ${peer} on commitment ${c.id} ("${c.userRequest.slice(0, 120)}") but no fingerprint resolved from known-agents.json. Add ${peer} to known-agents.json or close the commitment. (I will not raise this again for this peer for ${Math.round(this.cfg.unreachableEscalationCooldownMs / 3600000)}h.)`,
               priority: 'medium',
               source: 'collaboration-redrive',
             });
-            this.unresolvedNameStrikes.set(peer, 0);
+            this.recordUnreachableEscalation(peer, nowMs);
           } catch {
             // non-fatal
           }
         }
         continue;
       }
-      this.unresolvedNameStrikes.delete(peer);
 
       const currentCount = (c.redriveCount ?? 0) + 1;
       const nudgeText = this.buildNudge(c, currentCount);
@@ -312,6 +382,18 @@ export class CollaborationRedriveEngine {
   }
 
   private resolveFingerprint(peerName: string): string | null {
+    // Dogfood gap (2026-05-28): `relatedAgent` on a real threadline-reply
+    // commitment is sometimes ALREADY a 32-char hex fingerprint, not a
+    // display name (e.g. when the commitment was opened from an inbound
+    // whose sender we only knew by fingerprint). The original v3 resolver
+    // assumed display-name-only, so the lookup missed and every such
+    // commitment skipped with `unresolved-name`. Verified live: ~10/15
+    // open threadline-reply commitments on Echo used the fingerprint as
+    // the peer field. Detect the fingerprint case structurally and use
+    // it directly; otherwise fall back to the name lookup.
+    if (CollaborationRedriveEngine.looksLikeFingerprint(peerName)) {
+      return peerName.toLowerCase();
+    }
     try {
       const raw = fs.readFileSync(this.deps.knownAgentsPath, 'utf-8');
       const data = JSON.parse(raw);
@@ -323,6 +405,16 @@ export class CollaborationRedriveEngine {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * `relatedAgent` looks like a Threadline fingerprint if it is exactly 32
+   * hex characters (the format `computeFingerprint` produces — first 16
+   * bytes of the Ed25519 public key, hex-encoded). Matched
+   * case-insensitively; the resolver normalises to lowercase before use.
+   */
+  static looksLikeFingerprint(s: string): boolean {
+    return typeof s === 'string' && /^[0-9a-f]{32}$/i.test(s);
   }
 
   private buildNudge(c: Commitment, attemptNumber: number): string {

--- a/tests/unit/CollaborationRedriveEngine.test.ts
+++ b/tests/unit/CollaborationRedriveEngine.test.ts
@@ -337,3 +337,172 @@ describe('referenceMs', () => {
     expect(referenceMs(c)).toBe(Number.POSITIVE_INFINITY);
   });
 });
+
+// ── Fingerprint-as-relatedAgent (dogfood-surfaced 2026-05-28) ────────
+
+describe('CollaborationRedriveEngine — fingerprint-as-relatedAgent (dogfood fix)', () => {
+  it('looksLikeFingerprint accepts 32-char lowercase hex', () => {
+    expect(CollaborationRedriveEngine.looksLikeFingerprint('8c7928aa9f04fbda947172a2f9b2d81a')).toBe(true);
+  });
+  it('looksLikeFingerprint accepts 32-char uppercase hex', () => {
+    expect(CollaborationRedriveEngine.looksLikeFingerprint('8C7928AA9F04FBDA947172A2F9B2D81A')).toBe(true);
+  });
+  it('looksLikeFingerprint rejects non-hex strings', () => {
+    expect(CollaborationRedriveEngine.looksLikeFingerprint('dawn')).toBe(false);
+    expect(CollaborationRedriveEngine.looksLikeFingerprint('not-a-fingerprint-123456789abcdef')).toBe(false);
+  });
+  it('looksLikeFingerprint rejects wrong-length hex (31 or 33 chars)', () => {
+    expect(CollaborationRedriveEngine.looksLikeFingerprint('8c7928aa9f04fbda947172a2f9b2d81')).toBe(false);
+    expect(CollaborationRedriveEngine.looksLikeFingerprint('8c7928aa9f04fbda947172a2f9b2d81a1')).toBe(false);
+  });
+
+  it('a commitment with relatedAgent already set to a fingerprint hex resolves DIRECTLY and the engine sends', async () => {
+    const dir = makeTmpDir();
+    try {
+      const tracker = setupTracker(dir);
+      const relay = makeRelayStub();
+      const engine = new CollaborationRedriveEngine(
+        {
+          commitmentTracker: tracker,
+          completionEvaluator: new CompletionEvaluator({ intelligence: makeStubIntelligence('NOT_MET') }),
+          relayClient: relay.client as never,
+          // known-agents.json is intentionally EMPTY — the engine must
+          // resolve from the fingerprint pattern alone.
+          knownAgentsPath: makeKnownAgents(dir, []),
+          now: () => Date.parse('2026-05-28T22:00:00Z'),
+          log: { log: () => undefined, warn: () => undefined },
+        },
+        { ...DEFAULT_REDRIVE_CONFIG, enabled: true },
+      );
+      const c = recordThreadlineReplyCommitment(tracker, {
+        relatedAgent: '8C7928AA9F04FBDA947172A2F9B2D81A', // uppercase fingerprint
+        lastReplyAt: '2026-05-28T19:00:00Z',
+      });
+      const result = await engine.tick();
+      expect(result.sent).toBe(1);
+      expect(relay.sent.length).toBe(1);
+      // case-normalised lowercase used as the routing fingerprint
+      expect(relay.sent[0].fingerprint).toBe('8c7928aa9f04fbda947172a2f9b2d81a');
+      const updated = tracker.get(c.id)!;
+      expect(updated.redriveCount).toBe(1);
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/CollaborationRedriveEngine.test.ts cleanup' });
+    }
+  });
+});
+
+// ── Per-peer unreachable-escalation cooldown (the "noise flood" fix) ────
+
+describe('CollaborationRedriveEngine — unreachable-escalation cooldown (flood fix)', () => {
+  it('an unresolvable peer escalates ONCE then stays silent for the cooldown window', async () => {
+    const dir = makeTmpDir();
+    try {
+      const tracker = setupTracker(dir);
+      const escalations: Array<{ title: string }> = [];
+      const knownAgentsPath = makeKnownAgents(dir, []); // empty — "dawn" won't resolve
+      const buildEngine = (nowMs: number) => new CollaborationRedriveEngine(
+        {
+          commitmentTracker: tracker,
+          completionEvaluator: new CompletionEvaluator({ intelligence: makeStubIntelligence('NOT_MET') }),
+          knownAgentsPath,
+          escalationLogPath: path.join(dir, 'escalation-log.json'),
+          raiseAttention: async (item) => { escalations.push({ title: item.title }); return undefined; },
+          now: () => nowMs,
+          log: { log: () => undefined, warn: () => undefined },
+        },
+        { ...DEFAULT_REDRIVE_CONFIG, enabled: true, unreachableEscalationCooldownMs: 24 * 60 * 60 * 1000 },
+      );
+      recordThreadlineReplyCommitment(tracker, { relatedAgent: 'dawn', lastReplyAt: '2026-05-28T18:00:00Z' });
+
+      // Tick #1 — first time hitting unresolvable dawn → ONE escalation.
+      await buildEngine(Date.parse('2026-05-28T20:00:00Z')).tick();
+      expect(escalations.length).toBe(1);
+      expect(escalations[0].title).toContain('dawn');
+
+      // Tick #2 (5 min later, same day) — still unresolvable, but cooldown not elapsed → ZERO new escalations.
+      await buildEngine(Date.parse('2026-05-28T20:05:00Z')).tick();
+      expect(escalations.length).toBe(1);
+
+      // Tick #3 (12 h later) — still in cooldown window → ZERO new escalations.
+      await buildEngine(Date.parse('2026-05-29T08:00:00Z')).tick();
+      expect(escalations.length).toBe(1);
+
+      // Tick #4 (25 h later) — past cooldown → ONE more escalation (the renewed warning).
+      await buildEngine(Date.parse('2026-05-29T21:00:00Z')).tick();
+      expect(escalations.length).toBe(2);
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/CollaborationRedriveEngine.test.ts cleanup' });
+    }
+  });
+
+  it('multiple commitments to the SAME unresolvable peer in one tick still produce just ONE escalation', async () => {
+    const dir = makeTmpDir();
+    try {
+      const tracker = setupTracker(dir);
+      const escalations: Array<{ title: string }> = [];
+      const knownAgentsPath = makeKnownAgents(dir, []);
+      const engine = new CollaborationRedriveEngine(
+        {
+          commitmentTracker: tracker,
+          completionEvaluator: new CompletionEvaluator({ intelligence: makeStubIntelligence('NOT_MET') }),
+          knownAgentsPath,
+          escalationLogPath: path.join(dir, 'escalation-log.json'),
+          raiseAttention: async (item) => { escalations.push({ title: item.title }); return undefined; },
+          now: () => Date.parse('2026-05-28T20:00:00Z'),
+          log: { log: () => undefined, warn: () => undefined },
+        },
+        { ...DEFAULT_REDRIVE_CONFIG, enabled: true },
+      );
+      // Five commitments, same unresolvable peer.
+      for (let i = 0; i < 5; i++) {
+        recordThreadlineReplyCommitment(tracker, {
+          relatedAgent: 'ai-guy',
+          relatedThreadId: `thread-${i}`,
+          lastReplyAt: '2026-05-28T18:00:00Z',
+        });
+      }
+      await engine.tick();
+      // The cooldown check happens BEFORE escalating, so the first
+      // commitment triggers + records; the next four see the recorded
+      // timestamp and skip silently. Exactly ONE escalation for the peer.
+      expect(escalations.length).toBe(1);
+      expect(escalations[0].title).toContain('ai-guy');
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/CollaborationRedriveEngine.test.ts cleanup' });
+    }
+  });
+
+  it('escalation cooldown is DURABLE across a process restart (a fresh engine reads the log)', async () => {
+    const dir = makeTmpDir();
+    try {
+      const tracker = setupTracker(dir);
+      const escalations: Array<{ title: string }> = [];
+      const knownAgentsPath = makeKnownAgents(dir, []);
+      const logPath = path.join(dir, 'escalation-log.json');
+      const makeEngine = () => new CollaborationRedriveEngine(
+        {
+          commitmentTracker: tracker,
+          completionEvaluator: new CompletionEvaluator({ intelligence: makeStubIntelligence('NOT_MET') }),
+          knownAgentsPath,
+          escalationLogPath: logPath,
+          raiseAttention: async (item) => { escalations.push({ title: item.title }); return undefined; },
+          now: () => Date.parse('2026-05-28T20:00:00Z'),
+          log: { log: () => undefined, warn: () => undefined },
+        },
+        { ...DEFAULT_REDRIVE_CONFIG, enabled: true },
+      );
+      recordThreadlineReplyCommitment(tracker, { relatedAgent: 'codey', lastReplyAt: '2026-05-28T18:00:00Z' });
+      await makeEngine().tick();
+      expect(escalations.length).toBe(1);
+      // Brand-new engine instance reads the SAME log → still in cooldown.
+      await makeEngine().tick();
+      expect(escalations.length).toBe(1);
+      // And the log file is present + correct on disk.
+      expect(fs.existsSync(logPath)).toBe(true);
+      const onDisk = JSON.parse(fs.readFileSync(logPath, 'utf-8'));
+      expect(onDisk.codey).toBeTruthy();
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/CollaborationRedriveEngine.test.ts cleanup' });
+    }
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,30 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Two dogfood-surfaced fixes for `CollaborationRedriveEngine` (shipped in v1.3.66 via #490, dogfood-enabled on Echo today):
+
+1. **Fingerprint-as-relatedAgent.** Many real `threadline-reply` commitments store the peer's 32-character hex fingerprint directly in `relatedAgent` (not a display name). The resolver now detects that case (`/^[0-9a-f]{32}$/i`) and uses the value directly as the routing address, normalising to lowercase. Falls through to the name lookup only for non-fingerprint strings. Without this fix, ~10 of 15 active commitments on Echo would skip with `unresolved-name` instead of nudging.
+
+2. **Escalation flood.** The original `unresolved-name` path raised an Attention-queue item after 3 in-memory strikes per peer and reset the counter — producing a fresh "can't reach <peer>" item every few sweeps for every unresolvable peer (35+ items in <30 min observed on Echo). Replaced with a **durable per-peer 24h cooldown** persisted to `<knownAgentsDir>/collab-redrive-escalation-log.json`. At most one escalation per peer per `unreachableEscalationCooldownMs` (new config knob, default 24h). The log survives restart, so a server bounce does not re-flood.
+
+## What to Tell Your User
+
+- If you turned on collaboration-redrive and saw a flood of "can't reach X" attention items, that's fixed: at most one per peer per day, and a log file remembers across restarts so it doesn't reset.
+- If I had open "I'm waiting on agent X" commitments where X was a raw fingerprint instead of a name, those will now resolve and nudge instead of skipping silently.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Fingerprint-hex as routing address | Automatic — no config required. Any `relatedAgent` matching `/^[0-9a-f]{32}$/i` is treated as a fingerprint. |
+| Unreachable-escalation cooldown | Optional override: `monitoring.collaborationRedrive.unreachableEscalationCooldownMs` (default 86400000 ms = 24h) |
+
+## Evidence
+
+- Three new unit tests for the fingerprint case (`looksLikeFingerprint` accepts/rejects boundary cases; engine sends directly with empty `known-agents.json`).
+- Three new unit tests for the cooldown (single escalation per peer; multiple same-peer commitments in one tick collapse to one; restart-survival via on-disk log).
+- Combined Tier-1 test count: 19 → 27, all passing.
+- Side-effects review: `upgrades/side-effects/collab-redrive-fp-as-relatedAgent-and-flood-fix.md`.

--- a/upgrades/side-effects/collab-redrive-fp-as-relatedAgent-and-flood-fix.md
+++ b/upgrades/side-effects/collab-redrive-fp-as-relatedAgent-and-flood-fix.md
@@ -1,0 +1,26 @@
+# Side-Effects Review — CollaborationRedrive: fingerprint-as-relatedAgent + escalation-flood fix
+
+**Context:** Dogfood-armed PR #490 on Echo's live node, 2026-05-28. Within minutes of the engine going `armed`, Justin caught a notification flood on his Telegram Attention queue (35+ items in <30 min, screenshot). Two distinct bugs.
+
+## Bug 1 — fingerprint-as-relatedAgent
+**Symptom.** ~10 of 15 active `threadline-reply` commitments on Echo store the peer's 32-character hex fingerprint directly in `relatedAgent` (when the commitment was opened from an inbound whose sender we only knew by fingerprint). The original `resolveFingerprint` always ran a name lookup against `known-agents.json` — a hex string is not a name → lookup misses → engine skips with `unresolved-name` → in the original code, escalates as "can't reach <fingerprint>".
+
+**Fix.** Detect the fingerprint case structurally (`/^[0-9a-f]{32}$/i`) and use the value directly as the routing address; normalise to lowercase. Fall through to the name lookup only for non-fingerprint strings.
+
+**Tests added.** `looksLikeFingerprint` accepts lowercase/uppercase 32-hex, rejects non-hex and wrong-length strings; a commitment with a fingerprint `relatedAgent` resolves directly with an empty `known-agents.json` and the engine sends.
+
+## Bug 2 — escalation flood
+**Symptom.** The original `unresolved-name` path used an in-memory strike counter that escalated to the Attention queue after 3 strikes per peer AND reset the counter to 0 — so the next sweep started accumulating strikes again, and the queue received a new `can't reach <peer>` item every few sweeps for every unresolvable peer. Verified live: 35 stacked items in ~30 min covering `dawn`, `ai-guy`, `codey`, `instar-codey`, `8c7928aa…`.
+
+**Fix.** Replace the strike counter with a **durable per-peer cooldown**: a peer's `lastEscalatedAt` ISO is persisted to `<knownAgentsDir>/collab-redrive-escalation-log.json`; the engine escalates only if `(now - lastEscalatedAt) >= unreachableEscalationCooldownMs` (default 24h). New config knob `unreachableEscalationCooldownMs`. Within a single tick, multiple commitments to the same unresolvable peer collapse to exactly one escalation. The log survives restart so a server bounce does not re-flood.
+
+**Tests added.** First sweep escalates once; sweeps within 12h produce zero new escalations; sweep past 24h produces one renewed escalation. Five commitments to the same peer in one tick → exactly one escalation. A fresh engine instance reading the same log respects the cooldown (restart-survival).
+
+## 1-7 Side-effects review
+1. **Over/under-block** — Strictly less escalation than before. The cooldown can be lowered if rare repeats are wanted; the cap is a knob, not a hard rule.
+2. **Level-of-abstraction** — Reuses the existing `raiseAttention` injected dep + a tiny on-disk JSON sibling to `known-agents.json`. No new transport.
+3. **Signal vs Authority** — The cooldown is purely a *delivery throttle* on a signal; the underlying engine behaviour (skip-don't-increment on unresolved) is unchanged. The operator still receives the signal — just once per peer per day.
+4. **Interactions** — Touches only the resolveFingerprint code path and the per-peer escalation path in `tick()`. No effect on the durable redrive cap, the per-peer 24h send cap, the engine-wide daily fuse, the per-tick fuse, or the completion gate.
+5. **Rollback** — Both fixes are confined to `CollaborationRedriveEngine.ts`. Reverting restores the original behaviour with no data implications. The escalation log file is a stateless cache (deleting it just allows one more escalation per peer).
+6. **Data integrity** — No commitment-record mutations beyond what shipped in #490. The new on-disk log is a write-only-rotate map of `{peerKey: iso}` — corrupt JSON parses to empty (fail-open into a renewed escalation, not a stuck silent state).
+7. **Failure modes** — (a) Log file write fails → warn + continue without persisting (engine state degrades to in-memory, not to flood). (b) Clock skew makes `lastEscalatedAt` parse to NaN → cooldown treats as elapsed → re-escalates once (then records a sane timestamp). (c) Multi-machine scenario where two engines escalate the same peer near-simultaneously → at most one extra item due to write race; acceptable, the file is per-agent-home.


### PR DESCRIPTION
## Summary
Two dogfood-surfaced fixes for the engine shipped in #490, both observed live on Echo within minutes of arming the engine today:

1. **Fingerprint-as-relatedAgent.** Many real \`threadline-reply\` commitments store the peer's 32-character hex fingerprint directly in \`relatedAgent\` (not a display name — e.g. when the commitment was opened from an inbound whose sender we only knew by fingerprint). Resolver now detects that case (\`/^[0-9a-f]{32}$/i\`) and routes directly, normalising to lowercase. Without this, ~10 of 15 active commitments on Echo would skip with \`unresolved-name\` instead of nudging.

2. **Escalation flood (the actual reason Justin pinged me).** The original \`unresolved-name\` path raised an Attention-queue item after 3 in-memory strikes per peer AND reset the counter — so the queue received a fresh "can't reach <peer>" item every few sweeps for every unresolvable peer. **35+ items in <30 min observed live on Echo's Telegram.** Replaced with a **durable per-peer 24h cooldown** persisted to \`<knownAgentsDir>/collab-redrive-escalation-log.json\`. New config knob \`unreachableEscalationCooldownMs\` (default 86400000 = 24h). Survives restart by design.

## What this fixes (plain version)
- If you turned on collaboration-redrive and saw a flood of "can't reach X" attention items — gone. At most one per peer per day, period.
- The "I'm waiting on 8c7928aa..." rows where the peer field IS the fingerprint now resolve and nudge instead of skipping silently.

## Test plan
- [x] Tier-1 unit tests: 19 → 27 (3 for fingerprint case, 3 for cooldown including restart-survival), all passing locally
- [x] \`tsc --noEmit\` clean
- [x] instar-dev gate clean
- [ ] Full CI green

## Operational follow-through
After merge: my server picks up the new code on its next auto-update restart (frequent — 4 releases in the last 2 hours). I'll also resolve the 35 already-stacked attention items so they don't keep sitting on Justin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)