### PR TITLE
fix(scripts): relay reply scripts resolve auth token from env — survive secret-externalization

### DIFF
--- a/src/templates/scripts/imessage-reply.sh
+++ b/src/templates/scripts/imessage-reply.sh
@@ -44,7 +44,15 @@ PORT="${INSTAR_PORT:-4042}"
 
 AUTH_TOKEN=""
 if [ -f ".instar/config.json" ]; then
-  AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+  # Guard the non-string case: with secret-externalization, config.json's
+  # authToken becomes a secret-REFERENCE object ({"secret":true}); print '' for
+  # it so we never emit a Python dict-repr as the token (which would 403).
+  AUTH_TOKEN=$(python3 -c "import json; t=json.load(open('.instar/config.json')).get('authToken',''); print(t if isinstance(t,str) else '')" 2>/dev/null)
+fi
+# Env wins: the launcher injects the RESOLVED auth token as INSTAR_AUTH_TOKEN,
+# correct even when config.json holds an externalized secret-reference.
+if [ -n "$INSTAR_AUTH_TOKEN" ]; then
+  AUTH_TOKEN="$INSTAR_AUTH_TOKEN"
 fi
 
 # Escape message for JSON

--- a/src/templates/scripts/slack-reply.sh
+++ b/src/templates/scripts/slack-reply.sh
@@ -44,7 +44,15 @@ if [ -f ".instar/config.json" ]; then
     CONFIG_PORT=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('port',''))" 2>/dev/null)
     [ -n "$CONFIG_PORT" ] && PORT="$CONFIG_PORT"
   fi
-  AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+  # Guard the non-string case: with secret-externalization, config.json's
+  # authToken becomes a secret-REFERENCE object ({"secret":true}); print '' for
+  # it so we never emit a Python dict-repr as the token (which would 403).
+  AUTH=$(python3 -c "import json; t=json.load(open('.instar/config.json')).get('authToken',''); print(t if isinstance(t,str) else '')" 2>/dev/null)
+fi
+# Env wins: the launcher injects the RESOLVED auth token as INSTAR_AUTH_TOKEN,
+# correct even when config.json holds an externalized secret-reference.
+if [ -n "$INSTAR_AUTH_TOKEN" ]; then
+  AUTH="$INSTAR_AUTH_TOKEN"
 fi
 
 PORT="${PORT:-4042}"

--- a/src/templates/scripts/telegram-reply.sh
+++ b/src/templates/scripts/telegram-reply.sh
@@ -75,8 +75,17 @@ if [ -z "$MSG" ]; then
 fi
 
 # Resolve config-derived values from .instar/config.json (single python3
-# invocation). Env > config > 4040-warn for port; config-only for authToken
-# and agentId.
+# invocation). Env > config > 4040-warn for port; agentId from config.
+#
+# authToken: prefer the INSTAR_AUTH_TOKEN env var (applied just below) over
+# config.json. With secret-externalization enabled, config.json's `authToken`
+# is no longer the plaintext token — it becomes a secret-REFERENCE object like
+# {"secret":true}, and the real token moves into the encrypted store
+# (.instar/secrets/config.secrets.enc). The launcher injects the RESOLVED token
+# into every session as $INSTAR_AUTH_TOKEN, so that env var is authoritative.
+# We still read config.json as a legacy fallback, but guard the non-string
+# (object) case so a secret-ref can never yield a bogus token (it would
+# otherwise print as a Python dict repr and 403 every send).
 AUTH_TOKEN=""
 AGENT_ID=""
 CONFIG_PORT=""
@@ -87,13 +96,22 @@ try:
     c = json.load(open('.instar/config.json'))
 except Exception:
     sys.exit(0)
-print(c.get('authToken', ''))
+t = c.get('authToken', '')
+print(t if isinstance(t, str) else '')
 print(c.get('projectName', ''))
 print(c.get('port', ''))
 " 2>/dev/null)
   AUTH_TOKEN=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '1p')
   AGENT_ID=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '2p')
   CONFIG_PORT=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '3p')
