### PR TITLE
test(conformance): codex adapter observability readers — close the audit coverage gap

### DIFF
--- a/tests/integration/conformance/observabilityReaders.conformance.test.ts
+++ b/tests/integration/conformance/observabilityReaders.conformance.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Conformance — observability READ primitives across adapters.
+ *
+ * Closes the parity-coverage gap found in the 2026-05-31 codex audit: the
+ * openai-codex adapter ships conversationLogReader / conversationLogTailer /
+ * sessionResumeIndex implementations, but NO test exercised them — so a codex
+ * adapter that silently dropped one of these (declared the capability but wired
+ * no impl, or drifted the method shape) would pass CI. This runs the SAME
+ * contract-shape suite against BOTH the anthropic and codex adapters, mirroring
+ * oneShotCompletion.conformance.test.ts (which the codex adapter was also absent
+ * from). Behavior-against-real-logs stays per-adapter + realApi-gated; this is
+ * the contract-shape floor that must hold for every adapter that declares the
+ * capability.
+ */
+import { describe, it, expect } from 'vitest';
+import { createAnthropicHeadlessAdapter } from '../../../src/providers/adapters/anthropic-headless/index.js';
+import { createOpenAiCodexAdapter } from '../../../src/providers/adapters/openai-codex/index.js';
+import { CapabilityFlag } from '../../../src/providers/capabilities.js';
+
+interface AdapterUnderTest {
+  id: string;
+  factory: () => {
+    primitive(cap: CapabilityFlag): unknown;
+    capabilities: ReadonlySet<CapabilityFlag>;
+  };
+}
+
+const ADAPTERS: AdapterUnderTest[] = [
+  { id: 'anthropic-headless', factory: () => createAnthropicHeadlessAdapter() },
+  { id: 'openai-codex', factory: () => createOpenAiCodexAdapter() },
+];
+
+// Each observability READ primitive + the methods its interface requires.
+const PRIMITIVES: ReadonlyArray<{ cap: CapabilityFlag; methods: readonly string[] }> = [
+  { cap: CapabilityFlag.ConversationLogReader, methods: ['read', 'readStream'] },
+  { cap: CapabilityFlag.ConversationLogTailer, methods: ['tail'] },
+  { cap: CapabilityFlag.SessionResumeIndex, methods: ['findById', 'findRecent', 'listByProject', 'resume'] },
+];
+
+for (const adapter of ADAPTERS) {
+  describe(`Observability-reader conformance — ${adapter.id}`, () => {
+    for (const p of PRIMITIVES) {
+      describe(p.cap, () => {
+        it('declares the capability flag', () => {
+          expect(adapter.factory().capabilities.has(p.cap)).toBe(true);
+        });
+
+        it('returns a primitive carrying the matching capability marker', () => {
+          const prim = adapter.factory().primitive(p.cap) as { capability?: string } | undefined;
+          expect(prim, `${adapter.id} declares ${p.cap} but primitive(${p.cap}) returned nothing`).toBeDefined();
+          expect(prim!.capability).toBe(p.cap);
+        });
+
+        it('exposes its contract methods as callables', () => {
+          const prim = adapter.factory().primitive(p.cap) as Record<string, unknown>;
+          for (const m of p.methods) {
+            expect(typeof prim[m], `${adapter.id} ${p.cap}.${m} must be a function`).toBe('function');
+          }
+        });
+      });
+    }
+  });
+}

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,39 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13435; test-only parity-coverage addition from the codex audit)
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — codex adapter observability readers now have conformance coverage
+
+The provider-adapter conformance harness only exercised the OneShotCompletion primitive, and
+only against the two Anthropic adapters. The codex adapter shipped conversation-log readers and
+a session-resume index, but no test exercised them — so a codex adapter that declared one of
+those capabilities while wiring no implementation (or drifting a method shape) would have passed
+CI. This adds a contract-shape conformance suite that runs the SAME assertions against BOTH the
+Anthropic and codex adapters for all three observability read primitives.
+
+## Summary of New Capabilities
+
+- New `tests/integration/conformance/observabilityReaders.conformance.test.ts` asserts, for the
+  `anthropic-headless` and `openai-codex` adapters: each declares the ConversationLogReader /
+  ConversationLogTailer / SessionResumeIndex capability, returns a primitive carrying the
+  matching capability marker, and exposes the interface methods as callables (18 cases).
+- Test-only; no runtime/src change. Confirms the codex adapter wires all three readers correctly
+  and guards against future drift.
+
+## What to Tell Your User
+
+Nothing user-facing — this is internal test coverage that makes the codex (and future
+non-Claude) adapters safer to evolve.
+
+## Evidence
+
+- `npx vitest run tests/integration/conformance/observabilityReaders.conformance.test.ts` → 18 passed.
+- `tsc --noEmit` clean; `npm run lint` clean.
+- Closes the parity-coverage gap logged in the framework-issue ledger
+  (dedupKey `codex-adapter-readers-no-conformance-coverage`).


### PR DESCRIPTION
## Why
From the 2026-05-31 codex parity audit (directive #1): the provider-adapter conformance harness only exercised `OneShotCompletion`, and only against the two **Anthropic** adapters. The `openai-codex` adapter ships `conversationLogReader` / `conversationLogTailer` / `sessionResumeIndex` implementations with **zero test coverage** — so a codex adapter that declared one of those capabilities while wiring no impl, or drifted a method shape, would have passed CI.

## What
A contract-shape conformance suite that runs the **same** assertions against **both** `anthropic-headless` and `openai-codex` for all three observability read primitives:
- declares the capability flag
- `primitive(cap)` returns an impl carrying the matching `capability` marker
- the interface methods (`read`/`readStream`, `tail`, `findById`/`findRecent`/`listByProject`/`resume`) are callables

18 cases, all green — confirms codex wires all three readers correctly and guards against future drift. **Test-only; no runtime/src change.**

## Evidence
- `npx vitest run tests/integration/conformance/observabilityReaders.conformance.test.ts` → 18 passed.
- `tsc --noEmit` + `npm run lint` clean.
- Closes the framework-issue-ledger finding `codex-adapter-readers-no-conformance-coverage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)