### PR TITLE
fix(ship-gate): print the exact sha + recipe on artifact-sha-mismatch

### DIFF
--- a/docs/specs/SHIP-GATE-SHA-MISMATCH-ERROR-SPEC.md
+++ b/docs/specs/SHIP-GATE-SHA-MISMATCH-ERROR-SPEC.md
@@ -1,0 +1,71 @@
+---
+title: Ship-gate prints the exact sha and a recipe on artifact-sha-mismatch
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: SHIP-GATE-SHA-MISMATCH-ERROR.eli16.md
+---
+
+# Ship-Gate sha-Mismatch Error Becomes Self-Service
+
+## Problem
+
+`scripts/instar-dev-precommit.js` blocks a commit when the staged side-effects
+artifact's sha256 does not match the sha recorded in the trace. The old message
+was:
+
+> artifact content has changed since the trace was written (sha mismatch)
+
+It never told the author WHAT sha to write. So the author regenerates the
+artifact to "fix" it — but the artifact carries a volatile field (a `Date:`
+line), so regenerating changes the bytes, which changes the sha, which still
+does not match the trace. The author chases the hash forever. This is a real
+non-determinism trap that cost a ~2h grind on 2026-05-30; it bites codex agents
+hardest because they tend to regenerate artifacts rather than freeze them.
+
+The hook already computes the correct sha at the moment it reports the mismatch.
+It simply was not printing it.
+
+## Scope
+
+Improve the sha-mismatch error to be self-service.
+
+In scope:
+
+- `scripts/instar-dev-precommit.js` — when the sha mismatches, the message now
+  includes the recorded sha (truncated), the EXACT computed sha to write, and
+  the recipe: set `artifactSha256` to the computed value, re-stage BOTH the
+  artifact and the trace, commit fresh (no amend), and do not regenerate the
+  artifact (freeze the bytes, hash once).
+
+Out of scope: the broader ship-gate cost for codex agents (LLM-bound steps on a
+loaded box) — a larger topic; this closes the single most-painful, concrete
+instance.
+
+## Design
+
+The change is strictly to the failure-path message string. The pass/fail logic
+is untouched: the sha is still computed the same way and the commit is still
+blocked on a mismatch. Only the text printed on a block changes — from a dead end
+into a copy-paste fix. The printed sha is the artifact's content hash (not
+sensitive).
+
+## Testing
+
+- **Unit** (`tests/unit/instar-dev-precommit-sha-error.test.ts`): a sandbox git
+  repo stages a valid evidence bundle (spec + eli16 + artifact + src + fresh
+  trace) but with a deliberately WRONG `artifactSha256`. Running the hook
+  subprocess: the commit is blocked, and the output contains the EXACT computed
+  sha of the artifact plus the recipe phrases (`re-stage`, `do NOT amend`,
+  `sha mismatch`). Mirrors the established `runHook` sandbox harness from the
+  deferrals test.
+- **Regression**: the existing `instar-dev-precommit-deferrals` suite (11 tests)
+  stays green — those fixtures use correct shas, so they never hit this branch.
+
+## Risks and non-goals
+
+- No functional/behavioral change — the gate blocks exactly the same commits; it
+  only explains the failure better. The worst case is a longer (but accurate)
+  error message.
+- This is a `scripts/`-scoped change, so it trips the very gate it improves —
+  whoever ships it dogfoods the new message, which is the best possible
+  acceptance test.

