### PR TITLE
feat(worktree): exclude agent worktrees from macOS Spotlight indexing

### DIFF
--- a/docs/specs/worktree-spotlight-exclusion.eli16.md
+++ b/docs/specs/worktree-spotlight-exclusion.eli16.md
@@ -1,0 +1,47 @@
+# ELI16 — Worktree Spotlight exclusion
+
+## What this is, in plain English
+
+When instar does parallel development, it makes "worktrees" — extra full copies of
+the project's source code sitting in a folder on disk. Over time these pile up; on
+the dev machine there were over 120 of them.
+
+macOS has a search feature, Spotlight, plus a media-scanning helper called
+mediaanalysisd. They constantly crawl new files on disk to make them searchable.
+To them, 120 copies of a big source tree look like 120 big piles of new stuff to
+scan — over and over. On the machine we measured, that scanning was the single
+biggest CPU hog on the whole computer, far bigger than anything the AI agents
+themselves were doing. So the computer felt slow for a reason that had nothing to
+do with the actual work.
+
+## What already exists
+
+macOS has a built-in, no-special-permission way to say "don't index this folder":
+you drop an empty file named `.metadata_never_index` into it. Lots of developer
+tools do this to keep Spotlight off their build folders.
+
+## What's new
+
+instar now drops that one little marker file at the top of the worktrees folder.
+Spotlight then skips that whole folder and everything inside it. It happens
+automatically:
+- Every new worktree is covered the moment it's created.
+- Agents that already piled up worktrees before this existed get the marker added
+  for them automatically when they update.
+
+## The safeguards, in plain terms
+
+- The marker sits at the container folder, not inside each worktree copy, so it
+  doesn't show up as a stray file in anyone's source code.
+- It's completely safe and reversible — it's just an empty hint file. Delete it
+  and indexing comes back.
+- On non-Mac machines it does nothing (no harm).
+- If for some reason the file can't be written, instar just shrugs and carries on
+  exactly as before — it never blocks creating a worktree.
+
+## What you actually need to decide
+
+Nothing. This is automatic, safe, and reversible. On a Mac you should simply notice
+lower idle CPU after the update — especially if you've built up a lot of worktrees.
+It's the first piece of the broader "use resources responsibly" effort, aimed
+specifically at the macOS-caused load.

--- a/docs/specs/worktree-spotlight-exclusion.md
+++ b/docs/specs/worktree-spotlight-exclusion.md
@@ -1,0 +1,75 @@
+---
+title: Worktree Spotlight exclusion (OS resource hygiene)
+slug: worktree-spotlight-exclusion
+status: approved
+review-convergence: 2026-05-31T01:10:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate during an explicit
+  5-hour autonomous run (topic 16782, 2026-05-30) where Justin directed: "put a
+  lot of focus into what we can do to mitigate [macOS resource load] from the
+  instar side" and confirmed OS resource hygiene belongs in the Responsible
+  Resource Usage standard. Flagged in the PR per cross-agent discipline.
+---
+
+# Worktree Spotlight exclusion (OS resource hygiene)
+
+## Problem
+
+Live evidence on the dev box showed the single biggest CPU consumer was NOT
+instar code but macOS indexing — `mediaanalysisd` ~80% CPU / 1GB RSS plus
+`mds_stores` (Spotlight) — driven by ~118–121 git worktrees on disk under
+`~/.instar/agents/<agent>/.worktrees/`. Each worktree is a full source-tree
+checkout of the instar repo; Spotlight insists on indexing and re-indexing every
+one. instar indirectly feeds a large OS-level CPU drain that has nothing to do
+with agents doing work.
+
+## Goal
+
+Stop macOS Spotlight/mediaanalysisd from indexing agent worktrees, automatically
+and for both new and existing agents. Level 4 (OS resource hygiene) of the
+Responsible Resource Usage standard.
+
+## Non-goals
+
+- Not reclaiming stale worktrees (that is the sibling CLI-worktree-reaper work).
+- No change to worktree creation semantics or the convention.
+
+## Design
+
+A single `.metadata_never_index` marker at the `.worktrees/` **container root**
+tells Spotlight to skip the entire subtree (the marker is honored recursively).
+Placing it at the container — not inside each worktree — means zero git noise
+inside any worktree and one marker covers all of them regardless of how a
+worktree was created.
+
+- New exported helper `ensureWorktreeSpotlightExclusion(worktreesDir): boolean` in
+  `InstarWorktreeManager.ts` — idempotent, best-effort (never throws; a write
+  failure just leaves Spotlight indexing as before), returns whether it created
+  the marker.
+- `ensureWorktreesDir()` (the single chokepoint every CLI create path runs
+  through) calls it, so new worktrees are covered at creation.
+- The convention wrapper's raw-`git worktree add` fallback drops the same marker.
+- `PostUpdateMigrator.migrateWorktreeSpotlightExclusion` backfills the marker into
+  existing agents' `.worktrees/` on update (the wrapper itself is already
+  always-overwritten by `migrateWorktreeConvention`, so the fallback change
+  propagates for free).
+
+## Decision points (signal vs authority)
+
+None. This adds no decision logic and no blocking authority — it drops an inert
+OS-hint file. Pure additive observability/hygiene. Per `docs/signal-vs-authority.md`,
+nothing here gates information flow or behavior.
+
+## Testing
+
+Unit: the helper (creates marker, idempotent, never throws on an unwritable path)
+and the migration backfill (drops the marker into an existing `.worktrees/`,
+idempotent). Existing InstarWorktreeManager + migrateWorktreeConvention tests stay
+green (the `ensureWorktreesDir` hook keeps its prior mkdir/chmod behavior).
+
+## Rollback
+
+Trivial. The marker is an inert file; deleting it restores indexing. A PR revert
+removes the create-path drop + migration. No state, no schema, no irreversible op.

