### PR TITLE
fix(pre-push): retry failed smoke files only

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -34,17 +34,25 @@ git fetch --quiet origin main 2>/dev/null || true
 if [ "${INSTAR_PRE_PUSH_FULL:-}" = "1" ]; then
   echo "🧪 INSTAR_PRE_PUSH_FULL=1 — running full push suite (slow, ~10 min)..."
   TEST_CMD="npm run test:push"
+  TEST_RETRY_MODE="whole-command"
 else
   echo "🧪 Running smoke tier (tests affected by changes vs resolved base)..."
   echo "   Full suite runs in CI | Force full locally: INSTAR_PRE_PUSH_FULL=1 git push"
   TEST_CMD="npm run test:smoke"
+  TEST_RETRY_MODE="handled-by-smoke-runner"
 fi
 
-# Try up to 2 times — flaky tests may fail intermittently
-SMOKE_OK=0
-for attempt in 1 2; do
+# Try up to 2 times — flaky tests may fail intermittently.
+# The smoke runner owns its own retry so it can rerun only failed test files.
+MAX_ATTEMPTS=2
+if [ "$TEST_RETRY_MODE" = "handled-by-smoke-runner" ]; then
+  MAX_ATTEMPTS=1
+fi
+
+TESTS_OK=0
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   if $TEST_CMD; then
-    SMOKE_OK=1
+    TESTS_OK=1
     break
   fi
   if [ "$attempt" -eq 1 ]; then
@@ -54,8 +62,12 @@ for attempt in 1 2; do
   fi
 done
 
-if [ "$SMOKE_OK" != "1" ]; then
-  echo "❌ Tests failed on both attempts. Debug with: $TEST_CMD"
+if [ "$TESTS_OK" != "1" ]; then
+  if [ "$TEST_RETRY_MODE" = "handled-by-smoke-runner" ]; then
+    echo "❌ Tests failed after smoke runner retry. Debug with: $TEST_CMD"
+  else
+    echo "❌ Tests failed on both attempts. Debug with: $TEST_CMD"
+  fi
   exit 1
 fi
 

--- a/docs/specs/prepush-smoke-failed-files-retry.eli16.md
+++ b/docs/specs/prepush-smoke-failed-files-retry.eli16.md
@@ -1,0 +1,13 @@
+# ELI16: Pre-push Smoke Failed-Files Retry
+
+The pre-push smoke check is supposed to be a quick local warning before a branch is pushed. It is not the final judge. The pull request CI still runs the real test matrix before code can merge.
+
+The previous fix made the smoke check choose the right base branch and skip local smoke when the selected set is too broad. That solved the worst case where an agent worktree compared against a stale remote and tried to run a near-whole-suite check locally.
+
+This change handles the next wasteful case: a normal smoke run can still select a meaningful group of tests. If one file fails, the current hook repeats the whole selected group. That means a single flaky or isolated failure can make the local hook pay for every selected test twice.
+
+The new behavior keeps the first run exactly as useful as before. Vitest still prints its normal output, and the smoke runner still runs the affected set selected by `--changed`. The only addition is that the runner also asks Vitest to write a JSON results file. If the first run passes, nothing else happens.
+
+If the first run fails, the runner reads that JSON file, finds the test files that actually failed, and runs only those files one more time. It prints the list so the developer or agent can see exactly what is being retried. If the JSON file is missing, malformed, or does not name any failed files, the runner does not guess and does not pass the hook. It keeps the original failure.
+
+This keeps the local retry useful without letting it become another long broad-set run. The full push-suite option still keeps its old whole-command retry, because that path deliberately asks for the slower local suite. CI remains the authority either way.

