### PR TITLE
fix(session-pool): advertise machine tunnel URL into the mesh — lastKnownUrl was never populated

### DIFF
--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -365,6 +365,13 @@ export async function joinMesh(repoUrl: string, options: JoinOptions): Promise<v
         // Store the remote machine's identity
         mgr.storeRemoteIdentity(result.machineIdentity);
         mgr.registerMachine(result.machineIdentity, 'awake');
+        // Record the URL we connected THROUGH as the awake machine's reachable
+        // URL, so this (standby) machine can route mesh RPCs back to it without
+        // waiting for a registry sync. Cross-machine routing reads lastKnownUrl;
+        // the joiner is the one place that authoritatively knows this URL.
+        try {
+          mgr.updateMachineUrl(result.machineIdentity.machineId, repoUrl.replace(/\/+$/, ''));
+        } catch { /* best-effort — entry was just registered above */ }
         console.log(pc.green(`  Paired with: ${result.machineIdentity.name}`));
       }
     } catch (err) {

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -62,6 +62,7 @@ import { SessionMonitor } from '../monitoring/SessionMonitor.js';
 import { SessionRecovery } from '../monitoring/SessionRecovery.js';
 import { MultiMachineCoordinator } from '../core/MultiMachineCoordinator.js';
 import { MachineIdentityManager } from '../core/MachineIdentity.js';
+import { resolveAdvertisedMeshUrl, advertiseSelfMeshUrl } from '../core/MeshUrlAdvertiser.js';
 import { GitSyncManager } from '../core/GitSync.js';
 import { RegistrySyncDebouncer } from '../core/RegistrySyncDebouncer.js';
 import { wireRegistrySync } from '../core/wireRegistrySync.js';
@@ -6821,6 +6822,19 @@ export async function startServer(options: StartOptions): Promise<void> {
               const tunnelUrl = await tunnel.start();
               console.log(`[SleepWake] Tunnel restarted: ${tunnelUrl}`);
 
+              // Re-advertise the mesh URL — a quick tunnel gets a NEW URL after a
+              // sleep/wake restart, so the previously-advertised lastKnownUrl is
+              // now stale; peers must learn the new one or cross-machine routing
+              // silently breaks post-wake.
+              if (coordinator.enabled && coordinator.identity) {
+                advertiseSelfMeshUrl(
+                  coordinator.managers.identityManager,
+                  coordinator.identity.machineId,
+                  resolveAdvertisedMeshUrl(config.tunnel, tunnelUrl),
+                  (m) => console.log(pc.dim(m)),
+                );
+              }
+
               // Re-broadcast dashboard URL after tunnel restart (quick tunnels get new URL)
               if (tunnelUrl) {
                 const tunnelType = config.tunnel?.type || 'quick';
@@ -9226,6 +9240,19 @@ export async function startServer(options: StartOptions): Promise<void> {
       try {
         const tunnelUrl = await tunnel.start();
         console.log(pc.green(`  Tunnel active: ${pc.bold(tunnelUrl)}`));
+        // Mesh URL advertisement: record THIS machine's reachable URL into its
+        // registry entry so cross-machine routing (deliver/transfer/lease) can
+        // reach it. Without this, lastKnownUrl is null and every peer is filtered
+        // out (the session pool is inert across machines). The existing
+        // RegistrySyncDebouncer propagates the populated entry to peers.
+        if (coordinator.enabled && coordinator.identity) {
+          advertiseSelfMeshUrl(
+            coordinator.managers.identityManager,
+            coordinator.identity.machineId,
+            resolveAdvertisedMeshUrl(config.tunnel, tunnelUrl),
+            (m) => console.log(pc.dim(m)),
+          );
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(pc.red(`  Tunnel start failed (manager will keep retrying in background): ${msg}`));

--- a/src/core/MeshUrlAdvertiser.ts
+++ b/src/core/MeshUrlAdvertiser.ts
@@ -1,0 +1,81 @@
+/**
+ * MeshUrlAdvertiser — populate a machine's `lastKnownUrl` so cross-machine
+ * routing can actually reach it.
+ *
+ * THE BUG THIS FIXES (found via real-hardware dogfooding, 2026-05-29):
+ * the Multi-Machine Session Pool routes every cross-machine RPC (deliver /
+ * transfer / lease) to a peer by reading `registry.machines[id].lastKnownUrl`.
+ * But the only writer of that field — `MachineIdentityManager.updateMachineUrl`
+ * — had ZERO callers. So in production every peer's URL was null, the peer
+ * filters (`!!e.lastKnownUrl`) dropped every peer, and no session could ever be
+ * delivered or transferred across machines. The 3-tier tests missed it because
+ * they inject peers with mock URLs and never exercise the runtime "where does
+ * lastKnownUrl come from" path.
+ *
+ * A machine's reachable URL is its tunnel URL: a named tunnel's hostname is
+ * known from config; a quick tunnel's URL is only known once `tunnel.start()`
+ * resolves it. This module turns either into the value to advertise, and writes
+ * it into the registry entry — from where the existing git-backed registry sync
+ * (RegistrySyncDebouncer) propagates it to peers.
+ */
+
+export interface MeshTunnelConfig {
+  enabled?: boolean;
+  type?: string;
+  hostname?: string;
+}
+
+/**
+ * Resolve the URL this machine should advertise to the mesh.
+ *
+ * Preference order:
+ *  1. A concretely-resolved tunnel URL (quick tunnels only know it at runtime;
+ *     `tunnel.start()` returns it). This is authoritative when present.
+ *  2. A named tunnel's deterministic `https://<hostname>`.
+ *  3. null — no reachable URL (tunnel disabled / not configured). A machine
+ *     with no tunnel is genuinely not reachable cross-machine; advertising
+ *     nothing is correct (peers will skip it rather than route to a dead URL).
+ */
+export function resolveAdvertisedMeshUrl(
+  tunnel: MeshTunnelConfig | undefined,
+  resolvedTunnelUrl?: string | null,
+): string | null {
+  if (resolvedTunnelUrl && /^https?:\/\/\S+$/.test(resolvedTunnelUrl.trim())) {
+    return resolvedTunnelUrl.trim().replace(/\/+$/, '');
+  }
+  if (tunnel?.enabled !== false && tunnel?.hostname && tunnel.hostname.trim()) {
+    const host = tunnel.hostname.trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+    if (host) return `https://${host}`;
+  }
+  return null;
+}
+
+/** Minimal slice of MachineIdentityManager this module needs (keeps it testable). */
+export interface MeshUrlRecorder {
+  getMachineUrl(machineId: string): string | null;
+  updateMachineUrl(machineId: string, url: string): void;
+}
+
+/**
+ * Advertise this machine's reachable URL into its own registry entry so peers
+ * can route to it. Idempotent (no write when unchanged), and tolerant when the
+ * self entry isn't present yet (best-effort — boot ordering can race the
+ * registration). Returns true iff it wrote a new value.
+ */
+export function advertiseSelfMeshUrl(
+  recorder: MeshUrlRecorder,
+  selfMachineId: string,
+  url: string | null,
+  log?: (msg: string) => void,
+): boolean {
+  if (!url || !selfMachineId) return false;
+  try {
+    if (recorder.getMachineUrl(selfMachineId) === url) return false; // idempotent
+    recorder.updateMachineUrl(selfMachineId, url);
+    log?.(`  Mesh: advertised self URL → ${url}`);
+    return true;
+  } catch {
+    // Self entry not present yet — caller may retry on a later lifecycle event.
+    return false;
+  }
+}

--- a/tests/unit/mesh-url-advertisement-wiring.test.ts
+++ b/tests/unit/mesh-url-advertisement-wiring.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Wiring-integrity test for mesh URL advertisement.
+ *
+ * The original bug was a WIRING hole, not a logic bug: updateMachineUrl() (the
+ * only writer of lastKnownUrl) had zero callers, so the cross-machine router —
+ * which filters peers by lastKnownUrl — silently dropped every peer. Unit tests
+ * of the router passed because they injected mock peer URLs. This test pins the
+ * wiring structurally: the self-URL advertiser MUST be invoked on the
+ * tunnel-ready path, and the joiner MUST record the URL it connected through.
+ * If either call site is removed, lastKnownUrl regresses to never-populated and
+ * cross-machine routing goes inert again — this test fails first.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SERVER = path.join(process.cwd(), 'src/commands/server.ts');
+const JOIN = path.join(process.cwd(), 'src/commands/machine.ts');
+
+describe('mesh URL advertisement wiring', () => {
+  const server = fs.readFileSync(SERVER, 'utf-8');
+  const join = fs.readFileSync(JOIN, 'utf-8');
+
+  it('server.ts imports the advertiser', () => {
+    expect(server).toContain("from '../core/MeshUrlAdvertiser.js'");
+    expect(server).toContain('advertiseSelfMeshUrl');
+    expect(server).toContain('resolveAdvertisedMeshUrl');
+  });
+
+  it('the self-URL is advertised after the boot tunnel.start() resolves a URL', () => {
+    // The advertise call must sit in the same neighborhood as the boot tunnel
+    // start (so it runs once the machine's reachable URL is actually known).
+    const bootIdx = server.indexOf('Tunnel active:');
+    expect(bootIdx).toBeGreaterThan(0);
+    const block = server.slice(bootIdx, bootIdx + 800);
+    expect(block).toContain('advertiseSelfMeshUrl(');
+    expect(block).toContain('resolveAdvertisedMeshUrl(config.tunnel, tunnelUrl)');
+    expect(block).toContain('coordinator.managers.identityManager');
+  });
+
+  it('the self-URL is re-advertised after a sleep/wake tunnel restart (quick URL changes)', () => {
+    const wakeIdx = server.indexOf('[SleepWake] Tunnel restarted');
+    expect(wakeIdx).toBeGreaterThan(0);
+    const block = server.slice(wakeIdx, wakeIdx + 800);
+    expect(block).toContain('advertiseSelfMeshUrl(');
+  });
+
+  it('the joiner records the URL it connected through as the awake peer URL', () => {
+    const idx = join.indexOf('Paired with:');
+    expect(idx).toBeGreaterThan(0);
+    // The updateMachineUrl call sits in the same registration block as the pairing.
+    const block = join.slice(Math.max(0, idx - 400), idx + 100);
+    expect(block).toContain('updateMachineUrl(result.machineIdentity.machineId, repoUrl');
+  });
+});

--- a/tests/unit/mesh-url-advertiser.test.ts
+++ b/tests/unit/mesh-url-advertiser.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for MeshUrlAdvertiser — the fix for the "lastKnownUrl is never
+ * populated" gap that made the Multi-Machine Session Pool inert across real
+ * machines (cross-machine routing filters peers by lastKnownUrl, which nothing
+ * ever wrote). Found via real-hardware dogfooding 2026-05-29.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { MachineIdentityManager } from '../../src/core/MachineIdentity.js';
+import { resolveAdvertisedMeshUrl, advertiseSelfMeshUrl } from '../../src/core/MeshUrlAdvertiser.js';
+
+describe('resolveAdvertisedMeshUrl', () => {
+  it('prefers a concretely-resolved quick-tunnel URL (only known at runtime)', () => {
+    expect(resolveAdvertisedMeshUrl({ enabled: true, type: 'quick' }, 'https://abc-def.trycloudflare.com'))
+      .toBe('https://abc-def.trycloudflare.com');
+  });
+
+  it('strips a trailing slash from the resolved URL', () => {
+    expect(resolveAdvertisedMeshUrl({ type: 'quick' }, 'https://x.trycloudflare.com/'))
+      .toBe('https://x.trycloudflare.com');
+  });
+
+  it('derives https://<hostname> for a named tunnel when no resolved URL is given', () => {
+    expect(resolveAdvertisedMeshUrl({ enabled: true, type: 'named', hostname: 'echo.dawn-tunnel.dev' }))
+      .toBe('https://echo.dawn-tunnel.dev');
+  });
+
+  it('normalizes a hostname that already includes a scheme', () => {
+    expect(resolveAdvertisedMeshUrl({ type: 'named', hostname: 'https://echo.dawn-tunnel.dev/' }))
+      .toBe('https://echo.dawn-tunnel.dev');
+  });
+
+  it('returns null when the tunnel is disabled (machine is not reachable cross-machine)', () => {
+    expect(resolveAdvertisedMeshUrl({ enabled: false, hostname: 'echo.dawn-tunnel.dev' })).toBeNull();
+  });
+
+  it('returns null when there is no tunnel config and no resolved URL', () => {
+    expect(resolveAdvertisedMeshUrl(undefined)).toBeNull();
+    expect(resolveAdvertisedMeshUrl({})).toBeNull();
+  });
+
+  it('ignores a non-http resolved URL and falls through to the named hostname', () => {
+    expect(resolveAdvertisedMeshUrl({ type: 'named', hostname: 'echo.dawn-tunnel.dev' }, 'not-a-url'))
+      .toBe('https://echo.dawn-tunnel.dev');
+  });
+});
+
+describe('advertiseSelfMeshUrl (against a real MachineIdentityManager)', () => {
+  let dir: string;
+  let mgr: MachineIdentityManager;
+  let selfId: string;
+
+  beforeEach(async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mesh-url-'));
+    mgr = new MachineIdentityManager(dir);
+    const identity = await mgr.generateIdentity({ name: 'self' });
+    selfId = identity.machineId;
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes lastKnownUrl onto the self registry entry (the bug: this never happened)', () => {
+    // Precondition: a freshly-registered machine has NO url — this is exactly
+    // the null that filtered every peer out of cross-machine routing.
+    expect(mgr.getMachineUrl(selfId)).toBeNull();
+
+    const wrote = advertiseSelfMeshUrl(mgr, selfId, 'https://echo.dawn-tunnel.dev');
+    expect(wrote).toBe(true);
+    expect(mgr.getMachineUrl(selfId)).toBe('https://echo.dawn-tunnel.dev');
+  });
+
+  it('is idempotent — no rewrite when the URL is unchanged', () => {
+    advertiseSelfMeshUrl(mgr, selfId, 'https://echo.dawn-tunnel.dev');
+    expect(advertiseSelfMeshUrl(mgr, selfId, 'https://echo.dawn-tunnel.dev')).toBe(false);
+    expect(mgr.getMachineUrl(selfId)).toBe('https://echo.dawn-tunnel.dev');
+  });
+
+  it('updates when the URL changes (quick tunnel gets a new URL after sleep/wake)', () => {
+    advertiseSelfMeshUrl(mgr, selfId, 'https://old.trycloudflare.com');
+    expect(advertiseSelfMeshUrl(mgr, selfId, 'https://new.trycloudflare.com')).toBe(true);
+    expect(mgr.getMachineUrl(selfId)).toBe('https://new.trycloudflare.com');
+  });
+
+  it('no-ops on a null URL (tunnel disabled) rather than throwing', () => {
+    expect(advertiseSelfMeshUrl(mgr, selfId, null)).toBe(false);
+    expect(mgr.getMachineUrl(selfId)).toBeNull();
+  });
+
+  it('is tolerant when the self entry is absent (boot ordering race)', () => {
+    expect(advertiseSelfMeshUrl(mgr, 'm_does_not_exist', 'https://x.dev')).toBe(false);
+  });
+});

--- a/tests/unit/mesh-url-advertiser.test.ts
+++ b/tests/unit/mesh-url-advertiser.test.ts
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { MachineIdentityManager } from '../../src/core/MachineIdentity.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 import { resolveAdvertisedMeshUrl, advertiseSelfMeshUrl } from '../../src/core/MeshUrlAdvertiser.js';
 
 describe('resolveAdvertisedMeshUrl', () => {
@@ -60,7 +61,7 @@ describe('advertiseSelfMeshUrl (against a real MachineIdentityManager)', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/mesh-url-advertiser.test.ts:afterEach' });
   });
 
   it('writes lastKnownUrl onto the self registry entry (the bug: this never happened)', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,38 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Multi-Machine Session Pool — cross-machine routing fix (still dark).** Real
+hardware bring-up of a second machine surfaced a wiring gap: the session pool
+routes every cross-machine action (deliver / transfer / lease) to a peer by its
+`lastKnownUrl` (its tunnel URL), but nothing in the shipped code ever wrote that
+field — so every peer was filtered out and no session could be routed or
+transferred across machines. A machine now advertises its own tunnel URL into
+the mesh registry once the tunnel is up (and re-advertises after a sleep/wake
+restart, since a quick tunnel's URL changes), and a joining machine records the
+URL it paired through. The whole layer remains gated behind
+`multiMachine.sessionPool` (default off / `stage:'dark'`), so single-machine
+agents are unaffected.
+
+## What to Tell Your User
+
+Nothing changes yet — this is still off by default. It fixes a foundational gap
+so that, when the session pool is enabled, conversations can actually be placed
+on and moved between machines.
+
+## Summary of New Capabilities
+
+- `MeshUrlAdvertiser` (`resolveAdvertisedMeshUrl` + `advertiseSelfMeshUrl`):
+  populates a machine's `lastKnownUrl` from its tunnel URL on boot + sleep/wake.
+- `instar join` now records the awake machine's URL on the joining (standby) side.
+
+## Evidence
+
+- Unit: `tests/unit/mesh-url-advertiser.test.ts` (resolver + advertiser vs a real
+  MachineIdentityManager).
+- Wiring-integrity: `tests/unit/mesh-url-advertisement-wiring.test.ts` (asserts
+  the advertiser is actually invoked — the tier that would have caught the
+  original zero-callers gap).
+- Side-effects: `upgrades/side-effects/mesh-url-advertisement.md`.

--- a/upgrades/side-effects/mesh-url-advertisement.md
+++ b/upgrades/side-effects/mesh-url-advertisement.md
@@ -1,0 +1,66 @@
+# Side-effects review — Mesh URL advertisement (lastKnownUrl population)
+
+## What changed
+
+`updateMachineUrl()` (the only writer of `registry.machines[id].lastKnownUrl`)
+had **zero callers** on main. The Multi-Machine Session Pool routes every
+cross-machine RPC — `deliverMessage`, session transfer, lease ops — to a peer by
+reading that peer's `lastKnownUrl`, and filters peers with `!!e.lastKnownUrl`.
+With the field never written, every peer was filtered out and **no session
+could ever be delivered or transferred across machines**. The feature was inert
+across real machines despite green 3-tier tests (which inject mock peer URLs).
+
+Found 2026-05-29 bringing up a second real machine (the mini) for the
+session-pool real-hardware proof.
+
+This change adds:
+- `src/core/MeshUrlAdvertiser.ts` — `resolveAdvertisedMeshUrl(tunnel, resolvedUrl?)`
+  (named → `https://<hostname>`, quick → the runtime-resolved start URL, none →
+  null) + `advertiseSelfMeshUrl(recorder, selfId, url)` (idempotent, tolerant of
+  a missing self entry).
+- `src/commands/server.ts` — calls the advertiser after `tunnel.start()` on both
+  the boot path and the sleep/wake restart path (a quick tunnel gets a new URL
+  after a wake, so the previously-advertised URL goes stale).
+- `src/commands/machine.ts` (`joinMesh`) — the joiner records the URL it
+  connected through as the awake peer's `lastKnownUrl`, so a standby can route
+  back to the awake machine immediately without waiting for a registry sync.
+
+## Blast radius
+
+- **Dark-feature-only effect.** The populated `lastKnownUrl` is consumed solely
+  by the session-pool mesh code, which is gated behind `multiMachine.sessionPool`
+  (default `enabled:false`, `stage:'dark'`). On a single-machine agent there are
+  no peers, so nothing changes. Populating the field is otherwise inert.
+- **No new config, no new route, no schema change** → no migration needed.
+  Existing agents pick up the behavior at boot on the next release. No
+  `PostUpdateMigrator` entry required (the code runs at startup unconditionally
+  when multi-machine is enabled and a tunnel URL exists).
+- **Idempotent + fail-safe.** `advertiseSelfMeshUrl` writes only when the URL
+  changed and swallows the "self entry not present yet" race (returns false).
+  A tunnel-disabled machine advertises nothing (correct — it is genuinely
+  unreachable cross-machine; peers skip it rather than route to a dead URL).
+- **No secret exposure.** A tunnel URL is already public (the dashboard link).
+  Recording it in the registry adds no new exposure.
+
+## What this does NOT close (scoped, decision-gated follow-up)
+
+The **awake machine learning a git-uncredentialed standby's URL** still needs one
+of: (a) the standby having git push creds for the shared agent repo (so its
+advertised entry syncs via the existing git-backed RegistrySyncDebouncer), or
+(b) a signed mesh `announce-url` RPC so a standby can publish its URL to the
+awake machine over authenticated MeshRpc without git. (b) also requires the
+awake side to persist the joiner's identity, which today only happens via the
+**interactive SAS pairing** confirmation — so closing this fully touches the
+pairing security model. That is a genuine design fork (creds vs. new RPC +
+non-interactive registration), not a silent deferral, and is raised explicitly
+rather than hand-resolved on a production identity.
+
+## Tests
+
+- `tests/unit/mesh-url-advertiser.test.ts` — resolver (named/quick/disabled/none)
+  + advertiser against a real `MachineIdentityManager` (writes, idempotent,
+  updates on change, null no-op, missing-entry tolerance).
+- `tests/unit/mesh-url-advertisement-wiring.test.ts` — wiring-integrity: asserts
+  the advertiser is invoked on the boot + sleep/wake tunnel paths and the joiner
+  records the connect URL. This is the tier that was missing — it would have
+  caught the original "zero callers" gap.


### PR DESCRIPTION
## The bug (real-hardware dogfooding find)

Bringing up a second real machine (the mini) for the Session Pool hardware proof surfaced a wiring gap that the 3-tier tests could not catch:

`MachineIdentityManager.updateMachineUrl()` — the **only** writer of `registry.machines[id].lastKnownUrl` — had **zero callers**. But the entire cross-machine layer routes every `deliverMessage` / session-transfer / lease RPC to a peer by reading that peer's `lastKnownUrl`, and filters peers with `!!e.lastKnownUrl`. With the field never written, **every peer was filtered out → no session could ever be delivered or transferred across machines.** The session pool was inert across real machines despite green unit/integration/E2E (they inject peers with mock URLs, so they never exercised "where does `lastKnownUrl` come from at runtime").

## The fix

- **`src/core/MeshUrlAdvertiser.ts`** (new): `resolveAdvertisedMeshUrl(tunnel, resolvedUrl?)` (named → `https://<hostname>`, quick → the runtime-resolved `tunnel.start()` URL, none → null) + `advertiseSelfMeshUrl(recorder, selfId, url)` (idempotent, tolerant of a not-yet-present self entry).
- **`src/commands/server.ts`**: advertise the self URL after `tunnel.start()` on the boot path **and** the sleep/wake restart path (a quick tunnel gets a *new* URL after wake, so the prior value goes stale).
- **`src/commands/machine.ts`** (`joinMesh`): the joiner records the URL it paired through as the awake peer's `lastKnownUrl`, so a standby can route back to the awake machine immediately without waiting for a registry sync.

The populated `lastKnownUrl` propagates to peers via the existing git-backed `RegistrySyncDebouncer`.

## Tests

- `tests/unit/mesh-url-advertiser.test.ts` — resolver (named/quick/disabled/none/normalization) + advertiser against a real `MachineIdentityManager` (writes, idempotent, updates on change, null no-op, missing-entry tolerance).
- `tests/unit/mesh-url-advertisement-wiring.test.ts` — **wiring-integrity**: asserts the advertiser is actually invoked on the boot + sleep/wake tunnel paths and that the joiner records the connect URL. This is the tier that was missing — it would have caught the original zero-callers gap.

## Safety / scope

- Still **dark**: `lastKnownUrl` is consumed only by the session-pool mesh code, gated behind `multiMachine.sessionPool` (default `enabled:false`, `stage:'dark'`). Single-machine agents are unaffected (no peers).
- **No new config / route / schema → no migration.** Behavior runs at boot on the next release for existing agents.
- Idempotent + fail-safe; a tunnel-disabled machine advertises nothing (correct — it's genuinely unreachable cross-machine).

## Not closed here (scoped, decision-gated follow-up)

The **awake machine learning a git-uncredentialed standby's URL** still needs either (a) the standby having git push creds for the shared agent repo, or (b) a signed mesh `announce-url` RPC (which also requires the awake side to persist the joiner's identity — today only done via interactive SAS pairing). That is a genuine design fork that touches the pairing security model; raised explicitly rather than hand-resolved. See `upgrades/side-effects/mesh-url-advertisement.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)