### PR TITLE
fix(multi-machine): silent-standby git-less lease — observe-only + legacy-key fallback

### DIFF
--- a/docs/specs/silent-standby-lease.eli16.md
+++ b/docs/specs/silent-standby-lease.eli16.md
@@ -1,0 +1,46 @@
+# Silent-standby lease — explain it like I'm 16
+
+Imagine two computers (a laptop and a Mac mini) that are supposed to act like ONE
+assistant. Only one of them is allowed to be "in charge" at a time — the one in
+charge answers your texts. They decide who's in charge with a thing called a
+"lease": a numbered permission slip that says "I'm the boss right now, this is
+slip #105." Whoever holds the highest-numbered slip is the boss, and the other
+machine is supposed to just watch and agree.
+
+We were trying to get the laptop to hand a live conversation over to the mini
+("move this to the Mac Mini"). It kept failing, and we chased the reason down
+through several layers. The last two layers are what this change fixes.
+
+**Bug #4 — the mini couldn't find its own ID card.** Every machine signs its
+messages with a private key, like a signature on a letter so the other machine
+knows it's really them. The code that loads that key only looked for a file named
+`signing-key.pem`. But the mini's key was saved years-ago-style under an older
+name, `signing-private.pem`. So when the mini tried to start the part of itself
+that watches the lease, it couldn't find the key, threw an error, and quietly gave
+up on the whole "watch the lease" system. That's why the mini never knew who the
+boss was — it never even turned that system on. The fix: if the new-name file
+isn't there, also check the old-name file before giving up. (The texting part of
+the mini already did this; the lease part had been missed.)
+
+**Bug #5 — both machines kept fighting to be boss.** Here's the subtle one. The
+rule was "whoever holds the lease is the boss," and EVERY machine, on startup,
+would grab a lease for itself before it had a chance to hear from the other one.
+Normally there's a shared notebook (backed by git) where they take turns writing
+"I'm #105, now I'm #106" so they can't both claim the same number. But the mini
+didn't have that shared notebook — it used a private notepad only it could see. So
+the laptop wrote "#105, #106, #107" in its notepad, the mini wrote "#105, #106" in
+ITS notepad, and because the mini's own number (106) looked higher than the
+laptop's incoming message it happened to see (105), the mini said "nah, you're
+behind me, I'm the boss" — and rejected the laptop. Two bosses. Nobody hands off.
+
+The fix is a clean idea: the mini is configured as a "silent standby" — it never
+answers texts on its own (`telegramPolling: false`). A machine that never serves
+should never try to BE the boss. So now a silent standby simply doesn't grab a
+lease at all. It only watches. Its notepad stays blank (number 0), so the laptop's
+slip always wins, the mini agrees the laptop is boss, and when the laptop says
+"here, take this conversation," the mini trusts it and accepts. One boss, clean
+handoff.
+
+In short: teach the mini to find its ID card under either name, and tell the quiet
+backup machine to stop trying to crown itself. Those two together let the laptop
+actually move a live chat onto the mini.

