### PR TITLE
fix(perf): exclude agent node_modules from macOS Spotlight (top idle-CPU source)

### DIFF
--- a/docs/specs/node-modules-spotlight-exclusion.eli16.md
+++ b/docs/specs/node-modules-spotlight-exclusion.eli16.md
@@ -1,0 +1,45 @@
+# Explain it like I'm 16: stop Spotlight from chewing on node_modules
+
+## The setup
+
+On a Mac, there's a built-in search system called Spotlight. It quietly reads every file on
+your disk and builds an index so you can search them later. Whenever files change, it re-reads
+them to keep the index fresh.
+
+Each of our AI agents lives in its own folder, and inside each one is a `node_modules` folder —
+that's where all the downloaded code libraries go. It's HUGE: on one agent it was 1.3 gigabytes
+and about 25,000 files. And there's a second copy (the "shadow install") that's another ~600
+megabytes. We run about ten agents. So that's roughly 20 gigabytes of library files.
+
+## The problem
+
+Those library folders change a LOT — every time an agent updates itself or reinstalls its
+dependencies. And every time they change, Spotlight wakes up and re-reads all 20 gigabytes to
+update its search index. We measured it: the Mac's two busiest programs were Spotlight's
+indexer and a media-analysis helper — together eating more CPU than any of our actual agents.
+That's wasted work slowing down the whole machine (and a loaded machine is part of why other
+things were struggling).
+
+Here's the kicker: you would NEVER search inside node_modules. It's machine-generated build
+junk. So all that indexing is 100% pointless.
+
+## The fix
+
+Mac has an official "please don't index this folder" signal: you drop an empty file named
+`.metadata_never_index` inside the folder, and Spotlight skips it. We already did this for one
+kind of folder (throwaway "worktrees"), but we'd never done it for the big node_modules folders.
+
+So this change teaches each agent to drop that little marker file into its `node_modules` and
+its shadow-install copy, automatically, every time it updates. Spotlight then leaves those
+folders alone forever, and stops burning CPU re-reading 20 gigabytes of library files nobody
+searches.
+
+## Why it's safe
+
+The marker file does exactly one thing: tell Spotlight "skip me." It doesn't touch how the code
+runs, how files are read, or how anything builds — node_modules works exactly the same, it's
+just not in the search index anymore (which you never wanted it to be). On a non-Mac it does
+nothing at all. And if for some reason we can't write the marker, we just shrug and move on —
+the worst case is Spotlight keeps indexing like before. There's no way for this to break
+anything; we also already applied it by hand across the live machine to get the relief now, and
+this makes it permanent and automatic.

