### PR TITLE
fix(threadline): byte-cap a2a spawn history + latest body (fix "command too long")

### DIFF
--- a/docs/specs/threadline-a2a-spawn-history-bytecap.eli16.md
+++ b/docs/specs/threadline-a2a-spawn-history-bytecap.eli16.md
@@ -1,0 +1,38 @@
+# ELI16 — Why agent-to-agent messages stopped going through on long threads
+
+Imagine two robots passing notes. Every time Robot A sends Robot B a note, the
+system doesn't just hand over the new note — it staples the **entire past
+conversation** to the front so Robot B remembers what they were talking about.
+Then it shoves that whole stack of paper through a mail slot to wake Robot B up.
+
+The mail slot has a fixed width. A few notes? Fine. But the longer two robots
+talk, the taller the stack gets — and one day the stack is too thick to fit
+through the slot. The note doesn't get delivered late; it doesn't get delivered
+at all. The system just says "command too long" and gives up. The robots go
+quiet, and nobody can tell why.
+
+That's exactly what happened here. When one Instar agent messages another, the
+code builds a wake-up prompt that includes the full thread history plus the new
+message, and it passes that prompt to `tmux` (the tool that starts the other
+agent's session) as a command-line argument. `tmux` refuses any command longer
+than about 16 kilobytes. On a busy thread — especially one where a chatty agent
+repeats itself — the history blows past that limit, and the spawn fails outright.
+Multi-agent communication silently breaks on precisely the long, active
+conversations that matter most. It even broke mid-session while I was mentoring
+another agent: I literally couldn't send my next message.
+
+The fix is to stop stapling the whole stack. We now keep only the most recent
+slice of the conversation that fits in a sensible budget (about 6 KB of history),
+trimming any single giant message and dropping the oldest messages first so the
+newest context always survives. We also cap the new message itself (about 3.5 KB)
+in case a peer sends something enormous. Together that keeps the whole wake-up
+command well under the mail-slot width, with room to spare.
+
+We chose this targeted trim instead of a bigger rebuild (passing the prompt
+through a temp file, which some other spawn paths already do) because the bigger
+rebuild touches how *every* session starts — too risky for an urgent fix that
+needed to restore agent messaging right now. The only downside of trimming is
+that on a very long thread the spawned agent sees recent context instead of the
+entire back-history, which is a fine trade for "messages actually get delivered."
+The full file-based rewrite is noted as a follow-up so we eventually keep all the
+context without any width limit at all.

--- a/docs/specs/threadline-a2a-spawn-history-bytecap.md
+++ b/docs/specs/threadline-a2a-spawn-history-bytecap.md
@@ -1,0 +1,94 @@
+---
+title: Threadline a2a spawn — byte-cap the history + latest body (fix "command too long")
+date: 2026-05-30
+author: echo
+review-convergence: urgent-fleet-hotfix-2026-05-30
+approved: true
+approved-by: Justin
+approved-via: Standing authorization for urgent fleet bugs — "anything urgent like this should automatically be fixed and deployed please remember this" (Justin, recorded in MEMORY feedback_auto_fix_deploy_urgent_fleet_bugs). This bug breaks multi-agent communication outright on long threads and blocked Echo's own live mentorship session. Reported to Justin in topic 13435 at fix time.
+eli16-overview: threadline-a2a-spawn-history-bytecap.eli16.md
+---
+
+# Spec — Threadline a2a spawn history byte-cap
+
+**Date:** 2026-05-30
+**Author:** echo
+**Status:** approved (urgent fleet hotfix)
+
+## Triggering incident
+
+During a live mentorship session, `threadline_send` to a peer agent (instar-codey)
+on an active 10-message thread failed with:
+
+```
+Spawn denied: Failed to create tmux session: ... command too long
+```
+
+The a2a reply-spawn embeds the **entire thread history** plus the latest message
+into a one-shot prompt, and that prompt is passed as a **command-line argument**
+to `tmux new-session -d -s … <codex/claude exec … PROMPT>` (via
+`SessionManager.spawnSession` → `frameworkSessionLaunch` → `execFileSync`). tmux's
+`new-session` command length limit is ~16 KB (verified empirically on this host: a
+15 KB argument succeeds, 16 KB fails with the literal "command too long"). As a
+thread accumulates messages the prompt grows without bound, so once a thread is
+long/verbose enough the spawn fails **outright** — silently breaking agent-to-agent
+communication on exactly the long-running threads that need it most.
+
+This is the same failure class as the Mentor Stage-A "command too long" bug
+(`MentorStageA.ts`, fixed by capping its growing compose context).
+
+## Root cause
+
+`ThreadlineRouter.buildHistoryContext()` capped the history by **message count**
+(`maxHistoryMessages`) but embedded each message's **full body** with no byte
+bound. Verbose multi-KB messages (and the codex-duplicate-reply bug, which fills a
+thread with repeated near-identical closeouts) push the assembled prompt past
+tmux's ceiling. `buildPrompt()` likewise embedded the latest message body verbatim
+— a second unbounded input (a peer can send an arbitrarily large message).
+
+## Fix
+
+Bound both unbounded inputs so the assembled `tmux new-session` command stays
+comfortably under the ~16 KB cliff:
+
+1. **History byte-cap** — `buildBoundedHistorySection()` (pure, exported) walks the
+   selected messages newest→oldest, truncates any single message to
+   `MAX_HISTORY_MESSAGE_BYTES` (1500), and stops adding older messages once
+   `MAX_HISTORY_BYTES` (6000) is reached — always keeping at least the newest
+   message. The header reports the included/total counts and notes when older
+   messages were omitted. The existing message-count cap is retained; the byte cap
+   is the belt-and-suspenders that actually bounds size.
+2. **Latest-body cap** — `capMessageBody()` (pure, exported) truncates the latest
+   message body to `MAX_LATEST_BODY_BYTES` (3500) with an explicit marker.
+
+Worst-case assembled prompt ≈ 6 KB history + 3.5 KB latest + ~2.5 KB
+template/grounding/env ≈ 12 KB — a ~4 KB margin under the 16 KB cliff.
+
+## Why a cap, not the file-based prompt (alternatives considered)
+
+`PipeSessionSpawner` already passes its prompt via a temp file using a
+`"$(< file)"` shell expression (no command-line length issue, no context loss).
+The architecturally-cleanest fix would route `SessionManager.spawnSession` through
+the same file-based mechanism — eliminating the length limit for ALL spawn paths
+and preserving full context.
+
+We deliberately defer that to a follow-up <!-- tracked: issue-562 --> (issue #562): it changes the core spawn used by every
+session (jobs, mentor, interactive, a2a), so its blast radius is the whole fleet's
+session spawning. For an **urgent** hotfix that must unblock multi-agent comms now,
+the targeted byte-cap (scoped entirely to `ThreadlineRouter`, zero change to the
+core spawn) is the correct low-risk move. The cap's only cost is dropping the
+oldest context on very long threads — acceptable, and softened by keeping the
+newest messages. Tracked follow-up <!-- tracked: issue-562 --> (issue #562): file-based prompt in `SessionManager.spawnSession`.
+
+## Testing
+
+- **Unit (pure):** `tests/unit/threadline/ThreadlineRouter-history-cap.test.ts` —
+  `capMessageBody` (no-op under budget; truncates with accurate marker);
+  `buildBoundedHistorySection` (empty; all-included header; over-budget bounds total
+  size + keeps newest + drops oldest + "older omitted" header; single oversized
+  message truncated; always keeps ≥1 newest even under a tiny budget).
+- **Wiring (router):** `tests/unit/threadline/ThreadlineRouter.test.ts` — a 40×2.5 KB
+  history + 20 KB latest body flows through `handleInboundMessage` and the captured
+  spawn `context` is `< 14000` chars, contains the newest message, drops the oldest,
+  and truncates the latest body. Proves the router actually applies the cap.
+- **Regression:** existing 32 `ThreadlineRouter` tests pass unchanged.

--- a/src/threadline/ThreadlineRouter.ts
+++ b/src/threadline/ThreadlineRouter.ts
@@ -161,6 +161,71 @@ Subject: {latest_subject}
 
 Respond to this message. Use the threadline_send MCP tool with the agentId set to "{remote_agent}" and include the threadId "{thread_id}" to send your reply.`;
 
+/**
+ * Byte budget for the thread-history block injected into a spawn prompt.
+ *
+ * The spawn prompt is passed as a `tmux new-session ... <command>` ARGUMENT
+ * (SessionManager.spawnSession → execFileSync). tmux's command-line limit is
+ * ~16 KB (empirically: a 15 KB arg succeeds, 16 KB fails with the literal
+ * "command too long"). An UNBOUNDED, ever-growing thread history made the spawn
+ * command exceed that ceiling, so multi-agent reply-spawns failed OUTRIGHT once
+ * a thread accumulated enough messages — silently breaking agent-to-agent
+ * communication on exactly the long-running threads that need it most.
+ *
+ * Same failure class + fix as Mentor Stage-A (see MentorStageA.ts, which caps
+ * its own growing compose context). We bound the history (newest-first) plus the
+ * latest body so the whole assembled command stays comfortably under the cliff
+ * (worst case ≈ 6 KB history + 3.5 KB latest + ~2.5 KB env/flags/grounding ≈
+ * 12 KB, a ~4 KB margin). The existing message-COUNT cap (maxHistoryMessages)
+ * is kept; this byte cap is the belt-and-suspenders that actually bounds size.
+ */
+const MAX_HISTORY_BYTES = 6000;
+/** Per-message cap inside the history block, so one huge message can't dominate the budget. */
+const MAX_HISTORY_MESSAGE_BYTES = 1500;
+/** Cap on the latest (triggering) message body embedded in the spawn prompt. */
+const MAX_LATEST_BODY_BYTES = 3500;
+
+/**
+ * Truncate a message body to a byte budget with an explicit marker. Pure +
+ * exported for unit testing. No-op when already under budget.
+ */
+export function capMessageBody(body: string, maxBytes: number): string {
+  if (body.length <= maxBytes) return body;
+  return `${body.slice(0, maxBytes)}\n…[truncated ${body.length - maxBytes} chars]`;
+}
+
+/**
+ * Build the bounded "Recent thread history" block. Walks newest→oldest so the
+ * most recent context always survives, truncates any single oversized message,
+ * and stops adding older messages once the byte budget is hit (always keeping at
+ * least the newest one). Pure + exported for unit testing.
+ */
+export function buildBoundedHistorySection(
+  messages: Array<{ agent: string; createdAt: string; body: string }>,
+  totalCount: number,
+  opts: { maxBytes: number; perMessageBytes: number },
+): string {
+  if (messages.length === 0) return '';
+  const entries: string[] = [];
+  let usedBytes = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    const body = capMessageBody(m.body, opts.perMessageBytes);
+    const entry = `${m.agent} (${m.createdAt}):\n${body}`;
+    // Always include at least the newest message; stop adding older ones once
+    // the budget would be exceeded.
+    if (entries.length > 0 && usedBytes + entry.length > opts.maxBytes) break;
+    entries.unshift(entry);
+    usedBytes += entry.length;
+  }
+  const numbered = entries.map((e, i) => `[${i + 1}] ${e}`).join('\n\n');
+  const omitted = totalCount - entries.length;
+  const header = omitted > 0
+    ? `Recent thread history (${entries.length} of ${totalCount} messages, older omitted to fit):`
+    : `Recent thread history (${entries.length} of ${totalCount} messages):`;
+  return `${header}\n${numbered}`;
+}
+
 // ── Implementation ──────────────────────────────────────────────
 
 export class ThreadlineRouter {
@@ -778,16 +843,22 @@ export class ThreadlineRouter {
         return '';
       }
 
-      // Take the last N messages for context
-      const recentMessages = threadData.messages
-        .slice(-limit)
-        .map((env, i) => {
-          const msg = env.message;
-          return `[${i + 1}] ${msg.from.agent} (${msg.createdAt}):\n${msg.body}`;
-        })
-        .join('\n\n');
+      // Take the last N messages, then enforce a total BYTE budget. The block
+      // this produces is embedded in a spawn prompt passed as a `tmux
+      // new-session` command argument (~16 KB ceiling), so an unbounded history
+      // would fail the spawn outright on long threads ("command too long").
+      // buildBoundedHistorySection walks newest-first and drops/truncates older
+      // content to fit — see MAX_HISTORY_BYTES.
+      const recent = threadData.messages.slice(-limit).map((env) => ({
+        agent: env.message.from.agent,
+        createdAt: env.message.createdAt,
+        body: env.message.body,
+      }));
 
-      return `Recent thread history (${Math.min(threadData.messages.length, limit)} of ${threadData.messages.length} messages):\n${recentMessages}`;
+      return buildBoundedHistorySection(recent, threadData.messages.length, {
+        maxBytes: MAX_HISTORY_BYTES,
+        perMessageBytes: MAX_HISTORY_MESSAGE_BYTES,
+      });
     } catch {
       // @silent-fallback-ok — thread history is supplementary context; missing it degrades but doesn't break
       return '';
@@ -809,6 +880,12 @@ export class ThreadlineRouter {
       ? `${historyContext}\n`
       : 'No previous history available.\n';
 
+    // Cap the latest body too: it's the other unbounded input to the spawn
+    // command argument (a peer can send an arbitrarily large message). Together
+    // with the bounded history this keeps the whole `tmux new-session` command
+    // under tmux's ~16 KB "command too long" ceiling.
+    const latestBody = capMessageBody(latestMessage.body, MAX_LATEST_BODY_BYTES);
+
     const basePrompt = THREAD_SPAWN_PROMPT_TEMPLATE
       .replaceAll('{remote_agent}', remoteAgent)
       .replaceAll('{thread_id}', threadId)
@@ -816,7 +893,7 @@ export class ThreadlineRouter {
       .replaceAll('{message_count}', String(messageCount))
       .replaceAll('{history_section}', historySection)
       .replaceAll('{latest_subject}', latestMessage.subject)
-      .replaceAll('{latest_body}', latestMessage.body);
+      .replaceAll('{latest_body}', latestBody);
 
     // If relay context is present, wrap with grounding preamble
     if (relayContext) {

--- a/tests/unit/threadline/ThreadlineRouter-history-cap.test.ts
+++ b/tests/unit/threadline/ThreadlineRouter-history-cap.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Byte-cap guards for the Threadline a2a spawn prompt.
+ *
+ * Regression coverage for the "command too long" fleet bug: the a2a reply-spawn
+ * embeds the thread history + latest message into a prompt that is passed as a
+ * `tmux new-session ... <command>` ARGUMENT. tmux's command-line limit is ~16 KB
+ * (empirically: 15 KB OK, 16 KB → "command too long"), so an unbounded,
+ * ever-growing history made long-thread reply-spawns fail outright — silently
+ * breaking agent-to-agent communication. These tests pin the byte budget that
+ * bounds the assembled prompt regardless of thread length or message size.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  capMessageBody,
+  buildBoundedHistorySection,
+} from '../../../src/threadline/ThreadlineRouter.js';
+
+describe('capMessageBody', () => {
+  it('is a no-op when the body is within budget', () => {
+    expect(capMessageBody('short', 100)).toBe('short');
+    const exact = 'x'.repeat(100);
+    expect(capMessageBody(exact, 100)).toBe(exact);
+  });
+
+  it('truncates over-budget bodies and reports the dropped char count', () => {
+    const body = 'y'.repeat(5000);
+    const out = capMessageBody(body, 1500);
+    expect(out.startsWith('y'.repeat(1500))).toBe(true);
+    expect(out).toContain('[truncated 3500 chars]');
+    // bounded: budget + a small fixed marker, never the full 5000
+    expect(out.length).toBeLessThan(1600);
+  });
+});
+
+describe('buildBoundedHistorySection', () => {
+  const opts = { maxBytes: 6000, perMessageBytes: 1500 };
+
+  function msgs(n: number, bodyLen: number) {
+    return Array.from({ length: n }, (_, i) => ({
+      agent: i % 2 === 0 ? 'echo' : 'instar-codey',
+      createdAt: `2026-05-30T10:0${i % 10}:00.000Z`,
+      body: `m${i}-${'a'.repeat(bodyLen)}`,
+    }));
+  }
+
+  it('returns empty string for no messages', () => {
+    expect(buildBoundedHistorySection([], 0, opts)).toBe('');
+  });
+
+  it('includes all messages and numbers them when within budget', () => {
+    const out = buildBoundedHistorySection(msgs(3, 20), 3, opts);
+    expect(out).toContain('Recent thread history (3 of 3 messages):');
+    expect(out).toContain('[1] echo');
+    expect(out).toContain('[2] instar-codey');
+    expect(out).toContain('[3] echo');
+    expect(out).not.toContain('older omitted');
+  });
+
+  it('bounds total size and keeps the NEWEST messages when over budget', () => {
+    // 50 messages × ~2000 chars each = ~100 KB of raw history.
+    const out = buildBoundedHistorySection(msgs(50, 2000), 50, opts);
+    // Hard size guarantee: total ≤ maxBytes + one per-message cap + headers slack.
+    expect(out.length).toBeLessThan(opts.maxBytes + opts.perMessageBytes + 500);
+    // Newest message (m49) survives; an old one (m0) is dropped.
+    expect(out).toContain('m49-');
+    expect(out).not.toContain('m0-');
+    // Header reflects truncation and an accurate included-count.
+    expect(out).toMatch(/Recent thread history \(\d+ of 50 messages, older omitted to fit\):/);
+  });
+
+  it('truncates a single oversized message via the per-message cap', () => {
+    const out = buildBoundedHistorySection(
+      [{ agent: 'echo', createdAt: '2026-05-30T10:00:00.000Z', body: 'z'.repeat(9000) }],
+      1,
+      opts,
+    );
+    expect(out).toContain('[truncated');
+    expect(out.length).toBeLessThan(opts.perMessageBytes + 200);
+  });
+
+  it('always keeps at least the newest message even if it alone exceeds maxBytes', () => {
+    // perMessageBytes caps each entry; with a tiny maxBytes the newest still lands.
+    const out = buildBoundedHistorySection(msgs(5, 1200), 5, { maxBytes: 100, perMessageBytes: 1500 });
+    expect(out).toContain('m4-'); // newest
+    expect(out).toContain('[1]');
+    expect(out).toContain('older omitted to fit');
+  });
+});

--- a/tests/unit/threadline/ThreadlineRouter.test.ts
+++ b/tests/unit/threadline/ThreadlineRouter.test.ts
@@ -411,6 +411,41 @@ describe('ThreadlineRouter', () => {
       expect(call.context).toContain('remote-agent');
     });
 
+    it('bounds the spawn prompt under tmux command limits even with a long, heavy history', async () => {
+      // Regression: the spawn prompt is passed as a `tmux new-session` command
+      // ARGUMENT (~16 KB ceiling). An unbounded thread history + huge latest body
+      // made long-thread reply-spawns fail with "command too long". The router
+      // must cap both so multi-agent comms survive long threads.
+      const threadId = crypto.randomUUID();
+      // Simulate a long-running thread: 40 messages × ~2.5 KB ≈ 100 KB raw.
+      const heavyMessages = Array.from({ length: 40 }, (_, i) => ({
+        message: {
+          from: { agent: i % 2 === 0 ? 'remote-agent' : 'local-agent' },
+          createdAt: `2026-05-30T10:00:${String(i).padStart(2, '0')}.000Z`,
+          body: `history-msg-${i} ${'h'.repeat(2500)}`,
+        },
+      }));
+      mockRouter.getThread.mockResolvedValue({ messages: heavyMessages } as any);
+
+      const envelope = makeEnvelope({
+        threadId,
+        subject: 'Latest',
+        body: `latest-body ${'L'.repeat(20000)}`, // pathologically large latest message
+      });
+
+      await router.handleInboundMessage(envelope);
+
+      const call = mockSpawnManager.evaluate.mock.calls[0][0];
+      // Whole assembled prompt stays well under tmux's ~16 KB cliff.
+      expect(call.context.length).toBeLessThan(14000);
+      // Newest history message survives; the oldest is dropped to fit.
+      expect(call.context).toContain('history-msg-39');
+      expect(call.context).not.toContain('history-msg-0 ');
+      // The oversized latest body is present but truncated, not verbatim.
+      expect(call.context).toContain('[truncated');
+      expect(call.context).not.toContain('L'.repeat(20000));
+    });
+
     it('sets correct spawn priority for critical messages', async () => {
       const threadId = crypto.randomUUID();
       const envelope = makeEnvelope({ threadId, priority: 'critical' });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,58 @@
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Agent-to-agent messages no longer fail outright on long Threadline threads.**
+
+When one Instar agent messages another, the reply-spawn builds a wake-up prompt
+that embeds the thread history plus the latest message, and that prompt is passed
+as a command-line argument to `tmux new-session`. tmux's command length limit is
+~16 KB (empirically: a 15 KB argument succeeds, 16 KB fails with "command too
+long"). `ThreadlineRouter.buildHistoryContext()` capped history by message *count*
+but embedded each message's full body with no byte bound, so on a long or verbose
+thread the prompt grew past tmux's ceiling and the spawn failed — silently
+breaking agent-to-agent communication on exactly the long-running threads that
+need it most. (Hit live: a `threadline_send` on a 10-message mentorship thread
+failed mid-session.)
+
+The fix byte-caps both unbounded inputs in `ThreadlineRouter`: the history block
+(`buildBoundedHistorySection`, newest-first, ~6 KB budget with a 1500-byte
+per-message cap) and the latest body (`capMessageBody`, 3500-byte cap), keeping
+the whole assembled command comfortably under tmux's limit (~4 KB margin). Full
+message bodies remain in the durable thread store; only the inline copy in the
+one-shot spawn prompt is trimmed. Same failure class + fix as the Mentor Stage-A
+"command too long" bug.
+
+## What to Tell Your User
+
+On long conversations between me and another agent, my outgoing messages could
+silently fail to send once the thread got long enough — the system was trying to
+cram the entire conversation history into a single startup command and hit a
+length limit, so the message never went through and nobody could tell why. I fixed
+it so I now carry only the most recent slice of the conversation when waking
+another agent, dropping the oldest parts first so the latest context always
+survives. The result is that agent-to-agent chats stay reliable no matter how long
+they run. You shouldn't notice anything change except that cross-agent
+collaboration no longer goes quiet on long threads.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Bounded a2a spawn prompt (no "command too long") | Automatic — long Threadline threads now spawn reply workers reliably |
+| Newest-first history retention | Automatic — when history exceeds the budget, the most recent messages are kept and older ones omitted |
+
+## Evidence
+
+- **Live reproduction:** `threadline_send` to instar-codey on a 10-message thread
+  failed with "Failed to create tmux session: … command too long". The empirical
+  tmux ceiling on this host: a 15 KB `new-session` argument succeeds, 16 KB fails.
+- **Tests:** `tests/unit/threadline/ThreadlineRouter-history-cap.test.ts` (7) —
+  byte-cap helpers, both sides of the budget boundary. A router wiring test in
+  `tests/unit/threadline/ThreadlineRouter.test.ts` proves a 40×2.5 KB history +
+  20 KB latest body yields a spawn prompt under 14 KB with the newest message kept
+  and the oldest dropped. Existing 32 router tests pass unchanged. `tsc` clean.
+- Spec: `docs/specs/threadline-a2a-spawn-history-bytecap.md`. Side-effects:
+  `upgrades/side-effects/threadline-a2a-spawn-history-bytecap.md`.

--- a/upgrades/side-effects/threadline-a2a-spawn-history-bytecap.md
+++ b/upgrades/side-effects/threadline-a2a-spawn-history-bytecap.md
@@ -1,0 +1,47 @@
+# Side-effects — Threadline a2a spawn history byte-cap
+
+**Change:** `ThreadlineRouter.buildHistoryContext()` and `buildPrompt()` now bound
+the thread-history block and the latest-message body by bytes before they are
+embedded in the a2a reply-spawn prompt. New pure exported helpers
+`capMessageBody()` and `buildBoundedHistorySection()`.
+
+## Behavioral side-effects
+
+- **Spawned a2a reply workers see a bounded history.** On long threads (history
+  exceeding ~6 KB), the spawn prompt now contains the most recent messages that
+  fit rather than the entire thread. Older messages are dropped (newest-first);
+  the history header notes "older omitted to fit". This is a deliberate trade to
+  keep the spawn command under tmux's ~16 KB limit. Resume-based sessions and the
+  durable thread store are unaffected — full history still lives in
+  `conversations.json`; only the one-shot wake-up prompt is trimmed.
+- **Very large single messages are truncated in the prompt** (per-message 1500
+  bytes in history; 3500 bytes for the latest body) with an explicit
+  `…[truncated N chars]` marker. The full message body is still persisted in the
+  thread store; only its inline copy in the spawn prompt is capped.
+- **No change to behavior on short threads.** Threads whose total history is under
+  budget render identically to before (same numbering, same "N of N messages"
+  header without the "older omitted" suffix).
+
+## Blast radius
+
+- Scoped entirely to `src/threadline/ThreadlineRouter.ts`. No change to
+  `SessionManager.spawnSession`, the core tmux spawn, job sessions, or any other
+  framework path.
+- No config, schema, hook, or migration changes. No new dependencies.
+- The cap constants are module-level (not configurable) — matching the Mentor
+  Stage-A precedent. If a future need arises they can be promoted to
+  `ThreadlineRouterConfig`.
+
+## Migration parity
+
+None required — this is internal runtime logic shipped in `src/`. Existing agents
+receive it on their normal version update; there is no agent-installed file
+(`.claude/settings.json`, `.instar/config.json`, CLAUDE.md template, hook, or
+skill) to migrate.
+
+## Follow-up (not in this change)
+
+File-based prompt passing in `SessionManager.spawnSession` (mirroring
+`PipeSessionSpawner`'s `"$(< file)"` pattern) would eliminate the command-length
+limit for all spawn paths and preserve full context — deferred as higher blast
+radius than an urgent hotfix warrants.


### PR DESCRIPTION
## Problem (hit live, fleet-wide)

A threadline_send to a peer on an active 10-message thread failed mid-session with **Failed to create tmux session: command too long**. The a2a reply-spawn embeds the **full thread history + latest message** into a prompt passed as a tmux new-session command **argument** (SessionManager.spawnSession via execFileSync). tmux's command-line limit is ~16KB (empirically verified: 15KB arg OK, 16KB fails with 'command too long'). buildHistoryContext capped by message **count** but embedded each full body with no byte bound, so on long/verbose threads the prompt blows the ceiling and the spawn fails **outright** — silently breaking agent-to-agent communication on exactly the long-running threads that need it most.

Same failure class as the Mentor Stage-A 'command too long' bug.

## Fix

Byte-cap both unbounded inputs in ThreadlineRouter (pure exported helpers):
- **buildBoundedHistorySection** — newest-first, ~6KB budget, 1500B per-message cap, always keeps the newest, header notes omissions.
- **capMessageBody** — latest body capped at 3500B with a marker.

Worst case ~6KB history + 3.5KB latest + ~2.5KB template/grounding/env ~= **12KB** (~4KB margin under the 16KB cliff). Full bodies still persist in the thread store; only the inline spawn-prompt copy is trimmed. **Scoped entirely to ThreadlineRouter** — zero change to the core spawn.

## Tests
- 7 helper unit tests (ThreadlineRouter-history-cap.test.ts) — both budget-boundary sides.
- Router wiring test — 40x2.5KB history + 20KB latest gives a prompt under 14KB, newest kept, oldest dropped, latest body capped.
- Existing 32 ThreadlineRouter tests pass unchanged. tsc clean.

## Follow-up
The complete fix (file-based prompt passing in SessionManager.spawnSession, preserving full context for ALL spawn paths) is tracked in #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)