### PR TITLE
feat(monitoring): idle-aware poller cadence (IdleAwareCadence + TokenLedgerPoller)

### DIFF
--- a/docs/specs/idle-poller-cadence.eli16.md
+++ b/docs/specs/idle-poller-cadence.eli16.md
@@ -1,0 +1,44 @@
+# ELI16 — Idle-aware poller cadence
+
+## What this is, in plain English
+
+Every instar agent has a couple dozen little background "checkers" that wake up on
+a timer and do a small job — scan some logs, peek at a session, update a tally.
+That's fine when the agent is busy. But when the agent is just sitting there with
+nobody talking to it, those checkers STILL wake up on the same fast schedule and
+do work for no reason. Multiply that by a couple dozen checkers times nine agents
+all running on one laptop, and it's a steady, pointless drain on the machine.
+
+## What already exists
+
+The checkers each run on a fixed timer (for example, the token-usage scanner runs
+every 60 seconds, always). There was no notion of "the agent is idle, so slow
+down."
+
+## What's new
+
+A small reusable gadget called IdleAwareCadence. You give it two speeds — a fast
+one for when the agent is active and a slow one for when it's idle — and a way to
+ask "are we idle right now?" It runs the job on the fast schedule when there's work
+and the slow schedule when there isn't, and it speeds back up the moment things get
+busy again.
+
+The first checker to use it is the token-usage scanner: when no session is running,
+there are literally no new tokens to count, so it now slows from every 60 seconds to
+every 5 minutes. The mechanism is built so the other checkers (and, later, a full
+"agent sleep" mode) can adopt it one at a time.
+
+## The safeguards, in plain terms
+
+- It only changes how OFTEN a checker runs, never WHAT it does — so it can't break
+  anything or miss real work; the worst case is "we didn't save as much CPU."
+- If the "are we idle?" question ever errors out, it assumes the agent is ACTIVE and
+  keeps the fast schedule — it never slows down when it's unsure.
+- If a checker's job throws an error, the loop just keeps going.
+- The other checker that doesn't opt in behaves exactly as before.
+
+## What you actually need to decide
+
+Nothing. This is automatic and conservative. You should just see a little less idle
+CPU from each agent, and it lays the groundwork for the bigger "idle agents cost
+almost nothing" goal.

