### PR TITLE
feat(mentor): autonomous-fix loop ("just be Echo") — Opus guardian replaces observe-only

### DIFF
--- a/docs/specs/MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.eli16.md
+++ b/docs/specs/MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.eli16.md
@@ -1,0 +1,48 @@
+# In plain English: make the mentor job actually FIX things, as Echo, on Opus
+
+## What this is about
+
+Echo runs a "mentor" job that helps another agent (Codey) by checking in every so
+often. Today that job only WATCHES and TAKES NOTES: it sends Codey a check-in
+message (written by a small, cheap model), looks at Codey's logs, and writes down
+any problems it spots into a list. It never actually fixes anything. The real
+fixing — watch how Codey is doing, find a bug, and ship a proper fix for it — has
+always been done by a developer by hand.
+
+## What Justin asked for
+
+He wants the job to do the WHOLE thing automatically, the same way a developer
+does it in a live session: give Codey a real task, watch both the chat experience
+and Codey's internals, and FIX whatever is broken as a real, shipped code change —
+with all the fixing done by a powerful Opus model. In his words, "if it could just
+be you taking on that job that would be ideal."
+
+## What's new
+
+A new switch, `mentor.autonomousFix.enabled`. When it's on, the mentor heartbeat
+stops doing the watch-and-note routine and instead becomes a GUARDIAN. Each
+heartbeat it asks four questions: is the feature on? is there budget left? is a
+loop session already running? has enough time passed? If all four pass, it starts
+ONE full-power Opus session that is basically a copy of Echo. That session runs
+one full cycle — check Codey's health (and fix it if it's down), give Codey a real
+task, watch the chat and the internals, fix any problem as a proper pull request
+through the normal ship checks, and report back — then it exits. The guardian
+starts the next cycle later on its own.
+
+## Why it won't run wild
+
+The most important guard is "only one at a time." A single cycle (assign, watch,
+fix, ship, report) takes a long time — much longer than the 15-minute heartbeat.
+So without a guard, the heartbeat would keep launching new expensive Opus sessions
+on top of each other. The single-instance check means: if one is already running,
+the heartbeat does nothing. Budget and a minimum-wait also gate it. And the whole
+thing ships OFF by default — each agent has to opt in. The Opus session also has
+to pass the exact same automated ship checks (tests, CI) as a human, so it can't
+land code that fails.
+
+## What you need to decide
+
+Nothing to configure to stay safe — it's off until you turn it on. To turn it on
+for an agent, set `mentor.autonomousFix.enabled: true` in that agent's config. You
+can watch what it does in `GET /mentor/status` (it reports `spawned`,
+`loop-active`, `budget`, and so on) and in the pull requests it opens.

--- a/docs/specs/MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.md
+++ b/docs/specs/MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.md
@@ -1,0 +1,124 @@
+---
+title: Mentor Autonomous-Fix Loop — the "just be Echo" guardian
+status: approved
+review-convergence: converged
+approved: true
+approval-basis: >
+  Direct user directive (Justin, 2026-05-29, topic 13435). After I verified that
+  the automated mentor job only OBSERVES + LOGS (it assigns the mentee a task and
+  captures findings to a read-only ledger, but never fixes anything), Justin said:
+  "Yes, just make sure all the fixing is done by an opus model just like you're
+  running now it should replicate exactly what you've been doing in this thread.
+  In fact, if it could just be you taking on that job that would be ideal." That
+  resolves the one open design decision (full auto-fix vs propose) in favour of
+  full auto-fix, performed by an Opus session that is an Echo clone.
+eli16-overview: MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.eli16.md
+date: 2026-05-29
+---
+
+# Mentor Autonomous-Fix Loop — the "just be Echo" guardian
+
+## Problem
+
+The Framework-Onboarding mentor heartbeat (`runMentorTick`) OBSERVES and LOGS. Each
+cycle it spawns a tool-less haiku session to compose a check-in, runs Stage-B
+forensics over the mentee's signals, and captures findings to a read-only issue
+ledger. It never FIXES anything: the "watch the experience and fix what's broken
+as shipped code" half of the dogfooding loop is done by a developer by hand.
+
+Justin's intent is that the automated job do the WHOLE loop — assign the mentee a
+real task, observe both the Telegram UX and the mentee's internals, and fix every
+issue it finds as a proper fleet PR — with all fixing done by an Opus model, "just
+be you taking on that job."
+
+## Design
+
+Add a config-gated GUARDIAN execution path to the mentor heartbeat. When
+`mentor.autonomousFix.enabled` is true, the heartbeat stops running the haiku
+observe-pipeline and instead keeps ONE full-tool **Opus** session alive on the
+manual dogfooding loop. The spawned session IS an Echo clone: it runs one full
+cycle (health-check → assign → observe → fix-as-PR → report) and exits; the
+guardian — not the session — starts the next cycle on its own heartbeat.
+
+### Components
+
+1. **`MentorAutonomousGuardian` (pure)** — `runAutonomousGuardian(deps)` runs the
+   gate sequence and spawns. Every side-effect (the spawn, the alive-check, the
+   goal builder) is injected, so the gate logic is unit-tested with no
+   SessionManager / tmux / LLM. `buildAutoloopGoal(params)` is the deterministic
+   default goal-prompt that encodes the loop and the discipline.
+
+2. **`MentorOnboardingRunner` branch** — `tick()` routes to `autonomousTick()`
+   when `autonomousFix.enabled`, regardless of `mode` (mode gates only the haiku
+   pipeline). The runner wires the injected guardian services and advances the
+   per-day + min-interval counters when a cycle actually spawns.
+
+3. **`AgentServer` wiring** — `spawnLoopSession` spawns a full-tool session
+   (`allowedTools` omitted → Echo's default toolset; `model` from config → opus;
+   a deterministic `mentor-autoloop-<ts>` name; `maxDurationMinutes` from
+   `maxCycleMinutes`). `loopSessionAlive` matches any running session whose name
+   carries the prefix. `buildAutoloopGoal` is parameterized from config.
+
+### Gate sequence (load-bearing order)
+
+`enabled → budget → single-instance → min-interval → spawn`.
+
+- **enabled** — ships dark; a disabled config never spawns or spends.
+- **budget** — fail-closed BEFORE any spawn (the mentor per-day round cap).
+- **single-instance** — at most ONE loop session. A cycle (assign → observe →
+  fix-as-PR → report) outlives many heartbeat ticks, so this gate is what stops a
+  15-minute heartbeat from spawn-storming expensive Opus sessions: if a loop
+  session is alive, the tick is a deliberate no-op (`reason: 'loop-active'`).
+- **min-interval** — a floor before respawning after a cycle ends, so a
+  fast-finishing or fast-failing cycle cannot busy-loop.
+
+A spawn that throws surfaces as `reason: 'spawn-failed'` with the underlying error
+in `GET /mentor/status .lastResult.error` — never a silent no-op.
+
+### The goal prompt
+
+`buildAutoloopGoal` encodes one full cycle: (1) health-check the mentee and
+recover it self-healingly if it is down; (2) assign one real instar task over
+Telegram; (3) observe both the Telegram UX and the mentee's internals; (4) fix any
+issue as a proper fleet PR through the full ship gate; (5) report honestly,
+including anything skipped or still failing. It carries the same
+verify-before-you-claim, no-narrated-tool-calls discipline a developer uses, and
+ends with "one cycle, then exit" so the session never spawns a copy of itself. A
+host may override it via `mentor.autonomousFix.goalTemplate`.
+
+## Safety
+
+- Ships **dark**: `mentor.autonomousFix.enabled` defaults false. Opt-in per agent.
+- The expensive Opus session spawns only behind all four gates, so it never
+  idle-burns or spawn-storms.
+- The spawned Echo ships fixes through the SAME structural ship gate as an
+  interactive developer (husky pre-commit, the instar-dev gate, CI branch
+  protection). Those gates do not care whether the author is interactive or
+  autonomous, so an autonomous fix cannot land code that fails CI.
+- `maxCycleMinutes` bounds a runaway cycle.
+
+## Migration parity
+
+`mentor.autonomousFix` is added to `ConfigDefaults` (`SHARED_DEFAULTS`), so
+`migrateConfig`'s `applyDefaults` deep-merge adds the dark sub-block to existing
+agents on update (existence-checked, never overwriting an operator's choice). The
+CLAUDE.md mentor section gains an autonomous-fix-loop paragraph in both new-agent
+generation and `migrateClaudeMd` (a content-sniffed paragraph for agents that
+already have the section). No new job is needed: the existing
+`mentor-onboarding` heartbeat drives the guardian.
+
+## Testing
+
+- **Tier 1 unit** — `MentorAutonomousGuardian.test.ts`: every gate, both sides,
+  gate-order, spawn-failure surfacing, and the goal-prompt assembly.
+  `MentorOnboardingRunner.test.ts`: the branch routes to the guardian (not the
+  observe-pipeline) regardless of mode; single-instance; counter advancement;
+  the unwired-spawner clear error; the dark default.
+- **Tier 2 integration** — `mentor-routes.test.ts`: `POST /mentor/tick` routes to
+  the guardian over HTTP and respects single-instance.
+- **Tier 3 E2E** — `mentor-onboarding-lifecycle.test.ts`: the REAL AgentServer on
+  the production init path spawns (via a spy SessionManager) with the OPUS model,
+  the full tool grant, the autoloop name, and the real dogfooding-loop prompt —
+  proving the feature is alive in production wiring with no real spawn.
+- **Migration parity** — `ConfigDefaults.test.ts`: an existing mentor block gains
+  the dark `autonomousFix` on update, idempotently.

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -190,6 +190,16 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
     minIntervalMs: 600000, // 10-min floor between ticks (anti-forced-cadence)
     maxRoundsPerDay: 24,
     dailySpendCapUsd: 0.5,
+    // The "just be Echo" autonomous-fix loop (MENTOR-AUTONOMOUS-FIX-LOOP-SPEC):
+    // when enabled, the heartbeat keeps ONE full-tool Opus loop session alive on
+    // the manual dogfooding loop (assign → observe → FIX as a fleet PR → report)
+    // instead of the haiku observe-pipeline. Ships dark; opt-in per agent.
+    autonomousFix: {
+      enabled: false,
+      model: 'opus',
+      sessionNamePrefix: 'mentor-autoloop',
+      maxCycleMinutes: 120,
+    },
   },
   // Mentee receiver wiring (MENTOR-LIVE-READINESS-SPEC §Recipient side).
   // The mirror of the mentor block: this agent ACCEPTS inbound mentor prompts

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2708,10 +2708,21 @@ A durable, bucket-tagged record of behavioral issues observed while onboarding a
 - Issues logged for a framework: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/framework-issues\` (optional \`?framework=X&bucket=...&status=...&limit=N\`)
 - The onboarding playbook (generalizable lessons from PRIOR frameworks, impact-ranked): \`curl -H "Authorization: Bearer $AUTH" "http://localhost:${port}/framework-issues/playbook?targetFramework=X"\`
 - Both routes are read-only and return references, not log contents.
+
+**Autonomous-fix loop ("just be Echo")** — when \`mentor.autonomousFix.enabled\` is true, the mentor heartbeat stops running the observe-and-log pipeline and instead keeps ONE full-tool **Opus** session alive on the manual dogfooding loop: assign the mentee a real task over Telegram, observe the UX + the mentee's internals, FIX whatever is broken as a proper fleet PR (full ship gate), and report. Ships **dark** (off by default). The expensive Opus session only spawns when no loop session is already running (single-instance), budget is OK, and the min-interval has elapsed — so it never idle-burns or spawn-storms. Enable per agent in \`.instar/config.json\` → \`mentor.autonomousFix\`. Status lands in \`GET /mentor/status .lastResult\` (\`reason: 'spawned' | 'loop-active' | 'budget' | …\`).
 `;
       content += '\n' + fwLedgerSection;
       patched = true;
       result.upgraded.push('CLAUDE.md: added Framework-Onboarding Mentor System issue-ledger awareness section');
