### PR TITLE
[codex] Authenticate self-discovery capability checks

### DIFF
--- a/.instar/instar-dev-traces/2026-05-29T13-47-30-000Z-capabilities-auth-self-discovery.json
+++ b/.instar/instar-dev-traces/2026-05-29T13-47-30-000Z-capabilities-auth-self-discovery.json
@@ -1,0 +1,21 @@
+{
+  "id": "capabilities-auth-self-discovery",
+  "timestamp": "2026-05-29T13:47:30.000Z",
+  "task": "Align self-discovery capability-check docs with authenticated /capabilities contract",
+  "changedFiles": [
+    "src/commands/init.ts",
+    "src/core/PostUpdateMigrator.ts",
+    "tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts",
+    "src/data/builtin-manifest.json",
+    "upgrades/NEXT.md",
+    "upgrades/side-effects/capabilities-auth-self-discovery.md"
+  ],
+  "riskReview": [
+    "Does not exempt /capabilities from auth.",
+    "Migrator rewrites only legacy unauthenticated localhost capabilities curl commands.",
+    "Fresh and migrated instructions now agree with the runtime server contract."
+  ],
+  "validation": [
+    "npx vitest run tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts — 13 tests passed"
+  ]
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1441,7 +1441,7 @@ Skills compound over time. Each one makes future sessions more capable. You are 
 Before EVER saying "I don't have", "I can't", or "this isn't available" — check what actually exists:
 
 \`\`\`bash
-curl http://localhost:\${INSTAR_PORT:-${port}}/capabilities
+curl -H "Authorization: Bearer $AUTH" http://localhost:\${INSTAR_PORT:-${port}}/capabilities
 \`\`\`
 
 This returns your full capability matrix: scripts, hooks, Telegram status, jobs, relationships, and more. It is the source of truth about what you can do. **Never hallucinate about missing capabilities — verify first.**

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2853,6 +2853,8 @@ If the user reports they were "unresponsive for a while during updates," check \
       result.skipped.push('CLAUDE.md: Self-Heal section already present');
     }
 
+    const authenticatedCapabilitiesCurl = `curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/capabilities`;
+
     // Self-Discovery section
     if (!content.includes('Self-Discovery') && !content.includes('/capabilities')) {
       const section = `
@@ -2861,7 +2863,7 @@ If the user reports they were "unresponsive for a while during updates," check \
 Before EVER saying "I don't have", "I can't", or "this isn't available" — check what actually exists:
 
 \`\`\`bash
-curl http://localhost:${port}/capabilities
+${authenticatedCapabilitiesCurl}
 \`\`\`
 
 This returns your full capability matrix: scripts, hooks, Telegram status, jobs, relationships, and more. It is the source of truth about what you can do. **Never hallucinate about missing capabilities — verify first.**
@@ -2880,6 +2882,14 @@ This returns your full capability matrix: scripts, hooks, Telegram status, jobs,
       result.upgraded.push('CLAUDE.md: added Self-Discovery section');
     } else {
       result.skipped.push('CLAUDE.md: Self-Discovery section already present');
+    }
+
+    const legacyCapabilitiesCurl =
+      /curl(?: -s)? http:\/\/localhost:(?:\$\{INSTAR_PORT:-)?\d+\}?\/capabilities/g;
+    if (legacyCapabilitiesCurl.test(content)) {
+      content = content.replace(legacyCapabilitiesCurl, () => authenticatedCapabilitiesCurl);
+      patched = true;
+      result.upgraded.push('CLAUDE.md: authenticated Self-Discovery capabilities curl');
     }
 
     // Telegram Relay section — add if Telegram is configured but section is missing

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-29T13:14:46.887Z",
-  "instarVersion": "1.3.88",
+  "generatedAt": "2026-05-29T13:47:56.820Z",
+  "instarVersion": "1.3.89",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -1489,7 +1489,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "1fd1742471085a3b4ea20557d99aee966ea8bc4d92582b51cf18791ce76429d3",
+      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts
+++ b/tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts
@@ -268,4 +268,41 @@ describe('PostUpdateMigrator — CLAUDE.md Secret Drop rewrite', () => {
     expect(after).not.toMatch(/\/secrets\/retrieve\/TOKEN`/);
     expect(result.upgraded.some(u => u.includes('hardened helper'))).toBe(true);
   });
