### PR TITLE
fix(multi-machine): router confirms remote placement (placing→active) — bug #11

### DIFF
--- a/docs/specs/router-confirm-claim-on-place.eli16.md
+++ b/docs/specs/router-confirm-claim-on-place.eli16.md
@@ -1,0 +1,42 @@
+# Confirm the move so it doesn't get stuck — explain it like I'm 16
+
+When you move a conversation from the laptop to the Mac mini, the system tracks who
+"owns" that conversation using a little state machine. The handoff is supposed to go
+in two steps:
+
+1. **place** — the laptop says "this conversation is being assigned to the mini." The
+   status becomes "placing" (in progress).
+2. **claim** — the new owner confirms "yes, I've got it now." The status becomes
+   "active" (done).
+
+The bug: step 1 happened, but step 2 NEVER did. The laptop assigned the conversation
+to the mini (status "placing") and sent it the message to start up — but nobody ever
+flipped the status to "active." So the conversation got stuck in "placing" limbo
+forever.
+
+Why does that break things? Because the router (the laptop) has a rule: "if a
+conversation's status is 'placing' or 'transferring' (i.e. mid-handoff), don't send it
+anywhere yet — just hold the message." That rule is correct for a brief moment during a
+handoff. But since the status never advanced past "placing," EVERY later message you
+sent just got held and then quietly handled back on the laptop. The move looked like it
+silently failed.
+
+The fix is small: right after the laptop tells the mini to start the conversation, the
+laptop also marks the conversation "active" (the confirm step that was missing). It's
+allowed to do this because the state machine only lets you confirm a conversation for
+the machine it was just assigned to — which is exactly the mini. So the laptop confirms
+"the mini owns this now, active," and from then on it correctly forwards your messages
+to the mini instead of holding them.
+
+I only do this confirm for a REMOTE move (to the mini). If the router decides to keep a
+conversation on itself, there's no remote handoff to confirm — it just handles it
+locally, same as always. I added tests for both: a remote placement now triggers the
+confirm with the right machine, and a keep-it-local placement does not.
+
+One honest caveat about scope: this makes the live move WORK, but it doesn't yet make
+ownership survive a restart — the ownership record currently lives only in memory on
+each machine (a shared, durable store across machines is a separate, bigger piece that
+was planned but not built). And separately, even with the move now finalizing, the mini
+still can't send replies back to you yet (it has no messaging token) — that's the next
+and final rung. So this clears the "the move silently sticks" wall; the remaining work
+is durability hardening and the reply path.