+    } else if (!content.includes('Autonomous-fix loop ("just be Echo")')) {
+      // Migration parity: agents that already have the mentor section (shipped
+      // before the autonomous-fix loop) must still learn about the new dark
+      // capability. Append just the autonomousFix paragraph, content-sniffed so
+      // it is idempotent.
+      content +=
+        '\n**Autonomous-fix loop ("just be Echo")** — when `mentor.autonomousFix.enabled` is true, the mentor heartbeat keeps ONE full-tool **Opus** session alive on the manual dogfooding loop (assign the mentee a real task → observe the UX + internals → FIX as a proper fleet PR → report) instead of the observe-and-log pipeline. Ships **dark** (off by default); single-instance + budget + min-interval gated so it never idle-burns. Enable in `.instar/config.json` → `mentor.autonomousFix`; status in `GET /mentor/status .lastResult`.\n';
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added autonomous-fix loop ("just be Echo") awareness paragraph');
     }
 
     // Version-Skew Self-Recovery section

--- a/src/scheduler/MentorAutonomousGuardian.ts
+++ b/src/scheduler/MentorAutonomousGuardian.ts
@@ -1,0 +1,146 @@
+/**
+ * MentorAutonomousGuardian — the "just be Echo" autonomous-fix loop core
+ * (MENTOR-AUTONOMOUS-FIX-LOOP-SPEC).
+ *
+ * Where {@link runMentorTick} OBSERVES + LOGS (a tool-less haiku composes a
+ * check-in, Stage-B captures findings to a read-only ledger, nothing is fixed),
+ * this guardian makes the mentor heartbeat KEEP ONE FULL-TOOL OPUS SESSION
+ * ALIVE on the manual dogfooding loop. The spawned session IS an Echo clone: it
+ * assigns the mentee a real task over Telegram, observes the UX + the mentee's
+ * internals, FIXES whatever is broken as a proper fleet-wide PR, and reports —
+ * exactly the loop a developer runs by hand. (Justin's constraint: all fixing
+ * is done by an Opus model, ideally "just be you taking on that job".)
+ *
+ * This module is PURE orchestration: every side-effect (the spawn, the
+ * already-running check, the goal builder) is injected, so the gate logic is
+ * unit-testable with no SessionManager / tmux / LLM. The structural guarantees
+ * live HERE, in code, not in a prompt:
+ *
+ *   - enabled gate    — ships dark; a disabled config never spawns or spends.
+ *   - budget gate     — fail-closed BEFORE any spawn (the mentor per-day cap).
+ *   - single-instance — never more than ONE loop session. A single cycle
+ *     (assign → observe → fix-as-PR → report) outlives MANY heartbeat ticks, so
+ *     this is the gate that stops a 15-min heartbeat from spawn-storming
+ *     expensive Opus sessions: if a loop session is alive, the tick is a no-op.
+ *   - min-interval    — even after a cycle ends, a brief floor before respawn.
+ *
+ * Order is load-bearing: enabled → budget → single-instance → min-interval → spawn.
+ */
+
+export interface AutonomousGuardianDeps {
+  /** The framework being mentored (parametric; flows into the goal prompt). */
+  framework: string;
+  /** mentor.autonomousFix.enabled — the master switch (ships dark when false). */
+  enabled: boolean;
+  /** Fail-closed budget gate — shared with the observe-pipeline (per-day round
+   *  cap). Checked BEFORE any spawn so a depleted budget never starts a cycle. */
+  budgetOk: boolean;
+  /** True when a loop session (name-prefix match) is already running. The
+   *  single-instance invariant: at most one Opus loop session at a time. */
+  loopSessionAlive: boolean;
+  /** Min-interval floor elapsed since the last spawn (anti spawn-storm). */
+  minIntervalElapsed: boolean;
+  /** The model the spawned loop session runs on (Justin's constraint: opus). */
+  model: string;
+  /** Build the dogfooding-loop goal prompt for the spawned session. Injected so
+   *  the host can parameterize it (mentee name, topics) without this core
+   *  depending on config shape. */
+  buildGoal: () => string;
+  /** Spawn the full-tool Opus loop session; resolves with its session name.
+   *  Injected so the pure guardian has no SessionManager dependency. */
+  spawnLoopSession: (goal: string, model: string) => Promise<{ sessionName: string }>;
+  /** Tick id for provenance. */
+  tickId?: string;
+  now?: () => number;
+}
+
+export type AutonomousGuardianReason =
+  | 'disabled'
+  | 'budget'
+  | 'loop-active'
+  | 'unsafe-interval'
+  | 'spawned'
+  | 'spawn-failed';
+
+export interface AutonomousGuardianResult {
+  ran: boolean;
+  reason: AutonomousGuardianReason;
+  /** The spawned loop session's name (only when reason === 'spawned'). */
+  sessionName?: string;
+  /** Underlying error message (only when reason === 'spawn-failed'). */
+  error?: string;
+}
+
+/**
+ * Run one guardian tick. Returns a structured result; the only side effect is
+ * the injected {@link AutonomousGuardianDeps.spawnLoopSession}. Order is
+ * load-bearing — see the module doc.
+ */
+export async function runAutonomousGuardian(
+  deps: AutonomousGuardianDeps,
+): Promise<AutonomousGuardianResult> {
+  // 1. enabled — ships dark; a disabled config never spawns or spends.
+  if (!deps.enabled) return { ran: false, reason: 'disabled' };
+
+  // 2. budget — fail-closed BEFORE any spawn (reuses the mentor per-day round
+  //    cap). A depleted budget must never start an expensive Opus cycle.
+  if (!deps.budgetOk) return { ran: false, reason: 'budget' };
+
+  // 3. single-instance — never more than ONE loop session. A cycle outlives many
+  //    heartbeat ticks, so without this gate the 15-min heartbeat would
+  //    spawn-storm. If one is alive, the tick is a deliberate no-op.
+  if (deps.loopSessionAlive) return { ran: false, reason: 'loop-active' };
+
+  // 4. min-interval — a brief floor before respawning after a cycle ends, so a
+  //    fast-finishing or fast-failing cycle can't busy-loop.
+  if (!deps.minIntervalElapsed) return { ran: false, reason: 'unsafe-interval' };
+
+  // 5. spawn the full-tool Opus loop session (the Echo clone running the loop).
+  try {
+    const { sessionName } = await deps.spawnLoopSession(deps.buildGoal(), deps.model);
+    return { ran: true, reason: 'spawned', sessionName };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ran: false, reason: 'spawn-failed', error: message };
+  }
+}
+
+export interface AutoloopGoalParams {
+  /** The mentee's agent-registry name (e.g. 'instar-codey'). */
+  menteeAgentName: string;
+  /** The mentee framework (e.g. 'codex-cli'). */
+  menteeFramework: string;
+  /** Telegram topic the spawned Echo reports progress to (the human's topic). */
+  reportTopicId?: number;
+  /** Telegram topic the spawned Echo drives the mentee in. */
+  menteeTopicId?: number;
+}
+
+/**
+ * The built-in dogfooding-loop goal prompt for the spawned Opus session. This
+ * is the durable encoding of "replicate exactly what you've been doing": one
+ * full cycle of health-check → assign → observe → fix-as-PR → report, with the
+ * same verify-don't-confabulate discipline, then a clean exit (the guardian —
+ * not the session — starts the next cycle). Pure + deterministic so it is
+ * unit-testable. A host may override it via mentor.autonomousFix.goalTemplate.
+ */
+export function buildAutoloopGoal(p: AutoloopGoalParams): string {
+  const driveIn = p.menteeTopicId !== undefined ? ` (Telegram topic ${p.menteeTopicId})` : '';
+  const reportLine =
+    p.reportTopicId !== undefined
+      ? `Report what happened — honestly, including anything skipped or still failing — to Telegram topic ${p.reportTopicId} (.instar/scripts/telegram-reply.sh).`
+      : `Report what happened — honestly, including anything skipped or still failing — to your owner over Telegram.`;
+  return [
+    `You are Echo, the instar developer agent, running ONE autonomous cycle of the ${p.menteeFramework} (${p.menteeAgentName}) dogfooding-and-fix loop.`,
+    `This is the exact loop a developer runs by hand: drive the mentee through real work, watch the experience from both sides, and FIX what is broken — fully, as shipped code.`,
+    ``,
+    `Do, in order:`,
+    `1. HEALTH FIRST. Check ${p.menteeAgentName}'s health (its server /health, recent logs, sqlite subsystems). If it is down or crash-looping, recover it self-healingly before anything else — that recovery IS this cycle. If a problem can affect other instar agents, fix it fleet-wide.`,
+    `2. ASSIGN. If the mentee is healthy and idle, give it ONE real, useful instar development task over Telegram${driveIn} — a genuine improvement, not a toy exercise.`,
+    `3. OBSERVE BOTH SIDES. (a) The Telegram UX: is it seamless and coherent — no leaked internals, no confusing receipts, replies that make sense to a human watching? (b) The mentee's internals: logs, health, token/rate-limit pressure, any errors or stalls.`,
+    `4. FIX. For any instar or ${p.menteeFramework} issue you find, fix it as a PROPER fleet-wide PR: converged+approved spec → build → all three test tiers green → the instar-dev ship gate → merge to JKHeadley/main → release → deploy → re-verify on the DEPLOYED artifact. All fixing is yours, on this Opus model. A bug that bricks/downs an agent, loses data, breaks the mandatory Telegram relay, or hits security: fix and deploy without asking.`,
+    `5. ${reportLine}`,
+    ``,
+    `Discipline (non-negotiable): verify before you claim — never write a result or a number before the producing tool has returned it. Never narrate a tool call you did not make. One cycle, then exit cleanly — do NOT spawn another copy of this loop or schedule a follow-up; the guardian starts the next cycle on its own heartbeat.`,
+  ].join('\n');
+}

