### PR TITLE
feat(codex): read codex /status rate-limit usage over HTTP (GET /codex/usage) [#4a]

### DIFF
--- a/docs/specs/CODEX-USAGE-VISIBILITY-SPEC.md
+++ b/docs/specs/CODEX-USAGE-VISIBILITY-SPEC.md
@@ -1,0 +1,114 @@
+---
+title: Read codex /status rate-limit usage over HTTP (GET /codex/usage)
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: CODEX-USAGE-VISIBILITY.eli16.md
+---
+
+# Read Codex `/status` Rate-Limit Usage Over HTTP
+
+## Problem
+
+Codex has no public usage endpoint. The openai-codex `UsageMeterProvider`
+implementation says so explicitly: `isAuthoritative()` returns `false` and it
+falls back to local accounting from `turn.completed.usage` events. So an instar
+agent driving codex has no way to answer "how much codex usage is left?" or
+"are we about to hit the weekly limit?" — the only surface is the codex CLI's
+interactive `/status` TUI, which an agent cannot read.
+
+This is a concrete operational gap: a codex agent (e.g. codey) whose weekly
+window is nearly exhausted will start failing turns with no warning, and the
+supervising agent cannot see it coming or react (e.g. by swapping to a model
+with a separate quota bucket).
+
+## Key insight
+
+The codex CLI DOES persist the authoritative account rate-limit windows it
+receives from OpenAI. Every turn, it appends a `token_count` event to the
+session rollout JSONL whose `payload.rate_limits` carries the same windows the
+`/status` screen shows:
+
+```
+{ "type": "event_msg",
+  "payload": {
+    "type": "token_count",
+    "rate_limits": {
+      "limit_id": "codex",
+      "primary":   { "used_percent": 13, "window_minutes": 300,   "resets_at": 1780171524 },
+      "secondary": { "used_percent": 93, "window_minutes": 10080, "resets_at": 1780174809 },
+      "plan_type": "plus",
+      "rate_limit_reached_type": null } } }
+```
+
+`primary` is the 5h rolling window; `secondary` is the weekly window. This was
+verified against a live rollout: `secondary.used_percent = 93` (7% weekly
+remaining) matched the `/status` screen at the same instant.
+
+## Solution
+
+A read-only reader + route. No mutation of any session state.
+
+1. **`codexRateLimitReader.ts`** (`src/providers/adapters/openai-codex/observability/`)
+   - `readLatestCodexUsage({ codexHome?, nowMs?, maxRolloutsScanned?, tailBytes? })`
+     — uses the existing `listAllRollouts` to get the newest rollouts, tail-reads
+     each (rate-limit events are appended per-turn, so the freshest is near the
+     end), parses the most recent `token_count` `rate_limits`, and returns a
+     structured `CodexUsageSnapshot`. Falls through to the next-newest rollout
+     when the newest has no `token_count` yet. Returns `null` when no codex
+     rollout with rate-limit data exists.
+   - `parseUsageFromTail(tail, rolloutPath, nowMs)` — pure parser, exported for
+     unit tests. Newest matching event wins; malformed lines are skipped; a
+     missing window degrades to `null` for that window only; `model` is a
+     best-effort read of the latest `turn_context.model`.
+   - Derived fields: `remainingPercent` (100 − used, clamped), `resetsAtIso`,
+     and `resetsInSeconds` (relative to an injectable clock).
+
+2. **`GET /codex/usage`** (`src/server/routes.ts`)
+   - Returns `{ available: true, usage: <snapshot> }` when data exists, else
+     `{ available: false, usage: null, reason }`. Always HTTP 200 when wired —
+     it is a disk reader, not a 503 wired-or-not subsystem. Optional
+     `?codexHome=` targets a specific `$CODEX_HOME` (defaults to `~/.codex`).
+   - Bearer-gated like every non-health route. Read-only (no POST/PUT/DELETE).
+
+3. **Discoverability + awareness.** A `CapabilityIndex` entry under the
+   `/codex` prefix (so the route is classified for the capabilities lint and
+   surfaced via `GET /capabilities`); a CLAUDE.md template section
+   (`generateClaudeMd`) for new agents; and a `migrateClaudeMd` content-sniff
+   block (on the `/codex/usage` marker) for existing agents on update.
+
+## Signal vs authority
+
+This change is a pure SIGNAL producer with NO blocking authority. It reads
+on-disk data and returns it. It gates nothing, blocks nothing, and filters no
+message. The downstream model-swap policy (a separate change) is the consumer
+that will *act* on this signal; this spec only surfaces it. Per
+`docs/signal-vs-authority.md`, a read-only reporter at the observability layer is
+exactly the right shape — there is no decision point here to get wrong.
+
+## Testing
+
+Three tiers (16 tests):
+- **Unit** (`tests/unit/codexRateLimitReader.test.ts`) — parser + reader, both
+  sides of every boundary (latest-event-wins, malformed-skipped,
+  missing-window-tolerated, reached-type-surfaced, no-data→null,
+  fallback-to-older-rollout).
+- **Integration** (`tests/integration/codex-usage-route.test.ts`) — the route
+  over HTTP against a rollout fixture (data → `available:true`; exhausted-window
+  signal; none → `available:false` + 200).
+- **E2E** (`tests/e2e/codex-usage-lifecycle.test.ts`) — boots the real
+  `AgentServer`: route is alive (200), Bearer-gated (401), read-only (POST→404).
+
+## Rollback
+
+Pure additive. Back-out is removing the route + reader + the
+`CapabilityIndex`/template/migrator entries; no data migration, no agent-state
+repair. The migrator block is idempotent (content-sniffed), so a re-run is
+safe.
+
+## Authority note
+
+Shipped autonomously under the 12-hour session's "merge → release → deploy →
+verify" mandate, which delegates the `approved: true` flip. Flagged in the PR
+for asynchronous human review. `review-convergence: retrospective-single-pass`
+reflects that the design converged in a single pass during the autonomous run
+rather than through a separate multi-pass `/spec-converge` cycle.

--- a/docs/specs/CODEX-USAGE-VISIBILITY.eli16.md
+++ b/docs/specs/CODEX-USAGE-VISIBILITY.eli16.md
@@ -1,0 +1,58 @@
+# Plain-English overview: checking codex usage over HTTP
+
+## What this is
+
+Some instar agents run on "codex" (OpenAI's coding CLI) instead of Claude.
+Codex accounts have usage limits — a 5-hour window and a weekly window — and
+when you run out, codex just starts failing. Today, the only way to see how much
+you have left is to open codex's interactive status screen and read it with your
+eyes. An agent can't do that. So a codex agent has no idea it's about to hit a
+wall, and a supervising agent can't see it coming either.
+
+## The trick
+
+It turns out codex already writes down those exact limit numbers. Every time it
+finishes a turn, it saves a little record to a log file on disk that includes
+"5-hour window: 13% used" and "weekly window: 93% used," plus when each one
+resets. We checked a real log against the live status screen and the numbers
+matched. So the data is already there — nobody was reading it.
+
+## What's new
+
+We added a small reader that finds the most recent codex log, reads just the
+tail end of it (where the freshest numbers are), and pulls out the usage. Then
+we added one web address on the agent's own server — `GET /codex/usage` — that
+returns those numbers as clean JSON: percent used and remaining on each window,
+when they reset, which model is running, and whether either window is maxed out.
+
+## What already existed
+
+Codex agents already had a separate token-counter, but it self-admits it's not
+authoritative — it only adds up tokens locally and can't see the real account
+limits. This new reader uses the *real* limits codex got back from OpenAI, which
+is the number that actually matters.
+
+## Safeguards
+
+This change only *reads*. It never changes a codex session, never blocks
+anything, and never makes a decision. If there's no codex data on disk (for
+example, a pure-Claude agent), the endpoint politely says "available: false" and
+still returns a normal 200 response instead of an error. It needs the normal
+login token like every other endpoint, and you can only read from it — there's
+no way to write through it.
+
+## What you need to decide
+
+Nothing risky. This is a pure add-on: a new read-only endpoint, plus a note in
+the agent's instructions so it knows the endpoint exists. If it were ever
+unwanted, removing it is clean — there's no data to migrate and no state to
+repair. The main thing to confirm is that surfacing account usage this way is
+fine (it is the same information the codex status screen already shows the
+account owner).
+
+## What comes next
+
+This is the first half of a pair. The second half — a separate change — will
+*use* this signal to automatically switch codex to a backup model with its own
+quota when the weekly window is nearly empty. This change just makes the number
+visible; it does not act on it.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2641,6 +2641,23 @@ A repo-gated watchdog that makes a stalled instar release impossible to miss: it
       result.upgraded.push('CLAUDE.md: added Release Readiness watchdog awareness (release-readiness-visibility)');
     }
 
