### PR TITLE
fix(self-heal): CI green-up for the better-sqlite3 ABI heal (lint + stale test)

### DIFF
--- a/src/lifeline/ServerSupervisor.ts
+++ b/src/lifeline/ServerSupervisor.ts
@@ -827,7 +827,7 @@ export class ServerSupervisor extends EventEmitter {
             lastErr = (r.stderr || '').slice(-200);
           }
           if (rebuilt) {
-            try { if (hasBackup) fs.unlinkSync(backupPath); } catch { /* ignore */ }
+            try { if (hasBackup) SafeFsExecutor.safeUnlinkSync(backupPath, { operation: 'ServerSupervisor.preflight:bsq-backup-cleanup' }); } catch { /* ignore */ }
             healed.push(`better-sqlite3 rebuilt at ${path.relative(this.stateDir, copy.packageDir)}`);
             console.log(`[Supervisor] Preflight: better-sqlite3 rebuilt and verified at ${copy.packageDir}`);
           } else {
@@ -835,7 +835,7 @@ export class ServerSupervisor extends EventEmitter {
             // module that crashes subsystem init.
             let restored = false;
             try {
-              if (hasBackup) { fs.copyFileSync(backupPath, copy.binaryPath); fs.unlinkSync(backupPath); restored = true; }
+              if (hasBackup) { fs.copyFileSync(backupPath, copy.binaryPath); SafeFsExecutor.safeUnlinkSync(backupPath, { operation: 'ServerSupervisor.preflight:bsq-backup-restore' }); restored = true; }
             } catch { /* ignore */ }
             console.error(`[Supervisor] Preflight: better-sqlite3 rebuild could not produce a loadable module at ${copy.packageDir}${restored ? ' — restored prior binary (sqlite stays degraded, not bricked)' : ''}: ${lastErr}`);
           }

--- a/tests/unit/lifeline/version-skew-recovery.test.ts
+++ b/tests/unit/lifeline/version-skew-recovery.test.ts
@@ -61,38 +61,33 @@ describe('Version-skew recovery — CLI service label', () => {
   });
 });
 
