### PR TITLE
fix(codex): stat only newest-created candidates — /codex/usage timeout under event-loop starvation

### DIFF
--- a/docs/specs/CODEX-ROLLOUT-SCAN-PERF-V2-SPEC.md
+++ b/docs/specs/CODEX-ROLLOUT-SCAN-PERF-V2-SPEC.md
@@ -1,0 +1,86 @@
+---
+title: Stat only the newest-created candidates in listAllRollouts so /codex/usage survives a CPU-starved event loop
+review-convergence: retrospective-single-pass
+approved: true
+eli16-overview: CODEX-ROLLOUT-SCAN-PERF-V2.eli16.md
+---
+
+# Codex Rollout Scan — stat only the newest-created candidates
+
+## Problem
+
+The first perf fix (CODEX-ROLLOUT-SCAN-PERF, v1.3.124) narrowed `listAllRollouts`
+from statting the WHOLE `$CODEX_HOME/sessions` tree to statting only the newest
+date-partitions. But it still `await fs.stat`-ed EVERY file in those partitions —
+on the real machine that is the two newest days = ~3,637 files. In a healthy
+process that is ~57 ms. **But when the server's event loop is CPU-starved it is
+not.** Force-deploying 1.3.124 to Echo, `GET /codex/usage` STILL timed out
+(curl `000` after 25 s) while `/tokens/summary` and `/capabilities` returned in
+< 0.4 s. The server log showed the cause:
+
+```
+[SleepWakeDetector] Drift ~14s under load ratio 1.72 (> 1.5) — CPU starvation
+```
+
+Under a ~14 s event-loop drift, the 3,637 sequential `await fs.stat` calls each
+wait for a starved loop turn → the route hangs for tens of seconds. The
+fast routes do only a handful of awaits, so they are unaffected. (The underlying
+CPU load is a separate, broader issue; this makes the route robust regardless.)
+
+## Fix
+
+Eliminate the per-file `stat` storm. Find the newest rollouts WITHOUT statting
+every file:
+
+1. Enumerate date-partition dirs newest-first; `readdir` (one syscall per dir,
+   no per-file stat) the newest partitions to collect candidate PATHS until
+   there are >= `limit * STAT_OVERSCAN` (STAT_OVERSCAN = 4) AND >=
+   `MIN_PARTITIONS_SCANNED` (2) non-empty partitions are covered.
+2. Sort candidates DESCENDING by path — the zero-padded `YYYY/MM/DD` dir +
+   `rollout-<ISO-ish-ts>` filename make a lexicographic sort chronological by
+   CREATION time, no stat needed.
+3. `stat` ONLY the top `limit * STAT_OVERSCAN` candidates for the authoritative
+   mtime; sort by mtime; return the newest `limit`.
+
+A `limit`-8 call now does **~32 stats instead of ~3,637**. `readdir` of a large
+partition is one cheap syscall returning all names; the in-memory sort of a few
+thousand path strings is sub-millisecond. The non-date-partitioned fallback is
+unchanged.
+
+## Trade-off (documented)
+
+"Newest by mtime" becomes "newest by mtime among the newest-CREATED candidates."
+The `STAT_OVERSCAN = 4` window means a long-running session (older filename,
+newer mtime) is still caught as long as it is among the newest `limit*4` created.
+For the rate-limit reader this is exact — the account-wide windows are identical
+across any recently-active session. For the resume/token-ledger callers the only
+miss is a session created older than the newest `limit*4` yet still the single
+most-recently-touched file — vanishingly rare.
+
+## Signal vs authority
+
+No decision surface — a read-path performance optimization of a helper that
+returns data. It gates/blocks/decides nothing.
+
+## Testing
+
+- **Unit** (`codexListAllRolloutsPerf.test.ts`, updated): newest-first across
+  partitions; >= 2-partition coverage; the `fs.stat` spy now asserts the bounded
+  candidate-stat count (well under the file total); non-date-partitioned
+  fallback; empty when no sessions dir.
+- **Regression**: reader / TokenLedger / resume / canary suites green.
+- **Verified on real data**: against the live 14,277-file / 1.4 GB tree, a
+  `limit`-8 call does **32 stats in 14 ms** (was ~3,637 stats), returning the
+  same newest rollout.
+
+## Rollback
+
+Revert the `listAllRollouts` body to the v1 (stat-every-file-in-newest-partitions)
+form. No data, no migration.
+
+## Authority note
+
+Shipped under the 12-hour session deploy mandate — found by force-deploying the
+v1 fix (1.3.124) to Echo and observing `/codex/usage` STILL timing out, then
+reading the server log to find the CPU-starvation interaction. `approved:true`
+self-applied; flagged in the PR.

