### PR TITLE
fix(multi-machine): load mesh signing key from canonical signing-key.pem (send-side break)

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -2467,9 +2467,20 @@ export async function startServer(options: StartOptions): Promise<void> {
     let localSigningKeyPem = '';
     if (coordinator.enabled && coordinator.identity) {
       try {
-        const keyPath = path.join(config.stateDir, 'machine', 'signing-private.pem');
-        if (fs.existsSync(keyPath)) {
-          localSigningKeyPem = fs.readFileSync(keyPath, 'utf-8');
+        // The canonical signing-key filename is `signing-key.pem` (MachineIdentity.SIGNING_KEY_FILE,
+        // what every normally-created install has + what idMgr.loadSigningKey reads). This loader
+        // historically hard-coded `signing-private.pem`, which only EXISTS on installs that were
+        // propagated with that (non-canonical) name — so a normally-created machine got an EMPTY
+        // localSigningKeyPem, its MeshRpcClient then signed every cross-machine command with no key,
+        // the send threw, and it could not PULL/transfer to any peer (while still RECEIVING fine,
+        // since receive verifies the OTHER machine's key). Try the canonical name first, then fall
+        // back to the legacy/propagated name so both layouts work.
+        for (const name of ['signing-key.pem', 'signing-private.pem']) {
+          const keyPath = path.join(config.stateDir, 'machine', name);
+          if (fs.existsSync(keyPath)) {
+            localSigningKeyPem = fs.readFileSync(keyPath, 'utf-8');
+            break;
+          }
         }
       } catch { /* @silent-fallback-ok — signing key optional */ }
     }

--- a/tests/unit/mesh-signing-key-resolution.test.ts
+++ b/tests/unit/mesh-signing-key-resolution.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Mesh signing-key resolution (Multi-Machine Session Pool §L0 — the bug that broke
+ * the SEND side of every normally-created machine).
+ *
+ * The server-boot loader for `localSigningKeyPem` (the private key the MeshRpcClient
+ * signs every outbound m2m command with) hard-coded the filename `signing-private.pem`.
+ * But `MachineIdentity` writes the key as `signing-key.pem` (its `SIGNING_KEY_FILE`),
+ * so every normally-created install had `signing-private.pem` ABSENT → `localSigningKeyPem`
+ * stayed '' → the MeshRpcClient signed with an empty key → the send threw → the machine
+ * could not PULL presence from / TRANSFER to any peer (while still RECEIVING fine, since
+ * receive verifies the OTHER machine's key). An install propagated with the non-canonical
+ * `signing-private.pem` worked only by accident. Found on real hardware: the laptop (canonical
+ * `signing-key.pem`) never recorded the mini until given the legacy filename.
+ *
+ * These tests pin that the loader prefers the canonical `signing-key.pem` and falls back to
+ * the legacy `signing-private.pem`, so BOTH layouts load a key.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('server-boot wiring: mesh signing-key resolution (§L0)', () => {
+  const src = fs.readFileSync(path.join(process.cwd(), 'src/commands/server.ts'), 'utf-8');
+
+  it('the localSigningKeyPem loader reads the CANONICAL signing-key.pem (not only signing-private.pem)', () => {
+    const idx = src.indexOf('let localSigningKeyPem');
+    expect(idx).toBeGreaterThan(0);
+    const block = src.slice(idx, idx + 1200);
+    expect(block).toContain("'signing-key.pem'");
+  });
+
+  it('tries the canonical name BEFORE the legacy/propagated signing-private.pem (fallback order)', () => {
+    const idx = src.indexOf('let localSigningKeyPem');
+    const block = src.slice(idx, idx + 1200);
+    const canonicalAt = block.indexOf("'signing-key.pem'");
+    const legacyAt = block.indexOf("'signing-private.pem'");
+    expect(canonicalAt).toBeGreaterThan(0);
+    expect(legacyAt).toBeGreaterThan(0);
+    expect(canonicalAt).toBeLessThan(legacyAt); // canonical first, legacy fallback
+  });
+
+  it('the canonical filename matches MachineIdentity.SIGNING_KEY_FILE', () => {
+    const mi = fs.readFileSync(path.join(process.cwd(), 'src/core/MachineIdentity.ts'), 'utf-8');
+    expect(mi).toContain("SIGNING_KEY_FILE = 'signing-key.pem'");
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -13,12 +13,29 @@ away, so it was undiagnosable from `GET /mentor/status`. Now: the real error is
 surfaced into `lastResult.error`, and the Stage-A compose-session spawn retries
 once with a short backoff before failing with a clear, specific message.
 
+**Multi-machine: the SEND side of the cross-machine command channel now works on
+a normally-created machine.** The private per-machine key used to sign every
+machine-to-machine command was being loaded from the wrong filename
+(`signing-private.pem`), but a normally-created machine stores it as
+`signing-key.pem`. So a normal machine signed its outbound commands with an empty
+key and the send silently failed — it could receive from peers but never call out
+to them (check a peer's presence, hand off a conversation, move one). The loader
+now reads the canonical filename, falling back to the legacy one. This is the
+send-side companion to the recent command-channel auth fix; together they make
+the cross-machine pool actually work over the network. (Found on real hardware:
+the laptop couldn't see the mini until its signing key loaded.)
+
 ## What to Tell Your User
 
 Only relevant if you run the (off-by-default) Framework-Onboarding mentor. It now
 recovers from a transient compose-session spawn failure, and when it does fail it
-tells you exactly why (visible at `/mentor/status`) instead of an unexplained
-"stage-a-failed."
+tells you exactly why (visible on the mentor status page) instead of an
+unexplained "stage-a-failed."
+
+If you run across two machines: this release fixes the last piece that kept a
+normally-created machine from being able to reach its peers — a second machine
+will now correctly show as online and be eligible to receive conversations, and
+moving a conversation between machines works. Both machines need to update.
 
 ## Summary of New Capabilities
 
@@ -26,6 +43,9 @@ tells you exactly why (visible at `/mentor/status`) instead of an unexplained
   cause (`MentorTickResult.error`), instead of swallowing it.
 - `spawnStageA` retries the compose-session spawn once (transient resilience) and
   throws a clear `stage-a-spawn-failed: … — <cause>` on persistent failure.
+- The MeshRpcClient signing-key loader reads the canonical `signing-key.pem`
+  (falling back to legacy `signing-private.pem`), so a normally-created machine
+  can sign — and therefore SEND — cross-machine commands.
 
 ## Evidence
 
@@ -34,4 +54,11 @@ tells you exactly why (visible at `/mentor/status`) instead of an unexplained
   asserts the cause is surfaced (was swallowed by a bare catch in
   `runMentorTick`). Full mentor/stage suite (113 tests / 9 files) green;
   `tsc --noEmit` clean.
-- Side-effects: `upgrades/side-effects/mentor-stage-a-robustness.md`.
+- `tests/unit/mesh-signing-key-resolution.test.ts` — the loader reads the
+  canonical `signing-key.pem`, tries it before the legacy `signing-private.pem`,
+  and the canonical name matches `MachineIdentity.SIGNING_KEY_FILE`.
+- Found on real hardware (laptop + mini): the laptop's puller recorded the mini
+  online over the signed HTTP channel only after its signing key loaded; before,
+  it signed with an empty key and the send threw.
+- Side-effects: `upgrades/side-effects/mentor-stage-a-robustness.md`,
+  `upgrades/side-effects/mesh-signing-key-filename-fix.md`.

--- a/upgrades/side-effects/mesh-signing-key-filename-fix.md
+++ b/upgrades/side-effects/mesh-signing-key-filename-fix.md
@@ -1,0 +1,54 @@
+# Side-effects review — mesh signing-key filename fix (the SEND-side break)
+
+## What was happening (real-hardware, 2026-05-30)
+
+After the /mesh/rpc auth exemption (v1.3.104) deployed to BOTH machines, the Mac
+mini STILL showed offline on the laptop (the router). The mini→laptop presence
+pull worked (the mini's log: `recorded 1 peer(s) online: m_cc2ec651`), but the
+laptop→mini direction never fired and the mini never even RECEIVED the laptop's
+`session-status` call.
+
+Root cause: the server-boot loader for `localSigningKeyPem` — the private key the
+`MeshRpcClient` signs every outbound machine-to-machine command with — hard-coded
+the filename `signing-private.pem`. But `MachineIdentity` writes the signing key
+as `signing-key.pem` (its `SIGNING_KEY_FILE`). So a normally-created install had
+`signing-private.pem` ABSENT → `localSigningKeyPem` stayed `''` → the
+`MeshRpcClient` signed with an empty key → the send threw → the machine could NOT
+pull presence from / deliver to / transfer to any peer. It still RECEIVED fine,
+because the receive path verifies the OTHER machine's key (which it has), not its
+own. That produced the exact asymmetry observed: the mini (propagated with the
+non-canonical `signing-private.pem`) could send; the laptop (canonical
+`signing-key.pem`) could not — two filename bugs lining up.
+
+Confirmed by giving the laptop a `signing-private.pem` copy of its own key +
+restarting: the laptop immediately began recording the mini online over HTTP, and
+the pool showed both machines online.
+
+## The fix
+
+- **`src/commands/server.ts`** — the loader now reads the CANONICAL
+  `signing-key.pem` first, falling back to the legacy/propagated
+  `signing-private.pem`, so BOTH layouts load a key. (The lease transport already
+  used `idMgr.loadSigningKey()`, which reads the canonical name — only this
+  MeshRpcClient loader was on the wrong filename.)
+
+## Blast radius
+
+- **Pure fix to a boot-time read on the multi-machine path.** A single-machine
+  agent never constructs a MeshRpcClient, so it is unaffected. A machine that
+  already had `signing-private.pem` (propagated) keeps working via the fallback.
+  A machine with the canonical `signing-key.pem` (the common case) now loads its
+  key and can SEND cross-machine commands — the bug fix.
+- **No new config / route / schema / hook / skill → no migration.** Server code;
+  existing agents pick it up on the next release. This is the SEND-side companion
+  to the /mesh/rpc auth exemption (the receive-side fix) — both were needed for
+  the cross-machine pool to function over the wire.
+- **Separately, the propagation path should write the canonical `signing-key.pem`**
+  (it currently writes `signing-private.pem`); that is a propagation-side cleanup
+  tracked separately. This fix makes the loader tolerant of both regardless.
+
+## Tests
+
+- `tests/unit/mesh-signing-key-resolution.test.ts` — the loader reads the
+  canonical `signing-key.pem`, tries it BEFORE the legacy `signing-private.pem`
+  (fallback order), and the canonical name matches `MachineIdentity.SIGNING_KEY_FILE`.


### PR DESCRIPTION
## The send-side break (found on real hardware, 2026-05-30)

After the `/mesh/rpc` auth exemption (#543, v1.3.104) deployed to **both** machines, the Mac mini *still* showed offline on the laptop (router). The **mini→laptop** presence pull worked (`recorded 1 peer(s) online: m_cc2ec651`), but **laptop→mini** never fired — the mini never even *received* the laptop's `session-status`.

Root cause: the server-boot loader for `localSigningKeyPem` (the private key `MeshRpcClient` signs every outbound m2m command with) hard-coded the filename **`signing-private.pem`**. But `MachineIdentity` writes the key as **`signing-key.pem`** (`SIGNING_KEY_FILE`). So a normally-created install had `signing-private.pem` absent → `localSigningKeyPem=''` → it signed every cross-machine command with an **empty key** → the send threw → it could **receive** from peers (receive verifies the *other* machine's key) but never call **out**. The mini worked only because it was propagated with the non-canonical `signing-private.pem` — two filename bugs lining up.

Confirmed: giving the laptop a `signing-private.pem` copy of its own key + restarting → it immediately recorded the mini online over the signed HTTP channel; the pool showed both machines online.

This is the **send-side** companion to #543's receive-side auth exemption — both were needed for the cross-machine pool to function over the wire.

## Fix

`src/commands/server.ts` — the loader reads the canonical `signing-key.pem` first, falling back to legacy/propagated `signing-private.pem`, so both layouts load a key. (The lease transport already used `idMgr.loadSigningKey()` = the canonical name; only this MeshRpcClient loader was wrong.)

## Tests

- `tests/unit/mesh-signing-key-resolution.test.ts` — the loader reads canonical `signing-key.pem`, tries it before legacy `signing-private.pem`, and the canonical name matches `MachineIdentity.SIGNING_KEY_FILE`.

Side-effects: `upgrades/side-effects/mesh-signing-key-filename-fix.md`. Note: the propagation path writing the non-canonical filename is a separate cleanup; this loader is tolerant of both. **Both machines need this release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)