--- a/docs/specs/idle-poller-cadence.md
+++ b/docs/specs/idle-poller-cadence.md
@@ -1,0 +1,77 @@
+---
+title: Idle-aware poller cadence (IdleAwareCadence + TokenLedgerPoller)
+slug: idle-poller-cadence
+status: approved
+review-convergence: 2026-05-31T02:30:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate during an explicit
+  5-hour autonomous run (topic 16782, 2026-05-30) on the Responsible Resource
+  Usage standard. This is the first concrete slice of Level 1 (tool/idle sleep):
+  instar's OWN background pollers backing off when the agent is idle. (instar
+  can't hibernate Claude-Code-spawned MCP servers — see the standard's L1 note —
+  so the in-scope win is reducing instar's own idle footprint.) Flagged in PR.
+---
+
+# Idle-aware poller cadence
+
+## Problem
+
+Each instar agent runs ~27 timer-driven background monitors. On an idle agent
+(no active sessions) most of them still wake on a fixed cadence and do work —
+JSONL scans, tmux captures, ledger rollups — even though nothing is happening.
+Across ~9 always-on agent stacks on one box, that fixed-cadence churn is a real
+slice of the always-on CPU floor the Responsible Resource Usage standard targets.
+
+instar cannot hibernate the MCP servers (Claude Code spawns those from
+`.mcp.json`), but it CAN make its own pollers cheaper when idle.
+
+## Goal
+
+A reusable primitive that lets any poller run at full cadence while active and
+back off while idle, snapping back when activity resumes. Apply it first to the
+clearest offender — `TokenLedgerPoller` (60s JSONL scan) — establishing the
+mechanism that later pollers and agent-sleep (Level 3) build on.
+
+## Non-goals
+
+- Not converting all 27 pollers (incremental — this ships the primitive + one
+  application; others adopt it in follow-ups, each verified safe to back off).
+- Not agent-sleep itself (Level 3) — this is a building block for it.
+
+## Design
+
+`IdleAwareCadence` (`src/monitoring/IdleAwareCadence.ts`): a self-rescheduling
+`setTimeout` loop. Each reschedule samples `isIdle()` and waits `idleMs` (idle) or
+`activeMs` (active). Safety: `isIdle()` throwing ⇒ ACTIVE (never backs off on an
+ambiguous signal); `tick()` throwing ⇒ swallowed (the loop survives). Because the
+idle state is re-sampled on every reschedule, resuming activity restores full
+cadence within at most one idle interval.
+
+`TokenLedgerPoller`: gains optional `isIdle` + `idleIntervalMs` (default 5 min).
+When `isIdle` is provided it drives ticks through `IdleAwareCadence` (active =
+`intervalMs` 60s, idle = `idleIntervalMs`); otherwise it keeps the prior fixed
+`setInterval` exactly (backward-compatible). `AgentServer` wires
+`isIdle: () => sessionManager.listRunningSessions().length === 0` — scanning the
+token JSONL when no session is running attributes nothing, so backing off is both
+safe and correct.
+
+## Decision points (signal vs authority)
+
+No blocking authority. This only changes the *cadence* of a read-only
+observability poller; it never gates information flow. `isIdle` ambiguity degrades
+to full cadence (the prior behavior), so the failure mode is "no savings," never
+"missed work." Per `docs/signal-vs-authority.md`, nothing here is brittle-with-authority.
+
+## Testing
+
+Unit: `IdleAwareCadence` with fake timers (active interval, idle backoff,
+re-evaluation active→idle, isIdle-throw⇒active, tick-throw-survives, stop()), and
+the `TokenLedgerPoller` wiring (backs off while idle, full cadence while active,
+fixed cadence without `isIdle`). Existing TokenLedger/poller tests stay green.
+
+## Rollback
+
+Behavior-only, additive. Omitting `isIdle` restores the exact prior fixed cadence;
+a PR revert removes the helper + the poller option. No config, no schema, no state.

