### PR TITLE
test: make TokenLedger scanAllAsync deterministic

### DIFF
--- a/docs/specs/tokenledger-scanall-async-deterministic.eli16.md
+++ b/docs/specs/tokenledger-scanall-async-deterministic.eli16.md
@@ -1,0 +1,29 @@
+# TokenLedger scanAllAsync deterministic yield test
+
+TokenLedger has a background scan that reads token-usage transcript files. The
+async version is supposed to pause briefly between batches so the rest of the
+server can keep responding while a large scan is running.
+
+The old test tried to prove that pause by starting a one-millisecond timer and
+checking whether that timer fired before the scan finished. That sounds
+reasonable, but it is not deterministic. JavaScript has several event-loop
+queues, and `setImmediate` does not guarantee that a one-millisecond interval
+will fire before a very small scan completes. On a fast local run, the scan can
+do the right thing and the timer can still stay at zero.
+
+The fix is to test the behavior directly. TokenLedger now accepts an optional
+async yield function. Normal production code does not pass this option, so it
+still uses the same `setImmediate` yield as before. The unit test passes a small
+function that increments a counter whenever the scan yields. That gives the test
+a direct, reliable signal: if the counter went up, the async scanner yielded.
+
+This does not change how TokenLedger scans files in the real server. It only
+removes the unit test's dependency on wall-clock timer scheduling. The behavior
+under test is the same behavior users care about: scanAllAsync should process
+all files, insert all events, and yield during the scan so it does not monopolize
+the event loop.
+
+The practical result is a quieter development loop. A developer can run the
+TokenLedger unit test locally and trust the result. If it fails after this
+change, it should point to a real scanner problem instead of a timer callback
+that happened not to fire quickly enough.

--- a/docs/specs/tokenledger-scanall-async-deterministic.md
+++ b/docs/specs/tokenledger-scanall-async-deterministic.md
@@ -1,0 +1,38 @@
+---
+title: TokenLedger scanAllAsync deterministic yield test
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: tokenledger-scanall-async-deterministic.eli16.md
+---
+
+# TokenLedger scanAllAsync deterministic yield test
+
+## Problem
+
+`TokenLedger.scanAllAsync` has a unit test that can fail locally even when run
+alone. The implementation yields with `setImmediate`, but the test proves that
+yield indirectly by starting a real `setInterval(..., 1)` and expecting the
+interval callback to run before `scanAllAsync` resolves.
+
+That is a timing race. On a fast machine, `scanAllAsync` can yield and complete
+before the timer phase runs the interval callback. The scanner did yield; the
+test simply observed the wrong event-loop signal.
+
+## Change
+
+Add a narrow `asyncYieldFn` option to `TokenLedgerOptions`. Production keeps the
+existing behavior by defaulting to `setImmediate`. The unit test injects a
+deterministic async yield function and counts how many times `scanAllAsync`
+invokes it.
+
+## Acceptance
+
+- The `scanAllAsync` test no longer uses real timers.
+- The test still proves the async path yields during the scan.
+- Production behavior remains unchanged when no test hook is provided.
+- The affected test passes repeatedly in local isolation.
+
+## Side Effects
+
+The new option is intentionally narrow and only affects `scanAllAsync`'s yield
+primitive. Existing callers do not pass it, so their behavior remains the same.

--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -230,6 +230,10 @@ export interface TokenLedgerOptions {
    * seconds without yielding.
    */
   yieldEveryNFiles?: number;
+  /**
+   * Test seam for scanAllAsync's event-loop yield. Production uses setImmediate.
+   */
+  asyncYieldFn?: () => Promise<void>;
 }
 
 interface AssistantLine {
@@ -260,6 +264,7 @@ export class TokenLedger {
   private maxFileAgeMs: number;
   private maxFilesPerScan: number;
   private yieldEveryNFiles: number;
+  private asyncYieldFn: () => Promise<void>;
   // Cursor between scan calls — when a tick stops at the per-scan cap,
   // the next tick resumes from here instead of restarting the whole tree.
   private scanCursor: { dirIdx: number; fileIdx: number } = { dirIdx: 0, fileIdx: 0 };
@@ -275,6 +280,7 @@ export class TokenLedger {
     this.maxFileAgeMs = opts.maxFileAgeMs && opts.maxFileAgeMs > 0 ? opts.maxFileAgeMs : 0;
     this.maxFilesPerScan = opts.maxFilesPerScan && opts.maxFilesPerScan > 0 ? opts.maxFilesPerScan : 500;
     this.yieldEveryNFiles = opts.yieldEveryNFiles && opts.yieldEveryNFiles > 0 ? opts.yieldEveryNFiles : 25;
+    this.asyncYieldFn = opts.asyncYieldFn ?? (() => new Promise<void>(resolve => setImmediate(resolve)));
     if (opts.dbPath !== ':memory:') {
       fs.mkdirSync(path.dirname(opts.dbPath), { recursive: true });
     }
@@ -586,7 +592,7 @@ export class TokenLedger {
    */
   async scanAllAsync(): Promise<ScanAllResult> {
     return this.scanInternal({
-      yieldFn: () => new Promise<void>(resolve => setImmediate(resolve)),
+      yieldFn: this.asyncYieldFn,
     });
   }
 

--- a/tests/unit/token-ledger.test.ts
+++ b/tests/unit/token-ledger.test.ts
@@ -362,23 +362,19 @@ describe('TokenLedger.scanAll bounded behavior', () => {
         assistantLine({ requestId: `r${i}`, sessionId: `s${i}` }) + '\n',
       );
     }
+    let yieldCount = 0;
     const ledger = new TokenLedger({
       dbPath: ':memory:',
       claudeProjectsDir: projectsDir,
       yieldEveryNFiles: 2,
+      asyncYieldFn: async () => { yieldCount++; },
     });
 
-    let interleavedTicks = 0;
-    const interleaver = setInterval(() => { interleavedTicks++; }, 1);
-
     const r = await ledger.scanAllAsync();
-    clearInterval(interleaver);
 
     expect(r.filesScanned).toBe(8);
     expect(r.inserted).toBe(8);
-    // The async path must have yielded to the event loop at least once
-    // (otherwise the setInterval callback could not fire).
-    expect(interleavedTicks).toBeGreaterThan(0);
+    expect(yieldCount).toBeGreaterThan(0);
     ledger.close();
   });
 });

