### PR TITLE
fix(mentor): spawn autonomous-fix loop session with no project MCP (headless boot-hang)

### DIFF
--- a/docs/specs/LOOP-SESSION-NO-MCP-SPEC.eli16.md
+++ b/docs/specs/LOOP-SESSION-NO-MCP-SPEC.eli16.md
@@ -1,0 +1,42 @@
+# In plain English: stop the mentor loop's helper session from hanging on startup
+
+## What this is about
+
+The mentor "autonomous-fix loop" works by starting up a fresh AI session (a copy
+of Echo) every cycle to do real work — check on the other agent, fix bugs, ship
+the fix. That fresh session is started in the background, headless, with no
+human watching.
+
+## What went wrong
+
+When you start an AI session in this project, it normally loads a bunch of extra
+"tools" called MCP servers — things that let it use Fathom, a browser, and so on.
+Some of those tools need you to log in (an OAuth pop-up) the first time. But a
+headless background session has no screen and no human to click "approve" — so
+those login-required tools just sit there waiting forever, and the whole session
+gets stuck before it even starts doing its job.
+
+We saw this live: the first real loop session sat for four and a half minutes
+using almost no CPU, produced nothing, and never started its task. The startup
+was correct in every other way (right model, right instructions) — it was purely
+the tool-loading that jammed it.
+
+## What's new
+
+The loop session now starts with NO MCP tools at all. The AI command has a switch
+for this — basically "ignore the project's tool list and start with an empty one."
+The loop doesn't need any of those tools anyway: it talks to the other agent over
+Telegram and ships fixes using the built-in file and command tools. With the
+switch on, a session that used to hang for minutes now starts in about nine
+seconds.
+
+The switch is opt-in: only the loop session uses it. Every other kind of session
+in the system keeps all its tools exactly as before — nothing else changes.
+
+## What the reader needs to decide
+
+Nothing to configure. This is a reliability fix for the (off-by-default) mentor
+autonomous-fix loop, found by actually running it. A unit test checks the right
+switches are produced, and the end-to-end test proves the real startup path turns
+the switch on. The proof it works is the re-run: the loop session now boots and
+does its cycle instead of hanging.