--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -13,8 +13,42 @@
  * Ships dormant: `mentor.enabled=false` / `mentor.mode='off'` by default (§16).
  */
 import { runMentorTick, type MentorTickResult, type MentorMode } from './MentorOnboardingTick.js';
+import {
+  runAutonomousGuardian,
+  type AutonomousGuardianReason,
+} from './MentorAutonomousGuardian.js';
 import type { ConversationSurface } from '../monitoring/MentorStageA.js';
 import type { CaptureRunInput, CaptureRunResult, ForensicFinding } from '../monitoring/FrameworkIssueLedger.js';
+
+/**
+ * The "just be Echo" autonomous-fix loop (MENTOR-AUTONOMOUS-FIX-LOOP-SPEC).
+ * When enabled, the mentor heartbeat stops running the haiku observe-pipeline
+ * and instead acts as a GUARDIAN: it keeps ONE full-tool Opus session (an Echo
+ * clone) alive on the manual dogfooding loop — assign the mentee a real task,
+ * observe the UX + internals, FIX issues as proper fleet PRs, report. Ships
+ * dark (`enabled:false`). The expensive Opus session only spawns when no loop
+ * session is already running (single-instance), budget is OK, and the
+ * min-interval has elapsed — so it never idle-burns or spawn-storms.
+ */
+export interface MentorAutonomousFixConfig {
+  /** Master switch. Default false → the heartbeat runs the observe-pipeline. */
+  enabled: boolean;
+  /** Model the spawned loop session runs on. Justin's constraint: all fixing by
+   *  an Opus model, exactly like the manual loop. Default 'opus'. */
+  model: string;
+  /** Session-name prefix for the spawned loop session; the single-instance gate
+   *  matches live sessions by this prefix. Default 'mentor-autoloop'. */
+  sessionNamePrefix?: string;
+  /** Telegram topic the spawned Echo reports progress to (the human's topic).
+   *  When unset, falls back to the mentor/mentee topic resolution. */
+  reportTopicId?: number;
+  /** Optional override for the loop goal-prompt. When unset, the built-in
+   *  buildAutoloopGoal template is used (parameterized by mentee + topics). */
+  goalTemplate?: string;
+  /** Max wall-clock minutes for one loop-cycle session before it is force-killed
+   *  (a runaway guard). Default 120. */
+  maxCycleMinutes?: number;
+}
 
 export interface MentorConfig {
   enabled: boolean;
@@ -67,6 +101,13 @@ export interface MentorConfig {
    * opt-in, and the mentor itself is already gated behind `enabled`/`mode`). Flows
    * into the Stage-A surface's `onboardingAgenda`. */
   onboardingAgenda?: string[];
+  /**
+   * The "just be Echo" autonomous-fix loop. When `autonomousFix.enabled` is
+   * true, the heartbeat runs the GUARDIAN path (keep one full-tool Opus loop
+   * session alive) instead of the haiku observe-pipeline — regardless of `mode`.
+   * Absent/`enabled:false` ⇒ unchanged observe behaviour (ships dark).
+   */
+  autonomousFix?: MentorAutonomousFixConfig;
 }
 
 /**
@@ -113,12 +154,27 @@ export interface MentorRunnerServices {
    *  min-interval clock and the per-day run counter. */
   onTickRan?: () => void;
   now?: () => number;
+  // --- Autonomous-fix loop ("just be Echo") services. Only consulted when
+  //     mentor.autonomousFix.enabled is true; absent ⇒ the guardian path is
+  //     unreachable (a missing spawn surfaces as a clear spawn-failed result). ---
+  /** True when a loop session (name-prefix match) is already running — the
+   *  single-instance gate. */
+  loopSessionAlive?: () => boolean;
+  /** Spawn the full-tool Opus loop session; resolve with its session name. */
+  spawnLoopSession?: (goal: string, model: string) => Promise<{ sessionName: string }>;
+  /** Build the dogfooding-loop goal prompt for the framework. */
+  buildAutoloopGoal?: (framework: string) => string;
 }
 
