### PR TITLE
fix(pre-push): resolve smoke base and cap broad runs

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -13,7 +13,7 @@ if ! node scripts/pre-push-fixture-guard.mjs; then
   exit 1
 fi
 
-# ── Smoke tier: run only tests affected by files changed vs origin/main ──
+# ── Smoke tier: run only tests affected by files changed vs the resolved base ──
 # Full suite still runs in CI across 8 sharded runners — that's the authority.
 # Pre-push is a fast signal to catch obvious breakage before it costs a CI run.
 #
@@ -25,14 +25,17 @@ if [ "${INSTAR_PRE_PUSH_SKIP:-}" = "1" ]; then
   exit 0
 fi
 
-# Ensure the base ref we diff against is fresh.
+# Keep common candidate base refs fresh. Fail-open: stale refs only make the
+# local smoke signal broader; CI remains the authority.
+git fetch --quiet JKHeadley main 2>/dev/null || true
+git fetch --quiet upstream main 2>/dev/null || true
 git fetch --quiet origin main 2>/dev/null || true
 
 if [ "${INSTAR_PRE_PUSH_FULL:-}" = "1" ]; then
   echo "🧪 INSTAR_PRE_PUSH_FULL=1 — running full push suite (slow, ~10 min)..."
   TEST_CMD="npm run test:push"
 else
-  echo "🧪 Running smoke tier (tests affected by changes vs origin/main)..."
+  echo "🧪 Running smoke tier (tests affected by changes vs resolved base)..."
   echo "   Full suite runs in CI | Force full locally: INSTAR_PRE_PUSH_FULL=1 git push"
   TEST_CMD="npm run test:smoke"
 fi

--- a/docs/specs/prepush-smoke-base-guard.eli16.md
+++ b/docs/specs/prepush-smoke-base-guard.eli16.md
@@ -1,0 +1,9 @@
+# ELI16: Pre-push Smoke Base Resolver and Breadth Guard
+
+The pre-push hook is meant to be a quick local check before a branch is pushed. It should catch obvious test failures quickly, then let the pull request CI run the full authoritative test suite.
+
+The bug was that the local smoke check could compare the branch against the wrong remote base. If the base was stale or unrelated, the tool believed many files had changed and selected a very large set of tests. That made a "quick smoke check" run for a long time, even though CI would still be the real gate later.
+
+This change teaches the hook how to choose a better base. It first looks at the branch's configured upstream or push remote, because that is usually the remote the developer or agent is actually pushing to. If that is not available, it tries the standard main branches in a predictable order: `JKHeadley/main`, then `upstream/main`, then `origin/main`.
+
+The hook also prints what it chose before running tests: the base reference and how many files changed relative to that base. If the changed file count or selected test count is too large, the hook stops the local smoke run and says plainly that local smoke is too broad and CI is the authority. This keeps local feedback fast without weakening the real merge checks.

