### PR TITLE
fix(mentor): gate the onboarding tick on the LLM rate-limit circuit so it stops re-tripping it (#46)

### DIFF
--- a/docs/specs/mentor-llm-circuit-gate.eli16.md
+++ b/docs/specs/mentor-llm-circuit-gate.eli16.md
@@ -1,0 +1,30 @@
+# Mentor LLM rate-limit gate — explained simply
+
+## The everyday version
+
+The agent runs a "mentor" routine that periodically studies a mentee agent and writes up findings —
+and that study uses the AI model (it runs an `claude -p` analysis). Separately, there's a safety
+breaker: when the AI provider says "you're going too fast, slow down" (rate-limited), a circuit
+flips OPEN and pauses ALL AI work for about 15 minutes to let things cool off.
+
+The bug: the mentor routine checked whether it had spent too much money before running — but it did
+NOT check whether the AI was currently rate-limited. So while the provider was throttled (breaker
+open), the mentor would still fire off its AI analysis, which immediately failed... and that failure
+re-tripped the breaker, restarting the 15-minute pause. It was the agent tripping itself, over and
+over.
+
+## What we changed
+
+The mentor now also checks the breaker before it runs. If the AI is currently rate-limited (breaker
+open), the mentor simply skips this round and tries again later when things have recovered — instead
+of throwing a doomed request at a throttled provider and re-tripping the pause for everything else.
+
+## Why it's safe
+
+When the provider is rate-limited, the mentor's AI work would just fail anyway — so skipping is
+strictly better: no wasted request, and it stops the self-inflicted re-tripping that was pausing all
+the agent's other AI-backed monitors. The mentor's analysis isn't time-sensitive; a skipped round is
+picked up on the next one. The check is read-only (it just peeks at the breaker's state; it doesn't
+consume the one "probe" slot the breaker allows while recovering). And the order of the gates is
+preserved — the money/budget check still comes first. We added tests proving the mentor skips with a
+clear "llm-rate-limited" reason and never even starts its AI work when the breaker is open.

--- a/docs/specs/mentor-llm-circuit-gate.md
+++ b/docs/specs/mentor-llm-circuit-gate.md
@@ -1,0 +1,73 @@
+---
+title: Gate the mentor tick on the LLM rate-limit circuit so it stops re-tripping it
+slug: mentor-llm-circuit-gate
+date: 2026-05-31
+author: echo
+status: approved
+review-convergence: internal-self-review-2026-05-31
+approved: true
+approved-by: Echo under the 12h autonomous deploy mandate (self-approved; flagged in PR). Directly addresses mandate task 1 ("treat the rate-limit signal as a SUSPECTED Instar bug").
+approval-note: >
+  Found via own-operation watch (Echo's server-stderr.log showed the LLM circuit OPENing repeatedly —
+  trip #7 — on the mentor's `claude -p` forensics call). The mentor tick gated on budget (spend) but
+  not on the LLM rate-limit circuit, so it kept running LLM-backed work while the provider was
+  throttled and re-tripped the circuit. Small, contained, clearly-correct gate addition.
+second-pass-required: false
+second-pass-status: n/a-small-clearly-correct-read-only-gate-both-sides-unit-tested
+eli16-overview: mentor-llm-circuit-gate.eli16.md
+---
+
+# Mentor LLM rate-limit gate (#46 — task 1)
+
+## The bug, grounded
+
+Echo's `server-stderr.log` showed `[llm-circuit] OPEN: provider rate-limited — pausing ALL
+LLM-backed work for ~900s (trip #7); reason: Claude CLI error ... /opt/homebrew/bin/claude -p You
+are the developer hat of a framework-onboarding mentor`.
+
+`MentorOnboardingTick` (`MentorOnboardingTick.ts`) gates each tick on: a leak canary, the **budget**
+(spend) gate, and the safe-window. It does NOT gate on the **LLM rate-limit circuit**
+(`LlmCircuitBreaker`). So when the provider is rate-limited (circuit open), the tick still runs Stage
+A (`spawnStageA` — spawns an LLM session) and Stage B (`runStageBForensics` — the `claude -p`
+"developer hat"), both of which fail rate-limited and **re-trip the circuit** — and each trip pauses
+ALL LLM-backed work (every monitor) for ~900s. The mentor is thus a code-side contributor to the
+rate-limit churn on mentor-enabled agents (Echo). (Most agents ship the mentor dark, so this is
+Echo-class today; the fix is general.)
+
+## Fix
+
+Add an `llmAvailable` gate to the tick, immediately after the budget gate:
+```ts
+if (!deps.budgetOk) return { ran: false, reason: 'budget' };
+if (!deps.llmAvailable) return { ran: false, reason: 'llm-rate-limited' };
+```
+`llmAvailable` is computed by the runner from the shared circuit via a new read-only helper
+`llmCircuitAvailable()` (`LlmCircuitBreaker.ts`): `!status().enabled || status().state === 'closed'`.
+The helper is **non-mutating** — unlike the breaker's admission check, it does NOT consume a
+half-open probe slot, so using it as a gate has no side effects. When the circuit is open/half-open,
+the mentor backs off (skips the tick) and resumes automatically when it closes.
+
+## Safety
+- Clearly correct: when the provider is rate-limited, the tick's LLM work would just fail anyway, so
+  skipping is strictly better (no wasted call, no re-trip). The mentor's forensics aren't
+  time-critical; a skipped tick is picked up on the next eligible one.
+- Gate order: budget → llm-rate-limit → safe-window. Budget still wins a tie (fail-closed precedence
+  unchanged). Unit-tested.
+- Read-only circuit query (no probe consumed). No new state, timers, or I/O.
+- Scope: the observe-and-log onboarding tick (the path that produced the trips). The dark
+  autonomous-fix guardian (`MentorAutonomousGuardian`) makes LLM calls too and should get the same
+  gate — noted as a small follow-up; not bundled here to keep the change focused on the active path.
+
+## Migration parity
+N/A — code-only, compiled into `dist`; ships in the normal release. No agent-installed file / config /
+template change → no `PostUpdateMigrator` pass.
+
+## Agent Awareness
+N/A — internal mentor-scheduler gating.
+
+## Test plan
+Unit (`MentorOnboardingTick.test.ts`, +2): `llmAvailable:false` → skips with reason `llm-rate-limited`
+BEFORE any spawn/forensics (Stage A + Stage B not called); budget is checked before the llm gate (tie
+→ `budget`). The existing gate-order + happy-path cases stay green (`makeDeps` defaults
+`llmAvailable:true`). The `llmCircuitAvailable()` helper is exercised through the runner; the existing
+`LlmCircuitBreaker` suite stays green.

--- a/src/core/LlmCircuitBreaker.ts
+++ b/src/core/LlmCircuitBreaker.ts
@@ -278,6 +278,18 @@ export function configureLlmCircuitBreaker(opts: { openMs?: number; enabled?: bo
   getLlmCircuitBreaker().configure(opts);
 }
 
+/**
+ * Read-only convenience: is the shared LLM circuit currently AVAILABLE for new
+ * LLM-backed work? True when the breaker is disabled, or its state is 'closed'.
+ * False when 'open' or 'half-open' (the provider is rate-limited / probing).
+ * Non-mutating — unlike the admission check, it does NOT consume a half-open
+ * probe slot, so callers can use it as a pure gate (e.g. the mentor tick backing
+ * off rather than re-tripping the circuit). */
+export function llmCircuitAvailable(): boolean {
+  const s = getLlmCircuitBreaker().status();
+  return !s.enabled || s.state === 'closed';
+}
+
 /** Test-only: drop the singleton so a fresh one is built next access. */
 export function __resetLlmCircuitBreakerSingleton(): void {
   _singleton = null;

--- a/src/scheduler/MentorOnboardingRunner.ts
+++ b/src/scheduler/MentorOnboardingRunner.ts
@@ -13,6 +13,7 @@
  * Ships dormant: `mentor.enabled=false` / `mentor.mode='off'` by default (§16).
  */
 import { runMentorTick, type MentorTickResult, type MentorMode } from './MentorOnboardingTick.js';
+import { llmCircuitAvailable } from '../core/LlmCircuitBreaker.js';
 import {
   runAutonomousGuardian,
   type AutonomousGuardianReason,
@@ -264,6 +265,7 @@ export class MentorOnboardingRunner {
       // Safe window = mentee at rest AND the min-interval floor elapsed (§12 Q3).
       safeWindowOpen: !this.services.isMenteeBusy() && this.services.minIntervalElapsed(),
       budgetOk: this.services.budgetOk(),
+      llmAvailable: llmCircuitAvailable(),
       spawnStageA: this.services.spawnStageA,
       runStageBForensics: () => this.services.runStageBForensics(framework),
       capture: this.services.capture,

--- a/src/scheduler/MentorOnboardingTick.ts
+++ b/src/scheduler/MentorOnboardingTick.ts
@@ -42,6 +42,11 @@ export interface MentorTickDeps {
   safeWindowOpen: boolean;
   /** Fail-closed budget gate (the GET /autonomous/can-start precedent). */
   budgetOk: boolean;
+  /** LLM-availability gate: false when the shared LlmCircuitBreaker is open/half-open
+   *  (the provider is rate-limited). The tick's Stage A (spawn) and Stage B (`claude -p`
+   *  forensics) are both LLM-backed, so running while rate-limited just fails and
+   *  RE-TRIPS the circuit (which pauses ALL LLM-backed work). Skip instead. */
+  llmAvailable: boolean;
   /** Spawn Stage A (empty tool grant) and return its transcript. Injected so the
    *  pure tick has no SessionManager/tmux dependency. */
   spawnStageA: (prompt: string) => Promise<string>;
@@ -68,6 +73,7 @@ export interface MentorTickDeps {
 export type MentorTickReason =
   | 'canary-failed'
   | 'budget'
+  | 'llm-rate-limited'
   | 'unsafe-window'
   | 'stage-a-failed'
   | 'ran';
@@ -123,6 +129,11 @@ export async function runMentorTick(deps: MentorTickDeps): Promise<MentorTickRes
 
   // 2. Budget gate — fail-closed BEFORE any spend or contact (§6).
   if (!deps.budgetOk) return { ran: false, reason: 'budget' };
+
+  // 2b. LLM rate-limit gate — when the shared provider circuit is open, the
+  // tick's Stage A + Stage B are LLM-backed and would just fail and RE-TRIP the
+  // circuit (re-pausing all LLM work ~900s). Back off; we'll run when it closes.
+  if (!deps.llmAvailable) return { ran: false, reason: 'llm-rate-limited' };
 
   // 3. Safe-window — only act at a durable mentee state transition (§12 Q3).
   if (!deps.safeWindowOpen) return { ran: false, reason: 'unsafe-window' };

--- a/tests/unit/MentorOnboardingTick.test.ts
+++ b/tests/unit/MentorOnboardingTick.test.ts
@@ -29,6 +29,7 @@ function makeDeps(over: Partial<MentorTickDeps> = {}): { deps: MentorTickDeps; c
     surface: { framework: 'codex-cli', threadlineHistory: 'how is it going?' },
     safeWindowOpen: true,
     budgetOk: true,
+    llmAvailable: true,
     spawnStageA: vi.fn(async () => 'Nice progress — ready for the next one?'),
     runStageBForensics: vi.fn(async () => []),
     capture,
@@ -56,6 +57,21 @@ describe('runMentorTick — gate order + structural guarantees', () => {
     expect(deps.spawnStageA).not.toHaveBeenCalled();
     expect(deps.runStageBForensics).not.toHaveBeenCalled();
     expect(captures).toHaveLength(0); // no contact, no capture
+  });
+
+  it('skips the tick when the LLM circuit is open (rate-limited) BEFORE any spend/spawn — does not re-trip the circuit', async () => {
+    const { deps } = makeDeps({ llmAvailable: false, canaryCheck: () => true });
+    const r = await runMentorTick(deps);
+    expect(r.ran).toBe(false);
+    expect(r.reason).toBe('llm-rate-limited');
+    expect(deps.spawnStageA).not.toHaveBeenCalled();
+    expect(deps.runStageBForensics).not.toHaveBeenCalled();
+  });
+
+  it('budget is checked BEFORE the llm-rate-limit gate (order)', async () => {
+    const { deps } = makeDeps({ budgetOk: false, llmAvailable: false, canaryCheck: () => true });
+    const r = await runMentorTick(deps);
+    expect(r.reason).toBe('budget'); // budget wins the tie
   });
 
   it('skips when the safe window is closed (durable-state gate, §12 Q3)', async () => {

--- a/upgrades/next/mentor-llm-circuit-gate.md
+++ b/upgrades/next/mentor-llm-circuit-gate.md
@@ -1,0 +1,21 @@
+<!-- bump: patch -->
+
+## What Changed — The mentor routine no longer hammers a rate-limited provider and re-trips the pause
+
+Agents can run a "mentor" routine that periodically studies a mentee agent using the AI model. There's also a safety breaker that pauses all AI work for a while when the provider says you're going too fast (rate-limited). The mentor checked its spending budget before running, but not whether the AI was currently rate-limited — so while the provider was throttled, the mentor kept firing off doomed analyses that failed and re-tripped the pause, restarting it again and again. The agent was effectively tripping itself.
+
+Now the mentor also checks the breaker: if the AI is currently rate-limited, it skips this round and picks up on the next one, instead of throwing a doomed request at a throttled provider and re-pausing all the agent's other AI-backed monitors.
+
+## Summary of New Capabilities
+
+- The mentor onboarding tick now gates on LLM availability (the shared rate-limit circuit breaker) in addition to budget and safe-window: when the provider is rate-limited it backs off with reason `llm-rate-limited` and resumes automatically when the breaker closes. A new read-only `llmCircuitAvailable()` helper exposes the breaker state without consuming its recovery probe.
+
+## What to Tell Your User
+
+If you run an agent with the mentor routine enabled, it will stop making things worse during AI rate-limit periods — it now waits for the provider to recover instead of repeatedly tripping the system-wide pause. Nothing to configure.
+
+## Evidence
+
+- Found in the agent's own server log: the LLM circuit breaker opening repeatedly (trip #7) on the mentor's `claude -p` forensics call.
+- The mentor tick gated on budget but not on the rate-limit circuit, so it ran LLM-backed Stage A + Stage B while the provider was throttled, re-tripping the breaker (which pauses all LLM-backed work ~900s per trip).
+- Unit tests: the tick skips with reason `llm-rate-limited` BEFORE any spawn/forensics when the circuit is open; budget is still checked first; the existing gate-order and happy-path cases stay green.

--- a/upgrades/side-effects/mentor-llm-circuit-gate.md
+++ b/upgrades/side-effects/mentor-llm-circuit-gate.md
@@ -1,0 +1,39 @@
+# Side-effects — Mentor LLM rate-limit gate
+
+## 1. What files/state does this touch at runtime?
+`MentorOnboardingTick.ts` (new `llmAvailable` dep + a gate), `MentorOnboardingRunner.ts` (computes
+`llmAvailable` from the circuit), `LlmCircuitBreaker.ts` (a new read-only `llmCircuitAvailable()`
+helper). No new state, config, or schema.
+
+## 2. Does it change any functional behavior?
+The mentor onboarding tick now SKIPS (returns `{ran:false, reason:'llm-rate-limited'}`) when the
+shared LLM circuit is open/half-open, instead of running Stage A + Stage B and failing. When the
+circuit is closed (or disabled), behavior is unchanged.
+
+## 3. What happens on failure / weird config?
+If the breaker is disabled, `llmCircuitAvailable()` returns true (the mentor runs as before). The
+helper is read-only (cannot throw on a normal status read). A skipped tick is simply retried on the
+next eligible cycle — no work is lost (the mentor's forensics are not time-critical).
+
+## 4. Migration parity — do existing agents get it?
+Yes, via the normal release — code-only, compiled into `dist`. No agent-installed file / config /
+template change → no `PostUpdateMigrator` pass.
+
+## 5. Could it spam / flood / burn resources?
+The opposite — it REDUCES burn: it stops the mentor from firing doomed LLM calls at a throttled
+provider and re-tripping the circuit (each trip pauses all LLM-backed work ~900s). The added work is
+one read-only circuit-status read per tick.
+
+## 6. Rollback / off-switch?
+Revert the gate + the `llmAvailable` dep + the helper. No data, no migration, no flag.
+
+## 7. Concurrency / ordering?
+Gate order is budget → llm-rate-limit → safe-window (budget still wins a tie; fail-closed precedence
+unchanged). The circuit query is non-mutating — it does NOT consume the breaker's half-open probe
+slot, so it can't perturb the breaker's recovery.
+
+## Blast radius
+Small + contained, mentor-only. One gate in the onboarding tick + a read-only circuit helper. Only
+mentor-enabled agents (the mentor ships dark elsewhere) are affected, and only when the LLM circuit
+is open. The dark autonomous-fix guardian makes LLM calls too and should get the same gate — noted as
+a small follow-up, not bundled here.


### PR DESCRIPTION
## What & why (found via own-operation watch — mandate task 1)

Echo's `server-stderr.log` showed the LLM circuit breaker OPENing repeatedly (`[llm-circuit] OPEN ... trip #7`) on the mentor's `claude -p` forensics call. `MentorOnboardingTick` gated each tick on the **budget** (spend) + safe-window, but **not** on the **LLM rate-limit circuit** (`LlmCircuitBreaker`). So while the provider was throttled (circuit open), the tick still ran Stage A (spawn) + Stage B (`claude -p` forensics) — which failed and **re-tripped the circuit**, and each trip pauses *all* LLM-backed work (every monitor) ~900s. The mentor was a code-side contributor to the rate-limit churn — exactly the "treat the rate-limit as a suspected bug" mandate.

## The fix

Add an `llmAvailable` gate to the tick, right after the budget gate:
```ts
if (!deps.budgetOk) return { ran: false, reason: 'budget' };
if (!deps.llmAvailable) return { ran: false, reason: 'llm-rate-limited' };
```
The runner computes `llmAvailable` from the shared breaker via a new **read-only** `llmCircuitAvailable()` helper (`!status().enabled || status().state === 'closed'`). The helper is **non-mutating** — unlike the breaker's admission check, it does NOT consume a half-open probe slot — so it's a pure gate. When the circuit is open/half-open the mentor backs off and resumes automatically when it closes.

## Safety
- Clearly correct: when rate-limited, the tick's LLM work would just fail anyway — skipping is strictly better (no wasted call, no re-trip). The mentor's forensics aren't time-critical.
- Gate order preserved: budget → llm-rate-limit → safe-window (budget still wins a tie). Read-only circuit query, no new state/timers/IO.
- Scope: the observe-and-log onboarding tick (the path that produced the trips). The dark autonomous-fix guardian makes LLM calls too and should get the same gate — noted as a small follow-up, kept out to stay focused.

## Tests
`MentorOnboardingTick.test.ts` (+2): `llmAvailable:false` → skips with reason `llm-rate-limited` BEFORE any spawn/forensics (Stage A + Stage B not called); budget is checked before the llm gate. Existing gate-order + happy-path cases green.

Self-approved under the 12h autonomous deploy mandate (flagged for review). Spec: `docs/specs/mentor-llm-circuit-gate.md` (+ `.eli16.md`); side-effects + fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