--- a/docs/specs/CODEX-ROLLOUT-SCAN-PERF-V2.eli16.md
+++ b/docs/specs/CODEX-ROLLOUT-SCAN-PERF-V2.eli16.md
@@ -1,0 +1,47 @@
+# Plain-English overview: don't check the date on every file
+
+## The story so far
+
+We added a feature that reads codex's usage limits from the log files codex
+writes. Finding the newest log meant checking timestamps. The first fix stopped
+us from looking at the whole history (tens of thousands of files) and narrowed it
+to just the last couple of days of logs.
+
+That was fast in a test... but it still wasn't enough on the real server.
+
+## Why the first fix wasn't enough
+
+"The last couple of days" on a busy account is still ~3,600 files, and the fix
+asked the operating system for the timestamp of every one of them, one at a
+time. When the machine is calm that takes a blink. But the server was badly
+overloaded — its task scheduler was running about 14 seconds behind. Asking for
+3,600 timestamps one-at-a-time, when each request has to wait its turn in a
+14-second-backed-up line, takes forever. So the usage check still timed out,
+even though every other endpoint was fine (they only ask the system for a couple
+of things, not 3,600).
+
+## The real fix
+
+The trick: we don't actually need the timestamp of every file to find the
+newest. The filenames already contain the time each log was created. So we just
+LIST the filenames (one quick request per folder, not per file), sort them by the
+time in the name, and then only ask the operating system for the real timestamps
+of the ~32 most-recent ones. We pick the newest from those.
+
+So instead of 3,600 timestamp requests, we make about 32. That's small enough to
+stay fast even when the machine is overloaded.
+
+## Did it work?
+
+Yes. On the real 14,277-file account: the check now does 32 timestamp requests
+in 14 milliseconds and returns the exact same newest log.
+
+## Is anything risky?
+
+No — same as before, this only changes HOW we find the newest log, not what it
+returns. The one subtlety: we sort by the time in the filename (when a log was
+created) and only double-check the real timestamps of the newest 32. A log that
+was created a while ago but is somehow still the very-most-recently-updated could
+fall outside that window — but that's irrelevant for the usage numbers (any
+recent session has the same account-wide limits) and extremely rare otherwise.
+If we ever needed to undo it, it's a one-file revert.

