### PR TITLE
fix(monitoring): recognize codex exec --json sessions as actively working (silence watchdog)

### DIFF
--- a/docs/specs/CODEX-EXEC-JSON-SILENCE-SIGNAL-SPEC.md
+++ b/docs/specs/CODEX-EXEC-JSON-SILENCE-SIGNAL-SPEC.md
@@ -1,0 +1,90 @@
+---
+title: Silence sentinel recognizes codex exec --json sessions as actively working
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: CODEX-EXEC-JSON-SILENCE-SIGNAL.eli16.md
+---
+
+# Silence Sentinel Recognizes codex exec --json Sessions
+
+## Problem
+
+The ActiveWorkSilenceSentinel detects a session that was producing output and
+then froze mid-task. To avoid flagging a session that is simply idle at its
+prompt, the wiring (`OutputActivityTracker`) only surfaces sessions whose most
+recent frame `looksActivelyWorking`; an idle frame is marked `paused` and the
+sentinel skips it.
+
+`looksActivelyWorking` consults per-framework signatures
+(`frameworkActivitySignals.ts`). The codex signatures were derived from the
+interactive TUI — `• Working (Ns • esc to interrupt)`, `• Ran ...`, the dot
+spinner. But codex JOB and autonomous-spawn sessions run `codex exec --json`,
+which emits a JSON EVENT STREAM, not the TUI status line:
+`{"type":"thread.started"}`, `{"type":"turn.started"}`,
+`{"type":"item.started"|"item.completed"|"item.updated"}`. None of the TUI
+patterns match that, so a working `codex exec --json` session reads as NOT active
+→ is marked `paused` → is skipped by the silence sentinel.
+
+Consequence: a genuinely-wedged exec-json job is invisible to the silence
+watchdog. This was observed live 2026-05-30 — a `codex exec --json`
+commitment-detection job frozen mid-turn (last output `{"type":"turn.started"}`)
+for 8.5 hours, never detected.
+
+## Scope
+
+Extend the codex `toolCallOrSpinner` signature to recognize the `codex exec
+--json` event stream. One file plus a test.
+
+In scope:
+
+- `src/monitoring/frameworkActivitySignals.ts` — add the event-stream
+  namespaces (`"type":"thread."`, `"type":"turn."`, `"type":"item."`) to
+  `CODEX_CLI_SIGNAL.toolCallOrSpinner`, keeping every existing TUI pattern.
+
+Out of scope: SessionWatchdog's separate `getClaudePid`-only model (it detects
+stuck CHILD commands, a different failure than a wedged LLM turn) — tracked
+separately; the silence sentinel is the correct owner of the wedged-turn case.
+
+## Design
+
+Add the alternation `|"type":\s*"(thread|turn|item)\.` to the codex regex. A
+frame containing any of those structured event markers is `active`, so:
+
+- While the job streams events, the `OutputActivityTracker` sees the pane hash
+  change and stamps `lastChangeAt` — the session is silence-eligible.
+- When the job freezes (no new events), `lastChangeAt` stops advancing and the
+  sentinel reports silence after its threshold (default 15 min), then nudges and
+  escalates.
+
+The tracker's existing observed-change requirement is preserved: a session
+frozen *before* the tracker first saw it keeps `lastOutputAt: 0` and is still
+skipped, so a long-dead pane whose last frame happens to contain an event marker
+cannot be flagged en masse on a server restart.
+
+The change is strictly additive — it can only make MORE frozen sessions
+detectable, never fewer. It does not touch the framework-agnostic detection
+logic, only the codex signature feeding it.
+
+## Testing
+
+- **Unit** (`tests/unit/codexExecJsonSilenceSignal.test.ts`):
+  - a `codex exec --json` event frame (`turn.started`, `thread.started`,
+    `item.completed`, multi-line tail) → `looksActivelyWorking` true.
+  - the interactive TUI signatures still register (no regression).
+  - the critical guard holds: the idle codex model-name line
+    (`gpt-5.3-codex medium · <dir>`) and the placeholder prompt stay inactive —
+    the 2026-05-23 false-positive must not return.
+  - empty / unrelated output → false; claude-code detection unaffected (a codex
+    JSON frame does not register under claude signals).
+- **Regression**: the activity-signal + sentinel-wiring suite
+  (frameworkActivitySignals, codex-activity-signal, presence-proxy-codex-
+  blindness, sentinelWiring, StallTriageNurse — 143 tests) stays green.
+
+## Risks and non-goals
+
+- A false positive would require a pane literally containing the structured
+  marker `"type":"thread."` / `"turn."` / `"item."` outside a codex event stream
+  — not normal idle text. The match is anchored to the JSON key form.
+- This fixes only the silence sentinel's codex coverage. The wedged-job kill
+  (the specific 8.5h process) and the SessionWatchdog stuck-child model are
+  separate items.