--- a/src/core/InstarWorktreeManager.ts
+++ b/src/core/InstarWorktreeManager.ts
@@ -592,11 +592,38 @@ function ensureWorktreesDir(worktreesDir: string): void {
   if (fs.existsSync(worktreesDir)) {
     // Re-assert 0700 every call to recover from drift.
     fs.chmodSync(worktreesDir, 0o700);
-    return;
+  } else {
+    fs.mkdirSync(worktreesDir, { recursive: true, mode: 0o700 });
+    // mkdirSync's `mode` is masked by umask — re-apply explicitly.
+    fs.chmodSync(worktreesDir, 0o700);
   }
-  fs.mkdirSync(worktreesDir, { recursive: true, mode: 0o700 });
-  // mkdirSync's `mode` is masked by umask — re-apply explicitly.
-  fs.chmodSync(worktreesDir, 0o700);
+  ensureWorktreeSpotlightExclusion(worktreesDir);
+}
+
+/**
+ * Drop a `.metadata_never_index` marker at the `.worktrees/` container root so
+ * macOS Spotlight (mds_stores) + mediaanalysisd skip indexing every worktree
+ * beneath it. Worktrees are throwaway full source trees; re-indexing dozens of
+ * them is a top OS-level CPU consumer (measured: mediaanalysisd ~80% CPU under a
+ * ~120-worktree backlog). The marker is honored recursively for the whole
+ * subtree, lives at the container (not inside any worktree, so no git noise),
+ * is a harmless no-op on non-macOS, and is idempotent. Returns true if it
+ * created the marker, false if it already existed or could not be written.
+ *
+ * Part of the Responsible Resource Usage standard — OS resource hygiene.
+ */
+export function ensureWorktreeSpotlightExclusion(worktreesDir: string): boolean {
+  const marker = path.join(worktreesDir, '.metadata_never_index');
+  try {
+    if (fs.existsSync(marker)) return false;
+    fs.writeFileSync(marker, '');
+    return true;
+  } catch {
+    // @silent-fallback-ok — a best-effort OS indexing hint. Failure to write it
+    // just means Spotlight keeps indexing (the prior behavior); it must never
+    // block worktree creation or a migration pass.
+    return false;
+  }
 }
 
 // ── Audit ledger ─────────────────────────────────────────────────────────

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -26,7 +26,7 @@ import { execFileSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import { SafeGitExecutor } from './SafeGitExecutor.js';
 import { ensureInstarBashPreToolUseHooks, type SettingsMatcherEntry } from './instarSettingsHooks.js';
-import { resolveAgentHome as resolveAgentHomeForWorktree } from './InstarWorktreeManager.js';
+import { resolveAgentHome as resolveAgentHomeForWorktree, ensureWorktreeSpotlightExclusion } from './InstarWorktreeManager.js';
 import { fileURLToPath } from 'node:url';
 import { TreeGenerator } from '../knowledge/TreeGenerator.js';
 import { HTTP_HOOK_TEMPLATES, buildHttpHookSettings } from '../data/http-hook-templates.js';
@@ -228,6 +228,7 @@ export class PostUpdateMigrator {
     this.migrateParitySentinelTrust(result);
     this.migrateConversationalCatalogPlaybookManifest(result);
     this.migrateWorktreeConvention(result);
+    this.migrateWorktreeSpotlightExclusion(result);
     this.migrateBootWrapperToCjs(result);
     this.migrateBootWrapperAbiCheck(result);
     this.migrateStaleLifelineSignal(result);
@@ -688,6 +689,40 @@ export class PostUpdateMigrator {
   //     somewhere else simply opt out — the wrapper isn't applicable).
   //   - `<agent_home>/.bin` exists as a symlink (defeats the
   //     /usr/local/bin clobber attack surface).
+  /**
+   * OS resource hygiene (Responsible Resource Usage standard): ensure a
+   * `.metadata_never_index` marker at the agent's `.worktrees/` container so
+   * macOS Spotlight/mediaanalysisd stop re-indexing every worktree beneath it.
+   * Existing agents accumulated dozens of worktrees before the create-path drop
+   * existed; this backfills the marker so they get the relief on update. The
+   * marker is honored recursively, harmless on non-macOS, and idempotent.
+   */
+  private migrateWorktreeSpotlightExclusion(result: MigrationResult): void {
+    const agentHome = path.dirname(this.config.stateDir);
+    let resolved: { agentHome: string; agentName: string };
+    try {
+      resolved = resolveAgentHomeForWorktree({ env: { INSTAR_AGENT_HOME: agentHome } });
+    } catch {
+      result.skipped.push('worktree-spotlight-exclusion: agent home does not match the convention');
+      return;
+    }
+    const worktreesDir = path.join(resolved.agentHome, '.worktrees');
+    if (!fs.existsSync(worktreesDir)) {
+      result.skipped.push('worktree-spotlight-exclusion: no .worktrees/ directory');
+      return;
+    }
+    try {
+      const created = ensureWorktreeSpotlightExclusion(worktreesDir);
+      if (created) {
+        result.upgraded.push('worktree-spotlight-exclusion: dropped .metadata_never_index at .worktrees/ (excludes worktrees from Spotlight indexing)');
+      } else {
+        result.skipped.push('worktree-spotlight-exclusion: marker already present');
+      }
+    } catch (err) {
+      result.errors.push(`worktree-spotlight-exclusion: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   private migrateWorktreeConvention(result: MigrationResult): void {
     const agentHome = path.dirname(this.config.stateDir);
 

--- a/src/templates/scripts/instar-worktree-create.sh
+++ b/src/templates/scripts/instar-worktree-create.sh
@@ -67,6 +67,10 @@ if [[ -e "$WORKTREE_PATH" ]]; then
 fi
 mkdir -p "$WORKTREES_ROOT"
 chmod 0700 "$WORKTREES_ROOT"
+# OS resource hygiene: keep macOS Spotlight/mediaanalysisd from re-indexing every
+# worktree under here (a top OS-level CPU consumer). Honored recursively; no-op
+# elsewhere. The CLI path does the same via ensureWorktreeSpotlightExclusion.
+[[ -f "$WORKTREES_ROOT/.metadata_never_index" ]] || : > "$WORKTREES_ROOT/.metadata_never_index" 2>/dev/null || true
 cd "$INSTAR_REPO"
 if git rev-parse --verify --quiet "$BRANCH" >/dev/null; then
   git worktree add "$WORKTREE_PATH" "$BRANCH"

--- a/tests/unit/worktree-spotlight-exclusion.test.ts
+++ b/tests/unit/worktree-spotlight-exclusion.test.ts
@@ -1,0 +1,103 @@
+/**
+ * OS resource hygiene (Responsible Resource Usage standard): the worktrees
+ * container carries a `.metadata_never_index` marker so macOS Spotlight skips
+ * re-indexing every worktree beneath it. Covers the reusable helper and the
+ * PostUpdateMigrator backfill (existing agents get the marker on update).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ensureWorktreeSpotlightExclusion } from '../../src/core/InstarWorktreeManager.js';
+import { PostUpdateMigrator } from '../../src/core/PostUpdateMigrator.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+const OP = 'tests/unit/worktree-spotlight-exclusion.test.ts';
+
+describe('ensureWorktreeSpotlightExclusion', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-spotlight-')); });
+  afterEach(() => { SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: OP }); });
+
+  it('creates the .metadata_never_index marker at the worktrees root', () => {
+    const created = ensureWorktreeSpotlightExclusion(tmp);
+    expect(created).toBe(true);
+    expect(fs.existsSync(path.join(tmp, '.metadata_never_index'))).toBe(true);
+  });
+
+  it('is idempotent — returns false when the marker already exists', () => {
+    expect(ensureWorktreeSpotlightExclusion(tmp)).toBe(true);
+    expect(ensureWorktreeSpotlightExclusion(tmp)).toBe(false);
+    // Still exactly one marker, still empty.
+    expect(fs.readFileSync(path.join(tmp, '.metadata_never_index'), 'utf-8')).toBe('');
+  });
+
+  it('never throws on an unwritable path — best-effort OS hint', () => {
+    expect(ensureWorktreeSpotlightExclusion('/proc/nonexistent-xyz/.worktrees')).toBe(false);
+  });
+});
+
+// ── Migration backfill (mirrors migrateWorktreeConvention.test.ts hermetic setup) ──
+
+let originalHome: string | undefined;
+let originalAuditDir: string | undefined;
+let tmpHome: string;
+
+function setHome(dir: string): void { originalHome = process.env.HOME; process.env.HOME = dir; }
+function restoreHome(): void {
+  if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+}
+
+function setupAgentHome(name: string): { agentHome: string; stateDir: string } {
+  const instarHome = path.join(tmpHome, '.instar');
+  fs.mkdirSync(instarHome, { recursive: true });
+  fs.writeFileSync(path.join(instarHome, 'registry.json'), JSON.stringify({
+    version: 1,
+    entries: [{
+      name, type: 'standalone', path: path.join(instarHome, 'agents', name),
+      port: 9999, pid: 0, status: 'stopped',
+      createdAt: new Date().toISOString(), lastHeartbeat: new Date().toISOString(),
+    }],
+  }));
+  const agentHome = path.join(instarHome, 'agents', name);
+  const stateDir = path.join(agentHome, '.instar');
+  fs.mkdirSync(stateDir, { recursive: true });
+  return { agentHome, stateDir };
+}
+
+function makeMigrator(stateDir: string): PostUpdateMigrator {
+  return new PostUpdateMigrator({
+    projectDir: path.dirname(stateDir), stateDir, port: 9999, hasTelegram: false, projectName: 'integ-agent',
+  });
+}
+
+describe('PostUpdateMigrator.migrateWorktreeSpotlightExclusion', () => {
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-spotlight-mig-'));
+    setHome(tmpHome);
+    originalAuditDir = process.env.INSTAR_AUDIT_LOG_DIR;
+    process.env.INSTAR_AUDIT_LOG_DIR = path.join(tmpHome, 'audit');
+  });
+  afterEach(() => {
+    if (originalAuditDir === undefined) delete process.env.INSTAR_AUDIT_LOG_DIR;
+    else process.env.INSTAR_AUDIT_LOG_DIR = originalAuditDir;
+    restoreHome();
+    SafeFsExecutor.safeRmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100, operation: OP });
+  });
+
+  it('backfills the marker into an existing .worktrees/ on update', () => {
+    const { agentHome } = setupAgentHome('echo-spotlight');
+    const result = makeMigrator(path.join(agentHome, '.instar')).migrate();
+    expect(result.upgraded.some((s) => s.includes('worktree-spotlight-exclusion'))).toBe(true);
+    expect(fs.existsSync(path.join(agentHome, '.worktrees', '.metadata_never_index'))).toBe(true);
+  });
+
+  it('is idempotent — second run reports already-present, no error', () => {
+    const { agentHome } = setupAgentHome('echo-spotlight-idem');
+    makeMigrator(path.join(agentHome, '.instar')).migrate();
+    const result2 = makeMigrator(path.join(agentHome, '.instar')).migrate();
+    expect(result2.errors).toEqual([]);
+    expect(result2.skipped.some((s) => s.includes('worktree-spotlight-exclusion: marker already present'))).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,56 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Agent worktrees are now excluded from macOS Spotlight indexing — a top
+OS-level CPU drain on multi-worktree machines.**
+
+Each `instar worktree create` leaves a full source tree on disk under the agent's
+`.worktrees/` directory. macOS Spotlight (mds_stores) and mediaanalysisd treat
+every one of those trees as new content to index and re-index — and on a machine
+that has accumulated dozens of worktrees that becomes one of the single biggest
+CPU consumers on the box (measured: mediaanalysisd pulling ~80% CPU under a
+~120-worktree backlog), entirely separate from anything instar's own code is
+doing.
+
+instar now drops a single `.metadata_never_index` marker at the `.worktrees/`
+container root, which tells Spotlight to skip that whole subtree. New worktrees
+are covered automatically at creation time, and existing agents get the marker
+backfilled on update via a new migration. The marker lives at the container (not
+inside any worktree, so it adds no git noise), is honored recursively for every
+worktree beneath it, is harmless on non-macOS, and is idempotent.
+
+This is the first piece of the **OS resource hygiene** facet of the Responsible
+Resource Usage standard.
+
+## What to Tell Your User
+
+Nothing to configure. On a Mac, the throwaway worktrees instar creates for
+parallel development will no longer be re-indexed by Spotlight — which quietly
+removes a large chunk of background CPU load that had nothing to do with your
+agents actually working. If you have built up a lot of worktrees over time, you
+should feel this as lower idle CPU after the update settles.
+
+## Summary of New Capabilities
+
+- `instar worktree create` (and the convention wrapper's fallback path) drop a
+  `.metadata_never_index` marker at the `.worktrees/` container so Spotlight skips
+  indexing every worktree under it.
+- New exported helper `ensureWorktreeSpotlightExclusion(worktreesDir)` — idempotent,
+  best-effort, never throws, returns whether it created the marker.
+- New `PostUpdateMigrator.migrateWorktreeSpotlightExclusion` backfills the marker
+  into existing agents' `.worktrees/` on update.
+
+## Evidence
+
+- `tests/unit/worktree-spotlight-exclusion.test.ts` — new: the helper (creates the
+  marker, idempotent return, never throws on an unwritable path) and the migration
+  backfill (drops the marker into an existing `.worktrees/`, idempotent on re-run).
+- `tests/unit/InstarWorktreeManager.test.ts` + `migrateWorktreeConvention.test.ts`
+  still green (the `ensureWorktreesDir` hook + always-overwrite wrapper unchanged
+  in behavior).
+- Operationally verified live: dropping the marker on echo's real 121-worktree
+  `.worktrees/` directory; mediaanalysisd dropped from its earlier ~80% spike.
+- Full `npm run lint` clean.

--- a/upgrades/side-effects/worktree-spotlight-exclusion.md
+++ b/upgrades/side-effects/worktree-spotlight-exclusion.md
@@ -1,0 +1,81 @@
+# Side-Effects Review — Worktree Spotlight exclusion
+
+**Version / slug:** `worktree-spotlight-exclusion`
+**Date:** `2026-05-30`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Drop a `.metadata_never_index` marker at the `.worktrees/` container root so macOS
+Spotlight/mediaanalysisd skip indexing every worktree beneath it. Covered at
+creation (`ensureWorktreesDir` → `ensureWorktreeSpotlightExclusion`, plus the
+convention wrapper's fallback path) and backfilled for existing agents via a new
+`PostUpdateMigrator.migrateWorktreeSpotlightExclusion`.
+
+## Decision-point inventory
+
+None. The change adds no decision logic — it writes one inert OS-hint file.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** Nothing is rejected. The marker
+only affects Spotlight indexing of throwaway build trees; it does not change git,
+the worktree, the build, or any agent behavior. Source files inside worktrees are
+unaffected (the marker is at the container, not inside a worktree).
+
+## 2. Under-block
+
+**What does this still miss?** It does not reduce indexing of anything outside
+`.worktrees/` (by design), and it does not reclaim the worktrees themselves (the
+sibling reaper work). Spotlight may take time to honor a newly-dropped marker on an
+already-indexed tree, so the relief on existing backlogs is gradual, not instant.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The marker-ensure lives in `ensureWorktreesDir`, the single
+chokepoint all CLI create paths run through, and the backfill lives beside the
+existing `migrateWorktreeConvention`. The exported helper keeps the rule in one
+place, reused by the migrator.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No blocking authority added. The helper is best-effort and total: a write failure
+returns false and is swallowed (`@silent-fallback-ok`), never throwing and never
+blocking worktree creation or a migration pass.
+
+## 5. Interactions
+
+Reuses `resolveAgentHomeForWorktree` (same validation as `migrateWorktreeConvention`)
+so non-convention agents are skipped silently. The wrapper fallback change rides the
+existing always-overwrite of `instar-worktree-create.sh`. No interaction with the
+SessionReaper, sentinels, or recovery paths. Idempotent everywhere.
+
+## 6. External surfaces
+
+One new on-disk file per agent (`.worktrees/.metadata_never_index`, empty). No HTTP
+routes, no config, no notifications, no Telegram. Purely a filesystem hint to the OS.
+
+## 7. Rollback cost
+
+Trivial. Delete the marker to restore indexing; revert the PR to remove the
+create-path drop + migration. No state, no schema, no irreversible op.
+
+## Conclusion
+
+Lowest-risk possible change: additive, inert, idempotent, best-effort, reversible,
+no decision logic. Directly targets a measured top OS-level CPU drain (mediaanalysisd
+~80% under a ~120-worktree backlog). Operationally pre-validated by dropping the
+marker on echo's real `.worktrees/` (121 worktrees) live.
+
+## Second-pass review (if required)
+
+Not required — inert additive OS hint, no authority, no decision logic.
+
+## Evidence pointers
+
+- `tests/unit/worktree-spotlight-exclusion.test.ts` — helper + migration backfill.
+- `tests/unit/InstarWorktreeManager.test.ts`, `migrateWorktreeConvention.test.ts` — green.
+- `upgrades/NEXT.md` — upgrade guide.


### PR DESCRIPTION
## What & why

**OS resource hygiene** — Level 4 of the Responsible Resource Usage standard. Live evidence showed the single biggest CPU consumer on the dev box was **macOS indexing** (`mediaanalysisd` ~80% CPU / 1GB RSS + `mds_stores`), driven by ~120 git worktrees under `.worktrees/` — each a full source tree Spotlight insists on re-indexing. That's instar indirectly feeding a large OS-level CPU drain unrelated to agents doing work.

Drop a single `.metadata_never_index` marker at the `.worktrees/` **container root** (honored recursively, so it covers every worktree; at the container so it adds no git noise inside any worktree). Automatic on create, backfilled for existing agents.

## Changes
- `ensureWorktreeSpotlightExclusion(worktreesDir)` — exported helper, idempotent, best-effort (never throws, returns whether it created the marker).
- `ensureWorktreesDir()` (the single chokepoint all CLI create paths run through) drops it; the convention wrapper's raw-`git worktree add` fallback drops it too.
- `PostUpdateMigrator.migrateWorktreeSpotlightExclusion` backfills existing `.worktrees/`.

## Approval
⚠️ **Self-approved spec** under the delegated deploy mandate — Justin directed this OS-hygiene work and confirmed it belongs in the standard (topic 16782). Spec + ELI16 + side-effects review included.

## Tests / evidence
- `tests/unit/worktree-spotlight-exclusion.test.ts` — helper (create / idempotent / never-throws) + migration backfill (drop / idempotent).
- `InstarWorktreeManager` + `migrateWorktreeConvention` tests stay green; lint clean; `upgrades/NEXT.md` present.
- **Operationally pre-verified live**: dropped the marker on echo's real 121-worktree `.worktrees/`; mediaanalysisd already down from its ~80% spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)