### PR TITLE
fix(safety): dangerous-command-guard refuses gh pr merge on non-passing checks

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3984,6 +3984,54 @@ for pattern in "rm -rf \\." "git push --force" "git push -f" "git reset --hard" 
     fi
   fi
 done
+
+# 'gh pr merge' watch-exit-merge gate — closes the PR #539 class.
+# 'gh run watch' returns 0 on workflow COMPLETION regardless of conclusion;
+# branch-protection checks can still be RED. Refuse 'gh pr merge' if any
+# check is non-pass. '--auto' is the documented safe path; let it through.
+if echo "\$INPUT" | grep -qiE '(^|[;&|(\\s])gh +pr +merge( |\$|--)'; then
+  if echo "\$INPUT" | grep -qE '(^| )--auto( |\$)'; then
+    : # --auto is the safe async gate; allow.
+  else
+    PR_NUM=\$(echo "\$INPUT" | grep -oE 'gh +pr +merge[ +-]+[0-9]+' | grep -oE '[0-9]+' | head -1)
+    if [ -z "\$PR_NUM" ]; then
+      PR_NUM=\$(gh pr view --json number -q .number 2>/dev/null)
+    fi
+    if [ -n "\$PR_NUM" ]; then
+      CHECKS_JSON=\$(gh pr checks "\$PR_NUM" --json name,state 2>/dev/null)
+      if [ -n "\$CHECKS_JSON" ]; then
+        NON_OK=\$(echo "\$CHECKS_JSON" | python3 -c "
+import sys, json
+try:
+    rows = json.loads(sys.stdin.read())
+    if isinstance(rows, list):
+        bad = [r.get('name','?') + '=' + str(r.get('state','?')) for r in rows
+               if str(r.get('state','')).upper() not in ('SUCCESS','SKIPPED','SKIPPING','NEUTRAL','')]
+        print(','.join(bad))
+except Exception:
+    pass
+" 2>/dev/null)
+        if [ -n "\$NON_OK" ]; then
+          echo "BLOCKED: PR #\$PR_NUM has non-passing checks: \$NON_OK" >&2
+          echo "" >&2
+          echo "'gh pr merge' must not run while any check is failing, pending, or queued." >&2
+          echo "Closes the 2026-05-27 #539 watch-exit-merge class — 'gh run watch' returns 0" >&2
+          echo "on workflow completion regardless of conclusion, which caused a fix-forward" >&2
+          echo "(#540) + a fleet outage when #539 was merged on a red unit-test shard." >&2
+          echo "" >&2
+          echo "Options:" >&2
+          echo "  1) Wait. Re-check with: gh pr checks \$PR_NUM" >&2
+          echo "  2) Use 'gh pr merge --auto' — async gate that ONLY fires when all" >&2
+          echo "     checks pass. Documented safe path." >&2
+          echo "  3) If a non-passing check is an intentional skip (e.g. Contract Tests" >&2
+          echo "     on non-tagged PRs), it appears as SKIPPED / SKIPPING in" >&2
+          echo "     'gh pr checks --json state' output and the gate already allows it." >&2
+          exit 2
+        fi
+      fi
+    fi
+  fi
+fi
 `, { mode: 0o755 });
 
   // Grounding before messaging — full pipeline with convergence check.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -5500,6 +5500,61 @@ for pattern in "rm -rf \\." "git push --force" "git push -f" "git reset --hard" 
     fi
   fi
 done
+
+# 'gh pr merge' watch-exit-merge gate — closes the PR #539 class.
+# Justin merged #539 on 'gh run watch' exit code (= success), but 'watch'
+# returns 0 on workflow COMPLETION regardless of conclusion; meanwhile the
+# PR's branch-protection checks were RED. Cost a fix-forward (#540) + a
+# fleet outage. The rule: 'gh pr merge' must NEVER fire if any PR-event
+# check is non-pass. This guard runs 'gh pr checks <num>' and refuses on
+# any failure / pending / queued check.
+#
+# 'gh pr merge --auto' is the documented safe path (only fires when
+# checks pass) — let it through. Other flags (--admin, no flag) get
+# verified against the live check state.
+if echo "$INPUT" | grep -qiE '(^|[;&|(\\s])gh +pr +merge( |\$|--)'; then
+  if echo "$INPUT" | grep -qE '(^| )--auto( |$)'; then
+    : # --auto is the safe async gate; allow.
+  else
+    PR_NUM=$(echo "$INPUT" | grep -oE 'gh +pr +merge[ +-]+[0-9]+' | grep -oE '[0-9]+' | head -1)
+    if [ -z "$PR_NUM" ]; then
+      PR_NUM=$(gh pr view --json number -q .number 2>/dev/null)
+    fi
+    if [ -n "$PR_NUM" ]; then
+      CHECKS_JSON=$(gh pr checks "$PR_NUM" --json name,state 2>/dev/null)
+      if [ -n "$CHECKS_JSON" ]; then
+        NON_OK=$(echo "$CHECKS_JSON" | python3 -c "
+import sys, json
+try:
+    rows = json.loads(sys.stdin.read())
+    if isinstance(rows, list):
+        bad = [r.get('name','?') + '=' + str(r.get('state','?')) for r in rows
+               if str(r.get('state','')).upper() not in ('SUCCESS','SKIPPED','SKIPPING','NEUTRAL','')]
+        print(','.join(bad))
+except Exception:
+    pass
+" 2>/dev/null)
+        if [ -n "$NON_OK" ]; then
+          echo "BLOCKED: PR #$PR_NUM has non-passing checks: $NON_OK" >&2
+          echo "" >&2
+          echo "'gh pr merge' must not run while any check is failing, pending, or queued." >&2
+          echo "Closes the 2026-05-27 #539 watch-exit-merge class — 'gh run watch' returns 0" >&2
+          echo "on workflow completion regardless of conclusion, which caused a fix-forward" >&2
+          echo "(#540) + a fleet outage when #539 was merged on a red unit-test shard." >&2
+          echo "" >&2
+          echo "Options:" >&2
+          echo "  1) Wait. Re-check with: gh pr checks $PR_NUM" >&2
+          echo "  2) Use 'gh pr merge --auto' — async gate that ONLY fires when all" >&2
+          echo "     checks pass. Documented safe path." >&2
+          echo "  3) If a non-passing check is an intentional skip (e.g. Contract Tests" >&2
+          echo "     on non-tagged PRs), it appears as SKIPPED / SKIPPING in" >&2
+          echo "     'gh pr checks --json state' output and the gate already allows it." >&2
+          exit 2
+        fi
+      fi
+    fi
+  fi
+fi
 `;
   }
 