--- a/upgrades/side-effects/tokenledger-scanall-async-deterministic.md
+++ b/upgrades/side-effects/tokenledger-scanall-async-deterministic.md
@@ -1,0 +1,34 @@
+# TokenLedger scanAllAsync deterministic yield test
+
+## Scope
+
+This change touches `TokenLedger` and its unit test for `scanAllAsync`.
+
+## Behavioral Change
+
+Production behavior is unchanged by default. `scanAllAsync` still yields with
+`setImmediate` when callers do not provide an override.
+
+The new behavior is an optional constructor seam, `asyncYieldFn`, that lets
+tests or specialized callers provide the async yield primitive used by
+`scanAllAsync`.
+
+## Side Effects Review
+
+1. User-facing behavior: none expected. The server's token ledger scanner keeps
+   the same default event-loop yielding behavior.
+2. Data persistence: none. No database schema, ingestion format, offset, or
+   summary-query behavior changes.
+3. Runtime risk: low. The new option is opt-in and defaults to the previous
+   implementation.
+4. Signal versus authority: no new blocking or routing authority is introduced.
+   The seam only changes how an async pause is performed.
+5. Test quality: improved. The unit test now observes the scanner's yield call
+   directly instead of depending on wall-clock timer scheduling.
+6. Rollback: remove the option and restore the prior test. No migration or state
+   cleanup is required.
+
+## Verification
+
+- Affected test passed 10 consecutive local runs.
+- Full `tests/unit/token-ledger.test.ts` passed locally.


### PR DESCRIPTION
## Summary
- add a narrow async yield injection seam to TokenLedger, defaulting to the existing setImmediate behavior
- replace the scanAllAsync unit test real 1ms interval proof with deterministic yield-call counting
- add Instar-dev spec, ELI16 companion, side-effects artifact, and trace-gated commit

## Root Cause
The flaky test used setInterval(..., 1) to infer that scanAllAsync yielded. scanAllAsync yields via setImmediate, and on fast local runs the scan can yield and finish before the timer callback fires, leaving the counter at 0 even though yielding occurred.

## Validation
- affected scanAllAsync test passed 10/10 locally
- npm test -- tests/unit/token-ledger.test.ts
- npm run lint
- npm run build
- npm run check:upgrade-guide
- node scripts/instar-dev-precommit.js
- npm run check:pre-push-gate
- publish pre-check was skipped after an unrelated local smoke run exceeded 32 minutes and surfaced pre-existing failures outside this change; PR CI is the authoritative full gate

## Unrelated local smoke failures observed
- SessionManager behavioral tests > spawnSession > includes model in session data when provided
- probe_server_identity — behaviour > omits Authorization when config has no authToken (still probes)
- spawnInteractiveSession: resume-failure fallback > emits resumeFailed and falls back to a fresh spawn when --resume crashes during startup
- SessionManager.spawnInteractiveSession --resume support > includes --resume <uuid> when resumeSessionId is provided
- SessionManager.spawnInteractiveSession --resume support > places --resume after --dangerously-skip-permissions
- SessionManager.spawnInteractiveSession --resume support > includes both --resume and telegram topic env when both provided
- SessionManager.spawnInteractiveSession --resume support > passes UUID exactly as-is, not modified
- per-topic framework dispatch end-to-end > omitting framework falls back to claude-code (v0.x compat)
