### PR TITLE
fix(multi-machine): share one monotonic machineAuth sequence across all channels (cascade bug #3)

### DIFF
--- a/docs/specs/machineauth-shared-sequence.eli16.md
+++ b/docs/specs/machineauth-shared-sequence.eli16.md
@@ -1,0 +1,52 @@
+# ELI16 — machineAuth shared monotonic sequence
+
+## What this is, in plain English
+
+When two of your machines talk to each other, every message is stamped with a
+running number (a "sequence number") that only ever goes up. The receiving
+machine remembers the highest number it has seen from the other machine, and
+throws away anything with a number that isn't higher — that's how it spots a
+sneaky attacker replaying an old captured message.
+
+The catch: a single machine doesn't have just one line of communication to the
+other — it has several (one for the "who's in charge" lease, one for the
+heartbeat, one for handing off a conversation, one for streaming the live tail,
+and so on). Each of those lines was keeping its OWN running number, and each
+started its counter from "the current clock time" at the moment it was set up.
+Because they're set up a few milliseconds apart during startup, they started at
+slightly different numbers and then drifted apart.
+
+But the receiver only tracks ONE highest-number-seen per machine, shared across
+all those lines. So the fast, chatty line (the heartbeat) quickly pushed that
+number way up, and then the quieter line (the lease) — whose own counter was
+sitting lower — looked like it was sending old, out-of-order messages. The
+receiver rejected every one of them as a replay. The result: the standby machine
+never received the "I'm in charge" announcement, so it refused to take over a
+conversation.
+
+## What we changed
+
+We gave the whole machine ONE shared running number that every outgoing line
+draws from. There's a single chokepoint that every signed message passes through,
+and we made that chokepoint hand out the next number from one shared counter.
+Now no matter which line sends a message, the numbers always go up in order, so
+the receiver never mistakes a legitimate message for a replay.
+
+We did it at that one shared chokepoint on purpose: it's impossible for any line
+of communication — even ones added in the future — to accidentally go back to
+having its own counter and re-break this. The clock-time seed is kept so that
+after a restart the number is still higher than anything sent before (time only
+moves forward).
+
+## Why it matters
+
+This was the third hidden bug in a chain that was stopping "move this conversation
+to the other machine" from working. With it fixed, the standby machine can finally
+receive the lease announcement, recognize who's in charge, and accept a handed-off
+conversation.
+
+## What you'd notice
+
+Nothing on a single machine. On two machines, the replay-rejections that were
+silently dropping the lease announcements stop, which is the next step toward the
+conversation hand-off completing end to end.

--- a/docs/specs/machineauth-shared-sequence.md
+++ b/docs/specs/machineauth-shared-sequence.md
@@ -1,0 +1,81 @@
+---
+title: machineAuth shared monotonic sequence (cross-transport replay fix)
+slug: machineauth-shared-sequence
+status: approved
+review-convergence: 2026-05-31T05:35:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate. Justin directed
+  building each multi-machine live-transfer cascade fix in-session on 2026-05-31
+  (topic 13481), explicitly correcting any "leave it for a later pass" framing as
+  a non-reason for an Instar agent. This is bug #3 of that cascade, found live
+  after #1/#2 shipped (v1.3.140). The full fix ships in THIS PR. Flagged per
+  cross-agent discipline.
+---
+
+# machineAuth shared monotonic sequence (cross-transport replay fix)
+
+## Problem
+
+Bug #3 of the multi-machine live-transfer cascade (after the lease-coordinator
+wiring + effectiveView fixes shipped as v1.3.140). The live two-machine test
+showed the laptop holds the lease and broadcasts it, but the standby's
+`leaseHolder` stayed null — so MeshRpc still rejected transfers as `not-router`.
+
+The mini's `security.jsonl` proved why: the lease broadcasts REACH the mini but
+`machineAuthMiddleware` rejects them — `replay_detected: "Sequence
+1780200440053 <= last seen 1780200440744 from <laptop>"`.
+
+Root cause: `NonceStore.validate` enforces a monotonic sequence PER SENDING
+MACHINE (one watermark per peer). But each machine-to-machine channel constructs
+its OWN sequence counter, each seeded from `Date.now()` at construction
+(`let leaseSeq = Date.now()`, `handoffSeq`, `markerSeq`, `liveTailWireSeq` in
+server.ts; `this.machineSequence` in MessageRouter; etc.). Because the transports
+are constructed at slightly different milliseconds during boot, their seeds
+differ; whichever sends first with the highest seed sets the receiver's watermark,
+and any channel with a lower seed (e.g. the lease broadcast, seeded earlier) is
+then rejected as an out-of-order replay forever. The lease broadcast never lands,
+so the standby never observes the holder.
+
+## Goal
+
+All of a machine's outbound machineAuth-signed requests share ONE process-global
+monotonic sequence, so the receiver's per-machine watermark is never violated by
+a different channel — eliminating the cross-transport replay collision.
+
+## Non-goals
+
+- No change to `NonceStore`'s replay model (per-machine monotonic sequence +
+  nonce uniqueness + 30s timestamp window stay exactly as documented).
+- No change to the on-the-wire signed-message format or headers.
+
+## Design
+
+Make `signRequest` (the single chokepoint EVERY machineAuth request flows through)
+draw its sequence from a process-global monotonic counter
+(`nextMachineAuthSequence()`), instead of the per-caller `sequence` argument. The
+argument is retained for signature compatibility but ignored. The counter is
+seeded from `Date.now()` so it stays monotonic across a process restart
+(wall-clock only advances, so the receiver's persisted watermark from a prior run
+is never above the fresh seed).
+
+Chosen at the chokepoint (not threaded through each caller) deliberately: it is
+impossible for any current OR future caller (lease, heartbeat, handoff,
+reply-marker, live-tail, MessageRouter relay, CLI) to bypass it — which matters
+because this cascade has repeatedly shown how easy it is to miss a caller.
+
+## Testing
+
+- `tests/unit/machine-auth.test.ts`: updated to the new contract (passed sequence
+  ignored → process-global monotonic). Adds a regression — two channels signing
+  via signRequest stay strictly monotonic (no collision) — and a direct NonceStore
+  stale-sequence-rejection test (receiver behavior preserved). 21/21 green.
+- `tests/integration/machine-routes.test.ts`: 23/23 green (no sequence regression).
+- Tier-3: re-run the live two-machine transfer after deploy; the mini must now
+  observe the lease (`leaseHolder` = laptop) and accept the forwarded session.
+
+## Migration parity
+
+Pure code in a shared function. No config/hook/route/CLAUDE.md change. Existing
+agents get it on the v-next update.

