### PR TITLE
fix(mentor): surface the real Stage-A error + harden the compose-session spawn

### DIFF
--- a/docs/specs/MENTOR-STAGE-A-ROBUSTNESS-SPEC.eli16.md
+++ b/docs/specs/MENTOR-STAGE-A-ROBUSTNESS-SPEC.eli16.md
@@ -1,0 +1,45 @@
+# In plain English: make the mentor tell us WHY it failed, and stop failing so easily
+
+## What this is about
+
+Instar has a "mentor" that coaches another agent (Codey) through tasks. Each
+cycle, the mentor does a step called **Stage-A**: it spins up a tiny throwaway AI
+session whose only job is to write the next coaching message (as if it were the
+user), then it reads what that session wrote and sends it to the mentee.
+
+On the live agent, Stage-A was **failing every time** — the mentee got nothing —
+and worse, we couldn't tell WHY.
+
+## What went wrong
+
+1. **The error was hidden.** When Stage-A failed, the code caught the error and
+   threw it away, recording only a useless label: "stage-a-failed." The actual
+   reason went to a log line that never showed up where we could read it. So the
+   status page just said "stage-a-failed" with zero detail — a dead end for
+   debugging.
+
+2. **The setup was fragile.** Stage-A creates that throwaway AI session with no
+   safety net. On a busy machine running many agents, creating a new session can
+   fail for a moment (too many at once / load). When that happened, Stage-A just
+   gave up instantly — no retry, no clear message.
+
+## What's new
+
+1. **Tell us why.** The code now keeps the real error message and puts it on the
+   status page (`/mentor/status` → `lastResult.error`). So next time Stage-A
+   fails, we see the actual cause — "couldn't create the session: too many open"
+   or "timed out" — instead of a blank "stage-a-failed."
+
+2. **Try harder before giving up.** Creating the throwaway session now retries
+   once after a short pause (so a momentary hiccup on a busy machine doesn't kill
+   the whole cycle). If it still can't, it throws a clear, specific error that —
+   thanks to fix #1 — shows up on the status page.
+
+## What the reader needs to decide
+
+Nothing to configure. This doesn't change how the mentor coaches — it just makes
+a failing Stage-A both more survivable (a retry) and finally explainable (the
+real error is visible). A test proves a failing Stage-A now reports its true
+cause instead of the empty "stage-a-failed." If the visible cause later turns out
+to be a hard limit (e.g. too many sessions), the next fix becomes obvious from
+the message — which is exactly the point.