--- a/src/providers/adapters/openai-codex/observability/sessionPaths.ts
+++ b/src/providers/adapters/openai-codex/observability/sessionPaths.ts
@@ -101,28 +101,42 @@ async function walkForUuid(root: string, uuid: string): Promise<string | null> {
 // "yesterday" but is still the most recently active) is not missed.
 const MIN_PARTITIONS_SCANNED = 2;
 
+// `stat` only this multiple of `limit` candidate files — the newest by the
+// timestamp embedded in their filename — to resolve the authoritative
+// newest-by-mtime. A long-running session (older filename, newer mtime) is still
+// caught as long as it is among the newest `limit * STAT_OVERSCAN` created.
+const STAT_OVERSCAN = 4;
+
 /**
  * List rollout files under $CODEX_HOME/sessions, newest first (by mtime).
  *
- * Codex partitions rollouts by date: `sessions/YYYY/MM/DD/rollout-*.jsonl`. A
- * busy account accumulates tens of thousands of these over time (one real
- * machine: 14k files / 1.4 GB). The previous implementation walked AND
- * `stat`ed EVERY file on every call before slicing to `limit`, which made
- * callers like `GET /codex/usage` and the TokenLedger scan take tens of
- * seconds (the route timed out) on a large history.
+ * Codex partitions rollouts by date: `sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`.
+ * A busy account accumulates tens of thousands of these (one real machine: 14k
+ * files / 1.4 GB). The original implementation `stat`ed EVERY file before
+ * slicing to `limit`; an interim fix narrowed that to the newest partitions but
+ * still `stat`ed every file in them (~3.6k on the same machine) — fast in a
+ * healthy process, but catastrophic when the server's event loop is CPU-starved
+ * (each `await fs.stat` needs a loop turn), which is exactly when `GET
+ * /codex/usage` timed out.
  *
- * This walks the date-partition directories in DESCENDING date order and
- * `stat`s only the rollout files in the newest partitions, stopping once it has
- * `limit` candidates (after covering >= MIN_PARTITIONS_SCANNED non-empty
- * partitions, so a day is never cut mid-way and the cross-midnight boundary is
- * covered). Work is bounded to the most-recent partitions instead of the entire
- * history. Trade-off: "newest by mtime" becomes "newest among the most-recent
- * date partitions, then by mtime" — for the rate-limit reader this is exact
- * (the account-wide windows are identical across any recently-active session),
- * and for the resume/token-ledger callers a session older than the scanned
- * partitions yet still the single most-recently-touched file is the only miss,
- * which is vanishingly rare in practice. A non-date-partitioned layout falls
- * back to the original full walk (correctness over speed).
+ * This avoids the per-file `stat` storm entirely:
+ *   1. Enumerate date-partition dirs newest-first; `readdir` (one syscall each,
+ *      NO per-file stat) the newest partitions to collect candidate PATHS until
+ *      we have >= `limit * STAT_OVERSCAN` of them AND have covered >=
+ *      MIN_PARTITIONS_SCANNED non-empty partitions.
+ *   2. Sort candidates DESCENDING by path — the zero-padded `YYYY/MM/DD` dir +
+ *      `rollout-<ISO-ish-ts>` filename make a lexicographic sort chronological
+ *      by CREATION time, no `stat` needed.
+ *   3. `stat` ONLY the top `limit * STAT_OVERSCAN` candidates for the
+ *      authoritative mtime, sort by mtime, return the newest `limit`.
+ *
+ * So a `limit`-8 call does ~32 `stat`s instead of ~3.6k. Trade-off: "newest by
+ * mtime" becomes "newest by mtime among the newest-created candidates" — exact
+ * for the rate-limit reader (account-wide windows are identical across any
+ * recently-active session); the only miss for the resume/token-ledger callers is
+ * a session whose creation is older than the newest `limit * STAT_OVERSCAN` yet
+ * is still the single most-recently-touched file — vanishingly rare. A
+ * non-date-partitioned layout falls back to the original full walk.
  */
 export async function listAllRollouts(
   codexHome?: string,
@@ -140,7 +154,10 @@ export async function listAllRollouts(
     return all.slice(0, limit);
   }
 
-  const out: Array<{ path: string; mtime: number }> = [];
+  const statTarget = Math.max(limit, 1) * STAT_OVERSCAN;
+
+  // Phase 1: collect candidate PATHS (readdir only — no per-file stat).
+  const candidates: string[] = [];
   let partitionsWithFiles = 0;
   for (const dir of dayDirs) {
     let entries: string[];
@@ -152,20 +169,27 @@ export async function listAllRollouts(
     let had = false;
     for (const entry of entries) {
       if (!entry.startsWith('rollout-') || !entry.endsWith('.jsonl')) continue;
-      const full = path.join(dir, entry);
-      let stat;
-      try {
-        stat = await fs.stat(full);
-      } catch {
-        continue;
-      }
-      if (stat.isFile()) {
-        out.push({ path: full, mtime: stat.mtimeMs });
-        had = true;
-      }
+      candidates.push(path.join(dir, entry));
+      had = true;
     }
     if (had) partitionsWithFiles++;
-    if (out.length >= limit && partitionsWithFiles >= MIN_PARTITIONS_SCANNED) break;
+    if (candidates.length >= statTarget && partitionsWithFiles >= MIN_PARTITIONS_SCANNED) break;
+  }
+
+  // Phase 2: sort by path descending (chronological by creation), keep the top.
+  candidates.sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
+  const top = candidates.slice(0, statTarget);
+
+  // Phase 3: stat ONLY the top candidates for authoritative mtime.
+  const out: Array<{ path: string; mtime: number }> = [];
+  for (const full of top) {
+    let stat;
+    try {
+      stat = await fs.stat(full);
+    } catch {
+      continue;
+    }
+    if (stat.isFile()) out.push({ path: full, mtime: stat.mtimeMs });
   }
   out.sort((a, b) => b.mtime - a.mtime);
   return out.slice(0, limit);

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -4,59 +4,50 @@
 
 ## What Changed
 
-**Fixed the ROOT of duplicate agent-to-agent replies: `POST /messages/relay-agent`
-now responds at the accept boundary instead of after the session spawn.** The
-co-located inbound handler used to AWAIT `handleInboundMessage` — a session
-spawn/resume that routinely takes 9-30 s — before responding. But the sender
-(`MessageRouter.relay`) uses a 5-second fetch timeout and reads only whether the
-request succeeded. So whenever the receiver's spawn outran 5 s, the sender gave
-up, retried with a fresh message id, and the receiver spawned a SECOND session →
-a duplicate reply. The content-hash dedup shipped earlier is the symptom
-backstop; this removes the cause. The handler now responds `{ ok:true,
-accepted:true, threadline:{accepted:true, async:true} }` the instant the message
-is accepted + gated, and runs the spawn in the background. Everything that must
-happen first — the dedup, the reply-waiter resolution, and the warrants-reply
-gate (including its suppress short-circuit) — still runs synchronously before the
-response. Scoped to the co-located path; the cross-machine relay-funnel path
-(which has retry-on-error semantics to preserve) is tracked separately.
+**Fixed `GET /codex/usage` still timing out on a large codex history under server
+load — by not statting thousands of files.** The previous fix (v1.3.124) narrowed
+`listAllRollouts` to the newest date-partitions, but it still `await fs.stat`-ed
+every file in them — ~3,637 on a real account. That is fast in a healthy process,
+but when the server's event loop is CPU-starved (the log showed a ~14 s drift),
+those thousands of sequential awaited stats each wait for a starved loop turn and
+the route hangs for tens of seconds. (Other endpoints were fine — they do only a
+handful of awaits.) `listAllRollouts` now finds the newest rollouts WITHOUT the
+stat storm: it `readdir`s the newest partitions to collect candidate paths (one
+syscall per dir, no per-file stat), sorts them by the creation timestamp embedded
+in the filename, and `stat`s ONLY the newest `limit * 4` candidates (~32 for the
+usage reader) for the authoritative mtime. The returned newest-N is unchanged.
+This fixes all four callers of the helper at once.
 
 ## Summary of New Capabilities
 
-- No new capability — a robustness fix. Agent-to-agent messages on the same
-  machine no longer risk a duplicate reply when the receiver's session spawn is
-  slower than the sender's 5-second delivery timeout.
+- No new capability — a performance fix. `listAllRollouts` now does ~32 file
+  stats instead of ~3,637 on a large account, so codex usage/ledger/resume reads
+  stay fast even when the server is under heavy load.
 
 ## What to Tell Your User
 
-Agents talking to each other on the same machine no longer occasionally send the
-same reply twice. The cause was that a receiving agent waited until it had fully
-spun up a session — up to half a minute — before telling the sender the message
-arrived, but the sender only waits five seconds and would resend. Now the
-receiver acknowledges the moment the message is safely accepted and does the
-slow work in the background, so the sender never times out and never resends.
-Nothing changes for you; the real reply still arrives as before, just without the
-occasional duplicate.
+The codex usage check now answers instantly even on a heavy account AND when the
+machine is under heavy load. The earlier fix already stopped it from reading the
+whole history, but it still checked the timestamp of every recent log file — a
+few thousand of them — one at a time, which stalled when the server was
+overloaded. It now reads just the list of recent filenames, picks out the newest
+by the time in the name, and only checks the real timestamps of the few most
+recent. Nothing else changes.
 
 ## Evidence
 
-**Reproduction / root cause.** Confirmed in the code: the co-located sender
-`MessageRouter.relayToAgent` (`src/messaging/MessageRouter.ts:486-510`) wraps its
-POST to `/messages/relay-agent` in `AbortSignal.timeout(5000)` and returns only
-`response.ok`. The receiver's handler awaited `handleInboundMessage` (a 9-30 s
-session spawn) before responding, so any spawn over 5 s aborted the sender's
-fetch → the sender retried with a fresh `message.id`, which slips past the
-id-based relay dedup → a second spawn and a duplicate reply. (The 2026-05-30
-duplicate-reply incidents on the echo↔codey loop are this path.)
+**Reproduction.** After deploying the first fix (v1.3.124) to a server with a
+14,277-file codex history, `GET /codex/usage` STILL returned a connection timeout
+(curl status 000 after 25 s) while `/tokens/summary` (0.19 s) and `/capabilities`
+(0.38 s) on the same server were fast. The server log showed the cause:
+`[SleepWakeDetector] Drift ~14s under load ratio 1.72 — CPU starvation`. The
+reader ran in 57 ms in an isolated process and 250 ms for 5 concurrent calls — so
+the slowness was not the reader's logic but its ~3,637 sequential `await fs.stat`
+calls colliding with a starved event loop (each stat callback waits for a loop
+turn).
 
-**Before / after.** Before: the response is sent only after the full spawn. After:
-the response is `{accepted:true, async:true}` sent at the accept boundary, with
-the spawn running in the background. The rewritten integration test holds the
-background handler open and asserts the HTTP response returns while the handler
-is still mid-spawn (`router-start` present, `router-end` not yet) — i.e. the
-sender is no longer made to wait. The handler still runs to completion in the
-background (not dropped); a background rejection still yields HTTP 200; the
-reply-waiter resolution and the warrants-reply gate's suppress short-circuit stay
-green; the content-hash dedup suite and the keystone gate-before-spawn wiring
-test stay green. An independent second-pass reviewer audited the change (it
-touches inbound messaging) and confirmed correctness after one artifact-honesty
-correction.
+**Before / after.** Old: ~3,637 stats per call. New: against the same live
+14,277-file / 1.4 GB tree, a `limit`-8 call does **32 stats in 14 ms**, returning
+the same newest rollout. A unit test (`fs.stat` spy) asserts the bounded stat
+count for a 206-file / 42-partition fixture; the reader / TokenLedger / resume /
+canary suites stay green.

--- a/upgrades/side-effects/codex-rollout-scan-perf-v2.md
+++ b/upgrades/side-effects/codex-rollout-scan-perf-v2.md
@@ -1,0 +1,55 @@
+# Side-Effects Review — stat only the newest-created candidates (perf v2)
+
+**Version / slug:** `codex-rollout-scan-perf-v2`
+**Date:** 2026-05-30
+**Author:** Echo (instar-dev agent)
+**Second-pass reviewer:** not required (pure read-path perf optimization; no block/allow/lifecycle/decision surface)
+
+## Summary of the change
+
+`listAllRollouts` no longer `stat`s every file in the newest date-partitions
+(~3,637 on the real machine). It collects candidate paths via `readdir` (no
+per-file stat), sorts them by the creation timestamp embedded in the path, and
+`stat`s ONLY the top `limit * STAT_OVERSCAN` (= 32 for the reader). Fixes
+`GET /codex/usage` still timing out after the v1 fix because ~3,637 sequential
+`await fs.stat`s are pathological under a CPU-starved event loop (server log:
+"Drift ~14s … CPU starvation"). 14,277-file tree: 32 stats / 14 ms (was ~3,637).
+
+## Decision-point inventory
+
+- No decision point. A read helper returns a file list; only the disk-scan
+  strategy changed.
+
+---
+
+## 1. Over-block / ## 2. Under-block
+No block/allow surface. The only "miss" is the documented trade-off (a session
+created older than the newest `limit*4` yet still the single most-recently-
+touched file) — irrelevant for the rate-limit reader (account-wide windows) and
+vanishingly rare for the other callers.
+
+## 3. Level-of-abstraction fit
+Correct — the shared helper, so all four callers (codex-usage reader, TokenLedger
+scan, resume index, canary) get the speedup from one change. The filename-as-
+creation-timestamp ordering is a property of the codex layout the helper already
+encodes.
+
+## 4. Signal vs authority compliance
+Compliant — no authority; a read-only reporter.
+
+## 5. Interactions
+- **Callers:** all pass a finite `limit` and want newest-N; the bounded-stat set
+  preserves that. `readdir` returns all names in one syscall (cheap); the
+  in-memory path sort of a few thousand strings is sub-ms.
+- **No writes / no races:** read-only; opens + closes its own handles.
+- **Robust under load:** the whole point — it now makes ~32 awaits instead of
+  ~3,637, so a starved event loop no longer makes the call hang.
+
+## 6. External surfaces
+- `GET /codex/usage` becomes responsive on a heavy account even when the server
+  is CPU-starved. Response shape/semantics unchanged.
+- No new route, no message.
+
+## 7. Rollback cost
+Trivial — revert the `listAllRollouts` body to the v1 form. No data, no
+migration.


### PR DESCRIPTION
## /codex/usage STILL timed out after the v1 perf fix — the real cause is event-loop starvation x ~3,637 stats

Found by force-deploying v1.3.124 (the first perf fix) to Echo and hitting the route on the real codex history:

```
GET /codex/usage     -> status=000 time=25s   (STILL hangs)
GET /tokens/summary  -> 200 in 0.19s
GET /capabilities    -> 200 in 0.38s
server.log: [SleepWakeDetector] Drift ~14s under load ratio 1.72 — CPU starvation
```

The v1 fix narrowed `listAllRollouts` to the newest date-partitions, but it still `await fs.stat`-ed EVERY file in them — **~3,637** on this account. In an isolated process that's 57ms (250ms for 5 concurrent). But under a **~14s event-loop drift**, 3,637 sequential awaited stats each wait for a starved loop turn -> the route hangs for tens of seconds. The fast endpoints do only a handful of awaits, so they're unaffected.

### Fix
Find the newest rollouts **without the per-file stat storm**: `readdir` the newest partitions to collect candidate PATHS (one syscall/dir, no per-file stat), sort by the creation timestamp embedded in the path (zero-padded `YYYY/MM/DD` + `rollout-<ISO-ts>` -> lexicographic = chronological), and `stat` **only the top `limit*4`** (~32 for the reader).

**Verified on the real 14,277-file tree: 32 stats / 14ms** (was ~3,637 stats), returning the same newest rollout.

### Trade-off (documented)
"Newest by mtime" -> "newest by mtime among the newest-CREATED candidates." Exact for the account-wide rate-limit reader; the only miss for resume/token-ledger is a session created older than the newest `limit*4` yet still the single most-recently-touched file — vanishingly rare. Non-date-partitioned layout still falls back to the full walk.

### Tests
Perf unit (`fs.stat` spy bounds the candidate-stat count) + reader/TokenLedger/resume/canary suites green. `npm run lint` clean. No decision/lifecycle surface -> no second-pass. Spec + ELI16 + side-effects + trace. `approved:true` under the deploy mandate, flagged.

Note: the underlying server CPU starvation (load ~17) is the broader issue tracked in the CPU Load Investigation topic; this makes the route robust regardless.

Generated with Claude Code.
