### PR TITLE
feat(codex): CompactionSentinel codex parity — codex-aware recovery verification

### DIFF
--- a/docs/specs/compaction-sentinel-codex-parity.eli16.md
+++ b/docs/specs/compaction-sentinel-codex-parity.eli16.md
@@ -1,0 +1,49 @@
+# CompactionSentinel codex parity — explained simply
+
+## The recovery nurse who couldn't read codex's chart
+
+When an AI session gets "compacted" (its memory summarized to free up space), there's a
+brief moment where it has to re-find its footing. Instar has a recovery nurse
+(CompactionSentinel) who watches for a session that DIDN'T come back cleanly: she gently
+re-hands it its instructions, then checks whether it started working again by watching its
+"logbook" (transcript) grow. If it doesn't grow, she re-hands the instructions again, up to
+3 times, then flags a failure.
+
+The problem: the nurse only knew where CLAUDE sessions keep their logbook. For a CODEX
+session (like Codey), she looked in the wrong place, found nothing, and concluded "still not
+working" — EVERY time. So after every codex compaction she'd re-hand the instructions 3
+times (stacking confusing "you're restarting" prompts on top of the user's real message —
+a known disruptive loop) and then wrongly flag a failure. The session had actually
+recovered fine; she just couldn't see it.
+
+## The fix
+
+This is the exact same fix we already shipped + had independently reviewed for the
+rate-limit nurse (#33): teach `readJsonlBaseline` to read codex's actual logbook. An OpenAI
+rate situation is account-wide, so "is codex working again?" is the same as "did codex's
+newest logbook just grow?" — which a small, fast helper (already in the codebase) checks.
+No fragile per-session id. Claude's path is completely untouched (we proved it — all 22 of
+the nurse's existing tests still pass).
+
+## Safety
+
+The worst this can do for codex is what it already does today (find nothing, return
+"unknown"). Everywhere it CAN see the codex logbook, it can only turn a broken check into a
+correct one. So it can't make anything worse — and it's switched ON (not dark) precisely
+because the broken behavior (the 3× re-hand + false failure) is happening right now on
+every codex compaction.
+
+## The one honest caveat (same as #33)
+
+Because the signal is the whole codex account's newest logbook (not one specific session's),
+if TWO codex sessions are recovering at the exact same moment, one's output could make the
+nurse think both recovered. But that just means she stops re-handing instructions one beat
+early — gentler than the redundant re-handing she does now — and a later check re-triggers
+if needed. Codey runs one codex session at a time, so this can't bite today. Closing it
+fully (per-session logbooks) is tracked alongside #33's same caveat.
+
+## Why it matters
+
+Codey gets compacted on long runs. Right now every one of those triggers a confusing
+re-prompt storm and a false "recovery failed." After this, codex sessions get the same
+clean, correct compaction-recovery that Claude sessions already get.

