### PR TITLE
fix(multi-machine): short-circuit remote placement in inbound dispatch (bug #8)

### DIFF
--- a/docs/specs/session-pool-route-shortcircuit.eli16.md
+++ b/docs/specs/session-pool-route-shortcircuit.eli16.md
@@ -1,0 +1,43 @@
+# Short-circuit remote placement — explain it like I'm 16
+
+Two computers act as one assistant. When you say "move this conversation to the Mac
+mini," the laptop is supposed to hand that conversation off so the mini takes over.
+
+Here's how a message gets handled when the feature is on. Every incoming message
+goes to a "router" that decides: should I handle this here, or send it to the other
+machine? The router gives back a one-word answer about what it did:
+- "forwarded" / "duplicate" → I sent it to the machine that owns this conversation.
+- "spawned" → this conversation had no owner yet, so I picked a machine, claimed it,
+  and started it up THERE.
+- "handled-locally" → I'm keeping it right here on this machine.
+- a few others (queued, blocked).
+
+The bug: the code that reads the router's answer only knew to "stop and not also
+handle it here" for the answers "forwarded" and "duplicate." But when you MOVE a
+conversation, the router picks the mini, claims it, and answers "spawned" (start it
+on the mini). The reading code didn't recognize "spawned" as "it went to another
+machine," so it ALSO shoved the message into the old session still sitting on the
+laptop. Result: the conversation got started on the mini AND kept being answered on
+the laptop — so from your side, the move looked like it did nothing; the laptop just
+kept replying.
+
+The fix is small and precise. I wrote one tiny pure function,
+`isRemotelyHandled(answer, me)`, that knows the full rule: "forwarded"/"duplicate"
+always mean it left this machine; "spawned" means it left this machine UNLESS the
+machine it picked is me; same idea for one other answer ("owner-dead-replaced").
+Everything else means "handle it here." The reading code now just asks that
+function. Because it's a separate little function, I could write tests that check
+every possible answer — including the tricky case where I don't even know my own
+machine name yet (in which case I play it safe and handle locally, so a message is
+never silently dropped).
+
+I also added one log line that prints, for every message, what the router decided
+and which machine owns it. Before, that decision was invisible — the live test
+could see the "move" command land but had no idea what the router did next, which
+is exactly what hid this bug. Now the next live run can see it plainly.
+
+To be clear about what this does and doesn't do: it stops the double-handling so a
+moved conversation actually leaves the laptop. It does NOT yet fix the separate
+problem that the mini has no way to send Telegram replies back to you (that's a
+different piece I'm tracking). So this is one rung of the ladder, with the next rung
+clearly in view.

--- a/docs/specs/session-pool-route-shortcircuit.md
+++ b/docs/specs/session-pool-route-shortcircuit.md
@@ -1,0 +1,89 @@
+---
+title: Session-pool inbound dispatch — short-circuit remote placement (no double-dispatch)
+slug: session-pool-route-shortcircuit
+status: approved
+review-convergence: 2026-05-31T10:45:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h deploy mandate (topic 13481).
+  Bug #8 of the multi-machine live-transfer cascade, found by running the full
+  live "move this to the Mac mini" Telegram test (Justin authorized autonomous
+  live testing — see feedback_live_transfer_test_autonomous_authorized). Flagged
+  in the PR per cross-agent discipline.
+---
+
+# Session-pool inbound dispatch — short-circuit remote placement
+
+## Problem
+
+Found live (2026-05-31) running the full "move this to the Mac mini" transfer on a
+throwaway topic. The recognizer fired correctly (pin set to the mini, ownership
+released), but the follow-up message was injected into the existing LOCAL laptop
+session instead of forwarding to the mini.
+
+Root cause is in the inbound-dispatch call site (`src/commands/server.ts`, the
+Telegram `onMessage` handler). When the rollout stage is live it calls
+`SessionRouter.route(...)` and only short-circuits local dispatch on
+`outcome.action === 'forwarded' || 'duplicate'`. But `SessionRouter.placeAndClaim`
+returns **`'spawned'`** when it places + claims a session on a REMOTE machine
+(self-placement returns `'handled-locally'`, never `'spawned'`), and
+`'owner-dead-replaced'` for either self or remote. A remote `'spawned'` /
+`'owner-dead-replaced'` was NOT short-circuited → the message both got spawned on
+the target AND fell through to local injection (double-dispatch), so a just-moved
+topic kept being served on the origin machine.
+
+A second factor (whether the recognizer's ownership-release propagates, vs the pin
+being honored by `PlacementExecutor`) was indistinguishable from the logs because
+`route()`'s placement/forward decision was never logged — the live path was a black
+box past the recognizer's pin line.
+
+## Goal
+
+When the session pool is live, an inbound message whose routing decision places or
+forwards the session onto ANOTHER machine must NOT also be dispatched locally; and
+the routing decision must be observable so the remaining cascade (pin-honored vs
+ownership-released) can be pinpointed on the next live run.
+
+## Non-goals
+
+- Does NOT fix the standby's missing outbound Telegram (bug #7 — a moved session on
+  a tokenless standby still can't reply; tracked separately).
+- Does NOT change `SessionRouter.route()` / `PlacementExecutor` decision logic — only
+  how the inbound caller INTERPRETS the outcome.
+- Does NOT alter the `'dark'` path (still byte-identical to single-machine dispatch).
+
+## Design
+
+1. **Pure helper `isRemotelyHandled(outcome, selfMachineId)`** (exported from
+   `SessionRouter.ts`, co-located with `RouteOutcome`): true for `'forwarded'` /
+   `'duplicate'` (delivered to a remote owner) and for `'spawned'` /
+   `'owner-dead-replaced'` whose resolved `owner` is not self. Pure → unit-testable
+   over every `RouteAction` and the self/remote/null-self boundaries.
+
+2. **Call site uses the helper** (`server.ts`): `if (isRemotelyHandled(outcome,
+   _meshSelfId)) { …; return; }` replaces the `'forwarded'||'duplicate'`-only check.
+   A new module-level `_meshSelfId` (set in the mesh block beside `_sessionRouter`)
+   supplies self-identity. Fail-safe: a null self with an unknown owner is treated
+   as NOT-remote (falls through to local — never silently drops a message).
+
+3. **Routing-decision log**: one line per routed inbound —
+   `[session-pool] route topic N → action=… owner=… self=…` — permanent
+   observability for the otherwise-invisible live transfer path.
+
+## Testing
+
+- Tier 1 (`SessionRouter.test.ts`): `isRemotelyHandled` over forwarded/duplicate,
+  remote vs self `spawned`, remote vs self `owner-dead-replaced`, local/queued/blocked
+  fall-through, and the null-self fail-safe.
+- Wiring (`session-pool-activation-wiring.test.ts`): the call site uses
+  `isRemotelyHandled(outcome, _meshSelfId)` and still fails safe to local dispatch.
+- 50 session-pool tests green; `tsc --noEmit` clean.
+- Tier-3: the next live run reads the new route-decision log to confirm the forward
+  fires (and to pinpoint pin-vs-ownership for the remaining cascade).
+
+## Migration parity
+
+Pure code (one exported helper + a call-site swap + one module ref + a log). No
+config / hook / route / CLAUDE.md change. The pool path is gated past `'dark'`
+(default), so existing agents are unaffected until they enable the pool.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -62,6 +62,7 @@ import { SessionMonitor } from '../monitoring/SessionMonitor.js';
 import { SessionRecovery } from '../monitoring/SessionRecovery.js';
 import { MultiMachineCoordinator } from '../core/MultiMachineCoordinator.js';
 import { MachineIdentityManager } from '../core/MachineIdentity.js';
+import { isRemotelyHandled } from '../core/SessionRouter.js';
 import { resolveAdvertisedMeshUrl, advertiseSelfMeshUrl } from '../core/MeshUrlAdvertiser.js';
 import { GitSyncManager } from '../core/GitSync.js';
 import { RegistrySyncDebouncer } from '../core/RegistrySyncDebouncer.js';
@@ -355,6 +356,10 @@ let _topicResumeMap: import('../core/TopicResumeMap.js').TopicResumeMap | null =
 // is byte-identical to today's always-local dispatch. Set once in startServer().
 let _sessionRouter: import('../core/SessionRouter.js').SessionRouter | null = null;
 let _sessionPoolStage: () => string = () => 'dark';
+/** This machine's mesh id — lets the inbound dispatch tell a REMOTE placement
+ *  (forward/spawn on another machine → must NOT also dispatch locally) from a
+ *  self placement. Set once in startServer()'s mesh block. */
+let _meshSelfId: string | null = null;
 /** Multi-Machine Session Pool §L4: per-topic placement pin store ("move this to <nickname>"). */
 let _topicPinStore: import('../core/TopicPlacementPinStore.js').TopicPlacementPinStore | null = null;
 /** Recognize + apply a "move/run this on <nickname>" relocation on inbound; returns handled=true when the message WAS a relocation command (so it must not also be dispatched). */
@@ -1352,11 +1357,20 @@ function wireTelegramRouting(
           payload: text,
           topicMetadata: _topicPinStore?.asTopicMetadata(String(topicId)),
         });
-        if (outcome.action === 'forwarded' || outcome.action === 'duplicate') {
+        // Routing-decision observability — the live transfer path is otherwise a black
+        // box (the recognizer logs its pin, but route()'s actual placement/forward
+        // decision was invisible; that hid the bug below from the first live test).
+        console.log(`[session-pool] route topic ${topicId} → action=${outcome.action} owner=${outcome.owner ?? '?'} self=${_meshSelfId ?? '?'}`);
+        // Short-circuit local dispatch whenever the session ended up on ANOTHER machine
+        // (forward/duplicate, OR a fresh remote 'spawned'/'owner-dead-replaced'). Before
+        // this, only 'forwarded'/'duplicate' were caught, so a just-moved topic was
+        // spawned on the target AND injected into the stale local session
+        // (double-dispatch — the bug the first live transfer test surfaced, 2026-05-31).
+        if (isRemotelyHandled(outcome, _meshSelfId)) {
           console.log(`[session-pool] topic ${topicId} handled by owner ${outcome.owner ?? '?'} (${outcome.action}) — not dispatching locally`);
           return;
         }
-        // 'handled-locally' / 'spawned'(self) / 'owner-dead-replaced' / 'queued' /
+        // 'handled-locally' / 'spawned'(self) / 'owner-dead-replaced'(self) / 'queued' /
         // 'placement-blocked' → fall through to the existing local dispatch below.
       } catch (err) {
         console.warn(`[session-pool] route error for topic ${topicId} — falling back to local dispatch: ${err instanceof Error ? err.message : String(err)}`);
@@ -9361,6 +9375,7 @@ export async function startServer(options: StartOptions): Promise<void> {
           });
           const peerUrl = (machineId: string): string | null =>
             meshIdMgr.getActiveMachines().find((m) => m.machineId === machineId)?.entry.lastKnownUrl ?? null;
+          _meshSelfId = meshSelfId;
           _sessionRouter = new routerMod.SessionRouter({
             selfMachineId: meshSelfId,
             placement: new placeMod.PlacementExecutor(),

--- a/src/core/SessionRouter.ts
+++ b/src/core/SessionRouter.ts
@@ -58,6 +58,31 @@ export interface RouteOutcome {
   acked: boolean;
 }
 
+/**
+ * Did this route() outcome place/forward the session onto ANOTHER machine — i.e.
+ * the inbound dispatch caller must NOT also handle it locally?
+ *
+ * `'forwarded'`/`'duplicate'` always mean delivered to a remote owner. A fresh
+ * placement on a remote machine returns `'spawned'` (self-placement returns
+ * `'handled-locally'`, never `'spawned'`), and owner-dead re-placement returns
+ * `'owner-dead-replaced'` for EITHER self or remote — so those two are remote only
+ * when the resolved owner is not us. Everything else ('handled-locally', a
+ * self 'owner-dead-replaced', 'queued', 'placement-blocked') is local/no-op and
+ * falls through to local dispatch.
+ *
+ * Pure + caller-agnostic so the inbound dispatch decision is unit-testable. Before
+ * this, the caller only treated 'forwarded'/'duplicate' as remote, so a just-moved
+ * topic was spawned on the target AND injected into the stale local session
+ * (double-dispatch — the bug the first live transfer test surfaced, 2026-05-31).
+ */
+export function isRemotelyHandled(outcome: RouteOutcome, selfMachineId: string | null): boolean {
+  if (outcome.action === 'forwarded' || outcome.action === 'duplicate') return true;
+  const remoteOwner = outcome.owner != null && outcome.owner !== selfMachineId;
+  if (outcome.action === 'spawned' && remoteOwner) return true;
+  if (outcome.action === 'owner-dead-replaced' && remoteOwner) return true;
+  return false;
+}
+
 export interface SessionRouterConfig {
   deliverMessageMaxRetries: number;
   deliverMessageRetryBackoffStartMs: number;

--- a/tests/unit/SessionRouter.test.ts
+++ b/tests/unit/SessionRouter.test.ts
@@ -6,7 +6,7 @@
  * in-order / one-in-flight serialization guarantee.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { SessionRouter, type SessionRouterDeps, type OwnershipView, type DeliverAck, type InboundMessage } from '../../src/core/SessionRouter.js';
+import { SessionRouter, isRemotelyHandled, type SessionRouterDeps, type OwnershipView, type DeliverAck, type InboundMessage, type RouteOutcome } from '../../src/core/SessionRouter.js';
 import { PlacementExecutor } from '../../src/core/PlacementExecutor.js';
 import type { MachineCapacity } from '../../src/core/types.js';
 
@@ -213,5 +213,42 @@ describe('SessionRouter.dispatch (§L4)', () => {
     const { router } = makeRouter({ resolveOwnership: () => ({ owner: SELF, epoch: 1, status: 'active' }), handleLocally });
     await Promise.all([router.route(msg({ sessionKey: 'a' })), router.route(msg({ sessionKey: 'b' }))]);
     expect(order.sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('isRemotelyHandled (inbound dispatch short-circuit — bug #8)', () => {
+  const oc = (action: RouteOutcome['action'], owner?: string | null): RouteOutcome => ({ action, owner, acked: true });
+
+  it('forwarded / duplicate are always remote (delivered to owner)', () => {
+    expect(isRemotelyHandled(oc('forwarded', 'm_other'), SELF)).toBe(true);
+    expect(isRemotelyHandled(oc('duplicate', 'm_other'), SELF)).toBe(true);
+    // owner-agnostic: forwarded means it went to whoever owns it
+    expect(isRemotelyHandled(oc('forwarded', null), SELF)).toBe(true);
+  });
+
+  it('spawned on a REMOTE machine short-circuits (the bug #8 case: was double-dispatched)', () => {
+    expect(isRemotelyHandled(oc('spawned', 'm_mini'), SELF)).toBe(true);
+  });
+
+  it('spawned on SELF does NOT short-circuit (handled locally below)', () => {
+    // (placeAndClaim actually returns 'handled-locally' for self, but defend the contract)
+    expect(isRemotelyHandled(oc('spawned', SELF), SELF)).toBe(false);
+  });
+
+  it('owner-dead-replaced short-circuits only when the new owner is remote', () => {
+    expect(isRemotelyHandled(oc('owner-dead-replaced', 'm_mini'), SELF)).toBe(true);
+    expect(isRemotelyHandled(oc('owner-dead-replaced', SELF), SELF)).toBe(false);
+  });
+
+  it('local / no-op outcomes fall through to local dispatch', () => {
+    expect(isRemotelyHandled(oc('handled-locally', SELF), SELF)).toBe(false);
+    expect(isRemotelyHandled(oc('queued'), SELF)).toBe(false);
+    expect(isRemotelyHandled(oc('placement-blocked'), SELF)).toBe(false);
+  });
+
+  it('a null selfMachineId treats any concrete owner as remote (fail-safe: do not double-dispatch)', () => {
+    expect(isRemotelyHandled(oc('spawned', 'm_mini'), null)).toBe(true);
+    // self unknown + owner unknown → not provably remote → fall through (local)
+    expect(isRemotelyHandled(oc('spawned', null), null)).toBe(false);
   });
 });

--- a/tests/unit/session-pool-activation-wiring.test.ts
+++ b/tests/unit/session-pool-activation-wiring.test.ts
@@ -25,12 +25,14 @@ describe('Session Pool activation wiring (§L4)', () => {
 
   it('the interception FAILS SAFE — any route error falls back to local dispatch', () => {
     const idx = src.indexOf("_sessionRouter && _sessionPoolStage() !== 'dark'");
-    const block = src.slice(idx, idx + 1200);
+    const block = src.slice(idx, idx + 2200);
     expect(block).toContain('try {');
     expect(block).toContain('await _sessionRouter.route(');
     expect(block).toContain('falling back to local dispatch');
     // Only a remote-handled outcome short-circuits; everything else falls through.
-    expect(block).toContain("outcome.action === 'forwarded' || outcome.action === 'duplicate'");
+    // (bug #8: remote 'spawned'/'owner-dead-replaced' must short-circuit too — the
+    // decision is the pure isRemotelyHandled() helper, unit-tested in SessionRouter.test.ts.)
+    expect(block).toContain('isRemotelyHandled(outcome, _meshSelfId)');
   });
 
   it('the SessionRouter is constructed with the real registry/ownership/placement + outbound mesh client', () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,59 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13481; multi-machine live-transfer cascade)
+---
+
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — moving a conversation between machines no longer double-handles it
+
+Part of bringing the multi-machine "move this conversation to my other machine"
+feature to life. When the feature is on and you move a conversation, an incoming
+message is routed by a dispatcher that decides whether to keep it on this machine or
+send it to the machine that now owns the conversation. The code reading that
+dispatcher's decision only recognized two of its "it went to the other machine"
+answers — it missed the answer the dispatcher gives when it freshly starts a moved
+conversation on the target machine. So a just-moved conversation was started on the
+target AND still answered on the original machine, which made the move look like it
+did nothing.
+
+This release teaches the reader the full set of "handled on another machine" answers
+via a small, well-tested helper, and adds a log line that records every routing
+decision so the live path is no longer a black box.
+
+## Summary of New Capabilities
+
+- New exported `isRemotelyHandled(outcome, selfMachineId)` in `SessionRouter` — the
+  pure, unit-tested rule for whether a routed message was handled on another machine
+  (forwarded/duplicate always; spawned/owner-dead-replaced only when the owner isn't
+  this machine). Fail-safe: an unknown self with an unknown owner falls through to
+  local handling, never dropping a message.
+- The inbound dispatcher uses it (instead of a forwarded/duplicate-only check), so a
+  freshly-placed remote session is no longer also dispatched locally.
+- A new per-message routing-decision log line for session-pool observability.
+
+## What to Tell Your User
+
+If you run your agent on more than one machine and move a conversation between them,
+the move now actually takes effect instead of the original machine continuing to
+answer alongside the new one. This is one step in a larger effort to make moving live
+conversations between your machines reliable. It only applies when the multi-machine
+session pool is turned on; single-machine agents are unaffected. Nothing to configure.
+
+## Evidence
+
+- Found live on 2026-05-31 running the real "move this to the Mac mini" test on a
+  throwaway topic: the move command was recognized and pinned to the mini, but the
+  next message was injected into the existing local session instead of forwarding —
+  because the dispatcher's "spawned on the target" answer was not treated as remote.
+- Unit, `tests/unit/SessionRouter.test.ts`: isRemotelyHandled across forwarded,
+  duplicate, remote vs self spawned, remote vs self owner-dead-replaced,
+  local/queued/blocked fall-through, and the null-self fail-safe.
+- Wiring, `tests/unit/session-pool-activation-wiring.test.ts`: the dispatcher uses
+  the helper and still falls back to local dispatch on any routing error.
+- 50 session-pool tests pass; tsc --noEmit clean.
+- Spec, `docs/specs/session-pool-route-shortcircuit.md` plus the .eli16.md sibling.
+- Side-effects, `upgrades/side-effects/session-pool-route-shortcircuit.md`.

--- a/upgrades/side-effects/session-pool-route-shortcircuit.md
+++ b/upgrades/side-effects/session-pool-route-shortcircuit.md
@@ -1,0 +1,98 @@
+# Side-Effects Review — Session-pool inbound dispatch short-circuit (bug #8)
+
+**Version / slug:** `session-pool-route-shortcircuit`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+Inbound Telegram dispatch (`src/commands/server.ts`) now short-circuits local
+dispatch whenever `SessionRouter.route()` placed/forwarded the session onto another
+machine — via a new pure helper `isRemotelyHandled(outcome, selfMachineId)` exported
+from `SessionRouter.ts`. Previously only `'forwarded'`/`'duplicate'` short-circuited,
+so a remote `'spawned'`/`'owner-dead-replaced'` fell through and double-dispatched
+(spawn on target + inject into the stale local session). Adds a module-level
+`_meshSelfId` and a one-line routing-decision log.
+
+## Decision-point inventory
+
+- **isRemotelyHandled** — the sole decision: forwarded|duplicate → remote;
+  spawned|owner-dead-replaced → remote only when owner!==self; everything else →
+  local. Both sides + the null-self boundary unit-tested.
+- **call site** — `if (isRemotelyHandled(outcome, _meshSelfId)) return;` else fall
+  through to existing local dispatch (unchanged).
+
+## 1. Over-block
+
+**What legitimate inputs does this reject?** None are dropped. A remote outcome now
+returns early (correct — the message was already handled on the owner machine). A
+self/local/queued/blocked outcome still falls through to local dispatch exactly as
+before. The change only ADDS two remote actions to the early-return set.
+
+## 2. Under-block
+
+**What does this still miss?** It does not address bug #7 (a moved session on a
+tokenless standby cannot send Telegram replies). It does not change WHICH machine
+`route()`/`PlacementExecutor` chooses — if the pin isn't honored or ownership isn't
+released, `route()` returns a LOCAL outcome and this still (correctly) handles
+locally; the new route-decision log is what will pinpoint that on the next live run.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The decision is a pure function beside the `RouteOutcome` type
+it interprets (testable, reusable). The call site is the single inbound chokepoint
+that already consulted the router. `_meshSelfId` mirrors the existing
+`_sessionRouter`/`_sessionPoolStage` module-capture pattern.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No new blocking authority. The helper only decides local-vs-already-handled-remotely
+for dispatch; it gates nothing user-facing and blocks no message (a not-provably-
+remote outcome falls through to local — fail-safe toward handling, never dropping).
+
+## 5. Interactions
+
+Consumes `SessionRouter.route()`'s existing `RouteOutcome`; no router behavior
+change. Pairs with the `_tryNicknameRelocation` recognizer (which sets the pin +
+releases ownership) — this fix makes the SUBSEQUENT routed message's remote
+placement actually short-circuit the stale local session. Gated past `'dark'`, so
+inert on single-machine / pool-disabled agents. Idempotent (pure decision per
+message).
+
+## 6. External surfaces
+
+No HTTP routes, config, or notifications. One new server-log line per routed inbound
+(`[session-pool] route topic N → action=… owner=… self=…`) — log-only observability.
+
+## 7. Rollback cost
+
+Low. Revert restores the `'forwarded'||'duplicate'`-only check (re-introducing the
+double-dispatch on remote placement) and drops the helper + log. No schema, no
+persisted state, no migration.
+
+## Conclusion
+
+Minimal, additive interpretation fix with a pure unit-tested decision, no new
+authority, log-only external surface, cheap revert. Closes the double-dispatch half
+of bug #8 and adds the observability to pinpoint the remainder of the live-transfer
+cascade.
+
+## Second-pass review (if required)
+
+Not required — pure decision helper, both branches + fail-safe tested, no destructive
+op, reversible, pool-gated. Live two-machine re-test is the Tier-3 gate that follows.
+
+## Evidence pointers
+
+- `tests/unit/SessionRouter.test.ts` — `isRemotelyHandled` over all RouteActions +
+  self/remote/null-self boundaries.
+- `tests/unit/session-pool-activation-wiring.test.ts` — call site uses the helper +
+  still fails safe to local dispatch.
+- 50 session-pool tests green; `tsc --noEmit` clean.
+- Found live 2026-05-31 on throwaway topic 8882: recognizer pinned to mini, but the
+  follow-up injected into the local laptop session (`Injecting into
+  echo-standby-mode-edits`) — no forward.
+- Spec: `docs/specs/session-pool-route-shortcircuit.md` (+ `.eli16.md`).


### PR DESCRIPTION
## Bug #8 of the live-transfer cascade — found running the live Telegram test

Running the full "move this to the Mac mini" transfer live (Justin authorized
autonomous live testing): the recognizer fired and pinned the topic to the mini, but
the follow-up message was **injected into the existing LOCAL laptop session** rather
than forwarding to the mini (`[telegram→session] Injecting into echo-standby-mode-edits`).

**Root cause:** the inbound dispatch call site (`src/commands/server.ts`) only
short-circuited local dispatch on `route()` outcomes `'forwarded'`/`'duplicate'`. But
`SessionRouter.placeAndClaim` returns `'spawned'` when it places + claims a session on
a **remote** machine (self-placement returns `'handled-locally'`, never `'spawned'`),
and `'owner-dead-replaced'` for either. A remote `'spawned'`/`'owner-dead-replaced'`
fell through → the message was spawned on the target AND injected into the stale local
session (double-dispatch), so a just-moved topic kept being served on the origin.

## Fix
- New pure `isRemotelyHandled(outcome, selfMachineId)` in `SessionRouter.ts` (forwarded/duplicate always remote; spawned/owner-dead-replaced remote only when owner≠self; fail-safe to local on unknown self).
- Call site uses it (+ a new `_meshSelfId` module capture) instead of the forwarded/duplicate-only check.
- New per-message routing-decision log — the live path was a black box past the recognizer's pin line, which hid this; now `[session-pool] route topic N → action=… owner=… self=…`.
- No change to `route()`/`PlacementExecutor` decision logic; pool-gated past `'dark'`.

## Tests
- `tests/unit/SessionRouter.test.ts` — `isRemotelyHandled` over every RouteAction + self/remote/null-self boundaries.
- `tests/unit/session-pool-activation-wiring.test.ts` — call site uses the helper + still fails safe to local dispatch.
- 50 session-pool tests green; `tsc --noEmit` clean.

## Scope
Closes the double-dispatch half of bug #8 + adds the observability to pinpoint the rest of the cascade on the next live run. **Bug #7** (a moved session on a tokenless standby cannot send Telegram replies → mute) is separate and still open.

## Ship-gate
Spec `docs/specs/session-pool-route-shortcircuit.md` (+ `.eli16.md`), self-approved under the standing 12h deploy mandate (topic 13481) — flagged here per cross-agent discipline. Side-effects + NEXT.md included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
