### PR TITLE
fix(threadline): accept-boundary on /threadline/messages/receive (relay-funnel duplicate-reply root, #3)

### DIFF
--- a/docs/specs/relay-funnel-accept-boundary.eli16.md
+++ b/docs/specs/relay-funnel-accept-boundary.eli16.md
@@ -1,0 +1,41 @@
+# Relay-funnel accept-boundary — explained simply
+
+## The everyday version
+
+Imagine you text a friend "can you grab milk?" Your phone waits for them to actually go to the
+store, buy the milk, and come back before it shows your text as "delivered." That's absurd — and if
+your phone gives up waiting after 10 seconds and re-sends the text, your friend ends up with two
+identical requests and buys milk twice.
+
+That's almost exactly what was happening between two agents on different machines. When agent A
+sends a message to agent B, B has to spin up a whole work session to handle it — which takes 9 to 30
+seconds. But A only waits about 10 seconds for B to say "got it." So A would give up, assume the
+message failed, and send it again with a fresh ID. B, not recognizing the resend as a duplicate
+(different ID), would spin up a SECOND session and reply twice. The user saw the agent answer the
+same thing twice.
+
+## What we changed
+
+B now says "got it" the instant the message arrives and is verified — *before* doing the slow work.
+Then it does the work in the background. So A never gives up, never re-sends, and B never replies
+twice. The actual reply still comes back through a separate channel, so nothing is lost by replying
+"got it" early.
+
+## Why it's safe
+
+We checked exactly who sends to this door: both senders only look at whether the response says "ok,"
+and they give up after ~10 seconds. Since the old code couldn't even produce its answer until 9-30
+seconds in, those senders never actually saw the detailed error response the old code returned —
+they'd already given up. So switching to "say ok immediately" breaks nothing: no sender was relying
+on the slow detailed answer.
+
+This is the exact same fix we already shipped and proved for agents on the *same* machine (it worked
+there). This change applies it to agents on *different* machines, which was deliberately left for a
+follow-up. We didn't need to add any duplicate-catching net either, because removing the re-send
+removes the cause. The one thing to know: if the background work genuinely fails (not just runs
+slow), it gets logged instead of automatically retried — a rare case, and the same trade the
+same-machine fix made.
+
+We proved it with a test that holds the slow work open and checks the "got it" response comes back
+first, then lets the work finish — plus a test that a background crash still leaves the sender with a
+clean "ok."

--- a/docs/specs/relay-funnel-accept-boundary.md
+++ b/docs/specs/relay-funnel-accept-boundary.md
@@ -1,0 +1,94 @@
+---
+title: Respond at the accept boundary on /threadline/messages/receive (relay-funnel duplicate-reply root fix)
+slug: relay-funnel-accept-boundary
+date: 2026-05-31
+author: echo
+status: approved
+review-convergence: internal-plus-adversarial-self-review-2026-05-31
+approved: true
+approved-by: Justin (Telegram topic 13435, 2026-05-31 08:46Z — "Yes, please proceed. I'll go with your recommendations for all of these")
+approval-note: >
+  Justin greenlit this from the approved-priorities list (#3 duplicate-reply accept-boundary root
+  fix). This completes the issue-580 follow-up that #581 (the co-located accept-boundary) explicitly
+  deferred: applying the same proven accept-boundary to the relay-FUNNEL path. Grounded by reading
+  the funnel's senders and confirming they read only response.ok within a timeout shorter than the
+  spawn — so the 422-retryable path the prior spec worried about is already unreachable.
+second-pass-required: false
+second-pass-status: n/a-mirrors-proven-581-pattern-caller-contract-verified
+eli16-overview: relay-funnel-accept-boundary.eli16.md
+---
+
+# Relay-funnel accept-boundary (duplicate-reply ROOT fix, part 2)
+
+## Background — the deferred half of the duplicate-reply root
+
+The duplicate-reply root has two ingress paths. #581 fixed the **co-located** path
+(`/messages/relay-agent`) and explicitly deferred the **relay-funnel** path
+(`POST /threadline/messages/receive`, `ThreadlineEndpoints.ts`) to issue-580, noting it "has the
+same blocking shape but DIFFERENT error semantics (a 422-retryable response on `result.error`) that
+an accept-boundary conversion must redesign." This spec is that redesign.
+
+The funnel handler `await`ed `threadlineRouter.handleInboundMessage(envelope)` — a session
+spawn/resume that routinely takes 9-30s — before responding. But the funnel's senders
+(`MessageRouter` cross-machine relay at `MessageRouter.ts:747` and `AgentBus.httpSend` at
+`AgentBus.ts:506`) both read **only `response.ok`** within a **~10s timeout** and fall back to a
+durable queue on failure. So whenever the spawn outran ~10s, the sender aborted, treated delivery
+as failed, and retried — and a retry arrived with a FRESH nonce/id that slipped past the nonce +
+id dedup, causing a second spawn → a DUPLICATE reply.
+
+## The 422-retryable "redesign" turns out to be a non-issue
+
+The error-semantics concern #581 flagged is moot in practice: the senders never **see** the
+422. They read only `response.ok` and abort at ~10s — long before the 9-30s spawn produces the
+`result.error` → 422. So the 422-retryable path is already unreachable by every real sender; no
+caller's correctness depends on the synchronous spawn outcome. (The actual reply flows back via the
+decoupled reply-waiter, not this HTTP response — identical to the co-located path.)
+
+## Fix
+
+Respond at the ACCEPT BOUNDARY, mirroring #581. The message is accepted + authenticated +
+validated by the time we reach the router call, so we respond
+`{ accepted: true, async: true, threadId }` immediately and run `handleInboundMessage(envelope)` in
+the background (`void` + `.then`/`.catch` logging). The handler is NOT dropped; its outcome is
+logged; a background rejection can't 500 a response that already returned.
+
+Only the spawn timing changes. Auth, payload validation, and the `!threadlineRouter` 503 guard are
+unchanged and still synchronous (all before the response).
+
+## Scope decision — accept-boundary only, no new dedup
+
+The accept-boundary removes the **cause** (sender timeout → retry). The content-hash dedup that
+#573 added to the co-located path was the SYMPTOM backstop for when the root wasn't fixed; with the
+root fixed here, the funnel's retry-source is gone, and the router's existing `pendingSpawns` guard
+already blocks concurrent same-thread spawns. So a funnel content-dedup is not needed for the
+reported bug and is left out to keep the change minimal. (A shared cross-path content-dedup remains
+a possible future hardening, noted as a follow-up — not required here.)
+
+## Residual (documented, matches #581 precedent)
+
+A *genuine* background spawn failure (not a timeout) is now logged rather than surfaced as a
+422-retryable response, so it is not redelivered. This is the same trade #581 made for the
+co-located path: it is rare, logged, and the reply path is decoupled. Adding durable
+requeue-on-genuine-failure for cross-machine is a separate robustness item, not this fix.
+
+## Migration parity
+
+N/A — code-only (`ThreadlineEndpoints.ts`, compiled into `dist`); ships in the normal release. No
+agent-installed file, config, or CLAUDE.md template change → no `PostUpdateMigrator` pass.
+
+## Agent Awareness
+
+N/A — internal relay-ingress timing. No new API endpoint, trigger, registry lookup, or building
+block to surface.
+
+## Test plan
+
+The behavior is HTTP-route-level (response shape + timing), so the right tier is an integration
+test of the route with a held handler (mirrors #581's `threadline-relay-agent-result.test.ts`):
+- `ThreadlineEndpoints.test.ts` (extended): with a valid cryptographically-signed receive (real
+  handshake + Ed25519 signature) and a mock router whose `handleInboundMessage` is held open, the
+  response is `{ accepted: true, async: true, threadId }` WITHOUT spawn fields and returns BEFORE
+  the held handler finishes (handler started, not finished — proving we did not await); the handler
+  still completes in the background; a background **rejection** still yields 200 accepted.
+- Regression: the full threadline suite (ThreadlineRouter, ThreadlineIntegration, the keystone
+  gate-before-spawn wiring test) stays green; the funnel's auth tests are unchanged.

--- a/src/threadline/ThreadlineEndpoints.ts
+++ b/src/threadline/ThreadlineEndpoints.ts
@@ -410,24 +410,34 @@ export function createThreadlineRoutes(
           createdAt: new Date().toISOString(),
         },
       };
