### PR TITLE
feat(multi-machine): standby-no-poll Telegram guard — a standby joins the pool without owning the poll

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1734,6 +1734,21 @@ export interface MultiMachineConfig {
    * the single-awake seamlessness model above; a 1-machine agent is a no-op.
    */
   sessionPool?: SessionPoolConfig;
+  /**
+   * Whether THIS machine's lifeline owns the Telegram long-poll. Telegram allows
+   * exactly one getUpdates poller per bot token, so a second machine that also
+   * polls causes a permanent 409-conflict war and nondeterministic message
+   * delivery (the 2026-05-29 duplicate-poller incident). A standby machine MUST
+   * set this false so it runs the full server + joins the session pool WITHOUT
+   * polling Telegram — only the awake/primary machine polls.
+   *
+   * DEFAULT (undefined) = poll, so every existing single-machine agent is
+   * unchanged. Only a machine that explicitly sets `false` suppresses its poll.
+   * This is a per-machine LOCAL flag (read from this machine's own config); it
+   * does not require any shared/git-synced coordination, so a credential-less
+   * standby can honor it. Consumed by TelegramLifeline.start().
+   */
+  telegramPolling?: boolean;
 }
 
 /**

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -57,6 +57,7 @@ import {
   type VersionSkewBody,
 } from './forwardErrors.js';
 import { writeStartupMarker } from './startupMarker.js';
+import { shouldOwnTelegramPoll } from './telegramPollOwnership.js';
 import { writeLease as writePollOwnerLease } from './TelegramPollOwnerLease.js';
 import { RestartOrchestrator } from './RestartOrchestrator.js';
 import { detectLaunchdSupervised } from './detectLaunchdSupervised.js';
@@ -430,15 +431,34 @@ export class TelegramLifeline {
       console.log(pc.yellow('  Server failed to start — lifeline will keep trying'));
     }
 
-    // Flush stale Telegram connections before starting poll loop.
-    // After hard kills or sleep/wake, a previous long-poll connection may still be
-    // held by Telegram's servers, causing 409 Conflict errors for ~30s.
-    await this.flushStaleConnection();
+    // Telegram poll ownership (standby-no-poll guard). Telegram allows exactly
+    // ONE getUpdates poller per bot token; a second machine that also polls
+    // causes a permanent 409-conflict war and nondeterministic delivery (the
+    // 2026-05-29 duplicate-poller incident). A standby machine sets
+    // multiMachine.telegramPolling:false so it runs the full server + joins the
+    // session pool (supervisor.start() above already ran) WITHOUT polling.
+    // DEFAULT (undefined) = poll, so every existing single-machine agent is
+    // unchanged — only a machine that explicitly opts out is suppressed. This is
+    // a per-machine LOCAL flag, so a credential-less standby can honor it.
+    const telegramPollingEnabled = shouldOwnTelegramPoll(this.projectConfig);
+    if (telegramPollingEnabled) {
+      // Flush stale Telegram connections before starting poll loop.
+      // After hard kills or sleep/wake, a previous long-poll connection may still be
+      // held by Telegram's servers, causing 409 Conflict errors for ~30s.
+      await this.flushStaleConnection();
 
-    // Start Telegram polling
-    this.polling = true;
-    this.poll();
-    console.log(pc.green('  Telegram polling active'));
+      // Start Telegram polling
+      this.polling = true;
+      this.poll();
+      console.log(pc.green('  Telegram polling active'));
+    } else {
+      // Standby: do NOT touch Telegram (no flush, no getUpdates) — the awake
+      // machine owns the single poll slot. Server supervision + queue replay +
+      // restart-signal handling all continue, so this machine is a full,
+      // reachable pool member that simply never polls.
+      this.polling = false;
+      console.log(pc.yellow('  Telegram polling SUPPRESSED (standby: multiMachine.telegramPolling=false) — server runs without owning the poll slot'));
+    }
 
     // Start periodic queue replay (in case server comes back between health checks)
     this.replayInterval = setInterval(() => {

--- a/src/lifeline/telegramPollOwnership.ts
+++ b/src/lifeline/telegramPollOwnership.ts
@@ -1,0 +1,30 @@
+/**
+ * telegramPollOwnership — the pure predicate behind the standby-no-poll guard
+ * (Multi-Machine; the 2026-05-29 duplicate-poller 409 cure).
+ *
+ * Telegram allows exactly ONE getUpdates long-poll per bot token. The lifeline
+ * is the poller; with two machines both lifelines polled the same token → a
+ * permanent 409-conflict war and nondeterministic delivery. A standby machine
+ * must run the full server (so it still joins the session pool) but NOT own the
+ * Telegram poll. This decision is a per-machine LOCAL config read — no shared/
+ * git-synced coordination — so a credential-less standby can honor it.
+ *
+ * Pulled out as a pure function so the default-true semantics are unit-testable
+ * in isolation (TelegramLifeline.start() itself is not cleanly instantiable).
+ */
+
+/** The slice of config this decision reads. */
+export interface PollOwnershipConfig {
+  multiMachine?: { telegramPolling?: boolean };
+}
+
+/**
+ * Whether THIS machine's lifeline should own the Telegram long-poll.
+ *
+ * DEFAULT (flag undefined / multiMachine absent) = TRUE (poll), so every
+ * existing single-machine agent is unchanged. ONLY an explicit
+ * `multiMachine.telegramPolling === false` suppresses the poll (a standby).
+ */
+export function shouldOwnTelegramPoll(config: PollOwnershipConfig | undefined | null): boolean {
+  return config?.multiMachine?.telegramPolling !== false;
+}