+    // codex-usage-visibility (Agent Awareness + Migration Parity): existing
+    // agents must learn they can check codex `/status` usage over HTTP without
+    // the interactive TUI. Content-sniff on the route marker.
+    if (!content.includes('/codex/usage')) {
+      const codexUsageSection = `
+### Codex Usage (the codex \`/status\` rate-limit windows)
+
+Check where codex account usage sits without the interactive TUI. The codex CLI persists the authoritative primary (5h) + secondary (weekly) rate-limit windows into its session rollout files; this surfaces the freshest snapshot.
+- Check: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/codex/usage\`
+- Returns \`{ available, usage: { primary, secondary, model, planType, rateLimitReachedType } }\`; each window has \`usedPercent\`, \`remainingPercent\`, \`windowMinutes\`, \`resetsAt\`/\`resetsAtIso\`, \`resetsInSeconds\`. \`available:false\` means no codex session data on disk yet (e.g. a pure-Claude agent).
+- **When to use**: "how much codex usage is left?" / "am I near the limit?", before scheduling heavy codex work, or to drive a model-swap when a window is exhausted (\`rateLimitReachedType\` non-null, or \`secondary.remainingPercent\` low).
+`;
+      content += '\n' + codexUsageSection;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Codex Usage (/codex/usage) awareness (codex-usage-visibility)');
+    }
+
     // update-message-topic-routing §Fix 3 — existing agents need to learn that
     // self-broadcast about ships/restarts/updates must route through the
     // post-update channel (lands in the Agent Updates topic), not the active

