### PR TITLE
fix threadline send default wait

### DIFF
--- a/docs/specs/THREADLINE-NETWORK-INTEROP-SPEC.md
+++ b/docs/specs/THREADLINE-NETWORK-INTEROP-SPEC.md
@@ -321,7 +321,7 @@ Exposes Threadline capabilities as MCP tools. Any MCP-capable agent (Claude, Ope
           "agentId": { "type": "string", "description": "Target agent identifier" },
           "threadId": { "type": "string", "description": "Thread ID to resume (omit for new conversation)" },
           "message": { "type": "string", "description": "Message content" },
-          "waitForReply": { "type": "boolean", "default": true, "description": "Wait for the agent's response" },
+          "waitForReply": { "type": "boolean", "default": false, "description": "Wait for the agent's response. Set true only when a synchronous reply is required." },
           "timeoutSeconds": { "type": "number", "default": 120, "description": "Max seconds to wait for reply (only with waitForReply)" }
         },
         "required": ["agentId", "message"]

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-30T10:58:15.149Z",
-  "instarVersion": "1.3.115",
+  "generatedAt": "2026-05-30T11:23:02.544Z",
+  "instarVersion": "1.3.116",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-30T09:36:35.178Z",
-  "instarVersion": "1.3.111",
+  "generatedAt": "2026-05-30T10:58:15.149Z",
+  "instarVersion": "1.3.115",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -409,7 +409,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -417,7 +417,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -425,7 +425,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -433,7 +433,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -441,7 +441,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -449,7 +449,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -457,7 +457,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -465,7 +465,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -473,7 +473,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -481,7 +481,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -489,7 +489,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -497,7 +497,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -505,7 +505,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -513,7 +513,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -521,7 +521,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -529,7 +529,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -537,7 +537,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -545,7 +545,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -553,7 +553,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -561,7 +561,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -569,7 +569,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -577,7 +577,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -585,7 +585,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -593,7 +593,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -601,7 +601,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -609,7 +609,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -617,7 +617,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -625,7 +625,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -633,7 +633,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -641,7 +641,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -649,7 +649,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -657,7 +657,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -665,7 +665,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -673,7 +673,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -681,7 +681,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -689,7 +689,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -697,7 +697,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -705,7 +705,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -713,7 +713,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -721,7 +721,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -729,7 +729,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -737,7 +737,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -745,7 +745,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -761,7 +761,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "80b68f39cb6113a879db06c1e704cbc1f999b95c8a5021cbf1b0bbac1f0dbb8d",
+      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1521,7 +1521,7 @@
       "type": "subsystem",
       "domain": "communication",
       "sourcePath": "src/lifeline/TelegramLifeline.ts",
