### PR TITLE
Retire stale Threadline conversations

### DIFF
--- a/specs/threadline-stale-thread-retirement.eli16.md
+++ b/specs/threadline-stale-thread-retirement.eli16.md
@@ -1,0 +1,11 @@
+# Threadline Stale Thread Retirement - Plain-English Overview
+
+Threadline is the part of Instar that lets agents keep a relationship over time instead of treating every message as brand new. That persistent relationship is useful, but it also means the system has to know the difference between a live conversation and old conversation history. Echo noticed that Codey had a much higher active thread count than the other agents. That was a strong sign that old relay threads were staying marked active even after the useful exchange was over.
+
+The change is deliberately conservative. It does not delete conversations. It only moves old, quiet conversations out of the active set and into the archived state after a full day with no activity. The thread history and metadata stay on disk, so a later reply can still pick up relationship context. Pinned conversations are never retired by this rule because pinning is the local signal that a thread should stay visible even if it is quiet.
+
+This is implemented at the storage layer, where Threadline conversations already live, and then called from the active-thread views. That avoids adding a new background worker or timer that could be harder to reason about. Whenever the system asks for active Threadline conversations, it first performs the small cleanup pass and then returns the view. The active-agent metric is also corrected so idle conversations do not count as active work.
+
+The practical result is simple: old Threadline conversations stop inflating active counts, while relationship memory remains intact. The user and other agents get a cleaner view of what is really active, and the system keeps the ability to resume a relationship if the other side comes back later.
+
+The main safety point is that this is archival, not deletion. A too-aggressive cleanup rule would be dangerous if it erased history. This one only changes the state of stale, non-pinned records and leaves the data available for future handling or inspection. Tests cover stale active retirement, stale idle retirement, pinned-thread preservation, fresh-thread preservation, and the corrected active count.

