### PR TITLE
fix: normalize reap log skipped disposition

### DIFF
--- a/.instar/instar-dev-traces/2026-05-29T11-28-50-749Z-reap-log-skipped-disposition-c7e0f093.json
+++ b/.instar/instar-dev-traces/2026-05-29T11-28-50-749Z-reap-log-skipped-disposition-c7e0f093.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "sessionId": "c001de80-4f1a-4717-aafe-a4362d76b0ef",
+  "timestamp": "2026-05-29T11:28:50.749Z",
+  "artifactPath": "upgrades/side-effects/reap-log-skipped-disposition.md",
+  "artifactSha256": "dcd21023490d0751c871b84f396d590fcc244804d153c60e78f161380b6bd89c",
+  "specPath": "docs/specs/reap-log-skipped-disposition.md",
+  "coveredFiles": [
+    "docs/specs/reap-log-skipped-disposition.eli16.md",
+    "docs/specs/reap-log-skipped-disposition.md",
+    "src/data/builtin-manifest.json",
+    "src/monitoring/ReapLog.ts",
+    "tests/e2e/reap-log-lifecycle.test.ts",
+    "tests/integration/reap-log-route.test.ts",
+    "tests/unit/reap-log.test.ts",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/reap-log-skipped-disposition.md"
+  ],
+  "phase": "complete",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/reap-log-skipped-disposition.eli16.md
+++ b/docs/specs/reap-log-skipped-disposition.eli16.md
@@ -1,0 +1,11 @@
+# ELI16: Reap Log Skipped Disposition
+
+Reap Log exists so an agent or operator can answer a simple operational question: "why did this session disappear?" It also needs to answer the nearby question: "why did this session not get killed when something tried to reap it?"
+
+When I tested Codey's Reap Log, the endpoint worked and the backing file existed. The recent rows were real. They included old job sessions that were cleaned up during boot, a session-recovery bounce, and one skipped recovery attempt. The skipped row had a useful detail field saying why the kill was refused, but it did not have the same `disposition` field as the reaped rows.
+
+That is small but important. A person or dashboard should not need special-case logic to understand the outcome column. Every row should say what actually happened. For a terminal reap, the disposition is `terminal`. For a recovery bounce, it is `recovery-bounce`. For a skipped reap, the disposition should say that it was skipped and why, such as `skipped:not-lease-holder` or `skipped:pending-injection`.
+
+The fix keeps the old `skipped` field because it is already part of the API and tests. It simply adds a normalized `disposition` to skipped rows too. It also normalizes older log rows as they are read, so existing logs become easier to consume immediately without a migration or rewrite.
+
+This does not change the safety behavior of session reaping. It does not make more sessions end, and it does not weaken protected-session, lease-holder, or in-flight guards. It only makes the audit trail easier to read and more consistent.

