### PR TITLE
fix(mentor): bound the Stage-A compose prompt under tmux's command-line limit

### DIFF
--- a/docs/specs/MENTOR-STAGE-A-PROMPT-BOUND-SPEC.eli16.md
+++ b/docs/specs/MENTOR-STAGE-A-PROMPT-BOUND-SPEC.eli16.md
@@ -1,0 +1,41 @@
+# In plain English: stop the mentor's message from getting too long to send
+
+## What this is about
+
+The mentor coaches another agent (Codey). Each cycle it does "Stage-A": it spins
+up a tiny throwaway AI session to write the next coaching message. To start that
+session, the code runs a `tmux` command, and it passes the ENTIRE prompt — which
+includes the whole conversation history so far — as part of that command.
+
+## What went wrong
+
+`tmux` (the tool that manages those sessions) has a limit on how long a single
+command can be — about 12 to 16 thousand characters. Early in the mentorship the
+conversation was short, so the prompt fit and everything worked. But every cycle,
+the conversation got longer, and the prompt grew with it. Eventually the prompt
+got bigger than tmux allows, and tmux refused to start the session with the error
+"command too long." That made the whole step fail — the mentee got nothing.
+
+(We only KNEW this was the cause because the previous fix made the mentor report
+its real error instead of a vague "stage-a-failed." This is that fix's payoff.)
+
+## What's new
+
+The code now caps how much conversation history it stuffs into the prompt. It
+keeps the most-recent ~6,000 characters of the conversation (the recent back-and-
+forth is what matters for "what should the mentee do next?") and replaces the
+older middle with a short note saying how much was left out. The agenda and the
+current task status are kept in full.
+
+The result: the prompt now stays safely under tmux's limit, so the session always
+starts — no matter how long the mentorship runs. Older history is summarized-away
+on purpose, not lost by accident.
+
+## What the reader needs to decide
+
+Nothing to configure. This makes the mentor's Stage-A step reliable for the long
+haul. A test proves that even an 80,000-character history produces a prompt under
+12,000 characters that still keeps the most-recent exchange and marks what was
+elided — and a cold test of tmux confirms the cap is safely below its real limit.
+Combined with the previous fix (which now reports the true cause of any failure),
+the mentor's Stage-A step is both reliable and debuggable.

--- a/docs/specs/MENTOR-STAGE-A-PROMPT-BOUND-SPEC.md
+++ b/docs/specs/MENTOR-STAGE-A-PROMPT-BOUND-SPEC.md
@@ -1,0 +1,80 @@
+---
+title: Mentor Stage-A — bound the compose prompt under tmux's command-line limit
+status: approved
+review-convergence: converged
+approved: true
+approval-basis: >
+  Direct user directive (Justin, 2026-05-29, topic 13435): "lets fix this and
+  make it more robust." The diagnosability fix (PR #544) surfaced the exact root
+  cause this PR fixes: the Stage-A compose-session spawn failed because the
+  prompt (the whole growing mentor↔mentee conversation) exceeded tmux's
+  new-session command-line length limit.
+eli16-overview: MENTOR-STAGE-A-PROMPT-BOUND-SPEC.eli16.md
+date: 2026-05-29
+---
+
+# Mentor Stage-A: bound the compose prompt under tmux's command-line limit
+
+## Problem (root cause, now confirmed)
+
+The mentor Stage-A step composes the next coaching message by spawning a
+tool-less Haiku session whose **prompt is passed as a command-line argument** to
+`claude` via `tmux new-session`. The prompt is built by `buildStageAContext`,
+which embeds `surface.threadlineHistory` — the **entire mentor↔mentee
+conversation so far**. As that history accumulates, the command line grows; once
+it crosses tmux's `new-session` command-length limit, `tmux new-session` fails
+with `"command too long"`, the spawn throws, and the whole tick reports
+`stage-a-failed` (visible now via PR #544's `lastResult.error`).
+
+Confirmed empirically: a ~120KB argument to `tmux new-session` fails with
+`command too long`; 2–12KB pass, 16KB fails — so the practical limit is ~12-16KB
+(and the real command's env/flags prefix eats into that). This is exactly why the
+mentor worked at 16:03Z (short history) and broke later (history accumulated).
+
+## Design
+
+Bound the conversation history in `buildStageAContext` so the assembled prompt
+can never exceed tmux's limit:
+
+- Cap `threadlineHistory` at `MAX_HISTORY_CHARS = 6000`. Everything else in the
+  prompt (the fixed instructions + agenda + visible status + commitments) is
+  small and not user-growing.
+- Keep the **most-recent** `MAX_HISTORY_CHARS` of history (the recent exchanges
+  are what matter for deciding the next action) and prepend an explicit marker
+  noting how much older conversation was elided — never silently dropped.
+
+This keeps the total prompt comfortably under the ~12KB practical budget (history
+≤6KB + a few KB of fixed structure) with margin for the env/command prefix,
+making the Stage-A spawn length-proof no matter how long the mentorship runs. The
+two-hats isolation, the agenda-driven behaviour, and the prompt structure are all
+unchanged.
+
+## Convergence notes (adversarial self-review)
+
+- *Does the bound lose context the mentor needs?* The mentor's job each tick is
+  to decide ONE next action from the recent state + the agenda. The most-recent
+  6KB of exchanges + the (separate, retained) agenda + visible task status carry
+  that. Older middle history is the least relevant to "what's the next task."
+- *Could a single recent message still blow the limit?* `MAX_HISTORY_CHARS` caps
+  the history block regardless of message boundaries (a hard char slice), so the
+  block can't exceed 6KB even if one message is huge.
+- *Could the fixed parts (agenda) blow the limit?* The agenda is operator config,
+  not user-growing; it is bounded in practice. The history was the only
+  unbounded-growth vector.
+- *Behaviour when history is small?* Unchanged — the bound only engages above
+  6000 chars.
+
+## Testing
+
+- **Unit** (`tests/unit/MentorStageA.test.ts`): an ~80KB history yields a prompt
+  under 12KB that (a) preserves the most-recent exchange, (b) carries the
+  `older conversation elided` marker, and (c) keeps the prompt structure
+  (`Conversation so far` / `Visible task status`). Existing buildStageAContext +
+  full mentor/stage suite (114 tests / 9 files) stay green; `tsc` + lint clean.
+- **At-scale (manual)**: reproduced tmux's limit cold (120KB arg → `command too
+  long`; 12KB passes), confirming the cap is safely below it.
+
+## Migration parity
+
+Server-internal monitoring code, not an agent-installed file — every agent gets
+the fix by running the new build. No PostUpdateMigrator entry required.

--- a/src/monitoring/MentorStageA.ts
+++ b/src/monitoring/MentorStageA.ts
@@ -167,6 +167,20 @@ export function buildStageAContext(surface: ConversationSurface): string {
   const agendaLines = hasAgenda
     ? surface.onboardingAgenda!.map((t) => `  - ${t}`).join('\n')
     : '';
+  // Bound the conversation history so the assembled Stage-A prompt can never
+  // exceed tmux's `new-session` command-line limit (~12-16KB). The prompt is
+  // passed as a command-line ARGUMENT to the spawned compose session, so an
+  // unbounded, ever-growing history eventually makes `tmux new-session` fail
+  // ("command too long") — the spawn throws and the whole tick reports
+  // stage-a-failed. (Root-caused live: the mentor worked early on, then broke as
+  // the mentor↔mentee history accumulated past the limit.) Keep the MOST-RECENT
+  // exchanges (what actually matters for deciding the next action) + a marker.
+  const MAX_HISTORY_CHARS = 6000;
+  const rawHistory = surface.threadlineHistory.trim() || '(no prior conversation)';
+  const boundedHistory =
+    rawHistory.length > MAX_HISTORY_CHARS
+      ? `[… ${rawHistory.length - MAX_HISTORY_CHARS} chars of older conversation elided to fit the spawn command-line limit; most-recent exchanges kept below …]\n${rawHistory.slice(-MAX_HISTORY_CHARS)}`
+      : rawHistory;
   return [
     `You are acting as the USER checking in on an AI developer ("${surface.framework}").`,
     `You can ONLY see what a real user would see — the conversation below and the visible task`,
@@ -187,7 +201,7 @@ export function buildStageAContext(surface: ConversationSurface): string {
       : []),
     ``,
     `--- Conversation so far ---`,
-    surface.threadlineHistory.trim() || '(no prior conversation)',
+    boundedHistory,
     ``,
     `--- Visible task status ---`,
     surface.assignedTaskStatus?.trim() || '(no task assigned yet)',

--- a/tests/unit/MentorStageA.test.ts
+++ b/tests/unit/MentorStageA.test.ts
@@ -58,6 +58,25 @@ describe('buildStageAContext — only the conversation surface', () => {
     expect(ctx).toContain('no prior conversation');
     expect(ctx).toContain('no task assigned yet');
   });
+
+  it('bounds a huge history so the prompt stays under tmux\'s command-line limit (keeps recent + marks elision)', () => {
+    // The Stage-A prompt is passed as a tmux new-session command-line argument
+    // (limit ~12-16KB). An unbounded growing history made `tmux new-session`
+    // fail ("command too long") → stage-a-failed. The bound keeps the recent
+    // tail and elides the older middle.
+    const RECENT_MARKER = 'Echo: MOST-RECENT-EXCHANGE-SENTINEL';
+    const huge = 'OLD '.repeat(20000) + `\n${RECENT_MARKER}\nCodey: ack`; // ~80KB history
+    const ctx = buildStageAContext({ framework: 'codex-cli', threadlineHistory: huge });
+    // Total prompt comfortably under the tmux limit (history capped at 6KB + small fixed parts).
+    expect(ctx.length).toBeLessThan(12_000);
+    // The most-recent exchange is preserved...
+    expect(ctx).toContain(RECENT_MARKER);
+    // ...older history is elided with an explicit marker (not silently dropped).
+    expect(ctx).toContain('older conversation elided');
+    // The prompt structure is intact.
+    expect(ctx).toContain('--- Conversation so far ---');
+    expect(ctx).toContain('--- Visible task status ---');
+  });
 });
 
 describe('detectStageALeak — the mandatory leakage detector (§4.3)', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,39 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Fixed the root cause of the Framework-Onboarding mentor's Stage-A failures: the
+compose prompt grew past tmux's command-line limit.** Stage-A spawns a session to
+compose the next coaching message, passing the prompt — which embeds the whole
+growing mentor↔mentee conversation — as a `tmux new-session` command-line
+argument. tmux has a command-length limit (~12-16KB); once the accumulated
+history crossed it, `tmux new-session` failed with "command too long", so the
+step failed and the mentee got nothing (it worked early on, then broke as history
+piled up). The conversation history fed into the Stage-A prompt is now bounded to
+the most-recent ~6KB (with an explicit "older conversation elided" marker), so the
+spawn stays under tmux's limit no matter how long the mentorship runs.
+
+## What to Tell Your User
+
+Only relevant if you run the (off-by-default) Framework-Onboarding mentor. Its
+Stage-A step is now reliable for long-running mentorships — the prompt can't grow
+past the limit that was making it fail. No behaviour change for short
+conversations.
+
+## Summary of New Capabilities
+
+- `buildStageAContext` bounds the conversation history at 6000 chars (keeps the
+  most-recent exchanges + a marker), keeping the Stage-A prompt under tmux's
+  command-line limit — fixes the `stage-a-failed` root cause.
+
+## Evidence
+
+- `tests/unit/MentorStageA.test.ts` (+1): an ~80KB history produces a prompt
+  under 12KB that keeps the most-recent exchange, carries the elision marker, and
+  preserves the prompt structure. Full mentor/stage suite (114 tests / 9 files)
+  green; `tsc` + `npm run lint` clean.
+- Cold tmux repro: a 120KB argument to `tmux new-session` fails with "command too
+  long"; 12KB passes — confirming the 6KB history cap is safely below the limit.
+- Side-effects: `upgrades/side-effects/mentor-stage-a-prompt-bound.md`.

--- a/upgrades/side-effects/mentor-stage-a-prompt-bound.md
+++ b/upgrades/side-effects/mentor-stage-a-prompt-bound.md
@@ -1,0 +1,55 @@
+# Side-effects review — Mentor Stage-A: bound the compose prompt
+
+**Spec:** `docs/specs/MENTOR-STAGE-A-PROMPT-BOUND-SPEC.md`
+**Change:** `src/monitoring/MentorStageA.ts` (`buildStageAContext`) + unit test
+**Class:** mentor reliability fix (root cause of `stage-a-failed`).
+
+## What changed
+
+`buildStageAContext` now caps `surface.threadlineHistory` at `MAX_HISTORY_CHARS =
+6000`, keeping the most-recent tail + an explicit `older conversation elided`
+marker, so the assembled Stage-A prompt can't exceed tmux's `new-session`
+command-line limit (~12-16KB) — the confirmed cause of the spawn failure.
+
+## Blast radius
+
+- **`buildStageAContext` callers:** only `runMentorTick` (Stage-A). The function
+  signature/output shape is unchanged (still returns the prompt string); only the
+  history portion is bounded when it exceeds 6000 chars.
+- **Mentor behaviour:** unchanged for short histories (the bound only engages
+  above 6000 chars). For long histories, the prompt now contains the recent
+  exchanges + a marker instead of the full transcript — the mentor still has the
+  agenda + recent state to decide the next action.
+- **Two-hats isolation / leak detection / agenda logic:** untouched.
+- **Public API / DB schema / config / other spawns:** none changed. Regular
+  (non-mentor) session spawns are unaffected (their prompts are small and were
+  never the growth vector).
+
+## What could break (and why it doesn't)
+
+- **Mentor lacks older context?** By design — the recent 6KB + agenda + status
+  carry the "what's next" decision; older middle history is least relevant.
+- **A single huge recent message?** The hard char cap bounds the history block
+  regardless of message boundaries.
+- **Leak detector seeing a truncated transcript?** It runs on the Stage-A
+  *output* transcript, not on this input prompt — unaffected.
+
+## Security
+
+No new external input / network / auth / fs surface. Pure in-memory string bound.
+
+## Migration parity
+
+Server-internal monitoring code — every agent gets it by running the new build.
+No PostUpdateMigrator entry required.
+
+## Rollback
+
+Revert the commit. No persisted state, schema, or API contract affected.
+
+## Tests
+
+`tests/unit/MentorStageA.test.ts` (+1): an ~80KB history → prompt < 12KB, keeps
+the most-recent exchange, carries the elision marker, preserves structure. Full
+mentor/stage suite (114 tests / 9 files) green; `tsc` + `npm run lint` clean.
+Cold tmux repro confirmed the limit (120KB → "command too long"; 12KB passes).


### PR DESCRIPTION
## Root cause (surfaced by #544's diagnosability fix)

The mentor Stage-A step composes the next coaching message by spawning a tool-less session whose **prompt is passed as a `tmux new-session` command-line argument**. The prompt (`buildStageAContext`) embeds `surface.threadlineHistory` — the **entire growing** mentor↔mentee conversation. tmux's `new-session` has a command-length limit (~12-16KB); once the accumulated history crosses it, `tmux new-session` fails with `"command too long"`, the spawn throws, and the tick reports `stage-a-failed`. This is exactly why the mentor worked at 16:03Z (short history) and broke later.

**Confirmed cold:** a 120KB arg to `tmux new-session` → `command too long`; 2–12KB pass, 16KB fails. PR #544's `lastResult.error` is what revealed it: `…Failed to create tmux session: …tmux new-session …claude …-p <the entire conversation>`.

## Fix

`buildStageAContext` now caps `threadlineHistory` at `MAX_HISTORY_CHARS = 6000`, keeping the **most-recent** exchanges (what matters for deciding the next action) + an explicit `older conversation elided` marker. The total prompt stays comfortably under tmux's limit (history ≤6KB + small fixed parts) regardless of how long the mentorship runs. Two-hats isolation, agenda behaviour, leak detection, and prompt structure are unchanged; the bound only engages above 6000 chars.

## Tests

`tests/unit/MentorStageA.test.ts` (+1): an ~80KB history → prompt **< 12KB** that preserves the most-recent exchange, carries the elision marker, and keeps the structure (`Conversation so far` / `Visible task status`). Full mentor/stage suite — **114 tests / 9 files** — green; `tsc --noEmit` + `npm run lint` clean.

Spec: `docs/specs/MENTOR-STAGE-A-PROMPT-BOUND-SPEC.md` (+ ELI16 + side-effects). The actual fix following #544 (which made this root cause visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)