### PR TITLE
docs(upgrades): plain-language NEXT.md user section (unblock v1.3.76 publish)

### DIFF
--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -21,9 +21,9 @@ hasn't configured it).
 ## What to Tell Your User
 
 If you run the mentor cycle and don't want its automated check-ins mixed into
-your own conversation topic with the mentee, give it a dedicated topic: set
-`mentor.mentorTopicId` in `.instar/config.json` to a topic id in the mentee's
-chat. Leave it unset to keep today's behavior.
+your own conversation topic with the agent, you can now give the mentor its own
+dedicated topic — just point the mentor's topic setting at a separate topic in
+the mentee's chat. Leave it as-is to keep today's behavior.
 
 ## Summary of New Capabilities
 


### PR DESCRIPTION
The v1.3.76 publish failed the upgrade-guide check — the NEXT.md "What to Tell Your User" section had inline code (backticks), which the linter forbids (user-facing text must be plain). Rewrote it plainly. Unblocks the v1.3.76 release carrying the P3 mentor-topic fix (#504). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)