-export type MentorRunReason = MentorTickResult['reason'] | 'disabled';
+export type MentorRunReason =
+  | MentorTickResult['reason']
+  | 'disabled'
+  | AutonomousGuardianReason;
 
 export interface MentorRunResult extends Omit<MentorTickResult, 'reason'> {
   reason: MentorRunReason;
+  /** The spawned loop session's name (autonomous-fix guardian path only). */
+  sessionName?: string;
 }
 
 export class MentorOnboardingRunner {
@@ -156,7 +212,11 @@ export class MentorOnboardingRunner {
    */
   startTick(): { accepted: boolean; reason?: string } {
     const cfg = this.getConfig();
-    if (!cfg.enabled || cfg.mode === 'off') {
+    // The autonomous-fix guardian is a distinct execution path: it runs whenever
+    // `enabled && autonomousFix.enabled`, regardless of `mode` (mode gates only
+    // the haiku observe-pipeline). So `mode:'off'` does NOT disable it.
+    const autonomous = cfg.autonomousFix?.enabled === true;
+    if (!cfg.enabled || (cfg.mode === 'off' && !autonomous)) {
       this.lastResult = { ran: false, reason: 'disabled', at: (this.services.now ?? Date.now)() };
       return { accepted: false, reason: 'disabled' };
     }
@@ -186,12 +246,15 @@ export class MentorOnboardingRunner {
     return { accepted: true };
   }
 
-  /** Run one tick. Short-circuits to `disabled` when the feature is off (§16). */
+  /** Run one tick. Short-circuits to `disabled` when the feature is off (§16).
+   *  Branches to the autonomous-fix guardian when `autonomousFix.enabled`. */
   async tick(): Promise<MentorRunResult> {
     const cfg = this.getConfig();
-    if (!cfg.enabled || cfg.mode === 'off') {
+    const autonomous = cfg.autonomousFix?.enabled === true;
+    if (!cfg.enabled || (cfg.mode === 'off' && !autonomous)) {
       return { ran: false, reason: 'disabled' };
     }
+    if (autonomous) return this.autonomousTick(cfg);
     const framework = cfg.menteeFramework;
     const mode: MentorMode = cfg.mode === 'live' ? 'live' : 'dry-run';
     const result = await runMentorTick({
@@ -209,5 +272,45 @@ export class MentorOnboardingRunner {
     });
     if (result.ran) this.services.onTickRan?.();
     return result;
+  }
+
+  /**
+   * The "just be Echo" autonomous-fix path. Delegates to the pure
+   * {@link runAutonomousGuardian}: keep ONE full-tool Opus loop session alive on
+   * the manual dogfooding loop. The runner wires the injected guardian services
+   * (alive-check, spawn, goal builder) and advances the run counters when a
+   * cycle actually spawns. A host that enabled `autonomousFix` but failed to
+   * wire `spawnLoopSession` surfaces a clear `spawn-failed` result rather than a
+   * silent no-op.
+   */
+  private async autonomousTick(cfg: MentorConfig): Promise<MentorRunResult> {
+    const af = cfg.autonomousFix!;
+    const framework = cfg.menteeFramework;
+    const result = await runAutonomousGuardian({
+      framework,
+      enabled: af.enabled,
+      budgetOk: this.services.budgetOk(),
+      loopSessionAlive: this.services.loopSessionAlive?.() ?? false,
+      minIntervalElapsed: this.services.minIntervalElapsed(),
+      model: af.model || 'opus',
+      buildGoal: () =>
+        af.goalTemplate ?? this.services.buildAutoloopGoal?.(framework) ?? '',
+      spawnLoopSession:
+        this.services.spawnLoopSession ??
+        (async () => {
+          throw new Error(
+            'spawnLoopSession not wired — autonomousFix.enabled but the host injected no loop-session spawner',
+          );
+        }),
+      now: this.services.now,
+    });
+    // A spawned cycle counts as a run (advances the per-day cap + interval clock).
+    if (result.reason === 'spawned') this.services.onTickRan?.();
+    return {
+      ran: result.ran,
+      reason: result.reason,
+      sessionName: result.sessionName,
+      error: result.error,
+    };
   }
 }

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -64,6 +64,7 @@ import { TokenLedger } from '../monitoring/TokenLedger.js';
 import { TokenLedgerPoller } from '../monitoring/TokenLedgerPoller.js';
 import { FrameworkIssueLedger } from '../monitoring/FrameworkIssueLedger.js';
 import { MentorOnboardingRunner, DEFAULT_MENTOR_CONFIG, resolveMentorDeliveryTopic, type MentorConfig } from '../scheduler/MentorOnboardingRunner.js';
+import { buildAutoloopGoal } from '../scheduler/MentorAutonomousGuardian.js';
 import {
   STAGE_A_ALLOWED_TOOLS,
   buildConversationSurface,
@@ -1837,6 +1838,47 @@ export class AgentServer {
         onTickRan: () => {
           self.mentorLastTickAt = Date.now();
           self.mentorRunsToday += 1;
+        },
+        // --- Autonomous-fix loop ("just be Echo") services (MENTOR-AUTONOMOUS-
+        //     FIX-LOOP-SPEC). Only consulted when mentor.autonomousFix.enabled.
+        //     E2E-PAIRING: EXEMPT — these are internal closures wired into the
+        //     existing /mentor/tick + /mentor/status routes (no new API surface);
+        //     covered by MentorAutonomousGuardian.test.ts (unit) + the mentor
+        //     integration/E2E suites. ---
+        loopSessionAlive: (): boolean => {
+          const cfg = getConfig();
+          const prefix = cfg.autonomousFix?.sessionNamePrefix || 'mentor-autoloop';
+          // Single-instance: a loop session is any running session whose name
+          // carries the prefix. A cycle outlives many heartbeats, so this is the
+          // gate that prevents spawn-storming expensive Opus sessions.
+          return self.sessionManager.listRunningSessions().some((s) => s.name?.startsWith(prefix));
+        },
+        buildAutoloopGoal: (framework: string): string =>
+          buildAutoloopGoal({
+            menteeAgentName: getConfig().menteeAgentName || `instar-${framework}`,
+            menteeFramework: framework,
+            // Report into the human's topic (autonomousFix.reportTopicId), else
+            // the resolved mentor/mentee delivery topic.
+            reportTopicId: getConfig().autonomousFix?.reportTopicId ?? resolveMentorDeliveryTopic(getConfig()),
+            menteeTopicId: getConfig().menteeTopicId,
+          }),
+        spawnLoopSession: async (goal: string, model: string): Promise<{ sessionName: string }> => {
+          const cfg = getConfig();
+          const prefix = cfg.autonomousFix?.sessionNamePrefix || 'mentor-autoloop';
+          const name = `${prefix}-${Date.now()}`;
+          const maxCycleMinutes = cfg.autonomousFix?.maxCycleMinutes ?? 120;
+          // Full-tool grant: omit allowedTools so the loop session gets Echo's
+          // default toolset (bash/edit/git/gh) — it must actually be able to
+          // ship fixes. Opus by config (Justin's constraint: all fixing on Opus).
+          // spawnSession resolves once the session has STARTED (not completed),
+          // so the guardian returns 'spawned' immediately while the cycle runs.
+          await self.sessionManager.spawnSession({
+            name,
+            prompt: goal,
+            model: model || 'opus',
+            maxDurationMinutes: Math.max(5, maxCycleMinutes),
+          });
+          return { sessionName: name };
         },
         now: () => Date.now(),
       },

--- a/tests/e2e/mentor-onboarding-lifecycle.test.ts
+++ b/tests/e2e/mentor-onboarding-lifecycle.test.ts
@@ -7,7 +7,7 @@
  * reason:'disabled'} — the loop never spawns or spends until a human promotes
  * it. Also asserts the built-in job template ships off by default.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import fs from 'node:fs';
@@ -176,5 +176,103 @@ describe('Mentor ledger survives a broken TokenLedger (regression: production ca
     const fi = await request(app).get('/framework-issues').set(auth());
     expect(fi.status).toBe(200); // ledger alive despite TokenLedger failure
     expect(Array.isArray(fi.body.issues)).toBe(true);
+  });
+});
+
+/**
+ * Tier-3 E2E "feature is alive" for the autonomous-fix loop ("just be Echo",
+ * MENTOR-AUTONOMOUS-FIX-LOOP-SPEC). Boots the REAL AgentServer with
+ * mentor.autonomousFix.enabled on the production init path, then POSTs a real
+ * tick. A spy sessionManager intercepts the spawn, so we prove the production
+ * wiring end-to-end (buildMentorRunner → guardian → spawnLoopSession → the real
+ * sessionManager.spawnSession with the OPUS model + full tools + the autoloop
+ * name) WITHOUT spawning a real session. This is the single most important test
+ * for the feature: it is genuinely alive in production wiring, not just unit-true.
+ */
+describe('Autonomous-fix loop E2E (alive on the production init path, no real spawn)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let server: AgentServer;
+  let app: express.Express;
+  const AUTH = 'test-e2e-autoloop';
+  const spawnSpy = vi.fn(async (opts: { name: string }) => ({
+    id: 'fake-loop',
+    name: opts.name,
+    tmuxSession: 'fake',
+    claudeSessionId: undefined,
+    framework: 'codex-cli',
+  }));
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'autoloop-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    // Enable the loop ON DISK — buildMentorRunner reads config.json via
+    // readMentorConfigFromDisk, so this is the real production config path.
+    fs.writeFileSync(
+      path.join(stateDir, 'config.json'),
+      JSON.stringify({
+        port: 0,
+        projectName: 'e2e',
+        agentName: 'E2E',
+        mentor: {
+          enabled: true,
+          mode: 'off', // guardian must run regardless of mode
+          menteeFramework: 'codex-cli',
+          menteeAgentName: 'instar-codey',
+          autonomousFix: { enabled: true, model: 'opus', sessionNamePrefix: 'mentor-autoloop', maxCycleMinutes: 90 },
+        },
+      }),
+    );
+
+    const config: InstarConfig = {
+      projectName: 'e2e', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH,
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    } as InstarConfig;
+
+    const sessionManager = {
+      listRunningSessions: () => [], // no loop alive → the gate lets a spawn through
+      getSession: () => null,
+      spawnSession: spawnSpy,
+    };
+    server = new AgentServer({ config, sessionManager: sessionManager as any, state: new StateManager(stateDir) });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/mentor-onboarding-lifecycle.test.ts:autoloop' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('POST /mentor/tick spawns an Opus full-tool loop session via the production wiring', async () => {
+    const res = await request(app).post('/mentor/tick').set(auth());
+    expect(res.status).toBe(202); // enabled → fire-and-forget
+    expect(res.body.accepted).toBe(true);
+    await new Promise((r) => setTimeout(r, 25)); // let the async guardian settle
+
+    const status = await request(app).get('/mentor/status').set(auth());
+    expect(status.status).toBe(200);
+    expect(status.body.lastResult?.reason).toBe('spawned');
+    expect(status.body.lastResult?.sessionName).toMatch(/^mentor-autoloop-/);
+
+    // Wiring integrity: the real spawn closure ran with Justin's constraints —
+    // the OPUS model, the autoloop name, a bounded cycle, and the FULL tool grant
+    // (allowedTools omitted, not the empty Stage-A grant).
+    expect(spawnSpy).toHaveBeenCalledOnce();
+    const spawnArgs = spawnSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(spawnArgs.model).toBe('opus');
+    expect(String(spawnArgs.name)).toMatch(/^mentor-autoloop-/);
+    expect(spawnArgs.allowedTools).toBeUndefined(); // full tools, not [] (Stage-A)
+    expect(spawnArgs.maxDurationMinutes).toBe(90);
+    // The goal prompt is the real dogfooding loop (not empty / not a stub).
+    expect(String(spawnArgs.prompt)).toMatch(/instar-codey/);
+    expect(String(spawnArgs.prompt)).toMatch(/HEALTH FIRST/);
   });
 });

