### PR TITLE
fix(session): transient-API-error recovery — re-arm the nudge + generalize backoff to the whole 5xx/timeout class

### DIFF
--- a/docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.eli16.md
+++ b/docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.eli16.md
@@ -37,8 +37,28 @@ Long autonomous runs survive transient service hiccups on their own — the agen
 itself back to work each time, instead of silently freezing after the first one. No
 config to set; it ships to every agent with the next update.
 
+## The bigger half: make the smart recovery cover ALL these errors
+
+We already had a *smart* recovery helper for one specific case — when the AI service says
+"slow down, you're sending too much" (a rate limit). For that, it doesn't just retry
+instantly; it waits a bit, then a bit longer, then longer (so it doesn't make things
+worse), tells you "I'm backing off, you're not dropped," checks whether the retry worked,
+and gives up gracefully if it never does. That's exactly the behavior we want.
+
+The problem: that smart helper ONLY knew about the "slow down" error. A regular hiccup
+like "Error 500" didn't get the smart treatment — just the dumb instant tap.
+
+The fix: teach the smart helper about the **whole family** of temporary hiccups (500,
+502, 503, timeouts, dropped connections), not just rate limits. A 500 now gets the same
+"wait, retry, check, escalate if needed" treatment — except the waits start short (5
+seconds), because a 500 usually clears in seconds, whereas a rate limit needs minutes.
+
+**Future-proof:** there's one list of "what counts as a temporary hiccup." Add a new kind
+of hiccup to that list and it automatically gets the smart recovery — no extra wiring.
+
 ## What it does NOT do
 
