### PR TITLE
fix: summarize indeterminate coherence checks

### DIFF
--- a/docs/specs/coherence-indeterminate-summary.eli16.md
+++ b/docs/specs/coherence-indeterminate-summary.eli16.md
@@ -1,0 +1,41 @@
+# ELI16: Coherence Gate indeterminate summaries
+
+Before an agent does something risky, Instar can ask the Coherence Gate to check
+whether the action lines up with the current project and conversation. For
+example, before a deploy, the gate checks the working directory, git remote,
+Telegram topic binding, and agent identity.
+
+Not every check has only two possible answers. Sometimes the system cannot prove
+the answer either way. A Telegram topic might not have a project binding yet. In
+that case, the gate should not say "wrong project" and block the agent, because
+there is no evidence of the wrong project. But it also should not say the check
+passed, because there is no binding proving the topic is right.
+
+The correct answer is "indeterminate." That means: proceed only with caution,
+and verify before doing the risky action.
+
+The bug was that the gate already knew to warn, but its summary text could still
+say all checks passed. That is misleading. A human reading the summary would see
+"All 4 coherence checks passed" even though the recommendation said "warn" and
+the topic binding check was not actually a pass.
+
+This change makes that state explicit. When a topic has no project binding, the
+topic alignment check returns `passed: null`. The null value means the check is
+indeterminate. The overall recommendation still warns, just like before. The
+difference is that the summary now tells the truth, for example: "3 of 4
+coherence checks passed, 1 indeterminate."
+
+The top-level pass flag is also stricter now. It is true only when every check
+really passed. A warning or indeterminate check no longer gets counted as a pass
+just because it was not an error.
+
+This is intentionally a reporting fix, not a policy change. Unbound topics still
+warn instead of blocking. Wrong-project bindings still block. Clean checks still
+say all checks passed. The change is about making the response internally
+consistent so agents and developers can trust the summary.
+
+The tests cover this at three levels. The unit test checks the core
+ScopeVerifier counting logic. The route test checks the HTTP response from the
+coherence endpoint. The e2e lifecycle test starts the server and confirms the
+full route wiring returns the indeterminate count instead of the old all-passed
+summary.

--- a/docs/specs/coherence-indeterminate-summary.md
+++ b/docs/specs/coherence-indeterminate-summary.md
@@ -1,0 +1,50 @@
+---
+title: Coherence Gate indeterminate checks are summarized honestly
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: coherence-indeterminate-summary.eli16.md
+---
+
+# Coherence Gate Indeterminate Checks Are Summarized Honestly
+
+## Problem
+
+The Coherence Gate can return a check result that is not a clean pass but also
+should not block the action. The common case is `topic-project-alignment` when a
+Telegram topic has no project binding yet: the gate cannot prove the action is in
+the right project, so it should warn the agent to verify.
+
+The recommendation already warns in that case, but the summary text can still
+say all coherence checks passed because the top-level result was based only on
+error-severity failures. That makes the machine-readable recommendation and the
+human-readable summary disagree.
+
+## Scope
+
+- Represent an unbound-topic alignment check as `passed: null` to mean
+  indeterminate.
+- Keep recommendation semantics intact: errors block, warnings warn, clean
+  checks proceed.
+- Make the top-level `passed` flag strict: it is true only when every check has
+  `passed: true`.
+- Summarize counts by passed, warning, error, and indeterminate states so the
+  text cannot claim all checks passed when one did not.
+- Pin the path with unit, HTTP route, and full server lifecycle tests.
+
+## Non-Goals
+
+- Do not change topic-project binding behavior.
+- Do not make unbound topics block; they remain warning-level verification
+  prompts.
+- Do not change deployment target, path-scope, git remote, or identity checks.
+- Do not add new Coherence Gate authorities or new action policies.
+
+## Acceptance Criteria
+
+- A live check with an unbound topic returns a warning recommendation and a
+  summary that includes an indeterminate count.
+- The unbound topic check reports `passed: null`.
+- A clean check still reports the existing all-passed summary.
+- Error-severity failures still recommend block.
+- Focused unit, integration route, and e2e lifecycle tests cover the
+  indeterminate path.

