### PR TITLE
fix(hooks): scope-coherence Stop hook codex stdout-safe (empty=allow) — live-found on Codey

### DIFF
--- a/docs/specs/codex-scope-coherence-stdout-safe.eli16.md
+++ b/docs/specs/codex-scope-coherence-stdout-safe.eli16.md
@@ -1,0 +1,54 @@
+# Explain it like I'm 16: stop the scope-check hook from confusing Codex
+
+## The setup
+
+When an AI agent finishes responding, little programs called "Stop hooks" run.
+One of ours, the "scope-coherence checkpoint," watches whether the agent has been
+heads-down coding for a long time without stepping back to look at the big picture.
+If so, it gently interrupts ("hey, zoom out, re-read the spec"). If not, it just
+says "all good, carry on."
+
+Each hook talks back to the agent runtime by printing something. There are two
+runtimes: Claude and Codex (OpenAI's). They have slightly different rules for what a
+Stop hook is allowed to print.
+
+## The problem
+
+Our scope-check hook, when it decides "all good, carry on," printed a little
+message: `{"decision":"approve"}`. Claude is fine with that — it reads it as "okay,
+allow." But **Codex has a stricter rule**: to interrupt, print
+`{"decision":"block"}`; to allow, print **nothing at all**. Printing
+`{"decision":"approve"}` isn't on Codex's menu, so Codex throws an error every time:
+"invalid stop hook JSON output."
+
+We caught this live: while test-driving our Codex agent "Codey," it finished a task
+perfectly and sent its reply — and then that error popped up right after. The reply
+went out fine (so nothing actually broke), but the error showed up on *every* Codex
+session completion. Annoying and wrong.
+
+## The fix
+
+Teach the hook the universal rule: **to allow, print nothing.** We removed the
+`{"decision":"approve"}` print on all the "carry on" paths, leaving them to just
+exit quietly. The "interrupt" path still prints `{"decision":"block", ...}` exactly
+as before, because both Claude and Codex understand that one.
+
+The neat part: printing nothing means "allow" on **both** runtimes. So for Claude
+this is a zero-change (empty and "approve" mean the same thing there), and for Codex
+it makes the error disappear. It's the same convention we already applied to another
+hook (the autonomous-loop one) a couple of fixes ago.
+
+## Why it's safe
+
+The scope-check's actual job — interrupting when you've been coding too long without
+zooming out — is untouched; that path still prints its block message. We only
+changed the "do nothing, allow" paths to literally do nothing. And because every
+agent rewrites this hook from our source on its next update, the fix reaches all of
+them automatically, including Codey.
+
+## How we know it works
+
+Tests confirm: the "allow" paths now print empty (and exit cleanly), the generated
+hook contains no `approve` message anywhere, and it still keeps the `block` message
+for the real interrupt. 28 related hook tests pass. Final proof comes from
+re-driving Codey after it updates and seeing the error gone.

--- a/docs/specs/codex-scope-coherence-stdout-safe.md
+++ b/docs/specs/codex-scope-coherence-stdout-safe.md
@@ -1,0 +1,88 @@
+---
+title: scope-coherence-checkpoint Stop hook — codex stdout-safe (empty=allow)
+slug: codex-scope-coherence-stdout-safe
+date: 2026-05-31
+author: echo
+status: approved
+review-convergence: internal-plus-second-pass-2026-05-31
+approved: true
+approved-by: echo (standing 12h autonomous deploy mandate, topic 13435)
+approval-note: >
+  Self-approved under the standing deploy mandate. LIVE-FOUND while driving Codey
+  over Telegram (the mentorship loop): after Codey completed a single-turn task and
+  sent its reply, its codex session reported "Stop hook (failed) — invalid stop
+  hook JSON output". Root-caused to scope-coherence-checkpoint.js emitting
+  {decision:'approve'} on its allow paths; codex's Stop-hook contract is empty=allow
+  (only {decision:'block',...} is a valid emission). Byte-equivalent for Claude
+  (empty == approve), so zero behavior change there; fixes codex. Sibling of #604.
+second-pass-required: false
+second-pass-status: n/a-codex-stdout-convention-mirrors-604
+eli16-overview: codex-scope-coherence-stdout-safe.eli16.md
+---
+
+# scope-coherence-checkpoint — codex stdout-safe
+
+## Background — found by the live mentorship drive
+
+Driving Codey (a codex agent) over Telegram with a real task, Codey completed it
+and **sent its reply successfully**, then its codex session printed: `Stop hook
+(failed) error: hook returned invalid stop hook JSON output`. Codey's Stop chain is
+five instar hooks. Auditing each: `stop-gate-router`, `response-review`, and
+`claim-intercept-response` write to stdout **only on a block decision** (codex-safe);
+the autonomous-stop-hook was already fixed in #604. The remaining culprit is
+**`scope-coherence-checkpoint.js`**, which writes `{decision:'approve'}` to stdout
+on *every allow path*.
+
+## Root cause
+
+codex's Stop-hook contract: **empty stdout = allow**; a recognized **`{decision:
+'block',...}`** = block; anything else non-empty (including `{decision:'approve'}`)
+is rejected as "invalid stop hook JSON output". Claude Code tolerates an explicit
+`{decision:'approve'}` (treats it as allow, same as empty). So the hook worked on
+Claude but tripped the error on every codex session completion. The reply itself is
+sent *before* the Stop hook runs, so impact is cosmetic (no lost work) — but every
+codex session completion emits the error. This is the exact convention #604
+established for the autonomous-stop-hook (it moved approve-path output off stdout).
+
+## Design
+
+In `PostUpdateMigrator.getScopeCoherenceCheckpointHook()` (the source-of-truth that
+generates `.instar/hooks/instar/scope-coherence-checkpoint.js`), change every allow
+path to **emit nothing** (`process.exit(0)` with empty stdout) instead of
+`process.stdout.write(JSON.stringify({decision:'approve'}))`. The BLOCK path
+(`{decision:'block', reason}`) — the actual scope-checkpoint feature — is unchanged
+(codex accepts block decisions). Five try-block allow paths + the catch-all error
+path are emptied.
+
+- **Claude:** byte-equivalent — empty stdout == approve. The re-entry guard
+  (`stop_hook_active`) still allows immediately (never re-blocks a continuation);
+  the headless/job, depth, cooldown, and min-age short-circuits all still allow.
+- **codex:** empty stdout = allow, so no more invalid-JSON error.
+
+## Migration parity
+
+`scope-coherence-checkpoint.js` is in the **always-overwrite** built-in-hook list
+(`PostUpdateMigrator` rewrites it on every update run). So fixing the generator
+method auto-redeploys the corrected hook to every agent (incl. instar-codey) on its
+next update — no marker or sniff needed.
+
+## Scope note (not in this PR)
+
+A separate hook just above `getScopeCoherenceCheckpointHook` also emits
+`{decision:'approve'}` on stdout, and several other hooks emit `{decision:'approve',
+additionalContext:...}` (signal hooks). Those need the same codex-stdout treatment
+(the additionalContext ones require a codex-appropriate context-injection path, not
+just emptying) — tracked under the #32 parity audit / ledger issue
+`codex-stop-chain-multi-json-invalid`. This PR fixes the **confirmed Stop-chain
+culprit** observed live on Codey.
+
+## Test plan
+- Unit (`tests/unit/scope-coherence-reentry.test.ts`, extended):
+  - re-entry continuation (`stop_hook_active=true`) → exit 0 + **empty stdout**.
+  - fresh Stop below depth threshold → exit 0 + **empty stdout**.
+  - the generated hook source contains **no** `{decision:'approve'}` and **keeps**
+    `{decision:'block'}` (codex contract: empty=allow, block-JSON=block).
+- Regression: PostUpdateMigrator-buildStopHook + migration-parity-hooks +
+  installCodexHooks suites stay green (28 tests).
+- Verification (post-deploy): re-drive Codey once it's updated and confirm the
+  "invalid stop hook JSON output" error is gone.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -7554,14 +7554,17 @@ function fetchActiveJob() {
   } catch { process.exit(0); }
 
   try {
-    // Re-entry guard: if this Stop is a correction continuation (stop_hook_active),
-    // approve immediately — never re-block a continuation. Without this, a block →
-    // continue → still-deep → block loop could wedge an autonomous session (the cooldown
-    // mitigates but does not strictly prevent it). Mirrors claim-intercept-response.
+    // ALLOW = empty stdout + exit 0. We deliberately do NOT emit
+    // {decision:'approve'} on the allow paths: codex's Stop-hook contract treats
+    // any non-empty stdout that isn't a recognized block decision as invalid
+    // ('hook returned invalid stop hook JSON output'), so an explicit approve-JSON
+    // breaks every codex session completion. Claude treats empty == approve, so
+    // emitting nothing is byte-equivalent there. Only the BLOCK path writes JSON
+    // (codex accepts {decision:'block',...}). Sibling of #604 (autonomous-stop-hook).
     let _input = {};
     try { _input = JSON.parse(data); } catch {}
     if (_input && _input.stop_hook_active) {
-      process.stdout.write(JSON.stringify({ decision: 'approve' }));
+      // Re-entry guard: never re-block a correction continuation. (allow = empty)
       process.exit(0);
       return;
     }
@@ -7569,7 +7572,6 @@ function fetchActiveJob() {
     // Never block headless/job sessions — no human to dismiss the block.
     // INSTAR_SESSION_ID is set for all server-spawned sessions.
     if (process.env.INSTAR_SESSION_ID && !process.env.TERM_PROGRAM) {
-      process.stdout.write(JSON.stringify({ decision: 'approve' }));
       process.exit(0);
       return;
     }
@@ -7579,7 +7581,6 @@ function fetchActiveJob() {
     const depth = state.implementationDepth || 0;
 
     if (depth < DEPTH_THRESHOLD) {
-      process.stdout.write(JSON.stringify({ decision: 'approve' }));
       process.exit(0);
       return;
     }
@@ -7588,7 +7589,6 @@ function fetchActiveJob() {
     if (state.lastCheckpointPrompt) {
       const elapsed = now - new Date(state.lastCheckpointPrompt).getTime();
       if (elapsed < COOLDOWN_MS) {
-        process.stdout.write(JSON.stringify({ decision: 'approve' }));
         process.exit(0);
         return;
       }
@@ -7598,7 +7598,6 @@ function fetchActiveJob() {
     if (state.sessionStart) {
       const age = now - new Date(state.sessionStart).getTime();
       if (age < MIN_AGE_MS) {
-        process.stdout.write(JSON.stringify({ decision: 'approve' }));
         process.exit(0);
         return;
       }
@@ -7650,7 +7649,7 @@ function fetchActiveJob() {
 
     process.stdout.write(JSON.stringify({ decision: 'block', reason: reason }));
   } catch {
-    process.stdout.write(JSON.stringify({ decision: 'approve' }));
+    // On any error, allow (empty stdout) — never emit approve-JSON (codex-unsafe).
   }
   process.exit(0);
 })();

--- a/tests/unit/scope-coherence-reentry.test.ts
+++ b/tests/unit/scope-coherence-reentry.test.ts
@@ -37,7 +37,7 @@ afterAll(() => {
   SafeFsExecutor.safeRmSync(tmpDir, { recursive: true, force: true, operation: 'tests/unit/scope-coherence-reentry.test.ts:afterAll' });
 });
 
-function run(payload: object): { exitCode: number; decision?: string } {
+function run(payload: object): { exitCode: number; stdout: string; decision?: string } {
   // Run from a clean cwd with no INSTAR_SESSION_ID so the headless short-circuit
   // doesn't mask the re-entry guard we're testing.
   const res = spawnSync('node', [hookPath], {
@@ -47,21 +47,34 @@ function run(payload: object): { exitCode: number; decision?: string } {
     cwd: tmpDir,
     env: { ...process.env, INSTAR_SESSION_ID: '', TERM_PROGRAM: 'iTerm.app' },
   });
+  const stdout = (res.stdout || '').trim();
   let decision: string | undefined;
-  try { decision = JSON.parse(res.stdout).decision; } catch { /* no json */ }
-  return { exitCode: res.status ?? -1, decision };
+  try { decision = JSON.parse(stdout).decision; } catch { /* no json */ }
+  return { exitCode: res.status ?? -1, stdout, decision };
 }
 
-describe('scope-coherence-checkpoint — re-entry guard (C3)', () => {
-  it('approves immediately on a correction continuation (stop_hook_active=true)', () => {
+describe('scope-coherence-checkpoint — re-entry guard (C3) + codex stdout-safety', () => {
+  it('allows immediately on a correction continuation (stop_hook_active=true) with EMPTY stdout', () => {
     const r = run({ hook_event_name: 'Stop', stop_hook_active: true });
     expect(r.exitCode).toBe(0);
-    expect(r.decision).toBe('approve');
+    // ALLOW is now signalled by empty stdout (codex-safe), NOT {decision:'approve'}.
+    expect(r.stdout).toBe('');
+    expect(r.decision).toBeUndefined();
   });
 
-  it('does not block a fresh Stop below the depth threshold (sanity — normal approve path)', () => {
+  it('allows a fresh Stop below the depth threshold with EMPTY stdout (codex-safe allow path)', () => {
     const r = run({ hook_event_name: 'Stop', stop_hook_active: false });
     expect(r.exitCode).toBe(0);
-    expect(r.decision).toBe('approve'); // no state file => depth 0 => approve
+    expect(r.stdout).toBe(''); // no state file => depth 0 => allow => empty
+    expect(r.decision).toBeUndefined();
+  });
+
+  it('the generated hook emits NO {decision:"approve"} on stdout but DOES keep the block path (codex Stop-hook contract: empty=allow, block-JSON=block)', () => {
+    const src = fs.readFileSync(hookPath, 'utf-8');
+    // No approve-JSON anywhere — codex rejects it as "invalid stop hook JSON output".
+    expect(src).not.toContain("decision: 'approve'");
+    expect(src).not.toContain('decision: "approve"');
+    // The scope-checkpoint BLOCK path is preserved (codex accepts block decisions).
+    expect(src).toContain("decision: 'block'");
   });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,54 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13435; live-found driving Codey)
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — the scope-check Stop hook no longer confuses Codex
+
+When an agent finishes a turn, a "scope-coherence checkpoint" Stop hook runs and, on
+the normal allow path, used to print a tiny `{decision:approve}` message. Claude
+treats that as allow, but Codex's Stop-hook contract is stricter: print
+`{decision:block,...}` to interrupt, print **nothing** to allow — an explicit
+approve message is rejected as "invalid stop hook JSON output". So on every Codex
+session completion that hook reported an error (the reply was already sent, so
+nothing actually broke, but the error was noisy and wrong). Found live while
+test-driving the Codex agent.
+
+The fix changes every allow path to emit nothing (empty stdout = allow), which is
+byte-equivalent for Claude and removes the error for Codex. The interrupt (block)
+path is unchanged. The hook is regenerated from source on every update, so all
+agents get the fix automatically.
+
+## Summary of New Capabilities
+
+- `scope-coherence-checkpoint` Stop hook is now Codex-stdout-safe: allow paths emit
+  empty stdout (instead of `{decision:approve}`); the block/checkpoint path is
+  unchanged. Sibling of the earlier autonomous-stop-hook Codex fix.
+
+## What to Tell Your User
+
+If you run a Codex-based agent, it will stop logging a spurious "invalid stop hook"
+error every time it finishes a turn. Nothing actually broke before (replies still
+went out), and Claude agents are unaffected — this just makes the scope-check hook
+speak Codex's dialect correctly. It applies automatically on the next update.
+
+## Evidence
+
+- Live: driving the Codex agent over Telegram, it completed a task + sent its reply,
+  then its session reported "Stop hook (failed) — invalid stop hook JSON output".
+- Audited the 5-hook Stop chain: only scope-coherence-checkpoint writes on the allow
+  path; the others write only on block (codex-safe), and the autonomous hook was
+  fixed earlier.
+- Unit: `tests/unit/scope-coherence-reentry.test.ts` — allow paths now exit 0 with
+  empty stdout; the generated hook contains no `{decision:approve}` and keeps
+  `{decision:block}`.
+- Regression: PostUpdateMigrator-buildStopHook + migration-parity-hooks +
+  installCodexHooks — 28 tests pass.
+- `tsc --noEmit` + `npm run lint` clean.
+- Spec: `docs/specs/codex-scope-coherence-stdout-safe.md` (+ `.eli16.md`).
+- Side-effects: `upgrades/side-effects/codex-scope-coherence-stdout-safe.md`.

--- a/upgrades/side-effects/codex-scope-coherence-stdout-safe.md
+++ b/upgrades/side-effects/codex-scope-coherence-stdout-safe.md
@@ -1,0 +1,42 @@
+# Side-effects — scope-coherence-checkpoint codex stdout-safe
+
+## 1. What files/state does this touch at runtime?
+Only the generated `.instar/hooks/instar/scope-coherence-checkpoint.js` (rewritten
+by the always-overwrite built-in-hook migration). At Stop time the hook reads its
+state file + (when deep) fetches active-job context — unchanged. The only change is
+what it writes to stdout on the allow paths (now nothing).
+
+## 2. Does it change any functional behavior?
+- **Claude:** none. Empty stdout == approve in Claude Code, identical to the prior
+  explicit `{decision:'approve'}`. The scope-checkpoint still blocks (prompts) when
+  deep-implementation + cooldown + min-age conditions are met.
+- **codex:** the allow paths no longer emit `{decision:'approve'}`, so codex stops
+  reporting "invalid stop hook JSON output" on session completion. The block path is
+  unchanged (codex accepts `{decision:'block',...}`).
+
+## 3. What happens on failure / weird input?
+The catch-all error path now allows (empty stdout) instead of emitting approve-JSON
+— same allow outcome, codex-safe. Malformed stdin still falls through to allow.
+
+## 4. Migration parity — do existing agents get it?
+Yes, automatically. The hook is in the always-overwrite built-in-hook set, so every
+agent regenerates it from the fixed `getScopeCoherenceCheckpointHook()` on its next
+update (incl. instar-codey). No marker/sniff needed.
+
+## 5. Could it spam / flood / burn resources?
+No — it REDUCES output (writes less). The hook runs only at Stop, same as before.
+
+## 6. Rollback / off-switch?
+Revert the PR; the next update regenerates the prior hook. No residual state, no
+flag. Reverting restores `{decision:'approve'}` (Claude unaffected; codex error
+returns).
+
+## 7. Concurrency / ordering?
+None new. Single short-lived hook process per Stop event, unchanged.
+
+## Blast radius
+Small + behavior-preserving on Claude, error-fixing on codex. One generator method
+in PostUpdateMigrator (six allow-path stdout writes removed; block path kept) + test
+updates. Mirrors the #604 codex-stdout convention. The broader approve-JSON class
+(other hooks + additionalContext signal hooks) is explicitly out of scope, tracked
+under #32 / ledger issue codex-stop-chain-multi-json-invalid.


### PR DESCRIPTION
## What & why (found live driving Codey)

Driving Codey (codex agent) over Telegram with a real task, it completed the task and **sent its reply successfully**, then its codex session printed: `Stop hook (failed) error: hook returned invalid stop hook JSON output`.

Audited Codey's 5-hook Stop chain:
- `stop-gate-router`, `response-review`, `claim-intercept-response` — write stdout only on a **block** decision (codex-safe).
- autonomous-stop-hook — already fixed in **#604**.
- **`scope-coherence-checkpoint.js`** — writes `{decision:'approve'}` on *every allow path*. ← the culprit.

**Root cause:** codex's Stop-hook contract is **empty stdout = allow**, `{decision:'block',...}` = block; an explicit `{decision:'approve'}` is rejected as "invalid stop hook JSON output". Claude Code tolerates it (empty == approve), so the hook worked on Claude but errored on **every** codex session completion. Cosmetic (the reply is sent *before* the Stop hook runs), but noisy + wrong, and a real parity gap.

## Change
`PostUpdateMigrator.getScopeCoherenceCheckpointHook()` now emits **empty stdout** on all allow paths (5 try-block short-circuits + the catch-all). The **block/checkpoint path is unchanged** (`{decision:'block', reason}` — codex accepts block decisions). Byte-equivalent on Claude (empty == approve); fixes codex.

## Migration parity
`scope-coherence-checkpoint.js` is in the **always-overwrite** built-in-hook set, so every agent (incl. instar-codey) regenerates the corrected hook on its next update — no marker/sniff needed.

## Tests / gate
- Unit (`tests/unit/scope-coherence-reentry.test.ts`): re-entry continuation + fresh-below-threshold → exit 0 + **empty stdout**; generated hook has **no** `{decision:'approve'}` and **keeps** `{decision:'block'}`.
- Regression: PostUpdateMigrator-buildStopHook + migration-parity-hooks + installCodexHooks — **28 tests pass**.
- `tsc --noEmit` + `npm run lint` clean; instar-dev gate (spec `approved:true` + ELI16 + side-effects + trace).

## Scope / verification
Fixes the **confirmed Stop-chain culprit**. The broader approve-JSON class (a sibling hook + several `{decision:'approve', additionalContext}` signal hooks — the latter need a codex context-injection path, not just emptying) is out of scope, tracked under **#32** / ledger issue `codex-stop-chain-multi-json-invalid`. Final verification: re-drive Codey post-deploy and confirm the error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Self-approved under the standing 12h autonomous deploy mandate (topic 13435). Sibling of #604.