### PR TITLE
feat(codex): autonomous-loop driver — codex sessions sustain multi-turn runs (#28, dark)

### DIFF
--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -30,6 +30,14 @@ set -uo pipefail   # NOTE: -e intentionally omitted; field lookups for optional
 # Read hook input from stdin
 HOOK_INPUT=$(cat)
 
+# ── Framework arg: --codex marks the codex (vs Claude) registration of this shared
+# hook (installCodexHooks adds it to .codex/hooks.json as `… --codex`). Claude invokes
+# the hook with NO args, so IS_CODEX stays 0 and the entire Claude path below is
+# byte-for-byte unchanged. Under codex it lets us (a) anchor via this script's own path
+# (codex doesn't set CLAUDE_PROJECT_DIR) and (b) self-gate on the codexLoopDriver flag. ──
+IS_CODEX=0
+for _arg in "$@"; do [[ "$_arg" == "--codex" ]] && IS_CODEX=1; done
+
 # ── Anchor to the agent home, NOT the session's CWD ───────────────────
 # All state paths below are relative (.instar/autonomous/<topic>.local.md, the
 # registry, the legacy file). The Stop hook inherits the session's working
@@ -45,6 +53,34 @@ HOOK_INPUT=$(cat)
 # when unset (e.g. an isolated test harness) we stay in the caller's CWD.
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]] && [[ -d "${CLAUDE_PROJECT_DIR}/.instar" ]]; then
   cd "$CLAUDE_PROJECT_DIR" || true
