### PR TITLE
feat(usher): wire precision numerator via auto-use + miss-map correlation

### DIFF
--- a/site/src/content/docs/features/observability.md
+++ b/site/src/content/docs/features/observability.md
@@ -98,6 +98,21 @@ Read-only token-usage observability. The ledger scans Claude Code's JSONL sessio
 
 The ledger never mutates source files — it only reads. The poller is the only writer (to its own SQLite index), and even that is restartable from any state.
 
+## Usher precision (continuous-working-awareness)
+
+Components: `UsherSignalStore`, `UsherActedCorrelator`.
+
+The Usher (rung 4 of the [Continuous Working Awareness](/foundations/north-star/) loop) watches mid-task and fires a *re-surface signal* when a faded-but-now-relevant context comes back. Those signals are signal-only — they never interrupt the agent yet. Whether they ever earn the right to interrupt (rung 5) is gated on one number: **precision** = how often a re-surfaced nudge was actually useful.
+
+`UsherSignalStore` records every fired signal and exposes the precision funnel at `GET /usher/metrics?topicId=N` — `fired`, `acted`, and `precision` (`acted / fired`), plus `acted_by_use` / `acted_by_miss` so the numerator is visible split by which path earned it. `GET /usher/signals?topicId=N` is the read-only pull surface of recent suggestions.
+
+`UsherActedCorrelator` is what moves the `acted` numerator. A nudge is credited two ways, both best-effort and never blocking delivery:
+
+- **auto-use** — when the agent's next reply on the topic actually uses the re-surfaced context (salient-term coverage match), the signal is marked acted (`via: 'use'`).
+- **miss-map** — when the user later has to *correct* the agent on a context a recent nudge already flagged (a `HumanAsDetectorLog` signal), that nudge was a genuine catch the agent ignored — still a true positive, marked acted (`via: 'miss'`).
+
+Matching is precision-over-recall: a falsely-high precision is the dangerous direction (it gates interruption), so the correlator under-credits a fast or marginal reply rather than inflating the gate. Pair `/usher/metrics` (what the Usher caught and used) with `/human-as-detector/summary` (what the user still had to catch) for the full "is the working-awareness loop actually working?" read.
+
 ## What the agent does with all this
 
 Every observability signal lands in the `DegradationReporter` channel, which dedupes, prioritizes, and surfaces signals to whichever notification path is configured (Telegram by default). Repeating patterns get grouped — three similar burns in one day become "Burn pattern: heavy reflection-trigger runs" rather than three separate alerts.

--- a/site/src/content/docs/foundations/north-star.md
+++ b/site/src/content/docs/foundations/north-star.md
@@ -66,6 +66,7 @@ Two design choices carry the whole thing:
 
 - **Signal vs. authority.** The Librarian and Usher are cheap and fast, and they only emit *signals* — "this might matter," "this might be worth re-surfacing." A higher-context decision step decides whether to actually inject or stay silent.
 - **Near-silent by default.** A loop that chatters becomes the next thing dismissed 73 times. The Usher injects only when it would change the agent's next action. Everything else goes to a pull surface, never into the agent's face.
+- **The right to interrupt is earned, not assumed.** Before the Usher is ever allowed to inject mid-task, it has to prove its re-surface signals are useful. `UsherSignalStore` records every fired signal and its precision (`acted / fired`); `UsherActedCorrelator` credits a signal when the agent's next reply actually uses the re-surfaced context, or when the user later has to correct the agent on something a nudge already flagged. That measured precision is the hard precondition on the final rung — the loop must demonstrate accuracy before it gets to interrupt. See [Observability](/features/observability/) for the live metrics.
 
 ## Not starting from scratch
 

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -98,6 +98,7 @@ import { DispatchScopeEnforcer } from '../core/DispatchScopeEnforcer.js';
 import { TrustRecovery } from '../core/TrustRecovery.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import { HumanAsDetectorLog, observeInboundMessage } from '../monitoring/HumanAsDetectorLog.js';
+import { creditUsherOnMiss } from '../core/UsherActedCorrelator.js';
 import { resolveStableNodeBinary } from '../utils/resolveNodeBinary.js';
 import { SelfKnowledgeTree } from '../knowledge/SelfKnowledgeTree.js';
 import { CoverageAuditor } from '../knowledge/CoverageAuditor.js';
