### PR TITLE
fix(codex): autonomous-loop Stop hook must keep stdout JSON-only (live-test bug)

### DIFF
--- a/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
+++ b/.claude/skills/autonomous/hooks/autonomous-stop-hook.sh
@@ -38,6 +38,18 @@ HOOK_INPUT=$(cat)
 IS_CODEX=0
 for _arg in "$@"; do [[ "$_arg" == "--codex" ]] && IS_CODEX=1; done
 
+# hook-capability: codex-stdout-json-safe — see emit() below (migration marker; bumped so
+# existing #28 installs re-deploy this fixed hook even though they already have CODEX_LOOP_ENABLED).
+# emit — human-facing approve/status text. In codex mode the Stop hook's STDOUT must be
+# ONLY valid decision-JSON (the `{"decision":"block",...}` case far below) or empty:
+# codex rejects ANY other stdout as "invalid stop hook JSON output" and reports the stop
+# hook as FAILED (observed live 2026-05-31 — a completion-promise approve echoed plain
+# text to stdout, so codex logged "Stop hook (failed)" on every terminal stop with the
+# loop flag on). So in codex mode these messages go to STDERR; Claude keeps them on
+# STDOUT (unchanged — Claude surfaces approve-path stdout to the user). The block-decision
+# JSON is printed directly (never via emit), so it always reaches stdout.
+emit() { if [[ "$IS_CODEX" == "1" ]]; then printf '%s\n' "$*" >&2; else printf '%s\n' "$*"; fi; }
+
 # ── Anchor to the agent home, NOT the session's CWD ───────────────────
 # All state paths below are relative (.instar/autonomous/<topic>.local.md, the
 # registry, the legacy file). The Stop hook inherits the session's working
@@ -359,8 +371,8 @@ if [[ "$DURATION_SECONDS" =~ ^[0-9]+$ ]] && [[ $DURATION_SECONDS -gt 0 ]]; then
     NOW_EPOCH=$(date +%s)
     ELAPSED=$(( NOW_EPOCH - START_EPOCH ))
     if [[ $ELAPSED -ge $DURATION_SECONDS ]]; then
-      echo "⏰ Autonomous mode: Duration expired ($ELAPSED seconds elapsed)."
-      echo "   Session is free to exit."
+      emit "⏰ Autonomous mode: Duration expired ($ELAPSED seconds elapsed)."
+      emit "   Session is free to exit."
       notify_terminal_stop "⏰ My autonomous run on \"$(goal_snippet)\" just hit its time limit and stopped. Ask me and I'll pick up where I left off."
       rm -f "$STATE_FILE"
       exit 0
@@ -374,7 +386,7 @@ fi
 
 # Emergency stop (global — halts every autonomous job on its next fire)
 if [[ -f ".instar/autonomous-emergency-stop" ]]; then
-  echo "🛑 Autonomous mode: Emergency stop detected."
+  emit "🛑 Autonomous mode: Emergency stop detected."
   notify_terminal_stop "🛑 My autonomous run on \"$(goal_snippet)\" was stopped (emergency stop)."
   rm -f "$STATE_FILE"
   # NOTE: the emergency flag is left in place so OTHER topics' hooks also see it
