### PR TITLE
fix(supervisor): stop the native-rebuild + wake-socket crash loop (fleet-wide CPU runaway)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7420,6 +7420,19 @@ export async function startServer(options: StartOptions): Promise<void> {
     try {
       const { WakeSocketServer } = await import('../threadline/WakeSocketServer.js');
       wakeSocketServer = new WakeSocketServer(config.stateDir);
+      // CRITICAL (fleet crash-loop fix): WakeSocketServer emits 'error'
+      // ASYNCHRONOUSLY (e.g. EADDRINUSE when a live peer — a duplicate instance
+      // or a transient rapid-respawn race — already holds listener.sock). The
+      // try/catch around .start() only catches synchronous errors, so without a
+      // listener this async 'error' is an unhandled EventEmitter 'error' and
+      // CRASHES THE WHOLE SERVER PROCESS. Combined with the supervisor respawn,
+      // that produced an unrecoverable crash loop (observed: inspec, 1830
+      // restarts). The wake socket is an optimization (fast wake/failover from
+      // the listener daemon) — degrade gracefully without it rather than take
+      // the entire agent down.
+      wakeSocketServer.on('error', (err: Error) => {
+        console.log(pc.dim(`  Wake socket: degraded — continuing without it (${err instanceof Error ? err.message : err})`));
+      });
       wakeSocketServer.on('wake', () => {
         // Daemon wrote a new inbox entry — read and process it
         const inboxPath = path.join(config.stateDir, 'threadline', 'inbox.jsonl.active');

--- a/src/lifeline/ServerSupervisor.ts
+++ b/src/lifeline/ServerSupervisor.ts
@@ -731,24 +731,31 @@ export class ServerSupervisor extends EventEmitter {
       const checkNode = (fs.existsSync(serverNode)) ? serverNode : process.execPath;
       const shadowNodeModules = path.join(this.stateDir, 'shadow-install', 'node_modules');
       const sqliteCopies = findBetterSqlite3Copies(shadowNodeModules);
-      const force = this.consecutiveBindFailures >= 2;
-      if (force) {
-        console.log(`[Supervisor] Preflight: ${this.consecutiveBindFailures} consecutive bind failures — forcing aggressive better-sqlite3 rebuild`);
-      }
+      // FLEET FIX (native-module rebuild-loop, 2026-05-29): a BIND failure (e.g.
+      // EADDRINUSE from a held/duplicate listener.sock or HTTP port) is NOT
+      // evidence of a native-module ABI problem. Previously we force-rebuilt
+      // better-sqlite3 on any >=2 consecutive bind failures EVEN when the module
+      // loaded fine — turning a held-socket situation into hundreds of futile,
+      // CPU-heavy node-gyp rebuilds (observed fleet-wide: sagemind 202,
+      // deep-signal 144, inspec 112, ai-guy 104). We now rebuild ONLY a copy that
+      // actually fails to load with a NODE_MODULE_VERSION ABI mismatch. Genuine
+      // native-module crash-loops still self-heal (the load check below catches a
+      // server that crashed before binding because the module failed to load); a
+      // held-socket bind failure no longer burns the machine on a futile rebuild.
+      let anyAbiMismatch = false;
       for (const copy of sqliteCopies) {
         try {
-          // Try loading the native module with the SERVER's Node — if it fails, rebuild.
-          // When we're escalating after consecutive bind failures, force the rebuild
-          // even if the require-load succeeds (the load may pass for one copy while
-          // a different cached copy is what actually got resolved at runtime).
+          // Try loading the native module with the SERVER's Node — rebuild only
+          // if it ACTUALLY fails to load with an ABI mismatch.
           const result = spawnSync(checkNode, ['-e', `require('${copy.binaryPath.replace(/'/g, "\\'")}')`], {
             encoding: 'utf-8',
             timeout: 10_000,
             cwd: this.projectDir,
           });
-          const needsRebuild = force || (result.status !== 0 && result.stderr?.includes('NODE_MODULE_VERSION'));
+          const needsRebuild = result.status !== 0 && (result.stderr?.includes('NODE_MODULE_VERSION') ?? false);
           if (!needsRebuild) continue;
-          console.log(`[Supervisor] Preflight: better-sqlite3 ${force ? 'force-rebuild' : 'version mismatch'} at ${copy.packageDir} — rebuilding (server node: ${checkNode})`);
+          anyAbiMismatch = true;
+          console.log(`[Supervisor] Preflight: better-sqlite3 version mismatch at ${copy.packageDir} — rebuilding (server node: ${checkNode})`);
           const npmPath = this.findNpmPath();
           if (!npmPath) {
             console.error('[Supervisor] Preflight: no npm binary found — cannot rebuild better-sqlite3');
@@ -775,7 +782,6 @@ export class ServerSupervisor extends EventEmitter {
             'better-sqlite3',
             '--prefix', copy.prefixDir,
           ];
-          if (force) rebuildArgs.push('--force');
           const rebuildResult = spawnSync(checkNode, [npmPath, ...rebuildArgs], {
             encoding: 'utf-8',
             timeout: 120_000,
@@ -798,6 +804,14 @@ export class ServerSupervisor extends EventEmitter {
         } catch (err) {
           console.error(`[Supervisor] Preflight: native module check failed at ${copy.packageDir}: ${err}`);
         }
+      }
+      // Diagnostic: repeated bind failures while better-sqlite3 loads fine means
+      // the failure is NOT a native-module problem (almost always a held/stale
+      // listener.sock or HTTP port from a duplicate/stuck instance). Say so loudly
+      // instead of silently rebuilding — the real remedy is freeing the socket
+      // (WakeSocketServer now degrades gracefully instead of crash-looping).
+      if (this.consecutiveBindFailures >= this.bindFailureEscalationThreshold && !anyAbiMismatch && sqliteCopies.length > 0) {
+        console.log(`[Supervisor] Preflight: ${this.consecutiveBindFailures} consecutive bind failures but better-sqlite3 loads fine — NOT a native-module problem (likely a held socket/port from a duplicate or stuck instance). Skipping native rebuild.`);
       }
     }
 

--- a/tests/unit/server-supervisor-preflight.test.ts
+++ b/tests/unit/server-supervisor-preflight.test.ts
@@ -115,6 +115,67 @@ describe('ServerSupervisor preflight self-heal', () => {
     );
     expect(abortCalls.length).toBe(0);
   });
+
+  // ── Fleet fix: bind failures must NOT trigger a native-module rebuild ──
+  // when better-sqlite3 actually loads fine. A held/duplicate listener.sock or
+  // HTTP port (EADDRINUSE) is a bind failure, NOT a native ABI problem — the old
+  // code force-rebuilt on >=2 bind failures regardless, producing hundreds of
+  // futile CPU-heavy rebuilds across the fleet.
+  function seedSqliteCopy(): void {
+    const rel = path.join(tmpDir, '.instar', 'shadow-install', 'node_modules', 'better-sqlite3', 'build', 'Release');
+    fs.mkdirSync(rel, { recursive: true });
+    fs.writeFileSync(path.join(rel, 'better_sqlite3.node'), 'binary');
+    fs.writeFileSync(path.join(tmpDir, '.instar', 'shadow-install', 'node_modules', 'better-sqlite3', 'package.json'), '{"name":"better-sqlite3"}');
+  }
+  function isRebuildCall(call: any): boolean {
+    const args = call[1] as string[] | undefined;
+    return Array.isArray(args) && args.includes('rebuild') && args.includes('better-sqlite3');
+  }
+  function isLoadCheck(call: any): boolean {
+    const args = call[1] as string[] | undefined;
+    return Array.isArray(args) && args[0] === '-e' && String(args[1] ?? '').includes('require');
+  }
+
+  it('does NOT force-rebuild better-sqlite3 on bind failures when the module loads fine', () => {
+    seedSqliteCopy();
+    (supervisor as any).consecutiveBindFailures = 5; // well past the escalation threshold
+    const mockSpawnSync = vi.mocked(spawnSync);
+    mockSpawnSync.mockImplementation((_cmd: string, args?: readonly string[]) => {
+      const a = args as string[] | undefined;
+      // The require-load check succeeds → better-sqlite3 is fine.
+      if (a?.[0] === '-e') return { stdout: '', stderr: '', status: 0, signal: null, pid: 0, output: [] } as unknown as SpawnSyncReturns<string>;
+      // git status clean, everything else status 0.
+      return { stdout: '', stderr: '', status: 0, signal: null, pid: 0, output: [] } as unknown as SpawnSyncReturns<string>;
+    });
+
+    (supervisor as any).preflightSelfHeal();
+
+    const rebuildCalls = mockSpawnSync.mock.calls.filter(isRebuildCall);
+    expect(rebuildCalls.length).toBe(0); // the misattribution is gone
+    // It still verified the module loads (the load check ran).
+    expect(mockSpawnSync.mock.calls.some(isLoadCheck)).toBe(true);
+  });
+
+  it('DOES rebuild better-sqlite3 when it actually fails to load (NODE_MODULE_VERSION)', () => {
+    seedSqliteCopy();
+    (supervisor as any).consecutiveBindFailures = 0; // not a bind-failure scenario at all
+    (supervisor as any).findNpmPath = () => '/usr/bin/npm';
+    const mockSpawnSync = vi.mocked(spawnSync);
+    mockSpawnSync.mockImplementation((_cmd: string, args?: readonly string[]) => {
+      const a = args as string[] | undefined;
+      // The require-load check FAILS with an ABI mismatch.
+      if (a?.[0] === '-e') {
+        return { stdout: '', stderr: 'Error: ... NODE_MODULE_VERSION 115 ... requires 127', status: 1, signal: null, pid: 0, output: [] } as unknown as SpawnSyncReturns<string>;
+      }
+      // npm rebuild + the post-rebuild verify succeed.
+      return { stdout: '', stderr: '', status: 0, signal: null, pid: 0, output: [] } as unknown as SpawnSyncReturns<string>;
+    });
+
+    (supervisor as any).preflightSelfHeal();
+
+    const rebuildCalls = mockSpawnSync.mock.calls.filter(isRebuildCall);
+    expect(rebuildCalls.length).toBeGreaterThanOrEqual(1); // genuine ABI failure still self-heals
+  });
 });
 
 describe('shellExec shell detection', () => {

--- a/tests/unit/wake-socket-error-handling.test.ts
+++ b/tests/unit/wake-socket-error-handling.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Fleet crash-loop fix: the WakeSocketServer emits 'error' ASYNCHRONOUSLY when a
+ * LIVE peer (a duplicate instance / a rapid-respawn race) already holds
+ * listener.sock. The server-boot consumer wired 'wake' + 'failover-trigger'
+ * listeners but NO 'error' listener, and its try/catch around .start() only
+ * catches synchronous errors — so the async EADDRINUSE was an unhandled
+ * EventEmitter 'error' that CRASHED THE WHOLE SERVER PROCESS. With the supervisor
+ * respawn, that became an unrecoverable crash loop (inspec: 1830 restarts).
+ *
+ * These tests pin (1) the consumer now attaches an 'error' handler before
+ * .start(), and (2) the live-peer EADDRINUSE surfaces as a catchable 'error'
+ * event rather than throwing uncaught.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import net from 'node:net';
+import { WakeSocketServer } from '../../src/threadline/WakeSocketServer.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('server-boot wiring: wake socket has a graceful error handler', () => {
+  const src = fs.readFileSync(path.join(process.cwd(), 'src/commands/server.ts'), 'utf-8');
+
+  it("attaches wakeSocketServer.on('error') BEFORE .start() so an async EADDRINUSE cannot crash the process", () => {
+    const errIdx = src.indexOf("wakeSocketServer.on('error'");
+    const startIdx = src.indexOf('wakeSocketServer.start()');
+    expect(errIdx).toBeGreaterThan(0);
+    expect(startIdx).toBeGreaterThan(0);
+    expect(errIdx).toBeLessThan(startIdx);
+    // The handler degrades (continues without the wake socket), not rethrows.
+    const block = src.slice(errIdx, errIdx + 240);
+    expect(block.toLowerCase()).toContain('degraded');
+  });
+});
+
+describe('WakeSocketServer — live-peer EADDRINUSE surfaces as a catchable error', () => {
+  let dir: string;
+  let livePeer: net.Server;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-err-'));
+  });
+  afterEach(async () => {
+    await new Promise<void>((r) => { try { livePeer?.close(() => r()); } catch { r(); } });
+    try { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/wake-socket-error-handling.test.ts:afterEach' }); } catch { /* cleanup */ }
+  });
+
+  it('emits an EADDRINUSE error event (not an uncaught throw) when a live peer holds the socket', async () => {
+    const socketPath = path.join(dir, 'listener.sock');
+    // Stand up a LIVE peer already listening on the socket.
+    await new Promise<void>((resolve) => {
+      livePeer = net.createServer();
+      livePeer.listen(socketPath, () => resolve());
+    });
+
+    const wss = new WakeSocketServer(dir);
+    const err = await new Promise<NodeJS.ErrnoException>((resolve, reject) => {
+      wss.on('error', (e: NodeJS.ErrnoException) => resolve(e)); // a handler exists → no crash
+      setTimeout(() => reject(new Error('no error event within 3s')), 3000);
+      wss.start();
+    });
+
+    expect(err.code).toBe('EADDRINUSE'); // surfaced as a normal, handleable event
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,37 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Fleet fix — runaway CPU from a server crash/rebuild loop.** Some agents could
+get stuck restarting their server hundreds of times while pinning a CPU core.
+Two bugs compounded: (1) the wake-socket helper threw an *asynchronous*
+EADDRINUSE that the server boot didn't catch, crashing the whole server when a
+duplicate/stale `listener.sock` holder was present; (2) the supervisor then
+mis-read those bind failures as a native-module (better-sqlite3) problem and
+force-rebuilt it on every restart — futile, CPU-heavy node-gyp compiles
+(observed fleet-wide: hundreds of rebuilds across several agents). Now the wake
+socket degrades gracefully on error (the agent keeps serving without it), and
+better-sqlite3 is only rebuilt when it *actually* fails to load with an ABI
+mismatch. This stops the loop and frees the CPU it was burning.
+
+## What to Tell Your User
+
+If your machine ever felt hot or an agent seemed to be "restarting a lot," this
+removes a cause of that. No action needed — nothing changes in normal operation.
+
+## Summary of New Capabilities
+
+- Wake-socket failures (e.g. a duplicate/stale `listener.sock` holder) degrade
+  gracefully instead of crashing the server process.
+- better-sqlite3 is rebuilt only on a real `NODE_MODULE_VERSION` ABI mismatch —
+  bind failures no longer trigger futile native rebuilds.
+
+## Evidence
+
+- `tests/unit/wake-socket-error-handling.test.ts` (wiring + live-peer EADDRINUSE
+  surfaces as a catchable event).
+- `tests/unit/server-supervisor-preflight.test.ts` (no rebuild on bind-failure
+  when the module loads; rebuild still fires on a real ABI mismatch).
+- Side-effects: `upgrades/side-effects/native-rebuild-loop-and-wake-socket-crash-fix.md`.

--- a/upgrades/side-effects/native-rebuild-loop-and-wake-socket-crash-fix.md
+++ b/upgrades/side-effects/native-rebuild-loop-and-wake-socket-crash-fix.md
@@ -1,0 +1,66 @@
+# Side-effects review — Fleet fix: native-module rebuild-loop + wake-socket crash-loop
+
+## What was happening (real-hardware, 2026-05-29)
+
+The "inspec" agent's server had restarted **1830 times** and was pinning a CPU
+core. Root cause was a self-perpetuating crash loop with two independent bugs
+that compounded — and the rebuild half had fired across the whole fleet:
+
+1. **WakeSocketServer async `'error'` crashed the entire server process.** When a
+   LIVE peer (a duplicate instance, or a transient rapid-respawn race) already
+   holds `listener.sock`, `WakeSocketServer` emits `'error'` (EADDRINUSE)
+   **asynchronously**. The server-boot consumer wired `'wake'` and
+   `'failover-trigger'` listeners but **no `'error'` listener**, and its
+   try/catch around `.start()` only catches *synchronous* errors. So the async
+   EADDRINUSE was an unhandled EventEmitter `'error'` → the whole server process
+   crashed. With the supervisor respawn, that became an unrecoverable loop.
+
+2. **The supervisor misattributed bind failures to a native-module problem.**
+   On ≥2 consecutive bind failures, `ServerSupervisor.preflightSelfHeal()`
+   force-rebuilt better-sqlite3 **even when the module loaded fine** (`force =
+   consecutiveBindFailures >= 2; needsRebuild = force || abiMismatch`). A bind
+   failure is almost always a held/stale socket or port (EADDRINUSE), NOT a
+   native ABI mismatch — so this burned the machine on futile, CPU-heavy
+   node-gyp rebuilds. Fleet-wide rebuild counts: **sagemind 202, deep-signal
+   144, inspec 112, ai-guy 104, codey 46.**
+
+(inspec also had an inspec-SPECIFIC trigger: a leftover duplicate launchd job,
+`ai.instar.echo-server-inspec`, ran a *second* server `--dir monroe-workspace`
+that raced the lifeline-managed one for the socket. That was remediated
+operationally — disabled + plist renamed `.DISABLED` — and is not a code change.)
+
+## The fix
+
+- **`src/commands/server.ts`** — attach `wakeSocketServer.on('error', …)`
+  BEFORE `.start()`. The wake socket is an optimization (fast wake/failover from
+  the listener daemon); on any error it now **degrades gracefully** (logs,
+  continues without it) instead of crashing the agent. This alone breaks the
+  crash loop — the server stays up even if the wake socket can't bind.
+
+- **`src/lifeline/ServerSupervisor.ts`** — `preflightSelfHeal()` rebuilds
+  better-sqlite3 **only** when a copy actually fails to load with a
+  `NODE_MODULE_VERSION` ABI mismatch. The bind-failure-count force-rebuild is
+  gone. A genuine native crash-loop still self-heals (a server that crashes
+  before binding because the module won't load is caught by the load check); a
+  held-socket bind failure now logs a clear diagnostic ("…NOT a native-module
+  problem (likely a held socket/port)…") instead of rebuilding.
+
+## Blast radius
+
+- **Pure robustness/CPU fix — no behavior change in the healthy path.** A server
+  that binds cleanly is unaffected. Genuine ABI mismatches still rebuild.
+- **No new config / route / schema → no migration.** Server + supervisor code;
+  existing agents pick it up on the next release. Fleet-wide benefit: stops the
+  futile rebuild CPU drain + the wake-socket crash loop for every agent.
+- **Degradation is safe:** without the wake socket, the agent falls back to its
+  normal inbox/poll path; it just loses the fast-wake optimization.
+
+## Tests
+
+- `tests/unit/wake-socket-error-handling.test.ts` — wiring: the consumer
+  attaches a graceful `'error'` handler before `.start()`; behavioral: a
+  live-peer EADDRINUSE surfaces as a catchable `'error'` event (not an uncaught
+  throw).
+- `tests/unit/server-supervisor-preflight.test.ts` — bind failures + a
+  fine-loading better-sqlite3 → **no** rebuild; an actual NODE_MODULE_VERSION
+  load failure → rebuild still fires.


### PR DESCRIPTION
## The find (real hardware)

The **inspec** agent's server had restarted **1830 times** while pinning a CPU core. Root cause was a self-perpetuating crash loop from two independent bugs — and the rebuild half had fired across the whole fleet.

### Bug 1 — WakeSocketServer async `'error'` crashes the whole server
When a **live peer** (a duplicate instance, or a transient rapid-respawn race) already holds `listener.sock`, `WakeSocketServer` emits `'error'` (EADDRINUSE) **asynchronously**. The server-boot consumer (`src/commands/server.ts`) wired `'wake'` + `'failover-trigger'` listeners but **no `'error'` listener**, and its `try/catch` around `.start()` only catches *synchronous* errors. So the async EADDRINUSE was an **unhandled EventEmitter `'error'` → whole-process crash**. With the supervisor respawn → unrecoverable loop.

**Fix:** attach `wakeSocketServer.on('error', …)` **before** `.start()`. The wake socket is an optimization (fast wake/failover from the listener daemon); on error it now **degrades gracefully** (logs, keeps serving without it) instead of crashing the agent.

### Bug 2 — supervisor misattributes bind failures to a native-module problem
On ≥2 consecutive bind failures, `ServerSupervisor.preflightSelfHeal()` force-rebuilt better-sqlite3 **even when the module loaded fine** (`force = consecutiveBindFailures >= 2; needsRebuild = force || abiMismatch`). A bind failure is almost always a held/stale socket or port (EADDRINUSE), **not** a native ABI mismatch — so it burned the machine on futile, CPU-heavy `node-gyp` rebuilds. Fleet-wide rebuild counts observed: **sagemind 202, deep-signal 144, inspec 112, ai-guy 104, codey 46.**

**Fix:** rebuild better-sqlite3 **only** on an actual `NODE_MODULE_VERSION` load failure. A genuine native crash-loop still self-heals (the per-copy load check catches a server that crashed before binding because the module won't load); a held-socket bind failure now logs a clear diagnostic instead of rebuilding.

*(inspec also had an inspec-specific trigger — a leftover duplicate launchd job running a second server that raced for the socket. Remediated operationally; not a code change.)*

## Safety / scope

- Pure robustness/CPU fix — **healthy path unchanged** (a server that binds cleanly is unaffected; real ABI mismatches still rebuild).
- **No new config / route / schema → no migration.** Server + supervisor code; existing agents get it on the next release. Fleet-wide benefit.
- Wake-socket degradation is safe (falls back to the normal inbox/poll path; only loses the fast-wake optimization).

## Tests

- `tests/unit/wake-socket-error-handling.test.ts` — consumer attaches a graceful `'error'` handler before `.start()`; a live-peer EADDRINUSE surfaces as a catchable `'error'` event (not an uncaught throw).
- `tests/unit/server-supervisor-preflight.test.ts` — bind failures + fine-loading better-sqlite3 → **no** rebuild; a real `NODE_MODULE_VERSION` failure → rebuild still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)