### PR TITLE
feat(codex): auto-wire native /goal for codex autonomous mode (Claude parity — headline #40)

### DIFF
--- a/.claude/skills/autonomous/scripts/setup-autonomous.sh
+++ b/.claude/skills/autonomous/scripts/setup-autonomous.sh
@@ -211,6 +211,16 @@ if [[ -n "$COMPLETION_CONDITION" ]] && [[ -n "$REPORT_TOPIC" ]]; then
       NATIVE_GOAL_OK="true"
     fi
   fi
+  # Codex agents have their OWN native /goal loop — the Claude Code version gate above does
+  # not apply (`claude --version` is empty for a codex agent), which previously left codex
+  # autonomous jobs in Phase-1 (the dark codexLoopDriver, a no-op) so they never sustained
+  # multi-turn. Detect a codex agent via config enabledFrameworks and enable native /goal
+  # delegation so codex autonomous mode auto-sustains multi-turn via /goal — parity with
+  # Claude's stop-hook auto-sustain. (Proven: codex /goal sustains 1→2→3 across turns.)
+  if [[ "$NATIVE_GOAL_OK" != "true" ]]; then
+    IS_CODEX_AGENT=$(python3 -c "import json;print('1' if 'codex-cli' in (json.load(open('.instar/config.json')).get('enabledFrameworks') or []) else '0')" 2>/dev/null || echo "0")
+    [[ "$IS_CODEX_AGENT" == "1" ]] && NATIVE_GOAL_OK="true"
+  fi
   if [[ "$NATIVE_GOAL_OK" == "true" ]]; then
     NG_PORT=$(python3 -c "import json;print(json.load(open('.instar/config.json')).get('port',4040))" 2>/dev/null || echo 4040)
     NG_AUTH=$(python3 -c "import json;print(json.load(open('.instar/config.json')).get('authToken',''))" 2>/dev/null || echo "")

--- a/docs/specs/codex-autonomy-native-goal-autowire.eli16.md
+++ b/docs/specs/codex-autonomy-native-goal-autowire.eli16.md
@@ -1,0 +1,53 @@
+# Explain it like I'm 16: let Codex agents run on their own, too
+
+## The setup
+
+Some of our AI agents run on Anthropic's Claude; others run on OpenAI's Codex. When you put an
+agent in "autonomous mode," it's supposed to keep working across many turns on its own — do a
+step, keep going, do the next step — until the job is done, instead of stopping after one turn.
+
+For a **Claude** agent this already works: a little "stop hook" nudges it to continue each time
+it tries to stop. For a **Codex** agent, that nudge approach doesn't fit — but Codex has its OWN
+built-in way to keep going: a command called `/goal`. You hand `/goal` the objective, and Codex
+drives itself turn after turn until it's met. We already proved this works (Codex counted 1, 2,
+3 across separate turns on its own).
+
+## The problem
+
+We already had code to hand the goal to `/goal` automatically when autonomous mode starts. But
+that code had a gate that said, in effect, "only do this if Claude's command-line tool is
+version 2.1.139 or newer." That check makes sense for Claude — but a **Codex** agent doesn't
+have Claude's command-line tool at all, so the check comes back empty and **fails**. Result:
+Codex agents silently never got handed to `/goal`, and so a Codex agent in autonomous mode
+would quietly stop after one turn instead of continuing. The capability was there; the wiring
+just had a Claude-shaped hole that Codex fell through.
+
+## The fix
+
+Add a small fallback right after that Claude version check: if the Claude check didn't pass,
+look at the agent's own config to see if it's a Codex agent (its `enabledFrameworks` list
+contains `codex-cli`). If so, turn the native-`/goal` hand-off on — because Codex has `/goal`
+and we've proven it works. Now a Codex agent in autonomous mode automatically drives itself
+with `/goal`, just like a Claude agent drives itself with the stop hook. Same outcome —
+"keep going until done" — for both.
+
+## Why it's safe
+
+It's a five-line, additive fallback. The Claude version check is completely untouched, so
+nothing changes for Claude agents. We don't touch the sensitive stop-hook at all (the part
+that defers to `/goal` was already there and already proven). If, for any reason, reading the
+config fails, the worst case is we just fall back to exactly the old behavior — no regression.
+
+## Making sure existing agents get it
+
+The setup script lives inside each agent and isn't auto-overwritten, so we bump a little
+"version marker" the update process watches for. Agents that have the older setup (with the
+Claude-only gate) get the fixed script automatically on their next update; agents that
+customized their script are left alone; agents already updated skip.
+
+## How we know it works
+
+Tests check both sides: a Codex agent turns native `/goal` ON; a Claude agent leaves it OFF;
+a mixed agent that includes Codex turns it ON; and the update correctly re-deploys the fixed
+script to older agents. The final proof is driving a real Codex agent through autonomous mode
+and watching it sustain multiple turns on its own.