--- a/docs/specs/prepush-smoke-base-guard.md
+++ b/docs/specs/prepush-smoke-base-guard.md
@@ -1,0 +1,42 @@
+---
+title: Pre-push smoke base resolver and breadth guard
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: prepush-smoke-base-guard.eli16.md
+---
+
+# Pre-push Smoke Base Resolver and Breadth Guard
+
+## Problem
+
+The pre-push hook currently asks Vitest for changed tests relative to a hard-coded remote base. In agent worktrees, that base can be stale or unrelated to the branch being pushed. When the base is wrong, `vitest --changed` can select a broad test set and turn a local smoke check into a long-running gate.
+
+That behavior is especially harmful because local smoke is supposed to provide fast feedback. It must not compete with PR CI as the merge authority.
+
+## Scope
+
+This change updates the pre-push smoke path only:
+
+- Resolve the smoke base from the branch's configured upstream or push remote first.
+- Fall back through `JKHeadley/main`, `upstream/main`, and `origin/main`.
+- Log the chosen base and changed-file count before invoking Vitest.
+- Count the selected Vitest affected set before running it.
+- Skip local smoke when the changed-file or selected-test set is too broad, with a clear message that CI remains the authority.
+
+The failed-files-only retry behavior is intentionally not included in this PR's accepted scope.
+
+## Non-Goals
+
+- Do not change CI behavior.
+- Do not change the Vitest push config itself.
+- Do not add failed-files-only retry semantics in this PR.
+- Do not make local smoke mandatory for broad changes.
+
+## Acceptance Criteria
+
+- The smoke runner prefers branch upstream or push remote before canonical fallback remotes.
+- The hook logs the selected base and changed-file count before Vitest list/run commands.
+- The runner skips local smoke when the selected set exceeds configured caps.
+- The skip message states that local smoke is too broad and CI is the authority.
+- Unit tests cover resolver ordering and breadth-guard behavior.
+- The instar-dev precommit gate passes before publishing.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:push": "vitest run --config vitest.push.config.ts",
-    "test:smoke": "vitest run --config vitest.push.config.ts --changed origin/main",
+    "test:smoke": "node scripts/pre-push-smoke.mjs",
     "test:flaky": "vitest run tests/unit/relationship-routes.test.ts tests/integration/messaging-routes.test.ts tests/integration/whatsapp-routes.test.ts tests/unit/server.test.ts tests/e2e/semantic-memory-lifecycle.test.ts tests/e2e/system-reviewer-e2e.test.ts tests/e2e/working-memory-lifecycle.test.ts tests/e2e/messaging-multi-agent.test.ts",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",