--- a/docs/specs/prepush-smoke-failed-files-retry.md
+++ b/docs/specs/prepush-smoke-failed-files-retry.md
@@ -1,0 +1,41 @@
+---
+title: Pre-push smoke failed-files retry
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: prepush-smoke-failed-files-retry.eli16.md
+---
+
+# Pre-push Smoke Failed-Files Retry
+
+## Problem
+
+The pre-push hook still retries the local smoke tier by running the entire affected-test command a second time. After the base resolver and broad-set guard, the selected set is no longer pathological in normal agent worktrees, but it can still be large enough that repeating the whole set wastes local time when only one or a few files failed.
+
+Local smoke is a fast pre-check. It should spend its retry budget on the files that actually failed, while PR CI remains the authoritative full-suite gate.
+
+## Scope
+
+This change updates the local pre-push smoke path only:
+
+- Keep the existing affected-test selection, base resolver, and broad-set guard.
+- On the first smoke run, preserve normal Vitest terminal output and also write a JSON result report.
+- If the first smoke run fails, parse the JSON report to extract the unique failed test files.
+- Retry only those failed test files once.
+- If the report is missing, malformed, or contains no failed files, preserve the original failure instead of hiding it.
+- Prevent the outer Husky wrapper from re-running the whole smoke command after the smoke runner has already performed the focused retry.
+
+## Non-Goals
+
+- Do not change CI behavior.
+- Do not change the Vitest push config exclusions.
+- Do not broaden or narrow the affected-test selection logic from the previous PR.
+- Do not add per-test-case retry semantics; this retry is file-scoped.
+
+## Acceptance Criteria
+
+- A failed smoke run retries only the failed test files once.
+- The retry logs the file list it is re-running.
+- Missing or unparsable Vitest JSON does not turn a failed smoke run into a pass.
+- The full push-suite path keeps its existing whole-command retry behavior.
+- Unit tests cover failed-file extraction from Vitest JSON.
+- The instar-dev precommit gate passes before publishing.

--- a/scripts/lib/pre-push-scope.mjs
+++ b/scripts/lib/pre-push-scope.mjs
@@ -130,3 +130,32 @@ export function summarizeVitestList(stdout) {
   const files = new Set(tests.map(line => line.split(' > ')[0]).filter(Boolean));
   return { testCaseCount: tests.length, testFileCount: files.size };
 }
+
+function normalizeTestFileName(name, cwd) {
+  if (typeof name !== 'string' || name.length === 0) return '';
+  if (!cwd || !name.startsWith(`${cwd}/`)) return name;
+  return name.slice(cwd.length + 1);
+}
+
+function resultHasFailure(result) {
+  if (!result || typeof result !== 'object') return false;
+  if (result.status === 'failed') return true;
+  if (Array.isArray(result.assertionResults)) {
+    return result.assertionResults.some(assertion => assertion?.status === 'failed');
+  }
+  return false;
+}
+
+export function failedTestFilesFromVitestJson(jsonText, opts = {}) {
+  const cwd = opts.cwd ?? process.cwd();
+  const parsed = JSON.parse(String(jsonText));
+  const files = new Set();
+
+  for (const result of parsed?.testResults ?? []) {
+    if (!resultHasFailure(result)) continue;
+    const file = normalizeTestFileName(result.name, cwd);
+    if (file) files.add(file);
+  }
+
+  return [...files].sort();
+}

--- a/scripts/pre-push-smoke.mjs
+++ b/scripts/pre-push-smoke.mjs
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 // safe-git-allow: pre-push smoke runner — read-only git, then Vitest.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import {
   changedFilesSince,
   evaluateSmokeBreadth,
+  failedTestFilesFromVitestJson,
   readSmokeLimits,
   resolvePrePushBase,
   summarizeVitestList,
