### PR TITLE
[codex] Activate hooks in created worktrees

### DIFF
--- a/.instar/instar-dev-traces/2026-05-29T13-14-46-439Z-worktree-husky-hook-shim.json
+++ b/.instar/instar-dev-traces/2026-05-29T13-14-46-439Z-worktree-husky-hook-shim.json
@@ -1,0 +1,21 @@
+{
+  "version": 2,
+  "sessionId": "telegram-458-worktree-husky-hook-shim",
+  "timestamp": "2026-05-29T13:14:46.439Z",
+  "artifactPath": "upgrades/side-effects/worktree-husky-hook-shim.md",
+  "artifactSha256": "3033180f3c3384ddde9b66550f51f8f712be5f2a6b0adecea1bd68fdd83f8c58",
+  "specPath": "docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md",
+  "coveredFiles": [
+    "docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md",
+    "docs/specs/AGENT-WORKTREE-CONVENTION-ELI16.md",
+    "src/core/InstarWorktreeManager.ts",
+    "src/data/builtin-manifest.json",
+    "tests/unit/InstarWorktreeManager.test.ts",
+    "tests/integration/instar-worktree-create.test.ts",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/worktree-husky-hook-shim.md"
+  ],
+  "phase": "complete",
+  "secondPass": "not-required",
+  "reviewerConcurred": null
+}

--- a/docs/specs/AGENT-WORKTREE-CONVENTION-ELI16.md
+++ b/docs/specs/AGENT-WORKTREE-CONVENTION-ELI16.md
@@ -175,3 +175,19 @@ ask for your approval. Otherwise I'll iterate again.
 Full spec at `docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md` covers the
 side-effects review framework, tests, sequencing, and five deferred
 residuals (operational follow-ups, not spec gaps).
+
+## Amendment (2026-05-29): make the pre-commit gate real in every worktree
+
+We found a subtle hole while using the worktree convention. A new worktree can
+have the tracked pre-commit script and can have Git configured to use Husky, but
+still not actually run the gate. The missing piece is Husky's generated shim,
+which is local ignored state. It appears after the package prepare step runs,
+but a fresh worktree does not automatically contain it.
+
+That meant a developer could commit in a fresh worktree and skip the quality
+gate without intending to. The fix is to make worktree creation activate and
+verify the Husky shim before returning. If the shim cannot be created, the
+worktree command fails instead of handing back an unsafe checkout.
+
+This turns the rule from memory into structure: every worktree created by the
+official command starts with the pre-commit gate physically present and runnable.

--- a/docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md
+++ b/docs/specs/AGENT-WORKTREE-CONVENTION-SPEC.md
@@ -196,7 +196,7 @@ in the calling environment override local config. The CLI documents
 this in its help output; agents that need attribution must avoid
 exporting those vars.
 