--- a/docs/specs/CODEX-EXEC-JSON-SILENCE-SIGNAL.eli16.md
+++ b/docs/specs/CODEX-EXEC-JSON-SILENCE-SIGNAL.eli16.md
@@ -1,0 +1,37 @@
+# Why a frozen Codex background job went unnoticed for 8.5 hours
+
+The system has a watchdog whose job is to notice when one of these AI agents
+freezes in the middle of doing something. The idea is simple: if an agent was
+clearly busy and then went completely silent for a long time, the watchdog steps
+in, gives it a nudge, and raises an alarm if it stays stuck.
+
+To avoid crying wolf, the watchdog first decides whether the agent even LOOKS
+busy. An agent just sitting quietly waiting for the next instruction is not
+"stuck" — it is simply resting. So the watchdog only pays attention to agents
+whose screen shows signs of active work.
+
+The trouble was in how it recognized "active work" for agents built on the Codex
+engine. It was taught to look for the things Codex shows in its normal
+interactive window — a little "Working..." status line, a spinning indicator,
+and so on. But when Codex runs a background job, it does not show that friendly
+status line at all. Instead it prints a stream of structured machine-readable
+progress messages — short lines that announce things like a new turn starting or
+an item finishing. The watchdog did not recognize any of those as "work," so it
+concluded these background Codex jobs were idle and ignored them completely.
+
+That had a real cost. One background Codex job got stuck waiting on a reply that
+never came and sat frozen for eight and a half hours. The watchdog never noticed,
+because it had decided that job was not the kind of thing it watches.
+
+The fix teaches the watchdog to recognize Codex's background progress messages as
+a sign of real work. Now when one of those jobs is streaming its progress lines,
+the watchdog counts it as busy and keeps an eye on it. If the progress lines stop
+coming for too long, the watchdog finally does its job: it notices the freeze,
+nudges, and raises the alarm.
+
+Two safeguards stay in place. First, all of Codex's normal interactive signals
+still count, so nothing changes for an agent you are watching live. Second, an
+important earlier guard is preserved: the system still refuses to treat Codex's
+plain "I am idle" status line as work, so it will not go back to falsely thinking
+every resting agent is busy. The change only ever lets the watchdog catch MORE
+freezes, never fewer.

