### PR TITLE
fix(pipeline): warn on unimplemented failure-learning sources + assert hook migration parity

### DIFF
--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -689,6 +689,24 @@ export class AgentServer {
             },
           });
         }
+
+        // Sources whose CONFIG FLAGS exist but whose IMPLEMENTATIONS have not
+        // shipped yet are silent no-ops — turning them on creates a false sense
+        // of coverage. Surface that boundary loudly at boot so the operator
+        // (and any tier-1 supervisor) sees the gap instead of trusting an
+        // invisible-and-broken pipeline. Per the 2026-05-29 pipeline post-mortem:
+        // "specced but not wired" was a recurring class behind shipped bugs.
+        const unimplementedActive: string[] = [];
+        if (sources?.regression === true) unimplementedActive.push('regression');
+        if (Array.isArray(sources?.degradation) && sources.degradation.length > 0) unimplementedActive.push('degradation');
+        if (unimplementedActive.length > 0) {
+          console.warn(
+            `[instar] failure-learning: source(s) [${unimplementedActive.join(', ')}] are configured ON ` +
+            `but have no implementation yet — they are silent no-ops. ` +
+            `Set them back to off (regression: false, degradation: []) until the source impl ships, ` +
+            `or you'll have a flag that lies about coverage.`,
+          );
+        }
       }
     } catch (err) {
       console.warn('[instar] failure-learning init failed (non-fatal):', err);

--- a/tests/unit/failure-learning-sources-wiring.test.ts
+++ b/tests/unit/failure-learning-sources-wiring.test.ts
@@ -1,0 +1,170 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup only.
+/**
+ * Wiring-integrity: Failure-Learning Loop ingestion sources are constructed
+ * iff their config flag is set, and started post-listen / stopped on close.
+ *
+ * Per the 2026-05-29 pipeline post-mortem: the substrate for `ci` and `revert`
+ * was already shipped (PRs around #484), but no test asserts that flipping the
+ * flag actually causes the corresponding poller/detector to come online. This
+ * file closes that gap and serves as the canonical check that future flag
+ * additions (regression, degradation) must satisfy before being claimed alive.
+ *
+ * Also asserts that the `regression` and `degradation` flags — config-only
+ * with no implementation yet — produce a LOUD warning at boot instead of
+ * silently no-op'ing. "Specced but not wired" was one of the five recurring
+ * bug classes; this test is the structural backstop.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AgentServer } from '../../src/server/AgentServer.js';
+
+let tmpDir: string;
+let projectDir: string;
+let stateDir: string;
+
+function baseConfig(sources: Record<string, unknown>) {
+  return {
+    projectName: 'test-fl-wiring',
+    projectDir,
+    stateDir,
+    port: 0,
+    authToken: 'test-token-abc',
+    sessions: { claudePath: 'claude' },
+    monitoring: {
+      failureLearning: {
+        enabled: true,
+        minSupport: 4,
+        minDistinctSessions: 3,
+        minDistinctCauseCommits: 3,
+        attributionConfidenceFloor: 0.6,
+        insightTelegramEscalation: false,
+        sources,
+      },
+    },
+  };
+}
+
+function makeServer(config: ReturnType<typeof baseConfig>): AgentServer {
+  return new AgentServer({
+    config: config as never,
+    sessionManager: { getSessions: () => [], getSession: () => null } as never,
+    state: { read: () => ({ sessions: [] }), write: () => undefined } as never,
+  } as never);
+}
+
+function getPrivate<T>(srv: AgentServer, name: string): T {
+  return (srv as unknown as Record<string, T>)[name];
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-fl-wiring-'));
+  projectDir = tmpDir;
+  stateDir = path.join(tmpDir, '.instar');
+  fs.mkdirSync(stateDir, { recursive: true });
+});
+
+afterEach(() => {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* test cleanup */ } // safe-fs-allow
+});
+
+describe('Failure-Learning sources: constructed iff flag set', () => {
+  it('all sources off → no poller, no detector', () => {
+    const srv = makeServer(baseConfig({ ci: false, revert: false, regression: false, degradation: [] }));
+    expect(getPrivate<unknown>(srv, 'ciFailurePoller')).toBeNull();
+    expect(getPrivate<unknown>(srv, 'revertDetector')).toBeNull();
+    expect(getPrivate<unknown>(srv, 'failureLedger')).not.toBeNull();
+  });
+
+  it('ci: true → CiFailurePoller constructed (but not started until listen)', () => {
+    const srv = makeServer(baseConfig({ ci: true, revert: false, regression: false, degradation: [] }));
+    const poller = getPrivate<{ start: unknown; stop: unknown } | null>(srv, 'ciFailurePoller');
+    expect(poller, 'CiFailurePoller should be constructed when sources.ci=true').not.toBeNull();
+    expect(typeof poller?.start, 'poller exposes start()').toBe('function');
+    expect(typeof poller?.stop, 'poller exposes stop()').toBe('function');
+    expect(getPrivate<unknown>(srv, 'revertDetector'), 'revertDetector stays null when revert=false').toBeNull();
+  });
+
+  it('revert: true → RevertDetector constructed', () => {
+    const srv = makeServer(baseConfig({ ci: false, revert: true, regression: false, degradation: [] }));
+    const det = getPrivate<{ start: unknown; stop: unknown } | null>(srv, 'revertDetector');
+    expect(det, 'RevertDetector should be constructed when sources.revert=true').not.toBeNull();
+    expect(typeof det?.start, 'detector exposes start()').toBe('function');
+    expect(typeof det?.stop, 'detector exposes stop()').toBe('function');
+    expect(getPrivate<unknown>(srv, 'ciFailurePoller'), 'ciFailurePoller stays null when ci=false').toBeNull();
+  });
+
+  it('both ci+revert on → both constructed independently', () => {
+    const srv = makeServer(baseConfig({ ci: true, revert: true, regression: false, degradation: [] }));
+    expect(getPrivate<unknown>(srv, 'ciFailurePoller')).not.toBeNull();
+    expect(getPrivate<unknown>(srv, 'revertDetector')).not.toBeNull();
+  });
+
+  it('failureLearning.enabled: false → ledger AND sources are inert even if source flags set', () => {
+    const cfg = baseConfig({ ci: true, revert: true, regression: false, degradation: [] });
+    cfg.monitoring.failureLearning.enabled = false;
+    const srv = makeServer(cfg);
+    expect(getPrivate<unknown>(srv, 'failureLedger')).toBeNull();
+    expect(getPrivate<unknown>(srv, 'ciFailurePoller')).toBeNull();
+    expect(getPrivate<unknown>(srv, 'revertDetector')).toBeNull();
+  });
+});
+
+describe('Unimplemented sources: loud warning, not silent no-op', () => {
+  it('regression: true triggers a console.warn naming the gap', () => {
+    const warns: string[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+    try {
+      makeServer(baseConfig({ ci: false, revert: false, regression: true, degradation: [] }));
+    } finally {
+      console.warn = orig;
+    }
+    const flWarn = warns.find(w => w.includes('failure-learning') && w.includes('regression'));
+    expect(flWarn, 'expected a warning naming the unimplemented regression source').toBeTruthy();
+    expect(flWarn).toContain('no implementation');
+  });
+
+  it('degradation: [item] triggers a console.warn naming the gap', () => {
+    const warns: string[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+    try {
+      makeServer(baseConfig({ ci: false, revert: false, regression: false, degradation: ['stuck-session'] }));
+    } finally {
+      console.warn = orig;
+    }
+    const flWarn = warns.find(w => w.includes('failure-learning') && w.includes('degradation'));
+    expect(flWarn, 'expected a warning naming the unimplemented degradation source').toBeTruthy();
+  });
+
+  it('both unimplemented on → one warning listing both', () => {
+    const warns: string[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+    try {
+      makeServer(baseConfig({ ci: false, revert: false, regression: true, degradation: ['x'] }));
+    } finally {
+      console.warn = orig;
+    }
+    const flWarn = warns.find(w => w.includes('failure-learning'));
+    expect(flWarn).toBeTruthy();
+    expect(flWarn).toContain('regression');
+    expect(flWarn).toContain('degradation');
+  });
+
+  it('only implemented sources on → NO unimplemented-source warning emitted', () => {
+    const warns: string[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+    try {
+      makeServer(baseConfig({ ci: true, revert: true, regression: false, degradation: [] }));
+    } finally {
+      console.warn = orig;
+    }
+    const flWarn = warns.find(w => w.includes('failure-learning') && w.includes('no implementation'));
+    expect(flWarn).toBeFalsy();
+  });
+});

--- a/tests/unit/migration-parity-hooks.test.ts
+++ b/tests/unit/migration-parity-hooks.test.ts
@@ -1,0 +1,167 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup only.
+/**
+ * Migration-parity assertion: the set of hook files written by `installHooks()`
+ * (fresh-init code path, src/commands/init.ts) MUST match the set written by
+ * `PostUpdateMigrator.migrateHooks()` (auto-update code path), and for every
+ * file produced by both paths the *content* must be byte-equal.
+ *
+ * Why this test exists
+ * --------------------
+ * Per the 2026-05-29 pipeline post-mortem, "Migration parity skip" was one of
+ * five recurring bug classes — a feature shipped to fresh agents but not to
+ * existing ones (or vice-versa). The slack-channel-context.sh fix-up in PR #542
+ * was caught mid-PR by manual diff; without this test it would have shipped
+ * stale for the 2 weeks between releases.
+ *
+ * Concrete failure mode this test catches
+ * ---------------------------------------
+ * Today (snapshotted while writing): `installHooks()` writes 16 hook files;
+ * `migrateHooks()` writes 21. Five files (telegram-topic-context.sh,
+ * slopcheck-guard.js, scope-coherence-collector.js,
+ * scope-coherence-checkpoint.js, free-text-guard.sh, skill-usage-telemetry.sh)
+ * exist on disk only AFTER the first auto-update — a fresh `instar init` agent
+ * is missing them until the first migration cycle runs. The test records the
+ * gap explicitly (allowlist below), so any NEW gap fails immediately.
+ *
+ * Allowlist semantics
+ * -------------------
+ * `INSTALL_VS_MIGRATE_KNOWN_GAPS` enumerates the files we KNOW are
+ * migrator-only and have explicitly accepted as a deferred-install
+ * compromise (each entry MUST cite a follow-up issue or rationale). Adding to
+ * the allowlist requires updating the rationale; failing to add to the
+ * allowlist when introducing a new migrator-only file fails this test.
+ *
+ * What this test does NOT catch (and tests added in companion PRs do)
+ * ------------------------------
+ * - Content drift between `src/templates/hooks/*.sh` files and the migrator's
+ *   `getHookContent()` output (separate manifest SHA check in
+ *   `lint-template-sha-history`).
+ * - Drift between `installHooks` content and `getHookContent` for files
+ *   produced by BOTH paths: covered HERE via byte-equality assertion.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const INIT_PATH = path.join(REPO_ROOT, 'src/commands/init.ts');
+const MIGRATOR_PATH = path.join(REPO_ROOT, 'src/core/PostUpdateMigrator.ts');
+
+/**
+ * Known-and-accepted gaps: filenames written by `migrateHooks()` but NOT
+ * `installHooks()`. Adding to this allowlist requires citing why the deferred
+ * install is acceptable.
+ *
+ * Audit timestamp: 2026-05-29 (during the pipeline post-mortem PR).
+ */
+const INSTALL_VS_MIGRATE_KNOWN_GAPS: Record<string, string> = {
+  'telegram-topic-context.sh':
+    'Deferred-install accepted: settings.json references this hook on init, ' +
+    'but the file is written by PostUpdateMigrator on first auto-update. ' +
+    'A fresh-init agent will fail-silent on this hook for the ~30min until ' +
+    'the first auto-update tick. Follow-up: surface in `installHooks()`.',
+  'slopcheck-guard.js':
+    'Deferred-install accepted: optional review hook; first auto-update covers it.',
+  'scope-coherence-collector.js':
+    'Deferred-install accepted: scope-coherence-* hooks are scaffolded by the ' +
+    'auto-update path. Follow-up: move to installHooks() for fresh-init parity.',
+  'scope-coherence-checkpoint.js':
+    'Deferred-install accepted: same scope-coherence-* group.',
+  'free-text-guard.sh':
+    'Deferred-install accepted: free-text-guard hook is migrator-only.',
+  'skill-usage-telemetry.sh':
+    'Deferred-install accepted: telemetry hook is migrator-only.',
+};
+
+/**
+ * Parse the list of `writeFileSync(path.join(<HOOKS_DIR_VAR>, '<filename>'), …)`
+ * calls from a source file by simple regex. We deliberately do NOT run the
+ * code — installHooks() has side-effects, and the static surface is the
+ * authoritative thing to check.
+ *
+ * Only hook-directory writes count (writes to `instarScriptsDir` are scripts,
+ * not hooks; those have their own parity story via `migrateScripts` and live
+ * outside the scope of this test).
+ *
+ * Regex covers the canonical hook-dir variable names used in both files:
+ *   fs.writeFileSync(path.join(hooksDir,         'foo.sh'), …)
+ *   fs.writeFileSync(path.join(instarHooksDir,   'foo.sh'), …)
+ */
+const WRITE_RE = /fs\.writeFileSync\(\s*path\.join\(\s*(?:hooksDir|instarHooksDir)\s*,\s*['"]([^'"]+\.(?:sh|js))['"]/g;
+
+function extractWrittenFiles(filePath: string, regionStart: RegExp, regionEnd: RegExp): Set<string> {
+  const src = fs.readFileSync(filePath, 'utf-8');
+  const startIdx = src.search(regionStart);
+  if (startIdx < 0) throw new Error(`region-start regex did not match in ${filePath}`);
+  const tail = src.slice(startIdx);
+  const endRel = tail.search(regionEnd);
+  if (endRel < 0) throw new Error(`region-end regex did not match in ${filePath}`);
+  const region = tail.slice(0, endRel);
+  const out = new Set<string>();
+  let m: RegExpExecArray | null;
+  WRITE_RE.lastIndex = 0;
+  while ((m = WRITE_RE.exec(region)) !== null) out.add(m[1]);
+  return out;
+}
+
+function installHooksWrites(): Set<string> {
+  return extractWrittenFiles(
+    INIT_PATH,
+    /^function installHooks\(/m,
+    /\n\}\s*\n\s*function /,
+  );
+}
+
+function migrateHooksWrites(): Set<string> {
+  return extractWrittenFiles(
+    MIGRATOR_PATH,
+    /private migrateHooks\(/m,
+    /\n {2}private [a-zA-Z]/,
+  );
+}
+
+describe('Migration parity — fresh init vs auto-update', () => {
+  it('installHooks() writes a non-empty set of hook files', () => {
+    const files = installHooksWrites();
+    expect(files.size, 'fresh-init must install some hooks').toBeGreaterThan(0);
+  });
+
+  it('migrateHooks() writes a non-empty set of hook files', () => {
+    const files = migrateHooksWrites();
+    expect(files.size, 'auto-update must install some hooks').toBeGreaterThan(0);
+  });
+
+  it('every migrator-installed hook is either also installed on fresh init OR explicitly allowlisted', () => {
+    const fresh = installHooksWrites();
+    const update = migrateHooksWrites();
+    const migratorOnly = [...update].filter(f => !fresh.has(f));
+    const unaccepted = migratorOnly.filter(f => !(f in INSTALL_VS_MIGRATE_KNOWN_GAPS));
+    expect(
+      unaccepted,
+      `migrator-only hook files (not installed on fresh init) must be added to ` +
+      `INSTALL_VS_MIGRATE_KNOWN_GAPS with a documented rationale. ` +
+      `Newly-unaccepted: [${unaccepted.join(', ')}]`,
+    ).toEqual([]);
+  });
+
+  it('no install-only hooks (fresh init must not write a file the migrator doesn\'t maintain)', () => {
+    const fresh = installHooksWrites();
+    const update = migrateHooksWrites();
+    const installOnly = [...fresh].filter(f => !update.has(f));
+    expect(
+      installOnly,
+      `fresh-init writes a hook the auto-update path does not maintain — ` +
+      `that file will drift on every release. Add it to migrateHooks() or remove from ` +
+      `installHooks(). Affected: [${installOnly.join(', ')}]`,
+    ).toEqual([]);
+  });
+
+  it('the known-gap allowlist itself stays small (regression alarm if it grows past ~10)', () => {
+    // A growing allowlist signals the migration-parity problem is getting
+    // worse, not better. Bump this ceiling deliberately if you have a reason.
+    const count = Object.keys(INSTALL_VS_MIGRATE_KNOWN_GAPS).length;
+    expect(count, `allowlist size ${count} exceeds the soft cap; the deferred-install gap is widening`).toBeLessThanOrEqual(10);
+  });
+});

--- a/upgrades/NEXT.eli16.md
+++ b/upgrades/NEXT.eli16.md
@@ -2,70 +2,81 @@
 
 ## What this change is
 
-Your agent has a bunch of helper scripts that need to talk to its own local
-server. They authenticate using an "auth token" — basically a password the
-server expects in every request.
+Your agent has a feature called the "Failure-Learning Loop" — it watches for
+things that go wrong (a CI run fails, a recent commit gets reverted, an
+internal health-check trips) and writes a little record so you can later ask
+"why do my agents keep breaking?" and get a real answer instead of vibes.
 
-Recently we added a feature that **moves that password out of the plain
-config file into an encrypted store**, so the password no longer sits in
-plain text on disk. That's a good security improvement.
+The loop has a config switch for each kind of failure it watches. Some of
+those switches were checked in months ago but never connected to anything —
+flipping them on did literally nothing, the loop just pretended the source
+was active. That's exactly the failure mode the post-mortem yesterday named
+as "specced but not wired" — a real, repeat offender.
 
-But when we did that, we forgot to update *every* place the helpers read
-the password from. So a bunch of helpers kept reading the plain config
-file, found the placeholder marker (a tiny note that says "the real
-password lives in the encrypted store now"), and used **that marker** as
-the password. The server rejected every request. The helpers didn't
-notice the rejection — they just quietly emitted nothing.
+This change does two things:
 
-The user-visible result: your agent comes back from a memory compaction
-and has no idea what conversation you were in. So it greets you like a
-stranger.
+1. **Loud warning when you flip on a switch that isn't wired up.** If you set
+   `monitoring.failureLearning.sources.regression: true` or
+   `monitoring.failureLearning.sources.degradation: [...]`, the agent now
+   says, at startup: "you turned this on but nothing implements it yet —
+   set it back off until the impl ships." Before, those switches were silent
+   no-ops.
+
+2. **A new automated check that catches a different bug class.** When you do
+   a fresh `instar init`, certain hooks get installed. When the agent
+   auto-updates, a different bit of code re-installs hooks. We had at least
+   one case in the last release where the two lists disagreed — a fresh
+   agent was missing a hook that existing agents had, because nobody had
+   noticed the divergence. The new check reads both lists and refuses
+   to commit any change that creates a new divergence (with a small
+   allowlist for documented technical debt).
 
 ## What already exists
 
-- The `INSTAR_AUTH_TOKEN` environment variable. Every time the agent
-  spawns a new session, it sets this env var with the real password.
-- The encrypted secret store at `.instar/secrets/config.secrets.enc`,
-  managed by `SecretMigrator` / `SecretStore`.
-- A migration system (`PostUpdateMigrator`) that rewrites helper scripts
-  on every auto-update. Some helpers were already on this track; others
-  weren't.
+- The Failure-Learning Loop itself, with ledger + analyzer + API at `/failures/*`.
+- The `ci` and `revert` ingestion sources, which actually work and capture events.
+- The `regression` and `degradation` source flags in config defaults
+  (just no implementation behind them).
+- `PostUpdateMigrator` (the auto-update path) and `installHooks()`
+  (the fresh-init path), both of which write hooks to disk independently.
 
 ## What's new
 
-- **Every helper now reads `INSTAR_AUTH_TOKEN` env first.** The env var
-  is always present in a session, so it's the canonical path.
-- **The disk-fallback now has a "is this actually a password?" check.**
-  If the config file says `{ "secret": true }` (the placeholder), the
-  guard rejects it and falls through to no-auth instead of sending the
-  placeholder as a password.
-- **A second, unrelated bug** also got fixed in the same change: the
-  helpers parsed the server port from the config file with a regex that
-  refused to allow whitespace, so `"port": 4042` (the format we
-  actually ship) was unparseable. The helpers exited silently with no
-  port, hitting nothing. Replaced with a whitespace-tolerant pattern.
-- **A new automated check** scans every helper for this broken pattern
-  and refuses to commit any future change that reintroduces it.
-- **An update routine** that fixes the helpers on existing deployed
-  agents (without overwriting any custom scripts the user wrote
-  themselves).
+- Boot-time warning if `regression` or `degradation` source flag is on but
+  unimplemented.
+- Unit test that pins the source-flag-to-poller wiring so future regressions
+  fail the test suite instead of silently disabling the loop.
+- Unit test that diffs the fresh-init hook list against the auto-update hook
+  list and fails on any new divergence.
+- A small allowlist of currently-accepted divergences (six entries, with
+  rationale per entry; soft cap of ten so the list can't quietly grow).
 
 ## What you need to decide
 
-Nothing. This is a bug fix, no configuration involved. Auto-update will
-heal every deployed agent on next version bump.
+Nothing. This is structural backstop, no configuration involved. Existing
+agents pick up the warning on next process restart (auto-update will trigger
+that). Future PRs that try to introduce a new fresh-init-vs-auto-update gap
+will fail their tests.
 
 ## How to verify it worked after deploy
 
-After your agent updates past the version that includes this fix, send
-yourself a Telegram message in any forum topic. The agent's response
-should reference what you actually said — not greet you like it's the
-first message. If it doesn't, something else is wrong; please flag.
+If you haven't touched `monitoring.failureLearning.sources` in your config,
+you should see exactly the same behavior. If you flipped one of the
+unimplemented sources on, you'll see a one-line warning at startup.
+
+To start actually USING the Failure-Learning Loop on your agent, set
+`monitoring.failureLearning.sources.ci: true` and `sources.revert: true`
+in `.instar/config.json`. The substrate has been ready since late April;
+this PR just adds the tests around it. Echo's local config is being flipped
+out-of-band as a dogfooding step.
 
 ## Why this matters more than it might look
 
-This is a "silent failure" class — the helpers were broken but emitted
-no error, so the bug only surfaced through the symptom (incoherent
-agent replies after compaction). That makes the failure invisible until
-a user notices the symptom. The structural lint added in this change
-makes the class itself impossible to reintroduce silently.
+The 14-day fix-shape rate to main is around 19% — we've been shipping a lot
+of bugs and finding out from users instead of from instrumentation. The
+Failure-Learning Loop is the meta-trace that turns "we keep shipping bugs"
+into "here are the three patterns most of them share." But it was sitting
+unused because the ingestion sources were silent. This PR closes one half
+of that gap (the wiring-test + the unimplemented-source warning); flipping
+the working sources on for each agent closes the other half. Several more
+PRs from the same post-mortem will follow.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,72 @@
+---
+review-convergence: complete
+approved: true
+approved-by: justin (verbal, topic 2169: "yes lets start with pipeline" + "Yes please!" on the A+C proposal)
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Two pipeline backstops from the 2026-05-29 fix-shape post-mortem.**
+
+- **Failure-Learning Loop: unimplemented-source warning + wiring-integrity test.**
+  `monitoring.failureLearning.sources.regression` and
+  `monitoring.failureLearning.sources.degradation` are config flags that exist
+  in defaults but have **no implementation** yet — setting them on did
+  absolutely nothing. The loop reported them as "configured" without ever
+  capturing a single corresponding event. Per the "specced but not wired"
+  bug class named in the post-mortem (PR #530 was the worst recent instance),
+  this PR makes the unimplemented sources surface their gap at boot via a
+  clear `console.warn` and adds a unit-tier wiring-integrity test that pins
+  the gating logic — the existing `ci` and `revert` sources must construct
+  their poller/detector when their flag is on, must stay null when it's off,
+  and the unimplemented sources must produce a warning when on but stay
+  quiet when off. The substrate for `ci` and `revert` was already shipped;
+  this PR adds the missing tests around it.
+
+- **Migration parity: a static assertion that fresh-init hook installs match
+  auto-update hook installs.** Per the "Migration parity skip" class — the
+  telegram-reply.sh 403 (PR-of-record never shipped a migrator), the
+  autonomous-stop-hook broken path, the slack-channel-context.sh divergence
+  we found mid-build during PR #542. The new test reads
+  `installHooks()` (src/commands/init.ts) and `migrateHooks()`
+  (src/core/PostUpdateMigrator.ts), extracts the set of hook files each
+  writes, and asserts the sets agree — except for a small documented
+  allowlist of migrator-only deferred-install hooks. The allowlist's soft
+  cap (10) catches the gap widening, and current contents document the
+  followups.
+
+This is the first of several pipeline hardenings the post-mortem
+recommended. Levers B (real-world-state fixture tests), D (silent-failure
+ban lint), and E (pre-merge `gh pr checks` enforcement) come in
+follow-up PRs.
+
+## What to Tell Your User
+
+Nothing visible in normal operation. If you previously turned on the
+regression or degradation failure-learning sources expecting them to do
+something, you'll now see a warning at startup telling you they are
+silent no-ops; you can set them back off. Otherwise no behavior change.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Unimplemented failure-learning sources warn loudly | Automatic at boot. If `sources.regression` or `sources.degradation` is set the agent logs a one-line warning. |
+| Wiring-integrity test for failure-learning sources | Automatic (CI). Any future regression in the source-construction gating fails the unit suite. |
+| Migration-parity assertion for hooks | Automatic (CI). Any new install-only or migrator-only hook fails the unit suite unless it is explicitly added to `INSTALL_VS_MIGRATE_KNOWN_GAPS` with a rationale. |
+
+## Evidence
+
+- 14 new unit tests; 5 existing related tests (CiFailurePoller, RevertDetector,
+  PostUpdateMigrator-time-injection) remain green.
+- `tsc --noEmit` clean.
+- Side-effects review:
+  `upgrades/side-effects/failure-learning-sources-wiring-and-migration-parity.md`.
+- Both new tests verified by destructive-negative test (introduce a fake
+  install-only or migrator-only-without-allowlist hook → migration-parity
+  test fails as expected; remove the warning block → wiring test fails as
+  expected).

--- a/upgrades/side-effects/failure-learning-sources-wiring-and-migration-parity.md
+++ b/upgrades/side-effects/failure-learning-sources-wiring-and-migration-parity.md
@@ -1,0 +1,127 @@
+# Side-effects review — Failure-Learning sources wiring + migration-parity assertion
+
+## What changed
+
+Two structural backstops shipped together, both targeting recurring bug classes
+named in the 2026-05-29 pipeline post-mortem.
+
+1. **Failure-Learning Loop: unimplemented-source warning + wiring-integrity test.**
+   `monitoring.failureLearning.sources.regression` and
+   `monitoring.failureLearning.sources.degradation` are config flags shipped
+   without implementations: setting them on did absolutely nothing. The flag
+   created a false sense of coverage — exactly the "specced but not wired"
+   class that produced PR #530 (AttributionResolver Phase 2 specced, never
+   wired, every burn alarm read 100% pre-attribution). A new boot-time
+   `console.warn` names the unimplemented sources, says they are silent
+   no-ops, and tells the operator to set them back off until impl ships.
+   A new unit-tier test asserts the CiFailurePoller and RevertDetector are
+   constructed iff their flags are on, and that the unimplemented-source
+   warning fires on the right configurations and stays quiet on the right
+   ones — so a future regression in the gating logic cannot silently
+   disable the loop.
+
+2. **Migration parity: a static assertion that fresh-init hook installs match
+   auto-update hook installs.** Per the "Migration parity skip" class
+   (telegram-reply.sh 403, autonomous-stop-hook broken path, the
+   slack-channel-context.sh divergence we found mid-PR in #542). The test
+   reads `installHooks()` (src/commands/init.ts) and `migrateHooks()`
+   (src/core/PostUpdateMigrator.ts), extracts the set of hook files each
+   writes, and asserts neither side has a file the other doesn't —
+   except for a small documented allowlist of migrator-only deferred-install
+   files. The allowlist's soft cap (10) trips a regression alarm if the
+   gap widens.
+
+## Why
+
+The May 2026 fix-rate to main was ~19% (150 of 781 commits over 14 days). The
+Failure-Learning Loop had captured exactly **one** event total — a manual
+agent-diagnosed entry I posted on the morning of the post-mortem itself. The
+loop's substrate (CiFailurePoller, RevertDetector, FailureLedger,
+FailureAttributionEngine, /failures routes) was already shipped (slice 1 in
+late April, slice 1b around #484), but every ingestion source was switched OFF
+in `ConfigDefaults.ts`. So the meta-trace lever was unpulled.
+
+I cannot flip a config default to a fleet-wide ON in a single PR — per-agent
+opt-in is the model the spec sets. What I CAN ship is the missing structural
+backstop: unimplemented sources must surface their gap visibly, and the
+wiring-integrity test makes any future regression in the gating impossible to
+miss. Plus the migration-parity test catches THE specific class that produced
+the silent failure that initiated this whole conversation (a fresh-init agent
+missing a hook the migrator installs, including telegram-topic-context.sh —
+the exact file behind the 2026-05-29 incoherent-reply incident).
+
+Echo's local config is being flipped to `sources.ci: true, sources.revert: true`
+out-of-band as a dogfooding step; that's an agent-local change, not part of
+this PR.
+
+## Risk surface
+
+- **Boot-time `console.warn` for unimplemented sources** — only fires when the
+  agent has explicitly turned on `sources.regression: true` or
+  `sources.degradation: ["..."]`. Default-off agents see nothing. The warning
+  text is plain-English and tells the operator the explicit fix (set them
+  back off). No state mutation; no API surface change.
+- **Wiring-integrity test** — pure unit test, uses an in-process mock
+  `SessionManager`. Doesn't construct an HTTP server, doesn't touch the
+  network, doesn't read git. Risk: zero.
+- **Migration-parity test** — static-analysis-only test. Parses
+  `src/commands/init.ts` and `src/core/PostUpdateMigrator.ts` source files
+  with a small regex (`fs.writeFileSync(path.join(hooksDir|instarHooksDir,
+  '<filename>'), …)`) and compares the resulting sets. Doesn't run either
+  function. Risk: zero.
+- **Allowlist semantics** — the test treats the allowlist as deliberate
+  accepted technical debt; growing it requires explicit code change + a
+  documented rationale per entry. The soft cap (10) protects against silent
+  drift.
+
+## Bug surfaces eliminated
+
+- `sources.regression: true` previously silently no-op'd → now warns loudly.
+- `sources.degradation: ["x"]` previously silently no-op'd → now warns loudly.
+- A future PR that adds a `migrateHooks()` write without an `installHooks()`
+  counterpart → caught at commit time by the parity test.
+- A future PR that adds an `installHooks()` write without a `migrateHooks()`
+  counterpart → caught at commit time by the parity test (this is the more
+  dangerous direction — the migrator overwrites on every cycle; a fresh-init
+  file the migrator doesn't maintain drifts forever).
+- A future regression that disables the CiFailurePoller construction when
+  `sources.ci: true` → caught by wiring-integrity test.
+
+## Migration footprint
+
+- No fleet migration required. The boot-warning is purely an in-process side
+  effect at AgentServer construction time; existing agents pick it up on the
+  next process restart (which auto-update will trigger anyway).
+- Default config defaults are unchanged. Per-agent opt-in remains the
+  intended model for the sources.
+
+## Testing
+
+- Unit (wiring): `tests/unit/failure-learning-sources-wiring.test.ts` —
+  9 tests. Constructed iff flag set (both directions), enabled:false
+  inert across all source flags, unimplemented sources trigger one
+  consolidated warning, implemented-only configs stay quiet.
+- Unit (migration parity): `tests/unit/migration-parity-hooks.test.ts` —
+  5 tests. Non-empty both sides, no install-only, no migrator-only outside
+  allowlist, allowlist soft cap. Positive + destructive-negative verified
+  (fake install-only write fails; fake migrator-only-without-allowlist
+  fails).
+
+## Test count
+
+14 new tests across the unit tier. Existing related tests
+(`CiFailurePoller.test.ts: 12`, `RevertDetector.test.ts: 9`,
+`PostUpdateMigrator-time-injection.test.ts: 13`) remain green.
+
+## Follow-ups (NOT in this PR — surfaced explicitly so the allowlist doesn't
+hide them indefinitely):
+
+- The `INSTALL_VS_MIGRATE_KNOWN_GAPS` allowlist enumerates 6 currently-accepted
+  migrator-only hooks. Each entry is technical debt that should be closed by
+  moving the file into `installHooks()` (or removing it from the migrator if
+  it's no longer needed). Tracked in the allowlist comments so the soft cap
+  surfaces drift.
+- The `regression` and `degradation` source IMPLEMENTATIONS still need to
+  ship. Those are separate features (the post-mortem's lever B —
+  real-world-state fixture tests — closely related). This PR's warning
+  closes the misleading-flag gap until then.


### PR DESCRIPTION
## Summary

Two structural backstops from the [2026-05-29 pipeline post-mortem](https://github.com/JKHeadley/instar/pull/542) — both target recurring bug classes named there.

**A — Failure-Learning Loop: surface "specced but not wired" boundary.** `monitoring.failureLearning.sources.regression` and `sources.degradation` are config flags that exist in defaults but have NO implementation. Turning them on did absolutely nothing. The loop reported them as configured without ever capturing the corresponding events. Boot-time `console.warn` now names the gap. A unit-tier wiring-integrity test (9 tests) pins the gating logic so any regression in `CiFailurePoller` / `RevertDetector` construction fails the suite.

**C — Migration parity: static assertion that fresh-init hook installs match auto-update hook installs.** Per the "Migration parity skip" class (telegram-reply.sh 403, autonomous-stop-hook broken path, slack-channel-context.sh divergence I found mid-build during #542). Reads `installHooks()` and `migrateHooks()`, extracts hook-file sets, asserts neither side has a file the other doesn't except for an explicitly-documented `INSTALL_VS_MIGRATE_KNOWN_GAPS` allowlist (6 entries, rationale per entry; soft cap of 10 catches drift).

The audit surfaced six existing migrator-only hooks that fresh-init agents are missing for the first ~30 minutes — including `telegram-topic-context.sh`, the same file PR #542 fixed. Each is in the allowlist with a rationale. Future PRs that add a NEW gap (in either direction) fail the test.

## What changed

**Source (1 file)**
- `src/server/AgentServer.ts` — `console.warn` block fires when `sources.regression: true` or `sources.degradation: [...]` is set. No other behavior change; default-off agents see nothing.

**Tests (2 files, 14 new tests)**
- `tests/unit/failure-learning-sources-wiring.test.ts` — 9 tests (wiring integrity + unimplemented-source warning).
- `tests/unit/migration-parity-hooks.test.ts` — 5 tests (non-empty both sides, no install-only, no migrator-only outside allowlist, allowlist soft cap).

**Spec (3 files)**
- `upgrades/NEXT.md` — bump: patch + frontmatter (`review-convergence: complete`, `approved: true`).
- `upgrades/NEXT.eli16.md` — plain-English overview.
- `upgrades/side-effects/failure-learning-sources-wiring-and-migration-parity.md` — side-effects review.

## Test plan

- [x] vitest run on the two new files — 14/14 green.
- [x] CiFailurePoller + RevertDetector + PostUpdateMigrator-time-injection suites — 34/34 green (no regression).
- [x] tsc --noEmit clean.
- [x] Destructive-negative tests confirm new gaps fail in both directions.
- [ ] CI green (await GitHub Actions).
- [ ] Echo dogfooding: local config will be flipped to ci=true, revert=true out-of-band (NOT in this PR) to verify capture works end-to-end.

Generated with Claude Code.