--- a/src/providers/adapters/openai-codex/observability/codexRateLimitReader.ts
+++ b/src/providers/adapters/openai-codex/observability/codexRateLimitReader.ts
@@ -1,0 +1,225 @@
+/**
+ * Reads the codex CLI's `/status`-equivalent rate-limit usage from the
+ * on-disk rollout JSONL stream — WITHOUT the interactive TUI.
+ *
+ * Codex has no public usage endpoint (the UsageMeterProvider falls back to
+ * local token accounting and reports isAuthoritative()=false). But the codex
+ * CLI DOES persist the authoritative account rate-limit windows it gets back
+ * from OpenAI: every turn it appends a `token_count` event to the session
+ * rollout whose `payload.rate_limits` carries the same primary (5h) /
+ * secondary (weekly) windows the TUI's `/status` shows:
+ *
+ *   { "type": "event_msg",
+ *     "payload": {
+ *       "type": "token_count",
+ *       "rate_limits": {
+ *         "limit_id": "codex",
+ *         "primary":   { "used_percent": 13, "window_minutes": 300,   "resets_at": 1780171524 },
+ *         "secondary": { "used_percent": 93, "window_minutes": 10080, "resets_at": 1780174809 },
+ *         "plan_type": "prolite",
+ *         "rate_limit_reached_type": null } } }
+ *
+ * This reader finds the newest rollout(s), reads only the tail (rate-limit
+ * events are appended per-turn, so the freshest is near the end), and returns
+ * the most recent snapshot. It is read-only and never mutates any session
+ * state — the same discipline as the rest of the codex observability layer.
+ *
+ * RULE 3.1 RATIONALE
+ *   Criticality: high (cost-routing / model-swap input)
+ *   Frequency:   per-poll / on-demand (route hit)
+ *   Stability:   semi-stable (codex rollout layout changes occasionally —
+ *                shared with sessionPaths, covered by codexSessionLayoutCanary)
+ *   Fallback:    return null when no rollout / no token_count event is found
+ *   Verdict:     deterministic tail-scan; canary covers the layout
+ */
+
+import { promises as fs } from 'node:fs';
+import { listAllRollouts } from './sessionPaths.js';
+
+/** A single rate-limit window (5h primary or weekly secondary). */
+export interface CodexRateWindow {
+  /** Percent of the window's budget consumed (0-100). */
+  usedPercent: number;
+  /** Convenience: 100 - usedPercent, clamped to [0, 100]. */
+  remainingPercent: number;
+  /** Window length in minutes (300 = 5h, 10080 = weekly). */
+  windowMinutes: number;
+  /** Absolute reset time, unix epoch seconds (as codex reports it). */
+  resetsAt: number;
+  /** Derived ISO-8601 of `resetsAt`, or null if `resetsAt` is missing/invalid. */
+  resetsAtIso: string | null;
+  /** Seconds until reset relative to the provided clock, or null when no clock. */
+  resetsInSeconds: number | null;
+}
+
+/** A point-in-time snapshot of codex account rate-limit usage. */
+export interface CodexUsageSnapshot {
+  source: 'codex-rollout';
+  /** The rollout file the snapshot was read from. */
+  rolloutPath: string;
+  /** Thread UUID parsed from the rollout filename, or null. */
+  threadId: string | null;
+  /** Timestamp of the token_count event the snapshot came from (ISO), or null. */
+  capturedAt: string | null;
+  /** Model in effect at capture (best-effort from the latest turn_context), or null. */
+  model: string | null;
+  /** Plan tier codex reports (e.g. "plus", "prolite"), or null. */
+  planType: string | null;
+  /**
+   * Which window (if any) is currently exhausted. codex sets this to e.g.
+   * "primary" / "secondary" when a limit is hit; null when usage is fine.
+   * This is the authoritative "we are rate-limited" signal.
+   */
+  rateLimitReachedType: string | null;
+  /** The 5h rolling window (window_minutes 300), or null if absent. */
+  primary: CodexRateWindow | null;
+  /** The weekly rolling window (window_minutes 10080), or null if absent. */
+  secondary: CodexRateWindow | null;
+}
+
+export interface ReadCodexUsageOptions {
+  /** Override $CODEX_HOME (defaults to ~/.codex). */
+  codexHome?: string;
+  /** Clock for deriving `resetsInSeconds` (defaults to Date.now()). */
+  nowMs?: number;
+  /** How many newest rollouts to scan for a token_count event (default 8). */
+  maxRolloutsScanned?: number;
+  /** Tail size to read from each rollout (default 512 KiB). */
+  tailBytes?: number;
+}
+
+const DEFAULT_TAIL_BYTES = 512 * 1024;
+const DEFAULT_MAX_ROLLOUTS = 8;
+const UUID_RE = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i;
+
+/**
+ * Read the freshest codex rate-limit snapshot from disk. Returns null when
+ * there is no codex rollout with a rate-limit-bearing token_count event
+ * (e.g. a pure-Claude agent, or a session that has not completed a turn yet).
+ */
+export async function readLatestCodexUsage(
+  opts: ReadCodexUsageOptions = {},
+): Promise<CodexUsageSnapshot | null> {
+  const nowMs = opts.nowMs ?? Date.now();
+  const tailBytes = opts.tailBytes ?? DEFAULT_TAIL_BYTES;
+  const maxRollouts = opts.maxRolloutsScanned ?? DEFAULT_MAX_ROLLOUTS;
+
+  const rollouts = await listAllRollouts(opts.codexHome, maxRollouts);
+  for (const { path: rolloutPath } of rollouts) {
+    let tail: string;
+    try {
+      tail = await readTail(rolloutPath, tailBytes);
+    } catch {
+      continue;
+    }
+    const snapshot = parseUsageFromTail(tail, rolloutPath, nowMs);
+    if (snapshot) return snapshot;
+  }
+  return null;
+}
+
+/**
+ * Parse the freshest rate-limit snapshot out of a rollout tail. Exported for
+ * unit tests so they can exercise the parser without touching disk.
+ */
+export function parseUsageFromTail(
+  tail: string,
+  rolloutPath: string,
+  nowMs: number,
+): CodexUsageSnapshot | null {
+  const lines = tail.split('\n');
+  let rateLimits: Record<string, unknown> | null = null;
+  let capturedAt: string | null = null;
+  let model: string | null = null;
+
+  for (const line of lines) {
+    if (!line || line[0] !== '{') continue;
+    // Cheap pre-filter before the JSON.parse cost.
+    const hasRate = line.includes('"rate_limits"');
+    const hasModel = line.includes('"turn_context"') && line.includes('"model"');
+    if (!hasRate && !hasModel) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const payload = obj.payload as Record<string, unknown> | undefined;
+    if (!payload) continue;
+    if (payload.type === 'token_count' && payload.rate_limits) {
+      rateLimits = payload.rate_limits as Record<string, unknown>;
+      capturedAt = typeof obj.timestamp === 'string' ? obj.timestamp : capturedAt;
+    } else if (payload.type === undefined && obj.type === 'turn_context') {
+      // turn_context nests its fields directly under payload.
+      const m = payload.model;
+      if (typeof m === 'string' && m) model = m;
+    }
+  }
+
+  if (!rateLimits) return null;
+
+  return {
+    source: 'codex-rollout',
+    rolloutPath,
+    threadId: parseThreadId(rolloutPath),
+    capturedAt,
+    model,
+    planType: typeof rateLimits.plan_type === 'string' ? rateLimits.plan_type : null,
+    rateLimitReachedType:
+      typeof rateLimits.rate_limit_reached_type === 'string'
+        ? rateLimits.rate_limit_reached_type
+        : null,
+    primary: parseWindow(rateLimits.primary, nowMs),
+    secondary: parseWindow(rateLimits.secondary, nowMs),
+  };
+}
+
+function parseWindow(raw: unknown, nowMs: number): CodexRateWindow | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const w = raw as Record<string, unknown>;
+  const usedPercent = typeof w.used_percent === 'number' ? w.used_percent : null;
+  const windowMinutes = typeof w.window_minutes === 'number' ? w.window_minutes : null;
+  const resetsAt = typeof w.resets_at === 'number' ? w.resets_at : null;
+  if (usedPercent === null || windowMinutes === null || resetsAt === null) return null;
+  const validReset = Number.isFinite(resetsAt) && resetsAt > 0;
+  return {
+    usedPercent,
+    remainingPercent: clampPercent(100 - usedPercent),
+    windowMinutes,
+    resetsAt,
+    resetsAtIso: validReset ? new Date(resetsAt * 1000).toISOString() : null,
+    resetsInSeconds: validReset ? Math.round((resetsAt * 1000 - nowMs) / 1000) : null,
+  };
+}
+
+function clampPercent(n: number): number {
+  if (n < 0) return 0;
+  if (n > 100) return 100;
+  return n;
+}
+
+function parseThreadId(rolloutPath: string): string | null {
+  const m = UUID_RE.exec(rolloutPath);
+  return m ? m[1] : null;
+}
+
+async function readTail(filePath: string, maxBytes: number): Promise<string> {
+  const handle = await fs.open(filePath, 'r');
+  try {
+    const { size } = await handle.stat();
+    const start = size > maxBytes ? size - maxBytes : 0;
+    const length = size - start;
+    if (length <= 0) return '';
+    const buf = Buffer.alloc(length);
+    await handle.read(buf, 0, length, start);
+    let text = buf.toString('utf8');
+    if (start > 0) {
+      // The first line is likely partial — drop up to the first newline.
+      const nl = text.indexOf('\n');
+      text = nl >= 0 ? text.slice(nl + 1) : '';
+    }
+    return text;
+  } finally {
+    await handle.close();
+  }
+}

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -609,6 +609,11 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - **Auto-sync**: Search automatically syncs before querying, so results are always current.
 - **When to use**: When looking for something you know you wrote but can't remember where. When a user asks "didn't we discuss X?" When building context for a task from past learnings.
 
