### PR TITLE
[codex] Wire Threadline session completion retirement

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7428,6 +7428,16 @@ export async function startServer(options: StartOptions): Promise<void> {
       null, // autonomyGate
       messageDelivery, // PR-4: live-session injection path
     );
+    sessionManager.on('sessionComplete', (session: import('../core/types.js').Session) => {
+      const sessionName = session.tmuxSession || session.name;
+      if (!sessionName) return;
+      const result = threadlineRouter.onSessionComplete(sessionName, session.claudeSessionId);
+      if (result.demoted > 0 || result.skippedAwaitingReply > 0) {
+        console.log(
+          `[ThreadlineRouter] sessionComplete ${sessionName}: demoted ${result.demoted} thread(s), skipped ${result.skippedAwaitingReply} awaiting-reply thread(s)`,
+        );
+      }
+    });
 
     // Topic linkage handler — Per THREAD-TOPIC-LINKAGE-SPEC.md.
     // Ties threadline conversations to the originating Telegram topic so

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-30T11:45:41.849Z",
+  "generatedAt": "2026-05-30T11:51:32.993Z",
   "instarVersion": "1.3.117",
   "entryCount": 193,
   "entries": {

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-30T11:23:02.544Z",
-  "instarVersion": "1.3.116",
+  "generatedAt": "2026-05-30T11:45:41.849Z",
+  "instarVersion": "1.3.117",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {

--- a/src/threadline/ThreadResumeMap.ts
+++ b/src/threadline/ThreadResumeMap.ts
@@ -19,7 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { spawnSync } from 'node:child_process';
-import { ConversationStore, type Conversation } from './ConversationStore.js';
+import { ConversationStore, type Conversation, type ConversationState } from './ConversationStore.js';
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -44,6 +44,12 @@ export interface ThreadResumeEntry {
   spawnMode?: 'interactive' | 'pipe';
   originTopicId?: number;
   originSessionName?: string;
+}
+
+export interface ThreadResumeSessionMatch {
+  threadId: string;
+  entry: ThreadResumeEntry;
+  conversationState: ConversationState;
 }
 
 // ── Field bridge ────────────────────────────────────────────────
@@ -202,6 +208,17 @@ export class ThreadResumeMap {
     return this.store.listActive()
       .map(c => ({ threadId: c.threadId, entry: conversationToEntry(c) }))
       .filter(({ entry }) => entry.state === 'active' || entry.state === 'idle');
+  }
+
+  /** Reverse lookup live conversation entries by their bound tmux session name. */
+  getBySessionName(sessionName: string): ThreadResumeSessionMatch[] {
+    return this.store.listActive()
+      .filter(c => c.boundSessionName === sessionName)
+      .map(c => ({
+        threadId: c.threadId,
+        entry: conversationToEntry(c),
+        conversationState: c.state,
+      }));
   }
 
   /** Archive stale non-pinned active/idle/open conversations. */

--- a/src/threadline/ThreadlineRouter.ts
+++ b/src/threadline/ThreadlineRouter.ts
@@ -592,6 +592,28 @@ export class ThreadlineRouter {
   }
 
   /**
+   * Notify the router that a bound worker session has completed.
+   * Reverse-maps the tmux session to all active thread entries and demotes only
+   * threads that are no longer legitimately waiting on the remote peer.
+   */
+  onSessionComplete(sessionName: string, uuid?: string): { demoted: number; skippedAwaitingReply: number } {
+    const matches = this.threadResumeMap.getBySessionName(sessionName);
+    let demoted = 0;
+    let skippedAwaitingReply = 0;
+
+    for (const match of matches) {
+      if (match.conversationState === 'awaiting-reply') {
+        skippedAwaitingReply += 1;
+        continue;
+      }
+      this.onSessionEnd(match.threadId, uuid || match.entry.uuid, sessionName);
+      demoted += 1;
+    }
+
+    return { demoted, skippedAwaitingReply };
+  }
+
+  /**
    * Notify the router that a thread has been resolved (conversation complete).
    *
    * Emits a `thread-closed` ledger event wrapped in try/finally so the ledger

--- a/tests/unit/threadline/ThreadlineRouter.test.ts
+++ b/tests/unit/threadline/ThreadlineRouter.test.ts
@@ -677,6 +677,109 @@ describe('ThreadlineRouter', () => {
     it('does nothing for unknown thread', () => {
       expect(() => router.onSessionEnd('unknown-thread', 'some-uuid', 'some-session')).not.toThrow();
     });
+
+    it('demotes all active threads bound to a completed session', () => {
+      const threadId1 = crypto.randomUUID();
+      const threadId2 = crypto.randomUUID();
+      const oldUuid = existingUuid;
+      const newUuid = 'newuuid1-2222-3333-4444-555555555555';
+      createFakeJsonl(oldUuid);
+
+      threadResumeMap.save(threadId1, makeEntry({
+        uuid: oldUuid,
+        state: 'active',
+        sessionName: 'completed-session',
+      }));
+      threadResumeMap.save(threadId2, makeEntry({
+        uuid: oldUuid,
+        state: 'active',
+        sessionName: 'completed-session',
+      }));
+
+      expect(router.onSessionComplete('completed-session', newUuid)).toEqual({
+        demoted: 2,
+        skippedAwaitingReply: 0,
+      });
+
+      const data = JSON.parse(fs.readFileSync(path.join(temp.stateDir, 'threadline', 'conversations.json'), 'utf-8')).conversations;
+      expect(data[threadId1].state).toBe('idle');
+      expect(data[threadId1].sessionUuid).toBe(newUuid);
+      expect(data[threadId2].state).toBe('idle');
+      expect(data[threadId2].sessionUuid).toBe(newUuid);
+    });
+
+    it('does not demote awaiting-reply threads when their session completes', () => {
+      const threadId = crypto.randomUUID();
+      const oldUuid = existingUuid;
+      createFakeJsonl(oldUuid);
+      threadResumeMap.save(threadId, makeEntry({
+        uuid: oldUuid,
+        state: 'active',
+        sessionName: 'completed-session',
+      }));
+
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      raw.conversations[threadId].state = 'awaiting-reply';
+      fs.writeFileSync(filePath, JSON.stringify(raw, null, 2));
+      const freshThreadResumeMap = new ThreadResumeMap(temp.stateDir, '/test/project');
+      const freshRouter = new ThreadlineRouter(
+        mockRouter as any,
+        mockSpawnManager as any,
+        freshThreadResumeMap,
+        mockStore as any,
+        { localAgent: 'local-agent', localMachine: 'local-machine' },
+      );
+
+      expect(freshRouter.onSessionComplete('completed-session', 'newuuid1-2222-3333-4444-555555555555')).toEqual({
+        demoted: 0,
+        skippedAwaitingReply: 1,
+      });
+
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')).conversations;
+      expect(data[threadId].state).toBe('awaiting-reply');
+      expect(data[threadId].sessionUuid).toBe(oldUuid);
+    });
+
+    it('does not archive unrelated stale awaiting-reply threads during session completion lookup', () => {
+      const completedThreadId = crypto.randomUUID();
+      const unrelatedThreadId = crypto.randomUUID();
+      const oldUuid = existingUuid;
+      createFakeJsonl(oldUuid);
+      threadResumeMap.save(completedThreadId, makeEntry({
+        uuid: oldUuid,
+        state: 'active',
+        sessionName: 'completed-session',
+      }));
+      threadResumeMap.save(unrelatedThreadId, makeEntry({
+        uuid: oldUuid,
+        state: 'active',
+        sessionName: 'other-session',
+      }));
+
+      const filePath = path.join(temp.stateDir, 'threadline', 'conversations.json');
+      const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      raw.conversations[unrelatedThreadId].state = 'awaiting-reply';
+      raw.conversations[unrelatedThreadId].lastActivityAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+      fs.writeFileSync(filePath, JSON.stringify(raw, null, 2));
+      const freshThreadResumeMap = new ThreadResumeMap(temp.stateDir, '/test/project');
+      const freshRouter = new ThreadlineRouter(
+        mockRouter as any,
+        mockSpawnManager as any,
+        freshThreadResumeMap,
+        mockStore as any,
+        { localAgent: 'local-agent', localMachine: 'local-machine' },
+      );
+
+      expect(freshRouter.onSessionComplete('completed-session', 'newuuid1-2222-3333-4444-555555555555')).toEqual({
+        demoted: 1,
+        skippedAwaitingReply: 0,
+      });
+
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')).conversations;
+      expect(data[completedThreadId].state).toBe('idle');
+      expect(data[unrelatedThreadId].state).toBe('awaiting-reply');
+    });
   });
 
   describe('onThreadResolved', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,24 @@
+# Upgrade Guide - vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+Threadline conversation lifecycle now retires stale active and idle threads automatically. Conversations that have seen no activity for 24 hours are archived instead of staying in the active set forever, while pinned conversations are left alone. Archived conversations keep their history and metadata, so a later peer reply can still reactivate the relationship context.
+
+The Threadline active-agent summary also now reports only truly active threads. Idle conversations are no longer counted as active work, which makes agent health and collaboration dashboards reflect the real current workload instead of accumulated stale conversations.
+
+## What to Tell Your User
+
+- **Cleaner Threadline state**: "I now clean up old Threadline conversations automatically, so stale inter-agent chats stop cluttering the active thread count while the relationship history remains available."
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Stale Threadline retirement | Automatic during Threadline active-thread reads |
+| Accurate active thread counts | Automatic in threadline agent status |
+
+## Evidence
+
+Codey's live Threadline store showed 42 conversations before the change: 39 active, 3 idle, and 38 with Echo. Many were single-message relay threads from May 23-28 that still counted as active on May 30. Focused regression tests now prove stale active and idle conversations are archived without deletion, pinned stale threads remain active, and idle threads no longer increment the active thread metric.

--- a/upgrades/side-effects/threadline-session-complete-retirement.md
+++ b/upgrades/side-effects/threadline-session-complete-retirement.md
@@ -1,0 +1,93 @@
+# Side-Effects Review — Threadline Session Completion Retirement
+
+**Version / slug:** `threadline-session-complete-retirement`
+**Date:** `2026-05-30`
+**Author:** `instar-codey`
+**Second-pass reviewer:** `Feynman`
+
+## Summary of the change
+
+This change wires `SessionManager`'s `sessionComplete` event into Threadline thread lifecycle handling. `ThreadResumeMap` gains a reverse lookup from bound tmux session name to live thread records, `ThreadlineRouter` gains `onSessionComplete()` to demote completed non-awaiting thread workers through the existing `onSessionEnd()` path, and `src/commands/server.ts` attaches the listener after the router is constructed. The touched decision point is session lifecycle state transition: whether a live Threadline conversation should leave the active set promptly when its worker session completes.
+
+## Decision-point inventory
+
+- `ThreadlineRouter.onSessionComplete()` — add — decides which bound threads are demoted on a completed worker session.
+- `ThreadResumeMap.getBySessionName()` — add — lookup primitive only; it returns live conversation state and does not decide.
+- `server.ts sessionComplete listener` — add — forwards a completed tmux session name and optional resume UUID into the router.
+
+---
+
+## 1. Over-block
+
+No block/allow surface. The change does not reject inbound or outbound messages. The main over-demotion risk is a thread that is still waiting for the peer being moved to `idle`; this is guarded by checking the underlying ConversationStore state and skipping `awaiting-reply`.
+
+---
+
+## 2. Under-block
+
+No block/allow surface. The remaining miss is any completed worker whose thread record lacks `boundSessionName`; there is no safe reverse mapping for that case, so it will still rely on the 24h stale-retirement backstop. A session with no captured `claudeSessionId` is still demoted using the existing stored UUID.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is at the Threadline router/session lifecycle layer, which already owns `onSessionEnd(threadId, uuid, sessionName)`. The new method does not reimplement demotion; it reverse-maps session name to thread ids and delegates each eligible thread to the existing router primitive. The raw `awaiting-reply` guard stays near `ConversationStore` state because the legacy `ThreadResumeEntry` view maps `awaiting-reply` to `active`.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+**Does this change hold blocking authority with brittle logic?**
+
+- [ ] No — this change produces a signal consumed by an existing smart gate.
+- [x] No — this change has no block/allow surface.
+- [ ] Yes — but the logic is a smart gate with full conversational context (LLM-backed with recent history or equivalent).
+- [ ] Yes, with brittle logic — STOP. Reshape the design. Brittle detectors must not own block authority. Either promote the logic to smart-gate level (with proper context) or demote it to a signal that feeds an existing smart gate.
+
+The logic is a lifecycle transition, not a message judgment. It does not block, filter, or score content. The only deterministic guard is whether the stored lifecycle state is `awaiting-reply`, which is a hard state-machine invariant rather than a brittle semantic detector.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** The listener runs after `SessionManager` emits completion and before the existing 24h stale-retirement backstop would archive stale active entries. It does not shadow inbound routing; future peer replies can still reactivate an idle thread through the normal resume path.
+- **Double-fire:** Multiple completion events for the same tmux session are idempotent enough: already-idle entries may be saved as idle again, and `awaiting-reply` entries remain untouched. The log only emits when at least one matching thread is found.
+- **Races:** The reverse lookup reads active conversation records without running stale-retirement as a lookup side effect, then each demotion uses `ThreadResumeMap.save()`, which writes through the ConversationStore mutation path. A concurrent state change to `awaiting-reply` after lookup remains the main race; the window is small and the next inbound/outbound action can restore state.
+- **Feedback loops:** Demoting a thread reduces active-list noise and prevents the stale backstop from being the first lifecycle update. It does not spawn sessions or send messages.
+
+---
+
+## 6. External surfaces
+
+Other agents see more accurate Threadline active-thread state sooner after a worker finishes. Persistent state changes in `{stateDir}/threadline/conversations.json` move eligible records from `active`/`open` to `idle` and refresh the stored session UUID when available. There are no Telegram, Slack, GitHub, Cloudflare, or wire-format changes. Timing depends on `SessionManager` completion detection, but that event already drives other lifecycle systems.
+
+---
+
+## 7. Rollback cost
+
+Hot-fix release: revert the listener and helper methods, then ship the next patch. No migration is required. Existing records demoted to `idle` remain valid and can still be resumed/reactivated on the next peer reply; no agent state repair is expected.
+
+---
+
+## Conclusion
+
+The change is clear to ship after second-pass review. It narrows the stale-active Threadline window from the 24h backstop to the worker's actual completion event while preserving the important `awaiting-reply` state. Focused regressions cover completed-session demotion and awaiting-reply preservation.
+
+---
+
+## Second-pass review (if required)
+
+**Reviewer:** `Feynman`
+**Independent read of the artifact:** `concern resolved`
+
+Initial concern: `getBySessionName()` called `retireInactive()` before filtering by session, so a `sessionComplete` event could archive unrelated stale live conversations, including stale `awaiting-reply` records. Resolution: remove stale-retirement from the reverse lookup and add regression coverage that an unrelated stale `awaiting-reply` thread remains untouched during completion handling.
+
+---
+
+## Evidence pointers
+
+- `npx vitest run tests/unit/threadline/ThreadlineRouter.test.ts` — 36/36 passed.
+- `npx vitest run tests/unit/threadline/ThreadResumeMap.test.ts` — 41/41 passed.
+- `npm run build` — passed; local signing key absent, lockfile signing skipped as documented transitional state.


### PR DESCRIPTION
## Summary

Wires Threadline thread retirement to `SessionManager` completion events so finished worker sessions stop leaving their conversations counted as active until the 24h stale backstop.

Changes:
- Adds `ThreadResumeMap.getBySessionName()` for reverse lookup of live conversations bound to a completed tmux session.
- Adds `ThreadlineRouter.onSessionComplete()` to demote matched non-`awaiting-reply` threads through the existing `onSessionEnd()` path.
- Wires `sessionManager.on('sessionComplete')` in `server.ts` after Threadline router construction.
- Adds regressions for completed-session demotion, `awaiting-reply` preservation, and no unrelated stale-thread archiving as a lookup side effect.
- Adds instar-dev side-effects artifact with second-pass review resolution.

## Root Cause

The stale-thread retirement work only had the 24h backstop. Threadline already had a precise session lifecycle event available, but nothing reverse-mapped completed worker sessions back to their conversation records.

## Validation

- `npx vitest run tests/unit/threadline/ThreadlineRouter.test.ts tests/unit/threadline/ThreadResumeMap.test.ts` — 77/77 passed.
- `npm run build` — passed; local signing key absent, lockfile signing skipped as documented transitional state.
- Pre-commit hook passed: lint, instar-dev trace/spec/artifact checks.
- Pre-push smoke gate — 79/79 passed.
- Pre-push scoped Threadline e2e — 331/331 passed.

## Review Note

Second-pass reviewer raised a real concern that the first reverse lookup called stale retirement before filtering by session. Fixed by making `getBySessionName()` side-effect-free and adding a regression that an unrelated stale `awaiting-reply` thread remains untouched during session completion handling.
