### PR TITLE
feat(codex): auto-swap to fallback model when weekly window exhausted [#4b]

### DIFF
--- a/docs/specs/CODEX-MODEL-SWAP-SPEC.md
+++ b/docs/specs/CODEX-MODEL-SWAP-SPEC.md
@@ -1,0 +1,105 @@
+---
+title: Auto-swap the codex launch model to a fallback when the weekly window is exhausted
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: CODEX-MODEL-SWAP.eli16.md
+---
+
+# Codex Rate-Limit Model-Swap
+
+## Problem
+
+A codex agent's main model (e.g. `gpt-5.5`) draws on an account quota with a 5h
+and a weekly window. When the weekly window is exhausted, codex starts failing —
+and the agent stalls. Codex offers other models (e.g. a Codex-Spark tier) on
+SEPARATE quota buckets. Justin's ask (2026-05-30): "swap to GPT-5.3-Codex-Spark
+when the other usage hits the limit." This makes that swap automatic.
+
+Builds directly on `GET /codex/usage` / `readLatestCodexUsage`
+(CODEX-USAGE-VISIBILITY-SPEC) — the authoritative on-disk rate-limit reader is
+the signal source. The `rate_limit_reached_type` field and the weekly window's
+remaining percent are what the policy reacts to.
+
+## Solution
+
+A pure decision + a launch-path hook. A running session can't change model
+mid-turn, so the swap naturally applies at the NEXT session launch — exactly
+when it matters.
+
+1. **`codexModelSwapPolicy.ts`** (openai-codex/observability):
+   - `resolveCodexLaunchModel({ framework, requestedModel, config, usage })` —
+     PURE. Returns the fallback model when: framework is codex-cli AND the swap
+     is enabled AND a `fallbackModel` is configured AND not already on it AND
+     usage shows exhaustion (`rate_limit_reached_type` set, OR the weekly
+     window's `remainingPercent <= weeklyRemainingThreshold`, default 10).
+     Otherwise returns the requested model unchanged. Never throws.
+   - `resolveCodexLaunchModelWithUsage({ ..., readUsage? })` — best-effort async
+     wrapper. Fast-path guards (non-codex / disabled / no fallback) return
+     immediately with ZERO disk I/O. Otherwise reads usage (injectable for
+     tests) and applies the pure policy. A read failure resolves to "no swap" —
+     it NEVER blocks a launch.
+
+2. **`SessionManager`** — a private `resolveCodexLaunchModel(framework, model)`
+   helper reads `config.codex.rateLimitModelSwap` and delegates to the wrapper.
+   BOTH codex launch paths call it: the headless path (`spawnSession` →
+   `buildHeadlessLaunch`) and the interactive/user-facing path
+   (`spawnInteractiveSession` → `buildInteractiveLaunch`). The resolved model is
+   what the builder launches with. No separate poller — the decision is made at
+   the one moment it can take effect (launch).
+
+## Config (dark by default)
+
+`.instar/config.json` → `codex.rateLimitModelSwap`:
+```
+{ "enabled": false,                       // master switch; absent/false = off
+  "fallbackModel": "<codex model id>",    // REQUIRED to swap — operator-set
+  "weeklyRemainingThreshold": 10 }        // swap when weekly remaining <= this %
+```
+Ships DARK: absence of the block = disabled = zero spawn-path overhead. The
+`fallbackModel` id is intentionally NOT defaulted — the exact Codex-Spark
+`--model` string and its availability on a given ChatGPT subscription are the
+account owner's to confirm (it is not in instar's probed model list,
+`models.ts`). The operator sets the verified id to arm the feature.
+
+## Signal vs authority
+
+This is a signal-driven DECISION with no blocking authority (ref
+`docs/signal-vs-authority.md`). It reads a signal (usage) and PICKS a model. It
+blocks nothing, filters no message, and fails safe (read failure → launch with
+the requested model). It consumes the CODEX-USAGE-VISIBILITY signal; it adds no
+brittle gate.
+
+## Testing
+
+- **Unit** (`codexModelSwapPolicy.test.ts`, 16) — the pure policy + the wrapper,
+  both sides of every guard (threshold, reached-flag, non-codex, disabled,
+  no-fallback, already-on-fallback, null-usage, missing-window, read-throws,
+  zero-disk-IO fast-paths).
+- **Integration** (`codex-model-swap-integration.test.ts`, 3) — the wrapper with
+  the REAL `readLatestCodexUsage` against a rollout fixture (exhausted → swap;
+  healthy → no swap; no data → no swap).
+- **Wiring** (`codex-model-swap-wiring.test.ts`, 7) — reflection on
+  `SessionManager.resolveCodexLaunchModel` (deterministic fast-paths, no disk) +
+  source assertions that BOTH spawn paths launch with the resolved model (so the
+  swap can't be silently disconnected from a path).
+
+A live end-to-end "spawn a real codex session on the fallback" test is NOT
+included: it would consume real account quota and depends on the operator's
+verified Spark id — out of scope for CI. The integration test covers the
+read→decide path against real on-disk data; the wiring test covers the spawn
+hookup.
+
+## Rollback
+
+Pure additive + dark. Back-out = revert the policy module + the SessionManager
+helper/wiring + tests. No data migration, no state repair. Because it ships off
+(config absence), a bad interaction can also be neutralised in the field by
+simply not setting `codex.rateLimitModelSwap.enabled` (or removing it).
+
+## Authority note
+
+Shipped autonomously under the 12-hour session's "merge → release → deploy →
+verify" mandate, which delegates the `approved: true` flip; flagged in the PR
+for async human review. `review-convergence: retrospective-single-pass` reflects
+single-pass convergence during the autonomous run. The mechanism ships armed-by-
+config; Justin confirms the Spark `--model` id before enabling.

--- a/docs/specs/CODEX-MODEL-SWAP.eli16.md
+++ b/docs/specs/CODEX-MODEL-SWAP.eli16.md
@@ -1,0 +1,50 @@
+# Plain-English overview: auto-switch the codex model when its quota runs out
+
+## What this is
+
+A codex agent runs on a main model (like gpt-5.5). That model has a usage limit
+with a weekly cap. When the weekly cap is used up, codex just starts failing and
+the agent gets stuck. But codex also offers other models — and at least one of
+them (a "Codex-Spark" tier) uses a SEPARATE quota bucket. So when the main
+model's weekly quota is empty, you can keep working by switching to the other
+model, which still has budget.
+
+This change makes that switch automatic.
+
+## How it decides
+
+It reuses the usage reader we just added (the one behind `GET /codex/usage`),
+which reads the real 5-hour and weekly limit numbers codex writes to disk. When
+it's time to start a new codex session, the agent checks: is the weekly window
+basically empty (at or below a small threshold, default 10% left), or has codex
+flagged that a limit was actually hit? If so, it launches that session on the
+backup model instead of the main one. A session that's already running can't
+change models in the middle, so the switch happens at the next launch — which is
+exactly the moment it matters.
+
+## Why it's safe
+
+- **Off by default.** Nothing happens unless an operator turns it on AND fills in
+  which backup model to use. If it's off, the code doesn't even read the disk —
+  zero extra work on the normal path.
+- **It only picks a model.** It never blocks anything, never cancels a launch,
+  and never touches a running session. If it can't read the usage for any reason,
+  it just launches with the normal model. Fail-safe.
+- **The backup model name is yours to set.** We deliberately did NOT hard-code
+  "Codex-Spark" anywhere, because the exact model name and whether it works on
+  your specific ChatGPT subscription is something only the account owner can
+  confirm. You put the verified name in the config to arm the feature.
+
+## What you need to decide
+
+Two things, and only when you want to turn it on: (1) confirm the exact backup
+model id that works on your codex subscription, and (2) set it (plus enabled:
+true) in the agent's config. Until then this ships completely inert. If it ever
+misbehaves, turning it off is just removing one config block — there's no data to
+migrate and nothing to repair.
+
+## How it connects to the other change
+
+This is the second half of a pair. The first half made codex usage readable. This
+half acts on it — automatically moving to a fresh-quota model when the main one is
+spent — so a codex agent doesn't silently stall on a depleted weekly limit.

--- a/src/core/SessionManager.ts
+++ b/src/core/SessionManager.ts
@@ -61,6 +61,10 @@ import {
   resolveModelForFramework,
 } from './frameworkSessionLaunch.js';
 import { frameworkFromEnv } from './intelligenceProviderFactory.js';
+import {
+  resolveCodexLaunchModelWithUsage,
+  type CodexModelSwapConfig,
+} from '../providers/adapters/openai-codex/observability/codexModelSwapPolicy.js';
 import { StateManager } from './StateManager.js';
 import { buildInjectionTag } from '../types/pipeline.js';
 import { sanitizeSenderName, sanitizeTopicName } from '../utils/sanitize.js';
@@ -1148,10 +1152,16 @@ rm()  { "${shimRunner}" rm  "$@"; }
     const headlessBinaryPath =
       this.config.frameworkBinaryPaths?.[headlessFramework]
       ?? this.config.claudePath;
+
+    // Codex rate-limit model-swap (dark by default): when the agent's main
+    // codex model has exhausted its weekly window, launch on a configured
+    // fallback model (separate quota bucket) instead of stalling. No-op +
+    // zero disk I/O unless codex.rateLimitModelSwap is enabled. Best-effort.
+    const launchModel = await this.resolveCodexLaunchModel(headlessFramework, options.model);
     const headlessSpec = buildHeadlessLaunch(headlessFramework, {
       binaryPath: headlessBinaryPath,
       prompt: options.prompt,
-      model: options.model,
+      model: launchModel,
       ...(options.codexLocalProvider ? { codexLocalProvider: options.codexLocalProvider } : {}),
       // Per-agent codex threadline MCP override (ignored by non-codex builders).
       // Ensures a headless codex worker — notably a Threadline inbound-reply
@@ -1908,6 +1918,33 @@ rm()  { "${shimRunner}" rm  "$@"; }
   }
 
   /**
+   * Resolve the codex launch model, applying the rate-limit model-swap when
+   * configured. For non-codex frameworks, or when codex.rateLimitModelSwap is
+   * disabled / has no fallbackModel, returns the requested model unchanged with
+   * ZERO disk I/O (the fast-path guard lives in resolveCodexLaunchModelWithUsage).
+   * Best-effort: a usage-read failure resolves to the requested model — it never
+   * blocks a spawn. Used by both the headless (spawnSession) and interactive
+   * (spawnInteractiveSession) codex launch paths.
+   */
+  private async resolveCodexLaunchModel(
+    framework: IntelligenceFramework,
+    requestedModel: string | undefined,
+  ): Promise<string | undefined> {
+    const swapCfg = (this.config as { codex?: { rateLimitModelSwap?: CodexModelSwapConfig } })
+      .codex?.rateLimitModelSwap;
+    const decision = await resolveCodexLaunchModelWithUsage({
+      framework,
+      requestedModel,
+      config: swapCfg,
+    });
+    if (decision.swapped) {
+      console.log(`[SessionManager] ${decision.reason}`);
+      return decision.model;
+    }
+    return requestedModel;
+  }
+
+  /**
    * Spawn an interactive Claude Code session (no -p prompt — opens at the REPL).
    * Used for Telegram-driven conversational sessions.
    * Optionally sends an initial message after Claude is ready.
@@ -1981,10 +2018,13 @@ rm()  { "${shimRunner}" rm  "$@"; }
     // local model id) wins over config defaults. Config defaults survive
     // for cloud-Codex topics that haven't been customized.
     const defaultModel = options?.defaultModel ?? this.config.frameworkDefaultModels?.[framework];
+    // Codex rate-limit model-swap (see resolveCodexLaunchModel) — applies to the
+    // interactive (user-facing) codex session too, not just headless spawns.
+    const launchDefaultModel = await this.resolveCodexLaunchModel(framework, defaultModel);
     const launchSpec = buildInteractiveLaunch(framework, {
       binaryPath,
       ...(options?.resumeSessionId ? { resumeSessionId: options.resumeSessionId } : {}),
-      ...(defaultModel ? { defaultModel } : {}),
+      ...(launchDefaultModel ? { defaultModel: launchDefaultModel } : {}),
       ...(options?.codexLocalProvider ? { codexLocalProvider: options.codexLocalProvider } : {}),
       // Per-agent codex threadline MCP override (ignored by non-codex builders).
       ...(this.config.codexThreadlineMcp ? { codexThreadlineMcp: this.config.codexThreadlineMcp } : {}),

--- a/src/providers/adapters/openai-codex/observability/codexModelSwapPolicy.ts
+++ b/src/providers/adapters/openai-codex/observability/codexModelSwapPolicy.ts
@@ -1,0 +1,131 @@
+/**
+ * Codex rate-limit model-swap policy.
+ *
+ * Justin's ask (2026-05-30): "swap to GPT-5.3-Codex-Spark when the other usage
+ * hits the limit." Codex's primary model (e.g. gpt-5.5) and a fallback like
+ * Codex-Spark draw on SEPARATE account quota buckets, so when the main model's
+ * weekly window is exhausted, launching the next session on the fallback keeps
+ * the agent working instead of stalling on a depleted window.
+ *
+ * This module is the DECISION; it holds no authority of its own. The pure
+ * `resolveCodexLaunchModel` takes a usage snapshot (from `readLatestCodexUsage`,
+ * the authoritative on-disk rate-limit reader) and the operator config and
+ * returns which model the NEXT codex session should launch with. A running
+ * session can't change model mid-turn, so the swap naturally applies at launch.
+ *
+ * Safe-by-default: ships DARK. With `enabled` false (the default) or no
+ * `fallbackModel` set, it is a no-op and adds zero overhead to the spawn path.
+ * The fallback model id is OPERATOR CONFIG — never hardcoded — because the exact
+ * Codex-Spark `--model` string + its subscription availability is the account
+ * owner's to confirm (it is not in instar's probed model list).
+ *
+ * RULE 3.1 RATIONALE
+ *   Criticality: medium (cost-routing; never blocks a launch)
+ *   Frequency:   per codex session launch, only when enabled
+ *   Stability:   stable (pure decision over a structured snapshot)
+ *   Fallback:    no swap (launch with the requested model) on any uncertainty
+ *   Verdict:     pure policy + best-effort usage read; unit-tested both sides
+ */
+
+import type { CodexUsageSnapshot } from './codexRateLimitReader.js';
+import { readLatestCodexUsage } from './codexRateLimitReader.js';
+
+/** Operator config for the swap, read from `.instar/config.json` → codex.rateLimitModelSwap. */
+export interface CodexModelSwapConfig {
+  /** Master switch. Default false — the feature ships dark. */
+  enabled?: boolean;
+  /**
+   * The model to launch on when the main model's window is exhausted (e.g. the
+   * Codex-Spark model id). REQUIRED to swap — no default, because the exact id +
+   * subscription availability is the account owner's to confirm.
+   */
+  fallbackModel?: string;
+  /**
+   * Swap when the weekly (secondary) window's remaining percent is at or below
+   * this. Default 10. The authoritative `rate_limit_reached_type` flag also
+   * triggers a swap regardless of this threshold.
+   */
+  weeklyRemainingThreshold?: number;
+}
+
+export interface CodexModelSwapDecision {
+  /** The model the session should launch with (the request, unchanged, or the fallback). */
+  model: string | undefined;
+  /** True only when the policy actually substituted the fallback. */
+  swapped: boolean;
+  /** Human-readable reason when swapped, else null. */
+  reason: string | null;
+}
+
+export const DEFAULT_WEEKLY_REMAINING_THRESHOLD = 10;
+
+/**
+ * Pure decision: given the framework, the requested model, the operator config,
+ * and the current codex usage snapshot, return which model to launch with.
+ * Never throws. Returns the requested model unchanged on any reason not to swap.
+ */
+export function resolveCodexLaunchModel(params: {
+  framework: string;
+  requestedModel: string | undefined;
+  config: CodexModelSwapConfig | undefined;
+  usage: CodexUsageSnapshot | null;
+}): CodexModelSwapDecision {
+  const { framework, requestedModel, config, usage } = params;
+  const noSwap: CodexModelSwapDecision = { model: requestedModel, swapped: false, reason: null };
+
+  if (framework !== 'codex-cli') return noSwap;
+  if (!config?.enabled) return noSwap;
+  const fallback = config.fallbackModel;
+  if (!fallback) return noSwap; // nothing to swap to — operator hasn't set the id
+  // Already on the fallback → don't re-swap (no-op / avoids a confusing log).
+  if (requestedModel && requestedModel === fallback) return noSwap;
+  if (!usage) return noSwap; // couldn't read usage → conservative: launch as requested
+
+  const threshold = config.weeklyRemainingThreshold ?? DEFAULT_WEEKLY_REMAINING_THRESHOLD;
+  const reached = usage.rateLimitReachedType; // authoritative "a window is hit NOW"
+  const weeklyRemaining = usage.secondary?.remainingPercent;
+
+  const reachedHit = reached !== null && reached !== undefined;
+  const weeklyLow = typeof weeklyRemaining === 'number' && weeklyRemaining <= threshold;
+  if (!reachedHit && !weeklyLow) return noSwap;
+
+  return {
+    model: fallback,
+    swapped: true,
+    reason: reachedHit
+      ? `codex rate_limit_reached_type=${reached}; swapping launch model to ${fallback}`
+      : `codex weekly window at ${weeklyRemaining}% remaining (<= ${threshold}%); swapping launch model to ${fallback}`,
+  };
+}
+
+/**
+ * Best-effort async wrapper used on the spawn path. Reads the current codex
+ * usage (only when the feature is enabled — disabled = zero disk I/O) and
+ * applies {@link resolveCodexLaunchModel}. NEVER throws and NEVER blocks a
+ * launch: any read failure resolves to "no swap" (launch with the requested
+ * model). `readUsage` is injectable for tests.
+ */
+export async function resolveCodexLaunchModelWithUsage(params: {
+  framework: string;
+  requestedModel: string | undefined;
+  config: CodexModelSwapConfig | undefined;
+  codexHome?: string;
+  readUsage?: (opts: { codexHome?: string }) => Promise<CodexUsageSnapshot | null>;
+}): Promise<CodexModelSwapDecision> {
+  const { framework, requestedModel, config, codexHome } = params;
+  const noSwap: CodexModelSwapDecision = { model: requestedModel, swapped: false, reason: null };
+
+  // Fast paths that avoid any disk read when the feature can't act.
+  if (framework !== 'codex-cli') return noSwap;
+  if (!config?.enabled || !config.fallbackModel) return noSwap;
+  if (requestedModel && requestedModel === config.fallbackModel) return noSwap;
+
+  const read = params.readUsage ?? readLatestCodexUsage;
+  let usage: CodexUsageSnapshot | null = null;
+  try {
+    usage = await read({ codexHome });
+  } catch {
+    return noSwap; // best-effort: never block a launch on a usage read
+  }
+  return resolveCodexLaunchModel({ framework, requestedModel, config, usage });
+}

--- a/tests/integration/codex-model-swap-integration.test.ts
+++ b/tests/integration/codex-model-swap-integration.test.ts
@@ -1,0 +1,85 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Integration test for the codex model-swap (directive #4b): the policy
+ * composed with the REAL on-disk rate-limit reader (not mocked). Proves the
+ * end-to-end path an agent's spawn uses — read the codex rollout, decide the
+ * launch model — works against a real rollout fixture on disk.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveCodexLaunchModelWithUsage } from '../../src/providers/adapters/openai-codex/observability/codexModelSwapPolicy.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const ON = { enabled: true, fallbackModel: 'gpt-5.3-codex-spark' };
+
+describe('codex model-swap × real rate-limit reader (integration)', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-swap-int-'));
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'tests/integration/codex-model-swap-integration.test.ts:cleanup' });
+  });
+
+  function writeRollout(weeklyUsedPercent: number, reached: string | null = null): void {
+    const dir = path.join(home, 'sessions', '2026', '05', '30');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'rollout-2026-05-30T12-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl'),
+      JSON.stringify({
+        timestamp: '2026-05-30T19:22:00.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          rate_limits: {
+            limit_id: 'codex',
+            primary: { used_percent: 10, window_minutes: 300, resets_at: 1780171524 },
+            secondary: { used_percent: weeklyUsedPercent, window_minutes: 10080, resets_at: 1780174809 },
+            plan_type: 'plus',
+            rate_limit_reached_type: reached,
+          },
+        },
+      }) + '\n',
+    );
+  }
+
+  it('swaps to the fallback when the real rollout shows an exhausted weekly window', async () => {
+    writeRollout(93); // 7% weekly remaining
+    const d = await resolveCodexLaunchModelWithUsage({
+      framework: 'codex-cli',
+      requestedModel: 'gpt-5.5',
+      config: ON,
+      codexHome: home,
+    });
+    expect(d.swapped).toBe(true);
+    expect(d.model).toBe('gpt-5.3-codex-spark');
+  });
+
+  it('keeps the requested model when the real rollout shows a healthy window', async () => {
+    writeRollout(40); // 60% weekly remaining
+    const d = await resolveCodexLaunchModelWithUsage({
+      framework: 'codex-cli',
+      requestedModel: 'gpt-5.5',
+      config: ON,
+      codexHome: home,
+    });
+    expect(d.swapped).toBe(false);
+    expect(d.model).toBe('gpt-5.5');
+  });
+
+  it('keeps the requested model when there is no codex data on disk', async () => {
+    const d = await resolveCodexLaunchModelWithUsage({
+      framework: 'codex-cli',
+      requestedModel: 'gpt-5.5',
+      config: ON,
+      codexHome: home,
+    });
+    expect(d.swapped).toBe(false);
+    expect(d.model).toBe('gpt-5.5');
+  });
+});

