### PR TITLE
feat(session-pool): non-interactive, code-authenticated pool join (trust model A)

### DIFF
--- a/site/src/content/docs/features/multi-machine.md
+++ b/site/src/content/docs/features/multi-machine.md
@@ -115,3 +115,17 @@ sent by both machines.
 Each component above ships flag-gated until live two-machine verification
 passes; see the cross-machine seamlessness spec for the full §-by-§ wiring
 plan.
+
+### Joining the pool — code-authenticated, non-interactive
+
+An active-active pool forms its mesh automatically, so machines join without a
+human confirming visual symbols. `instar pair` (run on an awake machine) mints a
+short-lived, single-use pairing code and persists it via **`PairingSessionStore`**
+(`.instar/machine/pairing-session.json`, 0600). `instar join <url> --code <code>`
+(run on the new machine) presents that code to the awake machine's `/api/pair`
+endpoint, which validates it against the stored session and — on success —
+registers the joiner as **standby**, stores its public keys, and records its
+reachable URL. The pairing code (carried over the TLS tunnel) is the shared
+secret; it is single-use, attempt-capped, and time-limited, and a joiner can only
+ever register as standby. The persisted session that `PairingSessionStore` holds
+is what lets the *running server* validate a join without an interactive step.

--- a/src/commands/machine.ts
+++ b/src/commands/machine.ts
@@ -201,6 +201,7 @@ export async function startPairing(options: PairOptions): Promise<void> {
 
   const { generatePairingCode, createPairingSession } = await import('../core/PairingProtocol.js');
   const { migrateSecrets } = await import('../core/SecretMigrator.js');
+  const { PairingSessionStore } = await import('../core/PairingSessionStore.js');
 
   // Migrate secrets from config.json before pairing (ensures they're in the encrypted store)
   const configPath = path.join(config.stateDir, 'config.json');
@@ -210,7 +211,13 @@ export async function startPairing(options: PairOptions): Promise<void> {
   }
 
   const pairingCode = generatePairingCode();
-  const _pairingSession = createPairingSession({ code: pairingCode });
+  // Give the operator a usable window to run `instar join` on the other machine.
+  const pairingSession = createPairingSession({ code: pairingCode, expiryMs: 10 * 60 * 1000 });
+  // Persist the session so the RUNNING server's /api/pair can validate the code
+  // non-interactively (code-authenticated pool join — no human SAS step). Without
+  // this the session was created into an unused variable and discarded, leaving
+  // /api/pair unable to validate anything (the interactive-SAS-only gap).
+  new PairingSessionStore(config.stateDir).save(pairingSession);
 
   console.log(pc.bold(`\n  Pairing Code for ${pc.cyan(config.projectName)}\n`));
   console.log(`  ${pc.bold(pc.yellow(pairingCode))}`);
@@ -343,6 +350,12 @@ export async function joinMesh(repoUrl: string, options: JoinOptions): Promise<v
     console.log(`  Contacting ${redactUrl(repoUrl)}...`);
     try {
       const identity = mgr.loadIdentity();
+      // Advertise our own reachable URL (if we already have one — a named tunnel
+      // is known at config time; a quick tunnel is only known after our server
+      // starts, so this may be null and the awake machine learns it later via the
+      // heartbeat URL field instead).
+      const { resolveAdvertisedMeshUrl } = await import('../core/MeshUrlAdvertiser.js');
+      const advertisedUrl = resolveAdvertisedMeshUrl(config.tunnel);
       const resp = await fetch(`${repoUrl}/api/pair`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -350,6 +363,7 @@ export async function joinMesh(repoUrl: string, options: JoinOptions): Promise<v
           pairingCode: options.code,
           machineIdentity: identity,
           ephemeralPublicKey: identity.encryptionPublicKey,
+          ...(advertisedUrl ? { advertisedUrl } : {}),
         }),
         signal: AbortSignal.timeout(10_000),
       });

--- a/src/core/MachineIdentity.ts
+++ b/src/core/MachineIdentity.ts
@@ -138,6 +138,11 @@ export class MachineIdentityManager {
     this.instarDir = instarDir;
   }
 
