### PR TITLE
feat(agent-sleep): hard-sleep stop+wake mechanism (Stage B slice 2, dark + dry-run)

### DIFF
--- a/docs/specs/agent-hard-sleep-mechanism.eli16.md
+++ b/docs/specs/agent-hard-sleep-mechanism.eli16.md
@@ -1,0 +1,51 @@
+# ELI16 — Actually letting an idle agent sleep, and wake when you message it
+
+## What this is, in plain English
+
+The previous slice taught an idle agent how to DECIDE "is it safe for me to sleep
+right now?" — but it never actually slept; it just watched and logged. This slice
+builds the part that ACTS on that decision: when an agent has been idle long enough
+and it's safe, its heavy background server actually stops to save your machine's
+resources, and then it wakes back up the instant you send a message — like a laptop
+sleeping and waking.
+
+## How it works (the handshake)
+
+There are two always-running pieces: the heavy "server" (does the real work) and a
+tiny "lifeline" that just listens for your messages. A small "supervisor" babysits
+the server and normally restarts it if it ever goes down.
+
+- **Going to sleep:** when the decision says "safe to sleep," a little file gets
+  written (`sleep-requested.json`). The supervisor sees it, stops the server, and
+  drops a "I am intentionally asleep" marker. Critically, while that marker is set,
+  the supervisor does NOT treat the stopped server as a crash — it won't keep
+  restarting it. (That one change is the whole trick, and it's a no-op unless the
+  agent actually went to sleep.)
+- **Waking up:** you send a message. The lifeline (still listening) notices the
+  server is asleep, writes a `wake-requested.json` file, and holds your message in
+  its existing durable queue. The supervisor sees the wake file and starts the
+  server back up. Once it's healthy, your held message is delivered — nothing is
+  lost. You'd see a brief "waking up…" pause, like when the agent compacts its
+  memory.
+
+## Why it's safe to ship now
+
+It's **off by default**, and the file that triggers a sleep is only ever written
+when sleep is explicitly turned on. So on every normal agent, none of this does
+anything — the server stays up exactly like today. There's also a belt-and-braces
+safety: if some outside watchdog force-restarts the whole agent while it's asleep,
+the supervisor reads the "intentionally asleep" marker on startup and stays asleep
+instead of fighting it — so it can't get stuck flapping, and it can't get bricked.
+
+The risky existing behavior — "if the server crashes, restart it" — is completely
+unchanged except in the one case where the agent chose to sleep. The existing
+supervisor tests all still pass to prove that.
+
+## What you need to decide
+
+Nothing to flip today. This ships dark. The real decision — turning sleep ON — is
+the part worth doing carefully: we'd enable it on one test agent first, with you
+watching, and confirm it actually sleeps when idle and wakes cleanly when messaged,
+before it ever touches a real agent you use. A few refinements (making a due
+scheduled job wake the server, and showing "asleep" instead of "down" on the health
+page) come with that enablement; the dark mechanism is safe without them.