--- a/docs/specs/SHIP-GATE-SHA-MISMATCH-ERROR.eli16.md
+++ b/docs/specs/SHIP-GATE-SHA-MISMATCH-ERROR.eli16.md
@@ -1,0 +1,33 @@
+# Why a ship-gate error message wasted two hours, and the one-line cure
+
+When a developer agent finishes a change, the system makes it attach a short
+"side-effects review" document plus a little record-card that lists, among other
+things, a fingerprint of that document. Before letting the change be saved, a
+gatekeeper recomputes the fingerprint and checks it matches the one on the
+record-card. If they do not match, the gatekeeper blocks the save — because a
+mismatch usually means the document was edited after the card was written.
+
+The old block message just said "the fingerprint does not match" and stopped
+there. It never told the author the new correct fingerprint. So the author would
+naturally try to fix it by regenerating the side-effects document — but that
+document includes today's date, and regenerating it stamps a fresh date, which
+changes the document, which changes its fingerprint, which STILL does not match
+the card. Round and round. One agent burned about two hours stuck in exactly
+this loop. Agents built on the Codex engine fall into it most, because they tend
+to rebuild documents from scratch rather than leave them frozen.
+
+The frustrating part is that the gatekeeper already knew the correct fingerprint
+at the very moment it complained — it had just computed it to do the comparison.
+It simply was not showing it.
+
+The fix makes the block message helpful. Now when the fingerprints do not match,
+the message prints the exact correct fingerprint and a short recipe: put this
+fingerprint on the record-card, re-stage both files, and commit fresh without
+amending — and do not rebuild the document again, just leave its bytes alone.
+That turns a two-hour guessing game into a ten-second copy-and-paste.
+
+Nothing about WHAT the gatekeeper blocks changes — it still blocks exactly the
+same mismatches, for exactly the same safety reasons. The only thing that
+changes is that the explanation is now actionable instead of a dead end. The
+fingerprint it prints is just a checksum of a public review document, so there
+is nothing sensitive in showing it.

