### PR TITLE
fix(hooks,scripts): survive secret-externalization across the fleet

### DIFF
--- a/scripts/threadline-bridge-backfill.mjs
+++ b/scripts/threadline-bridge-backfill.mjs
@@ -192,10 +192,16 @@ function parseArgs(argv) {
 }
 
 function readAuthToken() {
+  // INSTAR_AUTH_TOKEN env first — survives the secret-externalization refactor
+  // that moved authToken out of config.json into the encrypted store. Legacy
+  // plaintext-config fallback uses a string-type guard so the
+  // { "secret": true } placeholder produced by SecretMigrator never leaks
+  // through as a bogus Bearer.
+  if (process.env.INSTAR_AUTH_TOKEN) return process.env.INSTAR_AUTH_TOKEN;
   try {
     const raw = fs.readFileSync(path.join(STATE_DIR, 'config.json'), 'utf-8');
     const cfg = JSON.parse(raw);
-    return cfg.authToken ?? '';
+    return typeof cfg.authToken === 'string' ? cfg.authToken : '';
   } catch { return ''; }
 }
 

--- a/src/commands/gate.ts
+++ b/src/commands/gate.ts
@@ -23,9 +23,16 @@ type GateMode = 'off' | 'shadow' | 'enforce';
 
 function readConfig(stateDir: string): { port: number; authToken: string } {
   const cfg = JSON.parse(fs.readFileSync(path.join(stateDir, 'config.json'), 'utf-8'));
+  // INSTAR_AUTH_TOKEN env first — survives the secret-externalization refactor
+  // that moves authToken out of config.json into the encrypted store. Falls
+  // back to the plaintext config field only when it's still a string (the
+  // { secret: true } placeholder is rejected so the bogus value never reaches
+  // a Bearer header). Note: this CLI command runs out-of-process from the
+  // server so it can't use loadConfig() — it needs explicit handling here.
+  const tokenFromConfig = typeof cfg.authToken === 'string' ? cfg.authToken : '';
   return {
     port: cfg.port ?? 4042,
-    authToken: cfg.authToken ?? '',
+    authToken: process.env.INSTAR_AUTH_TOKEN || tokenFromConfig,
   };
 }
 

--- a/src/commands/nuke.ts
+++ b/src/commands/nuke.ts
@@ -190,12 +190,17 @@ export async function nukeAgent(name: string, options: NukeOptions = {}): Promis
 
     const telegramEntry = config.messaging?.find((m: { type: string }) => m.type === 'telegram');
     if (telegramEntry?.config) {
+      // String-type guards reject the { secret: true } placeholder produced by
+      // SecretMigrator after multi-machine pairing — the real values are already
+      // in the encrypted store in that case, so backing up the placeholder
+      // would silently corrupt the backup.
+      const asStr = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
       secretMgr.backupFromConfig({
-        telegramToken: telegramEntry.config.token,
-        telegramChatId: telegramEntry.config.chatId,
-        authToken: config.authToken,
-        dashboardPin: config.dashboardPin,
-        tunnelToken: config.tunnel?.token,
+        telegramToken: asStr(telegramEntry.config.token),
+        telegramChatId: asStr(telegramEntry.config.chatId),
+        authToken: asStr(config.authToken),
+        dashboardPin: asStr(config.dashboardPin),
+        tunnelToken: asStr(config.tunnel?.token),
       });
       console.log(`  ${pc.green('✓')} Secrets backed up (will auto-restore on reinstall)`);
     }
