### PR TITLE
fix(mentor): route mentor a2a to a dedicated topic, off the human conversation

### DIFF
--- a/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
+++ b/docs/specs/MENTOR-LIVE-READINESS-SPEC.md
@@ -10,9 +10,16 @@ approved: true
 approved-by: Justin (Telegram topic 13435, 2026-05-27 — after substrate + /idle + dollar-cap user-fidelity corrections)
 supersedes-rounds: 2 prior convergence rounds on file-based mentor-outbox design (committed but re-architected after Justin substrate correction, topic 13435, 2026-05-27)
 supervision: tier1
+amendments:
+  - date: "2026-05-28"
+    by: "echo"
+    approved-by: "justin (topic 13435 — Codey-dogfooding 'P3 - agreed')"
+    summary: "Dedicated mentor topic: add optional mentor.mentorTopicId; the mentor exchange's telegramTopicId resolves to mentorTopicId ?? menteeTopicId, so mentor a2a no longer interleaves with the human↔mentee conversation topic. Backward-compatible (falls back to menteeTopicId)."
 ---
 
 # Agent-to-Agent Telegram comms primitive + Mentor live-readiness
+
+> **Amendment 2026-05-28 — dedicated mentor topic (P3).** During the Codey-over-Telegram dogfooding run, the mentor cycle's a2a check-ins were observed interleaving with the topic Justin chats with Codey in (`menteeTopicId`, topic 458) — the mentor delivery passed `menteeTopicId` as its `telegramTopicId`, which drives both the `/a2a/inbox` body (where the mentee binds its session + reply) and the Telegram fallback. Fix: an optional `mentor.mentorTopicId`; `resolveMentorDeliveryTopic(cfg)` returns `mentorTopicId ?? menteeTopicId`, so configuring a dedicated topic moves the entire mentor exchange off the human conversation topic. Unset → unchanged behavior.
 
 ## Summary
 