--- a/scripts/lib/pre-push-scope.mjs
+++ b/scripts/lib/pre-push-scope.mjs
@@ -1,0 +1,132 @@
+// safe-git-allow: pre-push bootstrap helpers — read-only git only.
+import { execFileSync } from 'node:child_process';
+
+export const DEFAULT_SMOKE_LIMITS = Object.freeze({
+  maxChangedFiles: 200,
+  maxTestFiles: 80,
+  maxTestCases: 1000,
+});
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, {
+    cwd: opts.cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: opts.env ?? process.env,
+  }).trim();
+}
+
+function tryGit(args, opts = {}) {
+  try {
+    const out = (opts.git ?? git)(args, opts);
+    return out ? String(out).trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+function remoteRef(remote, branch = 'main') {
+  if (!remote) return '';
+  return `refs/remotes/${remote}/${branch}`;
+}
+
+function refExists(ref, opts = {}) {
+  if (!ref) return false;
+  return Boolean(tryGit(['rev-parse', '--verify', ref], opts));
+}
+
+function addCandidate(candidates, seen, ref, reason, opts) {
+  if (!ref || seen.has(ref)) return;
+  seen.add(ref);
+  if (refExists(ref, opts)) candidates.push({ ref, reason });
+}
+
+function shortRemoteRef(ref) {
+  return ref.startsWith('refs/remotes/') ? ref.slice('refs/remotes/'.length) : ref;
+}
+
+export function resolvePrePushBase(opts = {}) {
+  const candidates = [];
+  const seen = new Set();
+  const branch = tryGit(['branch', '--show-current'], opts);
+  const upstream = tryGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], opts);
+
+  if (upstream) {
+    const parts = upstream.split('/');
+    const upstreamRemote = parts[0];
+    const upstreamBranch = parts.slice(1).join('/');
+    if (upstreamBranch === 'main') {
+      addCandidate(candidates, seen, `refs/remotes/${upstream}`, 'branch upstream', opts);
+    } else {
+      addCandidate(candidates, seen, remoteRef(upstreamRemote), 'branch upstream remote main', opts);
+    }
+  }
+
+  const pushRemote =
+    (branch && tryGit(['config', `branch.${branch}.pushRemote`], opts)) ||
+    tryGit(['config', 'remote.pushDefault'], opts);
+  addCandidate(candidates, seen, remoteRef(pushRemote), 'push remote main', opts);
+
+  const branchRemote = branch ? tryGit(['config', `branch.${branch}.remote`], opts) : '';
+  addCandidate(candidates, seen, remoteRef(branchRemote), 'branch remote main', opts);
+
+  addCandidate(candidates, seen, 'refs/remotes/JKHeadley/main', 'fallback JKHeadley/main', opts);
+  addCandidate(candidates, seen, 'refs/remotes/upstream/main', 'fallback upstream/main', opts);
+  addCandidate(candidates, seen, 'refs/remotes/origin/main', 'fallback origin/main', opts);
+
+  if (candidates.length > 0) {
+    return { ref: shortRemoteRef(candidates[0].ref), reason: candidates[0].reason };
+  }
+
+  const previousCommit = tryGit(['rev-parse', 'HEAD~1'], opts);
+  if (previousCommit) return { ref: previousCommit, reason: 'fallback HEAD~1' };
+
+  return { ref: 'HEAD', reason: 'fallback HEAD' };
+}
+
+export function changedFilesSince(baseRef, opts = {}) {
+  const out = (opts.git ?? git)(['diff', '--name-only', `${baseRef}...HEAD`], opts);
+  return String(out)
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+export function readSmokeLimits(env = process.env) {
+  return {
+    maxChangedFiles: Number.parseInt(env.INSTAR_PRE_PUSH_SMOKE_MAX_CHANGED_FILES ?? '', 10) || DEFAULT_SMOKE_LIMITS.maxChangedFiles,
+    maxTestFiles: Number.parseInt(env.INSTAR_PRE_PUSH_SMOKE_MAX_TEST_FILES ?? '', 10) || DEFAULT_SMOKE_LIMITS.maxTestFiles,
+    maxTestCases: Number.parseInt(env.INSTAR_PRE_PUSH_SMOKE_MAX_TEST_CASES ?? '', 10) || DEFAULT_SMOKE_LIMITS.maxTestCases,
+  };
+}
+
+export function evaluateSmokeBreadth({ changedFileCount, testFileCount, testCaseCount }, limits = DEFAULT_SMOKE_LIMITS) {
+  if (changedFileCount > limits.maxChangedFiles) {
+    return {
+      skip: true,
+      reason: `changed file count ${changedFileCount} exceeds local smoke cap ${limits.maxChangedFiles}`,
+    };
+  }
+  if (testFileCount > limits.maxTestFiles) {
+    return {
+      skip: true,
+      reason: `affected test file count ${testFileCount} exceeds local smoke cap ${limits.maxTestFiles}`,
+    };
+  }
+  if (testCaseCount > limits.maxTestCases) {
+    return {
+      skip: true,
+      reason: `affected test case count ${testCaseCount} exceeds local smoke cap ${limits.maxTestCases}`,
+    };
+  }
+  return { skip: false, reason: 'within local smoke caps' };
+}
+
+export function summarizeVitestList(stdout) {
+  const tests = String(stdout)
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean);
+  const files = new Set(tests.map(line => line.split(' > ')[0]).filter(Boolean));
+  return { testCaseCount: tests.length, testFileCount: files.size };
+}

