### PR TITLE
Fix AutoUpdater restart activation deferrals

### DIFF
--- a/docs/specs/auto-updater-restart-activation-visibility.eli16.md
+++ b/docs/specs/auto-updater-restart-activation-visibility.eli16.md
@@ -1,0 +1,11 @@
+# AutoUpdater Restart Activation Visibility — Plain-English Overview
+
+Instar agents update in two steps. First, the AutoUpdater downloads the new package into the agent's private shadow install. Second, the running server has to restart so the process actually starts using those new files. The bug Justin hit was in the second step: the shadow install had moved forward, but the running server stayed old because restart gating kept seeing "healthy active sessions" forever.
+
+The important distinction is that not every running session is equally important. A live user conversation should be treated conservatively, because interrupting it can lose work or break trust. A recurring background job is different: if it is just sitting at its normal prompt between runs, it should not hold back a server restart that activates a fleet-wide fix. But if that job is currently executing real work, it should be allowed to finish.
+
+This change uses an existing ground truth instead of inventing a new guess. SessionManager already has a process-tree check called `hasActiveProcesses`. It ignores baseline processes and returns true only when the session has real non-baseline child work. The restart gate now applies that check only to sessions that are clearly background jobs, identified by `jobSlug`. If the process tree says the job session is idle, it does not block restart. If the process tree says it is active, or if the gate cannot check safely, the job still blocks.
+
+The change also makes the restart wait visible. AutoUpdater now persists a restart-wait object in its state file with the target version, when the wait first started, why activation is waiting, the current blockers, and the next retry time. Authenticated health and update status expose the same object, so "installed but not active" is no longer hidden in logs. The misleading "binary resolution mismatch" wording is replaced for intentional restart waits: the log now says the new version is installed but restart activation is intentionally waiting.
+
+What this does not do: it does not force restart interactive sessions, does not park or checkpoint user work, does not change the npm polling cadence, and does not change how the supervisor consumes restart requests. It is a narrow fix for safe background-job de-counting plus clear observability when activation is waiting.

--- a/docs/specs/auto-updater-restart-activation-visibility.md
+++ b/docs/specs/auto-updater-restart-activation-visibility.md
@@ -1,0 +1,44 @@
+---
+slug: auto-updater-restart-activation-visibility
+title: AutoUpdater restart activation visibility and safe background-job restart blockers
+date: 2026-05-29
+author: instar-codey
+review-convergence: telegram-scope-review-2026-05-29-topic-458
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 458 at 2026-05-29 01:46 PDT
+eli16-overview: auto-updater-restart-activation-visibility.eli16.md
+---
+
+# Spec — AutoUpdater Restart Activation Visibility
+
+## Problem
+
+AutoUpdater can install new bytes into an agent's shadow install while the running server stays on the old version indefinitely. The install path is healthy, but activation waits because restart gating counts long-lived recurring/background sessions as active blockers. The state file and health surfaces do not make the active restart wait obvious, and the log line frames the old-running/new-installed state as a binary resolution mismatch even when the wait is intentional.
+
+## Scope
+
+1. Keep interactive user sessions conservative. Do not add forced interruption, checkpointing, or parking for interactive work.
+2. Do not count recurring/background job sessions as restart blockers when they are safe to ignore: the session has a `jobSlug`, a tmux session name, and the existing `SessionManager.hasActiveProcesses(tmuxSession)` ground truth says no non-baseline work is running.
+3. Continue blocking while a background job is actively executing, or when process-tree activity cannot be checked.
+4. Persist restart-wait state in `state/auto-updater.json`: target version, first wait time, reason, current blockers, next retry, and update timestamp.
+5. Surface the persisted restart-wait state via AutoUpdater status and authenticated `/health`, and include it in `/updates/status`.
+6. Replace the misleading intentional-wait log wording with activation-pending wording.
+
+## Non-Goals
+
+- No bounded restart policy for interactive sessions.
+- No faster npm polling cadence.
+- No change to the supervisor restart request file shape.
+- No failed-files-only retry or unrelated dev-gate behavior.
+
+## Acceptance Criteria
+
+- Unit tests prove idle background job sessions do not block, actively executing background job sessions still block, and interactive sessions remain conservative.
+- AutoUpdater tests prove restart-wait details are persisted and loaded.
+- Server route tests prove authenticated health includes restart-wait details.
+- `npm run lint`, focused tests, build, upgrade-guide validation, and instar-dev precommit gate pass.
+
+## Rollback
+
+Revert the UpdateGate, AutoUpdater, route, and test changes and ship a patch. The only new persistent state is additive JSON under the AutoUpdater restart-wait status object; older versions ignore it, and rollback does not require data cleanup.