--- a/docs/specs/router-confirm-claim-on-place.md
+++ b/docs/specs/router-confirm-claim-on-place.md
@@ -1,0 +1,81 @@
+---
+title: Router confirms a remote placement (placing → active) so transfers don't stick
+slug: router-confirm-claim-on-place
+status: approved
+review-convergence: 2026-05-31T12:10:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h deploy mandate (topic 13481).
+  Bug #11 of the multi-machine live-transfer cascade, found live: a moved session's
+  ownership never left 'placing', so the laptop queued every later message instead
+  of forwarding to the mini. Scoped to the single-router topology; the cross-machine
+  durable ownership store (Track-H) is separate hardening. Flagged in the PR per
+  cross-agent discipline.
+---
+
+# Router confirms a remote placement (placing → active)
+
+## Problem
+
+Found live (2026-05-31): with bugs #4/#5/#6/#8/#9/#10 fixed, "move this to the Mac
+mini" forwards, the mini accepts + spawns + persists the session. But subsequent
+messages for that topic logged `route … action=queued owner=?` and fell through to
+local injection — the conversation never actually moved.
+
+Root, traced through the ownership FSM (`SessionOwnership.ts`): a new-session
+placement is `place` (→ status `placing`) then the owner must `claim` (→ `active`).
+`SessionRouter.placeAndClaim` does the `place` and dispatches the spawn, but NOTHING
+ever issues the `claim`. So the record stays `placing` forever, and
+`SessionRouter.dispatchOne` routes a `placing`/`transferring` record to the
+queue-and-return branch → every later message queues. This affects EVERY transfer,
+not just a crashed one.
+
+(The owner-side resume runs on the target machine, and the live ownership store is
+per-machine in-memory — the shared cross-machine store is the separate, unbuilt
+"Track-H" piece — so the target cannot itself advance the router's authoritative
+record. In the single-router topology the router holds that record.)
+
+## Goal
+
+After the router places a session on a remote machine and dispatches the spawn, the
+ownership record advances `placing → active` so the router forwards subsequent
+messages to the new owner instead of queueing them forever.
+
+## Non-goals
+
+- Does NOT wire the shared cross-machine durable ownership store (Track-H) — ownership
+  is still per-machine in-memory and non-durable across restarts. That is separate
+  hardening; this makes the live single-router transfer FUNCTION.
+- Does NOT change self-placement (router == owner → handled locally, no remote claim).
+- Does NOT address bug #7 (the standby has no Telegram token → a running moved session
+  is still mute).
+
+## Design
+
+`SessionRouter` gains an optional `confirmClaim(sessionKey, machineId)` dep. In
+`placeAndClaim`, immediately after a successful `spawnOnMachine(remote)` (and only on
+the remote branch — self-placement returns handled-locally and never confirms), the
+router calls `confirmClaim(sessionKey, chosenMachine)`.
+
+`server.ts` wires it to `ownReg.cas({ type: 'claim', machineId }, …)`. The FSM permits
+a `claim` whose `machineId` equals the placed owner (the `place` set
+`ownerMachineId = chosenMachine`), so the router legitimately confirms on the target's
+behalf. Best-effort: a confirm failure leaves the placement to recover via the normal
+owner-dead/stale fences.
+
+## Testing
+
+- Tier 1 (`SessionRouter.test.ts`): a remote placement now calls
+  `confirmClaim('s1','m_remote')` after the spawn; a self-placement does NOT confirm.
+  The FSM `place(placing) → claim(active)` transition is already covered in
+  `SessionOwnership.test.ts`.
+- 47 SessionRouter + ownership + wiring tests green; `tsc --noEmit` clean.
+- Tier-3: the live re-test (fresh topic — avoids the prior stuck record) shows
+  subsequent messages forward to the mini instead of queueing.
+
+## Migration parity
+
+Pure code (one optional dep + a call + the wiring). No config/hook/route/CLAUDE.md
+change. The dep is optional → callers that don't wire it are unaffected; the pool path
+is gated past `'dark'`. Existing agents get it on the v-next update.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9397,6 +9397,14 @@ export async function startServer(options: StartOptions): Promise<void> {
               const r = ownReg.cas({ type: 'place', machineId }, { sessionKey: sk, sender: meshSelfId, nonce: `${meshSelfId}:c:${++routerNonce}` });
               return { ok: r.ok, epoch: ownReg.read(sk)?.ownershipEpoch ?? 0 };
             },
+            // bug #11: confirm the remote owner (placing → active) after the spawn is
+            // dispatched. The router holds the authoritative ownReg (single-router
+            // topology); the FSM permits a claim whose machineId equals the placed
+            // owner, so the router confirms on the target's behalf. Without this the
+            // record stays 'placing' and every later message for the session queues.
+            confirmClaim: (sk, machineId) => {
+              ownReg.cas({ type: 'claim', machineId }, { sessionKey: sk, sender: meshSelfId, nonce: `${meshSelfId}:cl:${++routerNonce}` });
+            },
             deliverMessage: async (target, env) => {
               const url = peerUrl(target);
               if (!url) throw new Error(`no peer url for ${target}`);

--- a/src/core/SessionRouter.ts
+++ b/src/core/SessionRouter.ts
@@ -112,6 +112,16 @@ export interface SessionRouterDeps {
   handleLocally: (msg: InboundMessage) => Promise<void>;
   /** Instruct the chosen machine to spawn/resume the session. */
   spawnOnMachine: (machineId: string, msg: InboundMessage) => Promise<void>;
+  /**
+   * Confirm a just-placed REMOTE session as the owner (status placing→active) once
+   * the spawn has been dispatched to it. Without this the ownership stays 'placing'
+   * forever and every later message for the session queues (bug #11). Best-effort —
+   * a confirm failure leaves the placement to recover via the normal fences.
+   * (The owner-side resume runs on the target; in the single-router topology the
+   * router holds the authoritative ownReg, so it confirms on the target's behalf —
+   * the FSM only permits a claim whose machineId equals the placed owner.)
+   */
+  confirmClaim?: (sessionKey: string, machineId: string) => void;
   queueMessage: (msg: InboundMessage, reason: string) => void;
   raiseAttention: (title: string, body: string) => void;
   markOwnerSuspect?: (machineId: string) => void;
@@ -250,6 +260,10 @@ export class SessionRouter {
       return { action: fromDead ? 'owner-dead-replaced' : 'handled-locally', owner: decision.chosenMachine, detail: 'placed-self', acked: true };
     }
     await this.deps.spawnOnMachine(decision.chosenMachine, msg);
+    // Confirm the remote owner (placing → active). The 'place' above left the record
+    // transient; without this the session is owned-but-never-active and every later
+    // message routes to the placing/transferring branch → queued forever (bug #11).
+    this.deps.confirmClaim?.(msg.sessionKey, decision.chosenMachine);
     return { action, owner: decision.chosenMachine, acked: true };
   }
 }