+**Codex Usage** — Check where codex account usage sits (the codex \`/status\` rate-limit windows) without the interactive TUI. Reads the authoritative primary (5h) + secondary (weekly) windows the codex CLI persists into its session rollout files.
+- Check: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/codex/usage\`
+- Returns \`{ available, usage: { primary, secondary, model, planType, rateLimitReachedType } }\` where each window has \`usedPercent\`, \`remainingPercent\`, \`windowMinutes\`, \`resetsAt\`/\`resetsAtIso\`, \`resetsInSeconds\`. \`available:false\` means no codex session data on disk yet (e.g. a pure-Claude agent).
+- **When to use**: when asked "how much codex usage is left?" / "am I near the limit?", before scheduling heavy codex work, or to drive a model-swap when a window is exhausted (\`rateLimitReachedType\` is non-null, or \`secondary.remainingPercent\` is low).
+
 **Git Sync** — Automatic version-control and multi-machine synchronization of your state.
 - **How it works**: The \`git-sync\` job runs hourly, commits local changes, pulls remote changes, and pushes — all automatically. It uses a gate script to skip when nothing has changed (zero-token cost).
 - **Project-bound agents**: Your state (\`.instar/\`) lives inside the parent project's git repo. The git-sync job uses this repo directly — no separate repo needed. Just make sure the parent repo has a remote configured (\`git remote -v\`).

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -500,6 +500,17 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
     }),
   },
   {
+    key: 'codexUsage',
+    prefixes: ['/codex'],
+    description: 'Codex usage — the codex `/status` rate-limit windows (5h + weekly) read from the on-disk rollout stream; no interactive TUI. Read-only.',
+    build: () => ({
+      enabled: true,
+      endpoints: [
+        'GET /codex/usage — freshest codex account rate-limit snapshot (primary 5h + secondary weekly windows; used/remaining percent, resets, plan, reached-type)',
+      ],
+    }),
+  },
+  {
     key: 'frameworkIssues',
     prefixes: ['/framework-issues'],
     description: 'Framework-Onboarding Mentor System — read-only issue-ledger observability (never gates)',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -29,6 +29,7 @@ import { FailureAnalyzer } from '../monitoring/FailureAnalyzer.js';
 import { FailureLoopDriver } from '../monitoring/FailureLoopDriver.js';
 import { HumanAsDetectorLog } from '../monitoring/HumanAsDetectorLog.js';
 import { parseVersion, compareVersions } from '../lifeline/versionHandshake.js';
+import { readLatestCodexUsage } from '../providers/adapters/openai-codex/observability/codexRateLimitReader.js';
 import {
   GATE_ROUTE_VERSION,
   GATE_ROUTE_MINIMUM_VERSION,
@@ -4435,6 +4436,37 @@ export function createRoutes(ctx: RouteContext): Router {
       if (n > 0) idleMs = n;
     }
     res.json({ idleMs, orphans: ctx.tokenLedger.orphans({ idleMs }) });
+  });
+
+  // ── Codex usage (the codex `/status` equivalent, read from disk) ─────
+  // Codex has no usage API, but the codex CLI persists the authoritative
+  // account rate-limit windows (primary=5h, secondary=weekly) into each
+  // session rollout's `token_count` events. This route surfaces the freshest
+  // snapshot so an agent can answer "where does codex usage sit?" and so the
+  // model-swap policy can react to an exhausted window — without the
+  // interactive TUI. Read-only; never mutates session state. Always 200 when
+  // wired ("alive"): `available:false` (not 503) means simply no codex data
+  // on disk yet (e.g. a pure-Claude agent).
+  router.get('/codex/usage', async (req, res) => {
+    const codexHome =
+      typeof req.query.codexHome === 'string' && req.query.codexHome
+        ? req.query.codexHome
+        : undefined;
+    let usage = null;
+    try {
+      usage = await readLatestCodexUsage({ codexHome });
+    } catch {
+      usage = null;
+    }
+    if (!usage) {
+      res.json({
+        available: false,
+        usage: null,
+        reason: 'no codex rollout with rate-limit data found',
+      });
+      return;
+    }
+    res.json({ available: true, usage });
   });
 
   // ── Framework-Onboarding Mentor System: issue ledger (read-only) ──

--- a/tests/e2e/codex-usage-lifecycle.test.ts
+++ b/tests/e2e/codex-usage-lifecycle.test.ts
@@ -1,0 +1,121 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Tier-3 E2E "feature is alive" lifecycle test for GET /codex/usage — the
+ * codex `/status`-equivalent rate-limit surface.
+ *
+ * Per TESTING-INTEGRITY-SPEC: the single most important test for a feature
+ * with API routes — is it actually alive on the production init path (returns
+ * 200, not 404/503)? This boots the REAL AgentServer (the same path server.ts
+ * uses) and verifies:
+ *   1. GET /codex/usage returns 200 and the structured snapshot when a codex
+ *      rollout with rate-limit data exists on disk.
+ *   2. With no codex data it still returns 200 + available:false (it's a disk
+ *      reader, never a 503 wired-or-not subsystem).
+ *   3. The route requires Bearer auth.
+ *   4. The route is read-only (POST not registered → 404).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { InstarConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function createMockSessionManager() {
+  return { listRunningSessions: () => [], getSession: () => null };
+}
+
+describe('Codex usage E2E lifecycle (feature is alive)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let codexHome: string;
+  let server: AgentServer;
+  let app: express.Express;
+  const AUTH = 'test-e2e-codex-usage';
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-usage-e2e-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'e2e', agentName: 'E2E' }));
+
+    // A real codex rollout fixture under a fake $CODEX_HOME.
+    codexHome = path.join(tmpDir, 'codex');
+    const dir = path.join(codexHome, 'sessions', '2026', '05', '30');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'rollout-2026-05-30T12-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'),
+      JSON.stringify({ timestamp: '2026-05-30T19:20:00.000Z', type: 'turn_context', payload: { model: 'gpt-5.5' } }) +
+        '\n' +
+        JSON.stringify({
+          timestamp: '2026-05-30T19:22:00.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'token_count',
+            rate_limits: {
+              limit_id: 'codex',
+              primary: { used_percent: 13, window_minutes: 300, resets_at: 1780171524 },
+              secondary: { used_percent: 93, window_minutes: 10080, resets_at: 1780174809 },
+              plan_type: 'plus',
+              rate_limit_reached_type: null,
+            },
+          },
+        }) +
+        '\n',
+    );
+
+    const config: InstarConfig = {
+      projectName: 'e2e', projectDir: tmpDir, stateDir, port: 0, authToken: AUTH,
+      requestTimeoutMs: 10000, version: '0.0.0',
+      sessions: { claudePath: '/usr/bin/echo', maxSessions: 3, defaultMaxDurationMinutes: 30, protectedSessions: [], monitorIntervalMs: 5000 },
+      scheduler: { enabled: false, jobsFile: '', maxParallelJobs: 1 },
+      messaging: [], monitoring: {}, updates: {},
+    } as InstarConfig;
+
+    server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir) });
+    await server.start();
+    app = server.getApp();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/e2e/codex-usage-lifecycle.test.ts' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH}` });
+
+  it('GET /codex/usage is alive (200) and surfaces the rate-limit snapshot', async () => {
+    const res = await request(app).get('/codex/usage').query({ codexHome }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.available).toBe(true);
+    expect(res.body.usage.secondary.usedPercent).toBe(93);
+    expect(res.body.usage.secondary.remainingPercent).toBe(7);
+    expect(res.body.usage.primary.usedPercent).toBe(13);
+    expect(res.body.usage.model).toBe('gpt-5.5');
+    expect(res.body.usage.source).toBe('codex-rollout');
+  });
+
+  it('returns 200 + available:false when there is no codex data', async () => {
+    const emptyHome = path.join(tmpDir, 'empty-codex');
+    fs.mkdirSync(emptyHome, { recursive: true });
+    const res = await request(app).get('/codex/usage').query({ codexHome: emptyHome }).set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.available).toBe(false);
+    expect(res.body.usage).toBeNull();
+  });
+
+  it('requires Bearer auth', async () => {
+    const res = await request(app).get('/codex/usage');
+    expect(res.status).toBe(401);
+  });
+
+  it('is read-only — POST is not registered (404)', async () => {
+    expect((await request(app).post('/codex/usage').set(auth())).status).toBe(404);
+  });
+});

