### PR TITLE
fix(stop-gate): half-open retry reports breakerOpen (stop the /health degradation creep)

### DIFF
--- a/docs/specs/stopgate-halfopen-quiet.eli16.md
+++ b/docs/specs/stopgate-halfopen-quiet.eli16.md
@@ -1,0 +1,36 @@
+# ELI16 — Why my health page kept saying "degraded" even after the fix
+
+A while back I shipped a "circuit breaker" for a safety check that runs every time
+I finish a turn. On accounts without an API key, that check has to launch a little
+helper program that takes 5-6 seconds, but it's only given about 2 seconds — so it
+times out every single time. Each timeout was launching-and-killing the helper for
+nothing AND posting a "something degraded" note to my health page. The breaker
+fixed the big problem: after a few timeouts it "trips" and stops launching the
+helper for a cooldown period, so no more wasted work and no more flood of notes.
+
+But there was a leftover. A tripped breaker isn't permanent — every cooldown it
+does ONE test call to see if the helper is working again ("half-open retry"). If
+the helper is still slow, that one test call times out too — and the old code
+treated that timeout like any other, posting a fresh "degraded" note. So once per
+cooldown, a new note piled on. The count slowly climbed (I watched it go from 3 to
+10 in about forty minutes), and my health page kept showing "degraded" even though
+nothing was actually wrong — the breaker had already done its job.
+
+It's like a smoke detector that correctly went quiet after a false alarm, but every
+few minutes it still chirps once to test itself, and each chirp gets logged as a
+new fire. The fires aren't real; the log just looks alarming.
+
+The fix is small: when the breaker's test call fails and re-trips the breaker, I now
+label that outcome "breaker is open (will retry later)" instead of "timeout." My
+health page already knows to stay quiet about "breaker is open" notes, so the test
+chirps stop getting logged as new problems. The count stops climbing — it settles
+at the small number of real timeouts that happened before the breaker first
+tripped — and my health page can go back to "OK" instead of being stuck on
+"degraded."
+
+Nothing about my actual behavior changes. When I finish a turn, the safety check
+still fails open exactly the same way (it lets me stop). The only difference is that
+the routine self-test the breaker does each cooldown no longer pretends to be a
+brand-new problem on the health dashboard. It's purely about making the health
+signal honest, so that if something genuinely IS wrong later, "degraded" actually
+means something instead of being permanently lit by a harmless self-test.