--- a/docs/specs/MENTOR-STAGE-A-ROBUSTNESS-SPEC.md
+++ b/docs/specs/MENTOR-STAGE-A-ROBUSTNESS-SPEC.md
@@ -1,0 +1,85 @@
+---
+title: Mentor Stage-A — surface the real error + harden the compose-session spawn
+status: approved
+review-convergence: converged
+approved: true
+approval-basis: >
+  Direct user directive (Justin, 2026-05-29, topic 13435): "lets fix this and
+  make it more robust." Diagnosed live: the mentor tick passes all gates but
+  reliably fails at Stage-A (GET /mentor/status .lastResult.reason =
+  'stage-a-failed') with the real cause swallowed by a bare catch.
+eli16-overview: MENTOR-STAGE-A-ROBUSTNESS-SPEC.eli16.md
+date: 2026-05-29
+---
+
+# Mentor Stage-A: surface the real error + harden the spawn
+
+## Problem (mentor delivers nothing; opaque failure)
+
+The Framework-Onboarding mentor tick (`POST /mentor/tick`, in-process) passes
+every gate (canary → budget → safe-window) and reaches **Stage-A** — the step
+that spawns a tool-less Haiku session to compose the curriculum message
+as-the-user, then polls its tmux output to capture it. On the live agent this
+**reliably fails**: `GET /mentor/status` shows
+`lastResult = {ran:false, reason:'stage-a-failed'}` and nothing reaches the
+mentee. Two defects compound:
+
+1. **Opaque failure.** `runMentorTick` wraps the `spawnStageA` call in a **bare
+   `catch {}`** that discards the error and returns `reason:'stage-a-failed'`
+   with no detail. The real cause goes only to a `console.warn` that did not
+   reach the readable logs, and `lastResult` carried no error — so the failure
+   was undiagnosable from the status endpoint.
+
+2. **Fragile spawn.** `spawnStageA` calls `sessionManager.spawnSession(...)` with
+   **no error handling**. On a busy multi-agent box a transient spawn failure
+   (session-cap pressure / load) throws straight through, collapsing the whole
+   tick to the opaque `stage-a-failed` with no retry and no clear message.
+   (Observed: no compose session appears at all — the spawn throws before
+   creating it.)
+
+## Design
+
+1. **Surface the real error (diagnosability).** `MentorTickResult` gains an
+   optional `error?: string`. `runMentorTick`'s catch captures the message,
+   includes it in the returned result AND in the recorded finding's title, so
+   `GET /mentor/status .lastResult.error` shows exactly why Stage-A failed. The
+   runner's own fire-and-forget `.catch` is given the same `error` field as a
+   belt-and-suspenders for a rejected `tick()`.
+
+2. **Harden the spawn (robustness).** `spawnStageA` now retries the
+   `spawnSession` once with a brief backoff (transient cap/load resilience); on a
+   persistent failure it throws a CLEAR, specific error
+   (`stage-a-spawn-failed: … — <cause>`) which — via change (1) — lands in
+   `lastResult.error`. So the next failure is both more survivable and fully
+   diagnosable.
+
+This is the smallest change that makes the failure non-opaque and adds real
+resilience without altering Stage-A's two-hats isolation design (it still spawns
+an empty-tool-grant session). If the surfaced cause turns out to be a persistent
+session-cap refusal, the targeted next move (exempting the ephemeral internal
+compose session from the user-facing cap) becomes obvious from the error text.
+
+## Convergence notes (adversarial self-review)
+
+- *Does the runner's `.then` path carry the error?* Yes — `runMentorTick`
+  returns `{…, error}`; the runner sets `lastResult = {...r, at}`;
+  `MentorRunResult extends Omit<MentorTickResult,'reason'>` keeps `error?`.
+- *Could the retry mask a real persistent failure?* No — a persistent failure
+  still throws after 2 attempts, with the cause in the message.
+- *Two-hats isolation preserved?* Yes — the spawn still uses the empty
+  `STAGE_A_ALLOWED_TOOLS` grant; only error handling + a retry were added.
+- *Healthy ticks unaffected?* Yes — the new code only runs on the failure path
+  (catch) or a spawn that throws.
+
+## Testing
+
+- **Unit** (`tests/unit/MentorOnboardingRunner.test.ts`): a `spawnStageA` that
+  throws now yields `lastResult = {ran:false, reason:'stage-a-failed', error:<msg>}`
+  — asserts the real cause is surfaced (was swallowed before). Existing 12
+  runner tests + the full mentor/stage suite (113 tests across 9 files) stay
+  green; `tsc --noEmit` clean.
+
+## Migration parity
+
+Server-internal scheduler/server code, not an agent-installed file — every agent
+gets the fix by running the new build. No PostUpdateMigrator entry required.

--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -167,13 +167,18 @@ export class MentorOnboardingRunner {
         this.lastResult = { ...r, at: (this.services.now ?? Date.now)() };
       })
       .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
         this.lastResult = {
           ran: false,
           reason: 'stage-a-failed',
+          // Surface the real failure so GET /mentor/status.lastResult.error is
+          // diagnosable, instead of an opaque 'stage-a-failed' with the cause
+          // only in a console.warn that may never reach the readable logs.
+          error: message,
           at: (this.services.now ?? Date.now)(),
         } as MentorRunResult & { at: number };
         // eslint-disable-next-line no-console