--- a/tests/unit/lifeline/standby-no-poll-wiring.test.ts
+++ b/tests/unit/lifeline/standby-no-poll-wiring.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Standby-no-poll guard — wiring integrity (Multi-Machine; the 2026-05-29
+ * duplicate-poller 409 cure).
+ *
+ * Telegram allows exactly ONE getUpdates long-poll per bot token. The lifeline
+ * is the poller. With two machines, both lifelines polled the same token → a
+ * permanent 409-conflict war + nondeterministic delivery (half the user's
+ * messages stolen by the standby). The guard lets a standby run the FULL server
+ * (so it still joins the session pool) but NOT own the Telegram poll, gated on a
+ * per-machine LOCAL flag `multiMachine.telegramPolling` (default = poll, so every
+ * existing single-machine agent is unchanged).
+ *
+ * `TelegramLifeline.start()` isn't cleanly unit-instantiable (its constructor
+ * does loadConfig + registry + state-dir side effects), so — like
+ * version-skew-alert-routing.test.ts — this pins the wiring against source:
+ *   - the gate predicate is the default-true `!== false` form
+ *   - flushStaleConnection() + this.poll() are INSIDE the gate (suppressed when off)
+ *   - supervisor.start() is BEFORE/OUTSIDE the gate (a standby still serves + pools)
+ *   - the suppressed branch sets polling=false and logs it (no silent no-op)
+ *   - the config flag exists on MultiMachineConfig
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const lifelineSrc = fs.readFileSync(
+  path.join(repoRoot, 'src', 'lifeline', 'TelegramLifeline.ts'),
+  'utf-8',
+);
+const typesSrc = fs.readFileSync(
+  path.join(repoRoot, 'src', 'core', 'types.ts'),
+  'utf-8',
+);
+
+describe('standby-no-poll guard — config flag', () => {
+  it('MultiMachineConfig declares an optional telegramPolling flag', () => {
+    expect(typesSrc).toContain('telegramPolling?: boolean');
+  });
+});
+
+describe('standby-no-poll guard — TelegramLifeline.start() wiring', () => {
+  it('gates on the shared default-TRUE predicate (only an explicit false suppresses)', () => {
+    // Source delegates to the pure, separately-unit-tested predicate so the
+    // wiring and the default-true semantics cannot drift.
+    expect(lifelineSrc).toMatch(
+      /const\s+telegramPollingEnabled\s*=\s*shouldOwnTelegramPoll\(this\.projectConfig\)/,
+    );
+    expect(lifelineSrc).toContain("import { shouldOwnTelegramPoll } from './telegramPollOwnership.js'");
+  });
+
+  it('runs the server supervisor BEFORE/OUTSIDE the poll gate (a standby still serves + joins the pool)', () => {
+    const supervisorIdx = lifelineSrc.indexOf('await this.supervisor.start()');
+    const gateIdx = lifelineSrc.indexOf('const telegramPollingEnabled =');
+    expect(supervisorIdx).toBeGreaterThan(0);
+    expect(gateIdx).toBeGreaterThan(0);
+    expect(supervisorIdx).toBeLessThan(gateIdx); // supervisor.start() is not inside the gate
+  });
+
+  it('flushStaleConnection() + poll() are INSIDE the enabled branch (suppressed when off)', () => {
+    const gateIdx = lifelineSrc.indexOf('if (telegramPollingEnabled) {');
+    expect(gateIdx).toBeGreaterThan(0);
+    const elseIdx = lifelineSrc.indexOf('} else {', gateIdx);
+    expect(elseIdx).toBeGreaterThan(gateIdx);
+    const enabledBlock = lifelineSrc.slice(gateIdx, elseIdx);
+    expect(enabledBlock).toContain('await this.flushStaleConnection();');
+    expect(enabledBlock).toContain('this.poll();');
+    expect(enabledBlock).toContain('this.polling = true;');
+  });
+
+  it('the suppressed branch sets polling=false and logs it (not a silent no-op)', () => {
+    const gateIdx = lifelineSrc.indexOf('if (telegramPollingEnabled) {');
+    const elseIdx = lifelineSrc.indexOf('} else {', gateIdx);
+    // window from the else through a bit past it to capture the standby branch body
+    const elseBlock = lifelineSrc.slice(elseIdx, elseIdx + 600);
+    expect(elseBlock).toContain('this.polling = false;');
+    expect(elseBlock).toMatch(/SUPPRESSED/);
+    // it must NOT call flush or poll in the standby branch
+    expect(elseBlock).not.toContain('this.poll();');
+    expect(elseBlock).not.toContain('flushStaleConnection');
+  });
+
+  it('keeps queue replay OUTSIDE the gate (a standby still drains its queue when the server is healthy)', () => {
+    // The replay interval is set up after the gate closes; assert it still exists
+    // and is not accidentally nested inside the poll-enabled branch.
+    const replayIdx = lifelineSrc.indexOf('this.replayInterval = setInterval(');
+    const gateIdx = lifelineSrc.indexOf('if (telegramPollingEnabled) {');
+    expect(replayIdx).toBeGreaterThan(gateIdx); // after the gate
+  });
+});