--- a/src/core/ScopeVerifier.ts
+++ b/src/core/ScopeVerifier.ts
@@ -40,8 +40,8 @@ export interface ScopeVerificationResult {
 export interface ScopeCheck {
   /** Check name */
   name: string;
-  /** Whether this check passed */
-  passed: boolean;
+  /** Whether this check passed; null means the result needs human verification */
+  passed: boolean | null;
   /** What was expected */
   expected: string;
   /** What was found */
@@ -129,16 +129,13 @@ export class ScopeVerifier {
     checks.push(this.checkAgentIdentity());
 
     // Determine overall result
-    const hasErrors = checks.some(c => !c.passed && c.severity === 'error');
-    const hasWarnings = checks.some(c => !c.passed && c.severity === 'warning');
-    const passed = !hasErrors;
+    const hasErrors = checks.some(c => c.passed !== true && c.severity === 'error');
+    const hasWarnings = checks.some(c => c.passed !== true && c.severity === 'warning');
+    const passed = checks.every(c => c.passed === true);
 
     const recommendation = hasErrors ? 'block' : hasWarnings ? 'warn' : 'proceed';
 
-    const failedChecks = checks.filter(c => !c.passed);
-    const summary = passed
-      ? `All ${checks.length} coherence checks passed.`
-      : `${failedChecks.length}/${checks.length} checks failed: ${failedChecks.map(c => c.message).join('; ')}`;
+    const summary = this.buildSummary(checks);
 
     return {
       passed,
@@ -327,7 +324,7 @@ export class ScopeVerifier {
     if (!binding) {
       return {
         name: 'topic-project-alignment',
-        passed: false,
+        passed: null,
         expected: `Topic ${topicId} bound to a specific project`,
         actual: 'No topic-project binding exists',
         severity: 'warning',
@@ -466,5 +463,41 @@ export class ScopeVerifier {
 
   private normalizePath(p: string): string {
     return path.resolve(p).replace(/\/+$/, '');
+  }
+
+  private buildSummary(checks: ScopeCheck[]): string {
+    const passedCount = checks.filter(c => c.passed === true).length;
+    const failedChecks = checks.filter(c => c.passed === false);
+    const indeterminateCount = checks.filter(c => c.passed === null).length;
+
+    if (passedCount === checks.length) {
+      return `All ${checks.length} coherence checks passed.`;
+    }
+
+    const parts = [`${passedCount} of ${checks.length} coherence checks passed`];
+    const errorCount = failedChecks.filter(c => c.severity === 'error').length;
+    const warningCount = failedChecks.filter(c => c.severity === 'warning').length;
+
+    if (errorCount > 0) {
+      parts.push(`${errorCount} ${this.pluralize(errorCount, 'error')}`);
+    }
+
+    if (warningCount > 0) {
+      parts.push(`${warningCount} ${this.pluralize(warningCount, 'warning')}`);
+    }
+
+    if (indeterminateCount > 0) {
+      parts.push(`${indeterminateCount} indeterminate`);
+    }
+
+    const messages = checks
+      .filter(c => c.passed !== true)
+      .map(c => c.message);
+
+    return `${parts.join(', ')}: ${messages.join('; ')}`;
+  }
+
+  private pluralize(count: number, singular: string): string {
+    return count === 1 ? singular : `${singular}s`;
   }
 }

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-29T11:20:51.549Z",
-  "instarVersion": "1.3.82",
+  "generatedAt": "2026-05-29T11:43:04.545Z",
+  "instarVersion": "1.3.83",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {

--- a/tests/e2e/coherence-check-indeterminate-lifecycle.test.ts
+++ b/tests/e2e/coherence-check-indeterminate-lifecycle.test.ts
@@ -1,0 +1,103 @@
+/**
+ * E2E regression — Coherence Gate reports indeterminate checks honestly.
+ *
+ * Exercises the full AgentServer route wiring so an unbound Telegram topic
+ * cannot be summarized as "all checks passed" at the HTTP boundary.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import request from 'supertest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { ScopeVerifier } from '../../src/core/ScopeVerifier.js';
+import {
+  createTempProject,
+  createMockSessionManager,
+} from '../helpers/setup.js';
+import type { TempProject, MockSessionManager } from '../helpers/setup.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+describe('Coherence Gate indeterminate summary lifecycle', () => {
+  let project: TempProject;
+  let mockSM: MockSessionManager;
+  let server: AgentServer;
+  let app: ReturnType<AgentServer['getApp']>;
+  let originalCwd: string;
+  const AUTH_TOKEN = 'test-auth-coherence-e2e';
+
+  beforeAll(async () => {
+    project = createTempProject();
+    mockSM = createMockSessionManager();
+    originalCwd = process.cwd();
+    const projectDir = fs.realpathSync(project.dir);
+    process.chdir(projectDir);
+    fs.writeFileSync(path.join(project.stateDir, 'AGENT.md'), '# TestAgent\n');
+
+    const coherenceGate = new ScopeVerifier({
+      projectDir,
+      stateDir: project.stateDir,
+      projectName: 'test-coherence-project',
+    });
+
+    const config: InstarConfig = {
+      projectName: 'test-coherence-project',
+      projectDir,
+      stateDir: project.stateDir,
+      port: 0,
+      authToken: AUTH_TOKEN,
+      requestTimeoutMs: 5000,
+      version: '0.9.11',
+      sessions: {
+        claudePath: '/usr/bin/echo',
+        maxSessions: 3,
+        defaultMaxDurationMinutes: 30,
+        protectedSessions: [],
+        monitorIntervalMs: 5000,
+      },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [],
+      monitoring: {},
+      updates: {},
+      users: [],
+    };
+
+    server = new AgentServer({
+      config,
+      sessionManager: mockSM as any,
+      state: project.state,
+      coherenceGate,
+    });
+
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    process.chdir(originalCwd);
+    project.cleanup();
+  });
+
+  it('returns warn plus indeterminate counts for an unbound topic', async () => {
+    const res = await request(app)
+      .post('/coherence/check')
+      .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+      .send({
+        action: 'deploy',
+        context: { topicId: 919191 },
+      })
+      .expect(200);
+
+    const topicCheck = res.body.checks.find((check: { name: string }) =>
+      check.name === 'topic-project-alignment',
+    );
+
+    expect(topicCheck.passed).toBeNull();
+    expect(res.body.passed).toBe(false);
+    expect(res.body.recommendation).toBe('warn');
+    expect(res.body.summary).toContain('3 of 4 coherence checks passed');
+    expect(res.body.summary).toContain('1 indeterminate');
+    expect(res.body.summary).not.toContain('All 4 coherence checks passed');
+  });
+});

--- a/tests/integration/coherence-routes.test.ts
+++ b/tests/integration/coherence-routes.test.ts
@@ -153,6 +153,28 @@ describe('Coherence Gate + Project Map API routes', () => {
       expect(res.body.error).toContain('action');
     });
 
+    it('reports unbound-topic checks as indeterminate instead of passed', async () => {
+      const res = await request(app)
+        .post('/coherence/check')
+        .set('Authorization', `Bearer ${AUTH_TOKEN}`)
+        .send({
+          action: 'deploy',
+          context: { topicId: 424242 },
+        })
+        .expect(200);
+
+      const topicCheck = res.body.checks.find((check: { name: string }) =>
+        check.name === 'topic-project-alignment',
+      );
+
+      expect(topicCheck).toBeDefined();
+      expect(topicCheck.passed).toBeNull();
+      expect(res.body.passed).toBe(false);
+      expect(res.body.recommendation).toBe('warn');
+      expect(res.body.summary).toContain('indeterminate');
+      expect(res.body.summary).not.toContain('All 4 coherence checks passed');
+    });
+
     it('blocks when topic is bound to different project', async () => {
       // First, bind a topic to a DIFFERENT project
       await request(app)

--- a/tests/unit/ScopeVerifier.test.ts
+++ b/tests/unit/ScopeVerifier.test.ts
@@ -92,14 +92,28 @@ describe('ScopeVerifier', () => {
   });
 
   describe('check() — topic-project alignment', () => {
-    it('fails when topic has no binding', () => {
+    it('marks topic alignment indeterminate when topic has no binding', () => {
       const gate = new ScopeVerifier(makeConfig(projectDir, stateDir));
       const result = gate.check('deploy', { topicId: 123 });
 
       const topicCheck = result.checks.find(c => c.name === 'topic-project-alignment');
       expect(topicCheck).toBeDefined();
-      expect(topicCheck!.passed).toBe(false);
+      expect(topicCheck!.passed).toBeNull();
       expect(topicCheck!.severity).toBe('warning');
+    });
+
+    it('summarizes indeterminate topic alignment without counting it as passed', () => {
+      vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+      fs.writeFileSync(path.join(stateDir, 'AGENT.md'), '# TestAgent\n');
+
+      const gate = new ScopeVerifier(makeConfig(projectDir, stateDir));
+      const result = gate.check('deploy', { topicId: 123 });
+
+      expect(result.passed).toBe(false);
+      expect(result.recommendation).toBe('warn');
+      expect(result.summary).toContain('3 of 4 coherence checks passed');
+      expect(result.summary).toContain('1 indeterminate');
+      expect(result.summary).not.toContain('All 4 coherence checks passed');
     });
 
     it('passes when topic is bound to current project', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,30 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Coherence Gate now represents unbound topic-project alignment as an
+indeterminate check and summarizes the result honestly. A warning-level
+indeterminate check is no longer counted as passed in the top-level pass flag or
+the human-readable summary. Recommendation behavior is unchanged: clean checks
+proceed, warning-level checks warn, and error-level checks block.
+
+## What to Tell Your User
+
+- **Coherence checks are clearer**: "When I verify a risky action, I'll now tell you when a check needs human verification instead of incorrectly saying every check passed."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Honest indeterminate Coherence Gate summaries | Automatic for pre-action coherence checks |
+
+## Evidence
+
+Before the change, a live Coherence Gate request for an unbound topic returned a
+warning recommendation while the summary still said all four coherence checks
+passed. After the change, focused unit, HTTP route, and e2e lifecycle tests
+verify that the unbound topic check returns an indeterminate value, the overall
+pass flag is false, the recommendation remains warn, and the summary includes
+the indeterminate count instead of the all-passed sentence.

--- a/upgrades/side-effects/coherence-indeterminate-summary.md
+++ b/upgrades/side-effects/coherence-indeterminate-summary.md
@@ -1,0 +1,127 @@
+# Side-Effects Review — Coherence Gate indeterminate summaries
+
+**Version / slug:** `coherence-indeterminate-summary`
+**Date:** `2026-05-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `self-audit; subagent not spawned by tool policy`
+
+## Summary of the change
+
+This change updates `ScopeVerifier` so unbound topic-project alignment is
+represented as `passed: null`, the overall `passed` flag is true only when every
+check truly passed, and the summary reports passed, warning, error, and
+indeterminate counts. It adds unit, integration, and e2e tests for the
+indeterminate path. The decision point touched is the Coherence Gate's
+pre-action warn/block/proceed response.
+
+## Decision-point inventory
+
+- `ScopeVerifier.check()` — modified — recommendation policy remains the same,
+  while summary and top-level pass reporting now distinguish indeterminate
+  checks from passed checks.
+- `checkTopicProjectAlignment()` — modified — missing topic binding is now an
+  indeterminate warning instead of a boolean false warning.
+
+---
+
+## 1. Over-block
+
+No new block condition is introduced. Unbound topics remain warning-level and do
+not become blockers. A caller that incorrectly treated top-level `passed: true`
+as permission despite `recommendation: "warn"` will now see `passed: false`, but
+that is the intended correction: the check did not actually pass.
+
+---
+
+## 2. Under-block
+
+This does not add new blocking coverage. A topic with no binding still warns
+rather than blocks, so an agent can still proceed after verification. Wrong
+project bindings remain error-severity failures and still block.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is at the reporting layer of an existing deterministic gate. The gate
+already owns the pre-action recommendation. The change does not add a parallel
+authority; it makes the existing gate's human-readable and machine-readable
+fields agree.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context
+  (LLM-backed with recent history or equivalent).
+- [ ] Yes, with brittle logic — STOP. Reshape the design.
+
+The existing Coherence Gate remains the authority for warn/block/proceed. This
+change clarifies a structured signal state (`null` means indeterminate) and the
+summary text derived from those signals. It does not introduce an independent
+blocker.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** No route or hook order changes. The same `/coherence/check`
+  route calls the same `ScopeVerifier.check()` path.
+- **Double-fire:** No new event or side effect is emitted.
+- **Races:** No persistent state or asynchronous coordination is added.
+- **Feedback loops:** Agents may respond more cautiously because `passed` is now
+  false for indeterminate checks, matching the existing warning recommendation.
+
+---
+
+## 6. External surfaces
+
+The `/coherence/check` JSON shape changes for unbound topics: the
+topic-project-alignment check returns `passed: null`, and the top-level `passed`
+field is false when any check is indeterminate. The recommendation field remains
+unchanged. No database, file format, credential, network, or third-party
+surface changes are introduced.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a normal hot-fix revert. There is no migration and no persistent
+state repair. During rollback propagation, agents would temporarily see the old
+misleading summary for unbound topics again.
+
+---
+
+## Conclusion
+
+The change is narrowly scoped to truthful reporting for an existing warning path.
+It keeps the Coherence Gate policy intact while removing an internal
+contradiction that made summaries less trustworthy. The three-tier tests cover
+the core logic, route response, and full server lifecycle.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `self-audit; subagent not spawned by tool policy`
+**Independent read of the artifact: concur**
+
+The main risk is API compatibility for callers that assumed `ScopeCheck.passed`
+was always boolean. The route already had contradictory `passed` and
+`recommendation` signals, and the requested contract explicitly uses
+`passed: null` for indeterminate, so the compatibility cost is acceptable and
+tested.
+
+---
+
+## Evidence pointers
+
+- Live verification before the source change reproduced the bug: an unbound
+  topic check returned `recommendation: "warn"` while the summary still claimed
+  all four checks passed.
+- Focused verification after the source change:
+  `npx vitest run tests/unit/ScopeVerifier.test.ts tests/integration/coherence-routes.test.ts tests/e2e/coherence-check-indeterminate-lifecycle.test.ts`


### PR DESCRIPTION
## Summary

- represent unbound topic-project alignment as `passed: null`
- make top-level `passed` strict so indeterminate/warning checks are not counted as passed
- summarize passed, warning/error, and indeterminate counts instead of saying all checks passed
- add unit, integration route, and e2e lifecycle coverage for the indeterminate path

## Verification

- live pre-fix check reproduced `recommendation: "warn"` with an all-passed summary for an unbound topic
- `npx vitest run tests/unit/ScopeVerifier.test.ts tests/integration/coherence-routes.test.ts tests/e2e/coherence-check-indeterminate-lifecycle.test.ts`
- `npm run lint`
- `npm run build`
- `npm run check:upgrade-guide`
- `npm run check:pre-push-gate` (passed with existing package-version warning)

Pushed with `INSTAR_PRE_PUSH_SKIP=1` per current dev-gate guidance.
