### PR TITLE
fix: include related worktrees in project map

### DIFF
--- a/.instar/instar-dev-traces/2026-05-29T11-21-47-072Z-project-map-related-worktrees-40a88c55.json
+++ b/.instar/instar-dev-traces/2026-05-29T11-21-47-072Z-project-map-related-worktrees-40a88c55.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "sessionId": "c001de80-4f1a-4717-aafe-a4362d76b0ef",
+  "timestamp": "2026-05-29T11:21:47.072Z",
+  "artifactPath": "upgrades/side-effects/project-map-related-worktrees.md",
+  "artifactSha256": "49c6dbcc8a05f0edcd6bde85b15ee15d8bf52e2e5fad5b4edd3187d1614c18e6",
+  "specPath": "docs/specs/project-map-related-worktrees.md",
+  "coveredFiles": [
+    "docs/specs/project-map-related-worktrees.eli16.md",
+    "docs/specs/project-map-related-worktrees.md",
+    "src/core/ProjectMapper.ts",
+    "src/data/builtin-manifest.json",
+    "src/index.ts",
+    "tests/unit/ProjectMapper.test.ts",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/project-map-related-worktrees.md"
+  ],
+  "phase": "complete",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/project-map-related-worktrees.eli16.md
+++ b/docs/specs/project-map-related-worktrees.eli16.md
@@ -1,0 +1,13 @@
+# ELI16: Project Map Related Worktrees
+
+The Project Map is supposed to help an agent understand the shape of the place it is working in. That matters because an agent can easily make a wrong edit if it thinks it is in one project while the real work is happening somewhere nearby.
+
+When I tested the map from this topic, the endpoint itself worked: the compact view loaded, and refresh produced a fresh map. But the content was only partly useful. It described the small Codey wrapper project, which has a few files and two visible top-level directories. That was technically true, but it missed the important part of this topic's workspace: the Instar source worktrees under Codey's agent home. Those worktrees are where the real development PRs are happening.
+
+The fix is to keep the existing project map and add a small related-worktrees section. This is deliberately not a general file crawler. It does not scan the whole home directory and it does not try to map every possible repository on the machine. It only looks in the conventional per-agent worktree area for this project, plus any explicit roots passed by code or tests. For each direct child that is actually a git worktree, it records the worktree name, path, branch, remote, and a short list of high-signal directories such as source, tests, docs, dashboard, scripts, upgrades, skills, and packages.
+
+The compact map then becomes more useful without becoming noisy. It can still say what project the agent is bound to, but it can also say "there are related worktrees" and name the most relevant ones. That is enough for spatial awareness: the agent can see that the tiny wrapper project is not the whole working surface.
+
+This change is read-only. It does not create worktrees, clean worktrees, or enforce placement rules. Those jobs belong to the worktree manager and worktree detector. Project Map only reports the nearby worktree context so the user and agent can orient themselves quickly.
+
+While testing this area, we also found that the headline file count could count hidden state or worktree directories even though the visible top-level directory list hides those directories. That creates confusing output: the map can say there are hundreds of thousands of files while only showing a few normal project directories. The same PR makes the total count follow the same hidden-directory rule as the breakdown, so the headline number and the visible list describe the same project surface.

