### PR TITLE
ci(release): per-PR release-note fragments — fix the NEXT.md concurrency bottleneck

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,16 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      - name: Assemble release-note fragments
+        # Release notes are authored as per-PR FRAGMENTS in upgrades/next/<slug>.md
+        # so concurrent PRs never collide on a single shared NEXT.md. This pre-step
+        # folds every fragment (+ any legacy upgrades/NEXT.md) into upgrades/NEXT.md
+        # BEFORE the existing pipeline runs — everything downstream is UNCHANGED.
+        # No fragments AND no legacy NEXT.md → it does nothing and the next step's
+        # skip logic fires exactly as before. A malformed fragment exits non-zero
+        # and fails the run loudly (better than shipping a broken guide).
+        run: node scripts/assemble-next-md.mjs
+
       - name: Check if NEXT.md has content to publish
         id: guide-check
         run: |
@@ -159,6 +169,13 @@ jobs:
             echo "Renamed upgrades/NEXT.md → upgrades/${{ steps.bump.outputs.version }}.md"
           else
             echo "No upgrades/NEXT.md found — check-upgrade-guide will enforce"
+          fi
+          # Consume the per-PR fragments now that their content has been folded
+          # into the version-specific guide. The commit step's `git add upgrades/`
+          # stages these deletions, so released fragments don't accumulate.
+          if ls upgrades/next/*.md >/dev/null 2>&1; then
+            rm -f upgrades/next/*.md
+            echo "Removed consumed release-note fragments from upgrades/next/"
           fi
 
       - name: Check upgrade guide

--- a/docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md
+++ b/docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md
@@ -480,15 +480,17 @@ These are patterns Instar has *already built infrastructure for*. Any new spec t
 
 ---
 
-### L10. Release notes in same PR
+### L10. Release notes in same PR — write a FRAGMENT, not the shared NEXT.md
 
-**Lesson:** Every behavior-changing instar PR must fill `upgrades/NEXT.md` in the SAME commit. Required by the release-cut gate.
+**Lesson:** Every behavior-changing instar PR must ship its release note in the SAME commit. Author it as a per-PR **fragment** at `upgrades/next/<slug>.md` — NOT by editing the shared `upgrades/NEXT.md`. The fragment carries the same sections (`## What Changed`, `## What to Tell Your User`, `## Summary of New Capabilities`, optional `## Evidence`) and a `<!-- bump: patch|minor|major -->` hint. Two PRs touch different fragment files, so they never collide on the release notes — which is exactly the bottleneck that made concurrent merges un-landable when every PR rewrote the one shared NEXT.md.
 
-**Source:** `.instar/memory/feedback_release_notes_in_same_pr.md`.
+**Why fragments:** the publish pipeline now runs `scripts/assemble-next-md.mjs` as a pre-step that folds every `upgrades/next/*.md` (deterministic filename order) — plus any legacy `upgrades/NEXT.md` — into a single `upgrades/NEXT.md` by section, then the unchanged downstream pipeline renames it to `upgrades/<version>.md` and deletes the consumed fragments. The assembled bump directive is the MAX tier across fragments; the REAL release tier is still `.instar/release-tier.json`.
 
-**Infrastructure built:** Pre-push gate checks NEXT.md presence + structure.
+**Source:** `.instar/memory/feedback_release_notes_in_same_pr.md`; per-PR fragment system (`scripts/assemble-next-md.mjs`).
 
-**Design-pipeline application:** The NEXT.md content is what the user sees on update. Lead with "What to Tell Your User" — single conversational sentence, no jargon, no code snippets.
+**Infrastructure built:** Pre-push gate is fragment-aware — it assembles fragments + any legacy NEXT.md in-memory and validates that result (presence + structure + content), so a fragment-only PR passes the same checks. `upgrades/NEXT.md` remains fully supported as a legacy / backward-compat path (a hand-authored NEXT.md is folded in), but new PRs should write fragments.
+
+**Design-pipeline application:** The assembled content is what the user sees on update. Lead each fragment's "What to Tell Your User" with a single conversational sentence — no jargon, no code snippets, no backticks (the validator rejects inline code / camelCase config keys in that section).
 
 ---
 

--- a/docs/specs/pre-push-upgrade-guide-validation.md
+++ b/docs/specs/pre-push-upgrade-guide-validation.md
@@ -58,3 +58,16 @@ Revert `scripts/pre-push-gate.js` and the test additions, ship a patch release. 
 ## Convergence Notes
 
 Single-iteration. The motivating incident is documented in PR #228 (which manually unblocked the same publish failure today). Justin's authorization on Telegram topic 8615 explicitly covered "the publish pipe failing silently for two days is the deeper issue here. The cleanest fix would be to move the upgrade-guide validation INTO the pre-push gate." This PR implements that exact ask.
+
+## Addendum — fragment-aware validation (per-PR release-note fragments)
+
+Release notes are now authored as per-PR FRAGMENTS at `upgrades/next/<slug>.md` instead of a single shared `upgrades/NEXT.md`, so concurrent PRs never collide on the release notes (see `scripts/assemble-next-md.mjs` and the L10 lesson in `docs/INSTAR-DESIGN-PRINCIPLES-AND-LESSONS.md`).
+
+The pre-push gate stays symmetric with publish by validating the ASSEMBLED result rather than NEXT.md alone:
+
+- It calls `gatherFragmentInputs` + `assembleNextMd` (the SAME assembler the publish workflow runs) to fold `upgrades/next/*.md` + any legacy `upgrades/NEXT.md` into an in-memory string, then runs `validateGuideContent` on that string. A PR that ships ONLY a fragment therefore passes the identical section/content checks.
+- It assembles in-memory ONLY — it never writes `upgrades/NEXT.md` to disk during pre-push, so the PR keeps its fragment, not a generated guide.
+- A malformed fragment (content but no parseable `## ` section) fails the push loudly, mirroring the loud failure the publish workflow would hit.
+- When no fragment and no legacy NEXT.md is staged, it falls back to validating the versioned `${version}.md` (post-release-cut state), preserving prior behavior.
+
+Authority is unchanged: `validateGuideContent` is still the single deterministic authority; the assembler is a transform that feeds it, not a new gate. `upgrades/NEXT.md` remains a fully supported legacy path.

--- a/scripts/assemble-next-md.mjs
+++ b/scripts/assemble-next-md.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/**
+ * assemble-next-md — fold per-PR release-note FRAGMENTS into a single NEXT.md.
+ *
+ * ── Why this exists ───────────────────────────────────────────────────
+ * The release pipeline consumes a single shared `upgrades/NEXT.md` per merge.
+ * With many agents merging concurrently, EVERY PR rewrote that one file, so
+ * every PR collided on it within minutes — the release notes became an
+ * un-landable hot file. The fix is per-PR FRAGMENTS: each PR ships its note as
+ * `upgrades/next/<slug>.md`, touching a distinct file, so two PRs never
+ * collide. This script concatenates the fragments into `upgrades/NEXT.md`
+ * BEFORE the existing publish pipeline runs, leaving everything downstream
+ * unchanged.
+ *
+ * ── What it does ──────────────────────────────────────────────────────
+ *   1. Reads every `upgrades/next/*.md` fragment (deterministic filename sort).
+ *   2. Folds in a legacy `upgrades/NEXT.md` too, if one exists (backward compat).
+ *   3. Merges by section: the result has ONE "## What Changed", ONE
+ *      "## Summary of New Capabilities", ONE "## What to Tell Your User", ONE
+ *      "## Evidence" — each section is the concatenation of that section across
+ *      all inputs (in source order). Any non-canonical H2 section is preserved
+ *      and appended after the canonical ones (also concatenated by title).
+ *   4. The bump directive is the HIGHEST tier among the inputs
+ *      (major > minor > patch), emitted as `<!-- bump: X -->`. This is a
+ *      documentation hint only — the REAL release tier is
+ *      `.instar/release-tier.json`, which this script never touches.
+ *   5. Writes the merged result to `upgrades/NEXT.md`.
+ *
+ * ── No-op / failure semantics ─────────────────────────────────────────
+ *   - NO fragments AND NO legacy NEXT.md → does nothing, exits 0 quietly. The
+ *     existing publish "skip if no NEXT.md" logic then fires unchanged.
+ *   - A real malformation (a fragment with content but no parseable H2 section
+ *     at all) → exits non-zero with a clear message, so the workflow fails
+ *     loudly rather than shipping a broken guide.
+ *   - Idempotent: running twice produces the same NEXT.md. (When a generated
+ *     NEXT.md is the ONLY input — no fragments — it is re-emitted byte-stable.)
+ *
+ * The core `assembleNextMd()` function is pure (string in / string out) and is
+ * exported for unit testing. The CLI wrapper at the bottom handles I/O.
+ *
+ * Usage:
+ *   node scripts/assemble-next-md.mjs            # assemble + write upgrades/NEXT.md
+ *   node scripts/assemble-next-md.mjs --upgrades-dir <path>   # override (tests)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// ── Canonical section order ───────────────────────────────────────────
+// These four are the sections check-upgrade-guide.js / upgrade-guide-validator
+// know about. We emit them in this order; any other H2 is appended after.
+export const CANONICAL_SECTIONS = [
+  'What Changed',
+  'What to Tell Your User',
+  'Summary of New Capabilities',
+  'Evidence',
+];
+
+const BUMP_RANK = { patch: 0, minor: 1, major: 2 };
+const RANK_BUMP = ['patch', 'minor', 'major'];
+
+const H1_HEADER = '# Upgrade Guide — vNEXT';
+
+// Stable marker stamped into every machine-assembled NEXT.md. It lets us
+// recognize (and skip re-folding) a NEXT.md that this script generated, which
+// is what keeps the on-disk assemble idempotent: a second run shouldn't fold
+// the previous run's output back in on top of the still-present fragments. A
+// hand-authored legacy NEXT.md (no marker) is still folded for backward compat.
+export const GENERATED_MARKER = '<!-- assembled-by: assemble-next-md -->';
+
+/** True when content was produced by this assembler (carries the marker). */
+export function isAssembledOutput(content) {
+  return String(content).includes(GENERATED_MARKER);
+}
+
+/**
+ * Parse the declared bump type from a fragment's `<!-- bump: TYPE -->` comment.
+ * Returns 'patch' | 'minor' | 'major' | null.
+ */
+export function parseBumpType(content) {
+  const match = /<!--\s*bump:\s*(patch|minor|major)\s*-->/i.exec(content);
+  return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * Split a fragment body into H2 sections: [{ title, body }] in source order.
+ * `body` excludes the heading line itself and is right-trimmed.
+ * Content before the first H2 (H1 header, bump comment, stray prose) is dropped
+ * from the section map — the assembler synthesizes a fresh H1 + bump comment.
+ */
+export function parseSections(content) {
+  const out = [];
+  const lines = String(content).replace(/\r\n/g, '\n').split('\n');
+  let current = null;
+  for (const line of lines) {
+    const m = /^##\s+(.+?)\s*$/.exec(line);
+    if (m) {
+      if (current) out.push(current);
+      current = { title: m[1].trim(), lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) out.push(current);
+  return out.map((s) => ({ title: s.title, body: s.lines.join('\n').replace(/\s+$/, '') }));
+}
+
+/**
+ * Is this fragment content "empty" for assembly purposes? True when stripping
+ * HTML comments and whitespace leaves nothing.
+ */
+function isEffectivelyEmpty(content) {
+  return String(content).replace(/<!--[\s\S]*?-->/g, '').trim().length === 0;
+}
+
+/**
+ * Core assembler. Pure: takes named fragment inputs, returns the merged NEXT.md
+ * string (or throws on a real malformation).
+ *
+ * @param {Array<{ name: string, content: string }>} fragments
+ *   Each input fragment, in the order they should be concatenated. `name` is
+ *   used only for error messages.
+ * @returns {string} the assembled NEXT.md content (with trailing newline).
+ * @throws {Error} when a fragment has content but no parseable H2 section.
+ */
+export function assembleNextMd(fragments) {
+  // Idempotency guard: a previously-assembled NEXT.md (carrying GENERATED_MARKER)
+  // is the FOLD of the current fragments — folding it again on top of the same
+  // fragments would duplicate every section. So when at least one non-generated
+  // input is present, drop the generated one(s). When a generated output is the
+  // SOLE input (no fragments), keep it: parse→emit is stable, so it re-emits
+  // identically.
+  const nonGenerated = fragments.filter((f) => !isAssembledOutput(f.content ?? ''));
+  const effective = nonGenerated.length > 0 ? nonGenerated : fragments;
+
+  // Map title -> array of section bodies (in source order).
+  const merged = new Map();
+  // Preserve first-seen order of non-canonical titles.
+  const extraOrder = [];
+  let maxBumpRank = 0;
+  let sawAnyBump = false;
+
+  for (const frag of effective) {
+    const content = frag.content ?? '';
+    const bump = parseBumpType(content);
+    if (bump) {
+      sawAnyBump = true;
+      maxBumpRank = Math.max(maxBumpRank, BUMP_RANK[bump]);
+    }
+
+    const sections = parseSections(content);
+    if (sections.length === 0) {
+      // No H2 sections. An effectively-empty fragment (only comments/whitespace)
+      // is malformed — a fragment file should always carry real notes.
+      // A fragment with real prose but no headings is also malformed: we can't
+      // place its content under a known section.
+      throw new Error(
+        `release-note fragment "${frag.name}" has no recognizable "## " section. ` +
+        `Every fragment must contain at least one section heading ` +
+        `(e.g. "## What Changed"). Fix or remove this fragment.`,
+      );
+    }
+
+    for (const sec of sections) {
+      const body = sec.body.trim();
+      // Skip a section whose body is only whitespace/comments — nothing to fold.
+      if (isEffectivelyEmpty(body)) continue;
+      if (!merged.has(sec.title)) {
+        merged.set(sec.title, []);
+        if (!CANONICAL_SECTIONS.includes(sec.title)) extraOrder.push(sec.title);
+      }
+      merged.get(sec.title).push(body);
+    }
+  }
+
+  // If after folding there is genuinely nothing to say, that's a malformation
+  // for a non-empty input set (every fragment was comments-only).
+  if (merged.size === 0) {
+    throw new Error(
+      'release-note fragments produced no content — every section was empty. ' +
+      'Fill in at least "## What Changed" in one fragment.',
+    );
+  }
+
+  // Emit canonical sections first (only when present), then extras in
+  // first-seen order.
+  const titleOrder = [
+    ...CANONICAL_SECTIONS.filter((t) => merged.has(t)),
+    ...extraOrder,
+  ];
+
+  const bump = sawAnyBump ? RANK_BUMP[maxBumpRank] : 'patch';
+
+  const parts = [];
+  parts.push(H1_HEADER);
+  parts.push('');
+  parts.push(GENERATED_MARKER);
+  parts.push(`<!-- bump: ${bump} -->`);
+  parts.push('');
+  for (const title of titleOrder) {
+    const bodies = merged.get(title);
+    parts.push(`## ${title}`);
+    parts.push('');
+    // Concatenate each fragment's body for this section, separated by a blank
+    // line. Bodies were already trimmed.
+    parts.push(bodies.join('\n\n'));
+    parts.push('');
+  }
+
+  // Single trailing newline, no duplicate blank lines at EOF.
+  return parts.join('\n').replace(/\n+$/, '\n');
+}
+
+// ── CLI entry point ────────────────────────────────────────────────────
+
+/**
+ * Gather fragment inputs from disk in deterministic order: legacy NEXT.md first
+ * (so its content leads), then `next/*.md` sorted by filename.
+ */
+export function gatherFragmentInputs(upgradesDir) {
+  const inputs = [];
+
+  const legacyPath = path.join(upgradesDir, 'NEXT.md');
+  const fragmentsDir = path.join(upgradesDir, 'next');
+
+  let legacyContent = null;
+  if (fs.existsSync(legacyPath)) {
+    legacyContent = fs.readFileSync(legacyPath, 'utf-8');
+  }
+
+  let fragmentFiles = [];
+  if (fs.existsSync(fragmentsDir)) {
+    fragmentFiles = fs
+      .readdirSync(fragmentsDir)
+      .filter((f) => f.endsWith('.md'))
+      .sort((a, b) => a.localeCompare(b, 'en'));
+  }
+
+  // Fold the legacy NEXT.md in first — only when it carries real content
+  // (skip a bare template/empty file so re-runs are idempotent and a fresh
+  // template doesn't masquerade as content).
+  if (legacyContent !== null && !isEffectivelyEmpty(legacyContent)) {
+    inputs.push({ name: 'NEXT.md', content: legacyContent });
+  }
+
+  for (const file of fragmentFiles) {
+    const content = fs.readFileSync(path.join(fragmentsDir, file), 'utf-8');
+    inputs.push({ name: `next/${file}`, content });
+  }
+
+  return { inputs, hadLegacy: legacyContent !== null, fragmentCount: fragmentFiles.length };
+}
+
+function main() {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const ROOT = path.resolve(__dirname, '..');
+
+  // Allow tests / callers to point at an alternate upgrades dir.
+  const argIdx = process.argv.indexOf('--upgrades-dir');
+  const upgradesDir =
+    argIdx !== -1 && process.argv[argIdx + 1]
+      ? path.resolve(process.argv[argIdx + 1])
+      : path.join(ROOT, 'upgrades');
+
+  const { inputs, hadLegacy, fragmentCount } = gatherFragmentInputs(upgradesDir);
+
+  if (inputs.length === 0) {
+    // No fragments and no (content-bearing) legacy NEXT.md. Do nothing — the
+    // existing publish skip logic handles the "nothing to publish" case.
+    console.log(
+      `[assemble-next-md] no fragments in ${path.join(upgradesDir, 'next')} ` +
+      `and no content-bearing NEXT.md — nothing to assemble.`,
+    );
+    process.exit(0);
+  }
+
+  let assembled;
+  try {
+    assembled = assembleNextMd(inputs);
+  } catch (err) {
+    console.error(`[assemble-next-md] ERROR: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  const nextPath = path.join(upgradesDir, 'NEXT.md');
+  fs.mkdirSync(upgradesDir, { recursive: true });
+  fs.writeFileSync(nextPath, assembled);
+
+  console.log(
+    `[assemble-next-md] assembled ${fragmentCount} fragment(s)` +
+    `${hadLegacy ? ' + legacy NEXT.md' : ''} → ${path.relative(ROOT, nextPath)}`,
+  );
+  process.exit(0);
+}
+
+// Only run main() when invoked directly (not when imported by tests).
+// Compare resolved file URLs rather than string-concatenating argv[1] — that
+// naive form breaks on relative paths and paths containing spaces.
+function invokedDirectly() {
+  if (!process.argv[1]) return false;
+  try {
+    return import.meta.url === pathToFileURL(fs.realpathSync(process.argv[1])).href;
+  } catch {
+    return import.meta.url === pathToFileURL(process.argv[1]).href;
+  }
+}
+
+if (invokedDirectly()) {
+  main();
+}

--- a/scripts/pre-push-gate.js
+++ b/scripts/pre-push-gate.js
@@ -14,11 +14,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { validateGuideContent } from './upgrade-guide-validator.mjs';
+import { assembleNextMd, gatherFragmentInputs } from './assemble-next-md.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
 const upgradesDir = path.join(ROOT, 'upgrades');
-const nextPath = path.join(ROOT, 'upgrades', 'NEXT.md');
 const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf-8'));
 const version = pkg.version;
 
@@ -34,38 +34,66 @@ const REQUIRED_SECTIONS = [
 let errors = [];
 let warnings = [];
 
-// ── 1. NEXT.md validation ─────────────────────────────────────────────
+// ── 1. Release-note validation (fragment-aware) ───────────────────────
+//
+// Release notes are authored as per-PR FRAGMENTS in upgrades/next/<slug>.md
+// (so concurrent PRs never collide on a single shared NEXT.md). The pre-push
+// gate validates the ASSEMBLED result — fragments folded together with any
+// legacy upgrades/NEXT.md — so a PR that ships only a fragment passes the same
+// section/content checks the publish gate enforces. We assemble in-memory and
+// NEVER write NEXT.md to disk here: the PR keeps its fragment, not a generated
+// guide. publish.yml runs the real assemble step before publishing.
 
 const versionedGuidePath = path.join(upgradesDir, `${version}.md`);
 const versionedGuideExists = fs.existsSync(versionedGuidePath);
-const nextExists = fs.existsSync(nextPath);
 
-// Pick the active guide for this push. NEXT.md wins if present (in-flight
-// release notes); fall back to the versioned guide once NEXT.md has been
-// renamed during a publish.
-const activeGuidePath = nextExists
-  ? nextPath
-  : (versionedGuideExists ? versionedGuidePath : null);
-const activeGuideLabel = nextExists
-  ? 'NEXT.md'
+// Assemble fragments + legacy NEXT.md in-memory.
+let assembledContent = null;
+let assembleError = null;
+{
+  const { inputs } = gatherFragmentInputs(upgradesDir);
+  if (inputs.length > 0) {
+    try {
+      assembledContent = assembleNextMd(inputs);
+    } catch (err) {
+      assembleError = err instanceof Error ? err.message : String(err);
+    }
+  }
+}
+
+// The active guide for validation: the assembled fragments/NEXT.md (in-flight
+// release notes) win when present; otherwise fall back to the versioned guide
+// (post-release-cut state, when NEXT.md has been renamed and no new fragment is
+// staged yet).
+const activeGuideLabel = assembledContent !== null
+  ? 'assembled release notes (upgrades/next/*.md + NEXT.md)'
   : (versionedGuideExists ? `${version}.md` : null);
 
-if (activeGuidePath && activeGuideLabel) {
-  const content = fs.readFileSync(activeGuidePath, 'utf-8');
-
+if (assembleError) {
+  // A malformed fragment must fail the push loudly — the same loud failure the
+  // publish workflow would hit.
+  errors.push(`Release-note fragments are malformed: ${assembleError}`);
+} else if (assembledContent !== null) {
   // Run the shared validator (same checks as check-upgrade-guide.js at publish
   // time). This catches the publish-blocker bugs that previously slipped past
   // pre-push: inline code / fenced blocks / camelCase config keys in "What to
   // Tell Your User", and missing "## Evidence" when "What Changed" claims a fix.
   // Before this gate, those defects only surfaced as silently-dropped publish
   // runs on main — agents never received the merged code.
-  const validatorIssues = validateGuideContent(content);
+  const validatorIssues = validateGuideContent(assembledContent);
   for (const issue of validatorIssues) {
     errors.push(`${activeGuideLabel}: ${issue}`);
   }
+} else if (versionedGuideExists) {
+  const content = fs.readFileSync(versionedGuidePath, 'utf-8');
+  const validatorIssues = validateGuideContent(content);
+  for (const issue of validatorIssues) {
+    errors.push(`${version}.md: ${issue}`);
+  }
 } else {
   errors.push(
-    `No upgrade guide found. Create upgrades/NEXT.md with sections: ${REQUIRED_SECTIONS.join(', ')}`
+    `No upgrade guide found. Create a release-note fragment ` +
+    `upgrades/next/<slug>.md (or legacy upgrades/NEXT.md) with sections: ${REQUIRED_SECTIONS.join(', ')}`
   );
 }
 
@@ -221,14 +249,16 @@ if (!process.env.CI) {
     /\bnew\b/i,
   ];
 
-  // When NEXT.md exists, it represents the *next* shipment being prepared in
-  // this push — prefer it over the (frozen) versioned guide, which describes
-  // the already-released version and isn't what this PR is changing. This is
-  // the post-release-cut + new-PR state: both files coexist, but only NEXT.md
-  // is in flight. Falls back to the versioned guide when no NEXT.md is staged.
-  const guidePath = nextExists ? nextPath : (versionedGuideExists ? versionedGuidePath : null);
-  if (guidePath && fs.existsSync(guidePath)) {
-    const guideContent = fs.readFileSync(guidePath, 'utf-8');
+  // The in-flight release notes (assembled fragments + legacy NEXT.md) represent
+  // the *next* shipment being prepared in this push — prefer them over the
+  // (frozen) versioned guide, which describes the already-released version and
+  // isn't what this PR is changing. Falls back to the versioned guide when no
+  // fragment / NEXT.md is staged (post-release-cut state).
+  const inFlight = assembledContent !== null;
+  const guideContent = inFlight
+    ? assembledContent
+    : (versionedGuideExists ? fs.readFileSync(versionedGuidePath, 'utf-8') : null);
+  if (guideContent !== null) {
     // Extract "## What Changed" section
     const whatChangedMatch = guideContent.match(/## What Changed\s*([\s\S]*?)(?=\n##\s|$)/);
     const whatChanged = whatChangedMatch ? whatChangedMatch[1] : '';
@@ -237,10 +267,10 @@ if (!process.env.CI) {
 
     if (qualifies) {
       const sideEffectsDir = path.join(ROOT, 'upgrades', 'side-effects');
-      // If NEXT.md is the active guide, any fresh artifact (last 24h) counts —
-      // the versioned-filename requirement only applies when a versioned guide
-      // is being validated without an in-flight NEXT.md.
-      const artifactName = (!nextExists && versionedGuideExists) ? `${version}.md` : null;
+      // When in-flight notes (fragments/NEXT.md) drive the push, any fresh
+      // artifact (last 24h) counts — the versioned-filename requirement only
+      // applies when a versioned guide is being validated without in-flight notes.
+      const artifactName = (!inFlight && versionedGuideExists) ? `${version}.md` : null;
       let artifactFound = false;
 
       if (fs.existsSync(sideEffectsDir)) {
@@ -248,9 +278,9 @@ if (!process.env.CI) {
         if (artifactName) {
           artifactFound = files.includes(artifactName);
         } else {
-          // For NEXT.md, any fresh artifact from the last 24h counts.
-          // The expectation is that during release cut, NEXT.md -> <version>.md
-          // rename will pair with the artifact rename as well.
+          // For in-flight notes (fragments/NEXT.md), any fresh artifact from the
+          // last 24h counts. The expectation is that during release cut, the
+          // fragment/NEXT.md -> <version>.md rename pairs with an artifact rename.
           const recent = files.filter((f) => {
             const stat = fs.statSync(path.join(sideEffectsDir, f));
             return Date.now() - stat.mtimeMs < 24 * 60 * 60 * 1000;

--- a/src/data/builtin-manifest.json
+++ b/src/data/builtin-manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./builtin-manifest.schema.json",
   "schemaVersion": 1,
-  "generatedAt": "2026-05-31T02:53:23.522Z",
-  "instarVersion": "1.3.135",
+  "generatedAt": "2026-05-31T09:05:31.324Z",
+  "instarVersion": "1.3.151",
   "entryCount": 193,
   "entries": {
     "hook:session-start": {
@@ -11,7 +11,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/session-start.sh",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:dangerous-command-guard": {
@@ -20,7 +20,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/dangerous-command-guard.sh",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:grounding-before-messaging": {
@@ -29,7 +29,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/grounding-before-messaging.sh",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:compaction-recovery": {
@@ -38,7 +38,7 @@
       "domain": "identity",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/compaction-recovery.sh",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:external-operation-gate": {
@@ -47,7 +47,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-operation-gate.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:deferral-detector": {
@@ -56,7 +56,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/deferral-detector.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:post-action-reflection": {
@@ -65,7 +65,7 @@
       "domain": "evolution",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/post-action-reflection.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:external-communication-guard": {
@@ -74,7 +74,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/external-communication-guard.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-collector": {
@@ -83,7 +83,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-collector.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:scope-coherence-checkpoint": {
@@ -92,7 +92,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/scope-coherence-checkpoint.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:free-text-guard": {
@@ -101,7 +101,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/free-text-guard.sh",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:claim-intercept": {
@@ -110,7 +110,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:claim-intercept-response": {
@@ -119,7 +119,7 @@
       "domain": "coherence",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/claim-intercept-response.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:stop-gate-router": {
@@ -128,7 +128,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/stop-gate-router.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "hook:auto-approve-permissions": {
@@ -137,7 +137,7 @@
       "domain": "safety",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
       "installedPath": ".instar/hooks/instar/auto-approve-permissions.js",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "job:health-check": {
@@ -409,7 +409,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:agents": {
@@ -417,7 +417,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:backups": {
@@ -425,7 +425,7 @@
       "type": "route-group",
       "domain": "operations",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:git": {
@@ -433,7 +433,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:memory": {
@@ -441,7 +441,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:semantic": {
@@ -449,7 +449,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:status": {
@@ -457,7 +457,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:capabilities": {
@@ -465,7 +465,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:project-map": {
@@ -473,7 +473,7 @@
       "type": "route-group",
       "domain": "mapping",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:coherence": {
@@ -481,7 +481,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:topic-bindings": {
@@ -489,7 +489,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:context": {
@@ -497,7 +497,7 @@
       "type": "route-group",
       "domain": "context",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:scope-coherence": {
@@ -505,7 +505,7 @@
       "type": "route-group",
       "domain": "coherence",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:canonical-state": {
@@ -513,7 +513,7 @@
       "type": "route-group",
       "domain": "state",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:ci": {
@@ -521,7 +521,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:sessions": {
@@ -529,7 +529,7 @@
       "type": "route-group",
       "domain": "sessions",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:jobs": {
@@ -537,7 +537,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:skip-ledger": {
@@ -545,7 +545,7 @@
       "type": "route-group",
       "domain": "scheduling",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:telegram": {
@@ -553,7 +553,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:attention": {
@@ -561,7 +561,7 @@
       "type": "route-group",
       "domain": "communication",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:relationships": {
@@ -569,7 +569,7 @@
       "type": "route-group",
       "domain": "relationships",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:feedback": {
@@ -577,7 +577,7 @@
       "type": "route-group",
       "domain": "feedback",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:updates": {
@@ -585,7 +585,7 @@
       "type": "route-group",
       "domain": "updates",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:dispatches": {
@@ -593,7 +593,7 @@
       "type": "route-group",
       "domain": "dispatches",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:quota": {
@@ -601,7 +601,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:publishing": {
@@ -609,7 +609,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:private-views": {
@@ -617,7 +617,7 @@
       "type": "route-group",
       "domain": "publishing",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:tunnel": {
@@ -625,7 +625,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:events": {
@@ -633,7 +633,7 @@
       "type": "route-group",
       "domain": "networking",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:evolution": {
@@ -641,7 +641,7 @@
       "type": "route-group",
       "domain": "evolution",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:watchdog": {
@@ -649,7 +649,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:topic-memory": {
@@ -657,7 +657,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:state-sync": {
@@ -665,7 +665,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:intent": {
@@ -673,7 +673,7 @@
       "type": "route-group",
       "domain": "intent",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:triage": {
@@ -681,7 +681,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:operations": {
@@ -689,7 +689,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:sentinel": {
@@ -697,7 +697,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:trust": {
@@ -705,7 +705,7 @@
       "type": "route-group",
       "domain": "safety",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:monitoring": {
@@ -713,7 +713,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:commitments": {
@@ -721,7 +721,7 @@
       "type": "route-group",
       "domain": "commitments",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:episodes": {
@@ -729,7 +729,7 @@
       "type": "route-group",
       "domain": "memory",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:messages": {
@@ -737,7 +737,7 @@
       "type": "route-group",
       "domain": "coordination",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:system-reviews": {
@@ -745,7 +745,7 @@
       "type": "route-group",
       "domain": "monitoring",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "route-group:machine-mesh": {
@@ -761,7 +761,7 @@
       "type": "route-group",
       "domain": "security",
       "sourcePath": "src/server/routes.ts",
-      "contentHash": "ad22e53682a80bde894e1a183a19167cd76dc3e1c09dfd8d70d283aca77ed295",
+      "contentHash": "ae23600508f36ee8fab00180d252a4c5f374ae910465231768f8e2daad7e7dcf",
       "since": "2025-01-01"
     },
     "cli:init": {
@@ -1457,7 +1457,7 @@
       "type": "subsystem",
       "domain": "server",
       "sourcePath": "src/server/AgentServer.ts",
-      "contentHash": "9a47e31522e076c933c0e5267b7c1373bb3cd45ab5509114e30796857e9b093e",
+      "contentHash": "e4b33671553c638bfd201a8a7217e76a52722324685dedc1b7f15ef2548060a6",
       "since": "2025-01-01"
     },
     "subsystem:session-manager": {
@@ -1489,7 +1489,7 @@
       "type": "subsystem",
       "domain": "updates",
       "sourcePath": "src/core/PostUpdateMigrator.ts",
-      "contentHash": "6654fc8574091fc57d2f94b98f13e66ae2d2b6d2e4787b66dad9b76c0e93c448",
+      "contentHash": "3418f7109a38172a28a3a202c8a878c1064f55911a82155c53a0b1ccde44e804",
       "since": "2025-01-01"
     },
     "subsystem:scheduler": {
@@ -1521,7 +1521,7 @@
       "type": "subsystem",
       "domain": "communication",
       "sourcePath": "src/lifeline/TelegramLifeline.ts",
-      "contentHash": "03f9fc147f3e520e114e32df64fe6ba2a69f58664c3cb94f495532d47f5bcded",
+      "contentHash": "6105f8a126654011c81e900be2c049ff52dc1b9b369831432ad910a9650dc84e",
       "since": "2025-01-01"
     },
     "subsystem:orphan-process-reaper": {
@@ -1545,7 +1545,7 @@
       "type": "subsystem",
       "domain": "coordination",
       "sourcePath": "src/core/MultiMachineCoordinator.ts",
-      "contentHash": "44aa63dff721e15ad680db4c1d552abfc9e97e610498b6752496c222f27f323b",
+      "contentHash": "1dc3fb11c8ddea5cfe5f02561636cd54c1661d0e9da04f54607ad7679f027ea6",
       "since": "2025-01-01"
     },
     "subsystem:backup-manager": {

--- a/tests/unit/assemble-next-md.test.ts
+++ b/tests/unit/assemble-next-md.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Unit tests — assemble-next-md.mjs (per-PR release-note fragments).
+ *
+ * The release pipeline historically consumed a single shared upgrades/NEXT.md
+ * per merge, so concurrent PRs collided on that one file within minutes. The
+ * fix is per-PR FRAGMENTS (upgrades/next/<slug>.md) that an assemble pre-step
+ * folds into NEXT.md before the existing pipeline runs. This suite hammers the
+ * pure assembler: it is the critical new code that must merge sections
+ * deterministically, pick the max bump tier, fold a legacy NEXT.md, no-op
+ * cleanly when there's nothing, fail loudly on malformation, and stay
+ * idempotent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { SafeFsExecutor } from '../../src/core/SafeFsExecutor.js';
+// @ts-expect-error — .mjs script, no type declarations; runtime import is fine under vitest
+import {
+  assembleNextMd,
+  parseBumpType,
+  parseSections,
+  gatherFragmentInputs,
+  CANONICAL_SECTIONS,
+} from '../../scripts/assemble-next-md.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..');
+const scriptPath = path.join(ROOT, 'scripts', 'assemble-next-md.mjs');
+
+function frag(name: string, content: string) {
+  return { name, content };
+}
+
+// A minimal well-formed fragment body for a given "What Changed" line.
+function makeFragment(opts: {
+  bump?: string;
+  whatChanged?: string;
+  wttyu?: string;
+  capabilities?: string;
+  evidence?: string;
+}): string {
+  const lines: string[] = ['# Upgrade Guide — vNEXT', ''];
+  if (opts.bump) lines.push(`<!-- bump: ${opts.bump} -->`, '');
+  if (opts.whatChanged) lines.push('## What Changed', '', opts.whatChanged, '');
+  if (opts.wttyu) lines.push('## What to Tell Your User', '', opts.wttyu, '');
+  if (opts.capabilities) lines.push('## Summary of New Capabilities', '', opts.capabilities, '');
+  if (opts.evidence) lines.push('## Evidence', '', opts.evidence, '');
+  return lines.join('\n');
+}
+
+describe('parseBumpType', () => {
+  it('extracts patch/minor/major', () => {
+    expect(parseBumpType('<!-- bump: patch -->')).toBe('patch');
+    expect(parseBumpType('<!-- bump: minor -->')).toBe('minor');
+    expect(parseBumpType('<!-- bump: major -->')).toBe('major');
+  });
+  it('is case-insensitive and tolerant of spacing', () => {
+    expect(parseBumpType('<!--bump:MINOR-->')).toBe('minor');
+  });
+  it('returns null when absent', () => {
+    expect(parseBumpType('## What Changed\n\nstuff')).toBeNull();
+  });
+});
+
+describe('parseSections', () => {
+  it('splits H2 sections in source order, dropping pre-H2 preamble', () => {
+    const secs = parseSections('# H1\n<!-- bump: patch -->\n## A\n\nbody a\n## B\n\nbody b\n');
+    expect(secs.map((s: { title: string }) => s.title)).toEqual(['A', 'B']);
+    expect(secs[0].body.trim()).toBe('body a');
+    expect(secs[1].body.trim()).toBe('body b');
+  });
+  it('returns empty array when there are no H2 sections', () => {
+    expect(parseSections('# only an h1\n\nsome prose')).toEqual([]);
+  });
+});
+
+describe('assembleNextMd — merging', () => {
+  it('merges multiple fragments into ONE of each canonical section', () => {
+    const a = makeFragment({
+      bump: 'patch',
+      whatChanged: 'Fragment A changed the scheduler.',
+      wttyu: 'I tuned up the scheduler.',
+      capabilities: '| Scheduler tune | automatic |',
+    });
+    const b = makeFragment({
+      bump: 'patch',
+      whatChanged: 'Fragment B changed the relay.',
+      wttyu: 'I tuned up the relay.',
+      capabilities: '| Relay tune | automatic |',
+    });
+    const out = assembleNextMd([frag('next/a.md', a), frag('next/b.md', b)]);
+
+    // Exactly ONE of each canonical heading.
+    expect((out.match(/^## What Changed$/gm) || []).length).toBe(1);
+    expect((out.match(/^## What to Tell Your User$/gm) || []).length).toBe(1);
+    expect((out.match(/^## Summary of New Capabilities$/gm) || []).length).toBe(1);
+
+    // Both fragments' content present under the merged section.
+    expect(out).toContain('Fragment A changed the scheduler.');
+    expect(out).toContain('Fragment B changed the relay.');
+    expect(out).toContain('Scheduler tune');
+    expect(out).toContain('Relay tune');
+  });
+
+  it('orders sections canonically: What Changed, WTTYU, Summary, Evidence', () => {
+    const a = makeFragment({
+      bump: 'patch',
+      whatChanged: 'Fixed the stall.',
+      wttyu: 'I fixed a stall.',
+      capabilities: '| x | automatic |',
+      evidence: 'Reproduced the stall on a live box; after the fix it no longer hangs at the prompt.',
+    });
+    const out = assembleNextMd([frag('next/a.md', a)]);
+    const iWhat = out.indexOf('## What Changed');
+    const iUser = out.indexOf('## What to Tell Your User');
+    const iSum = out.indexOf('## Summary of New Capabilities');
+    const iEvi = out.indexOf('## Evidence');
+    expect(iWhat).toBeGreaterThanOrEqual(0);
+    expect(iWhat).toBeLessThan(iUser);
+    expect(iUser).toBeLessThan(iSum);
+    expect(iSum).toBeLessThan(iEvi);
+  });
+
+  it('appends non-canonical sections after the canonical ones, also merged', () => {
+    const a = makeFragment({ bump: 'patch', whatChanged: 'A' });
+    const withExtra = a + '\n## Migration Notes\n\nrun the migrator\n';
+    const b = makeFragment({ bump: 'patch', whatChanged: 'B' });
+    const withExtraB = b + '\n## Migration Notes\n\nand restart\n';
+    const out = assembleNextMd([frag('next/a.md', withExtra), frag('next/b.md', withExtraB)]);
+    expect((out.match(/^## Migration Notes$/gm) || []).length).toBe(1);
+    expect(out.indexOf('## Migration Notes')).toBeGreaterThan(out.indexOf('## What Changed'));
+    expect(out).toContain('run the migrator');
+    expect(out).toContain('and restart');
+  });
+
+  it('processes fragments in the order provided (deterministic)', () => {
+    const a = makeFragment({ bump: 'patch', whatChanged: 'AAA first' });
+    const b = makeFragment({ bump: 'patch', whatChanged: 'BBB second' });
+    const out = assembleNextMd([frag('next/a.md', a), frag('next/b.md', b)]);
+    expect(out.indexOf('AAA first')).toBeLessThan(out.indexOf('BBB second'));
+  });
+});
+
+describe('assembleNextMd — bump tier', () => {
+  it('takes the MAX tier across fragments (major > minor > patch)', () => {
+    const p = makeFragment({ bump: 'patch', whatChanged: 'a' });
+    const mi = makeFragment({ bump: 'minor', whatChanged: 'b' });
+    const ma = makeFragment({ bump: 'major', whatChanged: 'c' });
+    expect(assembleNextMd([frag('p', p), frag('mi', mi)])).toContain('<!-- bump: minor -->');
+    expect(assembleNextMd([frag('mi', mi), frag('ma', ma)])).toContain('<!-- bump: major -->');
+    expect(assembleNextMd([frag('p', p)])).toContain('<!-- bump: patch -->');
+  });
+
+  it('defaults to patch when no fragment declares a bump', () => {
+    const noBump = '## What Changed\n\nsomething\n';
+    expect(assembleNextMd([frag('x', noBump)])).toContain('<!-- bump: patch -->');
+  });
+});
+
+describe('assembleNextMd — single fragment', () => {
+  it('passes a single fragment through as a well-formed guide', () => {
+    const a = makeFragment({
+      bump: 'minor',
+      whatChanged: 'Added the fragment system.',
+      wttyu: 'Release notes now compose from per-change pieces.',
+      capabilities: '| Fragments | automatic |',
+    });
+    const out = assembleNextMd([frag('next/a.md', a)]);
+    expect(out).toMatch(/^# Upgrade Guide — vNEXT$/m);
+    expect(out).toContain('<!-- bump: minor -->');
+    expect(out).toContain('Added the fragment system.');
+  });
+});
+
+describe('assembleNextMd — malformation', () => {
+  it('throws on a fragment with content but no "## " section', () => {
+    expect(() => assembleNextMd([frag('next/bad.md', '# H1 only\n\njust prose, no headings')]))
+      .toThrow(/no recognizable "## " section/);
+  });
+
+  it('throws on an effectively-empty fragment (only comments/whitespace)', () => {
+    expect(() => assembleNextMd([frag('next/empty.md', '<!-- bump: patch -->\n\n   \n')]))
+      .toThrow(/no recognizable "## " section/);
+  });
+
+  it('throws when every section across inputs is comment-only (nothing to fold)', () => {
+    const onlyComments = '## What Changed\n\n<!-- placeholder -->\n';
+    expect(() => assembleNextMd([frag('next/c.md', onlyComments)]))
+      .toThrow(/no content/);
+  });
+});
+
+describe('assembleNextMd — idempotency', () => {
+  it('running twice (feeding output back in) yields the same result', () => {
+    const a = makeFragment({
+      bump: 'minor',
+      whatChanged: 'Did a thing.',
+      wttyu: 'I did a thing.',
+      capabilities: '| Thing | automatic |',
+    });
+    const first = assembleNextMd([frag('next/a.md', a)]);
+    // Feed the generated NEXT.md back in as the sole input — must be stable.
+    const second = assembleNextMd([frag('NEXT.md', first)]);
+    expect(second).toBe(first);
+  });
+});
+
+describe('assembleNextMd — WTTYU stays backtick-free', () => {
+  it('preserves a backtick-free "What to Tell Your User" when inputs are clean', () => {
+    const a = makeFragment({
+      bump: 'patch',
+      whatChanged: 'internal `config` key change',
+      wttyu: 'Nothing changes about how I talk to you. I picked up a tune-up.',
+    });
+    const out = assembleNextMd([frag('next/a.md', a)]);
+    // Extract the WTTYU section body (until the next H2 or EOF) and assert no
+    // inline code leaked in from "What Changed".
+    const m = out.match(/## What to Tell Your User\n\n([\s\S]*?)(?:\n## |$)/);
+    expect(m).not.toBeNull();
+    expect(m![1]).not.toMatch(/`/);
+  });
+});
+
+// ── Disk-level: gatherFragmentInputs + legacy fold + no-op ───────────────
+
+describe('gatherFragmentInputs + legacy NEXT.md fold', () => {
+  let scratch: string;
+  let upgrades: string;
+
+  beforeEach(() => {
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'assemble-next-'));
+    upgrades = path.join(scratch, 'upgrades');
+    fs.mkdirSync(path.join(upgrades, 'next'), { recursive: true });
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(scratch, { recursive: true, force: true, operation: 'tests/unit/assemble-next-md.test.ts:afterEach' });
+  });
+
+  it('folds legacy NEXT.md FIRST, then fragments sorted by filename', () => {
+    fs.writeFileSync(
+      path.join(upgrades, 'NEXT.md'),
+      makeFragment({ bump: 'patch', whatChanged: 'Legacy NEXT content.' }),
+    );
+    // Write fragments out of lexical order to prove the sort.
+    fs.writeFileSync(path.join(upgrades, 'next', 'zzz.md'), makeFragment({ bump: 'patch', whatChanged: 'Zed fragment.' }));
+    fs.writeFileSync(path.join(upgrades, 'next', 'aaa.md'), makeFragment({ bump: 'minor', whatChanged: 'Aay fragment.' }));
+
+    const { inputs, hadLegacy, fragmentCount } = gatherFragmentInputs(upgrades);
+    expect(hadLegacy).toBe(true);
+    expect(fragmentCount).toBe(2);
+    expect(inputs.map((i: { name: string }) => i.name)).toEqual(['NEXT.md', 'next/aaa.md', 'next/zzz.md']);
+
+    const out = assembleNextMd(inputs);
+    // Legacy content leads, fragments follow in filename order.
+    expect(out.indexOf('Legacy NEXT content.')).toBeLessThan(out.indexOf('Aay fragment.'));
+    expect(out.indexOf('Aay fragment.')).toBeLessThan(out.indexOf('Zed fragment.'));
+    // Max tier across legacy(patch)+aaa(minor)+zzz(patch) = minor.
+    expect(out).toContain('<!-- bump: minor -->');
+  });
+
+  it('skips a content-free legacy NEXT.md (bare template) so it does not masquerade as content', () => {
+    fs.writeFileSync(path.join(upgrades, 'NEXT.md'), '<!-- bump: patch -->\n\n   \n');
+    fs.writeFileSync(path.join(upgrades, 'next', 'a.md'), makeFragment({ bump: 'patch', whatChanged: 'real frag' }));
+    const { inputs } = gatherFragmentInputs(upgrades);
+    // hadLegacy true on disk, but a whitespace/comment-only NEXT.md is NOT fed in.
+    expect(inputs.map((i: { name: string }) => i.name)).toEqual(['next/a.md']);
+  });
+
+  it('returns no inputs when there are NO fragments and NO legacy NEXT.md', () => {
+    const { inputs, fragmentCount } = gatherFragmentInputs(upgrades);
+    expect(inputs).toEqual([]);
+    expect(fragmentCount).toBe(0);
+  });
+});
+
+// ── CLI behavior: no-op exit 0, write, loud failure ──────────────────────
+
+describe('assemble-next-md.mjs CLI', () => {
+  let scratch: string;
+  let upgrades: string;
+
+  beforeEach(() => {
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'assemble-cli-'));
+    upgrades = path.join(scratch, 'upgrades');
+    fs.mkdirSync(path.join(upgrades, 'next'), { recursive: true });
+  });
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(scratch, { recursive: true, force: true, operation: 'tests/unit/assemble-next-md.test.ts:afterEach' });
+  });
+
+  function run(): { status: number | null; stdout: string; stderr: string } {
+    const r = spawnSync(process.execPath, [scriptPath, '--upgrades-dir', upgrades], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+    });
+    return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+  }
+
+  it('exits 0 quietly and writes NOTHING when there are no fragments + no NEXT.md', () => {
+    const { status } = run();
+    expect(status).toBe(0);
+    expect(fs.existsSync(path.join(upgrades, 'NEXT.md'))).toBe(false);
+  });
+
+  it('writes upgrades/NEXT.md from a fragment and exits 0', () => {
+    fs.writeFileSync(
+      path.join(upgrades, 'next', 'feature.md'),
+      makeFragment({ bump: 'minor', whatChanged: 'Shipped the thing.', wttyu: 'I shipped the thing.' }),
+    );
+    const { status } = run();
+    expect(status).toBe(0);
+    const written = fs.readFileSync(path.join(upgrades, 'NEXT.md'), 'utf-8');
+    expect(written).toContain('Shipped the thing.');
+    expect(written).toContain('<!-- bump: minor -->');
+  });
+
+  it('exits non-zero and prints a clear error on a malformed fragment', () => {
+    fs.writeFileSync(path.join(upgrades, 'next', 'bad.md'), 'no headings here, just text');
+    const { status, stderr } = run();
+    expect(status).not.toBe(0);
+    expect(stderr).toContain('no recognizable "## " section');
+    // Must not have written a broken NEXT.md.
+    expect(fs.existsSync(path.join(upgrades, 'NEXT.md'))).toBe(false);
+  });
+
+  it('is idempotent on disk — running twice produces identical NEXT.md', () => {
+    fs.writeFileSync(
+      path.join(upgrades, 'next', 'a.md'),
+      makeFragment({ bump: 'patch', whatChanged: 'A.', wttyu: 'I did A.', capabilities: '| A | automatic |' }),
+    );
+    run();
+    const first = fs.readFileSync(path.join(upgrades, 'NEXT.md'), 'utf-8');
+    run();
+    const second = fs.readFileSync(path.join(upgrades, 'NEXT.md'), 'utf-8');
+    expect(second).toBe(first);
+  });
+});
+
+describe('CANONICAL_SECTIONS export', () => {
+  it('matches the four sections the publish validator knows', () => {
+    expect(CANONICAL_SECTIONS).toEqual([
+      'What Changed',
+      'What to Tell Your User',
+      'Summary of New Capabilities',
+      'Evidence',
+    ]);
+  });
+});