--- a/src/server/machineAuth.ts
+++ b/src/server/machineAuth.ts
@@ -157,20 +157,47 @@ export interface SignedHeaders {
 }
 
 /**
+ * Process-global monotonic sequence for ALL machineAuth-signed outbound requests.
+ *
+ * The receiver's NonceStore tracks ONE monotonic sequence PER SENDING MACHINE
+ * (src/core/NonceStore.ts) — so EVERY signed channel from this process (lease
+ * broadcast, machine heartbeat, handoff, reply-marker, live-tail, …) MUST draw
+ * from a single shared counter. They previously each used their own
+ * `Date.now()`-seeded counter; the fast-firing heartbeat pushed the receiver's
+ * per-machine watermark high while the slow lease counter stayed low, so every
+ * lease broadcast was rejected as an out-of-order replay and the standby never
+ * learned the holder (found live 2026-05-31:
+ * `Sequence 1780200440053 <= last seen 1780200440744`). Seeding from `Date.now()`
+ * keeps it monotonic across a process restart (wall-clock only advances), so the
+ * receiver's persisted watermark from a prior run is never above our fresh seed.
+ */
+let __machineAuthSequence = Date.now();
+/** The next process-global machineAuth sequence (strictly increasing). */
+export function nextMachineAuthSequence(): number {
+  __machineAuthSequence += 1;
+  return __machineAuthSequence;
+}
+
+/**
  * Sign an outgoing request with machine credentials.
  *
  * @param machineId - This machine's ID
  * @param privateKeyPem - Ed25519 private key in PEM format
  * @param body - The request body (will be JSON stringified for hashing)
- * @param sequence - The sequence number for this request
+ * @param _legacySequence - IGNORED. Retained for signature compatibility with
+ *   existing callers. The sequence is now drawn from the process-global
+ *   `nextMachineAuthSequence()` so every channel shares one monotonic counter
+ *   (see the note above — per-caller counters collided on the receiver's
+ *   per-machine watermark). New callers may omit it.
  * @returns Headers to include in the request
  */
 export function signRequest(
   machineId: string,
   privateKeyPem: string,
   body: unknown,
-  sequence: number,
+  _legacySequence?: number,
 ): SignedHeaders {
+  const sequence = nextMachineAuthSequence();
   const timestamp = Math.floor(Date.now() / 1000).toString();
   const nonce = crypto.randomBytes(16).toString('hex');
   const bodyHash = crypto.createHash('sha256')

--- a/tests/unit/machine-auth.test.ts
+++ b/tests/unit/machine-auth.test.ts
@@ -140,19 +140,23 @@ describe('machineAuthMiddleware', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.machineId).toBe(env.remoteId);
-    expect(res.body.sequence).toBe(0);
+    // signRequest now assigns a process-global monotonic sequence (the passed
+    // arg is ignored — per-caller counters were the 2026-05-31 cross-transport
+    // replay-collision bug), so it's a large positive number, not the passed 0.
+    expect(res.body.sequence).toBeGreaterThan(0);
   });
 