--- a/tests/unit/codex-model-swap-wiring.test.ts
+++ b/tests/unit/codex-model-swap-wiring.test.ts
@@ -1,0 +1,104 @@
+// safe-fs-allow: test file — SafeFsExecutor used for tmpdir cleanup.
+
+/**
+ * Wiring-integrity coverage for the codex model-swap (directive #4b): proves
+ * the policy is ACTUALLY wired into SessionManager's spawn paths — not dead
+ * code — via two complementary checks:
+ *   1. Reflection: SessionManager.resolveCodexLaunchModel exists, reads
+ *      config.codex.rateLimitModelSwap, and returns the requested model on the
+ *      deterministic fast-paths (non-codex / disabled / no-fallback) WITHOUT
+ *      touching disk.
+ *   2. Source assertion: BOTH launch paths (headless buildHeadlessLaunch +
+ *      interactive buildInteractiveLaunch) take their model from the helper, so
+ *      the swap can't be silently disconnected from a spawn path.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { SessionManager } from '../../src/core/SessionManager.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import type { SessionManagerConfig } from '../../src/core/types.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('codex model-swap wiring — SessionManager.resolveCodexLaunchModel', () => {
+  let tmpDir: string;
+  let manager: SessionManager;
+
+  function build(swap?: unknown): SessionManager {
+    const config = {
+      tmuxPath: '/usr/bin/tmux',
+      claudePath: '/usr/local/bin/claude',
+      projectDir: tmpDir,
+      maxSessions: 3,
+      protectedSessions: [],
+      completionPatterns: [],
+      ...(swap !== undefined ? { codex: { rateLimitModelSwap: swap } } : {}),
+    } as unknown as SessionManagerConfig;
+    return new SessionManager(config, new StateManager(path.join(tmpDir, 'state')));
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-swap-wiring-'));
+    fs.mkdirSync(path.join(tmpDir, 'state'), { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/codex-model-swap-wiring.test.ts:cleanup' });
+  });
+
+  // Reflection helper — the method is private by design (internal spawn detail).
+  const resolve = (m: SessionManager, fw: string, model: string | undefined) =>
+    (m as unknown as { resolveCodexLaunchModel: (f: string, x: string | undefined) => Promise<string | undefined> })
+      .resolveCodexLaunchModel(fw, model);
+
+  it('returns the requested model unchanged for a non-codex framework', async () => {
+    manager = build({ enabled: true, fallbackModel: 'gpt-5.3-codex-spark' });
+    expect(await resolve(manager, 'claude-code', 'opus')).toBe('opus');
+  });
+
+  it('returns the requested model when the swap is disabled (default)', async () => {
+    manager = build(undefined); // no codex config at all
+    expect(await resolve(manager, 'codex-cli', 'gpt-5.5')).toBe('gpt-5.5');
+    manager = build({ enabled: false, fallbackModel: 'gpt-5.3-codex-spark' });
+    expect(await resolve(manager, 'codex-cli', 'gpt-5.5')).toBe('gpt-5.5');
+  });
+
+  it('returns the requested model when enabled but no fallbackModel is configured', async () => {
+    manager = build({ enabled: true });
+    expect(await resolve(manager, 'codex-cli', 'gpt-5.5')).toBe('gpt-5.5');
+  });
+});
+
+describe('codex model-swap wiring — both spawn paths consume the helper', () => {
+  const src = fs.readFileSync(
+    path.join(process.cwd(), 'src', 'core', 'SessionManager.ts'),
+    'utf-8',
+  );
+
+  it('imports the model-swap policy', () => {
+    expect(src).toContain('resolveCodexLaunchModelWithUsage');
+    expect(src).toContain('codexModelSwapPolicy.js');
+  });
+
+  it('defines the private resolveCodexLaunchModel helper', () => {
+    expect(src).toMatch(/private async resolveCodexLaunchModel\(/);
+  });
+
+  it('headless spawn (buildHeadlessLaunch) launches with the resolved model', () => {
+    const idx = src.indexOf('buildHeadlessLaunch(headlessFramework');
+    expect(idx).toBeGreaterThan(0);
+    const before = src.slice(Math.max(0, idx - 400), idx);
+    expect(before).toContain('this.resolveCodexLaunchModel(headlessFramework');
+    // the builder receives the resolved variable, not the raw options.model
+    expect(src.slice(idx, idx + 200)).toMatch(/model:\s*launchModel/);
+  });
+
+  it('interactive spawn (buildInteractiveLaunch) launches with the resolved model', () => {
+    const idx = src.indexOf('buildInteractiveLaunch(framework');
+    expect(idx).toBeGreaterThan(0);
+    const before = src.slice(Math.max(0, idx - 400), idx);
+    expect(before).toContain('this.resolveCodexLaunchModel(framework');
+    expect(src.slice(idx, idx + 250)).toContain('launchDefaultModel');
+  });
+});

--- a/tests/unit/codexModelSwapPolicy.test.ts
+++ b/tests/unit/codexModelSwapPolicy.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveCodexLaunchModel,
+  resolveCodexLaunchModelWithUsage,
+  DEFAULT_WEEKLY_REMAINING_THRESHOLD,
+  type CodexModelSwapConfig,
+} from '../../src/providers/adapters/openai-codex/observability/codexModelSwapPolicy.js';
+import type { CodexUsageSnapshot } from '../../src/providers/adapters/openai-codex/observability/codexRateLimitReader.js';
+
+/**
+ * Unit coverage for the codex rate-limit model-swap policy (directive #4b).
+ * Pure decision + the best-effort async wrapper. Every guard is exercised on
+ * both sides: swaps only when codex + enabled + fallback set + a window is
+ * exhausted; otherwise passes the requested model through untouched.
+ */
+
+function usage(opts: { weeklyRemaining?: number; reached?: string | null }): CodexUsageSnapshot {
+  return {
+    source: 'codex-rollout',
+    rolloutPath: '/x/rollout.jsonl',
+    threadId: 'tid',
+    capturedAt: '2026-05-30T19:22:00.000Z',
+    model: 'gpt-5.5',
+    planType: 'plus',
+    rateLimitReachedType: opts.reached ?? null,
+    primary: { usedPercent: 10, remainingPercent: 90, windowMinutes: 300, resetsAt: 1, resetsAtIso: null, resetsInSeconds: null },
+    secondary:
+      opts.weeklyRemaining === undefined
+        ? null
+        : { usedPercent: 100 - opts.weeklyRemaining, remainingPercent: opts.weeklyRemaining, windowMinutes: 10080, resetsAt: 1, resetsAtIso: null, resetsInSeconds: null },
+  };
+}
+
+const ON: CodexModelSwapConfig = { enabled: true, fallbackModel: 'gpt-5.3-codex-spark' };
+
+describe('resolveCodexLaunchModel (pure)', () => {
+  it('swaps to the fallback when the weekly window is at/below the threshold', () => {
+    const d = resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.5', config: ON, usage: usage({ weeklyRemaining: 7 }) });
+    expect(d.swapped).toBe(true);
+    expect(d.model).toBe('gpt-5.3-codex-spark');
+    expect(d.reason).toContain('7%');
+  });
+
+  it('swaps when rate_limit_reached_type is set, regardless of threshold', () => {
+    const d = resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.5', config: ON, usage: usage({ weeklyRemaining: 80, reached: 'secondary' }) });
+    expect(d.swapped).toBe(true);
+    expect(d.model).toBe('gpt-5.3-codex-spark');
+    expect(d.reason).toContain('reached');
+  });
+
+  it('does NOT swap when the weekly window is comfortably above threshold', () => {
+    const d = resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.5', config: ON, usage: usage({ weeklyRemaining: 50 }) });
+    expect(d.swapped).toBe(false);
+    expect(d.model).toBe('gpt-5.5');
+  });
+
+  it('uses the default threshold (10%) when none is configured', () => {
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'm', config: ON, usage: usage({ weeklyRemaining: DEFAULT_WEEKLY_REMAINING_THRESHOLD }) }).swapped).toBe(true);
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'm', config: ON, usage: usage({ weeklyRemaining: DEFAULT_WEEKLY_REMAINING_THRESHOLD + 1 }) }).swapped).toBe(false);
+  });
+
+  it('respects a custom threshold', () => {
+    const cfg: CodexModelSwapConfig = { ...ON, weeklyRemainingThreshold: 25 };
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'm', config: cfg, usage: usage({ weeklyRemaining: 20 }) }).swapped).toBe(true);
+  });
+
+  it('does NOT swap for a non-codex framework', () => {
+    expect(resolveCodexLaunchModel({ framework: 'claude-code', requestedModel: 'opus', config: ON, usage: usage({ weeklyRemaining: 1 }) }).swapped).toBe(false);
+  });
+
+  it('does NOT swap when disabled', () => {
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.5', config: { ...ON, enabled: false }, usage: usage({ weeklyRemaining: 1 }) }).swapped).toBe(false);
+  });
+
+  it('does NOT swap when no fallbackModel is set (operator has not confirmed the id)', () => {
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.5', config: { enabled: true }, usage: usage({ weeklyRemaining: 1 }) }).swapped).toBe(false);
+  });
+
+  it('does NOT re-swap when already on the fallback model', () => {
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.3-codex-spark', config: ON, usage: usage({ weeklyRemaining: 1 }) }).swapped).toBe(false);
+  });
+
+  it('does NOT swap when usage is unavailable (conservative)', () => {
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.5', config: ON, usage: null }).swapped).toBe(false);
+  });
+
+  it('tolerates a missing weekly window (only swaps on reached flag then)', () => {
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.5', config: ON, usage: usage({}) }).swapped).toBe(false);
+    expect(resolveCodexLaunchModel({ framework: 'codex-cli', requestedModel: 'gpt-5.5', config: ON, usage: usage({ reached: 'primary' }) }).swapped).toBe(true);
+  });
+});
+
+describe('resolveCodexLaunchModelWithUsage (best-effort wrapper)', () => {
+  it('reads usage and swaps when exhausted', async () => {
+    const d = await resolveCodexLaunchModelWithUsage({
+      framework: 'codex-cli',
+      requestedModel: 'gpt-5.5',
+      config: ON,
+      readUsage: async () => usage({ weeklyRemaining: 5 }),
+    });
+    expect(d.swapped).toBe(true);
+    expect(d.model).toBe('gpt-5.3-codex-spark');
+  });
+
+  it('does NOT read usage at all when disabled (zero disk I/O fast-path)', async () => {
+    let read = 0;
+    const d = await resolveCodexLaunchModelWithUsage({
+      framework: 'codex-cli',
+      requestedModel: 'gpt-5.5',
+      config: { ...ON, enabled: false },
+      readUsage: async () => { read++; return usage({ weeklyRemaining: 1 }); },
+    });
+    expect(read).toBe(0);
+    expect(d.swapped).toBe(false);
+  });
+
+  it('does NOT read usage for a non-codex framework', async () => {
+    let read = 0;
+    await resolveCodexLaunchModelWithUsage({
+      framework: 'claude-code',
+      requestedModel: 'opus',
+      config: ON,
+      readUsage: async () => { read++; return usage({ weeklyRemaining: 1 }); },
+    });
+    expect(read).toBe(0);
+  });
+
+  it('does NOT read usage when no fallbackModel is set', async () => {
+    let read = 0;
+    await resolveCodexLaunchModelWithUsage({
+      framework: 'codex-cli',
+      requestedModel: 'gpt-5.5',
+      config: { enabled: true },
+      readUsage: async () => { read++; return null; },
+    });
+    expect(read).toBe(0);
+  });
+
+  it('never throws and resolves to the requested model when the read fails', async () => {
+    const d = await resolveCodexLaunchModelWithUsage({
+      framework: 'codex-cli',
+      requestedModel: 'gpt-5.5',
+      config: ON,
+      readUsage: async () => { throw new Error('disk gone'); },
+    });
+    expect(d.swapped).toBe(false);
+    expect(d.model).toBe('gpt-5.5');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -35,6 +35,18 @@ green by tracking two prior dark/operational migrator sections
 (`Autonomous-fix loop`, `Multi-Machine Session Pool`) that had not been
 registered.
 
+**Codex agents can auto-swap to a fallback model when their weekly window is
+exhausted (ships DARK).** Building on the usage reader above: at codex session
+launch, if the main model's weekly window is spent (or codex flags a limit hit),
+the next session launches on a configured fallback model that draws on a separate
+quota bucket — instead of stalling. The decision is a pure policy
+(`resolveCodexLaunchModel`) wired into both codex launch paths in
+`SessionManager` (headless + interactive). Gated behind
+`codex.rateLimitModelSwap.{enabled,fallbackModel,weeklyRemainingThreshold}`;
+off by default with zero spawn-path overhead. The fallback model id is operator
+config — never hardcoded — because the exact id and its subscription
+availability are the account owner's to confirm.
+
 ## Summary of New Capabilities
 
 - `GET /codex/usage` — the freshest codex account rate-limit snapshot (primary
@@ -45,6 +57,11 @@ registered.
   (defaults to `~/.codex`).
 - Agent-awareness: the capability appears in `GET /capabilities`, the CLAUDE.md
   template, and is migrated into existing agents.
+- Codex rate-limit model-swap (dark): `codex.rateLimitModelSwap` —
+  auto-launch the next codex session on `fallbackModel` when the weekly window's
+  remaining percent is at or below `weeklyRemainingThreshold` (default 10) or
+  codex reports a limit hit. Off by default; best-effort and fail-safe (a usage
+  read never blocks a launch).
 
 ## What to Tell Your User
 
@@ -55,6 +72,13 @@ remaining on each window, when each one resets, which model is in effect, and
 whether either window is currently maxed out. This also gives me the signal I
 need to switch models before the weekly limit runs out. Nothing changes for you
 on update; the capability is simply there when you need it.
+
+And if you want it, I can now do that switch automatically: when a codex agent's
+weekly model quota is nearly spent, the next session it starts can launch on a
+backup model that has its own separate budget, so it keeps working instead of
+stalling. This is off until you turn it on and tell me which backup model to use
+— the exact name and whether it works on your subscription is something only you
+can confirm — so nothing changes by default.
 
 ## Evidence
 

--- a/upgrades/side-effects/codex-model-swap.md
+++ b/upgrades/side-effects/codex-model-swap.md
@@ -1,0 +1,134 @@
+# Side-Effects Review — Codex rate-limit model-swap (directive #4b)
+
+**Version / slug:** `codex-model-swap`
+**Date:** 2026-05-30
+**Author:** Echo (instar-dev agent)
+**Second-pass reviewer:** REQUIRED (touches session spawn / lifecycle) — see verdict at end
+
+## Summary of the change
+
+At codex session launch, if the agent's main model has exhausted its weekly
+window, launch the next session on a configured fallback model (separate quota
+bucket) instead of stalling. New pure policy
+(`src/providers/adapters/openai-codex/observability/codexModelSwapPolicy.ts`) +
+a private `SessionManager.resolveCodexLaunchModel` helper wired into BOTH codex
+launch paths (`spawnSession`→`buildHeadlessLaunch`,
+`spawnInteractiveSession`→`buildInteractiveLaunch`). Consumes the on-disk
+`readLatestCodexUsage` reader (shipped in CODEX-USAGE-VISIBILITY). Ships DARK
+behind `config.codex.rateLimitModelSwap.{enabled,fallbackModel,weeklyRemainingThreshold}`.
+
+## Decision-point inventory
+
+- `SessionManager.resolveCodexLaunchModel` (NEW decision) — picks the launch
+  model for a codex spawn. Add. It is a model SELECTION, not a block/allow gate:
+  the only outcomes are "requested model" or "configured fallback model". Both
+  spawn paths consume it (pass-through for non-codex / disabled).
+
+---
+
+## 1. Over-block
+
+**No block/allow surface — over-block not applicable.** The policy never rejects
+or cancels a launch. Its worst "wrong" outcome is launching on the fallback
+model when it didn't strictly need to (e.g. weekly at exactly the threshold) —
+which still produces a working session, just on the other quota bucket.
+
+## 2. Under-block
+
+**Not a blocker.** The closest "miss": the swap only takes effect at the NEXT
+launch — a session already mid-turn on an exhausted model still fails that turn
+(it can't change model mid-flight). That is inherent to how model selection
+works and is the correct scope; the RateLimitSentinel covers the in-flight
+throttle messaging separately. Also: if usage can't be read, no swap happens
+(fail-safe) — a genuinely-exhausted agent with an unreadable rollout would not
+swap. Acceptable: it degrades to today's behavior (launch on the main model).
+
+## 3. Level-of-abstraction fit
+
+Right layer. The decision lives in the openai-codex observability namespace
+(beside the reader it consumes) as a pure function; the WIRING lives in
+SessionManager at the single point where the launch model is finalized for each
+spawn path. It does not belong in the reader (that's a pure read surface) nor in
+a separate poller (a poller would have to persist an override and re-apply it —
+more state, more drift; deciding at launch is stateless and exact).
+
+## 4. Signal vs authority compliance
+
+**Compliant.** Pure signal-driven decision, zero blocking authority (ref
+`docs/signal-vs-authority.md`). It consumes the authoritative usage signal and
+selects a model. No brittle gate, no veto. Fails safe (read failure → requested
+model). The signal producer (the reader) and this consumer are cleanly split.
+
+## 5. Interactions
+
+- **Shadowing / double-fire:** none. It's the only thing that selects the codex
+  launch model; it runs once per spawn. The two call sites are mutually
+  exclusive (headless vs interactive spawn of a given session).
+- **RateLimitSentinel:** complementary, not conflicting. The sentinel handles an
+  IN-FLIGHT throttle (backoff + notify + verify recovery); this picks the model
+  for the NEXT launch. They operate at different moments and don't race.
+- **`/local-model` + `frameworkDefaultModels`:** the swap takes `options.model`
+  / `defaultModel` (already resolved from those) as its INPUT and only overrides
+  when armed + exhausted, so an explicit per-call/local model still flows through
+  untouched when the feature is off (default) or the window is healthy.
+- **Shared `~/.codex/config.toml`:** unaffected — the model flows via the launch
+  flag (`-c model=` / `--model`), the per-spawn override that already wins over
+  the shared config (same mechanism as `codexThreadlineMcpFlags`). No multi-agent
+  config collision.
+- **Spawn-path latency:** when DISABLED (default) the fast-path guards return
+  before any disk read — zero added latency. When enabled, the read is the same
+  bounded path the shipped `/codex/usage` route uses: a recursive walk of
+  `$CODEX_HOME/sessions` (`listAllRollouts`, capped to the newest few) plus a
+  tail-read of the newest rollout. All async fs, wrapped best-effort (never
+  throws, never blocks the spawn). Only runs when the feature is armed.
+
+## 6. External surfaces
+
+- **Behavioral, opt-in:** when an operator enables it with a verified
+  `fallbackModel`, a codex session may launch on a different model than the
+  configured default once the weekly window is low. That is the intended,
+  operator-armed behavior. A `[SessionManager]` log line records every swap with
+  the reason.
+- No new HTTP surface, no new message, no change visible to other agents.
+- Off by default → no change for any existing agent on update.
+
+## 7. Rollback cost
+
+Low. Pure additive + dark. Back-out = revert the policy module + the
+SessionManager helper/wiring + tests; no data migration, no agent-state repair.
+In the field, neutralise instantly by not setting (or removing)
+`codex.rateLimitModelSwap.enabled` — no redeploy of code required.
+
+---
+
+## Phase 5 — Second-pass reviewer verdict
+
+**Concur with the review.** An independent reviewer subagent audited this artifact
+AND the actual code (not just the claims), verifying each risk with file:line
+citations:
+
+- **Never blocks/delays/breaks a launch:** the single new
+  `await this.resolveCodexLaunchModel(...)` on each spawn path delegates to
+  `resolveCodexLaunchModelWithUsage`, whose disk read is `try/catch`-wrapped and
+  returns no-swap on any throw (`codexModelSwapPolicy.ts:125-129`); the helper
+  always returns `string | undefined`, never throws (`SessionManager.ts`).
+- **Zero disk I/O when disabled:** the three fast-path guards (non-codex /
+  disabled-or-no-fallback / already-on-fallback) all return BEFORE the
+  `read(...)` call; unit tests assert `read===0` for each.
+- **Disabled/default path is byte-identical:** on every fast-path the helper
+  returns the requested model unchanged, so the builder input is unchanged for
+  non-codex agents and codex agents with no config block.
+- **Swap-decision correctness:** swaps only on the documented conjunction; uses
+  the weekly (`secondary`) window not `primary`; `<=` threshold off-by-one
+  covered both ways; never swaps to an empty model.
+- **Both spawn paths covered**, enforced by source-assertion tests.
+- **No conflict** with RateLimitSentinel (different moment), the shared
+  `~/.codex/config.toml` (per-spawn flag override wins), or `/local-model`
+  (its model is the helper's input, passes through when off).
+
+Reviewer notes addressed: §5's spawn-path-latency wording was corrected to
+acknowledge the `listAllRollouts` directory walk (not just a single tail-read).
+One non-blocking nit noted for a future graduation-out-of-dark: the config is
+read via an inline cast rather than a typed `codex?` field on
+`SessionManagerConfig` — intentional to keep the feature dark without a schema
+change; can be promoted to a typed field if/when it ships on by default.


### PR DESCRIPTION
## Directive #4b — auto-swap codex model when the weekly window is exhausted

Justin's directive #4b: *"maybe swap to GPT-5.3-Codex-Spark when the other usage hits the limit."* This builds the mechanism, consuming #4a's `GET /codex/usage` reader as the signal.

### What it does
At codex session launch, if the main model's weekly window is spent (or codex flags a limit hit), launch the next session on a configured **fallback model** (separate quota bucket) instead of stalling. A running session can't change model mid-turn — so the swap applies at the next launch, exactly when it matters.

- **Pure policy** (`resolveCodexLaunchModel`) + best-effort async wrapper. Swaps only when codex-cli + enabled + `fallbackModel` set + not-already-on-fallback + (`rate_limit_reached_type` set **OR** weekly `remainingPercent <= threshold`, default 10). Fast-path guards do **zero disk I/O** when disabled. Never throws, never blocks a launch.
- Wired into **both** codex launch paths in `SessionManager` (headless `spawnSession` + interactive `spawnInteractiveSession`).

### Safe by default
- **Ships DARK** behind `codex.rateLimitModelSwap.{enabled,fallbackModel,weeklyRemainingThreshold}`. Absence = off = byte-identical behavior; zero spawn-path overhead.
- The `fallbackModel` id is **operator config, never hardcoded** — the exact Codex-Spark `--model` string and its availability on a given ChatGPT subscription are the account owner's to confirm (it's not in instar's probed model list). **@JKHeadley: set the verified Spark id + `enabled:true` to arm it.**

### Tests — 26, 3 tiers (all green)
- Unit: pure policy (both sides of every guard) + wrapper (zero-disk-IO fast-paths, read-throws fail-safe).
- Integration: the wrapper with the **real** `readLatestCodexUsage` against a rollout fixture.
- Wiring: reflection on `SessionManager.resolveCodexLaunchModel` (deterministic fast-paths) + source-assertions that **both** spawn paths launch with the resolved model.

**Phase-5 second-pass reviewer concurred** (independent subagent audited artifact + code with file:line cites — verified fail-safe, zero-overhead-when-off, byte-identical default path, both paths covered).

`npm run lint` clean. Spec `docs/specs/CODEX-MODEL-SWAP-SPEC.md` + ELI16 + side-effects artifact + trace. **`approved:true` self-applied under the 12h autonomous deploy mandate — flagged for async human review.** Pure signal-driven decision, no blocking authority.

> Note: `upgrades/NEXT.md` here covers **both** #577 (#4a) and this PR — they release together on the next publish. (GitHub Actions push-event delivery was glitching when #577 merged, so its release is still pending; this merge re-attempts the trigger.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