--- a/tests/unit/lifeline/telegramPollOwnership.test.ts
+++ b/tests/unit/lifeline/telegramPollOwnership.test.ts
@@ -1,0 +1,33 @@
+/**
+ * shouldOwnTelegramPoll — pure predicate for the standby-no-poll guard.
+ *
+ * Both sides of the decision boundary with realistic inputs (Testing Integrity
+ * Standard): the DEFAULT must be poll (so no existing single-machine agent
+ * changes), and ONLY an explicit `multiMachine.telegramPolling === false`
+ * suppresses the poll.
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldOwnTelegramPoll } from '../../../src/lifeline/telegramPollOwnership.js';
+
+describe('shouldOwnTelegramPoll', () => {
+  it('DEFAULTS to true when multiMachine is absent (existing single-machine agent → polls)', () => {
+    expect(shouldOwnTelegramPoll({})).toBe(true);
+  });
+
+  it('DEFAULTS to true when telegramPolling is undefined (multiMachine present, flag unset)', () => {
+    expect(shouldOwnTelegramPoll({ multiMachine: {} })).toBe(true);
+  });
+
+  it('returns true when telegramPolling is explicitly true (awake/primary machine)', () => {
+    expect(shouldOwnTelegramPoll({ multiMachine: { telegramPolling: true } })).toBe(true);
+  });
+
+  it('returns FALSE only when telegramPolling is explicitly false (standby suppresses its poll)', () => {
+    expect(shouldOwnTelegramPoll({ multiMachine: { telegramPolling: false } })).toBe(false);
+  });
+
+  it('tolerates null/undefined config (fail-safe → polls)', () => {
+    expect(shouldOwnTelegramPoll(undefined)).toBe(true);
+    expect(shouldOwnTelegramPoll(null)).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -42,11 +42,29 @@ This is the LAST recommended post-mortem lever. PR #542 (silent-403)
 through #552 (bare-catch ban) closed individual incident classes; THIS
 one closes the broader pattern that produced them.
 
+**Multi-machine: a standby machine no longer steals your Telegram
+messages.** Telegram allows exactly one connection per bot to receive
+messages. When you ran one agent across two machines, BOTH machines tried
+to receive — so the messaging service handed each message to one of them
+at random, and about half landed on the machine you weren't watching
+(looking like the agent ignored you). A standby machine can now be told
+"don't own the Telegram connection": it runs the full server and stays a
+full member of the machine pool (so work can move to it), but it never
+opens the receive connection — only the primary machine does. The default
+is unchanged (every existing single-machine agent keeps receiving exactly
+as before); only a machine explicitly set to standby stops receiving.
+
 ## What to Tell Your User
 
 Nothing visible in normal operation. If you want to run the big
-fixtures locally before pushing, `INSTAR_REAL_WORLD_BIG=1 npm test` will
-enable the nightly tier. The CI default is the PR tier only.
+fixtures locally before pushing, set the INSTAR_REAL_WORLD_BIG environment
+variable when you run the tests to enable the nightly tier. The CI default
+is the PR tier only.
+
+If you run one agent across two machines: the second machine can now be a
+silent standby that helps with work but never grabs your messages — no
+more "I messaged it and got no reply" from a background machine. Nothing
+to do on a single-machine setup.
 
 ## Summary of New Capabilities
 
@@ -56,6 +74,7 @@ enable the nightly tier. The CI default is the PR tier only.
 | Tier-gated execution | 'pr' runs every shard; 'nightly' skips unless `INSTAR_REAL_WORLD_BIG=1`. |
 | `makeAgentFixture()` helper | Per-test scratch dir simulating an agent home (projectDir + .instar/). Returns a cleanup callback. |
 | Externalized-config-boot regression check | `loadConfig()` against the externalized shape is asserted on every PR. #542's class can never regress silently. |
+| Standby-no-poll Telegram guard | Set `multiMachine.telegramPolling: false` in a standby machine's config — it runs the full server + joins the pool but never owns the Telegram poll. Default (unset) = poll, so existing agents are unchanged. |
 
 ## Evidence
 
@@ -69,3 +88,10 @@ enable the nightly tier. The CI default is the PR tier only.
 - `tsc --noEmit` clean.
 - Side-effects review:
   `upgrades/side-effects/real-world-state-fixture-framework.md`.
+- Standby-no-poll guard: `tests/unit/lifeline/telegramPollOwnership.test.ts`
+  (5 cases — both sides of the default-true boundary) +
+  `tests/unit/lifeline/standby-no-poll-wiring.test.ts` (6 cases — the
+  lifeline gate wraps flush+poll, supervisor + queue replay stay outside
+  it, the suppressed branch sets polling=false and logs it). 11/11 green;
+  `tsc --noEmit` clean. Side-effects:
+  `upgrades/side-effects/standby-no-poll-guard.md`.

--- a/upgrades/side-effects/standby-no-poll-guard.md
+++ b/upgrades/side-effects/standby-no-poll-guard.md
@@ -1,0 +1,75 @@
+# Side-effects review — standby-no-poll Telegram guard
+
+## What was happening (real-hardware, 2026-05-29/30)
+
+Telegram allows exactly ONE `getUpdates` long-poll per bot token. instar's
+**lifeline** owns that poll (it starts the server child with `--no-telegram` and
+forwards updates). There was no awake/standby gate on the poll: EVERY machine's
+lifeline polled unconditionally. So bringing up a second machine (the Mac mini,
+for session-pool dogfooding) meant two lifelines polling the same token → a
+permanent **409-conflict war** and nondeterministic delivery — roughly half of
+Justin's messages were grabbed by the mini (where no one was watching), and the
+409 churn also drove ~10-minute server restarts. This recurred repeatedly because
+the only mitigation was operator discipline (`launchctl disable` the mini's
+lifeline), which does not survive a reboot/re-pair — and crucially, deploying new
+code to the mini by kickstarting its launchd job RE-STARTED its poller.
+
+It was also a structural dead-end for the session pool: the mini can only JOIN
+the pool when it runs under its lifeline, but the lifeline is also what polls
+Telegram — so "in the pool" and "polling" were the same switch. You could not
+have a non-polling pool member.
+
+## The fix
+
+A per-machine LOCAL config flag splits those two concerns apart:
+
+- **`src/lifeline/telegramPollOwnership.ts`** (new) — pure
+  `shouldOwnTelegramPoll(config)`: returns `true` by DEFAULT (flag undefined /
+  `multiMachine` absent), and `false` ONLY when
+  `multiMachine.telegramPolling === false`.
+- **`src/core/types.ts`** — `telegramPolling?: boolean` on `MultiMachineConfig`.
+- **`src/lifeline/TelegramLifeline.ts`** `start()` — gates
+  `flushStaleConnection()` + `this.poll()` on the predicate. When suppressed it
+  sets `polling=false` and logs it; the server supervisor (`supervisor.start()`),
+  queue replay, and the restart-signal loop all stay OUTSIDE the gate — so a
+  standby still runs the full server, joins the session pool, and drains its
+  queue; it simply never opens the Telegram poll.
+
+A standby machine sets `multiMachine.telegramPolling: false` in its OWN config.
+Because the decision is a local read (no shared/git-synced coordination), a
+credential-less standby — the exact case that broke the git-based approaches —
+can honor it.
+
+## Blast radius
+
+- **DEFAULT-SAFE: zero change for every existing agent.** The flag defaults to
+  poll. A single-machine agent (no `multiMachine` block, or the flag unset) takes
+  the identical `flush → poll` path as before. Only a machine that EXPLICITLY
+  sets `telegramPolling:false` is suppressed. Verified both directions by the
+  pure-predicate unit test.
+- **No new route / schema / hook / skill.** One new config field (optional,
+  default-poll) + one new pure module + a gated branch in the lifeline. No
+  migration needed: absent flag = poll = today's behavior. (A future
+  auto-elect-the-poll-owner-on-failover enhancement could set it automatically;
+  this v1 is the manual per-machine flag, which is what unblocks the pool.)
+- **The suppressed branch is not a silent no-op** — it logs
+  `Telegram polling SUPPRESSED (standby: multiMachine.telegramPolling=false)` so
+  the state is visible in the lifeline log.
+
+## Tests (tiering note)
+
+`TelegramLifeline.start()` is not cleanly unit-instantiable (its constructor does
+`loadConfig` + agent-registry + state-dir side effects), and this change adds no
+HTTP route — so the honest tiering is **unit + source-wiring**, not e2e/integration:
+
+- `tests/unit/lifeline/telegramPollOwnership.test.ts` — the pure predicate, BOTH
+  sides of the boundary: default-true (absent / undefined / explicit-true) and
+  false-only-on-explicit-false, plus null/undefined-config fail-safe. 5 cases.
+- `tests/unit/lifeline/standby-no-poll-wiring.test.ts` — pins the wiring against
+  source: the gate delegates to `shouldOwnTelegramPoll(this.projectConfig)` (+ the
+  import); `flush`+`poll`+`polling=true` are INSIDE the enabled branch; the
+  suppressed branch sets `polling=false`, logs SUPPRESSED, and calls neither
+  flush nor poll; `supervisor.start()` and queue replay stay OUTSIDE the gate. 6
+  cases.
+
+11/11 green; `tsc --noEmit` clean.


### PR DESCRIPTION
Splits 'join the session pool' from 'own the Telegram poll' so a standby machine can be a full pool member without stealing the user's messages (the 2026-05-29 duplicate-poller 409 incident).

## Root cause
Telegram allows exactly one getUpdates poller per bot token. The lifeline is the poller, with NO awake/standby gate — every machine's lifeline polled unconditionally. Two machines → permanent 409-conflict war + nondeterministic delivery (~half the user's messages grabbed by the standby mini). Also a structural dead-end: a machine only joins the pool under its lifeline, but the lifeline is what polls — 'in pool' and 'polling' were the same switch.

## Fix (per-machine LOCAL flag, default-safe)
- src/lifeline/telegramPollOwnership.ts (new) — pure shouldOwnTelegramPoll(config): default true; false ONLY when multiMachine.telegramPolling === false. Local read (no shared/git coordination) so a credential-less standby can honor it.
- src/core/types.ts — telegramPolling?: boolean on MultiMachineConfig.
- TelegramLifeline.start() — gates flushStaleConnection()+poll() on the predicate; supervisor.start() + queue replay stay OUTSIDE the gate (standby still serves + joins the pool); suppressed branch sets polling=false and logs it.

DEFAULT-SAFE: every existing single-machine agent unchanged (default = poll). No new route/schema/hook/skill; no migration (absent flag = poll = today).

## Tests (tiering: lifeline change, no HTTP route, start() not cleanly instantiable → unit + source-wiring)
- tests/unit/lifeline/telegramPollOwnership.test.ts — pure predicate, both sides of the boundary (5).
- tests/unit/lifeline/standby-no-poll-wiring.test.ts — gate wraps flush+poll; supervisor + queue replay outside it; suppressed branch sets polling=false + logs, calls neither flush nor poll (6).
11/11 green; tsc --noEmit clean.

Side-effects: upgrades/side-effects/standby-no-poll-guard.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)