--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -48,6 +48,29 @@ export interface MentorConfig {
   menteeChatId?: string;
   /** Topic id within menteeChatId that Echo writes mentor prompts to. */
   menteeTopicId?: number;
+  /** Dedicated topic id (within menteeChatId) for mentor a2a traffic, so the
+   *  mentor's check-ins do NOT interleave with the human↔mentee conversation
+   *  topic (`menteeTopicId`). When unset, falls back to `menteeTopicId`
+   *  (backward-compatible). Surfaced live: the mentor cycle was polluting the
+   *  topic Justin chats with Codey in (topic 13435, 2026-05-28). The whole
+   *  mentor exchange — prompt delivery AND the mentee's session/reply binding —
+   *  keys off this one topic id (it's the `telegramTopicId` passed to
+   *  deliverA2aMessage, used both in the /a2a/inbox body and the Telegram
+   *  fallback), so routing it here moves the entire exchange off the human topic. */
+  mentorTopicId?: number;
+}
+
+/**
+ * The Telegram topic the mentor exchange flows through. Prefers a dedicated
+ * `mentorTopicId` (so mentor a2a stays OFF the human↔mentee conversation
+ * topic), falling back to `menteeTopicId` for backward compatibility. This one
+ * id drives both the /a2a/inbox body (mentee session/reply binding) and the
+ * Telegram fallback, so the whole exchange moves together.
+ */
+export function resolveMentorDeliveryTopic(
+  cfg: Pick<MentorConfig, 'mentorTopicId' | 'menteeTopicId'>,
+): number | undefined {
+  return cfg.mentorTopicId ?? cfg.menteeTopicId;
 }
 
 export const DEFAULT_MENTOR_CONFIG: MentorConfig = {

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -63,7 +63,7 @@ import os from 'node:os';
 import { TokenLedger } from '../monitoring/TokenLedger.js';
 import { TokenLedgerPoller } from '../monitoring/TokenLedgerPoller.js';
 import { FrameworkIssueLedger } from '../monitoring/FrameworkIssueLedger.js';
-import { MentorOnboardingRunner, DEFAULT_MENTOR_CONFIG, type MentorConfig } from '../scheduler/MentorOnboardingRunner.js';
+import { MentorOnboardingRunner, DEFAULT_MENTOR_CONFIG, resolveMentorDeliveryTopic, type MentorConfig } from '../scheduler/MentorOnboardingRunner.js';
 import { STAGE_A_ALLOWED_TOOLS } from '../monitoring/MentorStageA.js';
 import { analyzeForensics } from '../scheduler/MentorStageBForensics.js';
 import { TelegramAdapter as MentorTelegramAdapter } from '../messaging/TelegramAdapter.js';
@@ -1642,7 +1642,13 @@ export class AgentServer {
             corr,
             body: message,
             allowedRoles: new Set(['mentor']),
-            telegramTopicId: cfg.menteeTopicId,
+            // Route the mentor exchange to a DEDICATED mentor topic when one is
+            // configured, so the mentor's a2a check-ins don't interleave with
+            // the human↔mentee conversation topic (menteeTopicId). This one id
+            // drives both the /a2a/inbox body (where the mentee binds its
+            // session) and the Telegram fallback, so the whole exchange moves
+            // together. Falls back to menteeTopicId (backward-compatible).
+            telegramTopicId: resolveMentorDeliveryTopic(cfg),
             // fromBotId = echo's mentor-bot id, so the mentee's allowlist
             // (knownMentors[echo].botId === senderBotId) passes.
             fromBotId: cfg.botToken ? cfg.botToken.split(':')[0] : undefined,

--- a/tests/unit/MentorOnboardingRunner.test.ts
+++ b/tests/unit/MentorOnboardingRunner.test.ts
@@ -7,9 +7,27 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   MentorOnboardingRunner,
   DEFAULT_MENTOR_CONFIG,
+  resolveMentorDeliveryTopic,
   type MentorConfig,
   type MentorRunnerServices,
 } from '../../src/scheduler/MentorOnboardingRunner.js';
+
+describe('resolveMentorDeliveryTopic — mentor a2a topic routing (Codey-dogfooding P3)', () => {
+  it('prefers the dedicated mentorTopicId when set (keeps mentor a2a off the human topic)', () => {
+    expect(resolveMentorDeliveryTopic({ mentorTopicId: 77, menteeTopicId: 458 })).toBe(77);
+  });
+  it('falls back to menteeTopicId when mentorTopicId is unset (backward-compatible)', () => {
+    expect(resolveMentorDeliveryTopic({ menteeTopicId: 458 })).toBe(458);
+    expect(resolveMentorDeliveryTopic({ mentorTopicId: undefined, menteeTopicId: 458 })).toBe(458);
+  });
+  it('returns undefined when neither is configured (mentor wiring stays dark)', () => {
+    expect(resolveMentorDeliveryTopic({})).toBeUndefined();
+  });
+  it('treats mentorTopicId 0 as a real topic (nullish, not falsy)', () => {
+    // Topic 0 ("General") is a valid forum topic — must not fall through to menteeTopicId.
+    expect(resolveMentorDeliveryTopic({ mentorTopicId: 0, menteeTopicId: 458 })).toBe(0);
+  });
+});
 
 function fakeServices(over: Partial<MentorRunnerServices> = {}): MentorRunnerServices {
   return {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,42 @@
+# Instar Upgrade Guide — NEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Mentor check-ins can have their own Telegram topic — off the human conversation.**
+
+The Framework-Onboarding Mentor delivers its periodic a2a check-ins to the
+mentee. That delivery used `mentor.menteeTopicId` as its Telegram topic — which
+is the SAME topic the human chats with the mentee in. So the mentor's automated
+check-ins interleaved with the real human↔agent conversation (surfaced while
+dogfooding Codey over Telegram, topic 13435).
+
+New optional `mentor.mentorTopicId`: when set, the mentor exchange (the prompt
+delivery AND the mentee's session/reply binding, which both key off one topic
+id) flows through that dedicated topic instead. Unset → falls back to
+`menteeTopicId` (fully backward-compatible — no behavior change for anyone who
+hasn't configured it).
+
+## What to Tell Your User
+
+If you run the mentor cycle and don't want its automated check-ins mixed into
+your own conversation topic with the mentee, give it a dedicated topic: set
+`mentor.mentorTopicId` in `.instar/config.json` to a topic id in the mentee's
+chat. Leave it unset to keep today's behavior.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Dedicated mentor topic | Set `mentor.mentorTopicId` in `.instar/config.json`. The mentor exchange routes there instead of `menteeTopicId`. Falls back to `menteeTopicId` when unset. |
+
+## Evidence
+
+- Unit: `tests/unit/MentorOnboardingRunner.test.ts` — `resolveMentorDeliveryTopic`
+  cases: prefers `mentorTopicId`, falls back to `menteeTopicId`, undefined when
+  neither set, and treats topic `0` as a real topic (nullish, not falsy).
+- Live: observed during the Codey dogfooding run (mentor markers in topic 458);
+  verified after configuring a dedicated topic (evidence in the PR).
+
+Spec: `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` (2026-05-28 amendment).

--- a/upgrades/side-effects/mentor-own-topic.md
+++ b/upgrades/side-effects/mentor-own-topic.md
@@ -1,0 +1,61 @@
+# Side-effects review — dedicated mentor topic (mentor.mentorTopicId)
+
+**Scope**: Stop the mentor cycle's a2a check-ins from interleaving with the
+human↔mentee conversation topic. Add an optional `mentor.mentorTopicId`; route
+the mentor exchange's `telegramTopicId` to `mentorTopicId ?? menteeTopicId`.
+
+**Files touched**:
+- `src/scheduler/MentorOnboardingRunner.ts` — add `mentorTopicId?: number` to
+  `MentorConfig`; add pure exported `resolveMentorDeliveryTopic(cfg)` returning
+  `cfg.mentorTopicId ?? cfg.menteeTopicId`.
+- `src/server/AgentServer.ts` — `deliverToMentee` now passes
+  `telegramTopicId: resolveMentorDeliveryTopic(cfg)` (was `cfg.menteeTopicId`);
+  import the helper.
+- `tests/unit/MentorOnboardingRunner.test.ts` — 4 cases for the resolver.
+- `docs/specs/MENTOR-LIVE-READINESS-SPEC.md` — 2026-05-28 amendment.
+- `upgrades/NEXT.md` — release note (patch bump).
+
+**Under-block (does it ever route to the WRONG topic / break delivery?)**:
+- Default is unchanged: with `mentorTopicId` unset, `resolveMentorDeliveryTopic`
+  returns `menteeTopicId` — byte-identical to prior behavior. No deployed agent
+  changes unless it explicitly sets `mentorTopicId`.
+- Uses nullish coalescing (`??`), not `||`, so `mentorTopicId: 0` (the "General"
+  forum topic) is honored rather than falling through (the classic zero-is-falsy
+  trap; covered by a test).
+- `getConfig()` already spreads the whole `mentor` block, so the new field flows
+  through with no plumbing change; no config-schema validator gates the mentor
+  block (verified by grep), so the additive field is accepted.
+
+**Over-block (does it move something that should stay in the human topic?)**:
+- It moves ONLY the mentor a2a exchange (Echo→mentee prompt + the mentee's
+  session/reply binding, which both derive from this one `telegramTopicId`).
+  The human's own conversation in `menteeTopicId` is untouched. That's the
+  intent: separate automated mentor chatter from human conversation.
+
+**Level-of-abstraction fit**: The topic-resolution rule lives as a pure,
+unit-tested helper in `MentorOnboardingRunner` (which owns `MentorConfig`),
+not as an inline `??` buried in the server closure. `AgentServer` just calls it.
+
+**Signal vs authority**: No authority change. This is pure routing — which
+topic the existing delivery targets. Delivery success/refusal, the anti-loop
+gate, and the budget gate are all unchanged.
+
+**Interactions**:
+- The mentee's REPLY leg uses its own `menteeCfg.replyTopicId` (separate
+  config, separate concern) — not changed here. This amendment addresses the
+  PROMPT-side pollution (Echo's mentor bot posting role=mentor markers into the
+  human topic), which is the observed P3 symptom.
+- Same-machine HTTP a2a remains primary; the Telegram fallback (when HTTP
+  fails) now posts to the dedicated topic too, since both read this one id.
+
+**Migration parity**: Additive OPTIONAL config field with a backward-compatible
+default (falls back to `menteeTopicId`). Unconfigured agents are unaffected, so
+NO `PostUpdateMigrator` entry is required. New + existing agents pick up the
+capability via the normal `instar` package update; it activates only when an
+operator sets `mentor.mentorTopicId`.
+
+**Rollback cost**: Single revert (`MentorOnboardingRunner.ts` field + helper,
+`AgentServer.ts` one-line call). No schema/on-disk/API changes.
+
+**Spec**: `MENTOR-LIVE-READINESS-SPEC.md` 2026-05-28 amendment (approved by
+Justin, topic 13435 — Codey-dogfooding "P3 - agreed").


### PR DESCRIPTION
## What & why
Found dogfooding Codey over Telegram (topic 13435): the mentor cycle's a2a check-ins posted into `mentor.menteeTopicId` — the **same topic Justin chats with Codey in** — so automated mentor markers interleaved with the real human↔agent conversation.

## Fix
Optional `mentor.mentorTopicId`. `resolveMentorDeliveryTopic(cfg)` → `mentorTopicId ?? menteeTopicId`; `deliverToMentee` passes that as `telegramTopicId`. That one id drives **both** the `/a2a/inbox` body (where the mentee binds its session + reply) **and** the Telegram fallback, so the whole mentor exchange moves to the dedicated topic together. Unset → falls back to `menteeTopicId` (**backward-compatible**; no change for unconfigured agents). Uses `??` (not `||`) so `mentorTopicId: 0` ("General") is honored.

## Tests
`tests/unit/MentorOnboardingRunner.test.ts` — `resolveMentorDeliveryTopic`: prefers `mentorTopicId`, falls back to `menteeTopicId`, undefined when neither set, treats `0` as a real topic. tsc + lint clean.

## Notes
- Additive optional config field with backward-compatible default → no `PostUpdateMigrator` entry needed.
- Reply leg uses its own `replyTopicId` (separate concern); this addresses the observed prompt-side pollution (Echo's mentor bot posting `role=mentor` markers into the human topic).

Spec: `MENTOR-LIVE-READINESS-SPEC.md` 2026-05-28 amendment (approved by Justin, topic 13435 — "P3 - agreed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)