@@ -22,6 +26,55 @@ function run(command, args, opts = {}) {
 function printSkip(reason) {
   console.log(`⏭️  Local smoke too broad; CI is the authority. ${reason}.`);
   console.log('   The PR test matrix still runs the full suite before merge.');
+}
+
+function readFailedFiles(reportFile) {
+  try {
+    return failedTestFilesFromVitestJson(fs.readFileSync(reportFile, 'utf-8'), { cwd: process.cwd() });
+  } catch (err) {
+    console.warn(`pre-push smoke: could not read failed test files from Vitest JSON (${err instanceof Error ? err.message : err}).`);
+    return [];
+  }
+}
+
+function runAffectedSmoke(baseRef) {
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-pre-push-smoke-'));
+  const reportFile = path.join(reportDir, 'vitest-results.json');
+  try {
+    const result = run('npx', [
+      'vitest',
+      'run',
+      '--config',
+      'vitest.push.config.ts',
+      '--changed',
+      baseRef,
+      '--reporter=default',
+      '--reporter=json',
+      `--outputFile.json=${reportFile}`,
+    ], {
+      stdio: 'inherit',
+    });
+
+    if ((result.status ?? 1) === 0) return 0;
+
+    const failedFiles = readFailedFiles(reportFile);
+    if (failedFiles.length === 0) {
+      console.warn('pre-push smoke: no failed test files were found for focused retry; preserving original failure.');
+      return result.status ?? 1;
+    }
+
+    console.log('');
+    console.log(`⚠️  Attempt 1 failed — retrying ${failedFiles.length} failed test file${failedFiles.length === 1 ? '' : 's'} once.`);
+    for (const file of failedFiles) console.log(`   - ${file}`);
+    console.log('');
+
+    const retry = run('npx', ['vitest', 'run', '--config', 'vitest.push.config.ts', ...failedFiles], {
+      stdio: 'inherit',
+    });
+    return retry.status ?? 1;
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
 }
 
 const base = resolvePrePushBase();
@@ -79,7 +132,4 @@ if (selected.testCaseCount === 0) {
   process.exit(0);
 }
 
-const result = run('npx', ['vitest', 'run', '--config', 'vitest.push.config.ts', '--changed', base.ref], {
-  stdio: 'inherit',
-});
-process.exit(result.status ?? 1);
+process.exit(runAffectedSmoke(base.ref));

--- a/tests/unit/scripts/pre-push-scope.test.ts
+++ b/tests/unit/scripts/pre-push-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   evaluateSmokeBreadth,
+  failedTestFilesFromVitestJson,
   resolvePrePushBase,
   summarizeVitestList,
 } from '../../../scripts/lib/pre-push-scope.mjs';
@@ -85,5 +86,48 @@ describe('pre-push smoke scope helpers', () => {
     ].join('\n'));
 
     expect(summary).toEqual({ testCaseCount: 3, testFileCount: 2 });
+  });
+
+  it('extracts unique failed files from Vitest JSON output', () => {
+    const failed = failedTestFilesFromVitestJson(JSON.stringify({
+      testResults: [
+        {
+          name: '/repo/tests/unit/a.test.ts',
+          status: 'passed',
+          assertionResults: [{ status: 'passed' }],
+        },
+        {
+          name: '/repo/tests/unit/b.test.ts',
+          status: 'failed',
+          assertionResults: [{ status: 'failed' }],
+        },
+        {
+          name: '/repo/tests/unit/c.test.ts',
+          status: 'passed',
+          assertionResults: [{ status: 'failed' }],
+        },
+        {
+          name: '/repo/tests/unit/b.test.ts',
+          status: 'failed',
+          assertionResults: [{ status: 'failed' }],
+        },
+      ],
+    }), { cwd: '/repo' });
+
+    expect(failed).toEqual(['tests/unit/b.test.ts', 'tests/unit/c.test.ts']);
+  });
+
+  it('returns an empty list when Vitest JSON has no failed files', () => {
+    const failed = failedTestFilesFromVitestJson(JSON.stringify({
+      testResults: [
+        {
+          name: '/repo/tests/unit/a.test.ts',
+          status: 'passed',
+          assertionResults: [{ status: 'passed' }],
+        },
+      ],
+    }), { cwd: '/repo' });
+
+    expect(failed).toEqual([]);
   });
 });