--- a/docs/specs/LOOP-SESSION-NO-MCP-SPEC.md
+++ b/docs/specs/LOOP-SESSION-NO-MCP-SPEC.md
@@ -1,0 +1,89 @@
+---
+title: Mentor loop session spawns with no project MCP (headless MCP-boot stall fix)
+status: approved
+review-convergence: converged
+approved: true
+approval-basis: >
+  Live dogfood finding (Echo, 2026-05-30, topic 13435). After shipping the mentor
+  autonomous-fix loop (#554, v1.3.109), I deployed it and ran a real cycle. The
+  guardian spawned the Opus loop session correctly, but the spawned headless
+  session HUNG ~4.5 min at 0.1% CPU on MCP-server boot and never processed its
+  goal — the auth-required remote MCP servers in the project .mcp.json can't
+  complete OAuth in a headless `claude -p` run. This is the "observe and fix as
+  you go" loop Justin asked for (topic 13435: "replicate exactly what you've been
+  doing... if it could just be you taking on that job") doing its job: the
+  dogfood found a real bug in the feature, and this is the fix.
+eli16-overview: LOOP-SESSION-NO-MCP-SPEC.eli16.md
+date: 2026-05-30
+---
+
+# Mentor loop session spawns with no project MCP
+
+## Problem
+
+The mentor autonomous-fix loop (`mentor.autonomousFix`, #554) spawns a full-tool
+Opus session per cycle via `SessionManager.spawnSession`. A headless one-shot
+`claude -p` spawn inherits the project's `.mcp.json`, which for Echo includes
+interactively-authenticated remote MCP servers (Fathom's `mcp-remote`, the
+claude.ai connectors). Those can't complete their OAuth handshake in a headless
+run, so the session never finishes booting MCP and never processes its prompt.
+
+Verified live: the spawned loop session sat ~4.5 min at 0.1% CPU with no
+transcript and a parked event loop (`_pthread_cond_wait`); the MCP child
+processes (`@playwright/mcp`, `mcp-remote …fathom`) were alive at 0% CPU. The
+guardian's spawn was otherwise correct — right model (opus), right full-tool
+grant, the real dogfooding-loop goal — but the session was non-functional.
+
+## Fix
+
+Spawn the loop session with **no project MCP servers**. The claude CLI supports
+`--strict-mcp-config` ("only use MCP servers from `--mcp-config`, ignoring all
+other MCP configurations") and `--mcp-config` accepts an inline JSON string. An
+empty strict config — `--strict-mcp-config --mcp-config '{"mcpServers":{}}'` —
+makes claude start with zero MCP servers. Verified: a headless spawn that
+otherwise stalled now boots in ~9s.
+
+The loop session needs none of those MCP servers: it drives the mentee over
+Telegram (bash + the relay script / the mentor a2a HTTP), observes via the
+filesystem + HTTP, and ships fixes with built-in tools (Bash/Edit/Read/Write +
+git/gh via Bash). MCP is pure overhead for it, and the auth-required ones are an
+active hazard.
+
+### Components
+
+- **`claudeHeadlessExtraFlags(opts)` (pure, `frameworkSessionLaunch.ts`)** — the
+  single builder for the claude-code headless flags spliced before `-p`: the
+  existing `--allowedTools` scope and the new `--strict-mcp-config` no-MCP spawn.
+  Returns `[]` for non-claude frameworks or when neither is requested. Replaces
+  the two inline splice blocks in `SessionManager` with one tested function.
+- **`SessionManager.spawnSession({ disableProjectMcp })`** — a new opt-in option.
+  When set on a claude-code spawn, the helper emits the no-MCP flags. Default
+  unset ⇒ unchanged behaviour (project MCP loads as before).
+- **`spawnLoopSession` (`AgentServer`)** — passes `disableProjectMcp: true`.
+
+## Blast radius
+
+- Only the mentor loop spawn opts in. Every other `spawnSession` caller
+  (interactive sessions, mentee-handle, Stage-A, jobs) leaves `disableProjectMcp`
+  unset ⇒ identical argv to today. Stage-A already runs MCP-free in practice
+  (empty tool grant); regular sessions keep their MCP.
+- Codex spawns are unaffected (the helper returns `[]` for non-claude).
+- The `--allowedTools` behaviour is preserved exactly (same flags, now via the
+  shared helper).
+
+## Testing
+
+- **Tier 1 unit** — `claude-headless-extra-flags.test.ts`: every branch of the
+  helper (neither / allowlist only / MCP-disable only / both / empty allowlist /
+  non-claude), including that the MCP config is a valid EMPTY config.
+- **Tier 3 E2E** — `mentor-onboarding-lifecycle.test.ts` (extended): the REAL
+  AgentServer production wiring spawns the loop session with
+  `disableProjectMcp: true` (via the spy SessionManager), alongside the existing
+  opus / full-tools / name / goal assertions.
+- **Live re-dogfood** — after deploy, enable the loop, spawn a cycle, and confirm
+  the session boots and works (no MCP stall) instead of hanging.
+
+## Rollback
+
+Revert the commit, or stop passing `disableProjectMcp`. No persisted state,
+schema, config, or API contract changes.

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -56,6 +56,7 @@ import type { IntelligenceFramework } from './intelligenceProviderFactory.js';
 import {
   buildInteractiveLaunch,
   buildHeadlessLaunch,
+  claudeHeadlessExtraFlags,
   resolveInteractiveFramework,
   resolveModelForFramework,
 } from './frameworkSessionLaunch.js';
@@ -1064,6 +1065,17 @@ rm()  { "${shimRunner}" rm  "$@"; }
      *  Jobs leave this false and keep the workspace-write sandbox. No effect
      *  on non-codex frameworks. */
     codexAllowMcpTools?: boolean;
+    /** When true, a claude-code spawn launches with NO project MCP servers
+     *  (`--strict-mcp-config` + an empty `--mcp-config`), ignoring the project's
+     *  `.mcp.json`. This is required for headless one-shot spawns that don't need
+     *  MCP: the project's MCP set includes interactively-authenticated remote
+     *  servers (e.g. Fathom's `mcp-remote`, the claude.ai connectors) that can't
+     *  complete their OAuth handshake in a headless `claude -p` run, so the
+     *  session HANGS on boot and never processes its prompt. Verified live: the
+     *  mentor autonomous-fix loop session stalled ~4.5 min at 0.1% CPU on MCP
+     *  init; with this flag a headless spawn boots in ~9s. No effect on Codex
+     *  spawns (Codex MCP wiring is separate). */
+    disableProjectMcp?: boolean;
   }): Promise<Session> {
     const runningSessions = this.listRunningSessions();
     if (runningSessions.length >= this.config.maxSessions) {
@@ -1151,24 +1163,25 @@ rm()  { "${shimRunner}" rm  "$@"; }
       ...(options.codexAllowMcpTools ? { codexAllowMcpTools: true } : {}),
     });
 
-    // Per-job tool allowlist (INSTAR-JOBS-AS-AGENTMD spec §5): when the
-    // caller provides a non-empty `allowedTools` array, scope the spawned
-    // session. Currently Claude-only — `--allowedTools` is a Claude CLI
-    // flag with no Codex equivalent (Codex uses sandbox modes via the
-    // headless builder). For Codex spawns the allowlist is silently
-    // ignored; the spec's enforcement is via Codex sandbox flags upstream.
-    if (
-      headlessFramework === 'claude-code'
-      && options.allowedTools
-      && options.allowedTools.length > 0
-    ) {
-      // Insert --allowedTools <list> before the -p prompt positional so
-      // Claude CLI parses it correctly. The helper builds argv with
-      // structure [binary, --dangerously-skip-permissions, (--model X)?, -p, prompt]
-      // — splice right before -p.
+    // Extra claude-code headless flags, spliced before the `-p` prompt positional
+    // (argv structure: [binary, --dangerously-skip-permissions, (--model X)?, -p,
+    // prompt]). Currently Claude-only — Codex has no `--allowedTools`/MCP-config
+    // CLI equivalent (it uses sandbox modes via the headless builder), so the
+    // helper returns [] for Codex and the splice is skipped:
+    //  - `--allowedTools <list>` — per-job tool-scope allowlist (INSTAR-JOBS-AS-
+    //    AGENTMD §5).
+    //  - `--strict-mcp-config --mcp-config {}` — no-project-MCP spawn for headless
+    //    one-shot sessions that would otherwise hang on auth-required remote MCP
+    //    boot (the mentor autonomous-fix loop). See claudeHeadlessExtraFlags.
+    const extraClaudeFlags = claudeHeadlessExtraFlags({
+      framework: headlessFramework,
+      allowedTools: options.allowedTools,
+      disableProjectMcp: options.disableProjectMcp,
+    });
+    if (extraClaudeFlags.length > 0) {
       const dashPIndex = headlessSpec.argv.indexOf('-p');
       if (dashPIndex > 0) {
-        headlessSpec.argv.splice(dashPIndex, 0, '--allowedTools', options.allowedTools.join(','));
+        headlessSpec.argv.splice(dashPIndex, 0, ...extraClaudeFlags);
       }
     }
 

--- a/src/core/frameworkSessionLaunch.ts
+++ b/src/core/frameworkSessionLaunch.ts
@@ -458,3 +458,34 @@ export function buildHeadlessLaunch(
   }
   return builder(options);
 }
+
+/**
+ * Extra claude-code headless flags spliced before the `-p` prompt positional:
+ *  - `--allowedTools <list>` — the per-session tool-scope allowlist.
+ *  - `--strict-mcp-config --mcp-config {"mcpServers":{}}` — the no-project-MCP
+ *    spawn: a headless one-shot `claude -p` session that inherits the project
+ *    `.mcp.json` HANGS on boot when that set includes interactively-authenticated
+ *    remote MCP servers (they can't complete OAuth headless), so it never
+ *    processes its prompt. An empty strict MCP config makes claude ignore the
+ *    project config and start with zero MCP servers (verified live: a mentor
+ *    autonomous-fix loop session stalled ~4.5 min at 0.1% CPU on MCP init; with
+ *    this flag a headless spawn boots in ~9s).
+ *
+ * Returns `[]` for non-claude frameworks or when neither option is requested, so
+ * the caller can splice unconditionally. Pure + order-stable for testing.
+ */
+export function claudeHeadlessExtraFlags(opts: {
+  framework: IntelligenceFramework | string;
+  allowedTools?: string[];
+  disableProjectMcp?: boolean;
+}): string[] {
+  if (opts.framework !== 'claude-code') return [];
+  const flags: string[] = [];
+  if (opts.allowedTools && opts.allowedTools.length > 0) {
+    flags.push('--allowedTools', opts.allowedTools.join(','));
+  }
+  if (opts.disableProjectMcp) {
+    flags.push('--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}');
+  }
+  return flags;
+}

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -1872,11 +1872,17 @@ export class AgentServer {
           // ship fixes. Opus by config (Justin's constraint: all fixing on Opus).
           // spawnSession resolves once the session has STARTED (not completed),
           // so the guardian returns 'spawned' immediately while the cycle runs.
+          // disableProjectMcp: a headless one-shot session that inherits the
+          // project .mcp.json HANGS on boot (the auth-required remote MCP servers
+          // can't OAuth headless). The loop uses built-in tools + bash + curl, not
+          // MCP — so spawn with NO project MCP servers (verified: 4.5-min stall →
+          // ~9s boot). Found by the live dogfood of the autonomous-fix loop.
           await self.sessionManager.spawnSession({
             name,
             prompt: goal,
             model: model || 'opus',
             maxDurationMinutes: Math.max(5, maxCycleMinutes),
+            disableProjectMcp: true,
           });
           return { sessionName: name };
         },

--- a/tests/e2e/mentor-onboarding-lifecycle.test.ts
+++ b/tests/e2e/mentor-onboarding-lifecycle.test.ts
@@ -271,6 +271,10 @@ describe('Autonomous-fix loop E2E (alive on the production init path, no real sp
     expect(String(spawnArgs.name)).toMatch(/^mentor-autoloop-/);
     expect(spawnArgs.allowedTools).toBeUndefined(); // full tools, not [] (Stage-A)
     expect(spawnArgs.maxDurationMinutes).toBe(90);
+    // No-project-MCP: the loop session must spawn WITHOUT the project .mcp.json,
+    // or a headless run hangs on auth-required remote MCP boot (the live dogfood
+    // finding). The production wiring passes disableProjectMcp through.
+    expect(spawnArgs.disableProjectMcp).toBe(true);
     // The goal prompt is the real dogfooding loop (not empty / not a stub).
     expect(String(spawnArgs.prompt)).toMatch(/instar-codey/);
     expect(String(spawnArgs.prompt)).toMatch(/HEALTH FIRST/);

--- a/tests/unit/claude-headless-extra-flags.test.ts
+++ b/tests/unit/claude-headless-extra-flags.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tier-1 unit tests for claudeHeadlessExtraFlags — the pure builder for the
+ * extra claude-code headless flags spliced before `-p` (the per-job
+ * `--allowedTools` scope and the no-project-MCP `--strict-mcp-config` spawn).
+ *
+ * The MCP-disable path is the fix for a live dogfood finding: a headless mentor
+ * autonomous-fix loop session inherited the project `.mcp.json` and HUNG ~4.5min
+ * on auth-required remote MCP boot. `--strict-mcp-config` + an empty `--mcp-config`
+ * makes claude start with zero MCP servers (verified: ~9s boot).
+ */
+import { describe, it, expect } from 'vitest';
+import { claudeHeadlessExtraFlags } from '../../src/core/frameworkSessionLaunch.js';
+
+describe('claudeHeadlessExtraFlags', () => {
+  it('returns [] when neither option is requested (full-tool, project-MCP spawn)', () => {
+    expect(claudeHeadlessExtraFlags({ framework: 'claude-code' })).toEqual([]);
+  });
+
+  it('emits --strict-mcp-config + an EMPTY --mcp-config when disableProjectMcp is set', () => {
+    const flags = claudeHeadlessExtraFlags({ framework: 'claude-code', disableProjectMcp: true });
+    expect(flags).toEqual(['--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}']);
+    // The config must be EMPTY (no servers) — an inline string claude accepts.
+    expect(flags).toContain('{"mcpServers":{}}');
+    expect(JSON.parse(flags[flags.indexOf('--mcp-config') + 1])).toEqual({ mcpServers: {} });
+  });
+
+  it('emits --allowedTools for a non-empty allowlist', () => {
+    expect(claudeHeadlessExtraFlags({ framework: 'claude-code', allowedTools: ['Bash', 'Read'] }))
+      .toEqual(['--allowedTools', 'Bash,Read']);
+  });
+
+  it('omits --allowedTools for an empty allowlist (no scoping flag)', () => {
+    expect(claudeHeadlessExtraFlags({ framework: 'claude-code', allowedTools: [] })).toEqual([]);
+  });
+
+  it('combines both: allowlist then MCP-disable, all before -p (order-stable)', () => {
+    const flags = claudeHeadlessExtraFlags({
+      framework: 'claude-code',
+      allowedTools: ['Bash'],
+      disableProjectMcp: true,
+    });
+    expect(flags).toEqual([
+      '--allowedTools', 'Bash',
+      '--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}',
+    ]);
+  });
+
+  it('returns [] for non-claude frameworks even when options are set (Codex MCP is separate)', () => {
+    expect(claudeHeadlessExtraFlags({ framework: 'codex-cli', disableProjectMcp: true, allowedTools: ['Bash'] }))
+      .toEqual([]);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,55 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**The mentor autonomous-fix loop now spawns its per-cycle session with NO project
+MCP servers — fixing a headless boot-hang found by dogfooding the loop live.**
+
+The loop (shipped dark in v1.3.109) starts a full-tool Opus session each cycle. A
+headless `claude -p` spawn inherits the project `.mcp.json`, which includes
+interactively-authenticated remote MCP servers (Fathom's `mcp-remote`, the
+claude.ai connectors). Those can't complete their OAuth handshake headless, so
+the session hung on MCP boot — observed live at ~4.5 min, 0.1% CPU, no transcript,
+parked event loop — and never ran its cycle. The spawn was otherwise correct
+(opus, full tools, the real goal); only MCP-loading jammed it.
+
+The loop session now spawns with `--strict-mcp-config --mcp-config '{"mcpServers":{}}'`
+(zero MCP servers). It needs none — it drives the mentee over Telegram and ships
+fixes with built-in tools. A headless spawn that stalled now boots in ~9s. The
+flag is opt-in (`spawnSession({ disableProjectMcp: true })`); every other spawn
+keeps its MCP. The `--allowedTools` and new MCP-disable splices are unified in one
+tested pure helper (`claudeHeadlessExtraFlags`).
+
+## What to Tell Your User
+
+Only relevant if you run the (off-by-default) mentor autonomous-fix loop. I
+dogfooded it live and found its background worker session was hanging on startup
+— it was trying to load login-required tools that can't sign in without a human,
+so it froze before doing any work. I fixed it so the loop's worker starts with a
+clean, minimal toolset and boots in seconds instead of hanging. Nothing changes
+for any other session — they keep all their tools. This is the observe-and-fix
+loop doing its job, just with me driving it this round.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| No-MCP headless spawn option | `spawnSession({ disableProjectMcp: true })` (opt-in; used by the mentor loop) |
+| Mentor loop session boots reliably | Automatic when `mentor.autonomousFix.enabled` — no more MCP boot-hang |
+
+## Evidence
+
+- **Live reproduction (before):** the first real loop session (`mentor-autoloop-…`)
+  spawned as `claude --dangerously-skip-permissions --model opus -p '…'` and sat
+  ~4.5 min at 0.1% CPU, no transcript written, main thread in `_pthread_cond_wait`;
+  child procs `@playwright/mcp` and `mcp-remote …fathom` alive at 0% CPU.
+- **Fix verified (after):** `claude --strict-mcp-config --mcp-config '{"mcpServers":{}}'
+  --model haiku -p '…'` in the same project returned in ~9s with no MCP boot.
+- **Tests:** `tests/unit/claude-headless-extra-flags.test.ts` (6, every branch incl.
+  the empty-MCP-config validity); `tests/e2e/mentor-onboarding-lifecycle.test.ts`
+  (+1: the production loop spawn passes the no-MCP flag). Framework-launch
+  regression suite (56) green. `tsc` + lint clean.
+- Side-effects: `upgrades/side-effects/loop-session-no-mcp.md`. Spec:
+  `docs/specs/LOOP-SESSION-NO-MCP-SPEC.md`.

--- a/upgrades/side-effects/loop-session-no-mcp.md
+++ b/upgrades/side-effects/loop-session-no-mcp.md
@@ -1,0 +1,65 @@
+# Side-effects review — Mentor loop session spawns with no project MCP
+
+**Spec:** `docs/specs/LOOP-SESSION-NO-MCP-SPEC.md`
+**Change:** the mentor autonomous-fix loop spawns its per-cycle Opus session with
+no project MCP servers, so a headless spawn doesn't hang on auth-required remote
+MCP boot. Found by the live dogfood of the loop (#554).
+**Class:** mentor-loop reliability fix (the feature ships dark).
+
+## What changed
+
+- **`src/core/frameworkSessionLaunch.ts`** (+1 export) — `claudeHeadlessExtraFlags(opts)`:
+  the single pure builder for the claude-code headless flags spliced before `-p`
+  (the existing `--allowedTools` scope + the new `--strict-mcp-config --mcp-config
+  '{"mcpServers":{}}'` no-MCP spawn). Returns `[]` for non-claude / no options.
+- **`src/core/SessionManager.ts`** — new opt-in `spawnSession({ disableProjectMcp })`;
+  the two inline flag-splice blocks (`--allowedTools` + the new MCP-disable) are
+  replaced by one call to `claudeHeadlessExtraFlags`.
+- **`src/server/AgentServer.ts`** — `spawnLoopSession` passes `disableProjectMcp: true`.
+
+## Blast radius
+
+- **Other spawn callers:** unchanged. `disableProjectMcp` is opt-in (default
+  unset). Interactive sessions, mentee-handle spawns, Stage-A, and jobs leave it
+  unset ⇒ byte-identical argv to today (project MCP loads as before).
+- **`--allowedTools` behaviour:** preserved exactly — same flags, now built by the
+  shared helper instead of an inline splice. Covered by the existing
+  framework-launch unit suite (56 tests still green) + the new helper test.
+- **Codex spawns:** unaffected — the helper returns `[]` for non-claude
+  frameworks (Codex MCP wiring is separate, via sandbox modes).
+- **MCP for the loop session:** the loop drives the mentee over Telegram (bash +
+  relay / a2a HTTP) and ships fixes with built-in tools — it used no MCP, so
+  removing it has no functional loss, only removes the boot hazard.
+
+## What could break (and why it doesn't)
+
+- **Loop needs an MCP tool?** It doesn't — it uses built-in Bash/Edit/Read/Write
+  + git/gh via Bash, and Telegram via the relay script. If a future loop variant
+  needs a specific MCP, pass a curated `--mcp-config` rather than the project one.
+- **`--mcp-config` inline-string support?** Verified against the installed claude
+  CLI: `--mcp-config '{"mcpServers":{}}'` is accepted and starts zero servers
+  (a headless `-p` run that otherwise stalled booted in ~9s).
+- **Splice position?** The helper's flags are spliced before `-p` exactly like the
+  prior `--allowedTools` code; argv structure is unchanged otherwise.
+
+## Security
+
+No new external input / network / auth / fs surface. The change REMOVES MCP
+servers from one spawn path (strictly fewer external connections). The empty MCP
+config is a constant inline string.
+
+## Migration parity
+
+Server-internal session-spawn code — every agent gets it by running the new
+build. No config, schema, hook, or CLAUDE.md change. No PostUpdateMigrator entry.
+
+## Rollback
+
+Revert the commit, or stop passing `disableProjectMcp`. No persisted state.
+
+## Tests
+
+`tests/unit/claude-headless-extra-flags.test.ts` (+6): every helper branch incl.
+the empty-MCP-config validity. `tests/e2e/mentor-onboarding-lifecycle.test.ts`
+(+1 assertion): the production loop spawn passes `disableProjectMcp: true`.
+Framework-launch regression suite (56 tests) green. `tsc` + `npm run lint` clean.


### PR DESCRIPTION
## What

The mentor autonomous-fix loop (#554, shipped dark in v1.3.109) spawns a full-tool Opus session per cycle. **The live dogfood found that spawned session HANGS on boot:** a headless `claude -p` inherits the project `.mcp.json`, and the auth-required remote MCP servers (Fathom's `mcp-remote`, the claude.ai connectors) can't complete their OAuth handshake headless — so MCP init never finishes and the session never runs its goal.

**Observed live:** the loop session sat ~4.5 min at 0.1% CPU, no transcript written, main thread parked in `_pthread_cond_wait`, MCP child procs (`@playwright/mcp`, `mcp-remote …fathom`) alive at 0% CPU.

## Fix

Spawn the loop session with **no project MCP servers** — `--strict-mcp-config --mcp-config '{"mcpServers":{}}'` (zero servers). The loop needs none: it drives the mentee over Telegram (bash + relay / a2a HTTP) and ships fixes with built-in tools. **Verified:** a headless spawn that stalled now boots in ~9s.

- New opt-in `spawnSession({ disableProjectMcp })` (claude-code only; default unset = unchanged).
- `spawnLoopSession` passes `disableProjectMcp: true`.
- Unified the `--allowedTools` + new MCP-disable splices into one tested pure helper `claudeHeadlessExtraFlags` (allowlist behaviour preserved exactly).

## Why this is the right shape

This is the "observe and fix as you go" loop Justin asked for — the dogfood found a real bug in the feature, and this is the fix. Found by running it, fixed by running it again.

## Tests

- **Unit** — `claude-headless-extra-flags.test.ts` (6): every helper branch incl. the empty-MCP-config validity.
- **E2E** — `mentor-onboarding-lifecycle.test.ts` (+1): the REAL production loop spawn passes `disableProjectMcp: true`.
- Framework-launch + allowlist regression suites green (no behaviour change for existing spawns). `tsc` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)