--- a/src/monitoring/frameworkActivitySignals.ts
+++ b/src/monitoring/frameworkActivitySignals.ts
@@ -75,7 +75,18 @@ const CODEX_CLI_SIGNAL: FrameworkActivitySignal = {
   // proxy default to "still working" forever (the 2026-05-23 stuck-session
   // incident). The placeholder prompt "Find and fix a bug in @filename" is
   // likewise an IDLE indicator, not work.
-  toolCallOrSpinner: /Working\s*\(\d+\s*s|•\s*Ran\b|exec\(|shell\(|apply_patch\(|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\bgenerating\b/i,
+  //
+  // codex EXEC --json mode (jobs, autonomous spawns) emits a JSON EVENT STREAM,
+  // not the TUI status line: {"type":"thread.started"}, {"type":"turn.started"},
+  // {"type":"item.started"|"item.completed"|"item.updated"}, etc. None of the
+  // TUI patterns above match that, so a working `codex exec --json` session read
+  // as NOT active → marked paused → skipped by ActiveWorkSilenceSentinel. That
+  // hid a genuinely-wedged exec-json job (frozen mid-turn ~8.5h) from the
+  // silence watchdog. Match the event-stream namespaces so an exec-json session
+  // that streamed events THEN froze is silence-eligible (the OutputActivity-
+  // Tracker's observed-change requirement still gates "frozen before we watched").
+  // These are structured JSON markers, not idle status text.
+  toolCallOrSpinner: /Working\s*\(\d+\s*s|•\s*Ran\b|exec\(|shell\(|apply_patch\(|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|\bgenerating\b|"type":\s*"(thread|turn|item)\./i,
   // Codex shows a BARE "esc to interrupt" (no "press"/"hit" prefix) inside
   // its working status line, so the Claude-style prefixed pattern never
   // matched a real Codex pane. Match the bare form.

--- a/tests/unit/codexExecJsonSilenceSignal.test.ts
+++ b/tests/unit/codexExecJsonSilenceSignal.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { looksActivelyWorking } from '../../src/monitoring/sentinelWiring.js';
+
+/**
+ * The silence-sentinel codex-coverage fix: a `codex exec --json` session (jobs,
+ * autonomous spawns) emits a JSON event stream, not the interactive TUI status
+ * line. Before the fix none of the codex patterns matched that stream, so a
+ * working exec-json session read as NOT active → marked paused → skipped by the
+ * ActiveWorkSilenceSentinel → a wedged exec-json job (the 8.5h-hung
+ * commitment-detection job) was invisible. These tests pin the new behaviour
+ * AND the critical no-false-positive guard (idle model-name line stays inactive).
+ */
+describe('looksActivelyWorking — codex exec --json coverage', () => {
+  it('recognizes a codex exec --json event-stream frame as active', () => {
+    expect(looksActivelyWorking('{"type":"turn.started"}', 'codex-cli')).toBe(true);
+    expect(looksActivelyWorking('{"type":"thread.started","thread_id":"abc"}', 'codex-cli')).toBe(true);
+    expect(
+      looksActivelyWorking('{"type":"item.completed","item":{"id":"item_0"}}', 'codex-cli'),
+    ).toBe(true);
+    // realistic multi-line pane tail
+    const pane = [
+      '{"type":"thread.started","thread_id":"019e77ca"}',
+      '{"type":"turn.started"}',
+    ].join('\n');
+    expect(looksActivelyWorking(pane, 'codex-cli')).toBe(true);
+  });
+
+  it('still recognizes the interactive TUI working signatures (no regression)', () => {
+    expect(looksActivelyWorking('• Working (12s • esc to interrupt)', 'codex-cli')).toBe(true);
+    expect(looksActivelyWorking('• Ran apply_patch', 'codex-cli')).toBe(true);
+  });
+
+  it('does NOT treat the idle codex model-name status line as active (critical guard)', () => {
+    // The 2026-05-23 incident: matching "codex" made every idle session look busy.
+    expect(looksActivelyWorking('gpt-5.3-codex medium · ~/project', 'codex-cli')).toBe(false);
+    expect(looksActivelyWorking('Find and fix a bug in @filename', 'codex-cli')).toBe(false);
+  });
+
+  it('does not false-positive on empty or unrelated output', () => {
+    expect(looksActivelyWorking('', 'codex-cli')).toBe(false);
+    expect(looksActivelyWorking('$ ', 'codex-cli')).toBe(false);
+  });
+
+  it('leaves claude-code detection unaffected', () => {
+    expect(looksActivelyWorking('Read(file.ts)', 'claude-code')).toBe(true);
+    // a codex JSON frame should NOT register under claude-code signals
+    expect(looksActivelyWorking('{"type":"turn.started"}', 'claude-code')).toBe(false);
+  });
+});

--- a/upgrades/side-effects/codex-exec-json-silence-signal.md
+++ b/upgrades/side-effects/codex-exec-json-silence-signal.md
@@ -1,0 +1,64 @@
+# Side-Effects Review — silence sentinel recognizes codex exec --json sessions
+
+**Version / slug:** `codex-exec-json-silence-signal`
+**Date:** `2026-05-30`
+**Author:** `instar-echo`
+**Second-pass reviewer:** `instar-echo second-pass checklist`
+
+## Summary of the change
+
+The ActiveWorkSilenceSentinel only watches sessions that `looksActivelyWorking`;
+an idle frame is marked `paused` and skipped. The codex activity signatures in
+`frameworkActivitySignals.ts` matched only the interactive TUI. Codex job and
+autonomous-spawn sessions run `codex exec --json`, which emits a JSON event
+stream (`{"type":"thread.started"}`, `{"type":"turn.started"}`,
+`{"type":"item.completed"}`, ...) that matched nothing — so a working exec-json
+session read as not-active, was marked paused, and the silence watchdog never
+considered it. A wedged exec-json job (frozen mid-turn ~8.5h, 2026-05-30) was
+invisible.
+
+The change adds the event-stream namespaces to
+`CODEX_CLI_SIGNAL.toolCallOrSpinner` (`"type":"thread."`/`"turn."`/`"item."`),
+keeping every existing TUI pattern. A working exec-json session is now active and
+silence-eligible; when it freezes the sentinel detects the output gap.
+
+## Decision-point inventory
+
+- `CODEX_CLI_SIGNAL.toolCallOrSpinner` — modify — extends the "is codex actively
+  working" signature to cover the exec-json event stream, not just the TUI.
+
+---
+
+## 1. Over-block
+
+"Over-block" here would mean flagging a session as frozen when it is fine. The
+change cannot cause that: it only makes a session ELIGIBLE for silence checking
+(by counting it as active). The actual freeze decision is still the
+output-silence threshold plus the tracker's observed-change requirement — both
+unchanged. A live, still-streaming exec-json session keeps advancing
+`lastChangeAt` and is never flagged.
+
+## 2. Under-block
+
+A truly-idle exec-json pane that happens to contain a stale event marker could
+read as active. This does not cause a false alarm (the tracker requires an
+observed active→silent transition; a pane frozen before first sighting stays
+`lastOutputAt: 0` and is skipped). The critical 2026-05-23 guard — never match
+the idle model-name status line — is preserved and explicitly tested.
+
+## 3. Level-of-abstraction fit
+
+The codex event-stream signature belongs in `frameworkActivitySignals.ts`, the
+single module that owns per-framework activity patterns. The framework-agnostic
+detection in `sentinelWiring`/`ActiveWorkSilenceSentinel` is untouched — only the
+codex signature it consumes is extended, so every framework's detection path
+stays uniform.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] This is a detector signature, not authority. It feeds the existing silence
+  detector; it issues no kill and no block. Its only effect is to let the
+  detector SEE codex exec-json sessions it was previously blind to. The
+  downstream nudge/escalation policy is unchanged and already tone-gated.


### PR DESCRIPTION
## Problem
`ActiveWorkSilenceSentinel` only watches sessions that `looksActivelyWorking` (an idle frame is marked `paused` and skipped). The codex activity signatures matched only the interactive TUI (`Working (Ns ...)`, `Ran`, the spinner). But codex **job / autonomous-spawn** sessions run `codex exec --json`, which emits a JSON event stream (`{"type":"thread.started"}`, `{"type":"turn.started"}`, `{"type":"item.completed"}`). None matched, so a working exec-json session read as **not active** → marked paused → the silence watchdog never considered it. A wedged exec-json job (frozen mid-turn ~8.5h, 2026-05-30) was invisible.

## Fix
Add the event-stream namespaces (`"type":"(thread|turn|item)."`) to `CODEX_CLI_SIGNAL.toolCallOrSpinner`, keeping every existing TUI pattern. A working exec-json session is now active and silence-eligible; when it freezes the sentinel detects the output gap. The tracker's observed-change requirement still gates "frozen before we watched", and the critical 2026-05-23 idle-model-name guard is preserved.

## Testing
- **unit** `tests/unit/codexExecJsonSilenceSignal.test.ts` (5): exec-json frame to active; TUI signatures still work; idle model-name line stays inactive; empty/unrelated false; claude-code unaffected.
- regression: 143 activity-signal / sentinel-wiring tests green; `tsc` / `npm run lint` clean.

Strictly additive — can only make MORE frozen sessions detectable, never fewer. SessionWatchdog's separate stuck-child model is tracked separately.

Spec: `docs/specs/CODEX-EXEC-JSON-SILENCE-SIGNAL-SPEC.md`

Shipped autonomously under the 12h session's deploy mandate; spec self-approved under delegated authority, flagged for review.

Generated with Claude Code.
