### PR TITLE
[codex] Hot-read mentor config

### DIFF
--- a/.instar/instar-dev-traces/2026-05-29T12-50-23-122Z-mentor-config-hot-read.json
+++ b/.instar/instar-dev-traces/2026-05-29T12-50-23-122Z-mentor-config-hot-read.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "sessionId": "telegram-458-mentor-config-hot-read",
+  "timestamp": "2026-05-29T12:50:23.122Z",
+  "artifactPath": "upgrades/side-effects/mentor-config-hot-read.md",
+  "artifactSha256": "93b22e339c3a6bc43257b840f24ed88a00ea0785d499cf6db4ae65c3827b9007",
+  "specPath": "docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md",
+  "coveredFiles": [
+    "docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md",
+    "docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md",
+    "src/data/builtin-manifest.json",
+    "src/server/AgentServer.ts",
+    "tests/e2e/mentor-onboarding-lifecycle.test.ts",
+    "tests/integration/mentor-routes.test.ts",
+    "tests/unit/AgentServer-mentor-config-hot-read.test.ts",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/mentor-config-hot-read.md"
+  ],
+  "phase": "complete",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md
+++ b/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.eli16.md
@@ -96,3 +96,11 @@ We found two reasons the automated mentor would have behaved that way. First, th
 This change fixes both. The mentor now gets a real picture: the new agent's recent replies, plus an optional onboarding to-do list (the operator's plan — "check the Secret Drop flow", "exercise the Playbook", etc.). When the new agent is idle and there are items left on the list, the mentor now hands over the next concrete task instead of a hollow check-in. If the agent is mid-task, blocked, or asked a question, it still does the sensible thing (wait, unblock, or answer).
 
 Two safety notes. The to-do list is the mentor's own plan, not anything private about the agent it's mentoring, so handing over a task from it is allowed and doesn't trip the "did the mentor peek at internals?" detector. And the whole thing is off unless someone turns it on: the mentor is disabled by default, and even when enabled it stays in today's passive mode until an operator actually fills in a to-do list. So nothing changes for anyone automatically — it's there to be switched on deliberately, once the operator decides they want the mentor proactively assigning onboarding tasks.
+
+## Amendment (2026-05-29): changing the mentor plan without restarting
+
+The to-do-list amendment only works well if the operator can tune the list while the mentor is running. Before this update, the server read the mentor settings once when it started. If someone edited the mentor's agenda or related settings after that, the running mentor kept using the old copy until the server restarted.
+
+This update makes the mentor check the current mentor settings each time it needs them. If the config edit is valid, the new agenda or settings take effect on the next status check or mentor tick. If the config file is temporarily broken, missing, or has a bad mentor section, the mentor falls back to the safe settings it started with instead of crashing the tick.
+
+This does not make the mentor more autonomous. It does not send anything new by itself, create new topics, or bypass the existing off-by-default gates. It only makes the already-approved mentor plan easier to adjust while dogfooding the curriculum live.

--- a/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
+++ b/docs/specs/FRAMEWORK-ONBOARDING-MENTOR-SPEC.md
@@ -550,10 +550,10 @@ Ships staged (off → dry-run on Echo↔Codey → live) per the graduated-rollou
 
 The mentor is already off by default (`enabled:false`/`mode:'off'`). The agenda is additionally empty by default, so even an enabled mentor keeps today's passive behaviour until an operator sets `mentor.onboardingAgenda`. No fleet behaviour change without explicit opt-in.
 
-### Open decisions to flag (not in this PR)
+### Operator decisions to flag before live rollout
 
 - **Should the automated mentor proactively assign onboarding tasks to mentees fleet-wide?** (a UX/product call for the operator before populating an agenda + enabling.)