--- a/docs/specs/reap-log-skipped-disposition.md
+++ b/docs/specs/reap-log-skipped-disposition.md
@@ -1,0 +1,39 @@
+---
+title: Reap Log Skipped Disposition
+review-convergence: 2026-05-29T11:28:00Z
+approved: true
+eli16-overview: reap-log-skipped-disposition.eli16.md
+---
+
+# Reap Log Skipped Disposition
+
+## Problem
+
+Reap Log is the file-backed answer to "where did my session go?" It records both sessions that were actually reaped and terminate attempts that were refused by the authority.
+
+Dogfooding showed the endpoint is alive and useful, but skipped entries had an inconsistent shape. Reaped entries included `disposition`, while skipped entries only included `skipped`. That means a client asking for `ts/type/session/reason/disposition` sees a missing outcome field exactly on the rows that explain why a session did not vanish.
+
+## Proposed Change
+
+Normalize Reap Log entries so every returned row includes `disposition`:
+
+- reaped terminal rows use `terminal`;
+- reaped recovery bounces use `recovery-bounce`;
+- skipped rows use `skipped:<authority-reason>`.
+
+Keep the existing `skipped` field on skipped rows for compatibility and detail. When reading old log lines that predate this field, backfill `disposition` in memory without rewriting the log.
+
+## Acceptance Criteria
+
+- New skipped entries are written with both `skipped` and `disposition`.
+- Old skipped entries without `disposition` are returned with a normalized `disposition`.
+- Existing reaped entries still return a disposition, defaulting to `terminal` when older calls omitted it.
+- The route remains read-only and file-backed.
+
+## Decision Points
+
+This changes only the shape and normalization of Reap Log audit rows. It does not change reap authority, session termination, notification, or lease behavior.
+
+## Rollback
+
+Rollback is a normal code revert. Existing log lines are JSONL and remain readable; newer rows with `disposition` are ignored by older readers.

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-29T10:58:17.221Z",
-  "instarVersion": "1.3.81",
+  "generatedAt": "2026-05-29T11:28:15.958Z",
+  "instarVersion": "1.3.82",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {

--- a/src/monitoring/ReapLog.ts
+++ b/src/monitoring/ReapLog.ts
@@ -24,7 +24,8 @@ export interface ReapLogEntry {
   tmuxSession: string;
   /** The reason the killer requested (e.g. 'idle-zombie', 'age-limit'). */
   reason: string;
-  disposition?: 'terminal' | 'recovery-bounce';
+  /** What actually happened: terminal/recovery-bounce, or skipped:<authority-reason>. */
+  disposition: 'terminal' | 'recovery-bounce' | `skipped:${string}`;
   origin?: 'operator' | 'autonomous';
   /** For 'skipped': why the authority refused (protected / not-lease-holder / a KEEP / in-flight). */
   skipped?: string;
@@ -53,7 +54,7 @@ export class ReapLog {
       session: e.session,
       tmuxSession: e.tmuxSession,
       reason: e.reason,
-      disposition: e.disposition,
+      disposition: e.disposition ?? 'terminal',
       origin: e.origin,
       machine: this.machineId?.(),
     });
@@ -72,6 +73,7 @@ export class ReapLog {
       session: e.session,
       tmuxSession: e.tmuxSession,
       reason: e.reason,
+      disposition: `skipped:${e.skipped}`,
       skipped: e.skipped,
       origin: e.origin,
       machine: this.machineId?.(),
@@ -102,11 +104,34 @@ export class ReapLog {
     const out: ReapLogEntry[] = [];
     for (const line of tail) {
       try {
-        out.push(JSON.parse(line) as ReapLogEntry);
+        out.push(this.normalizeEntry(JSON.parse(line) as Partial<ReapLogEntry>));
       } catch {
         // skip a corrupt/partial line rather than failing the whole read
       }
     }
     return out;
+  }
+
+  private normalizeEntry(entry: Partial<ReapLogEntry>): ReapLogEntry {
+    const type = entry.type === 'skipped' ? 'skipped' : 'reaped';
+    const skipped = typeof entry.skipped === 'string' ? entry.skipped : undefined;
+    let disposition = entry.disposition;
+    if (!disposition) {
+      disposition = type === 'skipped'
+        ? `skipped:${skipped ?? 'unknown'}`
+        : 'terminal';
+    }
+
+    return {
+      ts: typeof entry.ts === 'string' ? entry.ts : new Date(0).toISOString(),
+      type,
+      session: typeof entry.session === 'string' ? entry.session : 'unknown',
+      tmuxSession: typeof entry.tmuxSession === 'string' ? entry.tmuxSession : 'unknown',
+      reason: typeof entry.reason === 'string' ? entry.reason : 'unknown',
+      disposition,
+      origin: entry.origin,
+      skipped,
+      machine: entry.machine,
+    };
   }
 }

--- a/tests/e2e/reap-log-lifecycle.test.ts
+++ b/tests/e2e/reap-log-lifecycle.test.ts
@@ -72,7 +72,11 @@ describe('Reap-log E2E lifecycle (feature is alive)', () => {
     expect(Array.isArray(res.body.entries)).toBe(true);
     expect(res.body.entries).toHaveLength(2);
     expect(res.body.entries[0]).toMatchObject({ type: 'reaped', session: 'sess-x', reason: 'idle-zombie', machine: 'e2e-machine' });
-    expect(res.body.entries[1]).toMatchObject({ type: 'skipped', skipped: 'not-lease-holder' });
+    expect(res.body.entries[1]).toMatchObject({
+      type: 'skipped',
+      skipped: 'not-lease-holder',
+      disposition: 'skipped:not-lease-holder',
+    });
   });
 
   it('requires Bearer auth', async () => {

--- a/tests/integration/reap-log-route.test.ts
+++ b/tests/integration/reap-log-route.test.ts
@@ -61,7 +61,11 @@ describe('GET /sessions/reap-log (integration §P4)', () => {
     expect(res.status).toBe(200);
     expect(res.body.entries).toHaveLength(2);
     expect(res.body.entries[0]).toMatchObject({ type: 'reaped', session: 'sess-a', reason: 'idle-zombie' });
-    expect(res.body.entries[1]).toMatchObject({ type: 'skipped', skipped: 'protected' });
+    expect(res.body.entries[1]).toMatchObject({
+      type: 'skipped',
+      skipped: 'protected',
+      disposition: 'skipped:protected',
+    });
   });
 
   it('honours ?limit by returning only the most-recent N', async () => {

--- a/tests/unit/reap-log.test.ts
+++ b/tests/unit/reap-log.test.ts
@@ -40,7 +40,31 @@ describe('ReapLog (§P4)', () => {
     const log = new ReapLog(stateDir);
     log.recordSkipped({ session: 's2', tmuxSession: 't2', reason: 'boot-purge-dead', skipped: 'not-lease-holder', origin: 'autonomous' });
     const entries = log.read();
-    expect(entries[0]).toMatchObject({ type: 'skipped', skipped: 'not-lease-holder', reason: 'boot-purge-dead' });
+    expect(entries[0]).toMatchObject({
+      type: 'skipped',
+      skipped: 'not-lease-holder',
+      reason: 'boot-purge-dead',
+      disposition: 'skipped:not-lease-holder',
+    });
+  });
+
+  it('normalizes legacy skipped entries so every read entry has a disposition', () => {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.appendFileSync(logPath, JSON.stringify({
+      ts: '2026-05-29T00:00:00.000Z',
+      type: 'skipped',
+      session: 'legacy',
+      tmuxSession: 'legacy-tmux',
+      reason: 'session-recovery',
+      skipped: 'pending-injection',
+    }) + '\n');
+
+    const entries = new ReapLog(stateDir).read();
+    expect(entries[0]).toMatchObject({
+      type: 'skipped',
+      skipped: 'pending-injection',
+      disposition: 'skipped:pending-injection',
+    });
   });
 
   it('encodes a newline-laden reason as valid JSON (no injection)', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,25 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Reap Log entries now include a consistent disposition field for skipped rows as well as reaped rows. This fixes a dogfood issue where skipped rows explained the authority refusal in a separate field but did not populate the common outcome field, making "where did my session go?" tooling harder to consume.
+
+## What to Tell Your User
+
+The session reap log is easier to read now: every row has a clear outcome, including attempts that were safely skipped.
+
+## Summary of New Capabilities
+
+| Area | Capability |
+| --- | --- |
+| Reap Log | Skipped rows now include a normalized outcome like skipped:protected or skipped:not-lease-holder. |
+| Observability | Older skipped log lines are normalized when read, so existing logs become easier to interpret immediately. |
+| Compatibility | The existing skipped detail field remains available for clients that already use it. |
+
+## Evidence
+
+- Unit coverage: `tests/unit/reap-log.test.ts` verifies new skipped entries and legacy skipped rows include a normalized disposition.
+- Integration coverage: `tests/integration/reap-log-route.test.ts` verifies the route surfaces skipped dispositions.
+- E2E coverage: `tests/e2e/reap-log-lifecycle.test.ts` verifies the live server path returns the normalized skipped disposition.

--- a/upgrades/side-effects/reap-log-skipped-disposition.md
+++ b/upgrades/side-effects/reap-log-skipped-disposition.md
@@ -1,0 +1,86 @@
+# Side-Effects Review — Reap Log Skipped Disposition
+
+**Version / slug:** `reap-log-skipped-disposition`
+**Date:** `2026-05-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `not required by tooling`
+
+## Summary of the change
+
+This change normalizes Reap Log entries so both reaped and skipped rows expose `disposition`. Skipped rows keep their existing `skipped` detail and add `disposition: skipped:<reason>`. The reader also backfills this field for old skipped log lines.
+
+## Decision-point inventory
+
+- `ReapLog.recordSkipped()` — add an outcome disposition when writing skipped rows.
+- `ReapLog.read()` — normalize legacy rows in memory.
+- Reap Log route tests — assert skipped rows include the normalized disposition.
+
+---
+
+## 1. Over-block
+
+No blocking behavior changes. This is read-only audit normalization.
+
+---
+
+## 2. Under-block
+
+No reap authority behavior changes. Protected-session, lease-holder, KEEP-guard, and in-flight decisions are untouched.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The Reap Log audit sink owns the durable row shape, so it is the right layer to normalize old and new entries. Route handlers continue to read through the existing sink.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no conversational block/allow surface.
+
+This output is explanatory observability only.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** None. Session termination authority remains in `SessionManager`.
+- **Double-fire:** None. One terminate attempt still creates at most one Reap Log row.
+- **Races:** None added. Reads normalize returned objects without rewriting the JSONL file.
+- **Feedback loops:** Positive loop: agents and dashboards can answer "what happened?" without special-casing skipped rows.
+
+---
+
+## 6. External surfaces
+
+The `GET /sessions/reap-log` response now includes `disposition` on skipped rows. Existing clients using `skipped` continue to work.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a normal code revert. Newer log rows contain an extra JSON field that older readers ignore.
+
+---
+
+## Conclusion
+
+The change is clear to ship. It fixes a real schema inconsistency found during Reap Log dogfooding without changing reap behavior.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `not required by tooling`
+**Independent read of the artifact:** `not required`
+
+---
+
+## Evidence pointers
+
+- `tests/unit/reap-log.test.ts`
+- `tests/integration/reap-log-route.test.ts`
+- `tests/e2e/reap-log-lifecycle.test.ts`


### PR DESCRIPTION
## Summary
- add normalized disposition values to skipped Reap Log rows
- backfill disposition in memory when reading old skipped rows
- keep the existing skipped detail field for compatibility

## Dogfood Finding
GET /sessions/reap-log?limit=20 on Codey returned real entries from the file-backed log: boot-purge terminal reaps, a recovery-bounce reap, and one skipped recovery row. The skipped row explained the authority refusal in `skipped`, but lacked the common `disposition` field, so consumers had to special-case skipped rows to answer what happened.

## Validation
- npx vitest run tests/unit/reap-log.test.ts tests/integration/reap-log-route.test.ts tests/e2e/reap-log-lifecycle.test.ts
- npm run lint
- npm run build
- npm run check:upgrade-guide
- node scripts/instar-dev-precommit.js
- built reader against Codey existing log shows the legacy skipped row normalized to a skipped disposition