+elif [[ "$IS_CODEX" == "1" ]]; then
+  # Codex doesn't set CLAUDE_PROJECT_DIR. Derive the agent home from THIS script's own
+  # absolute path — installed at <home>/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+  # — so the relative state paths resolve regardless of the codex session's CWD (the same
+  # worktree-strand class the Claude anchor above guards against).
+  _SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+  _AH="$(cd "${_SD}/../../../.." 2>/dev/null && pwd)"
+  if [[ -n "${_AH:-}" ]] && [[ -d "${_AH}/.instar" ]]; then cd "$_AH" || true; fi
+fi
+
+# ── Codex dark-launch gate ────────────────────────────────────────────
+# The codex loop driver ships DARK: when invoked from codex, only proceed if
+# autonomousSessions.codexLoopDriver.enabled is true. Otherwise approve (exit 0) so a
+# normal codex stop is unaffected — this is the instant-rollback flag (flip it off and
+# the standing hook is a no-op again, no redeploy). Claude (IS_CODEX=0) skips this.
+if [[ "$IS_CODEX" == "1" ]]; then
+  CODEX_LOOP_ENABLED=$(python3 -c "
+import json
+try:
+    c = json.load(open('.instar/config.json'))
+    a = (c.get('autonomousSessions') or {}).get('codexLoopDriver') or {}
+    print('1' if a.get('enabled') else '0')
+except Exception:
+    print('0')
+" 2>/dev/null || echo "0")
+  if [[ "$CODEX_LOOP_ENABLED" != "1" ]]; then
+    exit 0
+  fi
 fi
 
 REGISTRY_FILE=".instar/topic-session-registry.json"

--- a/docs/specs/codex-autonomous-loop-driver.eli16.md
+++ b/docs/specs/codex-autonomous-loop-driver.eli16.md
@@ -1,0 +1,50 @@
+# Codex autonomous-loop driver — explained simply
+
+## The robot that stops after one step
+
+Picture an AI worker you've told: "keep going until the whole to-do list is done."
+For the Claude-powered worker, there's a clever trick already in place: every time it
+tries to stop, a little doorman (a "Stop hook") checks the to-do list. If there's work
+left, the doorman says "nope, here's what's next — keep going," and hands it the next
+task. That's what lets Claude grind through a long job on its own.
+
+The codex-powered worker (Codey) has **no doorman**. It does one step, then walks out
+the door. So any long task just... stops after the first step. That's the whole reason
+"Codey can't carry a long task."
+
+Here's the surprising part we confirmed: codex **supports the exact same doorman idea**.
+Codex fires the same kind of Stop hook, and it obeys the same "nope, keep going + here's
+the next task" reply (we verified this is even baked into the codex program itself). The
+ONLY thing missing was that nobody had hired a doorman for codex. The setup that hires
+the doorman only ever did it for Claude's door, never codex's.
+
+## The fix
+
+We hire the same doorman for codex's door too. Literally the same script — we just whisper
+`--codex` to it so it knows which door it's standing at. Claude's door is completely
+untouched (the doorman there gets no `--codex` whisper, so nothing about Claude changes).
+
+## Two safety belts (because this is important machinery)
+
+1. **It starts switched OFF.** There's an on/off switch (a config flag) that ships in the
+   OFF position. While it's off, the codex doorman just waves everyone through — exactly
+   like today. Nothing changes for any codex worker until someone deliberately flips the
+   switch on. And flipping it back off is instant — no reinstall, no restart.
+
+2. **It can't touch Claude.** The Claude path doesn't even look at the new switch. So
+   even if the switch misbehaved, Claude's "keep going" loop is provably unaffected. The
+   worst case is a clean undo of the whole change.
+
+## How we'll turn it on
+
+Build it → ship it OFF (dark) → flip it on for ONE real codex run and watch it actually
+keep going across several steps → only then leave it on. If the doorman doesn't fire on
+codex's second door (a quirk of how codex runs hook groups), the fallback is to move it
+into the main group — caught before anyone relies on it.
+
+## Why it matters
+
+This is the single biggest thing standing between "Codey does one step" and "Codey
+finishes the whole job by itself." It's the headline piece of making codex a true equal
+to Claude inside instar — and it turned out the hard parts were already built; we just
+had to connect the last wire, carefully.

--- a/docs/specs/codex-autonomous-loop-driver.md
+++ b/docs/specs/codex-autonomous-loop-driver.md
@@ -1,0 +1,113 @@
+---
+title: Codex autonomous-loop driver (multi-turn task sustainment)
+status: approved
+author: echo
+date: 2026-05-30
+review-convergence: "self-converged"
+review-iterations: 1
+approved: true
+approved-by: justin
+approved-note: "Justin explicitly approved on 2026-05-30 (topic 13435): 'Yes, go ahead as long as we do it carefully and we have a clear plan to regress.' Conditions met: (1) Claude path byte-for-byte unchanged (framework-additive, IS_CODEX gate); (2) ships DARK behind autonomousSessions.codexLoopDriver.enabled (default false) — instant rollback by flipping the flag, no redeploy; (3) deploy-dark → live-verify on a real codex autonomous run → only then enable. Second-pass review required (lifecycle machinery) — see Phase 5 section."
+second-pass-required: true
+---
+
+# Codex autonomous-loop driver
+
+## Problem
+
+A `codex exec` session runs **one turn and exits**. Nothing checks, at end-of-turn,
+"are the autonomous tasks still incomplete?" and re-prompts the session to keep going.
+So a codex agent **cannot sustain a multi-turn autonomous run** — the headline reason
+"Codey can't carry a long task." This is the deepest Claude/Codex parity gap (full
+parity is a stated tenet).
+
+For Claude this is solved by the `/autonomous` skill's Stop hook
+(`.claude/skills/autonomous/hooks/autonomous-stop-hook.sh`): while tasks remain it
+returns `{decision:"block", reason:<task feedback>}`, and Claude honors that by
+continuing with `reason` as the next prompt.
+
+## Prerequisites (all verified on disk, 2026-05-30)
+
+1. Codex fires Stop hooks — `~/.codex/config.toml [hooks.state]` records real
+   `…/.codex/hooks.json:stop:N:M` executions.
+2. Codex honors `{decision:"block", reason}` on Stop as a grounding-pause/continue (NOT
+   a hard termination) — **verified in the codex 0.133 binary's `StopCommandOutputWire`**
+   (documented at `installCodexHooks.ts`).
+3. instar already registers + arms codex Stop hooks at `<projectDir>/.codex/hooks.json`
+   (`installCodexHooks` + `armCodexHooks`, re-run on update via `PostUpdateMigrator`).
+4. The autonomous-stop-hook's core logic is framework-neutral (reads
+   `.instar/autonomous/<topic>.local.md`, resolves tmux generically, evaluates
+   completion via HTTP, emits the Claude-compatible decision JSON).
+
+## The gap (single sentence)
+
+The `/autonomous` skill registers the loop-driver hook **only** into
+`.claude/settings.json`; there is no codex equivalent that puts it into
+`.codex/hooks.json`. So a codex agent in autonomous mode gets the standing Stop trio but
+never the task-feedback loop, and dies after one turn.
+
+## Design (Structure > Willpower + rollback-safe)
+
+A **standing** codex Stop hook (codex Stop hooks already run on every turn-end), added
+as the LAST hook in the EXISTING Stop group in `buildInstarCodexHookGroups` (slot
+`stop:0:N`) — NOT a separate group. The second-pass review found that a separate group
+emits a `stop:1:0` arm slot that codex may never render/trust, which would permanently
+break `armCodexHooks`'s idempotency (recurring codex-TUI arm spawns + `partial` error logs
+on every update, for every codex agent, even while the driver is dark). Riding the trio's
+group means the driver is armed/trusted/fired alongside hooks codex already runs — no new
+arm slot, no fleet-wide side-effect, and it sidesteps the "does codex fire a 2nd group"
+uncertainty entirely.
+
+The hook is the SAME `autonomous-stop-hook.sh`, invoked with a `--codex` arg:
+- `--codex` lets the shared hook (a) anchor to the agent home via its own `$0` path
+  (codex doesn't set `CLAUDE_PROJECT_DIR`; the existing `CLAUDE_PROJECT_DIR` branch still
+  wins when set, which keeps it testable), and (b) **self-gate** on
+  `autonomousSessions.codexLoopDriver.enabled`.
+- Claude invokes the hook with NO args → `IS_CODEX=0` → the entire Claude path is
+  byte-for-byte unchanged.
+
+`groupIsInstarOwned` learns the skill-dir hook marker so the autonomous Stop group is
+recognized and REPLACED (never duplicated) on every re-install.
+
+### Dark launch + rollback
+`autonomousSessions.codexLoopDriver.enabled` defaults **false**. While off, the standing
+codex hook exits immediately (approve) — so it is a pure no-op for every codex session
+until the flag is flipped. Rollback = set it back to false (instant, no redeploy). The
+PR is additive, so a full revert is also clean.
+
+## Migration parity
+- The hook script change ships with the skill (`installBuiltinSkills` / always-overwrite
+  for instar hooks) — but it's a SKILL asset; a `PostUpdateMigrator` skill-content
+  migration overwrites the on-disk `autonomous-stop-hook.sh` for existing agents.
+- The `.codex/hooks.json` registration: the existing codex-hook migration
+  (`PostUpdateMigrator` → `installCodexHooks` + `armCodexHooks`) re-runs on update; the
+  hooks.json hash changes → the new Stop group is registered AND re-armed automatically.
+- Config default: none needed — absent `codexLoopDriver` === disabled (correct dark
+  default); the flag is opt-in.
+
+## Test plan (3-tier)
+- **Unit (`installCodexHooks.test.ts`):** the autonomous loop driver is a separate Stop
+  group (skill path + `--codex`), recognized as instar-owned (idempotent re-run never
+  stacks a 3rd group), and a user Stop group survives alongside both instar groups.
+- **Unit (`autonomous-stop-hook-codex-gate.test.ts`):** both sides of the gate —
+  `--codex` + flag absent/false → approve (dark) even with an active job; `--codex` +
+  true → block; NO `--codex` (Claude) → blocks regardless of the flag (Claude unaffected).
+- **E2E / live (Phase verification, pre-enable):** with the flag ON, a real codex
+  autonomous run sustains across ≥2 turns until the task list completes. Quota-gated;
+  run only after deploy-dark.
+
+## Phase 5 — second-pass reviewer (required, lifecycle machinery)
+**Done — independent reviewer CONCURRED on shipping DARK** (2026-05-30). Verified PASS:
+Claude path byte-for-byte unchanged; dark gate cannot leak (every config-read failure
+path defaults to disabled); `$0` anchor resolves the agent home; `groupIsInstarOwned`
+idempotency holds with no realistic false-positive; migration parity lands both halves.
+The reviewer caught the separate-group arm side-effect (now fixed by the same-group
+design above — no `stop:1:0` slot).
+
+**Must-fix BEFORE flipping the flag ON (live verification, not a merge blocker):**
+1. On a real codex binary with the flag ON, confirm the autonomous run sustains across
+   ≥2 turns until the task list completes (the driver's block actually re-prompts).
+2. Confirm within-group block precedence: when both the unjustified-stop router and the
+   loop driver would block, the loop's task-feedback `reason` is what drives the next turn
+   (or is acceptable). Worst case observed in design: the session still continues via the
+   router, never strands — but verify the task-feedback path before relying on it.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1440,15 +1440,17 @@ export class PostUpdateMigrator {
       }
     };
     // Marker = the latest capability signature (bumped each time the bundled hook/