--- a/specs/threadline-stale-thread-retirement.md
+++ b/specs/threadline-stale-thread-retirement.md
@@ -1,0 +1,31 @@
+---
+title: Threadline stale thread retirement
+review-convergence: true
+approved: true
+eli16-overview: threadline-stale-thread-retirement.eli16.md
+---
+
+# Threadline Stale Thread Retirement
+
+## Problem
+
+Threadline conversations can stay in active or idle state long after the useful exchange has ended. Codey's live store showed dozens of Echo relay conversations, many with only a single message, still counted as active days later. That makes active thread counts read like current work even when they mostly describe stale relationship history.
+
+## Design
+
+Add a store-level retirement method that archives inactive, non-pinned conversations after a conservative threshold. The default threshold is 24 hours. The method uses the existing mutation path so concurrent writers keep the same safety properties as other conversation updates.
+
+Run the retirement check before active Threadline views are returned. This keeps compatibility surfaces honest without adding a separate background process. Correct the MCP active-agent metric so it counts only active state entries, not idle entries.
+
+## Acceptance Criteria
+
+- Stale active conversations are archived after the threshold.
+- Stale idle conversations are archived after the threshold.
+- Pinned stale conversations are not archived.
+- Fresh conversations stay active.
+- Archived conversations remain in the store.
+- The active-agent metric excludes idle and resolved conversations.
+
+## Verification
+
+Focused tests cover the store primitive, the resume-map active listing path, and the MCP active-thread count. Broader Threadline integration tests continue to exercise relay and conversation handling.

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-29T23:20:48.398Z",
-  "instarVersion": "1.3.99",
+  "generatedAt": "2026-05-30T09:36:35.178Z",
+  "instarVersion": "1.3.111",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -409,7 +409,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -417,7 +417,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -425,7 +425,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -433,7 +433,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -441,7 +441,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -449,7 +449,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -457,7 +457,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -465,7 +465,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -473,7 +473,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -481,7 +481,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -489,7 +489,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -497,7 +497,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -505,7 +505,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -513,7 +513,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -521,7 +521,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -529,7 +529,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -537,7 +537,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -545,7 +545,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -553,7 +553,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -561,7 +561,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -569,7 +569,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -577,7 +577,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -585,7 +585,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -593,7 +593,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -601,7 +601,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -609,7 +609,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -617,7 +617,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -625,7 +625,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -633,7 +633,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -641,7 +641,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -649,7 +649,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -657,7 +657,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -665,7 +665,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -673,7 +673,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -681,7 +681,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -689,7 +689,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -697,7 +697,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -705,7 +705,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -713,7 +713,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -721,7 +721,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -729,7 +729,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -737,7 +737,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -745,7 +745,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -761,7 +761,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "e53b3b0a111e0da46df9d26f3e5eafd68e909e3c245aff6a1e6e43d57c597aeb",
+      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1457,7 +1457,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "e7205849075aac7b50c06822b38a99b80909aad221e773d0a83a3e21a7242697",
+      "contentHash": "73e2eeaf3187a5dbb590d455f80ec40d14f2dc7210e5d433891f9786dd1c106d",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1465,7 +1465,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "c5d5f33e8793229dea8d9a7f3ee2073c0cd19bd8885425d245d57b6bc9076521",
+      "contentHash": "ea96b2d0255ee327844da18fd964bb9deb3cf60bdb09e1b572a0f8d0b5f0f089",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {
@@ -1489,7 +1489,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "a2f7941039c9bb8bfe6777412d3fee869077eb9a3d6e359c8f5efe52b3a693bb",
+      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/src/threadline/ConversationStore.ts
+++ b/src/threadline/ConversationStore.ts
@@ -137,6 +137,8 @@ const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const RESOLVED_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
 /** Cap before LRU eviction of non-pinned entries — matches ThreadResumeMap. */
 const MAX_ENTRIES = 1000;
+/** Inactive non-pinned conversations leave the active set after this window. */
+const DEFAULT_INACTIVE_RETIRE_MS = 24 * 60 * 60 * 1000;
 
 /** Max depth of the per-id mutate queue. Enqueue beyond this rejects. */
 const MUTATE_QUEUE_MAX_DEPTH = 256;
@@ -447,6 +449,40 @@ export class ConversationStore {
       this.writeFileAtomic(file);
       this.invalidateCache();
     }
+  }
+
+  /**
+   * Move stale non-terminal conversations out of the active set without
+   * deleting them. Archived records keep history/resume metadata; a later peer
+   * reply can still reactivate the thread through the normal resume path.
+   */
+  retireInactive(maxInactiveMs: number = DEFAULT_INACTIVE_RETIRE_MS, now: Date = new Date()): number {
+    const cutoff = now.getTime() - maxInactiveMs;
+    const file = this.readFileFresh();
+    const candidates: string[] = [];
+    let retired = 0;
+
+    for (const c of Object.values(file.conversations)) {
+      if (c.pinned) continue;
+      if (c.state !== 'active' && c.state !== 'idle' && c.state !== 'open' && c.state !== 'awaiting-reply') continue;
+      const last = new Date(c.lastActivityAt || c.savedAt).getTime();
+      if (!Number.isFinite(last) || last >= cutoff) continue;
+      candidates.push(c.threadId);
+    }
+
+    for (const threadId of candidates) {
+      const next = this.mutateSync(threadId, d => {
+        if (d.pinned) return d;
+        if (d.state !== 'active' && d.state !== 'idle' && d.state !== 'open' && d.state !== 'awaiting-reply') return d;
+        const last = new Date(d.lastActivityAt || d.savedAt).getTime();
+        if (!Number.isFinite(last) || last >= cutoff) return d;
+        d.state = 'archived';
+        return d;
+      });
+      if (next?.state === 'archived') retired += 1;
+    }
+
+    return retired;
   }
 
   // ── Ephemeral verified-only peer affinity (in-memory, non-durable) ──

--- a/src/threadline/ThreadResumeMap.ts
+++ b/src/threadline/ThreadResumeMap.ts
@@ -110,6 +110,7 @@ function applyEntryToConversation(entry: ThreadResumeEntry, draft: Conversation)
 
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const RESOLVED_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_INACTIVE_RETIRE_MS = 24 * 60 * 60 * 1000;
 
 // ── Implementation ──────────────────────────────────────────────
 