@@ -6408,7 +6409,18 @@ export async function startServer(options: StartOptions): Promise<void> {
         const beforeHadCallback = telegram.onMessageLogged;
         telegram.onMessageLogged = (entry) => {
           if (beforeHadCallback) beforeHadCallback(entry);
-          observeInboundMessage(humanAsDetectorLog, entry);
+          const missSignal = observeInboundMessage(humanAsDetectorLog, entry);
+          // ── Usher precision, path (b): the user just had to correct me (a
+          // human-as-detector miss). If a recent faded-context nudge on this
+          // topic covers what they're correcting, that nudge was a REAL catch I
+          // ignored → mark it acted. This is the miss-map → precision-numerator
+          // correlation that pairs with path (a). Best-effort (never throws).
+          if (missSignal && usherSignalStore) {
+            const credited = creditUsherOnMiss(usherSignalStore, missSignal, entry);
+            if (credited.length) {
+              console.log(`[Usher] ${credited.length} signal(s) marked acted (miss) on topic ${entry.topicId}`);
+            }
+          }
         };
 
         // ── Topic-Intent ArcCheck (rung 3 / Layer 3) ────────────────────

--- a/src/core/UsherActedCorrelator.ts
+++ b/src/core/UsherActedCorrelator.ts
@@ -1,0 +1,194 @@
+/**
+ * UsherActedCorrelator — the precision-numerator wiring for the Usher (rung 4 of
+ * continuous-working-awareness).
+ *
+ * The Usher FIRES re-surface signals (UsherSignalStore.recordSignal). Until this
+ * module, nothing ever called markActed — so `precision = acted/fired` was pinned
+ * at 0 and the rung-5 (mid-task injection) gate could never be satisfied by data.
+ * This closes that loop via TWO correlation paths, both reducing to "does some
+ * probe text COVER a fired signal's contextText?":
+ *
+ *   (a) auto-use   — the agent's next reply on the topic uses the re-surfaced
+ *                    context. creditUsherOnOutbound(). The nudge was useful: the
+ *                    agent acted on it.
+ *   (b) miss-map   — the user later had to CORRECT the agent (a HumanAsDetector
+ *                    signal) on that same context. creditUsherOnMiss(). The nudge
+ *                    was a genuine catch the agent ignored — still a true positive
+ *                    for the Usher's precision.
+ *
+ * Matching is deliberately PRECISION-OVER-RECALL: precision gates whether the
+ * Usher earns the right to interrupt (rung 5), so a falsely-HIGH precision is the
+ * dangerous direction. We require a meaningful salient-term overlap (≥ MIN_SHARED
+ * shared content words AND ≥ MIN_COVERAGE of the context's terms) and only credit
+ * recently-fired signals. Under-crediting a fast reply is acceptable; inflating
+ * the gate is not.
+ *
+ * All exported integration fns are best-effort and NEVER throw into the
+ * message/delivery path — mirroring the Usher's own degrade-safety invariants.
+ */
+
+import type { UsherSignal, UsherSignalStore } from './UsherSignalStore.js';
+
+/** Minimal inbound-entry shape the miss path reads (matches InboundMessageEntry). */
+export interface MissEntry {
+  topicId?: number | null;
+  text?: string;
+}
+
+// ── Matching knobs (precision-over-recall) ───────────────────────────────────
+export const MIN_SHARED = 2; // a single coincidental word can't credit a signal
+export const MIN_COVERAGE = 0.5; // must cover at least half the context's salient terms
+/** Window in which the agent's reply still counts as "using" a just-fired nudge. */
+export const USE_WINDOW_MS = 6 * 60 * 60 * 1000; // 6h
+/** Window in which a later user correction still credits a prior nudge. */
+export const MISS_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h
+
+// English stopwords + a few instar-conversation fillers. Kept small and stable:
+// the goal is to drop function words so overlap reflects real subject matter.
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'are', 'but', 'not', 'you', 'your', 'with', 'that', 'this',
+  'have', 'has', 'had', 'was', 'were', 'will', 'would', 'should', 'could', 'can',
+  'its', 'it', 'is', 'be', 'been', 'being', 'from', 'into', 'over', 'under', 'about',
+  'they', 'them', 'their', 'there', 'here', 'what', 'when', 'where', 'which', 'who',
+  'how', 'why', 'all', 'any', 'some', 'one', 'two', 'now', 'then', 'than', 'just',
+  'out', 'off', 'too', 'very', 'our', 'his', 'her', 'him', 'she', 'his', 'we',
+  'get', 'got', 'let', 'see', 'use', 'used', 'make', 'made', 'want', 'need',
+  'yes', 'yeah', 'okay', 'sure', 'thing', 'things', 'stuff', 'like', 'also',
+  'going', 'gonna', 'really', 'much', 'more', 'most', 'still', 'back', 'done',
+]);
+
+/**
+ * Salient content tokens of a text: lowercased, alphanumeric-split, ≥3 chars,
+ * stopwords removed. Pure + deterministic.
+ */
+export function salientTerms(text: string): Set<string> {
+  const out = new Set<string>();
+  if (!text || typeof text !== 'string') return out;
+  for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (raw.length < 3) continue;
+    if (STOPWORDS.has(raw)) continue;
+    out.add(raw);
+  }
+  return out;
+}
+
+/**
+ * Does `probeText` cover enough of `contextText`'s salient terms to count as a
+ * genuine reference to it? Requires ≥ minShared shared terms AND ≥ minCoverage
+ * fraction of the context's terms (so single-coincidental-word matches fail, and
+ * a long context needs proportionally more overlap).
+ */
+export function contextCoveredBy(
+  contextText: string,
+  probeText: string,
+  opts?: { minShared?: number; minCoverage?: number },
+): boolean {
+  const ctx = salientTerms(contextText);
+  if (ctx.size === 0) return false;
+  const probe = salientTerms(probeText);
+  if (probe.size === 0) return false;
+  let shared = 0;
+  for (const t of ctx) if (probe.has(t)) shared++;
+  const coverage = shared / ctx.size;
+  return shared >= (opts?.minShared ?? MIN_SHARED) && coverage >= (opts?.minCoverage ?? MIN_COVERAGE);
+}
+
+/**
+ * Pure: among NOT-yet-acted signals, which ones does `probeText` cover? Returns
+ * their ids. `maxAgeMs`+`nowMs` optionally drop signals older than the window.
+ */
+export function findCoveredSignalIds(
+  signals: UsherSignal[],
+  probeText: string,
+  opts?: { minShared?: number; minCoverage?: number; maxAgeMs?: number; nowMs?: number },
+): string[] {
+  const ids: string[] = [];
+  const maxAgeMs = opts?.maxAgeMs;
+  const nowMs = opts?.nowMs ?? Date.now();
+  for (const s of signals) {
+    if (!s || s.acted) continue;
+    if (maxAgeMs !== undefined) {
+      const firedMs = Date.parse(s.at);
+      if (!Number.isNaN(firedMs) && nowMs - firedMs > maxAgeMs) continue;
+    }
+    if (contextCoveredBy(s.contextText, probeText, opts)) ids.push(s.id);
+  }
+  return ids;
+}
+
+/**
+ * Core integration: correlate `probeText` against a topic's fired signals and
+ * mark the matches acted (stamped with `via`). Best-effort, never throws.
+ * Returns the ids actually marked.
+ */
+export function markActedByCoverage(
+  store: UsherSignalStore,
+  topicId: number,
+  probeText: string,
+  via: 'use' | 'miss',
+  opts?: { now?: () => number; maxAgeMs?: number; minShared?: number; minCoverage?: number; onMarked?: (id: string) => void },
+): string[] {
+  try {
+    if (!probeText || typeof probeText !== 'string') return [];
+    if (typeof topicId !== 'number' || !Number.isFinite(topicId)) return [];
+    const nowMs = (opts?.now ?? (() => Date.now()))();
+    const signals = store.getSignals(topicId, 50);
+    const ids = findCoveredSignalIds(signals, probeText, {
+      minShared: opts?.minShared,
+      minCoverage: opts?.minCoverage,
+      maxAgeMs: opts?.maxAgeMs,
+      nowMs,
+    });
+    if (ids.length === 0) return [];
+    const at = new Date(nowMs).toISOString();
+    const marked: string[] = [];
+    for (const id of ids) {
+      if (store.markActed(topicId, id, { via, at })) {
+        marked.push(id);
+        try { opts?.onMarked?.(id); } catch { /* observability hook must not break */ }
+      }
+    }
+    return marked;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Path (a): the agent's reply just went out on `topicId`. Credit any recent
+ * faded-context nudge the reply actually used. Wire on the outbound-reply path.
+ */
+export function creditUsherOnOutbound(
+  store: UsherSignalStore | null | undefined,
+  topicId: number,
+  replyText: string,
+  opts?: { now?: () => number; maxAgeMs?: number },
+): string[] {
+  if (!store) return [];
+  return markActedByCoverage(store, topicId, replyText, 'use', {
+    now: opts?.now,
+    maxAgeMs: opts?.maxAgeMs ?? USE_WINDOW_MS,
+  });
+}
+
+/**
+ * Path (b): the user just had to correct the agent (`missSignal` non-null). If a
+ * recent nudge on this topic covers what they're correcting, that nudge was a
+ * real catch the agent ignored → credit it. Wire on the inbound human-detector
+ * seam. No-op when there was no miss, no topic, or no text.
+ */
+export function creditUsherOnMiss(
+  store: UsherSignalStore | null | undefined,
+  missSignal: unknown,
+  entry: MissEntry,
+  opts?: { now?: () => number; maxAgeMs?: number },
+): string[] {
+  if (!store || !missSignal) return [];
+  const topicId = entry?.topicId;
+  const text = entry?.text;
+  if (typeof topicId !== 'number' || !text) return [];
+  return markActedByCoverage(store, topicId, text, 'miss', {
+    now: opts?.now,
+    maxAgeMs: opts?.maxAgeMs ?? MISS_WINDOW_MS,
+  });
+}

--- a/src/core/UsherSignalStore.ts
+++ b/src/core/UsherSignalStore.ts
@@ -28,12 +28,25 @@ export interface UsherSignal {
   at: string;
   /** True once the re-surfaced context was actually used (precision numerator). */
   acted: boolean;
+  /**
+   * Which path confirmed the signal was useful (set when `acted` flips true):
+   *   'use'  — the agent's next reply actually used the re-surfaced context.
+   *   'miss' — the user later had to correct the agent on that same context, so
+   *            the nudge was a genuine catch the agent ignored.
+   * Optional for backward-compat with signals/callers that pre-date the split.
+   */
+  actedVia?: 'use' | 'miss';
+  /** ISO timestamp when the signal was marked acted. */
+  actedAt?: string;
 }
 
 export interface UsherMetrics {
   fired: number;
   acted: number;
   last_fired_at: string | null;
+  /** Precision numerator, split by which path confirmed usefulness (observability). */
+  acted_by_use?: number;
+  acted_by_miss?: number;
 }
 
 interface UsherTopicFile {
@@ -116,14 +129,26 @@ export class UsherSignalStore {
     }
   }
 
-  /** Mark a signal as acted-on (precision numerator). Best-effort. */
-  markActed(topicId: number, signalId: string): boolean {
+  /**
+   * Mark a signal as acted-on (precision numerator). Best-effort, idempotent
+   * (a second call on the same signal is a no-op returning false).
+   *
+   * `opts.via` records WHICH correlation path confirmed usefulness ('use' =
+   * the agent used it in a reply; 'miss' = the user had to correct on it) and
+   * is reflected in the split metrics. `opts.at` lets callers stamp a
+   * deterministic timestamp (tests); defaults to now.
+   */
+  markActed(topicId: number, signalId: string, opts?: { via?: 'use' | 'miss'; at?: string }): boolean {
     try {
       const file = this.load(topicId);
       const sig = file.signals.find(x => x.id === signalId);
       if (!sig || sig.acted) return false;
       sig.acted = true;
+      if (opts?.via) sig.actedVia = opts.via;
+      sig.actedAt = opts?.at ?? new Date().toISOString();
       file.metrics.acted += 1;
+      if (opts?.via === 'use') file.metrics.acted_by_use = (file.metrics.acted_by_use ?? 0) + 1;
+      else if (opts?.via === 'miss') file.metrics.acted_by_miss = (file.metrics.acted_by_miss ?? 0) + 1;
       this.save(file);
       return true;
     } catch {

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -723,6 +723,7 @@ export class AgentServer {
       responseReviewGate: options.responseReviewGate ?? null,
       messagingToneGate: options.messagingToneGate ?? null,
       topicIntentArcCheck: options.topicIntentArcCheck ?? null,
+      usherSignalStore: options.usherSignalStore ?? null,
       outboundDedupGate: options.outboundDedupGate ?? null,
       telemetryHeartbeat: options.telemetryHeartbeat ?? null,
       pasteManager: options.pasteManager ?? null,

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -20,6 +20,7 @@ import type { InstarConfig, JobPriority } from '../core/types.js';
 import { rateLimiter, signViewPath } from './middleware.js';
 import type { WriteOperation, WriteToken } from '../core/StateWriteAuthority.js';
 import { writeLifelineRestartSignal } from '../core/version-skew.js';
+import { creditUsherOnOutbound } from '../core/UsherActedCorrelator.js';
 import { validateWriteToken, canPerformOperation } from '../core/StateWriteAuthority.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 import { FailureLedger } from '../monitoring/FailureLedger.js';
@@ -604,6 +605,10 @@ export interface RouteContext {
    *  in-process by checkOutboundMessage so the tone gate sees ArcCheck's
    *  signal alongside junk/jargon/duplicate. Null when disabled. */
   topicIntentArcCheck: import('../core/TopicIntentArcCheck.js').ArcCheck | null;
+  /** Usher signal store (rung 4). Used by the outbound-reply path to credit a
+   *  re-surface nudge the agent's reply actually used (precision numerator,
+   *  path (a)). Optional/null when the Usher is disabled. */
+  usherSignalStore?: import('../core/UsherSignalStore.js').UsherSignalStore | null;
   /** Deterministic dedup gate. Blocks near-duplicate outbound messages in
    *  the same conversation — universal safety net against respawn races,
    *  idempotency gaps, and other lifecycle hazards. No LLM call, runs on
@@ -5550,6 +5555,17 @@ export function createRoutes(ctx: RouteContext): Router {
       // Proxy messages should not reset stall detection timers
       if (!isProxy) {
         ctx.sessionManager.clearInjectionTracker(topicId);
+      }
+      // ── Usher precision, path (a): the agent's genuine reply just went out. If
+      // it actually USED a faded context the Usher re-surfaced for this topic,
+      // mark that signal acted — the precision numerator that gates rung-5
+      // mid-task injection. Proxy/system templates aren't the agent reasoning, so
+      // they can't "use" a nudge and are excluded. Best-effort (never throws).
+      if (!isProxy && !isSystemTemplate) {
+        const credited = creditUsherOnOutbound(ctx.usherSignalStore, topicId, text);
+        if (credited.length) {
+          console.log(`[Usher] ${credited.length} signal(s) marked acted (use) on topic ${topicId}`);
+        }
       }
       // ── Exactly-once ingress: commit reply_committed (spec §8 G3a) ──
       // The agent's real reply just went out → mark the inbound event this topic

--- a/src/server/usherRoutes.ts
+++ b/src/server/usherRoutes.ts
@@ -38,8 +38,14 @@ export function createUsherRoutes(deps: { signalStore: UsherSignalStore | null }
     const m = store.getMetrics(parsed.data);
     // Precision = acted / fired (the read that gates rung 5; paired externally
     // with the human-as-detector miss-map for the "what it missed" half).
+    // acted_by_use / acted_by_miss split the numerator by which correlation path
+    // confirmed usefulness (agent used it vs user had to correct on it); defaulted
+    // so legacy topic files (pre-split) report 0 rather than undefined.
     const precision = m.fired > 0 ? m.acted / m.fired : null;
-    res.json({ topicId: parsed.data, metrics: { ...m, precision } });
+    res.json({
+      topicId: parsed.data,
+      metrics: { ...m, acted_by_use: m.acted_by_use ?? 0, acted_by_miss: m.acted_by_miss ?? 0, precision },
+    });
   });
 
   return router;

--- a/tests/e2e/usher-precision-lifecycle.test.ts
+++ b/tests/e2e/usher-precision-lifecycle.test.ts
@@ -1,0 +1,154 @@
+/**
+ * E2E lifecycle test (Tier 3) for the Usher PRECISION LOOP (rung 4).
+ *
+ * The single most important test: is the precision loop actually ALIVE
+ * end-to-end? Before this feature, the Usher fired signals but markActed had no
+ * caller, so precision was pinned at 0 (the rung-5 gate could never move). This
+ * boots the real createRoutes tree on a live HTTP server and proves BOTH credit
+ * paths flip a fired signal to acted and the change is visible over real HTTP at
+ * GET /usher/metrics:
+ *
+ *   path (a) — POST /telegram/reply with a reply that USES a re-surfaced context
+ *              → the nudge is marked acted_by_use; precision moves null → 1.0.
+ *   path (b) — an inbound human correction (the exact two-line server.ts seam:
+ *              observeInboundMessage → creditUsherOnMiss) credits a prior nudge
+ *              the agent ignored → acted_by_miss.
+ *
+ * Returns 200, not 503 — the "feature is alive" gate (CLAUDE.md Testing
+ * Integrity Standard).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import type { Server } from 'node:http';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { createUsherRoutes } from '../../src/server/usherRoutes.js';
+import { UsherSignalStore } from '../../src/core/UsherSignalStore.js';
+import { HumanAsDetectorLog, observeInboundMessage } from '../../src/monitoring/HumanAsDetectorLog.js';
+import { creditUsherOnMiss } from '../../src/core/UsherActedCorrelator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('E2E: Usher precision loop lifecycle', () => {
+  let projectDir: string;
+  let stateDir: string;
+  let server: Server;
+  let baseUrl: string;
+  let store: UsherSignalStore;
+  const TOPIC_A = 12118; // path (a) topic
+  const TOPIC_B = 13481; // path (b) topic
+
+  beforeAll(async () => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-usher-prec-e2e-'));
+    stateDir = path.join(projectDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    store = new UsherSignalStore(stateDir);
+    // Pre-fire the nudges the agent will (a) use and (b) get corrected on.
+    store.recordSignal(TOPIC_A, { contextRef: 'ref-a', contextText: 'deploy the staging pipeline tonight', reason: 'the user re-raised the staging plan', turn: 4 });
+    store.recordSignal(TOPIC_B, { contextRef: 'ref-b', contextText: 'we are testing the mesh over telegram', reason: 'the user re-raised the test setup', turn: 9 });
+
+    HumanAsDetectorLog.resetForTesting();
+    HumanAsDetectorLog.getInstance().configure({ stateDir, agentName: 'usher-prec-e2e' });
+
+    let sent = 0;
+    const ctx = {
+      config: { projectName: 'usher-prec-e2e', projectDir, stateDir, port: 0, sessions: {} as any, scheduler: {} as any } as any,
+      sessionManager: { listRunningSessions: () => [], clearInjectionTracker: () => {} } as any,
+      state: { getJobState: () => null, getSession: () => null } as any,
+      telegram: { sendToTopic: async () => { sent++; } } as any,
+      usherSignalStore: store,
+      // Null gate → checkOutboundMessage passes through (the reply isn't blocked).
+      messagingToneGate: null, outboundDedupGate: null, topicIntentArcCheck: null,
+      topicMemory: null, messageLedger: null, currentInboundByTopic: null,
+      scheduler: null, relationships: null, feedback: null, dispatches: null,
+      updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+      publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+      triageNurse: null, discoveryEvaluator: null, coordinator: null, replyMarkerTransport: null,
+      startTime: new Date(),
+    } as unknown as RouteContext;
+
+    const app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(ctx));
+    app.use(createUsherRoutes({ signalStore: store }));
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        const addr = server.address();
+        const port = typeof addr === 'object' && addr ? addr.port : 0;
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    HumanAsDetectorLog.resetForTesting();
+    try {
+      SafeFsExecutor.safeRmSync(projectDir, { recursive: true, force: true, operation: 'tests/e2e/usher-precision-lifecycle.test.ts' });
+    } catch { /* best-effort */ }
+  });
+
+  it('precision starts pinned at 0 (a fired-but-unacted nudge) — the exact pre-fix state', async () => {
+    // This IS the bug this feature fixes: fired>0 but acted==0 → precision 0,
+    // structurally stuck (markActed had no caller). The next test moves it.
+    const res = await fetch(`${baseUrl}/usher/metrics?topicId=${TOPIC_A}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.metrics.fired).toBe(1);
+    expect(body.metrics.acted).toBe(0);
+    expect(body.metrics.precision).toBe(0);
+  });
+
+  it('path (a): a reply that USES the re-surfaced context flips the nudge acted (precision → 1.0)', async () => {
+    const reply = await fetch(`${baseUrl}/telegram/reply/${TOPIC_A}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'On it — I will deploy the staging pipeline tonight and report back when it lands.' }),
+    });
+    expect(reply.status).toBe(200);
+
+    const res = await fetch(`${baseUrl}/usher/metrics?topicId=${TOPIC_A}`);
+    const body = await res.json();
+    expect(body.metrics.acted).toBe(1);
+    expect(body.metrics.acted_by_use).toBe(1);
+    expect(body.metrics.precision).toBe(1);
+  });
+
+  it('path (a) does NOT credit an unrelated reply', async () => {
+    // Fire a fresh nudge on a clean topic, reply with something off-topic.
+    store.recordSignal(555, { contextRef: 'ref-c', contextText: 'rotate the cloudflare tunnel token', reason: 'r', turn: 1 });
+    const reply = await fetch(`${baseUrl}/telegram/reply/555`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'Sounds good, talk later!' }),
+    });
+    expect(reply.status).toBe(200);
+    const res = await fetch(`${baseUrl}/usher/metrics?topicId=555`);
+    const body = await res.json();
+    expect(body.metrics.acted).toBe(0);
+    expect(body.metrics.precision).toBe(0); // fired 1, acted 0
+  });
+
+  it('path (b): an inbound correction credits a prior ignored nudge (acted_by_miss)', async () => {
+    // The exact two lines server.ts runs on the inbound human-detector seam.
+    const missSignal = observeInboundMessage(HumanAsDetectorLog.getInstance(), {
+      fromUser: true,
+      text: "actually, you forgot we are testing the mesh over telegram — that's stale",
+      topicId: TOPIC_B,
+      messageId: 42,
+    });
+    expect(missSignal).not.toBeNull();
+    const credited = creditUsherOnMiss(store, missSignal, { topicId: TOPIC_B, text: "actually, you forgot we are testing the mesh over telegram — that's stale" });
+    expect(credited.length).toBe(1);
+
+    const res = await fetch(`${baseUrl}/usher/metrics?topicId=${TOPIC_B}`);
+    const body = await res.json();
+    expect(body.metrics.acted).toBe(1);
+    expect(body.metrics.acted_by_miss).toBe(1);
+    expect(body.metrics.precision).toBe(1);
+  });
+});

