### PR TITLE
fix(attention): lock down topic-spam — per-source+global forum-topic circuit breaker + collaboration-redrive housekeeping fix

### DIFF
--- a/docs/specs/attention-topic-flood-guard.convergence.md
+++ b/docs/specs/attention-topic-flood-guard.convergence.md
@@ -1,0 +1,82 @@
+# Convergence Report — Attention Topic-Flood Guard
+
+**Spec:** `docs/specs/attention-topic-flood-guard.md`
+**Method:** four independent reviewer agents, one round, distinct lenses
+(adversarial/security, integration/over-block, architecture/signal-vs-authority,
+scalability/correctness), auditing the spec against the actual diff.
+**Date:** 2026-05-28
+**Outcome:** converged after addressing all material findings in code; no findings
+deferred (per the /instar-dev no-deferrals rule).
+
+## Findings and resolutions
+
+Severity in brackets. ✅ = fixed in code this iteration; 📝 = addressed in spec text.
+
+1. **[HIGH] High-cardinality `sourceContext` defeats the per-source budget AND
+   leaks the tracking maps** (security + scalability reviewers). A mis-wired
+   source varying its key per item dodged the budget — breaking the guard's
+   central "any mis-wired feature is throttled" promise — and grew the `events`
+   map unbounded. ✅ Added a **global ceiling** (`maxTopicsGlobal`, default 8):
+   once total topic creation in the window exceeds it, non-critical items of any
+   source coalesce into one shared `'*'` bucket. Added stale-key eviction + a hard
+   `maxTrackedSources` cap. Unit test: `GLOBAL cap defeats source-key variation`.
+
+2. **[HIGH] Coalesced items break `/ack` routing, corrupt the reverse map on
+   restart, and resolving one closes the shared topic for all siblings**
+   (integration reviewer). ✅ Coalesced items are flagged `coalesced: true`, are
+   NOT registered in the per-item topic maps, and `loadAttentionItems` skips them;
+   they are managed via `/attention` (PATCH / dashboard). `updateAttentionStatus`
+   therefore never closes the shared notice topic. Notice-topic intro states the
+   management path.
+
+3. **[HIGH] Critical-priority bypass was case-sensitive** (security reviewer). A
+   lower-cased `'high'`/`'critical'` could be coalesced. ✅ `decide()` upper-cases
+   the priority and treats `HIGH`/`URGENT`/`CRITICAL` as critical. Unit test
+   covers all cases.
+
+4. **[MEDIUM-HIGH] Async double-create race in the notice topic** (scalability
+   reviewer). Concurrent coalesced items for one bucket could each create a topic.
+   ✅ Per-bucket in-flight creation promise (`floodNoticePending`); concurrent
+   callers share one `createForumTopic`. Integration test: `concurrent coalesced
+   items … create exactly ONE notice topic`.
+
+5. **[MEDIUM] Episode/topic churn for a flapping source** (architecture +
+   scalability reviewers). A source straddling the window boundary spawned a new
+   notice topic per episode. ✅ The notice topic is now created once per bucket and
+   reused thereafter (no per-episode churn).
+
+6. **[MEDIUM] Hex fingerprint sent plaintext to any unverified address**
+   (security reviewer). ✅ The hex path is now trust-gated: it routes only when the
+   hex matches a known agent's `publicKey`; an unknown hex falls to the log-only
+   path. Unit test: `an UNKNOWN hex relatedAgent is NOT routed`.
+
+7. **[MEDIUM] `NaN`/negative config silently disabled the guard** (security
+   reviewer). ✅ Constructor coerces all numeric config to safe defaults. Unit
+   test covers it.
+
+8. **[MEDIUM] Unbounded suppression audit log** (scalability reviewer). ✅
+   `attention-suppressed.jsonl` rotates at ~2 MB.
+
+9. **[LOW/framing] Layer positioning, SentinelNotifier divergence, and the
+   `*Guard` name** (architecture reviewer). 📝 Spec §4 now positions the guard as a
+   transport-mechanics backstop below the tone-gate authority, documents why it is
+   not unified with `SentinelNotifier`, and notes the name does not imply blocking
+   authority (the class doc says so explicitly).
+
+## Verified non-issues / out of scope
+
+- **No recursion** — the notice topic is created via `createForumTopic` directly,
+  never via `createAttentionItem` (all reviewers concurred).
+- **Layer/placement** — `src/messaging/` is the right home (adapter-owned pure
+  helper); concur.
+- **Pre-existing** — the CLAUDE.md template's stale `/attention` payload example
+  (`priority:"medium"`, `source:`) and `makeAttentionPoster` lower-case priority
+  are pre-existing, not introduced here; tracked separately, out of scope for this
+  spec. <!-- tracked: topic-11960 follow-up -->
+
+## Residual risk
+
+A legitimate non-critical source raising >3 items / 10 min is coalesced (grouped,
+not dropped). This is aligned with the operator's stated intent ("only critical
+things as their own messages") and is tunable per adapter; genuinely must-see
+items should be raised to HIGH. Accepted.

--- a/docs/specs/attention-topic-flood-guard.eli16.md
+++ b/docs/specs/attention-topic-flood-guard.eli16.md
@@ -1,0 +1,38 @@
+# Attention Topic-Flood Guard — Plain-English Overview
+
+> The one-line version: notices from a misbehaving feature can no longer bury you in a wall of Telegram topics — past a small budget they fold into one topic and the rest go to the logs, while genuinely critical alerts always still come through on their own.
+
+## The problem in one breath
+
+Twice now, a background feature has spammed the chat with dozens of brand-new Telegram topics popping up out of nowhere — first the "session went quiet" watchdog (May 22), now a feature that pings other AI agents and kept announcing "can't reach that agent" over and over. Each announcement opened its own topic, forever. The user's reaction both times: this is noise I should never have to see, and it needs to stop happening for good — not get patched one feature at a time.
+
+## What already exists
+
+- **The Attention queue** — the system that posts important "you should look at this" items to Telegram. By design it opens a fresh topic per item so each can be acknowledged on its own. That's the right behavior for a real to-do, and the wrong behavior when a routine background feature fires hundreds of them.
+- **SentinelNotifier (the May-22 fix)** — taught the session watchdogs to send their routine activity to the logs instead of Telegram, and to bundle real alerts into one system topic. It fixed *that one* feature. It did not stop the *next* feature from doing the same thing.
+- **The collaboration re-drive feature** — the May-28 culprit. It nudges other agents when a shared conversation goes quiet. To nudge one it has to look up the agent's network address; when the address book is empty every lookup fails and it announced the failure as a new topic, on a loop.
+
+## What this adds
+
+The headline change is a **circuit breaker that sits at the single place every Telegram topic gets created**. It watches how many topics each "source" has opened recently. Past a small budget (default: 3 in 10 minutes), it stops opening new topics for that source and instead folds everything into ONE running "notices coalesced" topic, with the full detail written to a log file. The moment a source calms down, its budget refills. Because it lives at the one chokepoint, it protects against *any* feature — including ones not written yet — not just today's offender.
+
+Two hard promises sit on top of it:
+- **Critical alerts are never folded away.** Anything marked HIGH or URGENT always gets its own topic, every time.
+- **Nothing is ever lost.** A folded item is still recorded and still logged; only its separate *topic* is withheld.
+
+The secondary change fixes the actual offender: the re-drive feature now treats "can't reach an agent" as a quiet log line (never a topic, and it no longer repeats), and it correctly recognizes when an agent's "address" is already a raw network fingerprint instead of a name.
+
+## The new pieces
+
+- **AttentionTopicGuard** — the circuit breaker. It only decides *how* a non-critical notice is delivered (its own topic, or folded into a shared one). It is explicitly **not** allowed to drop a notice, block any agent action, or suppress a critical alert. It is a delivery shaper, not a gatekeeper — the same category of thing as the May-22 SentinelNotifier.
+
+## The safeguards
+
+- HIGH/URGENT bypass the breaker entirely, so a real emergency can never be coalesced into silence.
+- Every coalesced item lands in a durable audit log (`state/attention-suppressed.jsonl`), so "where did that notice go?" always has an answer.
+- The shared "notices coalesced" topic is created through the low-level topic call directly, so it can never loop back through the breaker and trigger itself.
+- It ships on by default for the whole fleet with no configuration, and the back-out is a single config flag — there is no stored state to repair and no data to migrate.
+
+## What you actually need to decide
+
+Whether to approve shipping this to every instar agent. It changes how *noisy, non-critical* notices are delivered (folded instead of one-topic-each) while leaving critical alerts and the legitimate one-topic-per-real-to-do behavior untouched. The only judgment call baked in is the default budget — 3 non-critical topics per source per 10 minutes before folding — which is tunable per agent.