--- a/docs/specs/stopgate-halfopen-quiet.md
+++ b/docs/specs/stopgate-halfopen-quiet.md
@@ -1,0 +1,66 @@
+---
+title: Stop-gate breaker — half-open retry reports breakerOpen (stop the per-cooldown /health degradation creep)
+date: 2026-05-30
+author: echo
+review-convergence: robustness-residual-2026-05-30
+approved: true
+approved-by: Justin
+approved-via: 12h autonomous mentorship+robustness session mandate — "any Instar robustness or Codex issue I find, I fix as a proper fleet PR (full ship-gate)". This is a robustness residual-fix for the shipped stop-gate breaker (#559). Reported to Justin in topic 13435.
+eli16-overview: stopgate-halfopen-quiet.eli16.md
+---
+
+# Spec — Stop-gate breaker half-open quiet
+
+**Date:** 2026-05-30
+**Author:** echo
+**Status:** approved (robustness residual-fix for #559)
+
+## Context
+
+The UnjustifiedStopGate circuit breaker (#559, v1.3.112) fixed the chronic
+`/health` degraded-flood on subscription agents: the gate Haiku-judges every Stop
+via a ~5-6s `claude -p` subprocess against a ~2s budget, so it times out on EVERY
+stop — fail-opening (correct) but wastefully spawning+killing a subprocess and
+emitting one `DegradationReport` per stop. The breaker opens after K consecutive
+provider failures and short-circuits (no spawn, no degradation) for a cooldown,
+then half-open-retries once.
+
+## Problem (observed live)
+
+After the breaker deployed, the degradation count still **slowly grew** (observed 3
+→ 10 over ~40 min) and `/health` stayed `degraded`. Root: once open, the breaker's
+periodic **half-open retry probe** calls the still-unavailable provider once per
+cooldown. That call times out and `evaluate()` returned `timeout` /
+`llmUnavailable` — each of which the route reports as a fresh `DegradationReport`.
+So every cooldown re-emitted one degradation, climbing the count and keeping
+`/health` degraded long after the breaker had already stopped the actual flood +
+subprocess churn. Cosmetic (the flood + waste were fixed) but a misleading signal.
+
+## Fix
+
+In `evaluate()`'s catch, after `onProviderFailure()`: if that failure (re)opened
+the breaker (`now < breakerOpenUntil`), report the outcome as `breakerOpen` instead
+of `timeout` / `llmUnavailable`. The route already suppresses `breakerOpen` from
+degradation reporting (#559), so:
+
+- The first **threshold-1** failures still report `timeout`/`llmUnavailable` and
+  emit a degradation (informative — the provider is failing).
+- The threshold-th failure (which opens the breaker) and every subsequent
+  half-open retry (which re-opens it) report `breakerOpen` — suppressed.
+
+So the degradation count caps at threshold-1 (default 2) and never creeps. The
+fail-open DECISION is unchanged (`breakerOpen` allows the stop exactly like
+`timeout`); only the degradation-emission of the breaker-(re)opening failure
+changes. `breakerThreshold: 0` (disabled) is respected — `onProviderFailure()`
+returns early, `breakerOpenUntil` stays 0, and failures report
+`timeout`/`llmUnavailable` as before.
+
+## Testing
+
+- `tests/unit/UnjustifiedStopGate-breaker.test.ts` — updated "opens after
+  threshold" (the opening failure now reports breakerOpen; count of provider calls
+  unchanged); strengthened "retries half-open" (the retry reports breakerOpen);
+  new dedicated regression: threshold=1, walk 4 cooldowns, every half-open retry
+  reports breakerOpen, never timeout/llmUnavailable. `breakerThreshold=0` and
+  "reachable resets" and "real timeout counts" tests pass unchanged.
+- Full gate/router-hook suites (18 + 2) green; no regression.

--- a/src/core/UnjustifiedStopGate.ts
+++ b/src/core/UnjustifiedStopGate.ts
@@ -344,6 +344,24 @@ export class UnjustifiedStopGate {
       // A timeout or unavailable provider counts toward the breaker — if it
       // trips, subsequent stops short-circuit (no spawn) until the cooldown.
       this.onProviderFailure();
+      // If this failure (re)opened the breaker, report it AS breakerOpen rather
+      // than timeout/llmUnavailable. The fail-open decision is identical, but
+      // breakerOpen is suppressed from /health degradation reporting — so the
+      // periodic half-open retry probe (which calls the still-unavailable
+      // provider once per cooldown and re-opens the breaker) stops emitting a
+      // fresh degradation every cycle. That residual was slowly growing the
+      // degradation count and keeping /health "degraded" long after the breaker
+      // had already stopped the actual flood + subprocess churn.
+      if (this.config.now() < this.breakerOpenUntil) {
+        return {
+          ok: false,
+          failure: {
+            kind: 'breakerOpen',
+            detail: `provider failure (re)opened breaker after ${this.consecutiveProviderFailures} consecutive failures; retrying after cooldown`,
+            latencyMs,
+          },
+        };
+      }
       if (msg === 'timeout') {
         return { ok: false, failure: { kind: 'timeout', detail: `>${this.config.clientTimeoutMs}ms`, latencyMs } };
       }

--- a/tests/unit/UnjustifiedStopGate-breaker.test.ts
+++ b/tests/unit/UnjustifiedStopGate-breaker.test.ts
@@ -44,13 +44,21 @@ describe('UnjustifiedStopGate circuit breaker', () => {
       now: c.now,
     });
 
-    // First 3 calls hit the provider (and fail-open with llmUnavailable).
-    for (let i = 0; i < 3; i++) {
+    // The first threshold-1 failures hit the provider and fail-open with
+    // llmUnavailable (these DO emit a /health degradation — informative that the
+    // provider is failing).
+    for (let i = 0; i < 2; i++) {
       const r = await gate.evaluate(INPUT);
       expect(r.ok).toBe(false);
       if (!r.ok) expect(r.failure.kind).toBe('llmUnavailable');
     }
-    expect(calls()).toBe(3);
+    // The threshold-th failure ALSO hits the provider, but because it OPENS the
+    // breaker it is reported as breakerOpen (suppressed from degradation) — so
+    // the count caps at threshold-1 instead of climbing forever.
+    const opening = await gate.evaluate(INPUT);
+    expect(opening.ok).toBe(false);
+    if (!opening.ok) expect(opening.failure.kind).toBe('breakerOpen');
+    expect(calls()).toBe(3); // the opening failure still called the provider
     expect(gate.breakerState().open).toBe(true);
 
     // Breaker now open: the next calls short-circuit to breakerOpen and DON'T
@@ -80,10 +88,15 @@ describe('UnjustifiedStopGate circuit breaker', () => {
     expect((await gate.evaluate(INPUT) as { failure: { kind: string } }).failure.kind).toBe('breakerOpen');
     expect(calls()).toBe(2);
 
-    // Cooldown elapsed → the gate retries the provider (half-open).
+    // Cooldown elapsed → the gate retries the provider (half-open). The provider
+    // is still down, so the retry re-opens the breaker and is reported as
+    // breakerOpen (NOT a fresh llmUnavailable) — this is what stops the
+    // per-cooldown /health degradation creep.
     c.advance(2);
-    await gate.evaluate(INPUT);
+    const halfOpen = await gate.evaluate(INPUT);
     expect(calls()).toBe(3); // provider called again after cooldown
+    expect(halfOpen.ok).toBe(false);
+    if (!halfOpen.ok) expect(halfOpen.failure.kind).toBe('breakerOpen');
   });
 
   it('a reachable provider resets the breaker (consecutive failures cleared)', async () => {
@@ -142,5 +155,34 @@ describe('UnjustifiedStopGate circuit breaker', () => {
     const r3 = await gate.evaluate(INPUT);
     if (!r3.ok) expect(r3.failure.kind).toBe('breakerOpen');
     expect(calls).toBe(2); // 3rd call short-circuited (no provider call)
+  });
+
+  it('suppresses per-cooldown degradation: every half-open retry re-opens as breakerOpen, never re-emitting timeout/llmUnavailable', async () => {
+    // Regression for the breaker residual (#18): once open, the periodic
+    // half-open retry probe calls the still-down provider once per cooldown.
+    // Each such failure must report breakerOpen (suppressed from /health
+    // degradation) — NOT a fresh timeout/llmUnavailable — so the degradation
+    // count stops climbing and /health doesn't stay "degraded" indefinitely
+    // after the breaker has already stopped the actual flood + subprocess churn.
+    const { provider } = throwingProvider();
+    const c = clock();
+    const gate = new UnjustifiedStopGate({
+      intelligence: provider, breakerThreshold: 1, breakerCooldownMs: 5_000, now: c.now,
+    });
+
+    // threshold 1 → the very first failure opens the breaker → breakerOpen.
+    const first = await gate.evaluate(INPUT);
+    expect(first.ok).toBe(false);
+    if (!first.ok) expect(first.failure.kind).toBe('breakerOpen');
+
+    // Walk several cooldowns; each half-open retry of the still-down provider
+    // re-opens the breaker and reports breakerOpen — never a degradation-emitting
+    // kind. This is the cap that prevents the slow per-cooldown creep.
+    for (let i = 0; i < 4; i++) {
+      c.advance(5_001); // cooldown elapsed → half-open retry calls the provider
+      const r = await gate.evaluate(INPUT);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.failure.kind).toBe('breakerOpen');
+    }
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,51 @@
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**The stop-gate circuit breaker no longer slowly creeps the `/health` degradation
+count while it's open.**
+
+Follow-up to the breaker shipped in #559. Once the breaker is open, it does one
+half-open retry probe per cooldown to check whether the (still-unavailable)
+provider has recovered. That probe timed out and `evaluate()` returned
+`timeout`/`llmUnavailable`, each of which the route reports as a fresh
+`DegradationReport` — so the count climbed ~1 per cooldown (observed 3 → 10 over
+~40 min) and `/health` stayed `degraded` long after the breaker had already
+stopped the actual flood + subprocess churn.
+
+Fix: when a provider failure (re)opens the breaker, `evaluate()` now reports
+`breakerOpen` instead of `timeout`/`llmUnavailable`. The route already suppresses
+`breakerOpen` from degradation reporting, so the half-open retry stops emitting a
+fresh degradation each cooldown. The count caps at `breakerThreshold - 1` and
+`/health` can return to `ok`. The fail-open decision is unchanged.
+
+## What to Tell Your User
+
+After the earlier circuit-breaker fix, my health page could still slowly drift into
+"degraded" and stay there — not because anything was wrong, but because the breaker
+does a routine self-test once per cooldown, and each self-test was being logged as a
+brand-new problem. I changed that self-test to be recognized as the breaker's normal
+"still cooling down" state instead of a fresh fault, so it stops piling up false
+"degraded" notes. My health signal is now honest again — if it says degraded, it
+means something. Nothing about how I actually behave changed.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Quiet half-open breaker retry | Automatic — the breaker's per-cooldown self-test no longer emits a health degradation |
+
+## Evidence
+
+- **Live observation:** with the breaker deployed (v1.3.112) the degradation count
+  climbed from 3 to 10 over ~40 minutes — one per cooldown from the half-open retry
+  probe — and the health status stayed degraded.
+- **Tests:** `tests/unit/UnjustifiedStopGate-breaker.test.ts` — updated the
+  threshold-opening assertion, strengthened the half-open assertion, and added a
+  dedicated regression that walks 4 cooldowns and verifies every half-open retry
+  reports the suppressed breaker-open kind, never a fresh timeout. Full gate +
+  router-hook suites (18 + 2) green.
+- Spec: `docs/specs/stopgate-halfopen-quiet.md`. Side-effects:
+  `upgrades/side-effects/stopgate-halfopen-quiet.md`.

--- a/upgrades/side-effects/stopgate-halfopen-quiet.md
+++ b/upgrades/side-effects/stopgate-halfopen-quiet.md
@@ -1,0 +1,36 @@
+# Side-effects — Stop-gate breaker half-open quiet
+
+**Change:** `UnjustifiedStopGate.evaluate()` now reports `breakerOpen` (instead of
+`timeout` / `llmUnavailable`) for a provider failure that (re)opens the breaker.
+
+## Behavioral side-effects
+
+- **The `/health` degradation count no longer creeps while the breaker is open.**
+  Previously each per-cooldown half-open retry of a still-down provider emitted a
+  fresh `timeout`/`llmUnavailable` degradation; now those report the suppressed
+  `breakerOpen` kind. The count caps at `breakerThreshold - 1` (default 2) instead
+  of climbing indefinitely, and `/health` can return to `ok` once the initial
+  failures age out.
+- **The breaker-opening failure is now categorized `breakerOpen` in the stop-gate
+  audit DB / log**, not `timeout`/`llmUnavailable`. Anyone reading the stop-gate
+  log sees the breaker open at the threshold-th failure rather than seeing K
+  identical timeouts then a separate open. The provider IS still called on that
+  failure (call counts unchanged); only the reported kind changes.
+- **The fail-open decision is unchanged.** `breakerOpen` allows the stop exactly
+  like `timeout` did — agents stop on a degraded gate identically. No behavior
+  change to when/whether a session may stop.
+- **No change with the breaker disabled.** `breakerThreshold: 0` short-circuits
+  `onProviderFailure()`; `breakerOpenUntil` stays 0; failures report
+  `timeout`/`llmUnavailable` exactly as before.
+
+## Blast radius
+
+- Scoped to `src/core/UnjustifiedStopGate.ts` (one catch block). No route change
+  (the route already suppresses `breakerOpen` from #559). No config, schema, hook,
+  or migration changes. No new dependencies.
+
+## Migration parity
+
+None required — internal runtime logic in `src/`. Existing agents receive it on
+their normal version update; no agent-installed file to migrate. Builds on #559's
+breaker which already shipped fleet-wide.


### PR DESCRIPTION
## Problem (observed live)

Residual-fix for the stop-gate circuit breaker (#559, v1.3.112). The breaker fixed the degraded-FLOOD, but the count still slowly **crept** (observed 3 -> 10 over ~40 min) and /health stayed 'degraded'. Root: once open, the breaker's per-cooldown **half-open retry probe** calls the still-down provider; that call timed out and evaluate() returned timeout/llmUnavailable — each reported by the route as a fresh DegradationReport. So every cooldown re-emitted one degradation, climbing the count long after the breaker had already stopped the actual flood + subprocess churn. Cosmetic, but a misleading health signal.

## Fix

In evaluate()'s catch, after onProviderFailure(): if that failure (re)opened the breaker (now < breakerOpenUntil), report breakerOpen instead of timeout/llmUnavailable. The route already suppresses breakerOpen from degradation reporting (#559), so:
- the first **threshold-1** failures still report timeout/llmUnavailable and emit a degradation (informative);
- the threshold-th failure (opens the breaker) and every half-open retry (re-opens it) report breakerOpen — suppressed.

Count caps at breakerThreshold-1 (default 2); /health can return to ok. **Fail-open decision unchanged** (breakerOpen allows the stop exactly like timeout). breakerThreshold:0 (disabled) respected.

## Tests
- Updated 'opens after threshold' (opening failure now reports breakerOpen; provider call-count unchanged) + strengthened 'retries half-open' (retry reports breakerOpen).
- New regression: threshold=1, walk 4 cooldowns, every half-open retry reports breakerOpen, never timeout/llmUnavailable.
- breakerThreshold=0 / reachable-reset / real-timeout tests pass unchanged. Full gate + router-hook suites (18+2) green.

Scoped to src/core/UnjustifiedStopGate.ts (one catch block) — no route change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)