--- a/tests/unit/feature-delivery-completeness.test.ts
+++ b/tests/unit/feature-delivery-completeness.test.ts
@@ -22,6 +22,8 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+// @ts-expect-error — .mjs script, no type declarations; runtime import is fine under vitest
+import { assembleNextMd, gatherFragmentInputs } from '../../scripts/assemble-next-md.mjs';
 
 const srcDir = path.join(process.cwd(), 'src');
 const initSource = fs.readFileSync(path.join(srcDir, 'commands/init.ts'), 'utf-8');
@@ -245,17 +247,41 @@ describe('Feature Delivery Completeness', () => {
 
   describe('Upgrade guide lifecycle', () => {
     const upgradesDir = path.join(process.cwd(), 'upgrades');
+    const fragmentsDir = path.join(upgradesDir, 'next');
     const nextGuidePath = path.join(upgradesDir, 'NEXT.md');
 
-    it('NEXT.md template exists', () => {
-      expect(fs.existsSync(nextGuidePath)).toBe(true);
+    // Release notes are authored as per-PR FRAGMENTS (upgrades/next/<slug>.md)
+    // so concurrent PRs never collide on a single shared NEXT.md. A legacy
+    // upgrades/NEXT.md remains supported (backward compat). "In-flight release
+    // notes exist" therefore means: at least one fragment OR a legacy NEXT.md.
+    // Between a release cut and the next PR, neither may be present — that is a
+    // valid (notes-already-consumed) state, so the existence assertion only
+    // fires when we'd otherwise expect in-flight notes.
+    const hasFragments =
+      fs.existsSync(fragmentsDir) &&
+      fs.readdirSync(fragmentsDir).some((f) => f.endsWith('.md'));
+    const hasLegacyNext = fs.existsSync(nextGuidePath);
+
+    it('release-note source exists as fragments or a legacy NEXT.md (or notes were just consumed)', () => {
+      // At least one delivery surface must be wired: in-flight notes (fragments
+      // / NEXT.md) OR a shipped versioned guide. A repo with neither has no
+      // release-note machinery at all.
+      const versionedGuides = fs
+        .readdirSync(upgradesDir)
+        .filter((f) => /^\d+\.\d+\.\d+\.md$/.test(f));
+      expect(hasFragments || hasLegacyNext || versionedGuides.length > 0).toBe(true);
     });
 
-    it('NEXT.md has required section headers', () => {
-      const content = fs.readFileSync(nextGuidePath, 'utf-8');
-      expect(content).toContain('## What Changed');
-      expect(content).toContain('## What to Tell Your User');
-      expect(content).toContain('## Summary of New Capabilities');
+    it('in-flight release notes (assembled fragments + NEXT.md) carry required sections', () => {
+      if (!hasFragments && !hasLegacyNext) {
+        // No in-flight notes (post-release-cut, pre-next-PR). Nothing to assert.
+        return;
+      }
+      const { inputs } = gatherFragmentInputs(upgradesDir);
+      const assembled = assembleNextMd(inputs);
+      expect(assembled).toContain('## What Changed');
+      expect(assembled).toContain('## What to Tell Your User');
+      expect(assembled).toContain('## Summary of New Capabilities');
     });
 
     it('at least one versioned upgrade guide exists (proof of delivery)', () => {

--- a/tests/unit/pre-push-gate.test.ts
+++ b/tests/unit/pre-push-gate.test.ts
@@ -98,7 +98,7 @@ describe('Pre-push gate integration — malformed NEXT.md', () => {
     // script would still see the production __dirname and walk the production
     // tree — making the integration test sensitive to unrelated changes in
     // the rest of the repo. Copying isolates the test to its scratch dir.
-    for (const file of ['pre-push-gate.js', 'upgrade-guide-validator.mjs', 'lint-no-direct-destructive.js', 'lint-no-direct-llm-http.js']) {
+    for (const file of ['pre-push-gate.js', 'upgrade-guide-validator.mjs', 'assemble-next-md.mjs', 'lint-no-direct-destructive.js', 'lint-no-direct-llm-http.js']) {
       fs.copyFileSync(
         path.join(ROOT, 'scripts', file),
         path.join(scratch, 'scripts', file),
@@ -252,5 +252,123 @@ describe('Pre-push gate integration — malformed NEXT.md', () => {
 
     const { status } = runGate();
     expect(status).toBe(0);
+  });
+});
+
+// ── Integration: fragment-aware validation ───────────────────────────
+//
+// Release notes are now authored as per-PR fragments (upgrades/next/<slug>.md)
+// so concurrent PRs never collide on a shared NEXT.md. The pre-push gate must
+// validate the ASSEMBLED result so a PR that ships ONLY a fragment (no NEXT.md)
+// still passes the same section/content checks. It must also reject a malformed
+// fragment loudly, and must NOT write a generated NEXT.md to disk.
+
+describe('Pre-push gate integration — release-note fragments', () => {
+  let scratch: string;
+
+  beforeEach(() => {
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'prepush-frag-'));
+    fs.mkdirSync(path.join(scratch, 'scripts'), { recursive: true });
+    fs.mkdirSync(path.join(scratch, 'upgrades', 'next'), { recursive: true });
+    fs.mkdirSync(path.join(scratch, 'upgrades', 'side-effects'), { recursive: true });
+    fs.mkdirSync(path.join(scratch, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(scratch, 'package.json'),
+      JSON.stringify({ name: 'instar-test', version: '0.28.999' }),
+    );
+    for (const file of ['pre-push-gate.js', 'upgrade-guide-validator.mjs', 'assemble-next-md.mjs', 'lint-no-direct-destructive.js', 'lint-no-direct-llm-http.js']) {
+      fs.copyFileSync(path.join(ROOT, 'scripts', file), path.join(scratch, 'scripts', file));
+    }
+  });
+
+  afterEach(() => {
+    SafeFsExecutor.safeRmSync(scratch, { recursive: true, force: true, operation: 'tests/unit/pre-push-gate.test.ts:afterEach' });
+  });
+
+  function runGate(): { status: number | null; stdout: string; stderr: string } {
+    const result = spawnSync(process.execPath, [path.join(scratch, 'scripts', 'pre-push-gate.js')], {
+      cwd: scratch,
+      encoding: 'utf-8',
+      env: { ...process.env, CI: '', NODE_ENV: 'test' },
+    });
+    return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+  }
+
+  it('ACCEPTS a fragment-only push (no NEXT.md) and writes no NEXT.md', () => {
+    fs.writeFileSync(
+      path.join(scratch, 'upgrades', 'side-effects', 'frag-artifact.md'),
+      '# Side-Effects Review (test scratch)\n\nMinimal placeholder.\n',
+    );
+    fs.writeFileSync(
+      path.join(scratch, 'upgrades', 'next', 'my-feature.md'),
+      [
+        '# Upgrade Guide — vNEXT',
+        '',
+        '<!-- bump: minor -->',
+        '',
+        '## What Changed',
+        '',
+        'A small improvement to the agent infrastructure.',
+        '',
+        '## What to Tell Your User',
+        '',
+        'Your agent picked up a small tune-up. Nothing changes about how it talks to you.',
+        '',
+        '## Summary of New Capabilities',
+        '',
+        '| Capability | How to Use |',
+        '|-----------|-----------|',
+        '| Tune-up | automatic |',
+        '',
+      ].join('\n'),
+    );
+
+    const { status } = runGate();
+    expect(status).toBe(0);
+    // The gate assembles in-memory only — it must NOT leave a NEXT.md on disk.
+    expect(fs.existsSync(path.join(scratch, 'upgrades', 'NEXT.md'))).toBe(false);
+    // The fragment itself is untouched.
+    expect(fs.existsSync(path.join(scratch, 'upgrades', 'next', 'my-feature.md'))).toBe(true);
+  });
+
+  it('REJECTS a fragment-only push when WTTYU has inline code (validates assembled result)', () => {
+    fs.writeFileSync(
+      path.join(scratch, 'upgrades', 'next', 'bad-wttyu.md'),
+      [
+        '# Upgrade Guide — vNEXT',
+        '',
+        '<!-- bump: patch -->',
+        '',
+        '## What Changed',
+        '',
+        'A general improvement.',
+        '',
+        '## What to Tell Your User',
+        '',
+        'Your agent now reads from `~/.instar/config.json` automatically.',
+        '',
+        '## Summary of New Capabilities',
+        '',
+        '| Capability | How to Use |',
+        '|-----------|-----------|',
+        '| Auto-config | automatic |',
+        '',
+      ].join('\n'),
+    );
+
+    const { status, stdout } = runGate();
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('contains inline code');
+  });
+
+  it('REJECTS a malformed fragment (no "## " section) loudly', () => {
+    fs.writeFileSync(
+      path.join(scratch, 'upgrades', 'next', 'broken.md'),
+      'just some prose with no section headings at all',
+    );
+
+    const { status, stdout } = runGate();
+    expect(status).not.toBe(0);
+    expect(stdout).toContain('Release-note fragments are malformed');
   });
 });

--- a/upgrades/next/release-note-fragments.md
+++ b/upgrades/next/release-note-fragments.md
@@ -1,0 +1,50 @@
+# Upgrade Guide — vNEXT
+
+<!-- bump: minor -->
+
+## What Changed
+
+Release notes are now authored as per-PR **fragments** instead of a single shared
+`upgrades/NEXT.md`. Each PR drops its release note at `upgrades/next/<slug>.md`,
+touching a distinct file, so two concurrent PRs never collide on the release
+notes — the bottleneck that made many-agent merges un-landable in real time.
+
+A new pure script, `scripts/assemble-next-md.mjs`, folds every fragment (sorted
+deterministically by filename) — plus any legacy `upgrades/NEXT.md`, for backward
+compatibility — into a single `upgrades/NEXT.md`, merging by section: one What
+Changed, one What to Tell Your User, one Summary of New Capabilities, one Evidence,
+each being the concatenation of that section across all inputs. Non-canonical
+sections are preserved and appended. The emitted bump directive is the highest tier
+among the fragments (major beats minor beats patch); it is a documentation hint only
+— the real release tier still comes from `.instar/release-tier.json`, which is
+untouched.
+
+The publish workflow gains ONE new step, "Assemble release-note fragments", placed
+immediately before the existing "Check if NEXT.md has content to publish" step.
+Everything downstream — the tier gate, version resolution, the rename, the upgrade
+guide check, publish, and commit — is unchanged. With no fragments and no legacy
+NEXT.md, the assemble step does nothing and the existing skip logic fires exactly as
+before, so the no-fragments path reproduces current behavior byte-for-byte. After a
+release is cut, consumed fragments are deleted (`rm -f upgrades/next/*.md`) and the
+existing commit step stages the deletions. The pre-push gate is now fragment-aware:
+it validates the assembled result in-memory (never writing NEXT.md to disk during
+pre-push), so a PR that ships only a fragment passes the same section and content
+checks the publish gate enforces, and a malformed fragment fails the push loudly.
+`upgrades/NEXT.md` remains fully supported as a legacy, backward-compatible path.
+
+## What to Tell Your User
+
+Behind the scenes, the way I prepare release notes got a lot more robust. Each
+change now writes its own small note in its own file, instead of every change
+fighting over one shared notes file. That means when several updates are being
+prepared at the same time, they no longer block each other, so improvements reach
+you faster and with less risk of a release getting stuck. Nothing changes about how
+I talk to you — this is purely a smoother release pipeline on my side.
+
+## Summary of New Capabilities
+
+| Capability | How to Use |
+|-----------|-----------|
+| Per-PR release-note fragments | Write `upgrades/next/<slug>.md` (one file per change) |
+| Fragment assembler | `node scripts/assemble-next-md.mjs` (runs automatically in publish) |
+| Legacy NEXT.md | Still supported — folded in for backward compatibility |

--- a/upgrades/side-effects/nextmd-release-note-fragments.md
+++ b/upgrades/side-effects/nextmd-release-note-fragments.md
@@ -1,0 +1,151 @@
+# Side-Effects Review — Per-PR release-note fragments
+
+**Version / slug:** `nextmd-release-note-fragments`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `required` (release-pipeline blast radius — see §1, §7)
+
+## Summary of the change
+
+The release pipeline consumed a single shared `upgrades/NEXT.md` per merge. With
+many agents merging concurrently, every PR rewrote NEXT.md, so every PR collided on
+it within minutes — the release notes became an un-landable hot file. This change
+introduces per-PR release-note FRAGMENTS (`upgrades/next/<slug>.md`): two PRs touch
+different fragment files and never collide.
+
+The mechanism is an ASSEMBLE PRE-STEP. A new pure script
+(`scripts/assemble-next-md.mjs`) folds every fragment (deterministic filename sort)
+plus any legacy `upgrades/NEXT.md` into a single `upgrades/NEXT.md`, merging by
+section. The publish workflow runs it immediately BEFORE the existing
+"Check if NEXT.md has content to publish" step; everything downstream is unchanged.
+The pre-push gate validates the assembled result in-memory (never writing NEXT.md).
+
+## Decision-point inventory
+
+1. **No-fragments / no-legacy-NEXT.md → no-op (exit 0 quietly).** The existing skip
+   logic then fires. This is the load-bearing backward-compat boundary.
+2. **Malformed fragment (content but no parseable `## ` section, or only
+   comments/whitespace) → loud non-zero exit.** Fails the workflow rather than
+   shipping a broken guide.
+3. **Idempotency guard:** an input carrying `GENERATED_MARKER` is dropped when any
+   non-generated input is present; folded straight through (stable re-emit) when it
+   is the sole input. Decides "is this a fresh fragment set or a re-run on prior
+   output?"
+4. **Bump tier = MAX(fragments).** A hint only; the real tier is
+   `.instar/release-tier.json` (untouched).
+5. **pre-push gate active-guide selection:** assembled in-flight notes win; else fall
+   back to the versioned guide; else "no guide" error.
+
+## 1. Over-block
+
+**What legitimate inputs does this change reject?** A fragment with real prose but no
+`## ` heading is rejected — intentional, because the assembler can't place headless
+prose under a known section. An effectively-empty fragment (comments/whitespace only)
+is rejected — intentional, an empty fragment file is a mistake. A hand-authored legacy
+`upgrades/NEXT.md` is NOT rejected: it is folded in (backward compat). The
+no-fragments-and-no-NEXT.md case is NOT an error — it is a clean exit-0 no-op, so the
+existing "nothing to publish" skip is preserved exactly. **No legitimate current input
+is newly rejected:** today's flow ships a NEXT.md, which still validates and publishes
+unchanged.
+
+## 2. Under-block
+
+**What does this still miss?** The assembler does not deep-validate each fragment's
+section CONTENT (camelCase keys, inline code, missing Evidence) — that remains the job
+of `validateGuideContent`, which runs against the ASSEMBLED result in both the pre-push
+gate and (post-rename) `check-upgrade-guide.js`. So a defect in a fragment is caught at
+the assembled layer, not per-fragment; this is acceptable because the assembled doc is
+exactly what publishes. It does not detect two fragments making contradictory claims —
+out of scope (humans review notes). It does not garbage-collect stale fragments that
+were never released; the publish path deletes only the fragments it just consumed.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The assembler is a pure string→string function with a thin CLI
+wrapper (same shape as `resolve-release-tier.mjs` / `resolve-publish-version.mjs`),
+unit-tested in isolation. The workflow change is one additive step plus one `rm` in the
+existing consumption path — it does not touch the tier gate, version resolution, rename,
+guide check, publish, or commit logic. The pre-push gate reuses the SAME assemble
+function (single source of truth), so pre-push and publish can never diverge on how
+fragments fold.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No new blocking AUTHORITY over releases is added. The assembler is a transform, not a
+gate: its only failure mode is a malformation (exit non-zero), which is the same loud
+behavior the publish workflow already wants. The real publish AUTHORITY is unchanged —
+`.instar/release-tier.json` (Layer 2) and `validateGuideContent` (the section/content
+gate) still decide what ships. The emitted bump comment is explicitly a documentation
+SIGNAL, not authority (the code comment and the artifact both say so).
+
+## 5. Interactions
+
+- **UpgradeGuideProcessor**: scans `upgrades/` for files matching
+  `^(\d+\.\d+\.\d+)\.md$`. `readdirSync` returns the subdir name `next` (no `.md`
+  suffix) → not matched → ignored. Verified by reading `getAvailableGuides`. The
+  `upgrades/next/` directory is invisible to guide delivery.
+- **check-upgrade-guide.js**: iterates `upgrades/*.md` files (skips `NEXT.md`); the
+  `next/` subdir is not a `.md` file → skipped. By publish time fragments are already
+  deleted and NEXT.md renamed, so it validates the assembled+renamed guide. Verified
+  end-to-end in a scratch dir (assemble → rename → check → exit 0).
+- **pre-push-gate.js**: now imports the assembler; assembles in-memory; the side-effects
+  artifact check (§5 of the gate) reads the assembled "What Changed" instead of raw
+  NEXT.md. No NEXT.md is written during pre-push.
+- **Idempotency / re-runs**: the `GENERATED_MARKER` guard prevents a re-run from
+  double-folding prior output back over still-present fragments.
+- No interaction with SessionReaper, sentinels, recovery, or any runtime path — this is
+  build/CI tooling only.
+
+## 6. External surfaces
+
+- New directory `upgrades/next/` and new file convention `upgrades/next/<slug>.md`.
+- New script `scripts/assemble-next-md.mjs` (build-time only; never shipped to agent
+  runtime paths).
+- One new publish workflow step + one `rm` in the existing rename step.
+- New CLAUDE.md / build-skill guidance instructing fragment authoring; a
+  `PostUpdateMigrator` CLAUDE.md backfill for deployed agents.
+- No HTTP routes, no config keys, no Telegram, no agent runtime behavior change.
+
+## 7. Rollback cost
+
+**Low and clean.** Three independent revert points, each safe on its own:
+- Remove the "Assemble release-note fragments" workflow step + the `rm` line → publish
+  reverts to consuming NEXT.md directly (NEXT.md authoring still works).
+- Revert the pre-push gate to validating NEXT.md directly.
+- Delete `scripts/assemble-next-md.mjs` + its test.
+Because the no-fragments path is a byte-for-byte no-op, a half-rollback (e.g. removing
+only the workflow step while authors still write fragments) degrades gracefully: the
+release simply skips (no NEXT.md), which the release-readiness sentinel surfaces — it
+never ships a wrong or partial guide. No state, no schema, no irreversible op, no data
+migration. Fragments are plain markdown files.
+
+## Conclusion
+
+Additive, backward-compatible, pure-function-at-the-core change to build/CI tooling.
+The release-critical invariant — "the no-fragments path reproduces exact current
+behavior" — is enforced by code (clean exit-0 no-op) and covered by tests (CLI exits 0
+and writes nothing; pre-push accepts a fragment-only push and rejects a malformed one).
+Blast radius is contained to the assemble pre-step; the tier gate, version resolution,
+and content validation that actually authorize a release are untouched.
+
+## Second-pass review (if required)
+
+Required (release-pipeline). Reviewer focus: confirm the publish.yml diff is additive
+(the assemble step precedes the unchanged skip-check; the `rm` rides the existing
+`if:` guard and the existing `git add upgrades/`), and that the no-fragments path still
+skips cleanly. Pending.
+
+## Evidence pointers
+
+- `tests/unit/assemble-next-md.test.ts` — 25 tests: section merge, deterministic order,
+  max bump tier, single fragment, legacy fold, no-op/quiet, malformed→loud, idempotent
+  (in-memory + on-disk CLI), WTTYU backtick-free.
+- `tests/unit/pre-push-gate.test.ts` — fragment-aware integration: accepts fragment-only
+  push (writes no NEXT.md), rejects WTTYU inline code via assembled validation, rejects
+  malformed fragment loudly.
+- Manual end-to-end (scratch dir): fragment → `assemble-next-md.mjs` →
+  `mv NEXT.md <version>.md` + `rm next/*.md` → `check-upgrade-guide.js` exit 0.
+- `upgrades/next/release-note-fragments.md` — this PR's own release note (dogfoods the
+  mechanism; the PR does not touch `upgrades/NEXT.md`).


### PR DESCRIPTION
## Per-PR release-note fragments — fix the NEXT.md concurrency bottleneck

**Problem:** the publish pipeline consumes a single shared `upgrades/NEXT.md` per merge. With multiple agents merging concurrently, every PR rewrites NEXT.md, so every PR conflicts on it within minutes — un-landable in real time (and a conflicting PR gets no CI run at all). This was the root cause of a multi-hour ship grind across all agents.

**Fix:** PRs author release notes as per-PR **fragments** — `upgrades/next/<slug>.md`. Two PRs touch different files → they never collide.

### How it works (minimal, additive, backward-compatible)
- New `scripts/assemble-next-md.mjs` (pure, 25 unit tests): folds all `upgrades/next/*.md` fragments — plus any legacy `upgrades/NEXT.md` — into one `upgrades/NEXT.md`, merging by canonical section, idempotent (GENERATED_MARKER), byte-stable when legacy NEXT.md is the sole input, loud-fail on malformation.
- publish.yml: ONE new step (`Assemble release-note fragments`) **before** the existing "Check NEXT.md" step; everything downstream is unchanged. Consumed fragments are `rm`'d on release. **The publish.yml diff is purely additive — zero existing lines removed — so the no-fragments path reproduces current behavior exactly.**
- `pre-push-gate.js` is fragment-aware (validates the assembled result in-memory, so a fragment-only PR passes without writing NEXT.md to disk).
- Backward-compatible: legacy NEXT.md still works, so other agents' in-flight PRs keep releasing while everyone migrates.

### Self-bootstrapping
This PR ships its own release note as `upgrades/next/release-note-fragments.md` — it does **not** touch the shared NEXT.md, so it lands clean through the very churn it fixes. When it merges, the new publish.yml assembles that fragment and releases it (dogfooding the mechanism).

### Verification (self-run)
build ✅ · lint ✅ · docs-coverage ✅ · 104 tests green (assemble 25, pre-push 13 incl. fragment cases, parity guards). publish.yml diff confirmed additive-only.