--- a/docs/specs/compaction-sentinel-codex-parity.md
+++ b/docs/specs/compaction-sentinel-codex-parity.md
@@ -1,0 +1,70 @@
+---
+title: CompactionSentinel codex parity (codex-aware recovery verification)
+slug: compaction-sentinel-codex-parity
+status: approved
+review-convergence: 2026-05-31T02:45:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h autonomous deploy mandate (topic 13435,
+  "any robustness or Codex issue I find, I fix as a proper fleet PR"). An INDEPENDENT
+  second-pass review CONCURRED on shipping (active, not dark) with NO must-fix items — it
+  verified the Claude path is byte-for-byte unchanged, the fix is strictly-better than the
+  current broken-for-codex behavior (worst case degrades to today's null-return), and the
+  concurrent-codex-session caveat is less harmful than the redundant re-injection it
+  replaces. This is a faithful application of the already-shipped + already-reviewed
+  RateLimitSentinel #33 recipe to the second of the two sentinels #26 traced as codex-blind.
+second-pass-required: true
+second-pass-status: concur-ship-active
+---
+
+# CompactionSentinel codex parity
+
+## Problem
+
+CompactionSentinel detects a session that didn't recover after compaction, re-injects a
+recovery prompt (`recoverFn`), and verifies recovery by watching the session's transcript
+JSONL GROW; if no growth it RETRIES re-injection up to `maxInjectAttempts` then emits
+`compaction:failed`. Its `readJsonlBaseline` only knew the Claude projects path
+(`$HOME/.claude/projects/<hash>`), so for a CODEX session it returned `null` → verification
+could NEVER confirm growth → the sentinel re-injected the recovery prompt up to 3× per
+codex compaction (stacking bootstraps under the user's real message — the "false session
+is restarting" loop the code itself warns about) then emitted a false `compaction:failed`.
+
+This is the second of the two sentinels #26 traced as codex-blind (RateLimitSentinel was
+the first, fixed in #33).
+
+## Design (the #33 recipe, faithfully reapplied)
+
+`readJsonlBaseline` gains a codex branch: when `getSessionFramework(name) === 'codex-cli'`
+it returns the newest codex rollout via `findNewestRolloutSync(codexHome)` (the OpenAI
+account is account-wide, so "is codex producing output again?" == "did the newest rollout
+grow?"; NO per-session UUID — that was #33-v1's bug). Deps `getSessionFramework` +
+`codexHome` added; `server.ts` wires `getSessionFramework`. No vendor messages needed
+(CompactionSentinel emits events, not user-facing vendor-specific text). The existing
+`verify()` size-growth + baseline-refresh logic is reused unchanged.
+
+## Safety
+- Claude path byte-for-byte unchanged (codex branch strictly gated on `codex-cli`; the
+  22 existing CompactionSentinel tests pass).
+- Worst case (codex tree unreadable / no rollout) the codex branch returns `null` — exactly
+  today's behavior. Everywhere it returns non-null it only ENABLES a correct recovery
+  detection that is impossible today. So the fix is strictly-better than the current broken
+  state (2nd-pass-verified).
+- Ships ACTIVE (no flag) — appropriate because the failure it fixes (redundant
+  bootstrap-stacking + false `compaction:failed` on every codex compaction) is firing today.
+
+## Known limitation (same as #33, not a must-fix)
+The account-wide newest-rollout signal is shared across concurrent codex sessions — with
+≥2 concurrent codex compactions, one session's output could false-recover a still-stuck
+sibling. For CompactionSentinel this means stopping a re-injection one cycle early (LESS
+harmful than the current redundant re-inject), and a future compaction detection re-triggers
+recovery. Correct for single-codex-session (the operational reality). Per-session rollout
+tracking is the eventual close (tracked with #33's same caveat).
+
+## Test plan (3-tier)
+- **Unit (`CompactionSentinel-codex.test.ts`):** codex session recovers when its newest
+  rollout grows; fails (no false-recover) when it never grows. Claude path unchanged
+  (existing `CompactionSentinel.test.ts`, 22 tests).
+- The detection (PreCompact / watchdog triggers) is framework-neutral already; the gap was
+  purely the recovery-verification path fixed here.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -5664,6 +5664,10 @@ export async function startServer(options: StartOptions): Promise<void> {
             .find(s => s.tmuxSession === sessionName);
           return session?.claudeSessionId;
         },
+        // Codex parity: for codex sessions, recovery-verification reads the newest codex
+        // rollout's growth (account-wide signal) instead of the Claude transcript (#33 recipe).
+        getSessionFramework: (name) =>
+          sessionManager.listRunningSessions().find((s) => s.tmuxSession === name)?.framework,
         // Don't re-inject a recovery prompt into a session that's actively
         // working (mid extended-think / tool call). Re-injecting buries the
         // user's real message under stacked recovery bootstraps — the false

--- a/src/monitoring/CompactionSentinel.ts
+++ b/src/monitoring/CompactionSentinel.ts
@@ -35,6 +35,7 @@
 import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import path from 'node:path';
+import { findNewestRolloutSync } from '../providers/adapters/openai-codex/observability/sessionPaths.js';
 
 export type CompactionTrigger = 'PreCompact' | 'watchdog-poll' | 'recovery-hook' | string;
 
@@ -82,6 +83,17 @@ export interface CompactionSentinelDeps {
    * recovered. Return undefined for sessions whose uuid isn't known yet.
    */
   getClaudeSessionId?: (sessionName: string) => string | undefined;
+
+  /**
+   * Resolve a session's framework ('codex-cli' | 'claude-code' | undefined). When it
+   * returns 'codex-cli', recovery-verification reads the newest codex ROLLOUT jsonl
+   * (account-wide growth signal) instead of the Claude transcript. Absent/non-codex →
+   * the unchanged Claude path is used (Claude behavior byte-for-byte preserved).
+   */
+  getSessionFramework?: (sessionName: string) => string | undefined;
+
+  /** Override $CODEX_HOME (tests). Defaults to ~/.codex. Only used for codex sessions. */
+  codexHome?: string;
 
   /**
    * Override for the JSONL lookup root. Primarily for tests. Defaults to
@@ -423,6 +435,15 @@ export class CompactionSentinel extends EventEmitter {
    * most recently-modified file in the project's jsonl root.
    */
   private readJsonlBaseline(sessionName: string): { path: string; size: number; mtime: number } | null {
+    // Codex parity: a codex session's transcript is the newest rollout JSONL under
+    // $CODEX_HOME/sessions, NOT the Claude projects tree. Compaction-recovery is verified
+    // by post-recovery output, and for codex "the account is producing output again" ==
+    // "the newest rollout grew" (the OpenAI account-wide signal). Only taken for codex
+    // sessions; everything else falls through to the unchanged Claude path (Claude
+    // behavior byte-for-byte preserved). Mirrors the RateLimitSentinel codex fix (#33).
+    if (this.deps.getSessionFramework?.(sessionName) === 'codex-cli') {
+      return findNewestRolloutSync(this.deps.codexHome);
+    }
     try {
       const root = this.deps.jsonlRoot
         || path.join(process.env.HOME || '/tmp', '.claude', 'projects',

--- a/tests/unit/CompactionSentinel-codex.test.ts
+++ b/tests/unit/CompactionSentinel-codex.test.ts
@@ -1,0 +1,75 @@
+// Codex parity: CompactionSentinel recovery-verification must read a CODEX session's
+// newest rollout JSONL (account-wide OpenAI signal) instead of the Claude transcript, so
+// a codex session's compaction-recovery is confirmed exactly as a Claude one is. Both
+// sides: rollout grows → recovered; rollout doesn't grow → failed. Claude path unaffected.
+// Mirrors the RateLimitSentinel codex fix (#33).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { CompactionSentinel } from '../../src/monitoring/CompactionSentinel.js';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+function makeCodexHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'compaction-codex-'));
+  const dayDir = path.join(home, '.codex', 'sessions', '2026', '05', '31');
+  fs.mkdirSync(dayDir, { recursive: true });
+  const rollout = path.join(dayDir, 'rollout-2026-05-31T09-00-00-aaaa1111-0000-0000-0000-000000000001.jsonl');
+  return {
+    codexHome: path.join(home, '.codex'),
+    write: (bytes: number) => fs.writeFileSync(rollout, 'x'.repeat(bytes)),
+    cleanup: () => SafeFsExecutor.safeRmSync(home, { recursive: true, force: true, operation: 'tests/unit/CompactionSentinel-codex.test.ts:cleanup' }),
+  };
+}
+
+describe('CompactionSentinel — codex recovery via newest rollout', () => {
+  let codex: ReturnType<typeof makeCodexHome>;
+  let recoverFn: ReturnType<typeof vi.fn>;
+  let sentinel: CompactionSentinel;
+  let events: Array<{ type: string; payload: any }>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    codex = makeCodexHome();
+    recoverFn = vi.fn().mockResolvedValue(true);
+    sentinel = new CompactionSentinel(
+      {
+        recoverFn: recoverFn as any,
+        projectDir: '/fake/project',
+        getSessionFramework: () => 'codex-cli',
+        codexHome: codex.codexHome,
+      },
+      { dedupeWindowMs: 60_000, verifyWindowMs: 25_000, maxInjectAttempts: 3, recoveryGuardMs: 10 * 60_000 },
+    );
+    events = [];
+    for (const e of ['compaction:detected', 'compaction:recovered', 'compaction:failed']) {
+      sentinel.on(e as any, (p: any) => events.push({ type: e, payload: p }));
+    }
+  });
+  afterEach(() => {
+    sentinel.stop();
+    codex.cleanup();
+    vi.useRealTimers();
+  });
+
+  it('recovers a codex session when its newest ROLLOUT jsonl grows', async () => {
+    codex.write(100);
+    sentinel.report('codey-1', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(recoverFn).toHaveBeenCalledWith('codey-1', 'watchdog-poll');
+    codex.write(600); // a codex turn appended to the rollout
+    await vi.advanceTimersByTimeAsync(25_500);
+    expect(events.some((e) => e.type === 'compaction:recovered')).toBe(true);
+  });
+
+  it('fails a codex session when the rollout never grows (no recovery)', async () => {
+    codex.write(100);
+    sentinel.report('codey-1', 'watchdog-poll');
+    await vi.advanceTimersByTimeAsync(0);
+    // never grow the rollout → exhaust attempts
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(events.some((e) => e.type === 'compaction:recovered')).toBe(false);
+    expect(events.some((e) => e.type === 'compaction:failed')).toBe(true);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,50 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13435; independent 2nd-pass review CONCUR ship-active, no must-fix)
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — codex compaction-recovery is now verified correctly (fixes a real codex bug)
+
+CompactionSentinel re-injects a recovery prompt to a session that didn't come back cleanly
+after compaction, then confirms recovery by watching the session's transcript grow. It only
+knew where Claude keeps transcripts, so for a codex session it found nothing → concluded
+"still stuck" → re-injected the recovery prompt up to 3 times (stacking confusing restart
+prompts on the user's real message — a known disruptive loop) and then falsely reported a
+recovery failure, every single codex compaction.
+
+Now it reads the codex session's actual rollout (the same account-wide "is codex producing
+output again?" signal used for the codex rate-limit fix, no fragile per-session id). Claude
+behavior is byte-for-byte unchanged. This is the second of the two sentinels that were codex-
+blind (the rate-limit one shipped previously).
+
+## What to Tell Your User
+
+If you run a codex agent that gets compacted on a long task, it will now recover cleanly
+instead of getting hit with a burst of confusing restart prompts and a false "recovery
+failed." Nothing to configure — it is simply correct now.
+
+## Summary of New Capabilities
+
+- `CompactionSentinel` recovery-verification is codex-aware: for codex sessions it reads the
+  newest codex rollout's growth (via `findNewestRolloutSync`) instead of the Claude transcript.
+- New deps `getSessionFramework` + `codexHome`; Claude path untouched.
+
+## Evidence
+
+- Repro: a codex session that recovers from compaction is wrongly re-injected ×maxInjectAttempts
+  then marked `compaction:failed`, because `readJsonlBaseline` returned null for codex.
+- Before/after: before — codex verification always null → false-fail; after — reads the codex
+  rollout's growth → `compaction:recovered`.
+- Unit: `tests/unit/CompactionSentinel-codex.test.ts` (rollout grows → recovered; never grows
+  → failed). Claude-unchanged: existing `tests/unit/CompactionSentinel.test.ts` (22 tests pass).
+- `tsc --noEmit` clean; `npm run lint` clean.
+- Independent second-pass review: CONCUR ship-active, NO must-fix (verified Claude byte-
+  identical + strictly-better than the current broken-for-codex behavior). Same single-account
+  concurrent-codex-session caveat as the rate-limit fix (less harmful here; single-session correct).
+- Spec: `docs/specs/compaction-sentinel-codex-parity.md` (+ `.eli16.md`).
+- Side-effects: `upgrades/side-effects/compaction-sentinel-codex-parity.md`.

--- a/upgrades/side-effects/compaction-sentinel-codex-parity.md
+++ b/upgrades/side-effects/compaction-sentinel-codex-parity.md
@@ -1,0 +1,60 @@
+# Side-Effects Review — CompactionSentinel codex parity
+
+**Slug:** `compaction-sentinel-codex-parity`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** independent review — **CONCUR (ship active), no must-fix.**
+
+## Summary
+CompactionSentinel.readJsonlBaseline gains a codex branch (newest rollout via
+findNewestRolloutSync) so codex compaction-recovery is verified instead of falsely failing.
+The #33 recipe, reapplied. Claude path byte-for-byte unchanged. Ships ACTIVE (the broken
+behavior fires today).
+
+## Decision-point inventory
+1. `getSessionFramework === 'codex-cli'` gate in readJsonlBaseline.
+2. findNewestRolloutSync ("which rollout is newest").
+
+## 1. Over-block / 2. Under-block
+No blocking surface. CompactionSentinel re-injects a recovery prompt + verifies. The fix
+makes verify CORRECT for codex (was: always-fails → redundant re-inject ×3 → false
+compaction:failed). Worst case the codex branch returns null = today's behavior. Concurrent
+codex sessions: a false-recovery stops re-injection one cycle early (LESS harmful than the
+current redundant re-inject); single-session = correct.
+
+## 3. Level-of-abstraction fit
+Identical surface to the #33 RateLimitSentinel fix; reuses the same findNewestRolloutSync
+helper + the framework-aware readJsonlBaseline pattern. No new subsystem.
+
+## 4. Signal vs authority compliance
+[docs/signal-vs-authority.md](../../docs/signal-vs-authority.md). Recovery (re-inject +
+verify) is an existing authority surface; this extends the SAME lifecycle to codex, does
+not newly elevate authority. No monitoring→blocker conversion.
+
+## 5. Interactions
+- Claude sessions: unchanged (gate is codex-only; 22 existing tests pass).
+- RateLimitSentinel: independent; both now use findNewestRolloutSync (shared, pure helper).
+- Concurrent codex sessions: the account-wide-signal caveat (#33's), less harmful here.
+
+## 6. External surfaces
+None new. Reads local codex rollout files. No HTTP route, no external API, no user-facing
+vendor strings (CompactionSentinel emits events + console logs only).
+
+## 7. Rollback cost
+Low. The codex branch is additive + gated; a PR revert restores the prior (broken-for-codex
+but claude-correct) behavior. No flag (active), but the change cannot regress Claude.
+
+## Conclusion
+Safe to ship ACTIVE. Strictly-better than the current broken-for-codex behavior
+(2nd-pass-verified). Concurrent-session caveat documented (same as #33, less harmful here).
+
+## Second-pass review
+Independent reviewer **CONCUR ship-active, NO must-fix.** Verified: Claude path
+byte-identical; recipe correctly applied (import + codexHome arg + early return + null-safe);
+strictly-better than current broken state (worst case = today's null-return); concurrent
+caveat acceptable. Non-blocking: same single-account caveat as #33.
+
+## Evidence pointers
+- Unit: `tests/unit/CompactionSentinel-codex.test.ts` (grow→recover, no-grow→fail).
+- Claude-unchanged: existing `tests/unit/CompactionSentinel.test.ts` (22 tests pass).
+- Spec: `docs/specs/compaction-sentinel-codex-parity.md` (+ `.eli16.md`).


### PR DESCRIPTION
## CompactionSentinel codex parity (ships ACTIVE)

The 2nd of the two sentinels #26 traced as codex-blind (RateLimitSentinel was #33). CompactionSentinel re-injects a recovery prompt to a session that didn't recover after compaction, then verifies via transcript growth. `readJsonlBaseline` only knew the Claude projects path → for codex it returned null → verification never confirmed → it re-injected the recovery prompt up to `maxInjectAttempts` (stacking bootstraps, the false-restart loop the code warns about) then emitted a false `compaction:failed`, **every codex compaction**.

### Fix (the #33 recipe, reapplied)
- `readJsonlBaseline` codex branch: `if getSessionFramework(name)==='codex-cli' return findNewestRolloutSync(codexHome)` (account-wide rollout-growth signal; no per-session UUID). Deps `getSessionFramework`+`codexHome`; `server.ts` wires `getSessionFramework`. No vendor messages (CompactionSentinel emits events only).

### Safety
- **Claude path byte-for-byte unchanged** (codex-gated; 22 existing tests pass).
- Worst case the codex branch returns null = **today's behavior** → strictly-better.
- Ships **ACTIVE** (no flag) — appropriate: the broken behavior (redundant re-inject + false-fail) fires today.

### Second-pass review (required)
Independent reviewer **CONCUR ship-active, NO must-fix.** Verified claude-unchanged + recipe-correct + strictly-better-than-broken. Same single-account concurrent-codex-session caveat as #33 (less harmful here — stops a re-inject one cycle early vs the current redundant re-inject; single-codex-session = correct).

### Tests
`CompactionSentinel-codex.test.ts` (grow→recover, no-grow→fail) + existing `CompactionSentinel.test.ts` (22, claude unchanged). lint + tsc clean.

Spec: `docs/specs/compaction-sentinel-codex-parity.md` (+ `.eli16.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