--- a/docs/specs/agent-hard-sleep-mechanism.md
+++ b/docs/specs/agent-hard-sleep-mechanism.md
@@ -1,0 +1,130 @@
+---
+title: Agent hard-sleep — the stop+wake mechanism (Stage B, slice 2)
+slug: agent-hard-sleep-mechanism
+status: approved
+review-convergence: 2026-05-31T04:30:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate. Justin directed building
+  Stage B now, in-session (topic 16782, 2026-05-31). This slice ships the stop+wake
+  MECHANISM but DARK + dry-run (monitoring.agentSleep.enabled defaults false; the live
+  requestSleep that writes the sleep-request flag only fires when enabled && !dryRun).
+  Because it can stop the serving process, the *enablement* — not this dark ship — is
+  the reviewed gate: turn it on first on a test agent with Justin watching, per the
+  spec's "ships OFF + a dry-run would-stop log first." Flagged in the PR per
+  cross-agent discipline. Builds on the merged slice-1 SleepController
+  (docs/specs/agent-hard-sleep-controller.md).
+---
+
+# Agent hard-sleep — the stop+wake mechanism
+
+## Problem
+
+Slice 1 (SleepController) decides, dark + dry-run, when it is safe for a deeply-idle
+agent to sleep. This slice wires the MECHANISM that acts on a `would-sleep` verdict:
+stop the server to near-zero footprint, and respawn it on the next message without
+losing that message. This is the high-risk half — the supervisor's auto-respawn of a
+down server is load-bearing, and the lifeline is the single always-on ear. Done
+wrong, an agent never wakes. So the whole handshake reuses the proven
+`restart-requested.json` lifecycle rather than inventing a new one.
+
+## The handshake (mirrors restart-requested.json)
+
+Three file flags under `state/`, all consumed by the supervisor's existing
+health-check loop (alongside `checkRestartRequest()`):
+
+1. **`sleep-requested.json`** — written by the SleepController in LIVE mode when its
+   verdict is `would-sleep` (the `requestSleep` consumer, unwired in slice 1).
+   `checkSleepRequest()` validates it, then STOPS the server's tmux session and sets
+   an internal `slept` state. Crucially, while `slept`:
+   - the health loop does NOT treat the absent server as `serverDown` and does NOT
+     auto-respawn it (the one real change to load-bearing supervisor behavior — gated
+     behind `slept` so a genuine crash still auto-recovers);
+   - a `state/slept-marker.json` records `{ sleptAt, version }` so a fresh supervisor
+     boot (or the fleet watchdog) recognizes "intentionally asleep", not "crashed".
+2. **`wake-requested.json`** — written by the lifeline when a wake trigger fires.
+   `checkWakeRequest()` clears `slept`, calls `spawnServer()` (the same fresh-spawn
+   the restart path uses), and removes the slept marker.
+3. The SleepController clears `sleep-requested.json` semantics via its existing
+   once-per-episode latch; the supervisor consumes each flag on read (like restart).
+
+## Wake triggers (the lifeline, the always-on ear)
+
+The lifeline stays up while the server sleeps (it is cheap). It writes
+`wake-requested.json` on any of:
+
+- **An inbound Telegram message.** The lifeline FIRST durably buffers the message
+  (the existing PendingRelay / message-ledger path — zero loss), writes
+  `wake-requested.json`, then polls the server's `/health` until healthy and forwards
+  the buffered message via the existing replay path. User-facing contract: an
+  immediate "waking up…" ack, then the real reply once up — identical UX to a
+  compaction pause. Wake latency = cold server boot (~30–45s observed).
+- **An agent-to-agent ping** (Threadline) — same buffer-then-wake path.
+- **A scheduled job due.** The scheduler's next-fire becomes a wake timer the
+  lifeline arms before sleep (the `nextScheduledJobAt` SleepController already
+  computes — wired live in this slice). The lifeline writes `wake-requested.json`
+  shortly before the fire time.
+
+## Interactions / hard constraints
+
+- **Multi-machine lease.** The SleepController already refuses to sleep while this
+  machine holds the serving lease (slice 1 guard). This slice adds: a slept machine
+  must have released/handed off the lease first; and a slept standby must still be
+  able to take the lease (wake on a lease-acquisition signal).
+- **Fleet watchdog.** The out-of-process watchdog must read `slept-marker.json` and
+  treat a slept agent as healthy (NOT force-restart it as down). This is the single
+  most important safety wire — without it the watchdog fights the sleep.
+- **Observability while asleep.** `GET /health` must remain answerable — the lifeline
+  serves a minimal `{ state: 'asleep', sleptAt }` health on the server's behalf so
+  monitors and the dashboard see "asleep", not "down".
+- **Scheduled jobs.** Covered by the wake-timer above; a job must never be silently
+  missed because the server was asleep.
+
+## Decision points (signal vs authority)
+
+The `would-sleep → stop` action IS an authority (it stops the serving process). It is
+gated exactly like the SessionReaper: positive proof of deep idle (slice 1's verdict
+with all guards), KEEP-awake on any ambiguity, ships OFF + a dry-run "would-stop" log
+first, and never sleeps a lease-holder without a handoff. The SleepController's
+dry-run already produces the evidence to validate this before enablement.
+
+## Implementation status (this slice)
+
+Built + tested in this slice:
+- `SleepController.sleepRequestWriter` — live-mode `requestSleep` writes the
+  TTL-stamped `sleep-requested.json`.
+- `ServerSupervisor` — `checkSleepRequest` (stop server + enter `slept` + write
+  `slept-marker.json`), `checkWakeRequest` (respawn + clear), the health-loop
+  `slept` short-circuit (suppresses auto-respawn), and the boot-time slept-marker
+  read (a rebooted supervisor — or one bounced by the fleet watchdog — stays asleep).
+- `TelegramLifeline.requestWakeIfSlept` (via the pure `writeWakeRequestIfSlept`
+  helper) — an inbound message writes `wake-requested.json`; the existing
+  forward-retry queue replays the buffered message once the server is healthy.
+
+Enablement-gated refinements (the dark mechanism is safe without them — they
+improve behavior once sleep is turned ON): a fuller relay/forward-queue in-flight
+signal; the scheduler next-fire wake timer (so a cron job due during sleep wakes
+the server — `nextScheduledJobAt` is currently conservative-null); the lifeline
+serving a minimal `{state:'asleep'}` on `/health` so the fleet watchdog and the
+dashboard read "asleep" rather than "down" (today the boot-stay-asleep marker is the
+brick-defense). <!-- tracked: topic-16782 -->
+
+## Testing
+
+Unit + regression (this slice): `ServerSupervisor-sleep-wake.test.ts` (sleep stops +
+marks + slept; no-request no-op; expired-request ignored; wake respawns + clears;
+wake-when-not-slept no-op; idempotent re-sleep; boot marker signal),
+`agentSleepWake.test.ts` (marker→wake-request, no-marker→no-op), `SleepController`
+`sleepRequestWriter` (TTL-stamped flag). Regression: the existing
+`ServerSupervisor-handshake` / `supervisor-health-check` / `supervisor-cpu-starvation`
+suites stay green — the `slept` short-circuit is the only loop-flow change and is a
+no-op unless a sleep-request was honored. A full live two-stage lifecycle (actual
+stop → real inbound → respawn → replay) is the enablement validation on a test agent.
+
+## Rollback
+
+Dark + dry-run by default (`monitoring.agentSleep.enabled` + the slice-1 `dryRun`).
+`enabled:false` keeps the server always-up (today's behavior). The supervisor's
+`slept`-gated branch is a no-op unless a `sleep-requested.json` is ever written, which
+only the live SleepController does.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -8906,7 +8906,7 @@ export async function startServer(options: StartOptions): Promise<void> {
     // inbound-message chokepoint (/internal/telegram-forward).
     const { AgentActivityState } = await import('../monitoring/AgentActivityState.js');
     const agentActivityState = new AgentActivityState();
-    const { SleepController, sleepAuditSink } = await import('../monitoring/SleepController.js');
+    const { SleepController, sleepAuditSink, sleepRequestWriter } = await import('../monitoring/SleepController.js');
     const _sleepCfg = config.monitoring?.agentSleep;
     const sleepController = new SleepController(
       {
@@ -8920,14 +8920,18 @@ export async function startServer(options: StartOptions): Promise<void> {
             // Lease guard: only relevant when multi-machine coordination is active.
             leaseActive: coordinator.enabled,
             holdsLease: coordinator.enabled ? coordinator.holdsLease() : false,
-            // In-flight: an inbound message currently being handled. (The relay/forward
-            // in-flight + scheduler-wake signals are wired with the stop mechanism in
-            // the next slice — this slice is dry-run, so it never acts on them.)
+            // In-flight: an inbound message currently being handled. (A fuller
+            // relay/forward-queue in-flight signal + the scheduler next-fire wake are
+            // tracked refinements; nextScheduledJobAt stays null until scheduler-wake
+            // lands, so the scheduled-job guard is conservative-off for now.)
             inflightWork: (currentInboundByTopic?.size ?? 0) > 0,
             nextScheduledJobAt: null,
           };
         },
         audit: sleepAuditSink(config.stateDir),
+        // Live-mode only (enabled && !dryRun): writes state/sleep-requested.json
+        // for the ServerSupervisor to honor. Dark/dry-run never invokes this.
+        requestSleep: sleepRequestWriter(config.stateDir),
       },
       {
         enabled: _sleepCfg?.enabled ?? false,

--- a/src/lifeline/ServerSupervisor.ts
+++ b/src/lifeline/ServerSupervisor.ts
@@ -241,6 +241,14 @@ export class ServerSupervisor extends EventEmitter {
   private maintenanceWaitMs = 5 * 60_000; // 5 minutes default (configurable via maintenanceWaitMinutes)
   private pendingUpdateVersion: string | null = null; // Version being applied — triggers lifeline self-restart on recovery
 
+  // Agent hard-sleep (Stage B mechanism; docs/specs/agent-hard-sleep-mechanism.md).
+  // When `slept` is true the server was INTENTIONALLY stopped to save resources —
+  // the health loop must NOT treat it as down or auto-respawn it; it only watches
+  // for a wake-request. Gated upstream by the SleepController, which writes the
+  // sleep-request flag only in live mode (enabled + !dryRun). Always-off here until
+  // a sleep-request flag is honored, so existing crash-recovery behavior is intact.
+  private slept = false;
+
   // Circuit breaker — give up after too many total failures, but retry periodically
   private totalFailures = 0;
   private totalFailureWindowStart = 0;
@@ -362,6 +370,22 @@ export class ServerSupervisor extends EventEmitter {
   /**
    * Stop the server and monitoring.
    */
+  /**
+   * Operator-explicit wake from agent hard-sleep. Clears the `slept` state + the
+   * slept-marker so a manual `/lifeline restart` (or `/restart`) actually brings the
+   * server back up — without this, startHealthChecks() re-reads the marker and the
+   * supervisor immediately re-enters `slept`, leaving an un-monitored server and no
+   * in-band recovery. Distinct from a fleet-watchdog auto-bounce (which intentionally
+   * stays asleep via the boot-marker); this is reached only from an explicit command.
+   */
+  wakeFromSleep(): void {
+    if (this.slept || this.sleptMarkerPresent()) {
+      this.clearSleptMarker();
+      this.slept = false;
+      console.log('[Supervisor] Explicit wake — cleared slept state for operator restart');
+    }
+  }
+
   async stop(): Promise<void> {
     this.stopHealthChecks();
 
@@ -1057,6 +1081,14 @@ export class ServerSupervisor extends EventEmitter {
   private startHealthChecks(): void {
     if (this.healthCheckInterval) return;
 
+    // Agent hard-sleep: if a slept-marker survived from before this supervisor boot,
+    // the server was intentionally asleep — stay asleep (the health loop will only
+    // watch for a wake-request) rather than respawning it as if it had crashed.
+    if (this.sleptMarkerPresent()) {
+      this.slept = true;
+      console.log('[Supervisor] Booted with a slept-marker present — staying asleep until a wake-request');
+    }
+
     // Start SleepWakeDetector to catch short sleeps (10-30s) that the gap-based
     // detection below misses (its 2-minute threshold is too high for brief suspends).
     // On wake, reset failure counters so stale pre-sleep failures don't cascade.
@@ -1098,6 +1130,15 @@ export class ServerSupervisor extends EventEmitter {
         this.wakeTransitionUntil = now + this.wakeTransitionMs;
       }
       this.lastHealthCheckAt = now;
+
+      // Agent hard-sleep: when intentionally slept, the server is down BY DESIGN.
+      // Skip all health/respawn logic and only watch for a wake-request. This is
+      // the single change to the loop's control flow — a pure short-circuit that is
+      // a no-op unless a sleep-request was honored (slept === false otherwise).
+      if (this.slept) {
+        this.checkWakeRequest();
+        return;
+      }
 
       // During startup grace period: probe health optimistically but don't act on failures.
       // This allows `lastHealthy` to update as soon as the server is responsive, so
@@ -1173,6 +1214,8 @@ export class ServerSupervisor extends EventEmitter {
       this.checkRestartRequest();
       // Check for debug restart requests from doctor sessions
       this.checkDebugRestartRequest();
+      // Agent hard-sleep: honor a sleep-request written by the live SleepController
+      this.checkSleepRequest();
     }, 10_000); // Check every 10 seconds
   }
 
@@ -1226,6 +1269,88 @@ export class ServerSupervisor extends EventEmitter {
       }
     }
     return false;
+  }
+
+  // ── Agent hard-sleep: sleep/wake request handling ─────────────────
+  //
+  // Mirrors the restart-requested.json lifecycle. The live SleepController writes
+  // `state/sleep-requested.json` on a would-sleep verdict; this honors it by
+  // STOPPING the server (no respawn) and entering `slept`. The lifeline writes
+  // `state/wake-requested.json` on the next inbound message; checkWakeRequest()
+  // (called only while slept) respawns the server. A `state/slept-marker.json`
+  // records the intentional-sleep so a supervisor reboot — or the fleet watchdog —
+  // recognizes "asleep", not "crashed". Spec: docs/specs/agent-hard-sleep-mechanism.md.
+
+  /** Stop the server tmux session and enter `slept`. Honors sleep-requested.json. */
+  private checkSleepRequest(): void {
+    if (!this.stateDir || this.slept) return;
+    const flagPath = path.join(this.stateDir, 'state', 'sleep-requested.json');
+    try {
+      if (!fs.existsSync(flagPath)) return;
+      let data: { requestedBy?: string; reason?: string; expiresAt?: string } = {};
+      try { data = JSON.parse(fs.readFileSync(flagPath, 'utf-8')); } catch { /* tolerate */ }
+      // Consume the flag BEFORE acting so a malformed/processed request can't loop.
+      try { SafeFsExecutor.safeUnlinkSync(flagPath, { operation: 'src/lifeline/ServerSupervisor.ts:checkSleepRequest' }); } catch { /* ignore */ }
+      if (data.expiresAt && new Date(data.expiresAt).getTime() < Date.now()) {
+        console.log('[Supervisor] Expired sleep request — ignoring');
+        return;
+      }
+      console.log(`[Supervisor] Sleep requested (${data.reason ?? 'deep-idle'}) — stopping server to save resources`);
+      // Record the intentional sleep BEFORE stopping, so a reboot/watchdog sees it.
+      this.writeSleptMarker(data.reason ?? 'deep-idle');
+      this.slept = true;
+      this.isRunning = false;
+      // Stop the server tmux session WITHOUT respawning (the wake path respawns).
+      if (this.tmuxPath) {
+        try {
+          execFileSync(this.tmuxPath, ['kill-session', '-t', `=${this.serverSessionName}`], { stdio: 'ignore', timeout: 10_000 });
+        } catch { /* @silent-fallback-ok — session may already be gone */ }
+      }
+      this.emit('serverSlept');
+    } catch {
+      try { SafeFsExecutor.safeUnlinkSync(flagPath, { operation: 'src/lifeline/ServerSupervisor.ts:checkSleepRequest:catch' }); } catch { /* ignore */ }
+    }
+  }
+
+  /** Respawn the server on a wake-request. Called from the health loop ONLY while slept. */
+  private checkWakeRequest(): void {
+    if (!this.stateDir || !this.slept) return;
+    const flagPath = path.join(this.stateDir, 'state', 'wake-requested.json');
+    try {
+      if (!fs.existsSync(flagPath)) return;
+      try { SafeFsExecutor.safeUnlinkSync(flagPath, { operation: 'src/lifeline/ServerSupervisor.ts:checkWakeRequest' }); } catch { /* ignore */ }
+      console.log('[Supervisor] Wake requested — respawning server');
+      this.clearSleptMarker();
+      this.slept = false;
+      // Give the fresh server the full startup grace from now (mirrors restart path).
+      this.spawnedAt = Date.now();
+      this.consecutiveFailures = 0;
+      this.restartAttempts = 0;
+      this.spawnServer();
+      this.emit('serverWoke');
+    } catch {
+      try { SafeFsExecutor.safeUnlinkSync(flagPath, { operation: 'src/lifeline/ServerSupervisor.ts:checkWakeRequest:catch' }); } catch { /* ignore */ }
+    }
+  }
+
+  private writeSleptMarker(reason: string): void {
+    if (!this.stateDir) return;
+    try {
+      const dir = path.join(this.stateDir, 'state');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'slept-marker.json'), JSON.stringify({ sleptAt: new Date().toISOString(), reason }));
+    } catch { /* @silent-fallback-ok — marker is best-effort observability */ }
+  }
+
+  private clearSleptMarker(): void {
+    if (!this.stateDir) return;
+    try { SafeFsExecutor.safeUnlinkSync(path.join(this.stateDir, 'state', 'slept-marker.json'), { operation: 'src/lifeline/ServerSupervisor.ts:clearSleptMarker' }); } catch { /* ignore */ }
+  }
+
+  /** True when a slept-marker is on disk — read at boot so a reboot stays asleep. */
+  private sleptMarkerPresent(): boolean {
+    if (!this.stateDir) return false;
+    try { return fs.existsSync(path.join(this.stateDir, 'state', 'slept-marker.json')); } catch { return false; }
   }
 
   // ── Restart request handling ──────────────────────────────────────

--- a/src/lifeline/TelegramLifeline.ts
+++ b/src/lifeline/TelegramLifeline.ts
@@ -60,6 +60,7 @@ import { writeStartupMarker } from './startupMarker.js';
 import { shouldOwnTelegramPoll } from './telegramPollOwnership.js';
 import { writeLease as writePollOwnerLease } from './TelegramPollOwnerLease.js';
 import { RestartOrchestrator } from './RestartOrchestrator.js';
+import { writeWakeRequestIfSlept } from './agentSleepWake.js';
 import { detectLaunchdSupervised } from './detectLaunchdSupervised.js';
 import { LifelineDriftPromoter, DRIFT_RESTART_PENDING_NOTICE_FILE } from './LifelineDriftPromoter.js';
 import {
@@ -993,6 +994,14 @@ export class TelegramLifeline {
   }
 
   private async processUpdate(update: TelegramUpdate): Promise<void> {
+    // Agent hard-sleep wake trigger. ANY inbound update is user activity — so write
+    // the wake-request FIRST, before the supervisor.healthy gate below. A slept
+    // server is NOT healthy, so without this the message would take the "server
+    // down → queue" path and never wake the server (the brick the review caught).
+    // No-op unless a slept-marker is present; the message then replays via the
+    // existing queue once the respawned server is healthy.
+    this.requestWakeIfSlept();
+
     // Forward callback queries (inline keyboard button presses) to the server
     // These come from Prompt Gate relay buttons — the server handles the response injection
     if (update.callback_query) {
@@ -1324,6 +1333,19 @@ export class TelegramLifeline {
   /** Full semver of this lifeline, read once at construction. */
   private readonly lifelineVersion = getInstarVersion();
 
+  /**
+   * Agent hard-sleep wake trigger. When the ServerSupervisor has intentionally
+   * slept the server (a `state/slept-marker.json` is present), write
+   * `state/wake-requested.json` so the supervisor respawns it. Idempotent + cheap:
+   * the supervisor consumes the flag and removes the marker on wake, so steady-state
+   * (awake) this is a single `existsSync` no-op per forward.
+   */
+  private requestWakeIfSlept(): void {
+    if (writeWakeRequestIfSlept(this.projectConfig.stateDir, new Date().toISOString())) {
+      console.log('[Lifeline] Server is asleep — wrote wake-request; message will replay once it boots');
+    }
+  }
+
   private async forwardToServer(
     topicId: number,
     text: string,
@@ -1652,6 +1674,7 @@ export class TelegramLifeline {
 
     if (cmd === '/lifeline restart') {
       await this.sendToTopic(topicId, 'Restarting server...');
+      this.supervisor.wakeFromSleep(); // explicit restart clears any hard-sleep state
       this.supervisor.resetCircuitBreaker();
       await this.supervisor.stop();
       const started = await this.supervisor.start();
@@ -1660,6 +1683,7 @@ export class TelegramLifeline {
     }
 
     if (cmd === '/lifeline reset') {
+      this.supervisor.wakeFromSleep(); // explicit reset clears any hard-sleep state
       this.supervisor.resetCircuitBreaker();
       await this.sendToTopic(topicId, 'Circuit breaker reset. Restarting server...');
       await this.supervisor.stop();

--- a/src/lifeline/agentSleepWake.ts
+++ b/src/lifeline/agentSleepWake.ts
@@ -1,0 +1,34 @@
+/**
+ * Agent hard-sleep wake-trigger helper (Stage B mechanism). Pure + testable,
+ * shared by the TelegramLifeline forward path. When the ServerSupervisor has
+ * intentionally slept the server, a `state/slept-marker.json` is on disk; an
+ * inbound message is the wake trigger, so the lifeline writes
+ * `state/wake-requested.json` for the supervisor to honor (it respawns the server,
+ * consumes the flag, and removes the marker). The buffered message replays via the
+ * existing forward-retry queue once the server is healthy — zero loss.
+ *
+ * Idempotent + cheap: steady-state (server awake, no marker) this is a single
+ * existsSync no-op. Best-effort: a failed write just delays the wake one tick,
+ * since the lifeline calls this on every forward attempt while a marker persists.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * If a slept-marker is present, write a wake-request and return true.
+ * Returns false (no-op) when the server is not asleep.
+ */
+export function writeWakeRequestIfSlept(stateDir: string, nowIso: string): boolean {
+  try {
+    const stateSub = path.join(stateDir, 'state');
+    if (!fs.existsSync(path.join(stateSub, 'slept-marker.json'))) return false;
+    fs.mkdirSync(stateSub, { recursive: true });
+    fs.writeFileSync(
+      path.join(stateSub, 'wake-requested.json'),
+      JSON.stringify({ requestedBy: 'TelegramLifeline', requestedAt: nowIso }),
+    );
+    return true;
+  } catch {
+    return false; // @silent-fallback-ok — forward retry/queue still delivers the message
+  }
+}

--- a/src/monitoring/SleepController.ts
+++ b/src/monitoring/SleepController.ts
@@ -149,6 +149,34 @@ export function sleepAuditSink(stateDir: string): SleepAuditSink {
   };
 }
 
+/**
+ * Live-mode `requestSleep` impl (Stage B mechanism): writes
+ * `state/sleep-requested.json` for the ServerSupervisor to honor (it stops the
+ * server). Only ever called by the SleepController in live mode (enabled &&
+ * !dryRun), so a dark / dry-run agent never writes it. TTL-stamped so a stale
+ * request can't sleep a server long after it was queued.
+ */
+export function sleepRequestWriter(stateDir: string, ttlMs = 300_000): (verdict: SleepVerdict) => void {
+  return (verdict: SleepVerdict) => {
+    try {
+      const dir = path.join(stateDir, 'state');
+      fs.mkdirSync(dir, { recursive: true });
+      const now = Date.now();
+      fs.writeFileSync(
+        path.join(dir, 'sleep-requested.json'),
+        JSON.stringify({
+          requestedBy: 'SleepController',
+          reason: verdict.reason,
+          requestedAt: new Date(now).toISOString(),
+          expiresAt: new Date(now + ttlMs).toISOString(),
+        }),
+      );
+    } catch {
+      /* @silent-fallback-ok — supervisor re-checks each tick; a missed write just delays sleep */
+    }
+  };
+}
+
 export interface SleepControllerOptions {
   enabled: boolean;
   /** When true (default), evaluate + audit but NEVER write the sleep-request flag. */

--- a/tests/unit/ServerSupervisor-sleep-wake.test.ts
+++ b/tests/unit/ServerSupervisor-sleep-wake.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests — ServerSupervisor agent hard-sleep mechanism (Stage B slice 2).
+ *
+ * The handshake mirrors restart-requested.json: a sleep-request stops the server
+ * and enters `slept` (the health loop then suppresses auto-respawn); a wake-request
+ * respawns it. THE safety-critical invariant: a slept server is NOT treated as
+ * crashed (no auto-respawn), and a genuine crash while NOT slept still recovers.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import * as childProcess from 'node:child_process';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return { ...actual, spawnSync: vi.fn(() => ({ stdout: '', stderr: '', status: 0, signal: null, pid: 0, output: [] })), execFileSync: vi.fn(() => '') };
+});
+vi.mock('../../src/core/Config.js', () => ({ detectTmuxPath: () => '/usr/bin/tmux' }));
+vi.mock('../../src/core/SleepWakeDetector.js', () => ({
+  SleepWakeDetector: vi.fn().mockImplementation(() => ({ start: vi.fn(), stop: vi.fn(), on: vi.fn() })),
+}));
+
+import { ServerSupervisor } from '../../src/lifeline/ServerSupervisor.js';
+
+function tmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'supervisor-sleep-'));
+  fs.mkdirSync(path.join(dir, '.instar', 'state'), { recursive: true });
+  return dir;
+}
+
+describe('ServerSupervisor — agent hard-sleep', () => {
+  let dir: string;
+  let stateDir: string;
+  let sup: ServerSupervisor;
+
+  beforeEach(() => {
+    dir = tmp();
+    stateDir = path.join(dir, '.instar');
+    sup = new ServerSupervisor({ projectDir: dir, projectName: 'test-agent', port: 0, stateDir });
+    (childProcess.execFileSync as unknown as ReturnType<typeof vi.fn>).mockClear();
+  });
+  afterEach(() => {
+    if (fs.existsSync(dir)) SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/ServerSupervisor-sleep-wake.test.ts' });
+  });
+
+  const flag = (name: string, body: object = {}) =>
+    fs.writeFileSync(path.join(stateDir, 'state', name), JSON.stringify(body));
+  const exists = (name: string) => fs.existsSync(path.join(stateDir, 'state', name));
+
+  it('checkSleepRequest stops the server + enters slept + writes the slept-marker', () => {
+    flag('sleep-requested.json', { reason: 'deep-idle 30m', expiresAt: new Date(Date.now() + 60_000).toISOString() });
+    (sup as any).checkSleepRequest();
+    expect((sup as any).slept).toBe(true);
+    expect(exists('slept-marker.json')).toBe(true);
+    expect(exists('sleep-requested.json')).toBe(false); // consumed
+    // killed the tmux server session
+    const calls = (childProcess.execFileSync as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.some((c) => Array.isArray(c[1]) && c[1][0] === 'kill-session')).toBe(true);
+  });
+
+  it('no sleep-request → no-op (server NOT slept, no marker)', () => {
+    (sup as any).checkSleepRequest();
+    expect((sup as any).slept).toBe(false);
+    expect(exists('slept-marker.json')).toBe(false);
+  });
+
+  it('an EXPIRED sleep-request is ignored (consumed, but does not sleep)', () => {
+    flag('sleep-requested.json', { reason: 'stale', expiresAt: new Date(Date.now() - 1000).toISOString() });
+    (sup as any).checkSleepRequest();
+    expect((sup as any).slept).toBe(false);
+    expect(exists('slept-marker.json')).toBe(false);
+    expect(exists('sleep-requested.json')).toBe(false); // still consumed
+  });
+
+  it('checkWakeRequest (while slept) respawns the server + clears slept + marker', () => {
+    const spawnSpy = vi.spyOn(sup as any, 'spawnServer').mockReturnValue(true);
+    // put it to sleep first
+    flag('sleep-requested.json', {});
+    (sup as any).checkSleepRequest();
+    expect((sup as any).slept).toBe(true);
+    // now wake
+    flag('wake-requested.json', {});
+    (sup as any).checkWakeRequest();
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    expect((sup as any).slept).toBe(false);
+    expect(exists('slept-marker.json')).toBe(false);
+    expect(exists('wake-requested.json')).toBe(false); // consumed
+  });
+
+  it('checkWakeRequest is a no-op when NOT slept (never spuriously respawns)', () => {
+    const spawnSpy = vi.spyOn(sup as any, 'spawnServer').mockReturnValue(true);
+    flag('wake-requested.json', {});
+    (sup as any).checkWakeRequest();
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect((sup as any).slept).toBe(false);
+  });
+
+  it('sleeping is idempotent: a second checkSleepRequest while already slept is a no-op', () => {
+    flag('sleep-requested.json', {});
+    (sup as any).checkSleepRequest();
+    const killCountAfterFirst = (childProcess.execFileSync as unknown as ReturnType<typeof vi.fn>).mock.calls.length;
+    flag('sleep-requested.json', {});
+    (sup as any).checkSleepRequest(); // slept===true → early return, flag untouched by this method
+    expect((childProcess.execFileSync as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(killCountAfterFirst);
+  });
+
+  it('sleptMarkerPresent reflects the marker on disk (boot-time stay-asleep signal)', () => {
+    expect((sup as any).sleptMarkerPresent()).toBe(false);
+    flag('slept-marker.json', { sleptAt: new Date().toISOString() });
+    expect((sup as any).sleptMarkerPresent()).toBe(true);
+  });
+
+  it('wakeFromSleep clears slept + marker (operator escape hatch — /lifeline restart)', () => {
+    flag('sleep-requested.json', {});
+    (sup as any).checkSleepRequest();
+    expect((sup as any).slept).toBe(true);
+    expect(exists('slept-marker.json')).toBe(true);
+    // an explicit operator restart must clear the state so the server actually comes up
+    sup.wakeFromSleep();
+    expect((sup as any).slept).toBe(false);
+    expect(exists('slept-marker.json')).toBe(false);
+  });
+
+  it('wakeFromSleep also clears a marker present without in-memory slept (post-reboot)', () => {
+    flag('slept-marker.json', { sleptAt: new Date().toISOString() });
+    expect((sup as any).slept).toBe(false); // fresh instance, not yet booted into slept
+    sup.wakeFromSleep();
+    expect(exists('slept-marker.json')).toBe(false);
+  });
+});

--- a/tests/unit/SleepController.test.ts
+++ b/tests/unit/SleepController.test.ts
@@ -189,3 +189,27 @@ describe('AgentActivityState', () => {
     expect(a.snapshot()).toEqual({ lastInboundAt: NOW - 1000, lastActivityAt: NOW });
   });
 });
+
+import { sleepRequestWriter } from '../../src/monitoring/SleepController.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+describe('sleepRequestWriter', () => {
+  it('writes a TTL-stamped sleep-requested.json the supervisor can consume', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sleep-req-'));
+    try {
+      const write = sleepRequestWriter(dir, 60_000);
+      write({ decision: 'would-sleep', reason: 'deep-idle 30m', idleForMs: 1_800_000 });
+      const p = path.join(dir, 'state', 'sleep-requested.json');
+      expect(fs.existsSync(p)).toBe(true);
+      const data = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      expect(data.requestedBy).toBe('SleepController');
+      expect(data.reason).toMatch(/deep-idle/);
+      expect(new Date(data.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    } finally {
+      SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'test-cleanup' });
+    }
+  });
+});

--- a/tests/unit/agentSleepWake.test.ts
+++ b/tests/unit/agentSleepWake.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests — agent hard-sleep wake-trigger helper (the lifeline side of the
+ * stop+wake handshake). Both sides: marker present → wake-request written; marker
+ * absent → no-op (steady-state awake never writes).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+import { writeWakeRequestIfSlept } from '../../src/lifeline/agentSleepWake.js';
+
+function tmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wake-helper-'));
+  fs.mkdirSync(path.join(dir, 'state'), { recursive: true });
+  return dir;
+}
+
+describe('writeWakeRequestIfSlept', () => {
+  it('no-op when the server is NOT asleep (no slept-marker)', () => {
+    const dir = tmp();
+    try {
+      expect(writeWakeRequestIfSlept(dir, new Date().toISOString())).toBe(false);
+      expect(fs.existsSync(path.join(dir, 'state', 'wake-requested.json'))).toBe(false);
+    } finally { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'test-cleanup' }); }
+  });
+
+  it('writes wake-requested.json when a slept-marker is present', () => {
+    const dir = tmp();
+    try {
+      fs.writeFileSync(path.join(dir, 'state', 'slept-marker.json'), JSON.stringify({ sleptAt: new Date().toISOString() }));
+      const iso = new Date().toISOString();
+      expect(writeWakeRequestIfSlept(dir, iso)).toBe(true);
+      const p = path.join(dir, 'state', 'wake-requested.json');
+      expect(fs.existsSync(p)).toBe(true);
+      const data = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      expect(data.requestedBy).toBe('TelegramLifeline');
+      expect(data.requestedAt).toBe(iso);
+    } finally { SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'test-cleanup' }); }
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,53 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed
+
+**Agent hard-sleep can now actually stop and wake the server (dark + dry-run).**
+The previous step taught an idle agent how to DECIDE whether it is safe to sleep but
+never acted. This step builds the mechanism that acts on that decision: when sleep is
+enabled and the agent is deeply idle and safe, its heavy background server is
+stopped to save the machine's resources, and it wakes the instant a message arrives.
+
+The handshake reuses the proven restart lifecycle: the decision layer writes a
+sleep-request file, the supervisor stops the server and marks it intentionally
+asleep (so it is NOT treated as a crash and is NOT auto-restarted), and an inbound
+message makes the lifeline write a wake-request that the supervisor honors by
+respawning the server. The waiting message is held in the existing durable queue and
+delivered once the server is healthy, so nothing is lost. A safety marker means that
+even if an outside watchdog force-restarts the agent mid-sleep, it reads the marker
+on startup and stays asleep instead of fighting it. The existing crash-recovery
+behavior is unchanged except in the one case where the agent chose to sleep, proven
+by the existing supervisor tests staying green.
+
+## What to Tell Your User
+
+Nothing changes on any normal agent — this ships off by default, and the file that
+triggers a sleep is only ever written when sleep is explicitly turned on. The future
+ability it builds toward: a completely idle agent quiets its server to save your
+machine, then wakes the moment you message it, holding your message until it is back
+up. Turning it on is a deliberate step we would validate on one test agent first.
+
+## Summary of New Capabilities
+
+- ServerSupervisor honors a sleep-request by stopping the server and entering an
+  intentionally-asleep state that suppresses auto-respawn; honors a wake-request by
+  respawning. A slept-marker keeps a rebooted (or watchdog-bounced) supervisor asleep.
+- The decision layer writes a TTL-stamped sleep-request only in live mode.
+- The lifeline writes a wake-request on the next inbound message when the server is
+  asleep; the existing forward-retry queue replays the held message after wake.
+- All gated by the existing monitoring.agentSleep config — OFF + dry-run by default.
+
+## Evidence
+
+- `tests/unit/ServerSupervisor-sleep-wake.test.ts` — sleep stops + marks + enters
+  slept; no-request no-op; expired-request ignored; wake respawns + clears; wake-when-
+  not-slept no-op; idempotent re-sleep; boot-marker signal.
+- `tests/unit/agentSleepWake.test.ts` — marker present writes the wake-request; no
+  marker is a no-op (steady-state awake never writes).
+- `tests/unit/SleepController.test.ts` — sleepRequestWriter writes the TTL-stamped flag.
+- Regression: the existing ServerSupervisor-handshake / supervisor-health-check /
+  supervisor-cpu-starvation suites stay green — the slept short-circuit is the only
+  loop-flow change and is a no-op until a live sleep-request is honored.
+- Side-effects: `upgrades/side-effects/agent-hard-sleep-mechanism.md`.

--- a/upgrades/side-effects/agent-hard-sleep-mechanism.md
+++ b/upgrades/side-effects/agent-hard-sleep-mechanism.md
@@ -1,0 +1,115 @@
+# Side-Effects Review — Agent hard-sleep stop+wake mechanism (Stage B, slice 2)
+
+**Version / slug:** `agent-hard-sleep-mechanism`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `adversarial review performed — found a critical brick (wake-trigger gated on health) + a broken manual escape hatch; BOTH fixed + tested before commit. Concurs the dark code is inert. Enablement remains the reviewed gate (live on a test agent with Justin watching).`
+
+## Summary of the change
+
+Acts on the slice-1 SleepController verdict: in live mode it writes
+`state/sleep-requested.json`; the ServerSupervisor honors it by stopping the server
+tmux session and entering a `slept` state; the health loop then short-circuits
+(suppressing auto-respawn) and only watches for `state/wake-requested.json`, which
+the TelegramLifeline writes on the next inbound message → the supervisor respawns
+the server and the existing forward-retry queue replays the buffered message. Files:
+`SleepController.ts` (+`sleepRequestWriter`), `ServerSupervisor.ts`
+(checkSleepRequest/checkWakeRequest/`slept` guard/boot-marker), `TelegramLifeline.ts`
+(+`requestWakeIfSlept` via the pure `agentSleepWake.ts` helper). No new config (the
+slice-1 `monitoring.agentSleep` gates it), no new route, no agent-installed file.
+
+## Decision-point inventory
+
+- `ServerSupervisor` health-loop control flow — modify — adds ONE short-circuit: `if (slept) { checkWakeRequest(); return; }` at the loop top.
+- `ServerSupervisor.checkSleepRequest` / `checkWakeRequest` — add — the stop/respawn handlers (mirror checkRestartRequest).
+- `ServerSupervisor` boot — modify — reads `slept-marker.json` to stay asleep across a supervisor reboot.
+- `SleepController.requestSleep` consumer — add — `sleepRequestWriter` (live-mode only).
+- `TelegramLifeline.forwardToServer` — pass-through — prepends a non-blocking `requestWakeIfSlept()` side-call.
+
+---
+
+## 1. Over-block
+
+No block/allow surface over messages. The only "blocking-like" behavior is the
+`slept` short-circuit suppressing auto-respawn — which is exactly intended and gated
+on `slept`, set only after a live sleep-request is honored. A genuine crash (slept
+=== false) still flows through the unchanged `evaluateUnhealthyServer` path.
+
+## 2. Under-block
+
+Could the server fail to wake (the brick risk)? **The adversarial second-pass review
+caught a real brick in the first cut and it was fixed:** the wake-trigger was
+originally placed inside `forwardToServer()`, which is gated on `supervisor.healthy`
+— but a slept server is not healthy, so an inbound message took the "server down →
+queue" path and never wrote `wake-requested.json` → the server would never wake.
+**Fix:** `requestWakeIfSlept()` now runs at the TOP of `processUpdate()`, before any
+health gate, so EVERY inbound update writes the wake flag when slept (covered by the
+helper test + the corrected call-site). The review also caught that `/lifeline
+restart` (the manual escape hatch) didn't clear the slept-marker, so a manual restart
+re-read the marker and re-slept — **fixed** via `ServerSupervisor.wakeFromSleep()`,
+called from both `/lifeline restart` and `/lifeline reset` (tested).
+
+Remaining wake robustness: the supervisor checks the wake flag every 10s while slept;
+a single missed flag write self-heals on the next inbound; a fleet-watchdog mid-sleep
+bounce stays asleep via the boot-marker AND wakes on the next inbound. The
+scheduler-wake (a cron job due during sleep) is the one tracked gap (conservative-null
+for now), enablement-gated — dark default means no real agent is affected.
+
+## 3. Level-of-abstraction fit
+
+Correct. The mechanism reuses the proven `restart-requested.json` lifecycle shape
+(file flag consumed in the health loop) rather than inventing a new lifecycle; the
+stop is the existing tmux `kill-session`, the wake is the existing `spawnServer()`.
+The lifeline wake-trigger is extracted into a pure, unit-tested helper
+(`writeWakeRequestIfSlept`) rather than buried in the un-testable heavy class.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+- [x] No — the SleepController remains the decision-maker (signal, with all guards);
+  this slice is the mechanism it drives. The stop IS an authority (stops a process),
+  but it is gated exactly like a planned restart: positive proof (the slice-1
+  would-sleep verdict with every guard), ships OFF + dry-run, never fires unless
+  enabled && !dryRun, and KEEPs-awake on any ambiguity upstream.
+
+## 5. Interactions
+
+- **Shadowing:** the `slept` short-circuit runs before the health/restart logic; it
+  is a no-op when `slept===false` (always, until a live sleep-request lands), so it
+  cannot shadow the existing restart/health paths in normal operation. Verified by
+  the unchanged `ServerSupervisor-handshake` + `supervisor-health-check` suites.
+- **Double-fire:** sleep is idempotent (`checkSleepRequest` early-returns when
+  already slept); wake is idempotent (early-returns when not slept). The
+  `sleep-requested`/`wake-requested` flags are consumed on read.
+- **Races:** the fleet watchdog vs sleep — resolved by the boot-marker (reboot stays
+  asleep). The lifeline writing a wake flag while the supervisor is mid-respawn —
+  harmless (the supervisor clears `slept` first, so a redundant wake flag is consumed
+  next tick as a no-op).
+- **Feedback loops:** none — the flags are one-shot, consumed by the consumer.
+
+## 6. External surfaces
+
+- **Install base:** pure additive source, no config/route/agent-installed-file
+  change → every agent picks it up on update; behavior is byte-identical until
+  `monitoring.agentSleep` is enabled live. The slice-1 dark default holds.
+- **Other agents / external systems:** none.
+- **Persistent state:** three transient `state/*.json` flags + one `slept-marker.json`
+  (best-effort, consumed/removed by the supervisor).
+- **Timing:** the existing 10s health tick; no new timer.
+
+## 7. Rollback cost
+
+Pure additive code, no config/migration. Revert → `checkSleepRequest` /
+`checkWakeRequest` / the `slept` guard / the lifeline side-call disappear; the
+supervisor + lifeline behave exactly as before. No persistent state needs cleanup
+(the flags are transient). No user-visible change during rollback (dark by default).
+
+## Conclusion
+
+This review confirmed the mechanism is a tightly-scoped, additive layer on the
+proven restart lifecycle, with ONE load-bearing change (the `slept` short-circuit)
+that is a no-op until a live sleep-request is honored and is regression-covered by
+the existing supervisor suites. The brick risk is closed at multiple layers
+(per-forward wake re-write, 10s wake poll, boot-stay-asleep marker). It ships dark;
+the enablement (turning sleep ON) is the reviewed validation step on a test agent.


### PR DESCRIPTION
## What & why

Stage B's mechanism — the part that ACTS on the slice-1 SleepController decision. When sleep is enabled and an agent is deeply idle + safe, its heavy server is stopped to save the machine's resources and respawned the instant a message arrives. Ships **dark + dry-run** (`monitoring.agentSleep`, off by default; the live `requestSleep` flag is only written when `enabled && !dryRun`). Builds on merged #599.

## The handshake (reuses the proven restart lifecycle)

- **Sleep:** live SleepController writes `state/sleep-requested.json` → `ServerSupervisor.checkSleepRequest()` stops the server tmux session, sets `slept`, writes `state/slept-marker.json`.
- **Suppress auto-respawn:** the health loop short-circuits at the top — `if (this.slept) { checkWakeRequest(); return; }` — so a slept server isn't treated as crashed. This is the **only** loop-flow change, and it's a no-op until a live sleep-request lands.
- **Wake:** an inbound message → `TelegramLifeline.requestWakeIfSlept()` (at the top of `processUpdate`, ungated) writes `state/wake-requested.json` → `checkWakeRequest()` respawns via `spawnServer()`. The held message replays through the existing forward-retry queue once healthy (zero loss).
- **Brick defense:** a `slept-marker` keeps a rebooted (or fleet-watchdog-bounced) supervisor asleep; `wakeFromSleep()` is the operator escape hatch wired into `/lifeline restart` + `/reset`.

## ⚠️ Adversarial second-pass review caught a critical brick — fixed

The review found the wake-trigger was originally inside `forwardToServer()`, which is gated on `supervisor.healthy` — but a slept server is **not** healthy, so an inbound message would queue and **never** write the wake flag → the server would never wake. **Fixed:** moved `requestWakeIfSlept()` to the top of `processUpdate()`, before any health gate. The review also found `/lifeline restart` didn't clear the slept-marker (manual recovery also bricked) — **fixed** via `wakeFromSleep()`. Both fixes are tested. The reviewer confirmed the dark code is inert by default.

## Tests (unit + regression)

- `ServerSupervisor-sleep-wake.test.ts` — sleep stops + marks + enters slept; no-request no-op; expired-request ignored; wake respawns + clears; wake-when-not-slept no-op; idempotent re-sleep; boot-marker signal; **wakeFromSleep clears slept+marker** (escape hatch).
- `agentSleepWake.test.ts` — marker→wake-request; no-marker→no-op.
- `SleepController.test.ts` — `sleepRequestWriter` writes the TTL-stamped flag.
- **Regression:** `ServerSupervisor-handshake` / `supervisor-health-check` / `supervisor-cpu-starvation` stay green — existing crash-recovery is byte-identical when `slept===false`.

## Safety / process

- **Dark + dry-run + additive.** No new config/route/agent-installed-file. Revert = the handlers + the `slept` short-circuit disappear; supervisor/lifeline behave as before.
- **Spec** `docs/specs/agent-hard-sleep-mechanism.md` (converged + `approved: true`) + ELI16. **Side-effects** `upgrades/side-effects/agent-hard-sleep-mechanism.md`.
- ⚠️ **Self-approved under the delegated deploy mandate** (Justin: build Stage B now, topic 16782). The *enablement* — not this dark ship — is the reviewed gate: turn it on first on a test agent with Justin watching. A few enablement-gated refinements (scheduler-wake, lifeline-serves-health-while-asleep) are tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)