### PR TITLE
perf(memory): idle-unload the ONNX embedding pipeline to stop the thread-pool busy-spin

### DIFF
--- a/docs/specs/onnx-idle-unload.eli16.md
+++ b/docs/specs/onnx-idle-unload.eli16.md
@@ -1,0 +1,37 @@
+# ELI16 — Why a "paused" agent was still burning CPU
+
+Every agent has a little local AI model it uses to understand and search its own
+memories (it turns text into number-vectors). Loading that model is slow-ish, so
+once it's loaded we kept it in memory, ready to go. Sounds efficient — except the
+engine that runs the model (onnxruntime) keeps a team of worker threads, and those
+threads don't actually go to sleep when there's nothing to do. They *busy-wait* —
+they keep spinning in a tight loop checking "is there work yet? is there work yet?"
+— which burns real CPU even when the agent is completely idle.
+
+I measured it live: a loaded-but-idle model eats about 3.6% of a CPU core on a quiet
+machine, and I'd earlier seen it hit ~44% on a busy one. Now picture five agents on
+one computer — Echo, AI Guy, Dawn, and a couple more — each keeping its own model
+loaded and spinning while they're all supposedly "paused." That's a big chunk of a
+machine's CPU spent on literally nothing. It's one of the real reasons the box felt
+overloaded.
+
+The fix is simple: if an agent hasn't needed its memory model for a while (5 minutes
+by default), unload it — tell the engine to release its worker threads — and just
+reload it the next time it's actually needed. Loading takes only a second or two,
+and memory searches aren't the kind of thing that needs to be instant, so paying a
+one-time second when you come back from a long idle is a great trade for not burning
+CPU the whole time you're idle.
+
+I verified the whole cycle on the real model, not just in a unit test: idle CPU went
+from 3.6% down to **0.0%** after unloading, and after reloading, the model produced
+the *exact same* number-vector for the same text (so nothing is lost or corrupted by
+unloading and reloading). I also made sure it's safe: if the agent IS in the middle
+of a big batch of memory work when the timer goes off, it won't yank the model out
+from under it — it waits until the work is done. And if an operator ever wants the
+old "keep it loaded forever" behavior, they can set the idle time to zero to turn the
+feature off.
+
+The upshot: agents that aren't doing memory work stop wasting CPU on a spinning
+model. Active agents are unaffected — every time they use memory, the clock resets,
+so the model stays loaded as long as they keep using it. It only unloads during
+genuine idle, which is exactly when that CPU should be free for something else.

