### PR TITLE
fix(failure-learning): opt git reads into sourceTreeReadOk so loop works on dogfooding agents

### DIFF
--- a/src/monitoring/RevertDetector.ts
+++ b/src/monitoring/RevertDetector.ts
@@ -71,7 +71,18 @@ export class RevertDetector {
     this.ledger = opts.ledger;
     this.resolveByCommit = opts.resolveByCommit;
     this.cwd = opts.cwd;
-    this.git = opts.git ?? ((args) => SafeGitExecutor.readSync(args, { cwd: this.cwd, operation: 'failure-learning:revert-detect' }));
+    // sourceTreeReadOk: this detector legitimately reads git history from the
+    // instar source tree (the failure-learning loop's whole point is to find
+    // reverts in the agent's OWN repo). All verbs used here (`log`, `show`,
+    // `cat-file`) are in SOURCE_TREE_READ_TIER_VERBS. Without this opt-in,
+    // SourceTreeGuard blocks every tick on agents whose projectDir IS the
+    // instar checkout (notably Echo — surfaced 2026-05-29 by the silent-fail
+    // warnings in server-stderr.log).
+    this.git = opts.git ?? ((args) => SafeGitExecutor.readSync(args, {
+      cwd: this.cwd,
+      operation: 'failure-learning:revert-detect',
+      sourceTreeReadOk: true,
+          }));
     this.isLeaseHolder = opts.isLeaseHolder ?? (() => true);
     this.intervalMs = opts.intervalMs && opts.intervalMs > 0 ? opts.intervalMs : 6 * 60 * 60 * 1000;
     this.scanWindow = opts.scanWindow && opts.scanWindow > 0 ? opts.scanWindow : 100;

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -641,8 +641,14 @@ export class AgentServer {
           commitTouchedFiles: (oid) => {
             try {
               // Read-only git via the SafeGitExecutor funnel (lint-no-direct-destructive).
+              // sourceTreeReadOk: this attribution read legitimately runs against
+              // the instar source tree on dogfooding agents (Echo). `show` is in
+              // SOURCE_TREE_READ_TIER_VERBS — without the flag, SourceTreeGuard
+              // silently blocked every attribution lookup on Echo.
               const out = SafeGitExecutor.readSync(['show', '--name-only', '--pretty=format:', oid], {
-                cwd: projectDir, operation: 'failure-learning:commit-touched-files',
+                cwd: projectDir,
+                operation: 'failure-learning:commit-touched-files',
+                sourceTreeReadOk: true,
               });
               return out.split('\n').map((s) => s.trim()).filter(Boolean);
             } catch { return []; }
@@ -664,8 +670,16 @@ export class AgentServer {
             },
             resolveRepo: () => {
               try {
+                // sourceTreeReadOk: this resolver legitimately reads the agent's
+                // own remote URL on dogfooding agents whose checkout IS the
+                // instar source. `remote` is in SOURCE_TREE_READ_TIER_VERBS;
+                // without the flag, SourceTreeGuard silently blocked the
+                // resolver on Echo and the CI poller never knew which repo to
+                // poll.
                 const url = SafeGitExecutor.readSync(['remote', 'get-url', 'origin'], {
-                  cwd: projectDir, operation: 'failure-learning:ci-resolve-repo',
+                  cwd: projectDir,
+                  operation: 'failure-learning:ci-resolve-repo',
+                  sourceTreeReadOk: true,
                 }).trim();
                 const m = url.match(/github\.com[:/](.+?)(?:\.git)?$/);
                 return m ? m[1] : null; // validated by REPO_RE inside the poller

--- a/tests/integration/failure-learning-real-source-tree.test.ts
+++ b/tests/integration/failure-learning-real-source-tree.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Integration: RevertDetector's DEFAULT git invocation (no mock) succeeds when
+ * run against the actual instar source tree.
+ *
+ * The 2026-05-29 incident: Echo's RevertDetector was failing once per tick with
+ * `SourceTreeGuardError: Refusing to run failure-learning:revert-detect against
+ * the instar source tree`, but `/failures/analysis` still reported success
+ * because the failure was caught inside the detector and emitted as a `warn` to
+ * stderr. The existing unit tests entirely mocked the `git` injection point, so
+ * the SafeGitExecutor → SourceTreeGuard path was never exercised. This test
+ * closes that gap by exercising the default code path on the real source tree.
+ *
+ * The test is hermetic enough for Tier 2: it runs `git log --grep` against the
+ * test's own repo root (which IS the instar source). No tmpdir, no spawn, no
+ * HTTP; just verify the default invocation returns without throwing.
+ */
+
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { RevertDetector } from '../../src/monitoring/RevertDetector.js';
+import { FailureLedger } from '../../src/monitoring/FailureLedger.js';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+describe('RevertDetector against the real instar source tree', () => {
+  it('default SafeGitExecutor.readSync invocation does not throw SourceTreeGuardError on the source tree', () => {
+    // No `git` override: forces the default SafeGitExecutor.readSync path,
+    // which is the path that was silently failing on Echo before the fix.
+    const det = new RevertDetector({
+      ledger: { } as unknown as FailureLedger, // unused — we never reach ledger.upsert in this test
+      resolveByCommit: () => undefined,
+      cwd: REPO_ROOT,
+      // suppress console noise; we only care that no error reaches here
+      onError: () => undefined,
+      // make scan window small so the assertion runs fast
+      scanWindow: 1,
+    });
+
+    // We cannot easily reach the detector's private scan method without
+    // restructuring, but we CAN reach it by calling its public `start()` /
+    // `stop()`. Starting will perform the first scan synchronously enough
+    // that any SourceTreeGuardError thrown by the default git invocation
+    // would bubble up via the `onError` callback. We capture that.
+    const errors: unknown[] = [];
+    const det2 = new RevertDetector({
+      ledger: {
+        // FailureLedger stubs needed by the scan path:
+        listByCauseCommitOid: () => [],
+        upsert: () => ({ inserted: false } as never),
+        update: () => ({ ok: true } as never),
+      } as unknown as FailureLedger,
+      resolveByCommit: () => undefined,
+      cwd: REPO_ROOT,
+      onError: (err) => errors.push(err),
+      scanWindow: 5,
+    });
+
+    det2.start();
+    // start() schedules a tick — for the assertion to mean something we need
+    // to also trigger an immediate scan. The class exposes `start()` only,
+    // so we use `stop()` then call `start()` once more to be sure no error
+    // is queued. The point: the constructor + start sequence must not throw
+    // SourceTreeGuardError, and onError must not receive one.
+    det2.stop();
+
+    expect(errors.filter((e) => e instanceof Error && /SourceTreeGuardError|source tree/i.test((e as Error).message))).toEqual([]);
+
+    // Belt-and-suspenders: explicitly verify the default git invocation
+    // doesn't throw when invoked directly.
+    const safeGitInvocation = () => {
+      // Reach through to the default git function. It's stored on the
+      // instance under `git`, which is private; cast to any for the probe.
+      const fn = (det as unknown as { git: (args: readonly string[]) => string }).git;
+      // A read that exists on every git repo: HEAD commit subject.
+      return fn(['log', '-1', '--pretty=%s', 'HEAD']);
+    };
+    expect(safeGitInvocation, 'default git invocation against the instar source tree must not throw').not.toThrow();
+    const out = safeGitInvocation();
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/failure-learning-source-tree-readok-wiring.test.ts
+++ b/tests/unit/failure-learning-source-tree-readok-wiring.test.ts
@@ -1,0 +1,119 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup only.
+/**
+ * Wiring: every failure-learning git read against the agent's projectDir must
+ * carry `sourceTreeReadOk: true`. Without it, SourceTreeGuard silently blocks
+ * the read on dogfooding agents whose checkout IS the instar source tree
+ * (the Echo case surfaced 2026-05-29, where RevertDetector's every-poll
+ * `SourceTreeGuardError: Refusing to run failure-learning:revert-detect…`
+ * warning sat in server-stderr.log for hours while the loop's `/failures/*`
+ * API kept reporting "1 captured" — i.e. zero from CI/revert sources).
+ *
+ * Approach: static introspection. Each of the three canonical callsites
+ * (RevertDetector default, AgentServer commitTouchedFiles for the
+ * attribution engine, AgentServer resolveRepo for the CI poller) must
+ * include `sourceTreeReadOk: true` in its SafeGitExecutor.readSync options
+ * block. Static check is lightweight, runs every CI shard, and catches the
+ * regression class without spinning up a stub server.
+ *
+ * Why not runtime: a runtime test could inject a SafeGitExecutor mock and
+ * assert on its arguments, but mocks are how the existing tests masked this
+ * gap (they bypass SafeGitExecutor entirely). The static check pins the
+ * call-shape directly so future maintainers can't refactor it away by
+ * accident.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+/**
+ * Match: SafeGitExecutor.readSync( <args>, { … sourceTreeReadOk: true … } )
+ * — across multiple lines, with the option potentially anywhere in the opts
+ * object.
+ */
+function readSyncBlocksIn(file: string): Array<{ opsIdx: number; hasFlag: boolean; operation: string }> {
+  const src = fs.readFileSync(file, 'utf-8');
+  // Match SafeGitExecutor.readSync(…, { …opts… }) across multiple lines.
+  // Greedy across the args + opts. We scan with an iterative regex on
+  // `SafeGitExecutor.readSync(` and balance-count parens to find the call's
+  // end — robust to nested options.
+  const out: Array<{ opsIdx: number; hasFlag: boolean; operation: string }> = [];
+  const needle = 'SafeGitExecutor.readSync(';
+  let i = 0;
+  while ((i = src.indexOf(needle, i)) !== -1) {
+    const start = i + needle.length;
+    // Walk forward, counting parens; end when we close the readSync(...)
+    let depth = 1;
+    let j = start;
+    while (j < src.length && depth > 0) {
+      const c = src[j];
+      if (c === '(') depth++;
+      else if (c === ')') depth--;
+      j++;
+    }
+    const callText = src.slice(start, j - 1); // inner args, excluding the closing )
+    const hasFlag = /\bsourceTreeReadOk\s*:\s*true\b/.test(callText);
+    const opMatch = callText.match(/operation\s*:\s*['"]([^'"]+)['"]/);
+    out.push({
+      opsIdx: i,
+      hasFlag,
+      operation: opMatch ? opMatch[1] : '<no operation literal>',
+    });
+    i = j;
+  }
+  return out;
+}
+
+describe('Failure-learning sources: sourceTreeReadOk wiring', () => {
+  it('RevertDetector default git invocation passes sourceTreeReadOk: true', () => {
+    const file = path.join(REPO_ROOT, 'src/monitoring/RevertDetector.ts');
+    const calls = readSyncBlocksIn(file).filter(c => c.operation.startsWith('failure-learning:'));
+    expect(calls.length, 'expected ≥1 SafeGitExecutor.readSync call tagged failure-learning:*').toBeGreaterThan(0);
+    const bad = calls.filter(c => !c.hasFlag);
+    expect(
+      bad.map(c => c.operation),
+      'every failure-learning git read must include sourceTreeReadOk: true to work on dogfooding agents',
+    ).toEqual([]);
+  });
+
+  it('AgentServer attribution-engine commitTouchedFiles passes sourceTreeReadOk: true', () => {
+    const file = path.join(REPO_ROOT, 'src/server/AgentServer.ts');
+    const calls = readSyncBlocksIn(file)
+      .filter(c => c.operation === 'failure-learning:commit-touched-files');
+    expect(calls.length, 'expected the commit-touched-files readSync to exist').toBe(1);
+    expect(calls[0].hasFlag, 'commit-touched-files must carry sourceTreeReadOk: true').toBe(true);
+  });
+
+  it('AgentServer CI-poller resolveRepo passes sourceTreeReadOk: true', () => {
+    const file = path.join(REPO_ROOT, 'src/server/AgentServer.ts');
+    const calls = readSyncBlocksIn(file)
+      .filter(c => c.operation === 'failure-learning:ci-resolve-repo');
+    expect(calls.length, 'expected the ci-resolve-repo readSync to exist').toBe(1);
+    expect(calls[0].hasFlag, 'ci-resolve-repo must carry sourceTreeReadOk: true').toBe(true);
+  });
+
+  it('every failure-learning:* readSync in src/ carries the flag (catch-all)', () => {
+    // Catch-all: any future failure-learning readSync added without the flag
+    // surfaces here even if the per-callsite tests above haven't been updated
+    // to enumerate it.
+    const filesToCheck = [
+      path.join(REPO_ROOT, 'src/monitoring/RevertDetector.ts'),
+      path.join(REPO_ROOT, 'src/monitoring/CiFailurePoller.ts'),
+      path.join(REPO_ROOT, 'src/server/AgentServer.ts'),
+      path.join(REPO_ROOT, 'src/monitoring/FailureAttributionEngine.ts'),
+      path.join(REPO_ROOT, 'src/monitoring/FailureLedger.ts'),
+    ];
+    const offenders: Array<{ file: string; operation: string }> = [];
+    for (const f of filesToCheck) {
+      if (!fs.existsSync(f)) continue;
+      for (const c of readSyncBlocksIn(f)) {
+        if (c.operation.startsWith('failure-learning:') && !c.hasFlag) {
+          offenders.push({ file: path.relative(REPO_ROOT, f), operation: c.operation });
+        }
+      }
+    }
+    expect(offenders, 'failure-learning git reads without sourceTreeReadOk silently fail on dogfooding agents').toEqual([]);
+  });
+});

--- a/upgrades/NEXT.eli16.md
+++ b/upgrades/NEXT.eli16.md
@@ -2,81 +2,72 @@
 
 ## What this change is
 
-Your agent has a feature called the "Failure-Learning Loop" — it watches for
-things that go wrong (a CI run fails, a recent commit gets reverted, an
-internal health-check trips) and writes a little record so you can later ask
-"why do my agents keep breaking?" and get a real answer instead of vibes.
+There's a safety guard called SourceTreeGuard. Its job is to refuse any
+operation that would touch the instar source code from inside an agent
+that's running against that source code. The 2026-04-22 incident — an agent
+accidentally clobbering its own source tree — was the reason the guard
+shipped. It's saved us from a repeat several times.
 
-The loop has a config switch for each kind of failure it watches. Some of
-those switches were checked in months ago but never connected to anything —
-flipping them on did literally nothing, the loop just pretended the source
-was active. That's exactly the failure mode the post-mortem yesterday named
-as "specced but not wired" — a real, repeat offender.
+But the guard treats READ and WRITE the same: it refuses BOTH. That's
+overcautious — reading the git log of a repo is harmless. And the
+Failure-Learning Loop we just turned on yesterday needs to read git log
+to find reverts, and to read `git remote get-url` to know which GitHub
+repo to poll for CI failures. So on Echo (the canonical dogfooding agent,
+whose checkout IS the instar source), the loop has been silently failing
+once per detector tick for the past ~5 hours: a warning in stderr, no
+event in the ledger, no surfacing in the API.
 
-This change does two things:
-
-1. **Loud warning when you flip on a switch that isn't wired up.** If you set
-   `monitoring.failureLearning.sources.regression: true` or
-   `monitoring.failureLearning.sources.degradation: [...]`, the agent now
-   says, at startup: "you turned this on but nothing implements it yet —
-   set it back off until the impl ships." Before, those switches were silent
-   no-ops.
-
-2. **A new automated check that catches a different bug class.** When you do
-   a fresh `instar init`, certain hooks get installed. When the agent
-   auto-updates, a different bit of code re-installs hooks. We had at least
-   one case in the last release where the two lists disagreed — a fresh
-   agent was missing a hook that existing agents had, because nobody had
-   noticed the divergence. The new check reads both lists and refuses
-   to commit any change that creates a new divergence (with a small
-   allowlist for documented technical debt).
+There's already an escape hatch — `sourceTreeReadOk: true` — that other
+read-only callers (the worktree-manager, the canonical-ref reconciler)
+use. This PR plugs the Failure-Learning Loop's three read callsites into
+the same hatch. No changes to the guard itself.
 
 ## What already exists
 
-- The Failure-Learning Loop itself, with ledger + analyzer + API at `/failures/*`.
-- The `ci` and `revert` ingestion sources, which actually work and capture events.
-- The `regression` and `degradation` source flags in config defaults
-  (just no implementation behind them).
-- `PostUpdateMigrator` (the auto-update path) and `installHooks()`
-  (the fresh-init path), both of which write hooks to disk independently.
+- `SourceTreeGuard` (`src/core/SourceTreeGuard.ts`) — refuses operations
+  against the instar source tree.
+- `SafeGitExecutor` with `readSync` and `execSync` methods, plus
+  `sourceTreeReadOk` opt-in.
+- `SOURCE_TREE_READ_TIER_VERBS` — an allowlist of read-only verbs
+  (`log`, `show`, `remote`, `rev-parse`, …) that the opt-in legitimizes.
+- `RevertDetector`, `CiFailurePoller`, `FailureAttributionEngine` — the
+  three failure-learning components that read git.
 
 ## What's new
 
-- Boot-time warning if `regression` or `degradation` source flag is on but
-  unimplemented.
-- Unit test that pins the source-flag-to-poller wiring so future regressions
-  fail the test suite instead of silently disabling the loop.
-- Unit test that diffs the fresh-init hook list against the auto-update hook
-  list and fails on any new divergence.
-- A small allowlist of currently-accepted divergences (six entries, with
-  rationale per entry; soft cap of ten so the list can't quietly grow).
+- Three call sites updated to pass `sourceTreeReadOk: true`:
+  - RevertDetector's default git function
+  - AgentServer's `commitTouchedFiles` for the attribution engine
+  - AgentServer's `resolveRepo` for the CI poller
+- A unit test that scans the failure-learning code for any
+  `SafeGitExecutor.readSync` call missing the flag. Catches any future
+  new callsite that ships without the opt-in.
+- An integration test that runs the DEFAULT RevertDetector against the
+  real instar source tree (the existing tests entirely mocked git, which
+  is how this gap shipped silently).
 
 ## What you need to decide
 
-Nothing. This is structural backstop, no configuration involved. Existing
-agents pick up the warning on next process restart (auto-update will trigger
-that). Future PRs that try to introduce a new fresh-init-vs-auto-update gap
-will fail their tests.
+Nothing. Surgical fix, no config, no fleet migration. Existing agents
+pick it up on the next process restart from auto-update.
 
 ## How to verify it worked after deploy
 
-If you haven't touched `monitoring.failureLearning.sources` in your config,
-you should see exactly the same behavior. If you flipped one of the
-unimplemented sources on, you'll see a one-line warning at startup.
-
-To start actually USING the Failure-Learning Loop on your agent, set
-`monitoring.failureLearning.sources.ci: true` and `sources.revert: true`
-in `.instar/config.json`. The substrate has been ready since late April;
-this PR just adds the tests around it. Echo's local config is being flipped
-out-of-band as a dogfooding step.
+If you have `monitoring.failureLearning.sources.revert: true` (or
+`sources.ci: true`) set on an agent whose project directory is the
+instar source tree, check `logs/server-stderr.log` after the next
+restart. The recurring `[revert-detector] SourceTreeGuardError`
+warnings should stop. After a couple of detector ticks (the default is
+6 hours but you can lower it), `/failures/analysis` should start
+showing captured events with attribution.
 
 ## Why this matters more than it might look
 
-The 14-day fix-shape rate to main is around 19% — we've been shipping a lot
-of bugs and finding out from users instead of from instrumentation. The
-Failure-Learning Loop is the meta-trace that turns "we keep shipping bugs"
-into "here are the three patterns most of them share." But it was sitting
-unused because the ingestion sources were silent. This PR closes one half
-of that gap (the wiring-test + the unimplemented-source warning); flipping
-the working sources on for each agent closes the other half. Several more
-PRs from the same post-mortem will follow.
+The Failure-Learning Loop is the meta-trace we just deliberately enabled
+because we've been shipping bugs faster than we can learn from them. If
+that loop itself is silently broken on the canonical dogfooding agent,
+the whole "we'll start learning from our bugs" plan is theater. This is
+the post-mortem's lesson reflected back on itself: shipping ≠ working.
+And the catch — that the existing unit tests masked the bug because
+they entirely mocked the git layer — is precisely the
+"tested-on-mocks-not-real-state" pattern the post-mortem named.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,72 @@
+---
+review-convergence: complete
+approved: true
+approved-by: justin (verbal, topic 2169: "Please proceed as you best to see fit" — my judgment call to fix SourceTreeGuard's read-vs-write distinction first, since it blocks the failure-learning telemetry I just enabled)
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Failure-Learning Loop's git reads now work on dogfooding agents.**
+
+The 2026-05-29 pipeline post-mortem (PR #545) flipped on the `ci` and
+`revert` ingestion sources for Echo. The next ~hour of `server-stderr.log`
+filled with `[revert-detector] SourceTreeGuardError: Refusing to run
+failure-learning:revert-detect against the instar source tree` warnings,
+once per detector tick, while `/failures/analysis` kept reporting `total: 1`.
+The loop's whole point — capture CI failures + reverts so we can learn from
+them — was silently broken on the canonical dogfooding agent.
+
+Cause: `RevertDetector` (and the `CiFailurePoller`'s `resolveRepo`, and the
+`FailureAttributionEngine`'s `commitTouchedFiles`) call
+`SafeGitExecutor.readSync` to read `git log` / `git show` / `git remote
+get-url`. SourceTreeGuard refuses any operation against the agent's own
+checkout when that checkout IS the instar source tree — which is exactly the
+case for Echo. The guard exists for write protection (the 2026-04-22
+destructive-tool-target class), but it gates reads by default too. There's
+an existing, audited escape hatch — `SafeGitOptions.sourceTreeReadOk:
+true` — already used by the worktree-manager and the canonical-ref
+reconciler, scoped to the explicit `SOURCE_TREE_READ_TIER_VERBS` set
+(`log`, `show`, `cat-file`, `remote`, `rev-parse`, `ls-tree`, …).
+
+Fix: opt every failure-learning git read at every callsite into that
+escape hatch. No guard weakening; only the three loop callsites change.
+
+The existing RevertDetector + CiFailurePoller unit tests entirely mocked
+the `git` / `runGh` injection points, which is how the gap shipped silently
+in the first place. This PR adds a static-introspection unit test that
+pins the call shape, plus an integration test that exercises the DEFAULT
+git invocation against the actual instar source tree (the path the
+existing tests never touched).
+
+## What to Tell Your User
+
+Nothing visible unless you've also flipped on `monitoring.failureLearning.
+sources.ci: true` / `sources.revert: true` on an agent whose project
+directory IS the instar source tree. If you have, the
+`[revert-detector] SourceTreeGuardError` warnings in `server-stderr.log`
+will stop on the next process restart, and the failure-learning loop's
+revert + CI sources will start actually capturing events.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Failure-learning revert detection works on dogfooding agents | Automatic. RevertDetector's default git invocation now passes `sourceTreeReadOk: true`. |
+| Failure-learning CI poller resolves repo on dogfooding agents | Automatic. `resolveRepo` no longer trips SourceTreeGuard. |
+| Failure-learning attribution engine reads touched files on dogfooding agents | Automatic. `commitTouchedFiles` no longer trips SourceTreeGuard. |
+| Static-introspection guard against future failure-learning git reads missing the flag | Automatic (CI). A new unit test scans every `SafeGitExecutor.readSync` tagged `failure-learning:*` and fails if `sourceTreeReadOk: true` is missing. |
+
+## Evidence
+
+- 5 new tests (4 unit + 1 integration). Both new tests verified by
+  destructive-negative test (removing the flag from `RevertDetector` →
+  both tests fail as expected, with `SourceTreeGuardError` surfacing).
+- `tsc --noEmit` clean.
+- Side-effects review:
+  `upgrades/side-effects/failure-learning-source-tree-readok.md`.
+- Existing `RevertDetector.test.ts` (9 tests) and `CiFailurePoller.test.ts`
+  (12 tests) remain green.

--- a/upgrades/side-effects/failure-learning-source-tree-readok.md
+++ b/upgrades/side-effects/failure-learning-source-tree-readok.md
@@ -1,0 +1,113 @@
+# Side-effects review — Failure-Learning git reads opt into sourceTreeReadOk
+
+## What changed
+
+Three `SafeGitExecutor.readSync` call-sites used by the Failure-Learning Loop
+now pass `sourceTreeReadOk: true`:
+
+1. `src/monitoring/RevertDetector.ts` — default `git` injection (used when the
+   constructor caller doesn't supply an override).
+2. `src/server/AgentServer.ts` — the `FailureAttributionEngine`'s
+   `commitTouchedFiles` (uses `git show --name-only`).
+3. `src/server/AgentServer.ts` — the `CiFailurePoller`'s `resolveRepo` (uses
+   `git remote get-url origin`).
+
+All three verbs (`log`, `show`, `remote`) are already in
+`SOURCE_TREE_READ_TIER_VERBS`, so the flag legitimately opens the read on the
+instar source tree without weakening the destructive-write protection.
+
+## Why
+
+The 2026-05-29 pipeline post-mortem (PR #545) flipped the
+`monitoring.failureLearning.sources.ci: true` and `sources.revert: true`
+flags on Echo. Within an hour of the flip — and continuing for several hours
+after — `logs/server-stderr.log` filled with
+
+```
+[WARN] [revert-detector] SourceTreeGuardError: Refusing to run
+failure-learning:revert-detect against the instar source tree (requested
+dir: /Users/justin/.instar/agents/echo, resolved git root: /Users/justin/
+.instar/agents/echo).
+```
+
+once per detector tick (every ~5 min). `GET /failures/analysis` reported
+`total: 1` (the manually-diagnosed entry I posted that morning) because
+every actual CI/revert ingestion attempt was silently bouncing off the
+guard. The detector's `onError` callback logged a warn and then returned,
+so the ledger never saw the event.
+
+`SourceTreeGuard` exists to prevent destructive operations against the
+instar source tree (the 2026-04-22 incident class). The escape hatch
+`SafeGitOptions.sourceTreeReadOk: true` is the documented opt-in for
+legitimate read-tier calls against an agent's own checkout — already used
+by the worktree-manager and the canonical-ref reconciler. The
+Failure-Learning Loop's revert-detector and CI-poller are exactly the
+same shape: they read the agent's own repo to do their job. The fix is
+to opt them into the existing escape hatch, not to weaken the guard.
+
+The substrate (`SOURCE_TREE_READ_TIER_VERBS`, `sourceTreeReadOk`,
+`isSourceTreeCheckBypassed`) was already shipped — this PR just wires
+the failure-learning consumers into it.
+
+## Risk surface
+
+- **No new destructive-shape exposure.** `sourceTreeReadOk: true` only
+  bypasses the source-tree check for verbs in the explicit
+  `SOURCE_TREE_READ_TIER_VERBS` set. Destructive verbs still hit the
+  guard the same as before. `readSync` itself also fails-closed on any
+  non-read shape (via `isReadOnlyShape` + `READONLY_GIT_VERBS`) before
+  the source-tree check is even consulted.
+- **No fleet config change.** Default off agents see no behavior change.
+  Agents that have already opted in (only Echo today) start capturing
+  CI failures + reverts on the next process restart.
+- **Tests** — one unit (4 sub-tests, static introspection of the
+  call-shape across RevertDetector + AgentServer + the catch-all
+  failure-learning callsite scanner) and one integration (1 sub-test,
+  exercises the DEFAULT git invocation against the actual instar
+  source tree — the path the existing unit tests entirely mocked,
+  which is how the gap shipped silently in the first place). Both
+  positive- and negative-verified by removing the flag.
+
+## Bug surfaces eliminated
+
+- The failure-learning loop's `revert` source captures real reverts on
+  dogfooding agents (Echo).
+- The failure-learning loop's `ci` source can now resolve the GitHub
+  repo URL on dogfooding agents (it was silently returning `null` from
+  `resolveRepo` and skipping the entire poll).
+- Future failure-learning git reads added against the agent's source
+  tree must carry the flag — surfaced at commit time by the catch-all
+  test.
+
+## Migration footprint
+
+None. This is pure source-code wiring; no config schema change, no
+fleet migration required. Existing agents pick up the fix on next
+process restart (auto-update path).
+
+## Testing
+
+- Unit: `tests/unit/failure-learning-source-tree-readok-wiring.test.ts`
+  — 4 tests. Per-callsite positive checks + catch-all that scans the
+  failure-learning surface. Verified positive + destructive-negative
+  (removing the flag from RevertDetector → catch-all test fails as
+  expected).
+- Integration: `tests/integration/failure-learning-real-source-tree.test.ts`
+  — 1 test. Constructs RevertDetector with NO git override (forces the
+  default SafeGitExecutor.readSync path), points `cwd` at the test's own
+  repo root (which IS the instar source on every CI shard), asserts the
+  default invocation does not throw SourceTreeGuardError and returns a
+  real commit-subject string. Verified negative — removing the flag
+  makes the test fail with `SourceTreeGuardError`.
+
+## Follow-ups
+
+- Meta lesson: the existing RevertDetector + CiFailurePoller unit tests
+  mock `git`/`runGh` entirely, which is how this gap shipped silently.
+  This is an instance of post-mortem pattern #1 ("tested on fresh state,
+  not real-world state"). Post-mortem lever B (real-world-state fixture
+  test class) closes the broader pattern; until then, the catch-all
+  static-introspection test pins this specific class.
+- Echo's accumulated `[revert-detector] SourceTreeGuardError` warnings
+  in `server-stderr.log` will stop appearing after the v1.3.109+
+  auto-update lands.


### PR DESCRIPTION
## Summary

Surgical fix for the issue I surfaced to Justin while verifying PR #545:
the Failure-Learning Loop's `revert` and `ci` sources were silently
failing on Echo (and every other dogfooding agent whose checkout IS the
instar source tree) because `SafeGitExecutor.readSync` callsites were
missing the `sourceTreeReadOk: true` opt-in.

Three callsites updated:
- `RevertDetector` default git invocation (uses `log` / `show` / `cat-file`)
- `AgentServer` attribution-engine `commitTouchedFiles` (uses `show --name-only`)
- `AgentServer` CI poller `resolveRepo` (uses `remote get-url`)

All three verbs are in the existing `SOURCE_TREE_READ_TIER_VERBS` allowlist, so the opt-in legitimately opens the read without weakening the destructive-write protection. No SourceTreeGuard change; no SafeGitExecutor change; no fleet migration.

## Why this matters

The whole post-mortem premise — "let's start learning from our bugs" — needs the loop to actually capture events. With this fix, Echo's revert detection works within 5 min of restart; its CI poller can resolve the GitHub repo and start ingesting failed runs within the 6h poll window.

Bonus meta lesson: the existing RevertDetector + CiFailurePoller unit tests entirely mocked the `git` / `runGh` injection points, which is how the gap shipped silently. This PR adds the missing integration test that exercises the DEFAULT git invocation against the actual source tree. Closes the immediate pattern; lever B from the post-mortem closes the broader "tested on mocks, not real state" class.

## What changed

- `src/monitoring/RevertDetector.ts` — default git invocation passes `sourceTreeReadOk: true`.
- `src/server/AgentServer.ts` — `commitTouchedFiles` and `resolveRepo` both updated.

## Tests

- `tests/unit/failure-learning-source-tree-readok-wiring.test.ts` (4 tests) — static introspection per-callsite + catch-all scanner.
- `tests/integration/failure-learning-real-source-tree.test.ts` (1 test) — DEFAULT RevertDetector against the real source tree.

Both positive-verified (current PR) and destructive-negative-verified (removing the flag → both tests fail). Existing RevertDetector + CiFailurePoller suites still green.

## Test plan

- [x] vitest run on the two new files — 5/5 green.
- [x] RevertDetector + CiFailurePoller existing suites — 21/21 green (no regression).
- [x] tsc --noEmit clean.
- [x] Destructive-negative confirms both new tests catch flag removal.
- [ ] CI green (await GitHub Actions).
- [ ] Post-deploy verification: server-stderr.log on Echo stops showing `[revert-detector] SourceTreeGuardError`; `/failures/analysis` starts showing captures attributable to merge commits.

Generated with Claude Code.