--- a/tests/integration/usher-routes.test.ts
+++ b/tests/integration/usher-routes.test.ts
@@ -90,12 +90,64 @@ describe('Usher disabled', () => {
   });
 });
 
+describe('precision split (acted_by_use / acted_by_miss)', () => {
+  let project: TempProject;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+
+  beforeAll(() => {
+    project = createTempProject();
+    fs.writeFileSync(path.join(project.stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'usplit', agentName: 'USplit' }));
+    const store = new UsherSignalStore(project.stateDir);
+    const a = store.recordSignal(77, { contextRef: 'r1', contextText: 'unify the memory stores', reason: 'r', turn: 1 });
+    const b = store.recordSignal(77, { contextRef: 'r2', contextText: 'we are testing over telegram', reason: 'r', turn: 2 });
+    store.recordSignal(77, { contextRef: 'r3', contextText: 'unrelated', reason: 'r', turn: 3 }); // stays unacted
+    store.markActed(77, a!, { via: 'use' });
+    store.markActed(77, b!, { via: 'miss' });
+    server = new AgentServer({ config: buildConfig(project), sessionManager: createMockSessionManager() as any, state: project.state, usherSignalStore: store });
+    app = server.getApp();
+  });
+  afterAll(() => { project?.cleanup(); });
+
+  it('GET /usher/metrics splits the numerator by path and computes precision', async () => {
+    const res = await request(app).get('/usher/metrics').query({ topicId: 77 }).set({ Authorization: `Bearer ${AUTH}` });
+    expect(res.status).toBe(200);
+    expect(res.body.metrics.fired).toBe(3);
+    expect(res.body.metrics.acted).toBe(2);
+    expect(res.body.metrics.acted_by_use).toBe(1);
+    expect(res.body.metrics.acted_by_miss).toBe(1);
+    expect(res.body.metrics.precision).toBeCloseTo(2 / 3, 5);
+  });
+
+  it('a legacy topic (no acted) still reports the split fields as 0', async () => {
+    const res = await request(app).get('/usher/metrics').query({ topicId: 4242 }).set({ Authorization: `Bearer ${AUTH}` });
+    expect(res.status).toBe(200);
+    expect(res.body.metrics.acted_by_use).toBe(0);
+    expect(res.body.metrics.acted_by_miss).toBe(0);
+    expect(res.body.metrics.precision).toBeNull();
+  });
+});
+
 describe('wiring-integrity (anti-shipped-but-asleep)', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
   it('server.ts attaches the Usher loop to the live message callback', () => {
-    const here = path.dirname(fileURLToPath(import.meta.url));
     const src = fs.readFileSync(path.join(here, '../../src/commands/server.ts'), 'utf-8');
     expect(src).toContain('createUsherLoop(');
     expect(src).toContain('__instarUsherWired');
     expect(src).toMatch(/telegram\.onMessageLogged\s*=\s*\(entry\)\s*=>\s*\{[\s\S]*usherLoop\(/);
+  });
+
+  it('routes.ts credits the Usher (path a) on the outbound reply path', () => {
+    const src = fs.readFileSync(path.join(here, '../../src/server/routes.ts'), 'utf-8');
+    expect(src).toContain('creditUsherOnOutbound');
+    expect(src).toMatch(/creditUsherOnOutbound\(ctx\.usherSignalStore,\s*topicId,\s*text\)/);
+  });
+
+  it('server.ts credits the Usher (path b) right after the human-as-detector observe', () => {
+    const src = fs.readFileSync(path.join(here, '../../src/commands/server.ts'), 'utf-8');
+    expect(src).toContain('creditUsherOnMiss');
+    // the miss signal returned by observeInboundMessage feeds the correlator
+    expect(src).toMatch(/const missSignal = observeInboundMessage\(humanAsDetectorLog,\s*entry\)/);
+    expect(src).toMatch(/creditUsherOnMiss\(usherSignalStore,\s*missSignal,\s*entry\)/);
   });
 });

--- a/tests/unit/UsherActedCorrelator.test.ts
+++ b/tests/unit/UsherActedCorrelator.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Unit (Tier 1) for the Usher precision-numerator wiring (rung 4).
+ *
+ * Covers BOTH sides of every decision boundary with realistic inputs:
+ *   - salientTerms: stopword/short-token stripping, lowercasing
+ *   - contextCoveredBy: covers (≥2 shared & ≥50%) vs not (1 shared / low coverage / empty)
+ *   - findCoveredSignalIds: skips already-acted, respects the recency window
+ *   - markActedByCoverage: marks matches, stamps via/at, idempotent, never-throws
+ *   - UsherSignalStore.markActed opts: via stamping + acted_by_use/miss split + backward-compat
+ *   - creditUsherOnOutbound / creditUsherOnMiss: guards (null store / null miss / no topic / no text)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { UsherSignalStore, type UsherSignal } from '../../src/core/UsherSignalStore.js';
+import {
+  salientTerms,
+  contextCoveredBy,
+  findCoveredSignalIds,
+  markActedByCoverage,
+  creditUsherOnOutbound,
+  creditUsherOnMiss,
+  USE_WINDOW_MS,
+} from '../../src/core/UsherActedCorrelator.js';
+
+let tempDir: string;
+let store: UsherSignalStore;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'usher-acted-'));
+  store = new UsherSignalStore(tempDir);
+});
+afterEach(() => {
+  try { SafeFsExecutor.safeRmSync(tempDir, { recursive: true, force: true, operation: 'tests/unit/UsherActedCorrelator.test.ts' }); } catch { /* */ }
+});
+
+function sig(overrides: Partial<UsherSignal> = {}): UsherSignal {
+  return {
+    id: overrides.id ?? 'usig-x',
+    contextRef: overrides.contextRef ?? 'ref-1',
+    contextText: overrides.contextText ?? 'we are testing the pipeline over telegram',
+    reason: overrides.reason ?? 'why',
+    turn: overrides.turn ?? 1,
+    at: overrides.at ?? new Date().toISOString(),
+    acted: overrides.acted ?? false,
+    actedVia: overrides.actedVia,
+    actedAt: overrides.actedAt,
+  };
+}
+
+describe('salientTerms', () => {
+  it('lowercases, strips stopwords + short tokens, dedupes', () => {
+    const t = salientTerms('We are TESTING the Pipeline over Telegram!!');
+    expect(t.has('testing')).toBe(true);
+    expect(t.has('pipeline')).toBe(true);
+    expect(t.has('telegram')).toBe(true);
+    // stopwords + short tokens gone
+    expect(t.has('we')).toBe(false);
+    expect(t.has('are')).toBe(false);
+    expect(t.has('the')).toBe(false);
+    expect(t.has('over')).toBe(false);
+  });
+  it('empty / non-string → empty set', () => {
+    expect(salientTerms('').size).toBe(0);
+    // @ts-expect-error testing defensive path
+    expect(salientTerms(null).size).toBe(0);
+  });
+});
+
+describe('contextCoveredBy', () => {
+  it('TRUE when the probe covers ≥2 shared terms and ≥50% of the context', () => {
+    expect(contextCoveredBy(
+      'testing pipeline telegram',
+      'Sure — I will keep testing the pipeline tonight.',
+    )).toBe(true); // shared {testing,pipeline}=2, coverage 2/3≈0.67
+  });
+  it('FALSE on a single coincidental shared word', () => {
+    expect(contextCoveredBy(
+      'testing pipeline telegram',
+      'the telegram bot is unrelated chatter',
+    )).toBe(false); // shared {telegram}=1 < MIN_SHARED
+  });
+  it('FALSE when coverage is below half even with 2 shared', () => {
+    expect(contextCoveredBy(
+      'alpha beta gamma delta epsilon zeta', // 6 salient
+      'alpha beta only', // shared 2 but coverage 2/6≈0.33
+    )).toBe(false);
+  });
+  it('FALSE on empty context or empty probe', () => {
+    expect(contextCoveredBy('', 'anything here')).toBe(false);
+    expect(contextCoveredBy('testing pipeline', '')).toBe(false);
+  });
+});
+
+describe('findCoveredSignalIds', () => {
+  it('returns ids of covered, NOT-acted signals only', () => {
+    const signals = [
+      sig({ id: 'a', contextText: 'deploy staging pipeline tonight' }),
+      sig({ id: 'b', contextText: 'unrelated neo4j migration', acted: false }),
+      sig({ id: 'c', contextText: 'deploy staging pipeline tonight', acted: true }), // already acted → skip
+    ];
+    const ids = findCoveredSignalIds(signals, 'I will deploy the staging pipeline now');
+    expect(ids).toContain('a');
+    expect(ids).not.toContain('b');
+    expect(ids).not.toContain('c');
+  });
+  it('respects the recency window (maxAgeMs)', () => {
+    const now = 1_000_000_000_000;
+    const fresh = sig({ id: 'fresh', at: new Date(now - 1000).toISOString(), contextText: 'deploy staging pipeline' });
+    const old = sig({ id: 'old', at: new Date(now - 10 * 60 * 60 * 1000).toISOString(), contextText: 'deploy staging pipeline' });
+    const ids = findCoveredSignalIds([fresh, old], 'deploy the staging pipeline', { maxAgeMs: 6 * 60 * 60 * 1000, nowMs: now });
+    expect(ids).toEqual(['fresh']);
+  });
+});
+
+describe('UsherSignalStore.markActed opts (via split + backward-compat)', () => {
+  it('stamps actedVia/actedAt and increments the matching split counter', () => {
+    const id = store.recordSignal(7, { contextRef: 'r', contextText: 't', reason: 'w', turn: 1 })!;
+    expect(store.markActed(7, id, { via: 'use', at: '2026-01-01T00:00:00.000Z' })).toBe(true);
+    const m = store.getMetrics(7);
+    expect(m.acted).toBe(1);
+    expect(m.acted_by_use).toBe(1);
+    expect(m.acted_by_miss ?? 0).toBe(0);
+    const s = store.getSignals(7).find(x => x.id === id)!;
+    expect(s.actedVia).toBe('use');
+    expect(s.actedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+  it('miss path increments acted_by_miss; idempotent on repeat', () => {
+    const id = store.recordSignal(7, { contextRef: 'r', contextText: 't', reason: 'w', turn: 1 })!;
+    expect(store.markActed(7, id, { via: 'miss' })).toBe(true);
+    expect(store.markActed(7, id, { via: 'miss' })).toBe(false); // idempotent
+    const m = store.getMetrics(7);
+    expect(m.acted).toBe(1);
+    expect(m.acted_by_miss).toBe(1);
+  });
+  it('backward-compat: 2-arg markActed still works (no via)', () => {
+    const id = store.recordSignal(7, { contextRef: 'r', contextText: 't', reason: 'w', turn: 1 })!;
+    expect(store.markActed(7, id)).toBe(true);
+    expect(store.getMetrics(7).acted).toBe(1);
+  });
+});
+
+describe('markActedByCoverage (integration over the real store)', () => {
+  it('marks the covered signal acted with the given via, returns its id', () => {
+    const id = store.recordSignal(9, { contextRef: 'r', contextText: 'deploy staging pipeline tonight', reason: 'w', turn: 1 })!;
+    const marked = markActedByCoverage(store, 9, 'On it — I will deploy the staging pipeline tonight.', 'use');
+    expect(marked).toEqual([id]);
+    expect(store.getMetrics(9).acted_by_use).toBe(1);
+  });
+  it('does nothing when nothing is covered', () => {
+    store.recordSignal(9, { contextRef: 'r', contextText: 'deploy staging pipeline', reason: 'w', turn: 1 });
+    expect(markActedByCoverage(store, 9, 'totally unrelated chit chat about lunch', 'use')).toEqual([]);
+    expect(store.getMetrics(9).acted).toBe(0);
+  });
+  it('best-effort: bad probe text / topic → [] (never throws)', () => {
+    // @ts-expect-error defensive
+    expect(markActedByCoverage(store, 9, null, 'use')).toEqual([]);
+    // @ts-expect-error defensive
+    expect(markActedByCoverage(store, NaN, 'text', 'use')).toEqual([]);
+  });
+});
+
+describe('creditUsherOnOutbound (path a wrapper)', () => {
+  it('credits a recent matching nudge with via=use', () => {
+    const id = store.recordSignal(11, { contextRef: 'r', contextText: 'unify the memory stores', reason: 'w', turn: 1 })!;
+    const credited = creditUsherOnOutbound(store, 11, 'Great — unifying the memory stores now.');
+    expect(credited).toEqual([id]);
+    expect(store.getMetrics(11).acted_by_use).toBe(1);
+  });
+  it('null/undefined store → [] (Usher disabled)', () => {
+    expect(creditUsherOnOutbound(null, 11, 'anything')).toEqual([]);
+    expect(creditUsherOnOutbound(undefined, 11, 'anything')).toEqual([]);
+  });
+  it('does not credit a nudge older than the use window', () => {
+    const now = 2_000_000_000_000;
+    store.recordSignal(11, { contextRef: 'r', contextText: 'unify the memory stores', reason: 'w', turn: 1, at: new Date(now - USE_WINDOW_MS - 1000).toISOString() });
+    const credited = creditUsherOnOutbound(store, 11, 'unifying the memory stores', { now: () => now });
+    expect(credited).toEqual([]);
+  });
+});
+
+describe('creditUsherOnMiss (path b wrapper)', () => {
+  it('credits a prior nudge with via=miss when the correction covers it', () => {
+    const id = store.recordSignal(13, { contextRef: 'r', contextText: 'we are testing over telegram', reason: 'w', turn: 1 })!;
+    const missSignal = { category: 'staleness' }; // non-null = a real miss
+    const credited = creditUsherOnMiss(store, missSignal, { topicId: 13, text: "actually, you forgot we are testing over telegram" });
+    expect(credited).toEqual([id]);
+    expect(store.getMetrics(13).acted_by_miss).toBe(1);
+  });
+  it('no-op when there was no miss (null signal)', () => {
+    store.recordSignal(13, { contextRef: 'r', contextText: 'we are testing over telegram', reason: 'w', turn: 1 });
+    expect(creditUsherOnMiss(store, null, { topicId: 13, text: 'we are testing over telegram' })).toEqual([]);
+    expect(store.getMetrics(13).acted).toBe(0);
+  });
+  it('no-op when topic or text is missing', () => {
+    store.recordSignal(13, { contextRef: 'r', contextText: 'we are testing over telegram', reason: 'w', turn: 1 });
+    const miss = { category: 'staleness' };
+    expect(creditUsherOnMiss(store, miss, { topicId: null, text: 'we are testing over telegram' })).toEqual([]);
+    expect(creditUsherOnMiss(store, miss, { topicId: 13 })).toEqual([]);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,73 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**The Usher's precision loop is now wired — `acted` can finally move off zero.**
+
+The Usher (rung 4 of continuous-working-awareness) fires "re-surface" signals
+when a faded context becomes relevant again, and exposes a precision read
+(`acted / fired`) that is the hard precondition for ever letting it interrupt
+mid-task (rung 5). But `UsherSignalStore.markActed` — the precision *numerator* —
+had **no caller anywhere**. So `acted` stayed 0 on every topic and precision was
+structurally pinned at 0: the gate could never be satisfied by data. The Usher's
+accuracy half had shipped asleep — the exact "shipped but asleep" trap the rest
+of this project exists to kill, hiding inside our own accuracy meter.
+
+This closes the loop with two correlation paths, both reducing to "does some
+probe text COVER a fired signal's proposition?":
+
+1. **Auto-use (path a).** When the agent's genuine reply goes out on a topic and
+   it actually *uses* a re-surfaced context the Usher flagged, that signal is
+   marked acted (`via: 'use'`). Wired on the outbound `/telegram/reply` path.
+2. **Miss-map (path b).** When the user has to *correct* the agent (a
+   HumanAsDetector signal) on a context a recent nudge had already flagged, that
+   nudge was a genuine catch the agent ignored — still a true positive. It's
+   marked acted (`via: 'miss'`). Wired right after the inbound human-detector
+   observe seam.
+
+Matching is deliberately precision-over-recall (≥2 shared salient terms AND ≥50%
+coverage, within a recency window): a falsely-*high* precision is the dangerous
+direction since it gates interruption, so under-crediting a fast reply is
+acceptable, inflating the gate is not. Everything is best-effort and never throws
+into the message/delivery path.
+
+`GET /usher/metrics` now also reports `acted_by_use` and `acted_by_miss` so the
+precision numerator is visible split by which path confirmed usefulness.
+
+## What to Tell Your User
+
+The Usher now measures whether its mid-task reminders were actually useful — on
+its own, two ways: when my next reply uses a reminder, and when you later have to
+correct me on something a reminder had already flagged. That useful rate is the
+number that has to look good before the Usher ever earns the right to interrupt me
+(the final rung), so instead of sitting stuck at zero it can now gather real
+numbers as we work. Nothing for you to set up — it just runs, and I can show you
+the per-conversation numbers whenever you want them.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Usher precision numerator wired | Automatic — `markActed` is now called from the outbound-reply path (agent used the nudge) and the inbound human-detector seam (user corrected on it). |
+| `acted_by_use` / `acted_by_miss` split | `GET /usher/metrics?topicId=N` returns the precision numerator broken down by which correlation path confirmed usefulness. |
+| `UsherActedCorrelator` | Pure, exported coverage matcher (`salientTerms`, `contextCoveredBy`, `findCoveredSignalIds`, `markActedByCoverage`) + two thin wiring wrappers (`creditUsherOnOutbound`, `creditUsherOnMiss`). Unit-tested both-sides-of-the-boundary. |
+
+## Evidence
+
+- Unit: `tests/unit/UsherActedCorrelator.test.ts` — 20 cases covering salient-term
+  extraction, coverage thresholds (covers vs single-coincidental-word vs
+  low-coverage vs empty), recency-window filtering, the via-split + backward-compat
+  on `markActed`, and the two wrappers' guards.
+- Integration: `tests/integration/usher-routes.test.ts` — `GET /usher/metrics`
+  exposes the `acted_by_use`/`acted_by_miss` split + precision; legacy topics
+  report the split as 0; source-guards prove `routes.ts` calls
+  `creditUsherOnOutbound` and `server.ts` calls `creditUsherOnMiss` after the
+  human-detector observe (anti-shipped-but-asleep).
+- E2E: `tests/e2e/usher-precision-lifecycle.test.ts` — boots the real route tree
+  on a live HTTP server, proves the pre-fix state (precision pinned at 0 with a
+  fired-but-unacted nudge), then drives BOTH paths: a reply that uses the context
+  flips precision 0 → 1.0 (`acted_by_use`), an off-topic reply does not, and an
+  inbound correction credits a prior ignored nudge (`acted_by_miss`) — all visible
+  over real HTTP at `GET /usher/metrics`.

--- a/upgrades/side-effects/usher-precision-loop.md
+++ b/upgrades/side-effects/usher-precision-loop.md
@@ -1,0 +1,131 @@
+# Side-Effects Review — Usher precision numerator wiring (rung 4)
+
+**Version / slug:** `usher-precision-loop`
+**Date:** `2026-05-28`
+**Author:** `echo`
+**Second-pass reviewer:** `not required` (signal-only observability change, no blocking surface)
+**Spec:** `docs/specs/cwa-usher.md` (approved:true by justin; review-note explicitly names "the usher_acted precision definition that gates rung 5" as the in-scope follow-up this change implements)
+
+## Summary of the change
+
+The Usher fires re-surface signals (`UsherSignalStore.recordSignal`) and exposes a
+precision read (`acted / fired`) that the spec designates as the hard precondition
+for rung 5 (mid-task injection). But `UsherSignalStore.markActed` — the precision
+*numerator* — had no caller anywhere, so `acted` was pinned at 0 on every topic
+and precision could never move. This wires the numerator via two correlation paths
+in a new pure helper `src/core/UsherActedCorrelator.ts`: (a) **auto-use** — when the
+agent's outbound reply on a topic uses a re-surfaced context, mark that signal
+`acted(via:'use')`, called from the `POST /telegram/reply` handler in
+`src/server/routes.ts` after a genuine (non-proxy, non-system) reply sends; (b)
+**miss-map** — when the user has to correct the agent (a `HumanAsDetector` signal)
+on a context a recent nudge flagged, mark it `acted(via:'miss')`, called right after
+the inbound `observeInboundMessage` seam in `src/commands/server.ts`. `markActed` now
+also stamps `actedVia`/`actedAt`, and `GET /usher/metrics` reports
+`acted_by_use`/`acted_by_miss`. Files: `UsherSignalStore.ts`, `UsherActedCorrelator.ts`
+(new), `usherRoutes.ts`, `routes.ts` (+`RouteContext.usherSignalStore`),
+`AgentServer.ts` (route ctx wiring), `server.ts` (path-b seam).
+
+## Decision-point inventory
+
+The only "decision" this change makes is whether to increment an observability
+counter (`acted`). It gates nothing — no message is blocked, delayed, or altered.
+
+- `UsherActedCorrelator.contextCoveredBy` — **add** — pure text-coverage match deciding whether a probe references a fired signal's proposition. Output feeds `markActed` only; no authority over delivery.
+- `routes.ts POST /telegram/reply` (path a) — **pass-through** — the existing send decision is untouched; crediting runs *after* the reply has already gone out.
+- `server.ts` inbound human-detector seam (path b) — **pass-through** — crediting runs after `observeInboundMessage`, which itself is signal-only.
+
+---
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject that it shouldn't?**
+
+No block/allow surface — over-block not applicable. `markActed` only increments a
+metric; it cannot reject, delay, or modify any inbound or outbound message. Both
+call sites run strictly *after* the message has been processed/sent, and both are
+wrapped best-effort (never throw into the message path).
+
+## 2. Under-block
+
+**What failure modes does this still miss?**
+
+By design (precision-over-recall — a falsely-HIGH precision is the dangerous
+direction since precision gates rung 5), the correlator deliberately UNDER-credits:
+
+- **Path (a) timing race:** the Usher's signal is recorded by an async, LLM-backed
+  fire-and-forget loop (~8–10s). A very fast agent reply can land before the signal
+  is persisted, so that use goes uncredited. Acceptable: the full reply (after the
+  agent's work) usually lands well after the signal persists, and under-crediting
+  never inflates the gate.
+- **Short contexts:** a context with fewer than 2 salient terms can never reach the
+  `MIN_SHARED=2` threshold, so single-word propositions are never auto-credited.
+- **Recency window:** uses/corrections outside `USE_WINDOW_MS` (6h) / `MISS_WINDOW_MS`
+  (24h) are not credited.
+
+These are recall gaps, not correctness bugs — the precision number will be a *floor*
+on true usefulness, which is the conservative posture the rung-5 gate wants.
+
+## 3. Level-of-abstraction fit
+
+**Is this at the right layer?**
+
+Yes. `markActed` already existed on `UsherSignalStore` (the spec's numerator); this
+change only supplies its missing callers. The matching logic lives in a pure,
+unit-tested helper (`UsherActedCorrelator`) rather than inline at the call sites,
+and the two call sites are the two existing seams where the relevant text is already
+in hand (outbound reply text; inbound correction text + its `HumanAsDetector`
+verdict). No higher layer owns "was this nudge used" — this is the layer that has
+both the fired signals and the probe text. No smarter gate exists that should own
+it instead.
+
+## 4. Signal vs authority compliance
+
+**Does this hold blocking authority with brittle logic, or produce a signal?**
+
+Compliant (`docs/signal-vs-authority.md`). The coverage matcher is intentionally
+brittle (keyword overlap, no LLM) — and that is acceptable *precisely because it has
+zero authority*. It produces a signal (the precision numerator) and nothing else. It
+never blocks, never gates delivery, and feeds only the operator-facing
+`GET /usher/metrics`. A brittle detector with no blocking power is the correct
+pattern; the anti-pattern (brittle check WITH blocking authority) is not present.
+
+## 5. Interactions
+
+**Does it shadow another check, get shadowed, double-fire, or race?**
+
+- **Idempotency:** `markActed` guards `if (sig.acted) return false`, so paths (a) and
+  (b) marking the same signal, or repeated calls, increment `acted` at most once per
+  signal. The split counters (`acted_by_use`/`acted_by_miss`) only increment on the
+  successful (first) mark.
+- **Ordering on the inbound seam:** path (b) runs in the human-detector callback,
+  which is chained *before* the Usher loop callback on the same `onMessageLogged`.
+  It correlates the correction against signals fired on PRIOR turns (already
+  persisted) — it does not race the current turn's not-yet-fired signal.
+- **No shadowing:** the outbound tone-gate / dedup / ArcCheck path is unchanged;
+  crediting runs after the gate passed and the send succeeded, so it cannot affect
+  any block/allow outcome.
+
+## 6. External surfaces
+
+**Does it change anything visible to other agents, users, or systems?**
+
+- `GET /usher/metrics` gains two additive fields (`acted_by_use`, `acted_by_miss`)
+  and `acted`/`precision` now actually move. This endpoint is operator-only
+  (`INTERNAL_PREFIXES`), not surfaced to end users or other agents.
+- The per-topic `usher/<topicId>.json` store files gain optional `actedVia`/`actedAt`
+  on signals — additive; `load()` already tolerates unknown/missing fields and old
+  readers ignore them.
+- No change to any message content, no new outbound traffic, nothing visible to
+  peer agents. Behavior depends on conversation/topic state but is fully best-effort.
+
+## 7. Rollback cost
+
+**If this turns out wrong in production, what's the back-out?**
+
+Cheap and clean: revert the commit (a normal patch release). No data migration — the
+new optional fields are tolerated by existing `load()` and ignored by older binaries;
+a topic file written by the new code is readable by the old code and vice-versa.
+Worst case after revert: `precision` returns to its prior pinned-at-0 state (the bug
+this fixes). No agent-state repair, no hot-data fix. Because the change is
+observability-only, a wrong precision number cannot itself cause an outage — at most
+it would mislead the rung-5 decision, which is human-gated and not part of this change.


### PR DESCRIPTION
## What & why

The Usher (rung 4 of continuous-working-awareness) fires re-surface signals, and `UsherSignalStore` exposes a precision read (`acted / fired`) that the spec designates as the hard precondition for **rung 5** (mid-task injection). But `markActed` — the precision **numerator** — had **no caller anywhere**, so `acted` was pinned at 0 on every topic and precision could never move off zero. The Usher's accuracy half had shipped asleep — the exact "shipped but asleep" trap, sitting inside our own accuracy meter. (Found by dogfooding the observability live: ~590 signals fired across active topics, `acted=0` / `precision=0` everywhere.)

This wires the numerator via two correlation paths, both reducing to *"does some probe text COVER a fired signal's proposition?"*:

- **(a) auto-use** — the agent's genuine outbound reply uses a re-surfaced context → `markActed(via:'use')`. Wired on `POST /telegram/reply` after a non-proxy/non-system reply sends.
- **(b) miss-map** — the user has to correct the agent (a `HumanAsDetector` signal) on a context a recent nudge flagged → `markActed(via:'miss')`. The nudge was a genuine catch the agent ignored — still a true positive. Wired right after the inbound human-detector observe seam.

Matching is **precision-over-recall** (≥2 shared salient terms AND ≥50% coverage, within a recency window): a falsely-*high* precision is the dangerous direction since precision gates interruption, so under-crediting a fast reply is acceptable, inflating the gate is not. All best-effort — never throws into the message/delivery path.

`markActed` now stamps `actedVia`/`actedAt`, and `GET /usher/metrics` reports `acted_by_use` / `acted_by_miss` so the numerator is visible split by which path earned it.

## Spec & governance

- Spec: `docs/specs/cwa-usher.md` (approved:true by justin). Its `review-note` explicitly names *"the usher_acted precision definition that gates rung 5"* as the in-scope follow-up — this PR implements exactly that.
- Side-effects review: `upgrades/side-effects/usher-precision-loop.md` (signal-vs-authority compliant — brittle matcher, **zero** blocking authority; observability-only; clean revert path).

## Test tiers

- **Unit** (`tests/unit/UsherActedCorrelator.test.ts`, 20 cases): salient-term extraction, coverage thresholds (covers vs single-coincidental-word vs low-coverage vs empty), recency-window filtering, `markActed` via-split + backward-compat, both wrappers' guards.
- **Integration** (`tests/integration/usher-routes.test.ts`): `GET /usher/metrics` exposes the `acted_by_use`/`acted_by_miss` split + precision; legacy topics report 0; source-guards prove `routes.ts` calls `creditUsherOnOutbound` and `server.ts` calls `creditUsherOnMiss` after the human-detector observe (anti-shipped-but-asleep).
- **E2E** (`tests/e2e/usher-precision-lifecycle.test.ts`): boots the real route tree on a live HTTP server — proves the pre-fix state (precision pinned at 0 with a fired-but-unacted nudge), then drives both paths: a reply that uses the context flips precision 0 → 1.0 (`acted_by_use`), an off-topic reply does not, and an inbound correction credits a prior ignored nudge (`acted_by_miss`) — all visible over real HTTP.

Local smoke tier (`vitest.push.config.ts --changed JKHeadley/main`): **91 files / 844 tests green**. Full 8-shard suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
