### PR TITLE
fix(threadline): accept-boundary on /messages/relay-agent — duplicate-reply ROOT [#3]

### DIFF
--- a/docs/specs/RELAY-AGENT-ACCEPT-BOUNDARY-SPEC.md
+++ b/docs/specs/RELAY-AGENT-ACCEPT-BOUNDARY-SPEC.md
@@ -1,0 +1,99 @@
+---
+title: Respond at the accept boundary on /messages/relay-agent so a slow spawn can't cause a duplicate reply
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: RELAY-AGENT-ACCEPT-BOUNDARY.eli16.md
+---
+
+# Relay-Agent Accept-Boundary Response (duplicate-reply ROOT fix)
+
+## Problem
+
+The co-located agent-to-agent inbound handler `POST /messages/relay-agent`
+(`src/server/routes.ts`) AWAITED `ThreadlineRouter.handleInboundMessage` — a
+session spawn/resume that routinely takes 9-30 s — before responding. But the
+SENDER, `MessageRouter.relay` (`src/messaging/MessageRouter.ts:494-505`), uses
+`AbortSignal.timeout(5000)` and reads only `response.ok`. So whenever the
+receiver's spawn outran 5 s, the sender's fetch aborted, it treated delivery as
+failed, and it retried (or fell to the drop directory) — and a retry arrived
+with a FRESH `message.id`, which slipped past the id-based relay dedup and
+caused a second spawn → a DUPLICATE reply.
+
+The content-hash dedup (PR #573) is the symptom backstop — it collapses an
+identical retry. This spec removes the ROOT: the receiver should not make the
+sender wait on a 9-30 s spawn behind a 5 s timeout.
+
+History: the original handler fire-and-forgot the router and returned `{ok:true}`
+immediately. PR-1 ("stop lying about delivery") made it AWAIT and return the
+spawn result, so callers could learn the outcome. But no caller's CORRECTNESS
+depends on the synchronous outcome — `MessageRouter.relay` reads only
+`response.ok`, and the actual reply flows back via the reply-waiter mechanism,
+decoupled from this HTTP response. The one place the outcome fields ARE read —
+the `/threadline/relay-send` local fast-path (`routes.ts:13824-13835`) — uses
+them only to build an informational `deliveryOutcome` string, which now degrades
+gracefully to the existing `'accepted'` default (no retry/delivery/correctness
+impact; `delivered` stays `true`). So PR-1 traded the duplicate-reply root for an
+outcome that only feeds an observability string.
+
+## Fix
+
+Respond at the ACCEPT BOUNDARY. The message is already accepted into the inbox
+(`messageRouter.relay`) and has passed the warrants-reply gate by the time we
+reach the router block, so we respond `{ ok: true, accepted: true, threadline:
+{ accepted: true, async: true } }` immediately and run
+`handleInboundMessage(envelope)` in the background (`void` + `.then`/`.catch`
+logging). The handler is NOT dropped; its outcome is logged; a rejection can't
+500 a response that already returned.
+
+What is preserved, unchanged and still synchronous (all fast, all before the
+response):
+- the content-hash dedup short-circuit,
+- the reply-waiter resolution (delivers a reply to a waiting sender),
+- the warrants-reply gate (suppress → `{suppressed:true}` short-circuit, never
+  reaching the spawn).
+
+Only the non-suppressed spawn path changes: sync-spawn-result → async-spawn +
+accept-ack.
+
+## Scope
+
+This spec covers ONLY the co-located path (`/messages/relay-agent`) — the
+confirmed bug (the same-machine echo↔codey loop, `MessageRouter.relay`'s 5 s
+timeout). The relay-FUNNEL path
+(`ThreadlineEndpoints` `/threadline/messages/receive`) has the same blocking
+shape but DIFFERENT error semantics (a `422`-retryable response on
+`result.error`) that an accept-boundary conversion must redesign — a distinct
+change with its own design, tracked in issue-580. <!-- tracked: issue-580 -->
+It is not part of this PR (which is complete on its own terms: it fully fixes
+the co-located duplicate-reply root).
+
+## Signal vs authority
+
+No new authority. The handler already DECIDED to accept (relay) and to reply
+(gate) before this point; the change is only WHEN it responds relative to the
+background spawn. Nothing is gated, blocked, or filtered differently.
+
+## Testing
+
+- **Integration** (`threadline-relay-agent-result.test.ts`, rewritten): the
+  response is `{accepted:true, async:true}` WITHOUT the spawn fields; it returns
+  BEFORE a deliberately-held handler finishes (router-start present, router-end
+  not — proving we did not await); the handler still runs to completion in the
+  background; a background rejection still yields 200 accepted; the reply-waiter
+  tests (resolution before the response) are unchanged and green.
+- **Regression**: the content-hash dedup suite + the keystone wiring test
+  (gate-runs-before-spawn, made formatting-robust) stay green.
+
+## Rollback
+
+Revert the one `routes.ts` block (re-await + return the result) and the test.
+No data, no migration. The content-hash dedup remains as the symptom backstop
+regardless.
+
+## Authority note
+
+Shipped under the 12-hour session deploy mandate; `approved:true` self-applied,
+flagged in the PR. Justin explicitly asked to "move forward with the
+duplicate-reply fix." Grounded by reading the sole co-located sender
+(`MessageRouter.relay`) and confirming it reads only `response.ok` within a 5 s
+timeout — so the accept-boundary breaks no consumer.

--- a/docs/specs/RELAY-AGENT-ACCEPT-BOUNDARY.eli16.md
+++ b/docs/specs/RELAY-AGENT-ACCEPT-BOUNDARY.eli16.md
@@ -1,0 +1,45 @@
+# Plain-English overview: stop making the sender wait, so it doesn't double-send
+
+## The problem
+
+When one agent messages another agent on the same machine, the receiving agent
+used to do ALL the work — spin up a whole new session to handle the message,
+which can take 9 to 30 seconds — and only THEN tell the sender "got it."
+
+But the sender only waits 5 seconds for that "got it." After 5 seconds it gives
+up, assumes the message failed, and sends it AGAIN with a brand-new id. The
+receiver, still busy, treats the resend as a new message and spins up a SECOND
+session — so the user gets a duplicate reply. That's the duplicate-reply bug.
+
+We already shipped a safety net that notices the resend and throws it away. This
+change fixes the actual cause.
+
+## The fix
+
+The receiver now says "got it" the instant the message is safely accepted — not
+after the 9-to-30-second session spin-up. It does the slow work in the
+background afterward. So the sender gets its answer well within 5 seconds, never
+times out, and never double-sends.
+
+Nothing important is lost: the only thing the sender ever checked was "did it
+arrive?", and the real reply comes back through a separate channel anyway, not
+through this quick "got it." Everything that has to happen before we say "got
+it" — checking for a duplicate, waking up anyone waiting for a reply, deciding
+whether a reply is even warranted — still happens first, and is fast.
+
+## Is anything risky?
+
+This is a messaging change, so it got an extra independent review. The key
+checks: the sender genuinely only reads "did it arrive," not the session
+details (confirmed in the code); a failure in the background work can't break a
+response that already went out (it's just logged); and the "is a reply
+warranted?" gate still runs before any session is started. We also scoped this
+to the same-machine path that actually has the bug; the cross-machine path works
+a little differently (it can ask the sender to retry on a real error) and is
+handled separately so we don't accidentally remove that retry.
+
+## What you'd notice
+
+Agents talking to each other on the same machine stop occasionally double-
+replying, and the sender gets a snappy acknowledgment instead of a 30-second
+hang.

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -12858,27 +12858,35 @@ export function createRoutes(ctx: RouteContext): Router {
           }
         }
 
-        // If we have a ThreadlineRouter, route the message through it for
-        // session resume/spawn. We AWAIT the result so callers learn the real
-        // outcome (spawned / resumed / injected / handled:false). The message
-        // has already been accepted into the inbox, so we don't alter the HTTP
-        // status unless the router throws.
+        // ACCEPT-BOUNDARY (duplicate-reply ROOT fix). The message is already
+        // accepted into the inbox AND past the warrants-reply gate above, so we
+        // respond NOW — an honest "accepted, processing async" — instead of
+        // AWAITING handleInboundMessage. That await is a session spawn/resume
+        // that routinely takes 9-30s, far longer than the sender's relay-fetch
+        // timeout: MessageRouter.relay uses AbortSignal.timeout(5000) and only
+        // reads response.ok (never the spawned/resumed fields). Past 5s the
+        // sender treats delivery as failed and retries with a FRESH message.id
+        // → a duplicate spawn/reply. The content-hash dedup (#573) is the
+        // symptom backstop; responding at the accept boundary removes the ROOT.
+        // The actual reply still flows back via the reply-waiter mechanism
+        // (resolved above), decoupled from this HTTP response.
         if (ctx.threadlineRouter) {
-          try {
-            const threadlineResult = await ctx.threadlineRouter.handleInboundMessage(envelope);
-            res.json({ ok: true, threadline: threadlineResult });
-            return;
-          } catch (err) {
-            console.error('[routes] ThreadlineRouter handling error:', err);
-            res.json({
-              ok: true,
-              threadline: {
-                handled: false,
-                error: err instanceof Error ? err.message : 'Unknown error',
-              },
+          res.json({ ok: true, accepted: true, threadline: { accepted: true, async: true } });
+          // Process asynchronously — the response is already sent.
+          // handleInboundMessage is NOT dropped: it runs to completion in the
+          // background; its outcome is logged (never surfaced to the closed
+          // response), and a failure can't 500 a request that already returned.
+          void ctx.threadlineRouter
+            .handleInboundMessage(envelope)
+            .then((threadlineResult) => {
+              console.log(
+                `[relay-agent] async handleInboundMessage complete (thread ${envelope.message?.threadId ?? 'none'}): ${JSON.stringify(threadlineResult)}`,
+              );
+            })
+            .catch((err) => {
+              console.error('[routes] ThreadlineRouter async handling error:', err);
             });
-            return;
-          }
+          return;
         }
         res.json({ ok: true });
       } else {

--- a/tests/e2e/threadline/conversation-keystone-wiring.test.ts
+++ b/tests/e2e/threadline/conversation-keystone-wiring.test.ts
@@ -73,7 +73,11 @@ describe('Threadline keystone — wiring integrity (feature alive)', () => {
     expect(relayAgentIdx).toBeGreaterThan(0);
     const route = routesSrc.slice(relayAgentIdx, relayAgentIdx + 12000);
     const gateIdx = route.indexOf('evaluateAndRecordInbound(ctx.warrantsReplyGate, ctx.conversationStore');
-    const routerIdx = route.indexOf('ctx.threadlineRouter.handleInboundMessage(envelope)');
+    // Match the call by method+arg so the assertion survives formatting of the
+    // `ctx.threadlineRouter` receiver (the accept-boundary fix runs it async, so
+    // `.handleInboundMessage(envelope)` may sit on its own line). The gate still
+    // runs BEFORE this spawn call — which is what this guards.
+    const routerIdx = route.indexOf('handleInboundMessage(envelope)');
     expect(gateIdx).toBeGreaterThan(0);
     expect(routerIdx).toBeGreaterThan(gateIdx); // gate runs BEFORE the spawn
     expect(route.slice(gateIdx, routerIdx)).toMatch(/if\s*\(\s*decision\.suppress\s*\)/);

--- a/tests/integration/threadline-relay-agent-result.test.ts
+++ b/tests/integration/threadline-relay-agent-result.test.ts
@@ -1,13 +1,19 @@
 /**
- * Integration test — /messages/relay-agent now returns the ThreadlineRouter
- * result synchronously (PR-1: stop lying about delivery).
+ * Integration test — /messages/relay-agent responds at the ACCEPT BOUNDARY
+ * (duplicate-reply ROOT fix), not after the session spawn.
  *
- * Previously the handler fire-and-forgot ThreadlineRouter.handleInboundMessage
- * and returned `{ok:true}` immediately. This meant callers could never tell
- * whether the message was actually spawned, resumed, or dropped.
- *
- * After PR-1 the handler awaits the router and includes the result in the
- * response body under `threadline`.
+ * History: the original handler fire-and-forgot handleInboundMessage and
+ * returned `{ok:true}`. PR-1 ("stop lying about delivery") made it AWAIT the
+ * router and return the spawn result synchronously. That await is the root of
+ * the duplicate-reply bug: handleInboundMessage is a session spawn/resume that
+ * routinely takes 9-30s, but the co-located sender (MessageRouter.relay) uses
+ * `AbortSignal.timeout(5000)` and only reads `response.ok`. Past 5s the sender
+ * treats delivery as failed and retries with a FRESH message.id → a duplicate
+ * spawn/reply (the content-hash dedup is the symptom backstop; this is the
+ * root). So we now respond `{accepted:true, async:true}` as soon as the message
+ * is accepted + gated, and run handleInboundMessage in the background. The
+ * actual reply still flows back via the reply-waiter mechanism (resolved
+ * BEFORE the response — those tests below are unchanged).
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
@@ -28,7 +34,7 @@ import type { TempProject, MockSessionManager } from '../helpers/setup.js';
 import type { InstarConfig } from '../../src/core/types.js';
 import type { ThreadlineHandleResult } from '../../src/threadline/ThreadlineRouter.js';
 
-describe('/messages/relay-agent — threadline result propagation (PR-1)', () => {
+describe('/messages/relay-agent — accept-boundary response (duplicate-reply root fix)', () => {
   let project: TempProject;
   let mockSM: MockSessionManager;
   let server: AgentServer;
@@ -38,8 +44,11 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
   let relayAgentToken: string;
   let handleInboundMessage: ReturnType<typeof vi.fn>;
   let handlerOrder: string[];
-  const AUTH_TOKEN = 'test-auth-pr1';
-  const PROJECT = 'test-pr1-project';
+  // A manually-resolved gate so a test can hold handleInboundMessage "spawning"
+  // while it asserts the HTTP response already came back.
+  let releaseHandler: (() => void) | null;
+  const AUTH_TOKEN = 'test-auth-accept-boundary';
+  const PROJECT = 'test-accept-boundary-project';
 
   beforeAll(async () => {
     project = createTempProject();
@@ -91,17 +100,16 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
     };
 
     handlerOrder = [];
+    releaseHandler = null;
     handleInboundMessage = vi.fn(async (): Promise<ThreadlineHandleResult> => {
       handlerOrder.push('router-start');
-      // Simulate async work so we can verify the handler awaited us.
-      await new Promise((r) => setTimeout(r, 25));
+      // Block until the test releases us (simulates a slow 9-30s spawn) — or,
+      // when no gate is armed, resolve on the next tick.
+      if (releaseHandler === null) {
+        await new Promise<void>((r) => { releaseHandler = r; });
+      }
       handlerOrder.push('router-end');
-      return {
-        handled: true,
-        spawned: true,
-        threadId: 'thread-abc',
-        sessionName: 'session-xyz',
-      };
+      return { handled: true, spawned: true, threadId: 'thread-abc', sessionName: 'session-xyz' };
     });
 
     const fakeRouter = { handleInboundMessage } as any;
@@ -141,7 +149,7 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
     return {
       schemaVersion: 1,
       message: {
-        id: `pr1-${Date.now()}-${Math.random()}`,
+        id: `ab-${Date.now()}-${Math.random()}`,
         from: { agent: 'other-agent', session: 's', machine: 'remote' },
         to: { agent: PROJECT, session: 'best', machine: 'local' },
         type: 'request',
@@ -162,7 +170,9 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
     };
   }
 
-  it('returns the threadline router result in the response', async () => {
+  it('responds {accepted:true} at the accept boundary without the spawn result', async () => {
+    handlerOrder.length = 0;
+    releaseHandler = null;
     const res = await request(app)
       .post('/messages/relay-agent')
       .set('Authorization', `Bearer ${relayAgentToken}`)
@@ -170,29 +180,42 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
       .expect(200);
 
     expect(res.body.ok).toBe(true);
-    expect(res.body.threadline).toBeDefined();
-    expect(res.body.threadline.handled).toBe(true);
-    expect(res.body.threadline.spawned).toBe(true);
-    expect(res.body.threadline.threadId).toBe('thread-abc');
-    expect(res.body.threadline.sessionName).toBe('session-xyz');
-    expect(handleInboundMessage).toHaveBeenCalled();
+    expect(res.body.accepted).toBe(true);
+    expect(res.body.threadline).toEqual({ accepted: true, async: true });
+    // The synchronous spawn result is intentionally NOT in the response.
+    expect(res.body.threadline.spawned).toBeUndefined();
+    expect(res.body.threadline.sessionName).toBeUndefined();
+
+    // Release the (still-pending) background handler and let it finish.
+    await vi.waitFor(() => expect(releaseHandler).not.toBeNull());
+    releaseHandler!();
   });
 
-  it('awaits the router before responding (not fire-and-forget)', async () => {
+  it('returns BEFORE the slow handler finishes (the duplicate-reply root fix)', async () => {
     handlerOrder.length = 0;
+    releaseHandler = null;
     await request(app)
       .post('/messages/relay-agent')
       .set('Authorization', `Bearer ${relayAgentToken}`)
       .send(validEnvelope())
       .expect(200);
 
-    // router-start AND router-end must both be in the order array before
-    // we get here — this only holds if the handler awaited.
-    expect(handlerOrder).toEqual(['router-start', 'router-end']);
+    // The response is already back. The background handler has STARTED but not
+    // finished (it's blocked on the release gate) — proving we did not await it.
+    expect(handlerOrder).toContain('router-start');
+    expect(handlerOrder).not.toContain('router-end');
+
+    // Now release it and confirm it runs to completion in the background
+    // (handleInboundMessage is NOT dropped).
+    await vi.waitFor(() => expect(releaseHandler).not.toBeNull());
+    releaseHandler!();
+    await vi.waitFor(() => expect(handlerOrder).toContain('router-end'));
+    expect(handleInboundMessage).toHaveBeenCalled();
   });
 
-  it('returns handled:false threadline result cleanly', async () => {
-    handleInboundMessage.mockResolvedValueOnce({ handled: false });
+  it('still returns 200 accepted when the background handler rejects (error never surfaced to the closed response)', async () => {
+    releaseHandler = null;
+    handleInboundMessage.mockRejectedValueOnce(new Error('boom'));
     const res = await request(app)
       .post('/messages/relay-agent')
       .set('Authorization', `Bearer ${relayAgentToken}`)
@@ -200,12 +223,14 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
       .expect(200);
 
     expect(res.body.ok).toBe(true);
-    expect(res.body.threadline).toEqual({ handled: false });
+    expect(res.body.accepted).toBe(true);
+    // The rejection is logged async; it cannot 500 a response that already returned.
   });
 
-  // ── PR-3: waiters re-keyed by threadId ─────────────────────────
+  // ── PR-3: waiters re-keyed by threadId (resolved BEFORE the response — unchanged) ──
 
   it('resolves reply waiter by threadId, not sender agent name', async () => {
+    releaseHandler = null;
     const routeCtx = (server as any).routeContext as { threadlineReplyWaiters: Map<string, any> };
     expect(routeCtx.threadlineReplyWaiters).toBeDefined();
 
@@ -236,9 +261,11 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
     await Promise.race([waiterPromise, new Promise((_, rej) => setTimeout(() => rej(new Error('waiter never resolved')), 2000))]);
     expect(resolvedReply).toBe('actual reply content');
     expect(routeCtx.threadlineReplyWaiters.has(threadId)).toBe(false);
+    if (releaseHandler) (releaseHandler as () => void)();
   });
 
   it('does not resolve waiter for a different threadId even if sender matches', async () => {
+    releaseHandler = null;
     const routeCtx = (server as any).routeContext as { threadlineReplyWaiters: Map<string, any> };
     const waiterThreadId = crypto.randomUUID();
     let resolved = false;
@@ -249,7 +276,6 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
       timer: setTimeout(() => {}, 10_000) as ReturnType<typeof setTimeout>,
     });
 
-    // Inbound message from same sender, DIFFERENT threadId — must not resolve
     const env = validEnvelope();
     env.message.threadId = crypto.randomUUID();
     await request(app)
@@ -261,18 +287,6 @@ describe('/messages/relay-agent — threadline result propagation (PR-1)', () =>
     await new Promise((r) => setTimeout(r, 50));
     expect(resolved).toBe(false);
     routeCtx.threadlineReplyWaiters.delete(waiterThreadId);
-  });
-
-  it('still returns 200 if the router throws, with error surfaced', async () => {
-    handleInboundMessage.mockRejectedValueOnce(new Error('boom'));
-    const res = await request(app)
-      .post('/messages/relay-agent')
-      .set('Authorization', `Bearer ${relayAgentToken}`)
-      .send(validEnvelope())
-      .expect(200);
-
-    expect(res.body.ok).toBe(true);
-    expect(res.body.threadline.handled).toBe(false);
-    expect(res.body.threadline.error).toBe('boom');
+    if (releaseHandler) (releaseHandler as () => void)();
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,62 @@
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Fixed the ROOT of duplicate agent-to-agent replies: `POST /messages/relay-agent`
+now responds at the accept boundary instead of after the session spawn.** The
+co-located inbound handler used to AWAIT `handleInboundMessage` — a session
+spawn/resume that routinely takes 9-30 s — before responding. But the sender
+(`MessageRouter.relay`) uses a 5-second fetch timeout and reads only whether the
+request succeeded. So whenever the receiver's spawn outran 5 s, the sender gave
+up, retried with a fresh message id, and the receiver spawned a SECOND session →
+a duplicate reply. The content-hash dedup shipped earlier is the symptom
+backstop; this removes the cause. The handler now responds `{ ok:true,
+accepted:true, threadline:{accepted:true, async:true} }` the instant the message
+is accepted + gated, and runs the spawn in the background. Everything that must
+happen first — the dedup, the reply-waiter resolution, and the warrants-reply
+gate (including its suppress short-circuit) — still runs synchronously before the
+response. Scoped to the co-located path; the cross-machine relay-funnel path
+(which has retry-on-error semantics to preserve) is tracked separately.
+
+## Summary of New Capabilities
+
+- No new capability — a robustness fix. Agent-to-agent messages on the same
+  machine no longer risk a duplicate reply when the receiver's session spawn is
+  slower than the sender's 5-second delivery timeout.
+
+## What to Tell Your User
+
+Agents talking to each other on the same machine no longer occasionally send the
+same reply twice. The cause was that a receiving agent waited until it had fully
+spun up a session — up to half a minute — before telling the sender the message
+arrived, but the sender only waits five seconds and would resend. Now the
+receiver acknowledges the moment the message is safely accepted and does the
+slow work in the background, so the sender never times out and never resends.
+Nothing changes for you; the real reply still arrives as before, just without the
+occasional duplicate.
+
+## Evidence
+
+**Reproduction / root cause.** Confirmed in the code: the co-located sender
+`MessageRouter.relayToAgent` (`src/messaging/MessageRouter.ts:486-510`) wraps its
+POST to `/messages/relay-agent` in `AbortSignal.timeout(5000)` and returns only
+`response.ok`. The receiver's handler awaited `handleInboundMessage` (a 9-30 s
+session spawn) before responding, so any spawn over 5 s aborted the sender's
+fetch → the sender retried with a fresh `message.id`, which slips past the
+id-based relay dedup → a second spawn and a duplicate reply. (The 2026-05-30
+duplicate-reply incidents on the echo↔codey loop are this path.)
+
+**Before / after.** Before: the response is sent only after the full spawn. After:
+the response is `{accepted:true, async:true}` sent at the accept boundary, with
+the spawn running in the background. The rewritten integration test holds the
+background handler open and asserts the HTTP response returns while the handler
+is still mid-spawn (`router-start` present, `router-end` not yet) — i.e. the
+sender is no longer made to wait. The handler still runs to completion in the
+background (not dropped); a background rejection still yields HTTP 200; the
+reply-waiter resolution and the warrants-reply gate's suppress short-circuit stay
+green; the content-hash dedup suite and the keystone gate-before-spawn wiring
+test stay green. An independent second-pass reviewer audited the change (it
+touches inbound messaging) and confirmed correctness after one artifact-honesty
+correction.

--- a/upgrades/side-effects/relay-agent-accept-boundary.md
+++ b/upgrades/side-effects/relay-agent-accept-boundary.md
@@ -1,0 +1,128 @@
+# Side-Effects Review — relay-agent accept-boundary (duplicate-reply root)
+
+**Version / slug:** `relay-agent-accept-boundary`
+**Date:** 2026-05-30
+**Author:** Echo (instar-dev agent)
+**Second-pass reviewer:** REQUIRED (inbound agent-to-agent messaging path) — verdict appended below
+
+## Summary of the change
+
+`POST /messages/relay-agent` (`src/server/routes.ts`) now responds at the accept
+boundary — `{ ok:true, accepted:true, threadline:{accepted:true, async:true} }`
+— instead of awaiting `handleInboundMessage` (a 9-30 s session spawn) before
+responding. The spawn runs in the background (`void` + logged `.then`/`.catch`).
+This removes the duplicate-reply ROOT: the co-located sender
+(`MessageRouter.relay`) uses `AbortSignal.timeout(5000)` and reads only
+`response.ok`, so awaiting the spawn past 5 s made it retry with a fresh id →
+duplicate spawn. Scoped to the co-located path only; the relay-funnel path is
+tracked separately.
+
+## Decision-point inventory
+
+- No decision is added or changed. The accept decision (`relay`) and the
+  warrants-reply gate already ran upstream and are unchanged. This only moves
+  WHEN the HTTP response is sent relative to the background spawn —
+  modify (pass-through of the decision, not a new decision).
+
+---
+
+## 1. Over-block
+No block/allow surface added. The change responds *sooner*; it rejects nothing
+it didn't reject before (auth, envelope-validation, dedup, and the
+warrants-reply suppress path are all unchanged and still run before the
+response).
+
+## 2. Under-block
+The warrants-reply gate's suppress→short-circuit is preserved and still runs
+synchronously before the spawn, so a no-reply verdict still prevents the spawn.
+The only thing no longer surfaced synchronously is the spawn OUTCOME
+(spawned/handled/error) — which no caller reads (see §5/§6); it is logged.
+
+## 3. Level-of-abstraction fit
+Correct layer — the fix is at the HTTP handler that owns the request/response
+lifecycle for this path. The decision of WHAT to do (accept, gate, spawn) is
+unchanged; only the response timing within the handler moves.
+
+## 4. Signal vs authority compliance
+Compliant. No authority added. The handler already held the accept + gate
+authority upstream; the change carries no new gate and fails safe (a background
+error is logged, never surfaced as a 500 on an already-sent response).
+
+## 5. Interactions
+- **Sender (`MessageRouter.relay`, src/messaging/MessageRouter.ts:494-505):**
+  reads ONLY `response.ok` within a 5 s `AbortSignal.timeout` — verified. The
+  accept-boundary gives it a fast `ok` and never the spawn fields it never
+  read.
+- **Reply-waiter mechanism:** resolved synchronously BEFORE the response
+  (unchanged) — the actual reply path is decoupled from this response. Tests
+  for waiter-by-threadId stay green.
+- **Content-hash dedup (#573):** runs before the response, unchanged; remains
+  the backstop for any retry that still slips through.
+- **Keystone gate-before-spawn:** the warrants-reply gate still runs before the
+  (now async) spawn; the wiring test asserting that ordering stays green (made
+  formatting-robust).
+- **No double-fire:** the spawn runs exactly once per accepted message, just
+  asynchronously.
+
+## 6. External surfaces
+- The `/messages/relay-agent` response body changes from `{ok, threadline:
+  <spawnResult>}` to `{ok, accepted, threadline:{accepted, async}}`. Audited
+  consumers:
+  - `MessageRouter.relayToAgent` (`src/messaging/MessageRouter.ts:486-510`) —
+    reads ONLY `response.ok` within `AbortSignal.timeout(5000)`. Fully satisfied
+    by the fast `ok`; never read the spawn fields. No behavior change.
+  - **`/threadline/relay-send` local fast-path** (`src/server/routes.ts:13824-
+    13835`) — the SENDER side of this same co-located hop reads
+    `threadline.{injected,spawned,resumed,gateDecision,error,handled}` to build
+    an informational `deliveryOutcome` string (logged + returned to the calling
+    agent's `threadline_send` MCP result via `mcp-http-client` →
+    `ThreadlineMCPServer:575`). With the accept-boundary those fields are
+    `undefined`, so `outcome` falls through to the existing default `'accepted'`
+    (previously e.g. `'spawned new session'`/`'resumed existing thread'`). This
+    is a **cosmetic/observability degradation only**: `delivered` is computed as
+    `!outcome.startsWith('error')`, and `'accepted'` is not an error, so
+    `delivered` stays `true` exactly as before; `outcome` gates no retry, no
+    delivery, no reply-wait. `'accepted'` is also the HONEST value — the local
+    send IS accepted and processing async. (Found by the Phase-5 reviewer; the
+    original draft of this section wrongly claimed `MessageRouter.relay` was the
+    only consumer.)
+- The change is invisible to the sender's actual behavior (fast ack) and to the
+  user (the real reply still arrives via the session, just without a 30 s sender
+  hang and without the occasional duplicate).
+- No new route, no new message.
+
+## 7. Rollback cost
+Trivial — revert the one handler block (re-await + return the result) and the
+test rewrite. No data, no migration. The content-hash dedup stays as the
+symptom backstop regardless.
+
+---
+
+## Phase 5 — Second-pass reviewer verdict
+
+An independent reviewer subagent adversarially audited the artifact AND the
+actual handler code (not just the claims), and **raised one concern — now
+addressed**:
+
+- **Concern (artifact overstatement, not a code bug):** §6's original draft
+  claimed `MessageRouter.relay` + the test suite were the only consumers. The
+  reviewer found a SECOND consumer — the `/threadline/relay-send` local
+  fast-path (`routes.ts:13824-13835`) reads the spawn-outcome fields to compute
+  an informational `deliveryOutcome`. **Resolution:** §6 corrected above to name
+  this consumer and document that it degrades gracefully to the existing
+  `'accepted'` outcome — `delivered` stays `true` (`'accepted'` is not an
+  error), no retry/delivery/correctness impact. The CODE is safe to ship as-is;
+  only the artifact's honesty needed the fix.
+
+- **What the reviewer verified as correct (the core change is sound):** handler
+  ordering preserved — dedup, reply-waiter resolution, and the warrants-reply
+  gate's `suppress`→short-circuit all still run synchronously BEFORE the
+  response; `handleInboundMessage` is called exactly once (never dropped), its
+  rejection caught (can't 500 an already-sent response); the reply-waiter path
+  is decoupled and unbroken; the sole co-located sender reads only `response.ok`
+  within the 5 s timeout, so the accept-boundary genuinely removes the
+  duplicate-reply root; no test breaks; the rewritten test asserts the right
+  things (returns before `router-end`, no spawn fields, background completion,
+  error → still 200).
+
+Verdict after the §6 correction: concern resolved; change is correct and safe.


### PR DESCRIPTION
## Directive #3 — the duplicate-reply ROOT fix (accept-boundary)

Justin: "Please move forward with the duplicate-reply fix." The content-hash dedup (#573) is the symptom backstop; this removes the cause.

### Root cause (grounded in the code)
`POST /messages/relay-agent` awaited `handleInboundMessage` (a 9-30s session spawn) before responding. But the co-located sender `MessageRouter.relayToAgent` (MessageRouter.ts:486-510) uses `AbortSignal.timeout(5000)` and reads only `response.ok`. So any spawn over 5s -> the sender's fetch aborts -> it retries with a fresh `message.id` -> slips past the id-based dedup -> a second spawn -> duplicate reply.

### Fix
Respond `{ok:true, accepted:true, threadline:{accepted:true, async:true}}` the instant the message is accepted + gated; run `handleInboundMessage` in the background (void + logged then/catch; never dropped, can't 500 a sent response). Everything that must precede the response — content-hash dedup, reply-waiter resolution, and the warrants-reply gate suppress short-circuit — still runs synchronously first.

Scoped to the co-located path. The relay-funnel path (ThreadlineEndpoints, 422-retry semantics) is a distinct change -> issue #580.

### Tests
- Rewrote the PR-1 test to encode the accept-boundary: holds the background handler open and asserts the HTTP response returns while the handler is still mid-spawn (router-start present, router-end not); handler still completes in background; background rejection -> still 200; reply-waiter + gate-suppress paths green.
- Keystone gate-before-spawn assertion made formatting-robust; content-hash dedup suite green.

Independent Phase-5 reviewer (inbound messaging) confirmed correctness after one artifact-honesty correction: a second consumer (the /threadline/relay-send local fast-path) reads the spawn-outcome fields only for an info string -> degrades gracefully to the existing 'accepted' outcome (delivered stays true; no retry/correctness impact).

lint clean; spec + ELI16 + side-effects + trace. approved:true under the deploy mandate, flagged.

Generated with Claude Code.