--- a/scripts/instar-dev-precommit.js
+++ b/scripts/instar-dev-precommit.js
@@ -202,8 +202,17 @@ for (const entry of traceEntries) {
 
   const sha = crypto.createHash('sha256').update(artifactContent).digest('hex');
   if (trace.artifactSha256 && trace.artifactSha256 !== sha) {
+    // Self-service fix: tell the author the EXACT sha to write, plus the
+    // freeze-recipe. Without this, an agent (especially codex, which often
+    // regenerates artifacts) chases the hash forever — regenerate → a volatile
+    // field (e.g. a `Date:` line) changes → new sha → repeat. Printing the
+    // computed sha turns a ~2h grind into a copy-paste fix.
     attempts.push(
-      `${path.basename(entry.file)}: artifact content has changed since the trace was written (sha mismatch)`,
+      `${path.basename(entry.file)}: artifact ${trace.artifactPath} sha mismatch — ` +
+        `trace records ${String(trace.artifactSha256).slice(0, 12)}… but the staged bytes hash to ${sha.slice(0, 12)}…. ` +
+        `If the current artifact is correct, set "artifactSha256": "${sha}" in the trace, ` +
+        `re-stage BOTH the artifact and the trace, and commit fresh (do NOT amend). ` +
+        `Common cause: a volatile field (e.g. a Date line) was regenerated — freeze the bytes, hash once, do not regenerate the artifact again.`,
     );
     continue;
   }

--- a/tests/unit/instar-dev-precommit-sha-error.test.ts
+++ b/tests/unit/instar-dev-precommit-sha-error.test.ts
@@ -1,0 +1,124 @@
+// safe-git-allow: test file — execFileSync('git', ...) builds the sandbox repo
+//   fixture (init, add). No production code path.
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Tests for the improved artifact-sha-mismatch error in
+ * scripts/instar-dev-precommit.js. The old message ("artifact content has
+ * changed (sha mismatch)") never told the author what sha to write, so an
+ * agent — especially codex, which regenerates artifacts — would chase the hash
+ * forever (regenerate → a volatile Date line changes → new sha → repeat). This
+ * cost a real ~2h grind on 2026-05-30. The fix prints the EXACT computed sha
+ * plus the freeze/re-stage/no-amend recipe, turning it into a copy-paste fix.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn, execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const HOOK_SCRIPT = path.join(REPO_ROOT, 'scripts', 'instar-dev-precommit.js');
+
+interface RunResult { status: number | null; stdout: string; stderr: string; }
+
+async function runHook(env: NodeJS.ProcessEnv, cwd: string): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const sandboxHook = path.join(cwd, 'scripts', 'instar-dev-precommit.js');
+    const proc = spawn('node', [sandboxHook], { env, cwd });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', d => { stdout += d.toString(); });
+    proc.stderr.on('data', d => { stderr += d.toString(); });
+    proc.on('error', reject);
+    proc.on('close', status => resolve({ status, stdout, stderr }));
+    setTimeout(() => { proc.kill('SIGKILL'); reject(new Error('hook timeout')); }, 15_000);
+  });
+}
+
+describe('instar-dev pre-commit — artifact sha-mismatch error message', () => {
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'sha-error-hook-'));
+    execFileSync('git', ['init', '-q'], { cwd: sandbox });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: sandbox });
+    execFileSync('git', ['config', 'user.name', 'test'], { cwd: sandbox });
+    fs.mkdirSync(path.join(sandbox, 'scripts'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'docs', 'specs'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'upgrades', 'side-effects'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, '.instar', 'instar-dev-traces'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, 'skills', 'instar-dev', 'scripts'), { recursive: true });
+
+    // Stub the eli16 + promotion deps (not reached on a sha failure, but the
+    // hook imports them at module load).
+    fs.writeFileSync(
+      path.join(sandbox, 'scripts', 'eli16-overview-check.mjs'),
+      `import path from 'node:path';\n` +
+      `export function checkEli16Overview(specPath) {\n` +
+      `  const eli16Path = path.join(path.dirname(specPath), path.basename(specPath, '.md') + '.eli16.md');\n` +
+      `  return { ok: true, eli16Path, charCount: 9999, minChars: 1 };\n` +
+      `}\n`,
+    );
+    fs.writeFileSync(
+      path.join(sandbox, 'skills', 'instar-dev', 'scripts', 'verify-proposal-derived-runbook.mjs'),
+      'export function verifyProposalDerivedRunbooks() { return { ok: true, reason: "ok" }; }\n',
+    );
+    fs.copyFileSync(HOOK_SCRIPT, path.join(sandbox, 'scripts', 'instar-dev-precommit.js'));
+  });
+
+  afterEach(() => {
+    try { SafeFsExecutor.safeRmSync(sandbox, { recursive: true, force: true, operation: 'tests/unit/instar-dev-precommit-sha-error.test.ts:cleanup' }); } catch { /* ignore */ }
+  });
+
+  /** Stage a valid bundle but with a deliberately WRONG artifactSha256 in the trace. */
+  function stageWithBadSha(): { realSha: string } {
+    const specRel = path.join('docs', 'specs', 'fixture.md');
+    const eli16Rel = path.join('docs', 'specs', 'fixture.eli16.md');
+    const artifactRel = path.join('upgrades', 'side-effects', 'fixture.md');
+    const srcRel = 'src/touched.ts';
+    const traceRel = path.join('.instar', 'instar-dev-traces', `${Date.now()}-fixture.json`);
+
+    const artifactBody = `# Side-effects review\n\n## Summary\n\n${'x'.repeat(400)}\n`;
+    const realSha = crypto.createHash('sha256').update(artifactBody).digest('hex');
+
+    fs.writeFileSync(path.join(sandbox, specRel), `---\ntitle: Fixture\napproved: true\nreview-convergence: tactical\neli16-overview: fixture.eli16.md\n---\n\nbody\n`);
+    fs.writeFileSync(path.join(sandbox, eli16Rel), `# ELI16\n\n${'x'.repeat(400)}\n`);
+    fs.writeFileSync(path.join(sandbox, artifactRel), artifactBody);
+    fs.writeFileSync(path.join(sandbox, srcRel), '// touched\n');
+
+    fs.writeFileSync(
+      path.join(sandbox, traceRel),
+      JSON.stringify({
+        phase: 'complete',
+        slug: 'fixture',
+        coveredFiles: [srcRel],
+        artifactPath: artifactRel,
+        artifactSha256: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef', // WRONG
+        specPath: specRel,
+        createdAt: new Date().toISOString(),
+      }, null, 2),
+    );
+
+    execFileSync('git', ['add', srcRel, specRel, eli16Rel, artifactRel], { cwd: sandbox });
+    return { realSha };
+  }
+
+  it('blocks the commit and prints the EXACT computed sha + freeze recipe', async () => {
+    const { realSha } = stageWithBadSha();
+    const result = await runHook(process.env, sandbox);
+
+    expect(result.status).not.toBe(0); // blocked
+    const out = result.stderr + result.stdout;
+    // The killer feature: the exact sha to write is in the message.
+    expect(out).toContain(realSha);
+    // And the self-service recipe.
+    expect(out).toMatch(/re-stage/i);
+    expect(out).toMatch(/do NOT amend/i);
+    expect(out).toMatch(/sha mismatch/i);
+  });
+});