--- a/tests/unit/dangerous-command-guard-gh-pr-merge-gate.test.ts
+++ b/tests/unit/dangerous-command-guard-gh-pr-merge-gate.test.ts
@@ -1,0 +1,212 @@
+// safe-git-allow: test file — fs.rmSync is per-test tmpdir cleanup only.
+/**
+ * Wiring: the `dangerous-command-guard.sh` hook refuses `gh pr merge` when
+ * any PR check is non-passing. Closes the 2026-05-27 PR #539
+ * watch-exit-merge class (`gh run watch` returns 0 on workflow completion
+ * regardless of conclusion, so a `watch && gh pr merge` chain merged a
+ * branch with red unit-test shards — cost a fix-forward + a fleet outage).
+ *
+ * Tests cover:
+ *   1. Guard content (both `installHooks` inline copy in init.ts AND
+ *      `PostUpdateMigrator.getDangerousCommandGuard()`) carries the new
+ *      gate block.
+ *   2. Behavioral: spawn the actual rendered guard script with a mocked
+ *      `gh` binary on PATH; verify the gate blocks when checks are red,
+ *      allows when checks are green, allows `--auto`, allows when the
+ *      command is something other than `gh pr merge`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+function renderMigratorGuard(): string {
+  const m = new PostUpdateMigrator({
+    stateDir: '/tmp/no-state',
+    projectDir: '/tmp/no-proj',
+    port: 4042,
+    sessions: { claudePath: 'claude' },
+  } as never);
+  return (m as unknown as { getDangerousCommandGuard(): string }).getDangerousCommandGuard();
+}
+
+function readInitGuard(): string {
+  // The dangerous-command-guard content is inlined in src/commands/init.ts.
+  // Extract the template-literal body between the writeFileSync open and
+  // the closing backtick + `, { mode: 0o755 });`.
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'src/commands/init.ts'), 'utf-8');
+  const open = src.indexOf("'dangerous-command-guard.sh'");
+  const start = src.indexOf('`#!/bin/bash', open);
+  const end = src.indexOf('`, { mode: 0o755 });', start);
+  return src.slice(start + 1, end);
+}
+
+describe('dangerous-command-guard.sh: gh pr merge gate is present in both writers', () => {
+  it('PostUpdateMigrator.getDangerousCommandGuard contains the gh pr merge gate', () => {
+    const guard = renderMigratorGuard();
+    expect(guard).toMatch(/gh \+pr \+merge/);
+    expect(guard).toContain('--auto');
+    expect(guard).toContain('watch-exit-merge');
+    expect(guard).toContain('gh pr checks');
+  });
+
+  it('init.ts installHooks inline copy contains the gh pr merge gate', () => {
+    const guard = readInitGuard();
+    expect(guard).toMatch(/gh \+pr \+merge/);
+    expect(guard).toContain('--auto');
+    expect(guard).toContain('watch-exit-merge');
+  });
+});
+
+// ── Behavioral: run the rendered hook with a mocked gh on PATH ─────────
+
+let tmpDir: string;
+let guardPath: string;
+let mockGhDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-pr-merge-gate-'));
+  guardPath = path.join(tmpDir, 'guard.sh');
+  fs.writeFileSync(guardPath, renderMigratorGuard(), { mode: 0o755 });
+  mockGhDir = path.join(tmpDir, 'bin');
+  fs.mkdirSync(mockGhDir);
+});
+
+afterEach(() => {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* test cleanup */ } // safe-fs-allow
+});
+
+/**
+ * Drop a fake `gh` binary on PATH that emits `out` for any `gh pr checks` call
+ * and `viewPr` for any `gh pr view` call.
+ */
+function installMockGh({ checks, prNum }: { checks: Array<{ name: string; state: string }>; prNum?: number }): void {
+  const checksJson = JSON.stringify(checks);
+  const viewJson = String(prNum ?? '');
+  const ghScript = [
+    '#!/bin/bash',
+    'case "$1 $2" in',
+    '  "pr checks")',
+    `    cat <<'JSON'`,
+    checksJson,
+    `JSON`,
+    '    ;;',
+    '  "pr view")',
+    `    printf '%s' '${viewJson}'`,
+    '    ;;',
+    '  *)',
+    '    exit 0',
+    '    ;;',
+    'esac',
+  ].join('\n');
+  fs.writeFileSync(path.join(mockGhDir, 'gh'), ghScript, { mode: 0o755 });
+}
+
+function runGuard(command: string): { stdout: string; stderr: string; code: number | null } {
+  const env = {
+    ...process.env,
+    PATH: `${mockGhDir}:${process.env.PATH}`,
+    CLAUDE_PROJECT_DIR: tmpDir,
+  };
+  const res = spawnSync('bash', [guardPath, command], { env, encoding: 'utf-8', timeout: 5000 });
+  return { stdout: res.stdout ?? '', stderr: res.stderr ?? '', code: res.status };
+}
+
+describe('dangerous-command-guard.sh: gh pr merge runtime behavior', () => {
+  it('BLOCKS when a check is in FAILURE state', () => {
+    installMockGh({
+      checks: [{ name: 'Unit Tests (node 20, shard 1/4)', state: 'FAILURE' }, { name: 'verify', state: 'SUCCESS' }],
+      prNum: 999,
+    });
+    const r = runGuard('gh pr merge 999 --squash');
+    expect(r.code, `expected exit 2 (BLOCKED), got code=${r.code} stderr=${r.stderr}`).toBe(2);
+    expect(r.stderr).toContain('non-passing checks');
+    expect(r.stderr).toContain('FAILURE');
+  });
+
+  it('BLOCKS when a check is still PENDING', () => {
+    installMockGh({
+      checks: [{ name: 'Unit Tests', state: 'PENDING' }, { name: 'Build', state: 'SUCCESS' }],
+      prNum: 999,
+    });
+    const r = runGuard('gh pr merge 999 --squash');
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('PENDING');
+  });
+
+  it('ALLOWS when every check is SUCCESS', () => {
+    installMockGh({
+      checks: [
+        { name: 'Unit Tests', state: 'SUCCESS' },
+        { name: 'verify', state: 'SUCCESS' },
+        { name: 'Build', state: 'SUCCESS' },
+      ],
+      prNum: 999,
+    });
+    const r = runGuard('gh pr merge 999 --squash');
+    expect(r.code, `expected exit 0 (ALLOWED), got code=${r.code} stderr=${r.stderr}`).toBe(0);
+    expect(r.stderr).not.toContain('non-passing');
+  });
+
+  it('ALLOWS when SKIPPED / SKIPPING checks are present alongside SUCCESS', () => {
+    installMockGh({
+      checks: [
+        { name: 'Unit Tests', state: 'SUCCESS' },
+        { name: 'Contract Tests (Live API)', state: 'SKIPPING' },
+        { name: 'verify', state: 'SUCCESS' },
+      ],
+      prNum: 999,
+    });
+    const r = runGuard('gh pr merge 999 --squash');
+    expect(r.code).toBe(0);
+  });
+
+  it('ALLOWS gh pr merge --auto (the safe async gate)', () => {
+    installMockGh({
+      // checks are intentionally red — the gate should NOT consult them
+      // when --auto is passed.
+      checks: [{ name: 'Unit Tests', state: 'FAILURE' }],
+      prNum: 999,
+    });
+    const r = runGuard('gh pr merge 999 --auto --squash');
+    expect(r.code, `expected exit 0 when --auto is passed, got code=${r.code} stderr=${r.stderr}`).toBe(0);
+  });
+
+  it('IGNORES commands that are not gh pr merge', () => {
+    installMockGh({ checks: [{ name: 'Unit Tests', state: 'FAILURE' }], prNum: 999 });
+    const safeCommands = [
+      'gh pr view 999',
+      'gh pr checks 999',
+      'ls -la',
+      'echo "gh pr merge in a string literal that should not trigger"',
+    ];
+    for (const c of safeCommands) {
+      const r = runGuard(c);
+      expect(r.code, `expected exit 0 for safe command ${JSON.stringify(c)} (got ${r.code} / ${r.stderr})`).toBe(0);
+    }
+  });
+
+  it('BLOCKS gh pr merge with --admin when checks are red (the #539 incident shape)', () => {
+    installMockGh({
+      checks: [{ name: 'Unit Tests', state: 'FAILURE' }],
+      prNum: 539,
+    });
+    const r = runGuard('gh pr merge 539 --admin --squash');
+    expect(r.code, '--admin must not bypass the gate when checks are red').toBe(2);
+  });
+
+  it('BLOCKS when invoked without a PR number, using current-branch PR resolution', () => {
+    installMockGh({
+      checks: [{ name: 'Unit Tests', state: 'FAILURE' }],
+      prNum: 42, // gh pr view returns 42 as current PR
+    });
+    const r = runGuard('gh pr merge --squash');
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('PR #42');
+  });
+});

