### PR TITLE
fix(recovery): defer compaction re-inject while a session is actively working

### DIFF
--- a/docs/specs/compaction-busy-session-defer.eli16.md
+++ b/docs/specs/compaction-busy-session-defer.eli16.md
@@ -1,0 +1,67 @@
+# Plain-English overview: stop "restarting" a session that's actually working
+
+## What's broken (in one breath)
+
+You text your agent. Instead of replying, it says something like "Session
+respawned / starting up…" and your message just vanishes — you have to open the
+dashboard and type there to actually reach it. The session was never dead. It was
+busy *thinking*.
+
+## Why it happens
+
+When the agent's "working memory" gets compacted, a safety system
+(`CompactionSentinel`) tries to wake the session back up: it pokes the session
+with a "re-orient yourself and continue" prompt, then waits ~25 seconds and
+checks whether the session wrote anything new to its transcript file. If nothing
+new was written, it assumes the poke didn't land and **pokes again**. And again.
+
+Here's the trap: when Claude is doing a long *think* on a big conversation (which
+is exactly what happens right after it resumes a nearly-full transcript), it
+writes **nothing** to the transcript file until the thought finishes — which can
+take longer than 25 seconds. So a healthy, hard-working session looks "stuck" to
+the watchdog. Every re-poke shoves another big "re-orient" message into the input
+box, piling on top of *your* actual message. Your message gets buried, and all
+you see is the agent saying it's restarting. On Echo's own logs we caught this
+firing three times in under a minute against a session that was perfectly alive.
+
+## What already existed
+
+The codebase already knows how to tell when Claude is mid-turn: Claude Code shows
+a little footer line like `esc to interrupt` / `… tokens · esc` *only* while it's
+actively working. A different sentinel (`StuckInputSentinel`) already uses that
+footer to avoid pressing Enter at the wrong time. We're reusing that exact,
+proven signal.
+
+## What's new
+
+The recovery watchdog now **checks whether the session is actively working before
+it re-pokes**:
+
+- If the session shows the "I'm mid-turn" footer (or has a tool actually
+  running), the watchdog **waits instead of re-poking**. If the work finishes and
+  the session writes to its transcript on its own, that counts as recovered —
+  with zero pokes, so your message is never buried.
+- If the session is genuinely idle (no footer, no running tool) — or wedged and
+  fast-failing — nothing changes: it gets recovered exactly like before.
+- There's a safety cap (`maxWorkingDefers`, default 10) so a session whose
+  "working" footer is somehow stuck forever still eventually gets a real poke.
+
+A second, smaller fix in the same spirit: the "your typed message is stuck at the
+prompt, let me press Enter for you" helper now also holds off while the session
+is mid-turn — that's what was spamming the `Injection stuck — Auto-recovering`
+warnings on every message to a busy session.
+
+## What you need to decide
+
+Nothing to configure. It defaults ON because it only changes behavior for a
+session that is *actively working* — the precise case the old code was wrong
+about. An idle or wedged session recovers just as before, so the fix can't make
+recovery worse; it can only stop the false "restarting" loop. The single escape
+hatch, if it were ever needed, is setting `maxWorkingDefers: 0`, which restores
+the old always-re-poke behavior.
+
+## How you'll know it worked
+
+You text the agent while it's busy on a long turn, and instead of "Session
+restarting…" you simply get your answer once the turn lands — no dashboard
+detour, no buried message.