--- a/docs/specs/attention-topic-flood-guard.md
+++ b/docs/specs/attention-topic-flood-guard.md
@@ -1,0 +1,238 @@
+---
+title: Attention Topic-Flood Guard — per-source forum-topic circuit breaker + collaboration-redrive housekeeping fix
+slug: attention-topic-flood-guard
+author: echo
+date: 2026-05-28
+status: in-flight
+review-convergence: 2026-05-28-four-reviewer-panel
+convergence-report: docs/specs/attention-topic-flood-guard.convergence.md
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 11960 ("Approved please continue", 2026-05-28 — after the live incident, the 4-reviewer convergence summary, and the default-budget confirmation)
+eli16-overview: attention-topic-flood-guard.eli16.md
+ships-staged: false
+rollout-flag-path: messaging[].config.attentionTopicGuard
+---
+
+# Attention Topic-Flood Guard
+
+## 1. Problem
+
+On 2026-05-28 a live agent (Echo) flooded its operator's Telegram with a wall of
+new forum topics — "can't reach `<peer>` — unknown routing", one per peer, every
+few minutes, indefinitely. This is the **second** topic-flood of this exact
+shape; the first (2026-05-22) came from the silently-stopped sentinels and was
+fixed point-wise by `SentinelNotifier` (housekeeping → logs, escalations
+coalesced to one system topic, default-off).
+
+Root cause, both times, is structural and unchanged:
+
+1. **`TelegramAdapter.createAttentionItem` spawns a brand-new forum topic per
+   item.** This is correct for a genuine, individually-`/ack`-able operator
+   to-do. It is catastrophic when a *housekeeping* feature raises attention items
+   at volume.
+2. **There is no gate at that chokepoint** stopping a high-volume source from
+   spawning unbounded topics. Each new feature that raises attention items can
+   re-introduce the flood, and the fix-per-feature approach relies on every
+   future author remembering the lesson.
+
+The 2026-05-28 trigger was `CollaborationRedriveEngine`:
+
+- Its `known-agents.json` (the Threadline routing address book) was empty on the
+  affected machine, so `resolveFingerprint(peer)` returned `null` for **every**
+  peer.
+- On each null it incremented a per-peer strike counter and, at strike ≥ 3,
+  raised an attention item (= a new topic) — then **reset the counter to 0**, so
+  it re-escalated the same peer every ~3 sweeps, forever.
+- Commitments registered with a 32-char hex **fingerprint** as `relatedAgent`
+  (instead of a name) could never resolve by name, guaranteeing the null path
+  (the `can't reach 8c7928aa…` entries; CMT-663).
+
+## 2. Goals / non-goals
+
+**Goals**
+- Make the topic-flood failure mode *structurally impossible to recur*,
+  independent of which feature misbehaves — at the one chokepoint, not per
+  feature.
+- Fix the specific 2026-05-28 offender so it does not generate the noise in the
+  first place.
+- Preserve the operator's ability to see genuinely critical, individually
+  actionable items as their own topics.
+- Ship to the entire fleet through the normal dist update with zero operator
+  config.
+
+**Non-goals**
+- Changing the Attention queue's one-topic-per-item model for *legitimate*
+  operator to-dos.
+- Fixing the empty-`known-agents.json` provisioning problem (separate; this spec
+  only ensures it degrades quietly).
+- Turning `collaborationRedrive` on by default (it stays ship-OFF).
+
+## 3. Design
+
+### 3.1 `AttentionTopicGuard` (the structural backstop)
+
+A pure, unit-testable per-source circuit breaker (`src/messaging/AttentionTopicGuard.ts`),
+consulted by `createAttentionItem` *before* it creates a topic.
+
+State: per-source rolling event timestamps + per-bucket episode counter + a
+global rolling event timeline; all bounded (stale source keys are evicted, with a
+hard `maxTrackedSources` cap). Config (validated/coerced — a `NaN`/negative value
+falls back to the default, so a fat-fingered number can never silently disable the
+guard): `{ enabled, windowMs, maxTopicsPerSource, maxTopicsGlobal, maxTrackedSources }`,
+default `{ true, 600000, 3, 8, 512 }`.
+
+`decide(source, priority) → { action: 'allow' } | { action: 'coalesce', firstInEpisode, suppressedCount, bucket }`:
+
+- Priority normalized to upper-case; `∈ {HIGH, URGENT, CRITICAL}` → **always
+  `allow`**, never counted. Critical items always get their own topic. This is the
+  load-bearing safety invariant, and it is case-proof (a lower-cased `'high'`
+  still bypasses).
+- Otherwise key on `source` (the item's `sourceContext`, falling back to
+  `category`, then `'unknown'`). Two ceilings are checked: the **per-source**
+  budget and a **global** ceiling across all sources. If per-source trips →
+  `coalesce` under the *source* bucket (one topic per genuinely-flooding source).
+  If only the global trips (many low-volume sources collectively flooding, e.g. a
+  mis-wired feature varying its `sourceContext` per item to dodge the per-source
+  budget) → `coalesce` under the shared `'*'` global bucket (ONE topic total).
+  Else → `allow`. Every decision records an event in both timelines, so a
+  *sustained* flood keeps the window full and stays a single episode until a full
+  window of silence refills the budget. The global ceiling is what makes the
+  "any mis-wired feature is auto-throttled" guarantee independent of source
+  cardinality.
+
+`createAttentionItem` on a `coalesce` decision:
+- Writes the item to the suppression audit log (`state/attention-suppressed.jsonl`,
+  size-capped with one rotation) — nothing is dropped.
+- Routes it into ONE reused "notices coalesced" topic for its `bucket` (created
+  lazily once per bucket and reused thereafter, so a flapping source does not
+  churn a new topic per episode; concurrent coalesced items for one bucket share a
+  single in-flight creation, so there is no double-create race).
+- Marks the item `coalesced: true` and records the (shared) notice `topicId` for
+  reference **only** — it deliberately does NOT register the per-item topic maps
+  (`attentionItemToTopic` / `attentionTopicToItem`). Many items share one notice
+  topic, so registering them would (a) last-writer-win-corrupt the reverse map on
+  `loadAttentionItems` restart and (b) make `updateAttentionStatus` close the
+  shared topic when one sibling resolves. Coalesced items are managed via
+  `/attention` (PATCH / dashboard), not per-topic `/ack` — `loadAttentionItems`
+  skips per-item-map registration for `coalesced` items.
+- Returns without creating a per-item topic.
+
+On an `allow` decision the existing per-item-topic path runs unchanged.
+
+### 3.2 `CollaborationRedriveEngine` fix (the offender)
+
+- "can't reach / unknown routing" becomes **log-only housekeeping**: the engine
+  no longer calls `raiseAttention` on an unresolvable peer, logs once per peer at
+  strike 3, and never resets the strike counter (so it never re-fires). It is a
+  config/address-book gap, not a collaboration outcome the operator must act on
+  from Telegram.
+- A `relatedAgent` matching `/^[0-9a-f]{32,64}$/i` is treated as the routing
+  fingerprint directly **only when it matches a known agent's `publicKey`** in
+  `known-agents.json` — trust-gated exactly like the name path, so the engine
+  never plaintext-sends a nudge (which carries the operator's commitment text) to
+  an unverified address. An unknown hex falls through to the log-only path.
+- The bounded cap-hit escalation ("stalled — your call") is unchanged — it is the
+  feature's designed, per-commitment-bounded operator hand-off, and is now
+  additionally protected by the guard.
+
+## 4. Signal vs. authority compliance
+
+`docs/signal-vs-authority.md` requires: no brittle check may hold blocking
+authority over agent behavior or information flow.
+
+The guard does **not** block agent behavior or drop information. It is a *delivery
+shaper* on an output channel: it changes the *form* of delivery (one coalesced
+topic + a log line) for non-critical, high-volume notices, and never withholds a
+critical (HIGH/URGENT) notice or deletes an item. It is the same class of
+mechanism as `SentinelNotifier` (a delivery sink, explicitly "not a gate, no
+blocking authority"). The redrive change *removes* an authority-bearing escalation
+on a brittle signal (unresolved name) and downgrades it to a pure log signal —
+strictly in the direction the principle wants.
+
+**Layer positioning (review finding).** The guard deliberately sits *below* the
+existing outbound authorities on the `/attention` route (the tone-gate
+`checkOutboundMessage` and the CMT-519 threadline-hub redirect). It is the
+*transport-mechanics* backstop — a rate-counter on topic creation, an allowed
+detector class under the principle's "rate counters / transport dedup" carve-outs
+— not a fourth judgment filter on message *meaning*. It does not interpret content;
+it only shapes how many topics a high-volume channel may spawn.
+
+**Relationship to `SentinelNotifier` (review finding).** Two coalescing
+mechanisms now exist and are intentionally distinct: `SentinelNotifier` is
+*generate-or-not* (sentinel housekeeping is never emitted; real escalations
+coalesce by a flush-timer into the single reused system topic), while this guard
+is *always-record, sometimes-spawn-topic* (it shapes the attention queue, which
+every feature can post to). They are not unified because their lifecycles differ;
+the shared idea — coalesce housekeeping into one reused topic, never a wall — is
+held in both. Note the user-visible consequence: under a multi-source flood you
+get one reused notice topic *per flooding source* (plus one shared `'*'` topic if
+the global cap trips), not literally a single topic — bounded, not unbounded.
+
+**Naming.** `*Guard` elsewhere in instar denotes hard blockers (`SourceTreeGuard`,
+`dangerous-command-guard`). This one does NOT block; the class doc states plainly
+it is a delivery shaper, not a gate, to pre-empt that confusion.
+
+## 5. Threat model / edge cases
+
+- **Critical alert suppressed?** No — HIGH/URGENT bypass the guard entirely.
+- **Item lost?** No — every coalesced item is in the attention store and the audit
+  log; only the per-item topic is withheld.
+- **Legitimate burst over-coalesced?** A non-critical source exceeding 3 topics /
+  10 min is folded into one topic with every item listed — grouped, not lost, and
+  aligned with the operator's stated "only critical things as their own messages"
+  intent. Tunable per-adapter; raise the priority to HIGH for always-separate.
+- **Notice topic recursion?** The coalesced notice topic is created via
+  `createForumTopic` directly, not through `createAttentionItem`, so it cannot
+  re-enter the guard.
+- **Hex false-positive?** A real agent *name* that is 32–64 hex chars would be
+  misrouted as a fingerprint. Agent names are human-readable slugs (`dawn`,
+  `instar-codey`); a 32+ hex string is by construction a fingerprint. Acceptable.
+- **High-cardinality dodge (review finding):** a source that varies its
+  `sourceContext` per item to dodge the per-source budget is bounded by the global
+  ceiling — after `maxTopicsGlobal` total topics in the window, everything (of any
+  source) coalesces into ONE `'*'` topic. The same eviction logic prevents the
+  varied keys from leaking the tracking maps unbounded.
+- **Concurrency (review finding):** `createAttentionItem` is async and awaits
+  `createForumTopic`; concurrent coalesced items for one bucket share a single
+  in-flight creation promise, so they cannot double-create the notice topic.
+- **Restart map safety (review finding):** coalesced items are flagged and
+  excluded from per-item topic-map registration on load, so N items sharing one
+  notice topic cannot corrupt the reverse map (last-writer-win) and resolving one
+  never closes the shared topic for its siblings.
+- **Config validation (review finding):** numeric config is coerced; a `NaN` or
+  negative value falls back to the default rather than silently disabling the
+  guard (`>= NaN` is always false).
+- **Restart:** guard counters are in-memory (intentionally — a flood episode is a
+  short-window phenomenon). After a restart the budget refills; the suppression
+  audit log persists on disk (size-capped with one rotation so it can't grow
+  unbounded under a sustained flood).
+
+## 6. Testing (all three tiers)
+
+- **Unit:** `AttentionTopicGuard` (budget/coalesce/critical-bypass/per-source
+  isolation/sustained-flood-single-episode/post-silence-reset/disabled);
+  `CollaborationRedriveEngine` (unresolvable peer never raises attention across
+  many sweeps; 32-hex peer resolves directly); `PostUpdateMigrator` (Topic-Flood
+  Guard section backfill + idempotency).
+- **Integration:** real `TelegramAdapter.createAttentionItem` — a flooding source
+  is capped at budget + 1 topics, HIGH bypasses, a different source is unaffected,
+  no item dropped, audit log populated.
+- **E2E:** stock fleet config (NO `attentionTopicGuard` key) still caps a flood —
+  the migration-parity guarantee.
+
+## 7. Migration / rollout
+
+Pure `src/` logic, default-ON in code — no agent-installed file changes, so every
+agent is protected on the normal dist update with nothing to patch.
+`PostUpdateMigrator.migrateClaudeMd` backfills a "Topic-Flood Guard" awareness
+section (idempotent; registered in `feature-delivery-completeness`).
+`collaborationRedrive` keeps its ship-OFF default.
+
+## 8. Rollback
+
+Single env/config back-out: set `messaging[].config.attentionTopicGuard.enabled =
+false` to restore pre-guard per-item-topic behavior. No data migration, no agent
+state repair — the guard holds no durable state and the redrive change only
+removes an escalation path. Worst case is a revert of the `src/` diff and a patch
+release.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2765,6 +2765,26 @@ If a user asks "are my sentinels alerting?" or "why isn't the watchdog notifying
       result.skipped.push('CLAUDE.md: Sentinel Notifications section already present');
     }
 
+    // Topic-Flood Guard (2026-05-28 lockdown) — the structural backstop that
+    // caps how many forum topics a single attention source may spawn. Without
+    // this section an agent asked "why are my notices grouped / where did topic
+    // X go?" has no grounded answer. Idempotent via the unique marker phrase.
+    if (!content.includes('Topic-Flood Guard') && !content.includes('attention-suppressed.jsonl')) {
+      const section = `
+## Topic-Flood Guard (attention queue circuit breaker)
+
+The attention queue spawns ONE Telegram forum topic per item — right for a genuine /ack-able to-do, catastrophic when a HOUSEKEEPING feature raises items at volume (this is exactly the 2026-05-22 sentinel flood and the 2026-05-28 collaboration-redrive flood). A per-source circuit breaker now sits at the topic-creation chokepoint (\`TelegramAdapter.createAttentionItem\`): if a single attention \`sourceContext\` exceeds its topic budget within a rolling window, further NON-critical items from that source are COALESCED into ONE running "notices coalesced" topic and recorded in \`state/attention-suppressed.jsonl\` — never a wall of new topics. HIGH/URGENT items are NEVER coalesced (critical messages always get their own topic). No item is dropped — only its per-item topic is withheld; every item is still in the attention store.
+
+- Default-ON, no config required (it ships in code). Tune via \`messaging[].config.attentionTopicGuard\` = \`{ "enabled": true, "windowMs": 600000, "maxTopicsPerSource": 3 }\`.
+- If a user asks "why are my notices grouped together / where did topic X go / what is this 'notices coalesced' topic?" — read \`state/attention-suppressed.jsonl\` for the per-source suppressed items and explain the breaker above. The real fix for a recurring flood is to make the offending feature route housekeeping to the logs (like the sentinels and collaboration-redrive now do); the guard is the backstop that protects you regardless.
+`;
+      content += '\n' + section;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Topic-Flood Guard section');
+    } else {
+      result.skipped.push('CLAUDE.md: Topic-Flood Guard section already present');
+    }
+
     // ContextWedgeSentinel — the 4th silently-stopped sentinel. Tells the agent
     // about the thinking-block-400 wedge + that auto-recovery is opt-in. Without
     // it, an agent asked "why did my session keep failing instantly / what is

--- a/src/messaging/AttentionTopicGuard.ts
+++ b/src/messaging/AttentionTopicGuard.ts
@@ -1,0 +1,187 @@
+/**
+ * AttentionTopicGuard — a per-source + global circuit breaker for forum-topic
+ * creation. NOT a blocker: it is a DELIVERY SHAPER (same class as
+ * SentinelNotifier), never a gate. It holds no authority over agent behavior or
+ * information flow — it only changes the FORM of delivery (one coalesced topic +
+ * a log line) for non-critical, high-volume notices, and never withholds a
+ * critical notice or drops an item. See docs/signal-vs-authority.md (the rate-
+ * counter / transport-dedup carve-outs).
+ *
+ * Built in response to the 2026-05-28 topic-spam flood (the SECOND such flood;
+ * the first, 2026-05-22, produced the SentinelNotifier fix). Root cause both
+ * times: `TelegramAdapter.createAttentionItem` spawns a BRAND-NEW forum topic
+ * per attention item, and there was no structural gate stopping a housekeeping
+ * feature from raising attention items at volume.
+ *
+ * It sits at the one chokepoint (createAttentionItem) and caps how many NEW
+ * topics may be spawned in a rolling window — BOTH per source AND globally. Past
+ * the budget, items are COALESCED into one running notice topic + logged. The
+ * GLOBAL cap is load-bearing: a mis-wired feature that varies its `sourceContext`
+ * per item would dodge a per-source-only budget, so once total topic creation in
+ * the window exceeds the global ceiling, every further non-critical item — of any
+ * source — coalesces into ONE shared global bucket. That makes the "a brand-new
+ * mis-wired feature gets auto-throttled" guarantee hold regardless of source
+ * cardinality.
+ *
+ * Invariants:
+ *  - HIGH / URGENT (case-insensitive; CRITICAL treated as URGENT) ALWAYS get
+ *    their own topic and are never counted. Critical messages are never coalesced.
+ *  - No item is ever DROPPED. A coalesced item is still recorded in the attention
+ *    store and written to the suppression audit log; only its per-item TOPIC is
+ *    withheld.
+ *
+ * Pure logic, injectable clock, bounded memory — unit-testable in isolation.
+ */
+
+export interface AttentionTopicGuardConfig {
+  /** When false, every item is allowed its own topic (pre-guard behavior). */
+  enabled: boolean;
+  /** Rolling window over which topic creations are counted. */
+  windowMs: number;
+  /** Max NEW topics a single source may spawn within `windowMs`. */
+  maxTopicsPerSource: number;
+  /**
+   * Max NEW topics across ALL sources within `windowMs`. Backstop against a
+   * source that varies its key per item to dodge the per-source budget. Past
+   * this, non-critical items coalesce into one shared global bucket regardless
+   * of source. Must be >= maxTopicsPerSource to be meaningful.
+   */
+  maxTopicsGlobal: number;
+  /** Hard cap on distinct source keys tracked (memory bound). */
+  maxTrackedSources: number;
+}
+
+export const DEFAULT_ATTENTION_TOPIC_GUARD: AttentionTopicGuardConfig = {
+  enabled: true,
+  windowMs: 10 * 60 * 1000,
+  maxTopicsPerSource: 3,
+  maxTopicsGlobal: 8,
+  maxTrackedSources: 512,
+};
+
+/** The shared key used when the GLOBAL cap (not a per-source cap) trips. */
+export const GLOBAL_BUCKET = '*';
+
+export type GuardDecision =
+  | { action: 'allow' }
+  | { action: 'coalesce'; firstInEpisode: boolean; suppressedCount: number; bucket: string };
+
+/** Priorities that always get their own topic and are never counted. */
+const CRITICAL_PRIORITIES = new Set(['HIGH', 'URGENT', 'CRITICAL']);
+
+function coerceNum(v: unknown, fallback: number, { int = false, min = 0 }: { int?: boolean; min?: number } = {}): number {
+  const n = typeof v === 'number' ? v : NaN;
+  if (!Number.isFinite(n) || n < min) return fallback;
+  return int ? Math.floor(n) : n;
+}
+
+export class AttentionTopicGuard {
+  private readonly cfg: AttentionTopicGuardConfig;
+  private readonly now: () => number;
+  /** source key -> timestamps of recent topic-relevant events within the window. */
+  private readonly events = new Map<string, number[]>();
+  /** bucket key -> count of items coalesced in the CURRENT (uninterrupted) episode. */
+  private readonly episode = new Map<string, number>();
+  /** Global rolling timeline of topic-relevant events (all sources). */
+  private globalEvents: number[] = [];
+
+  constructor(cfg: Partial<AttentionTopicGuardConfig> = {}, now: () => number = () => Date.now()) {
+    // Validate/coerce: a fat-fingered NaN/negative must NOT silently disable the
+    // guard (NaN comparisons are always false → it would never trip).
+    const d = DEFAULT_ATTENTION_TOPIC_GUARD;
+    const windowMs = coerceNum(cfg.windowMs, d.windowMs, { min: 1 });
+    const maxTopicsPerSource = coerceNum(cfg.maxTopicsPerSource, d.maxTopicsPerSource, { int: true, min: 0 });
+    this.cfg = {
+      enabled: cfg.enabled !== false,
+      windowMs,
+      maxTopicsPerSource,
+      // Independent global ceiling. A LOW global with a HIGH per-source budget is
+      // the intended high-cardinality config (cap total topics regardless of how
+      // many distinct source keys appear), so we do NOT clamp it up to per-source.
+      maxTopicsGlobal: coerceNum(cfg.maxTopicsGlobal, d.maxTopicsGlobal, { int: true, min: 1 }),
+      maxTrackedSources: coerceNum(cfg.maxTrackedSources, d.maxTrackedSources, { int: true, min: 1 }),
+    };
+    this.now = now;
+  }
+
+  get config(): Readonly<AttentionTopicGuardConfig> {
+    return this.cfg;
+  }
+
+  /**
+   * Decide whether an item from `source` at `priority` may spawn its own topic.
+   * Returns the coalesce `bucket` (the source key, or GLOBAL_BUCKET when only the
+   * global cap tripped) so the adapter routes all global-flood notices into ONE
+   * shared topic rather than one-per-varying-source.
+   */
+  decide(source: string | undefined, priority: string | undefined): GuardDecision {
+    if (!this.cfg.enabled) return { action: 'allow' };
+    const p = (priority ?? '').toUpperCase();
+    if (CRITICAL_PRIORITIES.has(p)) return { action: 'allow' };
+
+    const key = source && source.trim() ? source : 'unknown';
+    const now = this.now();
+    const cutoff = now - this.cfg.windowMs;
+
+    const perRecent = (this.events.get(key) ?? []).filter((t) => t >= cutoff);
+    this.globalEvents = this.globalEvents.filter((t) => t >= cutoff);
+
+    const perTripped = perRecent.length >= this.cfg.maxTopicsPerSource;
+    const globalTripped = this.globalEvents.length >= this.cfg.maxTopicsGlobal;
+
+    // Record this event in both timelines so a sustained flood keeps the window
+    // full and stays in a single coalesce episode.
+    perRecent.push(now);
+    this.events.set(key, perRecent);
+    this.globalEvents.push(now);
+    this.evictStaleSources(cutoff);
+
+    if (perTripped || globalTripped) {
+      // Per-source flood → coalesce under the source (one topic per flooding
+      // source). Global-only flood (many low-volume sources) → coalesce under the
+      // shared global bucket (one topic total), defeating key-variation dodges.
+      const bucket = perTripped ? key : GLOBAL_BUCKET;
+      const count = (this.episode.get(bucket) ?? 0) + 1;
+      this.episode.set(bucket, count);
+      return { action: 'coalesce', firstInEpisode: count === 1, suppressedCount: count, bucket };
+    }
+
+    // Under both budgets: own topic, and any prior episode for this source is over.
+    this.episode.set(key, 0);
+    return { action: 'allow' };
+  }
+
+  /** Drop source keys whose events have all aged out, and hard-cap map size. */
+  private evictStaleSources(cutoff: number): void {
+    if (this.events.size <= this.cfg.maxTrackedSources) {
+      // cheap path: nothing to do until we approach the cap.
+      return;
+    }
+    for (const [k, ts] of this.events) {
+      const live = ts.filter((t) => t >= cutoff);
+      if (live.length === 0) {
+        this.events.delete(k);
+        this.episode.delete(k);
+      } else {
+        this.events.set(k, live);
+      }
+    }
+    // If still over the cap (many genuinely-active sources), drop the oldest.
+    while (this.events.size > this.cfg.maxTrackedSources) {
+      const oldest = this.events.keys().next().value;
+      if (oldest === undefined) break;
+      this.events.delete(oldest);
+      this.episode.delete(oldest);
+    }
+  }
+
+  /** Test/inspection seam. */
+  episodeCount(bucket: string): number {
+    return this.episode.get(bucket && bucket.trim() ? bucket : 'unknown') ?? 0;
+  }
+
+  /** Test/inspection seam — number of distinct source keys currently tracked. */
+  get trackedSourceCount(): number {
+    return this.events.size;
+  }
+}

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -34,6 +34,7 @@ import {
 } from './telegramFormatMetrics.js';
 import { SafeFsExecutor } from '../core/SafeFsExecutor.js';
 import { stopAutonomousTopic } from '../core/AutonomousSessions.js';
+import { AttentionTopicGuard, type AttentionTopicGuardConfig } from './AttentionTopicGuard.js';
 
 export interface TelegramConfig {
   /** Bot token from @BotFather */
@@ -93,6 +94,14 @@ export interface TelegramConfig {
   getFormatMode?: () => FormatMode | undefined;
   /** Hot-reloadable accessor for lint-strict mode. */
   getLintStrict?: () => boolean | undefined;
+  /**
+   * Per-source forum-topic circuit breaker. Caps how many NEW topics a single
+   * attention `sourceContext` may spawn in a rolling window; past the budget,
+   * items coalesce into one running notice topic instead of a wall of topics.
+   * Defaults to DEFAULT_ATTENTION_TOPIC_GUARD (enabled) — the 2026-05-28
+   * topic-flood lockdown. See AttentionTopicGuard.
+   */
+  attentionTopicGuard?: Partial<AttentionTopicGuardConfig>;
 }
 
 /** Tracks a pending text reply for a Prompt Gate relay (no-button prompts) */
@@ -212,6 +221,13 @@ export interface AttentionItem {
   createdAt: string;
   updatedAt: string;
   topicId?: number;
+  /**
+   * True when the topic-flood guard coalesced this item into a shared "notices
+   * coalesced" topic instead of giving it its own. Such items are NOT registered
+   * in the per-item topic maps and are managed via /attention (PATCH / dashboard),
+   * not per-topic /ack — so resolving one never closes the shared notice topic.
+   */
+  coalesced?: boolean;
 }
 
 /**
@@ -377,6 +393,14 @@ export class TelegramAdapter implements MessagingAdapter {
   private attentionTopicToItem: Map<number, string> = new Map();
   private attentionItems: Map<string, AttentionItem> = new Map();
   private attentionFilePath: string;
+  // Per-source forum-topic circuit breaker (2026-05-28 topic-flood lockdown).
+  private attentionTopicGuard!: AttentionTopicGuard;
+  // bucket -> the single reused "notices coalesced" topic for that bucket.
+  private floodNoticeTopicByBucket: Map<string, number> = new Map();
+  // bucket -> in-flight createForumTopic promise, so concurrent coalesced items
+  // for one bucket share ONE topic creation (no double-create race).
+  private floodNoticePending: Map<string, Promise<number | null>> = new Map();
+  private attentionSuppressedLogPath!: string;
 
   // Stall detection
   private pendingMessages: Map<string, PendingMessage> = new Map(); // key = topicId-timestamp
@@ -597,6 +621,8 @@ export class TelegramAdapter implements MessagingAdapter {
     this.messageLogPath = path.join(this.botStateDir, 'telegram-messages.jsonl');
     this.offsetPath = path.join(this.botStateDir, 'telegram-poll-offset.json');
     this.attentionFilePath = path.join(this.botStateDir, 'state', 'attention-items.json');
+    this.attentionSuppressedLogPath = path.join(this.botStateDir, 'state', 'attention-suppressed.jsonl');
+    this.attentionTopicGuard = new AttentionTopicGuard(config.attentionTopicGuard ?? {});
     this.loadRegistry();
     this.loadOffset();
     this.loadAttentionItems();
@@ -3311,6 +3337,30 @@ export class TelegramAdapter implements MessagingAdapter {
       updatedAt: now,
     };
 
+    // ── Topic-flood circuit breaker (2026-05-28 lockdown) ──────────────
+    // Before spawning a per-item forum topic, consult the per-source guard.
+    // HIGH/URGENT always pass (critical items must always be visible). A
+    // non-critical source that exceeds its topic budget within the window has
+    // its items COALESCED into one running notice topic + logged — never a
+    // wall of new topics. No item is dropped; only the per-item topic is held.
+    const guardSource = item.sourceContext || item.category || 'unknown';
+    const decision = this.attentionTopicGuard.decide(guardSource, item.priority);
+    if (decision.action === 'coalesce') {
+      this.writeSuppressedAttentionLog(attention, decision.bucket, decision.suppressedCount);
+      const noticeTopicId = await this.routeToFloodNotice(decision.bucket, attention, decision);
+      // Mark coalesced and record the (shared) notice topic for reference ONLY.
+      // Deliberately do NOT register the per-item topic maps: many items share one
+      // notice topic, so registering them would (a) make `loadAttentionItems`
+      // last-writer-win-corrupt the reverse map on restart and (b) make
+      // `updateAttentionStatus` close the shared topic when ONE sibling resolves.
+      // Coalesced items are managed via /attention (PATCH / dashboard), not /ack.
+      attention.coalesced = true;
+      if (noticeTopicId !== null) attention.topicId = noticeTopicId;
+      this.attentionItems.set(item.id, attention);
+      this.saveAttentionItems();
+      return attention;
+    }
+
     // Create Telegram topic (uses the centralized method for forum detection)
     try {
       const emoji = PRIORITY_EMOJI[item.priority] || PRIORITY_EMOJI.NORMAL;
@@ -3364,6 +3414,110 @@ export class TelegramAdapter implements MessagingAdapter {
     this.attentionItems.set(item.id, attention);
     this.saveAttentionItems();
     return attention;
+  }
+
+  /**
+   * Append a suppressed attention item to the audit trail. This is the
+   * "housekeeping goes to the logs" path for the topic-flood guard — the item
+   * is preserved, just not given its own forum topic. Size-capped with a single
+   * rotation (the flood is exactly the failure mode that grows this fastest).
+   */
+  private writeSuppressedAttentionLog(item: AttentionItem, bucket: string, episodeCount: number): void {
+    const entry = {
+      ts: new Date().toISOString(),
+      bucket,
+      episodeCount,
+      id: item.id,
+      priority: item.priority,
+      category: item.category,
+      title: item.title,
+      summary: item.summary,
+    };
+    try {
+      fs.mkdirSync(path.dirname(this.attentionSuppressedLogPath), { recursive: true });
+      // Rotate at ~2MB so a sustained flood can't grow the audit log unbounded.
+      try {
+        const st = fs.statSync(this.attentionSuppressedLogPath);
+        if (st.size > 2 * 1024 * 1024) {
+          fs.renameSync(this.attentionSuppressedLogPath, `${this.attentionSuppressedLogPath}.1`);
+        }
+      } catch { /* no existing file — nothing to rotate */ }
+      fs.appendFileSync(this.attentionSuppressedLogPath, JSON.stringify(entry) + '\n');
+    } catch {
+      // @silent-fallback-ok — an audit-log write failure must never crash the
+      // attention path; the item is still recorded in the in-memory store.
+    }
+    console.log(`[telegram] attention topic-flood guard: coalesced "${item.title}" (bucket=${bucket}, #${episodeCount}) — logged, no new topic`);
+  }
+
+  /**
+   * Route a coalesced attention item into ONE reused notice topic for its bucket
+   * (the source key, or the shared global bucket when the global cap tripped).
+   * The topic is created lazily once per bucket and reused thereafter (so a
+   * flapping source does not churn a new topic per episode). Concurrent coalesced
+   * items for one bucket share a single in-flight creation (no double-create
+   * race). Returns the notice topicId, or null if Telegram is unavailable (the
+   * item is still recorded + logged).
+   */
+  private async routeToFloodNotice(
+    bucket: string,
+    item: AttentionItem,
+    decision: { suppressedCount: number },
+  ): Promise<number | null> {
+    let topicId: number | null;
+    try {
+      topicId = await this.ensureFloodNoticeTopic(bucket);
+    } catch (err) {
+      console.error(`[telegram] flood-notice topic creation failed for bucket "${bucket}": ${err}`);
+      topicId = this.floodNoticeTopicByBucket.get(bucket) ?? null;
+    }
+    if (topicId === null) return null;
+    const line = `• [#${decision.suppressedCount}] ${this.escapeHtml(item.title)} — ${this.escapeHtml(String(item.summary ?? '').slice(0, 200))}`;
+    // @silent-fallback-ok — best-effort coalesce line; the item is already
+    // recorded + audit-logged, so a transient send failure is non-fatal. If the
+    // topic was deleted out from under us, drop the mapping so it's recreated.
+    await this.sendToTopic(topicId, line).catch(() => {
+      this.floodNoticeTopicByBucket.delete(bucket);
+    });
+    return topicId;
+  }
+
+  /** Lazily create (once) and return the reused notice topic id for a bucket. */
+  private async ensureFloodNoticeTopic(bucket: string): Promise<number | null> {
+    const existing = this.floodNoticeTopicByBucket.get(bucket);
+    if (existing !== undefined) return existing;
+    const inFlight = this.floodNoticePending.get(bucket);
+    if (inFlight) return inFlight;
+
+    const creation = (async (): Promise<number | null> => {
+      const label = bucket === '*' ? 'multiple sources' : bucket;
+      const title = `🔁 ${label}: notices coalesced (flood guard)`.slice(0, 128);
+      const topic = await this.createForumTopic(title, PRIORITY_COLOR.LOW ?? PRIORITY_COLOR.NORMAL);
+      const topicId = topic.topicId;
+      this.floodNoticeTopicByBucket.set(bucket, topicId);
+      this.topicToName.set(topicId, title);
+      const intro = [
+        `<b>${this.escapeHtml(label)}</b> raised more than its topic budget in a short window, so I'm collecting these notices HERE instead of spawning a new topic per item (housekeeping flood guard, 2026-05-28).`,
+        ``,
+        `Each item is also recorded in <code>state/attention-suppressed.jsonl</code> and in the attention list — manage them via the dashboard / <code>/attention</code>, not per-item /ack here. Critical (HIGH/URGENT) items are never coalesced — they still get their own topic.`,
+      ].join('\n');
+      const introParams: Record<string, unknown> = {
+        chat_id: this.config.chatId,
+        text: intro,
+        parse_mode: 'HTML',
+        _formatMode: 'html',
+      };
+      if (!isGeneralTopic(topicId)) introParams.message_thread_id = topicId;
+      await this.apiCall('sendMessage', introParams);
+      return topicId;
+    })();
+
+    this.floodNoticePending.set(bucket, creation);
+    try {
+      return await creation;
+    } finally {
+      this.floodNoticePending.delete(bucket);
+    }
   }
 
   /**
@@ -3463,7 +3617,10 @@ export class TelegramAdapter implements MessagingAdapter {
       if (data.items) {
         for (const item of data.items) {
           this.attentionItems.set(item.id, item);
-          if (item.topicId) {
+          // Coalesced items share ONE notice topic; registering them in the
+          // per-item maps would last-writer-win-corrupt the reverse map and make
+          // resolving one close the shared topic. They are managed via /attention.
+          if (item.topicId && !item.coalesced) {
             this.attentionItemToTopic.set(item.id, item.topicId);
             this.attentionTopicToItem.set(item.topicId, item.id);
           }

--- a/src/monitoring/CollaborationRedriveEngine.ts
+++ b/src/monitoring/CollaborationRedriveEngine.ts
@@ -195,18 +195,17 @@ export class CollaborationRedriveEngine {
         const strikes = (this.unresolvedNameStrikes.get(peer) ?? 0) + 1;
         this.unresolvedNameStrikes.set(peer, strikes);
         result.skipped[c.id] = `unresolved-name (strike ${strikes})`;
-        if (strikes >= 3 && this.deps.raiseAttention) {
-          try {
-            await this.deps.raiseAttention({
-              title: `can't reach ${peer} — unknown routing`,
-              body: `Tried to nudge ${peer} on commitment ${c.id} ("${c.userRequest.slice(0, 120)}") but no fingerprint resolved from known-agents.json after ${strikes} attempts. Add ${peer} to known-agents.json or close the commitment.`,
-              priority: 'medium',
-              source: 'collaboration-redrive',
-            });
-            this.unresolvedNameStrikes.set(peer, 0);
-          } catch {
-            // non-fatal
-          }
+        // HOUSEKEEPING — an unresolvable peer means known-agents.json has no
+        // routing entry for it (a config/address-book gap), NOT a collaboration
+        // outcome the operator must act on from Telegram. Log it ONCE per peer
+        // and move on: never escalate to the attention queue, never spawn a
+        // topic. This path was the 2026-05-28 flood — it raised one
+        // "can't reach <peer> — unknown routing" attention item (= one new forum
+        // topic) every few sweeps, forever, because it reset the strike counter
+        // to 0 after each escalation. We neither escalate nor reset now, so it
+        // is silent after a single log line.
+        if (strikes === 3) {
+          this.log.warn(`unresolvable peer "${peer}" on commitment ${c.id}: no fingerprint in known-agents.json after ${strikes} sweeps — skipping redrive (add ${peer} to known-agents.json or close the commitment). Housekeeping: logged once, no Telegram, no topic.`);
         }
         continue;
       }
@@ -312,11 +311,27 @@ export class CollaborationRedriveEngine {
   }
 
   private resolveFingerprint(peerName: string): string | null {
+    const isHex = /^[0-9a-f]{32,64}$/i.test(peerName);
     try {
       const raw = fs.readFileSync(this.deps.knownAgentsPath, 'utf-8');
       const data = JSON.parse(raw);
       const agents = (data.agents ?? data) as Array<{ publicKey?: string; name?: string }>;
       if (!Array.isArray(agents)) return null;
+
+      // A relatedAgent that is ALREADY a raw routing fingerprint (hex, 32–64
+      // chars) is treated as the address — but ONLY if it matches a KNOWN agent's
+      // publicKey. We never plaintext-send a nudge (which contains the operator's
+      // commitment text) to an unverified address. Commitments are sometimes
+      // registered with the peer's fingerprint as `relatedAgent` instead of a
+      // human name; the name lookup could never match those, which is what
+      // produced the "can't reach 8c7928aa…" entries in the 2026-05-28 flood
+      // (CMT-663) — but the fix must stay trust-gated, like the name path.
+      if (isHex) {
+        const lower = peerName.toLowerCase();
+        const known = agents.some((a) => typeof a.publicKey === 'string' && a.publicKey.toLowerCase() === lower);
+        return known ? lower : null;
+      }
+
       const matches = agents.filter((a) => a.name === peerName && typeof a.publicKey === 'string');
       if (matches.length !== 1) return null;
       return matches[0].publicKey ?? null;

--- a/tests/e2e/attention-topic-flood-guard-lifecycle.test.ts
+++ b/tests/e2e/attention-topic-flood-guard-lifecycle.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tier-3 lifecycle test for the topic-flood circuit breaker (2026-05-28
+ * lockdown).
+ *
+ * The single most important question for the FLEET: an already-deployed agent
+ * that auto-updates to this version and NEVER touches its config — does it get
+ * the flood protection? The guard ships ENABLED by default and is constructed
+ * unconditionally inside TelegramAdapter, so the answer must be yes with zero
+ * config. This test constructs the adapter exactly as a stock production config
+ * would (NO `attentionTopicGuard` key) and proves a flooding source is capped.
+ *
+ * This is the migration-parity guarantee in test form: the previous two floods
+ * (2026-05-22 sentinels, 2026-05-28 collaboration-redrive) both reached users
+ * who had no special config — so the fix must protect them with no special
+ * config too.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { DEFAULT_ATTENTION_TOPIC_GUARD } from '../../src/messaging/AttentionTopicGuard.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('Topic-flood guard — fleet default (no config) lifecycle', () => {
+  let adapter: TelegramAdapter;
+  let tmpDir: string;
+  let forumTopicsCreated: number;
+  let coalescedTopics: number;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-flood-e2e-'));
+    // Stock production config: token + chatId ONLY. No attentionTopicGuard key —
+    // exactly what an existing fleet agent has after a silent dist update.
+    adapter = new TelegramAdapter({ token: 't', chatId: '-100999' }, tmpDir);
+
+    forumTopicsCreated = 0;
+    coalescedTopics = 0;
+    let seq = 5000;
+    vi.spyOn(
+      adapter as unknown as { apiCall: (m: string, p: Record<string, unknown>) => Promise<unknown> },
+      'apiCall',
+    ).mockImplementation(async (method: string, params: Record<string, unknown>) => {
+      if (method === 'createForumTopic') {
+        forumTopicsCreated++;
+        if (String(params.name ?? '').includes('coalesced')) coalescedTopics++;
+        return { message_thread_id: ++seq, name: params.name };
+      }
+      if (method === 'sendMessage') return { message_id: ++seq };
+      return { ok: true };
+    });
+  });
+
+  afterEach(async () => {
+    await adapter.stop();
+    vi.restoreAllMocks();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'flood-guard-e2e cleanup' });
+  });
+
+  it('caps a flooding source at the default budget + one coalesced notice, with NO config', async () => {
+    const budget = DEFAULT_ATTENTION_TOPIC_GUARD.maxTopicsPerSource;
+    const FLOOD = budget + 25;
+
+    for (let i = 0; i < FLOOD; i++) {
+      await adapter.createAttentionItem({
+        id: `collab-redrive-${i}`,
+        title: `can't reach peer-${i} — unknown routing`,
+        summary: 'housekeeping nudge failure',
+        category: 'collaboration-redrive',
+        priority: 'NORMAL',
+        sourceContext: 'collaboration-redrive',
+      });
+    }
+
+    // The flood is bounded EXACTLY: `budget` per-item topics + exactly ONE
+    // coalesced notice topic, regardless of how many items arrived (pre-fix this
+    // was FLOOD topics). A single flooding source's per-source cap fires before
+    // the global cap, so it coalesces under its own bucket.
+    expect(forumTopicsCreated).toBe(budget + 1);
+    expect(coalescedTopics).toBe(1);
+
+    // Every item is still durably recorded — nothing dropped — and everything
+    // past the budget is flagged coalesced.
+    const items = adapter.getAttentionItems();
+    expect(items.length).toBe(FLOOD);
+    expect(items.filter(a => a.coalesced).length).toBe(FLOOD - budget);
+  });
+});

--- a/tests/integration/attention-topic-flood-guard.test.ts
+++ b/tests/integration/attention-topic-flood-guard.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tier-2 integration test for the topic-flood circuit breaker (2026-05-28
+ * lockdown) — exercises the REAL TelegramAdapter.createAttentionItem with the
+ * Telegram HTTP layer (apiCall) stubbed, so we observe exactly how many forum
+ * topics a flooding source spawns.
+ *
+ * This is the regression for the live incident: CollaborationRedriveEngine
+ * raised one "can't reach <peer>" attention item per failed sweep, and each
+ * createAttentionItem spawned a brand-new forum topic → a wall of topics. The
+ * guard caps per-item topics per source and coalesces the rest into one notice
+ * topic.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TelegramAdapter } from '../../src/messaging/TelegramAdapter.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+interface Recorder {
+  forumTopicsCreated: number;
+  topicTitles: string[];
+}
+
+function installApiStub(adapter: TelegramAdapter): Recorder {
+  const rec: Recorder = { forumTopicsCreated: 0, topicTitles: [] };
+  let threadSeq = 1000;
+  // Spy on the private HTTP funnel. createForumTopic() and sendMessage()/
+  // sendToTopic() all route through apiCall, so this is the single seam.
+  vi.spyOn(adapter as unknown as { apiCall: (m: string, p: Record<string, unknown>) => Promise<unknown> }, 'apiCall')
+    .mockImplementation(async (method: string, params: Record<string, unknown>) => {
+      if (method === 'createForumTopic') {
+        rec.forumTopicsCreated++;
+        rec.topicTitles.push(String(params.name ?? ''));
+        return { message_thread_id: ++threadSeq, name: params.name };
+      }
+      if (method === 'sendMessage') {
+        return { message_id: Math.floor(threadSeq * 10 + Math.random() * 9) };
+      }
+      return { ok: true };
+    });
+  return rec;
+}
+
+describe('Attention topic-flood guard (integration with real TelegramAdapter)', () => {
+  let adapter: TelegramAdapter;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-flood-guard-test-'));
+    adapter = new TelegramAdapter(
+      {
+        token: 'test-token-123',
+        chatId: '-100123456',
+        pollIntervalMs: 100,
+        // Tight per-source budget so the test is fast and deterministic; large
+        // window + generous global ceiling so these per-source tests aren't
+        // perturbed by the global cap (the global cap has its own unit coverage).
+        attentionTopicGuard: { enabled: true, windowMs: 60 * 60 * 1000, maxTopicsPerSource: 3, maxTopicsGlobal: 500, maxTrackedSources: 1000 },
+      },
+      tmpDir,
+    );
+  });
+
+  afterEach(async () => {
+    await adapter.stop();
+    vi.restoreAllMocks();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'attention-topic-flood-guard cleanup' });
+  });
+
+  it('caps per-item topics for one flooding source and coalesces the rest into ONE notice topic', async () => {
+    const rec = installApiStub(adapter);
+
+    const N = 12;
+    const items = [];
+    for (let i = 0; i < N; i++) {
+      items.push(await adapter.createAttentionItem({
+        id: `collab-redrive-${i}`,
+        title: `can't reach peer-${i} — unknown routing`,
+        summary: `nudge attempt for peer-${i}`,
+        category: 'collaboration-redrive',
+        priority: 'NORMAL',
+        sourceContext: 'collaboration-redrive',
+      }));
+    }
+
+    // 3 per-item topics (the budget) + exactly 1 coalesced notice topic = 4.
+    // NOT 12 (the pre-fix flood).
+    expect(rec.forumTopicsCreated).toBe(4);
+    expect(rec.topicTitles.filter(t => t.includes('coalesced')).length).toBe(1);
+
+    // No item is dropped — all 12 are recorded in the attention store.
+    const all = adapter.getAttentionItems();
+    expect(all.filter(a => a.sourceContext === 'collaboration-redrive').length).toBe(N);
+
+    // The coalesced items (4..11) all share the single reused notice topic,
+    // and are flagged coalesced (so they don't corrupt the per-item topic maps).
+    const coalescedTopicIds = new Set(items.slice(3).map(a => a.topicId));
+    expect(coalescedTopicIds.size).toBe(1);
+    expect(items.slice(3).every(a => a.coalesced === true)).toBe(true);
+    expect(items.slice(0, 3).every(a => !a.coalesced)).toBe(true);
+
+    // The suppression audit trail captured the housekeeping detail.
+    const auditPath = path.join(tmpDir, 'state', 'attention-suppressed.jsonl');
+    expect(fs.existsSync(auditPath)).toBe(true);
+    const lines = fs.readFileSync(auditPath, 'utf-8').trim().split('\n').filter(Boolean);
+    expect(lines.length).toBe(N - 3); // 9 suppressed
+  });
+
+  it('a HIGH-priority item from the SAME flooding source still gets its own topic (critical never coalesced)', async () => {
+    const rec = installApiStub(adapter);
+
+    // Saturate the NORMAL budget for the source.
+    for (let i = 0; i < 6; i++) {
+      await adapter.createAttentionItem({
+        id: `noise-${i}`, title: `noise ${i}`, summary: 's',
+        category: 'svc', priority: 'NORMAL', sourceContext: 'svc',
+      });
+    }
+    const topicsBefore = rec.forumTopicsCreated;
+
+    const critical = await adapter.createAttentionItem({
+      id: 'crit-1', title: 'real escalation', summary: 'user must see this',
+      category: 'svc', priority: 'HIGH', sourceContext: 'svc',
+    });
+
+    // The HIGH item created a NEW dedicated topic of its own.
+    expect(rec.forumTopicsCreated).toBe(topicsBefore + 1);
+    expect(typeof critical.topicId).toBe('number');
+    // And it is NOT the coalesced notice topic.
+    const noticeTitle = rec.topicTitles.find(t => t.includes('coalesced'));
+    expect(noticeTitle).toBeDefined();
+    expect(rec.topicTitles[rec.topicTitles.length - 1]).toContain('real escalation');
+  });
+
+  it('a DIFFERENT source is unaffected by another source flooding', async () => {
+    const rec = installApiStub(adapter);
+    for (let i = 0; i < 8; i++) {
+      await adapter.createAttentionItem({
+        id: `flood-${i}`, title: `flood ${i}`, summary: 's',
+        category: 'noisy', priority: 'NORMAL', sourceContext: 'noisy',
+      });
+    }
+    const before = rec.forumTopicsCreated;
+    const calm = await adapter.createAttentionItem({
+      id: 'calm-1', title: 'a single legit item', summary: 's',
+      category: 'quiet', priority: 'NORMAL', sourceContext: 'quiet',
+    });
+    expect(rec.forumTopicsCreated).toBe(before + 1);
+    expect(typeof calm.topicId).toBe('number');
+  });
+
+  it('concurrent coalesced items for one source create exactly ONE notice topic (no double-create race)', async () => {
+    const rec = installApiStub(adapter);
+    // Burn the budget so everything after coalesces.
+    for (let i = 0; i < 3; i++) {
+      await adapter.createAttentionItem({
+        id: `seed-${i}`, title: `seed ${i}`, summary: 's',
+        category: 'racey', priority: 'NORMAL', sourceContext: 'racey',
+      });
+    }
+    const ownTopics = rec.forumTopicsCreated; // 3 per-item topics
+    // Fire many coalesced items for the SAME source concurrently — they must
+    // share ONE in-flight notice-topic creation, not each create their own.
+    const items = await Promise.all(
+      Array.from({ length: 10 }, (_, i) => adapter.createAttentionItem({
+        id: `race-${i}`, title: `race ${i}`, summary: 's',
+        category: 'racey', priority: 'NORMAL', sourceContext: 'racey',
+      })),
+    );
+    // Exactly one notice topic across all concurrent coalesced items.
+    expect(rec.forumTopicsCreated).toBe(ownTopics + 1);
+    expect(rec.topicTitles.filter(t => t.includes('coalesced')).length).toBe(1);
+    expect(new Set(items.map(a => a.topicId)).size).toBe(1);
+  });
+});

--- a/tests/unit/AttentionTopicGuard.test.ts
+++ b/tests/unit/AttentionTopicGuard.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tier-1 unit tests for AttentionTopicGuard — the per-source + global forum-topic
+ * circuit breaker (2026-05-28 topic-flood lockdown). Covers both sides of every
+ * boundary: under/over budget, critical-priority bypass (case-insensitive),
+ * sustained-flood single episode, post-silence reset, the GLOBAL cap that defeats
+ * source-key variation, config validation, and key eviction.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AttentionTopicGuard, DEFAULT_ATTENTION_TOPIC_GUARD, GLOBAL_BUCKET } from '../../src/messaging/AttentionTopicGuard.js';
+
+function makeClock(start = 1_000_000): { now: () => number; advance: (ms: number) => void } {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
+// A budget that won't let the global cap interfere with per-source tests.
+const HIGH_GLOBAL = { maxTopicsGlobal: 100_000, maxTrackedSources: 100_000 };
+
+describe('AttentionTopicGuard', () => {
+  it('allows items up to the budget, then coalesces the rest within the window (under the source bucket)', () => {
+    const clock = makeClock();
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: 10 * 60_000, maxTopicsPerSource: 3, ...HIGH_GLOBAL }, clock.now);
+
+    expect(g.decide('collaboration-redrive', 'NORMAL')).toEqual({ action: 'allow' });
+    expect(g.decide('collaboration-redrive', 'NORMAL')).toEqual({ action: 'allow' });
+    expect(g.decide('collaboration-redrive', 'NORMAL')).toEqual({ action: 'allow' });
+    expect(g.decide('collaboration-redrive', 'NORMAL')).toEqual({ action: 'coalesce', firstInEpisode: true, suppressedCount: 1, bucket: 'collaboration-redrive' });
+    expect(g.decide('collaboration-redrive', 'NORMAL')).toEqual({ action: 'coalesce', firstInEpisode: false, suppressedCount: 2, bucket: 'collaboration-redrive' });
+  });
+
+  it('isolates the per-source budget (while under the global cap)', () => {
+    const clock = makeClock();
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: 10 * 60_000, maxTopicsPerSource: 1, ...HIGH_GLOBAL }, clock.now);
+    expect(g.decide('source-a', 'NORMAL').action).toBe('allow');
+    expect(g.decide('source-a', 'NORMAL').action).toBe('coalesce');
+    expect(g.decide('source-b', 'NORMAL').action).toBe('allow'); // its own fresh budget
+  });
+
+  it('NEVER coalesces HIGH or URGENT, case-insensitive, and treats CRITICAL as critical', () => {
+    const clock = makeClock();
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: 10 * 60_000, maxTopicsPerSource: 1, maxTopicsGlobal: 1, maxTrackedSources: 10 }, clock.now);
+    expect(g.decide('svc', 'NORMAL').action).toBe('allow');
+    expect(g.decide('svc', 'NORMAL').action).toBe('coalesce'); // budget burned
+    // critical priorities always bypass — in any case, repeatedly, even over budget.
+    for (const p of ['HIGH', 'high', 'URGENT', 'urgent', 'CRITICAL', 'critical']) {
+      expect(g.decide('svc', p).action).toBe('allow');
+    }
+  });
+
+  it('GLOBAL cap defeats source-key variation (the high-cardinality dodge)', () => {
+    const clock = makeClock();
+    // per-source budget is generous, but the global ceiling is 4. A mis-wired
+    // source that uses a UNIQUE key per item must still be bounded.
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: 10 * 60_000, maxTopicsPerSource: 100, maxTopicsGlobal: 4, maxTrackedSources: 10_000 }, clock.now);
+    let allowed = 0;
+    let globalCoalesced = 0;
+    for (let i = 0; i < 50; i++) {
+      const d = g.decide(`unique-source-${i}`, 'NORMAL'); // never repeats a key
+      if (d.action === 'allow') allowed++;
+      else { expect(d.bucket).toBe(GLOBAL_BUCKET); globalCoalesced++; }
+    }
+    expect(allowed).toBe(4);          // exactly the global ceiling of new topics
+    expect(globalCoalesced).toBe(46); // everything else folds into ONE global bucket
+  });
+
+  it('a sustained flood stays a SINGLE episode (one bucket) while items keep arriving', () => {
+    const clock = makeClock();
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: 10 * 60_000, maxTopicsPerSource: 3, ...HIGH_GLOBAL }, clock.now);
+    for (let i = 0; i < 3; i++) expect(g.decide('flood', 'NORMAL').action).toBe('allow');
+    let firstSeen = false;
+    for (let i = 0; i < 20; i++) {
+      clock.advance(60_000); // 1 min apart — window stays full
+      const d = g.decide('flood', 'NORMAL');
+      expect(d.action).toBe('coalesce');
+      if (d.action === 'coalesce' && d.firstInEpisode) firstSeen = true;
+    }
+    expect(firstSeen).toBe(true);
+    expect(g.episodeCount('flood')).toBe(20); // one running episode, not 20 topics
+  });
+
+  it('resets the episode after a full window of silence', () => {
+    const clock = makeClock();
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: 10 * 60_000, maxTopicsPerSource: 1, ...HIGH_GLOBAL }, clock.now);
+    expect(g.decide('s', 'NORMAL').action).toBe('allow');
+    expect(g.decide('s', 'NORMAL').action).toBe('coalesce');
+    expect(g.episodeCount('s')).toBe(1);
+    clock.advance(11 * 60_000); // longer than the window
+    expect(g.decide('s', 'NORMAL').action).toBe('allow'); // budget refilled
+    expect(g.episodeCount('s')).toBe(0);
+  });
+
+  it('is a pass-through when disabled', () => {
+    const g = new AttentionTopicGuard({ enabled: false, windowMs: 1, maxTopicsPerSource: 0, maxTopicsGlobal: 0, maxTrackedSources: 1 });
+    for (let i = 0; i < 50; i++) expect(g.decide('x', 'NORMAL').action).toBe('allow');
+  });
+
+  it('treats missing/blank source as a single "unknown" bucket', () => {
+    const clock = makeClock();
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: 10 * 60_000, maxTopicsPerSource: 1, ...HIGH_GLOBAL }, clock.now);
+    expect(g.decide(undefined, 'NORMAL').action).toBe('allow');
+    expect(g.decide('   ', 'NORMAL').action).toBe('coalesce');
+  });
+
+  it('coerces invalid config so a NaN/negative value cannot silently disable the guard', () => {
+    const clock = makeClock();
+    // NaN budget would make `>= NaN` always false → guard never trips. Coercion
+    // must fall back to the safe default instead.
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: NaN as unknown as number, maxTopicsPerSource: NaN as unknown as number, maxTopicsGlobal: -5 as unknown as number, maxTrackedSources: 0 }, clock.now);
+    expect(g.config.windowMs).toBe(DEFAULT_ATTENTION_TOPIC_GUARD.windowMs);
+    expect(g.config.maxTopicsPerSource).toBe(DEFAULT_ATTENTION_TOPIC_GUARD.maxTopicsPerSource);
+    expect(g.config.maxTopicsGlobal).toBeGreaterThanOrEqual(g.config.maxTopicsPerSource);
+    // and it actually trips:
+    for (let i = 0; i < DEFAULT_ATTENTION_TOPIC_GUARD.maxTopicsPerSource; i++) expect(g.decide('s', 'NORMAL').action).toBe('allow');
+    expect(g.decide('s', 'NORMAL').action).toBe('coalesce');
+  });
+
+  it('bounds memory: distinct source keys are evicted once stale beyond the cap', () => {
+    const clock = makeClock();
+    const g = new AttentionTopicGuard({ enabled: true, windowMs: 60_000, maxTopicsPerSource: 1, maxTopicsGlobal: 1_000_000, maxTrackedSources: 50 }, clock.now);
+    for (let i = 0; i < 200; i++) {
+      g.decide(`s-${i}`, 'NORMAL');
+      clock.advance(2_000); // 2s apart; after 60s, old keys age out of the window
+    }
+    expect(g.trackedSourceCount).toBeLessThanOrEqual(50);
+  });
+
+  it('ships enabled by default with a sane budget and a global ceiling', () => {
+    expect(DEFAULT_ATTENTION_TOPIC_GUARD.enabled).toBe(true);
+    expect(DEFAULT_ATTENTION_TOPIC_GUARD.maxTopicsPerSource).toBeGreaterThan(0);
+    expect(DEFAULT_ATTENTION_TOPIC_GUARD.maxTopicsGlobal).toBeGreaterThanOrEqual(DEFAULT_ATTENTION_TOPIC_GUARD.maxTopicsPerSource);
+    expect(DEFAULT_ATTENTION_TOPIC_GUARD.windowMs).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/CollaborationRedriveEngine.test.ts
+++ b/tests/unit/CollaborationRedriveEngine.test.ts
@@ -311,6 +311,96 @@ describe('CollaborationRedriveEngine — disabled mode', () => {
   });
 });
 
+describe('CollaborationRedriveEngine — topic-flood lockdown (2026-05-28)', () => {
+  let dir: string;
+  beforeEach(() => { dir = makeTmpDir(); });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/CollaborationRedriveEngine.test.ts cleanup' });
+  });
+
+  it('an unresolvable peer NEVER raises an attention item, no matter how many sweeps (housekeeping → logs)', async () => {
+    const tracker = setupTracker(dir);
+    const relay = makeRelayStub();
+    const raiseAttention = vi.fn(async () => undefined);
+    const engine = new CollaborationRedriveEngine(
+      {
+        commitmentTracker: tracker,
+        completionEvaluator: new CompletionEvaluator({ intelligence: makeStubIntelligence('NOT_MET') }),
+        relayClient: relay.client as never,
+        raiseAttention,
+        // No matching name → resolveFingerprint returns null every sweep.
+        knownAgentsPath: makeKnownAgents(dir, [{ name: 'someone-else', publicKey: 'fp-other' }]),
+        now: () => Date.parse('2026-05-28T20:00:00Z'),
+        log: { log: () => undefined, warn: () => undefined },
+      },
+      { ...DEFAULT_REDRIVE_CONFIG, enabled: true },
+    );
+    const c = recordThreadlineReplyCommitment(tracker, { relatedAgent: 'dawn', lastReplyAt: '2026-05-28T18:00:00Z' });
+
+    // Sweep well past the old strike threshold (was 3) — the pre-fix code raised
+    // one "can't reach" attention item (= one new forum topic) per cycle, forever.
+    for (let i = 0; i < 8; i++) {
+      const r = await engine.tick();
+      expect(r.sent).toBe(0);
+      expect(r.skipped[c.id]).toContain('unresolved-name');
+    }
+
+    expect(raiseAttention).not.toHaveBeenCalled();   // the flood source is gone
+    expect(relay.sent.length).toBe(0);
+    expect((tracker.get(c.id)!.redriveCount ?? 0)).toBe(0);
+  });
+
+  it('a 32-char hex relatedAgent resolves directly as the fingerprint when it is a KNOWN publicKey, and sends (CMT-663)', async () => {
+    const tracker = setupTracker(dir);
+    const relay = makeRelayStub();
+    const fp = '8c7928aa9f04fbda947172a2f9b2d81a';
+    const engine = new CollaborationRedriveEngine(
+      {
+        commitmentTracker: tracker,
+        completionEvaluator: new CompletionEvaluator({ intelligence: makeStubIntelligence('NOT_MET') }),
+        relayClient: relay.client as never,
+        // The hex IS a known agent's publicKey → trusted address → routable.
+        knownAgentsPath: makeKnownAgents(dir, [{ name: 'dawn', publicKey: fp }]),
+        now: () => Date.parse('2026-05-28T20:00:00Z'),
+        log: { log: () => undefined, warn: () => undefined },
+      },
+      { ...DEFAULT_REDRIVE_CONFIG, enabled: true },
+    );
+    const c = recordThreadlineReplyCommitment(tracker, { relatedAgent: fp, lastReplyAt: '2026-05-28T18:00:00Z' });
+
+    const r = await engine.tick();
+    expect(r.sent).toBe(1);
+    expect(relay.sent.length).toBe(1);
+    expect(relay.sent[0].fingerprint).toBe(fp.toLowerCase());
+    expect(tracker.get(c.id)!.redriveCount).toBe(1);
+  });
+
+  it('an UNKNOWN hex relatedAgent is NOT routed (trust-gated) — never plaintext-sends to an unverified address, and never escalates', async () => {
+    const tracker = setupTracker(dir);
+    const relay = makeRelayStub();
+    const raiseAttention = vi.fn(async () => undefined);
+    const engine = new CollaborationRedriveEngine(
+      {
+        commitmentTracker: tracker,
+        completionEvaluator: new CompletionEvaluator({ intelligence: makeStubIntelligence('NOT_MET') }),
+        relayClient: relay.client as never,
+        raiseAttention,
+        // Address book does NOT contain this hex → untrusted → must not route.
+        knownAgentsPath: makeKnownAgents(dir, [{ name: 'dawn', publicKey: 'fp-dawn-1' }]),
+        now: () => Date.parse('2026-05-28T20:00:00Z'),
+        log: { log: () => undefined, warn: () => undefined },
+      },
+      { ...DEFAULT_REDRIVE_CONFIG, enabled: true },
+    );
+    const c = recordThreadlineReplyCommitment(tracker, { relatedAgent: 'deadbeefdeadbeefdeadbeefdeadbeef', lastReplyAt: '2026-05-28T18:00:00Z' });
+
+    for (let i = 0; i < 5; i++) await engine.tick();
+    expect(relay.sent.length).toBe(0);                 // no plaintext to an unverified address
+    expect(raiseAttention).not.toHaveBeenCalled();     // and no topic-spawning escalation
+    expect((tracker.get(c.id)!.redriveCount ?? 0)).toBe(0);
+  });
+});
+
 describe('jaccard3gram', () => {
   it('returns 0 for non-overlapping phrases', () => {
     expect(jaccard3gram('one two three', 'four five six')).toBe(0);

--- a/tests/unit/PostUpdateMigrator-topicFloodGuard.test.ts
+++ b/tests/unit/PostUpdateMigrator-topicFloodGuard.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Verifies PostUpdateMigrator backfills the Topic-Flood Guard CLAUDE.md section
+ * into existing agents on update (Migration Parity + Agent Awareness Standards).
+ *
+ * The guard itself ships in code (pure src, default-ON) so every fleet agent is
+ * PROTECTED on the dist update with no config. This section is the awareness
+ * layer: so an agent can answer "why are my notices grouped / where did topic X
+ * go?". New agents get it via the first migrateClaudeMd run; this proves it at
+ * runtime and that it is idempotent.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+type MigrationResult = { upgraded: string[]; skipped: string[]; errors: string[] };
+
+function runClaudeMdMigration(migrator: PostUpdateMigrator): MigrationResult {
+  const result: MigrationResult = { upgraded: [], skipped: [], errors: [] };
+  (migrator as unknown as { migrateClaudeMd(r: MigrationResult): void }).migrateClaudeMd(result);
+  return result;
+}
+
+describe('PostUpdateMigrator — Topic-Flood Guard CLAUDE.md section', () => {
+  let projectDir: string;
+  let claudeMdPath: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-floodguard-'));
+    fs.mkdirSync(path.join(projectDir, '.instar'), { recursive: true });
+    claudeMdPath = path.join(projectDir, 'CLAUDE.md');
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(projectDir, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/PostUpdateMigrator-topicFloodGuard.test.ts:cleanup',
+    });
+  });
+
+  function newMigrator(): PostUpdateMigrator {
+    return new PostUpdateMigrator({
+      projectDir,
+      stateDir: path.join(projectDir, '.instar'),
+      port: 4042,
+      hasTelegram: false,
+      projectName: 'test',
+    });
+  }
+
+  it('adds the Topic-Flood Guard section when CLAUDE.md does not already contain it', () => {
+    fs.writeFileSync(claudeMdPath, '# CLAUDE.md\n\nMy existing CLAUDE.md.\n');
+    const result = runClaudeMdMigration(newMigrator());
+    const content = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(content).toContain('Topic-Flood Guard');
+    expect(content).toContain('attention-suppressed.jsonl');
+    expect(result.upgraded.some((u) => u.includes('Topic-Flood Guard'))).toBe(true);
+  });
+
+  it('is idempotent — a second run does not duplicate the section', () => {
+    fs.writeFileSync(claudeMdPath, '# CLAUDE.md\n\nMy existing CLAUDE.md.\n');
+    runClaudeMdMigration(newMigrator());
+    const after1 = fs.readFileSync(claudeMdPath, 'utf-8');
+    const result2 = runClaudeMdMigration(newMigrator());
+    const after2 = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after2).toBe(after1);
+    const occurrences = after2.split('## Topic-Flood Guard (attention queue circuit breaker)').length - 1;
+    expect(occurrences).toBe(1);
+    expect(result2.upgraded.some((u) => u.includes('Topic-Flood Guard'))).toBe(false);
+  });
+});

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -220,6 +220,7 @@ describe('Feature Delivery Completeness', () => {
       '/release-readiness',                                // alternate endpoint check for the templated Release Readiness section
       'Agent Updates topic (self-broadcasts about ships, restarts, updates)', // self-broadcast routing operational knowledge, migrator-only
       '/sessions/reap-log',                               // UNIFIED-SESSION-LIFECYCLE §P4 reap-log: operational observability the agent READS to answer "where did my session go?" — like Sentinel Notifications, not a user-invokable capability requiring framework-shadow parity
+      'Topic-Flood Guard',                                // 2026-05-28 attention-queue circuit breaker: operational housekeeping the agent READS (state/attention-suppressed.jsonl) to answer "why are my notices grouped?" — like Sentinel Notifications, migrator-only (no template/shadow parity)
     ];
 
     it('all new migrator CLAUDE.md sections are tracked', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,66 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Topic-spam, locked down at the source.** A second Telegram topic-flood (after
+the 2026-05-22 sentinel flood) hit a live agent: `CollaborationRedriveEngine`
+raised one "can't reach `<peer>` — unknown routing" attention item per failed
+peer-resolution, every sweep, forever — and because `createAttentionItem` spawns
+a brand-new forum topic per item, that became a wall of topics. Two fixes landed
+— a per-feature cleanup AND a structural backstop so the *class* of bug can't
+recur regardless of which feature misbehaves next.
+
+**1. Structural backstop — `AttentionTopicGuard` (the lockdown).** A per-source
+circuit breaker now sits at the one chokepoint, `TelegramAdapter.createAttentionItem`.
+If a single attention `sourceContext` exceeds its topic budget within a rolling
+window (default: 3 topics / 10 min), further **non-critical** items from that
+source are COALESCED into ONE running "notices coalesced" topic and recorded in
+`state/attention-suppressed.jsonl` — never a wall of new topics. Invariants:
+HIGH/URGENT items are **never** coalesced (critical messages always get their own
+topic), and **no item is dropped** — only its per-item topic is withheld; the
+item is still in the attention store. Ships **enabled by default in code**, so
+every fleet agent is protected on the dist update with zero config.
+
+**2. Per-feature cleanup — `CollaborationRedriveEngine`.**
+- "can't reach / unknown routing" is now **log-only housekeeping** — it never
+  raises an attention item (so it never spawns a topic) and never re-fires. The
+  old code reset its strike counter to 0 after each escalation, which is why it
+  flooded forever.
+- A `relatedAgent` that is **already a 32–64-char hex routing fingerprint** now
+  resolves directly instead of failing a name lookup that can never match (the
+  `can't reach 8c7928aa…` entries; CMT-663).
+
+## What to Tell Your User
+
+- The "wall of topics popping up out of nowhere" problem is fixed at its root.
+  If any background feature ever tries to flood the chat with notices again, it's
+  now capped automatically: a few at most, then everything folds into one quiet
+  "notices coalesced" topic, with the detail kept in the logs. Genuinely critical
+  alerts (HIGH/URGENT) are never affected — they always come through on their own.
+- No action or config needed; it's on by default.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Attention topic-flood circuit breaker | Automatic, on by default. Tune via `messaging[].config.attentionTopicGuard` = `{ "enabled": true, "windowMs": 600000, "maxTopicsPerSource": 3 }`. |
+| Suppressed-notice audit trail | When a source is coalesced, each item is logged to `state/attention-suppressed.jsonl`. Read it to answer "why are my notices grouped / where did topic X go?" |
+
+## Migration Notes
+
+The guard is **pure `src/` logic, default-ON in code** (`AttentionTopicGuard` +
+`TelegramAdapter`) — no agent-installed file changed, so every agent receives the
+protection through the normal dist update with nothing to patch. A
+`migrateClaudeMd()` entry backfills the **Topic-Flood Guard** awareness section
+into existing agents' CLAUDE.md (idempotent). `collaborationRedrive` keeps its
+ship-OFF default; the fix only makes it safe for agents that turn it on.
+
+## Evidence
+
+- Unit: `tests/unit/AttentionTopicGuard.test.ts` (8) — budget/coalesce/critical-bypass/episode-reset;
+  `tests/unit/CollaborationRedriveEngine.test.ts` (+2) — unresolvable peer never raises attention; hex peer resolves directly;
+  `tests/unit/PostUpdateMigrator-topicFloodGuard.test.ts` (2) — migrator backfill + idempotency.
+- Integration: `tests/integration/attention-topic-flood-guard.test.ts` (3) — REAL `TelegramAdapter`: a flooding source is capped at budget+1 topics, HIGH bypasses, other sources unaffected, no item dropped.
+- E2E: `tests/e2e/attention-topic-flood-guard-lifecycle.test.ts` (1) — fleet default (NO config) still caps a flood (migration-parity guarantee).

--- a/upgrades/side-effects/attention-topic-flood-guard.md
+++ b/upgrades/side-effects/attention-topic-flood-guard.md
@@ -1,0 +1,74 @@
+# Side-Effects Review — Attention Topic-Flood Guard
+
+**Spec:** `docs/specs/attention-topic-flood-guard.md` (converged, 4-reviewer panel)
+**Change:** per-source + global forum-topic circuit breaker at
+`TelegramAdapter.createAttentionItem`, plus `CollaborationRedriveEngine`
+housekeeping/hex-trust fix.
+**Files:** `src/messaging/AttentionTopicGuard.ts` (new),
+`src/messaging/TelegramAdapter.ts`, `src/monitoring/CollaborationRedriveEngine.ts`,
+`src/core/PostUpdateMigrator.ts`, tests, `tests/unit/feature-delivery-completeness.ts`,
+`upgrades/NEXT.md`.
+
+## Phase 4 — the seven questions
+
+1. **Over-block.** The guard never blocks an agent action or drops an item — it
+   only changes *delivery form* (own topic vs. one coalesced topic + a log line)
+   for **non-critical** items. The one legitimate behavior it changes: a
+   non-critical source raising >3 items / 10 min has the surplus coalesced. That
+   is the *intended* behavior (the operator asked for exactly this) and is tunable
+   per adapter. HIGH/URGENT are never affected. No agent capability is rejected.
+
+2. **Under-block.** Before the global ceiling was added, a source varying its
+   `sourceContext` per item would have dodged the per-source budget — the review
+   caught this; the global cap + key eviction now bound it regardless of source
+   cardinality. Remaining under-block: a flood composed entirely of HIGH/URGENT
+   items is not coalesced (by design — critical items must always be visible). A
+   feature mis-marking routine noise as HIGH would still flood; that is a
+   mis-classification bug in that feature, not in the guard, and is the correct
+   place to fix it.
+
+3. **Level-of-abstraction fit.** Correct layer: the breaker sits at the single
+   chokepoint (`createAttentionItem`) where every attention item becomes a topic,
+   so it covers all current and future callers. It is deliberately *below* the
+   tone-gate authority on the `/attention` route (a transport-mechanics
+   rate-counter, not a content-judgment filter). The per-feature redrive fix is at
+   the feature layer; the guard is the substrate backstop — two layers, by intent.
+
+4. **Signal vs authority.** Compliant. The guard holds no blocking authority over
+   agent behavior or information flow; it is a delivery *shaper* (the rate-counter
+   / transport-dedup carve-out in `docs/signal-vs-authority.md`), the same class as
+   `SentinelNotifier`. It never withholds a critical notice and never drops an
+   item. The redrive change *removes* an authority-bearing escalation on a brittle
+   signal and downgrades it to a log signal — in the direction the principle wants.
+
+5. **Interactions.** Audited against `SentinelNotifier` (separate path → the
+   single reused system topic; no collision — it never flows through the guard) and
+   the `agent-attention-topic` (not registered in the attention maps, untouched).
+   Restart interaction (coalesced items vs. `loadAttentionItems` reverse-map
+   corruption) and concurrency (double-create race) were both found by review and
+   fixed. `updateAttentionStatus` no longer closes a shared topic when one
+   coalesced sibling resolves (coalesced items aren't in the per-item maps).
+
+6. **External surfaces.** User-visible change: a flooding source now produces one
+   "🔁 …: notices coalesced (flood guard)" topic instead of a wall; the rest goes
+   to `state/attention-suppressed.jsonl`. Fleet-wide via dist update, default-ON,
+   no config. No new network calls; no new external dependency. The CLAUDE.md
+   awareness section is backfilled to existing agents (idempotent migrator).
+
+7. **Rollback cost.** Cheap. Single config flag:
+   `messaging[].config.attentionTopicGuard.enabled = false` restores per-item-topic
+   behavior. No data migration, no agent-state repair (the guard holds only
+   in-memory counters; the redrive change only removes an escalation path). Worst
+   case is a `src/` revert + patch release.
+
+## Phase 5 — second-pass review (REQUIRED: touches a "guard" + outbound messaging)
+
+An independent four-reviewer convergence panel (adversarial/security, integration,
+architecture, scalability) audited the change against the diff. It raised 7
+material concerns (global-cap dodge, `/ack`+shared-topic-close, case-sensitive
+critical bypass, double-create race, hex plaintext to unverified address, NaN
+config disable, unbounded audit log) plus framing notes. **All 7 were fixed in
+code this iteration; none deferred.** Full record:
+`docs/specs/attention-topic-flood-guard.convergence.md`. **Concur with the review —
+the design after this iteration addresses every raised concern; no blocking
+authority on brittle logic remains.**


### PR DESCRIPTION
## What & why

Second Telegram topic-flood (after the 2026-05-22 sentinel flood). An agent's `CollaborationRedriveEngine` raised one **"can't reach `<peer>` — unknown routing"** attention item per failed peer-resolution every sweep, forever (it reset its strike counter to 0 after each escalation), and `createAttentionItem` spawns a **brand-new forum topic per item** → a wall of topics. The empty `known-agents.json` on that machine made every peer unresolvable.

Fixed in two layers — *fix the offender AND make the class of bug impossible*:

### 1. Structural backstop — `AttentionTopicGuard` (the lockdown)
A per-source **and global** circuit breaker at the one chokepoint (`TelegramAdapter.createAttentionItem`). Once a non-critical source — or, via the **global ceiling**, all sources collectively — exceeds its topic budget within a rolling window, further items **coalesce into ONE reused notice topic** and are recorded in `state/attention-suppressed.jsonl` (size-capped). Never a wall.
- **Global ceiling** makes the "any mis-wired feature is auto-throttled" guarantee hold even when a feature varies its `sourceContext` per item.
- **HIGH/URGENT/CRITICAL (case-insensitive) are never coalesced** — critical messages always get their own topic.
- **No item is dropped** — coalesced items are flagged and excluded from the per-item topic maps, so resolving one never closes the shared topic and a restart can't corrupt the reverse map.
- **No double-create race** — concurrent coalesced items for a bucket share one in-flight topic creation.
- **Config validated** — a `NaN`/negative value can't silently disable it.
- **Default-ON in code** → every fleet agent is protected on the dist update with zero config. Rollback = `messaging[].config.attentionTopicGuard.enabled=false`.

### 2. Offender fix — `CollaborationRedriveEngine`
- "can't reach / unknown routing" is now **log-only housekeeping** (no attention item, no topic, no re-fire).
- A 32–64-char-hex `relatedAgent` resolves directly as the routing fingerprint **only when it matches a known agent's `publicKey`** (trust-gated — never plaintext-sends to an unverified address; CMT-663).

## Review

Converged via a **4-reviewer panel** (adversarial/security, integration, architecture, scalability). All **7 material findings fixed in code, none deferred**. See `docs/specs/attention-topic-flood-guard.{md,eli16.md,convergence.md}` and `upgrades/side-effects/attention-topic-flood-guard.md`.

## Tests (all 3 tiers)
- **Unit** — `AttentionTopicGuard` (11: budget/global-cap/critical-bypass/episode/eviction/config-validation), `CollaborationRedriveEngine` (+3: housekeeping log-only, hex-known-routes, hex-unknown-blocked), `PostUpdateMigrator-topicFloodGuard` (2).
- **Integration** — real `TelegramAdapter`: flood capped at budget+1 topics, HIGH bypasses, concurrent-coalesce → one topic, different source unaffected, no item dropped, audit log populated.
- **E2E** — fleet default (NO config) still caps a flood exactly (migration-parity).

Migrator backfills a "Topic-Flood Guard" awareness section (idempotent). `collaborationRedrive` keeps its ship-OFF default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)