-describe('Version-skew recovery — native rebuild uses --build-from-source', () => {
-  it('ServerSupervisor preflight rebuild passes --build-from-source', () => {
+describe('Version-skew recovery — native rebuild is ABI-pinned + prebuilt-first', () => {
+  // Updated 2026-05-29 (PR #539): the rebuild no longer uses --build-from-source
+  // as the ONLY strategy. `npm rebuild` always node-gyp-compiles and can't fetch
+  // a prebuilt, so on a box without a C++ toolchain it can never heal (it left
+  // instar-codey's sqlite offline 16h). Both paths now PIN the toolchain to the
+  // server/running Node (correct ABI regardless of PATH) and PREFER the prebuilt
+  // (`npm install` → prebuild-install) with --build-from-source as the fallback.
+  it('ServerSupervisor preflight rebuild pins the server Node and prefers the prebuilt', () => {
     const src = fs.readFileSync(
       path.join(repoRoot, 'src', 'lifeline', 'ServerSupervisor.ts'),
       'utf-8',
     );
-    // Find the rebuildArgs assignment used for the better-sqlite3 rebuild.
-    const rebuildArgsLine = src.match(/const\s+rebuildArgs\s*=\s*\[([\s\S]*?)\]/);
-    expect(rebuildArgsLine).toBeTruthy();
-    const body = rebuildArgsLine?.[1] ?? '';
-    expect(body).toMatch(/'--build-from-source'/);
-    expect(body).toMatch(/'--ignore-scripts'/);
-    expect(body).toMatch(/'better-sqlite3'/);
+    expect(src).toMatch(/npm_node_execpath/);            // toolchain pinned to the server Node
+    expect(src).toMatch(/'install'/);                    // prebuilt-first (prebuild-install)
+    expect(src).toMatch(/'--build-from-source'/);        // compile fallback retained
+    expect(src).toMatch(/'--ignore-scripts'/);
+    expect(src).toMatch(/'better-sqlite3'/);
   });
 
-  it('NativeModuleHealer in-line rebuild passes --build-from-source', () => {
+  it('NativeModuleHealer in-line rebuild pins the running Node and prefers the prebuilt', () => {
     const src = fs.readFileSync(
       path.join(repoRoot, 'src', 'memory', 'NativeModuleHealer.ts'),
       'utf-8',
     );
-    // The in-line healBetterSqlite3Sync path used to be the one that
-    // missed the flag (the Remediator-orchestrated path already had it).
-    // Make sure BOTH paths now use --build-from-source. We assert that
-    // every spawnSync that targets `npm rebuild ... better-sqlite3` in
-    // this file includes the flag.
-    const rebuildSpawns = [...src.matchAll(/spawnSync\(\s*[^,]+,\s*\[\s*([^\]]+)\]/g)]
-      .map(m => m[1])
-      .filter(args => args.includes("'rebuild'") && args.includes("'better-sqlite3'"));
-    expect(rebuildSpawns.length).toBeGreaterThan(0);
-    for (const args of rebuildSpawns) {
-      expect(args).toMatch(/'--build-from-source'/);
-    }
+    expect(src).toMatch(/npm_node_execpath/);            // toolchain pinned to the running Node
+    expect(src).toMatch(/'install'/);                    // prebuilt-first
+    expect(src).toMatch(/'--build-from-source'/);        // compile fallback retained
   });
 });
 

--- a/tests/unit/server-supervisor-preflight.test.ts
+++ b/tests/unit/server-supervisor-preflight.test.ts
@@ -255,7 +255,7 @@ describe('ServerSupervisor preflight self-heal', () => {
     // from-source attempt DELETES the binary (the real footgun) to prove the
     // restore brings it back.
     mockAbiMismatch(/*failVerify*/ true, (a) => {
-      if (a.includes('--build-from-source')) { try { fs.unlinkSync(binaryPath); } catch { /* ignore */ } }
+      if (a.includes('--build-from-source')) { try { SafeFsExecutor.safeUnlinkSync(binaryPath, { operation: 'test:simulate-bsq-delete' }); } catch { /* ignore */ } }
     });
 
     (supervisor as any).preflightSelfHeal();

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,33 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Internal compliance + test correctness for the better-sqlite3 self-heal fix
+(shipped functionally in v1.3.100).** No user-facing behavior change. Two
+non-functional CI items from the previous cut are corrected: the self-heal's
+binary backup/restore now uses `SafeFsExecutor.safeUnlinkSync` (destructive-tool
+containment) instead of a direct `fs.unlinkSync`, and a stale source-text test
+that asserted the rebuild "only uses --build-from-source" is updated to the new
+ABI-pinned, prebuilt-first invariants (with `--build-from-source` retained as the
+compile fallback).
+
+## What to Tell Your User
+
+Nothing to do. This is a code-hygiene + test follow-up to the SQLite self-heal
+fix that already shipped — it does not change how your agent behaves.
+
+## Summary of New Capabilities
+
+- (none) — compliance + test correctness only. The native-module self-heal
+  behavior is unchanged from v1.3.100.
+
+## Evidence
+
+- `npm run lint` clean (destructive-tool-containment passes).
+- `tests/unit/lifeline/version-skew-recovery.test.ts` updated to assert
+  ABI-pinned + prebuilt-first; `tests/unit/server-supervisor-preflight.test.ts`
+  + `tests/unit/NativeModuleHealer.test.ts` green. 52 tests across the affected
+  files pass; `tsc --noEmit` clean.
+- Side-effects: `upgrades/side-effects/native-module-heal-abi-correct.md` (Fix-forward note).

--- a/upgrades/side-effects/native-module-heal-abi-correct.md
+++ b/upgrades/side-effects/native-module-heal-abi-correct.md
@@ -39,3 +39,17 @@ Revert the commit. No persisted state or schema affected; the load-test gate is 
 ## Tests
 
 `tests/unit/server-supervisor-preflight.test.ts` (+3: PATH-pin, prebuilt-first, restore-on-failure) and `tests/unit/NativeModuleHealer.test.ts` (+1: prebuilt-first + PATH-pin). 32 tests across the two files green; existing 37 healer tests + preflight tests still pass; `tsc --noEmit` clean. At-scale: `npm install better-sqlite3@12.10.0` (PATH-pinned) fetched the ABI-141 prebuilt in ~2s on the affected box.
+
+## Fix-forward note (CI green-up)
+
+The first cut of this change (shipped functionally in v1.3.100) tripped two CI
+checks that are non-functional: (1) the destructive-tool-containment lint —
+the backup cleanup/restore used direct `fs.unlinkSync` instead of
+`SafeFsExecutor.safeUnlinkSync`; and (2) a stale source-text test
+(`version-skew-recovery.test.ts`) that asserted the rebuild "uses
+--build-from-source" as its only strategy — the exact policy this change
+replaces with prebuilt-first. This follow-up swaps the `fs.unlinkSync` calls for
+`SafeFsExecutor.safeUnlinkSync` and updates that test to assert the new
+invariants (ABI-pinned + prebuilt-first, with `--build-from-source` retained as
+the compile fallback). Pure compliance/test correctness — no runtime behavior
+change beyond what v1.3.100 already shipped.


### PR DESCRIPTION
Follow-up to **v1.3.100 / #539** (the better-sqlite3 ABI self-heal fix), which shipped **functionally correct** but tripped two **non-functional** CI checks. This makes main's CI green again — no runtime behavior change beyond v1.3.100.

## What was red

1. **Destructive-tool-containment lint** (Type Check job): the new backup cleanup/restore used direct `fs.unlinkSync` → now `SafeFsExecutor.safeUnlinkSync`.
2. **Stale source-text test** (`tests/unit/lifeline/version-skew-recovery.test.ts`, unit shard 3/4): it asserted the rebuild "uses `--build-from-source`" as its *only* strategy — the exact policy #539 deliberately replaces with **prebuilt-first**. Updated to assert the new invariants: toolchain pinned to the server/running Node (`npm_node_execpath`) + prebuilt-first (`npm install`), with `--build-from-source` retained as the compile fallback.

## Verification

- `npm run lint` clean.
- 52 tests across `version-skew-recovery` + `server-supervisor-preflight` + `NativeModuleHealer` + `NativeModuleHealer-invokeFromRemediator` pass; `tsc --noEmit` clean.

Spec: `docs/specs/NATIVE-MODULE-HEAL-ABI-CORRECT-SPEC.md` (Fix-forward note in the side-effects artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)