### PR TITLE
test(conformance): add codex adapter to OneShotCompletion conformance

### DIFF
--- a/tests/integration/conformance/oneShotCompletion.conformance.test.ts
+++ b/tests/integration/conformance/oneShotCompletion.conformance.test.ts
@@ -24,6 +24,7 @@
 import { describe, it, expect } from 'vitest';
 import { createAnthropicHeadlessAdapter } from '../../../src/providers/adapters/anthropic-headless/index.js';
 import { createAnthropicInteractivePoolAdapter } from '../../../src/providers/adapters/anthropic-interactive-pool/index.js';
+import { createOpenAiCodexAdapter } from '../../../src/providers/adapters/openai-codex/index.js';
 import { CapabilityFlag } from '../../../src/providers/capabilities.js';
 import type { OneShotCompletion } from '../../../src/providers/primitives/transport/oneShotCompletion.js';
 
@@ -48,6 +49,13 @@ const ADAPTERS: AdapterUnderTest[] = [
   {
     id: 'anthropic-interactive-pool',
     factory: () => createAnthropicInteractivePoolAdapter({ poolSize: 1, canaryIntervalMs: 0 }),
+  },
+  {
+    // Codex declares OneShotCompletion (capabilities.ts) but was absent from this harness —
+    // a parity-coverage gap from the 2026-05-31 audit. Contract-shape conformance runs the
+    // same assertions against codex; the realApi behavior case stays opt-in.
+    id: 'openai-codex',
+    factory: () => createOpenAiCodexAdapter(),
   },
 ];
 

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,38 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13435; codex parity-coverage from the audit)
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — codex adapter added to the OneShotCompletion conformance harness
+
+The OneShotCompletion conformance suite ran only the two Anthropic adapters, even though the
+codex adapter declares `OneShotCompletion` (capabilities.ts). That parity-coverage gap was
+logged in the 2026-05-31 audit. This adds `openai-codex` to the harness so the same
+contract-shape assertions (declares the capability, returns a primitive with the matching
+marker, exposes `evaluate` as a function) run against codex too. Codex passes — confirming its
+OneShotCompletion primitive is wired correctly — and is now guarded against drift.
+
+## Summary of New Capabilities
+
+- `tests/integration/conformance/oneShotCompletion.conformance.test.ts` now enumerates
+  `openai-codex` alongside the Anthropic adapters. The real-API behavior case stays opt-in
+  (`INSTAR_REAL_API=1`); the contract-shape cases run always.
+- Test-only; no runtime/src change.
+
+## What to Tell Your User
+
+Nothing user-facing — internal test coverage that keeps the codex adapter's one-shot-completion
+contract honest as the code evolves.
+
+## Evidence
+
+- `npx vitest run tests/integration/conformance/oneShotCompletion.conformance.test.ts` →
+  9 passed / 6 skipped (realApi), codex contract-shape green.
+- `tsc --noEmit` + `npm run lint` clean.
+- Narrows the logged finding `conformance-framework-mostly-unwired-codex-omitted` (the
+  oneShotCompletion-omits-codex half).


### PR DESCRIPTION
From the 2026-05-31 codex parity audit (directive #1): the `oneShotCompletion.conformance.test.ts` harness ran only the two Anthropic adapters, even though `openai-codex` declares `OneShotCompletion`. This adds codex to the harness so the contract-shape assertions (declares capability / primitive carries the marker / `evaluate` is callable) run against it too. **Codex passes** — confirms the primitive is wired + guards against drift. realApi behavior case stays opt-in. Test-only.

Narrows the logged ledger finding `conformance-framework-mostly-unwired-codex-omitted` (the oneShotCompletion-omits-codex half; #600 closed the observability-reader half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)