### PR TITLE
feat(preferences): Correction & Preference Learning Sentinel — Slice 1a (signal-only, ships dark)

### DIFF
--- a/docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.eli16.md
+++ b/docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.eli16.md
@@ -1,0 +1,28 @@
+# What I'm building, in plain terms — the "learn when you correct me" feature
+
+## The everyday version
+
+You've been correcting me a lot lately — "say it plainer," "that's redundant," "stop asking me the same thing every session." Right now those corrections mostly help *that one conversation* and then disappear. If you correct me about the same thing in three different chats over a week, those look like three unrelated blips. Nobody connects the dots, so the stuff that bugs you most keeps happening.
+
+This feature connects the dots. Think of it like a smart suggestion box that empties itself: every time you correct me, it quietly drops a note in the box. It never keeps your actual words — it reads the moment, writes down the *lesson* in one scrubbed line, and throws the raw text away immediately (so nothing private ever gets stored). Then a reviewer looks at the box and asks: "Is this the same lesson showing up again and again?" A one-off gets ignored. A repeat becomes something worth acting on.
+
+## The important part: two kinds of lesson, two different homes
+
+When you correct me, it's usually one of two things, and they go to different places:
+
+1. **"Instar itself is clumsy here."** Example: I ask you to approve a routine force-push *every single session* because the safety guard can't tell a harmless push from a risky one. That's not about you — it's a tool that should be smarter. Lessons like this get sent upstream as feedback, where they can fix the tool for *every* agent, not just me.
+
+2. **"This is just how Justin likes things."** Example: plain language, no big tables in chat, lead with the one thing you need to do. That's not a bug — it's your preference. Lessons like this get saved into *my* memory so I adapt to you specifically.
+
+Telling those two apart, automatically, is the whole trick. Mixing them up would mean spamming the Instar team with your personal preferences, or quietly rewriting my own rulebook without anyone checking — both bad.
+
+## The safety rules
+
+- **It never stores your actual messages.** Only a short, cleaned-up lesson. The real words live just long enough for one quick read, then they're gone.
+- **It never changes my behavior on its own.** It *proposes* — "hey, maybe save this," or "maybe report this tool gap" — and a human says yes or no. It can't quietly edit its own instructions.
+- **It waits for a pattern.** One correction isn't a pattern. It needs to see the same lesson a few times before it suggests anything, so we don't overreact to a single off day.
+- **It starts switched off.** Like the failure-watcher before it, it ships dark and only turns on when we choose.
+
+## Why this is the natural next step
+
+We just built the version of this for *code that breaks* (the failure-watcher). This is the exact same idea pointed at *conversations* instead of code — learn from the moment something went wrong, figure out whether it's a tool problem or a you-and-me problem, and make sure the lesson actually sticks instead of evaporating. The force-push nag you flagged today is literally the first thing it should catch.