@@ -369,12 +374,16 @@ export async function nukeHere(options: NukeHereOptions = {}): Promise<void> {
       (m: { type: string }) => m.type === 'telegram',
     );
     if (telegramEntry?.config) {
+      // Same string-guard treatment as the in-place backup above — reject the
+      // { secret: true } placeholder so the backup never re-saves the marker
+      // instead of the real value.
+      const asStr = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
       secretMgr.backupFromConfig({
-        telegramToken: telegramEntry.config.token,
-        telegramChatId: telegramEntry.config.chatId,
-        authToken: config.authToken,
-        dashboardPin: config.dashboardPin,
-        tunnelToken: config.tunnel?.token,
+        telegramToken: asStr(telegramEntry.config.token),
+        telegramChatId: asStr(telegramEntry.config.chatId),
+        authToken: asStr(config.authToken),
+        dashboardPin: asStr(config.dashboardPin),
+        tunnelToken: asStr(config.tunnel?.token),
       });
       console.log(`  ${pc.green('✓')} Secrets backed up`);
     }

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -203,6 +203,7 @@ export class PostUpdateMigrator {
     this.migrateClaudeMd(result);
     this.migrateFrameworkShadowCapabilities(result);
     this.migrateScripts(result);
+    this.migrateSecretExternalizationSurvivability(result);
     this.migrateSettings(result);
     this.migrateConfig(result);
     this.migrateLegacyMaxSessions(result);
@@ -3835,6 +3836,95 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
   }
 
   /**
+   * Secret-externalization survivability migration.
+   *
+   * On first multi-machine pairing, `SecretMigrator` moves authToken out of
+   * plaintext config.json into the encrypted secret store and replaces the
+   * on-disk field with the literal `{ "secret": true }` placeholder. Any
+   * shipped script that reads authToken directly from config.json then sends
+   * the placeholder as a Bearer token and the server returns 403 silently —
+   * the script just emits nothing. This caused the 2026-05-29 incident where
+   * the telegram topic-history injection hook stopped firing and the agent
+   * came back from compaction with no idea what the user had been saying.
+   *
+   * The canonical hook scripts (session-start.sh, compaction-recovery.sh,
+   * telegram-topic-context.sh) are always-overwritten by the existing
+   * `migrateHooks()` path, so this method only addresses the auxiliary
+   * shipped scripts that aren't on the always-overwrite track: the messaging
+   * channel-context hook (slack-channel-context.sh), the iMessage reply
+   * script, and the serendipity-capture helper. Telegram/Slack/WhatsApp
+   * reply scripts have their own SHA-based migrators that already detect
+   * stale auth-handling via the extended-marker check in
+   * `migrateReplyScriptTo408()`.
+   *
+   * The detection is structural: the file is upgraded iff
+   *   1. it exists at the expected path,
+   *   2. it contains the shipped header marker (so we don't touch custom
+   *      forks),
+   *   3. AND it does NOT contain `INSTAR_AUTH_TOKEN` (the env-first canary
+   *      that proves the new resolver pattern is in place).
+   *
+   * Idempotent: re-running after the upgrade finds (3) violated, so it
+   * skips silently.
+   */
+  private migrateSecretExternalizationSurvivability(result: MigrationResult): void {
+    type Target = {
+      relPath: string;
+      templateDir: 'scripts' | 'hooks';
+      templateFilename: string;
+      shippedMarker: string;
+      label: string;
+    };
+    const targets: Target[] = [
+      {
+        relPath: path.join(this.config.stateDir, 'scripts', 'imessage-reply.sh'),
+        templateDir: 'scripts',
+        templateFilename: 'imessage-reply.sh',
+        // First-line shipped marker — present in every shipped version, so it
+        // identifies our copies without touching custom forks.
+        shippedMarker: '# imessage-reply.sh',
+        label: 'scripts/imessage-reply.sh',
+      },
+      {
+        relPath: path.join(this.config.stateDir, 'scripts', 'serendipity-capture.sh'),
+        templateDir: 'scripts',
+        templateFilename: 'serendipity-capture.sh',
+        shippedMarker: 'serendipity-capture.sh',
+        label: 'scripts/serendipity-capture.sh',
+      },
+      {
+        relPath: path.join(this.config.projectDir, '.claude', 'hooks', 'instar', 'slack-channel-context.sh'),
+        templateDir: 'hooks',
+        templateFilename: 'slack-channel-context.sh',
+        shippedMarker: 'slack-channel-context.sh',
+        label: '.claude/hooks/instar/slack-channel-context.sh',
+      },
+    ];
+
+    for (const target of targets) {
+      if (!fs.existsSync(target.relPath)) continue;
+      try {
+        const existing = fs.readFileSync(target.relPath, 'utf-8');
+        const looksShipped = existing.includes(target.shippedMarker);
+        const hasAuthEnvHandling = existing.includes('INSTAR_AUTH_TOKEN');
+        if (!looksShipped || hasAuthEnvHandling) {
+          // Skip custom forks and already-current installs.
+          continue;
+        }
+        const template = this.loadTemplate(target.templateDir, target.templateFilename);
+        if (!template) {
+          result.errors.push(`${target.label}: template file not found`);
+          continue;
+        }
+        fs.writeFileSync(target.relPath, template, { mode: 0o755 });
+        result.upgraded.push(`${target.label} (auth-env-first; secret-externalization survivability)`);
+      } catch (err) {
+        result.errors.push(`${target.label}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
+  /**
    * Ensure .claude/settings.json has required MCP servers and correct hook wiring.
    * Migrates legacy PostToolUse/Notification hooks to proper SessionStart type.
    */
@@ -4974,7 +5064,7 @@ if [ -n "\$INSTAR_TELEGRAM_TOPIC" ]; then
   TOPIC_ID="\$INSTAR_TELEGRAM_TOPIC"
   CONFIG_FILE="$INSTAR_DIR/config.json"
   if [ -f "\$CONFIG_FILE" ]; then
-    PORT=\$(grep -o '"port":[0-9]*' "\$CONFIG_FILE" | head -1 | cut -d':' -f2)
+    PORT=\$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "\$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
     if [ -n "\$PORT" ]; then
       TOPIC_CTX=\$(curl -s "http://localhost:\${PORT}/topic/context/\${TOPIC_ID}?recent=30" 2>/dev/null)
       if [ -n "\$TOPIC_CTX" ] && echo "\$TOPIC_CTX" | grep -q '"totalMessages"'; then
@@ -5015,8 +5105,12 @@ fi
 # auth failure — endpoint returns 503 when disabled, empty body when enabled
 # but has no entries. Either way we only echo when content is present.
 if [ -f "$INSTAR_DIR/config.json" ]; then
-  PORT=\${PORT:-\$(grep -o '"port":[0-9]*' "$INSTAR_DIR/config.json" | head -1 | cut -d':' -f2)}
-  TOKEN=\$(grep -o '"authToken":"[^"]*"' "$INSTAR_DIR/config.json" | head -1 | sed 's/"authToken":"//;s/"$//')
+  PORT=\${PORT:-\$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$INSTAR_DIR/config.json" | head -1 | grep -oE '[0-9]+' | head -1)}
+  # Env first (set by SessionManager per-session) — survives secret-externalization.
+  # Fallback grep: matches only a plaintext-string authToken. After externalization,
+  # the value is the literal { "secret": true } placeholder which has no "..." form,
+  # so the grep yields empty — we never send a bogus Bearer token.
+  TOKEN="\${INSTAR_AUTH_TOKEN:-\$(grep -o '"authToken":"[^"]*"' "$INSTAR_DIR/config.json" | head -1 | sed 's/"authToken":"//;s/"$//')}"
   if [ -n "\$PORT" ] && [ -n "\$TOKEN" ]; then
     SHARED_STATE=\$(curl -sf -H "Authorization: Bearer \$TOKEN" "http://localhost:\${PORT}/shared-state/render?limit=50" 2>/dev/null)
     if [ -n "\$SHARED_STATE" ]; then
@@ -5227,9 +5321,16 @@ echo "IMPORTANT: To report bugs or request features, use POST /feedback on your 
 # Working Memory — surface relevant knowledge from SemanticMemory + EpisodicMemory
 # Right context at the right moment: query-driven, not a full dump.
 if [ -f "$INSTAR_DIR/config.json" ]; then
-  PORT=\$(grep -o '"port":[0-9]*' "$INSTAR_DIR/config.json" | head -1 | cut -d':' -f2)
+  PORT=\$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$INSTAR_DIR/config.json" | head -1 | grep -oE '[0-9]+' | head -1)
   if [ -n "\$PORT" ]; then
-    AUTH_TOKEN=\$(python3 -c "import json; print(json.load(open('$INSTAR_DIR/config.json')).get('authToken',''))" 2>/dev/null)
+    # Resolve auth token: env first (set by SessionManager for every spawned
+    # session), legacy plaintext-config fallback with string-type guard so the
+    # { "secret": true } placeholder produced by SecretMigrator never leaks
+    # through as a bogus Bearer token.
+    AUTH_TOKEN="\${INSTAR_AUTH_TOKEN:-}"
+    if [ -z "\$AUTH_TOKEN" ]; then
+      AUTH_TOKEN=\$(python3 -c "import json; v=json.load(open('$INSTAR_DIR/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+    fi
     HEALTH=\$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:\${PORT}/health" 2>/dev/null)
     if [ "\$HEALTH" = "200" ]; then
       # Build query from available context signals
@@ -5670,7 +5771,7 @@ if [ ! -f "\$CONFIG_FILE" ]; then
   exit 0
 fi
 
-PORT=\$(grep -o '"port":[0-9]*' "\$CONFIG_FILE" | head -1 | cut -d':' -f2)
+PORT=\$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "\$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
 if [ -z "\$PORT" ]; then
   exit 0
 fi
@@ -5681,8 +5782,20 @@ if [ "\$HEALTH" != "200" ]; then
   exit 0
 fi
 
+# Resolve the auth token. INSTAR_AUTH_TOKEN env first (set by SessionManager and
+# JobScheduler for every spawned session) — survives the secret-externalization
+# refactor that moved authToken out of config.json into the encrypted store.
+# Legacy fallback: read from config.json with a string-type guard. When authToken
+# has been externalized, the value is the literal placeholder { "secret": true } —
+# the guard rejects it and yields empty, so we never send the placeholder as a
+# Bearer token (which the server rejects with 403, silently breaking history
+# injection — the 2026-05-29 incident this fix is for).
+AUTH_TOKEN="\${INSTAR_AUTH_TOKEN:-}"
+if [ -z "\$AUTH_TOKEN" ] && [ -f "\$CONFIG_FILE" ]; then
+  AUTH_TOKEN=\$(python3 -c "import json; v=json.load(open('\$CONFIG_FILE')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+fi
+
 # Fetch recent messages for this topic
-AUTH_TOKEN=\$(python3 -c "import json; print(json.load(open('\$CONFIG_FILE')).get('authToken',''))" 2>/dev/null)
 if [ -n "\$AUTH_TOKEN" ]; then
   RECENT_MSGS=\$(curl -s \\
     -H "Authorization: Bearer \${AUTH_TOKEN}" \\
@@ -5771,7 +5884,7 @@ if [ -n "\$INSTAR_TELEGRAM_TOPIC" ]; then
   TOPIC_ID="\$INSTAR_TELEGRAM_TOPIC"
   CONFIG_FILE="\$INSTAR_DIR/config.json"
   if [ -f "\$CONFIG_FILE" ]; then
-    PORT=\$(grep -o '"port":[0-9]*' "\$CONFIG_FILE" | head -1 | cut -d':' -f2)
+    PORT=\$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "\$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
     if [ -n "\$PORT" ]; then
       TOPIC_CTX=\$(curl -s "http://localhost:\${PORT}/topic/context/\${TOPIC_ID}?recent=20" 2>/dev/null)
       if [ -n "\$TOPIC_CTX" ] && echo "\$TOPIC_CTX" | grep -q '"totalMessages"'; then
@@ -5951,9 +6064,16 @@ echo ""
 # Working Memory — surface relevant knowledge after compaction
 # This restores what you knew before compaction that's relevant now.
 if [ -f "$INSTAR_DIR/config.json" ]; then
-  PORT=\$(grep -o '"port":[0-9]*' "$INSTAR_DIR/config.json" | head -1 | cut -d':' -f2)
+  PORT=\$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$INSTAR_DIR/config.json" | head -1 | grep -oE '[0-9]+' | head -1)
   if [ -n "\$PORT" ]; then
-    AUTH_TOKEN=\$(python3 -c "import json; print(json.load(open('$INSTAR_DIR/config.json')).get('authToken',''))" 2>/dev/null)
+    # Resolve auth token: env first (set by SessionManager for every spawned
+    # session), legacy plaintext-config fallback with string-type guard so the
+    # { "secret": true } placeholder produced by SecretMigrator never leaks
+    # through as a bogus Bearer token.
+    AUTH_TOKEN="\${INSTAR_AUTH_TOKEN:-}"
+    if [ -z "\$AUTH_TOKEN" ]; then
+      AUTH_TOKEN=\$(python3 -c "import json; v=json.load(open('$INSTAR_DIR/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+    fi
     HEALTH=\$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:\${PORT}/health" 2>/dev/null)
     if [ "\$HEALTH" = "200" ]; then
       WM_QUERY=\$(python3 -c "import urllib.parse; print(urllib.parse.quote('compaction-recovery context-restoration'))" 2>/dev/null)
@@ -6512,16 +6632,20 @@ process.stdin.on('end', async () => {
     // Build description
     const description = action.replace(/_/g, ' ') + ' on ' + service;
 
-    // Read config (port + auth token) via dynamic import to stay ESM-compatible
+    // Read config (port + auth token) via dynamic import to stay ESM-compatible.
+    // Auth-token resolution: INSTAR_AUTH_TOKEN env first (SessionManager injects
+    // it into every spawned session, survives secret-externalization), legacy
+    // plaintext-config fallback with a string-type guard so the { secret: true }
+    // placeholder produced by SecretMigrator can never leak through as a Bearer.
     let port = 4321;
-    let authToken = '';
+    let authToken = process.env.INSTAR_AUTH_TOKEN || '';
     try {
       const nodeFs = await import('node:fs');
       const configPath = (process.env.CLAUDE_PROJECT_DIR || '.') + '/.instar/config.json';
       const raw = nodeFs.readFileSync(configPath, 'utf-8');
       const cfg = JSON.parse(raw);
       port = cfg.port || 4321;
-      authToken = cfg.authToken || '';
+      if (!authToken && typeof cfg.authToken === 'string') authToken = cfg.authToken;
     } catch { /* use defaults */ }
 
     // Call the gate API using global fetch (Node 18+)
@@ -6831,7 +6955,16 @@ process.stdin.on('end', async () => {
       const existing = fs.readFileSync(opts.scriptPath, 'utf-8');
       const looksShipped = existing.includes(opts.shippedMarker);
       const hasNewHandling = existing.includes('HTTP_CODE" = "408"');
-      if (!looksShipped || hasNewHandling) {
+      // Secret-externalization survivability marker: the canonical auth
+      // resolver pattern uses INSTAR_AUTH_TOKEN env first. Existing scripts
+      // that have the 408 marker but still read authToken straight from
+      // config.json silently 403 after secret-externalization (the
+      // 2026-05-29 telegram-topic-context incident). Treat the env-first
+      // pattern as a separate upgrade marker so a deployed-but-stale script
+      // gets refreshed rather than skipped as "already up to date".
+      const hasAuthEnvHandling = existing.includes('INSTAR_AUTH_TOKEN');
+      const fullyCurrent = hasNewHandling && hasAuthEnvHandling;
+      if (!looksShipped || fullyCurrent) {
         opts.result.skipped.push(`${opts.label} (already up to date or customized)`);
         return;
       }
@@ -6841,7 +6974,10 @@ process.stdin.on('end', async () => {
         return;
       }
       fs.writeFileSync(opts.scriptPath, template, { mode: 0o755 });
-      opts.result.upgraded.push(`${opts.label} (upgraded to HTTP 408 ambiguous-outcome handling)`);
+      const reason = hasNewHandling
+        ? 'auth-env-first (secret-externalization survivability)'
+        : 'HTTP 408 ambiguous-outcome handling';
+      opts.result.upgraded.push(`${opts.label} (upgraded to ${reason})`);
     } catch (err) {
       opts.result.errors.push(`${opts.label} migration: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -7490,15 +7626,18 @@ function findContradictions(text, state) {
   const path = await import('node:path');
   const http = await import('node:http');
 
-// Read config for port and auth token
+// Read config for port and auth token. Token: env first (SessionManager injects
+// INSTAR_AUTH_TOKEN per spawned session — survives secret-externalization), legacy
+// plaintext-config fallback with a string-type guard so the { secret: true }
+// placeholder produced by SecretMigrator can never leak as a Bearer.
 let serverPort = ${port};
-let authToken = '';
+let authToken = process.env.INSTAR_AUTH_TOKEN || '';
 try {
   const configPath = path.join(process.env.CLAUDE_PROJECT_DIR || '.', '.instar', 'config.json');
   const raw = fs.readFileSync(configPath, 'utf-8');
   const cfg = JSON.parse(raw);
   serverPort = cfg.port || ${port};
-  authToken = cfg.authToken || '';
+  if (!authToken && typeof cfg.authToken === 'string') authToken = cfg.authToken;
 } catch {}
 
 // Check if response review is enabled in config
@@ -7625,11 +7764,14 @@ if (!reviewEnabled) {
   const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const configPath = path.join(projectDir, '.instar', 'config.json');
   let serverPort = ${port};
-  let authToken = '';
+  // INSTAR_AUTH_TOKEN env first — SessionManager injects it per spawned session
+  // and it survives secret-externalization. Legacy plaintext-config fallback
+  // with string-type guard so the { secret: true } placeholder cannot leak.
+  let authToken = process.env.INSTAR_AUTH_TOKEN || '';
   try {
     const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     serverPort = cfg.port || ${port};
-    authToken = cfg.authToken || '';
+    if (!authToken && typeof cfg.authToken === 'string') authToken = cfg.authToken;
   } catch {}
 
   function postJson(urlPath, payload, timeoutMs) {

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-29T13:47:56.820Z",
-  "instarVersion": "1.3.89",
+  "generatedAt": "2026-05-29T23:20:48.398Z",
+  "instarVersion": "1.3.99",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -409,7 +409,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -417,7 +417,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -425,7 +425,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -433,7 +433,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -441,7 +441,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -449,7 +449,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -457,7 +457,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -465,7 +465,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -473,7 +473,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -481,7 +481,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -489,7 +489,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -497,7 +497,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -505,7 +505,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -513,7 +513,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -521,7 +521,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -529,7 +529,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -537,7 +537,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -545,7 +545,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -553,7 +553,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -561,7 +561,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -569,7 +569,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -577,7 +577,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -585,7 +585,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -593,7 +593,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -601,7 +601,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -609,7 +609,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -617,7 +617,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -625,7 +625,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -633,7 +633,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -641,7 +641,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -649,7 +649,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -657,7 +657,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -665,7 +665,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -673,7 +673,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -681,7 +681,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -689,7 +689,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -697,7 +697,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -705,7 +705,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -713,7 +713,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -721,7 +721,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -729,7 +729,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -737,7 +737,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -745,7 +745,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -753,7 +753,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/machineRoutes.ts",
-      "contentHash": "b8a789fea855d5e45cffc3ffaea6fcf3c04d4cbb39b3097a1590ee76ccc5378b",
+      "contentHash": "1d64bdcd5106044c1d9d976dfbd610876f09755ac38a57a76e2994eaa39b238d",
       "since": "2025-01-01"
     },
     "route-group:secret-drop": {
@@ -761,7 +761,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "517da73db0582410890849ec9b65f3bc2c35fae88daadf9864f4433335ed6857",
+      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1009,7 +1009,7 @@
       "type": "template",
       "domain": "safety",
       "sourcePath": "src/templates/hooks/compaction-recovery.sh",
-      "contentHash": "ca6a2a5c2ee03839654c9708912292bc03d81c61281dffbbb958d4877ee1dc91",
+      "contentHash": "f65f4731a5142981cf021e948afa5b064dcc35ceadf6efd5354d749f2d85569f",
       "since": "2025-01-01"
     },
     "template:dangerous-command-guard.sh": {
@@ -1049,7 +1049,7 @@
       "type": "template",
       "domain": "safety",
       "sourcePath": "src/templates/hooks/session-start.sh",
-      "contentHash": "4d98736d3ee30fe8639f0851e5e492416ad05f4ae49f84e8695723faa4b9398e",
+      "contentHash": "d8b20ab9e46aecc400171bde09a5a64f5a1eeb53e09017564cebc65e67fca062",
       "since": "2025-01-01"
     },
     "template:settings-template.json": {
@@ -1073,7 +1073,7 @@
       "type": "template",
       "domain": "safety",
       "sourcePath": "src/templates/hooks/slack-channel-context.sh",
-      "contentHash": "da9c34225af5d0a1f202d51263d864ac2ac8facf7f4e4b4d736e2b2b9b54d70a",
+      "contentHash": "ebb2a74ce3819a148b1cfaace3d3467d317ed8cccd98db5cd7ffe0df3a2e9784",
       "since": "2025-01-01"
     },
     "template:telegram-topic-context.sh": {
@@ -1081,7 +1081,7 @@
       "type": "template",
       "domain": "safety",
       "sourcePath": "src/templates/hooks/telegram-topic-context.sh",
-      "contentHash": "57cfb744bbffcd21f6290c5f38726b105b93258bf09cc539c24d66aebed9c40e",
+      "contentHash": "317b11084547271dab3f333be8bdf5e536a5af7239f50d51030c62990b4b7e59",
       "since": "2025-01-01"
     },
     "template:convergence-check.sh": {
@@ -1113,7 +1113,7 @@
       "type": "template",
       "domain": "operations",
       "sourcePath": "src/templates/scripts/imessage-reply.sh",
-      "contentHash": "aa34955027f094d5a78973762ac30c92816cc73399108b1ad0fb427e3ae70f1c",
+      "contentHash": "e4ecc66feaaea92c5f65f008e5b82b1022c7fd61ee9e4f1ed1346106b4a63d6c",
       "since": "2025-01-01"
     },
     "template:instar-watchdog.sh": {
@@ -1121,7 +1121,7 @@
       "type": "template",
       "domain": "operations",
       "sourcePath": "src/templates/scripts/instar-watchdog.sh",
-      "contentHash": "d81ed54264fbb6091f2b29365c6dd318f491f2acfabbbb5ff20582336867f53d",
+      "contentHash": "1f462b267e6724bea21692e617bd61a6b7cd4def7187321871cdc1fc178d1d1b",
       "since": "2025-01-01"
     },
     "template:instar-worktree-create.sh": {
@@ -1137,7 +1137,7 @@
       "type": "template",
       "domain": "operations",
       "sourcePath": "src/templates/scripts/secret-drop-retrieve.mjs",
-      "contentHash": "2acc881ce53c879047f0e98b9afd5c66f293c48046c62fff8587123078145c98",
+      "contentHash": "3c99a8d8898868e31e88c4b729b57968c14cb723c9ffb6f903d36a1e18841156",
       "since": "2025-01-01"
     },
     "template:serendipity-capture.sh": {
@@ -1145,7 +1145,7 @@
       "type": "template",
       "domain": "operations",
       "sourcePath": "src/templates/scripts/serendipity-capture.sh",
-      "contentHash": "2e905386fd889bfc9246a44a3b2c58a6cb68f02e703aded8900107ab5188570b",
+      "contentHash": "317bc0bbb09bf03c9755ab25ca0b8da940eccb8a74886fac60045163c6bdd091",
       "since": "2025-01-01"
     },
     "template:slack-reply.sh": {
@@ -1153,7 +1153,7 @@
       "type": "template",
       "domain": "operations",
       "sourcePath": "src/templates/scripts/slack-reply.sh",
-      "contentHash": "1813442032e435e4ecbf01467510e39a33c3feb3acb1407307c5569a65f30305",
+      "contentHash": "ea698ef54e0e48233d82225c6cfcf886f58c7939101d966cfafc5e85edcac6a4",
       "since": "2025-01-01"
     },
     "template:smart-fetch.py": {
@@ -1169,7 +1169,7 @@
       "type": "template",
       "domain": "operations",
       "sourcePath": "src/templates/scripts/telegram-reply.sh",
-      "contentHash": "371d7e8f4f72146bf8bd07115873bdbbaaf32e851ac6e1318ba5b8929cd06e68",
+      "contentHash": "0f6d27a522b123551871e6081774f8c89d1ad0ce248597af7dd60d8522871069",
       "since": "2025-01-01"
     },
     "template:whatsapp-reply.sh": {
@@ -1177,7 +1177,7 @@
       "type": "template",
       "domain": "operations",
       "sourcePath": "src/templates/scripts/whatsapp-reply.sh",
-      "contentHash": "a226d76025036d6b0f11ffcded50a748ff8d2102f2dbb06ce86599001b62ec23",
+      "contentHash": "942712aa272235bca9f14ab6baa23bbe5ae0a8bf20f76edf87c963b181a7764c",
       "since": "2025-01-01"
     },
     "playbook-script:atomic_write.py": {
@@ -1457,7 +1457,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "58f8f59f8d94511835333083269d3c512e8916dede7cc69fcdaf3b159b7e392b",
+      "contentHash": "e7205849075aac7b50c06822b38a99b80909aad221e773d0a83a3e21a7242697",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1465,7 +1465,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "abb9f617bbb0568510470625c390bee45604b421cf48f6fda263c5e8c311f5d9",
+      "contentHash": "c5d5f33e8793229dea8d9a7f3ee2073c0cd19bd8885425d245d57b6bc9076521",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {
@@ -1489,7 +1489,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "02e081441560e8b3a82c3cd7ed647ff0cb8f7042b166a4ab1241a86d8c113883",
+      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {
@@ -1545,7 +1545,7 @@
       "type": "subsystem",
       "domain": "coordination",
       "sourcePath": "src/core/MultiMachineCoordinator.ts",
-      "contentHash": "f0ad105ab4996bb6d14d2c836430fb6f7c8b7adab512c6a21c03bd5f029d8d3b",
+      "contentHash": "44aa63dff721e15ad680db4c1d552abfc9e97e610498b6752496c222f27f323b",
       "since": "2025-01-01"
     },
     "subsystem:backup-manager": {

--- a/src/templates/hooks/compaction-recovery.sh
+++ b/src/templates/hooks/compaction-recovery.sh
@@ -174,9 +174,12 @@ echo ""
 # Resolves Open Question #5 from the Consent & Discovery Framework spec:
 # lastSurfacedAt timestamps persist in SQLite regardless of context state.
 if [ -f "$CONFIG_FILE" ]; then
-  PORT=$(grep -o '"port":[0-9]*' "$CONFIG_FILE" | head -1 | cut -d':' -f2)
+  PORT=$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
   if [ -n "$PORT" ]; then
-    AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('authToken',''))" 2>/dev/null)
+    AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+    if [ -z "$AUTH_TOKEN" ]; then
+      AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('$CONFIG_FILE')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+    fi
     FEATURES_JSON=$(curl -s -H "Authorization: Bearer ${AUTH_TOKEN}" \
       "http://localhost:${PORT}/features/summary" 2>/dev/null)
     if [ -n "$FEATURES_JSON" ]; then
@@ -235,7 +238,7 @@ fi
 # Server health reminder + recent Telegram context
 CONFIG_FILE="$INSTAR_DIR/config.json"
 if [ -f "$CONFIG_FILE" ]; then
-  PORT=$(grep -o '"port":[0-9]*' "$CONFIG_FILE" | head -1 | cut -d':' -f2)
+  PORT=$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
   if [ -n "$PORT" ]; then
     echo "Server: curl http://localhost:${PORT}/health | Capabilities: curl http://localhost:${PORT}/capabilities"
 
@@ -247,7 +250,10 @@ if [ -f "$CONFIG_FILE" ]; then
       # Slack channel context — if INSTAR_SLACK_CHANNEL is set, this is a Slack session
       SLACK_CHANNEL="${INSTAR_SLACK_CHANNEL:-}"
       if [ -n "$SLACK_CHANNEL" ]; then
-        AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('authToken',''))" 2>/dev/null)
+        AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+    if [ -z "$AUTH_TOKEN" ]; then
+      AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('$CONFIG_FILE')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+    fi
         SLACK_MSGS=$(curl -s \
           -H "Authorization: Bearer ${AUTH_TOKEN}" \
           "http://localhost:${PORT}/slack/channels/${SLACK_CHANNEL}/messages?limit=20" 2>/dev/null)
@@ -346,7 +352,10 @@ except Exception:
       fi
 
       if [ -n "$TOPIC_FOR_CONTEXT" ]; then
-        AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('authToken',''))" 2>/dev/null)
+        AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+    if [ -z "$AUTH_TOKEN" ]; then
+      AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('$CONFIG_FILE')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+    fi
         if [ -n "$AUTH_TOKEN" ]; then
           RECENT_MSGS=$(curl -s \
             -H "Authorization: Bearer ${AUTH_TOKEN}" \
@@ -418,9 +427,12 @@ fi
 # This surfaces what you already know that's relevant to the current context,
 # preventing you from re-deriving knowledge you've already accumulated.
 if [ -f "$CONFIG_FILE" ]; then
-  PORT=$(grep -o '"port":[0-9]*' "$CONFIG_FILE" | head -1 | cut -d':' -f2)
+  PORT=$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
   if [ -n "$PORT" ]; then
-    AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('authToken',''))" 2>/dev/null)
+    AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+    if [ -z "$AUTH_TOKEN" ]; then
+      AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('$CONFIG_FILE')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+    fi
     WORKING_MEM=$(curl -s -H "Authorization: Bearer ${AUTH_TOKEN}" \
       "http://localhost:${PORT}/context/working-memory?prompt=compaction-recovery&limit=5" 2>/dev/null)
     if [ -n "$WORKING_MEM" ]; then
@@ -452,10 +464,13 @@ fi
 # so it gives us a guaranteed signal. The server will check for unanswered user
 # messages and re-inject them shortly after this hook completes.
 if [ -f "$CONFIG_FILE" ] && command -v tmux >/dev/null 2>&1; then
-  PORT=$(grep -o '"port":[0-9]*' "$CONFIG_FILE" | head -1 | cut -d':' -f2)
+  PORT=$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
   TMUX_SESSION=$(tmux display-message -p '#S' 2>/dev/null)
   if [ -n "$PORT" ] && [ -n "$TMUX_SESSION" ]; then
-    AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('authToken',''))" 2>/dev/null)
+    AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+    if [ -z "$AUTH_TOKEN" ]; then
+      AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('$CONFIG_FILE')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+    fi
     curl -s -m 2 -X POST \
       -H "Authorization: Bearer ${AUTH_TOKEN}" \
       -H "Content-Type: application/json" \

--- a/src/templates/hooks/session-start.sh
+++ b/src/templates/hooks/session-start.sh
@@ -21,12 +21,19 @@ if [ ! -f "$CONFIG_FILE" ]; then
   exit 0
 fi
 
-PORT=$(grep -o '"port":[0-9]*' "$CONFIG_FILE" | head -1 | cut -d':' -f2)
+PORT=$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
 if [ -z "$PORT" ]; then
   exit 0
 fi
 
-AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('authToken',''))" 2>/dev/null)
+# Resolve auth token: INSTAR_AUTH_TOKEN env first (SessionManager injects it per
+# spawned session — survives secret-externalization), legacy plaintext-config
+# fallback with string-type guard so the { "secret": true } placeholder produced
+# by SecretMigrator cannot leak through as a bogus Bearer.
+AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+if [ -z "$AUTH_TOKEN" ]; then
+  AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('$CONFIG_FILE')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+fi
 
 # Check if server is alive
 HEALTH=$(curl -s -o /dev/null -w "%{http_code}" \

--- a/src/templates/hooks/slack-channel-context.sh
+++ b/src/templates/hooks/slack-channel-context.sh
@@ -29,7 +29,14 @@ if [ -f ".instar/config.json" ]; then
     CONFIG_PORT=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('port',''))" 2>/dev/null)
     [ -n "$CONFIG_PORT" ] && PORT="$CONFIG_PORT"
   fi
-  AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+  # Auth resolution: INSTAR_AUTH_TOKEN env first (SessionManager injects it per
+  # spawned session — survives secret-externalization), legacy plaintext-config
+  # fallback with string-type guard so the { "secret": true } placeholder
+  # produced by SecretMigrator cannot leak through as a bogus Bearer.
+  AUTH="${INSTAR_AUTH_TOKEN:-}"
+  if [ -z "$AUTH" ]; then
+    AUTH=$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+  fi
 fi
 
 PORT="${PORT:-4042}"

--- a/src/templates/hooks/telegram-topic-context.sh
+++ b/src/templates/hooks/telegram-topic-context.sh
@@ -43,7 +43,7 @@ if [ ! -f "$CONFIG_FILE" ]; then
   exit 0
 fi
 
-PORT=$(grep -o '"port":[0-9]*' "$CONFIG_FILE" | head -1 | cut -d':' -f2)
+PORT=$(grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+' "$CONFIG_FILE" | head -1 | grep -oE '[0-9]+' | head -1)
 if [ -z "$PORT" ]; then
   exit 0
 fi
@@ -54,8 +54,20 @@ if [ "$HEALTH" != "200" ]; then
   exit 0
 fi
 
+# Resolve the auth token. INSTAR_AUTH_TOKEN env first — SessionManager injects
+# this into every spawned Claude Code session, so hooks running inside a session
+# always have it; survives the secret-externalization refactor that moved authToken
+# out of config.json into the encrypted store. Legacy fallback reads config.json
+# with a string-type guard: after externalization the value is the literal
+# placeholder { "secret": true } — the guard rejects it and yields empty so we
+# never send the placeholder as a Bearer token (which the server rejects with 403,
+# silently breaking history injection — the 2026-05-29 incident this fix is for).
+AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+if [ -z "$AUTH_TOKEN" ] && [ -f "$CONFIG_FILE" ]; then
+  AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('$CONFIG_FILE')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+fi
+
 # Fetch recent messages for this topic
-AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('$CONFIG_FILE')).get('authToken',''))" 2>/dev/null)
 if [ -n "$AUTH_TOKEN" ]; then
   RECENT_MSGS=$(curl -s \
     -H "Authorization: Bearer ${AUTH_TOKEN}" \

--- a/src/templates/scripts/imessage-reply.sh
+++ b/src/templates/scripts/imessage-reply.sh
@@ -42,9 +42,13 @@ fi
 
 PORT="${INSTAR_PORT:-4042}"
 
-AUTH_TOKEN=""
-if [ -f ".instar/config.json" ]; then
-  AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+# Auth: env first (SessionManager injects it per spawned session and it
+# survives secret-externalization), legacy plaintext-config fallback with
+# string-type guard so the { "secret": true } placeholder produced by
+# SecretMigrator cannot leak through as a bogus Bearer.
+AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+if [ -z "$AUTH_TOKEN" ] && [ -f ".instar/config.json" ]; then
+  AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
 fi
 
 # Escape message for JSON

--- a/src/templates/scripts/instar-watchdog.sh
+++ b/src/templates/scripts/instar-watchdog.sh
@@ -324,7 +324,11 @@ escalate_via_peer() {
     node_bin=$(resolve_node || true)
     [ -z "$node_bin" ] && continue
     local peer_meta
-    peer_meta=$("$node_bin" -e "const c=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));process.stdout.write((c.port||'')+'\t'+(c.authToken||''))" "$peer_dir/.instar/config.json" 2>/dev/null || true)
+    # The string-type guard on authToken protects against the { secret: true }
+    # placeholder that SecretMigrator writes after externalizing the auth token:
+    # `c.authToken || ''` would otherwise return the object itself (truthy)
+    # which serializes to "[object Object]" — never a valid Bearer.
+    peer_meta=$("$node_bin" -e "const c=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const t=typeof c.authToken==='string'?c.authToken:'';process.stdout.write((c.port||'')+'\t'+t)" "$peer_dir/.instar/config.json" 2>/dev/null || true)
     peer_port="${peer_meta%%	*}"
     peer_auth="${peer_meta##*	}"
     [ -z "$peer_port" ] && continue
@@ -434,11 +438,16 @@ probe_server_identity() {
   node_bin=$(resolve_node || true)
   [ -z "$node_bin" ] && return 0
 
-  # Read port + authToken in one node invocation. The authToken is required
-  # because /health gates the `project` field behind authentication — without
-  # it the probe can't verify identity and would silently fail-open.
+  # Read port + authToken in one node invocation. The authToken is needed
+  # because /health gates the `project` field behind authentication; without
+  # it the probe can still hit /health for a basic alive check but loses the
+  # identity disambiguation. INSTAR_AUTH_TOKEN env is preferred when set
+  # (preserves cross-version compatibility). The string-type guard rejects the
+  # { secret: true } placeholder SecretMigrator writes after externalizing the
+  # auth token — `String(c.authToken || '')` would otherwise yield
+  # "[object Object]" and the Bearer would be invalid.
   local meta
-  meta=$("$node_bin" -e "const c=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));process.stdout.write(String(c.port||'')+'\t'+String(c.authToken||''))" "$config_file" 2>/dev/null || true)
+  meta=$("$node_bin" -e "const c=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));const t=process.env.INSTAR_AUTH_TOKEN||(typeof c.authToken==='string'?c.authToken:'');process.stdout.write(String(c.port||'')+'\t'+t)" "$config_file" 2>/dev/null || true)
   port="${meta%%	*}"
   auth_token="${meta##*	}"
   # Lifeline-only agents have no port; treat as healthy from probe POV.

--- a/src/templates/scripts/secret-drop-retrieve.mjs
+++ b/src/templates/scripts/secret-drop-retrieve.mjs
@@ -47,15 +47,23 @@ if (!token || !mode || mode === '--consume') {
   process.exit(2);
 }
 
-let authToken;
+// Auth-token resolution: INSTAR_AUTH_TOKEN env first (SessionManager and
+// JobScheduler inject it for every spawned context; survives the
+// secret-externalization refactor that moved authToken out of config.json into
+// the encrypted store), legacy plaintext-config fallback with a string-type
+// guard so the { "secret": true } placeholder produced by SecretMigrator
+// cannot leak through as a bogus Bearer.
+let authToken = process.env.INSTAR_AUTH_TOKEN || '';
 let port;
 try {
   const config = JSON.parse(fs.readFileSync('.instar/config.json', 'utf-8'));
-  authToken = config.authToken;
+  if (!authToken && typeof config.authToken === 'string') authToken = config.authToken;
   port = config.port;
 } catch (e) {
-  process.stderr.write('cannot read .instar/config.json: ' + e.message + '\n');
-  process.exit(2);
+  if (!authToken) {
+    process.stderr.write('cannot read .instar/config.json: ' + e.message + '\n');
+    process.exit(2);
+  }
 }
 
 // Port resolution: env > config. Mirrors the telegram-reply.sh precedence

--- a/src/templates/scripts/serendipity-capture.sh
+++ b/src/templates/scripts/serendipity-capture.sh
@@ -294,15 +294,21 @@ if patch_file or artifact_type:
 # Key derivation: HMAC-SHA256(authToken, "serendipity-v1:" + sessionId)
 signing_key = os.environ.get("SERENDIPITY_SIGNING_KEY", "")
 if not signing_key:
-    # Derive from auth token + session
-    config_path = os.environ.get("CONFIG_FILE", "")
-    auth_token = ""
-    if config_path and os.path.exists(config_path):
-        try:
-            cfg = json.load(open(config_path))
-            auth_token = cfg.get("authToken", "")
-        except:
-            pass
+    # Derive from auth token + session. Token: INSTAR_AUTH_TOKEN env first
+    # (SessionManager injects it; survives secret-externalization), legacy
+    # plaintext-config fallback with a string-type guard so the
+    # { "secret": true } placeholder produced by SecretMigrator cannot leak.
+    auth_token = os.environ.get("INSTAR_AUTH_TOKEN", "")
+    if not auth_token:
+        config_path = os.environ.get("CONFIG_FILE", "")
+        if config_path and os.path.exists(config_path):
+            try:
+                cfg = json.load(open(config_path))
+                v = cfg.get("authToken", "")
+                if isinstance(v, str):
+                    auth_token = v
+            except:
+                pass
     session_id = finding["source"]["sessionId"]
     key_material = f"serendipity-v1:{session_id}"
     signing_key = hmac.new(

--- a/src/templates/scripts/slack-reply.sh
+++ b/src/templates/scripts/slack-reply.sh
@@ -44,7 +44,14 @@ if [ -f ".instar/config.json" ]; then
     CONFIG_PORT=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('port',''))" 2>/dev/null)
     [ -n "$CONFIG_PORT" ] && PORT="$CONFIG_PORT"
   fi
-  AUTH=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+  # Auth: env first (SessionManager injects it into spawned sessions; survives
+  # secret-externalization), legacy plaintext-config fallback with string-type
+  # guard so the { "secret": true } placeholder produced by SecretMigrator
+  # cannot leak as a bogus Bearer.
+  AUTH="${INSTAR_AUTH_TOKEN:-}"
+  if [ -z "$AUTH" ]; then
+    AUTH=$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
+  fi
 fi
 
 PORT="${PORT:-4042}"

--- a/src/templates/scripts/telegram-reply.sh
+++ b/src/templates/scripts/telegram-reply.sh
@@ -75,9 +75,13 @@ if [ -z "$MSG" ]; then
 fi
 
 # Resolve config-derived values from .instar/config.json (single python3
-# invocation). Env > config > 4040-warn for port; config-only for authToken
-# and agentId.
-AUTH_TOKEN=""
+# invocation). Env > config > 4040-warn for port. Auth: INSTAR_AUTH_TOKEN env
+# first (SessionManager injects it per spawned session; survives the
+# secret-externalization refactor that moved authToken out of config.json into
+# the encrypted store), legacy plaintext-config fallback with a string-type
+# guard so the { "secret": true } placeholder produced by SecretMigrator
+# cannot leak through as a bogus Bearer.
+AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
 AGENT_ID=""
 CONFIG_PORT=""
 if [ -f ".instar/config.json" ]; then
@@ -87,11 +91,13 @@ try:
     c = json.load(open('.instar/config.json'))
 except Exception:
     sys.exit(0)
-print(c.get('authToken', ''))
+v = c.get('authToken', '')
+print(v if isinstance(v, str) else '')
 print(c.get('projectName', ''))
 print(c.get('port', ''))
 " 2>/dev/null)
-  AUTH_TOKEN=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '1p')
+  CONFIG_AUTH=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '1p')
+  [ -z "$AUTH_TOKEN" ] && AUTH_TOKEN="$CONFIG_AUTH"
   AGENT_ID=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '2p')
   CONFIG_PORT=$(printf '%s\n' "$CONFIG_VALUES" | sed -n '3p')
 fi

--- a/src/templates/scripts/whatsapp-reply.sh
+++ b/src/templates/scripts/whatsapp-reply.sh
@@ -33,10 +33,13 @@ fi
 
 PORT="${INSTAR_PORT:-4040}"
 
-# Read auth token from config (if present)
-AUTH_TOKEN=""
-if [ -f ".instar/config.json" ]; then
-  AUTH_TOKEN=$(python3 -c "import json; print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null)
+# Read auth token: env first (SessionManager injects it per spawned session and
+# it survives secret-externalization), legacy plaintext-config fallback with
+# string-type guard so the { "secret": true } placeholder produced by
+# SecretMigrator cannot leak through as a bogus Bearer.
+AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"
+if [ -z "$AUTH_TOKEN" ] && [ -f ".instar/config.json" ]; then
+  AUTH_TOKEN=$(python3 -c "import json; v=json.load(open('.instar/config.json')).get('authToken',''); print(v if isinstance(v, str) else '')" 2>/dev/null)
 fi
 
 # Escape for JSON

--- a/src/threadline/listener-daemon.ts
+++ b/src/threadline/listener-daemon.ts
@@ -189,16 +189,26 @@ export class ListenerDaemon extends EventEmitter {
       }
     }
 
-    // Fallback: derive from authToken in config.json
-    const configPath = path.join(this.config.stateDir, 'config.json');
-    if (!fs.existsSync(configPath)) {
-      this.log.error('No HMAC key file and no config.json found');
-      process.exit(1);
-    }
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    const authToken = config.authToken;
+    // Fallback: derive from authToken. INSTAR_AUTH_TOKEN env first (preserves
+    // derivation when authToken has been moved out of config.json into the
+    // encrypted store by SecretMigrator), legacy plaintext-config fallback with
+    // a string-type guard so the { secret: true } placeholder cannot be used as
+    // HKDF input material (it would produce a key tied to the placeholder, not
+    // the real secret — and silently mismatch every peer).
+    let authToken = process.env.INSTAR_AUTH_TOKEN || '';
     if (!authToken) {
-      this.log.error('No authToken in config.json and no HMAC key file');
+      const configPath = path.join(this.config.stateDir, 'config.json');
+      if (!fs.existsSync(configPath)) {
+        this.log.error('No HMAC key file and no config.json found');
+        process.exit(1);
+      }
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (typeof config.authToken === 'string') {
+        authToken = config.authToken;
+      }
+    }
+    if (!authToken) {
+      this.log.error('No authToken (env or config.json) and no HMAC key file');
       process.exit(1);
     }
 

--- a/src/threadline/mcp-stdio-entry.ts
+++ b/src/threadline/mcp-stdio-entry.ts
@@ -168,15 +168,19 @@ async function main(): Promise<void> {
     fs.mkdirSync(threadlineDir, { recursive: true });
   }
 
-  // Read server port and auth token from config
+  // Read server port and auth token. Token: INSTAR_AUTH_TOKEN env first
+  // (survives the secret-externalization refactor that moved authToken out of
+  // config.json into the encrypted store), legacy plaintext-config fallback with
+  // a string-type guard so the { "secret": true } placeholder produced by
+  // SecretMigrator cannot leak through as a bogus Bearer.
   const configPath = path.join(stateDir, 'config.json');
   let serverPort = 4040;
-  let agentToken = '';
+  let agentToken = process.env.INSTAR_AUTH_TOKEN || '';
   if (fs.existsSync(configPath)) {
     try {
       const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
       serverPort = config.port ?? 4040;
-      agentToken = config.authToken ?? '';
+      if (!agentToken && typeof config.authToken === 'string') agentToken = config.authToken;
     } catch {
       // Use defaults
     }

--- a/tests/e2e/secret-externalization-hook-lifecycle.test.ts
+++ b/tests/e2e/secret-externalization-hook-lifecycle.test.ts
@@ -1,0 +1,161 @@
+// safe-git-allow: test file — fs.rmSync calls are per-test tmpdir cleanup only.
+/**
+ * E2E: full agent-update lifecycle survives secret-externalization.
+ *
+ * Simulates a real deployed agent in two states:
+ *   1. Pre-fix agent — has the old broken hook scripts on disk AND has gone
+ *      through secret-externalization (config.json contains the
+ *      `{ "secret": true }` placeholder).
+ *   2. Post-fix agent — runs `PostUpdateMigrator.migrate()`, which is the
+ *      single code path that any auto-updated production instar agent
+ *      exercises on every version bump.
+ *
+ * Asserts that, after `migrate()`, every shipped hook/script on the agent's
+ * disk has the env-first INSTAR_AUTH_TOKEN canary AND a string-type guard.
+ * This is the "feature is alive in production" property — the canonical
+ * `Tier 3` test per the Testing Integrity Standard.
+ *
+ * Without this test, a regression that broke the migrator's hook-rewrite
+ * path (e.g. an install-if-missing slip on a script that previously was
+ * always-overwrite) would not be caught by the unit + integration tiers
+ * alone.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+
+describe('secret-externalization survivability — e2e lifecycle', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let claudeHooksInstarDir: string;
+  let claudeScriptsDir: string;
+  let instarScriptsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-secext-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    claudeHooksInstarDir = path.join(tmpDir, '.claude', 'hooks', 'instar');
+    claudeScriptsDir = path.join(tmpDir, '.claude', 'scripts');
+    instarScriptsDir = path.join(stateDir, 'scripts');
+
+    fs.mkdirSync(claudeHooksInstarDir, { recursive: true });
+    fs.mkdirSync(claudeScriptsDir, { recursive: true });
+    fs.mkdirSync(instarScriptsDir, { recursive: true });
+
+    // Seed config.json in the externalized state — the placeholder is on disk
+    // because SecretMigrator ran (multi-machine pairing happened).
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({
+      projectName: 'test-e2e',
+      projectDir: tmpDir,
+      stateDir,
+      port: 4242,
+      authToken: { secret: true },
+    }));
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* test cleanup */ } // safe-fs-allow
+  });
+
+  function seedBrokenHook(relPath: string, marker: string): string {
+    const full = path.join(tmpDir, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    const body = [
+      '#!/bin/bash',
+      `# ${marker}`,
+      'AUTH=""',
+      'if [ -f ".instar/config.json" ]; then',
+      '  AUTH=$(python3 -c "import json; print(json.load(open(\'.instar/config.json\')).get(\'authToken\',\'\'))" 2>/dev/null)',
+      'fi',
+    ].join('\n') + '\n';
+    fs.writeFileSync(full, body);
+    return full;
+  }
+
+  it('every shipped hook+script on a pre-fix deployed agent has env-first auth after migrate()', () => {
+    // Seed pre-fix copies of every script that gets installed during init.
+    // After migrate() runs (the auto-update path), each must contain the
+    // INSTAR_AUTH_TOKEN canary AND the string-guard.
+    const seeded: string[] = [];
+    seeded.push(seedBrokenHook('.instar/scripts/imessage-reply.sh', 'imessage-reply.sh'));
+    seeded.push(seedBrokenHook('.instar/scripts/serendipity-capture.sh', 'serendipity-capture.sh'));
+    seeded.push(seedBrokenHook('.claude/hooks/instar/slack-channel-context.sh', 'slack-channel-context.sh'));
+
+    // Trigger the canonical migration path the live updater runs.
+    const migrator = new PostUpdateMigrator({
+      stateDir,
+      projectDir: tmpDir,
+      port: 4242,
+      sessions: { claudePath: 'claude' },
+      hasTelegram: false,
+    } as any);
+    (migrator as any).migrate();
+
+    // Every seeded file must now have the env-first canary AND a string guard.
+    for (const file of seeded) {
+      const body = fs.readFileSync(file, 'utf-8');
+      expect(body, `${path.relative(tmpDir, file)}: missing INSTAR_AUTH_TOKEN env-first marker`).toContain('INSTAR_AUTH_TOKEN');
+      const hasShellGuard = /isinstance\([^,]+,\s*str\)/.test(body) || /typeof\s+\w+\s*===\s*['"]string['"]/.test(body);
+      expect(hasShellGuard, `${path.relative(tmpDir, file)}: missing string-type guard against { secret: true } placeholder`).toBe(true);
+    }
+  });
+
+  it('canonical migrator-emitted hooks (telegram-topic-context, session-start, compaction-recovery) always carry the env-first canary', () => {
+    // These three are written from `getHookContent()` on EVERY migration run
+    // (per the always-overwrite policy of the Migration Parity Standard).
+    // Assert the emitted content carries the canary so we never ship a
+    // version that silently 403s after secret-externalization again.
+    const migrator = new PostUpdateMigrator({
+      stateDir,
+      projectDir: tmpDir,
+      port: 4242,
+      sessions: { claudePath: 'claude' },
+      hasTelegram: false,
+    } as any);
+
+    const names: Array<'telegram-topic-context' | 'session-start' | 'compaction-recovery'> = [
+      'telegram-topic-context',
+      'session-start',
+      'compaction-recovery',
+    ];
+    for (const name of names) {
+      const body: string = (migrator as any).getHookContent(name);
+      expect(body, `${name}: missing INSTAR_AUTH_TOKEN env-first marker`).toContain('INSTAR_AUTH_TOKEN');
+      expect(body, `${name}: missing string-type guard against { secret: true } placeholder`).toMatch(/isinstance\([^,]+,\s*str\)/);
+    }
+  });
+
+  it('idempotent: a second migrate() pass produces no further upgrades for the already-fixed scripts', () => {
+    // Seed broken first pass.
+    seedBrokenHook('.instar/scripts/imessage-reply.sh', 'imessage-reply.sh');
+    seedBrokenHook('.instar/scripts/serendipity-capture.sh', 'serendipity-capture.sh');
+
+    const migrator = new PostUpdateMigrator({
+      stateDir,
+      projectDir: tmpDir,
+      port: 4242,
+      sessions: { claudePath: 'claude' },
+      hasTelegram: false,
+    } as any);
+
+    const r1 = (migrator as any).migrate();
+    const upgraded1 = (r1.upgraded as string[]).filter(u =>
+      u.includes('imessage-reply.sh') || u.includes('serendipity-capture.sh'));
+    expect(upgraded1.length, 'first pass should upgrade both seeded files').toBeGreaterThanOrEqual(2);
+
+    const migrator2 = new PostUpdateMigrator({
+      stateDir,
+      projectDir: tmpDir,
+      port: 4242,
+      sessions: { claudePath: 'claude' },
+      hasTelegram: false,
+    } as any);
+    const r2 = (migrator2 as any).migrate();
+    const upgraded2 = (r2.upgraded as string[]).filter(u =>
+      u.includes('imessage-reply.sh') || u.includes('serendipity-capture.sh'));
+    expect(upgraded2.length, 'second pass should be a no-op for the already-fixed files').toBe(0);
+  });
+});

--- a/tests/unit/package-completeness.test.ts
+++ b/tests/unit/package-completeness.test.ts
@@ -250,7 +250,11 @@ describe('Package completeness', () => {
       expect.fail('upgrades/ directory does not exist');
     }
 
-    const guides = fs.readdirSync(upgradesDir).filter(f => f.endsWith('.md') && f !== 'NEXT.md');
+    // Exclude NEXT.md (validated separately) and *.eli16.md companion files
+    // (plain-English overviews shipped alongside the technical guide; they
+    // have their own shape and are checked by the instar-dev pre-commit gate).
+    const guides = fs.readdirSync(upgradesDir).filter(f =>
+      f.endsWith('.md') && f !== 'NEXT.md' && !f.endsWith('.eli16.md'));
     expect(guides.length).toBeGreaterThan(0);
 
     const requiredSections = [

--- a/tests/unit/secret-externalization-hook-injection.test.ts
+++ b/tests/unit/secret-externalization-hook-injection.test.ts
@@ -1,0 +1,153 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup only.
+/**
+ * Integration-grade: telegram-topic-context.sh injects topic history when
+ * authToken has been externalized into the encrypted store and only
+ * INSTAR_AUTH_TOKEN env is present.
+ *
+ * Regression test for the 2026-05-29 incident: SecretMigrator pairing moved
+ * authToken out of plaintext config.json, the hook (which read config.json
+ * directly) sent the `{ secret: true }` placeholder as a Bearer token, the
+ * server 403'd, and topic history stopped being injected — leaving the
+ * agent with no idea what the user had been saying after compaction.
+ *
+ * The test seeds the broken state on disk (config.json has the placeholder)
+ * and asserts the new env-first resolver path still produces the injected
+ * output. It exercises the CANONICAL migrator-emitted hook (the one written
+ * by PostUpdateMigrator.getTelegramTopicContextHook()).
+ *
+ * Lives in tests/unit/ rather than tests/integration/ because the only
+ * external moving piece is a per-test in-process stub HTTP server.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+
+describe('telegram-topic-context.sh: secret-externalization survivability', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let hookPath: string;
+  let port: number;
+  let server: http.Server;
+  let recordedHeaders: string[];
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-secext-int-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    recordedHeaders = [];
+
+    // Stub server that mimics the auth-gated /telegram/topics/N/messages route.
+    await new Promise<void>(resolve => {
+      server = http.createServer((req, res) => {
+        recordedHeaders.push(req.headers['authorization'] ?? '');
+        if (req.headers['authorization'] === 'Bearer THE_REAL_TOKEN'
+          && (req.url ?? '').includes('/telegram/topics/')) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            messages: [
+              { text: 'hello agent', fromUser: true, timestamp: '2026-05-29T15:00:00Z' },
+              { text: 'hi user', fromUser: false, timestamp: '2026-05-29T15:01:00Z' },
+            ],
+          }));
+          return;
+        }
+        // /topic-intent/briefing returns empty for both authed + unauthed
+        // (no briefings tracked); the hook tolerates an empty body silently.
+        if ((req.url ?? '').includes('/topic-intent/')) {
+          res.writeHead(204);
+          res.end();
+          return;
+        }
+        // /health gate — without it the hook early-exits before fetching messages.
+        if ((req.url ?? '') === '/health') {
+          res.writeHead(200);
+          res.end(JSON.stringify({ status: 'ok' }));
+          return;
+        }
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid auth token' }));
+      });
+      // Bind to all interfaces. The hook uses `http://localhost:...` which
+      // can resolve to ::1 on Node 25+ which prefers IPv6; a 127.0.0.1-only
+      // bind silently refuses those connections and the test hangs until
+      // execFileSync's timeout fires.
+      server.listen(0, () => {
+        port = (server.address() as { port: number }).port;
+        resolve();
+      });
+    });
+
+    // Seed config.json in the externalized state — the placeholder is on disk.
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({
+      projectName: 'test-secext',
+      projectDir: tmpDir,
+      stateDir,
+      port,
+      authToken: { secret: true },
+    }));
+
+    const migrator = new PostUpdateMigrator({
+      stateDir,
+      projectDir: tmpDir,
+      port,
+      sessions: { claudePath: 'claude' },
+      hasTelegram: false,
+    } as any);
+    const hookContent = (migrator as any).getHookContent('telegram-topic-context');
+    hookPath = path.join(tmpDir, 'telegram-topic-context.sh');
+    fs.writeFileSync(hookPath, hookContent, { mode: 0o755 });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* test cleanup */ } // safe-fs-allow
+  });
+
+  // Async exec is REQUIRED — execFileSync blocks Node's event loop, which
+  // freezes the in-process stub HTTP server and the hook's curl /health
+  // hangs forever. We need the server able to accept connections while the
+  // subprocess runs.
+  function runHook(env: Record<string, string>): Promise<{ stdout: string; stderr: string }> {
+    return new Promise(resolve => {
+      const parentEnv = { ...process.env } as Record<string, string>;
+      delete parentEnv.INSTAR_AUTH_TOKEN;
+      const proc = spawn('bash', [hookPath], {
+        env: { ...parentEnv, ...env, CLAUDE_PROJECT_DIR: tmpDir },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      proc.stdout.on('data', c => stdoutChunks.push(c));
+      proc.stderr.on('data', c => stderrChunks.push(c));
+      proc.on('close', () => resolve({
+        stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+      }));
+      proc.stdin.write(JSON.stringify({ prompt: `[telegram:2169] hello?` }));
+      proc.stdin.end();
+      // Hard timeout backstop.
+      setTimeout(() => proc.kill('SIGKILL'), 8000);
+    });
+  }
+
+  it('injects topic history when INSTAR_AUTH_TOKEN env is set and config has the placeholder', async () => {
+    const out = await runHook({ INSTAR_AUTH_TOKEN: 'THE_REAL_TOKEN' });
+    expect(out.stdout).toContain('TOPIC 2169 RECENT HISTORY');
+    expect(out.stdout).toContain('hello agent');
+    expect(out.stdout).toContain('hi user');
+    expect(recordedHeaders.some(h => h === 'Bearer THE_REAL_TOKEN')).toBe(true);
+    expect(recordedHeaders.some(h => h.includes('secret') || h.includes('object') || h.includes('True'))).toBe(false);
+  });
+
+  it('never leaks the { secret: true } placeholder as a Bearer when env missing', async () => {
+    const out = await runHook({ PATH: process.env.PATH ?? '' });
+    expect(out.stdout).not.toContain('hello agent');
+    // CRITICAL: the placeholder MUST NEVER reach the Authorization header.
+    expect(recordedHeaders.some(h => h.includes('secret') || h.includes('object') || h.includes('True'))).toBe(false);
+  });
+});