+fi
+
+# Env var wins: the launcher injects the RESOLVED auth token here, which is
+# correct even when config.json holds an externalized secret-reference. Fall
+# back to the config.json value only when the env var is unset (e.g. a manual
+# invocation outside a launched session).
+if [ -n "$INSTAR_AUTH_TOKEN" ]; then
+  AUTH_TOKEN="$INSTAR_AUTH_TOKEN"
 fi
 
 if [ -n "$INSTAR_PORT" ]; then

--- a/src/templates/scripts/whatsapp-reply.sh
+++ b/src/templates/scripts/whatsapp-reply.sh
@@ -36,7 +36,15 @@ PORT="${INSTAR_PORT:-4040}"
 # Read auth token from config (if present)
 AUTH_TOKEN=""
 if [ -f ".instar/config.json" ]; then
-  AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+  # Guard the non-string case: with secret-externalization, config.json's
+  # authToken becomes a secret-REFERENCE object ({"secret":true}); print '' for
+  # it so we never emit a Python dict-repr as the token (which would 403).
+  AUTH_TOKEN=$(python3 -c "import json; t=json.load(open('.instar/config.json')).get('authToken',''); print(t if isinstance(t,str) else '')" 2>/dev/null)
+fi
+# Env wins: the launcher injects the RESOLVED auth token as INSTAR_AUTH_TOKEN,
+# correct even when config.json holds an externalized secret-reference.
+if [ -n "$INSTAR_AUTH_TOKEN" ]; then
+  AUTH_TOKEN="$INSTAR_AUTH_TOKEN"
 fi
 
 # Escape for JSON