--- a/tests/unit/SessionRouter.test.ts
+++ b/tests/unit/SessionRouter.test.ts
@@ -131,19 +131,24 @@ describe('SessionRouter.dispatch (§L4)', () => {
     expect(deps.queueMessage).toHaveBeenCalledWith(expect.anything(), 'ownership-contention');
   });
 
-  it('unowned → place → CAS won → spawn on the chosen remote machine', async () => {
+  it('unowned → place → CAS won → spawn on the chosen remote machine + CONFIRM the owner (placing→active, bug #11)', async () => {
     const spawn = vi.fn(async () => {});
-    const { router } = makeRouter({ spawnOnMachine: spawn }, [cap(SELF, { loadAvg: 9 }), cap('m_remote', { loadAvg: 0 })]);
+    const confirmClaim = vi.fn();
+    const { router } = makeRouter({ spawnOnMachine: spawn, confirmClaim }, [cap(SELF, { loadAvg: 9 }), cap('m_remote', { loadAvg: 0 })]);
     const out = await router.route(msg());
     expect(out).toMatchObject({ action: 'spawned', owner: 'm_remote', acked: true });
     expect(spawn).toHaveBeenCalledWith('m_remote', expect.objectContaining({ sessionKey: 's1' }));
+    // bug #11: without this confirm the record stays 'placing' and later messages queue forever.
+    expect(confirmClaim).toHaveBeenCalledWith('s1', 'm_remote');
   });
 
-  it('unowned → place chooses SELF → handled locally', async () => {
-    const { router, deps } = makeRouter({}, [cap(SELF, { loadAvg: 0 }), cap('m_remote', { loadAvg: 9 })]);
+  it('unowned → place chooses SELF → handled locally, NO remote confirm', async () => {
+    const confirmClaim = vi.fn();
+    const { router, deps } = makeRouter({ confirmClaim }, [cap(SELF, { loadAvg: 0 }), cap('m_remote', { loadAvg: 9 })]);
     const out = await router.route(msg());
     expect(out).toMatchObject({ action: 'handled-locally', owner: SELF, acked: true });
     expect(deps.handleLocally).toHaveBeenCalledOnce();
+    expect(confirmClaim).not.toHaveBeenCalled(); // self-placement handles locally; no placing→active confirm
   });
 
   it('unowned → corrupt topic metadata → placement-blocked, attention raised, NOT acked', async () => {

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,52 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13481; multi-machine live-transfer cascade)
+---
+
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — a moved conversation now finishes its handoff instead of getting stuck
+
+Another step toward the multi-machine "move this conversation to my other machine"
+feature. The handoff tracks ownership in two steps: the router assigns the conversation
+to the target machine (status "placing"), then the new owner is confirmed (status
+"active"). The confirm step was never being issued, so a moved conversation stayed in
+"placing" limbo forever — and the router's rule of "hold messages while a handoff is in
+progress" then held every later message, so the move silently failed.
+
+This release has the router issue the confirm right after it hands the conversation to
+the target machine, advancing ownership to "active". From then on the router correctly
+forwards your messages to the new owner. The state machine only allows confirming the
+exact machine the conversation was just assigned to, so this stays safe.
+
+## Summary of New Capabilities
+
+- `SessionRouter` gains an optional `confirmClaim(sessionKey, machineId)` dep, invoked
+  after a successful remote `spawnOnMachine`, advancing the ownership record
+  `placing → active`. Self-placement (router keeps it) does not confirm.
+- Wired in the server to the ownership-registry `claim` CAS.
+
+## What to Tell Your User
+
+If you run your agent on more than one machine and move a conversation between them, the
+move now actually sticks — the receiving machine is confirmed as the new owner and your
+following messages route to it, instead of the move quietly failing. This only applies
+when the multi-machine session pool is on; single-machine agents are unaffected. Nothing
+to configure. (Two related pieces are still in progress: ownership surviving a restart,
+and the moved conversation being able to reply — tracked separately.)
+
+## Evidence
+
+- Found live on 2026-05-31: after a move, every later message logged
+  "route … action=queued owner=?" and was handled back on the origin — the ownership
+  state machine requires place→claim→active and the claim was never issued, so the
+  record stayed "placing".
+- Unit, `tests/unit/SessionRouter.test.ts`: a remote placement now confirms the owner
+  (placing→active); a self-placement does not.
+- Unit, `tests/unit/SessionOwnership.test.ts`: the place→claim→active transition.
+- 47 SessionRouter + ownership + wiring tests pass; tsc --noEmit clean.
+- Spec, `docs/specs/router-confirm-claim-on-place.md` plus the .eli16.md sibling.
+- Side-effects, `upgrades/side-effects/router-confirm-claim-on-place.md`.

--- a/upgrades/side-effects/router-confirm-claim-on-place.md
+++ b/upgrades/side-effects/router-confirm-claim-on-place.md
@@ -1,0 +1,96 @@
+# Side-Effects Review — Router confirms remote placement (bug #11)
+
+**Version / slug:** `router-confirm-claim-on-place`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`SessionRouter` gains an optional `confirmClaim(sessionKey, machineId)` dep, called in
+`placeAndClaim` right after a successful `spawnOnMachine` on a REMOTE target. `server.ts`
+wires it to `ownReg.cas({ type: 'claim', machineId }, …)`, advancing the ownership
+record `placing → active`. Without it the record stayed `placing` and every later
+message for the session queued (bug #11).
+
+## Decision-point inventory
+
+- **remote branch only** — `confirmClaim` is called only in `placeAndClaim`'s
+  remote-spawn path (after `spawnOnMachine`). Self-placement returns handled-locally
+  and never confirms. Both covered by tests.
+- **FSM gate** — `claim` is permitted only when the record's `ownerMachineId` equals the
+  claimed `machineId` (the placed owner). Covered in `SessionOwnership.test.ts`.
+
+## 1. Over-block
+
+**What legitimate inputs does this reject?** Nothing. It only ADDS a confirm after a
+remote placement. Self-placement, forwarding to an existing owner, owner-dead
+re-placement, and queue paths are unchanged. A `confirmClaim` that fails (e.g. CAS
+contention) is best-effort and leaves the placement to recover via the normal fences.
+
+## 2. Under-block
+
+**What does this still miss?** It does not make ownership durable across restarts (the
+store is per-machine in-memory — the shared Track-H store is separate). It confirms
+optimistically once the spawn is DISPATCHED (the deliverMessage/spawn RPC resolved); if
+the target's session later dies, the existing owner-dead detection re-places it. It does
+not address bug #7 (standby outbound mute).
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The confirm lives in `SessionRouter.placeAndClaim` — the exact
+place that owns the place→spawn lifecycle and already does the `place` CAS. The dep is
+injected (testable, same pattern as `casClaimOwnership`/`spawnOnMachine`). The FSM
+transition itself stays in `SessionOwnership.ts`.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+This advances an ownership record through its designed FSM (`place → claim`), gated by
+the FSM's own legal-transition check (claim machineId must equal the placed owner). It
+adds no user-facing authority and blocks nothing. It RELAXES nothing about who may own a
+session — it completes a transition that was already supposed to happen.
+
+## 5. Interactions
+
+Consumes the existing `ownReg` CAS (the same registry `place`/`transfer`/`release` use).
+Pairs with `placeAndClaim`'s `place` CAS (the two halves of a new-session handoff). After
+the confirm, `dispatchOne` sees `active` (not `placing`) and forwards subsequent messages
+to the owner instead of queueing. Idempotent at the FSM level (a duplicate claim on an
+already-active record is rejected `claim-out-of-sequence`, harmless). No interaction with
+the lease or the shared-state read-only guard.
+
+## 6. External surfaces
+
+None. No HTTP routes, config, or notifications. The visible effect is a moved session's
+ownership reaching `active` (so `/pool` + routing reflect the new owner).
+
+## 7. Rollback cost
+
+Low. Remove the `confirmClaim` dep + call + wiring; transfers revert to stuck-`placing`
+(bug #11). No schema, no persisted state, no migration (the dep is optional + in-memory).
+
+## Conclusion
+
+Minimal, FSM-gated completion of a handoff transition that was missing, scoped to the
+remote-placement branch, both branches + the FSM transition unit-tested, no new
+authority, no external surface, cheap revert. Makes the live single-router transfer's
+ownership finalize instead of sticking. Durable cross-machine ownership (Track-H) and
+the reply relay (#7) remain separate.
+
+## Second-pass review (if required)
+
+Not required — completes an existing FSM transition via its own legality gate, remote-
+branch-only, both sides tested, no shared-state authority changed, reversible. The live
+two-machine re-test (fresh topic) is the Tier-3 gate that follows.
+
+## Evidence pointers
+
+- `tests/unit/SessionRouter.test.ts` — remote placement calls `confirmClaim('s1','m_remote')`;
+  self-placement does not.
+- `tests/unit/SessionOwnership.test.ts` — `place(placing) → claim(active)` transition.
+- 47 SessionRouter + ownership + wiring tests green; `tsc --noEmit` clean.
+- Found live: `route … action=queued owner=?` on every post-move message; the ownership
+  FSM requires place→claim→active and the claim was never issued.
+- Spec: `docs/specs/router-confirm-claim-on-place.md` (+ `.eli16.md`).


### PR DESCRIPTION
## Bug #11 of the live-transfer cascade — found live

With bugs #4/#5/#6/#8/#9/#10 fixed, "move this to the Mac mini" forwards, the mini
accepts + spawns + persists the session. But every subsequent message logged
`route … action=queued owner=?` and fell through to local injection — the move silently
failed.

**Root (ownership FSM, `SessionOwnership.ts`):** a new-session placement is
`place` (→ `placing`) then the owner must `claim` (→ `active`).
`SessionRouter.placeAndClaim` does the `place` + dispatches the spawn, but **nothing ever
issues the `claim`** — so the record stays `placing` forever and `dispatchOne` routes
every later message to the queue-and-return branch. Affects *every* transfer.

(The owner-side resume runs on the target, and the live ownership store is per-machine
in-memory — the shared cross-machine store is the separate, unbuilt "Track-H" piece — so
the target can't advance the router's authoritative record. In the single-router
topology the router holds it.)

## Fix
`SessionRouter` gains an optional `confirmClaim(sessionKey, machineId)` dep, called after
a successful **remote** `spawnOnMachine` (self-placement returns handled-locally → no
confirm). `server.ts` wires it to `ownReg.cas({type:'claim', machineId})`. The FSM only
permits a `claim` whose `machineId` equals the placed owner, so the router legitimately
confirms on the target's behalf → `placing → active`.

## Tests
- `tests/unit/SessionRouter.test.ts`: a remote placement now calls `confirmClaim('s1','m_remote')`; a self-placement does not.
- `tests/unit/SessionOwnership.test.ts`: the `place(placing) → claim(active)` transition.
- 47 SessionRouter + ownership + wiring tests green; `tsc --noEmit` clean.

## Scope
Makes the live single-router transfer's ownership finalize instead of sticking. **Out of scope (separate):** the shared cross-machine durable ownership store (Track-H — ownership isn't yet restart-durable), and **bug #7** (the standby has no Telegram token → a running moved session is still mute, the true completion gate).

## Ship-gate
Spec `docs/specs/router-confirm-claim-on-place.md` (+ `.eli16.md`), self-approved under the standing 12h deploy mandate (topic 13481) — flagged here per cross-agent discipline. Side-effects + NEXT.md included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