--- a/docs/specs/onnx-idle-unload.md
+++ b/docs/specs/onnx-idle-unload.md
@@ -1,0 +1,74 @@
+---
+title: EmbeddingProvider idle-unload — dispose the ONNX pipeline when idle to stop the thread-pool busy-spin
+date: 2026-05-30
+author: echo
+review-convergence: robustness-load-2026-05-30
+approved: true
+approved-by: Justin
+approved-via: 12h autonomous mentorship+robustness session mandate — "treat load as suspect → diagnose as a bug" + "any Instar robustness issue I find, I fix as a proper fleet PR (full ship-gate)". This is a measured fleet-load fix (idle CPU waste). Reported to Justin in topic 13435.
+eli16-overview: onnx-idle-unload.eli16.md
+---
+
+# Spec — EmbeddingProvider idle-unload
+
+**Date:** 2026-05-30
+**Author:** echo
+**Status:** approved (robustness / fleet-load fix)
+
+## Problem (measured live)
+
+`EmbeddingProvider` (the shared local embedding service backing SemanticMemory,
+MemoryIndex, TopicMemory) loads the all-MiniLM-L6-v2 ONNX model lazily on first
+`embed()` and then **keeps it resident forever**. onnxruntime's thread pool
+**busy-spins even when no embedding is happening**. Measured on a live box via
+`process.cpuUsage()` over a 3s idle window with the model loaded:
+
+- **IDLE-while-LOADED: ~3.6% of one core** on a quiet process — and previously
+  observed at **~44%** on a contended agent (AI Guy) that was supposedly "paused".
+
+That is pure wasted CPU for any agent that isn't actively doing memory work. With
+several agents on one box each holding an idle, spinning model, it's a real,
+multiplied contributor to fleet load — exactly the "load is suspect" signal this
+session was asked to chase.
+
+## Fix
+
+Idle-unload the pipeline. After `idleUnloadMs` (default 300000 = 5 min) with no
+`embed()` call, dispose the loaded pipeline — freeing the onnxruntime session +
+its thread pool — and lazily reload on the next `embed()`.
+
+- A rolling timer is re-armed on every embed (entry/exit), so an actively-embedding
+  agent keeps the model resident; one that goes quiet unloads it.
+- An `inFlight` counter guards `maybeUnload()` so a long-running batch that outlasts
+  the window is never disposed mid-flight (its completion re-arms the timer).
+- The timer is `unref()`'d so it can never hold the process open on its own.
+- `idleUnloadMs: 0` disables the behavior (keep resident — the prior behavior).
+- A public `dispose()` releases the model + cancels the timer for shutdown/tests.
+
+## Verification (live, not just unit)
+
+Ran the real model through `process.cpuUsage()`:
+- **IDLE-while-LOADED: 3.6% of one core** → **IDLE-after-DISPOSE: 0.0%**. `dispose()`
+  exists on the pipeline and stops the spin.
+- **dispose → reload → embed produced an IDENTICAL embedding** (`[0]=-0.0345` both
+  before and after; `RELOAD CYCLE OK`), confirming the lazy reload is correct and
+  the dispose+reload pattern is clean (no mutex/exit race in the production path,
+  which disposes during idle and keeps running).
+
+## Testing
+
+- `tests/unit/EmbeddingProvider-idle-unload.test.ts` (5, mock pipeline + fake
+  timers): disposes after the idle window + lazily reloads; stays resident while
+  embeds keep coming (timer resets); `idleUnloadMs:0` disables; inFlight guard
+  (never disposes mid-embed, disposes once idle); explicit `dispose()` releases +
+  cancels the timer.
+- `tsc` clean. `isReady` is not used by any caller to gate embeds, so its now-dynamic
+  value (can flip false after unload) is safe. The production singleton
+  (`server.ts`) constructs with defaults → idle-unload ON at 5 min.
+
+## Scope / tuning
+
+Internal runtime logic in `src/memory/`. No agent-installed file, config schema,
+or migration changes (the default lives in the constructor config). `idleUnloadMs`
+is tunable via the `EmbeddingProvider` constructor; wiring it to `.instar/config.json`
+can be added later if an operator needs to tune it without a code change.

