### PR TITLE
fix(multi-machine): standby may persist its pool-owned sessions (bug #9)

### DIFF
--- a/docs/specs/standby-pool-session-writes.eli16.md
+++ b/docs/specs/standby-pool-session-writes.eli16.md
@@ -1,0 +1,49 @@
+# Standby may persist its own sessions — explain it like I'm 16
+
+Two computers act as one assistant: a main one (the laptop) and a backup (the Mac
+mini). To keep them from corrupting each other's shared notes, the backup runs in
+"read-only" mode — it can READ the shared state but is forbidden from WRITING any of
+it. That's a safety rule: if both machines wrote to the same shared notebook, you'd
+get two conflicting versions ("a fork"), which is a mess.
+
+Now we're adding a new ability: you can MOVE a single conversation from the laptop to
+the mini, and the mini takes it over. We got that working far enough that the mini
+RECEIVES the moved conversation and tries to start it up. But then it hit a wall:
+starting a conversation means writing down "I now own this conversation, here's its
+state" — and the mini is read-only, so that write got blocked:
+
+  "StateManager is read-only (this machine is on standby). Blocked: saveSession"
+
+So the read-only safety rule, which is correct for shared notes, was ALSO blocking
+the mini from saving the one conversation it legitimately now owns. Two goals
+collided: "backup can't touch shared state" vs "backup needs to run conversations
+handed to it."
+
+The fix splits writes into two kinds:
+- SHARED writes (the cluster-wide notebook: who's in charge, jobs, the key-value
+  store, the event log). The backup STILL can't touch these — the safety rule holds.
+- PER-CONVERSATION writes (one conversation's own little file). The backup CAN make
+  these — but only when the conversation-moving feature is turned on.
+
+Why is the per-conversation write safe even on a read-only backup? Because the system
+already guarantees that only ONE machine owns a given conversation at a time (it uses
+a claim-and-confirm step). So when the mini saves "conversation 8882's state," no
+other machine is also writing that same file — there's nothing to fork. And the only
+way the mini even tries this is through the move feature, which only runs when that
+feature is switched on. So the safe write is gated three ways: it must be a
+single-conversation file, the move feature must be on, and the conversation must have
+been formally handed to this machine.
+
+In code it's tiny: the backup gets a flag "the conversation-pool is active," and the
+two per-conversation save/remove operations are marked "this is a single-conversation
+write." The guard then says: if I'm read-only, block it — UNLESS it's a
+single-conversation write and the pool is active. Everything else a backup might try
+to write stays blocked exactly as before, and a backup with no pool turned on behaves
+identically to today (fully read-only). I added tests for every combination: the
+backup allows a session save when the pool is on, still refuses shared writes, still
+refuses session saves when the pool is off, and a normal machine writes everything.
+
+This is one more rung of the ladder. With it, a moved conversation can actually be
+recorded on the mini. The last remaining rung is letting the mini send its replies
+back to you (right now the backup has no way to message Telegram) — that's a separate
+fix I'm tracking next.

--- a/docs/specs/standby-pool-session-writes.md
+++ b/docs/specs/standby-pool-session-writes.md
@@ -1,0 +1,89 @@
+---
+title: Standby may persist its pool-owned sessions (read-only guard scoped to shared state)
+slug: standby-pool-session-writes
+status: approved
+review-convergence: 2026-05-31T11:15:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h deploy mandate (topic 13481).
+  Bug #9 of the multi-machine live-transfer cascade, found running the full live
+  "move this to the Mac mini" Telegram test (Justin authorized autonomous live
+  testing — feedback_live_transfer_test_autonomous_authorized). Touches the
+  standby read-only split-brain guard; scoped narrowly. Flagged in the PR per
+  cross-agent discipline.
+---
+
+# Standby may persist its pool-owned sessions
+
+## Problem
+
+Found live (2026-05-31): with bug #8 fixed, "move this to the Mac mini" now
+forwards correctly — the mini RECEIVES the session and begins spawning it. But the
+owner-side resume aborts:
+
+```
+[session-pool] owner-side resume failed for topic 8882:
+  StateManager is read-only (this machine is on standby). Blocked: saveSession
+```
+
+Root: `MultiMachineCoordinator` sets `state.setReadOnly(!holdsLease)` — the
+non-lease-holder (the mini) is read-only, so `StateManager.guardWrite` throws on
+ALL writes, including `saveSession`. That read-only guard exists to stop a standby
+from forking SHARED cluster state (lease, kv, jobs, events). But the active-active
+session pool legitimately hands the standby sessions to OWN and serve — and serving
+requires persisting their per-session state. The two models collide: one-awake
+read-only-standby vs active-active pool standby-owns-sessions.
+
+## Goal
+
+A standby that participates in the session pool can persist the PER-SESSION state of
+sessions it owns (so a moved session actually starts there), WITHOUT weakening the
+guard that prevents a standby from forking shared cluster state. A pure one-awake
+standby (no pool) stays fully read-only — unchanged.
+
+## Non-goals
+
+- Does NOT fix bug #7 (the standby has no Telegram token, so the spawned session
+  still can't reply — tracked separately).
+- Does NOT let a standby write shared cluster state (`set`/`delete`/`saveJobState`/
+  `appendEvent`) — those stay blocked.
+- Does NOT remove or weaken the read-only guard for non-pool agents.
+
+## Design
+
+1. **`StateManager` gains `_sessionPoolActive` + `setSessionPoolActive(active)`** and
+   a `sessionScoped` option on the private `guardWrite`:
+   - `guardWrite(op)` (shared write) → throws when read-only, as before.
+   - `guardWrite(op, { sessionScoped: true })` → permitted when read-only ONLY if
+     `_sessionPoolActive` is true; otherwise throws.
+   Why it's safe: a `sessionScoped` write targets one session's own file
+   (`state/sessions/<id>.json`). The session pool's CAS ownership guarantees a single
+   owner per session, so an owned-session file write cannot fork shared state. And the
+   only code path that calls `saveSession` on a standby is the pool's owner-side resume
+   — which itself fires only past the `'dark'` rollout stage and only for a
+   CAS-confirmed owned session.
+
+2. **`saveSession` / `removeSession` pass `{ sessionScoped: true }`** (per-session
+   lifecycle). All other guarded writes are untouched (shared → still blocked).
+
+3. **`server.ts` calls `state.setSessionPoolActive(true)`** where the SessionRouter is
+   wired (this machine is a pool participant). Default stays false → pure one-awake
+   agents are byte-identical to today.
+
+## Testing
+
+- Tier 1 (`state-manager-readonly.test.ts`): read-only + pool-active ALLOWS
+  saveSession/removeSession (and the file persists); STILL BLOCKS set/delete/
+  saveJobState/appendEvent; read-only + pool-INACTIVE blocks saveSession (one-awake
+  unchanged); pool-active without read-only leaves all writes working. Existing
+  read-only block tests stay green (default pool-inactive).
+- 104 StateManager-family + coordinator + wiring tests green; `tsc --noEmit` clean.
+- Tier-3: the next live re-test confirms the mini's owner-side resume now persists +
+  the session serves (the remaining mute is bug #7).
+
+## Migration parity
+
+Pure code (one flag + a guard option + a wiring call). No config/hook/route/CLAUDE.md
+change. Default `false` → existing standbys remain fully read-only until the session
+pool is enabled. Existing agents get it on the v-next update.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9376,6 +9376,12 @@ export async function startServer(options: StartOptions): Promise<void> {
           const peerUrl = (machineId: string): string | null =>
             meshIdMgr.getActiveMachines().find((m) => m.machineId === machineId)?.entry.lastKnownUrl ?? null;
           _meshSelfId = meshSelfId;
+          // This machine participates in the session pool, so a read-only standby may
+          // persist the PER-SESSION state of sessions it's handed (the pool's owner-side
+          // resume only fires for CAS-confirmed owned sessions, and only past 'dark').
+          // Shared-cluster writes stay blocked on a standby. (bug #9: the moved session's
+          // saveSession was blocked by the standby read-only guard.)
+          state.setSessionPoolActive(true);
           _sessionRouter = new routerMod.SessionRouter({
             selfMachineId: meshSelfId,
             placement: new placeMod.PlacementExecutor(),

--- a/src/core/StateManager.ts
+++ b/src/core/StateManager.ts
@@ -52,6 +52,7 @@ function describeReadError(err: unknown, filePath: string): {
 export class StateManager {
   private stateDir: string;
   private _readOnly: boolean = false;
+  private _sessionPoolActive: boolean = false;
   private _machineId: string | null = null;
 
   constructor(stateDir: string) {
@@ -85,11 +86,30 @@ export class StateManager {
     this._readOnly = readOnly;
   }
 
-  /** Guard that throws if in read-only mode. */
-  private guardWrite(operation: string): void {
-    if (this._readOnly) {
-      throw new Error(`StateManager is read-only (this machine is on standby). Blocked: ${operation}`);
-    }
+  /**
+   * Whether the active-active session pool is enabled for this machine. When true, a
+   * read-only standby is still permitted to write the PER-SESSION state of sessions it
+   * legitimately OWNS (the pool's CAS ownership guarantees a single owner per session,
+   * so a per-session file write can't fork shared cluster state). Shared-cluster writes
+   * (set/delete/saveJobState/appendEvent) stay blocked on a standby regardless.
+   * Default false → a pure one-awake standby remains fully read-only (unchanged).
+   */
+  setSessionPoolActive(active: boolean): void {
+    this._sessionPoolActive = active;
+  }
+
+  /**
+   * Guard that throws in read-only mode. `sessionScoped` marks a write that targets a
+   * single owned session's own file (state/sessions/<id>.json) — permitted on a
+   * read-only standby ONLY when the session pool is active (bug #9: a moved session's
+   * owner-side resume must persist on the standby that now owns it; the pool path that
+   * triggers it only fires for CAS-confirmed owned sessions). Shared-state writes pass
+   * no opts and stay blocked.
+   */
+  private guardWrite(operation: string, opts?: { sessionScoped?: boolean }): void {
+    if (!this._readOnly) return;
+    if (opts?.sessionScoped && this._sessionPoolActive) return;
+    throw new Error(`StateManager is read-only (this machine is on standby). Blocked: ${operation}`);
   }
 
   /** Validate a key/ID contains only safe characters to prevent path traversal. */
@@ -122,7 +142,7 @@ export class StateManager {
   }
 
   saveSession(session: Session): void {
-    this.guardWrite('saveSession');
+    this.guardWrite('saveSession', { sessionScoped: true });
     this.validateKey(session.id, 'sessionId');
     const filePath = path.join(this.stateDir, 'state', 'sessions', `${session.id}.json`);
     this.atomicWrite(filePath, JSON.stringify(session, null, 2));
@@ -158,7 +178,7 @@ export class StateManager {
   }
 
   removeSession(sessionId: string): boolean {
-    this.guardWrite('removeSession');
+    this.guardWrite('removeSession', { sessionScoped: true });
     this.validateKey(sessionId, 'sessionId');
     const filePath = path.join(this.stateDir, 'state', 'sessions', `${sessionId}.json`);
     if (!fs.existsSync(filePath)) return false;

--- a/tests/unit/state-manager-readonly.test.ts
+++ b/tests/unit/state-manager-readonly.test.ts
@@ -148,3 +148,48 @@ describe('StateManager read-only mode', () => {
     });
   });
 });
+
+describe('StateManager read-only + session pool active (bug #9)', () => {
+  let tmpDir: string;
+  let state: StateManager;
+  const sess = (id: string) => ({ id, status: 'running', createdAt: new Date(0).toISOString(), updatedAt: new Date(0).toISOString() } as any);
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+    state = new StateManager(tmpDir);
+    state.setReadOnly(true);          // standby
+    state.setSessionPoolActive(true); // but participates in the active-active pool
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('ALLOWS saveSession for an owned session (per-session write, pool CAS = single owner)', () => {
+    expect(() => state.saveSession(sess('moved-1'))).not.toThrow();
+    expect(state.getSession('moved-1')).toMatchObject({ id: 'moved-1' });
+  });
+
+  it('ALLOWS removeSession (per-session lifecycle)', () => {
+    state.saveSession(sess('moved-2'));
+    expect(() => state.removeSession('moved-2')).not.toThrow();
+    expect(state.getSession('moved-2')).toBeNull();
+  });
+
+  it('STILL BLOCKS shared-cluster writes on a standby (no state fork)', () => {
+    expect(() => state.set('shared-key', { x: 1 })).toThrow('read-only');
+    expect(() => state.delete('shared-key')).toThrow('read-only');
+    expect(() => state.saveJobState({ slug: 'j', lastRun: new Date(0).toISOString() } as any)).toThrow('read-only');
+    expect(() => state.appendEvent({ type: 't', timestamp: new Date(0).toISOString() } as any)).toThrow('read-only');
+  });
+
+  it('a read-only standby with the pool INACTIVE blocks saveSession too (pure one-awake unchanged)', () => {
+    const s2 = new StateManager(createTempDir());
+    s2.setReadOnly(true); // pool NOT active (default)
+    expect(() => s2.saveSession(sess('x'))).toThrow('read-only');
+  });
+
+  it('pool-active alone (not read-only) leaves all writes working', () => {
+    const s3 = new StateManager(createTempDir());
+    s3.setSessionPoolActive(true);
+    expect(() => s3.set('k', 'v')).not.toThrow();
+    expect(() => s3.saveSession(sess('y'))).not.toThrow();
+  });
+});

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,54 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13481; multi-machine live-transfer cascade)
+---
+
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — a backup machine can now keep a conversation that was moved to it
+
+Another step in making the multi-machine "move this conversation to my other machine"
+feature work. To stay safe, a backup machine runs in read-only mode so it can never
+fork the shared cluster state. But when you move a single conversation to that
+machine, it has to record that it now owns and is running that conversation — and the
+read-only rule was blocking that save, so the moved conversation never started.
+
+This release splits writes into two kinds. Shared cluster state stays fully blocked on
+a backup, exactly as before. But a single conversation's own state — for a
+conversation the machine legitimately owns through the pool — is now allowed when the
+conversation-pool feature is on. That is safe because the system already guarantees a
+single owner per conversation, so there is nothing for that write to conflict with.
+
+## Summary of New Capabilities
+
+- `StateManager.setSessionPoolActive(active)` + a `sessionScoped` write option: a
+  read-only standby permits per-session writes (`saveSession`/`removeSession`) only
+  when the session pool is active; shared writes (`set`/`delete`/`saveJobState`/
+  `appendEvent`) stay blocked.
+- The server marks a pool-participant machine session-pool-active where it wires the
+  session router; a non-pool agent stays fully read-only (default off).
+
+## What to Tell Your User
+
+If you run your agent across more than one machine and move a conversation to another
+one, that machine can now actually record and run the moved conversation instead of
+refusing to save it. Your backup machine still can't touch shared cluster state, so
+the safety against split state is unchanged. This only matters when the multi-machine
+session pool is turned on; single-machine agents are unaffected. Nothing to configure.
+
+## Evidence
+
+- Found live on 2026-05-31: after the previous release made the move forward
+  correctly, the mini received the conversation and tried to start it but logged
+  "StateManager is read-only (this machine is on standby). Blocked: saveSession", so
+  the owner-side resume aborted.
+- Unit, `tests/unit/state-manager-readonly.test.ts`: a read-only standby with the
+  pool active allows saveSession/removeSession and the file persists; still blocks
+  set/delete/saveJobState/appendEvent; with the pool inactive it blocks saveSession
+  too (one-awake unchanged); a normal machine writes everything.
+- 104 StateManager-family + coordinator + wiring tests pass; tsc --noEmit clean.
+- Spec, `docs/specs/standby-pool-session-writes.md` plus the .eli16.md sibling.
+- Side-effects, `upgrades/side-effects/standby-pool-session-writes.md`.

--- a/upgrades/side-effects/standby-pool-session-writes.md
+++ b/upgrades/side-effects/standby-pool-session-writes.md
@@ -1,0 +1,100 @@
+# Side-Effects Review — Standby persists pool-owned sessions (bug #9)
+
+**Version / slug:** `standby-pool-session-writes`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`StateManager` gains a `_sessionPoolActive` flag (`setSessionPoolActive`) and a
+`sessionScoped` option on the private `guardWrite`. A read-only standby now permits
+`saveSession`/`removeSession` (per-session file writes) ONLY when the session pool is
+active; all shared-cluster writes (`set`/`delete`/`saveJobState`/`appendEvent`) stay
+blocked. `server.ts` sets `setSessionPoolActive(true)` where the SessionRouter is
+wired. Closes bug #9 (the standby's owner-side resume was blocked at `saveSession`).
+
+## Decision-point inventory
+
+- **guardWrite** — read-only? no → allow. read-only + sessionScoped + poolActive →
+  allow. else → throw. All three paths unit-tested.
+- **saveSession / removeSession** — tagged `sessionScoped: true`. All other guarded
+  writes unchanged (no opts → shared → blocked when read-only).
+- **server wiring** — `setSessionPoolActive(true)` only in the SessionRouter-wired
+  (pool-participant) block; default false elsewhere.
+
+## 1. Over-block
+
+**What legitimate inputs does this reject?** Nothing new is rejected. It RELAXES one
+case: a read-only standby may now persist per-session state when the pool is on.
+Shared writes are still rejected on a standby exactly as before. A non-pool agent is
+unchanged (flag defaults false).
+
+## 2. Under-block
+
+**What does this still miss?** It does not address bug #7 (the standby has no
+Telegram token → a moved session is mute). It scopes the exception to `saveSession`/
+`removeSession`; if the owner-side resume later needs another per-session write, that
+write would need the same tag (the next live re-test will surface it — same cascade
+method). It does not add a pool-ownership re-check inside StateManager (the upstream
+owner-side-resume path already gates on stage!=dark + CAS ownership; StateManager
+trusts that, scoped to per-session files which cannot fork shared state).
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The guard lives in `StateManager.guardWrite` (the single write
+chokepoint). The per-session vs shared distinction is expressed at each write's call
+site via one boolean. The pool-participant signal is set once where the pool is
+wired. No duplicated policy.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+This IS a safety-authority guard (read-only standby prevents state forks). The change
+NARROWS the guard's scope for a provably-safe case (per-session owned files under
+single-owner CAS), never widening it for shared state. It blocks nothing new and
+adds no user-facing gate.
+
+## 5. Interactions
+
+The read-only flag is toggled dynamically by `MultiMachineCoordinator`
+(`setReadOnly(!holdsLease)`); `_sessionPoolActive` is orthogonal (set once at pool
+wiring). Together: a non-holder standby with the pool on may write owned sessions but
+not shared state. The owner-side resume (`server.ts` onAccepted) is the consumer —
+its `saveSession` now succeeds on the standby. Idempotent. No interaction with the
+lease/registry shared-state path (still guarded).
+
+## 6. External surfaces
+
+None. No HTTP routes, config, or notifications. The visible effect is the absence of
+the `owner-side resume failed … Blocked: saveSession` warning on a pool standby.
+
+## 7. Rollback cost
+
+Low. Revert restores the unconditional read-only block on saveSession (re-introducing
+bug #9). No schema, no persisted state, no migration. The `_sessionPoolActive` flag is
+in-memory only.
+
+## Conclusion
+
+Minimal, scoped relaxation of a safety guard for a provably-fork-safe case
+(per-session owned writes under single-owner CAS), both sides + the one-awake-default
+unit-tested, no shared-state exposure, no external surface, cheap revert. Lets a moved
+session actually persist on the machine that now owns it.
+
+## Second-pass review (if required)
+
+Not required — narrowly-scoped guard relaxation, every decision branch + the
+one-awake default tested, no shared-state write enabled, reversible, pool-gated. The
+live two-machine re-test is the Tier-3 gate that follows.
+
+## Evidence pointers
+
+- `tests/unit/state-manager-readonly.test.ts` — read-only+pool-active allows
+  saveSession/removeSession + persists; still blocks shared writes; read-only+pool-
+  inactive blocks saveSession; normal machine writes all. Existing block tests green.
+- 104 StateManager-family + coordinator + wiring tests green; `tsc --noEmit` clean.
+- Found live on the mini: `owner-side resume failed for topic 8882: StateManager is
+  read-only (this machine is on standby). Blocked: saveSession`.
+- Spec: `docs/specs/standby-pool-session-writes.md` (+ `.eli16.md`).


### PR DESCRIPTION
## Bug #9 of the live-transfer cascade — found running the live Telegram test

With bug #8 fixed (PR #615), "move this to the Mac mini" now forwards correctly and
the mini RECEIVES the session and begins spawning it. But the owner-side resume aborts:

```
[session-pool] owner-side resume failed for topic 8882:
  StateManager is read-only (this machine is on standby). Blocked: saveSession
```

**Root:** `MultiMachineCoordinator` sets `state.setReadOnly(!holdsLease)` — the
non-lease-holder (mini) is read-only, so `guardWrite` throws on ALL writes. That guard
prevents a standby from forking SHARED cluster state — but the active-active pool
legitimately hands the standby sessions to own and serve, which requires persisting
their per-session state. One-awake-read-only vs active-active-pool collide.

## Fix (scoped — touches the split-brain safety guard)
- `StateManager` gains `_sessionPoolActive` (`setSessionPoolActive`) + a `sessionScoped` option on `guardWrite`. A read-only standby permits `saveSession`/`removeSession` (per-session file writes) ONLY when the pool is active; shared writes (`set`/`delete`/`saveJobState`/`appendEvent`) stay blocked.
- Safe because: a `sessionScoped` write targets one session's own file, and the pool's CAS ownership guarantees a single owner per session (no fork). The only path that calls `saveSession` on a standby is the pool owner-side resume, gated on stage≠dark + CAS ownership.
- `server.ts` sets `setSessionPoolActive(true)` where the SessionRouter is wired. Default off → pure one-awake standbys are byte-identical to today.

## Tests
- `tests/unit/state-manager-readonly.test.ts`: read-only+pool-active ALLOWS saveSession/removeSession (+ persists); STILL BLOCKS set/delete/saveJobState/appendEvent; read-only+pool-inactive blocks saveSession (one-awake unchanged); normal machine writes all. Existing read-only block tests stay green.
- 104 StateManager-family + coordinator + wiring tests green; `tsc --noEmit` clean.

## Scope
Lets a moved session persist on the machine that now owns it. **Bug #7** (the standby has no Telegram token → the spawned session is mute) is separate and still open.

## Ship-gate
Spec `docs/specs/standby-pool-session-writes.md` (+ `.eli16.md`), self-approved under the standing 12h deploy mandate (topic 13481) — flagged here per cross-agent discipline. Side-effects + NEXT.md included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