--- a/src/monitoring/IdleAwareCadence.ts
+++ b/src/monitoring/IdleAwareCadence.ts
@@ -1,0 +1,69 @@
+/**
+ * IdleAwareCadence — a self-rescheduling timer that runs work on a SHORT interval
+ * while the agent is active and a LONG interval while it is idle (no active
+ * sessions). Background pollers on an idle agent are pure waste: they wake on a
+ * fixed cadence and scan/capture even when there is nothing happening, which is a
+ * meaningful slice of the always-on CPU floor on a multi-agent box. This primitive
+ * lets a poller back off when idle and snap back to full cadence the moment work
+ * resumes — the building block for both poller-cadence backoff and (later) agent
+ * sleep mode. Part of the Responsible Resource Usage standard.
+ *
+ * Safety: `isIdle()` throwing → treated as ACTIVE (full cadence — it never backs
+ * off on an ambiguous signal). `tick()` throwing → swallowed (never crashes the
+ * timer loop). The idle state is re-evaluated on EVERY reschedule, so resuming
+ * activity restores full cadence within at most one idle interval.
+ */
+export interface IdleAwareCadenceOptions {
+  /** Interval (ms) while the agent is active. */
+  activeMs: number;
+  /** Interval (ms) while the agent is idle. Should be >= activeMs. */
+  idleMs: number;
+  /** True when the agent is idle (e.g. no running sessions) — back off. */
+  isIdle: () => boolean;
+  /** The work to run each tick. */
+  tick: () => void | Promise<void>;
+}
+
+export class IdleAwareCadence {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+  private running = false;
+
+  constructor(private readonly opts: IdleAwareCadenceOptions) {}
+
+  start(): void {
+    if (this.timer || this.stopped) return;
+    this.schedule();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+  }
+
+  /** The delay (ms) the NEXT tick will wait, given the current idle state. */
+  currentIntervalMs(): number {
+    return this.idleSafe() ? this.opts.idleMs : this.opts.activeMs;
+  }
+
+  private idleSafe(): boolean {
+    try { return this.opts.isIdle(); }
+    catch { return false; } // @silent-fallback-ok — ambiguous ⇒ ACTIVE (never back off on error)
+  }
+
+  private schedule(): void {
+    if (this.stopped) return;
+    const delay = this.idleSafe() ? this.opts.idleMs : this.opts.activeMs;
+    this.timer = setTimeout(() => { void this.run(); }, delay);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  private async run(): Promise<void> {
+    if (this.stopped || this.running) { this.schedule(); return; }
+    this.running = true;
+    try { await this.opts.tick(); }
+    catch { /* never throw out of the timer loop */ }
+    finally { this.running = false; }
+    this.schedule(); // re-evaluate idle state on every reschedule
+  }
+}

--- a/src/monitoring/TokenLedgerPoller.ts
+++ b/src/monitoring/TokenLedgerPoller.ts
@@ -5,11 +5,21 @@
  * Read-only observability: never mutates the source JSONL files.
  */
 import type { TokenLedger } from './TokenLedger.js';
+import { IdleAwareCadence } from './IdleAwareCadence.js';
 
 export interface TokenLedgerPollerOptions {
   ledger: TokenLedger;
-  /** Polling interval (ms). Defaults to 60_000. */
+  /** Polling interval (ms) while the agent is active. Defaults to 60_000. */
   intervalMs?: number;
+  /**
+   * When provided, the poller backs off to {@link idleIntervalMs} while this
+   * returns true (e.g. no active sessions). Scanning JSONL for token usage when
+   * nothing is running is wasted work — this trims it from the idle CPU floor.
+   * Omit for the prior fixed-cadence behavior. (Responsible Resource Usage.)
+   */
+  isIdle?: () => boolean;
+  /** Polling interval (ms) while idle. Defaults to 5 minutes. */
+  idleIntervalMs?: number;
   /** Optional logger (defaults to console.warn for errors only). */
   onError?: (err: unknown) => void;
   /**
@@ -25,7 +35,10 @@ export interface TokenLedgerPollerOptions {
 export class TokenLedgerPoller {
   private ledger: TokenLedger;
   private intervalMs: number;
+  private idleIntervalMs: number;
+  private isIdle: (() => boolean) | null;
   private timer: ReturnType<typeof setInterval> | null = null;
+  private cadence: IdleAwareCadence | null = null;
   private running = false;
   private onError: (err: unknown) => void;
   private codexProjectDir: string | null;
@@ -34,6 +47,8 @@ export class TokenLedgerPoller {
   constructor(opts: TokenLedgerPollerOptions) {
     this.ledger = opts.ledger;
     this.intervalMs = opts.intervalMs ?? 60_000;
+    this.isIdle = opts.isIdle ?? null;
+    this.idleIntervalMs = opts.idleIntervalMs && opts.idleIntervalMs > 0 ? opts.idleIntervalMs : 5 * 60_000;
     this.codexProjectDir = opts.codexProjectDir ?? null;
     this.codexMaxFileAgeMs = opts.codexMaxFileAgeMs && opts.codexMaxFileAgeMs > 0
       ? opts.codexMaxFileAgeMs
@@ -44,17 +59,32 @@ export class TokenLedgerPoller {
   }
 
   start(): void {
-    if (this.timer) return;
+    if (this.timer || this.cadence) return;
     // Immediate first tick (non-blocking) so the dashboard has data fast.
     queueMicrotask(() => this.tick());
-    this.timer = setInterval(() => this.tick(), this.intervalMs);
-    if (typeof this.timer.unref === 'function') this.timer.unref();
+    if (this.isIdle) {
+      // Idle-aware: full cadence while active, back off while idle.
+      this.cadence = new IdleAwareCadence({
+        activeMs: this.intervalMs,
+        idleMs: this.idleIntervalMs,
+        isIdle: this.isIdle,
+        tick: () => this.tick(),
+      });
+      this.cadence.start();
+    } else {
+      this.timer = setInterval(() => this.tick(), this.intervalMs);
+      if (typeof this.timer.unref === 'function') this.timer.unref();
+    }
   }
 
   stop(): void {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+    if (this.cadence) {
+      this.cadence.stop();
+      this.cadence = null;
     }
   }
 

--- a/src/server/AgentServer.ts
+++ b/src/server/AgentServer.ts
@@ -1979,6 +1979,10 @@ export class AgentServer {
             this.tokenLedgerPoller = new TokenLedgerPoller({
               ledger: this.tokenLedger,
               codexProjectDir: process.cwd(),
+              // Idle-aware cadence (Responsible Resource Usage): back off the
+              // JSONL scan while no sessions are running — there are no new
+              // tokens to attribute, so the full-cadence scan is wasted.
+              isIdle: () => this.sessionManager.listRunningSessions().length === 0,
             });
             this.tokenLedgerPoller.start();
           } catch (err) {

--- a/tests/unit/IdleAwareCadence.test.ts
+++ b/tests/unit/IdleAwareCadence.test.ts
@@ -1,0 +1,95 @@
+/**
+ * IdleAwareCadence — runs work on a SHORT interval while active and a LONG
+ * interval while idle, re-evaluating idle state on every reschedule. Safety:
+ * isIdle() throwing ⇒ ACTIVE (never backs off on ambiguity); tick() throwing ⇒
+ * the loop survives.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IdleAwareCadence } from '../../src/monitoring/IdleAwareCadence.js';
+
+describe('IdleAwareCadence', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+  const ACTIVE = 1_000;
+  const IDLE = 10_000;
+
+  it('uses the ACTIVE interval while not idle', async () => {
+    const tick = vi.fn();
+    const c = new IdleAwareCadence({ activeMs: ACTIVE, idleMs: IDLE, isIdle: () => false, tick });
+    c.start();
+    await vi.advanceTimersByTimeAsync(ACTIVE);
+    expect(tick).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(ACTIVE);
+    expect(tick).toHaveBeenCalledTimes(2);
+    c.stop();
+  });
+
+  it('uses the IDLE interval while idle (no tick before idleMs)', async () => {
+    const tick = vi.fn();
+    const c = new IdleAwareCadence({ activeMs: ACTIVE, idleMs: IDLE, isIdle: () => true, tick });
+    c.start();
+    await vi.advanceTimersByTimeAsync(ACTIVE * 5); // 5s < idleMs(10s)
+    expect(tick).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(IDLE - ACTIVE * 5);
+    expect(tick).toHaveBeenCalledTimes(1);
+    c.stop();
+  });
+
+  it('re-evaluates idle state on every reschedule (active → idle backs off)', async () => {
+    let idle = false;
+    const tick = vi.fn();
+    const c = new IdleAwareCadence({ activeMs: ACTIVE, idleMs: IDLE, isIdle: () => idle, tick });
+    c.start();
+    await vi.advanceTimersByTimeAsync(ACTIVE);        // tick#1 (active)
+    expect(tick).toHaveBeenCalledTimes(1);
+    idle = true;                                       // activity stops mid-active-interval
+    await vi.advanceTimersByTimeAsync(ACTIVE);        // tick#2 fires (its reschedule was still active)
+    expect(tick).toHaveBeenCalledTimes(2);
+    // tick#2's reschedule sampled idle=true ⇒ next is the LONG interval.
+    await vi.advanceTimersByTimeAsync(ACTIVE * 3);    // 3s < idleMs(10s) ⇒ no tick (backed off)
+    expect(tick).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(IDLE);          // idle interval elapses ⇒ tick#3
+    expect(tick).toHaveBeenCalledTimes(3);
+    c.stop();
+  });
+
+  it('treats an isIdle() THROW as active (never backs off on ambiguity)', async () => {
+    const tick = vi.fn();
+    const c = new IdleAwareCadence({ activeMs: ACTIVE, idleMs: IDLE, isIdle: () => { throw new Error('boom'); }, tick });
+    c.start();
+    await vi.advanceTimersByTimeAsync(ACTIVE);
+    expect(tick).toHaveBeenCalledTimes(1); // fired at active, not idle
+    c.stop();
+  });
+
+  it('survives a tick() that throws (loop keeps going)', async () => {
+    const tick = vi.fn(() => { throw new Error('tick boom'); });
+    const c = new IdleAwareCadence({ activeMs: ACTIVE, idleMs: IDLE, isIdle: () => false, tick });
+    c.start();
+    await vi.advanceTimersByTimeAsync(ACTIVE);
+    await vi.advanceTimersByTimeAsync(ACTIVE);
+    expect(tick).toHaveBeenCalledTimes(2);
+    c.stop();
+  });
+
+  it('stop() halts all further ticks', async () => {
+    const tick = vi.fn();
+    const c = new IdleAwareCadence({ activeMs: ACTIVE, idleMs: IDLE, isIdle: () => false, tick });
+    c.start();
+    await vi.advanceTimersByTimeAsync(ACTIVE);
+    expect(tick).toHaveBeenCalledTimes(1);
+    c.stop();
+    await vi.advanceTimersByTimeAsync(ACTIVE * 10);
+    expect(tick).toHaveBeenCalledTimes(1); // no more
+  });
+
+  it('currentIntervalMs reflects the live idle state', () => {
+    let idle = false;
+    const c = new IdleAwareCadence({ activeMs: ACTIVE, idleMs: IDLE, isIdle: () => idle, tick: () => {} });
+    expect(c.currentIntervalMs()).toBe(ACTIVE);
+    idle = true;
+    expect(c.currentIntervalMs()).toBe(IDLE);
+  });
+});

--- a/tests/unit/token-ledger-poller-idle.test.ts
+++ b/tests/unit/token-ledger-poller-idle.test.ts
@@ -1,0 +1,54 @@
+/**
+ * TokenLedgerPoller idle-aware cadence wiring (Responsible Resource Usage):
+ * with `isIdle` provided, the poller backs off the JSONL scan while idle and
+ * runs at full cadence while active. Without it, the prior fixed cadence holds.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TokenLedgerPoller } from '../../src/monitoring/TokenLedgerPoller.js';
+
+function fakeLedger() {
+  return { scanAllAsync: vi.fn(() => Promise.resolve(0)) } as unknown as import('../../src/monitoring/TokenLedger.js').TokenLedger;
+}
+
+describe('TokenLedgerPoller — idle-aware cadence', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+  it('backs off the scan while idle (no active-interval scans)', async () => {
+    const ledger = fakeLedger();
+    const p = new TokenLedgerPoller({ ledger, intervalMs: 1_000, idleIntervalMs: 60_000, isIdle: () => true });
+    p.start();
+    await vi.advanceTimersByTimeAsync(0); // drain the immediate microtask tick
+    (ledger.scanAllAsync as ReturnType<typeof vi.fn>).mockClear(); // ignore the eager first scan
+    await vi.advanceTimersByTimeAsync(5_000); // 5s < idleIntervalMs(60s)
+    expect(ledger.scanAllAsync).not.toHaveBeenCalled(); // backed off — no scan yet
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(ledger.scanAllAsync).toHaveBeenCalledTimes(1);
+    p.stop();
+  });
+
+  it('runs at full cadence while active', async () => {
+    const ledger = fakeLedger();
+    const p = new TokenLedgerPoller({ ledger, intervalMs: 1_000, idleIntervalMs: 60_000, isIdle: () => false });
+    p.start();
+    await vi.advanceTimersByTimeAsync(0);
+    (ledger.scanAllAsync as ReturnType<typeof vi.fn>).mockClear();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(ledger.scanAllAsync).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(ledger.scanAllAsync).toHaveBeenCalledTimes(2);
+    p.stop();
+  });
+
+  it('without isIdle keeps the prior fixed cadence', async () => {
+    const ledger = fakeLedger();
+    const p = new TokenLedgerPoller({ ledger, intervalMs: 1_000 });
+    p.start();
+    await vi.advanceTimersByTimeAsync(0);
+    (ledger.scanAllAsync as ReturnType<typeof vi.fn>).mockClear();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(ledger.scanAllAsync).toHaveBeenCalledTimes(1);
+    p.stop();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,53 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Background pollers now back off when the agent is idle — trimming wasted work
+from the always-on CPU floor.**
+
+Each instar agent runs a couple dozen timer-driven background monitors. On an idle
+agent (no active sessions) most still wake on a fixed cadence and do work — log
+scans, session captures, ledger rollups — for no reason. Across many always-on
+agents on one machine, that fixed-cadence churn is a real slice of baseline CPU.
+
+This adds a reusable `IdleAwareCadence` primitive: a self-rescheduling timer that
+runs short while active and long while idle, re-checking the idle state on every
+cycle so it snaps back to full speed the moment work resumes. The first poller to
+adopt it is the token-usage scanner (`TokenLedgerPoller`): when no session is
+running there are no new tokens to attribute, so it backs off from every 60s to
+every 5 minutes. The mechanism is built so the other pollers — and, later, a full
+agent-sleep mode — can adopt it incrementally.
+
+This is the first slice of Level 1 (idle footprint) of the Responsible Resource
+Usage standard. (instar can't hibernate the MCP servers Claude Code spawns, so the
+in-scope win is making instar's own pollers cheaper when idle.)
+
+## What to Tell Your User
+
+Nothing to configure. When an agent is just sitting idle, its background checkers
+now run less often instead of waking up on a fast timer for no reason — so each
+agent uses a little less CPU when nothing is happening, and speeds right back up
+the moment you give it work. It is conservative by design: it only changes how
+often these checkers run, never what they do, and if it is ever unsure whether the
+agent is idle it stays on the fast schedule.
+
+## Summary of New Capabilities
+
+- New `IdleAwareCadence` (`src/monitoring/IdleAwareCadence.ts`) — reusable
+  active/idle self-rescheduling timer; `isIdle()` throw degrades to active;
+  `tick()` throw never breaks the loop; `currentIntervalMs()` for observability.
+- `TokenLedgerPoller` gains optional `isIdle` + `idleIntervalMs` (default 5 min);
+  without them it keeps the prior fixed cadence exactly.
+- `AgentServer` wires the token poller's idle signal to "no running sessions."
+
+## Evidence
+
+- `tests/unit/IdleAwareCadence.test.ts` — active interval, idle backoff,
+  active→idle re-evaluation, `isIdle`-throw⇒active, `tick`-throw-survives, `stop()`,
+  `currentIntervalMs`.
+- `tests/unit/token-ledger-poller-idle.test.ts` — the poller backs off while idle,
+  runs full cadence while active, and keeps the fixed cadence without `isIdle`.
+- `tests/unit/token-ledger.test.ts` + `TokenLedgerPoller-codex.test.ts` green
+  (backward-compatible). `npm run lint` clean.

--- a/upgrades/side-effects/idle-poller-cadence.md
+++ b/upgrades/side-effects/idle-poller-cadence.md
@@ -1,0 +1,84 @@
+# Side-Effects Review — Idle-aware poller cadence
+
+**Version / slug:** `idle-poller-cadence`
+**Date:** `2026-05-30`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+New `IdleAwareCadence` primitive (a self-rescheduling timer that runs short while
+active, long while idle, re-sampling idle state each reschedule). Applied to
+`TokenLedgerPoller` via optional `isIdle`/`idleIntervalMs`; `AgentServer` wires
+`isIdle = no running sessions`. First slice of Level 1 (instar's own idle footprint).
+
+## Decision-point inventory
+
+None with authority. The only decision is "active vs idle interval," which affects
+cadence, not control flow.
+
+## 1. Over-block
+
+**What legitimate work does this skip?** None. It changes only how often a
+read-only scan runs. When idle, the token JSONL has no new content to attribute, so
+the skipped scans were no-ops anyway. Resuming activity restores full cadence within
+one idle interval.
+
+## 2. Under-block
+
+**What does it miss?** It does not (yet) back off the other ~26 pollers — incremental
+by design. And the idle signal is coarse (no running sessions); a future refinement
+could include recent inbound activity. Neither is a correctness gap.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. `IdleAwareCadence` is a generic monitoring primitive; the
+poller opts in via a constructor option; the idle signal is injected by `AgentServer`
+(which owns the session manager). The poller's scan logic is untouched.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No blocking authority. The change is cadence-only on a read-only observability
+poller. The safety bias is explicit: an `isIdle()` throw degrades to ACTIVE (full
+cadence = prior behavior), so failure means "no savings," never "missed work."
+
+## 5. Interactions
+
+`TokenLedgerPoller` without `isIdle` keeps the exact prior fixed `setInterval`
+(backward-compatible — covered by a test). No interaction with the SessionReaper,
+sentinels, burn-detector, or recovery paths — they each keep their own timers. The
+reentry guard in `tick()` is preserved.
+
+## 6. External surfaces
+
+None. No HTTP route, no config key, no on-disk state, no notifications. Purely an
+internal cadence change. The `/tokens/*` data is unaffected (same scan, just less
+often while idle).
+
+## 7. Rollback cost
+
+Trivial. Omitting `isIdle` restores the prior behavior with zero code change at the
+call site; a PR revert removes the helper + the poller option. No migration, no
+schema, no irreversible op.
+
+## Conclusion
+
+Lowest-risk class: additive, behavior-cadence-only, backward-compatible, conservative
+on ambiguity, no authority. Trims wasted idle-poller work and establishes the reusable
+idle-cadence primitive that further pollers and agent-sleep (L3) build on.
+
+## Second-pass review (if required)
+
+Not required — cadence-only change, no authority, no decision logic.
+
+## Evidence pointers
+
+- `tests/unit/IdleAwareCadence.test.ts` — the primitive (active/idle intervals,
+  re-evaluation, isIdle-throw⇒active, tick-throw-survives, stop, currentIntervalMs).
+- `tests/unit/token-ledger-poller-idle.test.ts` — poller backs off while idle, full
+  cadence while active, fixed cadence without `isIdle`.
+- `tests/unit/token-ledger.test.ts` + `TokenLedgerPoller-codex.test.ts` — green
+  (backward-compat).
+- `upgrades/NEXT.md` — upgrade guide.


### PR DESCRIPTION
## What & why

**Responsible Resource Usage — Level 1** (instar's own idle footprint). ~27 timer-driven monitors per agent wake on a fixed cadence even when the agent is idle; across ~9 always-on stacks that's a real slice of wasted baseline CPU. instar can't hibernate the MCP servers Claude Code spawns, so the in-scope win is making instar's *own* pollers cheaper when idle.

New `IdleAwareCadence` primitive: a self-rescheduling timer that runs **short while active, long while idle**, re-sampling the idle state on every reschedule (snaps back to full speed the moment work resumes). Applied to `TokenLedgerPoller` (60s → 5min when no sessions — there are no new tokens to attribute while idle); `AgentServer` wires `isIdle = no running sessions`.

## Safety
- `isIdle()` throw ⇒ **ACTIVE** (never backs off on ambiguity).
- `tick()` throw ⇒ swallowed (loop survives).
- **Backward-compatible**: without `isIdle`, the poller keeps its exact prior fixed cadence (tested).
- Behavior-cadence-only — no route, no config, no state, no authority. Worst case = "no savings," never "missed work."

## Foundation
This is the reusable primitive that the other pollers (incrementally) and **agent-sleep (Level 3)** build on.

## Approval
⚠️ Self-approved spec under the delegated deploy mandate (autonomous run, topic 16782). Spec + ELI16 + side-effects included.

## Tests
- `tests/unit/IdleAwareCadence.test.ts` — active/idle intervals, active→idle re-evaluation, isIdle-throw⇒active, tick-throw-survives, stop, currentIntervalMs (fake timers).
- `tests/unit/token-ledger-poller-idle.test.ts` — backs off while idle / full cadence while active / fixed cadence without isIdle.
- Existing TokenLedger + poller-codex tests green (backward-compat); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)