### PR TITLE
fix(presence-proxy): suppress redundant Tier-1 standby after the agent acks

### DIFF
--- a/docs/specs/presence-proxy-ack-and-baseline.eli16.md
+++ b/docs/specs/presence-proxy-ack-and-baseline.eli16.md
@@ -1,0 +1,38 @@
+# PresenceProxy — brief-ack tolerance + post-message baseline — Plain-English Overview
+
+> The one-line version: when you message your agent, the "still working on it…" standby updates should be honest, on-topic, and quiet when they'd just be noise — not vanish, not describe the wrong thing, and not pile a redundant echo on top of the agent's own "got it."
+
+## The problem in one breath
+
+When you send your agent a message over Telegram, a background helper ("PresenceProxy") posts gentle "still working…" updates so you're not left wondering if it's alive. Three things went wrong with it over time: (1) the agent's polite "Got it, looking into this" was accidentally switching the whole standby system OFF, so a genuinely stuck agent would go silent forever; (2) when standby updates DID fire, they sometimes summarized what the agent was doing BEFORE your message instead of what it's doing now; and (3) even after the agent already said "got it," the helper would post its own near-duplicate "agent is just starting to respond to <your question restated>" a moment before the real answer — clutter on every single turn.
+
+## What already exists
+
+- **The standby helper (PresenceProxy)** — watches for a user message that hasn't been answered yet and, after a short delay, posts a tiered "still working" update (a first signal of life, then a 2-minute progress note, then a stall check). It's what reassures you during a long wait.
+- **The agent's own acknowledgement** — every agent is told to fire a quick "Got it, on it" the instant your message lands, so you know it was received.
+- **A shared "is this a real reply or just system chatter?" classifier** — used by several subsystems; not changed here.
+
+## What this adds
+
+The headline: the standby helper now treats a quick acknowledgement correctly in two ways at once — it does NOT let the ack silently kill the safety timers (so a real stall is still caught), AND it no longer posts a redundant standby on top of that ack (so a normal quick task reads cleanly as: ack → answer).
+
+- A small, conservative classifier (`isBriefAck`) recognizes short, forward-looking acks ("On it", "Got it", "Looking into this") without mistaking a real substantive reply for an ack.
+- A "baseline snapshot" taken the moment your message arrives, so the standby update describes only what happened AFTER your message — not stale earlier work.
+- Post-ack suppression: if the agent already acked, the first-tier standby message is withheld (the ack already covered "I'm alive"), while the later tiers stay armed for genuine silence.
+
+## The new pieces
+
+- **`isBriefAck`** — a signal, not a gatekeeper. It only withholds a cancellation/standby that was about to happen; it never makes the final call on what you see. Biased to be safe: a false "that's an ack" costs at most one missing standby, never a missed stall.
+- **Baseline scoping** — narrows the input the summarizer sees to post-message activity; the summarizer still decides the wording.
+
+## The safeguards
+
+**Prevents an agent from going silently dead.** An ack keeps the safety chain armed — if the agent acks and then stalls, the 2-minute and stall-check tiers still fire.
+
+**Prevents wrong-context summaries.** The baseline anchor means updates talk about the current task, falling back to the full view only when the screen has scrolled.
+
+**Prevents per-turn clutter (the new bit).** After an ack, no duplicate "still working" echo — and this works for codex agents too, where the older fix didn't because their screen carries extra stream noise.
+
+## What ships when
+
+One fleet-wide code change to PresenceProxy plus tests; no schema changes, no on-disk artifacts. Every Instar agent benefits on its next update. Rollback is a single-file revert.

--- a/docs/specs/presence-proxy-ack-and-baseline.md
+++ b/docs/specs/presence-proxy-ack-and-baseline.md
@@ -9,6 +9,12 @@ approved: true
 approved-by: "justin"
 approved-at: "2026-05-05T03:52:00Z"
 incident-origin: "topic 8882 (justin), 2026-05-05 03:52 UTC"
+eli16-overview: "presence-proxy-ack-and-baseline.eli16.md"
+amendments:
+  - date: "2026-05-28"
+    by: "echo"
+    approved-by: "justin (topic 13435 — Codey-dogfooding 'P1 - yes')"
+    summary: "Layer C — post-ack Tier-1 suppression: an ack now SUPPRESSES the redundant Tier-1 standby message (not just keeps timers alive); chain stays armed so stall detection is preserved."
 ---
 
 # PresenceProxy — brief-ack tolerance + post-message baseline