-- **Fuller conversation surface.** This PR feeds the mentor the mentee's *replies* but not the mentor's *own* prior prompts (their content isn't logged today — `a2a-sent.jsonl` is metadata-only). So agenda rotation is inferred from the mentee's replies. Logging the mentor's sent-prompt content for a complete two-sided surface is a scoped follow-up; acceptable for a dark feature, and the mentor-outstanding tracker already prevents back-to-back duplicate sends.
+- **Fuller conversation surface.** This PR feeds the mentor the mentee's *replies* but not the mentor's *own* prior prompts (their content isn't logged today — `a2a-sent.jsonl` is metadata-only). So agenda rotation is inferred from the mentee's replies. Logging the mentor's sent-prompt content for a complete two-sided surface can be handled as a separate scoped change; acceptable for a dark feature, and the mentor-outstanding tracker already prevents back-to-back duplicate sends.
 
 ### Acceptance Criteria (amendment)
 
@@ -566,3 +566,25 @@ M5. Empty agenda + no replies → behaviour identical to the prior stub (the pas
 ### Rollback (amendment)
 
 Revert the `onboardingAgenda` field + the `buildStageAContext` agenda block + the `getSurface` builder back to the empty-surface stub. No state/migration/contract change; the reverted-to state is today's passive mentor.
+
+## Amendment (2026-05-29): hot-read mentor config
+
+The active task-driving amendment made `mentor.onboardingAgenda` the operator's opt-in source for the mentor's concrete task list. Dogfooding then surfaced a runtime usability gap: `AgentServer.buildMentorRunner` captured the mentor block from startup config once, so editing the agenda or related mentor settings in the agent config file had no effect until the whole server restarted. That undermines the purpose of an operator-curated onboarding agenda, especially while tuning the curriculum live.
+
+### Change
+
+- **`AgentServer.buildMentorRunner` getConfig hot-reads the mentor block** from the current agent config file each time the runner asks for config.
+- **Startup config remains the safe fallback.** The server keeps the startup mentor config snapshot and returns it if the runtime config file is missing, unreadable, malformed JSON, or has a malformed mentor block.
+- **Good runtime reads merge with defaults.** A valid on-disk mentor object still inherits `DEFAULT_MENTOR_CONFIG`, preserving existing default behavior while reflecting changed agenda and settings immediately.
+- **The runner abstraction stays unchanged.** `MentorOnboardingRunner` still receives a `() => MentorConfig`; the server owns file I/O and defensive fallback.
+
+### Safety and behavior
+
+This does not introduce a new delivery path, topic creation path, or authority surface. It only changes how the already-gated mentor runner reads its existing config. The mentor remains off by default, agenda remains empty by default, and malformed runtime config edits degrade to the startup snapshot instead of throwing into a tick.
+
+### Acceptance Criteria (hot-read amendment)
+
+H1. Changing the on-disk `mentor.onboardingAgenda` is reflected on the next mentor config read without restarting the server.
+H2. A missing, unreadable, malformed, or bad-shape runtime config read returns the startup mentor config snapshot and never throws into a status check or tick.
+H3. Server-backed mentor status reflects a valid runtime config edit without reconstructing `AgentServer`.
+H4. The hot-read logic has unit coverage for agenda updates and fallback-on-bad-read, route coverage for fresh config reads, and server-backed e2e coverage for no-restart behavior.

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-29T12:31:54.315Z",
-  "instarVersion": "1.3.86",
+  "generatedAt": "2026-05-29T12:51:43.807Z",
+  "instarVersion": "1.3.87",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -1457,7 +1457,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "5841418da3e9385c441f0158bc5375025dc0f39bf9ae0b4f14c2bdb7d526bf1b",
+      "contentHash": "58f8f59f8d94511835333083269d3c512e8916dede7cc69fcdaf3b159b7e392b",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -92,6 +92,32 @@ import { registerBurnDetectionSubscriber } from '../monitoring/BurnDetectionSubs
 import { NativeModuleHealer } from '../memory/NativeModuleHealer.js';
 import { bridgeNativeHealToDegradation } from '../monitoring/NativeHealDegradationBridge.js';
 
+export function readMentorConfigFromDisk(
+  stateDir: string | undefined,
+  fallback: MentorConfig,
+): MentorConfig {
+  if (!stateDir) return fallback;
+  try {
+    const raw = fs.readFileSync(path.join(stateDir, 'config.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as { mentor?: unknown };
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return fallback;
+    }
+    if (parsed.mentor === undefined) {
+      return { ...DEFAULT_MENTOR_CONFIG };
+    }
+    if (!parsed.mentor || typeof parsed.mentor !== 'object' || Array.isArray(parsed.mentor)) {
+      return fallback;
+    }
+    return {
+      ...DEFAULT_MENTOR_CONFIG,
+      ...(parsed.mentor as Partial<MentorConfig>),
+    };
+  } catch {
+    return fallback;
+  }
+}
+
 export class AgentServer {
   private app: Express;
   private server: Server | null = null;
@@ -1522,10 +1548,11 @@ export class AgentServer {
     options: { config: { stateDir?: string }; intelligence?: import('../core/types.js').IntelligenceProvider | null },
     serverDataDir: string,
   ): MentorOnboardingRunner {
-    const getConfig = (): MentorConfig => ({
+    const startupMentorConfig: MentorConfig = {
       ...DEFAULT_MENTOR_CONFIG,
       ...((options.config as unknown as { mentor?: Partial<MentorConfig> }).mentor ?? {}),
-    });
+    };
+    const getConfig = (): MentorConfig => readMentorConfigFromDisk(options.config.stateDir, startupMentorConfig);
     const intelligence = options.intelligence ?? null;
     const self = this;
     return new MentorOnboardingRunner(

--- a/tests/e2e/mentor-onboarding-lifecycle.test.ts
+++ b/tests/e2e/mentor-onboarding-lifecycle.test.ts
@@ -76,6 +76,27 @@ describe('Mentor-onboarding E2E lifecycle (alive + dormant)', () => {
     expect(JSON.stringify(res.body)).toMatch(/\/mentor/);
   });
 
+  it('hot-reads mentor config changes from config.json without a restart', async () => {
+    const configPath = path.join(stateDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({
+      port: 0,
+      projectName: 'e2e',
+      agentName: 'E2E',
+      mentor: { enabled: true, mode: 'dry-run', menteeFramework: 'cursor' },
+    }));
+
+    const updated = await request(app).get('/mentor/status').set(auth());
+    expect(updated.status).toBe(200);
+    expect(updated.body).toMatchObject({ enabled: true, mode: 'dry-run', menteeFramework: 'cursor' });
+
+    fs.writeFileSync(configPath, '{not valid json');
+    const fallback = await request(app).get('/mentor/status').set(auth());
+    expect(fallback.status).toBe(200);
+    expect(fallback.body).toMatchObject({ enabled: false, mode: 'off', menteeFramework: 'codex-cli' });
+
+    fs.writeFileSync(configPath, JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+  });
+
   it('mentor routes require auth like every non-/health route', async () => {
     expect((await request(app).get('/mentor/status')).status).toBe(401);
   });

--- a/tests/integration/mentor-routes.test.ts
+++ b/tests/integration/mentor-routes.test.ts
@@ -60,6 +60,19 @@ describe('Mentor routes (integration)', () => {
     expect(res.body).toMatchObject({ enabled: false, mode: 'off', menteeFramework: 'codex-cli', inFlight: false });
   });
 
+  it('GET /mentor/status asks the runner for fresh config on each request', async () => {
+    let cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG };
+    const runner = new MentorOnboardingRunner(fakeServices(), () => cfg);
+    const app = appWith(runner);
+
+    expect((await request(app).get('/mentor/status')).body).toMatchObject({ enabled: false, mode: 'off' });
+
+    cfg = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'dry-run', menteeFramework: 'cursor' };
+    const res = await request(app).get('/mentor/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ enabled: true, mode: 'dry-run', menteeFramework: 'cursor' });
+  });
+
   it('POST /mentor/tick returns {ran:false, reason:"disabled"} by default (dormant)', async () => {
     const runner = new MentorOnboardingRunner(fakeServices(), () => ({ ...DEFAULT_MENTOR_CONFIG }));
     const res = await request(appWith(runner)).post('/mentor/tick');

--- a/tests/unit/AgentServer-mentor-config-hot-read.test.ts
+++ b/tests/unit/AgentServer-mentor-config-hot-read.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { readMentorConfigFromDisk } from '../../src/server/AgentServer.js';
+import { DEFAULT_MENTOR_CONFIG, type MentorConfig } from '../../src/scheduler/MentorOnboardingRunner.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('readMentorConfigFromDisk', () => {
+  let dir: string;
+  let stateDir: string;
+  let fallback: MentorConfig;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mentor-config-hot-read-unit-'));
+    stateDir = path.join(dir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fallback = {
+      ...DEFAULT_MENTOR_CONFIG,
+      enabled: true,
+      mode: 'dry-run',
+      onboardingAgenda: ['startup agenda'],
+      minIntervalMs: 123,
+    };
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/AgentServer-mentor-config-hot-read.test.ts' });
+  });
+
+  it('picks up a changed on-disk mentor agenda on the next read', () => {
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({
+      mentor: {
+        enabled: true,
+        mode: 'live',
+        onboardingAgenda: ['updated agenda'],
+        minIntervalMs: 456,
+      },
+    }));
+
+    expect(readMentorConfigFromDisk(stateDir, fallback)).toMatchObject({
+      enabled: true,
+      mode: 'live',
+      onboardingAgenda: ['updated agenda'],
+      minIntervalMs: 456,
+      menteeFramework: 'codex-cli',
+    });
+
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({
+      mentor: {
+        enabled: true,
+        mode: 'live',
+        onboardingAgenda: ['second agenda'],
+        minIntervalMs: 789,
+      },
+    }));
+
+    expect(readMentorConfigFromDisk(stateDir, fallback)).toMatchObject({
+      onboardingAgenda: ['second agenda'],
+      minIntervalMs: 789,
+    });
+  });
+
+  it('falls back to the startup mentor config when config cannot be parsed', () => {
+    fs.writeFileSync(path.join(stateDir, 'config.json'), '{not valid json');
+
+    expect(readMentorConfigFromDisk(stateDir, fallback)).toEqual(fallback);
+  });
+
+  it('falls back to the startup mentor config when the mentor block has a bad shape', () => {
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ mentor: ['bad'] }));
+
+    expect(readMentorConfigFromDisk(stateDir, fallback)).toEqual(fallback);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,30 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Mentor onboarding now hot-reads the mentor settings from the agent config file
+each time the runner checks its configuration. Updating the mentor curriculum or
+mentor runtime settings no longer requires a full server restart. If the config
+file is missing, unreadable, malformed, or has a malformed mentor block, the
+runner falls back to the startup snapshot instead of throwing into a mentor tick.
+
+## What to Tell Your User
+
+- **Mentor settings update without a restart**: "When you adjust the mentor curriculum or related mentor settings, the running server picks them up on the next mentor check. If the config edit is malformed, the mentor keeps using its last safe startup settings instead of failing a tick."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Mentor config hot-read | Edit mentor settings in the agent config file; the next mentor status check or tick reads the updated mentor block |
+| Defensive mentor config fallback | Malformed config edits keep the mentor on its startup settings until the file is repaired |
+
+## Evidence
+
+Unit coverage proves changed on-disk mentor agendas are read on the next call
+and malformed config falls back to the startup snapshot. Integration coverage
+pins the mentor route to fresh runner config reads. Server-backed e2e coverage
+proves a running AgentServer reflects mentor config edits without restart and
+falls back safely when the config file is malformed.

--- a/upgrades/side-effects/mentor-config-hot-read.md
+++ b/upgrades/side-effects/mentor-config-hot-read.md
@@ -1,0 +1,103 @@
+# Side-Effects Review — Mentor config hot-read
+
+**Version / slug:** `mentor-config-hot-read`
+**Date:** `2026-05-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `instar-codey second-pass checklist`
+
+## Summary of the change
+
+This change makes the mentor runner read the mentor block from the agent config
+file each time it needs configuration. The startup mentor config is retained as
+the fallback for missing, unreadable, or malformed config reads. This lets
+operators adjust the mentor curriculum and runtime settings without restarting
+the server while keeping mentor ticks defensive.
+
+## Decision-point inventory
+
+- `readMentorConfigFromDisk` — add — reads and merges the current on-disk mentor
+  block with defaults, or returns the startup fallback on unsafe reads.
+- `AgentServer.buildMentorRunner` — modify — passes a fresh-reading getConfig
+  closure to the mentor runner instead of closing over startup config.
+- Mentor route and e2e tests — modify — pin route-level and server-level hot-read
+  behavior.
+
+---
+
+## 1. Over-block
+
+A malformed mentor block now falls back to the startup snapshot rather than
+partially applying valid fields around the malformed value. That is intentional:
+the config edit is not trustworthy enough to merge safely, and keeping the last
+known startup behavior is less surprising than accepting a half-bad shape.
+
+## 2. Under-block
+
+The helper performs only shallow shape validation, matching the previous runtime
+behavior that trusted the loaded config shape. Invalid field values inside an
+object can still flow through. This PR does not add schema validation because the
+request was scoped to hot-reading and defensive read failures, not changing the
+mentor config contract.
+
+## 3. Level-of-abstraction fit
+
+The hot-read belongs at the `AgentServer` runner boundary, where the server
+already wires state directory access into the mentor runner. The runner remains a
+pure dependency-injected orchestrator and still receives a simple getConfig
+function.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [x] Not applicable to conversational/product judgment — this is runtime config
+  loading for a dormant/off-by-default mentor job.
+
+## 5. Interactions
+
+- **Shadowing:** The helper reads only the mentor block and does not mutate the
+  main server config object.
+- **Double-fire:** No new timers or routes are introduced; existing mentor status
+  and tick calls simply observe fresher config.
+- **Races:** A config write racing with a mentor tick can produce a transient
+  parse failure. The fallback path handles that by using the startup snapshot.
+- **Feedback loops:** Live mentor delivery can now observe changed topic or
+  curriculum settings without restart. Outstanding-prompt safeguards remain
+  unchanged.
+
+## 6. External surfaces
+
+Operators can update mentor settings while the server is running. A bad edit no
+longer risks throwing through a mentor tick. No public API shape changes, data
+migrations, Telegram topic creation, or dashboard changes are introduced.
+
+## 7. Rollback cost
+
+Rollback is a code and test revert. No persisted data is migrated or rewritten.
+
+## Conclusion
+
+The change addresses the stale mentor config cache directly and keeps the mentor
+loop defensive under malformed runtime config edits. Unit, integration, and e2e
+tests cover the hot-read and fallback behavior.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** instar-codey second-pass checklist
+**Independent read of the artifact:** concur
+
+The second pass agrees that the helper is scoped to mentor config only, preserves
+the runner abstraction, and does not introduce new authority or delivery paths.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/AgentServer-mentor-config-hot-read.test.ts`
+- `tests/integration/mentor-routes.test.ts`
+- `tests/e2e/mentor-onboarding-lifecycle.test.ts`


### PR DESCRIPTION
## Summary

Makes the mentor runner hot-read the `mentor` block from `.instar/config.json` every time it asks for config, so onboarding agenda and mentor settings update without a server restart.

## Root Cause

`AgentServer.buildMentorRunner` closed over `options.config.mentor` at startup. Runtime edits to `mentor.onboardingAgenda` or other mentor settings were invisible until the server restarted.

## Changes

- Added a defensive `readMentorConfigFromDisk` helper with fallback to the cached startup mentor config on read, parse, or bad-shape failures.
- Wired the mentor runner `getConfig` closure to read the current on-disk mentor block each call.
- Added unit, integration, and server-backed e2e coverage for hot-read and fallback behavior.
- Added fresh `upgrades/NEXT.md` and side-effects review artifact.

## Validation

- `npx vitest run tests/unit/AgentServer-mentor-config-hot-read.test.ts tests/integration/mentor-routes.test.ts tests/e2e/mentor-onboarding-lifecycle.test.ts`
- `npm run lint`
- `npm run build`
- `npm run check:upgrade-guide`
- `npm run check:pre-push-gate`

Notes: upgrade-guide validation still reports existing historical-guide warnings; this branch's active guide validated. Pre-push gate passed with the known release-cut package-version warning.