--- a/tests/unit/secret-externalization-hook-resolver-lint.test.ts
+++ b/tests/unit/secret-externalization-hook-resolver-lint.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Lint: hooks/scripts/migrator-emitted templates must NOT read authToken
+ * directly from config.json without an INSTAR_AUTH_TOKEN env-first fallback
+ * and a string-type guard.
+ *
+ * Why this lint exists:
+ *
+ * The instar server moves authToken out of plaintext config.json into an
+ * encrypted secret store on first multi-machine pairing (`SecretMigrator`).
+ * The on-disk value becomes the literal placeholder `{ "secret": true }`.
+ * Any reader that does a raw `cfg.authToken` or
+ * `json.load(...).get('authToken','')` then gets a non-string (an object or
+ * Python dict repr) and sends `[object Object]` / `{'secret': True}` as a
+ * Bearer token. The server rejects every request 403, but the failure is
+ * SILENT inside the caller — the hook just emits no output. The user sees an
+ * agent that has no idea what the conversation is about.
+ *
+ * This bug already happened twice in the fleet:
+ *   1. 2026-05-28: telegram-reply.sh 403s after secret-externalization.
+ *   2. 2026-05-29: telegram-topic-context.sh stopped injecting topic history.
+ *                  The agent came back from compaction with no idea what the
+ *                  user had been saying, produced an incoherent reply, and the
+ *                  user (Justin) had to manually trace it back to this class.
+ *
+ * The rule:
+ *
+ *   For every place that reads authToken from `.instar/config.json`,
+ *   `INSTAR_AUTH_TOKEN` env MUST be tried first AND the disk fallback must
+ *   guard against non-string values. SessionManager + JobScheduler already
+ *   inject INSTAR_AUTH_TOKEN into every spawned context, so the env path is
+ *   the canonical one.
+ *
+ * What's banned:
+ *
+ *   - Shell:   `python3 ... json.load(...).get('authToken','')` without a
+ *              preceding `${INSTAR_AUTH_TOKEN:-...}` guard.
+ *   - Shell:   `grep -o '"authToken":"..."'` without an env guard.
+ *   - Node:    `cfg.authToken || ''` / `cfg.authToken ?? ''` without an
+ *              `INSTAR_AUTH_TOKEN` env fallback OR a typeof === 'string'
+ *              check.
+ *
+ * What's allowed:
+ *
+ *   - Callsites that go through `loadConfig()` (in-process; that path runs
+ *     `mergeConfigWithSecrets` and returns the real value).
+ *   - The migrator's own setup-time code (it owns the SecretStore).
+ *   - The lint test itself (this file references the patterns to detect
+ *     them — we use sentinel comments instead of raw substring matching to
+ *     avoid a self-trip).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+const ALLOWLIST = new Set<string>([
+  // The lint test itself.
+  'tests/unit/secret-externalization-hook-resolver-lint.test.ts',
+  // The CLI loads config via the in-process loadConfig() which merges secrets.
+  // Pattern matches incidentally because the file mentions the field name.
+  'src/cli.ts',
+  // The PolicyEnforcementLayer uses Config.loadConfig() in-process.
+  'src/core/PolicyEnforcementLayer.ts',
+  // SecretMigrator owns the canonical SecretStore + plaintext config path.
+  'src/core/SecretMigrator.ts',
+  // SecretStore implementation — privileged.
+  'src/core/SecretStore.ts',
+  // ListenerSessionManager constructor receives the resolved token as a param.
+  'src/threadline/ListenerSessionManager.ts',
+]);
+
+function walk(dir: string, exts: string[]): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(full, exts));
+    } else if (exts.some(e => entry.name.endsWith(e))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function relRepo(p: string): string {
+  return path.relative(REPO_ROOT, p).replace(/\\/g, '/');
+}
+
+// ── Shell patterns ───────────────────────────────────────────────────────
+
+// Forbidden: python3 -c "...json.load(...).get('authToken'...)..." without a
+// string-type guard. Nested parens (open('$CONFIG_FILE')) make a strict regex
+// fragile, so we match per-line on the co-occurrence of `json.load` and
+// `authToken` — the only realistic shape this pattern takes.
+const STRING_GUARD_REGEX = /isinstance\([^,]+,\s*str\)/;
+const ENV_FIRST_REGEX = /INSTAR_AUTH_TOKEN/;
+function hasRawPyAuthRead(content: string): boolean {
+  return content.split('\n').some(line => /json\.load\(/.test(line) && /['"]authToken['"]/.test(line));
+}
+
+// Forbidden: grep -o '"authToken":"..."' without an INSTAR_AUTH_TOKEN env guard
+// in the same file.
+const RAW_GREP_AUTHTOKEN = /grep -o[E]?\s+['"]"authToken"/;
+
+describe('hooks/scripts: authToken reads must survive secret-externalization', () => {
+  const shellFiles = [
+    ...walk(path.join(REPO_ROOT, 'src/templates'), ['.sh', '.mjs', '.py']),
+    ...walk(path.join(REPO_ROOT, 'scripts'), ['.sh', '.mjs', '.js']),
+  ];
+
+  it('every shell/mjs auth-token read goes through env-first with a string-type guard', () => {
+    const offenders: string[] = [];
+    for (const f of shellFiles) {
+      const rel = relRepo(f);
+      if (ALLOWLIST.has(rel)) continue;
+      const content = fs.readFileSync(f, 'utf-8');
+
+      if (hasRawPyAuthRead(content)) {
+        // python3 -c "...authToken..." appears. Must have BOTH env-first AND
+        // string-type guard somewhere in the file.
+        if (!ENV_FIRST_REGEX.test(content) || !STRING_GUARD_REGEX.test(content)) {
+          offenders.push(`${rel}: python3 authToken read lacks INSTAR_AUTH_TOKEN env-first OR isinstance(_, str) guard`);
+        }
+      }
+
+      if (RAW_GREP_AUTHTOKEN.test(content)) {
+        // grep -o '"authToken":"..."' read. Must be guarded by INSTAR_AUTH_TOKEN
+        // env (the grep itself only matches a plaintext string token, so the
+        // externalization case auto-yields empty — env is the cure).
+        if (!ENV_FIRST_REGEX.test(content)) {
+          offenders.push(`${rel}: grep authToken read lacks INSTAR_AUTH_TOKEN env-first`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+// ── PostUpdateMigrator embedded-string patterns ──────────────────────────
+
+describe('PostUpdateMigrator emitted templates: same rule', () => {
+  it('the migrator does not emit any raw authToken-from-config bash pattern', () => {
+    const f = path.join(REPO_ROOT, 'src/core/PostUpdateMigrator.ts');
+    const s = fs.readFileSync(f, 'utf-8');
+
+    // Search for the exact dangerous bash patterns inside template-literal blocks.
+    // (We allow the patterns to appear inside COMMENT lines or inside the SAFE
+    // string-guarded form.)
+    const lines = s.split('\n');
+    const offenders: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+
+      // Raw python read with no string-type guard.
+      const pyMatch = /json\.load\(open\([^)]*\)\)\.get\(['"]authToken['"]/.test(line);
+      const stringGuard = /isinstance\([^,]+,\s*str\)/.test(line);
+      if (pyMatch && !stringGuard) {
+        offenders.push(`PostUpdateMigrator.ts:${i + 1}: raw json.load authToken without isinstance(_, str) guard`);
+      }
+
+      // Raw grep -o '"authToken":"..."' without env-first on the same or previous line.
+      const grepMatch = /grep -o\s+['"]+"authToken"/.test(line);
+      if (grepMatch) {
+        // Look at this line and the 5 preceding lines for INSTAR_AUTH_TOKEN env-first.
+        const window = lines.slice(Math.max(0, i - 5), i + 1).join('\n');
+        if (!/INSTAR_AUTH_TOKEN/.test(window)) {
+          offenders.push(`PostUpdateMigrator.ts:${i + 1}: raw grep authToken without INSTAR_AUTH_TOKEN env-first`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+// ── src/ Node patterns ───────────────────────────────────────────────────
+
+describe('Node reads of authToken: same rule applies', () => {
+  it('every src/**/*.ts direct-disk read of config.json + authToken has env-first OR typeof string guard', () => {
+    // The safe path is `loadConfig()` (from src/core/Config.ts) — it calls
+    // mergeConfigWithSecrets() and returns the real string. This lint is
+    // therefore scoped to callers that bypass loadConfig() by doing their
+    // OWN `JSON.parse(fs.readFileSync(...config.json...))` and then accessing
+    // `.authToken` on the parsed object. Those are the ones at risk.
+    const srcFiles = walk(path.join(REPO_ROOT, 'src'), ['.ts']);
+    const offenders: string[] = [];
+
+    for (const f of srcFiles) {
+      const rel = relRepo(f);
+      if (ALLOWLIST.has(rel)) continue;
+      const content = fs.readFileSync(f, 'utf-8');
+
+      // Does this file do a raw disk read of config.json AND access .authToken?
+      const doesRawDiskRead = /JSON\.parse\(\s*(?:fs|nodeFs)\.readFileSync\([^)]*config\.json/.test(content)
+        || /readFileSync\(\s*[^,]*config\.json/.test(content);
+      const accessesAuthTokenField = /\.authToken\b/.test(content);
+      if (!doesRawDiskRead || !accessesAuthTokenField) continue;
+
+      // Must have INSTAR_AUTH_TOKEN env-first OR a typeof-string check
+      // protecting every read of .authToken. The typeof check can be either
+      // direct (`typeof cfg.authToken === 'string'`) or via a guard helper
+      // (`typeof v === 'string'`) — both reject the { secret: true } placeholder.
+      const hasEnvFirst = ENV_FIRST_REGEX.test(content);
+      const hasDirectTypeofGuard = /typeof\s+[A-Za-z_$][\w$]*\.authToken\s*===\s*['"]string['"]/.test(content);
+      const hasHelperTypeofGuard = /typeof\s+[A-Za-z_$][\w$]*\s*===\s*['"]string['"]/.test(content);
+      if (!hasEnvFirst && !hasDirectTypeofGuard && !hasHelperTypeofGuard) {
+        offenders.push(`${rel}: raw disk read of config.json + .authToken access without INSTAR_AUTH_TOKEN env-first OR typeof string guard`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/secret-externalization-survivability-migrator.test.ts
+++ b/tests/unit/secret-externalization-survivability-migrator.test.ts
@@ -1,0 +1,169 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup only.
+/**
+ * Unit: PostUpdateMigrator's secret-externalization survivability migration.
+ *
+ * Verifies the structural rule: any deployed agent that has the OLD broken
+ * version of a secret-sensitive script (auxiliary path — not on the
+ * always-overwrite track) gets the new env-first version on next update,
+ * while custom forks are left alone.
+ *
+ * The canonical hooks (session-start.sh, compaction-recovery.sh,
+ * telegram-topic-context.sh) are covered by separate always-overwrite tests
+ * elsewhere; this file is scoped to the auxiliary migration path
+ * (migrateSecretExternalizationSurvivability + migrateReplyScriptTo408 with
+ * extended-marker check).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+
+let tmpRoot: string;
+let projectDir: string;
+let stateDir: string;
+let scriptsDir: string;
+let claudeHooksInstarDir: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-secext-mig-'));
+  projectDir = tmpRoot;
+  stateDir = path.join(projectDir, '.instar');
+  scriptsDir = path.join(stateDir, 'scripts');
+  claudeHooksInstarDir = path.join(projectDir, '.claude', 'hooks', 'instar');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.mkdirSync(claudeHooksInstarDir, { recursive: true });
+});
+
+afterEach(() => {
+  try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* test cleanup; tmpRoot may already be gone */ } // safe-fs-allow: per-test tmpdir cleanup
+});
+
+function makeMigrator(): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    stateDir,
+    projectDir,
+    port: 4042,
+    sessions: { claudePath: 'claude' },
+    hasTelegram: false,
+  } as any);
+}
+
+// The migrator is a class so we exercise the public `migrate()` and observe
+// disk effects rather than calling private methods directly.
+function runMigrate(m: PostUpdateMigrator): { upgraded: string[]; skipped: string[]; errors: string[] } {
+  // migrate() handles all phases; we want to assert that
+  // migrateSecretExternalizationSurvivability ran and produced expected
+  // disk changes for the targets we seeded.
+  const result = (m as any).migrate();
+  return {
+    upgraded: result.upgraded ?? [],
+    skipped: result.skipped ?? [],
+    errors: result.errors ?? [],
+  };
+}
+
+describe('secret-externalization survivability migration', () => {
+  it('upgrades imessage-reply.sh when the deployed copy has the broken pattern', () => {
+    // Seed the broken pre-fix shape: shipped-marker header + no INSTAR_AUTH_TOKEN.
+    const broken = [
+      '#!/bin/bash',
+      '# imessage-reply.sh — old shipped version',
+      'AUTH_TOKEN=""',
+      'if [ -f ".instar/config.json" ]; then',
+      '  AUTH_TOKEN=$(python3 -c "import json; print(json.load(open(\'.instar/config.json\')).get(\'authToken\',\'\'))" 2>/dev/null)',
+      'fi',
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(scriptsDir, 'imessage-reply.sh'), broken);
+
+    const m = makeMigrator();
+    const out = runMigrate(m);
+
+    const final = fs.readFileSync(path.join(scriptsDir, 'imessage-reply.sh'), 'utf-8');
+    expect(final).toContain('INSTAR_AUTH_TOKEN');
+    expect(final).toContain('isinstance(v, str)');
+    expect(out.upgraded.some(u => u.includes('imessage-reply.sh'))).toBe(true);
+  });
+
+  it('leaves a CUSTOM imessage-reply.sh fork untouched (no shipped marker)', () => {
+    // No shipped marker → custom; never auto-overwrite.
+    const custom = [
+      '#!/bin/bash',
+      '# user-rolled imessage helper',
+      'echo "custom: $@"',
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(scriptsDir, 'imessage-reply.sh'), custom);
+
+    const m = makeMigrator();
+    runMigrate(m);
+
+    const final = fs.readFileSync(path.join(scriptsDir, 'imessage-reply.sh'), 'utf-8');
+    expect(final).toBe(custom);
+  });
+
+  it('idempotent: when the file is already current it is left alone', () => {
+    // Already-fixed shape (has INSTAR_AUTH_TOKEN env-first).
+    const current = [
+      '#!/bin/bash',
+      '# imessage-reply.sh — current version',
+      'AUTH_TOKEN="${INSTAR_AUTH_TOKEN:-}"',
+      'if [ -z "$AUTH_TOKEN" ] && [ -f ".instar/config.json" ]; then',
+      '  AUTH_TOKEN=$(python3 -c "import json; v=json.load(open(\'.instar/config.json\')).get(\'authToken\',\'\'); print(v if isinstance(v, str) else \'\')" 2>/dev/null)',
+      'fi',
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(scriptsDir, 'imessage-reply.sh'), current);
+
+    const m = makeMigrator();
+    runMigrate(m);
+
+    const final = fs.readFileSync(path.join(scriptsDir, 'imessage-reply.sh'), 'utf-8');
+    expect(final).toBe(current);
+  });
+
+  it('upgrades slack-channel-context.sh when present with broken auth pattern', () => {
+    const broken = [
+      '#!/bin/bash',
+      '# slack-channel-context.sh — auto-inject Slack channel history',
+      'AUTH=""',
+      'if [ -f ".instar/config.json" ]; then',
+      '  AUTH=$(python3 -c "import json; print(json.load(open(\'.instar/config.json\')).get(\'authToken\',\'\'))" 2>/dev/null)',
+      'fi',
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(claudeHooksInstarDir, 'slack-channel-context.sh'), broken);
+
+    const m = makeMigrator();
+    runMigrate(m);
+
+    const final = fs.readFileSync(path.join(claudeHooksInstarDir, 'slack-channel-context.sh'), 'utf-8');
+    expect(final).toContain('INSTAR_AUTH_TOKEN');
+    expect(final).toContain('isinstance(v, str)');
+  });
+});
+
+describe('migrateReplyScriptTo408: extended INSTAR_AUTH_TOKEN marker check', () => {
+  it('upgrades a slack-reply.sh that has 408 handling BUT lacks INSTAR_AUTH_TOKEN env-first', () => {
+    // Old shipped marker; has 408 (old upgrade marker); LACKS INSTAR_AUTH_TOKEN
+    // → was previously stuck in "already up to date" branch and would silently
+    // 403 forever after the agent's authToken got externalized.
+    const broken = [
+      '#!/bin/bash',
+      '# slack-reply.sh — Send a message to a Slack channel via the instar server',
+      'HTTP_CODE=$(echo "$RESPONSE" | tail -1)',
+      'if [ "$HTTP_CODE" = "408" ]; then',
+      '  echo "408 ambiguous" >&2',
+      'fi',
+      'AUTH=$(python3 -c "import json; print(json.load(open(\'.instar/config.json\')).get(\'authToken\',\'\'))" 2>/dev/null)',
+    ].join('\n') + '\n';
+    const scriptPath = path.join(projectDir, '.claude', 'scripts', 'slack-reply.sh');
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.writeFileSync(scriptPath, broken);
+
+    const m = makeMigrator();
+    runMigrate(m);
+
+    const final = fs.readFileSync(scriptPath, 'utf-8');
+    expect(final).toContain('INSTAR_AUTH_TOKEN');
+    expect(final).toContain('isinstance(v, str)');
+  });
+});

--- a/tests/unit/upgrade-guide-check.test.ts
+++ b/tests/unit/upgrade-guide-check.test.ts
@@ -24,8 +24,13 @@ describe('Upgrade Guide Infrastructure', () => {
     const allGuideFiles = fs.existsSync(upgradesDir)
       ? fs.readdirSync(upgradesDir).filter(f => f.endsWith('.md'))
       : [];
-    // NEXT.md is the pending guide for the next release — validated separately
-    const versionedGuides = allGuideFiles.filter(f => f !== 'NEXT.md');
+    // NEXT.md is the pending guide for the next release — validated separately.
+    // *.eli16.md files are plain-English companion overviews (per the
+    // instar-dev pre-commit gate's ELI16 requirement); they have their own
+    // shape (no "What Changed" / "What to Tell Your User" headers, sibling
+    // filename rather than semver). Excluded from the technical-guide shape
+    // checks.
+    const versionedGuides = allGuideFiles.filter(f => f !== 'NEXT.md' && !f.endsWith('.eli16.md'));
 
     it('has at least one upgrade guide', () => {
       expect(allGuideFiles.length).toBeGreaterThan(0);

--- a/upgrades/NEXT.eli16.md
+++ b/upgrades/NEXT.eli16.md
@@ -1,0 +1,71 @@
+# vNEXT — plain English overview
+
+## What this change is
+
+Your agent has a bunch of helper scripts that need to talk to its own local
+server. They authenticate using an "auth token" — basically a password the
+server expects in every request.
+
+Recently we added a feature that **moves that password out of the plain
+config file into an encrypted store**, so the password no longer sits in
+plain text on disk. That's a good security improvement.
+
+But when we did that, we forgot to update *every* place the helpers read
+the password from. So a bunch of helpers kept reading the plain config
+file, found the placeholder marker (a tiny note that says "the real
+password lives in the encrypted store now"), and used **that marker** as
+the password. The server rejected every request. The helpers didn't
+notice the rejection — they just quietly emitted nothing.
+
+The user-visible result: your agent comes back from a memory compaction
+and has no idea what conversation you were in. So it greets you like a
+stranger.
+
+## What already exists
+
+- The `INSTAR_AUTH_TOKEN` environment variable. Every time the agent
+  spawns a new session, it sets this env var with the real password.
+- The encrypted secret store at `.instar/secrets/config.secrets.enc`,
+  managed by `SecretMigrator` / `SecretStore`.
+- A migration system (`PostUpdateMigrator`) that rewrites helper scripts
+  on every auto-update. Some helpers were already on this track; others
+  weren't.
+
+## What's new
+
+- **Every helper now reads `INSTAR_AUTH_TOKEN` env first.** The env var
+  is always present in a session, so it's the canonical path.
+- **The disk-fallback now has a "is this actually a password?" check.**
+  If the config file says `{ "secret": true }` (the placeholder), the
+  guard rejects it and falls through to no-auth instead of sending the
+  placeholder as a password.
+- **A second, unrelated bug** also got fixed in the same change: the
+  helpers parsed the server port from the config file with a regex that
+  refused to allow whitespace, so `"port": 4042` (the format we
+  actually ship) was unparseable. The helpers exited silently with no
+  port, hitting nothing. Replaced with a whitespace-tolerant pattern.
+- **A new automated check** scans every helper for this broken pattern
+  and refuses to commit any future change that reintroduces it.
+- **An update routine** that fixes the helpers on existing deployed
+  agents (without overwriting any custom scripts the user wrote
+  themselves).
+
+## What you need to decide
+
+Nothing. This is a bug fix, no configuration involved. Auto-update will
+heal every deployed agent on next version bump.
+
+## How to verify it worked after deploy
+
+After your agent updates past the version that includes this fix, send
+yourself a Telegram message in any forum topic. The agent's response
+should reference what you actually said — not greet you like it's the
+first message. If it doesn't, something else is wrong; please flag.
+
+## Why this matters more than it might look
+
+This is a "silent failure" class — the helpers were broken but emitted
+no error, so the bug only surfaced through the symptom (incoherent
+agent replies after compaction). That makes the failure invisible until
+a user notices the symptom. The structural lint added in this change
+makes the class itself impossible to reintroduce silently.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,77 @@
+---
+review-convergence: complete
+approved: true
+approved-by: justin (verbal, topic 2169: "yes! then we need to do a full, robust audit to fix this whole class of issues since it keeps coming up")
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Fleet-wide fix for the silent-403 class.** Every shipped hook, script, Node
+helper, and migrator-emitted template that resolves the agent's `authToken`
+now survives the secret-externalization refactor. Two related bugs landed
+together because both produced the same user-visible symptom (a hook that
+stops emitting any output):
+
+- **Auth-token resolution: env-first with a string-type guard.**
+  `INSTAR_AUTH_TOKEN` (set by `SessionManager` per spawned session and by
+  `JobScheduler` per scheduled job) is checked first. The disk fallback now
+  guards `cfg.authToken` against non-string values, so the literal
+  `{ "secret": true }` placeholder produced by `SecretMigrator` after
+  multi-machine pairing can never leak through as a Bearer token. (Previously,
+  scripts sent `[object Object]` or `{'secret': True}` as the Authorization
+  header, the server 403'd, and the script's downstream Python parser
+  silently exited on the error JSON — no output at all.)
+
+- **Port-parse tolerates whitespace.** The `grep -o '"port":[0-9]*'` pattern
+  used in every hook required no whitespace between the colon and the
+  number, but our prettified `config.json` writes `"port": 4042` (with
+  space). The pattern silently produced empty `$PORT`, the hook exited
+  early, and not a single HTTP request reached the server. Replaced with
+  `grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+'` + digit-only extraction.
+
+The structural cure includes a unit-tier lint that fails any future re-
+introduction of the broken pattern (positive + negative-verified) and a new
+migration pass (`migrateSecretExternalizationSurvivability`) that upgrades
+deployed auxiliary scripts (`imessage-reply.sh`, `serendipity-capture.sh`,
+`slack-channel-context.sh`) without touching custom forks. The canonical
+always-overwrite hooks (`session-start.sh`, `compaction-recovery.sh`,
+`telegram-topic-context.sh`) heal on next auto-update by the existing
+`migrateHooks` path.
+
+## What to Tell Your User
+
+If your agent recently went silent after compaction — emitting only the
+wall-clock-time block and then nothing else, despite a healthy server — this
+is the fix. Topic-history injection is back. No configuration needed.
+
+After auto-update, send yourself a Telegram message in any forum topic.
+The agent's response should reference what you actually said — not greet
+you like it's the first message. If it doesn't, something else is wrong;
+please flag.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Auth-token resolution survives secret-externalization | Automatic. Every shipped script + hook now reads `INSTAR_AUTH_TOKEN` env first, then falls back to `config.json` with a string-type guard. |
+| Port-parse tolerates JSON whitespace | Automatic. Hooks no longer exit-early when `config.json` is prettified. |
+| Lint blocks future regressions | `tests/unit/secret-externalization-hook-resolver-lint.test.ts` greps every shell + Node read for the broken pattern and fails on any reintroduction. |
+| Auxiliary-script migration for deployed agents | Existing agents with the old `imessage-reply.sh` / `serendipity-capture.sh` / `slack-channel-context.sh` get the fix on next auto-update via `migrateSecretExternalizationSurvivability`. Custom forks (no shipped marker) are untouched. |
+
+## Evidence
+
+- 13 new tests across 3 tiers (unit + integration-grade + e2e). All green on a
+  full `vitest` run.
+- 35 PostUpdateMigrator-* unit test files (232 tests) verified clean (no
+  regression from migrator extensions).
+- Manual smoke test against a real externalized agent: the fixed
+  `getTelegramTopicContextHook()` content correctly fetches topic history
+  with INSTAR_AUTH_TOKEN env alone (config.json holds the placeholder), and
+  correctly degrades to the unauth branch without leaking the placeholder
+  when env is missing.
+- Side-effects review:
+  `upgrades/side-effects/secret-externalization-hook-resolver-audit.md`.

--- a/upgrades/side-effects/secret-externalization-hook-resolver-audit.md
+++ b/upgrades/side-effects/secret-externalization-hook-resolver-audit.md
@@ -1,0 +1,48 @@
+# Side-effects review — secret-externalization hook resolver audit
+
+## What changed
+
+Two related fleet-wide classes are fixed in one PR.
+
+1. **Auth-token reads survive secret-externalization.** Every shipped shell hook, shell script, Node helper, and migrator-emitted template string that resolves the instar server's `authToken` now:
+   - Prefers `INSTAR_AUTH_TOKEN` env (set by `SessionManager` per spawned session and by `JobScheduler` per scheduled job — always available inside the Claude Code session).
+   - Falls back to reading `config.json` with a string-type guard. When `SecretMigrator` has externalized the token, on-disk `authToken` is the literal placeholder `{ "secret": true }`; the guard rejects it and yields empty so the placeholder cannot leak as a Bearer.
+2. **Port-parse regex tolerates whitespace.** `grep -o '"port":[0-9]*'` is replaced by `grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+'` + digit-only extraction. The previous form silently produced empty PORT whenever `config.json` had `"port": 4042` (with space) — and our prettified configs all do — making every history-injection hook exit early on a healthy install. Both bugs together produced the 2026-05-29 silent-history failure.
+
+## Why
+
+The 2026-05-29 incident: Justin's `telegram-topic-context.sh` stopped injecting topic history after the agent compacted. The hook silently 403'd because `authToken` had been moved to the encrypted secret store and the hook was still reading the literal `{ secret: true }` placeholder out of `config.json` as a Bearer token. The agent came back with no topic context, sent an incoherent reply, and Justin had to manually trace the root cause back. This is the SECOND time a script in this class has bitten a deployed agent (the 2026-05-28 `telegram-reply.sh` 403 was the first), so the fix is structural: env-first everywhere + string-type guard + lint that catches the broken pattern + migrator that upgrades stale-on-disk copies.
+
+## Risk surface
+
+- **Hook scripts (always-overwritten):** `session-start.sh`, `compaction-recovery.sh`, `telegram-topic-context.sh`. Existing agents get the fix on first auto-update. The canonical content lives inside `PostUpdateMigrator.getHookContent()`; the parallel `src/templates/hooks/*.sh` files are kept in sync (the manifest tracks their SHA256). Risk: low — these are already overwritten on every migration tick.
+- **Reply scripts (SHA-based migration):** `telegram-reply.sh` upgrades via `migrateReplyScriptToPortConfig` (pre-PR SHA `371d7e8f…` is already in the prior-shipped allowlist; agents get the fix on first auto-update). `slack-reply.sh` and `whatsapp-reply.sh` upgrade via `migrateReplyScriptTo408`, extended to also fire when `INSTAR_AUTH_TOKEN` is missing — previously the function skipped any script with HTTP 408 handling, which would have stranded a 408-aware-but-auth-broken copy forever. Risk: low — the marker-string check still protects custom forks.
+- **Auxiliary scripts (new migration):** `imessage-reply.sh`, `serendipity-capture.sh`, `slack-channel-context.sh` get a new `migrateSecretExternalizationSurvivability` pass that upgrades shipped copies and skips custom forks (shipped-marker check). Risk: low — guarded by both the marker check and the negative `INSTAR_AUTH_TOKEN` check.
+- **CLI/in-process callers:** `gate.ts` and `nuke.ts` did raw `JSON.parse(fs.readFileSync('config.json'))` then `cfg.authToken` directly. Patched to env-first + string-type-guard. The other CLI commands go through `loadConfig()` (which calls `mergeConfigWithSecrets`) and are already safe. Risk: low — the change is the same env-first/string-guard pattern.
+- **Daemons:** `listener-daemon.ts` (HMAC-derives a signing key from `authToken`), `mcp-stdio-entry.ts` (uses `authToken` as the inbound Bearer). Both now env-first + string-type-guard. Risk: low — the env-first path is preferred when the daemon is launched by the spawn pipeline (which exports the var); the disk fallback still works for plaintext-config installs.
+- **CI / lint:** new unit test `secret-externalization-hook-resolver-lint.test.ts` greps every shell + Node read of `authToken`. The lint MUST go green on the fixed tree (verified) and MUST fail on any re-introduction of the broken pattern (verified via destructive negative test). Risk: low — the lint is allowlisted for in-process `loadConfig` callers; future authors won't trip on the safe path.
+
+## Bug surfaces eliminated
+
+- Topic-history injection silently 403s after secret externalization. (Direct cause of the 2026-05-29 incident.)
+- `telegram-reply.sh` 403s when invoked from a session whose env is missing — partially mitigated in the 2026-05-28 fix but the audit confirmed the disk-fallback path was still broken; this PR closes both halves.
+- `session-start.sh` could not fetch working-memory or shared-state after externalization (same root cause as the topic-history bug).
+- `compaction-recovery.sh` lost its post-compaction memory query after externalization.
+- A standby-machine daemon whose key derivation went through `authToken` would silently derive a key from `{ secret: true }` and lose peer connectivity. (Speculative — no incident observed, but the path was broken.)
+
+## Migration footprint
+
+- `migrateHooks()` already always-overwrites the three canonical hooks → existing agents heal automatically on next auto-update.
+- `migrateScripts()` already SHA-migrates `telegram-reply.sh` and now (with the extended INSTAR_AUTH_TOKEN check) auto-migrates `slack-reply.sh` + `whatsapp-reply.sh` when the previously-shipped marker is present.
+- `migrateSecretExternalizationSurvivability()` (NEW) auto-migrates `imessage-reply.sh`, `serendipity-capture.sh`, `slack-channel-context.sh`. Idempotent on the post-fix shape.
+
+## Testing
+
+- Unit (lint): `tests/unit/secret-externalization-hook-resolver-lint.test.ts` — 3 tests. Greps `src/templates/`, `src/`, `scripts/` for the broken pattern; verified negative (broken pattern caught) and positive (clean pattern passes).
+- Unit (migrator): `tests/unit/secret-externalization-survivability-migrator.test.ts` — 5 tests. Seeds broken state, runs `migrate()`, asserts upgrade. Custom-fork test verifies the marker check protects user-modified scripts.
+- Integration-grade (in `tests/unit/`): `tests/unit/secret-externalization-hook-injection.test.ts` — 2 tests. Spins an in-process stub server (bound to all interfaces; ASYNC `spawn` is required because `execFileSync` blocks Node's event loop and freezes the stub). Seeds `config.json` with the placeholder, runs the canonical migrator-emitted hook, asserts injection works with env-first auth and never leaks the placeholder as a Bearer.
+- E2E: `tests/e2e/secret-externalization-hook-lifecycle.test.ts` — 3 tests. Simulates pre-fix agent → `migrate()` → asserts every shipped script carries the env-first canary; verifies idempotency on a second pass; verifies the canonical migrator-emitted hooks always carry the canary.
+
+## Test count
+
+13 new tests across 3 tiers (per Testing Integrity Standard). 29 existing related tests (`PostUpdateMigrator-time-injection.test.ts`, `compaction-telegram-context.test.ts`) remain green.


### PR DESCRIPTION
## Summary

- Fleet-wide fix for the silent-403 class that produced the 2026-05-29 telegram-topic-context incident: every shipped hook, script, Node helper, and migrator-emitted template now resolves `authToken` via `INSTAR_AUTH_TOKEN` env first (`SessionManager`/`JobScheduler` inject it per spawned context) and falls back to `config.json` with a string-type guard that rejects the `{ "secret": true }` placeholder produced by `SecretMigrator`.
- Second bug found and fixed in the same sweep: the port-parse regex (`grep -o '"port":[0-9]*'`) refused JSON whitespace, so prettified configs (which is what we ship) produced empty `$PORT` and every hook silently exited before reaching any HTTP call. Replaced with `grep -oE '"port"[[:space:]]*:[[:space:]]*[0-9]+'` + digit-only extraction across all 12 callsites.
- Structural cure: unit lint blocks future regression (positive + destructive-negative verified); new `migrateSecretExternalizationSurvivability` pass auto-upgrades deployed auxiliary scripts (`imessage-reply.sh`, `serendipity-capture.sh`, `slack-channel-context.sh`) without touching custom forks; `migrateReplyScriptTo408` extended to upgrade when `INSTAR_AUTH_TOKEN` canary is missing; the always-overwrite canonical hooks heal on next auto-update.

## What changed

**Source (18 files)**
- `src/core/PostUpdateMigrator.ts` — env-first + string-guard in every embedded template string (5 callsites), 6 port-parse callsite fixes, new `migrateSecretExternalizationSurvivability` pass, `migrateReplyScriptTo408` extended with the INSTAR_AUTH_TOKEN canary.
- `src/templates/hooks/{session-start,compaction-recovery,telegram-topic-context,slack-channel-context}.sh` — env-first auth resolution + whitespace-tolerant port parse.
- `src/templates/scripts/{telegram,slack,whatsapp,imessage}-reply.sh`, `serendipity-capture.sh`, `secret-drop-retrieve.mjs`, `instar-watchdog.sh` — same pattern.
- `src/threadline/{listener-daemon,mcp-stdio-entry}.ts`, `src/commands/{gate,nuke}.ts`, `scripts/threadline-bridge-backfill.mjs` — env-first auth resolution.
- `src/data/builtin-manifest.json` — SHA bumps for every entry whose `sourcePath` is `PostUpdateMigrator.ts` (automatic; expected).

**Tests (4 files, 13 new tests across all 3 tiers per Testing Integrity Standard)**
- `tests/unit/secret-externalization-hook-resolver-lint.test.ts` — 3 tests, grep-style lint; positive + destructive-negative verified.
- `tests/unit/secret-externalization-survivability-migrator.test.ts` — 5 tests, migration upgrades broken scripts, leaves custom forks alone, idempotent.
- `tests/unit/secret-externalization-hook-injection.test.ts` — 2 tests, in-process stub server, asserts canonical migrator-emitted hook injects topic history under externalized config AND never leaks the placeholder as a Bearer.
- `tests/e2e/secret-externalization-hook-lifecycle.test.ts` — 3 tests, full `migrate()` lifecycle on pre-fix deployed agent, idempotency.

**Spec (3 files)**
- `upgrades/NEXT.md` — bump: patch + frontmatter (`review-convergence: complete`, `approved: true`).
- `upgrades/NEXT.eli16.md` — plain-English companion.
- `upgrades/side-effects/secret-externalization-hook-resolver-audit.md` — per-killer side-effects review.

## Test plan

- [x] `npx vitest run tests/unit/secret-externalization-*.test.ts tests/e2e/secret-externalization-*.test.ts` — 13/13 green.
- [x] `npx vitest run tests/unit/PostUpdateMigrator-*.test.ts` — 232/232 green (no regression).
- [x] `npx vitest run tests/unit` — full suite green (exit 0).
- [x] `npx tsc --noEmit -p .` — clean.
- [x] Pre-push gate's scoped e2e suite — 331/331 green.
- [x] Manual smoke test on Echo's real config: fixed `telegram-topic-context.sh` correctly fetches topic history with INSTAR_AUTH_TOKEN env alone (config.json holds the placeholder); degrades cleanly without leaking the placeholder when env is missing.
- [ ] CI green (await GitHub Actions).
- [ ] Deploy verification: after auto-update lands on Echo, send a Telegram message and verify the topic-history injection works end-to-end (not just in tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)