### PR TITLE
fix(slack): guard Socket-Mode ack send so a reconnect race can't crash the whole agent (#43)

### DIFF
--- a/docs/specs/slack-reconnect-crash-guard.eli16.md
+++ b/docs/specs/slack-reconnect-crash-guard.eli16.md
@@ -1,0 +1,36 @@
+# Slack reconnect crash guard — explained simply
+
+## The everyday version
+
+Your laptop sleeps and wakes all day. Every time it wakes, the agent has to reconnect its live
+connection to Slack — like re-establishing a phone call that dropped. There's a rule that the agent
+must say "got it" (an acknowledgement) the instant Slack sends it a message.
+
+The bug: sometimes a message arrived in the split-second WHILE the connection was still being
+re-established — the line wasn't fully open yet. The agent tried to send its "got it" down a line
+that wasn't ready, which threw an error. And because that error happened in a background handler
+nobody was watching, it bubbled all the way up and **crashed the entire agent** — taking down its
+databases and everything else — just because one Slack acknowledgement couldn't be sent.
+
+## What we changed
+
+Two safety nets:
+
+1. **At the source:** before sending the "got it," the agent now checks that the line is actually
+   open. If it isn't (mid-reconnect), it skips the ack — and that's fine, because Slack simply
+   re-sends the message a moment later. We also wrapped it so even a split-second timing fluke can't
+   throw.
+
+2. **As a backstop:** the agent already had a short list of "minor errors that should never crash the
+   whole thing" (like harmless web-response races). We added this Slack reconnect hiccup to that list.
+   So even if some other Slack timing glitch slips through, the agent logs it and keeps running
+   instead of crashing and closing its databases.
+
+## Why it's safe
+
+The "minor errors" list is kept very tight — only specific, isolated, self-healing errors go on it.
+A genuinely serious error (like a database problem) is NOT on the list and still crashes-and-restarts
+as before, which is the safe thing to do. We pulled that list into its own small piece of code and
+tested it both ways: the Slack hiccup and the known harmless races are treated as recoverable, while
+made-up serious errors are still treated as fatal. And skipping a Slack ack loses nothing, because
+Slack re-delivers anything it didn't hear "got it" for.

