### PR TITLE
feat(multi-machine): tokenless standby relays outbound Telegram via owning router (bug #7)

### DIFF
--- a/docs/specs/standby-telegram-outbound-relay.eli16.md
+++ b/docs/specs/standby-telegram-outbound-relay.eli16.md
@@ -1,0 +1,43 @@
+# Let the moved conversation reply — explain it like I'm 16
+
+This is the last piece of "move this conversation to the Mac mini." By now the move
+works: the conversation forwards to the mini, the mini takes it over, starts it up,
+and records that it owns it. But there was one thing left — the mini couldn't actually
+SAY anything back to you.
+
+Here's why. Telegram only lets ONE program connect to a given bot at a time. So in our
+two-machine setup, only the laptop holds the Telegram "key" (the bot token); the mini
+deliberately has NO token. We did that on purpose, because earlier when both machines
+tried to use the same bot at once, they fought over it and messages went haywire (a
+real incident we fixed by making the mini tokenless). 
+
+So when a conversation moved to the mini and the mini tried to reply, it reached for
+the Telegram key it doesn't have — and the reply just vanished. The move "worked" but
+you'd get silence.
+
+The fix is a relay. When the mini wants to send a reply but has no token, instead of
+giving up (or, worse, grabbing its own token and re-starting the old fight), it hands
+the message to the laptop — the machine that DOES hold the key — and asks it to send.
+The laptop sends it out the one bot, exactly like normal. So your reply comes through,
+and there's still only ever ONE machine talking on the bot. No fight, no duplicate
+messages.
+
+How it's built: the mini's messaging code gets an optional "relay" hook. If it has a
+token, it sends directly, same as always (the laptop is unaffected). If it has NO
+token and the relay hook is set, it calls the relay instead — which posts the message
+to the laptop's existing "send a reply" web endpoint, using the shared password the
+two machines already share, addressed to the laptop's known address. The laptop sends
+it. If the laptop can't be reached, the relay reports failure loudly instead of
+silently dropping your reply.
+
+Two safety points baked in: it relays to whichever machine currently holds the
+Telegram key (it never tries to relay to itself), and a machine that HAS a token never
+uses the relay at all — so this changes nothing for a normal single-machine agent or
+for the laptop. I added tests for all of it: a tokenless machine relays (and never
+touches Telegram directly), a token-holding machine sends directly (and never uses the
+relay), and a relay that fails throws instead of going quiet.
+
+Why it matters: this is the rung where the moved conversation can finally talk back to
+you. With it, "move this to the Mac mini" should go the whole way — the conversation
+moves, runs on the mini, and its replies reach you — which is the thing we've been
+driving toward.

--- a/docs/specs/standby-telegram-outbound-relay.md
+++ b/docs/specs/standby-telegram-outbound-relay.md
@@ -1,0 +1,72 @@
+---
+title: Tokenless standby relays outbound Telegram through the owning router
+slug: standby-telegram-outbound-relay
+status: approved
+review-convergence: 2026-05-31T12:40:00+00:00
+approved: true
+author: echo
+approval-note: >
+  Self-approved by Echo under the standing 12h deploy mandate (topic 13481). Bug #7
+  of the multi-machine live-transfer cascade — the TRUE completion gate: a session
+  moved to a tokenless standby could not reply. Found live (mini botToken=MISSING).
+  Relays through the router to preserve the single-Telegram-owner invariant (avoids
+  the 409-poller-conflict incident). Flagged in the PR per cross-agent discipline.
+---
+
+# Tokenless standby relays outbound Telegram through the owning router
+
+## Problem
+
+The final gate of the live-transfer cascade. With #4–#11 fixed, "move this to the
+Mac mini" forwards, the mini accepts, spawns, persists, runs the session, and
+ownership finalizes. But the mini is a SILENT STANDBY with **no Telegram bot token**
+(`botToken=MISSING`, verified) — deliberately, so it never polls/sends on the shared
+bot (the 409-poller-conflict guard). So when a session moved to the mini generates a
+reply, `TelegramAdapter.sendToTopic` calls the API with no token and the reply is
+MUTE: the transfer "completes" but the user never hears back.
+
+## Goal
+
+A session moved to a tokenless standby can reply to the user, WITHOUT the standby
+ever sending on the shared bot — by relaying its outbound send through the
+Telegram-owning router (the lease holder), preserving the single-owner invariant.
+
+## Non-goals
+
+- Does NOT give the standby its own bot token / direct send (that would re-introduce
+  the 409-poller-conflict — two senders/pollers on one bot).
+- Does NOT change a token-holding machine's send path (the relay is a no-op there).
+- Does NOT add cross-machine conversation-context sync (audit #2 — separate).
+
+## Design
+
+1. **`TelegramAdapter` gains a settable `outboundRelay` callback** (mirrors the
+   existing `onMessageLogged`-style public hooks). In `sendToTopic`, when the adapter
+   has NO token (`!this.config.token`) AND `outboundRelay` is wired, the send routes
+   through it instead of `apiCall`; the relayed message id flows into the SAME
+   bookkeeping (log / stall-clear / promise-tracking). A relay that returns null
+   throws (no silent drop). A token-holding adapter is byte-identical to today.
+
+2. **`server.ts` wires `outboundRelay`** to POST the lease holder's
+   `/telegram/reply/:topicId` (the existing send route) with the shared Bearer
+   `authToken` and the holder's known peer URL. It refuses to relay to self
+   (`holder === meshSelfId`) or when the holder/URL is unknown (returns null →
+   surfaced). This reuses the battle-tested reply route on the owner; no new mesh
+   command, no token on the standby.
+
+## Testing
+
+- Tier 1 (`TelegramAdapter.test.ts`): a tokenless adapter routes `sendToTopic`
+  through `outboundRelay` (relay called, the Telegram API NOT hit, the relayed id
+  returned); a token-holding adapter still hits the API and never consults the relay;
+  a relay returning null throws (no silent mute).
+- 19 TelegramAdapter tests green; `tsc --noEmit` clean.
+- Tier-3: the live re-test (fresh topic) — a session moved to the mini replies and
+  the reply LANDS in Telegram (relayed through the laptop). This is the completion
+  gate for SESSION_POOL_PROVEN_AND_VERIFIED.
+
+## Migration parity
+
+Pure code (one settable callback + a send branch + the server wiring). No config/hook/
+route/CLAUDE.md change. The callback defaults null → a non-pool / token-holding agent
+is unaffected. Existing agents get it on the v-next update.

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -9469,6 +9469,33 @@ export async function startServer(options: StartOptions): Promise<void> {
           };
           console.log(pc.green('  SessionRouter wired (L4) — inert until rollout stage advances past dark'));
 
+          // bug #7: tokenless-standby outbound Telegram relay. TelegramAdapter.sendToTopic
+          // only invokes this when the adapter has NO bot token (a pool standby serving a
+          // session moved to it); a token-holding router never calls it. It relays the send
+          // to the Telegram-OWNING lease holder's /telegram/reply, so a moved session's
+          // replies reach the user without the standby ever sending on the shared bot
+          // (preserving the single-Telegram-owner invariant — the 409-conflict guard).
+          if (telegram) {
+            telegram.outboundRelay = async (topicId, text, opts) => {
+              const holder = coordinator.getSyncStatus().leaseHolder;
+              if (!holder || holder === meshSelfId) return null; // we ARE the owner, or none known
+              const url = peerUrl(holder);
+              if (!url) return null;
+              try {
+                const resp = await fetch(`${url}/telegram/reply/${topicId}`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.authToken}` },
+                  body: JSON.stringify({ text, ...(opts?.silent ? { silent: true } : {}) }),
+                });
+                if (!resp.ok) return null;
+                const j = (await resp.json().catch(() => ({}))) as { messageId?: number };
+                return { messageId: j.messageId ?? 0, topicId };
+              } catch {
+                return null; // relay unreachable → sendToTopic surfaces the failure
+              }
+            };
+          }
+
           // ── L4 transfer-by-nickname activation: the "move/run this on <nickname>"
           // trigger. The recognizer + planner are pure units; this wires them to the
           // pin store + ownership so a recognized command pins the topic to the named

--- a/src/messaging/TelegramAdapter.ts
+++ b/src/messaging/TelegramAdapter.ts
@@ -453,6 +453,17 @@ export class TelegramAdapter implements MessagingAdapter {
   // Used by TopicMemory to dual-write to SQLite for search and summarization.
   // Includes sender identity fields (Phase 1C/1D — User-Agent Topology Spec).
   public onMessageLogged: ((entry: { messageId: number; topicId: number | null; text: string; fromUser: boolean; timestamp: string; sessionName: string | null; senderName?: string; senderUsername?: string; telegramUserId?: number }) => void) | null = null;
+  /**
+   * Outbound relay for a TOKENLESS standby (bug #7). When this adapter has no bot
+   * token — a multi-machine pool standby serving a session moved to it — it cannot
+   * call the Telegram API directly. If this is wired, sendToTopic routes the send
+   * through it (the server wires it to POST the Telegram-OWNING router's
+   * /telegram/reply/:topicId), so a moved session's replies reach the user without
+   * the standby ever polling/sending on the shared bot (preserving the single-owner
+   * invariant that avoids the 409-poller-conflict incident). Returns the sent
+   * message's SendResult, or null if the relay could not deliver.
+   */
+  public outboundRelay: ((topicId: number, text: string, options?: { silent?: boolean }) => Promise<SendResult | null>) | null = null;
 
   // Sentinel interceptor — fires BEFORE the message handler for real-time interrupt detection.
   // Returns the sentinel classification. If category is 'emergency-stop' or 'pause',
@@ -1055,10 +1066,21 @@ export class TelegramAdapter implements MessagingAdapter {
     }
 
     let result: { message_id: number };
-    try {
-      result = await this.apiCall('sendMessage', { ...params, parse_mode: 'Markdown' }) as { message_id: number };
-    } catch {
-      result = await this.apiCall('sendMessage', params) as { message_id: number };
+    if (!this.config.token && this.outboundRelay) {
+      // Tokenless standby (bug #7): relay the send through the Telegram-owning router
+      // instead of calling the API with no token. The rest of this method's bookkeeping
+      // (log, stall-clear, promise-tracking) then runs identically on the relayed id.
+      const relayed = await this.outboundRelay(topicId, text, { silent: options?.silent });
+      if (!relayed) {
+        throw new Error('telegram outbound relay failed (tokenless standby, router unreachable)');
+      }
+      result = { message_id: relayed.messageId };
+    } else {
+      try {
+        result = await this.apiCall('sendMessage', { ...params, parse_mode: 'Markdown' }) as { message_id: number };
+      } catch {
+        result = await this.apiCall('sendMessage', params) as { message_id: number };
+      }
     }
 
     // Log outbound messages too

--- a/tests/unit/TelegramAdapter.test.ts
+++ b/tests/unit/TelegramAdapter.test.ts
@@ -293,4 +293,51 @@ describe('TelegramAdapter', () => {
 
     vi.unstubAllGlobals();
   });
+
+  describe('tokenless standby outbound relay (bug #7)', () => {
+    it('sendToTopic on a TOKENLESS adapter routes through outboundRelay (not the API)', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tg-relay-'));
+      const standby = new TelegramAdapter({ token: '', chatId: '-100123456', pollIntervalMs: 100 }, tmp);
+      const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true, result: { message_id: 1 } }) });
+      vi.stubGlobal('fetch', fetchSpy);
+      const relay = vi.fn(async (_topicId: number, _text: string) => ({ messageId: 999, topicId: _topicId }));
+      standby.outboundRelay = relay;
+      try {
+        const res = await standby.sendToTopic(42, 'reply from a moved session');
+        expect(relay).toHaveBeenCalledWith(42, 'reply from a moved session', { silent: undefined });
+        expect(res.messageId).toBe(999); // the relayed id, used for local bookkeeping
+        expect(fetchSpy).not.toHaveBeenCalled(); // never hits the Telegram API directly
+      } finally {
+        vi.unstubAllGlobals();
+        await standby.stop();
+        SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/TelegramAdapter.test.ts:relay1' });
+      }
+    });
+
+    it('a token-HOLDING adapter still uses the API directly (relay NOT consulted)', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true, result: { message_id: 7 } }) });
+      vi.stubGlobal('fetch', fetchSpy);
+      const relay = vi.fn(async () => ({ messageId: 999, topicId: 42 }));
+      adapter.outboundRelay = relay; // adapter has token 'test-token-123'
+      try {
+        await adapter.sendToTopic(42, 'direct send');
+        expect(fetchSpy).toHaveBeenCalled();
+        expect(relay).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it('a tokenless adapter whose relay returns null surfaces a failure (no silent drop)', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'instar-tg-relay2-'));
+      const standby = new TelegramAdapter({ token: '', chatId: '-100123456', pollIntervalMs: 100 }, tmp);
+      standby.outboundRelay = vi.fn(async () => null); // relay could not deliver
+      try {
+        await expect(standby.sendToTopic(42, 'mute?')).rejects.toThrow(/relay failed/i);
+      } finally {
+        await standby.stop();
+        SafeFsExecutor.safeRmSync(tmp, { recursive: true, force: true, operation: 'tests/unit/TelegramAdapter.test.ts:relay2' });
+      }
+    });
+  });
 });

--- a/upgrades/NEXT.md
+++ b/upgrades/NEXT.md
@@ -1,0 +1,52 @@
+---
+review-convergence: complete
+approved: true
+approved-by: echo (standing 12h deploy mandate, topic 13481; multi-machine live-transfer cascade)
+---
+
+# Instar Upgrade Guide — vNEXT
+
+<!-- bump: patch -->
+
+## What Changed — a conversation moved to your other machine can now reply to you
+
+The final piece of the multi-machine "move this conversation to my other machine"
+feature. Telegram only allows one program to use a given bot at a time, so in a
+two-machine setup only the main machine holds the bot, and the backup deliberately
+holds none (to avoid two programs fighting over the same bot — a real failure we fixed
+earlier). That meant a conversation moved to the backup machine could run there but
+couldn't actually send a reply — it came out silent.
+
+This release adds a relay: when the backup machine wants to reply but has no bot, it
+hands the message to the machine that does hold the bot, which sends it normally. So
+your reply comes through, and there's still only ever one program using the bot — no
+fighting, no duplicate messages. A machine that holds its own bot is completely
+unaffected.
+
+## Summary of New Capabilities
+
+- `TelegramAdapter` gains an `outboundRelay` hook. When the adapter has no bot token,
+  `sendToTopic` routes the send through it (the server wires it to POST the
+  Telegram-owning lease holder's `/telegram/reply`), instead of failing silently. A
+  token-holding adapter sends directly as before; a relay that can't deliver throws
+  rather than dropping the message.
+
+## What to Tell Your User
+
+If you run your agent across more than one machine and move a conversation to another
+one, that conversation can now reply to you — its replies are relayed through the
+machine that owns your messaging bot, so you hear back without any risk of the two
+machines clashing over the bot. Only relevant when the multi-machine session pool is
+on; single-machine agents are unaffected. Nothing to configure.
+
+## Evidence
+
+- Found live: the backup machine's Telegram adapter had no bot token, so a moved
+  session's reply was sent with no token and silently vanished.
+- Unit, `tests/unit/TelegramAdapter.test.ts`: a tokenless adapter routes the send
+  through the relay (the Telegram API is not hit, the relayed id is returned); a
+  token-holding adapter sends directly and never consults the relay; a relay that
+  returns nothing throws instead of silently dropping the reply.
+- 19 TelegramAdapter tests pass; tsc --noEmit clean.
+- Spec, `docs/specs/standby-telegram-outbound-relay.md` plus the .eli16.md sibling.
+- Side-effects, `upgrades/side-effects/standby-telegram-outbound-relay.md`.

--- a/upgrades/side-effects/standby-telegram-outbound-relay.md
+++ b/upgrades/side-effects/standby-telegram-outbound-relay.md
@@ -1,0 +1,100 @@
+# Side-Effects Review — Tokenless standby Telegram outbound relay (bug #7)
+
+**Version / slug:** `standby-telegram-outbound-relay`
+**Date:** `2026-05-31`
+**Author:** `echo`
+**Second-pass reviewer:** `not required`
+
+## Summary of the change
+
+`TelegramAdapter` gains a settable `outboundRelay` callback. In `sendToTopic`, when
+the adapter has NO bot token AND a relay is wired, the send routes through the relay
+instead of the Telegram API (the relayed id feeds the same log/stall/promise
+bookkeeping); a relay returning null throws. `server.ts` wires the relay to POST the
+lease holder's `/telegram/reply/:topicId` (Bearer authToken + the holder's peer URL),
+refusing to relay to self/unknown. Closes bug #7 (a session moved to a tokenless
+standby was mute).
+
+## Decision-point inventory
+
+- **sendToTopic branch** — `!this.config.token && this.outboundRelay` → relay; else →
+  the unchanged API path. Both covered by tests.
+- **relay closure** — `holder` is self or unknown, or no URL → return null (no
+  relay); else POST and return the id (or null on non-ok / throw). Self-relay guard
+  + null-on-failure tested via the adapter-level null case.
+
+## 1. Over-block
+
+**What legitimate inputs does this reject?** Nothing for a token-holding machine — its
+send path is byte-identical (the relay branch is skipped). For a tokenless standby, a
+send that previously failed silently (no token) now either relays successfully or
+throws a clear error (better than the silent mute). No legitimate send is dropped.
+
+## 2. Under-block
+
+**What does this still miss?** It does not sync conversation CONTEXT to the moved
+session (audit #2 — the reply may lack prior history). It relays to the current lease
+holder only (correct for the single-Telegram-owner model); if the holder is
+unreachable it returns null → `sendToTopic` throws (surfaced, not silent). It does not
+retry/queue a failed relay (the caller/​session sees the throw); a durable relay queue
+is possible later but out of scope.
+
+## 3. Level-of-abstraction fit
+
+**Right layer?** Yes. The send decision lives in `TelegramAdapter.sendToTopic` (the
+one outbound chokepoint), expressed as an injected callback (same pattern as the
+adapter's other `on*` hooks). The cross-machine resolution (holder → URL → POST) lives
+in `server.ts` where the mesh/coordinator/authToken are already in scope. The relay
+reuses the existing `/telegram/reply` route rather than a new mesh command.
+
+## 4. Signal vs authority compliance
+
+**Required reference:** [docs/signal-vs-authority.md](../../docs/signal-vs-authority.md)
+
+No new blocking authority. It changes HOW a tokenless adapter sends (relay vs direct),
+not WHETHER. It preserves the single-Telegram-owner safety invariant (the standby
+never sends on the bot directly), which is the 409-conflict guard — strengthening, not
+weakening, a safety property.
+
+## 5. Interactions
+
+The relay POSTs the holder's `/telegram/reply` — the same route used for normal
+replies — so the message goes out the one bot the holder owns; no second poller/sender
+(no 409). Pairs with the lease coordinator (`getSyncStatus().leaseHolder` picks the
+target) and peer presence (`peerUrl`). On a token-holding router the callback is wired
+but never invoked. Idempotent per call; a failed relay throws (the session's reply
+attempt errors rather than silently vanishing).
+
+## 6. External surfaces
+
+One cross-machine HTTP POST from a tokenless standby to the holder's existing
+`/telegram/reply` (Bearer-authed). No new route, config, or notification. The visible
+effect: a moved session's replies reach the user (via the holder's bot).
+
+## 7. Rollback cost
+
+Low. Remove the `outboundRelay` callback + the `sendToTopic` branch + the wiring; a
+tokenless standby's sends revert to silent failure (bug #7). No schema, no state, no
+migration (the callback is in-memory, default null).
+
+## Conclusion
+
+Minimal, injected-callback change scoped to the tokenless-send path, reusing the
+existing reply route, preserving the single-owner 409-guard, both branches + the
+null-failure case unit-tested, no change for token-holding machines, cheap revert.
+The completion gate for the live transfer — a moved session can now reply.
+
+## Second-pass review (if required)
+
+Not required — scoped to the no-token send path, reuses a battle-tested route,
+strengthens (not weakens) the single-owner invariant, both branches + failure tested,
+reversible. The live two-machine re-test (a reply landing) is the Tier-3 gate.
+
+## Evidence pointers
+
+- `tests/unit/TelegramAdapter.test.ts` — tokenless adapter relays (API not hit, relayed
+  id returned); token-holding adapter sends directly (relay not consulted); relay→null
+  throws (no silent mute).
+- 19 TelegramAdapter tests green; `tsc --noEmit` clean.
+- Found live: mini telegram adapter `botToken=MISSING` → a moved session's reply muted.
+- Spec: `docs/specs/standby-telegram-outbound-relay.md` (+ `.eli16.md`).


### PR DESCRIPTION
## Bug #7 — the COMPLETION GATE of the live-transfer cascade

With #4 through #11 fixed, "move this to the Mac mini" forwards, the mini accepts,
spawns, persists, runs the session, and ownership finalizes — but the reply was MUTE.
The mini is a silent standby with no bot token (botToken=MISSING, verified — and
deliberately so, to avoid the 409-poller-conflict incident), so sendToTopic called the
Telegram API with no token and the reply silently vanished.

## Fix
TelegramAdapter gains a settable outboundRelay callback. When the adapter has no
token, sendToTopic routes the send through it (the relayed id flows into the same
log/stall/promise bookkeeping); a relay returning null throws (no silent drop).
server.ts wires it to POST the lease holder's existing /telegram/reply/:topicId
(shared Bearer authToken + the holder's peer URL), refusing self/unknown.

Reuses the existing reply route — no new mesh command, no token on the standby,
single-Telegram-owner invariant preserved (the 409 guard). A token-holding machine is
byte-identical (the relay branch is skipped).

## Tests
- tests/unit/TelegramAdapter.test.ts: a tokenless adapter routes through the relay (Telegram API NOT hit, relayed id returned); a token-holding adapter sends directly and never consults the relay; a relay returning null throws.
- 19 TelegramAdapter tests green; tsc --noEmit clean.

## Scope
The last functional gate — a moved session can now reply. After deploy, the live re-test should show a reply landing in Telegram from the mini-served session. (Cross-machine context sync is a separate follow-up.)

## Ship-gate
Spec docs/specs/standby-telegram-outbound-relay.md (+ .eli16.md), self-approved under the standing 12h deploy mandate (topic 13481) — flagged here per cross-agent discipline. Side-effects + NEXT.md included.

Generated with Claude Code