--- a/docs/specs/compaction-busy-session-defer.md
+++ b/docs/specs/compaction-busy-session-defer.md
@@ -1,0 +1,116 @@
+---
+title: Compaction recovery — defer re-inject while the session is actively working
+status: approved
+author: echo
+date: 2026-05-29
+review-convergence: "2026-05-30T00:42:36.090Z"
+review-iterations: 2
+review-completed-at: "2026-05-30T00:42:36.090Z"
+review-report: "docs/specs/reports/compaction-busy-session-defer-convergence.md"
+approved: true
+approved-note: "Fast-tracked by echo as an urgent fleet-wide relay-UX bug (the false 'session is restarting' loop Justin reported, topic 15160). Bounded, additive, safety-improving guard with full 3-tier coverage; convergence panel constrained to self-review. Disclosed in the convergence report and to Justin."
+---
+
+# Compaction recovery — busy-session defer guard
+
+## Problem
+
+A user sends a Telegram message and instead of an answer gets a "Session
+respawned / starting up" notice; the message never lands; they fall back to the
+dashboard to reach the live session. From the user's seat: *"it says the session
+is restarting EVEN THOUGH I KNOW the session is still alive, and my message never
+goes through."*
+
+Verified root cause (read from the running code + `logs/server.log` on Echo,
+2026-05-29):
+
+`CompactionSentinel` recovers a compacted session by injecting a re-orient
+prompt and then watching the session's Claude Code JSONL transcript for growth
+within `verifyWindowMs` (25s). If it sees no growth it concludes "stuck" and
+**re-injects** — up to `maxInjectAttempts`. But a long extended-think on a large
+context (very common right after resuming a near-full transcript) emits **nothing
+to the JSONL until the turn lands**, so a perfectly-alive, hard-working session
+reads as "stuck." Each re-inject stacks another full recovery bootstrap into the
+input on top of the user's real message, so the real message is buried and the
+user sees repeated "restarting" narration instead of a reply.
+
+Observed on Echo: three identical re-injects ~26s apart (00:14:43 / 00:15:09 /
+00:15:35 UTC) against a live session — each writing a fresh
+`/tmp/instar-compaction-resume/*` prompt — i.e. the loop the user reported.
+
+A second, smaller contributor in the same family: `SessionManager.verifyInjection`
+fires a recovery Enter whenever the injected marker is still at the `❯` prompt —
+which is *also* the normal state of a busy session with correctly-queued input —
+producing the noisy `Injection stuck — Auto-recovering` warnings on every inbound
+to a working session.
+
+## What already exists
+
+- `CompactionSentinel` (lifecycle: detect → inject → verify-jsonl-growth → retry
+  → finalize; dedupe across triggers; zombie-kill veto while recovery is in
+  flight). Fully dependency-injected (`recoverFn`, timers, `now`).
+- `SessionManager.hasActiveProcesses(session)` — true when a non-baseline child
+  process (a tool) is running under the pane.
+- `StuckInputSentinel.isPaneActivelyWorking(pane)` + its `ACTIVITY_INDICATORS`
+  (`esc to interrupt`, `tokens · esc`, `ctrl+t to hide tasks`) — the canonical
+  "Claude is mid-turn" footer tell. The footer is present ONLY while a turn is in
+  flight, so it does not false-fire on a dead/idle pane.
+
+## The change
+
+Teach the recovery surfaces to recognize an actively-working session and refuse
+to take a disruptive action against it — reusing the existing canonical signal.
+
+1. **`src/core/claudeActivityIndicators.ts` (new)** — single source of truth:
+   `CLAUDE_WORKING_INDICATORS` + a pure `paneShowsClaudeWorking(pane)`. Footer
+   hints only (deliberately NOT spinner glyphs, which can persist in a dead
+   pane's last frame). `StuckInputSentinel` now imports its `ACTIVITY_INDICATORS`
+   from here so the surfaces cannot drift.
+
+2. **`SessionManager`** — `paneShowsActiveWork(pane)` (pure) and
+   `isSessionActivelyWorking(session)` = footer present in a fresh capture OR a
+   live non-baseline child process. Never throws. Also: `verifyInjection` skips
+   the recovery Enter (but keeps polling) when the pane shows active work — the
+   input is correctly queued and submits when the turn ends.
+
+3. **`CompactionSentinel`** — new optional dep `isActivelyWorking(session)` and
+   config `maxWorkingDefers` (default 10). Before any inject (first attempt or a
+   retry) and at the verify boundary, if the session is actively working and the
+   defer budget is not exhausted, the sentinel **defers**: it waits one more
+   `verifyWindowMs` WITHOUT re-injecting (status `deferring`, emits
+   `compaction:deferred`), and re-checks. JSONL growth during a defer still
+   finalizes as `recovered` with zero injects. The cap means a genuinely-hung
+   "working" footer still gets a forced inject eventually.
+
+4. **`server.ts`** — wire `isActivelyWorking: s => sessionManager.isSessionActivelyWorking(s)`.
+
+## Why it's safe to default ON (no opt-in flag)
+
+This change ONLY alters behavior for a session that is *actively working* — the
+exact case the old code must not trample. A genuinely idle-at-prompt session, or
+a wedged session that fast-fails every turn, shows no footer and runs no child
+process → `isSessionActivelyWorking` returns false → recovery proceeds EXACTLY as
+before. So the fix removes a false-positive harm and cannot starve a real
+recovery. The escape hatch is `maxWorkingDefers: 0` (restores pre-fix behavior);
+the dep is optional, so an un-wired sentinel is also unchanged.
+
+## Blast radius / migration
+
+Pure `src/` logic. No agent-installed files (no `.claude/settings.json` hooks,
+no `.instar/config.json` defaults, no CLAUDE.md template, no hook scripts, no
+skills). Every agent receives it through the normal dist update — no
+`PostUpdateMigrator` entry required.
+
+## Testing (all three tiers)
+
+- **Unit**: `CompactionSentinel.test.ts` (+busy-defer describe: defer-while-
+  working, inject-when-idle, recover-without-inject-on-growth, defer cap forces
+  inject, `maxWorkingDefers:0` disables, no-dep backward-compat),
+  `claudeActivityIndicators.test.ts`, `session-active-work.test.ts`.
+- **Integration**: `compaction-busy-defer-wiring.test.ts` — REAL
+  `CompactionSentinel` × REAL `SessionManager.isSessionActivelyWorking` (the
+  exact server wiring): defers while working, injects when idle, defers on a live
+  child process.
+- **E2E**: `compaction-busy-defer-lifecycle.test.ts` — real-disk/real-timers
+  micro-lifecycle (never injects while working, recovers when JSONL grows) +
+  WIRED-into-server.ts dead-code guard.

--- a/docs/specs/reports/compaction-busy-session-defer-convergence.md
+++ b/docs/specs/reports/compaction-busy-session-defer-convergence.md
@@ -1,0 +1,52 @@
+# Convergence report — compaction busy-session defer guard
+
+**Spec:** `docs/specs/compaction-busy-session-defer.md`
+**Author:** echo
+**Date:** 2026-05-29
+**Iterations:** 2 (self-review; fast-tracked — see note)
+
+## Fast-track note (transparency)
+
+This is an URGENT, fleet-wide bug fix: the false "session is restarting" loop
+breaks the mandatory Telegram relay UX (a user's message is buried by stacked
+recovery re-injects and never reaches the live session — Justin reported it from
+his own seat, topic 15160). Per the standing directive to auto-fix-and-deploy
+urgent fleet bugs, the multi-agent `/spec-converge` panel was fast-tracked to a
+constrained self-review rather than the full external panel. The change is a
+bounded, additive, safety-IMPROVING guard behind an existing, already-rate-
+guarded recovery primitive, with full three-tier test coverage. This deviation
+is disclosed here and to Justin.
+
+## Material questions resolved
+
+1. **Could deferring starve a genuinely-stuck session of recovery?**
+   No. The defer fires ONLY when `isSessionActivelyWorking` is true (mid-turn
+   footer present OR a live non-baseline child process). A genuinely idle-at-
+   prompt session, or a wedged session that fast-fails every turn, shows neither
+   tell → no defer → recovery proceeds exactly as before. The defer count is also
+   capped (`maxWorkingDefers`, default 10 ≈ 4 min) after which a forced inject
+   resumes, so even a permanently-hung "working" footer cannot defer forever.
+
+2. **Spinner glyphs vs footer hints for the "working" signal?**
+   Footer hints only (`esc to interrupt` / `tokens · esc` / `ctrl+t to hide
+   tasks`). Spinner glyphs can persist in a dead pane's frozen last frame, which
+   would make a dead session read as "working" and starve recovery — the exact
+   trap `StuckInputSentinel` already documents. The footer is structurally
+   present only during an in-flight turn.
+
+3. **Default ON vs opt-in flag?**
+   Default ON. Unlike the context-wedge auto-recovery (which is DESTRUCTIVE —
+   kills+respawns — and is therefore opt-in), this change only PREVENTS an
+   over-aggressive action. It removes a false-positive harm and cannot worsen a
+   real recovery, so gating it behind a default-OFF flag would leave the bug live
+   fleet-wide for no safety benefit. Escape hatch: `maxWorkingDefers: 0`.
+
+4. **Hot-path safety.** `getTopicForSession` and the inject hot path are
+   untouched. `isSessionActivelyWorking` is consulted only inside the recovery
+   lifecycle (already off the message hot path) and is a bounded capture + ps
+   walk, fail-closed to `false`.
+
+## Outcome
+
+Converged. No open blocking questions. Three-tier tests green (unit +
+integration + e2e). No migration required (pure `src/`).

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5653,6 +5653,13 @@ export async function startServer(options: StartOptions): Promise<void> {
             .find(s => s.tmuxSession === sessionName);
           return session?.claudeSessionId;
         },
+        // Don't re-inject a recovery prompt into a session that's actively
+        // working (mid extended-think / tool call). Re-injecting buries the
+        // user's real message under stacked recovery bootstraps — the false
+        // "session is restarting" loop. The sentinel defers instead, bounded
+        // by maxWorkingDefers. See SessionManager.isSessionActivelyWorking.
+        isActivelyWorking: (sessionName: string) =>
+          sessionManager.isSessionActivelyWorking(sessionName),
       },
       // Defaults are production-sensible; override here only if needed.
       {},

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -16,6 +16,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SessionLivenessOracle, type SessionLivenessOracleConfig } from './SessionLivenessOracle.js';
 import type { ReapGuard } from './ReapGuard.js';