@@ -98,6 +104,36 @@ Baseline is intentionally NOT persisted to disk (consistent with the
 existing tier1Snapshot / tier2Snapshot policy — too large, potentially
 sensitive). After a session restart, recoverFromRestart sets baseline to
 null and prompts use the full-pane fallback path.
+
+### Layer C — post-ack Tier-1 suppression (amendment, 2026-05-28)
+
+Layer A keeps the tier timers running through an ack (so stall detection
+survives). But it left a UX wart that surfaced during the Codey-dogfooding
+run (topic 13435): when the agent had already acked ("Got it, pulling the
+live values now."), the proxy STILL posted a Tier-1 standby a beat before the
+real answer — "instar-codey is currently just starting to respond to <restates
+the user's question>". For a normal 30–60s task the user thus saw: ack →
+verbose standby echo → answer. Double-acknowledgement noise on every turn.
+
+The prior mitigation (the `isPostMessageDeltaAckOnly` short-circuit to a fixed
+"check back at the 2-minute mark" placeholder) only fired when the post-message
+pane delta was *itself* ack-only. That returns false for **codex** sessions,
+whose tmux pane carries stream noise (tool-call lines, thinking markers) beyond
+the ack text — so codex agents fell through to the verbose LLM summary. That
+placeholder branch is removed in favor of:
+
+**If the agent has acked since the user's message arrived
+(`state.lastAckText && state.lastAckAt >= state.userMessageAt`), suppress the
+Tier-1 standby MESSAGE entirely.** The ack already gave the user a signal of
+life; a Tier-1 "still working" on top is redundant. Crucially, the tier CHAIN
+is kept alive — Tier 1 is marked fired (`tier1FiredAt`) and Tier 2 is scheduled
+— so a genuine *ack-then-stall* is still caught at the 2-minute mark (Tier 2)
+and by Tier 3. This is strictly broader than the old short-circuit (it does not
+depend on the pane delta being ack-only) and framework-agnostic (the trusted
+signal is the ack itself, length/opener-gated by `isBriefAck`, not the pane).
+
+Net per-turn UX: **ack → [Tier 2 only if still silent at 2 min] → answer.** No
+redundant Tier-1 noise; stall detection unchanged.
 
 ## Decision-point inventory
 

--- a/src/monitoring/PresenceProxy.ts
+++ b/src/monitoring/PresenceProxy.ts
@@ -1037,20 +1037,39 @@ export class PresenceProxy {
       }
     }
 