--- a/docs/specs/node-modules-spotlight-exclusion.md
+++ b/docs/specs/node-modules-spotlight-exclusion.md
@@ -1,0 +1,57 @@
+---
+title: Exclude agent node_modules from macOS Spotlight (idle-CPU hygiene)
+slug: node-modules-spotlight-exclusion
+status: approved
+review-convergence: 2026-05-31T06:00:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h autonomous deploy mandate (topic 13435).
+  Directly serves the foundational mandate task: "treat the degraded/rate-limit signal as a
+  SUSPECTED Instar bug — load points to bugs." Live profiling identified macOS Spotlight
+  re-indexing un-excluded agent node_modules as a top OS-level CPU consumer (the box's #1/#2
+  CPU users were Metadata.framework + mediaanalysisd, not instar processes). node_modules
+  exclusion is unambiguously correct hygiene (build deps never need indexing), so the change is
+  safe + low-risk; it mirrors the already-shipped worktree exclusion.
+second-pass-required: false
+second-pass-status: n/a-os-hygiene-additive
+---
+
+# Exclude agent node_modules from macOS Spotlight
+
+## Problem
+
+macOS Spotlight (`mds_stores` / `Metadata.framework`) and `mediaanalysisd` re-index file trees
+on change. Each instar agent home carries a full `node_modules/` (~1.3GB / ~25k files measured
+on echo) AND a `.instar/shadow-install/node_modules/` (~600MB). These churn constantly — every
+`npm ci` in a dev checkout, every shadow-install update during auto-update. Across a ~10-agent
+fleet that is ~20GB of node_modules being continually re-indexed, measured live as
+`Metadata.framework` ~62% CPU + `mediaanalysisd` ~52% (the box's top two CPU consumers, above
+every instar process). instar already excludes `.worktrees/` (the prior top consumer under a
+worktree backlog) but never excluded the agent-home / shadow-install node_modules.
+
+## Design
+
+Add `PostUpdateMigrator.migrateNodeModulesSpotlightExclusion`, wired into `run()` immediately
+after `migrateWorktreeSpotlightExclusion`. It drops a `.metadata_never_index` marker at:
+- `<agentHome>/node_modules`
+- `<stateDir>/shadow-install/node_modules`
+
+It reuses the existing generic marker-dropper `ensureWorktreeSpotlightExclusion(dir)` (the
+function is dir-agnostic — it just creates the marker if absent and returns whether it did).
+Missing dirs are skipped silently; each created marker is reported in `result.upgraded`; the
+pass is idempotent (a present marker → no re-report, no error). Runs on every update, so
+existing agents are backfilled.
+
+## Safety
+- `.metadata_never_index` is a Spotlight-only hint — it changes nothing functional (no effect
+  on file access, module resolution, or builds). node_modules never need to be searchable, so
+  excluding them is unambiguously correct (not a tradeoff).
+- Honored recursively, harmless no-op on non-macOS, idempotent, best-effort (a write failure is
+  swallowed by the helper — it must never block the migration).
+- Worst case: Spotlight keeps indexing (the prior behavior). No regression is possible.
+
+## Test plan
+- Unit (`worktree-spotlight-exclusion.test.ts`, extended): the migration drops the marker into
+  agent-home node_modules AND shadow-install on update; skips missing node_modules dirs without
+  error; idempotent (second run does not re-report). The existing worktree cases stay green.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -229,6 +229,7 @@ export class PostUpdateMigrator {
     this.migrateConversationalCatalogPlaybookManifest(result);
     this.migrateWorktreeConvention(result);
     this.migrateWorktreeSpotlightExclusion(result);
+    this.migrateNodeModulesSpotlightExclusion(result);
     this.migrateBootWrapperToCjs(result);
     this.migrateBootWrapperAbiCheck(result);
     this.migrateStaleLifelineSignal(result);
@@ -720,6 +721,38 @@ export class PostUpdateMigrator {
       }
     } catch (err) {
       result.errors.push(`worktree-spotlight-exclusion: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /**
+   * OS resource hygiene (Responsible Resource Usage standard): exclude the agent's
+   * node_modules trees from macOS Spotlight. The worktree exclusion above covers
+   * `.worktrees/`, but the bigger churning set was never excluded — each agent home
+   * carries a full `node_modules/` (~1.3GB / ~25k files measured) AND a
+   * `.instar/shadow-install/node_modules/` (~600MB), re-indexed by Spotlight /
+   * mediaanalysisd on every `npm ci` and every shadow-install update. Across a
+   * ~10-agent fleet that is ~20GB of un-excluded node_modules — a top OS-level CPU
+   * consumer (measured: Metadata.framework ~62% CPU). node_modules never need
+   * Spotlight indexing, so the marker is unambiguously safe; it is honored
+   * recursively, harmless on non-macOS, and idempotent. Reuses the generic
+   * marker-dropper. (`ensureWorktreeSpotlightExclusion` is dir-agnostic.)
+   */
+  private migrateNodeModulesSpotlightExclusion(result: MigrationResult): void {
+    const agentHome = path.dirname(this.config.stateDir);
+    const dirs = [
+      path.join(agentHome, 'node_modules'),
+      path.join(this.config.stateDir, 'shadow-install', 'node_modules'),
+    ];
+    for (const dir of dirs) {
+      if (!fs.existsSync(dir)) continue;
+      try {
+        if (ensureWorktreeSpotlightExclusion(dir)) {
+          const rel = path.relative(agentHome, dir) || dir;
+          result.upgraded.push(`node-modules-spotlight-exclusion: dropped .metadata_never_index at ${rel} (excludes node_modules from Spotlight indexing)`);
+        }
+      } catch (err) {
+        result.errors.push(`node-modules-spotlight-exclusion: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
 

--- a/tests/unit/worktree-spotlight-exclusion.test.ts
+++ b/tests/unit/worktree-spotlight-exclusion.test.ts
@@ -101,3 +101,44 @@ describe('PostUpdateMigrator.migrateWorktreeSpotlightExclusion', () => {
     expect(result2.skipped.some((s) => s.includes('worktree-spotlight-exclusion: marker already present'))).toBe(true);
   });
 });
