### PR TITLE
fix(monitoring): guard TokenLedger async scan loop against use-after-close

### DIFF
--- a/docs/specs/TOKENLEDGER-SCANLOOP-CLOSE-GUARD-SPEC.eli16.md
+++ b/docs/specs/TOKENLEDGER-SCANLOOP-CLOSE-GUARD-SPEC.eli16.md
@@ -1,0 +1,47 @@
+# In plain English: don't read the token database after it's been shut
+
+## What this is about
+
+The agent keeps a small database of how many tokens it has used (the "token
+ledger"). In the background, it slowly scans through the agent's chat logs to
+count usage. To avoid hogging the computer, that scan does a little work, then
+pauses to let everything else run, then does a little more, and so on.
+
+## What went wrong
+
+When the agent (or a test) shuts the database down, it might do so *exactly
+during one of those pauses*. When the scan wakes back up from its pause, it tries
+to read the next chat-log file and write to the database — but the database is
+already closed. The database library then complains: "the database connection is
+not open."
+
+In practice this was harmless: it only happened while shutting things down, the
+error was caught and logged, and nothing was lost or crashed. But it printed a
+scary-looking error line that could hide *real* problems, and reading something
+after you've closed it is just a latent bug waiting to bite.
+
+## What already exists
+
+The recent startup fix (the one that stopped a big token database from freezing
+the agent on boot) added a simple "I'm closed now" flag the ledger sets when it
+shuts down, and the background backfill already checks that flag. The scanning
+loop, though, never looked at it.
+
+## What's new
+
+The scanning loop now checks that same "I'm closed now" flag right after each
+pause — before it touches the database or the disk again. If the ledger was
+closed during the pause, the scan simply stops cleanly instead of trying to use
+the closed database. That's the whole change: one quick check in two spots.
+
+The all-at-once (non-paused) version of the scan doesn't need this, because it
+never pauses, so a shutdown can't sneak in halfway through it.
+
+## What the reader needs to decide
+
+Nothing to configure, nothing for a user to notice. It only changes what happens
+during shutdown: instead of a caught-and-logged "database not open" error, the
+scan ends quietly. A test proves the fix works — it deliberately closes the
+database mid-scan and confirms the scan now ends cleanly (and confirms that
+without the fix, the old error comes back). This is a small, safe robustness
+cleanup that finishes the shutdown-safety work started by the startup fix.

--- a/docs/specs/TOKENLEDGER-SCANLOOP-CLOSE-GUARD-SPEC.md
+++ b/docs/specs/TOKENLEDGER-SCANLOOP-CLOSE-GUARD-SPEC.md
@@ -1,0 +1,78 @@
+---
+title: TokenLedger async scan loop must not touch a closed DB
+status: approved
+review-convergence: converged
+approved: true
+approval-basis: >
+  Completes the use-after-close hardening introduced with the #534 boot-fix
+  (which added the `closed` flag for the background backfill timer). Same defect
+  class, surfaced as a benign stderr during E2E teardown while shipping #534.
+  Test-verified (fails without the guard with the exact runtime error) and
+  changes behavior only during shutdown. Shipped under the standing
+  complete-delivery directive (Justin, topic 13435); self-approved as a
+  low-risk robustness completion and flagged to Justin for review.
+eli16-overview: TOKENLEDGER-SCANLOOP-CLOSE-GUARD-SPEC.eli16.md
+date: 2026-05-29
+---
+
+# TokenLedger async scan loop must not touch a closed DB
+
+## Problem
+
+`TokenLedger.scanLoopAsync()` walks the Claude Code JSONL transcript tree and
+`await`s an event-loop yield (`yieldFn`) every N files so a large backfill can't
+monopolise the event loop. If `close()` runs **during one of those yields**, the
+resumed loop calls `ingestFile()` on a connection that is already closed, and
+better-sqlite3 throws `TypeError: The database connection is not open`.
+
+This was observed as a benign `[token-ledger] scan error: ... database
+connection is not open` line during E2E test teardown (the test closes the
+ledger while the poller-driven async scan is mid-flight). The scan is a
+best-effort observability task, so the throw is caught upstream and logged — no
+data loss, no crash — but it is noise that masks real scan errors and is a latent
+use-after-close.
+
+## Root cause
+
+`scanLoopAsync` had no liveness check after resuming from `await yieldFn()`.
+`close()` already sets a `this.closed` flag and clears the background backfill
+timer (added with the #534 boot-fix), but the scan loop never consulted it.
+
+## Design
+
+Consult the existing `this.closed` flag inside `scanLoopAsync`, returning the
+partial result (`{ filesScanned, inserted }`) before any further DB or filesystem
+work whenever the ledger has been closed:
+
+- At the top of the outer (per-directory) loop — covers a `close()` that landed
+  during the directory-boundary yield, before `listJsonlFiles`.
+- At the top of the inner (per-file) loop — covers a `close()` that landed during
+  the per-file yield, before the next `ingestFile()`.
+
+The synchronous scan path (`scanLoopSync`) needs no guard: it never `await`s, so
+`close()` cannot interleave with it.
+
+## Convergence notes (adversarial self-review)
+
+- *Does returning early lose data?* No — the scan is best-effort and resumes from
+  its persisted cursor on the next poll tick of a live ledger. A closed ledger
+  has no next tick by definition.
+- *Could the guard mask a real scan that should continue?* No — the only state
+  that sets `this.closed` is `close()`. After `close()` the ledger is terminal.
+- *Why not also wrap `ingestFile` in try/catch?* That would swallow the symptom
+  without fixing the race; the guard removes the use-after-close at its source.
+
+## Testing
+
+- **Unit** (`tests/unit/token-ledger.test.ts`): a new test injects an
+  `asyncYieldFn` that calls `close()` on the first yield, then `await`s
+  `scanAllAsync()` and asserts it resolves without throwing and bailed before
+  scanning the remaining files. Verified that the test FAILS without the guard
+  (with the exact `database connection is not open` error) and passes with it —
+  a genuine regression test, not a tautology.
+
+## Migration parity
+
+Server-internal monitoring code, not an agent-installed file — no
+PostUpdateMigrator entry required. Every agent receives the fix by running the
+new server build.

--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -969,9 +969,14 @@ export class TokenLedger {
     let filesScanned = 0;
     let inserted = 0;
     while (this.scanCursor.dirIdx < projectDirs.length && filesScanned < this.maxFilesPerScan) {
+      // close() may have run while we were suspended at an `await yieldFn()`
+      // below. Bail before any further DB/fs work so a resumed scan never
+      // touches a closed connection ("database connection is not open").
+      if (this.closed) return { filesScanned, inserted };
       const dir = projectDirs[this.scanCursor.dirIdx];
       const files = this.listJsonlFiles(dir);
       while (this.scanCursor.fileIdx < files.length && filesScanned < this.maxFilesPerScan) {
+        if (this.closed) return { filesScanned, inserted };
         const fp = files[this.scanCursor.fileIdx];
         this.scanCursor.fileIdx++;
         if (!this.shouldScanFile(fp, ageCutoff)) continue;

--- a/tests/unit/token-ledger.test.ts
+++ b/tests/unit/token-ledger.test.ts
@@ -378,6 +378,45 @@ describe('TokenLedger.scanAll bounded behavior', () => {
     expect(yieldCount).toBeGreaterThan(0);
     ledger.close();
   });
+
+  it('scanAllAsync bails cleanly if close() races a yielded scan (no use-after-close)', async () => {
+    // Regression: scanLoopAsync yields between files (await yieldFn()). If
+    // close() runs during that yield, the resumed loop must NOT call
+    // ingestFile() on the now-closed DB — better-sqlite3 would throw
+    // "The database connection is not open". The closed-guard makes the loop
+    // return early instead. (Observed as a benign stderr during E2E teardown.)
+    const projDir = path.join(projectsDir, '-close-race');
+    fs.mkdirSync(projDir, { recursive: true });
+    for (let i = 0; i < 4; i++) {
+      fs.writeFileSync(
+        path.join(projDir, `s${i}.jsonl`),
+        assistantLine({ requestId: `r${i}`, sessionId: `s${i}` }) + '\n',
+      );
+    }
+    let ledger: TokenLedger;
+    let closedMidScan = false;
+    ledger = new TokenLedger({
+      dbPath: ':memory:',
+      claudeProjectsDir: projectsDir,
+      yieldEveryNFiles: 1, // yield after every file
+      attributionBackfill: 'off',
+      asyncYieldFn: async () => {
+        // Close on the first yield, simulating a shutdown racing the scan.
+        if (!closedMidScan) {
+          closedMidScan = true;
+          ledger.close();
+        }
+      },
+    });
+
+    // Must resolve without throwing — the guard returns before the next
+    // ingestFile() touches the closed DB.
+    const r = await ledger.scanAllAsync();
+    expect(closedMidScan).toBe(true);
+    // It processed the first file, then bailed on the post-yield resume rather
+    // than scanning the remaining files against a closed connection.
+    expect(r.filesScanned).toBeLessThan(4);
+  });
 });
 
 describe('TokenLedger.sessionActivitySince (SessionReaper gate F)', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,33 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Robustness cleanup — token-ledger background scan no longer logs a
+"database not open" error during shutdown.** The token-ledger's background scan
+yields the event loop between files; if the ledger was closed during one of
+those yields, the resumed scan tried to read the now-closed database and threw a
+caught-and-logged `database connection is not open` error. Harmless (no data
+loss, no crash — it only happens at shutdown) but noisy, and a latent
+use-after-close. The scan now checks a liveness flag after each yield and stops
+cleanly if the ledger has been closed. This completes the shutdown-safety work
+started by the token-ledger boot fix.
+
+## What to Tell Your User
+
+Nothing changes in normal operation. This removes a spurious error line that
+could appear in logs when an agent shut down mid-scan.
+
+## Summary of New Capabilities
+
+- Token-ledger background scan (`scanAllAsync`) bails cleanly if the ledger is
+  closed mid-scan, instead of throwing a use-after-close error.
+
+## Evidence
+
+- `tests/unit/token-ledger.test.ts` — new regression test injects a yield that
+  closes the ledger mid-scan and asserts the scan resolves without throwing.
+  Verified the test FAILS without the guard (with the exact `database connection
+  is not open` error) and passes with it.
+- Side-effects: `upgrades/side-effects/tokenledger-scanloop-close-guard.md`.

--- a/upgrades/side-effects/tokenledger-scanloop-close-guard.md
+++ b/upgrades/side-effects/tokenledger-scanloop-close-guard.md
@@ -1,0 +1,52 @@
+# Side-effects review — TokenLedger scanLoopAsync close guard
+
+**Spec:** `docs/specs/TOKENLEDGER-SCANLOOP-CLOSE-GUARD-SPEC.md`
+**Change:** `src/monitoring/TokenLedger.ts` (+ unit test)
+**Class:** use-after-close hardening (completes the #534 shutdown-safety work).
+
+## What changed
+
+`scanLoopAsync()` now checks the existing `this.closed` flag after resuming from
+an `await yieldFn()` — at the top of both the outer (per-directory) and inner
+(per-file) loops — and returns the partial `{ filesScanned, inserted }` before
+any further DB/fs work if the ledger was closed mid-scan. Two one-line guards;
+no other behavior changed.
+
+## Blast radius
+
+- **`scanAllAsync()` callers** (the poller): unchanged in the live case — the
+  guard only triggers after `close()`, which a live poller never calls mid-scan.
+  The only behavioral change is during shutdown: the scan ends early and cleanly
+  instead of throwing/logging a caught error.
+- **`scanAll()` / `scanLoopSync()`**: untouched — synchronous, cannot interleave
+  with `close()`.
+- **Public API / schema / config**: none. No signatures, no DB schema, no
+  options changed.
+
+## What could break (and why it doesn't)
+
+- **Lost scan progress?** No — the async scan is best-effort and resumes from its
+  persisted cursor on the next poll of a *live* ledger. A closed ledger has no
+  next tick, so there is nothing to resume.
+- **Masking a legitimate in-progress scan?** No — `this.closed` is set only by
+  `close()`, after which the ledger is terminal.
+
+## Security
+
+No new external input, network, auth, or filesystem surface. Pure liveness check
+on an internal flag.
+
+## Migration parity
+
+Server-internal monitoring code, not an agent-installed file — no
+PostUpdateMigrator entry required.
+
+## Rollback
+
+Revert the commit. No persisted state or schema is affected.
+
+## Tests
+
+Unit (`tests/unit/token-ledger.test.ts`): new close-during-scan regression test
+— verified to FAIL without the guard (exact `database connection is not open`
+error) and pass with it. 22 tests green; `tsc --noEmit` clean.


### PR DESCRIPTION
## Problem

`TokenLedger.scanLoopAsync()` yields the event loop between files (`await yieldFn()`) so a large backfill can't monopolise it. If `close()` runs **during one of those yields**, the resumed loop calls `ingestFile()` on a closed connection and better-sqlite3 throws `TypeError: The database connection is not open`.

Observed as a benign caught/logged stderr during E2E teardown while shipping #534 (`[token-ledger] scan error: ... database connection is not open`). No data loss, no crash — but noisy and a latent use-after-close.

## Fix

`scanLoopAsync()` now consults the existing `this.closed` flag (added with the #534 boot-fix for the background backfill timer) after each yield — at the top of both the outer (per-directory) and inner (per-file) loops — and returns the partial `{ filesScanned, inserted }` before any further DB/fs work if the ledger was closed mid-scan. Two one-line guards; nothing else changes. `scanLoopSync()` needs no guard (it never `await`s, so `close()` can't interleave).

This completes the use-after-close hardening started by #534.

## Tests

New regression in `tests/unit/token-ledger.test.ts`: injects an `asyncYieldFn` that calls `close()` on the first yield, then `await`s `scanAllAsync()` and asserts it resolves without throwing and bailed before scanning the rest. **Verified the test FAILS without the guard** (exact `database connection is not open` error) **and passes with it** — a genuine regression test. 22 unit tests green; `tsc --noEmit` clean.

Spec: `docs/specs/TOKENLEDGER-SCANLOOP-CLOSE-GUARD-SPEC.md` (+ ELI16 + side-effects artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)