--- a/tests/integration/codex-usage-route.test.ts
+++ b/tests/integration/codex-usage-route.test.ts
@@ -1,0 +1,110 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Integration tests for GET /codex/usage — the codex `/status`-equivalent
+ * rate-limit surface over HTTP. Verifies the route is actually reachable
+ * (not dead code) and returns the structured snapshot read from a rollout on
+ * disk, plus the both-sides boundary: data present → available:true; no codex
+ * data → available:false (and still 200, never 503 — it's a disk reader, not
+ * a wired-or-not subsystem).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function minimalCtx(): RouteContext {
+  return {
+    config: { projectName: 'test', projectDir: '/tmp', stateDir: '/tmp/.instar', port: 0, sessions: {} as any, scheduler: {} as any } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null, telegram: null, relationships: null, feedback: null, dispatches: null,
+    updateChecker: null, autoUpdater: null, autoDispatcher: null, quotaTracker: null,
+    publisher: null, viewer: null, tunnel: null, evolution: null, watchdog: null,
+    triageNurse: null, topicMemory: null, discoveryEvaluator: null, tokenLedger: null,
+    startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function tokenCountLine(primaryUsed: number, secondaryUsed: number, reached: string | null = null): string {
+  return JSON.stringify({
+    timestamp: '2026-05-30T19:22:00.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: { total_token_usage: { total_tokens: 100 } },
+      rate_limits: {
+        limit_id: 'codex',
+        primary: { used_percent: primaryUsed, window_minutes: 300, resets_at: 1780171524 },
+        secondary: { used_percent: secondaryUsed, window_minutes: 10080, resets_at: 1780174809 },
+        plan_type: 'plus',
+        rate_limit_reached_type: reached,
+      },
+    },
+  });
+}
+
+describe('GET /codex/usage (integration)', () => {
+  let home: string;
+  let app: express.Express;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-usage-route-'));
+    app = express();
+    app.use(express.json());
+    app.use('/', createRoutes(minimalCtx()));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'tests/integration/codex-usage-route.test.ts:cleanup' });
+  });
+
+  function writeRollout(uuid: string): void {
+    const dir = path.join(home, 'sessions', '2026', '05', '30');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `rollout-2026-05-30T12-00-00-${uuid}.jsonl`),
+      JSON.stringify({ timestamp: '2026-05-30T19:20:00.000Z', type: 'turn_context', payload: { model: 'gpt-5.5' } }) +
+        '\n' +
+        tokenCountLine(13, 93) +
+        '\n',
+    );
+  }
+
+  it('returns the structured rate-limit snapshot when codex data exists', async () => {
+    writeRollout('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    const res = await request(app).get('/codex/usage').query({ codexHome: home });
+    expect(res.status).toBe(200);
+    expect(res.body.available).toBe(true);
+    expect(res.body.usage.secondary.usedPercent).toBe(93);
+    expect(res.body.usage.secondary.remainingPercent).toBe(7);
+    expect(res.body.usage.primary.usedPercent).toBe(13);
+    expect(res.body.usage.model).toBe('gpt-5.5');
+    expect(res.body.usage.planType).toBe('plus');
+    expect(res.body.usage.threadId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  });
+
+  it('surfaces the exhausted-window signal', async () => {
+    const dir = path.join(home, 'sessions', '2026', '05', '30');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'rollout-2026-05-30T12-00-00-ffffffff-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'),
+      tokenCountLine(100, 100, 'secondary') + '\n',
+    );
+    const res = await request(app).get('/codex/usage').query({ codexHome: home });
+    expect(res.status).toBe(200);
+    expect(res.body.usage.rateLimitReachedType).toBe('secondary');
+  });
+
+  it('returns available:false (still 200) when there is no codex data', async () => {
+    const res = await request(app).get('/codex/usage').query({ codexHome: home });
+    expect(res.status).toBe(200);
+    expect(res.body.available).toBe(false);
+    expect(res.body.usage).toBeNull();
+  });
+});