@@ -405,7 +417,7 @@ if [[ -n "$COMPLETION_CONDITION" ]] && [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TR
     EVAL_REASON=$(printf '%s' "$EVAL_RESP" | jq -r '.reason // empty' 2>/dev/null || echo "")
   fi
   if [[ "$EVAL_MET" == "true" ]]; then
-    echo "✅ Autonomous mode: completion condition met (independent evaluator): ${EVAL_REASON}"
+    emit "✅ Autonomous mode: completion condition met (independent evaluator): ${EVAL_REASON}"
     notify_terminal_stop "✅ My autonomous run on \"$(goal_snippet)\" finished — the goal was met."
     rm -f "$STATE_FILE"
     exit 0
@@ -423,8 +435,8 @@ if [[ -n "$TRANSCRIPT_PATH" ]] && [[ -f "$TRANSCRIPT_PATH" ]]; then
     if [[ -n "$COMPLETION_PROMISE" ]] && [[ "$COMPLETION_PROMISE" != "null" ]]; then
       PROMISE_TEXT=$(printf '%s' "$LAST_OUTPUT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
       if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
-        echo "✅ Autonomous mode: Completion promise detected — <promise>$COMPLETION_PROMISE</promise>"
-        echo "   Session is free to exit. Good work!"
+        emit "✅ Autonomous mode: Completion promise detected — <promise>$COMPLETION_PROMISE</promise>"
+        emit "   Session is free to exit. Good work!"
         notify_terminal_stop "✅ My autonomous run on \"$(goal_snippet)\" finished — all the work is done."
         rm -f "$STATE_FILE"
         exit 0

--- a/docs/specs/codex-stop-hook-stdout-json-safe.eli16.md
+++ b/docs/specs/codex-stop-hook-stdout-json-safe.eli16.md
@@ -1,0 +1,45 @@
+# Explain it like I'm 16: the codex Stop-hook "invalid JSON" fix
+
+## The background
+
+Instar lets an AI agent keep working on a long task across many turns. The trick is a little
+script called a "Stop hook" that runs every time the AI tries to stop. If there's still work
+to do, the hook says "no, keep going"; if the work is done, the hook says "okay, you can stop."
+
+We recently taught this same hook to work for a second kind of AI — "codex" (the one our
+agent Codey runs on) — not just Claude. That's the #28 feature.
+
+## The bug
+
+Here's the catch: Claude and codex listen to the Stop hook differently.
+
+- **Claude** is relaxed about what the hook prints. If the hook prints a friendly note like
+  "✅ All done, good work!", Claude just shows it to you and stops. Fine.
+- **codex** is strict. It expects the Stop hook to print EITHER nothing OR one specific
+  machine-readable line (JSON). If the hook prints a friendly human sentence instead, codex
+  throws an error: "invalid stop hook JSON output," and marks the whole Stop hook as FAILED.
+
+Our hook had a few spots where, when a task finished, it printed a friendly "✅ Autonomous
+mode: all done" line. That's perfect for Claude — but for codex it's garbage on the wrong
+channel, so codex failed the hook every time a codex run finished. We only caught this by
+actually running a real task on Codey and watching it happen — our automated test had only
+ever checked the "keep going" case, never the "okay, stop" case.
+
+## The fix
+
+Think of a program as having two output channels: channel 1 ("stdout", the official answer)
+and channel 2 ("stderr", side notes). codex only reads channel 1 and demands it be clean JSON.
+
+So we added a tiny helper called `emit`. When the hook is talking to **codex**, `emit` sends
+all the friendly human messages to channel 2 (side notes), keeping channel 1 spotless for the
+one JSON line codex cares about. When the hook is talking to **Claude**, `emit` keeps sending
+those messages to channel 1, exactly like before — so nothing changes for Claude.
+
+## Why it's safe
+
+We never changed the actual decision (keep-going vs stop). We only changed WHICH channel the
+human-readable note goes out on, and only for codex. The worst that could go wrong is a status
+note showing up in the logs instead of on screen — never a wrong decision. And we added a test
+that fails if anyone ever prints a non-JSON line to codex's channel again, plus one that
+confirms Claude still gets its messages the old way. We also bumped the upgrade marker so every
+existing codex agent automatically picks up the fixed hook on its next update.

--- a/docs/specs/codex-stop-hook-stdout-json-safe.md
+++ b/docs/specs/codex-stop-hook-stdout-json-safe.md
@@ -1,0 +1,76 @@
+---
+title: Codex autonomous-loop Stop hook — stdout must be JSON-only
+slug: codex-stop-hook-stdout-json-safe
+status: approved
+review-convergence: 2026-05-31T05:00:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h autonomous deploy mandate (topic 13435).
+  This is a live-test-found bug that BLOCKS safe enablement of the #28 codex autonomous-loop
+  driver: with the flag on, the hook's approve paths echoed plain text to stdout and codex
+  rejected it ("invalid stop hook JSON output"), failing the Stop hook on every terminal stop.
+  Found by driving Codey through a real autonomous task over Telegram (the mentorship loop),
+  exactly the class of defect a unit test misses and a live run catches. Justin was watching
+  and directed proceeding with the live test.
+second-pass-required: false
+second-pass-status: n/a-bugfix-with-regression-test
+---
+
+# Codex autonomous-loop Stop hook — stdout must be JSON-only
+
+## Problem
+
+The shared `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh` is registered for both
+Claude (`settings.json`, no args) and codex (`.codex/hooks.json`, `--codex`). For Claude, a
+Stop hook may print human-readable text to stdout in the approve case (Claude surfaces it to
+the user) and exit 0. For **codex**, a Stop hook's stdout MUST be either empty or a single
+valid decision-JSON object — codex rejects any other stdout as "invalid stop hook JSON
+output" and marks the Stop hook FAILED.
+
+The hook's four terminal-approve paths (duration expired, emergency stop, completion condition
+met, completion promise detected) each `echo` a "✅/⏰/🛑 Autonomous mode: …" line to stdout
+before `exit 0`. Under codex (`IS_CODEX=1`) with the loop flag on, reaching any of these on a
+real stop produced the failure. Confirmed live (2026-05-31): a codex session finished a task,
+met its completion promise (line 426 echo), and its pane showed
+`Stop hook (failed) — error: hook returned invalid stop hook JSON output`.
+
+The existing unit test only covered flag-on WITH an active job that BLOCKS (the one path that
+legitimately emits JSON to stdout), so it never exercised an approve/exit path under codex.
+
+## Design
+
+Add `emit()` immediately after the `--codex` detection:
+`emit() { if [[ "$IS_CODEX" == "1" ]]; then printf '%s\n' "$*" >&2; else printf '%s\n' "$*"; fi; }`
+
+Replace the six approve-path `echo` calls (lines for duration-expired ×2, emergency-stop,
+completion-condition, completion-promise ×2) with `emit`. In codex mode these now go to
+stderr (codex ignores stderr); in Claude mode they stay on stdout (byte-identical behavior).
+The `{"decision":"block", …}` JSON is printed directly (never via `emit`), so it always
+reaches stdout in the one case codex expects output. The restart-resume audit line already
+appended to a file, and other diagnostics already used `>&2` — no other stdout writers exist.
+
+## Migration parity
+
+The migration `migrateAutonomousStopHookTopicKeyed` re-deploys the bundled hook only when the
+deployed copy LACKS the marker. The prior marker `CODEX_LOOP_ENABLED` is already present in
+every #28 install (including the buggy one), so it would wrongly skip them. The marker is
+bumped to `codex-stdout-json-safe` (present only in the fixed hook) so existing codex agents
+re-deploy the fix; customized hooks (no stock fingerprint `Autonomous Mode Stop Hook`) are
+still left untouched.
+
+## Safety
+
+- Claude path byte-for-byte unchanged (approve messages still on stdout; verified by a test
+  asserting the Claude approve-path still writes "Emergency stop detected" to stdout).
+- The fix only moves codex-mode approve text from stdout→stderr; it changes no decision logic.
+- Worst case if `emit` were wrong: an approve message is missing from a log — never a wrong
+  block/approve decision.
+
+## Test plan
+- Unit (`autonomous-stop-hook-codex-gate.test.ts`): codex approve-path (emergency stop) emits
+  NO non-JSON to stdout (regression); Claude approve-path still writes it to stdout; the four
+  pre-existing gate cases (dark default / disabled / enabled-blocks / Claude-unaffected) stay
+  green. 6 tests.
+- Migration (`PostUpdateMigrator-autonomousStopHook.test.ts`): old/stock hooks still upgrade to
+  the bundled (fixed) hook; idempotent on the new marker. 7 tests.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1475,17 +1475,18 @@ export class PostUpdateMigrator {
       }
     };
     // Marker = the latest capability signature (bumped each time the bundled hook/
