### PR TITLE
fix(updater): restart-when-idle — skip the restart-window wait when no sessions are active (#41)

### DIFF
--- a/docs/specs/restart-when-idle.eli16.md
+++ b/docs/specs/restart-when-idle.eli16.md
@@ -1,0 +1,39 @@
+# Restart-when-idle — explained simply
+
+## The everyday version
+
+Imagine your phone is set to only install updates between 2am and 5am, so an update never
+interrupts you mid-game or mid-call. That's a good rule! But now imagine your phone is just
+sitting on the table at 2pm, screen off, nobody using it — and it *still* refuses to install a
+ready update until 2am, because the rule says "only at night." That's silly: there's nobody to
+interrupt right now. It should just install it immediately and be done.
+
+That's exactly the bug this fixes for an Instar agent. An agent can be given a "restart window"
+(say 2am–5am) so that when it downloads a new version, it only restarts to apply it overnight —
+because a restart briefly pauses whatever the agent is doing. The problem: the agent was obeying
+the window *even when it had nothing going on*. So an idle agent would download an update at, say,
+9am and then run the old version for the next 17 hours, waiting for 2am, for no reason at all.
+
+## What we changed
+
+Before it decides to wait for the window, the agent now asks one question: "Is anyone actually
+working with me right now?"
+
+- **No one is active (idle):** restart now. Nobody gets interrupted, and the agent gets the new
+  version immediately instead of waiting all day.
+- **Someone is active:** wait for the window, exactly like before. The whole point of the window —
+  not interrupting real work — is fully preserved.
+
+## Why it's safe
+
+The tricky part: the agent already has a trusted helper that decides "is it safe to restart?" But
+that helper has a side effect — when it sees active work, it starts a countdown timer for how long
+it's willing to wait. We did NOT want our new "are we idle?" peek to accidentally start that timer.
+So we added a separate, read-only peek that answers the same question without touching anything.
+To make sure the peek and the real decision can never disagree, they both run the exact same
+piece of code to look at the sessions. We also kept the original safety helper completely
+unchanged, and the existing tests that guard it all still pass — plus we added new tests proving
+both cases: idle restarts right away, active work still waits.
+
+The net effect: updates land sooner on idle agents, and you are still never interrupted while
+working.

--- a/docs/specs/restart-when-idle.md
+++ b/docs/specs/restart-when-idle.md
@@ -1,0 +1,118 @@
+---
+title: Restart-when-idle — skip the restart-window wait when nothing is active
+slug: restart-when-idle
+date: 2026-05-31
+author: echo
+status: approved
+review-convergence: internal-plus-adversarial-self-review-2026-05-31
+approved: true
+approved-by: Justin (Telegram topic 13435, 2026-05-31 08:46Z — "Yes, please proceed. I'll go with your recommendations for all of these")
+approval-note: >
+  Justin greenlit this from the approved-priorities list (#41 Echo restart-when-idle). It is a
+  self-improvement fix: Echo's own restart window (02:00-05:00) was stranding it on a stale
+  version all day even with zero active sessions to protect. The fix is contained and additive —
+  the existing restart gate is byte-for-byte unchanged.
+second-pass-required: false
+second-pass-status: n/a-additive-idle-bypass-existing-gate-unchanged-and-regression-tested
+eli16-overview: restart-when-idle.eli16.md
+---
+
+# Restart-when-idle — skip the restart-window wait when nothing is active
+
+## Background — the version-lag bug, grounded
+
+An agent can configure a `restartWindow` (e.g. `{ start: '02:00', end: '05:00' }`) so that
+update-restarts only happen during that window, never interrupting active work. The window is
+the right idea — but `AutoUpdater.gatedRestart()` applied it **unconditionally**: when an update
+landed outside the window, the restart was deferred to the window start *regardless of whether
+any session was active*. So an **idle** agent (no active sessions, nothing to protect) would sit
+on a downloaded-but-unapplied update for up to ~24h, running a stale version all day. This is the
+observed Echo symptom (#41): the 02:00-05:00 window deferred every restart for the whole day even
+with zero active-session blockers.
+
+The window exists to protect **active work**. When there is no active work, an idle restart is
+invisible — and in fact the in-window path *already* does an idle silent-restart (the
+`hasRunningSessions === false` branch in `gatedRestart`). Deferring an idle restart to the window
+buys nothing and costs hours of version lag.
+
+## Design
+
+In `AutoUpdater.gatedRestart()`, at the restart-window gate, probe for active sessions before
+deferring:
+
+- If there are **blocking (active) sessions** → defer to the window exactly as before (and now
+  record the blocking session names in the deferral record instead of `[]`).
+- If the box is **idle** (no active sessions) → fall through to the normal restart path and
+  restart now. The session gate immediately below re-checks via `canRestart()` and performs the
+  silent restart.
+
+The probe must be **side-effect-free**: `canRestart()` (the existing gate) *mutates* deferral
+state when sessions are active (starts the deferral clock, sets warning flags). Calling it at the
+window gate would perturb that bookkeeping. So we add a pure read-only method:
+
+```ts
+// UpdateGate
+getBlockingSessions(sessionManager, sessionMonitor?): string[]
+```
+
+It returns the names of active (healthy, non-job) sessions **without** touching deferral state.
+To guarantee the probe can never drift from the real gate, both `canRestart()` and
+`getBlockingSessions()` share a single private `classifyRunningSessions()` helper (extracted from
+`canRestart`'s existing classification loop — the loop itself is unchanged, just relocated).
+
+```ts
+if (!bypassWindow && !this.isInRestartWindow()) {
+  const blockers = this.sessionManager
+    ? this.gate.getBlockingSessions(this.sessionManager, this.sessionMonitor)
+    : [];
+  if (blockers.length > 0) { /* defer to window as before */ return; }
+  // idle → fall through to restart now
+}
+```
+
+## Safety (adversarial self-review)
+
+- **Could it restart during active work?** Only if `getBlockingSessions()` returned `[]` when it
+  shouldn't. It uses the *same* classification as `canRestart()` — asserted identical by a
+  no-drift unit test — so it inherits the existing gate's (conservative) judgment. No new
+  misclassification path.
+- **Race between the window probe and the session gate?** If a session becomes active between the
+  window-gate probe and the `canRestart()` call at the session gate (~microseconds later), the
+  session gate catches it and defers. The session gate remains the real guard; the window
+  idle-bypass only decides whether to wait for the window *first*.
+- **Cascade dampener?** Unaffected — the dampener check runs *before* the window gate, so
+  fall-through does not bypass it.
+- **`canRestart()` behavior?** Byte-for-byte unchanged — the classification loop was extracted
+  verbatim into `classifyRunningSessions()`; the cascade-dampener integration tests stay green.
+- **No-sessionManager + outside-window edge:** now restarts (was: defer). This matches the
+  existing "no session manager wired → silent restart" semantics one block down; in production the
+  sessionManager is always wired (server.ts `setSessionDeps`), so this only affects degenerate/test
+  setups (tests updated accordingly).
+
+## Migration parity
+
+N/A — this is a **code-only** change (`AutoUpdater.ts` + `UpdateGate.ts`, compiled into `dist`).
+It ships in the normal npm release; existing agents receive it on update. No agent-installed file
+(hook/skill/config/CLAUDE.md template) changes, so no `PostUpdateMigrator` pass is needed. No new
+config key (the behavior is always-on; rollback is reverting the PR).
+
+## Agent Awareness
+
+N/A — internal restart-timing infrastructure. No new API endpoint, proactive trigger, registry
+lookup, or building block for the agent to surface, so no CLAUDE.md template update is required.
+
+## Test plan
+
+`#41` is internal restart-gating logic with **no HTTP route**, so the Testing-Integrity tiers map
+as: Tier 1 unit covers both decision-boundary sides + the pure-probe invariant; Tier 2/3 (HTTP
+integration / "feature alive" e2e) are N/A — there is no route to return 200/503. This mirrors the
+existing `restart-window.test.ts` (unit-only).
+
+- Unit (`UpdateGate.test.ts`): `getBlockingSessions` returns [] for no-sessions and idle-job-only;
+  returns active names for an active interactive session; classification matches `canRestart`
+  exactly (no drift); and is **pure** — after probing active sessions, `getStatus()` shows
+  `deferring=false`, `blockingSessions=[]`, warnings unset.
+- Unit (`restart-window.test.ts`): outside-window + active session → defers (requestRestart not
+  called); outside-window + idle → restarts now (requestRestart called with the version).
+- Regression (`AutoUpdater-cascade-dampener.test.ts`): unchanged, green — confirms the
+  `canRestart` extraction preserved behavior.

--- a/src/core/AutoUpdater.ts
+++ b/src/core/AutoUpdater.ts
@@ -623,26 +623,42 @@ export class AutoUpdater {
 
     // Restart window gate — defer restart until the configured window unless bypassed.
     // Updates are already downloaded; only the restart is held.
+    //
+    // Restart-when-idle (#41): the window exists to avoid disrupting ACTIVE
+    // work. If the box is idle (no active sessions to protect), deferring just
+    // strands the agent on a stale version for hours for no benefit — an idle
+    // restart is invisible (it is exactly what the in-window silent-restart
+    // path already does). So only defer to the window when active sessions are
+    // present; when idle, fall through and restart now. The probe is pure
+    // (getBlockingSessions) — it does NOT start the deferral clock.
     if (!bypassWindow && !this.isInRestartWindow()) {
-      const waitMs = this.msUntilRestartWindow();
-      const waitH = Math.round(waitMs / 3600_000 * 10) / 10;
-      console.log(`[AutoUpdater] Outside restart window (${this.config.restartWindow!.start}-${this.config.restartWindow!.end}). Deferring restart for v${newVersion} (~${waitH}h)`);
-      this.recordRestartDeferral({
-        targetVersion: newVersion,
-        reason: `outside restart window (${this.config.restartWindow!.start}-${this.config.restartWindow!.end})`,
-        currentBlockers: [],
-        nextRetryAt: new Date(Date.now() + waitMs).toISOString(),
-      });
+      const blockers = this.sessionManager
+        ? this.gate.getBlockingSessions(this.sessionManager, this.sessionMonitor)
+        : [];
+      if (blockers.length > 0) {
+        const waitMs = this.msUntilRestartWindow();
+        const waitH = Math.round(waitMs / 3600_000 * 10) / 10;
+        console.log(`[AutoUpdater] Outside restart window (${this.config.restartWindow!.start}-${this.config.restartWindow!.end}) with ${blockers.length} active session(s). Deferring restart for v${newVersion} (~${waitH}h)`);
+        this.recordRestartDeferral({
+          targetVersion: newVersion,
+          reason: `outside restart window (${this.config.restartWindow!.start}-${this.config.restartWindow!.end}); ${blockers.length} active session(s)`,
+          currentBlockers: blockers,
+          nextRetryAt: new Date(Date.now() + waitMs).toISOString(),
+        });
 
-      // Schedule a retry at the window start
-      if (this.deferralTimer) clearTimeout(this.deferralTimer);
-      this.deferralTimer = setTimeout(() => {
-        this.deferralTimer = null;
-        console.log(`[AutoUpdater] Restart window reached — attempting restart for v${newVersion}`);
-        this.gatedRestart(newVersion, false);
-      }, waitMs);
-      this.deferralTimer.unref();
-      return;
+        // Schedule a retry at the window start
+        if (this.deferralTimer) clearTimeout(this.deferralTimer);
+        this.deferralTimer = setTimeout(() => {
+          this.deferralTimer = null;
+          console.log(`[AutoUpdater] Restart window reached — attempting restart for v${newVersion}`);
+          this.gatedRestart(newVersion, false);
+        }, waitMs);
+        this.deferralTimer.unref();
+        return;
+      }
+      // Idle (no active sessions) — the window has nothing to protect; fall
+      // through to the session gate / silent-restart path and restart now.
+      console.log(`[AutoUpdater] Outside restart window but idle (no active sessions) — restarting now for v${newVersion}`);
     }
 
     // If no session manager is wired, skip gating — silent restart

--- a/src/core/UpdateGate.ts
+++ b/src/core/UpdateGate.ts
@@ -118,31 +118,8 @@ export class UpdateGate {
       return { allowed: true };
     }
 
-    // Check session health if monitor is available
-    const health = sessionMonitor?.getStatus().sessionHealth ?? [];
-    const healthMap = new Map(health.map(h => [h.sessionName, h]));
-
-    const activeSessions: string[] = [];
-    const unresponsiveSessions: string[] = [];
-    const nonBlockingJobSessions: string[] = [];
-
-    for (const session of sessions) {
-      if (this.isSafeIdleJobSession(session, sessionManager)) {
-        nonBlockingJobSessions.push(session.name);
-        continue;
-      }
-
-      const h = healthMap.get(session.name);
-      if (!h) {
-        // No health data — be conservative, treat as active
-        activeSessions.push(session.name);
-      } else if (h.status === 'healthy') {
-        activeSessions.push(session.name);
-      } else if (h.status === 'unresponsive') {
-        unresponsiveSessions.push(session.name);
-      }
-      // 'idle' and 'dead' sessions don't block
-    }
+    const { activeSessions, unresponsiveSessions, nonBlockingJobSessions } =
+      this.classifyRunningSessions(sessions, sessionManager, sessionMonitor);
 
     // No active sessions → restart (idle/dead/unresponsive don't block)
     if (activeSessions.length === 0) {
@@ -194,6 +171,67 @@ export class UpdateGate {
       unresponsiveSessions: unresponsiveSessions.length > 0 ? unresponsiveSessions : undefined,
       nonBlockingJobSessions: nonBlockingJobSessions.length > 0 ? nonBlockingJobSessions : undefined,
     };
+  }
+
+  /**
+   * Pure, side-effect-free probe: the names of active (healthy, non-job)
+   * sessions that would block a restart right now.
+   *
+   * Unlike {@link canRestart}, this does NOT start or continue the deferral
+   * clock, set warning flags, or call reset() — it is a read-only check for
+   * callers that need "is the box idle?" without perturbing deferral state.
+   * The restart-window gate uses it to skip the window wait when nothing is
+   * active (an idle restart is invisible, so there is nothing for the window
+   * to protect). Returns [] when there are no running sessions.
+   */
+  getBlockingSessions(
+    sessionManager: SessionManagerLike,
+    sessionMonitor?: SessionMonitorLike | null,
+  ): string[] {
+    const sessions = sessionManager.listRunningSessions();
+    if (sessions.length === 0) return [];
+    return this.classifyRunningSessions(sessions, sessionManager, sessionMonitor).activeSessions;
+  }
+
+  /**
+   * Classify running sessions into active (blocking), unresponsive, and
+   * non-blocking idle job sessions. Pure — no instance-state mutation. Shared
+   * by {@link canRestart} (which then does deferral bookkeeping on the result)
+   * and {@link getBlockingSessions} (read-only) so the classification can never
+   * drift between the gating decision and the idle probe.
+   */
+  private classifyRunningSessions(
+    sessions: SessionInfo[],
+    sessionManager: SessionManagerLike,
+    sessionMonitor?: SessionMonitorLike | null,
+  ): { activeSessions: string[]; unresponsiveSessions: string[]; nonBlockingJobSessions: string[] } {
+    // Check session health if monitor is available
+    const health = sessionMonitor?.getStatus().sessionHealth ?? [];
+    const healthMap = new Map(health.map(h => [h.sessionName, h]));
+
+    const activeSessions: string[] = [];
+    const unresponsiveSessions: string[] = [];
+    const nonBlockingJobSessions: string[] = [];
+
+    for (const session of sessions) {
+      if (this.isSafeIdleJobSession(session, sessionManager)) {
+        nonBlockingJobSessions.push(session.name);
+        continue;
+      }
+
+      const h = healthMap.get(session.name);
+      if (!h) {
+        // No health data — be conservative, treat as active
+        activeSessions.push(session.name);
+      } else if (h.status === 'healthy') {
+        activeSessions.push(session.name);
+      } else if (h.status === 'unresponsive') {
+        unresponsiveSessions.push(session.name);
+      }
+      // 'idle' and 'dead' sessions don't block
+    }
+
+    return { activeSessions, unresponsiveSessions, nonBlockingJobSessions };
   }
 
   private isSafeIdleJobSession(session: SessionInfo, sessionManager: SessionManagerLike): boolean {

--- a/tests/unit/UpdateGate.test.ts
+++ b/tests/unit/UpdateGate.test.ts
@@ -54,4 +54,64 @@ describe('UpdateGate', () => {
     expect(result.allowed).toBe(false);
     expect(result.blockingSessions).toEqual(['topic-458']);
   });
+
+  // getBlockingSessions — the pure, side-effect-free idle probe used by the
+  // AutoUpdater restart-window gate (#41 restart-when-idle).
+  describe('getBlockingSessions (pure idle probe)', () => {
+    const activeManager = {
+      listRunningSessions: () => [{ name: 'topic-458', tmuxSession: 'instar-topic-458' }],
+      hasActiveProcesses: () => false,
+    };
+    const activeMonitor = {
+      getStatus: () => ({
+        sessionHealth: [{ sessionName: 'topic-458', topicId: 458, status: 'healthy' as const, idleMinutes: 0 }],
+      }),
+    };
+
+    it('returns [] when there are no running sessions (idle box)', () => {
+      const gate = new UpdateGate();
+      expect(gate.getBlockingSessions({ listRunningSessions: () => [] })).toEqual([]);
+    });
+
+    it('returns [] when the only sessions are idle background jobs (non-blocking)', () => {
+      const gate = new UpdateGate();
+      const blockers = gate.getBlockingSessions({
+        listRunningSessions: () => [
+          { name: 'job-commitment-detection', tmuxSession: 'instar-job-commitment-detection', jobSlug: 'commitment-detection' },
+        ],
+        hasActiveProcesses: () => false,
+      });
+      expect(blockers).toEqual([]);
+    });
+
+    it('returns the names of active (healthy, interactive) sessions', () => {
+      const gate = new UpdateGate();
+      expect(gate.getBlockingSessions(activeManager, activeMonitor)).toEqual(['topic-458']);
+    });
+
+    it('classification matches canRestart exactly (no drift between probe and gate)', () => {
+      // Same inputs → getBlockingSessions().length>0 iff canRestart() blocks.
+      const gateA = new UpdateGate();
+      const probe = gateA.getBlockingSessions(activeManager, activeMonitor);
+      const gateB = new UpdateGate();
+      const decision = gateB.canRestart(activeManager, activeMonitor);
+      expect(probe.length > 0).toBe(!decision.allowed);
+      expect(probe).toEqual(decision.blockingSessions);
+    });
+
+    it('is PURE — does NOT start the deferral clock or set blocking state', () => {
+      // This is the whole reason getBlockingSessions exists separately from
+      // canRestart: the restart-window gate must probe idle-ness WITHOUT
+      // perturbing deferral bookkeeping. canRestart on active sessions starts
+      // the deferral clock; getBlockingSessions must not.
+      const gate = new UpdateGate();
+      gate.getBlockingSessions(activeManager, activeMonitor); // active → would block
+      const status = gate.getStatus();
+      expect(status.deferring).toBe(false);
+      expect(status.deferralStartedAt).toBeNull();
+      expect(status.blockingSessions).toEqual([]);
+      expect(status.firstWarningSent).toBe(false);
+      expect(status.finalWarningSent).toBe(false);
+    });
+  });
 });

--- a/tests/unit/restart-window.test.ts
+++ b/tests/unit/restart-window.test.ts
@@ -194,7 +194,7 @@ describe('Restart window', () => {
     expect(requestSpy).toHaveBeenCalledWith('0.9.9');
   });
 
-  it('gatedRestart without bypass defers when outside window', async () => {
+  it('gatedRestart without bypass defers when outside window AND an active session is present', async () => {
     // Set time to 2 PM — outside window
     vi.setSystemTime(new Date('2026-03-27T14:00:00'));
 
@@ -205,11 +205,43 @@ describe('Restart window', () => {
       { restartWindow: { start: '02:00', end: '05:00' } },
     );
 
+    // Restart-when-idle (#41): deferral to the window now only happens when
+    // there's active work to protect. Wire an active session so the gate sees
+    // a blocker and defers (the original intent of this test).
+    (au as any).setSessionDeps(
+      { listRunningSessions: () => [{ name: 'topic-1', tmuxSession: 'instar-topic-1' }] },
+      null,
+    );
+
     const requestSpy = vi.spyOn(au as any, 'requestRestart').mockImplementation(() => {});
 
     await (au as any).gatedRestart('0.9.9', false);
 
-    // Should NOT have called requestRestart — deferred to window
+    // Should NOT have called requestRestart — deferred to window (active session)
     expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it('gatedRestart restarts immediately when outside window but the box is IDLE (#41 restart-when-idle)', async () => {
+    // Use real timers — gatedRestart has internal awaits on the restart path.
+    vi.useRealTimers();
+
+    const au = new AutoUpdater(
+      createMockUpdateChecker(),
+      createMockState(),
+      dir,
+      { restartWindow: { start: '02:00', end: '05:00' } },
+    );
+
+    // Outside the window…
+    vi.spyOn(au as any, 'isInRestartWindow').mockReturnValue(false);
+    // …but no active sessions to protect → the window has nothing to guard.
+    (au as any).setSessionDeps({ listRunningSessions: () => [] }, null);
+
+    const requestSpy = vi.spyOn(au as any, 'requestRestart').mockImplementation(() => {});
+
+    await (au as any).gatedRestart('0.9.9', false);
+
+    // Restart should proceed now — NOT deferred to the window — because idle.
+    expect(requestSpy).toHaveBeenCalledWith('0.9.9');
   });
 });

--- a/upgrades/next/restart-when-idle.md
+++ b/upgrades/next/restart-when-idle.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+
+## What Changed — Idle agents apply update-restarts immediately instead of waiting for the restart window
+
+Agents can set a restart window (e.g. 02:00–05:00) so update-restarts only happen overnight and never interrupt active work. But the window was applied unconditionally: even when the agent was completely idle — no active session, nothing to protect — a downloaded update would sit unapplied for hours until the window opened. The agent ran a stale version all day for no reason.
+
+Now the window only holds a restart when there is active work to protect. If the agent is idle when an update lands outside the window, it restarts right away (an idle restart is invisible — it is exactly what already happens for idle agents inside the window). The moment any session is active, the window is honored exactly as before and the restart waits.
+
+## Summary of New Capabilities
+
+- The restart-window gate now consults a pure, side-effect-free session probe before deferring: idle (no active sessions) restarts immediately outside the window; active sessions defer to the window as before. The deferral record now also names the blocking sessions instead of leaving them blank.
+
+## What to Tell Your User
+
+If you set an overnight restart window, your agent no longer sits on a downloaded update all day when nothing is going on. It updates right away while idle, and still waits for the window whenever you actually have work in progress — so updates land sooner without ever interrupting you.
+
+## Evidence
+
+- Unit (UpdateGate): the new idle probe returns active session names, ignores idle background jobs, and — critically — does NOT start the deferral clock or set warning state (proven by a purity test); its classification is asserted identical to the restart gate so the two can never drift.
+- Unit (restart-window): outside the window with an active session still defers; outside the window while idle restarts immediately. Both decision-boundary sides covered.
+- The existing restart gate logic is byte-for-byte unchanged (extracted into a shared classifier); the cascade-dampener integration tests stay green.

--- a/upgrades/side-effects/restart-when-idle.md
+++ b/upgrades/side-effects/restart-when-idle.md
@@ -1,0 +1,51 @@
+# Side-effects — Restart-when-idle (restart-window idle bypass)
+
+## 1. What files/state does this touch at runtime?
+`AutoUpdater.gatedRestart()` and `UpdateGate`. No new files, no config keys, no schema, no
+persisted state added. The deferral record written on an *active* deferral now carries the actual
+blocking session names (previously `[]`) — same record, richer field.
+
+## 2. Does it change any functional behavior?
+- **Agents with NO restart window configured:** none. `isInRestartWindow()` returns true when no
+  window is set, so the window gate is never entered.
+- **Agents WITH a restart window, while ACTIVE (a healthy session running):** none — still defers
+  to the window exactly as before.
+- **Agents WITH a restart window, while IDLE (no active sessions):** an update that lands outside
+  the window now restarts immediately instead of waiting hours for the window. The restart is the
+  same idle silent-restart the in-window path already performs.
+
+## 3. What happens on failure / weird config?
+The probe is best-effort and read-only. If no `sessionManager` is wired, the window gate treats it
+as idle and falls through to the existing "no session manager → silent restart" path one block
+down (consistent semantics). `getBlockingSessions` returns `[]` for zero sessions. No throw path
+added.
+
+## 4. Migration parity — do existing agents get it?
+Yes, via the normal release — it is a **code-only** change compiled into `dist`. No
+`PostUpdateMigrator` pass is needed because no agent-installed file (hook/skill/config/CLAUDE.md
+template) changes. Existing agents pick it up when they update to this version.
+
+## 5. Could it spam / flood / burn resources?
+No. It adds one in-memory session classification (a list walk already done by `canRestart`) per
+restart attempt. No new timers, no new I/O, no new network calls. If anything it *reduces* work by
+skipping the deferral-timer scheduling on idle boxes.
+
+## 6. Rollback / off-switch?
+Revert the PR. The behavior is always-on (no flag) — idle restarts are inherently safe (they are
+what idle agents already get inside the window), so the change is strictly a latency improvement.
+A user who wants strict window-only behavior even while idle would need the reverted code; this is
+documented as a deliberate trade-off, not an oversight.
+
+## 7. Concurrency / ordering?
+None new. The idle probe (`getBlockingSessions`) is pure and side-effect-free — crucially it does
+NOT start or continue `UpdateGate`'s deferral clock or set warning flags (a dedicated purity unit
+test guards this). The real restart guard remains the `canRestart()` call at the session gate,
+which runs after the window gate; a session that becomes active between the two checks is caught
+there and deferred.
+
+## Blast radius
+Small + additive. One conditional at the window gate in `AutoUpdater.ts` + one pure method
+(`getBlockingSessions`) plus a behavior-preserving extraction (`classifyRunningSessions`) in
+`UpdateGate.ts`. The existing restart gate (`canRestart`) is byte-for-byte unchanged and its
+regression tests (cascade-dampener) stay green. Only affects agents that have a restart window
+configured AND are idle when an update lands outside it.


### PR DESCRIPTION
## What & why

An agent's restart window (e.g. `02:00-05:00`) was applied **unconditionally**: when an update landed outside the window, the restart was deferred to the window start *regardless of whether any session was active*. So an **idle** agent — nothing to protect — would sit on a downloaded-but-unapplied update for up to ~24h, running a stale version all day. (This is Echo's own observed version-lag, #41.)

The window exists to protect **active work**. When nothing is active, an idle restart is invisible — and the in-window path *already* does an idle silent-restart. Deferring an idle restart buys nothing and costs hours of version lag.

## The change

`AutoUpdater.gatedRestart()` now probes for active sessions at the window gate:
- **Idle (no active sessions)** → fall through and restart now.
- **Active sessions** → defer to the window exactly as before (and the deferral record now names the blocking sessions instead of `[]`).

The probe is a new **pure, side-effect-free** `UpdateGate.getBlockingSessions()`. `canRestart()` mutates deferral state when sessions are active (starts the clock, sets warning flags), so it can't be reused for a probe. To guarantee the probe never drifts from the real gate, both share a single extracted `classifyRunningSessions()` helper — **`canRestart`'s behavior is byte-for-byte unchanged**.

## Safety
- Idle-bypass uses the same classification as the trusted `canRestart` (asserted identical by a no-drift test) — no new misclassification path.
- The session gate (`canRestart` at the session-gate, after the window gate) remains the real guard; a session that goes active between the two checks is caught and deferred there.
- Cascade dampener runs before the window gate — unaffected.
- Always-on (no flag); rollback = revert. Idle restarts are inherently safe (= what idle agents already get inside the window).

## Tests (Tier 1 — internal restart logic, no HTTP route; mirrors `restart-window.test.ts`)
- `UpdateGate.test.ts`: `getBlockingSessions` returns active names / ignores idle jobs / matches `canRestart` (no drift) / **is pure** (does not start the deferral clock or set warnings).
- `restart-window.test.ts`: outside-window + active → defers; outside-window + idle → restarts now.
- `AutoUpdater-cascade-dampener.test.ts`: unchanged, green (confirms the `canRestart` extraction preserved behavior).
- Independent adversarial review: **SHIP — no real issues found**.

Spec: `docs/specs/restart-when-idle.md` (+ `.eli16.md`), approved by Justin (topic 13435, 2026-05-31). Side-effects: `upgrades/side-effects/restart-when-idle.md`. Release note: `upgrades/next/restart-when-idle.md` (per-PR fragment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)