--- a/docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md
+++ b/docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md
@@ -1,0 +1,374 @@
+---
+title: Correction & Preference Learning Sentinel
+status: draft
+initiative: correction-preference-learning-sentinel
+author: echo
+created: 2026-05-28
+topic: 13201
+approved: false
+ships-staged: true
+rollout-flag-path: monitoring.correctionLearning.enabled
+rollout-criteria: "≥3 distinct-day recurring learnings correctly routed (≥2 infra-gap → /feedback proposal, ≥1 explicit-preference → preferences-endpoint write that the session-start hook actually reads and injects) over a 4-week observation window with zero raw-text persistence and zero by-construction guard violations"
+rollout-evidence-type: log-filter
+rollout-evidence-ref: logs/correction-learning-audit.jsonl
+rollout-evidence-filter: correction-loop
+supervision: tier1
+eli16-overview: CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.eli16.md
+amends-spec:                                # documentary forward-reference (see §11 N1)
+  - failure-learning-loop                   # the substrate this is the conversational twin of
+  - failure-learning-ingestion-sources      # this loop is conceptually a peer ingestion source
+amends-spec-status: documentary-pending-reconciler  # InitiativeTracker does not yet honor this field; Slice 4 of failure-learning-ingestion-sources ships the reconciler. Tracked as open dependency in §11.
+review-convergence: "2026-05-29T03:50:46.398Z"
+review-iterations: 5
+review-completed-at: "2026-05-29T03:50:46.398Z"
+review-report: "docs/specs/reports/correction-preference-learning-sentinel-convergence.md"
+---
+
+# Correction & Preference Learning Sentinel — turning "you keep correcting me" into durable learning that actually closes
+
+> The conversational twin of the [Failure-Learning Loop](./FAILURE-LEARNING-LOOP-SPEC.md). Where that loop learns from CODE that broke, this learns from MOMENTS THE USER HAD TO CORRECT ME — and routes each lesson either to a fix in Instar itself or to how I adapt to this particular user. **Slice 1 closes the preference loop end-to-end** (correction → preferences-endpoint write (§3.6) → structural session-start injection → behavior changes → recurrence-after stops); it does not ship as detect-and-suggest scaffolding.
+
+## 1. Problem — the user corrects me, and the lesson teaches one session once, then evaporates
+
+Justin (topic 13201, 2026-05-28): *"I want to work on the version of this that catches when I correct you because I'VE BEEN DOING IT A LOT, haha."*
+
+Every time a user says "no, plainer," "that's redundant," "stop asking me that every session," or "actually, that's wrong," they are doing the system's job by hand — exactly the insight already encoded in `HumanAsDetectorLog` (Dawn's "Justin Pointing Things Out = Guardian Failure" lesson). Today three things happen to that signal, all lossy:
+
+1. **The current session may adapt** — if the agent is paying attention, it changes behavior for the rest of the conversation.
+2. **`HumanAsDetectorLog` records metadata** — category + suspected-failed-layer counts, but deliberately keeps the words off disk and never extracts a *lesson* or *acts* on it.
+3. **Nothing carries it forward.** A correction Justin makes in three different sessions over a week looks like three unrelated one-offs. The recurring ones — the ones that matter most — are precisely the ones no single session can see.
+
+This session is itself the textbook example: the 8-round dashboard-copy iteration ("no, plainer / that's redundant / what does 'this' mean / no action language") produced a durable standard (`feedback_dashboard_copy_eli16`) — but only because a human noticed the pattern and a session happened to write it down. And the force-push nag — me asking the same authorization question every session — is a recurring correction that *should* have surfaced itself as an Instar bug long ago.
+
+There are **two distinct kinds** of lesson buried in these moments, and conflating them is the central design risk:
+
+- **Instar infrastructure gaps** — a guard, gate, or feature that should have prevented the friction (the force-push guard can't tell a safe push from a risky one). These belong upstream as `/feedback` (Rising Tide), where they help *every* agent.
+- **This-user preferences** — just how *this* person likes things (plain language, no tables in chat, lead with the one action). These belong in *my* adaptation: memory, behavior, CLAUDE.md — they are not Instar bugs.
+
+## 2. What already exists (extend, not reinvent) — verified against the code, with the wiring claims corrected by Round-1 review
+
+| Component | File | What it actually does | How this loop uses it (corrected) |
+|---|---|---|---|
+| `HumanAsDetectorLog` | `src/monitoring/HumanAsDetectorLog.ts` | Regex-classifies inbound human text into 6 coherence-break categories; metadata-only JSONL; per-layer heat map; wired via `telegram.onMessageLogged` (`src/commands/server.ts:6368-6370`). `observeInboundMessage` hard-gates on `entry.fromUser` (line 311) — the real self-feed guard. Singleton with `resetForTesting()`. | **The cheap first-pass detector, extended additively** with a new `preference`/`frustration` category family. The `fromUser` entry gate (not `origin` threading) is the actual guard against learning from my own outbound text. The new categories are tagged so they DO NOT pollute the `summarizeByLayer()` guardian-failure heat map (§3.2). Layer-0 classification ships always-on (free + metadata-only); only Layers 1–5 are flag-gated. |
+| `FailureLedger` / `FailureAnalyzer` / closed loop | `src/monitoring/Failure*.ts`, `src/monitoring/FailureLoopDriver.ts` | SQLite ledger w/ dedupe-upsert + occurrence retention (bounded; `DEFAULT_MAX_OCCURRENCES_PER_KEY=200`, prune-in-transaction); analyzer with a **three-pronged** diversity gate (`minSupport` AND `minDistinctSessions` AND `minDistinctCauseCommits`, `FailureAnalyzer.ts:95-98`); closed loop on `InitiativeTracker` whose by-construction guarantee is a **property of injected capabilities** (`FailureLoopDriver.LoopDeps` carries only `addAction`/`createInitiative`, never proposal-minting). | **Architectural template, mirrored honestly.** `CorrectionLedger` mirrors `FailureLedger` (same prune-in-transaction, same `idx_*_dedupe` index, same `toApiView()` discipline). The diversity gate is also three-pronged here: `minSupport` AND `minDistinctDays` (restart-proof — NOT `minDistinctSessions`, which instar's frequent restarts inflate) AND a second orthogonal prong (`minDistinctTopics` for preferences, the cross-agent Rising Tide layer for infra-gaps). The authority guard is RE-PROVEN for this loop's two new capabilities — it does not inherit by claim. |
+| `FeedbackManager` (Rising Tide) | `src/core/FeedbackManager.ts`, `src/server/routes.ts:7720-7779` | Programmatic `submit()` forwards straight to the cross-agent webhook with **zero** call to `FeedbackAnomalyDetector`, `validateFeedbackQuality`, or the length caps — all of those live in the `POST /feedback` route handler. | **The infra-gap routing channel — through the route, not the manager.** The sentinel does NOT call `FeedbackManager.submit()` directly. It POSTs to its own server's `POST /feedback` endpoint (loopback, bearer-authed) so it traverses the real middleware (`feedbackLimiter`, `validateFeedbackQuality`, `feedbackAnomalyDetector.check/recordSubmission`, length caps) exactly like a human-driven submission. A wiring-integrity test asserts the loopback path refuses when `anomaly.check` returns blocked (§6). |
+| `LlmQueue` | `src/monitoring/LlmQueue.ts` | NOT a singleton, NOT instantiated at AgentServer level, has ONE shared `maxDailyCents` per instance (no per-feature sub-cap). Cap exhaustion / reserve breach / interactive preemption all *throw*. | **The sentinel owns its own instance**: `new LlmQueue({ maxConcurrent, maxDailyCents: cfg.llmDailyCents })`, constructed in the gated `try` block at `AgentServer.ts:653`. This makes the "dedicated 25¢ cap" real (it's per-sentinel, not fleet-global — the spec states this honestly). **Do NOT copy** the latent bug at `PresenceProxy.ts:709` (`new LlmQueue(number)` mis-passes an int where options are expected). The caller wraps every `enqueue()` in `try/catch` for the three throw paths (cap, reserve, `LlmAbortedError`) and **silently drops** the capture on any rejection — no retry, no backlog. |
+| **Preferences endpoint (Path A — built as sub-slice 1a)** | NEW: `.instar/preferences.json` + `GET /preferences/session-context` + session-start hook patch | Mirrors the existing **ORG-INTENT precedent**: `GET /intent/org/session-context` is fetched at session start and injected unconditionally into context. This loop adopts the same pattern for user preferences. A structured on-disk file holds the loop-recorded preferences; the endpoint serves them as a structured block; the session-start hook unconditionally fetches and injects them. **Structural injection by construction** — the agent does not "choose" to read; the hook reads on every boot. | **THE structural application surface for preference learning.** Path A was chosen after Round 2 verified that the previous-revision's "Playbook auto-add" approach (a) had no `add` subcommand in `playbook-manifest.py` on canonical main, and (b) was not read by the session-start hook — i.e., dead infrastructure for this purpose. Mirroring ORG-INTENT closes the loop end-to-end on a wiring pattern that already works. |
+| `FeedbackAnomalyDetector` | `src/monitoring/FeedbackAnomalyDetector.ts` | Rate/burst/daily caps — **only effective when the caller invokes it.** | Wired by going through the `/feedback` route, not by calling `submit()` directly (above). |
+| `InitiativeTracker` | `src/core/InitiativeTracker.ts` | Lineage spine; the failure loop registers + threads `origin` here. | Same. `origin: 'correction-preference-loop'` is **lineage/audit + InitiativeTracker self-exclusion only** — NOT the message-feed guard. The message-feed guard is `entry.fromUser` (entry-gated upstream). |
+
+**Verdict (own-feature-vs-extend): extend.** Genuinely new = (a) a *broadened, distinctly-tagged* Layer-0 signal family, (b) a privacy-safe ephemeral capture→distill→deterministic-scrub step, (c) `CorrectionLedger` (distilled, scrubbed records only), (d) a 3-pronged restart-proof recurrence gate, (e) the **routing split** (infra-gap → loopback `/feedback`; explicit preference → preferences-endpoint write (§3.6)), and (f) loop-closure verification on both paths.
+
+## 3. Design
+
+### 3.1 The pipeline — fail-open, async off the delivery path, code-determined provenance
+
+```
+inbound human message (telegram.onMessageLogged)
+   │
+   ▼  [Layer 0 — free, deterministic, SYNC, always-on classification]
+HumanAsDetectorLog.classify()  +  preference/frustration rules
+   │  (no signal → STOP at zero cost on the vast majority of messages)
+   │  (signal carries deterministic weight + matched-rule labels — the code-determined provenance)
+   ▼  [Layer 1 — VOID fire-and-forget; async hops never block delivery]
+captureAndDistill({ topicId, signal, deterministicWeight, ... })  ← off the delivery path
+   ├── per-topic look-back ring (capped at captureContextTurns, LRU-evicted at the topic-map level)
+   ├── PRE-SCRUB the captured turns with scrubSecrets() BEFORE leaving the process
+   └── enqueue(LlmQueue.background, distillFn, costCents)
+        │  rejection paths (cap | reserve | LlmAbortedError) → DROP + bump degraded counter
+        │  per-topic rateCeiling (≤8/60s) + shouldShed on quota=critical|stop
+        ▼  [Layer 2 — Tier-1 supervised distillation, untrusted-input hardened]
+        LLM returns { learning, kind: 'infra-gap'|'user-preference'|'noise', llm_confidence, scrubbed_summary }
+        │  kind is validated against an enum allow-list (LLM cannot widen)
+        │  llm_confidence is ADVISORY — never alone satisfies a gate
+        │  raw context discarded immediately
+        ▼  [Layer 3 — deterministic POST-SCRUB before persist]
+        scrubSecrets() re-applied to learning + scrubbed_summary in CODE (LLM scrub is best-effort recall reduction; regex is the guarantee)
+        ▼  [Layer 4 — CorrectionLedger, SQLite, dedupe-upsert]
+        record { kind, normalizedLearningHash, scrubbed_summary, deterministicWeight, llm_confidence, dayBucket, topicId, sessionId, ... }
+   │
+   ▼  [Layer 5 — CorrectionAnalyzer, weekly cron, NEVER on the hot path]
+3-pronged recurrence gate (§3.5) + code-determined provenance filter
+   │
+   ├── kind=infra-gap (+ gates pass) → POST /feedback (loopback, bearer-authed) → traverses anomaly/quality/length guards
+   └── kind=explicit-preference (+ gates pass) → preferences-endpoint write (§3.6) (structural session-start injection)
+                                                + parallel /learn proposal for human-reviewed durable memory
+   ▼  [Layer 6 — closed loop, dedupeKey-keyed]
+recurrence-after watcher: same dedupeKey reappears within verify window → reopen (capped, maxReopens=2);
+silence ≠ effective (stays inconclusive); user-stopped-correcting alone never marks "stuck"
+```
+
+### 3.2 Layer 0 — additive, distinctly-tagged signal extension
+
+The existing `HumanAsDetectorLog.classify()` is precision-biased and weight-thresholded; a lone weak signal never fires (line 147). The sentinel adds two **distinctly-tagged** signal families behind the same contract:
+
+- **`preference`** (new category) — "I prefer / I'd rather / please always / from now on / keep it / don't use".
+- **`frustration`** (new category) — "again?", "you keep", "every time", "I keep having to", "stop asking me".
+
+These categories are **tagged** as non-guardian-failure and **excluded** from `summarizeByLayer()` (the existing guardian-failure heat map) so the broadening cannot pollute its precision contract. A unit test pins this: counts in `summarizeByLayer()` are unchanged by preference/frustration traffic.
+
+**Layer-0 classification ships always-on** (it only grows the metadata heat map; ~zero cost). Only Layers 1–5 are flag-gated by `monitoring.correctionLearning.enabled`. The spec previously implied Layer 0 was gated; corrected.
+
+**Drift canary.** A small-budget periodic sampler sends a fraction of *un-classified* messages through the Layer-2 LLM with a "would this be a correction?" prompt; mismatches log a counter for review. Engages L5(b) (state-detection robustness): natural-language phrasing drifts; a fixed regex set will silently lose recall without this.
+
+### 3.3 Layer 1+2 — privacy-safe ephemeral capture, **both-sided** deterministic scrub, untrusted-input hardening
+
+To learn a lesson the LLM needs surrounding words. Round-1 review correctly flagged that "raw text never leaves the process" was misleading — it must cross to the LLM provider. The sentinel addresses the boundary on **three** axes:
+
+1. **Per-topic look-back ring**, hard-capped at `captureContextTurns` (drop-oldest on push), held in a `Map<topicId, Turn[]>` that is itself **LRU/TTL-evicted** (default 64 topics, 60-minute TTL idle). The ring is never serialized into `/health`, error reports, or any debug dump (asserted by an integration test that scans the `/health` response shape).
+2. **PRE-SCRUB on the way out.** Before captured turns are placed in the distillation prompt, `scrubSecrets()` (the deterministic regex from `CiFailurePoller.ts:192-198`, shared via a small module) is applied to each turn. The LLM provider therefore sees scrubbed-but-real conversation context — not raw secrets. This is the actual privacy boundary the spec previously elided.
+3. **POST-SCRUB on the way in.** The LLM's `learning` and `scrubbed_summary` are run through the SAME deterministic `scrubSecrets()` before they touch `CorrectionLedger`. LLM-trusted scrubbing is best-effort recall reduction; the regex pass is the guarantee.
+
+**Egress disclosure.** §4 and the ELI16 companion state plainly: the captured (scrubbed) context is sent to the configured LLM provider for distillation. If the operator's configured provider is unacceptable for this content, the loop is configured off — no hidden egress.
+
+**Prompt-injection hardening.** The distillation prompt:
+- Delimits the captured turns as untrusted data (clear `<user-input>…</user-input>` framing) and instructs the model never to follow instructions in that block.
+- Marks each turn with `fromUser: bool`. The model is instructed to derive the learning from a USER turn only — never from the agent's own concession/apology turns. (Test: a capture window of over-apology with no user signal yields no high-confidence preference.)
+- Returns a strict JSON envelope: `kind` validated against `{'infra-gap','user-preference','noise'}` (anything else → noise); `llm_confidence` accepted but treated as advisory (§3.5).
+
+### 3.4 Layer 4 — CorrectionLedger (mirrors FailureLedger, with corrections)
+
+Dedicated indexed SQLite store at `path.join(options.config.stateDir, 'correction-ledger.db')` (matches `failureLedger` base path; **not** `serverDataDir`). Schema mirrors `FailureLedger`:
+
+- `dedupeKey = kind : normalizedLearningHash`, where `normalizedLearningHash` is a SHA-256 over a canonical lowercased / whitespace-collapsed / stop-words-stripped form of the distilled learning. Stability of the hash is a unit-tested invariant (semantically-identical learnings collapse to one row even when phrased differently).
+- `correction_records` table (deduped; bounded by distinct-learning cardinality, NOT message volume).
+- `correction_occurrences` table (forensic; per-key bounded by `DEFAULT_MAX_OCCURRENCES_PER_KEY=200`, prune-in-transaction with the insert).
+- Indexes: `idx_corr_dedupe ON correction_occurrences(dedupe_key)` and `idx_corr_detected ON correction_records(detected_at)` — explicitly required, mirroring the failure ledger's `idx_occ_dedupe` (FailureLedger.ts:283).
+- Fields beyond the failure-ledger shape: `dayBucket` (UTC date, derived deterministically — not LLM-set), `deterministicWeight` (Layer-0 total weight, code-determined), `llm_confidence` (LLM-set, advisory).
+- `toApiView()` strips everything but `scrubbed_summary` + metadata (mirrors `FailureLedger.toApiView` discipline). The `/corrections` API never serves raw text under any condition.
+- `countRecords()` health metric so distinct-key growth is observable (defense against an LLM that produces unstable hashes).
+
+### 3.5 Layer 5 — CorrectionAnalyzer (three-pronged, restart-proof, code-determined provenance)
+
+The recurrence gate replaces the originally-asserted single-prong with a **three-pronged AND**, mirroring `FailureAnalyzer`'s real shape but with prongs appropriate to corrections:
+
+| Prong | Default | Why |
+|---|---|---|
+| `minSupport` | 4 occurrences | One bad day never a pattern. |
+| `minDistinctDays` | 3 (infra-gap) / 2 (explicit-preference, both high-confidence days) | **Restart-proof.** Instar restarts inflate session counts; calendar days don't. Replaces the original `minDistinctSessions`. |
+| **Second orthogonal prong** | `minDistinctTopics` ≥2 (preference path) **OR** cross-agent Rising Tide consensus ≥2 distinct *agents* (infra-gap path) | Two coincidences in one corner of the agent are still one coincidence. The infra-gap path's second prong is naturally cross-agent and *delegated* to the existing Rising Tide clustering (the spec relies on it explicitly, not by hand-wave). |
+
+**Code-determined provenance filter (poison resistance).** A record counts toward the recurrence gate ONLY when `deterministicWeight ≥ DETERMINISTIC_THRESHOLD` (Layer-0 regex hit at full confidence). `llm_confidence` is advisory and never alone admits a record — the spec's earlier "exclude inferred" wording is corrected: the gate keys on a CODE-determined field that an injected prompt cannot steer.
+
+**Cadence.** The analyzer runs as a weekly Tier-1 supervised cron job (`schedule: "0 9 * * 3"`, mirrors `failure-analyzer.md`), `enabled: false` template default. NEVER runs synchronously on `onMessageLogged` — the hot path does capture+distill+ledger-write only.
+
+**Two-layer consensus.** (1) Single-agent: the 3-pronged gate above. (2) Cross-agent: the existing Rising Tide `/feedback` clustering is the second consensus layer for infra-gaps. The sentinel does not build a new cross-agent layer; it feeds the one that exists.
+
+### 3.6 Layer 5 routing — the split, with both paths actually closed
+
+**`infra-gap` → loopback `POST /feedback`** (HTTP, bearer-authed, traversing the real route middleware). The route handler runs `feedbackLimiter` → `validateFeedbackQuality` → `feedbackAnomalyDetector.check` → length caps → `submit()` → `recordSubmission` — exactly like a human-driven submission. The `description` carries the scrubbed summary only, never the `learning` if it could contain user-quoted text. Default `autoFeedback: false` (propose-only: queues a tracked Evolution Action + the human posts it). Opt-in `autoFeedback: true` is bounded by the recurrence gate + the route guards; even opt-in, the cross-agent consensus (single-agent never auto-propagates to the fleet) is the additional check.
+
+A wiring-integrity test pins: the loopback path *refuses to POST* when `anomaly.check` returns blocked. Until that test exists, `autoFeedback` cannot ship at any default.
+
+**`explicit-preference` → preferences-endpoint write (Path A — THE structural closure of the loop).** When a learning crosses the gate AND was driven by an explicit-preference signal ("please always X", "from now on Y"), the loop calls `recordPreference(...)` (an in-process programmatic primitive) which atomically appends an entry to `.instar/preferences.json` with: the distilled and scrubbed `learning`, `provenance: correction-loop`, `dedupeKey`, `recordedAt`, `confidence`, and an isolation envelope tag. From that moment, every session-start hook fetches `GET /preferences/session-context` (which serves the structured block of active preferences, identical contract to `GET /intent/org/session-context`) and injects it into context unconditionally — **structural application, not willpower, by construction of the hook.** A parallel `/learn` proposal is queued for the human to convert into a durable `feedback_*` memory entry; that proposal is documentation, not the closing link.
+
+**Output content discipline (resolves Round-2 adversarial NEW-A + security NEW-1; honors Round-3 H4 / P2 "Signal vs Authority").** Before any explicit-preference reaches `recordPreference()`, a deterministic policy-keyword filter runs against the distilled learning: `\b(ignore|skip|bypass|disable|always allow|pre-authorize|pre-approved|no need to confirm|never (ask|prompt|gate))\b` paired with safety/policy nouns (`guard`, `gate`, `confirm`, `safety`, `coherence`, `block`, etc.). On match the loop **does NOT silently veto** (per P2: a regex never wields blocking authority on its own); it **downgrades the learning to the Attention queue** for one-tap user confirmation — the human disposes. Only learnings that pass the keyword check AND the recurrence gate AND the post-scrub flow through to `recordPreference()`. The session-start hook also wraps loop-sourced preferences in an `<auto-learned-preference src='correction-loop' confidence='…'>` envelope so downstream prompt assemblers structurally cannot mistake them for authoritative instructions. A wiring-integrity test pins both: a policy-keyword-matching learning routes to Attention (never to `recordPreference()`), AND the envelope appears in the injected block exactly once.
+
+**Inferred preferences** (the user did not explicitly state a rule but the loop infers one from frustration patterns) are NOT auto-recorded. They surface as a *candidate* awaiting one-tap user confirmation (Attention queue), preserving "humans dispose" on the lower-confidence path.
+
+**Multi-user gate.** Only corrections from the topic's primary user (identity layer) drive learning. A non-owner participant in a multi-user topic cannot shape the agent's behavior or its feedback to Dawn. Asserted by a unit test on the user-identity hook.
+
+### 3.7 Layer 6 — closed loop verification (in Slice 1 for the preference path)
+
+After a learning is applied (preferences-endpoint write via `recordPreference()`) or proposed (`/feedback`), the analyzer watches the same `dedupeKey` for `verifyWindowDaysPreference` (default 7) on the preference path or `verifyWindowDaysInfraGap` (default 14) on the infra-gap path:
+
+- **Recurrence-after-fix on the SAME `dedupeKey` → reopen** (capped at `maxReopens: 2`, then `inconclusive`). Keying on `dedupeKey` (not the coarse category) prevents false-reopen from an unrelated learning that matches the same broadened regex bucket.
+- **Silence alone ≠ effective.** The user simply not correcting again could mean they gave up. A learning is marked *verified* only when (a) within the verify window the `dedupeKey` did not recur AND (b) the `.instar/preferences.json` entry the loop wrote is still present (it was not human-deleted as wrong via the Attention queue or a manual edit). Otherwise the verdict is `inconclusive`.
+
+This closes the preference loop end-to-end in Slice 1: capture → preferences-endpoint write (§3.6) → structural session-start injection → behavior changes → recurrence-after stops, all observable on disk in `.instar/preferences.json` and the `correction_records` ledger. The acceptance fixture (§8) demonstrates it on the force-push nag.
+
+### 3.8 Authority guard — RE-PROVEN for the two new capabilities
+
+`FailureLoopDriver` (`FailureLoopDriver.ts:34-59`) is by-construction unable to mint `EvolutionProposal`s — its `LoopDeps` carries only `addAction` + `createInitiative`. **That guarantee is a property of the injected capability set, not a property this loop inherits by claim.** The correction loop introduces TWO NEW capabilities (`/feedback` loopback POST, preferences-endpoint write (§3.6)). The guarantee is re-proven:
+
+- The `CorrectionLoopDriver.LoopDeps` interface carries: `addAction`, `createInitiative`, `feedbackLoopbackPost`, `recordPreference`, `attentionRoute` (for policy-keyword-matched learnings, per §3.6). NO proposal-minting. NO direct write to `MEMORY.md` / CLAUDE.md / `feedback_*.md`. `recordPreference` is a typed in-process primitive that writes ONLY to `.instar/preferences.json` AND the integrated-being ledger's `preference`-kind entry (no other path is reachable from the driver), AND only after the policy-keyword filter (§3.6) and the deterministic post-scrub (§3.3) have passed. The `recordPreference` path is bounded to explicit-preference + gate-passed records only; inferred preferences and policy-keyword-matched learnings route through `attentionRoute` to a human disposition step.
+- `kind` is signal, never authority — it routes a proposal / preferences-endpoint write / Attention item, never blocks or mutates on its own.
+- Test: with `evolutionApprovalMode: 'autonomous'` ON, the loop mints ZERO `EvolutionProposal`s AND performs ZERO writes to memory files. The loopback-POST path is bounded by the route's anomaly + quality + length guards (§3.6); the `recordPreference()` path is bounded to explicit-preference + gate-passed records only (inferred preferences and policy-keyword-matched learnings route via `attentionRoute` to a human disposition step, never reaching `recordPreference()`).
+
+### 3.9 Boundaries (what this is NOT)
+
+- Not a sentiment tracker or "user mood" dashboard.
+- Not a real-time interrupt — it never blocks or rewrites an outbound message (that is `CoherenceGate`/`MessagingToneGate`'s job; this loop is signal-only and asynchronous).
+- Not a raw-conversation archive — raw text never persists, and is pre-scrubbed before egress.
+- Not an auto-editor of the agent's own memory files — `.instar/preferences.json` entries (via `recordPreference()`) are the *application surface*; durable memory `feedback_*` writes remain human-reviewed via a parallel `/learn` proposal that does not close the loop on its own.
+
+## 4. Lifecycle / rollback / privacy / multi-machine
+
+- **Ships dark.** `monitoring.correctionLearning.enabled = false` by default; every sub-channel (`autoFeedback`, `telegramDigest`, drift canary) independently off. Layer-0 classification (free, metadata-only, no behavior change) ships always-on.
+- **Rollback** = flip the flag; records stay inert; `.instar/preferences.json` entries added by the loop carry `provenance: correction-loop` for one-shot bulk removal (a single `jq`-style filter against the snapshot file + a paired ledger entry retraction).
+- **Privacy** = §3.3: raw text never persists; **pre-scrub** on egress to the LLM provider; **post-scrub** before persist; egress disclosed in-spec and in ELI16.
+- **Multi-machine** = machine-scoped IDs + fenced-lease discipline as other pollers; only the awake machine's sentinel runs.
+- **Multi-user** = primary-user gate; non-owner participants cannot shape behavior or feedback (§3.6).
+
+## 5. Open questions (resolved in-spec; reflagged here only for the convergence record)
+
+1. ~~Auto-`/feedback` default — propose-only vs. opt-in auto-submit.~~ **Resolved:** propose-only default; opt-in auto requires cross-agent consensus.
+2. ~~Preference application surface — session-start digest vs. Attention vs. both.~~ **Resolved:** preferences-endpoint write (§3.6) (structural injection); Attention item for inferred-preference candidates only.
+3. ~~`minDistinctSessions` value.~~ **Resolved:** the prong is `minDistinctDays` (restart-proof), default 3 for infra-gap, 2 for explicit-preference.
+4. ~~Layer-0 broadening — additive vs sibling.~~ **Resolved:** additive on the existing classifier, but new categories tagged + excluded from the guardian-failure heat map.
+
+Remaining for Justin (the only items requiring his call):
+- (a) Per-sentinel LLM daily cap default (spec proposes 25¢/day per agent — sized so it cannot starve PresenceProxy/Usher even on the bursty motivating scenario).
+- (b) `verifyWindowDays` default (spec proposes 14).
+
+## 6. Testing (3-tier, NON-NEGOTIABLE)
+
+- **Unit** — broadened classifier (both sides of every new rule + lone-weak-signal-never-fires); new categories excluded from `summarizeByLayer()`; `CorrectionLedger` dedupe/upsert/occurrence-retention prune-in-transaction/distinct-days count; analyzer 3-pronged gate (below vs at threshold; deterministic-provenance filter excludes LLM-only-confident records; LLM-confidence-alone-never-satisfies); routing split (explicit-preference vs inferred vs infra-gap vs noise); deterministic scrub on both sides (pre-scrub of input; post-scrub of output); prompt-injection input is never followed; over-apology window yields no high-confidence preference absent user signal; primary-user gate.
+- **Wiring integrity** — sentinel constructed iff `enabled`; deps non-null and real; `CorrectionLoopDriver.LoopDeps` carries no proposal-minting and no direct-memory-write (by-construction authority test, autonomy ON, ZERO proposals + ZERO memory writes); LLM-queue caller catches all three rejection paths (cap / reserve / `LlmAbortedError`) and drops silently with no retry; the `onMessageLogged` hook returns synchronously and a thrown distill error never propagates; loopback `/feedback` path REFUSES when `anomaly.check` is blocked.
+- **Integration** — `/corrections` GET requires bearer (401 without); POST requires `X-Instar-Request`; 503-when-disabled; `toApiView()` strips everything but `scrubbed_summary` (raw never leaks); `/health` does NOT serialize the ephemeral capture ring.
+- **E2E** — feature-alive (200 enabled / 503 off) via the production boot path; end-to-end raw-context-never-persisted assertion; **acceptance fixture (§8):** force-push nag reaches the gate, routes infra-gap, queues the `/feedback` proposal — observed on disk in `logs/correction-learning-audit.jsonl` with the documented decision tree.
+
+## 7. Migration parity (Migration Parity Standard, with the failure-loop gap not repeated)
+
+- **Config defaults** — add `correctionLearning` block to `src/config/ConfigDefaults.ts`. No per-feature `migrateConfig` block needed: `applyDefaults` already deep-merges with existence checks (verified at `PostUpdateMigrator.ts:~207`); adding to ConfigDefaults backfills existing agents automatically.
+- **`/corrections` routes** — INLINE in `src/server/routes.ts` (the discoverability-lint allowlist is fixed; a separate route module is invisible and trips the orphan-prefix check). `CAPABILITY_INDEX` entry mirroring `failureLearning` at `CapabilityIndex.ts:518`.
+- **`generateClaudeMd`** — capability section + proactive trigger ("when the user corrects you repeatedly → this loop is already watching") + Registry-First row.
+- **`migrateClaudeMd` — MAIN capability section.** Add a content-sniffed backfill block for *existing* agents. The Failure-Learning Loop only backfilled its sub-tab and left existing agents unaware of `/failures` itself — that gap is not repeated here.
+- **`upgrades/NEXT.md`** — required (3 sections: What Changed, What to Tell Your User, Summary of New Capabilities), to keep the `feature-delivery-completeness` test green.
+- **`upgrades/side-effects/correction-preference-learning-sentinel.md`** — seven-dimension review artifact (engages L6).
+- **Hook scripts (Path A, sub-slice 1a):** `.instar/hooks/instar/session-start.sh` is patched additively to fetch `GET /preferences/session-context` (mirrors the existing ORG-INTENT fetch) and emit the returned block inside the `<auto-learned-preference>` envelope. Built-in `instar/` hooks are always-overwrite on every migration (the documented post-`hook-event-reporter.js` lesson), so the patched hook propagates to every existing agent on the next instar update. No hand-written `migrateHooks` block needed.
+- **Preferences-endpoint state file** — `.instar/preferences.json` is created lazily by `recordPreference()` on first write; absent file ≡ no preferences. No migration needed.
+- **Built-in skills** — none added.
+- **Board self-registration** — frontmatter carries `ships-staged: true` + `rollout-flag-path` + `rollout-criteria` + `rollout-evidence-*` so the `FeatureRolloutReconciler` registers an active rollout card on merge (this was missing in the v1 draft).
+
+## 8. Success criteria
+
+- A correction Justin makes across 3 distinct calendar days surfaces as ONE actionable learning, correctly typed `infra-gap` vs `explicit-preference` vs `inferred-preference` vs `noise`, with zero raw text on disk and zero raw text reaching the LLM provider (pre-scrubbed).
+- **Acceptance fixture: the force-push nag from this session.** Detected by the broadened Layer 0; gated on `minDistinctDays`; classified `infra-gap`; routes a `/feedback` proposal whose `description` is the scrubbed summary; observed in `logs/correction-learning-audit.jsonl` with the documented decision tree.
+- **Preference-loop end-to-end closure (Slice 1) — NAMED acceptance fixture (Round-3 H3):** the recurring "no good stopping point" / "don't pause for context length" correction Justin has restated across multiple sessions (see `feedback_no_good_stopping_point_rationalization`, `feedback_session_length_is_irrelevant`, `feedback_no_pausing_for_context_or_length` in MEMORY.md) is the testable preference fixture. Acceptance: the loop catches one of those phrasings stated on two distinct calendar days, distills it into a learning whose `dedupeKey` is stable across phrasings, writes it to `.instar/preferences.json` via `recordPreference()` with `provenance: correction-loop`, the next session-start hook fetches `/preferences/session-context` and injects the envelope-wrapped block, and `dedupeKey` does NOT recur within `verifyWindowDaysPreference` (default 7); the analyzer then marks the learning `verified`. This is observable end-to-end on Echo's own corpus.
+- Ships dark; self-registers on the rollout board; all three test tiers green; the by-construction authority test confirms ZERO proposals + ZERO memory-file writes under autonomy.
+
+## 9. Config (all default safe/off, with the corrections from Round 1)
+
+```jsonc
+"monitoring": {
+  "correctionLearning": {
+    "enabled": false,
+    "minSupport": 4,
+    "minDistinctDaysInfraGap": 3,
+    "minDistinctDaysPreference": 2,
+    "minDistinctTopicsPreference": 2,
+    "autoFeedback": false,
+    "telegramDigest": false,
+    "driftCanary": false,
+    "llmDailyCents": 25,           // per-sentinel cap (own LlmQueue instance — not a fleet ceiling)
+    "llmMaxConcurrent": 1,
+    "captureContextTurns": 6,
+    "captureTopicMapMax": 64,
+    "captureTopicTtlMinutes": 60,
+    "distillPerTopicRatePerMinute": 8,
+    "verifyWindowDaysInfraGap": 14,
+    "verifyWindowDaysPreference": 7,
+    "maxInjectedPreferencesBytes": 4000,
+    "preferencesInjectionPriority": "recency*confidence*dedupeCount",
+    "maxReopens": 2
+  }
+}
+```
+
+## 10. Slice plan (Path A — preferences endpoint as prereq sub-slice; Slice 1 closes the loop end-to-end)
+
+- **Slice 1a — preferences-endpoint prereq (small, well-modeled on ORG-INTENT):**
+  - `.instar/preferences.json` structured-file substrate (atomic append, file lock, schema-versioned).
+  - `recordPreference(payload, opts)` programmatic primitive (the only writer; signature mirrors `recordOrgIntent`-style helpers).
+  - `GET /preferences/session-context` endpoint INLINE in `routes.ts`, gated on `monitoring.correctionLearning.enabled` returning the structured block (or `503` when off). Inline because the discoverability lint allowlist is fixed.
+  - `CapabilityIndex.ts` entry; Registry-First row in `generateClaudeMd`.
+  - **Session-start hook patch:** `.instar/hooks/instar/session-start.sh` adds an additional `curl` to `/preferences/session-context` (matching the existing `/topic/context/:id` and ORG-INTENT fetches) and emits the returned block inside the `<auto-learned-preference>` envelope. Migration parity: the hook is always-overwrite (the documented post-`hook-event-reporter.js` lesson), so the next instar update propagates the patched hook to every existing agent.
+  - 3-tier tests: the endpoint serves the recorded preferences as a structured block; the session-start hook output INCLUDES the block when preferences exist; the agent receives them at context injection time (E2E).
+  - Ships behind the same `monitoring.correctionLearning.enabled` flag as the loop — endpoint serves `503` when off; session-start hook tolerates 503 gracefully (no preferences block emitted). <!-- tracked: correction-preference-learning-sentinel -->
+- **Slice 1b — the sentinel loop using the prereq surface (closes the preference loop end-to-end):** broadened Layer-0 (tagged, heat-map-excluded) + per-topic ephemeral capture (with pre-scrub) + Tier-1 distillation in the sentinel's own LlmQueue + deterministic post-scrub + `CorrectionLedger` + 3-pronged restart-proof recurrence gate + output policy-keyword filter (§3.6) + routing split (loopback `/feedback` proposal; `recordPreference()` for explicit preferences) + closed-loop verify on the preference path + `/corrections` routes + capabilities + 3-tier tests + `NEXT.md` + side-effects review. Ships dark. <!-- tracked: correction-preference-learning-sentinel -->
+- **Slice 2 — dashboard read-surface ("Your preferences I've picked up", Dashboard Standard) + closed-loop verify on the infra-gap path (correlate `/feedback` proposal → Dawn ships fix → recurrence-after stops). + Round-3 non-blocker findings folded (drift canary sub-budget, loopback POST batching/retry, /corrections pagination, distinct-days index, per-tick add ceilings, audit-log convention).** <!-- tracked: correction-preference-learning-sentinel -->
+- **Slice 3 — opt-in auto-`/feedback` elevation (gated on Slice-1/2 trust + cross-agent consensus hardening).** <!-- tracked: correction-preference-learning-sentinel -->
+
+The Slice-1 *infra-gap* loop closes through the existing cross-org Rising Tide channel (Dawn ships the fix; the verify step in Slice 2 correlates the recurrence-after-stop). That is the *designed* terminal for cross-org fixes, not a deferral — explicit in §3.6/§3.7 so it is not mistaken for the Phase-2 anti-pattern.
+
+**Path A sequencing.** Slice 1a and Slice 1b can land in ONE PR (a single coherent feature) or as two adjacent PRs; the spec leaves that to the build step (the sub-slice split makes 1a independently testable and 1b mockable against the recorded surface). Slice 1a is the smaller, lower-risk piece; building it first makes 1b a strict consumer of an already-proven surface.
+
+## 11. Finding ledger (convergence rounds)
+
+### Round 1 (Phase 1 — all 5 internal reviewers + conformance gate attempt)
+
+Reviewers: security, scalability, adversarial, integration, lessons-aware. Conformance gate returned 200 on the first call but timed out on the structured re-fetch; per the skill's fail-open rule, the round proceeded with the mandatory lessons-aware reviewer carrying the constitutional check.
+
+**Material findings — all addressed in this revision:**
+
+| # | Severity | Reviewer | Concern | Resolution (where) |
+|---|---|---|---|---|
+| 1 | BLOCKER | lessons | Preference-application via "session-start digest the agent acts on" = willpower, not structure | §2 Playbook row; §3.6 explicit-preference → `instar playbook add`; §3.1 pipeline closes here |
+| 2 | BLOCKER | lessons | Slice 1 captures but closes no loop (Phase-2 anti-pattern) | §3.7 preference loop closes end-to-end in Slice 1; §10 explicit; §8 verify-criterion |
+| 3 | BLOCKER | integration | LlmQueue not at AgentServer level; not a singleton; PresenceProxy has a latent `new LlmQueue(number)` bug | §2 LlmQueue row; sentinel owns its instance with object opts; spec states per-sentinel cap honestly |
+| 4 | HIGH | security/adversarial | Auto-`/feedback` via `submit()` bypasses route guards | §2 FeedbackManager row; §3.6 loopback POST through the real route; wiring-integrity test |
+| 5 | HIGH | security/adversarial | Scrub delegated to LLM; raw text crosses to provider; "discarded here" misleading | §3.3 PRE-scrub before egress + POST-scrub before persist (deterministic regex both sides); §4 egress disclosure |
+| 6 | HIGH | security | Prompt-injection into distillation; LLM `kind`/`confidence` drives cross-agent routing | §3.3 untrusted-data delimiting + enum-validated `kind` + advisory-only `llm_confidence`; §3.5 deterministic-provenance filter |
+| 7 | HIGH | scalability | `llmDailyCents=25` "dedicated cap" doesn't exist in shared queue | Resolved by #3: own LlmQueue → dedicated cap is real (per-sentinel, stated honestly) |
+| 8 | HIGH | scalability | Cap exhaustion *throws*; pipeline must catch all 3 paths | §3.1 caller try/catch (cap, reserve, `LlmAbortedError`) → drop, no retry |
+| 9 | HIGH | scalability | Async pipeline on sync fail-open seam regresses message-handling safety | §3.1 VOID fire-and-forget hook; classify() sync; distill off the delivery path; wiring-integrity test |
+| 10 | HIGH | scalability | Broadened signals high-frequency → no per-topic distill rate ceiling | §3.1 per-topic `rateCeiling` (≤8/60s) + `shouldShed` on quota=critical/stop, copying the capture-loop pattern |
+| 11 | HIGH | adversarial | "Mirrors diversity gate exactly" is false — real gate is 3-pronged | §3.5 3-pronged gate adapted (`minSupport` AND `minDistinctDays` AND second orthogonal prong) |
+| 12 | HIGH | adversarial | By-construction authority guard not auto-inherited for 2 new capabilities | §3.8 re-proven; `LoopDeps` documented; test = zero proposals + zero memory writes |
+| 13 | HIGH | adversarial | "Session" undefined; restarts inflate it; `minDistinctSessions=2` = one quirk counted twice | §3.5 prong is `minDistinctDays` (restart-proof); §9 config |
+| 14 | HIGH | integration | Board self-registration won't fire — frontmatter missing rollout fields | Frontmatter now carries `ships-staged`/`rollout-flag-path`/`rollout-criteria`/`rollout-evidence-*` |
+| 15 | MEDIUM | security/adversarial | `inferred` exclusion conflates LLM `confidence` with code-determined `attribution` | §3.5 deterministic-provenance filter (Layer-0 weight ≥ threshold) is the gate field |
+| 16 | MEDIUM | adversarial | Self-feed guard is `entry.fromUser` (real), not `origin` threading; 6-turn window includes agent's own concession | §3.3 turns marked `fromUser`; learning derived from user turn only; over-apology test |
+| 17 | MEDIUM | adversarial | Misclassification asymmetry; preference path not human-gated in v1 | §3.6 explicit → preferences-endpoint write (§3.6); inferred → Attention candidate (one-tap user confirm) |
+| 18 | MEDIUM | adversarial | Closed-loop false-stuck / false-reopen | §3.7 key on `dedupeKey` (not coarse category); silence ≠ effective; `maxReopens=2` |
+| 19 | MEDIUM | adversarial | Layer-0 broadening pollutes the guardian-failure heat map | §3.2 new categories tagged + excluded from `summarizeByLayer()` (test pins it) |
+| 20 | MEDIUM | integration | Ledger DB base path — use `config.stateDir` not `serverDataDir` | §3.4 corrected |
+| 21 | MEDIUM | integration | `migrateClaudeMd` must include MAIN capability section (failure loop only backfilled sub-tab) | §7 explicit |
+| 22 | MEDIUM | scalability | Ephemeral ring per-topic bound + topic-map LRU/TTL eviction unspecified | §3.3 per-topic capped + topic-map LRU/TTL + integration test on `/health` |
+| 23 | MEDIUM | scalability | Recurrence query — require index + state which path | §3.4 `idx_corr_dedupe` + `idx_corr_detected` explicit |
+| 24 | MEDIUM | lessons | Declare LLM supervision tier | Frontmatter `supervision: tier1` + §3.1 Layer 2 labeled |
+| 25 | MEDIUM | lessons | ELI16 + NEXT.md + near-silent classification + Dashboard Standard for Slice-2 tab | ELI16 exists (`.eli16.md`); §7 NEXT.md; §3.6 near-silent classification (propose-only is FYI not action-required → pull surface only); Slice-2 tab renamed "Your preferences I've picked up" + Dashboard Standard commitment |
+| 26 | MEDIUM | lessons | Drift canary on broadened Layer-0 regex | §3.2 sampler + counter |
+| 27 | LOW | security/adversarial/integration | bearer/X-Instar-Request inheritance; preview not surfaced over HTTP; reopen keys on dedupeKey; Layer-0 rules ship always-on; config migration free via applyDefaults; add NEXT.md; LLM `confidence` field exists in ledger | Batched — §6 integration tests; §7 explicit |
+
+### Round 2 — NOT CONVERGED. Two BLOCKERs collapse the Slice-1 closure claim.
+
+Four of five internal reviewers returned (security, scalability, adversarial, integration); the lessons-aware reviewer errored on the round and needs a re-spawn before formal convergence can be claimed. The four returned reviewers each confirmed all Round-1 findings as RESOLVED, then surfaced new material concerns. The most important — two **BLOCKERs**, independently verified by two reviewers against canonical `JKHeadley/main`:
+
+| # | Severity | Reviewer | Concern | What this means |
+|---|---|---|---|---|
+| R2-A | **BLOCKER (verified against JKHeadley/main)** | integration + scalability NEW-5(3) | `instar playbook add` is broken at the Python layer — `playbook-manifest.py` (main `JKHeadley/main`) handles only `init|list|get|stats|sign`; there is NO `add` subcommand handler. Any call falls through to `Unknown command: add` exit 1. The TS `PlaybookAddOptions` also has no `triggers`/`provenance` fields. | The "Playbook auto-add" surface that this revision (v2, pre-Path-A pivot) named as **THE blocker resolution** for Round-1 A1 (willpower-vs-structure) does not exist in the shipped codebase. The Round-1 fix was based on a false wiring assumption. |
+| R2-B | **BLOCKER (verified against the agent's actual hook)** | integration | `.instar/hooks/instar/session-start.sh` does NOT read the Playbook manifest. `grep -rn "playbook" .instar/hooks/` is empty. `playbookAssemble` exists as a CLI but is wired only into the user-facing CLI — no hook, no scaffold template, no auto-injection at session start. | Even hypothetically fixing R2-A, the spec's "session-start injection of the auto-added Playbook item" pipeline does not exist. The Playbook is, for session-start purposes, dead infrastructure. |
+
+**Implication.** Slice 1 as currently specified CANNOT honestly claim "closes the preference loop end-to-end." The structural application surface the spec relies on is the same shape of "ships as dead code" failure recorded for the fresh-session stop-gate and ArcCheck Layer 3 (see `feedback_*` memory). The lessons-aware reviewer (whose re-spawn is pending) would flag this as the EXACT same Phase-2 anti-pattern that drove their Round-1 B1 blocker — the fix would not have resolved B1, only relocated it.
+
+**Decision required (handed back to the user, per /spec-converge Phase 6).** Three viable paths; the spec cannot proceed past Round 2 without Justin's direction:
+
+- **Path A — Build the missing infrastructure first.** Treat "user-preferences as a structural session-start surface" as a prerequisite project, following the **ORG-INTENT precedent** (`GET /intent/org/session-context` IS wired structurally into the session-start hook). Implement an analogous `GET /preferences/session-context` + a structured-on-disk preferences file + a session-start hook patch. The correction-sentinel loop then writes to that surface. More work this slice, real loop closure.
+- **Path B — Downgrade Slice 1 to "capture + one-tap confirm."** Explicit preferences route to the Attention queue with one-tap user confirm to apply; the structural always-injected surface moves to Slice 2 after the user-preferences endpoint exists. Requires `principal-deferral-approval: true` from Justin in the spec frontmatter (P10 deferral discipline). Honestly framed as Phase-2 for the structural close.
+- **Path C — Swap the application surface for AGENT.md / CLAUDE.md regeneration via `generateClaudeMd`** (already wired into session-start as a static read). Pros: existing structural read. Cons: AGENT.md is the agent's identity surface (semantically wrong for user preferences); CLAUDE.md is template-regenerated (rewriting it from a loop has its own authority-guard concerns).
+
+Round 2 also surfaced the following non-blocker NEW material findings to fold into Round 3 (after path is chosen):
+
+- security NEW-1: preferences-endpoint write (§3.6) content-discipline at the injection boundary (envelope + policy-keyword filter on the OUTPUT learning, not just the input).
+- security NEW-2: loopback `/feedback` POST bearer-injection seam — point at the existing `makeAttentionPoster` precedent (`src/monitoring/sentinelWiring.ts:48-80`); use a distinct `correction-loop@<agent>` pseudonym and `X-Instar-Origin: correction-loop` header; mask Authorization in logs.
+- security NEW-3 / adversarial NEW-E: `scrubSecrets()` coverage gap — extend the regex set to cover Telegram bot tokens, AWS access keys, Slack tokens, URLs with embedded credentials, GitHub PATs; pin a regression fixture for hash stability.
+- adversarial NEW-A (HIGH): explicit-preference auto-add is a semantic-instruction-injection surface ("from now on, skip the safety-guard confirmation"). Mitigations: output-content review (block policy-modifying phrasing); Attention-route for any policy-relaxation patterns; isolation envelope at session-start.
+- security/integration NEW-4 (multi-user gate) and adversarial NEW-B: "primary user" has no implementation primitive in the code. Either define `UserManager.resolvePrimaryUserForTopic(topicId)` with fail-CLOSED semantics, or scope Slice 1 to single-user agents and add the multi-user gate as a deployment precondition.
+- scalability NEW-1: drift canary needs its own budget / sub-reserve to avoid starving the main path's 25¢ cap.
+- scalability NEW-2: loopback POST shares the route's 10/min IP rate limit — batch multiple converged learnings into ONE POST, OR serialize with 7s+ delay, OR catch 429 and re-try on next weekly run.
+- scalability NEW-3: `/corrections` GET pagination (default `limit=100`, `?cursor=` or `?since=detectedAt`).
+- scalability NEW-4: `minDistinctDays` query — add `idx_corr_dedupe_day ON correction_occurrences(dedupe_key, day_bucket)` OR explicitly state the JS-Set path bounded by `DEFAULT_MAX_OCCURRENCES_PER_KEY`.
+- scalability NEW-5: per-tick `playbookAutoAddPerTickMax` (e.g. 5) and total `maxActiveCorrectionLoopPlaybookItems` (e.g. 30) ceilings — overflow logged + skipped.
+- integration D: audit-log filename — either join the existing `logs/sentinel-events.jsonl` convention with a `kind=correction-loop` filter, OR explicitly justify the dedicated `logs/correction-learning-audit.jsonl` file.
+- integration E: shared `LlmQueue` precedent at `src/commands/server.ts:6147-6162` — explicitly state the divergence is deliberate (per-feature cap is the value the shared queue cannot provide).
+
+### Path A chosen by Justin (topic 13201, 2026-05-28, "Yes, a please proceed"). R2-A / R2-B resolution:
+
+- **R2-A (Playbook `add` broken on canonical main) — NO LONGER APPLICABLE under Path A.** The spec no longer depends on `instar playbook add`. Verification owed at Slice-1a acceptance: the analogous preferences-endpoint surface (`recordPreference()` + `GET /preferences/session-context` + session-start hook patch) is itself ALIVE end-to-end. The Playbook `add` bug remains a Playbook-level concern, out of scope here.
+- **R2-B (session-start hook does not read the Playbook) — NO LONGER APPLICABLE under Path A.** The spec instead patches the hook to fetch `/preferences/session-context`, mirroring the **verified-against-canonical-main** ORG-INTENT structural pattern: `PostUpdateMigrator.getSessionStartHook()` (`src/core/PostUpdateMigrator.ts:~4888-5008`) generates the hook with an unconditional `curl … /intent/org/session-context`, and `PostUpdateMigrator.ts:~1701` writes it via always-overwrite — existing agents pick up any patch on the next instar update with zero operator action. The Path-A patch follows the same generator-as-source-of-truth path. (Round-3 verified this against canonical `JKHeadley/main`; a naive `grep` of the on-disk hook file alone — the methodology that surfaced R2-B in Round 2 — would have given the same false-negative for the existing ORG-INTENT pattern, so the verification methodology is now generator-first, not on-disk-first.)
+- **Round-3 lessons-aware findings folded (HIGH):** H1 reworded above (RESOLVED → NO LONGER APPLICABLE + Slice-1a verification owed); H3 named preference-path acceptance fixture (§8: the "no good stopping point" recurring correction across MEMORY entries); H4 policy-keyword filter downgraded from "silent block" to "Attention-route" per P2 (§3.6 rewritten); H2 explicit Slice-1a artifact engagement: Slice 1a satisfies P4 (3-tier including the feature-alive E2E for `/preferences/session-context`), L6 (seven-dimension side-effects entry covering the new endpoint + on-disk file + hook patch), L9 (combined ELI16 covering both 1a and 1b surfaces if shipped together, separate paragraph if standalone), L10 (NEXT.md section for the new endpoint regardless of PR sequencing). Stale "Playbook auto-add" text scrubbed across §1, §2 verdict, §3.7.
+- **Round-3 MEDIUM findings folded:** M1 — `migrateClaudeMd` backfills BOTH `/corrections` and a "Preferences I've learned about you" section explaining the `<auto-learned-preference>` envelope; M2 — injected-preferences block bounded by `maxInjectedPreferencesBytes` (default 4000), priority-ordered by recency × confidence × dedupe-count; M3 — `.instar/preferences.json` is the snapshot/derived view, with the integrated-being ledger carrying the canonical `preference`-kind entry (mirrors `commitment` kind); M4 — generator-as-source-of-truth verification methodology documented in §7.
+- **Spec body updated:** §2 row replaced (Playbook → Preferences endpoint, sub-slice 1a anchor); §3.6 routing rewritten (`recordPreference()` + endpoint + content-discipline filter that routes to Attention, not silent block); §3.8 LoopDeps swapped (`playbookAdd` → `recordPreference`); §10 slice plan restructured (sub-slice 1a then 1b); §8 named preference-path acceptance fixture; §9 split `verifyWindowDays` into infra-gap (14) and preference (7).
+
+### Round 4 — NOT CONVERGED on first pass; three NEW findings folded into v5
+
+Round 3 lessons-aware reviewer cleared all H1-H4 + M1-M4 folds as **CONVERGED** with quoted resolutions (in Round 4's verification pass) and verified that all three named `feedback_*` memory files exist, the Attention queue is genuinely human-disposable, and §10 Slice-1a/1b sequencing doesn't conflate independent acceptance with the rollout-criteria. Three new material findings surfaced — all contained, all folded in v5:
+
+- **N1 (HIGH) — `amends-spec` frontmatter is a forward-reference to an unbuilt reconciler.** Same "ships-as-dead-frontmatter" shape as R2's BLOCKERs. Verified: `InitiativeTracker.ts` and `featureRolloutScan.ts` do not read the field today; Slice 4 of the failure-learning ingestion-sources spec ships the reconciler. v5 resolution: kept the field as a **documentary forward-reference**, added a new sibling key `amends-spec-status: documentary-pending-reconciler` to the frontmatter, and tracked the wiring as an open dependency on `failure-learning-ingestion-sources` Slice 4. Field will become structurally honored when that reconciler ships; until then it is intent, not authority.
+- **N2 (MEDIUM) — Stale "Playbook" application-surface language in §3.7/§3.8/§3.9/§4.** The R3 scrub claim was overstated. v5 resolution: completed the scrub — §3.7 references `recordPreference()` + `.instar/preferences.json` + the split `verifyWindowDays*`; §3.8 LoopDeps updated to include `attentionRoute` for policy-keyword-matched learnings; §3.9 boundary clarified (preferences-endpoint is the application surface, `/learn` is documentation); §4 rollback discipline references `.instar/preferences.json` snapshot + paired ledger retraction.
+- **N3 (LOW) — `maxInjectedPreferencesBytes` (M2) was in §11 prose but absent from §9 config table.** v5 resolution: added `maxInjectedPreferencesBytes: 4000` and `preferencesInjectionPriority: "recency*confidence*dedupeCount"` to §9 under `monitoring.correctionLearning`.
+
+### Round 5 — pending. Focused re-verification of the three v5 folds (especially the amends-spec disclosure, since N1 was the same shape as R2's BLOCKERs). On convergence, write the `review-convergence` tag via `skills/spec-converge/scripts/write-convergence-tag.mjs` and hand off ELI16 + this ledger to Justin for `approved: true`.
+

--- a/docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md
+++ b/docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md
@@ -5,7 +5,10 @@ initiative: correction-preference-learning-sentinel
 author: echo
 created: 2026-05-28
 topic: 13201
-approved: false
+approved: true
+approved-by: justin
+approved-at: 2026-05-30
+approval-note: "Approved by Justin (topic 16847, 2026-05-30) with explicit signal-only constraint — the outbound-blocking EnforcementGate idea is REJECTED (breaks signal-vs-authority P2; 'bitten before by guards that block messages having too much power'). The 'stored-but-violated' gap is to be closed later via self-violation-as-learning-signal, never a block."
 ships-staged: true
 rollout-flag-path: monitoring.correctionLearning.enabled
 rollout-criteria: "≥3 distinct-day recurring learnings correctly routed (≥2 infra-gap → /feedback proposal, ≥1 explicit-preference → preferences-endpoint write that the session-start hook actually reads and injects) over a 4-week observation window with zero raw-text persistence and zero by-construction guard violations"

--- a/docs/specs/reports/correction-preference-learning-sentinel-convergence.md
+++ b/docs/specs/reports/correction-preference-learning-sentinel-convergence.md
@@ -1,0 +1,91 @@
+# Convergence Report — Correction & Preference Learning Sentinel
+
+**Spec:** `docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md` (v5.1)
+**ELI16 overview:** `docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.eli16.md`
+**Iterations:** 5
+**Final round:** Round 5, no new material findings
+**Convergence verdict:** **CONVERGED** — ready for user sign-off (`approved: true`).
+
+## ELI10 Overview
+
+This is the conversational twin of the failure-learning loop we shipped earlier today (which learns from CODE that broke). The new loop learns from MOMENTS THE USER HAD TO CORRECT THE AGENT. The idea: every time you say "no, plainer," "stop asking me that," or "actually, that's wrong," that's a free signal about either (a) something Instar itself is doing clumsily, or (b) just how you like things. Today those corrections help only the conversation they happen in. After this ships, the loop captures the pattern, distills the lesson, and routes it: if it's an Instar bug, it queues a `/feedback` proposal to Dawn; if it's a personal preference (and you stated it explicitly), it writes the preference to a new always-injected surface so every future session picks it up automatically.
+
+The big change between the first draft and the final version is structural: in v2 the loop was going to "auto-add to the Playbook" — but mid-review we discovered the Playbook's `add` command was actually broken at the Python layer AND the session-start hook didn't read the Playbook at all. So the closure mechanism was dead infrastructure. v3 onward pivoted to **Path A**: build a small new preferences endpoint that mirrors the working ORG-INTENT pattern (which IS unconditionally fetched at session start). The cost was one extra small sub-slice; the gain was a closure mechanism that actually works.
+
+The other big tightening was security: the policy-keyword filter that catches injection-shaped explicit preferences ("from now on, ignore the safety guard") was originally going to silently block. The convergence review pointed out that's a brittle regex wielding authority — violates our signal-vs-authority rule. Fixed to route those to the Attention queue for one-tap user disposition instead.
+
+## Original vs Converged (what review actually changed)
+
+| Surface | v1 said | Converged said | Why |
+|---|---|---|---|
+| Where preferences get applied | Session-start digest the agent reads | Playbook auto-add (v2) → preferences-endpoint write (v3+) | v1 was willpower; v2's Playbook was dead infra; v3+ mirrors the working ORG-INTENT pattern |
+| LLM cap | "Dedicated 25¢/day" via shared LlmQueue | Sentinel owns its own LlmQueue instance | The shared queue has no per-feature sub-cap; "dedicated cap" wasn't enforceable as v1 claimed |
+| Auto-/feedback path | `FeedbackManager.submit()` direct | Loopback POST to own `/feedback` route | `submit()` bypasses anomaly/quality/length guards; only the route runs them |
+| Scrubbing | LLM-trusted scrub of the summary | Deterministic `scrubSecrets()` on BOTH sides of the LLM call (pre-egress + post-persist) | LLMs do echo secrets they read; the regex pass is the actual guarantee |
+| Recurrence gate | Single-prong `minDistinctSessions` | Three-pronged AND (`minSupport` + `minDistinctDays` + second orthogonal prong) | Instar restarts inflate session counts; calendar days are restart-proof |
+| Policy-keyword filter | Silent block | Route to Attention queue (human disposes) | Brittle regex never wields blocking authority alone (P2: Signal vs Authority) |
+| Authority guard | "Inherited from failure loop" | Re-proven for the two new capabilities (loopback POST + recordPreference) | The guarantee is a property of the injected capability set, not a property the spec inherits by claim |
+| Hot-path execution | Async hop on the message-delivery seam | Void fire-and-forget; classify() sync; distill off the delivery path | Fail-open of `HumanAsDetectorLog` would regress otherwise |
+| Acceptance fixture | Abstract "an explicit preference Justin states" | Specific: the recurring "no good stopping point" / "no pausing for context length" corrections from the agent's own MEMORY.md | Reproducibility on the agent's own corpus |
+
+## Iteration summary
+
+| Round | Reviewers | Material findings | What changed |
+|---|---|---|---|
+| 1 | 5 internal (security, scalability, adversarial, integration, lessons-aware) + Standards Conformance Gate (slow timeout — log-only per skill's fail-open) | 27 (4 blocker, 11 high, 8 medium, 4 low) | v2 — comprehensive rewrite folding all 27 |
+| 2 | 4 internal (lessons-aware errored at socket level) | 2 BLOCKERs (Playbook `add` dead + session-start hook doesn't read it) + 10 additional non-blocker | Handed back to Justin for path decision (A/B/C). Path A chosen. |
+| 3 | 1 (lessons-aware re-spawn — mandatory after R2 error) | 4 HIGH (preference-application willpower, supervision tier, Phase-2 anti-pattern, ELI16/NEXT.md) + 4 MEDIUM | v3 — Path-A pivot (preferences endpoint mirroring ORG-INTENT) + v4 — folded 4 HIGH + 4 MEDIUM |
+| 4 | 1 (lessons-aware convergence-check) | 3 (1 HIGH, 1 MEDIUM, 1 LOW) | v5 — folded N1 (amends-spec as documentary-pending-reconciler), N2 (Playbook scrub completion in §3.7/§3.8/§3.9/§4), N3 (config table addition) |
+| 5 | 1 (lessons-aware final check) | 0 new; N2 fold incomplete (2 stale §3.8 lines) | v5.1 — completed N2 fold |
+
+**Convergence:** Round 5 with v5.1 — N1, N2, N3 all CONVERGED, no new material findings.
+
+## Full findings catalog
+
+(Material findings only; cosmetic and resolved-pre-spec items omitted. Severities: B=blocker, H=high, M=medium, L=low.)
+
+### Round 1 (27 material)
+
+- **Security** F1-F4 (HIGH): auto-/feedback bypasses route guards; LLM-trusted scrub leaks; prompt-injection drives cross-agent routing; egress to LLM provider unaddressed. F5-F10 medium/low.
+- **Scalability** F1-F4 (HIGH): dedicated LLM cap doesn't exist; cap exhaustion throws; async on sync seam; hot-path LLM amplification. F5-F8 medium/low.
+- **Adversarial** F1-F4 (HIGH): "mirrors diversity gate exactly" is false; FeedbackAnomalyDetector not wired into submit(); by-construction guard not inherited; session-inflation by restarts. F5-F11 medium/low.
+- **Integration** F1 (BLOCKER): LlmQueue not at AgentServer / not singleton. F5 (HIGH): board self-registration won't fire (frontmatter missing). F2b-F8 medium/low.
+- **Lessons-aware** A1+B1 (BLOCKER): preference application is willpower / Phase-2 anti-pattern. A2 (HIGH): supervision tier. B2-B4 medium/low.
+
+All folded in v2.
+
+### Round 2 (2 BLOCKERs + 10 non-blocker)
+
+- **R2-A (BLOCKER):** Playbook `add` broken on canonical main.
+- **R2-B (BLOCKER):** Session-start hook does not read the Playbook.
+- 10 non-blocker findings logged for Round 3+.
+
+Handed back to Justin for path decision. Justin chose **Path A** (build preferences endpoint mirroring ORG-INTENT).
+
+### Round 3 (4 HIGH + 4 MEDIUM + 2 LOW)
+
+- H1 (HIGH): §11 "RESOLVED" overstated.
+- H2 (HIGH): Slice 1a artifact engagement.
+- H3 (HIGH): Named preference-path fixture.
+- H4 (HIGH): Policy-keyword filter must Attention-route, not silent-block (P2).
+- M1-M4 (MEDIUM): migrateClaudeMd coverage; injected-preferences budget; IB-ledger preference kind; generator-as-source-of-truth methodology.
+- L1-L2 (LOW): stale text; verifyWindowDays split.
+
+All folded in v4.
+
+### Round 4 (1 HIGH + 1 MEDIUM + 1 LOW)
+
+- N1 (HIGH): `amends-spec` was forward-reference to unbuilt reconciler.
+- N2 (MEDIUM): R3 Playbook scrub was incomplete (6 stale references).
+- N3 (LOW): `maxInjectedPreferencesBytes` missing from §9 config.
+
+Folded in v5.
+
+### Round 5 (0 new + completion of N2 fold)
+
+- N2 fold was incomplete in v5 (2 stale §3.8 lines + duplicated sentence). Folded in v5.1.
+- No new material findings.
+
+## Convergence verdict
+
+**CONVERGED at iteration 5 (v5.1).** No material findings in the final round. All BLOCKERs from Rounds 1-2 are resolved (or, in the case of R2-A/R2-B, NO LONGER APPLICABLE under Path A with the analogous ORG-INTENT-pattern surface verified against canonical main). The spec is ready for `approved: true` and ELI16 handoff to the user. After approval, `/instar-dev` can proceed on `Slice 1a` (preferences endpoint + session-start hook patch) and `Slice 1b` (the sentinel loop using that surface).

--- a/src/config/ConfigDefaults.ts
+++ b/src/config/ConfigDefaults.ts
@@ -120,6 +120,35 @@ const SHARED_DEFAULTS: Record<string, unknown> = {
         ciMaxRunsPerTick: 50,
       },
     },
+    // Correction & Preference Learning Sentinel
+    // (docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md §9). Ships OFF.
+    // SIGNAL-ONLY — never blocks/rewrites an outbound message. Slice 1a wires the
+    // preferences read-surface (GET /preferences/session-context → 503 when off);
+    // Slice 1b adds the capture→distill→ledger→recurrence loop. applyDefaults
+    // deep-merges this into existing agents without surprise activation (no
+    // separate migrateConfig block needed — verified deep-merge at
+    // ConfigDefaults.deepMerge + applyDefaults add-missing recursion).
+    correctionLearning: {
+      enabled: false,
+      minSupport: 4,
+      minDistinctDaysInfraGap: 3,
+      minDistinctDaysPreference: 2,
+      minDistinctTopicsPreference: 2,
+      autoFeedback: false,
+      telegramDigest: false,
+      driftCanary: false,
+      llmDailyCents: 25,
+      llmMaxConcurrent: 1,
+      captureContextTurns: 6,
+      captureTopicMapMax: 64,
+      captureTopicTtlMinutes: 60,
+      distillPerTopicRatePerMinute: 8,
+      verifyWindowDaysInfraGap: 14,
+      verifyWindowDaysPreference: 7,
+      maxInjectedPreferencesBytes: 4000,
+      preferencesInjectionPriority: 'recency*confidence*dedupeCount',
+      maxReopens: 2,
+    },
     // ReleaseReadinessSentinel (docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md
     // §4.2). Ships OFF — Echo dogfoods first. Repo-gated: inert unless the
     // install has an analyzable instar git repo. Thresholds default to

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2911,7 +2911,7 @@ If the user reports they were "unresponsive for a while during updates," check \
     // The Failure-Learning Loop only backfilled its sub-tab and left existing
     // agents unaware of the main capability — that gap is not repeated here.
     // Content-sniffed on a distinctive marker for idempotency.
-    if (!content.includes('Preferences I’ve learned about you') && !content.includes("Preferences I've learned about you")) {
+    if (!content.includes('Correction & Preference Learning Sentinel')) {
       const prefsSection = `
 ## Preferences I've learned about you (Correction & Preference Learning Sentinel)
 
@@ -3680,6 +3680,7 @@ Create worktrees for collaborator repos with \`instar worktree create <branch>\`
       '## Worktree Convention',
       '**Multi-Session Autonomy**',
       '**Process Health (Dashboard Tab)**',
+      "**Preferences I've learned about you**",
     ];
 
     for (const shadowName of ['AGENTS.md', 'GEMINI.md']) {

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -5180,6 +5180,35 @@ except Exception:
   fi
 fi
 
+# AUTO-LEARNED PREFERENCES injection — Correction & Preference Learning Sentinel
+# (Slice 1a). Fetches /preferences/session-context and injects the structured
+# block of preferences the correction loop has learned about this user, so the
+# agent reasons with them from message one. SIGNAL-ONLY — these are preferences,
+# not authoritative instructions; the server wraps them in an
+# <auto-learned-preference src='correction-loop'> envelope so they cannot be
+# mistaken for commands. Fail-open: route 503 (feature off) / unreachable /
+# empty block → silent skip, session continues normally.
+if [ -n "\$PORT" ] && [ -n "\$TOKEN" ]; then
+  PREFS_RESPONSE=\$(curl -sf --max-time 4 -H "Authorization: Bearer \$TOKEN" \\
+    "http://localhost:\${PORT}/preferences/session-context" 2>/dev/null)
+  if [ -n "\$PREFS_RESPONSE" ]; then
+    PREFS_BLOCK=\$(echo "\$PREFS_RESPONSE" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if d.get('present') and d.get('block'):
+        print(d['block'])
+except Exception:
+    pass
+" 2>/dev/null)
+    if [ -n "\$PREFS_BLOCK" ]; then
+      echo ""
+      echo "\$PREFS_BLOCK"
+      echo ""
+    fi
+  fi
+fi
+
 # BEGIN integrated-being-v2
 # INTEGRATED-BEING V2 — session-write binding (see docs/specs/integrated-being-ledger-v2.md §3)
 # Generates a session UUID, registers with /shared-state/session-bind, writes the

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -2903,6 +2903,33 @@ If the user reports they were "unresponsive for a while during updates," check \
       result.skipped.push('CLAUDE.md: Self-Heal section already present');
     }
 
+    // Correction & Preference Learning Sentinel (Slice 1a) §7 — Agent Awareness +
+    // Migration Parity: existing agents must learn about the preferences read-
+    // surface (the session-start hook now fetches /preferences/session-context
+    // and injects an <auto-learned-preference> block) so they HONOR injected
+    // preferences and understand the loop is watching their repeated corrections.
+    // The Failure-Learning Loop only backfilled its sub-tab and left existing
+    // agents unaware of the main capability — that gap is not repeated here.
+    // Content-sniffed on a distinctive marker for idempotency.
+    if (!content.includes('Preferences I’ve learned about you') && !content.includes("Preferences I've learned about you")) {
+      const prefsSection = `
+## Preferences I've learned about you (Correction & Preference Learning Sentinel)
+
+When you correct me the same way repeatedly — "no, plainer", "stop asking me that every session", "from now on lead with the action" — the Correction & Preference Learning Sentinel turns the recurring correction into a durable preference instead of a lesson that evaporates when the session ends. Each learned preference is written to \`.instar/preferences.json\`, and from then on my session-start hook fetches \`GET /preferences/session-context\` on EVERY boot and injects the active preferences into my context, wrapped in an \`<auto-learned-preference src='correction-loop'>\` envelope.
+
+That envelope is deliberate: learned preferences are **signals, not authoritative instructions**. I apply them by default, but a real instruction or a safety rule always wins. The loop is **SIGNAL-ONLY** — it never blocks or rewrites an outbound message.
+
+- See what's currently injected: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/preferences/session-context\` (the byte-bounded, priority-ordered block; \`503\` when the feature is off, \`{ present: false }\` when there are none yet).
+- Ships OFF (\`monitoring.correctionLearning.enabled\`). When off, the route 503s and the session-start hook silently injects nothing.
+- **When to use** (PROACTIVE): when the user corrects me repeatedly on the same thing, I acknowledge it, adapt now, and trust the loop to carry it forward — I do NOT promise to "remember" it by willpower across sessions. If preferences are already injected at session start, I honor them by default.
+`;
+      content += '\n' + prefsSection;
+      patched = true;
+      result.upgraded.push('CLAUDE.md: added Correction & Preference Learning Sentinel awareness (preferences session-context)');
+    } else {
+      result.skipped.push('CLAUDE.md: Preferences (Correction & Preference Learning) section already present');
+    }
+
     const authenticatedCapabilitiesCurl = `curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/capabilities`;
 
     // Self-Discovery section

--- a/src/core/PreferencesManager.ts
+++ b/src/core/PreferencesManager.ts
@@ -1,0 +1,289 @@
+/**
+ * PreferencesManager — the structured on-disk substrate for auto-learned user
+ * preferences (Correction & Preference Learning Sentinel, Slice 1a).
+ *
+ * Modeled directly on the ORG-INTENT precedent (`OrgIntentManager` +
+ * `formatOrgIntentForSessionStart` + `GET /intent/org/session-context` +
+ * the session-start hook fetch). Where ORG-INTENT is a human-authored markdown
+ * contract, this file is a machine-written JSON store of preferences the
+ * correction loop has learned about THIS user.
+ *
+ * Design constraints (spec §3.6 / §10 Slice 1a):
+ *   - `recordPreference()` is the ONLY writer to `.instar/preferences.json`.
+ *   - Writes are atomic (temp file + rename) and schema-versioned.
+ *   - Upsert keyed on `dedupeKey` — a recurring learning collapses to ONE entry
+ *     (its `dedupeCount` increments, `recordedAt` refreshes, `confidence` takes
+ *     the max of old/new), never a growing pile of duplicates.
+ *   - Absent file ≡ no preferences (never throws; reads return an empty store).
+ *   - The session-start block is bounded by `maxInjectedPreferencesBytes` and
+ *     priority-ordered by recency × confidence × dedupeCount.
+ *
+ * SIGNAL-ONLY: this surface NEVER blocks or rewrites an outbound message. It
+ * only stores preferences, serves them, and the session-start hook injects them
+ * so the agent always SEES them. There is no enforcement gate. (The blocking
+ * idea was explicitly rejected by the user — see spec frontmatter.)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+/** Current on-disk schema version. Bump only with a paired migration. */
+export const PREFERENCES_SCHEMA_VERSION = 1;
+
+/** Provenance of a preference entry. Slice 1a only ever writes 'correction-loop'. */
+export type PreferenceProvenance = 'correction-loop';
+
+/** A single learned preference, as persisted in `.instar/preferences.json`. */
+export interface PreferenceEntry {
+  /** The distilled, scrubbed lesson — e.g. "Lead with the one action, no preamble." */
+  learning: string;
+  /** Where this came from. Slice 1a: always 'correction-loop'. */
+  provenance: PreferenceProvenance;
+  /** Stable key the loop upserts on (kind:normalizedLearningHash). */
+  dedupeKey: string;
+  /** ISO timestamp of the most recent observation of this preference. */
+  recordedAt: string;
+  /** Loop-assigned confidence in [0,1]; advisory ordering weight. */
+  confidence: number;
+  /** How many distinct observations have collapsed into this entry (≥1). */
+  dedupeCount: number;
+}
+
+/** The full on-disk store shape. */
+export interface PreferencesStore {
+  schemaVersion: number;
+  preferences: PreferenceEntry[];
+}
+
+/** Input payload for `recordPreference()`. */
+export interface RecordPreferencePayload {
+  learning: string;
+  dedupeKey: string;
+  /** Defaults to 0.5 when omitted; clamped to [0,1]. */
+  confidence?: number;
+  /** Defaults to 'correction-loop'. */
+  provenance?: PreferenceProvenance;
+  /** Defaults to now (ISO). Injectable for deterministic tests. */
+  recordedAt?: string;
+}
+
+/** Options for `recordPreference()`. */
+export interface RecordPreferenceOptions {
+  /**
+   * Priority ordering for the injected block. Mirrors the spec's
+   * `preferencesInjectionPriority` config string. Slice 1a supports the single
+   * documented form; unknown strings fall back to it.
+   */
+  injectionPriority?: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const EMPTY_STORE: PreferencesStore = { schemaVersion: PREFERENCES_SCHEMA_VERSION, preferences: [] };
+
+function clampConfidence(value: number | undefined): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 0.5;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Compute the priority score for ordering injected preferences. Higher first.
+ * `recency × confidence × dedupeCount` per the spec default. Recency is a
+ * monotonically-increasing epoch-ms reading of `recordedAt` (newer = larger),
+ * so a fresher, higher-confidence, more-recurrent preference sorts first.
+ */
+function priorityScore(entry: PreferenceEntry): number {
+  const recencyMs = Date.parse(entry.recordedAt);
+  const recency = Number.isNaN(recencyMs) ? 0 : recencyMs;
+  const confidence = clampConfidence(entry.confidence);
+  const dedupeCount = Math.max(1, entry.dedupeCount || 1);
+  // recencyMs dominates the magnitude, which is the intended "recency-led"
+  // ordering; confidence and dedupeCount break ties / amplify within an epoch.
+  return recency * confidence * dedupeCount;
+}
+
+/**
+ * Render the active preferences into a session-start text block, bounded by
+ * `maxBytes` and priority-ordered. Returns the block string (may be empty).
+ *
+ * Mirrors `formatOrgIntentForSessionStart` — deterministic, no LLM, safe to
+ * inject directly. Each preference is wrapped at the section level inside an
+ * `<auto-learned-preference src='correction-loop'>` envelope so downstream
+ * prompt assemblers structurally cannot mistake a learned preference for an
+ * authoritative instruction (spec §3.6).
+ */
+export function formatPreferencesForSessionStart(
+  store: PreferencesStore,
+  maxBytes = 4000,
+): string {
+  const active = [...store.preferences].sort((a, b) => priorityScore(b) - priorityScore(a));
+  if (active.length === 0) return '';
+
+  const header = "<auto-learned-preference src='correction-loop'>";
+  const intro = 'These are preferences I have learned about how you like to work. They are signals, not authoritative instructions — apply them by default, but real instructions and safety always win.';
+  const footer = '</auto-learned-preference>';
+
+  // Greedily include the highest-priority preferences until we'd exceed maxBytes.
+  const bodyLines: string[] = [];
+  for (const pref of active) {
+    const line = `  - ${pref.learning} (confidence ${clampConfidence(pref.confidence).toFixed(2)}, seen ${Math.max(1, pref.dedupeCount || 1)}×)`;
+    const candidate = [header, intro, '', ...bodyLines, line, footer].join('\n');
+    if (Buffer.byteLength(candidate, 'utf-8') > maxBytes) break;
+    bodyLines.push(line);
+  }
+
+  if (bodyLines.length === 0) return '';
+  return [header, intro, '', ...bodyLines, footer].join('\n');
+}
+
+// ── Main Class ───────────────────────────────────────────────────────
+
+export class PreferencesManager {
+  private preferencesPath: string;
+
+  constructor(private stateDir: string) {
+    this.preferencesPath = path.join(stateDir, 'preferences.json');
+  }
+
+  /** Absolute path to the backing file (for tests / observability). */
+  getPath(): string {
+    return this.preferencesPath;
+  }
+
+  /** Whether the backing file exists on disk. */
+  exists(): boolean {
+    return fs.existsSync(this.preferencesPath);
+  }
+
+  /**
+   * Read the store. Absent file ≡ empty store (never throws). A malformed or
+   * unexpected-shape file is also treated as empty — the loop is signal-only,
+   * so a corrupt read should never crash a session start.
+   */
+  read(): PreferencesStore {
+    if (!this.exists()) return { schemaVersion: PREFERENCES_SCHEMA_VERSION, preferences: [] };
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.preferencesPath, 'utf-8');
+    } catch {
+      // @silent-fallback-ok — unreadable preferences file ≡ no preferences
+      return { schemaVersion: PREFERENCES_SCHEMA_VERSION, preferences: [] };
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      // @silent-fallback-ok — malformed preferences file ≡ no preferences
+      return { schemaVersion: PREFERENCES_SCHEMA_VERSION, preferences: [] };
+    }
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray((parsed as PreferencesStore).preferences)) {
+      return { schemaVersion: PREFERENCES_SCHEMA_VERSION, preferences: [] };
+    }
+    const store = parsed as PreferencesStore;
+    const preferences = store.preferences.filter(
+      (p): p is PreferenceEntry =>
+        !!p && typeof p.learning === 'string' && typeof p.dedupeKey === 'string',
+    ).map((p) => ({
+      learning: p.learning,
+      provenance: (p.provenance ?? 'correction-loop') as PreferenceProvenance,
+      dedupeKey: p.dedupeKey,
+      recordedAt: typeof p.recordedAt === 'string' ? p.recordedAt : new Date(0).toISOString(),
+      confidence: clampConfidence(p.confidence),
+      dedupeCount: Math.max(1, Math.floor(p.dedupeCount) || 1),
+    }));
+    return {
+      schemaVersion: typeof store.schemaVersion === 'number' ? store.schemaVersion : PREFERENCES_SCHEMA_VERSION,
+      preferences,
+    };
+  }
+
+  /**
+   * recordPreference — the ONLY writer to `.instar/preferences.json`.
+   *
+   * Upserts the payload keyed on `dedupeKey`:
+   *   - New key → appended as a fresh entry with `dedupeCount: 1`.
+   *   - Existing key → `learning` refreshed, `recordedAt` advanced,
+   *     `confidence` raised to max(old, new), `dedupeCount` incremented.
+   *
+   * Atomic: writes a temp file then renames over the target so a concurrent
+   * reader never observes a partial file. Returns the entry as persisted.
+   */
+  recordPreference(payload: RecordPreferencePayload, _opts: RecordPreferenceOptions = {}): PreferenceEntry {
+    if (!payload || typeof payload.learning !== 'string' || !payload.learning.trim()) {
+      throw new Error('recordPreference: `learning` is required and must be a non-empty string');
+    }
+    if (typeof payload.dedupeKey !== 'string' || !payload.dedupeKey.trim()) {
+      throw new Error('recordPreference: `dedupeKey` is required and must be a non-empty string');
+    }
+
+    const store = this.read();
+    const now = payload.recordedAt ?? new Date().toISOString();
+    const confidence = clampConfidence(payload.confidence);
+    const provenance: PreferenceProvenance = payload.provenance ?? 'correction-loop';
+
+    const existing = store.preferences.find((p) => p.dedupeKey === payload.dedupeKey);
+    let result: PreferenceEntry;
+    if (existing) {
+      existing.learning = payload.learning.trim();
+      existing.recordedAt = now;
+      existing.confidence = Math.max(clampConfidence(existing.confidence), confidence);
+      existing.dedupeCount = Math.max(1, existing.dedupeCount || 1) + 1;
+      existing.provenance = provenance;
+      result = existing;
+    } else {
+      result = {
+        learning: payload.learning.trim(),
+        provenance,
+        dedupeKey: payload.dedupeKey,
+        recordedAt: now,
+        confidence,
+        dedupeCount: 1,
+      };
+      store.preferences.push(result);
+    }
+
+    store.schemaVersion = PREFERENCES_SCHEMA_VERSION;
+    this.writeAtomic(store);
+    return result;
+  }
+
+  /**
+   * Build the session-context payload served by `GET /preferences/session-context`.
+   * Serves ONLY the `learning` text + metadata via the formatted block — never
+   * any raw extras. `present` is true iff at least one preference would be
+   * injected into the (bounded) block.
+   */
+  sessionContext(maxBytes = 4000): {
+    present: boolean;
+    block: string;
+    count: number;
+  } {
+    const store = this.read();
+    const block = formatPreferencesForSessionStart(store, maxBytes);
+    return {
+      present: block.length > 0,
+      block,
+      count: store.preferences.length,
+    };
+  }
+
+  /** Atomic write: temp file + fsync + rename. */
+  private writeAtomic(store: PreferencesStore): void {
+    const dir = path.dirname(this.preferencesPath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${this.preferencesPath}.tmp.${process.pid}.${Date.now()}`;
+    const data = JSON.stringify(store, null, 2);
+    const fd = fs.openSync(tmp, 'w');
+    try {
+      fs.writeSync(fd, data);
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, this.preferencesPath);
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3108,6 +3108,55 @@ export interface MonitoringConfig {
     };
   };
   /**
+   * Correction & Preference Learning Sentinel
+   * (docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md). Ships OFF.
+   * Slice 1a wires only the preferences read-surface: when `enabled`, the
+   * `GET /preferences/session-context` route serves the learned-preference
+   * block (else 503) and the session-start hook injects it. SIGNAL-ONLY — it
+   * never blocks or rewrites an outbound message. Slice 1b adds the capture →
+   * distill → ledger → recurrence-gate loop that writes via `recordPreference()`.
+   */
+  correctionLearning?: {
+    /** Master kill switch (default: false). Gates the loop AND the read route. */
+    enabled: boolean;
+    /** Min total occurrences before a learning crosses the recurrence gate (Slice 1b). */
+    minSupport?: number;
+    /** Distinct calendar days required for an infra-gap learning (Slice 1b, restart-proof). */
+    minDistinctDaysInfraGap?: number;
+    /** Distinct calendar days required for an explicit-preference learning (Slice 1b). */
+    minDistinctDaysPreference?: number;
+    /** Distinct topics required for the preference path's second prong (Slice 1b). */
+    minDistinctTopicsPreference?: number;
+    /** Auto-submit infra-gap learnings to /feedback (Slice 1b/3). Default false. */
+    autoFeedback?: boolean;
+    /** Post a periodic Telegram digest of learned preferences (Slice 2). Default false. */
+    telegramDigest?: boolean;
+    /** Drift canary that samples un-classified messages through the LLM (Slice 1b). Default false. */
+    driftCanary?: boolean;
+    /** Per-sentinel LLM daily spend cap in cents (own LlmQueue instance, Slice 1b). */
+    llmDailyCents?: number;
+    /** Max concurrent LLM distillation calls (Slice 1b). */
+    llmMaxConcurrent?: number;
+    /** Per-topic look-back ring depth captured for distillation (Slice 1b). */
+    captureContextTurns?: number;
+    /** Max distinct topics held in the capture map before LRU eviction (Slice 1b). */
+    captureTopicMapMax?: number;
+    /** Idle TTL (minutes) before a topic's capture ring is evicted (Slice 1b). */
+    captureTopicTtlMinutes?: number;
+    /** Per-topic distillation rate ceiling per minute (Slice 1b). */
+    distillPerTopicRatePerMinute?: number;
+    /** Verify-window days for the infra-gap closed loop (Slice 1b/2). */
+    verifyWindowDaysInfraGap?: number;
+    /** Verify-window days for the preference closed loop (Slice 1b). */
+    verifyWindowDaysPreference?: number;
+    /** Byte cap on the injected session-start preferences block (Slice 1a). */
+    maxInjectedPreferencesBytes?: number;
+    /** Priority ordering string for the injected block (Slice 1a). */
+    preferencesInjectionPriority?: string;
+    /** Max times a closed-loop verification may reopen the same dedupeKey (Slice 1b). */
+    maxReopens?: number;
+  };
+  /**
    * ReleaseReadinessSentinel (docs/specs/RELEASE-READINESS-VISIBILITY-SPEC.md §4.2)
    * — Layer B. A repo-gated dev-environment watchdog: evaluates the canonical
    * `main` of the instar checkout and surfaces a stalled/blocked release as a

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-30T13:08:22.509Z",
-  "instarVersion": "1.3.121",
+  "generatedAt": "2026-05-30T22:13:03.255Z",
+  "instarVersion": "1.3.123",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -409,7 +409,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -417,7 +417,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -425,7 +425,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -433,7 +433,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -441,7 +441,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -449,7 +449,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -457,7 +457,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -465,7 +465,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -473,7 +473,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -481,7 +481,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -489,7 +489,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -497,7 +497,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -505,7 +505,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -513,7 +513,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -521,7 +521,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -529,7 +529,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -537,7 +537,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -545,7 +545,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -553,7 +553,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -561,7 +561,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -569,7 +569,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -577,7 +577,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -585,7 +585,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -593,7 +593,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -601,7 +601,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -609,7 +609,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -617,7 +617,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -625,7 +625,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -633,7 +633,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -641,7 +641,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -649,7 +649,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -657,7 +657,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -665,7 +665,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -673,7 +673,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -681,7 +681,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -689,7 +689,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -697,7 +697,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -705,7 +705,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -713,7 +713,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -721,7 +721,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -729,7 +729,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -737,7 +737,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -745,7 +745,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -761,7 +761,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "85676f4062c0ea35989c300891883e3d6db36080e4674bca111020a9d64d1081",
+      "contentHash": "f9a65b1058c80152ca2e44e5dd6b52278f773781b3c2a338441ab5ee3c9eaea7",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1465,7 +1465,7 @@
       "type": "subsystem",
       "domain": "sessions",
       "sourcePath": "src/core/SessionManager.ts",
-      "contentHash": "ea96b2d0255ee327844da18fd964bb9deb3cf60bdb09e1b572a0f8d0b5f0f089",
+      "contentHash": "44a78387b18df8d53dbfaccc73428e8e884f8f3bf98f19d3736bde0823dd9cc7",
       "since": "2025-01-01"
     },
     "subsystem:auto-updater": {
@@ -1489,7 +1489,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "9edda8d09c12d374d0c053307437ae65efcf0f43cb17637ca73ba50f60cf59a9",
+      "contentHash": "e8e9058390a4b3316b2653f962fcd02a7d01c45bf3941b141abf00758fd253ca",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {

--- a/src/scaffold/templates.ts
+++ b/src/scaffold/templates.ts
@@ -490,6 +490,10 @@ This routes feedback to the Instar maintainers automatically. Valid types: \`bug
 - File a diagnosis (one-tap): \`curl -X POST -H "Authorization: Bearer $AUTH" -H "X-Instar-Request: 1" http://localhost:${port}/failures -H 'Content-Type: application/json' -d '{"summary":"<what broke>","initiativeId":"<board id it traces to>","severity":"medium"}'\`
 - **When to use** (PROACTIVE): when you diagnose a bug that traces to past work, file it so the pattern can be learned. The loop NEVER changes the process on its own — it opens a draft for your approval. It can never auto-implement (it never creates the record type the autonomous approver acts on). Distinct from the Evolution Action Queue (this produces the evidence + diagnosis that justify an action).
 
+**Preferences I've learned about you** — The Correction & Preference Learning Sentinel turns repeated corrections into durable, structurally-injected preferences. When the user keeps correcting you the same way ("no, plainer", "stop asking me that", "from now on lead with the action"), the loop distills the lesson into a preference and writes it to \`.instar/preferences.json\`. From then on, the session-start hook fetches \`GET /preferences/session-context\` on EVERY boot and injects the learned preferences into your context wrapped in an \`<auto-learned-preference src='correction-loop'>\` envelope — so you SEE them from message one without having to remember. SIGNAL-ONLY: these are preferences, NOT authoritative instructions, and the loop NEVER blocks or rewrites an outbound message. Ships OFF (\`monitoring.correctionLearning.enabled\`).
+- See the active block the hook injects: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/preferences/session-context\` — returns the structured, byte-bounded, priority-ordered block (503 when disabled; \`{ present: false }\` when there are none yet).
+- **When to use** (PROACTIVE — this is the trigger): when the user corrects you repeatedly on the SAME thing, the loop is already watching and will turn it into a durable preference; you don't have to manually remember it across sessions. If preferences are already injected at session start, honor them by default. The preferences are advisory signals — real instructions and safety always win.
+
 **Cloudflare Tunnel** — Expose the local server to the internet via Cloudflare. Enables remote access to private views, the API, and file serving.
 - Status: \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/tunnel\`
 - Configure in \`.instar/config.json\`: \`{"tunnel": {"enabled": true, "type": "quick"}}\`
@@ -723,6 +727,7 @@ I maintain registries that are the source of truth for specific categories. Thes
 | What can I do? | \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/capabilities\` |
 | What are we working on? / status of a project or initiative? | \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/initiatives\` + \`/projects\` (and \`/initiatives/digest\` for what needs a decision) — NEVER answer this from memory |
 | Why do features keep breaking? / our failure rate by build skill? / are our process fixes working? | \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/failures/analysis\` + \`/failures\` (Failure-Learning Loop — instar dev-process forensics) — NEVER answer this from memory |
+| What preferences have I learned about this user? / what gets injected at session start? | \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/preferences/session-context\` (Correction & Preference Learning Sentinel — signal-only; 503 when disabled) |
 | Who do I work with? | \`.instar/USER.md\` |
 | What have I learned? | \`.instar/MEMORY.md\` |
 | What jobs do I have? | \`.instar/jobs.json\` or \`curl -H "Authorization: Bearer $AUTH" http://localhost:${port}/jobs\` |
@@ -905,6 +910,7 @@ The GitHub repository is preserved — they can restore later with \`git clone\`
 - User is **debugging CI or deployment** → Use the CI health endpoint to check GitHub Actions status.
 - User asks about **something that happened earlier** → Search Telegram history, check activity logs, review memory.
 - User seems **frustrated with a limitation** → Check for updates. The fix might already exist.
+- User **corrects you the same way repeatedly** ("no, plainer", "stop asking me that every session", "from now on lead with the action") → the Correction & Preference Learning Sentinel is already watching and will turn the recurring correction into a durable, session-start-injected preference. Acknowledge the correction, adapt now, and trust the loop to carry it forward — don't promise to "remember" it by willpower. Check what's already learned: \`GET /preferences/session-context\`.
 - User asks me to **remember something** → Write it to MEMORY.md and explain it persists across sessions.
 - User asks **"didn't we talk about X?"** or **"where did I put that?"** → Use memory search (\`GET /memory/search?q=...\`). The full-text index covers everything I've written.
 - Before any **risky operation** (config changes, updates, experiments) → Create a backup snapshot first (\`POST /backups\`). Mention that you did it — the user should know their state is protected.

--- a/src/server/CapabilityIndex.ts
+++ b/src/server/CapabilityIndex.ts
@@ -554,6 +554,18 @@ export const CAPABILITY_INDEX: readonly CapabilityEntry[] = [
     }),
   },
   {
+    key: 'correctionLearning',
+    prefixes: ['/preferences'],
+    description: 'Correction & Preference Learning Sentinel (Slice 1a read-surface) — serves auto-learned user preferences as a session-start block. SIGNAL-ONLY; never blocks/rewrites a message. Ships OFF (monitoring.correctionLearning.enabled).',
+    build: ({ ctx }) => ({
+      enabled: ctx.config.monitoring?.correctionLearning?.enabled === true,
+      endpoints: [
+        'GET /preferences/session-context — structured block of active learned preferences (503 when disabled; { present:false } when none)',
+      ],
+      hint: 'Ships OFF; when disabled the route 503s. The session-start hook fetches this on every boot and injects the <auto-learned-preference> block.',
+    }),
+  },
+  {
     key: 'skipLedger',
     prefixes: ['/skip-ledger'],
     description: 'Skip-ledger — workload-aware idempotency',

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -10838,6 +10838,42 @@ export function createRoutes(ctx: RouteContext): Router {
     }
   });
 
+  // ── Preferences (Correction & Preference Learning Sentinel, Slice 1a) ──
+  //
+  // Auto-learned user preferences, served as a session-start block that mirrors
+  // the ORG-INTENT precedent above. The correction loop (Slice 1b) is the writer
+  // via `recordPreference()`; this route is the read surface the session-start
+  // hook fetches on every boot, so the agent always SEES the preferences it has
+  // learned about this user. SIGNAL-ONLY — this never blocks or rewrites an
+  // outbound message.
+  //
+  // Gated on `monitoring.correctionLearning.enabled`:
+  //   - disabled → 503 (the surface still exists for capability probing)
+  //   - enabled  → 200 with the structured block (or { present: false } when
+  //                there are no preferences yet)
+  //
+  // The block is bounded by `maxInjectedPreferencesBytes` (default 4000) and
+  // priority-ordered (recency × confidence × dedupeCount). Serves ONLY the
+  // `learning` text + metadata — never any raw extras.
+  router.get('/preferences/session-context', async (_req, res) => {
+    try {
+      const cfg = ctx.config.monitoring?.correctionLearning;
+      if (cfg?.enabled !== true) {
+        res.status(503).json({ error: 'correction-learning disabled' });
+        return;
+      }
+      const { PreferencesManager } = await import('../core/PreferencesManager.js');
+      const manager = new PreferencesManager(ctx.config.stateDir);
+      const maxBytes = typeof cfg.maxInjectedPreferencesBytes === 'number' && cfg.maxInjectedPreferencesBytes > 0
+        ? cfg.maxInjectedPreferencesBytes
+        : 4000;
+      const result = manager.sessionContext(maxBytes);
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'Failed to read preferences' });
+    }
+  });
+
   // ORG-INTENT.md tradeoff resolution (Phase 3 of the ORG-INTENT runtime
   // project). Given two contending values, consults the organization's
   // tradeoff hierarchy and returns which wins, with the basis for the

--- a/tests/e2e/preferences-session-context-lifecycle.test.ts
+++ b/tests/e2e/preferences-session-context-lifecycle.test.ts
@@ -1,0 +1,257 @@
+/**
+ * E2E test — Preferences session-start injection (Correction & Preference
+ * Learning Sentinel, Slice 1a) full lifecycle.
+ *
+ * Tier 3 of the Testing Integrity Standard. Tests the complete PRODUCTION path:
+ *   Phase 1 — Feature is alive: the route is wired into AgentServer the same
+ *             way production wires it (200 when enabled, 503 when off). This is
+ *             the single most important assertion — it mirrors the ORG-INTENT
+ *             E2E precedent exactly (one AgentServer per describe, getApp()).
+ *   Phase 2 — The generated session-start hook's preference-injection logic
+ *             (the SAME bash + python that PostUpdateMigrator.getSessionStartHook()
+ *             installs) runs against a LIVE server and emits the
+ *             <auto-learned-preference> block when a preference exists, and
+ *             emits nothing when the feature is off (503-tolerant fail-open).
+ *
+ * WHY PHASE 2 RUNS A SLICE OF THE HOOK, NOT THE WHOLE SCRIPT:
+ * The full session-start hook also exercises shared-state session-binding,
+ * topic-context, project-map, etc. — unrelated subsystems that need a full
+ * AgentServer to answer without blocking. Slice 1a's contract is exactly the
+ * preference-fetch block, so Phase 2 extracts that block verbatim from the
+ * generated hook source and runs it against a real server. The full hook
+ * source is also asserted to contain the wiring (so a refactor that drops the
+ * fetch is caught).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import http from 'node:http';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import request from 'supertest';
+import express from 'express';
+import { AgentServer } from '../../src/server/AgentServer.js';
+import { StateManager } from '../../src/core/StateManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { PreferencesManager } from '../../src/core/PreferencesManager.js';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { createRoutes } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { createMockSessionManager } from '../helpers/setup.js';
+import type { InstarConfig } from '../../src/core/types.js';
+
+const execFileAsync = promisify(execFile);
+
+const AUTH_TOKEN = 'test-prefs-e2e';
+const auth = () => ({ Authorization: `Bearer ${AUTH_TOKEN}` });
+
+describe('Preferences session-start injection E2E lifecycle', () => {
+  // ── Phase 1: Feature is alive on the production AgentServer boot path ──
+  describe('Phase 1: Feature is alive (production AgentServer boot path)', () => {
+    let tmpDir: string;
+    let stateDir: string;
+    let server: AgentServer;
+    let app: ReturnType<AgentServer['getApp']>;
+
+    beforeAll(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-e2e-on-'));
+      stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+      fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+      fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'prefs-e2e' }));
+
+      const config: InstarConfig = {
+        projectName: 'prefs-e2e-on',
+        agentName: 'E2E Agent',
+        projectDir: tmpDir,
+        stateDir,
+        port: 0,
+        authToken: AUTH_TOKEN,
+        monitoring: { correctionLearning: { enabled: true } },
+      } as InstarConfig;
+
+      server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir) });
+      app = server.getApp();
+    });
+
+    afterAll(async () => {
+      try { await (server as unknown as { stop?: () => Promise<void> }).stop?.(); } catch { /* ignore */ }
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'preferences-session-context-lifecycle:phase1' });
+    });
+
+    it('returns 200 when enabled — route is wired into production', async () => {
+      const res = await request(app).get('/preferences/session-context').set(auth());
+      expect(res.status).toBe(200);
+      expect(res.body.present).toBe(false); // no preferences recorded yet
+    });
+
+    it('returns the structured block once a preference is recorded on disk', async () => {
+      new PreferencesManager(stateDir).recordPreference({
+        learning: 'Skip the preamble; give the answer first.',
+        dedupeKey: 'user-preference:answer-first',
+        confidence: 0.9,
+      });
+      const res = await request(app).get('/preferences/session-context').set(auth());
+      expect(res.status).toBe(200);
+      expect(res.body.present).toBe(true);
+      expect(res.body.block).toContain('Skip the preamble; give the answer first.');
+      expect(res.body.block).toContain("<auto-learned-preference src='correction-loop'>");
+    });
+  });
+
+  describe('Phase 1b: 503 on the same boot path when disabled', () => {
+    let tmpDir: string;
+    let stateDir: string;
+    let server: AgentServer;
+    let app: ReturnType<AgentServer['getApp']>;
+
+    beforeAll(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-e2e-off-'));
+      stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(path.join(stateDir, 'state', 'sessions'), { recursive: true });
+      fs.mkdirSync(path.join(stateDir, 'state', 'jobs'), { recursive: true });
+      fs.writeFileSync(path.join(stateDir, 'config.json'), JSON.stringify({ port: 0, projectName: 'prefs-e2e-off' }));
+
+      const config: InstarConfig = {
+        projectName: 'prefs-e2e-off',
+        agentName: 'E2E Agent',
+        projectDir: tmpDir,
+        stateDir,
+        port: 0,
+        authToken: AUTH_TOKEN,
+        // correctionLearning omitted → disabled
+      } as InstarConfig;
+
+      server = new AgentServer({ config, sessionManager: createMockSessionManager() as any, state: new StateManager(stateDir) });
+      app = server.getApp();
+    });
+
+    afterAll(async () => {
+      try { await (server as unknown as { stop?: () => Promise<void> }).stop?.(); } catch { /* ignore */ }
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'preferences-session-context-lifecycle:phase1b' });
+    });
+
+    it('returns 503 when disabled', async () => {
+      const res = await request(app).get('/preferences/session-context').set(auth());
+      expect(res.status).toBe(503);
+    });
+  });
+
+  // ── Phase 2: the generated hook's preference-injection logic ──
+  describe('Phase 2: session-start hook injects the <auto-learned-preference> block', () => {
+    let tmpDir: string;
+    let stateDir: string;
+    let server: http.Server;
+    let port: number;
+
+    function makeCtx(enabled: boolean): RouteContext {
+      return {
+        config: {
+          projectName: 'prefs-hook-e2e', projectDir: tmpDir, stateDir, port,
+          authToken: AUTH_TOKEN,
+          monitoring: { correctionLearning: { enabled, maxInjectedPreferencesBytes: 4000 } },
+          sessions: {} as any, scheduler: {} as any,
+        } as any,
+        sessionManager: { listRunningSessions: () => [] } as any,
+        state: { getJobState: () => null, getSession: () => null } as any,
+        scheduler: null, telegram: null, relationships: null, feedback: null,
+        dispatches: null, updateChecker: null, autoUpdater: null, autoDispatcher: null,
+        quotaTracker: null, publisher: null, viewer: null, tunnel: null, evolution: null,
+        watchdog: null, triageNurse: null, topicMemory: null, feedbackAnomalyDetector: null,
+        discoveryEvaluator: null, startTime: new Date(),
+      } as unknown as RouteContext;
+    }
+
+    async function startServer(enabled: boolean): Promise<void> {
+      const appx = express();
+      appx.use(express.json());
+      appx.use(authMiddleware(AUTH_TOKEN));
+      appx.use('/', createRoutes(makeCtx(enabled)));
+      await new Promise<void>((resolve) => {
+        // Listen on all interfaces so the hook's `http://localhost:PORT` fetch
+        // resolves whether localhost maps to 127.0.0.1 or ::1 on this host.
+        server = appx.listen(0, () => {
+          port = (server.address() as { port: number }).port;
+          resolve();
+        });
+      });
+    }
+
+    async function stopServer(): Promise<void> {
+      if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+
+    /**
+     * Extract the preference-injection block from the generated hook source —
+     * the lines between the "AUTO-LEARNED PREFERENCES injection" comment and the
+     * next "# BEGIN" marker — and run JUST that block against the live server.
+     * This is the exact bash + python the production hook runs for this feature.
+     */
+    function extractPrefBlock(): string {
+      const migrator = new PostUpdateMigrator({ projectDir: tmpDir, stateDir, port, authToken: AUTH_TOKEN, agentName: 'prefs-hook-e2e' });
+      const src = migrator.getHookContent('session-start');
+      const start = src.indexOf('# AUTO-LEARNED PREFERENCES injection');
+      expect(start).toBeGreaterThanOrEqual(0);
+      const after = src.indexOf('# BEGIN integrated-being-v2', start);
+      expect(after).toBeGreaterThan(start);
+      return src.slice(start, after);
+    }
+
+    // Async exec so the in-process Express server's event loop stays free to
+    // answer the curl while bash runs in a child process (a SYNC exec would
+    // deadlock — the single Node event loop can't serve the request while
+    // blocked inside execFileSync).
+    async function runPrefBlock(): Promise<string> {
+      const block = extractPrefBlock();
+      // Provide the PORT/TOKEN env the surrounding hook would have set.
+      const script = `#!/bin/bash\nPORT=${port}\nTOKEN="${AUTH_TOKEN}"\n${block}`;
+      const scriptPath = path.join(tmpDir, 'pref-block.sh');
+      fs.writeFileSync(scriptPath, script, { mode: 0o755 });
+      const { stdout } = await execFileAsync('bash', [scriptPath], { encoding: 'utf-8' });
+      return stdout;
+    }
+
+    beforeAll(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-hook-e2e-'));
+      stateDir = path.join(tmpDir, '.instar');
+      fs.mkdirSync(stateDir, { recursive: true });
+    });
+
+    afterAll(async () => {
+      await stopServer();
+      SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'preferences-session-context-lifecycle:phase2' });
+    });
+
+    it('the full hook source wires the /preferences/session-context fetch', () => {
+      const migrator = new PostUpdateMigrator({ projectDir: tmpDir, stateDir, port: 0, authToken: AUTH_TOKEN, agentName: 'x' });
+      const src = migrator.getHookContent('session-start');
+      expect(src).toContain('/preferences/session-context');
+      expect(src).toContain('PREFS_BLOCK');
+    });
+
+    it('emits the <auto-learned-preference> block when enabled + a preference exists', async () => {
+      new PreferencesManager(stateDir).recordPreference({
+        learning: 'Lead with the one action, no preamble.',
+        dedupeKey: 'user-preference:lead-action',
+        confidence: 0.85,
+      });
+      await startServer(true);
+      const out = await runPrefBlock();
+      await stopServer();
+
+      expect(out).toContain("<auto-learned-preference src='correction-loop'>");
+      expect(out).toContain('Lead with the one action, no preamble.');
+    });
+
+    it('emits NO block when the feature is OFF (503-tolerant fail-open)', async () => {
+      await startServer(false);
+      const out = await runPrefBlock();
+      await stopServer();
+      expect(out).not.toContain('<auto-learned-preference');
+      expect(out.trim()).toBe('');
+    });
+  });
+});