--- a/docs/specs/silent-standby-lease.md
+++ b/docs/specs/silent-standby-lease.md
@@ -1,0 +1,99 @@
+---
+title: Silent-standby git-less lease coordination (observe-only + legacy-key fallback)
+slug: silent-standby-lease
+status: approved
+review-convergence: 2026-05-31T08:50:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the delegated deploy mandate. Justin put Echo in a
+  12-hour autonomous run on 2026-05-31 (topic 13481) to iterate the multi-machine
+  live-transfer cascade to fully working, step-by-step. This is bugs #4 + #5 of
+  that cascade, both found + diagnosed live with instrumentation. Flagged per
+  cross-agent discipline.
+---
+
+# Silent-standby git-less lease coordination (observe-only + legacy-key fallback)
+
+## Problem
+
+Bugs #4 + #5 of the multi-machine live-transfer cascade (after v1.3.140's
+coordinator-wiring + v1.3.143's machineAuth-sequence fixes). Even with those
+deployed, the standby (mini) still never resolved the lease holder, so MeshRpc
+kept rejecting the forwarded transfer as `not-router`. Diagnosed live by adding
+debug logging to the mini's `/api/lease` handler + `LeaseCoordinator.effectiveView`:
+
+- **Bug #4:** the mini's lease setup threw at boot — `ENOENT … signing-key.pem`.
+  Its machine key was stored under the pre-canonical-rename name
+  `signing-private.pem`; `MachineIdentity.loadSigningKey()` reads only the
+  canonical `signing-key.pem`. Constructing the `HttpLeaseTransport`
+  (`signingKeyPem: idMgr.loadSigningKey()`) threw → the lease-try caught it → the
+  `LeaseCoordinator` NEVER ATTACHED on the mini → `currentHolder()` fell back to
+  null. (The mini's other key consumers had the key loaded a different way, which
+  is why presence/machineAuth still worked — masking this.)
+
+- **Bug #5 (split-brain):** with the key fixed and the coordinator attached, the
+  mini STILL rejected the laptop's lease — `effectiveView … accept=false
+  reason=below-git-floor (msg epoch 105 < committed 106)`. The role is DERIVED
+  from the lease (hold lease → become awake) and lease acquisition is UNGATED, so
+  at boot — before observing the laptop's broadcast — the mini acquired its OWN
+  lease, then (with the git-less `LocalLeaseStore`, which has no shared
+  compare-and-swap) both machines independently re-acquired and LEAPFROGGED epochs
+  (mini at 106, laptop at 105/107). The mini's own higher epoch dominated its
+  effectiveView, so it rejected the laptop's lease as below its own floor.
+
+## Goal
+
+A `telegramPolling:false` silent standby cleanly resolves the primary as lease
+holder (so it authenticates the primary's router-only MeshRpc commands and can
+receive a transferred session), with no split-brain leapfrog and no boot-time
+ENOENT abort — on any agent regardless of which name its signing key was stored
+under.
+
+## Non-goals
+
+- No change to the git-backed CAS path (`GitLeaseStore`) when git is available.
+- No auto-failover for a silent standby (a muted standby becoming awake-yet-not-
+  serving is incoherent; failover for it is a deliberate un-mute → telegramPolling
+  true, at which point it's a normal acquirer). Auto-failover for the active-active
+  pool is a separate concern.
+- No change to `NonceStore`, `acceptTunnelLease`, or the wire format.
+
+## Design
+
+1. **`MachineIdentity.loadSigningKey()` legacy fallback** — on ENOENT for the
+   canonical `signing-key.pem`, fall back to the legacy `signing-private.pem` if
+   present (else rethrow). Fixes the boot abort for any legacy-keyed agent
+   fleet-wide. (The lifeline loader already had this fallback; `loadSigningKey`
+   did not — #546 lineage.)
+
+2. **Silent standby = lease-observe-only** — add
+   `MultiMachineCoordinator.isLeaseObserveOnly` (`config.multiMachine.telegramPolling
+   === false`). In `initializeLease` and `tickLease`, a silent standby SKIPS
+   `acquireIfEligible`/`renew` entirely — it never holds its own lease, so its
+   `LocalLeaseStore` stays empty (epoch 0) and `effectiveView` folds the primary's
+   observed broadcast → `currentHolder` resolves to the primary. This removes the
+   boot-race self-acquisition that caused the leapfrog. (Maps the operator's
+   explicit "silent standby" designation to coherent lease behavior.)
+
+## Deploy note
+
+A machine that already self-acquired a stale lease (the mini's epoch-106
+`lease-local.json`) must have it cleared on deploy (`rm lease-local.json`), so its
+store starts empty and folds the primary. (The fix prevents re-creating it.)
+
+## Testing
+
+- Tier 1: `machine-identity.test.ts` — loadSigningKey falls back to the legacy
+  name; still throws when neither exists. `multi-machine-coordinator.test.ts` —
+  a silent standby never acquires/renews (initializeLease + tickLease); a normal
+  machine does acquire; `isLeaseObserveOnly` reflects the flag. 109 related tests
+  green (machine-identity, coordinator, LeaseCoordinator, mesh-signing-key,
+  syncstatus).
+- Tier-3: re-run the live two-machine transfer after deploy — the mini's
+  leaseHolder must resolve to the laptop and the forwarded session must be served.
+
+## Migration parity
+
+Pure code (new getter + a fallback + acquisition gate). No config default / hook /
+route / CLAUDE.md change. Existing agents get it on the v-next update.

--- a/src/core/MachineIdentity.ts
+++ b/src/core/MachineIdentity.ts
@@ -24,6 +24,9 @@ const MACHINE_DIR = 'machine';
 const MACHINES_DIR = 'machines';
 const IDENTITY_FILE = 'identity.json';
 const SIGNING_KEY_FILE = 'signing-key.pem';
+// Pre-canonical-rename name some machine identities were keyed under; loadSigningKey
+// falls back to it so a legacy-keyed agent's lease coordinator still attaches.
+const LEGACY_SIGNING_KEY_FILE = 'signing-private.pem';
 const ENCRYPTION_KEY_FILE = 'encryption-key.pem';
 const REGISTRY_FILE = 'registry.json';
 const KEY_FILE_MODE = 0o600;
@@ -243,7 +246,21 @@ export class MachineIdentityManager {
    * Load this machine's Ed25519 signing private key (PEM format).
    */
   loadSigningKey(): string {
-    return fs.readFileSync(this.signingKeyPath, 'utf-8');
+    try {
+      return fs.readFileSync(this.signingKeyPath, 'utf-8');
+    } catch (err) {
+      // Legacy fallback: machine identities created before the canonical rename
+      // wrote the signing key as 'signing-private.pem' (not 'signing-key.pem').
+      // Without this, such an agent throws ENOENT here — which aborts the whole
+      // lease-coordinator setup (found live 2026-05-31: the mini, keyed under the
+      // legacy name, never attached its LeaseCoordinator → never resolved the
+      // holder → MeshRpc rejected cross-machine transfer as not-router).
+      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+        const legacy = path.join(this.machineDir, LEGACY_SIGNING_KEY_FILE);
+        if (fs.existsSync(legacy)) return fs.readFileSync(legacy, 'utf-8');
+      }
+      throw err;
+    }
   }
 
   /**

--- a/src/core/MultiMachineCoordinator.ts
+++ b/src/core/MultiMachineCoordinator.ts
@@ -117,6 +117,23 @@ export class MultiMachineCoordinator extends EventEmitter {
   /** Whether this machine is the awake (primary) machine. */
   get isAwake(): boolean { return this._role === 'awake'; }
 
+  /**
+   * A SILENT standby (telegramPolling:false — the operator explicitly muted this
+   * machine so it never owns the Telegram poll) is LEASE-OBSERVE-ONLY: it never
+   * acquires/renews its own lease, it only observes the primary's broadcast and
+   * resolves leaseHolder to the primary. Rationale: the git-less LocalLeaseStore
+   * has no shared compare-and-swap, so a standby that acquires its own lease at
+   * boot (before it has observed the primary's broadcast) leapfrogs epochs with
+   * the primary and never adopts it as holder — leaving the standby unable to
+   * authenticate the primary's router-only MeshRpc commands (the 2026-05-31
+   * cross-machine-transfer split-brain). A muted standby auto-grabbing the awake
+   * role would also be incoherent (awake yet not serving Telegram). Failover for
+   * such a machine is a deliberate un-mute (telegramPolling → true), not auto.
+   */
+  get isLeaseObserveOnly(): boolean {
+    return this.config.multiMachine?.telegramPolling === false;
+  }
+
   /** The coordination mode (default: 'primary-standby'). */
   get coordinationMode(): CoordinationMode {
     return this.config.multiMachine?.coordinationMode ?? 'primary-standby';
@@ -453,6 +470,11 @@ export class MultiMachineCoordinator extends EventEmitter {
    */
   async initializeLease(): Promise<void> {
     if (!this.leaseCoordinator) return;
+    if (this.isLeaseObserveOnly) {
+      // Silent standby: do NOT acquire — only observe the primary's lease.
+      this.reconcileRoleToLease('lease-init-observe-only');
+      return;
+    }
     await this.leaseCoordinator.acquireIfEligible();
     this.reconcileRoleToLease('lease-init');
   }
@@ -479,12 +501,17 @@ export class MultiMachineCoordinator extends EventEmitter {
     if (!this.leaseCoordinator || this.leaseTicking) return;
     this.leaseTicking = true;
     try {
-      if (this.leaseCoordinator.holdsLease()) {
+      if (this.isLeaseObserveOnly) {
+        // Silent standby: never acquire/renew — just reconcile role to the
+        // observed holder (effectiveView folds the primary's broadcast lease).
+        this.reconcileRoleToLease('lease-tick-observe-only');
+      } else if (this.leaseCoordinator.holdsLease()) {
         await this.leaseCoordinator.renew();
+        this.reconcileRoleToLease('lease-tick');
       } else {
         await this.leaseCoordinator.acquireIfEligible();
+        this.reconcileRoleToLease('lease-tick');
       }
-      this.reconcileRoleToLease('lease-tick');
     } catch {
       // @silent-fallback-ok — a tick failure is retried next interval
     } finally {

--- a/tests/unit/machine-identity.test.ts
+++ b/tests/unit/machine-identity.test.ts
@@ -310,6 +310,29 @@ describe('MachineIdentityManager', () => {
     });
   });
 
+  describe('loadSigningKey (legacy fallback)', () => {
+    it('falls back to signing-private.pem when the canonical signing-key.pem is absent', async () => {
+      await manager.generateIdentity();
+      const canonical = manager.signingKeyPath;
+      const key = fs.readFileSync(canonical, 'utf-8');
+      // Simulate a machine keyed under the pre-canonical-rename name: only the
+      // legacy 'signing-private.pem' exists. (2026-05-31: such a machine threw
+      // ENOENT here, aborting its whole lease-coordinator setup.)
+      const legacy = path.join(path.dirname(canonical), 'signing-private.pem');
+      fs.renameSync(canonical, legacy);
+      expect(fs.existsSync(canonical)).toBe(false);
+      expect(manager.loadSigningKey()).toBe(key);
+    });
+
+    it('still throws when neither the canonical nor the legacy key exists', async () => {
+      await manager.generateIdentity();
+      const canonical = manager.signingKeyPath;
+      // Move it to a name that is neither canonical nor the legacy fallback.
+      fs.renameSync(canonical, canonical + '.gone');
+      expect(() => manager.loadSigningKey()).toThrow();
+    });
+  });
+
   describe('loadIdentity', () => {
     it('loads a previously generated identity', async () => {
       const original = await manager.generateIdentity();

--- a/tests/unit/multi-machine-coordinator.test.ts
+++ b/tests/unit/multi-machine-coordinator.test.ts
@@ -119,6 +119,46 @@ describe('MultiMachineCoordinator', () => {
     });
   });
 
+  // ── Silent-standby lease observe-only (2026-05-31 split-brain fix) ──
+  describe('silent-standby lease observe-only (telegramPolling:false)', () => {
+    function fakeLease() {
+      return {
+        acquireIfEligible: vi.fn(async () => false),
+        renew: vi.fn(async () => true),
+        holdsLease: vi.fn(() => false),
+        currentHolder: vi.fn(() => 'm_primary'),
+        currentEpoch: vi.fn(() => 5),
+      };
+    }
+
+    it('isLeaseObserveOnly is true when telegramPolling is false', () => {
+      const state = new StateManager(tmpDir);
+      const coord = new MultiMachineCoordinator(state, { stateDir: tmpDir, multiMachine: { telegramPolling: false } });
+      expect(coord.isLeaseObserveOnly).toBe(true);
+    });
+
+    it('a silent standby never acquires or renews the lease (initializeLease + tickLease)', async () => {
+      const state = new StateManager(tmpDir);
+      const coord = new MultiMachineCoordinator(state, { stateDir: tmpDir, multiMachine: { telegramPolling: false } });
+      const lc = fakeLease();
+      coord.attachLeaseCoordinator(lc as any);
+      await coord.initializeLease();
+      await (coord as any).tickLease();
+      expect(lc.acquireIfEligible).not.toHaveBeenCalled();
+      expect(lc.renew).not.toHaveBeenCalled();
+    });
+
+    it('a normal (polling) machine DOES acquire the lease', async () => {
+      const state = new StateManager(tmpDir);
+      const coord = new MultiMachineCoordinator(state, { stateDir: tmpDir });
+      const lc = fakeLease();
+      coord.attachLeaseCoordinator(lc as any);
+      expect(coord.isLeaseObserveOnly).toBe(false);
+      await coord.initializeLease();
+      expect(lc.acquireIfEligible).toHaveBeenCalled();
+    });
+  });
+
   // ── Multi-machine: awake startup ───────────────────────────────
 
   describe('startup as awake machine', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,65 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13481; multi-machine live-transfer cascade)
+---
+
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — a silent standby machine now correctly recognizes the awake machine as in charge
+
+Two narrow fixes for the multi-machine live session-transfer path (the one that
+moves a conversation from one machine to another when you say "move this to the
+Mac mini"). Both were found by running the transfer live between a laptop and a
+Mac mini and tracing why the handoff was rejected.
+
+1. **Signing-key fallback.** Each machine signs its mesh messages with a private
+   key file. The loader looked only for the current filename; a machine whose key
+   was saved under the older filename threw an error at boot, which silently
+   aborted its lease-coordination setup — so it never learned which machine was in
+   charge. The loader now also checks the legacy filename before giving up,
+   matching the fallback the lifeline loader already had.
+
+2. **Silent standby stops crowning itself.** A machine configured as a silent
+   standby (it never answers messages on its own) was still trying to claim the
+   "I'm in charge" lease at startup. On a machine without the shared git-backed
+   coordination medium, that produced a split-brain where both machines thought
+   they were in charge and the handoff was refused. A silent standby now only
+   watches the lease and never claims one, so the awake machine always wins and the
+   handoff is accepted.
+
+## Summary of New Capabilities
+
+- `MachineIdentity.loadSigningKey()` falls back to the legacy `signing-private.pem`
+  when the canonical `signing-key.pem` is absent (rethrows if neither exists).
+- `MultiMachineCoordinator.isLeaseObserveOnly` (driven by
+  `multiMachine.telegramPolling === false`): a silent standby skips lease
+  acquire/renew in both `initializeLease` and `tickLease`, only reconciling its
+  role to the observed lease — removing the git-less split-brain epoch leapfrog.
+
+## What to Tell Your User
+
+If you run your agent on more than one machine, moving a live conversation from one
+machine to another is now more reliable. A quiet backup machine will correctly
+treat your main machine as the one in charge instead of fighting it for control,
+and a machine whose security key was saved under an older filename will no longer
+fail to join the handoff. Nothing to configure — it applies on the next update.
+
+## Evidence
+
+- Both bugs were found live on the two-machine setup (laptop plus Mac mini) by
+  instrumenting the lease broadcast or observe path: the mini threw ENOENT on the
+  canonical key at boot so its lease coordinator never attached, and once that was
+  fixed it rejected the laptop's lease as below its own self-issued epoch floor.
+- Unit, `tests/unit/machine-identity.test.ts`: loadSigningKey falls back to the
+  legacy name and still throws when neither file exists.
+- Unit, `tests/unit/multi-machine-coordinator.test.ts`: a silent standby never
+  acquires or renews (across initializeLease and tickLease); a normal machine does
+  acquire; the observe-only flag reflects telegramPolling false.
+- 109 related unit tests pass (machine-identity, multi-machine-coordinator,
+  LeaseCoordinator, mesh-signing-key-resolution, multimachine-syncstatus);
+  tsc --noEmit clean.
+- Spec, `docs/specs/silent-standby-lease.md` plus the .eli16.md sibling.
+- Side-effects, `upgrades/side-effects/silent-standby-lease.md`.

--- a/upgrades/side-effects/silent-standby-lease.md
+++ b/upgrades/side-effects/silent-standby-lease.md
@@ -1,0 +1,115 @@
+# Side-Effects Review — Silent-standby git-less lease (observe-only + legacy-key fallback)
+
+**Version / slug:** `silent-standby-lease`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Two narrowly-scoped fixes for bugs #4 + #5 of the multi-machine live-transfer
+cascade:
+
+1. `MachineIdentity.loadSigningKey()` — on ENOENT for the canonical
+   `signing-key.pem`, fall back to the legacy `signing-private.pem` if present,
+   else rethrow. (The mini's key was under the legacy name; the lease setup threw
+   at boot, so the `LeaseCoordinator` never attached and the mini never resolved a
+   holder.)
+2. `MultiMachineCoordinator` — new `isLeaseObserveOnly` getter
+   (`multiMachine.telegramPolling === false`). A silent standby skips
+   `acquireIfEligible`/`renew` in both `initializeLease` and `tickLease`; it only
+   reconciles its role to whatever lease it observes. It never holds its own lease,
+   so with the git-less `LocalLeaseStore` (no shared CAS) it can't leapfrog the
+   primary's epoch and reject the primary as `below-git-floor`.
+
+## Decision-point inventory
+
+- **loadSigningKey fallback branch** — ENOENT on canonical → try legacy name →
+  exists? read it : rethrow original. Both sides covered by unit tests.
+- **isLeaseObserveOnly gate** — true (telegramPolling:false) → observe-only path
+  (no acquire/renew); false/undefined → unchanged acquire+renew path. Both sides
+  covered by unit tests (silent standby never acquires; normal machine does).
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** A silent standby
+(`telegramPolling:false`) no longer acquires a lease at all — so it can never
+become awake on its own. That is the INTENT: a muted standby that became "awake but
+not serving" is the incoherent state we are removing. A machine that should be able
+to take over sets `telegramPolling:true` (or unsets it), which is the unchanged
+acquire path. The key fallback rejects nothing — it only ADDS a second lookup
+location before the same rethrow.
+
+## 2. Under-block
+
+**What does this still miss?** It does not add auto-failover for a silent standby
+(out of scope — failover for it is a deliberate un-mute). It does not add a shared
+CAS to `LocalLeaseStore`; the split-brain is avoided by not acquiring rather than
+by making git-less acquisition safe (correct for the one-awake-machine model; the
+active-active pool, which needs real shared CAS, remains git-backed). The key
+fallback covers only the one known legacy name (`signing-private.pem`), matching
+the lifeline loader's existing fallback — not an open-ended search.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The key fallback lives in the single `loadSigningKey()`
+loader that every lease/transport consumer already calls (one chokepoint). The
+observe-only gate lives in `MultiMachineCoordinator`'s two lease entry points
+(`initializeLease`, `tickLease`) — the only places acquisition is decided — derived
+from the same `telegramPolling` flag that already designates a silent standby
+elsewhere. No new config surface, no duplicated rule.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No blocking authority added. The observe-only gate REMOVES an action (acquisition)
+for a configured-silent machine; it never blocks a message or an operation. The key
+fallback is a pure read-path widen with an unchanged terminal rethrow. Neither path
+gates any user-facing or outbound behavior.
+
+## 5. Interactions
+
+`loadSigningKey` feeds `HttpLeaseTransport` (lease broadcast/observe) and
+machineAuth signing; widening it only makes a previously-throwing legacy-keyed
+machine succeed — no consumer sees a different value, only a present-vs-throw
+difference. The observe-only gate interacts with `reconcileRoleToLease` (still
+called every tick, now inside each branch) and with `LeaseCoordinator.effectiveView`
+(a standby with an empty `LocalLeaseStore` folds the primary's observed broadcast
+cleanly). Idempotent: both paths produce the same result on repeated boots/ticks.
+
+## 6. External surfaces
+
+No HTTP routes, no config defaults, no notifications, no Telegram. `/health`'s
+`multiMachine.syncStatus.leaseHolder` will now correctly resolve to the primary on a
+silent standby (the visible, intended effect). Pure code.
+
+## 7. Rollback cost
+
+Low. Revert the PR: `loadSigningKey` returns to canonical-only (re-bricks a
+legacy-keyed machine's lease setup) and the coordinator returns to always-acquire
+(re-introduces the split-brain on git-less standbys). No schema, no migration, no
+persisted state created by this change. The one deploy-time action (clear the mini's
+stale self-issued `lease-local.json`) is a one-shot cleanup, not a rollback cost.
+
+## Conclusion
+
+Minimal, additive-or-removing-an-action change with both decision sides unit-tested,
+no new authority, no external surface beyond a corrected `/health` field, and a cheap
+revert. It closes the final two layers blocking the live two-machine transfer.
+
+## Second-pass review (if required)
+
+Not required — no new blocking authority, no destructive op, both decision branches
+covered by tests, reversible. (Live two-machine transfer proof is the Tier-3 gate
+that follows deploy.)
+
+## Evidence pointers
+
+- `tests/unit/machine-identity.test.ts` — loadSigningKey legacy fallback + still-throws.
+- `tests/unit/multi-machine-coordinator.test.ts` — observe-only never acquires/renews;
+  normal machine acquires; `isLeaseObserveOnly` reflects the flag.
+- 109 related unit tests green (machine-identity, coordinator, LeaseCoordinator,
+  mesh-signing-key-resolution, multimachine-syncstatus); `tsc --noEmit` clean.
+- Spec: `docs/specs/silent-standby-lease.md` (+ `.eli16.md`).
+- `upgrades/NEXT.md` — upgrade guide.


### PR DESCRIPTION
## Bugs #4 + #5 of the live-transfer cascade

Found live on the two-machine setup (laptop + Mac mini) while iterating the
"move this to the Mac mini" session transfer (autonomous run, topic 13481).
After PR 598 (git-less coordinator) and PR 601 (shared machineAuth sequence),
the mini STILL never resolved the lease holder, so MeshRpc kept rejecting the
forwarded session as not-router. Two remaining layers, both fixed here:

**Bug #4 — boot ENOENT aborts the mini's lease coordinator.**
`MachineIdentity.loadSigningKey()` read only the canonical `signing-key.pem`.
The mini's key was stored under the legacy name `signing-private.pem`, so
constructing the `HttpLeaseTransport` threw, the lease try-block swallowed it,
and the `LeaseCoordinator` never attached → `currentHolder()` fell back to null.
Fix: on ENOENT, fall back to `signing-private.pem` if present, else rethrow
(mirrors the fallback the lifeline loader already had).

**Bug #5 — git-less split-brain epoch leapfrog.**
Role is derived from the lease and acquisition was ungated, so at boot — before
observing the primary's broadcast — the mini acquired its OWN lease. With the
git-less `LocalLeaseStore` (no shared CAS) both machines independently
re-acquired and leapfrogged epochs; the mini's higher self-issued epoch
dominated its `effectiveView` and it rejected the laptop as below-git-floor.
Fix: a silent standby (`multiMachine.telegramPolling === false`) is now
lease-observe-only — `isLeaseObserveOnly` gates `initializeLease` and
`tickLease` to skip acquire/renew and only reconcile its role to the observed
lease. Its `LocalLeaseStore` stays empty (epoch 0), so it folds the primary's
broadcast and resolves the primary as holder.

## Tests
- `tests/unit/machine-identity.test.ts` — loadSigningKey legacy fallback + still-throws when neither exists.
- `tests/unit/multi-machine-coordinator.test.ts` — silent standby never acquires/renews (initializeLease + tickLease); normal machine acquires; `isLeaseObserveOnly` reflects the flag.
- 109 related unit tests green; `tsc --noEmit` clean.

## Ship-gate
- Spec `docs/specs/silent-standby-lease.md` (+ `.eli16.md`), self-approved under the standing 12h deploy mandate (topic 13481) — flagged here per cross-agent discipline.
- Side-effects `upgrades/side-effects/silent-standby-lease.md`; upgrade guide `upgrades/NEXT.md`.

## Follow-up (this PR's deploy)
After release, deploy to BOTH machines and clear the mini's stale self-issued `lease-local.json`, then re-run the live transfer and confirm the mini serves the moved session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