+  /** The state dir this manager is rooted at (for co-located stores, e.g. pairing sessions). */
+  get baseDir(): string {
+    return this.instarDir;
+  }
+
   // ── Paths ────────────────────────────────────────────────────────
 
   private get machineDir(): string {

--- a/src/core/PairingSessionStore.ts
+++ b/src/core/PairingSessionStore.ts
@@ -1,0 +1,58 @@
+/**
+ * PairingSessionStore — durably persist the active pairing session so the
+ * running server's `/api/pair` handler can validate a join request's code.
+ *
+ * WHY THIS EXISTS (found 2026-05-29 during the session-pool hardware bring-up):
+ * `instar pair` runs as a SEPARATE process from the server. It generated a
+ * pairing code, printed it, and assigned the session to an UNUSED `_pairingSession`
+ * — never persisting it. So the running server had no code to validate against,
+ * which is why `/api/pair` was "signal-only" and pairing could only complete via
+ * interactive SAS confirmation on both screens. An active-active session pool
+ * can't require a human to eyeball symbols per machine, so (per the operator's
+ * "Proceed with A" decision) pairing becomes code-authenticated + non-interactive:
+ * `instar pair` persists the session here, and `/api/pair` loads + validates it.
+ *
+ * Only the validation-relevant fields are persisted (NOT the ephemeral X25519
+ * private key, which is a `KeyObject` and is not needed for code-based auth).
+ * The file is written 0600 — the pairing code is a short-lived shared secret.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import type { PairingSession } from './PairingProtocol.js';
+
+/** The JSON-serializable subset of a PairingSession needed to validate a code. */
+export type StoredPairingSession = Omit<PairingSession, 'ephemeralKeys'>;
+
+export class PairingSessionStore {
+  private readonly filePath: string;
+
+  constructor(stateDir: string) {
+    this.filePath = path.join(stateDir, 'machine', 'pairing-session.json');
+  }
+
+  /** Persist (or overwrite) the active pairing session, secret-permissioned. */
+  save(session: StoredPairingSession): void {
+    const slim: StoredPairingSession = {
+      code: session.code,
+      createdAt: session.createdAt,
+      failedAttempts: session.failedAttempts,
+      maxAttempts: session.maxAttempts,
+      expiryMs: session.expiryMs,
+      consumed: session.consumed,
+    };
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, JSON.stringify(slim, null, 2), { mode: 0o600 });
+  }
+
+  /** Load the active pairing session, or null if none / unreadable. */
+  load(): StoredPairingSession | null {
+    try {
+      if (!fs.existsSync(this.filePath)) return null;
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as StoredPairingSession;
+      if (!parsed || typeof parsed.code !== 'string') return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/server/machineRoutes.ts
+++ b/src/server/machineRoutes.ts
@@ -24,6 +24,9 @@ import type { SecurityLog } from '../core/SecurityLog.js';
 import type { MachineAuthContext, MachineAuthDeps } from './machineAuth.js';
 import { machineAuthMiddleware, ChallengeStore } from './machineAuth.js';
 import type { MessageRouter } from '../messaging/MessageRouter.js';
+import { PairingSessionStore } from '../core/PairingSessionStore.js';
+import { validatePairingCode } from '../core/PairingProtocol.js';
+import type { PairingSession } from '../core/PairingProtocol.js';
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -99,6 +102,9 @@ export function createMachineRoutes(ctx: MachineRouteContext): Router {
   const authMiddleware = machineAuthMiddleware(ctx.authDeps);
   const handoffChallenges = new ChallengeStore();
   const secretChallenges = new ChallengeStore();
+  // Code-authenticated pool join: the active pairing session (written by
+  // `instar pair`) is the shared secret that authorizes a non-interactive join.
+  const pairingStore = new PairingSessionStore(ctx.identityManager.baseDir);
 
   // ── POST /api/lease — Receive a peer's fenced lease over the wire (spec §6) ──
   // The low-latency authoritative copy. Auth-verified; the lease holder must
@@ -214,31 +220,83 @@ export function createMachineRoutes(ctx: MachineRouteContext): Router {
   // Instead, it relies on the pairing code exchange for authentication.
 
   router.post('/api/pair', (req, res) => {
-    const { pairingCode, machineIdentity, ephemeralPublicKey } = req.body;
+    const { pairingCode, machineIdentity, ephemeralPublicKey, advertisedUrl } = req.body ?? {};
+    const ip = req.ip || req.socket.remoteAddress || 'unknown';
 
     if (!pairingCode || !machineIdentity || !ephemeralPublicKey) {
       res.status(400).json({ error: 'Missing required pairing fields' });
       return;
     }
+    // Validate the joiner's identity shape before we'd ever persist it.
+    if (
+      typeof machineIdentity.machineId !== 'string' ||
+      typeof machineIdentity.signingPublicKey !== 'string' ||
+      typeof machineIdentity.encryptionPublicKey !== 'string'
+    ) {
+      res.status(400).json({ error: 'Malformed machineIdentity' });
+      return;
+    }
 
-    // Pairing validation is handled by the caller (CLI command).
-    // This endpoint just receives the request and signals the pairing flow.
-    // The actual pairing code comparison and SAS verification happen interactively.
+    // ── Code-authenticated, non-interactive pool join ────────────────
+    // The pairing code (a short-lived, single-use, attempt-capped shared secret
+    // written by `instar pair` and carried over the TLS tunnel) IS the auth — no
+    // human SAS step (operator's "Proceed with A" trust-model decision). A joiner
+    // can only ever register as STANDBY; it can never claim the awake role here.
+    const stored = pairingStore.load();
+    if (!stored) {
+      ctx.securityLog.append({
+        event: 'pairing_rejected',
+        machineId: machineIdentity.machineId,
+        machineName: machineIdentity.name,
+        reason: 'no-active-session',
+        ip,
+      });
+      res.status(403).json({ error: 'No active pairing session. Run `instar pair` on the awake machine.' });
+      return;
+    }
+
+    const result = validatePairingCode(stored as unknown as PairingSession, String(pairingCode));
+    // Persist the mutated session (failedAttempts increments accumulate across
+    // requests so the attempt cap actually throttles brute force).
+    pairingStore.save(stored);
+    if (!result.valid) {
+      ctx.securityLog.append({
+        event: 'pairing_rejected',
+        machineId: machineIdentity.machineId,
+        machineName: machineIdentity.name,
+        reason: result.reason ?? 'invalid-code',
+        ip,
+      });
+      res.status(403).json({ error: result.reason ?? 'Invalid pairing code' });
+      return;
+    }
+
+    // Code valid → register the joiner as standby, persist its public keys (so
+    // MeshRpc can verify its signatures), record its advertised URL if it sent
+    // one, and burn the code (single-use).
+    ctx.identityManager.registerMachine(machineIdentity, 'standby');
+    ctx.identityManager.storeRemoteIdentity(machineIdentity);
+    if (typeof advertisedUrl === 'string' && /^https?:\/\/\S+$/.test(advertisedUrl)) {
+      try {
+        ctx.identityManager.updateMachineUrl(machineIdentity.machineId, advertisedUrl.trim().replace(/\/+$/, ''));
+      } catch { /* entry was just registered; best-effort */ }
+    }
+    stored.consumed = true;
+    pairingStore.save(stored);
 
     ctx.securityLog.append({
-      event: 'pairing_request',
+      event: 'pairing_completed',
       machineId: machineIdentity.machineId,
       machineName: machineIdentity.name,
-      ip: req.ip || req.socket.remoteAddress || 'unknown',
+      ip,
     });
 
-    // Return this machine's identity and an ephemeral key for the ECDH exchange
+    // Return this machine's identity so the joiner can register us as awake.
     const localIdentity = ctx.identityManager.loadIdentity();
-
     res.json({
-      status: 'pending',
+      status: 'paired',
       machineIdentity: localIdentity,
-      message: 'Pairing request received. Verify the SAS on both machines.',
+      message: 'Paired.',
     });
   });
 

--- a/tests/e2e/multi-machine-http.test.ts
+++ b/tests/e2e/multi-machine-http.test.ts
@@ -267,7 +267,17 @@ describe('Multi-Machine HTTP E2E', () => {
 
   // ── Pairing ─────────────────────────────────────────────────────
 
-  it('pairing endpoint works without machine auth', async () => {
+  it('pairing endpoint works without machine auth (code-authenticated, non-interactive)', async () => {
+    // Seed an active pairing session on A, as `instar pair` would. /api/pair is
+    // still reachable without machine auth (it is the bootstrap), but it now
+    // validates the code against this session and auto-registers the joiner
+    // instead of being signal-only.
+    const { PairingSessionStore } = await import('../../src/core/PairingSessionStore.js');
+    const { createPairingSession } = await import('../../src/core/PairingProtocol.js');
+    new PairingSessionStore(envA.stateDir).save(
+      createPairingSession({ code: 'TEST-CODE-1234', expiryMs: 600_000 }),
+    );
+
     const resp = await fetch(`http://127.0.0.1:${PORT_A}/api/pair`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -275,13 +285,16 @@ describe('Multi-Machine HTTP E2E', () => {
         pairingCode: 'TEST-CODE-1234',
         machineIdentity: envB.identity,
         ephemeralPublicKey: 'test-ephemeral-key',
+        advertisedUrl: 'https://machine-b.example.dev',
       }),
     });
 
     expect(resp.ok).toBe(true);
     const body = await resp.json() as { status: string; machineIdentity: any };
-    expect(body.status).toBe('pending');
+    expect(body.status).toBe('paired');
     expect(body.machineIdentity.machineId).toBe(envA.machineId);
+    // A now knows B's reachable URL (closes the one-directional gap).
+    expect(envA.mgr.getMachineUrl(envB.machineId)).toBe('https://machine-b.example.dev');
   });
 
   // ── Full Handoff Flow ──────────────────────────────────────────

--- a/tests/integration/machine-routes.test.ts
+++ b/tests/integration/machine-routes.test.ts
@@ -247,19 +247,26 @@ describe('Machine Routes Integration', () => {
   // ── Pairing ────────────────────────────────────────────────────
 
   describe('POST /api/pair', () => {
-    it('accepts pairing request (no auth required)', async () => {
+    it('reaches the handler without auth but rejects when there is no active pairing session (403)', async () => {
+      // /api/pair is intentionally unauthenticated (it is the bootstrap), but it
+      // is now code-authenticated: without an active pairing session written by
+      // `instar pair`, a well-formed join request is rejected (not silently
+      // accepted as the old signal-only handler did).
       const res = await request(env.app)
         .post('/api/pair')
         .set('Connection', 'close')
         .send({
           pairingCode: 'test-code',
-          machineIdentity: { machineId: 'm_new', name: 'new-machine' },
+          machineIdentity: {
+            machineId: 'm_new',
+            name: 'new-machine',
+            signingPublicKey: 'c2lnbg==',
+            encryptionPublicKey: 'ZW5j',
+          },
           ephemeralPublicKey: 'base64-key-data',
         });
 
-      expect(res.status).toBe(200);
-      expect(res.body.status).toBe('pending');
-      expect(res.body.machineIdentity).toBeTruthy();
+      expect(res.status).toBe(403);
     });
 
     it('rejects incomplete pairing request', async () => {

--- a/tests/integration/pool-noninteractive-pairing.test.ts
+++ b/tests/integration/pool-noninteractive-pairing.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration test for the non-interactive, code-authenticated pool join
+ * (operator's "Proceed with A" trust model).
+ *
+ * Before: /api/pair was "signal-only" — it never validated the code or
+ * registered the joiner; pairing completed only via interactive SAS, so a
+ * headless join left the awake machine NOT knowing the joiner (one-directional).
+ *
+ * After: /api/pair validates the persisted pairing code (single-use,
+ * attempt-capped, TTL'd) and, on success, registers the joiner as STANDBY,
+ * stores its public keys, records its advertised URL, and burns the code.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import express from 'express';
+import request from 'supertest';
+import {
+  MachineIdentityManager, generateSigningKeyPair, generateEncryptionKeyPair,
+  generateMachineId, pemToBase64,
+} from '../../src/core/MachineIdentity.js';
+import { HeartbeatManager } from '../../src/core/HeartbeatManager.js';
+import { NonceStore } from '../../src/core/NonceStore.js';
+import { SecurityLog } from '../../src/core/SecurityLog.js';
+import { createMachineRoutes } from '../../src/server/machineRoutes.js';
+import { PairingSessionStore } from '../../src/core/PairingSessionStore.js';
+import { createPairingSession } from '../../src/core/PairingProtocol.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import type { MachineIdentity } from '../../src/core/types.js';
+import type { MachineAuthDeps } from '../../src/server/machineAuth.js';
+
+function makeIdentity(name: string): MachineIdentity {
+  return {
+    machineId: generateMachineId(),
+    signingPublicKey: pemToBase64(generateSigningKeyPair().publicKey),
+    encryptionPublicKey: pemToBase64(generateEncryptionKeyPair().publicKey),
+    name,
+    platform: 'test',
+    createdAt: new Date().toISOString(),
+    capabilities: ['sessions'],
+  };
+}
+
+function makeApp(tmpDir: string) {
+  const identityManager = new MachineIdentityManager(tmpDir);
+  const awake = makeIdentity('awake-machine');
+  fs.mkdirSync(path.join(tmpDir, 'machine'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, 'machine', 'identity.json'), JSON.stringify(awake));
+  identityManager.registerMachine(awake, 'awake');
+
+  const securityLog = new SecurityLog(tmpDir);
+  securityLog.initialize();
+  const authDeps: MachineAuthDeps = {
+    identityManager,
+    nonceStore: new NonceStore(path.join(tmpDir, 'nonces')),
+    securityLog,
+    localMachineId: awake.machineId,
+  };
+  const routes = createMachineRoutes({
+    identityManager,
+    heartbeatManager: new HeartbeatManager(tmpDir, awake.machineId),
+    securityLog,
+    authDeps,
+    localMachineId: awake.machineId,
+    localSigningKeyPem: '',
+  });
+  const app = express();
+  app.use(express.json());
+  app.use(routes);
+  return { app, identityManager, awake, pairingStore: new PairingSessionStore(tmpDir) };
+}
+
+describe('non-interactive code-authenticated pool join (POST /api/pair)', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pool-pair-')); });
+  afterEach(() => { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/integration/pool-noninteractive-pairing.test.ts:afterEach' }); });
+
+  it('registers the joiner as STANDBY on a valid code + records its URL + returns the awake identity', async () => {
+    const { app, identityManager, awake, pairingStore } = makeApp(dir);
+    pairingStore.save(createPairingSession({ code: 'VIPER-PLAIN-3738', expiryMs: 600000 }));
+    const joiner = makeIdentity('mac-mini');
+
+    const res = await request(app).post('/api/pair').send({
+      pairingCode: 'VIPER-PLAIN-3738',
+      machineIdentity: joiner,
+      ephemeralPublicKey: joiner.encryptionPublicKey,
+      advertisedUrl: 'https://echo-mini.dawn-tunnel.dev',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('paired');
+    expect(res.body.machineIdentity.machineId).toBe(awake.machineId); // joiner learns the awake identity
+
+    // The awake machine now KNOWS the joiner (the one-directional gap is closed).
+    const reg = identityManager.loadRegistry().machines[joiner.machineId];
+    expect(reg).toBeTruthy();
+    expect(reg.role).toBe('standby'); // a joiner can never claim awake here
+    expect(identityManager.getMachineUrl(joiner.machineId)).toBe('https://echo-mini.dawn-tunnel.dev');
+    // Its public keys are persisted so MeshRpc can verify its signatures.
+    expect(identityManager.loadRemoteIdentity(joiner.machineId)?.signingPublicKey).toBe(joiner.signingPublicKey);
+    // Single-use: the code is now consumed.
+    expect(pairingStore.load()!.consumed).toBe(true);
+  });
+
+  it('rejects a wrong code (403) and increments the persisted failed-attempt count', async () => {
+    const { app, identityManager, pairingStore } = makeApp(dir);
+    pairingStore.save(createPairingSession({ code: 'RIGHT-CODE-0001', expiryMs: 600000 }));
+    const joiner = makeIdentity('intruder');
+
+    const res = await request(app).post('/api/pair').send({
+      pairingCode: 'WRONG-CODE-9999', machineIdentity: joiner, ephemeralPublicKey: joiner.encryptionPublicKey,
+    });
+    expect(res.status).toBe(403);
+    expect(pairingStore.load()!.failedAttempts).toBe(1);
+    expect(identityManager.loadRegistry().machines[joiner.machineId]).toBeUndefined(); // NOT registered
+  });
+
+  it('locks out after maxAttempts wrong codes (brute-force cap)', async () => {
+    const { app, pairingStore } = makeApp(dir);
+    pairingStore.save(createPairingSession({ code: 'SECRET-CODE-1234', maxAttempts: 3, expiryMs: 600000 }));
+    const joiner = makeIdentity('brute');
+    for (let i = 0; i < 3; i++) {
+      await request(app).post('/api/pair').send({ pairingCode: 'NOPE-NOPE-0000', machineIdentity: joiner, ephemeralPublicKey: 'x' });
+    }
+    // Even the CORRECT code is now rejected — the session is locked.
+    const res = await request(app).post('/api/pair').send({ pairingCode: 'SECRET-CODE-1234', machineIdentity: joiner, ephemeralPublicKey: 'x' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects when there is no active pairing session (403)', async () => {
+    const { app } = makeApp(dir);
+    const joiner = makeIdentity('uninvited');
+    const res = await request(app).post('/api/pair').send({
+      pairingCode: 'ANY-CODE-0000', machineIdentity: joiner, ephemeralPublicKey: joiner.encryptionPublicKey,
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a consumed (already-used) code (403)', async () => {
+    const { app, pairingStore } = makeApp(dir);
+    const session = createPairingSession({ code: 'ONCE-ONLY-0001', expiryMs: 600000 });
+    session.consumed = true;
+    pairingStore.save(session);
+    const joiner = makeIdentity('replay');
+    const res = await request(app).post('/api/pair').send({ pairingCode: 'ONCE-ONLY-0001', machineIdentity: joiner, ephemeralPublicKey: 'x' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects a malformed machineIdentity (400) before persisting anything', async () => {
+    const { app, pairingStore } = makeApp(dir);
+    pairingStore.save(createPairingSession({ code: 'GOOD-CODE-0001', expiryMs: 600000 }));
+    const res = await request(app).post('/api/pair').send({
+      pairingCode: 'GOOD-CODE-0001', machineIdentity: { machineId: 'm_x' }, ephemeralPublicKey: 'x',
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/unit/pairing-session-store.test.ts
+++ b/tests/unit/pairing-session-store.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for PairingSessionStore — persists the active pairing session so
+ * the running server's /api/pair handler can validate a join code (the fix for
+ * the unused-`_pairingSession` gap that left pairing interactive-SAS-only).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { PairingSessionStore } from '../../src/core/PairingSessionStore.js';
+import { createPairingSession } from '../../src/core/PairingProtocol.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('PairingSessionStore', () => {
+  let dir: string;
+  let store: PairingSessionStore;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pairing-store-'));
+    store = new PairingSessionStore(dir);
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/pairing-session-store.test.ts:afterEach' });
+  });
+
+  it('returns null when no session is stored', () => {
+    expect(store.load()).toBeNull();
+  });
+
+  it('persists and reloads the validation-relevant fields', () => {
+    const session = createPairingSession({ code: 'VIPER-PLAIN-3738', expiryMs: 600000 });
+    store.save(session);
+    const loaded = store.load();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.code).toBe('VIPER-PLAIN-3738');
+    expect(loaded!.consumed).toBe(false);
+    expect(loaded!.maxAttempts).toBe(session.maxAttempts);
+    expect(loaded!.expiryMs).toBe(600000);
+  });
+
+  it('does NOT persist the ephemeral private key (not JSON-serializable / not needed for code auth)', () => {
+    const session = createPairingSession({ code: 'ABLE-NOVA-1111' });
+    store.save(session);
+    const raw = fs.readFileSync(path.join(dir, 'machine', 'pairing-session.json'), 'utf-8');
+    expect(raw).not.toContain('ephemeralKeys');
+    expect(raw).not.toContain('privateKey');
+  });
+
+  it('writes the session file with 0600 permissions (the code is a shared secret)', () => {
+    store.save(createPairingSession({ code: 'ZULU-IRON-2222' }));
+    const mode = fs.statSync(path.join(dir, 'machine', 'pairing-session.json')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('overwrites a prior session (a new `instar pair` invalidates the old code)', () => {
+    store.save(createPairingSession({ code: 'OLD-CODE-0001' }));
+    store.save(createPairingSession({ code: 'NEW-CODE-0002' }));
+    expect(store.load()!.code).toBe('NEW-CODE-0002');
+  });
+
+  it('survives a malformed file (returns null rather than throwing)', () => {
+    fs.mkdirSync(path.join(dir, 'machine'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'machine', 'pairing-session.json'), 'not json{');
+    expect(store.load()).toBeNull();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,39 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Multi-Machine Session Pool — non-interactive, code-authenticated pool join
+(still dark).** An active-active pool has to form its mesh automatically, so a
+machine can't require a human to confirm matching visual symbols (SAS) to join.
+Pairing is now code-authenticated: `instar pair` persists a short-lived,
+single-use pairing code (via the new `PairingSessionStore`), and the awake
+machine's `/api/pair` endpoint validates the code presented by `instar join`,
+then auto-registers the joiner as **standby**, stores its public keys, and
+records its URL. The code (carried over the TLS tunnel) is the shared secret —
+single-use, attempt-capped, time-limited; a joiner can only ever become standby.
+This closes the one-directional-pairing gap (the awake machine now learns the
+joiner without an interactive step). The whole layer stays gated behind
+`multiMachine.sessionPool`.
+
+## What to Tell Your User
+
+Nothing changes yet — still off by default. It makes a multi-machine pool able to
+form its mesh automatically (no per-machine visual-symbol confirmation) when the
+pool is enabled.
+
+## Summary of New Capabilities
+
+- `PairingSessionStore` — persists the active pairing session so the running
+  server can validate a join code non-interactively.
+- `/api/pair` now validates the code + auto-registers the joiner (standby) +
+  exchanges URLs/keys, instead of being signal-only/interactive.
+
+## Evidence
+
+- Unit: `tests/unit/pairing-session-store.test.ts`.
+- Integration: `tests/integration/pool-noninteractive-pairing.test.ts`
+  (valid/wrong/locked-out/no-session/consumed/malformed) + updated legacy
+  `machine-routes.test.ts` assertion.
+- Side-effects + security analysis: `upgrades/side-effects/noninteractive-pool-join.md`.

--- a/upgrades/side-effects/noninteractive-pool-join.md
+++ b/upgrades/side-effects/noninteractive-pool-join.md
@@ -1,0 +1,85 @@
+# Side-effects review — Non-interactive, code-authenticated pool join (trust model A)
+
+## What changed & why
+
+Bringing up a second real machine for the Multi-Machine Session Pool surfaced
+that the awake machine never learned about a machine that joined headlessly: the
+existing `pair`/`join` flow is **interactive by design** — `/api/pair` was
+"signal-only" and real registration completed only via a human confirming
+matching SAS visual symbols on both screens. An active-active session pool can't
+require a human to eyeball symbols per machine, so (operator decision: "Proceed
+with A") pairing becomes **code-authenticated and non-interactive**: the
+time-limited, single-use pairing code (carried over the TLS tunnel) is the
+shared secret that authorizes the join; Ed25519-signed mesh RPCs handle trust
+thereafter.
+
+Root cause of the gap: `instar pair` created the `PairingSession` into an
+**unused** `_pairingSession` variable and discarded it, so the running server
+had no code to validate against.
+
+Changes:
+- **`src/core/PairingSessionStore.ts`** (new): persists the validation-relevant
+  fields of the active `PairingSession` to `.instar/machine/pairing-session.json`
+  (0600), and loads it. The ephemeral X25519 private key is deliberately NOT
+  persisted (it is a `KeyObject`, not JSON-serializable, and unused for code auth).
+- **`src/commands/machine.ts`** (`pairMachine`): persists the session via
+  `PairingSessionStore` (10-min window) instead of discarding it; (`joinMesh`):
+  sends the joiner's own advertised URL in the pair body when it already has one.
+- **`src/server/machineRoutes.ts`** (`/api/pair`): validates the submitted code
+  against the persisted session (`validatePairingCode` — single-use,
+  attempt-capped, TTL'd), and on success registers the joiner as **standby**,
+  stores its public keys (`storeRemoteIdentity`, so MeshRpc can verify it),
+  records its advertised URL, and burns the code. Rejections are audited.
+- **`src/core/MachineIdentity.ts`**: adds a `baseDir` getter so the route can
+  co-locate its `PairingSessionStore` with the registry.
+
+## Security analysis
+
+- **The code IS the auth.** It is a `WORD-WORD-NNNN` secret, single-use
+  (`consumed`), attempt-capped (default 3 — failed attempts persist across
+  requests so the cap actually throttles brute force), and TTL'd (10 min as set
+  by `instar pair`). It travels over the Cloudflare TLS tunnel. Brute force over
+  a large code space within 3 attempts is infeasible.
+- **A joiner can only ever become `standby`.** The role is hard-coded in the
+  handler; a join request can never claim the awake role or move the lease.
+- **`/api/pair` remains unauthenticated** (it is the bootstrap, before the joiner
+  is known) — but it is now *gated*: with no active session it rejects (403)
+  rather than the old behavior of accepting any request. Malformed identities are
+  rejected (400) before anything is persisted.
+- **What we trade away vs. SAS:** the human visual-symbol MITM check. Mitigated
+  by code-over-TLS + short TTL + single-use + attempt cap. This is the operator's
+  explicit trust-model choice for automated pool formation.
+
+## Blast radius
+
+- **Dark-feature-adjacent.** This is the multi-machine pairing path; a
+  single-machine agent never calls it. No behavior change unless an operator runs
+  `instar pair` + `instar join`.
+- **No new config / schema.** `/api/pair` is server code → existing agents get
+  the new handler on update; no `PostUpdateMigrator` entry needed. The
+  `pairing-session.json` file is created on demand by `instar pair`.
+- **Backward-compatible join:** `joinMesh` still registers the awake machine from
+  the response and records its URL (the #531 fix); the only response change is
+  `status: 'paired'` instead of `'pending'`, which `joinMesh` does not branch on.
+
+## Not closed here (scoped follow-up)
+
+For a **quick-tunnel** standby, its reachable URL is only known after its server
+starts (post-join), so it cannot be sent in the pair body. The awake machine
+therefore still needs a way to learn a quick-tunnel standby's URL — either the
+standby uses a named tunnel (deterministic URL, exchanged at pair time), or a
+dedicated authenticated URL-announce path is added (the standby is now registered
+with verifiable keys, so it can sign such a call). Raised explicitly; the
+heartbeat path is awake→standby (lease arbitration), so it is not a clean carrier.
+
+## Tests
+
+- `tests/unit/pairing-session-store.test.ts` — `PairingSessionStore` roundtrip,
+  null-on-absent, no-private-key-persisted, 0600 perms, overwrite, malformed-file
+  tolerance.
+- `tests/integration/pool-noninteractive-pairing.test.ts` — valid code registers
+  joiner as standby + records URL + stores keys + consumes code; wrong code 403 +
+  attempt increment; brute-force lockout; no-session 403; consumed 403; malformed
+  identity 400.
+- `tests/integration/machine-routes.test.ts` — updated the legacy signal-only
+  assertion to the new session-gated contract.


### PR DESCRIPTION
## Why

Bringing up a second real machine for the Session Pool hardware proof surfaced that the awake machine never learned about a machine that joined headlessly. The `pair`/`join` flow is **interactive by design** — `/api/pair` was "signal-only" and registration completed only via a human confirming matching SAS visual symbols on both screens. An active-active pool can't require that per machine.

Root cause: `instar pair` created the `PairingSession` into an **unused** `_pairingSession` and discarded it, so the running server had no code to validate against.

Per the operator's explicit trust-model decision (**"Proceed with A"**), pairing is now **code-authenticated and non-interactive** — the short-lived, single-use, attempt-capped pairing code (carried over the TLS tunnel) is the shared secret; Ed25519-signed mesh RPCs handle trust thereafter.

## Changes

- **`src/core/PairingSessionStore.ts`** (new): persists the validation-relevant fields of the active `PairingSession` to `.instar/machine/pairing-session.json` (0600). The ephemeral X25519 private key is **not** persisted (a `KeyObject`, not serializable, unused for code auth).
- **`src/commands/machine.ts`**: `pairMachine` persists the session (10-min window) instead of discarding it; `joinMesh` sends its own advertised URL in the pair body when known.
- **`src/server/machineRoutes.ts`** (`/api/pair`): validates the code (`validatePairingCode` — single-use, attempt-capped, TTL'd) and on success registers the joiner as **standby**, stores its public keys (`storeRemoteIdentity`), records its advertised URL, and burns the code. Rejects 403 (no session / wrong / expired / consumed / locked-out) and 400 (malformed identity); all audited.
- **`src/core/MachineIdentity.ts`**: adds a `baseDir` getter so the route co-locates its `PairingSessionStore`.

## Security

- The code IS the auth: single-use (`consumed`), attempt-capped (failed attempts persist across requests so the cap throttles brute force), TTL'd, over TLS. A joiner can **only ever register as standby** — never claims awake or moves the lease.
- `/api/pair` stays unauthenticated (it's the bootstrap, before the joiner is known) but is now **session-gated**: no active session → 403 (vs. the old accept-anything). Malformed identities → 400 before any persistence.
- Trade vs. SAS: the human visual-MITM check, mitigated by code-over-TLS + short TTL + single-use + attempt cap. The operator's explicit choice for automated pool formation.

## Tests

- `tests/unit/pairing-session-store.test.ts` — roundtrip, null-on-absent, no-private-key-persisted, 0600, overwrite, malformed-file tolerance.
- `tests/integration/pool-noninteractive-pairing.test.ts` — valid code registers joiner standby + records URL + stores keys + consumes; wrong code 403 + attempt increment; brute-force lockout; no-session 403; consumed 403; malformed 400.
- Updated the legacy signal-only assertion in `tests/integration/machine-routes.test.ts`.

## Scope / follow-up

Still dark (`multiMachine.sessionPool` off). No new config/schema → no migration. A **quick-tunnel** standby's URL is only known post-join, so the awake machine still needs a way to learn it (named tunnel → exchanged at pair time, or a dedicated authenticated URL-announce path) — raised explicitly in the side-effects doc, not hand-resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)