@@ -190,15 +191,22 @@ export class ThreadResumeMap {
 
   /** Find all (non-expired) threads with a specific remote agent. */
   getByRemoteAgent(agentName: string): Array<{ threadId: string; entry: ThreadResumeEntry }> {
+    this.retireInactive();
     return this.store.getByParticipant(agentName)
       .map(c => ({ threadId: c.threadId, entry: conversationToEntry(c) }));
   }
 
   /** List all active or idle threads. */
   listActive(): Array<{ threadId: string; entry: ThreadResumeEntry }> {
+    this.retireInactive();
     return this.store.listActive()
       .map(c => ({ threadId: c.threadId, entry: conversationToEntry(c) }))
       .filter(({ entry }) => entry.state === 'active' || entry.state === 'idle');
+  }
+
+  /** Archive stale non-pinned active/idle/open conversations. */
+  retireInactive(maxInactiveMs: number = DEFAULT_INACTIVE_RETIRE_MS, now: Date = new Date()): number {
+    return this.store.retireInactive(maxInactiveMs, now);
   }
 
   /** Cross-machine failover: demote a source machine's active threads to idle. */

--- a/src/threadline/ThreadlineMCPServer.ts
+++ b/src/threadline/ThreadlineMCPServer.ts
@@ -725,7 +725,7 @@ export class ThreadlineMCPServer {
             // Active threads with this agent
             const threads = this.deps.threadResumeMap.getByRemoteAgent(a.name);
             entry.activeThreads = threads.filter(
-              t => t.entry.state === 'active' || t.entry.state === 'idle'
+              t => t.entry.state === 'active'
             ).length;
 
             return entry;

--- a/tests/unit/ConversationStore.test.ts
+++ b/tests/unit/ConversationStore.test.ts
@@ -193,6 +193,25 @@ describe('ConversationStore', () => {
     expect(store.listActive().map(c => c.threadId).sort()).toEqual(['a']);
   });
 
+  it('retires stale non-pinned active and idle conversations without deleting them', async () => {
+    const store = new ConversationStore(stateDir);
+    const now = new Date('2026-05-30T09:00:00.000Z');
+    const stale = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
+    const fresh = new Date(now.getTime() - 10 * 60 * 1000).toISOString();
+
+    await store.mutate('stale-active', d => { d.state = 'active'; d.lastActivityAt = stale; return d; });
+    await store.mutate('stale-idle', d => { d.state = 'idle'; d.lastActivityAt = stale; return d; });
+    await store.mutate('fresh-active', d => { d.state = 'active'; d.lastActivityAt = fresh; return d; });
+    await store.mutate('pinned-stale', d => { d.state = 'active'; d.lastActivityAt = stale; d.pinned = true; return d; });
+
+    expect(store.retireInactive(24 * 60 * 60 * 1000, now)).toBe(2);
+    expect(store.get('stale-active')?.state).toBe('archived');
+    expect(store.get('stale-idle')?.state).toBe('archived');
+    expect(store.get('fresh-active')?.state).toBe('active');
+    expect(store.get('pinned-stale')?.state).toBe('active');
+    expect(store.listActive().map(c => c.threadId).sort()).toEqual(['fresh-active', 'pinned-stale']);
+  });
+
   it('CROSS-PROCESS: two store instances on one file lose no same-thread update', async () => {
     // Phase 2a: disk-backed per-record version-CAS — two instances (simulating
     // the server + the MCP child) mutating the SAME thread must not clobber.

--- a/tests/unit/Remediator.test.ts
+++ b/tests/unit/Remediator.test.ts
@@ -447,14 +447,12 @@ describe('Remediator', () => {
   });
 
   it('forged audit-token entries route to audit-rejected.jsonl', async () => {
-    // Strict token verifier: only accept tokens whose first byte is 0x42.
+    // Strict token verifier: reject every generated token. This must be
+    // deterministic; a prefix-based check made the test fail 1/256 CI runs.
     const strictFx = makeFixture({
-      tokenVerifier: (e) =>
-        e.auditToken.length > 0 && e.auditToken[0] === 0x42,
+      tokenVerifier: () => false,
     });
     try {
-      // FakeKeyVault produces random HKDF output; the leaf almost certainly
-      // does not start with 0x42, so every dispatch will be rejected.
       strictFx.remediator.registerRunbook(makeRunbook());
       await strictFx.remediator.dispatch(makeEvent());
 

--- a/tests/unit/threadline/ThreadResumeMap.test.ts
+++ b/tests/unit/threadline/ThreadResumeMap.test.ts
@@ -352,6 +352,21 @@ describe('ThreadResumeMap', () => {
       map.save('thread-resolved', makeEntry({ state: 'resolved' }));
       expect(map.listActive()).toHaveLength(0);
     });
+
+    it('archives stale active and idle threads before listing', () => {
+      const now = new Date('2026-05-30T09:00:00.000Z');
+      const stale = new Date(now.getTime() - 25 * 60 * 60 * 1000).toISOString();
+      const fresh = new Date(now.getTime() - 10 * 60 * 1000).toISOString();
+
+      map.save('stale-active', makeEntry({ state: 'active', lastAccessedAt: stale, savedAt: stale }));
+      map.save('stale-idle', makeEntry({ state: 'idle', lastAccessedAt: stale, savedAt: stale }));
+      map.save('fresh-active', makeEntry({ state: 'active', lastAccessedAt: fresh, savedAt: fresh }));
+
+      expect(map.retireInactive(24 * 60 * 60 * 1000, now)).toBe(2);
+      expect(map.listActive().map(t => t.threadId)).toEqual(['fresh-active']);
+      expect(map.get('stale-active')?.state).toBe('archived');
+      expect(map.get('stale-idle')?.state).toBe('archived');
+    });
   });
 
   // ── LRU Eviction at 1000 entries ─────────────────────────────

--- a/tests/unit/threadline/ThreadlineMCPServer.test.ts
+++ b/tests/unit/threadline/ThreadlineMCPServer.test.ts
@@ -764,6 +764,27 @@ describe('ThreadlineMCPServer', () => {
         const data = JSON.parse((result.content as any)[0].text);
         expect(data.count).toBe(1);
         expect(data.agents[0].name).toBe('test-agent');
+        expect(data.agents[0].activeThreads).toBe(0);
+      } finally {
+        await close();
+      }
+    });
+
+    it('does not count idle threads as active', async () => {
+      (deps.threadResumeMap.getByRemoteAgent as any).mockReturnValue([
+        { threadId: 'active-thread', entry: makeThreadEntry({ state: 'active' }) },
+        { threadId: 'idle-thread', entry: makeThreadEntry({ state: 'idle' }) },
+        { threadId: 'resolved-thread', entry: makeThreadEntry({ state: 'resolved' }) },
+      ]);
+
+      const { client, close } = await connectClientServer({}, deps);
+      try {
+        const result = await client.callTool({
+          name: 'threadline_agents',
+          arguments: {},
+        });
+
+        const data = JSON.parse((result.content as any)[0].text);
         expect(data.agents[0].activeThreads).toBe(1);
       } finally {
         await close();

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,24 @@
+# Upgrade Guide - vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Threadline conversation lifecycle now retires stale active and idle threads automatically. Conversations that have seen no activity for 24 hours are archived instead of staying in the active set forever, while pinned conversations are left alone. Archived conversations keep their history and metadata, so a later peer reply can still reactivate the relationship context.
+
+The Threadline active-agent summary also now reports only truly active threads. Idle conversations are no longer counted as active work, which makes agent health and collaboration dashboards reflect the real current workload instead of accumulated stale conversations.
+
+## What to Tell Your User
+
+- **Cleaner Threadline state**: "I now clean up old Threadline conversations automatically, so stale inter-agent chats stop cluttering the active thread count while the relationship history remains available."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Stale Threadline retirement | Automatic during Threadline active-thread reads |
+| Accurate active thread counts | Automatic in threadline agent status |
+
+## Evidence
+
+Codey's live Threadline store showed 42 conversations before the change: 39 active, 3 idle, and 38 with Echo. Many were single-message relay threads from May 23-28 that still counted as active on May 30. Focused regression tests now prove stale active and idle conversations are archived without deletion, pinned stale threads remain active, and idle threads no longer increment the active thread metric.

--- a/upgrades/side-effects/threadline-stale-thread-retirement.md
+++ b/upgrades/side-effects/threadline-stale-thread-retirement.md
@@ -1,0 +1,35 @@
+# Side-effects review - Threadline stale thread retirement
+
+## 1. Over-block / under-block
+
+Over-block risk is that an ongoing but quiet Threadline conversation could be archived after 24 hours. The mitigation is that archival is non-destructive: history, metadata, remote agent identity, and thread id stay in the conversation store, and a later peer reply can reactivate the same thread. Pinned conversations are excluded entirely.
+
+Under-block risk is that stale conversations younger than 24 hours still count as active until the threshold passes. That is intentional because a shorter threshold could retire normal overnight collaborations too aggressively. The active metric was also tightened so idle conversations stop inflating active counts immediately.
+
+## 2. Level-of-abstraction fit
+
+The retirement primitive lives in `ConversationStore`, which owns persisted Threadline conversation state. `ThreadResumeMap` invokes it before active-set reads because that class is the compatibility view used by Threadline surfaces. The MCP status metric is corrected at the presentation layer by counting only active states.
+
+## 3. Signal vs authority compliance
+
+The change does not add a brittle blocking detector. The store applies a deterministic lifecycle rule to local persisted state, and it archives rather than deletes. The active-thread metric is a signal to operators and agents; it no longer treats idle records as active authority.
+
+## 4. Interactions with adjacent systems
+
+Threadline resume remains intact because archived conversations are not deleted. Relay reply handling can still find the thread by id and update it. Pinned conversations remain available for long-running relationships. Existing resolved and archived conversations are unaffected.
+
+## 5. Rollback cost
+
+Low. Reverting the store method, resume-map call sites, and metric filter restores prior behavior. Already-archived stale conversations remain preserved on disk and can be reactivated by inbound messages or manually inspected.
+
+## 6. Backwards compatibility / drift surface
+
+The store schema does not change. The only behavior change is automatic state transition to `archived` for inactive, non-pinned conversations. The 24-hour threshold is centralized as a named default so future tuning has one obvious place.
+
+## 7. Authorization / trust posture
+
+No external calls, credentials, or user-visible messaging paths are added. The change only mutates local Threadline conversation state through the existing `ConversationStore` mutation path.
+
+## Outcome
+
+Ship. The fix addresses the observed active-thread accumulation without destroying conversation history or changing network protocols.


### PR DESCRIPTION
## Summary
- Add a conservative 24h stale-retirement path for non-pinned Threadline conversations in ConversationStore and ThreadResumeMap.
- Keep archived conversation history/resume metadata so a later peer reply can reactivate through the normal resume path.
- Correct threadline_agents activeThreads to count only active threads, not idle ones.
- Fix a probabilistic Remediator forged-token unit test that blocked CI when its random HKDF output happened to match the accepted prefix.
- Refresh the generated builtin manifest after build.

## Verification
- npm test -- tests/unit/ConversationStore.test.ts tests/unit/threadline/ThreadResumeMap.test.ts tests/unit/threadline/ThreadlineMCPServer.test.ts (104 tests passed)
- npm test -- tests/unit/Remediator.test.ts (12 tests passed)
- npm run test:integration -- tests/integration/threadline/ThreadlineIntegration.test.ts tests/integration/threadline/ThreadlineMCP.test.ts tests/integration/threadline/relay-send-local-roundtrip.test.ts tests/integration/threadline/single-store-cmt497.test.ts (84 tests passed)
- npm run test:e2e -- tests/e2e/threadline/RelayE2E.test.ts tests/e2e/threadline/RESTServerE2E.test.ts tests/e2e/threadline/OfflineQueueE2E.test.ts tests/e2e/threadline/conversation-keystone-wiring.test.ts (56 tests passed)
- npm run lint
- npm run build
- node scripts/instar-dev-precommit.js
- npm run check:pre-push-gate
- git push hook after latest commit: affected smoke tier passed 106/106; path-scoped Threadline E2E passed 331/331

## Notes
Full npm test currently has unrelated baseline/environment failures in tunnel reachability, runtime auth-token bleed, worktree detector assumptions, existing silent-fallback and ESM compliance gates, serendipity HMAC, Telegram end-to-end surface, and an unrelated CLAUDE section parity check. The focused Threadline and ship-gate checks for this change are green.

Supersedes #560 after rebasing onto current main without force-pushing.