-  it('accepts sequential requests with incrementing sequence', async () => {
+  it('accepts sequential requests (monotonic shared sequence)', async () => {
     const body = { data: 'first' };
     const h1 = signRequest(env.remoteId, env.remoteSigning.privateKey, body, 0);
-    await request(app).post('/test').set(h1).send(body).expect(200);
+    const r1 = await request(app).post('/test').set(h1).send(body);
+    expect(r1.status).toBe(200);
 
     const body2 = { data: 'second' };
     const h2 = signRequest(env.remoteId, env.remoteSigning.privateKey, body2, 1);
-    const res = await request(app).post('/test').set(h2).send(body2);
-    expect(res.status).toBe(200);
-    expect(res.body.sequence).toBe(1);
+    const r2 = await request(app).post('/test').set(h2).send(body2);
+    expect(r2.status).toBe(200);
+    expect(r2.body.sequence).toBeGreaterThan(r1.body.sequence); // global counter increases
   });
 
   // ── Missing headers ────────────────────────────────────────────
@@ -209,16 +213,21 @@ describe('machineAuthMiddleware', () => {
     expect(res.body.error).toContain('Anti-replay');
   });
 
-  it('rejects request with stale sequence number', async () => {
-    const body1 = { data: 'first' };
-    const h1 = signRequest(env.remoteId, env.remoteSigning.privateKey, body1, 5);
-    await request(app).post('/test').set(h1).send(body1).expect(200);
+  it('NonceStore rejects a stale (out-of-order) sequence for a peer', () => {
+    // The receiver's stale-sequence rejection is still enforced (NonceStore is
+    // unchanged). Tested directly now that signRequest no longer lets a caller
+    // craft a lower sequence (it draws from a process-global monotonic counter).
+    expect(env.nonceStore.validate(Date.now(), 'n-hi', 100, 'peerX').valid).toBe(true);
+    expect(env.nonceStore.validate(Date.now(), 'n-lo', 50, 'peerX').valid).toBe(false);
+  });
 
-    // Sequence 3 < last seen 5 → rejected
-    const body2 = { data: 'second' };
-    const h2 = signRequest(env.remoteId, env.remoteSigning.privateKey, body2, 3);
-    const res = await request(app).post('/test').set(h2).send(body2);
-    expect(res.status).toBe(403);
+  it('signRequest keeps sequences monotonic across interleaved channels (regression: 2026-05-31 cross-transport replay)', () => {
+    // Two logical channels both signing via signRequest must NOT collide on the
+    // receiver's per-machine sequence watermark — they share ONE process-global
+    // counter, so the second is strictly greater regardless of the passed arg.
+    const lease = signRequest(env.remoteId, env.remoteSigning.privateKey, { ch: 'lease' }, 999);
+    const heartbeat = signRequest(env.remoteId, env.remoteSigning.privateKey, { ch: 'heartbeat' }, 1);
+    expect(Number(heartbeat['X-Sequence'])).toBeGreaterThan(Number(lease['X-Sequence']));
   });
 
   // ── Invalid signature ──────────────────────────────────────────
@@ -272,7 +281,9 @@ describe('signRequest', () => {
     expect(headers['X-Machine-Id']).toBe('m_test123');
     expect(headers['X-Timestamp']).toBeTruthy();
     expect(headers['X-Nonce']).toHaveLength(32); // 16 bytes hex
-    expect(headers['X-Sequence']).toBe('42');
+    // The passed sequence (42) is ignored; a process-global monotonic value is
+    // assigned instead, so just assert it's a positive integer string.
+    expect(Number(headers['X-Sequence'])).toBeGreaterThan(0);
     expect(headers['X-Signature']).toBeTruthy();
   });
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,44 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Multi-machine: fixes the next bug blocking cross-machine session transfer.**
+When two machines talk, each message carries an ever-increasing number so the
+receiver can reject replayed old messages. A machine has several lines of
+communication to its peer (the in-charge lease, the heartbeat, handoffs, the live
+tail), and each kept its own number seeded from the clock — so they drifted apart.
+The receiver only tracks one highest-number-seen per machine, so the fast
+heartbeat pushed that number high and the quieter lease line's messages then
+looked out-of-order and were dropped as replays. The standby machine therefore
+never received the lease announcement and refused to take over a conversation.
+This change makes every line on a machine share ONE ever-increasing number from a
+single chokepoint, so legitimate messages are never mistaken for replays. The
+receiver's replay protection (unique tokens + a 30-second freshness window + the
+per-machine number) is unchanged. Single-machine agents are unaffected.
+
+## What to Tell Your User
+
+If you run on one machine, nothing changes. If you run one agent across two
+machines, this fixes a hidden issue where the second machine was silently dropping
+the messages that tell it which machine is in charge — a step toward moving a
+conversation between machines working end to end. Nothing to configure.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Shared machine-auth sequence | Automatic. All of a machine's signed peer requests now share one monotonic sequence, so the lease/heartbeat/handoff/live-tail channels no longer collide on the receiver's per-machine replay watermark. No configuration. |
+
+## Evidence
+
+- `tests/unit/machine-auth.test.ts` (21) updated to the new chokepoint contract,
+  plus a regression: two channels signing via signRequest stay strictly monotonic
+  (no cross-transport collision), and a direct NonceStore stale-sequence-rejection
+  test (receiver behavior preserved).
+- `tests/integration/machine-routes.test.ts` (23) green — no sequence regression.
+- `tsc --noEmit` + repo lint clean.
+- Live evidence that motivated it: the standby's security log showed
+  "Sequence …053 <= last seen …744" rejecting every lease broadcast.
+- Side-effects: `upgrades/side-effects/machineauth-shared-sequence.md`.

--- a/upgrades/side-effects/machineauth-shared-sequence.md
+++ b/upgrades/side-effects/machineauth-shared-sequence.md
@@ -1,0 +1,60 @@
+# Side-Effects Review — machineAuth shared monotonic sequence
+
+**Version / slug:** `machineauth-shared-sequence`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`signRequest` (the single function every machineAuth-signed outbound request flows
+through) now assigns the X-Sequence from a process-global monotonic counter
+(`nextMachineAuthSequence()`, seeded from `Date.now()`) instead of the per-caller
+`sequence` argument (now ignored). Fixes the cross-transport replay collision: the
+receiver tracks one monotonic sequence per sending machine, but each channel had
+its own `Date.now()`-seeded counter, so a lower-seeded channel (the lease
+broadcast) was rejected as out-of-order forever.
+
+## Decision-point inventory
+
+1. **signRequest sequence source** → always `nextMachineAuthSequence()` (global,
+   monotonic), regardless of the passed arg.
+
+## 1. Over-block
+
+**What legitimate inputs does this reject?** None — it makes MORE requests succeed.
+Previously-rejected legitimate lease broadcasts now pass. The receiver's replay
+defenses are unchanged: nonce uniqueness + 30s timestamp window + per-machine
+monotonic sequence all still run. A genuine replay (reused nonce, or stale
+timestamp, or a sequence below the watermark) is still rejected exactly as before.
+
+## 2. Under-block
+
+**What does this still miss?** Nothing new. Anti-replay strength is unchanged; the
+fix only makes a single sender's many channels share one monotonic sequence
+(which is what the per-machine watermark always assumed). Cross-MACHINE replay is
+still caught (each machine has its own watermark on the receiver).
+
+## 3. Blast radius
+
+- `signRequest` is used by every machineAuth sender: lease broadcast, heartbeat,
+  handoff, reply-marker, live-tail, MessageRouter relay, and the `instar pair`/
+  handoff CLI. ALL now share the global counter — this is the intended fix (the
+  chokepoint guarantees no caller can bypass it).
+- The per-caller sequence counters in server.ts / MessageRouter become inert
+  (their value is ignored); left in place to minimize churn — harmless dead args.
+- Tests: `machine-auth.test.ts` (21) updated to the new contract + a regression
+  for the interleaved-channel monotonicity + a direct NonceStore stale-rejection
+  test. `machine-routes.test.ts` integration (23) green. tsc + lint clean.
+
+## 4. Rollback
+
+Pure code (no migration/config/schema). Rollback = revert the PR. The sequence
+reverts to per-caller, re-introducing the collision (so don't revert without
+re-introducing bug #3).
+
+## 5. Failure modes
+
+- Process restart → counter re-seeds from the new (higher) `Date.now()`, still
+  above any prior watermark. Monotonic across restarts by construction.
+- Concurrency → single-threaded JS; `nextMachineAuthSequence` increments atomically.


### PR DESCRIPTION
## What + why (cascade bug #3)

After v1.3.140 (the lease-coordinator wiring + effectiveView fixes), the live two-machine transfer STILL failed: the standby's `leaseHolder` stayed null. The mini's `security.jsonl` proved why — every lease broadcast was rejected by `machineAuthMiddleware`:

```
replay_detected: "Sequence 1780200440053 <= last seen 1780200440744 from <laptop>"
```

`NonceStore.validate` enforces a monotonic sequence **per sending machine** (one watermark per peer). But each machine-to-machine channel (lease, heartbeat, handoff, reply-marker, live-tail, MessageRouter relay) kept its **own** `Date.now()`-seeded counter. They drift; the fast heartbeat pushes the receiver's watermark high, and the lower-seeded lease counter is then rejected as out-of-order **forever**. The lease broadcast never lands → the standby never observes the holder → MeshRpc keeps rejecting transfers as `not-router`.

## The fix

`signRequest` — the single chokepoint EVERY machineAuth request flows through — now draws `X-Sequence` from a **process-global monotonic counter** (`nextMachineAuthSequence()`, `Date.now()`-seeded so it stays monotonic across restarts) instead of the per-caller arg (now ignored). Chosen at the chokepoint deliberately: no current OR future caller can bypass it and re-break this (the cascade has shown how easy it is to miss a caller).

No change to the receiver's replay model (nonce uniqueness + 30s timestamp window + per-machine monotonic sequence all unchanged) or the wire format.

## Tests

- `tests/unit/machine-auth.test.ts` (21) updated to the new contract + a **regression** (two channels signing via signRequest stay strictly monotonic — no collision) + a direct `NonceStore` stale-sequence-rejection test (receiver behavior preserved).
- `tests/integration/machine-routes.test.ts` (23) green — no sequence regression.
- `tsc --noEmit` + repo lint clean.
- **Tier-3 (post-merge):** re-run the live two-machine transfer; the mini must now observe the lease (`leaseHolder` = laptop) and accept the forwarded session.

## Spec / approval

Spec `docs/specs/machineauth-shared-sequence.md` — **self-approved under the delegated deploy mandate** (Justin directed building each cascade fix in-session, topic 13481). Flagged per cross-agent discipline. `upgrades/NEXT.md` included for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)