-It does not handle a genuinely-broken agent forever (that's the limit), and it does not
-add a second separate watchdog (that would double-tap and fight itself). It's one small
-fix to the helper that already existed.
+It does not handle a genuinely-broken agent forever (there's a limit), and it does not add
+a second separate watchdog (that would double-tap and fight itself). It reuses the smart
+helper we already had and the simple tap we already had — just makes them cover the whole
+family of temporary API errors instead of one case each.

--- a/docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.eli16.md
+++ b/docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.eli16.md
@@ -1,0 +1,44 @@
+# Session Error-Nudge Re-Arm — the plain-English version
+
+## What broke
+
+Sometimes the AI service has a hiccup — it returns an "API Error: 500" and the agent's
+current turn just stops, leaving it sitting there doing nothing. The agent already had a
+helper that notices this and taps it on the shoulder: "you hit an error, keep going."
+
+The bug: that shoulder-tap only worked **once per session, ever**. The agent runs for
+hours. The first hiccup got a tap. Every hiccup after that got nothing — the agent just
+sat frozen until a human poked it. Over an 8-hour run, hiccups happen more than once, so
+the agent kept getting stuck. The user saw it stop "again" and asked us to fix it.
+
+## Why the obvious fix doesn't work
+
+You might think: "just make the stop-hook restart it." But the stop-hook only runs when a
+turn ends *normally*. An error-abort isn't normal — the hook never even gets a chance to
+run. So the fix has to live in the *outside* watcher (the monitor that already does the
+shoulder-tap), not inside the agent.
+
+## The fix
+
+Three small changes to the shoulder-tap:
+
+1. **It re-arms.** As soon as the agent starts working again, we forget that we already
+   tapped it — so the *next* hiccup gets its own tap. (Before: we remembered forever, so
+   there was never a second tap.)
+2. **It has a limit.** If an agent is truly broken and keeps erroring no matter how many
+   times we tap it (50 in one session), we stop tapping and let the normal cleanup take
+   over. We don't tap forever or waste money retrying a lost cause.
+3. **The decision is a tiny, testable rule.** "Tap if we haven't tapped this round AND
+   we're under the limit." Easy to verify both ways.
+
+## What you'll notice
+
+Long autonomous runs survive transient service hiccups on their own — the agent taps
+itself back to work each time, instead of silently freezing after the first one. No
+config to set; it ships to every agent with the next update.
+
+## What it does NOT do
+
+It does not handle a genuinely-broken agent forever (that's the limit), and it does not
+add a second separate watchdog (that would double-tap and fight itself). It's one small
+fix to the helper that already existed.

--- a/docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.md
+++ b/docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.md
@@ -1,0 +1,77 @@
+---
+title: "Session Error-Nudge Re-Arm — survive repeated transient API errors in a long-running session"
+status: approved
+approved: true
+approved-by: Justin
+approved-via: Telegram topic 13481 (2026-05-29 — "Looks like you got stopped again please fix this as well and deploy the fix for all agents", in direct response to the screenshot showing an autonomous session stranded idle after an 'API Error: 500'. Explicit go to fix + deploy fleet-wide.)
+review-convergence: "tactical-hotfix-2026-05-29 (single-author, code-grounded — root-cause traced in SessionManager.ts; same urgency class as the silently-stopped-trio tactical hotfix)"
+---
+
+# Session Error-Nudge Re-Arm
+
+## Problem (observed, 2026-05-29, topic 13481)
+
+An 8-hour autonomous run was found idle at the prompt after an `API Error: 500` (a
+transient Anthropic server-side error) aborted a turn mid-task. The session did not
+resume on its own; it sat idle until the user messaged it. This was the SECOND such
+stop in the run — the user's words: "got stopped **again**".
+
+### Root cause
+
+`SessionManager` already nudges a session that goes idle right after an API error:
+its `monitorTick` idle-detection path checks the captured terminal against
+`TERMINAL_ERROR_PATTERNS` (which includes `'API Error:'` and `'Internal server
+error'`), and on a match injects "You hit an API error. Please continue your work…"
+via `sendInput`. This is the correct recovery primitive.
+
+The defect: the nudge was gated by `errorNudgedSessions: Set<string>` keyed on session
+id, and that set was **only cleared on `sessionComplete`** — i.e. once the session
+*ends*. So a session was nudged **once per session, forever**. A long-running
+autonomous session that hit a SECOND transient API error (the common case over hours)
+was never re-nudged: the first error consumed the single nudge, and every subsequent
+error left the session idle until a human intervened. After the idle-kill threshold it
+would be zombie-killed — silently losing the run.
+
+The in-session autonomous **Stop hook cannot cover this gap**: it fires only on a
+*clean* Stop event, and an API-error abort is not a clean stop. The recovery therefore
+has to come from the out-of-process monitor (`SessionManager.monitorTick`), which is
+exactly where the error-nudge already lives — it just needed to be re-armable.
+
+## Fix
+
+Make the error-nudge **per-idle-episode** instead of **per-session-forever**, bounded
+by a lifetime runaway cap:
+
+1. **Re-arm on recovery.** `errorNudgedSessions` is now an episode flag: it is set when
+   we nudge, and **cleared when the session goes active again** (produces output /
+   leaves idle — the existing "Session is active" branch that clears `idlePromptSince`).
+   A session that recovers and later hits a NEW transient API error gets its own nudge.
+2. **Runaway cap.** A new `errorNudgeTotal: Map<sessionId, number>` counts nudges across
+   the session's whole lifetime (cleared only on `sessionComplete`). Once it reaches
+   `MAX_ERROR_NUDGES_PER_SESSION` (50 — generous for genuinely-transient errors over an
+   8h run), the session stops being nudged and falls through to the normal zombie-kill
+   path. This bounds a pathological session flapping error→nudge→error that never truly
+   recovers, so we never nudge forever or burn quota.
+3. **Pure gate.** The nudge decision is the pure, exported `shouldErrorNudge(armedThisEpisode, totalNudges, max)` = `!armedThisEpisode && totalNudges < max`, so the decision boundary is unit-testable without driving the tmux loop.
+
+The rate-limit/throttle path is unchanged (it still hands off to the RateLimitSentinel
+and does NOT consume a nudge token). The fix is server-side `SessionManager` code, so it
+deploys fleet-wide via the normal release/auto-update path — no agent-installed-file or
+config change, hence no PostUpdateMigrator entry needed.
+
+## Tests
+
+- `tests/unit/session-error-nudge.test.ts`:
+  - behavioral coverage of `shouldErrorNudge` across every branch (armed→skip,
+    not-armed+under-cap→nudge, at/over-cap→skip, re-arm-after-recovery→nudge);
+  - structural pins: the episode flag is CLEARED in the "Session is active" branch
+    (re-arm), and the production gate routes through `shouldErrorNudge`.
+- `tests/unit/session-manager-behavioral.test.ts` + the SessionManager-adjacent suites
+  (terminate, zombie-kill, reap-detect, injection, multishot-recovery) remain green — no
+  regression to the idle/kill path.
+
+## Non-goals
+
+- No new sentinel/watchdog. A parallel autonomous-resumption watchdog was considered and
+  rejected: it would double-nudge the same idle pane against this existing mechanism.
+  The single source of truth is `SessionManager`'s error-nudge; it just needed re-arming.

--- a/docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.md
+++ b/docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.md
@@ -1,13 +1,13 @@
 ---
-title: "Session Error-Nudge Re-Arm — survive repeated transient API errors in a long-running session"
+title: "Transient-API-Error Recovery — re-arm the nudge + generalize backoff recovery to the whole 5xx/timeout class"
 status: approved
 approved: true
 approved-by: Justin
-approved-via: Telegram topic 13481 (2026-05-29 — "Looks like you got stopped again please fix this as well and deploy the fix for all agents", in direct response to the screenshot showing an autonomous session stranded idle after an 'API Error: 500'. Explicit go to fix + deploy fleet-wide.)
-review-convergence: "tactical-hotfix-2026-05-29 (single-author, code-grounded — root-cause traced in SessionManager.ts; same urgency class as the silently-stopped-trio tactical hotfix)"
+approved-via: Telegram topic 13481 (2026-05-29 — two messages: (1) "Looks like you got stopped again please fix this as well and deploy the fix for all agents" re: the screenshot of an autonomous session stranded after an 'API Error: 500'; (2) "I thought we already had a sentinel… for the rate limit error, it attempted exponential back off… Does that sentinel not exist? we need something… intelligent enough and general enough that it's future-proof for at least API errors of this type." Explicit go to fix + generalize + deploy fleet-wide.)
+review-convergence: "tactical-hotfix-2026-05-29 (single-author, code-grounded — root-cause traced in SessionManager.ts + RateLimitSentinel.ts; same urgency class as the silently-stopped-trio tactical hotfix)"
 ---
 
-# Session Error-Nudge Re-Arm
+# Transient-API-Error Recovery (Error-Nudge Re-Arm + Backoff Generalization)
 
 ## Problem (observed, 2026-05-29, topic 13481)
 
@@ -70,8 +70,52 @@ config change, hence no PostUpdateMigrator entry needed.
   (terminate, zombie-kill, reap-detect, injection, multishot-recovery) remain green — no
   regression to the idle/kill path.
 
+## Part 2 — Generalize the intelligent backoff recovery to the whole transient-API class
+
+The re-arm above fixes the *immediate* nudge, but the immediate nudge is the "dumb"
+path: it retries instantly, with no backoff, verify, or escalation. instar already has
+the *intelligent* recovery lifecycle — `RateLimitSentinel` — which on a detected error
+sends a "backing off, you're not dropped" notice, waits an **exponential backoff**
+before re-engaging (so it doesn't re-hit a still-down API or burn quota), **verifies**
+the nudge took (JSONL growth), **escalates** after a bounded attempts/window envelope,
+and vetoes the zombie-killer while recovery is in flight. But it was scoped ONLY to
+**throttle / rate-limit / 529-Overloaded** errors. A generic `API Error: 500` never
+reached it.
+
+**Fix:** generalize that lifecycle to the whole transient-API-error class.
+
+- **`RateLimitSentinel` gains an `ApiErrorClass`** (`'throttle' | 'transient-api'`) on
+  `report(sessionName, trigger, { errorClass })` (default `'throttle'` — fully
+  back-compatible). The lifecycle is identical across classes; only two things differ:
+  - **Backoff schedule.** Throttle keeps the long schedule (`[30s,60s,2m,5m,…]` — re-hitting
+    a throttle burns quota). `'transient-api'` uses a **fast** schedule
+    (`transientApiBackoffScheduleMs` = `[5s,15s,30s,60s,2m,5m]`) because a 500/timeout
+    usually clears in seconds — first retry is quick, then escalates gently.
+  - **User wording.** "transient API error … retrying" vs "server-side throttle … backing off".
+- **`SessionManager`** routes the generic `TERMINAL_ERROR_PATTERNS` idle case to the
+  sentinel: when an `apiErrorAtIdle` listener is wired (production), it emits that signal
+  and hands off (no immediate retry that could re-hit a down API), exactly mirroring the
+  existing `rateLimitedAtIdle` handoff. The re-armable immediate nudge (Part 1) remains
+  the **fallback** when no sentinel is wired (bare/test).
+- **`server.ts`** wires `sessionManager.on('apiErrorAtIdle', name => rateLimitSentinel.report(name, 'idle-error', { errorClass: 'transient-api' }))`.
+
+**Future-proof:** the error class is driven by the existing `TERMINAL_ERROR_PATTERNS`
+list (`API Error:`, `Internal server error`, `502`/`503`/`ServiceUnavailable`,
+`ETIMEDOUT`, `ECONNREFUSED`, `fetch failed`, …). Adding a new transient pattern there
+automatically routes it through the intelligent backoff recovery — no new wiring.
+
+### Part 2 tests
+- `tests/unit/RateLimitSentinel.test.ts` — the throttle suite is unchanged (back-compat),
+  plus a `errorClass: 'transient-api'` block: fast first backoff (5s, not 30s),
+  transient-API-worded notice, full backoff→resume→verify→recovered lifecycle, and the
+  recovery state/`listActive` reflecting the class + short schedule.
+- `tests/unit/session-error-nudge.test.ts` — the generic-error idle path defers to the
+  sentinel via `apiErrorAtIdle` when wired, with the re-armable nudge as the fallback.
+
 ## Non-goals
 
-- No new sentinel/watchdog. A parallel autonomous-resumption watchdog was considered and
-  rejected: it would double-nudge the same idle pane against this existing mechanism.
-  The single source of truth is `SessionManager`'s error-nudge; it just needed re-arming.
+- No new parallel sentinel/watchdog. A standalone autonomous-resumption watchdog was
+  considered and rejected: it would double-nudge the same idle pane against the existing
+  mechanisms. The single source of truth is `SessionManager`'s idle path → (re-armable
+  immediate nudge as fallback) / (the generalized `RateLimitSentinel` lifecycle in
+  production). One owner per session, never two.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5705,6 +5705,13 @@ export async function startServer(options: StartOptions): Promise<void> {
     sessionManager.on('rateLimitedAtIdle', (sessionName: string) => {
       rateLimitSentinel.report(sessionName, 'idle-error');
     });
+    // Generic transient API errors (500/502/503, timeout, connection drop) ride the
+    // SAME backoff→verify→escalate lifecycle as throttles, with a faster backoff
+    // schedule (they usually clear in seconds). Generalizing the proven recovery to
+    // the whole transient-API class is the 2026-05-29 future-proofing ask (topic 13481).
+    sessionManager.on('apiErrorAtIdle', (sessionName: string) => {
+      rateLimitSentinel.report(sessionName, 'idle-error', { errorClass: 'transient-api' });
+    });
     if (rlsCfg.enabled !== false) {
       console.log(pc.green('  RateLimitSentinel enabled (server-throttle backoff + check-ins)'));
     }

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -919,7 +919,22 @@ rm()  { "${shimRunner}" rm  "$@"; }
                   }
                   const hasError = TERMINAL_ERROR_PATTERNS.some(p => recentOutput.includes(p));
                   if (hasError) {
+                    // Arm the per-episode guard (re-armed on recovery — see the
+                    // "Session is active" branch). Prevents per-tick re-emit/re-nudge.
                     this.errorNudgedSessions.add(session.id);
+                    // If a recovery sentinel owns the generic transient-API-error class
+                    // (production wiring), hand off to its backoff→verify→escalate
+                    // lifecycle rather than an immediate retry that could re-hit a
+                    // still-down API. The sentinel owns the retry budget + is re-armable
+                    // across episodes by design. (Mirrors the rate-limit handoff above;
+                    // generalizes that proven recovery to the whole transient-API class.)
+                    if (this.listenerCount('apiErrorAtIdle') > 0) {
+                      this.emit('apiErrorAtIdle', session.tmuxSession);
+                      this.idlePromptSince.delete(session.id);
+                      continue; // Skip to next session — sentinel owns recovery.
+                    }
+                    // Fallback (no sentinel wired, e.g. bare/test): the re-armable
+                    // immediate nudge, bounded by the lifetime cap.
                     this.errorNudgeTotal.set(session.id, nudgeTotal + 1);
                     console.log(`[SessionManager] Session "${session.name}" idle after API error — nudging to continue (nudge #${nudgeTotal + 1} this session).`);
                     this.sendInput(session.tmuxSession, 'You hit an API error. Please continue your work — skip or work around the action that failed.');

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -110,6 +110,25 @@ const TERMINAL_ERROR_PATTERNS = [
   'fetch failed',
 ];
 
+/** Runaway cap: max error-nudges per session across its whole lifetime, regardless of
+ *  per-episode re-arming. A session that flaps error→nudge→error this many times has a
+ *  persistent problem (not a transient API blip) and should fall through to zombie-kill
+ *  rather than be nudged forever. Generous enough that a long autonomous run with
+ *  genuinely-transient errors never hits it. */
+const MAX_ERROR_NUDGES_PER_SESSION = 50;
+
+/**
+ * Pure gate for the post-API-error nudge (the 2026-05-29 re-arm fix). A session is
+ * nudged only when it has NOT already been nudged in the CURRENT idle episode
+ * (`armedThisEpisode` false) AND it is under the lifetime runaway cap. The episode
+ * flag is cleared on recovery, so a long-running session that hits a SECOND transient
+ * API error is nudged again — fixing the prior once-per-session-forever strand.
+ * Exported so the decision boundary is unit-testable without driving the tmux loop.
+ */
+export function shouldErrorNudge(armedThisEpisode: boolean, totalNudges: number, max: number = MAX_ERROR_NUDGES_PER_SESSION): boolean {
+  return !armedThisEpisode && totalNudges < max;
+}
+
 /**
  * Process names that are always running in a Claude Code session (MCP servers, etc.)
  * These do NOT indicate activity — they're background infrastructure.
@@ -192,10 +211,19 @@ export class SessionManager extends EventEmitter {
    *  Key = tmuxSession name. Cleared when agent replies via /telegram/reply/:topicId. */
   private pendingInjections = new Map<string, { topicId: number; injectedAt: number; text: string }>();
 
-  /** Track sessions that have been nudged after an API error.
-   *  Key = session ID. Prevents infinite nudge loops — each session gets ONE nudge.
-   *  If it goes idle again after the nudge, the zombie detector kills it normally. */
+  /** Track sessions nudged after an API error in the CURRENT idle episode.
+   *  Key = session ID. Set when we nudge; CLEARED when the session recovers (produces
+   *  output / leaves idle), so the NEXT API-error episode in a long-running session
+   *  gets its own nudge. (Before 2026-05-29 this was once-per-session-FOREVER — a long
+   *  autonomous run that hit a SECOND transient API error was never re-nudged and
+   *  silently stranded at the prompt. The runaway cap lives in errorNudgeTotal.) */
   private errorNudgedSessions = new Set<string>();
+
+  /** Total error-nudges issued per session (never cleared until sessionComplete).
+   *  Bounds runaway: even with per-episode re-arming, a session stuck in a tight
+   *  error→nudge→error loop that never truly recovers stops being nudged after
+   *  MAX_ERROR_NUDGES_PER_SESSION and falls through to the normal zombie-kill path. */
+  private errorNudgeTotal = new Map<string, number>();
 
   /** Sessions where we've already retried Enter for stuck pasted text.
    *  Key = session ID. Prevents infinite retry loops — one retry per session. */
@@ -459,6 +487,7 @@ rm()  { "${shimRunner}" rm  "$@"; }
       detector.cleanup(session.tmuxSession);
       this.relayLeases.delete(session.id);
       this.errorNudgedSessions.delete(session.id);
+      this.errorNudgeTotal.delete(session.id);
       this.pasteRetried.delete(session.id);
     });
   }
@@ -872,7 +901,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
               // ── Error nudge: on first idle detection, check terminal for API errors ──
               // If the session went idle because of an API error (not a natural stop),
               // inject a nudge to get it working again instead of waiting 15m to kill.
-              if (!this.errorNudgedSessions.has(session.id)) {
+              const nudgeTotal = this.errorNudgeTotal.get(session.id) ?? 0;
+              if (shouldErrorNudge(this.errorNudgedSessions.has(session.id), nudgeTotal)) {
                 const recentOutput = this.captureOutput(session.tmuxSession, 30);
                 if (recentOutput) {
                   // Server-side throttle ("Server is temporarily limiting
@@ -890,7 +920,8 @@ rm()  { "${shimRunner}" rm  "$@"; }
                   const hasError = TERMINAL_ERROR_PATTERNS.some(p => recentOutput.includes(p));
                   if (hasError) {
                     this.errorNudgedSessions.add(session.id);
-                    console.log(`[SessionManager] Session "${session.name}" idle after API error — nudging to continue.`);
+                    this.errorNudgeTotal.set(session.id, nudgeTotal + 1);
+                    console.log(`[SessionManager] Session "${session.name}" idle after API error — nudging to continue (nudge #${nudgeTotal + 1} this session).`);
                     this.sendInput(session.tmuxSession, 'You hit an API error. Please continue your work — skip or work around the action that failed.');
                     this.idlePromptSince.delete(session.id); // Reset idle timer
                     continue; // Skip to next session
@@ -940,8 +971,13 @@ rm()  { "${shimRunner}" rm  "$@"; }
               }
             }
           } else {
-            // Session is active — clear idle tracker
+            // Session is active — clear idle tracker AND re-arm the error nudge.
+            // The session producing output means the prior idle episode is over (the
+            // nudge worked, or the error cleared), so a FUTURE API-error episode in
+            // this same long-running session deserves its own nudge. (errorNudgeTotal
+            // is NOT cleared here — it's the lifetime runaway cap.)
             this.idlePromptSince.delete(session.id);
+            this.errorNudgedSessions.delete(session.id);
           }
         }
       }

