### PR TITLE
fix(framework-detect): scan nvm version dirs for the CLI binary (bug #10)

### DIFF
--- a/docs/specs/detect-framework-binary-nvm.eli16.md
+++ b/docs/specs/detect-framework-binary-nvm.eli16.md
@@ -1,0 +1,41 @@
+# Find the Claude binary under nvm — explain it like I'm 16
+
+When the assistant moves a conversation to another machine (the Mac mini), that
+machine has to actually START a Claude session to take over the conversation. To do
+that, it needs to find the `claude` program on disk and run it.
+
+The code that finds `claude` checks a list of likely spots: the standard install
+folder, Homebrew, the npm global folder, and a couple of others. But on the mini,
+`claude` was installed through a tool called **nvm** (Node Version Manager), which
+keeps programs in a folder like `~/.nvm/versions/node/v24.14.1/bin/`. That folder is
+on your PATH when you open a terminal, because opening a terminal runs nvm's setup
+script. But the assistant's background server is started by the operating system's
+launcher (launchd), which does NOT run that setup script — so the nvm folder isn't on
+its PATH, and the special "NVM_BIN" hint that points to it isn't set either.
+
+So when the mini's server went looking for `claude`, it struck out everywhere and
+came back with "nothing." With no Claude program to run, the session it tried to
+start died the instant it launched. I confirmed this exactly by running the finder
+inside the mini server's own environment: it returned null, and NVM_BIN was unset.
+
+The fix teaches the finder one more place to look: the nvm folders themselves. It
+peeks into `~/.nvm/versions/node/`, prefers the version of node that's currently
+running, and otherwise checks any installed version — and grabs `claude` (or codex,
+or whatever) from there. This is the same trick the code already uses for a different
+tool manager (asdf), and for the same reason: the background launcher hides those
+folders from the PATH, so you have to look in them directly instead of trusting the
+PATH.
+
+It's a small, safe change. It only ADDS places to look — if the finder already found
+the program somewhere earlier in its list (like Homebrew), that still wins, so
+machines that worked before behave exactly the same. The only difference is that a
+machine where the program lives only in an nvm folder can now find it. I added a test
+that sets up a fake nvm folder with a stub program, deletes the NVM_BIN hint to prove
+it works without it, and checks the finder locates the program — plus a guard that
+the code keeps scanning the nvm folders so this can't quietly regress.
+
+Why it matters here: this is the rung that lets the moved conversation actually START
+on the mini. Before it, the mini received the conversation and tried to launch it but
+couldn't find Claude to run. After it, the session can boot. The next rung is still
+ahead — letting that session send its replies back to you — but this clears the
+"can't even start" wall.

--- a/docs/specs/detect-framework-binary-nvm.md
+++ b/docs/specs/detect-framework-binary-nvm.md
@@ -1,0 +1,78 @@
+---
+title: detectFrameworkBinary scans nvm version dirs (launchd-PATH-excluded binaries)
+slug: detect-framework-binary-nvm
+status: approved
+review-convergence: 2026-05-31T11:40:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h deploy mandate (topic 13481).
+  Bug #10 of the multi-machine live-transfer cascade, found live: a session spawn
+  on the nvm-only mini crashed because claudePath resolved to null. Verified in the
+  mini server's node env (detectClaudePath() => null, NVM_BIN unset). Flagged in the
+  PR per cross-agent discipline.
+---
+
+# detectFrameworkBinary scans nvm version dirs
+
+## Problem
+
+Found live (2026-05-31): with bugs #4/#5/#6/#8/#9 fixed, "move this to the Mac mini"
+forwards, the mini accepts + persists the session — but the spawned Claude session
+dies instantly: `Session "…" died during startup … tmux died during fresh startup`.
+
+Root, verified by running the resolver in the mini server's own node env:
+
+```
+detectClaudePath() => null
+NVM_BIN: (unset)
+PATH has nvm bin: false
+```
+
+The mini's `claude` binary lives at `~/.nvm/versions/node/<ver>/bin/claude`. But
+`detectFrameworkBinary` only finds an nvm binary via `process.env.NVM_BIN` — which is
+set by nvm's shell init, NOT in the launchd environment the server runs under. The
+other candidates miss too (no `~/.claude/local/claude`, no homebrew, `npm`/`which`
+not on the launchd PATH). So `claudePath` resolves to `null`, and a session spawned
+with no Claude binary dies immediately.
+
+This is the exact failure class the existing asdf-shim search already guards against
+("the launchd/login PATH frequently excludes that dir") — nvm needs the same.
+
+## Goal
+
+`detectFrameworkBinary` finds a framework CLI installed under an nvm version dir even
+when the server runs under launchd (no nvm-initialized shell, `NVM_BIN` unset), so a
+session spawn on an nvm-only machine works.
+
+## Non-goals
+
+- Does NOT change the candidate PREFERENCE order for machines where detection already
+  succeeds (the nvm scan is appended after the existing system/npm/NVM_BIN
+  candidates; a binary found earlier still wins).
+- Does NOT address bug #7 (standby outbound mute) — separate.
+- Does NOT add a runtime PATH mutation; it only widens detection.
+
+## Design
+
+In `detectFrameworkBinaryUncached`, after the `NVM_BIN` check, scan
+`~/.nvm/versions/node/`: push `<process.version>/bin/<name>` first (prefer the
+running node's version), then every installed `<ver>/bin/<name>`. Wrapped in a
+best-effort try/catch (a missing/unreadable nvm dir is a no-op). The existing
+candidate loop then returns the first that exists. Mirrors the asdf-shim handling.
+
+## Testing
+
+- Tier 1 (`detectFrameworkBinary.test.ts`): with `HOME` pointed at a temp dir
+  containing `~/.nvm/versions/node/v99.0.0/bin/plandex` and `NVM_BIN` DELETED,
+  detection resolves to that binary (proves it works without NVM_BIN — the launchd
+  case). Plus a source-guard that Config.ts scans the nvm version dirs.
+- 24 detection + loadConfig tests green; `tsc --noEmit` clean.
+- Tier-3: the next live re-test confirms the spawned session on the mini no longer
+  dies at startup (claudePath now resolves).
+
+## Migration parity
+
+Pure code (additional detection candidates). No config/hook/route/CLAUDE.md change.
+Strictly widens detection — machines that already resolved a binary are unaffected.
+Existing agents get it on the v-next update.

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -196,6 +196,26 @@ function detectFrameworkBinaryUncached(name: FrameworkBinary): string | null {
     candidates.push(path.join(process.env.NVM_BIN, name));
   }
 
+  // nvm version dirs. nvm installs node — and globally-installed CLIs like the
+  // `claude`/`codex` binaries — under ~/.nvm/versions/node/<version>/bin, and the
+  // launchd/login PATH frequently excludes that dir (same reason the asdf shim
+  // search below exists) with NVM_BIN unset outside an nvm-initialized shell. So a
+  // binary that works in the user's terminal is invisible to a server spawned by
+  // launchd. Prefer the RUNNING node's version, then any other installed version
+  // that has the binary. (2026-05-31: an nvm-only machine's session spawn crashed
+  // because claudePath resolved to null — the binary was here but unscanned.)
+  try {
+    const nvmNodeRoot = path.join(home, '.nvm', 'versions', 'node');
+    if (fs.existsSync(nvmNodeRoot)) {
+      candidates.push(path.join(nvmNodeRoot, process.version, 'bin', name));
+      for (const ver of fs.readdirSync(nvmNodeRoot)) {
+        candidates.push(path.join(nvmNodeRoot, ver, 'bin', name));
+      }
+    }
+  } catch {
+    // @silent-fallback-ok — nvm version-dir scan
+  }
+
   // asdf-managed shims. asdf installs CLIs as shims under its data dir, and
   // the launchd/login PATH frequently excludes that dir — so a binary that
   // works in the user's interactive terminal is invisible to instar without

--- a/tests/unit/detectFrameworkBinary.test.ts
+++ b/tests/unit/detectFrameworkBinary.test.ts
@@ -77,6 +77,43 @@ describe('detectFrameworkBinary', () => {
     }
   });
 
+  it('finds a binary in an nvm version dir when it lives nowhere else (bug #10)', async () => {
+    // Regression for the live-transfer cascade bug #10: a session spawn on an
+    // nvm-only machine crashed because claudePath resolved to null — the binary
+    // was under ~/.nvm/versions/node/<ver>/bin but the launchd server PATH
+    // excluded it and NVM_BIN was unset. detectFrameworkBinary must scan the nvm
+    // version dirs directly.
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nvm-home-test-'));
+    const prevHome = process.env.HOME;
+    const prevNvmBin = process.env.NVM_BIN;
+    try {
+      const binDir = path.join(tmpHome, '.nvm', 'versions', 'node', 'v99.0.0', 'bin');
+      fs.mkdirSync(binDir, { recursive: true });
+      const bin = path.join(binDir, 'plandex'); // unlikely installed on the host
+      fs.writeFileSync(bin, '#!/bin/sh\necho stub\n', { mode: 0o755 });
+      process.env.HOME = tmpHome;
+      delete process.env.NVM_BIN; // prove it resolves WITHOUT NVM_BIN (the launchd case)
+      _resetFrameworkBinaryCache();
+      expect(detectFrameworkBinary('plandex')).toBe(bin);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+      if (prevNvmBin === undefined) delete process.env.NVM_BIN; else process.env.NVM_BIN = prevNvmBin;
+      _resetFrameworkBinaryCache();
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it('source MUST search nvm version dirs (regression guard for bug #10)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const projectRoot = path.resolve(__dirname, '..', '..');
+    const source = fs.readFileSync(path.join(projectRoot, 'src/core/Config.ts'), 'utf-8');
+    expect(source, 'Config.ts must scan ~/.nvm/versions/node/<ver>/bin').toMatch(/\.nvm['"`,\s)].*versions.*node|versions.*node.*bin/);
+  });
+
   it('memoizes detection — repeated calls do not re-resolve (caches positive + negative)', () => {
     _resetFrameworkBinaryCache();
     const first = detectFrameworkBinary('codex');

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,50 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13481; multi-machine live-transfer cascade)
+---
+
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — the agent now finds its CLI when it's installed via nvm
+
+Another step toward making the multi-machine "move this conversation to my other
+machine" feature work, and a general robustness fix for any agent installed through
+nvm (Node Version Manager). To start a session, the agent has to find its CLI binary
+(like the Claude or Codex command) on disk. The finder checked the usual locations
+but missed binaries that nvm installs under its own version folders — because the
+background server is launched by the operating system, which does not load nvm's
+shell setup, so that folder is off the PATH and nvm's location hint is unset.
+
+The finder now also looks directly inside the nvm version folders (preferring the
+running version), exactly like it already does for the asdf tool manager, and for the
+same reason. On the machine where this surfaced, a session spawn was crashing
+instantly because the CLI couldn't be found; now it resolves.
+
+## Summary of New Capabilities
+
+- `detectFrameworkBinary` scans `~/.nvm/versions/node/<version>/bin/<name>` (running
+  version first, then any installed version) after the existing checks — so a CLI
+  installed only under nvm is found even when the server runs under launchd with
+  `NVM_BIN` unset and the nvm bin dir off the PATH.
+
+## What to Tell Your User
+
+If your agent's CLI was installed through nvm, the agent can now find and launch it
+reliably even when it's running as a background service. This fixes a case where a
+session would fail to start because the program couldn't be located. It only adds
+places to look, so agents that already worked are unaffected. Nothing to configure.
+
+## Evidence
+
+- Verified live in the affected machine's server environment: the binary detector
+  returned null, NVM_BIN was unset, and the PATH had no nvm directory — so a spawned
+  session died at startup with no CLI to run.
+- Unit, `tests/unit/detectFrameworkBinary.test.ts`: with HOME pointed at a temp nvm
+  layout and NVM_BIN deleted, detection resolves the binary; plus a source guard that
+  the detector scans the nvm version dirs.
+- 24 detection + loadConfig tests pass; tsc --noEmit clean.
+- Spec, `docs/specs/detect-framework-binary-nvm.md` plus the .eli16.md sibling.
+- Side-effects, `upgrades/side-effects/detect-framework-binary-nvm.md`.

--- a/upgrades/side-effects/detect-framework-binary-nvm.md
+++ b/upgrades/side-effects/detect-framework-binary-nvm.md
@@ -1,0 +1,92 @@
+# Side-Effects Review — detectFrameworkBinary scans nvm version dirs (bug #10)
+
+**Version / slug:** `detect-framework-binary-nvm`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`detectFrameworkBinaryUncached` now scans `~/.nvm/versions/node/<ver>/bin/<name>`
+(running node's version first, then any installed version) after the existing
+`NVM_BIN` check. A framework CLI installed only under nvm is now found even when the
+server runs under launchd (no nvm shell init → `NVM_BIN` unset, nvm bin off PATH).
+Closes bug #10: the mini's session spawn crashed because `claudePath` resolved to
+null.
+
+## Decision-point inventory
+
+- **nvm scan** — `~/.nvm/versions/node` exists? push running-version + all-version
+  `bin/<name>` candidates : skip. The existing candidate loop returns the first that
+  exists. Best-effort try/catch (unreadable dir → no-op).
+
+## 1. Over-block
+
+**What legitimate inputs does this reject?** Nothing. It only ADDS candidates; the
+existing candidate loop short-circuits on the first existing path, so machines that
+already resolved a binary (homebrew, npm prefix, NVM_BIN, asdf, PATH) return the same
+result as before. It cannot make detection return a worse/wrong path — every
+candidate is `fs.existsSync`-checked.
+
+## 2. Under-block
+
+**What does this still miss?** It scans the default `~/.nvm` root only (honors no
+`$NVM_DIR` override — nvm's standard location; an exotic relocated nvm is still
+covered by the `which`/NVM_BIN fallbacks if those are reachable). It does not address
+bug #7 (standby outbound mute). It picks the running node's version first, then
+directory order — adequate for locating a globally-installed CLI (the same binary is
+typically linked across versions).
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The scan sits in the single framework-binary detector beside
+the asdf-shim handling it mirrors (same launchd-PATH-exclusion rationale), feeding
+the same candidate loop. No duplication; benefits every framework name + every
+caller (claude/codex/gemini/…).
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No blocking authority. Pure detection widening; gates nothing, blocks nothing. A
+failure to scan (unreadable dir) is swallowed and falls through to the existing
+fallbacks.
+
+## 5. Interactions
+
+Memoized via the existing `_frameworkBinaryCache` (positive + negative), so the dir
+scan runs at most once per binary name per process. Feeds `claudePath`/`codexPath`
+resolution at config load, which feeds `SessionManager` spawn. No interaction with
+the lease/pool/state paths.
+
+## 6. External surfaces
+
+None. No HTTP routes, config, or notifications. The visible effect is a non-null
+`claudePath` on an nvm-only machine (so a spawned session has a binary to run).
+
+## 7. Rollback cost
+
+Trivial. Remove the nvm-scan block; an nvm-only machine reverts to null detection
+(re-introducing bug #10). No schema, no state, no migration.
+
+## Conclusion
+
+Minimal additive detection widening, mirroring the existing asdf-shim handling for
+the same launchd-PATH-exclusion reason, both the functional (NVM_BIN-deleted) case
+and a source guard unit-tested, no behavior change for already-resolving machines,
+trivial revert. Lets a moved session actually start on an nvm-only machine.
+
+## Second-pass review (if required)
+
+Not required — additive detection only, existsSync-guarded, memoized, no authority,
+reversible; the functional test proves it resolves WITHOUT NVM_BIN (the launchd case).
+The live two-machine re-test is the Tier-3 gate that follows.
+
+## Evidence pointers
+
+- `tests/unit/detectFrameworkBinary.test.ts` — resolves a binary in a temp nvm
+  version dir with NVM_BIN DELETED; source-guard that Config.ts scans the nvm dirs.
+- 24 detection + loadConfig tests green; `tsc --noEmit` clean.
+- Verified live in the mini server's node env: `detectClaudePath() => null`,
+  `NVM_BIN: (unset)`, PATH has no nvm bin — the spawned session died at startup.
+- Spec: `docs/specs/detect-framework-binary-nvm.md` (+ `.eli16.md`).


### PR DESCRIPTION
## Bug #10 of the live-transfer cascade — found live on the nvm-only mini

With bugs #4/#5/#6/#8/#9 fixed, "move this to the Mac mini" forwards, the mini accepts
+ persists the session — but the spawned Claude session dies at startup:
`Session "…" died during startup … tmux died during fresh startup`.

**Root (verified in the mini server's own node env, not inferred):**
```
detectClaudePath() => null
NVM_BIN: (unset)
PATH has nvm bin: false
```
The mini's `claude` is at `~/.nvm/versions/node/<ver>/bin/claude`, but
`detectFrameworkBinary` only found nvm binaries via `process.env.NVM_BIN` — set by
nvm's shell init, NOT in the launchd environment the server runs under. So
`claudePath` resolved `null` and the spawn had no binary to run. This is the exact
failure class the existing **asdf-shim** search already guards ("the launchd/login
PATH frequently excludes that dir").

## Fix
`detectFrameworkBinaryUncached` now scans `~/.nvm/versions/node/<ver>/bin/<name>`
(running node's version first, then any installed version) after the `NVM_BIN` check.
Best-effort, existsSync-guarded, additive — a binary found earlier still wins, so
already-resolving machines are unaffected. Mirrors the asdf-shim handling.

## Tests
- `tests/unit/detectFrameworkBinary.test.ts`: with HOME at a temp nvm layout and `NVM_BIN` **deleted**, detection resolves the binary (proves it works without NVM_BIN — the launchd case); plus a source guard that Config.ts scans the nvm dirs.
- 24 detection + loadConfig tests green; `tsc --noEmit` clean.

## Scope
Lets a moved session actually START on an nvm-only machine. **Bug #7** (the standby has no Telegram token → the running session is mute) is separate and still open.

## Ship-gate
Spec `docs/specs/detect-framework-binary-nvm.md` (+ `.eli16.md`), self-approved under the standing 12h deploy mandate (topic 13481) — flagged here per cross-agent discipline. Side-effects + NEXT.md included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
