### PR TITLE
Fix Threadline completion demotion write path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instar",
-  "version": "1.3.120",
+  "version": "1.3.121",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instar",
-      "version": "1.3.120",
+      "version": "1.3.121",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instar",
-  "version": "1.3.120",
+  "version": "1.3.121",
   "description": "Coherence infrastructure for self-evolving AI agents — on the Claude Code or Codex subscription you already have.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-30T12:31:41.858Z",
-  "instarVersion": "1.3.120",
+  "generatedAt": "2026-05-30T13:08:22.509Z",
+  "instarVersion": "1.3.121",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {

--- a/src/threadline/ThreadlineRouter.ts
+++ b/src/threadline/ThreadlineRouter.ts
@@ -614,7 +614,13 @@ export class ThreadlineRouter {
         skippedAwaitingReply += 1;
         continue;
       }
-      this.onSessionEnd(match.threadId, uuid || match.entry.uuid, sessionName);
+      this.threadResumeMap.save(match.threadId, {
+        ...match.entry,
+        uuid: uuid || match.entry.uuid,
+        sessionName,
+        state: 'idle',
+        lastAccessedAt: new Date().toISOString(),
+      });
       demoted += 1;
     }
 

--- a/tests/unit/threadline/ThreadlineRouter.test.ts
+++ b/tests/unit/threadline/ThreadlineRouter.test.ts
@@ -711,7 +711,6 @@ describe('ThreadlineRouter', () => {
     it('demotes an active thread when completion matches the SessionManager UUID but not the bound session name', () => {
       const threadId = crypto.randomUUID();
       const sessionManagerUuid = 'sessionmgr-2222-3333-4444-555555555555';
-      createFakeJsonl(sessionManagerUuid);
 
       threadResumeMap.save(threadId, makeEntry({
         uuid: sessionManagerUuid,

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,39 @@
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Threadline session-completion demotion now writes the matched conversation
+directly.**
+
+The v1.3.120 UUID fallback correctly found real inbound Threadline worker
+sessions by `SessionManager` UUID, but the demotion path re-entered the resume
+guard through `onSessionEnd()`. That guard expects a resumable Claude/Codex
+transcript JSONL, while live Threadline spawns persist the `SessionManager`
+session id. The result was a misleading `demoted 1` log with the conversation
+still left `active`.
+
+Fix: `ThreadlineRouter.onSessionComplete()` now demotes from the already matched
+conversation entry instead of re-reading through the resume guard. The existing
+awaiting-reply skip still applies before any write.
+
+## What to Tell Your User
+
+Threadline worker threads now really retire when their spawned session is
+stopped or completes. The previous release could log that it demoted a thread
+without actually moving the conversation out of the active list.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Direct completion demotion | Automatic when a Threadline worker emits `sessionComplete` |
+| Non-transcript SessionManager UUID support | Automatic for inbound Threadline spawns |
+
+## Evidence
+
+- **Regression:** `ThreadlineRouter.onSessionComplete()` demotes a UUID-matched
+  active thread even when that UUID has no transcript JSONL.
+- **Live canary basis:** v1.3.120 matched by UUID and logged `demoted 1`, but the
+  persisted conversation stayed `active`; this patch fixes that write path.

--- a/upgrades/side-effects/1.3.121.md
+++ b/upgrades/side-effects/1.3.121.md
@@ -1,0 +1,97 @@
+# Side-Effects Review — Threadline completion direct demotion
+
+**Version / slug:** `1.3.121`
+**Date:** 2026-05-30
+**Author:** `instar-codey`
+**Second-pass reviewer:** `live canary`
+
+## Summary of the change
+
+This patch fixes the final write step in Threadline session-completion
+retirement. The v1.3.120 UUID lookup found live inbound worker conversations,
+but `ThreadlineRouter.onSessionComplete()` delegated to `onSessionEnd()`, which
+re-read the thread through the resume guard. For live Threadline spawns the
+stored UUID is a `SessionManager` id, not a resumable transcript UUID, so the
+guard could return null. The completion log then said `demoted 1` while the
+conversation stayed `active`.
+
+The router now writes the matched entry to `idle` directly after the
+awaiting-reply guard passes.
+
+## Decision-point inventory
+
+- `ThreadlineRouter.onSessionComplete()` — modify — demotes from the matched
+  live conversation entry instead of re-entering the transcript resume guard.
+- `ThreadlineRouter.onSessionEnd()` — unchanged — remains the explicit
+  thread-id + resumable-UUID path.
+
+---
+
+## 1. Over-block
+
+No block/allow surface. The over-demotion risk is unchanged from v1.3.120:
+only active conversations already matched by bound session name or
+SessionManager UUID are moved to `idle`, and `awaiting-reply` conversations are
+skipped before any write.
+
+---
+
+## 2. Under-block
+
+The change still cannot demote records that have neither a matching
+`boundSessionName` nor a matching `sessionUuid`. The observed live path does
+persist `sessionUuid`, and v1.3.120 added the lookup.
+
+---
+
+## 3. Level-of-abstraction fit
+
+The fix stays in the lifecycle router, where the completion decision already
+lives. `ThreadResumeMap` remains the storage adapter; it is not given new
+authority to decide lifecycle state.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface.
+
+The authoritative completion signal still comes from `SessionManager`. This
+patch only corrects how the router applies that signal to a matched local
+conversation.
+
+---
+
+## 5. Interactions
+
+- **Resume guard:** direct demotion intentionally bypasses the transcript
+  existence guard because the match already came from a live conversation
+  record, not from a user-initiated resume lookup.
+- **Awaiting reply:** preserved; `awaiting-reply` records are counted and left
+  untouched before direct demotion runs.
+- **Double match:** still deduped by `threadId` before writes.
+- **Logging:** the existing `demoted N / skipped M` log now reflects actual
+  writes instead of possible guard-filtered no-ops.
+
+---
+
+## 6. External surfaces
+
+Other agents and dashboards should see completed Threadline worker conversations
+leave the active set promptly. Existing records are not migrated; they demote
+when their bound worker emits a completion event.
+
+---
+
+## 7. Rollback cost
+
+Rollback is a small patch reverting `onSessionComplete()` to delegate through
+`onSessionEnd()`. No schema or data migration is involved.
+
+## Conclusion
+
+The live canary caught a false-positive demotion log. This patch keeps the
+v1.3.120 name/UUID matching and makes the matched completion path actually
+persist `idle`.


### PR DESCRIPTION
## Summary
- demote matched Threadline completion records directly instead of re-reading through the transcript resume guard
- add regression for SessionManager UUID completion with no transcript JSONL
- prepare v1.3.121 release notes and side-effects artifact

## Verification
- npm test -- tests/unit/threadline/ThreadlineRouter.test.ts tests/unit/threadline/ThreadResumeMap.test.ts
- npm run build
- .husky/pre-push