--- a/src/monitoring/RateLimitSentinel.ts
+++ b/src/monitoring/RateLimitSentinel.ts
@@ -42,6 +42,20 @@ import path from 'node:path';
 
 export type RateLimitTrigger = 'watchdog-poll' | 'idle-error' | string;
 
+/**
+ * The CLASS of transient API error this recovery is riding out. The lifecycle
+ * (backoff → re-engage → verify → escalate) is identical across classes — only the
+ * backoff SCHEDULE and the user-facing wording differ:
+ *  - 'throttle'      — Anthropic capacity throttle / 529 Overloaded / rate limit.
+ *                      Re-hitting it immediately burns quota, so the backoff is LONG.
+ *  - 'transient-api' — a generic transient API error (500/502/503, timeout, connection
+ *                      drop). These usually clear in seconds, so the first retry is
+ *                      FAST and the schedule escalates more gently. Generalizing the
+ *                      proven throttle-recovery lifecycle to this whole class is the
+ *                      2026-05-29 future-proofing ask (topic 13481).
+ */
+export type ApiErrorClass = 'throttle' | 'transient-api';
+
 export type RateLimitStatus =
   | 'detected'      // reported; first user notice sent; first backoff scheduled
   | 'backing-off'   // waiting out the current backoff interval
@@ -52,6 +66,8 @@ export type RateLimitStatus =
 export interface RateLimitRecoveryState {
   sessionName: string;
   trigger: RateLimitTrigger;
+  /** Which transient-error class this recovery rides out (picks backoff + wording). */
+  errorClass: ApiErrorClass;
   detectedAt: number;
   attempts: number;
   lastInjectAt: number;
@@ -96,8 +112,13 @@ export interface RateLimitSentinelDeps {
 export interface RateLimitSentinelConfig {
   /** Master kill switch. When false, report() is a no-op. */
   enabled?: boolean;
-  /** Escalating wait (ms) before each re-engagement attempt. Last value repeats. */
+  /** Escalating wait (ms) before each re-engagement attempt for a THROTTLE/rate-limit
+   *  recovery. Last value repeats. */
   backoffScheduleMs?: number[];
+  /** Escalating wait (ms) for a generic 'transient-api' recovery (500/502/503/timeout/
+   *  connection). Shorter than the throttle schedule — these usually clear in seconds,
+   *  so the first retry is fast. Last value repeats. */
+  transientApiBackoffScheduleMs?: number[];
   /** Max re-engagement attempts before escalating. */
   maxAttempts?: number;
   /** Max wall-clock window (ms) a recovery may run before escalating. */
@@ -113,6 +134,7 @@ export interface RateLimitSentinelConfig {
 const DEFAULTS: Required<RateLimitSentinelConfig> = {
   enabled: true,
   backoffScheduleMs: [30_000, 60_000, 120_000, 300_000, 300_000, 300_000],
+  transientApiBackoffScheduleMs: [5_000, 15_000, 30_000, 60_000, 120_000, 300_000],
   maxAttempts: 6,
   maxWindowMs: 30 * 60_000,
   verifyWindowMs: 25_000,
@@ -148,6 +170,7 @@ export class RateLimitSentinel extends EventEmitter {
     this.cfg = {
       enabled: config.enabled ?? DEFAULTS.enabled,
       backoffScheduleMs: config.backoffScheduleMs ?? DEFAULTS.backoffScheduleMs,
+      transientApiBackoffScheduleMs: config.transientApiBackoffScheduleMs ?? DEFAULTS.transientApiBackoffScheduleMs,
       maxAttempts: config.maxAttempts ?? DEFAULTS.maxAttempts,
       maxWindowMs: config.maxWindowMs ?? DEFAULTS.maxWindowMs,
       verifyWindowMs: config.verifyWindowMs ?? DEFAULTS.verifyWindowMs,
@@ -179,9 +202,10 @@ export class RateLimitSentinel extends EventEmitter {
    * recovery is already active, or one was reported within the dedupe window,
    * or deferIf says another recovery owns this session, this is a no-op.
    */
-  report(sessionName: string, trigger: RateLimitTrigger): void {
+  report(sessionName: string, trigger: RateLimitTrigger, opts?: { errorClass?: ApiErrorClass }): void {
     if (!this.cfg.enabled) return;
     const now = this.now();
+    const errorClass: ApiErrorClass = opts?.errorClass ?? 'throttle';
 
     if (this.active.has(sessionName)) return;            // recovery in flight
     if (this.deferIf?.(sessionName)) return;             // another recovery owns it (S6)
@@ -193,6 +217,7 @@ export class RateLimitSentinel extends EventEmitter {
     const state: RateLimitRecoveryState = {
       sessionName,
       trigger,
+      errorClass,
       detectedAt: now,
       attempts: 0,
       lastInjectAt: 0,
@@ -205,18 +230,21 @@ export class RateLimitSentinel extends EventEmitter {
     this.active.set(sessionName, state);
 
     console.log(
-      `[RateLimitSentinel] detected throttle on "${sessionName}" via ${trigger}; ` +
+      `[RateLimitSentinel] detected ${errorClass} error on "${sessionName}" via ${trigger}; ` +
       `baseline jsonl=${state.baselineJsonlPath ? path.basename(state.baselineJsonlPath) : 'none'} ` +
       `size=${state.baselineJsonlSize ?? 'n/a'}`,
     );
     this.emit('rate-limit:detected', state);
 
-    // Immediate user notice (fixed template, no LLM).
+    // Immediate user notice (fixed template, no LLM), worded per error class.
     void this.notify(
       sessionName,
-      "Heads up — Claude hit a temporary server-side throttle on Anthropic's side " +
-      '(not your usage limit). I\'m backing off and will keep retrying. ' +
-      "You haven't been dropped — I'll check back in.",
+      errorClass === 'transient-api'
+        ? "Heads up — Claude hit a transient API error (likely a brief server-side blip). " +
+          "I'm waiting a moment and will retry. You haven't been dropped — I'll pick up where I left off."
+        : "Heads up — Claude hit a temporary server-side throttle on Anthropic's side " +
+          '(not your usage limit). I\'m backing off and will keep retrying. ' +
+          "You haven't been dropped — I'll check back in.",
     );
     state.lastCheckInAt = now;
 
@@ -254,18 +282,18 @@ export class RateLimitSentinel extends EventEmitter {
   listActive(): Array<RateLimitRecoveryState & { nextBackoffMs: number }> {
     return [...this.active.values()].map(s => ({
       ...s,
-      nextBackoffMs: this.backoffFor(s.attempts),
+      nextBackoffMs: this.backoffFor(s.attempts, s.errorClass),
     }));
   }
 
-  private backoffFor(attempts: number): number {
-    const sched = this.cfg.backoffScheduleMs;
+  private backoffFor(attempts: number, errorClass: ApiErrorClass = 'throttle'): number {
+    const sched = errorClass === 'transient-api' ? this.cfg.transientApiBackoffScheduleMs : this.cfg.backoffScheduleMs;
     if (sched.length === 0) return 0;
     return sched[Math.min(attempts, sched.length - 1)];
   }
 
   private scheduleBackoff(state: RateLimitRecoveryState): void {
-    const backoffMs = this.backoffFor(state.attempts);
+    const backoffMs = this.backoffFor(state.attempts, state.errorClass);
     state.status = 'backing-off';
     const handle = this.setTimer(() => {
       this.attemptResume(state).catch(err => {
@@ -293,7 +321,7 @@ export class RateLimitSentinel extends EventEmitter {
       `[RateLimitSentinel] resume-attempted on "${state.sessionName}" ` +
       `(attempt ${state.attempts}/${this.cfg.maxAttempts}, accepted=${accepted})`,
     );
-    this.emit('rate-limit:resuming', { ...state, backoffMs: this.backoffFor(state.attempts - 1) });
+    this.emit('rate-limit:resuming', { ...state, backoffMs: this.backoffFor(state.attempts - 1, state.errorClass) });
 
     if (!accepted) {
       // No pending work / session gone / injection blocked — nothing to recover.
@@ -328,7 +356,9 @@ export class RateLimitSentinel extends EventEmitter {
       this.emit('rate-limit:recovered', { ...state, jsonlDelta: delta });
       void this.notify(
         state.sessionName,
-        "Back online — Anthropic's throttle cleared. Continuing where I left off.",
+        state.errorClass === 'transient-api'
+          ? 'Back online — the API error cleared. Continuing where I left off.'
+          : "Back online — Anthropic's throttle cleared. Continuing where I left off.",
       );
       this.finalize(state, 'recovered');
       return;
@@ -363,8 +393,10 @@ export class RateLimitSentinel extends EventEmitter {
       state.lastCheckInAt = now;
       void this.notify(
         state.sessionName,
-        `Still throttled on Anthropic's side — next retry in ${humanizeMs(this.backoffFor(state.attempts))}. ` +
-        "Still here, haven't dropped you.",
+        state.errorClass === 'transient-api'
+          ? `Still hitting an API error — next retry in ${humanizeMs(this.backoffFor(state.attempts, state.errorClass))}. Still here, haven't dropped you.`
+          : `Still throttled on Anthropic's side — next retry in ${humanizeMs(this.backoffFor(state.attempts, state.errorClass))}. ` +
+            "Still here, haven't dropped you.",
       );
     }
 

--- a/tests/unit/RateLimitSentinel.test.ts
+++ b/tests/unit/RateLimitSentinel.test.ts
@@ -211,4 +211,46 @@ describe('RateLimitSentinel', () => {
     expect(sentinel.isRecoveryActive('b')).toBe(true);
     expect(events.filter(e => e.type === 'rate-limit:detected')).toHaveLength(2);
   });
+
+  // ─── Generic transient-API-error class (the 2026-05-29 generalization) ───
+  describe("errorClass: 'transient-api'", () => {
+    const TRANSIENT_FIRST_BACKOFF = 5_000;
+
+    it('uses the FAST first backoff (5s, not the 30s throttle schedule)', async () => {
+      jsonl.write('foo.jsonl', 100);
+      sentinel.report('s1', 'idle-error', { errorClass: 'transient-api' });
+      await vi.advanceTimersByTimeAsync(TRANSIENT_FIRST_BACKOFF - 500);
+      expect(resumeFn).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1000); // crosses 5s → re-engages (throttle would wait 30s)
+      expect(resumeFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends a transient-API-worded notice (not the throttle wording)', async () => {
+      jsonl.write('foo.jsonl', 100);
+      sentinel.report('s1', 'idle-error', { errorClass: 'transient-api' });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(notifyFn.mock.calls[0][1]).toMatch(/transient API error/i);
+      expect(notifyFn.mock.calls[0][1]).not.toMatch(/throttle/i);
+    });
+
+    it('rides the full lifecycle: backoff → resume → verify(jsonl growth) → recovered', async () => {
+      jsonl.write('foo.jsonl', 100);
+      sentinel.report('s1', 'idle-error', { errorClass: 'transient-api' });
+      await vi.advanceTimersByTimeAsync(TRANSIENT_FIRST_BACKOFF + 100); // resume fires
+      jsonl.write('foo.jsonl', 5000);                                  // session produced output
+      await vi.advanceTimersByTimeAsync(VERIFY + 100);                 // verify window
+      expect(events.some(e => e.type === 'rate-limit:recovered')).toBe(true);
+      const recoveredNotice = notifyFn.mock.calls.map(c => c[1]).find((t: string) => /back online/i.test(t));
+      expect(recoveredNotice).toMatch(/API error cleared/i);
+    });
+
+    it('records its errorClass + listActive reflects the short schedule', async () => {
+      jsonl.write('foo.jsonl', 100);
+      sentinel.report('s1', 'idle-error', { errorClass: 'transient-api' });
+      await vi.advanceTimersByTimeAsync(0);
+      const active = sentinel.listActive();
+      expect(active[0].errorClass).toBe('transient-api');
+      expect(active[0].nextBackoffMs).toBe(TRANSIENT_FIRST_BACKOFF);
+    });
+  });
 });

--- a/tests/unit/session-error-nudge.test.ts
+++ b/tests/unit/session-error-nudge.test.ts
@@ -57,12 +57,53 @@ describe('Session error nudge', () => {
       expect(source).toContain('errorNudgedSessions');
     });
 
-    it('only nudges once per session (prevents infinite loops)', () => {
+    it('arms the per-episode nudge guard before nudging and sets it after', () => {
       source = fs.readFileSync(SM_PATH, 'utf-8');
-      // Should check errorNudgedSessions before nudging
+      // Should check the per-episode guard before nudging
       expect(source).toContain('errorNudgedSessions.has(session.id)');
-      // Should add to set after nudging
+      // Should arm it after nudging
       expect(source).toContain('errorNudgedSessions.add(session.id)');
+    });
+
+    it('re-arms the nudge on recovery (NOT once-per-session-forever) so a long run survives repeated transient errors', () => {
+      source = fs.readFileSync(SM_PATH, 'utf-8');
+      // The per-episode guard must be CLEARED when the session goes active again,
+      // in the same "Session is active" branch that clears the idle tracker.
+      const activeBranch = source.slice(source.indexOf('Session is active'));
+      expect(activeBranch).toContain('errorNudgedSessions.delete(session.id)');
+    });
+
+    it('bounds runaway with a lifetime nudge cap (errorNudgeTotal + MAX_ERROR_NUDGES_PER_SESSION)', () => {
+      source = fs.readFileSync(SM_PATH, 'utf-8');
+      expect(source).toContain('errorNudgeTotal');
+      expect(source).toContain('MAX_ERROR_NUDGES_PER_SESSION');
+      // The production gate routes through the pure shouldErrorNudge() helper.
+      expect(source).toContain('shouldErrorNudge(this.errorNudgedSessions.has(session.id), nudgeTotal)');
+    });
+  });
+
+  // Behavioral coverage of the actual decision boundary (the production gate),
+  // not just source-grep — both sides of every branch.
+  describe('shouldErrorNudge (the production nudge gate)', () => {
+    it('nudges when not yet armed this episode and under the cap', async () => {
+      const { shouldErrorNudge } = await import('../../src/core/SessionManager.js');
+      expect(shouldErrorNudge(false, 0)).toBe(true);
+      expect(shouldErrorNudge(false, 49, 50)).toBe(true);
+    });
+    it('does NOT nudge while already armed this episode (prevents per-tick spam)', async () => {
+      const { shouldErrorNudge } = await import('../../src/core/SessionManager.js');
+      expect(shouldErrorNudge(true, 0)).toBe(false);
+    });
+    it('does NOT nudge once the lifetime cap is reached (runaway bound)', async () => {
+      const { shouldErrorNudge } = await import('../../src/core/SessionManager.js');
+      expect(shouldErrorNudge(false, 50, 50)).toBe(false);
+      expect(shouldErrorNudge(false, 51, 50)).toBe(false);
+    });
+    it('re-arms across episodes: clearing the episode flag (false) allows the next nudge under the cap', async () => {
+      const { shouldErrorNudge } = await import('../../src/core/SessionManager.js');
+      // Episode 1: armed → no nudge. Recovery clears the flag → episode 2: nudge again.
+      expect(shouldErrorNudge(true, 1)).toBe(false);
+      expect(shouldErrorNudge(false, 1)).toBe(true);
     });
 
     it('nudges on first idle detection when error is present', () => {

--- a/tests/unit/session-error-nudge.test.ts
+++ b/tests/unit/session-error-nudge.test.ts
@@ -105,6 +105,24 @@ describe('Session error nudge', () => {
       expect(shouldErrorNudge(true, 1)).toBe(false);
       expect(shouldErrorNudge(false, 1)).toBe(true);
     });
+  });
+
+  describe('transient-API-error handoff to the recovery sentinel', () => {
+    const SM_PATH = path.join(process.cwd(), 'src/core/SessionManager.ts');
+    it('defers to the recovery sentinel (apiErrorAtIdle) when one is wired, instead of an immediate retry', () => {
+      const source = fs.readFileSync(SM_PATH, 'utf-8');
+      // When a listener owns recovery, hand off (backoff→verify→escalate) rather than nudge.
+      expect(source).toContain("this.listenerCount('apiErrorAtIdle') > 0");
+      expect(source).toContain("this.emit('apiErrorAtIdle', session.tmuxSession)");
+    });
+    it('keeps the re-armable immediate nudge as the fallback when no sentinel is wired', () => {
+      const source = fs.readFileSync(SM_PATH, 'utf-8');
+      // The fallback path still nudges + counts against the lifetime cap.
+      const handoff = source.indexOf("this.emit('apiErrorAtIdle'");
+      const fallbackNudge = source.indexOf('You hit an API error. Please continue your work');
+      expect(handoff).toBeGreaterThan(0);
+      expect(fallbackNudge).toBeGreaterThan(handoff); // fallback nudge follows the handoff guard
+    });
 
     it('nudges on first idle detection when error is present', () => {
       source = fs.readFileSync(SM_PATH, 'utf-8');

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,45 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The automatic recovery nudge that restarts a session after a transient API error
+(e.g. "API Error: 500") is now **re-armable**. Previously a session was nudged at
+most once for its entire lifetime — the guard that prevented infinite nudge loops
+was only cleared when the session ended. A long-running autonomous session that hit
+a SECOND transient API error was therefore never re-nudged: it sat idle at the
+prompt until a human poked it, and was eventually zombie-killed, silently losing the
+run.
+
+Now the nudge guard is per-idle-episode: it is cleared the moment the session goes
+active again, so each fresh API-error episode gets its own nudge. A lifetime cap
+(50 nudges per session) bounds a session that flaps without ever recovering, so it
+still falls through to the normal zombie-kill path rather than being nudged forever.
+
+This closes a gap the in-session autonomous Stop hook structurally cannot cover — the
+Stop hook only fires on a clean turn end, never on an errored turn, so the recovery
+has to come from the out-of-process session monitor where this nudge already lived.
+
+## What to Tell Your User
+
+- **Long autonomous runs now survive repeated transient API hiccups on their own**:
+  "If the AI service has a momentary error mid-task, I tap myself back into work — and
+  now I do that every time it happens during a long run, not just the first time. So a
+  multi-hour autonomous job won't silently freeze after a second hiccup anymore."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|------------|
+| Re-armable API-error recovery nudge | Automatic — every agent gets it on update. A session idle after a transient API error is re-nudged to continue, once per error episode, capped at 50 per session lifetime. No config. |
+
+## Evidence
+
+Unit coverage in `tests/unit/session-error-nudge.test.ts` exercises the pure
+`shouldErrorNudge()` gate across every branch (already-nudged-this-episode → skip,
+fresh episode under the cap → nudge, at/over the lifetime cap → skip, re-arm after
+recovery → nudge again) and pins the structural invariants (the episode guard is
+cleared in the "Session is active" branch; the production path routes through the
+gate). The SessionManager behavioral + idle/kill suites remain green — no regression.
+Spec: `docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.md`.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -21,6 +21,15 @@ This closes a gap the in-session autonomous Stop hook structurally cannot cover 
 Stop hook only fires on a clean turn end, never on an errored turn, so the recovery
 has to come from the out-of-process session monitor where this nudge already lived.
 
+Beyond the re-arm, the **intelligent backoff recovery** that already existed for
+rate-limit/throttle errors (RateLimitSentinel: back off before retrying, tell you
+you're not dropped, verify the retry took, escalate if it never does) now covers the
+**whole class of transient API errors** — 500/502/503, overloaded, timeouts, connection
+drops — not just rate limits. A generic API error gets the same intelligent treatment,
+with a fast first retry (≈5s, since these usually clear quickly) escalating gently if it
+persists. Future-proof: the error set is driven by one pattern list, so adding a new
+transient pattern automatically routes it through the backoff recovery.
+
 ## What to Tell Your User
 
 - **Long autonomous runs now survive repeated transient API hiccups on their own**:

--- a/upgrades/side-effects/session-error-nudge-rearm.md
+++ b/upgrades/side-effects/session-error-nudge-rearm.md
@@ -1,0 +1,17 @@
+# Side effects — Session error-nudge re-arm (fleet-wide fix)
+
+## What this changes
+`src/core/SessionManager.ts` — the post-API-error idle nudge is now re-armable instead of once-per-session-forever.
+- `errorNudgedSessions` is now a per-idle-episode flag: set on nudge, CLEARED in the existing "Session is active" branch (recovery), so a long-running session that hits a SECOND transient API error is nudged again.
+- New `errorNudgeTotal: Map` + `MAX_ERROR_NUDGES_PER_SESSION` (50) bound runaway: a session flapping error→nudge→error without truly recovering stops being nudged and falls through to the normal zombie-kill path. Cleared on `sessionComplete`.
+- New pure exported `shouldErrorNudge(armedThisEpisode, totalNudges, max)` is the gate the production code routes through (unit-testable boundary).
+
+## Why
+A 2026-05-29 autonomous run was found idle after an `API Error: 500` — the SECOND such stop. Root cause: the nudge fired once per session, ever (the guard set was only cleared on sessionComplete). The in-session autonomous Stop hook cannot cover this (it fires only on a clean Stop, not an errored turn). Spec: docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.md.
+
+## Risk / blast radius
+Low + bounded. Behavior change is strictly MORE recovery (re-nudge on a fresh error episode) with a hard lifetime cap (50) so it can never nudge forever or burn quota. The rate-limit/throttle path is untouched (still hands off to RateLimitSentinel, consumes no nudge token). Server-side code → deploys fleet-wide via the normal release/auto-update; no agent-file or config change, no migrator entry needed.
+
+## Tests
+- `tests/unit/session-error-nudge.test.ts` — +behavioral coverage of shouldErrorNudge (both sides of every branch: armed/not-armed, under/over cap, re-arm-after-recovery) + structural pins (episode flag cleared in the active branch; gate routes through shouldErrorNudge).
+- SessionManager-adjacent suites (behavioral, terminate, zombie-kill-topic-binding, reap-detect, injection, multishot-recovery) all green — no regression to the idle/kill path.

--- a/upgrades/side-effects/transient-api-error-recovery-generalization.md
+++ b/upgrades/side-effects/transient-api-error-recovery-generalization.md
@@ -1,0 +1,18 @@
+# Side effects — Generalize backoff recovery to the whole transient-API-error class
+
+## What this changes
+Extends the intelligent throttle-recovery lifecycle (RateLimitSentinel) to cover ALL transient API errors (500/502/503, overloaded, timeouts, connection drops), not just rate limits — the 2026-05-29 future-proofing ask (topic 13481). Builds on the per-episode nudge re-arm (same branch).
+
+- `src/monitoring/RateLimitSentinel.ts` — new `ApiErrorClass = 'throttle' | 'transient-api'`. `report(name, trigger, { errorClass })` (default 'throttle' → fully back-compatible). Per-class backoff schedule (`transientApiBackoffScheduleMs` = [5s,15s,30s,60s,2m,5m], fast first retry) + per-class user wording in every notice. Lifecycle (backoff→resume→verify→escalate→zombie-veto) unchanged.
+- `src/core/SessionManager.ts` — the generic `TERMINAL_ERROR_PATTERNS` idle path now hands off to the sentinel via a new `apiErrorAtIdle` event when a listener is wired (production), mirroring the existing `rateLimitedAtIdle` handoff; the re-armable immediate nudge remains the fallback when no sentinel is wired (bare/test).
+- `src/commands/server.ts` — wires `sessionManager.on('apiErrorAtIdle', name => rateLimitSentinel.report(name, 'idle-error', { errorClass: 'transient-api' }))`.
+
+## Why
+A generic `API Error: 500` previously only got SessionManager's immediate single nudge — no backoff, no verify, no escalate — while the intelligent RateLimitSentinel was scoped to rate-limit/throttle only. Now a 500 rides the same proven backoff→verify→escalate lifecycle. Spec: docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.md (Part 2).
+
+## Risk / blast radius
+Low + back-compatible. `errorClass` defaults to 'throttle' so all existing rate-limit behavior is byte-identical (14 existing RateLimitSentinel tests unchanged + green). The generic-error handoff only changes behavior when an `apiErrorAtIdle` listener is wired; otherwise the (now re-armable) immediate nudge fallback runs. Future-proof: driven by the existing TERMINAL_ERROR_PATTERNS list. Server-side → deploys fleet-wide via release.
+
+## Tests
+- `tests/unit/RateLimitSentinel.test.ts` — +4 transient-api tests (fast 5s first backoff vs 30s throttle; transient-API wording; full lifecycle→recovered; state errorClass + listActive short schedule). Throttle suite unchanged.
+- `tests/unit/session-error-nudge.test.ts` — +2: generic-error idle path defers to the sentinel via apiErrorAtIdle when wired; re-armable nudge is the fallback. Plus the Part-1 re-arm + cap behavioral tests.


### PR DESCRIPTION
## Why
An 8h autonomous run was found idle after an `API Error: 500` — the **second** such stop (topic 13481). Two root causes, two fixes:

### Part 1 — re-arm the immediate nudge (the strand)
`SessionManager`'s post-API-error nudge was once-per-session-FOREVER (`errorNudgedSessions` cleared only on `sessionComplete`). A long run that hit a *second* transient API error was never re-nudged → idle until a human poked it → eventually zombie-killed. The in-session autonomous Stop hook **cannot** cover this — it fires only on a clean stop, never an errored turn.
- `errorNudgedSessions` is now a per-idle-EPISODE flag, **cleared on recovery** (the "Session is active" branch), so each fresh error episode gets its own nudge.
- Bounded by `errorNudgeTotal` + `MAX_ERROR_NUDGES_PER_SESSION` (50) so a session that never recovers stops being nudged and falls through to zombie-kill.
- Gate extracted to the pure exported `shouldErrorNudge()`.

### Part 2 — generalize the intelligent backoff recovery (Justin's future-proofing ask)
The `RateLimitSentinel` already does the smart thing (back off → re-engage → verify JSONL growth → escalate, zombie-veto) but **only for throttle/rate-limit**. A generic 500 got only the dumb immediate nudge.
- `RateLimitSentinel` gains `ApiErrorClass = 'throttle' | 'transient-api'` on `report(..., { errorClass })` (default `'throttle'` → fully back-compatible). `transient-api` uses a **fast** backoff (`[5s,15s,30s,60s,2m,5m]` — 500s clear quickly) + class-appropriate wording. Lifecycle identical.
- `SessionManager` routes the generic `TERMINAL_ERROR_PATTERNS` idle case to the sentinel via a new `apiErrorAtIdle` event (mirrors `rateLimitedAtIdle`); the re-armable nudge is the fallback when no sentinel is wired.
- **Future-proof:** the class is driven by the existing `TERMINAL_ERROR_PATTERNS` list — add a pattern, it's covered.

## Tests
- `tests/unit/session-error-nudge.test.ts` — behavioral `shouldErrorNudge` boundary (armed/cap/re-arm) + the sentinel-handoff structure.
- `tests/unit/RateLimitSentinel.test.ts` — 14 existing throttle tests unchanged + green; +4 `transient-api` (fast 5s backoff, wording, full lifecycle, state class).
- SessionManager-adjacent suites (behavioral, terminate, zombie-kill, reap-detect, injection, multishot) all green — no regression.

## Deploy
Server-side only → deploys fleet-wide via the normal release/auto-update. No agent-installed-file or config change, no PostUpdateMigrator entry needed.

Spec: `docs/specs/SESSION-ERROR-NUDGE-REARM-SPEC.md` (+ ELI16). approved-via topic 13481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)