-    // setup gains a feature, so prior installs upgrade): now the #28 codex
-    // autonomous-loop driver — the shared hook self-gates on `--codex` +
-    // autonomousSessions.codexLoopDriver (var `CODEX_LOOP_ENABLED`), which is absent
-    // from every prior install (incl. the notify-on-stop version). Bumping the marker
-    // re-deploys the bundled hook to stock installs so existing CODEX agents get the
-    // codex-aware hook; customized hooks (no stock fingerprint) are still left untouched.
+    // setup gains a feature, so prior installs upgrade): now `codex-stdout-json-safe` —
+    // the codex Stop hook must keep STDOUT JSON-only (emit() routes approve/status text
+    // to stderr in codex mode), fixing the live 2026-05-31 "invalid stop hook JSON output"
+    // failure. This marker is ABSENT from prior #28 installs (which already carry
+    // CODEX_LOOP_ENABLED — using that as the marker would wrongly skip them), so bumping
+    // to it re-deploys the FIXED hook to every existing codex agent; customized hooks (no
+    // stock fingerprint) are still left untouched.
     upgrade(
       '.claude/skills/autonomous/hooks/autonomous-stop-hook.sh',
-      'CODEX_LOOP_ENABLED',
+      'codex-stdout-json-safe',
       'Autonomous Mode Stop Hook',
-      'skills/autonomous/hooks/autonomous-stop-hook.sh (#28 codex autonomous-loop driver — --codex self-gate)',
+      'skills/autonomous/hooks/autonomous-stop-hook.sh (codex Stop stdout JSON-safe — emit() to stderr)',
     );
     upgrade(
       '.claude/skills/autonomous/scripts/setup-autonomous.sh',

--- a/tests/unit/autonomous-stop-hook-codex-gate.test.ts
+++ b/tests/unit/autonomous-stop-hook-codex-gate.test.ts
@@ -42,7 +42,8 @@ function writeConfig(codexLoopEnabled: boolean | undefined): void {
   fs.writeFileSync(path.join(homeDir, '.instar', 'config.json'), JSON.stringify(cfg));
 }
 
-function runHook(opts: { codex: boolean; tmuxSession: string }): { exitCode: number; decision: string | null } {
+function runHook(opts: { codex: boolean; tmuxSession: string; emergencyStop?: boolean }): { exitCode: number; decision: string | null; stdout: string } {
+  if (opts.emergencyStop) fs.writeFileSync(path.join(homeDir, '.instar', 'autonomous-emergency-stop'), '');
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     INSTAR_HOOK_TMUX_SESSION: opts.tmuxSession,
@@ -69,7 +70,7 @@ function runHook(opts: { codex: boolean; tmuxSession: string }): { exitCode: num
   } catch {
     decision = null;
   }
-  return { exitCode, decision };
+  return { exitCode, decision, stdout };
 }
 
 beforeEach(() => {
@@ -108,5 +109,26 @@ describe('autonomous stop hook — codex dark-launch gate (#28)', () => {
     writeConfig(false); // flag off must NOT suppress the Claude loop
     const r = runHook({ codex: false, tmuxSession: 'echo-codey' });
     expect(r.decision).toBe('block');
+  });
+
+  // Regression (live 2026-05-31): with the flag ON, a codex APPROVE path (here emergency
+  // stop) used to `echo` plain text to stdout — codex rejects any non-JSON stdout as
+  // "invalid stop hook JSON output" and logs the stop hook as FAILED. The fix routes those
+  // messages to stderr in codex mode (emit()). Stdout must be empty or valid JSON only.
+  it('ENABLED codex approve-path emits NO non-JSON to stdout (regression: invalid stop hook JSON)', () => {
+    writeActiveJob('13435', 'echo-codey');
+    writeConfig(true);
+    const r = runHook({ codex: true, tmuxSession: 'echo-codey', emergencyStop: true });
+    expect(r.decision).toBeNull(); // approves the stop (not a block)
+    const out = r.stdout.trim();
+    if (out.length > 0) expect(() => JSON.parse(out)).not.toThrow(); // only JSON allowed on stdout
+    expect(out).not.toMatch(/Autonomous mode: Emergency stop/); // the old plain-text leak is gone
+  });
+
+  it('Claude approve-path STILL writes the human message to stdout (emit() preserves Claude behavior)', () => {
+    writeActiveJob('13435', 'echo-codey');
+    writeConfig(false);
+    const r = runHook({ codex: false, tmuxSession: 'echo-codey', emergencyStop: true });
+    expect(r.stdout).toMatch(/Emergency stop detected/); // Claude surfaces approve stdout to the user
   });
 });

--- a/tests/unit/autonomous-stop-hook-notify.test.ts
+++ b/tests/unit/autonomous-stop-hook-notify.test.ts
@@ -175,10 +175,12 @@ describe('Layer A — existing agents receive the notify-enabled hook (migration
 
   it('uses the latest-capability marker for the autonomous-stop-hook migration', () => {
     // The marker is bumped each time the bundled hook gains a feature, so prior installs
-    // re-deploy. It advanced from `notify_terminal_stop` → `CODEX_LOOP_ENABLED` when the
-    // #28 codex autonomous-loop driver landed (the bundled hook still contains
-    // notify_terminal_stop — asserted above — so that capability is not lost on upgrade).
+    // re-deploy. It advanced `notify_terminal_stop` → `CODEX_LOOP_ENABLED` (#28 codex
+    // autonomous-loop driver) → `codex-stdout-json-safe` (the codex Stop hook must keep
+    // stdout JSON-only; the prior marker is already present in #28 installs so it would
+    // wrongly skip them). The bundled hook still contains notify_terminal_stop — asserted
+    // above — so that capability is not lost on upgrade.
     const src = fs.readFileSync(path.join(REPO_ROOT, 'src', 'core', 'PostUpdateMigrator.ts'), 'utf8');
-    expect(src).toMatch(/upgrade\(\s*'\.claude\/skills\/autonomous\/hooks\/autonomous-stop-hook\.sh',\s*'CODEX_LOOP_ENABLED'/);
+    expect(src).toMatch(/upgrade\(\s*'\.claude\/skills\/autonomous\/hooks\/autonomous-stop-hook\.sh',\s*'codex-stdout-json-safe'/);
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,54 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13435; live-test-found bug blocking #28 enablement — Justin watching)
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — codex autonomous-loop Stop hook no longer fails on approve (stdout must be JSON)
+
+Live-test finding (2026-05-31): when the codex autonomous-loop driver (#28) flag is on and a
+codex session reaches a terminal stop (e.g. it finished the task and met its completion
+promise), the shared `autonomous-stop-hook.sh` printed a human-readable approve message
+("✅ Autonomous mode: Completion promise detected…") to **stdout**. Codex treats ANY non-JSON
+on a Stop hook's stdout as a failure and logged "Stop hook (failed) — invalid stop hook JSON
+output" on every such stop. The unit test missed it because it only exercised the flag-on path
+WITH an active job that BLOCKS (the one path that legitimately prints JSON) — never an
+approve/exit path.
+
+The fix: in codex mode the hook routes all human-facing approve/status text to **stderr**
+(new `emit()` helper); the only thing it ever writes to stdout is the `{"decision":"block"…}`
+JSON. Claude behavior is unchanged (it still surfaces those messages on stdout to the user).
+
+## Summary of New Capabilities
+
+- `emit()` in `autonomous-stop-hook.sh`: codex mode → stderr, Claude mode → stdout. Applied to
+  the duration-expired, emergency-stop, completion-condition, and completion-promise approve
+  paths (the 4 places that wrote plain text to stdout).
+- Migration marker bumped `CODEX_LOOP_ENABLED` → `codex-stdout-json-safe` so existing #28
+  installs (which already carry `CODEX_LOOP_ENABLED`) re-deploy the FIXED hook. Customized
+  hooks (no stock fingerprint) are still left untouched.
+
+## What to Tell Your User
+
+If you run a codex agent with the autonomous-loop driver turned on, it will no longer log a
+failed Stop hook when a run finishes — the hook now keeps its codex output strictly to the
+machine-readable form codex expects. Nothing to configure.
+
+## Evidence
+
+- Repro (live): a codex session completed a 3-step task, hit its completion promise, and the
+  pane showed "Stop hook (failed) — error: hook returned invalid stop hook JSON output".
+- Fix: `emit()` routes approve/status text to stderr in codex mode; stdout carries only the
+  block-decision JSON.
+- Regression test: `tests/unit/autonomous-stop-hook-codex-gate.test.ts` — codex approve-path
+  (emergency stop) emits NO non-JSON to stdout; Claude approve-path STILL writes it to stdout
+  (both sides; 6 tests pass).
+- Migration parity: `tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts` (7 tests pass);
+  marker bump re-deploys the fixed hook to existing codex agents.
+- `tsc --noEmit` + `npm run lint` clean.
+- Spec: `docs/specs/codex-stop-hook-stdout-json-safe.md` (+ `.eli16.md`).
+- Side-effects: `upgrades/side-effects/codex-stop-hook-stdout-json-safe.md`.

--- a/upgrades/side-effects/codex-stop-hook-stdout-json-safe.md
+++ b/upgrades/side-effects/codex-stop-hook-stdout-json-safe.md
@@ -1,0 +1,40 @@
+# Side-effects — codex Stop hook stdout JSON-safe (emit())
+
+## 1. What files/state does this change touch at runtime?
+The shared `.claude/skills/autonomous/hooks/autonomous-stop-hook.sh` (a built-in skill hook).
+On update, `migrateAutonomousStopHookTopicKeyed` re-writes the deployed copy for stock agents.
+No config keys, no new files, no new state.
+
+## 2. Does it change any decision (block vs approve)?
+No. The hook's keep-going-vs-stop logic is untouched. Only the CHANNEL of human-facing
+approve/status text changes, and only in codex mode (stdout → stderr). The block-decision JSON
+is unchanged and still on stdout.
+
+## 3. Does it affect the Claude path?
+No — Claude behavior is byte-for-byte preserved (approve messages still print to stdout). A
+dedicated test asserts the Claude approve-path still writes "Emergency stop detected" to stdout.
+
+## 4. Migration parity — do existing agents get it?
+Yes — that's the point. The marker is bumped `CODEX_LOOP_ENABLED` → `codex-stdout-json-safe`,
+so every existing #28 install re-deploys the fixed hook on its next update (the old marker
+would have skipped them since they already carry it). Customized hooks (no stock fingerprint)
+are left untouched. Idempotent (re-running sees the new marker → skips). Covered by 7 migration
+tests.
+
+## 5. Could it spam / flood / burn resources?
+No. The change is a stdout→stderr redirect of a few echo lines in approve paths. No loops, no
+network, no new process, no message send.
+
+## 6. Rollback / off-switch?
+The #28 driver itself remains flag-gated (`autonomousSessions.codexLoopDriver`, default off) —
+this fix just makes the hook safe to run when that flag IS on. Reverting this PR restores the
+prior hook (and the bug); no residual state. The fix is inert for Claude agents and for codex
+agents with the flag off (they hit the early `exit 0` dark-gate before any approve path).
+
+## 7. Concurrency / ordering?
+None — the hook is a short-lived per-stop process; no shared state introduced.
+
+## Blast radius
+Minimal + targeted. One built-in hook script (4 approve paths: stdout→stderr in codex mode) +
+one migration-marker bump + test coverage. No runtime route, sentinel, schema, or decision
+path changes. Unblocks safe enablement of the already-shipped (dark) #28 driver.


### PR DESCRIPTION
## Why — found by a LIVE test, not a unit test
Driving Codey through a real autonomous task over Telegram (the mentorship loop), the codex pane showed `Stop hook (failed) — error: hook returned invalid stop hook JSON output` on the terminal stop. Cause: with the #28 `codexLoopDriver` flag on, the shared `autonomous-stop-hook.sh` echoed a human-readable approve message (`✅ Autonomous mode: Completion promise detected…`) to **stdout**. Codex rejects ANY non-JSON on a Stop hook's stdout. The unit test missed it because it only exercised flag-on WITH an active job that BLOCKS (the one path that legitimately emits JSON), never an approve/exit path. **This blocked safe enablement of #28.**

## Fix
- New `emit()` helper: codex mode → **stderr**, Claude mode → **stdout** (unchanged). Applied to the 4 approve paths (duration-expired, emergency-stop, completion-condition, completion-promise). stdout now only ever carries the `{"decision":"block",…}` JSON.
- **Migration parity:** marker bumped `CODEX_LOOP_ENABLED` → `codex-stdout-json-safe` so existing #28 installs (which already carry the old marker) re-deploy the FIXED hook; customized hooks untouched.

## Tests (both sides of the boundary)
- `autonomous-stop-hook-codex-gate.test.ts`: codex approve-path emits NO non-JSON to stdout (regression); Claude approve-path STILL writes it to stdout; 4 pre-existing gate cases stay green → **6 pass**.
- `PostUpdateMigrator-autonomousStopHook.test.ts`: **7 pass** (marker bump re-deploys).
- `tsc --noEmit` + `npm run lint` clean. Spec + ELI16 + side-effects + trace.

Claude path byte-for-byte unchanged; no decision logic touched (only the stdout/stderr channel for codex approve text). Unblocks the (still-dark, flag-gated) #28 driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)