-      "contentHash": "f44cbf8d78df7dab429a50f3e70c2bb27b6f36a8fb32ea48e7f088650680eec2",
+      "contentHash": "03f9fc147f3e520e114e32df64fe6ba2a69f58664c3cb94f495532d47f5bcded",
       "since": "2025-01-01"
     },
     "subsystem:orphan-process-reaper": {

--- a/src/threadline/ThreadlineMCPServer.ts
+++ b/src/threadline/ThreadlineMCPServer.ts
@@ -513,8 +513,8 @@ export class ThreadlineMCPServer {
           'Thread ID to resume (omit for new conversation)'
         ),
         message: z.string().describe('Message content'),
-        waitForReply: z.boolean().default(true).describe(
-          'Wait for the agent\'s response'
+        waitForReply: z.boolean().default(false).describe(
+          'Wait for the agent\'s response. Defaults to false so delivery acknowledgement returns promptly; set true only when the caller needs a synchronous reply.'
         ),
         timeoutSeconds: z.number().default(120).describe(
           'Max seconds to wait for reply (only with waitForReply)'

--- a/tests/e2e/threadline/ThreadlineMCPE2E.test.ts
+++ b/tests/e2e/threadline/ThreadlineMCPE2E.test.ts
@@ -206,7 +206,7 @@ describe('ThreadlineMCP E2E', () => {
       // Message 1: Start conversation
       const r1 = await e2e.client.callTool({
         name: 'threadline_send',
-        arguments: { agentId: 'research-bot', message: 'What is quantum computing?' },
+        arguments: { agentId: 'research-bot', message: 'What is quantum computing?', waitForReply: true },
       });
       const d1 = JSON.parse((r1.content as any)[0].text);
       const threadId = d1.threadId;
@@ -220,6 +220,7 @@ describe('ThreadlineMCP E2E', () => {
             agentId: 'research-bot',
             threadId,
             message: `Follow-up question ${i}`,
+            waitForReply: true,
           },
         });
         const d = JSON.parse((r.content as any)[0].text);
@@ -248,7 +249,7 @@ describe('ThreadlineMCP E2E', () => {
       for (const agent of agents) {
         const r = await e2e.client.callTool({
           name: 'threadline_send',
-          arguments: { agentId: agent, message: `Hello ${agent}!` },
+          arguments: { agentId: agent, message: `Hello ${agent}!`, waitForReply: true },
         });
         threads.push(JSON.parse((r.content as any)[0].text).threadId);
       }
@@ -264,6 +265,7 @@ describe('ThreadlineMCP E2E', () => {
               agentId: agents[i],
               threadId: threads[i],
               message: `Round ${round} to ${agents[i]}`,
+              waitForReply: true,
             },
           });
         }
@@ -537,14 +539,14 @@ describe('ThreadlineMCP E2E', () => {
       // Create
       const r1 = await e2e.client.callTool({
         name: 'threadline_send',
-        arguments: { agentId: 'lifecycle-agent', message: 'Birth' },
+        arguments: { agentId: 'lifecycle-agent', message: 'Birth', waitForReply: true },
       });
       const { threadId } = JSON.parse((r1.content as any)[0].text);
 
       // Interact
       await e2e.client.callTool({
         name: 'threadline_send',
-        arguments: { agentId: 'lifecycle-agent', threadId, message: 'Growth' },
+        arguments: { agentId: 'lifecycle-agent', threadId, message: 'Growth', waitForReply: true },
       });
 
       // Verify history

--- a/tests/unit/threadline/ThreadlineMCPServer.test.ts
+++ b/tests/unit/threadline/ThreadlineMCPServer.test.ts
@@ -506,8 +506,41 @@ describe('ThreadlineMCPServer', () => {
             targetAgent: 'remote-agent',
             threadId: 'existing-thread-42',
             message: 'Continuing our conversation',
+            waitForReply: false,
           }),
         );
+      } finally {
+        await close();
+      }
+    });
+
+    it('defaults to fire-and-forget so delivery ack does not wait for a reply', async () => {
+      (deps.sendMessage as any).mockResolvedValue({
+        success: true,
+        threadId: 'thread-default-no-wait',
+        messageId: 'msg-default-no-wait',
+      });
+
+      const { client, close } = await connectClientServer({}, deps);
+      try {
+        const result = await client.callTool({
+          name: 'threadline_send',
+          arguments: {
+            agentId: 'remote-agent',
+            message: 'Default send should return after delivery',
+          },
+        });
+
+        expect(deps.sendMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            waitForReply: false,
+            timeoutSeconds: 120,
+          }),
+        );
+        const data = JSON.parse((result.content as any)[0].text);
+        expect(data.delivered).toBe(true);
+        expect(data.reply).toBeUndefined();
+        expect(data.note).toBeUndefined();
       } finally {
         await close();
       }

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,52 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Threadline sends from Codex no longer duplicate after the delivery succeeds.**
+
+The MCP `threadline_send` tool used to default `waitForReply` to `true`, which
+meant a send could be accepted locally and then keep the MCP tool call open while
+waiting for a peer reply. Codex's tool layer times out long-running MCP calls at
+about 30 seconds, so an already-delivered send could be retried as if it had
+failed. That produced identical Threadline replies 2-3 times, and each duplicate
+also surfaced into the mirrored Telegram topic.
+
+The MCP default now matches the HTTP relay behavior: omitted `waitForReply`
+returns after delivery is accepted. Callers that intentionally need a synchronous
+request/response flow can still set `waitForReply: true`; the existing reply
+waiter and timeout semantics remain available for that explicit mode. The
+Threadline interop spec now documents the same default so downstream
+implementations do not preserve the old synchronous behavior accidentally.
+
+## What to Tell Your User
+
+When I message another agent through Threadline, my reply should now show up once
+instead of sometimes repeating after a short delay. The underlying send path now
+confirms delivery promptly by default, so the system no longer mistakes a slow
+wait for a failed send and tries the same message again. Direct back-and-forth
+agent collaboration should be quieter and less spammy in mirrored Telegram
+topics.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Threadline delivery acknowledgement by default | Automatic for MCP `threadline_send` calls that omit `waitForReply` |
+| Explicit synchronous Threadline replies | Set `waitForReply: true` when the caller really needs to wait for a reply |
+
+## Evidence
+
+- **Live reproduction:** Codey's own Threadline ACK to Echo was accepted by the
+  local relay, then the MCP tool call stayed open and timed out at about 30
+  seconds because the tool default waited for a reply. Prior log samples on the
+  same Threadline path showed identical accepted sends separated by roughly the
+  same retry-sized gap.
+- **Verified fix shape:** the MCP schema default now passes `waitForReply:
+  false` into the send dependency when the caller omits it, while tests that
+  explicitly set `waitForReply: true` still exercise the synchronous reply path.
+- **Tests:** `npm test -- tests/unit/threadline/ThreadlineMCPServer.test.ts`,
+  `npm test -- tests/e2e/threadline/ThreadlineMCPE2E.test.ts`,
+  `npm run lint`, and `npm run build` passed. Side-effects review:
+  `upgrades/side-effects/threadline-codex-send-timeout.md`.

--- a/upgrades/side-effects/threadline-codex-send-timeout.md
+++ b/upgrades/side-effects/threadline-codex-send-timeout.md
@@ -105,3 +105,7 @@ Darwin's second-pass concern was that `docs/specs/THREADLINE-NETWORK-INTEROP-SPE
 - `npm run test:smoke` via pre-push — passed the affected smoke set before the Threadline-scoped e2e gate exposed implicit synchronous-wait test assumptions.
 - `npm run lint` — passed.
 - `npm run build` — passed; `sign-lockfile` warned that no local signing key is configured, which is the documented transitional local-dev state.
+
+## Post-main-merge verification
+
+After `origin/main` advanced to `1.3.116`, this branch merged main cleanly and regenerated `src/data/builtin-manifest.json` so the manifest version matches the release base. Re-verification after that merge: `npm test -- tests/unit/threadline/ThreadlineMCPServer.test.ts tests/e2e/threadline/ThreadlineMCPE2E.test.ts` passed 60/60, and `npm run build` passed with the same local signing-key warning described above.

--- a/upgrades/side-effects/threadline-codex-send-timeout.md
+++ b/upgrades/side-effects/threadline-codex-send-timeout.md
@@ -1,0 +1,107 @@
+# Side-Effects Review — Threadline Codex send timeout duplicate fix
+
+**Version / slug:** `threadline-codex-send-timeout`
+**Date:** `2026-05-30`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Darwin`
+
+## Summary of the change
+
+This change makes the MCP `threadline_send` tool default to fire-and-forget delivery acknowledgement instead of waiting synchronously for a peer reply. The root cause came from live Codey evidence: local delivery to Echo succeeded, but the MCP tool call stayed open because `waitForReply` defaulted to `true`; Codex's tool layer timed out at about 30 seconds and retry-shaped duplicate sends followed. The changed runtime file is `src/threadline/ThreadlineMCPServer.ts`, with regression coverage in `tests/unit/threadline/ThreadlineMCPServer.test.ts`, explicit synchronous-reply e2e coverage in `tests/e2e/threadline/ThreadlineMCPE2E.test.ts`, an interop contract update in `docs/specs/THREADLINE-NETWORK-INTEROP-SPEC.md`, and regenerated manifest metadata in `src/data/builtin-manifest.json`.
+
+## Decision-point inventory
+
+- `threadline_send` MCP schema default — modify — omitted `waitForReply` now means "ack delivery and return" rather than "hold the tool call open for a synchronous reply."
+- `threadline_send` explicit synchronous mode — pass-through — callers that set `waitForReply: true` still use the existing reply waiter and timeout semantics.
+- Threadline interop documentation — modify — the documented MCP schema now matches the runtime default so downstream implementations do not preserve the old synchronous default accidentally.
+- Threadline MCP e2e tests — modify — scenarios that assert reply messages in history now request `waitForReply: true` explicitly.
+
+---
+
+## 1. Over-block
+
+No block/allow surface — over-block not applicable. This change does not reject any message or caller; it changes only the default waiting behavior when the caller omits an optional boolean.
+
+The closest compatibility risk is behavioral: a caller that omitted `waitForReply` while implicitly depending on the old default will no longer receive a synchronous `reply` field. That caller can restore prior behavior by sending `waitForReply: true`. Existing tests that require replies already set `waitForReply: true`, and the tool description now states the default explicitly.
+
+---
+
+## 2. Under-block
+
+This does not add a duplicate-send idempotency layer. It fixes the observed Codex retry trigger by returning promptly after accepted delivery. Duplicate sends caused by a caller explicitly setting `waitForReply: true` with a tool harness timeout shorter than the requested wait can still occur. That is intentional: explicit synchronous waits remain available for workflows that truly need request/response behavior.
+
+This also does not protect non-MCP direct HTTP callers that implement their own retry loop without idempotency. The `/threadline/relay-send` API already treats omitted `waitForReply` as false; the bad default lived at the MCP schema boundary.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The fix is at the right layer: the wrong behavior was an MCP tool default, not local delivery, SpawnLedger, the relay, or the reply waiter itself. Adding dedup deeper in transport would help a broader class later, but it would not remove the immediate Codex-specific timeout trigger. Changing only the MCP default preserves explicit synchronous reply semantics while making reply-worker sends safe by default.
+
+This is not a detector or a new authority. It is API-default hygiene at the boundary where model tool calls become HTTP sends.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] Yes, with brittle logic — STOP. Reshape the design. Brittle detectors must not own block authority.
+
+No brittle detector or blocking path is added. The change removes an accidental synchronous wait from the default send path; it does not decide whether content should be sent, surfaced, suppressed, or trusted.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The MCP default feeds `deps.sendMessage`, which posts to `/threadline/relay-send`. The HTTP route already waits only on truthy `waitForReply`, so the changed default aligns the MCP layer with route behavior instead of shadowing it.
+- **Double-fire:** The prior default created a double-fire risk by holding the tool call open past Codex's MCP timeout after delivery had already succeeded. The new default removes that retry pressure for omitted `waitForReply`.
+- **Races:** No shared state is introduced. Existing reply waiters, pending wait maps, and inbound reply resolution remain used only when the caller explicitly asks to wait.
+- **Feedback loops:** The change reduces the retry loop where a timed-out tool call led the model/harness to issue the same `threadline_send` again.
+
+---
+
+## 6. External surfaces
+
+- **Other agents:** Agents receiving Codex-origin Threadline replies should see fewer duplicate identical messages. Agents that rely on a synchronous response from `threadline_send` must set `waitForReply: true`.
+- **Interop readers:** The Threadline network interop spec now documents the new default. Implementers reading the spec should see the same default the MCP server enforces.
+- **Users:** Telegram topics that mirror agent chatter should see less duplicate inter-agent spam.
+- **External systems:** No relay protocol, Telegram, Slack, GitHub, or Cloudflare surface changes.
+- **Persistent state:** No migration or state write shape changes. Existing conversation, outbox, and Threadline stores keep the same schema.
+- **Timing:** The default tool call now returns as soon as delivery is accepted instead of waiting up to `timeoutSeconds`; explicit waits retain the old timing.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a small code revert: restore `waitForReply` default to `true` and ship a patch. No data migration or agent state repair is needed. The rollback risk is reintroducing Codex duplicate sends when the tool harness times out before the reply waiter returns.
+
+---
+
+## Conclusion
+
+This is clear to ship as a targeted default correction. It addresses the live Codey duplicate-send root cause without weakening transport validation, changing the relay protocol, or removing explicit synchronous request/response capability.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** Darwin
+**Independent read of the artifact: concern raised, then resolved**
+
+Darwin's second-pass concern was that `docs/specs/THREADLINE-NETWORK-INTEROP-SPEC.md` still documented `threadline_send.waitForReply` with `"default": true`, which would let downstream agents or implementers continue relying on the old synchronous default. Resolved by updating that interop schema to default `false` with an explicit note that callers should set `true` only when a synchronous reply is required.
+
+---
+
+## Evidence pointers
+
+- `npm test -- tests/unit/threadline/ThreadlineMCPServer.test.ts` — 45 tests passed, including the new omitted-`waitForReply` regression.
+- `npm test -- tests/e2e/threadline/ThreadlineMCPE2E.test.ts` — 15 tests passed after making synchronous-reply scenarios explicit.
+- `npm run test:smoke` via pre-push — passed the affected smoke set before the Threadline-scoped e2e gate exposed implicit synchronous-wait test assumptions.
+- `npm run lint` — passed.
+- `npm run build` — passed; `sign-lockfile` warned that no local signing key is configured, which is the documented transitional local-dev state.


### PR DESCRIPTION
## Summary

Fixes the Codex-specific duplicate Threadline reply loop by changing the MCP `threadline_send` default to return after delivery acknowledgement instead of waiting synchronously for a peer reply.

Root cause from local logs: the relay accepted Codey's send, but the MCP call stayed open because omitted `waitForReply` defaulted to `true`. Codex times out long-running MCP calls at about 30 seconds, so the tool call could be retried after the message was already delivered. Claude did not hit the same retry shape.

## Changes

- Default MCP `threadline_send.waitForReply` to `false`.
- Preserve explicit synchronous mode via `waitForReply: true`.
- Add a regression test for omitted `waitForReply`.
- Update MCP e2e tests that intentionally assert reply messages to request synchronous replies explicitly.
- Update the Threadline interop spec and release notes.
- Add side-effects review artifact: `upgrades/side-effects/threadline-codex-send-timeout.md`.

## Verification

- `npm test -- tests/unit/threadline/ThreadlineMCPServer.test.ts`
- `npm test -- tests/e2e/threadline/ThreadlineMCPE2E.test.ts`
- `npm run lint`
- `npm run build`
- Pre-push smoke tier: 18 tests passed
- Pre-push Threadline-scoped e2e gate: 16 files, 331 tests passed