--- a/src/memory/EmbeddingProvider.ts
+++ b/src/memory/EmbeddingProvider.ts
@@ -22,6 +22,23 @@ export interface EmbeddingProviderConfig {
   dimensions?: number;
   /** Maximum text length to embed in characters (default: 8192) */
   maxTextLength?: number;
+  /**
+   * Idle-unload window in ms. After this long with no embed() call, the loaded
+   * ONNX pipeline is disposed to free its thread pool, which busy-spins even
+   * when idle (measured: ~3.6% of a core on a quiet box, up to ~44% on a
+   * contended one — pure waste while an agent isn't doing memory work). The
+   * next embed() lazily reloads (~1-3s, verified-identical output). Default
+   * 300000 (5 min). Set 0 to disable (keep the model resident forever — the
+   * prior behavior).
+   */
+  idleUnloadMs?: number;
+  /**
+   * Test/advanced seam: factory that produces the feature-extraction pipeline.
+   * Defaults to the real `@huggingface/transformers` import. Tests inject a mock
+   * (a callable with a `dispose()`) to exercise the idle-unload lifecycle
+   * without loading the 80MB model.
+   */
+  pipelineFactory?: (modelName: string) => Promise<any>;
 }
 
 export class EmbeddingProvider {
@@ -30,12 +47,21 @@ export class EmbeddingProvider {
   private readonly modelName: string;
   readonly dimensions: number;
   private readonly maxTextLength: number;
+  private readonly idleUnloadMs: number;
+  private readonly pipelineFactory?: (modelName: string) => Promise<any>;
   private vecExtensionLoaded = new WeakSet<object>();
+
+  /** In-flight embed() calls — the idle-unload timer never disposes while > 0. */
+  private inFlight = 0;
+  /** Rolling idle-unload timer (reset on every embed); unref'd so it can't keep the process alive. */
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(config?: EmbeddingProviderConfig) {
     this.modelName = config?.modelName ?? 'Xenova/all-MiniLM-L6-v2';
     this.dimensions = config?.dimensions ?? 384;
     this.maxTextLength = config?.maxTextLength ?? 8192;
+    this.idleUnloadMs = config?.idleUnloadMs ?? 300_000;
+    this.pipelineFactory = config?.pipelineFactory;
   }
 
   // ─── Lifecycle ──────────────────────────────────────────────────
@@ -55,6 +81,10 @@ export class EmbeddingProvider {
   }
 
   private async loadModel(): Promise<void> {
+    if (this.pipelineFactory) {
+      this.pipeline = await this.pipelineFactory(this.modelName);
+      return;
+    }
     const { pipeline: createPipeline } = await import('@huggingface/transformers');
     this.pipeline = await createPipeline('feature-extraction', this.modelName, {
       dtype: 'fp32',
@@ -68,6 +98,60 @@ export class EmbeddingProvider {
     return this.pipeline !== null;
   }
 
+  /**
+   * Arm (or re-arm) the rolling idle-unload timer. Called after every embed so
+   * the window restarts on each use — an actively-embedding agent keeps the
+   * model resident; one that goes quiet for `idleUnloadMs` unloads it.
+   */
+  private scheduleIdleUnload(): void {
+    if (this.idleUnloadMs <= 0) return; // disabled — keep resident
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      void this.maybeUnload();
+    }, this.idleUnloadMs);
+    // Never let the idle timer hold the process open on its own.
+    this.idleTimer.unref?.();
+  }
+
+  /**
+   * Dispose the loaded pipeline if it's idle — frees the ONNX thread pool that
+   * busy-spins even when no embedding is happening. Guarded on inFlight so a
+   * long-running batch that outlasts the window is never disposed mid-flight;
+   * its completion re-arms the timer.
+   */
+  private async maybeUnload(): Promise<void> {
+    if (this.inFlight > 0 || !this.pipeline) return;
+    const p = this.pipeline;
+    this.pipeline = null;
+    this.loading = null;
+    try {
+      await p?.dispose?.();
+    } catch {
+      // @silent-fallback-ok — dispose is best-effort cleanup; failing to free
+      // the session is not fatal (the next embed reloads a fresh pipeline).
+    }
+  }
+
+  /**
+   * Explicitly release the model + cancel the idle timer (shutdown / tests).
+   * Idempotent.
+   */
+  async dispose(): Promise<void> {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+    if (this.pipeline) {
+      const p = this.pipeline;
+      this.pipeline = null;
+      this.loading = null;
+      try {
+        await p?.dispose?.();
+      } catch { /* @silent-fallback-ok — best-effort cleanup */ }
+    }
+  }
+
   // ─── Embedding ──────────────────────────────────────────────────
 
   /**
@@ -75,16 +159,22 @@ export class EmbeddingProvider {
    * Lazy-initializes the model on first call.
    */
   async embed(text: string): Promise<Float32Array> {
-    await this.initialize();
+    this.inFlight++;
+    try {
+      await this.initialize();
 
-    const truncated = text.slice(0, this.maxTextLength);
-    const output = await this.pipeline(truncated, {
-      pooling: 'mean',
-      normalize: true,
-    });
+      const truncated = text.slice(0, this.maxTextLength);
+      const output = await this.pipeline(truncated, {
+        pooling: 'mean',
+        normalize: true,
+      });
 
-    // output.data is a Float32Array from the ONNX model
-    return new Float32Array(output.data);
+      // output.data is a Float32Array from the ONNX model
+      return new Float32Array(output.data);
+    } finally {
+      this.inFlight--;
+      this.scheduleIdleUnload();
+    }
   }
 
   /**
@@ -93,27 +183,35 @@ export class EmbeddingProvider {
    */
   async embedBatch(texts: string[]): Promise<Float32Array[]> {
     if (texts.length === 0) return [];
+    // Single-text delegates to embed(), which owns its own inFlight + idle-timer
+    // bookkeeping — don't double-count here.
     if (texts.length === 1) return [await this.embed(texts[0])];
 
-    await this.initialize();
+    this.inFlight++;
+    try {
+      await this.initialize();
 
-    const truncated = texts.map(t => t.slice(0, this.maxTextLength));
-    const results: Float32Array[] = [];
+      const truncated = texts.map(t => t.slice(0, this.maxTextLength));
+      const results: Float32Array[] = [];
 
-    // Process in batches of 32 to avoid memory pressure
-    const batchSize = 32;
-    for (let i = 0; i < truncated.length; i += batchSize) {
-      const batch = truncated.slice(i, i + batchSize);
-      for (const text of batch) {
-        const output = await this.pipeline(text, {
-          pooling: 'mean',
-          normalize: true,
-        });
-        results.push(new Float32Array(output.data));
+      // Process in batches of 32 to avoid memory pressure
+      const batchSize = 32;
+      for (let i = 0; i < truncated.length; i += batchSize) {
+        const batch = truncated.slice(i, i + batchSize);
+        for (const text of batch) {
+          const output = await this.pipeline(text, {
+            pooling: 'mean',
+            normalize: true,
+          });
+          results.push(new Float32Array(output.data));
+        }
       }
-    }
 
-    return results;
+      return results;
+    } finally {
+      this.inFlight--;
+      this.scheduleIdleUnload();
+    }
   }
 
   // ─── sqlite-vec Extension ───────────────────────────────────────

--- a/tests/unit/EmbeddingProvider-idle-unload.test.ts
+++ b/tests/unit/EmbeddingProvider-idle-unload.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Idle-unload lifecycle for the shared ONNX EmbeddingProvider.
+ *
+ * The loaded feature-extraction pipeline's onnxruntime thread pool busy-spins
+ * even when no embedding is happening (measured live: ~3.6% of a core on a quiet
+ * box, ~44% on a contended one). For a "paused" agent that isn't doing memory
+ * work, that's pure wasted CPU — a real contributor to fleet load. These tests
+ * pin the fix: after `idleUnloadMs` of no embed() the pipeline is disposed (its
+ * thread pool freed), and the next embed() lazily reloads. A mock pipeline +
+ * fake timers exercise the lifecycle without loading the 80MB model (the real
+ * dispose→reload→identical-output behavior was verified live).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EmbeddingProvider } from '../../src/memory/EmbeddingProvider.js';
+
+function makeMockPipeline() {
+  const dispose = vi.fn().mockResolvedValue(undefined);
+  const fn: any = vi.fn(async () => ({ data: new Float32Array(384) }));
+  fn.dispose = dispose;
+  return fn;
+}
+
+describe('EmbeddingProvider idle-unload', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('disposes the pipeline after idleUnloadMs of no embed, then lazily reloads', async () => {
+    let created = 0;
+    const pipes: any[] = [];
+    const provider = new EmbeddingProvider({
+      idleUnloadMs: 1000,
+      pipelineFactory: async () => { created++; const p = makeMockPipeline(); pipes.push(p); return p; },
+    });
+
+    await provider.embed('hello');
+    expect(created).toBe(1);
+    expect(provider.isReady).toBe(true);
+
+    // Idle window elapses → unload fires, thread pool freed.
+    await vi.advanceTimersByTimeAsync(1001);
+    expect(pipes[0].dispose).toHaveBeenCalledOnce();
+    expect(provider.isReady).toBe(false);
+
+    // Next embed reloads a fresh pipeline (lazy).
+    const out = await provider.embed('again');
+    expect(out).toBeInstanceOf(Float32Array);
+    expect(created).toBe(2);
+    expect(provider.isReady).toBe(true);
+  });
+
+  it('stays resident while embeds keep coming (timer resets each call)', async () => {
+    let created = 0;
+    const provider = new EmbeddingProvider({
+      idleUnloadMs: 1000,
+      pipelineFactory: async () => { created++; return makeMockPipeline(); },
+    });
+    await provider.embed('a');
+    await vi.advanceTimersByTimeAsync(800); // < window
+    await provider.embed('b');              // resets the timer
+    await vi.advanceTimersByTimeAsync(800); // 800ms since last embed, < window
+    expect(provider.isReady).toBe(true);
+    expect(created).toBe(1); // never reloaded
+  });
+
+  it('idleUnloadMs:0 disables unloading (model stays resident forever)', async () => {
+    const pipes: any[] = [];
+    const provider = new EmbeddingProvider({
+      idleUnloadMs: 0,
+      pipelineFactory: async () => { const p = makeMockPipeline(); pipes.push(p); return p; },
+    });
+    await provider.embed('x');
+    await vi.advanceTimersByTimeAsync(10_000_000);
+    expect(provider.isReady).toBe(true);
+    expect(pipes[0].dispose).not.toHaveBeenCalled();
+  });
+
+  it('never disposes while an embed is in flight (inFlight guard), then disposes once idle', async () => {
+    // Flush enough microtask turns for the embed chain (inFlight++ →
+    // initialize → loadModel → factory → pipe()) to reach the pipe() call.
+    const flush = async () => { for (let i = 0; i < 12; i++) await Promise.resolve(); };
+    const dispose = vi.fn().mockResolvedValue(undefined);
+    const resolvers: Array<(v: any) => void> = [];
+    const pipe: any = vi.fn(() => new Promise((r) => { resolvers.push(r); }));
+    pipe.dispose = dispose;
+    const provider = new EmbeddingProvider({
+      idleUnloadMs: 500,
+      pipelineFactory: async () => pipe,
+    });
+
+    // First embed completes → arms the idle timer.
+    const a = provider.embed('a');
+    await flush();
+    resolvers[0]({ data: new Float32Array(384) });
+    await a;
+
+    // Second embed is now in flight (hangs unresolved → inFlight = 1).
+    const b = provider.embed('b');
+    await flush();
+    expect(resolvers).toHaveLength(2);
+    // The timer armed by embed A fires while B is in flight → must NOT dispose.
+    await vi.advanceTimersByTimeAsync(600);
+    expect(dispose).not.toHaveBeenCalled();
+    expect(provider.isReady).toBe(true);
+
+    // Release B → it completes and re-arms the timer; now idle → dispose.
+    resolvers[1]({ data: new Float32Array(384) });
+    await b;
+    await vi.advanceTimersByTimeAsync(600);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it('explicit dispose() releases the model + cancels the idle timer', async () => {
+    const pipes: any[] = [];
+    const provider = new EmbeddingProvider({
+      idleUnloadMs: 1000,
+      pipelineFactory: async () => { const p = makeMockPipeline(); pipes.push(p); return p; },
+    });
+    await provider.embed('y');
+    await provider.dispose();
+    expect(pipes[0].dispose).toHaveBeenCalledOnce();
+    expect(provider.isReady).toBe(false);
+    // The idle timer was cancelled — advancing can't double-dispose.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(pipes[0].dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,51 @@
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**The shared local embedding model now unloads when idle, freeing the CPU its
+ONNX thread pool was busy-spinning on.**
+
+`EmbeddingProvider` (backing SemanticMemory / MemoryIndex / TopicMemory) loaded the
+all-MiniLM-L6-v2 ONNX model lazily and then kept it resident forever. onnxruntime's
+thread pool busy-spins even when idle — measured live via `process.cpuUsage()` at
+~3.6% of a core on a quiet box, and previously ~44% on a contended agent that was
+supposedly paused. With several agents per box each holding an idle, spinning
+model, that's a real multiplied load source.
+
+Fix: after `idleUnloadMs` (default 300000 = 5 min) with no `embed()`, the pipeline
+is disposed (thread pool freed) and lazily reloaded on the next embed. A rolling
+timer resets on every embed (active agents stay resident), an `inFlight` guard
+prevents disposing mid-batch, and the timer is `unref()`'d. Set `idleUnloadMs: 0`
+to keep the prior keep-resident behavior. Verified live: idle CPU 3.6% → 0.0% after
+dispose, and dispose→reload→embed produces an identical vector.
+
+## What to Tell Your User
+
+Each agent keeps a small local AI model loaded to search its own memories, and the
+engine running that model was quietly burning CPU even when the agent was idle —
+its worker threads spin in a tight loop instead of sleeping. On a machine running
+several agents, that added up to real wasted CPU. I changed it so the model unloads
+after a few minutes of not being used and reloads in about a second the next time
+it's needed. Active memory work is unaffected (the timer resets every time it's
+used); only genuinely idle agents stop wasting CPU. I confirmed the model produces
+the exact same results after an unload-and-reload, so nothing is lost.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Idle-unload of the embedding model | Automatic — frees the ONNX thread pool after ~5 min idle, reloads on next use |
+| Keep the model resident | Construct the embedding provider with the idle window set to zero |
+
+## Evidence
+
+- **Live measurement:** loaded-but-idle model used ~3.6% of a core (3s window,
+  `process.cpuUsage()`); ~44% previously observed on a contended agent. After
+  dispose: 0.0%. dispose→reload→embed produced an identical embedding.
+- **Tests:** `tests/unit/EmbeddingProvider-idle-unload.test.ts` (5, mock pipeline +
+  fake timers) — dispose-after-idle + lazy reload, resident-while-active,
+  disable-via-zero, inFlight guard, explicit dispose. `tsc` clean.
+- Spec: `docs/specs/onnx-idle-unload.md`. Side-effects:
+  `upgrades/side-effects/onnx-idle-unload.md`.

--- a/upgrades/side-effects/onnx-idle-unload.md
+++ b/upgrades/side-effects/onnx-idle-unload.md
@@ -1,0 +1,36 @@
+# Side-effects — EmbeddingProvider idle-unload
+
+**Change:** `EmbeddingProvider` disposes its loaded ONNX pipeline after
+`idleUnloadMs` (default 5 min) of no `embed()` call, lazily reloading on the next
+embed. New `inFlight` guard, rolling idle timer, and a public `dispose()`.
+
+## Behavioral side-effects
+
+- **First embed after a long idle costs ~1-3s more** (a model reload). All
+  subsequent embeds during active use are unaffected — the idle timer resets on
+  every embed, so a busy agent keeps the model resident. Memory search/index are
+  not latency-critical, so the occasional reload is an acceptable trade for
+  eliminating the idle thread-pool spin (~3.6%-44% of a core).
+- **`isReady` is now dynamic.** Previously it returned true forever once loaded;
+  now it returns false while the model is unloaded between idle periods. No caller
+  uses `isReady` to gate embeds (verified) — `embed()` lazily re-initializes
+  regardless — so this is observational only.
+- **Embeddings are unchanged.** Verified live: dispose→reload→embed produces a
+  byte-identical vector. Unloading/reloading never alters output.
+- **Default-ON.** The production singleton constructs with defaults, so all agents
+  get 5-min idle-unload on update. Set `idleUnloadMs: 0` (constructor config) to
+  restore the prior keep-resident behavior.
+
+## Blast radius
+
+- Scoped to `src/memory/EmbeddingProvider.ts`. SemanticMemory / MemoryIndex /
+  TopicMemory consume it transparently (they call `embed()`/`embedBatch()`, which
+  handle reload internally). No call-site changes.
+- The idle timer is `unref()`'d — it can never keep the process alive.
+- No config schema, hook, or HTTP changes. No new dependencies.
+
+## Migration parity
+
+None required — internal runtime logic in `src/`. No agent-installed file
+(`.claude/settings.json`, `.instar/config.json`, CLAUDE.md template, hook, skill)
+changes. Existing agents receive it on their normal version update.


### PR DESCRIPTION
## Problem (measured live, goal-#1 'load is suspect')

EmbeddingProvider (backing SemanticMemory / MemoryIndex / TopicMemory) loaded all-MiniLM-L6-v2 lazily then kept it **resident forever**. onnxruntime's thread pool **busy-spins even when idle** — measured live via process.cpuUsage() over a 3s idle window at **~3.6% of a core** on a quiet box, and previously **~44%** on a contended agent (AI Guy) that was supposedly paused. Several agents per box each holding an idle spinning model is a real, multiplied fleet-load source.

## Fix

After idleUnloadMs (default 300000 = 5 min) with no embed(), dispose the pipeline (frees the onnxruntime session + thread pool), lazily reload on next embed.
- Rolling timer re-armed on every embed → actively-embedding agents stay resident; quiet ones unload.
- inFlight guard → never disposes mid-batch (a long batch's completion re-arms the timer).
- Timer is unref()'d → can't hold the process open.
- idleUnloadMs:0 disables (keep-resident, prior behavior). Public dispose() for shutdown.

## Verification (live, not just unit)
- **IDLE-while-LOADED 3.6% of a core → IDLE-after-DISPOSE 0.0%.** dispose() exists + stops the spin.
- **dispose → reload → embed produced an IDENTICAL vector** ([0]=-0.0345 both sides); reload is correct, no mutex/exit race in the production path (disposes during idle, keeps running).

## Tests
- tests/unit/EmbeddingProvider-idle-unload.test.ts (5, mock pipeline + fake timers): dispose-after-idle + lazy reload; resident-while-active (timer resets); idleUnloadMs:0 disables; inFlight guard; explicit dispose. tsc clean.
- isReady is not used by any caller to gate embeds (verified), so its now-dynamic value is safe. Production singleton constructs with defaults → ON at 5 min.

Scoped to src/memory/EmbeddingProvider.ts. No config/hook/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)