-        console.warn('[mentor] tick failed:', err instanceof Error ? err.message : String(err));
+        console.warn('[mentor] tick failed:', message);
       })
       .finally(() => {
         this.inFlight = false;

--- a/src/scheduler/MentorOnboardingTick.ts
+++ b/src/scheduler/MentorOnboardingTick.ts
@@ -83,6 +83,13 @@ export interface MentorTickResult {
   findingsCount?: number;
   /** The Stage-A message the mentor produced (delivered only in `live` mode by the runner). */
   stageAMessage?: string;
+  /**
+   * When a tick throws (e.g. the Stage-A compose-session spawn/capture fails),
+   * the underlying error message — surfaced in GET /mentor/status.lastResult so
+   * the real cause is visible instead of being swallowed into the opaque
+   * `reason: 'stage-a-failed'`. Diagnosability for the mentor failure class.
+   */
+  error?: string;
 }
 
 /**
@@ -124,14 +131,19 @@ export async function runMentorTick(deps: MentorTickDeps): Promise<MentorTickRes
   let transcript: string;
   try {
     transcript = await deps.spawnStageA(buildStageAContext(deps.surface));
-  } catch {
+  } catch (err) {
+    // Surface the real cause instead of swallowing it. The Stage-A
+    // compose-session can fail to spawn/produce/capture (e.g. session-cap
+    // refusal or reaping under load), and an opaque 'stage-a-failed' with the
+    // error discarded made this undebuggable from GET /mentor/status.
+    const message = err instanceof Error ? err.message : String(err);
     deps.capture({
       framework: deps.framework,
       tickId,
       findings: [
         {
           bucket: 'instar-integration-gap',
-          title: 'Stage-A spawn failed during a mentor tick',
+          title: `Stage-A spawn failed during a mentor tick: ${message}`,
           dedupKey: `${deps.framework}::stage-a-spawn-failed`,
           signature: 'stage-a-spawn-failed',
           severity: 'medium',
@@ -139,7 +151,7 @@ export async function runMentorTick(deps: MentorTickDeps): Promise<MentorTickRes
         },
       ],
     });
-    return { ran: false, reason: 'stage-a-failed' };
+    return { ran: false, reason: 'stage-a-failed', error: message };
   }
 
   // 5. Leakage detection on the Stage-A transcript (§4.3).

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -1574,12 +1574,30 @@ export class AgentServer {
         // §4); we bounded-wait for it to finish, then capture its transcript.
         spawnStageA: async (prompt: string): Promise<string> => {
           const spawnTs = Date.now();
-          const session = await self.sessionManager.spawnSession({
-            name: `mentor-stage-a-${Date.now()}`,
-            prompt,
-            model: 'haiku',
-            allowedTools: [...STAGE_A_ALLOWED_TOOLS], // empty → no tools
-            maxDurationMinutes: 5,
+          const spawnOnce = () =>
+            self.sessionManager.spawnSession({
+              name: `mentor-stage-a-${Date.now()}`,
+              prompt,
+              model: 'haiku',
+              allowedTools: [...STAGE_A_ALLOWED_TOOLS], // empty → no tools
+              maxDurationMinutes: 5,
+            });
+          // E2E-PAIRING: EXEMPT — hardens an existing internal closure (the
+          // Stage-A compose-session spawn: retry + clear error surfacing). Adds
+          // no API route; covered by MentorOnboardingRunner.test.ts.
+          // Robustness: a Stage-A compose-session spawn can fail transiently on a
+          // busy box (session-cap pressure / load). Retry once with a brief
+          // backoff; on a persistent failure throw a CLEAR, specific error
+          // (surfaced in GET /mentor/status.lastResult.error) instead of an
+          // opaque throw that collapses to 'stage-a-failed' with no cause.
+          const session = await spawnOnce().catch(async () => {
+            await new Promise((r) => setTimeout(r, 3000));
+            return spawnOnce().catch((err) => {
+              const why = err instanceof Error ? err.message : String(err);
+              throw new Error(
+                `stage-a-spawn-failed: could not spawn the Stage-A compose session after 2 attempts — ${why}`,
+              );
+            });
           });
           const tmux = session.tmuxSession;
           let finished = false;

--- a/tests/unit/MentorOnboardingRunner.test.ts
+++ b/tests/unit/MentorOnboardingRunner.test.ts
@@ -113,4 +113,22 @@ describe('MentorOnboardingRunner', () => {
     expect(svc.spawnStageA).not.toHaveBeenCalled();
     expect(runner.status().lastResult?.reason).toBe('disabled');
   });
+
+  it('surfaces the real Stage-A error into lastResult.error (not just an opaque stage-a-failed)', async () => {
+    const svc = fakeServices({
+      spawnStageA: vi.fn(async () => {
+        throw new Error('spawn refused: session cap reached');
+      }),
+    });
+    const cfg: MentorConfig = { ...DEFAULT_MENTOR_CONFIG, enabled: true, mode: 'dry-run' };
+    const runner = new MentorOnboardingRunner(svc, () => cfg);
+    runner.startTick();
+    await new Promise((res) => setTimeout(res, 10));
+    const lr = runner.status().lastResult;
+    expect(lr?.ran).toBe(false);
+    expect(lr?.reason).toBe('stage-a-failed');
+    // The real cause is now visible via GET /mentor/status.lastResult.error,
+    // instead of being swallowed by the bare catch in runMentorTick.
+    expect(lr?.error).toContain('spawn refused: session cap reached');
+  });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,37 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**The Framework-Onboarding mentor now reports WHY a tick failed, and its Stage-A
+step is more resilient.** The mentor's Stage-A step spawns a tiny tool-less
+session to compose the next coaching message, then captures it. When that spawn
+failed (common on a busy multi-agent box — session-cap pressure / load), the
+whole tick collapsed to an opaque `stage-a-failed` with the real cause thrown
+away, so it was undiagnosable from `GET /mentor/status`. Now: the real error is
+surfaced into `lastResult.error`, and the Stage-A compose-session spawn retries
+once with a short backoff before failing with a clear, specific message.
+
+## What to Tell Your User
+
+Only relevant if you run the (off-by-default) Framework-Onboarding mentor. It now
+recovers from a transient compose-session spawn failure, and when it does fail it
+tells you exactly why (visible at `/mentor/status`) instead of an unexplained
+"stage-a-failed."
+
+## Summary of New Capabilities
+
+- `GET /mentor/status` → `lastResult.error` now carries the real Stage-A failure
+  cause (`MentorTickResult.error`), instead of swallowing it.
+- `spawnStageA` retries the compose-session spawn once (transient resilience) and
+  throws a clear `stage-a-spawn-failed: … — <cause>` on persistent failure.
+
+## Evidence
+
+- `tests/unit/MentorOnboardingRunner.test.ts` (+1): a `spawnStageA` that throws
+  now yields `lastResult = {ran:false, reason:'stage-a-failed', error:<msg>}` —
+  asserts the cause is surfaced (was swallowed by a bare catch in
+  `runMentorTick`). Full mentor/stage suite (113 tests / 9 files) green;
+  `tsc --noEmit` clean.
+- Side-effects: `upgrades/side-effects/mentor-stage-a-robustness.md`.

--- a/upgrades/side-effects/mentor-stage-a-robustness.md
+++ b/upgrades/side-effects/mentor-stage-a-robustness.md
@@ -1,0 +1,57 @@
+# Side-effects review — Mentor Stage-A: surface error + harden spawn
+
+**Spec:** `docs/specs/MENTOR-STAGE-A-ROBUSTNESS-SPEC.md`
+**Changes:** `src/scheduler/MentorOnboardingTick.ts`, `src/scheduler/MentorOnboardingRunner.ts`, `src/server/AgentServer.ts` (+ unit test)
+**Class:** mentor reliability + diagnosability fix.
+
+## What changed
+
+1. `MentorTickResult` gains `error?: string`.
+2. `runMentorTick`'s bare `catch {}` around `spawnStageA` → `catch (err)` that
+   captures the message into the returned result (`{…, error}`) + the finding
+   title.
+3. `MentorOnboardingRunner.startTick().catch` adds the same `error` field (for a
+   rejected `tick()`).
+4. `spawnStageA` (AgentServer.ts) wraps `spawnSession` in a single retry with a
+   3s backoff; on persistent failure throws `stage-a-spawn-failed: … — <cause>`.
+
+## Blast radius
+
+- **`/mentor/status` consumers:** purely additive — `lastResult` may now include
+  an `error` string on the failure path. No field removed/renamed.
+- **Healthy mentor ticks:** unchanged — new code runs only on the catch/failure
+  path or a throwing spawn.
+- **Stage-A two-hats isolation:** unchanged — still spawns with the empty
+  `STAGE_A_ALLOWED_TOOLS` grant; only error handling + a retry added.
+- **Public API / DB schema / config:** none changed. No new route (the
+  AgentServer change is inside an existing closure — E2E-PAIRING exempt).
+
+## What could break (and why it doesn't)
+
+- **The retry doubling spawn load?** Only on a spawn that already failed once,
+  and capped at 2 attempts with a 3s gap — negligible, and only on the
+  already-failing path.
+- **`error` field typing:** flows through `MentorRunResult extends
+  Omit<MentorTickResult,'reason'>` which keeps `error?`. `tsc` clean.
+- **Masking a persistent failure:** no — a persistent failure still throws after
+  2 attempts, now with the cause in the message.
+
+## Security
+
+No new external input / network / auth / fs surface. The surfaced `error` is an
+internal spawn/timeout message (no secrets).
+
+## Migration parity
+
+Server-internal scheduler/server code — every agent gets it by running the new
+build. No PostUpdateMigrator entry required.
+
+## Rollback
+
+Revert the commit. No persisted state, schema, or API contract affected.
+
+## Tests
+
+`tests/unit/MentorOnboardingRunner.test.ts` (+1): a throwing `spawnStageA` now
+surfaces `lastResult.error` with the real message (was swallowed). Full
+mentor/stage suite — 113 tests across 9 files — green; `tsc --noEmit` clean.


### PR DESCRIPTION
## Problem (mentor delivers nothing; opaque failure)

The Framework-Onboarding mentor tick (`POST /mentor/tick`) passes every gate (canary → budget → safe-window) and reaches **Stage-A** — which spawns a tool-less Haiku session to compose the curriculum message and captures it. On the live agent this **reliably fails**: `GET /mentor/status` → `lastResult = {ran:false, reason:'stage-a-failed'}`, nothing reaches the mentee. Two compounding defects:

1. **Opaque failure** — `runMentorTick` wrapped `spawnStageA` in a **bare `catch {}`** that discarded the error and returned `reason:'stage-a-failed'` with no detail (the real cause went only to a `console.warn` that didn't reach the readable logs). Undiagnosable from the status endpoint.
2. **Fragile spawn** — `spawnStageA` called `sessionManager.spawnSession(...)` with **no error handling**; a transient spawn failure on a busy multi-agent box (session-cap pressure / load) threw straight through. (Observed: no compose session appears at all — the spawn throws before creating it.)

## Fix

1. **Surface the real error** — `MentorTickResult` gains `error?:string`; `runMentorTick`'s catch captures the message into the returned result + the recorded finding's title, so `GET /mentor/status.lastResult.error` shows exactly why Stage-A failed. The runner's fire-and-forget `.catch` gets the same field.
2. **Harden the spawn** — `spawnStageA` retries `spawnSession` once with a 3s backoff (transient resilience), then throws a clear `stage-a-spawn-failed: … — <cause>` on persistent failure — which (via #1) lands in `lastResult.error`.

Two-hats isolation unchanged (still the empty `STAGE_A_ALLOWED_TOOLS` grant). Healthy ticks unaffected (new code runs only on the failure path). The `AgentServer.ts` change is inside an existing closure (no new route — E2E-PAIRING exempt).

## Tests

`tests/unit/MentorOnboardingRunner.test.ts` (+1): a `spawnStageA` that throws now yields `lastResult = {ran:false, reason:'stage-a-failed', error:<msg>}` — asserts the cause is surfaced (was swallowed). Full mentor/stage suite — **113 tests across 9 files** — green; `tsc --noEmit` + `npm run lint` clean.

Spec: `docs/specs/MENTOR-STAGE-A-ROBUSTNESS-SPEC.md` (+ ELI16 + side-effects). Follows the live diagnosis on topic 13435 (Codey mentorship thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)