--- a/upgrades/side-effects/prepush-smoke-failed-files-retry.md
+++ b/upgrades/side-effects/prepush-smoke-failed-files-retry.md
@@ -1,0 +1,82 @@
+# Side-Effects Review — Pre-push smoke failed-files retry
+
+**Version / slug:** `prepush-smoke-failed-files-retry`
+**Date:** `2026-05-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `instar-codey second-pass checklist`
+
+## Summary of the change
+
+This change keeps the existing pre-push smoke base resolver and breadth guard, then makes the smoke retry file-scoped. `scripts/pre-push-smoke.mjs` now writes a Vitest JSON report during the affected smoke run; if that run fails, it extracts unique failed test files and reruns only those files once. `scripts/lib/pre-push-scope.mjs` owns the failed-file extraction helper, `tests/unit/scripts/pre-push-scope.test.ts` covers the parsing behavior, and `.husky/pre-push` no longer retries the whole smoke command after the smoke runner has handled its own retry. The full push-suite path keeps its previous whole-command retry behavior.
+
+## Decision-point inventory
+
+- `scripts/pre-push-smoke.mjs#runAffectedSmoke` — add — decides whether a failed smoke run has a trustworthy failed-file list and performs one focused retry.
+- `scripts/lib/pre-push-scope.mjs#failedTestFilesFromVitestJson` — add — extracts failed test file names from Vitest JSON output.
+- `.husky/pre-push` — modify — decides whether retry is owned by the smoke runner or by the outer hook loop.
+
+---
+
+## 1. Over-block
+
+The new JSON parser can fail to identify failed files if Vitest changes its JSON shape or the report file is not written. In that case the smoke runner preserves the original failure rather than passing the push. That can leave a developer with a normal failed smoke run instead of a focused retry, but it does not create a new block beyond the failure already observed.
+
+A file can be retried even if only one test case inside it failed. That is intentional: file-scoped retry avoids needing brittle test-name parsing while still shrinking the second run substantially.
+
+## 2. Under-block
+
+If a test passes on focused retry after failing in the affected-set run, the hook passes. That is the existing retry semantics applied more narrowly. A real ordering or cross-file interaction could be masked by retrying only the failed file, but PR CI remains the full authority and will run the broader matrix before merge.
+
+The change does not detect failures outside Vitest's affected-test selection. That limitation already exists in local smoke and is explicitly bounded by CI.
+
+## 3. Level-of-abstraction fit
+
+The failed-file parser is at the right layer: it consumes Vitest's structured report instead of scraping terminal prose. The retry decision lives in the smoke runner because that runner has the selected base, first-run result, and report file path. The outer Husky hook stays as the orchestration wrapper and still owns the full-suite retry path.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [x] Not applicable to conversational/product judgment — this is local developer-tooling retry control.
+
+The logic has local authority over which smoke files to retry, but it does not judge user intent, message meaning, external operations, or product behavior. It is deterministic process tooling. When the structured signal is unavailable, it fails conservatively by preserving the original failure.
+
+## 5. Interactions
+
+- **Shadowing:** The smoke runner's focused retry replaces the outer hook's whole-smoke retry only for `npm run test:smoke`. The full push-suite path is unchanged.
+- **Double-fire:** The outer hook now runs the smoke command once, so the focused retry cannot be followed by a whole affected-set retry from the wrapper.
+- **Races:** The JSON report is written into a per-run temporary directory and deleted in `finally`. No persistent state is shared across pushes.
+- **Feedback loops:** No runtime state feeds back into future runs. The retry list is computed only from the current Vitest report.
+
+## 6. External surfaces
+
+This affects local developers and agents pushing Instar branches. Terminal output changes when the first smoke attempt fails: the hook now prints the failed files being retried. CI, GitHub checks, Telegram, dashboard behavior, persisted ledgers, and installed-agent runtime behavior are unchanged.
+
+## 7. Rollback cost
+
+Rollback is a pure code revert of `.husky/pre-push`, `scripts/pre-push-smoke.mjs`, `scripts/lib/pre-push-scope.mjs`, the focused parser tests, and this artifact/spec pair. No data migration, agent state repair, or user notification is required. The regression during rollback would be returning to whole affected-set retry for local smoke failures.
+
+## Conclusion
+
+The review found one real tradeoff: a focused retry can pass after a cross-file interaction fails in the first affected run. That is acceptable for local smoke because CI is the authority and the first failure remains visible in the terminal output. The change is clear to ship with parser tests, a Vitest JSON compatibility probe, and the instar-dev gate.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** instar-codey second-pass checklist
+**Independent read of the artifact:** concur
+
+The second pass agrees that this is local developer-tooling behavior, not a product/message authority. The full-suite authority boundary remains CI, and malformed report handling is conservative.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/scripts/pre-push-scope.test.ts`
+- `scripts/pre-push-smoke.mjs`
+- `scripts/lib/pre-push-scope.mjs`
+- Manual Vitest 2 JSON reporter probe using a temporary failing test file; report shape confirmed as `testResults[].name/status/assertionResults[]`.


### PR DESCRIPTION
## Summary
- keep the pre-push smoke affected-set run as the first attempt, with normal Vitest output plus a JSON report
- on smoke failure, parse the report and rerun only the failed test files once
- keep the full push-suite path on its existing whole-command retry and add the required instar-dev spec/artifact

## Validation
- npx vitest run tests/unit/scripts/pre-push-scope.test.ts
- npm run test:smoke (7 changed files -> 1 test file / 8 cases, passed)
- npm run lint
- npm run build
- npm run check:upgrade-guide
- node scripts/instar-dev-precommit.js
- manual Vitest 2 JSON reporter probe with a temporary failing test file

## Notes
- node scripts/pre-push-gate.js currently fails on current main without a matching versioned side-effects artifact for the existing 1.3.76 guide; this reproduced in the prior clean #508 worktree and is unrelated to this PR. I pushed with CI=true INSTAR_PRE_PUSH_SKIP=1 so the local smoke gate being fixed here did not block publication; PR CI remains the authority.