--- a/tests/unit/codexRateLimitReader.test.ts
+++ b/tests/unit/codexRateLimitReader.test.ts
@@ -1,0 +1,177 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  readLatestCodexUsage,
+  parseUsageFromTail,
+} from '../../src/providers/adapters/openai-codex/observability/codexRateLimitReader.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+/**
+ * Unit coverage for the codex `/status`-equivalent rate-limit reader. The
+ * authoritative account windows (primary 5h, secondary weekly) are persisted
+ * by the codex CLI into each rollout's `token_count` events; this reader
+ * surfaces the freshest one. Both sides of every boundary: data present →
+ * structured snapshot; no data / no codex home → null.
+ */
+
+const NOW_MS = 1_780_171_000_000; // 2026-05-30T19:23:20Z, just before the resets below.
+
+function tokenCountLine(opts: {
+  ts: string;
+  primaryUsed: number;
+  secondaryUsed: number;
+  reached?: string | null;
+  plan?: string;
+}): string {
+  return JSON.stringify({
+    timestamp: opts.ts,
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: { total_token_usage: { total_tokens: 100 } },
+      rate_limits: {
+        limit_id: 'codex',
+        primary: { used_percent: opts.primaryUsed, window_minutes: 300, resets_at: 1780171524 },
+        secondary: { used_percent: opts.secondaryUsed, window_minutes: 10080, resets_at: 1780174809 },
+        credits: null,
+        plan_type: opts.plan ?? 'plus',
+        rate_limit_reached_type: opts.reached ?? null,
+      },
+    },
+  });
+}
+
+function turnContextLine(model: string): string {
+  return JSON.stringify({
+    timestamp: '2026-05-30T19:20:00.000Z',
+    type: 'turn_context',
+    payload: { turn_id: 'x', model, approval_policy: 'never' },
+  });
+}
+
+describe('parseUsageFromTail', () => {
+  it('extracts the latest token_count rate_limits with derived fields', () => {
+    const tail = [
+      turnContextLine('gpt-5.5'),
+      tokenCountLine({ ts: '2026-05-30T19:00:00.000Z', primaryUsed: 5, secondaryUsed: 50 }),
+      tokenCountLine({ ts: '2026-05-30T19:22:00.000Z', primaryUsed: 13, secondaryUsed: 93 }),
+    ].join('\n');
+
+    const snap = parseUsageFromTail(tail, '/x/rollout-2026-05-30T12-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl', NOW_MS);
+    expect(snap).not.toBeNull();
+    // Latest event wins (93%, not the earlier 50%).
+    expect(snap!.secondary!.usedPercent).toBe(93);
+    expect(snap!.secondary!.remainingPercent).toBe(7);
+    expect(snap!.secondary!.windowMinutes).toBe(10080);
+    expect(snap!.primary!.usedPercent).toBe(13);
+    expect(snap!.primary!.remainingPercent).toBe(87);
+    expect(snap!.model).toBe('gpt-5.5');
+    expect(snap!.planType).toBe('plus');
+    expect(snap!.threadId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    expect(snap!.capturedAt).toBe('2026-05-30T19:22:00.000Z');
+    // Derived reset fields.
+    expect(snap!.secondary!.resetsAtIso).toBe(new Date(1780174809 * 1000).toISOString());
+    expect(snap!.secondary!.resetsInSeconds).toBe(Math.round((1780174809 * 1000 - NOW_MS) / 1000));
+  });
+
+  it('surfaces rate_limit_reached_type when a window is exhausted', () => {
+    const tail = tokenCountLine({ ts: '2026-05-30T19:22:00.000Z', primaryUsed: 100, secondaryUsed: 100, reached: 'secondary' });
+    const snap = parseUsageFromTail(tail, '/x/rollout-2026-05-30T12-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl', NOW_MS);
+    expect(snap!.rateLimitReachedType).toBe('secondary');
+    expect(snap!.secondary!.remainingPercent).toBe(0);
+  });
+
+  it('returns null when the tail has no token_count event', () => {
+    const tail = [turnContextLine('gpt-5.2'), '{"type":"agent_message","payload":{}}'].join('\n');
+    expect(parseUsageFromTail(tail, '/x/rollout-x.jsonl', NOW_MS)).toBeNull();
+  });
+
+  it('ignores malformed JSON lines and still finds a valid token_count', () => {
+    const tail = ['{not json', tokenCountLine({ ts: '2026-05-30T19:22:00.000Z', primaryUsed: 1, secondaryUsed: 2 }), 'garbage'].join('\n');
+    const snap = parseUsageFromTail(tail, '/x/rollout-x.jsonl', NOW_MS);
+    expect(snap!.primary!.usedPercent).toBe(1);
+  });
+
+  it('tolerates a missing window (only primary present)', () => {
+    const line = JSON.stringify({
+      timestamp: '2026-05-30T19:22:00.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        rate_limits: {
+          primary: { used_percent: 40, window_minutes: 300, resets_at: 1780171524 },
+          plan_type: 'plus',
+          rate_limit_reached_type: null,
+        },
+      },
+    });
+    const snap = parseUsageFromTail(line, '/x/rollout-x.jsonl', NOW_MS);
+    expect(snap!.primary!.usedPercent).toBe(40);
+    expect(snap!.secondary).toBeNull();
+  });
+});
+
+describe('readLatestCodexUsage', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-usage-'));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'tests/unit/codexRateLimitReader.test.ts:cleanup' });
+  });
+
+  function writeRollout(uuid: string, ts: string, lines: string[], ymd = ['2026', '05', '30']): string {
+    const dir = path.join(home, 'sessions', ...ymd);
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `rollout-${ts}-${uuid}.jsonl`);
+    fs.writeFileSync(file, lines.join('\n') + '\n');
+    return file;
+  }
+
+  it('reads the freshest snapshot from the newest rollout on disk', async () => {
+    writeRollout('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', '2026-05-30T12-00-00', [
+      turnContextLine('gpt-5.5'),
+      tokenCountLine({ ts: '2026-05-30T19:22:00.000Z', primaryUsed: 13, secondaryUsed: 93 }),
+    ]);
+    const snap = await readLatestCodexUsage({ codexHome: home, nowMs: NOW_MS });
+    expect(snap).not.toBeNull();
+    expect(snap!.secondary!.usedPercent).toBe(93);
+    expect(snap!.source).toBe('codex-rollout');
+    expect(snap!.threadId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  });
+
+  it('falls back to an older rollout when the newest has no token_count yet', async () => {
+    // Older file HAS rate-limit data.
+    writeRollout('11111111-1111-1111-1111-111111111111', '2026-05-30T10-00-00', [
+      tokenCountLine({ ts: '2026-05-30T17:00:00.000Z', primaryUsed: 20, secondaryUsed: 60 }),
+    ]);
+    // Newest file (later mtime via later write) has NO token_count.
+    const newer = writeRollout('22222222-2222-2222-2222-222222222222', '2026-05-30T20-00-00', [
+      '{"type":"session_meta","payload":{}}',
+    ]);
+    // Make the no-data file unambiguously newer by mtime.
+    const future = new Date(NOW_MS + 60_000);
+    fs.utimesSync(newer, future, future);
+
+    const snap = await readLatestCodexUsage({ codexHome: home, nowMs: NOW_MS });
+    expect(snap).not.toBeNull();
+    expect(snap!.primary!.usedPercent).toBe(20);
+  });
+
+  it('returns null when no sessions dir exists (pure Claude agent)', async () => {
+    expect(await readLatestCodexUsage({ codexHome: home, nowMs: NOW_MS })).toBeNull();
+  });
+
+  it('returns null when rollouts exist but none carry rate-limit data', async () => {
+    writeRollout('33333333-3333-3333-3333-333333333333', '2026-05-30T12-00-00', [
+      '{"type":"agent_message","payload":{"type":"agent_message"}}',
+    ]);
+    expect(await readLatestCodexUsage({ codexHome: home, nowMs: NOW_MS })).toBeNull();
+  });
+});

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -218,9 +218,12 @@ describe('Feature Delivery Completeness', () => {
       'What address reaches me (Threadline routing fingerprint)', // Threadline routing-fingerprint operational knowledge, migrator-only (no template/shadow parity)
       'ContextWedgeSentinel',                              // thinking-block-400 wedge recovery; operational self-heal awareness, migrator-only (no template parity) — see context-wedge-sentinel.md
       '/release-readiness',                                // alternate endpoint check for the templated Release Readiness section
+      '/codex/usage',                                      // codex `/status` rate-limit READ surface (templated "Codex Usage" + migrator): observability the agent READS to answer "how much codex usage is left?" — like Release Readiness, discoverable via GET /capabilities; not a framework-shadowed user-invokable capability
       'Agent Updates topic (self-broadcasts about ships, restarts, updates)', // self-broadcast routing operational knowledge, migrator-only
       '/sessions/reap-log',                               // UNIFIED-SESSION-LIFECYCLE §P4 reap-log: operational observability the agent READS to answer "where did my session go?" — like Sentinel Notifications, not a user-invokable capability requiring framework-shadow parity
       'Topic-Flood Guard',                                // 2026-05-28 attention-queue circuit breaker: operational housekeeping the agent READS (state/attention-suppressed.jsonl) to answer "why are my notices grouped?" — like Sentinel Notifications, migrator-only (no template/shadow parity)
+      'Autonomous-fix loop ("just be Echo")',             // mentor.autonomousFix dark dogfooding-loop awareness: developer-layer operational knowledge added via migrator only (like Framework-Onboarding Mentor System), gated off by default — no new-agent template/shadow parity required
+      'Multi-Machine Session Pool (active-active',         // multi-machine session-pool awareness: ships DARK (multiMachine.sessionPool.stage default 'dark'), no-op on a single-machine agent; discoverable via GET /pool + GET /capabilities — operational/dark capability, migrator-tracked like ContextWedgeSentinel/Topic-Flood Guard
     ];
 
     it('all new migrator CLAUDE.md sections are tracked', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,81 @@
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Codex usage is now readable over HTTP — the codex `/status` rate-limit
+windows, without the interactive TUI.** Codex has no public usage API, but the
+codex CLI persists the authoritative account rate-limit windows it gets back
+from OpenAI — primary (5h rolling) and secondary (weekly) — into each session
+rollout's `token_count` events. A new reader
+(`readLatestCodexUsage`) finds the newest rollout, reads only its tail (the
+windows are appended per-turn, so the freshest is near the end), and returns a
+structured snapshot. A new read-only route, `GET /codex/usage`, surfaces it:
+
+```
+{ "available": true,
+  "usage": {
+    "primary":   { "usedPercent": 13, "remainingPercent": 87, "windowMinutes": 300,   "resetsAtIso": "…", "resetsInSeconds": … },
+    "secondary": { "usedPercent": 93, "remainingPercent": 7,  "windowMinutes": 10080, "resetsAtIso": "…", "resetsInSeconds": … },
+    "model": "gpt-5.5", "planType": "plus", "rateLimitReachedType": null } }
+```
+
+`available:false` (still HTTP 200, never 503 — it is a disk reader) means there
+is simply no codex session data on disk yet (e.g. a pure-Claude agent). This is
+the data an agent needs to answer "how much codex usage is left?" and to drive a
+model-swap when a window is exhausted (`rateLimitReachedType` non-null, or
+`secondary.remainingPercent` low).
+
+The route is classified in the capability index (discoverable via
+`GET /capabilities`), surfaced in the CLAUDE.md template for new agents, and
+back-filled into existing agents' CLAUDE.md by the migrator (so deployed agents
+learn it on update). Also restores the feature-delivery-completeness test to
+green by tracking two prior dark/operational migrator sections
+(`Autonomous-fix loop`, `Multi-Machine Session Pool`) that had not been
+registered.
+
+## Summary of New Capabilities
+
+- `GET /codex/usage` — the freshest codex account rate-limit snapshot (primary
+  5h + secondary weekly windows, with used/remaining percent, window length,
+  absolute + relative reset, plan type, and which window — if any — is
+  exhausted). Read-only; never mutates session state.
+- An optional `?codexHome=` query parameter targets a specific `$CODEX_HOME`
+  (defaults to `~/.codex`).
+- Agent-awareness: the capability appears in `GET /capabilities`, the CLAUDE.md
+  template, and is migrated into existing agents.
+
+## What to Tell Your User
+
+You can now ask me how much codex usage is left and I can answer directly,
+without opening the codex status screen myself — I read the same five-hour and
+weekly limit windows the codex tool reports. I can tell you the percent used and
+remaining on each window, when each one resets, which model is in effect, and
+whether either window is currently maxed out. This also gives me the signal I
+need to switch models before the weekly limit runs out. Nothing changes for you
+on update; the capability is simply there when you need it.
+
+## Evidence
+
+**Source of truth.** Inspected a live codex rollout
+(`~/.codex/sessions/2026/05/30/rollout-…jsonl`) and confirmed each
+`token_count` event carries `payload.rate_limits` with `primary`
+(window_minutes 300) and `secondary` (window_minutes 10080) sub-objects, each
+with `used_percent` and `resets_at`, plus `plan_type` and
+`rate_limit_reached_type`. The observed `secondary.used_percent` of 93 (i.e. 7%
+weekly remaining) matched the codex `/status` screen at the same moment —
+verifying the on-disk windows equal the TUI's.
+
+**Before:** there was no way for an agent to read codex usage programmatically —
+the only surface was the interactive TUI (`UsageMeterProvider.isAuthoritative()`
+returns false and only does local token accounting), so an agent could not
+answer "where does codex usage sit?" or react to an exhausted window.
+
+**After:** `GET /codex/usage` returns the structured snapshot above. Verified by
+a 3-tier test suite (16 tests, all green): unit tests parse the latest
+`token_count` (newest event wins; malformed lines skipped; missing-window
+tolerated; reached-type surfaced), an integration test drives the route over
+HTTP against a rollout fixture (data → `available:true`; none → `available:false`
++ 200), and a Tier-3 lifecycle test boots the real AgentServer and confirms the
+route is alive (200, Bearer-gated, read-only POST→404).

--- a/upgrades/side-effects/codex-usage-visibility.md
+++ b/upgrades/side-effects/codex-usage-visibility.md
@@ -1,0 +1,107 @@
+# Side-Effects Review — Codex usage over HTTP (GET /codex/usage)
+
+**Version / slug:** `codex-usage-visibility`
+**Date:** 2026-05-30
+**Author:** Echo (instar-dev agent)
+**Second-pass reviewer:** not required (no block/allow/lifecycle decision surface)
+
+## Summary of the change
+
+Adds a read-only way to see codex account rate-limit usage (the codex `/status`
+windows) without the interactive TUI. A new reader
+(`src/providers/adapters/openai-codex/observability/codexRateLimitReader.ts`)
+finds the newest codex rollout, tail-reads its freshest `token_count`
+`rate_limits`, and returns a structured snapshot. A new route
+(`src/server/routes.ts` → `GET /codex/usage`) surfaces it. Discoverability +
+awareness via `src/server/CapabilityIndex.ts` (capabilities entry),
+`src/scaffold/templates.ts` (new-agent CLAUDE.md section), and
+`src/core/PostUpdateMigrator.ts` (existing-agent back-fill). Also registers two
+prior dark/operational migrator sections in
+`tests/unit/feature-delivery-completeness.test.ts` that were untracked
+(pre-existing red on main). No runtime decision point is touched.
+
+## Decision-point inventory
+
+- No decision point. The reader returns data; the route returns it over HTTP.
+  Nothing is gated, blocked, filtered, or routed based on the result. The route
+  is read-only (GET) and Bearer-gated by the existing auth middleware (not new
+  logic).
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable.** The route is a read-only
+GET that returns 200 with either the snapshot or `available:false`. It rejects
+nothing.
+
+## 2. Under-block
+
+**No block/allow surface — under-block not applicable.** There is no failure
+mode the change is meant to catch-and-stop; it only reports.
+
+The closest "miss" is data freshness: the snapshot reflects the last
+`token_count` codex wrote, which can lag the true account state by up to one
+codex turn. This is acceptable and documented — it is the same data the `/status`
+screen shows, which is also turn-stamped. Callers that need to react to a hard
+exhaustion should treat `rateLimitReachedType` as the authoritative "we are
+limited now" flag (codex sets it when a window is actually hit).
+
+## 3. Level-of-abstraction fit
+
+Correct layer. It sits in the openai-codex observability namespace alongside
+`sessionPaths`/`usageMeterProvider` (it reuses `listAllRollouts`), and is exposed
+through the same HTTP routes layer as the other read-only observability surfaces
+(`/tokens/*`, `/sessions/reap-log`). It does NOT belong in the
+`UsageMeterProvider` interface, because that interface's `read()` is a generic
+token-accounting contract and this is codex-specific authoritative rate-limit
+data — conflating them would muddy the `isAuthoritative()` semantics (the meter
+is correctly non-authoritative; these windows ARE authoritative). A future
+refactor could expose this through a dedicated authoritative-windows method, but
+the standalone reader is the right minimal surface now.
+
+## 4. Signal vs authority compliance
+
+**Compliant.** This is a pure signal producer with zero blocking authority (ref
+`docs/signal-vs-authority.md`). It reads on-disk data and returns it. The
+model-swap policy that will *consume* this signal is a separate change; keeping
+the reader authority-free is exactly the prescribed split (brittle/cheap signal
+at the edge, decisions made by a downstream consumer).
+
+## 5. Interactions
+
+- **Shadowing:** none. No other route serves `/codex/usage`; no existing reader
+  parses `rate_limits`. It reuses `listAllRollouts` (read-only) but does not
+  change it.
+- **Double-fire / race:** none. Stateless per-request disk read; no writes, no
+  locks, no shared mutable state. Concurrent requests each open + close their own
+  file handles.
+- **Adjacent cleanup:** the codex rollout files it reads are owned/rotated by the
+  codex CLI; this reader never deletes or mutates them, so it cannot race
+  rollout rotation destructively (a rotated-away file just yields the next
+  newest, or `null`).
+- **Capabilities lint:** the new `/codex` prefix is now classified in
+  `CapabilityIndex`, satisfying the capabilities-discoverability lint (verified
+  green).
+
+## 6. External surfaces
+
+- **New HTTP route** visible to any Bearer-authenticated caller: `GET
+  /codex/usage`. It exposes the account's codex rate-limit percentages, reset
+  times, plan type, and active model — the same information the account owner
+  already sees on the codex `/status` screen. No secrets, tokens, or message
+  content are exposed.
+- **CLAUDE.md** gains a "Codex Usage" section for new agents (templates.ts) and
+  existing agents (migrator back-fill, idempotent content-sniff). This changes
+  agent-visible instructions, handled per Migration Parity.
+- **Timing dependence:** only freshness (see §2) — bounded by codex's per-turn
+  write cadence. No dependence on conversation state or uncontrolled runtime
+  conditions.
+
+## 7. Rollback cost
+
+Low. Pure additive feature. Back-out = revert the route + reader + the
+CapabilityIndex/template/migrator/test entries. No data migration, no agent-state
+repair, no release coordination beyond a normal patch. The migrator block is
+idempotent (content-sniffed on `/codex/usage`), so partial application or re-run
+is safe.


### PR DESCRIPTION
## Directive #4a — check codex `/status` usage programmatically

Justin asked (paraphrased): *"get you to be able to check `/status` with codex and see where usage sits."* This delivers that.

### The gap
Codex has no public usage API — the openai-codex `UsageMeterProvider` self-reports `isAuthoritative() = false` and only does local token accounting. So a codex agent (e.g. codey, whose weekly window was at 7% remaining tonight) has no way to see it's near the limit, and a supervising agent can't react.

### The insight
The codex CLI **already persists** the authoritative account windows it gets from OpenAI. Every turn it appends a `token_count` event to the session rollout whose `payload.rate_limits` carries the same `primary` (5h / 300min) and `secondary` (weekly / 10080min) windows the `/status` TUI shows. Verified against a live rollout: `secondary.used_percent = 93` matched the `/status` screen (7% weekly remaining) at the same instant.

### What this adds
- **`codexRateLimitReader.ts`** — `readLatestCodexUsage()` finds the newest rollout, tail-reads the freshest `token_count` `rate_limits`, returns a structured snapshot (used/remaining %, window length, absolute + relative reset, plan type, exhausted-window signal). Falls through to older rollouts if the newest has no event yet. Read-only; reuses `listAllRollouts`.
- **`GET /codex/usage`** — always 200 (`available:false` when no codex data on disk, never 503 — it's a disk reader). Optional `?codexHome=`. Bearer-gated, read-only.
- **Discoverability + awareness** — `CapabilityIndex` entry (`GET /capabilities`), CLAUDE.md template section, and `migrateClaudeMd` back-fill for existing agents.

### Side note (Zero-Failure Standard)
`feature-delivery-completeness` was **red on clean `main`** — two prior dark/operational migrator sections (`Autonomous-fix loop`, `Multi-Machine Session Pool`) were never registered in the tracking lists. Release commits are `[skip ci]`, so they slipped in. Registered them here to restore green.

### Tests — 3 tiers, 16 cases (all green)
- Unit: parser + reader, both sides of every boundary (latest-wins, malformed-skipped, missing-window-tolerated, reached-type-surfaced, no-data→null, fallback-to-older-rollout).
- Integration: route over HTTP against a rollout fixture (data → `available:true`; exhausted signal; none → `available:false` + 200).
- E2E lifecycle: boots the real `AgentServer` (200, Bearer-gated 401, read-only POST→404).

`npm run lint` clean; capabilities-discoverability lint green; instar-dev gate passed (spec + ELI16 + side-effects artifact + trace).

### Spec / authority
`docs/specs/CODEX-USAGE-VISIBILITY-SPEC.md` + `.eli16.md`. **`approved: true` was self-applied under the 12-hour autonomous session's "merge → release → deploy → verify" mandate — flagged here for asynchronous human review.** Pure signal producer, no blocking authority (the model-swap consumer is directive #4b, a separate PR).

This PR also includes `upgrades/NEXT.md`, so merging it triggers the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