-      const result = await threadlineRouter.handleInboundMessage(envelope);
+      // Accept-boundary (#3 / issue-580): respond the instant the message is
+      // accepted + authenticated, then run the (typically 9-30s) spawn in the
+      // BACKGROUND. The sole senders (MessageRouter cross-machine relay and
+      // AgentBus.httpSend) read only `response.ok` within a ~10s timeout and
+      // fall back to a durable queue on failure — so AWAITING the spawn meant
+      // the sender timed out before we replied, treated delivery as failed, and
+      // retried with a FRESH nonce/id that slipped past the nonce + id dedup,
+      // causing a DUPLICATE spawn/reply. This mirrors the proven co-located fix
+      // (#581, /messages/relay-agent). The reply itself flows back via the
+      // decoupled reply-waiter, not this HTTP response, so no caller's
+      // correctness depends on the synchronous spawn outcome; a genuine
+      // background failure is logged (it cannot 500 a response that already
+      // returned). The former 422-retryable path was already unreachable — the
+      // sender aborts at ~10s, long before the 9-30s spawn produced it.
+      res.json({ accepted: true, async: true, threadId: body.message?.threadId });
 
-      if (result.error) {
-        res.status(422).json(makeError(
-          ERROR_CODES.TL_INTERNAL_ERROR,
-          result.error,
-          true,
-          5,
-        ));
-        return;
-      }
-
-      res.json({
-        accepted: true,
-        threadId: result.threadId,
-        spawned: result.spawned,
-        resumed: result.resumed,
-      });
+      void threadlineRouter.handleInboundMessage(envelope)
+        .then((result) => {
+          if (result?.error) {
+            console.warn(
+              `[ThreadlineEndpoints] Background handleInboundMessage reported: ${result.error}`,
+            );
+          }
+        })
+        .catch((err) => {
+          console.error('[ThreadlineEndpoints] Background handleInboundMessage failed:', err);
+        });
+      return;
     } catch (err) {
       console.error('[ThreadlineEndpoints] Message receive error:', err);
       res.status(500).json(makeError(

--- a/tests/unit/threadline/ThreadlineEndpoints.test.ts
+++ b/tests/unit/threadline/ThreadlineEndpoints.test.ts
@@ -313,6 +313,141 @@ describe('ThreadlineEndpoints', () => {
     });
   });
 
+  // Accept-boundary (#3 / issue-580): the receive handler must respond the
+  // instant the message is accepted + authenticated and run the (slow) spawn in
+  // the background — NOT await it — so a sender on a ~10s timeout can't time out,
+  // treat delivery as failed, and retry with a fresh nonce → duplicate spawn.
+  describe('POST /threadline/messages/receive — accept-boundary', () => {
+    // Self-contained agents so we control agent-a's signing key directly: write a
+    // KNOWN hex identity for agent-a before constructing its manager, then sign
+    // with that exact private key (the outer managers persist their identity
+    // lazily/in-memory, which we can't read back).
+    let abA: HandshakeManager;
+    let abB: HandshakeManager;
+    let abDirB: string;
+    let aPriv: Buffer;
+
+    beforeEach(() => {
+      const dirA = path.join(tmpDir, 'ab-a');
+      abDirB = path.join(tmpDir, 'ab-b');
+      // HandshakeManager keeps identity under <stateDir>/threadline/identity.json.
+      fs.mkdirSync(path.join(dirA, 'threadline'), { recursive: true });
+      fs.mkdirSync(abDirB, { recursive: true });
+      const kp = generateIdentityKeyPair();
+      aPriv = kp.privateKey;
+      fs.writeFileSync(path.join(dirA, 'threadline', 'identity.json'), JSON.stringify({
+        publicKey: kp.publicKey.toString('hex'),
+        privateKey: kp.privateKey.toString('hex'),
+      }, null, 2));
+      abA = new HandshakeManager(dirA, 'agent-a');
+      abB = new HandshakeManager(abDirB, 'agent-b');
+      // Sanity: the manager loaded OUR known key (so our signature will verify).
+      expect(abA.getIdentityPublicKey()).toBe(kp.publicKey.toString('hex'));
+    }, 20000);
+
+    /** Complete the A→B handshake so agent-b trusts agent-a's identity. */
+    function completeHandshake() {
+      const init = abA.initiateHandshake('agent-b');
+      if (!('payload' in init)) throw new Error('unexpected');
+      const resp = abB.handleHello(init.payload);
+      if (!('payload' in resp)) throw new Error('unexpected');
+      const confirm = abA.handleHelloResponse(resp.payload);
+      if (!('confirmPayload' in confirm)) throw new Error('unexpected');
+      abB.handleConfirm(confirm.confirmPayload);
+    }
+
+    /** Build agent-b's app wired to a controllable mock router (not null). */
+    function appBWithRouter(router: unknown) {
+      const app = express();
+      app.use(express.json());
+      app.use(createThreadlineRoutes(abB, router as never, {
+        localAgent: 'agent-b',
+        version: '1.0',
+        stateDir: abDirB,
+      }));
+      return app;
+    }
+
+    /** Sign a receive request exactly as the threadlineAuth middleware verifies:
+     *  Ed25519 over (METHOD\nPATH\nNONCE\nTIMESTAMP\n + sha256(JSON.stringify(body))). */
+    function signedReceiveHeaders(body: unknown) {
+      const nonce = crypto.randomBytes(16).toString('hex');
+      const timestamp = new Date().toISOString();
+      const bodyHash = crypto.createHash('sha256').update(JSON.stringify(body)).digest();
+      const signedData = Buffer.concat([
+        Buffer.from(`POST\n/threadline/messages/receive\n${nonce}\n${timestamp}\n`, 'utf-8'),
+        bodyHash,
+      ]);
+      const signature = sign(aPriv, signedData).toString('hex');
+      return {
+        Authorization: `Threadline-Relay ${abA.getRelayToken('agent-b')!}`,
+        'X-Threadline-Agent': 'agent-a',
+        'X-Threadline-Nonce': nonce,
+        'X-Threadline-Timestamp': timestamp,
+        'X-Threadline-Signature': signature,
+      };
+    }
+
+    it('responds {accepted, async} BEFORE the slow spawn finishes, then runs it in the background', async () => {
+      completeHandshake();
+
+      // A handler we hold open: started=true on entry, finished=true only once
+      // we release it — so we can prove the response returned WITHOUT awaiting.
+      let started = false;
+      let finished = false;
+      let release: () => void = () => {};
+      const held = new Promise<void>((r) => { release = r; });
+      const router = {
+        handleInboundMessage: async () => {
+          started = true;
+          await held;
+          finished = true;
+          // Deliberately a DIFFERENT threadId than the body's, to prove the
+          // accept response sources threadId from the envelope (not the router
+          // result it no longer awaits).
+          return { handled: true, threadId: 'router-thread' };
+        },
+      };
+
+      const body = { message: { threadId: 't-1', from: { agent: 'agent-a' }, body: 'hi' } };
+      const res = await request(appBWithRouter(router))
+        .post('/threadline/messages/receive')
+        .set(signedReceiveHeaders(body))
+        .send(body);
+
+      // Accepted immediately, async flagged, no spawn-outcome fields.
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ accepted: true, async: true, threadId: 't-1' });
+      expect(res.body.spawned).toBeUndefined();
+      expect(res.body.resumed).toBeUndefined();
+      // The handler STARTED but the response did NOT await it (still pending).
+      expect(started).toBe(true);
+      expect(finished).toBe(false);
+
+      // Background work completes after we release it.
+      release();
+      await new Promise((r) => setImmediate(r));
+      expect(finished).toBe(true);
+    });
+
+    it('still returns 200 accepted even when the background spawn rejects', async () => {
+      await completeHandshake();
+      const router = {
+        handleInboundMessage: async () => { throw new Error('spawn boom'); },
+      };
+      const body = { message: { threadId: 't-2', from: { agent: 'agent-a' }, body: 'yo' } };
+      const res = await request(appBWithRouter(router))
+        .post('/threadline/messages/receive')
+        .set(signedReceiveHeaders(body))
+        .send(body);
+
+      // A background rejection can't break a response that already returned.
+      expect(res.status).toBe(200);
+      expect(res.body.accepted).toBe(true);
+      await new Promise((r) => setImmediate(r));
+    });
+  });
+
   describe('GET /threadline/messages/thread/:id', () => {
     it('requires authentication', async () => {
       const res = await request(appA).get('/threadline/messages/thread/test-thread');

--- a/upgrades/next/relay-funnel-accept-boundary.md
+++ b/upgrades/next/relay-funnel-accept-boundary.md
@@ -1,0 +1,24 @@
+<!-- bump: patch -->
+
+## What Changed — Cross-machine agent messages no longer cause duplicate replies
+
+When one agent sends a message to another agent on a different machine, the receiver has to spin up a work session to handle it — which can take 9 to 30 seconds. But the sender only waits about 10 seconds for an acknowledgement. So the sender would give up, assume the message failed, and re-send it with a fresh ID — and the receiver, not recognizing the resend, would spin up a second session and reply twice.
+
+The receiver now acknowledges the message the instant it arrives and is verified, then does the slow work in the background. The sender gets its acknowledgement immediately, never times out, and never re-sends — so there are no more duplicate replies. The actual reply still flows back through its normal channel, so nothing is lost by acknowledging early.
+
+This completes the duplicate-reply fix: the same approach was already shipped and proven for agents on the same machine; this extends it to agents on different machines.
+
+## Summary of New Capabilities
+
+- The relay-funnel receive endpoint (`/threadline/messages/receive`) now responds at the accept boundary: it acknowledges immediately after authenticating the message and runs the session spawn in the background, instead of making the sender wait through the spawn. Mirrors the co-located relay-agent fix.
+
+## What to Tell Your User
+
+If you run agents that talk to each other across different machines, they won't double-reply anymore. The receiving agent now confirms it got the message right away and does the work in the background, so the sender never times out and re-sends. Nothing to configure — it applies on the next update.
+
+## Evidence
+
+- Root traced by reading the two funnel senders (cross-machine relay and the agent-bus HTTP send): both read only whether the response is ok, within a ~10s timeout, and fall back to a durable queue on failure — so awaiting a 9-30s spawn guaranteed a timeout, a "failed" verdict, and a retry with a fresh id that slipped past dedup.
+- Integration test: with a real signed request and a deliberately-held handler, the response returns `{accepted, async}` BEFORE the handler finishes (handler started, not finished), the handler still completes in the background, and a background rejection still yields a clean 200.
+- Regression: the full threadline suite (router, integration, the gate-before-spawn keystone test) stays green; the receive endpoint's auth tests are unchanged.
+- Mirrors the proven co-located accept-boundary fix; the former error-retry response was already unreachable by every real sender.

--- a/upgrades/side-effects/relay-funnel-accept-boundary.md
+++ b/upgrades/side-effects/relay-funnel-accept-boundary.md
@@ -1,0 +1,42 @@
+# Side-effects — Relay-funnel accept-boundary
+
+## 1. What files/state does this touch at runtime?
+`ThreadlineEndpoints.ts`, the `POST /threadline/messages/receive` handler only. No new files, no
+config keys, no schema, no persisted state. The spawn (`handleInboundMessage`) still runs — just in
+the background instead of awaited.
+
+## 2. Does it change any functional behavior?
+- The success response changes from `{ accepted, threadId, spawned, resumed }` (after the 9-30s
+  spawn) to `{ accepted: true, async: true, threadId }` (immediately). The `spawned`/`resumed`
+  fields are gone (they required awaiting the spawn).
+- The former `422`-retryable-on-`result.error` response is gone — but it was already unreachable by
+  every real sender (they read only `response.ok` and abort at ~10s, before the spawn produced it).
+- Auth, payload validation, and the missing-router 503 are unchanged.
+
+## 3. What happens on failure / weird config?
+A background `handleInboundMessage` rejection is caught and logged (`console.error`); it cannot
+affect the already-sent 200 response. A reported `result.error` is logged (`console.warn`). The
+missing-router 503 still fires synchronously before the accept response.
+
+## 4. Migration parity — do existing agents get it?
+Yes, via the normal release — code-only, compiled into `dist`. No agent-installed file / config /
+template change, so no `PostUpdateMigrator` pass is needed.
+
+## 5. Could it spam / flood / burn resources?
+No — strictly fewer resources: it does the SAME single spawn, but the sender no longer times out and
+retries, so it eliminates the duplicate spawn (the bug). No new timers, I/O, or network calls.
+
+## 6. Rollback / off-switch?
+Revert the one `ThreadlineEndpoints.ts` block (re-`await` the router and return its result) and the
+test. No data, no migration, no flag. Mirrors #581's rollback.
+
+## 7. Concurrency / ordering?
+The spawn now runs after the response returns instead of before. The router's existing
+`pendingSpawns` guard still blocks concurrent same-thread spawns. A sender that genuinely double-
+sends (distinct content) is unaffected by this change (it was never the duplicate source the
+accept-boundary targets — that was the timeout→retry of the SAME message).
+
+## Blast radius
+Small + additive: one handler block in `ThreadlineEndpoints.ts` swapped from await-then-respond to
+respond-then-background-spawn. Exactly mirrors the proven co-located fix (#581). Only the relay-
+funnel receive path is affected; the router, the co-located path, and all auth are untouched.


### PR DESCRIPTION
## What & why

The relay-funnel inbound handler (`POST /threadline/messages/receive`) **awaited** `handleInboundMessage` — a 9-30s session spawn — before responding. But the funnel's senders (`MessageRouter` cross-machine relay, `AgentBus.httpSend`) read **only `response.ok`** within a **~10s timeout** and fall back to a durable queue on failure. So when the spawn outran the timeout, the sender treated delivery as failed and retried — with a **fresh nonce/id** that slipped past the nonce + id dedup, causing a **duplicate spawn/reply**.

This is the issue-580 follow-up that **#581 explicitly deferred** when it fixed the co-located path. It applies the same proven accept-boundary to the relay-funnel path.

## The change

After auth + validation, respond `{ accepted: true, async: true, threadId }` immediately and run `handleInboundMessage(envelope)` in the **background** (`void` + `.catch` logging). Only the spawn timing changes; auth, validation, and the missing-router 503 are untouched.

## Why it's safe

- The 422-retryable-on-`result.error` response #581 worried about was **already unreachable**: every real sender reads only `response.ok` and aborts at ~10s, long before the 9-30s spawn produced the 422.
- No in-repo consumer of this endpoint reads `.spawned`/`.resumed`/`.threadId` or branches on its 422 (the in-process caller uses `handleInboundMessage` directly; the `.spawned` HTTP reader is the co-located path, already converted by #581).
- The reply flows back via the decoupled reply-waiter, not this HTTP response.
- No new dedup needed: the accept-boundary removes the retry-source, and the router's `pendingSpawns` guard already blocks concurrent same-thread spawns.
- Residual (documented, matches #581): a genuine background failure is logged, not redelivered — rare, same trade #581 made.

## Tests

- `ThreadlineEndpoints.test.ts`: a real cryptographically-signed receive + a held mock router proves the response returns `{accepted, async, threadId}` BEFORE the handler finishes (re-adding `await` would hang/timeout), the handler still completes in the background, and a background rejection still yields 200. threadId is sourced from the envelope (mock returns a different one to prove it).
- Regression: full threadline suite (router/integration/keystone) green; auth tests unchanged.
- Independent adversarial review: SHIP, no real issues (double-response structurally impossible; no consumer depends on the dropped fields; reply decoupling confirmed).

Spec: docs/specs/relay-funnel-accept-boundary.md (+ .eli16.md), approved by Justin (topic 13435, 2026-05-31). Side-effects + release-note fragment included.

Generated with Claude Code