--- a/scripts/pre-push-smoke.mjs
+++ b/scripts/pre-push-smoke.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// safe-git-allow: pre-push smoke runner — read-only git, then Vitest.
+import { spawnSync } from 'node:child_process';
+import {
+  changedFilesSince,
+  evaluateSmokeBreadth,
+  readSmokeLimits,
+  resolvePrePushBase,
+  summarizeVitestList,
+} from './lib/pre-push-scope.mjs';
+
+function run(command, args, opts = {}) {
+  return spawnSync(command, args, {
+    cwd: opts.cwd ?? process.cwd(),
+    env: opts.env ?? process.env,
+    encoding: 'utf-8',
+    stdio: opts.stdio ?? ['ignore', 'pipe', 'pipe'],
+    timeout: opts.timeout,
+  });
+}
+
+function printSkip(reason) {
+  console.log(`⏭️  Local smoke too broad; CI is the authority. ${reason}.`);
+  console.log('   The PR test matrix still runs the full suite before merge.');
+}
+
+const base = resolvePrePushBase();
+const limits = readSmokeLimits();
+let changed = [];
+
+try {
+  changed = changedFilesSince(base.ref);
+} catch (err) {
+  console.warn(`pre-push smoke: could not compute changed files from ${base.ref} (${err instanceof Error ? err.message : err}) — skipping local smoke; CI is the authority.`);
+  process.exit(0);
+}
+
+console.log(`🧪 Running smoke tier against ${base.ref} (${base.reason}); changed files: ${changed.length}.`);
+
+if (changed.length === 0) {
+  console.log('✅ No changed files relative to smoke base; skipping local smoke.');
+  process.exit(0);
+}
+
+let breadth = evaluateSmokeBreadth({ changedFileCount: changed.length, testFileCount: 0, testCaseCount: 0 }, limits);
+if (breadth.skip) {
+  printSkip(breadth.reason);
+  process.exit(0);
+}
+
+const list = run('npx', ['vitest', 'list', '--config', 'vitest.push.config.ts', '--changed', base.ref], {
+  timeout: Number.parseInt(process.env.INSTAR_PRE_PUSH_SMOKE_LIST_TIMEOUT_MS ?? '', 10) || 120_000,
+});
+
+if (list.status !== 0) {
+  process.stdout.write(list.stdout ?? '');
+  process.stderr.write(list.stderr ?? '');
+  if (list.signal === 'SIGTERM') {
+    console.warn('pre-push smoke: affected-test listing timed out — skipping local smoke; CI is the authority.');
+    process.exit(0);
+  }
+  process.exit(list.status ?? 1);
+}
+
+const selected = summarizeVitestList(list.stdout);
+console.log(`🧪 Smoke affected set: ${selected.testFileCount} test files / ${selected.testCaseCount} test cases.`);
+
+breadth = evaluateSmokeBreadth(
+  { changedFileCount: changed.length, testFileCount: selected.testFileCount, testCaseCount: selected.testCaseCount },
+  limits,
+);
+if (breadth.skip) {
+  printSkip(breadth.reason);
+  process.exit(0);
+}
+
+if (selected.testCaseCount === 0) {
+  console.log('✅ No affected tests selected by Vitest.');
+  process.exit(0);
+}
+
+const result = run('npx', ['vitest', 'run', '--config', 'vitest.push.config.ts', '--changed', base.ref], {
+  stdio: 'inherit',
+});
+process.exit(result.status ?? 1);