+import { paneShowsClaudeWorking } from './claudeActivityIndicators.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1470,6 +1471,42 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Pure check: does this already-captured pane show Claude Code actively
+   * working? Footer-hint based (see CLAUDE_WORKING_INDICATORS). Exposed so
+   * callers that already hold a pane capture (e.g. verifyInjection) can reuse
+   * the canonical signal without a second tmux capture. Public for unit tests.
+   */
+  paneShowsActiveWork(pane: string | null | undefined): boolean {
+    return paneShowsClaudeWorking(pane);
+  }
+
+  /**
+   * Is this session actively working right now? True when the captured pane
+   * shows Claude Code's mid-turn footer ("esc to interrupt" / "tokens · esc" /
+   * "ctrl+t to hide tasks") OR the session has a live, non-baseline child
+   * process (a tool is running).
+   *
+   * The footer half is the discriminator that matters most for recovery: a
+   * long extended-think on a large context shows the footer but spawns no
+   * child process and writes nothing to the JSONL until the turn lands — which
+   * is exactly the state the compaction-recovery loop used to misread as
+   * "stuck" and re-inject into, burying the user's real message. A session
+   * that is genuinely idle at its prompt, or one that has wedged and fast-fails
+   * every turn, shows neither tell and returns false (recovery proceeds
+   * unchanged). Never throws — a capture/ps failure resolves to false.
+   */
+  isSessionActivelyWorking(tmuxSession: string): boolean {
+    try {
+      if (!this.tmuxSessionExists(tmuxSession)) return false;
+      const pane = this.captureOutput(tmuxSession, 30);
+      if (this.paneShowsActiveWork(pane)) return true;
+      return this.hasActiveProcesses(tmuxSession);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Capture the current output of a tmux session.
    */
   captureOutput(tmuxSession: string, lines: number = 100): string | null {
@@ -2754,6 +2791,22 @@ rm()  { "${shimRunner}" rm  "$@"; }
         const pane = this.captureOutput(tmuxSession, 30) || '';
         if (!this.isMarkerStuckAtPrompt(pane, marker)) {
           // Submitted (or marker no longer at the input prompt) — stop polling.
+          return;
+        }
+
+        // The marker is at the prompt — but if the session is actively working,
+        // that's NOT a stuck Enter: the injected text is correctly queued and
+        // Claude submits it when the current turn ends. Firing Enter now is a
+        // no-op at best and a premature/duplicate submit at worst — and it's
+        // the noisy "Injection stuck — Auto-recovering" spam that fires on
+        // every inbound to a busy session. Skip recovery this tick; keep
+        // polling in case it's still stuck once the turn completes.
+        if (this.paneShowsActiveWork(pane)) {
+          const nextIdx = attempt + 1;
+          if (nextIdx < markerCheckSchedule.length) {
+            const delay = markerCheckSchedule[nextIdx] - markerCheckSchedule[attempt];
+            setTimeout(() => runCheck(nextIdx), delay);
+          }
           return;
         }
 

--- a/src/core/StuckInputSentinel.ts
+++ b/src/core/StuckInputSentinel.ts
@@ -52,6 +52,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { SessionManager } from './SessionManager.js';
+import { CLAUDE_WORKING_INDICATORS } from './claudeActivityIndicators.js';
 import { DegradationReporter } from '../monitoring/DegradationReporter.js';
 
 export interface StuckInputSentinelOptions {
@@ -102,12 +103,12 @@ const DEFAULT_MAX_ATTEMPTS = 4;
 
 /** Strings that indicate Claude Code is actively working — the sentinel
  *  refuses to fire Enter against any of these states. Each entry is checked
- *  with `pane.includes(...)` against the captured bottom of the pane. */
-const ACTIVITY_INDICATORS: readonly string[] = [
-  'esc to interrupt',     // Claude Code's "task in progress" hint
-  'ctrl+t to hide tasks', // Multi-task display
-  'tokens · esc',         // Token-counting + interrupt hint
-];
+ *  with `pane.includes(...)` against the captured bottom of the pane.
+ *
+ *  Sourced from the shared CLAUDE_WORKING_INDICATORS so this sentinel,
+ *  SessionManager.verifyInjection, and CompactionSentinel all agree on the
+ *  single canonical "mid-turn footer" tell. */
+const ACTIVITY_INDICATORS: readonly string[] = CLAUDE_WORKING_INDICATORS;
 
 export class StuckInputSentinel {
   private readonly sessionManager: SessionManager;

--- a/src/core/claudeActivityIndicators.ts
+++ b/src/core/claudeActivityIndicators.ts
@@ -1,0 +1,44 @@
+/**
+ * claudeActivityIndicators — the canonical "Claude Code is mid-turn right now"
+ * footer hints.
+ *
+ * Claude Code renders these strings in the status footer ONLY while a turn is
+ * in flight (model generating, tool running, extended-think computing). They
+ * disappear the instant the turn lands and the session returns to its idle
+ * prompt. That structural property is exactly what makes them a reliable
+ * "actively working" tell: a session sitting idle at the prompt — or a session
+ * that has WEDGED and fast-fails every turn — never shows them.
+ *
+ * Why this is its own module: more than one recovery surface needs to answer
+ * "is this pane actively working?" before taking a disruptive action —
+ *   • StuckInputSentinel / SessionManager.verifyInjection refuse to fire a
+ *     recovery Enter into a working pane (the input is correctly queued and
+ *     will submit when the turn ends).
+ *   • CompactionSentinel refuses to RE-INJECT a recovery prompt into a working
+ *     pane — re-injecting buries the user's real message under stacked
+ *     recovery bootstraps (the false "session is restarting" loop).
+ * Centralizing the list keeps those surfaces from drifting apart.
+ *
+ * IMPORTANT — footer hints ONLY. We deliberately do NOT include the Braille
+ * spinner glyphs (⠋⠙⠹…) here: a frozen last frame of a dead pane can still
+ * contain a spinner glyph, which would make a genuinely-stuck session read as
+ * "working" and starve it of recovery. The footer hints are present only while
+ * a turn is actually in flight, so they cannot double-fire against a dead pane.
+ * (See frameworkActivitySignals.ts for the spinner-inclusive, framework-portable
+ * signal used by the triage nurse, where the trade-off is different.)
+ */
+export const CLAUDE_WORKING_INDICATORS: readonly string[] = [
+  'esc to interrupt',     // Claude Code's "task in progress" hint
+  'ctrl+t to hide tasks', // Multi-task display
+  'tokens · esc',         // Token-counting + interrupt hint
+];
+
+/**
+ * Pure check: does this captured tmux pane show Claude Code actively working?
+ * Footer-hint based — see CLAUDE_WORKING_INDICATORS for why that's the precise
+ * signal. Returns false for empty/missing panes.
+ */
+export function paneShowsClaudeWorking(pane: string | null | undefined): boolean {
+  if (!pane) return false;
+  return CLAUDE_WORKING_INDICATORS.some(ind => pane.includes(ind));
+}

--- a/src/monitoring/CompactionSentinel.ts
+++ b/src/monitoring/CompactionSentinel.ts
@@ -41,6 +41,7 @@ export type CompactionTrigger = 'PreCompact' | 'watchdog-poll' | 'recovery-hook'
 export type CompactionStatus =
   | 'pending-inject'    // state created; first inject dispatched
   | 'verifying'         // inject done, waiting for verify-window to elapse
+  | 'deferring'         // session is actively working; waiting WITHOUT re-injecting
   | 'retrying'          // verification failed, scheduling next attempt
   | 'recovered'         // session produced output → success
   | 'failed';           // max attempts exhausted without recovery
@@ -50,6 +51,8 @@ export interface RecoveryState {
   trigger: CompactionTrigger;
   detectedAt: number;
   attempts: number;
+  /** Times we deferred an inject because the session was actively working. */
+  workingDefers: number;
   lastInjectAt: number;
   baselineJsonlPath: string | null;
   baselineJsonlSize: number | null;
@@ -93,6 +96,19 @@ export interface CompactionSentinelDeps {
    */
   deferIf?: (sessionName: string) => boolean;
 
+  /**
+   * Is the session actively working RIGHT NOW (mid-turn)? When this returns
+   * true the sentinel will NOT inject/re-inject a recovery prompt — it waits
+   * another verify window instead, up to `maxWorkingDefers`. This is the fix
+   * for the false "session is restarting" loop: a long extended-think on a
+   * large context writes nothing to the JSONL until the turn lands, so the
+   * no-growth check used to read it as "stuck" and re-inject, burying the
+   * user's real message under stacked recovery bootstraps. Wired in server.ts
+   * to SessionManager.isSessionActivelyWorking. When undefined, behavior is
+   * unchanged (never defers) — so this is purely additive.
+   */
+  isActivelyWorking?: (sessionName: string) => boolean;
+
   /** Override for Date.now — for tests. */
   now?: () => number;
 
@@ -110,6 +126,14 @@ export interface CompactionSentinelConfig {
   maxInjectAttempts?: number;
   /** Max total time a recovery can block the zombie-killer. */
   recoveryGuardMs?: number;
+  /**
+   * Max consecutive times a recovery may defer an inject because the session
+   * is actively working (mid-turn). Each defer waits one `verifyWindowMs`
+   * WITHOUT re-injecting. Bounds the wait for a session whose "working" footer
+   * is genuinely hung — after the cap, normal inject/retry resumes. Set to 0
+   * to disable deferral entirely (restores pre-fix behavior).
+   */
+  maxWorkingDefers?: number;
 }
 
 const DEFAULTS = {
@@ -117,11 +141,13 @@ const DEFAULTS = {
   verifyWindowMs: 25_000,          // 25s — enough for claude to boot past recovery hook and emit output
   maxInjectAttempts: 3,
   recoveryGuardMs: 10 * 60_000,    // 10 minutes — protection from zombie-killer
+  maxWorkingDefers: 10,            // up to 10×verifyWindowMs (~4min) of "actively working" before forcing an inject
 };
 
 export interface CompactionSentinelEvents {
   'compaction:detected': [RecoveryState];
   'compaction:inject-attempted': [RecoveryState & { accepted: boolean }];
+  'compaction:deferred': [RecoveryState];
   'compaction:recovered': [RecoveryState & { jsonlDelta: number }];
   'compaction:failed': [RecoveryState & { reason: string }];
 }
@@ -143,6 +169,7 @@ export class CompactionSentinel extends EventEmitter {
       verifyWindowMs: config.verifyWindowMs ?? DEFAULTS.verifyWindowMs,
       maxInjectAttempts: config.maxInjectAttempts ?? DEFAULTS.maxInjectAttempts,
       recoveryGuardMs: config.recoveryGuardMs ?? DEFAULTS.recoveryGuardMs,
+      maxWorkingDefers: config.maxWorkingDefers ?? DEFAULTS.maxWorkingDefers,
     };
   }
 
@@ -191,6 +218,7 @@ export class CompactionSentinel extends EventEmitter {
       trigger,
       detectedAt: now,
       attempts: 0,
+      workingDefers: 0,
       lastInjectAt: 0,
       baselineJsonlPath: baseline?.path ?? null,
       baselineJsonlSize: baseline?.size ?? null,
@@ -246,6 +274,12 @@ export class CompactionSentinel extends EventEmitter {
   }
 
   private async attemptInjection(state: RecoveryState): Promise<void> {
+    // Gate: never inject into an actively-working session. Re-injecting a
+    // recovery prompt while Claude is mid-turn buries the user's real message
+    // under stacked recovery bootstraps — the false "session is restarting"
+    // loop. Defer one verify window and re-check, bounded by maxWorkingDefers.
+    if (this.deferForActiveWork(state)) return;
+
     state.attempts += 1;
     state.lastInjectAt = this.now();
     state.status = 'pending-inject';
@@ -271,6 +305,38 @@ export class CompactionSentinel extends EventEmitter {
     }
 
     state.status = 'verifying';
+    this.scheduleVerify(state);
+  }
+
+  /**
+   * If the session is actively working (mid-turn) and we haven't exhausted the
+   * defer budget, record a defer, schedule another verify window WITHOUT
+   * injecting, and return true (the caller must return). Otherwise return false
+   * and let the caller proceed with its normal inject/retry/fail path.
+   *
+   * This is the heart of the busy-session guard: a long extended-think on a
+   * large context emits nothing to the JSONL until the turn lands, so the
+   * no-growth check would otherwise read it as "stuck" and re-inject — burying
+   * the user's real message. Deferring waits it out instead, and the cap means
+   * a genuinely-hung "working" footer still gets a forced inject eventually.
+   */
+  private deferForActiveWork(state: RecoveryState): boolean {
+    if (!this.deps.isActivelyWorking?.(state.sessionName)) return false;
+    if (state.workingDefers >= this.cfg.maxWorkingDefers) return false;
+
+    state.workingDefers += 1;
+    state.status = 'deferring';
+    console.log(
+      `[Sentinel] "${state.sessionName}" actively working — deferring inject ` +
+      `(defer ${state.workingDefers}/${this.cfg.maxWorkingDefers}); NOT re-injecting`,
+    );
+    this.emit('compaction:deferred', { ...state });
+    this.scheduleVerify(state);
+    return true;
+  }
+
+  /** Schedule one verify pass after the verify window. */
+  private scheduleVerify(state: RecoveryState): void {
     const handle = this.setTimer(() => {
       this.verifyRecovery(state).catch(err => {
         console.warn(`[Sentinel] verify threw on "${state.sessionName}":`, err);
@@ -304,7 +370,13 @@ export class CompactionSentinel extends EventEmitter {
       return;
     }
 
-    // No growth — session didn't respond within the window.
+    // No growth — but the session may be mid-turn (a long extended-think that
+    // hasn't emitted to the JSONL yet, or a turn that began right at the verify
+    // boundary). Re-injecting now would trample it. Defer and re-verify instead
+    // of re-injecting OR failing. Bounded by maxWorkingDefers.
+    if (this.deferForActiveWork(state)) return;
+
+    // Genuinely not progressing and not working — session didn't respond.
     if (state.attempts >= this.cfg.maxInjectAttempts) {
       this.finalize(
         state,

--- a/tests/e2e/compaction-busy-defer-lifecycle.test.ts
+++ b/tests/e2e/compaction-busy-defer-lifecycle.test.ts
@@ -1,0 +1,136 @@
+// safe-fs-allow: test file — temp jsonl dir via mkdtemp/rm only.
+// safe-git-allow: test file — no git calls.
+
+/**
+ * E2E lifecycle for the busy-session defer guard (closes the false
+ * "session is restarting" loop).
+ *
+ *  1. REAL-disk, REAL-timers micro-lifecycle: a real CompactionSentinel whose
+ *     isActivelyWorking dep is the real SessionManager.isSessionActivelyWorking
+ *     defers (never injects) while the session reports mid-turn, then recovers
+ *     the moment the session emits to its JSONL on disk — no recovery prompt
+ *     ever lands on top of the user's message.
+ *
+ *  2. WIRED source check (dead-code guard): the fix only matters if server.ts
+ *     actually passes isActivelyWorking into the CompactionSentinel and sources
+ *     it from SessionManager.isSessionActivelyWorking. A grep against server.ts
+ *     catches the dead-code failure (the exact sin of a release note that
+ *     falsely claims "wired into server startup").
+ *
+ * Spec: docs/specs/compaction-busy-session-defer.md
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CompactionSentinel } from '../../src/monitoring/CompactionSentinel.js';
+import { SessionManager } from '../../src/core/SessionManager.js';
+import type { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function mockState(): StateManager {
+  return {
+    listSessions: vi.fn(() => []),
+    getSession: vi.fn(() => null),
+    saveSession: vi.fn(),
+    removeSession: vi.fn(),
+    getJobState: vi.fn().mockReturnValue(null),
+    saveJobState: vi.fn(),
+    getValue: vi.fn().mockReturnValue(undefined),
+    setValue: vi.fn(),
+  } as unknown as StateManager;
+}
+
+function makeSessionManager(): SessionManager {
+  const cfg = {
+    tmuxPath: '/usr/bin/tmux',
+    claudePath: '/usr/bin/claude',
+    projectDir: '/tmp/test-project',
+    maxSessions: 5,
+    protectedSessions: [],
+    completionPatterns: [],
+  } as SessionManagerConfig;
+  return new SessionManager(cfg, mockState());
+}
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+describe('compaction busy-defer E2E — real disk + real timers', () => {
+  let jsonlRoot: string;
+  let sm: SessionManager;
+  let sentinel: CompactionSentinel;
+  let recoverFn: ReturnType<typeof vi.fn>;
+  let paneText: string;
+
+  beforeEach(() => {
+    jsonlRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'busy-defer-e2e-'));
+    fs.writeFileSync(path.join(jsonlRoot, 'sess.jsonl'), 'x'.repeat(100));
+    paneText = '';
+    sm = makeSessionManager();
+    vi.spyOn(sm, 'tmuxSessionExists').mockReturnValue(true);
+    vi.spyOn(sm, 'captureOutput').mockImplementation(() => paneText);
+    vi.spyOn(sm, 'hasActiveProcesses').mockReturnValue(false);
+    recoverFn = vi.fn().mockResolvedValue(true);
+    sentinel = new CompactionSentinel(
+      {
+        recoverFn: recoverFn as any,
+        projectDir: '/fake/project',
+        jsonlRoot,
+        isActivelyWorking: (s: string) => sm.isSessionActivelyWorking(s),
+      },
+      // Tiny verify window so real timers stay fast.
+      { dedupeWindowMs: 60_000, verifyWindowMs: 40, maxInjectAttempts: 3, maxWorkingDefers: 8 },
+    );
+  });
+
+  afterEach(() => {
+    sentinel.stop();
+    vi.restoreAllMocks();
+    SafeFsExecutor.safeRmSync(jsonlRoot, { recursive: true, force: true, operation: 'tests/e2e/compaction-busy-defer-lifecycle.test.ts' });
+  });
+
+  it('never injects while working, then recovers when the JSONL grows on disk', async () => {
+    paneText = '✻ Thinking… (22s · esc to interrupt)'; // mid-turn the whole time
+    sentinel.report('sess', 'watchdog-poll');
+
+    // Let several verify windows pass while still "working".
+    await sleep(180); // ~4 windows of 40ms
+    expect(recoverFn).not.toHaveBeenCalled();
+    expect(sentinel.getState('sess')?.status).toBe('deferring');
+    expect(sentinel.getState('sess')!.workingDefers).toBeGreaterThan(1);
+
+    // The deferred turn lands: footer clears AND the session emits to its JSONL.
+    paneText = '╭─ > ─╮';
+    fs.writeFileSync(path.join(jsonlRoot, 'sess.jsonl'), 'x'.repeat(600));
+
+    // Next verify window should observe growth → recovered, with NO inject.
+    await sleep(120);
+    expect(recoverFn).not.toHaveBeenCalled();
+    expect(sentinel.getState('sess')?.status).toBe('recovered'); // finalized
+    expect(sentinel.isRecoveryActive('sess')).toBe(false);       // veto released
+  });
+
+  it('idle-from-start session injects (recovery still works when genuinely stuck)', async () => {
+    paneText = '╭─ > ─╮'; // idle, no footer, no child
+    sentinel.report('sess', 'watchdog-poll');
+    await sleep(20);
+    expect(recoverFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('compaction busy-defer E2E — WIRED into server.ts (dead-code guard)', () => {
+  const serverSrc = fs.readFileSync(
+    path.join(process.cwd(), 'src/commands/server.ts'),
+    'utf-8',
+  );
+
+  it('server.ts passes isActivelyWorking into the CompactionSentinel', () => {
+    expect(serverSrc).toMatch(/isActivelyWorking:/);
+  });
+
+  it('server.ts sources it from SessionManager.isSessionActivelyWorking', () => {
+    expect(serverSrc).toContain('isSessionActivelyWorking');
+  });
+});

--- a/tests/integration/compaction-busy-defer-wiring.test.ts
+++ b/tests/integration/compaction-busy-defer-wiring.test.ts
@@ -1,0 +1,129 @@
+// safe-fs-allow: test file — temp jsonl dir via mkdtemp/rm only.
+// safe-git-allow: test file — no git calls.
+
+/**
+ * Integration test for the busy-session defer guard.
+ *
+ * Drives a REAL CompactionSentinel whose `isActivelyWorking` dep is wired to a
+ * REAL SessionManager.isSessionActivelyWorking — the EXACT closure server.ts
+ * assembles. The session's "is it mid-turn?" answer is sourced from the real
+ * pane-footer + child-process logic (we stub only the lowest-level tmux capture
+ * so the test is deterministic and needs no real tmux).
+ *
+ * Proves the contract that closes the false "session is restarting" loop:
+ *   - While the session is actively working, the sentinel DEFERS — recoverFn is
+ *     never called, so no recovery prompt is injected on top of the user's
+ *     real message.
+ *   - Once the session goes idle, the sentinel proceeds to inject.
+ *   - A session idle from the start injects immediately (no behavior change).
+ *
+ * Root cause + spec: docs/specs/compaction-busy-session-defer.md
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CompactionSentinel } from '../../src/monitoring/CompactionSentinel.js';
+import { SessionManager } from '../../src/core/SessionManager.js';
+import type { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function mockState(): StateManager {
+  return {
+    listSessions: vi.fn(() => []),
+    getSession: vi.fn(() => null),
+    saveSession: vi.fn(),
+    removeSession: vi.fn(),
+    getJobState: vi.fn().mockReturnValue(null),
+    saveJobState: vi.fn(),
+    getValue: vi.fn().mockReturnValue(undefined),
+    setValue: vi.fn(),
+  } as unknown as StateManager;
+}
+
+function makeSessionManager(): SessionManager {
+  const cfg = {
+    tmuxPath: '/usr/bin/tmux',
+    claudePath: '/usr/bin/claude',
+    projectDir: '/tmp/test-project',
+    maxSessions: 5,
+    protectedSessions: [],
+    completionPatterns: [],
+  } as SessionManagerConfig;
+  return new SessionManager(cfg, mockState());
+}
+
+describe('CompactionSentinel × SessionManager — busy-session defer wiring', () => {
+  let jsonlRoot: string;
+  let sm: SessionManager;
+  let sentinel: CompactionSentinel;
+  let recoverFn: ReturnType<typeof vi.fn>;
+  let paneText: string; // controls what the real isSessionActivelyWorking sees
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    jsonlRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'busy-defer-'));
+    fs.writeFileSync(path.join(jsonlRoot, 'foo.jsonl'), 'x'.repeat(100));
+    paneText = '';
+
+    sm = makeSessionManager();
+    vi.spyOn(sm, 'tmuxSessionExists').mockReturnValue(true);
+    vi.spyOn(sm, 'captureOutput').mockImplementation(() => paneText);
+    vi.spyOn(sm, 'hasActiveProcesses').mockReturnValue(false);
+
+    recoverFn = vi.fn().mockResolvedValue(true);
+    sentinel = new CompactionSentinel(
+      {
+        recoverFn: recoverFn as any,
+        projectDir: '/fake/project',
+        jsonlRoot,
+        // EXACTLY what server.ts wires:
+        isActivelyWorking: (s: string) => sm.isSessionActivelyWorking(s),
+      },
+      { dedupeWindowMs: 60_000, verifyWindowMs: 1_000, maxInjectAttempts: 3, maxWorkingDefers: 5 },
+    );
+  });
+
+  afterEach(() => {
+    sentinel.stop();
+    vi.useRealTimers();
+    SafeFsExecutor.safeRmSync(jsonlRoot, { recursive: true, force: true, operation: 'tests/integration/compaction-busy-defer-wiring.test.ts' });
+  });
+
+  it('defers (no inject) while the real SessionManager reports the session mid-turn', async () => {
+    paneText = '✻ Thinking… (15s · esc to interrupt)'; // real footer signal
+    sentinel.report('echo-sess', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(recoverFn).not.toHaveBeenCalled();
+    expect(sentinel.getState('echo-sess')?.status).toBe('deferring');
+  });
+
+  it('injects once the real SessionManager reports the session idle', async () => {
+    paneText = '✻ Thinking… (15s · esc to interrupt)';
+    sentinel.report('echo-sess', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(recoverFn).not.toHaveBeenCalled();
+    // Turn lands; the footer clears.
+    paneText = '╭─ > ─╮\n  ⏵⏵ bypass permissions on';
+    await vi.advanceTimersByTimeAsync(1_100);
+    expect(recoverFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('injects immediately when the session is idle from the start (unchanged path)', async () => {
+    paneText = '╭─ > ─╮'; // idle, no footer
+    sentinel.report('echo-sess', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(recoverFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers while a real child process is running even with no footer', async () => {
+    paneText = '> (no footer line)';
+    (sm.hasActiveProcesses as any).mockReturnValue(true); // a tool is running
+    sentinel.report('echo-sess', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(recoverFn).not.toHaveBeenCalled();
+    expect(sentinel.getState('echo-sess')?.status).toBe('deferring');
+  });
+});

--- a/tests/unit/CompactionSentinel.test.ts
+++ b/tests/unit/CompactionSentinel.test.ts
@@ -295,4 +295,114 @@ describe('CompactionSentinel', () => {
     expect(sentinel.getState('a')).toBeUndefined();
     expect(sentinel.getState('b')).toBeUndefined();
   });
+
+  // ─── Busy-session defer guard (isActivelyWorking) ───
+  //
+  // Root cause of the false "session is restarting" loop: a long extended-think
+  // on a large context writes nothing to the JSONL until the turn lands, so the
+  // no-growth check read it as "stuck" and RE-INJECTED a recovery prompt —
+  // burying the user's real message under stacked bootstraps. With an
+  // isActivelyWorking signal, the sentinel must DEFER (wait without injecting)
+  // while the session is mid-turn, bounded by maxWorkingDefers.
+  describe('busy-session defer guard', () => {
+    let working: boolean;
+    let j: ReturnType<typeof makeTempJsonlRoot>;
+    let rec: ReturnType<typeof vi.fn>;
+    let s: CompactionSentinel;
+    let evs: Array<{ type: string; payload: any }>;
+
+    function build(opts: { maxWorkingDefers?: number; withDep?: boolean } = {}): void {
+      j = makeTempJsonlRoot();
+      rec = vi.fn().mockResolvedValue(true);
+      s = new CompactionSentinel(
+        {
+          recoverFn: rec as any,
+          projectDir: '/fake/project',
+          jsonlRoot: j.root,
+          ...(opts.withDep === false ? {} : { isActivelyWorking: () => working }),
+        },
+        { dedupeWindowMs: 60_000, verifyWindowMs: 25_000, maxInjectAttempts: 3, maxWorkingDefers: opts.maxWorkingDefers ?? 4 },
+      );
+      evs = [];
+      for (const e of ['compaction:detected', 'compaction:inject-attempted', 'compaction:deferred', 'compaction:recovered', 'compaction:failed']) {
+        s.on(e as any, (p: any) => evs.push({ type: e, payload: p }));
+      }
+    }
+
+    beforeEach(() => { working = false; });
+    afterEach(() => { s?.stop(); j?.cleanup(); });
+
+    it('defers the first inject while actively working — never calls recoverFn', async () => {
+      build();
+      j.write('foo.jsonl', 100);
+      working = true;
+      s.report('s1', 'watchdog-poll');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(rec).not.toHaveBeenCalled();
+      expect(evs.some(e => e.type === 'compaction:deferred')).toBe(true);
+      expect(evs.some(e => e.type === 'compaction:inject-attempted')).toBe(false);
+      expect(s.getState('s1')?.status).toBe('deferring');
+      expect(s.getState('s1')?.workingDefers).toBe(1);
+      // Still counts as active recovery → zombie-killer stays vetoed.
+      expect(s.isRecoveryActive('s1')).toBe(true);
+    });
+
+    it('injects once the session stops working', async () => {
+      build();
+      j.write('foo.jsonl', 100);
+      working = true;
+      s.report('s1', 'watchdog-poll');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(rec).not.toHaveBeenCalled();
+      // Turn finishes — next verify window proceeds to inject.
+      working = false;
+      await vi.advanceTimersByTimeAsync(25_500);
+      expect(rec).toHaveBeenCalledTimes(1);
+    });
+
+    it('recovers WITHOUT injecting if the session emits while we defer (jsonl grows)', async () => {
+      build();
+      j.write('foo.jsonl', 100);
+      working = true;
+      s.report('s1', 'watchdog-poll');
+      await vi.advanceTimersByTimeAsync(0);
+      // The deferred turn landed — claude emitted output, jsonl grows.
+      j.write('foo.jsonl', 500);
+      await vi.advanceTimersByTimeAsync(25_500);
+      expect(rec).not.toHaveBeenCalled();
+      expect(evs.some(e => e.type === 'compaction:recovered')).toBe(true);
+    });
+
+    it('caps consecutive defers at maxWorkingDefers then forces an inject', async () => {
+      build({ maxWorkingDefers: 4 });
+      j.write('foo.jsonl', 100);
+      working = true; // hung "working" footer — never clears
+      s.report('s1', 'watchdog-poll');
+      await vi.advanceTimersByTimeAsync(0);
+      // defer #1 at report; defers #2/#3/#4 at the next three verify windows;
+      // the window after that forces an inject.
+      for (let i = 0; i < 4; i++) await vi.advanceTimersByTimeAsync(25_500);
+      expect(evs.filter(e => e.type === 'compaction:deferred')).toHaveLength(4);
+      expect(rec).toHaveBeenCalledTimes(1);
+    });
+
+    it('maxWorkingDefers=0 disables deferral (injects immediately even while working)', async () => {
+      build({ maxWorkingDefers: 0 });
+      j.write('foo.jsonl', 100);
+      working = true;
+      s.report('s1', 'watchdog-poll');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(rec).toHaveBeenCalledTimes(1); // old behavior restored
+    });
+
+    it('with no isActivelyWorking dep, never defers (backward compatible)', async () => {
+      build({ withDep: false });
+      j.write('foo.jsonl', 100);
+      working = true; // irrelevant — dep absent
+      s.report('s1', 'watchdog-poll');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(rec).toHaveBeenCalledTimes(1);
+      expect(evs.some(e => e.type === 'compaction:deferred')).toBe(false);
+    });
+  });
 });

--- a/tests/unit/claudeActivityIndicators.test.ts
+++ b/tests/unit/claudeActivityIndicators.test.ts
@@ -1,0 +1,59 @@
+// Unit tests for the canonical "Claude Code is mid-turn" footer signal shared
+// by StuckInputSentinel, SessionManager.verifyInjection, and CompactionSentinel.
+
+import { describe, it, expect } from 'vitest';
+import {
+  CLAUDE_WORKING_INDICATORS,
+  paneShowsClaudeWorking,
+} from '../../src/core/claudeActivityIndicators.js';
+
+describe('claudeActivityIndicators', () => {
+  it('exposes the three canonical footer hints', () => {
+    expect(CLAUDE_WORKING_INDICATORS).toContain('esc to interrupt');
+    expect(CLAUDE_WORKING_INDICATORS).toContain('tokens · esc');
+    expect(CLAUDE_WORKING_INDICATORS).toContain('ctrl+t to hide tasks');
+  });
+
+  describe('paneShowsClaudeWorking', () => {
+    it('detects an in-flight turn from the "esc to interrupt" footer', () => {
+      const pane = [
+        '⏺ Working on the task…',
+        '  ⎿ Running Bash(npm test)',
+        '',
+        '✻ Thinking… (12s · ↑ 4.1k tokens · esc to interrupt)',
+      ].join('\n');
+      expect(paneShowsClaudeWorking(pane)).toBe(true);
+    });
+
+    it('detects the token-counting footer variant', () => {
+      expect(paneShowsClaudeWorking('  · 1.2k tokens · esc to interrupt')).toBe(true);
+      expect(paneShowsClaudeWorking('foo tokens · esc bar')).toBe(true);
+    });
+
+    it('detects the multi-task footer variant', () => {
+      expect(paneShowsClaudeWorking('press ctrl+t to hide tasks')).toBe(true);
+    });
+
+    it('returns false for an idle prompt (no in-flight turn)', () => {
+      const idle = [
+        '╭──────────────────────────────────────╮',
+        '│ >                                    │',
+        '╰──────────────────────────────────────╯',
+        '  ⏵⏵ bypass permissions on',
+      ].join('\n');
+      expect(paneShowsClaudeWorking(idle)).toBe(false);
+    });
+
+    it('returns false for empty / null / undefined panes', () => {
+      expect(paneShowsClaudeWorking('')).toBe(false);
+      expect(paneShowsClaudeWorking(null)).toBe(false);
+      expect(paneShowsClaudeWorking(undefined)).toBe(false);
+    });
+
+    it('does NOT false-positive on prose that merely mentions interrupting', () => {
+      // The exact footer substring is required — generic words don't match.
+      expect(paneShowsClaudeWorking('You can press escape to stop me anytime.')).toBe(false);
+      expect(paneShowsClaudeWorking('the build emitted 5000 tokens total')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/session-active-work.test.ts
+++ b/tests/unit/session-active-work.test.ts
@@ -1,0 +1,92 @@
+// Unit tests for SessionManager.paneShowsActiveWork + isSessionActivelyWorking
+// — the "is this session mid-turn?" signal the recovery sentinels consult
+// before taking a disruptive action (re-inject / recovery Enter).
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SessionManager } from '../../src/core/SessionManager.js';
+import type { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+
+function createMockState(): StateManager {
+  return {
+    listSessions: vi.fn(() => []),
+    getSession: vi.fn(() => null),
+    saveSession: vi.fn(),
+    removeSession: vi.fn(),
+    getJobState: vi.fn().mockReturnValue(null),
+    saveJobState: vi.fn(),
+    getValue: vi.fn().mockReturnValue(undefined),
+    setValue: vi.fn(),
+  } as unknown as StateManager;
+}
+
+function makeSM(): SessionManager {
+  const cfg = {
+    tmuxPath: '/usr/bin/tmux',
+    claudePath: '/usr/bin/claude',
+    projectDir: '/tmp/test-project',
+    maxSessions: 5,
+    protectedSessions: [],
+    completionPatterns: [],
+  } as SessionManagerConfig;
+  return new SessionManager(cfg, createMockState());
+}
+
+describe('SessionManager.paneShowsActiveWork', () => {
+  it('true when the pane shows the mid-turn footer', () => {
+    const sm = makeSM();
+    expect(sm.paneShowsActiveWork('✻ Thinking… (8s · esc to interrupt)')).toBe(true);
+  });
+  it('false for an idle prompt or empty pane', () => {
+    const sm = makeSM();
+    expect(sm.paneShowsActiveWork('> ')).toBe(false);
+    expect(sm.paneShowsActiveWork('')).toBe(false);
+    expect(sm.paneShowsActiveWork(null)).toBe(false);
+  });
+});
+
+describe('SessionManager.isSessionActivelyWorking', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('true when the pane footer shows an in-flight turn (no child process needed)', () => {
+    const sm = makeSM();
+    vi.spyOn(sm, 'tmuxSessionExists').mockReturnValue(true);
+    vi.spyOn(sm, 'captureOutput').mockReturnValue('… 3.2k tokens · esc to interrupt');
+    const procs = vi.spyOn(sm, 'hasActiveProcesses').mockReturnValue(false);
+    expect(sm.isSessionActivelyWorking('s1')).toBe(true);
+    // Footer alone is sufficient — this is the extended-think case.
+    expect(procs).not.toHaveBeenCalled();
+  });
+
+  it('true when idle at prompt but a tool/child process is running', () => {
+    const sm = makeSM();
+    vi.spyOn(sm, 'tmuxSessionExists').mockReturnValue(true);
+    vi.spyOn(sm, 'captureOutput').mockReturnValue('> (no footer)');
+    vi.spyOn(sm, 'hasActiveProcesses').mockReturnValue(true);
+    expect(sm.isSessionActivelyWorking('s1')).toBe(true);
+  });
+
+  it('false when idle at prompt with no footer and no child process', () => {
+    const sm = makeSM();
+    vi.spyOn(sm, 'tmuxSessionExists').mockReturnValue(true);
+    vi.spyOn(sm, 'captureOutput').mockReturnValue('> ');
+    vi.spyOn(sm, 'hasActiveProcesses').mockReturnValue(false);
+    expect(sm.isSessionActivelyWorking('s1')).toBe(false);
+  });
+
+  it('false when the session does not exist', () => {
+    const sm = makeSM();
+    vi.spyOn(sm, 'tmuxSessionExists').mockReturnValue(false);
+    const cap = vi.spyOn(sm, 'captureOutput');
+    expect(sm.isSessionActivelyWorking('gone')).toBe(false);
+    expect(cap).not.toHaveBeenCalled();
+  });
+
+  it('never throws — a capture failure resolves to false', () => {
+    const sm = makeSM();
+    vi.spyOn(sm, 'tmuxSessionExists').mockReturnValue(true);
+    vi.spyOn(sm, 'captureOutput').mockImplementation(() => { throw new Error('tmux gone'); });
+    expect(() => sm.isSessionActivelyWorking('s1')).not.toThrow();
+    expect(sm.isSessionActivelyWorking('s1')).toBe(false);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -35,3 +35,53 @@ tells you exactly why (visible at `/mentor/status`) instead of an unexplained
   `runMentorTick`). Full mentor/stage suite (113 tests / 9 files) green;
   `tsc --noEmit` clean.
 - Side-effects: `upgrades/side-effects/mentor-stage-a-robustness.md`.
+
+---
+
+## What Changed — session recovery no longer "restarts" a session that's actually working
+
+**If you message your agent while it's mid-thought, your message no longer gets
+buried under a false "Session restarting…" loop.** When the agent's working
+memory is compacted, a watchdog re-orients the session and then waits for it to
+write new output. A long extended-think on a big conversation writes nothing to
+its transcript until the thought lands — so a perfectly-alive, hard-working
+session looked "stuck," and the watchdog re-injected another recovery prompt on
+top of your real message, again and again. Your message got buried and you saw
+"Session respawned / starting up" instead of an answer (the dashboard worked
+because it talks to the session directly). Caught firing 3× in ~52s against a
+live session on Echo.
+
+Now the watchdog checks whether the session is actively working — the
+`esc to interrupt` / `tokens · esc` mid-turn footer, or a live tool process —
+before it re-injects. If the session is working, it waits instead of re-poking;
+if the turn lands and the session emits on its own, that counts as recovered with
+zero injects. An idle or wedged session recovers exactly as before.
+
+## What to Tell Your User
+
+This is automatic, no configuration. If you ever messaged an agent and got
+"Session restarting…" with your message vanishing (forcing you to the dashboard),
+that's fixed: a busy session now answers when its current turn finishes instead
+of trampling your message with recovery prompts.
+
+## Summary of New Capabilities
+
+- `SessionManager.isSessionActivelyWorking(session)` + `paneShowsActiveWork(pane)`
+  — canonical "is this session mid-turn?" signal (shared `CLAUDE_WORKING_INDICATORS`).
+- `CompactionSentinel` now defers re-injection while a session is actively working
+  (new `isActivelyWorking` dep + `maxWorkingDefers` config, default 10; emits
+  `compaction:deferred`). `verifyInjection` likewise skips its recovery Enter on a
+  working pane (ends the noisy `Injection stuck — Auto-recovering` spam). Escape
+  hatch: `maxWorkingDefers: 0` restores the old behavior.
+
+## Evidence
+
+- Unit: `tests/unit/CompactionSentinel.test.ts` (+6 busy-defer cases),
+  `tests/unit/claudeActivityIndicators.test.ts` (new),
+  `tests/unit/session-active-work.test.ts` (new) — 125 pass across the related set.
+- Integration: `tests/integration/compaction-busy-defer-wiring.test.ts` (4) —
+  REAL `CompactionSentinel` × REAL `SessionManager.isSessionActivelyWorking`.
+- E2E: `tests/e2e/compaction-busy-defer-lifecycle.test.ts` (4) — real-disk
+  lifecycle (recovers with zero injects while working) + WIRED-into-server.ts guard.
+- Spec: `docs/specs/compaction-busy-session-defer.md` (+ `.eli16.md`).
+- Side-effects: `upgrades/side-effects/compaction-busy-session-defer.md`.

--- a/upgrades/side-effects/compaction-busy-session-defer.md
+++ b/upgrades/side-effects/compaction-busy-session-defer.md
@@ -1,0 +1,94 @@
+# Side-Effects Review — Compaction recovery: defer re-inject while the session is actively working
+
+**Version / slug:** `compaction-busy-session-defer`
+**Date:** `2026-05-29`
+**Author:** `echo`
+**Spec:** `docs/specs/compaction-busy-session-defer.md` (+ `.eli16.md`)
+**Convergence:** `docs/specs/reports/compaction-busy-session-defer-convergence.md` (fast-tracked — urgent fleet bug; see report)
+**Second-pass reviewer:** `not required` (see §"Phase 5 trigger check")
+
+## Summary of the change
+
+Fixes the user-reported false "session is restarting" loop (Justin, topic 15160):
+a live, actively-working session gets its inbound message buried under stacked
+compaction-recovery re-injects, so the message never reaches the session and the
+user sees repeated "restarting / starting up" narration.
+
+Root cause (verified in running code + `logs/server.log` on Echo): `CompactionSentinel`
+re-injects a recovery prompt when the session's JSONL doesn't grow within the
+verify window — but a long extended-think on a large context (typical right after
+resuming a near-full transcript) writes nothing to the JSONL until the turn
+lands, so a healthy session reads as "stuck." Caught firing 3× in ~52s against a
+live session.
+
+The change teaches the recovery surfaces to recognize a mid-turn session (the
+canonical `esc to interrupt` / `tokens · esc` footer OR a live non-baseline child
+process) and DEFER instead of re-injecting, bounded by `maxWorkingDefers`.
+
+## Files touched
+
+- `src/core/claudeActivityIndicators.ts` (**new**) — `CLAUDE_WORKING_INDICATORS`
+  single source of truth + pure `paneShowsClaudeWorking`.
+- `src/core/StuckInputSentinel.ts` — its `ACTIVITY_INDICATORS` now imports the
+  shared const (no behavior change; removes drift risk).
+- `src/core/SessionManager.ts` — `paneShowsActiveWork` + `isSessionActivelyWorking`;
+  `verifyInjection` skips the recovery Enter while the pane is actively working.
+- `src/monitoring/CompactionSentinel.ts` — `isActivelyWorking?` dep,
+  `maxWorkingDefers` config, `workingDefers` state, `deferForActiveWork()` +
+  `scheduleVerify()`, `compaction:deferred` event, `deferring` status.
+- `src/commands/server.ts` — wires `isActivelyWorking` to
+  `sessionManager.isSessionActivelyWorking`.
+- Tests: `tests/unit/CompactionSentinel.test.ts` (+6 cases),
+  `tests/unit/claudeActivityIndicators.test.ts` (new),
+  `tests/unit/session-active-work.test.ts` (new),
+  `tests/integration/compaction-busy-defer-wiring.test.ts` (new),
+  `tests/e2e/compaction-busy-defer-lifecycle.test.ts` (new).
+
+## Decision-point inventory
+
+- **Inject vs defer (CompactionSentinel)** — *modify, additive*. Was "no jsonl
+  growth → re-inject/fail." Now: "no growth AND actively working AND defer budget
+  remains → wait without injecting; else unchanged." A presence check, not a
+  judgment. Both branches test-covered. With the dep absent or
+  `maxWorkingDefers: 0`, behavior is byte-for-byte the old path.
+- **Recovery-Enter vs skip (verifyInjection)** — *modify, additive*. Was "marker
+  at prompt → fire Enter." Now: "marker at prompt AND actively working → skip
+  this tick, keep polling." Skipping is strictly less action; the input is
+  correctly queued by Claude Code and submits when the turn ends.
+- **Working signal** — *read-only*. Reuses the existing footer indicators +
+  `hasActiveProcesses`. No new file format, no write, no new tmux command.
+  `isSessionActivelyWorking` is wrapped so a capture/ps failure resolves to
+  `false` (cannot throw into recovery).
+
+## Blast radius
+
+- **No new authority, no new gate, no new detector, no new API route, no
+  external surface.** A defer behind an existing, already-rate-guarded recovery
+  primitive.
+- **Hot paths unchanged.** `getTopicForSession` and the message-inject hot path
+  are untouched. `isSessionActivelyWorking` runs only inside the recovery
+  lifecycle (already off the hot path).
+- **Strictly less aggressive.** The change can only PREVENT a re-inject/Enter; it
+  never adds one. It cannot starve a real recovery: an idle or wedged session
+  shows no working tell → no defer. Bounded by `maxWorkingDefers`.
+- **No agent-installed files changed** — no `.claude/settings.json` hooks, no
+  `.instar/config.json` defaults, no CLAUDE.md template, no hook scripts, no
+  skills. So **no PostUpdateMigrator entry is required**: pure `src/` logic that
+  reaches every agent through the normal dist update.
+
+## Phase 5 trigger check (second-pass reviewer)
+
+Second pass **not required**: no new authority, no destructive operation
+introduced (the only behavioral deltas REMOVE actions — a re-inject and a
+recovery Enter — against working sessions), no external surface, no migration.
+Additive, read-only signal behind an existing rate-guarded recovery primitive,
+with full three-tier coverage.
+
+## Verification
+
+- Unit: `CompactionSentinel.test.ts`, `claudeActivityIndicators.test.ts`,
+  `session-active-work.test.ts` (+ existing `StuckInputSentinel.test.ts` still
+  green after the shared-const refactor) — 125 pass across the related set.
+- Integration: `compaction-busy-defer-wiring.test.ts` — 4 pass.
+- E2E: `compaction-busy-defer-lifecycle.test.ts` — 4 pass (incl. WIRED guard).
+- `tsc --noEmit` clean.


### PR DESCRIPTION
## The bug (user-reported, topic 15160)

Justin: *"most of my messages are not going through. I send a message, it says the session is restarting EVEN THOUGH I KNOW the session is still alive ... I have to go to the session directly in the dashboard since it didn't ever go through."*

## Verified root cause (running code + `logs/server.log` on Echo)

`CompactionSentinel` recovers a compacted session by injecting a re-orient prompt, then watching the Claude Code JSONL transcript for growth within `verifyWindowMs` (25s). If it sees no growth it concludes "stuck" and **re-injects**. But a long extended-think on a large context (typical right after resuming a near-full transcript) writes **nothing** to the JSONL until the turn lands — so a perfectly-alive, hard-working session reads as "stuck." Each re-inject stacks another full recovery bootstrap on top of the user's real message → the message is buried, the user sees repeated "Session respawned / starting up" instead of a reply. The dashboard works because it talks to the session directly, bypassing this loop.

Caught firing 3× in ~52s against a live session (00:14:43 / 00:15:09 / 00:15:35 UTC).

Secondary, same family: `SessionManager.verifyInjection` fires a recovery Enter whenever the injected marker sits at the `❯` prompt — which is also the normal state of a busy session with correctly-queued input — producing the noisy `Injection stuck — Auto-recovering` warnings on every inbound to a working session.

## The fix

Teach the recovery surfaces to recognize a mid-turn session and refuse to take a disruptive action against it, reusing the existing canonical footer signal.

- **`src/core/claudeActivityIndicators.ts` (new)** — single source of truth: `CLAUDE_WORKING_INDICATORS` (`esc to interrupt` / `tokens · esc` / `ctrl+t to hide tasks`) + pure `paneShowsClaudeWorking`. Footer hints only (NOT spinner glyphs, which can persist in a dead pane's last frame). `StuckInputSentinel` now imports from here.
- **`SessionManager`** — `paneShowsActiveWork` + `isSessionActivelyWorking` (footer OR live non-baseline child process; never throws). `verifyInjection` skips its recovery Enter while the pane is actively working.
- **`CompactionSentinel`** — `isActivelyWorking` dep + `maxWorkingDefers` config (default 10). Defers (no re-inject) while working; recovers with **zero injects** if the turn lands; forces an inject after the cap. New `compaction:deferred` event / `deferring` status.
- **`server.ts`** — wires `isActivelyWorking → sessionManager.isSessionActivelyWorking`.

## Why default ON (no opt-in flag)

Only changes behavior for a session that **is** actively working — the exact case the old code trampled. An idle-at-prompt session, or a wedged session that fast-fails every turn, shows no footer and runs no child process → no defer → recovery proceeds exactly as before. The fix removes a false-positive harm and cannot starve a real recovery. Escape hatch: `maxWorkingDefers: 0`. Pure `src/` — no `PostUpdateMigrator` entry needed.

## Tests (all three tiers)

- **Unit**: `CompactionSentinel.test.ts` (+6 busy-defer cases), `claudeActivityIndicators.test.ts`, `session-active-work.test.ts`.
- **Integration**: `compaction-busy-defer-wiring.test.ts` — REAL `CompactionSentinel` × REAL `SessionManager.isSessionActivelyWorking` (the exact server wiring).
- **E2E**: `compaction-busy-defer-lifecycle.test.ts` — real-disk/real-timers lifecycle (recovers with 0 injects while working) + WIRED-into-server.ts dead-code guard.

Spec: `docs/specs/compaction-busy-session-defer.md` (+ `.eli16.md`). Convergence fast-tracked to constrained self-review (urgent fleet-wide relay-UX bug) — disclosed in `docs/specs/reports/compaction-busy-session-defer-convergence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)