--- a/upgrades/NEXT.eli16.md
+++ b/upgrades/NEXT.eli16.md
@@ -2,72 +2,67 @@
 
 ## What this change is
 
-There's a safety guard called SourceTreeGuard. Its job is to refuse any
-operation that would touch the instar source code from inside an agent
-that's running against that source code. The 2026-04-22 incident — an agent
-accidentally clobbering its own source tree — was the reason the guard
-shipped. It's saved us from a repeat several times.
+Yesterday Justin merged a pull request (PR #539) on the back of a
+GitHub CLI command exit code that looked successful. The catch: that
+command (`gh run watch`) returns "success" when the workflow is FINISHED,
+regardless of whether the tests passed or failed. The workflow had
+finished with red unit-test shards. The merge went through anyway. We
+spent the next 16 hours dealing with the resulting fleet outage and
+shipped a follow-up PR (#540) to fix the damage.
 
-But the guard treats READ and WRITE the same: it refuses BOTH. That's
-overcautious — reading the git log of a repo is harmless. And the
-Failure-Learning Loop we just turned on yesterday needs to read git log
-to find reverts, and to read `git remote get-url` to know which GitHub
-repo to poll for CI failures. So on Echo (the canonical dogfooding agent,
-whose checkout IS the instar source), the loop has been silently failing
-once per detector tick for the past ~5 hours: a warning in stderr, no
-event in the ledger, no surfacing in the API.
+We wrote a memory note afterward saying "don't merge on watch exit;
+verify with `gh pr checks` first." That's a willpower fix — it works
+until the next time someone forgets, which will happen.
 
-There's already an escape hatch — `sourceTreeReadOk: true` — that other
-read-only callers (the worktree-manager, the canonical-ref reconciler)
-use. This PR plugs the Failure-Learning Loop's three read callsites into
-the same hatch. No changes to the guard itself.
+This PR replaces the willpower fix with a structural one: the agent's
+dangerous-command-guard hook now intercepts any `gh pr merge` command,
+queries the PR's check status via `gh pr checks`, and refuses to run
+the merge if anything is failing or pending. The agent literally
+cannot run a bad merge command from the Bash tool — the hook blocks
+it.
 
 ## What already exists
 
-- `SourceTreeGuard` (`src/core/SourceTreeGuard.ts`) — refuses operations
-  against the instar source tree.
-- `SafeGitExecutor` with `readSync` and `execSync` methods, plus
-  `sourceTreeReadOk` opt-in.
-- `SOURCE_TREE_READ_TIER_VERBS` — an allowlist of read-only verbs
-  (`log`, `show`, `remote`, `rev-parse`, …) that the opt-in legitimizes.
-- `RevertDetector`, `CiFailurePoller`, `FailureAttributionEngine` — the
-  three failure-learning components that read git.
+- `dangerous-command-guard.sh` — a PreToolUse hook on Bash that already
+  refuses catastrophic commands (`rm -rf /`, `mkfs.`, etc.) and risky
+  commands (`git push --force`, etc.) under safety.level 1.
+- `gh pr checks` — the CLI command that returns the live state of all
+  branch-protection checks on a PR.
 
 ## What's new
 
-- Three call sites updated to pass `sourceTreeReadOk: true`:
-  - RevertDetector's default git function
-  - AgentServer's `commitTouchedFiles` for the attribution engine
-  - AgentServer's `resolveRepo` for the CI poller
-- A unit test that scans the failure-learning code for any
-  `SafeGitExecutor.readSync` call missing the flag. Catches any future
-  new callsite that ships without the opt-in.
-- An integration test that runs the DEFAULT RevertDetector against the
-  real instar source tree (the existing tests entirely mocked git, which
-  is how this gap shipped silently).
+- A new block in `dangerous-command-guard.sh` that fires when
+  `gh pr merge` is detected at a command boundary.
+- The block calls `gh pr checks <num> --json name,state` and refuses
+  the merge if any state is `FAILURE`, `PENDING`, `QUEUED`, or similar.
+- `SUCCESS`, `SKIPPED`, and `SKIPPING` are explicitly OK — those are
+  the intentional pass / intentional-skip states.
+- `gh pr merge --auto` (the documented async safe path) is allowed
+  through unchanged. That command only fires when checks pass; it's
+  the right way to do an "I'm done, merge when ready" workflow.
+- 10 unit tests, including realistic scenarios — the actual hook is
+  spawned with a mocked `gh` binary on PATH so the behavior is
+  end-to-end tested, not just static-analyzed.
 
 ## What you need to decide
 
-Nothing. Surgical fix, no config, no fleet migration. Existing agents
-pick it up on the next process restart from auto-update.
+Nothing. Pure structural enforcement. Existing agents get the new gate
+on the next auto-update tick (every ~30 min).
 
 ## How to verify it worked after deploy
 
-If you have `monitoring.failureLearning.sources.revert: true` (or
-`sources.ci: true`) set on an agent whose project directory is the
-instar source tree, check `logs/server-stderr.log` after the next
-restart. The recurring `[revert-detector] SourceTreeGuardError`
-warnings should stop. After a couple of detector ticks (the default is
-6 hours but you can lower it), `/failures/analysis` should start
-showing captured events with attribution.
+In Bash, try to invoke `gh pr merge <num>` against a PR that has any
+pending or failing check. The agent will see a BLOCKED message in
+stderr with the list of non-passing checks. Try the same command with
+`--auto` appended — it goes through cleanly (because `--auto` is the
+documented safe path).
 
 ## Why this matters more than it might look
 
-The Failure-Learning Loop is the meta-trace we just deliberately enabled
-because we've been shipping bugs faster than we can learn from them. If
-that loop itself is silently broken on the canonical dogfooding agent,
-the whole "we'll start learning from our bugs" plan is theater. This is
-the post-mortem's lesson reflected back on itself: shipping ≠ working.
-And the catch — that the existing unit tests masked the bug because
-they entirely mocked the git layer — is precisely the
-"tested-on-mocks-not-real-state" pattern the post-mortem named.
+This is the third post-mortem fix landing today (after #545 and #550).
+Each one closes a class — not just one incident. The PR #539 class is
+arguably the most embarrassing of the three, because the human
+component of the loop (the agent or a human picking the merge command)
+had been advised to verify checks first and didn't — willpower failed.
+Structural enforcement closes that loop. The agent will not be ABLE
+to merge a red PR from Bash, even on autopilot, even with `--admin`.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,7 +1,7 @@
 ---
 review-convergence: complete
 approved: true
-approved-by: justin (verbal, topic 2169: "Please proceed as you best to see fit" — my judgment call to fix SourceTreeGuard's read-vs-write distinction first, since it blocks the failure-learning telemetry I just enabled)
+approved-by: justin (verbal, topic 2169: "Please proceed as you best to see fit" — my judgment-call to ship lever E next per the post-mortem ordering I proposed)
 ---
 
 # Upgrade Guide — vNEXT
@@ -10,63 +10,53 @@ approved-by: justin (verbal, topic 2169: "Please proceed as you best to see fit"
 
 ## What Changed
 
-**Failure-Learning Loop's git reads now work on dogfooding agents.**
+**Pipeline post-mortem lever E: `dangerous-command-guard.sh` now refuses
+`gh pr merge` when any PR check is non-passing.**
 
-The 2026-05-29 pipeline post-mortem (PR #545) flipped on the `ci` and
-`revert` ingestion sources for Echo. The next ~hour of `server-stderr.log`
-filled with `[revert-detector] SourceTreeGuardError: Refusing to run
-failure-learning:revert-detect against the instar source tree` warnings,
-once per detector tick, while `/failures/analysis` kept reporting `total: 1`.
-The loop's whole point — capture CI failures + reverts so we can learn from
-them — was silently broken on the canonical dogfooding agent.
+Closes the 2026-05-27 PR #539 watch-exit-merge class — `gh run watch`
+returns exit 0 on workflow completion regardless of conclusion, which
+caused PR #539 to merge with red unit-test shards (cost a fix-forward
+#540 + a ~16h fleet outage on instar-codey when the ABI-heal regression
+hit production). The memory entry afterward
+(`[feedback_never_merge_on_watch_exit_verify_checks]`) tried to prevent
+recurrence via convention; this PR replaces that convention with a
+structural gate.
 
-Cause: `RevertDetector` (and the `CiFailurePoller`'s `resolveRepo`, and the
-`FailureAttributionEngine`'s `commitTouchedFiles`) call
-`SafeGitExecutor.readSync` to read `git log` / `git show` / `git remote
-get-url`. SourceTreeGuard refuses any operation against the agent's own
-checkout when that checkout IS the instar source tree — which is exactly the
-case for Echo. The guard exists for write protection (the 2026-04-22
-destructive-tool-target class), but it gates reads by default too. There's
-an existing, audited escape hatch — `SafeGitOptions.sourceTreeReadOk:
-true` — already used by the worktree-manager and the canonical-ref
-reconciler, scoped to the explicit `SOURCE_TREE_READ_TIER_VERBS` set
-(`log`, `show`, `cat-file`, `remote`, `rev-parse`, `ls-tree`, …).
+The gate runs `gh pr checks <PR> --json name,state` before allowing the
+merge and refuses if any check is in `FAILURE`, `PENDING`, `QUEUED`, or
+similar non-passing state. `SKIPPED` / `SKIPPING` (e.g. Contract Tests
+on non-tagged PRs) are explicitly OK. `gh pr merge --auto` — the
+documented async safe path — is allowed through unchanged.
 
-Fix: opt every failure-learning git read at every callsite into that
-escape hatch. No guard weakening; only the three loop callsites change.
-
-The existing RevertDetector + CiFailurePoller unit tests entirely mocked
-the `git` / `runGh` injection points, which is how the gap shipped silently
-in the first place. This PR adds a static-introspection unit test that
-pins the call shape, plus an integration test that exercises the DEFAULT
-git invocation against the actual instar source tree (the path the
-existing tests never touched).
+Pattern matching is bounded to command-start boundaries so commands that
+merely mention `gh pr merge` in a string literal (`echo "fix gh pr merge
+bug"`) do not trigger.
 
 ## What to Tell Your User
 
-Nothing visible unless you've also flipped on `monitoring.failureLearning.
-sources.ci: true` / `sources.revert: true` on an agent whose project
-directory IS the instar source tree. If you have, the
-`[revert-detector] SourceTreeGuardError` warnings in `server-stderr.log`
-will stop on the next process restart, and the failure-learning loop's
-revert + CI sources will start actually capturing events.
+Nothing visible in normal operation. The agent now refuses to merge a PR
+while any CI check is failing or pending — even with `--admin`. If you
+want async-merge behavior (auto-fire when all checks pass), use
+`gh pr merge --auto` and the gate will allow it through.
 
 ## Summary of New Capabilities
 
 | Capability | How to Use |
 |-----------|-----------|
-| Failure-learning revert detection works on dogfooding agents | Automatic. RevertDetector's default git invocation now passes `sourceTreeReadOk: true`. |
-| Failure-learning CI poller resolves repo on dogfooding agents | Automatic. `resolveRepo` no longer trips SourceTreeGuard. |
-| Failure-learning attribution engine reads touched files on dogfooding agents | Automatic. `commitTouchedFiles` no longer trips SourceTreeGuard. |
-| Static-introspection guard against future failure-learning git reads missing the flag | Automatic (CI). A new unit test scans every `SafeGitExecutor.readSync` tagged `failure-learning:*` and fails if `sourceTreeReadOk: true` is missing. |
+| `gh pr merge` refused when any check is non-passing | Automatic. The Bash PreToolUse hook intercepts the command, runs `gh pr checks`, and blocks if anything is FAILURE / PENDING / QUEUED. |
+| `gh pr merge --auto` allowed through | Use it as the safe async gate. Only fires when checks pass. Documented behavior of `gh` itself. |
+| `--admin` does not bypass | The #539 incident shape itself: `gh pr merge --admin <num>` with red checks now blocks. |
 
 ## Evidence
 
-- 5 new tests (4 unit + 1 integration). Both new tests verified by
-  destructive-negative test (removing the flag from `RevertDetector` →
-  both tests fail as expected, with `SourceTreeGuardError` surfacing).
+- 10 new unit tests covering both writers (init.ts + PostUpdateMigrator)
+  for content, plus eight runtime-behavior tests that spawn the rendered
+  hook with a mocked `gh` binary on PATH (BLOCK on FAILURE, BLOCK on
+  PENDING, ALLOW on SUCCESS, ALLOW on SKIPPED, ALLOW on `--auto`, IGNORE
+  non-`gh pr merge` commands, BLOCK on `--admin` with red checks, BLOCK
+  on no-PR-number with red current-branch PR).
+- Migration-parity test from PR #545 still green — the new gate landed in
+  BOTH writers in lockstep.
 - `tsc --noEmit` clean.
 - Side-effects review:
-  `upgrades/side-effects/failure-learning-source-tree-readok.md`.
-- Existing `RevertDetector.test.ts` (9 tests) and `CiFailurePoller.test.ts`
-  (12 tests) remain green.
+  `upgrades/side-effects/dangerous-command-guard-gh-pr-merge-gate.md`.

--- a/upgrades/side-effects/dangerous-command-guard-gh-pr-merge-gate.md
+++ b/upgrades/side-effects/dangerous-command-guard-gh-pr-merge-gate.md
@@ -1,0 +1,102 @@
+# Side-effects review — dangerous-command-guard gh-pr-merge gate
+
+## What changed
+
+`dangerous-command-guard.sh` (PreToolUse hook on the Bash tool) gains a new
+gate block that refuses `gh pr merge` invocations when any PR check is
+non-passing.
+
+- The gate runs `gh pr checks <num> --json name,state` (uses the current
+  branch's PR if no number is given on the command).
+- A check is "ok" iff its state is `SUCCESS`, `SKIPPED`, `SKIPPING`, or
+  `NEUTRAL`. Anything else (`FAILURE`, `PENDING`, `QUEUED`, etc.) is
+  non-passing.
+- `gh pr merge --auto` is allowed through — it's the documented async safe
+  path that only fires when checks pass.
+- All other shapes (`gh pr merge <num> --squash`, `gh pr merge --admin
+  <num>`, no-flag) are gated.
+- Pattern match is bounded to command-start boundary (`^`, `;`, `&&`, `||`,
+  `|`, `(`, or whitespace), so commands that merely mention "gh pr merge"
+  in a string literal (e.g. `echo "fix gh pr merge bug"`) do not trigger.
+
+The gate lives inline in `dangerous-command-guard.sh`, matching the existing
+safety-gate pattern (catastrophic / deployment-coherence / risky-commands
+blocks). Same content is duplicated in `src/commands/init.ts` (fresh-init
+copy) and `src/core/PostUpdateMigrator.ts` `getDangerousCommandGuard()`
+(auto-update copy), per the existing parity allowlist in
+`migration-parity-hooks.test.ts`.
+
+## Why
+
+This closes the **2026-05-27 PR #539 watch-exit-merge class**. Justin merged
+PR #539 (the better-sqlite3 ABI heal) on the back of `gh run watch` returning
+exit 0. But `gh run watch` returns 0 on workflow COMPLETION regardless of
+conclusion. The PR's branch-protection checks were RED (Type Check + 2 unit
+shards failing), and merging on the false-positive watch exit cost:
+- A fix-forward (#540) for the green-up of the same change.
+- A ~16-hour fleet outage on instar-codey when the ABI-heal regression hit
+  production.
+- A memory entry (`[feedback_never_merge_on_watch_exit_verify_checks]`)
+  warning against the pattern in the future, which is exactly the
+  "structure > willpower" antipattern this PR replaces.
+
+Per the post-mortem (PR #545), this is lever E: smallest of the remaining
+levers, closes the most embarrassing class. Pure structural enforcement —
+no relying on the agent to remember to check.
+
+## Risk surface
+
+- **`gh pr merge --auto` is allowed.** This is the documented async safe
+  path — async, fires only when checks pass, idempotent. Allowing it does
+  not weaken the gate.
+- **Pattern-bounded.** The command-start anchor (`(^|[;&|(\s])`) prevents
+  false-positives on string literals, comments, or commands that happen to
+  contain the literal phrase.
+- **No-PR fallback.** If no PR number is in the command line, the gate
+  consults `gh pr view --json number` to resolve the current branch's PR.
+  If that fails (e.g. not in a git repo, or no PR exists), the gate
+  exits silently — allowing the command. This is the documented behavior
+  of `gh pr merge` itself when no PR exists; we don't add new failure
+  modes.
+- **Skipped-checks tolerance.** `SKIPPED` / `SKIPPING` checks (e.g.
+  Contract Tests on non-tagged PRs) are explicitly OK. The most common
+  intentionally-skipped case in our pipeline.
+- **Default-on for new and existing agents.** New agents get it via fresh
+  init; existing agents get it via PostUpdateMigrator's always-overwrite
+  rewrite of `dangerous-command-guard.sh` on every auto-update tick.
+
+## Bug surfaces eliminated
+
+- A future "merged on a red CI shard because watch exited 0" incident is
+  structurally impossible from the dangerous-command-guard surface.
+- `gh pr merge --admin` with red checks is also blocked (the #539 incident
+  shape itself).
+- `gh pr merge` with PENDING checks (e.g. immediately after a push, before
+  CI has fired) is blocked — the agent must wait, OR use `--auto`.
+
+## Migration footprint
+
+`dangerous-command-guard.sh` is on the always-overwrite list (per
+`PostUpdateMigrator.migrateHooks`). Existing agents pick up the new gate on
+the next auto-update tick — typically within ~30 min of release. No config
+schema change, no per-agent migration.
+
+## Testing
+
+- Unit: `tests/unit/dangerous-command-guard-gh-pr-merge-gate.test.ts` — 10
+  tests. Two surface checks (both guard writers contain the gate block) +
+  eight behavioral checks (spawn the rendered hook with a mocked `gh`
+  binary on PATH, verify BLOCK on FAILURE / PENDING, ALLOW on SUCCESS /
+  SKIPPED, ALLOW on `--auto`, IGNORE non-`gh pr merge` commands, BLOCK on
+  `--admin` with red checks, BLOCK on no-PR-number with red current-branch
+  PR).
+- `tests/unit/migration-parity-hooks.test.ts` (from PR #545) still green:
+  the new gate landed in BOTH writers in lockstep, so no new gap surfaces.
+- `tsc --noEmit` clean.
+
+## Follow-ups
+
+- The other post-mortem levers from PR #545's "What Changed" still pending:
+  B (real-world-state fixture tests — biggest, separate conversation), D
+  (silent-failure ban lint — small, similar shape to PR #542's
+  secret-externalization lint).


### PR DESCRIPTION
## Summary

Pipeline post-mortem **lever E**: structural refusal of `gh pr merge` when any PR check is non-passing. Closes the 2026-05-27 PR #539 watch-exit-merge class — Justin merged #539 on the back of `gh run watch` exit 0 (which means "workflow completed", not "workflow succeeded"), cost a fix-forward (#540) + ~16h fleet outage. The memory note afterward tried to prevent recurrence via convention; this PR replaces that convention with a hook that the agent literally cannot bypass.

New block in `dangerous-command-guard.sh` (PreToolUse Bash hook):
- Matches `gh pr merge` at command boundary (not in string literals).
- Allows `gh pr merge --auto` through (documented async safe path).
- Otherwise runs `gh pr checks <num> --json name,state` and refuses if any state is not `SUCCESS` / `SKIPPED` / `SKIPPING` / `NEUTRAL`.
- `--admin` does NOT bypass — the #539 incident shape itself.

Same content in both `installHooks()` and `PostUpdateMigrator.getDangerousCommandGuard()` in lockstep — passes the migration-parity test from PR #545.

## What changed

- `src/commands/init.ts` — installHooks inline copy gains the gate.
- `src/core/PostUpdateMigrator.ts` — getDangerousCommandGuard gains the gate.
- `tests/unit/dangerous-command-guard-gh-pr-merge-gate.test.ts` — 10 tests (2 surface + 8 runtime behavior).
- Standard ship artifacts (NEXT.md + eli16 + side-effects).

## Test plan

- [x] 10 unit tests green locally — 2 static content checks across both writers, 8 runtime tests that spawn the rendered hook with a mocked `gh` binary and assert BLOCK / ALLOW behavior across the full matrix (FAILURE, PENDING, SUCCESS, SKIPPED, `--auto`, non-`gh pr merge` commands, `--admin` with red checks, no-PR-number with red current-branch PR).
- [x] Migration-parity test from PR #545 still green — new gate landed in BOTH writers in lockstep.
- [x] `tsc --noEmit` clean.
- [ ] CI green (await GitHub Actions).
- [ ] Self-eat-own-dog-food: this PR's own merge will go through this gate. If CI's all green, the gate allows. If anything is red, the gate blocks.

Generated with Claude Code.