+
+describe('PostUpdateMigrator.migrateNodeModulesSpotlightExclusion', () => {
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nm-spotlight-mig-'));
+    setHome(tmpHome);
+    originalAuditDir = process.env.INSTAR_AUDIT_LOG_DIR;
+    process.env.INSTAR_AUDIT_LOG_DIR = path.join(tmpHome, 'audit');
+  });
+  afterEach(() => {
+    if (originalAuditDir === undefined) delete process.env.INSTAR_AUDIT_LOG_DIR;
+    else process.env.INSTAR_AUDIT_LOG_DIR = originalAuditDir;
+    restoreHome();
+    SafeFsExecutor.safeRmSync(tmpHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100, operation: OP });
+  });
+
+  it('drops the marker into agent-home node_modules AND shadow-install on update', () => {
+    const { agentHome, stateDir } = setupAgentHome('echo-nm');
+    fs.mkdirSync(path.join(agentHome, 'node_modules'), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, 'shadow-install', 'node_modules'), { recursive: true });
+    const result = makeMigrator(stateDir).migrate();
+    expect(result.upgraded.some((s) => s.includes('node-modules-spotlight-exclusion'))).toBe(true);
+    expect(fs.existsSync(path.join(agentHome, 'node_modules', '.metadata_never_index'))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir, 'shadow-install', 'node_modules', '.metadata_never_index'))).toBe(true);
+  });
+
+  it('skips missing node_modules dirs without error (no node_modules present)', () => {
+    const { stateDir } = setupAgentHome('echo-nm-none');
+    const result = makeMigrator(stateDir).migrate();
+    expect(result.errors).toEqual([]);
+    expect(result.upgraded.some((s) => s.includes('node-modules-spotlight-exclusion'))).toBe(false);
+  });
+
+  it('is idempotent — second run does not re-report the exclusion', () => {
+    const { agentHome, stateDir } = setupAgentHome('echo-nm-idem');
+    fs.mkdirSync(path.join(agentHome, 'node_modules'), { recursive: true });
+    makeMigrator(stateDir).migrate();
+    const result2 = makeMigrator(stateDir).migrate();
+    expect(result2.errors).toEqual([]);
+    expect(result2.upgraded.some((s) => s.includes('node-modules-spotlight-exclusion'))).toBe(false);
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,51 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13435; load/CPU root — Justin: treat load as a suspected Instar bug)
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — exclude agent node_modules from macOS Spotlight (a top idle-CPU source)
+
+Live profiling on the dev box (2026-05-31) found macOS Spotlight (`Metadata.framework`) +
+`mediaanalysisd` as the top CPU consumers (~62% / ~52%), not instar's own processes. Instar
+already drops a `.metadata_never_index` marker at the `.worktrees/` container, but the **bigger
+churning set was never excluded**: each agent home carries a full `node_modules/` (~1.3GB /
+~25k files measured) AND a `.instar/shadow-install/node_modules/` (~600MB), which Spotlight
+re-indexes on every `npm ci` and every shadow-install update. Across a ~10-agent fleet that is
+~20GB of un-excluded node_modules being continually re-indexed.
+
+This adds a `PostUpdateMigrator` pass that drops the `.metadata_never_index` marker into the
+agent's `node_modules/` and `shadow-install/node_modules/` (mirroring the worktree exclusion),
+so existing agents get the relief on their next update. node_modules never need Spotlight
+indexing, so the marker is unambiguously safe, honored recursively, harmless on non-macOS, and
+idempotent.
+
+## Summary of New Capabilities
+
+- `PostUpdateMigrator.migrateNodeModulesSpotlightExclusion` — drops `.metadata_never_index` at
+  `<agentHome>/node_modules` and `<stateDir>/shadow-install/node_modules` (skips missing dirs,
+  reuses the existing generic marker-dropper, reports per dir, idempotent).
+- Wired into the migration `run()` sequence right after the worktree exclusion.
+
+## What to Tell Your User
+
+On macOS, your agent will stop letting Spotlight re-index its node_modules folders — those are
+build dependencies that never need to be searchable, and re-indexing them was a real background
+CPU drain. Nothing to configure; it applies on the next update.
+
+## Evidence
+
+- Live: `ps` showed `Metadata.framework` ~62% CPU; agent node_modules (echo) = 1.3GB / 24,592
+  files + 635MB shadow-install, none carrying the exclusion marker (worktrees did).
+- Unit: `tests/unit/worktree-spotlight-exclusion.test.ts` — new cases: drops the marker into
+  agent-home node_modules AND shadow-install on update; skips missing dirs without error;
+  idempotent (8 tests pass).
+- Immediate operational mitigation already applied across the live fleet (43 node_modules dirs
+  marked); this migration makes it permanent + automatic for all agents.
+- `tsc --noEmit` + `npm run lint` clean.
+- Spec: `docs/specs/node-modules-spotlight-exclusion.md` (+ `.eli16.md`).
+- Side-effects: `upgrades/side-effects/node-modules-spotlight-exclusion.md`.

--- a/upgrades/side-effects/node-modules-spotlight-exclusion.md
+++ b/upgrades/side-effects/node-modules-spotlight-exclusion.md
@@ -1,0 +1,38 @@
+# Side-effects — node_modules Spotlight exclusion
+
+## 1. What files/state does this touch at runtime?
+Drops one empty `.metadata_never_index` file into `<agentHome>/node_modules` and
+`<stateDir>/shadow-install/node_modules` (if they exist) during the PostUpdateMigrator pass.
+No other files, no config keys, no schema.
+
+## 2. Does it change any functional behavior?
+No. `.metadata_never_index` is a macOS Spotlight hint only — it has zero effect on file access,
+Node module resolution, builds, or any instar logic. It just tells Spotlight not to index the
+folder (which is correct — node_modules is never searched).
+
+## 3. What happens on failure / unwritable path / non-macOS?
+Best-effort: the shared helper swallows write failures (`@silent-fallback-ok`) and returns
+false, so the migration never errors or blocks on it. On non-macOS the file is inert.
+
+## 4. Migration parity — do existing agents get it?
+Yes — it's a PostUpdateMigrator pass that runs on every update, so existing agents are
+backfilled on their next update. Idempotent (present marker → no-op, no re-report). New agents'
+node_modules get marked the first time the migrator runs post-init.
+
+## 5. Could it spam / flood / burn resources?
+The opposite — it REDUCES resource use (stops Spotlight re-indexing ~20GB of node_modules
+fleet-wide). The migration itself does at most two `existsSync` + two `writeFileSync` per agent
+per update. No loop, no network, no process spawn.
+
+## 6. Rollback / off-switch?
+Reverting the PR stops new markers being added; existing markers are harmless and can be left
+(or removed with `find ... -name .metadata_never_index -delete` to re-enable indexing). No
+residual state, no flag needed.
+
+## 7. Concurrency / ordering?
+None — runs inline in the single-threaded migration sequence after the worktree exclusion.
+
+## Blast radius
+Minimal + additive. One new PostUpdateMigrator method + its run() wiring + test coverage.
+Mirrors the already-shipped worktree exclusion. No change to any route, sentinel, schema, or
+decision path. Pure OS-hygiene win addressing the measured top idle-CPU source.


### PR DESCRIPTION
## Why — load profiling (mandate task #1: treat load as a suspected bug)
Live `ps` on the dev box: the top CPU consumers were macOS **Spotlight `Metadata.framework` (~62%)** + **`mediaanalysisd` (~52%)** — above every instar process. Instar already excludes `.worktrees/` from Spotlight, but never the **agent-home node_modules** (~1.3GB / ~25k files measured) or **`.instar/shadow-install/node_modules`** (~600MB). Those churn on every `npm ci` / shadow-install update → Spotlight re-indexes ~20GB of node_modules fleet-wide.

## What
`PostUpdateMigrator.migrateNodeModulesSpotlightExclusion` (wired right after the worktree exclusion): drops `.metadata_never_index` into `<agentHome>/node_modules` and `<stateDir>/shadow-install/node_modules`. Reuses the existing generic marker-dropper; skips missing dirs; idempotent; best-effort; non-macOS no-op. Existing agents backfilled on update. **node_modules never need indexing → unambiguously safe, no functional change.**

The operational mitigation is already applied live (43 node_modules dirs marked across the fleet); this makes it permanent + automatic.

## Tests
- `worktree-spotlight-exclusion.test.ts` extended: drops marker into agent-home node_modules AND shadow-install / skips-missing-without-error / idempotent — 8 pass (worktree cases stay green).
- `tsc --noEmit` + `npm run lint` clean. Spec + ELI16 + side-effects + trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)