### PR TITLE
feat(session-pool): activation wiring — SessionRouter boot + gated live-ingress interception (dark)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -343,6 +343,16 @@ let _fixDeps: FixCommandDeps | null = null;
 // Module-level reference for session resume mapping.
 // Set once in startServer() and used by spawnSessionForTopic/respawnSessionForTopic.
 let _topicResumeMap: import('../core/TopicResumeMap.js').TopicResumeMap | null = null;
+
+// ── Multi-Machine Session Pool (§L4) activation refs ──────────────────────
+// The SessionRouter is constructed in startServer()'s mesh block, but the inbound
+// dispatch handler that consults it is defined ABOVE startServer — so the router is
+// shared via this module-level ref (the same pattern as _orphanReaper/_topicResumeMap).
+// `_sessionPoolStage()` reads the live rollout stage; the inbound interception only
+// routes through the pool when it returns a non-'dark' stage, so DARK (the default)
+// is byte-identical to today's always-local dispatch. Set once in startServer().
+let _sessionRouter: import('../core/SessionRouter.js').SessionRouter | null = null;
+let _sessionPoolStage: () => string = () => 'dark';
 /** Per-topic framework override (claude-code | codex-cli). Populated from
  *  `config.topicFrameworks` at server boot. Boot-immutable; runtime
  *  mutations go through `_topicFrameworksStore` instead so they persist
@@ -1306,6 +1316,31 @@ function wireTelegramRouting(
 
     // Route message to corresponding session
     const targetSession = telegram.getSessionForTopic(topicId);
+
+    // ── Multi-Machine Session Pool (§L4): route through the pool when active ──
+    // When the rollout stage is past 'dark', consult the SessionRouter: it may
+    // forward this topic's message to the machine that OWNS the session (over the
+    // mesh) instead of handling it locally. DARK (the default) skips this block
+    // entirely → byte-identical to single-machine dispatch. Any error falls back
+    // to the local path below (fail-safe). The live-transfer behavior is gated by
+    // the staged rollout (StageAdvancer); shadow records ownership but stays local.
+    if (_sessionRouter && _sessionPoolStage() !== 'dark') {
+      try {
+        const outcome = await _sessionRouter.route({
+          sessionKey: String(topicId),
+          messageId: String(msg.id),
+          payload: text,
+        });
+        if (outcome.action === 'forwarded' || outcome.action === 'duplicate') {
+          console.log(`[session-pool] topic ${topicId} handled by owner ${outcome.owner ?? '?'} (${outcome.action}) — not dispatching locally`);
+          return;
+        }
+        // 'handled-locally' / 'spawned'(self) / 'owner-dead-replaced' / 'queued' /
+        // 'placement-blocked' → fall through to the existing local dispatch below.
+      } catch (err) {
+        console.warn(`[session-pool] route error for topic ${topicId} — falling back to local dispatch: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
 
     if (targetSession) {
       // Session is mapped — check if it's alive, inject or respawn
@@ -8911,6 +8946,71 @@ export async function startServer(options: StartOptions): Promise<void> {
           },
           logger: (m: string) => console.log(pc.dim(`  ${m}`)),
         });
+
+        // ── L4 SessionRouter (activation transport) — shared via _sessionRouter ──
+        // Constructed with the real registry/ownership/placement + the outbound
+        // MeshRpcClient so it can reach peers. INERT until the rollout stage advances
+        // past 'dark': the inbound dispatch interception only consults it when
+        // _sessionPoolStage() !== 'dark'. Single-machine → placement keeps everything local.
+        try {
+          const routerMod = await import('../core/SessionRouter.js');
+          const placeMod = await import('../core/PlacementExecutor.js');
+          const clientMod = await import('../core/MeshRpcClient.js');
+          let routerNonce = 0;
+          const meshClient = new clientMod.MeshRpcClient({
+            selfMachineId: meshSelfId,
+            sign: (c) => idMod.sign(c, localSigningKeyPem),
+            nonce: () => `${meshSelfId}:r:${Date.now()}:${++routerNonce}`,
+            now: () => Date.now(),
+          });
+          const peerUrl = (machineId: string): string | null =>
+            meshIdMgr.getActiveMachines().find((m) => m.machineId === machineId)?.entry.lastKnownUrl ?? null;
+          _sessionRouter = new routerMod.SessionRouter({
+            selfMachineId: meshSelfId,
+            placement: new placeMod.PlacementExecutor(),
+            machineRegistry: () => machinePoolRegistry?.getCapacities() ?? [],
+            resolveOwnership: (sk) => {
+              const r = ownReg.read(sk);
+              if (!r) return { owner: null, epoch: 0, status: null };
+              const status = r.status === 'released' ? null : (r.status as 'active' | 'placing' | 'transferring');
+              return { owner: ownReg.ownerOf(sk), epoch: r.ownershipEpoch, status, target: ownReg.placementTargetOf(sk) ?? undefined };
+            },
+            isMachineAlive: (m) => m === meshSelfId || (machinePoolRegistry?.getCapacity(m)?.online ?? false),
+            casClaimOwnership: (sk, machineId) => {
+              const r = ownReg.cas({ type: 'place', machineId }, { sessionKey: sk, sender: meshSelfId, nonce: `${meshSelfId}:c:${++routerNonce}` });
+              return { ok: r.ok, epoch: ownReg.read(sk)?.ownershipEpoch ?? 0 };
+            },
+            deliverMessage: async (target, env) => {
+              const url = peerUrl(target);
+              if (!url) throw new Error(`no peer url for ${target}`);
+              const res = await meshClient.send({ machineId: target, url }, { type: 'deliverMessage', session: env.sessionKey, messageId: env.messageId, payload: env.payload, ownershipEpoch: env.ownershipEpoch }, env.ownershipEpoch);
+              if (res.ok && res.result && typeof res.result === 'object' && 'accepted' in (res.result as object)) {
+                return res.result as { messageId: string; accepted: 'queued' | 'duplicate' | 'stale-ownership' };
+              }
+              throw new Error(`deliverMessage rejected: ${res.status} ${res.reason ?? ''}`);
+            },
+            spawnOnMachine: async (machineId, msg) => {
+              const url = peerUrl(machineId);
+              if (!url) throw new Error(`no peer url for ${machineId}`);
+              await meshClient.send({ machineId, url }, { type: 'deliverMessage', session: msg.sessionKey, messageId: msg.messageId, payload: msg.payload, ownershipEpoch: 0 }, 0);
+            },
+            handleLocally: async () => { /* inbound interception falls through to the existing local spawn */ },
+            queueMessage: () => { /* queued — left for the inbound path's redelivery/retry */ },
+            raiseAttention: (title, body) => console.log(pc.dim(`  [session-router] attention: ${title} — ${body}`)),
+            sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+            log: (line) => console.log(pc.dim(`  [session-router] ${line}`)),
+          });
+          _sessionPoolStage = () => {
+            try {
+              const fallback = (config.multiMachine?.sessionPool ?? {}) as { enabled?: boolean; stage?: string };
+              const live = liveConfig.get('multiMachine.sessionPool', fallback) as { enabled?: boolean; stage?: string };
+              return live?.enabled && live?.stage ? String(live.stage) : 'dark';
+            } catch { return 'dark'; }
+          };
+          console.log(pc.green('  SessionRouter wired (L4) — inert until rollout stage advances past dark'));
+        } catch (err) {
+          console.log(pc.dim(`  [session-router] not wired: ${err instanceof Error ? err.message : String(err)}`));
+        }
       }
     } catch (err) {
       console.log(pc.dim(`  [mesh-rpc] dispatcher not wired: ${err instanceof Error ? err.message : String(err)}`));

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8909,6 +8909,30 @@ export async function startServer(options: StartOptions): Promise<void> {
             deliverSeenFallback.add(messageId);
             return true;
           },
+          // Owner-side bridge (§L4 handoff): a forwarded message landed → spawn/resume
+          // the local session for the topic so the conversation continues on THIS machine.
+          // Only fires for a FIRST-seen forwarded deliverMessage (the ledger dedupes
+          // redeliveries), and a deliverMessage only arrives from a router peer — but we
+          // double-gate on stage!=='dark' to be safe. Fire-and-forget: the durable receipt
+          // is already recorded + ACKed before this runs.
+          onAccepted: (cmd) => {
+            if (_sessionPoolStage() === 'dark' || !telegram) return;
+            const tg = telegram;
+            const topicId = Number(cmd.session);
+            if (!Number.isFinite(topicId)) return;
+            const text = typeof cmd.payload === 'string'
+              ? cmd.payload
+              : (cmd.payload && typeof cmd.payload === 'object' && 'text' in (cmd.payload as object))
+                ? String((cmd.payload as { text: unknown }).text)
+                : undefined;
+            const sessionName = tg.getSessionForTopic(topicId) ?? `topic-${topicId}`;
+            void spawnSessionForTopic(sessionManager, tg, sessionName, topicId, text, undefined, undefined)
+              .then((name) => {
+                tg.registerTopicSession(topicId, name, sessionName);
+                console.log(pc.green(`  [session-pool] owner-side resume for forwarded topic ${topicId} → ${name}`));
+              })
+              .catch((err) => console.warn(`  [session-pool] owner-side resume failed for topic ${topicId}: ${err instanceof Error ? err.message : String(err)}`));
+          },
         });
         meshRpcDispatcher = new meshMod.MeshRpcDispatcher({
           verify: {

--- a/tests/unit/session-pool-activation-wiring.test.ts
+++ b/tests/unit/session-pool-activation-wiring.test.ts
@@ -52,7 +52,7 @@ describe('Session Pool activation wiring (§L4)', () => {
   it('the owner-side bridge resumes the local session on a forwarded message, gated + fail-safe', () => {
     const idx = src.indexOf('onAccepted: (cmd) => {');
     expect(idx).toBeGreaterThan(0);
-    const block = src.slice(idx, idx + 900);
+    const block = src.slice(idx, idx + 1500);
     // Gated on a non-dark stage + only with Telegram present.
     expect(block).toContain("_sessionPoolStage() === 'dark' || !telegram");
     // Bridges to the existing local spawn/resume path for the topic.

--- a/tests/unit/session-pool-activation-wiring.test.ts
+++ b/tests/unit/session-pool-activation-wiring.test.ts
@@ -48,4 +48,16 @@ describe('Session Pool activation wiring (§L4)', () => {
     expect(src).toContain("let _sessionRouter: import('../core/SessionRouter.js').SessionRouter | null = null");
     expect(src).toContain('_sessionRouter = new routerMod.SessionRouter(');
   });
+
+  it('the owner-side bridge resumes the local session on a forwarded message, gated + fail-safe', () => {
+    const idx = src.indexOf('onAccepted: (cmd) => {');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 900);
+    // Gated on a non-dark stage + only with Telegram present.
+    expect(block).toContain("_sessionPoolStage() === 'dark' || !telegram");
+    // Bridges to the existing local spawn/resume path for the topic.
+    expect(block).toContain('spawnSessionForTopic(sessionManager, tg, sessionName, topicId, text');
+    // Fire-and-forget + fail-safe (the receipt is already durably ACKed before this).
+    expect(block).toContain('owner-side resume failed');
+  });
 });

--- a/tests/unit/session-pool-activation-wiring.test.ts
+++ b/tests/unit/session-pool-activation-wiring.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Wiring-integrity test for the Multi-Machine Session Pool ACTIVATION (§L4).
+ * The live-ingress interception is the single highest-blast-radius change in the
+ * feature (it sits in the inbound message-dispatch path), so its safety invariants
+ * are pinned structurally: it is GATED on a non-dark rollout stage (default dark →
+ * inert → byte-identical to single-machine dispatch), it FAILS SAFE (try/catch →
+ * local dispatch), and the SessionRouter is constructed with the real registry +
+ * ownership + placement + outbound mesh client. A regression that removes the gate
+ * would activate cross-machine routing unconditionally — this test guards that.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERVER = path.join(process.cwd(), 'src/commands/server.ts');
+
+describe('Session Pool activation wiring (§L4)', () => {
+  const src = fs.readFileSync(SERVER, 'utf-8');
+
+  it('the inbound interception is GATED on a non-dark rollout stage (default-dark → inert)', () => {
+    expect(src).toContain("_sessionRouter && _sessionPoolStage() !== 'dark'");
+    // The stage getter defaults to dark until startServer wires it to liveConfig.
+    expect(src).toContain("let _sessionPoolStage: () => string = () => 'dark'");
+  });
+
+  it('the interception FAILS SAFE — any route error falls back to local dispatch', () => {
+    const idx = src.indexOf("_sessionRouter && _sessionPoolStage() !== 'dark'");
+    const block = src.slice(idx, idx + 1200);
+    expect(block).toContain('try {');
+    expect(block).toContain('await _sessionRouter.route(');
+    expect(block).toContain('falling back to local dispatch');
+    // Only a remote-handled outcome short-circuits; everything else falls through.
+    expect(block).toContain("outcome.action === 'forwarded' || outcome.action === 'duplicate'");
+  });
+
+  it('the SessionRouter is constructed with the real registry/ownership/placement + outbound mesh client', () => {
+    const idx = src.indexOf('new routerMod.SessionRouter({');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 2000);
+    expect(block).toContain('machineRegistry: () => machinePoolRegistry?.getCapacities()');
+    expect(block).toContain('resolveOwnership:');
+    expect(block).toContain('casClaimOwnership:');
+    expect(block).toContain('deliverMessage:'); // outbound via MeshRpcClient
+    expect(src).toContain('new clientMod.MeshRpcClient({');
+  });
+
+  it('the router is shared via a module-level ref (inbound handler is defined above startServer)', () => {
+    expect(src).toContain("let _sessionRouter: import('../core/SessionRouter.js').SessionRouter | null = null");
+    expect(src).toContain('_sessionRouter = new routerMod.SessionRouter(');
+  });
+});

--- a/upgrades/1.3.92.md
+++ b/upgrades/1.3.92.md
@@ -1,63 +1,27 @@
-# Instar Upgrade Guide — NEXT
+# Upgrade Guide — vNEXT
 
-> In-flight shipment notes for the **Multi-Machine Session Pool** (active-active,
-> per-session placement + transfer). Built track-by-track behind a dark stage
-> gate; this guide grows as tracks land and becomes the versioned guide at the
-> release cut. Spec: docs/specs/MULTI-MACHINE-SESSION-POOL-SPEC.md (approved).
+<!-- bump: patch -->
 
 ## What Changed
 
-**Multi-Machine Session Pool — foundation (Track A: Router-Leader Lease).** The
-groundwork for one agent identity running across several machines, all awake at
-once, with each conversation placed on the best-fit machine and transferable
-between machines. This shipment lands the foundation and ships **dark** (the
-entire layer is inert unless explicitly enabled and its rollout stage advanced):
-
-- **Clock-jump-proof router lease.** The machine that holds the "who's in charge"
-  lease now judges its own lease expiry on a **monotonic clock** instead of the
-  wall clock. A wall-clock jump — an NTP correction, a VM pause/resume, a
-  sleep/wake, or a CPU-starvation timer slip — can no longer fool a partitioned
-  machine into thinking it still holds the lease (or into giving it up early).
-  This is the lease-substrate-robustness hardening that the whole session pool
-  rests on, and it directly answers the SleepWakeDetector CPU-starvation lesson.
-- **Router role.** The existing leader lease is now also addressable as the
-  "router" role (the machine that dispatches conversations to machines). On a
-  single machine this is a no-op — it is its own router.
-- **Dark config block.** A new `multiMachine.sessionPool` config block ships
-  turned off (`enabled: false`, `stage: 'dark'`, `dryRun: true`). Existing
-  agents receive these dark defaults automatically on update.
-
-**Track B (part 1: machine nicknames).** Every machine the agent is installed on
-now gets a friendly, auto-assigned **nickname** (e.g. "Mac Mini", "Justins Macbook
-Pro") — the handle you'll use to say "run this on the mini" / "move this to <name>".
-Nicknames are unique within the pool, editable, and derived deterministically from
-the machine's hostname. Still dark (the Machines dashboard tab + the placement
-commands that consume nicknames land in the next part of Track B).
+The Multi-Machine Session Pool gains its activation wiring (still DARK): the SessionRouter
+is now constructed at boot and consulted on the inbound message path — but ONLY when the
+rollout stage is advanced past 'dark'. A single-machine, un-activated agent behaves exactly
+as before (the interception is gated off on three independent conditions and fails safe to
+local dispatch).
 
 ## What to Tell Your User
 
-Nothing changes for you yet — this ships turned off. When the full feature is
-ready, your agent will be able to spread conversations across all the machines
-it's installed on (and you'll get a Machines tab in the dashboard to name them
-and move conversations between them by nickname). For now, this update just makes
-the under-the-hood "who's in charge" machinery immune to clock jumps, which makes
-everything steadier. A one-machine agent behaves exactly as before.
+Nothing changes yet — this is the plumbing that lets the session pool actually move
+conversations between machines once it's staged on. It stays off until explicitly activated.
 
 ## Summary of New Capabilities
 
-- Monotonic, clock-jump-proof self-fence for the router/leader lease
-  (`LeaseCoordinator`).
-- `MultiMachineCoordinator.isRouter()` — router-role accessor (alias of
-  `holdsLease()`).
-- `multiMachine.sessionPool` dark config block (`enabled`/`stage`/`dryRun`) with
-  migration parity for existing agents.
+| Area | Capability |
+| --- | --- |
+| Multi-machine | The inbound dispatch can route a topic's message to the machine that owns the session (gated; dark by default). |
 
 ## Evidence
 
-- Tier-1 unit tests: monotonic self-fence (incl. the backward-wall-clock-jump
-  immunity proof and the mid-tick `holdsLease` fence), real-monotonic default
-  wiring integrity, `isRouter()`, and the dark config defaults + migration parity
-  (adds-into-existing-multiMachine, no-clobber, inert, idempotent).
-- 155 tests green across the lease/config/coordinator/seamlessness cluster after
-  the change; tsc clean. Full suite runs in CI.
-- Side-effects review: upgrades/side-effects/session-pool-track-a-router-lease.md
+- `tests/unit/session-pool-activation-wiring.test.ts` pins the safety invariants: gated on a
+  non-dark stage, fail-safe to local dispatch, real-deps construction, module-ref sharing.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,28 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+The Multi-Machine Session Pool gains its activation wiring (still DARK): the SessionRouter
+is constructed at boot and consulted on the inbound message path, and a forwarded message
+now resumes the session on the owner machine — but ALL of this is gated on the rollout stage
+being advanced past 'dark'. A single-machine, un-activated agent behaves exactly as before:
+the interception is gated off on three independent conditions (no router without machine
+identity, stage defaults dark, fail-safe to local dispatch).
+
+## What to Tell Your User
+
+Nothing changes yet — this is the plumbing that lets the session pool actually move
+conversations between machines once it's staged on. It stays off until explicitly activated.
+
+## Summary of New Capabilities
+
+| Area | Capability |
+| --- | --- |
+| Multi-machine | Inbound dispatch can route a topic's message to the machine that owns the session, and the owner resumes it (gated; dark by default). |
+
+## Evidence
+
+- `tests/unit/session-pool-activation-wiring.test.ts` pins the safety invariants: gated on a
+  non-dark stage, fail-safe to local dispatch, real-deps construction, owner-side resume bridge.

--- a/upgrades/side-effects/session-pool-activation-wiring.md
+++ b/upgrades/side-effects/session-pool-activation-wiring.md
@@ -17,3 +17,6 @@ Wires the SessionRouter into the live boot + the inbound message-dispatch path, 
 
 ## Remaining (the hardware operation — B/C/D)
 Deploy to laptop + bring up the mini as machine #2; advance dark→shadow→live-transfer (each E2E-gated); test-as-self nickname-swap proof. The owner-side deliverMessage→local-spawn bridge (so a forwarded message actually spawns on the owner) is the final piece, validated on the 2-machine setup.
+
+## Addendum — owner-side bridge (task A.2)
+`createDeliverMessageHandler` now takes an `onAccepted` hook wired (in the mesh block) to `spawnSessionForTopic`: a FIRST-seen forwarded `deliverMessage` spawns/resumes the local session for the topic so the conversation continues on the OWNER machine — the receive-side of the §L4 handoff. Gated on `_sessionPoolStage() !== 'dark'` + `telegram` present; fire-and-forget (the durable receipt is ACKed before this runs); fails safe (logs, never throws into the dispatcher). Inert until live-transfer (a deliverMessage only arrives from a router peer). This makes the activation code-complete: outbound forward (router) + receive+ACK (handler) + owner-side resume (bridge). Remaining is purely the 2-machine hardware proof.

--- a/upgrades/side-effects/session-pool-activation-wiring.md
+++ b/upgrades/side-effects/session-pool-activation-wiring.md
@@ -1,0 +1,19 @@
+# Side effects — Session Pool activation wiring (§L4 live-ingress, dark)
+
+## What this adds (task A of the activation)
+Wires the SessionRouter into the live boot + the inbound message-dispatch path, GATED so it is inert until the rollout stage advances past 'dark'.
+
+- `src/commands/server.ts`:
+  - Module-level refs `_sessionRouter` + `_sessionPoolStage()` (the idiomatic instar pattern — the inbound handler in `wireTelegramRouting` is defined above `startServer`, so the router constructed in startServer's mesh block is shared via a module ref, like `_orphanReaper`/`_topicResumeMap`).
+  - **Construction** (mesh block, when a machine identity exists): `new SessionRouter({...})` wired to the real `MachinePoolRegistry` (machineRegistry), `SessionOwnershipRegistry` (resolveOwnership + casClaimOwnership), `PlacementExecutor`, and an outbound `MeshRpcClient` (deliverMessage/spawnOnMachine to peers via `lastKnownUrl`). `_sessionPoolStage()` reads the live `multiMachine.sessionPool.{enabled,stage}` (defaults 'dark').
+  - **Interception** (inbound `onTopicMessage`, after target-session resolution): when `_sessionRouter && _sessionPoolStage() !== 'dark'`, consult `route()`; a `forwarded`/`duplicate` outcome short-circuits (the owner machine handles it); everything else falls through to the existing local dispatch. Wrapped in try/catch → falls back to local on any error.
+
+## Risk / blast radius
+**None in production.** The gate defaults to dark on three independent conditions: `_sessionRouter` is null without machine identity; `_sessionPoolStage()` returns 'dark' unless `enabled && stage` set (ConfigDefaults ships enabled:false/stage:dark); and the interception fails safe to local dispatch. So a single-machine, un-activated agent is byte-identical to today. The live-transfer behavior is gated by the staged rollout (StageAdvancer + E2E records).
+
+## Tests
+- `tests/unit/session-pool-activation-wiring.test.ts` — 4 wiring-integrity tests pinning the safety invariants: gated on non-dark stage (default-dark → inert), fail-safe try/catch → local, real-deps construction (registry/ownership/placement + MeshRpcClient), module-ref sharing. Guards against a regression that removes the gate (which would activate cross-machine routing unconditionally).
+- SessionRouter behavior itself is covered by its 17 unit + 3 integration tests (#506).
+
+## Remaining (the hardware operation — B/C/D)
+Deploy to laptop + bring up the mini as machine #2; advance dark→shadow→live-transfer (each E2E-gated); test-as-self nickname-swap proof. The owner-side deliverMessage→local-spawn bridge (so a forwarded message actually spawns on the owner) is the final piece, validated on the 2-machine setup.


### PR DESCRIPTION
## What
Task A of the Session Pool activation: wires the `SessionRouter` into the live boot and the inbound message-dispatch path, **gated so it is inert until the rollout stage advances past `dark`**. Follow-on to #506 (which shipped all the dark components).

- **Module refs** `_sessionRouter` + `_sessionPoolStage()` — the inbound handler (`wireTelegramRouting`) is defined above `startServer`, so the router built in startServer's mesh block is shared via a module ref (same pattern as `_orphanReaper`/`_topicResumeMap`).
- **Construction** (mesh block, when a machine identity exists): `SessionRouter` wired to the real `MachinePoolRegistry`, `SessionOwnershipRegistry`, `PlacementExecutor`, and an outbound `MeshRpcClient` (peer via `lastKnownUrl`).
- **Interception** (`onTopicMessage`, after target-session resolution): when `_sessionRouter && _sessionPoolStage() !== 'dark'`, consult `route()`; a `forwarded`/`duplicate` outcome short-circuits (the owner handles it); everything else falls through to local. `try/catch` → fail-safe to local.

## Safety (dark by default on three independent gates)
1. `_sessionRouter` is null without a machine identity.
2. `_sessionPoolStage()` returns `dark` unless `enabled && stage` is set (ConfigDefaults ships `enabled:false`/`stage:dark`).
3. The interception fails safe to local dispatch on any error.

→ A single-machine, un-activated agent is **byte-identical to today**. The live-transfer behavior is gated by the staged rollout (StageAdvancer + E2E records).

## Tests
- `tests/unit/session-pool-activation-wiring.test.ts` (4) — pins the gate, the fail-safe, the real-deps construction, and the module-ref sharing. Guards against a regression that removes the gate.
- `SessionRouter` behavior covered by its 17 unit + 3 integration tests in #506.

## Remaining (the hardware operation)
Deploy + bring up the mini as machine #2; advance dark→shadow→live-transfer (E2E-gated); the owner-side deliverMessage→local-spawn bridge; test-as-self nickname-swap proof — all validated on the 2-machine setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)