### PR TITLE
fix(a2a): accept-boundary on /a2a/inbox role-handler hook — third path; stop false mentor-delivery timeouts (#45)

### DIFF
--- a/docs/specs/a2a-inbox-accept-boundary.eli16.md
+++ b/docs/specs/a2a-inbox-accept-boundary.eli16.md
@@ -1,0 +1,31 @@
+# /a2a/inbox accept-boundary — explained simply
+
+## The everyday version
+
+When the mentor agent sends a task to the mentee agent (on the same machine), it does it with an
+HTTP call: "here's a task." The mentee is supposed to say "got it" back. But the code on the mentee
+side was saying "got it" only AFTER it had completely finished the task — and the task is "spin up a
+whole work session and wait for it to think and reply," which takes minutes.
+
+Meanwhile the sender only waits about 10 seconds for "got it." So it gave up every time, and logged
+"delivery failed" — even though the message was actually received fine and the mentee was busy
+working on it. The mentee's real answer comes back later as a totally separate message, so the sender
+never needed to wait for the work to finish in the first place.
+
+## What we changed
+
+The mentee now says "got it" the instant it accepts the message — before doing the slow work — and
+does the work in the background. The sender gets its acknowledgement right away, stops logging false
+failures, and stops holding a connection open for 10 seconds. The answer still comes back on its own
+channel exactly as before.
+
+## Why it's safe
+
+This is the exact same fix we already shipped and proved twice this session — for the two other ways
+agents talk to each other (the co-located relay path and the cross-machine threadline path). This is
+the third and last of those paths. We checked the one piece of code that calls this door: it only
+looks at whether the response says "got it," within a 10-second window — it never depended on the
+work being done first. The message is also still marked "seen" the instant it arrives, so a duplicate
+delivery is still ignored. And if the background work errors out, it's logged quietly — it can't break
+a "got it" that already went out. We added tests proving the "got it" comes back immediately (the old
+code would have hung forever on a held task) and that a background error still leaves a clean "got it."

--- a/docs/specs/a2a-inbox-accept-boundary.md
+++ b/docs/specs/a2a-inbox-accept-boundary.md
@@ -1,0 +1,71 @@
+---
+title: Respond at the accept boundary on the /a2a/inbox role-handler hook (third accept-boundary path)
+slug: a2a-inbox-accept-boundary
+date: 2026-05-31
+author: echo
+status: approved
+review-convergence: internal-plus-adversarial-self-review-2026-05-31
+approved: true
+approved-by: Echo under the 12h autonomous deploy mandate (self-approved; flagged in PR). Found via the mandate's own-operation watch (a2a delivery to instar-codey timing out in Echo's server-stderr.log).
+approval-note: >
+  Completes the accept-boundary trilogy: #581 fixed /messages/relay-agent, #3 fixed
+  /threadline/messages/receive, this fixes the third synchronous-spawn a2a path — the /a2a/inbox
+  role-handler hook (the mentor↔mentee transport). Grounded by tracing the await chain to
+  installAgentMessageHook.ts:120 and confirming the reply flows back on a separate channel.
+second-pass-required: false
+second-pass-status: n/a-mirrors-proven-581-3-pattern-caller-contract-verified
+eli16-overview: a2a-inbox-accept-boundary.eli16.md
+---
+
+# /a2a/inbox accept-boundary (#45 — third accept-boundary path)
+
+## The bug, grounded
+
+Echo's `server-stderr.log` showed recurring `[a2a] local-inbox delivery attempt failed
+(to=instar-codey): The operation was aborted due to timeout`. Tracing it:
+
+- The SENDER (`AgentServer.deliverA2aMessage`) POSTs to the peer's `/a2a/inbox` with
+  `AbortSignal.timeout(10_000)` (`AgentServer.ts:1479`) and treats `{agentMessage:true}` as success.
+- The RECEIVER's `/a2a/inbox` route (`routes.ts:9888`) `await`s `dispatchAgentMessageHook`, which
+  `await`s the agent-message hook (`TelegramAdapter`), which — in `buildAgentMessageHook`
+  (`installAgentMessageHook.ts:120`) — did `await handler(msg, …)` before returning `{handled:true}`.
+- The registered `mentor` role handler (`AgentServer.ts:1283`) SPAWNS a mentee session and
+  bounded-waits for the reply (`sessionTimeoutMs` — minutes), then delivers its reply OUT via a
+  SEPARATE a2a message.
+
+So the `/a2a/inbox` response was held for the entire minutes-long spawn+poll, the sender's ~10s
+timeout fired, and it logged a FALSE failure — the message was in fact accepted (its id is marked
+processed) and the reply arrives on its own channel. (No duplicate spawn: the idempotency mark dedups
+any retry, and the sender doesn't re-POST locally — so the harm is the false-failure log + a wasted
+10s hold, not duplicates. The accept-boundary is still the correct fix and removes both.)
+
+## Fix
+
+`installAgentMessageHook.ts`: after validating + marking the id processed, respond `{handled:true}`
+immediately and run the role handler in the BACKGROUND (`void Promise.resolve().then(() =>
+handler(…)).catch(log)`). The handler delivers its reply on its own a2a channel; the HTTP response
+never needed it. Mirrors #581 (`/messages/relay-agent`) and #3 (`/threadline/messages/receive`).
+
+## Caller-contract safety
+- The sole consumer (`AgentServer.deliverA2aMessage`) reads only `result.agentMessage === true` (the
+  ack) within a 10s timeout — it does not depend on the handler having completed. With the fix it
+  gets the ack immediately; the reply still flows back as a separate a2a message.
+- The idempotency mark (`markProcessed`, before the handler) is unchanged, so a re-delivered id is
+  still deduped. The validation/spoof/unknown-role/idempotency early-returns are all unchanged
+  (they run before the handler).
+- A background handler rejection is caught + logged (it can't reject a response that already
+  returned). The id stays marked (same as before — a re-attempt would just re-fail).
+
+## Migration parity
+N/A — code-only (`installAgentMessageHook.ts`), compiled into `dist`; ships in the normal release. No
+agent-installed file / config / template change → no `PostUpdateMigrator` pass.
+
+## Agent Awareness
+N/A — internal a2a-ingress timing.
+
+## Test plan
+Unit (`installAgentMessageHook.test.ts`, +2): a slow (held) role handler does NOT block the response
+— `{handled:true}` returns immediately (would HANG if it still awaited), the handler runs + completes
+in the background, and the id is marked before the async handler; a background handler rejection still
+yields `{handled:true}`. The existing HANDLER-ERROR test is updated to tick before asserting the now-
+async error log. ROUTE / IDEMPOTENCY / SPOOF / UNKNOWN-ROLE cases stay green.

--- a/src/messaging/installAgentMessageHook.ts
+++ b/src/messaging/installAgentMessageHook.ts
@@ -116,15 +116,26 @@ export function buildAgentMessageHook(deps: InstallAgentMessageHookDeps): AgentM
       telegramSenderChatId: input.senderChatId,
       topicId: input.topicId,
     });
-    try {
-      await handler(msg, { topicId: input.topicId, senderBotId: input.senderBotId });
-    } catch (err) {
-      // A role-handler failure is recorded but doesn't un-mark the id (we still treat
-      // the message as processed; retrying would just re-fail). Stage-B forensics can see
-      // the routed row + the absence of a downstream effect.
-      // eslint-disable-next-line no-console
-      console.error(`[a2a] role-handler "${msg.role}" failed:`, err instanceof Error ? err.message : String(err));
-    }
+    // Accept-boundary (the #581 / #3 class — this is the THIRD a2a path): a role
+    // handler (e.g. the mentee mentor-message handler) SPAWNS a session and
+    // bounded-waits for the reply — that can take MINUTES — and delivers its
+    // reply OUT via a separate a2a message, not this HTTP response. AWAITING it
+    // here meant the caller's /a2a/inbox POST waited the full handler, so the
+    // sender's ~10s `AbortSignal.timeout` fired and logged a FALSE "local-inbox
+    // delivery attempt failed" (the message was in fact accepted — its id is
+    // marked processed above — and the reply will arrive on its own channel).
+    // Respond ACCEPTED immediately and run the handler in the background. The
+    // idempotency mark above still dedups any retry; a handler failure is caught
+    // + logged async (it can't reject a response that already returned).
+    void Promise.resolve()
+      .then(() => handler(msg, { topicId: input.topicId, senderBotId: input.senderBotId }))
+      .catch((err) => {
+        // A role-handler failure is recorded but doesn't un-mark the id (we still
+        // treat the message as processed; retrying would just re-fail). Stage-B
+        // forensics can see the routed row + the absence of a downstream effect.
+        // eslint-disable-next-line no-console
+        console.error(`[a2a] role-handler "${msg.role}" failed:`, err instanceof Error ? err.message : String(err));
+      });
     return { handled: true };
   };
 }

--- a/tests/unit/messaging/installAgentMessageHook.test.ts
+++ b/tests/unit/messaging/installAgentMessageHook.test.ts
@@ -81,6 +81,44 @@ describe('buildAgentMessageHook — closure end-to-end', () => {
     expect(store.hasProcessed('r1')).toBe(true); // idempotency anchor recorded
   });
 
+  it('ACCEPT-BOUNDARY: a slow role-handler does NOT block the response — returns {handled:true} immediately, runs in background', async () => {
+    // The mentee mentor-message handler spawns a session + bounded-waits MINUTES,
+    // replying out via a separate a2a message. Awaiting it here made the caller's
+    // /a2a/inbox POST time out (~10s) and log a FALSE "delivery failed". The hook
+    // must respond accepted immediately and run the handler in the background.
+    let started = false;
+    let finished = false;
+    let release: () => void = () => {};
+    const held = new Promise<void>((r) => { release = r; });
+    const slowHandler: RoleHandler = async () => { started = true; await held; finished = true; };
+    const handlers = new Map<string, RoleHandler>([['mentor-reply', slowHandler]]);
+    const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: handlers });
+
+    // If the hook AWAITED the handler (the bug), this would HANG on `held`.
+    const r = await hook(input(marker()));
+    expect(r).toEqual({ handled: true });
+    expect(store.hasProcessed('r1')).toBe(true); // id marked before the async handler
+
+    await new Promise((res) => setImmediate(res)); // let the background handler start
+    expect(started).toBe(true);
+    expect(finished).toBe(false); // started but NOT awaited to completion
+
+    release();
+    await new Promise((res) => setImmediate(res));
+    expect(finished).toBe(true); // completed in the background
+  });
+
+  it('ACCEPT-BOUNDARY: a background handler rejection still yields {handled:true} (error caught async)', async () => {
+    const boomHandler: RoleHandler = async () => { throw new Error('handler boom'); };
+    const handlers = new Map<string, RoleHandler>([['mentor-reply', boomHandler]]);
+    const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: handlers });
+
+    const r = await hook(input(marker()));
+    expect(r).toEqual({ handled: true });
+    expect(store.hasProcessed('r1')).toBe(true);
+    await new Promise((res) => setImmediate(res)); // let the async .catch fire (no unhandled rejection)
+  });
+
   it('IDEMPOTENCY: a re-delivered marker (same id) is dropped without calling the handler', async () => {
     const handlers = new Map<string, RoleHandler>([['mentor-reply', recordingHandler]]);
     const hook = buildAgentMessageHook({ config: cfg(), ledger, processedIds: store, roleHandlers: handlers });
@@ -120,6 +158,9 @@ describe('buildAgentMessageHook — closure end-to-end', () => {
     const r = await hook(input(marker({ id: 'e1', corr: 'e1' })));
     expect(r).toEqual({ handled: true });
     expect(store.hasProcessed('e1')).toBe(true); // marked even though handler failed
+    // Accept-boundary: the handler now runs in the background, so its failure is
+    // logged on a later microtask — tick before asserting the error was logged.
+    await new Promise((res) => setImmediate(res));
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
   });

--- a/upgrades/next/a2a-inbox-accept-boundary.md
+++ b/upgrades/next/a2a-inbox-accept-boundary.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+
+## What Changed — Agent-to-agent task delivery no longer logs false "delivery failed" timeouts
+
+When one of your agents hands a task to another agent on the same machine (for example a mentor agent assigning work to a mentee), the receiver was only acknowledging the message AFTER it had finished the whole task — which means spinning up a work session and waiting minutes for it to think and reply. But the sender only waits about 10 seconds for an acknowledgement, so it gave up and logged a "delivery failed" every time — even though the message was actually received fine and the reply was on its way back on a separate channel.
+
+Now the receiver acknowledges the moment it accepts the message and does the work in the background. The sender gets its acknowledgement right away, stops logging false failures, and stops holding a connection open for ten seconds each time. The actual reply still comes back exactly as before.
+
+## Summary of New Capabilities
+
+- The agent-to-agent inbox hook (the third and last of the agent-to-agent transports) now responds at the accept boundary: it acknowledges immediately after validating the message and runs the (potentially minutes-long) handler in the background, instead of making the sender wait through it. Completes the same fix already shipped for the co-located relay and the cross-machine threadline paths.
+
+## What to Tell Your User
+
+If you run multiple agents that talk to each other, you'll stop seeing spurious "delivery failed" timeouts in the logs for messages that actually went through fine. The receiving agent now confirms it got the message right away and does the work in the background, and the reply still comes back as normal.
+
+## Evidence
+
+- Found in the agent's own server log: recurring "[a2a] local-inbox delivery attempt failed (to=instar-codey): aborted due to timeout".
+- Root traced through the call chain: the /a2a/inbox response awaited the role handler, which spawns a session and waits minutes; the sender's ~10s timeout fired first. The reply flows back on a separate channel, so awaiting was unnecessary.
+- Unit tests: a held (slow) handler no longer blocks the response (it would have hung if still awaited); a background handler error still yields a clean acknowledgement. Idempotency, validation, and spoof-defense cases unchanged. Independent adversarial review.

--- a/upgrades/side-effects/a2a-inbox-accept-boundary.md
+++ b/upgrades/side-effects/a2a-inbox-accept-boundary.md
@@ -1,0 +1,40 @@
+# Side-effects — /a2a/inbox accept-boundary
+
+## 1. What files/state does this touch at runtime?
+`installAgentMessageHook.ts` — the role-handler invocation in the agent-message hook. No new files,
+config, schema, or state. The role handler still runs (now in the background); the idempotency mark
+and ledger row are unchanged.
+
+## 2. Does it change any functional behavior?
+The `/a2a/inbox` HTTP response now returns `{handled:true}` immediately after the message is validated
++ marked processed, instead of after the (minutes-long) role handler completes. The handler runs in
+the background and delivers its reply on its own a2a channel exactly as before. Net: the sender no
+longer times out (its ~10s `AbortSignal.timeout`) and no longer logs a false "delivery failed".
+
+## 3. What happens on failure / weird config?
+A background handler rejection is caught and logged (`console.error`), exactly as the old `try/catch`
+did — just on a later microtask. The id stays marked processed (unchanged). Validation failures
+(unknown role, spoof, already-processed) still short-circuit BEFORE the handler, unchanged.
+
+## 4. Migration parity — do existing agents get it?
+Yes, via the normal release — code-only, compiled into `dist`. No agent-installed file / config /
+template change → no `PostUpdateMigrator` pass.
+
+## 5. Could it spam / flood / burn resources?
+No — it REDUCES resource use (no 10s held connection per mentor a2a message). Same single handler
+run, no new timers/IO/network. The idempotency mark still bounds duplicate processing.
+
+## 6. Rollback / off-switch?
+Revert the one block (re-`await` the handler). No data, no migration, no flag. Mirrors #581/#3
+rollback.
+
+## 7. Concurrency / ordering?
+The handler now runs after the response returns instead of before. The idempotency `markProcessed`
+still happens BEFORE the response (so retries dedup). The reply-out is unchanged (a separate a2a
+send). A background handler error cannot affect the already-sent response.
+
+## Blast radius
+Small + additive: one block in `installAgentMessageHook.ts` swapped from await-then-respond to
+respond-then-background. Exactly mirrors the proven #581 (`/messages/relay-agent`) and #3
+(`/threadline/messages/receive`) accept-boundaries. Only the a2a role-handler dispatch timing
+changes; validation, idempotency, ledger, and the reply path are untouched.


### PR DESCRIPTION
## What & why (found via own-operation watch)

Echo's `server-stderr.log` had recurring `[a2a] local-inbox delivery attempt failed (to=instar-codey): aborted due to timeout`. Tracing the chain: `/a2a/inbox` (`routes.ts:9888`) awaits `dispatchAgentMessageHook` → the agent-message hook → `installAgentMessageHook.ts:120` did `await handler(msg, ...)` before returning `{handled:true}`. The registered `mentor` role handler (`AgentServer.ts:1283`) **spawns a mentee session and bounded-waits for the reply — minutes** — then delivers its reply OUT on a **separate** a2a channel. So the `/a2a/inbox` response was held the whole time, and the sender's `AbortSignal.timeout(10_000)` (`AgentServer.ts:1479`) fired → a **false** "delivery failed" (the message was accepted; its id is marked processed; the reply arrives on its own channel).

This is the **third and last** accept-boundary path — #581 fixed `/messages/relay-agent`, #3 fixed `/threadline/messages/receive`.

## The fix

Respond `{handled:true}` immediately after validation + marking the id processed, and run the role handler in the **background** (`void Promise.resolve().then(() => handler(...)).catch(log)`).

## Safety (adversarially reviewed — SHIP)

- `markProcessed(msg.id)` stays **before** the response, so a retried delivery still dedups.
- The **sole consumer** (`AgentServer.deliverA2aMessage`) reads only `result.agentMessage === true` within its 10s timeout — it never depended on the handler completing. With the fix it gets the ack immediately; the reply still flows back as a separate a2a message.
- A background handler rejection is caught + logged (can't reject a response that already returned); the `Promise.resolve().then(...).catch()` form also catches a synchronous throw.
- **No duplicate spawns**: the idempotency mark + the sender not re-POSTing locally already prevented those — the harm was the false log + a wasted 10s hold, both removed.

## Tests
- A held (slow) handler no longer blocks the response — `{handled:true}` returns immediately (would **hang** if still awaited; reverting the fix makes the test time out, confirmed by review). A background rejection still yields `{handled:true}`. The existing HANDLER-ERROR test ticks for the now-async error log. Idempotency / spoof / unknown-role cases unchanged. 17/17 green.
- **Independent adversarial review: SHIP** — markProcessed-before-response intact, no caller depends on handler completion, reply decoupled, no unhandledRejection.

Self-approved under the 12h autonomous deploy mandate (flagged for review). Spec: `docs/specs/a2a-inbox-accept-boundary.md` (+ `.eli16.md`); side-effects + fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