--- a/docs/specs/codex-autonomy-native-goal-autowire.md
+++ b/docs/specs/codex-autonomy-native-goal-autowire.md
@@ -1,0 +1,78 @@
+---
+title: Codex autonomous mode — auto-wire native /goal delegation (Claude parity)
+slug: codex-autonomy-native-goal-autowire
+date: 2026-05-31
+author: echo
+status: approved
+review-convergence: internal-plus-second-pass-2026-05-31
+approved: true
+approved-by: Justin (Telegram topic 13435, 2026-05-31 08:46Z — "Yes, please proceed. I'll go with your recommendations for all of these")
+approval-note: >
+  Justin explicitly greenlit this (the headline codex/Claude parity item) with "go with your
+  recommendations." FULL Claude/Codex parity is a stated tenet. The fix proved surgical after
+  reading the code (verify-don't-infer): the native /goal auto-delegation already exists in
+  setup-autonomous.sh but was gated on a Claude-CLI-only version check that excludes codex.
+second-pass-required: false
+second-pass-status: n/a-additive-codex-branch-claude-path-unchanged
+eli16-overview: codex-autonomy-native-goal-autowire.eli16.md
+---
+
+# Codex autonomous mode — auto-wire native /goal delegation
+
+## Background — the headline parity gap, grounded
+
+A Claude agent in autonomous mode auto-sustains multi-turn work: the autonomous-stop-hook
+re-prompts on each Stop until the goal/duration is met. A **codex** agent could not — `codex
+exec` runs one turn and stops. Round 2 proved (live) that codex CAN sustain multi-turn
+**natively via `/goal`** (instar's Phase-2 "native /goal delegation": inject `/goal
+<condition>` + mark the job `goal_mode:native`; the stop-hook then defers to native /goal).
+
+Reading the code revealed the auto-delegation **already exists** in
+`.claude/skills/autonomous/scripts/setup-autonomous.sh` — but it is gated on
+`claude --version >= 2.1.139` (lines ~205-213). For a codex agent, `claude --version` is
+empty/fails, so `NATIVE_GOAL_OK` stays false and the codex autonomous job falls through to
+Phase-1 (the `codexLoopDriver` flag, which ships dark → a no-op). Net: **a codex agent's
+autonomous mode silently never sustains multi-turn**, even though codex has native `/goal`.
+
+## Design
+
+In `setup-autonomous.sh`, after the Claude-CLI version gate, add a framework-aware fallback:
+if `NATIVE_GOAL_OK` is still false, detect a codex agent via config `enabledFrameworks`
+containing `codex-cli` and set `NATIVE_GOAL_OK=true`. The existing delegation block then
+POSTs `/autonomous/native-goal/set` (inject `/goal <completion_condition>` + `goal_mode:
+native`), and the **already-present** stop-hook `goal_mode:native` branch defers completion
+to native `/goal`. So codex autonomous mode now auto-sustains via native `/goal` — Claude
+parity — with **no change to the sensitive stop-hook** and **no change to the Claude path**
+(the Claude version gate is untouched; codex is an additive fallback).
+
+```
+IS_CODEX_AGENT=$(python3 -c "import json;print('1' if 'codex-cli' in
+  (json.load(open('.instar/config.json')).get('enabledFrameworks') or []) else '0')" 2>/dev/null || echo "0")
+[[ "$IS_CODEX_AGENT" == "1" ]] && NATIVE_GOAL_OK="true"
+```
+
+## Migration parity
+
+`setup-autonomous.sh` is skill content; `installAutonomousSkill()` is install-if-missing, so
+existing agents only get it through `PostUpdateMigrator.migrateAutonomousStopHookTopicKeyed`,
+which overwrites the deployed script from the bundled copy gated on a content marker. The
+marker is bumped `native-goal/set` → `IS_CODEX_AGENT`: a prior native-/goal install carries
+`native-goal/set` but not `IS_CODEX_AGENT`, so it is re-deployed; customized scripts (no stock
+`autonomous-state.local.md` fingerprint) are left untouched; agents already on the new version
+skip (idempotent).
+
+## Safety
+- Additive codex fallback — the Claude version gate and the entire Claude path are byte-for-byte
+  unchanged. Best-effort (`|| echo "0"`); a config read miss → not-codex → prior behavior.
+- No change to the stop-hook (the goal_mode:native defer already exists and is proven).
+- Worst case (detection fails): codex falls back to prior behavior (Phase-1 no-op) — no regression.
+
+## Test plan
+- Unit (`autonomous-codex-native-goal-detection.test.ts`): both sides of the decision boundary —
+  codex (enabledFrameworks⊇codex-cli) → enable; Claude / absent → skip; multi-framework⊇codex →
+  enable; missing config → best-effort skip.
+- Unit (`PostUpdateMigrator-autonomousStopHook.test.ts`, extended): a prior native-/goal setup
+  (marker `native-goal/set`, no `IS_CODEX_AGENT`) is re-deployed by the marker bump; existing
+  cases (old→per-topic, customized-untouched, idempotent, run()-wired) stay green.
+- LIVE-VERIFY (the real proof): drive Codey to run the actual `/autonomous` skill (not a manual
+  native-goal call) and confirm setup auto-delegates → codex autonomous sustains multi-turn.

--- a/src/core/PostUpdateMigrator.ts
+++ b/src/core/PostUpdateMigrator.ts
@@ -1530,11 +1530,18 @@ export class PostUpdateMigrator {
       'Autonomous Mode Stop Hook',
       'skills/autonomous/hooks/autonomous-stop-hook.sh (codex Stop stdout JSON-safe — emit() to stderr)',
     );
+    // setup-autonomous.sh marker bumped `native-goal/set` → `IS_CODEX_AGENT`: the bundled
+    // setup now ALSO auto-delegates to native /goal for CODEX agents (the prior native /goal
+    // wiring was gated on `claude --version >= 2.1.139`, which is empty for a codex agent, so
+    // codex autonomous jobs fell through to the dark Phase-1 codexLoopDriver no-op and never
+    // sustained multi-turn). Bumping the marker re-deploys the FIXED setup to existing agents
+    // (which carry `native-goal/set` but not `IS_CODEX_AGENT`); customized scripts (no stock
+    // `autonomous-state.local.md` fingerprint) are still left untouched.
     upgrade(
       '.claude/skills/autonomous/scripts/setup-autonomous.sh',
-      'native-goal/set',
+      'IS_CODEX_AGENT',
       'autonomous-state.local.md',
-      'skills/autonomous/scripts/setup-autonomous.sh (per-topic + completion-condition + native /goal)',
+      'skills/autonomous/scripts/setup-autonomous.sh (codex native /goal auto-wire)',
     );
   }
 

--- a/tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts
+++ b/tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts
@@ -53,6 +53,17 @@ active: true
 EOF
 `;
 
+// A prior-version setup that ALREADY has native /goal (the prior marker 'native-goal/set')
+// but NOT the codex native-/goal auto-wire ('IS_CODEX_AGENT'). Carries the stock fingerprint
+// ('autonomous-state.local.md'). Under the old marker this would be SKIPPED as current; after
+// the marker bump it must be re-deployed so codex agents get native /goal auto-delegation.
+const PRIOR_NATIVE_GOAL_SETUP = `#!/bin/bash
+# setup-autonomous.sh — legacy fallback is .instar/autonomous-state.local.md
+STATE_PATH=".instar/autonomous/\${REPORT_TOPIC}.local.md"
+# native /goal delegation (Claude only, gated on claude --version)
+curl -s --data-binary @- "http://localhost:4040/autonomous/native-goal/set" >/dev/null 2>&1
+`;
+
 function deploySetup(projectDir: string, content: string): string {
   const dst = path.join(projectDir, SETUP_REL);
   fs.mkdirSync(path.dirname(dst), { recursive: true });
@@ -165,6 +176,24 @@ describe('PostUpdateMigrator — autonomous stop hook topic-keying', () => {
 
     const updated = fs.readFileSync(dst, 'utf8');
     expect(updated).toContain('STATE_PATH=".instar/autonomous/'); // per-topic path
+    expect(result.upgraded.some(u => u.includes('setup-autonomous.sh'))).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('re-deploys a prior native-/goal setup so codex agents get native /goal auto-wire (#40 marker bump)', () => {
+    // Prior version carries the old marker `native-goal/set` (Claude-only native /goal) but
+    // not `IS_CODEX_AGENT` — under the old marker it would be wrongly skipped as current.
+    const dst = deploySetup(projectDir, PRIOR_NATIVE_GOAL_SETUP);
+    const before = fs.readFileSync(dst, 'utf8');
+    expect(before).toContain('native-goal/set');
+    expect(before).not.toContain('IS_CODEX_AGENT');
+
+    const result = runMigration(newMigrator(projectDir));
+
+    const updated = fs.readFileSync(dst, 'utf8');
+    expect(updated).toContain('IS_CODEX_AGENT');           // codex native /goal auto-wire present
+    expect(updated).toContain("'codex-cli' in");            // detects codex via enabledFrameworks
+    expect((fs.statSync(dst).mode & 0o111)).not.toBe(0);    // executable
     expect(result.upgraded.some(u => u.includes('setup-autonomous.sh'))).toBe(true);
     expect(result.errors).toEqual([]);
   });

--- a/tests/unit/autonomous-codex-native-goal-detection.test.ts
+++ b/tests/unit/autonomous-codex-native-goal-detection.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Verifies the codex-agent detection that setup-autonomous.sh uses to enable native /goal
+ * auto-delegation for codex (#40). The script's claude-version gate is empty for a codex
+ * agent, so it falls back to this config-enabledFrameworks check. This tests both sides of
+ * the decision boundary: a codex agent enables native /goal; a Claude agent does not.
+ *
+ * The detection is the exact python one-liner embedded in setup-autonomous.sh:
+ *   'codex-cli' in (config.enabledFrameworks or [])  → '1' (enable) else '0' (skip)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+
+// The exact expression from setup-autonomous.sh (run with cwd = the agent dir).
+const DETECT =
+  "import json;print('1' if 'codex-cli' in (json.load(open('.instar/config.json')).get('enabledFrameworks') or []) else '0')";
+
+function detect(dir: string): string {
+  const r = spawnSync('python3', ['-c', DETECT], { cwd: dir, encoding: 'utf-8', timeout: 5000 });
+  return (r.stdout || '').trim();
+}
+
+function writeConfig(dir: string, config: object): void {
+  fs.mkdirSync(path.join(dir, '.instar'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.instar', 'config.json'), JSON.stringify(config));
+}
+
+describe('setup-autonomous.sh codex detection (#40 native /goal auto-wire)', () => {
+  let dir: string;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-detect-')); });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(dir, { recursive: true, force: true, operation: 'tests/unit/autonomous-codex-native-goal-detection.test.ts' });
+  });
+
+  it('enables (1) for a codex agent (enabledFrameworks includes codex-cli)', () => {
+    writeConfig(dir, { enabledFrameworks: ['codex-cli'], frameworkBinaryPaths: { 'codex-cli': '/x/codex' } });
+    expect(detect(dir)).toBe('1');
+  });
+
+  it('does NOT enable (0) for a Claude agent (no codex-cli)', () => {
+    writeConfig(dir, { enabledFrameworks: ['claude-code'] });
+    expect(detect(dir)).toBe('0');
+  });
+
+  it('does NOT enable (0) when enabledFrameworks is absent', () => {
+    writeConfig(dir, { port: 4042 });
+    expect(detect(dir)).toBe('0');
+  });
+
+  it('enables (1) for a multi-framework agent that includes codex-cli', () => {
+    writeConfig(dir, { enabledFrameworks: ['claude-code', 'codex-cli'] });
+    expect(detect(dir)).toBe('1');
+  });
+
+  it('does NOT throw (best-effort 0) when config.json is missing', () => {
+    // No config written — the embedded one-liner is wrapped in `|| echo "0"` in the script;
+    // here the python errors, so stdout is empty → the script treats it as not-codex.
+    expect(detect(dir)).toBe('');
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,53 @@
+---
+review-convergence: complete
+approved: true
+approved-by: Justin (topic 13435, 2026-05-31 08:46Z — "go with your recommendations")
+---
+
+# Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — Codex agents now run autonomous mode on their own (Claude parity)
+
+When you put an agent in autonomous mode, it should keep working across many turns until the job
+is done. Claude agents already did this (via the stop hook). Codex agents did NOT — they would
+quietly stop after one turn. Codex actually has its own way to sustain a multi-turn run (its
+built-in /goal loop), and instar already handed the goal off to it automatically — but only
+behind a check for "Claude command-line version 2.1.139+", which is empty for a Codex agent. So
+Codex agents fell through that Claude-shaped gate and never got the hand-off.
+
+This adds a small framework-aware fallback: if the Claude check doesn't apply, instar detects a
+Codex agent (from its own config) and hands the goal to Codex's native /goal loop. Now a Codex
+agent in autonomous mode sustains multi-turn work automatically, the same as a Claude agent. The
+Claude path is unchanged, and the sensitive stop hook is untouched.
+
+## Summary of New Capabilities
+
+- `setup-autonomous.sh` now enables native /goal delegation for Codex agents (detected via config
+  `enabledFrameworks` containing `codex-cli`), not just Claude Code >= 2.1.139. Codex autonomous
+  mode auto-delegates to native /goal; the stop-hook's existing `goal_mode:native` branch defers.
+- `PostUpdateMigrator` marker bump (`native-goal/set` → `IS_CODEX_AGENT`) re-deploys the fixed
+  setup script to existing agents.
+
+## What to Tell Your User
+
+If you run a Codex-based agent, it can now run in autonomous mode and keep itself going across
+many turns until the goal is met — the same way a Claude agent does. Before, a Codex agent in
+autonomous mode would quietly stop after a single turn. Nothing to configure; it applies on the
+next update, and Claude agents are unaffected.
+
+## Evidence
+
+- Root cause traced by reading setup-autonomous.sh: the native /goal hand-off existed but was
+  gated on `claude --version >= 2.1.139` (empty for a codex agent → codex fell to the dark
+  Phase-1 no-op). Proven live in round 2 that codex /goal sustains 1→2→3 across turns.
+- Unit: `tests/unit/autonomous-codex-native-goal-detection.test.ts` — both sides of the
+  decision boundary (codex enables, Claude/absent skips, multi-framework enables, missing config
+  best-effort skips).
+- Unit: `tests/unit/PostUpdateMigrator-autonomousStopHook.test.ts` — a prior native-/goal setup
+  is re-deployed by the marker bump; all existing cases stay green (8 tests).
+- `tsc --noEmit` + `npm run lint` clean.
+- Spec: `docs/specs/codex-autonomy-native-goal-autowire.md` (+ `.eli16.md`).
+- Side-effects: `upgrades/side-effects/codex-autonomy-native-goal-autowire.md`.
+- Final proof is the live drive: Codey running the real /autonomous skill and sustaining multi-turn.

--- a/upgrades/side-effects/codex-autonomy-native-goal-autowire.md
+++ b/upgrades/side-effects/codex-autonomy-native-goal-autowire.md
@@ -1,0 +1,43 @@
+# Side-effects — Codex autonomous native /goal auto-wire
+
+## 1. What files/state does this touch at runtime?
+`.claude/skills/autonomous/scripts/setup-autonomous.sh` (skill content). At autonomous-mode
+activation on a CODEX agent, it now additionally POSTs `/autonomous/native-goal/set` (which the
+script already did for Claude>=2.1.139) — injecting `/goal <completion_condition>` into the
+session and marking the job `goal_mode:native` in `<topic>.local.md`. No new files, no config
+keys, no schema. The PostUpdateMigrator re-deploys the script to existing agents (marker bump).
+
+## 2. Does it change any functional behavior?
+- **Claude agents:** none. The Claude version gate is untouched; the codex check only runs when
+  the Claude gate already failed.
+- **Codex agents:** a codex autonomous job now auto-delegates to native `/goal` (previously it
+  fell through to the dark Phase-1 codexLoopDriver no-op and silently never sustained multi-turn).
+  The stop-hook's existing `goal_mode:native` branch then defers to native `/goal`.
+
+## 3. What happens on failure / weird config?
+Best-effort: the detection one-liner is `... 2>/dev/null || echo "0"`, so a missing/malformed
+config.json or absent python → `0` → not-codex → exactly the prior behavior (no regression). A
+codex agent whose native `/goal` POST fails → the script prints "Native /goal: unavailable" and
+instar's own completion evaluator drives (the existing fallback).
+
+## 4. Migration parity — do existing agents get it?
+Yes. `migrateAutonomousStopHookTopicKeyed` marker bumped `native-goal/set` → `IS_CODEX_AGENT`,
+so prior native-/goal installs are re-deployed; customized scripts (no stock fingerprint) are
+left untouched; already-updated agents skip (idempotent). New agents get it via installAutonomousSkill.
+
+## 5. Could it spam / flood / burn resources?
+No. It adds at most one extra `python3` config read + (for codex) one `native-goal/set` POST,
+once, at autonomous-mode activation — the same POST the script already made for Claude.
+
+## 6. Rollback / off-switch?
+Revert the PR. The marker would revert too; a reverted-version agent retains `native-goal/set`
+(still functional for Claude). No residual state, no flag.
+
+## 7. Concurrency / ordering?
+None new. Runs inline in the single setup-autonomous.sh activation flow, after the Claude gate.
+
+## Blast radius
+Small + additive, codex-only. One ~5-line fallback in setup-autonomous.sh + one migration marker
+bump in PostUpdateMigrator. No change to the sensitive stop-hook (the goal_mode:native defer
+already existed), no change to the Claude path. Mirrors the #604/#609 codex framework-additive
+pattern. The codexLoopDriver:true config footgun is a separate low-pri follow-up (#40 notes).


### PR DESCRIPTION
## What & why (the headline Claude/Codex parity win — Justin-approved)

A **Claude** agent in autonomous mode auto-sustains multi-turn work (the stop-hook re-prompts each Stop). A **codex** agent could not — `codex exec` runs one turn and stops. Round 2 proved (live) that codex CAN sustain multi-turn **natively via `/goal`** (instar's Phase-2 "native /goal delegation": inject `/goal <condition>` + mark `goal_mode:native`; the stop-hook defers to native /goal).

**Reading the code (verify-don't-infer) found the bug is tiny, not the big stop-hook change I'd first designed:** the native /goal auto-delegation *already exists* in `setup-autonomous.sh`, but it's gated on `claude --version >= 2.1.139` (a Claude-CLI check). For a codex agent `claude --version` is empty → `NATIVE_GOAL_OK=false` → the codex autonomous job falls through to the dark Phase-1 `codexLoopDriver` no-op and **silently never sustains multi-turn**.

## Change
A ~5-line framework-aware fallback in `setup-autonomous.sh`: if the Claude gate fails, detect a codex agent via config `enabledFrameworks` containing `codex-cli` → `NATIVE_GOAL_OK=true`. The existing block then POSTs `/autonomous/native-goal/set` and the **already-present** stop-hook `goal_mode:native` branch defers to native `/goal`.

- **Claude path untouched** (version gate unchanged; codex is an additive fallback).
- **Stop-hook untouched** (the `goal_mode:native` defer already existed + is proven).
- Worst case (detection fails): codex falls back to prior behavior — no regression.

## Migration parity
`migrateAutonomousStopHookTopicKeyed` marker bumped `native-goal/set` → `IS_CODEX_AGENT` so prior native-/goal installs are re-deployed; customized scripts (no stock fingerprint) left untouched; updated agents skip (idempotent).

## Tests / gate
- Unit (`autonomous-codex-native-goal-detection.test.ts`): both sides of the decision boundary — codex enables; Claude/absent skips; multi-framework⊇codex enables; missing config best-effort skips.
- Unit (`PostUpdateMigrator-autonomousStopHook.test.ts`, extended): a prior native-/goal setup is re-deployed by the marker bump; all 8 existing cases stay green.
- `tsc --noEmit` + `npm run lint` clean; instar-dev gate (spec `approved:true` + ELI16 + side-effects + trace). **13 tests green.**

## Live-verify (the real proof, post-deploy)
Drive Codey to run the actual `/autonomous` skill (not a manual native-goal call) → confirm setup auto-delegates → codex autonomous sustains multi-turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Approved by Justin (topic 13435, 2026-05-31): "go with your recommendations." Round-3 autonomous session.