--- a/tests/unit/scripts/pre-push-scope.test.ts
+++ b/tests/unit/scripts/pre-push-scope.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateSmokeBreadth,
+  resolvePrePushBase,
+  summarizeVitestList,
+} from '../../../scripts/lib/pre-push-scope.mjs';
+
+function fakeGit(outputs: Record<string, string | Error>) {
+  return (args: string[]) => {
+    const key = args.join(' ');
+    const value = outputs[key];
+    if (value instanceof Error) throw value;
+    if (value === undefined) throw new Error(`unexpected git call: ${key}`);
+    return value;
+  };
+}
+
+describe('pre-push smoke scope helpers', () => {
+  it('uses a branch upstream when the upstream branch is main', () => {
+    const base = resolvePrePushBase({
+      git: fakeGit({
+        'branch --show-current': 'codey/fix',
+        'rev-parse --abbrev-ref --symbolic-full-name @{u}': 'JKHeadley/main',
+        'rev-parse --verify refs/remotes/JKHeadley/main': 'abc123',
+      }),
+    });
+
+    expect(base).toEqual({ ref: 'JKHeadley/main', reason: 'branch upstream' });
+  });
+
+  it('uses the upstream remote main when the branch upstream points at the feature branch', () => {
+    const base = resolvePrePushBase({
+      git: fakeGit({
+        'branch --show-current': 'codey/fix',
+        'rev-parse --abbrev-ref --symbolic-full-name @{u}': 'JKHeadley/codey/fix',
+        'rev-parse --verify refs/remotes/JKHeadley/main': 'abc123',
+      }),
+    });
+
+    expect(base).toEqual({ ref: 'JKHeadley/main', reason: 'branch upstream remote main' });
+  });
+
+  it('falls back through canonical remotes before origin/main', () => {
+    const base = resolvePrePushBase({
+      git: fakeGit({
+        'branch --show-current': 'codey/fix',
+        'rev-parse --abbrev-ref --symbolic-full-name @{u}': new Error('no upstream'),
+        'config branch.codey/fix.pushRemote': new Error('unset'),
+        'config remote.pushDefault': new Error('unset'),
+        'config branch.codey/fix.remote': new Error('unset'),
+        'rev-parse --verify refs/remotes/JKHeadley/main': new Error('missing'),
+        'rev-parse --verify refs/remotes/upstream/main': 'def456',
+      }),
+    });
+
+    expect(base).toEqual({ ref: 'upstream/main', reason: 'fallback upstream/main' });
+  });
+
+  it('skips local smoke when changed-file count exceeds the cap', () => {
+    const result = evaluateSmokeBreadth(
+      { changedFileCount: 201, testFileCount: 0, testCaseCount: 0 },
+      { maxChangedFiles: 200, maxTestFiles: 80, maxTestCases: 1000 },
+    );
+
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain('changed file count 201');
+  });
+
+  it('skips local smoke when affected test files exceed the cap', () => {
+    const result = evaluateSmokeBreadth(
+      { changedFileCount: 5, testFileCount: 81, testCaseCount: 900 },
+      { maxChangedFiles: 200, maxTestFiles: 80, maxTestCases: 1000 },
+    );
+
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain('affected test file count 81');
+  });
+
+  it('summarizes Vitest list output by test cases and unique files', () => {
+    const summary = summarizeVitestList([
+      'tests/unit/a.test.ts > suite > case 1',
+      'tests/unit/a.test.ts > suite > case 2',
+      'tests/integration/b.test.ts > suite > case 1',
+      '',
+    ].join('\n'));
+
+    expect(summary).toEqual({ testCaseCount: 3, testFileCount: 2 });
+  });
+});