--- a/docs/specs/slack-reconnect-crash-guard.md
+++ b/docs/specs/slack-reconnect-crash-guard.md
@@ -1,0 +1,93 @@
+---
+title: Stop a Slack Socket-Mode reconnect race from crashing the whole agent
+slug: slack-reconnect-crash-guard
+date: 2026-05-31
+author: echo
+status: approved
+review-convergence: internal-plus-adversarial-self-review-2026-05-31
+approved: true
+approved-by: Echo under the 12h autonomous deploy mandate (self-approved; flagged in PR). Found via the mandate's "watch my own operation — fix anything blocking autonomous operation" task in Echo's own server.log; reported to Justin (topic 13435, 2026-05-31).
+approval-note: >
+  An uncaught exception that crashes the whole agent (closing its SQLite databases) is squarely the
+  "fix anything blocking autonomous operation" mandate. Found live in Echo's own log after a
+  sleep/wake. The fix is small + low-risk: a readyState guard at the root + a precedent-matching
+  allowlist entry as a backstop.
+second-pass-required: false
+second-pass-status: n/a-small-guard-plus-behavior-preserving-extraction-adversarially-reviewed
+eli16-overview: slack-reconnect-crash-guard.eli16.md
+---
+
+# Slack reconnect crash guard (#43)
+
+## The crash, grounded
+
+Echo's own `server.log` recorded a `[FATAL] Uncaught exception — closing databases before crash:
+Sent before connected.` immediately after a sleep/wake Slack reconnect:
+```
+[slack] Reconnecting Socket Mode...
+[SleepWake] Slack reconnected
+[FATAL] Uncaught exception — closing databases before crash: Sent before connected.
+```
+Sequence: `SleepWakeDetector` wake → `SlackAdapter.reconnect()` (try/caught) succeeds → then a
+WebSocket send fired on the freshly-reconnecting socket and threw "Sent before connected". The throw
+was in an **async message handler** (`SocketModeClient._handleRawMessage`), so it escaped the
+reconnect's try/catch and reached the process-level `uncaughtException` handler, which crashes
+(closes databases, `process.exit(1)`). For a laptop agent that sleeps/wakes constantly, this is a
+recurring-outage risk.
+
+## Root cause
+
+`SocketModeClient._handleRawMessage` acks every inbound event:
+```ts
+if (envelope.envelope_id) {
+  this.ws?.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
+}
+```
+It checked `ws` is non-null (`?.`) but NOT `readyState === OPEN`, and was not in a try/catch — unlike
+the guarded `queueOutbound` (readyState check) and the liveness probe (try/catch). During a reconnect
+race the socket can be CONNECTING/CLOSING, so `ws.send()` throws.
+
+## Fix — two layers
+
+**Root** — guard the ack send (mirrors `queueOutbound` + the probe):
+```ts
+if (envelope.envelope_id && this.ws && this.ws.readyState === WebSocket.OPEN) {
+  try { this.ws.send(JSON.stringify({ envelope_id: envelope.envelope_id })); }
+  catch (err) { console.warn(`[slack-socket] Ack send failed (socket mid-transition): ${err.message}`); }
+}
+```
+If the ack is skipped, Slack redelivers the unacked event — no loss. Event processing (after the ack)
+is unchanged.
+
+**Safety net** — the process `uncaughtException` handler already suppresses a small allowlist of
+isolated, recoverable errors (HTTP double-response races) instead of crashing. Extract that allowlist
+into a unit-testable `src/core/uncaughtExceptionPolicy.ts` (`isNonFatalUncaught`) and add
+`'Sent before connected'`: an isolated Slack WS race (the `SocketModeClient` self-reconnects with
+backoff; Slack redelivers) must never crash the whole agent and close its databases. The handler now
+calls `isNonFatalUncaught(err)`; the FATAL path for unrecognized errors is unchanged.
+
+## Safety (adversarial self-review)
+- The extraction is behavior-preserving: same 4 HTTP patterns, same `includes()` substring semantics,
+  and `isNonFatalUncaught` returns false for an error with no message (matching the old `?.includes`).
+  The only behavioral change is the intended new `'Sent before connected'` suppression.
+- Over-suppression: `'Sent before connected'` is specific to the Slack WS send race (it does not
+  appear elsewhere in src), and it is genuinely recoverable (the client reconnects on backoff). It
+  cannot mask the known fatals (e.g. `mutex lock failed`, sqlite-closed) — tested in
+  `uncaughtExceptionPolicy.test.ts`.
+- The root guard means the throw is normally prevented at source; the allowlist is the backstop for
+  any other Slack WS send race.
+
+## Migration parity
+N/A — code-only (`SocketModeClient.ts`, `server.ts`, new `uncaughtExceptionPolicy.ts`), compiled into
+`dist`. No agent-installed file / config / template change → no `PostUpdateMigrator` pass.
+
+## Agent Awareness
+N/A — internal crash-resilience. No new endpoint/trigger/lookup to surface.
+
+## Test plan
+- Unit (`uncaughtExceptionPolicy.test.ts`): `isNonFatalUncaught` — Slack WS race + HTTP races →
+  recoverable; unknown errors (mutex/sqlite/undefined) → fatal; non-Error inputs robust.
+- Source-assertion (`slack-socket-reconnect.test.ts`, the file's established style): the ack send is
+  guarded on `readyState === OPEN` + try/catch; the server routes uncaught exceptions through
+  `isNonFatalUncaught`.
+- Regression: the slack socket reconnect + heartbeat suites stay green.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -17,6 +17,7 @@ import pc from 'picocolors';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import { loadConfig, ensureStateDir, detectTmuxPath } from '../core/Config.js';
+import { isNonFatalUncaught } from '../core/uncaughtExceptionPolicy.js';
 import { SessionManager } from '../core/SessionManager.js';
 import { StateManager } from '../core/StateManager.js';
 import { StuckInputSentinel } from '../core/StuckInputSentinel.js';
@@ -9975,17 +9976,11 @@ export async function startServer(options: StartOptions): Promise<void> {
     // the "mutex lock failed" error on next start. This doesn't prevent the crash,
     // but ensures the next boot is clean.
     process.on('uncaughtException', (err) => {
-      // Non-fatal HTTP errors — log and continue, don't crash the server.
-      // "Cannot set headers" is a double-response race condition (common during
-      // tunnel reconnect storms). The affected request is already handled; the
-      // server can keep serving new requests.
-      const nonFatalPatterns = [
-        'Cannot set headers after they are sent',
-        'write after end',
-        'ERR_HTTP_HEADERS_SENT',
-        'ERR_STREAM_WRITE_AFTER_END',
-      ];
-      if (nonFatalPatterns.some(p => err.message?.includes(p))) {
+      // Isolated, recoverable uncaught exceptions — log and continue, don't
+      // crash the server (which would close its databases + drop in-flight
+      // work). See isNonFatalUncaught for the allowlist + rationale (HTTP
+      // double-response races, Slack Socket Mode reconnect races).
+      if (isNonFatalUncaught(err)) {
         console.warn(`[WARN] Non-fatal uncaught exception (suppressed): ${err.message}`);
         return; // Don't crash — the server is fine
       }

--- a/src/core/uncaughtExceptionPolicy.ts
+++ b/src/core/uncaughtExceptionPolicy.ts
@@ -1,0 +1,43 @@
+/**
+ * Policy for which process-level uncaught exceptions are RECOVERABLE (log +
+ * continue) vs FATAL (close databases + exit).
+ *
+ * The server's `process.on('uncaughtException')` handler crashes by default —
+ * the safe thing for a truly-unknown exception. But a small set of exceptions
+ * are ISOLATED and recoverable: the failing operation has already unwound, the
+ * rest of the agent (databases, HTTP, the other messaging platforms) is intact,
+ * and the owning subsystem self-heals. For those, crashing the whole agent —
+ * which closes its SQLite databases and drops in-flight work — is strictly worse
+ * than logging and continuing.
+ *
+ * Extracted from server.ts so the decision boundary is unit-testable on both
+ * sides. Adding a pattern here is a deliberate assertion that the matching error
+ * is isolated + recoverable; keep the list tight.
+ */
+const NON_FATAL_UNCAUGHT_PATTERNS = [
+  // HTTP double-response races (common during tunnel reconnect storms). The
+  // affected request is already handled; the server keeps serving new requests.
+  'Cannot set headers after they are sent',
+  'write after end',
+  'ERR_HTTP_HEADERS_SENT',
+  'ERR_STREAM_WRITE_AFTER_END',
+  // Slack Socket Mode reconnect race: a WebSocket send on a still-connecting
+  // socket throws ("Sent before connected"). The SocketModeClient reconnects
+  // with backoff on its own, and Slack redelivers any unacked event — so an
+  // isolated Slack WS hiccup must not crash the whole agent (esp. on a laptop
+  // that sleeps/wakes often, where reconnects are frequent). The root cause is
+  // also guarded at the ack send site; this is the defense-in-depth backstop.
+  'Sent before connected',
+];
+
+/**
+ * True when an uncaught exception is a known isolated/recoverable error that the
+ * server should log-and-continue on, rather than crash. Matches on the error
+ * message (substring). Returns false for anything unrecognized (→ crash, the
+ * safe default).
+ */
+export function isNonFatalUncaught(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  if (!msg) return false;
+  return NON_FATAL_UNCAUGHT_PATTERNS.some((p) => msg.includes(p));
+}

--- a/src/messaging/slack/SocketModeClient.ts
+++ b/src/messaging/slack/SocketModeClient.ts
@@ -188,9 +188,22 @@ export class SocketModeClient {
       return;
     }
 
-    // Acknowledge immediately (must be within 3 seconds)
-    if (envelope.envelope_id) {
-      this.ws?.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
+    // Acknowledge immediately (must be within 3 seconds). Guard the send:
+    // during a reconnect race the socket can be mid-transition (CONNECTING /
+    // CLOSING), and an unguarded ws.send() on a non-OPEN socket throws — which,
+    // uncaught in this async message handler, crashed the whole server (the
+    // observed "Sent before connected" FATAL after a sleep/wake reconnect).
+    // Mirror queueOutbound's readyState guard + the liveness-probe try/catch.
+    if (envelope.envelope_id && this.ws && this.ws.readyState === WebSocket.OPEN) {
+      try {
+        this.ws.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
+      } catch (err) {
+        // Socket changed state between the check and the send (rare race) —
+        // log and move on; Slack will redeliver the unacked event.
+        console.warn(
+          `[slack-socket] Ack send failed (socket mid-transition): ${(err as Error).message}`,
+        );
+      }
     }
 
     // Process event with exception guard (post-ack — Slack won't redeliver)

--- a/tests/unit/slack-socket-reconnect.test.ts
+++ b/tests/unit/slack-socket-reconnect.test.ts
@@ -88,3 +88,27 @@ describe('SleepWake Slack reconnection', () => {
     expect(serverSource).toMatch(/slackAdapter[\s\S]*?reconnect[\s\S]*?catch/);
   });
 });
+
+describe('Ack send guard against a mid-reconnect socket (#43 — no whole-agent crash)', () => {
+  it('guards the event ack on socket readyState === OPEN', () => {
+    // The "must ack within 3s" send previously called this.ws?.send() with only
+    // a null check — during a reconnect race the socket can be CONNECTING/CLOSING,
+    // and the unguarded send threw "Sent before connected" → uncaught → FATAL.
+    expect(socketClientSource).toMatch(
+      /envelope\.envelope_id[\s\S]*?this\.ws\.readyState === WebSocket\.OPEN[\s\S]*?this\.ws\.send\(/,
+    );
+  });
+
+  it('wraps the ack send in try/catch (state can change between check and send)', () => {
+    expect(socketClientSource).toMatch(
+      /this\.ws\.readyState === WebSocket\.OPEN\) \{[\s\S]*?try \{[\s\S]*?this\.ws\.send\([\s\S]*?\} catch/,
+    );
+  });
+
+  it('server routes uncaught exceptions through the isNonFatalUncaught policy (defense-in-depth)', () => {
+    // The recoverable-error allowlist (HTTP races + the Slack WS race) is now a
+    // testable module, used by the process-level handler instead of an inline list.
+    expect(serverSource).toContain("import { isNonFatalUncaught } from '../core/uncaughtExceptionPolicy.js'");
+    expect(serverSource).toMatch(/if \(isNonFatalUncaught\(err\)\) \{[\s\S]*?return;/);
+  });
+});

--- a/tests/unit/uncaughtExceptionPolicy.test.ts
+++ b/tests/unit/uncaughtExceptionPolicy.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Verifies the uncaught-exception recoverability policy (#43). The server's
+ * process-level uncaughtException handler crashes by default; this policy is the
+ * allowlist of isolated, recoverable errors it should log-and-continue on
+ * instead of closing its databases and exiting. Both sides of the boundary are
+ * tested with realistic messages.
+ */
+import { describe, it, expect } from 'vitest';
+import { isNonFatalUncaught } from '../../src/core/uncaughtExceptionPolicy.js';
+
+describe('isNonFatalUncaught', () => {
+  it('treats the Slack Socket Mode reconnect race as recoverable (#43 — must not crash the agent)', () => {
+    expect(isNonFatalUncaught(new Error('Sent before connected.'))).toBe(true);
+    // Substring match — the WS layer may decorate the message.
+    expect(isNonFatalUncaught(new Error('WebSocket error: Sent before connected'))).toBe(true);
+  });
+
+  it('treats the existing HTTP double-response races as recoverable (precedent unchanged)', () => {
+    expect(isNonFatalUncaught(new Error('Cannot set headers after they are sent to the client'))).toBe(true);
+    expect(isNonFatalUncaught(new Error('write after end'))).toBe(true);
+    expect(isNonFatalUncaught(new Error('ERR_HTTP_HEADERS_SENT'))).toBe(true);
+    expect(isNonFatalUncaught(new Error('ERR_STREAM_WRITE_AFTER_END'))).toBe(true);
+  });
+
+  it('treats an UNKNOWN error as fatal (crash is the safe default)', () => {
+    expect(isNonFatalUncaught(new Error('mutex lock failed'))).toBe(false);
+    expect(isNonFatalUncaught(new Error('Cannot read properties of undefined'))).toBe(false);
+    expect(isNonFatalUncaught(new Error('better-sqlite3 database is closed'))).toBe(false);
+  });
+
+  it('is robust to non-Error inputs', () => {
+    expect(isNonFatalUncaught(undefined)).toBe(false);
+    expect(isNonFatalUncaught(null)).toBe(false);
+    expect(isNonFatalUncaught('Sent before connected')).toBe(true); // string with a known pattern
+    expect(isNonFatalUncaught({})).toBe(false);
+    expect(isNonFatalUncaught(new Error(''))).toBe(false); // empty message → not matched
+  });
+});

--- a/upgrades/next/slack-reconnect-crash-guard.md
+++ b/upgrades/next/slack-reconnect-crash-guard.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+
+## What Changed — A Slack reconnect after sleep/wake can no longer crash the whole agent
+
+Agents that use Slack keep a live connection open, and reconnect it whenever the machine sleeps and wakes. A timing race during that reconnect could throw an error from deep inside the Slack connection (trying to acknowledge a message a split-second before the line was fully open). Because that error happened in a background handler, it bubbled all the way up and crashed the entire agent — closing its databases and dropping in-flight work — just because one Slack acknowledgement couldn't be sent. For a laptop agent that sleeps and wakes constantly, that was a recurring-outage risk.
+
+Now there are two safety nets: the agent checks the connection is actually open before sending the acknowledgement (and Slack re-delivers anything it didn't hear back on, so nothing is lost), and the kind of isolated, self-healing Slack reconnect hiccup that caused the crash is now treated as recoverable — logged and shrugged off — instead of taking the whole agent down. Genuinely serious errors still crash-and-restart as before.
+
+## Summary of New Capabilities
+
+- The Slack Socket Mode client guards its event acknowledgement on the socket being open (with a try/catch), so a mid-reconnect send can't throw. The process-level crash handler's recoverable-error allowlist was extracted into a small testable module and now also covers the Slack reconnect race, so an isolated Slack WebSocket hiccup never crashes the agent or closes its databases.
+
+## What to Tell Your User
+
+If you run a Slack-connected agent on a laptop, it won't get knocked offline by a sleep/wake reconnect glitch anymore. A brief Slack hiccup is now logged and recovered from instead of crashing the whole agent, and any Slack message involved is re-delivered, so nothing is lost.
+
+## Evidence
+
+- Found in the agent's own server log: a FATAL uncaught "Sent before connected" crash right after a sleep/wake Slack reconnect, closing the databases.
+- Root traced to an unguarded WebSocket acknowledgement send in the Slack client (it checked the socket existed but not that it was open, and wasn't in a try/catch), throwing in an async handler that escaped the reconnect's error handling.
+- Unit tests: the recoverable-error policy treats the Slack race + the existing HTTP races as recoverable and unknown/serious errors (mutex, sqlite-closed) as fatal; source assertions confirm the ack is guarded and the handler routes through the policy. Slack reconnect + heartbeat suites stay green. Independent adversarial review confirmed the extraction is behavior-preserving and the new suppression is safe.

--- a/upgrades/side-effects/slack-reconnect-crash-guard.md
+++ b/upgrades/side-effects/slack-reconnect-crash-guard.md
@@ -1,0 +1,40 @@
+# Side-effects — Slack reconnect crash guard
+
+## 1. What files/state does this touch at runtime?
+`SocketModeClient.ts` (the event-ack send), `server.ts` (the process uncaughtException handler), and a
+new `src/core/uncaughtExceptionPolicy.ts`. No new state, config, or schema.
+
+## 2. Does it change any functional behavior?
+- The Slack event ack is now skipped when the socket isn't OPEN (instead of throwing). Slack
+  redelivers the unacked event, so no event is lost; event processing is unchanged.
+- The process uncaughtException handler now suppresses (logs + continues) one additional error class —
+  the Slack WS reconnect race ("Sent before connected") — instead of crashing. All other errors,
+  including the existing HTTP-race allowlist, are handled exactly as before.
+
+## 3. What happens on failure / weird config?
+The ack guard is a pure readyState check + try/catch — it can't fail destructively (worst case: an
+ack is skipped and Slack redelivers). `isNonFatalUncaught` returns false for anything unrecognized, so
+an unknown error still triggers the FATAL crash-and-restart (the safe default).
+
+## 4. Migration parity — do existing agents get it?
+Yes, via the normal release — code-only, compiled into `dist`. No agent-installed file / config /
+template change → no `PostUpdateMigrator` pass.
+
+## 5. Could it spam / flood / burn resources?
+No. It removes a crash (and its restart cost). The only new log is a `[WARN]` when an ack is skipped
+mid-reconnect (rare) or a recoverable uncaught is suppressed (rare). No new timers/IO/network.
+
+## 6. Rollback / off-switch?
+Revert the 3 files (re-inline the allowlist in server.ts, drop the new module, restore the unguarded
+ack). No data, no migration, no flag.
+
+## 7. Concurrency / ordering?
+The ack guard adds a readyState check + try/catch around an existing synchronous send; the try/catch
+also covers the (rare) TOCTOU where the socket changes state between the check and the send. No new
+concurrency.
+
+## Blast radius
+Small + defensive. One guarded send in `SocketModeClient`, one extracted+extended allowlist used by
+the process crash handler. The extraction is behavior-preserving for the existing patterns
+(adversarially verified); the only behavioral change is that an isolated Slack WS reconnect race no
+longer crashes the whole agent.


### PR DESCRIPTION
## What & why

Found via the autonomous mandate's "watch my own operation" task — Echo's own `server.log` had a `[FATAL] Uncaught exception — closing databases before crash: Sent before connected.` right after a sleep/wake Slack reconnect. A Slack Socket-Mode event-ack send fired on a still-connecting socket and threw; the throw was in an async message handler, so it escaped `SlackAdapter.reconnect()`'s try/catch and reached the process-level uncaughtException handler, which **crashes the whole agent** (closes its SQLite databases). For a laptop agent that sleeps/wakes constantly, a recurring-outage risk.

## The fix (two layers)

1. **Root** — `SocketModeClient` acked every event with `this.ws?.send()`, checking `ws` non-null but NOT `readyState === OPEN`, and not try/caught (unlike `queueOutbound` and the liveness probe). Guard it: `readyState === OPEN` + try/catch. If the ack is skipped (mid-reconnect), Slack redelivers the unacked event; event processing (after the ack) is unchanged.
2. **Safety net** — the process uncaughtException handler already suppresses an allowlist of isolated, recoverable errors (HTTP double-response races). Extract it into a testable `src/core/uncaughtExceptionPolicy.ts` (`isNonFatalUncaught`) and add `'Sent before connected'`: an isolated Slack WS reconnect race (the client self-reconnects with backoff; Slack redelivers) must never crash the whole agent. The FATAL path for unknown errors is unchanged.

## Safety
- The extraction is **behavior-preserving** for the existing patterns (same 4 strings, same `includes()` semantics, FATAL path intact) — adversarially verified. The only behavioral change is the intended new suppression.
- `'Sent before connected'` is specific to the Slack WS race (not present elsewhere in src), genuinely recoverable, and cannot mask a real fatal (mutex/sqlite/etc. still crash) — tested both sides.

## Tests
- Unit (`uncaughtExceptionPolicy.test.ts`): Slack race + HTTP races → recoverable; mutex/sqlite/undefined → fatal; non-Error inputs robust.
- Source-assertion (`slack-socket-reconnect.test.ts`, the file's style): ack is OPEN-guarded + try/caught; the handler routes through `isNonFatalUncaught`. (A behavioral test driving the ack path is a noted optional hardening; the higher-risk policy extraction has full behavioral coverage.)
- Slack reconnect + heartbeat suites green. **Independent adversarial review: SHIP** (extraction behavior-preserving, suppression safe, FATAL path intact, ack guard correct).

Self-approved under the 12h autonomous deploy mandate (flagged for review). Spec: `docs/specs/slack-reconnect-crash-guard.md` (+ `.eli16.md`); side-effects + fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