--- a/docs/specs/project-map-related-worktrees.md
+++ b/docs/specs/project-map-related-worktrees.md
@@ -1,0 +1,46 @@
+---
+title: Project Map Related Worktrees
+review-convergence: 2026-05-29T11:18:00Z
+approved: true
+eli16-overview: project-map-related-worktrees.eli16.md
+---
+
+# Project Map Related Worktrees
+
+## Problem
+
+The Project Map endpoint accurately describes the bound project directory, but for a project-bound development agent that keeps Instar source work in the conventional agent worktree area, the compact map can be misleadingly small. In Codey's case it reported the wrapper project and two top-level directories, while the active Instar development workspace lived in nearby source worktrees.
+
+That is a spatial-awareness UX problem. The map is meant to answer "where am I and what does this project look like?" For development agents, nearby worktrees are part of the real workspace the agent must reason about.
+
+There is a related count-consistency problem in the same mapper. The top-level directory breakdown intentionally hides dot-directories, but the headline total could still recurse into hidden state or worktree directories at the project root. On older agents with large transcript/state directories, that makes the headline file count much larger than the visible breakdown and therefore hard to interpret.
+
+## Proposed Change
+
+Extend `ProjectMapper` with a narrow related-worktree summary:
+
+- keep the existing project-root map unchanged;
+- discover conventional agent worktrees under the matching agent home worktree directory;
+- allow tests and direct callers to pass explicit related-worktree roots;
+- summarize each related git worktree by name, path, branch, remote, and high-signal top-level directories;
+- show a concise "Related Worktrees" section in markdown and compact output;
+- make the headline total skip hidden directories consistently with the visible directory breakdown.
+
+The mapper must not crawl arbitrary home directories. It should only inspect configured roots plus the conventional per-agent worktree root derived from the current project directory name.
+
+## Acceptance Criteria
+
+- `GET /project-map?format=compact` remains concise.
+- `POST /project-map/refresh` still writes the same project map files.
+- A project with no related worktree root keeps its previous output shape apart from an empty optional field.
+- A project with related git worktrees lists them in JSON, markdown, and compact output.
+- The summary includes enough information to identify active Instar source worktrees without enumerating thousands of files.
+- Hidden state/worktree directories do not inflate the headline total when they are omitted from the visible breakdown.
+
+## Decision Points
+
+This is a spatial-awareness enhancement, not a worktree manager or safety-policy change. It does not create, delete, or mutate worktrees. It only reads direct child git worktrees under a narrow root and reports a short summary.
+
+## Rollback
+
+Rollback is a normal revert. Existing project maps remain readable because the new field is optional and display helpers tolerate old saved maps that do not include it.

