### PR TITLE
fix(codex): jsonlExists resolves codex rollout files so resume works for codex agents

### DIFF
--- a/docs/specs/CODEX-RESUME-JSONL-EXISTS-SPEC.md
+++ b/docs/specs/CODEX-RESUME-JSONL-EXISTS-SPEC.md
@@ -1,0 +1,85 @@
+---
+title: jsonlExists resolves codex rollout files so resume works for codex agents
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: CODEX-RESUME-JSONL-EXISTS.eli16.md
+---
+
+# jsonlExists Resolves Codex Rollout Files
+
+## Problem
+
+`ThreadResumeMap.jsonlExists` and `TopicResumeMap.jsonlExists` are the guards
+that decide whether a saved session UUID still has a transcript on disk before
+the resume maps return it from `get()`. Both check ONLY the Claude flat layout —
+`~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`.
+
+A codex agent never writes there. Codex writes date-partitioned rollout files:
+`$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`. So for every codex
+session, `jsonlExists` returns `false`, the resume entry is treated as
+expired/missing, `get()` returns `null`, and the ~9 consumers that depend on it
+(ThreadlineRouter resume, ThreadlineMCPServer, TopicLinkageHandler, the
+server-side topic resume path) all silently fail to resume. Resume is broken
+fleet-wide for codex agents.
+
+## Scope
+
+Make both `jsonlExists` predicates framework-aware by adding a codex rollout
+fallback, reusing the existing codex session-path helpers.
+
+In scope:
+
+- `src/providers/adapters/openai-codex/observability/sessionPaths.ts` — add
+  `findRolloutFileSync(threadId, codexHome?)`, a synchronous sibling of the
+  existing async `findRolloutFile` (the resume-map guards are synchronous and
+  cannot await).
+- `src/threadline/ThreadResumeMap.ts` — `jsonlExists` checks the Claude layout
+  first (unchanged), then falls back to `findRolloutFileSync`.
+- `src/core/TopicResumeMap.ts` — same fallback in its `jsonlExists`.
+
+Out of scope: the other claude-first assumptions surfaced in the same audit
+(RateLimitSentinel / CompactionSentinel default JSONL roots, the silence
+sentinel's codex activity signals) — tracked separately.
+
+## Design
+
+`findRolloutFileSync` mirrors the async `findRolloutFile` exactly — a recursive
+filesystem walk of `$CODEX_HOME/sessions` for a file matching
+`rollout-*-<uuid>.jsonl` — using the synchronous `readdirSync`/`statSync`. A
+missing `$CODEX_HOME/sessions` (the common case for a pure Claude agent) returns
+`null` immediately because `readdirSync` throws and is caught.
+
+Each `jsonlExists` keeps its existing Claude check unchanged and returns early on
+a Claude hit, so Claude behavior is byte-for-byte unchanged. Only when the Claude
+layout has no match does it consult the codex layout. Both checks are wrapped so
+a filesystem error in one layout falls through to the other rather than throwing.
+
+Reuse rationale: `findRolloutFile` / `codexHomeFromConfig` are the same helpers
+`TokenLedger` already uses to attribute codex token usage — this is the
+established codex-awareness seam, not a new one.
+
+## Testing
+
+- **Unit** (`tests/unit/codexRolloutFileSync.test.ts`):
+  - `findRolloutFileSync` — both sides of the boundary: present rollout (any date
+    partition) → path; no matching uuid → null; missing `$CODEX_HOME/sessions` →
+    null; empty uuid → null; a non-rollout file containing the uuid → null.
+  - `TopicResumeMap.jsonlExists` (via the existing `jsonlExistsPublic` hook, with
+    `$HOME` pointed at a fixture) — a codex session with only a rollout file (no
+    Claude jsonl) now returns `true`; an absent uuid returns `false`. This is the
+    exact fix boundary: it was `false` before.
+- **Regression**: the full resume-map suite (ThreadResumeMap, TopicResumeMap,
+  topic-resume-map, resume-failed-uuid-gate, session-resume-e2e — 133 tests)
+  stays green, confirming the Claude path is unchanged.
+
+## Risks and non-goals
+
+- `jsonlExists` now does a codex-tree walk when the Claude layout misses. For a
+  Claude-only agent there is no `$CODEX_HOME/sessions`, so the walk is a single
+  failed `readdirSync` — negligible. For a codex agent the walk is bounded by the
+  session count; this is the same cost the async path already pays per resume.
+- Claude is checked first, so a codex agent pays a small redundant Claude-dir
+  read before the codex hit. Acceptable — keeping the order framework-agnostic
+  avoids threading framework state into the predicate.
+- This fixes the resume predicate only. Other claude-first assumptions are out of
+  scope and tracked separately.

--- a/docs/specs/CODEX-RESUME-JSONL-EXISTS.eli16.md
+++ b/docs/specs/CODEX-RESUME-JSONL-EXISTS.eli16.md
@@ -1,0 +1,32 @@
+# Why Codex agents could never resume a conversation
+
+These AI agents can be paused and later picked back up where they left off. To
+pick a conversation back up, the agent first checks that the saved record of
+that conversation still exists on the computer. If the record is there, it
+resumes; if not, it assumes the conversation is gone and starts fresh.
+
+The check for that record only ever looked in ONE place — the folder where
+Claude-based agents keep their conversation files. But agents built on a
+different engine called Codex keep their conversation files somewhere completely
+different, organized into folders by date. So whenever a Codex agent tried to
+pick a conversation back up, the check looked in the Claude folder, found
+nothing, and wrongly concluded the conversation was gone. The Codex agent could
+never resume — it always started over and lost the thread, even though its
+record was sitting right there in the Codex folder the whole time.
+
+The fix teaches the check to look in BOTH places. It still looks in the Claude
+folder first, exactly as before, so nothing changes for Claude agents. But if it
+does not find the record there, it now also looks in the Codex folder — walking
+the date-organized layout to find the matching conversation file. If the record
+exists in either place, the agent resumes correctly.
+
+For an agent that only uses Claude, the extra Codex look-up costs essentially
+nothing: the Codex folder does not even exist, so the check notices that
+instantly and moves on. For a Codex agent, it finds the record where it actually
+lives, and resume finally works.
+
+This reuses the same Codex file-finding helper the system already uses elsewhere
+to track how many tokens a Codex agent has spent, so it is not new or untested
+machinery — it just points the resume check at the Codex layout it was always
+missing. The change only touches the one check that asks "does this conversation
+record still exist"; everything else about how resume works is untouched.

--- a/src/core/TopicResumeMap.ts
+++ b/src/core/TopicResumeMap.ts
@@ -14,6 +14,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { findRolloutFileSync } from '../providers/adapters/openai-codex/observability/sessionPaths.js';
 
 interface ResumeEntry {
   uuid: string;
@@ -279,11 +280,22 @@ export class TopicResumeMap {
    * Check if a JSONL file exists for the given UUID in this project's directory.
    */
   private jsonlExists(uuid: string): boolean {
+    if (!uuid) return false;
+    // Claude: flat <project-jsonl-dir>/<uuid>.jsonl.
     const jsonlPath = path.join(this.claudeProjectJsonlDir(), `${uuid}.jsonl`);
     try {
-      return fs.existsSync(jsonlPath);
+      if (fs.existsSync(jsonlPath)) return true;
     } catch {
-      return false;
+      // Can't check the Claude layout — fall through to the codex layout.
     }
+    // Codex: date-partitioned $CODEX_HOME/sessions/.../rollout-<ts>-<uuid>.jsonl.
+    // Without this every codex session looks expired/missing and resume breaks
+    // fleet-wide for codex agents (codex-compat root).
+    try {
+      if (findRolloutFileSync(uuid) !== null) return true;
+    } catch {
+      // Can't check the codex layout — treat as not found.
+    }
+    return false;
   }
 }

--- a/src/providers/adapters/openai-codex/observability/sessionPaths.ts
+++ b/src/providers/adapters/openai-codex/observability/sessionPaths.ts
@@ -13,7 +13,7 @@
  *   Verdict:     deterministic FS walk + canary (canary at canary/codexSessionLayoutCanary.ts)
  */
 
-import { promises as fs } from 'node:fs';
+import { promises as fs, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
 
@@ -29,6 +29,46 @@ export async function findRolloutFile(
   if (!threadId) return null;
   const root = path.join(codexHomeFromConfig(codexHome), 'sessions');
   return walkForUuid(root, threadId);
+}
+
+/**
+ * Synchronous variant of {@link findRolloutFile}. Needed by callers that run on
+ * a sync code path and cannot await — notably the resume-map `jsonlExists`
+ * guards (ThreadResumeMap, TopicResumeMap), which previously checked only the
+ * Claude flat layout and so returned false for EVERY codex session (the
+ * codex-compat resume bug: every codex thread looked expired/missing). Returns
+ * the rollout path or null. A missing `$CODEX_HOME/sessions` (e.g. a pure
+ * Claude agent) returns null fast — `readdirSync` throws and is caught.
+ */
+export function findRolloutFileSync(threadId: string, codexHome?: string): string | null {
+  if (!threadId) return null;
+  const root = path.join(codexHomeFromConfig(codexHome), 'sessions');
+  return walkForUuidSync(root, threadId);
+}
+
+function walkForUuidSync(root: string, uuid: string): string | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const full = path.join(root, entry);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      const nested = walkForUuidSync(full, uuid);
+      if (nested) return nested;
+    } else if (stat.isFile() && entry.startsWith('rollout-') && entry.includes(uuid) && entry.endsWith('.jsonl')) {
+      return full;
+    }
+  }
+  return null;
 }
 
 async function walkForUuid(root: string, uuid: string): Promise<string | null> {

--- a/src/threadline/ThreadResumeMap.ts
+++ b/src/threadline/ThreadResumeMap.ts
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { findRolloutFileSync } from '../providers/adapters/openai-codex/observability/sessionPaths.js';
 import { ConversationStore, type Conversation, type ConversationState } from './ConversationStore.js';
 
 // ── Types ───────────────────────────────────────────────────────
@@ -351,14 +352,24 @@ export class ThreadResumeMap {
    *  tests can bypass the filesystem check via a subclass.) */
   protected jsonlExists(uuid: string): boolean {
     if (!uuid) return false;
+    // Claude: flat ~/.claude/projects/<encoded-cwd>/<uuid>.jsonl.
     const claudeProjectsDir = path.join(os.homedir(), '.claude', 'projects');
-    if (!fs.existsSync(claudeProjectsDir)) return false;
-    try {
-      for (const dir of fs.readdirSync(claudeProjectsDir)) {
-        if (fs.existsSync(path.join(claudeProjectsDir, dir, `${uuid}.jsonl`))) return true;
+    if (fs.existsSync(claudeProjectsDir)) {
+      try {
+        for (const dir of fs.readdirSync(claudeProjectsDir)) {
+          if (fs.existsSync(path.join(claudeProjectsDir, dir, `${uuid}.jsonl`))) return true;
+        }
+      } catch {
+        // Can't check the Claude layout — fall through to the codex layout.
       }
+    }
+    // Codex: date-partitioned $CODEX_HOME/sessions/.../rollout-<ts>-<uuid>.jsonl.
+    // A codex thread has no Claude jsonl, so without this every codex session
+    // looks expired/missing and resume breaks fleet-wide (codex-compat root).
+    try {
+      if (findRolloutFileSync(uuid) !== null) return true;
     } catch {
-      // Can't check — assume not found.
+      // Can't check the codex layout — treat as not found.
     }
     return false;
   }

--- a/tests/unit/codexRolloutFileSync.test.ts
+++ b/tests/unit/codexRolloutFileSync.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { findRolloutFileSync } from '../../src/providers/adapters/openai-codex/observability/sessionPaths.js';
+import { TopicResumeMap } from '../../src/core/TopicResumeMap.js';
+
+/**
+ * Unit coverage for findRolloutFileSync — the sync codex rollout lookup behind
+ * the codex-compat resume fix (jsonlExists must see codex sessions, which live
+ * at $CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl, not the Claude
+ * flat layout). Both sides of the boundary: present → path, absent/no-home → null.
+ */
+describe('findRolloutFileSync', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeRollout(uuid: string, ymd = ['2026', '05', '30']): string {
+    const dir = path.join(home, 'sessions', ...ymd);
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `rollout-2026-05-30T12-00-00-${uuid}.jsonl`);
+    fs.writeFileSync(file, '{"type":"thread.started"}\n');
+    return file;
+  }
+
+  it('finds a rollout file by uuid in the date-partitioned tree', () => {
+    const uuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const expected = writeRollout(uuid);
+    expect(findRolloutFileSync(uuid, home)).toBe(expected);
+  });
+
+  it('returns null when no rollout matches the uuid', () => {
+    writeRollout('some-other-uuid');
+    expect(findRolloutFileSync('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', home)).toBeNull();
+  });
+
+  it('returns null fast when $CODEX_HOME/sessions does not exist (pure Claude agent)', () => {
+    // home exists but has no sessions/ dir.
+    expect(findRolloutFileSync('any-uuid', home)).toBeNull();
+  });
+
+  it('returns null for an empty uuid', () => {
+    writeRollout('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    expect(findRolloutFileSync('', home)).toBeNull();
+  });
+
+  it('does not match a non-rollout file that happens to contain the uuid', () => {
+    const uuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const dir = path.join(home, 'sessions', '2026', '05', '30');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `notes-${uuid}.txt`), 'x'); // not rollout-*.jsonl
+    expect(findRolloutFileSync(uuid, home)).toBeNull();
+  });
+
+  it('finds a rollout nested under any date partition', () => {
+    const uuid = '11112222-3333-4444-5555-666677778888';
+    const expected = writeRollout(uuid, ['2026', '04', '01']);
+    expect(findRolloutFileSync(uuid, home)).toBe(expected);
+  });
+});
+
+/**
+ * The actual codex-compat fix boundary: TopicResumeMap.jsonlExists must return
+ * true for a codex session (rollout file present), where before it returned
+ * false (claude-only) and resume broke for every codex agent.
+ */
+describe('TopicResumeMap.jsonlExists — codex rollout branch', () => {
+  let tmpDir: string;
+  let fakeHome: string;
+  let priorHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-resume-'));
+    fakeHome = path.join(tmpDir, 'home');
+    fs.mkdirSync(fakeHome, { recursive: true });
+    // jsonlExists' codex branch resolves $CODEX_HOME via os.homedir()/.codex,
+    // and os.homedir() reads $HOME on POSIX — point it at the fixture home.
+    priorHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+  });
+
+  afterEach(() => {
+    if (priorHome === undefined) delete process.env.HOME;
+    else process.env.HOME = priorHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns true when only a codex rollout exists (no claude jsonl)', () => {
+    const uuid = '99998888-7777-6666-5555-444433332222';
+    const dir = path.join(fakeHome, '.codex', 'sessions', '2026', '05', '30');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `rollout-2026-05-30T01-02-03-${uuid}.jsonl`), '{"type":"turn.started"}\n');
+
+    const stateDir = path.join(tmpDir, 'state');
+    const projectDir = path.join(tmpDir, 'project');
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.mkdirSync(projectDir, { recursive: true });
+    const resumeMap = new TopicResumeMap(stateDir, projectDir);
+
+    expect(resumeMap.jsonlExistsPublic(uuid)).toBe(true);
+    expect(resumeMap.jsonlExistsPublic('deadbeef-dead-beef-dead-beefdeadbeef')).toBe(false);
+  });
+});