--- a/upgrades/side-effects/prepush-smoke-base-guard.md
+++ b/upgrades/side-effects/prepush-smoke-base-guard.md
@@ -1,0 +1,84 @@
+# Side-Effects Review — Pre-push smoke base resolver and breadth guard
+
+**Version / slug:** `prepush-smoke-base-guard`
+**Date:** `2026-05-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `instar-codey second-pass checklist`
+
+## Summary of the change
+
+This change moves the pre-push smoke selection logic into `scripts/pre-push-smoke.mjs` and `scripts/lib/pre-push-scope.mjs`, updates `.husky/pre-push` to use that runner, and adds focused unit tests in `tests/unit/scripts/pre-push-scope.test.ts`. The smoke runner now resolves a branch-appropriate base, logs that base plus changed-file count, lists the affected Vitest set, and skips local smoke when the selected set is too broad. CI remains the authoritative merge gate.
+
+## Decision-point inventory
+
+- `scripts/lib/pre-push-scope.mjs#resolvePrePushBase` — add — chooses which git base local smoke uses for changed-test selection.
+- `scripts/lib/pre-push-scope.mjs#evaluateSmokeBreadth` — add — decides whether local smoke is small enough to run locally.
+- `scripts/pre-push-smoke.mjs` — add — applies the local-only smoke skip decision before invoking Vitest run.
+- `.husky/pre-push` — modify — delegates smoke execution to the runner after best-effort remote fetches.
+
+---
+
+## 1. Over-block
+
+The broad-set guard can skip local smoke for a legitimate branch that changes many files or maps to many tests. That does not block the push or merge; it only declines to run a local smoke subset. The hook prints that CI is the authority, and the PR test matrix still runs before merge.
+
+The resolver can choose a branch upstream or push remote whose `main` is missing or stale. It falls back through canonical remotes, and the hook performs best-effort fetches for those remotes before running the resolver.
+
+## 2. Under-block
+
+This change does not guarantee a local smoke run catches every failure. A branch under the caps may still have failures outside Vitest's changed-test selection. That is an accepted limitation of local smoke; CI remains the full authority.
+
+The runner also skips local smoke if changed-file calculation or affected-test listing fails due to local git/Vitest state. This avoids pathological local blocking but leaves the real failure detection to CI.
+
+## 3. Level-of-abstraction fit
+
+The resolver is a local git-scope helper. The broad-set guard is a deterministic local ergonomics check, not a product or conversational authority. It operates at the pre-push developer-tooling layer where the question is only whether the optional local smoke run is small enough to be useful.
+
+The implementation uses existing git configuration and Vitest changed-test listing rather than adding a new cross-system state source.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [x] Not applicable to conversational/product judgment — this is a local developer-tooling guard that fails open to CI.
+
+This change does hold local skip authority over an optional smoke run, but it does not block user messages, external operations, information flow, or product behavior. It is a fail-open performance guard: when the local set is too broad, it avoids running the local subset and explicitly defers to CI.
+
+## 5. Interactions
+
+- **Shadowing:** The broad-set guard runs before `vitest run`. It can shadow local smoke execution, but it cannot shadow CI because CI is separate and unchanged.
+- **Double-fire:** `.husky/pre-push` still wraps `npm run test:smoke` in the existing retry loop. When the runner skips broad smoke, it exits successfully and the retry loop does not repeat.
+- **Races:** The runner reads git refs after the hook performs best-effort fetches. Concurrent branch updates could change remote refs during a push, but that risk already exists for local changed-test selection.
+- **Feedback loops:** No persistent state is written. The hook does not feed its skip decision back into future runs.
+
+## 6. External surfaces
+
+This affects developers and agents pushing branches from this repository. It changes local terminal output and can reduce local pre-push runtime for broad affected sets. It does not change CI, GitHub PR checks, Telegram messaging, dashboard behavior, persisted ledgers, or external service APIs.
+
+## 7. Rollback cost
+
+Rollback is a pure code revert of `.husky/pre-push`, `package.json`, the new smoke runner/helper files, and tests. No migration, persistent state repair, or user notification is required. The only user-visible regression during rollback would be returning to the older hard-coded local smoke base behavior.
+
+## Conclusion
+
+The review found the main risk is local under-testing when a broad affected set is skipped. That is acceptable because local smoke is not the merge authority, and the skip message makes the authority boundary explicit. The change is clear to ship with focused tests and the instar-dev gate.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** instar-codey second-pass checklist
+**Independent read of the artifact:** concur
+
+The second pass agrees that the guard is local-only, fail-open, and does not introduce a brittle product/message blocking authority. The main risk is documented as reliance on CI for broad changes.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/scripts/pre-push-scope.test.ts`
+- `scripts/pre-push-smoke.mjs`
+- `scripts/lib/pre-push-scope.mjs`


### PR DESCRIPTION
## Summary
- resolve pre-push smoke base from branch upstream/push remote before canonical main fallbacks
- log chosen base and changed-file count before Vitest selection
- skip local smoke when changed/test set is too broad and leave CI as the authority

## Validation
- npm test -- tests/unit/scripts/pre-push-scope.test.ts
- node scripts/pre-push-smoke.mjs
- npm run lint
- node scripts/instar-dev-precommit.js

Published with the local pre-push skip flag because this branch fixes that hook path.