--- a/src/core/ProjectMapper.ts
+++ b/src/core/ProjectMapper.ts
@@ -15,7 +15,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
+import os from 'node:os';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
 
 export interface ProjectMapConfig {
@@ -29,6 +29,8 @@ export interface ProjectMapConfig {
   skipDirs?: string[];
   /** Max files to enumerate per directory (default: 50) */
   maxFilesPerDir?: number;
+  /** Additional roots containing related git worktrees to summarize */
+  relatedWorktreeRoots?: string[];
 }
 
 export interface ProjectMapEntry {
@@ -65,8 +67,23 @@ export interface ProjectMap {
   projectType: string;
   /** Deployment targets detected */
   deploymentTargets: string[];
+  /** Nearby worktrees that are part of the same agent workspace */
+  relatedWorktrees?: RelatedWorktreeSummary[];
   /** Generated at timestamp */
   generatedAt: string;
+}
+
+export interface RelatedWorktreeSummary {
+  /** Worktree directory name */
+  name: string;
+  /** Absolute path to the worktree */
+  path: string;
+  /** Current git branch */
+  gitBranch: string | null;
+  /** Git remote URL */
+  gitRemote: string | null;
+  /** High-signal top-level directories present in the worktree */
+  keyDirectories: string[];
 }
 
 const DEFAULT_SKIP_DIRS = new Set([
@@ -116,6 +133,7 @@ export class ProjectMapper {
       keyFiles: this.findKeyFiles(),
       projectType: this.detectProjectType(),
       deploymentTargets: this.detectDeploymentTargets(),
+      relatedWorktrees: this.findRelatedWorktrees(),
       generatedAt: new Date().toISOString(),
     };
   }
@@ -141,6 +159,7 @@ export class ProjectMapper {
    * Convert a project map to human-readable markdown for session injection.
    */
   toMarkdown(map: ProjectMap): string {
+    const relatedWorktrees = map.relatedWorktrees ?? [];
     const lines: string[] = [
       `# Project Map: ${map.projectName}`,
       '',
@@ -160,6 +179,10 @@ export class ProjectMapper {
       lines.push(`**Deployment Targets**: ${map.deploymentTargets.join(', ')}`);
     }
 
+    if (relatedWorktrees.length > 0) {
+      lines.push(`**Related Worktrees**: ${relatedWorktrees.length}`);
+    }
+
     lines.push('');
     lines.push('## Directory Structure');
     lines.push('');
@@ -177,6 +200,22 @@ export class ProjectMapper {
       }
     }
 
+    if (relatedWorktrees.length > 0) {
+      lines.push('');
+      lines.push('## Related Worktrees');
+      lines.push('');
+      for (const worktree of relatedWorktrees.slice(0, 12)) {
+        const branch = worktree.gitBranch ? ` [${worktree.gitBranch}]` : '';
+        const dirs = worktree.keyDirectories.length > 0
+          ? ` — ${worktree.keyDirectories.join(', ')}`
+          : '';
+        lines.push(`- **${worktree.name}/**${branch}${dirs}`);
+      }
+      if (relatedWorktrees.length > 12) {
+        lines.push(`- ... and ${relatedWorktrees.length - 12} more worktrees`);
+      }
+    }
+
     lines.push('');
     lines.push(`*Generated: ${map.generatedAt}*`);
 
@@ -189,6 +228,7 @@ export class ProjectMapper {
   getCompactSummary(map?: ProjectMap): string {
     const m = map || this.loadSavedMap();
     if (!m) return '';
+    const relatedWorktrees = m.relatedWorktrees ?? [];
 
     const lines: string[] = [
       `Project: ${m.projectName} (${m.projectType})`,
@@ -204,6 +244,10 @@ export class ProjectMapper {
     }
 
     lines.push(`Files: ${m.totalFiles} across ${m.directories.length} directories`);
+
+    if (relatedWorktrees.length > 0) {
+      lines.push(`Related worktrees: ${relatedWorktrees.length}`);
+    }
     lines.push('');
 
     // Top directories
@@ -213,6 +257,17 @@ export class ProjectMapper {
     }
     if (m.directories.length > 8) {
       lines.push(`  ... and ${m.directories.length - 8} more directories`);
+    }
+
+    for (const worktree of relatedWorktrees.slice(0, 5)) {
+      const branch = worktree.gitBranch ? ` [${worktree.gitBranch}]` : '';
+      const dirs = worktree.keyDirectories.length > 0
+        ? ` — ${worktree.keyDirectories.join(', ')}`
+        : '';
+      lines.push(`  worktree: ${worktree.name}${branch}${dirs}`);
+    }
+    if (relatedWorktrees.length > 5) {
+      lines.push(`  ... and ${relatedWorktrees.length - 5} more worktrees`);
     }
 
     return lines.join('\n');
@@ -412,6 +467,106 @@ export class ProjectMapper {
     return found;
   }
 
+  private findRelatedWorktrees(): RelatedWorktreeSummary[] {
+    const roots = this.findRelatedWorktreeRoots();
+    const byPath = new Map<string, RelatedWorktreeSummary>();
+
+    for (const root of roots) {
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(root, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+        const worktreePath = path.join(root, entry.name);
+        if (!this.isGitWorktree(worktreePath)) continue;
+        const realPath = this.realpathOrNull(worktreePath);
+        if (!realPath || byPath.has(realPath)) continue;
+
+        byPath.set(realPath, {
+          name: entry.name,
+          path: realPath,
+          gitBranch: this.detectGitBranchFor(realPath),
+          gitRemote: this.detectGitRemoteFor(realPath),
+          keyDirectories: this.findKeyDirectories(realPath),
+        });
+      }
+    }
+
+    return [...byPath.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private findRelatedWorktreeRoots(): string[] {
+    const roots = new Set<string>();
+
+    for (const configured of this.config.relatedWorktreeRoots ?? []) {
+      if (!configured.trim()) continue;
+      roots.add(path.resolve(configured));
+    }
+
+    const projectBasename = path.basename(this.config.projectDir);
+    roots.add(path.join(os.homedir(), '.instar', 'agents', projectBasename, '.worktrees'));
+
+    return [...roots]
+      .map((root) => this.realpathOrNull(root))
+      .filter((root): root is string => Boolean(root));
+  }
+
+  private isGitWorktree(dir: string): boolean {
+    return fs.existsSync(path.join(dir, '.git'));
+  }
+
+  private detectGitRemoteFor(dir: string): string | null {
+    try {
+      const result = SafeGitExecutor.readSync(['remote', 'get-url', 'JKHeadley'], { cwd: dir,
+        encoding: 'utf-8',
+        stdio: 'pipe', sourceTreeReadOk: true, operation: 'src/core/ProjectMapper.ts:related-remote-jkheadley' });
+      return result.trim() || null;
+    } catch {
+      try {
+        const result = SafeGitExecutor.readSync(['remote', 'get-url', 'origin'], { cwd: dir,
+          encoding: 'utf-8',
+          stdio: 'pipe', sourceTreeReadOk: true, operation: 'src/core/ProjectMapper.ts:related-remote-origin' });
+        return result.trim() || null;
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  private detectGitBranchFor(dir: string): string | null {
+    try {
+      const result = SafeGitExecutor.readSync(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: dir,
+        encoding: 'utf-8', sourceTreeReadOk: true,
+        stdio: 'pipe', operation: 'src/core/ProjectMapper.ts:related-branch' });
+      return result.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private findKeyDirectories(dir: string): string[] {
+    const priority = ['src', 'tests', 'docs', 'dashboard', 'scripts', 'upgrades', 'skills', 'packages'];
+    return priority.filter((name) => {
+      try {
+        return fs.statSync(path.join(dir, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  private realpathOrNull(target: string): string | null {
+    try {
+      return fs.realpathSync(target);
+    } catch {
+      return null;
+    }
+  }
+
   private countFiles(dir: string, depth: number): number {
     const maxDepth = this.config.maxDepth ?? 4;
     if (depth > maxDepth) return 0;
@@ -421,7 +576,7 @@ export class ProjectMapper {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
         if (this.skipDirs.has(entry.name)) continue;
-        if (entry.name.startsWith('.') && depth > 0) continue;
+        if (entry.isDirectory() && entry.name.startsWith('.')) continue;
 
         if (entry.isFile()) {
           count++;

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-29T10:58:17.221Z",
-  "instarVersion": "1.3.81",
+  "generatedAt": "2026-05-29T11:20:51.549Z",
+  "instarVersion": "1.3.82",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -1505,7 +1505,7 @@
       "type": "subsystem",
       "domain": "mapping",
       "sourcePath": "src/core/ProjectMapper.ts",
-      "contentHash": "383837d846ca206eb2c5baa1aeb4d19dd2edc15f11d502c8bc20fb99efb5898a",
+      "contentHash": "cb424f18c539d99522e9489059bab40b2f5118fb27885bffd8994b60b8e98b3b",
       "since": "2025-01-01"
     },
     "subsystem:degradation-reporter": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ export type {
 export type { MigrationResult as SecretMigrationResult } from './core/SecretMigrator.js';
 export { GitStateManager } from './core/GitStateManager.js';
 export { ProjectMapper } from './core/ProjectMapper.js';
-export type { ProjectMapConfig, ProjectMap, ProjectMapEntry } from './core/ProjectMapper.js';
+export type { ProjectMapConfig, ProjectMap, ProjectMapEntry, RelatedWorktreeSummary } from './core/ProjectMapper.js';
 export { CapabilityMapper } from './core/CapabilityMapper.js';
 export type { CapabilityMap, CapabilityDomain, Capability, CapabilityType, CapabilityStatus, Provenance, CapabilityMapperConfig, DriftReport } from './core/CapabilityMapper.js';
 export { ScopeVerifier } from './core/ScopeVerifier.js';

--- a/tests/unit/ProjectMapper.test.ts
+++ b/tests/unit/ProjectMapper.test.ts
@@ -19,6 +19,7 @@ import os from 'node:os';
 import { ProjectMapper } from '../../src/core/ProjectMapper.js';
 import type { ProjectMapConfig } from '../../src/core/ProjectMapper.js';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -31,6 +32,21 @@ function createTmpProject(): { projectDir: string; stateDir: string } {
 
 function makeConfig(projectDir: string, stateDir: string): ProjectMapConfig {
   return { projectDir, stateDir };
+}
+
+function createRelatedWorktree(root: string, name: string, branch = 'feature/test'): string {
+  const worktreeDir = path.join(root, name);
+  fs.mkdirSync(path.join(worktreeDir, 'src'), { recursive: true });
+  fs.mkdirSync(path.join(worktreeDir, 'tests'), { recursive: true });
+  fs.writeFileSync(path.join(worktreeDir, 'src', 'index.ts'), '');
+  SafeGitExecutor.execSync(['init'], { cwd: worktreeDir, stdio: 'ignore', operation: 'tests/unit/ProjectMapper.test.ts:git-init' });
+  SafeGitExecutor.execSync(['config', 'user.name', 'ProjectMapper Test'], { cwd: worktreeDir, stdio: 'ignore', operation: 'tests/unit/ProjectMapper.test.ts:git-config-name' });
+  SafeGitExecutor.execSync(['config', 'user.email', 'projectmapper@example.test'], { cwd: worktreeDir, stdio: 'ignore', operation: 'tests/unit/ProjectMapper.test.ts:git-config-email' });
+  SafeGitExecutor.execSync(['add', '.'], { cwd: worktreeDir, stdio: 'ignore', operation: 'tests/unit/ProjectMapper.test.ts:git-add' });
+  SafeGitExecutor.execSync(['commit', '-m', 'init'], { cwd: worktreeDir, stdio: 'ignore', operation: 'tests/unit/ProjectMapper.test.ts:git-commit' });
+  SafeGitExecutor.execSync(['checkout', '-b', branch], { cwd: worktreeDir, stdio: 'ignore', operation: 'tests/unit/ProjectMapper.test.ts:git-checkout' });
+  SafeGitExecutor.execSync(['remote', 'add', 'JKHeadley', 'https://github.com/JKHeadley/instar.git'], { cwd: worktreeDir, stdio: 'ignore', operation: 'tests/unit/ProjectMapper.test.ts:git-remote' });
+  return worktreeDir;
 }
 
 // ── Tests ────────────────────────────────────────────────────────
@@ -92,17 +108,21 @@ describe('ProjectMapper', () => {
       expect(map.totalFiles).toBeGreaterThanOrEqual(3);
     });
 
-    it('skips node_modules and .git directories', () => {
+    it('skips node_modules and hidden directories from total file counts', () => {
       fs.mkdirSync(path.join(projectDir, 'node_modules', 'some-pkg'), { recursive: true });
       fs.writeFileSync(path.join(projectDir, 'node_modules', 'some-pkg', 'index.js'), '');
       fs.mkdirSync(path.join(projectDir, '.git', 'objects'), { recursive: true });
       fs.writeFileSync(path.join(projectDir, '.git', 'objects', 'abc'), '');
+      fs.mkdirSync(path.join(projectDir, '.worktrees', 'feature', 'src'), { recursive: true });
+      fs.writeFileSync(path.join(projectDir, '.worktrees', 'feature', 'src', 'ignored.ts'), '');
+      fs.mkdirSync(path.join(projectDir, '.hidden-state'), { recursive: true });
+      fs.writeFileSync(path.join(projectDir, '.hidden-state', 'ignored.jsonl'), '');
       fs.writeFileSync(path.join(projectDir, 'real-file.ts'), '');
 
       const mapper = new ProjectMapper(makeConfig(projectDir, stateDir));
       const map = mapper.generate();
 
-      // Should not count node_modules or .git files
+      // Should not count dependency, git, or hidden state/worktree directories.
       expect(map.totalFiles).toBe(1); // Only real-file.ts
     });
 
@@ -219,6 +239,61 @@ describe('ProjectMapper', () => {
 
       expect(map.keyFiles).toContain('CLAUDE.md');
       expect(map.keyFiles).toContain('README.md');
+    });
+  });
+
+  describe('related worktree discovery', () => {
+    it('summarizes configured related worktree roots', () => {
+      const worktreesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'projmap-worktrees-'));
+      try {
+        const worktreeDir = createRelatedWorktree(worktreesRoot, 'project-map-workspace-awareness');
+
+        const mapper = new ProjectMapper({
+          ...makeConfig(projectDir, stateDir),
+          relatedWorktreeRoots: [worktreesRoot],
+        });
+        const map = mapper.generate();
+
+        const related = map.relatedWorktrees ?? [];
+        expect(related).toHaveLength(1);
+        expect(related[0]).toMatchObject({
+          name: 'project-map-workspace-awareness',
+          path: fs.realpathSync(worktreeDir),
+          gitBranch: 'feature/test',
+          gitRemote: 'https://github.com/JKHeadley/instar.git',
+        });
+        expect(related[0].keyDirectories).toEqual(['src', 'tests']);
+      } finally {
+        SafeFsExecutor.safeRmSync(worktreesRoot, {
+          recursive: true,
+          force: true,
+          operation: 'tests/unit/ProjectMapper.test.ts:related-worktrees-cleanup',
+        });
+      }
+    });
+
+    it('includes related worktrees in markdown and compact summaries', () => {
+      const worktreesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'projmap-worktrees-'));
+      try {
+        createRelatedWorktree(worktreesRoot, 'tokenledger-scanall-flake', 'codey/tokenledger-scanall-flake');
+
+        const mapper = new ProjectMapper({
+          ...makeConfig(projectDir, stateDir),
+          relatedWorktreeRoots: [worktreesRoot],
+        });
+        const map = mapper.generate();
+
+        expect(mapper.toMarkdown(map)).toContain('## Related Worktrees');
+        expect(mapper.toMarkdown(map)).toContain('tokenledger-scanall-flake/');
+        expect(mapper.getCompactSummary(map)).toContain('Related worktrees: 1');
+        expect(mapper.getCompactSummary(map)).toContain('worktree: tokenledger-scanall-flake');
+      } finally {
+        SafeFsExecutor.safeRmSync(worktreesRoot, {
+          recursive: true,
+          force: true,
+          operation: 'tests/unit/ProjectMapper.test.ts:summary-worktrees-cleanup',
+        });
+      }
     });
   });
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Project Map now includes a concise related-worktrees section when an agent has source worktrees in its conventional workspace. This fixes a dogfood issue where Codey's map was technically fresh and accurate for the small wrapper project, but omitted the Instar source worktrees where the real development work was happening. The headline file count also now skips hidden state/worktree directories consistently with the visible directory breakdown, so aged agents with large transcript/state folders do not get noisy inflated totals.
+
+## What to Tell Your User
+
+Project Map now gives me better spatial awareness when I’m developing through nearby source worktrees, and its headline file count is less likely to be inflated by hidden runtime state.
+
+## Summary of New Capabilities
+
+| Area | Capability |
+| --- | --- |
+| Project Map | Compact and markdown maps can show related agent worktrees when they exist. |
+| Spatial awareness | Development agents can see nearby source worktrees without scanning the whole machine. |
+| Count accuracy | Hidden state and worktree directories no longer inflate the headline project file count. |
+| Refresh safety | Agents without related worktrees keep the existing compact map behavior. |
+
+## Evidence
+
+- Unit coverage: `tests/unit/ProjectMapper.test.ts` verifies related worktree discovery and compact/markdown rendering.
+- Integration coverage: `tests/integration/coherence-routes.test.ts` verifies the Project Map API routes still serve JSON, markdown, compact, and refresh responses.

--- a/upgrades/side-effects/project-map-related-worktrees.md
+++ b/upgrades/side-effects/project-map-related-worktrees.md
@@ -1,0 +1,85 @@
+# Side-Effects Review — Project Map Related Worktrees
+
+**Version / slug:** `project-map-related-worktrees`
+**Date:** `2026-05-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required by tooling`
+
+## Summary of the change
+
+This change extends Project Map with a concise related-worktrees summary and makes the headline total file count skip hidden directories consistently with the visible top-level breakdown. The existing project-root map remains the primary output, and related git worktrees are discovered only from configured roots plus the conventional agent worktree directory derived from the project directory name.
+
+## Decision-point inventory
+
+- `ProjectMapper.generate()` — add optional related-worktree metadata to generated maps.
+- `ProjectMapper.toMarkdown()` and `getCompactSummary()` — display related worktrees when present.
+- `ProjectMapper.countFiles()` — skip hidden directories consistently at every depth so hidden state does not inflate the headline total.
+
+---
+
+## 1. Over-block
+
+No blocking behavior changes. This is read-only reporting.
+
+---
+
+## 2. Under-block
+
+No authorization or safety gate changes. The mapper does not make worktree placement decisions and does not suppress existing worktree detector findings.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Project Map already owns spatial awareness for the current workspace. Reporting nearby conventional worktrees belongs at this layer because it helps the agent understand the real working surface without coupling the session-start context to worktree-manager internals.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no conversational block/allow surface.
+
+The output is informational. It helps orientation but does not authorize edits or replace coherence checks.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** None. Worktree safety remains owned by the worktree manager and detector.
+- **Double-fire:** None. Refresh still writes one JSON map and one markdown map.
+- **Races:** A worktree can be created or removed while the map is generating. The mapper handles missing or unreadable entries by skipping them, preserving refresh reliability.
+- **Feedback loops:** Positive loop: agents should be less likely to overlook the source worktrees they are actively using.
+
+---
+
+## 6. External surfaces
+
+Users and agents will see a related-worktrees section in Project Map JSON, markdown, and compact output when conventional worktrees exist. Agents without such worktrees keep effectively the same map, except headline totals become less noisy if hidden state directories were previously included.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a normal code revert. Saved maps with the optional related-worktrees field remain harmless if older code ignores it.
+
+---
+
+## Conclusion
+
+The change is clear to ship. It fixes real spatial-awareness and count-consistency gaps found during Project Map dogfooding without widening the mapper into a broad filesystem scanner.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `not required by tooling`
+**Independent read of the artifact:** `not required`
+
+---
+
+## Evidence pointers
+
+- `tests/unit/ProjectMapper.test.ts`
+- `tests/integration/coherence-routes.test.ts`


### PR DESCRIPTION
## Summary
- add related worktree summaries to Project Map JSON, markdown, and compact output
- keep discovery narrow: explicit roots plus the conventional agent worktree root derived from the project name
- make the headline file count skip hidden directories consistently with the visible top-level breakdown

## Validation
- GET /project-map?format=compact and POST /project-map/refresh on Codey
- npx vitest run tests/unit/ProjectMapper.test.ts tests/integration/coherence-routes.test.ts
- npm run lint
- npm run build
- npm run check:upgrade-guide
- node scripts/instar-dev-precommit.js

## Dogfood observation
Before this change, Codey's compact map was fresh but only showed the small wrapper project and omitted the Instar source worktrees used for real development. The new compact output shows the bound project plus related worktrees and branch names, while the total file count now matches the visible project surface instead of counting hidden runtime/worktree state.
