### PR TITLE
fix(worktree-reaper): SourceTreeGuard read-tier + non-forced worktree remove so the reaper actually runs

### DIFF
--- a/docs/specs/source-tree-guard-reaper-readtier.eli16.md
+++ b/docs/specs/source-tree-guard-reaper-readtier.eli16.md
@@ -1,0 +1,55 @@
+# ELI16 — Letting the worktree-cleanup robot actually do its job
+
+## What this is, in plain English
+
+Instar makes lots of "worktrees" — extra full copies of the project's code that
+pile up on disk (there were 100+ on the dev machine). A while back I built a small
+robot, the AgentWorktreeReaper, that finds the ones that are completely safe to
+delete — meaning the work in them is already saved into the main project, there are
+no unsaved edits, and nothing is using them right now — and removes them to free
+disk and reduce how much the Mac has to index.
+
+The problem: the robot never deleted anything, and it always reported "0 to clean
+up," even when 50 were obviously safe to remove.
+
+## Why it was stuck
+
+Instar has a safety wall called the SourceTreeGuard. It exists because of a real
+past incident: it stops the program from running dangerous git commands against its
+own source code. The robot lives *inside* instar, and the folder it cleans up sits
+right next to instar's own code — so the safety wall treated every single thing the
+robot tried to do as "a dangerous command against our own code" and blocked it.
+
+The robot needed four git commands: "list the worktrees," "is this one clean (no
+unsaved edits)?", "is this one's work already saved into the main branch?", and
+"remove this one." All four were blocked. Worse, the "is the work already saved?"
+command (`git cherry`) wasn't even recognized as a harmless read, so it failed
+instantly — and the robot interpreted that failure as "not safe, keep it." That's
+why it always said zero.
+
+## What changed
+
+I taught the safety wall to recognize exactly these four commands as allowed *for
+this specific cleanup job* — and nothing more:
+
+- The three read-only commands (list, check-clean, check-already-saved) are now
+  recognized as harmless reads.
+- The one command that actually deletes a worktree is allowed **only in its safe
+  form**. Normally `git worktree remove` refuses to delete anything with unsaved
+  edits. There's a "--force" version that ignores that and deletes anyway — and
+  that forced version is **still blocked**, so the robot can never destroy unsaved
+  work even by accident. The robot never asks for the forced version.
+
+Everything else the safety wall blocked before, it still blocks. The robot's own
+rules are unchanged: it still only deletes worktrees that are saved AND clean AND
+not in use, and it still ships turned off + in "dry run" (just report, don't delete)
+by default.
+
+## What you need to decide
+
+Nothing risky here. This is the second half you already said yes to ("yes, both").
+The safeguard is concrete: the only deleting command allowed is the one that
+refuses to touch unsaved work, and the dangerous forced variant stays walled off.
+The change is pure code — no settings, no migration — so undoing it is just
+reverting one commit, and the robot goes back to reporting zero. The real proof is
+live: after deploy, the cleanup report should show a real number instead of 0.

--- a/docs/specs/source-tree-guard-reaper-readtier.md
+++ b/docs/specs/source-tree-guard-reaper-readtier.md
@@ -1,0 +1,100 @@
+---
+title: SourceTreeGuard read-tier + worktree-remove allowance for the AgentWorktreeReaper
+slug: source-tree-guard-reaper-readtier
+status: approved
+review-convergence: 2026-05-31T03:20:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate. Justin explicitly
+  authorized this exact change in Telegram topic 16782 (2026-05-31): "yes, both"
+  — approving both (1) reclaiming the stale worktrees now and (2) the proper
+  SourceTreeGuard reaper-fix. This PR is item (2). Flagged in the PR per
+  cross-agent discipline; it is a safety-guard change, so the side-effects
+  review below is deliberately exhaustive about the new surface.
+---
+
+# SourceTreeGuard read-tier + worktree-remove allowance for the AgentWorktreeReaper
+
+## Problem
+
+The AgentWorktreeReaper (shipped v1.3.133, #589) reclaims merged + clean +
+not-in-use CLI worktrees under `~/.instar/agents/<agent>/.worktrees/`. It runs
+inside the instar server, and the agent home **is itself a checkout of the instar
+source tree**. Every git call the reaper makes therefore hits the SourceTreeGuard
+(via `SafeGitExecutor`), which blocks destructive operations against the source
+tree as a defense against the 2026-04-22 incident class.
+
+The reaper needs four git operations, ALL of which the guard blocked:
+
+1. `git worktree list --porcelain` — enumerate worktrees (read).
+2. `git status --porcelain` — per-worktree cleanliness (read).
+3. `git cherry <base> <sha>` — merged-detection via patch-id equivalence (read).
+4. `git worktree remove <path>` — reclaim a worktree (mutation, non-forced).
+
+Two distinct failures stacked:
+
+- **`cherry` was an *unknown* verb to `readSync`** — not in `READONLY_GIT_VERBS` —
+  so `readSync` rejected it as "destructive verb 'cherry'" before the source-tree
+  check even ran. The reaper's `isBranchMerged` caught the throw and returned
+  "unmerged" (KEEP), so **nothing was ever detected as merged** → the reaper
+  reported 0 reclaimable in production regardless of reality.
+- The source-tree bypass allowlists were too narrow: `SOURCE_TREE_READ_TIER_VERBS`
+  didn't include `status`/`cherry`, and the worktree-manager invocation allowlist
+  (`sourceTreeWorktreeManagerOk`) permitted only `add`/`prune`, not `list`/`remove`.
+- The reaper's own git wrapper didn't pass the bypass flags at all.
+
+## What's new
+
+Three precise, minimal widenings — each shape-checked, none broadening the guard
+for arbitrary callers:
+
+1. **`cherry` added to `READONLY_GIT_VERBS`.** `git cherry` lists `+`/`-`
+   patch-equivalence lines vs an upstream; it never mutates. This makes `readSync`
+   accept it (the actual root cause of the silent 0-reclaim).
+2. **`status` + `cherry` added to `SOURCE_TREE_READ_TIER_VERBS`.** Both are pure
+   reads, gated by the existing `sourceTreeReadOk` opt. This set is already the
+   documented home for "read-tier verbs the watchdog/reconciler need against the
+   source tree." The bounded-size test still holds (≤10).
+3. **Worktree-manager allowlist extended** (`isAllowedWorktreeManagerSubcommand`,
+   gated by `sourceTreeWorktreeManagerOk`): in addition to `add`/`prune`, allow
+   `list` (read) and `remove` — but **`remove` only in its non-forced form**.
+   `git worktree remove` without `--force` refuses to delete a worktree with
+   uncommitted changes or a lock, so it cannot destroy in-flight work. `--force`
+   / `-f` is explicitly denied and still trips the guard.
+
+The reaper's git wrapper (`agentWorktreeGit.ts`) now passes `sourceTreeReadOk`
++ `sourceTreeWorktreeManagerOk` on its reads and `sourceTreeWorktreeManagerOk`
+on the non-forced `worktree remove`.
+
+## Safeguards (why this is safe)
+
+- **`readSync` rejects any destructive shape regardless of flags**, so widening the
+  source-tree bypass on the read path cannot enable a mutation there.
+- **`--force` remains blocked** even with the flag — the one form of
+  `worktree remove` that could destroy uncommitted work. The reaper never passes it.
+- **The reaper's safety gates are unchanged**: it still only removes worktrees that
+  are merged AND clean AND not-in-use, and ships dark + dry-run by default.
+- **No new authority** — these are signals/reads plus one narrowly-shaped,
+  self-protecting mutation. Nothing here holds blocking authority over a message.
+
+## Testing
+
+- Unit (`SafeGitExecutor-sourceTreeReadOk.test.ts`): status/cherry/worktree-list
+  blocked-by-default + allowed-with-flag; worktree remove (non-forced) actually
+  removes; `worktree remove --force`/`-f` STILL blocked even with the flag; the
+  read flag does NOT grant remove authority; closed-set membership for status/cherry.
+- Integration (`agent-worktree-reaper.test.ts`): the **real** `makeAgentWorktreeReaperDeps`
+  (real `SafeGitExecutor`, real git) against a repo promoted to an instar source
+  tree with real merged/dirty/unmerged worktrees — list + isClean + isMerged +
+  removeWorktree all work through the guard; end-to-end the reaper reaps the
+  merged+clean one and keeps dirty + unmerged. This is the test the original
+  (fake-git) suite lacked, which is exactly why the bug shipped.
+- Live: deploy to echo, then `GET /worktrees/agent-reaper` reports non-zero
+  reclaimable instead of 0.
+
+## Rollback
+
+Pure source change. Revert the commit → the reaper reverts to reporting 0
+(blocked) and the manual `git worktree remove` path (used for the immediate
+reclaim) is unaffected. No config, no migration, no agent-installed files.

--- a/src/core/SafeGitExecutor.ts
+++ b/src/core/SafeGitExecutor.ts
@@ -106,6 +106,7 @@ export const READONLY_GIT_VERBS: ReadonlySet<string> = new Set([
   'name-rev',
   'blame',
   'cat-file',
+  'cherry', // read-only: lists +/- patch-equivalence vs an upstream; no mutation
   'grep',
   'shortlog',
   'count-objects',
@@ -155,6 +156,11 @@ export const SOURCE_TREE_READ_TIER_VERBS: ReadonlySet<string> = new Set([
   'cat-file',
   'merge-base',
   'remote', // shape-checked to list/get-url only; needed by resolveCanonicalRemote
+  // read-tier verbs the AgentWorktreeReaper needs against the source tree to
+  // decide whether a worktree is reclaimable. Both are pure reads (no mutation
+  // possible): `status --porcelain` for cleanliness, `cherry` for merged-detection.
+  'status',
+  'cherry',
 ]);
 
 // ── Env denylist ────────────────────────────────────────────────────
@@ -859,7 +865,7 @@ function isSourceTreeWorktreeManagerInvocation(verb: string, verbArgs: readonly 
     case 'config':
       return isReadOnlyConfigInvocation(verbArgs) || isWorktreeIdentityConfigWrite(verbArgs);
     case 'worktree':
-      return isWorktreeManagerMutation(verbArgs);
+      return isAllowedWorktreeManagerSubcommand(verbArgs);
     default:
       return false;
   }
@@ -870,9 +876,29 @@ function isWorktreeIdentityConfigWrite(verbArgs: readonly string[]): boolean {
   return verbArgs[0] === 'user.name' || verbArgs[0] === 'user.email';
 }
 
-function isWorktreeManagerMutation(verbArgs: readonly string[]): boolean {
+/**
+ * Worktree subcommands the worktree-manager / AgentWorktreeReaper may run against
+ * the instar source tree:
+ *  - `add` / `prune` — the `instar worktree create` lifecycle (unchanged).
+ *  - `list`           — pure read; the reaper enumerates worktrees to evaluate.
+ *  - `remove`         — the reaper reclaims a merged+clean+idle worktree, but ONLY
+ *                       in its SAFE form. `git worktree remove` without `--force`
+ *                       refuses to delete a worktree with uncommitted changes or a
+ *                       lock, so it can never destroy in-flight work. `--force`/`-f`
+ *                       is explicitly denied here — that is the one form that could.
+ */
+function isAllowedWorktreeManagerSubcommand(verbArgs: readonly string[]): boolean {
   const subcommand = verbArgs.find((arg) => !arg.startsWith('-'));
-  return subcommand === 'add' || subcommand === 'prune';
+  if (subcommand === 'add' || subcommand === 'prune' || subcommand === 'list') return true;
+  if (subcommand === 'remove') {
+    // Only the non-forced form. --force can delete a dirty worktree (data loss),
+    // so it must still trip the source-tree guard. Deny ANY force-ish token shape
+    // (`--force`, `--force=1`, `-f`, `-fxyz`) rather than relying on git's own
+    // parser to reject lookalikes — the guard stays self-sufficient even if git's
+    // argument parsing changes. `worktree remove` has no other `-f`-prefixed flag.
+    return !verbArgs.some((arg) => /^--force(=|$)/.test(arg) || /^-f/.test(arg));
+  }
+  return false;
 }
 
 function runSourceTreeChecks(

--- a/src/monitoring/agentWorktreeGit.ts
+++ b/src/monitoring/agentWorktreeGit.ts
@@ -17,7 +17,18 @@ import type { AgentWorktreeReaperDeps, WorktreeInfo } from './AgentWorktreeReape
 export type ReadGit = (args: string[], cwd: string) => string;
 
 const defaultReadGit: ReadGit = (args, cwd) =>
-  SafeGitExecutor.readSync(args, { cwd, encoding: 'utf-8', timeout: 30_000, operation: 'src/monitoring/agentWorktreeGit.ts' });
+  SafeGitExecutor.readSync(args, {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    operation: 'src/monitoring/agentWorktreeGit.ts',
+    // The agent home IS a checkout of the instar source tree, so every read the
+    // reaper makes (worktree list, status, cherry, rev-parse) trips the
+    // SourceTreeGuard without these. readSync still rejects any destructive shape,
+    // so the flags only widen the SOURCE-TREE bypass for genuine reads.
+    sourceTreeReadOk: true,
+    sourceTreeWorktreeManagerOk: true,
+  });
 
 /**
  * Resolve the canonical default branch ref that exists locally, preferring the
@@ -165,9 +176,14 @@ export function makeAgentWorktreeReaperDeps(opts: {
     },
 
     removeWorktree: (p: string): void => {
+      // Deliberately NOT --force: the non-forced form refuses to remove a worktree
+      // with uncommitted changes or a lock, so it can never destroy in-flight work.
+      // The SourceTreeGuard mirrors this — it allows `worktree remove` against the
+      // source tree only without --force (see isAllowedWorktreeManagerSubcommand).
       SafeGitExecutor.execSync(['-C', repo, 'worktree', 'remove', p], {
         timeout: 60_000,
         operation: 'src/monitoring/agentWorktreeGit.ts:removeWorktree',
+        sourceTreeWorktreeManagerOk: true,
       });
     },
 

--- a/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
+++ b/tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts
@@ -125,6 +125,9 @@ describe('SafeGitExecutor.sourceTreeReadOk', () => {
     expect(SOURCE_TREE_READ_TIER_VERBS.has('rm')).toBe(false);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('branch')).toBe(false);
     expect(SOURCE_TREE_READ_TIER_VERBS.has('tag')).toBe(false);
+    // Read-tier verbs the AgentWorktreeReaper needs (pure reads, no mutation):
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('status')).toBe(true);
+    expect(SOURCE_TREE_READ_TIER_VERBS.has('cherry')).toBe(true);
     // Bounded — adding to this set requires a spec edit + side-effects review.
     expect(SOURCE_TREE_READ_TIER_VERBS.size).toBeLessThanOrEqual(10);
   });
@@ -166,6 +169,90 @@ describe('SafeGitExecutor.sourceTreeReadOk', () => {
     expect(() => SafeGitExecutor.run(
       ['add', '-A'],
       { cwd: srcTree, operation: 't:add-still-blocked', sourceTreeWorktreeManagerOk: true },
+    )).toThrow(SourceTreeGuardError);
+  });
+
+  // ── AgentWorktreeReaper source-tree read/remove bypass ──────────────
+  // The reaper runs against the agent home (which IS a source tree): it needs
+  // `status --porcelain` (cleanliness), `cherry` (merged-detection), `worktree
+  // list` (enumeration), and `worktree remove` (reclaim, non-forced only).
+
+  it('status --porcelain on a source tree: blocked by default, allowed with sourceTreeReadOk', () => {
+    expect(() => SafeGitExecutor.run(
+      ['status', '--porcelain'],
+      { cwd: srcTree, operation: 't:status-default' },
+    )).toThrow(SourceTreeGuardError);
+    expect(() => SafeGitExecutor.run(
+      ['status', '--porcelain'],
+      { cwd: srcTree, operation: 't:status-allowed', sourceTreeReadOk: true },
+    )).not.toThrow();
+  });
+
+  it('cherry on a source tree: blocked by default, allowed with sourceTreeReadOk', () => {
+    expect(() => SafeGitExecutor.run(
+      ['cherry', 'main', 'HEAD'],
+      { cwd: srcTree, operation: 't:cherry-default' },
+    )).toThrow(SourceTreeGuardError);
+    expect(() => SafeGitExecutor.run(
+      ['cherry', 'main', 'HEAD'],
+      { cwd: srcTree, operation: 't:cherry-allowed', sourceTreeReadOk: true },
+    )).not.toThrow();
+  });
+
+  it('worktree list on a source tree: blocked by default, allowed with sourceTreeWorktreeManagerOk', () => {
+    expect(() => SafeGitExecutor.run(
+      ['worktree', 'list', '--porcelain'],
+      { cwd: srcTree, operation: 't:wt-list-default' },
+    )).toThrow(SourceTreeGuardError);
+    expect(() => SafeGitExecutor.run(
+      ['worktree', 'list', '--porcelain'],
+      { cwd: srcTree, operation: 't:wt-list-allowed', sourceTreeWorktreeManagerOk: true },
+    )).not.toThrow();
+  });
+
+  it('worktree remove (non-forced) on a source tree is allowed with the flag and actually removes', () => {
+    const wtPath = fs.mkdtempSync(path.join(os.tmpdir(), 'sgx-wt-')) + '-checkout';
+    // add (manager op — needs the flag) then remove (reaper op — needs the flag)
+    SafeGitExecutor.run(
+      ['worktree', 'add', '--detach', wtPath, 'HEAD'],
+      { cwd: srcTree, operation: 't:wt-add', sourceTreeWorktreeManagerOk: true },
+    );
+    expect(fs.existsSync(wtPath)).toBe(true);
+    expect(() => SafeGitExecutor.run(
+      ['worktree', 'remove', wtPath],
+      { cwd: srcTree, operation: 't:wt-remove-allowed', sourceTreeWorktreeManagerOk: true },
+    )).not.toThrow();
+    expect(fs.existsSync(wtPath)).toBe(false);
+  });
+
+  it('worktree remove --force is STILL blocked even with the flag (could delete a dirty worktree)', () => {
+    // The guard fires before git runs, so a non-existent path still proves the block.
+    expect(() => SafeGitExecutor.run(
+      ['worktree', 'remove', '--force', '/tmp/does-not-matter'],
+      { cwd: srcTree, operation: 't:wt-remove-force', sourceTreeWorktreeManagerOk: true },
+    )).toThrow(SourceTreeGuardError);
+    expect(() => SafeGitExecutor.run(
+      ['worktree', 'remove', '-f', '/tmp/does-not-matter'],
+      { cwd: srcTree, operation: 't:wt-remove-force-short', sourceTreeWorktreeManagerOk: true },
+    )).toThrow(SourceTreeGuardError);
+    // Self-sufficient denial — force LOOKALIKES are blocked too, not left to git's
+    // parser: `--force=1`, `-fxyz`, and `--force` before the subcommand.
+    for (const variant of [
+      ['worktree', 'remove', '--force=1', '/tmp/x'],
+      ['worktree', 'remove', '-fq', '/tmp/x'],
+      ['worktree', '--force', 'remove', '/tmp/x'],
+    ]) {
+      expect(() => SafeGitExecutor.run(
+        variant,
+        { cwd: srcTree, operation: 't:wt-remove-force-lookalike', sourceTreeWorktreeManagerOk: true },
+      )).toThrow(SourceTreeGuardError);
+    }
+  });
+
+  it('sourceTreeReadOk does NOT enable worktree remove (read flag ≠ mutation authority)', () => {
+    expect(() => SafeGitExecutor.run(
+      ['worktree', 'remove', '/tmp/whatever'],
+      { cwd: srcTree, operation: 't:wt-remove-readflag', sourceTreeReadOk: true },
     )).toThrow(SourceTreeGuardError);
   });
 });

--- a/tests/unit/agent-worktree-reaper.test.ts
+++ b/tests/unit/agent-worktree-reaper.test.ts
@@ -17,6 +17,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { SafeGitExecutor } from '../../src/core/SafeGitExecutor.js';
 
 const NOW = 1_000_000_000_000;
 
@@ -177,5 +178,94 @@ describe('resolveBaseRef', () => {
   it('returns null when no base ref resolves', () => {
     const git: ReadGit = () => { throw new Error('no'); };
     expect(resolveBaseRef(git, '/repo')).toBeNull();
+  });
+});
+
+/**
+ * Integration: the REAL deps (real SafeGitExecutor, real git) against a repo
+ * promoted to an instar source tree — the scenario the fake-git tests above
+ * never exercised, which is exactly why the SourceTreeGuard blocked every reaper
+ * git call in production and it reported 0 reclaimable. This is the regression
+ * guard for that bug: if the guard ever stops permitting the reaper's reads /
+ * non-forced remove against the source tree, these fail.
+ */
+describe('makeAgentWorktreeReaperDeps — real git against an instar source tree', () => {
+  let repo: string;
+  let worktreesDir: string;
+
+  function g(cwd: string, args: string[]) {
+    return SafeGitExecutor.run(args, { cwd, operation: 'tests/unit/agent-worktree-reaper.test.ts:setup' });
+  }
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'awr-repo-'));
+    g(repo, ['init', '-q', '-b', 'main']);
+    g(repo, ['config', 'user.email', 't@t.l']);
+    g(repo, ['config', 'user.name', 'T']);
+    g(repo, ['config', 'commit.gpgsign', 'false']);
+    fs.writeFileSync(path.join(repo, 'README.md'), '#');
+    g(repo, ['add', '-A']);
+    g(repo, ['commit', '-qm', 'init']);
+
+    // Create the worktrees BEFORE promotion (so the `worktree add` itself is not
+    // yet guarded). worktreesDir bounds which worktrees the reaper considers.
+    worktreesDir = path.join(repo, '.worktrees');
+    fs.mkdirSync(worktreesDir);
+    // merged + clean → reclaimable
+    g(repo, ['worktree', 'add', '-q', path.join(worktreesDir, 'merged'), '-b', 'feat-merged', 'HEAD']);
+    // unmerged: a real new commit not in main
+    g(repo, ['worktree', 'add', '-q', path.join(worktreesDir, 'unmerged'), '-b', 'feat-unmerged', 'HEAD']);
+    fs.writeFileSync(path.join(worktreesDir, 'unmerged', 'new.txt'), 'x');
+    g(path.join(worktreesDir, 'unmerged'), ['add', '-A']);
+    g(path.join(worktreesDir, 'unmerged'), ['commit', '-qm', 'ahead']);
+    // dirty: merged branch but uncommitted change
+    g(repo, ['worktree', 'add', '-q', path.join(worktreesDir, 'dirty'), '-b', 'feat-dirty', 'HEAD']);
+    fs.writeFileSync(path.join(worktreesDir, 'dirty', 'wip.txt'), 'uncommitted');
+
+    // Promote repo to an instar source tree — now every reaper git call must go
+    // through the source-tree bypass or it throws.
+    g(repo, ['remote', 'add', 'origin', 'https://github.com/dawn/instar.git']);
+  });
+
+  afterEach(() => {
+    try {
+      const cfgPath = path.join(repo, '.git', 'config');
+      const cfg = fs.readFileSync(cfgPath, 'utf-8').replace(/\[remote "origin"\][\s\S]*?(?=\n\[|$)/g, '');
+      fs.writeFileSync(cfgPath, cfg);
+    } catch { /* tolerate */ }
+    SafeFsExecutor.safeRmSync(repo, { recursive: true, force: true, operation: 'tests/unit/agent-worktree-reaper.test.ts:afterEach' });
+  });
+
+  it('listWorktrees + isClean + isMerged all work against the source tree (no guard error)', () => {
+    const deps = makeAgentWorktreeReaperDeps({ instarRepo: repo, worktreesDir });
+    const list = deps.listWorktrees();
+    // main checkout excluded by `within`; only the three under .worktrees/
+    const byName = Object.fromEntries(list.map((w) => [path.basename(w.path), w]));
+    expect(Object.keys(byName).sort()).toEqual(['dirty', 'merged', 'unmerged']);
+
+    expect(deps.isClean(byName.merged.path)).toBe(true);
+    expect(deps.isClean(byName.dirty.path)).toBe(false);
+
+    expect(deps.isMerged(byName.merged)).toBe(true);
+    expect(deps.isMerged(byName.unmerged)).toBe(false);
+  });
+
+  it('removeWorktree actually reclaims a merged+clean worktree through the guard', () => {
+    const deps = makeAgentWorktreeReaperDeps({ instarRepo: repo, worktreesDir });
+    const mergedPath = path.join(worktreesDir, 'merged');
+    expect(fs.existsSync(mergedPath)).toBe(true);
+    expect(() => deps.removeWorktree(mergedPath)).not.toThrow();
+    expect(fs.existsSync(mergedPath)).toBe(false);
+  });
+
+  it('AgentWorktreeReaper end-to-end with real deps: reaps merged+clean, keeps dirty + unmerged', () => {
+    const deps = makeAgentWorktreeReaperDeps({ instarRepo: repo, worktreesDir });
+    const reaper = new AgentWorktreeReaper(deps, { enabled: true, dryRun: true });
+    const verdicts = Object.fromEntries(
+      deps.listWorktrees().map((w) => [path.basename(w.path), reaper.evaluate(w).verdict]),
+    );
+    expect(verdicts.merged).toBe('reap-eligible');
+    expect(verdicts.dirty).not.toBe('reap-eligible');
+    expect(verdicts.unmerged).not.toBe('reap-eligible');
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,57 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**The stale-worktree cleanup robot can finally run.** The AgentWorktreeReaper
+(shipped recently, off by default) finds CLI worktrees that are completely safe to
+reclaim — their work is already merged into main, they have no uncommitted changes,
+and nothing is using them — and removes the checkout to free disk and reduce macOS
+indexing load. But it never worked in production: it lives inside the instar server,
+whose working directory is itself a checkout of the instar source tree, so the
+SourceTreeGuard (the safety wall that blocks risky git operations against instar's
+own code) blocked every git call the reaper made. It silently reported "0 to clean
+up" no matter what.
+
+Two fixes: (1) the merged-detection command (`git cherry`) wasn't even recognized as
+a read-only command, so it failed instantly and the reaper treated every worktree as
+"not merged → keep" — that's the real reason it always said zero; (2) the
+source-tree safety wall now recognizes exactly the four operations the reaper needs
+— list worktrees, check-clean, check-merged, and remove — and nothing more. The one
+operation that deletes a worktree is allowed only in its safe form, which refuses to
+touch a worktree with uncommitted changes; the forced variant that could delete
+unsaved work stays blocked.
+
+## What to Tell Your User
+
+Nothing to configure. The worktree-cleanup feature stays off by default. If you turn
+it on, it can now actually find and reclaim the worktrees that are safe to remove,
+instead of always reporting zero. It can never delete a worktree that has unsaved
+changes or that something is currently using — those are always kept.
+
+## Summary of New Capabilities
+
+- The AgentWorktreeReaper's git calls (list, status, cherry, non-forced remove) now
+  pass the SourceTreeGuard against the agent's own instar checkout, so it reports a
+  real reclaimable count and can reclaim when enabled.
+- The merged-detection command is recognized as read-only, fixing the silent
+  always-zero behavior.
+- The forced delete variant remains blocked against the source tree — the reaper can
+  never destroy a dirty or in-use worktree.
+
+## Evidence
+
+- `tests/unit/SafeGitExecutor-sourceTreeReadOk.test.ts` — new cases: status / cherry
+  / worktree-list blocked-by-default and allowed-with-flag; non-forced worktree
+  remove actually removes; `worktree remove --force` and `-f` STILL blocked even
+  with the flag; the read flag does not grant remove authority.
+- `tests/unit/agent-worktree-reaper.test.ts` — new real-git integration block: the
+  real reaper deps against a repo promoted to an instar source tree, with real
+  merged / dirty / unmerged worktrees — list, isClean, isMerged, and removeWorktree
+  all work through the guard; end-to-end the reaper reaps the merged+clean worktree
+  and keeps the dirty and unmerged ones. This is the test the original fake-git suite
+  lacked, which is why the bug shipped.
+- Live verification: `GET /worktrees/agent-reaper` reports a non-zero reclaimable
+  count on echo instead of 0.
+- Side-effects: `upgrades/side-effects/source-tree-guard-reaper-readtier.md`.

--- a/upgrades/side-effects/source-tree-guard-reaper-readtier.md
+++ b/upgrades/side-effects/source-tree-guard-reaper-readtier.md
@@ -1,0 +1,132 @@
+# Side-Effects Review — SourceTreeGuard read-tier + worktree-remove for the AgentWorktreeReaper
+
+**Version / slug:** `source-tree-guard-reaper-readtier`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required (single-author safety-guard fix; review is exhaustive below)`
+
+## Summary of the change
+
+The AgentWorktreeReaper (v1.3.133) runs inside the instar server, whose working
+directory IS a checkout of the instar source tree. Every git call it makes was
+blocked by the SourceTreeGuard, so it reported 0 reclaimable in production. This
+change makes three precise, shape-checked widenings in `src/core/SafeGitExecutor.ts`
+— add `cherry` to `READONLY_GIT_VERBS`; add `status` + `cherry` to
+`SOURCE_TREE_READ_TIER_VERBS`; extend the worktree-manager source-tree allowlist
+(`isAllowedWorktreeManagerSubcommand`) to permit `worktree list` and non-forced
+`worktree remove` alongside `add`/`prune` — and passes the corresponding bypass
+flags from the reaper's git wrapper (`src/monitoring/agentWorktreeGit.ts`). It
+interacts with one decision point: the SourceTreeGuard source-tree bypass.
+
+## Decision-point inventory
+
+- `SafeGitExecutor.isSourceTreeCheckBypassed` (via `SOURCE_TREE_READ_TIER_VERBS`) — modify — add two pure-read verbs (`status`, `cherry`) to the read-tier allowlist.
+- `SafeGitExecutor.isAllowedWorktreeManagerSubcommand` (renamed from `isWorktreeManagerMutation`) — modify — add `list` + non-forced `remove` to the worktree-manager allowlist; explicitly deny `--force`/`-f`.
+- `SafeGitExecutor.readSync` verb classification (via `READONLY_GIT_VERBS`) — modify — recognize `cherry` as read-only (root cause of the silent failure).
+- `agentWorktreeGit.ts` `defaultReadGit` / `removeWorktree` — modify — pass the bypass flags.
+
+---
+
+## 1. Over-block
+
+After the change the guard is slightly *more* permissive, not less, so over-block
+risk is unchanged for everyone except the reaper. The one thing that could be
+called "over-block" is intentional: `worktree remove --force` against the source
+tree is still rejected even with `sourceTreeWorktreeManagerOk`. That is by design —
+the forced form is the only one that can delete a dirty worktree, and the reaper
+never needs it. No legitimate caller is newly rejected.
+
+---
+
+## 2. Under-block
+
+The relevant question for a guard-*widening* is "does this newly ALLOW something
+dangerous?" The widenings are: two pure reads (`status`, `cherry` — cannot mutate)
+and `worktree remove` without `--force` (which git itself refuses to run against a
+dirty/locked worktree). The residual under-block surface: a caller holding
+`sourceTreeWorktreeManagerOk` could now run `worktree remove` (non-forced) against
+the source tree. That flag is opt-in per call and currently set only by
+`instar worktree create` and this reaper; the non-forced form is self-protecting
+(refuses dirty/locked), so even a misuse cannot delete uncommitted work. `--force`
+stays blocked, which closes the only data-loss path.
+
+---
+
+## 3. Level-of-abstraction fit
+
+Correct layer. These are pure reads plus one narrowly-shaped, self-protecting
+mutation, expressed as additions to existing closed allowlists (the established
+pattern for `fetch`/`rev-parse`/`add`/`prune`). The reaper continues to USE the
+`SafeGitExecutor` primitive rather than re-implementing git access, and the
+merged/clean/in-use reasoning stays in the reaper classifier — this change only
+unblocks the reads/remove it already wanted to make.
+
+---
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — this change has no block/allow surface over messages or user-facing
+  actions. It widens an internal git safety allowlist for one internal consumer.
+
+The SourceTreeGuard does hold blocking authority, but its logic here is a closed,
+shape-checked allowlist (not brittle heuristic), and the change makes it recognize
+two harmless reads and one self-protecting mutation. No new blocking authority is
+introduced; the reaper itself remains signal-only (dark + dry-run by default).
+
+---
+
+## 5. Interactions
+
+- **Shadowing:** none. The bypass check runs in the same place it always has
+  (`isSourceTreeCheckBypassed` inside `readSync`/`execSync`); we add entries to its
+  allowlists, we don't reorder checks. `readSync` still rejects destructive shapes
+  before the source-tree check, so the read-path widening cannot enable a mutation.
+- **Double-fire:** none. The reaper is the only new consumer; the immediate manual
+  reclaim used direct shell `git` (not via SafeGitExecutor) and is unaffected.
+- **Races:** the reaper's `worktree remove` and a concurrent session inside the same
+  worktree — covered by the reaper's existing not-in-use gate (lock file + live
+  process cwd) AND by git's own non-forced refusal if the worktree is locked. Two
+  layers.
+- **Feedback loops:** none.
+
+---
+
+## 6. External surfaces
+
+- **Other agents on the same machine:** the guard widening is per-call opt-in via
+  flags only this reaper and `instar worktree create` set, so other code paths are
+  unchanged. The reaper ships dark + dry-run, so no agent's worktrees are touched
+  until explicitly enabled.
+- **Install base:** pure source change, no config/migration/agent-installed files —
+  every agent picks it up on the normal update; behavior is identical until the
+  reaper is enabled.
+- **External systems:** none.
+- **Persistent state:** none added. When enabled, the reaper removes worktree
+  *checkouts* (disk) but never branches/commits — the work is preserved in the
+  branch ref and in main.
+- **Timing:** none we don't control.
+
+---
+
+## 7. Rollback cost
+
+- **Hot-fix release:** revert the one commit, ship as the next patch. The reaper
+  reverts to reporting 0 (blocked); no functional regression elsewhere.
+- **Data migration:** none — no persistent state introduced.
+- **Agent state repair:** none — no agent needs notification or reset.
+- **User visibility:** none — the reaper is dark by default, so no user sees a
+  change during a rollback window.
+
+---
+
+## Conclusion
+
+This review confirmed the change is a tightly-scoped guard widening: two pure reads
+and one self-protecting mutation, with the only data-loss path (`worktree remove
+--force`) explicitly kept blocked. The review reinforced the decision to deny
+`--force` in the allowlist (not just rely on the reaper never passing it) and to
+add a real-git integration test against a promoted source tree — the test the
+original fake-git suite lacked, which is why the reaper shipped non-functional.
+Clear to ship; verify live via `GET /worktrees/agent-reaper` reporting non-zero.


### PR DESCRIPTION
## What & why

The **AgentWorktreeReaper** (shipped v1.3.133, #589) runs inside the instar server, whose working directory **is itself a checkout of the instar source tree**. So the **SourceTreeGuard** blocked every git call it made — it reported **0 reclaimable in production regardless of reality**.

Two stacked root causes:
1. **`git cherry` was an *unknown* verb to `readSync`** (not in `READONLY_GIT_VERBS`) → readSync rejected it as "destructive verb" before the source-tree check even ran. The reaper's `isBranchMerged` caught the throw and returned "unmerged" (KEEP) → **nothing was ever detected as merged** → always 0.
2. The source-tree bypass allowlists were too narrow: `SOURCE_TREE_READ_TIER_VERBS` lacked `status`/`cherry`; the worktree-manager allowlist permitted only `add`/`prune`, not `list`/`remove`. And the reaper's git wrapper passed no bypass flags.

## The fix (tightly scoped, shape-checked)

- Add `cherry` to `READONLY_GIT_VERBS` (genuine read — the actual root cause of the silent 0).
- Add `status` + `cherry` to `SOURCE_TREE_READ_TIER_VERBS` (pure reads, gated by `sourceTreeReadOk`).
- Extend the worktree-manager allowlist (`isAllowedWorktreeManagerSubcommand`, gated by `sourceTreeWorktreeManagerOk`): permit `list` + **non-forced** `remove`. Any force-ish token (`--force`, `--force=1`, `-f`, `-fxyz`) is denied **self-sufficiently** — the guard no longer relies on git's own parser to reject lookalikes.
- The reaper's git wrapper passes the bypass flags.

`git worktree remove` without `--force` refuses to delete a dirty/locked worktree, so the reaper can never destroy in-flight work; `--force` stays blocked. The reaper still only removes merged+clean+not-in-use worktrees, ships dark + dry-run, and never deletes branches.

## Tests (3-tier)

- **Unit** (`SafeGitExecutor-sourceTreeReadOk.test.ts`): status/cherry/worktree-list blocked-by-default + allowed-with-flag; non-forced remove actually removes; `--force`/`-f`/`--force=1`/`-fxyz`/flag-before-subcommand STILL blocked even with the flag; read flag ≠ remove authority; closed-set membership.
- **Integration** (`agent-worktree-reaper.test.ts`): the **real** `makeAgentWorktreeReaperDeps` (real `SafeGitExecutor`, real git) against a repo promoted to an instar source tree with real merged/dirty/unmerged worktrees — list/isClean/isMerged/removeWorktree all work through the guard; end-to-end the reaper reaps merged+clean and keeps dirty+unmerged. **This is the test the original fake-git suite lacked — which is exactly why the bug shipped.**
- **Live**: after deploy, `GET /worktrees/agent-reaper` reports non-zero instead of 0.

## Process

- **Spec**: `docs/specs/source-tree-guard-reaper-readtier.md` (converged + `approved: true`) + ELI16 sibling.
- **Side-effects**: `upgrades/side-effects/source-tree-guard-reaper-readtier.md`.
- **Adversarial second-pass review: CONCUR — safe to ship** (independently verified `--force` denial holds at two layers, `cherry`/`status` cannot mutate, the two bypass flags are orthogonal, no branch deletion). The reviewer's one hardening nit (force-lookalikes) is **applied** in this PR.
- ⚠️ **Self-approved under the delegated deploy mandate.** Justin authorized this exact change in Telegram topic 16782 (2026-05-31): "yes, both". It is a **safety-guard change** — flagged here per cross-agent discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)