--- a/src/core/AutoUpdater.ts
+++ b/src/core/AutoUpdater.ts
@@ -96,6 +96,18 @@ export interface AutoUpdaterStatus {
   deferralElapsedMinutes: number;
   /** Max deferral before forced restart */
   maxDeferralHours: number;
+  /** Persisted restart deferral details, surfaced for "installed but not active" diagnosis */
+  restartDeferral: RestartDeferralState | null;
+}
+
+export interface RestartDeferralState {
+  active: boolean;
+  targetVersion: string;
+  firstDeferredAt: string;
+  reason: string;
+  currentBlockers: string[];
+  nextRetryAt: string | null;
+  updatedAt: string;
 }
 
 export class AutoUpdater {
@@ -124,6 +136,7 @@ export class AutoUpdater {
   private sessionManager: SessionManagerLike | null = null;
   private sessionMonitor: SessionMonitorLike | null = null;
   private deferralTimer: ReturnType<typeof setTimeout> | null = null;
+  private restartDeferral: RestartDeferralState | null = null;
 
   // Loop prevention — track version mismatch notifications to avoid spam
   private notifiedVersionMismatch: string | null = null;
@@ -249,6 +262,7 @@ export class AutoUpdater {
       deferralReason: gateStatus.deferralReason,
       deferralElapsedMinutes: gateStatus.deferralElapsedMinutes,
       maxDeferralHours: gateStatus.maxDeferralHours,
+      restartDeferral: this.restartDeferral ? { ...this.restartDeferral } : null,
     };
   }
 
@@ -329,6 +343,7 @@ export class AutoUpdater {
         this.pendingUpdate = null;
         this.pendingUpdateDetectedAt = null;
         this.coalescingUntil = null;
+        this.clearRestartDeferral();
         if (this.applyTimer) {
           clearTimeout(this.applyTimer);
           this.applyTimer = null;
@@ -343,20 +358,28 @@ export class AutoUpdater {
       // is broken (e.g., npx cache vs global install). Don't keep re-applying.
       // This prevents the update→restart→detect→update→restart loop.
       if (this.lastAppliedVersion === info.latestVersion) {
-        console.log(
-          `[AutoUpdater] Skipping — v${info.latestVersion} was already applied ` +
-          `(at ${this.lastApply}) but getInstalledVersion() still reports v${info.currentVersion}. ` +
-          `Binary resolution mismatch — manual restart may be needed.`
-        );
+        const deferral = this.getActiveRestartDeferral(info.latestVersion);
+        if (deferral) {
+          console.log(
+            `[AutoUpdater] Skipping — v${info.latestVersion} is installed in the shadow install ` +
+            `(at ${this.lastApply}) but the running process is still v${info.currentVersion}. ` +
+            `Restart activation is intentionally deferred: ${deferral.reason}.`
+          );
+        } else {
+          console.log(
+            `[AutoUpdater] Skipping — v${info.latestVersion} was already applied ` +
+            `(at ${this.lastApply}) but getInstalledVersion() still reports v${info.currentVersion}. ` +
+            `A restart has not activated the new version yet.`
+          );
+        }
         // Only notify once about the mismatch
         if (!this.notifiedVersionMismatch) {
           this.notifiedVersionMismatch = info.latestVersion;
           // Check if restart is actively deferred — if so, clarify that's the reason
-          const gateStatus = this.gate.getStatus();
-          if (gateStatus.deferring) {
+          if (deferral) {
             await this.notify(
               `v${info.latestVersion} is downloaded and waiting for a restart — still running v${info.currentVersion}. ` +
-              `Restart is being held back by ${gateStatus.deferralReason ?? 'active sessions'}. ` +
+              `Restart is being held back by ${deferral.reason}. ` +
               `I'll switch over automatically once they finish.`
             );
           } else {
@@ -604,6 +627,12 @@ export class AutoUpdater {
       const waitMs = this.msUntilRestartWindow();
       const waitH = Math.round(waitMs / 3600_000 * 10) / 10;
       console.log(`[AutoUpdater] Outside restart window (${this.config.restartWindow!.start}-${this.config.restartWindow!.end}). Deferring restart for v${newVersion} (~${waitH}h)`);
+      this.recordRestartDeferral({
+        targetVersion: newVersion,
+        reason: `outside restart window (${this.config.restartWindow!.start}-${this.config.restartWindow!.end})`,
+        currentBlockers: [],
+        nextRetryAt: new Date(Date.now() + waitMs).toISOString(),
+      });
 
       // Schedule a retry at the window start
       if (this.deferralTimer) clearTimeout(this.deferralTimer);
@@ -631,6 +660,9 @@ export class AutoUpdater {
 
     if (result.unresponsiveSessions?.length) {
       console.log(`[AutoUpdater] Unresponsive sessions (not blocking): ${result.unresponsiveSessions.join(', ')}`);
+    }
+    if (result.nonBlockingJobSessions?.length) {
+      console.log(`[AutoUpdater] Idle background job sessions (not blocking): ${result.nonBlockingJobSessions.join(', ')}`);
     }
 
     if (result.allowed) {
@@ -710,6 +742,7 @@ export class AutoUpdater {
       // of the v0.12.10 notification spam bug.
       this.lastRestartRequestedAt = new Date().toISOString();
       this.lastRestartRequestedVersion = newVersion;
+      this.clearRestartDeferral();
       this.saveState();
 
       await new Promise(r => setTimeout(r, 2000));
@@ -719,6 +752,12 @@ export class AutoUpdater {
 
     // Sessions are blocking — defer
     console.log(`[AutoUpdater] Restart deferred: ${result.reason}. Will retry in ${Math.round((result.retryInMs ?? 300_000) / 60_000)}m`);
+    this.recordRestartDeferral({
+      targetVersion: newVersion,
+      reason: result.reason ?? 'active sessions',
+      currentBlockers: result.blockingSessions ?? [],
+      nextRetryAt: new Date(Date.now() + (result.retryInMs ?? 300_000)).toISOString(),
+    });
 
     // Send warnings at thresholds
     if (this.gate.shouldSendFinalWarning()) {
@@ -967,6 +1006,7 @@ export class AutoUpdater {
         // Restart cooldown — prevents rapid restart cycling
         this.lastRestartRequestedAt = data.lastRestartRequestedAt ?? null;
         this.lastRestartRequestedVersion = data.lastRestartRequestedVersion ?? null;
+        this.restartDeferral = this.parseRestartDeferral(data.restartDeferral);
         // Don't restore coalescingUntil — the timer is in-memory only.
         // On restart, if there's still a pendingUpdate, the next tick()
         // will re-detect it and start a fresh coalescing timer.
@@ -994,6 +1034,7 @@ export class AutoUpdater {
       // Restart cooldown — prevents rapid restart cycling
       lastRestartRequestedAt: this.lastRestartRequestedAt,
       lastRestartRequestedVersion: this.lastRestartRequestedVersion,
+      restartDeferral: this.restartDeferral,
       savedAt: new Date().toISOString(),
     };
 
@@ -1005,5 +1046,55 @@ export class AutoUpdater {
     } catch {
       try { SafeFsExecutor.safeUnlinkSync(tmpPath, { operation: 'src/core/AutoUpdater.ts:786' }); } catch { /* ignore */ }
     }
+  }
+
+  private getActiveRestartDeferral(targetVersion?: string): RestartDeferralState | null {
+    if (!this.restartDeferral?.active) return null;
+    if (targetVersion && this.restartDeferral.targetVersion !== targetVersion) return null;
+    return this.restartDeferral;
+  }
+
+  private recordRestartDeferral(input: {
+    targetVersion: string;
+    reason: string;
+    currentBlockers: string[];
+    nextRetryAt: string | null;
+  }): void {
+    const existing = this.restartDeferral?.targetVersion === input.targetVersion
+      ? this.restartDeferral
+      : null;
+    this.restartDeferral = {
+      active: true,
+      targetVersion: input.targetVersion,
+      firstDeferredAt: existing?.firstDeferredAt ?? new Date().toISOString(),
+      reason: input.reason,
+      currentBlockers: input.currentBlockers,
+      nextRetryAt: input.nextRetryAt,
+      updatedAt: new Date().toISOString(),
+    };
+    this.saveState();
+  }
+
+  private clearRestartDeferral(): void {
+    this.restartDeferral = null;
+  }
+
+  private parseRestartDeferral(value: unknown): RestartDeferralState | null {
+    if (!value || typeof value !== 'object') return null;
+    const data = value as Partial<RestartDeferralState>;
+    if (!data.active || typeof data.targetVersion !== 'string' || typeof data.reason !== 'string') {
+      return null;
+    }
+    return {
+      active: true,
+      targetVersion: data.targetVersion,
+      firstDeferredAt: typeof data.firstDeferredAt === 'string' ? data.firstDeferredAt : new Date().toISOString(),
+      reason: data.reason,
+      currentBlockers: Array.isArray(data.currentBlockers)
+        ? data.currentBlockers.filter((b): b is string => typeof b === 'string')
+        : [],
+      nextRetryAt: typeof data.nextRetryAt === 'string' ? data.nextRetryAt : null,
+      updatedAt: typeof data.updatedAt === 'string' ? data.updatedAt : new Date().toISOString(),
+    };
   }
 }

--- a/src/core/UpdateGate.ts
+++ b/src/core/UpdateGate.ts
@@ -12,7 +12,11 @@
 
 export interface SessionInfo {
   name: string;
+  /** tmux session name; required for process-tree idle checks */
+  tmuxSession?: string;
   topicId?: number;
+  /** The job that spawned this session, if any */
+  jobSlug?: string;
 }
 
 export interface SessionHealthEntry {
@@ -30,6 +34,8 @@ export interface GateResult {
   blockingSessions?: string[];
   /** Sessions that are unresponsive (warned but not blocking) */
   unresponsiveSessions?: string[];
+  /** Background job sessions that were safe to ignore for restart gating */
+  nonBlockingJobSessions?: string[];
 }
 
 export interface UpdateGateConfig {
@@ -54,6 +60,8 @@ export interface UpdateGateStatus {
   maxDeferralHours: number;
   /** Reason for current deferral */
   deferralReason: string | null;
+  /** Sessions currently blocking restart */
+  blockingSessions: string[];
   /** Whether the first warning (T-30min) has been sent */
   firstWarningSent: boolean;
   /** Whether the final warning (T-5min) has been sent */
@@ -63,6 +71,7 @@ export interface UpdateGateStatus {
 /** Minimal interface for SessionManager — only what we need */
 export interface SessionManagerLike {
   listRunningSessions(): SessionInfo[];
+  hasActiveProcesses?(tmuxSession: string): boolean;
 }
 
 /** Minimal interface for SessionMonitor — only what we need */
@@ -76,6 +85,7 @@ export class UpdateGate {
   private config: Required<UpdateGateConfig>;
   private deferralStartedAt: number | null = null;
   private deferralReason: string | null = null;
+  private blockingSessions: string[] = [];
   private firstWarningSent = false;
   private firstWarningPending = false;
   private finalWarningSent = false;
@@ -114,8 +124,14 @@ export class UpdateGate {
 
     const activeSessions: string[] = [];
     const unresponsiveSessions: string[] = [];
+    const nonBlockingJobSessions: string[] = [];
 
     for (const session of sessions) {
+      if (this.isSafeIdleJobSession(session, sessionManager)) {
+        nonBlockingJobSessions.push(session.name);
+        continue;
+      }
+
       const h = healthMap.get(session.name);
       if (!h) {
         // No health data — be conservative, treat as active
@@ -134,6 +150,7 @@ export class UpdateGate {
       return {
         allowed: true,
         unresponsiveSessions: unresponsiveSessions.length > 0 ? unresponsiveSessions : undefined,
+        nonBlockingJobSessions: nonBlockingJobSessions.length > 0 ? nonBlockingJobSessions : undefined,
       };
     }
 
@@ -147,6 +164,7 @@ export class UpdateGate {
     const remainingMs = maxDeferralMs - elapsedMs;
 
     this.deferralReason = `${activeSessions.length} active session(s): ${activeSessions.join(', ')}`;
+    this.blockingSessions = activeSessions;
 
     // Max deferral exceeded — but only force restart if no HEALTHY sessions.
     // Active, healthy sessions should NEVER be killed for an update.
@@ -174,7 +192,15 @@ export class UpdateGate {
       retryInMs: this.config.retryIntervalMs,
       blockingSessions: activeSessions,
       unresponsiveSessions: unresponsiveSessions.length > 0 ? unresponsiveSessions : undefined,
+      nonBlockingJobSessions: nonBlockingJobSessions.length > 0 ? nonBlockingJobSessions : undefined,
     };
+  }
+
+  private isSafeIdleJobSession(session: SessionInfo, sessionManager: SessionManagerLike): boolean {
+    if (!session.jobSlug || !session.tmuxSession || !sessionManager.hasActiveProcesses) {
+      return false;
+    }
+    return !sessionManager.hasActiveProcesses(session.tmuxSession);
   }
 
   /**
@@ -188,6 +214,7 @@ export class UpdateGate {
       deferralElapsedMinutes: Math.round(elapsedMs / 60_000),
       maxDeferralHours: this.config.maxDeferralHours,
       deferralReason: this.deferralReason,
+      blockingSessions: this.blockingSessions,
       firstWarningSent: this.firstWarningSent,
       finalWarningSent: this.finalWarningSent,
     };
@@ -223,6 +250,7 @@ export class UpdateGate {
   reset(): void {
     this.deferralStartedAt = null;
     this.deferralReason = null;
+    this.blockingSessions = [];
     this.firstWarningSent = false;
     this.firstWarningPending = false;
     this.finalWarningSent = false;

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-28T08:18:59.110Z",
-  "instarVersion": "1.3.56",
+  "generatedAt": "2026-05-29T08:55:09.055Z",
+  "instarVersion": "1.3.78",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -409,7 +409,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -417,7 +417,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -425,7 +425,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -433,7 +433,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -441,7 +441,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -449,7 +449,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -457,7 +457,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -465,7 +465,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -473,7 +473,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -481,7 +481,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -489,7 +489,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -497,7 +497,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -505,7 +505,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -513,7 +513,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -521,7 +521,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -529,7 +529,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -537,7 +537,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -545,7 +545,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -553,7 +553,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -561,7 +561,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -569,7 +569,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -577,7 +577,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -585,7 +585,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -593,7 +593,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -601,7 +601,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -609,7 +609,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -617,7 +617,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -625,7 +625,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -633,7 +633,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -641,7 +641,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -649,7 +649,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -657,7 +657,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -665,7 +665,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -673,7 +673,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -681,7 +681,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -689,7 +689,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -697,7 +697,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -705,7 +705,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -713,7 +713,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -721,7 +721,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -729,7 +729,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -737,7 +737,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -745,7 +745,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -761,7 +761,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "83556e7d3550fd59ede03ed0df1ce18ddcbee59e0eb5649f9c104536d0aeb0fe",
+      "contentHash": "ebfff1d513782dbd9f087ba44305986336e4daa3c0c5ee0a70ccf9a2bbacb4bd",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1457,7 +1457,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "3c346b47c843bc5bd1d3c04a14d384727fd4669d1e83a83dc958ae18d5dccbc3",
+      "contentHash": "24636c91006739740344ff9c9c566f4d6131f52b0b9bbb8f5bec17768954cec7",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1465,7 +1465,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "a689041288c39070fd0d13362193bd4335367cb5a1db5458e3f73a6295b6e4c7",
+      "contentHash": "abb9f617bbb0568510470625c390bee45604b421cf48f6fda263c5e8c311f5d9",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {
@@ -1473,7 +1473,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/AutoUpdater.ts",
-      "contentHash": "54bf74ad97fa1b0a32cbada911454a023abab6717ec34ff3762516255ea2b306",
+      "contentHash": "bf97e19c12e7ce6ce21c69b49bdd94edebc155e5be2f16e38933a0067f41b3f5",
       "since": "2025-01-01"
     },
     "subsystem:auto-dispatcher": {
@@ -1489,7 +1489,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "f30e12b40a5234a4f4d8c64bbfcec20c4aa04b52cbd1a17069fc24de84bbef96",
+      "contentHash": "cf0c9bfcfa78083bb0a5f6cd2e0f1f175b16204178f373c95cca674e33eae52a",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {
@@ -1497,7 +1497,7 @@
       "type": "subsystem",
       "domain": "scheduling",
       "sourcePath": "src/scheduler/JobScheduler.ts",
-      "contentHash": "91e02d0321467469a91ff42df2c5138ef28e21273ae85d82d57b20c4a73cec92",
+      "contentHash": "f490bc91cd9bac62329fd66152225d8f90549cb167909ceea349d1e3a5323b96",
       "since": "2025-01-01"
     },
     "subsystem:project-mapper": {
@@ -1529,7 +1529,7 @@
       "type": "subsystem",
       "domain": "monitoring",
       "sourcePath": "src/monitoring/OrphanProcessReaper.ts",
-      "contentHash": "5d1a3a2b01fef05b741a0e527130026c8c565ee73ba60e97f0d3bcc5abe179c1",
+      "contentHash": "40855b07f6b43a41c23e35b1b476582a3a1b00190b726befb1a184d32245b7ae",
       "since": "2025-01-01"
     },
     "subsystem:semantic-memory": {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1307,6 +1307,17 @@ export function createRoutes(ctx: RouteContext): Router {
         heapUsed: Math.round(mem.heapUsed / 1024 / 1024),
         heapTotal: Math.round(mem.heapTotal / 1024 / 1024),
       };
+      if (ctx.autoUpdater) {
+        const auto = ctx.autoUpdater.getStatus();
+        base.autoUpdater = {
+          lastCheck: auto.lastCheck,
+          lastApply: auto.lastApply,
+          lastAppliedVersion: auto.lastAppliedVersion,
+          pendingUpdate: auto.pendingUpdate,
+          restartDeferral: auto.restartDeferral,
+          lastError: auto.lastError,
+        };
+      }
 
       // System-wide memory state (prefer MemoryPressureMonitor's vm_stat-based
       // calculation on macOS — os.freemem() only counts "Pages free" and ignores
@@ -7992,6 +8003,7 @@ export function createRoutes(ctx: RouteContext): Router {
         deferralReason: auto.deferralReason,
         deferralElapsedMinutes: auto.deferralElapsedMinutes,
         maxDeferralHours: auto.maxDeferralHours,
+        restartDeferral: auto.restartDeferral,
         lastCheck: auto.lastCheck,
         lastApply: auto.lastApply,
         lastAppliedVersion: auto.lastAppliedVersion,

--- a/tests/unit/AutoUpdater.test.ts
+++ b/tests/unit/AutoUpdater.test.ts
@@ -196,6 +196,37 @@ describe('AutoUpdater', () => {
 
       expect(updater.getStatus().lastCheck).toBeNull();
     });
+
+    it('loads persisted restart deferral details', () => {
+      const stateFile = path.join(tmpDir, 'state', 'auto-updater.json');
+      fs.writeFileSync(stateFile, JSON.stringify({
+        restartDeferral: {
+          active: true,
+          targetVersion: '1.3.78',
+          firstDeferredAt: '2026-05-29T08:00:00.000Z',
+          reason: '1 active session(s): topic-458',
+          currentBlockers: ['topic-458'],
+          nextRetryAt: '2026-05-29T08:05:00.000Z',
+          updatedAt: '2026-05-29T08:00:00.000Z',
+        },
+      }));
+
+      const updater = new AutoUpdater(
+        createMockUpdateChecker(),
+        createMockState(),
+        tmpDir,
+      );
+
+      expect(updater.getStatus().restartDeferral).toEqual({
+        active: true,
+        targetVersion: '1.3.78',
+        firstDeferredAt: '2026-05-29T08:00:00.000Z',
+        reason: '1 active session(s): topic-458',
+        currentBlockers: ['topic-458'],
+        nextRetryAt: '2026-05-29T08:05:00.000Z',
+        updatedAt: '2026-05-29T08:00:00.000Z',
+      });
+    });
   });
 
   describe('loop guard', () => {
@@ -249,6 +280,59 @@ describe('AutoUpdater', () => {
   });
 
   describe('gatedRestart notification dedup', () => {
+    it('persists restart deferral details when active sessions block activation', async () => {
+      const stateFile = path.join(tmpDir, 'state', 'auto-updater.json');
+
+      const mockChecker = createMockUpdateChecker({
+        check: vi.fn().mockResolvedValue({
+          currentVersion: '0.9.8',
+          latestVersion: '0.9.9',
+          updateAvailable: true,
+          checkedAt: new Date().toISOString(),
+        }),
+        applyUpdate: vi.fn().mockResolvedValue({
+          success: true,
+          previousVersion: '0.9.8',
+          newVersion: '0.9.9',
+          message: 'Updated',
+          restartNeeded: true,
+          healthCheck: 'skipped',
+        }),
+      });
+
+      const mockSessionManager = {
+        listRunningSessions: vi.fn().mockReturnValue([{ name: 'topic-458', topicId: 458 }]),
+      };
+      const mockSessionMonitor = {
+        getStatus: vi.fn().mockReturnValue({
+          sessionHealth: [{ sessionName: 'topic-458', topicId: 458, status: 'healthy', idleMinutes: 0 }],
+        }),
+      };
+
+      const updater = new AutoUpdater(
+        mockChecker,
+        createMockState(),
+        tmpDir,
+        { autoApply: true, applyDelayMinutes: 0 },
+      );
+      updater.setSessionDeps(mockSessionManager as any, mockSessionMonitor as any);
+      updater.start();
+
+      await vi.advanceTimersByTimeAsync(11_000);
+      updater.stop();
+
+      const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+      expect(state.restartDeferral).toMatchObject({
+        active: true,
+        targetVersion: '0.9.9',
+        reason: '1 active session(s): topic-458',
+        currentBlockers: ['topic-458'],
+      });
+      expect(state.restartDeferral.firstDeferredAt).toBeTruthy();
+      expect(state.restartDeferral.nextRetryAt).toBeTruthy();
+      expect(updater.getStatus().restartDeferral?.currentBlockers).toEqual(['topic-458']);
+    });
+
     it('persists lastNotifiedRestartVersion to state file before restart', async () => {
       // This is the root cause of the v0.12.10 notification spam:
       // gatedRestart() set lastNotifiedRestartVersion in memory but never

--- a/tests/unit/UpdateGate.test.ts
+++ b/tests/unit/UpdateGate.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { UpdateGate } from '../../src/core/UpdateGate.js';
+
+describe('UpdateGate', () => {
+  it('does not block restart on idle background job sessions when process tree is idle', () => {
+    const gate = new UpdateGate();
+    const result = gate.canRestart({
+      listRunningSessions: () => [
+        { name: 'job-commitment-detection', tmuxSession: 'instar-job-commitment-detection', jobSlug: 'commitment-detection' },
+      ],
+      hasActiveProcesses: () => false,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.nonBlockingJobSessions).toEqual(['job-commitment-detection']);
+    expect(gate.getStatus().blockingSessions).toEqual([]);
+  });
+
+  it('still blocks restart while a background job is actively executing', () => {
+    const gate = new UpdateGate();
+    const result = gate.canRestart({
+      listRunningSessions: () => [
+        { name: 'job-commitment-detection', tmuxSession: 'instar-job-commitment-detection', jobSlug: 'commitment-detection' },
+      ],
+      hasActiveProcesses: () => true,
+    }, {
+      getStatus: () => ({
+        sessionHealth: [
+          { sessionName: 'job-commitment-detection', topicId: 0, status: 'healthy', idleMinutes: 0 },
+        ],
+      }),
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.blockingSessions).toEqual(['job-commitment-detection']);
+    expect(gate.getStatus().blockingSessions).toEqual(['job-commitment-detection']);
+  });
+
+  it('keeps interactive sessions conservative even when they have no active child process', () => {
+    const gate = new UpdateGate();
+    const result = gate.canRestart({
+      listRunningSessions: () => [
+        { name: 'topic-458', tmuxSession: 'instar-topic-458' },
+      ],
+      hasActiveProcesses: () => false,
+    }, {
+      getStatus: () => ({
+        sessionHealth: [
+          { sessionName: 'topic-458', topicId: 458, status: 'healthy', idleMinutes: 0 },
+        ],
+      }),
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.blockingSessions).toEqual(['topic-458']);
+  });
+});

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -83,6 +83,49 @@ describe('AgentServer', () => {
       expect(res.status).toBe(200);
       expect(res.body.node).toBe(process.version);
     });
+
+    it('includes auto-updater restart deferral details when configured', async () => {
+      const localProject = createTempProject();
+      const localServer = new AgentServer({
+        config: fakeConfig,
+        sessionManager: createMockSessionManager() as any,
+        state: localProject.state,
+        autoUpdater: {
+          getStatus: () => ({
+            running: true,
+            lastCheck: '2026-05-29T08:00:00.000Z',
+            lastApply: '2026-05-29T08:01:00.000Z',
+            lastAppliedVersion: '1.3.78',
+            config: {},
+            pendingUpdate: null,
+            lastError: null,
+            coalescingUntil: null,
+            pendingUpdateDetectedAt: null,
+            deferralReason: '1 active session(s): topic-458',
+            deferralElapsedMinutes: 7,
+            maxDeferralHours: 4,
+            restartDeferral: {
+              active: true,
+              targetVersion: '1.3.78',
+              firstDeferredAt: '2026-05-29T08:01:00.000Z',
+              reason: '1 active session(s): topic-458',
+              currentBlockers: ['topic-458'],
+              nextRetryAt: '2026-05-29T08:06:00.000Z',
+              updatedAt: '2026-05-29T08:01:00.000Z',
+            },
+          }),
+        } as any,
+      });
+
+      const res = await request(localServer.getApp()).get('/health');
+      localProject.cleanup();
+
+      expect(res.status).toBe(200);
+      expect(res.body.autoUpdater.restartDeferral).toMatchObject({
+        targetVersion: '1.3.78',
+        currentBlockers: ['topic-458'],
+      });
+    });
   });
 
   describe('GET /status', () => {

--- a/upgrades/side-effects/auto-updater-restart-activation-visibility.md
+++ b/upgrades/side-effects/auto-updater-restart-activation-visibility.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — AutoUpdater restart activation visibility
+
+**Version / slug:** `auto-updater-restart-activation-visibility`
+**Date:** `2026-05-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Justin review requested in PR`
+
+## Summary of the change
+
+This change narrows AutoUpdater restart blockers and makes activation waits observable. `src/core/UpdateGate.ts` now ignores a running job session only when it has a `jobSlug`, a tmux session name, and `SessionManager.hasActiveProcesses(tmuxSession)` says no real non-baseline process is running. `src/core/AutoUpdater.ts` persists a restart-wait object with target version, first wait time, reason, blockers, next retry, and updated time. `src/server/routes.ts` surfaces that object on authenticated `/health` and `/updates/status`. Tests cover safe idle jobs, active jobs, interactive session conservatism, AutoUpdater state persistence, and health output.
+
+## Decision-point inventory
+
+- `UpdateGate.canRestart` — modify — decides whether an update-driven server restart can proceed now or must wait.
+- `AutoUpdater.gatedRestart` — modify — records and clears restart-wait state around the existing restart decision.
+- `GET /health` and `GET /updates/status` — modify — surface restart-wait state; no blocking authority.
+
+---
+
+## 1. Over-block
+
+The main remaining over-block is intentional: interactive sessions still block when the monitor reports them healthy, even if a process-tree check would say no active child work. Justin explicitly held the bounded restart policy for interactive sessions, so this PR does not relax that path. Background job sessions also still block when `hasActiveProcesses` is unavailable or fails, because the safe-idle proof is missing.
+
+---
+
+## 2. Under-block
+
+A background job could be incorrectly treated as idle if `hasActiveProcesses` misses a real work process. That risk already exists anywhere the process-tree ground truth is used, but this PR limits reliance to sessions that are explicitly job-spawned and still fails closed when the method is unavailable. A job that is about to start work but has not spawned a non-baseline child yet may be restarted; that is acceptable for the requested "idle/between-runs" class and no different from restarting before a scheduled job fires.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The restart decision belongs in `UpdateGate`, which is already the authority for update-driven restart gating. This change does not add a parallel gate. It feeds the existing authority a stronger low-level signal: the already-established process-tree active-work check. AutoUpdater owns persistence and user/operator visibility, so persisting `restartDeferral` there is the right layer.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] Yes, with brittle logic — STOP. Reshape the design. Brittle detectors must not own block authority.
+
+`hasActiveProcesses` is a detector-like primitive, but it does not become a standalone blocker or allower. Its output is consumed by the existing restart authority in `UpdateGate`, and only for job sessions where the distinction between idle and executing is mechanically meaningful.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The safe-idle job check runs before session-health classification, but only for `jobSlug` sessions with process-tree proof. It does not shadow interactive session health.
+- **Double-fire:** Persisting `restartDeferral` writes the same AutoUpdater state file already used for updater state. It does not write restart-requested signals and cannot trigger a restart by itself.
+- **Races:** The persisted restart-wait object is best-effort observability. If a retry fires while status is being read, readers may see the previous `nextRetryAt` until the next state save; this is acceptable and self-correcting.
+- **Feedback loops:** The old "already applied" loop guard remains. The log/notification language now distinguishes intentional restart waits from generic activation lag, reducing false manual-restart diagnoses.
+
+---
+
+## 6. External surfaces
+
+Authenticated `/health`, `/updates/status`, and `/updates/auto` now expose additive `restartDeferral` fields. Existing callers that ignore unknown fields continue to work. The state file gains an additive `restartDeferral` object; older versions ignore it. Other agents benefit after update activation because idle background jobs stop holding restarts forever, but active user sessions remain protected.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a hot-fix release that reverts the code and tests. No database migration or state repair is needed. The only persistent addition is JSON in `state/auto-updater.json`; leaving it behind is harmless because older code ignores unknown fields.
+
+---
+
+## Conclusion
+
+The change is narrow and matches the approved scope: safe background-job de-counting plus restart-wait observability. The design explicitly avoids the held interactive-session policy and keeps restart authority centralized in `UpdateGate`. Clear to ship for PR review.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Justin review requested in PR
+**Independent read of the artifact: pending external review**
+
+This touches restart gating, so the PR is intentionally opened for Justin review before merge. I did not implement the held interactive-session restart policy.
+
+---
+
+## Evidence pointers
+
+- `npm test -- --run tests/unit/UpdateGate.test.ts tests/unit/AutoUpdater.test.ts tests/unit/server.test.ts`
+- `npm run lint`
+- `npm run build`
+- `npm run check:upgrade-guide`
+- `node scripts/instar-dev-precommit.js`


### PR DESCRIPTION
## Summary

- ignores background job sessions as restart blockers only when `hasActiveProcesses(tmuxSession)` proves they are idle
- persists AutoUpdater restart-wait state with target version, blockers, reason, first wait time, and next retry
- surfaces restart-wait state through authenticated `/health`, `/updates/status`, and AutoUpdater status
- updates intentional activation-wait logging so it no longer reports this as a binary-resolution mismatch

## Validation

- `npm test -- --run tests/unit/UpdateGate.test.ts tests/unit/AutoUpdater.test.ts tests/unit/server.test.ts`
- `npm run lint`
- `npm run build`
- `npm run check:upgrade-guide`
- `node scripts/instar-dev-precommit.js`

## Notes

Pushed with `CI=1 INSTAR_PRE_PUSH_SKIP=1` because the local pre-push hook still has the current-main versioned side-effects artifact mismatch for the already-published `1.3.78` guide; the smoke tier was intentionally skipped per instruction while this hook path is under active repair. PR CI remains the authority.

I did not implement bounded restarts for interactive sessions.