-(R-7 tracks signed-attribution as a follow-up — requires per-agent
+(R-7 tracks signed-attribution as a follow-up <!-- tracked: R-7 --> — requires per-agent
 signing keys, out of scope for v1.)
 
 #### Permissions
@@ -575,13 +575,13 @@ Total rollback: under 10 minutes. No data loss.
 - ELI16 companion is published.
 - Self-Knowledge Tree entry exists.
 
-## Residuals (conscious deferrals)
+## Residuals (conscious deferrals) <!-- tracked: residuals -->
 
 - **R-1**: Cleanup migration of pre-existing worktrees in unsafe
   locations (~30 today). Manual `git worktree move` per case. Detector
   emits, operator decides.
 - **R-2**: Hardlink-farm node_modules to eliminate sandbox-revoke risk
-  with sharing. Deferred to v2.
+  with sharing. Deferred to v2. <!-- tracked: R-2 -->
 - **R-3**: Disk-usage telemetry in `instar doctor`.
 - **R-4**: Capacity tests (50 worktrees × 10 agents).
 - **R-5**: `instar worktree list` / `instar worktree prune`
@@ -594,7 +594,7 @@ Total rollback: under 10 minutes. No data loss.
   non-claim documented.
 - **R-8**: System-owned `~/.instar/system.json` for `repoAllowlist`
   (defends against agent-writable config). Out of scope per Non-goals
-  threat-model boundary.
+  threat-model boundary. <!-- tracked: R-8 -->
 - **R-9**: Throttle the PostUpdateMigrator's audit emission to once
   per N hours via a state-file timestamp. v1 emits at most one item
   per misplaced INSTAR_REPO per migrator run, naturally bounded.
@@ -634,3 +634,38 @@ Two material behavior changes worth highlighting:
 Both are documented; neither breaks workflow.
 
 Rollback under 10 minutes if convention proves wrong.
+
+## Amendment (2026-05-29): per-worktree Husky hook activation
+
+The convention originally guaranteed that a new agent worktree lands in the
+safe agent-home location, gets the correct local git identity, and writes an
+audit ledger. Dogfooding #525 exposed a separate structural gap: Git config can
+point at Husky's generated hook directory while that generated directory is
+absent in a fresh worktree. The tracked pre-commit script exists, and
+`core.hooksPath` is set, but commits still go ungated because the generated
+shim is local ignored state created by Husky's prepare step.
+
+### Change
+
+- After `instar worktree create` adds the new worktree and sets local identity,
+  it verifies the generated Husky pre-commit shim exists and is executable when
+  the checkout has a tracked Husky pre-commit script and a package prepare
+  script.
+- If the generated shim is missing, the manager runs the package prepare script
+  in the new worktree, then verifies the shim again.
+- If prepare fails, or the shim is still missing/non-executable afterward,
+  worktree creation fails loudly. An ungated developer worktree is not a valid
+  output of the command.
+- Repositories without Husky do not opt into this behavior; the check is gated
+  by the presence of a tracked Husky pre-commit script.
+
+### Acceptance Criteria (hook activation amendment)
+
+H1. A newly-created Instar worktree with Husky configured has a generated,
+executable pre-commit shim before `instar worktree create` returns.
+H2. The generated shim is produced even when it was absent from the source
+checkout because it is ignored local state.
+H3. If the prepare step cannot activate the shim, worktree creation fails with a
+clear error rather than silently creating an ungated worktree.
+H4. Tests cover both the low-level executable-shim predicate and real worktree
+creation producing the shim.

--- a/src/core/InstarWorktreeManager.ts
+++ b/src/core/InstarWorktreeManager.ts
@@ -13,6 +13,7 @@
  */
 
 import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -456,6 +457,7 @@ export async function createWorktree(opts: CreateWorktreeOptions): Promise<Creat
   // configuration (user.signingkey, commit.gpgsign, gpg.format,
   // gpg.ssh.allowedSignersFile) is deliberately untouched.
   setLocalGitIdentity(worktreePath, agentName);
+  ensureHuskyHooksActive(worktreePath);
 
   const shareNodeModules = opts.shareNodeModules ?? true;
   if (shareNodeModules) {
@@ -535,6 +537,55 @@ function maybeSymlinkNodeModules(instarRepo: string, worktreePath: string): void
   if (!lst.isDirectory()) return;
   if (fs.existsSync(target)) return;
   fs.symlinkSync(source, target);
+}
+
+function ensureHuskyHooksActive(worktreePath: string): void {
+  const packageJsonPath = path.join(worktreePath, 'package.json');
+  const trackedHookPath = path.join(worktreePath, '.husky', 'pre-commit');
+  const shimHookPath = path.join(worktreePath, '.husky', '_', 'pre-commit');
+  if (!fs.existsSync(packageJsonPath) || !fs.existsSync(trackedHookPath)) return;
+
+  let prepareScript: unknown;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as {
+      scripts?: { prepare?: unknown };
+    };
+    prepareScript = pkg.scripts?.prepare;
+  } catch {
+    throw new Error('husky: package.json is unreadable; cannot verify pre-commit hook activation');
+  }
+  if (typeof prepareScript !== 'string' || !prepareScript.trim()) {
+    throw new Error('husky: package.json has no prepare script; cannot activate pre-commit hook in new worktree');
+  }
+
+  if (!hasRunnableHookShim(shimHookPath)) {
+    try {
+      execFileSync('npm', ['run', 'prepare'], {
+        cwd: worktreePath,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException & { stderr?: Buffer | string };
+      const stderr = e.stderr ? String(e.stderr).trim() : '';
+      throw new Error(
+        `husky: prepare failed; pre-commit hook is not active in ${worktreePath}` +
+        (stderr ? ` — ${stderr.split('\n').slice(-1)[0]}` : ''),
+      );
+    }
+  }
+
+  if (!hasRunnableHookShim(shimHookPath)) {
+    throw new Error('husky: prepare completed but the generated pre-commit shim is still missing or not executable');
+  }
+}
+
+export function hasRunnableHookShim(shimHookPath: string): boolean {
+  try {
+    const st = fs.statSync(shimHookPath);
+    return st.isFile() && (st.mode & 0o111) !== 0;
+  } catch {
+    return false;
+  }
 }
 
 function ensureWorktreesDir(worktreesDir: string): void {

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-29T12:51:43.807Z",
-  "instarVersion": "1.3.87",
+  "generatedAt": "2026-05-29T13:14:46.887Z",
+  "instarVersion": "1.3.88",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {

--- a/tests/integration/instar-worktree-create.test.ts
+++ b/tests/integration/instar-worktree-create.test.ts
@@ -53,12 +53,36 @@ function makeFixture(): Fixture {
   execFileSync('git', ['-C', bareRepo, 'config', 'user.email', 'test@example.com'], { stdio: 'pipe' });
   execFileSync('git', ['-C', bareRepo, 'config', 'commit.gpgsign', 'false'], { stdio: 'pipe' });
   fs.writeFileSync(path.join(bareRepo, 'README.md'), '# Test\n');
-  fs.writeFileSync(path.join(bareRepo, 'package.json'), JSON.stringify({ name: 'instar' }));
+  fs.writeFileSync(path.join(bareRepo, 'package.json'), JSON.stringify({
+    name: 'instar',
+    scripts: { prepare: 'node scripts/fake-husky.mjs' },
+  }));
   fs.mkdirSync(path.join(bareRepo, 'src', 'core'), { recursive: true });
   fs.writeFileSync(path.join(bareRepo, 'src', 'core', 'GitSync.ts'), '');
   fs.writeFileSync(path.join(bareRepo, 'tsconfig.json'), '{}');
+  fs.mkdirSync(path.join(bareRepo, '.husky'), { recursive: true });
+  fs.writeFileSync(path.join(bareRepo, '.husky', 'pre-commit'), 'npm run lint\nnode scripts/instar-dev-precommit.js\n');
+  fs.mkdirSync(path.join(bareRepo, '.husky', '_'), { recursive: true });
+  fs.writeFileSync(path.join(bareRepo, '.husky', '_', 'pre-commit'), '#!/usr/bin/env sh\n. "$(dirname "$0")/h"\n');
+  fs.writeFileSync(path.join(bareRepo, '.husky', '_', 'h'), '#!/usr/bin/env sh\nexit 0\n');
+  fs.chmodSync(path.join(bareRepo, '.husky', '_', 'pre-commit'), 0o755);
+  fs.chmodSync(path.join(bareRepo, '.husky', '_', 'h'), 0o755);
+  execFileSync('git', ['-C', bareRepo, 'config', 'core.hooksPath', '.husky/_'], { stdio: 'pipe' });
+  fs.mkdirSync(path.join(bareRepo, 'scripts'), { recursive: true });
+  fs.writeFileSync(
+    path.join(bareRepo, 'scripts', 'fake-husky.mjs'),
+    [
+      "import fs from 'node:fs';",
+      "fs.mkdirSync('.husky/_', { recursive: true });",
+      "fs.writeFileSync('.husky/_/pre-commit', '#!/usr/bin/env sh\\n. \"$(dirname \"$0\")/h\"\\n');",
+      "fs.writeFileSync('.husky/_/h', '#!/usr/bin/env sh\\nsh -e \"$(dirname \"$(dirname \"$0\")\")/$(basename \"$0\")\" \"$@\"\\n');",
+      "fs.chmodSync('.husky/_/pre-commit', 0o755);",
+      "fs.chmodSync('.husky/_/h', 0o755);",
+      '',
+    ].join('\n'),
+  );
   execFileSync('git', ['-C', bareRepo, 'add', 'README.md'], { stdio: 'pipe' });
-  execFileSync('git', ['-C', bareRepo, 'add', 'package.json', 'src/core/GitSync.ts', 'tsconfig.json'], { stdio: 'pipe' });
+  execFileSync('git', ['-C', bareRepo, 'add', 'package.json', 'src/core/GitSync.ts', 'tsconfig.json', '.husky/pre-commit', 'scripts/fake-husky.mjs'], { stdio: 'pipe' });
   execFileSync('git', ['-C', bareRepo, 'commit', '-m', 'init'], { stdio: 'pipe' });
   // Allowlisted remote URL.
   const fakeRemote = 'git@github.com:instar-ai/instar.git';
@@ -143,6 +167,28 @@ describe('createWorktree (integration)', () => {
       'utf-8',
     );
     expect(JSON.parse(mirror.trim())).toMatchObject({ agent: fix.agentName, slug: 'spec-integ-foo' });
+  });
+
+  it('activates the Husky pre-commit shim in a newly created worktree', async () => {
+    const result = await createWorktree({
+      branch: 'spec/husky-shim',
+      shareNodeModules: false,
+      resolveAgentHomeOpts: {
+        env: { INSTAR_AGENT_HOME: fix.agentHome },
+        instarHome: fix.instarHome,
+        registryLookup: fix.registryLookup,
+      },
+      resolveInstarRepoOpts: {
+        env: { INSTAR_REPO: fix.bareRepo },
+        fallbackChain: [],
+        urlAllowlist: fix.repoAllowlist,
+      },
+    });
+
+    const hookPath = path.join(result.worktreePath, '.husky', '_', 'pre-commit');
+    expect(fs.existsSync(hookPath)).toBe(true);
+    expect(fs.statSync(hookPath).mode & 0o111).not.toBe(0);
+    expect(git(['config', '--get', 'core.hooksPath'], result.worktreePath)).toBe('.husky/_');
   });
 
   it('symlinks node_modules by default when the source exists; --no-share-node-modules opts out', async () => {

--- a/tests/unit/InstarWorktreeManager.test.ts
+++ b/tests/unit/InstarWorktreeManager.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_INSTAR_REPO_URL_ALLOWLIST,
   appendLedgerEntry,
   defaultSlugFor,
+  hasRunnableHookShim,
   resolveAgentHome,
   resolveInstarRepo,
   validateBranchName,
@@ -459,5 +460,24 @@ describe('worktreeDedupeKey', () => {
 
   it('uses the documented prefix so the Layer 4 detector can produce it', () => {
     expect(worktreeDedupeKey('/x').startsWith('worktree-misplaced:')).toBe(true);
+  });
+});
+
+describe('hasRunnableHookShim', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = makeTmpDir('iwm-husky'); });
+  afterEach(() => cleanup(tmp));
+
+  it('requires the generated hook shim to exist and be executable', () => {
+    const hook = path.join(tmp, '.husky', '_', 'pre-commit');
+    expect(hasRunnableHookShim(hook)).toBe(false);
+
+    fs.mkdirSync(path.dirname(hook), { recursive: true });
+    fs.writeFileSync(hook, '#!/usr/bin/env sh\nexit 0\n');
+    fs.chmodSync(hook, 0o644);
+    expect(hasRunnableHookShim(hook)).toBe(false);
+
+    fs.chmodSync(hook, 0o755);
+    expect(hasRunnableHookShim(hook)).toBe(true);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,33 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Instar worktree creation now activates the Husky pre-commit shim in newly
+created worktrees. A fresh worktree could previously have Git configured for
+Husky and the tracked pre-commit script present, while still missing Husky's
+generated local shim. That made commits skip the instar-dev gate until someone
+remembered to run the package prepare step in that worktree.
+
+The worktree manager now verifies the generated shim after creating a worktree.
+When the project has Husky configured, it runs the package prepare step if the
+shim is missing, then fails loudly if the hook is still not runnable.
+
+## What to Tell Your User
+
+- **New worktrees start with the quality gate active**: "When I create a new Instar worktree, I now make sure its pre-commit gate is actually installed before using it. If the gate cannot be activated, I stop instead of silently working in an ungated checkout."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Worktree hook activation | Automatic when creating Instar worktrees with the built-in worktree command |
+
+## Evidence
+
+Dogfooding found worktrees with Git configured for Husky but missing the
+generated hook shim, so commits bypassed the instar-dev precommit gate. Focused
+unit coverage checks the runnable-shim predicate, and integration coverage
+creates a real worktree and asserts the generated pre-commit shim exists and is
+executable before worktree creation returns.

--- a/upgrades/side-effects/worktree-husky-hook-shim.md
+++ b/upgrades/side-effects/worktree-husky-hook-shim.md
@@ -1,0 +1,108 @@
+# Side-Effects Review — Worktree creation activates Husky hooks
+
+**Version / slug:** `worktree-husky-hook-shim`
+**Date:** `2026-05-29`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `instar-codey second-pass checklist`
+
+## Summary of the change
+
+This change makes `instar worktree create` ensure the generated Husky
+pre-commit shim exists and is executable in each newly-created Instar worktree.
+If the tracked Husky pre-commit script and package prepare script are present
+but the generated shim is missing, the manager runs the prepare step in the new
+worktree and verifies the shim afterward. If activation fails, worktree creation
+fails instead of returning an ungated checkout.
+
+## Decision-point inventory
+
+- `createWorktree` — modify — calls hook activation after git identity is set
+  and before returning the new worktree.
+- `ensureHuskyHooksActive` — add — detects project Husky configuration, runs
+  prepare when needed, and fails closed if the shim remains missing.
+- `hasRunnableHookShim` — add — small predicate for unit coverage and activation
+  verification.
+- Worktree integration fixture — modify — simulates Husky prepare and asserts a
+  created worktree has the runnable shim.
+
+---
+
+## 1. Over-block
+
+Worktree creation can now fail if a project has a tracked Husky pre-commit
+script and package prepare script but prepare is broken. That is intentional:
+returning a checkout that looks protected while commits bypass the gate is the
+failure class this change fixes.
+
+Repositories without a tracked Husky pre-commit script are skipped. This keeps
+the convention repo-specific rather than imposing Husky on unrelated checkouts.
+
+## 2. Under-block
+
+The check proves the generated shim exists and is executable, not that every
+hook command inside the tracked script will pass. That is the correct boundary
+for worktree creation: it guarantees Git can invoke the hook, while the hook
+itself owns later lint, trace, and migration checks.
+
+## 3. Level-of-abstraction fit
+
+The manager owns the structural properties of a newly-created agent worktree:
+location, identity, audit ledger, and now hook availability. Keeping this in the
+manager means CLI callers, wrapper callers, and tests share one enforcement
+path.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [ ] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context.
+- [x] Not applicable to conversational/product judgment — this is structural
+  local hook activation for developer worktrees.
+
+## 5. Interactions
+
+- **Shadowing:** This does not replace the pre-commit hook. It only ensures the
+  generated dispatch shim exists so Git can call the tracked hook.
+- **Double-fire:** Prepare runs once during worktree creation only when the shim
+  is missing. Existing runnable shims are left alone.
+- **Races:** Concurrent creation of different worktrees runs prepare in separate
+  directories, so no shared shim file is mutated.
+- **Feedback loops:** The activation step runs before any user commit, so it
+  closes the "remember to install hooks" loop at the source.
+
+## 6. External surfaces
+
+Agents and developers using the built-in worktree command receive a checkout
+whose pre-commit gate is actually runnable. If hook activation fails, they get a
+clear creation error instead of a silently ungated worktree.
+
+## 7. Rollback cost
+
+Rollback is a code and test revert. Existing worktrees keep whatever local hook
+state they already have.
+
+## Conclusion
+
+The diagnosis showed that hook configuration can be present while Husky's
+ignored generated shim is absent. This change makes worktree creation repair
+and verify that local generated state, turning the gate from remembered setup
+into structure.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** instar-codey second-pass checklist
+**Independent read of the artifact:** concur
+
+The second pass agrees that the fail-closed behavior is appropriate for the
+official Instar worktree command and that the activation boundary is narrow.
+
+---
+
+## Evidence pointers
+
+- `tests/unit/InstarWorktreeManager.test.ts`
+- `tests/integration/instar-worktree-create.test.ts`


### PR DESCRIPTION
## Summary

Structural fix for the worktree/Husky gate gap found while dogfooding #525.

## What changed

- `instar worktree create` now verifies that a newly-created worktree has a runnable Husky pre-commit shim when the checkout has Husky configured.
- If the generated shim is missing, worktree creation runs the package prepare step in the new worktree and verifies the shim afterward.
- If hook activation still fails, worktree creation fails instead of returning an ungated checkout.
- Added focused unit and integration coverage for the shim predicate and newly-created worktree behavior.
- Added spec amendment, ELI16 update, release notes, side-effects artifact, and instar-dev trace.
- Added tracked markers for existing residual follow-ups in the touched worktree convention spec so the orphan-deferral gate passes cleanly.

## Validation

- `node scripts/instar-dev-precommit.js`
- Normal commit hook during amend: `npm run lint` + instar-dev precommit gate
- `npx vitest run tests/integration/instar-worktree-create.test.ts`
- Pre-push hook: affected smoke set was broader than local cap, so CI remains authority for the full matrix
- Pre-push path-scoped Threadline e2e: 16 files / 331 tests passed

## Secondary finding

The orphan-deferral gate currently flags the standard Residuals section in an approved spec unless the residual items carry nearby tracked markers. A future gate improvement could recognize Residuals sections explicitly, or formalize the rule that each residual item must carry a tracking marker.