-    if (!snapshot || snapshot.trim().length < 10) {
-      message = `${this.prefix} ${this.config.agentName} is active but hasn't produced visible output yet. Your message has been delivered.`;
-    } else if (
-      !isConversation
-      && state.lastAckText
+    // ── Post-ack suppression (Codey-dogfooding finding, 2026-05-28) ──
+    // If the agent has ALREADY acknowledged the user since their message
+    // arrived, the user already has a signal of life — a Tier-1 standby on top
+    // of that ack is redundant noise. Observed live: Codey replied "Got it,
+    // pulling the live values now." and the proxy then ALSO posted "instar-codey
+    // is currently just starting to respond to <restated question>" a beat
+    // before the real answer. Suppress the Tier-1 MESSAGE, but keep the tier
+    // chain alive (mark fired + schedule Tier 2) so a genuine ack-then-stall is
+    // still caught at the 2-minute mark and by Tier 3.
+    //
+    // This is BROADER than the prior ack-only-delta placeholder branch (now
+    // removed): it does NOT require isPostMessageDeltaAckOnly, which returns
+    // false for codex sessions whose tmux pane carries stream noise beyond the
+    // ack text — exactly why Codey fell through to the verbose LLM summary.
+    // The ack itself (length/opening-gated by isAck) is the signal we trust.
+    if (
+      state.lastAckText
       && state.lastAckAt !== null
       && state.lastAckAt >= state.userMessageAt
-      && isPostMessageDeltaAckOnly(snapshot, state.userMessageBaselineSnapshot, state.lastAckText)
     ) {
-      // Agent has only acked since the user's message arrived. Asking the LLM
-      // to summarize would just paraphrase the ack ("Echo acknowledged..."),
-      // which reads as generic and adds no information. Emit a fixed
-      // placeholder; Tier 2 will pick up substantive activity at 2 minutes.
-      message = `${this.prefix} ${this.config.agentName} is on this — I'll check back at the 2-minute mark with a progress update.`;
+      if (state.cancelled) return;
+      state.tier1FiredAt = Date.now();
+      this.persistState(topicId, state);
+      const remainingToTier2 = this.tier2DelayMs - (Date.now() - state.userMessageAt);
+      if (remainingToTier2 > 0) this.scheduleTier(topicId, 2, remainingToTier2);
+      console.log(
+        `[PresenceProxy] Tier 1 suppressed for topic ${topicId} — agent acked since user message (post-ack); Tier 2 still scheduled for stall detection.`,
+      );
+      return;
+    }
+
+    if (!snapshot || snapshot.trim().length < 10) {
+      message = `${this.prefix} ${this.config.agentName} is active but hasn't produced visible output yet. Your message has been delivered.`;
     } else {
       try {
         const prompt = isConversation

--- a/tests/unit/presence-proxy-ack-and-baseline.test.ts
+++ b/tests/unit/presence-proxy-ack-and-baseline.test.ts
@@ -161,7 +161,12 @@ describe('PresenceProxy brief-ack handling', () => {
     vi.useRealTimers();
   });
 
-  it('keeps tier timers running when agent sends a brief ack', async () => {
+  it('an ack suppresses the Tier-1 standby but keeps the chain alive (Tier 2 still fires)', async () => {
+    // Post-ack suppression (2026-05-28): a brief ack still must NOT cancel the
+    // tier timers (the silently-stopped guard), but the Tier-1 STANDBY message
+    // is now suppressed — the ack already gave the user a signal of life, so a
+    // Tier-1 "still working" on top is redundant noise. The chain stays alive,
+    // so Tier 2 fires on continued silence (ack-then-stall is still caught).
     const { proxy, sentMessages } = createTestProxy();
 
     proxy.onMessageLogged({
@@ -181,13 +186,14 @@ describe('PresenceProxy brief-ack handling', () => {
       timestamp: new Date().toISOString(),
     });
 
-    // Advance past tier 1 — it MUST still fire because the ack didn't cancel
+    // Past Tier 1: suppressed because the agent acked — no standby noise.
     await vi.advanceTimersByTimeAsync(60);
-    expect(sentMessages.length).toBe(1);
+    expect(sentMessages.length).toBe(0);
 
-    // And tier 2 should also fire
+    // Past Tier 2: the agent stayed silent after the ack, so the chain (kept
+    // alive by the suppression) breaks the silence here. Stall detection intact.
     await vi.advanceTimersByTimeAsync(250);
-    expect(sentMessages.length).toBe(2);
+    expect(sentMessages.length).toBe(1);
   });
 
   it('cancels tier timers on a substantive (non-ack) agent reply', async () => {
@@ -219,7 +225,7 @@ describe('PresenceProxy brief-ack handling', () => {
     expect(sentMessages.length).toBe(0);
   });
 
-  it('multiple brief acks still do not cancel; substantive reply finally does', async () => {
+  it('multiple brief acks still do not cancel; suppressed Tier 1, then a substantive reply cancels the rest', async () => {
     const { proxy, sentMessages } = createTestProxy();
 
     proxy.onMessageLogged({
@@ -242,11 +248,12 @@ describe('PresenceProxy brief-ack handling', () => {
       timestamp: new Date().toISOString(),
     });
 
-    // Tier 1 fires
+    // Tier 1 suppressed (the agent acked) — no standby noise, but the chain
+    // is still armed (Tier 2 would fire on continued silence).
     await vi.advanceTimersByTimeAsync(60);
-    expect(sentMessages.length).toBe(1);
+    expect(sentMessages.length).toBe(0);
 
-    // Substantive reply now arrives — this should cancel
+    // Substantive reply now arrives — this cancels the still-armed chain.
     proxy.onMessageLogged({
       messageId: 4, channelId: '902',
       text:
@@ -258,9 +265,9 @@ describe('PresenceProxy brief-ack handling', () => {
       timestamp: new Date().toISOString(),
     });
 
-    // Tier 2 should NOT fire
+    // Tier 2 should NOT fire (cancelled by the substantive reply) — stays at 0.
     await vi.advanceTimersByTimeAsync(250);
-    expect(sentMessages.length).toBe(1);
+    expect(sentMessages.length).toBe(0);
   });
 });
 

--- a/tests/unit/presence-proxy-race-guard-ack.test.ts
+++ b/tests/unit/presence-proxy-race-guard-ack.test.ts
@@ -170,12 +170,12 @@ describe('checkLogForAgentResponse (race-guard log filter)', () => {
   });
 });
 
-describe('Tier 1 fires with placeholder message when only an ack is observed', () => {
+describe('Tier 1 post-ack suppression (Codey-dogfooding finding, 2026-05-28)', () => {
   let tmpDir: string;
   let sentMessages: Array<{ topicId: number; text: string }>;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pp-tier1-ack-'));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pp-postack-'));
     sentMessages = [];
     vi.useFakeTimers();
   });
@@ -185,13 +185,9 @@ describe('Tier 1 fires with placeholder message when only an ack is observed', (
     try { SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/presence-proxy-race-guard-ack' }); } catch { /* ok */ }
   });
 
-  function makeProxy(captures: { baseline: string; tier1: string }) {
-    let call = 0;
-    const captureSpy = vi.fn(() => {
-      call += 1;
-      return call === 1 ? captures.baseline : captures.tier1;
-    });
-    const llmSpy = vi.fn(async () => 'this LLM call should NOT have been made');
+  function makeProxy(tier1Snapshot: string, opts: { tier2DelayMs?: number } = {}) {
+    const captureSpy = vi.fn(() => tier1Snapshot);
+    const llmSpy = vi.fn(async () => 'LLM summary that should NOT be posted at Tier 1');
 
     const config = {
       stateDir: tmpDir,
@@ -205,48 +201,74 @@ describe('Tier 1 fires with placeholder message when only an ack is observed', (
       },
       getAuthorizedUserIds: () => [],
       getProcessTree: () => [{ pid: 1234, command: 'claude' }], // not idle
-      hasAgentRespondedSince: () => false,
+      hasAgentRespondedSince: () => false, // ack is not a "substantive response"
       tier1DelayMs: 50,
-      tier2DelayMs: 100000,
-      tier3DelayMs: 200000,
+      tier2DelayMs: opts.tier2DelayMs ?? 100000,
+      tier3DelayMs: 300000,
     };
     const proxy = new PresenceProxy(config as any);
     proxy.start();
-    return { proxy, captureSpy, llmSpy };
+    return { proxy, llmSpy };
   }
 
-  it('emits the fixed "checking back at 2 minutes" placeholder, not an LLM summary', async () => {
-    const baseline = 'pane A\npane B\npane C\nprompt> _';
-    // tier1 snapshot has baseline anchor + just the typed ack — short delta
-    const tier1 = `${baseline}\n> Got it — looking into this now.`;
-    const { proxy, llmSpy } = makeProxy({ baseline, tier1 });
-
-    // Simulate user message
+  function userThenMaybeAck(proxy: PresenceProxy, ackText: string | null) {
     proxy.onMessageLogged({
-      channelId: '777',
-      text: 'standby seems downgraded',
-      fromUser: true,
-      timestamp: new Date().toISOString(),
+      channelId: '777', text: 'do the thing', fromUser: true, timestamp: new Date().toISOString(),
     } as any);
+    if (ackText) {
+      proxy.onMessageLogged({
+        channelId: '777', text: ackText, fromUser: false, timestamp: new Date().toISOString(),
+      } as any);
+    }
+  }
 
-    // Simulate agent ack arriving before Tier 1 fires
-    proxy.onMessageLogged({
-      channelId: '777',
-      text: 'Got it — looking into this now.',
-      fromUser: false,
-      timestamp: new Date().toISOString(),
-    } as any);
+  it('CODEX CASE: suppresses Tier 1 entirely when the agent acked, even though the pane delta is NOT ack-only', async () => {
+    // The exact Codey scenario: agent acked ("Got it, pulling the live values
+    // now."), but its codex pane shows stream noise beyond the ack — so the old
+    // isPostMessageDeltaAckOnly short-circuit returned false and the proxy fell
+    // through to a verbose LLM summary ("instar-codey is currently just starting
+    // to respond to <restated question>"). Post-ack suppression kills that noise.
+    const codexPane = [
+      'prompt> _',
+      '> Got it, pulling the live values now.',
+      ...Array.from({ length: 14 }, (_, i) => `  [codex] tool_call ${i}: read state-${i}.json`),
+    ].join('\n');
+    const { proxy, llmSpy } = makeProxy(codexPane);
+    userThenMaybeAck(proxy, 'Got it, pulling the live values now.');
 
-    // Run timers up to Tier 1
+    await vi.advanceTimersByTimeAsync(80); // past Tier 1 (50ms), well short of Tier 2 (100000ms)
+
+    expect(sentMessages.length).toBe(0); // NO Tier-1 standby noise on top of the ack
+    expect(llmSpy).not.toHaveBeenCalled(); // did not fall through to the verbose LLM summary
+  });
+
+  it('ACK-GATED: still fires a Tier-1 standby when the agent has NOT acked (genuine silence)', async () => {
+    const silentPane = [
+      'prompt> _',
+      ...Array.from({ length: 14 }, (_, i) => `  [codex] tool_call ${i}: read state-${i}.json`),
+    ].join('\n');
+    const { proxy } = makeProxy(silentPane);
+    userThenMaybeAck(proxy, null); // no ack from the agent
+
     await vi.advanceTimersByTimeAsync(80);
-    // Flush any microtasks Tier 1 scheduled
-    await vi.runOnlyPendingTimersAsync();
 
-    expect(llmSpy).not.toHaveBeenCalled();
-    // Placeholder must appear exactly once (Tier 1). Tier 2 may also fire
-    // under fake-timer interleavings with its own different message — we
-    // pin only the short-circuit's exact-once semantic here.
-    const placeholderHits = sentMessages.filter(m => /on this — I'll check back at the 2-minute mark/.test(m.text));
-    expect(placeholderHits.length).toBe(1);
+    // First signal of life still fires when there's no ack to cover presence.
+    expect(sentMessages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('STALL DETECTION PRESERVED: after a suppressed Tier 1, Tier 2 still fires (ack-then-stall is caught)', async () => {
+    const codexPane = [
+      'prompt> _',
+      '> On it.',
+      ...Array.from({ length: 14 }, (_, i) => `  [codex] tool_call ${i}: thinking…`),
+    ].join('\n');
+    const { proxy } = makeProxy(codexPane, { tier2DelayMs: 120 });
+    userThenMaybeAck(proxy, 'On it, give me a moment.');
+
+    // Advance past Tier 1 (suppressed) AND Tier 2 (120ms) — the agent stayed
+    // silent after the ack, so Tier 2 MUST still reach the user.
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(sentMessages.length).toBeGreaterThanOrEqual(1); // Tier 2 broke the silence
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,54 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Quieter standby on quick replies — no more double-acknowledgement.**
+
+When you message your agent and it fires its quick "Got it, on it" ack, the
+background standby helper (PresenceProxy) used to ALSO post a near-duplicate
+first-tier update a beat later — e.g. *"<agent> is currently just starting to
+respond to <your question, restated>"* — right before the real answer. On a
+normal 30–60s task you'd see: **ack → redundant standby echo → answer**, on
+every single turn. (Surfaced live while dogfooding the Codey/codex agent over
+Telegram.)
+
+Now: if the agent has already acknowledged you since your message arrived, the
+**first-tier standby message is suppressed** — the ack already told you the
+agent is alive and on it. The safety chain stays fully armed: a genuine
+*ack-then-stall* is still caught by the 2-minute progress tier and the stall
+tier. Net per-turn experience: **ack → (a progress note only if it's still
+silent at 2 minutes) → answer.**
+
+This replaces an earlier narrower mitigation that only worked when the
+session's terminal pane showed *nothing but* the ack — which was never true for
+**codex** agents (their pane carries tool-call/thinking stream noise), so codex
+agents always got the verbose echo. The new behavior keys off the ack itself,
+so it's framework-agnostic.
+
+## What to Tell Your User
+
+Conversations with your agent read cleaner now: a quick task is just "got it"
+then the answer, instead of "got it" + a redundant "still working on it" + the
+answer. If the agent genuinely goes quiet for a couple minutes, you'll still get
+the progress and stall updates exactly as before.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Post-ack standby suppression | Automatic — once your agent acks a message, PresenceProxy withholds its redundant first-tier standby but keeps the 2-min / stall tiers armed for real silence. |
+
+## Evidence
+
+- Unit: `tests/unit/presence-proxy-race-guard-ack.test.ts` — new "post-ack
+  suppression" cases: codex-pane suppression (ack present, delta NOT ack-only →
+  no message, no LLM call), ack-gating (no ack → Tier 1 still fires), and
+  stall-detection preservation (after a suppressed Tier 1, Tier 2 still fires).
+  `tests/unit/presence-proxy-ack-and-baseline.test.ts` updated to the new
+  behavior. Full PresenceProxy suite (88 tests) green.
+- Live: observed + fixed during the Codey-over-Telegram dogfooding run; the
+  verbose post-ack echo is the exact noise removed.
+
+Spec: `docs/specs/presence-proxy-ack-and-baseline.md` (Layer C amendment).

--- a/upgrades/side-effects/presence-proxy-post-ack-suppression.md
+++ b/upgrades/side-effects/presence-proxy-post-ack-suppression.md
@@ -1,0 +1,77 @@
+# Side-effects review — PresenceProxy post-ack Tier-1 suppression
+
+**Scope**: Remove the redundant first-tier standby that PresenceProxy posts
+*after* the agent has already acked the user (observed live in the Codey-
+over-Telegram dogfooding run). Suppress the Tier-1 MESSAGE on a recent ack while
+keeping the tier chain armed so stall detection is unchanged.
+
+**Files touched**:
+- `src/monitoring/PresenceProxy.ts` — in `fireTier1`, add a post-ack
+  early-return: if `state.lastAckText && state.lastAckAt !== null &&
+  state.lastAckAt >= state.userMessageAt`, set `tier1FiredAt`, persist, schedule
+  Tier 2, and return WITHOUT sending a message. Removed the prior
+  `isPostMessageDeltaAckOnly` placeholder `else if` branch (now subsumed — the
+  new check fires earlier and is broader).
+- `tests/unit/presence-proxy-race-guard-ack.test.ts` — replaced the
+  placeholder-assertion block with three cases: codex-pane suppression,
+  ack-gating, stall-detection preservation.
+- `tests/unit/presence-proxy-ack-and-baseline.test.ts` — updated the two
+  brief-ack tests that asserted "Tier 1 fires a message after an ack" to the new
+  "Tier 1 suppressed, chain stays armed" behavior.
+- `docs/specs/presence-proxy-ack-and-baseline.md` — Layer C amendment +
+  `eli16-overview` frontmatter + amendment provenance.
+- `docs/specs/presence-proxy-ack-and-baseline.eli16.md` — NEW (the spec lacked
+  the now-required ELI16 overview; created it covering all three layers).
+- `upgrades/NEXT.md` — release note (patch bump).
+
+**Under-block (does it ever now FAIL to reassure / FAIL to catch a stall?)**:
+- Suppression is strictly ack-gated. With NO ack, Tier 1 fires exactly as
+  before (tested: "ack-gating"). So the "first signal of life on genuine
+  silence" path is untouched.
+- The tier CHAIN is preserved: the suppression sets `tier1FiredAt` (which
+  `fireTier2` requires at line ~1102) and schedules Tier 2. So an ack-then-stall
+  is still caught at the 2-minute tier and by Tier 3 (tested: "stall detection
+  preserved"). This is the critical guard against re-opening the
+  "silently-stopped" standby-flood/silence bug this spec originally fixed.
+
+**Over-block (does it suppress something the user WANTED?)**:
+- It withholds only the FIRST-tier standby, and only when the agent already
+  acked — i.e. only when the message would be redundant with the ack. Tier 2
+  (substantive 2-min progress) and Tier 3 (stall) are never suppressed by this
+  change.
+- Quota-exhaustion detection still runs BEFORE the suppression (placement is
+  after the quota block), so an ack-then-quota-stall still surfaces the quota
+  message.
+- Conversation-mode richer Tier-1 is only skipped when an ack is present;
+  without an ack, conversation mode is unchanged.
+
+**Level-of-abstraction fit**: The change lives entirely inside
+`PresenceProxy.fireTier1` — the one place that decides the Tier-1 message. It
+keys off existing state (`lastAckText`/`lastAckAt`, already populated by the
+Layer A ack machinery) — no new fields, no new helpers, no change to the shared
+`isSystemOrProxyMessage` / `isBriefAck` classifiers.
+
+**Signal vs authority**: No authority change. The ack remains a SIGNAL (it
+withholds a redundant standby; it does not cancel the safety chain). The
+authorities are unchanged: a substantive reply cancels the chain; the LLM still
+authors any tier message that does fire.
+
+**Interactions**:
+- `isPostMessageDeltaAckOnly` stays exported (still unit-tested) but is no
+  longer called from `fireTier1`; its placeholder branch is removed. No other
+  caller (verified by grep).
+- Tier 2/3 logic untouched. Cancel-on-substantive-reply untouched.
+- Framework-agnostic: keys off the ack, not the tmux pane — so it fixes codex
+  agents (whose pane stream noise defeated the old ack-only-delta short-circuit)
+  as well as claude agents.
+
+**Migration parity**: Pure `dist/` code change — no agent-installed files
+(settings hooks, config defaults, CLAUDE.md template, hook scripts, skills)
+touched. Existing agents pick it up on the normal `instar` package auto-update.
+No `PostUpdateMigrator` entry required.
+
+**Rollback cost**: Single-file revert (`PresenceProxy.ts`) + test revert. No
+schema/API/on-disk changes.
+
+**Spec**: `presence-proxy-ack-and-baseline.md` Layer C (amendment approved by
+Justin, topic 13435, 2026-05-28 — Codey-dogfooding "P1 - yes").


### PR DESCRIPTION
## What & why

Found live while dogfooding Codey over Telegram (topic 13435): after the agent fired its quick ack (*"Got it, pulling the live values now."*), **PresenceProxy still posted a Tier-1 standby** a beat before the real answer — *"instar-codey is currently just starting to respond to &lt;restates the user's question&gt;"*. So every quick turn read as **ack → redundant standby echo → answer**. Double-acknowledgement noise on every message, fleet-wide.

## Fix (Layer C of `presence-proxy-ack-and-baseline`)

In `fireTier1`: if the agent has acked since the user's message (`state.lastAckText && state.lastAckAt >= state.userMessageAt`), **suppress the Tier-1 message** — the ack already gave the user a signal of life. Crucially, keep the tier chain armed: set `tier1FiredAt` + schedule Tier 2, so a genuine **ack-then-stall** is still caught at the 2-minute tier and by Tier 3 (this is the guard against re-opening the "silently-stopped" standby bug this spec originally fixed).

This **replaces** the prior `isPostMessageDeltaAckOnly` placeholder branch, which only fired when the tmux pane delta was *ack-only* — never true for **codex** agents (their pane carries tool-call/thinking stream noise), so codex agents always fell through to the verbose LLM summary. The new check keys off the ack itself → framework-agnostic.

**Net per-turn UX:** `ack → [Tier 2 only if still silent at 2 min] → answer`. Stall detection unchanged.

## Tests
- `tests/unit/presence-proxy-race-guard-ack.test.ts` — new post-ack-suppression cases: **codex suppression** (ack present, pane delta NOT ack-only → no message, no LLM call), **ack-gating** (no ack → Tier 1 still fires), **stall-detection preserved** (after suppressed Tier 1, Tier 2 still fires).
- `tests/unit/presence-proxy-ack-and-baseline.test.ts` — updated the two brief-ack tests to the new behavior.
- Full PresenceProxy suite (88 tests) green; lint clean.

## Spec
`docs/specs/presence-proxy-ack-and-baseline.md` — Layer C amendment (approved by Justin, topic 13435, 2026-05-28) + added the previously-missing `.eli16.md` overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)