--- a/tests/unit/codexRolloutFileSync.test.ts
+++ b/tests/unit/codexRolloutFileSync.test.ts
@@ -1,9 +1,12 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { findRolloutFileSync } from '../../src/providers/adapters/openai-codex/observability/sessionPaths.js';
 import { TopicResumeMap } from '../../src/core/TopicResumeMap.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
 
 /**
  * Unit coverage for findRolloutFileSync — the sync codex rollout lookup behind
@@ -19,7 +22,7 @@ describe('findRolloutFileSync', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(home, { recursive: true, force: true });
+    SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'tests/unit/codexRolloutFileSync.test.ts:cleanup' });
   });
 
   function writeRollout(uuid: string, ymd = ['2026', '05', '30']): string {
@@ -89,7 +92,7 @@ describe('TopicResumeMap.jsonlExists — codex rollout branch', () => {
   afterEach(() => {
     if (priorHome === undefined) delete process.env.HOME;
     else process.env.HOME = priorHome;
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/codexRolloutFileSync.test.ts:cleanup' });
   });
 
   it('returns true when only a codex rollout exists (no claude jsonl)', () => {

--- a/upgrades/side-effects/codex-resume-jsonl-exists.md
+++ b/upgrades/side-effects/codex-resume-jsonl-exists.md
@@ -1,0 +1,68 @@
+# Side-Effects Review — jsonlExists resolves codex rollout files
+
+**Version / slug:** `codex-resume-jsonl-exists`
+**Date:** `2026-05-30`
+**Author:** `instar-echo`
+**Second-pass reviewer:** `instar-echo second-pass checklist`
+
+## Summary of the change
+
+`ThreadResumeMap.jsonlExists` and `TopicResumeMap.jsonlExists` decided a saved
+session UUID was missing unless a Claude flat-layout transcript
+(`~/.claude/projects/<encoded>/<uuid>.jsonl`) existed. Codex writes rollout files
+at `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`, so both
+predicates returned `false` for every codex session — `get()` returned null and
+resume broke fleet-wide for codex agents (~9 consumers).
+
+The change adds `findRolloutFileSync` to the openai-codex `sessionPaths` helper
+(a synchronous sibling of the existing async `findRolloutFile`, since the resume
+guards are synchronous) and makes both `jsonlExists` predicates check the Claude
+layout first (unchanged, early-return on hit) then fall back to the codex layout.
+Returns true if either exists. Reuses the codex session-path seam `TokenLedger`
+already uses.
+
+## Decision-point inventory
+
+- `findRolloutFileSync` — add — sync codex rollout lookup; chooses whether a
+  codex thread has an on-disk rollout.
+- `ThreadResumeMap.jsonlExists` — modify — now resolves codex rollouts in
+  addition to the Claude layout.
+- `TopicResumeMap.jsonlExists` — modify — same codex fallback.
+
+---
+
+## 1. Over-block
+
+A false "missing" would now require BOTH the Claude layout and the codex layout
+to lack the uuid. The change can only make `jsonlExists` return true in MORE
+cases than before (it adds a second place to look, never removes the first), so
+it cannot newly over-block a session that previously resolved. The only residual
+over-block is the pre-existing one: a genuinely-deleted transcript correctly
+reads as missing in both layouts.
+
+## 2. Under-block
+
+The codex fallback could in principle resolve a uuid collision — a rollout file
+whose name contains the uuid substring but belongs to a different session. This
+mirrors the existing async `findRolloutFile` matching (`rollout-*-<uuid>.jsonl`)
+and uuids are effectively unique, so the risk is the same as the established
+codex path. The match also requires the `rollout-` prefix and `.jsonl` suffix, so
+an unrelated file merely containing the uuid is not matched (covered by test).
+
+## 3. Level-of-abstraction fit
+
+The sync lookup lives in the openai-codex `sessionPaths` module, alongside the
+async `findRolloutFile` it mirrors — the one place that owns the codex on-disk
+session layout. The resume predicates consume it rather than reimplementing the
+walk, so the codex layout knowledge stays in exactly one module. No framework
+state is threaded into the predicate; it simply consults both layouts.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No LLM judgment. This is a deterministic filesystem existence check feeding
+  an existing guard. It exercises no new authority — it only makes the existing
+  "does this transcript exist" predicate correct for codex agents. Its single
+  effect is to let a codex session resume that previously could not; it never
+  blocks, kills, or messages.


### PR DESCRIPTION
## Problem
`ThreadResumeMap.jsonlExists` + `TopicResumeMap.jsonlExists` checked only the claude flat layout (`~/.claude/projects/<enc>/<uuid>.jsonl`), so they returned false for **every codex session** → `get()` returned null → session resume was silently broken fleet-wide for codex agents (~9 consumers: ThreadlineRouter resume, ThreadlineMCPServer, TopicLinkageHandler, the server topic-resume path).

## Fix
Add a synchronous `findRolloutFileSync` (sibling of the existing async `findRolloutFile`) in the openai-codex `sessionPaths` helper, and make both `jsonlExists` predicates check the codex rollout layout (`$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`) as a fallback **after** the claude check. The claude path is byte-for-byte unchanged.

## Testing
- **unit** `tests/unit/codexRolloutFileSync.test.ts` (7): `findRolloutFileSync` both sides of the boundary + the `jsonlExists` codex boundary (codex rollout present → `true`, where it was `false` before).
- **regression**: 133 resume-map tests (ThreadResumeMap / TopicResumeMap / topic-resume-map / resume-failed-uuid-gate / session-resume-e2e) green — claude path unchanged.
- `tsc --noEmit` clean.

Spec: `docs/specs/CODEX-RESUME-JSONL-EXISTS-SPEC.md`

> Shipped autonomously under the 12h autonomous session's deploy mandate (the goal explicitly directs merge→release→deploy). Spec self-approved under that delegated authority — flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)