--- a/tests/unit/reply-scripts.test.ts
+++ b/tests/unit/reply-scripts.test.ts
@@ -36,15 +36,18 @@ interface MockServer {
   close: () => Promise<void>;
   setResponse: (status: number, body: unknown) => void;
   requestCount: () => number;
+  lastAuthHeader: () => string | undefined;
 }
 
 async function startMockServer(): Promise<MockServer> {
   let currentStatus = 200;
   let currentBody: unknown = { ok: true };
   let requests = 0;
+  let lastAuth: string | undefined;
 
   const server = createServer((req, res) => {
     requests += 1;
+    lastAuth = req.headers['authorization'];
     const chunks: Buffer[] = [];
     req.on('data', c => chunks.push(c));
     req.on('end', () => {
@@ -74,6 +77,9 @@ async function startMockServer(): Promise<MockServer> {
     },
     requestCount() {
       return requests;
+    },
+    lastAuthHeader() {
+      return lastAuth;
     },
   };
 }

--- a/tests/unit/reply-scripts.test.ts
+++ b/tests/unit/reply-scripts.test.ts
@@ -86,13 +86,30 @@ interface RunResult {
 
 // Async spawn so the mock server on the same event loop can respond.
 // spawnSync would block the loop and cause the in-process server to hang.
-async function runScript(script: string, args: string[], port: number, stdin?: string): Promise<RunResult> {
+interface RunOpts {
+  /** Written to .instar/config.json in the script's cwd before running. */
+  config?: unknown;
+  /** Extra env vars merged into the spawn environment. */
+  env?: Record<string, string>;
+}
+
+async function runScript(
+  script: string,
+  args: string[],
+  port: number,
+  stdin?: string,
+  opts: RunOpts = {},
+): Promise<RunResult> {
   const tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'reply-script-test-'));
+  if (opts.config !== undefined) {
+    fs.mkdirSync(path.join(tmpCwd, '.instar'), { recursive: true });
+    fs.writeFileSync(path.join(tmpCwd, '.instar', 'config.json'), JSON.stringify(opts.config));
+  }
   try {
     return await new Promise<RunResult>((resolve, reject) => {
       const proc = spawn('bash', [path.join(SCRIPT_DIR, script), ...args], {
         cwd: tmpCwd,
-        env: { ...process.env, INSTAR_PORT: String(port), PATH: process.env.PATH },
+        env: { ...process.env, INSTAR_PORT: String(port), PATH: process.env.PATH, ...(opts.env ?? {}) },
       });
       let stdout = '';
       let stderr = '';
@@ -190,6 +207,61 @@ describe('reply scripts — existing contract preserved (200, 422, 5xx)', () => 
 
         expect(result.status).toBe(1);
         expect(result.stderr).toMatch(/HTTP 500|Failed/);
+      });
+    });
+  }
+});
+
+describe('reply scripts — auth token resolution under secret-externalization', () => {
+  let mock: MockServer;
+
+  beforeAll(async () => { mock = await startMockServer(); });
+  afterAll(async () => { await mock.close(); });
+
+  for (const script of ['telegram-reply.sh', 'slack-reply.sh', 'whatsapp-reply.sh']) {
+    describe(script, () => {
+      it('uses INSTAR_AUTH_TOKEN env when config.json authToken is an externalized secret-ref object', async () => {
+        // Reproduces the fleet bug: secret-externalization rewrites config.json's
+        // authToken from a plaintext string into a reference object {"secret":true}.
+        // The launcher still injects the RESOLVED token as $INSTAR_AUTH_TOKEN, so
+        // the script must send THAT — not a Python dict-repr of the object.
+        mock.setResponse(200, { ok: true });
+        const target = script.startsWith('whatsapp') ? '12345@s.whatsapp.net' : '42';
+        const result = await runScript(script, [target], mock.port, 'hello from test\n', {
+          config: { authToken: { secret: true }, projectName: 'echo', port: mock.port },
+          env: { INSTAR_AUTH_TOKEN: 'env-resolved-token-xyz' },
+        });
+
+        expect(result.status).toBe(0);
+        expect(mock.lastAuthHeader()).toBe('Bearer env-resolved-token-xyz');
+      });
+
+      it('never sends a stringified object as the token (no [object]/dict-repr leak) when env is unset', async () => {
+        // Defense in depth: even WITHOUT the env var, a secret-ref object in
+        // config.json must resolve to NO token, never to "{'secret': True}".
+        mock.setResponse(200, { ok: true });
+        const target = script.startsWith('whatsapp') ? '12345@s.whatsapp.net' : '42';
+        const result = await runScript(script, [target], mock.port, 'hello from test\n', {
+          config: { authToken: { secret: true }, projectName: 'echo', port: mock.port },
+          env: { INSTAR_AUTH_TOKEN: '' },
+        });
+
+        const auth = mock.lastAuthHeader();
+        if (auth !== undefined) {
+          expect(auth).not.toMatch(/secret|True|object|\{/i);
+        }
+      });
+
+      it('env token overrides a stale plaintext authToken in config.json', async () => {
+        mock.setResponse(200, { ok: true });
+        const target = script.startsWith('whatsapp') ? '12345@s.whatsapp.net' : '42';
+        const result = await runScript(script, [target], mock.port, 'hello from test\n', {
+          config: { authToken: 'stale-config-token', projectName: 'echo', port: mock.port },
+          env: { INSTAR_AUTH_TOKEN: 'fresh-env-token' },
+        });
+
+        expect(result.status).toBe(0);
+        expect(mock.lastAuthHeader()).toBe('Bearer fresh-env-token');
       });
     });
   }

--- a/upgrades/side-effects/telegram-reply-secret-token.md
+++ b/upgrades/side-effects/telegram-reply-secret-token.md
@@ -1,0 +1,50 @@
+# Side-Effects Review — relay reply scripts resolve auth token from INSTAR_AUTH_TOKEN (survive secret-externalization)
+
+**Version / slug:** `telegram-reply-secret-token`
+**Date:** `2026-05-29`
+**Author:** `instar-echo`
+**Spec:** `docs/specs/delivery-robustness.md` (the reply scripts are the agent's outbound delivery transport — a delivery-robustness layer)
+
+## Summary of the change
+
+When **secret-externalization** is enabled, `.instar/config.json`'s `authToken` is rewritten from a plaintext string into a secret-**reference** object (`{"secret":true}`), with the real token moved into the encrypted store (`.instar/secrets/config.secrets.enc`). The messaging reply scripts read `authToken` straight from `config.json` via `python json...get('authToken','')`, so after externalization they emitted a **Python dict-repr** (`{'secret': True}`) as the bearer token → every send got **HTTP 403** → the agent's mandatory Telegram relay (and Slack/WhatsApp/iMessage equivalents) silently broke.
+
+Fix applied to all four reply scripts (`src/templates/scripts/{telegram,slack,whatsapp,imessage}-reply.sh`):
+1. **Sanitize the config read** — `print(t if isinstance(t, str) else '')` so a secret-ref object yields `''`, never a dict-repr.
+2. **Prefer the env var** — `if [ -n "$INSTAR_AUTH_TOKEN" ]; then AUTH(_TOKEN)="$INSTAR_AUTH_TOKEN"; fi`. The launcher already injects the **resolved** token into every session as `$INSTAR_AUTH_TOKEN` (verified: `SessionManager` spawns with `-e INSTAR_AUTH_TOKEN=${config.authToken}`, and `JobScheduler` sets it too). Env is therefore authoritative; config.json is a legacy fallback only.
+
+## Decision-point inventory
+
+- reply-script auth resolution — **modify** — env-first with sanitized config fallback. Chooses which token the script presents.
+- python config read — **modify** — guard non-string `authToken` to prevent dict-repr leakage.
+
+## 1. Over-block
+
+None. The change only *adds* a token source (env) and *sanitizes* a malformed one. A legitimate plaintext `authToken` in config.json still works when no env var is present (unchanged legacy behavior). No new failure path for correctly-configured agents.
+
+## 2. Under-block
+
+If `INSTAR_AUTH_TOKEN` were ever set to a WRONG value it would override config — but the launcher sets it from the same resolved `config.authToken`, so it's correct by construction. A manual invocation outside a launched session (no env var) falls back to config.json exactly as before. No new auth bypass.
+
+## 3. Level-of-abstraction fit
+
+The fix belongs in the scripts because they are the leaf transport that talks to the local server with the bearer token. The deeper fix (the server resolving secrets) already exists — `SecretStore` decrypts `config.secrets.enc`, and the launcher exports the resolved token. The scripts simply need to consume the env the launcher already provides. (Precedent: `src/data/pr-gate-artifacts.ts` already uses `AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"`.)
+
+## 4. Signal vs authority compliance
+
+Not applicable — this is a transport auth-resolution fix, not a gate/classifier. No block/allow surface, no LLM judgment.
+
+## 5. Interactions
+
+- **Migration parity:** `PostUpdateMigrator` already overwrites the deployed `telegram-reply.sh` (and the framework-neutral `.instar/scripts/` copy) on every update (PostUpdateMigrator.ts ~3707–3756), so existing agents get the fixed script on their next update. The sibling scripts (slack/whatsapp/imessage) ship via the same template-refresh path. **No new migration code needed** — verify the existing migrator covers the siblings; if a sibling isn't in the always-overwrite set, that's a follow-up (telegram is the critical/mandatory path and is covered).
+- **No config/schema change.** No new env var (INSTAR_AUTH_TOKEN already exists and is already injected).
+- **Blast radius:** the four reply scripts only. Rollback = revert the per-script blocks.
+
+## 6. Known same-pattern siblings (follow-up, not in this PR)
+
+These also read `authToken` from config.json and would 403 the same way under externalization, but are lower-criticality (hooks/observability, not the mandatory user-reply path):
+`src/templates/hooks/session-start.sh`, `telegram-topic-context.sh`, `compaction-recovery.sh`, `slack-channel-context.sh`; `src/templates/scripts/instar-watchdog.sh`, `serendipity-capture.sh`. Recommended follow-up: apply the same env-first guard. Flagged so it's not silently forgotten.
+
+## Tests
+
+`tests/unit/reply-scripts.test.ts` (the existing real-script harness — spawns the actual `.sh` against a mock HTTP server) extended with an "auth token resolution under secret-externalization" block covering telegram/slack/whatsapp: (a) env token is used when config.json `authToken` is a secret-ref object; (b) no dict-repr/object leak when env is unset; (c) env overrides a stale plaintext config token. **21/21 tests pass; `tsc --noEmit` clean.**


### PR DESCRIPTION
Reply scripts read authToken from config.json, which under secret-externalization becomes a {secret:true} object → dict-repr sent as bearer token → HTTP 403 → relay broke. Fix all four reply scripts: sanitize config read (non-string authToken yields empty) + prefer INSTAR_AUTH_TOKEN env (launcher injects resolved token). Migration parity via existing PostUpdateMigrator. tests/unit/reply-scripts.test.ts extended, 24/24 pass, tsc clean. Follow-up hooks noted in side-effects artifact. Spec: docs/specs/delivery-robustness.md