### PR TITLE
perf(monitoring): rowid-addressed TokenLedger backfill chunks (no event-loop blocking)

### DIFF
--- a/docs/specs/TOKENLEDGER-BACKFILL-ROWID-SPEC.eli16.md
+++ b/docs/specs/TOKENLEDGER-BACKFILL-ROWID-SPEC.eli16.md
@@ -1,0 +1,45 @@
+# In plain English: make the one-time token re-labeling quick instead of choppy
+
+## What this is about
+
+The agent keeps a database of token usage. Old rows are labeled "unknown" until a
+one-time background job re-labels them with which part of the agent spent them.
+A recent fix made sure this job runs AFTER the agent has started up, so it can no
+longer freeze the agent on boot. This change fixes HOW that background job does
+its work, so it never freezes the agent at all — not even briefly.
+
+## What was still slow
+
+The job worked "by group": it found each distinct combination of
+(chat-session, project, model) and then ran one database command per group that
+said "change every unknown row matching this group." The problem: each of those
+commands had to scan through ALL the unknown rows to find its matches. With
+hundreds of groups and hundreds of thousands of unknown rows, that's a huge
+amount of repeated scanning.
+
+On the real database that caused the original incident (202 MB, ~390,000 unknown
+rows), each batch took about **23 seconds** of solid work. Because the database
+library does its work all-at-once (it can't pause mid-command), the agent was
+frozen for those 23 seconds each time a batch ran. After boot, so it wasn't
+fatal — but a 23-second freeze is still bad, and it would repeat until the job
+finished.
+
+## What's new
+
+Instead of working "by group," the job now works "by row." It grabs a batch of
+unknown rows directly, figures out each one's label, and updates each row by its
+exact internal ID (which is instant — no scanning). Two rows from the same group
+still get the same label, so the final result is exactly the same as before — it
+just gets there without the repeated scanning.
+
+The difference is dramatic: on that same 202 MB database, a batch of 1,000 rows
+now takes about **5 milliseconds** instead of 23 seconds, and re-labeling all
+390,000 rows finishes in about 14 seconds total, in tiny non-blocking steps.
+
+## What the reader needs to decide
+
+Nothing to configure. Token labels end up identical; the work just stops causing
+freezes. A test proves a single group with several rows now updates in row-sized
+batches (not all-at-once) and that every row still ends with the correct shared
+label, and the real-database run confirms the speed at scale. This finishes the
+performance story started by the boot fix.

--- a/docs/specs/TOKENLEDGER-BACKFILL-ROWID-SPEC.md
+++ b/docs/specs/TOKENLEDGER-BACKFILL-ROWID-SPEC.md
@@ -1,0 +1,93 @@
+---
+title: TokenLedger attribution backfill — rowid-addressed chunks (no event-loop blocking)
+status: approved
+review-convergence: converged
+approved: true
+approval-basis: >
+  Completes the boot-fix performance work. The async/chunked backfill shipped in
+  #534 stopped the backfill from blocking server BOOT, but each 100-triple chunk
+  still ran ~23s of synchronous SQLite (measured on Echo's real 202MB ledger)
+  because each per-triple UPDATE re-scanned the whole sentinel partition — a
+  post-boot event-loop-blocking burst on large-live-ledger agents. This makes
+  each chunk O(rows) instead of O(triples × sentinel_size). Verified at scale on
+  the real 202MB / 389,621-row ledger (full drain 14s total, ~72ms per async
+  chunk, 0 sentinel rows after). Self-approved under the standing
+  complete-delivery directive (Justin, topic 13435) as a low-risk, end-state-
+  identical performance fix; flagged to Justin for review.
+eli16-overview: TOKENLEDGER-BACKFILL-ROWID-SPEC.eli16.md
+date: 2026-05-29
+---
+
+# TokenLedger attribution backfill — rowid-addressed chunks
+
+## Problem
+
+The one-shot attribution backfill (`backfillAttributionChunk`) processed up to
+`limit` DISTINCT `(session_id, project_path, model)` triples per chunk, running
+one `UPDATE token_events SET attribution_key = ? WHERE attribution_key =
+<sentinel> AND session_id = ? AND project_path IS ? AND model IS ?` per triple.
+
+Each such UPDATE uses the `(attribution_key, ts)` index to reach the sentinel
+partition, then filters by session/project/model — so it touches the WHOLE
+sentinel partition. With 100 triples per chunk that is O(100 × sentinel_size).
+On Echo's real ledger (202MB, 389,621 sentinel rows) each 100-triple chunk took
+**~23 seconds** of synchronous `better_sqlite3` work.
+
+The #534 fix moved this off the BOOT path (so it no longer bricks startup), but a
+23s synchronous chunk still blocks the Node event loop in a burst whenever it
+runs. On an agent whose LIVE ledger is large and sentinel-heavy, the background
+drain would freeze health checks / request handling for ~23s at a time until the
+one-time drain completed.
+
+## Design
+
+Make each chunk O(rows), independent of ledger size:
+
+- Select up to `limit` individual still-sentinel ROWS, addressed by `rowid`:
+  `SELECT rowid, session_id, project_path, model FROM token_events WHERE
+  attribution_key = <sentinel> LIMIT @limit`.
+- Resolve each row's key (same `resolveAttribution`) and update it by its integer
+  primary key: `UPDATE token_events SET attribution_key = ? WHERE rowid = ?` — an
+  O(1) point update.
+- `limit` now bounds ROWS, not distinct triples. The chunk constant is raised to
+  2000 rows (each chunk ~5–72ms even on a 202MB ledger).
+
+Two rows of the same triple resolve to the same key, so the END STATE is
+identical to the old triple-batched approach — only the work-per-chunk and its
+shape change. Termination is unchanged: an empty SELECT (or a batch that moves
+nothing off the sentinel — the documented acceptable worst case) sets the
+completion marker and reports `done`. The marker key/value is unchanged, so an
+agent that already completed the backfill never re-runs, and one interrupted
+mid-drain resumes from the remaining sentinel rows.
+
+## Convergence notes (adversarial self-review)
+
+- *Same end state?* Yes — `resolveAttribution` is a pure function of
+  (session, project, model); per-row resolution yields the same key for every
+  row of a triple. Unit test asserts all rows of a multi-row triple collapse to
+  one key with the correct `eventCount`.
+- *Termination?* `resolveAttribution` never returns the sentinel, so every
+  selected row converts → progress every chunk → SELECT eventually returns 0 →
+  marker set. The "no progress → finalize" guard remains as defense.
+- *Could a huge `limit` reintroduce a long burst?* The constant (2000) is chosen
+  so each chunk is well under any health-timeout; the value is the only tunable.
+- *Index dependency?* The SELECT relies on the existing `(attribution_key, ts)`
+  index to reach the sentinel partition cheaply; that index already exists.
+
+## Testing
+
+- **Unit** (`tests/unit/burn-attribution-wiring.test.ts`): new test proves the
+  chunk bounds by ROWS not triples (a single triple with 5 rows converts 2 at
+  `limit=2`, not all 5 — which the old DISTINCT-triple design would have done),
+  drains fully, and all 5 rows collapse to one resolved key with `eventCount` 5.
+  Existing chunk/async/idempotency tests still pass (their seed is 1 row per
+  triple, so rows == triples).
+- **At-scale (manual, on the real artifact)**: drove the rowid backfill over a
+  copy of Echo's real 202MB / 389,621-sentinel-row ledger — full drain 14s total
+  (vs the old design's ~23s for a single 100-triple chunk), ~5ms per 1000 rows,
+  0 sentinel rows remaining.
+
+## Migration parity
+
+Server-internal monitoring code, not an agent-installed file — no
+PostUpdateMigrator entry required. Marker key/value unchanged.

--- a/src/monitoring/TokenLedger.ts
+++ b/src/monitoring/TokenLedger.ts
@@ -23,8 +23,8 @@ import { resolveAttribution, PRE_ATTRIBUTION_KEY } from './AttributionResolver.j
 
 /** ledger_meta marker key — set exactly once when the attribution backfill is complete. */
 const ATTRIBUTION_BACKFILL_MARKER = 'attribution-backfill-v1';
-/** Distinct (session, project, model) triples processed per backfill chunk. Bounds each write transaction. */
-const ATTRIBUTION_BACKFILL_CHUNK = 100;
+/** Rows processed per backfill chunk (rowid-addressed UPDATEs). Bounds each write transaction; ~5ms/1000 rows even on a 202MB ledger. */
+const ATTRIBUTION_BACKFILL_CHUNK = 2000;
 /** Delay between background backfill chunks — yields the event loop so /health + requests aren't blocked. */
 const ATTRIBUTION_BACKFILL_TICK_MS = 200;
 /** Give up the background backfill after this many consecutive chunk failures (rows stay on the sentinel). */
@@ -449,13 +449,23 @@ export class TokenLedger {
   }
 
   /**
-   * Process up to `limit` distinct still-sentinel (session, project, model)
-   * triples, committing per chunk so progress survives a restart. Returns
-   * done=true once the completion marker is set — either no sentinel rows remain
-   * or this batch could move none off the sentinel (the remaining rows stay
-   * unattributed, the documented acceptable worst case, and are exempt from burn
-   * alerts). Bounded + committable so it can be driven incrementally off the
-   * event loop without a multi-minute write transaction blocking the process.
+   * Process up to `limit` still-sentinel ROWS, resolving each to its attribution
+   * key and updating it by rowid (an O(1) integer-primary-key update). Committed
+   * per chunk so progress survives a restart. Returns done=true once the
+   * completion marker is set — either no sentinel rows remain, or this batch
+   * could move none off the sentinel (the documented acceptable worst case;
+   * remaining rows stay unattributed and are exempt from burn alerts).
+   *
+   * Row-scoped (not distinct-triple-scoped) on purpose. The prior design ran one
+   * `UPDATE ... WHERE attribution_key = sentinel AND session/project/model = ...`
+   * per distinct triple, and EACH such UPDATE re-scanned the whole sentinel
+   * partition — O(triples × sentinel_size). On a 202MB / ~390k-sentinel-row
+   * ledger that was ~23s of synchronous work per 100-triple chunk, blocking the
+   * event loop in bursts even though it ran off the boot path. Selecting N rows
+   * and updating each by rowid is O(N) per chunk regardless of ledger size
+   * (~5ms for 1000 rows on that same DB), so no chunk blocks the event loop.
+   * Two rows of the same (session, project, model) triple resolve to the same
+   * key, so the end state is identical to the old triple-batched approach.
    */
   backfillAttributionChunk(
     limit: number = ATTRIBUTION_BACKFILL_CHUNK
@@ -464,59 +474,51 @@ export class TokenLedger {
       return { backfilled: 0, done: true };
     }
 
-    // Distinct (session_id, project_path, model) triples still on the sentinel.
-    const triples = this.db
+    // Up to `limit` individual rows still on the sentinel, addressed by rowid.
+    const rows = this.db
       .prepare(
-        `SELECT DISTINCT session_id AS sessionId, project_path AS projectPath, model AS model
+        `SELECT rowid AS rid, session_id AS sessionId, project_path AS projectPath, model AS model
            FROM token_events
           WHERE attribution_key = ?
           LIMIT ?`
       )
       .all(PRE_ATTRIBUTION_KEY, limit) as Array<{
+        rid: number | bigint;
         sessionId: string;
         projectPath: string | null;
         model: string | null;
       }>;
 
-    if (triples.length === 0) {
+    if (rows.length === 0) {
       this.setMeta(ATTRIBUTION_BACKFILL_MARKER, new Date().toISOString());
       return { backfilled: 0, done: true };
     }
 
     const update = this.db.prepare(
-      `UPDATE token_events
-          SET attribution_key = @newKey
-        WHERE attribution_key = @sentinel
-          AND session_id = @sessionId
-          AND (project_path IS @projectPath OR project_path = @projectPath)
-          AND (model IS @model OR model = @model)`
+      `UPDATE token_events SET attribution_key = @newKey WHERE rowid = @rid`
     );
 
     let backfilled = 0;
     const run = this.db.transaction(() => {
-      for (const t of triples) {
+      for (const r of rows) {
         const newKey = resolveAttribution({
-          sessionId: t.sessionId,
-          projectPath: t.projectPath,
+          sessionId: r.sessionId,
+          projectPath: r.projectPath,
           prompt: null,
-          model: t.model,
+          model: r.model,
         });
-        // resolveAttribution never returns the sentinel, but guard anyway.
+        // resolveAttribution never returns the sentinel, but guard anyway so an
+        // unconvertible row can't be rewritten to the same sentinel (which would
+        // let it be re-selected forever).
         if (newKey === PRE_ATTRIBUTION_KEY) continue;
-        const res = update.run({
-          newKey,
-          sentinel: PRE_ATTRIBUTION_KEY,
-          sessionId: t.sessionId,
-          projectPath: t.projectPath,
-          model: t.model,
-        });
+        const res = update.run({ newKey, rid: r.rid });
         backfilled += res.changes;
       }
     });
     run();
 
-    // No row could be moved off the sentinel this batch (every triple resolved
-    // back to the sentinel). Re-selecting them would loop forever, so finalize.
+    // No row could be moved off the sentinel this batch (every row resolved back
+    // to the sentinel). Re-selecting them would loop forever, so finalize.
     if (backfilled === 0) {
       this.setMeta(ATTRIBUTION_BACKFILL_MARKER, new Date().toISOString());
       return { backfilled: 0, done: true };

--- a/tests/unit/burn-attribution-wiring.test.ts
+++ b/tests/unit/burn-attribution-wiring.test.ts
@@ -269,7 +269,7 @@ describe('TokenLedger.backfillAttributionOnce — converts legacy sentinel rows,
     // 'off' → no auto-run; we drive chunks explicitly and assert bounding.
     const led = new TokenLedger({ dbPath, claudeProjectsDir: tmp, attributionBackfill: 'off' });
     const c1 = led.backfillAttributionChunk(2);
-    expect(c1.backfilled).toBe(2); // 2 distinct triples × 1 row each
+    expect(c1.backfilled).toBe(2); // 2 rows (here: 1 per distinct session)
     expect(c1.done).toBe(false);
     led.backfillAttributionChunk(2); // 2 more
     led.backfillAttributionChunk(2); // last 2
@@ -281,6 +281,42 @@ describe('TokenLedger.backfillAttributionOnce — converts legacy sentinel rows,
     ).toBeUndefined();
     // Marker is set → a further explicit full drain is a no-op.
     expect(led.backfillAttributionOnce().alreadyDone).toBe(true);
+    led.close();
+  });
+
+  it('bounds by ROWS not distinct triples (rowid-addressed; multi-row triple)', () => {
+    // One session (one (session,project,model) triple) with 5 sentinel rows.
+    // The rowid-based chunk bounds by ROWS: chunk(2) converts 2 of the 5 — NOT
+    // "the whole triple at once" (the old DISTINCT-triple design would convert
+    // all 5 for limit=2, since it counted triples). All 5 still resolve to the
+    // SAME key (same triple), so the end state is identical to the old design.
+    const seed = new TokenLedger({ dbPath, claudeProjectsDir: tmp, attributionBackfill: 'sync' });
+    for (let i = 0; i < 5; i++) {
+      seed.recordEvent({
+        requestId: `multi-${i}`, sessionId: 'sessMULTI0000', ts: 2000 + i,
+        inputTokens: 1, outputTokens: 1, attributionKey: PRE_ATTRIBUTION_KEY,
+      });
+    }
+    seed.close();
+    const raw = new Database(dbPath);
+    raw.prepare(`DELETE FROM ledger_meta WHERE key = 'attribution-backfill-v1'`).run();
+    raw.close();
+
+    const led = new TokenLedger({ dbPath, claudeProjectsDir: tmp, attributionBackfill: 'off' });
+    const c1 = led.backfillAttributionChunk(2);
+    expect(c1.backfilled).toBe(2); // 2 ROWS of the single triple — not all 5
+    expect(c1.done).toBe(false);
+
+    // Drain the remaining rows.
+    let guard = 0;
+    while (!led.backfillAttributionChunk(2).done && ++guard < 20) { /* keep draining */ }
+
+    const rows = led.byAttributionKey({ sinceMs: 0 });
+    expect(rows.find((r) => r.attributionKey === PRE_ATTRIBUTION_KEY)).toBeUndefined();
+    // All 5 rows collapsed to ONE resolved key with eventCount 5 (same triple).
+    const resolved = rows.filter((r) => r.attributionKey !== PRE_ATTRIBUTION_KEY);
+    expect(resolved.length).toBe(1);
+    expect(resolved[0].eventCount).toBe(5);
     led.close();
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,47 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Token-ledger attribution backfill is now fast and never blocks the event
+loop.** The one-time backfill that re-labels legacy "unknown" token rows used to
+work one distinct (session, project, model) group at a time, and each group's
+UPDATE re-scanned the whole unknown-row partition — on a very large ledger
+(Echo's real one: 202 MB / ~390k unknown rows) that was ~23 seconds of
+synchronous database work per batch. The boot fix had already moved this off the
+startup path (so it couldn't brick boot), but a 23s batch could still freeze a
+large-ledger agent's health checks while it ran in the background.
+
+The backfill now works row-by-row, updating each row by its internal id (an
+instant point update) instead of re-scanning per group. Same end result (every
+row gets the same label it would have before), but each batch is ~5 ms per 1,000
+rows instead of 23 s — so the background re-labeling never freezes the agent.
+Measured on the real 202 MB ledger: all ~390k rows re-labeled in ~14 s total, in
+tiny non-blocking steps.
+
+## What to Tell Your User
+
+Nothing to configure. If you run an agent with a very large token-usage history,
+its one-time usage re-labeling now runs quietly in the background without any
+freezes. Most agents won't notice anything — this completes the performance
+story of the recent token-ledger boot fix.
+
+## Summary of New Capabilities
+
+- Attribution backfill processes rows in `rowid`-addressed batches (O(1) per
+  row) instead of per-distinct-triple full scans — no event-loop-blocking bursts
+  on large ledgers.
+- `ATTRIBUTION_BACKFILL_CHUNK` now bounds rows per chunk (2000), tuned so each
+  chunk stays well under any health-check timeout.
+
+## Evidence
+
+- `tests/unit/burn-attribution-wiring.test.ts` — new test: the chunk bounds by
+  ROWS not distinct triples (a single triple with 5 rows converts 2 at limit=2,
+  not all 5), drains fully, and all 5 rows collapse to one resolved key with
+  eventCount 5. Existing chunk/async/idempotency tests still pass.
+- Manual at-scale run on a copy of Echo's real 202 MB / 389,621-sentinel-row
+  ledger: full drain 14 s total (vs the old design's ~23 s for a single
+  100-triple chunk), ~5 ms per 1,000 rows, 0 sentinel rows remaining.
+- Side-effects: `upgrades/side-effects/tokenledger-backfill-rowid.md`.

--- a/upgrades/side-effects/tokenledger-backfill-rowid.md
+++ b/upgrades/side-effects/tokenledger-backfill-rowid.md
@@ -1,0 +1,65 @@
+# Side-effects review — TokenLedger rowid-addressed backfill chunk
+
+**Spec:** `docs/specs/TOKENLEDGER-BACKFILL-ROWID-SPEC.md`
+**Change:** `src/monitoring/TokenLedger.ts` (+ unit test)
+**Class:** performance fix — eliminates per-chunk event-loop blocking in the
+one-shot attribution backfill (completes the #534 boot-fix work).
+
+## What changed
+
+`backfillAttributionChunk(limit)` rewritten from DISTINCT-triple-scoped to
+ROW-scoped:
+
+- Was: `SELECT DISTINCT session_id, project_path, model ... LIMIT limit` then one
+  `UPDATE ... WHERE attribution_key = sentinel AND session/project/model = ...`
+  per triple (each UPDATE O(sentinel_size)).
+- Now: `SELECT rowid, session_id, project_path, model ... LIMIT limit` then one
+  `UPDATE ... WHERE rowid = ?` per row (O(1) per row).
+
+`ATTRIBUTION_BACKFILL_CHUNK` raised 100 → 2000 (now ROWS, not triples).
+
+## Blast radius
+
+- **`backfillAttributionOnce()` / async driver**: unchanged signatures and
+  return shapes (`{ backfilled, done }`, `{ backfilled, alreadyDone }`). Same
+  marker key/value (`attribution-backfill-v1`) → already-complete agents never
+  re-run; interrupted agents resume.
+- **End state**: identical — every sentinel row receives the same resolved key it
+  would have under the old triple-batched code (resolver is a pure function of
+  the triple).
+- **`limit` semantics**: changes from "distinct triples" to "rows". Only callers
+  are the async driver, `backfillAttributionOnce`, and tests. Tests that pass an
+  explicit `limit` with 1 row per triple are unaffected (rows == triples there).
+- **Public API / schema / config**: none changed.
+
+## What could break (and why it doesn't)
+
+- **A caller relying on `backfilled` meaning "triples"?** None exists — it always
+  meant "rows changed" (`res.changes`), and still does.
+- **Index dependency**: the SELECT uses the existing `(attribution_key, ts)`
+  index to reach the sentinel partition; no new index required.
+- **Long burst from a big `limit`?** 2000 rows = ~5ms (measured on a 202MB
+  ledger); far under any health-timeout. `limit` is the only tunable.
+
+## Security
+
+No new external input, network, auth, or filesystem surface. Pure change to an
+internal SQLite maintenance query.
+
+## Migration parity
+
+Server-internal monitoring code, not an agent-installed file — no
+PostUpdateMigrator entry required.
+
+## Rollback
+
+Revert the commit. Marker key/value unchanged; a rolled-back agent mid-drain or
+complete is consistent under the prior code.
+
+## Tests
+
+Unit (`burn-attribution-wiring`, `token-ledger`) + integration
+(`tokens-503-regression`) — 38 green; `tsc --noEmit` clean. New row-granular
+regression test (bounds by rows; multi-row triple collapses to one key).
+Manual at-scale run on the real 202MB / 389,621-row ledger: full drain 14s,
+0 sentinel rows after.


### PR DESCRIPTION
## Problem

The one-shot attribution backfill (`backfillAttributionChunk`) processed up to `limit` DISTINCT `(session_id, project_path, model)` triples per chunk, running one `UPDATE token_events SET attribution_key=? WHERE attribution_key=<sentinel> AND session_id=? AND project_path IS ? AND model IS ?` per triple. Each such UPDATE reaches the sentinel partition via the `(attribution_key, ts)` index then filters — i.e. it touches the **whole sentinel partition**, so a chunk is O(triples × sentinel_size).

On Echo's real ledger (**202MB, 389,621 sentinel rows**) each 100-triple chunk took **~23 seconds** of synchronous `better_sqlite3` work. #534 moved the backfill off the **boot** path (so it can't brick startup), but a 23s synchronous chunk still **blocks the Node event loop** in a burst whenever it runs — so a large-live-ledger agent's background drain would freeze health checks ~23s at a time until the one-time drain finished.

## Fix

Make each chunk **O(rows)**, independent of ledger size:

- `SELECT rowid, session_id, project_path, model FROM token_events WHERE attribution_key=<sentinel> LIMIT @limit`
- resolve each row's key (same `resolveAttribution`) and `UPDATE ... SET attribution_key=? WHERE rowid=?` — an O(1) point update.
- `limit` now bounds **rows** (not distinct triples); `ATTRIBUTION_BACKFILL_CHUNK` 100 → 2000.

Two rows of the same triple resolve to the same key, so the **end state is identical** to the old triple-batched approach. Marker key/value unchanged (done agents never re-run; interrupted agents resume).

## Verification (on the real artifact)

Drove the rowid backfill over a copy of Echo's real **202MB / 389,621-sentinel-row** ledger:
- **Full drain: 14s total** (vs the old design's ~23s for a *single* 100-triple chunk)
- **~5ms per 1000 rows / ~8ms per 2000** (so each async chunk ≈ tens of ms — never blocks the event loop)
- **0 sentinel rows remaining**, `backfilled == sentinelBefore` (all 389,621 converted)

## Tests

New row-granular regression in `tests/unit/burn-attribution-wiring.test.ts`: proves the chunk bounds by **rows not distinct triples** (a single triple with 5 rows converts 2 at `limit=2`, not all 5 — which the old DISTINCT-triple design would have done), drains fully, and all 5 rows collapse to **one** resolved key with `eventCount` 5. Existing chunk/async/idempotency + 503-regression tests still pass. 38 green; `tsc --noEmit` clean.

Spec: `docs/specs/TOKENLEDGER-BACKFILL-ROWID-SPEC.md` (+ ELI16 + side-effects artifact). Completes the performance story of the #534 boot-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)