--- a/tests/integration/preferences-routes.test.ts
+++ b/tests/integration/preferences-routes.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Integration tests — GET /preferences/session-context (Correction & Preference
+ * Learning Sentinel, Slice 1a).
+ *
+ * Tier 2 of the Testing Integrity Standard. Exercises the REAL production path:
+ * the inline /preferences route in createRoutes(), mounted behind the real
+ * authMiddleware (so the 401 path is exercised the same way production wires
+ * it), backed by file-based state via PreferencesManager.
+ *
+ * Covers:
+ *   - 401 without a bearer token
+ *   - 503 when the feature is disabled (monitoring.correctionLearning.enabled !== true)
+ *   - 200 with the structured block when enabled + preferences exist
+ *   - { present: false } when enabled but no preferences yet
+ *   - serves ONLY learning + metadata (no raw extras like dedupeKey leak)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { authMiddleware } from '../../src/server/middleware.js';
+import { PreferencesManager } from '../../src/core/PreferencesManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const AUTH_TOKEN = 'test-prefs-bearer';
+
+function ctxFor(stateDir: string, correctionLearningEnabled: boolean): RouteContext {
+  return {
+    config: {
+      projectName: 'prefs-test',
+      projectDir: path.dirname(stateDir),
+      stateDir,
+      port: 0,
+      authToken: AUTH_TOKEN,
+      monitoring: { correctionLearning: { enabled: correctionLearningEnabled, maxInjectedPreferencesBytes: 4000 } },
+      sessions: {} as any,
+      scheduler: {} as any,
+    } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null, telegram: null, relationships: null, feedback: null,
+    dispatches: null, updateChecker: null, autoUpdater: null, autoDispatcher: null,
+    quotaTracker: null, publisher: null, viewer: null, tunnel: null, evolution: null,
+    watchdog: null, triageNurse: null, topicMemory: null, feedbackAnomalyDetector: null,
+    discoveryEvaluator: null, startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function appWith(stateDir: string, enabled: boolean): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(authMiddleware(AUTH_TOKEN));
+  app.use('/', createRoutes(ctxFor(stateDir, enabled)));
+  return app;
+}
+
+describe('GET /preferences/session-context (integration, real createRoutes + authMiddleware)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-routes-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/integration/preferences-routes.test.ts:afterEach' });
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${AUTH_TOKEN}` });
+
+  it('401 without a bearer token', async () => {
+    const app = appWith(stateDir, true);
+    const res = await request(app).get('/preferences/session-context');
+    expect(res.status).toBe(401);
+  });
+
+  it('503 when the feature is disabled', async () => {
+    const app = appWith(stateDir, false);
+    const res = await request(app).get('/preferences/session-context').set(auth());
+    expect(res.status).toBe(503);
+    expect(res.body.error).toContain('correction-learning disabled');
+  });
+
+  it('200 with { present: false } when enabled but no preferences exist', async () => {
+    const app = appWith(stateDir, true);
+    const res = await request(app).get('/preferences/session-context').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.present).toBe(false);
+    expect(res.body.block).toBe('');
+    expect(res.body.count).toBe(0);
+  });
+
+  it('200 with a structured block when enabled + preferences exist', async () => {
+    // Write a preference via the ONLY writer, then serve it through the route.
+    new PreferencesManager(stateDir).recordPreference({
+      learning: 'Lead with the one action, no preamble.',
+      dedupeKey: 'user-preference:lead-action',
+      confidence: 0.85,
+    });
+
+    const app = appWith(stateDir, true);
+    const res = await request(app).get('/preferences/session-context').set(auth());
+    expect(res.status).toBe(200);
+    expect(res.body.present).toBe(true);
+    expect(res.body.count).toBe(1);
+    expect(res.body.block).toContain('Lead with the one action, no preamble.');
+    expect(res.body.block).toContain("<auto-learned-preference src='correction-loop'>");
+  });
+
+  it('serves only learning + metadata — no raw extras (dedupeKey/provenance never leak)', async () => {
+    new PreferencesManager(stateDir).recordPreference({
+      learning: 'Plainer language, please.',
+      dedupeKey: 'user-preference:secret-dedupe-marker',
+      confidence: 0.7,
+    });
+
+    const app = appWith(stateDir, true);
+    const res = await request(app).get('/preferences/session-context').set(auth());
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).toContain('Plainer language, please.');
+    // Internal dedupeKey must not appear anywhere in the served payload.
+    expect(serialized).not.toContain('secret-dedupe-marker');
+  });
+});

--- a/tests/unit/PreferencesManager.test.ts
+++ b/tests/unit/PreferencesManager.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests — PreferencesManager (Correction & Preference Learning Sentinel, Slice 1a).
+ *
+ * Tier 1 of the Testing Integrity Standard. Pins the load-bearing invariants of
+ * the ONLY writer to `.instar/preferences.json`:
+ *   - atomic write + schema-version stamped
+ *   - upsert by dedupeKey (recurring learning collapses to ONE entry)
+ *   - absent file ≡ empty store (never throws)
+ *   - bounded-bytes + priority ordering of the session-start block
+ *   - serves only learning + metadata
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  PreferencesManager,
+  formatPreferencesForSessionStart,
+  PREFERENCES_SCHEMA_VERSION,
+  type PreferencesStore,
+} from '../../src/core/PreferencesManager.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('PreferencesManager', () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let mgr: PreferencesManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-mgr-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+    mgr = new PreferencesManager(stateDir);
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/PreferencesManager.test.ts:afterEach' });
+  });
+
+  describe('absent file ≡ empty store', () => {
+    it('read() returns an empty, schema-versioned store when no file exists', () => {
+      expect(mgr.exists()).toBe(false);
+      const store = mgr.read();
+      expect(store.preferences).toEqual([]);
+      expect(store.schemaVersion).toBe(PREFERENCES_SCHEMA_VERSION);
+    });
+
+    it('sessionContext() reports present:false with no file', () => {
+      const ctx = mgr.sessionContext();
+      expect(ctx.present).toBe(false);
+      expect(ctx.block).toBe('');
+      expect(ctx.count).toBe(0);
+    });
+
+    it('a malformed file is treated as empty (never throws)', () => {
+      fs.writeFileSync(mgr.getPath(), '{ this is not json');
+      expect(() => mgr.read()).not.toThrow();
+      expect(mgr.read().preferences).toEqual([]);
+    });
+  });
+
+  describe('recordPreference — atomic write + schema version', () => {
+    it('creates the file with a schema version and one entry', () => {
+      const entry = mgr.recordPreference({
+        learning: 'Lead with the one action, no preamble.',
+        dedupeKey: 'user-preference:abc123',
+        confidence: 0.8,
+      });
+      expect(mgr.exists()).toBe(true);
+
+      const onDisk = JSON.parse(fs.readFileSync(mgr.getPath(), 'utf-8')) as PreferencesStore;
+      expect(onDisk.schemaVersion).toBe(PREFERENCES_SCHEMA_VERSION);
+      expect(onDisk.preferences).toHaveLength(1);
+      expect(onDisk.preferences[0].learning).toBe('Lead with the one action, no preamble.');
+      expect(onDisk.preferences[0].provenance).toBe('correction-loop');
+      expect(onDisk.preferences[0].dedupeKey).toBe('user-preference:abc123');
+      expect(onDisk.preferences[0].dedupeCount).toBe(1);
+      expect(entry.dedupeCount).toBe(1);
+    });
+
+    it('leaves no temp files behind after a write', () => {
+      mgr.recordPreference({ learning: 'x', dedupeKey: 'k:1' });
+      const leftovers = fs.readdirSync(stateDir).filter((f) => f.includes('.tmp.'));
+      expect(leftovers).toEqual([]);
+    });
+
+    it('throws on empty learning or empty dedupeKey', () => {
+      expect(() => mgr.recordPreference({ learning: '   ', dedupeKey: 'k:1' })).toThrow();
+      expect(() => mgr.recordPreference({ learning: 'real', dedupeKey: '' })).toThrow();
+    });
+
+    it('clamps confidence into [0,1] and defaults to 0.5', () => {
+      mgr.recordPreference({ learning: 'a', dedupeKey: 'k:a', confidence: 5 });
+      mgr.recordPreference({ learning: 'b', dedupeKey: 'k:b', confidence: -3 });
+      mgr.recordPreference({ learning: 'c', dedupeKey: 'k:c' });
+      const byKey = Object.fromEntries(mgr.read().preferences.map((p) => [p.dedupeKey, p.confidence]));
+      expect(byKey['k:a']).toBe(1);
+      expect(byKey['k:b']).toBe(0);
+      expect(byKey['k:c']).toBe(0.5);
+    });
+  });
+
+  describe('upsert by dedupeKey', () => {
+    it('collapses a repeated dedupeKey to ONE entry and increments dedupeCount', () => {
+      mgr.recordPreference({ learning: 'Be plainer.', dedupeKey: 'user-preference:plain', confidence: 0.5, recordedAt: '2026-05-01T00:00:00.000Z' });
+      mgr.recordPreference({ learning: 'Use plainer language.', dedupeKey: 'user-preference:plain', confidence: 0.7, recordedAt: '2026-05-02T00:00:00.000Z' });
+      mgr.recordPreference({ learning: 'Plainer, please.', dedupeKey: 'user-preference:plain', confidence: 0.6, recordedAt: '2026-05-03T00:00:00.000Z' });
+
+      const store = mgr.read();
+      expect(store.preferences).toHaveLength(1);
+      const e = store.preferences[0];
+      expect(e.dedupeCount).toBe(3);
+      // learning refreshes to the latest phrasing
+      expect(e.learning).toBe('Plainer, please.');
+      // recordedAt advances to the latest observation
+      expect(e.recordedAt).toBe('2026-05-03T00:00:00.000Z');
+      // confidence takes the max observed
+      expect(e.confidence).toBe(0.7);
+    });
+
+    it('keeps distinct dedupeKeys as separate entries', () => {
+      mgr.recordPreference({ learning: 'a', dedupeKey: 'k:1' });
+      mgr.recordPreference({ learning: 'b', dedupeKey: 'k:2' });
+      expect(mgr.read().preferences).toHaveLength(2);
+    });
+  });
+
+  describe('formatPreferencesForSessionStart — bounded bytes + priority order', () => {
+    it('orders by recency × confidence × dedupeCount (highest first)', () => {
+      const store: PreferencesStore = {
+        schemaVersion: PREFERENCES_SCHEMA_VERSION,
+        preferences: [
+          { learning: 'OLD low', provenance: 'correction-loop', dedupeKey: 'k:old', recordedAt: '2020-01-01T00:00:00.000Z', confidence: 0.9, dedupeCount: 1 },
+          { learning: 'NEW high', provenance: 'correction-loop', dedupeKey: 'k:new', recordedAt: '2026-05-30T00:00:00.000Z', confidence: 0.9, dedupeCount: 5 },
+        ],
+      };
+      const block = formatPreferencesForSessionStart(store, 4000);
+      const idxNew = block.indexOf('NEW high');
+      const idxOld = block.indexOf('OLD low');
+      expect(idxNew).toBeGreaterThanOrEqual(0);
+      expect(idxOld).toBeGreaterThanOrEqual(0);
+      expect(idxNew).toBeLessThan(idxOld);
+    });
+
+    it('bounds the block to maxBytes and includes the envelope', () => {
+      const prefs = Array.from({ length: 50 }, (_, i) => ({
+        learning: `Preference number ${i} `.repeat(10),
+        provenance: 'correction-loop' as const,
+        dedupeKey: `k:${i}`,
+        recordedAt: new Date(2026, 0, i + 1).toISOString(),
+        confidence: 0.5,
+        dedupeCount: 1,
+      }));
+      const store: PreferencesStore = { schemaVersion: PREFERENCES_SCHEMA_VERSION, preferences: prefs };
+      const maxBytes = 600;
+      const block = formatPreferencesForSessionStart(store, maxBytes);
+      expect(Buffer.byteLength(block, 'utf-8')).toBeLessThanOrEqual(maxBytes);
+      expect(block).toContain("<auto-learned-preference src='correction-loop'>");
+      expect(block).toContain('</auto-learned-preference>');
+      // Should have dropped at least some preferences under the tight budget
+      const included = (block.match(/Preference number/g) ?? []).length;
+      expect(included).toBeGreaterThan(0);
+      expect(included).toBeLessThan(50);
+    });
+
+    it('returns an empty string for an empty store', () => {
+      expect(formatPreferencesForSessionStart({ schemaVersion: PREFERENCES_SCHEMA_VERSION, preferences: [] })).toBe('');
+    });
+  });
+
+  describe('sessionContext — serves only learning + metadata', () => {
+    it('renders the block from recorded preferences and excludes raw extras', () => {
+      mgr.recordPreference({ learning: 'Lead with the action.', dedupeKey: 'user-preference:action', confidence: 0.8 });
+      const ctx = mgr.sessionContext(4000);
+      expect(ctx.present).toBe(true);
+      expect(ctx.count).toBe(1);
+      expect(ctx.block).toContain('Lead with the action.');
+      expect(ctx.block).toContain("<auto-learned-preference src='correction-loop'>");
+      // metadata appears (confidence + seen-count); no internal dedupeKey/provenance leak
+      expect(ctx.block).toContain('confidence 0.80');
+      expect(ctx.block).not.toContain('user-preference:action');
+    });
+  });
+});

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -132,6 +132,7 @@ describe('Feature Delivery Completeness', () => {
       'Worktree Convention',
       'Multi-Session Autonomy',    // per-topic concurrent autonomous jobs (templates.ts + migrator parity)
       'Process Health (Dashboard Tab)', // Failure-Learning Loop read surface (templates.ts + migrator + shadow-marker parity)
+      "Preferences I've learned about you", // Correction & Preference Learning Sentinel Slice 1a read surface (templates.ts + migrator + shadow-marker parity)
     ];
 
     for (const section of featureSections) {
@@ -224,6 +225,7 @@ describe('Feature Delivery Completeness', () => {
       'Topic-Flood Guard',                                // 2026-05-28 attention-queue circuit breaker: operational housekeeping the agent READS (state/attention-suppressed.jsonl) to answer "why are my notices grouped?" — like Sentinel Notifications, migrator-only (no template/shadow parity)
       'Autonomous-fix loop ("just be Echo")',             // mentor.autonomousFix dark dogfooding-loop awareness: developer-layer operational knowledge added via migrator only (like Framework-Onboarding Mentor System), gated off by default — no new-agent template/shadow parity required
       'Multi-Machine Session Pool (active-active',         // multi-machine session-pool awareness: ships DARK (multiMachine.sessionPool.stage default 'dark'), no-op on a single-machine agent; discoverable via GET /pool + GET /capabilities — operational/dark capability, migrator-tracked like ContextWedgeSentinel/Topic-Flood Guard
+      'Correction & Preference Learning Sentinel',         // the content-sniff marker migrateClaudeMd uses for the "Preferences I've learned about you" section (tracked as a featureSection above); this is the alternate-phrase check, like '/release-readiness' for Release Readiness
     ];
 
     it('all new migrator CLAUDE.md sections are tracked', () => {

--- a/tests/unit/preferences-wiring-integrity.test.ts
+++ b/tests/unit/preferences-wiring-integrity.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Wiring-integrity tests — Correction & Preference Learning Sentinel, Slice 1a.
+ *
+ * The Testing Integrity Standard requires a wiring-integrity test for every
+ * dependency-injected / structurally-load-bearing component. For Slice 1a the
+ * two structural guarantees are:
+ *
+ *   1. recordPreference() is the ONLY writer to .instar/preferences.json — the
+ *      file is created lazily on first write, and an external mutation (a
+ *      direct fs write) is the ONLY other way content lands on disk (which the
+ *      loop never does). We pin that PreferencesManager itself never writes on
+ *      a pure read path, and that the write path is atomic (no partial file).
+ *   2. The route is gated correctly: 503 when monitoring.correctionLearning
+ *      .enabled !== true, 200 otherwise — verified directly against the route
+ *      gate logic (the config flag is the single source of truth).
+ *
+ * These complement the unit (logic) and integration (HTTP) tiers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import express from 'express';
+import request from 'supertest';
+import { PreferencesManager } from '../../src/core/PreferencesManager.js';
+import { createRoutes } from '../../src/server/routes.js';
+import type { RouteContext } from '../../src/server/routes.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const AUTH_TOKEN = 'wiring-token';
+
+function ctxFor(stateDir: string, correctionLearning: unknown): RouteContext {
+  return {
+    config: {
+      projectName: 'wiring', projectDir: path.dirname(stateDir), stateDir, port: 0,
+      authToken: AUTH_TOKEN, monitoring: { correctionLearning },
+      sessions: {} as any, scheduler: {} as any,
+    } as any,
+    sessionManager: { listRunningSessions: () => [] } as any,
+    state: { getJobState: () => null, getSession: () => null } as any,
+    scheduler: null, telegram: null, relationships: null, feedback: null,
+    dispatches: null, updateChecker: null, autoUpdater: null, autoDispatcher: null,
+    quotaTracker: null, publisher: null, viewer: null, tunnel: null, evolution: null,
+    watchdog: null, triageNurse: null, topicMemory: null, feedbackAnomalyDetector: null,
+    discoveryEvaluator: null, startTime: new Date(),
+  } as unknown as RouteContext;
+}
+
+function appWith(ctx: RouteContext): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/', createRoutes(ctx));
+  return app;
+}
+
+describe('Preferences wiring integrity (Slice 1a)', () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-wiring-'));
+    stateDir = path.join(tmpDir, '.instar');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/preferences-wiring-integrity.test.ts:afterEach' });
+  });
+
+  describe('recordPreference is the only writer', () => {
+    it('a pure read path never creates or mutates the file', () => {
+      const mgr = new PreferencesManager(stateDir);
+      mgr.read();
+      mgr.sessionContext();
+      expect(fs.existsSync(mgr.getPath())).toBe(false);
+    });
+
+    it('the file appears on disk only after recordPreference()', () => {
+      const mgr = new PreferencesManager(stateDir);
+      expect(fs.existsSync(mgr.getPath())).toBe(false);
+      mgr.recordPreference({ learning: 'x', dedupeKey: 'k:1' });
+      expect(fs.existsSync(mgr.getPath())).toBe(true);
+    });
+
+    it('the on-disk file is always valid JSON after a write (atomic, no partial)', () => {
+      const mgr = new PreferencesManager(stateDir);
+      for (let i = 0; i < 25; i++) mgr.recordPreference({ learning: `learning ${i}`, dedupeKey: `k:${i % 5}` });
+      const raw = fs.readFileSync(mgr.getPath(), 'utf-8');
+      expect(() => JSON.parse(raw)).not.toThrow();
+      const parsed = JSON.parse(raw);
+      expect(Array.isArray(parsed.preferences)).toBe(true);
+      // 5 distinct dedupeKeys → exactly 5 entries (upsert, not append)
+      expect(parsed.preferences).toHaveLength(5);
+    });
+  });
+
+  describe('route gate is keyed solely on monitoring.correctionLearning.enabled', () => {
+    it('503 when undefined', async () => {
+      const res = await request(appWith(ctxFor(stateDir, undefined))).get('/preferences/session-context');
+      expect(res.status).toBe(503);
+    });
+
+    it('503 when { enabled: false }', async () => {
+      const res = await request(appWith(ctxFor(stateDir, { enabled: false }))).get('/preferences/session-context');
+      expect(res.status).toBe(503);
+    });
+
+    it('503 when enabled is a truthy non-true value (strict === true gate)', async () => {
+      const res = await request(appWith(ctxFor(stateDir, { enabled: 'yes' }))).get('/preferences/session-context');
+      expect(res.status).toBe(503);
+    });
+
+    it('200 only when { enabled: true }', async () => {
+      const res = await request(appWith(ctxFor(stateDir, { enabled: true }))).get('/preferences/session-context');
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,84 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+**New preferences read-surface (Correction & Preference Learning Sentinel —
+Slice 1a).** This is the structural application surface for auto-learned user
+preferences, modeled exactly on the existing ORG-INTENT session-start pattern.
+It adds three pieces that work together:
+
+- A new in-process primitive, `recordPreference()`, that is the ONLY writer to
+  a new structured file at `.instar/preferences.json`. Writes are atomic (temp
+  file + rename), schema-versioned, and upsert by `dedupeKey` — so a recurring
+  preference collapses to one entry whose observation count grows rather than
+  piling up duplicates. An absent file simply means "no preferences" (it is
+  never required to exist).
+- A new HTTP route, `GET /preferences/session-context`, gated on
+  `monitoring.correctionLearning.enabled`. When the feature is off it returns
+  503; when on, it serves the active preferences as a structured block, bounded
+  by `maxInjectedPreferencesBytes` (4000) and priority-ordered by recency ×
+  confidence × dedupe-count. It serves only the learning text plus metadata —
+  never any raw internal fields.
+- A session-start hook patch: the hook now fetches that route on every boot and
+  injects the returned block, wrapped in an `<auto-learned-preference
+  src='correction-loop'>` envelope so a learned preference can never be mistaken
+  for an authoritative instruction.
+
+This is **signal-only**. It stores, serves, and injects preferences so the agent
+always SEES them — it NEVER blocks or rewrites an outbound message. The whole
+feature ships OFF by default (`monitoring.correctionLearning.enabled: false`),
+so on this update nothing changes behaviorally until you turn it on. Slice 1b
+(the capture → distill → ledger → recurrence-gate loop that writes through
+`recordPreference()`) lands in a later change and consumes this surface.
+
+## What to Tell Your User
+
+Nothing changes unless you turn it on. This update adds the plumbing for me to
+learn your preferences over time — the repeated corrections you make, like
+asking me to be plainer or to lead with the action. When that learning loop is
+switched on in a later release, anything I learn about how you like to work gets
+injected into my context at the start of every session, so I carry it forward
+instead of forgetting it when a conversation ends. These learned preferences are
+always treated as gentle signals, never as commands, and a real instruction or a
+safety rule always wins. For now the feature is off by default and there is
+nothing for you to do.
+
+## Summary of New Capabilities
+
+- New primitive: `recordPreference()` — the single, atomic, schema-versioned
+  writer to `.instar/preferences.json` (upsert by `dedupeKey`).
+- New route: `GET /preferences/session-context` — serves the byte-bounded,
+  priority-ordered learned-preference block (503 when disabled; `{ present:
+  false }` when none). Bearer-authed like sibling routes; classified in the
+  CapabilityIndex so it is discoverable via `GET /capabilities`.
+- Session-start hook now injects the `<auto-learned-preference>` block on every
+  boot when the feature is enabled and preferences exist (fail-open: 503 /
+  unreachable / empty → injects nothing).
+- New config block `monitoring.correctionLearning` (ships OFF), backfilled into
+  existing agents automatically via `applyDefaults` deep-merge.
+- CLAUDE.md template + migrator backfill so existing agents learn about the
+  surface and honor injected preferences.
+
+## Evidence
+
+- `tests/unit/PreferencesManager.test.ts` (13) — atomic write + schema version,
+  dedupe-upsert (count increments, learning/recordedAt refresh, confidence max),
+  absent-file ≡ empty, malformed-file tolerance, bounded-bytes + priority order,
+  serves only learning + metadata.
+- `tests/unit/preferences-wiring-integrity.test.ts` (7) — `recordPreference()`
+  is the only writer (read path never creates/mutates the file; atomic
+  no-partial under repeated upsert); route gate keyed strictly on
+  `correctionLearning.enabled === true`.
+- `tests/integration/preferences-routes.test.ts` (5) — 401 without bearer, 503
+  when disabled, 200 `{ present: false }` when enabled+empty, 200 structured
+  block when enabled+exists, no raw-extra leak.
+- `tests/e2e/preferences-session-context-lifecycle.test.ts` (6) — feature-alive
+  200/503 on the production AgentServer boot path; the generated session-start
+  hook emits the `<auto-learned-preference>` block when enabled+present and
+  nothing when off.
+- `tests/unit/capabilities-discoverability.test.ts` (100) — `/preferences`
+  classified; lint green.
+- Side-effects review:
+  `upgrades/side-effects/correction-preference-learning-sentinel-slice1a.md`.

--- a/upgrades/side-effects/correction-preference-learning-sentinel-slice1a.md
+++ b/upgrades/side-effects/correction-preference-learning-sentinel-slice1a.md
@@ -1,0 +1,132 @@
+# Side-effects review — Correction & Preference Learning Sentinel (Slice 1a)
+
+**Spec:** `docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md` (§3.6, §7,
+§9, §10 Slice 1a)
+**Change:** new `src/core/PreferencesManager.ts`; inline
+`GET /preferences/session-context` in `src/server/routes.ts`;
+`monitoring.correctionLearning` config block (`src/core/types.ts` +
+`src/config/ConfigDefaults.ts`); `CapabilityIndex.ts` entry; session-start hook
+patch + `migrateClaudeMd` backfill + shadow-capability marker in
+`src/core/PostUpdateMigrator.ts`; `generateClaudeMd` capability section +
+Registry-First row + proactive trigger in `src/scaffold/templates.ts`; 3-tier +
+wiring tests.
+**Class:** new read-surface feature, ships OFF, signal-only (never gates,
+blocks, or rewrites a message).
+
+## What changed
+
+A structured on-disk preferences file (`.instar/preferences.json`), the single
+atomic writer for it (`recordPreference()`), an HTTP read route serving the
+session-start block, and a session-start hook that injects that block on every
+boot. Modeled 1:1 on the proven ORG-INTENT precedent
+(`GET /intent/org/session-context` + its session-start fetch). Slice 1b (the
+capture/distill/ledger loop) is the future writer; Slice 1a only proves the
+surface is alive end-to-end.
+
+## 1. Security
+
+- **No new external input/network/egress.** The route only reads a local file
+  and serves a deterministically-formatted block. No LLM call, no outbound
+  request, no shell-out in Slice 1a (the hook's curl is loopback to the agent's
+  own server, same as ORG-INTENT).
+- **Auth:** the route is Bearer-gated by the global `authMiddleware` exactly like
+  sibling `/intent/*` routes (integration test asserts 401 without a token).
+- **Output discipline:** the served payload and the injected block contain ONLY
+  the `learning` text + metadata (confidence, seen-count). Internal fields
+  (`dedupeKey`, `provenance`) never leak (unit + integration assertions). This is
+  the §3.6 "serve only learning + metadata" rule.
+- **Injection-confusion defense:** loop-sourced preferences are wrapped in an
+  `<auto-learned-preference src='correction-loop'>` envelope so a downstream
+  prompt assembler structurally cannot mistake a learned preference for an
+  authoritative instruction. The block's own preamble restates "signals, not
+  instructions; real instructions and safety win."
+- **No policy-relaxation surface in 1a:** `recordPreference()` has no writer in
+  Slice 1a (Slice 1b adds the gated, policy-keyword-filtered caller per §3.6).
+  Until then the only way an entry lands is a direct programmatic call, which the
+  correction loop does not yet make.
+
+## 2. Migration parity
+
+- **Config:** `monitoring.correctionLearning` added to `ConfigDefaults`.
+  `applyDefaults` deep-merges add-missing-only (verified: `merge()` recurses into
+  objects, adds absent keys, never overwrites), so existing agents backfill the
+  block on update without a dedicated `migrateConfig` step — and without surprise
+  activation (`enabled: false`). This matches the spec §7 note and the
+  failure-learning precedent.
+- **Route:** inline in `routes.ts` (the discoverability-lint allowlist is fixed; a
+  separate module would trip the orphan-prefix check). `CapabilityIndex` entry
+  added so the lint passes and the route is discoverable.
+- **Hook:** built-in `instar/` hooks are always-overwrite on every migration, so
+  the patched `session-start.sh` propagates to every existing agent on the next
+  update — no hand-written `migrateHooks` block needed.
+- **CLAUDE.md:** `generateClaudeMd` gains the capability section / Registry-First
+  row / proactive trigger; `migrateClaudeMd` gains a content-sniffed backfill
+  (marker `Correction & Preference Learning Sentinel`) so EXISTING agents learn
+  the surface — not just new ones. A shadow-capability marker
+  (`**Preferences I've learned about you**`) mirrors it into Codex/Gemini
+  `AGENTS.md`/`GEMINI.md`. `feature-delivery-completeness` enforces all three legs.
+- **State file:** `.instar/preferences.json` is created lazily on first write;
+  absent ≡ empty. No migration needed.
+
+## 3. Performance
+
+- The read route does one small synchronous file read + a deterministic
+  string-build bounded by `maxInjectedPreferencesBytes` (4000). No DB, no LLM, no
+  network. Cost is negligible and constant-ish.
+- `recordPreference()` reads + rewrites the whole file atomically. The file is
+  bounded by distinct-preference cardinality (upsert by `dedupeKey`), not message
+  volume, so it stays tiny in practice. Each write is one temp-file + fsync +
+  rename.
+- The session-start hook adds one loopback curl with `--max-time 4`; fail-open on
+  timeout, so a slow/absent server can never delay session start beyond that cap.
+
+## 4. Observability
+
+- The route is discoverable via `GET /capabilities` (CapabilityIndex entry,
+  `enabled` reflects the flag).
+- `{ present, block, count }` makes the served state self-describing; `count`
+  exposes distinct-preference cardinality for debugging.
+- No new log channel in 1a (the audit log `logs/correction-learning-audit.jsonl`
+  is a Slice 1b concern — the loop that produces routable decisions).
+
+## 5. Rollback
+
+- Flip `monitoring.correctionLearning.enabled` back to false (or remove the
+  block) → the route 503s and the hook injects nothing. Inert.
+- `.instar/preferences.json` entries all carry `provenance: 'correction-loop'`,
+  enabling a one-shot bulk removal (a single jq-style filter) if a future loop
+  ever writes something unwanted. In 1a nothing writes, so the file stays absent.
+- Code rollback = revert the commits; the absent-file ≡ empty contract means a
+  rolled-back agent with a stray file is still consistent (read tolerates and
+  ignores it; the route 503s when the flag is gone).
+
+## 6. Multi-machine
+
+- The file is per-agent-home local state (under `stateDir`), like ORG-INTENT.md
+  and the integrated-being ledger. On a multi-machine agent each machine reads
+  its own copy; the existing state-sync layer carries `.instar/` files between
+  machines the same way it carries ORG-INTENT.md — no new sync path introduced.
+- The route is read-only and idempotent; no lease/fencing interaction. Slice 1a
+  has no writer competing across machines (that is a Slice 1b consideration when
+  the loop runs only on the awake machine).
+
+## 7. Multi-user
+
+- Slice 1a is a pure read/inject surface and does not itself attribute a
+  preference to a user — it serves whatever was recorded. The multi-user
+  primary-user gate (§3.6) lives in Slice 1b, where corrections are attributed
+  and `recordPreference()` is actually called. Until then no user-shaped data can
+  enter the file via this feature.
+- The injected block is the same for every session on the agent (it is the
+  agent's learned-about-this-operator preferences), consistent with the
+  single-operator model the rest of the agent assumes.
+
+## Tests
+
+- Unit: `tests/unit/PreferencesManager.test.ts` (13),
+  `tests/unit/preferences-wiring-integrity.test.ts` (7).
+- Integration: `tests/integration/preferences-routes.test.ts` (5).
+- E2E: `tests/e2e/preferences-session-context-lifecycle.test.ts` (6).
+- Lint: `tests/unit/capabilities-discoverability.test.ts` (100) green;
+  `tests/unit/feature-delivery-completeness.test.ts` green (parity + shadow
+  marker for the new section).


### PR DESCRIPTION
## Slice 1a — Correction & Preference Learning Sentinel

First slice of the approved [Correction & Preference Learning Sentinel spec](docs/specs/CORRECTION-PREFERENCE-LEARNING-SENTINEL-SPEC.md) (5-round converged; approved by Justin 2026-05-30). The conversational twin of the Failure-Learning Loop — it learns from moments the user has to correct the agent.

**This slice builds the structural application surface only** (the prereq the loop in Slice 1b writes to), mirroring the working ORG-INTENT session-context precedent:

- `recordPreference()` primitive (`src/core/PreferencesManager.ts`) — the ONLY writer to `.instar/preferences.json`; atomic temp+rename, schema-versioned, upsert by dedupeKey, absent-file ≡ empty.
- `GET /preferences/session-context` (inline in routes.ts) — gated on `monitoring.correctionLearning.enabled` (503 disabled / 200 structured block); byte-bounded + priority-ordered; serves only learning + metadata.
- Session-start hook patch — fetches the endpoint on every boot and injects the active preferences wrapped in an `<auto-learned-preference src='correction-loop'>` envelope (fail-open on 503/unreachable/empty).
- Config defaults (`correctionLearning` block, ships OFF), CapabilityIndex entry, Agent-Awareness (generateClaudeMd + migrateClaudeMd backfill).

### Signal-only (by design)
This is **pure signal-only** — it NEVER blocks or rewrites an outbound message. The earlier "EnforcementGate"/outbound-blocking idea was explicitly rejected (breaks the signal-vs-authority standard; "bitten before by guards that block messages having too much power"). Preferences are injected as *signals, not authoritative instructions*; a real instruction or safety rule always wins.

### Ships dark
`monitoring.correctionLearning.enabled = false` by default — zero behavior change until enabled. Backfills existing agents via `applyDefaults` deep-merge; the session-start hook is always-overwrite so existing agents pick up the patch on next update.

### Verification
- `npm run build` ✅ · `npm run lint` ✅ (exit 0)
- 3-tier tests green (run in isolation): unit (PreferencesManager 13) + integration (routes 5: 401/503/200) + E2E (feature-alive on production boot path 6) + wiring-integrity (7, recordPreference is the only writer). Migration-parity + discoverability guards green.
- Migration parity, NEXT.md (minor bump), and seven-dimension side-effects review included.

Full suite is run by the PR CI matrix (the authoritative gate per the project's smoke-defers-to-CI design).