--- a/upgrades/side-effects/ship-gate-sha-mismatch-error.md
+++ b/upgrades/side-effects/ship-gate-sha-mismatch-error.md
@@ -1,0 +1,54 @@
+# Side-Effects Review — ship-gate sha-mismatch error becomes self-service
+
+**Version / slug:** `ship-gate-sha-mismatch-error`
+**Date:** `2026-05-30`
+**Author:** `instar-echo`
+**Second-pass reviewer:** `instar-echo second-pass checklist`
+
+## Summary of the change
+
+`scripts/instar-dev-precommit.js` blocks a commit when the staged side-effects
+artifact's sha256 differs from the sha recorded in the trace. The old message
+("artifact content has changed ... sha mismatch") never printed the correct sha,
+so authors regenerated the artifact — whose volatile `Date:` field changed the
+bytes and thus the sha — and chased the hash forever (a ~2h grind 2026-05-30,
+worst for codex agents). The hook already computes the correct sha to do the
+comparison; it just was not showing it. The change prints the recorded sha
+(truncated), the EXACT computed sha to write, and the freeze/re-stage/no-amend
+recipe. Failure-path text only; pass/fail logic unchanged.
+
+## Decision-point inventory
+
+- sha-mismatch error string in `instar-dev-precommit.js` — modify — turns a dead
+  end into an actionable self-service fix; does not change which commits block.
+
+---
+
+## 1. Over-block
+
+None changed. The gate blocks exactly the same set of commits (a mismatching
+sha). No commit that passed before now fails, and none that failed now passes —
+the comparison is byte-identical. Only the message emitted on an existing block
+changes.
+
+## 2. Under-block
+
+None changed. The change cannot let a genuinely-mismatched artifact through; the
+`continue` on mismatch is unchanged, so a bad bundle still fails to produce a
+valid trace and the commit is still blocked. Printing the computed sha does not
+weaken the check — the author still has to actually set it and re-stage.
+
+## 3. Level-of-abstraction fit
+
+The message lives exactly where the mismatch is detected, in the pre-commit
+validator, beside the sha computation it already performs. No new module, no new
+data flow — the fix uses a value the function already holds.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No LLM, no new authority. This is a developer-experience improvement to an
+  existing deterministic gate's error output. The gate's blocking authority is
+  unchanged; the change only makes its existing refusal explainable and fixable.
+  The printed sha is a checksum of a public review artifact (not sensitive).


### PR DESCRIPTION
## Problem
`scripts/instar-dev-precommit.js` blocks a commit when the staged side-effects artifact's sha256 differs from the sha recorded in the trace. The old message ("artifact content has changed ... sha mismatch") never printed the correct sha, so authors regenerated the artifact — whose volatile `Date:` field changed the bytes and thus the sha — and chased the hash forever (a ~2h grind 2026-05-30, worst for codex agents). The hook already computes the correct sha to do the comparison; it just was not showing it.

## Fix
Print the recorded sha (truncated), the **exact computed sha** to write, and the recipe: set `artifactSha256` to the computed value, re-stage BOTH the artifact and the trace, commit fresh (no amend), do not regenerate the artifact. Failure-path message only; pass/fail logic byte-identical.

## Testing
- **unit** `tests/unit/instar-dev-precommit-sha-error.test.ts` (1): a sandbox git repo stages a valid evidence bundle with a deliberately WRONG `artifactSha256`; running the hook subprocess blocks the commit and the output contains the exact computed sha + recipe phrases (`re-stage`, `do NOT amend`, `sha mismatch`). Mirrors the established `runHook` harness.
- regression: `instar-dev-precommit-deferrals` (11) green; `npm run lint` clean.

This is a `scripts/`-scoped change, so it trips the very gate it improves — this PR's own commit dogfooded the new message.

Spec: `docs/specs/SHIP-GATE-SHA-MISMATCH-ERROR-SPEC.md`

Shipped autonomously under the 12h session's deploy mandate; spec self-approved under delegated authority, flagged for review.

Generated with Claude Code.