--- a/tests/integration/mentor-routes.test.ts
+++ b/tests/integration/mentor-routes.test.ts
@@ -6,7 +6,7 @@
  * Uses supertest + a real MentorOnboardingRunner with fake services, so the
  * route↔runner contract is exercised over the full HTTP pipeline.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import { createRoutes } from '../../src/server/routes.js';
@@ -91,5 +91,54 @@ describe('Mentor routes (integration)', () => {
     const status = await request(app).get('/mentor/status');
     expect(status.body.lastResult?.ran).toBe(true);
     expect(status.body.lastResult?.mode).toBe('dry-run');
+  });
+
+  it('POST /mentor/tick routes to the autonomous-fix guardian when enabled; spawns a loop session', async () => {
+    const spawnLoopSession = vi.fn(async () => ({ sessionName: 'mentor-autoloop-int' }));
+    const cfg: MentorConfig = {
+      ...DEFAULT_MENTOR_CONFIG,
+      enabled: true,
+      mode: 'off', // guardian runs regardless of mode
+      autonomousFix: { enabled: true, model: 'opus', sessionNamePrefix: 'mentor-autoloop' },
+    };
+    const svc: MentorRunnerServices = {
+      ...fakeServices(),
+      loopSessionAlive: () => false,
+      spawnLoopSession,
+      buildAutoloopGoal: () => 'GOAL',
+    };
+    const runner = new MentorOnboardingRunner(svc, () => cfg);
+    const app = appWith(runner);
+    const res = await request(app).post('/mentor/tick');
+    expect(res.status).toBe(202);
+    expect(res.body.accepted).toBe(true);
+    await new Promise((r) => setTimeout(r, 10));
+    const status = await request(app).get('/mentor/status');
+    expect(status.body.lastResult?.reason).toBe('spawned');
+    expect(status.body.lastResult?.sessionName).toBe('mentor-autoloop-int');
+    expect(spawnLoopSession).toHaveBeenCalledOnce();
+  });
+
+  it('POST /mentor/tick guardian path respects single-instance over HTTP (loop-active, no spawn)', async () => {
+    const spawnLoopSession = vi.fn(async () => ({ sessionName: 'x' }));
+    const cfg: MentorConfig = {
+      ...DEFAULT_MENTOR_CONFIG,
+      enabled: true,
+      mode: 'off',
+      autonomousFix: { enabled: true, model: 'opus', sessionNamePrefix: 'mentor-autoloop' },
+    };
+    const svc: MentorRunnerServices = {
+      ...fakeServices(),
+      loopSessionAlive: () => true, // a cycle is already running
+      spawnLoopSession,
+      buildAutoloopGoal: () => 'GOAL',
+    };
+    const runner = new MentorOnboardingRunner(svc, () => cfg);
+    const app = appWith(runner);
+    await request(app).post('/mentor/tick');
+    await new Promise((r) => setTimeout(r, 10));
+    const status = await request(app).get('/mentor/status');
+    expect(status.body.lastResult?.reason).toBe('loop-active');
+    expect(spawnLoopSession).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/ConfigDefaults.test.ts
+++ b/tests/unit/ConfigDefaults.test.ts
@@ -103,6 +103,25 @@ describe('ConfigDefaults', () => {
       expect(changes.some((c: string) => c.includes('sessionPool'))).toBe(true);
     });
 
+    it('migrates mentor.autonomousFix (dark) into an EXISTING mentor block on update (parity)', () => {
+      // An agent that already had the mentor block (pre-autonomous-fix) must
+      // receive the new dark autonomousFix sub-block on update — so the "just be
+      // Echo" loop is discoverable + opt-in, never silently absent.
+      const config: any = { mentor: { enabled: false, mode: 'off', menteeFramework: 'codex-cli' } };
+      const { patched } = applyDefaults(config, getMigrationDefaults('managed-project'));
+      expect(patched).toBe(true);
+      expect(config.mentor.menteeFramework).toBe('codex-cli'); // existing field preserved
+      expect(config.mentor.autonomousFix.enabled).toBe(false); // ships dark
+      expect(config.mentor.autonomousFix.model).toBe('opus'); // Justin's constraint
+    });
+
+    it('does NOT overwrite an operator-enabled mentor.autonomousFix on re-migration (idempotent)', () => {
+      const config: any = { mentor: { enabled: true, autonomousFix: { enabled: true, model: 'opus' } } };
+      const { changes } = applyDefaults(config, getMigrationDefaults('managed-project'));
+      expect(config.mentor.autonomousFix.enabled).toBe(true); // operator choice kept
+      expect(changes.some((c: string) => c.includes('autonomousFix.enabled'))).toBe(false);
+    });
+
     it('migrates an inert multiMachine:{sessionPool} into a config with NO multiMachine block (does not enable it)', () => {
       const config: any = { monitoring: {} };
       applyDefaults(config, getMigrationDefaults('managed-project'));

--- a/tests/unit/MentorAutonomousGuardian.test.ts
+++ b/tests/unit/MentorAutonomousGuardian.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tier-1 unit tests for MentorAutonomousGuardian — the pure "just be Echo"
+ * autonomous-fix loop core (MENTOR-AUTONOMOUS-FIX-LOOP-SPEC).
+ *
+ * The guardian's job is the gate sequence (enabled → budget → single-instance →
+ * min-interval → spawn); every side-effect is injected, so this exercises BOTH
+ * sides of every decision boundary with no SessionManager/tmux/LLM. Plus
+ * buildAutoloopGoal's deterministic prompt assembly.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runAutonomousGuardian,
+  buildAutoloopGoal,
+  type AutonomousGuardianDeps,
+} from '../../src/scheduler/MentorAutonomousGuardian.js';
+
+function deps(over: Partial<AutonomousGuardianDeps> = {}): AutonomousGuardianDeps {
+  return {
+    framework: 'codex-cli',
+    enabled: true,
+    budgetOk: true,
+    loopSessionAlive: false,
+    minIntervalElapsed: true,
+    model: 'opus',
+    buildGoal: () => 'GOAL',
+    spawnLoopSession: vi.fn(async () => ({ sessionName: 'mentor-autoloop-123' })),
+    ...over,
+  };
+}
+
+describe('runAutonomousGuardian — gate sequence', () => {
+  it('spawns one Opus loop session when all gates pass (happy path)', async () => {
+    const spawn = vi.fn(async () => ({ sessionName: 'mentor-autoloop-999' }));
+    const d = deps({ spawnLoopSession: spawn });
+    const r = await runAutonomousGuardian(d);
+    expect(r).toEqual({ ran: true, reason: 'spawned', sessionName: 'mentor-autoloop-999' });
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(spawn).toHaveBeenCalledWith('GOAL', 'opus');
+  });
+
+  it('disabled → no spawn, reason=disabled (ships dark)', async () => {
+    const spawn = vi.fn(async () => ({ sessionName: 'x' }));
+    const r = await runAutonomousGuardian(deps({ enabled: false, spawnLoopSession: spawn }));
+    expect(r).toEqual({ ran: false, reason: 'disabled' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('budget depleted → no spawn, reason=budget (fail-closed BEFORE spend)', async () => {
+    const spawn = vi.fn(async () => ({ sessionName: 'x' }));
+    const r = await runAutonomousGuardian(deps({ budgetOk: false, spawnLoopSession: spawn }));
+    expect(r).toEqual({ ran: false, reason: 'budget' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('a loop session already alive → no spawn, reason=loop-active (single-instance)', async () => {
+    const spawn = vi.fn(async () => ({ sessionName: 'x' }));
+    const r = await runAutonomousGuardian(deps({ loopSessionAlive: true, spawnLoopSession: spawn }));
+    expect(r).toEqual({ ran: false, reason: 'loop-active' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('min-interval not elapsed → no spawn, reason=unsafe-interval (anti spawn-storm)', async () => {
+    const spawn = vi.fn(async () => ({ sessionName: 'x' }));
+    const r = await runAutonomousGuardian(deps({ minIntervalElapsed: false, spawnLoopSession: spawn }));
+    expect(r).toEqual({ ran: false, reason: 'unsafe-interval' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('spawn throws → reason=spawn-failed with the surfaced error (not a silent no-op)', async () => {
+    const spawn = vi.fn(async () => {
+      throw new Error('session cap reached');
+    });
+    const r = await runAutonomousGuardian(deps({ spawnLoopSession: spawn }));
+    expect(r.ran).toBe(false);
+    expect(r.reason).toBe('spawn-failed');
+    expect(r.error).toContain('session cap reached');
+  });
+
+  it('gate order is load-bearing: budget is checked before single-instance', async () => {
+    // Both budget-depleted AND a loop alive: budget must win (it is earlier).
+    const r = await runAutonomousGuardian(deps({ budgetOk: false, loopSessionAlive: true }));
+    expect(r.reason).toBe('budget');
+  });
+
+  it('single-instance is checked before min-interval', async () => {
+    // Both a loop alive AND interval not elapsed: loop-active must win (earlier).
+    const r = await runAutonomousGuardian(deps({ loopSessionAlive: true, minIntervalElapsed: false }));
+    expect(r.reason).toBe('loop-active');
+  });
+
+  it('disabled wins over every other failing gate', async () => {
+    const r = await runAutonomousGuardian(
+      deps({ enabled: false, budgetOk: false, loopSessionAlive: true, minIntervalElapsed: false }),
+    );
+    expect(r.reason).toBe('disabled');
+  });
+
+  it('passes the configured model through to the spawn (not hard-coded)', async () => {
+    const spawn = vi.fn(async () => ({ sessionName: 'm' }));
+    await runAutonomousGuardian(deps({ model: 'sonnet', spawnLoopSession: spawn }));
+    expect(spawn).toHaveBeenCalledWith('GOAL', 'sonnet');
+  });
+});
+
+describe('buildAutoloopGoal — deterministic prompt assembly', () => {
+  it('encodes the full cycle: health → assign → observe → fix-as-PR → report', () => {
+    const goal = buildAutoloopGoal({
+      menteeAgentName: 'instar-codey',
+      menteeFramework: 'codex-cli',
+      reportTopicId: 13435,
+      menteeTopicId: 458,
+    });
+    expect(goal).toContain('instar-codey');
+    expect(goal).toContain('codex-cli');
+    expect(goal).toMatch(/HEALTH FIRST/);
+    expect(goal).toMatch(/ASSIGN/);
+    expect(goal).toMatch(/OBSERVE BOTH SIDES/);
+    expect(goal).toMatch(/FIX/);
+    expect(goal).toContain('topic 13435'); // report topic
+    expect(goal).toContain('topic 458'); // drive topic
+    // The ship discipline + anti-confabulation must be in the prompt.
+    expect(goal).toMatch(/JKHeadley\/main/);
+    expect(goal).toMatch(/verify before you claim/i);
+    expect(goal).toMatch(/one cycle, then exit/i);
+  });
+
+  it('degrades gracefully when topics are unset (no "topic undefined" text)', () => {
+    const goal = buildAutoloopGoal({ menteeAgentName: 'instar-codey', menteeFramework: 'codex-cli' });
+    expect(goal).not.toContain('undefined');
+    expect(goal).toMatch(/over Telegram/);
+  });
+});

--- a/tests/unit/MentorOnboardingRunner.test.ts
+++ b/tests/unit/MentorOnboardingRunner.test.ts
@@ -132,3 +132,103 @@ describe('MentorOnboardingRunner', () => {
     expect(lr?.error).toContain('spawn refused: session cap reached');
   });
 });
+
+describe('MentorOnboardingRunner — autonomous-fix guardian branch ("just be Echo")', () => {
+  function autoCfg(over: Partial<MentorConfig> = {}): MentorConfig {
+    return {
+      ...DEFAULT_MENTOR_CONFIG,
+      enabled: true,
+      mode: 'off', // the guardian must run REGARDLESS of mode
+      autonomousFix: { enabled: true, model: 'opus', sessionNamePrefix: 'mentor-autoloop' },
+      ...over,
+    };
+  }
+
+  it('routes to the guardian (NOT the observe-pipeline) when autonomousFix.enabled, even with mode:off', async () => {
+    const spawnStageA = vi.fn(async () => 'should-not-be-called');
+    const spawnLoopSession = vi.fn(async () => ({ sessionName: 'mentor-autoloop-1' }));
+    const svc = fakeServices({
+      spawnStageA,
+      loopSessionAlive: () => false,
+      spawnLoopSession,
+      buildAutoloopGoal: () => 'GOAL',
+    });
+    const runner = new MentorOnboardingRunner(svc, () => autoCfg());
+    const r = await runner.tick();
+    expect(r.reason).toBe('spawned');
+    expect(r.ran).toBe(true);
+    expect(r.sessionName).toBe('mentor-autoloop-1');
+    // The observe-pipeline's Stage-A compose must NEVER run on the guardian path.
+    expect(spawnStageA).not.toHaveBeenCalled();
+    expect(spawnLoopSession).toHaveBeenCalledOnce();
+  });
+
+  it('single-instance: a live loop session short-circuits to loop-active (no second spawn)', async () => {
+    const spawnLoopSession = vi.fn(async () => ({ sessionName: 'x' }));
+    const svc = fakeServices({
+      loopSessionAlive: () => true,
+      spawnLoopSession,
+      buildAutoloopGoal: () => 'GOAL',
+    });
+    const runner = new MentorOnboardingRunner(svc, () => autoCfg());
+    const r = await runner.tick();
+    expect(r.reason).toBe('loop-active');
+    expect(spawnLoopSession).not.toHaveBeenCalled();
+  });
+
+  it('a spawned cycle advances the run counters (onTickRan) once', async () => {
+    const onTickRan = vi.fn();
+    const svc = fakeServices({
+      loopSessionAlive: () => false,
+      spawnLoopSession: async () => ({ sessionName: 'mentor-autoloop-2' }),
+      buildAutoloopGoal: () => 'GOAL',
+      onTickRan,
+    });
+    const runner = new MentorOnboardingRunner(svc, () => autoCfg());
+    await runner.tick();
+    expect(onTickRan).toHaveBeenCalledOnce();
+  });
+
+  it('a skipped cycle (loop-active) does NOT advance the run counters', async () => {
+    const onTickRan = vi.fn();
+    const svc = fakeServices({
+      loopSessionAlive: () => true,
+      spawnLoopSession: async () => ({ sessionName: 'x' }),
+      buildAutoloopGoal: () => 'GOAL',
+      onTickRan,
+    });
+    const runner = new MentorOnboardingRunner(svc, () => autoCfg());
+    await runner.tick();
+    expect(onTickRan).not.toHaveBeenCalled();
+  });
+
+  it('autonomousFix.enabled but spawnLoopSession not wired → clear spawn-failed (not a silent no-op)', async () => {
+    // Host enabled the feature but forgot to inject the spawner: must surface.
+    const svc = fakeServices({ loopSessionAlive: () => false, buildAutoloopGoal: () => 'GOAL' });
+    const runner = new MentorOnboardingRunner(svc, () => autoCfg());
+    const r = await runner.tick();
+    expect(r.reason).toBe('spawn-failed');
+    expect(r.error).toMatch(/spawnLoopSession not wired/);
+  });
+
+  it('still ships dark: autonomousFix present but enabled:false runs the observe-pipeline, not the guardian', async () => {
+    const spawnLoopSession = vi.fn(async () => ({ sessionName: 'x' }));
+    const svc = fakeServices({ spawnLoopSession, loopSessionAlive: () => false });
+    const cfg = autoCfg({ mode: 'dry-run', autonomousFix: { enabled: false, model: 'opus' } });
+    const runner = new MentorOnboardingRunner(svc, () => cfg);
+    const r = await runner.tick();
+    expect(r.reason).not.toBe('spawned');
+    expect(spawnLoopSession).not.toHaveBeenCalled();
+    expect(svc.spawnStageA).toHaveBeenCalled(); // observe-pipeline ran instead
+  });
+
+  it('mentor.enabled:false keeps the guardian dark even with autonomousFix.enabled', async () => {
+    const spawnLoopSession = vi.fn(async () => ({ sessionName: 'x' }));
+    const svc = fakeServices({ spawnLoopSession, loopSessionAlive: () => false });
+    const cfg = autoCfg({ enabled: false });
+    const runner = new MentorOnboardingRunner(svc, () => cfg);
+    const r = await runner.tick();
+    expect(r.reason).toBe('disabled');
+    expect(spawnLoopSession).not.toHaveBeenCalled();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,7 +1,7 @@
 ---
 review-convergence: complete
 approved: true
-approved-by: justin (verbal, topic 2169: "Please proceed as you best to see fit" — my judgment-call to ship lever D next per the post-mortem ordering I proposed)
+approved-by: justin (verbal — topic 13435: the mentor autonomous-fix loop "just be you taking on that job"; topic 2169: post-mortem lever D "proceed as you best see fit")
 ---
 
 # Upgrade Guide — vNEXT
@@ -10,91 +10,46 @@ approved-by: justin (verbal, topic 2169: "Please proceed as you best to see fit"
 
 ## What Changed
 
-**Pipeline post-mortem lever D: a new unit lint refuses bare `catch {}`
-blocks unless they carry the `@silent-fallback-ok` annotation.**
+**1. Mentor Autonomous-Fix Loop ("just be Echo").** The Framework-Onboarding
+mentor can now do the WHOLE dogfooding loop automatically, on an Opus model —
+not just observe-and-log. Until now the mentor heartbeat only watched: it sent
+the mentee a check-in (written by a small model), read the mentee's signals, and
+logged findings to a read-only ledger. It never FIXED anything. A new dark switch
+turns the heartbeat into a GUARDIAN: each tick it checks four gates (enabled →
+budget → single-instance → min-interval) and, if they pass, keeps ONE full-tool
+**Opus** session — an Echo clone — alive on the manual loop: health-check the
+mentee (recover it if down) → assign one real task over Telegram → observe the UX
++ the mentee's internals → FIX any issue as a proper fleet PR through the full
+ship gate → report, then exit. The single-instance gate is load-bearing: a cycle
+outlives many heartbeats, so it stops the 15-minute tick from spawn-storming
+expensive Opus sessions. Ships dark (off by default).
 
-Closes the post-mortem's pattern #4 — "silent failure caught only by
-user." Worst recent instance: the **PromptGate $452 incident**, a bare
-`catch {}` in a 5-second hot-path detection loop that swallowed every
-rate-limit failure for hours, bypassing both QuotaTracker and LlmQueue
-spend guards. By the time it surfaced, $452 was gone.
-
-The seven existing offenders on main are annotated in this same PR
-(five in `src/paste/PasteManager.ts` for unlink/stat cleanup, one each
-for the pending-index reader, the audit-log append, and the tunnel-URL
-fallback in `routes.ts`). Each annotation documents WHY the silent
-swallow is safe. The ratchet baseline starts at zero so every future
-bare catch must be annotated or have a real body before commit.
-
-This lint is COMPLEMENTARY to the existing `no-silent-fallbacks.test.ts`
-(which catches catches that produce a degraded value: `return null`
-etc.). This new lint catches the shape THAT one misses: catches that
-produce no value, no log, no nothing.
-
-This is the last of the small post-mortem PRs (lever B —
-real-world-state fixture tests — is bigger and deserves its own
-conversation).
-
-## What to Tell Your User
-
-Nothing visible. If you write new code that tries to ship a bare
-`catch {}` block, the unit suite will fail with a message naming
-PromptGate and the post-mortem context. Fix: either give the catch a
-real body, or add `@silent-fallback-ok` with a one-line rationale.
-
-## Summary of New Capabilities
-
-| Capability | How to Use |
-|-----------|-----------|
-| Bare `catch {}` blocks are refused at commit time | Automatic. Add `// @silent-fallback-ok — <why>` on the line above the catch, or `catch { /* @silent-fallback-ok */ }` inside the braces. |
-| Annotated existing offenders documented | The 7 sites (PasteManager, routes.ts) carry `@silent-fallback-ok` with rationale per site. |
-| Focused PromptGate.ts regression check | Zero-tolerance assertion on the file that gave the post-mortem its poster-child incident — it can never silently regress. |
-
-## Evidence
-
-- 4 new unit tests (files-to-analyze sanity, ratchet baseline, PromptGate
-  zero-tolerance, annotation-parser sanity). Verified positive (passes
-  on current code) and destructive-negative (adding an unannotated bare
-  catch fails the ratchet with a message naming the post-mortem).
-- `tsc --noEmit` clean.
-- 7 offenders annotated in-PR — `PasteManager.ts` (×5 cleanup, ×1
-  pending-index read, ×1 audit-log append) and `server/routes.ts` (×1
-  tunnel-url fallback). No functional changes; only annotations.
-- Side-effects review:
-  `upgrades/side-effects/no-empty-catch-blocks-lint.md`.
-
----
-
-## What Changed — Mentor Autonomous-Fix Loop ("just be Echo")
-
-**The Framework-Onboarding mentor can now do the WHOLE dogfooding loop
-automatically, on an Opus model — not just observe-and-log.**
-
-Until now the mentor heartbeat only watched: it sent the mentee a check-in
-(written by a small model), read the mentee's signals, and logged findings to a
-read-only ledger. It never FIXED anything — the "watch the experience and fix
-what's broken as shipped code" half was always done by a developer by hand.
-
-A new dark switch, `mentor.autonomousFix.enabled`, turns the heartbeat into a
-GUARDIAN: each tick it checks four gates (enabled → budget → single-instance →
-min-interval) and, if they pass, keeps ONE full-tool **Opus** session — an Echo
-clone — alive on the manual loop: health-check the mentee (recover it if down) →
-assign one real task over Telegram → observe the UX + the mentee's internals →
-FIX any issue as a proper fleet PR through the full ship gate → report, then
-exit. The guardian starts the next cycle on its own heartbeat.
-
-The single-instance gate is the load-bearing one: a cycle outlives many
-heartbeats, so it stops the 15-minute tick from spawn-storming expensive Opus
-sessions. Budget + min-interval add two more bounds.
+**2. Pipeline post-mortem lever D: a unit lint refuses bare `catch {}` blocks**
+unless they carry the `@silent-fallback-ok` annotation. Closes the post-mortem's
+pattern #4 — "silent failure caught only by user." Worst recent instance: the
+PromptGate $452 incident, a bare `catch {}` in a 5-second hot-path detection loop
+that swallowed every rate-limit failure for hours, bypassing both QuotaTracker
+and LlmQueue spend guards. The seven existing offenders on main are annotated in
+the same PR (five in `PasteManager.ts`, one each for the pending-index reader, the
+audit-log append, and the tunnel-URL fallback in `routes.ts`). The ratchet
+baseline starts at zero, so every future bare catch must be annotated or have a
+real body before commit. This is complementary to `no-silent-fallbacks.test.ts`,
+which catches the shape this one misses: catches that produce no value, no log,
+nothing.
 
 ## What to Tell Your User
 
-Only relevant if you run the (off-by-default) Framework-Onboarding mentor. The
-mentor can now optionally fix issues it finds — fully autonomously, on Opus —
-instead of only logging them. It ships OFF; enable per agent with
-`mentor.autonomousFix.enabled: true`. Watch it via `GET /mentor/status`
-(`lastResult.reason` = `spawned` / `loop-active` / `budget` / …) and the PRs it
-opens.
+Two things, both mostly behind the scenes.
+
+First, if you run the (off-by-default) Framework-Onboarding mentor, it can now
+optionally FIX the issues it finds — fully autonomously, on an Opus model —
+instead of only logging them. It still ships off; just ask me to turn on the
+autonomous mentor loop for an agent and I'll enable it. You can watch what it
+does through the mentor status and the pull requests it opens.
+
+Second, nothing visible: an internal code-quality guard for instar's own
+development now stops a new empty error-swallowing block from shipping. Nothing
+changes in how I work day to day.
 
 ## Summary of New Capabilities
 
@@ -102,18 +57,24 @@ opens.
 |-----------|-----------|
 | Autonomous-fix mentor loop (Opus) | `.instar/config.json` → `mentor.autonomousFix.enabled: true` (default false) |
 | Single-instance + budget + min-interval gating | Automatic — never more than one loop session; never idle-burns or spawn-storms |
-| Status visibility | `GET /mentor/status` → `lastResult.reason` (`spawned`, `loop-active`, …) |
+| Mentor loop status visibility | `GET /mentor/status` → `lastResult.reason` (`spawned`, `loop-active`, …) |
+| Bare `catch {}` blocks refused at commit time | Automatic. Add `// @silent-fallback-ok — <why>` above the catch, or a real body. |
 
 ## Evidence
 
-- 48 mentor tests green across all three tiers: unit guardian (every gate, both
-  sides, gate-order, spawn-failure surfacing, goal-prompt assembly) + runner
-  branch; integration `/mentor/tick` routes to the guardian over HTTP; E2E proves
-  the REAL production wiring spawns with the OPUS model + full tools + the real
-  dogfooding-loop prompt (via a spy SessionManager — no real spawn).
-- Migration-parity unit tests: an existing mentor block gains the dark
-  `autonomousFix` on update, idempotently.
-- `tsc --noEmit` clean.
-- Spec: `docs/specs/MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.md` (+ ELI16).
-- Side-effects review:
+- **Mentor autonomous-fix loop:** 48 mentor tests green across all three tiers —
+  unit guardian (every gate, both sides, gate-order, spawn-failure surfacing,
+  goal-prompt assembly) + runner branch; integration `/mentor/tick` routes to the
+  guardian over HTTP; E2E proves the REAL production wiring spawns with the OPUS
+  model + full tools + the real dogfooding-loop prompt (via a spy SessionManager —
+  no real spawn). Migration-parity unit tests: an existing mentor block gains the
+  dark `autonomousFix` on update, idempotently. Spec:
+  `docs/specs/MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.md` (+ ELI16). Side-effects:
   `upgrades/side-effects/mentor-autonomous-fix-loop.md`.
+- **Bare-catch lint:** 4 new unit tests (files-to-analyze sanity, ratchet
+  baseline, PromptGate zero-tolerance, annotation-parser sanity), verified
+  positive (passes on current code) and destructive-negative (an unannotated bare
+  catch fails the ratchet with a message naming the post-mortem). 7 offenders
+  annotated in-PR with no functional change. Side-effects:
+  `upgrades/side-effects/no-empty-catch-blocks-lint.md`.
+- `tsc --noEmit` clean for both.

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -62,3 +62,58 @@ real body, or add `@silent-fallback-ok` with a one-line rationale.
   tunnel-url fallback). No functional changes; only annotations.
 - Side-effects review:
   `upgrades/side-effects/no-empty-catch-blocks-lint.md`.
+
+---
+
+## What Changed — Mentor Autonomous-Fix Loop ("just be Echo")
+
+**The Framework-Onboarding mentor can now do the WHOLE dogfooding loop
+automatically, on an Opus model — not just observe-and-log.**
+
+Until now the mentor heartbeat only watched: it sent the mentee a check-in
+(written by a small model), read the mentee's signals, and logged findings to a
+read-only ledger. It never FIXED anything — the "watch the experience and fix
+what's broken as shipped code" half was always done by a developer by hand.
+
+A new dark switch, `mentor.autonomousFix.enabled`, turns the heartbeat into a
+GUARDIAN: each tick it checks four gates (enabled → budget → single-instance →
+min-interval) and, if they pass, keeps ONE full-tool **Opus** session — an Echo
+clone — alive on the manual loop: health-check the mentee (recover it if down) →
+assign one real task over Telegram → observe the UX + the mentee's internals →
+FIX any issue as a proper fleet PR through the full ship gate → report, then
+exit. The guardian starts the next cycle on its own heartbeat.
+
+The single-instance gate is the load-bearing one: a cycle outlives many
+heartbeats, so it stops the 15-minute tick from spawn-storming expensive Opus
+sessions. Budget + min-interval add two more bounds.
+
+## What to Tell Your User
+
+Only relevant if you run the (off-by-default) Framework-Onboarding mentor. The
+mentor can now optionally fix issues it finds — fully autonomously, on Opus —
+instead of only logging them. It ships OFF; enable per agent with
+`mentor.autonomousFix.enabled: true`. Watch it via `GET /mentor/status`
+(`lastResult.reason` = `spawned` / `loop-active` / `budget` / …) and the PRs it
+opens.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Autonomous-fix mentor loop (Opus) | `.instar/config.json` → `mentor.autonomousFix.enabled: true` (default false) |
+| Single-instance + budget + min-interval gating | Automatic — never more than one loop session; never idle-burns or spawn-storms |
+| Status visibility | `GET /mentor/status` → `lastResult.reason` (`spawned`, `loop-active`, …) |
+
+## Evidence
+
+- 48 mentor tests green across all three tiers: unit guardian (every gate, both
+  sides, gate-order, spawn-failure surfacing, goal-prompt assembly) + runner
+  branch; integration `/mentor/tick` routes to the guardian over HTTP; E2E proves
+  the REAL production wiring spawns with the OPUS model + full tools + the real
+  dogfooding-loop prompt (via a spy SessionManager — no real spawn).
+- Migration-parity unit tests: an existing mentor block gains the dark
+  `autonomousFix` on update, idempotently.
+- `tsc --noEmit` clean.
+- Spec: `docs/specs/MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.md` (+ ELI16).
+- Side-effects review:
+  `upgrades/side-effects/mentor-autonomous-fix-loop.md`.

--- a/upgrades/side-effects/mentor-autonomous-fix-loop.md
+++ b/upgrades/side-effects/mentor-autonomous-fix-loop.md
@@ -1,0 +1,79 @@
+# Side-effects review — Mentor Autonomous-Fix Loop ("just be Echo")
+
+**Spec:** `docs/specs/MENTOR-AUTONOMOUS-FIX-LOOP-SPEC.md`
+**Change:** a config-gated GUARDIAN path on the mentor heartbeat that keeps one
+full-tool Opus session alive on the manual dogfooding loop (assign → observe →
+FIX as a fleet PR → report) instead of the haiku observe-and-log pipeline.
+**Class:** mentor capability (off by default; opt-in per agent).
+
+## What changed
+
+- **`src/scheduler/MentorAutonomousGuardian.ts`** (new) — pure
+  `runAutonomousGuardian(deps)` gate sequence + `buildAutoloopGoal(params)`
+  deterministic goal prompt. No I/O; every side-effect injected.
+- **`src/scheduler/MentorOnboardingRunner.ts`** — new `MentorAutonomousFixConfig`
+  type + optional `MentorConfig.autonomousFix`; three optional guardian services
+  on `MentorRunnerServices`; widened `MentorRunReason` + `sessionName` on
+  `MentorRunResult`; `tick()`/`startTick()` route to the guardian when
+  `autonomousFix.enabled` (regardless of `mode`); new private `autonomousTick`.
+- **`src/config/ConfigDefaults.ts`** — `mentor.autonomousFix` dark default added
+  to `SHARED_DEFAULTS`.
+- **`src/server/AgentServer.ts`** — wired `loopSessionAlive`, `spawnLoopSession`
+  (full-tool Opus spawn), `buildAutoloopGoal` into `buildMentorRunner`.
+- **`src/core/PostUpdateMigrator.ts`** — CLAUDE.md mentor section gains the
+  autonomous-fix paragraph (new-agent text + a content-sniffed parity paragraph
+  for agents that already have the section).
+
+## Blast radius
+
+- **Observe-pipeline:** unchanged. The guardian is a separate branch reached only
+  when `autonomousFix.enabled`. With the dark default, every existing agent runs
+  exactly the prior code path.
+- **`runMentorTick` (pure):** untouched — the guardian is a sibling module, not a
+  modification of the tick core.
+- **Config reads:** `readMentorConfigFromDisk` already spreads
+  `{...DEFAULT_MENTOR_CONFIG, ...parsed.mentor}`; an absent `autonomousFix` reads
+  as `undefined` → disabled. Safe for every config on disk today.
+- **Session spawn:** the loop session uses the normal `spawnSession` path
+  (full-tool, like a regular session) — no new spawn machinery. The only new
+  behaviour is that, when ENABLED, the heartbeat can start a session; the four
+  gates bound that.
+- **Other subsystems / DB schema / HTTP routes:** none added or changed. The
+  guardian rides the existing `/mentor/tick` + `/mentor/status` routes.
+
+## What could break (and why it doesn't)
+
+- **Spawn-storm of expensive Opus sessions?** The single-instance gate
+  (`loopSessionAlive`) makes the heartbeat a no-op while a cycle is running; a
+  cycle outlives many heartbeats. Budget + min-interval add two more bounds.
+- **Enabled but no spawner wired?** Surfaces as `reason: 'spawn-failed'` with a
+  clear message in `/mentor/status.lastResult.error` — never a silent no-op.
+- **Autonomous code landing untested?** The spawned Echo passes the same husky +
+  instar-dev + CI gates as an interactive developer; those are framework-agnostic.
+- **`mode: 'off'` blocking it?** Intentional: the guardian is a distinct path that
+  keys on `enabled && autonomousFix.enabled`, so `mode` (which gates only the
+  haiku pipeline) does not disable it.
+
+## Security
+
+No new external input, network, auth, or fs surface. The loop session is spawned
+through the existing SessionManager with the agent's normal tool grant. Spawning
+is gated behind an opt-in dark flag.
+
+## Migration parity
+
+`mentor.autonomousFix` is in `SHARED_DEFAULTS`, so `migrateConfig`'s `applyDefaults`
+deep-merge adds the dark sub-block to existing agents on update
+(existence-checked). CLAUDE.md parity handled in `migrateClaudeMd`. No new job.
+
+## Rollback
+
+Set `mentor.autonomousFix.enabled: false` (or remove the block) — instantly back
+to the observe-pipeline. Revert the commit to remove the code; no persisted state,
+schema, or API contract is affected.
+
+## Tests
+
+48 mentor tests green across all three tiers (unit guardian + runner branch,
+integration routes, E2E production-wiring spawn with the Opus model + full tools),
+plus migration-parity unit tests. `tsc` clean.


### PR DESCRIPTION
## What

When `mentor.autonomousFix.enabled`, the Framework-Onboarding mentor heartbeat stops running the haiku **observe-and-log** pipeline and instead becomes a **guardian**: it keeps ONE full-tool **Opus** session — an Echo clone — alive on the manual dogfooding loop:

> health-check the mentee (recover it if down) → assign one real instar task over Telegram → observe the UX + the mentee's internals → **FIX** any issue as a proper fleet PR through the full ship gate → report → exit.

The guardian starts the next cycle on its own heartbeat. This closes the gap I verified with Justin: the automated job previously only *logged* findings to a read-only ledger; it never fixed anything (that was always manual).

## Why

Direct user directive (Justin, topic 13435, 2026-05-29): *"all the fixing is done by an opus model just like you're running now it should replicate exactly what you've been doing in this thread. In fact, if it could just be you taking on that job that would be ideal."*

## Gates (load-bearing order)

`enabled → budget → single-instance → min-interval → spawn`

The **single-instance** gate is the load-bearing one: a cycle (assign → observe → fix-as-PR → report) outlives many 15-min heartbeats, so it stops the heartbeat from spawn-storming expensive Opus sessions. Budget + min-interval add two more bounds. A spawn that throws surfaces as `reason: 'spawn-failed'` in `/mentor/status.lastResult.error` — never a silent no-op.

## Safety

- Ships **dark** (`mentor.autonomousFix.enabled` defaults false; opt-in per agent).
- The expensive Opus session spawns only behind all four gates.
- The spawned Echo ships through the **same** structural ship gate as an interactive developer (husky, instar-dev, CI branch protection) — those are framework-agnostic, so autonomous fixes can't land code that fails CI.
- `maxCycleMinutes` bounds a runaway cycle.

## Tests (48 mentor tests, all 3 tiers)

- **Unit** — `MentorAutonomousGuardian.test.ts` (every gate, both sides, gate-order, spawn-failure surfacing, goal-prompt assembly); runner-branch tests (routes to guardian regardless of `mode`; single-instance; counter advancement; unwired-spawner clear error; dark default).
- **Integration** — `/mentor/tick` routes to the guardian over HTTP + respects single-instance.
- **E2E** — the REAL AgentServer on the production init path spawns (via a spy SessionManager) with the **OPUS model**, the **full tool grant**, the autoloop name, and the real dogfooding-loop prompt — proving production wiring, no real spawn.
- **Migration parity** — existing mentor block gains the dark `autonomousFix` on update, idempotently.

`tsc` clean. Spec + ELI16 + side-effects artifact included. Ships dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)