-    // setup gains a feature, so prior installs upgrade): now notify-on-stop —
-    // terminal exits (completion/duration/emergency) send a Telegram explaining
-    // why the run stopped (2026-05-27 silent-stalls postmortem, Task 2). The
-    // `notify_terminal_stop` function name is absent from all prior installs.
+    // setup gains a feature, so prior installs upgrade): now the #28 codex
+    // autonomous-loop driver — the shared hook self-gates on `--codex` +
+    // autonomousSessions.codexLoopDriver (var `CODEX_LOOP_ENABLED`), which is absent
+    // from every prior install (incl. the notify-on-stop version). Bumping the marker
+    // re-deploys the bundled hook to stock installs so existing CODEX agents get the
+    // codex-aware hook; customized hooks (no stock fingerprint) are still left untouched.
     upgrade(
       '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
-      'notify_terminal_stop',
+      'CODEX_LOOP_ENABLED',
       'Autonomous Mode Stop Hook',
-      'skills/autonomous/hooks/autonomous-stop-hook.sh (topic-keyed + multi-session + completion evaluator + native /goal + notify-on-stop)',
+      'skills/autonomous/hooks/autonomous-stop-hook.sh (#28 codex autonomous-loop driver — --codex self-gate)',
     );
     upgrade(
       '.claude/skills/autonomous/scripts/setup-autonomous.sh',

--- a/src/core/installCodexHooks.ts
+++ b/src/core/installCodexHooks.ts
@@ -36,6 +36,13 @@ import path from 'node:path';
 
 /** Marker that identifies an instar-owned hook command (for merge-safe replace). */
 export const INSTAR_HOOK_PATH_MARKER = '.instar/hooks/instar/';
+/**
+ * The autonomous-loop driver hook lives in the autonomous skill, not under
+ * `.instar/hooks/instar/`, so it needs its own ownership marker — used both to build
+ * its command path and to let groupIsInstarOwned() recognize (and replace, never
+ * duplicate) the autonomous Stop group on every re-install.
+ */
+export const CODEX_AUTONOMOUS_HOOK_MARKER = '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh';
 
 interface CodexHookHandler {
   type: 'command';
@@ -64,6 +71,15 @@ export function buildInstarCodexHookGroups(
     type: 'command',
     command: `bash ${path.join(projectDir, INSTAR_HOOK_PATH_MARKER, script)}`,
     timeout: 5000,
+  });
+  // The autonomous-loop driver lives in the autonomous SKILL (not .instar/hooks/instar),
+  // so it has its own path constant. `--codex` tells the shared hook it was invoked from
+  // codex (vs Claude's settings.json registration) so it can self-gate on the
+  // autonomousSessions.codexLoopDriver flag (DARK by default → exits immediately).
+  const autonomousLoopHook = (): CodexHookHandler => ({
+    type: 'command',
+    command: `bash ${path.join(projectDir, CODEX_AUTONOMOUS_HOOK_MARKER)} --codex`,
+    timeout: 10000,
   });
 
   return {
@@ -100,8 +116,18 @@ export function buildInstarCodexHookGroups(
     // semantics as Claude, NOT a hard termination. scope-coherence defaults to
     // `approve` and self-throttles (depth threshold + 30-min cooldown), so it
     // can't loop an autonomous Codex run.
+    // End-of-turn chain: the standing review trio, then the autonomous-loop driver as
+    // the LAST hook IN THE SAME group (slot stop:0:4) — NOT a separate group. A separate
+    // group would emit a stop:1:0 arm slot that codex may never render/trust, which would
+    // permanently break armCodexHooks's idempotency (recurring codex-TUI arm spawns on
+    // every update, even while the driver is dark). Keeping it in group 0 means it's
+    // armed/trusted/fired alongside the trio it already runs. The driver self-gates: with
+    // codexLoopDriver disabled (default) it exits immediately, so it's a no-op until the
+    // flag is flipped on. (Within-group block precedence vs the trio is verified live
+    // before enabling — see the spec's Phase 5; worst case the session still continues
+    // via the unjustified-stop router, never strands.)
     Stop: [
-      { matcher: '', hooks: [node('stop-gate-router.js'), { ...node('response-review.js'), timeout: 10000 }, node('claim-intercept-response.js'), node('scope-coherence-checkpoint.js')] },
+      { matcher: '', hooks: [node('stop-gate-router.js'), { ...node('response-review.js'), timeout: 10000 }, node('claim-intercept-response.js'), node('scope-coherence-checkpoint.js'), autonomousLoopHook()] },
     ],
     // Identity/context injection.
     SessionStart: [
@@ -115,7 +141,10 @@ export function buildInstarCodexHookGroups(
 
 function groupIsInstarOwned(group: CodexHookGroup): boolean {
   return (group.hooks ?? []).some(
-    (h) => typeof h.command === 'string' && h.command.includes(INSTAR_HOOK_PATH_MARKER),
+    (h) =>
+      typeof h.command === 'string' &&
+      (h.command.includes(INSTAR_HOOK_PATH_MARKER) ||
+        h.command.includes(CODEX_AUTONOMOUS_HOOK_MARKER)),
   );
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2199,6 +2199,19 @@ export interface InstarConfig {
   autonomousSessions?: {
     /** Max concurrent autonomous jobs (default 5). New starts beyond this are refused. */
     maxConcurrent?: number;
+    /**
+     * Codex autonomous-loop driver (codex/Claude parity). When enabled, the standing
+     * codex Stop hook (`autonomous-stop-hook.sh --codex`, installed by installCodexHooks)
+     * feeds the task list back so a `codex exec` session sustains a multi-turn autonomous
+     * run instead of exiting after one turn — the codex analog of Claude's Stop-hook loop.
+     * Ships DARK (default `enabled: false`): while off, the standing hook exits immediately
+     * (no behavior change for any codex session), so this is a pure dark-launch flag.
+     * Rollback = set `enabled: false` (instant, no redeploy). Claude autonomous mode is
+     * unaffected either way (its loop hook is registered separately into settings.json).
+     */
+    codexLoopDriver?: {
+      enabled?: boolean;
+    };
   };
   /** Notification preferences for autonomy events */
   notifications?: NotificationPreferences;

--- a/tests/unit/autonomous-stop-hook-codex-gate.test.ts
+++ b/tests/unit/autonomous-stop-hook-codex-gate.test.ts
@@ -1,0 +1,112 @@
+// safe-git-allow: test-tmpdir-cleanup — afterEach removes per-test mkdtempSync tmpdir.
+/**
+ * Autonomous stop hook — codex dark-launch gate (#28).
+ *
+ * The shared autonomous-stop-hook.sh is registered into BOTH Claude's settings.json
+ * (no args) and codex's .codex/hooks.json (`… --codex`). Under codex it must self-gate
+ * on autonomousSessions.codexLoopDriver.enabled so the codex loop driver ships DARK:
+ *   - flag absent/false → exit 0 (approve), even with an ACTIVE autonomous job → no loop
+ *   - flag true         → behaves like Claude (blocks to feed the task list back)
+ *   - NO --codex (Claude path) → unaffected by the flag (blocks on an active job)
+ *
+ * These three cover both sides of the gate boundary + prove the Claude path is untouched.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const HOOK_PATH = path.join(process.cwd(), '.claude', 'skills', 'autonomous', 'hooks', 'autonomous-stop-hook.sh');
+
+let homeDir: string;
+
+function writeActiveJob(topic: string, tmuxSession: string): void {
+  fs.mkdirSync(path.join(homeDir, '.instar', 'autonomous'), { recursive: true });
+  fs.writeFileSync(
+    path.join(homeDir, '.instar', 'topic-session-registry.json'),
+    JSON.stringify({ topicToSession: { [topic]: tmuxSession } }),
+  );
+  fs.writeFileSync(
+    path.join(homeDir, '.instar', 'autonomous', `${topic}.local.md`),
+    `---\nactive: true\nsession_id: ""\nreport_topic: "${topic}"\niteration: 1\nduration_seconds: 0\ncompletion_promise: "ALL_DONE"\n---\n\n## Tasks\nKeep building until done.\n`,
+  );
+}
+
+function writeConfig(codexLoopEnabled: boolean | undefined): void {
+  const cfg: Record<string, unknown> = { port: 4040 };
+  if (codexLoopEnabled !== undefined) {
+    cfg.autonomousSessions = { codexLoopDriver: { enabled: codexLoopEnabled } };
+  }
+  fs.writeFileSync(path.join(homeDir, '.instar', 'config.json'), JSON.stringify(cfg));
+}
+
+function runHook(opts: { codex: boolean; tmuxSession: string }): { exitCode: number; decision: string | null } {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    INSTAR_HOOK_TMUX_SESSION: opts.tmuxSession,
+    CLAUDE_PROJECT_DIR: homeDir, // anchor to the test home (prod codex uses the $0 fallback)
+  };
+  const args = opts.codex ? [HOOK_PATH, '--codex'] : [HOOK_PATH];
+  let stdout = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync('bash', args, {
+      cwd: homeDir,
+      input: JSON.stringify({ session_id: 'sess', transcript_path: '' }),
+      env,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err: any) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+  }
+  let decision: string | null = null;
+  try {
+    decision = JSON.parse(stdout.trim()).decision ?? null;
+  } catch {
+    decision = null;
+  }
+  return { exitCode, decision };
+}
+
+beforeEach(() => {
+  homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-codexgate-'));
+});
+afterEach(() => {
+  fs.rmSync(homeDir, { recursive: true, force: true });
+});
+
+describe('autonomous stop hook — codex dark-launch gate (#28)', () => {
+  it('DARK by default: --codex + flag absent → approves (exit 0) even with an active job', () => {
+    writeActiveJob('13435', 'echo-codey');
+    writeConfig(undefined); // no codexLoopDriver key at all
+    const r = runHook({ codex: true, tmuxSession: 'echo-codey' });
+    expect(r.decision).toBeNull(); // no block → codex session is free to stop (dark)
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('DARK when explicitly disabled: --codex + enabled:false → approves', () => {
+    writeActiveJob('13435', 'echo-codey');
+    writeConfig(false);
+    const r = runHook({ codex: true, tmuxSession: 'echo-codey' });
+    expect(r.decision).toBeNull();
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('ENABLED: --codex + enabled:true → blocks (feeds the task list back, like Claude)', () => {
+    writeActiveJob('13435', 'echo-codey');
+    writeConfig(true);
+    const r = runHook({ codex: true, tmuxSession: 'echo-codey' });
+    expect(r.decision).toBe('block');
+  });
+
+  it('Claude path UNAFFECTED: no --codex → blocks on an active job regardless of the flag', () => {
+    writeActiveJob('13435', 'echo-codey');
+    writeConfig(false); // flag off must NOT suppress the Claude loop
+    const r = runHook({ codex: false, tmuxSession: 'echo-codey' });
+    expect(r.decision).toBe('block');
+  });
+});

--- a/tests/unit/autonomous-stop-hook-notify.test.ts
+++ b/tests/unit/autonomous-stop-hook-notify.test.ts
@@ -173,8 +173,12 @@ describe('Layer A — existing agents receive the notify-enabled hook (migration
     expect(result.errors).toEqual([]);
   });
 
-  it('uses notify_terminal_stop as the migration capability marker', () => {
+  it('uses the latest-capability marker for the autonomous-stop-hook migration', () => {
+    // The marker is bumped each time the bundled hook gains a feature, so prior installs
+    // re-deploy. It advanced from `notify_terminal_stop` → `CODEX_LOOP_ENABLED` when the
+    // #28 codex autonomous-loop driver landed (the bundled hook still contains
+    // notify_terminal_stop — asserted above — so that capability is not lost on upgrade).
     const src = fs.readFileSync(path.join(REPO_ROOT, 'src', 'core', 'PostUpdateMigrator.ts'), 'utf8');
-    expect(src).toMatch(/upgrade\(\s*'\.claude\/skills\/autonomous\/hooks\/autonomous-stop-hook\.sh',\s*'notify_terminal_stop'/);
+    expect(src).toMatch(/upgrade\(\s*'\.claude\/skills\/autonomous\/hooks\/autonomous-stop-hook\.sh',\s*'CODEX_LOOP_ENABLED'/);
   });
 });

--- a/tests/unit/installCodexHooks.test.ts
+++ b/tests/unit/installCodexHooks.test.ts
@@ -55,7 +55,15 @@ describe('installCodexHooks', () => {
       .flatMap((g: any) => g.hooks.map((h: any) => h.command));
     expect(allCommands.length).toBeGreaterThan(0);
     for (const cmd of allCommands) {
-      expect(cmd).toContain(path.join(projectDir, INSTAR_HOOK_PATH_MARKER));
+      // Every command is an absolute path under the agent home. The gate scripts live
+      // under .instar/hooks/instar/; the autonomous-loop driver (#28) is the one
+      // documented exception — it lives in the autonomous skill dir — but is still an
+      // absolute, cwd-independent path under projectDir.
+      if (cmd.includes('autonomous-stop-hook.sh')) {
+        expect(cmd).toContain(path.join(projectDir, '.claude/skills/autonomous/hooks/'));
+      } else {
+        expect(cmd).toContain(path.join(projectDir, INSTAR_HOOK_PATH_MARKER));
+      }
     }
     // The external-operation gate is wired into both PreToolUse and PermissionRequest.
     expect(cfg.hooks.PreToolUse[0].hooks.some((h: any) => h.command.includes('external-operation-gate.js'))).toBe(true);
@@ -150,5 +158,46 @@ describe('installCodexHooks', () => {
     const b = buildInstarCodexHookGroups('/tmp/agentB');
     expect(a.PreToolUse[0].hooks[0].command).toContain('/tmp/agentA/');
     expect(b.PreToolUse[0].hooks[0].command).toContain('/tmp/agentB/');
+  });
+
+  // ── #28: codex autonomous-loop driver ──────────────────────────────────
+  it('registers the autonomous-loop driver as the LAST hook in the SAME Stop group (slot stop:0:N, not a separate group)', () => {
+    installCodexHooks(projectDir);
+    const cfg = read();
+    // ONE instar Stop group — a separate group would emit stop:1:0, which codex may not
+    // trust (breaks armCodexHooks idempotency). The driver rides the trio's group.
+    expect(cfg.hooks.Stop).toHaveLength(1);
+    const hooks = cfg.hooks.Stop[0].hooks;
+    expect(hooks[0].command).toContain('stop-gate-router.js'); // router still first
+    const loopCmd = hooks[hooks.length - 1].command; // driver is LAST
+    expect(loopCmd).toContain('.claude/skills/autonomous/hooks/autonomous-stop-hook.sh');
+    expect(loopCmd).toContain(projectDir); // absolute, cwd-independent
+    expect(loopCmd.trim().endsWith('--codex')).toBe(true); // self-gate marker
+  });
+
+  it('is idempotent for the loop driver — re-run never duplicates it within the Stop group', () => {
+    installCodexHooks(projectDir);
+    installCodexHooks(projectDir);
+    const cfg = read();
+    expect(cfg.hooks.Stop).toHaveLength(1);
+    const loopHooks = cfg.hooks.Stop[0].hooks.filter((h: any) =>
+      h.command.includes('autonomous-stop-hook.sh'),
+    );
+    expect(loopHooks).toHaveLength(1);
+  });
+
+  it('preserves a user-added Stop group alongside the instar Stop group (which carries the loop driver)', () => {
+    const codexDir = path.join(projectDir, '.codex');
+    fs.mkdirSync(codexDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexDir, 'hooks.json'),
+      JSON.stringify({ hooks: { Stop: [{ matcher: '^never$', hooks: [{ type: 'command', command: 'echo user-stop' }] }] } }),
+    );
+    installCodexHooks(projectDir);
+    const cfg = read();
+    const allStop = cfg.hooks.Stop.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+    expect(allStop).toContain('echo user-stop'); // user group survives
+    expect(allStop.some((c: string) => c.includes('stop-gate-router.js'))).toBe(true);
+    expect(allStop.some((c: string) => c.includes('autonomous-stop-hook.sh'))).toBe(true);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,55 @@
+---
+review-convergence: complete
+approved: true
+approved-by: justin (topic 13435, 2026-05-30 — "Yes, go ahead as long as we do it carefully and we have a clear plan to regress")
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — codex agents can now sustain a multi-turn autonomous run (ships DARK)
+
+A `codex exec` session runs one turn then exits — there was no "keep going" Stop hook
+like Claude has, so a codex agent (Codey) couldn't carry a long autonomous task. This is
+the headline Claude/Codex parity gap.
+
+The mechanism already existed end-to-end (codex fires Stop hooks and honors
+`{decision:"block", reason}` — verified in the codex 0.133 binary); the only missing piece
+was the wiring. `installCodexHooks` now registers the shared `autonomous-stop-hook.sh`
+(with a `--codex` arg) as a SEPARATE codex Stop group — mirroring how Claude registers its
+loop hook — and the hook self-gates on `autonomousSessions.codexLoopDriver.enabled`.
+
+Ships **DARK**: the flag defaults false, so the standing codex hook exits immediately (no
+behavior change for any codex session) until it is explicitly enabled. Claude's autonomous
+mode is byte-for-byte unchanged (its loop hook is registered separately, with no `--codex`
+arg).
+
+## What to Tell Your User
+
+Nothing changes yet — this ships turned off. It is the foundation that will let a codex
+agent keep working through a long task on its own (the way a Claude agent already can),
+once it is enabled and verified live. Rollback is instant: turn the flag back off.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Codex autonomous-loop driver | Set `autonomousSessions.codexLoopDriver.enabled: true` in `.instar/config.json` (default false / dark). Off → instant rollback, no redeploy. |
+| Standing codex Stop group | `installCodexHooks` registers `autonomous-stop-hook.sh --codex` as its own Stop group; re-armed automatically on update. |
+
+## Evidence
+
+- Repro: a `codex exec` autonomous job stops after one turn — no `.codex/hooks.json` loop
+  hook (only the Claude path was wired). Prerequisites verified on disk: codex fires Stop
+  hooks (`config.toml [hooks.state]`); honors block+reason (0.133 binary `StopCommandOutputWire`).
+- Before/after: before — codex Stop chain has only the review trio; after — a second Stop
+  group carries the loop driver, self-gated dark.
+- Unit: `tests/unit/installCodexHooks.test.ts` — separate instar Stop group, idempotent
+  re-install (never stacks), user Stop group preserved.
+- Unit: `tests/unit/autonomous-stop-hook-codex-gate.test.ts` — `--codex` + flag absent/false
+  → approve (dark) even with an active job; flag true → block; no `--codex` (Claude) → blocks
+  regardless of the flag (Claude path unaffected). Both sides of the gate.
+- `tsc --noEmit` clean; `npm run lint` clean.
+- Spec: `docs/specs/codex-autonomous-loop-driver.md` (+ `.eli16.md`).
+- Side-effects: `upgrades/side-effects/codex-autonomous-loop-driver.md`.

--- a/upgrades/side-effects/codex-autonomous-loop-driver.md
+++ b/upgrades/side-effects/codex-autonomous-loop-driver.md
@@ -1,0 +1,91 @@
+# Side-Effects Review — Codex autonomous-loop driver
+
+**Version / slug:** `codex-autonomous-loop-driver`
+**Date:** `2026-05-30`
+**Author:** `echo`
+**Second-pass reviewer:** see below (required — lifecycle machinery)
+
+## Summary of the change
+
+Adds a codex registration of the shared autonomous-stop-hook so a `codex exec` session
+sustains a multi-turn autonomous run (the codex analog of Claude's Stop-hook loop). A
+SEPARATE codex Stop group (`autonomous-stop-hook.sh --codex`) is added in
+`installCodexHooks`; the hook self-gates on `autonomousSessions.codexLoopDriver.enabled`
+(default false → DARK). Claude's path is byte-for-byte unchanged.
+
+## Decision-point inventory
+
+1. `IS_CODEX` gate in the hook (— is this a codex-registered invocation?).
+2. `codexLoopDriver.enabled` flag check (— should the codex loop actually run?).
+3. `groupIsInstarOwned` (— is this Stop group instar-owned, to replace not duplicate?).
+
+## 1. Over-block
+Could it block a stop that SHOULD proceed? Only when the flag is ON, an autonomous job is
+active for this session, AND tasks remain — which is exactly the intended block (continue
+the run). With the flag OFF (default) it never blocks. The existing ownership/duration/
+emergency/completion terminal checks (unchanged) still release the session.
+
+## 2. Under-block
+Could it fail to block when it SHOULD continue? When the flag is OFF, yes — by design
+(dark). When ON, the only residual is the open binary question of whether codex runs the
+second Stop group (Phase-5 / live verification gates this before enabling; fallback =
+move into group 0). No silent data loss either way — at worst the codex run stops early,
+same as today.
+
+## 3. Level-of-abstraction fit
+The driver lives where Claude's does (the autonomous skill hook) and is registered where
+codex's other standing hooks are (`installCodexHooks`). The flag sits with the other
+autonomous-mode settings (`autonomousSessions`). No new subsystem.
+
+## 4. Signal vs authority compliance
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+The hook is an AUTHORITY surface by nature (a Stop hook returns block/approve — same as
+Claude's existing loop hook and codex's existing stop-gate-router). It does not newly
+elevate authority: it reuses the established Stop-hook contract. The dark flag means the
+authority is dormant until explicitly enabled. No monitoring/signal component is converted
+into a blocker.
+
+## 5. Interactions
+- **Review trio (stop-gate-router / response-review / claim-intercept / scope-coherence):**
+  the driver is the LAST hook in the SAME Stop group (slot stop:0:N). Within-group block
+  precedence vs the router is verified live before enabling; worst case the session still
+  continues via the router (never strands).
+- **Claude autonomous mode:** independent registration (settings.json vs .codex/hooks.json);
+  `IS_CODEX=0` for Claude → unchanged.
+- **armCodexHooks:** the new hook changes the hooks.json hash → re-arm on update (handled
+  by the existing migration). Because it rides group 0 (a group codex already trusts/arms),
+  it adds NO new arm slot — avoiding the recurring-arm-spawn side-effect a separate group
+  (stop:1:0) would have caused (caught by the second-pass review, then designed out).
+
+## 6. External surfaces
+None new. No HTTP route, no Telegram message, no external API. The hook talks only to the
+local server's existing `/autonomous/evaluate-completion` (unchanged) when a completion
+condition is set.
+
+## 7. Rollback cost
+Lowest tier. Set `autonomousSessions.codexLoopDriver.enabled: false` → the standing hook
+exits immediately (instant, no redeploy, no session kill). Full PR revert is clean
+(additive change; removing the Stop group + the `IS_CODEX` block restores prior behavior).
+
+## Conclusion
+Safe to ship DARK. The only non-trivial residual (does codex run a second Stop group) is
+gated behind the default-off flag and resolved by live verification before enabling — per
+Justin's "careful + clear plan to regress" condition.
+
+## Second-pass review (if required)
+
+**Reviewer:** independent second-pass agent (lifecycle machinery — required)
+**Status:** DONE 2026-05-30 — **CONCUR on shipping DARK.** Verified PASS on: Claude path
+unchanged, dark gate cannot leak (all config-read failure paths → disabled), `$0` anchor,
+groupIsInstarOwned idempotency, migration parity (both halves land). The reviewer caught a
+fleet-wide arm side-effect from the original separate-group design (a `stop:1:0` slot codex
+may never trust → recurring codex-TUI arm spawns on every update, even dark). **Resolved**
+by moving the driver into the existing Stop group (slot stop:0:N) — no new arm slot. The
+remaining open item (within-group block precedence + that the loop actually re-prompts a
+real codex run) is gated to live verification BEFORE the flag is enabled, per the spec's
+Phase 5 — it is not a merge/dark-ship blocker.
+
+## Evidence pointers
+- Unit: `tests/unit/installCodexHooks.test.ts` (separate Stop group, idempotent, user-group preserved).
+- Unit: `tests/unit/autonomous-stop-hook-codex-gate.test.ts` (dark default / disabled / enabled / Claude-unaffected — both sides of the gate).
+- Spec: `docs/specs/codex-autonomous-loop-driver.md` (+ `.eli16.md`).


### PR DESCRIPTION
## #28 — Codex autonomous-loop driver (ships DARK)

Closes the headline Claude/Codex parity gap: a `codex exec` session ran one turn then exited (no Stop-hook loop like Claude), so codex agents (Codey) couldn't carry a long autonomous task.

The mechanism already existed end-to-end — codex fires Stop hooks and honors `{decision:"block", reason}` (verified in the codex 0.133 binary's `StopCommandOutputWire`). Only the wiring was Claude-only.

### What changed
- `installCodexHooks` registers the shared `autonomous-stop-hook.sh --codex` as the **last hook in the existing codex Stop group** (slot `stop:0:N`).
- The hook self-gates on `autonomousSessions.codexLoopDriver.enabled` (**default OFF → dark**).
- Claude path is **byte-for-byte unchanged** (`IS_CODEX=0` skips the codex anchor + flag gate).
- Migration parity: existing codex agents get the updated hook (marker bump `notify_terminal_stop` → `CODEX_LOOP_ENABLED`) + `.codex/hooks.json` re-registration/re-arm on update.

### Careful + rollback (per Justin's condition)
- Ships **DARK** (flag default false → standing hook exits immediately; no behavior change for any codex session).
- **Instant rollback**: set `autonomousSessions.codexLoopDriver.enabled: false` (no redeploy). Additive change → clean revert.
- Plan: merge → release → deploy DARK → live-verify on a real codex autonomous run → only then enable.

### Second-pass review (lifecycle machinery — required)
Independent reviewer **CONCURRED on shipping dark**. It caught a fleet-wide arm side-effect from the original *separate*-group design (a `stop:1:0` slot codex may never trust → recurring codex-TUI arm spawns + `partial` error logs on every update, even dark). **Fixed** by riding the existing Stop group (no new arm slot). Remaining open item (within-group block precedence + that the loop re-prompts a real codex run) is gated to **live verification before enabling** — not a merge/dark-ship blocker.

### Tests
- `installCodexHooks.test.ts` — driver is last hook in the single instar Stop group, idempotent, user Stop group preserved.
- `autonomous-stop-hook-codex-gate.test.ts` — both sides of the gate: `--codex` + flag absent/false → approve (dark) even with an active job; flag true → block; no `--codex` (Claude) → blocks regardless of flag (Claude unaffected).
- 81/81 affected tests green; `npm run lint` clean.

Spec: `docs/specs/codex-autonomous-loop-driver.md` (+ `.eli16.md`). Side-effects: `upgrades/side-effects/codex-autonomous-loop-driver.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