+
+  it('rewrites legacy unauthenticated Self-Discovery capabilities curl', () => {
+    const legacy = [
+      '# CLAUDE.md — test',
+      '',
+      '### Self-Discovery (Know Before You Claim)',
+      '',
+      'Before EVER saying "I don\'t have", check what actually exists:',
+      '',
+      '```bash',
+      'curl http://localhost:4040/capabilities',
+      '```',
+      '',
+    ].join('\n');
+    fs.writeFileSync(claudeMdPath, legacy);
+
+    const result = runMigrateClaudeMd(createMigrator(projectDir));
+    expect(result.errors).toEqual([]);
+
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after).toContain('curl -H "Authorization: Bearer $AUTH" http://localhost:4042/capabilities');
+    expect(after).not.toContain('curl http://localhost:4040/capabilities');
+    expect(result.upgraded.some(u => u.includes('authenticated Self-Discovery capabilities curl'))).toBe(true);
+  });
+
+  it('adds Self-Discovery with the authenticated capabilities curl when missing', () => {
+    fs.writeFileSync(claudeMdPath, '# CLAUDE.md — test\n\n### How to Build New Capabilities\n\nBuild it.\n');
+
+    const result = runMigrateClaudeMd(createMigrator(projectDir));
+    expect(result.errors).toEqual([]);
+
+    const after = fs.readFileSync(claudeMdPath, 'utf-8');
+    expect(after).toContain('### Self-Discovery (Know Before You Claim)');
+    expect(after).toContain('curl -H "Authorization: Bearer $AUTH" http://localhost:4042/capabilities');
+    expect(after).not.toContain('curl http://localhost:4042/capabilities');
+    expect(result.upgraded.some(u => u.includes('added Self-Discovery section'))).toBe(true);
+  });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,35 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The self-discovery guidance for capability checks now matches the authenticated
+server contract. Existing instructions told agents to call the capabilities
+endpoint without an authorization header, but the endpoint requires the agent's
+Bearer token. Agents following the documented "know before you claim" step could
+therefore get a 401 instead of the capability matrix.
+
+Fresh initialization now renders the authenticated capabilities command, and the
+post-update migrator both adds the authenticated form for stale files missing the
+section and rewrites legacy unauthenticated capability-check commands in
+existing CLAUDE.md files.
+
+## What to Tell Your User
+
+- **Self-discovery now uses the working authenticated request**: "When I check
+  what I can actually do, my local instructions now use the same authenticated
+  capabilities call the server expects, so the documented verification step no
+  longer fails before it can answer."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Authenticated self-discovery guidance | Existing agents receive the corrected capability-check instruction on update; new agents get it during initialization |
+
+## Evidence
+
+Unit coverage verifies the post-update migrator rewrites legacy unauthenticated
+capabilities checks and adds the self-discovery section with the authenticated
+form when it is missing.

--- a/upgrades/side-effects/capabilities-auth-self-discovery.md
+++ b/upgrades/side-effects/capabilities-auth-self-discovery.md
@@ -1,0 +1,31 @@
+# Side Effects Review — capabilities auth self-discovery
+
+## Change
+
+Align agent-facing self-discovery instructions with the runtime server contract:
+capability checks require the configured Bearer token.
+
+## Surfaces Touched
+
+- Fresh init CLAUDE.md generation.
+- Post-update CLAUDE.md migration for existing agents.
+- Built-in manifest regeneration for changed source templates.
+
+## Expected Effects
+
+- Agents following "know before you claim" get the capability matrix instead of
+  an authentication error.
+- Existing stale CLAUDE.md files are corrected during update without requiring a
+  full re-init.
+
+## Risk Review
+
+- The change does not relax API auth or expose capability data publicly.
+- The migrator rewrite targets only unauthenticated localhost capabilities curl
+  commands and replaces them with the authenticated form for the configured
+  server port.
+- Existing already-authenticated commands are left unchanged.
+
+## Validation
+
+- Focused unit coverage covers both rewrite and missing-section insertion.


### PR DESCRIPTION
## Summary

Fixes the self-discovery doc/runtime mismatch where agent instructions told agents to call `/capabilities` without auth even though the server requires the Bearer token.

## What changed

- Updates the init-generated Self-Discovery section to include the auth header.
- Updates the post-update migrator to add the authenticated form when Self-Discovery is missing.
- Adds a migrator rewrite for legacy unauthenticated localhost capability checks in existing CLAUDE.md files.
- Regenerates the built-in manifest and adds release/side-effects/trace artifacts.
- Adds regression coverage for both adding and rewriting the Self-Discovery capability-check command.

## Validation

- `npx vitest run tests/unit/PostUpdateMigrator-secretDropHardenedRetrieve.test.ts` — 13 tests passed
- Normal commit hook after regenerating the Husky shim: `npm run lint` + instar-dev precommit gate passed
- Pre-push hook: affected smoke set exceeded the local cap, so CI remains authority for the full matrix
- Pre-push path-scoped Threadline e2e: 16 files / 331 tests passed

## Note

This PR keeps `/capabilities` authenticated and aligns the agent-facing instructions with that contract rather than making the endpoint public.