### PR TITLE
Fix Threadline completion matching by session UUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.3.119",
+  "version": "1.3.120",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.3.119",
+      "version": "1.3.120",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.3.119",
+  "version": "1.3.120",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -7431,7 +7431,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     sessionManager.on('sessionComplete', (session: import('../core/types.js').Session) => {
       const sessionName = session.tmuxSession || session.name;
       if (!sessionName) return;
-      const result = threadlineRouter.onSessionComplete(sessionName, session.claudeSessionId);
+      const result = threadlineRouter.onSessionComplete(sessionName, session.id || session.claudeSessionId);
       if (result.demoted > 0 || result.skippedAwaitingReply > 0) {
         console.log(
           `[ThreadlineRouter] sessionComplete ${sessionName}: demoted ${result.demoted} thread(s), skipped ${result.skippedAwaitingReply} awaiting-reply thread(s)`,

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-30T12:08:01.041Z",
-  "instarVersion": "1.3.119",
+  "generatedAt": "2026-05-30T12:31:41.858Z",
+  "instarVersion": "1.3.120",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {

--- a/src/threadline/ThreadResumeMap.ts
+++ b/src/threadline/ThreadResumeMap.ts
@@ -221,6 +221,17 @@ export class ThreadResumeMap {
       }));
   }
 
+  /** Reverse lookup live conversation entries by their bound SessionManager UUID. */
+  getBySessionUuid(uuid: string): ThreadResumeSessionMatch[] {
+    return this.store.listActive()
+      .filter(c => c.sessionUuid === uuid)
+      .map(c => ({
+        threadId: c.threadId,
+        entry: conversationToEntry(c),
+        conversationState: c.state,
+      }));
+  }
+
   /** Archive stale non-pinned active/idle/open conversations. */
   retireInactive(maxInactiveMs: number = DEFAULT_INACTIVE_RETIRE_MS, now: Date = new Date()): number {
     return this.store.retireInactive(maxInactiveMs, now);

--- a/src/threadline/ThreadlineRouter.ts
+++ b/src/threadline/ThreadlineRouter.ts
@@ -597,11 +597,19 @@ export class ThreadlineRouter {
    * threads that are no longer legitimately waiting on the remote peer.
    */
   onSessionComplete(sessionName: string, uuid?: string): { demoted: number; skippedAwaitingReply: number } {
-    const matches = this.threadResumeMap.getBySessionName(sessionName);
+    const matchesByThreadId = new Map(
+      this.threadResumeMap.getBySessionName(sessionName)
+        .map(match => [match.threadId, match]),
+    );
+    if (uuid) {
+      for (const match of this.threadResumeMap.getBySessionUuid(uuid)) {
+        matchesByThreadId.set(match.threadId, match);
+      }
+    }
     let demoted = 0;
     let skippedAwaitingReply = 0;
 
-    for (const match of matches) {
+    for (const match of matchesByThreadId.values()) {
       if (match.conversationState === 'awaiting-reply') {
         skippedAwaitingReply += 1;
         continue;

--- a/tests/unit/threadline/ThreadlineRouter.test.ts
+++ b/tests/unit/threadline/ThreadlineRouter.test.ts
@@ -708,6 +708,28 @@ describe('ThreadlineRouter', () => {
       expect(data[threadId2].sessionUuid).toBe(newUuid);
     });
 
+    it('demotes an active thread when completion matches the SessionManager UUID but not the bound session name', () => {
+      const threadId = crypto.randomUUID();
+      const sessionManagerUuid = 'sessionmgr-2222-3333-4444-555555555555';
+      createFakeJsonl(sessionManagerUuid);
+
+      threadResumeMap.save(threadId, makeEntry({
+        uuid: sessionManagerUuid,
+        state: 'active',
+        sessionName: 'thread-short-name',
+      }));
+
+      expect(router.onSessionComplete('instar-codey-msg-spawn-1234567890', sessionManagerUuid)).toEqual({
+        demoted: 1,
+        skippedAwaitingReply: 0,
+      });
+
+      const data = JSON.parse(fs.readFileSync(path.join(temp.stateDir, 'threadline', 'conversations.json'), 'utf-8')).conversations;
+      expect(data[threadId].state).toBe('idle');
+      expect(data[threadId].sessionUuid).toBe(sessionManagerUuid);
+      expect(data[threadId].boundSessionName).toBe('instar-codey-msg-spawn-1234567890');
+    });
+
     it('does not demote awaiting-reply threads when their session completes', () => {
       const threadId = crypto.randomUUID();
       const oldUuid = existingUuid;

--- a/upgrades/1.3.120.md
+++ b/upgrades/1.3.120.md
@@ -1,0 +1,38 @@
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Threadline session-completion retirement now matches real SessionManager
+bindings.**
+
+The previous retirement hook listened for `sessionComplete` and reverse-looked
+up conversations by bound session name. A live canary showed the real inbound
+Threadline spawn path persists the SessionManager session id as `sessionUuid`,
+while the visible bound name can be the short logical thread name. That meant a
+completion event could legitimately demote zero threads even though the worker
+had finished.
+
+Fix: `ThreadResumeMap` now supports a side-effect-free reverse lookup by
+SessionManager UUID, `ThreadlineRouter.onSessionComplete()` unions the
+session-name and UUID matches, and the server passes `session.id` into the
+router. The existing awaiting-reply guard still applies to both match paths.
+
+## What to Tell Your User
+
+Threadline active-thread cleanup now works with the real session identifiers
+emitted by the server, not only mocked tmux-name bindings. Completed worker
+threads retire promptly, while threads waiting for a peer reply stay active.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| SessionManager UUID completion matching | Automatic when a Threadline worker session emits `sessionComplete` |
+| Name + UUID deduped completion lookup | Automatic — a thread matching both paths is demoted once |
+
+## Evidence
+
+- **Focused local tests:** `npm test -- tests/unit/threadline/ThreadlineRouter.test.ts tests/unit/threadline/ThreadResumeMap.test.ts` — 78/78 passed, including the real-shape UUID fallback regression.
+- **Side-effects review:** `upgrades/side-effects/threadline-session-complete-retirement.md`.

--- a/upgrades/side-effects/1.3.120.md
+++ b/upgrades/side-effects/1.3.120.md
@@ -1,0 +1,129 @@
+# Side-Effects Review — Threadline sessionComplete UUID fallback
+
+**Version / slug:** `1.3.120`
+**Date:** 2026-05-30
+**Author:** `instar-codey`
+**Second-pass reviewer:** `echo`
+
+## Summary of the change
+
+This change fixes the real production binding shape for Threadline worker
+completion. `ThreadResumeMap` gains a side-effect-free reverse lookup by
+`sessionUuid`, `ThreadlineRouter.onSessionComplete()` unions the existing
+bound-session-name lookup with the UUID lookup, and `src/commands/server.ts`
+passes `session.id` from the `SessionManager.sessionComplete` event. The touched
+decision point is Threadline lifecycle demotion: whether a completed worker
+session should move a conversation out of the active set.
+
+## Decision-point inventory
+
+- `ThreadlineRouter.onSessionComplete()` — modify — demotes matching active
+  conversations when a worker session completes, now matching by name or UUID.
+- `server.ts sessionComplete listener` — modify — forwards the SessionManager
+  session id so the router can match the value persisted during inbound spawn.
+- `ThreadResumeMap.getBySessionUuid()` — add — lookup primitive only; no direct
+  lifecycle authority and no stale-retirement side effect.
+
+---
+
+## 1. Over-block
+
+No block/allow surface. The closest equivalent is over-demotion: a live
+conversation could be moved to `idle` if a different completed session reuses
+the same UUID. SessionManager ids are unique per session, and the lookup is
+limited to active conversation records, so the expected legitimate-input impact
+is none. Awaiting-reply conversations are still explicitly skipped.
+
+---
+
+## 2. Under-block
+
+The change still misses any conversation record that has neither a matching
+`boundSessionName` nor a matching `sessionUuid`. That would require an earlier
+write path to omit both identifiers. It also does not retroactively repair
+already-active records written with the old logical short name and no UUID, but
+the observed live path did persist `sessionUuid = session.id`.
+
+---
+
+## 3. Level-of-abstraction fit
+
+This is at the lifecycle-router layer, which is the same layer that already
+owns `onSessionEnd()` demotion. The lower-level resume map only exposes a lookup
+primitive; it does not decide what to demote. The server listener remains a thin
+event adapter from SessionManager shape to Threadline router shape.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+This is not a brittle detector holding blocking authority over user or agent
+messages. It is lifecycle state reconciliation after SessionManager has already
+emitted an authoritative completion event. The router's authority is limited to
+moving matching conversation records from active to idle, with the existing
+awaiting-reply guard preserved.
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** the UUID lookup complements the existing bound-session-name
+  lookup; it does not replace it. Old records that match by name still demote.
+- **Double-fire:** matches are deduped by `threadId`, so a record matching both
+  name and UUID is demoted once.
+- **Races:** both reverse lookups read `ConversationStore.listActive()` directly
+  and do not trigger stale retirement. The final write still goes through
+  `onSessionEnd()`, preserving the existing persistence path.
+- **Feedback loops:** no new loop. Completion can only demote local state; it
+  does not send Threadline messages or spawn sessions.
+
+---
+
+## 6. External surfaces
+
+Other local agents see more accurate Threadline active-thread state after a
+worker completes. The log line added in v1.3.119 now has a real chance to report
+`demoted 1` for inbound Threadline spawns whose bound name differs from the
+tmux/session name. Persistent `conversations.json` records may have
+`boundSessionName` updated to the actual completed tmux session name during
+demotion; no schema migration is required.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a hot-fix release reverting the UUID lookup and server listener
+argument. No data migration is required. Records already demoted to `idle` would
+remain idle, which is the same terminal state the stale-retirement backstop would
+eventually have reached for completed workers.
+
+## Conclusion
+
+The live canary found a genuine integration mismatch that the original mocked
+tests could not catch. The fix keeps the original name-based path, adds the
+SessionManager UUID path the real runtime needs, and preserves the
+awaiting-reply and no-unrelated-archiving protections. Clear to ship.
+
+---
+
+## Second-pass review
+
+**Reviewer:** `echo`
+**Independent read of the artifact:** `concern incorporated`
+
+Echo specifically called out the integration risk that `boundSessionName` might
+not equal the `sessionComplete` event's name (`session.name` vs `tmuxSession`) and
+asked for a real post-deploy canary. That canary reproduced the mismatch. This
+patch is the resolution: match by persisted SessionManager UUID as well as name.
+
+---
+
+## Evidence pointers
+
+- `npm test -- tests/unit/threadline/ThreadlineRouter.test.ts tests/unit/threadline/ThreadResumeMap.test.ts` — 78/78 passed.
+- `npm run build` — passed; local signing key absent, lockfile signing skipped as documented transitional state.
+- `.husky/pre-push` before commit ran the scoped Threadline e2e suite — 331/331 passed.

--- a/upgrades/side-effects/threadline-session-complete-retirement.md
+++ b/upgrades/side-effects/threadline-session-complete-retirement.md
@@ -91,4 +91,5 @@ Initial concern: `getBySessionName()` called `retireInactive()` before filtering
 - `npx vitest run tests/unit/threadline/ThreadlineRouter.test.ts` — 36/36 passed.
 - `npx vitest run tests/unit/threadline/ThreadResumeMap.test.ts` — 41/41 passed.
 - `npm test -- tests/unit/threadline/ThreadlineRouter.test.ts tests/unit/threadline/ThreadResumeMap.test.ts` — 77/77 passed after merging `v1.3.118` main into the PR branch and preparing `v1.3.119` release metadata.
+- `npm test -- tests/unit/threadline/ThreadlineRouter.test.ts tests/unit/threadline/ThreadResumeMap.test.ts` — 78/78 passed after adding SessionManager UUID fallback coverage for the real inbound Threadline binding shape.
 - `npm run build` — passed; local signing key absent, lockfile signing skipped as documented transitional state.


### PR DESCRIPTION
## Summary
- Add side-effect-free ThreadResumeMap lookup by SessionManager UUID
- Let ThreadlineRouter session completion demote threads matched by bound session name or session UUID
- Pass SessionManager session.id from the server sessionComplete listener and add the real-shape regression

## Verification
- npm test -- tests/unit/threadline/ThreadlineRouter.test.ts tests/unit/threadline/ThreadResumeMap.test.ts (78/78)
- npm run build
- .husky/pre-push affected smoke (79/79)
- .husky/pre-push scoped Threadline e2e (331/331)

Live canary note: v1.3.119 proved inbound Threadline records can persist sessionUuid=session.id while boundSessionName is the short logical thread name, so name-only completion lookup demoted zero. This PR closes that mismatch.