### PR TITLE
fix(monitoring): wire attribution resolver + exempt pre-attribution sentinel from burn alarm

### DIFF
--- a/src/monitoring/AttributionResolver.ts
+++ b/src/monitoring/AttributionResolver.ts
@@ -20,6 +20,25 @@
 import { buildAttributionKey } from './attributionKey.js';
 import { ATTRIBUTION_MANIFEST, type AttributionPattern } from './attribution-manifest.js';
 
+/**
+ * Sentinel attribution key meaning "the resolver has NEVER run on this event."
+ *
+ * This is the column DEFAULT and the historical hardcoded value the ingest
+ * path wrote before Phase 2 was wired. It is NOT a resolution outcome —
+ * `resolveAttribution()` never returns it (it always resolves to a manifest,
+ * job, hook, sessionId-prefix, or `unknown::no-session` key).
+ *
+ * The distinction matters for burn detection: a bucket sitting at 100% of
+ * spend under THIS key means "we don't attribute anything yet" (a coverage
+ * gap), not "one component is burning." Per the umbrella spec
+ * (docs/specs/token-burn-detection-and-self-heal.md §"Threshold logic"), the
+ * BurnDetector must treat this sentinel as a coverage signal and never let it
+ * trip the absolute-share trigger. The genuinely-residual `unknown::<sid>`
+ * key (resolver ran, found no match) is a real signal and still triggers
+ * normally.
+ */
+export const PRE_ATTRIBUTION_KEY = 'unknown::pre-attribution';
+
 export interface AttributionEvent {
   sessionId: string;
   /** cwd / projectPath field from the JSONL line. */

--- a/src/monitoring/BurnDetector.ts
+++ b/src/monitoring/BurnDetector.ts
@@ -27,6 +27,7 @@
 
 import type { TokenLedger, AttributionKeyRow } from './TokenLedger.js';
 import type { DegradationReporter } from './DegradationReporter.js';
+import { PRE_ATTRIBUTION_KEY } from './AttributionResolver.js';
 
 export interface BurnDetectionConfig {
   enabled: boolean;
@@ -162,7 +163,22 @@ export class BurnDetector {
       let baselineMedian7d: number | undefined;
 
       // Trigger 1 — absolute share.
-      if (share > this.config.absoluteShareThreshold) {
+      //
+      // The PRE_ATTRIBUTION_KEY sentinel ("resolver never ran") is EXEMPT from
+      // this trigger. A bucket at 100% share under the sentinel means "we
+      // don't attribute these events yet" — a coverage gap — not "one
+      // component is burning." Before attribution was wired, every event sat
+      // under this sentinel, so absolute-share fired forever (the false
+      // positive this change closes). Per the umbrella spec §"Threshold
+      // logic", the sentinel is a coverage signal, never an absolute-share
+      // burn trigger. The genuinely-residual `unknown::<sessionId>` key
+      // (resolver ran, found no match) is NOT exempt and still alerts —
+      // that's the spec's "alert on unattributable spend." Baseline-divergence
+      // (trigger 2) is intentionally still allowed on the sentinel: a sudden
+      // spike of NEW unattributed spend vs its own 7-day history is worth
+      // surfacing even though its absolute share is not.
+      const isPreAttributionSentinel = key24h.attributionKey === PRE_ATTRIBUTION_KEY;
+      if (!isPreAttributionSentinel && share > this.config.absoluteShareThreshold) {
         trigger = 'absolute-share';
       }
 

--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -19,6 +19,7 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import { NativeModuleHealer } from '../memory/NativeModuleHealer.js';
 import { parseCodexRollout, type ParsedCodexSession } from './CodexRolloutParser.js';
+import { resolveAttribution, PRE_ATTRIBUTION_KEY } from './AttributionResolver.js';
 
 /**
  * Compute a small content fingerprint for a JSONL file. Used to detect
@@ -56,6 +57,10 @@ const SCHEMA = [
      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
      cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
      service_tier          TEXT,
+     -- Default is the PRE_ATTRIBUTION_KEY sentinel ("resolver never ran").
+     -- The ingest path now resolves a real key at write time; this default
+     -- only applies to rows inserted before Phase 2 was wired, which the
+     -- one-shot backfill (backfillAttributionOnce) converts to resolved keys.
      attribution_key       TEXT NOT NULL DEFAULT 'unknown::pre-attribution'
    )`,
   // Migration for installs that pre-date attribution_key. This MUST run BEFORE any
@@ -113,6 +118,14 @@ const SCHEMA = [
    )`,
   `CREATE INDEX IF NOT EXISTS idx_codex_sessions_last_ts ON codex_token_sessions(last_ts)`,
   `CREATE INDEX IF NOT EXISTS idx_codex_sessions_project ON codex_token_sessions(project_path)`,
+  // Small key/value table for one-shot maintenance markers (e.g. the
+  // attribution backfill). Keeps idempotent migrations from re-running on
+  // every boot without needing an external migration framework.
+  `CREATE TABLE IF NOT EXISTS ledger_meta (
+     key        TEXT PRIMARY KEY,
+     value      TEXT,
+     updated_at INTEGER NOT NULL DEFAULT 0
+   )`,
 ];
 
 // ── Types ─────────────────────────────────────────────────────────────
@@ -324,6 +337,111 @@ export class TokenLedger {
       }
     }
     this.prepareStatements();
+    // One-shot: convert legacy rows written before Phase 2 attribution was
+    // wired (all under the PRE_ATTRIBUTION_KEY sentinel) into resolved keys.
+    // Marker-guarded so it runs exactly once per DB, even across restarts.
+    // Self-healing on boot — existing agents get this on their next server
+    // start with no PostUpdateMigrator change required.
+    try {
+      this.backfillAttributionOnce();
+    } catch (err) {
+      // Never let a backfill failure take down ledger init — the worst case
+      // is the sentinel rows stay unattributed (and exempt from burn alerts).
+      console.warn(`[token-ledger] attribution backfill skipped (non-fatal): ${(err as Error).message}`);
+    }
+  }
+
+  /** Read a value from the ledger_meta key/value table (null if absent). */
+  private getMeta(key: string): string | null {
+    try {
+      const row = this.db
+        .prepare(`SELECT value FROM ledger_meta WHERE key = ?`)
+        .get(key) as { value: string | null } | undefined;
+      return row ? row.value : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Upsert a value into the ledger_meta key/value table. */
+  private setMeta(key: string, value: string): void {
+    this.db
+      .prepare(
+        `INSERT INTO ledger_meta (key, value, updated_at) VALUES (?, ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+      )
+      .run(key, value, Date.now());
+  }
+
+  /**
+   * One-shot, idempotent backfill of the attribution_key column for legacy
+   * rows that still carry the PRE_ATTRIBUTION_KEY sentinel (i.e. were ingested
+   * before Phase 2 attribution was wired into ingestLine).
+   *
+   * Why it's needed: before this fix, every JSONL-sourced event was hardcoded
+   * to `unknown::pre-attribution`, so 100% of spend sat in one bucket and the
+   * BurnDetector's absolute-share trigger fired forever (the false-positive
+   * this whole change closes). Backfilling re-resolves those rows from the
+   * signals we DO have on each row (session_id, project_path, model) — the
+   * same read-only signals the live ingest path now uses (prompt is
+   * unavailable, so this is cwd/job/hook/session-level attribution).
+   *
+   * Performance: resolution depends only on (session_id, project_path, model),
+   * so we resolve ONCE per distinct triple and bulk-update by triple inside a
+   * single transaction. On Echo's real DB that's ~hundreds of sessions vs
+   * ~384k rows — cheap. Marker-guarded via ledger_meta so it never re-runs.
+   */
+  backfillAttributionOnce(): { backfilled: number; alreadyDone: boolean } {
+    const MARKER = 'attribution-backfill-v1';
+    if (this.getMeta(MARKER)) return { backfilled: 0, alreadyDone: true };
+
+    // Distinct (session_id, project_path, model) triples still on the sentinel.
+    const triples = this.db
+      .prepare(
+        `SELECT DISTINCT session_id AS sessionId, project_path AS projectPath, model AS model
+           FROM token_events
+          WHERE attribution_key = ?`
+      )
+      .all(PRE_ATTRIBUTION_KEY) as Array<{
+        sessionId: string;
+        projectPath: string | null;
+        model: string | null;
+      }>;
+
+    const update = this.db.prepare(
+      `UPDATE token_events
+          SET attribution_key = @newKey
+        WHERE attribution_key = @sentinel
+          AND session_id = @sessionId
+          AND (project_path IS @projectPath OR project_path = @projectPath)
+          AND (model IS @model OR model = @model)`
+    );
+
+    let backfilled = 0;
+    const run = this.db.transaction(() => {
+      for (const t of triples) {
+        const newKey = resolveAttribution({
+          sessionId: t.sessionId,
+          projectPath: t.projectPath,
+          prompt: null,
+          model: t.model,
+        });
+        // resolveAttribution never returns the sentinel, but guard anyway so a
+        // future change can't silently no-op the marker.
+        if (newKey === PRE_ATTRIBUTION_KEY) continue;
+        const res = update.run({
+          newKey,
+          sentinel: PRE_ATTRIBUTION_KEY,
+          sessionId: t.sessionId,
+          projectPath: t.projectPath,
+          model: t.model,
+        });
+        backfilled += res.changes;
+      }
+      this.setMeta(MARKER, new Date().toISOString());
+    });
+    run();
+    return { backfilled, alreadyDone: false };
   }
 
   private prepareStatements(): void {
@@ -420,10 +538,21 @@ export class TokenLedger {
         cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
         cacheReadTokens: usage.cache_read_input_tokens ?? 0,
         serviceTier: usage.service_tier ?? null,
-        // JSONL-source events do not carry attribution; Phase 2 will run an
-        // AttributionResolver on the read side that maps these to a known
-        // component when possible. Until then they sit under the default key.
-        attributionKey: 'unknown::pre-attribution',
+        // Phase 2 (now wired): resolve the attribution key at ingest from the
+        // signals the JSONL line carries — sessionId, cwd, and model. The
+        // Claude-CLI JSONL trail has no user prompt on the assistant line, so
+        // prompt-shape matching is unavailable here; the resolver falls through
+        // to cwd-based job/hook inference or a stable per-session key. This is
+        // what splits the old single `unknown::pre-attribution` bucket (which
+        // was always 100% of spend → a permanent false BurnDetector alarm)
+        // into per-origin keys. Prompt-shape attribution is a separate
+        // follow-up that needs user+assistant line correlation at ingest.
+        attributionKey: resolveAttribution({
+          sessionId: obj.sessionId,
+          projectPath: obj.cwd ?? null,
+          prompt: null,
+          model: obj.message?.model ?? null,
+        }),
       });
       return { inserted: result.changes > 0, reason: result.changes > 0 ? undefined : 'duplicate' };
     } catch {

--- a/tests/unit/burn-attribution-wiring.test.ts
+++ b/tests/unit/burn-attribution-wiring.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests — attribution wiring fix (the "unknown::pre-attribution = 100%
+ * of 24h spend" false-positive closure).
+ *
+ * Root cause this suite pins: Phase 2's AttributionResolver was written but
+ * never wired into the ingest path, so EVERY JSONL-sourced token event was
+ * hardcoded to the `unknown::pre-attribution` sentinel. With a single bucket,
+ * its share was always 100%, so the BurnDetector's absolute-share trigger
+ * (>25%) fired every hour forever — a false alarm, not a real burn.
+ *
+ * The fix has three observable behaviors, each covered here:
+ *   1. AttributionResolver NEVER returns the sentinel — it always resolves to
+ *      a real key. The sentinel is purely the column default / "never ran".
+ *   2. TokenLedger.ingestLine now resolves a real key at write time, and a
+ *      one-shot idempotent backfill converts legacy sentinel rows on boot.
+ *   3. BurnDetector exempts the sentinel from the absolute-share trigger (a
+ *      coverage gap is not a burn) while a genuinely-residual `unknown::<sid>`
+ *      key still triggers normally.
+ *
+ * Spec: docs/specs/token-burn-detection-and-self-heal.md (Phase 2 wiring +
+ * §"Threshold logic" sentinel-is-a-coverage-signal).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import {
+  resolveAttribution,
+  PRE_ATTRIBUTION_KEY,
+} from '../../src/monitoring/AttributionResolver.js';
+import { TokenLedger } from '../../src/monitoring/TokenLedger.js';
+import type { AttributionKeyRow } from '../../src/monitoring/TokenLedger.js';
+import { BurnDetector } from '../../src/monitoring/BurnDetector.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function assistantLine(opts: {
+  requestId: string;
+  sessionId: string;
+  cwd?: string;
+  ts?: string;
+  model?: string;
+  input?: number;
+  output?: number;
+}): string {
+  return JSON.stringify({
+    type: 'assistant',
+    sessionId: opts.sessionId,
+    cwd: opts.cwd ?? '/',
+    timestamp: opts.ts ?? '2026-05-29T16:00:00.000Z',
+    uuid: 'uuid-' + opts.requestId,
+    requestId: opts.requestId,
+    message: {
+      id: 'msg-' + opts.requestId,
+      model: opts.model ?? 'claude-opus-4-8',
+      usage: {
+        input_tokens: opts.input ?? 10,
+        output_tokens: opts.output ?? 100,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        service_tier: 'standard',
+      },
+    },
+  });
+}
+
+// ── 1. The resolver never returns the sentinel ────────────────────────────
+
+describe('AttributionResolver — never returns the PRE_ATTRIBUTION_KEY sentinel', () => {
+  it('exports the sentinel as the documented literal', () => {
+    expect(PRE_ATTRIBUTION_KEY).toBe('unknown::pre-attribution');
+  });
+
+  it('resolves a real key for every shape — never the sentinel', () => {
+    const cases = [
+      // The dominant Claude-CLI shape: no prompt on the assistant line, cwd '/'.
+      { sessionId: '0418632d-aa11-4440-8110-b26af9335100', projectPath: '/', prompt: null },
+      // Manifest prompt match.
+      { sessionId: 's', prompt: 'analyzing terminal output' },
+      // Scheduled-job cwd.
+      { sessionId: 's', projectPath: '/Users/x/.instar/jobs/daily-summary', prompt: null },
+      // Hook cwd.
+      { sessionId: 's', projectPath: '/Users/x/.instar/hooks/instar/foo.js', prompt: null },
+      // Empty session, no signals.
+      { sessionId: '', projectPath: null, prompt: null },
+      // Everything missing.
+      { sessionId: 'abcdefgh8901', projectPath: undefined, prompt: undefined, model: undefined },
+    ];
+    for (const c of cases) {
+      const key = resolveAttribution(c as any);
+      expect(key).not.toBe(PRE_ATTRIBUTION_KEY);
+      expect(key.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('falls back to a stable per-session key when only sessionId is known', () => {
+    const key = resolveAttribution({ sessionId: '0418632d-aa11-4440', projectPath: '/', prompt: null });
+    expect(key).toBe('unknown::0418632d');
+    expect(key).not.toBe(PRE_ATTRIBUTION_KEY);
+  });
+});
+
+// ── 2. ingest resolves + one-shot backfill ────────────────────────────────
+
+describe('TokenLedger — ingest resolves attribution (no more sentinel pile-up)', () => {
+  let ledger: TokenLedger;
+
+  beforeEach(() => {
+    ledger = new TokenLedger({ dbPath: ':memory:', claudeProjectsDir: '/tmp/nonexistent' });
+  });
+  afterEach(() => ledger.close());
+
+  it('ingestLine on a normal assistant line stores a resolved per-session key, NOT the sentinel', () => {
+    const sessionId = '0418632d-aa11-4440-8110-b26af9335100';
+    ledger.ingestLine(assistantLine({ requestId: 'r1', sessionId, cwd: '/' }));
+    const rows = ledger.byAttributionKey({ sinceMs: 0 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].attributionKey).toBe('unknown::' + sessionId.slice(0, 8));
+    expect(rows[0].attributionKey).not.toBe(PRE_ATTRIBUTION_KEY);
+  });
+
+  it('attributes a scheduled-job cwd to a user-job:<name> key', () => {
+    ledger.ingestLine(
+      assistantLine({
+        requestId: 'r1',
+        sessionId: 's',
+        cwd: '/Users/x/.instar/jobs/commitment-check',
+      }),
+    );
+    const rows = ledger.byAttributionKey({ sinceMs: 0 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].attributionKey.startsWith('user-job:commitment-check')).toBe(true);
+  });
+
+  it('two different sessions split into two keys (the 100%-one-bucket bug is gone)', () => {
+    ledger.ingestLine(assistantLine({ requestId: 'r1', sessionId: 'aaaaaaaa-1', cwd: '/' }));
+    ledger.ingestLine(assistantLine({ requestId: 'r2', sessionId: 'bbbbbbbb-2', cwd: '/' }));
+    const rows = ledger.byAttributionKey({ sinceMs: 0 });
+    expect(rows).toHaveLength(2);
+    const keys = rows.map((r) => r.attributionKey).sort();
+    expect(keys).toEqual(['unknown::aaaaaaaa', 'unknown::bbbbbbbb']);
+  });
+});
+
+describe('TokenLedger.backfillAttributionOnce — converts legacy sentinel rows, idempotent', () => {
+  let tmp: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'attr-backfill-'));
+    dbPath = path.join(tmp, 'ledger.db');
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmp, {
+      recursive: true,
+      force: true,
+      operation: 'tests/unit/burn-attribution-wiring.test.ts',
+    });
+  });
+
+  it('is idempotent: a second call on a fresh ledger reports alreadyDone', () => {
+    const ledger = new TokenLedger({ dbPath, claudeProjectsDir: tmp });
+    // The constructor already ran the one-shot backfill (0 rows → marker set).
+    const second = ledger.backfillAttributionOnce();
+    expect(second.alreadyDone).toBe(true);
+    expect(second.backfilled).toBe(0);
+    ledger.close();
+  });
+
+  it('converts pre-existing sentinel rows on the next boot (the real upgrade path)', () => {
+    // Phase 1: open a ledger and seed rows that still carry the sentinel,
+    // simulating an agent whose DB pre-dates Phase 2 wiring. recordEvent lets
+    // us force the sentinel key explicitly.
+    const seed = new TokenLedger({ dbPath, claudeProjectsDir: tmp });
+    seed.recordEvent({
+      requestId: 'legacy-1', sessionId: 'sessA1234567', ts: 1000,
+      inputTokens: 100, outputTokens: 50, attributionKey: PRE_ATTRIBUTION_KEY,
+    });
+    seed.recordEvent({
+      requestId: 'legacy-2', sessionId: 'sessA1234567', ts: 2000,
+      inputTokens: 10, outputTokens: 5, attributionKey: PRE_ATTRIBUTION_KEY,
+    });
+    seed.recordEvent({
+      requestId: 'legacy-3', sessionId: 'sessB7654321', ts: 3000,
+      inputTokens: 10, outputTokens: 5, attributionKey: PRE_ATTRIBUTION_KEY,
+    });
+    seed.close();
+
+    // Both rows are under the sentinel, and the constructor's backfill already
+    // marked the DB done (it found these rows AFTER the marker, since seed's
+    // constructor ran on an empty DB). Simulate the genuine pre-wiring DB by
+    // removing the marker so the NEXT boot's backfill actually runs.
+    const raw = new Database(dbPath);
+    raw.prepare(`DELETE FROM ledger_meta WHERE key = 'attribution-backfill-v1'`).run();
+    // Sanity: the seeded rows really are on the sentinel before backfill.
+    const before = raw
+      .prepare(`SELECT COUNT(*) AS c FROM token_events WHERE attribution_key = ?`)
+      .get(PRE_ATTRIBUTION_KEY) as { c: number };
+    expect(before.c).toBe(3);
+    raw.close();
+
+    // Phase 2: re-open. The constructor runs backfillAttributionOnce(), which
+    // finds the sentinel rows + no marker → converts them.
+    const reopened = new TokenLedger({ dbPath, claudeProjectsDir: tmp });
+    const rows = reopened.byAttributionKey({ sinceMs: 0 });
+    // No row should remain on the sentinel.
+    expect(rows.find((r) => r.attributionKey === PRE_ATTRIBUTION_KEY)).toBeUndefined();
+    // The two sessions resolve to two stable per-session keys
+    // (sessionId.slice(0, 8) — 'sessA123' / 'sessB765').
+    const keys = rows.map((r) => r.attributionKey).sort();
+    expect(keys).toEqual(['unknown::sessA123', 'unknown::sessB765']);
+    // A subsequent explicit call is a no-op (marker now set).
+    const again = reopened.backfillAttributionOnce();
+    expect(again.alreadyDone).toBe(true);
+    expect(again.backfilled).toBe(0);
+    reopened.close();
+  });
+});
+
+// ── 3. BurnDetector exempts the sentinel from absolute-share ───────────────
+
+function stubLedger(byKey: AttributionKeyRow[]) {
+  return {
+    byAttributionKey(): AttributionKeyRow[] {
+      return byKey;
+    },
+    summary: () => ({ totalTokens: 0 } as any),
+  };
+}
+function stubReporter() {
+  const reports: any[] = [];
+  return { reports, report(ev: any) { reports.push(ev); } };
+}
+
+describe('BurnDetector — PRE_ATTRIBUTION_KEY is exempt from absolute-share', () => {
+  it('does NOT emit absolute-share when the sentinel is 100% of spend (the false-positive regression)', () => {
+    const ledger = stubLedger([
+      { attributionKey: PRE_ATTRIBUTION_KEY, totalTokens: 2_000_000, eventCount: 40, firstTs: 0, lastTs: 0 },
+    ]);
+    const reporter = stubReporter();
+    const detector = new BurnDetector({
+      ledger,
+      reporter,
+      // Infinite cold-start isolates absolute-share from baseline-divergence.
+      config: { coldStartMs: Number.MAX_SAFE_INTEGER },
+      now: () => 1_000_000_000_000,
+    });
+    expect(detector.tick()).toHaveLength(0);
+    expect(reporter.reports).toHaveLength(0);
+  });
+
+  it('STILL emits absolute-share for a genuinely-residual unknown::<sid> key at 100%', () => {
+    const ledger = stubLedger([
+      { attributionKey: 'unknown::0418632d', totalTokens: 2_000_000, eventCount: 40, firstTs: 0, lastTs: 0 },
+    ]);
+    const reporter = stubReporter();
+    const detector = new BurnDetector({
+      ledger,
+      reporter,
+      config: { coldStartMs: Number.MAX_SAFE_INTEGER },
+      now: () => 1_000_000_000_000,
+    });
+    const signals = detector.tick();
+    expect(signals).toHaveLength(1);
+    expect(signals[0].trigger).toBe('absolute-share');
+    expect(signals[0].attributionKey).toBe('unknown::0418632d');
+  });
+
+  it('does not let the sentinel mask a real burner sharing the window', () => {
+    // Sentinel at 60% + a real component at 40%: the sentinel is skipped, the
+    // real component still trips the 25% threshold.
+    const ledger = stubLedger([
+      { attributionKey: PRE_ATTRIBUTION_KEY, totalTokens: 600, eventCount: 10, firstTs: 0, lastTs: 0 },
+      { attributionKey: 'InputDetector::abcd1234', totalTokens: 400, eventCount: 10, firstTs: 0, lastTs: 0 },
+    ]);
+    const reporter = stubReporter();
+    const detector = new BurnDetector({
+      ledger,
+      reporter,
+      config: { coldStartMs: Number.MAX_SAFE_INTEGER },
+      now: () => 1_000_000_000_000,
+    });
+    const signals = detector.tick();
+    expect(signals).toHaveLength(1);
+    expect(signals[0].attributionKey).toBe('InputDetector::abcd1234');
+  });
+});

--- a/tests/unit/token-ledger.test.ts
+++ b/tests/unit/token-ledger.test.ts
@@ -468,12 +468,18 @@ describe('TokenLedger pre-attribution DB migration (schema-order regression)', (
     expect(cols).toContain('attribution_key');
 
     // The attribution_key-referencing queries (which back /tokens/*) work, and the
-    // pre-existing row was backfilled with the migration DEFAULT rather than dropped.
+    // pre-existing row survives the migration. Phase 2 wiring: the one-shot
+    // backfillAttributionOnce() in the constructor re-resolves the legacy
+    // unknown::pre-attribution DEFAULT into a real key. The seeded row has
+    // session_id 'sess-old' and no cwd/model, so it resolves to the stable
+    // per-session fallback 'unknown::sess-old' (sessionId.slice(0, 8)). The
+    // row is backfilled, not dropped — and the sentinel is gone.
     const summary = ledger!.summary();
     expect(summary.eventCount).toBe(1);
     const byKey = ledger!.byAttributionKey();
     expect(byKey.length).toBeGreaterThanOrEqual(1);
-    expect(byKey.some((r) => r.attributionKey === 'unknown::pre-attribution')).toBe(true);
+    expect(byKey.some((r) => r.attributionKey === 'unknown::pre-attribution')).toBe(false);
+    expect(byKey.some((r) => r.attributionKey === 'unknown::sess-old')).toBe(true);
   });
 
   it('re-initialising a migrated DB is idempotent (duplicate-column ALTER swallowed)', () => {

--- a/upgrades/side-effects/burn-attribution-wiring.md
+++ b/upgrades/side-effects/burn-attribution-wiring.md
@@ -1,0 +1,103 @@
+# Side-Effects Review — wire AttributionResolver into ingest + exempt the pre-attribution sentinel
+
+## What changed
+
+Completes **Phase 2** of `docs/specs/token-burn-detection-and-self-heal.md`, which
+was specced but never wired. Three source files + their tests:
+
+1. **`src/monitoring/AttributionResolver.ts`** — exports a new
+   `PRE_ATTRIBUTION_KEY = 'unknown::pre-attribution'` constant: the sentinel
+   meaning "the resolver has never run on this event" (the column default and
+   the historical hardcoded ingest value). `resolveAttribution()` itself is
+   unchanged and never returns this sentinel.
+
+2. **`src/monitoring/TokenLedger.ts`**
+   - `ingestLine()` now calls `resolveAttribution({sessionId, projectPath: cwd,
+     prompt: null, model})` instead of hardcoding `'unknown::pre-attribution'`.
+     The Claude-CLI JSONL assistant line carries no user prompt, so this is
+     cwd/job/hook/session-level attribution; prompt-shape attribution remains a
+     separate follow-up (needs user+assistant line correlation at ingest).
+   - New `ledger_meta` key/value table + `getMeta`/`setMeta` helpers.
+   - New `backfillAttributionOnce()` — one-shot, idempotent, marker-guarded
+     (`attribution-backfill-v1`) re-resolution of legacy sentinel rows, run
+     non-fatally from the constructor after `prepareStatements()`.
+
+3. **`src/monitoring/BurnDetector.ts`** — `tick()` exempts the
+   `PRE_ATTRIBUTION_KEY` sentinel from the **absolute-share** trigger only. A
+   bucket at 100% under the sentinel is a coverage gap, not a burn. The
+   genuinely-residual `unknown::<sessionId>` key (resolver ran, no match) is
+   NOT exempt and still alerts (the spec's "alert on unattributable spend").
+   Baseline-divergence is unaffected.
+
+## Why
+
+The recurring `unknown::pre-attribution consumed 100.0% of 24h spend
+(threshold 25%)` alert was a **fleet-wide false positive**. Because the
+resolver was never wired, every JSONL-sourced event defaulted to the single
+sentinel bucket, whose share was always 100%, so the absolute-share trigger
+fired every hour forever — on every agent with burn-detection enabled (default)
+and any daily spend. Real spend on the reporting agent was ~1.5M tokens/24h
+(the bleed this system targets was ~3B/day).
+
+## Behavioral side effects
+
+- **BurnDetector no longer emits absolute-share on the sentinel.** Intended.
+  This is the false-positive fix. Real burns are unaffected: (a) any resolved
+  key (component/job/hook/`unknown::<sid>`) still trips at >25%; (b) the
+  sentinel only exists transiently until backfill clears it; (c) a real burner
+  sharing the 24h window with sentinel rows still trips (the sentinel is
+  skipped, not counted against the burner's share — verified by test
+  "does not let the sentinel mask a real burner sharing the window").
+- **Existing attribution distribution changes shape.** Instead of one 100%
+  bucket, spend now splits per origin (mostly `unknown::<sessionId>` for the
+  dominant Claude-CLI path, plus `user-job:*` / `user-hook:*`). The
+  `/tokens/*` summary/sessions/by-project routes are unchanged in schema; only
+  the `byAttributionKey` grouping is now meaningful. No route signature changed.
+- **One-time backfill UPDATE on first boot after upgrade.** On the reporting
+  agent that's ~384k rows across a few hundred distinct (session, project,
+  model) triples — resolved once per triple inside a single transaction, so a
+  handful of bulk UPDATEs, not 384k. Marker-guarded → runs exactly once per DB.
+  Wrapped in try/catch in the constructor: a backfill failure logs and is
+  swallowed (worst case: sentinel rows stay unattributed and thus exempt from
+  burn alerts — i.e. degrades to the old-but-safe behavior, never a crash).
+
+## Migration parity
+
+No `PostUpdateMigrator` change required. The backfill self-heals on the
+constructor's next run, which happens on every server start. Existing agents
+get it on their next restart onto a version carrying this change. The new
+`ledger_meta` table is created idempotently in the SCHEMA list alongside the
+existing tables.
+
+## Blast radius / isolation
+
+- Scope is the three monitoring files. **No HTTP route, server-boot, or
+  CapabilityIndex change** → no agent-awareness/CLAUDE.md-template update owed.
+- Codex token sessions live in a separate table (`codex_token_sessions`) and
+  are untouched — burn detection reads only `token_events`.
+- Read-only-observability invariant of the TokenLedger is preserved: the only
+  new write is to the ledger's own SQLite DB (the backfill UPDATE + the meta
+  marker). No source JSONL file is touched.
+
+## Rollback
+
+Revert the three `src/monitoring/*` files. Backfilled `attribution_key` values
+are harmless if the revert lands (they're just better labels); the
+`ledger_meta` table and its marker row are inert without the new code. No data
+loss, no schema-incompatible state. (Per-phase revert matches the umbrella
+spec's rollback model.)
+
+## Tests
+
+- New `tests/unit/burn-attribution-wiring.test.ts` (11 tests): resolver never
+  returns the sentinel; ingest now resolves a real key; two sessions split into
+  two keys; job-cwd → `user-job:*`; backfill converts legacy sentinel rows on
+  reopen + is idempotent; BurnDetector regression — sentinel at 100% emits
+  nothing, residual `unknown::<sid>` at 100% still emits, sentinel doesn't mask
+  a co-occurring real burner.
+- Updated `tests/unit/token-ledger.test.ts` (#512 schema-order migration test):
+  now asserts the migrated legacy row is backfilled to `unknown::sess-old` and
+  the sentinel is gone, instead of asserting the sentinel persists.
+- Full sweep green: `vitest run` over burn-detection-phase-1..6 + token-ledger +
+  TokenLedger-codex + TokenLedgerPoller-codex + burn-attribution-wiring =
+  **149 passed, 0 failed**. `tsc --noEmit` clean.


### PR DESCRIPTION
## Problem

The recurring BurnDetector alert `unknown::pre-attribution consumed 100.0% of 24h spend (threshold 25%)` is a **fleet-wide false positive** — not a real token burn.

**Root cause:** Phase 2 of `docs/specs/token-burn-detection-and-self-heal.md` (the read-side `AttributionResolver` that labels each token event by component) was specced but **never wired**. `TokenLedger.ingestLine` hardcoded every JSONL-sourced event to the `unknown::pre-attribution` sentinel, so 100% of spend sat in one bucket → the absolute-share trigger (>25%) fired every hour, forever, on every agent with burn-detection enabled and any daily spend. (On the reporting agent: 100% of all 383,855 events were on the sentinel; real spend ~1.5M tok/24h vs the ~3B/day bleed this system targets.)

The spec itself predicts this exact false positive and says the unattributed catch-all should be a *coverage signal*, never a burn trigger — that exemption was never coded either.

## Fix

1. **`AttributionResolver.ts`** — export `PRE_ATTRIBUTION_KEY` sentinel ('resolver never ran'), distinct from a resolved `unknown::<sid>` ('ran, no match').
2. **`TokenLedger.ingestLine`** — resolve the attribution key at write time from the signals the assistant JSONL line carries (sessionId / cwd / model). Prompt-shape attribution is a separate follow-up (assistant lines carry no prompt).
3. **`TokenLedger.backfillAttributionOnce()`** — one-shot, idempotent, marker-guarded re-resolution of legacy sentinel rows, run non-fatally from the constructor. **Self-heals on each agent's next restart — no `PostUpdateMigrator` change needed.**
4. **`BurnDetector.tick`** — exempt the `PRE_ATTRIBUTION_KEY` sentinel from the absolute-share trigger only. A coverage gap is not a burn. A genuinely-residual `unknown::<sid>` key still alerts (the spec's 'alert on unattributable spend'), and the sentinel can't mask a co-occurring real burner.

## Migration parity

No `PostUpdateMigrator` change required — the backfill runs on the constructor's next boot on every server start. No new HTTP route → no CapabilityIndex / CLAUDE.md-template change.

## Tests

- New `tests/unit/burn-attribution-wiring.test.ts` (11 tests): resolver never returns the sentinel; ingest now resolves a real key; sessions split into distinct keys; job-cwd → `user-job:*`; backfill converts legacy rows on reopen + is idempotent; **BurnDetector regression** — sentinel at 100% emits nothing, residual `unknown::<sid>` at 100% still emits, sentinel doesn't mask a real burner.
- Updated the #512 schema-order migration test to expect the backfilled key.
- Full sweep green: burn-detection-phase-1..6 + token-ledger + codex = **149 passed, 0 failed**. `tsc --noEmit` clean.

Completes Phase 2 of `docs/specs/token-burn-detection-and-self-heal.md` (approved 2026-05-15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)