### PR TITLE
fix(multi-machine): loadEncryptionKey legacy-name fallback (mesh transport setup)

### DIFF
--- a/docs/specs/encryption-key-fallback.eli16.md
+++ b/docs/specs/encryption-key-fallback.eli16.md
@@ -1,0 +1,42 @@
+# Encryption-key fallback — explain it like I'm 16
+
+Two computers that act as one assistant talk to each other over an encrypted
+channel. Each machine has TWO little key files it needs to open that channel:
+
+1. A **signing key** — like a signature, so the other machine knows a message
+   really came from this machine and wasn't faked.
+2. An **encryption key** — like a lockbox key, so the contents of the message can
+   be scrambled and only the right machine can unscramble them.
+
+A while back the project renamed these key files to cleaner names
+(`signing-key.pem` and `encryption-key.pem`). But the Mac mini was set up BEFORE
+that rename, so on disk its keys still had the old names
+(`signing-private.pem` and `encryption-private.pem`).
+
+The code that opens the encrypted channel goes looking for the NEW names. If it
+can't find a file, it throws an error and gives up on setting up the channel.
+
+Last fix (#610) taught the SIGNING-key loader: "if you can't find the new name,
+try the old name before giving up." That fixed half the problem. But I only fixed
+the signing key. When I deployed it and watched the mini boot, it got past the
+signing key… and then threw the exact same kind of error on the ENCRYPTION key,
+because that loader was never taught the same trick. The error literally said:
+"no such file: encryption-key.pem." So the secure channel still couldn't finish
+turning on.
+
+This change teaches the encryption-key loader the same fallback: look for the new
+name first, and if it's missing, fall back to the old name before giving up. Now a
+machine set up under the old naming can open BOTH halves of its secure channel
+without anyone copying files around by hand.
+
+Why it matters: until both keys load, the mini can't fully join the mesh — it
+can't be trusted to receive a conversation moved over from the laptop. With both
+loaders fixed, an old-style machine joins cleanly on its own.
+
+It's a tiny change — one new line remembering the old filename, plus a few lines in
+one function that say "try the old name if the new one is missing" — but it closes
+the last of a pair of identical gaps that were silently keeping a real machine from
+joining the group. The signing-key half shipped in #610; this is the encryption-key
+half. Both are the same lesson: when you rename a file, teach the code that opens it
+to still recognize the old name, or machines created under the old name quietly
+break.

--- a/docs/specs/encryption-key-fallback.md
+++ b/docs/specs/encryption-key-fallback.md
@@ -1,0 +1,73 @@
+---
+title: loadEncryptionKey legacy-name fallback (mesh transport setup)
+slug: encryption-key-fallback
+status: approved
+review-convergence: 2026-05-31T09:40:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h deploy mandate (topic 13481,
+  multi-machine live-transfer cascade). Direct follow-up to #610: the same
+  legacy-key-name defect, found live on the mini for the ENCRYPTION key after
+  #610 fixed it for the SIGNING key. Flagged per cross-agent discipline.
+---
+
+# loadEncryptionKey legacy-name fallback (mesh transport setup)
+
+## Problem
+
+PR #610 (v1.3.151) gave `MachineIdentity.loadSigningKey()` a fallback to the
+legacy `signing-private.pem` when the canonical `signing-key.pem` is absent,
+because the mini — keyed before the canonical rename — otherwise threw ENOENT at
+lease/transport setup and never attached its coordinator.
+
+Deploying #610 to the mini revealed the IDENTICAL defect one layer down:
+`loadEncryptionKey()` is canonical-only (`fs.readFileSync(encryptionKeyPath)`),
+and the mini had only the legacy `encryption-private.pem`, not the canonical
+`encryption-key.pem`. So with the signing key resolved, the mesh lease/transport
+setup STILL threw:
+
+```
+Lease/transport setup: ENOENT: no such file or directory, open
+  '…/.instar/machine/encryption-key.pem'
+```
+
+The mesh transport loads BOTH keys (Ed25519 signing for envelope signatures,
+X25519 encryption for E2E payload encryption). A legacy-keyed machine resolves the
+first and trips on the second — so the transport could not fully initialize on the
+mini until the canonical encryption key was provided by hand.
+
+## Goal
+
+A machine whose identity was created before the canonical key rename loads BOTH
+its signing and encryption keys without a hand-placed copy, so its mesh transport
+initializes cleanly and it can participate in cross-machine lease + session
+transfer.
+
+## Non-goals
+
+- No change to key GENERATION (new identities already write the canonical names).
+- No open-ended key search — exactly one legacy name (`encryption-private.pem`),
+  mirroring the signing-key fallback's single legacy name.
+- No change to the wire format, NonceStore, or transport protocol.
+
+## Design
+
+`MachineIdentity.loadEncryptionKey()` mirrors `loadSigningKey()`: read the
+canonical `encryption-key.pem`; on ENOENT, fall back to the legacy
+`encryption-private.pem` if it exists, else rethrow. A new module constant
+`LEGACY_ENCRYPTION_KEY_FILE = 'encryption-private.pem'` sits beside
+`LEGACY_SIGNING_KEY_FILE`.
+
+## Testing
+
+- Tier 1 (`machine-identity.test.ts`): `loadEncryptionKey` falls back to the legacy
+  name when the canonical is absent; still throws when neither exists. (Mirrors the
+  signing-key cases #610 added.) 68 machine-identity tests green; tsc clean.
+
+## Migration parity
+
+Pure code (one constant + one method's catch branch). No config/hook/route/
+CLAUDE.md change. Existing agents get it on the v-next update; a legacy-keyed
+machine already deployed keeps working (the hand-placed canonical copy is harmless;
+the fallback simply means future fresh machines need no hand copy).

--- a/src/core/MachineIdentity.ts
+++ b/src/core/MachineIdentity.ts
@@ -28,6 +28,9 @@ const SIGNING_KEY_FILE = 'signing-key.pem';
 // falls back to it so a legacy-keyed agent's lease coordinator still attaches.
 const LEGACY_SIGNING_KEY_FILE = 'signing-private.pem';
 const ENCRYPTION_KEY_FILE = 'encryption-key.pem';
+// Pre-canonical-rename name; loadEncryptionKey falls back to it for the same reason
+// loadSigningKey does (the mesh transport loads BOTH keys at lease/transport setup).
+const LEGACY_ENCRYPTION_KEY_FILE = 'encryption-private.pem';
 const REGISTRY_FILE = 'registry.json';
 const KEY_FILE_MODE = 0o600;
 const REGISTRY_VERSION = 1;
@@ -267,7 +270,21 @@ export class MachineIdentityManager {
    * Load this machine's X25519 encryption private key (PEM format).
    */
   loadEncryptionKey(): string {
-    return fs.readFileSync(this.encryptionKeyPath, 'utf-8');
+    try {
+      return fs.readFileSync(this.encryptionKeyPath, 'utf-8');
+    } catch (err) {
+      // Same legacy fallback as loadSigningKey: identities created before the
+      // canonical rename wrote the encryption key as 'encryption-private.pem'.
+      // The mesh lease/transport setup loads this key too — found live
+      // 2026-05-31: with the signing key resolved, the mini's transport setup
+      // still threw ENOENT on the canonical 'encryption-key.pem', so the
+      // legacy-keyed machine's transport couldn't fully initialize.
+      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+        const legacy = path.join(this.machineDir, LEGACY_ENCRYPTION_KEY_FILE);
+        if (fs.existsSync(legacy)) return fs.readFileSync(legacy, 'utf-8');
+      }
+      throw err;
+    }
   }
 
   // ── Registry Management ──────────────────────────────────────────

--- a/tests/unit/machine-identity.test.ts
+++ b/tests/unit/machine-identity.test.ts
@@ -333,6 +333,28 @@ describe('MachineIdentityManager', () => {
     });
   });
 
+  describe('loadEncryptionKey (legacy fallback)', () => {
+    it('falls back to encryption-private.pem when the canonical encryption-key.pem is absent', async () => {
+      await manager.generateIdentity();
+      const canonical = manager.encryptionKeyPath;
+      const key = fs.readFileSync(canonical, 'utf-8');
+      // The mesh transport loads the encryption key too; a legacy-keyed machine
+      // (2026-05-31: the mini) had only 'encryption-private.pem', so the canonical
+      // read threw ENOENT and the transport setup could not fully initialize.
+      const legacy = path.join(path.dirname(canonical), 'encryption-private.pem');
+      fs.renameSync(canonical, legacy);
+      expect(fs.existsSync(canonical)).toBe(false);
+      expect(manager.loadEncryptionKey()).toBe(key);
+    });
+
+    it('still throws when neither the canonical nor the legacy key exists', async () => {
+      await manager.generateIdentity();
+      const canonical = manager.encryptionKeyPath;
+      fs.renameSync(canonical, canonical + '.gone');
+      expect(() => manager.loadEncryptionKey()).toThrow();
+    });
+  });
+
   describe('loadIdentity', () => {
     it('loads a previously generated identity', async () => {
       const original = await manager.generateIdentity();

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,50 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13481; multi-machine live-transfer cascade)
+---
+
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — the encryption key now has the same legacy-name fallback the signing key got
+
+A direct follow-up to the previous release. Each machine in a multi-machine setup
+opens an encrypted channel to the others using two key files: a signing key and an
+encryption key. The project renamed these files to canonical names at some point,
+and a machine set up before that rename keeps its keys under the older names.
+
+The previous release taught the signing-key loader to fall back to the older
+filename. Deploying that revealed the identical gap one layer down: the
+encryption-key loader was still looking only for the canonical name, so a
+legacy-named machine got past the signing key and then threw an ENOENT on the
+encryption key, leaving its mesh transport unable to fully initialize. This release
+gives the encryption-key loader the same fallback.
+
+## Summary of New Capabilities
+
+- `MachineIdentity.loadEncryptionKey()` falls back to the legacy
+  `encryption-private.pem` when the canonical `encryption-key.pem` is absent
+  (rethrows if neither exists), mirroring `loadSigningKey()`.
+- A machine whose identity predates the canonical key rename now resolves BOTH
+  keys and completes its lease/transport setup without a hand-placed key file.
+
+## What to Tell Your User
+
+If you run your agent across more than one machine, a machine that was set up a
+while ago will now join the encrypted group channel on its own, without needing
+anyone to copy a key file into place by hand. This closes the second half of a pair
+of identical gaps that were quietly stopping an older machine from fully joining.
+Nothing to configure — it applies on the next update.
+
+## Evidence
+
+- Found live on the Mac mini: after the prior release resolved the signing key, the
+  mini still logged a startup error, no such file encryption-key.pem, at mesh
+  transport setup because it had only the legacy encryption-private.pem.
+- Unit, `tests/unit/machine-identity.test.ts`: loadEncryptionKey falls back to the
+  legacy name and still throws when neither file exists.
+- 68 machine-identity tests pass; tsc --noEmit clean.
+- Spec, `docs/specs/encryption-key-fallback.md` plus the .eli16.md sibling.
+- Side-effects, `upgrades/side-effects/encryption-key-fallback.md`.

--- a/upgrades/side-effects/encryption-key-fallback.md
+++ b/upgrades/side-effects/encryption-key-fallback.md
@@ -1,0 +1,85 @@
+# Side-Effects Review — loadEncryptionKey legacy-name fallback
+
+**Version / slug:** `encryption-key-fallback`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`MachineIdentity.loadEncryptionKey()` now mirrors `loadSigningKey()` (shipped in
+#610): read the canonical `encryption-key.pem`; on ENOENT, fall back to the legacy
+`encryption-private.pem` if present, else rethrow. Adds one module constant
+`LEGACY_ENCRYPTION_KEY_FILE`.
+
+## Decision-point inventory
+
+- **loadEncryptionKey catch branch** — canonical read throws ENOENT → legacy file
+  exists? read it : rethrow. Both branches covered by unit tests (falls back; still
+  throws when neither exists).
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** Nothing new. It only ADDS a
+second lookup location before the same terminal rethrow. Callers that previously
+succeeded (canonical present) are unaffected; callers that previously threw ENOENT
+with a legacy-only key now succeed.
+
+## 2. Under-block
+
+**What does this still miss?** Only the one known legacy name
+(`encryption-private.pem`) is tried, matching the signing-key fallback's single
+legacy name — not an open-ended search. A machine missing BOTH the canonical and
+the legacy file still throws (correct — there is no key to load).
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The fix lives in the single `loadEncryptionKey()` loader that
+every encryption-key consumer already calls, directly beside the `loadSigningKey()`
+fallback it mirrors. One constant beside `LEGACY_SIGNING_KEY_FILE`. No duplication.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No blocking authority added. A pure read-path widen with an unchanged terminal
+rethrow; gates nothing.
+
+## 5. Interactions
+
+`loadEncryptionKey` feeds the mesh transport's X25519 E2E encryption setup.
+Widening it only makes a previously-throwing legacy-keyed machine succeed — no
+consumer observes a different value, only present-vs-throw. Idempotent. Pairs with
+#610's signing-key fallback so a legacy-keyed machine resolves BOTH keys and its
+lease/transport setup completes.
+
+## 6. External surfaces
+
+None. No HTTP routes, config, notifications, or Telegram. The visible effect is the
+absence of the `Lease/transport setup: ENOENT … encryption-key.pem` boot warning on
+a legacy-keyed machine.
+
+## 7. Rollback cost
+
+Low. Revert the method to canonical-only and drop the constant; a legacy-keyed
+machine then re-trips the ENOENT at transport setup. No schema, no migration, no
+persisted state.
+
+## Conclusion
+
+Minimal additive read-path fallback, both branches unit-tested, no new authority,
+no external surface, cheap revert. Closes the encryption-key half of the legacy-key
+defect pair (#610 closed the signing-key half).
+
+## Second-pass review (if required)
+
+Not required — no new blocking authority, no destructive op, both branches tested,
+reversible; direct mirror of the already-reviewed #610 fallback.
+
+## Evidence pointers
+
+- `tests/unit/machine-identity.test.ts` — loadEncryptionKey legacy fallback + still-throws.
+- 68 machine-identity tests green; `tsc --noEmit` clean.
+- Found live on the mini: `Lease/transport setup: ENOENT … encryption-key.pem`
+  after #610 resolved the signing key.
+- Spec: `docs/specs/encryption-key-fallback.md` (+ `.eli16.md`).


### PR DESCRIPTION
## Bug #6 of the live-transfer cascade — direct follow-up to #610

#610 (v1.3.151) gave `MachineIdentity.loadSigningKey()` a fallback to the legacy
`signing-private.pem`. Deploying it to the mini surfaced the IDENTICAL defect one
layer down: `loadEncryptionKey()` was canonical-only, and the mini (keyed before
the canonical rename) had only `encryption-private.pem`. So with the signing key
resolved, mesh lease/transport setup STILL threw at boot:

```
Lease/transport setup: ENOENT: no such file or directory, open
  '…/.instar/machine/encryption-key.pem'
```

The transport loads BOTH keys (Ed25519 signing + X25519 encryption); a legacy-keyed
machine resolved the first and tripped on the second.

`loadEncryptionKey()` now mirrors `loadSigningKey()`: canonical first, fall back to
the legacy `encryption-private.pem` on ENOENT, else rethrow. One new constant
`LEGACY_ENCRYPTION_KEY_FILE`.

## Tests
- `tests/unit/machine-identity.test.ts` — loadEncryptionKey falls back to the legacy name; still throws when neither exists.
- 68 machine-identity tests green; `tsc --noEmit` clean.

## Ship-gate
- Spec `docs/specs/encryption-key-fallback.md` (+ `.eli16.md`), self-approved under the standing 12h deploy mandate (topic 13481) — flagged here per cross-agent discipline.
- Side-effects `upgrades/side-effects/encryption-key-fallback.md`; upgrade guide `upgrades/NEXT.md`.

## Live status
Found + worked around live on the mini (canonical key provided by hand → transport now boots clean, mini resolves leaseHolder=laptop). This PR is the proper code fix so future legacy-keyed machines need no hand copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
